### PR TITLE
[codex] fail open keeper cascade on provider cooldown

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -114,6 +114,23 @@ let is_auto_recoverable_cascade_fail_open_error
   Oas_worker_named.sdk_error_is_hard_quota err
   || is_auto_recoverable_cascade_exhausted_error err
 
+let fallback_cascade_for_unavailable_profile
+    ~(base_cascade : string)
+    ~(effective_cascade : string) : string option =
+  let normalized_base =
+    Keeper_cascade_profile.normalize_declared_name base_cascade
+  in
+  let normalized_effective =
+    Keeper_cascade_profile.normalize_declared_name effective_cascade
+  in
+  if not (String.equal normalized_effective normalized_base)
+  then Some normalized_base
+  else if
+    String.equal normalized_effective Keeper_config.local_only_cascade_name
+    || String.equal normalized_effective Keeper_config.default_cascade_name
+  then None
+  else Some Keeper_config.default_cascade_name
+
 let fail_open_cascade_after_auto_recoverable_error
     ~(base_cascade : string)
     ~(effective_cascade : string)
@@ -121,19 +138,8 @@ let fail_open_cascade_after_auto_recoverable_error
   if not (is_auto_recoverable_cascade_fail_open_error err)
   then None
   else
-    let normalized_base =
-      Keeper_cascade_profile.normalize_declared_name base_cascade
-    in
-    let normalized_effective =
-      Keeper_cascade_profile.normalize_declared_name effective_cascade
-    in
-    if not (String.equal normalized_effective normalized_base)
-    then Some normalized_base
-    else if
-      String.equal normalized_effective Keeper_config.local_only_cascade_name
-      || String.equal normalized_effective Keeper_config.default_cascade_name
-    then None
-    else Some Keeper_config.default_cascade_name
+    fallback_cascade_for_unavailable_profile
+      ~base_cascade ~effective_cascade
 
 let is_auto_recoverable_turn_error (err : Oas.Error.sdk_error) : bool =
   is_transient_network_error err

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -49,6 +49,11 @@ val is_cascade_exhausted_error : Oas.Error.sdk_error -> bool
     fully-filtered exhaustion event. Returns [Some cascade] for a one-shot
     same-turn retry target, or [None] when the current cascade should remain
     authoritative. *)
+val fallback_cascade_for_unavailable_profile :
+  base_cascade:string ->
+  effective_cascade:string ->
+  string option
+
 val fail_open_cascade_after_auto_recoverable_error :
   base_cascade:string ->
   effective_cascade:string ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -585,6 +585,26 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             meta.name (String.concat ", " routed_labels) resolved_cascade;
         resolved_cascade
       in
+      let effective_cascade_name =
+        match
+          Keeper_world_observation.provider_cooldown_remaining_sec_for_cascade
+            ~cascade_name:effective_cascade_name
+        with
+        | Some remaining_sec ->
+            (match
+               EC.fallback_cascade_for_unavailable_profile
+                 ~base_cascade:meta.cascade_name
+                 ~effective_cascade:effective_cascade_name
+             with
+             | Some fallback_cascade
+               when not (String.equal fallback_cascade effective_cascade_name) ->
+                 Log.Keeper.warn
+                   "%s: cascade %s provider cooldown pending (%ds); fail-opening to %s"
+                   meta.name effective_cascade_name remaining_sec fallback_cascade;
+                 fallback_cascade
+             | _ -> effective_cascade_name)
+        | None -> effective_cascade_name
+      in
       (* 1. Check API keys *)
       let meta_for_cascade = { meta with cascade_name = effective_cascade_name } in
       let model_labels = Keeper_coordination.effective_model_labels_for_turn meta_for_cascade in

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -68,6 +68,7 @@ type skip_reason =
   | Keeper_paused
   | Approval_pending
   | Scheduled_autonomous_disabled
+  | Provider_cooldown_pending of { remaining_sec : int }
   | Idle_gate_pending of { remaining_sec : int }
   | Cooldown_pending of { remaining_sec : int }
   | No_signal
@@ -91,6 +92,7 @@ let skip_reason_to_string = function
   | Keeper_paused -> "keeper_paused"
   | Approval_pending -> "approval_pending"
   | Scheduled_autonomous_disabled -> "scheduled_autonomous_disabled"
+  | Provider_cooldown_pending _ -> "provider_cooldown_pending"
   | Idle_gate_pending _ -> "idle_gate_pending"
   | Cooldown_pending _ -> "cooldown_pending"
   | No_signal -> "no_signal"
@@ -748,8 +750,66 @@ let effective_scheduled_autonomous_cooldown
 let effective_proactive_cooldown =
   effective_scheduled_autonomous_cooldown
 
+let fallback_cascade_for_provider_cooldown
+    ~(base_cascade : string)
+    ~(effective_cascade : string) : string option =
+  let normalized_base =
+    Keeper_cascade_profile.normalize_declared_name base_cascade
+  in
+  let normalized_effective =
+    Keeper_cascade_profile.normalize_declared_name effective_cascade
+  in
+  if not (String.equal normalized_effective normalized_base)
+  then Some normalized_base
+  else if
+    String.equal normalized_effective Keeper_config.local_only_cascade_name
+    || String.equal normalized_effective Keeper_config.default_cascade_name
+  then None
+  else Some Keeper_config.default_cascade_name
 
-let keeper_cycle_decision ~(meta : keeper_meta) (observation : world_observation) =
+let provider_cooldown_remaining_sec_for_cascade
+    ~(cascade_name : string) : int option =
+  let model_ids =
+    Cascade_runtime.models_of_cascade_name cascade_name
+    |> Cascade_config.parse_model_strings
+    |> List.map (fun (cfg : Llm_provider.Provider_config.t) ->
+           String.trim cfg.model_id)
+    |> List.filter (fun model_id -> model_id <> "")
+    |> List.sort_uniq String.compare
+  in
+  match model_ids with
+  | [] -> None
+  | _ ->
+      let provider_infos =
+        List.map
+          (fun provider_key ->
+             Cascade_health_tracker.provider_info
+               Cascade_health_tracker.global ~provider_key)
+          model_ids
+      in
+      if not (List.for_all Option.is_some provider_infos) then None
+      else
+        let provider_infos = List.filter_map Fun.id provider_infos in
+        if not (List.for_all (fun info -> info.Cascade_health_tracker.in_cooldown) provider_infos)
+        then None
+        else
+          let now = Time_compat.now () in
+          provider_infos
+          |> List.filter_map
+               (fun info -> info.Cascade_health_tracker.cooldown_expires_at)
+          |> List.map (fun expires_at ->
+                 int_of_float
+                   (Float.max 0.0 (Float.ceil (expires_at -. now))))
+          |> function
+          | [] -> Some 0
+          | first :: rest -> Some (List.fold_left min first rest)
+
+
+let keeper_cycle_decision
+    ?(provider_cooldown_remaining_sec =
+        provider_cooldown_remaining_sec_for_cascade)
+    ~(meta : keeper_meta)
+    (observation : world_observation) =
   let reactive_triggers =
     [
       (if observation.pending_mentions <> [] then Some Mention_pending else None);
@@ -857,8 +917,33 @@ let keeper_cycle_decision ~(meta : keeper_meta) (observation : world_observation
           && (backlog_elapsed
               || (idle_gate_elapsed && cooldown_elapsed))
         in
+        let provider_cooldown_remaining_sec =
+          if should_run
+          then provider_cooldown_remaining_sec ~cascade_name:meta.cascade_name
+          else None
+        in
+        let provider_cooldown_fail_open =
+          match provider_cooldown_remaining_sec with
+          | Some _ ->
+              fallback_cascade_for_provider_cooldown
+                ~base_cascade:meta.cascade_name
+                ~effective_cascade:meta.cascade_name
+          | None -> None
+        in
         let verdict =
-          if should_run then
+          if
+            Option.is_some provider_cooldown_remaining_sec
+            && Option.is_none provider_cooldown_fail_open
+          then
+            Skip {
+              reasons = (
+                Provider_cooldown_pending {
+                  remaining_sec =
+                    Option.value ~default:0 provider_cooldown_remaining_sec;
+                },
+                [] );
+            }
+          else if should_run then
             let run_reasons =
               [
                 Some Scheduled_autonomous_turn;

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -109,6 +109,7 @@ type skip_reason =
   | Keeper_paused
   | Approval_pending
   | Scheduled_autonomous_disabled
+  | Provider_cooldown_pending of { remaining_sec : int }
   | Idle_gate_pending of { remaining_sec : int }
   | Cooldown_pending of { remaining_sec : int }
   | No_signal
@@ -220,10 +221,15 @@ val effective_proactive_cooldown :
   base_cooldown:int -> since_last:int ->
   ?consecutive_noop_count:int -> unit -> int
 
+val provider_cooldown_remaining_sec_for_cascade :
+  cascade_name:string -> int option
+
 val keeper_cycle_decision :
+  ?provider_cooldown_remaining_sec:(cascade_name:string -> int option) ->
   meta:Keeper_types.keeper_meta -> world_observation -> keeper_cycle_decision
 
 val unified_turn_decision :
+  ?provider_cooldown_remaining_sec:(cascade_name:string -> int option) ->
   meta:Keeper_types.keeper_meta -> world_observation -> keeper_cycle_decision
 
 val should_run_keeper_cycle :

--- a/test/test_decision_pipeline.ml
+++ b/test/test_decision_pipeline.ml
@@ -74,6 +74,7 @@ let test_skip_reason_to_string_coverage () =
     WO.Keeper_paused;
     WO.Approval_pending;
     WO.Scheduled_autonomous_disabled;
+    WO.Provider_cooldown_pending { remaining_sec = 45 };
     WO.Idle_gate_pending { remaining_sec = 30 };
     WO.Cooldown_pending { remaining_sec = 15 };
     WO.No_signal;

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -414,6 +414,77 @@ let test_scheduled_turn_requires_idle_gate () =
            (first :: rest)
      | WO.Run _ -> false)
 
+let test_provider_cooldown_blocks_scheduled_turn_when_work_is_ready () =
+  let meta =
+    { minimal_meta with
+      current_task_id =
+        (match Masc_mcp.Keeper_id.Task_id.of_string "task-456" with
+         | Ok value -> Some value
+         | Error err -> fail ("task id parse failed: " ^ err));
+      proactive =
+        { enabled = true; idle_sec = 0; cooldown_sec = 60 };
+      runtime =
+        { minimal_meta.runtime with
+          proactive_rt =
+            { minimal_meta.runtime.proactive_rt with
+              last_ts = Time_compat.now () -. 120.0;
+            };
+        };
+    }
+  in
+  let decision =
+    WO.keeper_cycle_decision
+      ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> Some 3599)
+      ~meta
+      base_observation
+  in
+  check bool "provider cooldown blocks scheduled turn" false decision.should_run;
+  check string "channel stays scheduled_autonomous" "scheduled_autonomous"
+    (WO.channel_to_string decision.channel);
+  check bool "decision records provider cooldown wait reason" true
+    (match decision.verdict with
+     | WO.Skip { reasons = (first, rest) } ->
+         List.exists
+           (function WO.Provider_cooldown_pending { remaining_sec = 3599 } -> true | _ -> false)
+           (first :: rest)
+     | WO.Run _ -> false)
+
+let test_provider_cooldown_keeps_scheduled_turn_open_when_fail_open_exists () =
+  let meta =
+    { minimal_meta with
+      cascade_name = "tool_use_strict";
+      current_task_id =
+        (match Masc_mcp.Keeper_id.Task_id.of_string "task-789" with
+         | Ok value -> Some value
+         | Error err -> fail ("task id parse failed: " ^ err));
+      proactive =
+        { enabled = true; idle_sec = 0; cooldown_sec = 60 };
+      runtime =
+        { minimal_meta.runtime with
+          proactive_rt =
+            { minimal_meta.runtime.proactive_rt with
+              last_ts = Time_compat.now () -. 120.0;
+            };
+        };
+    }
+  in
+  let decision =
+    WO.keeper_cycle_decision
+      ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> Some 3599)
+      ~meta
+      base_observation
+  in
+  check bool "provider cooldown keeps scheduled turn open when fallback exists"
+    true decision.should_run;
+  check bool "decision does not surface cooldown skip when fail-open exists"
+    false
+    (match decision.verdict with
+     | WO.Skip { reasons = (first, rest) } ->
+         List.exists
+           (function WO.Provider_cooldown_pending _ -> true | _ -> false)
+           (first :: rest)
+     | WO.Run _ -> false)
+
 let test_effective_cooldown_no_decay_within_base () =
   (* Within the base cooldown period, no decay should apply. *)
   let result =
@@ -597,12 +668,22 @@ let test_verdict_reasons_to_strings_uses_structured_skip_tags () =
           ( WO.Cooldown_pending { remaining_sec = 60 }, [] );
       }
   in
+  let provider_cooldown_verdict =
+    WO.Skip
+      {
+        reasons =
+          ( WO.Provider_cooldown_pending { remaining_sec = 3599 }, [] );
+      }
+  in
   check (list string) "structured idle-gate skip tags"
     [ "idle_gate_pending" ]
     (WO.verdict_reasons_to_strings idle_gate_verdict);
   check (list string) "structured cooldown skip tags"
     [ "cooldown_pending" ]
-    (WO.verdict_reasons_to_strings cooldown_verdict)
+    (WO.verdict_reasons_to_strings cooldown_verdict);
+  check (list string) "structured provider cooldown skip tags"
+    [ "provider_cooldown_pending" ]
+    (WO.verdict_reasons_to_strings provider_cooldown_verdict)
 
 let test_paused_keeper_blocks_turns_even_with_reactive_signal () =
   let meta = { minimal_meta with paused = true } in
@@ -2102,6 +2183,24 @@ let test_fail_open_cascade_after_auto_recoverable_error_skips_default_cascade ()
   in
   check (option string) "default cascade has no broader fallback" None
     fallback
+
+let test_fallback_cascade_for_unavailable_profile_prefers_default () =
+  let fallback =
+    EC.fallback_cascade_for_unavailable_profile
+      ~base_cascade:"tool_use_strict"
+      ~effective_cascade:"tool_use_strict"
+  in
+  check (option string) "strict cascade fallback target is default"
+    (Some KC.default_cascade_name) fallback
+
+let test_fallback_cascade_for_unavailable_profile_prefers_base_after_phase_override () =
+  let fallback =
+    EC.fallback_cascade_for_unavailable_profile
+      ~base_cascade:"tool_use_strict"
+      ~effective_cascade:KC.local_recovery_cascade_name
+  in
+  check (option string) "phase override fallback target is base cascade"
+    (Some "tool_use_strict") fallback
 
 (* context_overflow_limit is now in OAS as Retry.extract_context_limit.
    These tests verify the OAS SSOT API is accessible from MASC. *)
@@ -3779,6 +3878,10 @@ let () =
             test_scheduled_turn_respects_cooldown;
           test_case "scheduled turn requires idle gate" `Quick
             test_scheduled_turn_requires_idle_gate;
+          test_case "provider cooldown blocks scheduled turn" `Quick
+            test_provider_cooldown_blocks_scheduled_turn_when_work_is_ready;
+          test_case "provider cooldown keeps scheduled turn open when fail-open exists" `Quick
+            test_provider_cooldown_keeps_scheduled_turn_open_when_fail_open_exists;
           test_case "idle decay: no decay within base" `Quick
             test_effective_cooldown_no_decay_within_base;
           test_case "idle decay: at boundary" `Quick
@@ -4175,6 +4278,10 @@ let () =
             test_fail_open_cascade_after_auto_recoverable_error_preserves_explicit_local_only;
           test_case "default cascade has no broader fail-open target" `Quick
             test_fail_open_cascade_after_auto_recoverable_error_skips_default_cascade;
+          test_case "unavailable profile fallback prefers default" `Quick
+            test_fallback_cascade_for_unavailable_profile_prefers_default;
+          test_case "unavailable phase override fallback prefers base" `Quick
+            test_fallback_cascade_for_unavailable_profile_prefers_base_after_phase_override;
         ] );
       ( "tool_classification",
         [


### PR DESCRIPTION
## Summary
- add a reusable fallback helper for unavailable keeper cascades
- detect when every provider in the current cascade is in cooldown and fail-open to a broader cascade when available
- keep scheduled autonomous turns quiet with `provider_cooldown_pending` only when no fallback cascade exists
- add regression tests for cooldown skip, cooldown fail-open, and decision pipeline skip reason coverage

## Root Cause
`tool_use_strict` could become effectively unusable when its only provider entered hard quota cooldown. Keeper kept attempting scheduled turns against the same cascade, which produced repeated `cascade_exhausted` / `candidates_filtered_after_cycles` failures instead of either switching to a broader profile or backing off cleanly.

## Behavior Change
- cooldown on a strict or phase-routed cascade now fail-opens to the base or default cascade before the unified turn runs
- if no broader cascade exists, scheduled autonomous work is skipped with a cooldown-pending reason instead of logging another failed cycle
- test fixtures were updated to match the current `NetworkError` record shape

## Validation
- `dune exec test/test_keeper_unified.exe`
- `dune exec test/test_decision_pipeline.exe`
- `dune exec test/test_oas_worker.exe`
- `dune build`
