### PR TITLE
test(dashboard): align toml fixture with big_three

### DIFF
--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -312,7 +312,7 @@ let test_raw_config_toml_source_is_read_only () =
     {|
 comment = "test"
 
-[keeper_unified]
+[big_three]
 models = ["ollama:qwen3.5:35b-a3b-nvfp4"]
 |}
   in
@@ -379,7 +379,7 @@ let test_save_raw_config_json_persists_and_refreshes_projection () =
 let test_save_raw_config_json_rejects_toml_source () =
   let toml =
     {|
-[keeper_unified]
+[big_three]
 models = ["ollama:qwen3.5:35b-a3b-nvfp4"]
 |}
   in


### PR DESCRIPTION
## Summary
- align the two TOML fixture section headers with big_three
- keep test_dashboard_cascade fixtures consistent with the profile rename merged in #9427

## Testing
- clean local rebuild was blocked in this shell because the active opam switch is missing agent_sdk.llm_provider
