### PR TITLE
fix(test): safe-autonomy test record field access

### DIFF
--- a/test/test_dashboard_surface_readiness.ml
+++ b/test/test_dashboard_surface_readiness.ml
@@ -178,11 +178,11 @@ let test_safe_autonomy_surface_matches_monitoring_contract () =
   | None -> fail "monitoring.safe-autonomy missing"
   | Some surface ->
       check string "exposure_status" "main"
-        Yojson.Safe.Util.(surface |> member "exposure_status" |> to_string);
+        surface.exposure_status;
       check bool "hidden_from_nav" false
-        Yojson.Safe.Util.(surface |> member "hidden_from_nav" |> to_bool);
+        surface.hidden_from_nav;
       check bool "meets_main_gate" true
-        Yojson.Safe.Util.(surface |> member "meets_main_gate" |> to_bool)
+        surface.meets_main_gate
 
 let () =
   run "Dashboard_surface_readiness"


### PR DESCRIPTION
## Summary

Follow-up fix for PR #9424. The `test_safe_autonomy_surface_matches_monitoring_contract` test incorrectly used `Yojson.Safe.Util.member` access on a `surface_contract` OCaml record value. This fixes the type error by using direct record field access.

## Changes

- `test/test_dashboard_surface_readiness.ml`: Replace JSON member projection with `.exposure_status`, `.hidden_from_nav`, `.meets_main_gate`

## Verification

- [x] `dune build --root . @check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)