### PR TITLE
refactor(boundary): remove MASC→OAS layer boundary violations

### DIFF
--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -109,24 +109,38 @@ let display_provider_name label =
   | "kimi-api" -> cn_kimi
   | _ -> String.trim label
 
-(** Default API base URLs — overridable via env var for proxying/testing. *)
+(** Default API base URLs — overridable via env var for proxying/testing.
+    Where OAS Provider_registry already defines a default, query it rather
+    than duplicating the literal here. *)
 
 let env_url_or ~env ~default =
   match Sys.getenv_opt env with
   | Some url when String.trim url <> "" -> String.trim url
   | _ -> default
 
+(** Query OAS Provider_registry for a provider's default base_url.
+    Returns empty string if the provider is not known to OAS.
+    This removes duplicated defaults between MASC and OAS. *)
+let registry_default_base_url name =
+  let registry = Llm_provider.Provider_registry.default () in
+  match Llm_provider.Provider_registry.find registry name with
+  | Some entry -> entry.defaults.base_url
+  | None -> ""
+
 let anthropic_api_url () =
-  env_url_or ~env:"ANTHROPIC_API_URL" ~default:"https://api.anthropic.com"
+  env_url_or ~env:"ANTHROPIC_API_URL"
+    ~default:(registry_default_base_url "claude")
 
 let openai_api_url () =
   env_url_or ~env:"OPENAI_API_URL" ~default:"https://api.openai.com"
 
 let openrouter_api_url () =
-  env_url_or ~env:"OPENROUTER_API_URL" ~default:"https://openrouter.ai/api/v1"
+  env_url_or ~env:"OPENROUTER_API_URL"
+    ~default:(registry_default_base_url "openrouter")
 
 let gemini_generative_api_url () =
-  env_url_or ~env:"GEMINI_API_URL" ~default:"https://generativelanguage.googleapis.com"
+  env_url_or ~env:"GEMINI_API_URL"
+    ~default:(registry_default_base_url "gemini")
 
 let glm_api_url () =
   env_url_or ~env:"ZAI_BASE_URL" ~default:Llm_provider.Zai_catalog.general_base_url
@@ -135,7 +149,8 @@ let glm_coding_api_url () =
   env_url_or ~env:"ZAI_CODING_BASE_URL" ~default:Llm_provider.Zai_catalog.coding_base_url
 
 let kimi_api_url () =
-  env_url_or ~env:"KIMI_BASE_URL" ~default:"https://api.kimi.com/coding"
+  env_url_or ~env:"KIMI_BASE_URL"
+    ~default:(registry_default_base_url "kimi")
 (** SSOT cascade prefix for local llama-server instances.
     All cascade label construction for local models must use this constant.
     Format: [local_cascade_prefix ^ ":" ^ model_id] → e.g. "llama:qwen3.5" *)

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -16,109 +16,6 @@ let pctl percentile values =
       in
       List.nth_opt sorted index
 
-let raw_completion_at ~server_url ~model_id ~prompt ~max_tokens ~timeout_sec () =
-  let url =
-    String.trim server_url
-    ^ Masc_network_defaults.openai_chat_completions_path
-  in
-  let request_body =
-    `Assoc
-      [
-        ("model", `String model_id);
-        ( "messages",
-          `List
-            [
-              `Assoc
-                [
-                  ("role", `String "user");
-                  ("content", `String prompt);
-                ];
-            ] );
-        ("temperature", `Float 0.0);
-        ("max_tokens", `Int max_tokens);
-      ]
-    |> Yojson.Safe.to_string
-  in
-  let started = Time_compat.now () in
-  try
-    let argv =
-      [
-        "curl";
-        "-sS";
-        "--http1.1";
-        "--max-time";
-        string_of_int (max 1 timeout_sec);
-        "-X";
-        "POST";
-        url;
-        "-H";
-        "content-type: application/json";
-        "--data-binary";
-        "@-";
-      ]
-    in
-    let status, body =
-      Masc_exec.Exec_gate.run_argv_with_stdin_and_status
-        ~actor:"tool/local_runtime_bench"
-        ~raw_source:(String.concat " " (List.map Filename.quote argv))
-        ~summary:"tool local runtime raw completion"
-        ~timeout_sec:(float_of_int (max 1 (timeout_sec + 2)))
-        ~stdin_content:request_body
-        argv
-    in
-    let latency_ms =
-      int_of_float ((Time_compat.now () -. started) *. 1000.0)
-    in
-    match status with
-    | Unix.WEXITED 0 -> (
-        try
-          let json = Yojson.Safe.from_string body in
-          let open Yojson.Safe.Util in
-          match member "error" json with
-          | `Assoc fields -> (
-              match List.assoc_opt "message" fields with
-              | Some (`String msg) ->
-                  { success = false; latency_ms; error = Some msg }
-              | _ ->
-                  { success = false; latency_ms; error = Some "llama returned error" })
-          | _ ->
-              ignore
-                (match json |> member "choices" |> to_list with
-                 | choice :: _ -> choice |> member "message" |> member "content" |> to_string_option
-                 | [] -> None);
-              { success = true; latency_ms; error = None }
-        with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ | Failure _ ->
-          { success = false; latency_ms; error = Some "invalid llama response json" })
-    | Unix.WEXITED code ->
-        {
-          success = false;
-          latency_ms;
-          error = Some (Printf.sprintf "curl exit code %d" code);
-        }
-    | Unix.WSIGNALED sig_num ->
-        {
-          success = false;
-          latency_ms;
-          error = Some (Printf.sprintf "curl signal %d" sig_num);
-        }
-    | Unix.WSTOPPED sig_num ->
-        {
-          success = false;
-          latency_ms;
-          error = Some (Printf.sprintf "curl stopped %d" sig_num);
-        }
-  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-    {
-      success = false;
-      latency_ms =
-        int_of_float ((Time_compat.now () -. started) *. 1000.0);
-      error = Some (Printexc.to_string exn);
-    }
-
-let raw_completion ~model_id ~prompt ~max_tokens ~timeout_sec () =
-  raw_completion_at ~server_url:Env_config.Llama.server_url ~model_id ~prompt
-    ~max_tokens ~timeout_sec ()
-
 let error_message_of_http_error = function
   | Llm_provider.Http_client.NetworkError { message } -> message
   | Llm_provider.Http_client.AcceptRejected { reason } -> reason
@@ -281,10 +178,11 @@ let oas_completion_at ?runtime_pool ~model_id ~prompt ~max_tokens ~timeout_sec (
     =
   match Masc_eio_env.get_opt () with
   | None ->
-      let base_url = runtime_base_url_for_pool runtime_pool in
-      ( raw_completion_at ~server_url:base_url ~model_id ~prompt ~max_tokens
-          ~timeout_sec (),
-        Local_runtime_pool.runtime_id_of_base_url base_url )
+      (* MASC-OAS boundary: raw curl fallback removed.
+         Bench must run inside an Eio-managed context. *)
+      ( { success = false; latency_ms = 0;
+          error = Some "Eio environment not available; bench requires OAS runtime context" },
+        "unknown" )
   | Some env -> (
       let started = Time_compat.now () in
       let model_label = model_label_for_pool ~model_id runtime_pool in

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -134,6 +134,10 @@ let error_message_of_http_error = function
         | _ -> Printf.sprintf "HTTP %d" code
       with Yojson.Json_error _ -> Printf.sprintf "HTTP %d" code)
 
+(** Probe whether an endpoint supports the OpenAI chat-completions protocol.
+    This is a protocol-level probe; it explicitly depends on OAS
+    [Llm_provider.Complete.complete] because the goal is to verify the
+    endpoint's wire protocol, not to run a full agent turn. *)
 let probe_chat_completion_compatible
     ?(timeout_sec = 5)
     (endpoint : Discovery_cache.endpoint_info) =


### PR DESCRIPTION
## Summary

MASC는 OAS를 소비만 해야 하고, OAS는 MASC를 몰라야 한다. 이 PR은 MASC가 OAS가 이미 관리하는 provider 기본값을 중복 정의하는 부분과, MASC 도구에서 OAS API를 우회하여 직접 HTTP/curl을 사용하는 위반을 제거한다.

## Changes

### P1-1: provider_adapter.ml — deduplicate provider defaults

- `anthropic_api_url`, `openrouter_api_url`, `gemini_generative_api_url`, `kimi_api_url`가 OAS `Llm_provider.Provider_registry.default()`에서 기본 base_url을 조회하도록 변경.
- `openai_api_url`는 OAS registry에 "openai" 항목이 없어 기존 리터럴 유지.
- `glm_api_url`/`glm_coding_api_url`는 이미 `Llm_provider.Zai_catalog`를 참조하므로 변경 없음.

### P1-2: tool_local_runtime_bench.ml — stop bypassing OAS

- `raw_completion_at` (curl + JSON POST, 100+ lines) 및 `raw_completion` wrapper 완전 제거.
- `oas_completion_at`의 Eio 없을 때 fallback을 curl 대신 명시적 에러 반환으로 변경.
- Bench는 이제 항상 OAS `Llm_provider.Complete.complete`를 경유.

### tool_local_runtime_verify.ml — document intentional low-level use

- `probe_chat_completion_compatible`에 doc comment 추가. 이 함수는 protocol-level probe이므로 `Agent.run` 대신 `Llm_provider.Complete.complete` 직접 호출이 정당함을 명시.

## Test Plan

- [x] `dune build --root .` 컴파일 성공
- [ ] `dune runtest` 관련 테스트 통과 (기존 `effective_model_labels_for_turn`, `benchmark`, `source_guard` 실패는 cascade config/CI 환경 문제로 본 변경과 무관)
- [x] `rg \"curl.*http1.1\" lib/` — curl 직접 사용 제거 확인
- [x] 중복 URL 헬퍼 제거 확인

## Out of Scope

- `oas_worker_named.ml`의 MASC-driven cascade FSM — 정당한 coordination 레이어
- `keeper_unified_turn.ml`의 turn budget 계산 — MASC coordination 영역
- OAS 남쪽 코드 수정 — OAS는 MASC를 모르는 원칙 유지