### PR TITLE
fix(kimi-cli): inject MASC_MCP_TOKEN into runtime MCP HTTP headers

### DIFF
--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -197,6 +197,11 @@ let public_mcp_runtime_policy_of_tool_names (tool_names : string list) :
   if not (tool_names_are_public_mcp tool_names) then
     None
   else
+    let masc_headers =
+      match first_nonempty_env [ "MASC_MCP_TOKEN" ] with
+      | Some token -> [ ("Authorization", "Bearer " ^ token) ]
+      | None -> []
+    in
     Some
       {
         Llm_provider.Llm_transport.empty_runtime_mcp_policy with
@@ -206,7 +211,7 @@ let public_mcp_runtime_policy_of_tool_names (tool_names : string list) :
               {
                 name = "masc";
                 url = Env_config_runtime.Local_runtime.mcp_url ();
-                headers = [];
+                headers = masc_headers;
               };
           ];
         allowed_server_names = [ "masc" ];


### PR DESCRIPTION
## Problem

`public_mcp_runtime_policy_of_tool_names` previously set `headers = []` for the `masc` HTTP MCP server. This caused **401 Unauthorized** when `kimi` CLI (or any HTTP MCP consumer) tried to call MASC endpoints that require Bearer token auth.

## Fix

Read `MASC_MCP_TOKEN` from the environment and inject it as an `Authorization: Bearer <token>` header. This aligns with `Auth.ensure_keeper_credential` which sources the same env var for keeper subprocess auth.

## Changes

- `lib/oas_worker_exec_transport.ml`: `public_mcp_runtime_policy_of_tool_names` now reads `MASC_MCP_TOKEN` and includes it in the `masc` HTTP server headers.

## Verification

- [ ] Local dune build passes
- [ ] Integration test with `kimi` CLI against local MASC MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)