### PR TITLE
[codex] relax keeper docker sandbox fs

### DIFF
--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -301,6 +301,7 @@ spawn 시 인자로 직접 설정하는 필드.
 
 - keeper shell write는 자기 sandbox 안에서만 허용된다. 현재 local/docker backend의 디스크 구현은 `.masc/playground/<keeper>/`이지만 keeper-facing 경로는 `.` / `mind` / `repos`이다.
 - `sandbox_profile=docker`는 keeper identity 전체에 적용된다. `keeper_bash`뿐 아니라 `keeper_fs_read`, `keeper_fs_edit`, `keeper_shell`의 read/write/git/gh 흐름도 Docker로 라우팅된다. 기본은 read-only rootfs, tmpfs `/tmp`, `cap-drop=ALL`, `no-new-privileges`, `pids-limit`, memory limit, private sandbox mount, network=`none`이다.
+- Docker 내부에서 더 자유로운 부트스트랩/설치가 필요하면 `MASC_KEEPER_SANDBOX_RELAX_FS=true`로 rootfs writable + executable `/tmp` 조합을 켤 수 있다. 이 경우에도 host mount 범위, `cap-drop=ALL`, `no-new-privileges`, pids/memory limit은 유지된다.
 - git/gh 명령 dispatch: `sandbox_profile=docker` 에서 network가 필요한 `git`/`gh` 계열 명령(`keeper_bash`, `keeper_shell op=gh`, `keeper_shell op=git_clone`)은 한 명령 단위로 network=bridge + `~/.config/gh` / `~/.gitconfig` read-only mount + `GH_TOKEN` env forward 경로를 사용한다. 그 외 명령은 계속 network=none 의 hardened container 또는 turn-scoped `docker exec` runtime 으로 실행된다. Docker 라우트 응답에는 `via: "docker"`가 들어오고, git credential dispatch가 켜진 경우 `git_creds_enabled: true`도 함께 들어온다. 비활성화하려면 `MASC_KEEPER_SANDBOX_GIT_DISPATCH=false`. `~/.ssh` mount 는 `MASC_KEEPER_SANDBOX_SSH_DIR` 환경 변수로 명시 opt-in 시에만 활성화된다.
 - 기본 sandbox 이미지는 `masc-keeper-sandbox:local`이다. Docker keeper를 올리기 전에 `scripts/build-keeper-sandbox-image.sh`를 실행해 이미지를 만들고, smoke 검증은 `scripts/keeper-sandbox-smoke.sh`를 사용한다.
 - `shared_memory_scope=room`은 공용 writable mount가 아니라 flattened `default` namespace typed lane만 연다.

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -558,6 +558,30 @@ module KeeperSandbox = struct
   let tmpfs_size () =
     get_string ~default:"256m" "MASC_KEEPER_SANDBOX_TMPFS_SIZE"
 
+  (** Relax filesystem hardening inside the Docker sandbox while still
+      keeping host isolation and the same sandbox mount topology.
+
+      When true:
+      - omit [--read-only] so the image rootfs is writable
+      - drop [/tmp]'s [noexec] bit so installers/runtime bootstraps can
+        execute temporary files inside the container
+
+      This is intentionally narrower than a full "unsafe" mode: caps,
+      no-new-privileges, memory/pids limits, and mount scoping remain. *)
+  let relax_fs () =
+    get_bool ~default:false "MASC_KEEPER_SANDBOX_RELAX_FS"
+
+  let read_only_rootfs_args () =
+    if relax_fs () then [] else [ "--read-only" ]
+
+  let tmpfs_mount () =
+    let exec_suffix =
+      if relax_fs () then "" else ",noexec"
+    in
+    Printf.sprintf "/tmp:rw,nosuid,nodev%s,size=%s"
+      exec_suffix
+      (tmpfs_size ())
+
   (** Optional seccomp profile path passed to [docker run --security-opt]. *)
   let seccomp_profile () =
     get_string ~default:"" "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE"

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -254,8 +254,6 @@ let keeper_entries =
   [
     entry ~default:"true" "MASC_KEEPER_BOOTSTRAP_ENABLED"
       "Enable keeper auto-bootstrap";
-    entry ~default:"10000" "MASC_KEEPER_BOOTSTRAP_MAX_ACTIVE_KEEPERS"
-      "Max concurrent active keepers";
     entry ~default:"300" "MASC_KEEPER_SNAPSHOT_SEC"
       "Keeper keepalive snapshot interval";
     entry ~default:"false" "MASC_KEEPER_DEBUG" "Enable keeper debug logging";
@@ -538,6 +536,8 @@ let keeper_sandbox_entries =
       "Memory limit for hardened keeper containers";
     entry ~default:"256m" "MASC_KEEPER_SANDBOX_TMPFS_SIZE"
       "Writable /tmp tmpfs size for hardened keeper containers";
+    entry ~default:"false" "MASC_KEEPER_SANDBOX_RELAX_FS"
+      "Relax Docker sandbox filesystem hardening (writable rootfs + exec /tmp)";
     entry ~default:"(none)" "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE"
       "Optional seccomp profile path for hardened keeper containers";
     entry ~default:"false" "MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS"

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -1389,6 +1389,8 @@ let keeper_config_json (config : Coord.config) (name : string)
             string_or_null (Env_config_keeper.KeeperSandbox.memory ()));
           ("tmpfs_size",
             string_or_null (Env_config_keeper.KeeperSandbox.tmpfs_size ()));
+          ("relax_fs",
+            `Bool (Env_config_keeper.KeeperSandbox.relax_fs ()));
           ("seccomp_profile",
             string_or_null
               (Env_config_keeper.KeeperSandbox.seccomp_profile ()));

--- a/lib/keeper/keeper_docker_read.ml
+++ b/lib/keeper/keeper_docker_read.ml
@@ -68,10 +68,11 @@ let build_docker_argv ~image ~container_name ~host_root ~croot
     "--name"; container_name;
     "-i";
     "--user"; Printf.sprintf "%d:%d" uid gid;
-    "--read-only";
+  ]
+  @ Env_config_keeper.KeeperSandbox.read_only_rootfs_args ()
+  @ [
     "--tmpfs";
-    Printf.sprintf "/tmp:rw,nosuid,nodev,noexec,size=%s"
-      (Env_config_keeper.KeeperSandbox.tmpfs_size ());
+    Env_config_keeper.KeeperSandbox.tmpfs_mount ();
     "--cap-drop=ALL";
     "--security-opt"; "no-new-privileges";
   ]

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -184,10 +184,11 @@ let run_docker_shell_command_with_status
           "-i";
           "--user";
           Printf.sprintf "%d:%d" uid gid;
-          "--read-only";
+        ]
+        @ Env_config_keeper.KeeperSandbox.read_only_rootfs_args ()
+        @ [
           "--tmpfs";
-          (Printf.sprintf "/tmp:rw,nosuid,nodev,noexec,size=%s"
-             (Env_config_keeper.KeeperSandbox.tmpfs_size ()));
+          Env_config_keeper.KeeperSandbox.tmpfs_mount ();
           "--cap-drop=ALL";
           "--security-opt";
           "no-new-privileges";

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -130,10 +130,11 @@ let start_container (t : t) ~(timeout_sec : float) =
             container_name;
             "--user";
             Printf.sprintf "%d:%d" t.uid t.gid;
-            "--read-only";
+          ]
+          @ Env_config_keeper.KeeperSandbox.read_only_rootfs_args ()
+          @ [
             "--tmpfs";
-            Printf.sprintf "/tmp:rw,nosuid,nodev,noexec,size=%s"
-              (Env_config_keeper.KeeperSandbox.tmpfs_size ());
+            Env_config_keeper.KeeperSandbox.tmpfs_mount ();
             "--cap-drop=ALL";
             "--security-opt";
             "no-new-privileges";

--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -13,6 +13,7 @@ module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_alerting_path = Masc_mcp.Keeper_alerting_path
 module Keeper_sandbox = Masc_mcp.Keeper_sandbox
 module Keeper_sandbox_runtime = Masc_mcp.Keeper_sandbox_runtime
+module Env_config_keeper = Masc_mcp.Env_config_keeper
 
 (* ── Helpers ─────────────────────────────────────────────────────── *)
 
@@ -544,6 +545,73 @@ let test_turn_runtime_reuses_single_container () =
   Alcotest.(check int) "docker exec happens twice" 2 (count "exec ");
   Alcotest.(check int) "docker rm happens once" 1 (count "rm -f ")
 
+let test_default_fs_hardening_helpers () =
+  with_env "MASC_KEEPER_SANDBOX_RELAX_FS" "false" @@ fun () ->
+  Alcotest.(check (list string)) "default helper keeps read-only rootfs"
+    [ "--read-only" ]
+    (Env_config_keeper.KeeperSandbox.read_only_rootfs_args ());
+  Alcotest.(check bool) "default helper keeps tmpfs noexec" true
+    (contains_substring
+       (Env_config_keeper.KeeperSandbox.tmpfs_mount ())
+       "/tmp:rw,nosuid,nodev,noexec,size=")
+
+let test_relaxed_fs_helpers () =
+  with_env "MASC_KEEPER_SANDBOX_RELAX_FS" "true" @@ fun () ->
+  Alcotest.(check (list string)) "relaxed helper drops read-only rootfs"
+    [] (Env_config_keeper.KeeperSandbox.read_only_rootfs_args ());
+  Alcotest.(check bool) "relaxed helper drops tmpfs noexec" false
+    (contains_substring
+       (Env_config_keeper.KeeperSandbox.tmpfs_mount ())
+       "/tmp:rw,nosuid,nodev,noexec,size=");
+  Alcotest.(check bool) "relaxed helper keeps writable tmpfs mount" true
+    (contains_substring
+       (Env_config_keeper.KeeperSandbox.tmpfs_mount ())
+       "/tmp:rw,nosuid,nodev,size=")
+
+let test_turn_runtime_relaxed_fs_omits_readonly_and_noexec () =
+  with_fake_docker fake_docker_turn_runtime_script @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE" "" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS" "false" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_REQUIRE_USERNS" "false" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_RELAX_FS" "true" @@ fun () ->
+  let base, config, meta = setup_config "minjae" in
+  let log_path = Filename.concat base "docker.log" in
+  let host_root =
+    Filename.concat (Keeper_alerting_path.project_root_of_config config)
+      (Keeper_alerting_path.playground_path_of_keeper meta.name)
+  in
+  ensure_dir host_root;
+  with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
+  let runtime = Keeper_turn_sandbox_runtime.create ~config ~meta in
+  Fun.protect ~finally:(fun () ->
+    Keeper_turn_sandbox_runtime.cleanup runtime;
+    cleanup_dir base) @@ fun () ->
+  (match
+     Keeper_docker_read.run_command_in_container_with_status
+       ~turn_sandbox_runtime:runtime
+       ~config ~meta
+       ~command_argv:[ "cat"; "/home/keeper/playground/minjae/mind/demo.txt" ]
+       ~max_bytes:4096 ~timeout_sec:5.0 ()
+   with
+   | Error msg -> Alcotest.failf "expected turn runtime command success, got %s" msg
+   | Ok _ -> ());
+  Keeper_turn_sandbox_runtime.cleanup runtime;
+  let run_line =
+    read_file log_path
+    |> String.split_on_char '\n'
+    |> List.find_opt (fun line -> String.starts_with ~prefix:"run -d " line)
+  in
+  match run_line with
+  | None -> Alcotest.fail "expected docker run log line"
+  | Some line ->
+      Alcotest.(check bool) "relaxed runtime drops read-only rootfs" false
+        (contains_substring line "--read-only");
+      Alcotest.(check bool) "relaxed runtime drops tmpfs noexec" false
+        (contains_substring line "/tmp:rw,nosuid,nodev,noexec,size=");
+      Alcotest.(check bool) "relaxed runtime keeps tmpfs mount" true
+        (contains_substring line "/tmp:rw,nosuid,nodev,size=")
+
 let () =
   Alcotest.run "Keeper_docker_read"
     [
@@ -584,8 +652,15 @@ let () =
             test_run_command_allows_configured_nonzero_exit;
           Alcotest.test_case "preserves bare command argv" `Quick
             test_run_command_preserves_bare_command_argv;
+          Alcotest.test_case "default fs hardening helpers" `Quick
+            test_default_fs_hardening_helpers;
+          Alcotest.test_case "relaxed fs helpers" `Quick
+            test_relaxed_fs_helpers;
           Alcotest.test_case "turn runtime reuses single container" `Quick
             test_turn_runtime_reuses_single_container;
+          Alcotest.test_case
+            "turn runtime relaxed fs omits readonly and noexec"
+            `Quick test_turn_runtime_relaxed_fs_omits_readonly_and_noexec;
         ] );
       ( "docker_preflight",
         [


### PR DESCRIPTION
## What changed
- add opt-in `MASC_KEEPER_SANDBOX_RELAX_FS=true` to relax Docker sandbox filesystem hardening for keeper
- reuse the same relaxed FS behavior across keeper shell, docker read, and turn sandbox runtime
- surface the new env in config snapshot, dashboard runtime info, tests, and keeper user manual
- dedupe the duplicate `MASC_KEEPER_BOOTSTRAP_MAX_ACTIVE_KEEPERS` snapshot entry so the keeper env snapshot stays SSOT-clean

## Why
Keeper Docker sandbox was working, but the hardened default blocked common in-container bootstrap flows. This adds an explicit opt-in path for writable rootfs and executable `/tmp` while keeping the default hardened behavior unchanged.

The snapshot list also had one duplicate env registration for `MASC_KEEPER_BOOTSTRAP_MAX_ACTIVE_KEEPERS`, which made the env inventory noisier than intended.

## Impact
- default keeper Docker sandbox behavior stays hardened
- operators can opt into a looser dev-container style filesystem with `MASC_KEEPER_SANDBOX_RELAX_FS=true`
- dashboard/config surfaces now expose that mode clearly
- snapshot env inventory no longer contains the duplicate bootstrap active-keeper entry

## Validation
- duplicate snapshot entry scan on `lib/config/env_config_snapshot.ml` returns no duplicates
- `./_build/default/test/test_keeper_docker_read.exe`
- `./_build/default/test/test_keeper_shell_docker_route.exe`
- `scripts/keeper-sandbox-smoke.sh`

## Follow-up
- fresh clean worktree build path issue tracked separately: https://github.com/jeong-sik/masc-mcp/issues/9438
