### PR TITLE
[codex] Fix OAS worker env helper order

### DIFF
--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -191,6 +191,16 @@ let public_mcp_tools_of_oas_tools (tools : Oas.Tool.t list) =
 let tool_names_are_public_mcp (tool_names : string list) =
   tool_names <> [] && List.for_all Tool_catalog.is_public_mcp tool_names
 
+let trim_nonempty value =
+  match value with
+  | Some raw ->
+      let trimmed = String.trim raw in
+      if String.equal trimmed "" then None else Some trimmed
+  | None -> None
+
+let first_nonempty_env names =
+  List.find_map (fun name -> Sys.getenv_opt name |> trim_nonempty) names
+
 let public_mcp_runtime_policy_of_tool_names (tool_names : string list) :
     Llm_provider.Llm_transport.runtime_mcp_policy option =
   let tool_names = dedupe_preserve_order tool_names in
@@ -224,16 +234,6 @@ let provider_label (provider_cfg : Llm_provider.Provider_config.t) =
   Printf.sprintf "%s:%s"
     (Llm_provider.Provider_config.string_of_provider_kind provider_cfg.kind)
     provider_cfg.model_id
-
-let trim_nonempty value =
-  match value with
-  | Some raw ->
-      let trimmed = String.trim raw in
-      if String.equal trimmed "" then None else Some trimmed
-  | None -> None
-
-let first_nonempty_env names =
-  List.find_map (fun name -> Sys.getenv_opt name |> trim_nonempty) names
 
 let kimi_cli_auth_value (provider_cfg : Llm_provider.Provider_config.t) =
   match trim_nonempty (Some provider_cfg.api_key) with


### PR DESCRIPTION
## What changed
- move `trim_nonempty` and `first_nonempty_env` above `public_mcp_runtime_policy_of_tool_names`
- keep the helper behavior unchanged while removing the forward-reference build break

## Why
- the recent MASC MCP header injection started calling `first_nonempty_env` before its definition in `lib/oas_worker_exec_transport.ml`
- OCaml value bindings are order-dependent here, so the build failed with `Unbound value first_nonempty_env`

## Impact
- restores successful compilation for the OAS worker transport path
- avoids a repo-wide `@check` failure from a single helper ordering regression

## Validation
- `dune build --root . lib/oas_worker_exec_transport.ml`
- `dune build --root . @check --display short`