### PR TITLE
fix(test): correct Env_config_keeper alias in docker read test

### DIFF
--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -13,7 +13,7 @@ module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_alerting_path = Masc_mcp.Keeper_alerting_path
 module Keeper_sandbox = Masc_mcp.Keeper_sandbox
 module Keeper_sandbox_runtime = Masc_mcp.Keeper_sandbox_runtime
-module Env_config_keeper = Masc_mcp.Env_config_keeper
+module Env_config_keeper = Env_config_keeper
 
 (* ── Helpers ─────────────────────────────────────────────────────── *)
 


### PR DESCRIPTION
## Summary

PR #9439 introduced `module Env_config_keeper = Masc_mcp.Env_config_keeper` in `test/test_keeper_docker_read.ml`, but `Env_config_keeper` lives in the `masc_mcp.config` sub-library and is not directly exposed through `Masc_mcp`.

This fix uses the unqualified `Env_config_keeper` alias instead, consistent with how the test module accesses other keeper sub-library modules.

## Test plan

- [x] `dune build --root . test/test_keeper_docker_read.exe` compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)