### PR TITLE
fix(test): correct Env_config_keeper module path (#9438)

### DIFF
--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -13,7 +13,7 @@ module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_alerting_path = Masc_mcp.Keeper_alerting_path
 module Keeper_sandbox = Masc_mcp.Keeper_sandbox
 module Keeper_sandbox_runtime = Masc_mcp.Keeper_sandbox_runtime
-module Env_config_keeper = Masc_mcp.Env_config_keeper
+module Env_config_keeper = Env_config_keeper
 
 (* ── Helpers ─────────────────────────────────────────────────────── *)
 


### PR DESCRIPTION
## Problem

Fresh worktree builds failed with:

```
Error: Unbound module Masc_mcp.Env_config_keeper
```

## Root Cause

`Env_config_keeper` is defined in the `masc_mcp.config` sub-library
(`lib/config/dune`), not directly in the `masc_mcp` library itself.
`lib/dune` does not list `env_config_keeper` in its `(modules ...)`
stanza, so `Masc_mcp.Env_config_keeper` is not a valid name.

The test dependency wrapper (`test/deps/dune`) already re-exports
`masc_mcp.config`, making `Env_config_keeper` available unqualified.

## Fix

Change `Masc_mcp.Env_config_keeper` → `Env_config_keeper`.

Fixes #9438