### PR TITLE
feat(exec): structured error alternatives (axis 2)

### DIFF
--- a/lib/exec/exec_semantic.ml
+++ b/lib/exec/exec_semantic.ml
@@ -89,6 +89,36 @@ let to_hint = function
   | `Permission_denied path ->
       Some (Printf.sprintf "EACCES: cannot execute %s" path)
 
+(** Structured self-correction alternatives for each semantic exit kind.
+    Empty list = no auto-correction possible (operator required).
+    Each alternative string is a complete, actionable suggestion that an
+    LLM agent can execute directly without further clarification. *)
+let to_alternatives = function
+  | `Ok -> []
+  | `Fail _ -> []
+  | `Timeout _ ->
+      [ "Split the command into smaller steps that each complete faster."
+      ; "Pipe intermediate results to a file instead of holding in memory."
+      ]
+  | `Signaled _ -> []
+  | `Git_not_a_repo ->
+      [ "Run `pwd` to check current directory."
+      ; "Clone the repository first: `git clone <url> <dir>` then cd into it."
+      ]
+  | `Oom_killed ->
+      [ "Reduce input size: process fewer files or rows at once."
+      ; "Stream output line-by-line instead of buffering everything."
+      ]
+  | `Policy_denied _ -> []
+  | `Tool_missing tool ->
+      [ Printf.sprintf "Install the missing tool: `opam install %s` or `brew install %s`." tool tool
+      ; Printf.sprintf "Check if %s is installed but not on PATH: `which %s` or `command -v %s`." tool tool tool
+      ]
+  | `Permission_denied _ ->
+      [ "Check file permissions: `ls -la <path>`."
+      ; "The binary may need execute permission: `chmod +x <path>` (if you own it)."
+      ]
+
 type payload_value =
   [ `String of string
   | `Int of int

--- a/lib/exec/exec_semantic.mli
+++ b/lib/exec/exec_semantic.mli
@@ -69,6 +69,12 @@ val interpret_cmd :
 val to_hint : t -> string option
 (** Human-readable operator hint for LLM consumption. None for [`Ok]. *)
 
+val to_alternatives : t -> string list
+(** Self-correction alternatives for each semantic exit kind.
+    Each string is a complete, actionable suggestion that an LLM agent
+    can execute directly. Empty list means no auto-correction is
+    possible (operator intervention required). *)
+
 type payload_value =
   [ `String of string
   | `Int of int

--- a/lib/exec_core.ml
+++ b/lib/exec_core.ml
@@ -71,6 +71,7 @@ type blocked_result = {
   error : string;
   reason : string;
   hint : string;
+  alternatives : string list;
   classification : classification;
   retryability : retryability;
   summary : string;
@@ -494,7 +495,8 @@ let build_process_outcome ~artifact_policy ~base_path ~keeper_name ~cmd ~status
       recovery_hint;
     }
 
-let build_blocked_outcome ~cmd ~error ~reason ?hint ?(retryability = Self_correct) () =
+let build_blocked_outcome ~cmd ~error ~reason ?hint
+    ?(alternatives = []) ?(retryability = Self_correct) () =
   let classification = classify_command ~cmd in
   let summary = summary_of_status classification Blocked in
   let recovery_hint =
@@ -511,6 +513,7 @@ let build_blocked_outcome ~cmd ~error ~reason ?hint ?(retryability = Self_correc
       error;
       reason;
       hint = recovery_hint;
+      alternatives;
       classification;
       retryability;
       summary;
@@ -585,8 +588,17 @@ let semantic_fields_of_executed (result : executed_result) :
       | None -> []
       | Some h -> [ "hint", `String h ]
     in
+    let alternatives_field =
+      match Masc_exec.Exec_semantic.to_alternatives sem with
+      | [] -> []
+      | alts ->
+          [ ( "alternatives",
+              `List (List.map (fun a -> `String a) alts) ) ]
+    in
     let semantic_obj : Yojson.Safe.t =
-      `Assoc (("kind", `String kind) :: payload_fields @ hint_field)
+      `Assoc
+        (("kind", `String kind) :: payload_fields @ hint_field
+       @ alternatives_field)
     in
     let rci_field =
       match Masc_exec.Exec_semantic.to_hint sem with
@@ -694,6 +706,11 @@ let outcome_to_json ?(extra = []) = function
          @ hint_fields
          @ semantic_fields_of_executed result)
   | Blocked_result result ->
+      let alternatives_field =
+        match result.alternatives with
+        | [] -> []
+        | alts -> [ ("alternatives", `List (List.map (fun a -> `String a) alts)) ]
+      in
       `Assoc
         ([
            ("ok", `Bool false);
@@ -708,7 +725,8 @@ let outcome_to_json ?(extra = []) = function
              ("summary", `String result.summary);
              ("hint", `String result.hint);
              ("recovery_hint", `String result.hint);
-           ])
+           ]
+         @ alternatives_field)
 
 let process_result_json ?(artifact_policy = Persist_if_large) ~base_path
     ~keeper_name ~cmd ?(extra = []) ~status ~output () =
@@ -716,7 +734,7 @@ let process_result_json ?(artifact_policy = Persist_if_large) ~base_path
     ~output
   |> outcome_to_json ~extra
 
-let blocked_result_json ~cmd ~error ~reason ?hint ?(retryability = Self_correct)
-    ?(extra = []) () =
-  build_blocked_outcome ~cmd ~error ~reason ?hint ~retryability ()
+let blocked_result_json ~cmd ~error ~reason ?hint ?(alternatives = [])
+    ?(retryability = Self_correct) ?(extra = []) () =
+  build_blocked_outcome ~cmd ~error ~reason ?hint ~alternatives ~retryability ()
   |> outcome_to_json ~extra

--- a/lib/exec_core.mli
+++ b/lib/exec_core.mli
@@ -71,6 +71,7 @@ type blocked_result = {
   error : string;
   reason : string;
   hint : string;
+  alternatives : string list;
   classification : classification;
   retryability : retryability;
   summary : string;
@@ -106,6 +107,7 @@ val build_blocked_outcome :
   error:string ->
   reason:string ->
   ?hint:string ->
+  ?alternatives:string list ->
   ?retryability:retryability ->
   unit ->
   outcome
@@ -131,6 +133,7 @@ val blocked_result_json :
   error:string ->
   reason:string ->
   ?hint:string ->
+  ?alternatives:string list ->
   ?retryability:retryability ->
   ?extra:(string * Yojson.Safe.t) list ->
   unit ->

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -579,6 +579,11 @@ let handle_keeper_bash
            ~reason:
              "This command is destructive (force push, push to main, rm -rf, \
               etc.) and is blocked for all presets."
+           ~alternatives:
+             [ "Use `git push` without --force for normal pushes."
+             ; "For cleanup, target specific files instead of rm -rf."
+             ; "Ask a human operator to perform this destructive action."
+             ]
            ~retryability:Exec_core.Operator_required
            ~extra:[ "cmd", `String cmd_for_log ]
            ()))
@@ -621,12 +626,37 @@ let handle_keeper_bash
           | Empty_command ->
             "Provide a non-empty command string."
         in
+        let alternatives =
+          match reason with
+          | Worker_dev_tools.Command_not_allowed name
+            when String.lowercase_ascii name = "gh" ->
+            [ "Use keeper_shell with op=\"gh\" for GitHub CLI operations."
+            ; "Example: keeper_shell op=gh cmd=\"pr list --state open\"."
+            ]
+          | Chain_or_redirect | Pipes_not_allowed | Unsafe_redirect ->
+            [ "Break the pipeline into separate keeper_bash calls."
+            ; "Save intermediate output to a file, then process it in the next call."
+            ]
+          | Injection | Process_substitution ->
+            [ "Use keeper_shell with a specific op (rg, find, ls) for structured queries."
+            ; "Avoid $(...) and backtick substitution in commands."
+            ]
+          | Command_not_allowed _ ->
+            [ "Use keeper_shell for structured ops (rg, ls, find)."
+            ; "Check if the command is available under a different name or op."
+            ]
+          | Empty_command ->
+            [ "Provide a non-empty command string."
+            ; "Example: keeper_bash cmd='ls -la lib/'."
+            ]
+        in
         Yojson.Safe.to_string
           (Exec_core.blocked_result_json
              ~cmd
              ~error:"command_blocked"
              ~reason:reason_str
              ~hint
+             ~alternatives
              ())
       | Ok () ->
         (* Branch-switch guard *)
@@ -649,6 +679,12 @@ let handle_keeper_bash
                ~hint:(Printf.sprintf
                         "Use cwd=%srepos/REPO/.worktrees/TASK"
                         (Playground_paths.bundle_root meta.name))
+               ~alternatives:
+                 [ Printf.sprintf
+                     "Clone the repo first: keeper_shell op=git_clone, then use cwd=%srepos/REPO/.worktrees/TASK."
+                     (Playground_paths.bundle_root meta.name)
+                 ; "Use keeper_shell op=git op_cmd='branch -a' to list available branches."
+                 ]
                ~retryability:Exec_core.Operator_required
                ~extra:[ "cmd", `String cmd_for_log ]
                ()))
@@ -664,6 +700,10 @@ let handle_keeper_bash
                ~reason:
                  "This command modifies state (git push/commit, make deploy, etc.). \
                   A write-enabled preset (Coding/Delivery/Full) is required."
+               ~alternatives:
+                 [ "Read-only alternatives: use keeper_bash for git log, git diff, git status."
+                 ; "If you need write access, ask the operator to assign a Coding/Delivery/Full preset."
+                 ]
                ~retryability:Exec_core.Operator_required
                ~extra:[ "cmd", `String cmd_for_log ]
                ()))
@@ -699,6 +739,13 @@ let handle_keeper_bash
                         "cwd must start with %s and usually looks like %srepos/REPO/.worktrees/TASK"
                         (Playground_paths.bundle_root meta.name)
                         (Playground_paths.bundle_root meta.name))
+               ~alternatives:
+                 [ Printf.sprintf
+                     "Clone into your sandbox: keeper_shell op=git_clone, then cd to %srepos/REPO/."
+                     (Playground_paths.bundle_root meta.name)
+                 ; "Create a worktree inside your sandbox with masc_worktree_create."
+                 ; "Use keeper_bash with a cwd pointing to your sandbox worktree."
+                 ]
                ~retryability:Exec_core.Operator_required
                ~extra:[ "cmd", `String cmd_for_log; "cwd", `String cwd ]
                ()))


### PR DESCRIPTION
## Summary

Axis 2 of the keeper_bash revolution: **Error Teaching**.

Every blocked command now returns structured `alternatives` — actionable next steps that teach the LLM what to do instead of retrying the same failed approach.

### What changed

- `blocked_result` type gains `alternatives : string list` field
- `exec_semantic.to_alternatives` provides per-exit-kind self-corrections (timeout, git_not_a_repo, oom_killed, tool_missing, permission_denied)
- `semantic_fields_of_executed` includes alternatives in JSON output for executed results too
- 5 block paths in `keeper_exec_shell` supply context-specific alternatives:
  1. **destructive operations** → safe alternatives
  2. **command validation** → structured ops or command-specific fixes
  3. **branch switch** → sandbox clone + worktree path
  4. **write gate** → read-only alternatives or preset upgrade
  5. **write containment** → sandbox + worktree setup steps

### Why

Feedback memory `tool-error-messages-teach-llm` (#7459/#7464/#7466): terse error messages cause LLM retry loops. Each failure reason needs redirect/context/search-hint to converge.

### Backward compatibility

`alternatives` defaults to `[]`. Empty list omits the key from JSON output. No existing callers break.

## Test plan

- [x] `dune build` passes (library targets type-check)
- [x] No exec_core/exec_semantic test regressions
- [ ] Keeper integration: run a keeper and verify blocked commands include alternatives in JSON output
- [ ] LLM behavior: observe that keepers self-correct instead of retrying on blocked commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)