### PR TITLE
refactor: simplify redundant String.concat to ^ operator (task-173)

### DIFF
--- a/lib/agent_economy.ml
+++ b/lib/agent_economy.ml
@@ -149,9 +149,7 @@ let transaction_of_json (json : Yojson.Safe.t) : transaction option =
 
 let generate_txn_id () =
   let rnd = Mirage_crypto_rng.generate 8 in
-  let hex = String.concat ""
-    (List.init (String.length rnd) (fun i ->
-       Printf.sprintf "%02x" (Char.code (String.get rnd i))))
+  let hex = List.fold_left (fun acc s -> acc ^ s) "" (List.init (String.length rnd) (fun i -> Printf.sprintf "%02x" (Char.code (String.get rnd i))))
   in
   Printf.sprintf "txn-%s" hex
 

--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -44,11 +44,7 @@ let with_loops_ro f = Eio.Mutex.use_ro loops_mu (fun () -> f ())
 
 let generate_loop_id () =
   let rnd = Mirage_crypto_rng.generate 4 in
-  let hex = String.concat "" (
-    List.init (String.length rnd) (fun i ->
-      Printf.sprintf "%02x" (Char.code (String.get rnd i))
-    )
-  ) in
+  let hex = List.fold_left (fun acc s -> acc ^ s) "" (List.init (String.length rnd) (fun i -> Printf.sprintf "%02x" (Char.code (String.get rnd i)))) in
   "ar-" ^ hex
 
 let option_first_some left right =

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -619,7 +619,7 @@ let text_of_response (resp : Llm_provider.Types.api_response) : string =
   |> List.filter_map (function
     | Llm_provider.Types.Text t -> Some t
     | _ -> None)
-  |> String.concat ""
+  |> fun lst -> List.fold_left (fun acc s -> acc ^ s) "" lst
 
 (* ── Model resolution: named -> "default" -> hardcoded ─── *)
 

--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -334,7 +334,7 @@ let autoresearch_loops_csv ~(base_path : string) : string =
       ] ^ "\n"
     ) sorted
   in
-  headers ^ String.concat "" rows
+  List.fold_left (fun acc r -> acc ^ r) headers rows
 
 (** Build the loop detail JSON for GET /api/v1/autoresearch/loops/:loopId.
     Includes full cycle history. *)

--- a/lib/grpc/masc_grpc_server.ml
+++ b/lib/grpc/masc_grpc_server.ml
@@ -247,11 +247,7 @@ module Reflection_bridge = struct
         services
     in
     let list_response =
-      String.concat ""
-        (List.map
-           (fun msg ->
-             encode_length_delimited Wire.list_service_service msg)
-           service_msgs)
+      List.fold_left (fun acc msg -> acc ^ encode_length_delimited Wire.list_service_service msg) "" service_msgs
     in
     encode_length_delimited Wire.resp_list_services_response list_response
 
@@ -270,7 +266,7 @@ module Reflection_bridge = struct
     let payload =
       descriptors
       |> List.map (encode_length_delimited Wire.file_descriptor_proto)
-      |> String.concat ""
+      |> fun lst -> List.fold_left (fun acc s -> acc ^ s) "" lst
     in
     encode_length_delimited Wire.resp_file_descriptor_response payload
 

--- a/lib/keeper/keeper_decision_audit.ml
+++ b/lib/keeper/keeper_decision_audit.ml
@@ -191,7 +191,7 @@ let flush_if_needed ~base_path ~keeper_name =
               | Some r -> gather (i + 1) ((Yojson.Safe.to_string (to_json r) ^ "\n") :: acc)
               | None -> gather (i + 1) acc
           in
-          String.concat "" (gather 0 [])
+          List.fold_left (fun acc s -> acc ^ s) "" (gather 0 [])
         in
         (try
           Fs_compat.append_file dir flush_lines;

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -62,19 +62,19 @@ let with_lock f =
 (** {1 Metric Registration} *)
 
 let register_counter ~name ~help ?(labels=[]) () =
-  let key = name ^ (String.concat "" (List.map (fun (k, v) -> k ^ v) labels)) in
+  let key = name ^ (List.fold_left (fun acc (k, v) -> acc ^ k ^ v) "" labels) in
   with_lock (fun () ->
     if not (Hashtbl.mem metrics key) then
       Hashtbl.add metrics key { name; help; metric_type = Counter; value = 0.0; labels })
 
 let register_gauge ~name ~help ?(labels=[]) () =
-  let key = name ^ (String.concat "" (List.map (fun (k, v) -> k ^ v) labels)) in
+  let key = name ^ (List.fold_left (fun acc (k, v) -> acc ^ k ^ v) "" labels) in
   with_lock (fun () ->
     if not (Hashtbl.mem metrics key) then
       Hashtbl.add metrics key { name; help; metric_type = Gauge; value = 0.0; labels })
 
 let register_histogram ~name ~help ?(labels=[]) () =
-  let key = name ^ (String.concat "" (List.map (fun (k, v) -> k ^ v) labels)) in
+  let key = name ^ (List.fold_left (fun acc (k, v) -> acc ^ k ^ v) "" labels) in
   with_lock (fun () ->
     if not (Hashtbl.mem metrics key) then
       Hashtbl.add metrics key { name; help; metric_type = Histogram; value = 0.0; labels })
@@ -82,7 +82,7 @@ let register_histogram ~name ~help ?(labels=[]) () =
 (** {1 Metric Updates} *)
 
 let inc_counter name ?(labels=[]) ?(delta=1.0) () =
-  let key = name ^ (String.concat "" (List.map (fun (k, v) -> k ^ v) labels)) in
+  let key = name ^ (List.fold_left (fun acc (k, v) -> acc ^ k ^ v) "" labels) in
   with_lock (fun () ->
     match Hashtbl.find_opt metrics key with
     | Some m -> m.value <- m.value +. delta
@@ -96,7 +96,7 @@ let inc_counter name ?(labels=[]) ?(delta=1.0) () =
         })
 
 let set_gauge name ?(labels=[]) value =
-  let key = name ^ (String.concat "" (List.map (fun (k, v) -> k ^ v) labels)) in
+  let key = name ^ (List.fold_left (fun acc (k, v) -> acc ^ k ^ v) "" labels) in
   with_lock (fun () ->
     match Hashtbl.find_opt metrics key with
     | Some m -> m.value <- value
@@ -110,7 +110,7 @@ let set_gauge name ?(labels=[]) value =
         })
 
 let inc_gauge name ?(labels=[]) ?(delta=1.0) () =
-  let key = name ^ (String.concat "" (List.map (fun (k, v) -> k ^ v) labels)) in
+  let key = name ^ (List.fold_left (fun acc (k, v) -> acc ^ k ^ v) "" labels) in
   with_lock (fun () ->
     match Hashtbl.find_opt metrics key with
     | Some m -> m.value <- m.value +. delta
@@ -128,7 +128,7 @@ let dec_gauge name ?(labels=[]) ?(delta=1.0) () =
 
 (** Get current metric value by name + labels (if any). *)
 let get_metric_value name ?(labels=[]) () =
-  let key = name ^ (String.concat "" (List.map (fun (k, v) -> k ^ v) labels)) in
+  let key = name ^ (List.fold_left (fun acc (k, v) -> acc ^ k ^ v) "" labels) in
   with_lock (fun () ->
     Hashtbl.find_opt metrics key |> Option.map (fun m -> m.value))
 
@@ -146,8 +146,8 @@ let metric_total name =
     Tracks cumulative sum in the metric value; a matching _count counter
     is auto-created for computing averages. *)
 let observe_histogram name ?(labels=[]) value =
-  let key = name ^ (String.concat "" (List.map (fun (k, v) -> k ^ v) labels)) in
-  let count_key = name ^ "_count" ^ (String.concat "" (List.map (fun (k, v) -> k ^ v) labels)) in
+  let key = name ^ (List.fold_left (fun acc (k, v) -> acc ^ k ^ v) "" labels) in
+  let count_key = name ^ "_count" ^ (List.fold_left (fun acc (k, v) -> acc ^ k ^ v) "" labels) in
   with_lock (fun () ->
     (match Hashtbl.find_opt metrics key with
      | Some m -> m.value <- m.value +. value
@@ -508,7 +508,7 @@ let to_prometheus_text () =
     ) ms
   ) by_name;
   let label_key labels =
-    String.concat "" (List.map (fun (k, v) -> k ^ v) labels)
+    List.fold_left (fun acc (k, v) -> acc ^ k ^ v) "" labels
   in
   Hashtbl.iter (fun name ms ->
     let is_histogram_count =

--- a/lib/random_id/random_id.ml
+++ b/lib/random_id/random_id.ml
@@ -8,9 +8,7 @@
 
 let hex ~bytes =
   let rnd = Mirage_crypto_rng.generate bytes in
-  String.concat ""
-    (List.init (String.length rnd) (fun i ->
-       Printf.sprintf "%02x" (Char.code (String.get rnd i))))
+  List.fold_left (fun acc s -> acc ^ s) "" (List.init (String.length rnd) (fun i -> Printf.sprintf "%02x" (Char.code (String.get rnd i))))
 
 let prefixed ~prefix ~bytes =
   prefix ^ hex ~bytes


### PR DESCRIPTION
## Summary

Replaces `String.concat "" (List.map f xs)` patterns with `List.fold_left (fun acc x -> acc ^ f x) "" xs` across 8 files.

## Files changed

- `lib/autoresearch.ml`
- `lib/agent_economy.ml`
- `lib/random_id/random_id.ml`
- `lib/keeper/keeper_decision_audit.ml`
- `lib/prometheus.ml` (10 occurrences)
- `lib/grpc/masc_grpc_server.ml` (2 occurrences)
- `lib/cascade/cascade_config.ml`
- `lib/dashboard/dashboard_http_autoresearch.ml`

## Verification

- `dune build` passes
- No functional change (pure refactor)

Closes task-173.