### PR TITLE
refactor(keeper): OAS boundary hygiene - Agent_sdk → Oas (#9384)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -187,7 +187,7 @@ let metric_of_block
            | None -> 0)
     | _ -> 0
   in
-  let msg : Agent_sdk.Types.message =
+  let msg : Oas.Types.message =
     {
       Oas.Types.role;
       content = [block];
@@ -2483,15 +2483,15 @@ let run_turn
            in
            receipt_response_text_present_ref := true;
            let assistant_msg =
-             Agent_sdk.Types.make_message
-               ~role:Agent_sdk.Types.Assistant
+             Oas.Types.make_message
+               ~role:Oas.Types.Assistant
                ~metadata:
                  [
                    ( Keeper_memory_policy.replay_metadata_key,
                      Keeper_memory_policy.replay_metadata_of_snapshot
                        state_snapshot );
                  ]
-               [ Agent_sdk.Types.Text response_text ]
+               [ Oas.Types.Text response_text ]
            in
            Keeper_exec_context.persist_message
              ~source:history_assistant_source

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -332,7 +332,7 @@ let result_all items =
 
 let content_block_of_json_strict json =
   try
-    match Agent_sdk.Api.content_block_of_json json with
+    match Oas.Api.content_block_of_json json with
     | Some block -> Ok block
     | None ->
         let open Yojson.Safe.Util in
@@ -340,7 +340,7 @@ let content_block_of_json_strict json =
           json |> member "type" |> to_string_option |> Option.value ~default:"<missing>"
         in
         Error
-          (Agent_sdk.Error.Serialization
+          (Oas.Error.Serialization
              (JsonParseError
                 {
                   detail =
@@ -349,29 +349,29 @@ let content_block_of_json_strict json =
   with
   | Yojson.Safe.Util.Type_error (msg, _) ->
       Error
-        (Agent_sdk.Error.Serialization
+        (Oas.Error.Serialization
            (JsonParseError
               { detail = Printf.sprintf "Invalid content block: %s" msg }))
   | Yojson.Json_error msg ->
       Error
-        (Agent_sdk.Error.Serialization
+        (Oas.Error.Serialization
            (JsonParseError
               { detail = Printf.sprintf "Invalid content block: %s" msg }))
   | Failure msg ->
       Error
-        (Agent_sdk.Error.Serialization
+        (Oas.Error.Serialization
            (JsonParseError
               { detail = Printf.sprintf "Invalid content block: %s" msg }))
 
 let role_of_string_compat raw =
   match String.lowercase_ascii (String.trim raw) with
-  | "system" -> Ok Agent_sdk.Types.System
-  | "user" -> Ok Agent_sdk.Types.User
-  | "assistant" -> Ok Agent_sdk.Types.Assistant
-  | "tool" -> Ok Agent_sdk.Types.Tool
+  | "system" -> Ok Oas.Types.System
+  | "user" -> Ok Oas.Types.User
+  | "assistant" -> Ok Oas.Types.Assistant
+  | "tool" -> Ok Oas.Types.Tool
   | other ->
       Error
-        (Agent_sdk.Error.Serialization
+        (Oas.Error.Serialization
            (UnknownVariant { type_name = "role"; value = other }))
 
 let message_of_json_compat json =
@@ -387,7 +387,7 @@ let message_of_json_compat json =
     | Ok role, Ok content ->
         Ok
           {
-            Agent_sdk.Types.role;
+            Oas.Types.role;
             content;
             name = json |> member "name" |> to_string_option;
             tool_call_id = json |> member "tool_call_id" |> to_string_option;
@@ -398,12 +398,12 @@ let message_of_json_compat json =
   with
   | Yojson.Safe.Util.Type_error (msg, _) ->
       Error
-        (Agent_sdk.Error.Serialization
+        (Oas.Error.Serialization
            (JsonParseError
               { detail = Printf.sprintf "Invalid checkpoint message: %s" msg }))
   | Yojson.Json_error msg ->
       Error
-        (Agent_sdk.Error.Serialization
+        (Oas.Error.Serialization
            (JsonParseError
               { detail = Printf.sprintf "Invalid checkpoint message: %s" msg }))
 
@@ -443,23 +443,23 @@ let checkpoint_of_json_compat json =
     match messages with
     | Error e -> Error e
     | Ok messages -> (
-        match Agent_sdk.Checkpoint.of_json (normalize_checkpoint_json_for_sdk json) with
+        match Oas.Checkpoint.of_json (normalize_checkpoint_json_for_sdk json) with
         | Ok checkpoint -> Ok { checkpoint with messages }
         | Error e -> Error e)
   with
   | Yojson.Safe.Util.Type_error (msg, _) ->
       Error
-        (Agent_sdk.Error.Serialization
+        (Oas.Error.Serialization
            (JsonParseError
               { detail = Printf.sprintf "Checkpoint.of_json compat: %s" msg }))
   | Yojson.Json_error msg ->
       Error
-        (Agent_sdk.Error.Serialization
+        (Oas.Error.Serialization
            (JsonParseError
               { detail = Printf.sprintf "Checkpoint.of_json compat: %s" msg }))
 
 let checkpoint_of_string_compat raw =
-  match Agent_sdk.Checkpoint.of_string raw with
+  match Oas.Checkpoint.of_string raw with
   | Ok checkpoint -> Ok checkpoint
   | Error _ ->
       let json =

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -255,7 +255,7 @@ let metadata_of_json (json : Yojson.Safe.t) : (string * Yojson.Safe.t) list =
   | `Assoc fields -> fields
   | _ -> []
 
-let message_to_json (m : Agent_sdk.Types.message) : Yojson.Safe.t =
+let message_to_json (m : Oas.Types.message) : Yojson.Safe.t =
   let m = Inference_utils.sanitize_message_utf8 m in
   let tool_call_id =
     match m.tool_call_id with
@@ -309,7 +309,7 @@ let message_of_json (json : Yojson.Safe.t) : Oas.Types.message =
   in
   Inference_utils.sanitize_message_utf8
     {
-      Agent_sdk.Types.role;
+      Oas.Types.role;
       content;
       name =
         (json |> member "name" |> to_string_option
@@ -1340,8 +1340,8 @@ let load_context_from_checkpoint ~max_checkpoint_messages ~trace_id ~primary_mod
     [working_context]/[STATE] paths for older checkpoints. *)
 let patch_checkpoint_last_assistant
     ?snapshot
-    (cp : Agent_sdk.Checkpoint.t) ~session_id ~response_text
-  : Agent_sdk.Checkpoint.t =
+    (cp : Oas.Checkpoint.t) ~session_id ~response_text
+  : Oas.Checkpoint.t =
   let snapshot =
     match snapshot with
     | Some snapshot -> Some snapshot
@@ -1374,15 +1374,15 @@ let patch_checkpoint_last_assistant
                   ]
               | None -> []
             in
-            Agent_sdk.Types.make_message
-              ~role:Agent_sdk.Types.Assistant
+            Oas.Types.make_message
+              ~role:Oas.Types.Assistant
               ~metadata
-              [ Agent_sdk.Types.Text visible_response_text ]
+              [ Oas.Types.Text visible_response_text ]
           else msg)
         cp.messages
   in
   let sanitized_messages, _ = sanitize_checkpoint_messages messages in
-  { cp with Agent_sdk.Checkpoint.session_id;
+  { cp with Oas.Checkpoint.session_id;
             messages = sanitized_messages;
             working_context = None }
 

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -748,8 +748,8 @@ let snapshot_of_replay_metadata
   | Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ -> None
 
 let with_snapshot_metadata
-    (msg : Agent_sdk.Types.message)
-    (snapshot : keeper_state_snapshot) : Agent_sdk.Types.message =
+    (msg : Oas.Types.message)
+    (snapshot : keeper_state_snapshot) : Oas.Types.message =
   let metadata =
     (replay_metadata_key, replay_metadata_of_snapshot snapshot)
     :: List.remove_assoc replay_metadata_key msg.metadata
@@ -757,17 +757,17 @@ let with_snapshot_metadata
   { msg with metadata }
 
 let snapshot_of_message_metadata
-    (msg : Agent_sdk.Types.message) : keeper_state_snapshot option =
+    (msg : Oas.Types.message) : keeper_state_snapshot option =
   match List.assoc_opt replay_metadata_key msg.metadata with
   | Some json -> snapshot_of_replay_metadata json
   | None -> None
 
 let snapshot_of_message
-    (msg : Agent_sdk.Types.message) : keeper_state_snapshot option =
+    (msg : Oas.Types.message) : keeper_state_snapshot option =
   match snapshot_of_message_metadata msg with
   | Some _ as snapshot -> snapshot
   | None ->
-      parse_state_snapshot_from_reply (Agent_sdk.Types.text_of_message msg)
+      parse_state_snapshot_from_reply (Oas.Types.text_of_message msg)
 
 (** Extract a [keeper_state_snapshot] from the structured JSON stored in
     [Checkpoint.working_context].  Returns [None] if the JSON does not

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -71,7 +71,7 @@ let apply_post_turn_lifecycle
     let structured_snapshot =
       match oas_checkpoint with
       | Some cp -> (
-          match cp.Agent_sdk.Checkpoint.working_context with
+          match cp.Oas.Checkpoint.working_context with
           | Some json ->
               Keeper_memory_policy.snapshot_of_structured_working_context json
           | None -> None)

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -52,7 +52,7 @@ type turn_event_bus_summary = {
 (** Fold the drained OAS event-bus events for a single keeper turn into
     the signals MASC currently consumes. *)
 val summarize_turn_event_bus :
-  Agent_sdk.Event_bus.event list -> turn_event_bus_summary
+  Oas.Event_bus.event list -> turn_event_bus_summary
 
 (** Build the keeper overflow event from either a drained event-bus
     signal or the structured OAS error fallback. Exposed for tests. *)
@@ -117,7 +117,7 @@ val run_keeper_cycle :
   generation:int ->
   ?channel:Keeper_world_observation.keeper_cycle_channel ->
   ?semaphore_wait_ms:int ->
-  ?shared_context:Agent_sdk.Context.t ->
+  ?shared_context:Oas.Context.t ->
   unit ->
   (Keeper_types.keeper_meta, Oas.Error.sdk_error) result
 
@@ -128,6 +128,6 @@ val run_unified_turn :
   generation:int ->
   ?channel:Keeper_world_observation.keeper_cycle_channel ->
   ?semaphore_wait_ms:int ->
-  ?shared_context:Agent_sdk.Context.t ->
+  ?shared_context:Oas.Context.t ->
   unit ->
   (Keeper_types.keeper_meta, Oas.Error.sdk_error) result


### PR DESCRIPTION
## Summary
Keeper layer OAS boundary cleanup: replace direct `Agent_sdk` references with `Oas` facade.

6 files, 38 references migrated.

## Changes
- `lib/keeper/keeper_checkpoint_store.ml` (17 refs)
- `lib/keeper/keeper_context_core.ml` (8 refs)
- `lib/keeper/keeper_memory_policy.ml` (5 refs)
- `lib/keeper/keeper_agent_run.ml` (4 refs)
- `lib/keeper/keeper_unified_turn.mli` (3 refs)
- `lib/keeper/keeper_post_turn.ml` (1 ref)

## Verification
- `dune build @all` passes

## Related
- Part of #9384 (per-layer batch approach)