### PR TITLE
fix(autoresearch): harden approval gates and git operations

### DIFF
--- a/lib/autoresearch/autoresearch_git.ml
+++ b/lib/autoresearch/autoresearch_git.ml
@@ -64,7 +64,7 @@ let git_commit ~workdir ~message
     Result.error "not inside a git repository"
   else
   let add_status, add_output =
-    run_git_with_status ~timeout_sec:30.0 ~workdir [ "add"; "-A" ]
+    run_git_with_status ~timeout_sec:30.0 ~workdir [ "add"; "--update" ]
   in
   match add_status with
   | Unix.WEXITED 0 -> (
@@ -110,7 +110,7 @@ let git_restore_head ~workdir =
   (try
     let (status, _output) =
       run_git_with_status ~timeout_sec:30.0 ~workdir
-        [ "reset"; "--hard"; "HEAD" ]
+        [ "restore"; "--source=HEAD"; "--worktree"; "--"; "." ]
     in
     match status with
     | Unix.WEXITED 0 -> ()
@@ -124,7 +124,7 @@ let git_reset_last ~workdir =
   (try
     let (status, _output) =
       run_git_with_status ~timeout_sec:30.0 ~workdir
-        [ "reset"; "--hard"; "HEAD~1" ]
+        [ "reset"; "--soft"; "HEAD~1" ]
     in
     match status with
     | Unix.WEXITED 0 -> ()

--- a/lib/autoresearch_codegen.ml
+++ b/lib/autoresearch_codegen.ml
@@ -145,7 +145,9 @@ let generate_code_change ~goal ~baseline ~lower_is_better ~history ~insights
           ~cascade_name:"autoresearch" ~fallback:(fun () -> 0.7))
         ~max_tokens:(Cascade_inference.resolve_max_tokens
           ~cascade_name:"autoresearch" ~fallback:(fun () -> 4096))
-        ~approval:Approval_callbacks.auto_approve
+        ~approval:(Governance_pipeline.to_oas_approval_callback
+                     ~governance_level:(Env_config_core.governance_level ())
+                     ~keeper_name:"autoresearch-system" ())
         ()
     )
   with


### PR DESCRIPTION
## Summary

Hardens two operational safety boundaries in the autoresearch pipeline.

### Phase 1.1 — Approval Gate Hardening

`lib/autoresearch_codegen.ml` previously bypassed HITL approval by passing `~approval:Approval_callbacks.auto_approve` to `Oas_worker.run_named`. Code-generated file mutations (`keeper_fs_edit`, `keeper_write`) now route through `Governance_pipeline.to_oas_approval_callback` at the same `High`/`Critical` risk threshold used by keeper runtime.

### Phase 4.2 — Git Operation Hardening

`lib/autoresearch/autoresearch_git.ml` used destructive git commands:
- `git add -A` → `git add --update` (scoped to tracked files)
- `git reset --hard HEAD` → `git restore --source=HEAD --worktree -- .` (non-destructive)
- `git reset --hard HEAD~1` → `git reset --soft HEAD~1` (preserves working tree)

## Verification

- [ ] `dune build` passes
- [ ] `dune test` passes
- [ ] Autoresearch codegen file-write triggers governance queue entry

## Risk

Low. Autoresearch runs with `max_turns:1` and no persistent keeper identity; a synthetic keeper name (`"autoresearch-system"`) is used for the approval queue.