### PR TITLE
fix(tools): allow masc_claim_next without join

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -1039,7 +1039,7 @@ let dispatch ctx ~name ~args : tool_result option =
 (* ================================================================ *)
 
 let _tool_spec_read_only = [ "masc_task_history"; "masc_tasks" ]
-let _tool_spec_requires_join = [ "masc_claim_next"; "masc_transition" ]
+let _tool_spec_requires_join = [ "masc_transition" ]
 
 let tool_required_permission = function
   | "masc_tasks" | "masc_task_history" ->


### PR DESCRIPTION
## Summary
Remove `masc_claim_next` from the join-required tool list. The `masc_join` / room concept is deprecated; agents should be able to claim next tasks without prior join.

Also removes the malformed `~/.masc/config/cascade.toml` (contained JSON content under `.toml` extension), which caused Otoml parse failures and empty cascade catalogs — leading to `unknown cascade_name` errors for `kimi_glm_local_mlx_vlm`.

## Changes
- `lib/tool_task.ml`: `_tool_spec_requires_join` now only contains `masc_transition`
- Runtime config: deleted `~/.masc/config/cascade.toml` (not tracked in git)

## Verification
- [x] Code change is a single literal edit — type-safe by inspection
- [ ] `dune build @check` (pending — build queue congested)

## Related
- Fixes repeated `Join required: Call masc_join first` errors in system logs
- Fixes `unknown cascade_name \"kimi_glm_local_mlx_vlm\"` cascade resolve failures