### PR TITLE
[codex] Wire goal transition and verification tools

### DIFF
--- a/lib/coord_goals.ml
+++ b/lib/coord_goals.ml
@@ -213,6 +213,20 @@ let parse_optional_transition_action args field =
            ~expected:"string"
            ~received:(Yojson.Safe.to_string json))
 
+let actor_must_be_operator action =
+  match action with
+  | Goal_phase.Operator_block
+  | Goal_phase.Operator_unblock
+  | Goal_phase.Approve_completion
+  | Goal_phase.Reject_completion ->
+      true
+  | Goal_phase.Request_complete
+  | Goal_phase.Pause
+  | Goal_phase.Resume
+  | Goal_phase.Drop
+  | Goal_phase.Reopen ->
+      false
+
 let parse_optional_string_list args field =
   match Yojson.Safe.Util.member field args with
   | `Null -> Ok None
@@ -383,194 +397,200 @@ let handle_goal_transition (ctx : context) args =
       validation_error_result [ err ]
   | Ok goal_id, Ok (Some action), Ok (Some actor) -> (
       let note = get_string_opt args "note" in
-      match Goal_store.get_goal ctx.config ~goal_id with
-      | None -> error_result_typed ~code:Not_found "goal not found"
-      | Some goal ->
-          let goals = Goal_store.list_goals ctx.config () in
-          let effective_policy =
-            Goal_verification.effective_policy_for_nodes
-              ~goals:(goal_policy_nodes goals) ~goal_id
-          in
-          begin
-            match effective_policy with
-            | Error msg -> error_result_typed ~code:Validation_error msg
-            | Ok effective_policy ->
-                let has_effective_verifier_policy =
-                  Option.is_some effective_policy
-                in
-                match
-                  Goal_phase.decide_transition ~phase:goal.phase ~action
-                    ~has_effective_verifier_policy
-                    ~require_completion_approval:goal.require_completion_approval
-                with
-                | Error msg -> error_result_typed ~code:Conflict msg
-                | Ok Goal_phase.Open_verification -> (
-                    match effective_policy with
-                    | None ->
-                        error_result_typed ~code:Internal_error
-                          "effective verifier policy missing"
-                    | Some effective_policy -> (
-                        match
-                          Goal_verification.exclude_requester
-                            ~policy_snapshot:effective_policy ~requested_by:actor
-                        with
-                        | Error msg ->
-                            error_result_typed ~code:Validation_error msg
-                        | Ok policy_snapshot -> (
-                            match
-                              Goal_verification.create_request ctx.config ~goal_id
-                                ~requested_by:actor ~policy_snapshot
-                            with
-                            | Error msg ->
-                                error_result_typed ~code:Internal_error msg
-                            | Ok request -> (
-                                match
-                                  update_goal_phase ctx goal
-                                    ~phase:Goal_phase.Awaiting_verification ?note
-                                    ~active_verification_request_id:request.id ()
-                                with
-                                | Error msg ->
-                                    error_result_typed ~code:Internal_error msg
-                                | Ok updated_goal ->
-                                    emit_goal_event ctx ~goal_id ~event_type:"goal_phase"
-                                      ~payload:
-                                        (`Assoc
-                                          [
-                                            ("phase", Goal_phase.to_yojson updated_goal.phase);
-                                            ("actor", Goal_verification.goal_principal_to_yojson actor);
-                                          ]);
-                                    emit_goal_event ctx ~goal_id
-                                      ~event_type:"goal_verification_opened"
-                                      ~payload:
-                                        (`Assoc
-                                          [
-                                            ( "request",
-                                              Goal_verification.goal_verification_request_to_yojson
-                                                request );
-                                          ]);
-                                    ok_result
-                                      [
-                                        ("goal_id", `String goal_id);
-                                        ( "action",
-                                          `String
-                                            (Goal_phase.action_to_string action) );
-                                        ("goal", Goal_store.goal_to_yojson updated_goal);
-                                        ( "verification_request",
-                                          Goal_verification.goal_verification_request_to_yojson
-                                            request );
-                                        ( "verification_summary",
-                                          verification_summary_json updated_goal
-                                            (Some policy_snapshot) (Some request) );
-                                      ]))))
-                | Ok Goal_phase.Open_approval -> (
-                    match
-                      update_goal_phase ctx goal ~phase:Goal_phase.Awaiting_approval
-                        ?note ~clear_active_verification_request:true ()
-                    with
-                    | Error msg -> error_result_typed ~code:Internal_error msg
-                    | Ok updated_goal ->
-                        emit_goal_event ctx ~goal_id ~event_type:"goal_phase"
-                          ~payload:
-                            (`Assoc
-                              [
-                                ("phase", Goal_phase.to_yojson updated_goal.phase);
-                                ("actor", Goal_verification.goal_principal_to_yojson actor);
-                              ]);
-                        emit_goal_event ctx ~goal_id
-                          ~event_type:"goal_approval_opened"
-                          ~payload:
-                            (`Assoc
-                              [
-                                ("actor", Goal_verification.goal_principal_to_yojson actor);
-                              ]);
-                        ok_result
-                          [
-                            ("goal_id", `String goal_id);
-                            ("action", `String (Goal_phase.action_to_string action));
-                            ("goal", Goal_store.goal_to_yojson updated_goal);
-                            ( "verification_summary",
-                              verification_summary_json updated_goal
-                                effective_policy None );
-                          ])
-                | Ok Goal_phase.Complete -> (
-                    match
-                      update_goal_phase ctx goal ~phase:Goal_phase.Completed ?note
-                        ~clear_active_verification_request:true ()
-                    with
-                    | Error msg -> error_result_typed ~code:Internal_error msg
-                    | Ok updated_goal ->
-                        emit_goal_event ctx ~goal_id ~event_type:"goal_phase"
-                          ~payload:
-                            (`Assoc
-                              [
-                                ("phase", Goal_phase.to_yojson updated_goal.phase);
-                                ("actor", Goal_verification.goal_principal_to_yojson actor);
-                              ]);
-                        ok_result
-                          [
-                            ("goal_id", `String goal_id);
-                            ("action", `String (Goal_phase.action_to_string action));
-                            ("goal", Goal_store.goal_to_yojson updated_goal);
-                            ( "verification_summary",
-                              verification_summary_json updated_goal
-                                effective_policy None );
-                          ])
-                | Ok (Goal_phase.Move_to next_phase) ->
-                    let _ =
-                      match goal.active_verification_request_id, next_phase with
-                      | Some request_id, Goal_phase.Dropped
-                      | Some request_id, Goal_phase.Executing
-                        when goal.phase = Goal_phase.Awaiting_verification ->
-                          ignore (Goal_verification.cancel_request ctx.config ~request_id);
-                          emit_goal_event ctx ~goal_id
-                            ~event_type:"goal_verification_resolved"
+      if actor_must_be_operator action
+         && actor.Goal_verification.kind <> Goal_verification.Operator
+      then
+        error_result_typed ~code:Validation_error
+          "actor.kind must be operator for this transition"
+      else
+        match Goal_store.get_goal ctx.config ~goal_id with
+        | None -> error_result_typed ~code:Not_found "goal not found"
+        | Some goal ->
+            let goals = Goal_store.list_goals ctx.config () in
+            let effective_policy =
+              Goal_verification.effective_policy_for_nodes
+                ~goals:(goal_policy_nodes goals) ~goal_id
+            in
+            begin
+              match effective_policy with
+              | Error msg -> error_result_typed ~code:Validation_error msg
+              | Ok effective_policy ->
+                  let has_effective_verifier_policy =
+                    Option.is_some effective_policy
+                  in
+                  match
+                    Goal_phase.decide_transition ~phase:goal.phase ~action
+                      ~has_effective_verifier_policy
+                      ~require_completion_approval:goal.require_completion_approval
+                  with
+                  | Error msg -> error_result_typed ~code:Conflict msg
+                  | Ok Goal_phase.Open_verification -> (
+                      match effective_policy with
+                      | None ->
+                          error_result_typed ~code:Internal_error
+                            "effective verifier policy missing"
+                      | Some effective_policy -> (
+                          match
+                            Goal_verification.exclude_requester
+                              ~policy_snapshot:effective_policy ~requested_by:actor
+                          with
+                          | Error msg ->
+                              error_result_typed ~code:Validation_error msg
+                          | Ok policy_snapshot -> (
+                              match
+                                Goal_verification.create_request ctx.config ~goal_id
+                                  ~requested_by:actor ~policy_snapshot
+                              with
+                              | Error msg ->
+                                  error_result_typed ~code:Internal_error msg
+                              | Ok request -> (
+                                  match
+                                    update_goal_phase ctx goal
+                                      ~phase:Goal_phase.Awaiting_verification ?note
+                                      ~active_verification_request_id:request.id ()
+                                  with
+                                  | Error msg ->
+                                      error_result_typed ~code:Internal_error msg
+                                  | Ok updated_goal ->
+                                      emit_goal_event ctx ~goal_id ~event_type:"goal_phase"
+                                        ~payload:
+                                          (`Assoc
+                                            [
+                                              ("phase", Goal_phase.to_yojson updated_goal.phase);
+                                              ("actor", Goal_verification.goal_principal_to_yojson actor);
+                                            ]);
+                                      emit_goal_event ctx ~goal_id
+                                        ~event_type:"goal_verification_opened"
+                                        ~payload:
+                                          (`Assoc
+                                            [
+                                              ( "request",
+                                                Goal_verification.goal_verification_request_to_yojson
+                                                  request );
+                                            ]);
+                                      ok_result
+                                        [
+                                          ("goal_id", `String goal_id);
+                                          ( "action",
+                                            `String
+                                              (Goal_phase.action_to_string action) );
+                                          ("goal", Goal_store.goal_to_yojson updated_goal);
+                                          ( "verification_request",
+                                            Goal_verification.goal_verification_request_to_yojson
+                                              request );
+                                          ( "verification_summary",
+                                            verification_summary_json updated_goal
+                                              (Some policy_snapshot) (Some request) );
+                                        ]))))
+                  | Ok Goal_phase.Open_approval -> (
+                      match
+                        update_goal_phase ctx goal ~phase:Goal_phase.Awaiting_approval
+                          ?note ~clear_active_verification_request:true ()
+                      with
+                      | Error msg -> error_result_typed ~code:Internal_error msg
+                      | Ok updated_goal ->
+                          emit_goal_event ctx ~goal_id ~event_type:"goal_phase"
                             ~payload:
                               (`Assoc
                                 [
-                                  ("request_id", `String request_id);
-                                  ("status", `String "cancelled");
-                                ])
-                      | _ -> ()
-                    in
-                    match
-                      update_goal_phase ctx goal ~phase:next_phase ?note
-                        ~clear_active_verification_request:
-                          (next_phase <> Goal_phase.Awaiting_verification)
-                        ()
-                    with
-                    | Error msg -> error_result_typed ~code:Internal_error msg
-                    | Ok updated_goal ->
-                        emit_goal_event ctx ~goal_id ~event_type:"goal_phase"
-                          ~payload:
-                            (`Assoc
-                              [
-                                ("phase", Goal_phase.to_yojson updated_goal.phase);
-                                ("actor", Goal_verification.goal_principal_to_yojson actor);
-                              ]);
-                        if action = Goal_phase.Approve_completion
-                           || action = Goal_phase.Reject_completion then
-                          emit_goal_event ctx ~goal_id
-                            ~event_type:"goal_approval_resolved"
-                            ~payload:
-                              (`Assoc
-                                [
-                                  ( "decision",
-                                    `String
-                                      (if action = Goal_phase.Approve_completion then
-                                         "approve"
-                                       else
-                                         "reject") );
+                                  ("phase", Goal_phase.to_yojson updated_goal.phase);
+                                  ("actor", Goal_verification.goal_principal_to_yojson actor);
                                 ]);
-                        ok_result
-                          [
-                            ("goal_id", `String goal_id);
-                            ("action", `String (Goal_phase.action_to_string action));
-                            ("goal", Goal_store.goal_to_yojson updated_goal);
-                            ( "verification_summary",
-                              verification_summary_json updated_goal
-                                effective_policy None );
-                          ]
-          end)
+                          emit_goal_event ctx ~goal_id
+                            ~event_type:"goal_approval_opened"
+                            ~payload:
+                              (`Assoc
+                                [
+                                  ("actor", Goal_verification.goal_principal_to_yojson actor);
+                                ]);
+                          ok_result
+                            [
+                              ("goal_id", `String goal_id);
+                              ("action", `String (Goal_phase.action_to_string action));
+                              ("goal", Goal_store.goal_to_yojson updated_goal);
+                              ( "verification_summary",
+                                verification_summary_json updated_goal
+                                  effective_policy None );
+                            ])
+                  | Ok Goal_phase.Complete -> (
+                      match
+                        update_goal_phase ctx goal ~phase:Goal_phase.Completed ?note
+                          ~clear_active_verification_request:true ()
+                      with
+                      | Error msg -> error_result_typed ~code:Internal_error msg
+                      | Ok updated_goal ->
+                          emit_goal_event ctx ~goal_id ~event_type:"goal_phase"
+                            ~payload:
+                              (`Assoc
+                                [
+                                  ("phase", Goal_phase.to_yojson updated_goal.phase);
+                                  ("actor", Goal_verification.goal_principal_to_yojson actor);
+                                ]);
+                          ok_result
+                            [
+                              ("goal_id", `String goal_id);
+                              ("action", `String (Goal_phase.action_to_string action));
+                              ("goal", Goal_store.goal_to_yojson updated_goal);
+                              ( "verification_summary",
+                                verification_summary_json updated_goal
+                                  effective_policy None );
+                            ])
+                  | Ok (Goal_phase.Move_to next_phase) ->
+                      let _ =
+                        match goal.active_verification_request_id, next_phase with
+                        | Some request_id, Goal_phase.Dropped
+                        | Some request_id, Goal_phase.Executing
+                          when goal.phase = Goal_phase.Awaiting_verification ->
+                            ignore (Goal_verification.cancel_request ctx.config ~request_id);
+                            emit_goal_event ctx ~goal_id
+                              ~event_type:"goal_verification_resolved"
+                              ~payload:
+                                (`Assoc
+                                  [
+                                    ("request_id", `String request_id);
+                                    ("status", `String "cancelled");
+                                  ])
+                        | _ -> ()
+                      in
+                      match
+                        update_goal_phase ctx goal ~phase:next_phase ?note
+                          ~clear_active_verification_request:
+                            (next_phase <> Goal_phase.Awaiting_verification)
+                          ()
+                      with
+                      | Error msg -> error_result_typed ~code:Internal_error msg
+                      | Ok updated_goal ->
+                          emit_goal_event ctx ~goal_id ~event_type:"goal_phase"
+                            ~payload:
+                              (`Assoc
+                                [
+                                  ("phase", Goal_phase.to_yojson updated_goal.phase);
+                                  ("actor", Goal_verification.goal_principal_to_yojson actor);
+                                ]);
+                          if action = Goal_phase.Approve_completion
+                             || action = Goal_phase.Reject_completion then
+                            emit_goal_event ctx ~goal_id
+                              ~event_type:"goal_approval_resolved"
+                              ~payload:
+                                (`Assoc
+                                  [
+                                    ( "decision",
+                                      `String
+                                        (if action = Goal_phase.Approve_completion then
+                                           "approve"
+                                         else
+                                           "reject") );
+                                  ]);
+                          ok_result
+                            [
+                              ("goal_id", `String goal_id);
+                              ("action", `String (Goal_phase.action_to_string action));
+                              ("goal", Goal_store.goal_to_yojson updated_goal);
+                              ( "verification_summary",
+                                verification_summary_json updated_goal
+                                  effective_policy None );
+                            ]
+            end)
   | Ok _, Ok None, _ ->
       validation_error_result
         [

--- a/lib/coord_goals.ml
+++ b/lib/coord_goals.ml
@@ -1,11 +1,37 @@
-(** Coord_goals - Handlers for goal management tools *)
+(** Coord_goals - Handlers for goal management tools. *)
 
 open Coord_types
 open Tool_args
 
 let goal_horizon_strings = [ "short"; "mid"; "long" ]
 let goal_status_strings = [ "active"; "paused"; "done"; "dropped" ]
+let goal_phase_strings =
+  [
+    "executing";
+    "awaiting_verification";
+    "awaiting_approval";
+    "blocked";
+    "paused";
+    "completed";
+    "dropped";
+  ]
+
 let goal_review_outcome_strings = [ "done"; "progress"; "blocked"; "dropped" ]
+let goal_transition_action_strings =
+  [
+    "request_complete";
+    "approve_completion";
+    "reject_completion";
+    "pause";
+    "resume";
+    "operator_block";
+    "operator_unblock";
+    "drop";
+    "reopen";
+  ]
+
+let goal_vote_decision_strings = [ "approve"; "reject" ]
+let goal_principal_kind_strings = [ "operator"; "keeper" ]
 
 let make_enum_field_error ~field ~allowed ~received =
   {
@@ -58,6 +84,22 @@ let parse_optional_goal_status args field =
            ~expected:"string"
            ~received:(Yojson.Safe.to_string json))
 
+let parse_optional_goal_phase args field =
+  match Yojson.Safe.Util.member field args with
+  | `Null -> Ok None
+  | `String raw -> (
+      match Goal_store.parse_goal_phase (Some raw) with
+      | Some phase -> Ok (Some phase)
+      | None ->
+          Error
+            (make_enum_field_error ~field ~allowed:goal_phase_strings
+               ~received:raw))
+  | json ->
+      Error
+        (make_type_field_error ~field ~constraint_violated:Type_string
+           ~expected:"string"
+           ~received:(Yojson.Safe.to_string json))
+
 let parse_optional_review_outcome args field =
   match Yojson.Safe.Util.member field args with
   | `Null -> Ok None
@@ -94,6 +136,167 @@ let parse_optional_priority args field =
            ~expected:"integer"
            ~received:(Yojson.Safe.to_string json))
 
+let parse_optional_bool args field =
+  match Yojson.Safe.Util.member field args with
+  | `Null -> Ok None
+  | `Bool value -> Ok (Some value)
+  | json ->
+      Error
+        (make_type_field_error ~field ~constraint_violated:Type_bool
+           ~expected:"boolean"
+           ~received:(Yojson.Safe.to_string json))
+
+let parse_optional_policy args field =
+  match Yojson.Safe.Util.member field args with
+  | `Null -> Ok None
+  | json -> (
+      match Goal_verification.goal_verifier_policy_of_yojson json with
+      | Ok policy -> Ok (Some policy)
+      | Error msg ->
+          Error
+            {
+              field;
+              constraint_violated = Type_string;
+              message = msg;
+              expected = Some "goal_verifier_policy";
+              received = Some (Yojson.Safe.to_string json);
+            })
+
+let parse_optional_principal args field =
+  match Yojson.Safe.Util.member field args with
+  | `Null -> Ok None
+  | json -> (
+      match Goal_verification.goal_principal_of_yojson json with
+      | Ok principal -> Ok (Some principal)
+      | Error msg ->
+          Error
+            {
+              field;
+              constraint_violated = Type_string;
+              message = msg;
+              expected = Some "goal_principal";
+              received = Some (Yojson.Safe.to_string json);
+            })
+
+let parse_optional_vote_decision args field =
+  match Yojson.Safe.Util.member field args with
+  | `Null -> Ok None
+  | `String raw -> (
+      match
+        String.trim raw |> String.lowercase_ascii
+        |> Goal_verification.vote_decision_of_string
+      with
+      | Some decision -> Ok (Some decision)
+      | None ->
+          Error
+            (make_enum_field_error ~field ~allowed:goal_vote_decision_strings
+               ~received:raw))
+  | json ->
+      Error
+        (make_type_field_error ~field ~constraint_violated:Type_string
+           ~expected:"string"
+           ~received:(Yojson.Safe.to_string json))
+
+let parse_optional_transition_action args field =
+  match Yojson.Safe.Util.member field args with
+  | `Null -> Ok None
+  | `String raw -> (
+      match Goal_phase.parse_action raw with
+      | Some action -> Ok (Some action)
+      | None ->
+          Error
+            (make_enum_field_error ~field ~allowed:goal_transition_action_strings
+               ~received:raw))
+  | json ->
+      Error
+        (make_type_field_error ~field ~constraint_violated:Type_string
+           ~expected:"string"
+           ~received:(Yojson.Safe.to_string json))
+
+let parse_optional_string_list args field =
+  match Yojson.Safe.Util.member field args with
+  | `Null -> Ok None
+  | `List values -> (
+      try Ok (Some (List.map Yojson.Safe.Util.to_string values))
+      with _ ->
+        Error
+          (make_type_field_error ~field ~constraint_violated:Type_string
+             ~expected:"string[]"
+             ~received:(Yojson.Safe.to_string (`List values))))
+  | json ->
+      Error
+        (make_type_field_error ~field ~constraint_violated:Type_string
+           ~expected:"string[]"
+           ~received:(Yojson.Safe.to_string json))
+
+let goal_policy_nodes goals =
+  List.map
+    (fun (goal : Goal_store.goal) ->
+      {
+        Goal_verification.goal_id = goal.id;
+        parent_goal_id = goal.parent_goal_id;
+        verifier_policy = goal.verifier_policy;
+      })
+    goals
+
+let verification_summary_json (goal : Goal_store.goal)
+    (effective_policy : Goal_verification.policy_snapshot option)
+    (open_request : Goal_verification.goal_verification_request option) =
+  let effective_policy_json =
+    match effective_policy with
+    | None -> `Null
+    | Some policy -> Goal_verification.policy_snapshot_to_yojson policy
+  in
+  let open_request_json =
+    match open_request with
+    | None -> `Null
+    | Some request -> Goal_verification.goal_verification_request_to_yojson request
+  in
+  let approve_count, reject_count, remaining_possible =
+    match open_request with
+    | None -> (0, 0, 0)
+    | Some request ->
+        ( Goal_verification.count_votes ~decision:Goal_verification.Approve request,
+          Goal_verification.count_votes ~decision:Goal_verification.Reject request,
+          Goal_verification.remaining_possible_votes request )
+  in
+  `Assoc
+    [
+      ("phase", Goal_phase.to_yojson goal.phase);
+      ("effective_policy", effective_policy_json);
+      ("open_request", open_request_json);
+      ("approve_count", `Int approve_count);
+      ("reject_count", `Int reject_count);
+      ("remaining_possible", `Int remaining_possible);
+      ("pending_verification_count", `Int (if open_request = None then 0 else 1));
+    ]
+
+let update_goal_phase (ctx : context) (goal : Goal_store.goal) ~phase ?note
+    ?active_verification_request_id ?(clear_active_verification_request = false)
+    () =
+  let last_review_note, last_review_at =
+    match note with
+    | Some note -> (Some note, Some (Types.now_iso ()))
+    | None -> (goal.last_review_note, goal.last_review_at)
+  in
+  Goal_store.update_goal ctx.config ~goal_id:goal.id (fun current ->
+      {
+        current with
+        phase;
+        status = Goal_store.goal_status_of_phase phase;
+        active_verification_request_id =
+          (if clear_active_verification_request then
+             None
+           else match active_verification_request_id with
+          | Some value -> Some value
+          | None -> current.active_verification_request_id);
+        last_review_note;
+        last_review_at;
+      })
+
+let emit_goal_event ctx ~goal_id ~event_type ~payload =
+  Goal_verification.emit_event ctx.config ~goal_id ~event_type ~payload
+
 let handle_goal_list (ctx : context) args =
   match parse_optional_horizon args "horizon", parse_optional_goal_status args "status" with
   | Error err, _
@@ -114,46 +317,414 @@ let handle_goal_upsert (ctx : context) args =
   match
     parse_optional_horizon args "horizon",
     parse_optional_goal_status args "status",
-    parse_optional_priority args "priority"
+    parse_optional_goal_phase args "phase",
+    parse_optional_priority args "priority",
+    parse_optional_policy args "verifier_policy",
+    parse_optional_bool args "require_completion_approval"
   with
-  | Error err, _, _
-  | _, Error err, _
-  | _, _, Error err ->
+  | Error err, _, _, _, _, _
+  | _, Error err, _, _, _, _
+  | _, _, Error err, _, _, _
+  | _, _, _, Error err, _, _
+  | _, _, _, _, Error err, _
+  | _, _, _, _, _, Error err ->
       validation_error_result [ err ]
-  | Ok horizon, Ok status, Ok priority ->
+  | Ok horizon, Ok status, Ok phase, Ok priority, Ok verifier_policy,
+    Ok require_completion_approval ->
       let id = get_string_opt args "id" in
       let title = get_string_opt args "title" in
       let metric = get_string_opt args "metric" in
       let target_value = get_string_opt args "target_value" in
       let due_date = get_string_opt args "due_date" in
       let parent_goal_id = get_string_opt args "parent_goal_id" in
-      match
-        Goal_store.upsert_goal ctx.config ?id ?horizon ?title ?metric
-          ?target_value ?due_date ?priority ?status ?parent_goal_id ()
-      with
-      | Error msg -> error_result_typed ~code:Validation_error msg
-      | Ok (goal, action) ->
-          let action_name =
-            match action with
-            | `created -> "created"
-            | `updated -> "updated"
+      begin
+        match phase with
+        | Some Goal_phase.Awaiting_verification
+        | Some Goal_phase.Awaiting_approval ->
+            error_result_typed ~code:Validation_error
+              "Use masc_goal_transition for verification and approval phases"
+        | _ -> (
+            match
+              Goal_store.upsert_goal ctx.config ?id ?horizon ?title ?metric
+                ?target_value ?due_date ?priority ?status ?phase ?parent_goal_id
+                ?verifier_policy ?require_completion_approval ()
+            with
+            | Error msg -> error_result_typed ~code:Validation_error msg
+            | Ok (goal, action) ->
+                let action_name =
+                  match action with
+                  | `created -> "created"
+                  | `updated -> "updated"
+                in
+                let task_marker = Printf.sprintf "[goal:%s]" goal.id in
+                ok_result
+                  [
+                    ("action", `String action_name);
+                    ("goal_id", `String goal.id);
+                    ("goal", Goal_store.goal_to_yojson goal);
+                    ( "task_goal_id_example",
+                      `String
+                        (Printf.sprintf
+                           {|masc_add_task({title: "Implement %s", goal_id: "%s"})|}
+                           goal.title goal.id) );
+                    ("task_title_marker", `String task_marker);
+                    ( "linked_task_title_example",
+                      `String
+                        (Printf.sprintf "%s[child] %s" task_marker goal.title) );
+                  ])
+      end
+
+let handle_goal_transition (ctx : context) args =
+  match validate_string_required args "goal_id", parse_optional_transition_action args "action",
+        parse_optional_principal args "actor" with
+  | Error err, _, _
+  | _, Error err, _
+  | _, _, Error err ->
+      validation_error_result [ err ]
+  | Ok goal_id, Ok (Some action), Ok (Some actor) -> (
+      let note = get_string_opt args "note" in
+      match Goal_store.get_goal ctx.config ~goal_id with
+      | None -> error_result_typed ~code:Not_found "goal not found"
+      | Some goal ->
+          let goals = Goal_store.list_goals ctx.config () in
+          let effective_policy =
+            Goal_verification.effective_policy_for_nodes
+              ~goals:(goal_policy_nodes goals) ~goal_id
           in
-          let task_marker = Printf.sprintf "[goal:%s]" goal.id in
-          ok_result
-            [
-              ("action", `String action_name);
-              ("goal_id", `String goal.id);
-              ("goal", Goal_store.goal_to_yojson goal);
-              ( "task_goal_id_example",
-                `String
-                  (Printf.sprintf
-                     {|masc_add_task({title: "Implement %s", goal_id: "%s"})|}
-                     goal.title goal.id) );
-              ("task_title_marker", `String task_marker);
-              ( "linked_task_title_example",
-                `String
-                  (Printf.sprintf "%s[child] %s" task_marker goal.title) );
-            ]
+          begin
+            match effective_policy with
+            | Error msg -> error_result_typed ~code:Validation_error msg
+            | Ok effective_policy ->
+                let has_effective_verifier_policy =
+                  Option.is_some effective_policy
+                in
+                match
+                  Goal_phase.decide_transition ~phase:goal.phase ~action
+                    ~has_effective_verifier_policy
+                    ~require_completion_approval:goal.require_completion_approval
+                with
+                | Error msg -> error_result_typed ~code:Conflict msg
+                | Ok Goal_phase.Open_verification -> (
+                    match effective_policy with
+                    | None ->
+                        error_result_typed ~code:Internal_error
+                          "effective verifier policy missing"
+                    | Some effective_policy -> (
+                        match
+                          Goal_verification.exclude_requester
+                            ~policy_snapshot:effective_policy ~requested_by:actor
+                        with
+                        | Error msg ->
+                            error_result_typed ~code:Validation_error msg
+                        | Ok policy_snapshot -> (
+                            match
+                              Goal_verification.create_request ctx.config ~goal_id
+                                ~requested_by:actor ~policy_snapshot
+                            with
+                            | Error msg ->
+                                error_result_typed ~code:Internal_error msg
+                            | Ok request -> (
+                                match
+                                  update_goal_phase ctx goal
+                                    ~phase:Goal_phase.Awaiting_verification ?note
+                                    ~active_verification_request_id:request.id ()
+                                with
+                                | Error msg ->
+                                    error_result_typed ~code:Internal_error msg
+                                | Ok updated_goal ->
+                                    emit_goal_event ctx ~goal_id ~event_type:"goal_phase"
+                                      ~payload:
+                                        (`Assoc
+                                          [
+                                            ("phase", Goal_phase.to_yojson updated_goal.phase);
+                                            ("actor", Goal_verification.goal_principal_to_yojson actor);
+                                          ]);
+                                    emit_goal_event ctx ~goal_id
+                                      ~event_type:"goal_verification_opened"
+                                      ~payload:
+                                        (`Assoc
+                                          [
+                                            ( "request",
+                                              Goal_verification.goal_verification_request_to_yojson
+                                                request );
+                                          ]);
+                                    ok_result
+                                      [
+                                        ("goal_id", `String goal_id);
+                                        ( "action",
+                                          `String
+                                            (Goal_phase.action_to_string action) );
+                                        ("goal", Goal_store.goal_to_yojson updated_goal);
+                                        ( "verification_request",
+                                          Goal_verification.goal_verification_request_to_yojson
+                                            request );
+                                        ( "verification_summary",
+                                          verification_summary_json updated_goal
+                                            (Some policy_snapshot) (Some request) );
+                                      ]))))
+                | Ok Goal_phase.Open_approval -> (
+                    match
+                      update_goal_phase ctx goal ~phase:Goal_phase.Awaiting_approval
+                        ?note ~clear_active_verification_request:true ()
+                    with
+                    | Error msg -> error_result_typed ~code:Internal_error msg
+                    | Ok updated_goal ->
+                        emit_goal_event ctx ~goal_id ~event_type:"goal_phase"
+                          ~payload:
+                            (`Assoc
+                              [
+                                ("phase", Goal_phase.to_yojson updated_goal.phase);
+                                ("actor", Goal_verification.goal_principal_to_yojson actor);
+                              ]);
+                        emit_goal_event ctx ~goal_id
+                          ~event_type:"goal_approval_opened"
+                          ~payload:
+                            (`Assoc
+                              [
+                                ("actor", Goal_verification.goal_principal_to_yojson actor);
+                              ]);
+                        ok_result
+                          [
+                            ("goal_id", `String goal_id);
+                            ("action", `String (Goal_phase.action_to_string action));
+                            ("goal", Goal_store.goal_to_yojson updated_goal);
+                            ( "verification_summary",
+                              verification_summary_json updated_goal
+                                effective_policy None );
+                          ])
+                | Ok Goal_phase.Complete -> (
+                    match
+                      update_goal_phase ctx goal ~phase:Goal_phase.Completed ?note
+                        ~clear_active_verification_request:true ()
+                    with
+                    | Error msg -> error_result_typed ~code:Internal_error msg
+                    | Ok updated_goal ->
+                        emit_goal_event ctx ~goal_id ~event_type:"goal_phase"
+                          ~payload:
+                            (`Assoc
+                              [
+                                ("phase", Goal_phase.to_yojson updated_goal.phase);
+                                ("actor", Goal_verification.goal_principal_to_yojson actor);
+                              ]);
+                        ok_result
+                          [
+                            ("goal_id", `String goal_id);
+                            ("action", `String (Goal_phase.action_to_string action));
+                            ("goal", Goal_store.goal_to_yojson updated_goal);
+                            ( "verification_summary",
+                              verification_summary_json updated_goal
+                                effective_policy None );
+                          ])
+                | Ok (Goal_phase.Move_to next_phase) ->
+                    let _ =
+                      match goal.active_verification_request_id, next_phase with
+                      | Some request_id, Goal_phase.Dropped
+                      | Some request_id, Goal_phase.Executing
+                        when goal.phase = Goal_phase.Awaiting_verification ->
+                          ignore (Goal_verification.cancel_request ctx.config ~request_id);
+                          emit_goal_event ctx ~goal_id
+                            ~event_type:"goal_verification_resolved"
+                            ~payload:
+                              (`Assoc
+                                [
+                                  ("request_id", `String request_id);
+                                  ("status", `String "cancelled");
+                                ])
+                      | _ -> ()
+                    in
+                    match
+                      update_goal_phase ctx goal ~phase:next_phase ?note
+                        ~clear_active_verification_request:
+                          (next_phase <> Goal_phase.Awaiting_verification)
+                        ()
+                    with
+                    | Error msg -> error_result_typed ~code:Internal_error msg
+                    | Ok updated_goal ->
+                        emit_goal_event ctx ~goal_id ~event_type:"goal_phase"
+                          ~payload:
+                            (`Assoc
+                              [
+                                ("phase", Goal_phase.to_yojson updated_goal.phase);
+                                ("actor", Goal_verification.goal_principal_to_yojson actor);
+                              ]);
+                        if action = Goal_phase.Approve_completion
+                           || action = Goal_phase.Reject_completion then
+                          emit_goal_event ctx ~goal_id
+                            ~event_type:"goal_approval_resolved"
+                            ~payload:
+                              (`Assoc
+                                [
+                                  ( "decision",
+                                    `String
+                                      (if action = Goal_phase.Approve_completion then
+                                         "approve"
+                                       else
+                                         "reject") );
+                                ]);
+                        ok_result
+                          [
+                            ("goal_id", `String goal_id);
+                            ("action", `String (Goal_phase.action_to_string action));
+                            ("goal", Goal_store.goal_to_yojson updated_goal);
+                            ( "verification_summary",
+                              verification_summary_json updated_goal
+                                effective_policy None );
+                          ]
+          end)
+  | Ok _, Ok None, _ ->
+      validation_error_result
+        [
+          {
+            field = "action";
+            constraint_violated = Required;
+            message = "action is required";
+            expected = Some "string";
+            received = None;
+          };
+        ]
+  | Ok _, _, Ok None ->
+      validation_error_result
+        [
+          {
+            field = "actor";
+            constraint_violated = Required;
+            message = "actor is required";
+            expected = Some "goal_principal";
+            received = None;
+          };
+        ]
+
+let handle_goal_verify (ctx : context) args =
+  match validate_string_required args "goal_id", parse_optional_principal args "principal",
+        parse_optional_vote_decision args "decision",
+        parse_optional_string_list args "evidence_refs" with
+  | Error err, _, _, _
+  | _, Error err, _, _
+  | _, _, Error err, _
+  | _, _, _, Error err ->
+      validation_error_result [ err ]
+  | Ok goal_id, Ok (Some principal), Ok (Some decision), Ok evidence_refs -> (
+      let note = get_string_opt args "note" in
+      let evidence_refs = Option.value evidence_refs ~default:[] in
+      let request_id = get_string_opt args "request_id" in
+      match Goal_store.get_goal ctx.config ~goal_id with
+      | None -> error_result_typed ~code:Not_found "goal not found"
+      | Some goal -> (
+          let request_id =
+            match request_id with
+            | Some request_id -> Some request_id
+            | None -> goal.active_verification_request_id
+          in
+          match request_id with
+          | None ->
+              error_result_typed ~code:Conflict
+                "goal has no active verification request"
+          | Some request_id -> (
+              match
+                Goal_verification.submit_vote ctx.config ~request_id ~principal
+                  ~decision ?note ~evidence_refs ()
+              with
+              | Error msg -> error_result_typed ~code:Conflict msg
+              | Ok (request, quorum_result) ->
+                  let goals = Goal_store.list_goals ctx.config () in
+                  let effective_policy =
+                    Goal_verification.effective_policy_for_nodes
+                      ~goals:(goal_policy_nodes goals) ~goal_id
+                  in
+                  let effective_policy =
+                    match effective_policy with
+                    | Ok policy -> policy
+                    | Error _ -> None
+                  in
+                  emit_goal_event ctx ~goal_id ~event_type:"goal_vote"
+                    ~payload:
+                      (`Assoc
+                        [
+                          ( "vote",
+                            Goal_verification.goal_verification_vote_to_yojson
+                              (List.hd (List.rev request.votes)) );
+                        ]);
+                  let finalize ~phase ~event_status =
+                    match
+                      update_goal_phase ctx goal ~phase ?note
+                        ~clear_active_verification_request:true ()
+                    with
+                    | Error msg -> error_result_typed ~code:Internal_error msg
+                    | Ok updated_goal ->
+                        emit_goal_event ctx ~goal_id
+                          ~event_type:"goal_verification_resolved"
+                          ~payload:
+                            (`Assoc
+                              [
+                                ("request_id", `String request.id);
+                                ("status", `String event_status);
+                              ]);
+                        emit_goal_event ctx ~goal_id ~event_type:"goal_phase"
+                          ~payload:
+                            (`Assoc [ ("phase", Goal_phase.to_yojson updated_goal.phase) ]);
+                        ok_result
+                          [
+                            ("goal_id", `String goal_id);
+                            ("goal", Goal_store.goal_to_yojson updated_goal);
+                            ( "verification_request",
+                              Goal_verification.goal_verification_request_to_yojson
+                                request );
+                            ( "verification_summary",
+                              verification_summary_json updated_goal
+                                effective_policy
+                                (if updated_goal.phase = Goal_phase.Awaiting_verification then
+                                   Some request
+                                 else
+                                   None) );
+                          ]
+                  in
+                  match quorum_result with
+                  | Goal_verification.Pending ->
+                      ok_result
+                        [
+                          ("goal_id", `String goal_id);
+                          ("goal", Goal_store.goal_to_yojson goal);
+                          ( "verification_request",
+                            Goal_verification.goal_verification_request_to_yojson request );
+                          ( "verification_summary",
+                            verification_summary_json goal effective_policy
+                              (Some request) );
+                        ]
+                  | Goal_verification.Passed ->
+                      if goal.require_completion_approval then begin
+                        emit_goal_event ctx ~goal_id
+                          ~event_type:"goal_approval_opened"
+                          ~payload:(`Assoc [ ("request_id", `String request.id) ]);
+                        finalize ~phase:Goal_phase.Awaiting_approval
+                          ~event_status:"approved"
+                      end else
+                        finalize ~phase:Goal_phase.Completed
+                          ~event_status:"approved"
+                  | Goal_verification.Failed ->
+                      finalize ~phase:Goal_phase.Executing
+                        ~event_status:"rejected")))
+  | Ok _, Ok None, _, _ ->
+      validation_error_result
+        [
+          {
+            field = "principal";
+            constraint_violated = Required;
+            message = "principal is required";
+            expected = Some "goal_principal";
+            received = None;
+          };
+        ]
+  | Ok _, _, Ok None, _ ->
+      validation_error_result
+        [
+          {
+            field = "decision";
+            constraint_violated = Required;
+            message = "decision is required";
+            expected = Some "string";
+            received = None;
+          };
+        ]
 
 let handle_goal_review (ctx : context) args =
   match validate_string_required args "goal_id", parse_optional_review_outcome args "outcome",
@@ -162,21 +733,49 @@ let handle_goal_review (ctx : context) args =
   | _, Error err, _
   | _, _, Error err ->
       validation_error_result [ err ]
-  | Ok goal_id, Ok (Some outcome), Ok new_horizon ->
+  | Ok goal_id, Ok (Some outcome), Ok new_horizon -> (
       let note = get_string_opt args "note" in
-      begin
-        match
-          Goal_store.review_goal ctx.config ~goal_id ~outcome ?new_horizon ?note ()
-        with
-        | Error msg ->
-            error_result_typed ~code:Not_found msg
-        | Ok goal ->
-            ok_result
-              [
-                ("goal_id", `String goal.id);
-                ("goal", Goal_store.goal_to_yojson goal);
-              ]
-      end
+      match Goal_store.get_goal ctx.config ~goal_id with
+      | None -> error_result_typed ~code:Not_found "goal not found"
+      | Some goal -> (
+          match goal.phase with
+          | Goal_phase.Awaiting_verification
+          | Goal_phase.Awaiting_approval ->
+              error_result_typed ~code:Conflict
+                "masc_goal_review is ambiguous while verification or approval is pending; use masc_goal_transition / masc_goal_verify"
+          | _ -> (
+              match outcome with
+              | Goal_store.ReviewDone ->
+                  handle_goal_transition ctx
+                    (`Assoc
+                      [
+                        ("goal_id", `String goal_id);
+                        ("action", `String "request_complete");
+                        ( "actor",
+                          Goal_verification.goal_principal_to_yojson
+                            {
+                              kind = Goal_verification.Operator;
+                              id = ctx.agent_name;
+                              display_name = Some ctx.agent_name;
+                            } );
+                        ( "note",
+                          match note with Some value -> `String value | None -> `Null );
+                      ])
+              | Goal_store.ReviewProgress
+              | Goal_store.ReviewBlocked
+              | Goal_store.ReviewDropped -> (
+                  match
+                    Goal_store.review_goal ctx.config ~goal_id ~outcome ?new_horizon
+                      ?note ()
+                  with
+                  | Error msg ->
+                      error_result_typed ~code:Not_found msg
+                  | Ok goal ->
+                      ok_result
+                        [
+                          ("goal_id", `String goal.id);
+                          ("goal", Goal_store.goal_to_yojson goal);
+                        ]))))
   | Ok _, Ok None, _ ->
       validation_error_result
         [

--- a/lib/dune
+++ b/lib/dune
@@ -266,6 +266,8 @@
    provider_kind_resolver
    progress
    relay
+   goal_phase
+   goal_verification
    goal_store
    goal_guard
    goal_janitor

--- a/lib/goal/goal_janitor.ml
+++ b/lib/goal/goal_janitor.ml
@@ -59,17 +59,18 @@ let sweep_goals ~(config : sweep_config) (goals : Goal_store.goal list)
   let result =
     goals |> List.filter_map (fun (g : Goal_store.goal) ->
       let age = days_since_update g ~now in
-      match g.status, age with
-      | Goal_store.Dropped, Some d when d >= config.dropped_ttl_days ->
+      match g.phase, age with
+      | Goal_phase.Dropped, Some d when d >= config.dropped_ttl_days ->
         incr purged;
         Log.Misc.info "[GoalJanitor] purge: %s (%s, dropped %d days ago)"
           g.id g.title d;
         None
-      | Goal_store.Active, Some d when d >= config.stagnant_days ->
+      | Goal_phase.Executing, Some d when d >= config.stagnant_days ->
         incr stagnated;
         Log.Misc.info "[GoalJanitor] stagnate: %s (%s, no update for %d days)"
           g.id g.title d;
         Some { g with
+               phase = Goal_phase.Dropped;
                status = Goal_store.Dropped;
                last_review_note = Some (Printf.sprintf "auto-dropped: no update for %d days" d);
                last_review_at = Some iso_now;

--- a/lib/goal/goal_phase.ml
+++ b/lib/goal/goal_phase.ml
@@ -1,0 +1,113 @@
+type t =
+  | Executing
+  | Awaiting_verification
+  | Awaiting_approval
+  | Blocked
+  | Paused
+  | Completed
+  | Dropped
+
+let to_string = function
+  | Executing -> "executing"
+  | Awaiting_verification -> "awaiting_verification"
+  | Awaiting_approval -> "awaiting_approval"
+  | Blocked -> "blocked"
+  | Paused -> "paused"
+  | Completed -> "completed"
+  | Dropped -> "dropped"
+
+let of_string = function
+  | "executing" -> Some Executing
+  | "awaiting_verification" -> Some Awaiting_verification
+  | "awaiting_approval" -> Some Awaiting_approval
+  | "blocked" -> Some Blocked
+  | "paused" -> Some Paused
+  | "completed" -> Some Completed
+  | "dropped" -> Some Dropped
+  | _ -> None
+
+let parse s =
+  String.trim s |> String.lowercase_ascii |> of_string
+
+let to_yojson t =
+  `String (to_string t)
+
+let of_yojson = function
+  | `String raw -> (
+      match parse raw with
+      | Some phase -> Ok phase
+      | None -> Error ("goal_phase_of_yojson: " ^ raw))
+  | json ->
+      Error ("goal_phase_of_yojson: " ^ Yojson.Safe.to_string json)
+
+type action =
+  | Request_complete
+  | Approve_completion
+  | Reject_completion
+  | Pause
+  | Resume
+  | Operator_block
+  | Operator_unblock
+  | Drop
+  | Reopen
+
+let action_to_string = function
+  | Request_complete -> "request_complete"
+  | Approve_completion -> "approve_completion"
+  | Reject_completion -> "reject_completion"
+  | Pause -> "pause"
+  | Resume -> "resume"
+  | Operator_block -> "operator_block"
+  | Operator_unblock -> "operator_unblock"
+  | Drop -> "drop"
+  | Reopen -> "reopen"
+
+let action_of_string = function
+  | "request_complete" -> Some Request_complete
+  | "approve_completion" -> Some Approve_completion
+  | "reject_completion" -> Some Reject_completion
+  | "pause" -> Some Pause
+  | "resume" -> Some Resume
+  | "operator_block" -> Some Operator_block
+  | "operator_unblock" -> Some Operator_unblock
+  | "drop" -> Some Drop
+  | "reopen" -> Some Reopen
+  | _ -> None
+
+let parse_action s =
+  String.trim s |> String.lowercase_ascii |> action_of_string
+
+type transition_outcome =
+  | Move_to of t
+  | Open_verification
+  | Open_approval
+  | Complete
+
+let decide_transition ~phase ~(action : action) ~has_effective_verifier_policy
+    ~require_completion_approval =
+  match phase, action with
+  | Executing, Request_complete ->
+      if has_effective_verifier_policy then
+        Ok Open_verification
+      else if require_completion_approval then
+        Ok Open_approval
+      else
+        Ok Complete
+  | Executing, Pause -> Ok (Move_to Paused)
+  | Executing, Operator_block -> Ok (Move_to Blocked)
+  | Executing, Drop -> Ok (Move_to Dropped)
+  | Paused, Resume -> Ok (Move_to Executing)
+  | Paused, Drop -> Ok (Move_to Dropped)
+  | Blocked, Operator_unblock -> Ok (Move_to Executing)
+  | Blocked, Drop -> Ok (Move_to Dropped)
+  | Awaiting_approval, Approve_completion -> Ok Complete
+  | Awaiting_approval, Reject_completion -> Ok (Move_to Blocked)
+  | Awaiting_approval, Drop -> Ok (Move_to Dropped)
+  | Awaiting_verification, Drop -> Ok (Move_to Dropped)
+  | Completed, Reopen -> Ok (Move_to Executing)
+  | Completed, Drop -> Ok (Move_to Dropped)
+  | Dropped, Reopen -> Ok (Move_to Executing)
+  | _ ->
+      Error
+        (Printf.sprintf "invalid goal transition: %s -> %s"
+           (to_string phase) (action_to_string action))

--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -1,7 +1,12 @@
-(* Variant types for domain values — Parse, Don't Validate.
-   Custom yojson serializers maintain backward-compatible JSON ("active", "short", etc.). *)
+(* Goal store — shared planning goals with a dedicated lifecycle phase.
+   Legacy [status] remains persisted for compatibility, but it is derived
+   from [phase] on write and inferred on read for old rows. *)
 
-type goal_status = Active | Paused | Done | Dropped
+type goal_status =
+  | Active
+  | Paused
+  | Done
+  | Dropped
 
 let goal_status_to_yojson = function
   | Active -> `String "active"
@@ -16,7 +21,10 @@ let goal_status_of_yojson = function
   | `String "dropped" -> Ok Dropped
   | j -> Error ("goal_status_of_yojson: " ^ Yojson.Safe.to_string j)
 
-type horizon = Short | Mid | Long
+type horizon =
+  | Short
+  | Mid
+  | Long
 
 let horizon_to_yojson = function
   | Short -> `String "short"
@@ -29,7 +37,10 @@ let horizon_of_yojson = function
   | `String "long" -> Ok Long
   | j -> Error ("horizon_of_yojson: " ^ Yojson.Safe.to_string j)
 
-type refresh_mode = Daily | Weekly | Monthly
+type refresh_mode =
+  | Daily
+  | Weekly
+  | Monthly
 
 let refresh_mode_to_yojson = function
   | Daily -> `String "daily"
@@ -42,7 +53,11 @@ let refresh_mode_of_yojson = function
   | `String "monthly" -> Ok Monthly
   | j -> Error ("refresh_mode_of_yojson: " ^ Yojson.Safe.to_string j)
 
-type snapshot_mode = SnapDaily | SnapWeekly | SnapMonthly | SnapManual
+type snapshot_mode =
+  | SnapDaily
+  | SnapWeekly
+  | SnapMonthly
+  | SnapManual
 
 let snapshot_mode_to_yojson = function
   | SnapDaily -> `String "daily"
@@ -70,7 +85,11 @@ let parse_snapshot_mode s =
   | "manual" -> Some SnapManual
   | _ -> None
 
-type review_outcome = ReviewDone | ReviewProgress | ReviewBlocked | ReviewDropped
+type review_outcome =
+  | ReviewDone
+  | ReviewProgress
+  | ReviewBlocked
+  | ReviewDropped
 
 let review_outcome_to_yojson = function
   | ReviewDone -> `String "done"
@@ -85,7 +104,8 @@ let review_outcome_of_yojson = function
   | `String "dropped" -> Ok ReviewDropped
   | j -> Error ("review_outcome_of_yojson: " ^ Yojson.Safe.to_string j)
 
-(* Record types *)
+let clamp_priority p =
+  max 1 (min 5 p)
 
 type goal = {
   id : string;
@@ -96,20 +116,190 @@ type goal = {
   due_date : string option;
   priority : int;
   status : goal_status;
+  phase : Goal_phase.t;
+  verifier_policy : Goal_verification.goal_verifier_policy option;
+  require_completion_approval : bool;
+  active_verification_request_id : string option;
   parent_goal_id : string option;
   last_review_note : string option;
   last_review_at : string option;
   created_at : string;
   updated_at : string;
 }
-[@@deriving yojson]
 
 type state = {
   version : int;
   updated_at : string;
   goals : goal list;
 }
-[@@deriving yojson]
+
+let rec state_to_yojson (state : state) =
+  `Assoc
+    [
+      ("version", `Int state.version);
+      ("updated_at", `String state.updated_at);
+      ("goals", `List (List.map (fun goal -> goal_to_yojson goal) state.goals));
+    ]
+
+and goal_to_yojson (goal : goal) =
+  `Assoc
+    [
+      ("id", `String goal.id);
+      ("horizon", horizon_to_yojson goal.horizon);
+      ("title", `String goal.title);
+      ("metric", match goal.metric with Some value -> `String value | None -> `Null);
+      ( "target_value",
+        match goal.target_value with Some value -> `String value | None -> `Null );
+      ("due_date", match goal.due_date with Some value -> `String value | None -> `Null);
+      ("priority", `Int goal.priority);
+      ("status", goal_status_to_yojson goal.status);
+      ("phase", Goal_phase.to_yojson goal.phase);
+      ( "verifier_policy",
+        match goal.verifier_policy with
+        | Some policy -> Goal_verification.goal_verifier_policy_to_yojson policy
+        | None -> `Null );
+      ("require_completion_approval", `Bool goal.require_completion_approval);
+      ( "active_verification_request_id",
+        match goal.active_verification_request_id with
+        | Some value -> `String value
+        | None -> `Null );
+      ( "parent_goal_id",
+        match goal.parent_goal_id with Some value -> `String value | None -> `Null );
+      ( "last_review_note",
+        match goal.last_review_note with Some value -> `String value | None -> `Null );
+      ( "last_review_at",
+        match goal.last_review_at with Some value -> `String value | None -> `Null );
+      ("created_at", `String goal.created_at);
+      ("updated_at", `String goal.updated_at);
+    ]
+
+and state_of_yojson = function
+  | `Assoc _ as json ->
+      let open Yojson.Safe.Util in
+      begin
+        match member "version" json, member "updated_at" json, member "goals" json with
+        | `Int version, `String updated_at, `List goals_json ->
+            let rec collect acc = function
+              | [] -> Ok (List.rev acc)
+              | row :: rest -> (
+                  match goal_of_yojson row with
+                  | Ok goal -> collect (goal :: acc) rest
+                  | Error msg -> Error msg)
+            in
+            Result.map
+              (fun goals -> { version; updated_at; goals })
+              (collect [] goals_json)
+        | _ -> Error "state_of_yojson: invalid state"
+      end
+  | json ->
+      Error ("state_of_yojson: " ^ Yojson.Safe.to_string json)
+
+and goal_of_yojson = function
+  | `Assoc _ as json ->
+      let open Yojson.Safe.Util in
+      begin
+        match member "id" json, horizon_of_yojson (member "horizon" json), member "title" json with
+        | `String id, Ok horizon, `String title ->
+            let legacy_status =
+              match member "status" json with
+              | `Null -> Ok Active
+              | status_json -> goal_status_of_yojson status_json
+            in
+            let phase =
+              match member "phase" json with
+              | `Null -> (
+                  match legacy_status with
+                  | Ok status -> Ok (phase_of_goal_status status)
+                  | Error msg -> Error msg)
+              | phase_json -> Goal_phase.of_yojson phase_json
+            in
+            let verifier_policy =
+              match member "verifier_policy" json with
+              | `Null -> Ok None
+              | policy_json ->
+                  Result.map
+                    Option.some
+                    (Goal_verification.goal_verifier_policy_of_yojson policy_json)
+            in
+            let created_at =
+              match member "created_at" json with
+              | `String value -> Ok value
+              | _ -> Error "goal_of_yojson: created_at missing"
+            in
+            let updated_at =
+              match member "updated_at" json with
+              | `String value -> Ok value
+              | _ -> Error "goal_of_yojson: updated_at missing"
+            in
+            begin
+              match legacy_status, phase, verifier_policy, created_at, updated_at with
+              | Ok _legacy_status, Ok phase, Ok verifier_policy, Ok created_at, Ok updated_at ->
+                  Ok
+                    (normalize_goal
+                       {
+                         id;
+                         horizon;
+                         title;
+                         metric = member "metric" json |> to_string_option;
+                         target_value = member "target_value" json |> to_string_option;
+                         due_date = member "due_date" json |> to_string_option;
+                         priority =
+                           (match member "priority" json with
+                           | `Int value -> clamp_priority value
+                           | _ -> 3);
+                         status = goal_status_of_phase phase;
+                         phase;
+                         verifier_policy;
+                         require_completion_approval =
+                           (match member "require_completion_approval" json with
+                           | `Bool value -> value
+                           | _ -> false);
+                         active_verification_request_id =
+                           member "active_verification_request_id" json |> to_string_option;
+                         parent_goal_id = member "parent_goal_id" json |> to_string_option;
+                         last_review_note = member "last_review_note" json |> to_string_option;
+                         last_review_at = member "last_review_at" json |> to_string_option;
+                         created_at;
+                         updated_at;
+                       })
+              | Error msg, _, _, _, _
+              | _, Error msg, _, _, _
+              | _, _, Error msg, _, _
+              | _, _, _, Error msg, _
+              | _, _, _, _, Error msg ->
+                  Error msg
+            end
+        | _ -> Error "goal_of_yojson: invalid goal"
+      end
+  | json ->
+      Error ("goal_of_yojson: " ^ Yojson.Safe.to_string json)
+
+and normalize_goal (goal : goal) =
+  {
+    goal with
+    status = goal_status_of_phase goal.phase;
+    active_verification_request_id =
+      (match goal.phase, goal.active_verification_request_id with
+      | Goal_phase.Awaiting_verification, request_id -> request_id
+      | _, _ -> None);
+  }
+
+and goal_status_of_phase = function
+  | Goal_phase.Executing
+  | Goal_phase.Awaiting_verification
+  | Goal_phase.Awaiting_approval ->
+      Active
+  | Goal_phase.Paused
+  | Goal_phase.Blocked ->
+      Paused
+  | Goal_phase.Completed -> Done
+  | Goal_phase.Dropped -> Dropped
+
+and phase_of_goal_status = function
+  | Active -> Goal_phase.Executing
+  | Paused -> Goal_phase.Paused
+  | Done -> Goal_phase.Completed
+  | Dropped -> Goal_phase.Dropped
 
 type rollup = {
   short_count : int;
@@ -141,8 +331,6 @@ type refresh_result = {
 }
 [@@deriving yojson]
 
-(* Parsing: string -> variant at the boundary *)
-
 let normalize_lower s =
   String.trim s |> String.lowercase_ascii
 
@@ -165,6 +353,10 @@ let parse_goal_status = function
       | _ -> None)
   | None -> None
 
+let parse_goal_phase = function
+  | Some s -> Goal_phase.parse s
+  | None -> None
+
 let parse_refresh_mode s =
   match normalize_lower s with
   | "daily" -> Some Daily
@@ -180,8 +372,6 @@ let parse_review_outcome s =
   | "dropped" -> Some ReviewDropped
   | _ -> None
 
-let clamp_priority p = max 1 (min 5 p)
-
 let goals_path config =
   Filename.concat (Coord.masc_dir config) "goals.json"
 
@@ -193,8 +383,7 @@ let scheduler_state_path config =
 
 let ensure_dirs config =
   Coord.mkdir_p (Coord.masc_dir config);
-  Coord.mkdir_p (snapshots_dir config);
-  ()
+  Coord.mkdir_p (snapshots_dir config)
 
 let default_state () =
   { version = 1; updated_at = Types.now_iso (); goals = [] }
@@ -203,51 +392,77 @@ let read_state config =
   ensure_dirs config;
   let path = goals_path config in
   if Coord.path_exists config path then
-    let json = Coord.read_json config path in
-    match state_of_yojson json with
-    | Ok s -> s
+    match state_of_yojson (Coord.read_json config path) with
+    | Ok state -> { state with goals = List.map normalize_goal state.goals }
     | Error _ -> default_state ()
   else
     default_state ()
 
-let write_state config st =
+let write_state config state =
   ensure_dirs config;
-  Coord.write_json config (goals_path config) (state_to_yojson st)
+  Coord.write_json config (goals_path config) (state_to_yojson state)
 
 let now_ms () =
   int_of_float (Time_compat.now () *. 1000.0)
 
 let gen_goal_id () =
-  Printf.sprintf "goal-%d-%04x" (now_ms ()) (Hashtbl.hash (Unix.gettimeofday ()) land 0xFFFF)
+  Printf.sprintf "goal-%d-%04x" (now_ms ())
+    (Hashtbl.hash (Unix.gettimeofday ()) land 0xFFFF)
 
 let find_goal goals id =
-  List.find_opt (fun g -> g.id = id) goals
+  List.find_opt (fun goal -> String.equal goal.id id) goals
 
 let replace_goal goals updated =
-  List.map (fun g -> if g.id = updated.id then updated else g) goals
+  List.map (fun goal -> if String.equal goal.id updated.id then updated else goal) goals
 
 let update_state config f =
   let lock_path = goals_path config in
   Coord.with_file_lock config lock_path (fun () ->
-    let st = read_state config in
-    let st' = f st in
-    write_state config st';
-    st')
+      let state = read_state config in
+      let next_state = f state in
+      write_state config next_state;
+      next_state)
+
+let get_goal config ~goal_id =
+  read_state config |> fun state -> find_goal state.goals goal_id
+
+let update_goal config ~goal_id f =
+  let found = ref false in
+  let now = Types.now_iso () in
+  let state =
+    update_state config (fun state ->
+        let goals =
+          List.map
+            (fun goal ->
+              if not (String.equal goal.id goal_id) then
+                goal
+              else begin
+                found := true;
+                normalize_goal (f { goal with updated_at = now })
+              end)
+            state.goals
+        in
+        { version = state.version + 1; updated_at = now; goals })
+  in
+  if not !found then
+    Error "goal not found"
+  else
+    match find_goal state.goals goal_id with
+    | Some goal -> Ok goal
+    | None -> Error "goal not found"
 
 let delete_goal config ~goal_id =
   let before = read_state config in
-  if not (List.exists (fun g -> g.id = goal_id) before.goals) then
+  if not (List.exists (fun goal -> String.equal goal.id goal_id) before.goals) then
     Error "Goal not found"
   else begin
-    (* Bump [version] so downstream replicas/snapshot consumers can detect
-       the change. The previous [{ st with ... }] form preserved [version]
-       unchanged, so 39 successive deletes all landed at v67 without a
-       single bump (Issue #7690). [refresh_all] and [review_goal] already
-       bump explicitly; match that convention here. *)
-    ignore (update_state config (fun st ->
-      { version = st.version + 1;
-        goals = List.filter (fun g -> g.id <> goal_id) st.goals;
-        updated_at = Types.now_iso () }));
+    ignore
+      (update_state config (fun state ->
+           {
+             version = state.version + 1;
+             goals = List.filter (fun goal -> not (String.equal goal.id goal_id)) state.goals;
+             updated_at = Types.now_iso ();
+           }));
     Ok ()
   end
 
@@ -258,132 +473,175 @@ let sort_goals goals =
     | Long -> 2
   in
   List.sort
-    (fun a b ->
-      let by_horizon = compare (horizon_rank a.horizon) (horizon_rank b.horizon) in
-      if by_horizon <> 0 then by_horizon
+    (fun left right ->
+      let by_horizon =
+        compare (horizon_rank left.horizon) (horizon_rank right.horizon)
+      in
+      if by_horizon <> 0 then
+        by_horizon
       else
-        let by_prio = compare a.priority b.priority in
-        if by_prio <> 0 then by_prio
-        else String.compare b.updated_at a.updated_at)
+        let by_priority = compare left.priority right.priority in
+        if by_priority <> 0 then
+          by_priority
+        else
+          String.compare right.updated_at left.updated_at)
     goals
 
 let list_goals config ?horizon ?status () =
-  let st = read_state config in
-  st.goals
-  |> List.filter (fun g ->
+  read_state config
+  |> fun state -> state.goals
+  |> List.filter (fun goal ->
          match horizon with
          | None -> true
-         | Some h -> g.horizon = h)
-  |> List.filter (fun g ->
+         | Some horizon -> goal.horizon = horizon)
+  |> List.filter (fun goal ->
          match status with
          | None -> true
-         | Some s -> g.status = s)
+         | Some status -> goal.status = status)
   |> sort_goals
 
 let upsert_goal config ?id ?horizon ?title ?metric ?target_value ?due_date
-    ?priority ?status ?parent_goal_id () =
+    ?priority ?status ?phase ?parent_goal_id ?verifier_policy
+    ?require_completion_approval () =
   let is_new_goal = id = None in
   if is_new_goal && (title = None || title = Some "") then
     Error "title required for new goal"
   else
-    let now = Types.now_iso () in
-    let resolved_id = Option.value id ~default:(gen_goal_id ()) in
-    let was_created = ref false in
-    let updated_goal =
-      update_state config (fun st ->
-          match find_goal st.goals resolved_id with
-          | Some existing ->
-              let next_goal =
-                {
-                  existing with
-                  horizon =
-                    Option.value horizon ~default:existing.horizon;
-                  title = Option.value title ~default:existing.title;
-                  metric = (match metric with Some _ -> metric | None -> existing.metric);
-                  target_value =
-                    (match target_value with
-                    | Some _ -> target_value
-                    | None -> existing.target_value);
-                  due_date =
-                    (match due_date with Some _ -> due_date | None -> existing.due_date);
-                  priority =
-                    clamp_priority
-                      (Option.value priority ~default:existing.priority);
-                  status = Option.value status ~default:existing.status;
-                  parent_goal_id =
-                    (match parent_goal_id with
-                    | Some _ -> parent_goal_id
-                    | None -> existing.parent_goal_id);
-                  updated_at = now;
-                }
-              in
-              {
-                version = st.version + 1;
-                updated_at = now;
-                goals = replace_goal st.goals next_goal;
-              }
-          | None ->
-              let new_goal =
-                {
-                  id = resolved_id;
-                  horizon = Option.value horizon ~default:Short;
-                  title = Option.value title ~default:"Untitled goal";
-                  metric;
-                  target_value;
-                  due_date;
-                  priority =
-                    clamp_priority (Option.value priority ~default:3);
-                  status = Option.value status ~default:Active;
-                  parent_goal_id;
-                  last_review_note = None;
-                  last_review_at = None;
-                  created_at = now;
-                  updated_at = now;
-                }
-              in
-              was_created := true;
-              {
-                version = st.version + 1;
-                updated_at = now;
-                goals = st.goals @ [ new_goal ];
-              })
+    let resolved_phase =
+      match phase, status with
+      | Some phase, Some status when phase <> phase_of_goal_status status ->
+          Error "phase and legacy status disagree"
+      | Some phase, _ -> Ok phase
+      | None, Some status -> Ok (phase_of_goal_status status)
+      | None, None -> Ok Goal_phase.Executing
     in
-    let saved = find_goal updated_goal.goals resolved_id in
-    match saved with
-    | Some g ->
-        Ok (g, if !was_created then `created else `updated)
-    | None -> Error "failed to save goal"
+    match resolved_phase with
+    | Error msg -> Error msg
+    | Ok default_phase ->
+        let now = Types.now_iso () in
+        let resolved_id = Option.value id ~default:(gen_goal_id ()) in
+        let was_created = ref false in
+        let state =
+          update_state config (fun state ->
+              match find_goal state.goals resolved_id with
+              | Some existing ->
+                  let next_phase =
+                    match phase, status with
+                    | Some phase, _ -> phase
+                    | None, Some legacy_status -> phase_of_goal_status legacy_status
+                    | None, None -> existing.phase
+                  in
+                  let next_goal =
+                    normalize_goal
+                      {
+                        existing with
+                        horizon = Option.value horizon ~default:existing.horizon;
+                        title = Option.value title ~default:existing.title;
+                        metric = (match metric with Some _ -> metric | None -> existing.metric);
+                        target_value =
+                          (match target_value with
+                          | Some _ -> target_value
+                          | None -> existing.target_value);
+                        due_date =
+                          (match due_date with
+                          | Some _ -> due_date
+                          | None -> existing.due_date);
+                        priority =
+                          clamp_priority
+                            (Option.value priority ~default:existing.priority);
+                        status = goal_status_of_phase next_phase;
+                        phase = next_phase;
+                        verifier_policy =
+                          (match verifier_policy with
+                          | Some _ -> verifier_policy
+                          | None -> existing.verifier_policy);
+                        require_completion_approval =
+                          (match require_completion_approval with
+                          | Some value -> value
+                          | None -> existing.require_completion_approval);
+                        active_verification_request_id =
+                          existing.active_verification_request_id;
+                        parent_goal_id =
+                          (match parent_goal_id with
+                          | Some _ -> parent_goal_id
+                          | None -> existing.parent_goal_id);
+                        updated_at = now;
+                      }
+                  in
+                  {
+                    version = state.version + 1;
+                    updated_at = now;
+                    goals = replace_goal state.goals next_goal;
+                  }
+              | None ->
+                  let new_goal =
+                    normalize_goal
+                      {
+                        id = resolved_id;
+                        horizon = Option.value horizon ~default:Short;
+                        title = Option.value title ~default:"Untitled goal";
+                        metric;
+                        target_value;
+                        due_date;
+                        priority = clamp_priority (Option.value priority ~default:3);
+                        status = goal_status_of_phase default_phase;
+                        phase = default_phase;
+                        verifier_policy;
+                        require_completion_approval =
+                          Option.value require_completion_approval ~default:false;
+                        active_verification_request_id = None;
+                        parent_goal_id;
+                        last_review_note = None;
+                        last_review_at = None;
+                        created_at = now;
+                        updated_at = now;
+                      }
+                  in
+                  was_created := true;
+                  {
+                    version = state.version + 1;
+                    updated_at = now;
+                    goals = state.goals @ [ new_goal ];
+                  })
+        in
+        match find_goal state.goals resolved_id with
+        | Some goal ->
+            Ok (goal, if !was_created then `created else `updated)
+        | None ->
+            Error "failed to save goal"
 
 let compute_rollup goals =
-  let count p = List.length (List.filter p goals) in
+  let count predicate =
+    List.length (List.filter predicate goals)
+  in
   {
-    short_count = count (fun g -> g.horizon = Short);
-    mid_count = count (fun g -> g.horizon = Mid);
-    long_count = count (fun g -> g.horizon = Long);
-    active_count = count (fun g -> g.status = Active);
-    paused_count = count (fun g -> g.status = Paused);
-    done_count = count (fun g -> g.status = Done);
-    dropped_count = count (fun g -> g.status = Dropped);
+    short_count = count (fun goal -> goal.horizon = Short);
+    mid_count = count (fun goal -> goal.horizon = Mid);
+    long_count = count (fun goal -> goal.horizon = Long);
+    active_count = count (fun goal -> goal.status = Active);
+    paused_count = count (fun goal -> goal.status = Paused);
+    done_count = count (fun goal -> goal.status = Done);
+    dropped_count = count (fun goal -> goal.status = Dropped);
   }
 
 let snapshot config ~mode =
   ensure_dirs config;
-  let st = read_state config in
+  let state = read_state config in
   let snapshot_id = Printf.sprintf "gsnap-%d" (now_ms ()) in
-  let snap =
+  let snapshot =
     {
       snapshot_id;
       created_at = Types.now_iso ();
       mode;
-      goals = st.goals;
-      rollup = compute_rollup st.goals;
+      goals = state.goals;
+      rollup = compute_rollup state.goals;
     }
   in
   let path =
     Filename.concat (snapshots_dir config) (snapshot_id ^ ".json")
   in
-  Coord.write_json config path (snapshot_to_yojson snap);
-  snap
+  Coord.write_json config path (snapshot_to_yojson snapshot);
+  snapshot
 
 let parse_yyyy_mm_dd s =
   try
@@ -405,15 +663,18 @@ let parse_yyyy_mm_dd s =
         let utc_as_local, _ = Unix.mktime (Unix.gmtime local_epoch) in
         let tz_offset = local_epoch -. utc_as_local in
         Some (local_epoch +. tz_offset))
-  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-    Log.Misc.warn "goal_store: parse_yyyy_mm_dd failed: %s" (Printexc.to_string exn);
-    None
+  with Eio.Cancel.Cancelled _ as exn ->
+    raise exn
+  | exn ->
+      Log.Misc.warn "goal_store: parse_yyyy_mm_dd failed: %s"
+        (Printexc.to_string exn);
+      None
 
 let days_until due_date =
   match due_date with
   | None -> None
-  | Some d -> (
-      match parse_yyyy_mm_dd d with
+  | Some due_date -> (
+      match parse_yyyy_mm_dd due_date with
       | None -> None
       | Some ts ->
           let diff = ts -. Unix.time () in
@@ -421,80 +682,77 @@ let days_until due_date =
 
 let should_refresh_goal mode goal =
   match mode with
-  | Daily -> goal.horizon = Short && goal.status = Active
-  | Weekly -> goal.horizon = Mid && goal.status = Active
-  | Monthly -> goal.horizon = Long && goal.status = Active
+  | Daily -> goal.horizon = Short && goal.phase = Goal_phase.Executing
+  | Weekly -> goal.horizon = Mid && goal.phase = Goal_phase.Executing
+  | Monthly -> goal.horizon = Long && goal.phase = Goal_phase.Executing
 
 let reprioritize mode goal =
   let next_priority =
     match days_until goal.due_date with
-    | Some d when d < 0 -> 1
-    | Some d when mode = Daily && d <= 3 -> max 1 (goal.priority - 1)
-    | Some d when mode = Weekly && d <= 14 -> max 1 (goal.priority - 1)
-    | Some d when mode = Monthly && d <= 45 -> max 1 (goal.priority - 1)
+    | Some days when days < 0 -> 1
+    | Some days when mode = Daily && days <= 3 -> max 1 (goal.priority - 1)
+    | Some days when mode = Weekly && days <= 14 -> max 1 (goal.priority - 1)
+    | Some days when mode = Monthly && days <= 45 -> max 1 (goal.priority - 1)
     | _ -> goal.priority
   in
   if next_priority = goal.priority then
     (goal, false)
   else
-    ({ goal with priority = next_priority; updated_at = Types.now_iso () }, true)
+    ( { goal with priority = next_priority; updated_at = Types.now_iso () }
+      |> normalize_goal,
+      true )
 
 let refresh config ~mode =
   let scanned = ref 0 in
   let updated = ref 0 in
   ignore
-    (update_state config (fun st ->
+    (update_state config (fun state ->
          let goals =
            List.map
-             (fun g ->
-               if should_refresh_goal mode g then (
+             (fun goal ->
+               if should_refresh_goal mode goal then begin
                  incr scanned;
-                 let g', changed = reprioritize mode g in
+                 let goal, changed = reprioritize mode goal in
                  if changed then incr updated;
-                 g')
-               else g)
-             st.goals
+                 goal
+               end else
+                 goal)
+             state.goals
          in
-         { version = st.version + 1; updated_at = Types.now_iso (); goals }));
-  let snap = snapshot config ~mode:(snapshot_mode_of_refresh_mode mode) in
-  { mode; scanned = !scanned; updated = !updated; snapshot_id = snap.snapshot_id }
+         { version = state.version + 1; updated_at = Types.now_iso (); goals }))
+  ;
+  let snapshot = snapshot config ~mode:(snapshot_mode_of_refresh_mode mode) in
+  {
+    mode;
+    scanned = !scanned;
+    updated = !updated;
+    snapshot_id = snapshot.snapshot_id;
+  }
 
 let review_goal config ~goal_id ~(outcome : review_outcome) ?new_horizon ?note () =
   let now = Types.now_iso () in
-  let found = ref false in
-  let st =
-    update_state config (fun state ->
-        let goals =
-          List.map
-            (fun g ->
-              if g.id <> goal_id then g
-              else (
-                found := true;
-                let status, priority =
-                  match outcome with
-                  | ReviewDone -> (Done, g.priority)
-                  | ReviewProgress -> (Active, max 1 (g.priority - 1))
-                  | ReviewBlocked -> (Paused, min 5 (g.priority + 1))
-                  | ReviewDropped -> (Dropped, g.priority)
-                in
-                {
-                  g with
-                  status;
-                  priority;
-                  horizon = Option.value new_horizon ~default:g.horizon;
-                  last_review_note = note;
-                  last_review_at = Some now;
-                  updated_at = now;
-                }))
-            state.goals
-        in
-        { version = state.version + 1; updated_at = now; goals })
-  in
-  if not !found then Error "goal not found"
-  else
-    match find_goal st.goals goal_id with
-    | Some g -> Ok g
-    | None -> Error "goal not found after review"
+  update_goal config ~goal_id (fun goal ->
+      let phase, priority =
+        match outcome with
+        | ReviewDone -> (Goal_phase.Completed, goal.priority)
+        | ReviewProgress -> (Goal_phase.Executing, max 1 (goal.priority - 1))
+        | ReviewBlocked -> (Goal_phase.Blocked, min 5 (goal.priority + 1))
+        | ReviewDropped -> (Goal_phase.Dropped, goal.priority)
+      in
+      {
+        goal with
+        phase;
+        status = goal_status_of_phase phase;
+        priority;
+        horizon = Option.value new_horizon ~default:goal.horizon;
+        last_review_note = note;
+        last_review_at = Some now;
+        active_verification_request_id =
+          (match phase with
+          | Goal_phase.Awaiting_verification -> goal.active_verification_request_id
+          | _ -> None);
+        updated_at = now;
+      })
 
 let active_goals config =
   list_goals config ~status:Active ()

--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -427,29 +427,23 @@ let get_goal config ~goal_id =
   read_state config |> fun state -> find_goal state.goals goal_id
 
 let update_goal config ~goal_id f =
-  let found = ref false in
-  let now = Types.now_iso () in
-  let state =
-    update_state config (fun state ->
-        let goals =
-          List.map
-            (fun goal ->
-              if not (String.equal goal.id goal_id) then
-                goal
-              else begin
-                found := true;
-                normalize_goal (f { goal with updated_at = now })
-              end)
-            state.goals
-        in
-        { version = state.version + 1; updated_at = now; goals })
-  in
-  if not !found then
-    Error "goal not found"
-  else
-    match find_goal state.goals goal_id with
-    | Some goal -> Ok goal
-    | None -> Error "goal not found"
+  let lock_path = goals_path config in
+  Coord.with_file_lock config lock_path (fun () ->
+      let state = read_state config in
+      match find_goal state.goals goal_id with
+      | None -> Error "goal not found"
+      | Some goal ->
+          let now = Types.now_iso () in
+          let updated_goal = normalize_goal (f { goal with updated_at = now }) in
+          let next_state =
+            {
+              version = state.version + 1;
+              updated_at = now;
+              goals = replace_goal state.goals updated_goal;
+            }
+          in
+          write_state config next_state;
+          Ok updated_goal)
 
 let delete_goal config ~goal_id =
   let before = read_state config in

--- a/lib/goal/goal_verification.ml
+++ b/lib/goal/goal_verification.ml
@@ -615,111 +615,84 @@ let evaluate_quorum request =
     Pending
 
 let cancel_request config ~(request_id : string) =
-  let resolved_at = Types.now_iso () in
-  let found = ref false in
-  let state =
-    update_state config (fun state ->
-        let requests =
-          List.map
-            (fun request ->
-              if String.equal request.id request_id then begin
-                found := true;
-                {
-                  request with
-                  status =
-                    (match request.status with
-                    | Open -> Cancelled
-                    | status -> status);
-                  resolved_at =
-                    (match request.status with
-                    | Open -> Some resolved_at
-                    | _ -> request.resolved_at);
-                }
-              end else
-                request)
-            state.requests
-        in
-        { version = state.version + 1; updated_at = resolved_at; requests })
-  in
-  if not !found then
-    Error "goal verification request not found"
-  else
-    match List.find_opt (fun request -> String.equal request.id request_id) state.requests with
-    | Some request -> Ok request
-    | None -> Error "goal verification request not found"
+  let lock_path = requests_path config in
+  Coord.with_file_lock config lock_path (fun () ->
+      let state = read_state config in
+      match List.find_opt (fun request -> String.equal request.id request_id) state.requests with
+      | None -> Error "goal verification request not found"
+      | Some request when request.status <> Open -> Ok request
+      | Some request ->
+          let resolved_at = Types.now_iso () in
+          let updated_request =
+            {
+              request with
+              status = Cancelled;
+              resolved_at = Some resolved_at;
+            }
+          in
+          let requests =
+            List.map
+              (fun row ->
+                if String.equal row.id request_id then updated_request else row)
+              state.requests
+          in
+          write_state config
+            { version = state.version + 1; updated_at = resolved_at; requests };
+          Ok updated_request)
 
 let submit_vote config ~(request_id : string) ~(principal : goal_principal)
     ~(decision : vote_decision) ?note ?(evidence_refs = []) () =
-  let submitted_at = Types.now_iso () in
-  let found = ref false in
-  let outcome = ref Pending in
-  let error = ref None in
-  let state =
-    update_state config (fun state ->
-        let requests =
-          List.map
-            (fun request ->
-              if not (String.equal request.id request_id) then
-                request
-              else begin
-                found := true;
-                if request.status <> Open then begin
-                  error := Some "goal verification request is not open";
-                  request
-                end else if principal_equal principal request.requested_by then begin
-                  error := Some "requester cannot vote on their own goal verification request";
-                  request
-                end else if
-                  not
-                    (List.exists
-                       (fun eligible -> principal_equal eligible principal)
-                       request.policy_snapshot.eligible_principals)
-                then begin
-                  error := Some "principal is not eligible for this goal verification request";
-                  request
-                end else if
-                  List.exists
-                    (fun vote -> principal_equal vote.principal principal)
-                    request.votes
-                then begin
-                  error := Some "principal has already voted on this request";
-                  request
-                end else
-                  let votes =
-                    request.votes
-                    @ [ { principal; decision; note; evidence_refs; submitted_at } ]
-                  in
-                  let next_request = { request with votes } in
-                  let next_request =
-                    match evaluate_quorum next_request with
-                    | Pending ->
-                        outcome := Pending;
-                        next_request
-                    | Passed ->
-                        outcome := Passed;
-                        {
-                          next_request with
-                          status = Approved;
-                          resolved_at = Some submitted_at;
-                        }
-                    | Failed ->
-                        outcome := Failed;
-                        {
-                          next_request with
-                          status = Rejected;
-                          resolved_at = Some submitted_at;
-                        }
-                  in
-                  next_request
-              end)
-            state.requests
-        in
-        { version = state.version + 1; updated_at = submitted_at; requests })
-  in
-  match !error with
-  | Some msg -> Error msg
-  | None when not !found -> Error "goal verification request not found"
-  | None -> (
+  let lock_path = requests_path config in
+  Coord.with_file_lock config lock_path (fun () ->
+      let state = read_state config in
       match List.find_opt (fun request -> String.equal request.id request_id) state.requests with
-      | Some request -> Ok (request, !outcome)
-      | None -> Error "goal verification request not found")
+      | None -> Error "goal verification request not found"
+      | Some request when request.status <> Open ->
+          Error "goal verification request is not open"
+      | Some request when principal_equal principal request.requested_by ->
+          Error "requester cannot vote on their own goal verification request"
+      | Some request
+        when not
+               (List.exists
+                  (fun eligible -> principal_equal eligible principal)
+                  request.policy_snapshot.eligible_principals) ->
+          Error "principal is not eligible for this goal verification request"
+      | Some request
+        when List.exists
+               (fun vote -> principal_equal vote.principal principal)
+               request.votes ->
+          Error "principal has already voted on this request"
+      | Some request ->
+          let submitted_at = Types.now_iso () in
+          let votes =
+            request.votes
+            @ [ { principal; decision; note; evidence_refs; submitted_at } ]
+          in
+          let next_request = { request with votes } in
+          let next_request, outcome =
+            match evaluate_quorum next_request with
+            | Pending -> (next_request, Pending)
+            | Passed ->
+                ( {
+                    next_request with
+                    status = Approved;
+                    resolved_at = Some submitted_at;
+                  },
+                  Passed )
+            | Failed ->
+                ( {
+                    next_request with
+                    status = Rejected;
+                    resolved_at = Some submitted_at;
+                  },
+                  Failed )
+          in
+          let requests =
+            List.map
+              (fun row ->
+                if String.equal row.id request_id then next_request else row)
+              state.requests
+          in
+          write_state config
+            { version = state.version + 1; updated_at = submitted_at; requests };
+          Ok (next_request, outcome))

--- a/lib/goal/goal_verification.ml
+++ b/lib/goal/goal_verification.ml
@@ -1,0 +1,725 @@
+type principal_kind =
+  | Operator
+  | Keeper
+
+let principal_kind_to_string = function
+  | Operator -> "operator"
+  | Keeper -> "keeper"
+
+let principal_kind_of_string = function
+  | "operator" -> Some Operator
+  | "keeper" -> Some Keeper
+  | _ -> None
+
+let principal_kind_to_yojson kind =
+  `String (principal_kind_to_string kind)
+
+let principal_kind_of_yojson = function
+  | `String raw -> (
+      match String.trim raw |> String.lowercase_ascii |> principal_kind_of_string with
+      | Some kind -> Ok kind
+      | None -> Error ("principal_kind_of_yojson: " ^ raw))
+  | json ->
+      Error ("principal_kind_of_yojson: " ^ Yojson.Safe.to_string json)
+
+type goal_principal = {
+  kind : principal_kind;
+  id : string;
+  display_name : string option;
+}
+
+let goal_principal_to_yojson (principal : goal_principal) =
+  `Assoc
+    [
+      ("kind", principal_kind_to_yojson principal.kind);
+      ("id", `String principal.id);
+      ( "display_name",
+        match principal.display_name with
+        | Some value -> `String value
+        | None -> `Null );
+    ]
+
+let goal_principal_of_yojson = function
+  | `Assoc fields as json -> (
+      let open Yojson.Safe.Util in
+      match principal_kind_of_yojson (member "kind" json) with
+      | Error msg -> Error msg
+      | Ok kind -> (
+          match member "id" json with
+          | `String id when String.trim id <> "" ->
+              Ok
+                {
+                  kind;
+                  id;
+                  display_name = member "display_name" json |> to_string_option;
+                }
+          | `String _ -> Error "goal_principal_of_yojson: id must be non-empty"
+          | other ->
+              Error
+                ("goal_principal_of_yojson: invalid id " ^ Yojson.Safe.to_string other)))
+  | json ->
+      Error ("goal_principal_of_yojson: " ^ Yojson.Safe.to_string json)
+
+type inherit_mode =
+  | Extend
+  | Replace
+
+let inherit_mode_to_string = function
+  | Extend -> "extend"
+  | Replace -> "replace"
+
+let inherit_mode_of_string = function
+  | "extend" -> Some Extend
+  | "replace" -> Some Replace
+  | _ -> None
+
+let inherit_mode_to_yojson mode =
+  `String (inherit_mode_to_string mode)
+
+let inherit_mode_of_yojson = function
+  | `String raw -> (
+      match String.trim raw |> String.lowercase_ascii |> inherit_mode_of_string with
+      | Some mode -> Ok mode
+      | None -> Error ("inherit_mode_of_yojson: " ^ raw))
+  | json ->
+      Error ("inherit_mode_of_yojson: " ^ Yojson.Safe.to_string json)
+
+type goal_verifier_policy = {
+  inherit_mode : inherit_mode;
+  principals : goal_principal list;
+  required_verdicts : int option;
+}
+
+let goal_verifier_policy_to_yojson (policy : goal_verifier_policy) =
+  `Assoc
+    [
+      ("inherit_mode", inherit_mode_to_yojson policy.inherit_mode);
+      ("principals", `List (List.map goal_principal_to_yojson policy.principals));
+      ( "required_verdicts",
+        match policy.required_verdicts with
+        | Some value -> `Int value
+        | None -> `Null );
+    ]
+
+let goal_verifier_policy_of_yojson = function
+  | `Assoc _ as json -> (
+      let open Yojson.Safe.Util in
+      match inherit_mode_of_yojson (member "inherit_mode" json) with
+      | Error msg -> Error msg
+      | Ok inherit_mode -> (
+          match member "principals" json with
+          | `List values -> (
+              let rec collect acc = function
+                | [] -> Ok (List.rev acc)
+                | raw :: rest -> (
+                    match goal_principal_of_yojson raw with
+                    | Ok principal -> collect (principal :: acc) rest
+                    | Error msg -> Error msg)
+              in
+              match collect [] values with
+              | Error msg -> Error msg
+              | Ok principals ->
+                  let required_verdicts =
+                    match member "required_verdicts" json with
+                    | `Null -> Ok None
+                    | `Int n -> Ok (Some n)
+                    | other ->
+                        Error
+                          ( "goal_verifier_policy_of_yojson: invalid required_verdicts "
+                          ^ Yojson.Safe.to_string other )
+                  in
+                  Result.map
+                    (fun required_verdicts ->
+                      { inherit_mode; principals; required_verdicts })
+                    required_verdicts)
+          | other ->
+              Error
+                ( "goal_verifier_policy_of_yojson: invalid principals "
+                ^ Yojson.Safe.to_string other )))
+  | json ->
+      Error ("goal_verifier_policy_of_yojson: " ^ Yojson.Safe.to_string json)
+
+type vote_decision =
+  | Approve
+  | Reject
+
+let vote_decision_to_string = function
+  | Approve -> "approve"
+  | Reject -> "reject"
+
+let vote_decision_of_string = function
+  | "approve" -> Some Approve
+  | "reject" -> Some Reject
+  | _ -> None
+
+let vote_decision_to_yojson decision =
+  `String (vote_decision_to_string decision)
+
+let vote_decision_of_yojson = function
+  | `String raw -> (
+      match String.trim raw |> String.lowercase_ascii |> vote_decision_of_string with
+      | Some decision -> Ok decision
+      | None -> Error ("vote_decision_of_yojson: " ^ raw))
+  | json ->
+      Error ("vote_decision_of_yojson: " ^ Yojson.Safe.to_string json)
+
+type request_status =
+  | Open
+  | Approved
+  | Rejected
+  | Cancelled
+
+let request_status_to_string = function
+  | Open -> "open"
+  | Approved -> "approved"
+  | Rejected -> "rejected"
+  | Cancelled -> "cancelled"
+
+let request_status_to_yojson status =
+  `String (request_status_to_string status)
+
+let request_status_of_yojson = function
+  | `String raw -> (
+      match String.trim raw |> String.lowercase_ascii with
+      | "open" -> Ok Open
+      | "approved" -> Ok Approved
+      | "rejected" -> Ok Rejected
+      | "cancelled" -> Ok Cancelled
+      | _ -> Error ("request_status_of_yojson: " ^ raw))
+  | json ->
+      Error ("request_status_of_yojson: " ^ Yojson.Safe.to_string json)
+
+type policy_snapshot = {
+  principals : goal_principal list;
+  eligible_principals : goal_principal list;
+  required_verdicts : int;
+}
+
+let policy_snapshot_to_yojson (snapshot : policy_snapshot) =
+  `Assoc
+    [
+      ("principals", `List (List.map goal_principal_to_yojson snapshot.principals));
+      ( "eligible_principals",
+        `List (List.map goal_principal_to_yojson snapshot.eligible_principals) );
+      ("required_verdicts", `Int snapshot.required_verdicts);
+    ]
+
+let policy_snapshot_of_yojson = function
+  | `Assoc _ as json -> (
+      let open Yojson.Safe.Util in
+      let parse_principal_list field =
+        match member field json with
+        | `List values ->
+            let rec collect acc = function
+              | [] -> Ok (List.rev acc)
+              | raw :: rest -> (
+                  match goal_principal_of_yojson raw with
+                  | Ok principal -> collect (principal :: acc) rest
+                  | Error msg -> Error msg)
+            in
+            collect [] values
+        | other ->
+            Error
+              (Printf.sprintf "policy_snapshot_of_yojson: invalid %s %s" field
+                 (Yojson.Safe.to_string other))
+      in
+      match parse_principal_list "principals", parse_principal_list "eligible_principals" with
+      | Ok principals, Ok eligible_principals -> (
+          match member "required_verdicts" json with
+          | `Int required_verdicts ->
+              Ok { principals; eligible_principals; required_verdicts }
+          | other ->
+              Error
+                ( "policy_snapshot_of_yojson: invalid required_verdicts "
+                ^ Yojson.Safe.to_string other ))
+      | Error msg, _
+      | _, Error msg ->
+          Error msg)
+  | json ->
+      Error ("policy_snapshot_of_yojson: " ^ Yojson.Safe.to_string json)
+
+type goal_verification_vote = {
+  principal : goal_principal;
+  decision : vote_decision;
+  note : string option;
+  evidence_refs : string list;
+  submitted_at : string;
+}
+
+let goal_verification_vote_to_yojson (vote : goal_verification_vote) =
+  `Assoc
+    [
+      ("principal", goal_principal_to_yojson vote.principal);
+      ("decision", vote_decision_to_yojson vote.decision);
+      ("note", match vote.note with Some value -> `String value | None -> `Null);
+      ("evidence_refs", `List (List.map (fun value -> `String value) vote.evidence_refs));
+      ("submitted_at", `String vote.submitted_at);
+    ]
+
+let goal_verification_vote_of_yojson = function
+  | `Assoc _ as json -> (
+      let open Yojson.Safe.Util in
+      match
+        goal_principal_of_yojson (member "principal" json),
+        vote_decision_of_yojson (member "decision" json)
+      with
+      | Ok principal, Ok decision -> (
+          match member "submitted_at" json with
+          | `String submitted_at ->
+              let evidence_refs =
+                match member "evidence_refs" json with
+                | `Null -> Ok []
+                | `List values -> (
+                    try Ok (List.map to_string values)
+                    with _ ->
+                      Error "goal_verification_vote_of_yojson: invalid evidence_refs")
+                | other ->
+                    Error
+                      ( "goal_verification_vote_of_yojson: invalid evidence_refs "
+                      ^ Yojson.Safe.to_string other )
+              in
+              Result.map
+                (fun evidence_refs ->
+                  {
+                    principal;
+                    decision;
+                    note = member "note" json |> to_string_option;
+                    evidence_refs;
+                    submitted_at;
+                  })
+                evidence_refs
+          | other ->
+              Error
+                ( "goal_verification_vote_of_yojson: invalid submitted_at "
+                ^ Yojson.Safe.to_string other ))
+      | Error msg, _
+      | _, Error msg ->
+          Error msg)
+  | json ->
+      Error ("goal_verification_vote_of_yojson: " ^ Yojson.Safe.to_string json)
+
+type goal_verification_request = {
+  id : string;
+  goal_id : string;
+  target_phase : Goal_phase.t;
+  requested_by : goal_principal;
+  policy_snapshot : policy_snapshot;
+  votes : goal_verification_vote list;
+  status : request_status;
+  created_at : string;
+  resolved_at : string option;
+}
+
+let goal_verification_request_to_yojson (request : goal_verification_request) =
+  `Assoc
+    [
+      ("id", `String request.id);
+      ("goal_id", `String request.goal_id);
+      ("target_phase", Goal_phase.to_yojson request.target_phase);
+      ("requested_by", goal_principal_to_yojson request.requested_by);
+      ("policy_snapshot", policy_snapshot_to_yojson request.policy_snapshot);
+      ("votes", `List (List.map goal_verification_vote_to_yojson request.votes));
+      ("status", request_status_to_yojson request.status);
+      ("created_at", `String request.created_at);
+      ("resolved_at", match request.resolved_at with Some value -> `String value | None -> `Null);
+    ]
+
+let goal_verification_request_of_yojson = function
+  | `Assoc _ as json -> (
+      let open Yojson.Safe.Util in
+      match
+        Goal_phase.of_yojson (member "target_phase" json),
+        goal_principal_of_yojson (member "requested_by" json),
+        policy_snapshot_of_yojson (member "policy_snapshot" json),
+        request_status_of_yojson (member "status" json)
+      with
+      | Ok target_phase, Ok requested_by, Ok policy_snapshot, Ok status -> (
+          match member "id" json, member "goal_id" json, member "created_at" json with
+          | `String id, `String goal_id, `String created_at ->
+              let votes =
+                match member "votes" json with
+                | `Null -> Ok []
+                | `List rows ->
+                    let rec collect acc = function
+                      | [] -> Ok (List.rev acc)
+                      | row :: rest -> (
+                          match goal_verification_vote_of_yojson row with
+                          | Ok vote -> collect (vote :: acc) rest
+                          | Error msg -> Error msg)
+                    in
+                    collect [] rows
+                | other ->
+                    Error
+                      ( "goal_verification_request_of_yojson: invalid votes "
+                      ^ Yojson.Safe.to_string other )
+              in
+              Result.map
+                (fun votes ->
+                  {
+                    id;
+                    goal_id;
+                    target_phase;
+                    requested_by;
+                    policy_snapshot;
+                    votes;
+                    status;
+                    created_at;
+                    resolved_at = member "resolved_at" json |> to_string_option;
+                  })
+                votes
+          | _ ->
+              Error "goal_verification_request_of_yojson: invalid id/goal_id/created_at")
+      | Error msg, _, _, _
+      | _, Error msg, _, _
+      | _, _, Error msg, _
+      | _, _, _, Error msg ->
+          Error msg)
+  | json ->
+      Error ("goal_verification_request_of_yojson: " ^ Yojson.Safe.to_string json)
+
+type state = {
+  version : int;
+  updated_at : string;
+  requests : goal_verification_request list;
+}
+
+type goal_policy_node = {
+  goal_id : string;
+  parent_goal_id : string option;
+  verifier_policy : goal_verifier_policy option;
+}
+
+let state_to_yojson (state : state) =
+  `Assoc
+    [
+      ("version", `Int state.version);
+      ("updated_at", `String state.updated_at);
+      ("requests", `List (List.map goal_verification_request_to_yojson state.requests));
+    ]
+
+let state_of_yojson = function
+  | `Assoc _ as json -> (
+      let open Yojson.Safe.Util in
+      match member "version" json, member "updated_at" json, member "requests" json with
+      | `Int version, `String updated_at, `List requests_json ->
+          let rec collect acc = function
+            | [] -> Ok (List.rev acc)
+            | row :: rest -> (
+                match goal_verification_request_of_yojson row with
+                | Ok request -> collect (request :: acc) rest
+                | Error msg -> Error msg)
+          in
+          Result.map
+            (fun requests -> { version; updated_at; requests })
+            (collect [] requests_json)
+      | _ -> Error "goal_verification_state_of_yojson: invalid state")
+  | json ->
+      Error ("goal_verification_state_of_yojson: " ^ Yojson.Safe.to_string json)
+
+type quorum_result =
+  | Pending
+  | Passed
+  | Failed
+
+let requests_path config =
+  Filename.concat (Coord.masc_dir config) "goal_verifications.json"
+
+let events_path config =
+  Filename.concat (Coord.masc_dir config) "goal_events.jsonl"
+
+let default_state () =
+  { version = 1; updated_at = Types.now_iso (); requests = [] }
+
+let read_state config =
+  let path = requests_path config in
+  if Coord.path_exists config path then
+    match state_of_yojson (Coord.read_json config path) with
+    | Ok state -> state
+    | Error _ -> default_state ()
+  else
+    default_state ()
+
+let write_state config (state : state) =
+  Coord.write_json config (requests_path config) (state_to_yojson state)
+
+let principal_key (principal : goal_principal) =
+  Printf.sprintf "%s:%s" (principal_kind_to_string principal.kind) principal.id
+
+let principal_equal left right =
+  String.equal (principal_key left) (principal_key right)
+
+let dedupe_principals principals =
+  let seen = Hashtbl.create 16 in
+  List.filter
+    (fun principal ->
+      let key = principal_key principal in
+      if Hashtbl.mem seen key then
+        false
+      else begin
+        Hashtbl.add seen key ();
+        true
+      end)
+    principals
+
+let effective_policy_for_nodes ~(goals : goal_policy_node list)
+    ~(goal_id : string) =
+  let by_id = Hashtbl.create (max 16 (List.length goals)) in
+  List.iter (fun (g : goal_policy_node) -> Hashtbl.replace by_id g.goal_id g) goals;
+  let rec lineage acc current =
+    match current.parent_goal_id with
+    | None -> current :: acc
+    | Some parent_id -> (
+        match Hashtbl.find_opt by_id parent_id with
+        | Some parent -> lineage (current :: acc) parent
+        | None -> current :: acc)
+  in
+  match Hashtbl.find_opt by_id goal_id with
+  | None -> Error "goal not found while resolving verifier policy"
+  | Some goal ->
+      let nodes = lineage [] goal in
+      let principals = ref [] in
+      let required_verdicts = ref None in
+      List.iter
+        (fun (g : goal_policy_node) ->
+          match g.verifier_policy with
+          | None -> ()
+          | Some policy ->
+              let next_principals =
+                match policy.inherit_mode with
+                | Extend -> !principals @ policy.principals
+                | Replace -> policy.principals
+              in
+              principals := dedupe_principals next_principals;
+              (match policy.required_verdicts with
+              | Some value -> required_verdicts := Some value
+              | None -> ()))
+        nodes;
+      if !principals = [] then
+        Ok None
+      else
+        match !required_verdicts with
+        | None -> Error "effective goal verifier policy is missing required_verdicts"
+        | Some required_verdicts when required_verdicts < 1 ->
+            Error "required_verdicts must be at least 1"
+        | Some required_verdicts when required_verdicts > List.length !principals ->
+            Error "required_verdicts cannot exceed effective verifier count"
+        | Some required_verdicts ->
+            Ok
+              (Some
+                 {
+                   principals = !principals;
+                   eligible_principals = !principals;
+                   required_verdicts;
+                 })
+
+let exclude_requester ~(policy_snapshot : policy_snapshot)
+    ~(requested_by : goal_principal) =
+  let eligible_principals =
+    List.filter
+      (fun principal -> not (principal_equal principal requested_by))
+      policy_snapshot.eligible_principals
+  in
+  if policy_snapshot.required_verdicts > List.length eligible_principals then
+    Error "requester exclusion makes goal verification quorum impossible"
+  else
+    Ok { policy_snapshot with eligible_principals }
+
+let emit_event config ~(goal_id : string) ~(event_type : string)
+    ~(payload : Yojson.Safe.t) =
+  let path = events_path config in
+  let event =
+    `Assoc
+      [
+        ("ts", `String (Types.now_iso ()));
+        ("goal_id", `String goal_id);
+        ("event_type", `String event_type);
+        ("payload", payload);
+      ]
+  in
+  Fs_compat.append_jsonl path event
+
+let update_state config f =
+  let lock_path = requests_path config in
+  Coord.with_file_lock config lock_path (fun () ->
+      let state = read_state config in
+      let next_state = f state in
+      write_state config next_state;
+      next_state)
+
+let gen_request_id () =
+  Printf.sprintf "gvr-%d-%04x"
+    (int_of_float (Time_compat.now () *. 1000.0))
+    (Hashtbl.hash (Unix.gettimeofday ()) land 0xFFFF)
+
+let create_request config ~(goal_id : string) ~(requested_by : goal_principal)
+    ~(policy_snapshot : policy_snapshot) =
+  let created_at = Types.now_iso () in
+  let request =
+    {
+      id = gen_request_id ();
+      goal_id;
+      target_phase = Goal_phase.Completed;
+      requested_by;
+      policy_snapshot;
+      votes = [];
+      status = Open;
+      created_at;
+      resolved_at = None;
+    }
+  in
+  let state =
+    update_state config (fun state ->
+        {
+          version = state.version + 1;
+          updated_at = created_at;
+          requests = state.requests @ [ request ];
+        })
+  in
+  let saved =
+    List.find_opt (fun row -> String.equal row.id request.id) state.requests
+  in
+  match saved with
+  | Some saved -> Ok saved
+  | None -> Error "failed to persist goal verification request"
+
+let list_requests_for_goal config ~(goal_id : string) =
+  read_state config
+  |> fun (state : state) ->
+  List.filter
+    (fun (request : goal_verification_request) ->
+      String.equal request.goal_id goal_id)
+    state.requests
+
+let find_request config ~(request_id : string) =
+  read_state config |> fun (state : state) ->
+  List.find_opt
+    (fun (request : goal_verification_request) ->
+      String.equal request.id request_id)
+    state.requests
+
+let count_votes ~(decision : vote_decision) request =
+  List.length
+    (List.filter (fun vote -> vote.decision = decision) request.votes)
+
+let remaining_possible_votes request =
+  List.length request.policy_snapshot.eligible_principals - List.length request.votes
+
+let evaluate_quorum request =
+  let approve_count = count_votes ~decision:Approve request in
+  let remaining = remaining_possible_votes request in
+  if approve_count >= request.policy_snapshot.required_verdicts then
+    Passed
+  else if approve_count + remaining < request.policy_snapshot.required_verdicts then
+    Failed
+  else
+    Pending
+
+let cancel_request config ~(request_id : string) =
+  let resolved_at = Types.now_iso () in
+  let found = ref false in
+  let state =
+    update_state config (fun state ->
+        let requests =
+          List.map
+            (fun request ->
+              if String.equal request.id request_id then begin
+                found := true;
+                {
+                  request with
+                  status =
+                    (match request.status with
+                    | Open -> Cancelled
+                    | status -> status);
+                  resolved_at =
+                    (match request.status with
+                    | Open -> Some resolved_at
+                    | _ -> request.resolved_at);
+                }
+              end else
+                request)
+            state.requests
+        in
+        { version = state.version + 1; updated_at = resolved_at; requests })
+  in
+  if not !found then
+    Error "goal verification request not found"
+  else
+    match List.find_opt (fun request -> String.equal request.id request_id) state.requests with
+    | Some request -> Ok request
+    | None -> Error "goal verification request not found"
+
+let submit_vote config ~(request_id : string) ~(principal : goal_principal)
+    ~(decision : vote_decision) ?note ?(evidence_refs = []) () =
+  let submitted_at = Types.now_iso () in
+  let found = ref false in
+  let outcome = ref Pending in
+  let error = ref None in
+  let state =
+    update_state config (fun state ->
+        let requests =
+          List.map
+            (fun request ->
+              if not (String.equal request.id request_id) then
+                request
+              else begin
+                found := true;
+                if request.status <> Open then begin
+                  error := Some "goal verification request is not open";
+                  request
+                end else if principal_equal principal request.requested_by then begin
+                  error := Some "requester cannot vote on their own goal verification request";
+                  request
+                end else if
+                  not
+                    (List.exists
+                       (fun eligible -> principal_equal eligible principal)
+                       request.policy_snapshot.eligible_principals)
+                then begin
+                  error := Some "principal is not eligible for this goal verification request";
+                  request
+                end else if
+                  List.exists
+                    (fun vote -> principal_equal vote.principal principal)
+                    request.votes
+                then begin
+                  error := Some "principal has already voted on this request";
+                  request
+                end else
+                  let votes =
+                    request.votes
+                    @ [ { principal; decision; note; evidence_refs; submitted_at } ]
+                  in
+                  let next_request = { request with votes } in
+                  let next_request =
+                    match evaluate_quorum next_request with
+                    | Pending ->
+                        outcome := Pending;
+                        next_request
+                    | Passed ->
+                        outcome := Passed;
+                        {
+                          next_request with
+                          status = Approved;
+                          resolved_at = Some submitted_at;
+                        }
+                    | Failed ->
+                        outcome := Failed;
+                        {
+                          next_request with
+                          status = Rejected;
+                          resolved_at = Some submitted_at;
+                        }
+                  in
+                  next_request
+              end)
+            state.requests
+        in
+        { version = state.version + 1; updated_at = submitted_at; requests })
+  in
+  match !error with
+  | Some msg -> Error msg
+  | None when not !found -> Error "goal verification request not found"
+  | None -> (
+      match List.find_opt (fun request -> String.equal request.id request_id) state.requests with
+      | Some request -> Ok (request, !outcome)
+      | None -> Error "goal verification request not found")

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -121,6 +121,7 @@ let public_mcp_surface_tools =
     "masc_claim_next"; "masc_transition";
     (* Planning *)
     "masc_goal_list"; "masc_goal_upsert"; "masc_goal_review";
+    "masc_goal_transition"; "masc_goal_verify";
     "masc_plan_init"; "masc_plan_get"; "masc_plan_set_task"; "masc_plan_update";
     (* Heartbeat *)
     "masc_heartbeat";
@@ -153,6 +154,7 @@ let spawned_agent_surface_tools =
     "masc_who"; "masc_agent_update"; "masc_add_task"; "masc_heartbeat";
     "masc_messages";
     "masc_goal_list"; "masc_goal_upsert"; "masc_goal_review";
+    "masc_goal_transition"; "masc_goal_verify";
     "masc_worktree_create"; "masc_worktree_remove"; "masc_worktree_list";
     "masc_board_list"; "masc_board_post"; "masc_board_comment";
     "masc_board_vote"; "masc_board_get";
@@ -172,6 +174,7 @@ let local_worker_surface_tools =
     "masc_status"; "masc_tasks"; "masc_claim_next"; "masc_transition";
     "masc_add_task"; "masc_heartbeat";
     "masc_goal_list"; "masc_goal_upsert"; "masc_goal_review";
+    "masc_goal_transition"; "masc_goal_verify";
     "masc_board_post"; "masc_board_list"; "masc_board_get";
     "masc_board_comment"; "masc_board_vote"; "masc_board_search";
     "masc_code_search"; "masc_code_symbols"; "masc_code_read";
@@ -185,6 +188,7 @@ let session_min_surface_tools =
     "masc_status"; "masc_tasks"; "masc_claim_next";
     "masc_plan_set_task"; "masc_transition"; "masc_add_task";
     "masc_goal_list"; "masc_goal_upsert"; "masc_goal_review";
+    "masc_goal_transition"; "masc_goal_verify";
     "masc_broadcast"; "masc_heartbeat";
   ]
 

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -589,6 +589,8 @@ let dispatch ctx ~name ~args : tool_result option =
   | "masc_goal_list" -> Some (Coord_goals.handle_goal_list ctx args)
   | "masc_goal_upsert" -> Some (Coord_goals.handle_goal_upsert ctx args)
   | "masc_goal_review" -> Some (Coord_goals.handle_goal_review ctx args)
+  | "masc_goal_transition" -> Some (Coord_goals.handle_goal_transition ctx args)
+  | "masc_goal_verify" -> Some (Coord_goals.handle_goal_verify ctx args)
   | "masc_reset" -> Some (handle_reset ctx args)
   | "masc_workflow_guide" -> Some (handle_workflow_guide ctx args)
   | "masc_check" ->
@@ -620,7 +622,8 @@ let tool_required_permission = function
   | "masc_status" | "masc_workflow_guide" | "masc_check"
   | "masc_goal_list" ->
       Some Types.CanReadState
-  | "masc_goal_upsert" | "masc_goal_review" ->
+  | "masc_goal_upsert" | "masc_goal_review"
+  | "masc_goal_transition" | "masc_goal_verify" ->
       Some Types.CanBroadcast
   | "masc_heartbeat" ->
       Some Types.CanBroadcast

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -196,7 +196,9 @@ module Masc = struct
     | Dispatch_plan
     | Goal_list
     | Goal_review
+    | Goal_transition
     | Goal_upsert
+    | Goal_verify
     | Find_by_capability
     | Governance_feed
     | Governance_status
@@ -291,7 +293,9 @@ module Masc = struct
     | Dispatch_plan -> "masc_dispatch_plan"
     | Goal_list -> "masc_goal_list"
     | Goal_review -> "masc_goal_review"
+    | Goal_transition -> "masc_goal_transition"
     | Goal_upsert -> "masc_goal_upsert"
+    | Goal_verify -> "masc_goal_verify"
     | Find_by_capability -> "masc_find_by_capability"
     | Governance_feed -> "masc_governance_feed"
     | Governance_status -> "masc_governance_status"
@@ -386,7 +390,9 @@ module Masc = struct
     | "masc_dispatch_plan" -> Some Dispatch_plan
     | "masc_goal_list" -> Some Goal_list
     | "masc_goal_review" -> Some Goal_review
+    | "masc_goal_transition" -> Some Goal_transition
     | "masc_goal_upsert" -> Some Goal_upsert
+    | "masc_goal_verify" -> Some Goal_verify
     | "masc_find_by_capability" -> Some Find_by_capability
     | "masc_governance_feed" -> Some Governance_feed
     | "masc_governance_status" -> Some Governance_status

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -104,7 +104,9 @@ module Masc : sig
     | Dispatch_plan
     | Goal_list
     | Goal_review
+    | Goal_transition
     | Goal_upsert
+    | Goal_verify
     | Find_by_capability
     | Governance_feed
     | Governance_status

--- a/lib/tool_permission_map.ml
+++ b/lib/tool_permission_map.ml
@@ -48,6 +48,8 @@ let legacy_permission_entries : (string * permission) list =
     ("masc_transition", CanCompleteTask);
     ("masc_broadcast", CanBroadcast);
     ("masc_heartbeat", CanBroadcast);
+    ("masc_goal_transition", CanBroadcast);
+    ("masc_goal_verify", CanBroadcast);
     ("masc_webrtc_offer", CanBroadcast);
     ("masc_webrtc_answer", CanBroadcast);
     ("channel_gate", CanBroadcast);

--- a/lib/tool_schemas/tool_schemas_coord_extra.ml
+++ b/lib/tool_schemas/tool_schemas_coord_extra.ml
@@ -1,19 +1,87 @@
-(** MCP tool schemas for project management operations (extra). *)
+(** MCP tool schemas for shared goal planning and goal lifecycle
+    operations. *)
 
 open Types
 
 let goal_horizon_enum = [ "short"; "mid"; "long" ]
 let goal_status_enum = [ "active"; "paused"; "done"; "dropped" ]
+let goal_phase_enum =
+  [
+    "executing";
+    "awaiting_verification";
+    "awaiting_approval";
+    "blocked";
+    "paused";
+    "completed";
+    "dropped";
+  ]
+
 let goal_review_outcome_enum = [ "done"; "progress"; "blocked"; "dropped" ]
+let goal_transition_action_enum =
+  [
+    "request_complete";
+    "approve_completion";
+    "reject_completion";
+    "pause";
+    "resume";
+    "operator_block";
+    "operator_unblock";
+    "drop";
+    "reopen";
+  ]
+
+let goal_vote_decision_enum = [ "approve"; "reject" ]
+let goal_principal_kind_enum = [ "operator"; "keeper" ]
+let goal_inherit_mode_enum = [ "extend"; "replace" ]
+
+let enum_schema ?description values =
+  `Assoc
+    ([
+       ("type", `String "string");
+       ("enum", `List (List.map (fun value -> `String value) values));
+     ]
+     @
+     match description with
+     | Some description -> [ ("description", `String description) ]
+     | None -> [])
+
+let goal_principal_schema =
+  `Assoc
+    [
+      ("type", `String "object");
+      ( "properties",
+        `Assoc
+          [
+            ("kind", enum_schema goal_principal_kind_enum);
+            ("id", `Assoc [ ("type", `String "string") ]);
+            ("display_name", `Assoc [ ("type", `String "string") ]);
+          ] );
+      ("required", `List [ `String "kind"; `String "id" ]);
+    ]
+
+let goal_verifier_policy_schema =
+  `Assoc
+    [
+      ("type", `String "object");
+      ( "properties",
+        `Assoc
+          [
+            ("inherit_mode", enum_schema goal_inherit_mode_enum);
+            ("principals", `Assoc [ ("type", `String "array"); ("items", goal_principal_schema) ]);
+            ("required_verdicts", `Assoc [ ("type", `String "integer") ]);
+          ] );
+      ("required", `List [ `String "inherit_mode"; `String "principals" ]);
+    ]
 
 let schemas : tool_schema list =
   [
     {
       name = "masc_goal_list";
       description =
-        "List shared planning goals from the Goal Store, optionally filtered by horizon or status. \
+        "List shared planning goals from the Goal Store, optionally filtered by horizon or legacy status. \
 Use when a PM/planner agent needs current long/mid/short goals before creating tasks or reviews. \
-The dashboard Goal Tree reads the same store. Linked tasks prefer explicit goal_id linkage; title tags like [goal:<id>] remain a legacy fallback.";
+The dashboard Goal Tree reads the same store. Linked tasks prefer explicit goal_id linkage; title tags like [goal:<id>] remain a legacy fallback. \
+The response includes each goal's explicit lifecycle phase and verification policy.";
       input_schema =
         `Assoc
           [
@@ -21,20 +89,8 @@ The dashboard Goal Tree reads the same store. Linked tasks prefer explicit goal_
             ( "properties",
               `Assoc
                 [
-                  ( "horizon",
-                    `Assoc
-                      [
-                        ("type", `String "string");
-                        ("enum", `List (List.map (fun v -> `String v) goal_horizon_enum));
-                        ("description", `String "Optional horizon filter: short | mid | long");
-                      ] );
-                  ( "status",
-                    `Assoc
-                      [
-                        ("type", `String "string");
-                        ("enum", `List (List.map (fun v -> `String v) goal_status_enum));
-                        ("description", `String "Optional status filter: active | paused | done | dropped");
-                      ] );
+                  ("horizon", enum_schema ~description:"Optional horizon filter" goal_horizon_enum);
+                  ("status", enum_schema ~description:"Optional legacy status filter" goal_status_enum);
                 ] );
           ];
     };
@@ -43,7 +99,9 @@ The dashboard Goal Tree reads the same store. Linked tasks prefer explicit goal_
       description =
         "Create or update a shared Goal Store entry used by Planning > Goal Tree. \
 For new goals, provide at least title; omitted horizon defaults to short. \
-After creation, link tasks into the tree with goal_id=<goal_id>; include [goal:<id>] in the title only for legacy compatibility.";
+After creation, link tasks into the tree with goal_id=<goal_id>; include [goal:<id>] in the title only for legacy compatibility. \
+Use this tool for goal metadata, parent linkage, and verifier-policy configuration. \
+Use masc_goal_transition / masc_goal_verify for lifecycle moves and votes.";
       input_schema =
         `Assoc
           [
@@ -52,33 +110,25 @@ After creation, link tasks into the tree with goal_id=<goal_id>; include [goal:<
               `Assoc
                 [
                   ("id", `Assoc [ ("type", `String "string") ]);
-                  ( "horizon",
-                    `Assoc
-                      [
-                        ("type", `String "string");
-                        ("enum", `List (List.map (fun v -> `String v) goal_horizon_enum));
-                      ] );
+                  ("horizon", enum_schema goal_horizon_enum);
                   ("title", `Assoc [ ("type", `String "string") ]);
                   ("metric", `Assoc [ ("type", `String "string") ]);
                   ("target_value", `Assoc [ ("type", `String "string") ]);
                   ("due_date", `Assoc [ ("type", `String "string") ]);
                   ("priority", `Assoc [ ("type", `String "integer") ]);
-                  ( "status",
-                    `Assoc
-                      [
-                        ("type", `String "string");
-                        ("enum", `List (List.map (fun v -> `String v) goal_status_enum));
-                      ] );
+                  ("status", enum_schema goal_status_enum);
+                  ("phase", enum_schema goal_phase_enum);
                   ("parent_goal_id", `Assoc [ ("type", `String "string") ]);
+                  ("verifier_policy", goal_verifier_policy_schema);
+                  ("require_completion_approval", `Assoc [ ("type", `String "boolean") ]);
                 ] );
           ];
     };
     {
       name = "masc_goal_review";
       description =
-        "Apply a review outcome to an existing shared goal. \
-Use to mark progress, completion, blockage, or drop decisions after evaluating sub-tasks. \
-Optionally move the goal to a new horizon and store a review note.";
+        "Compatibility wrapper for legacy goal review flows. \
+Use masc_goal_transition / masc_goal_verify for the full Goal FSM and quorum verification.";
       input_schema =
         `Assoc
           [
@@ -87,23 +137,58 @@ Optionally move the goal to a new horizon and store a review note.";
               `Assoc
                 [
                   ("goal_id", `Assoc [ ("type", `String "string") ]);
-                  ( "outcome",
-                    `Assoc
-                      [
-                        ("type", `String "string");
-                        ( "enum",
-                          `List
-                            (List.map (fun v -> `String v) goal_review_outcome_enum) );
-                      ] );
-                  ( "new_horizon",
-                    `Assoc
-                      [
-                        ("type", `String "string");
-                        ("enum", `List (List.map (fun v -> `String v) goal_horizon_enum));
-                      ] );
+                  ("outcome", enum_schema goal_review_outcome_enum);
+                  ("new_horizon", enum_schema goal_horizon_enum);
                   ("note", `Assoc [ ("type", `String "string") ]);
                 ] );
             ("required", `List [ `String "goal_id"; `String "outcome" ]);
+          ];
+    };
+    {
+      name = "masc_goal_transition";
+      description =
+        "Apply an explicit Goal FSM transition such as request_complete, pause, unblock, or approval resolution. \
+The actor field records who initiated the transition.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("goal_id", `Assoc [ ("type", `String "string") ]);
+                  ("action", enum_schema goal_transition_action_enum);
+                  ("actor", goal_principal_schema);
+                  ("note", `Assoc [ ("type", `String "string") ]);
+                ] );
+            ("required", `List [ `String "goal_id"; `String "action"; `String "actor" ]);
+          ];
+    };
+    {
+      name = "masc_goal_verify";
+      description =
+        "Submit one verifier vote on an open goal verification request. \
+Supports mixed operator and keeper principals, one vote per principal, and N-of-M quorum resolution.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("goal_id", `Assoc [ ("type", `String "string") ]);
+                  ("request_id", `Assoc [ ("type", `String "string") ]);
+                  ("principal", goal_principal_schema);
+                  ("decision", enum_schema goal_vote_decision_enum);
+                  ("note", `Assoc [ ("type", `String "string") ]);
+                  ( "evidence_refs",
+                    `Assoc
+                      [
+                        ("type", `String "array");
+                        ("items", `Assoc [ ("type", `String "string") ]);
+                      ] );
+                ] );
+            ("required", `List [ `String "goal_id"; `String "principal"; `String "decision" ]);
           ];
     };
   ]

--- a/test/dune
+++ b/test/dune
@@ -470,6 +470,7 @@
         test_goal_janitor
         test_goal_tools
         test_goal_store
+        test_goal_verification
         test_string_util
         test_board_core_payload
         test_voice_config)
@@ -635,6 +636,7 @@
         test_goal_janitor
         test_goal_tools
         test_goal_store
+        test_goal_verification
         test_string_util
         test_board_core_payload
         test_voice_config)

--- a/test/test_goal_janitor.ml
+++ b/test/test_goal_janitor.ml
@@ -42,7 +42,9 @@ let make_goal ?(status = Goal_store.Active) ?(days_ago = 0) id title =
   {
     Goal_store.id; horizon = Short; title;
     metric = None; target_value = None; due_date = None;
-    priority = 3; status; parent_goal_id = None;
+    priority = 3; status; phase = Goal_store.phase_of_goal_status status;
+    verifier_policy = None; require_completion_approval = false;
+    active_verification_request_id = None; parent_goal_id = None;
     last_review_note = None; last_review_at = None;
     created_at = ts; updated_at = ts;
   }

--- a/test/test_goal_store.ml
+++ b/test/test_goal_store.ml
@@ -43,7 +43,9 @@ let make_goal id title =
   {
     Goal_store.id; horizon = Short; title;
     metric = None; target_value = None; due_date = None;
-    priority = 3; status = Active; parent_goal_id = None;
+    priority = 3; status = Active; phase = Goal_phase.Executing;
+    verifier_policy = None; require_completion_approval = false;
+    active_verification_request_id = None; parent_goal_id = None;
     last_review_note = None; last_review_at = None;
     created_at = ts; updated_at = ts;
   }
@@ -98,6 +100,56 @@ let test_updated_at_also_refreshed () =
   let after = Goal_store.read_state config in
   check bool "updated_at refreshed" true (after.updated_at <> stale_ts)
 
+let test_legacy_status_defaults_phase () =
+  with_room @@ fun config ->
+  Coord.write_json config (Goal_store.goals_path config)
+    (`Assoc
+      [
+        ("version", `Int 1);
+        ("updated_at", `String (iso_now ()));
+        ( "goals",
+          `List
+            [
+              `Assoc
+                [
+                  ("id", `String "legacy-1");
+                  ("horizon", `String "short");
+                  ("title", `String "Legacy Goal");
+                  ("metric", `Null);
+                  ("target_value", `Null);
+                  ("due_date", `Null);
+                  ("priority", `Int 3);
+                  ("status", `String "active");
+                  ("parent_goal_id", `Null);
+                  ("last_review_note", `Null);
+                  ("last_review_at", `Null);
+                  ("created_at", `String (iso_now ()));
+                  ("updated_at", `String (iso_now ()));
+                ];
+            ] );
+      ]);
+  let state = Goal_store.read_state config in
+  match state.goals with
+  | [ goal ] ->
+      check string "legacy active becomes executing" "executing"
+        (Goal_phase.to_string goal.phase);
+      check string "legacy active status preserved" "active"
+        (match goal.status with Active -> "active" | _ -> "other")
+  | _ -> fail "expected one legacy goal"
+
+let test_blocked_phase_projects_legacy_status () =
+  with_room @@ fun config ->
+  let goal, _kind =
+    match Goal_store.upsert_goal config ~title:"Blocked goal"
+            ~phase:Goal_phase.Blocked ()
+    with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  check string "blocked phase stored" "blocked" (Goal_phase.to_string goal.phase);
+  check string "blocked phase projects to paused status" "paused"
+    (match goal.status with Paused -> "paused" | _ -> "other")
+
 let () =
   run "Goal_store.delete_goal"
     [ ( "regression-7690",
@@ -107,4 +159,8 @@ let () =
           test_case "missing goal: no bump" `Quick
             test_delete_nonexistent_does_not_bump;
           test_case "updated_at also refreshed" `Quick
-            test_updated_at_also_refreshed ] ) ]
+            test_updated_at_also_refreshed;
+          test_case "legacy status defaults phase" `Quick
+            test_legacy_status_defaults_phase;
+          test_case "blocked phase projects legacy status" `Quick
+            test_blocked_phase_projects_legacy_status ] ) ]

--- a/test/test_goal_store.ml
+++ b/test/test_goal_store.ml
@@ -150,6 +150,19 @@ let test_blocked_phase_projects_legacy_status () =
   check string "blocked phase projects to paused status" "paused"
     (match goal.status with Paused -> "paused" | _ -> "other")
 
+let test_update_missing_goal_does_not_bump () =
+  with_room @@ fun config ->
+  let goal = make_goal "exists" "one goal" in
+  Goal_store.write_state config
+    { version = 9; updated_at = iso_now (); goals = [ goal ] };
+  let before = Goal_store.read_state config in
+  (match Goal_store.update_goal config ~goal_id:"ghost" Fun.id with
+   | Error _ -> ()
+   | Ok _ -> fail "expected missing goal error");
+  let after = Goal_store.read_state config in
+  check int "version unchanged on missing update" before.version after.version;
+  check string "updated_at unchanged on missing update" before.updated_at after.updated_at
+
 let () =
   run "Goal_store.delete_goal"
     [ ( "regression-7690",
@@ -163,4 +176,6 @@ let () =
           test_case "legacy status defaults phase" `Quick
             test_legacy_status_defaults_phase;
           test_case "blocked phase projects legacy status" `Quick
-            test_blocked_phase_projects_legacy_status ] ) ]
+            test_blocked_phase_projects_legacy_status;
+          test_case "missing update: no bump" `Quick
+            test_update_missing_goal_does_not_bump ] ) ]

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -37,6 +37,14 @@ let parse_json_result = function
   | true, body -> Yojson.Safe.from_string body
   | false, body -> fail body
 
+let principal_json ~kind ~id =
+  `Assoc [ ("kind", `String kind); ("id", `String id) ]
+
+let get_string_field json field =
+  match Yojson.Safe.Util.member field json with
+  | `String value -> value
+  | _ -> fail (field ^ " missing")
+
 let test_goal_upsert_and_list () =
   with_room @@ fun config ->
   let created =
@@ -112,6 +120,191 @@ let test_goal_review_updates_status () =
   in
   check string "status updated to done" "done" status
 
+let test_goal_transition_verification_to_completion () =
+  with_room @@ fun config ->
+  let verifier_policy =
+    {
+      Goal_verification.inherit_mode = Goal_verification.Extend;
+      principals =
+        [
+          {
+            kind = Goal_verification.Keeper;
+            id = "keeper-alpha";
+            display_name = Some "keeper-alpha";
+          };
+        ];
+      required_verdicts = Some 1;
+    }
+  in
+  let goal, _kind =
+    match Goal_store.upsert_goal config ~title:"Verify me" ~verifier_policy () with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  let transitioned =
+    Tool_coord.dispatch (coord_ctx config) ~name:"masc_goal_transition"
+      ~args:
+        (`Assoc
+          [
+            ("goal_id", `String goal.id);
+            ("action", `String "request_complete");
+            ("actor", principal_json ~kind:"operator" ~id:"planner");
+          ])
+  in
+  let transitioned_json =
+    match transitioned with
+    | Some result -> parse_json_result result
+    | None -> fail "masc_goal_transition not handled"
+  in
+  let transitioned_goal = Yojson.Safe.Util.member "goal" transitioned_json in
+  check string "phase moved to awaiting_verification" "awaiting_verification"
+    (get_string_field transitioned_goal "phase");
+  let request_json =
+    Yojson.Safe.Util.member "verification_request" transitioned_json
+  in
+  let request_id = get_string_field request_json "id" in
+  let verified =
+    Tool_coord.dispatch (coord_ctx config) ~name:"masc_goal_verify"
+      ~args:
+        (`Assoc
+          [
+            ("goal_id", `String goal.id);
+            ("request_id", `String request_id);
+            ("principal", principal_json ~kind:"keeper" ~id:"keeper-alpha");
+            ("decision", `String "approve");
+          ])
+  in
+  let verified_json =
+    match verified with
+    | Some result -> parse_json_result result
+    | None -> fail "masc_goal_verify not handled"
+  in
+  let verified_goal = Yojson.Safe.Util.member "goal" verified_json in
+  check string "phase moved to completed" "completed"
+    (get_string_field verified_goal "phase")
+
+let test_goal_transition_approval_gate () =
+  with_room @@ fun config ->
+  let verifier_policy =
+    {
+      Goal_verification.inherit_mode = Goal_verification.Extend;
+      principals =
+        [
+          {
+            kind = Goal_verification.Keeper;
+            id = "keeper-alpha";
+            display_name = Some "keeper-alpha";
+          };
+        ];
+      required_verdicts = Some 1;
+    }
+  in
+  let goal, _kind =
+    match
+      Goal_store.upsert_goal config ~title:"Approve me" ~verifier_policy
+        ~require_completion_approval:true ()
+    with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  let transitioned =
+    Tool_coord.dispatch (coord_ctx config) ~name:"masc_goal_transition"
+      ~args:
+        (`Assoc
+          [
+            ("goal_id", `String goal.id);
+            ("action", `String "request_complete");
+            ("actor", principal_json ~kind:"operator" ~id:"planner");
+          ])
+  in
+  let transitioned_json =
+    match transitioned with
+    | Some result -> parse_json_result result
+    | None -> fail "masc_goal_transition not handled"
+  in
+  let request_id =
+    transitioned_json
+    |> Yojson.Safe.Util.member "verification_request"
+    |> fun json -> get_string_field json "id"
+  in
+  let verified =
+    Tool_coord.dispatch (coord_ctx config) ~name:"masc_goal_verify"
+      ~args:
+        (`Assoc
+          [
+            ("goal_id", `String goal.id);
+            ("request_id", `String request_id);
+            ("principal", principal_json ~kind:"keeper" ~id:"keeper-alpha");
+            ("decision", `String "approve");
+          ])
+  in
+  let verified_json =
+    match verified with
+    | Some result -> parse_json_result result
+    | None -> fail "masc_goal_verify not handled"
+  in
+  check string "phase moved to awaiting_approval" "awaiting_approval"
+    (verified_json |> Yojson.Safe.Util.member "goal" |> fun json ->
+     get_string_field json "phase");
+  let approved =
+    Tool_coord.dispatch (coord_ctx config) ~name:"masc_goal_transition"
+      ~args:
+        (`Assoc
+          [
+            ("goal_id", `String goal.id);
+            ("action", `String "approve_completion");
+            ("actor", principal_json ~kind:"operator" ~id:"planner");
+          ])
+  in
+  let approved_json =
+    match approved with
+    | Some result -> parse_json_result result
+    | None -> fail "masc_goal_transition not handled"
+  in
+  check string "phase moved to completed after approval" "completed"
+    (approved_json |> Yojson.Safe.Util.member "goal" |> fun json ->
+     get_string_field json "phase")
+
+let test_goal_review_done_uses_transition_flow () =
+  with_room @@ fun config ->
+  let verifier_policy =
+    {
+      Goal_verification.inherit_mode = Goal_verification.Extend;
+      principals =
+        [
+          {
+            kind = Goal_verification.Keeper;
+            id = "keeper-alpha";
+            display_name = Some "keeper-alpha";
+          };
+        ];
+      required_verdicts = Some 1;
+    }
+  in
+  let goal, _kind =
+    match Goal_store.upsert_goal config ~title:"Compat me" ~verifier_policy () with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  let reviewed =
+    Tool_coord.dispatch (coord_ctx config) ~name:"masc_goal_review"
+      ~args:
+        (`Assoc
+          [
+            ("goal_id", `String goal.id);
+            ("outcome", `String "done");
+          ])
+  in
+  let reviewed_json =
+    match reviewed with
+    | Some result -> parse_json_result result
+    | None -> fail "masc_goal_review not handled"
+  in
+  check string "legacy done routes to awaiting_verification"
+    "awaiting_verification"
+    (reviewed_json |> Yojson.Safe.Util.member "goal" |> fun json ->
+     get_string_field json "phase")
+
 let () =
   run "goal_tools"
     [
@@ -119,5 +312,11 @@ let () =
         [
           test_case "upsert and list" `Quick test_goal_upsert_and_list;
           test_case "review updates status" `Quick test_goal_review_updates_status;
+          test_case "transition verify complete" `Quick
+            test_goal_transition_verification_to_completion;
+          test_case "approval gate" `Quick
+            test_goal_transition_approval_gate;
+          test_case "review done compatibility" `Quick
+            test_goal_review_done_uses_transition_flow;
         ] );
     ]

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -45,6 +45,11 @@ let get_string_field json field =
   | `String value -> value
   | _ -> fail (field ^ " missing")
 
+let expect_error = function
+  | Some (false, body) -> Yojson.Safe.from_string body
+  | Some (true, _) -> fail "expected tool error"
+  | None -> fail "tool not handled"
+
 let test_goal_upsert_and_list () =
   with_room @@ fun config ->
   let created =
@@ -305,6 +310,67 @@ let test_goal_review_done_uses_transition_flow () =
     (reviewed_json |> Yojson.Safe.Util.member "goal" |> fun json ->
      get_string_field json "phase")
 
+let test_operator_actions_require_operator_principal () =
+  with_room @@ fun config ->
+  let goal, _kind =
+    match Goal_store.upsert_goal config ~title:"Only operators can block" () with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  let blocked =
+    Tool_coord.dispatch (coord_ctx config) ~name:"masc_goal_transition"
+      ~args:
+        (`Assoc
+          [
+            ("goal_id", `String goal.id);
+            ("action", `String "operator_block");
+            ("actor", principal_json ~kind:"keeper" ~id:"keeper-alpha");
+          ])
+  in
+  let error_json = expect_error blocked in
+  check string "keeper blocked by validation"
+    "validation_error"
+    (get_string_field error_json "error_code");
+  let saved_goal =
+    match Goal_store.get_goal config ~goal_id:goal.id with
+    | Some goal -> goal
+    | None -> fail "goal missing after rejected operator_block"
+  in
+  check string "phase unchanged" "executing"
+    (Goal_phase.to_string saved_goal.phase)
+
+let test_completion_approval_requires_operator_principal () =
+  with_room @@ fun config ->
+  let goal, _kind =
+    match
+      Goal_store.upsert_goal config ~title:"Only operators can approve"
+        ~phase:Goal_phase.Awaiting_approval ()
+    with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  let approved =
+    Tool_coord.dispatch (coord_ctx config) ~name:"masc_goal_transition"
+      ~args:
+        (`Assoc
+          [
+            ("goal_id", `String goal.id);
+            ("action", `String "approve_completion");
+            ("actor", principal_json ~kind:"keeper" ~id:"keeper-alpha");
+          ])
+  in
+  let error_json = expect_error approved in
+  check string "keeper approval blocked by validation"
+    "validation_error"
+    (get_string_field error_json "error_code");
+  let saved_goal =
+    match Goal_store.get_goal config ~goal_id:goal.id with
+    | Some goal -> goal
+    | None -> fail "goal missing after rejected approve_completion"
+  in
+  check string "phase unchanged" "awaiting_approval"
+    (Goal_phase.to_string saved_goal.phase)
+
 let () =
   run "goal_tools"
     [
@@ -318,5 +384,9 @@ let () =
             test_goal_transition_approval_gate;
           test_case "review done compatibility" `Quick
             test_goal_review_done_uses_transition_flow;
+          test_case "operator-only actions enforce operator principal" `Quick
+            test_operator_actions_require_operator_principal;
+          test_case "approval requires operator principal" `Quick
+            test_completion_approval_requires_operator_principal;
         ] );
     ]

--- a/test/test_goal_verification.ml
+++ b/test/test_goal_verification.ml
@@ -1,0 +1,97 @@
+(** Tests for Goal_verification error paths preserving state. *)
+
+open Alcotest
+open Masc_mcp
+
+let temp_dir () =
+  let path = Filename.temp_file "goal_verification_test" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+
+let rm_rf dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path
+        |> Array.iter (fun entry -> rm (Filename.concat path entry));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  try rm dir with _ -> ()
+
+let with_room f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () ->
+      let config = Coord.default_config dir in
+      ignore (Coord.init config ~agent_name:(Some "test"));
+      f config)
+
+let operator ?display_name id : Goal_verification.goal_principal =
+  { kind = Goal_verification.Operator; id; display_name }
+
+let keeper ?display_name id : Goal_verification.goal_principal =
+  { kind = Goal_verification.Keeper; id; display_name }
+
+let request_snapshot ~requested_by =
+  let reviewer = operator "reviewer-1" in
+  let verifier = keeper "keeper-a" in
+  let principals = [ requested_by; reviewer; verifier ] in
+  {
+    Goal_verification.principals;
+    eligible_principals = [ reviewer; verifier ];
+    required_verdicts = 2;
+  }
+
+let test_cancel_missing_request_does_not_bump () =
+  with_room @@ fun config ->
+  let before = Goal_verification.read_state config in
+  (match Goal_verification.cancel_request config ~request_id:"ghost" with
+   | Error _ -> ()
+   | Ok _ -> fail "expected missing request error");
+  let after = Goal_verification.read_state config in
+  check int "version unchanged" before.version after.version;
+  check string "updated_at unchanged" before.updated_at after.updated_at
+
+let test_invalid_vote_does_not_bump () =
+  with_room @@ fun config ->
+  let requested_by = operator "planner" in
+  let request =
+    match
+      Goal_verification.create_request config ~goal_id:"goal-1" ~requested_by
+        ~policy_snapshot:(request_snapshot ~requested_by)
+    with
+    | Ok request -> request
+    | Error msg -> fail msg
+  in
+  let before = Goal_verification.read_state config in
+  (match
+     Goal_verification.submit_vote config ~request_id:request.id
+       ~principal:requested_by ~decision:Goal_verification.Approve ()
+   with
+   | Error _ -> ()
+   | Ok _ -> fail "expected requester self-vote error");
+  let after = Goal_verification.read_state config in
+  check int "version unchanged on invalid vote" before.version after.version;
+  check string "updated_at unchanged on invalid vote" before.updated_at after.updated_at;
+  let saved =
+    match Goal_verification.find_request config ~request_id:request.id with
+    | Some request -> request
+    | None -> fail "request missing after invalid vote"
+  in
+  check int "no votes written" 0 (List.length saved.votes)
+
+let () =
+  run "Goal_verification"
+    [
+      ( "state_integrity",
+        [
+          test_case "missing cancel: no bump" `Quick
+            test_cancel_missing_request_does_not_bump;
+          test_case "invalid vote: no bump" `Quick
+            test_invalid_vote_does_not_bump;
+        ] );
+    ]

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -228,6 +228,11 @@ let test_masc_goal_upsert_schema () =
           Alcotest.(check bool) "has id" true (List.mem_assoc "id" props);
           Alcotest.(check bool) "has title" true (List.mem_assoc "title" props);
           Alcotest.(check bool) "has horizon" true (List.mem_assoc "horizon" props);
+          Alcotest.(check bool) "has phase" true (List.mem_assoc "phase" props);
+          Alcotest.(check bool) "has verifier_policy" true
+            (List.mem_assoc "verifier_policy" props);
+          Alcotest.(check bool) "has require_completion_approval" true
+            (List.mem_assoc "require_completion_approval" props);
           Alcotest.(check bool) "has parent_goal_id" true
             (List.mem_assoc "parent_goal_id" props)
       | None -> Alcotest.fail "masc_goal_upsert missing properties"
@@ -252,6 +257,58 @@ let test_masc_goal_review_schema () =
           Alcotest.(check bool) "outcome required" true
             (List.mem (`String "outcome") reqs)
       | None -> Alcotest.fail "masc_goal_review missing required field"
+
+let test_masc_goal_transition_schema () =
+  match find_tool "masc_goal_transition" with
+  | None -> Alcotest.fail "masc_goal_transition not found"
+  | Some schema ->
+      (match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has goal_id" true
+            (List.mem_assoc "goal_id" props);
+          Alcotest.(check bool) "has action" true
+            (List.mem_assoc "action" props);
+          Alcotest.(check bool) "has actor" true
+            (List.mem_assoc "actor" props);
+          Alcotest.(check bool) "has note" true
+            (List.mem_assoc "note" props)
+      | None -> Alcotest.fail "masc_goal_transition missing properties");
+      match get_json_list "required" schema.input_schema with
+      | Some reqs ->
+          Alcotest.(check bool) "goal_id required" true
+            (List.mem (`String "goal_id") reqs);
+          Alcotest.(check bool) "action required" true
+            (List.mem (`String "action") reqs);
+          Alcotest.(check bool) "actor required" true
+            (List.mem (`String "actor") reqs)
+      | None -> Alcotest.fail "masc_goal_transition missing required field"
+
+let test_masc_goal_verify_schema () =
+  match find_tool "masc_goal_verify" with
+  | None -> Alcotest.fail "masc_goal_verify not found"
+  | Some schema ->
+      (match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has goal_id" true
+            (List.mem_assoc "goal_id" props);
+          Alcotest.(check bool) "has request_id" true
+            (List.mem_assoc "request_id" props);
+          Alcotest.(check bool) "has principal" true
+            (List.mem_assoc "principal" props);
+          Alcotest.(check bool) "has decision" true
+            (List.mem_assoc "decision" props);
+          Alcotest.(check bool) "has evidence_refs" true
+            (List.mem_assoc "evidence_refs" props)
+      | None -> Alcotest.fail "masc_goal_verify missing properties");
+      match get_json_list "required" schema.input_schema with
+      | Some reqs ->
+          Alcotest.(check bool) "goal_id required" true
+            (List.mem (`String "goal_id") reqs);
+          Alcotest.(check bool) "principal required" true
+            (List.mem (`String "principal") reqs);
+          Alcotest.(check bool) "decision required" true
+            (List.mem (`String "decision") reqs)
+      | None -> Alcotest.fail "masc_goal_verify missing required field"
 
 let test_remote_operator_action_schema_is_strict () =
   let schema =
@@ -782,6 +839,8 @@ let () =
       Alcotest.test_case "goal_list" `Quick test_masc_goal_list_schema;
       Alcotest.test_case "goal_upsert" `Quick test_masc_goal_upsert_schema;
       Alcotest.test_case "goal_review" `Quick test_masc_goal_review_schema;
+      Alcotest.test_case "goal_transition" `Quick test_masc_goal_transition_schema;
+      Alcotest.test_case "goal_verify" `Quick test_masc_goal_verify_schema;
     ];
     "vote_tools", [
     ];


### PR DESCRIPTION
## What changed
- add `masc_goal_transition` and `masc_goal_verify`
- keep `masc_goal_review` as a compatibility wrapper onto the new goal flow
- wire goal FSM transitions, approval gating, and quorum vote submission through the tool surface
- add tool coverage and end-to-end goal tool tests for verification and approval paths
- restrict protected transitions to operator principals only

## Why
The core goal FSM is not usable until the coordinator tool surface can drive it safely. This PR adds the runtime/tool wiring and closes an authorization gap where keeper principals could trigger operator-only transitions.

## Validation
- `test_goal_store`
- `test_goal_janitor`
- `test_goal_tools`
- `test_tools_coverage`

## Notes
Stacked on #9463.