### PR TITLE
fix: make runtime telemetry nullable and provider policy declarative

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -3,6 +3,7 @@ import {
   fetchDashboardGovernance,
   fetchDashboardTools,
   fetchKeeperConfig,
+  fetchRuntimeModelMetrics,
   fetchToolQuality,
 } from './dashboard'
 
@@ -357,5 +358,71 @@ describe('fetchKeeperConfig', () => {
     expect(result.sources.cascade_runtime_json_editable).toBe(false)
     expect(result.metrics.total_cost_usd).toBe(0.12)
     expect(result.runtime.presence_keepalive_sec).toBe(30)
+  })
+})
+
+describe('fetchRuntimeModelMetrics', () => {
+  it('preserves null telemetry fields instead of coercing them to zero', async () => {
+    const rawResponse = {
+      window_minutes: 30,
+      bucket_minutes: 5,
+      total_entries: 1,
+      total_error_entries: 0,
+      models: [
+        {
+          model_id: 'kimi_cli:kimi-for-coding',
+          entry_count: 1,
+          success_count: 1,
+          usage_sample_count: 0,
+          telemetry_sample_count: 0,
+          avg_latency_ms: null,
+          total_input_tokens: null,
+          total_cost_usd: null,
+          recent_entries: [
+            {
+              ts_unix: 1,
+              input_tokens: null,
+              output_tokens: null,
+              latency_ms: null,
+              cost_usd: null,
+              tools_count: 0,
+            },
+          ],
+          buckets: [
+            {
+              ts_start: 1,
+              entry_count: 1,
+              success_count: 1,
+              error_count: 0,
+              p50_latency_ms: null,
+              p95_latency_ms: null,
+              error_rate: 0,
+              total_cost_usd: null,
+              cache_hit_ratio: null,
+            },
+          ],
+        },
+      ],
+    }
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchRuntimeModelMetrics()
+    const metric = result.models[0]!
+
+    expect(metric.usage_sample_count).toBe(0)
+    expect(metric.telemetry_sample_count).toBe(0)
+    expect(metric.total_input_tokens).toBeNull()
+    expect(metric.total_cost_usd).toBeNull()
+    expect(metric.recent_entries?.[0]?.input_tokens).toBeNull()
+    expect(metric.recent_entries?.[0]?.latency_ms).toBeNull()
+    expect(metric.buckets?.[0]?.p95_latency_ms).toBeNull()
+    expect(metric.buckets?.[0]?.cache_hit_ratio).toBeNull()
   })
 })

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -500,11 +500,11 @@ export interface BucketMetric {
   entry_count: number
   success_count: number
   error_count: number
-  p50_latency_ms: number
-  p95_latency_ms: number
+  p50_latency_ms: number | null
+  p95_latency_ms: number | null
   error_rate: number
-  total_cost_usd: number
-  cache_hit_ratio: number
+  total_cost_usd: number | null
+  cache_hit_ratio: number | null
 }
 
 export interface DashboardRuntimeModelMetric {
@@ -542,6 +542,8 @@ export interface DashboardRuntimeModelMetric {
   total_output_tokens?: number | null
   total_cache_read_tokens?: number | null
   total_reasoning_tokens?: number | null
+  usage_sample_count?: number | null
+  telemetry_sample_count?: number | null
   fallback_count?: number | null
   success_count?: number | null
   error_count?: number | null
@@ -551,12 +553,12 @@ export interface DashboardRuntimeModelMetric {
   top_tools?: Array<{ tool: string; count: number }> | null
   recent_entries?: Array<{
     ts_unix: number
-    input_tokens: number
-    output_tokens: number
-    latency_ms: number
+    input_tokens: number | null
+    output_tokens: number | null
+    latency_ms: number | null
     prompt_tok_per_sec?: number | null
     peak_memory_gb?: number | null
-    cost_usd: number
+    cost_usd: number | null
     tools_count: number
   }> | null
   buckets?: BucketMetric[] | null
@@ -648,6 +650,8 @@ function decodeRuntimeModelMetric(raw: unknown): DashboardRuntimeModelMetric | n
     total_output_tokens: asNumber(raw.total_output_tokens) ?? null,
     total_cache_read_tokens: asNumber(raw.total_cache_read_tokens) ?? null,
     total_reasoning_tokens: asNumber(raw.total_reasoning_tokens) ?? null,
+    usage_sample_count: asNumber(raw.usage_sample_count) ?? null,
+    telemetry_sample_count: asNumber(raw.telemetry_sample_count) ?? null,
     fallback_count: asNumber(raw.fallback_count) ?? null,
     success_count: asNumber(raw.success_count) ?? null,
     error_count: asNumber(raw.error_count) ?? null,
@@ -665,12 +669,12 @@ function decodeRuntimeModelMetric(raw: unknown): DashboardRuntimeModelMetric | n
           .filter(isRecord)
           .map(r => ({
             ts_unix: asNumber(r.ts_unix) ?? 0,
-            input_tokens: asNumber(r.input_tokens) ?? 0,
-            output_tokens: asNumber(r.output_tokens) ?? 0,
-            latency_ms: asNumber(r.latency_ms) ?? 0,
+            input_tokens: asNumber(r.input_tokens) ?? null,
+            output_tokens: asNumber(r.output_tokens) ?? null,
+            latency_ms: asNumber(r.latency_ms) ?? null,
             prompt_tok_per_sec: asNumber(r.prompt_tok_per_sec) ?? null,
             peak_memory_gb: asNumber(r.peak_memory_gb) ?? null,
-            cost_usd: asNumber(r.cost_usd) ?? 0,
+            cost_usd: asNumber(r.cost_usd) ?? null,
             tools_count: asNumber(r.tools_count) ?? 0,
           }))
       : null,
@@ -682,11 +686,11 @@ function decodeRuntimeModelMetric(raw: unknown): DashboardRuntimeModelMetric | n
             entry_count: asNumber(b.entry_count) ?? 0,
             success_count: asNumber(b.success_count) ?? 0,
             error_count: asNumber(b.error_count) ?? 0,
-            p50_latency_ms: asNumber(b.p50_latency_ms) ?? 0,
-            p95_latency_ms: asNumber(b.p95_latency_ms) ?? 0,
+            p50_latency_ms: asNumber(b.p50_latency_ms) ?? null,
+            p95_latency_ms: asNumber(b.p95_latency_ms) ?? null,
             error_rate: asNumber(b.error_rate) ?? 0,
-            total_cost_usd: asNumber(b.total_cost_usd) ?? 0,
-            cache_hit_ratio: asNumber(b.cache_hit_ratio) ?? 0,
+            total_cost_usd: asNumber(b.total_cost_usd) ?? null,
+            cache_hit_ratio: asNumber(b.cache_hit_ratio) ?? null,
           }))
       : null,
   }

--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { runtimeProviderTone, modelMetricTone, fmtCost, fmtSuccessRate, fmtNumber, filterModelMetrics, sortModelMetricsByUrgency } from './runtime-monitor'
+import { runtimeProviderTone, modelMetricTone, fmtCost, fmtSuccessRate, fmtNumber, filterModelMetrics, sortModelMetricsByUrgency, metricCoverageText } from './runtime-monitor'
 import type { DashboardRuntimeProviderSnapshot, DashboardRuntimeModelMetric } from '../api/dashboard'
 
 function makeProvider(overrides: Partial<DashboardRuntimeProviderSnapshot> = {}): DashboardRuntimeProviderSnapshot {
@@ -188,6 +188,32 @@ describe('fmtNumber', () => {
   it('formats with custom digits', () => {
     const result = fmtNumber(1234.567, 2)
     expect(result).toContain('1,234.57')
+  })
+})
+
+describe('metricCoverageText', () => {
+  it('returns null when all successful entries reported usage and telemetry', () => {
+    expect(
+      metricCoverageText(
+        makeMetric({
+          success_count: 3,
+          usage_sample_count: 3,
+          telemetry_sample_count: 3,
+        }),
+      ),
+    ).toBeNull()
+  })
+
+  it('renders partial coverage when usage or telemetry samples are missing', () => {
+    expect(
+      metricCoverageText(
+        makeMetric({
+          success_count: 5,
+          usage_sample_count: 0,
+          telemetry_sample_count: 2,
+        }),
+      ),
+    ).toBe('usage 0/5 · telemetry 2/5')
   })
 })
 

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -4,7 +4,6 @@ import { useSignal } from '@preact/signals'
 import {
   fetchRuntimeModelMetrics,
   fetchRuntimeProviders,
-  type BucketMetric,
   type DashboardRuntimeModelMetric,
   type DashboardRuntimeModelMetricsResponse,
   type DashboardRuntimeProviderSnapshot,
@@ -137,8 +136,8 @@ function fmtTime(tsUnix: number): string {
   return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', second: '2-digit' })
 }
 
-function fmtPct(value: number): string {
-  if (Number.isNaN(value)) return '--'
+function fmtPct(value?: number | null): string {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '--'
   return `${(value * 100).toFixed(1)}%`
 }
 
@@ -153,6 +152,27 @@ function sparklineSvg(values: number[], color: string, w = 80, h = 20): string {
     return `${x.toFixed(1)},${y.toFixed(1)}`
   }).join(' ')
   return `<svg width="${w}" height="${h}" class="inline-block align-middle" viewBox="0 0 ${w} ${h}" xmlns="http://www.w3.org/2000/svg"><polyline fill="none" stroke="${color}" stroke-width="1.5" stroke-linejoin="round" points="${points}"/></svg>`
+}
+
+function sumNullable(values: Array<number | null | undefined>): number | null {
+  let sawNumber = false
+  let total = 0
+  for (const value of values) {
+    if (typeof value === 'number' && !Number.isNaN(value)) {
+      sawNumber = true
+      total += value
+    }
+  }
+  return sawNumber ? total : null
+}
+
+export function metricCoverageText(metric: DashboardRuntimeModelMetric): string | null {
+  const successCount = metric.success_count ?? 0
+  if (successCount <= 0) return null
+  const usageCount = metric.usage_sample_count ?? 0
+  const telemetryCount = metric.telemetry_sample_count ?? 0
+  if (usageCount >= successCount && telemetryCount >= successCount) return null
+  return `usage ${fmtNumber(usageCount)}/${fmtNumber(successCount)} · telemetry ${fmtNumber(telemetryCount)}/${fmtNumber(successCount)}`
 }
 
 export function RuntimeMonitor() {
@@ -270,7 +290,7 @@ export function RuntimeMonitor() {
           />
           <${StatCell}
             label="Total Cost"
-            value=${fmtCost(metrics?.models.reduce((sum, m) => sum + (m.total_cost_usd ?? 0), 0))}
+            value=${fmtCost(sumNullable((metrics?.models ?? []).map(m => m.total_cost_usd)))}
             detail=${`${fmtNumber(metrics?.models.reduce((sum, m) => sum + (m.total_tool_calls ?? 0), 0))} tool calls`}
           />
         </div>
@@ -308,6 +328,9 @@ export function RuntimeMonitor() {
                     <div class="grid gap-1">
                       <strong class="text-sm text-text-strong">${metric.model_id}</strong>
                       <span class="text-xs text-text-muted">entries ${fmtNumber(metric.entry_count)} · fallback ${fmtNumber(metric.fallback_count)}</span>
+                      ${metricCoverageText(metric)
+                        ? html`<span class="text-2xs text-[var(--text-muted)]">${metricCoverageText(metric)}</span>`
+                        : null}
                     </div>
                     <div class="flex gap-2 items-center">
                       <${StatusChip}
@@ -343,18 +366,35 @@ export function RuntimeMonitor() {
                       ? html`<div class="col-span-3 text-text-muted">hw tok/s p50/p95 · ${fmtNumber(metric.hw_decode_p50_tok_per_sec, 1)} / ${fmtNumber(metric.hw_decode_p95_tok_per_sec, 1)} (decode-only; excludes queue/prefill/thinking)</div>`
                       : null}
                   </div>
-                  ${(metric.buckets ?? []).length >= 2
-                    ? html`<div class="flex items-center gap-4 mt-1 text-2xs text-[var(--text-muted)]">
-                        <span>p95 latency</span>
-                        <span dangerouslySetInnerHTML=${{ __html: sparklineSvg((metric.buckets as BucketMetric[]).map(b => b.p95_latency_ms), 'var(--status-warn)', 80, 18) }}></span>
-                        <span>error rate</span>
-                        <span dangerouslySetInnerHTML=${{ __html: sparklineSvg((metric.buckets as BucketMetric[]).map(b => b.error_rate), 'var(--status-bad)', 80, 18) }}></span>
-                      </div>`
-                    : null}
                   ${(() => {
-                    const cacheRead = metric.total_cache_read_tokens ?? 0
-                    const totalIn = cacheRead + (metric.total_input_tokens ?? 0)
-                    const cacheRatio = totalIn > 0 ? cacheRead / totalIn : 0
+                    const latencySeries = (metric.buckets ?? [])
+                      .map(b => b.p95_latency_ms)
+                      .filter((value): value is number => typeof value === 'number' && !Number.isNaN(value))
+                    const errorSeries = (metric.buckets ?? [])
+                      .map(b => b.error_rate)
+                      .filter((value): value is number => typeof value === 'number' && !Number.isNaN(value))
+                    if (latencySeries.length < 2 || errorSeries.length < 2) return null
+                    return html`<div class="flex items-center gap-4 mt-1 text-2xs text-[var(--text-muted)]">
+                        <span>p95 latency</span>
+                        <span dangerouslySetInnerHTML=${{ __html: sparklineSvg(latencySeries, 'var(--status-warn)', 80, 18) }}></span>
+                        <span>error rate</span>
+                        <span dangerouslySetInnerHTML=${{ __html: sparklineSvg(errorSeries, 'var(--status-bad)', 80, 18) }}></span>
+                      </div>`
+                  })()}
+                  ${(() => {
+                    const cacheRead = metric.total_cache_read_tokens
+                    const inputTokens = metric.total_input_tokens
+                    const hasCacheNumbers =
+                      typeof cacheRead === 'number' && typeof inputTokens === 'number'
+                    let cacheRatio: number | null = null
+                    if (hasCacheNumbers) {
+                      const totalTokens = cacheRead + inputTokens
+                      cacheRatio = totalTokens > 0 ? cacheRead / totalTokens : 0
+                    }
+                    const totalIn =
+                      hasCacheNumbers
+                        ? cacheRead + inputTokens
+                        : null
                     return html`<div class="text-2xs text-[var(--text-muted)] mt-1">
                       cost ${fmtCost(metric.total_cost_usd)} · cache savings ${fmtPct(cacheRatio)} (${fmtNumber(cacheRead)} / ${fmtNumber(totalIn)} tokens)
                     </div>`
@@ -386,10 +426,10 @@ export function RuntimeMonitor() {
                             </div>
                             ${metric.recent_entries?.map(re => html`
                               <div class="grid grid-cols-6 gap-1 text-2xs text-[var(--text-body)]">
-                                <div>${fmtTime(re.ts_unix)}</div>
-                                <div>${fmtNumber(re.input_tokens)}</div>
-                                <div>${fmtNumber(re.output_tokens)}</div>
-                                <div>${fmtNumber(re.latency_ms, 0)}ms</div>
+                              <div>${fmtTime(re.ts_unix)}</div>
+                              <div>${fmtNumber(re.input_tokens)}</div>
+                              <div>${fmtNumber(re.output_tokens)}</div>
+                                <div>${re.latency_ms == null ? '--' : `${fmtNumber(re.latency_ms, 0)}ms`}</div>
                                 <div>${fmtCost(re.cost_usd)}</div>
                                 <div>${re.tools_count}</div>
                               </div>

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -414,26 +414,12 @@ let expand_provider_auto ?rotation_scope ~spec provider models =
 let expand_auto_model_string ?rotation_scope (s : string) : string list =
   let trimmed = String.trim s in
   match split_provider_model trimmed with
-  | Some ("glm", model_id)
-    when String.lowercase_ascii model_id = "auto" ->
-    expand_provider_auto ?rotation_scope ~spec:trimmed "glm"
-      (Cascade_model_resolve.glm_auto_models ())
-  | Some ("glm-coding", model_id)
-    when String.lowercase_ascii model_id = "auto" ->
-    expand_provider_auto ?rotation_scope ~spec:trimmed "glm-coding"
-      (Cascade_model_resolve.glm_coding_auto_models ())
-  | Some ("gemini_cli", model_id)
-    when String.lowercase_ascii model_id = "auto" ->
-    expand_provider_auto ?rotation_scope ~spec:trimmed "gemini_cli"
-      (Cascade_model_resolve.gemini_cli_auto_models ())
-  | Some ("codex_cli", model_id)
-    when String.lowercase_ascii model_id = "auto" ->
-    expand_provider_auto ?rotation_scope ~spec:trimmed "codex_cli"
-      (Cascade_model_resolve.codex_cli_auto_models ())
-  | Some ("claude_code", model_id)
-    when String.lowercase_ascii model_id = "auto" ->
-    expand_provider_auto ?rotation_scope ~spec:trimmed "claude_code"
-      (Cascade_model_resolve.claude_code_auto_models ())
+  | Some (provider_name, model_id)
+    when String.lowercase_ascii model_id = "auto" -> (
+      match Provider_adapter.auto_models_for_cascade_prefix provider_name with
+      | Some models when models <> [] ->
+          expand_provider_auto ?rotation_scope ~spec:trimmed provider_name models
+      | _ -> [ trimmed ])
   | _ -> [ trimmed ]
 
 let expand_auto_models (strs : string list) : string list =

--- a/lib/cascade/cascade_model_resolve.ml
+++ b/lib/cascade/cascade_model_resolve.ml
@@ -35,11 +35,6 @@ type model_resolution = {
   provenance : model_resolution_provenance;
 }
 
-type provider_default_spec = {
-  env_var : string;
-  hardcoded_default : string option;
-}
-
 let env_value_opt ?(getenv = Sys.getenv_opt) var =
   match getenv var with
   | Some v ->
@@ -47,81 +42,41 @@ let env_value_opt ?(getenv = Sys.getenv_opt) var =
       if String.equal trimmed "" then None else Some trimmed
   | None -> None
 
-let provider_default_spec = function
-  | "glm" ->
-      Some { env_var = "ZAI_DEFAULT_MODEL"; hardcoded_default = Some "glm-5.1" }
-  | "glm-coding" ->
-      Some
-        {
-          env_var = "ZAI_CODING_DEFAULT_MODEL";
-          hardcoded_default = Some "glm-5.1";
-        }
-  | "llama" | "ollama" ->
-      Some { env_var = "OLLAMA_DEFAULT_MODEL"; hardcoded_default = None }
-  | "gemini" | "gemini_cli" ->
-      Some
-        {
-          env_var = "GEMINI_DEFAULT_MODEL";
-          hardcoded_default = Some "gemini-3-flash-preview";
-        }
-  | "claude" ->
-      Some
-        {
-          env_var = "ANTHROPIC_DEFAULT_MODEL";
-          hardcoded_default = Some "claude-sonnet-4-6-20250514";
-        }
-  | "openai" ->
-      Some { env_var = "OPENAI_DEFAULT_MODEL"; hardcoded_default = Some "gpt-4.1" }
-  | "openrouter" ->
-      Some { env_var = "OPENROUTER_DEFAULT_MODEL"; hardcoded_default = None }
-  | "kimi" ->
-      Some
-        {
-          env_var = "MOONSHOT_DEFAULT_MODEL";
-          hardcoded_default = Some "kimi-k2.5";
-        }
-  | _ -> None
-
 let explicit_resolution requested_model_id resolved_model_id =
   { requested_model_id; resolved_model_id; provenance = Explicit_input }
 
-let default_resolution ?getenv provider_name ~requested_model_id =
-  match provider_default_spec provider_name with
-  | Some { env_var; hardcoded_default } -> (
+let unresolved_auto requested_model_id =
+  {
+    requested_model_id;
+    resolved_model_id = requested_model_id;
+    provenance = Unresolved_auto;
+  }
+
+let default_resolution_from_policy
+    ?getenv
+    (policy : Provider_adapter.model_policy)
+    ~requested_model_id =
+  match policy.default_model_env with
+  | Some env_var -> (
       match env_value_opt ?getenv env_var with
       | Some resolved_model_id ->
           { requested_model_id; resolved_model_id; provenance = Env_default env_var }
       | None -> (
-          match hardcoded_default with
+          match policy.default_model_fallback with
           | Some resolved_model_id ->
               { requested_model_id; resolved_model_id; provenance = Hardcoded_default }
-          | None ->
-              {
-                requested_model_id;
-                resolved_model_id = requested_model_id;
-                provenance = Unresolved_auto;
-              }))
-  | None ->
-      {
-        requested_model_id;
-        resolved_model_id = requested_model_id;
-        provenance = Unresolved_auto;
-      }
+          | None -> unresolved_auto requested_model_id))
+  | None -> (
+      match policy.default_model_fallback with
+      | Some resolved_model_id ->
+          { requested_model_id; resolved_model_id; provenance = Hardcoded_default }
+      | None -> unresolved_auto requested_model_id)
 
-let csv_items raw =
-  raw
-  |> String.split_on_char ','
-  |> List.filter_map (fun item ->
-         let item = String.trim item in
-         if item = "" then None else Some item)
-
-let env_csv_or default var =
-  match env_value_opt var with
-  | Some raw -> (
-      match csv_items raw with
-      | [] -> default
-      | items -> items)
-  | None -> default
+let default_resolution ?getenv provider_name ~requested_model_id =
+  match Provider_adapter.resolve_adapter_by_cascade_prefix provider_name with
+  | Some adapter ->
+      default_resolution_from_policy ?getenv adapter.model_policy ~requested_model_id
+  | None -> unresolved_auto requested_model_id
 
 (** Default GLM auto-cascade order: quality-first, then speed.
     glm-5.1 = best quality (reasoning), glm-5-turbo = fast tool calling,
@@ -130,50 +85,21 @@ let env_csv_or default var =
 let glm_auto_models = Llm_provider.Zai_catalog.glm_auto_models
 let glm_coding_auto_models = Llm_provider.Zai_catalog.glm_coding_auto_models
 
-let gemini_cli_default_auto_models = [
-  "gemini-3-flash-preview";
-  "gemini-3.1-flash-lite-preview";
-  "gemini-2.5-flash";
-  "gemini-2.5-flash-lite";
-  "gemini-3.1-pro-preview";
-  "gemini-2.5-pro";
-]
-
 let gemini_cli_auto_models () =
-  match env_value_opt "MASC_GEMINI_CLI_AUTO_MODELS" with
-  | Some raw -> (
-      match csv_items raw with
-      | [] -> gemini_cli_default_auto_models
-      | items -> items)
-  | None -> (
-      match env_value_opt "GEMINI_DEFAULT_MODEL" with
-      | Some model -> [ model ]
-      | None -> gemini_cli_default_auto_models)
-
-(* Mirrors the Codex CLI models observed locally on 2026-04-20, reordered
-   light-to-heavy by generation (5.1 -> 5.4). Keep this operator-tunable
-   because hosted model menus drift.
-
-   2026-04-21: probe the ChatGPT-backed Codex CLI (v0.122.0) before setting
-   defaults. gpt-5.1-codex-mini, gpt-5.1-codex-max, and gpt-5.2-codex all
-   returned runtime 400 unsupported-model errors, while gpt-5.2,
-   gpt-5.3-codex-spark, gpt-5.3-codex, gpt-5.4-mini, and gpt-5.4 executed
-   successfully. Keep the default rotation to the supported set; operators can
-   still opt into a different list explicitly through
-   MASC_CODEX_CLI_AUTO_MODELS when their environment supports it. *)
-let codex_cli_default_auto_models = [
-  "gpt-5.2";
-  "gpt-5.3-codex-spark";
-  "gpt-5.3-codex";
-  "gpt-5.4-mini";
-  "gpt-5.4";
-]
+  Provider_adapter.auto_models_for_cascade_prefix "gemini_cli"
+  |> Option.value ~default:[]
 
 let codex_cli_auto_models () =
-  env_csv_or codex_cli_default_auto_models "MASC_CODEX_CLI_AUTO_MODELS"
+  Provider_adapter.auto_models_for_cascade_prefix "codex_cli"
+  |> Option.value ~default:[]
 
 let claude_code_auto_models () =
-  env_csv_or [ "auto" ] "MASC_CLAUDE_CODE_AUTO_MODELS"
+  Provider_adapter.auto_models_for_cascade_prefix "claude_code"
+  |> Option.value ~default:[]
+
+let kimi_cli_auto_models () =
+  Provider_adapter.auto_models_for_cascade_prefix "kimi_cli"
+  |> Option.value ~default:[]
 
 let resolve_glm_model ?getenv model_id =
   let default_model = default_resolution ?getenv "glm" ~requested_model_id:model_id in
@@ -237,56 +163,27 @@ let resolve_auto_model
     ?getenv
     ?(discover = Llm_provider.Discovery.first_discovered_model_id)
     provider_name model_id =
-  match provider_name with
-  | "llama" | "ollama" ->
+  match Provider_adapter.resolve_adapter_by_cascade_prefix provider_name with
+  | Some { runtime_kind = Provider_adapter.Local; _ } ->
       if String.equal model_id "auto" then
         match discover () with
         | Some resolved_model_id ->
             { requested_model_id = model_id; resolved_model_id; provenance = Discovery }
         | None -> default_resolution ?getenv provider_name ~requested_model_id:model_id
       else explicit_resolution model_id model_id
-  | "glm" -> resolve_glm_model ?getenv model_id
-  | "glm-coding" -> resolve_glm_coding_model ?getenv model_id
-  | "kimi" -> resolve_kimi_model ?getenv model_id
-  | "gemini" | "gemini_cli" ->
-      (* Default bumped from gemini-2.5-flash to gemini-3-flash-preview on
-         2026-04-16 (PR C Cadd follow-up). Capabilities are inherited via
-         the `starts_with "gemini-3"` prefix matcher in
-         oas/lib/llm_provider/capabilities.ml:269 (1M context, tools,
-         parallel tool calls). Override with GEMINI_DEFAULT_MODEL if you
-         still need the 2.5 line.
-
-         2026-04-20: `gemini_cli` joined the same branch. Without this,
-         `gemini_cli:auto` fell through to the wildcard tail and was
-         forwarded as the literal string "auto" into OAS.
-         `oas/lib/llm_provider/transport_gemini_cli.build_args` then
-         omits `--model`, so the gemini CLI chose its internal default —
-         `gemini-3.1-pro-preview` — whose quota is small enough that every
-         fleet call 429'd with `MODEL_CAPACITY_EXHAUSTED`. Mapping to
-         `gemini-3-flash-preview` (higher quota, 1M context, tool calls)
-         restores throughput. *)
+  | Some { model_policy = { family = Provider_adapter.Glm_general; _ }; _ } ->
+      resolve_glm_model ?getenv model_id
+  | Some { model_policy = { family = Provider_adapter.Glm_coding; _ }; _ } ->
+      resolve_glm_coding_model ?getenv model_id
+  | Some { model_policy = { family = Provider_adapter.Kimi_api_family; _ }; _ } ->
+      resolve_kimi_model ?getenv model_id
+  | Some _ ->
       if String.equal model_id "auto" then
         default_resolution ?getenv provider_name ~requested_model_id:model_id
-      else explicit_resolution model_id model_id
-  | "claude" ->
-      if String.equal model_id "auto" then
-        default_resolution ?getenv provider_name ~requested_model_id:model_id
-      else explicit_resolution model_id model_id
-  | "openai" ->
-      if String.equal model_id "auto" then
-        default_resolution ?getenv provider_name ~requested_model_id:model_id
-      else explicit_resolution model_id model_id
-  | "openrouter" ->
-      if String.equal model_id "auto" then
-        default_resolution ?getenv provider_name ~requested_model_id:model_id
-      else explicit_resolution model_id model_id
-  | _ ->
-      if String.equal model_id "auto" then
-        {
-          requested_model_id = model_id;
-          resolved_model_id = model_id;
-          provenance = Unresolved_auto;
-        }
+      else
+        explicit_resolution model_id model_id
+  | None ->
+      if String.equal model_id "auto" then unresolved_auto model_id
       else explicit_resolution model_id model_id
 
 let resolve_auto_model_id provider_name model_id =

--- a/lib/cascade/cascade_model_resolve.mli
+++ b/lib/cascade/cascade_model_resolve.mli
@@ -32,6 +32,11 @@ val codex_cli_auto_models : unit -> string list
     control unless an operator opts into model rotation. *)
 val claude_code_auto_models : unit -> string list
 
+(** Ordered Kimi CLI candidates for [kimi_cli:auto].
+    Configurable via [MASC_KIMI_CLI_AUTO_MODELS] (comma-separated).
+    Defaults to [["kimi-for-coding"]]. *)
+val kimi_cli_auto_models : unit -> string list
+
 type model_resolution_provenance =
   | Explicit_input
   | Alias of string

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -150,18 +150,10 @@ let model_id_of_label label =
 let catalog_models_for_provider provider =
   match Provider_adapter.resolve_direct_adapter provider with
   | Some { canonical_name; _ } when canonical_name = Provider_adapter.cn_llama -> []
-  | Some { canonical_name; _ } when canonical_name = Provider_adapter.cn_gemini ->
-      Cascade_model_resolve.gemini_cli_auto_models ()
-  | Some { canonical_name; _ } when canonical_name = Provider_adapter.cn_codex ->
-      Cascade_model_resolve.codex_cli_auto_models ()
-  | Some { canonical_name; _ } when canonical_name = Provider_adapter.cn_claude ->
-      Cascade_model_resolve.claude_code_auto_models ()
-  | Some { canonical_name; _ } when canonical_name = Provider_adapter.cn_glm ->
-      Cascade_model_resolve.glm_auto_models ()
-  | Some { canonical_name; _ }
-    when canonical_name = Provider_adapter.cn_glm_coding_plan ->
-      Cascade_model_resolve.glm_coding_auto_models ()
-  | Some _ -> [ "auto" ]
+  | Some _ -> (
+      match Provider_adapter.auto_models_for_provider provider with
+      | Some models -> models
+      | None -> [ "auto" ])
   | None -> []
 
 let default_model_for_provider provider =

--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -16,12 +16,12 @@ module IntMap = Map.Make (Int)
 type recent_entry = {
   re_ts_unix : float;
   re_provider : string option;
-  re_input_tokens : int;
-  re_output_tokens : int;
-  re_latency_ms : float;
+  re_input_tokens : int option;
+  re_output_tokens : int option;
+  re_latency_ms : float option;
   re_prompt_tok_per_sec : float option;
   re_peak_memory_gb : float option;
-  re_cost_usd : float;
+  re_cost_usd : float option;
   re_tools_count : int;
 }
 
@@ -30,11 +30,11 @@ type bucket_metric = {
   b_entry_count : int;
   b_success_count : int;
   b_error_count : int;
-  b_p50_latency_ms : float;
-  b_p95_latency_ms : float;
+  b_p50_latency_ms : float option;
+  b_p95_latency_ms : float option;
   b_error_rate : float;
-  b_total_cost_usd : float;
-  b_cache_hit_ratio : float;
+  b_total_cost_usd : float option;
+  b_cache_hit_ratio : float option;
 }
 
 type model_bucketed = {
@@ -46,9 +46,9 @@ type model_stats = {
   model_id : string;
   provider : string option;
   entry_count : int;
-  avg_tok_per_sec : float;
-  p50_tok_per_sec : float;
-  p95_tok_per_sec : float;
+  avg_tok_per_sec : float option;
+  p50_tok_per_sec : float option;
+  p95_tok_per_sec : float option;
   prompt_avg_tok_per_sec : float option;
   prompt_p50_tok_per_sec : float option;
   prompt_p95_tok_per_sec : float option;
@@ -67,17 +67,19 @@ type model_stats = {
      None when no entry in window reported thinking_enabled (older jsonl rows
      before the field was emitted, or providers that don't expose it). *)
   thinking_fraction : float option;
-  avg_latency_ms : float;
-  p50_latency_ms : float;
-  p95_latency_ms : float;
-  total_input_tokens : int;
-  total_output_tokens : int;
-  total_cache_read_tokens : int;
-  total_reasoning_tokens : int;
+  avg_latency_ms : float option;
+  p50_latency_ms : float option;
+  p95_latency_ms : float option;
+  total_input_tokens : int option;
+  total_output_tokens : int option;
+  total_cache_read_tokens : int option;
+  total_reasoning_tokens : int option;
+  usage_sample_count : int;
+  telemetry_sample_count : int;
   fallback_count : int;
   success_count : int;
   error_count : int;
-  total_cost_usd : float;
+  total_cost_usd : float option;
   avg_tool_calls_per_turn : float;
   total_tool_calls : int;
   top_tools : (string * int) list;
@@ -105,13 +107,42 @@ let percentile (sorted : float array) (p : float) : float =
     let frac = rank -. Float.of_int lo in
     sorted.(lo) *. (1.0 -. frac) +. sorted.(hi) *. frac
 
+let average_opt (arr : float array) =
+  let len = Array.length arr in
+  if len = 0 then None
+  else Some (Array.fold_left (+.) 0.0 arr /. Float.of_int len)
+
+let percentile_opt (arr : float array) p =
+  if Array.length arr = 0 then None else Some (percentile arr p)
+
+let sum_int_opt values =
+  match values with
+  | [] -> None
+  | xs -> Some (List.fold_left ( + ) 0 xs)
+
+let sum_float_opt values =
+  match values with
+  | [] -> None
+  | xs -> Some (List.fold_left ( +. ) 0.0 xs)
+
+let json_float_field_opt key (fields : (string * Yojson.Safe.t) list) =
+  match List.assoc_opt key fields with
+  | Some (`Float f) -> Some f
+  | Some (`Int n) -> Some (Float.of_int n)
+  | _ -> None
+
+let json_int_field_opt key (fields : (string * Yojson.Safe.t) list) =
+  match List.assoc_opt key fields with
+  | Some (`Int n) -> Some n
+  | _ -> None
+
 (* ── Parse telemetry from decisions.jsonl entries ────────── *)
 
 type raw_entry = {
   model : string;
   provider : string option;
   ts_unix : float;
-  tok_per_sec : float;
+  tok_per_sec : float option;
   prompt_tok_per_sec : float option;
   (* Hardware decode rate when present in telemetry; None for legacy entries
      and non-Ollama providers whose backend doesn't populate inference_timings. *)
@@ -120,13 +151,13 @@ type raw_entry = {
   (* Per-turn thinking_enabled as sent to the model (adaptive classifier output).
      None for entries that predate the field or providers that don't expose it. *)
   thinking_enabled : bool option;
-  latency_ms : float;
-  input_tokens : int;
-  output_tokens : int;
-  cache_read_tokens : int;
-  reasoning_tokens : int;
+  latency_ms : float option;
+  input_tokens : int option;
+  output_tokens : int option;
+  cache_read_tokens : int option;
+  reasoning_tokens : int option;
   fallback_applied : bool;
-  cost_usd : float;
+  cost_usd : float option;
   tool_call_count : int;
   tools_used : string list;
   is_error : bool;
@@ -182,16 +213,16 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option 
                | _ -> "__error__"
            in
            let provider = provider_opt_of_fields ~model tfields in
-           Some { model; ts_unix = ts; tok_per_sec = 0.0;
+           Some { model; ts_unix = ts; tok_per_sec = None;
                   provider;
                   prompt_tok_per_sec = None;
                   hw_decode_tok_per_sec = None;
                   peak_memory_gb = None;
                   thinking_enabled = None;
-                  latency_ms = 0.0;
-                  input_tokens = 0; output_tokens = 0;
-                  cache_read_tokens = 0; reasoning_tokens = 0;
-                  fallback_applied = false; cost_usd = 0.0;
+                  latency_ms = None;
+                  input_tokens = None; output_tokens = None;
+                  cache_read_tokens = None; reasoning_tokens = None;
+                  fallback_applied = false; cost_usd = None;
                   tool_call_count = outer_tool_call_count;
                   tools_used = outer_tools_used;
                   is_error = true }
@@ -206,10 +237,7 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option 
                    | _ -> "unknown")
            in
            let provider = provider_opt_of_fields ~model tfields in
-           let tok_per_sec =
-             match List.assoc_opt "tokens_per_second" tfields with
-             | Some (`Float f) -> f | Some (`Int n) -> Float.of_int n | _ -> 0.0
-           in
+           let tok_per_sec = json_float_field_opt "tokens_per_second" tfields in
            let prompt_tok_per_sec =
              match List.assoc_opt "prompt_per_second" tfields with
              | Some (`Float f) when f > 0.0 -> Some f
@@ -241,34 +269,16 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option 
              | Some _ as v -> v
              | None -> read "peak_memory"
            in
-           let latency_ms =
-             match List.assoc_opt "request_latency_ms" tfields with
-             | Some (`Float f) -> f | Some (`Int n) -> Float.of_int n | _ -> 0.0
-           in
-           let input_tokens =
-             match List.assoc_opt "input_tokens" tfields with
-             | Some (`Int n) -> n | _ -> 0
-           in
-           let output_tokens =
-             match List.assoc_opt "output_tokens" tfields with
-             | Some (`Int n) -> n | _ -> 0
-           in
-           let cache_read_tokens =
-             match List.assoc_opt "cache_read_tokens" tfields with
-             | Some (`Int n) -> n | _ -> 0
-           in
-           let reasoning_tokens =
-             match List.assoc_opt "reasoning_tokens" tfields with
-             | Some (`Int n) -> n | _ -> 0
-           in
+           let latency_ms = json_float_field_opt "request_latency_ms" tfields in
+           let input_tokens = json_int_field_opt "input_tokens" tfields in
+           let output_tokens = json_int_field_opt "output_tokens" tfields in
+           let cache_read_tokens = json_int_field_opt "cache_read_tokens" tfields in
+           let reasoning_tokens = json_int_field_opt "reasoning_tokens" tfields in
            let fallback_applied =
              match List.assoc_opt "fallback_applied" tfields with
              | Some (`Bool b) -> b | _ -> false
            in
-           let cost_usd =
-             match List.assoc_opt "cost_usd" tfields with
-             | Some (`Float f) -> f | Some (`Int n) -> Float.of_int n | _ -> 0.0
-           in
+           let cost_usd = json_float_field_opt "cost_usd" tfields in
            (* Per-turn thinking_enabled — emitted by keeper_unified_turn's
               append_decision_record under telemetry.thinking_enabled. Treat
               explicit null or absent as None so backfill stays clean. *)
@@ -342,9 +352,7 @@ let aggregate_by_model (entries : raw_entry list) : model_stats list =
     ) StringMap.empty entries in
   StringMap.fold (fun model_id entries acc ->
     let n = List.length entries in
-    let tok_vals = List.filter_map (fun e ->
-      if e.tok_per_sec > 0.0 then Some e.tok_per_sec else None
-    ) entries |> Array.of_list in
+    let tok_vals = List.filter_map (fun e -> e.tok_per_sec) entries |> Array.of_list in
     Array.sort Float.compare tok_vals;
     let prompt_vals =
       List.filter_map (fun e -> e.prompt_tok_per_sec) entries
@@ -359,19 +367,35 @@ let aggregate_by_model (entries : raw_entry list) : model_stats list =
       |> Array.of_list
     in
     Array.sort Float.compare peak_vals;
-    let lat_vals = List.filter_map (fun e ->
-      if e.latency_ms > 0.0 then Some e.latency_ms else None
-    ) entries |> Array.of_list in
+    let lat_vals = List.filter_map (fun e -> e.latency_ms) entries |> Array.of_list in
     Array.sort Float.compare lat_vals;
-    let avg arr =
-      let len = Array.length arr in
-      if len = 0 then 0.0
-      else Array.fold_left (+.) 0.0 arr /. Float.of_int len
-    in
     let success_count = List.length (List.filter (fun e -> not e.is_error) entries) in
     let error_count = List.length (List.filter (fun e -> e.is_error) entries) in
     let total_tool_calls = List.fold_left (fun acc e -> acc + e.tool_call_count) 0 entries in
-    let opt_if_any arr f = if Array.length arr = 0 then None else Some (f arr) in
+    let usage_sample_count =
+      List.fold_left
+        (fun acc e ->
+          if e.input_tokens <> None
+             || e.output_tokens <> None
+             || e.cache_read_tokens <> None
+             || e.reasoning_tokens <> None
+             || e.cost_usd <> None
+          then acc + 1
+          else acc)
+        0 entries
+    in
+    let telemetry_sample_count =
+      List.fold_left
+        (fun acc e ->
+          if e.tok_per_sec <> None
+             || e.prompt_tok_per_sec <> None
+             || e.hw_decode_tok_per_sec <> None
+             || e.peak_memory_gb <> None
+             || e.latency_ms <> None
+          then acc + 1
+          else acc)
+        0 entries
+    in
     (* thinking_fraction: count of entries with thinking_enabled=true over
        entries that reported the field. Entries without the field (older jsonl
        rows, providers that don't expose it) are excluded from denominator —
@@ -394,29 +418,34 @@ let aggregate_by_model (entries : raw_entry list) : model_stats list =
       model_id;
       provider;
       entry_count = n;
-      avg_tok_per_sec = avg tok_vals;
-      p50_tok_per_sec = percentile tok_vals 50.0;
-      p95_tok_per_sec = percentile tok_vals 95.0;
-      prompt_avg_tok_per_sec = opt_if_any prompt_vals avg;
-      prompt_p50_tok_per_sec = opt_if_any prompt_vals (fun a -> percentile a 50.0);
-      prompt_p95_tok_per_sec = opt_if_any prompt_vals (fun a -> percentile a 95.0);
-      hw_decode_avg_tok_per_sec = opt_if_any hw_vals avg;
-      hw_decode_p50_tok_per_sec = opt_if_any hw_vals (fun a -> percentile a 50.0);
-      hw_decode_p95_tok_per_sec = opt_if_any hw_vals (fun a -> percentile a 95.0);
+      avg_tok_per_sec = average_opt tok_vals;
+      p50_tok_per_sec = percentile_opt tok_vals 50.0;
+      p95_tok_per_sec = percentile_opt tok_vals 95.0;
+      prompt_avg_tok_per_sec = average_opt prompt_vals;
+      prompt_p50_tok_per_sec = percentile_opt prompt_vals 50.0;
+      prompt_p95_tok_per_sec = percentile_opt prompt_vals 95.0;
+      hw_decode_avg_tok_per_sec = average_opt hw_vals;
+      hw_decode_p50_tok_per_sec = percentile_opt hw_vals 50.0;
+      hw_decode_p95_tok_per_sec = percentile_opt hw_vals 95.0;
       max_peak_memory_gb =
-        opt_if_any peak_vals (fun a -> a.(Array.length a - 1));
+        if Array.length peak_vals = 0 then None
+        else Some peak_vals.(Array.length peak_vals - 1);
       thinking_fraction;
-      avg_latency_ms = avg lat_vals;
-      p50_latency_ms = percentile lat_vals 50.0;
-      p95_latency_ms = percentile lat_vals 95.0;
-      total_input_tokens = List.fold_left (fun acc e -> acc + e.input_tokens) 0 entries;
-      total_output_tokens = List.fold_left (fun acc e -> acc + e.output_tokens) 0 entries;
-      total_cache_read_tokens = List.fold_left (fun acc e -> acc + e.cache_read_tokens) 0 entries;
-      total_reasoning_tokens = List.fold_left (fun acc e -> acc + e.reasoning_tokens) 0 entries;
+      avg_latency_ms = average_opt lat_vals;
+      p50_latency_ms = percentile_opt lat_vals 50.0;
+      p95_latency_ms = percentile_opt lat_vals 95.0;
+      total_input_tokens = sum_int_opt (List.filter_map (fun e -> e.input_tokens) entries);
+      total_output_tokens = sum_int_opt (List.filter_map (fun e -> e.output_tokens) entries);
+      total_cache_read_tokens =
+        sum_int_opt (List.filter_map (fun e -> e.cache_read_tokens) entries);
+      total_reasoning_tokens =
+        sum_int_opt (List.filter_map (fun e -> e.reasoning_tokens) entries);
+      usage_sample_count;
+      telemetry_sample_count;
       fallback_count = List.length (List.filter (fun e -> e.fallback_applied) entries);
       success_count;
       error_count;
-      total_cost_usd = List.fold_left (fun acc e -> acc +. e.cost_usd) 0.0 entries;
+      total_cost_usd = sum_float_opt (List.filter_map (fun e -> e.cost_usd) entries);
       total_tool_calls;
       avg_tool_calls_per_turn =
         if n = 0 then 0.0
@@ -471,18 +500,21 @@ let bucket_entries_for_model (entries : raw_entry list) ~(bucket_sec : int)
     ) IntMap.empty entries in
   IntMap.fold (fun key bucket_entries acc ->
     let n = List.length bucket_entries in
-    let lat_vals = List.filter_map (fun e ->
-      if e.latency_ms > 0.0 then Some e.latency_ms else None
-    ) bucket_entries |> Array.of_list in
+    let lat_vals = List.filter_map (fun e -> e.latency_ms) bucket_entries |> Array.of_list in
     Array.sort Float.compare lat_vals;
     let success_count = List.length (List.filter (fun e -> not e.is_error) bucket_entries) in
     let error_count = List.length (List.filter (fun e -> e.is_error) bucket_entries) in
-    let total_cache_read = List.fold_left (fun acc e -> acc + e.cache_read_tokens) 0 bucket_entries in
-    let total_input = List.fold_left (fun acc e -> acc + e.input_tokens) 0 bucket_entries in
-    let denom = total_cache_read + total_input in
+    let cache_reads = List.filter_map (fun e -> e.cache_read_tokens) bucket_entries in
+    let inputs = List.filter_map (fun e -> e.input_tokens) bucket_entries in
     let cache_hit_ratio =
-      if denom = 0 then 0.0
-      else Float.of_int total_cache_read /. Float.of_int denom
+      match sum_int_opt cache_reads, sum_int_opt inputs with
+      | None, None -> None
+      | total_cache_read, total_input ->
+          let total_cache_read = Option.value ~default:0 total_cache_read in
+          let total_input = Option.value ~default:0 total_input in
+          let denom = total_cache_read + total_input in
+          if denom = 0 then Some 0.0
+          else Some (Float.of_int total_cache_read /. Float.of_int denom)
     in
     let error_rate =
       if n = 0 then 0.0
@@ -493,11 +525,11 @@ let bucket_entries_for_model (entries : raw_entry list) ~(bucket_sec : int)
       b_entry_count = n;
       b_success_count = success_count;
       b_error_count = error_count;
-      b_p50_latency_ms = percentile lat_vals 50.0;
-      b_p95_latency_ms = percentile lat_vals 95.0;
+      b_p50_latency_ms = percentile_opt lat_vals 50.0;
+      b_p95_latency_ms = percentile_opt lat_vals 95.0;
       b_error_rate = error_rate;
       b_total_cost_usd =
-        List.fold_left (fun acc e -> acc +. e.cost_usd) 0.0 bucket_entries;
+        sum_float_opt (List.filter_map (fun e -> e.cost_usd) bucket_entries);
       b_cache_hit_ratio = cache_hit_ratio;
     } in
     bucket :: acc
@@ -569,28 +601,30 @@ let aggregate_buckets ~base_path ~window_min ~bucket_min : model_bucketed list =
 (* ── JSON serialization ─────────────────────────────────── *)
 
 let bucket_metric_to_json (b : bucket_metric) : Yojson.Safe.t =
+  let opt_float = function Some f -> `Float f | None -> `Null in
   `Assoc
     [ ("ts_start", `Float b.b_ts_start)
     ; ("entry_count", `Int b.b_entry_count)
     ; ("success_count", `Int b.b_success_count)
     ; ("error_count", `Int b.b_error_count)
-    ; ("p50_latency_ms", `Float b.b_p50_latency_ms)
-    ; ("p95_latency_ms", `Float b.b_p95_latency_ms)
+    ; ("p50_latency_ms", opt_float b.b_p50_latency_ms)
+    ; ("p95_latency_ms", opt_float b.b_p95_latency_ms)
     ; ("error_rate", `Float b.b_error_rate)
-    ; ("total_cost_usd", `Float b.b_total_cost_usd)
-    ; ("cache_hit_ratio", `Float b.b_cache_hit_ratio)
+    ; ("total_cost_usd", opt_float b.b_total_cost_usd)
+    ; ("cache_hit_ratio", opt_float b.b_cache_hit_ratio)
     ]
 
 let model_stats_to_json (s : model_stats) : Yojson.Safe.t =
   let opt_float = function Some f -> `Float f | None -> `Null in
+  let opt_int = function Some n -> `Int n | None -> `Null in
   let opt_string = function Some s -> `String s | None -> `Null in
   `Assoc
     [ ("model_id", `String s.model_id)
     ; ("provider", opt_string s.provider)
     ; ("entry_count", `Int s.entry_count)
-    ; ("avg_tok_per_sec", `Float s.avg_tok_per_sec)
-    ; ("p50_tok_per_sec", `Float s.p50_tok_per_sec)
-    ; ("p95_tok_per_sec", `Float s.p95_tok_per_sec)
+    ; ("avg_tok_per_sec", opt_float s.avg_tok_per_sec)
+    ; ("p50_tok_per_sec", opt_float s.p50_tok_per_sec)
+    ; ("p95_tok_per_sec", opt_float s.p95_tok_per_sec)
     ; ("prompt_avg_tok_per_sec", opt_float s.prompt_avg_tok_per_sec)
     ; ("prompt_p50_tok_per_sec", opt_float s.prompt_p50_tok_per_sec)
     ; ("prompt_p95_tok_per_sec", opt_float s.prompt_p95_tok_per_sec)
@@ -599,17 +633,19 @@ let model_stats_to_json (s : model_stats) : Yojson.Safe.t =
     ; ("hw_decode_p95_tok_per_sec", opt_float s.hw_decode_p95_tok_per_sec)
     ; ("max_peak_memory_gb", opt_float s.max_peak_memory_gb)
     ; ("thinking_fraction", opt_float s.thinking_fraction)
-    ; ("avg_latency_ms", `Float s.avg_latency_ms)
-    ; ("p50_latency_ms", `Float s.p50_latency_ms)
-    ; ("p95_latency_ms", `Float s.p95_latency_ms)
-    ; ("total_input_tokens", `Int s.total_input_tokens)
-    ; ("total_output_tokens", `Int s.total_output_tokens)
-    ; ("total_cache_read_tokens", `Int s.total_cache_read_tokens)
-    ; ("total_reasoning_tokens", `Int s.total_reasoning_tokens)
+    ; ("avg_latency_ms", opt_float s.avg_latency_ms)
+    ; ("p50_latency_ms", opt_float s.p50_latency_ms)
+    ; ("p95_latency_ms", opt_float s.p95_latency_ms)
+    ; ("total_input_tokens", opt_int s.total_input_tokens)
+    ; ("total_output_tokens", opt_int s.total_output_tokens)
+    ; ("total_cache_read_tokens", opt_int s.total_cache_read_tokens)
+    ; ("total_reasoning_tokens", opt_int s.total_reasoning_tokens)
+    ; ("usage_sample_count", `Int s.usage_sample_count)
+    ; ("telemetry_sample_count", `Int s.telemetry_sample_count)
     ; ("fallback_count", `Int s.fallback_count)
     ; ("success_count", `Int s.success_count)
     ; ("error_count", `Int s.error_count)
-    ; ("total_cost_usd", `Float s.total_cost_usd)
+    ; ("total_cost_usd", opt_float s.total_cost_usd)
     ; ("avg_tool_calls_per_turn", `Float s.avg_tool_calls_per_turn)
     ; ("total_tool_calls", `Int s.total_tool_calls)
     ; ("top_tools", `List (List.map (fun (tool, count) ->
@@ -619,12 +655,12 @@ let model_stats_to_json (s : model_stats) : Yojson.Safe.t =
         `Assoc [
           ("ts_unix", `Float r.re_ts_unix);
           ("provider", opt_string r.re_provider);
-          ("input_tokens", `Int r.re_input_tokens);
-          ("output_tokens", `Int r.re_output_tokens);
-          ("latency_ms", `Float r.re_latency_ms);
+          ("input_tokens", opt_int r.re_input_tokens);
+          ("output_tokens", opt_int r.re_output_tokens);
+          ("latency_ms", opt_float r.re_latency_ms);
           ("prompt_tok_per_sec", opt_float r.re_prompt_tok_per_sec);
           ("peak_memory_gb", opt_float r.re_peak_memory_gb);
-          ("cost_usd", `Float r.re_cost_usd);
+          ("cost_usd", opt_float r.re_cost_usd);
           ("tools_count", `Int r.re_tools_count);
         ]
       ) s.recent_entries))

--- a/lib/model_inference_metrics.mli
+++ b/lib/model_inference_metrics.mli
@@ -9,12 +9,12 @@
 type recent_entry = {
   re_ts_unix : float;
   re_provider : string option;
-  re_input_tokens : int;
-  re_output_tokens : int;
-  re_latency_ms : float;
+  re_input_tokens : int option;
+  re_output_tokens : int option;
+  re_latency_ms : float option;
   re_prompt_tok_per_sec : float option;
   re_peak_memory_gb : float option;
-  re_cost_usd : float;
+  re_cost_usd : float option;
   re_tools_count : int;
 }
 
@@ -24,14 +24,15 @@ type bucket_metric = {
   b_entry_count : int;
   b_success_count : int;
   b_error_count : int;
-  b_p50_latency_ms : float;
-  b_p95_latency_ms : float;
+  b_p50_latency_ms : float option;
+  b_p95_latency_ms : float option;
   b_error_rate : float;
     (** error_count / entry_count; 0.0 when bucket is empty. *)
-  b_total_cost_usd : float;
-  b_cache_hit_ratio : float;
-    (** cache_read_tokens / (cache_read_tokens + input_tokens); 0.0 when
-        denominator is zero (do not return NaN). *)
+  b_total_cost_usd : float option;
+  b_cache_hit_ratio : float option;
+    (** cache_read_tokens / (cache_read_tokens + input_tokens); [Some 0.0]
+        when the denominator is explicitly zero, [None] when no bucket entry
+        reported either field. *)
 }
 
 type model_bucketed = {
@@ -44,9 +45,9 @@ type model_stats = {
   model_id : string;
   provider : string option;
   entry_count : int;
-  avg_tok_per_sec : float;
-  p50_tok_per_sec : float;
-  p95_tok_per_sec : float;
+  avg_tok_per_sec : float option;
+  p50_tok_per_sec : float option;
+  p95_tok_per_sec : float option;
   prompt_avg_tok_per_sec : float option;
   prompt_p50_tok_per_sec : float option;
   prompt_p95_tok_per_sec : float option;
@@ -60,17 +61,19 @@ type model_stats = {
         [None] when no entry in the window reported [thinking_enabled]
         (older jsonl rows predating the field, or providers that don't
         expose it). Denominator = count of reporting entries. *)
-  avg_latency_ms : float;
-  p50_latency_ms : float;
-  p95_latency_ms : float;
-  total_input_tokens : int;
-  total_output_tokens : int;
-  total_cache_read_tokens : int;
-  total_reasoning_tokens : int;
+  avg_latency_ms : float option;
+  p50_latency_ms : float option;
+  p95_latency_ms : float option;
+  total_input_tokens : int option;
+  total_output_tokens : int option;
+  total_cache_read_tokens : int option;
+  total_reasoning_tokens : int option;
+  usage_sample_count : int;
+  telemetry_sample_count : int;
   fallback_count : int;
   success_count : int;
   error_count : int;
-  total_cost_usd : float;
+  total_cost_usd : float option;
   avg_tool_calls_per_turn : float;
   total_tool_calls : int;
   top_tools : (string * int) list;

--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -154,33 +154,14 @@ let reset_cascade_counters_for_test () =
     Delegates to the current OAS registry helper so endpoint-distinct
     providers such as [glm], [glm-coding], and [openrouter] track the
     pinned agent_sdk behavior exactly. *)
-let starts_with ~prefix s =
-  let plen = String.length prefix in
-  String.length s >= plen && String.sub s 0 plen = prefix
-
-let is_kimi_model_id model_id =
-  let normalized = String.trim model_id |> String.lowercase_ascii in
-  starts_with ~prefix:"kimi-" normalized
-  || starts_with ~prefix:"moonshot-" normalized
-
-let is_moonshot_base_url base_url =
-  match Uri.host (Uri.of_string base_url) with
-  | Some host -> String.equal (String.lowercase_ascii host) "api.moonshot.ai"
-  | None -> false
-
 let provider_name_of_config (cfg : Llm_provider.Provider_config.t) =
-  if cfg.kind = Llm_provider.Provider_config.OpenAI_compat
-     && (is_kimi_model_id cfg.model_id || is_moonshot_base_url cfg.base_url)
-  then
-    "kimi"
-  else
-    Llm_provider.Provider_registry.provider_name_of_config cfg
+  Provider_adapter.provider_label_of_config cfg
 
 let display_provider_name_of_config (cfg : Llm_provider.Provider_config.t) =
-  Provider_adapter.display_provider_name (provider_name_of_config cfg)
+  Provider_adapter.display_provider_name_of_config cfg
 
 let model_label_of_config (cfg : Llm_provider.Provider_config.t) =
-  Printf.sprintf "%s:%s" (display_provider_name_of_config cfg) cfg.model_id
+  Provider_adapter.model_label_of_config cfg
 
 let model_label_option_of_model_id
     ~(candidate_cfgs : Llm_provider.Provider_config.t list)

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -12,6 +12,44 @@ type auth_mode =
       location_env : string;
     }
 
+type model_family =
+  | Generic
+  | Glm_general
+  | Glm_coding
+  | Kimi_api_family
+
+type auto_models_source =
+  | No_auto_models
+  | Env_csv_or_default of {
+      env_var : string;
+      defaults : string list;
+      prefer_default_model_env : bool;
+    }
+  | Zai_general_auto_models
+  | Zai_coding_auto_models
+
+type reporting_policy =
+  | Reported
+  | Missing_by_design
+  | Unknown
+
+type model_policy = {
+  default_model_env : string option;
+  default_model_fallback : string option;
+  auto_models : auto_models_source;
+  expand_auto : bool;
+  family : model_family;
+}
+
+type tool_policy = {
+  supports_runtime_mcp_http_headers : bool;
+}
+
+type telemetry_policy = {
+  usage_reporting : reporting_policy;
+  runtime_reporting : reporting_policy;
+}
+
 type voice_transport =
   | Voice_openai_compat
   | Voice_elevenlabs_direct
@@ -31,6 +69,9 @@ type adapter = {
   default_voice : string option;   (** Default TTS voice name. None = no voice assignment. *)
   endpoint_url : string option;    (** Base URL for the provider API. *)
   default_model_id : string option; (** Default model ID for the provider. *)
+  model_policy : model_policy;
+  tool_policy : tool_policy;
+  telemetry_policy : telemetry_policy;
 }
 
 type voice_adapter = {
@@ -83,6 +124,26 @@ let string_of_voice_transport = function
   | Voice_mcp -> "voice_mcp"
 
 let normalize_label label = String.trim label |> String.lowercase_ascii
+
+let env_value_opt ?(getenv = Sys.getenv_opt) name =
+  match getenv name with
+  | Some raw ->
+      let trimmed = String.trim raw in
+      if trimmed = "" then None else Some trimmed
+  | None -> None
+
+let csv_items raw =
+  raw
+  |> String.split_on_char ','
+  |> List.map String.trim
+  |> List.filter (fun s -> s <> "")
+
+let no_tool_http_headers = { supports_runtime_mcp_http_headers = false }
+let runtime_mcp_http_headers = { supports_runtime_mcp_http_headers = true }
+let telemetry_reported = { usage_reporting = Reported; runtime_reporting = Reported }
+let telemetry_unknown = { usage_reporting = Unknown; runtime_reporting = Unknown }
+let telemetry_usage_missing =
+  { usage_reporting = Missing_by_design; runtime_reporting = Unknown }
 
 (* ── Canonical adapter names (single definition point) ──────── *)
 
@@ -204,6 +265,16 @@ let direct_adapters =
       default_model_id =
         (let m = Env_config_runtime.Llama.default_model in
          if m = "" || m = "explicit-model-required" then None else Some m);
+      model_policy =
+        {
+          default_model_env = Some "OLLAMA_DEFAULT_MODEL";
+          default_model_fallback = None;
+          auto_models = No_auto_models;
+          expand_auto = false;
+          family = Generic;
+        };
+      tool_policy = no_tool_http_headers;
+      telemetry_policy = telemetry_reported;
     };
     {
       canonical_name = cn_ollama;
@@ -217,6 +288,16 @@ let direct_adapters =
       default_model_id =
         (let m = Env_config_runtime.Ollama.default_model in
          if m = "" then None else Some m);
+      model_policy =
+        {
+          default_model_env = Some "OLLAMA_DEFAULT_MODEL";
+          default_model_fallback = None;
+          auto_models = No_auto_models;
+          expand_auto = false;
+          family = Generic;
+        };
+      tool_policy = no_tool_http_headers;
+      telemetry_policy = telemetry_reported;
     };
     {
       canonical_name = cn_claude;
@@ -228,6 +309,22 @@ let direct_adapters =
       default_voice = Some "Sarah";
       endpoint_url = None;
       default_model_id = Some "auto";
+      model_policy =
+        {
+          default_model_env = None;
+          default_model_fallback = Some "auto";
+          auto_models =
+            Env_csv_or_default
+              {
+                env_var = "MASC_CLAUDE_CODE_AUTO_MODELS";
+                defaults = [ "auto" ];
+                prefer_default_model_env = false;
+              };
+          expand_auto = true;
+          family = Generic;
+        };
+      tool_policy = runtime_mcp_http_headers;
+      telemetry_policy = telemetry_reported;
     };
     {
       canonical_name = cn_codex;
@@ -239,6 +336,29 @@ let direct_adapters =
       default_voice = Some "George";
       endpoint_url = None;
       default_model_id = Some "auto";
+      model_policy =
+        {
+          default_model_env = None;
+          default_model_fallback = Some "auto";
+          auto_models =
+            Env_csv_or_default
+              {
+                env_var = "MASC_CODEX_CLI_AUTO_MODELS";
+                defaults =
+                  [
+                    "gpt-5.2";
+                    "gpt-5.3-codex-spark";
+                    "gpt-5.3-codex";
+                    "gpt-5.4-mini";
+                    "gpt-5.4";
+                  ];
+                prefer_default_model_env = false;
+              };
+          expand_auto = true;
+          family = Generic;
+        };
+      tool_policy = no_tool_http_headers;
+      telemetry_policy = telemetry_reported;
     };
     {
       canonical_name = cn_gemini;
@@ -250,6 +370,30 @@ let direct_adapters =
       default_voice = Some "Roger";
       endpoint_url = None;
       default_model_id = Some "auto";
+      model_policy =
+        {
+          default_model_env = Some "GEMINI_DEFAULT_MODEL";
+          default_model_fallback = Some "gemini-3-flash-preview";
+          auto_models =
+            Env_csv_or_default
+              {
+                env_var = "MASC_GEMINI_CLI_AUTO_MODELS";
+                defaults =
+                  [
+                    "gemini-3-flash-preview";
+                    "gemini-3.1-flash-lite-preview";
+                    "gemini-2.5-flash";
+                    "gemini-2.5-flash-lite";
+                    "gemini-3.1-pro-preview";
+                    "gemini-2.5-pro";
+                  ];
+                prefer_default_model_env = true;
+              };
+          expand_auto = true;
+          family = Generic;
+        };
+      tool_policy = no_tool_http_headers;
+      telemetry_policy = telemetry_reported;
     };
     {
       canonical_name = cn_kimi;
@@ -261,6 +405,22 @@ let direct_adapters =
       default_voice = None;
       endpoint_url = None;
       default_model_id = Some "auto";
+      model_policy =
+        {
+          default_model_env = None;
+          default_model_fallback = Some "kimi-for-coding";
+          auto_models =
+            Env_csv_or_default
+              {
+                env_var = "MASC_KIMI_CLI_AUTO_MODELS";
+                defaults = [ "kimi-for-coding" ];
+                prefer_default_model_env = false;
+              };
+          expand_auto = true;
+          family = Generic;
+        };
+      tool_policy = runtime_mcp_http_headers;
+      telemetry_policy = telemetry_usage_missing;
     };
     {
       canonical_name = cn_claude_api;
@@ -272,6 +432,16 @@ let direct_adapters =
       default_voice = Some "Sarah";
       endpoint_url = Some (anthropic_api_url ());
       default_model_id = Some "auto";
+      model_policy =
+        {
+          default_model_env = Some "ANTHROPIC_DEFAULT_MODEL";
+          default_model_fallback = Some "claude-sonnet-4-6-20250514";
+          auto_models = No_auto_models;
+          expand_auto = false;
+          family = Generic;
+        };
+      tool_policy = no_tool_http_headers;
+      telemetry_policy = telemetry_reported;
     };
     {
       canonical_name = cn_codex_api;
@@ -283,6 +453,16 @@ let direct_adapters =
       default_voice = Some "George";
       endpoint_url = Some (openai_api_url ());
       default_model_id = Some "auto";
+      model_policy =
+        {
+          default_model_env = Some "OPENAI_DEFAULT_MODEL";
+          default_model_fallback = Some "gpt-4.1";
+          auto_models = No_auto_models;
+          expand_auto = false;
+          family = Generic;
+        };
+      tool_policy = no_tool_http_headers;
+      telemetry_policy = telemetry_reported;
     };
     {
       canonical_name = cn_gemini_api;
@@ -299,6 +479,16 @@ let direct_adapters =
       default_voice = Some "Roger";
       endpoint_url = None; (** Resolved dynamically for Gemini *)
       default_model_id = Some "auto";
+      model_policy =
+        {
+          default_model_env = Some "GEMINI_DEFAULT_MODEL";
+          default_model_fallback = Some "gemini-3-flash-preview";
+          auto_models = No_auto_models;
+          expand_auto = false;
+          family = Generic;
+        };
+      tool_policy = no_tool_http_headers;
+      telemetry_policy = telemetry_reported;
     };
     {
       canonical_name = cn_kimi_api;
@@ -310,6 +500,16 @@ let direct_adapters =
       default_voice = None;
       endpoint_url = Some (kimi_api_url ());
       default_model_id = Some "auto";
+      model_policy =
+        {
+          default_model_env = Some "MOONSHOT_DEFAULT_MODEL";
+          default_model_fallback = Some "kimi-k2.5";
+          auto_models = No_auto_models;
+          expand_auto = false;
+          family = Kimi_api_family;
+        };
+      tool_policy = no_tool_http_headers;
+      telemetry_policy = telemetry_reported;
     };
     {
       canonical_name = cn_glm;
@@ -321,6 +521,16 @@ let direct_adapters =
       default_voice = None;
       endpoint_url = Some (glm_api_url ());
       default_model_id = Some "auto";
+      model_policy =
+        {
+          default_model_env = Some "ZAI_DEFAULT_MODEL";
+          default_model_fallback = Some "glm-5.1";
+          auto_models = Zai_general_auto_models;
+          expand_auto = true;
+          family = Glm_general;
+        };
+      tool_policy = no_tool_http_headers;
+      telemetry_policy = telemetry_reported;
     };
     {
       canonical_name = cn_glm_coding_plan;
@@ -332,6 +542,16 @@ let direct_adapters =
       default_voice = None;
       endpoint_url = Some (glm_coding_api_url ());
       default_model_id = Some "auto";
+      model_policy =
+        {
+          default_model_env = Some "ZAI_CODING_DEFAULT_MODEL";
+          default_model_fallback = Some "glm-5.1";
+          auto_models = Zai_coding_auto_models;
+          expand_auto = true;
+          family = Glm_coding;
+        };
+      tool_policy = no_tool_http_headers;
+      telemetry_policy = telemetry_reported;
     };
     {
       canonical_name = cn_openrouter;
@@ -343,8 +563,79 @@ let direct_adapters =
       default_voice = None;
       endpoint_url = Some (openrouter_api_url ());
       default_model_id = None;
+      model_policy =
+        {
+          default_model_env = Some "OPENROUTER_DEFAULT_MODEL";
+          default_model_fallback = None;
+          auto_models = No_auto_models;
+          expand_auto = false;
+          family = Generic;
+        };
+      tool_policy = no_tool_http_headers;
+      telemetry_policy = telemetry_reported;
     };
   ]
+
+let find_direct_adapter_by_alias label =
+  let normalized = normalize_label label in
+  List.find_opt
+    (fun (adapter : adapter) ->
+      List.exists (fun alias -> normalize_label alias = normalized) adapter.aliases)
+    direct_adapters
+
+let resolve_adapter_by_cascade_prefix label =
+  let normalized = normalize_label label in
+  List.find_opt
+    (fun (adapter : adapter) ->
+      normalize_label adapter.cascade_prefix = normalized)
+    direct_adapters
+
+let resolve_model_policy_default ?getenv (policy : model_policy) =
+  match policy.default_model_env with
+  | Some env_name -> (
+      match env_value_opt ?getenv env_name with
+      | Some _ as value -> value
+      | None -> policy.default_model_fallback)
+  | None -> policy.default_model_fallback
+
+let resolve_auto_models ?getenv (policy : model_policy) =
+  match policy.auto_models with
+  | No_auto_models -> None
+  | Zai_general_auto_models -> Some (Llm_provider.Zai_catalog.glm_auto_models ())
+  | Zai_coding_auto_models -> Some (Llm_provider.Zai_catalog.glm_coding_auto_models ())
+  | Env_csv_or_default { env_var; defaults; prefer_default_model_env } -> (
+      match env_value_opt ?getenv env_var with
+      | Some raw -> (
+          match csv_items raw with
+          | [] -> Some defaults
+          | items -> Some items)
+      | None when prefer_default_model_env -> (
+          match policy.default_model_env with
+          | Some default_env -> (
+              match env_value_opt ?getenv default_env with
+              | Some model_id -> Some [ model_id ]
+              | None -> Some defaults)
+          | None -> Some defaults)
+      | None -> Some defaults)
+
+let default_model_id_for_cascade_prefix ?getenv provider_name =
+  match resolve_adapter_by_cascade_prefix provider_name with
+  | Some adapter -> resolve_model_policy_default ?getenv adapter.model_policy
+  | None -> None
+
+let auto_models_for_provider ?getenv provider_name =
+  match find_direct_adapter_by_alias provider_name with
+  | Some adapter when adapter.model_policy.expand_auto ->
+      resolve_auto_models ?getenv adapter.model_policy
+  | Some _ -> None
+  | None -> None
+
+let auto_models_for_cascade_prefix ?getenv provider_name =
+  match resolve_adapter_by_cascade_prefix provider_name with
+  | Some adapter when adapter.model_policy.expand_auto ->
+      resolve_auto_models ?getenv adapter.model_policy
+  | Some _ -> None
+  | None -> None
 
 let voice_openai_compat_adapter =
   {
@@ -417,11 +708,7 @@ let default_local_fallback_label () =
   | None -> "auto"
 
 let resolve_direct_adapter label =
-  let normalized = normalize_label label in
-  List.find_opt
-    (fun (adapter : adapter) ->
-      List.exists (fun alias -> normalize_label alias = normalized) adapter.aliases)
-    direct_adapters
+  find_direct_adapter_by_alias label
 
 let resolve_direct_canonical_name label =
   Option.map (fun (adapter : adapter) -> adapter.canonical_name) (resolve_direct_adapter label)
@@ -1027,6 +1314,67 @@ let gemini_vertex_openai_base_url ~project ~location =
   Printf.sprintf
     "https://aiplatform.googleapis.com/v1/projects/%s/locations/%s/endpoints/openapi"
     project location
+
+let starts_with ~prefix s =
+  let plen = String.length prefix in
+  String.length s >= plen && String.sub s 0 plen = prefix
+
+let is_kimi_model_id model_id =
+  let normalized = String.trim model_id |> String.lowercase_ascii in
+  starts_with ~prefix:"kimi-" normalized
+  || starts_with ~prefix:"moonshot-" normalized
+
+let is_moonshot_base_url base_url =
+  match Uri.host (Uri.of_string base_url) with
+  | Some host -> String.equal (String.lowercase_ascii host) "api.moonshot.ai"
+  | None -> false
+
+let provider_label_from_registry (cfg : Llm_provider.Provider_config.t) =
+  if cfg.kind = Llm_provider.Provider_config.OpenAI_compat
+     && (is_kimi_model_id cfg.model_id || is_moonshot_base_url cfg.base_url)
+  then
+    "kimi"
+  else
+    Llm_provider.Provider_registry.provider_name_of_config cfg
+
+let adapter_of_provider_config (cfg : Llm_provider.Provider_config.t) =
+  match cfg.kind with
+  | Llm_provider.Provider_config.Claude_code ->
+      resolve_direct_adapter cn_claude
+  | Codex_cli ->
+      resolve_direct_adapter cn_codex
+  | Gemini_cli ->
+      resolve_direct_adapter cn_gemini
+  | Kimi_cli ->
+      resolve_direct_adapter cn_kimi
+  | Anthropic ->
+      resolve_direct_adapter cn_claude_api
+  | Gemini ->
+      resolve_direct_adapter cn_gemini_api
+  | Kimi ->
+      resolve_direct_adapter cn_kimi_api
+  | Ollama ->
+      resolve_direct_adapter cn_ollama
+  | Glm
+  | OpenAI_compat ->
+      resolve_adapter_by_cascade_prefix (provider_label_from_registry cfg)
+
+let provider_label_of_config (cfg : Llm_provider.Provider_config.t) =
+  match adapter_of_provider_config cfg with
+  | Some adapter -> adapter.cascade_prefix
+  | None -> provider_label_from_registry cfg
+
+let display_provider_name_of_config (cfg : Llm_provider.Provider_config.t) =
+  display_provider_name (provider_label_of_config cfg)
+
+let model_label_of_config (cfg : Llm_provider.Provider_config.t) =
+  Printf.sprintf "%s:%s" (display_provider_name_of_config cfg) cfg.model_id
+
+let supports_runtime_mcp_http_headers_for_config
+    (cfg : Llm_provider.Provider_config.t) =
+  match adapter_of_provider_config cfg with
+  | Some adapter -> adapter.tool_policy.supports_runtime_mcp_http_headers
+  | None -> false
 
 (* ── Generic provider auth detail ─────────────────────────────── *)
 

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -22,6 +22,44 @@ type auth_mode =
       location_env : string;
     }
 
+type model_family =
+  | Generic
+  | Glm_general
+  | Glm_coding
+  | Kimi_api_family
+
+type auto_models_source =
+  | No_auto_models
+  | Env_csv_or_default of {
+      env_var : string;
+      defaults : string list;
+      prefer_default_model_env : bool;
+    }
+  | Zai_general_auto_models
+  | Zai_coding_auto_models
+
+type reporting_policy =
+  | Reported
+  | Missing_by_design
+  | Unknown
+
+type model_policy = {
+  default_model_env : string option;
+  default_model_fallback : string option;
+  auto_models : auto_models_source;
+  expand_auto : bool;
+  family : model_family;
+}
+
+type tool_policy = {
+  supports_runtime_mcp_http_headers : bool;
+}
+
+type telemetry_policy = {
+  usage_reporting : reporting_policy;
+  runtime_reporting : reporting_policy;
+}
+
 type voice_transport =
   | Voice_openai_compat
   | Voice_elevenlabs_direct
@@ -37,6 +75,9 @@ type adapter = {
   default_voice : string option;
   endpoint_url : string option;
   default_model_id : string option;
+  model_policy : model_policy;
+  tool_policy : tool_policy;
+  telemetry_policy : telemetry_policy;
 }
 
 type voice_adapter = {
@@ -142,6 +183,9 @@ val all_auth_env_keys : unit -> string list
 (** Resolve an adapter by canonical name or alias. *)
 val resolve_direct_adapter : string -> adapter option
 
+(** Resolve an adapter by cascade prefix (e.g. ["gemini_cli"], ["kimi"]). *)
+val resolve_adapter_by_cascade_prefix : string -> adapter option
+
 (** Resolve the canonical name for a provider label. *)
 val resolve_direct_canonical_name : string -> string option
 
@@ -156,6 +200,18 @@ val is_spawnable_agent : string -> bool
 
 (** Return canonical names of all spawnable adapters. *)
 val spawnable_canonical_names : unit -> string list
+
+(** Resolve the declared default model id for a cascade prefix. *)
+val default_model_id_for_cascade_prefix :
+  ?getenv:(string -> string option) -> string -> string option
+
+(** Resolve declared auto-model expansion for a provider canonical name/alias. *)
+val auto_models_for_provider :
+  ?getenv:(string -> string option) -> string -> string list option
+
+(** Resolve declared auto-model expansion for a cascade prefix. *)
+val auto_models_for_cascade_prefix :
+  ?getenv:(string -> string option) -> string -> string list option
 
 (** Returns true if the provider uses runtime discovery (e.g. live /props probe). *)
 val requires_discovery : string -> bool
@@ -288,6 +344,26 @@ val resolve_gemini_direct_auth : unit -> gemini_direct_auth
 
 (** Compute the Vertex AI OpenAI-compatible endpoint URL. *)
 val gemini_vertex_openai_base_url : project:string -> location:string -> string
+
+(** Resolve the concrete provider adapter for a provider config. *)
+val adapter_of_provider_config :
+  Llm_provider.Provider_config.t -> adapter option
+
+(** Stable provider label/cascade prefix for a provider config. *)
+val provider_label_of_config :
+  Llm_provider.Provider_config.t -> string
+
+(** User-facing provider label for a provider config. *)
+val display_provider_name_of_config :
+  Llm_provider.Provider_config.t -> string
+
+(** Build the stable "provider:model" label for a provider config. *)
+val model_label_of_config :
+  Llm_provider.Provider_config.t -> string
+
+(** Whether the resolved adapter declares runtime MCP HTTP header support. *)
+val supports_runtime_mcp_http_headers_for_config :
+  Llm_provider.Provider_config.t -> bool
 
 (** {1 Misc} *)
 

--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -52,19 +52,7 @@ let oas_capabilities_of_config (provider_cfg : Llm_provider.Provider_config.t) =
 
 let supports_runtime_mcp_http_headers
     (provider_cfg : Llm_provider.Provider_config.t) =
-  match provider_cfg.kind with
-  | Llm_provider.Provider_config.Claude_code
-  | Kimi_cli ->
-      true
-  | Codex_cli
-  | Gemini_cli
-  | Anthropic
-  | OpenAI_compat
-  | Ollama
-  | Gemini
-  | Glm
-  | Kimi ->
-      false
+  Provider_adapter.supports_runtime_mcp_http_headers_for_config provider_cfg
 
 let capabilities_of_config (provider_cfg : Llm_provider.Provider_config.t) =
   let caps = oas_capabilities_of_config provider_cfg in

--- a/test/test_cascade_model_resolve.ml
+++ b/test/test_cascade_model_resolve.ml
@@ -27,6 +27,7 @@ let with_clean_env f =
     "MASC_GEMINI_CLI_AUTO_MODELS";
     "MASC_CODEX_CLI_AUTO_MODELS";
     "MASC_CLAUDE_CODE_AUTO_MODELS";
+    "MASC_KIMI_CLI_AUTO_MODELS";
   ];
   f ()
 
@@ -123,11 +124,25 @@ let test_codex_and_claude_cli_auto_models_env_override () =
     check (list string) "claude operator rotation"
       [ "sonnet"; "opus" ] claude)
 
+let test_kimi_cli_auto_model_policy () =
+  with_clean_env (fun () ->
+    check string "kimi_cli:auto resolves to concrete CLI default"
+      "kimi-for-coding"
+      (R.resolve_auto_model_id "kimi_cli" "auto");
+    check (list string) "kimi_cli:auto expands to declared default"
+      [ "kimi-for-coding" ]
+      (R.kimi_cli_auto_models ());
+    Unix.putenv "MASC_KIMI_CLI_AUTO_MODELS" "kimi-a,kimi-b";
+    let models = R.kimi_cli_auto_models () in
+    Unix.putenv "MASC_KIMI_CLI_AUTO_MODELS" "";
+    check (list string) "kimi cli operator rotation"
+      [ "kimi-a"; "kimi-b" ] models)
+
 let test_expand_auto_models_includes_cli_auto_specs () =
   with_clean_env (fun () ->
     let expanded =
       C.expand_auto_models
-        [ "gemini_cli:auto"; "codex_cli:auto"; "claude_code:auto" ]
+        [ "gemini_cli:auto"; "codex_cli:auto"; "claude_code:auto"; "kimi_cli:auto" ]
     in
     check (list string) "CLI auto specs expand in-place"
       [
@@ -143,6 +158,7 @@ let test_expand_auto_models_includes_cli_auto_specs () =
         "codex_cli:gpt-5.4-mini";
         "codex_cli:gpt-5.4";
         "claude_code:auto";
+        "kimi_cli:kimi-for-coding";
       ]
       expanded)
 
@@ -243,6 +259,8 @@ let () =
         `Quick test_gemini_cli_auto_models_env_override;
       test_case "codex/claude cli auto env list override"
         `Quick test_codex_and_claude_cli_auto_models_env_override;
+      test_case "kimi_cli:auto policy"
+        `Quick test_kimi_cli_auto_model_policy;
       test_case "expand_auto_models covers CLI auto"
         `Quick test_expand_auto_models_includes_cli_auto_specs;
       test_case "execution expansion matches auto expansion"

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -95,6 +95,22 @@ let error_entry ~cascade_name ~ts ?provider () =
     ]);
   ]
 
+let success_entry_without_usage ~model ~ts ?provider () =
+  let extra_fields =
+    match provider with
+    | Some value -> [ ("provider", `String value) ]
+    | None -> []
+  in
+  `Assoc [
+    ("ts_unix", `Float ts);
+    ("tool_call_count", `Int 0);
+    ("tools_used", `List []);
+    ("telemetry", `Assoc ([
+      ("model_used", `String model);
+      ("fallback_applied", `Bool false);
+    ] @ extra_fields));
+  ]
+
 (* ── Tests ───────────────────────────────────────── *)
 
 let test_empty_dir () =
@@ -128,13 +144,18 @@ let test_single_model_success () =
     check int "entry_count" 2 s.entry_count;
     check int "success_count" 2 s.success_count;
     check int "error_count" 0 s.error_count;
-    check int "total_input_tokens" 350 s.total_input_tokens;
-    check int "total_output_tokens" 180 s.total_output_tokens;
+    check (option int) "total_input_tokens" (Some 350) s.total_input_tokens;
+    check (option int) "total_output_tokens" (Some 180) s.total_output_tokens;
+    check int "usage samples" 2 s.usage_sample_count;
+    check int "telemetry samples" 2 s.telemetry_sample_count;
     check int "total_tool_calls" 3 s.total_tool_calls;
-    check bool "cost > 0" true (s.total_cost_usd > 0.0);
+    check bool "cost > 0" true
+      (Option.value ~default:0.0 s.total_cost_usd > 0.0);
     check bool "avg_tool_calls > 0" true (s.avg_tool_calls_per_turn > 0.0);
-    check bool "latency > 0" true (s.avg_latency_ms > 0.0);
-    check bool "tok/s > 0" true (s.avg_tok_per_sec > 0.0))
+    check bool "latency > 0" true
+      (Option.value ~default:0.0 s.avg_latency_ms > 0.0);
+    check bool "tok/s > 0" true
+      (Option.value ~default:0.0 s.avg_tok_per_sec > 0.0))
 
 let test_error_turns_counted () =
   let base = test_dir () in
@@ -155,7 +176,10 @@ let test_error_turns_counted () =
     let em = Option.get error_model in
     check (option string) "error provider unresolved" None em.provider;
     check int "error_count" 1 em.error_count;
-    check int "success_count" 0 em.success_count)
+    check int "success_count" 0 em.success_count;
+    check (option (float 0.001)) "error model latency unknown" None em.avg_latency_ms;
+    check (option int) "error model input unknown" None em.total_input_tokens;
+    check (option (float 0.001)) "error model cost unknown" None em.total_cost_usd)
 
 let test_multi_model () =
   let base = test_dir () in
@@ -245,6 +269,8 @@ let test_json_roundtrip () =
     check bool "provider unresolved -> null" true
       (match m |> member "provider" with `Null -> true | _ -> false);
     check int "success_count" 1 (m |> member "success_count" |> to_int);
+    check int "usage_sample_count" 1
+      (m |> member "usage_sample_count" |> to_int);
     check bool "total_cost_usd = 0.05" true
       (Float.abs (m |> member "total_cost_usd" |> to_float) -. 0.05 < 0.001);
     check bool "has top_tools list" true
@@ -297,6 +323,37 @@ let test_prompt_tps_and_peak_memory_aggregates () =
       (recent |> member "prompt_tok_per_sec" |> to_float);
     check (float 0.001) "recent peak mem json" 20.25
       (recent |> member "peak_memory_gb" |> to_float))
+
+let test_missing_usage_serializes_unknowns () =
+  let base = test_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+    let path = make_keeper_dir base "missing_usage" in
+    let ts = now_unix () in
+    write_decisions path [
+      success_entry_without_usage ~model:"kimi-for-coding" ~ts:(ts -. 5.0)
+        ~provider:"kimi_cli" ();
+    ];
+    let agg = M.compute ~base_path:base ~window_minutes:60 in
+    let s = List.hd agg.models in
+    check int "success_count" 1 s.success_count;
+    check int "usage samples" 0 s.usage_sample_count;
+    check int "telemetry samples" 0 s.telemetry_sample_count;
+    check (option int) "input unknown" None s.total_input_tokens;
+    check (option (float 0.001)) "latency unknown" None s.avg_latency_ms;
+    check (option (float 0.001)) "cost unknown" None s.total_cost_usd;
+    let recent = List.hd s.recent_entries in
+    check (option int) "recent input unknown" None recent.re_input_tokens;
+    check (option (float 0.001)) "recent latency unknown" None recent.re_latency_ms;
+    let json = M.to_json agg in
+    let open Yojson.Safe.Util in
+    let m = json |> member "models" |> to_list |> List.hd in
+    check bool "json input null" true
+      (match m |> member "total_input_tokens" with `Null -> true | _ -> false);
+    check bool "json latency null" true
+      (match m |> member "avg_latency_ms" with `Null -> true | _ -> false);
+    let recent_json = m |> member "recent_entries" |> to_list |> List.hd in
+    check bool "recent json input null" true
+      (match recent_json |> member "input_tokens" with `Null -> true | _ -> false))
 
 (* ── thinking_fraction tests ─────────────────────── *)
 
@@ -454,10 +511,11 @@ let test_buckets_cache_hit_ratio_zero_denom () =
     check int "one model" 1 (List.length result);
     let m = List.hd result in
     let b = List.hd m.mb_buckets in
+    check bool "cache_hit_ratio present" true (Option.is_some b.b_cache_hit_ratio);
     check bool "cache_hit_ratio not NaN" true
-      (not (Float.is_nan b.b_cache_hit_ratio));
-    check (float 0.001) "cache_hit_ratio = 0.0 when both tokens=0"
-      0.0 b.b_cache_hit_ratio)
+      (not (Float.is_nan (Option.value ~default:0.0 b.b_cache_hit_ratio)));
+    check (option (float 0.001)) "cache_hit_ratio = 0.0 when both tokens=0"
+      (Some 0.0) b.b_cache_hit_ratio)
 
 let test_buckets_with_compute () =
   let dir = test_dir () in
@@ -489,6 +547,7 @@ let () =
       test_case "top tools per model" `Quick test_top_tools_per_model;
       test_case "recent entries capped" `Quick test_recent_entries;
       test_case "prompt tps and peak memory aggregates" `Quick test_prompt_tps_and_peak_memory_aggregates;
+      test_case "missing usage serializes unknowns" `Quick test_missing_usage_serializes_unknowns;
       test_case "json roundtrip" `Quick test_json_roundtrip;
     ];
     "thinking_fraction", [

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -280,6 +280,60 @@ let test_stt_request_mcp_rejected () =
   | Ok _ -> fail "expected Error for voice_mcp endpoint"
   | Error _ -> ()
 
+let test_auto_models_use_declared_policy () =
+  with_env "MASC_KIMI_CLI_AUTO_MODELS" None (fun () ->
+      check (option (list string)) "kimi cli declared default"
+        (Some [ "kimi-for-coding" ])
+        (Adapter.auto_models_for_cascade_prefix "kimi_cli");
+      with_env "MASC_GEMINI_CLI_AUTO_MODELS" None (fun () ->
+          with_env "GEMINI_DEFAULT_MODEL" (Some "gemini-2.5-flash") (fun () ->
+              check (option (list string)) "gemini cli prefers explicit default model env"
+                (Some [ "gemini-2.5-flash" ])
+                (Adapter.auto_models_for_cascade_prefix "gemini_cli"))))
+
+let test_runtime_mcp_header_support_uses_declared_policy () =
+  let kimi_cli_cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.Kimi_cli
+      ~model_id:"kimi-for-coding"
+      ~base_url:""
+      ()
+  in
+  let codex_cli_cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.Codex_cli
+      ~model_id:"gpt-5.4"
+      ~base_url:""
+      ()
+  in
+  check bool "kimi cli supports runtime MCP headers" true
+    (Adapter.supports_runtime_mcp_http_headers_for_config kimi_cli_cfg);
+  check bool "codex cli does not support runtime MCP headers" false
+    (Adapter.supports_runtime_mcp_http_headers_for_config codex_cli_cfg)
+
+let test_provider_label_of_config_preserves_cli_vs_api_identity () =
+  let kimi_api_cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"kimi-k2.5"
+      ~base_url:"https://api.moonshot.ai/v1"
+      ~request_path:"/chat/completions"
+      ()
+  in
+  let kimi_cli_cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.Kimi_cli
+      ~model_id:"kimi-for-coding"
+      ~base_url:""
+      ()
+  in
+  check string "kimi api label" "kimi"
+    (Adapter.provider_label_of_config kimi_api_cfg);
+  check string "kimi cli label" "kimi_cli"
+    (Adapter.provider_label_of_config kimi_cli_cfg);
+  check string "kimi cli model label" "kimi_cli:kimi-for-coding"
+    (Adapter.model_label_of_config kimi_cli_cfg)
+
 let () =
   run "Provider Adapter"
     [
@@ -308,6 +362,12 @@ let () =
             test_default_model_provider_prefix_result;
           test_case "default override label" `Quick
             test_default_model_override_label_result;
+          test_case "declared auto model policy" `Quick
+            test_auto_models_use_declared_policy;
+          test_case "declared runtime MCP header policy" `Quick
+            test_runtime_mcp_header_support_uses_declared_policy;
+          test_case "provider label keeps cli vs api identity" `Quick
+            test_provider_label_of_config_preserves_cli_vs_api_identity;
           test_case "resolve voice aliases" `Quick test_resolve_voice_aliases;
           test_case "voice auth env resolution" `Quick
             test_voice_auth_env_resolution;


### PR DESCRIPTION
## Summary
- move provider auto-model/runtime capability wiring into declarative adapter policy metadata
- preserve missing runtime telemetry as null with explicit usage/telemetry sample coverage instead of flattening to zero
- update dashboard decoding/rendering and regression tests for nullable metrics and CLI auto-model expansion

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-declarative-provider-policy @default
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-declarative-provider-policy ./test/test_provider_adapter.exe
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-declarative-provider-policy ./test/test_cascade_model_resolve.exe
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-declarative-provider-policy ./test/test_model_inference_metrics.exe
- pnpm install --frozen-lockfile
- pnpm typecheck
- pnpm lint
- ./node_modules/.bin/vitest run src/api/dashboard.test.ts src/components/runtime-monitor.test.ts --no-file-parallelism --maxWorkers=1