### PR TITLE
[codex] stabilize keeper reactive continuity

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -31,6 +31,17 @@ let max_history_read_lines = 200
 let set_bus bus = Keeper_event_bus.set bus
 let get_bus () = Keeper_event_bus.get ()
 
+let effective_keepalive_meta
+    ~base_path
+    ~(fallback : keeper_meta)
+    ~(disk_meta_opt : keeper_meta option) : keeper_meta =
+  match disk_meta_opt with
+  | Some latest -> latest
+  | None -> (
+      match Keeper_registry.get ~base_path fallback.name with
+      | Some entry -> entry.meta
+      | None -> fallback)
+
 (* Global turn slot cap. Safety ceiling for ALL keeper turns (autonomous
    + reactive). Default 12 = headroom for up to 12 keepers. *)
 let keeper_turn_throttle_limit =
@@ -466,20 +477,19 @@ let wakeup_relevant_keeper_for_board_signal
     |> List.filter_map (fun name ->
       match read_meta config name with
       | Ok (Some meta) ->
-        let matched =
-          Keeper_world_observation.board_signal_match
+        let wake_reason =
+          Keeper_world_observation.board_signal_wake_reason
             ~continuity_summary:meta.continuity_summary
             ~meta
             ~signal
         in
-        Some (meta, matched)
+        Some (meta, wake_reason)
       | _ -> None)
   in
   let explicit =
     candidates
     |> List.filter
-         (fun (_meta, (matched : Keeper_world_observation.board_signal_match)) ->
-            matched.explicit_mention)
+         (fun (_meta, wake_reason) -> wake_reason = Some "explicit_mention")
   in
   let wake_meta (meta : keeper_meta) reason =
     if
@@ -497,10 +507,13 @@ let wakeup_relevant_keeper_for_board_signal
   in
   match explicit with
   | _ :: _ ->
-    explicit |> List.iter (fun (meta, _matched) -> wake_meta meta "explicit_mention")
+    explicit |> List.iter (fun (meta, _wake_reason) -> wake_meta meta "explicit_mention")
   | [] ->
     candidates
-    |> List.iter (fun (meta, _matched) -> wake_meta meta "board_activity")
+    |> List.iter (fun (meta, wake_reason) ->
+         match wake_reason with
+         | Some reason -> wake_meta meta reason
+         | None -> ())
 ;;
 
 let max_consecutive_heartbeat_failures () =
@@ -1489,17 +1502,30 @@ let run_heartbeat_loop
       Eio.Fiber.yield ();
       (* Phase 0: timing markers *)
       let t_presence_start = Time_compat.now () in
-      let meta_current =
+      let disk_meta_opt, new_meta_mtime =
         match read_meta_if_changed ctx.config m.name ~last_mtime:!last_meta_mtime with
         | Some (latest, new_mtime) ->
-          last_meta_mtime := new_mtime;
-          latest
-        | None -> m
+          Some latest, Some new_mtime
+        | None -> None, None
+      in
+      Option.iter (fun new_mtime -> last_meta_mtime := new_mtime) new_meta_mtime;
+      let meta_current =
+        effective_keepalive_meta
+          ~base_path:ctx.config.base_path
+          ~fallback:m
+          ~disk_meta_opt
       in
       (* Sync disk meta to registry so dashboard reads live values.  #5364.
-         Physical inequality: read_meta returns a fresh record when the JSON
-         file changed; same pointer means no disk change occurred. *)
-      if meta_current != m then
+         When disk meta is unchanged we still prefer the registry copy because
+         runtime writes update it via the write_meta hook. This keeps
+         continuity/runtime fields fresh even if disk mtime does not advance
+         between rapid writes inside a single loop window. *)
+      let registry_meta =
+        match Keeper_registry.get ~base_path:ctx.config.base_path meta_current.name with
+        | Some entry -> entry.meta
+        | None -> m
+      in
+      if meta_current != registry_meta then
         Keeper_registry.update_meta
           ~base_path:ctx.config.base_path meta_current.name meta_current;
       if
@@ -1649,6 +1675,58 @@ let with_keeper_entry_by_identity ~identity ~on_missing f =
      | None -> on_missing ())
 ;;
 
+let persist_directive_meta_update
+    (entry : Keeper_registry.registry_entry)
+    ~(updated_meta : keeper_meta) : unit =
+  let keeper_filename = entry.name ^ ".json" in
+  let masc_root = Coord_utils.masc_dir_from_base_path ~base_path:entry.base_path in
+  let default_path = Filename.concat (Filename.concat masc_root "keepers") keeper_filename in
+  let persisted_path =
+    if Fs_compat.file_exists default_path then
+      default_path
+    else
+      let clusters_dir = Filename.concat masc_root "clusters" in
+      let cluster_paths =
+        match Safe_ops.list_dir_safe clusters_dir with
+        | Ok names ->
+            names
+            |> List.map (fun cluster_name ->
+                   Filename.concat
+                     (Filename.concat (Filename.concat clusters_dir cluster_name) "keepers")
+                     keeper_filename)
+            |> List.filter Fs_compat.file_exists
+        | Error _ -> []
+      in
+      match cluster_paths with
+      | [] -> default_path
+      | [ path ] -> path
+      | paths ->
+          let by_mtime_desc a b =
+            let a_mtime = Option.value ~default:0.0 (Fs_compat.file_mtime a) in
+            let b_mtime = Option.value ~default:0.0 (Fs_compat.file_mtime b) in
+            Float.compare b_mtime a_mtime
+          in
+          List.sort by_mtime_desc paths |> List.hd
+  in
+  try
+    Keeper_fs.save_json_atomic persisted_path (meta_to_json updated_meta);
+    Keeper_registry.update_meta
+      ~base_path:entry.base_path
+      entry.name
+      updated_meta
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      let err = Printexc.to_string exn in
+      Log.Keeper.warn
+        "directive meta persist failed for %s: %s"
+        entry.name
+        err;
+      Keeper_registry.update_meta
+        ~base_path:entry.base_path
+        entry.name
+        updated_meta
+
 let set_keeper_paused_state ~agent_name paused =
   with_keeper_entry_by_identity
     ~identity:agent_name
@@ -1656,10 +1734,14 @@ let set_keeper_paused_state ~agent_name paused =
       let action = if paused then "pause" else "resume" in
       Log.Keeper.warn "directive %s: agent %s not in registry" action agent_name)
     (fun entry ->
-       Keeper_registry.update_meta
-         ~base_path:entry.base_path
-         entry.name
-         { entry.meta with paused };
+       let updated_meta =
+         {
+           entry.meta with
+           paused;
+           updated_at = now_iso ();
+         }
+       in
+       persist_directive_meta_update entry ~updated_meta;
        ignore
          (Keeper_registry.dispatch_event
             ~base_path:entry.base_path entry.name
@@ -1683,10 +1765,14 @@ let assign_keeper_task_from_directive ~agent_name ~task_id =
     ~on_missing:(fun () ->
       Log.Keeper.warn "directive claim: agent %s not in registry" agent_name)
     (fun entry ->
-       Keeper_registry.update_meta
-         ~base_path:entry.base_path
-         entry.name
-         { entry.meta with current_task_id = Some task_id };
+       let updated_meta =
+         {
+           entry.meta with
+           current_task_id = Some task_id;
+           updated_at = now_iso ();
+         }
+       in
+       persist_directive_meta_update entry ~updated_meta;
        wakeup_keeper ~base_path:entry.base_path entry.name)
 ;;
 

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -74,6 +74,15 @@ val with_keeper_turn_slot_for_test :
   (semaphore_wait_ms:int -> 'a) ->
   'a
 
+(** Keepalive loop meta selection. Disk wins when it changed; otherwise
+    fall back to the latest registry snapshot instead of the original boot
+    meta so continuity/runtime fields do not regress across turns. *)
+val effective_keepalive_meta :
+  base_path:string ->
+  fallback:keeper_meta ->
+  disk_meta_opt:keeper_meta option ->
+  keeper_meta
+
 val wakeup_relevant_keeper_for_board_signal :
   config:Coord.config -> Board_dispatch.keeper_board_signal -> unit
 

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -129,8 +129,7 @@ type board_signal_match = {
 }
 
 let scope_message_feed_enabled (meta : keeper_meta) : bool =
-  let _ = meta in
-  true
+  meta.room_signal_prompt_enabled
 
 let message_feed_targets (meta : keeper_meta) =
   if meta.mention_targets <> [] then meta.mention_targets else [ meta.name ]
@@ -469,6 +468,27 @@ let check_self_comment_status ~self_tokens ~(post_id : string)
             ( List.length external_after,
               Board.Agent_id.to_string latest.author,
               short_preview ~max_len:60 latest.content )
+
+let board_signal_wake_reason
+    ~continuity_summary
+    ~(meta : keeper_meta)
+    ~(signal : Board_dispatch.keeper_board_signal) : string option =
+  let matched = board_signal_match ~continuity_summary ~meta ~signal in
+  if matched.explicit_mention then
+    Some "explicit_mention"
+  else if scope_message_feed_enabled meta then
+    Some "board_activity"
+  else
+    let self_tokens =
+      [ meta.name; meta.agent_name ]
+      |> List.map (fun value -> String.lowercase_ascii (String.trim value))
+    in
+    match signal.kind with
+    | Board_dispatch.Board_comment_added ->
+        (match check_self_comment_status ~self_tokens ~post_id:signal.post_id with
+         | `New_external _ -> Some "thread_reply_after_self_comment"
+         | `Never | `No_new_external -> None)
+    | Board_dispatch.Board_post_created -> None
 
 (** Collect recent board activity using cursor-based tracking.
     Cursor state lives in Keeper_registry as [(updated_at, post_id)].

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -178,6 +178,12 @@ val board_signal_match :
   signal:Board_dispatch.keeper_board_signal ->
   board_signal_match
 
+val board_signal_wake_reason :
+  continuity_summary:string ->
+  meta:Keeper_types.keeper_meta ->
+  signal:Board_dispatch.keeper_board_signal ->
+  string option
+
 (** Read the best available continuity summary for a keeper.
     Recovery order is progress log -> checkpoint snapshot -> meta summary. *)
 val read_continuity_summary :

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -9,6 +9,32 @@ module Json = Yojson.Safe.Util
 
 let bp = "/tmp/test"
 
+let with_env name value f =
+  let old = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match old with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then (
+      Array.iter (fun name -> rm_rf (Filename.concat path name)) (Sys.readdir path);
+      Unix.rmdir path)
+    else
+      Unix.unlink path
+
+let temp_base_path label =
+  let base =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-%s-%06x" label (Random.bits ()))
+  in
+  Unix.mkdir base 0o755;
+  base
+
 let make_meta name =
   let json = `Assoc [
     ("name", `String name);
@@ -696,6 +722,48 @@ let test_directive_claim () =
      | None -> fail "expected current_task_id set")
   | None -> fail "expected dc1"
 
+let test_directive_pause_persists_meta () =
+  R.clear ();
+  let base_dir = temp_base_path "directive-pause-persist" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_dir)
+    (fun () ->
+      let config = make_test_config base_dir in
+      let meta = make_meta "dpersist" in
+      (match Keeper_types.write_meta ~force:true config meta with
+       | Ok () -> ()
+       | Error err -> fail ("write_meta failed: " ^ err));
+      ignore (R.register ~base_path:base_dir "dpersist" meta);
+      KK.process_directive ~agent_name:"agent-dpersist" "pause";
+      match Keeper_types.read_meta config "dpersist" with
+      | Ok (Some persisted) ->
+          check bool "paused persisted" true persisted.paused
+      | Ok None -> fail "expected persisted meta"
+      | Error err -> fail ("read_meta failed: " ^ err))
+
+let test_directive_claim_persists_meta () =
+  R.clear ();
+  let base_dir = temp_base_path "directive-claim-persist" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_dir)
+    (fun () ->
+      let config = make_test_config base_dir in
+      let meta = make_meta "dclaimpersist" in
+      (match Keeper_types.write_meta ~force:true config meta with
+       | Ok () -> ()
+       | Error err -> fail ("write_meta failed: " ^ err));
+      ignore (R.register ~base_path:base_dir "dclaimpersist" meta);
+      KK.process_directive ~agent_name:"agent-dclaimpersist" "claim:T-77";
+      match Keeper_types.read_meta config "dclaimpersist" with
+      | Ok (Some persisted) ->
+          (match persisted.current_task_id with
+           | Some task_id ->
+               check string "claimed task persisted" "T-77"
+                 (Masc_mcp.Keeper_id.Task_id.to_string task_id)
+           | None -> fail "expected persisted current_task_id")
+      | Ok None -> fail "expected persisted meta"
+      | Error err -> fail ("read_meta failed: " ^ err))
+
 let test_directive_unknown_no_crash () =
   R.clear ();
   let _entry = R.register ~base_path:bp "du1" (make_meta "du1") in
@@ -750,6 +818,221 @@ let test_wakeup_all_scoped_to_base_path () =
   check bool "base path A all wakeup set" true (Atomic.get entry_a.fiber_wakeup);
   check bool "base path B all wakeup stays unset" false
     (Atomic.get entry_b.fiber_wakeup)
+
+let test_board_signal_wakeup_ignores_unmatched_posts_without_opt_in () =
+  R.clear ();
+  let base_dir = temp_base_path "board-wakeup-ignore" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Board.reset_global_for_test ();
+      Masc_mcp.Board_dispatch.reset_for_test ();
+      rm_rf base_dir)
+    (fun () ->
+      with_env "MASC_BASE_PATH" base_dir (fun () ->
+        Masc_mcp.Board.reset_global_for_test ();
+        Masc_mcp.Board_dispatch.reset_for_test ();
+        Masc_mcp.Board_dispatch.init_jsonl ();
+        let config = make_test_config base_dir in
+        let alpha = make_meta "alpha" in
+        let beta = make_meta "beta" in
+        ignore (Keeper_types.write_meta ~force:true config alpha);
+        ignore (Keeper_types.write_meta ~force:true config beta);
+        let entry_a = R.register ~base_path:base_dir "alpha" alpha in
+        let entry_b = R.register ~base_path:base_dir "beta" beta in
+        let post =
+          match
+            Masc_mcp.Board_dispatch.create_post ~author:"alice"
+              ~title:"General update"
+              ~content:"No direct mention here"
+              ~post_kind:Masc_mcp.Board.Human_post ()
+          with
+          | Ok post -> post
+          | Error err -> fail (Masc_mcp.Board.show_board_error err)
+        in
+        let signal : Masc_mcp.Board_dispatch.keeper_board_signal =
+          {
+            kind = Masc_mcp.Board_dispatch.Board_post_created;
+            post_id = Masc_mcp.Board.Post_id.to_string post.id;
+            author = "alice";
+            title = post.title;
+            content = post.content;
+            hearth = post.hearth;
+          }
+        in
+        KK.wakeup_relevant_keeper_for_board_signal ~config signal;
+        check bool "alpha not woken" false (Atomic.get entry_a.fiber_wakeup);
+        check bool "beta not woken" false (Atomic.get entry_b.fiber_wakeup)))
+
+let test_board_signal_wakeup_only_wakes_opted_in_scope_keeper () =
+  R.clear ();
+  let base_dir = temp_base_path "board-wakeup-optin" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Board.reset_global_for_test ();
+      Masc_mcp.Board_dispatch.reset_for_test ();
+      rm_rf base_dir)
+    (fun () ->
+      with_env "MASC_BASE_PATH" base_dir (fun () ->
+        Masc_mcp.Board.reset_global_for_test ();
+        Masc_mcp.Board_dispatch.reset_for_test ();
+        Masc_mcp.Board_dispatch.init_jsonl ();
+        let config = make_test_config base_dir in
+        let opted_in_base = make_meta "opted-in" in
+        let opted_in = { opted_in_base with room_signal_prompt_enabled = true } in
+        let defaulted = make_meta "defaulted" in
+        ignore (Keeper_types.write_meta ~force:true config opted_in);
+        ignore (Keeper_types.write_meta ~force:true config defaulted);
+        let entry_a = R.register ~base_path:base_dir "opted-in" opted_in in
+        let entry_b = R.register ~base_path:base_dir "defaulted" defaulted in
+        let post =
+          match
+            Masc_mcp.Board_dispatch.create_post ~author:"alice"
+              ~title:"General update"
+              ~content:"No direct mention here"
+              ~post_kind:Masc_mcp.Board.Human_post ()
+          with
+          | Ok post -> post
+          | Error err -> fail (Masc_mcp.Board.show_board_error err)
+        in
+        let signal : Masc_mcp.Board_dispatch.keeper_board_signal =
+          {
+            kind = Masc_mcp.Board_dispatch.Board_post_created;
+            post_id = Masc_mcp.Board.Post_id.to_string post.id;
+            author = "alice";
+            title = post.title;
+            content = post.content;
+            hearth = post.hearth;
+          }
+        in
+        KK.wakeup_relevant_keeper_for_board_signal ~config signal;
+        check bool "opted-in keeper woken" true (Atomic.get entry_a.fiber_wakeup);
+        check bool "defaulted keeper stays asleep" false
+          (Atomic.get entry_b.fiber_wakeup)))
+
+let test_board_signal_wakeup_keeps_thread_reply_after_self_comment () =
+  R.clear ();
+  let base_dir = temp_base_path "board-wakeup-followup" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Board.reset_global_for_test ();
+      Masc_mcp.Board_dispatch.reset_for_test ();
+      rm_rf base_dir)
+    (fun () ->
+      with_env "MASC_BASE_PATH" base_dir (fun () ->
+        Masc_mcp.Board.reset_global_for_test ();
+        Masc_mcp.Board_dispatch.reset_for_test ();
+        Masc_mcp.Board_dispatch.init_jsonl ();
+        let config = make_test_config base_dir in
+        let participant = make_meta "participant" in
+        let bystander = make_meta "bystander" in
+        ignore (Keeper_types.write_meta ~force:true config participant);
+        ignore (Keeper_types.write_meta ~force:true config bystander);
+        let entry_a = R.register ~base_path:base_dir "participant" participant in
+        let entry_b = R.register ~base_path:base_dir "bystander" bystander in
+        let post =
+          match
+            Masc_mcp.Board_dispatch.create_post ~author:"alice"
+              ~title:"General update"
+              ~content:"No direct mention here"
+              ~post_kind:Masc_mcp.Board.Human_post ()
+          with
+          | Ok post -> post
+          | Error err -> fail (Masc_mcp.Board.show_board_error err)
+        in
+        let post_id = Masc_mcp.Board.Post_id.to_string post.id in
+        (match
+           Masc_mcp.Board_dispatch.add_comment ~post_id ~author:"participant"
+             ~content:"I am following this thread."
+             ()
+         with
+        | Ok _ -> ()
+        | Error err -> fail (Masc_mcp.Board.show_board_error err));
+        Unix.sleepf 0.02;
+        (match
+           Masc_mcp.Board_dispatch.add_comment ~post_id ~author:"bob"
+             ~content:"There is a new question for you."
+             ()
+         with
+        | Ok _ -> ()
+        | Error err -> fail (Masc_mcp.Board.show_board_error err));
+        let signal : Masc_mcp.Board_dispatch.keeper_board_signal =
+          {
+            kind = Masc_mcp.Board_dispatch.Board_comment_added;
+            post_id;
+            author = "bob";
+            title = post.title;
+            content = "There is a new question for you.";
+            hearth = post.hearth;
+          }
+        in
+        KK.wakeup_relevant_keeper_for_board_signal ~config signal;
+        check bool "participant keeper woken" true
+          (Atomic.get entry_a.fiber_wakeup);
+        check bool "bystander keeper stays asleep" false
+          (Atomic.get entry_b.fiber_wakeup)))
+
+let test_effective_keepalive_meta_prefers_registry_when_disk_unchanged () =
+  R.clear ();
+  let stale = make_meta "loop-meta" in
+  let fresh =
+    {
+      stale with
+      continuity_summary = "fresh continuity";
+      runtime =
+        {
+          stale.runtime with
+          usage = { stale.runtime.usage with total_turns = 9 };
+        };
+    }
+  in
+  ignore (R.register ~base_path:bp "loop-meta" fresh);
+  let chosen =
+    KK.effective_keepalive_meta
+      ~base_path:bp
+      ~fallback:stale
+      ~disk_meta_opt:None
+  in
+  check string "continuity comes from registry" "fresh continuity"
+    chosen.continuity_summary;
+  check int "turn count comes from registry" 9
+    chosen.runtime.usage.total_turns
+
+let test_effective_keepalive_meta_prefers_disk_when_present () =
+  R.clear ();
+  let stale = make_meta "loop-meta-disk" in
+  let registry_meta =
+    {
+      stale with
+      continuity_summary = "registry continuity";
+      runtime =
+        {
+          stale.runtime with
+          usage = { stale.runtime.usage with total_turns = 3 };
+        };
+    }
+  in
+  let disk_meta =
+    {
+      stale with
+      continuity_summary = "disk continuity";
+      runtime =
+        {
+          stale.runtime with
+          usage = { stale.runtime.usage with total_turns = 11 };
+        };
+    }
+  in
+  ignore (R.register ~base_path:bp "loop-meta-disk" registry_meta);
+  let chosen =
+    KK.effective_keepalive_meta
+      ~base_path:bp
+      ~fallback:stale
+      ~disk_meta_opt:(Some disk_meta)
+  in
+  check string "continuity comes from disk" "disk continuity"
+    chosen.continuity_summary;
+  check int "turn count comes from disk" 11
+    chosen.runtime.usage.total_turns
 
 let () =
   run "Keeper_registry"
@@ -825,6 +1108,8 @@ let () =
           eio_test "resume directive" test_directive_resume;
           eio_test "keeper-name directive alias" test_directive_keeper_name_alias;
           eio_test "claim directive" test_directive_claim;
+          eio_test "pause directive persists meta" test_directive_pause_persists_meta;
+          eio_test "claim directive persists meta" test_directive_claim_persists_meta;
           eio_test "unknown directive no crash" test_directive_unknown_no_crash;
           eio_test "nonexistent agent no crash" test_directive_nonexistent_agent;
           eio_test "stop keepalive scoped to base_path"
@@ -833,5 +1118,15 @@ let () =
             test_wakeup_keeper_scoped_to_base_path;
           eio_test "wakeup all scoped to base_path"
             test_wakeup_all_scoped_to_base_path;
+          eio_test "board wakeup ignores unmatched posts without opt-in"
+            test_board_signal_wakeup_ignores_unmatched_posts_without_opt_in;
+          eio_test "board wakeup only wakes opted-in scope keeper"
+            test_board_signal_wakeup_only_wakes_opted_in_scope_keeper;
+          eio_test "board wakeup keeps thread reply after self comment"
+            test_board_signal_wakeup_keeps_thread_reply_after_self_comment;
+          eio_test "effective keepalive meta prefers registry when disk unchanged"
+            test_effective_keepalive_meta_prefers_registry_when_disk_unchanged;
+          eio_test "effective keepalive meta prefers disk when present"
+            test_effective_keepalive_meta_prefers_disk_when_present;
         ] );
     ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -275,7 +275,38 @@ let test_collect_board_events_keeps_non_mentions_as_followup_signal () =
           ~continuity_summary:"goal test-keeper"
           ~meta:minimal_meta
       in
-      check int "keeps non-mention events" 1 (List.length events);
+      check int "default keepers ignore unmatched non-mention events" 0
+        (List.length events);
+      check int "new count includes non-mention" 1 new_count;
+      check int "mention count stays zero" 0 mention_count)
+
+let test_collect_board_events_keeps_non_mentions_for_room_signal_keepers () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      Unix.putenv "MASC_BASE_PATH" base_dir;
+      Masc_mcp.Board.reset_global_for_test ();
+      Masc_mcp.Board_dispatch.reset_for_test ();
+      Masc_mcp.Board_dispatch.init_jsonl ();
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+      (match
+         Masc_mcp.Board_dispatch.create_post ~author:"alice"
+           ~title:"General update" ~content:"No direct mention here"
+           ~post_kind:Masc_mcp.Board.Human_post ()
+       with
+      | Ok _ -> ()
+      | Error e -> fail ("create_post failed: " ^ Masc_mcp.Board.show_board_error e));
+      let events, new_count, mention_count =
+        WO.collect_board_events ~base_path:base_dir
+          ~continuity_summary:"goal test-keeper"
+          ~meta:room_signal_meta
+      in
+      check int "room-signal keepers keep non-mention events" 1
+        (List.length events);
       check int "new count includes non-mention" 1 new_count;
       check int "mention count stays zero" 0 mention_count;
       check bool "event is not explicit mention" false
@@ -333,6 +364,46 @@ let test_collect_board_events_keeps_external_replies_after_self_comment () =
           check string "latest external author" "bob"
             (Option.value ~default:"" event.latest_external_author)
       | _ -> fail "expected one follow-up board event")
+
+let test_observe_ignores_scope_messages_without_room_signal_opt_in () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      Unix.putenv "MASC_BASE_PATH" base_dir;
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+      ignore (Masc_mcp.Coord.broadcast config ~from_agent:"alice" ~content:"general room update");
+      let meta = { minimal_meta with joined_room_ids = [ "default" ] } in
+      let obs =
+        WO.observe ~pending_board_events:(Some [])
+          ~config ~meta
+      in
+      check int "mentions stay empty" 0 (List.length obs.pending_mentions);
+      check int "scope messages stay empty" 0
+        (List.length obs.pending_scope_messages))
+
+let test_observe_collects_scope_messages_for_room_signal_keepers () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      Unix.putenv "MASC_BASE_PATH" base_dir;
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+      ignore (Masc_mcp.Coord.broadcast config ~from_agent:"alice" ~content:"general room update");
+      let meta = { room_signal_meta with joined_room_ids = [ "default" ] } in
+      let obs =
+        WO.observe ~pending_board_events:(Some [])
+          ~config ~meta
+      in
+      check int "mentions stay empty" 0 (List.length obs.pending_mentions);
+      check bool "scope messages collected" true
+        (List.length obs.pending_scope_messages >= 1))
 
 let test_scheduled_turn_uses_cooldown_only () =
   let meta =
@@ -3955,10 +4026,16 @@ let () =
           test_case "with mentions" `Quick test_observation_with_mentions;
           test_case "uses precollected board events" `Quick
             test_observe_uses_precollected_board_events;
-          test_case "keeps non-mention board events as follow-up signal" `Quick
+          test_case "default keepers ignore unmatched non-mention board events" `Quick
             test_collect_board_events_keeps_non_mentions_as_followup_signal;
+          test_case "room-signal keepers keep unmatched non-mention board events" `Quick
+            test_collect_board_events_keeps_non_mentions_for_room_signal_keepers;
           test_case "keeps external replies after self comment" `Quick
             test_collect_board_events_keeps_external_replies_after_self_comment;
+          test_case "default keepers ignore scope messages" `Quick
+            test_observe_ignores_scope_messages_without_room_signal_opt_in;
+          test_case "room-signal keepers collect scope messages" `Quick
+            test_observe_collects_scope_messages_for_room_signal_keepers;
           test_case "scheduled turn uses cooldown only when work exists" `Quick
             test_scheduled_turn_uses_cooldown_only;
           test_case "scheduled turn skips without structured work signal" `Quick


### PR DESCRIPTION
## What changed
- narrow keeper board wakeups so unmatched generic board activity no longer wakes every running keeper
- make scope-message collection opt-in via `room_signal_prompt_enabled`
- preserve latest registry meta in keepalive when disk meta is unchanged, instead of falling back to stale boot-time state
- persist directive-driven `pause` / `resume` / `claim` updates back to keeper meta JSON so runtime and disk stay aligned
- add regression coverage for board wakeup filtering, scope message opt-in, keepalive meta precedence, and directive persistence

## Why
`adversary`-style keeper bursts were being driven by overly broad board-reactive wiring. Any board activity could wake all running keepers, and generic room chatter could keep entering turn context even when the keeper was not opted into those signals. Separately, keepalive could reuse stale boot meta when disk state had not changed, and directive updates only touched the in-memory registry, creating continuity drift after reloads.

## Impact
Keepers now react more selectively, thread follow-ups still work when there is a real external reply, turn-to-turn continuity is less likely to reset spuriously, and operator directives persist across reloads.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-board-fanout test/test_keeper_registry.exe`
- `./_build/default/test/test_keeper_registry.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-board-fanout ./test/test_keeper_unified.exe`