### PR TITLE
[codex] Add hard delete for dashboard agents

### DIFF
--- a/dashboard/src/api/actions.ts
+++ b/dashboard/src/api/actions.ts
@@ -103,3 +103,17 @@ export async function deleteTask(taskId: string): Promise<boolean> {
   const resp = await post<{ ok: boolean }>('/api/v1/dashboard/tasks/delete', { task_id: taskId })
   return resp.ok
 }
+
+export interface PurgeAgentResponse {
+  ok: boolean
+  target_kind: 'agent' | 'keeper' | string
+  agent_name: string
+  keeper_name?: string
+  removed_keeper_toml?: boolean
+}
+
+export async function purgeAgent(agentName: string): Promise<PurgeAgentResponse> {
+  return post<PurgeAgentResponse>('/api/v1/dashboard/agents/purge', {
+    agent_name: agentName,
+  })
+}

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -45,6 +45,10 @@ import { KeeperPhaseBadge } from './keeper-phase-indicator'
 import { trimText } from '../lib/truncate'
 import type { Task } from '../types'
 import { DialogOverlay } from './common/dialog'
+import { requestConfirm } from './common/confirm-dialog'
+import { showToast } from './common/toast'
+import { invalidateDashboardCache, refreshDashboard } from '../store'
+import { purgeAgent } from '../api/actions'
 
 // Re-export public API for external consumers
 export { selectedAgentName, openAgentDetail, closeAgentDetail } from './agent-detail-state'
@@ -173,6 +177,7 @@ export function AgentDetailOverlay() {
   const ownedTasks = assignedTasks(agentName)
   const lines = namespaceActivity.value
   const taskQuery = useSignal('')
+  const purgePending = useSignal(false)
   const historyRows = taskHistories.value
   const visibleOwnedTasks = useMemo(
     () => filterOwnedTasks(ownedTasks, taskQuery.value),
@@ -204,6 +209,36 @@ export function AgentDetailOverlay() {
   // Skip secondaryLabel when keeperIdentity already shows the agent runtime name
   const showSecondaryLabel = secondaryLabel && !keeperIdentity
   const titleId = `agent-detail-title-${agentName}`
+
+  const handlePurge = () => {
+    void (async () => {
+      const targetLabel = keeper ? `${displayName} 키퍼` : displayName
+      const confirmed = await requestConfirm({
+        title: '에이전트 완전 삭제',
+        message: `${targetLabel}를 완전 삭제합니다.\n런타임 상태, 인증, metrics가 제거되고 keeper면 config/keepers TOML도 함께 삭제됩니다.`,
+        tone: 'danger',
+        confirmText: '완전 삭제',
+      })
+      if (!confirmed) return
+      purgePending.value = true
+      try {
+        const result = await purgeAgent(agentName)
+        closeAgentDetail()
+        invalidateDashboardCache()
+        await refreshDashboard({ force: true })
+        showToast(
+          result.target_kind === 'keeper'
+            ? `${displayName} 완전 삭제됨`
+            : `${agentName} 삭제됨`,
+          'success',
+        )
+      } catch (err) {
+        showToast(err instanceof Error ? err.message : '에이전트 삭제 실패', 'error')
+      } finally {
+        purgePending.value = false
+      }
+    })()
+  }
 
   return html`
     <${DialogOverlay}
@@ -271,6 +306,15 @@ export function AgentDetailOverlay() {
               disabled=${loading.value}
             >
               ${loading.value ? '새로고침 중...' : '새로고침'}
+            <//>
+            <${ActionButton}
+              variant="danger"
+              size="lg"
+              class="px-4 py-2 text-sm rounded shadow-sm"
+              onClick=${handlePurge}
+              disabled=${purgePending.value}
+            >
+              ${purgePending.value ? '삭제 중...' : '완전 삭제'}
             <//>
             <button
               ref=${closeButtonRef}

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -30,6 +30,7 @@ import {
   KeeperRuntimeActions,
 } from './keeper-shared'
 import { showToast } from './common/toast'
+import { purgeAgent } from '../api/actions'
 import {
   ContextChart,
   CtxCompositionPanel,
@@ -589,6 +590,7 @@ export function KeeperDetailPage() {
   const [clearReason, setClearReason] = useState('')
   const [preserveSystemPrompt, setPreserveSystemPrompt] = useState(true)
   const [clearPending, setClearPending] = useState(false)
+  const [purgePending, setPurgePending] = useState(false)
   const [checkpointRefreshToken, setCheckpointRefreshToken] = useState(0)
   // Latest transition's wall_clock_at_decision, in unix seconds.  Used by
   // the header KeeperPhaseAndStage to render "현재 phase에 머문 시간" without
@@ -674,6 +676,29 @@ export function KeeperDetailPage() {
     })()
   }
 
+  const submitPurgeKeeper = () => {
+    void (async () => {
+      const confirmed = await requestConfirm({
+        title: '키퍼 완전 삭제',
+        message: `${keeper.name}를 완전 삭제합니다.\n런타임 상태, 세션 trace, 인증, metrics와 config/keepers/${keeper.name}.toml까지 함께 제거됩니다.`,
+        tone: 'danger',
+        confirmText: '완전 삭제',
+      })
+      if (!confirmed) return
+      setPurgePending(true)
+      try {
+        await purgeAgent(keeper.name)
+        closeKeeperDetail()
+        showToast(`${keeper.name} 완전 삭제됨`, 'success')
+        await refreshAfterRuntimeAction()
+      } catch (err) {
+        showToast(err instanceof Error ? err.message : '키퍼 삭제 실패', 'error')
+      } finally {
+        setPurgePending(false)
+      }
+    })()
+  }
+
   return html`
     <div class="mx-auto flex w-full max-w-[1600px] flex-col gap-5 pb-8">
       <div class="sticky top-0 z-20 overflow-hidden rounded-[28px] border border-[var(--card-border)] bg-[rgba(13,21,38,0.96)] shadow-[0_24px_64px_rgba(0,0,0,0.22)] backdrop-blur-xl">
@@ -690,6 +715,12 @@ export function KeeperDetailPage() {
               class="py-1 px-3 rounded text-2xs font-semibold cursor-pointer border border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--rose-light)] hover:bg-[var(--bad-soft)] transition-colors"
               onClick=${() => setClearDialogOpen(true)}
             >비우기</button>
+            <button
+              type="button"
+              disabled=${purgePending}
+              class="py-1 px-3 rounded text-2xs font-semibold cursor-pointer border border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--rose-light)] hover:bg-[var(--bad-soft)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              onClick=${submitPurgeKeeper}
+            >${purgePending ? '삭제 중...' : '완전 삭제'}</button>
             <${KeeperLifecycleButtons} keeper=${keeper} effectiveStatus=${effectiveStatus} />
             <button
               type="button"

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -1,13 +1,217 @@
-(** Dashboard delete action handlers — board, tasks, goals.
+(** Dashboard delete action handlers — board, tasks, goals, agents.
 
     Extracted from server_routes_http_routes_dashboard.ml.
     Contains POST handler logic for /api/v1/dashboard/board/delete,
     /api/v1/dashboard/tasks/delete, /api/v1/dashboard/goals/delete,
-    /api/v1/dashboard/goals/sweep. *)
+    /api/v1/dashboard/goals/sweep, /api/v1/dashboard/agents/purge. *)
 
 module Http = Http_server_eio
 
 open Server_auth
+
+type keeper_purge_target =
+  { keeper_name : string
+  ; agent_name : string
+  ; trace_id : string option
+  ; toml_path : string option
+  }
+
+let dedupe_keep_order items =
+  let seen = Hashtbl.create (List.length items) in
+  List.filter
+    (fun item ->
+      if Hashtbl.mem seen item
+      then false
+      else (
+        Hashtbl.add seen item ();
+        true))
+    items
+;;
+
+let rec rm_rf path =
+  if Fs_compat.file_exists path
+  then if Sys.is_directory path
+  then (
+    Sys.readdir path
+    |> Array.iter (fun entry -> rm_rf (Filename.concat path entry));
+    (try Fs_compat.rmdir path with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Log.Misc.warn "[agent_purge] failed to remove directory %s: %s"
+         path (Printexc.to_string exn)))
+  else Safe_ops.remove_file_logged ~context:"agent_purge" path
+;;
+
+let remove_path_if_exists ~context path =
+  if Fs_compat.file_exists path
+  then if Sys.is_directory path
+  then rm_rf path
+  else Safe_ops.remove_file_logged ~context path
+;;
+
+let credential_aliases agent_name =
+  let trimmed = String.trim agent_name in
+  let aliases =
+    [
+      Some trimmed;
+      (if Nickname.is_generated_nickname trimmed
+       then Nickname.extract_agent_type trimmed
+       else None);
+    ]
+  in
+  aliases
+  |> List.filter_map (function
+       | Some value when value <> "" -> Some value
+       | _ -> None)
+  |> dedupe_keep_order
+;;
+
+let agent_file_path config agent_name =
+  Filename.concat (Coord.agents_dir config)
+    (Coord.safe_filename agent_name ^ ".json")
+;;
+
+let resolve_keeper_purge_target config requested_name =
+  let trimmed = String.trim requested_name in
+  let candidates =
+    [
+      Some trimmed;
+      Keeper_types.canonical_keeper_name_from_agent_name trimmed;
+      Keeper_types.canonical_keeper_name trimmed;
+    ]
+    |> List.filter_map (function
+         | Some value when value <> "" -> Some value
+         | _ -> None)
+    |> dedupe_keep_order
+  in
+  let rec loop = function
+    | [] -> None
+    | candidate :: rest -> (
+      let candidate_meta_path = Keeper_types.keeper_meta_path config candidate in
+      let candidate_toml_path = Config_dir_resolver.keeper_toml_path_opt candidate in
+      match Keeper_types.read_meta_resolved config candidate with
+      | Ok (Some (resolved_name, meta)) ->
+        Some
+          {
+            keeper_name = resolved_name;
+            agent_name = meta.agent_name;
+            trace_id =
+              Some (Keeper_id.Trace_id.to_string meta.runtime.trace_id);
+            toml_path = Config_dir_resolver.keeper_toml_path_opt resolved_name;
+          }
+      | Ok None ->
+        if Fs_compat.file_exists candidate_meta_path
+           || Option.is_some candidate_toml_path
+        then
+          Some
+            {
+              keeper_name = candidate;
+              agent_name = Keeper_types.keeper_agent_name candidate;
+              trace_id = None;
+              toml_path = candidate_toml_path;
+            }
+        else loop rest
+      | Error err ->
+        if Fs_compat.file_exists candidate_meta_path
+           || Option.is_some candidate_toml_path
+        then (
+          Log.Keeper.warn
+            "agent purge: continuing despite keeper meta read failure for %s: %s"
+            candidate err;
+          Some
+            {
+              keeper_name = candidate;
+              agent_name = Keeper_types.keeper_agent_name candidate;
+              trace_id = None;
+              toml_path = candidate_toml_path;
+            })
+        else loop rest)
+  in
+  loop candidates
+;;
+
+let plain_agent_candidate_names config requested_name =
+  let trimmed = String.trim requested_name in
+  let resolved = Coord.resolve_agent_name config trimmed in
+  [ trimmed; resolved ]
+  |> List.filter (fun value -> value <> "")
+  |> dedupe_keep_order
+;;
+
+let plain_agent_artifacts_exist config agent_name =
+  let agent_exists = Fs_compat.file_exists (agent_file_path config agent_name) in
+  let metrics_exists =
+    Fs_compat.file_exists (Metrics_store_eio.agent_metrics_dir config agent_name)
+  in
+  let credential_exists =
+    credential_aliases agent_name
+    |> List.exists (fun alias ->
+         Fs_compat.file_exists
+           (Auth.credential_file config.base_path alias))
+  in
+  agent_exists || metrics_exists || credential_exists
+;;
+
+let resolve_plain_agent_target config requested_name =
+  plain_agent_candidate_names config requested_name
+  |> List.find_opt (plain_agent_artifacts_exist config)
+;;
+
+let purge_agent_filesystem_artifacts config agent_names =
+  agent_names
+  |> dedupe_keep_order
+  |> List.iter (fun agent_name ->
+       ignore
+         (Operator_pending_confirm.remove_pending_confirms_by_target config
+            ~target_type:"agent" ~target_id:(Some agent_name));
+       ignore (Heartbeat.stop_by_agent ~agent_name);
+       ignore (Coord.leave config ~agent_name);
+       remove_path_if_exists ~context:"agent_purge"
+         (agent_file_path config agent_name);
+       remove_path_if_exists ~context:"agent_purge"
+         (Metrics_store_eio.agent_metrics_dir config agent_name);
+       Tool_shard.remove_agent_shards agent_name;
+       credential_aliases agent_name
+       |> List.iter (Auth.delete_credential config.base_path))
+;;
+
+let purge_keeper_artifacts config requested_name
+    ({ keeper_name; agent_name; trace_id; toml_path } : keeper_purge_target) =
+  let keeper_dir = Keeper_types.keeper_dir config in
+  let keeper_runtime_dir = Filename.concat keeper_dir keeper_name in
+  let cleanup_names =
+    [ requested_name; keeper_name; agent_name ]
+    |> List.filter (fun value -> String.trim value <> "")
+    |> dedupe_keep_order
+  in
+  cleanup_names
+  |> List.iter (fun name ->
+       Keeper_keepalive.stop_keepalive ~base_path:config.base_path name);
+  ignore
+    (Operator_pending_confirm.remove_pending_confirms_by_target config
+       ~target_type:"keeper" ~target_id:(Some keeper_name));
+  Keeper_registry.unregister ~base_path:config.base_path keeper_name;
+  purge_agent_filesystem_artifacts config [ agent_name; keeper_name ];
+  List.iter
+    (remove_path_if_exists ~context:"keeper_purge")
+    [
+      Keeper_types.keeper_meta_path config keeper_name;
+      Keeper_types.keeper_metrics_path config keeper_name;
+      Keeper_types.keeper_memory_bank_path config keeper_name;
+      Keeper_types.keeper_generation_index_path config keeper_name;
+      Keeper_types.keeper_policy_log_path config keeper_name;
+      Keeper_types.keeper_decision_log_path config keeper_name;
+      Keeper_types.keeper_feedback_log_path config keeper_name;
+      Keeper_types.keeper_dataset_export_path config keeper_name;
+    ];
+  remove_path_if_exists ~context:"keeper_purge" keeper_runtime_dir;
+  Option.iter
+    (fun keeper_trace_id ->
+       remove_path_if_exists ~context:"keeper_purge"
+         (Keeper_types.keeper_session_dir config keeper_trace_id))
+    trace_id;
+  Option.iter (remove_path_if_exists ~context:"keeper_purge") toml_path
+;;
 
 let add_delete_action_routes router =
   router
@@ -83,6 +287,58 @@ let add_delete_action_routes router =
            with Yojson.Json_error _ ->
              Http.Response.json ~status:`Bad_request ~request:req
                {|{"ok":false,"error":"invalid request: requires {\"goal_id\":\"...\"}"}|} reqd
+         )
+       ) request reqd)
+
+  |> Http.Router.post "/api/v1/dashboard/agents/purge" (fun request reqd ->
+       with_token_permission_auth ~permission:Types.CanAdmin
+         (fun state _agent_name req reqd ->
+         Http.Request.read_body_async reqd (fun body_str ->
+           try
+             let json = Yojson.Safe.from_string body_str in
+             match Safe_ops.json_string_opt "agent_name" json with
+             | None ->
+               Http.Response.json ~status:`Bad_request ~request:req
+                 {|{"ok":false,"error":"invalid request: requires {\"agent_name\":\"...\"}"}|}
+                 reqd
+             | Some requested_name ->
+               let config = state.Mcp_server.room_config in
+               (match resolve_keeper_purge_target config requested_name with
+                | Some keeper_target ->
+                  let toml_deleted = Option.is_some keeper_target.toml_path in
+                  purge_keeper_artifacts config requested_name keeper_target;
+                  Http.Response.json ~compress:true ~request:req
+                    (Yojson.Safe.to_string
+                       (`Assoc
+                          [
+                            ("ok", `Bool true);
+                            ("target_kind", `String "keeper");
+                            ("agent_name", `String keeper_target.agent_name);
+                            ("keeper_name", `String keeper_target.keeper_name);
+                            ("removed_keeper_toml", `Bool toml_deleted);
+                          ]))
+                    reqd
+                | None -> (
+                  match resolve_plain_agent_target config requested_name with
+                  | Some agent_name ->
+                    purge_agent_filesystem_artifacts config [ requested_name; agent_name ];
+                    Http.Response.json ~compress:true ~request:req
+                      (Yojson.Safe.to_string
+                         (`Assoc
+                            [
+                              ("ok", `Bool true);
+                              ("target_kind", `String "agent");
+                              ("agent_name", `String agent_name);
+                            ]))
+                      reqd
+                  | None ->
+                    Http.Response.json ~status:`Not_found ~request:req
+                      {|{"ok":false,"error":"agent or keeper not found"}|}
+                      reqd))
+           with Yojson.Json_error _ ->
+             Http.Response.json ~status:`Bad_request ~request:req
+               {|{"ok":false,"error":"invalid request: requires {\"agent_name\":\"...\"}"}|}
+               reqd
          )
        ) request reqd)
 

--- a/lib/server/server_dashboard_http_delete_actions.mli
+++ b/lib/server/server_dashboard_http_delete_actions.mli
@@ -6,9 +6,10 @@
     - [/api/v1/dashboard/board/delete] — delete one board post
     - [/api/v1/dashboard/tasks/delete] — delete one task
     - [/api/v1/dashboard/goals/delete] — delete one goal
+    - [/api/v1/dashboard/agents/purge] — hard-delete one agent/keeper
     - [/api/v1/dashboard/goals/sweep] — run {!Goal_janitor} *)
 
-(** [add_delete_action_routes router] returns [router] with the four
+(** [add_delete_action_routes router] returns [router] with the five
     delete/sweep endpoints appended. Each route requires
     {!Types.CanAdmin} via [Server_auth.with_token_permission_auth]. *)
 val add_delete_action_routes :

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -516,6 +516,16 @@ let make_keeper_meta_json ?(name = "route-shadow-demo") () =
   | Error err -> fail ("keeper meta fixture parse failed: " ^ err)
 ;;
 
+let write_keeper_toml_fixture ~config_root ~keeper_name =
+  let keepers_dir = Filename.concat config_root "keepers" in
+  mkdir_p keepers_dir;
+  write_file
+    (Filename.concat keepers_dir (keeper_name ^ ".toml"))
+    (Printf.sprintf
+       "[keeper]\npersona_name = %S\nsandbox_profile = \"local\"\n"
+       keeper_name)
+;;
+
 let seed_auth_and_keeper ~base_path ~keeper_name =
   let config = Masc_mcp.Coord.default_config base_path in
   ignore (Masc_mcp.Coord.init config ~agent_name:(Some "bootstrap-admin"));
@@ -536,6 +546,27 @@ let seed_auth_and_keeper ~base_path ~keeper_name =
     | Error err -> fail (Types.masc_error_to_string err)
   in
   config, admin_token
+;;
+
+let seed_agent_file ?(agent_type = "worker") ?(capabilities = []) config agent_name =
+  let timestamp = Types.now_iso () in
+  let agent : Types.agent =
+    {
+      name = agent_name;
+      agent_type;
+      status = Types.Active;
+      capabilities;
+      current_task = None;
+      joined_at = timestamp;
+      last_seen = timestamp;
+      meta = None;
+    }
+  in
+  let agent_file =
+    Filename.concat (Masc_mcp.Coord.agents_dir config)
+      (Masc_mcp.Coord.safe_filename agent_name ^ ".json")
+  in
+  Masc_mcp.Coord.write_json config agent_file (Types.agent_to_yojson agent)
 ;;
 
 let append_execution_receipt config ~keeper_name =
@@ -867,6 +898,115 @@ let test_keeper_directive_resume_updates_paused_meta () =
       fail ("failed to read keeper meta after directive resume: " ^ err)
 ;;
 
+let test_agent_purge_route_removes_plain_agent_artifacts () =
+  with_seeded_server
+  @@ fun ~port ~config ~admin_token ~keeper_name:_ ->
+  let agent_name = "worker-swift-fox" in
+  seed_agent_file ~capabilities:[ "coding" ] config agent_name;
+  ignore
+    (Masc_mcp.Auth.create_token config.base_path ~agent_name ~role:Types.Admin);
+  let metrics_dir = Masc_mcp.Metrics_store_eio.agent_metrics_dir config agent_name in
+  Fs_compat.mkdir_p metrics_dir;
+  write_file (Filename.concat metrics_dir "2026-04.jsonl") "{}\n";
+  let purge_result =
+    run_curl_post
+      ~body:(Printf.sprintf {|{"agent_name":"%s"}|} agent_name)
+      ~token:admin_token
+      ~port
+      ~path:"/api/v1/dashboard/agents/purge"
+      ()
+  in
+  require_status "agent purge route returns 200" 200 purge_result;
+  check bool "agent purge identifies plain agent" true
+    (contains_substr {|"target_kind":"agent"|} purge_result.body);
+  check bool "agent file removed" false
+    (Sys.file_exists
+       (Filename.concat (Masc_mcp.Coord.agents_dir config)
+          (Masc_mcp.Coord.safe_filename agent_name ^ ".json")));
+  check bool "agent credential removed" false
+    (Sys.file_exists
+       (Masc_mcp.Auth.credential_file config.base_path agent_name));
+  check bool "agent metrics removed" false (Sys.file_exists metrics_dir)
+;;
+
+let test_agent_purge_route_removes_keeper_artifacts_and_toml () =
+  with_mock_model @@ fun valid_model ->
+  with_temp_config_root
+    (Printf.sprintf
+       {|{"default_models":["%s"],"keeper_unified_models":["%s"]}|}
+       valid_model
+       valid_model)
+  @@ fun config_root ->
+  let keeper_name = "route-shadow-demo" in
+  let keeper_toml_path =
+    Filename.concat (Filename.concat config_root "keepers") (keeper_name ^ ".toml")
+  in
+  write_keeper_toml_fixture ~config_root ~keeper_name;
+  with_seeded_server
+    ~env_overrides:[ "MASC_CONFIG_DIR", config_root ]
+  @@ fun ~port ~config ~admin_token ~keeper_name ->
+  let meta =
+    match Masc_mcp.Keeper_types.read_meta config keeper_name with
+    | Ok (Some meta) -> meta
+    | Ok None -> fail "keeper meta missing before purge"
+    | Error err -> fail ("failed to read keeper meta before purge: " ^ err)
+  in
+  seed_agent_file
+    ~agent_type:"keeper"
+    ~capabilities:[ "keeper" ]
+    config
+    meta.agent_name;
+  ignore
+    (Masc_mcp.Auth.create_token config.base_path ~agent_name:keeper_name
+       ~role:Types.Admin);
+  ignore
+    (Masc_mcp.Auth.create_token config.base_path ~agent_name:meta.agent_name
+       ~role:Types.Admin);
+  let agent_metrics_dir =
+    Masc_mcp.Metrics_store_eio.agent_metrics_dir config meta.agent_name
+  in
+  Fs_compat.mkdir_p agent_metrics_dir;
+  write_file (Filename.concat agent_metrics_dir "2026-04.jsonl") "{}\n";
+  append_execution_receipt config ~keeper_name;
+  let purge_result =
+    run_curl_post
+      ~body:(Printf.sprintf {|{"agent_name":"%s"}|} keeper_name)
+      ~token:admin_token
+      ~port
+      ~path:"/api/v1/dashboard/agents/purge"
+      ()
+  in
+  require_status "keeper purge route returns 200" 200 purge_result;
+  check bool "keeper purge identifies keeper target" true
+    (contains_substr {|"target_kind":"keeper"|} purge_result.body);
+  check bool "keeper purge reports toml deletion" true
+    (contains_substr {|"removed_keeper_toml":true|} purge_result.body);
+  (match Masc_mcp.Keeper_types.read_meta config keeper_name with
+   | Ok None -> ()
+   | Ok (Some _) -> fail "keeper meta should be removed after purge"
+   | Error err -> fail ("failed to read keeper meta after purge: " ^ err));
+  check bool "keeper toml removed" false (Sys.file_exists keeper_toml_path);
+  check bool "keeper agent file removed" false
+    (Sys.file_exists
+       (Filename.concat (Masc_mcp.Coord.agents_dir config)
+          (Masc_mcp.Coord.safe_filename meta.agent_name ^ ".json")));
+  check bool "keeper credential removed" false
+    (Sys.file_exists
+       (Masc_mcp.Auth.credential_file config.base_path keeper_name));
+  check bool "keeper agent credential removed" false
+    (Sys.file_exists
+       (Masc_mcp.Auth.credential_file config.base_path meta.agent_name));
+  check bool "keeper agent metrics removed" false
+    (Sys.file_exists agent_metrics_dir);
+  check bool "keeper runtime directory removed" false
+    (Sys.file_exists
+       (Filename.concat (Masc_mcp.Keeper_types.keeper_dir config) keeper_name));
+  check bool "keeper session trace removed" false
+    (Sys.file_exists
+       (Masc_mcp.Keeper_types.keeper_session_dir config
+          (Masc_mcp.Keeper_id.Trace_id.to_string meta.runtime.trace_id)))
+;;
+
 let test_available_cascade_profiles_filter_invalid_catalog_entries () =
   with_mock_model @@ fun valid_model ->
   with_temp_config_root
@@ -1045,6 +1185,14 @@ let () =
             "directive resume updates paused meta"
             `Slow
             test_keeper_directive_resume_updates_paused_meta
+        ; test_case
+            "agent purge removes plain agent artifacts"
+            `Slow
+            test_agent_purge_route_removes_plain_agent_artifacts
+        ; test_case
+            "agent purge removes keeper artifacts and keeper toml"
+            `Slow
+            test_agent_purge_route_removes_keeper_artifacts_and_toml
         ; test_case
             "available cascade profiles filter invalid catalog entries"
             `Quick


### PR DESCRIPTION
## What changed
- add a dedicated dashboard purge endpoint for full agent and keeper deletion
- remove agent artifacts including coord files, metrics, shards, pending confirms, and credentials
- remove keeper artifacts including keepalive/runtime/session state and `config/keepers/<name>.toml` so deleted keepers do not respawn
- add dashboard UI actions for full deletion from both agent and keeper detail panels
- cover plain-agent and keeper purge flows with route tests

## Why
- the existing leave flow only tombstones agents as inactive
- keeper autoboot and persisted runtime/config artifacts can make deleted entries reappear
- operators need an explicit destructive path when they really want a complete purge

## Impact
- dashboard operators can now fully delete stale agents and keepers from the UI
- keeper deletion now also removes its persisted config, preventing re-bootstrap on restart
- the purge path is scoped to explicit admin action and guarded by confirm prompts in the UI

## Validation
- `dune build --root . bin/main_eio.exe test/test_dashboard_keeper_routes.exe`
- `./_build/default/test/test_dashboard_keeper_routes.exe test dashboard_keeper_routes 3,4 -e`
- full `test_dashboard_keeper_routes.exe` still has pre-existing failures in lifecycle/directive/execution-trust cases; the new purge cases pass
