### PR TITLE
[codex] clear health ratchet regression

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1706,7 +1706,9 @@ let persist_directive_meta_update
             let b_mtime = Option.value ~default:0.0 (Fs_compat.file_mtime b) in
             Float.compare b_mtime a_mtime
           in
-          List.sort by_mtime_desc paths |> List.hd
+          (match List.sort by_mtime_desc paths with
+           | latest_path :: _ -> latest_path
+           | [] -> default_path)
   in
   try
     Keeper_fs.save_json_atomic persisted_path (meta_to_json updated_meta);


### PR DESCRIPTION
## What changed
- replace the new `List.hd` in `lib/keeper/keeper_keepalive.ml` with a safe pattern match when selecting the newest persisted keeper meta path
- replace the `List.hd` in `lib/coord_goals.ml` with a safe match before emitting the latest vote event

## Why
PR #9467 merged the keeper reactive continuity work, but the repo health ratchet still flagged `lib_list_hd` regressions. One occurrence came from the keeper continuity fix itself, and one was already present on `main` in `coord_goals`. This follow-up removes both unsafe list-head lookups so `scripts/health_snapshot.sh --fail-on-lib-regression` passes again.

## Impact
No behavior change is intended beyond avoiding partial list access. Empty-list cases now no-op instead of relying on `List.hd`.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/keeper-health-ratchet @check`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/keeper-health-ratchet ./test/test_keeper_unified.exe`
- `bash scripts/health_snapshot.sh --skip-build --baseline-ref origin/main --fail-on-lib-regression`