### PR TITLE
feat(guard): refuse server start with implicit basepath

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -379,6 +379,20 @@ let run_cmd host port base_path =
     Env_config.strip_path_trailing_slashes (String.trim base_path)
   in
   guard_self_repo_base_path normalized_base_path;
+  if String.equal resolution_source "implicit_home"
+     || String.equal resolution_source "implicit_repo_root"
+  then begin
+    Printf.eprintf
+      "[FATAL] Server refused to start with an implicit base path.\n\
+       Resolution source: %s\n\
+       Resolved path: %s\n\n\
+       Start the server with an explicit base path:\n\
+       \  --base-path /path/to/workspace     (CLI flag)\n\
+       \  MASC_BASE_PATH=/path/to/workspace  (environment variable)\n\n\
+       Use a workspace root, not the repository checkout or $HOME directly.\n"
+      resolution_source normalized_base_path;
+    exit 1
+  end;
   acquire_pid_lock port;
   Log.init_from_env ();
   if stripped_base_path <> ""


### PR DESCRIPTION
## Summary
- Add fail-closed guard in `bin/main_eio.ml` that prevents the server from starting when `base_path` is resolved implicitly (either from `$HOME` or `Sys.getcwd()` fallback).
- Requires explicit `--base-path /path/to/workspace` or `MASC_BASE_PATH=/path/to/workspace`.

## Motivation
When the server was started without an explicit base path, `default_base_path()` silently fell back to `$HOME` or the current working directory. This caused unexpected keeper autoboot from implicit locations, leading to 11+ keepers respawning unintentionally.

## Test plan
- [x] `dune build @install` passes
- [ ] Starting server without `--base-path` exits with code 1 and prints the guard message
- [ ] Starting server with `--base-path /tmp/test-masc` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)