### PR TITLE
fix(coord): replace List.hd with safe pattern match in goal verification

### DIFF
--- a/lib/coord_goals.ml
+++ b/lib/coord_goals.ml
@@ -663,8 +663,11 @@ let handle_goal_verify (ctx : context) args =
                       (`Assoc
                         [
                           ( "vote",
-                            Goal_verification.goal_verification_vote_to_yojson
-                              (List.hd (List.rev request.votes)) );
+                            match List.rev request.votes with
+                            | last_vote :: _ ->
+                                Goal_verification.goal_verification_vote_to_yojson
+                                  last_vote
+                            | [] -> `Null );
                         ]);
                   let finalize ~phase ~event_status =
                     match


### PR DESCRIPTION
## Summary

Replaces unsafe `List.hd` with a pattern match to satisfy the health check ratchet (`lib_list_hd` baseline = 0).

## Changes

- `lib/coord_goals.ml`: Pattern match on `List.rev request.votes` instead of `List.hd (List.rev request.votes)`

## Related

- Follow-up to #9468 (merged before this fix could be included)
- Part of the operational quality remediation plan

## Verification

- [x] `dune build` passes
- [ ] Health check ratchet passes (`lib_list_hd` count stays at 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)