### PR TITLE
[codex] Preserve local config root on bootstrap

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -106,6 +106,11 @@ let rec copy_missing_tree ~src ~dst =
   else
     copy_file_if_missing ~src ~dst
 
+let ensure_config_root_scaffold config_root =
+  Fs_compat.mkdir_p config_root;
+  [ "prompts"; "keepers"; "personas" ]
+  |> List.iter (fun name -> Fs_compat.mkdir_p (Filename.concat config_root name))
+
 let bootstrap_base_path_config_root ~base_path =
   let base_path = Env_config_core.normalize_masc_base_path_input base_path in
   if Option.is_some (Config_dir_resolver.current_env_config_dir_opt ()) then
@@ -117,24 +122,36 @@ let bootstrap_base_path_config_root ~base_path =
     let source_root =
       versioned_config_root_candidates () |> List.find_opt Sys.file_exists
     in
-    (match source_root with
-     | Some source ->
-         copy_missing_tree ~src:source ~dst:config_root;
-         Log.Server.info
-           "bootstrapped base-path config root: %s <- %s"
-           config_root source
-     | None ->
-         Fs_compat.mkdir_p (Filename.concat config_root "prompts");
-         Fs_compat.mkdir_p (Filename.concat config_root "keepers");
-         Fs_compat.mkdir_p (Filename.concat config_root "personas");
-         let cascade_path =
-           Filename.concat config_root Config_dir_resolver.cascade_json_filename
-         in
-         if not (Sys.file_exists cascade_path) then
-           Fs_compat.save_file cascade_path "{}";
-         Log.Server.warn
-           "bootstrapped minimal base-path config root without versioned source: %s"
-           config_root);
+    if Sys.file_exists config_root then
+      if Sys.is_directory config_root then begin
+        (* Preserve an existing local config root as the source of truth.
+           Re-filling missing files from repo config resurrects keepers/personas
+           that operators intentionally deleted under <base_path>/.masc/config. *)
+        ensure_config_root_scaffold config_root;
+        Log.Server.info
+          "preserved existing base-path config root without refilling missing entries: %s"
+          config_root
+      end else
+        Log.Server.warn
+          "base-path config root exists but is not a directory; skipping bootstrap: %s"
+          config_root
+    else
+      (match source_root with
+       | Some source ->
+           copy_missing_tree ~src:source ~dst:config_root;
+           Log.Server.info
+             "bootstrapped base-path config root: %s <- %s"
+             config_root source
+       | None ->
+           ensure_config_root_scaffold config_root;
+           let cascade_path =
+             Filename.concat config_root Config_dir_resolver.cascade_json_filename
+           in
+           if not (Sys.file_exists cascade_path) then
+             Fs_compat.save_file cascade_path "{}";
+           Log.Server.warn
+             "bootstrapped minimal base-path config root without versioned source: %s"
+             config_root);
     Config_dir_resolver.reset ()
 
 let startup_config_resolution ~base_path =

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -510,8 +510,8 @@ let test_bootstrap_base_path_config_root_copies_versioned_config () =
       Alcotest.(check bool) "keeper TOML copied" true
         (Sys.file_exists (Filename.concat config_root "keepers/example.toml")))
 
-let test_bootstrap_base_path_config_root_repairs_partial_root () =
-  with_temp_dir "startup-config-repair" (fun dir ->
+let test_bootstrap_base_path_config_root_preserves_existing_root_without_refill () =
+  with_temp_dir "startup-config-preserve" (fun dir ->
       let repo = Filename.concat dir "repo" in
       mkdir_p repo;
       ignore (make_config_root repo);
@@ -525,11 +525,16 @@ let test_bootstrap_base_path_config_root_repairs_partial_root () =
       Server_runtime_bootstrap.bootstrap_base_path_config_root ~base_path;
       Alcotest.(check string) "existing cascade preserved" "{\"seed\":\"local\"}"
         (read_file (Filename.concat config_root "cascade.json"));
-      Alcotest.(check bool) "keepers repaired" true
+      Alcotest.(check bool) "keepers dir scaffolded" true
         (Sys.is_directory (Filename.concat config_root "keepers"));
-      Alcotest.(check bool) "prompts repaired" true
+      Alcotest.(check bool) "prompts dir scaffolded" true
         (Sys.is_directory (Filename.concat config_root "prompts"));
-      Alcotest.(check bool) "tool policy repaired" true
+      Alcotest.(check bool) "versioned keeper not resurrected" false
+        (Sys.file_exists (Filename.concat config_root "keepers/example.toml"));
+      Alcotest.(check bool) "versioned prompt not resurrected" false
+        (Sys.file_exists
+           (Filename.concat config_root "prompts/keeper.unified.system.md"));
+      Alcotest.(check bool) "tool policy not backfilled" false
         (Sys.file_exists (Filename.concat config_root "tool_policy.toml")))
 
 let test_bootstrap_base_path_config_root_skips_explicit_config_override () =
@@ -1741,8 +1746,9 @@ let () =
             "bootstrap base-path config copies versioned config"
             `Quick test_bootstrap_base_path_config_root_copies_versioned_config;
           Alcotest.test_case
-            "bootstrap base-path config repairs partial root"
-            `Quick test_bootstrap_base_path_config_root_repairs_partial_root;
+            "bootstrap base-path config preserves existing root without refill"
+            `Quick
+            test_bootstrap_base_path_config_root_preserves_existing_root_without_refill;
           Alcotest.test_case
             "bootstrap base-path config skips explicit override"
             `Quick


### PR DESCRIPTION
## What changed
- stop server bootstrap from re-filling an existing `<base_path>/.masc/config` from repo `config/`
- keep a minimal scaffold (`prompts/`, `keepers/`, `personas/`) when the local config root already exists
- update runtime bootstrap tests to lock the new behavior in place

## Why
Deleting keepers or personas under the active base-path config looked like a real operator action, but the next startup copied repo seed files back in. That resurrected deleted keepers/personas and made local config behave like a cache instead of the source of truth.

## Behavior change
- fresh base paths still get a full seed from versioned repo config
- existing base-path config roots are now preserved as-is
- missing keeper/persona/prompt directories are recreated empty, but deleted repo-backed files are not restored

## Validation
- `dune build --root . test/test_server_runtime_bootstrap.exe`
- `dune build --root . bin/main_eio.exe test/test_server_runtime_bootstrap.exe`
- `./_build/default/test/test_server_runtime_bootstrap.exe`

## Notes
- `test_server_runtime_bootstrap` case 40 is already failing on `main` and is tracked separately in #9476
