### PR TITLE
[codex] Add cascade source editor and keeper assignment

### DIFF
--- a/dashboard/src/api/dashboard-cascade.test.ts
+++ b/dashboard/src/api/dashboard-cascade.test.ts
@@ -3,6 +3,7 @@ import {
   fetchCascadeClientCapacityHistory,
   fetchCascadeConfig as fetchCascadeConfigFromCascade,
   fetchCascadeStrategyTrace,
+  updateCascadeConfigRaw,
   updateKeeperCascade,
 } from './dashboard-cascade'
 import { fetchCascadeConfig as fetchCascadeConfigFromDashboard } from './dashboard'
@@ -75,5 +76,34 @@ describe('dashboard cascade split', () => {
       cascade_name: 'big_three',
     }))
     expect(result.ok).toBe(true)
+  })
+
+  it('posts cascade source edits as source_text', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        updated_at: '2026-04-22T00:00:00Z',
+        config_path: '/tmp/config/cascade.json',
+        source_kind: 'toml',
+        source_path: '/tmp/config/cascade.toml',
+        validation_status: 'validated',
+        validation_errors: [],
+        invalid_profiles: [],
+        profiles: [],
+        keeper_profiles: [],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await updateCascadeConfigRaw('[big_three]\nmodels = ["glm-coding:auto"]\n')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/cascade/config/raw')
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({ method: 'POST' })
+    expect(fetchMock.mock.calls[0]?.[1]?.body).toBe(JSON.stringify({
+      source_text: '[big_three]\nmodels = ["glm-coding:auto"]\n',
+    }))
   })
 })

--- a/dashboard/src/api/dashboard-cascade.ts
+++ b/dashboard/src/api/dashboard-cascade.ts
@@ -72,6 +72,8 @@ export interface CascadeRawConfigResponse {
   config_path: string | null
   source_kind: 'json' | 'toml'
   source_path: string
+  source_editable: boolean
+  source_text: string
   raw_json_editable: boolean
   raw_json: string
 }
@@ -113,8 +115,8 @@ export function fetchCascadeConfigRaw(
   })
 }
 
-export function updateCascadeConfigRaw(raw_json: string): Promise<CascadeConfigResponse> {
-  return post<CascadeConfigResponse>('/api/v1/cascade/config/raw', { raw_json })
+export function updateCascadeConfigRaw(source_text: string): Promise<CascadeConfigResponse> {
+  return post<CascadeConfigResponse>('/api/v1/cascade/config/raw', { source_text })
 }
 
 export function fetchCascadeHealth(

--- a/dashboard/src/components/cascade-config-panel.test.ts
+++ b/dashboard/src/components/cascade-config-panel.test.ts
@@ -19,7 +19,9 @@ import {
   keepersWithUnknownCanonical,
   profileSummaryText,
   profileKeeperAssignmentNote,
+  availableKeeperAssignments,
   rawConfigModeSummary,
+  validateSourceConfigText,
 } from './cascade-config-panel'
 import type {
   CascadeCandidate,
@@ -105,6 +107,8 @@ function makeRawConfig(
     config_path: '/tmp/config/cascade.json',
     source_kind: 'json',
     source_path: '/tmp/config/cascade.json',
+    source_editable: true,
+    source_text: '{}',
     raw_json_editable: true,
     raw_json: '{}',
     ...overrides,
@@ -188,7 +192,7 @@ describe('catalogSourceSummary', () => {
 })
 
 describe('rawConfigModeSummary', () => {
-  it('marks TOML-backed raw config as read-only generated view', () => {
+  it('marks TOML-backed config as editable source plus generated preview', () => {
     const summary = rawConfigModeSummary(
       makeRawConfig({
         source_kind: 'toml',
@@ -198,15 +202,18 @@ describe('rawConfigModeSummary', () => {
     )
     expect(summary.title).toContain('TOML SSOT')
     expect(summary.primary).toContain('/tmp/config/cascade.toml')
-    expect(summary.primary).toContain('generated cascade.json')
-    expect(summary.saveLabel).toBe('TOML-backed (read-only)')
+    expect(summary.primary).toContain('cascade.toml SSOT')
+    expect(summary.secondary).toContain('/tmp/config/cascade.json')
+    expect(summary.saveLabel).toBe('Save cascade.toml')
+    expect(summary.previewTitle).toBe('Generated cascade.json Preview')
   })
 
   it('keeps JSON mode editable', () => {
     const summary = rawConfigModeSummary(makeRawConfig())
-    expect(summary.title).toBe('Raw cascade.json Editor')
+    expect(summary.title).toBe('Active Cascade Source Editor')
     expect(summary.primary).toContain('/tmp/config/cascade.json')
     expect(summary.saveLabel).toBe('Save cascade.json')
+    expect(summary.previewTitle).toBeNull()
   })
 })
 
@@ -570,5 +577,41 @@ describe('profileKeeperAssignmentNote', () => {
     expect(profileKeeperAssignmentNote(profile, assignedKeepers)).toBe(
       'manual/system-only profile; current keepers still reference it',
     )
+  })
+})
+
+describe('availableKeeperAssignments', () => {
+  const assigned = groupKeepersByCanonicalCascade([
+    {
+      keeper: 'alice',
+      cascade_name: 'keeper_unified',
+      canonical: 'keeper_unified',
+    },
+  ]).get('keeper_unified') ?? []
+
+  it('returns sorted keepers not already assigned to the profile', () => {
+    expect(availableKeeperAssignments(['carol', 'alice', 'bob'], assigned)).toEqual([
+      'bob',
+      'carol',
+    ])
+  })
+
+  it('deduplicates repeated keeper names', () => {
+    expect(availableKeeperAssignments(['bob', 'bob', 'alice'], assigned)).toEqual(['bob'])
+  })
+})
+
+describe('validateSourceConfigText', () => {
+  it('validates JSON source client-side', () => {
+    expect(validateSourceConfigText(makeRawConfig(), '{ invalid')).not.toBeNull()
+  })
+
+  it('skips client-side syntax validation for TOML source', () => {
+    expect(
+      validateSourceConfigText(
+        makeRawConfig({ source_kind: 'toml', source_path: '/tmp/config/cascade.toml' }),
+        '[broken',
+      ),
+    ).toBeNull()
   })
 })

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -10,6 +10,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useRef } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
+import { fetchGateKeepers, type GateKeeperInfo } from '../api/gate'
 import {
   fetchCascadeClientCapacity,
   fetchCascadeClientCapacityHistory,
@@ -19,6 +20,7 @@ import {
   fetchCascadeConfigRaw,
   fetchCascadeHealth,
   updateCascadeConfigRaw,
+  updateKeeperCascade,
   type CascadeCandidate,
   type CascadeCapacityEventKind,
   type CascadeClientCapacityEntry,
@@ -50,6 +52,7 @@ import { createManagedAsyncResource, type ManagedAsyncResource } from '../lib/as
 interface CascadeData {
   config: CascadeConfigResponse | null
   rawConfig: CascadeRawConfigResponse | null
+  gateKeepers: GateKeeperInfo[]
   health: CascadeHealthResponse | null
   capacity: CascadeClientCapacityResponse | null
   history: CascadeClientCapacityHistoryResponse | null
@@ -59,16 +62,23 @@ interface CascadeData {
 
 async function loadCascadeData(resource: ManagedAsyncResource<CascadeData>) {
   await resource.load(async (signal) => {
-    const [config, rawConfig, health, capacity, history, trace, slo] = await Promise.all([
+    const gateKeepersPromise = fetchGateKeepers(signal)
+      .then(data => data.keepers)
+      .catch((error) => {
+        if (signal.aborted) throw error
+        return []
+      })
+    const [config, rawConfig, gateKeepers, health, capacity, history, trace, slo] = await Promise.all([
       fetchCascadeConfig({ signal }),
       fetchCascadeConfigRaw({ signal }),
+      gateKeepersPromise,
       fetchCascadeHealth({ signal }),
       fetchCascadeClientCapacity({ signal }),
       fetchCascadeClientCapacityHistory({ limit: 50, signal }),
       fetchCascadeStrategyTrace({ limit: 50, signal }),
       fetchCascadeSlo({ signal }),
     ])
-    return { config, rawConfig, health, capacity, history, trace, slo }
+    return { config, rawConfig, gateKeepers, health, capacity, history, trace, slo }
   })
 }
 
@@ -116,33 +126,38 @@ interface RawConfigModeSummary {
   primary: string
   secondary: string
   saveLabel: string
+  previewTitle: string | null
 }
 
 export function rawConfigModeSummary(
-  raw: Pick<CascadeRawConfigResponse, 'raw_json_editable' | 'source_path' | 'config_path'> | null,
+  raw: Pick<
+    CascadeRawConfigResponse,
+    'source_kind' | 'source_path' | 'config_path'
+  > | null,
 ): RawConfigModeSummary {
-  const rawEditable = raw?.raw_json_editable !== false
   const sourcePath = raw?.source_path ?? raw?.config_path ?? 'unresolved'
   const jsonPath = raw?.config_path ?? 'unresolved'
-  if (rawEditable) {
+  if (raw?.source_kind !== 'toml') {
     return {
-      title: 'Raw cascade.json Editor',
+      title: 'Active Cascade Source Editor',
       primary:
-        `dashboard에서 직접 cascade.json을 수정합니다. 저장 경로는 ${jsonPath} 이고, ` +
+        `dashboard에서 직접 ${sourcePath} 를 수정합니다. 저장 경로는 ${jsonPath} 이고, ` +
         '저장 후 current cascade snapshot 을 다시 읽습니다.',
       secondary:
         'semantics invalid profile 도 저장은 허용됩니다. 저장 후 위의 validation banner 에서 invalid/last-known-good 상태를 바로 확인하면 됩니다.',
       saveLabel: 'Save cascade.json',
+      previewTitle: null,
     }
   }
   return {
-    title: 'Generated cascade.json View (TOML SSOT)',
+    title: 'Active Cascade Source Editor (TOML SSOT)',
     primary:
-      `현재 active source는 ${sourcePath} 의 cascade.toml SSOT 라서 이 editor는 read-only 입니다. ` +
-      '아래 내용은 generated cascade.json runtime artifact 입니다.',
+      `현재 active source는 ${sourcePath} 이고, 이 editor에서 직접 cascade.toml SSOT 를 수정합니다. ` +
+      '저장 시 TOML parse 검증 뒤 generated runtime JSON을 다시 materialize 합니다.',
     secondary:
-      '수정은 cascade.toml source에서 하고, 여기서는 materialized runtime JSON만 확인합니다.',
-    saveLabel: 'TOML-backed (read-only)',
+      `아래 preview는 ${jsonPath} 에 기록되는 generated cascade.json runtime artifact 입니다.`,
+    saveLabel: 'Save cascade.toml',
+    previewTitle: 'Generated cascade.json Preview',
   }
 }
 
@@ -170,6 +185,30 @@ export function profileKeeperAssignmentNote(
   }
   if (keepers.length === 0) return 'no keepers assigned'
   return null
+}
+
+export function availableKeeperAssignments(
+  keeperNames: readonly string[],
+  keepers: readonly KeeperCascadeRow[],
+): string[] {
+  const assigned = new Set(keepers.map(keeper => keeper.keeper))
+  return Array.from(
+    new Set(
+      keeperNames
+        .map(name => name.trim())
+        .filter(Boolean)
+        .filter(name => !assigned.has(name)),
+    ),
+  ).sort((left, right) => left.localeCompare(right))
+}
+
+export function validateSourceConfigText(
+  raw: Pick<CascadeRawConfigResponse, 'source_kind'> | null,
+  sourceText: string,
+): string | null {
+  if (!raw) return null
+  if (raw?.source_kind === 'toml') return null
+  return validateJsonText(sourceText)
 }
 
 function validationTone(status: CascadeValidationStatus): 'ok' | 'warn' | 'bad' {
@@ -294,9 +333,41 @@ function KeeperChip({ row }: { row: KeeperCascadeRow }) {
 function ProfileCard({
   profile,
   keepers,
-}: { profile: CascadeProfile; keepers: readonly KeeperCascadeRow[] }) {
+  keeperNames,
+  onAssignKeeper,
+}: {
+  profile: CascadeProfile
+  keepers: readonly KeeperCascadeRow[]
+  keeperNames: readonly string[]
+  onAssignKeeper: (keeperName: string, cascadeName: string) => Promise<void>
+}) {
   const driftCount = keepers.reduce((n, k) => n + (k.drift ? 1 : 0), 0)
   const assignmentNote = profileKeeperAssignmentNote(profile, keepers)
+  const availableKeepers = availableKeeperAssignments(keeperNames, keepers)
+  const selectedKeeper = useSignal(availableKeepers[0] ?? '')
+  const assignmentMessage = useSignal<string | null>(null)
+  const assigning = useSignal(false)
+
+  useEffect(() => {
+    if (availableKeepers.includes(selectedKeeper.value)) return
+    selectedKeeper.value = availableKeepers[0] ?? ''
+  }, [profile.name, availableKeepers.join('\u0000')])
+
+  const handleAssignKeeper = async (event: Event) => {
+    event.preventDefault()
+    if (!profile.keeper_assignable || !selectedKeeper.value) return
+    assigning.value = true
+    assignmentMessage.value = null
+    try {
+      await onAssignKeeper(selectedKeeper.value, profile.name)
+      assignmentMessage.value = `${selectedKeeper.value} → ${profile.name}`
+    } catch (error) {
+      assignmentMessage.value = `Failed to assign: ${errorMessage(error)}`
+    } finally {
+      assigning.value = false
+    }
+  }
+
   return html`
     <article class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] p-3">
       <header class="flex items-center gap-2 mb-2 flex-wrap">
@@ -322,6 +393,64 @@ function ProfileCard({
           <div class="flex flex-wrap gap-1 mb-2">
             ${keepers.map(k => html`<${KeeperChip} row=${k} />`)}
           </div>
+        `
+        : null}
+      ${profile.keeper_assignable
+        ? html`
+          <form
+            class="rounded border border-[var(--card-border)] bg-[var(--bg-panel)] p-2 mb-3"
+            onSubmit=${handleAssignKeeper}
+          >
+            <div class="flex items-center gap-2 flex-wrap mb-2">
+              <span class="text-xs font-medium text-[var(--text-strong)]">Keeper assignment</span>
+              <span class="text-xs text-[var(--text-muted)]">
+                current profile로 keeper를 이동합니다.
+              </span>
+            </div>
+            ${availableKeepers.length > 0
+              ? html`
+                <div class="flex items-center gap-2 flex-wrap">
+                  <select
+                    class="min-w-44 rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)]"
+                    value=${selectedKeeper.value}
+                    disabled=${assigning.value}
+                    onChange=${(event: Event) => {
+                      selectedKeeper.value = (event.target as HTMLSelectElement).value
+                      assignmentMessage.value = null
+                    }}
+                  >
+                    ${availableKeepers.map(name => html`
+                      <option value=${name}>${name}</option>
+                    `)}
+                  </select>
+                  <button
+                    type="submit"
+                    class="rounded border border-[var(--accent-primary)] bg-[var(--accent-primary)] px-3 py-1 text-xs font-medium text-white hover:opacity-90 disabled:opacity-50"
+                    disabled=${assigning.value || selectedKeeper.value === ''}
+                  >
+                    ${assigning.value ? 'Assigning...' : 'Assign keeper'}
+                  </button>
+                </div>
+              `
+              : html`
+                <div class="text-xs text-[var(--text-muted)]">
+                  currently known keepers are already assigned to this profile.
+                </div>
+              `}
+            ${assignmentMessage.value
+              ? html`
+                <div
+                  class=${`mt-2 text-xs ${
+                    assignmentMessage.value.startsWith('Failed')
+                      ? 'text-[var(--bad-light)]'
+                      : 'text-[var(--text-muted)]'
+                  }`}
+                >
+                  ${assignmentMessage.value}
+                </div>
+              `
+              : null}
+          </form>
         `
         : null}
       ${profile.candidates.length === 0
@@ -824,34 +953,34 @@ function CascadeRawConfigEditor({
   raw: CascadeRawConfigResponse | null
   onRefresh: () => Promise<void>
 }) {
-  const editorText = useSignal(raw?.raw_json ?? '')
+  const editorText = useSignal(raw?.source_text ?? raw?.raw_json ?? '')
   const editorDirty = useSignal(false)
   const saving = useSignal(false)
   const saveMessage = useSignal<string | null>(null)
   const mode = rawConfigModeSummary(raw)
-  const rawEditable = raw?.raw_json_editable !== false
+  const sourceEditable = raw?.source_editable !== false
 
   useEffect(() => {
     if (!raw || editorDirty.value) return
-    editorText.value = raw.raw_json
-  }, [raw?.config_path, raw?.updated_at, raw?.raw_json])
+    editorText.value = raw.source_text
+  }, [raw?.config_path, raw?.updated_at, raw?.source_path, raw?.source_text])
 
-  const syntaxError = validateJsonText(editorText.value)
+  const syntaxError = validateSourceConfigText(raw, editorText.value)
   const saveDisabled = saving.value
     || !editorDirty.value
-    || !rawEditable
+    || !sourceEditable
     || raw?.config_path == null
     || syntaxError != null
 
   const handleReset = () => {
-    editorText.value = raw?.raw_json ?? ''
+    editorText.value = raw?.source_text ?? raw?.raw_json ?? ''
     editorDirty.value = false
-    saveMessage.value = 'Latest disk snapshot restored in the editor.'
+    saveMessage.value = 'Latest source snapshot restored in the editor.'
   }
 
   const handleSave = async (event: Event) => {
     event.preventDefault()
-    const currentSyntaxError = validateJsonText(editorText.value)
+    const currentSyntaxError = validateSourceConfigText(raw, editorText.value)
     if (currentSyntaxError) {
       saveMessage.value = `Invalid JSON: ${currentSyntaxError}`
       return
@@ -860,8 +989,8 @@ function CascadeRawConfigEditor({
       saveMessage.value = 'Resolved cascade config path is unavailable.'
       return
     }
-    if (!rawEditable) {
-      saveMessage.value = `Active source is TOML: edit ${raw?.source_path ?? raw?.config_path ?? 'unresolved'}`
+    if (!sourceEditable) {
+      saveMessage.value = `Active source is not editable: ${raw?.source_path ?? raw?.config_path ?? 'unresolved'}`
       return
     }
     saving.value = true
@@ -895,7 +1024,7 @@ function CascadeRawConfigEditor({
           <textarea
             class="h-96 w-full rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-2 font-mono text-xs text-[var(--text-strong)]"
             spellcheck="false"
-            readonly=${!rawEditable}
+            readonly=${!sourceEditable}
             value=${editorText.value}
             onInput=${(event: Event) => {
               editorText.value = (event.target as HTMLTextAreaElement).value
@@ -910,7 +1039,11 @@ function CascadeRawConfigEditor({
             </span>
             ${syntaxError
               ? html`<span class="text-[var(--bad-light)]">syntax: ${syntaxError}</span>`
-              : html`<span class="text-[var(--ok)]">syntax: valid JSON</span>`}
+              : html`
+                <span class="text-[var(--ok)]">
+                  ${raw?.source_kind === 'toml' ? 'syntax: validated on save (TOML)' : 'syntax: valid JSON'}
+                </span>
+              `}
             ${saveMessage.value
               ? html`
                 <span class=${saveMessage.value.startsWith('Failed') || saveMessage.value.startsWith('Invalid')
@@ -949,6 +1082,24 @@ function CascadeRawConfigEditor({
             </button>
           </div>
         </form>
+        ${mode.previewTitle
+          ? html`
+            <div class="flex flex-col gap-2">
+              <div class="text-xs font-medium text-[var(--text-strong)]">
+                ${mode.previewTitle}
+              </div>
+              <div class="text-xs text-[var(--text-muted)]">
+                ${raw?.config_path ?? 'unresolved'}
+              </div>
+              <textarea
+                class="h-72 w-full rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-2 font-mono text-xs text-[var(--text-strong)]"
+                spellcheck="false"
+                readonly
+                value=${raw?.raw_json ?? ''}
+              />
+            </div>
+          `
+          : null}
       </div>
     <//>
   `
@@ -972,6 +1123,7 @@ export function CascadeConfigPanel() {
   const current = resource.state.value
   const config = current.data?.config ?? null
   const rawConfig = current.data?.rawConfig ?? null
+  const gateKeepers = current.data?.gateKeepers ?? []
   const health = current.data?.health ?? null
   const capacity = current.data?.capacity ?? null
   const history = current.data?.history ?? null
@@ -1004,6 +1156,10 @@ export function CascadeConfigPanel() {
           ? (() => {
               const keeperGroups = groupKeepersByCanonicalCascade(config.keeper_profiles)
               const orphans = keepersWithUnknownCanonical(config.profiles, config.keeper_profiles)
+              const keeperNames = Array.from(new Set([
+                ...gateKeepers.map(keeper => keeper.name),
+                ...config.keeper_profiles.map(keeper => keeper.keeper),
+              ])).sort((left, right) => left.localeCompare(right))
               const driftTotal = config.keeper_profiles.reduce(
                 (n, k) => n + (k.cascade_name !== k.canonical ? 1 : 0),
                 0,
@@ -1032,7 +1188,15 @@ export function CascadeConfigPanel() {
                   : html`
                     <div class="grid gap-3 md:grid-cols-2 mb-3">
                       ${config.profiles.map(p => html`
-                        <${ProfileCard} profile=${p} keepers=${keeperGroups.get(p.name) ?? []} />
+                        <${ProfileCard}
+                          profile=${p}
+                          keepers=${keeperGroups.get(p.name) ?? []}
+                          keeperNames=${keeperNames}
+                          onAssignKeeper=${async (keeperName: string, cascadeName: string) => {
+                            await updateKeeperCascade(keeperName, cascadeName)
+                            await loadCascadeData(resource)
+                          }}
+                        />
                       `)}
                     </div>
                   `}

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -274,6 +274,14 @@ let load_raw_config_string path =
   else
     default_raw_config_json
 
+let invalidate_cascade_config config_path =
+  Cascade_config_loader.invalidate_cache_entry config_path;
+  Cascade_catalog_runtime.invalidate_path config_path
+
+let save_config_file path content =
+  Fs_compat.mkdir_p (Filename.dirname path);
+  Fs_compat.save_file_atomic path content
+
 let raw_config_json () =
   Config_dir_resolver.log_warnings ~context:"DashboardCascade" ();
   let source : Cascade_toml_materializer.source_info = source_info () in
@@ -281,6 +289,15 @@ let raw_config_json () =
   let _ =
     Cascade_toml_materializer.ensure_materialized_json
       ~config_path:source.json_path
+  in
+  let source_text =
+    try load_raw_config_string source.source_path with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | Sys_error msg ->
+        Log.Keeper.warn
+          "dashboard cascade source config: failed to read %s: %s"
+          source.source_path msg;
+        ""
   in
   let raw_json =
     match config_path with
@@ -302,6 +319,8 @@ let raw_config_json () =
         `String
           (Cascade_toml_materializer.source_kind_to_string source.kind) );
       ("source_path", `String source.source_path);
+      ("source_editable", `Bool true);
+      ("source_text", `String source_text);
       ("raw_json_editable", `Bool source.raw_json_editable);
       ("raw_json", `String raw_json);
     ]
@@ -310,37 +329,51 @@ let save_raw_config_json raw_json =
   Config_dir_resolver.log_warnings ~context:"DashboardCascade" ();
   let source : Cascade_toml_materializer.source_info = source_info () in
   let config_path = source.json_path in
-  if not source.raw_json_editable then
-    Error
-      (Printf.sprintf
-         "active cascade source is TOML: edit %s instead of %s"
-         source.source_path source.json_path)
-  else
-    let parse_result =
-      try
-        ignore (Yojson.Safe.from_string raw_json);
-        Ok ()
-      with
-      | Yojson.Json_error msg ->
-          Error (Printf.sprintf "invalid JSON: %s" msg)
-      | exn ->
-          Error
-            (Printf.sprintf "failed to parse JSON: %s" (Printexc.to_string exn))
-    in
-    match parse_result with
-    | Error _ as err -> err
-    | Ok () -> (
+  match source.kind with
+  | Cascade_toml_materializer.Json ->
+      let parse_result =
         try
-          Fs_compat.mkdir_p (Filename.dirname config_path);
-          match Fs_compat.save_file_atomic config_path raw_json with
-          | Error msg -> Error msg
-          | Ok () ->
-              Cascade_config_loader.invalidate_cache_entry config_path;
-              Cascade_catalog_runtime.invalidate_path config_path;
-              Ok (config_json ())
+          ignore (Yojson.Safe.from_string raw_json);
+          Ok ()
         with
-        | Eio.Cancel.Cancelled _ as exn -> raise exn
-        | Sys_error msg -> Error msg)
+        | Yojson.Json_error msg ->
+            Error (Printf.sprintf "invalid JSON: %s" msg)
+        | exn ->
+            Error
+              (Printf.sprintf "failed to parse JSON: %s" (Printexc.to_string exn))
+      in
+      (match parse_result with
+       | Error _ as err -> err
+       | Ok () -> (
+           try
+             match save_config_file config_path raw_json with
+             | Error msg -> Error msg
+             | Ok () ->
+                 invalidate_cascade_config config_path;
+                 Ok (config_json ())
+           with
+           | Eio.Cancel.Cancelled _ as exn -> raise exn
+           | Sys_error msg -> Error msg))
+  | Cascade_toml_materializer.Toml -> (
+      match Cascade_toml_materializer.render_toml_string_to_json_string raw_json with
+      | Error msg ->
+          Error (Printf.sprintf "invalid TOML: %s" msg)
+      | Ok _rendered_json -> (
+          try
+            match save_config_file source.source_path raw_json with
+            | Error msg -> Error msg
+            | Ok () -> (
+                match
+                  Cascade_toml_materializer.ensure_materialized_json
+                    ~config_path:config_path
+                with
+                | Error msg -> Error msg
+                | Ok _ ->
+                    invalidate_cascade_config config_path;
+                    Ok (config_json ()))
+          with
+          | Eio.Cancel.Cancelled _ as exn -> raise exn
+          | Sys_error msg -> Error msg))
 
 (* ── Health projection ──────────────────────────────── *)
 

--- a/lib/dashboard_cascade.mli
+++ b/lib/dashboard_cascade.mli
@@ -58,30 +58,39 @@ val config_json : unit -> Yojson.Safe.t
         "config_path": "/path/to/cascade.json" | null,
         "source_kind": "json" | "toml",
         "source_path": "/path/to/cascade.json" | "/path/to/cascade.toml",
+        "source_editable": true,
+        "source_text": "{ ... }\n" | "comment = ...\n[profile]\n...",
         "raw_json_editable": true | false,
         "raw_json": "{ ... }\n"
       }
     ]}
 
+    [source_text] is the editable active source file content. In JSON mode it
+    matches [raw_json]; in TOML mode it is the live [cascade.toml] source while
+    [raw_json] remains the generated runtime [cascade.json] preview.
+
     [config_path] is the resolver's candidate [cascade.json] path under the
     active config root, even when the file does not exist yet. In that missing
-    file case, [raw_json] defaults to ["{}\n"] so operators can bootstrap a
-    config from the dashboard editor. When [source_kind] is ["toml"], the raw
-    JSON remains readable as the generated runtime artifact but
-    [raw_json_editable] is [false] and writes are blocked.
+    JSON-file case, both [source_text] and [raw_json] default to ["{}\n"] so
+    operators can bootstrap a config from the dashboard editor. When
+    [source_kind] is ["toml"], [raw_json_editable] stays [false] because the
+    preview is generated, but [source_editable] remains [true].
 
     @since 0.160.1 *)
 val raw_config_json : unit -> Yojson.Safe.t
 
-(** Validate and persist a raw [cascade.json] payload to the resolved config
-    root, then return the refreshed {!config_json} snapshot.
+(** Validate and persist the active cascade authoring source, then return the
+    refreshed {!config_json} snapshot.
 
-    The input must be syntactically valid JSON. Semantic validation is not a
-    hard gate here: invalid cascades are still written and surfaced through the
-    returned validation metadata so the runtime can continue serving the last
-    known good snapshot. Missing parent directories are created on demand under
-    the active config root. Returns [Error _] when [cascade.toml] is the active
-    source because the dashboard must not overwrite generated [cascade.json].
+    In JSON mode, the input must be syntactically valid JSON and is written to
+    the active [cascade.json]. In TOML mode, the input must be syntactically
+    valid TOML and is written to the active [cascade.toml], after which the
+    generated runtime [cascade.json] is materialized from that source.
+
+    Semantic validation is not a hard gate here: invalid cascades are still
+    written and surfaced through the returned validation metadata so the
+    runtime can continue serving the last known good snapshot. Missing parent
+    directories are created on demand under the active config root.
 
     @since 0.160.1 *)
 val save_raw_config_json :

--- a/lib/server/server_routes_http_routes_cascade.ml
+++ b/lib/server/server_routes_http_routes_cascade.ml
@@ -21,16 +21,19 @@ let parse_history_since request =
   | None -> None
   | Some s -> float_of_string_opt (String.trim s)
 
-let raw_json_of_body body_str =
+let config_source_text_of_body body_str =
   match Yojson.Safe.from_string body_str with
   | `Assoc fields -> (
-      match List.assoc_opt "raw_json" fields with
-      | Some (`String raw_json) -> Ok raw_json
-      | _ -> Error "expected JSON body with string field raw_json")
+      match List.assoc_opt "source_text" fields with
+      | Some (`String source_text) -> Ok source_text
+      | Some _ -> Error "expected JSON body with string field source_text"
+      | None -> (
+          match List.assoc_opt "raw_json" fields with
+          | Some (`String raw_json) -> Ok raw_json
+          | _ ->
+              Error
+                "expected JSON body with string field source_text"))
   | _ -> Error "expected JSON object body"
-
-let is_toml_source_error msg =
-  String.starts_with ~prefix:"active cascade source is TOML" msg
 
 let add_routes router =
   router
@@ -56,7 +59,7 @@ let add_routes router =
                     (`Assoc [ ("ok", `Bool false); ("error", `String message) ]))
                  reqd
              in
-             match raw_json_of_body body_str with
+             match config_source_text_of_body body_str with
              | exception Yojson.Json_error msg ->
                  response `Bad_request ("invalid JSON body: " ^ msg)
              | Error msg ->
@@ -67,10 +70,7 @@ let add_routes router =
                      Http.Response.json ~request:req
                        (Yojson.Safe.to_string json) reqd
                  | Error msg ->
-                     response
-                       (if is_toml_source_error msg then `Conflict
-                        else `Bad_request)
-                       msg))
+                     response `Bad_request msg))
          ) request reqd)
   |> Http.Router.get "/api/v1/cascade/health" (fun request reqd ->
        with_public_read (fun _state req reqd ->

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -278,6 +278,7 @@ let test_raw_config_shape () =
     (fun cascade_path ->
       let j = Masc_mcp.Dashboard_cascade.raw_config_json () in
       let raw_json = Yojson.Safe.Util.(j |> member "raw_json" |> to_string) in
+      let source_text = Yojson.Safe.Util.(j |> member "source_text" |> to_string) in
       (match member "updated_at" j with
        | `String _ -> ()
        | _ -> fail "updated_at should be string");
@@ -288,8 +289,12 @@ let test_raw_config_shape () =
         Yojson.Safe.Util.(j |> member "source_kind" |> to_string);
       check string "json source path" cascade_path
         Yojson.Safe.Util.(j |> member "source_path" |> to_string);
+      check bool "source remains editable" true
+        Yojson.Safe.Util.(j |> member "source_editable" |> to_bool);
       check bool "json raw is editable" true
         Yojson.Safe.Util.(j |> member "raw_json_editable" |> to_bool);
+      check bool "source_text includes current file contents" true
+        (contains_substring source_text "big_three_models");
       check bool "raw_json includes current file contents" true
         (contains_substring raw_json "big_three_models"))
 
@@ -303,11 +308,14 @@ let test_raw_config_defaults_when_file_missing () =
         Yojson.Safe.Util.(j |> member "config_path" |> to_string_option);
       check bool "still editable in json mode" true
         Yojson.Safe.Util.(j |> member "raw_json_editable" |> to_bool);
+      check string "missing source file seeds default object"
+        "{}\n"
+        Yojson.Safe.Util.(j |> member "source_text" |> to_string);
       check string "missing file seeds default object"
         "{}\n"
         Yojson.Safe.Util.(j |> member "raw_json" |> to_string))
 
-let test_raw_config_toml_source_is_read_only () =
+let test_raw_config_toml_source_exposes_editable_source_and_preview () =
   let toml =
     {|
 comment = "test"
@@ -329,8 +337,14 @@ models = ["ollama:qwen3.5:35b-a3b-nvfp4"]
         Yojson.Safe.Util.(j |> member "source_kind" |> to_string);
       check string "toml source path" toml_path
         Yojson.Safe.Util.(j |> member "source_path" |> to_string);
-      check bool "read-only when toml active" false
+      check bool "source stays editable in toml mode" true
+        Yojson.Safe.Util.(j |> member "source_editable" |> to_bool);
+      check bool "generated json preview stays read-only" false
         Yojson.Safe.Util.(j |> member "raw_json_editable" |> to_bool);
+      check bool "source text surfaces toml contents" true
+        (contains_substring
+           Yojson.Safe.Util.(j |> member "source_text" |> to_string)
+           "[big_three]");
       check bool "generated runtime json visible" true
         (contains_substring
            Yojson.Safe.Util.(j |> member "raw_json" |> to_string)
@@ -376,7 +390,7 @@ let test_save_raw_config_json_persists_and_refreshes_projection () =
             next_raw
             (read_file cascade_path))
 
-let test_save_raw_config_json_rejects_toml_source () =
+let test_save_raw_config_json_rejects_invalid_toml () =
   let toml =
     {|
 [big_three]
@@ -388,12 +402,48 @@ models = ["ollama:qwen3.5:35b-a3b-nvfp4"]
     (fun _dir ->
       match
         Masc_mcp.Dashboard_cascade.save_raw_config_json
-          {|{"beta_models":["ollama:qwen3.5:35b-a3b-nvfp4"]}|}
+          {|
+[broken
+models = ["ollama:qwen3.5:35b-a3b-nvfp4"]
+|}
       with
-      | Ok _ -> fail "toml-backed source should reject raw json save"
+      | Ok _ -> fail "invalid TOML should be rejected"
       | Error msg ->
-          check bool "error mentions TOML source" true
-            (contains_substring msg "active cascade source is TOML"))
+          check bool "error mentions invalid TOML" true
+            (contains_substring msg "invalid TOML"))
+
+let test_save_raw_config_json_persists_toml_source_and_materializes_json () =
+  let toml =
+    {|
+[alpha]
+models = ["ollama:qwen3.5:35b-a3b-nvfp4"]
+|}
+  in
+  with_temp_config_root_setup
+    (fun dir -> write_file (Filename.concat dir "cascade.toml") toml)
+    (fun dir ->
+      let toml_path = Filename.concat dir "cascade.toml" in
+      let json_path = Filename.concat dir "cascade.json" in
+      let next_toml =
+        {|
+comment = "edited in dashboard"
+
+[beta_editor]
+models = ["ollama:qwen3.5:35b-a3b-nvfp4"]
+|}
+      in
+      match Masc_mcp.Dashboard_cascade.save_raw_config_json next_toml with
+      | Error msg -> fail ("save_raw_config_json failed for TOML source: " ^ msg)
+      | Ok saved_config ->
+          check bool "new profile visible immediately after save" true
+            (List.mem "beta_editor" (profile_names saved_config));
+          check bool "old profile removed after save" false
+            (List.mem "alpha" (profile_names saved_config));
+          check string "toml source persisted verbatim"
+            next_toml
+            (read_file toml_path);
+          check bool "materialized json refreshed" true
+            (contains_substring (read_file json_path) "beta_editor_models"))
 
 (* ── health_json ───────────────────────────────────── *)
 
@@ -625,14 +675,16 @@ let () =
       test_case "top-level shape" `Quick test_raw_config_shape;
       test_case "missing file seeds default object" `Quick
         test_raw_config_defaults_when_file_missing;
-      test_case "toml source is read-only" `Quick
-        test_raw_config_toml_source_is_read_only;
+      test_case "toml source exposes editable source + preview" `Quick
+        test_raw_config_toml_source_exposes_editable_source_and_preview;
       test_case "invalid JSON is rejected" `Quick
         test_save_raw_config_json_rejects_invalid_json;
-      test_case "toml source rejects save" `Quick
-        test_save_raw_config_json_rejects_toml_source;
+      test_case "invalid TOML is rejected" `Quick
+        test_save_raw_config_json_rejects_invalid_toml;
       test_case "save persists and refreshes config projection" `Quick
         test_save_raw_config_json_persists_and_refreshes_projection;
+      test_case "toml source save persists + materializes json" `Quick
+        test_save_raw_config_json_persists_toml_source_and_materializes_json;
     ];
     "health_json", [
       test_case "top-level shape" `Quick test_health_shape;


### PR DESCRIPTION
## What changed
- add dashboard authoring support for the active cascade source so JSON-backed setups edit `cascade.json` directly and TOML-backed setups edit `cascade.toml` directly
- keep the generated runtime `cascade.json` visible as a preview when TOML is the SSOT
- add profile-centric keeper assignment controls to the cascade routing panel using the existing keeper cascade update route
- extend dashboard/backend tests to cover TOML save + materialization, source editor contract changes, and assignment helpers

## Why
The dashboard could only edit raw `cascade.json`, which made TOML-backed deployments effectively read-only from the UI. Keeper assignment also lived only in the per-keeper config view, which made profile-oriented routing changes slower than they needed to be.

## Impact
- operators can edit `cascade.toml` from the dashboard without dropping to the filesystem
- operators can reassign keepers from the cascade profile view directly
- TOML saves validate syntax before persisting and immediately re-materialize the runtime `cascade.json`

## Validation
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/cascade-editor-keeper-assign ./test/test_dashboard_cascade.exe`
- `pnpm typecheck`
- `./node_modules/.bin/vitest run src/api/dashboard-cascade.test.ts src/components/cascade-config-panel.test.ts`
