### PR TITLE
[codex] Remove retired PG bootstrap path

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -5,8 +5,24 @@ open Server_routes_http
 module Mcp_server = Mcp_server
 module Mcp_eio = Mcp_server_eio
 
+let retired_pg_env_keys =
+  [ "MASC_POSTGRES_URL"; "DATABASE_URL"; "SUPABASE_DB_URL"; "SB_PG_URL" ]
+
+let clear_retired_pg_envs () =
+  List.iter
+    (fun key ->
+      match Sys.getenv_opt key |> Env_config_core.trim_opt with
+      | Some _ ->
+          Log.Server.warn
+            "Ignoring retired PG runtime env %s; filesystem-only bootstrap is enforced."
+            key;
+          Unix.putenv key ""
+      | None -> Unix.putenv key "")
+    retired_pg_env_keys
+
 let force_jsonl_fallback_env () =
-  Unix.putenv Env_config_core.storage_type_env_key "filesystem"
+  Unix.putenv Env_config_core.storage_type_env_key "filesystem";
+  clear_retired_pg_envs ()
 
 let requested_backend_mode () =
   Env_config_core.storage_type ()
@@ -193,6 +209,7 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   Eio_context.set_net net;
   Eio_context.set_clock clock;
   Eio_context.set_mono_clock mono_clock;
+  force_jsonl_fallback_env ();
   ensure_default_oas_cascade_timeout_env ();
   Process_eio.init ~cwd_default:Eio.Path.(fs / base_path) ~proc_mgr ~clock;
   Exec_tap.install_from_env ();
@@ -698,8 +715,8 @@ let startup_migrate_keeper_histories (state : Mcp_server.server_state) =
 
 (* bootstrap_keepers removed: the keeper_autoboot subsystem in
    start_keeper_loops now handles keeper startup in a dedicated
-   fiber with a 5-second delay, avoiding PG pool contention with
-   the 7+ dashboard refresh loops that share the same pool. *)
+   fiber with a 5-second delay, avoiding runtime bootstrap contention with
+   the 7+ dashboard refresh loops that start alongside it. *)
 
 let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
     ~make_h2_request_handler ~make_h2_error_handler =
@@ -745,6 +762,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
     | Env_config.Transport.Unknown_h2_mode _ -> `Auto
   in
   let socket = Server_bootstrap_http.listen_socket ~sw ~net config in
+  force_jsonl_fallback_env ();
   let initial_backend_mode = requested_backend_mode () in
   server_state := None;
   Server_startup_state.reset ~backend_mode:initial_backend_mode ();
@@ -818,7 +836,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
              detail
        | None -> ());
       let t1 = Eio.Time.now clock in
-      Log.Server.info "State created (PG pool) in %.1fs" (t1 -. t0);
+      Log.Server.info "State created (runtime state) in %.1fs" (t1 -. t0);
       bootstrap_server_state_blocking state;
       sync_admin_token_env state;
       let path_diagnostics =
@@ -891,7 +909,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
             fun () -> startup_prune_keeper_checkpoints state );
           (* keeper_bootstrap removed: keeper_autoboot subsystem in
              start_keeper_loops handles this in a dedicated fiber,
-             avoiding PG pool contention with dashboard refresh loops. *)
+             avoiding bootstrap contention with dashboard refresh loops. *)
         ]
       in
       let task_names = List.map fst tasks in

--- a/lib/server_startup_state.ml
+++ b/lib/server_startup_state.ml
@@ -20,14 +20,12 @@ type t = {
 
 let backend_phase_of_string s =
   match String.lowercase_ascii s with
-  | "postgresql" | "pg" -> Some Server_state_product.Backend.PostgreSQL
   | "filesystem" | "fs" -> Some Server_state_product.Backend.Filesystem
   | "degraded" -> Some Server_state_product.Backend.Degraded
   | "uninitialized" | "unknown" -> Some Server_state_product.Backend.Uninitialized
   | _ -> None
 
 let backend_phase_to_string = function
-  | Server_state_product.Backend.PostgreSQL -> "postgresql"
   | Server_state_product.Backend.Filesystem -> "filesystem"
   | Server_state_product.Backend.Degraded -> "degraded"
   | Server_state_product.Backend.Uninitialized -> "unknown"
@@ -201,7 +199,6 @@ let mark_state_ready ~backend_mode =
         | Backend.Uninitialized ->
             let event =
               match String.lowercase_ascii backend_mode with
-              | "postgresql" | "pg" -> Some Backend.Resolve_pg
               | "filesystem" | "fs" -> Some Backend.Resolve_fs
               | _ -> None
             in
@@ -244,7 +241,6 @@ let activate_lazy ~backend_mode ~tasks =
         | Backend.Uninitialized ->
             let event =
               match String.lowercase_ascii backend_mode with
-              | "postgresql" | "pg" -> Some Backend.Resolve_pg
               | "filesystem" | "fs" -> Some Backend.Resolve_fs
               | _ -> None
             in

--- a/lib/server_state_product.ml
+++ b/lib/server_state_product.ml
@@ -53,26 +53,22 @@ end
 module Backend = struct
   type phase =
     | Uninitialized
-    | PostgreSQL
     | Filesystem
     | Degraded
 
   let phase_to_string = function
     | Uninitialized -> "uninitialized"
-    | PostgreSQL -> "postgresql"
     | Filesystem -> "filesystem"
     | Degraded -> "degraded"
 
-  let all_phases = [Uninitialized; PostgreSQL; Filesystem; Degraded]
+  let all_phases = [Uninitialized; Filesystem; Degraded]
 
   type event =
-    | Resolve_pg
     | Resolve_fs
     | Degrade of string
     | Recover
 
   let event_to_string = function
-    | Resolve_pg -> "resolve_pg"
     | Resolve_fs -> "resolve_fs"
     | Degrade s -> "degrade:" ^ s
     | Recover -> "recover"
@@ -81,9 +77,7 @@ module Backend = struct
 
   let apply_event ~current event =
     match current, event with
-    | Uninitialized, Resolve_pg -> Applied PostgreSQL
     | Uninitialized, Resolve_fs -> Applied Filesystem
-    | PostgreSQL, Degrade _ -> Applied Degraded
     | Filesystem, Degrade _ -> Applied Degraded
     | Degraded, Recover -> Applied Filesystem
     | phase, event -> Ignored { phase; event }

--- a/lib/server_state_product.mli
+++ b/lib/server_state_product.mli
@@ -43,7 +43,6 @@ end
 module Backend : sig
   type phase =
     | Uninitialized (** Backend not yet resolved *)
-    | PostgreSQL    (** Connected to PostgreSQL *)
     | Filesystem    (** Fallback to filesystem backend *)
     | Degraded      (** Backend connection failed *)
 
@@ -51,7 +50,6 @@ module Backend : sig
   val all_phases : phase list
 
   type event =
-    | Resolve_pg
     | Resolve_fs
     | Degrade of string
     | Recover

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -15,8 +15,10 @@ if command -v opam >/dev/null 2>&1; then
     eval "$(opam env 2>/dev/null)" >/dev/null 2>/dev/null || true
 fi
 
-# Storage backend: filesystem by default.
-export MASC_STORAGE_TYPE="${MASC_STORAGE_TYPE:-filesystem}"
+# Storage backend: filesystem only. Clear retired PG selectors so inherited
+# shells cannot steer runtime startup onto a PostgreSQL lane.
+export MASC_STORAGE_TYPE="filesystem"
+unset MASC_POSTGRES_URL DATABASE_URL SUPABASE_DB_URL SB_PG_URL
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"

--- a/test/test_server_state_product.ml
+++ b/test/test_server_state_product.ml
@@ -52,12 +52,12 @@ let test_lifecycle_all_transitions () =
 (* ── Dimension 2: Backend ───────────────────────────────── *)
 
 let test_backend_resolve () =
-  let r = S.Backend.apply_event ~current:Uninitialized Resolve_pg in
-  check (of_pp S.Backend.pp_phase) "postgresql" PostgreSQL
+  let r = S.Backend.apply_event ~current:Uninitialized Resolve_fs in
+  check (of_pp S.Backend.pp_phase) "filesystem" Filesystem
     (match r with Applied p -> p | Ignored _ -> fail "ignored")
 
 let test_backend_degrade () =
-  let r = S.Backend.apply_event ~current:PostgreSQL (Degrade "conn_reset") in
+  let r = S.Backend.apply_event ~current:Filesystem (Degrade "conn_reset") in
   check (of_pp S.Backend.pp_phase) "degraded" Degraded
     (match r with Applied p -> p | Ignored _ -> fail "ignored")
 
@@ -128,7 +128,7 @@ let test_invariant_i5_booting_uninitialized () =
   let state =
     { S.initial with
       lifecycle = Booting;
-      backend = PostgreSQL
+      backend = Filesystem
     }
   in
   check_err "I5 violated" (S.check_invariants state)
@@ -137,7 +137,7 @@ let test_invariant_all_valid () =
   let state =
     { S.initial with
       lifecycle = Serving;
-      backend = PostgreSQL;
+      backend = Filesystem;
       readiness = Ready;
       lazy_tasks = Complete
     }
@@ -155,9 +155,9 @@ let test_apply_lifecycle_event () =
   check (of_pp S.Lifecycle.pp_phase) "serving" Serving state.lifecycle;
   let state =
     check_ok "resolve backend"
-      (S.apply_backend_event state Resolve_pg)
+      (S.apply_backend_event state Resolve_fs)
   in
-  check (of_pp S.Backend.pp_phase) "postgresql" PostgreSQL state.backend;
+  check (of_pp S.Backend.pp_phase) "filesystem" Filesystem state.backend;
   let state =
     check_ok "set ready"
       (S.apply_readiness_event state Set_ready)
@@ -168,7 +168,7 @@ let test_apply_backend_event_degrade () =
   let state =
     { S.initial with
       lifecycle = Serving;
-      backend = PostgreSQL;
+      backend = Filesystem;
       readiness = Ready
     }
   in
@@ -180,7 +180,7 @@ let test_apply_backend_event_degrade_after_not_ready () =
   let state =
     { S.initial with
       lifecycle = Serving;
-      backend = PostgreSQL;
+      backend = Filesystem;
       readiness = NotReady
     }
   in
@@ -261,8 +261,8 @@ let test_lifecycle_chain () =
   in
   check (of_pp S.Lifecycle.pp_phase) "serving" Serving state.lifecycle;
   let state =
-    check_ok "resolve pg"
-      (S.apply_backend_event state Resolve_pg)
+    check_ok "resolve fs"
+      (S.apply_backend_event state Resolve_fs)
   in
   let state =
     check_ok "set ready"
@@ -305,7 +305,7 @@ let test_backend_degrade_recover_cycle () =
   let state =
     { S.initial with
       lifecycle = Serving;
-      backend = PostgreSQL;
+      backend = Filesystem;
       readiness = NotReady
     }
   in
@@ -332,7 +332,7 @@ let () =
          test_case "all transitions" `Quick test_lifecycle_all_transitions;
        ]);
       ("backend",
-       [ test_case "resolve_pg" `Quick test_backend_resolve;
+       [ test_case "resolve_fs" `Quick test_backend_resolve;
          test_case "degrade" `Quick test_backend_degrade;
          test_case "recover" `Quick test_backend_recover;
        ]);


### PR DESCRIPTION
## Summary
- force filesystem-only bootstrap during server startup
- clear retired PG env selectors so inherited shells cannot steer runtime onto a PostgreSQL lane
- remove the PostgreSQL backend phase from startup state/product tests and keep the FSM filesystem-only

## Why
PG pool and `/state` are retired, but the runtime bootstrap and startup-state product still preserved a PostgreSQL resolution path. That left a gap where inherited env vars or stale startup transitions could still describe the server as having a PG backend even though the live deployment should be filesystem-only.

## Impact
- startup always resolves to the filesystem backend
- retired PG env vars are ignored during bootstrap
- backend tests now assert only the filesystem/degraded recovery path

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/pg-off-keeper`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/pg-off-keeper ./test/test_server_state_product.exe`
- launched the server locally and verified `/health` reports `backend_mode=filesystem`
