### PR TITLE
fix(keeper): replace List.hd with safe pattern match in keepalive

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1706,7 +1706,9 @@ let persist_directive_meta_update
             let b_mtime = Option.value ~default:0.0 (Fs_compat.file_mtime b) in
             Float.compare b_mtime a_mtime
           in
-          List.sort by_mtime_desc paths |> List.hd
+          match List.sort by_mtime_desc paths with
+          | most_recent :: _ -> most_recent
+          | [] -> default_path
   in
   try
     Keeper_fs.save_json_atomic persisted_path (meta_to_json updated_meta);


### PR DESCRIPTION
## Summary

Replaces unsafe `List.hd` with a pattern match to eliminate the last `List.hd` instance in `lib/`, satisfying the health check ratchet (`lib_list_hd` baseline = 0).

## Changes

- `lib/keeper/keeper_keepalive.ml`: Pattern match on sorted paths instead of `List.hd`

## Related

- Follow-up to #9475 (which was auto-merged before this fix could be included)
- Part of the operational quality remediation plan

## Verification

- [x] `dune build` passes
- [x] `rg 'List\.hd' lib/` returns 0 matches
- [ ] Health check ratchet passes (`lib_list_hd` count stays at 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)