### PR TITLE
fix(keeper): add autoboot_enabled to canonical TOML key list

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -630,6 +630,7 @@ let canonical_keeper_toml_key_names =
   ; "social_model"
   ; "cascade_name"
   ; "models"
+  ; "autoboot_enabled"
   ]
 
 (** Pure detector: returns TOML keys that [profile_defaults_of_toml] does not


### PR DESCRIPTION
## Summary
- Adds \`autoboot_enabled\` to \`canonical_keeper_toml_key_names\` in \`keeper_types_profile.ml\`
- Eliminates repeated WARN logs: \`keeper TOML ... has unknown keys: keeper.autoboot_enabled\`
- All declarative keeper configs already include this key; the parser simply didn't recognize it.

## Test plan
- [ ] \`dune runtest lib/keeper/\` passes
- [ ] Autoboot warnings no longer appear in system logs after server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)