### PR TITLE
fix(cascade,verification): log on config load and parse failures (#8391)

### DIFF
--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -274,7 +274,11 @@ let read_int_field json key =
 
 let resolve_inference_params ~config_path ~name =
   match load_json config_path with
-  | Error _ -> { temperature = None; max_tokens = None }
+  | Error msg ->
+      Eio.traceln
+        "[CascadeConfig] resolve_inference_params: %s (name=%s, path=%s)"
+        msg name config_path;
+      { temperature = None; max_tokens = None }
   | Ok json ->
     let temp =
       match read_float_field json (name ^ "_temperature") with
@@ -381,7 +385,11 @@ let empty_strategy_config = {
 
 let resolve_strategy_config ~config_path ~name =
   match load_json config_path with
-  | Error _ -> empty_strategy_config
+  | Error msg ->
+      Eio.traceln
+        "[CascadeConfig] resolve_strategy_config: %s (name=%s, path=%s)"
+        msg name config_path;
+      empty_strategy_config
   | Ok json ->
     {
       kind = read_string_field json (name ^ "_strategy");

--- a/lib/verification.ml
+++ b/lib/verification.ml
@@ -174,7 +174,9 @@ let request_of_yojson = function
                  List.filter_map (fun j ->
                    match criterion_of_yojson j with
                    | Ok c -> Some c
-                   | Error _ -> None
+                   | Error msg ->
+                     Eio.traceln "[Verification] dropping invalid criterion: %s" msg;
+                     None
                  ) l
              | _ -> []
            in
@@ -189,7 +191,9 @@ let request_of_yojson = function
            let status = match List.assoc_opt "status" fields with
              | Some json -> (match request_status_of_yojson json with
                  | Ok s -> s
-                 | Error _ -> Pending)
+                 | Error msg ->
+                   Eio.traceln "[Verification] unparseable status, falling back to Pending: %s" msg;
+                   Pending)
              | None -> Pending
            in
            Ok { id; task_id; output; criteria; worker; verifier; created_at; status }


### PR DESCRIPTION
## Summary
- Add `Eio.traceln` to 4 remaining `Error _ -> default` sites from silent failure sweep (#8391)
- `cascade_config_loader.ml:277` — `resolve_inference_params` now logs before returning empty params
- `cascade_config_loader.ml:384` — `resolve_strategy_config` now logs before returning empty config
- `verification.ml:177` — invalid criterion JSON now logs the parse error before dropping
- `verification.ml:192` — unparseable status now logs before falling back to Pending

## Context
HIGH #2 and HIGH #6 from #8391 were the only remaining unfixed silent failures. HIGH #1, #3, #4, #5 were already fixed in prior PRs.

Pattern follows existing `load_profile_weighted` and `resolve_api_key_env` in the same module.

## Test plan
- [x] `dune build --root .` passes
- [x] `dune runtest --root .` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)