### PR TITLE
[codex] fix keeper autoboot_enabled TOML handling

### DIFF
--- a/lib/keeper/keeper_exec_persona.ml
+++ b/lib/keeper/keeper_exec_persona.ml
@@ -37,6 +37,7 @@ let resolved_keeper_args_to_json
     ~name ~persona_name ~goal ~short_goal ~mid_goal ~long_goal
     ~instructions ~will ~needs ~desires ~policy_voice_enabled
     ~mention_targets
+    ~autoboot_enabled_opt
     ~tool_preset ~tool_also_allow ~tool_denylist
     ~proactive_enabled ~shards
     ~auto_handoff ~handoff_threshold ~handoff_cooldown_sec =
@@ -63,12 +64,17 @@ let resolved_keeper_args_to_json
       ("handoff_cooldown_sec", `Int handoff_cooldown_sec);
     ]
   in
+  let autoboot_field =
+    match autoboot_enabled_opt with
+    | Some value -> [ ("autoboot_enabled", `Bool value) ]
+    | None -> []
+  in
   let shards_field =
     match shards with
     | Some xs -> [("shards", string_list_to_json xs)]
     | None -> []
   in
-  `Assoc (base @ shards_field)
+  `Assoc (base @ autoboot_field @ shards_field)
 
 let validate_resolved_keeper_create_json (json : Yojson.Safe.t) : string list =
   let errors = ref [] in
@@ -174,6 +180,7 @@ let resolved_keeper_args_from_persona args :
               |> first_some defaults.proactive_enabled
               |> Option.value ~default:false
             in
+            let autoboot_enabled = get_bool_opt args "autoboot_enabled" in
             (match get_string_opt args "tool_preset" with
              | Some raw -> (
                  match tool_preset_of_string raw with
@@ -215,6 +222,7 @@ let resolved_keeper_args_from_persona args :
                          ~instructions  ~will ~needs ~desires
                          ~policy_voice_enabled
                          ~mention_targets
+                         ~autoboot_enabled_opt:autoboot_enabled
                          ~tool_preset ~tool_also_allow ~tool_denylist
                          ~proactive_enabled ~shards
                          ~auto_handoff ~handoff_threshold
@@ -265,6 +273,7 @@ let resolved_keeper_args_from_persona args :
                      ~instructions  ~will ~needs ~desires
                      ~policy_voice_enabled
                      ~mention_targets
+                     ~autoboot_enabled_opt:autoboot_enabled
                      ~tool_preset ~tool_also_allow ~tool_denylist
                      ~proactive_enabled ~shards
                      ~auto_handoff ~handoff_threshold

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -13,7 +13,10 @@ let bootable_keeper_names config =
   |> List.filter (fun name ->
          match read_meta_file_path (keeper_meta_path config name) with
          | Ok (Some meta) -> not meta.paused && meta.autoboot_enabled
-         | Ok None -> true
+         | Ok None ->
+             (match (load_keeper_profile_defaults name).autoboot_enabled with
+              | Some false -> false
+              | Some true | None -> true)
          | Error _ -> true)
 
 (** Apply a TOML profile default to a runtime meta value.
@@ -131,6 +134,8 @@ let ensure_keeper_meta config name =
     (* --- Policy --- *)
     let target_policy_voice_enabled =
       apply_default defaults.policy_voice_enabled meta.policy_voice_enabled in
+    let target_autoboot_enabled =
+      apply_default defaults.autoboot_enabled meta.autoboot_enabled in
     let target_mention_targets =
       match defaults.mention_targets with [] -> meta.mention_targets | xs -> xs in
     let target_execution_scope =
@@ -189,6 +194,7 @@ let ensure_keeper_meta config name =
       || meta.instructions <> target_instructions in
     let policy_changed =
       meta.policy_voice_enabled <> target_policy_voice_enabled
+      || meta.autoboot_enabled <> target_autoboot_enabled
       || meta.mention_targets <> target_mention_targets
       || meta.tool_access <> target_tool_access
       || meta.execution_scope <> target_execution_scope
@@ -255,6 +261,7 @@ let ensure_keeper_meta config name =
         desires = target_desires;
         instructions = target_instructions;
         policy_voice_enabled = target_policy_voice_enabled;
+        autoboot_enabled = target_autoboot_enabled;
         mention_targets = target_mention_targets;
         tool_access = target_tool_access;
         execution_scope = target_execution_scope;

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -31,7 +31,10 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         p.profile_defaults.goal |> Option.value ~default:""
         |> normalize_goal_horizon_text
   in
-  let autoboot_enabled = Option.value ~default:true p.autoboot_enabled_opt in
+  let autoboot_enabled =
+    first_some p.autoboot_enabled_opt p.profile_defaults.autoboot_enabled
+    |> Option.value ~default:true
+  in
   let policy_voice_enabled =
     first_some
       p.policy_voice_enabled_opt

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -1657,6 +1657,12 @@ let keeper_names config =
   persisted_keeper_names config
 ;;
 
+let declarative_autoboot_enabled_by_default name =
+  match (load_keeper_profile_defaults name).autoboot_enabled with
+  | Some false -> false
+  | Some true | None -> true
+;;
+
 let keepalive_keeper_names config =
   configured_keeper_names config
   |> List.filter_map (fun name ->
@@ -1664,7 +1670,8 @@ let keepalive_keeper_names config =
     | Ok (Some meta) when not meta.paused && meta.autoboot_enabled ->
         Some meta.name
     | Ok (Some _) -> None  (* paused or autoboot disabled *)
-    | Ok None -> Some name
+    | Ok None ->
+        if declarative_autoboot_enabled_by_default name then Some name else None
     | Error msg ->
         (* Issue #8377: was [_ -> None] which collapsed read/parse
            failures silently into "name disappeared". Discovery would

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -252,6 +252,7 @@ type keeper_profile_defaults = {
   desires : string option;
   instructions : string option;
   policy_voice_enabled : bool option;
+  autoboot_enabled : bool option;
   mention_targets : string list;
   proactive_enabled : bool option;
   proactive_idle_sec : int option;
@@ -311,6 +312,7 @@ let empty_keeper_profile_defaults = {
   desires = None;
   instructions = None;
   policy_voice_enabled = None;
+  autoboot_enabled = None;
   mention_targets = [];
   proactive_enabled = None;
   proactive_idle_sec = None;
@@ -528,6 +530,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         desires = str "desires";
         instructions = str "instructions";
         policy_voice_enabled = bool_ "policy_voice_enabled";
+        autoboot_enabled = bool_ "autoboot_enabled";
         mention_targets = strs "mention_targets";
         proactive_enabled = bool_ "proactive_enabled";
         proactive_idle_sec = int_ "proactive_idle_sec";
@@ -604,6 +607,7 @@ let canonical_keeper_toml_key_names =
   ; "desires"
   ; "instructions"
   ; "policy_voice_enabled"
+  ; "autoboot_enabled"
   ; "mention_targets"
   ; "proactive_enabled"
   ; "proactive_idle_sec"
@@ -737,6 +741,7 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                   (match Yojson.Safe.Util.member "policy_voice_enabled" keeper_json with
                   | `Bool flag -> Some flag
                   | _ -> None);
+                autoboot_enabled = None;
                 mention_targets = Safe_ops.json_string_list "mention_targets" keeper_json;
                 proactive_enabled = Safe_ops.json_bool_opt "proactive_enabled" keeper_json;
                 proactive_idle_sec = Safe_ops.json_int_opt "proactive_idle_sec" keeper_json;
@@ -844,6 +849,7 @@ let merge_keeper_profile_defaults
     instructions = prefer overlay.instructions base.instructions;
     policy_voice_enabled =
       prefer overlay.policy_voice_enabled base.policy_voice_enabled;
+    autoboot_enabled = prefer overlay.autoboot_enabled base.autoboot_enabled;
     mention_targets =
       merge_string_list ~base:base.mention_targets overlay.mention_targets;
     proactive_enabled = prefer overlay.proactive_enabled base.proactive_enabled;

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -51,19 +51,28 @@ let write_json path json =
   Out_channel.with_open_bin path (fun oc ->
       output_string oc (Yojson.Safe.pretty_to_string json))
 
-let write_keeper_toml_exn config ~name =
+let write_file path content =
+  Out_channel.with_open_bin path (fun oc -> output_string oc content)
+
+let write_keeper_toml_exn ?autoboot_enabled config ~name =
   let keepers_dir =
     Filename.concat (Coord.masc_root_dir config) "config/keepers"
+  in
+  let autoboot_line =
+    match autoboot_enabled with
+    | Some value -> Printf.sprintf "autoboot_enabled = %b\n" value
+    | None -> ""
   in
   Fs_compat.mkdir_p keepers_dir;
   Fs_compat.save_file
     (Filename.concat keepers_dir (name ^ ".toml"))
-    {|
-[keeper]
-goal = "test keeper"
-room_scope = "current"
-proactive_enabled = false
-|}
+    (Printf.sprintf
+       "[keeper]\n\
+        goal = \"test keeper\"\n\
+        %s\
+        room_scope = \"current\"\n\
+        proactive_enabled = false\n"
+       autoboot_line)
 
 let write_keeper_meta_exn ?(autoboot_enabled = true)
     ?(social_model = "bdi_speech_v1")
@@ -186,6 +195,107 @@ let test_bootable_keeper_names_skip_autoboot_disabled_meta () =
       let names = Keeper_runtime.bootable_keeper_names config in
       check bool "autoboot disabled sangsu excluded from bootable list" false
         (List.mem "sangsu" names))
+
+let test_declarative_autoboot_disabled_skips_boot_without_meta () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  with_clean_base_path_env @@ fun () ->
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Config_dir_resolver.reset ();
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      write_keeper_toml_exn ~autoboot_enabled:false config ~name:"sangsu";
+      let config_root = Filename.concat (Coord.masc_root_dir config) "config" in
+      Unix.putenv "MASC_CONFIG_DIR" config_root;
+      Config_dir_resolver.reset ();
+      let bootable_names = Keeper_runtime.bootable_keeper_names config in
+      check bool "bootable list excludes declarative autoboot-disabled keeper" false
+        (List.mem "sangsu" bootable_names);
+      let keepalive_names = Keeper_types.keepalive_keeper_names config in
+      check bool "keepalive list excludes declarative autoboot-disabled keeper" false
+        (List.mem "sangsu" keepalive_names))
+
+let test_autoboot_policy_resync_from_declarative_toml () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  with_clean_base_path_env @@ fun () ->
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Cascade_catalog_runtime.reset_cache_for_tests ();
+      Config_dir_resolver.reset ();
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      write_keeper_toml_exn ~autoboot_enabled:false config ~name:"sangsu";
+      let config_root = Filename.concat (Coord.masc_root_dir config) "config" in
+      let cascade_path = Filename.concat config_root "cascade.json" in
+      write_file
+        cascade_path
+        {|{
+  "big_three_models": ["test-only:model"]
+}|};
+      Unix.putenv "MASC_CONFIG_DIR" config_root;
+      Config_dir_resolver.reset ();
+      Cascade_catalog_runtime.install_snapshot_for_tests
+        ~source_path:cascade_path
+        ~profile_names:[ Keeper_config.default_cascade_name ];
+      write_keeper_meta_exn
+        ~autoboot_enabled:true config ~name:"sangsu" ~trace_id:"trace-sangsu";
+      match Keeper_runtime.ensure_keeper_meta config "sangsu" with
+      | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
+      | Ok updated ->
+          check bool "autoboot_enabled resynced from TOML" false
+            updated.Keeper_types.autoboot_enabled)
+
+let test_keeper_up_uses_toml_autoboot_default () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  with_clean_base_path_env @@ fun () ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "toml-autoboot-default" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Config_dir_resolver.reset ();
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      write_keeper_toml_exn ~autoboot_enabled:false config ~name:keeper_name;
+      let config_root = Filename.concat (Coord.masc_root_dir config) "config" in
+      Unix.putenv "MASC_CONFIG_DIR" config_root;
+      Config_dir_resolver.reset ();
+      let ctx = keeper_ctx env sw config "operator" in
+      let ok, body =
+        match
+          Tool_keeper.dispatch ctx ~name:"masc_keeper_up"
+            ~args:(`Assoc [ ("name", `String keeper_name) ])
+        with
+        | Some result -> result
+        | None -> fail "expected masc_keeper_up dispatch"
+      in
+      check bool "keeper_up ok" true ok;
+      match Keeper_types.read_meta config keeper_name with
+      | Ok (Some meta) ->
+          check bool "autoboot_enabled defaulted from TOML" false
+            meta.autoboot_enabled
+      | Ok None -> fail "keeper meta missing after keeper_up"
+      | Error e -> fail ("read_meta failed: " ^ e))
 
 let test_keeper_list_normalizes_unknown_social_model () =
   Eio_main.run @@ fun env ->
@@ -311,6 +421,12 @@ let () =
             test_keeper_listing_ignores_sidecar_json_files;
           test_case "bootable list skips autoboot-disabled meta" `Quick
             test_bootable_keeper_names_skip_autoboot_disabled_meta;
+          test_case "declarative autoboot-disabled keeper skips boot without meta"
+            `Quick test_declarative_autoboot_disabled_skips_boot_without_meta;
+          test_case "autoboot policy resyncs from declarative TOML" `Quick
+            test_autoboot_policy_resync_from_declarative_toml;
+          test_case "keeper_up uses TOML autoboot default" `Quick
+            test_keeper_up_uses_toml_autoboot_default;
           test_case "tool keeper list normalizes unknown social model" `Quick
             test_keeper_list_normalizes_unknown_social_model;
           test_case "tool keeper list preserves known social model" `Quick

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -449,6 +449,7 @@ mention_targets = ["sherlock", "log-analyzer"]
 proactive_enabled = true
 room_signal_prompt_enabled = true
 policy_voice_enabled = false
+autoboot_enabled = false
 |} in
   match TL.parse_toml input with
   | Error e -> fail e
@@ -465,7 +466,8 @@ policy_voice_enabled = false
       check (option bool) "proactive" (Some true) d.proactive_enabled;
       check (option bool) "room signal prompt" (Some true)
         d.room_signal_prompt_enabled;
-      check (option bool) "policy_voice" (Some false) d.policy_voice_enabled
+      check (option bool) "policy_voice" (Some false) d.policy_voice_enabled;
+      check (option bool) "autoboot_enabled" (Some false) d.autoboot_enabled
 
 let test_profile_rejects_invalid_social_model () =
   let input = {|
@@ -845,6 +847,35 @@ let test_persona_resolver_rejects_non_public_social_model_arg () =
          || contains_substring e "non-public keeper args");
       check bool "mentions social_model" true (contains_substring e "social_model")
 
+let test_persona_resolver_preserves_autoboot_enabled_arg () =
+  with_personas_dir @@ fun personas_dir ->
+  let persona_dir = Filename.concat personas_dir "probe" in
+  mkdir_p persona_dir;
+  write_file
+    (Filename.concat persona_dir "profile.json")
+    {|
+{
+  "name": "Probe",
+  "keeper": {
+    "goal": "test persona keeper"
+  }
+}
+|};
+  match
+    Masc_mcp.Keeper_exec_persona.resolved_keeper_args_from_persona
+      (`Assoc
+        [
+          ("persona_name", `String "probe");
+          ("autoboot_enabled", `Bool false);
+        ])
+  with
+  | Error e -> fail ("resolver failed: " ^ e)
+  | Ok (_, resolved) ->
+      check (option bool) "autoboot_enabled preserved" (Some false)
+        (match Yojson.Safe.Util.member "autoboot_enabled" resolved with
+         | `Bool value -> Some value
+         | _ -> None)
+
 (* ================================================================ *)
 (* Unknown-key detection                                             *)
 (* ================================================================ *)
@@ -856,6 +887,7 @@ goal = "canonical"
 mention_targets = ["a", "b"]
 tool_preset = "coding"
 tool_also_allow = ["x"]
+autoboot_enabled = false
 cascade_name = "big_three"
 |} in
   match TL.parse_toml input with
@@ -1136,5 +1168,7 @@ let () =
             test_persona_resolver_defaults_to_research_tool_preset;
           test_case "persona resolver rejects non-public social_model arg" `Quick
             test_persona_resolver_rejects_non_public_social_model_arg;
+          test_case "persona resolver preserves autoboot_enabled arg" `Quick
+            test_persona_resolver_preserves_autoboot_enabled_arg;
         ] );
     ]


### PR DESCRIPTION
## Summary
- wire keeper TOML `autoboot_enabled` into profile defaults and unknown-key detection
- honor declarative `autoboot_enabled` during boot selection and `keeper_up` defaults
- preserve `autoboot_enabled` in persona-backed keeper resolution and add regression coverage

## Root Cause
`autoboot_enabled` existed in keeper meta and tool args, but declarative TOML loading and no-meta autoboot selection did not read it. That made the field effectively dead for declarative keepers and produced false unknown-key warnings.

## Validation
- `dune build --root . --build-dir _build_codex_fix test/test_keeper_toml.exe test/test_keeper_meta_listing.exe`
- `./_build_codex_fix/default/test/test_keeper_toml.exe`
- `./_build_codex_fix/default/test/test_keeper_meta_listing.exe`

## Notes
- `./_build/default/test/test_keeper_runtime_config_ssot.exe` is already failing on `main` and was not used as merge-blocking validation for this fix.
