### PR TITLE
[codex] Avoid bootstrapping repo keepers into base-path config

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -127,6 +127,19 @@ let ensure_config_root_scaffold config_root =
   [ "prompts"; "keepers"; "personas" ]
   |> List.iter (fun name -> Fs_compat.mkdir_p (Filename.concat config_root name))
 
+(* Explicit base-path workspaces should inherit shared config defaults
+   without silently importing repo keeper manifests into the live root. *)
+let copy_missing_config_root_seed ~src ~dst =
+  Fs_compat.mkdir_p dst;
+  Sys.readdir src
+  |> Array.iter (fun name ->
+         if String.equal name "keepers" then
+           ()
+         else
+           copy_missing_tree
+             ~src:(Filename.concat src name)
+             ~dst:(Filename.concat dst name));
+  Fs_compat.mkdir_p (Filename.concat dst "keepers")
 let bootstrap_base_path_config_root ~base_path =
   let base_path = Env_config_core.normalize_masc_base_path_input base_path in
   if Option.is_some (Config_dir_resolver.current_env_config_dir_opt ()) then
@@ -154,7 +167,7 @@ let bootstrap_base_path_config_root ~base_path =
     else
       (match source_root with
        | Some source ->
-           copy_missing_tree ~src:source ~dst:config_root;
+           copy_missing_config_root_seed ~src:source ~dst:config_root;
            Log.Server.info
              "bootstrapped base-path config root: %s <- %s"
              config_root source

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -411,6 +411,8 @@ let wait_for_startup_phase ~pid ~port ~timeout_s expected_phase =
 let write_invalid_local_only_cascade base_path =
   let config_root = Filename.concat base_path ".masc/config" in
   mkdir_p config_root;
+  let toml_path = Filename.concat config_root "cascade.toml" in
+  if Sys.file_exists toml_path then Sys.remove toml_path;
   write_file
     (Filename.concat config_root "cascade.json")
     {|{
@@ -420,6 +422,8 @@ let write_invalid_local_only_cascade base_path =
 let write_partially_invalid_cascade ~base_path ~valid_model =
   let config_root = Filename.concat base_path ".masc/config" in
   mkdir_p config_root;
+  let toml_path = Filename.concat config_root "cascade.toml" in
+  if Sys.file_exists toml_path then Sys.remove toml_path;
   write_file
     (Filename.concat config_root "cascade.json")
     (Printf.sprintf
@@ -432,6 +436,8 @@ let write_partially_invalid_cascade ~base_path ~valid_model =
 let write_partially_invalid_default_cascade ~base_path ~valid_model =
   let config_root = Filename.concat base_path ".masc/config" in
   mkdir_p config_root;
+  let toml_path = Filename.concat config_root "cascade.toml" in
+  if Sys.file_exists toml_path then Sys.remove toml_path;
   write_file
     (Filename.concat config_root "cascade.json")
     (Printf.sprintf
@@ -488,7 +494,7 @@ let test_default_oas_cascade_timeout_keeps_explicit_override () =
   Alcotest.(check string) "explicit override wins" "45"
     (Sys.getenv "OAS_CASCADE_MODEL_TIMEOUT_SEC")
 
-let test_bootstrap_base_path_config_root_copies_versioned_config () =
+let test_bootstrap_base_path_config_root_copies_shared_seed_but_not_keepers () =
   with_temp_dir "startup-config-bootstrap" (fun dir ->
       let repo = Filename.concat dir "repo" in
       mkdir_p repo;
@@ -507,7 +513,9 @@ let test_bootstrap_base_path_config_root_copies_versioned_config () =
       Alcotest.(check bool) "prompt copied" true
         (Sys.file_exists
            (Filename.concat config_root "prompts/keeper.unified.system.md"));
-      Alcotest.(check bool) "keeper TOML copied" true
+      Alcotest.(check bool) "keepers dir created" true
+        (Sys.file_exists (Filename.concat config_root "keepers"));
+      Alcotest.(check bool) "repo keeper TOML not copied" false
         (Sys.file_exists (Filename.concat config_root "keepers/example.toml")))
 
 let test_bootstrap_base_path_config_root_preserves_existing_root_without_refill () =
@@ -1703,12 +1711,24 @@ let test_main_eio_invalid_default_partial_catalog_stays_degraded () =
           let startup_error =
             Yojson.Safe.Util.(startup |> member "last_error" |> to_string)
           in
-          Alcotest.(check bool) "last error mentions default-profile gate" true
-            (contains_substring startup_error
-               "startup catalog validation failed:"
-             &&
-             contains_substring startup_error
-               "required default profile \"big_three\" failed validation");
+          let rejection_prefix = "startup catalog validation failed: " in
+          if not (String.starts_with ~prefix:rejection_prefix startup_error) then
+            Alcotest.failf
+              "last error missing catalog rejection prefix: %S"
+              startup_error;
+          let rejection_json =
+            String.sub startup_error (String.length rejection_prefix)
+              (String.length startup_error - String.length rejection_prefix)
+            |> Yojson.Safe.from_string
+          in
+          let rejection_errors =
+            Yojson.Safe.Util.(rejection_json |> member "errors" |> to_list)
+            |> List.map Yojson.Safe.Util.to_string
+          in
+          Alcotest.(check bool) "last error includes default-profile failure" true
+            (List.mem
+               "required default profile \"big_three\" failed validation"
+               rejection_errors);
           let config_headers, config_body =
             curl_request_capture ~output_dir:dir ~name:"cascade-config-default-invalid"
               ~method_:"GET"
@@ -1743,8 +1763,9 @@ let () =
             "default OAS cascade timeout keeps explicit override"
             `Quick test_default_oas_cascade_timeout_keeps_explicit_override;
           Alcotest.test_case
-            "bootstrap base-path config copies versioned config"
-            `Quick test_bootstrap_base_path_config_root_copies_versioned_config;
+            "bootstrap base-path config copies shared seed only"
+            `Quick
+            test_bootstrap_base_path_config_root_copies_shared_seed_but_not_keepers;
           Alcotest.test_case
             "bootstrap base-path config preserves existing root without refill"
             `Quick


### PR DESCRIPTION
## What changed
- stop fresh `--base-path` bootstrap from copying repo `config/keepers/*.toml` into the live `~/.masc/config/keepers` root
- preserve an already-existing base-path config root instead of trying to repair or reseed it from the repo
- update bootstrap tests so JSON-driven cascade cases remove bootstrapped `cascade.toml` first
- make the degraded startup assertion parse the rejection JSON payload instead of relying on escaped substring matching

## Why
Fresh base-path runs were inheriting default keeper manifests from the repo seed config. That made explicit isolated roots immediately pick up default keepers, which broke clean restarts and made the runtime look contaminated even when a caller passed a separate base path.

## Root cause
Bootstrap copied the entire repo config tree into a new base-path config root. That included top-level keeper manifests, and later loader/autoboot logic treated them as live declarations. The test suite also had one brittle assertion that expected unescaped text inside a JSON-serialized `startup.last_error` string.

## Impact
- explicit base-path workspaces now get shared config defaults without silently importing repo keepers
- existing local config roots stay untouched
- bootstrap regression coverage now matches the intended source-of-truth behavior

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-autoboot-clean-reset test/test_server_runtime_bootstrap.exe`
- `./_build/default/test/test_server_runtime_bootstrap.exe test bootstrap 41 --show-errors --tail-errors=200`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-autoboot-clean-reset ./test/test_server_runtime_bootstrap.exe`