### PR TITLE
fix(dashboard): update resolveGovernanceApproval 3-param signature in test

### DIFF
--- a/dashboard/src/components/governance.test.ts
+++ b/dashboard/src/components/governance.test.ts
@@ -323,7 +323,7 @@ describe('Governance surface', () => {
     approveButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     await flushUi()
 
-    expect(resolveGovernanceApproval).toHaveBeenCalledWith('appr-1', 'approve')
+    expect(resolveGovernanceApproval).toHaveBeenCalledWith('appr-1', 'approve', false)
     expect(fetchDashboardGovernance).toHaveBeenCalledTimes(2)
   }, 20000)
 


### PR DESCRIPTION
## Summary
- `resolveGovernanceApproval` dispatch now passes a 3rd boolean `remember` parameter
- Update governance.test.ts expectation to match the actual call signature

## Test plan
- [x] `dune build --root .` passes
- [x] `dune runtest` — 118/119 pass (1 flaky keeper_tool_matrix known issue)
- [ ] Dashboard CI (Jest) should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)