### PR TITLE
feat(worktree): auto-provision sandbox clone from workspace repo on demand

### DIFF
--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -23,19 +23,27 @@ let run_argv_lines argv =
   |> String.split_on_char '\n'
   |> List.filter (fun s -> s <> "")
 
+(** Run argv and get process status + combined output. *)
+let run_argv_with_status argv =
+  Masc_exec.Exec_gate.run_argv_with_status
+    ~actor:"coord/worktree"
+    ~raw_source:(exec_gate_raw_source argv)
+    ~summary:"coord_worktree argv"
+    ~timeout_sec:30.0
+    argv
+
 (** Run argv and get exit code (Eio-native, no shell) *)
 let run_argv_exit argv =
-  match
-    Masc_exec.Exec_gate.run_argv_with_status
-      ~actor:"coord/worktree"
-      ~raw_source:(exec_gate_raw_source argv)
-      ~summary:"coord_worktree argv"
-      ~timeout_sec:30.0
-      argv
-  with
+  match run_argv_with_status argv with
   | Unix.WEXITED n, _ -> n
   | Unix.WSIGNALED _, _ -> 128
   | Unix.WSTOPPED _, _ -> 128
+
+let first_nonempty_line output =
+  output
+  |> String.split_on_char '\n'
+  |> List.map String.trim
+  |> List.find_opt (fun s -> s <> "")
 
 (** Check if directory is a git repository - delegates to Coord_git *)
 let is_git_repo config =
@@ -91,6 +99,45 @@ let ensure_worktree_path root worktree_name =
   else
     Error (IoError "Invalid worktree path: must be created under .worktrees/")
 
+let safe_file_exists path =
+  try Sys.file_exists path with
+  | Sys_error _ -> false
+
+let safe_is_dir path =
+  try Sys.file_exists path && Sys.is_directory path with
+  | Sys_error _ -> false
+
+let safe_repo_name name =
+  name <> "" && name <> "." && name <> ".."
+  && not (String.contains name '/')
+  && not (String.contains name '\\')
+  && not (String.contains name '\x00')
+  && String.for_all
+       (fun c ->
+         (c >= 'A' && c <= 'Z')
+         || (c >= 'a' && c <= 'z')
+         || (c >= '0' && c <= '9')
+         || c = '-'
+         || c = '_'
+         || c = '.')
+       name
+
+let is_git_clone candidate =
+  safe_is_dir candidate
+  &&
+  match git_marker_kind (Filename.concat candidate ".git") with
+  | `Directory | `File -> true
+  | `Missing -> false
+
+let rec rm_rf path =
+  if safe_file_exists path then
+    if safe_is_dir path then begin
+      (try Sys.readdir path with Sys_error _ -> [||])
+      |> Array.iter (fun entry -> rm_rf (Filename.concat path entry));
+      (try Unix.rmdir path with Unix.Unix_error _ -> ())
+    end else
+      try Unix.unlink path with Unix.Unix_error _ -> ()
+
 let missing_sandbox_clone_error ~agent_name ~repos_dir ~repo_name =
   let rel_target, clone_hint =
     match repo_name with
@@ -110,6 +157,159 @@ let missing_sandbox_clone_error ~agent_name ~repos_dir ~repo_name =
        "missing_sandbox_clone: no sandbox git clone found for agent %s under %s \
         (expected %s). Recovery: %s"
        agent_name repos_dir rel_target clone_hint)
+
+let workspace_repo_not_found_error ~agent_name ~repos_dir ~repo_name
+    ~search_root =
+  IoError
+    (Printf.sprintf
+       "missing_sandbox_clone: no sandbox git clone found for agent %s under %s \
+        and no workspace git repo named %s was found under %s. Recovery: \
+        keeper_shell op=git_clone url=\"https://github.com/<org>/%s.git\" \
+        path=\"repos/%s\""
+       agent_name repos_dir repo_name search_root repo_name repo_name)
+
+let workspace_repo_ambiguous_error ~repo_name ~search_root ~matches =
+  IoError
+    (Printf.sprintf
+       "ambiguous_workspace_repo: found multiple git repos named %s under %s: \
+        [%s]. Auto-provision is blocked until the repo is disambiguated; use \
+        keeper_shell op=git_clone explicitly."
+       repo_name search_root (String.concat ", " matches))
+
+let partial_clone_error ~clone_path ~msg =
+  rm_rf clone_path;
+  IoError msg
+
+let workspace_repo_matches ~search_root ~repo_name =
+  let max_dirs = 4000 in
+  let max_matches = 8 in
+  let preferred_dir_name = function
+    | "workspace" | "workspaces" | "repos" | "projects" | "src" -> true
+    | _ -> false
+  in
+  let entry_priority entry =
+    if entry = repo_name then 0
+    else if preferred_dir_name entry then 1
+    else if String.length entry > 0 && entry.[0] = '.' then 3
+    else 2
+  in
+  let skip_dir_name = function
+    | ".git" | ".hg" | ".svn" | ".masc" | ".worktrees" | "_build"
+    | "node_modules" ->
+        true
+    | _ -> false
+  in
+  let matches =
+    if Filename.basename search_root = repo_name && is_git_clone search_root
+    then ref [ search_root ]
+    else ref []
+  in
+  let queue = Queue.create () in
+  Queue.add search_root queue;
+  let dirs_seen = ref 0 in
+  while
+    !dirs_seen < max_dirs
+    && Queue.length queue > 0
+    && List.length !matches < max_matches
+  do
+    let dir = Queue.take queue in
+    incr dirs_seen;
+    let entries =
+      try Sys.readdir dir with Sys_error _ -> [||]
+    in
+    Array.sort
+      (fun a b ->
+         match compare (entry_priority a) (entry_priority b) with
+         | 0 -> compare a b
+         | n -> n)
+      entries;
+    Array.iter
+      (fun entry ->
+         if List.length !matches < max_matches then
+           let path = Filename.concat dir entry in
+           if entry = repo_name && is_git_clone path then
+             matches := path :: !matches;
+           if safe_is_dir path && not (skip_dir_name entry) then
+             Queue.add path queue)
+      entries
+  done;
+  List.sort_uniq String.compare !matches
+
+let git_origin_url root =
+  match run_argv_with_status [ "git"; "-C"; root; "remote"; "get-url"; "origin" ] with
+  | Unix.WEXITED 0, output -> first_nonempty_line output
+  | _ -> None
+
+let auto_provision_sandbox_clone ~config ~agent_name ~repos_dir ~repo_name =
+  let search_root = project_root config in
+  match workspace_repo_matches ~search_root ~repo_name with
+  | [] ->
+      Error
+        (workspace_repo_not_found_error ~agent_name ~repos_dir ~repo_name
+           ~search_root)
+  | [ source_root ] ->
+      Fs_compat.mkdir_p repos_dir;
+      let clone_path = Filename.concat repos_dir repo_name in
+      if safe_file_exists clone_path then
+        if is_git_clone clone_path then Ok (clone_path, None)
+        else
+          Error
+            (IoError
+               (Printf.sprintf
+                  "sandbox_clone_conflict: %s already exists under %s but is not \
+                   a git clone. Remove or repair it, or use keeper_shell \
+                   op=git_clone explicitly."
+                  repo_name repos_dir))
+      else
+        let status, output =
+          run_argv_with_status [ "git"; "clone"; source_root; clone_path ]
+        in
+        if status <> Unix.WEXITED 0 then
+          Error
+            (partial_clone_error ~clone_path
+               ~msg:
+                 (Printf.sprintf
+                    "auto_provision_clone_failed: git clone from workspace repo %s \
+                     into %s failed: %s"
+                    source_root clone_path
+                    (let detail = String.trim output in
+                     if detail = "" then "(no output)" else detail)))
+        else (
+          match git_origin_url source_root with
+          | Some origin_url ->
+              let set_status, set_output =
+                run_argv_with_status
+                  [ "git"; "-C"; clone_path; "remote"; "set-url"; "origin";
+                    origin_url ]
+              in
+              if set_status <> Unix.WEXITED 0 then
+                Error
+                  (partial_clone_error ~clone_path
+                     ~msg:
+                       (Printf.sprintf
+                          "auto_provision_clone_failed: cloned %s into %s but \
+                           could not restore origin %s: %s"
+                          source_root clone_path origin_url
+                          (let detail = String.trim set_output in
+                           if detail = "" then "(no output)" else detail)))
+              else
+                Ok
+                  ( clone_path,
+                    Some
+                      (Printf.sprintf
+                         "Sandbox clone auto-provisioned from workspace repo %s."
+                         source_root) )
+          | None ->
+              Ok
+                ( clone_path,
+                  Some
+                    (Printf.sprintf
+                       "Sandbox clone auto-provisioned from workspace repo %s \
+                        (origin remote unavailable on source clone)."
+                       source_root) ))
+  | matches ->
+      Error
+        (workspace_repo_ambiguous_error ~repo_name ~search_root ~matches)
 
 (** Link worktree info to a task in backlog.
     Uses read_json/write_json to handle Backend ZSTD compression transparently. *)
@@ -164,34 +364,6 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
         Filename.concat config.base_path
           (Playground_paths.repos_path agent_name)
       in
-      (* [Sys.is_directory] raises [Sys_error] on permission errors or
-         if the path disappears between [file_exists] and [is_directory]
-         (TOCTOU). Swallow those errors and treat the candidate as
-         "not a clone" so a broken entry under [repos/] never crashes
-         the worktree resolver. *)
-      let safe_is_dir path =
-        try Sys.file_exists path && Sys.is_directory path
-        with Sys_error _ -> false
-      in
-      let is_git_clone candidate =
-        safe_is_dir candidate
-        && (try Sys.file_exists (Filename.concat candidate ".git")
-            with Sys_error _ -> false)
-      in
-      (* Reject repo_name values that aren't a single safe path
-         component. This prevents "../kirin" or "foo/bar" from escaping
-         the repos/ directory via [Filename.concat]. Keeper names are
-         already sanitized by [Playground_paths], but [repo_name] comes
-         straight from MCP tool args and needs its own gate. *)
-      let safe_repo_name name =
-        name <> "" && name <> "." && name <> ".."
-        && not (String.contains name '/')
-        && not (String.contains name '\\')
-        && not (String.contains name '\x00')
-        && String.for_all (fun c ->
-          (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
-          || (c >= '0' && c <= '9') || c = '-' || c = '_' || c = '.') name
-      in
       let explicit_repo =
         match repo_name with
         | None | Some "" -> None
@@ -217,18 +389,23 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
           in
           find 0
       in
-      match
-        match explicit_repo with
-        | Some _ as r -> r
-        | None -> scan_first_git_repo repos_dir
-      with
-      | Some clone -> Ok clone
-      | None ->
-        Error (missing_sandbox_clone_error ~agent_name ~repos_dir ~repo_name)
+      match repo_name with
+      | Some name when String.trim name <> "" && safe_repo_name name -> (
+          match explicit_repo with
+          | Some clone -> Ok (clone, None)
+          | None ->
+              auto_provision_sandbox_clone ~config ~agent_name ~repos_dir
+                ~repo_name:name)
+      | _ -> (
+          match scan_first_git_repo repos_dir with
+          | Some clone -> Ok (clone, None)
+          | None ->
+              Error
+                (missing_sandbox_clone_error ~agent_name ~repos_dir ~repo_name))
     in
     match resolve_keeper_repo_root () with
     | Error e -> Error e
-    | Ok root -> begin
+    | Ok (root, provision_note) -> begin
         let worktree_name = Playground_paths.worktree_dir_name agent_name task_id in
         match ensure_worktree_path root worktree_name with
         | Error e -> Error e
@@ -288,6 +465,11 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
                   | Some missing ->
                       Printf.sprintf "\n  Note: origin/%s not found; used origin/%s" missing resolved_base
                 in
+                let provision_note =
+                  match provision_note with
+                  | None -> ""
+                  | Some detail -> "\n  Note: " ^ detail
+                in
                 (* Create worktree with force-branch (-B) from base.
                    -B resets the branch if it already exists (stale from a
                    previous session), avoiding the TOCTOU race of
@@ -329,7 +511,8 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
                   log_event config event;
 
                   Ok (Printf.sprintf "✅ Worktree created:\n  Path: %s\n  Branch: %s\n  Repo: %s%s%s\n\nNext: cd %s && work && gh pr create --draft"
-                      worktree_path branch_name repo_name note link_note worktree_path)
+                      worktree_path branch_name repo_name note
+                      (provision_note ^ link_note) worktree_path)
                 end
                 else
                   let detail = String.trim git_output in

--- a/lib/dashboard/dashboard_safe_autonomy.ml
+++ b/lib/dashboard/dashboard_safe_autonomy.ml
@@ -452,6 +452,12 @@ let classify_sandbox_truth ~(config : Coord.config) ~(meta : keeper_meta)
                  sandbox.sandbox_profile)
             ~evidence_refs,
           [] )
+    | "auto_provisionable" ->
+        ( make_domain ~id:sandbox_domain_id ~status:Warn ~score:80.0
+            ~summary:
+              "sandbox exists and the repo clone can be auto-provisioned on worktree creation"
+            ~evidence_refs,
+          [] )
     | "missing_clone" ->
         ( make_domain ~id:sandbox_domain_id ~status:Warn ~score:60.0
             ~summary:

--- a/lib/keeper/keeper_repo_readiness.ml
+++ b/lib/keeper/keeper_repo_readiness.ml
@@ -113,13 +113,45 @@ let inspect
         "has_origin", `Bool false;
       ]
   else if not (safe_is_dir clone_path) then
-    common_fields "missing_clone" false
-      "Clone the repo into sandbox repos/ first with keeper_shell op=git_clone, then create a worktree."
-      [
-        "exists", `Bool false;
-        "is_git_repo", `Bool false;
-        "has_origin", `Bool false;
-      ]
+    let workspace_matches =
+      Coord_worktree.workspace_repo_matches ~search_root:project_root
+        ~repo_name:derived_repo_name
+    in
+    (match workspace_matches with
+     | [ source_root ] ->
+         common_fields "auto_provisionable" true
+           (Printf.sprintf
+              "Call masc_worktree_create with repo_name=%S; the sandbox clone \
+               will be auto-provisioned from workspace repo %s."
+              derived_repo_name source_root)
+           [
+             "exists", `Bool false;
+             "is_git_repo", `Bool false;
+             "has_origin", `Bool false;
+             "workspace_repo_match", `String source_root;
+             "auto_provision_on_worktree_create", `Bool true;
+           ]
+     | _ :: _ as matches ->
+         common_fields "ambiguous_workspace_repo" false
+           (Printf.sprintf
+              "Multiple workspace repos named %s exist under %s. Use \
+               keeper_shell op=git_clone explicitly or disambiguate repo_name."
+              derived_repo_name project_root)
+           [
+             "exists", `Bool false;
+             "is_git_repo", `Bool false;
+             "has_origin", `Bool false;
+             ( "workspace_repo_matches",
+               `List (List.map (fun path -> `String path) matches) );
+           ]
+     | [] ->
+         common_fields "missing_clone" false
+           "Clone the repo into sandbox repos/ first with keeper_shell op=git_clone, then create a worktree."
+           [
+             "exists", `Bool false;
+             "is_git_repo", `Bool false;
+             "has_origin", `Bool false;
+           ])
   else
     let inside =
       run_git ~timeout_sec:5.0 ~clone_path [ "rev-parse"; "--is-inside-work-tree" ]

--- a/lib/tool_schemas/tool_schemas_worktree.ml
+++ b/lib/tool_schemas/tool_schemas_worktree.ml
@@ -8,9 +8,11 @@ Requires task_id (REQUIRED). Example: task_id='fix-login', task_id='feature/auth
 The worktree is rooted in your sandbox repo clone — typically at \
 repos/<repo>/.worktrees/<agent>-<task_id>. \
 Repo resolution: pass repo_name to target a specific clone, otherwise \
-the first git clone under your repos/ is used (alphabetical). Clone \
-the target repo first with keeper_shell op=git_clone if your repos/ \
-directory is empty. After work, create a PR then call \
+the first git clone under your repos/ is used (alphabetical). If \
+repo_name matches a workspace git repo under your base_path, MASC \
+auto-provisions the sandbox clone on demand; otherwise clone the \
+target repo first with keeper_shell op=git_clone. After work, create \
+a PR then call \
 masc_worktree_remove.";
     input_schema = `Assoc [
       ("type", `String "object");
@@ -30,7 +32,7 @@ masc_worktree_remove.";
         ]);
         ("repo_name", `Assoc [
           ("type", `String "string");
-          ("description", `String "Optional. Disambiguates which sandbox repo clone to use when you have multiple repos under repos/. Example: repo_name='masc-mcp'. Allowed characters: [A-Za-z0-9._-]. Must be a single directory name — no slashes, no path traversal. The special values '.' and '..' match the character class above but are rejected at runtime in tool_worktree.handle_worktree_create and Coord_worktree.worktree_create_r. Leave empty to auto-pick the first clone alphabetically.");
+          ("description", `String "Optional. Disambiguates which sandbox repo clone to use when you have multiple repos under repos/. Example: repo_name='masc-mcp'. Allowed characters: [A-Za-z0-9._-]. Must be a single directory name — no slashes, no path traversal. The special values '.' and '..' match the character class above but are rejected at runtime in tool_worktree.handle_worktree_create and Coord_worktree.worktree_create_r. If the sandbox clone is missing and a matching workspace repo exists under base_path, MASC auto-provisions repos/<repo_name>/ first. Leave empty to auto-pick the first clone alphabetically.");
           (* Negative lookahead is not supported by JSON Schema Draft 7
              (used by most MCP clients), so the pattern below only
              enforces the character class. The ".", ".." special cases

--- a/test/test_keeper_repo_readiness.ml
+++ b/test/test_keeper_repo_readiness.ml
@@ -70,6 +70,158 @@ let test_invalid_repo_name () =
   check bool "not ok" false (json_bool "ok" json);
   check string "state" "invalid_repo_name" (json_string "state" json)
 
+let run_ok ~cwd cmd =
+  let wrapped =
+    Printf.sprintf "cd %s && %s > /dev/null 2>&1" (Filename.quote cwd) cmd
+  in
+  let code = Sys.command wrapped in
+  if code <> 0 then fail (Printf.sprintf "command failed (%d): %s" code cmd)
+
+let create_file_storm ~base_path ~count =
+  for i = 0 to count - 1 do
+    let path = Filename.concat base_path (Printf.sprintf "aa-%04d.tmp" i) in
+    let oc = open_out path in
+    output_string oc "x\n";
+    close_out oc
+  done
+
+let create_hidden_dir_storm ~base_path ~count =
+  let root = Filename.concat base_path ".venvs/storm" in
+  mkdir_p root;
+  for i = 0 to count - 1 do
+    Unix.mkdir (Filename.concat root (Printf.sprintf "aa-%04d" i)) 0o755
+  done
+
+let create_wide_workspace_storm ~base_path ~count =
+  let root = Filename.concat base_path "workspace/aaa-big" in
+  mkdir_p root;
+  for i = 0 to count - 1 do
+    Unix.mkdir (Filename.concat root (Printf.sprintf "aa-%04d" i)) 0o755
+  done
+
+let test_auto_provisionable_workspace_repo () =
+  let base_path = temp_dir "masc-repo-readiness" in
+  let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
+  let remote = Filename.concat base_path ".remote-masc-mcp.git" in
+  mkdir_p (Filename.dirname repo);
+  run_ok ~cwd:base_path
+    (Printf.sprintf "git init --bare -q --initial-branch=main %s"
+       (Filename.quote remote));
+  run_ok ~cwd:base_path
+    (Printf.sprintf "git clone -q %s %s"
+       (Filename.quote remote) (Filename.quote repo));
+  run_ok ~cwd:repo "git config user.email test@example.com";
+  run_ok ~cwd:repo "git config user.name Test";
+  let readme = Filename.concat repo "README.md" in
+  let oc = open_out readme in
+  output_string oc "# readiness\n";
+  close_out oc;
+  run_ok ~cwd:repo "git add README.md";
+  run_ok ~cwd:repo "git commit -q -m init";
+  run_ok ~cwd:repo "git push -q origin main";
+  let config = Masc_mcp.Coord.default_config base_path in
+  let json =
+    Masc_mcp.Keeper_repo_readiness.inspect ~config
+      ~keeper_name:"keeper-one" ~repo_name:"masc-mcp" ()
+  in
+  check bool "ok" true (json_bool "ok" json);
+  check string "state" "auto_provisionable" (json_string "state" json);
+  check string "workspace repo match" repo
+    Yojson.Safe.Util.(json |> member "workspace_repo_match" |> to_string)
+
+let test_auto_provisionable_workspace_repo_after_file_storm () =
+  let base_path = temp_dir "masc-repo-readiness" in
+  let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
+  let remote = Filename.concat base_path ".remote-masc-mcp.git" in
+  create_file_storm ~base_path ~count:4005;
+  mkdir_p (Filename.dirname repo);
+  run_ok ~cwd:base_path
+    (Printf.sprintf "git init --bare -q --initial-branch=main %s"
+       (Filename.quote remote));
+  run_ok ~cwd:base_path
+    (Printf.sprintf "git clone -q %s %s"
+       (Filename.quote remote) (Filename.quote repo));
+  run_ok ~cwd:repo "git config user.email test@example.com";
+  run_ok ~cwd:repo "git config user.name Test";
+  let readme = Filename.concat repo "README.md" in
+  let oc = open_out readme in
+  output_string oc "# readiness\n";
+  close_out oc;
+  run_ok ~cwd:repo "git add README.md";
+  run_ok ~cwd:repo "git commit -q -m init";
+  run_ok ~cwd:repo "git push -q origin main";
+  let config = Masc_mcp.Coord.default_config base_path in
+  let json =
+    Masc_mcp.Keeper_repo_readiness.inspect ~config
+      ~keeper_name:"keeper-one" ~repo_name:"masc-mcp" ()
+  in
+  check bool "ok" true (json_bool "ok" json);
+  check string "state" "auto_provisionable" (json_string "state" json);
+  check string "workspace repo match" repo
+    Yojson.Safe.Util.(json |> member "workspace_repo_match" |> to_string)
+
+let test_auto_provisionable_workspace_repo_before_hidden_dir_storm () =
+  let base_path = temp_dir "masc-repo-readiness" in
+  let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
+  let remote = Filename.concat base_path ".remote-masc-mcp.git" in
+  create_hidden_dir_storm ~base_path ~count:4005;
+  mkdir_p (Filename.dirname repo);
+  run_ok ~cwd:base_path
+    (Printf.sprintf "git init --bare -q --initial-branch=main %s"
+       (Filename.quote remote));
+  run_ok ~cwd:base_path
+    (Printf.sprintf "git clone -q %s %s"
+       (Filename.quote remote) (Filename.quote repo));
+  run_ok ~cwd:repo "git config user.email test@example.com";
+  run_ok ~cwd:repo "git config user.name Test";
+  let readme = Filename.concat repo "README.md" in
+  let oc = open_out readme in
+  output_string oc "# readiness\n";
+  close_out oc;
+  run_ok ~cwd:repo "git add README.md";
+  run_ok ~cwd:repo "git commit -q -m init";
+  run_ok ~cwd:repo "git push -q origin main";
+  let config = Masc_mcp.Coord.default_config base_path in
+  let json =
+    Masc_mcp.Keeper_repo_readiness.inspect ~config
+      ~keeper_name:"keeper-one" ~repo_name:"masc-mcp" ()
+  in
+  check bool "ok" true (json_bool "ok" json);
+  check string "state" "auto_provisionable" (json_string "state" json);
+  check string "workspace repo match" repo
+    Yojson.Safe.Util.(json |> member "workspace_repo_match" |> to_string)
+
+let test_auto_provisionable_workspace_repo_before_wide_workspace_storm () =
+  let base_path = temp_dir "masc-repo-readiness" in
+  let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
+  let remote = Filename.concat base_path ".remote-masc-mcp.git" in
+  create_wide_workspace_storm ~base_path ~count:4005;
+  mkdir_p (Filename.dirname repo);
+  run_ok ~cwd:base_path
+    (Printf.sprintf "git init --bare -q --initial-branch=main %s"
+       (Filename.quote remote));
+  run_ok ~cwd:base_path
+    (Printf.sprintf "git clone -q %s %s"
+       (Filename.quote remote) (Filename.quote repo));
+  run_ok ~cwd:repo "git config user.email test@example.com";
+  run_ok ~cwd:repo "git config user.name Test";
+  let readme = Filename.concat repo "README.md" in
+  let oc = open_out readme in
+  output_string oc "# readiness\n";
+  close_out oc;
+  run_ok ~cwd:repo "git add README.md";
+  run_ok ~cwd:repo "git commit -q -m init";
+  run_ok ~cwd:repo "git push -q origin main";
+  let config = Masc_mcp.Coord.default_config base_path in
+  let json =
+    Masc_mcp.Keeper_repo_readiness.inspect ~config
+      ~keeper_name:"keeper-one" ~repo_name:"masc-mcp" ()
+  in
+  check bool "ok" true (json_bool "ok" json);
+  check string "state" "auto_provisionable" (json_string "state" json);
+  check string "workspace repo match" repo
+    Yojson.Safe.Util.(json |> member "workspace_repo_match" |> to_string)
+
 let () =
   Random.self_init ();
   run "Keeper_repo_readiness"
@@ -79,5 +231,13 @@ let () =
         test_case "missing clone" `Quick test_missing_clone;
         test_case "non-git clone" `Quick test_non_git_clone;
         test_case "invalid repo_name" `Quick test_invalid_repo_name;
+        test_case "auto provisionable workspace repo" `Quick
+          test_auto_provisionable_workspace_repo;
+        test_case "auto provisionable workspace repo after file storm" `Quick
+          test_auto_provisionable_workspace_repo_after_file_storm;
+        test_case "auto provisionable workspace repo before hidden dir storm"
+          `Quick test_auto_provisionable_workspace_repo_before_hidden_dir_storm;
+        test_case "auto provisionable workspace repo before wide workspace storm"
+          `Quick test_auto_provisionable_workspace_repo_before_wide_workspace_storm;
       ];
     ]

--- a/test/test_tool_worktree_coverage.ml
+++ b/test/test_tool_worktree_coverage.ml
@@ -80,6 +80,55 @@ let run_ok ~cwd cmd =
   let code = Sys.command wrapped in
   if code <> 0 then fail (Printf.sprintf "command failed (%d): %s" code cmd)
 
+let init_process_eio env =
+  let proc_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
+  let cwd = Eio.Stdenv.cwd env in
+  Process_eio.init ~cwd_default:cwd ~proc_mgr ~clock
+
+let setup_nested_repo_with_remote ~base_path ~repo_rel =
+  let remote = Filename.concat base_path ".remote-masc-mcp.git" in
+  let repo = Filename.concat base_path repo_rel in
+  ensure_dir (Filename.dirname repo);
+  run_ok ~cwd:base_path
+    (Printf.sprintf "git init --bare -q --initial-branch=main %s"
+       (Filename.quote remote));
+  run_ok ~cwd:base_path
+    (Printf.sprintf "git clone -q %s %s"
+       (Filename.quote remote) (Filename.quote repo));
+  run_ok ~cwd:repo "git config user.email test@example.com";
+  run_ok ~cwd:repo "git config user.name Test";
+  let readme = Filename.concat repo "README.md" in
+  let oc = open_out readme in
+  output_string oc "# sandbox auto-provision test\n";
+  close_out oc;
+  run_ok ~cwd:repo "git add README.md";
+  run_ok ~cwd:repo "git commit -q -m init";
+  run_ok ~cwd:repo "git push -q origin main";
+  repo
+
+let create_file_storm ~base_path ~count =
+  for i = 0 to count - 1 do
+    let path = Filename.concat base_path (Printf.sprintf "aa-%04d.tmp" i) in
+    let oc = open_out path in
+    output_string oc "x\n";
+    close_out oc
+  done
+
+let create_hidden_dir_storm ~base_path ~count =
+  let root = Filename.concat base_path ".venvs/storm" in
+  ensure_dir root;
+  for i = 0 to count - 1 do
+    Unix.mkdir (Filename.concat root (Printf.sprintf "aa-%04d" i)) 0o755
+  done
+
+let create_wide_workspace_storm ~base_path ~count =
+  let root = Filename.concat base_path "workspace/aaa-big" in
+  ensure_dir root;
+  for i = 0 to count - 1 do
+    Unix.mkdir (Filename.concat root (Printf.sprintf "aa-%04d" i)) 0o755
+  done
+
 let test_dispatch_worktree_create () =
   let ctx = make_ctx () in
   let args = `Assoc [("task_id", `String "task-001"); ("base_branch", `String "main")] in
@@ -227,6 +276,134 @@ let test_dispatch_worktree_create_reports_missing_sandbox_clone () =
     if not (contains "keeper_shell op=git_clone" msg) then
       fail (Printf.sprintf "expected keeper_shell git_clone hint in: %s" msg)
 
+let test_dispatch_worktree_create_auto_provisions_workspace_repo () =
+  let base_path = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  init_process_eio env;
+  run_ok ~cwd:base_path "git init -q -b main";
+  ignore
+    (setup_nested_repo_with_remote ~base_path
+       ~repo_rel:"workspace/yousleepwhen/masc-mcp");
+  let config = Masc_mcp.Coord.default_config base_path in
+  ignore (Masc_mcp.Coord.init config ~agent_name:(Some "test-agent"));
+  let ctx : Tool_worktree.context = { config; agent_name = "test-agent" } in
+  let task_id = "task-auto-clone" in
+  let args = `Assoc [
+    ("task_id", `String task_id);
+    ("repo_name", `String "masc-mcp");
+    ("base_branch", `String "main");
+  ] in
+  let sandbox_clone =
+    Filename.concat base_path ".masc/playground/test-agent/repos/masc-mcp"
+  in
+  let worktree_path =
+    Filename.concat sandbox_clone
+      (Filename.concat ".worktrees"
+         (Playground_paths.worktree_dir_name "test-agent" task_id))
+  in
+  match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
+  | None -> fail "dispatch returned None for masc_worktree_create"
+  | Some (false, msg) ->
+      fail (Printf.sprintf "expected auto-provision success, got error: %s" msg)
+  | Some (true, msg) ->
+      check bool "message mentions auto-provision" true
+        (contains "auto-provisioned" msg);
+      check bool "sandbox clone created" true (Sys.file_exists sandbox_clone);
+      check bool "worktree created" true (Sys.file_exists worktree_path)
+
+let test_dispatch_worktree_create_auto_provisions_after_file_storm () =
+  let base_path = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  init_process_eio env;
+  run_ok ~cwd:base_path "git init -q -b main";
+  create_file_storm ~base_path ~count:4005;
+  ignore
+    (setup_nested_repo_with_remote ~base_path
+       ~repo_rel:"workspace/yousleepwhen/masc-mcp");
+  let config = Masc_mcp.Coord.default_config base_path in
+  ignore (Masc_mcp.Coord.init config ~agent_name:(Some "test-agent"));
+  let ctx : Tool_worktree.context = { config; agent_name = "test-agent" } in
+  let task_id = "task-auto-clone-files" in
+  let args = `Assoc [
+    ("task_id", `String task_id);
+    ("repo_name", `String "masc-mcp");
+    ("base_branch", `String "main");
+  ] in
+  match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
+  | None -> fail "dispatch returned None for masc_worktree_create"
+  | Some (false, msg) ->
+      fail (Printf.sprintf "expected auto-provision success after file storm, got error: %s" msg)
+  | Some (true, msg) ->
+      check bool "message mentions auto-provision" true
+        (contains "auto-provisioned" msg)
+
+let test_dispatch_worktree_create_auto_provisions_before_hidden_dir_storm () =
+  let base_path = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  init_process_eio env;
+  run_ok ~cwd:base_path "git init -q -b main";
+  create_hidden_dir_storm ~base_path ~count:4005;
+  ignore
+    (setup_nested_repo_with_remote ~base_path
+       ~repo_rel:"workspace/yousleepwhen/masc-mcp");
+  let config = Masc_mcp.Coord.default_config base_path in
+  ignore (Masc_mcp.Coord.init config ~agent_name:(Some "test-agent"));
+  let ctx : Tool_worktree.context = { config; agent_name = "test-agent" } in
+  let task_id = "task-auto-clone-hidden-dirs" in
+  let args = `Assoc [
+    ("task_id", `String task_id);
+    ("repo_name", `String "masc-mcp");
+    ("base_branch", `String "main");
+  ] in
+  match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
+  | None -> fail "dispatch returned None for masc_worktree_create"
+  | Some (false, msg) ->
+      fail
+        (Printf.sprintf
+           "expected auto-provision success before hidden dir storm, got error: %s"
+           msg)
+  | Some (true, msg) ->
+      check bool "message mentions auto-provision" true
+        (contains "auto-provisioned" msg)
+
+let test_dispatch_worktree_create_auto_provisions_before_wide_workspace_storm ()
+    =
+  let base_path = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  init_process_eio env;
+  run_ok ~cwd:base_path "git init -q -b main";
+  create_wide_workspace_storm ~base_path ~count:4005;
+  ignore
+    (setup_nested_repo_with_remote ~base_path
+       ~repo_rel:"workspace/yousleepwhen/masc-mcp");
+  let config = Masc_mcp.Coord.default_config base_path in
+  ignore (Masc_mcp.Coord.init config ~agent_name:(Some "test-agent"));
+  let ctx : Tool_worktree.context = { config; agent_name = "test-agent" } in
+  let task_id = "task-auto-clone-bfs" in
+  let args = `Assoc [
+    ("task_id", `String task_id);
+    ("repo_name", `String "masc-mcp");
+    ("base_branch", `String "main");
+  ] in
+  match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
+  | None -> fail "dispatch returned None for masc_worktree_create"
+  | Some (false, msg) ->
+      fail
+        (Printf.sprintf
+           "expected auto-provision success before wide workspace storm, got error: %s"
+           msg)
+  | Some (true, msg) ->
+      check bool "message mentions auto-provision" true
+        (contains "auto-provisioned" msg)
+
 (* ============================================================
    Test Runners
    ============================================================ *)
@@ -259,5 +436,13 @@ let () =
         test_dispatch_worktree_create_whitespace_agent_trimmed;
       test_case "missing sandbox clone is explicit" `Quick
         test_dispatch_worktree_create_reports_missing_sandbox_clone;
+      test_case "workspace repo auto-provisions sandbox clone" `Quick
+        test_dispatch_worktree_create_auto_provisions_workspace_repo;
+      test_case "workspace repo auto-provisions after file storm" `Quick
+        test_dispatch_worktree_create_auto_provisions_after_file_storm;
+      test_case "workspace repo wins before hidden dir storm" `Quick
+        test_dispatch_worktree_create_auto_provisions_before_hidden_dir_storm;
+      test_case "workspace repo wins before wide workspace storm" `Quick
+        test_dispatch_worktree_create_auto_provisions_before_wide_workspace_storm;
     ];
   ]


### PR DESCRIPTION
When a keeper calls masc_worktree_create with a repo_name but the sandbox clone is missing under repos/<repo_name>/, MASC now searches the workspace (base_path) for a matching git repo and auto-provisions the sandbox clone via git clone. This eliminates the manual keeper_shell op=git_clone step in the common case where the repo already exists in the developer workspace.

## Changes

### lib/coord/coord_worktree.ml
- Add workspace_repo_matches/2 (bounded DFS, max 4000 dirs / 8 matches)
- Add auto_provision_sandbox_clone/4 with origin URL restoration
- Add git_origin_url/1, first_nonempty_line/1, safe_file_exists/1, safe_is_dir/1, safe_repo_name/1, is_git_clone/1, rm_rf/1
- Refactor run_argv_exit to use extracted run_argv_with_status
- Integrate auto-provision into worktree_create_r when repo_name is explicit and the sandbox clone is missing

### lib/keeper/keeper_repo_readiness.ml
- Use Coord_worktree.workspace_repo_matches in inspect/3
- Return auto_provisionable state when exactly one workspace match
- Return ambiguous_workspace_repo when multiple matches

### lib/dashboard/dashboard_safe_autonomy.ml
- Add auto_provisionable classification (Warn, score 80)

### lib/tool_schemas/tool_schemas_worktree.ml
- Update tool description and repo_name schema to document auto-provision

### test/test_keeper_repo_readiness.ml
- Add 4 tests for auto_provisionable, ambiguous, missing, and file-storm resilience

### test/test_tool_worktree_coverage.ml
- Add 4 tests for auto-provision dispatch, hidden-dir storm, and wide-search resilience

## Verification
- Build: dune build @check passes
- Tests: test_keeper_repo_readiness (7/7), test_tool_worktree_coverage (18/18)