### PR TITLE
[codex] remediate remaining fsm surface drift

### DIFF
--- a/dashboard/src/api/schemas/keeper-composite.test.ts
+++ b/dashboard/src/api/schemas/keeper-composite.test.ts
@@ -28,6 +28,7 @@ describe('parseKeeperCompositeSnapshot', () => {
   it('parses a valid snapshot', () => {
     const result = parseKeeperCompositeSnapshot(VALID_SNAPSHOT)
     expect(result.phase).toBe('Stable')
+    expect(result.collapsed_from).toBeUndefined()
     expect(result.turn_phase).toBe('idle')
     expect(result.is_live).toBe(true)
     expect(result.last_outcome).toBeNull()
@@ -95,6 +96,15 @@ describe('parseKeeperCompositeSnapshot', () => {
     expect(result.measurement.auto_rules).toBeDefined()
     expect(result.measurement.auto_rules!.reflect).toBe(true)
     expect(result.measurement.auto_rules!.goal_drift).toBe(0.1)
+  })
+
+  it('parses collapsed_from when Stable hides a raw keeper phase', () => {
+    const result = parseKeeperCompositeSnapshot({
+      ...VALID_SNAPSHOT,
+      collapsed_from: 'paused',
+    })
+    expect(result.phase).toBe('Stable')
+    expect(result.collapsed_from).toBe('paused')
   })
 
   it('throws CompositeSchemaDriftError for missing required field', () => {

--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -124,6 +124,7 @@ export const KeeperCompositeSnapshotSchema = object({
   run_id: string(),
   ts: number(),
   phase: KeeperCompositePhaseSchema,
+  collapsed_from: optional(nullable(string())),
   turn_phase: KeeperCompositeTurnPhaseSchema,
   decision: object({ stage: KeeperCompositeDecisionStageSchema }),
   cascade: object({ state: KeeperCompositeCascadeStateSchema }),

--- a/dashboard/src/components/fsm-hub-invariant-analysis.test.ts
+++ b/dashboard/src/components/fsm-hub-invariant-analysis.test.ts
@@ -225,6 +225,21 @@ describe('deriveOperationalInsight', () => {
     expect(insight.tone).toBe('warn')
   })
 
+  it('reports raw stable source in detail and evidence when collapsed_from is present', () => {
+    const insight = deriveOperationalInsight(
+      makeSnapshot({
+        phase: 'Stable',
+        collapsed_from: 'paused',
+      }),
+      noObservations,
+      now,
+    )
+    expect(insight.tone).toBe('warn')
+    expect(insight.detail).toContain('raw keeper phase is paused')
+    expect(insight.evidence).toContain('raw paused')
+    expect(insight.nextStep).toContain('paused')
+  })
+
   it('reports ok when not live with last_outcome', () => {
     const insight = deriveOperationalInsight(
       makeSnapshot({

--- a/dashboard/src/components/fsm-hub-invariant-analysis.ts
+++ b/dashboard/src/components/fsm-hub-invariant-analysis.ts
@@ -46,6 +46,7 @@ function invariantDetail(
 }
 
 function nextExpectedStep(snapshot: KeeperCompositeSnapshot): string {
+  const collapsedFrom = snapshot.phase === 'Stable' ? snapshot.collapsed_from : null
   if (!snapshot.is_live) {
     return snapshot.last_outcome
       ? 'The next live turn should repopulate KTC/KDP/KCL from idle placeholders.'
@@ -67,7 +68,9 @@ function nextExpectedStep(snapshot: KeeperCompositeSnapshot): string {
     return 'Draining should complete before the lifecycle settles into Stopped.'
   }
   if (snapshot.phase === 'Stable') {
-    return 'The lifecycle is outside the active turn cycle; the next meaningful edge should come from a new live turn or operator action.'
+    return collapsedFrom
+      ? `The lifecycle is collapsed into Stable from raw phase ${collapsedFrom}; the next meaningful edge should clear that underlying condition before turn activity resumes.`
+      : 'The lifecycle is outside the active turn cycle; the next meaningful edge should come from a new live turn or operator action.'
   }
   if (snapshot.decision.stage === 'gate_rejected') {
     return 'The blocked turn should finalize back to idle without entering cascade/tool execution.'
@@ -163,13 +166,17 @@ export function deriveOperationalInsight(
     }
   }
   if (snapshot.phase === 'Overflowed' || snapshot.phase === 'HandingOff' || snapshot.phase === 'Draining' || snapshot.phase === 'Stable') {
+    const collapsedDetail = snapshot.phase === 'Stable' && snapshot.collapsed_from
+      ? ` The raw keeper phase is ${snapshot.collapsed_from}, so this is not just generic idleness.`
+      : ''
     return {
       tone: 'warn',
       headline: `${snapshot.phase} is the active lifecycle edge`,
-      detail: 'The keeper is transitioning between stable lifecycle states, so the parent FSM matters more than sub-turn activity right now.',
+      detail: `The keeper is transitioning between stable lifecycle states, so the parent FSM matters more than sub-turn activity right now.${collapsedDetail}`,
       nextStep: nextExpectedStep(snapshot),
       evidence: [
         `KSM ${snapshot.phase}`,
+        ...(snapshot.collapsed_from ? [`raw ${snapshot.collapsed_from}`] : []),
         `live ${String(snapshot.is_live)}`,
       ],
     }

--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -251,7 +251,6 @@ const STATE_DESCRIPTIONS: Record<string, string> = {
   running: 'Raw keeper phase indicates the runtime is actively executing turns',
   failing: 'Raw keeper phase indicates recovery / retry handling is active',
   overflowed: 'Raw keeper phase indicates provider context overflow needs compaction or clearance',
-  compacting: 'Raw keeper phase indicates compaction currently owns lifecycle progress',
   handing_off: 'Raw keeper phase indicates state handoff is underway',
   draining: 'Raw keeper phase indicates shutdown is in progress',
   offline: 'Raw keeper phase indicates the keeper has not started yet',

--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -248,6 +248,18 @@ const STATE_DESCRIPTIONS: Record<string, string> = {
   Failing: 'Experiencing errors, will retry or recover',
   Draining: 'Finishing current work before shutdown',
   Stable: 'Outside the active turn cycle; idle terminal or quiescent parent phases collapse here',
+  running: 'Raw keeper phase indicates the runtime is actively executing turns',
+  failing: 'Raw keeper phase indicates recovery / retry handling is active',
+  overflowed: 'Raw keeper phase indicates provider context overflow needs compaction or clearance',
+  compacting: 'Raw keeper phase indicates compaction currently owns lifecycle progress',
+  handing_off: 'Raw keeper phase indicates state handoff is underway',
+  draining: 'Raw keeper phase indicates shutdown is in progress',
+  offline: 'Raw keeper phase indicates the keeper has not started yet',
+  paused: 'Raw keeper phase indicates operator pause or retry exhaustion',
+  stopped: 'Raw keeper phase indicates a clean terminal stop',
+  crashed: 'Raw keeper phase indicates a crash that may need restart or investigation',
+  restarting: 'Raw keeper phase indicates supervisor restart flow is active',
+  dead: 'Raw keeper phase indicates restart budget is exhausted',
 }
 
 export function HeroPhase({
@@ -284,11 +296,23 @@ export function HeroPhase({
   }
   const color = phaseColor[snapshot.phase] ?? 'text-[var(--accent)]'
   const heldFor = phaseSince != null ? fmtDuration(Math.max(0, now - phaseSince)) : null
+  const collapsedSource = snapshot.phase === 'Stable' ? snapshot.collapsed_from : null
+  const collapsedSourceLabel = collapsedSource
+    ? `${displayState(collapsedSource)} (${collapsedSource})`
+    : null
+  const title = collapsedSource
+    ? `${STATE_DESCRIPTIONS[snapshot.phase] ?? snapshot.phase}\nCollapsed from raw keeper phase: ${collapsedSource}\n${STATE_DESCRIPTIONS[collapsedSource] ?? collapsedSource}`
+    : (STATE_DESCRIPTIONS[snapshot.phase] ?? snapshot.phase)
+  const ariaLabel = [
+    `Keeper 상태: ${displayState(snapshot.phase)}`,
+    collapsedSourceLabel ? `collapsed from ${collapsedSourceLabel}` : null,
+    heldFor,
+  ].filter(Boolean).join(', ')
 
   return html`
     <div class=${`rounded border p-5 transition-all duration-700 ${flash ? 'border-[var(--accent)] bg-[rgba(71,184,255,0.06)] shadow-[0_0_16px_var(--accent-20)]' : 'border-[var(--white-8)] bg-[var(--white-2)]'}`}
-      role="status" aria-live="polite" aria-label=${`Keeper 상태: ${displayState(snapshot.phase)}${heldFor ? `, ${heldFor}` : ''}`}
-      title=${STATE_DESCRIPTIONS[snapshot.phase] ?? snapshot.phase}
+      role="status" aria-live="polite" aria-label=${ariaLabel}
+      title=${title}
     >
       <div class="flex items-baseline justify-between">
         <div>
@@ -297,6 +321,11 @@ export function HeroPhase({
             ${displayState(snapshot.phase)}
           </div>
           <div class="mt-0.5 text-3xs font-mono text-[var(--text-dim)]">${snapshot.phase}</div>
+          ${collapsedSourceLabel ? html`
+            <div class="mt-1 text-3xs font-mono text-[var(--text-dim)]">
+              collapsed from <span class="text-[var(--text-body)]">${collapsedSourceLabel}</span>
+            </div>
+          ` : null}
           ${heldFor ? html`
             <div class="mt-1 text-3xs font-mono text-[var(--text-dim)]" aria-hidden="true">
               유지 <span class="text-[var(--text-body)]">${heldFor}</span>

--- a/dashboard/src/components/fsm-hub-types.test.ts
+++ b/dashboard/src/components/fsm-hub-types.test.ts
@@ -86,6 +86,8 @@ describe('displayState', () => {
     expect(displayState('executing')).toBe('실행 중')
     expect(displayState('Crashed')).toBe('비정상 종료')
     expect(displayState('Paused')).toBe('일시 중지')
+    expect(displayState('paused')).toBe('일시 중지')
+    expect(displayState('crashed')).toBe('비정상 종료')
   })
 
   it('returns raw value for unknown states', () => {

--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -159,6 +159,18 @@ export const STATE_DISPLAY_NAMES: Record<string, string> = {
   // KMC
   accumulating: '수집 중',
   // KSM
+  running: '가동 중',
+  failing: '오류 발생',
+  overflowed: '컨텍스트 초과',
+  compacting: '압축 중',
+  handing_off: '인수인계',
+  draining: '종료 준비',
+  offline: '오프라인',
+  paused: '일시 중지',
+  stopped: '정지',
+  crashed: '비정상 종료',
+  restarting: '재시작 중',
+  dead: '종료됨',
   Running: '가동 중',
   Overflowed: '컨텍스트 초과',
   Compacting: '압축 중',

--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -162,7 +162,6 @@ export const STATE_DISPLAY_NAMES: Record<string, string> = {
   running: '가동 중',
   failing: '오류 발생',
   overflowed: '컨텍스트 초과',
-  compacting: '압축 중',
   handing_off: '인수인계',
   draining: '종료 준비',
   offline: '오프라인',

--- a/dashboard/src/components/fsm-hub.integration.test.ts
+++ b/dashboard/src/components/fsm-hub.integration.test.ts
@@ -118,8 +118,19 @@ describe('FSM Hub integration — API response shape', () => {
     it('accepts the current backend payload shape end-to-end', () => {
       const parsed = parseKeeperCompositeSnapshot(REAL_COMPOSITE_PAYLOAD)
       expect(parsed.phase).toBe('Running')
+      expect(parsed.collapsed_from).toBeUndefined()
       expect(parsed.invariants.phase_turn_alignment).toBe(true)
       expect(parsed.last_outcome).toBeNull()
+    })
+
+    it('preserves collapsed_from when Stable hides a raw keeper phase', () => {
+      const parsed = parseKeeperCompositeSnapshot({
+        ...REAL_COMPOSITE_PAYLOAD,
+        phase: 'Stable',
+        collapsed_from: 'paused',
+      })
+      expect(parsed.phase).toBe('Stable')
+      expect(parsed.collapsed_from).toBe('paused')
     })
 
     it('rejects payloads missing a required field with a pathful error', () => {

--- a/dashboard/src/components/goals/goal-helpers.test.ts
+++ b/dashboard/src/components/goals/goal-helpers.test.ts
@@ -4,7 +4,8 @@ import {
   horizonLabel,
   horizonColor,
   priorityLabel,
-  statusFilterLabel,
+  phaseFilterLabel,
+  matchesGoalPhaseFilter,
   sortByPriority,
   sortByTimeDesc,
   filterTasksByQuery,
@@ -112,28 +113,60 @@ describe('priorityLabel', () => {
 })
 
 // ================================================================
-// statusFilterLabel
+// phaseFilterLabel
 // ================================================================
 
-describe('statusFilterLabel', () => {
+describe('phaseFilterLabel', () => {
   it('returns 전체 for all', () => {
-    expect(statusFilterLabel('all')).toBe('전체')
+    expect(phaseFilterLabel('all')).toBe('전체')
   })
 
-  it('returns 진행 중 for active', () => {
-    expect(statusFilterLabel('active')).toBe('진행 중')
+  it('returns 실행 중 for executing', () => {
+    expect(phaseFilterLabel('executing')).toBe('실행 중')
   })
 
-  it('returns 완료 for completed', () => {
-    expect(statusFilterLabel('completed')).toBe('완료')
+  it('returns Goal 검증 대기 for awaiting_verification', () => {
+    expect(phaseFilterLabel('awaiting_verification')).toBe('Goal 검증 대기')
+  })
+
+  it('returns 승인 대기 for awaiting_approval', () => {
+    expect(phaseFilterLabel('awaiting_approval')).toBe('승인 대기')
+  })
+
+  it('returns 차단됨 for blocked', () => {
+    expect(phaseFilterLabel('blocked')).toBe('차단됨')
   })
 
   it('returns 일시정지 for paused', () => {
-    expect(statusFilterLabel('paused')).toBe('일시정지')
+    expect(phaseFilterLabel('paused')).toBe('일시정지')
+  })
+
+  it('returns 완료 for completed', () => {
+    expect(phaseFilterLabel('completed')).toBe('완료')
+  })
+
+  it('returns 중단 for dropped', () => {
+    expect(phaseFilterLabel('dropped')).toBe('중단')
   })
 
   it('returns 전체 for unknown', () => {
-    expect(statusFilterLabel('custom' as any)).toBe('전체')
+    expect(phaseFilterLabel('custom' as any)).toBe('전체')
+  })
+})
+
+// ================================================================
+// matchesGoalPhaseFilter
+// ================================================================
+
+describe('matchesGoalPhaseFilter', () => {
+  it('matches every phase when filter is all', () => {
+    expect(matchesGoalPhaseFilter('blocked', 'all')).toBe(true)
+    expect(matchesGoalPhaseFilter('completed', 'all')).toBe(true)
+  })
+
+  it('matches only the requested phase', () => {
+    expect(matchesGoalPhaseFilter('awaiting_approval', 'awaiting_approval')).toBe(true)
+    expect(matchesGoalPhaseFilter('executing', 'awaiting_approval')).toBe(false)
   })
 })
 

--- a/dashboard/src/components/goals/goal-helpers.ts
+++ b/dashboard/src/components/goals/goal-helpers.ts
@@ -9,10 +9,18 @@ import type { Goal, Task } from '../../types'
 // -- Filter state ------------------------------------------------
 
 type HorizonFilter = 'all' | 'short' | 'mid' | 'long'
-export type StatusFilter = 'all' | 'active' | 'completed' | 'paused'
+export type GoalPhaseFilter =
+  | 'all'
+  | 'executing'
+  | 'awaiting_verification'
+  | 'awaiting_approval'
+  | 'blocked'
+  | 'paused'
+  | 'completed'
+  | 'dropped'
 
 const horizonFilter = signal<HorizonFilter>('all')
-export const statusFilter = signal<StatusFilter>('all')
+export const phaseFilter = signal<GoalPhaseFilter>('all')
 
 // -- Task-level search (case-insensitive, title + description + assignee) --
 
@@ -56,8 +64,8 @@ const filteredGoals = computed(() => {
   if (horizonFilter.value !== 'all') {
     list = list.filter(g => g.horizon === horizonFilter.value)
   }
-  if (statusFilter.value !== 'all') {
-    list = list.filter(g => g.status === statusFilter.value)
+  if (phaseFilter.value !== 'all') {
+    list = list.filter(g => g.phase === phaseFilter.value)
   }
   return list
 })
@@ -137,11 +145,22 @@ export function priorityLabel(p: number): string {
   }
 }
 
-export function statusFilterLabel(value: StatusFilter): string {
+export function matchesGoalPhaseFilter(
+  phase: string,
+  filter: GoalPhaseFilter,
+): boolean {
+  return filter === 'all' || phase === filter
+}
+
+export function phaseFilterLabel(value: GoalPhaseFilter): string {
   switch (value) {
-    case 'active': return '진행 중'
-    case 'completed': return '완료'
+    case 'executing': return '실행 중'
+    case 'awaiting_verification': return 'Goal 검증 대기'
+    case 'awaiting_approval': return '승인 대기'
+    case 'blocked': return '차단됨'
     case 'paused': return '일시정지'
+    case 'completed': return '완료'
+    case 'dropped': return '중단'
     default: return '전체'
   }
 }

--- a/dashboard/src/components/goals/goal-tree.test.ts
+++ b/dashboard/src/components/goals/goal-tree.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { GoalTreeNode, GoalTreeTask } from '../../types'
-import { filterGoalTree } from './goal-tree'
+import { filterGoalTree, filterGoalTreeByPhase } from './goal-tree'
 
 function makeTask(overrides: Partial<GoalTreeTask> = {}): GoalTreeTask {
   return {
@@ -190,5 +190,58 @@ describe('filterGoalTree', () => {
     })
     const result = filterGoalTree([root], 'anything')
     expect(result).toHaveLength(0)
+  })
+})
+
+describe('filterGoalTreeByPhase', () => {
+  it('returns the input reference when phase filter is all', () => {
+    const nodes: readonly GoalTreeNode[] = [makeNode({ id: 'a', phase: 'executing' })]
+    expect(filterGoalTreeByPhase(nodes, 'all')).toBe(nodes)
+  })
+
+  it('keeps only nodes whose phase matches exactly', () => {
+    const nodes: readonly GoalTreeNode[] = [
+      makeNode({ id: 'a', phase: 'executing' }),
+      makeNode({ id: 'b', phase: 'awaiting_approval' }),
+      makeNode({ id: 'c', phase: 'blocked' }),
+    ]
+    const result = filterGoalTreeByPhase(nodes, 'awaiting_approval')
+    expect(result.map(node => node.id)).toEqual(['b'])
+  })
+
+  it('preserves ancestors when a descendant matches the phase filter', () => {
+    const leaf = makeNode({ id: 'leaf', phase: 'blocked', title: 'Blocked leaf' })
+    const mid = makeNode({
+      id: 'mid',
+      phase: 'executing',
+      title: 'Executing ancestor',
+      tasks: [makeTask({ id: 't-mid', title: 'ancestor task' })],
+      children: [leaf],
+    })
+    const root = makeNode({ id: 'root', phase: 'executing', children: [mid] })
+
+    const result = filterGoalTreeByPhase([root], 'blocked')
+    expect(result).toHaveLength(1)
+    expect(result[0]!.id).toBe('root')
+    expect(result[0]!.tasks).toEqual([])
+    expect(result[0]!.children).toHaveLength(1)
+    expect(result[0]!.children[0]!.id).toBe('mid')
+    expect(result[0]!.children[0]!.tasks).toEqual([])
+    expect(result[0]!.children[0]!.children[0]!.id).toBe('leaf')
+  })
+
+  it('prunes non-matching descendants even when the parent matches', () => {
+    const root = makeNode({
+      id: 'root',
+      phase: 'executing',
+      children: [
+        makeNode({ id: 'keep', phase: 'executing' }),
+        makeNode({ id: 'drop', phase: 'completed' }),
+      ],
+    })
+
+    const result = filterGoalTreeByPhase([root], 'executing')
+    expect(result).toHaveLength(1)
+    expect(result[0]!.children.map(child => child.id)).toEqual(['keep'])
   })
 })

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -6,6 +6,7 @@ import { useEffect, useMemo } from 'preact/hooks'
 import { fetchDashboardGoalDetail, fetchDashboardGoalsTree } from '../../api/dashboard'
 import { EmptyState, ErrorState, LoadingState } from '../common/feedback-state'
 import { ActionButton } from '../common/button'
+import { FilterChips } from '../common/filter-chips'
 import { StatusBadge } from '../common/status-badge'
 import { TimeAgo } from '../common/time-ago'
 import { TaskCreateForm } from '../task-manage/task-create-form'
@@ -25,8 +26,11 @@ import {
   countAwaitingVerificationTasks,
   countAwaitingVerificationInTree,
   countGoalVerificationInTree,
+  type GoalPhaseFilter,
   goalPhaseLabel,
   goalPhaseStatus,
+  matchesGoalPhaseFilter,
+  phaseFilterLabel,
 } from './goal-helpers'
 
 type GoalDetailTab = 'summary' | 'tasks' | 'evidence'
@@ -73,6 +77,41 @@ function pruneNode(node: GoalTreeNode, needle: string): GoalTreeNode | null {
   return {
     ...node,
     tasks: matchingTasks,
+    children: prunedChildren,
+  }
+}
+
+export function filterGoalTreeByPhase(
+  nodes: readonly GoalTreeNode[],
+  filter: GoalPhaseFilter,
+): readonly GoalTreeNode[] {
+  if (filter === 'all') return nodes
+
+  const result: GoalTreeNode[] = []
+  for (const node of nodes) {
+    const pruned = pruneNodeByPhase(node, filter)
+    if (pruned !== null) result.push(pruned)
+  }
+  return result
+}
+
+function pruneNodeByPhase(
+  node: GoalTreeNode,
+  filter: GoalPhaseFilter,
+): GoalTreeNode | null {
+  const nodeMatches = matchesGoalPhaseFilter(node.phase, filter)
+  const prunedChildren: GoalTreeNode[] = []
+  for (const child of node.children) {
+    const prunedChild = pruneNodeByPhase(child, filter)
+    if (prunedChild !== null) prunedChildren.push(prunedChild)
+  }
+
+  if (!nodeMatches && prunedChildren.length === 0) return null
+  if (nodeMatches && prunedChildren.length === node.children.length) return node
+
+  return {
+    ...node,
+    tasks: nodeMatches ? node.tasks : [],
     children: prunedChildren,
   }
 }
@@ -152,6 +191,7 @@ const treeLoading = signal(false)
 const treeError = signal<string | null>(null)
 const expandedNodes = signal<Set<string>>(new Set())
 const filterQuery = signal('')
+const treePhaseFilter = signal<GoalPhaseFilter>('all')
 const selectedGoalId = signal<string | null>(null)
 const detailData = signal<DashboardGoalDetailResponse | null>(null)
 const detailLoading = signal(false)
@@ -737,11 +777,15 @@ export function GoalTree() {
   const loading = treeLoading.value
   const error = treeError.value
   const query = filterQuery.value
+  const activePhaseFilter = treePhaseFilter.value
   const selectedId = selectedGoalId.value
 
   const visibleTree = useMemo(
-    () => (data ? filterGoalTree(data.tree, query) : []),
-    [data, query],
+    () => {
+      if (!data) return []
+      return filterGoalTree(filterGoalTreeByPhase(data.tree, activePhaseFilter), query)
+    },
+    [activePhaseFilter, data, query],
   )
 
   const allNodes = useMemo(
@@ -749,18 +793,30 @@ export function GoalTree() {
     [data],
   )
 
+  const visibleNodes = useMemo(
+    () => flattenGoalTree(visibleTree),
+    [visibleTree],
+  )
+
   const selectedNode = useMemo(
-    () => allNodes.find(node => node.id === selectedId) ?? null,
-    [allNodes, selectedId],
+    () => visibleNodes.find(node => node.id === selectedId) ?? null,
+    [selectedId, visibleNodes],
   )
 
   useEffect(() => {
-    if (!data || allNodes.length === 0) return
-    if (!selectedGoalId.value || !allNodes.some(node => node.id === selectedGoalId.value)) {
-      selectedGoalId.value = allNodes[0]!.id
-      expandedNodes.value = new Set([allNodes[0]!.id])
+    if (!data || allNodes.length === 0) {
+      selectedGoalId.value = null
+      return
     }
-  }, [data, allNodes])
+    if (visibleNodes.length === 0) {
+      selectedGoalId.value = null
+      return
+    }
+    if (!selectedGoalId.value || !visibleNodes.some(node => node.id === selectedGoalId.value)) {
+      selectedGoalId.value = visibleNodes[0]!.id
+      expandedNodes.value = new Set([visibleNodes[0]!.id])
+    }
+  }, [allNodes, data, visibleNodes])
 
   useEffect(() => {
     if (!selectedId) {
@@ -771,7 +827,26 @@ export function GoalTree() {
     void refreshGoalDetail(selectedId)
   }, [selectedId])
 
-  const isFiltering = query.trim() !== ''
+  const phaseCounts = useMemo(() => {
+    const counts: Record<GoalPhaseFilter, number> = {
+      all: allNodes.length,
+      executing: 0,
+      awaiting_verification: 0,
+      awaiting_approval: 0,
+      blocked: 0,
+      paused: 0,
+      completed: 0,
+      dropped: 0,
+    }
+    for (const node of allNodes) {
+      if (node.phase in counts) {
+        counts[node.phase as Exclude<GoalPhaseFilter, 'all'>] += 1
+      }
+    }
+    return counts
+  }, [allNodes])
+
+  const isFiltering = query.trim() !== '' || activePhaseFilter !== 'all'
 
   return html`
     <div class="flex flex-col gap-5">
@@ -812,6 +887,31 @@ export function GoalTree() {
             <//>
           </div>
         </div>
+
+        ${data && data.tree.length > 0 ? html`
+          <div class="mb-4 flex flex-wrap items-center gap-2">
+            <span class="text-3xs font-semibold uppercase tracking-[0.18em] text-text-muted">Goal Phase</span>
+            <${FilterChips}
+              chips=${([
+                'all',
+                'executing',
+                'awaiting_verification',
+                'awaiting_approval',
+                'blocked',
+                'paused',
+                'completed',
+                'dropped',
+              ] as GoalPhaseFilter[]).map(filter => ({
+                key: filter,
+                label: phaseFilterLabel(filter),
+                count: phaseCounts[filter],
+              }))}
+              active=${treePhaseFilter}
+              tone="accent"
+              size="sm"
+            />
+          </div>
+        ` : null}
 
         ${error ? html`<${ErrorState} message=${error} />` : null}
 

--- a/docs/spec/03-room-coordination.md
+++ b/docs/spec/03-room-coordination.md
@@ -1,12 +1,15 @@
 ---
 status: reference
-last_verified: 2026-04-17
+last_verified: 2026-04-22
 code_refs:
   - lib/coord/
+  - lib/coord_goals.ml
+  - lib/goal/
   - lib/tool_task.ml
   - lib/tool_agent.ml
   - lib/tool_worktree.ml
   - lib/tool_control.ml
+  - lib/tool_schemas/tool_schemas_coord_extra.ml
 ---
 
 # Room Coordination
@@ -256,6 +259,54 @@ type tempo_config = {
 3. **Starvation prevention**: 24시간 대기 시 priority boost (-1/24h, min 1)
 4. **정렬**: effective priority 오름차순, 동일 priority 내 FIFO (older first)
 5. **제외 목록**: `exclude_task_ids` + 직전 auto-release된 태스크
+
+---
+
+### 4.5 Goal Planning FSM
+
+Planning의 Goal Store는 task lifecycle과 별개의 Goal-native FSM을 가진다. source of truth는 legacy `status`가 아니라 explicit `phase`다.
+
+```ocaml
+type goal_phase =
+  | Executing
+  | Awaiting_verification
+  | Awaiting_approval
+  | Blocked
+  | Paused
+  | Completed
+  | Dropped
+```
+
+핵심 필드:
+- `goal.phase`: 실제 Goal FSM 상태
+- `goal.status`: coarse compatibility projection (`active | paused | done | dropped`)
+- `goal.verifier_policy`: parent inheritance + local override가 가능한 verifier roster / quorum 설정
+- `goal.require_completion_approval`: verification 통과 후 operator approval gate 필요 여부
+
+도구 surface:
+- `masc_goal_list`: `phase` 기준 조회를 우선 지원하고, `status`는 compatibility alias로만 유지
+- `masc_goal_upsert`: goal metadata + verifier policy 설정
+- `masc_goal_transition`: explicit Goal FSM action (`request_complete`, `pause`, `resume`, `operator_block`, `approve_completion`, ...)
+- `masc_goal_verify`: open verification request에 대한 1 principal 1 vote
+- `masc_goal_review`: legacy wrapper. 새 lifecycle / quorum flow의 정식 surface는 아님
+
+전이 요약:
+
+| 현재 | action | 다음 | 메모 |
+|------|--------|------|------|
+| `executing` | `request_complete` | `completed` | verifier policy도 approval gate도 없을 때 |
+| `executing` | `request_complete` | `awaiting_verification` | quorum verification request snapshot 생성 |
+| `awaiting_verification` | quorum pass | `awaiting_approval` or `completed` | approval 요구 여부에 따라 분기 |
+| `awaiting_verification` | quorum fail | `executing` | goal은 다시 실행 상태로 복귀 |
+| `awaiting_approval` | `approve_completion` | `completed` | verification 이후 최종 operator gate |
+| `awaiting_approval` | `reject_completion` | `blocked` | approval rejection은 blocked로 이동 |
+| `blocked` | `operator_unblock` | `executing` | 재실행 가능 |
+
+Goal verification은 기존 task verification과 저장/판정 모델이 다르다:
+- task verification: criteria 기반 request evaluation
+- goal verification: operator / keeper mixed principals의 N-of-M quorum voting
+
+따라서 Goal verification은 task verification storage를 재사용하지 않고 `lib/goal/goal_verification.ml`의 sibling subsystem으로 유지한다.
 
 ---
 

--- a/docs/spec/10-dashboard.md
+++ b/docs/spec/10-dashboard.md
@@ -1,6 +1,6 @@
 ---
 status: reference
-last_verified: 2026-04-17
+last_verified: 2026-04-22
 code_refs:
   - lib/dashboard/
   - lib/dashboard.ml
@@ -546,7 +546,51 @@ Journal: 최대 200개 항목 보관. agent/text/kind/timestamp.
 - `operator-store.ts`: Operator actions/digest
 - `pending-confirm.ts`: Pending confirmations
 
-### 4.6. Build Pipeline
+### 4.6. Planning / Goal Tree Contract
+
+Workspace `planning`은 Goal Store projection을 goal-first tree로 렌더링한다. 이 surface에서 lifecycle source of truth는 legacy `status`가 아니라 explicit Goal FSM `phase`다.
+
+Goal Tree / goal detail contract:
+- phase badge는 `executing`, `awaiting_verification`, `awaiting_approval`, `blocked`, `paused`, `completed`, `dropped`를 직접 표시
+- coarse `status`는 historical rollup / compatibility 용도만 가진다
+- Goal filter는 `phase` 기준으로 작동해야 하며, `status=active|paused|done|dropped` 같은 coarse bucket에 의존하지 않는다
+- goal verification과 task verification은 분리해서 보여준다
+  - goal-level: `Goal 검증 대기`, quorum summary, open request
+  - task-level: `Task 검증 대기`
+- `awaiting_approval`는 generic `FSM` badge가 아니라 explicit approval badge로 노출한다
+
+Goal Tree recursive filtering rule:
+- matching goal은 자신의 subtree를 유지하되, children도 같은 phase filter로 다시 prune한다
+- non-matching ancestor는 matching descendant의 context로만 유지하고 own task rows는 숨긴다
+
+### 4.7. Keeper Composite / FSM Hub Contract
+
+FSM Hub는 keeper raw lifecycle 전체를 그대로 노출하지 않고 reduced composite KSM (`Running | Failing | Overflowed | Compacting | HandingOff | Draining | Stable`)을 사용한다.
+
+`Stable`은 단순 idle이 아니다. 다음 raw keeper phases가 composite에서 collapse될 수 있다:
+- `offline`
+- `paused`
+- `stopped`
+- `crashed`
+- `restarting`
+- `dead`
+
+따라서 `/api/v1/keepers/:name/composite` snapshot은 optional `collapsed_from` field를 함께 보낸다.
+
+```json
+{
+  "phase": "Stable",
+  "collapsed_from": "paused"
+}
+```
+
+운영자 surface 규칙:
+- `phase`는 TLA-aligned reduced composite state로 유지
+- `collapsed_from`은 `phase="Stable"`일 때 raw keeper phase를 설명하는 보조 필드다
+- dashboard는 `Stable`을 generic calm state로 처리하지 말고, `collapsed_from`이 있으면 `Stable <- paused/crashed/...` 식으로 의미를 풀어줘야 한다
+- backend가 아직 이 field를 보내지 않는 pinned rollout도 있으므로 frontend schema는 missing `collapsed_from`을 허용해야 한다
+
+### 4.8. Build Pipeline
 
 ```bash
 cd dashboard && pnpm run dev    # Vite dev server :5173 (HMR)

--- a/lib/coord_goals.ml
+++ b/lib/coord_goals.ml
@@ -312,12 +312,17 @@ let emit_goal_event ctx ~goal_id ~event_type ~payload =
   Goal_verification.emit_event ctx.config ~goal_id ~event_type ~payload
 
 let handle_goal_list (ctx : context) args =
-  match parse_optional_horizon args "horizon", parse_optional_goal_status args "status" with
-  | Error err, _
-  | _, Error err ->
+  match
+    parse_optional_horizon args "horizon",
+    parse_optional_goal_status args "status",
+    parse_optional_goal_phase args "phase"
+  with
+  | Error err, _, _
+  | _, Error err, _
+  | _, _, Error err ->
       validation_error_result [ err ]
-  | Ok horizon, Ok status ->
-      let goals = Goal_store.list_goals ctx.config ?horizon ?status () in
+  | Ok horizon, Ok status, Ok phase ->
+      let goals = Goal_store.list_goals ctx.config ?horizon ?status ?phase () in
       let rollup = Goal_store.compute_rollup goals in
       ok_result
         [

--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -481,7 +481,7 @@ let sort_goals goals =
           String.compare right.updated_at left.updated_at)
     goals
 
-let list_goals config ?horizon ?status () =
+let list_goals config ?horizon ?status ?phase () =
   read_state config
   |> fun state -> state.goals
   |> List.filter (fun goal ->
@@ -492,6 +492,10 @@ let list_goals config ?horizon ?status () =
          match status with
          | None -> true
          | Some status -> goal.status = status)
+  |> List.filter (fun goal ->
+         match phase with
+         | None -> true
+         | Some phase -> goal.phase = phase)
   |> sort_goals
 
 let upsert_goal config ?id ?horizon ?title ?metric ?target_value ?due_date

--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -107,6 +107,7 @@ type snapshot = {
   run_id : string;
   ts : float;
   ksm_phase : ksm_phase;
+  collapsed_from : Keeper_state_machine.phase option;
   ktc_turn_phase : turn_phase;
   kdp_decision : decision_stage;
   kcl_cascade_state : cascade_state;
@@ -258,6 +259,19 @@ let derive_ksm_phase (phase : Keeper_state_machine.phase) : ksm_phase =
   | Keeper_state_machine.Restarting
   | Keeper_state_machine.Dead -> Ksm_stable
 
+let collapsed_from_phase
+    (phase : Keeper_state_machine.phase)
+    (derived : ksm_phase)
+    : Keeper_state_machine.phase option =
+  match derived with
+  | Ksm_stable -> Some phase
+  | Ksm_running
+  | Ksm_failing
+  | Ksm_overflowed
+  | Ksm_compacting
+  | Ksm_handing_off
+  | Ksm_draining -> None
+
 (* Exhaustive on [ksm_phase]: the prior wildcard hid the design
    decision for new ksm_phase variants and made the dashboard report
    Turn_idle for keepers in Ksm_failing / Ksm_overflowed when there is
@@ -396,6 +410,7 @@ let observe
   in
   let is_live = entry.current_turn_observation <> None in
   let ksm_phase = derive_ksm_phase entry.phase in
+  let collapsed_from = collapsed_from_phase entry.phase ksm_phase in
   let turn_phase = live_turn_phase entry in
   let compaction_stage = entry.compaction_stage in
   let decision_stage = live_decision_stage entry in
@@ -421,6 +436,7 @@ let observe
     run_id;
     ts;
     ksm_phase;
+    collapsed_from;
     ktc_turn_phase = turn_phase;
     kdp_decision = decision_stage;
     kcl_cascade_state = cascade_state;
@@ -479,6 +495,10 @@ let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
     "run_id", `String s.run_id;
     "ts", `Float s.ts;
     "phase", `String (ksm_phase_to_string s.ksm_phase);
+    ( "collapsed_from",
+      match s.collapsed_from with
+      | Some phase -> `String (Keeper_state_machine.phase_to_string phase)
+      | None -> `Null );
     "turn_phase", `String (turn_phase_to_string s.ktc_turn_phase);
     "decision", `Assoc [
       "stage", `String (decision_stage_to_string s.kdp_decision);

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -135,6 +135,11 @@ type snapshot = {
   run_id : string;
   ts : float;
   ksm_phase : ksm_phase;
+  collapsed_from : Keeper_state_machine.phase option;
+      (** Raw keeper phase collapsed into [Ksm_stable], when applicable.
+          [None] for active composite phases or older payload readers.
+          Lets operator surfaces distinguish "quiet" from terminal or
+          operator-paused raw phases without widening the composite enum. *)
   ktc_turn_phase : turn_phase;
   kdp_decision : decision_stage;
   kcl_cascade_state : cascade_state;

--- a/lib/tool_schemas/tool_schemas_coord_extra.ml
+++ b/lib/tool_schemas/tool_schemas_coord_extra.ml
@@ -78,7 +78,7 @@ let schemas : tool_schema list =
     {
       name = "masc_goal_list";
       description =
-        "List shared planning goals from the Goal Store, optionally filtered by horizon or legacy status. \
+        "List shared planning goals from the Goal Store, optionally filtered by horizon, explicit phase, or legacy status. \
 Use when a PM/planner agent needs current long/mid/short goals before creating tasks or reviews. \
 The dashboard Goal Tree reads the same store. Linked tasks prefer structured task.goal_id; title tags like [goal:<id>] remain a legacy fallback. \
 The response includes each goal's explicit lifecycle phase and verification policy.";
@@ -90,6 +90,7 @@ The response includes each goal's explicit lifecycle phase and verification poli
               `Assoc
                 [
                   ("horizon", enum_schema ~description:"Optional horizon filter" goal_horizon_enum);
+                  ("phase", enum_schema ~description:"Optional explicit Goal FSM phase filter" goal_phase_enum);
                   ("status", enum_schema ~description:"Optional legacy status filter" goal_status_enum);
                 ] );
           ];

--- a/test/test_goal_store.ml
+++ b/test/test_goal_store.ml
@@ -150,6 +150,26 @@ let test_blocked_phase_projects_legacy_status () =
   check string "blocked phase projects to paused status" "paused"
     (match goal.status with Paused -> "paused" | _ -> "other")
 
+let test_list_goals_filters_by_phase () =
+  with_room @@ fun config ->
+  let make title phase =
+    match Goal_store.upsert_goal config ~title ~phase () with
+    | Ok _ -> ()
+    | Error msg -> fail msg
+  in
+  make "Executing goal" Goal_phase.Executing;
+  make "Approval goal" Goal_phase.Awaiting_approval;
+  make "Blocked goal" Goal_phase.Blocked;
+  let goals =
+    Goal_store.list_goals config ~phase:Goal_phase.Awaiting_approval ()
+  in
+  check int "one goal in awaiting approval" 1 (List.length goals);
+  match goals with
+  | [ goal ] ->
+      check string "filtered phase preserved" "awaiting_approval"
+        (Goal_phase.to_string goal.phase)
+  | _ -> fail "expected one filtered goal"
+
 let test_update_missing_goal_does_not_bump () =
   with_room @@ fun config ->
   let goal = make_goal "exists" "one goal" in
@@ -177,5 +197,7 @@ let () =
             test_legacy_status_defaults_phase;
           test_case "blocked phase projects legacy status" `Quick
             test_blocked_phase_projects_legacy_status;
+          test_case "list_goals filters by phase" `Quick
+            test_list_goals_filters_by_phase;
           test_case "missing update: no bump" `Quick
             test_update_missing_goal_does_not_bump ] ) ]

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -101,6 +101,41 @@ let test_goal_upsert_and_list () =
   in
   check int "one listed goal" 1 count
 
+let test_goal_list_filters_by_phase () =
+  with_room @@ fun config ->
+  let create ~title ~phase =
+    let created =
+      Tool_coord.dispatch (coord_ctx config) ~name:"masc_goal_upsert"
+        ~args:
+          (`Assoc
+            [
+              ("title", `String title);
+              ("phase", `String phase);
+            ])
+    in
+    match created with
+    | Some result -> ignore (parse_json_result result)
+    | None -> fail "masc_goal_upsert not handled"
+  in
+  create ~title:"Executing goal" ~phase:"executing";
+  create ~title:"Blocked goal" ~phase:"blocked";
+  let listed =
+    Tool_coord.dispatch (coord_ctx config) ~name:"masc_goal_list"
+      ~args:(`Assoc [ ("phase", `String "blocked") ])
+  in
+  let listed_json =
+    match listed with
+    | Some result -> parse_json_result result
+    | None -> fail "masc_goal_list not handled"
+  in
+  let goals = Yojson.Safe.Util.member "goals" listed_json |> Yojson.Safe.Util.to_list in
+  check int "one listed goal by phase" 1 (List.length goals);
+  match goals with
+  | [ goal_json ] ->
+      check string "phase filter honored" "blocked"
+        (get_string_field goal_json "phase")
+  | _ -> fail "expected one filtered goal"
+
 let test_goal_review_updates_status () =
   with_room @@ fun config ->
   let goal, _kind =
@@ -383,6 +418,7 @@ let () =
       ( "tool_coord",
         [
           test_case "upsert and list" `Quick test_goal_upsert_and_list;
+          test_case "list filters by phase" `Quick test_goal_list_filters_by_phase;
           test_case "review updates status" `Quick test_goal_review_updates_status;
           test_case "transition verify complete" `Quick
             test_goal_transition_verification_to_completion;

--- a/test/test_keeper_composite_observer.ml
+++ b/test/test_keeper_composite_observer.ml
@@ -6,6 +6,10 @@ open Alcotest
 
 module Obs = Masc_mcp.Keeper_composite_observer
 module P = Masc_mcp.Prometheus
+module Json = Yojson.Safe.Util
+module Reg = Masc_mcp.Keeper_registry
+module Ksm = Masc_mcp.Keeper_state_machine
+module Keeper_types = Masc_mcp.Keeper_types
 
 let counter_name = "masc_keeper_invariant_violations_total"
 
@@ -28,6 +32,26 @@ let all_violated : Obs.invariants_check = {
   compaction_atomicity = false;
   event_priority_monotone = false;
 }
+
+let make_meta name =
+  match Keeper_types.meta_of_json
+          (`Assoc
+             [
+               ("name", `String name);
+               ("agent_name", `String ("agent-" ^ name));
+               ("trace_id", `String ("trace-" ^ name));
+             ])
+  with
+  | Ok meta -> meta
+  | Error err -> fail ("make_meta failed: " ^ err)
+
+let with_registry f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Reg.clear ();
+  Fun.protect
+    ~finally:(fun () -> Reg.clear ())
+    f
 
 (* --- bump: no-op when all satisfied ------------------------------- *)
 
@@ -103,6 +127,38 @@ let test_all_invariant_keys_mapped () =
       "CompactionAtomicity"; "EventPriorityMonotone" ]
     strings
 
+let test_snapshot_reports_collapsed_from_for_stable_phase () =
+  with_registry (fun () ->
+    let base_path = "/tmp/keeper-composite-collapsed-from" in
+    let keeper_name = "stable-paused" in
+    ignore (Reg.register ~base_path keeper_name (make_meta keeper_name));
+    ignore (Reg.dispatch_event ~base_path keeper_name Ksm.Operator_pause);
+    let entry =
+      match Reg.get ~base_path keeper_name with
+      | Some entry -> entry
+      | None -> fail "expected paused keeper entry"
+    in
+    let snapshot = Obs.observe entry |> Obs.snapshot_to_json in
+    check (option string) "stable snapshot exposes raw paused phase"
+      (Some "paused")
+      (Json.member "collapsed_from" snapshot |> Json.to_string_option);
+    check (option string) "collapsed snapshot stays on Stable composite phase"
+      (Some "Stable")
+      (Json.member "phase" snapshot |> Json.to_string_option))
+
+let test_snapshot_omits_collapsed_from_for_active_phase () =
+  with_registry (fun () ->
+    let base_path = "/tmp/keeper-composite-active-phase" in
+    let keeper_name = "still-running" in
+    let entry = Reg.register ~base_path keeper_name (make_meta keeper_name) in
+    let snapshot = Obs.observe entry |> Obs.snapshot_to_json in
+    check (option string) "active composite phase does not expose raw collapse"
+      None
+      (Json.member "collapsed_from" snapshot |> Json.to_string_option);
+    check (option string) "running phase preserved"
+      (Some "Running")
+      (Json.member "phase" snapshot |> Json.to_string_option))
+
 let () =
   run "keeper_composite_observer" [
     "bump_invariant_violations",
@@ -113,4 +169,8 @@ let () =
     ];
     "invariant_key mapping",
     [ test_case "all keys present and named" `Quick test_all_invariant_keys_mapped ];
+    "snapshot projection",
+    [ test_case "stable phase exposes collapsed_from" `Quick test_snapshot_reports_collapsed_from_for_stable_phase
+    ; test_case "active phase leaves collapsed_from null" `Quick test_snapshot_omits_collapsed_from_for_active_phase
+    ];
   ]


### PR DESCRIPTION
## What changed

- promoted Goal `phase` to a first-class query/filter axis across the backend tool surface and Planning UI
- exposed keeper composite `collapsed_from` so `Stable` snapshots can explain which raw keeper phase was collapsed
- documented the Goal FSM / quorum flow and dashboard semantics in the spec docs

## Why

The remaining FSM audit found that the core state machines were mostly sound, but the operator-facing surfaces were still lagging behind:

- `masc_goal_list` and Goal Tree filtering still leaned on legacy coarse `status` buckets instead of explicit Goal FSM `phase`
- the keeper composite/FSM Hub reduced too many raw keeper phases into `Stable`, which hid whether a keeper was paused, crashed, stopped, or just quiet
- the Goal FSM and new tool surfaces existed in code, but not in the spec/help docs

## Impact

- operators can now query goals by explicit lifecycle phase through `masc_goal_list`
- Workspace > Planning now supports direct phase filtering with ancestor-preserving tree pruning
- FSM Hub can show `Stable <- paused/crashed/...` instead of implying all stable snapshots mean the same thing
- docs now describe the Goal-native FSM, quorum verification flow, and the dashboard contract for phase/collapsed composite views

## Root cause

The FSM implementations landed ahead of their query, projection, and documentation surfaces. That left a drift where the state engines knew more than the operator-facing tools and UI exposed.

## Validation

- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fsm-audit-remediation ./test/test_goal_store.exe ./test/test_goal_tools.exe ./test/test_keeper_composite_observer.exe`
- `./_build/default/test/test_goal_store.exe`
- `./_build/default/test/test_goal_tools.exe`
- `./_build/default/test/test_keeper_composite_observer.exe`
- `git diff --check`

## Notes

- frontend package dependencies are not installed in this worktree (`dashboard/node_modules` missing), so Vitest/TS checks for the dashboard files were not run locally here
