### PR TITLE
[codex] avoid Claude in automatic cascades

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,22 +1,36 @@
 {
-  "_comment": "Checked-in seed for cascade authoring. Keep repo defaults boring: one keeper-assignable bootstrap profile (big_three), system-only fallback/phase-routing profiles (default, local_only, local_recovery, tool_rerank), and move personal/live experiments to $MASC_BASE_PATH/.masc/config/cascade.toml.",
-  "_comment_default": "System-only fallback profile for unknown/missing cascade names. Mirrors big_three so fallback stays boring.",
+  "_comment": "Checked-in seed for cascade authoring. Keep repo defaults boring: one keeper-assignable bootstrap profile (big_three), system-only fallback/judge/phase-routing profiles (default, governance_judge, operator_judge, local_only, local_recovery, tool_rerank), and move personal/live experiments to $MASC_BASE_PATH/.masc/config/cascade.toml.",
+  "_comment_default": "System-only fallback profile for unknown/missing cascade names. Mirrors big_three without Claude CLI so automatic recovery does not pull Claude by default.",
   "default_models": [
-    { "model": "claude_code:auto", "weight": 1 },
     { "model": "codex_cli:auto", "weight": 1 },
     { "model": "gemini_cli:auto", "weight": 1 }
   ],
   "default_temperature": 0.2,
   "default_max_tokens": 16384,
   "default_keeper_assignable": false,
-  "_comment_big_three": "Canonical keeper bootstrap profile exposed by the checked-in seed.",
+  "_comment_big_three": "Canonical keeper bootstrap profile exposed by the checked-in seed. Automatic keepers stay off Claude CLI unless an operator opts in via live config.",
   "big_three_models": [
-    { "model": "claude_code:auto", "weight": 1 },
     { "model": "codex_cli:auto", "weight": 1 },
     { "model": "gemini_cli:auto", "weight": 1 }
   ],
   "big_three_temperature": 0.2,
   "big_three_max_tokens": 16384,
+  "_comment_governance_judge": "System-only dashboard governance judge profile. Explicitly defined so background judge loops do not inherit fallback providers such as Claude CLI.",
+  "governance_judge_models": [
+    { "model": "codex_cli:auto", "weight": 1 },
+    { "model": "gemini_cli:auto", "weight": 1 }
+  ],
+  "governance_judge_temperature": 0.2,
+  "governance_judge_max_tokens": 16384,
+  "governance_judge_keeper_assignable": false,
+  "_comment_operator_judge": "System-only dashboard operator judge profile. Mirrors governance_judge so background control loops stay off Claude CLI by default.",
+  "operator_judge_models": [
+    { "model": "codex_cli:auto", "weight": 1 },
+    { "model": "gemini_cli:auto", "weight": 1 }
+  ],
+  "operator_judge_temperature": 0.2,
+  "operator_judge_max_tokens": 16384,
+  "operator_judge_keeper_assignable": false,
   "_comment_local_only": "System-only local phase-routing profile for compacting/handoff paths.",
   "local_only_models": [ "ollama:auto" ],
   "local_only_temperature": 0.2,

--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -1,9 +1,8 @@
-comment = "Checked-in seed for cascade authoring. Keep repo defaults boring: one keeper-assignable bootstrap profile (big_three), system-only fallback/phase-routing profiles (default, local_only, local_recovery, tool_rerank), and move personal/live experiments to $MASC_BASE_PATH/.masc/config/cascade.toml."
+comment = "Checked-in seed for cascade authoring. Keep repo defaults boring: one keeper-assignable bootstrap profile (big_three), system-only fallback/judge/phase-routing profiles (default, governance_judge, operator_judge, local_only, local_recovery, tool_rerank), and move personal/live experiments to $MASC_BASE_PATH/.masc/config/cascade.toml."
 
 [default]
-comment = "System-only fallback profile for unknown/missing cascade names. Mirrors big_three so fallback stays boring."
+comment = "System-only fallback profile for unknown/missing cascade names. Mirrors big_three without Claude CLI so automatic recovery does not pull Claude by default."
 models = [
-  { model = "claude_code:auto", weight = 1 },
   { model = "codex_cli:auto", weight = 1 },
   { model = "gemini_cli:auto", weight = 1 },
 ]
@@ -12,14 +11,33 @@ max_tokens = 16384
 keeper_assignable = false
 
 [big_three]
-comment = "Canonical keeper bootstrap profile exposed by the checked-in seed."
+comment = "Canonical keeper bootstrap profile exposed by the checked-in seed. Automatic keepers stay off Claude CLI unless an operator opts in via live config."
 models = [
-  { model = "claude_code:auto", weight = 1 },
   { model = "codex_cli:auto", weight = 1 },
   { model = "gemini_cli:auto", weight = 1 },
 ]
 temperature = 0.2
 max_tokens = 16384
+
+[governance_judge]
+comment = "System-only dashboard governance judge profile. Explicitly defined so background judge loops do not inherit fallback providers such as Claude CLI."
+models = [
+  { model = "codex_cli:auto", weight = 1 },
+  { model = "gemini_cli:auto", weight = 1 },
+]
+temperature = 0.2
+max_tokens = 16384
+keeper_assignable = false
+
+[operator_judge]
+comment = "System-only dashboard operator judge profile. Mirrors governance_judge so background control loops stay off Claude CLI by default."
+models = [
+  { model = "codex_cli:auto", weight = 1 },
+  { model = "gemini_cli:auto", weight = 1 },
+]
+temperature = 0.2
+max_tokens = 16384
+keeper_assignable = false
 
 [local_only]
 comment = "System-only local phase-routing profile for compacting/handoff paths."

--- a/test/dune
+++ b/test/dune
@@ -128,6 +128,7 @@
         test_observability_provider_contracts
         test_worker_oas_scope_gate
         test_config_doctor
+        test_cascade_toml_materialization
         test_doctor_dispatch
         test_disk_hygiene_script
         test_run_local_script
@@ -242,6 +243,7 @@
           test_observability_provider_contracts
           test_worker_oas_scope_gate
           test_config_doctor
+          test_cascade_toml_materialization
           test_doctor_dispatch
           test_disk_hygiene_script
           test_run_local_script

--- a/test/test_cascade_toml_materialization.ml
+++ b/test/test_cascade_toml_materialization.ml
@@ -1,4 +1,5 @@
 open Alcotest
+open Yojson.Safe.Util
 
 let contains_substring haystack needle =
   let haystack_len = String.length haystack in
@@ -95,6 +96,30 @@ let render_or_fail toml_path =
   | Ok rendered -> rendered
   | Error msg -> failf "unexpected TOML render failure: %s" msg
 
+let model_names_for_profile json profile_name =
+  json
+  |> member (profile_name ^ "_models")
+  |> to_list
+  |> List.map (function
+       | `String model -> model
+       | value -> value |> member "model" |> to_string)
+
+let test_repo_seed_excludes_claude_from_automatic_profiles () =
+  let rendered = render_or_fail (repo_toml_path ()) |> Yojson.Safe.from_string in
+  let expect_profile_models profile_name expected =
+    check (list string) (profile_name ^ " models")
+      expected
+      (model_names_for_profile rendered profile_name)
+  in
+  expect_profile_models "default" [ "codex_cli:auto"; "gemini_cli:auto" ];
+  expect_profile_models "big_three" [ "codex_cli:auto"; "gemini_cli:auto" ];
+  expect_profile_models "governance_judge" [ "codex_cli:auto"; "gemini_cli:auto" ];
+  expect_profile_models "operator_judge" [ "codex_cli:auto"; "gemini_cli:auto" ];
+  check bool "governance_judge is system-only" false
+    (rendered |> member "governance_judge_keeper_assignable" |> to_bool);
+  check bool "operator_judge is system-only" false
+    (rendered |> member "operator_judge_keeper_assignable" |> to_bool)
+
 let test_repo_toml_renders_to_committed_json () =
   let rendered = render_or_fail (repo_toml_path ()) in
   check string "repo cascade json stays in sync with toml"
@@ -180,6 +205,8 @@ let () =
         [
           test_case "repo toml renders to committed json" `Quick
             test_repo_toml_renders_to_committed_json;
+          test_case "repo seed excludes claude from automatic profiles" `Quick
+            test_repo_seed_excludes_claude_from_automatic_profiles;
         ] );
       ( "validation",
         [


### PR DESCRIPTION
## What changed
- remove `claude_code:auto` from the checked-in `default` and `big_three` cascade seeds
- add explicit system-only `governance_judge` and `operator_judge` profiles so dashboard judge loops do not inherit fallback providers
- register `test_cascade_toml_materialization` in `test/dune` and add a regression that asserts automatic seed profiles stay off Claude by default

## Why
Background keeper and dashboard judge paths can fall back to the repo seed cascades when a named system profile is missing. Because the checked-in automatic seeds included `claude_code:auto`, autonomous flows could hit Claude-specific failures such as session-end hook errors or quota exhaustion even when Claude was not intended to be in the default automatic path.

## Impact
Automatic keepers and dashboard judges no longer pull Claude CLI by default from the checked-in seed config. Operators can still opt into Claude explicitly through live cascade config when they actually want it.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-no-claude-auto-20260422 --build-dir /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-no-claude-auto-20260422/_build_codex_no_claude_auto`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-no-claude-auto-20260422 --build-dir /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-no-claude-auto-20260422/_build_codex_no_claude_auto ./test/test_cascade_toml_materialization.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-no-claude-auto-20260422 --build-dir /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-no-claude-auto-20260422/_build_codex_no_claude_auto ./test/test_keeper_cascade_profile.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-no-claude-auto-20260422 --build-dir /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-no-claude-auto-20260422/_build_codex_no_claude_auto ./test/test_dashboard_cascade.exe`