### PR TITLE
[codex] Fix persona create-from-persona pass-through

### DIFF
--- a/lib/keeper/keeper_exec_persona.ml
+++ b/lib/keeper/keeper_exec_persona.ml
@@ -37,7 +37,9 @@ let resolved_keeper_args_to_json
     ~name ~persona_name ~goal ~short_goal ~mid_goal ~long_goal
     ~instructions ~will ~needs ~desires ~policy_voice_enabled
     ~mention_targets
+    ~execution_scope_opt ~allowed_paths_opt
     ~autoboot_enabled_opt
+    ~tool_access_opt
     ~tool_preset ~tool_also_allow ~tool_denylist
     ~proactive_enabled ~shards
     ~auto_handoff ~handoff_threshold ~handoff_cooldown_sec =
@@ -55,8 +57,6 @@ let resolved_keeper_args_to_json
       ("desires", `String desires);
       ("policy_voice_enabled", `Bool policy_voice_enabled);
       ("mention_targets", string_list_to_json mention_targets);
-      ("tool_preset", `String (tool_preset_to_string tool_preset));
-      ("tool_also_allow", string_list_to_json tool_also_allow);
       ("tool_denylist", string_list_to_json tool_denylist);
       ("proactive_enabled", `Bool proactive_enabled);
       ("auto_handoff", `Bool auto_handoff);
@@ -64,17 +64,39 @@ let resolved_keeper_args_to_json
       ("handoff_cooldown_sec", `Int handoff_cooldown_sec);
     ]
   in
+  let execution_scope_field =
+    match execution_scope_opt with
+    | Some scope ->
+        [ ("execution_scope", `String (Keeper_execution_scope.to_string scope)) ]
+    | None -> []
+  in
+  let allowed_paths_field =
+    match allowed_paths_opt with
+    | Some paths -> [("allowed_paths", string_list_to_json paths)]
+    | None -> []
+  in
   let autoboot_field =
     match autoboot_enabled_opt with
     | Some value -> [ ("autoboot_enabled", `Bool value) ]
     | None -> []
+  in
+  let tool_policy_field =
+    match tool_access_opt with
+    | Some tool_access -> [("tool_access", tool_access_to_json tool_access)]
+    | None ->
+        [
+          ("tool_preset", `String (tool_preset_to_string tool_preset));
+          ("tool_also_allow", string_list_to_json tool_also_allow);
+        ]
   in
   let shards_field =
     match shards with
     | Some xs -> [("shards", string_list_to_json xs)]
     | None -> []
   in
-  `Assoc (base @ autoboot_field @ shards_field)
+  `Assoc
+    ( base @ execution_scope_field @ allowed_paths_field @ autoboot_field
+    @ tool_policy_field @ shards_field )
 
 let validate_resolved_keeper_create_json (json : Yojson.Safe.t) : string list =
   let errors = ref [] in
@@ -180,76 +202,56 @@ let resolved_keeper_args_from_persona args :
               |> first_some defaults.proactive_enabled
               |> Option.value ~default:false
             in
+            let execution_scope =
+              get_string_opt args "execution_scope"
+              |> Option.map (fun s ->
+                     match Keeper_execution_scope.of_string s with
+                     | Ok v -> v
+                     | Error (`Unknown_scope raw) ->
+                         Log.Keeper.warn
+                           "masc_keeper_create_from_persona: unknown execution_scope %S, using default"
+                           raw;
+                         Keeper_execution_scope.default)
+              |> first_some defaults.execution_scope
+            in
             let autoboot_enabled = get_bool_opt args "autoboot_enabled" in
-            (match get_string_opt args "tool_preset" with
-             | Some raw -> (
-                 match tool_preset_of_string raw with
-                 | None ->
-                     Error
-                       (Printf.sprintf
-                          "invalid tool_preset '%s' (allowed: minimal, messaging, coding, research, full)"
-                          raw)
-                 | Some tool_preset ->
-                     let tool_also_allow =
-                       match get_string_list args "tool_also_allow" with
-                       | _ :: _ as xs -> xs
-                       | [] -> Option.value ~default:[] defaults.tool_also_allow
-                     in
-                     let tool_denylist =
-                       match get_string_list args "tool_denylist" with
-                       | _ :: _ as xs -> xs
-                       | [] -> Option.value ~default:[] defaults.tool_denylist
-                     in
-                     let shards =
-                       match get_string_list args "shards" with
-                       | _ :: _ as xs -> Some xs
-                       | [] -> defaults.shards
-                     in
-                     let auto_handoff = get_bool args "auto_handoff" true in
-                     let handoff_threshold =
-                       Safe_ops.json_float_opt "handoff_threshold" args
-                       |> Option.value ~default:0.85
-                     in
-                     let handoff_cooldown_sec =
-                       Safe_ops.json_int_opt "handoff_cooldown_sec" args
-                       |> Option.value ~default:300
-                     in
-                     let resolved =
-                       resolved_keeper_args_to_json
-                         ~name
-                         ~persona_name
-                         ~goal ~short_goal ~mid_goal ~long_goal
-                         ~instructions  ~will ~needs ~desires
-                         ~policy_voice_enabled
-                         ~mention_targets
-                         ~autoboot_enabled_opt:autoboot_enabled
-                         ~tool_preset ~tool_also_allow ~tool_denylist
-                         ~proactive_enabled ~shards
-                         ~auto_handoff ~handoff_threshold
-                         ~handoff_cooldown_sec
-                     in
-                     Ok (persona, resolved))
-             | None ->
+            (match
+               Keeper_turn_up_args.parse_tool_access_input args,
+               Keeper_turn_up_args.parse_present_string_list_opt args "allowed_paths"
+             with
+            | Error err, _ | _, Error err -> Error err
+            | Ok (tool_access_opt, tool_preset_opt, tool_also_allow_opt), Ok allowed_paths_opt ->
                  (* #8605 family: warn-and-default via shared helper
                     [Keeper_preset_defaults.preset_of_defaults_warn].
                     Lifted from this file + keeper_turn_up_create to a
                     single SSOT (#8923) so a future third preset-source
                     path cannot diverge. *)
                  let tool_preset =
-                   Keeper_preset_defaults.preset_of_defaults_warn
-                     ~call_site:"keeper_exec_persona"
-                     ~defaults_tool_preset:defaults.tool_preset
-                   |> Option.value ~default:Research
+                   match tool_preset_opt with
+                   | Some preset -> preset
+                   | None -> (
+                       match tool_access_opt with
+                       | Some _ -> Research
+                       | None ->
+                           Keeper_preset_defaults.preset_of_defaults_warn
+                             ~call_site:"keeper_exec_persona"
+                             ~defaults_tool_preset:defaults.tool_preset
+                           |> Option.value ~default:Research)
                  in
                  let tool_also_allow =
-                   match get_string_list args "tool_also_allow" with
-                   | _ :: _ as xs -> xs
-                   | [] -> Option.value ~default:[] defaults.tool_also_allow
+                   match tool_also_allow_opt with
+                   | Some xs -> xs
+                   | None -> Option.value ~default:[] defaults.tool_also_allow
                  in
                  let tool_denylist =
                    match get_string_list args "tool_denylist" with
                    | _ :: _ as xs -> xs
                    | [] -> Option.value ~default:[] defaults.tool_denylist
+                 in
+                 let allowed_paths =
+                   match allowed_paths_opt with
+                   | Some _ as paths -> paths
+                   | None -> defaults.allowed_paths
                  in
                  let shards =
                    match get_string_list args "shards" with
@@ -273,7 +275,10 @@ let resolved_keeper_args_from_persona args :
                      ~instructions  ~will ~needs ~desires
                      ~policy_voice_enabled
                      ~mention_targets
+                     ~execution_scope_opt:execution_scope
+                     ~allowed_paths_opt:allowed_paths
                      ~autoboot_enabled_opt:autoboot_enabled
+                     ~tool_access_opt
                      ~tool_preset ~tool_also_allow ~tool_denylist
                      ~proactive_enabled ~shards
                      ~auto_handoff ~handoff_threshold

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -876,6 +876,85 @@ let test_persona_resolver_preserves_autoboot_enabled_arg () =
          | `Bool value -> Some value
          | _ -> None)
 
+let test_persona_resolver_preserves_execution_scope_from_persona_defaults () =
+  with_personas_dir @@ fun personas_dir ->
+  let persona_dir = Filename.concat personas_dir "probe" in
+  mkdir_p persona_dir;
+  write_file
+    (Filename.concat persona_dir "profile.json")
+    {|
+{
+  "name": "Probe",
+  "keeper": {
+    "goal": "test persona keeper",
+    "execution_scope": "observe_only"
+  }
+}
+|};
+  match
+    Masc_mcp.Keeper_exec_persona.resolved_keeper_args_from_persona
+      (`Assoc
+        [
+          ("persona_name", `String "probe");
+          ("name", `String "probe-shadow");
+        ])
+  with
+  | Error e -> fail ("resolver failed: " ^ e)
+  | Ok (_, resolved) ->
+      check (option string) "execution_scope preserved" (Some "observe_only")
+        (match Yojson.Safe.Util.member "execution_scope" resolved with
+         | `String value -> Some value
+         | _ -> None)
+
+let test_persona_resolver_preserves_canonical_tool_access_and_allowed_paths () =
+  with_personas_dir @@ fun personas_dir ->
+  let persona_dir = Filename.concat personas_dir "probe" in
+  mkdir_p persona_dir;
+  write_file
+    (Filename.concat persona_dir "profile.json")
+    {|
+{
+  "name": "Probe",
+  "keeper": {
+    "goal": "test persona keeper"
+  }
+}
+|};
+  let expected_tool_access =
+    Masc_mcp.Keeper_types.tool_access_to_json
+      (Masc_mcp.Keeper_types.Custom [ "masc_status" ])
+  in
+  match
+    Masc_mcp.Keeper_exec_persona.resolved_keeper_args_from_persona
+      (`Assoc
+        [
+          ("persona_name", `String "probe");
+          ("allowed_paths", `List [ `String "/tmp/demo" ]);
+          ( "tool_access",
+            `Assoc
+              [
+                ("kind", `String "custom");
+                ("tools", `List [ `String "masc_status" ]);
+              ] );
+        ])
+  with
+  | Error e -> fail ("resolver failed: " ^ e)
+  | Ok (_, resolved) ->
+      check string "tool_access preserved"
+        (Yojson.Safe.to_string expected_tool_access)
+        (Yojson.Safe.to_string (Yojson.Safe.Util.member "tool_access" resolved));
+      check (list string) "allowed_paths preserved" [ "/tmp/demo" ]
+        (match Yojson.Safe.Util.member "allowed_paths" resolved with
+         | `List items ->
+             List.filter_map
+               (function `String value -> Some value | _ -> None)
+               items
+         | _ -> []);
+      check bool "tool_preset omitted with canonical tool_access" false
+        (match Yojson.Safe.Util.member "tool_preset" resolved with
+         | `String _ -> true
+         | _ -> false)
+
 (* ================================================================ *)
 (* Unknown-key detection                                             *)
 (* ================================================================ *)
@@ -1170,5 +1249,9 @@ let () =
             test_persona_resolver_rejects_non_public_social_model_arg;
           test_case "persona resolver preserves autoboot_enabled arg" `Quick
             test_persona_resolver_preserves_autoboot_enabled_arg;
+          test_case "persona resolver preserves execution_scope from persona defaults" `Quick
+            test_persona_resolver_preserves_execution_scope_from_persona_defaults;
+          test_case "persona resolver preserves canonical tool_access and allowed_paths" `Quick
+            test_persona_resolver_preserves_canonical_tool_access_and_allowed_paths;
         ] );
     ]


### PR DESCRIPTION
## What Changed
- preserved `execution_scope` from persona-backed defaults when `masc_keeper_create_from_persona` resolves keeper args
- preserved explicit `allowed_paths` and canonical `tool_access` / `tool_custom_allowlist` inputs in the resolved keeper-up payload
- avoided emitting compatibility `tool_preset` fields when canonical `tool_access` is already present
- added regression tests covering `name != persona_name` plus canonical tool policy pass-through

## Why
`masc_keeper_create_from_persona` advertised these inputs in schema, but the resolver dropped them before handing off to `masc_keeper_up`. That made the feature effectively dead for persona-backed keeper creation.

## Impact
Persona-backed keeper creation now honors the same execution-scope and tool-policy inputs that callers are told they can set.

## Validation
- `dune build --root . test/test_keeper_toml.exe`
- `./_build/default/test/test_keeper_toml.exe`
