### PR TITLE
fix(lib): emit traceln on three MED silent-failure sites (#8391)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -612,7 +612,9 @@ let run_turn
         ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
     with
     | Ok cp -> Some cp
-    | Error _ -> None
+    | Error _ ->
+        Eio.traceln "[KeeperAgentRun] load_oas checkpoint failed";
+        None
   in
   (* Starting turn count for per-call budget calculation in hooks.
      With Agent.resume, turn count is cumulative from checkpoint. *)

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -1202,7 +1202,9 @@ let auto_label_for_adapter (adapter : adapter) =
   else
     match default_model_label_for_adapter adapter with
     | Ok label -> Some label
-    | Error _ -> None
+    | Error msg ->
+        Eio.traceln "[ProviderAdapter] default_model_label_for_adapter failed: %s" msg;
+        None
 
 (** Cloud adapters that participate in auto-detection (excludes llama
     which requires explicit model config, and openrouter which requires

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -579,7 +579,9 @@ let handle_vote args =
                   Printf.sprintf " [🧬 %s evolved: %s %s]"
                     author dimension (if is_positive then "+0.01" else "-0.01")
                 end else ""
-            | Error _ -> ""
+            | Error e ->
+                Eio.traceln "[ToolBoard] get_reputation_evolution failed: %s" (board_error_to_string e);
+                ""
       in
       (true, Printf.sprintf "%s Vote recorded. New score: %+d%s" arrow new_score evolution_msg)
   | Error (Board.Already_voted _) ->


### PR DESCRIPTION
Closes remaining MED findings from #8391.\n\n- `lib/tool_board.ml`: reputation lookup failure was concatenated as empty string; operator could not distinguish failure from ineligible.\n- `lib/provider_adapter.ml`: model label resolution failure was silently swallowed, hiding misconfigured provider entries.\n- `lib/keeper/keeper_agent_run.ml`: OAS checkpoint load failure silently fell back to fresh state without trace.\n\nAll three sites now emit `Eio.traceln` with context before returning the existing fallback value.