### PR TITLE
fix: isolate docker keeper sandbox worktrees

### DIFF
--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -129,6 +129,76 @@ let is_git_clone candidate =
   | `Directory | `File -> true
   | `Missing -> false
 
+let keeper_toml_path ~config ~agent_name =
+  let keeper_name = Playground_paths.sanitize_keeper_name agent_name in
+  Filename.concat
+    (Filename.concat
+       (Filename.concat
+          (masc_dir_from_base_path ~base_path:config.base_path)
+          "config")
+       "keepers")
+    (keeper_name ^ ".toml")
+
+let strip_inline_comment line =
+  match String.index_opt line '#' with
+  | Some idx -> String.sub line 0 idx
+  | None -> line
+
+let unquote value =
+  let len = String.length value in
+  if len >= 2 && value.[0] = '"' && value.[len - 1] = '"'
+  then String.sub value 1 (len - 2)
+  else value
+
+let keeper_uses_docker_sandbox ~config ~agent_name =
+  let path = keeper_toml_path ~config ~agent_name in
+  if not (safe_file_exists path) then false
+  else
+    try
+      let lines =
+        In_channel.with_open_text path In_channel.input_all
+        |> String.split_on_char '\n'
+      in
+      let rec loop in_keeper = function
+        | [] -> false
+        | raw_line :: rest ->
+            let line =
+              raw_line |> strip_inline_comment |> String.trim
+            in
+            if line = "" then loop in_keeper rest
+            else if String.length line > 0 && line.[0] = '[' then
+              loop (String.equal line "[keeper]") rest
+            else if
+              in_keeper
+              && String.starts_with ~prefix:"sandbox_profile" line
+            then
+              let value =
+                match String.index_opt line '=' with
+                | None -> ""
+                | Some idx ->
+                    String.sub line (idx + 1) (String.length line - idx - 1)
+                    |> String.trim
+                    |> unquote
+                    |> String.lowercase_ascii
+              in
+              String.equal value "docker"
+            else
+              loop in_keeper rest
+      in
+      loop false lines
+    with Sys_error _ -> false
+
+let repos_dir_of_keeper config agent_name =
+  let safe_name = Playground_paths.sanitize_keeper_name agent_name in
+  let repos_rel =
+    if keeper_uses_docker_sandbox ~config ~agent_name then
+      Printf.sprintf "%s/docker/%s/repos/"
+        Playground_paths.all_playgrounds_prefix safe_name
+    else
+      Playground_paths.repos_path agent_name
+  in
+  Filename.concat config.base_path repos_rel
+
 let rec rm_rf path =
   if safe_file_exists path then
     if safe_is_dir path then begin
@@ -353,17 +423,13 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
   | _, Error e -> Error e
   | Ok _, Ok _ ->
     (* Prefer a keeper's sandbox repo clone under
-       [.masc/playground/<agent>/repos/]. The layout is the SSOT in
-       [Playground_paths] (masc_config). If [repo_name] is supplied,
-       target that clone directly; otherwise scan the directory and
-       pick the first git clone (alphabetical). Keepers may work on
-       any repo their [tool_policy.toml] allows, but the worktree root
-       must come from a sandbox repo clone. *)
+       the keeper's backend-specific sandbox repo lane. If [repo_name]
+       is supplied, target that clone directly; otherwise scan the
+       directory and pick the first git clone (alphabetical). Keepers
+       may work on any repo their [tool_policy.toml] allows, but the
+       worktree root must come from a sandbox repo clone. *)
     let resolve_keeper_repo_root () =
-      let repos_dir =
-        Filename.concat config.base_path
-          (Playground_paths.repos_path agent_name)
-      in
+      let repos_dir = repos_dir_of_keeper config agent_name in
       let explicit_repo =
         match repo_name with
         | None | Some "" -> None
@@ -530,10 +596,7 @@ let worktree_remove_r config ~agent_name ~task_id : string masc_result =
   | _, Error e -> Error e
   | Ok _, Ok _ ->
     let resolve_existing_worktree_root () =
-      let repos_dir =
-        Filename.concat config.base_path
-          (Playground_paths.repos_path agent_name)
-      in
+      let repos_dir = repos_dir_of_keeper config agent_name in
       let worktree_name = Playground_paths.worktree_dir_name agent_name task_id in
       let safe_is_dir path =
         try Sys.file_exists path && Sys.is_directory path

--- a/lib/dashboard/dashboard_safe_autonomy.ml
+++ b/lib/dashboard/dashboard_safe_autonomy.ml
@@ -714,7 +714,7 @@ let build_keeper_snapshot
     ~(activity_by_keeper : (string, activity_stats) Hashtbl.t)
     (meta : keeper_meta) =
   let sandbox = Keeper_sandbox.of_meta ~config ~meta in
-  let repo_readiness = Keeper_repo_readiness.inspect ~config ~keeper_name:meta.name () in
+  let repo_readiness = Keeper_repo_readiness.inspect ~config ~meta () in
   let recommendation =
     recommendation_for_keeper bench_manifest ~keeper_name:meta.name
   in

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -2116,7 +2116,7 @@ let run_turn
     then Some (Keeper_runtime_resolved.admission_wait_timeout_sec ())
     else None
   in
-  ignore (Keeper_alerting_path.ensure_playground_bundle ~config ~name:meta.name);
+  ignore (Keeper_alerting_path.ensure_sandbox_bundle ~config ~meta);
   let effective_allowed_paths = Keeper_alerting_path.effective_allowed_paths ~meta in
   match
     Keeper_alerting_path.absolute_allowed_paths_result

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -270,10 +270,34 @@ let playground_mind_path = Playground_paths.mind_path
 let playground_repos_path = Playground_paths.repos_path
 let playground_bundle_paths = Playground_paths.bundle_paths
 let sandbox_path_of_keeper name = Keeper_sandbox.allowed_root_rel ~name
+let sandbox_path_of_meta ~(meta : Keeper_types.keeper_meta) =
+  Keeper_sandbox.allowed_root_rel_of_meta ~meta
+
+let sandbox_bundle_paths_of_meta ~(meta : Keeper_types.keeper_meta) =
+  let root = sandbox_path_of_meta ~meta |> strip_trailing_slashes in
+  [ root ^ "/"; root ^ "/mind/"; root ^ "/repos/" ]
 
 let ensure_playground_bundle ~(config : Coord.config) ~(name : string) : string list =
   let root = project_root_of_config config in
   playground_bundle_paths name
+  |> List.map (Filename.concat root)
+  |> List.map Keeper_fs.ensure_dir
+
+let ensure_sandbox_bundle ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta)
+    : string list =
+  let root = project_root_of_config config in
+  sandbox_bundle_paths_of_meta ~meta
+  |> List.map (Filename.concat root)
+  |> List.map Keeper_fs.ensure_dir
+
+let ensure_sandbox_bundle_for_profile ~(config : Coord.config)
+    ~(name : string) ~(sandbox_profile : Keeper_types.sandbox_profile) : string list =
+  let root = project_root_of_config config in
+  let sandbox_root =
+    Keeper_sandbox.host_root_rel_of_profile sandbox_profile name
+    |> strip_trailing_slashes
+  in
+  [ sandbox_root ^ "/"; sandbox_root ^ "/mind/"; sandbox_root ^ "/repos/" ]
   |> List.map (Filename.concat root)
   |> List.map Keeper_fs.ensure_dir
 
@@ -284,7 +308,7 @@ let ensure_playground_bundle ~(config : Coord.config) ~(name : string) : string 
     Workspace/local scope no longer grants extra hardcoded paths; every
     additional path must be listed explicitly in [allowed_paths]. *)
 let effective_allowed_paths ~(meta : Keeper_types.keeper_meta) : string list =
-  let sandbox_paths = Keeper_sandbox.allowed_path_roots ~name:meta.name in
+  let sandbox_paths = Keeper_sandbox.allowed_path_roots_of_meta ~meta in
   match meta.allowed_paths with
   | ["*"] -> []
   | explicit -> sandbox_paths @ explicit
@@ -296,7 +320,7 @@ let effective_allowed_paths ~(meta : Keeper_types.keeper_meta) : string list =
     scope no longer grants extra hardcoded paths; every additional path
     must be listed explicitly in [allowed_paths]. *)
 let effective_write_allowed_paths ~(meta : Keeper_types.keeper_meta) : string list =
-  let sandbox_paths = Keeper_sandbox.allowed_path_roots ~name:meta.name in
+  let sandbox_paths = Keeper_sandbox.allowed_path_roots_of_meta ~meta in
   match meta.allowed_paths with
   | ["*"] -> []
   | explicit -> sandbox_paths @ explicit

--- a/lib/keeper/keeper_docker_read.ml
+++ b/lib/keeper/keeper_docker_read.ml
@@ -24,9 +24,7 @@ let strip_trailing_slashes path =
   if len = String.length path then path else String.sub path 0 len
 
 let host_playground_root ~config ~(meta : keeper_meta) =
-  Filename.concat
-    (Keeper_alerting_path.project_root_of_config config)
-    (Keeper_alerting_path.playground_path_of_keeper meta.name)
+  Keeper_sandbox.host_root_abs_of_meta ~config meta
   |> Keeper_alerting_path.normalize_path_for_check
   |> strip_trailing_slashes
 

--- a/lib/keeper/keeper_exec_memory.ml
+++ b/lib/keeper/keeper_exec_memory.ml
@@ -374,9 +374,12 @@ let keeper_context_status_json
   (* Give the keeper sandbox-relative paths from the SSOT so it never needs
      to interpolate host storage paths such as ".masc/playground/<name>/". *)
   let sandbox = Keeper_sandbox.of_meta ~config ~meta in
-  let playground_bundle = Playground_paths.bundle_root meta.name in
-  let playground_mind = Playground_paths.mind_path meta.name in
-  let playground_repos = Playground_paths.repos_path meta.name in
+  let playground_bundle = sandbox.host_root_rel in
+  let sandbox_root =
+    Keeper_alerting_path.strip_trailing_slashes sandbox.host_root_rel
+  in
+  let playground_mind = sandbox_root ^ "/mind/" in
+  let playground_repos = sandbox_root ^ "/repos/" in
   Yojson.Safe.to_string
     (`Assoc
         ([ "name", `String meta.name

--- a/lib/keeper/keeper_exec_preflight.ml
+++ b/lib/keeper/keeper_exec_preflight.ml
@@ -98,13 +98,11 @@ let handle_keeper_preflight_check
       if repo_name_arg <> "" then repo_name_arg
       else Keeper_repo_readiness.repo_name_of_repo_arg ~project_root:root repo
     in
-    Filename.concat
-      (Keeper_alerting_path.playground_repos_path meta.name)
-      repo_name
+    Filename.concat "repos" repo_name
   in
   (* Check 6: sandbox repo readiness *)
   let repo_readiness =
-    Keeper_repo_readiness.inspect ~config ~keeper_name:meta.name
+    Keeper_repo_readiness.inspect ~config ~meta
       ?repo_name:(if repo_name_arg = "" then None else Some repo_name_arg)
       ~repo ~default_branch:!default_branch ()
   in

--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -17,9 +17,9 @@ let tool_result_or_error (ok, msg) = if ok then msg else error_json msg
     Follows Samchon harness pattern: field-level diagnostics with
     exact path, expected constraint, and concrete next action.
     Claude Code pattern: validateInput returns actionable guidance. *)
-let actionable_path_error ~(op : string) ~(keeper_name : string)
+let actionable_path_error ~(op : string) ~(meta : keeper_meta)
       ~(raw_path : string) ~(error : string) =
-  let playground = Printf.sprintf ".masc/playground/%s/" keeper_name in
+  let playground = Keeper_sandbox.allowed_root_rel_of_meta ~meta in
   let contains sub = String_util.contains_substring error sub in
   let action = match () with
     | () when String.length raw_path = 0 ->
@@ -103,8 +103,8 @@ let keeper_effective_write_allowed_paths ~(meta : keeper_meta) =
 ;;
 
 let keeper_playground_root ~(config : Coord.config) ~(meta : keeper_meta) =
-  ignore (Keeper_alerting_path.ensure_playground_bundle ~config ~name:meta.name);
-  Keeper_sandbox.host_root_abs ~config meta.name
+  ignore (Keeper_alerting_path.ensure_sandbox_bundle ~config ~meta);
+  Keeper_sandbox.host_root_abs_of_meta ~config meta
 ;;
 
 let keeper_default_write_root ~(config : Coord.config) ~(meta : keeper_meta) =
@@ -168,14 +168,20 @@ let strip_keeper_playground_prefix ~(meta : keeper_meta) (raw : string) =
       Some (if rest = "" then "." else rest)
     else None
   in
-  let bundle_root = Playground_paths.bundle_root meta.name in
+  let sandbox_root = Keeper_sandbox.allowed_root_rel_of_meta ~meta in
+  let legacy_bundle_root = Playground_paths.bundle_root meta.name in
   let short_root =
-    "playground/" ^ Playground_paths.sanitize_keeper_name meta.name
+    let rel = Keeper_alerting_path.strip_trailing_slashes sandbox_root in
+    if String.starts_with ~prefix:".masc/" rel then
+      String.sub rel 6 (String.length rel - 6)
+    else rel
   in
   let prefixes =
     [
-      bundle_root;
-      Keeper_alerting_path.strip_trailing_slashes bundle_root;
+      sandbox_root;
+      Keeper_alerting_path.strip_trailing_slashes sandbox_root;
+      legacy_bundle_root;
+      Keeper_alerting_path.strip_trailing_slashes legacy_bundle_root;
       short_root ^ "/";
       short_root;
     ]
@@ -267,7 +273,7 @@ let playground_relative_unless_allowed_root ~(config : Coord.config)
         keeper_playground_root ~config ~meta
         |> Keeper_alerting_path.strip_trailing_slashes
       in
-      let pg_bundle = Playground_paths.bundle_root meta.name in
+      let pg_bundle = Keeper_sandbox.allowed_root_rel_of_meta ~meta in
       let doubled_prefix = pg_root ^ "/" ^ pg_bundle in
       if String.starts_with ~prefix:doubled_prefix trimmed then
         let rest = String.sub trimmed

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -197,7 +197,7 @@ let rewrite_turn_runtime_paths_to_host
   =
   replace_all_substrings
     ~needle:(Keeper_sandbox.container_root meta.name)
-    ~replacement:(Keeper_sandbox.host_root_abs ~config meta.name)
+    ~replacement:(Keeper_sandbox.host_root_abs_of_meta ~config meta)
     text
 
 let run_argv_with_status_retry_eintr ?cwd ~timeout_sec argv =
@@ -366,7 +366,7 @@ let _docker_playground_cwd ~(config : Coord.config) ~(meta : keeper_meta) host_c
 let auto_correct_path ~(meta : keeper_meta) (raw : string) : string option =
   (* bundle_root yields ".masc/playground/<safe>/" — strip the trailing
      slash so we can append "/repos/..." cleanly. *)
-  let playground_bundle = Playground_paths.bundle_root meta.name in
+  let playground_bundle = Keeper_sandbox.allowed_root_rel_of_meta ~meta in
   let playground =
     if String.length playground_bundle > 0
        && playground_bundle.[String.length playground_bundle - 1] = '/'
@@ -545,7 +545,7 @@ let handle_keeper_bash
       normalize_path_for_containment cwd
     in
     let playground_rel =
-      Keeper_alerting_path.playground_path_of_keeper meta.name
+      Keeper_sandbox.allowed_root_rel_of_meta ~meta
     in
     let playground_abs =
       normalize_path_for_containment (Filename.concat root playground_rel)
@@ -667,6 +667,7 @@ let handle_keeper_bash
              ())
       | Ok () ->
         (* Branch-switch guard *)
+        let sandbox_root = Keeper_sandbox.allowed_root_rel_of_meta ~meta in
         if Worker_dev_tools.is_git_branch_switch cmd
                 && not (write_enabled && in_playground)
         then (
@@ -685,11 +686,11 @@ let handle_keeper_bash
                   under repos/<repo>/.worktrees/<task>."
                ~hint:(Printf.sprintf
                         "Use cwd=%srepos/REPO/.worktrees/TASK"
-                        (Playground_paths.bundle_root meta.name))
+                        sandbox_root)
                ~alternatives:
                  [ Printf.sprintf
                      "Clone the repo first: keeper_shell op=git_clone, then use cwd=%srepos/REPO/.worktrees/TASK."
-                     (Playground_paths.bundle_root meta.name)
+                     sandbox_root
                  ; "Use keeper_shell op=git op_cmd='branch -a' to list available branches."
                  ]
                ~retryability:Exec_core.Operator_required
@@ -742,15 +743,15 @@ let handle_keeper_bash
                      Open a sandbox clone first with keeper_shell op=git_clone \
                      if needed, then use masc_worktree_create and set cwd to \
                      the returned worktree path."
-                    (Playground_paths.bundle_root meta.name))
+                    sandbox_root)
                ~hint:(Printf.sprintf
                         "cwd must start with %s and usually looks like %srepos/REPO/.worktrees/TASK"
-                        (Playground_paths.bundle_root meta.name)
-                        (Playground_paths.bundle_root meta.name))
+                        sandbox_root
+                        sandbox_root)
                ~alternatives:
                  [ Printf.sprintf
                      "Clone into your sandbox: keeper_shell op=git_clone, then cd to %srepos/REPO/."
-                     (Playground_paths.bundle_root meta.name)
+                     sandbox_root
                  ; "Create a worktree inside your sandbox with masc_worktree_create."
                  ; "Use keeper_bash with a cwd pointing to your sandbox worktree."
                  ]
@@ -1055,7 +1056,7 @@ let handle_keeper_shell
   (* Actionable error: Samchon/Claude Code validateInput pattern.
      Returns structured JSON with tried path, playground root, and concrete next action. *)
   let path_error e =
-    actionable_path_error ~op ~keeper_name:meta.name ~raw_path ~error:e
+    actionable_path_error ~op ~meta ~raw_path ~error:e
   in
   let render_process_result ?cwd ~cmd argv =
     let st, out =
@@ -1880,11 +1881,9 @@ let handle_keeper_shell
                ; "url", `String url
                ])
        | Ok () ->
-         ignore (Keeper_alerting_path.ensure_playground_bundle ~config ~name:meta.name);
-         let playground = Filename.concat root
-           (Keeper_alerting_path.playground_path_of_keeper meta.name) in
-         let repos_dir = Filename.concat root
-           (Keeper_alerting_path.playground_repos_path meta.name) in
+         ignore (Keeper_alerting_path.ensure_sandbox_bundle ~config ~meta);
+         let playground = keeper_playground_root ~config ~meta in
+         let repos_dir = Filename.concat playground "repos" in
          Fs_compat.mkdir_p repos_dir;
          (* Derive repo name from URL: strip trailing slash, .git, then basename.
             Guard against empty/traversal names (e.g. url ending with "/" or ".."). *)

--- a/lib/keeper/keeper_repo_readiness.ml
+++ b/lib/keeper/keeper_repo_readiness.ml
@@ -1,8 +1,10 @@
 (** Keeper repository readiness.
 
     This is a read-only probe for the single keeper sandbox repo clone under
-    [.masc/playground/<keeper>/repos/<repo>/]. It gives preflight callers a
+    the keeper's backend-scoped sandbox repo lane. It gives preflight callers a
     concrete answer about whether code work can safely start from that clone. *)
+
+open Keeper_types
 
 type command_result =
   { ok : bool
@@ -45,9 +47,10 @@ let repo_name_of_repo_arg ~project_root repo =
       String.sub base 0 (String.length base - 4)
     else base
 
-let clone_path ~(config : Coord.config) ~keeper_name ~repo_name =
-  Filename.concat config.base_path
-    (Filename.concat (Playground_paths.repos_path keeper_name) repo_name)
+let clone_path ~(config : Coord.config) ~(meta : keeper_meta) ~repo_name =
+  Filename.concat
+    (Keeper_sandbox.host_root_abs_of_meta ~config meta)
+    (Filename.concat "repos" repo_name)
 
 let first_line_opt s =
   match
@@ -76,7 +79,7 @@ let int_opt_field name = function
 
 let inspect
     ~(config : Coord.config)
-    ~keeper_name
+    ~(meta : keeper_meta)
     ?repo_name
     ?(repo = "")
     ?(default_branch = "main")
@@ -88,17 +91,21 @@ let inspect
     | Some name when String.trim name <> "" -> String.trim name
     | _ -> repo_name_of_repo_arg ~project_root repo
   in
-  let clone_path = clone_path ~config ~keeper_name ~repo_name:derived_repo_name in
+  let clone_path = clone_path ~config ~meta ~repo_name:derived_repo_name in
   let common_fields state ok next_action extra =
     `Assoc
       ([
          "ok", `Bool ok;
          "state", `String state;
-         "keeper", `String keeper_name;
+         "keeper", `String meta.name;
          "repo", `String repo;
          "repo_name", `String derived_repo_name;
          "clone_path", `String clone_path;
-         "sandbox_repos", `String (Playground_paths.repos_path keeper_name);
+         "sandbox_repos",
+         `String
+           (Keeper_alerting_path.strip_trailing_slashes
+              (Keeper_sandbox.allowed_root_rel_of_meta ~meta)
+            ^ "/repos/");
          "default_branch", `String default_branch;
          "next_action", `String next_action;
        ]

--- a/lib/keeper/keeper_sandbox.ml
+++ b/lib/keeper/keeper_sandbox.ml
@@ -1,7 +1,7 @@
 (** Keeper sandbox contract.
 
     Keeper-facing tools expose exactly one logical sandbox.  The current
-    local storage implementation is still [.masc/playground/<keeper>], but
+    local storage implementation is still under [.masc/playground/], but
     that path is an implementation detail of the local/docker backends. *)
 
 type backend =
@@ -41,8 +41,31 @@ let backend_to_string = function
 let sandbox_id_of_name name =
   "keeper:" ^ Playground_paths.sanitize_keeper_name name
 
+let host_root_rel_of_backend ~(backend : backend) name =
+  match backend with
+  | Local -> Playground_paths.bundle_root name
+  | Docker ->
+      Printf.sprintf "%s/docker/%s/"
+        Playground_paths.all_playgrounds_prefix
+        (Playground_paths.sanitize_keeper_name name)
+
+let host_root_rel_of_profile sandbox_profile name =
+  host_root_rel_of_backend
+    ~backend:(backend_of_profile sandbox_profile)
+    name
+
+let host_root_rel_of_meta ~(meta : Keeper_types.keeper_meta) =
+  host_root_rel_of_profile meta.sandbox_profile meta.name
+
 let host_root_rel name =
   Playground_paths.bundle_root name
+
+let host_root_abs_of_backend ~(config : Coord.config) ~(backend : backend) name =
+  Filename.concat config.base_path (host_root_rel_of_backend ~backend name)
+
+let host_root_abs_of_meta ~(config : Coord.config)
+    (meta : Keeper_types.keeper_meta) =
+  Filename.concat config.base_path (host_root_rel_of_meta ~meta)
 
 let host_root_abs ~(config : Coord.config) name =
   Filename.concat config.base_path (host_root_rel name)
@@ -59,8 +82,8 @@ let of_meta ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta) : t =
   ; backend
   ; sandbox_profile = Keeper_types.sandbox_profile_to_string meta.sandbox_profile
   ; network_mode = Keeper_types.network_mode_to_string meta.network_mode
-  ; host_root_rel = host_root_rel meta.name
-  ; host_root_abs = host_root_abs ~config meta.name
+  ; host_root_rel = host_root_rel_of_meta ~meta
+  ; host_root_abs = host_root_abs_of_meta ~config meta
   ; container_root =
       (match backend with
        | Local -> None
@@ -74,10 +97,16 @@ let of_meta ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta) : t =
 let allowed_root_rel ~(name : string) : string =
   Playground_paths.bundle_root name
 
+let allowed_root_rel_of_meta ~(meta : Keeper_types.keeper_meta) : string =
+  host_root_rel_of_meta ~meta
+
 let allowed_path_roots ~(name : string) : string list =
   [ allowed_root_rel ~name ]
 
-let storage_lifetime = "persistent_base_task_overlay"
+let allowed_path_roots_of_meta ~(meta : Keeper_types.keeper_meta) : string list =
+  [ allowed_root_rel_of_meta ~meta ]
+
+let storage_lifetime = "persistent_backend_task_overlay"
 
 let context_status_fields (t : t) : (string * Yojson.Safe.t) list =
   [ "sandbox_id", `String t.sandbox_id

--- a/lib/keeper/keeper_sandbox.mli
+++ b/lib/keeper/keeper_sandbox.mli
@@ -33,8 +33,28 @@ val backend_to_string : backend -> string
 (** {1 Path resolution} *)
 
 (** [host_root_abs ~config name] returns the absolute host-side
-    sandbox root for [name] rooted at [config.base_path]. *)
+    legacy unscoped sandbox root for [name] rooted at [config.base_path]. *)
 val host_root_abs : config:Coord.config -> string -> string
+
+(** [host_root_rel_of_profile sandbox_profile name] returns the
+    backend-scoped relative sandbox root for the given profile/name. *)
+val host_root_rel_of_profile :
+  Keeper_types.sandbox_profile ->
+  string ->
+  string
+
+(** [host_root_rel_of_meta ~meta] returns the backend-scoped relative
+    sandbox root for [meta]. *)
+val host_root_rel_of_meta :
+  meta:Keeper_types.keeper_meta ->
+  string
+
+(** [host_root_abs_of_meta ~config meta] returns the absolute
+    backend-scoped sandbox root for [meta]. *)
+val host_root_abs_of_meta :
+  config:Coord.config ->
+  Keeper_types.keeper_meta ->
+  string
 
 (** [container_root name] returns the in-container path used by the
     hardened Docker backend. *)
@@ -52,11 +72,22 @@ val of_meta :
 (** {1 Access control hints} *)
 
 (** Relative roots that tools may touch inside the keeper's
-    sandbox. Currently a single-element list. *)
+    legacy unscoped sandbox. Currently a single-element list. *)
 val allowed_path_roots : name:string -> string list
 
-(** Single relative root for [name] (convenience). *)
+(** Relative roots that tools may touch inside [meta]'s backend-scoped
+    sandbox. Currently a single-element list. *)
+val allowed_path_roots_of_meta :
+  meta:Keeper_types.keeper_meta ->
+  string list
+
+(** Single legacy unscoped relative root for [name] (convenience). *)
 val allowed_root_rel : name:string -> string
+
+(** Single backend-scoped relative root for [meta]. *)
+val allowed_root_rel_of_meta :
+  meta:Keeper_types.keeper_meta ->
+  string
 
 (** {1 Dashboard / status output} *)
 

--- a/lib/keeper/keeper_sandbox_containment.ml
+++ b/lib/keeper/keeper_sandbox_containment.ml
@@ -11,9 +11,7 @@ let starts_with ~prefix s =
 (** Build the absolute, normalized playground bundle root for [meta]
     under [config.base_path]. *)
 let playground_root_abs ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta) =
-  let project_root = Keeper_alerting_path.project_root_of_config config in
-  let bundle_rel = Keeper_alerting_path.playground_path_of_keeper meta.name in
-  Filename.concat project_root bundle_rel |> normalize
+  Keeper_sandbox.host_root_abs_of_meta ~config meta |> normalize
 
 let target_is_inside_playground ~playground ~target =
   let playground = playground in

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -26,9 +26,7 @@ let docker_private_workspace_cwd ~(config : Coord.config) ~(meta : keeper_meta)
     |> Keeper_alerting_path.strip_trailing_slashes
   in
   let host_root =
-    Filename.concat
-      (Keeper_alerting_path.project_root_of_config config)
-      (Keeper_alerting_path.playground_path_of_keeper meta.name)
+    Keeper_sandbox.host_root_abs_of_meta ~config meta
     |> normalize_path_for_containment
   in
   let container_root = keeper_private_container_root meta in

--- a/lib/keeper/keeper_shell_gh_context.ml
+++ b/lib/keeper/keeper_shell_gh_context.ml
@@ -71,9 +71,7 @@ let gh_repo_context_error_json ~op ~cmd_display err =
 let resolve_gh_repo_context ~(config : Coord.config) ~(meta : keeper_meta)
     ~(cwd : string) =
   let sandbox_git_root =
-    Filename.concat
-      (Keeper_alerting_path.project_root_of_config config)
-      (Keeper_alerting_path.playground_path_of_keeper meta.name)
+    Keeper_sandbox.host_root_abs_of_meta ~config meta
   in
   let sandbox_worktree_cwd =
     if safe_is_dir cwd then cwd else sandbox_git_root

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -30,7 +30,7 @@ let create ~(config : Coord.config) ~(meta : keeper_meta) =
   {
     config;
     meta;
-    host_root = Keeper_sandbox.host_root_abs ~config meta.name |> normalize_path;
+    host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta |> normalize_path;
     container_root = Keeper_sandbox.container_root meta.name |> strip_trailing_slashes;
     uid = Unix.getuid ();
     gid = Unix.getgid ();

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -372,14 +372,14 @@ let resolve_shared_memory_scope ~preferred ~fallback =
   first_some preferred fallback
   |> Option.value ~default:default_shared_memory_scope
 
-let private_workspace_root_rel keeper_name =
-  Keeper_alerting_path.playground_path_of_keeper keeper_name
+let private_workspace_root_rel ~sandbox_profile keeper_name =
+  Keeper_sandbox.host_root_rel_of_profile sandbox_profile keeper_name
   |> Keeper_alerting_path.strip_trailing_slashes
 
-let private_workspace_root_abs ~(config : Coord.config) keeper_name =
+let private_workspace_root_abs ~(config : Coord.config) ~sandbox_profile keeper_name =
   Filename.concat
     (Keeper_alerting_path.project_root_of_config config)
-    (private_workspace_root_rel keeper_name)
+    (private_workspace_root_rel ~sandbox_profile keeper_name)
   |> Keeper_alerting_path.normalize_path_for_check
   |> Keeper_alerting_path.strip_trailing_slashes
 
@@ -400,13 +400,16 @@ let sandbox_allowed_path_has_forbidden_segments path =
 let sandbox_allowed_path_within_private_root
     ~(config : Coord.config)
     ~keeper_name
+    ~sandbox_profile
     path =
   let trimmed = String.trim path in
   if trimmed = "" then false
   else if sandbox_allowed_path_has_forbidden_segments trimmed then
     false
   else
-    let private_root = private_workspace_root_abs ~config keeper_name in
+    let private_root =
+      private_workspace_root_abs ~config ~sandbox_profile keeper_name
+    in
     let candidate =
       (if Filename.is_relative trimmed then
          Filename.concat
@@ -445,7 +448,8 @@ let validate_sandbox_settings
           List.filter
             (fun path ->
               not
-                (sandbox_allowed_path_within_private_root ~config ~keeper_name path))
+                (sandbox_allowed_path_within_private_root
+                   ~config ~keeper_name ~sandbox_profile path))
             allowed_paths
         in
         match escaping with
@@ -455,5 +459,5 @@ let validate_sandbox_settings
               (Printf.sprintf
                  "%s allowed_paths must stay under %s (rejected: %s)"
                  profile_label
-                 (private_workspace_root_rel keeper_name)
+                 (private_workspace_root_rel ~sandbox_profile keeper_name)
                  (String.concat ", " escaping))

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -282,8 +282,9 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                   (* Ensure full session dir tree, not just base_dir (issue #3019) *)
                   ignore (Keeper_fs.ensure_dir (Filename.concat base_dir trace_id));
                   ignore
-                    (Keeper_alerting_path.ensure_playground_bundle ~config:ctx.config
-                       ~name:p.name);
+                    (Keeper_alerting_path.ensure_sandbox_bundle_for_profile
+                       ~config:ctx.config ~name:p.name
+                       ~sandbox_profile);
                   let session =
                     Keeper_exec_context.create_session ~session_id:trace_id
                       ~base_dir

--- a/lib/tool_schemas/tool_schemas_worktree.ml
+++ b/lib/tool_schemas/tool_schemas_worktree.ml
@@ -55,14 +55,14 @@ After completing work in a worktree created by masc_worktree_create.";
       ("properties", `Assoc [
         ("agent_name", `Assoc [
           ("type", `String "string");
-          ("description", `String "Your agent name");
+          ("description", `String "Optional. Leave empty to use your registered agent name.");
         ]);
         ("task_id", `Assoc [
           ("type", `String "string");
           ("description", `String "Task ID used when creating the worktree");
         ]);
       ]);
-      ("required", `List [`String "agent_name"; `String "task_id"]);
+      ("required", `List [`String "task_id"]);
     ];
   };
   {

--- a/test/test_dashboard_safe_autonomy.ml
+++ b/test/test_dashboard_safe_autonomy.ml
@@ -90,11 +90,10 @@ let persist_keeper config =
   in
   match KT.write_meta ~force:true config meta with
   | Ok () ->
-      let sandbox_root = Keeper_sandbox.host_root_abs ~config meta.name in
+      let sandbox_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
       Fs_compat.mkdir_p sandbox_root;
       let repo_path =
-        Keeper_repo_readiness.clone_path ~config ~keeper_name:meta.name
-          ~repo_name:"masc-mcp"
+        Keeper_repo_readiness.clone_path ~config ~meta ~repo_name:"masc-mcp"
       in
       Fs_compat.mkdir_p repo_path;
       meta

--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -234,7 +234,7 @@ let test_sandbox_contract_reports_single_tool_root () =
     check string "sandbox id" "keeper:keeper" sb.sandbox_id;
     check string "sandbox root arg" "." sb.root_arg;
     check string "sandbox repos arg" "repos" sb.repos_arg;
-    check string "host root rel uses existing disk layout"
+    check string "local host root rel stays on local lane"
       ".masc/playground/keeper/" sb.host_root_rel;
     check (option string) "local has no container root" None sb.container_root)
 
@@ -257,6 +257,8 @@ let test_sandbox_contract_reports_docker_container_root () =
     let sb = KS.of_meta ~config ~meta in
     check string "docker backend" "docker"
       (KS.backend_to_string sb.backend);
+    check string "docker host root rel uses docker lane"
+      ".masc/playground/docker/keeper/" sb.host_root_rel;
     check (option string) "docker has private container root"
       (Some "/home/keeper/playground/keeper") sb.container_root)
 
@@ -439,7 +441,7 @@ let test_docker_rejects_paths_outside_private_root () =
     | Ok () -> fail "expected docker path rejection"
     | Error err ->
         check bool "mentions private playground" true
-          (String_util.contains_substring err ".masc/playground/sangsu"))
+          (String_util.contains_substring err ".masc/playground/docker/sangsu"))
 
 let test_docker_rejects_root_allowed_path () =
   with_temp_config (fun config ->
@@ -454,7 +456,7 @@ let test_docker_rejects_root_allowed_path () =
     | Ok () -> fail "expected docker root-path rejection"
     | Error err ->
         check bool "mentions private playground" true
-          (String_util.contains_substring err ".masc/playground/sangsu"))
+          (String_util.contains_substring err ".masc/playground/docker/sangsu"))
 
 let test_docker_rejects_glob_like_allowed_path () =
   with_temp_config (fun config ->
@@ -473,7 +475,9 @@ let test_docker_rejects_glob_like_allowed_path () =
 
 let test_docker_rejects_traversal_allowed_path () =
   with_temp_config (fun config ->
-    let private_root = KTU.private_workspace_root_rel "sangsu" in
+    let private_root =
+      KTU.private_workspace_root_rel ~sandbox_profile:KT.Docker "sangsu"
+    in
     match
       KTU.validate_sandbox_settings
         ~config
@@ -486,12 +490,16 @@ let test_docker_rejects_traversal_allowed_path () =
     | Ok () -> fail "expected docker traversal rejection"
     | Error err ->
         check bool "mentions private playground" true
-          (String_util.contains_substring err ".masc/playground/sangsu"))
+          (String_util.contains_substring err ".masc/playground/docker/sangsu"))
 
 let test_docker_accepts_private_root_paths () =
   with_temp_config (fun config ->
-    let private_root = KTU.private_workspace_root_rel "sangsu" in
-    ignore (KAP.ensure_playground_bundle ~config ~name:"sangsu");
+    let private_root =
+      KTU.private_workspace_root_rel ~sandbox_profile:KT.Docker "sangsu"
+    in
+    ignore
+      (KAP.ensure_sandbox_bundle_for_profile ~config ~name:"sangsu"
+         ~sandbox_profile:KT.Docker);
     let target_dir =
       Filename.concat (KAP.project_root_of_config config)
         (private_root ^ "/repos/demo")

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -528,7 +528,7 @@ let test_rewrite_turn_runtime_paths_to_host () =
   Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
   let meta = make_docker_meta "minjae" in
   let container_root = Keeper_sandbox.container_root meta.name in
-  let host_root = Keeper_sandbox.host_root_abs ~config meta.name in
+  let host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   let input =
     Printf.sprintf "worktree %s/repos/masc-mcp\npwd=%s/repos/masc-mcp\n"
       container_root container_root

--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -139,10 +139,7 @@ let with_fake_docker script f =
 let test_container_path_root_maps () =
   let base, config, meta = setup_config "minjae" in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
-  let host_root =
-    Filename.concat (Keeper_alerting_path.project_root_of_config config)
-      (Keeper_alerting_path.playground_path_of_keeper meta.name)
-  in
+  let host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   let croot = Keeper_sandbox.container_root meta.name in
   match
     Keeper_docker_read.container_path_of_host ~config ~meta
@@ -156,10 +153,7 @@ let test_container_path_root_maps () =
 let test_container_path_nested_maps_with_suffix () =
   let base, config, meta = setup_config "minjae" in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
-  let host_root =
-    Filename.concat (Keeper_alerting_path.project_root_of_config config)
-      (Keeper_alerting_path.playground_path_of_keeper meta.name)
-  in
+  let host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   let host_path = Filename.concat host_root "mind/scratch.md" in
   let croot = Keeper_sandbox.container_root meta.name in
   match
@@ -212,10 +206,7 @@ let test_read_empty_image_config_errors () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
   let base, config, meta = setup_config "minjae" in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
-  let host_root =
-    Filename.concat (Keeper_alerting_path.project_root_of_config config)
-      (Keeper_alerting_path.playground_path_of_keeper meta.name)
-  in
+  let host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   let host_path = Filename.concat host_root "mind/x" in
   match
     Keeper_docker_read.read_file_in_container ~config ~meta ~host_path
@@ -499,10 +490,7 @@ let test_turn_runtime_reuses_single_container () =
   with_env "MASC_KEEPER_SANDBOX_REQUIRE_USERNS" "false" @@ fun () ->
   let base, config, meta = setup_config "minjae" in
   let log_path = Filename.concat base "docker.log" in
-  let host_root =
-    Filename.concat (Keeper_alerting_path.project_root_of_config config)
-      (Keeper_alerting_path.playground_path_of_keeper meta.name)
-  in
+  let host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   ensure_dir host_root;
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
   let runtime = Keeper_turn_sandbox_runtime.create ~config ~meta in
@@ -577,10 +565,7 @@ let test_turn_runtime_relaxed_fs_omits_readonly_and_noexec () =
   with_env "MASC_KEEPER_SANDBOX_RELAX_FS" "true" @@ fun () ->
   let base, config, meta = setup_config "minjae" in
   let log_path = Filename.concat base "docker.log" in
-  let host_root =
-    Filename.concat (Keeper_alerting_path.project_root_of_config config)
-      (Keeper_alerting_path.playground_path_of_keeper meta.name)
-  in
+  let host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   ensure_dir host_root;
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
   let runtime = Keeper_turn_sandbox_runtime.create ~config ~meta in

--- a/test/test_keeper_repo_readiness.ml
+++ b/test/test_keeper_repo_readiness.ml
@@ -2,6 +2,24 @@
 
 open Alcotest
 
+module Keeper_types = Masc_mcp.Keeper_types
+
+let make_meta ?(sandbox = Keeper_types.Docker) name =
+  let json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("agent_name", `String ("agent-" ^ name));
+        ("trace_id", `String ("trace-" ^ name));
+        ("goal", `String "repo readiness test");
+        ( "sandbox_profile",
+          `String (Keeper_types.sandbox_profile_to_string sandbox) );
+      ]
+  in
+  match Keeper_types.meta_of_json json with
+  | Ok meta -> meta
+  | Error err -> fail ("meta_of_json failed: " ^ err)
+
 let temp_dir prefix =
   let base = Filename.get_temp_dir_name () in
   let rec loop n =
@@ -34,9 +52,10 @@ let json_string key json =
 let test_missing_clone () =
   let base_path = temp_dir "masc-repo-readiness" in
   let config = Masc_mcp.Coord.default_config base_path in
+  let meta = make_meta "keeper-one" in
   let json =
     Masc_mcp.Keeper_repo_readiness.inspect ~config
-      ~keeper_name:"keeper-one" ~repo:"jeong-sik/masc-mcp" ()
+      ~meta ~repo:"jeong-sik/masc-mcp" ()
   in
   check bool "not ok" false (json_bool "ok" json);
   check string "state" "missing_clone" (json_string "state" json);
@@ -46,14 +65,15 @@ let test_missing_clone () =
 let test_non_git_clone () =
   let base_path = temp_dir "masc-repo-readiness" in
   let config = Masc_mcp.Coord.default_config base_path in
+  let meta = make_meta "keeper-one" in
   let clone_path =
     Masc_mcp.Keeper_repo_readiness.clone_path ~config
-      ~keeper_name:"keeper-one" ~repo_name:"masc-mcp"
+      ~meta ~repo_name:"masc-mcp"
   in
   mkdir_p clone_path;
   let json =
     Masc_mcp.Keeper_repo_readiness.inspect ~config
-      ~keeper_name:"keeper-one" ~repo:"jeong-sik/masc-mcp" ()
+      ~meta ~repo:"jeong-sik/masc-mcp" ()
   in
   check bool "not ok" false (json_bool "ok" json);
   check string "state" "not_git_repo" (json_string "state" json);
@@ -63,9 +83,10 @@ let test_non_git_clone () =
 let test_invalid_repo_name () =
   let base_path = temp_dir "masc-repo-readiness" in
   let config = Masc_mcp.Coord.default_config base_path in
+  let meta = make_meta "keeper-one" in
   let json =
     Masc_mcp.Keeper_repo_readiness.inspect ~config
-      ~keeper_name:"keeper-one" ~repo_name:"../escape" ()
+      ~meta ~repo_name:"../escape" ()
   in
   check bool "not ok" false (json_bool "ok" json);
   check string "state" "invalid_repo_name" (json_string "state" json)
@@ -120,9 +141,10 @@ let test_auto_provisionable_workspace_repo () =
   run_ok ~cwd:repo "git commit -q -m init";
   run_ok ~cwd:repo "git push -q origin main";
   let config = Masc_mcp.Coord.default_config base_path in
+  let meta = make_meta "keeper-one" in
   let json =
     Masc_mcp.Keeper_repo_readiness.inspect ~config
-      ~keeper_name:"keeper-one" ~repo_name:"masc-mcp" ()
+      ~meta ~repo_name:"masc-mcp" ()
   in
   check bool "ok" true (json_bool "ok" json);
   check string "state" "auto_provisionable" (json_string "state" json);
@@ -151,9 +173,10 @@ let test_auto_provisionable_workspace_repo_after_file_storm () =
   run_ok ~cwd:repo "git commit -q -m init";
   run_ok ~cwd:repo "git push -q origin main";
   let config = Masc_mcp.Coord.default_config base_path in
+  let meta = make_meta "keeper-one" in
   let json =
     Masc_mcp.Keeper_repo_readiness.inspect ~config
-      ~keeper_name:"keeper-one" ~repo_name:"masc-mcp" ()
+      ~meta ~repo_name:"masc-mcp" ()
   in
   check bool "ok" true (json_bool "ok" json);
   check string "state" "auto_provisionable" (json_string "state" json);
@@ -182,9 +205,10 @@ let test_auto_provisionable_workspace_repo_before_hidden_dir_storm () =
   run_ok ~cwd:repo "git commit -q -m init";
   run_ok ~cwd:repo "git push -q origin main";
   let config = Masc_mcp.Coord.default_config base_path in
+  let meta = make_meta "keeper-one" in
   let json =
     Masc_mcp.Keeper_repo_readiness.inspect ~config
-      ~keeper_name:"keeper-one" ~repo_name:"masc-mcp" ()
+      ~meta ~repo_name:"masc-mcp" ()
   in
   check bool "ok" true (json_bool "ok" json);
   check string "state" "auto_provisionable" (json_string "state" json);
@@ -213,9 +237,10 @@ let test_auto_provisionable_workspace_repo_before_wide_workspace_storm () =
   run_ok ~cwd:repo "git commit -q -m init";
   run_ok ~cwd:repo "git push -q origin main";
   let config = Masc_mcp.Coord.default_config base_path in
+  let meta = make_meta "keeper-one" in
   let json =
     Masc_mcp.Keeper_repo_readiness.inspect ~config
-      ~keeper_name:"keeper-one" ~repo_name:"masc-mcp" ()
+      ~meta ~repo_name:"masc-mcp" ()
   in
   check bool "ok" true (json_bool "ok" json);
   check string "state" "auto_provisionable" (json_string "state" json);

--- a/test/test_keeper_sandbox_containment.ml
+++ b/test/test_keeper_sandbox_containment.ml
@@ -98,10 +98,7 @@ let test_docker_keeper_allows_inside_playground () =
   with_tmp_base @@ fun base ->
   let config = Coord.default_config base in
   let meta = make_meta ~name:"minjae" ~sandbox:Keeper_types.Docker in
-  let bundle =
-    Filename.concat base
-      (Keeper_alerting_path.playground_path_of_keeper meta.name)
-  in
+  let bundle = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   let inside = Filename.concat bundle "mind/scratch.md" in
   Alcotest.(check bool) "playground-internal path is allowed"
     true
@@ -127,10 +124,8 @@ let test_path_just_outside_playground_blocked () =
   (* Sibling directory with a name that LOOKS like a prefix of the playground
      path; must still be blocked (prevents the classic prefix-without-slash
      containment bypass). *)
-  let project_root = Keeper_alerting_path.project_root_of_config config in
-  let bundle = Keeper_alerting_path.playground_path_of_keeper meta.name in
   let bundle_normalized =
-    Filename.concat project_root bundle
+    Keeper_sandbox.host_root_abs_of_meta ~config meta
     |> Keeper_alerting_path.normalize_path_for_check
     |> Keeper_alerting_path.strip_trailing_slashes
   in

--- a/test/test_keeper_shell_containment.ml
+++ b/test/test_keeper_shell_containment.ml
@@ -10,6 +10,7 @@ module Coord = Masc_mcp.Coord
 module Keeper_exec_shell = Masc_mcp.Keeper_exec_shell
 module Keeper_id = Masc_mcp.Keeper_id
 module Keeper_registry = Masc_mcp.Keeper_registry
+module Keeper_sandbox = Masc_mcp.Keeper_sandbox
 module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_alerting_path = Masc_mcp.Keeper_alerting_path
 module Fs_compat = Fs_compat
@@ -88,10 +89,7 @@ let setup ~keeper_name ~sandbox f =
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
   Keeper_registry.clear ();
   let meta = make_meta ~name:keeper_name ~sandbox in
-  let playground =
-    Filename.concat base
-      (Keeper_alerting_path.playground_path_of_keeper meta.name)
-  in
+  let playground = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   ensure_dir playground;
   f ~base ~config ~meta ~playground
 

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -11,6 +11,7 @@
 module Coord = Masc_mcp.Coord
 module Keeper_exec_shell = Masc_mcp.Keeper_exec_shell
 module Keeper_registry = Masc_mcp.Keeper_registry
+module Keeper_sandbox = Masc_mcp.Keeper_sandbox
 module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_alerting_path = Masc_mcp.Keeper_alerting_path
 module Tool_code_write = Masc_mcp.Tool_code_write
@@ -91,10 +92,7 @@ let setup ~sandbox f =
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
   Keeper_registry.clear ();
   let meta = make_meta ~name:"minjae" ~sandbox in
-  let playground =
-    Filename.concat base
-      (Keeper_alerting_path.playground_path_of_keeper meta.name)
-  in
+  let playground = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   ensure_dir playground;
   f ~config ~meta ~playground
 

--- a/test/test_tool_worktree_coverage.ml
+++ b/test/test_tool_worktree_coverage.ml
@@ -75,6 +75,22 @@ let rec ensure_dir path =
     if parent <> path then ensure_dir parent;
     Unix.mkdir path 0o755)
 
+let write_file path content =
+  ensure_dir (Filename.dirname path);
+  let oc = open_out path in
+  Fun.protect ~finally:(fun () -> close_out oc) @@ fun () ->
+  output_string oc content
+
+let write_keeper_toml ~base_path ~name ~sandbox_profile =
+  let path =
+    Filename.concat base_path
+      (Printf.sprintf ".masc/config/keepers/%s.toml" name)
+  in
+  write_file path
+    (Printf.sprintf
+       "[keeper]\npersona_name = %S\nsandbox_profile = %S\n"
+       name sandbox_profile)
+
 let run_ok ~cwd cmd =
   let wrapped = Printf.sprintf "cd %s && %s > /dev/null 2>&1" (Filename.quote cwd) cmd in
   let code = Sys.command wrapped in
@@ -160,6 +176,21 @@ let test_dispatch_unknown_tool () =
   match Tool_worktree.dispatch ctx ~name:"masc_unknown" ~args:(`Assoc []) with
   | None -> ()
   | Some _ -> fail "expected None for unknown tool"
+
+let test_remove_schema_requires_only_task_id () =
+  let schema =
+    Tool_worktree.schemas
+    |> List.find (fun (s : Types.tool_schema) ->
+         String.equal s.name "masc_worktree_remove")
+  in
+  let open Yojson.Safe.Util in
+  let required =
+    schema.input_schema
+    |> member "required"
+    |> to_list
+    |> List.map to_string
+  in
+  check (list string) "remove required fields" [ "task_id" ] required
 
 (* ============================================================
    Iter-7 (#6527) — agent_name spoof rejection
@@ -404,6 +435,67 @@ let test_dispatch_worktree_create_auto_provisions_before_wide_workspace_storm ()
       check bool "message mentions auto-provision" true
         (contains "auto-provisioned" msg)
 
+let test_dispatch_worktree_create_and_remove_use_docker_keeper_lane () =
+  let base_path = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  init_process_eio env;
+  run_ok ~cwd:base_path "git init -q -b main";
+  ignore
+    (setup_nested_repo_with_remote ~base_path
+       ~repo_rel:"workspace/yousleepwhen/masc-mcp");
+  write_keeper_toml ~base_path ~name:"sangsu" ~sandbox_profile:"docker";
+  let config = Masc_mcp.Coord.default_config base_path in
+  ignore (Masc_mcp.Coord.init config ~agent_name:(Some "sangsu"));
+  let ctx : Tool_worktree.context = { config; agent_name = "sangsu" } in
+  let task_id = "task-auto-clone-docker" in
+  let create_args = `Assoc [
+    ("task_id", `String task_id);
+    ("repo_name", `String "masc-mcp");
+    ("base_branch", `String "main");
+  ] in
+  let docker_clone =
+    Filename.concat base_path ".masc/playground/docker/sangsu/repos/masc-mcp"
+  in
+  let docker_worktree =
+    Filename.concat docker_clone
+      (Filename.concat ".worktrees"
+         (Playground_paths.worktree_dir_name "sangsu" task_id))
+  in
+  let legacy_worktree =
+    Filename.concat base_path
+      (Filename.concat ".masc/playground/sangsu/repos/masc-mcp/.worktrees"
+         (Playground_paths.worktree_dir_name "sangsu" task_id))
+  in
+  match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args:create_args with
+  | None -> fail "dispatch returned None for masc_worktree_create"
+  | Some (false, msg) ->
+      fail
+        (Printf.sprintf
+           "expected docker keeper auto-provision success, got error: %s"
+           msg)
+  | Some (true, msg) ->
+      check bool "message mentions auto-provision" true
+        (contains "auto-provisioned" msg);
+      check bool "docker sandbox clone created" true
+        (Sys.file_exists docker_clone);
+      check bool "docker worktree created" true
+        (Sys.file_exists docker_worktree);
+      check bool "legacy worktree untouched" false
+        (Sys.file_exists legacy_worktree);
+      let remove_args = `Assoc [ ("task_id", `String task_id) ] in
+      match Tool_worktree.dispatch ctx ~name:"masc_worktree_remove" ~args:remove_args with
+      | None -> fail "dispatch returned None for masc_worktree_remove"
+      | Some (false, remove_msg) ->
+          fail
+            (Printf.sprintf
+               "expected docker keeper remove success, got error: %s"
+               remove_msg)
+      | Some (true, _remove_msg) ->
+          check bool "docker worktree removed" false
+            (Sys.file_exists docker_worktree)
+
 (* ============================================================
    Test Runners
    ============================================================ *)
@@ -424,6 +516,8 @@ let () =
       test_case "worktree_remove" `Quick test_dispatch_worktree_remove;
       test_case "worktree_list" `Quick test_dispatch_worktree_list;
       test_case "unknown" `Quick test_dispatch_unknown_tool;
+      test_case "remove schema requires only task_id" `Quick
+        test_remove_schema_requires_only_task_id;
     ];
     "agent_name_spoof", [
       test_case "spoofed agent_name blocked" `Quick
@@ -444,5 +538,7 @@ let () =
         test_dispatch_worktree_create_auto_provisions_before_hidden_dir_storm;
       test_case "workspace repo wins before wide workspace storm" `Quick
         test_dispatch_worktree_create_auto_provisions_before_wide_workspace_storm;
+      test_case "docker keeper uses docker lane for create/remove" `Quick
+        test_dispatch_worktree_create_and_remove_use_docker_keeper_lane;
     ];
   ]


### PR DESCRIPTION
## Summary
- split docker keeper sandbox storage into a dedicated docker lane under `.masc/playground/docker/<keeper>`
- auto-provision sandbox repo clones for docker worktree creation and keep create/remove/readiness routing backend-aware
- fix `masc_worktree_remove` schema so only `task_id` is required and add regression coverage

## Verification
- ./_build/default/test/test_tool_worktree_coverage.exe test dispatch 4 --show-errors
- ./_build/default/test/test_tool_worktree_coverage.exe test agent_name_spoof 9 --show-errors
- ./_build/default/test/test_keeper_repo_readiness.exe
- ./_build/default/test/test_keeper_docker_read.exe
- ./_build/default/test/test_keeper_sandbox_containment.exe
- ./_build/default/test/test_keeper_shell_containment.exe
- ./_build/default/test/test_dashboard_safe_autonomy.exe
- ./_build/default/test/test_keeper_shell_docker_route.exe
- ./_build/default/test/test_keeper_bash_safety.exe
- ./_build/default/test/test_keeper_allowed_paths.exe
- live MCP smoke with `sangsu`: `masc_start(path=/Users/dancer/me)` then `masc_worktree_create(repo_name="masc-mcp")` -> `/Users/dancer/me/.masc/playground/docker/sangsu/repos/masc-mcp/.worktrees/sangsu-task-030`