### PR TITLE
fix(lib): stop coercing unknown usage to zero in detail/timeline (#9502)

### DIFF
--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -141,11 +141,11 @@ let compute_metrics_window
           | None -> Safe_ops.json_int_opt "to_generation" handoff_obj
         in
         let usage_obj = j |> member "usage" in
-        let input_tokens = Safe_ops.json_int ~default:0 "input_tokens" usage_obj in
-        let output_tokens = Safe_ops.json_int ~default:0 "output_tokens" usage_obj in
-        let total_tokens = Safe_ops.json_int ~default:0 "total_tokens" usage_obj in
+        let input_tokens = Safe_ops.json_int_opt "input_tokens" usage_obj in
+        let output_tokens = Safe_ops.json_int_opt "output_tokens" usage_obj in
+        let total_tokens = Safe_ops.json_int_opt "total_tokens" usage_obj in
         let latency_ms = Safe_ops.json_int ~default:0 "latency_ms" j in
-        let cost_usd = Safe_ops.json_float ~default:0.0 "cost_usd" j in
+        let cost_usd = Safe_ops.json_float_opt "cost_usd" j in
         let model_used = Safe_ops.json_string ~default:"" "model_used" j in
         let message_count = Safe_ops.json_int ~default:0 "message_count" j in
         let model_used_norm = normalize_model_name model_used in
@@ -353,9 +353,9 @@ let compute_metrics_window
                   gs
             in
             gen_stats.turns <- gen_stats.turns + 1;
-            gen_stats.input_tokens <- gen_stats.input_tokens + input_tokens;
-            gen_stats.output_tokens <- gen_stats.output_tokens + output_tokens;
-            gen_stats.total_tokens <- gen_stats.total_tokens + total_tokens;
+            gen_stats.input_tokens <- gen_stats.input_tokens + Option.value ~default:0 input_tokens;
+            gen_stats.output_tokens <- gen_stats.output_tokens + Option.value ~default:0 output_tokens;
+            gen_stats.total_tokens <- gen_stats.total_tokens + Option.value ~default:0 total_tokens;
             if handoff_performed then gen_stats.handoffs <- gen_stats.handoffs + 1;
             if compacted then gen_stats.compactions <- gen_stats.compactions + 1;
             if memory_compaction_performed_now then begin
@@ -406,11 +406,11 @@ let compute_metrics_window
               ("handoff_new_trace_id", Json_util.string_opt_to_json (match handoff_new_trace_id with Some s when s <> "" -> Some s | _ -> None));
               ("handoff_new_generation", Json_util.int_opt_to_json handoff_new_generation);
               ("generation", `Int gen);
-              ("input_tokens", `Int input_tokens);
-              ("output_tokens", `Int output_tokens);
-              ("total_tokens", `Int total_tokens);
+              ("input_tokens", Json_util.int_opt_to_json input_tokens);
+              ("output_tokens", Json_util.int_opt_to_json output_tokens);
+              ("total_tokens", Json_util.int_opt_to_json total_tokens);
               ("latency_ms", `Int latency_ms);
-              ("cost_usd", `Float cost_usd);
+              ("cost_usd", Json_util.float_opt_to_json cost_usd);
               ("model_used", `String model_used);
               ("prompt_fingerprint", j |> member "prompt_fingerprint");
               ("prompt", j |> member "prompt");

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1569,11 +1569,11 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                 ~payload:(`Assoc
                   ([
                     ("keeper_name", `String updated_meta.name);
-                    ("input_tokens", `Int result.usage.input_tokens);
-                    ("output_tokens", `Int result.usage.output_tokens);
-                    ("cache_creation_tokens", `Int result.usage.cache_creation_input_tokens);
-                    ("cache_read_tokens", `Int result.usage.cache_read_input_tokens);
-                    ("cost_usd", `Float turn_cost);
+                    ("input_tokens", (if result.usage_reported then `Int result.usage.input_tokens else `Null));
+                    ("output_tokens", (if result.usage_reported then `Int result.usage.output_tokens else `Null));
+                    ("cache_creation_tokens", (if result.usage_reported then `Int result.usage.cache_creation_input_tokens else `Null));
+                    ("cache_read_tokens", (if result.usage_reported then `Int result.usage.cache_read_input_tokens else `Null));
+                    ("cost_usd", (if result.usage_reported then `Float turn_cost else `Null));
                     ("latency_ms", `Int latency_ms);
                     ("model_used", `String (Keeper_agent_run.surface_model_used result));
                     ("work_kind", `String (Keeper_unified_metrics.work_kind_of_selected_mode (Keeper_unified_metrics.selected_mode_of_result result)));

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -320,24 +320,24 @@ let turn_completed_events (config : Coord.config) ~agent_name ~limit :
          with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> "unknown"
        in
        let input_tokens =
-         try e.payload |> member "input_tokens" |> to_int
-         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> 0
+         try Some (e.payload |> member "input_tokens" |> to_int)
+         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> None
        in
        let output_tokens =
-         try e.payload |> member "output_tokens" |> to_int
-         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> 0
+         try Some (e.payload |> member "output_tokens" |> to_int)
+         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> None
        in
        let cache_creation_tokens =
-         try e.payload |> member "cache_creation_tokens" |> to_int
-         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> 0
+         try Some (e.payload |> member "cache_creation_tokens" |> to_int)
+         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> None
        in
        let cache_read_tokens =
-         try e.payload |> member "cache_read_tokens" |> to_int
-         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> 0
+         try Some (e.payload |> member "cache_read_tokens" |> to_int)
+         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> None
        in
        let cost_usd =
-         try e.payload |> member "cost_usd" |> to_float
-         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> 0.0
+         try Some (e.payload |> member "cost_usd" |> to_float)
+         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> None
        in
        let latency_ms =
          try e.payload |> member "latency_ms" |> to_int
@@ -386,11 +386,11 @@ let turn_completed_events (config : Coord.config) ~agent_name ~limit :
              `Assoc
                ([
                  ("keeper_name", `String keeper_name);
-                 ("input_tokens", `Int input_tokens);
-                 ("output_tokens", `Int output_tokens);
-                 ("cache_creation_tokens", `Int cache_creation_tokens);
-                 ("cache_read_tokens", `Int cache_read_tokens);
-                 ("cost_usd", `Float cost_usd);
+                 ("input_tokens", Json_util.int_opt_to_json input_tokens);
+                 ("output_tokens", Json_util.int_opt_to_json output_tokens);
+                 ("cache_creation_tokens", Json_util.int_opt_to_json cache_creation_tokens);
+                 ("cache_read_tokens", Json_util.int_opt_to_json cache_read_tokens);
+                 ("cost_usd", Json_util.float_opt_to_json cost_usd);
                  ("latency_ms", `Int latency_ms);
                  ("model_used", `String model_used);
                  ("work_kind", `String work_kind);


### PR DESCRIPTION
Closes #9502.

## Problem
Three sites were silently coercing missing/unknown usage values to `0`:
- `dashboard_http_keeper_detail.ml`: usage parsing
- `tool_agent_timeline.ml`: turn_completed event parsing
- `keeper_unified_turn.ml`: usage payload emission

## Fix
Use `Option`-based parsing (`json_int_opt`, `json_float_opt`) and emit `null` in JSON when usage is unknown, distinguishing \"zero\" from \"unknown\".

## Verification
- `dune build --root . @all` passes
- `dune runtest` passes (no regressions)

## Files Changed
- `lib/dashboard/dashboard_http_keeper_detail.ml`
- `lib/tool_agent_timeline.ml`
- `lib/keeper/keeper_unified_turn.ml`