### PR TITLE
[codex] Clarify keeper runtime limits panel copy

### DIFF
--- a/dashboard/src/components/tools/config-resolution-panel.test.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.test.ts
@@ -112,6 +112,18 @@ describe('ConfigResolutionPanel', () => {
             started_at: '2026-03-27T00:00:00Z',
             uptime_seconds: 42,
           },
+          keeper_runtime: {
+            bootstrap_max_active_keepers: { value: 9, source: 'toml' },
+            reactive_max_turns_per_call: { value: 15, source: 'toml' },
+            autonomous_max_turns_per_call: { value: 6, source: 'derived' },
+            reactive_max_idle_turns: { value: 15, source: 'toml' },
+            autonomous_max_idle_turns: { value: 3, source: 'derived' },
+            turn_timeout_sec: { value: 90, source: 'toml' },
+            admission_wait_timeout_sec: { value: 45, source: 'derived' },
+            oas_timeout_override_sec: { value: 120, source: 'env' },
+            oas_timeout_per_1k: { value: 7.5, source: 'derived' },
+            oas_timeout_per_turn: { value: 30, source: 'derived' },
+          },
         }}
       />`,
       container,
@@ -139,6 +151,9 @@ describe('ConfigResolutionPanel', () => {
     expect(container.textContent).toContain('ollama warm / kv probe')
     expect(container.textContent).toContain('kv likely reused')
     expect(container.textContent).toContain('qwen3.5:35b-a3b-coding-nvfp4')
+    expect(container.textContent).toContain('keeper runtime limits')
+    expect(container.textContent).toContain('Per-keeper runtime caps and timeouts. These values are not the live keeper count.')
+    expect(container.textContent).toContain('bootstrap max active keepers')
   })
   it('keeps the full path on hover title and hides duplicate source badges', () => {
     render(

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -288,7 +288,7 @@ const KEEPER_RUNTIME_ROWS: Array<{
   label: string
   fmt: 'int' | 'float' | 'duration'
 }> = [
-  { key: 'bootstrap_max_active_keepers', label: 'max active keepers', fmt: 'int' },
+  { key: 'bootstrap_max_active_keepers', label: 'bootstrap max active keepers', fmt: 'int' },
   { key: 'reactive_max_turns_per_call', label: 'reactive max turns/call', fmt: 'int' },
   { key: 'autonomous_max_turns_per_call', label: 'autonomous max turns/call', fmt: 'int' },
   { key: 'reactive_max_idle_turns', label: 'reactive max idle turns', fmt: 'int' },
@@ -326,13 +326,16 @@ function KeeperRuntimePanel({ runtime }: { runtime: KeeperRuntimeResolved | null
   return html`
     <div class="mt-4 rounded border border-[var(--card-border)] bg-[var(--white-3)] px-4 py-4">
       <div class="mb-3 flex flex-wrap items-center gap-2">
-        <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">keeper runtime</div>
+        <div class="text-2xs uppercase tracking-1 text-[var(--text-muted)]">keeper runtime limits</div>
         ${tomlCount > 0 ? html`
           <${StatusChip} tone=${sourceTone('toml')}>${tomlCount} TOML<//>
         ` : null}
         ${envCount > 0 ? html`
           <${StatusChip} tone=${sourceTone('env')}>${envCount} env<//>
         ` : null}
+      </div>
+      <div class="mb-3 text-xs text-[var(--text-muted)]">
+        Per-keeper runtime caps and timeouts. These values are not the live keeper count.
       </div>
       <div class="grid gap-2 md:grid-cols-2">
         ${KEEPER_RUNTIME_ROWS.map(row => {


### PR DESCRIPTION
## Summary

- clarify the keeper runtime panel labels so per-keeper limits are not confused with live keeper counts
- add explicit helper copy under the panel header
- cover the wording in the config-resolution-panel render test

## Why

The dashboard can show runtime limit values like `15` in keeper-related UI, which made it easy to misread the value as a keeper count.

## Impact

Operators can distinguish live keeper counts from per-keeper runtime limits more quickly.

## Validation

- `./node_modules/.bin/vitest run src/components/tools/config-resolution-panel.test.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false`
