### PR TITLE
fix(keeper): preserve cascade and agent alias wiring

### DIFF
--- a/lib/keeper/keeper_identity.ml
+++ b/lib/keeper/keeper_identity.ml
@@ -64,9 +64,18 @@ let keeper_name_from_agent_name agent_name =
   else
     None
 
+let is_keeper_agent_alias agent_name =
+  let prefix = "keeper-" and suffix = "-agent" in
+  let plen = String.length prefix and slen = String.length suffix in
+  let alen = String.length agent_name in
+  alen > plen + slen
+  && String.sub agent_name 0 plen = prefix
+  && String.sub agent_name (alen - slen) slen = suffix
+
 let canonical_keeper_name_from_agent_name agent_name =
   let trimmed = String.trim agent_name in
   match keeper_name_from_agent_name trimmed with
+  | Some keeper_name when is_keeper_agent_alias trimmed -> Some keeper_name
   | Some _ when Nickname.is_generated_nickname trimmed -> (
       match Nickname.extract_agent_type trimmed with
       | Some candidate when Keeper_config.validate_name candidate -> Some candidate

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -110,6 +110,16 @@ let direct_turn_observation (meta : keeper_meta) :
     work_discovery_due = false;
   }
 
+let resolve_turn_cascade_name (meta : keeper_meta) =
+  let raw_name = String.trim meta.cascade_name in
+  match Cascade_catalog_runtime.resolve_declared_name ~raw_name () with
+  | Ok cascade_name -> Ok cascade_name
+  | Error detail ->
+      Error
+        (Printf.sprintf
+           "invalid cascade_name %S for keeper %s: %s"
+           raw_name meta.name detail)
+
 (* -- handle_keeper_msg: orchestrator ---------------------------------------- *)
 
 let handle_keeper_msg ?on_text_delta ctx args : tool_result =
@@ -151,6 +161,11 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
       let turn_tracker = Progress.start_tracking ~task_id:turn_task_id ~total_steps:5 () in
       Progress.Tracker.step turn_tracker ~message:"Preparing keeper turn configuration" ();
       let meta = meta0 in
+      match resolve_turn_cascade_name meta with
+      | Error e ->
+        Progress.stop_tracking turn_task_id;
+        (false, "❌ " ^ e)
+      | Ok turn_cascade_name ->
       (* start_keepalive is deferred AFTER run_turn completes.
          Starting it here causes the heartbeat fiber to immediately grab LLM
          slots, starving the synchronous run_turn call (Issue #2610). *)
@@ -164,12 +179,6 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
           ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
           ~generation:meta.runtime.generation
       in
-      (* Historical drift: "keeper_turn" / "keeper_reply" were never defined
-         as separate cascade profiles in cascade.json; they always fell
-         through to default via Keeper_cascade_profile.canonicalize. Using
-         default_name here makes the resolution explicit and keeps metric
-         buckets/Prometheus labels from seeing ghost cascade names. *)
-      let turn_cascade_name = Keeper_cascade_profile.default_name in
       let effective_models =
         if direct_reply then
           Cascade_runtime.models_of_cascade_name turn_cascade_name

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -346,6 +346,9 @@ let test_keeper_direct_reply_contracts () =
      Keeper_cascade_profile.canonicalize. The fork is gone; the
      direct_reply flag now only affects persona prompt + skill-route
      suppression (checked below). *)
+  check bool "keeper manual turns resolve declared cascade through runtime catalog" true
+    (file_contains_pattern "lib/keeper/keeper_turn.ml"
+       "Cascade_catalog_runtime.resolve_declared_name ~raw_name");
   check bool "keeper turn suppresses skill route headers for direct reply" true
     (file_contains_pattern "lib/keeper/keeper_turn.ml"
        "let effective_no_skill_route = no_skill_route || direct_reply");

--- a/test/test_keeper_agent_isolation.ml
+++ b/test/test_keeper_agent_isolation.ml
@@ -303,6 +303,13 @@ let test_canonical_keeper_name_from_generated_nickname () =
     "generated nickname resolves to canonical keeper" (Some "claude")
     (Keeper_types.canonical_keeper_name_from_agent_name "claude-swift-fox")
 
+let test_canonical_keeper_name_from_keeper_agent_alias_preserves_full_name () =
+  Alcotest.(check (option string))
+    "keeper agent alias keeps hyphenated keeper name"
+    (Some "kimi-null-canary")
+    (Keeper_types.canonical_keeper_name_from_agent_name
+       "keeper-kimi-null-canary-agent")
+
 let test_canonical_keeper_name_from_legacy_keeper_name () =
   Alcotest.(check (option string))
     "legacy keeper-prefixed name normalizes" (Some "sangsu")
@@ -360,6 +367,8 @@ let () =
         test_keeper_name_from_agent_name_rejects_plain_name;
       Alcotest.test_case "generated nickname canonicalizes" `Quick
         test_canonical_keeper_name_from_generated_nickname;
+      Alcotest.test_case "keeper agent alias preserves full name" `Quick
+        test_canonical_keeper_name_from_keeper_agent_alias_preserves_full_name;
       Alcotest.test_case "legacy keeper name canonicalizes" `Quick
         test_canonical_keeper_name_from_legacy_keeper_name;
     ]);


### PR DESCRIPTION
## Summary

- make `masc_keeper_msg` resolve the keeper's declared `cascade_name` through the runtime catalog instead of silently forcing `big_three`
- preserve full hyphenated keeper names for `keeper-...-agent` aliases instead of collapsing them to generated nickname agent types
- add regression coverage for the alias case and a source guard for manual-turn cascade resolution

## Product impact

- direct keeper messages now execute on the keeper's configured cascade, so Kimi-only keepers no longer drift onto Claude in the manual message path
- keeper runtime artifacts and metrics stay under the real keeper name for hyphenated keepers instead of being misfiled under truncated aliases like `kimi`

## Evidence

- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-msg-cascade-wiring @default`
- `./_build/default/test/test_keeper_agent_isolation.exe`
- `./_build/default/test/test_ci_hardening_source.exe`
  - existing unrelated failure in `release truth contracts` (`health job reruns doc truth scripts`)
  - updated `keeper direct reply contracts` case passed

## Review evidence

- live repro before patch showed `kimi-null-canary` manual message turns running as `claude_code:auto` with `cascade_name:\"big_three\"`
- live repro before patch also created artifacts under `~/.masc/keepers/kimi*` for `keeper-kimi-null-canary-agent`
- patched code now aligns validation and execution on the resolved keeper cascade and preserves explicit keeper agent aliases

## Linked issue

- None
