### PR TITLE
[codex] guard shared base paths at startup

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -317,6 +317,16 @@ let acquire_pid_lock port =
            pid port pid);
       exit 1
 
+let acquire_base_path_lock base_path =
+  match Server_startup_takeover.acquire_base_path_lock base_path with
+  | Server_startup_takeover.Acquired -> ()
+  | Server_startup_takeover.Already_running { pid } ->
+      Log.legacy_stderr ~level:Log.Error ~module_name:"Server"
+        (Printf.sprintf
+           "[FATAL] Another MASC server (PID %d) already owns base path %s. Kill it first: kill %d"
+           pid base_path pid);
+      exit 1
+
 (** Reject base_path that points to the server's own source repo.
     Detects by checking if the running executable lives under base_path/_build/.
     Runtime state (.masc/keepers, traces, logs) must not pollute the repo. *)
@@ -393,7 +403,10 @@ let run_cmd host port base_path =
       resolution_source normalized_base_path;
     exit 1
   end;
+  let masc_dir = Filename.concat normalized_base_path ".masc" in
+  Fs_compat.mkdir_p masc_dir;
   acquire_pid_lock port;
+  acquire_base_path_lock normalized_base_path;
   Log.init_from_env ();
   if stripped_base_path <> ""
      && String.equal (Filename.basename stripped_base_path) ".masc"
@@ -407,9 +420,7 @@ let run_cmd host port base_path =
   (* Persist logs inside .masc/logs/ — colocated with state, not a sibling.
      Previous code wrote to base_path/logs/ which diverged from .masc/ when
      base_path differed from the repo checkout directory. *)
-  let masc_dir = Filename.concat normalized_base_path ".masc" in
   let log_dir = Filename.concat masc_dir "logs" in
-  Fs_compat.mkdir_p masc_dir;
   Fs_compat.mkdir_p log_dir;
   (* Migration: move .jsonl files from old base_path/logs/ if they exist *)
   let old_log_dir = Filename.concat normalized_base_path "logs" in

--- a/lib/server/server_startup_takeover.ml
+++ b/lib/server/server_startup_takeover.ml
@@ -4,6 +4,9 @@ type acquire_result =
 
 let pid_lock_path port = Printf.sprintf "/tmp/masc-%d.pid" port
 
+let base_path_lock_path base_path =
+  Filename.concat (Filename.concat base_path ".masc") "server-owner.pid"
+
 let close_quietly fd =
   try Unix.close fd with
   | Unix.Unix_error _ -> ()
@@ -155,6 +158,13 @@ let write_pid_file path pid =
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> Printf.fprintf oc "%d\n" pid)
 
+let claim_pid_file path =
+  Fs_compat.mkdir_p (Filename.dirname path);
+  let pid = Unix.getpid () in
+  write_pid_file path pid;
+  register_pid_cleanup ~path ~pid;
+  Acquired
+
 let acquire_pid_lock
     ?lock_path
     ?(probe_timeout_sec = 3.0)
@@ -224,8 +234,40 @@ let acquire_pid_lock
   | None -> Acquired)
   |> function
   | Already_running _ as result -> result
-  | Acquired ->
-      let pid = Unix.getpid () in
-      write_pid_file path pid;
-      register_pid_cleanup ~path ~pid;
-      Acquired
+  | Acquired -> claim_pid_file path
+
+let acquire_base_path_lock ?lock_path base_path =
+  let path =
+    match lock_path with
+    | Some value -> value
+    | None -> base_path_lock_path base_path
+  in
+  (match read_pid_file path with
+  | Some data -> (
+      match String.trim data |> int_of_string_opt with
+      | Some pid when pid > 0 ->
+          if pid_exists pid then
+            match process_command pid with
+            | Some command when looks_like_server_command command ->
+                Already_running { pid }
+            | Some _ | None ->
+                Log.legacy_stderr ~level:Log.Error ~module_name:"Server"
+                  (Printf.sprintf
+                     "[FATAL] PID %d owns %s but does not look like a masc-mcp server; refusing takeover"
+                     pid path);
+                Already_running { pid }
+          else begin
+            Log.legacy_stderr ~level:Log.Warn ~module_name:"Server"
+              (Printf.sprintf
+                 "[WARN] Removing stale base-path owner file (PID %d no longer running)"
+                 pid);
+            Acquired
+          end
+      | _ ->
+          Log.legacy_stderr ~level:Log.Warn ~module_name:"Server"
+            "[WARN] Invalid base-path owner file contents, overwriting";
+          Acquired)
+  | None -> Acquired)
+  |> function
+  | Already_running _ as result -> result
+  | Acquired -> claim_pid_file path

--- a/lib/server/server_startup_takeover.mli
+++ b/lib/server/server_startup_takeover.mli
@@ -4,6 +4,8 @@ type acquire_result =
 
 val pid_lock_path : int -> string
 
+val base_path_lock_path : string -> string
+
 val status_line_is_healthy : string -> bool
 
 val looks_like_server_command : string -> bool
@@ -20,4 +22,9 @@ val acquire_pid_lock :
   ?kill_wait_sec:float ->
   ?poll_interval_sec:float ->
   int ->
+  acquire_result
+
+val acquire_base_path_lock :
+  ?lock_path:string ->
+  string ->
   acquire_result

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -374,6 +374,20 @@ let wait_for_health ~pid ~port ~timeout_s =
   in
   loop ()
 
+let wait_for_process_exit ~pid ~timeout_s =
+  let deadline = Unix.gettimeofday () +. timeout_s in
+  let rec loop () =
+    if not (process_alive pid) then
+      true
+    else if Unix.gettimeofday () >= deadline then
+      false
+    else begin
+      Unix.sleepf 0.1;
+      loop ()
+    end
+  in
+  loop ()
+
 let wait_for_startup_phase ~pid ~port ~timeout_s expected_phase =
   let deadline = Unix.gettimeofday () +. timeout_s in
   let rec loop () =
@@ -1526,6 +1540,93 @@ let test_main_eio_fresh_bootstrap_and_mcp_handshake () =
           Alcotest.(check bool) "canonical tool present" true
             (List.mem "masc_status" tool_names)))
 
+let test_main_eio_rejects_same_base_path_on_second_server () =
+  with_temp_dir "startup-base-path-owner-lock" (fun dir ->
+      let exe = find_main_eio_exe () in
+      let primary_port = find_free_port () in
+      let secondary_port = find_free_port_from (primary_port + 1) in
+      let primary_log = Filename.concat dir "primary.log" in
+      let secondary_log = Filename.concat dir "secondary.log" in
+      let open_log path =
+        Unix.openfile path [ Unix.O_CREAT; Unix.O_WRONLY; Unix.O_TRUNC ] 0o644
+      in
+      with_env "MASC_CONFIG_DIR" None @@ fun () ->
+      with_env "MASC_PERSONAS_DIR" None @@ fun () ->
+      with_cwd (project_root ()) @@ fun () ->
+      Server_runtime_bootstrap.bootstrap_base_path_config_root ~base_path:dir;
+      let env =
+        merge_env_overrides
+          [
+            ("MASC_BASE_PATH", dir);
+            ("MASC_STORAGE_TYPE", "filesystem");
+            ("GRAPHQL_API_KEY", "");
+            ("GRAPHQL_URL", "http://127.0.0.1:9/graphql");
+            ("MASC_AUTONOMY_ENABLED", "0");
+            ("MASC_ORCHESTRATOR_ENABLED", "0");
+            ("MASC_KEEPER_BOOTSTRAP_ENABLED", "false");
+            ("MASC_USE_H2", "0");
+            ("DUNE_SOURCEROOT", project_root ());
+          ]
+      in
+      let primary_fd = open_log primary_log in
+      let primary_pid =
+        Unix.create_process_env exe
+          [|
+            exe;
+            "--host";
+            "127.0.0.1";
+            "--port";
+            string_of_int primary_port;
+            "--base-path";
+            dir;
+          |]
+          env Unix.stdin primary_fd primary_fd
+      in
+      Unix.close primary_fd;
+      let secondary_pid = ref None in
+      Fun.protect
+        ~finally:(fun () ->
+          (match !secondary_pid with
+           | Some pid -> stop_process pid
+           | None -> ());
+          stop_process primary_pid)
+        (fun () ->
+          if not (wait_for_health ~pid:primary_pid ~port:primary_port ~timeout_s:5.0)
+          then begin
+            prerr_endline
+              (Printf.sprintf
+                 "primary main_eio did not expose /health within timeout in this environment.\nlog:\n%s"
+                 (read_file primary_log));
+            Alcotest.skip ()
+          end;
+          let secondary_fd = open_log secondary_log in
+          let pid =
+            Unix.create_process_env exe
+              [|
+                exe;
+                "--host";
+                "127.0.0.1";
+                "--port";
+                string_of_int secondary_port;
+                "--base-path";
+                dir;
+              |]
+              env Unix.stdin secondary_fd secondary_fd
+          in
+          secondary_pid := Some pid;
+          Unix.close secondary_fd;
+          if not (wait_for_process_exit ~pid ~timeout_s:5.0) then
+            Alcotest.failf
+              "secondary main_eio stayed alive despite shared base path\nlog:\n%s"
+              (read_file secondary_log);
+          let secondary_text = read_file secondary_log in
+          Alcotest.(check bool) "secondary log mentions base-path owner" true
+            (contains_substring secondary_text "already owns base path");
+          Alcotest.(check bool) "secondary log mentions primary pid" true
+            (contains_substring secondary_text (string_of_int primary_pid));
+          Alcotest.(check bool) "primary server stays healthy" true
+            (wait_for_health ~pid:primary_pid ~port:primary_port ~timeout_s:1.0)))
+
 let test_main_eio_invalid_cascade_stays_degraded_but_serves_dashboard () =
   with_temp_dir "startup-invalid-cascade" (fun dir ->
       let exe = find_main_eio_exe () in
@@ -1934,6 +2035,9 @@ let () =
           Alcotest.test_case
             "main_eio fresh bootstrap and MCP handshake"
             `Slow test_main_eio_fresh_bootstrap_and_mcp_handshake;
+          Alcotest.test_case
+            "main_eio rejects second server on same base path"
+            `Slow test_main_eio_rejects_same_base_path_on_second_server;
           Alcotest.test_case
             "main_eio partial catalog stays ready and surfaces rejections"
             `Slow

--- a/test/test_server_startup_takeover.ml
+++ b/test/test_server_startup_takeover.ml
@@ -163,6 +163,9 @@ let with_forever_process ?argv0 ~ignore_sigterm f =
 let lock_path dir =
   Filename.concat dir "masc.pid"
 
+let base_path_lock_path dir =
+  Server_startup_takeover.base_path_lock_path dir
+
 let pid_from_file path =
   match read_file path |> String.trim |> int_of_string_opt with
   | Some pid -> pid
@@ -244,6 +247,40 @@ let test_escalates_sigkill_for_unresponsive_holder () =
           | Server_startup_takeover.Already_running _ ->
               Alcotest.fail "unresponsive holder should be reclaimed"))
 
+let test_base_path_lock_rejects_live_server_holder () =
+  with_temp_dir "startup-takeover-base-path-live" (fun dir ->
+      with_forever_process ~argv0:"main_eio.exe" ~ignore_sigterm:false (fun pid ->
+          let path = base_path_lock_path dir in
+          rm_rf (Filename.dirname path);
+          Unix.mkdir (Filename.dirname path) 0o755;
+          write_file path (Printf.sprintf "%d\n" pid);
+          match
+            Server_startup_takeover.acquire_base_path_lock ~lock_path:path dir
+          with
+          | Server_startup_takeover.Already_running { pid = running_pid } ->
+              Alcotest.(check int) "pid preserved" pid running_pid;
+              Alcotest.(check bool) "server process stays alive" true
+                (process_alive pid)
+          | Server_startup_takeover.Acquired ->
+              Alcotest.fail "live base-path owner should block takeover"))
+
+let test_base_path_lock_reclaims_stale_pid_file () =
+  with_temp_dir "startup-takeover-base-path-stale" (fun dir ->
+      with_forever_process ~ignore_sigterm:false (fun pid ->
+          stop_process pid;
+          let path = base_path_lock_path dir in
+          rm_rf (Filename.dirname path);
+          Unix.mkdir (Filename.dirname path) 0o755;
+          write_file path (Printf.sprintf "%d\n" pid);
+          match
+            Server_startup_takeover.acquire_base_path_lock ~lock_path:path dir
+          with
+          | Server_startup_takeover.Acquired ->
+              Alcotest.(check int) "current pid written" (Unix.getpid ())
+                (pid_from_file path)
+          | Server_startup_takeover.Already_running _ ->
+              Alcotest.fail "stale base-path owner should be reclaimed"))
+
 let () =
   Alcotest.run "Server_startup_takeover"
     [
@@ -264,5 +301,9 @@ let () =
             test_tolerates_invalid_pid_file;
           Alcotest.test_case "unresponsive holder escalates to sigkill" `Quick
             test_escalates_sigkill_for_unresponsive_holder;
+          Alcotest.test_case "live base-path owner blocks takeover" `Quick
+            test_base_path_lock_rejects_live_server_holder;
+          Alcotest.test_case "stale base-path owner is reclaimed" `Quick
+            test_base_path_lock_reclaims_stale_pid_file;
         ] );
     ]


### PR DESCRIPTION
## Summary
- add a dedicated base-path owner pidfile so only one masc-mcp server can own a runtime root at a time
- fail fast in `main_eio` when another live server already owns the same `--base-path`, even on a different port
- cover the new guard with startup takeover unit tests and a two-server `main_eio` integration test

## Root Cause
- startup only guarded on port, not on runtime root ownership
- two servers on different ports could share the same `base_path` and mutate the same `.masc` state
- that let an older worktree/server resurrect cleaned config and runtime files under the shared base path

## Validation
- `dune build --root . test/test_server_startup_takeover.exe test/test_server_runtime_bootstrap.exe bin/main_eio.exe`
- `./_build/default/test/test_server_startup_takeover.exe`
- `./_build/default/test/test_server_runtime_bootstrap.exe`

Closes #9512