### PR TITLE
fix(keeper): default work_discovery_enabled to true when None

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1597,7 +1597,8 @@ let run_turn
   let discover_work_nudge () : string option =
     let meta = !meta_ref in
     match meta.work_discovery_enabled with
-    | Some true ->
+    | Some false -> None
+    | _ ->
       let interval =
         Option.value ~default:600 meta.work_discovery_interval_sec in
       let since_last =
@@ -1699,7 +1700,6 @@ let run_turn
               Do not print fenced pseudo-calls. Pick the smallest viable \
               action and emit one or more structured tool calls now."
              interval (String.concat "\n\n" sections)))
-    | _ -> None
   in
   let base_hooks =
     (* Issue #8597 #3-5: dropped ~config / ~session / ~ctx_snapshot —

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -693,10 +693,16 @@ let observe ~(pending_board_events : pending_board_event list option)
         in
         events
   in
-  (* Work Discovery: check if scan interval has elapsed *)
+  (* Work Discovery: check if scan interval has elapsed.
+     None means "not explicitly configured" — default to enabled so
+     keepers that lack explicit work_discovery_enabled in their profile
+     still discover work autonomously.  Only Some false explicitly
+     disables the mechanism.  Ref: P0 keeper activity investigation,
+     15/16 keepers had None → idle forever. *)
   let work_discovery_due =
     match meta.work_discovery_enabled with
-    | Some true ->
+    | Some false -> false
+    | _ ->
       let interval =
         Option.value ~default:600 meta.work_discovery_interval_sec
       in
@@ -704,7 +710,6 @@ let observe ~(pending_board_events : pending_board_event list option)
         Time_compat.now () -. meta.runtime.proactive_rt.last_work_discovery_ts
       in
       since_last >= float_of_int interval
-    | _ -> false
   in
   {
     pending_mentions;


### PR DESCRIPTION
## Summary

- **work_discovery_enabled=None** was treated as disabled, keeping 15/16 keepers permanently idle
- Inverted the match logic: only `Some false` explicitly disables work discovery; `None` now defaults to enabled
- Two files changed: `keeper_world_observation.ml` (signal gate) and `keeper_agent_run.ml` (nudge injection)

## Root Cause

P0 keeper activity investigation: 15/16 keepers had `work_discovery_enabled=None` in runtime JSON. The match pattern `| Some true -> ... | _ -> false` treated `None` as disabled. Combined with no reactive triggers and no current_task_id, `proactive_work_signal_present` returned false → `should_run=false` → permanent idle.

```
work_discovery_enabled=None
  → work_discovery_due=false
  → proactive_work_signal_present=false (no mentions/board/tasks)
  → should_run=false
  → keeper never executes a turn
```

## Fix

- `keeper_world_observation.ml:697-708`: `Some false -> false; | _ ->` (enabled by default)
- `keeper_agent_run.ml:1599-1603`: Same inversion in `discover_work_nudge`
- Removed now-redundant `| _ -> None` catch-all in agent_run

## Test plan

- [x] `dune build --root .` — compiles clean
- [x] `dune runtest` — 118/121 pass; 3 failures are pre-existing room membership issues unrelated to this change
- [ ] Start server, observe keepers executing proactive turns via log output
- [ ] Verify `work_discovery_due=true` appears in keepalive decision logs for keepers with `work_discovery_enabled=None`

Refs: #6814, #8773

🤖 Generated with [Claude Code](https://claude.com/claude-code)