### PR TITLE
refactor: replace String.index with String.index_opt (#8355)

### DIFF
--- a/lib/metrics_store_eio.ml
+++ b/lib/metrics_store_eio.ml
@@ -124,9 +124,10 @@ let flush_pending () =
 (** Start the background flush fiber. Call once inside Eio_main.run.
     Drains the write queue every 500ms or when the stream has entries. *)
 let start_flush_fiber ~clock =
+  let flush_interval_s = 0.5 in
   Atomic.set queue_active true;
   let rec loop () =
-    Eio.Time.sleep clock 0.5;
+    Eio.Time.sleep clock flush_interval_s;
     flush_pending ();
     loop ()
   in

--- a/lib/retrieval_projection.ml
+++ b/lib/retrieval_projection.ml
@@ -92,19 +92,18 @@ let split_chunks input =
 let parse_labeled_chunk chunk =
   let trimmed = String.trim chunk in
   if String.length trimmed >= 4 && trimmed.[0] = '[' then
-    try
-      let close_idx = String.index trimmed ']' in
-      if close_idx + 2 < String.length trimmed && trimmed.[close_idx + 1] = ':' then
-        let label = String.sub trimmed 1 (close_idx - 1) in
-        let payload =
-          String.sub trimmed (close_idx + 2)
-            (String.length trimmed - close_idx - 2)
-          |> String.trim
-        in
-        (trim_to_option label, payload)
-      else
-        (None, trimmed)
-    with Not_found -> (None, trimmed)
+    match String.index_opt trimmed ']' with
+    | Some close_idx
+      when close_idx + 2 < String.length trimmed
+           && trimmed.[close_idx + 1] = ':' ->
+      let label = String.sub trimmed 1 (close_idx - 1) in
+      let payload =
+        String.sub trimmed (close_idx + 2)
+          (String.length trimmed - close_idx - 2)
+        |> String.trim
+      in
+      (trim_to_option label, payload)
+    | _ -> (None, trimmed)
   else
     (None, trimmed)
 

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -224,9 +224,9 @@ let command_blocked_hint name =
   let looks_like_source_code s =
     (* Contains '.' at a non-boundary position (A.B), or starts with a
        reserved OCaml keyword that no shell command uses. *)
-    (String.contains s '.'
-     && (String.index s '.' > 0)
-     && (String.index s '.' < String.length s - 1))
+    (match String.index_opt s '.' with
+     | Some i -> i > 0 && i < String.length s - 1
+     | None -> false)
     || List.mem s
          [ "let"; "match"; "if"; "then"; "else"; "fun"; "rec"; "in";
            "module"; "open"; "type"; "def"; "class"; "import"; "from" ]


### PR DESCRIPTION
## Summary
- Convert `String.index` + `try-with Not_found` to `String.index_opt` + `match` in `retrieval_projection.ml`
- Replace guarded `String.index` with `String.index_opt` + `match` in `worker_dev_tools.ml`, removing the `String.contains` precondition guard

## Test plan
- [x] `dune build --root . bin/main_eio.exe` passes
- [ ] CI Health/Build+Test/Lint green

🤖 Generated with [Claude Code](https://claude.com/claude-code)