### PR TITLE
fix(keeper): log swallowed exceptions in world observation

### DIFF
--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -241,14 +241,18 @@ let read_backlog_counts ~(config : Coord.config) : int * int * int =
     (unclaimed, failed, pending_verification)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
-  | _ -> (0, 0, 0)
+  | ex ->
+      Log.Keeper.warn "read_backlog_counts failed: %s" (Printexc.to_string ex);
+      (0, 0, 0)
 
 (** Count active agents in room. *)
 let count_active_agents ~(config : Coord.config) : int =
   try List.length (Coord.get_agents_raw config)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
-  | _ -> 0
+  | ex ->
+      Log.Keeper.warn "count_active_agents failed: %s" (Printexc.to_string ex);
+      0
 
 (** Compute idle seconds from keeper timestamps. *)
 let compute_idle_seconds ~(meta : keeper_meta) : int =


### PR DESCRIPTION
## Problem
\`read_backlog_counts\` and \`count_active_agents\` in \`keeper_world_observation.ml\` had catch-all exception handlers returning silent zeros:

```ocaml
| _ -> (0, 0, 0)
```

This swallowed all errors from \`Coord.read_backlog\` and \`Registry.active_agents\`, making it impossible to diagnose why keepers reported \`unclaimed_task_count: 0\` despite visible unclaimed tasks.

## Change
Replace silent catch-all with explicit logging before returning fallback:

```ocaml
| ex ->
    Log.Keeper.warn "read_backlog_counts failed: %s" (Printexc.to_string ex);
    (0, 0, 0)
```

Same pattern applied to \`count_active_agents\`.

## Verification
- [x] Compiles in worktree
- [ ] Runtime log confirmation (blocked by pending credential fix for keeper MCP auth)

## Related
Part of broader keeper observation clarity audit.