### PR TITLE
[docker] add --spec-stdin to worker-runtime entrypoint

### DIFF
--- a/Dockerfile.worker-runtime
+++ b/Dockerfile.worker-runtime
@@ -30,4 +30,4 @@ RUN apt-get update \
 
 COPY --from=build /src/_build/install/default/bin/masc-worker-run /usr/local/bin/masc-worker-run
 
-ENTRYPOINT ["/usr/local/bin/masc-worker-run"]
+ENTRYPOINT ["/usr/local/bin/masc-worker-run", "--spec-stdin"]


### PR DESCRIPTION
## What changed
Added \`--spec-stdin\` to the \`ENTRYPOINT\` in \`Dockerfile.worker-runtime\`.

## Why
PR #9515 attempted to migrate the worker Docker image from Alpine to Debian and add \`--spec-stdin\` to the entrypoint. The Alpine→Debian migration was already completed in \`Dockerfile.worker-runtime\` via #9524, but \`--spec-stdin\` was missing. This PR applies the remaining delta.

## Validation
- \`docker build -f Dockerfile.worker-runtime -t masc-worker-runtime:dev .\`
- \`echo '{}' | docker run --rm -i masc-worker-runtime:dev\`
  - expected: container starts and returns JSON spec_parse error because \`{}\` is not a valid worker spec