### PR TITLE
fix(run-local): exclude keepers from bootstrap by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Notes:
 
 - Check the default port for a target: `scripts/run-local.sh --print-port --target-dir /path/to/project`
 - To use a fixed port: `scripts/run-local.sh --target-dir /path/to/project --port 94xx`
+- Dir-local bootstrap excludes checked-in `config/keepers/*.toml` by default; add `--bootstrap-keepers` only when you explicitly want that seed copied into `<target>/.masc/config/keepers`
 - For shared repo/full-runtime paths, continue using `./start-masc-mcp.sh --http`
 - For a full boot/path/state inventory, see [docs/BOOT-ENV-STATE-INVENTORY.md](docs/BOOT-ENV-STATE-INVENTORY.md)
 - For active config/init diagnosis, use [docs/CONFIG-DOCTOR.md](docs/CONFIG-DOCTOR.md)
@@ -303,6 +304,7 @@ The dashboard should learn connector type and status from the gate descriptor
 surface instead of hardcoding vendor-specific assumptions.
 
 - `scripts/run-local.sh` does not build the dashboard automatically. Append `--build-dashboard` only when needed.
+- `scripts/run-local.sh` also excludes checked-in keeper manifests during bootstrap unless `--bootstrap-keepers` is passed.
 - `start-masc-mcp.sh` automatically builds the dashboard SPA if `pnpm` or `corepack pnpm` is available.
 - To run the dev server separately, use:
 

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -14,6 +14,7 @@ PORT_EXPLICIT=0
 PRINT_PORT_ONLY=0
 BOOTSTRAP_ONLY=0
 BUILD_DASHBOARD=0
+BOOTSTRAP_KEEPERS=0
 DUNE_JOBS="${MASC_DUNE_JOBS:-8}"
 
 git_common_root() {
@@ -33,7 +34,7 @@ git_common_root() {
 
 usage() {
   cat >&2 <<'EOF'
-Usage: scripts/run-local.sh [--target-dir PATH] [--host HOST] [--port PORT] [--print-port] [--bootstrap-only] [--build-dashboard]
+Usage: scripts/run-local.sh [--target-dir PATH] [--host HOST] [--port PORT] [--print-port] [--bootstrap-only] [--build-dashboard] [--bootstrap-keepers]
 
 Dir-local local-dev launcher:
   - runtime data root defaults to <target>/.masc/
@@ -41,6 +42,7 @@ Dir-local local-dev launcher:
   - personas root defaults to <target>/.masc/config/personas
   - gRPC / WS / WebRTC are disabled by default
   - --bootstrap-only materializes local config/build state but does not start the server
+  - checked-in keeper manifests are excluded by default; pass --bootstrap-keepers to seed config/keepers
 
 For shared repo/full-runtime startup, use ./start-masc-mcp.sh instead.
 EOF
@@ -107,6 +109,8 @@ bootstrap_local_config() {
   local target="$1"
   local local_masc_dir="$target/.masc"
   local local_config_dir="$local_masc_dir/config"
+  local item=""
+  local name=""
   if [ "${MASC_CONFIG_DIR+x}" = "x" ]; then
     return 0
   fi
@@ -116,8 +120,27 @@ bootstrap_local_config() {
 
   mkdir -p "$local_masc_dir"
   if [ -d "$REPO_ROOT/config" ]; then
-    cp -R "$REPO_ROOT/config" "$local_config_dir"
-    echo "[local-run] Bootstrapped config into $local_config_dir" >&2
+    mkdir -p "$local_config_dir"
+    for item in "$REPO_ROOT/config"/*; do
+      if [ ! -e "$item" ]; then
+        continue
+      fi
+      name="$(basename "$item")"
+      if [ "$name" = "keepers" ]; then
+        if [ "$BOOTSTRAP_KEEPERS" = "1" ]; then
+          cp -R "$item" "$local_config_dir/$name"
+        else
+          mkdir -p "$local_config_dir/keepers"
+        fi
+      else
+        cp -R "$item" "$local_config_dir/$name"
+      fi
+    done
+    if [ "$BOOTSTRAP_KEEPERS" = "1" ]; then
+      echo "[local-run] Bootstrapped config into $local_config_dir (keepers included)" >&2
+    else
+      echo "[local-run] Bootstrapped config into $local_config_dir (keepers excluded; pass --bootstrap-keepers to include)" >&2
+    fi
   else
     mkdir -p "$local_config_dir"
     echo "[local-run] Repo config/ missing; created empty $local_config_dir" >&2
@@ -179,6 +202,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --build-dashboard)
       BUILD_DASHBOARD=1
+      shift
+      ;;
+    --bootstrap-keepers)
+      BOOTSTRAP_KEEPERS=1
       shift
       ;;
     -h|--help)

--- a/test/test_run_local_script.ml
+++ b/test/test_run_local_script.ml
@@ -98,6 +98,11 @@ let make_config_root root =
   write_file (Filename.concat config "cascade.json") "{\"seed\":\"repo\"}";
   config
 
+let write_keeper_seed repo_root =
+  write_file
+    (Filename.concat repo_root "config/keepers/sangsu.toml")
+    "[keeper]\npersona_name = \"sangsu\"\n"
+
 let write_fake_eio_exe exe_path =
   mkdir_p (Filename.dirname exe_path);
   let content =
@@ -132,6 +137,7 @@ let setup_fake_repo root =
 let test_bootstraps_local_config_and_sets_http_only_env () =
   with_temp_dir "run-local-script" (fun dir ->
       let repo_root = setup_fake_repo dir in
+      write_keeper_seed repo_root;
       let target = Filename.concat dir "target" in
       mkdir_p target;
       let capture = Filename.concat dir "captured-env.txt" in
@@ -150,6 +156,9 @@ let test_bootstraps_local_config_and_sets_http_only_env () =
       let captured = read_file capture in
       check bool "bootstrapped cascade" true
         (Sys.file_exists (Filename.concat target_abs ".masc/config/cascade.json"));
+      check bool "bootstrapped keepers excluded by default" false
+        (Sys.file_exists
+           (Filename.concat target_abs ".masc/config/keepers/sangsu.toml"));
       check bool "base path set" true
         (contains_substring captured ("MASC_BASE_PATH=" ^ target_abs));
       check bool "config dir set" true
@@ -164,6 +173,28 @@ let test_bootstraps_local_config_and_sets_http_only_env () =
         (contains_substring captured "MASC_WEBRTC_ENABLED=0");
       check bool "port passed through" true
         (contains_substring captured "ARGS=--host=127.0.0.1 --port=9955"))
+
+let test_bootstrap_keepers_flag_is_opt_in () =
+  with_temp_dir "run-local-script" (fun dir ->
+      let repo_root = setup_fake_repo dir in
+      write_keeper_seed repo_root;
+      let target = Filename.concat dir "target" in
+      mkdir_p target;
+      let script = Filename.concat repo_root "scripts/run-local.sh" in
+      let code, stdout, stderr =
+        run_shell ~cwd:repo_root
+          ~unset_env:
+            [ "MASC_BASE_PATH"; "MASC_CONFIG_DIR"; "MASC_PERSONAS_DIR" ]
+          (Printf.sprintf "%s --target-dir %s --port 9956 --bootstrap-only --bootstrap-keepers"
+             (quote script) (quote target))
+      in
+      if code <> 0 then
+        failf "run-local bootstrap-keepers failed (%d)\nstdout:\n%s\nstderr:\n%s"
+          code stdout stderr;
+      check bool "bootstrapped keeper copied with flag" true
+        (Sys.file_exists (Filename.concat target ".masc/config/keepers/sangsu.toml"));
+      check bool "keepers included message" true
+        (contains_substring stderr "keepers included"))
 
 let test_print_port_is_stable_for_target_dir () =
   with_temp_dir "run-local-script" (fun dir ->
@@ -339,6 +370,8 @@ let () =
             test_print_port_is_stable_for_target_dir;
           test_case "build-dashboard flag is opt-in" `Quick
             test_build_dashboard_flag_is_opt_in;
+          test_case "bootstrap-keepers flag is opt-in" `Quick
+            test_bootstrap_keepers_flag_is_opt_in;
           test_case "existing target config is not overwritten" `Quick
             test_existing_target_config_is_not_overwritten;
           test_case "explicit config env is preserved without bootstrap" `Quick


### PR DESCRIPTION
## Summary
- exclude checked-in `config/keepers/*.toml` from `scripts/run-local.sh` dir-local bootstrap by default
- add an explicit `--bootstrap-keepers` opt-in to seed keeper manifests when that behavior is actually desired
- document the new default and cover both paths in the run-local script tests

## Root Cause
`scripts/run-local.sh` previously copied the repo's entire `config/` tree into the active local config root. Any worktree that still had extra keeper manifests under `config/keepers/` would therefore repopulate `~/.masc/config/keepers/` and inflate the live keeper roster unexpectedly.

## Validation
- `bash -n scripts/run-local.sh`
- manual smoke test confirmed default bootstrap leaves keeper seed out: `default_has_keeper=no`
- manual smoke test confirmed opt-in bootstrap includes keeper seed: `optin_has_keeper=yes`
- `dune build --root . test/test_run_local_script.exe` is currently blocked by unrelated pre-existing OCaml compile errors in keeper modules
