### PR TITLE
fix(keeper): align .mli signatures with #9527 runtime changes

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -598,7 +598,7 @@ let handle_keeper_bash
         "DOCKER_GIT_EXEC: keeper=%s cwd=%s cmd=%s"
         meta.name cwd cmd_for_log;
       run_docker_with_git_bash
-        ~turn_sandbox_runtime:turn_sandbox_runtime_git ~config ~meta ~cwd ~timeout_sec ~cmd)
+        ?turn_sandbox_runtime:turn_sandbox_runtime_git ~config ~meta ~cwd ~timeout_sec ~cmd)
     else if sandbox_profile = Docker then (
       Log.Keeper.info
         "DOCKER_EXEC: keeper=%s cwd=%s cmd=%s network=%s"

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -47,6 +47,7 @@ val cmd_targets_git_or_gh : string -> bool
 
 val handle_keeper_bash :
   turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
+  ?turn_sandbox_runtime_git:Keeper_turn_sandbox_runtime.t ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   args:Yojson.Safe.t ->

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -157,6 +157,7 @@ val execute_keeper_tool_call_with_outcome :
   meta:keeper_meta ->
   ctx_work:working_context ->
   ?turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t ->
+  ?turn_sandbox_runtime_git:Keeper_turn_sandbox_runtime.t ->
   ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t) ->
   name:string ->
   input:Yojson.Safe.t ->

--- a/lib/keeper/keeper_turn_sandbox_runtime.mli
+++ b/lib/keeper/keeper_turn_sandbox_runtime.mli
@@ -10,6 +10,7 @@ val create :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   ?network_mode:Keeper_types.network_mode ->
+  unit ->
   t
 
 val cleanup : t -> unit


### PR DESCRIPTION
## Summary
- Fix three `.mli` signature mismatches introduced by #9527 that broke the main branch build
- `keeper_turn_sandbox_runtime.mli`: add missing `unit` parameter to `create`
- `keeper_exec_tools.mli`: add `?turn_sandbox_runtime_git` to `execute_keeper_tool_call_with_outcome`
- `keeper_exec_shell.mli`: add `?turn_sandbox_runtime_git` to `handle_keeper_bash`
- `keeper_exec_shell.ml`: use `?` (option passthrough) instead of `~` for the optional parameter at line 601

## Test plan
- [x] `dune build -p masc_mcp` passes with 0 errors
- [x] `dune runtest -p masc_mcp` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)