### PR TITLE
fix(keeper): add tool_access.kind and tool_access.preset to canonical keys

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -620,6 +620,8 @@ let canonical_keeper_toml_key_names =
   ; "network_mode"
   ; "shared_memory_scope"
   ; "tool_preset"
+  ; "tool_access.kind"
+  ; "tool_access.preset"
   ; "tool_also_allow"
   ; "also_allow"
   ; "tool_denylist"


### PR DESCRIPTION
## Summary

Add `tool_access.kind` and `tool_access.preset` to `canonical_keeper_toml_key_names` to suppress repeated unknown-key WARNs at boot.

The `[keeper.tool_access]` nested TOML table (used by keepers like sangsu and scholar) contains `kind` and `preset` keys that were not in the canonical list, causing WARN logs on every keeper startup.

## Changes

- `lib/keeper/keeper_types_profile.ml`: add `"tool_access.kind"` and `"tool_access.preset"` to the canonical key names list.

## Related Issues

Closes #9536

## Verification

- [x] `dune build @install` passes in worktree