### PR TITLE
fix(keeper,tools,autoresearch): TOML re-sync, alias prefix strip, capacity fail-safe

### DIFF
--- a/lib/autoresearch_codegen.ml
+++ b/lib/autoresearch_codegen.ml
@@ -124,8 +124,8 @@ let has_background_capacity () =
       | Eio.Cancel.Cancelled _ as ex -> raise ex
       | ex ->
         Log.Autoresearch.warn "capacity check failed: %s" (Printexc.to_string ex);
-        true)
-  | _ -> true
+        false)
+  | _ -> false
 
 (** Generate code change via Cascade "autoresearch" profile.
     Returns Ok (hypothesis, new_code) or Error reason. *)

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -106,6 +106,11 @@ type docker_shell_result =
     network_label : string;
   }
 
+(* docker run --rm includes image layer pull + container creation cold start.
+   A 1s floor is insufficient even for trivial commands. This minimum applies
+   only to the run path, not to docker exec against a warm container. *)
+let docker_run_min_timeout_sec = 5.0
+
 let run_docker_shell_command_with_status
     ~(config : Coord.config)
     ~(meta : keeper_meta)
@@ -115,6 +120,7 @@ let run_docker_shell_command_with_status
     ~(git_creds_enabled : bool)
     ~(network_mode : network_mode)
   =
+  let timeout_sec = max timeout_sec docker_run_min_timeout_sec in
   let image = Env_config_keeper.KeeperSandbox.docker_image () in
   let sandbox_error message =
     Keeper_registry.record_error ~base_path:config.base_path meta.name message;

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -58,8 +58,20 @@ let to_public internal =
   | Some public -> public
   | None -> internal
 
+let strip_mcp_masc_prefix name =
+  let prefix = "mcp__masc__" in
+  let prefix_len = String.length prefix in
+  if String.length name >= prefix_len && String.sub name 0 prefix_len = prefix then
+    String.sub name prefix_len (String.length name - prefix_len)
+  else
+    name
+
 let canonicalize_observed names =
-  List.map (fun n -> match to_internal n with Some i -> i | None -> n) names
+  List.map
+    (fun n ->
+      let stripped = strip_mcp_masc_prefix n in
+      match to_internal stripped with Some i -> i | None -> stripped)
+    names
 
 let hallucinated_set =
   let t = Hashtbl.create (List.length hallucinated_builtins) in

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -198,14 +198,27 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     room_signal_prompt_enabled;
     proactive = {
       enabled =
-        Option.value
-          ~default:old.proactive.enabled
-          p.proactive_enabled_opt;
+        (match p.proactive_enabled_opt with
+         | Some v -> v
+         | None ->
+             (match p.profile_defaults.proactive_enabled with
+              | Some v -> v
+              | None -> old.proactive.enabled));
       idle_sec =
-        Option.value ~default:old.proactive.idle_sec p.proactive_idle_sec_opt
+        (match p.proactive_idle_sec_opt with
+         | Some v -> v
+         | None ->
+             (match p.profile_defaults.proactive_idle_sec with
+              | Some v -> v
+              | None -> old.proactive.idle_sec))
         |> normalize_proactive_idle_sec;
       cooldown_sec =
-        Option.value ~default:old.proactive.cooldown_sec p.proactive_cooldown_sec_opt
+        (match p.proactive_cooldown_sec_opt with
+         | Some v -> v
+         | None ->
+             (match p.profile_defaults.proactive_cooldown_sec with
+              | Some v -> v
+              | None -> old.proactive.cooldown_sec))
         |> normalize_proactive_cooldown_sec;
     };
     compaction = {

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -620,6 +620,8 @@ let canonical_keeper_toml_key_names =
   ; "network_mode"
   ; "shared_memory_scope"
   ; "tool_preset"
+  ; "tool_access.kind"
+  ; "tool_access.preset"
   ; "tool_also_allow"
   ; "also_allow"
   ; "tool_denylist"

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -404,10 +404,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         (* Persist nickname so subsequent calls can use it. *)
         write_mcp_session_agent nickname;
         write_term_session_agent nickname;
-        (try ignore (Session.register registry ~agent_name:nickname)
-         with
-         | Eio.Cancel.Cancelled _ as e -> raise e
-         | exn -> log_mcp_exn ~label:"session register (nickname) failed" exn);
+        ignore (Session.register registry ~agent_name:nickname);
         nickname
       end
     end else
@@ -416,10 +413,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
 
   (* Auto-register session for non-read-only tools *)
   if agent_name <> "unknown" && not is_read_only then
-    (try ignore (Session.register registry ~agent_name)
-     with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | exn -> log_mcp_exn ~label:"session register (tool) failed" exn);
+    ignore (Session.register registry ~agent_name);
 
   (* Log tool call *)
   Log.Mcp.debug "[%s] %s" agent_name name;

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -157,65 +157,70 @@ let parse_gemini_output raw =
   with Yojson.Json_error _ ->
     parse_raw_output raw
 
-(** Default spawn configs for known agents *)
-let default_configs = [
-  ("claude", {
-    agent_name = "claude";
-    command = "claude --output-format json -p";
-    timeout_seconds = Env_config.Spawn.timeout_seconds;
-    working_dir = None;
-    mcp_tools = masc_mcp_tools;
-    parse_output = parse_claude_output;
-    stdin_prompt = true;
-    mcp_mode = Mcp_joined "--allowedTools";
-    prompt_mode = Prompt_stdin;
-  });
-  ("gemini", {
-    agent_name = "gemini";
-    command = "gemini --yolo --output-format json";
-    timeout_seconds = Env_config.Spawn.timeout_seconds;
-    working_dir = None;
-    mcp_tools = masc_mcp_tools;
-    parse_output = parse_gemini_output;
-    stdin_prompt = false;
-    mcp_mode = Mcp_spread "--allowed-tools";
-    prompt_mode = Prompt_flag "-p";
-  });
-  ("codex", {
-    agent_name = "codex";
-    command = "codex exec";
-    timeout_seconds = Env_config.Spawn.timeout_seconds;
-    working_dir = None;
-    mcp_tools = masc_mcp_tools;
-    parse_output = parse_raw_output;
-    stdin_prompt = true;
-    mcp_mode = Mcp_none;
-    prompt_mode = Prompt_stdin;
-  });
-  ("llama", {
-    agent_name = "llama";
-    command = Provider_adapter.make_local_label "explicit-model-required";
-    timeout_seconds = Env_config.Spawn.timeout_seconds;
-    working_dir = None;
-    mcp_tools = masc_mcp_tools;
-    parse_output = parse_raw_output;
-    stdin_prompt = true;
-    mcp_mode = Mcp_none;
-    prompt_mode = Prompt_stdin;
-  });
-]
+(** Build a spawn config from a canonical spawn key.
+    SSOT for agent names and aliases is [Provider_adapter.direct_adapters];
+    this function only maps resolved keys to their CLI invocation shape. *)
+let spawn_config_of_key key =
+  let open Env_config.Spawn in
+  match key with
+  | "claude" ->
+      Some {
+        agent_name = "claude";
+        command = "claude --output-format json -p";
+        timeout_seconds;
+        working_dir = None;
+        mcp_tools = masc_mcp_tools;
+        parse_output = parse_claude_output;
+        stdin_prompt = true;
+        mcp_mode = Mcp_joined "--allowedTools";
+        prompt_mode = Prompt_stdin;
+      }
+  | "gemini" ->
+      Some {
+        agent_name = "gemini";
+        command = "gemini --yolo --output-format json";
+        timeout_seconds;
+        working_dir = None;
+        mcp_tools = masc_mcp_tools;
+        parse_output = parse_gemini_output;
+        stdin_prompt = false;
+        mcp_mode = Mcp_spread "--allowed-tools";
+        prompt_mode = Prompt_flag "-p";
+      }
+  | "codex" ->
+      Some {
+        agent_name = "codex";
+        command = "codex exec";
+        timeout_seconds;
+        working_dir = None;
+        mcp_tools = masc_mcp_tools;
+        parse_output = parse_raw_output;
+        stdin_prompt = true;
+        mcp_mode = Mcp_none;
+        prompt_mode = Prompt_stdin;
+      }
+  | "llama" ->
+      Some {
+        agent_name = "llama";
+        command = Provider_adapter.make_local_label "explicit-model-required";
+        timeout_seconds;
+        working_dir = None;
+        mcp_tools = masc_mcp_tools;
+        parse_output = parse_raw_output;
+        stdin_prompt = true;
+        mcp_mode = Mcp_none;
+        prompt_mode = Prompt_stdin;
+      }
+  | _ -> None
 
 (** Get spawn config for agent.
     Resolves all aliases via Provider_adapter registry (SSOT).
     spawn_alias_map removed — aliases are now in Provider_adapter.direct_adapters. *)
 let get_config agent_name =
   let normalized = String.lowercase_ascii (String.trim agent_name) in
-  match List.assoc_opt normalized default_configs with
-  | Some _ as result -> result
-  | None ->
-    match Provider_adapter.resolve_spawn_key normalized with
-    | Some key -> List.assoc_opt key default_configs
-    | None -> None
+  match Provider_adapter.resolve_spawn_key normalized with
+  | Some key -> spawn_config_of_key key
+  | None -> spawn_config_of_key normalized
 
 (** Build MCP flags from config's [mcp_mode] field.
     No agent-name matching — dispatch is config-driven. *)


### PR DESCRIPTION
## Summary

7-issue surgical fix bundle targeting root-cause bug classes (SSOT, TEL, STR, BND, SIL).

## Fixes

| Issue | File | Root Cause | Fix |
|-------|------|------------|-----|
| #9526 | `keeper_turn_up_update.ml` | `update_keeper` ignored TOML `profile_defaults` for proactive fields | Three-tier fallback matching goal/will/needs pattern |
| #9536 | `keeper_types_profile.ml` | Missing canonical TOML keys for `tool_access.kind/preset` | Add keys to `canonical_keeper_toml_key_names` |
| #9532 | `keeper_tool_alias.ml` | `mcp__masc__Bash` prefix broke alias resolution | `strip_mcp_masc_prefix` before lookup |
| #9537 finding 2 | `autoresearch_codegen.ml` | Capacity check unknown → permissive `true` | Fail-safe `false` fallback |
| #9537 finding 1 | `spawn.ml` | Hardcoded `default_configs` table drifted from `Provider_adapter` | Replace table with key-driven `spawn_config_of_key` builder |
| #9544 | `keeper_shell_docker.ml` | Docker `run --rm` cold start with 1s timeout floor | Enforce 5s minimum timeout for docker run path |
| #9547 | `mcp_server_eio_execute.ml` | `Session.register` wrapped in unnecessary `try/ignore` | Remove wrapper; `update_activity` already safe via `find_opt` |

## Also closed (diagnosed, not code-fixed)

- #9533 — agent-side workflow bug (codex-mcp-client skips claim step)
- #9534 — live cascade config drift (add model to runtime cascade.json)

## Test plan

- [ ] `dune build` (pre-existing errors in unrelated files excluded)
- [ ] CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)