### PR TITLE
[codex] unblock stdio MCP startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ surface instead of hardcoding vendor-specific assumptions.
 
 - `scripts/run-local.sh` does not build the dashboard automatically. Append `--build-dashboard` only when needed.
 - `scripts/run-local.sh` also excludes checked-in keeper manifests during bootstrap unless `--bootstrap-keepers` is passed.
-- `start-masc-mcp.sh` automatically builds the dashboard SPA if `pnpm` or `corepack pnpm` is available.
+- `start-masc-mcp.sh` skips dashboard builds in `--stdio` mode. In HTTP mode it starts `scripts/build-dashboard-if-needed.sh` in the background by default; set `MASC_DASHBOARD_BUILD_BLOCKING=1` if you need the old blocking behavior.
 - To run the dev server separately, use:
 
 ```bash

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -467,6 +467,7 @@ let handle_keeper_bash
       ~(config : Coord.config)
       ~(meta : keeper_meta)
       ~(args : Yojson.Safe.t)
+      ()
   =
   let cmd = Safe_ops.json_string ~default:"" "cmd" args |> String.trim in
   let root = Keeper_alerting_path.project_root_of_config config in
@@ -598,7 +599,7 @@ let handle_keeper_bash
         "DOCKER_GIT_EXEC: keeper=%s cwd=%s cmd=%s"
         meta.name cwd cmd_for_log;
       run_docker_with_git_bash
-        ?turn_sandbox_runtime:turn_sandbox_runtime_git ~config ~meta ~cwd ~timeout_sec ~cmd)
+        ?turn_sandbox_runtime:turn_sandbox_runtime_git ~config ~meta ~cwd ~timeout_sec ~cmd ())
     else if sandbox_profile = Docker then (
       Log.Keeper.info
         "DOCKER_EXEC: keeper=%s cwd=%s cmd=%s network=%s"

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -51,6 +51,7 @@ val handle_keeper_bash :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   args:Yojson.Safe.t ->
+  unit ->
   string
 
 val handle_keeper_bash_output :

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -247,7 +247,7 @@ let execute_keeper_tool_call_with_outcome
         (Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_runtime ~config ~meta ~args)
     | "keeper_bash" ->
       make_executed_tool_result
-        (Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_runtime ?turn_sandbox_runtime_git ~config ~meta ~args)
+        (Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_runtime ?turn_sandbox_runtime_git ~config ~meta ~args ())
     | "keeper_bash_output" ->
       make_executed_tool_result
         (Keeper_exec_shell.handle_keeper_bash_output ~config ~meta ~args)

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -226,7 +226,7 @@ let run_docker_with_git_bash
     ~(meta : keeper_meta)
     ~(cwd : string)
     ~(timeout_sec : float)
-    ~(cmd : string) =
+    ~(cmd : string) () =
   let image = Env_config_keeper.KeeperSandbox.docker_image () in
   let sandbox_error_json message =
     Keeper_registry.record_error ~base_path:config.base_path meta.name message;

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -126,13 +126,12 @@ resolve_base_path() {
 }
 
 build_dashboard_spa() {
-    local dashboard_dir="$SCRIPT_DIR/dashboard"
-    local dashboard_index="$SCRIPT_DIR/assets/dashboard/index.html"
+    local build_script="$SCRIPT_DIR/scripts/build-dashboard-if-needed.sh"
+    local temp_root="${TMPDIR:-/tmp}"
     local log_file=""
-    local dashboard_pm=()
-    local dashboard_pm_label=""
 
-    if [ ! -f "$dashboard_dir/package.json" ]; then
+    if [ "$HTTP_MODE" != "true" ]; then
+        echo "[dashboard] Skipping SPA build in stdio mode." >&2
         return 0
     fi
 
@@ -141,78 +140,34 @@ build_dashboard_spa() {
         return 0
     fi
 
-    if ! is_truthy "${MASC_DASHBOARD_BUILD_ALWAYS:-0}"; then
-        local stale=0
-        if [ ! -f "$dashboard_index" ]; then
-            stale=1
-        fi
-        for candidate in \
-            "$dashboard_dir/package.json" \
-            "$dashboard_dir/pnpm-lock.yaml" \
-            "$dashboard_dir/tsconfig.json" \
-            "$dashboard_dir/vite.config.ts"
-        do
-            if [ -f "$candidate" ] && [ "$candidate" -nt "$dashboard_index" ]; then
-                stale=1
-                break
-            fi
-        done
-        if [ "$stale" -eq 0 ] && [ -d "$dashboard_dir/src" ] && find "$dashboard_dir/src" -type f -newer "$dashboard_index" | head -n 1 | grep -q .; then
-            stale=1
-        fi
-        if [ "$stale" -eq 0 ] && [ -d "$dashboard_dir/public" ] && find "$dashboard_dir/public" -type f -newer "$dashboard_index" | head -n 1 | grep -q .; then
-            stale=1
-        fi
-        if [ "$stale" -eq 0 ]; then
-            echo "[dashboard] Build output is fresh; skipping SPA build." >&2
-            return 0
-        fi
-    fi
-
-    echo "[dashboard] Building SPA before server start..." >&2
-    if command -v pnpm >/dev/null 2>&1; then
-        dashboard_pm=(pnpm)
-    elif command -v corepack >/dev/null 2>&1; then
-        dashboard_pm=(corepack pnpm)
-    else
-        echo "[dashboard] pnpm/corepack not found, skipping dashboard build." >&2
+    if [ ! -f "$build_script" ]; then
+        echo "[dashboard] Build helper not found, skipping SPA build." >&2
         return 0
     fi
-    dashboard_pm_label="${dashboard_pm[*]}"
 
-    local temp_root="${TMPDIR:-/tmp}"
+    if is_truthy "${MASC_DASHBOARD_BUILD_BLOCKING:-0}"; then
+        echo "[dashboard] Building SPA before server start..." >&2
+        "$build_script"
+        return 0
+    fi
+
     temp_root="${temp_root%/}"
     if [ ! -d "$temp_root" ] || [ ! -w "$temp_root" ]; then
         temp_root="/tmp"
     fi
     if ! log_file="$(TMPDIR="$temp_root" mktemp "$temp_root/masc-dashboard-build.XXXXXX" 2>/dev/null)"; then
-        echo "[dashboard] Unable to create temp log file; falling back to stderr-less logging." >&2
+        echo "[dashboard] Unable to create temp log file; background build log disabled." >&2
         log_file="/dev/null"
     fi
-    if [ -d "$dashboard_dir/node_modules" ]; then
-        if (cd "$dashboard_dir" && "${dashboard_pm[@]}" run build >"$log_file" 2>&1); then
-            tail -n 3 "$log_file" >&2 || true
-            if [ "$log_file" != "/dev/null" ]; then
-                rm -f "$log_file"
-            fi
-            return 0
-        fi
-        echo "[dashboard] Existing deps build failed, retrying after ${dashboard_pm_label} install..." >&2
+    (
+        cd "$SCRIPT_DIR" &&
+        "$build_script"
+    ) >"$log_file" 2>&1 &
+    if [ "$log_file" = "/dev/null" ]; then
+        echo "[dashboard] Background SPA build started." >&2
+    else
+        echo "[dashboard] Background SPA build started (log: $log_file)." >&2
     fi
-
-    if (cd "$dashboard_dir" && "${dashboard_pm[@]}" install --frozen-lockfile --prefer-offline >"$log_file" 2>&1 && "${dashboard_pm[@]}" run build >>"$log_file" 2>&1); then
-        tail -n 6 "$log_file" >&2 || true
-        if [ "$log_file" != "/dev/null" ]; then
-            rm -f "$log_file"
-        fi
-        return 0
-    fi
-
-    tail -n 20 "$log_file" >&2 || true
-    if [ "$log_file" != "/dev/null" ]; then
-        rm -f "$log_file"
-    fi
-    echo "[dashboard] Build failed (non-fatal, server will show fallback page)." >&2
 }
 
 ask_config_bootstrap() {
@@ -659,12 +614,14 @@ check_port_in_use() {
     fi
 }
 
-check_port_in_use "$PORT" "HTTP"
-check_port_in_use "${MASC_GRPC_PORT:-8936}" "gRPC"
-check_port_in_use "${MASC_WS_PORT:-8937}" "WebSocket"
+if [ "$HTTP_MODE" = "true" ]; then
+    check_port_in_use "$PORT" "HTTP"
+    check_port_in_use "${MASC_GRPC_PORT:-8936}" "gRPC"
+    check_port_in_use "${MASC_WS_PORT:-8937}" "WebSocket"
+fi
 
-# Dashboard SPA build (Vite) — assets/dashboard/ is no longer committed to git.
-# Always attempt the build before server startup so the served bundle matches current sources.
+# Dashboard SPA build (Vite) — routed through the shared helper script.
+# HTTP mode starts it in the background by default; stdio skips it entirely.
 build_dashboard_spa
 
 # Resolve executable path
@@ -709,7 +666,7 @@ elif [ -x "$WORKSPACE_STDIO_EIO_EXE" ]; then
 fi
 
 # 5. Build Eio version if not found (Lwt deprecated, download disabled)
-if [ -z "$MASC_EIO_EXE" ]; then
+if [ "$HTTP_MODE" = "true" ] && [ -z "$MASC_EIO_EXE" ]; then
     echo "Building MASC MCP server from source..." >&2
     if ! command -v dune >/dev/null 2>&1; then
         echo "Error: dune not found. Install dune first." >&2
@@ -749,7 +706,7 @@ fi
 
 # Rebuild Eio version if sources are newer than the executable (avoids stale binary runs)
 # NOTE: Lwt version (main.exe) is deprecated - Eio is now the default
-if [ -n "$MASC_EIO_EXE" ] && command -v dune >/dev/null 2>&1; then
+if [ "$HTTP_MODE" = "true" ] && [ -n "$MASC_EIO_EXE" ] && command -v dune >/dev/null 2>&1; then
     if find "$SCRIPT_DIR/bin" "$SCRIPT_DIR/lib" \
         -type f \( -name '*.ml' -o -name '*.mli' -o -name 'dune' \) \
         -newer "$MASC_EIO_EXE" 2>/dev/null | head -n 1 | grep -q .; then
@@ -814,8 +771,10 @@ wait_for_port() {
         waited=$((waited + 1))
     done
 }
-if ! wait_for_port "$PORT"; then
-    exit 1
+if [ "$HTTP_MODE" = "true" ]; then
+    if ! wait_for_port "$PORT"; then
+        exit 1
+    fi
 fi
 
 # Select executable based on EIO_MODE

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -322,7 +322,7 @@ let test_docker_blocks_nested_docker_command () =
     Keeper_exec_shell.handle_keeper_bash
       ~turn_sandbox_runtime:None
       ~config ~meta
-      ~args:(`Assoc [ ("cmd", `String "docker run --rm alpine true") ])
+      ~args:(`Assoc [ ("cmd", `String "docker run --rm alpine true") ]) ()
   in
   match parse_error_field raw with
   | Some err ->
@@ -342,7 +342,7 @@ let test_docker_blocks_docker_socket_reference () =
     Keeper_exec_shell.handle_keeper_bash
       ~turn_sandbox_runtime:None
       ~config ~meta
-      ~args:(`Assoc [ ("cmd", `String "cat /var/run/docker.sock") ])
+      ~args:(`Assoc [ ("cmd", `String "cat /var/run/docker.sock") ]) ()
   in
   match parse_error_field raw with
   | Some err ->
@@ -365,7 +365,7 @@ let test_docker_missing_seccomp_profile_fails_closed () =
         Keeper_exec_shell.handle_keeper_bash
           ~turn_sandbox_runtime:None
           ~config ~meta
-          ~args:(`Assoc [ ("cmd", `String "pwd") ])
+          ~args:(`Assoc [ ("cmd", `String "pwd") ]) ()
       in
       match parse_error_field raw with
       | Some err ->

--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -493,7 +493,7 @@ let test_turn_runtime_reuses_single_container () =
   let host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   ensure_dir host_root;
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
-  let runtime = Keeper_turn_sandbox_runtime.create ~config ~meta in
+  let runtime = Keeper_turn_sandbox_runtime.create ~config ~meta () in
   Fun.protect ~finally:(fun () ->
     Keeper_turn_sandbox_runtime.cleanup runtime;
     cleanup_dir base) @@ fun () ->
@@ -568,7 +568,7 @@ let test_turn_runtime_relaxed_fs_omits_readonly_and_noexec () =
   let host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   ensure_dir host_root;
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
-  let runtime = Keeper_turn_sandbox_runtime.create ~config ~meta in
+  let runtime = Keeper_turn_sandbox_runtime.create ~config ~meta () in
   Fun.protect ~finally:(fun () ->
     Keeper_turn_sandbox_runtime.cleanup runtime;
     cleanup_dir base) @@ fun () ->

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -155,6 +155,12 @@ let make_fake_eio_exe repo_root =
   let exe_path = Filename.concat repo_root "_build/default/bin/main_eio.exe" in
   write_fake_eio_exe exe_path ~marker:"local"
 
+let make_fake_stdio_eio_exe repo_root =
+  let exe_path =
+    Filename.concat repo_root "_build/default/bin/main_stdio_eio.exe"
+  in
+  write_fake_eio_exe exe_path ~marker:"stdio"
+
 let make_fake_eio_exe_with_stderr repo_root =
   let exe_path = Filename.concat repo_root "_build/default/bin/main_eio.exe" in
   mkdir_p (Filename.dirname exe_path);
@@ -702,6 +708,55 @@ let test_grpc_direct_banner_is_preserved_in_stderr () =
       check bool "other stderr preserved" true
         (contains_substring stderr "stderr-keep"))
 
+let test_stdio_skips_dashboard_build_and_http_preflight () =
+  with_temp_dir "start-masc-script-stdio" (fun dir ->
+      let script = Filename.concat dir "start-masc-mcp.sh" in
+      let scripts_dir = Filename.concat dir "scripts" in
+      let fake_bin = Filename.concat dir "fake-bin" in
+      let dashboard_marker = Filename.concat dir "dashboard-build-ran.txt" in
+      let capture = Filename.concat dir "captured-stdio.txt" in
+      copy_script (script_path ()) script;
+      ignore (make_config_root dir);
+      mkdir_p scripts_dir;
+      mkdir_p fake_bin;
+      write_executable
+        (Filename.concat scripts_dir "build-dashboard-if-needed.sh")
+        (Printf.sprintf
+           {|
+#!/bin/sh
+set -eu
+echo ran > %s
+exit 0
+|} (quote dashboard_marker));
+      write_executable (Filename.concat fake_bin "lsof")
+        {|
+#!/bin/sh
+echo "4242"
+exit 0
+|};
+      make_fake_stdio_eio_exe dir;
+      let code, stdout, stderr =
+        run_shell ~cwd:dir
+          ~env:
+            [
+              ("FAKE_CAPTURE_FILE", capture);
+              ("MASC_BASE_PATH", dir);
+              ("PATH", fake_bin ^ ":" ^ Sys.getenv "PATH");
+            ]
+          (Printf.sprintf "%s --stdio --base-path %s"
+             (quote script) (quote dir))
+      in
+      if code <> 0 then
+        failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
+          stderr;
+      let captured = read_file capture in
+      check bool "stdio executable selected without HTTP build" true
+        (contains_substring captured "FAKE_EXE_MARKER=stdio");
+      check bool "dashboard helper not invoked in stdio mode" false
+        (Sys.file_exists dashboard_marker);
+      check bool "stderr explains stdio dashboard skip" true
+        (contains_substring stderr "Skipping SPA build in stdio mode."))
+
 let test_loopback_disables_keeper_autoboot_by_default_and_preserves_override ()
     =
   with_temp_dir "start-loopback-script" (fun dir ->
@@ -798,6 +853,8 @@ let () =
             test_explicit_http_port_derives_sidecar_ports;
           test_case "grpc-direct banner is preserved in stderr" `Quick
             test_grpc_direct_banner_is_preserved_in_stderr;
+          test_case "stdio skips dashboard build and HTTP preflight" `Quick
+            test_stdio_skips_dashboard_build_and_http_preflight;
           test_case "zshenv absolute base path is preserved" `Quick
             test_zshenv_absolute_base_path_is_preserved;
           test_case "shared-root env base path is preserved" `Quick


### PR DESCRIPTION
## What changed
- remove blocking startup work from `start-masc-mcp.sh` when launched with `--stdio`
- gate HTTP port preflight, `main_eio.exe` build/rebuild, and port wait logic behind HTTP mode only
- route dashboard build through the shared helper and start it in the background by default for HTTP mode
- add a regression test proving stdio mode skips dashboard build and HTTP-only preflight
- fix keeper shell call signatures that were leaving `dune build` broken after the launcher changes surfaced them

## Why
MCP startup was timing out because the launcher was doing unrelated blocking work before the stdio server process could start. Increasing `startup_timeout_sec` would only mask that behavior.

## Root cause
The stdio launch path still behaved like the HTTP server path. It tried to build dashboard assets, checked HTTP-related ports, and could force `main_eio.exe` build/rebuild work even though stdio mode only needs the stdio binary.

## Impact
- stdio MCP startup becomes immediate and does not depend on dashboard or HTTP-side prerequisites
- HTTP mode keeps dashboard refresh behavior, but no longer blocks startup by default
- the tree builds cleanly again with the keeper shell signature fixes

## Validation
- `dune runtest --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-startup-timeout-fix test/test_start_masc_mcp_script.exe`
- `dune runtest --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-startup-timeout-fix test/test_keeper_bash_safety.exe test/test_keeper_docker_read.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-startup-timeout-fix`
