### PR TITLE
[codex] fix startup codex MCP token self-heal

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -575,6 +575,67 @@ let sync_admin_token_env (state : Mcp_server.server_state) =
              admin_agent_name
              (Types.masc_error_to_string err))
 
+let sync_client_token_file ~base_path ~agent_name ~default_role =
+  let token_file =
+    Filename.concat (Auth.auth_dir base_path) (agent_name ^ ".token")
+  in
+  let existing_role =
+    match Auth.load_credential base_path agent_name with
+    | Some cred -> cred.role
+    | None -> default_role
+  in
+  let persist_raw_token raw_token =
+    Fs_compat.mkdir_p (Auth.auth_dir base_path);
+    Auth.save_private_text_file token_file raw_token
+  in
+  let create_and_persist ~reason =
+    match Auth.create_token base_path ~agent_name ~role:existing_role with
+    | Ok (raw_token, _cred) ->
+        (try
+           persist_raw_token raw_token;
+           Log.Server.warn
+             "startup %s raw bearer token file for %s at %s"
+             reason agent_name token_file
+         with exn ->
+           Log.Server.error
+             "startup failed to persist raw bearer token file for %s at %s: %s"
+             agent_name token_file (Printexc.to_string exn))
+    | Error err ->
+        Log.Server.error
+          "startup failed to mint raw bearer token for %s: %s"
+          agent_name (Types.masc_error_to_string err)
+  in
+  let normalize_existing raw_token =
+    try
+      persist_raw_token raw_token;
+      Log.Server.info
+        "startup verified raw bearer token file for %s at %s"
+        agent_name token_file
+    with exn ->
+      Log.Server.error
+        "startup failed to normalize raw bearer token file for %s at %s: %s"
+        agent_name token_file (Printexc.to_string exn)
+  in
+  let current_raw =
+    if Fs_compat.file_exists token_file then
+      try
+        let raw = String.trim (Fs_compat.load_file token_file) in
+        if raw = "" then None else Some raw
+      with exn ->
+        Log.Server.warn
+          "startup failed to read raw bearer token file for %s at %s: %s"
+          agent_name token_file (Printexc.to_string exn);
+        None
+    else
+      None
+  in
+  match current_raw with
+  | Some raw_token -> (
+      match Auth.verify_token base_path ~agent_name ~token:raw_token with
+      | Ok _ -> normalize_existing raw_token
+      | Error _ -> create_and_persist ~reason:"repaired")
+  | None -> create_and_persist ~reason:"created"
+
 let bootstrap_prompt_state (state : Mcp_server.server_state) =
   Config_dir_resolver.log_warnings ~context:"ServerBootstrap" ();
   Config_dir_resolver.log_resolution ~context:"ServerBootstrap" ();
@@ -881,6 +942,8 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       Log.Server.info "State created (runtime state) in %.1fs" (t1 -. t0);
       bootstrap_server_state_blocking state;
       sync_admin_token_env state;
+      sync_client_token_file ~base_path ~agent_name:"codex-mcp-client"
+        ~default_role:Types.Worker;
       let path_diagnostics =
         runtime_path_diagnostics ~input_base_path:base_path state
       in

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1540,6 +1540,94 @@ let test_main_eio_fresh_bootstrap_and_mcp_handshake () =
           Alcotest.(check bool) "canonical tool present" true
             (List.mem "masc_status" tool_names)))
 
+let test_main_eio_self_heals_codex_mcp_token_file () =
+  with_temp_dir "startup-codex-token-selfheal" (fun dir ->
+      let exe = find_main_eio_exe () in
+      let port = find_free_port () in
+      let log_file = Filename.concat dir "server.log" in
+      let log_fd =
+        Unix.openfile log_file [ Unix.O_CREAT; Unix.O_WRONLY; Unix.O_TRUNC ] 0o644
+      in
+      with_env "MASC_CONFIG_DIR" None @@ fun () ->
+      with_env "MASC_PERSONAS_DIR" None @@ fun () ->
+      with_cwd (project_root ()) @@ fun () ->
+      Server_runtime_bootstrap.bootstrap_base_path_config_root ~base_path:dir;
+      let auth_dir = Filename.concat dir ".masc/auth" in
+      let token_path = Filename.concat auth_dir "codex-mcp-client.token" in
+      Fs_compat.mkdir_p auth_dir;
+      let stale_hash =
+        match
+          Auth.save_raw_token_credential dir
+            ~agent_name:"codex-mcp-client" ~role:Types.Worker
+            ~raw_token:"stale-codex-raw-token"
+        with
+        | Ok cred -> cred.token
+        | Error err ->
+            Alcotest.failf "failed to seed stale codex credential: %s"
+              (Types.masc_error_to_string err)
+      in
+      write_file token_path stale_hash;
+      let env =
+        merge_env_overrides
+          [
+            ("MASC_BASE_PATH", dir);
+            ("MASC_STORAGE_TYPE", "filesystem");
+            ("GRAPHQL_API_KEY", "");
+            ("GRAPHQL_URL", "http://127.0.0.1:9/graphql");
+            ("MASC_AUTONOMY_ENABLED", "0");
+            ("MASC_ORCHESTRATOR_ENABLED", "0");
+            ("MASC_KEEPER_BOOTSTRAP_ENABLED", "false");
+            ("MASC_USE_H2", "0");
+            ("DUNE_SOURCEROOT", project_root ());
+          ]
+      in
+      let pid =
+        Unix.create_process_env exe
+          [|
+            exe;
+            "--host";
+            "127.0.0.1";
+            "--port";
+            string_of_int port;
+            "--base-path";
+            dir;
+          |]
+          env Unix.stdin log_fd log_fd
+      in
+      Unix.close log_fd;
+      Fun.protect
+        ~finally:(fun () -> stop_process pid)
+        (fun () ->
+          if not (wait_for_startup_phase ~pid ~port ~timeout_s:10.0 "ready") then begin
+            prerr_endline
+              (Printf.sprintf
+                 "main_eio codex token self-heal did not reach startup.phase=ready within timeout in this environment.\nlog:\n%s"
+                 (read_file log_file));
+            Alcotest.skip ()
+          end;
+          let repaired_raw = String.trim (read_file token_path) in
+          let repaired_mode = (Unix.stat token_path).Unix.st_perm land 0o777 in
+          Alcotest.(check bool) "startup replaced hashed token file" true
+            (repaired_raw <> stale_hash);
+          Alcotest.(check int) "token file is private" 0o600 repaired_mode;
+          let credential =
+            match Auth.load_credential dir "codex-mcp-client" with
+            | Some cred -> cred
+            | None -> Alcotest.fail "missing codex-mcp-client credential after startup"
+          in
+          Alcotest.(check bool) "existing role preserved" true
+            (credential.role = Types.Worker);
+          Alcotest.(check string) "raw token hashes to stored credential"
+            credential.token (Auth.sha256_hash repaired_raw);
+          match
+            Auth.verify_token dir ~agent_name:"codex-mcp-client"
+              ~token:repaired_raw
+          with
+          | Ok _ -> ()
+          | Error err ->
+              Alcotest.failf "repaired raw token should verify: %s"
+                (Types.masc_error_to_string err)))
+
 let test_main_eio_rejects_same_base_path_on_second_server () =
   with_temp_dir "startup-base-path-owner-lock" (fun dir ->
       let exe = find_main_eio_exe () in
@@ -2035,6 +2123,9 @@ let () =
           Alcotest.test_case
             "main_eio fresh bootstrap and MCP handshake"
             `Slow test_main_eio_fresh_bootstrap_and_mcp_handshake;
+          Alcotest.test_case
+            "main_eio self-heals codex mcp token file"
+            `Slow test_main_eio_self_heals_codex_mcp_token_file;
           Alcotest.test_case
             "main_eio rejects second server on same base path"
             `Slow test_main_eio_rejects_same_base_path_on_second_server;


### PR DESCRIPTION
## What changed
- add startup self-healing for `.masc/auth/codex-mcp-client.token`
- if the file is missing, empty, stale, or contains a hashed credential value instead of a raw bearer token, mint a fresh raw token and rewrite the file with private permissions
- add an end-to-end startup test that seeds a broken `codex-mcp-client.token` file and verifies startup repairs it into a valid raw token while preserving the worker role

## Why
Codex was repeatedly showing:
- `The masc MCP server is not logged in. Run codex mcp login masc.`
- `MCP startup incomplete (failed: masc)`

Root cause: local shell startup exported `MASC_MCP_TOKEN` from `.masc/auth/codex-mcp-client.token`, but that file could contain the hashed credential value instead of the raw bearer token. In that state, every HTTP MCP request fails with `Invalid token: Token mismatch`.

## Impact
- Codex local shells can recover automatically on the next `masc-mcp` startup instead of staying wedged on a bad token file
- startup normalizes the token file back to a private raw token file, so existing shell env loading stays compatible

## Root cause notes
- unrelated compile validation is currently blocked by an existing syntax error in `lib/coord/coord_task.ml`
- tracked separately in #9557

## Validation
- verified the live local symptom manually by reproducing MCP `initialize` auth failure with the stale token file
- repaired the local token file and confirmed a fresh `zsh` session could load `MASC_MCP_TOKEN` and complete HTTP MCP `initialize` with `200 OK`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-token-selfheal` is currently blocked by the unrelated syntax error tracked in #9557
