### PR TITLE
feat(exec): P8 teaching error messages

### DIFF
--- a/lib/exec_core.ml
+++ b/lib/exec_core.ml
@@ -66,6 +66,13 @@ type executed_result = {
   recovery_hint : string option;
 }
 
+type diagnosis = {
+  rule_id : string;
+  explanation : string;
+  rewrite : string option;
+  tool_suggestion : string option;
+}
+
 type blocked_result = {
   command : string;
   error : string;
@@ -75,6 +82,7 @@ type blocked_result = {
   classification : classification;
   retryability : retryability;
   summary : string;
+  diagnosis : diagnosis option;
 }
 
 type outcome =
@@ -574,7 +582,7 @@ let build_process_outcome ~artifact_policy ~base_path ~keeper_name ~cmd ~status
     }
 
 let build_blocked_outcome ~cmd ~error ~reason ?hint
-    ?(alternatives = []) ?(retryability = Self_correct) () =
+    ?(alternatives = []) ?(retryability = Self_correct) ?(diag = None) () =
   let classification = classify_command ~cmd in
   let summary = summary_of_status classification Blocked in
   let recovery_hint =
@@ -595,6 +603,7 @@ let build_blocked_outcome ~cmd ~error ~reason ?hint
       classification;
       retryability;
       summary;
+      diagnosis = diag;
     }
 
 let semantic_payload_to_yojson (key, value) =
@@ -794,6 +803,23 @@ let outcome_to_json ?(extra = []) ?(env_snapshot = None) = function
         | [] -> []
         | alts -> [ ("alternatives", `List (List.map (fun a -> `String a) alts)) ]
       in
+      let diagnosis_field =
+        match result.diagnosis with
+        | None -> []
+        | Some d ->
+            let rewrite_field = match d.rewrite with
+              | None -> [] | Some r -> [ ("rewrite", `String r) ]
+            in
+            let tool_field = match d.tool_suggestion with
+              | None -> [] | Some t -> [ ("tool_suggestion", `String t) ]
+            in
+            [ ( "diagnosis",
+                `Assoc
+                  ([ ("rule_id", `String d.rule_id)
+                   ; ("explanation", `String d.explanation)
+                   ]
+                   @ rewrite_field @ tool_field) ) ]
+      in
       let env_field = match env_snapshot with
         | None -> []
         | Some snap -> [ ("environment", env_snapshot_to_json snap) ]
@@ -813,6 +839,7 @@ let outcome_to_json ?(extra = []) ?(env_snapshot = None) = function
              ("hint", `String result.hint);
              ("recovery_hint", `String result.hint);
            ]
+         @ diagnosis_field
          @ alternatives_field
          @ env_field)
 
@@ -823,6 +850,8 @@ let process_result_json ?(artifact_policy = Persist_if_large) ~base_path
   |> outcome_to_json ~extra ~env_snapshot
 
 let blocked_result_json ~cmd ~error ~reason ?hint ?(alternatives = [])
-    ?(retryability = Self_correct) ?(extra = []) ?(env_snapshot = None) () =
-  build_blocked_outcome ~cmd ~error ~reason ?hint ~alternatives ~retryability ()
+    ?(retryability = Self_correct) ?(diag = None) ?(extra = [])
+    ?(env_snapshot = None) () =
+  build_blocked_outcome ~cmd ~error ~reason ?hint ~alternatives ~retryability
+    ~diag ()
   |> outcome_to_json ~extra ~env_snapshot

--- a/lib/exec_core.mli
+++ b/lib/exec_core.mli
@@ -66,6 +66,13 @@ type executed_result = {
   recovery_hint : string option;
 }
 
+type diagnosis = {
+  rule_id : string;
+  explanation : string;
+  rewrite : string option;
+  tool_suggestion : string option;
+}
+
 type blocked_result = {
   command : string;
   error : string;
@@ -75,6 +82,7 @@ type blocked_result = {
   classification : classification;
   retryability : retryability;
   summary : string;
+  diagnosis : diagnosis option;
 }
 
 type outcome =
@@ -130,6 +138,7 @@ val build_blocked_outcome :
   ?hint:string ->
   ?alternatives:string list ->
   ?retryability:retryability ->
+  ?diag:diagnosis option ->
   unit ->
   outcome
 
@@ -158,6 +167,7 @@ val blocked_result_json :
   ?hint:string ->
   ?alternatives:string list ->
   ?retryability:retryability ->
+  ?diag:diagnosis option ->
   ?extra:(string * Yojson.Safe.t) list ->
   ?env_snapshot:exec_env_snapshot option ->
   unit ->

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -166,6 +166,116 @@ let readonly_hint_of_category = function
        not accept destructive commands)."
   | _ -> "This operation is not allowed in readonly shell."
 
+(* P8: Structured diagnosis per readonly category.  The hint field is
+   human-oriented prose; the diagnosis field is machine-parseable so
+   small-LLM keepers can extract rule_id + rewrite without regex. *)
+let diagnosis_of_readonly_category category =
+  match category with
+  | "chaining" ->
+      Some { Exec_core.rule_id = "readonly_chaining_blocked"
+            ; explanation =
+                "&&, ||, and ; chain multiple commands; the readonly shell \
+                 validates one command per call."
+            ; rewrite =
+                Some "Split into two calls: keeper_shell op='custom' \
+                      command='git status' then keeper_shell op='custom' \
+                      command='git log -1'."
+            ; tool_suggestion = None }
+  | "redirect" ->
+      Some { Exec_core.rule_id = "readonly_redirect_blocked"
+            ; explanation =
+                "> and >> modify the filesystem; readonly shell forbids writes."
+            ; rewrite = None
+            ; tool_suggestion =
+                Some "keeper_fs_edit" }
+  | "git_write" ->
+      Some { Exec_core.rule_id = "readonly_git_write_blocked"
+            ; explanation =
+                "git commit/push/checkout modify state; readonly shell only \
+                 allows read-only git subcommands (log, diff, status, show)."
+            ; rewrite =
+                Some "Use keeper_bash with coding preset: keeper_bash \
+                      cmd='git add lib/foo.ml && git commit -m \"msg\"'."
+            ; tool_suggestion = None }
+  | "package_install" ->
+      Some { Exec_core.rule_id = "readonly_package_install_blocked"
+            ; explanation =
+                "opam install / npm install mutate the global environment; \
+                 readonly shell forbids package mutations."
+            ; rewrite =
+                Some "Use keeper_bash with coding preset: keeper_bash \
+                      cmd='opam install -y eio'."
+            ; tool_suggestion = None }
+  | "destructive" ->
+      Some { Exec_core.rule_id = "readonly_destructive_blocked"
+            ; explanation =
+                "rm, curl -o, and similar destructive commands modify or \
+                 delete state; readonly shell forbids them."
+            ; rewrite =
+                Some "Use keeper_bash with coding preset: keeper_bash \
+                      cmd='rm .tmp/scratch.log'."
+            ; tool_suggestion = None }
+  | _ -> None
+
+let diagnosis_of_block_reason reason =
+  match reason with
+  | Worker_dev_tools.Chain_or_redirect ->
+      Some { Exec_core.rule_id = "command_chaining_blocked"
+            ; explanation =
+                "Pipe | and chain && or ; combine multiple commands; the \
+                 keeper validates one command per call."
+            ; rewrite =
+                Some "Split into two keeper_bash calls, or use keeper_shell \
+                      with a specific op (rg, ls, find)."
+            ; tool_suggestion = None }
+  | Worker_dev_tools.Pipes_not_allowed ->
+      Some { Exec_core.rule_id = "command_pipe_blocked"
+            ; explanation =
+                "Pipes (|) connect two processes; each needs separate \
+                 validation in the keeper security model."
+            ; rewrite =
+                Some "Run the first command, then pipe the output into \
+                      the second keeper_bash call."
+            ; tool_suggestion = None }
+  | Worker_dev_tools.Unsafe_redirect ->
+      Some { Exec_core.rule_id = "command_redirect_blocked"
+            ; explanation =
+                "> and >> redirect output to files; use a dedicated write tool."
+            ; rewrite = None
+            ; tool_suggestion = Some "keeper_fs_edit" }
+  | Worker_dev_tools.Injection ->
+      Some { Exec_core.rule_id = "command_injection_blocked"
+            ; explanation =
+                "Shell metacharacters ($(), ``, eval) can inject arbitrary \
+                 commands; they are blocked for safety."
+            ; rewrite =
+                Some "Compute the value first, then pass it as a literal \
+                      argument in a second keeper_bash call."
+            ; tool_suggestion = None }
+  | Worker_dev_tools.Process_substitution ->
+      Some { Exec_core.rule_id = "command_process_subst_blocked"
+            ; explanation =
+                "<() and >() process substitutions create sub-processes; \
+                 they are blocked for safety."
+            ; rewrite =
+                Some "Write the intermediate result to a temp file, then \
+                      reference it in the second command."
+            ; tool_suggestion = None }
+  | Worker_dev_tools.Command_not_allowed name ->
+      Some { Exec_core.rule_id = "command_not_allowed"
+            ; explanation =
+                Printf.sprintf
+                  "'%s' is not on the allowed command list for this preset."
+                  name
+            ; rewrite = None
+            ; tool_suggestion = Some "keeper_shell" }
+  | Worker_dev_tools.Empty_command ->
+      Some { Exec_core.rule_id = "command_empty"
+            ; explanation = "The command string is empty."
+            ; rewrite =
+                Some "Provide a command: keeper_bash cmd='ls -la lib/'."
+            ; tool_suggestion = None }
+
 let process_status_is_timeout = function
   | Unix.WSIGNALED sig_num -> sig_num = Sys.sigterm
   | Unix.WEXITED 124 -> true  (* Process_eio returns 124 on Eio.Time.Timeout *)
@@ -590,6 +700,17 @@ let handle_keeper_bash
              ; "Ask a human operator to perform this destructive action."
              ]
            ~retryability:Exec_core.Operator_required
+           ~diag:
+             (Some { Exec_core.rule_id = "destructive_operation_blocked"
+                    ; explanation =
+                        "force push, rm -rf, and similar destructive \
+                         commands are blocked for all presets to protect \
+                         shared state."
+                    ; rewrite =
+                        Some "For git: use 'git push' without --force. \
+                              For cleanup: target specific files (rm file) \
+                              instead of rm -rf."
+                    ; tool_suggestion = None })
            ~extra:[ "cmd", `String cmd_for_log; "execution_time_ms", `Int 0 ]
            ~env_snapshot:env_snap
            ()))
@@ -663,6 +784,7 @@ let handle_keeper_bash
              ~reason:reason_str
              ~hint
              ~alternatives
+             ~diag:(diagnosis_of_block_reason reason)
              ~extra:[ "execution_time_ms", `Int 0 ]
              ~env_snapshot:env_snap
              ())
@@ -695,6 +817,15 @@ let handle_keeper_bash
                  ; "Use keeper_shell op=git op_cmd='branch -a' to list available branches."
                  ]
                ~retryability:Exec_core.Operator_required
+               ~diag:
+                 (Some { Exec_core.rule_id = "branch_switch_blocked"
+                        ; explanation =
+                            "git checkout/switch/branch mutations need a                              write-enabled preset and a sandbox clone."
+                        ; rewrite =
+                            Some (Printf.sprintf
+                              "First: keeper_shell op=git_clone.                                Then: set cwd=%srepos/REPO/.worktrees/TASK"
+                              sandbox_root)
+                        ; tool_suggestion = None })
                ~extra:[ "cmd", `String cmd_for_log; "execution_time_ms", `Int 0 ]
                ()))
         (* Write gate — preset layer *)
@@ -714,6 +845,13 @@ let handle_keeper_bash
                  ; "If you need write access, ask the operator to assign a Coding/Delivery/Full preset."
                  ]
                ~retryability:Exec_core.Operator_required
+               ~diag:
+                 (Some { Exec_core.rule_id = "write_operation_gated"
+                        ; explanation =
+                            "This command modifies state but the current preset                              is read-only. Write operations require Coding,                              Delivery, or Full preset."
+                        ; rewrite = None
+                        ; tool_suggestion =
+                            Some "Ask the operator for a write-enabled preset" })
                ~extra:[ "cmd", `String cmd_for_log; "execution_time_ms", `Int 0 ]
                ~env_snapshot:env_snap
                ()))
@@ -757,6 +895,15 @@ let handle_keeper_bash
                  ; "Use keeper_bash with a cwd pointing to your sandbox worktree."
                  ]
                ~retryability:Exec_core.Operator_required
+               ~diag:
+                 (Some { Exec_core.rule_id = "write_outside_playground_blocked"
+                        ; explanation =
+                            "Write operations must run inside the keeper sandbox.                              The current cwd is outside the sandbox root."
+                        ; rewrite =
+                            Some (Printf.sprintf
+                              "Clone into sandbox: keeper_shell op=git_clone,                                then set cwd=%srepos/REPO/.worktrees/TASK"
+                              sandbox_root)
+                        ; tool_suggestion = None })
                ~extra:[ "cmd", `String cmd_for_log; "cwd", `String cwd; "execution_time_ms", `Int 0 ]
                ()))
         else (
@@ -1800,6 +1947,7 @@ let handle_keeper_shell
                   "Readonly shell blocked pattern '%s' in category '%s'."
                   pat category)
              ~hint
+             ~diag:(diagnosis_of_readonly_category category)
              ~extra:
                [
                  "op", `String op;

--- a/test/test_exec_core.ml
+++ b/test/test_exec_core.ml
@@ -359,6 +359,92 @@ let test_output_cap_truncates_large_output () =
         check int "head_cap=8" 8 (cap |> member "head_cap" |> to_int);
         check int "tail_cap=8" 8 (cap |> member "tail_cap" |> to_int))))
 
+(* ---------- P8: Teaching Error Messages - diagnosis field -------------- *)
+
+let test_blocked_without_diagnosis_has_no_field () =
+  let json =
+    Masc_mcp.Exec_core.blocked_result_json
+      ~cmd:"some command"
+      ~error:"generic_blocked"
+      ~reason:"blocked for testing"
+      ()
+  in
+  match json |> member "diagnosis" with
+  | `Null -> ()
+  | _ -> fail "diagnosis must be absent when no ~diag passed"
+
+let test_blocked_with_diagnosis_has_all_fields () =
+  let diag =
+    { Masc_mcp.Exec_core.rule_id = "test_rule"
+    ; explanation = "explaining why"
+    ; rewrite = Some "use this instead"
+    ; tool_suggestion = None
+    }
+  in
+  let json =
+    Masc_mcp.Exec_core.blocked_result_json
+      ~cmd:"bad cmd"
+      ~error:"test_blocked"
+      ~reason:"testing"
+      ~diag:(Some diag)
+      ()
+  in
+  let d = json |> member "diagnosis" in
+  check string "rule_id" "test_rule" (d |> member "rule_id" |> to_string);
+  check string "explanation" "explaining why"
+    (d |> member "explanation" |> to_string);
+  check string "rewrite" "use this instead"
+    (d |> member "rewrite" |> to_string);
+  check bool "tool_suggestion absent" true
+    (match d |> member "tool_suggestion" with
+     | `Null -> true | _ -> false)
+
+let test_blocked_with_tool_suggestion () =
+  let diag =
+    { Masc_mcp.Exec_core.rule_id = "redirect_blocked"
+    ; explanation = "redirects are forbidden"
+    ; rewrite = None
+    ; tool_suggestion = Some "keeper_fs_edit"
+    }
+  in
+  let json =
+    Masc_mcp.Exec_core.blocked_result_json
+      ~cmd:"echo hi > file.txt"
+      ~error:"readonly_blocked"
+      ~reason:"redirect"
+      ~diag:(Some diag)
+      ()
+  in
+  let d = json |> member "diagnosis" in
+  check string "tool_suggestion" "keeper_fs_edit"
+    (d |> member "tool_suggestion" |> to_string);
+  check bool "rewrite absent" true
+    (match d |> member "rewrite" with
+     | `Null -> true | _ -> false)
+
+let test_blocked_diagnosis_both_rewrite_and_tool () =
+  let diag =
+    { Masc_mcp.Exec_core.rule_id = "chaining_blocked"
+    ; explanation = "chaining not allowed"
+    ; rewrite = Some "split into two calls"
+    ; tool_suggestion = Some "keeper_shell"
+    }
+  in
+  let json =
+    Masc_mcp.Exec_core.blocked_result_json
+      ~cmd:"a && b"
+      ~error:"command_blocked_readonly"
+      ~reason:"chaining"
+      ~diag:(Some diag)
+      ()
+  in
+  let d = json |> member "diagnosis" in
+  check string "rewrite" "split into two calls"
+    (d |> member "rewrite" |> to_string);
+  check string "tool_suggestion" "keeper_shell"
+    (d |> member "tool_suggestion" |> to_string)
+
+
 let () =
   run "exec_core"
     [
@@ -414,5 +500,16 @@ let () =
             `Quick test_output_cap_on_preserves_small_output;
           test_case "large output truncated with bytes_dropped > 0"
             `Quick test_output_cap_truncates_large_output;
+        ] );
+      ( "p8_diagnosis",
+        [
+          test_case "no diag => diagnosis absent" `Quick
+            test_blocked_without_diagnosis_has_no_field;
+          test_case "diag with rewrite => all fields present" `Quick
+            test_blocked_with_diagnosis_has_all_fields;
+          test_case "diag with tool_suggestion" `Quick
+            test_blocked_with_tool_suggestion;
+          test_case "diag with both rewrite and tool" `Quick
+            test_blocked_diagnosis_both_rewrite_and_tool;
         ] );
     ]


### PR DESCRIPTION
## Summary
- Add structured `diagnosis` object to blocked command JSON responses so LLM agents can self-correct without retry loops
- `diagnosis` contains `rule_id`, `explanation`, `rewrite` (optional), and `tool_suggestion` (optional)
- Wire `~diag` into all 6 `blocked_result_json` call sites in `keeper_exec_shell.ml`
- Map readonly categories (chaining/redirect/git_write/package_install/destructive) and block_reason variants to concrete diagnoses

## Test plan
- [x] 4 Alcotest cases in `test_exec_core.ml` covering: absent/rewrite-only/tool_suggestion-only/both
- [x] `dune build` passes with zero new errors (3 pre-existing errors in unrelated docker/safety test files)
- [ ] CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)