### PR TITLE
fix: handle EINTR in Unix fallback process polling

### DIFF
--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -303,10 +303,12 @@ let with_unix_capture ?env ?cwd ?stdin_content ?(capture_stderr = false)
                     timed_out := true;
                     kill_and_wait status_ref
                   end else
-                    ignore
-                      (Unix.select [] [] []
-                         (min 0.05
-                            (max 0.0 (deadline -. Unix.gettimeofday ()))))
+                    (try
+                       ignore
+                         (Unix.select [] [] []
+                            (min 0.05
+                               (max 0.0 (deadline -. Unix.gettimeofday ()))))
+                     with Unix.Unix_error (Unix.EINTR, _, _) -> ())
             done;
             close_quietly stdout_r;
             let status =


### PR DESCRIPTION
## Summary
- handle `EINTR` while polling the Unix fallback child-exit wait loop in `Process_eio`
- fix the reproducible `test_keeper_bash_safety` failure on latest `main`

## Repro
- failing test: `./_build/default/test/test_keeper_bash_safety.exe`
- failing case: `readonly_hints 0 doubled playground prefix auto-correct`
- observed error: `Unix fallback error: ... select: Interrupted system call`

## Validation
- `dune build --cache=disabled --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/main-build-fix test/test_keeper_bash_safety.exe`
- `./_build/default/test/test_keeper_bash_safety.exe`
- `./_build/default/test/test_process_eio_coverage.exe`
