### PR TITLE
[codex] Restore main build after result signature changes

### DIFF
--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -171,6 +171,11 @@ let apply_patch ~old_string ~new_string ~replace_all text =
       loop 0;
       Ok (Buffer.contents buf, occurrences)
 
+exception Fs_edit_error of string
+
+let raise_fs_edit_error ?fields message =
+  raise (Fs_edit_error (error_json ?fields message))
+
 let handle_keeper_fs_edit
       ~(turn_sandbox_runtime : Keeper_turn_sandbox_runtime.t option)
       ~(config : Coord.config)
@@ -235,24 +240,25 @@ let handle_keeper_fs_edit
                 in
                 (match write_result with
                  | Error msg ->
-                   error_json ~fields:[ "path", `String target ] msg
+                     raise_fs_edit_error ~fields:[ "path", `String target ] msg
                  | Ok () ->
-                   Log.Keeper.info
-                     "WRITE_AUDIT: keeper=%s fs_edit path=%s mode=patch \
-                      replace_all=%b occurrences=%d bytes=%d"
-                     meta.name target replace_all occurrences
-                     (String.length updated);
-                   Yojson.Safe.to_string
-                     (`Assoc
-                         ([ "ok", `Bool true
-                          ; "path", `String target
-                          ; "mode", `String "patch"
-                          ; "replace_all", `Bool replace_all
-                          ; "occurrences", `Int occurrences
-                          ; "bytes_written", `Int (String.length updated)
-                          ]
-                         @ via_field)))
+                     Log.Keeper.info
+                       "WRITE_AUDIT: keeper=%s fs_edit path=%s mode=patch \
+                        replace_all=%b occurrences=%d bytes=%d"
+                       meta.name target replace_all occurrences
+                       (String.length updated);
+                     Yojson.Safe.to_string
+                       (`Assoc
+                           ([ "ok", `Bool true
+                            ; "path", `String target
+                            ; "mode", `String "patch"
+                            ; "replace_all", `Bool replace_all
+                            ; "occurrences", `Int occurrences
+                            ; "bytes_written", `Int (String.length updated)
+                            ]
+                           @ via_field)))
           with
+          | Fs_edit_error json -> json
           | Invalid_argument e ->
             error_json ~fields:[ "path", `String target ] e
           | Sys_error e -> error_json ~fields:[ "path", `String target ] e
@@ -291,21 +297,23 @@ let handle_keeper_fs_edit
             | Patch -> Ok ())
        in
        match write_result with
-       | Error msg -> error_json ~fields:[ "path", `String target ] msg
+       | Error msg ->
+           raise_fs_edit_error ~fields:[ "path", `String target ] msg
        | Ok () ->
-         Log.Keeper.info "WRITE_AUDIT: keeper=%s fs_edit path=%s mode=%s bytes=%d"
-           meta.name target mode_label
-           (String.length content);
-         Yojson.Safe.to_string
-           (`Assoc
-               ([ "ok", `Bool true
-                ; "path", `String target
-                ; "mode", `String mode_label
-                ; "bytes_written", `Int (String.length content)
-                ]
-               @ via_field))
-     with
-     | Invalid_argument e -> error_json ~fields:[ "path", `String target ] e
+           Log.Keeper.info "WRITE_AUDIT: keeper=%s fs_edit path=%s mode=%s bytes=%d"
+             meta.name target mode_label
+             (String.length content);
+           Yojson.Safe.to_string
+             (`Assoc
+                 ([ "ok", `Bool true
+                  ; "path", `String target
+                  ; "mode", `String mode_label
+                  ; "bytes_written", `Int (String.length content)
+                  ]
+                 @ via_field))
+    with
+    | Fs_edit_error json -> json
+    | Invalid_argument e -> error_json ~fields:[ "path", `String target ] e
      | Sys_error e -> error_json ~fields:[ "path", `String target ] e
      | Unix.Unix_error (err, _, _) ->
        error_json ~fields:[ "path", `String target ] (Unix.error_message err))

--- a/lib/keeper/keeper_fs.mli
+++ b/lib/keeper/keeper_fs.mli
@@ -21,11 +21,11 @@ val clear_dir_cache : unit -> unit
 (** {1 Atomic File Writes} *)
 
 (** Atomically save [content] to [path] via write-to-temp + rename.
-    Returns [Error _] on I/O failure. *)
+    Returns [Error msg] on I/O failure. Cancellation still re-raises. *)
 val save_atomic : string -> string -> (unit, string) result
 
 (** Atomically save a JSON value as pretty-printed JSON.
-    Returns [Error _] on I/O failure. *)
+    Returns [Error msg] on I/O failure. Cancellation still re-raises. *)
 val save_json_atomic : string -> Yojson.Safe.t -> (unit, string) result
 
 (** {1 Standard Keeper Paths} *)

--- a/test/test_keeper_fs.ml
+++ b/test/test_keeper_fs.ml
@@ -30,6 +30,10 @@ let has_tmp_files dir =
   Sys.readdir dir
   |> Array.exists (fun name -> Filename.check_suffix name ".tmp")
 
+let require_ok label = function
+  | Ok () -> ()
+  | Error msg -> failf "%s: %s" label msg
+
 (* ================================================================ *)
 (* ensure_dir tests                                                 *)
 (* ================================================================ *)
@@ -99,7 +103,7 @@ let test_save_atomic_basic () =
   let base = temp_dir () in
   let path = Filename.concat base "data.json" in
   let content = {|{"key": "value"}|} in
-  check bool "save_atomic ok" true (Result.is_ok (KF.save_atomic path content));
+  require_ok "save_atomic basic" (KF.save_atomic path content);
   let loaded = read_file path in
   check string "content matches" content loaded;
   check bool "no tmp file" false (has_tmp_files base);
@@ -108,8 +112,8 @@ let test_save_atomic_basic () =
 let test_save_atomic_overwrites () =
   let base = temp_dir () in
   let path = Filename.concat base "overwrite.txt" in
-  check bool "first save ok" true (Result.is_ok (KF.save_atomic path "first"));
-  check bool "second save ok" true (Result.is_ok (KF.save_atomic path "second"));
+  require_ok "save_atomic first write" (KF.save_atomic path "first");
+  require_ok "save_atomic second write" (KF.save_atomic path "second");
   let loaded = read_file path in
   check string "second write wins" "second" loaded;
   cleanup_dir base
@@ -117,7 +121,7 @@ let test_save_atomic_overwrites () =
 let test_save_atomic_creates_parent_dir () =
   let base = temp_dir () in
   let path = Filename.concat base "deep/nested/file.txt" in
-  check bool "nested save ok" true (Result.is_ok (KF.save_atomic path "content"));
+  require_ok "save_atomic creates parent dir" (KF.save_atomic path "content");
   check bool "file exists" true (Sys.file_exists path);
   let loaded = read_file path in
   check string "content matches" "content" loaded;
@@ -127,7 +131,7 @@ let test_save_json_atomic () =
   let base = temp_dir () in
   let path = Filename.concat base "test.json" in
   let json = `Assoc [("name", `String "keeper"); ("gen", `Int 1)] in
-  check bool "save_json_atomic ok" true (Result.is_ok (KF.save_json_atomic path json));
+  require_ok "save_json_atomic" (KF.save_json_atomic path json);
   let loaded = Yojson.Safe.from_file path in
   let open Yojson.Safe.Util in
   check string "name field" "keeper" (loaded |> member "name" |> to_string);

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -38,6 +38,10 @@ let file_contains_pattern file_rel pattern =
 let file_not_contains_pattern file_rel pattern =
   not (file_contains_pattern file_rel pattern)
 
+let require_write_ok label = function
+  | Ok () -> ()
+  | Error msg -> failf "%s: %s" label msg
+
 let make_meta ?(name = "test-keeper") () : Keeper_types.keeper_meta =
   match Keeper_types.meta_of_json
     (`Assoc [("name", `String name); ("agent_name", `String name);
@@ -133,8 +137,7 @@ let test_atomic_write_not_empty () =
   let json =
     `Assoc [ ("name", `String "test"); ("status", `String "ok") ]
   in
-  check bool "write_json_local ok" true
-    (Result.is_ok (Coord_utils.write_json_local path json));
+  require_write_ok "atomic write" (Coord_utils.write_json_local path json);
   let content = Fs_compat.load_file path in
   check bool "file not empty after atomic write" true
     (String.length content > 0);
@@ -155,10 +158,9 @@ let test_concurrent_atomic_writes_never_empty () =
   (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
   let path = Filename.concat dir "agent.json" in
   (* Seed with initial content *)
-  check bool "seed write ok" true
-    (Result.is_ok
-       (Coord_utils.write_json_local path
-          (`Assoc [ ("name", `String "init") ])));
+  require_write_ok "seed write"
+    (Coord_utils.write_json_local path
+       (`Assoc [ ("name", `String "init") ]));
   let empty_seen = ref false in
   let iterations = 200 in
   Eio.Switch.run @@ fun sw ->
@@ -168,7 +170,7 @@ let test_concurrent_atomic_writes_never_empty () =
       let json =
         `Assoc [ ("name", `String (Printf.sprintf "v%d" i)) ]
       in
-      ignore (Coord_utils.write_json_local path json);
+      require_write_ok "concurrent write" (Coord_utils.write_json_local path json);
       Eio.Fiber.yield ()
     done);
   (* Reader fiber: read concurrently *)


### PR DESCRIPTION
## Summary
- fix the missing closing parenthesis in `coord_task.ml` that broke parsing
- restore `Spawn.default_configs` and align `keeper_fs.mli` with the result-returning atomic write helpers
- make `keeper_exec_fs.ml` propagate docker write failures through a typed error path instead of returning JSON in `unit` branches
- update keeper atomic-write tests to consume `result` values explicitly

## Root Cause
Several atomic-write helpers had already been refactored to return `(unit, string) result`, but some exposed interfaces and tests still assumed `unit`. In parallel, `coord_task.ml` had a parenthesis regression and `keeper_exec_fs.ml` mixed JSON-returning error helpers into `unit`-typed branches. Together these broke the main build.

## Impact
- restores successful project builds on the fix branch
- keeps the public interface consistent with the implementation
- makes the affected tests assert explicit success on atomic writes

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-main-build-20260423 --build-dir _build_fix_main_build`
- `./_build_fix_targets/default/test/test_keeper_fs.exe`
- `./_build_fix_targets/default/test/test_spawn.exe`
- `./_build_fix_main_build/default/test/test_warn_root_causes.exe`