### PR TITLE
[codex] canonicalize keeper turn mode

### DIFF
--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -661,12 +661,12 @@ Unified keeper의 내부 decision record는 `{keeper_dir}/{name}.decisions.jsonl
 - `id`: 고유 결정 ID (`dec-{timestamp_ms}-{hash}`)
 - `trigger_signals`: turn 시점에 관찰된 트리거 후보 (`direct_mention`, `board_activity`, `new_unclaimed_task` 등)
 - `observed_affordances`: 당시 가능한 액션 후보 (`task_claim`, `reply_in_room`, `board_post_or_comment` 등)
-- `selected_mode`: 실제 최종 결과 분류 (`tool_use`, `text_response`, `skip_text`, `noop`, `error`)
+- `turn_mode`: 실제 최종 결과 분류 (`tool_use`, `text_response`, `skip_text`, `noop`). 에러 여부는 `outcome`이 담당한다.
 - `tools_used`: 실제 호출된 tool 목록
 - `claim_was_available` / `claim_executed`: task claim 기회와 실행 여부
 - `response_preview`: 최종 응답 미리보기
 - `response_requests_confirmation`: keeper가 사람 확인을 요청했는지 여부
-- `outcome`: `success` 또는 `error`
+- `outcome`: `success`, `partial`, `error`
 
 주의:
 - unified path는 hidden chain-of-thought나 모델 내부 reasoning/confidence를 저장하지 않는다.

--- a/docs/NORTH-STAR-OCAML.md
+++ b/docs/NORTH-STAR-OCAML.md
@@ -136,24 +136,9 @@ OCaml 5.4 추가. 현재 keeper 우선순위 관리를 `List.sort`로 구현한 
 
 ## 3. 구체적 코드 수정안 (Tier 1 상세)
 
-### 3A. String-typed enum → variant 타입 (keeper_unified_turn.ml)
+### 3A. String-typed enum → variant 타입 (keeper_unified_metrics.ml)
 
 **현재** (line 750-761):
-```ocaml
-let selected_mode_of_result (result : Keeper_agent_run.run_result) : string =
-  (* ...returns "tool_use" | "noop" | "skip_text" | "text_response" *)
-
-let work_kind_of_selected_mode (selected_mode : string) : string =
-  match selected_mode with
-  | "tool_use" -> "tool_use"
-  | "noop" -> "noop"
-  | _ -> "text_turn"
-```
-
-**문제**: `selected_mode`와 `work_kind`가 string. 새 모드 추가 시 컴파일러가 완전성 검사 불가.
-`_ -> "text_turn"`은 unknown 입력을 text_turn으로 은밀히 분류.
-
-**수정안** — variant 타입 도입:
 ```ocaml
 type turn_mode =
   | Tool_use
@@ -161,19 +146,23 @@ type turn_mode =
   | Skip_text
   | Text_response
 
-type work_kind =
-  | Wk_tool_use
-  | Wk_noop
-  | Wk_text_turn
+let turn_mode_of_result (result : Keeper_agent_run.run_result) : turn_mode =
+  (* ...returns Tool_use | Noop | Skip_text | Text_response *)
 
 let work_kind_of_turn_mode = function
-  | Tool_use -> Wk_tool_use
-  | Noop -> Wk_noop
-  | Skip_text -> Wk_text_turn
-  | Text_response -> Wk_text_turn
+  | Tool_use -> "tool_use"
+  | Noop -> "noop"
+  | Skip_text -> "text_turn"
+  | Text_response -> "text_turn"
 ```
 
-**ROI**: 4개 call site 수정으로 컴파일러가 미래 variant 확장 시 반드시 모든 case 처리 보장.
+**문제**: `selected_mode`와 `work_kind`가 string이면 새 모드 추가 시 컴파일러가 완전성 검사를 못 한다.
+`_ -> "text_turn"` 같은 fallback은 unknown 입력을 text 계열로 은밀히 분류한다.
+
+**수정 결과**:
+- core/durable surface는 `turn_mode`만 저장
+- `work_kind`는 dashboard/timeline projection에서만 계산
+- future variant 추가 시 exhaustive match가 깨져서 컴파일 단계에서 바로 드러남
 
 ### 3B. post_commit_failure_kind_of_error — 재분류
 

--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -150,7 +150,10 @@ let compute_metrics_window
         let message_count = Safe_ops.json_int ~default:0 "message_count" j in
         let model_used_norm = normalize_model_name model_used in
         let model_bucket = if model_used_norm <> "" then model_used_norm else model_used in
-        let work_kind_raw = Safe_ops.json_string ~default:"" "work_kind" j in
+        let work_kind_raw =
+          Keeper_unified_metrics.work_kind_of_json j
+          |> Option.value ~default:""
+        in
         let memory_check = j |> member "memory_check" in
         let memory_performed = Safe_ops.json_bool ~default:false "performed" memory_check in
         let memory_query_kind = Safe_ops.json_string ~default:"none" "query_kind" memory_check in

--- a/lib/keeper/keeper_exec_status_metrics.ml
+++ b/lib/keeper/keeper_exec_status_metrics.ml
@@ -551,6 +551,7 @@ let latest_tool_audit_snapshot_from_decisions config keeper_name =
       ~parse_snapshot
       ~has_legacy_shape:(fun json ->
         Option.is_some (json_iso_opt json)
+        || Option.is_some (Safe_ops.json_string_opt "turn_mode" json)
         || Option.is_some (Safe_ops.json_string_opt "selected_mode" json)
         || Option.is_some (Safe_ops.json_string_opt "outcome" json))
     |> Option.map (fun snapshot ->
@@ -596,6 +597,7 @@ let latest_tool_audit_snapshot_from_metrics config keeper_name =
     ~has_legacy_shape:(fun json ->
       Option.is_some (json_iso_opt json)
       || Option.is_some (Safe_ops.json_string_opt "channel" json)
+      || Option.is_some (Safe_ops.json_string_opt "turn_mode" json)
       || Option.is_some (Safe_ops.json_string_opt "work_kind" json))
   |> Option.map (fun snapshot ->
          {

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -71,6 +71,31 @@ let scheduled_autonomous_outcome_of_result
   | false, true -> Proactive_tool_use
   | true, true -> Proactive_mixed_response
 
+type turn_mode =
+  | Tool_use
+  | Text_response
+  | Skip_text
+  | Noop
+
+let turn_mode_to_string = function
+  | Tool_use -> "tool_use"
+  | Text_response -> "text_response"
+  | Skip_text -> "skip_text"
+  | Noop -> "noop"
+
+let turn_mode_of_string (raw : string) : turn_mode option =
+  match String.trim raw with
+  | "tool_use" -> Some Tool_use
+  | "text_response" -> Some Text_response
+  | "skip_text" -> Some Skip_text
+  | "noop" -> Some Noop
+  | _ -> None
+
+let work_kind_of_turn_mode = function
+  | Tool_use -> "tool_use"
+  | Noop -> "noop"
+  | Text_response | Skip_text -> "text_turn"
+
 let has_substantive_tool_calls (tools_used : string list) : bool =
   let stay_silent = Tool_name.Keeper.to_string Tool_name.Keeper.Stay_silent in
   List.exists (fun name -> not (String.equal name stay_silent)) tools_used
@@ -150,18 +175,35 @@ let scheduled_autonomous_outcome_for_result
     ~has_text:(String.trim result.response_text <> "")
     ~has_tool_calls:(has_visible_tool_signal result)
 
-let selected_mode_of_result (result : Keeper_agent_run.run_result) : string =
+let turn_mode_of_result (result : Keeper_agent_run.run_result) : turn_mode =
   let text = String.trim result.response_text in
-  if has_visible_tool_signal result then "tool_use"
-  else if text = "" then "noop"
-  else if String.starts_with ~prefix:"SKIP:" text then "skip_text"
-  else "text_response"
+  if has_visible_tool_signal result then Tool_use
+  else if text = "" then Noop
+  else if String.starts_with ~prefix:"SKIP:" text then Skip_text
+  else Text_response
 
-let work_kind_of_selected_mode (selected_mode : string) : string =
-  match selected_mode with
-  | "tool_use" -> "tool_use"
-  | "noop" -> "noop"
-  | _ -> "text_turn"
+let turn_mode_of_json (json : Yojson.Safe.t) : turn_mode option =
+  match Safe_ops.json_string_opt "turn_mode" json with
+  | Some raw -> turn_mode_of_string raw
+  | None ->
+      (match Safe_ops.json_string_opt "selected_mode" json with
+       | Some raw -> turn_mode_of_string raw
+       | None ->
+           match Safe_ops.json_string_opt "work_kind" json with
+           | Some "tool_use" -> Some Tool_use
+           | Some "noop" -> Some Noop
+           | Some "text_turn" -> Some Text_response
+           | _ -> None)
+
+let work_kind_of_json (json : Yojson.Safe.t) : string option =
+  match turn_mode_of_json json with
+  | Some mode -> Some (work_kind_of_turn_mode mode)
+  | None ->
+      (match Safe_ops.json_string_opt "work_kind" json with
+       | Some raw ->
+           let value = String.trim raw in
+           if value = "" then None else Some value
+       | None -> None)
 
 (* A keeper acts as a verification authority when its persona wires the
    "verifier"/"검증자" mention targets. The dashboard and prompt builder
@@ -261,7 +303,7 @@ let append_decision_record
     ~(latency_ms : int)
     ?(semaphore_wait_ms : int = 0)
     ~(outcome : string)
-    ~(selected_mode : string)
+    ?turn_mode
     ?social_state
     ?deliberation_execution
     ?(result : Keeper_agent_run.run_result option = None)
@@ -354,11 +396,18 @@ let append_decision_record
               (Social.delivery_surface_to_string state.delivery_surface) );
         ]
   in
+  let turn_mode =
+    match turn_mode, result with
+    | Some mode, _ -> Some mode
+    | None, Some r -> Some (turn_mode_of_result r)
+    | None, None -> None
+  in
+  let turn_mode_label = Option.map turn_mode_to_string turn_mode in
   let suffix_seed =
     match response_preview, error with
     | Some preview, _ -> preview
     | None, Some err -> err
-    | None, None -> selected_mode
+    | None, None -> Option.value ~default:outcome turn_mode_label
   in
   let json =
     `Assoc
@@ -380,8 +429,7 @@ let append_decision_record
         ("approval_mode", Json_util.string_opt_to_json approval_mode);
         ("channel", `String (decision_channel_of_observation observation));
         ("outcome", `String outcome);
-        ("selected_mode", `String selected_mode);
-        ("selected_mode_source", `String "observed_result");
+        ("turn_mode", Json_util.string_opt_to_json turn_mode_label);
         ("latency_ms", `Int latency_ms);
         ("semaphore_wait_ms", `Int semaphore_wait_ms);
         ("trigger_signals", `List (List.map (fun s -> `String s) trigger_signals));
@@ -838,8 +886,7 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
     ?deliberation_execution () : unit =
   let now_ts = Time_compat.now () in
   let _observation = observation in
-  let selected_mode = selected_mode_of_result result in
-  let work_kind = work_kind_of_selected_mode selected_mode in
+  let turn_mode = turn_mode_of_result result in
   let surface_model_used = Keeper_agent_run.surface_model_used result in
   let scheduled_autonomous_outcome =
     if is_scheduled_autonomous_channel channel then
@@ -898,7 +945,7 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
           match compaction.trigger with
           | Some reason -> `String reason
           | None -> `Null);
-        ("work_kind", `String work_kind);
+        ("turn_mode", `String (turn_mode_to_string turn_mode));
         ( "scheduled_autonomous_outcome",
           match scheduled_autonomous_outcome with
           | Some outcome ->

--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -22,6 +22,12 @@ val observed_affordances_of_observation :
   Keeper_world_observation.world_observation ->
   string list
 
+type turn_mode =
+  | Tool_use
+  | Text_response
+  | Skip_text
+  | Noop
+
 val update_metrics_from_result :
   Keeper_types.keeper_meta ->
   latency_ms:int ->
@@ -72,7 +78,7 @@ val append_decision_record :
   latency_ms:int ->
   ?semaphore_wait_ms:int ->
   outcome:string ->
-  selected_mode:string ->
+  ?turn_mode:turn_mode ->
   ?social_state:Keeper_social_model.social_state ->
   ?deliberation_execution:Keeper_deliberation.execution_result ->
   ?result:Keeper_agent_run.run_result option ->
@@ -92,9 +98,17 @@ val has_substantive_tool_calls : string list -> bool
 val visible_run_validation :
   Keeper_agent_run.run_result -> Oas.Raw_trace.run_validation option
 
-val selected_mode_of_result : Keeper_agent_run.run_result -> string
+val turn_mode_of_result : Keeper_agent_run.run_result -> turn_mode
 
-val work_kind_of_selected_mode : string -> string
+val turn_mode_to_string : turn_mode -> string
+
+val turn_mode_of_string : string -> turn_mode option
+
+val turn_mode_of_json : Yojson.Safe.t -> turn_mode option
+
+val work_kind_of_turn_mode : turn_mode -> string
+
+val work_kind_of_json : Yojson.Safe.t -> string option
 
 val accountability_evidence_refs :
   trace_id:string ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1413,10 +1413,6 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           Keeper_unified_metrics.append_decision_record ~config ~meta:updated_meta ~observation
             ~latency_ms ~semaphore_wait_ms
             ~outcome:(if is_ambiguous_partial then "partial" else "error")
-            ~selected_mode:
-              (if is_ambiguous_partial
-               then "ambiguous_side_effect_error"
-               else "error")
             ~social_state
             ~error:e_str ();
           (match write_meta config updated_meta with
@@ -1559,7 +1555,10 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                Log.Keeper.error
                  "write metrics snapshot failed after keeper cycle: %s"
                  (Printexc.to_string exn));
-          let selected_mode = Keeper_unified_metrics.selected_mode_of_result result in
+          let turn_mode = Keeper_unified_metrics.turn_mode_of_result result in
+          let turn_mode_label =
+            Keeper_unified_metrics.turn_mode_to_string turn_mode
+          in
           (* Emit turn-completed event to Activity Graph for timeline token visibility *)
           (try
             let event =
@@ -1576,7 +1575,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                     ("cost_usd", (if result.usage_reported then `Float turn_cost else `Null));
                     ("latency_ms", `Int latency_ms);
                     ("model_used", `String (Keeper_agent_run.surface_model_used result));
-                    ("work_kind", `String (Keeper_unified_metrics.work_kind_of_selected_mode (Keeper_unified_metrics.selected_mode_of_result result)));
+                    ("turn_mode", `String turn_mode_label);
                     ("context_ratio", `Float lifecycle.context_ratio);
                     ("tools_used", `List (List.map (fun s -> `String s) result.tools_used));
                   ]
@@ -1608,7 +1607,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             ~handoff_json:lifecycle.handoff_json;
           Keeper_unified_metrics.append_decision_record ~config ~meta:updated_meta ~observation
             ~latency_ms ~semaphore_wait_ms ~outcome:"success"
-            ~selected_mode
+            ~turn_mode
             ~social_state
             ~result:(Some result) ();
           (match explicit_accountability_claim with
@@ -1686,7 +1685,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             updated_meta.name model_used
             (result.usage.input_tokens + result.usage.output_tokens)
             latency_ms
-            selected_mode
+            turn_mode_label
             outcome_str;
           (* 7. Persist updated meta *)
           (match write_meta config updated_meta with

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -348,8 +348,8 @@ let turn_completed_events (config : Coord.config) ~agent_name ~limit :
          with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> "unknown"
        in
        let work_kind =
-         try e.payload |> member "work_kind" |> to_string
-         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> "unknown"
+         Keeper_unified_metrics.work_kind_of_json e.payload
+         |> Option.value ~default:"unknown"
        in
        let context_ratio =
          try e.payload |> member "context_ratio" |> to_float

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1988,8 +1988,12 @@ let test_append_metrics_snapshot_treats_validated_evidence_as_tool_use () =
         | _ -> fail "expected one metrics line"
       in
       let json = Yojson.Safe.from_string line in
-      check string "work kind persisted as tool_use" "tool_use"
-        Yojson.Safe.Util.(json |> member "work_kind" |> to_string);
+      check string "turn mode persisted as tool_use" "tool_use"
+        Yojson.Safe.Util.(json |> member "turn_mode" |> to_string);
+      check bool "work_kind removed from snapshot" true
+        (match Yojson.Safe.Util.(json |> member "work_kind") with
+         | `Null -> true
+         | _ -> false);
       check string "scheduled autonomous outcome persisted as tool_use"
         "tool_use"
         Yojson.Safe.Util.(
@@ -2118,8 +2122,8 @@ let test_append_decision_record_persists_tool_calls () =
             ~meta
             ~observation:base_observation
             ~latency_ms:42
-            ~outcome:"tool_use"
-            ~selected_mode:"tool_use"
+            ~outcome:"success"
+            ~turn_mode:UM.Tool_use
             ~result:(Some result)
             ());
       let json =
@@ -2150,6 +2154,12 @@ let test_append_decision_record_persists_tool_calls () =
       check (list string) "tools used persisted"
         ["keeper_shell"; "keeper_board_post"]
         Yojson.Safe.Util.(json |> member "tools_used" |> to_list |> List.map to_string);
+      check (option string) "turn mode persisted" (Some "tool_use")
+        Yojson.Safe.Util.(json |> member "turn_mode" |> to_string_option);
+      check bool "selected_mode removed from decision log" true
+        (match Yojson.Safe.Util.(json |> member "selected_mode") with
+         | `Null -> true
+         | _ -> false);
       let recorded_tool_calls =
         Yojson.Safe.Util.(json |> member "tool_calls" |> to_list)
       in
@@ -2187,8 +2197,8 @@ let test_append_decision_record_nulls_unreported_usage () =
         ~meta:minimal_meta
         ~observation:base_observation
         ~latency_ms:420
-        ~outcome:"normal"
-        ~selected_mode:"normal"
+        ~outcome:"success"
+        ~turn_mode:UM.Text_response
         ~result:(Some result)
         ();
       let json =


### PR DESCRIPTION
## What changed
- introduced typed keeper `turn_mode` as the canonical turn/result classification
- replaced stringly-typed `selected_mode` helpers with exhaustive `turn_mode` mapping logic
- stopped writing durable `work_kind` in keeper metrics, decision logs, and activity payloads
- kept `work_kind` only as a read-model projection for dashboard/timeline consumers via `work_kind_of_json`
- updated keeper-facing docs and focused tests to the new contract

## Why
Keeper turn classification had multiple overlapping string fields, including fallback logic that could silently bucket unknown values as text turns. This PR makes the core contract typed and leaves convenience labels at the projection boundary only.

## Impact
- canonical write path now emits `turn_mode`
- dashboard/timeline readers still surface `work_kind`, but only by deriving it from `turn_mode` (with legacy read fallback)
- future turn-mode additions now require exhaustive handling at compile time

## Validation
- `dune build --root .`
- `git diff --check`
- `./_build/default/test/test_dashboard_mission.exe`
- `./_build/default/test/test_keeper_unified.exe` still has the same pre-existing failure on clean `origin/main` (`20a62df08`): `phase_gate 3 paused-state sync surfaces write fail`
