### PR TITLE
chore(keeper): deduplicate autoboot_enabled in canonical_toml_key_names

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -630,7 +630,6 @@ let canonical_keeper_toml_key_names =
   ; "social_model"
   ; "cascade_name"
   ; "models"
-  ; "autoboot_enabled"
   ]
 
 (** Pure detector: returns TOML keys that [profile_defaults_of_toml] does not


### PR DESCRIPTION
## What

Removes the trailing duplicate of \`\"autoboot_enabled\"\` in \`canonical_keeper_toml_key_names\`.

## Why

The key already appears at line 605. The duplicate at line 633 is harmless because the list is deduplicated downstream, but it is unnecessary noise.

## Verification

- [x] \`dune build --root . @install\` passes
- [x] No semantic change — \`dedupe_keep_order\` handles duplicates anyway

## Related

- Discovered during /loop log monitoring: \`autoboot_enabled\` WARNs from keepers \`nick0cave\`, \`masc-improver\`, \`qa-king\` are caused by a stale server binary (the key was added in #9543, merged but not yet restarted). This PR cleans up the duplicate that was introduced in the same commit.