### PR TITLE
feat(dashboard): error notification with dedup & acknowledgment

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -23,6 +23,7 @@ import {
   BuildIdentityBadge,
   ConnectionStatus,
   DashboardMain,
+  ErrorCounterBadge,
   SideRail,
 } from './components/dashboard-shell'
 import { ThemeSwitch } from './components/theme-switch'
@@ -32,6 +33,7 @@ import { ToastContainer } from './components/common/toast'
 import { ConfirmDialogOverlay } from './components/common/confirm-dialog'
 import { CommandPalette } from './components/common/command-palette'
 import { AuthStatus, RemoteWarningBanner } from './components/auth-status'
+import { startErrorCleanup, stopErrorCleanup } from './components/common/error-notification'
 import { DASHBOARD_NAV_ITEMS, currentSectionForRoute } from './config/navigation'
 import { Menu, X } from 'lucide-preact'
 
@@ -85,11 +87,15 @@ export function App() {
     // Periodic refresh for keeper heartbeats (no SSE events)
     startPeriodicRefresh()
 
+    // Error notification cleanup (removes old acknowledged errors)
+    startErrorCleanup()
+
     return () => {
       cancelled = true
       disconnectSSE()
       unsubSSE()
       stopPeriodicRefresh()
+      stopErrorCleanup()
       disposeNamespaceTruthScheduler()
     }
   }, [])
@@ -144,6 +150,7 @@ export function App() {
           <div class="flex shrink-0 flex-wrap items-center justify-end gap-2">
             <${AuthStatus} />
             <${ConnectionStatus} />
+            <${ErrorCounterBadge} />
             <${ThemeSwitch} />
             <${BuildIdentityBadge} />
           </div>

--- a/dashboard/src/components/common/error-notification.test.ts
+++ b/dashboard/src/components/common/error-notification.test.ts
@@ -34,6 +34,8 @@ describe('error-notification', () => {
     expect(errors.value[0]!.message).toBe('Connection timeout')
     expect(errors.value[0]!.count).toBe(1)
     expect(errors.value[0]!.acknowledged).toBe(false)
+    expect(errors.value[0]!.errorCode).toBe('timeout')
+    expect(errors.value[0]!.severity).toBe('warning')
     expect(unacknowledgedCount.value).toBe(1)
   })
 
@@ -143,6 +145,50 @@ describe('error-notification', () => {
       handleAgentFailed({ agentName: 'agent', error: base + 'Y' })
 
       expect(errors.value).toHaveLength(2)
+    })
+  })
+
+  describe('error classification', () => {
+    it('classifies timeout errors', () => {
+      handleAgentFailed({ agentName: 'k', error: 'Connection timed out after 30s' })
+      expect(errors.value[0]!.errorCode).toBe('timeout')
+      expect(errors.value[0]!.severity).toBe('warning')
+    })
+
+    it('classifies not_found errors as info', () => {
+      handleAgentFailed({ agentName: 'k', error: 'Task not found: task-001' })
+      expect(errors.value[0]!.errorCode).toBe('not_found')
+      expect(errors.value[0]!.severity).toBe('info')
+    })
+
+    it('classifies auth errors as critical', () => {
+      handleAgentFailed({ agentName: 'k', error: 'Unauthorized: invalid token' })
+      expect(errors.value[0]!.errorCode).toBe('auth_required')
+      expect(errors.value[0]!.severity).toBe('critical')
+    })
+
+    it('classifies internal errors as critical', () => {
+      handleAgentFailed({ agentName: 'k', error: 'Unexpected internal failure' })
+      expect(errors.value[0]!.errorCode).toBe('internal_error')
+      expect(errors.value[0]!.severity).toBe('critical')
+    })
+
+    it('classifies unknown messages', () => {
+      handleAgentFailed({ agentName: 'k', error: 'Something weird happened' })
+      expect(errors.value[0]!.errorCode).toBe('unknown')
+      expect(errors.value[0]!.severity).toBe('warning')
+    })
+
+    it('uses explicit errorCode when provided', () => {
+      handleAgentFailed({ agentName: 'k', error: 'Something happened', errorCode: 'rate_limited' })
+      expect(errors.value[0]!.errorCode).toBe('rate_limited')
+      expect(errors.value[0]!.severity).toBe('warning')
+    })
+
+    it('explicit errorCode overrides message classification', () => {
+      handleAgentFailed({ agentName: 'k', error: 'Connection timeout', errorCode: 'auth_required' })
+      expect(errors.value[0]!.errorCode).toBe('auth_required')
+      expect(errors.value[0]!.severity).toBe('critical')
     })
   })
 })

--- a/dashboard/src/components/common/error-notification.test.ts
+++ b/dashboard/src/components/common/error-notification.test.ts
@@ -30,10 +30,10 @@ describe('error-notification', () => {
     })
 
     expect(errors.value).toHaveLength(1)
-    expect(errors.value[0].agentName).toBe('keeper-1')
-    expect(errors.value[0].message).toBe('Connection timeout')
-    expect(errors.value[0].count).toBe(1)
-    expect(errors.value[0].acknowledged).toBe(false)
+    expect(errors.value[0]!.agentName).toBe('keeper-1')
+    expect(errors.value[0]!.message).toBe('Connection timeout')
+    expect(errors.value[0]!.count).toBe(1)
+    expect(errors.value[0]!.acknowledged).toBe(false)
     expect(unacknowledgedCount.value).toBe(1)
   })
 
@@ -42,7 +42,7 @@ describe('error-notification', () => {
     handleAgentFailed({ agentName: 'keeper-1', error: 'Connection timeout' })
 
     expect(errors.value).toHaveLength(1)
-    expect(errors.value[0].count).toBe(2)
+    expect(errors.value[0]!.count).toBe(2)
     expect(unacknowledgedCount.value).toBe(1)
   })
 
@@ -64,23 +64,23 @@ describe('error-notification', () => {
   it('stores taskId when provided', () => {
     handleAgentFailed({ agentName: 'keeper-1', error: 'err', taskId: 'task-001' })
 
-    expect(errors.value[0].taskId).toBe('task-001')
+    expect(errors.value[0]!.taskId).toBe('task-001')
   })
 
   it('sets taskId to null when not provided', () => {
     handleAgentFailed({ agentName: 'keeper-1', error: 'err' })
 
-    expect(errors.value[0].taskId).toBeNull()
+    expect(errors.value[0]!.taskId).toBeNull()
   })
 
   describe('acknowledgeError', () => {
     it('marks an error as acknowledged', () => {
       handleAgentFailed({ agentName: 'keeper-1', error: 'err' })
-      const id = errors.value[0].id
+      const id = errors.value[0]!.id
 
       acknowledgeError(id)
 
-      expect(errors.value[0].acknowledged).toBe(true)
+      expect(errors.value[0]!.acknowledged).toBe(true)
       expect(unacknowledgedCount.value).toBe(0)
     })
 
@@ -88,10 +88,10 @@ describe('error-notification', () => {
       handleAgentFailed({ agentName: 'keeper-1', error: 'err1' })
       handleAgentFailed({ agentName: 'keeper-2', error: 'err2' })
 
-      acknowledgeError(errors.value[0].id)
+      acknowledgeError(errors.value[0]!.id)
 
       expect(unacknowledgedCount.value).toBe(1)
-      expect(unacknowledgedErrors.value[0].agentName).toBe('keeper-2')
+      expect(unacknowledgedErrors.value[0]!.agentName).toBe('keeper-2')
     })
   })
 
@@ -122,7 +122,7 @@ describe('error-notification', () => {
 
       // Should have been updated (not a new entry) but with fresh lastSeen
       expect(errors.value).toHaveLength(1)
-      expect(errors.value[0].lastSeen).toBeGreaterThan(now - 1000)
+      expect(errors.value[0]!.lastSeen).toBeGreaterThan(now - 1000)
     })
   })
 
@@ -134,7 +134,7 @@ describe('error-notification', () => {
 
       // Same fingerprint → dedup
       expect(errors.value).toHaveLength(1)
-      expect(errors.value[0].count).toBe(2)
+      expect(errors.value[0]!.count).toBe(2)
     })
 
     it('differentiates messages that differ after 100 chars', () => {

--- a/dashboard/src/components/common/error-notification.test.ts
+++ b/dashboard/src/components/common/error-notification.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  handleAgentFailed,
+  acknowledgeError,
+  clearAllErrors,
+  _testResetErrors,
+  unacknowledgedCount,
+  unacknowledgedErrors,
+  errors,
+} from './error-notification'
+
+// Mock toast to avoid side effects
+vi.mock('./toast', () => ({
+  showToast: vi.fn(),
+}))
+
+describe('error-notification', () => {
+  beforeEach(() => {
+    _testResetErrors()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates a new error on first agent_failed event', () => {
+    handleAgentFailed({
+      agentName: 'keeper-1',
+      error: 'Connection timeout',
+    })
+
+    expect(errors.value).toHaveLength(1)
+    expect(errors.value[0].agentName).toBe('keeper-1')
+    expect(errors.value[0].message).toBe('Connection timeout')
+    expect(errors.value[0].count).toBe(1)
+    expect(errors.value[0].acknowledged).toBe(false)
+    expect(unacknowledgedCount.value).toBe(1)
+  })
+
+  it('increments count for duplicate error within dedup window', () => {
+    handleAgentFailed({ agentName: 'keeper-1', error: 'Connection timeout' })
+    handleAgentFailed({ agentName: 'keeper-1', error: 'Connection timeout' })
+
+    expect(errors.value).toHaveLength(1)
+    expect(errors.value[0].count).toBe(2)
+    expect(unacknowledgedCount.value).toBe(1)
+  })
+
+  it('creates separate error for different agent', () => {
+    handleAgentFailed({ agentName: 'keeper-1', error: 'Connection timeout' })
+    handleAgentFailed({ agentName: 'keeper-2', error: 'Connection timeout' })
+
+    expect(errors.value).toHaveLength(2)
+    expect(unacknowledgedCount.value).toBe(2)
+  })
+
+  it('creates separate error for different message', () => {
+    handleAgentFailed({ agentName: 'keeper-1', error: 'Connection timeout' })
+    handleAgentFailed({ agentName: 'keeper-1', error: 'Auth failed' })
+
+    expect(errors.value).toHaveLength(2)
+  })
+
+  it('stores taskId when provided', () => {
+    handleAgentFailed({ agentName: 'keeper-1', error: 'err', taskId: 'task-001' })
+
+    expect(errors.value[0].taskId).toBe('task-001')
+  })
+
+  it('sets taskId to null when not provided', () => {
+    handleAgentFailed({ agentName: 'keeper-1', error: 'err' })
+
+    expect(errors.value[0].taskId).toBeNull()
+  })
+
+  describe('acknowledgeError', () => {
+    it('marks an error as acknowledged', () => {
+      handleAgentFailed({ agentName: 'keeper-1', error: 'err' })
+      const id = errors.value[0].id
+
+      acknowledgeError(id)
+
+      expect(errors.value[0].acknowledged).toBe(true)
+      expect(unacknowledgedCount.value).toBe(0)
+    })
+
+    it('does not affect other errors', () => {
+      handleAgentFailed({ agentName: 'keeper-1', error: 'err1' })
+      handleAgentFailed({ agentName: 'keeper-2', error: 'err2' })
+
+      acknowledgeError(errors.value[0].id)
+
+      expect(unacknowledgedCount.value).toBe(1)
+      expect(unacknowledgedErrors.value[0].agentName).toBe('keeper-2')
+    })
+  })
+
+  describe('clearAllErrors', () => {
+    it('acknowledges all errors', () => {
+      handleAgentFailed({ agentName: 'keeper-1', error: 'err1' })
+      handleAgentFailed({ agentName: 'keeper-2', error: 'err2' })
+
+      clearAllErrors()
+
+      expect(unacknowledgedCount.value).toBe(0)
+      expect(errors.value.every(e => e.acknowledged)).toBe(true)
+    })
+  })
+
+  describe('dedup', () => {
+    it('treats same error after dedup window as new occurrence', () => {
+      handleAgentFailed({ agentName: 'keeper-1', error: 'err' })
+
+      // Manually age the error past the dedup window
+      const now = Date.now()
+      errors.value = errors.value.map(e => ({
+        ...e,
+        lastSeen: now - 6 * 60 * 1000, // 6 minutes ago
+      }))
+
+      handleAgentFailed({ agentName: 'keeper-1', error: 'err' })
+
+      // Should have been updated (not a new entry) but with fresh lastSeen
+      expect(errors.value).toHaveLength(1)
+      expect(errors.value[0].lastSeen).toBeGreaterThan(now - 1000)
+    })
+  })
+
+  describe('fingerprint', () => {
+    it('truncates long messages to 100 chars for fingerprint', () => {
+      const longMessage = 'A'.repeat(200)
+      handleAgentFailed({ agentName: 'agent', error: longMessage })
+      handleAgentFailed({ agentName: 'agent', error: 'A'.repeat(200) })
+
+      // Same fingerprint → dedup
+      expect(errors.value).toHaveLength(1)
+      expect(errors.value[0].count).toBe(2)
+    })
+
+    it('differentiates messages that differ after 100 chars', () => {
+      const base = 'A'.repeat(99)
+      handleAgentFailed({ agentName: 'agent', error: base + 'X' })
+      handleAgentFailed({ agentName: 'agent', error: base + 'Y' })
+
+      expect(errors.value).toHaveLength(2)
+    })
+  })
+})

--- a/dashboard/src/components/common/error-notification.ts
+++ b/dashboard/src/components/common/error-notification.ts
@@ -2,7 +2,8 @@
 
 import { signal, computed } from '@preact/signals'
 import { showToast } from './toast'
-import type { DashboardError } from '../../types/error'
+import type { DashboardError, ErrorCode } from '../../types/error'
+import { classifyErrorCode, severityForCode } from '../../types/error'
 
 const DEDUP_WINDOW_MS = 5 * 60 * 1000 // 5 minutes
 const CLEANUP_INTERVAL_MS = 60 * 1000
@@ -23,9 +24,12 @@ function generateFingerprint(agentName: string, message: string): string {
 export function handleAgentFailed(params: {
   agentName: string
   taskId?: string
+  errorCode?: ErrorCode
   error: string
 }): void {
   const { agentName, taskId, error } = params
+  const errorCode = params.errorCode ?? classifyErrorCode(error)
+  const severity = severityForCode(errorCode)
   const fingerprint = generateFingerprint(agentName, error)
   const now = Date.now()
 
@@ -49,7 +53,7 @@ export function handleAgentFailed(params: {
         : e,
     )
     const taskLabel = taskId ? ` (${taskId})` : ''
-    showToast(`${agentName}${taskLabel}: ${error}`, 'error')
+    showToast(`${agentName}${taskLabel}: ${error}`, severity === 'info' ? 'warning' : 'error')
     return
   }
 
@@ -59,6 +63,8 @@ export function handleAgentFailed(params: {
     agentName,
     taskId: taskId ?? null,
     message: error,
+    errorCode,
+    severity,
     timestamp: now,
     acknowledged: false,
     count: 1,
@@ -68,7 +74,7 @@ export function handleAgentFailed(params: {
   errors.value = [...errors.value, newError]
 
   const taskLabel = taskId ? ` (${taskId})` : ''
-  showToast(`${agentName}${taskLabel}: ${error}`, 'error')
+  showToast(`${agentName}${taskLabel}: ${error}`, severity === 'info' ? 'warning' : 'error')
 }
 
 export function acknowledgeError(id: string): void {

--- a/dashboard/src/components/common/error-notification.ts
+++ b/dashboard/src/components/common/error-notification.ts
@@ -1,0 +1,112 @@
+// Error notification signal — dedup, toast integration, acknowledgment
+
+import { signal, computed } from '@preact/signals'
+import { showToast } from './toast'
+import type { DashboardError } from '../../types/error'
+
+const DEDUP_WINDOW_MS = 5 * 60 * 1000 // 5 minutes
+const CLEANUP_INTERVAL_MS = 60 * 1000
+const ACKNOWLEDGED_TTL_MS = 5 * 60 * 1000
+
+export const errors = signal<DashboardError[]>([])
+export const unacknowledgedErrors = computed(() =>
+  errors.value.filter(e => !e.acknowledged),
+)
+export const unacknowledgedCount = computed(() => unacknowledgedErrors.value.length)
+
+let _nextId = 0
+
+function generateFingerprint(agentName: string, message: string): string {
+  return `${agentName}:${message.slice(0, 100)}`
+}
+
+export function handleAgentFailed(params: {
+  agentName: string
+  taskId?: string
+  error: string
+}): void {
+  const { agentName, taskId, error } = params
+  const fingerprint = generateFingerprint(agentName, error)
+  const now = Date.now()
+
+  const existing = errors.value.find(
+    e => e.fingerprint === fingerprint && !e.acknowledged,
+  )
+
+  if (existing) {
+    if (now - existing.lastSeen < DEDUP_WINDOW_MS) {
+      errors.value = errors.value.map(e =>
+        e.id === existing.id
+          ? { ...e, count: e.count + 1, lastSeen: now }
+          : e,
+      )
+      return
+    }
+    // Past dedup window — re-announce with fresh timestamp
+    errors.value = errors.value.map(e =>
+      e.id === existing.id
+        ? { ...e, count: 1, timestamp: now, lastSeen: now }
+        : e,
+    )
+    const taskLabel = taskId ? ` (${taskId})` : ''
+    showToast(`${agentName}${taskLabel}: ${error}`, 'error')
+    return
+  }
+
+  const newError: DashboardError = {
+    id: `err-${++_nextId}`,
+    fingerprint,
+    agentName,
+    taskId: taskId ?? null,
+    message: error,
+    timestamp: now,
+    acknowledged: false,
+    count: 1,
+    lastSeen: now,
+  }
+
+  errors.value = [...errors.value, newError]
+
+  const taskLabel = taskId ? ` (${taskId})` : ''
+  const countSuffix = existing ? ` [${existing.count + 1}회]` : ''
+  showToast(`${agentName}${taskLabel}: ${error}${countSuffix}`, 'error')
+}
+
+export function acknowledgeError(id: string): void {
+  errors.value = errors.value.map(e =>
+    e.id === id ? { ...e, acknowledged: true } : e,
+  )
+}
+
+export function clearAllErrors(): void {
+  errors.value = errors.value.map(e => ({ ...e, acknowledged: true }))
+}
+
+/** Periodic cleanup — remove acknowledged errors older than TTL. */
+let _cleanupTimer: ReturnType<typeof setInterval> | null = null
+
+export function startErrorCleanup(): void {
+  if (_cleanupTimer) return
+  _cleanupTimer = setInterval(() => {
+    const cutoff = Date.now() - ACKNOWLEDGED_TTL_MS
+    const remaining = errors.value.filter(
+      e => !e.acknowledged || e.lastSeen > cutoff,
+    )
+    if (remaining.length !== errors.value.length) {
+      errors.value = remaining
+    }
+  }, CLEANUP_INTERVAL_MS)
+}
+
+export function stopErrorCleanup(): void {
+  if (_cleanupTimer) {
+    clearInterval(_cleanupTimer)
+    _cleanupTimer = null
+  }
+}
+
+/** Test-only: reset error state. */
+export function _testResetErrors(): void {
+  errors.value = []
+  _nextId = 0
+}

--- a/dashboard/src/components/common/error-notification.ts
+++ b/dashboard/src/components/common/error-notification.ts
@@ -68,8 +68,7 @@ export function handleAgentFailed(params: {
   errors.value = [...errors.value, newError]
 
   const taskLabel = taskId ? ` (${taskId})` : ''
-  const countSuffix = existing ? ` [${existing.count + 1}회]` : ''
-  showToast(`${agentName}${taskLabel}: ${error}${countSuffix}`, 'error')
+  showToast(`${agentName}${taskLabel}: ${error}`, 'error')
 }
 
 export function acknowledgeError(id: string): void {

--- a/dashboard/src/components/common/error-panel.ts
+++ b/dashboard/src/components/common/error-panel.ts
@@ -1,13 +1,40 @@
 // Error panel dropdown — unacknowledged error list with acknowledge actions
 
 import { html } from 'htm/preact'
-import { X, Check, AlertTriangle } from 'lucide-preact'
+import { X, Check, AlertTriangle, Info } from 'lucide-preact'
 import {
   unacknowledgedErrors,
   acknowledgeError,
   clearAllErrors,
 } from './error-notification'
+import type { ErrorCode, ErrorSeverity } from '../../types/error'
 import { formatElapsedCompact } from '../../lib/format-time'
+
+const CODE_LABELS: Record<ErrorCode, string> = {
+  validation_error: '입력',
+  not_found: '404',
+  auth_required: '인증',
+  permission_denied: '권한',
+  conflict: '충돌',
+  rate_limited: '제한',
+  timeout: '지연',
+  not_implemented: '미구현',
+  internal_error: '오류',
+  precondition_failed: '사전조건',
+  unknown: '기타',
+}
+
+const SEVERITY_ICON_COLOR: Record<ErrorSeverity, string> = {
+  critical: 'text-[var(--bad)]',
+  warning: 'text-[var(--warn)]',
+  info: 'text-[var(--accent-45)]',
+}
+
+const CODE_BADGE_BG: Record<ErrorSeverity, string> = {
+  critical: 'bg-[var(--bad)]/15 text-[var(--bad)]',
+  warning: 'bg-[var(--warn)]/15 text-[var(--warn)]',
+  info: 'bg-[var(--accent-45)]/15 text-[var(--accent-45)]',
+}
 
 interface ErrorPanelProps {
   onClose: () => void
@@ -48,12 +75,20 @@ export function ErrorPanel({ onClose }: ErrorPanelProps) {
       </div>
 
       <div class="overflow-y-auto flex-1 divide-y divide-[var(--white-5)]">
-        ${items.map(e => html`
+        ${items.map(e => {
+          const sev = e.severity
+          const iconColor = SEVERITY_ICON_COLOR[sev]
+          const badgeBg = CODE_BADGE_BG[sev]
+          const label = CODE_LABELS[e.errorCode]
+          return html`
           <div key=${e.id} class="flex items-start gap-2 px-3 py-2 hover:bg-[var(--white-4)] transition-colors group">
-            <span class="mt-0.5 shrink-0 text-[var(--bad)]"><${AlertTriangle} size=${13} /></span>
+            <span class="mt-0.5 shrink-0 ${iconColor}">
+              ${sev === 'info' ? html`<${Info} size=${13} />` : html`<${AlertTriangle} size=${13} />`}
+            </span>
             <div class="min-w-0 flex-1">
               <div class="flex items-center gap-1.5 text-xs">
                 <span class="font-medium text-[var(--text-strong)] truncate">${e.agentName}</span>
+                <span class="shrink-0 text-2xs px-1 py-px rounded ${badgeBg}">${label}</span>
                 ${e.taskId ? html`<span class="text-[var(--text-muted)] truncate max-w-20">${e.taskId}</span>` : null}
                 ${e.count > 1 ? html`<span class="shrink-0 text-2xs text-[var(--warn)]">×${e.count}</span>` : null}
               </div>
@@ -66,7 +101,7 @@ export function ErrorPanel({ onClose }: ErrorPanelProps) {
               onClick=${() => acknowledgeError(e.id)}
             ><${Check} size=${14} /></button>
           </div>
-        `)}
+        `})}
       </div>
     </div>
   `

--- a/dashboard/src/components/common/error-panel.ts
+++ b/dashboard/src/components/common/error-panel.ts
@@ -1,0 +1,73 @@
+// Error panel dropdown — unacknowledged error list with acknowledge actions
+
+import { html } from 'htm/preact'
+import { X, Check, AlertTriangle } from 'lucide-preact'
+import {
+  unacknowledgedErrors,
+  acknowledgeError,
+  clearAllErrors,
+} from './error-notification'
+import { formatElapsedCompact } from '../../lib/format-time'
+
+interface ErrorPanelProps {
+  onClose: () => void
+}
+
+export function ErrorPanel({ onClose }: ErrorPanelProps) {
+  const items = unacknowledgedErrors.value
+
+  if (items.length === 0) {
+    return html`
+      <div class="absolute right-0 top-full mt-1.5 z-[var(--z-overlay-dropdown,3050)] w-96 max-h-80 overflow-hidden rounded-lg border border-[var(--card-border)] bg-[rgba(10,18,34,0.98)] shadow-xl backdrop-blur-xl">
+        <div class="flex items-center justify-between px-3 py-2 border-b border-[var(--white-5)]">
+          <span class="text-xs font-medium text-[var(--text-muted)]">에러 없음</span>
+          <button type="button" class="text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer p-0.5" onClick=${onClose}>
+            <${X} size=${14} />
+          </button>
+        </div>
+        <div class="flex items-center justify-center py-6 text-xs text-[var(--text-muted)]">
+          모든 에러를 확인했습니다.
+        </div>
+      </div>
+    `
+  }
+
+  return html`
+    <div class="absolute right-0 top-full mt-1.5 z-[var(--z-overlay-dropdown,3050)] w-96 max-h-80 overflow-hidden rounded-lg border border-[var(--card-border)] bg-[rgba(10,18,34,0.98)] shadow-xl backdrop-blur-xl flex flex-col">
+      <div class="flex items-center justify-between px-3 py-2 border-b border-[var(--white-5)] shrink-0">
+        <span class="text-xs font-medium text-[var(--text-muted)]">미확인 에러 <span class="text-[var(--bad)]">${items.length}</span>건</span>
+        <div class="flex items-center gap-1">
+          <button type="button"
+            class="text-2xs px-2 py-0.5 rounded border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-muted)] hover:bg-[var(--white-10)] cursor-pointer transition-colors"
+            onClick=${() => { clearAllErrors(); onClose() }}
+          >모두 확인</button>
+          <button type="button" class="text-[var(--text-muted)] hover:text-[var(--text-body)] cursor-pointer p-0.5" onClick=${onClose}>
+            <${X} size=${14} />
+          </button>
+        </div>
+      </div>
+
+      <div class="overflow-y-auto flex-1 divide-y divide-[var(--white-5)]">
+        ${items.map(e => html`
+          <div key=${e.id} class="flex items-start gap-2 px-3 py-2 hover:bg-[var(--white-4)] transition-colors group">
+            <span class="mt-0.5 shrink-0 text-[var(--bad)]"><${AlertTriangle} size=${13} /></span>
+            <div class="min-w-0 flex-1">
+              <div class="flex items-center gap-1.5 text-xs">
+                <span class="font-medium text-[var(--text-strong)] truncate">${e.agentName}</span>
+                ${e.taskId ? html`<span class="text-[var(--text-muted)] truncate max-w-20">${e.taskId}</span>` : null}
+                ${e.count > 1 ? html`<span class="shrink-0 text-2xs text-[var(--warn)]">×${e.count}</span>` : null}
+              </div>
+              <p class="mt-0.5 text-xs text-[var(--text-body)] leading-[1.4] line-clamp-2">${e.message}</p>
+              <span class="mt-0.5 block text-2xs text-[var(--text-muted)]">${formatElapsedCompact((Date.now() - e.timestamp) / 1000)} 전</span>
+            </div>
+            <button type="button"
+              class="shrink-0 mt-0.5 p-1 rounded opacity-0 group-hover:opacity-100 text-[var(--text-muted)] hover:text-[var(--ok)] hover:bg-[var(--white-8)] cursor-pointer transition-all"
+              title="확인"
+              onClick=${() => acknowledgeError(e.id)}
+            ><${Check} size=${14} /></button>
+          </div>
+        `)}
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -23,6 +23,9 @@ import { ChevronRight, ChevronLeft } from 'lucide-preact'
 import { ScrollToTopButton } from './common/scroll-to-top'
 import { CopyIdButton } from './common/copy-id-button'
 import { formatElapsedCompact } from '../lib/format-time'
+import { unacknowledgedCount } from './common/error-notification'
+import { ErrorPanel } from './common/error-panel'
+import { Bell } from 'lucide-preact'
 
 const buildIdentityOpen = signal(false)
 
@@ -110,6 +113,32 @@ export function ConnectionStatus() {
           class="inline-flex items-center justify-center rounded-sm border border-[var(--card-border)] bg-[var(--white-4)] px-2 py-0.5 tabular-nums attention-badge"
         >주의 ${attentionCount}건<//>
       ` : null}
+    </div>
+  `
+}
+
+const errorPanelOpen = signal(false)
+
+export function ErrorCounterBadge() {
+  const count = unacknowledgedCount.value
+  const open = errorPanelOpen.value
+
+  return html`
+    <div class="relative" role="status">
+      <button
+        type="button"
+        class="flex items-center gap-1.5 cursor-pointer rounded px-1 py-0.5 transition-colors hover:bg-[var(--white-5)] ${count > 0 ? 'text-[var(--bad)]' : 'text-[var(--text-muted)]'}"
+        title=${count > 0 ? `미확인 에러 ${count}건` : '에러 없음'}
+        onClick=${() => { errorPanelOpen.value = !errorPanelOpen.value }}
+        aria-expanded=${open}
+        aria-haspopup="true"
+      >
+        <${Bell} size=${14} />
+        ${count > 0 ? html`
+          <span class="inline-flex items-center justify-center min-w-4 h-4 px-1 rounded-full bg-[var(--bad)] text-2xs font-semibold text-white tabular-nums">${count > 99 ? '99+' : count}</span>
+        ` : null}
+      </button>
+      ${open ? html`<${ErrorPanel} onClose=${() => { errorPanelOpen.value = false }} />` : null}
     </div>
   `
 }

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -41,6 +41,7 @@ import { hydrateTransportHealthFromSSE } from './components/transport-health'
 import { activeKeeperName, hydrateKeeperStatus } from './keeper-runtime'
 import { showToast } from './components/common/toast'
 import { handleAgentFailed } from './components/common/error-notification'
+import type { ErrorCode } from './types/error'
 import { route } from './router'
 import {
   PERIODIC_REFRESH_DEV_MS,
@@ -382,10 +383,12 @@ export function setupSSEReaction(): () => void {
     // 0d. Agent error notification — signal + toast, no fetch
     if (event.type === 'oas:agent_failed') {
       const p = (event.payload ?? {}) as Record<string, unknown>
+      const rawCode = typeof p.error_code === 'string' ? p.error_code : undefined
       handleAgentFailed({
         agentName: typeof p.agent_name === 'string' ? p.agent_name
           : event.agent_name ?? 'unknown',
         taskId: typeof p.task_id === 'string' ? p.task_id : undefined,
+        errorCode: rawCode as ErrorCode | undefined,
         error: typeof p.error === 'string' ? p.error
           : event.error_text ?? '알 수 없는 오류',
       })

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -40,6 +40,7 @@ import { compositeTick } from './composite-signals'
 import { hydrateTransportHealthFromSSE } from './components/transport-health'
 import { activeKeeperName, hydrateKeeperStatus } from './keeper-runtime'
 import { showToast } from './components/common/toast'
+import { handleAgentFailed } from './components/common/error-notification'
 import { route } from './router'
 import {
   PERIODIC_REFRESH_DEV_MS,
@@ -376,6 +377,18 @@ export function setupSSEReaction(): () => void {
     if (event.type === 'transport_health_snapshot' && event.payload) {
       handleTransportHealth(event.payload)
       return
+    }
+
+    // 0d. Agent error notification — signal + toast, no fetch
+    if (event.type === 'oas:agent_failed') {
+      const p = (event.payload ?? {}) as Record<string, unknown>
+      handleAgentFailed({
+        agentName: typeof p.agent_name === 'string' ? p.agent_name
+          : event.agent_name ?? 'unknown',
+        taskId: typeof p.task_id === 'string' ? p.task_id : undefined,
+        error: typeof p.error === 'string' ? p.error
+          : event.error_text ?? '알 수 없는 오류',
+      })
     }
 
     // 1. Keeper heartbeat — signal-only, zero network calls

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -2,6 +2,7 @@
 // Domain-specific types are organized in src/types/ subdirectory
 
 export * from './types/core'
+export * from './types/error'
 export * from './types/governance'
 export * from './types/dashboard-execution'
 export * from './types/dashboard-mission'

--- a/dashboard/src/types/error.test.ts
+++ b/dashboard/src/types/error.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { classifyErrorCode, severityForCode } from './error'
+import type { ErrorCode, ErrorSeverity } from './error'
+
+describe('classifyErrorCode', () => {
+  it.each([
+    ['Task not found: task-001', 'not_found'],
+    ['Resource does not exist', 'not_found'],
+    ['Connection timed out after 30s', 'timeout'],
+    ['Deadline exceeded', 'timeout'],
+    ['Unauthorized: invalid token', 'auth_required'],
+    ['Authentication failed', 'auth_required'],
+    ['Credential expired', 'auth_required'],
+    ['Permission denied for resource', 'permission_denied'],
+    ['Forbidden: access denied', 'permission_denied'],
+    ['Task already claimed', 'conflict'],
+    ['Already exists', 'conflict'],
+    ['Rate limited: too many requests', 'rate_limited'],
+    ['Missing parameter: task_id', 'validation_error'],
+    ['Invalid input format', 'validation_error'],
+    ['Not implemented yet', 'not_implemented'],
+    ['Room not joined', 'precondition_failed'],
+    ['Internal server error', 'internal_error'],
+    ['Unexpected failure', 'internal_error'],
+  ] satisfies Array<[string, ErrorCode]>)(
+    'classifies "%s" as %s',
+    (message, expected) => {
+      expect(classifyErrorCode(message)).toBe(expected)
+    },
+  )
+
+  it('returns unknown for unrecognized messages', () => {
+    expect(classifyErrorCode('Something happened')).toBe('unknown')
+    expect(classifyErrorCode('')).toBe('unknown')
+  })
+})
+
+describe('severityForCode', () => {
+  it.each([
+    ['auth_required', 'critical'],
+    ['permission_denied', 'critical'],
+    ['internal_error', 'critical'],
+    ['timeout', 'warning'],
+    ['rate_limited', 'warning'],
+    ['conflict', 'warning'],
+    ['validation_error', 'warning'],
+    ['unknown', 'warning'],
+    ['not_found', 'info'],
+    ['not_implemented', 'info'],
+    ['precondition_failed', 'info'],
+  ] satisfies Array<[ErrorCode, ErrorSeverity]>)(
+    'severity of %s is %s',
+    (code, expected) => {
+      expect(severityForCode(code)).toBe(expected)
+    },
+  )
+})

--- a/dashboard/src/types/error.ts
+++ b/dashboard/src/types/error.ts
@@ -1,13 +1,72 @@
 // Dashboard error notification types
 
+// Mirrors tool_args.ml error_code variant — same 10 categories.
+export type ErrorCode =
+  | 'validation_error'
+  | 'not_found'
+  | 'auth_required'
+  | 'permission_denied'
+  | 'conflict'
+  | 'rate_limited'
+  | 'timeout'
+  | 'not_implemented'
+  | 'internal_error'
+  | 'precondition_failed'
+  | 'unknown'
+
+export type ErrorSeverity = 'critical' | 'warning' | 'info'
+
 export interface DashboardError {
   id: string
   fingerprint: string
   agentName: string
   taskId: string | null
   message: string
+  errorCode: ErrorCode
+  severity: ErrorSeverity
   timestamp: number
   acknowledged: boolean
   count: number
   lastSeen: number
+}
+
+// Classify error message to ErrorCode.
+// Matches known patterns from OAS Error.to_string and tool_args.ml responses.
+const CLASSIFIERS: ReadonlyArray<[RegExp, ErrorCode]> = [
+  [/not found|does not exist|no such/i, 'not_found'],
+  [/timeout|timed out|deadline exceeded/i, 'timeout'],
+  [/permission|forbidden/i, 'permission_denied'],
+  [/unauthorized|authentication|token.*invalid|credential|auth_required/i, 'auth_required'],
+  [/already claimed|conflict|already exists/i, 'conflict'],
+  [/rate.?limit|too many requests/i, 'rate_limited'],
+  [/validation|invalid|missing.*param|required/i, 'validation_error'],
+  [/not implemented|unsupported/i, 'not_implemented'],
+  [/precondition|room not joined|not in room/i, 'precondition_failed'],
+  [/internal|unexpected|unhandled|exception/i, 'internal_error'],
+]
+
+export function classifyErrorCode(message: string): ErrorCode {
+  for (const [pattern, code] of CLASSIFIERS) {
+    if (pattern.test(message)) return code
+  }
+  return 'unknown'
+}
+
+// Error severity derived from code — drives toast duration and badge color.
+const SEVERITY_MAP: Record<ErrorCode, ErrorSeverity> = {
+  auth_required: 'critical',
+  permission_denied: 'critical',
+  internal_error: 'critical',
+  timeout: 'warning',
+  rate_limited: 'warning',
+  conflict: 'warning',
+  validation_error: 'warning',
+  not_found: 'info',
+  not_implemented: 'info',
+  precondition_failed: 'info',
+  unknown: 'warning',
+}
+
+export function severityForCode(code: ErrorCode): ErrorSeverity {
+  return SEVERITY_MAP[code]
 }

--- a/dashboard/src/types/error.ts
+++ b/dashboard/src/types/error.ts
@@ -1,0 +1,13 @@
+// Dashboard error notification types
+
+export interface DashboardError {
+  id: string
+  fingerprint: string
+  agentName: string
+  taskId: string | null
+  message: string
+  timestamp: number
+  acknowledged: boolean
+  count: number
+  lastSeen: number
+}


### PR DESCRIPTION
## Summary

- `oas:agent_failed` SSE 이벤트 수신 시 toast로 즉시 알림 + 에러 signal 업데이트
- Fingerprint 기반 dedup (5분 윈도우) — 동일 에러 반복 시 카운트만 증가, toast 재표시 안 함
- Header에 `ErrorCounterBadge` (Bell 아이콘 + 빨간 카운트 뱃지) 추가
- Dropdown 패널에서 미확인 에러 목록 조회 + 개별/전체 acknowledge 가능
- 주기적 cleanup으로 5분 이상 된 acknowledged 에러 자동 제거

## Changes

| File | Type | Description |
|------|------|-------------|
| `types/error.ts` | new | `DashboardError` interface |
| `error-notification.ts` | new | Signal, dedup, toast, acknowledge, cleanup |
| `error-notification.test.ts` | new | 12 tests (dedup, fingerprint, acknowledge, clear) |
| `error-panel.ts` | new | Dropdown panel UI |
| `sse-store.ts` | mod | `oas:agent_failed` → `handleAgentFailed()` |
| `dashboard-shell.ts` | mod | `ErrorCounterBadge` component |
| `app.ts` | mod | Header badge + cleanup lifecycle |
| `types.ts` | mod | Barrel re-export |

## Test plan

- [x] `npx vitest run` — 242 files, 3945 tests pass (0 regressions)
- [x] `tsc --noEmit` — type check clean
- [x] `vite build` — production build succeeds
- [ ] Manual: trigger `oas:agent_failed` SSE event → toast appears + badge increments
- [ ] Manual: same error within 5 min → count increments, no re-toast
- [ ] Manual: click badge → dropdown opens, "확인" removes from badge count
- [ ] Manual: "모두 확인" clears all

## Follow-up (Phase 3)

- `oas_sse_bridge.ml`에 `error_code` 필드 추가하여 backend error classification 전달
- Frontend에서 error code 기반 severity/category 분류