### PR TITLE
[codex] Fix goal dashboard verification summary decoding

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   fetchDashboardGovernance,
+  fetchDashboardGoalDetail,
+  fetchDashboardGoalsTree,
   fetchDashboardTools,
   fetchKeeperConfig,
   fetchRuntimeModelMetrics,
@@ -10,6 +12,46 @@ import {
 afterEach(() => {
   vi.unstubAllGlobals()
 })
+
+function makeRawGoalNode(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'goal-1',
+    title: 'Goal 1',
+    horizon: 'quarterly',
+    status: 'active',
+    status_color: '#fff',
+    phase: 'executing',
+    phase_color: '#0ea5e9',
+    health: 'on_track',
+    health_color: '#4ade80',
+    badges: [],
+    status_reason: 'working',
+    priority: 1,
+    metric: null,
+    target_value: null,
+    due_date: null,
+    parent_goal_id: null,
+    convergence: 0.5,
+    convergence_pct: 50,
+    tasks: [],
+    task_count: 0,
+    task_done_count: 0,
+    pending_verification_count: 0,
+    timeline_events: [],
+    children: [],
+    child_count: 0,
+    last_activity_at: '2026-04-23T00:00:00Z',
+    stagnation_seconds: 0,
+    linked_keeper_names: [],
+    pending_approval_count: 0,
+    infra_risk_count: 0,
+    linkage_source: 'none',
+    linkage_warning_count: 0,
+    created_at: '2026-04-23T00:00:00Z',
+    updated_at: '2026-04-23T00:00:00Z',
+    ...overrides,
+  }
+}
 
 describe('fetchDashboardTools', () => {
   it('fills missing category and tier with defaults', async () => {
@@ -166,6 +208,62 @@ describe('fetchDashboardGovernance', () => {
       errorCode: 'computation_timeout',
     })
     expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('dashboard goals decoding', () => {
+  it('fills a missing verification_summary on goal tree payloads', async () => {
+    const rawResponse = {
+      tree: [makeRawGoalNode()],
+      summary: {},
+    }
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchDashboardGoalsTree()
+
+    expect(result.tree[0]?.verification_summary).toEqual({
+      effective_policy: null,
+      open_request: null,
+      approve_count: 0,
+      reject_count: 0,
+      remaining_possible: 0,
+    })
+  })
+
+  it('fills a missing verification_summary on goal detail payloads', async () => {
+    const rawResponse = {
+      goal: makeRawGoalNode(),
+      linked_tasks: [],
+      linked_keepers: [],
+      approvals: [],
+      execution_receipts: [],
+      timeline: [],
+    }
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchDashboardGoalDetail('goal-1')
+
+    expect(result.goal.verification_summary).toEqual({
+      effective_policy: null,
+      open_request: null,
+      approve_count: 0,
+      reject_count: 0,
+      remaining_possible: 0,
+    })
   })
 })
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -34,6 +34,14 @@ import type {
   DashboardPlanningResponse,
   DashboardGoalsTreeResponse,
   DashboardGoalDetailResponse,
+  GoalDetailKeeper,
+  GoalDetailTimelineEvent,
+  GoalTreeNode,
+  GoalTreeSummary,
+  GoalTreeTask,
+  GoalVerificationRequest,
+  GoalVerificationSummary,
+  GoalVerificationVote,
   DashboardNamespaceTruthResponse,
   DashboardShellResponse,
   BoardSortMode,
@@ -781,12 +789,302 @@ export function fetchDashboardPlanning(): Promise<DashboardPlanningResponse> {
   return get('/api/v1/dashboard/planning')
 }
 
-export function fetchDashboardGoalsTree(): Promise<DashboardGoalsTreeResponse> {
-  return get('/api/v1/dashboard/goals')
+function decodeGoalVerificationPrincipal(
+  raw: unknown,
+): GoalVerificationRequest['requested_by'] | null {
+  if (!isRecord(raw)) return null
+  const kind = asString(raw.kind)
+  const id = asString(raw.id)
+  if (!kind || !id) return null
+  return {
+    kind,
+    id,
+    display_name: asNullableString(raw.display_name),
+  }
 }
 
-export function fetchDashboardGoalDetail(goalId: string): Promise<DashboardGoalDetailResponse> {
-  return get(`/api/v1/dashboard/goals/detail?goal_id=${encodeURIComponent(goalId)}`)
+function decodeGoalVerificationPolicySnapshot(
+  raw: unknown,
+): GoalVerificationRequest['policy_snapshot'] | null {
+  if (!isRecord(raw)) return null
+  const principals = asRecordArray(raw.principals)
+    .map(decodeGoalVerificationPrincipal)
+    .filter(
+      (
+        principal,
+      ): principal is NonNullable<GoalVerificationRequest['policy_snapshot']>['principals'][number] =>
+        principal !== null,
+    )
+  const eligiblePrincipals = asRecordArray(raw.eligible_principals)
+    .map(decodeGoalVerificationPrincipal)
+    .filter(
+      (
+        principal,
+      ): principal is NonNullable<GoalVerificationRequest['policy_snapshot']>['eligible_principals'][number] =>
+        principal !== null,
+    )
+  return {
+    principals,
+    eligible_principals: eligiblePrincipals,
+    required_verdicts: asInt(raw.required_verdicts) ?? 0,
+  }
+}
+
+function decodeGoalVerificationVote(raw: unknown): GoalVerificationVote | null {
+  if (!isRecord(raw)) return null
+  const principal = decodeGoalVerificationPrincipal(raw.principal)
+  const decision = asString(raw.decision)
+  const submittedAt = asString(raw.submitted_at)
+  if (!principal || !decision || !submittedAt) return null
+  return {
+    principal,
+    decision,
+    note: asNullableString(raw.note),
+    evidence_refs: asStringArray(raw.evidence_refs),
+    submitted_at: submittedAt,
+  }
+}
+
+function decodeGoalVerificationRequest(raw: unknown): GoalVerificationRequest | null {
+  if (!isRecord(raw)) return null
+  const id = asString(raw.id)
+  const goalId = asString(raw.goal_id)
+  const targetPhase = asString(raw.target_phase)
+  const requestedBy = decodeGoalVerificationPrincipal(raw.requested_by)
+  const policySnapshot = decodeGoalVerificationPolicySnapshot(raw.policy_snapshot)
+  const status = asString(raw.status)
+  const createdAt = asString(raw.created_at)
+  if (!id || !goalId || !targetPhase || !requestedBy || !policySnapshot || !status || !createdAt) {
+    return null
+  }
+  return {
+    id,
+    goal_id: goalId,
+    target_phase: targetPhase,
+    requested_by: requestedBy,
+    policy_snapshot: policySnapshot,
+    votes: asRecordArray(raw.votes)
+      .map(decodeGoalVerificationVote)
+      .filter((vote): vote is GoalVerificationVote => vote !== null),
+    status,
+    created_at: createdAt,
+    resolved_at: asNullableString(raw.resolved_at),
+  }
+}
+
+function decodeGoalVerificationSummary(raw: unknown): GoalVerificationSummary {
+  if (!isRecord(raw)) {
+    return {
+      effective_policy: null,
+      open_request: null,
+      approve_count: 0,
+      reject_count: 0,
+      remaining_possible: 0,
+    }
+  }
+  return {
+    effective_policy: decodeGoalVerificationPolicySnapshot(raw.effective_policy),
+    open_request: decodeGoalVerificationRequest(raw.open_request),
+    approve_count: asInt(raw.approve_count) ?? 0,
+    reject_count: asInt(raw.reject_count) ?? 0,
+    remaining_possible: asInt(raw.remaining_possible) ?? 0,
+  }
+}
+
+function decodeGoalTreeTask(raw: unknown): GoalTreeTask | null {
+  if (!isRecord(raw)) return null
+  const id = asString(raw.id)
+  const title = asString(raw.title)
+  if (!id || !title) return null
+  return {
+    id,
+    title,
+    status: asString(raw.status, 'unknown'),
+    status_color: asString(raw.status_color, ''),
+    priority: asInt(raw.priority) ?? 0,
+    assignee: asNullableString(raw.assignee),
+    goal_id: asNullableString(raw.goal_id),
+    linkage_source: asString(raw.linkage_source, 'none'),
+    is_terminal: asBoolean(raw.is_terminal, false),
+    created_at: asString(raw.created_at, ''),
+    updated_at: asString(raw.updated_at, ''),
+  }
+}
+
+function decodeGoalTreeNode(raw: unknown): GoalTreeNode | null {
+  if (!isRecord(raw)) return null
+  const id = asString(raw.id)
+  const title = asString(raw.title)
+  if (!id || !title) return null
+  const tasks = asRecordArray(raw.tasks)
+    .map(decodeGoalTreeTask)
+    .filter((task): task is GoalTreeTask => task !== null)
+  const children = asRecordArray(raw.children)
+    .map(decodeGoalTreeNode)
+    .filter((node): node is GoalTreeNode => node !== null)
+  return {
+    id,
+    title,
+    horizon: asString(raw.horizon, 'unknown'),
+    status: asString(raw.status, 'unknown'),
+    status_color: asString(raw.status_color, ''),
+    phase: asString(raw.phase, 'unknown'),
+    phase_color: asString(raw.phase_color, ''),
+    health: asString(raw.health, 'on_track'),
+    health_color: asString(raw.health_color, ''),
+    badges: asStringArray(raw.badges),
+    status_reason: asString(raw.status_reason, ''),
+    priority: asInt(raw.priority) ?? 0,
+    metric: asNullableString(raw.metric),
+    target_value: asNullableString(raw.target_value),
+    due_date: asNullableString(raw.due_date),
+    parent_goal_id: asNullableString(raw.parent_goal_id),
+    convergence: asNumber(raw.convergence, 0),
+    convergence_pct: asInt(raw.convergence_pct) ?? 0,
+    tasks,
+    task_count: asInt(raw.task_count) ?? tasks.length,
+    task_done_count: asInt(raw.task_done_count) ?? 0,
+    verification_summary: decodeGoalVerificationSummary(raw.verification_summary),
+    effective_verifier_policy: decodeGoalVerificationPolicySnapshot(raw.effective_verifier_policy),
+    active_verification_request: decodeGoalVerificationRequest(raw.active_verification_request),
+    pending_verification_count: asInt(raw.pending_verification_count) ?? 0,
+    timeline_events: Array.isArray(raw.timeline_events) ? raw.timeline_events : [],
+    children,
+    child_count: asInt(raw.child_count) ?? children.length,
+    last_activity_at: asString(raw.last_activity_at, ''),
+    stagnation_seconds: asInt(raw.stagnation_seconds) ?? 0,
+    linked_keeper_names: asStringArray(raw.linked_keeper_names),
+    pending_approval_count: asInt(raw.pending_approval_count) ?? 0,
+    infra_risk_count: asInt(raw.infra_risk_count) ?? 0,
+    linkage_source: asString(raw.linkage_source, 'none'),
+    linkage_warning_count: asInt(raw.linkage_warning_count) ?? 0,
+    created_at: asString(raw.created_at, ''),
+    updated_at: asString(raw.updated_at, ''),
+  }
+}
+
+function decodeGoalTreeSummary(raw: unknown): GoalTreeSummary {
+  if (!isRecord(raw)) {
+    return {
+      total_goals: 0,
+      active_goals: 0,
+      done_goals: 0,
+      paused_goals: 0,
+      at_risk_goals: 0,
+      blocked_goals: 0,
+      total_tasks: 0,
+      done_tasks: 0,
+      pending_approvals: 0,
+      infra_risk_count: 0,
+      overall_convergence: 0,
+      overall_convergence_pct: 0,
+    }
+  }
+  return {
+    total_goals: asInt(raw.total_goals) ?? 0,
+    active_goals: asInt(raw.active_goals) ?? 0,
+    done_goals: asInt(raw.done_goals) ?? 0,
+    paused_goals: asInt(raw.paused_goals) ?? 0,
+    at_risk_goals: asInt(raw.at_risk_goals) ?? 0,
+    blocked_goals: asInt(raw.blocked_goals) ?? 0,
+    total_tasks: asInt(raw.total_tasks) ?? 0,
+    done_tasks: asInt(raw.done_tasks) ?? 0,
+    pending_approvals: asInt(raw.pending_approvals) ?? 0,
+    infra_risk_count: asInt(raw.infra_risk_count) ?? 0,
+    overall_convergence: asNumber(raw.overall_convergence, 0),
+    overall_convergence_pct: asInt(raw.overall_convergence_pct) ?? 0,
+  }
+}
+
+function decodeGoalDetailKeeper(raw: unknown): GoalDetailKeeper | null {
+  if (!isRecord(raw)) return null
+  const name = asString(raw.name)
+  const agentName = asString(raw.agent_name)
+  const sandboxProfile = asString(raw.sandbox_profile)
+  const networkMode = asString(raw.network_mode)
+  const cascadeName = asString(raw.cascade_name)
+  if (!name || !agentName || !sandboxProfile || !networkMode || !cascadeName) return null
+  return {
+    name,
+    agent_name: agentName,
+    current_task_id: asNullableString(raw.current_task_id),
+    active_goal_ids: asStringArray(raw.active_goal_ids),
+    sandbox_profile: sandboxProfile,
+    network_mode: networkMode,
+    cascade_name: cascadeName,
+    approval_profile: asNullableString(raw.approval_profile),
+    cascade_outcome: asNullableString(raw.cascade_outcome),
+    latest_execution_outcome: asNullableString(raw.latest_execution_outcome),
+    latest_execution_at: asNullableString(raw.latest_execution_at),
+    latest_receipt: isRecord(raw.latest_receipt) ? raw.latest_receipt : null,
+  }
+}
+
+function decodeGoalDetailTimelineEvent(raw: unknown): GoalDetailTimelineEvent | null {
+  if (!isRecord(raw)) return null
+  const ts = asString(raw.ts)
+  const kind = asString(raw.kind)
+  const lane = asString(raw.lane)
+  const title = asString(raw.title)
+  const summary = asString(raw.summary)
+  const severity = asString(raw.severity)
+  if (!ts || !kind || !lane || !title || !summary || !severity) return null
+  return {
+    ts,
+    kind,
+    lane,
+    title,
+    summary,
+    severity,
+  }
+}
+
+function decodeDashboardGoalsTreeResponse(raw: unknown): DashboardGoalsTreeResponse | null {
+  if (!isRecord(raw)) return null
+  const tree = asRecordArray(raw.tree)
+    .map(decodeGoalTreeNode)
+    .filter((node): node is GoalTreeNode => node !== null)
+  const summary = decodeGoalTreeSummary(raw.summary)
+  const generatedAt = asString(raw.generated_at)
+  return generatedAt
+    ? { generated_at: generatedAt, tree, summary }
+    : { tree, summary }
+}
+
+function decodeDashboardGoalDetailResponse(raw: unknown): DashboardGoalDetailResponse | null {
+  if (!isRecord(raw)) return null
+  const goal = decodeGoalTreeNode(raw.goal)
+  if (!goal) return null
+  const generatedAt = asString(raw.generated_at)
+  const decoded: DashboardGoalDetailResponse = {
+    goal,
+    linked_tasks: asRecordArray(raw.linked_tasks)
+      .map(decodeGoalTreeTask)
+      .filter((task): task is GoalTreeTask => task !== null),
+    linked_keepers: asRecordArray(raw.linked_keepers)
+      .map(decodeGoalDetailKeeper)
+      .filter((keeper): keeper is GoalDetailKeeper => keeper !== null),
+    approvals: asRecordArray(raw.approvals),
+    execution_receipts: asRecordArray(raw.execution_receipts),
+    timeline: asRecordArray(raw.timeline)
+      .map(decodeGoalDetailTimelineEvent)
+      .filter((event): event is GoalDetailTimelineEvent => event !== null),
+  }
+  return generatedAt ? { ...decoded, generated_at: generatedAt } : decoded
+}
+
+export async function fetchDashboardGoalsTree(): Promise<DashboardGoalsTreeResponse> {
+  const raw = await get<unknown>('/api/v1/dashboard/goals')
+  const decoded = decodeDashboardGoalsTreeResponse(raw)
+  if (!decoded) throw new Error('invalid dashboard goals payload')
+  return decoded
+}
+
+export async function fetchDashboardGoalDetail(goalId: string): Promise<DashboardGoalDetailResponse> {
+  const raw = await get<unknown>(`/api/v1/dashboard/goals/detail?goal_id=${encodeURIComponent(goalId)}`)
+  const decoded = decodeDashboardGoalDetailResponse(raw)
+  if (!decoded) throw new Error('invalid dashboard goal detail payload')
+  return decoded
 }
 
 // --- Tool metrics (P4 Phase 4.5) ---

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -18,6 +18,7 @@ import type {
   GoalTreeNode,
   GoalTreeTask,
   GoalTreeSummary,
+  GoalVerificationSummary,
 } from '../../types'
 import {
   horizonLabel,
@@ -199,6 +200,14 @@ const detailError = signal<string | null>(null)
 const detailTab = signal<GoalDetailTab>('summary')
 let detailRequestSeq = 0
 
+const EMPTY_GOAL_VERIFICATION_SUMMARY: GoalVerificationSummary = {
+  effective_policy: null,
+  open_request: null,
+  approve_count: 0,
+  reject_count: 0,
+  remaining_possible: 0,
+}
+
 function toggleNode(id: string) {
   const next = new Set(expandedNodes.value)
   if (next.has(id)) next.delete(id)
@@ -371,6 +380,7 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
   const isExpanded = expandedNodes.value.has(node.id)
   const hasContent = node.children.length > 0 || node.tasks.length > 0
   const isSelected = selectedGoalId.value === node.id
+  const verificationSummary = node.verification_summary ?? EMPTY_GOAL_VERIFICATION_SUMMARY
   const indent = depth * 20
   const headerBase = isSelected
     ? 'group flex items-start gap-3 rounded border border-accent/35 bg-[rgba(11,18,32,0.94)] p-3 transition-colors w-full text-left shadow-[0_0_0_1px_rgba(110,231,255,0.08)]'
@@ -429,8 +439,8 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
               </span>
             ` : null}
             ${node.child_count > 0 ? html`<span>${node.child_count} 하위 목표</span>` : null}
-            ${node.verification_summary.effective_policy ? html`
-              <span>quorum ${node.verification_summary.approve_count}/${node.verification_summary.effective_policy.required_verdicts}</span>
+            ${verificationSummary.effective_policy ? html`
+              <span>quorum ${verificationSummary.approve_count}/${verificationSummary.effective_policy.required_verdicts}</span>
             ` : null}
             ${node.pending_approval_count > 0 ? html`
               <span class="rounded border border-warn/30 bg-warn/10 px-2 py-0.5 text-3xs font-medium text-warn">
@@ -467,14 +477,14 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
 
       ${isExpanded ? html`
         <div class="mt-1.5 flex flex-col gap-1.5">
-          ${node.verification_summary.open_request ? html`
+          ${verificationSummary.open_request ? html`
             <div class="ml-6 rounded border border-amber-400/20 bg-amber-400/8 p-2 text-xs text-amber-100">
               <div class="mb-1 text-3xs font-semibold uppercase tracking-widest text-amber-200/80">Goal Verification</div>
-              <div>request ${node.verification_summary.open_request.id}</div>
+              <div>request ${verificationSummary.open_request.id}</div>
               <div>
-                quorum ${node.verification_summary.approve_count}/${node.verification_summary.open_request.policy_snapshot.required_verdicts},
-                reject ${node.verification_summary.reject_count},
-                remaining ${node.verification_summary.remaining_possible}
+                quorum ${verificationSummary.approve_count}/${verificationSummary.open_request.policy_snapshot.required_verdicts},
+                reject ${verificationSummary.reject_count},
+                remaining ${verificationSummary.remaining_possible}
               </div>
             </div>
           ` : null}
@@ -612,6 +622,7 @@ function GoalDetailPanel({
   }
 
   const detail = data?.goal.id === selectedNode.id ? data : null
+  const verificationSummary = selectedNode.verification_summary ?? EMPTY_GOAL_VERIFICATION_SUMMARY
 
   return html`
     <section class="flex flex-col gap-4 rounded border border-card-border/70 bg-[rgba(9,14,24,0.88)] p-5">
@@ -660,27 +671,27 @@ function GoalDetailPanel({
           <${DetailMetric} label="Last Activity" value=${selectedNode.stagnation_seconds > 0 ? `${Math.floor(selectedNode.stagnation_seconds / 3600)}h idle` : 'now'} tone=${selectedNode.badges.includes('stalled') ? 'warn' : 'default'} />
         </div>
 
-        ${selectedNode.verification_summary.effective_policy ? html`
+        ${verificationSummary.effective_policy ? html`
           <div class="rounded border border-card-border/60 bg-[var(--backdrop-deep)] p-4">
             <div class="mb-2 text-2xs font-semibold uppercase tracking-widest text-text-muted">Goal Verification</div>
             <div class="flex flex-wrap items-center gap-2 text-xs text-text-body">
               <span class="rounded border border-amber-400/20 bg-amber-400/8 px-2 py-1 text-amber-100">
-                quorum ${selectedNode.verification_summary.approve_count}/${selectedNode.verification_summary.effective_policy.required_verdicts}
+                quorum ${verificationSummary.approve_count}/${verificationSummary.effective_policy.required_verdicts}
               </span>
-              <span>reject ${selectedNode.verification_summary.reject_count}</span>
-              <span>remaining ${selectedNode.verification_summary.remaining_possible}</span>
+              <span>reject ${verificationSummary.reject_count}</span>
+              <span>remaining ${verificationSummary.remaining_possible}</span>
             </div>
             <div class="mt-3 flex flex-wrap gap-1.5">
-              ${selectedNode.verification_summary.effective_policy.eligible_principals.map(principal => html`
+              ${verificationSummary.effective_policy.eligible_principals.map(principal => html`
                 <span key=${`${principal.kind}:${principal.id}`} class="rounded border border-card-border/60 bg-white/4 px-2 py-0.5 text-3xs font-medium text-text-body">
                   ${principal.kind}:${principal.display_name ?? principal.id}
                 </span>
               `)}
             </div>
-            ${selectedNode.verification_summary.open_request ? html`
+            ${verificationSummary.open_request ? html`
               <div class="mt-3 rounded border border-amber-400/20 bg-amber-400/8 p-3 text-xs text-amber-100">
-                <div>request ${selectedNode.verification_summary.open_request.id}</div>
-                <div class="mt-1">status ${selectedNode.verification_summary.open_request.status}</div>
+                <div>request ${verificationSummary.open_request.id}</div>
+                <div class="mt-1">status ${verificationSummary.open_request.status}</div>
               </div>
             ` : null}
           </div>


### PR DESCRIPTION
## Summary

- Decode goal tree and goal detail payloads before exposing them to the UI, and synthesize an empty `verification_summary` when the API omits it.
- Add a renderer-side fallback in the goals tree/detail view so stale or partial payloads do not dereference `undefined`.
- Add regression tests for goal tree and goal detail payloads missing `verification_summary`.

## Product impact

- Promise affected: `ops visibility`
- User-visible change: the goal dashboard no longer throws `Cannot read properties of undefined (reading 'effective_policy')` when verification metadata is missing from the API response.

## Evidence

- `pnpm typecheck`
- `pnpm exec vitest run src/api/dashboard.test.ts src/components/goals/goal-tree.test.ts --no-file-parallelism --maxWorkers=1`

## Review evidence

- Self-review completed on the decoder and renderer fallback paths; the fix now guards both the API normalization boundary and the UI read path.
- Cross-model review not requested for this task.

## Linked issue

- Closes #
- Relates #