### PR TITLE
fix(keeper): add execution_scope to canonical TOML key names

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -628,6 +628,7 @@ let canonical_keeper_toml_key_names =
   ; "max_turns_per_call"
   ; "max_turns_per_call_scheduled_autonomous"
   ; "social_model"
+  ; "execution_scope"
   ; "cascade_name"
   ; "models"
   ]


### PR DESCRIPTION
## Problem

`execution_scope` is missing from `canonical_keeper_toml_key_names`, so keepers that declare it in their TOML produce a WARN on every autoboot/meta reload:

```
keeper TOML .../masc-improver.toml has unknown keys: keeper.execution_scope
keeper TOML .../nick0cave.toml has unknown keys: keeper.execution_scope
keeper TOML .../qa-king.toml has unknown keys: keeper.execution_scope
keeper TOML .../sangsu.toml has unknown keys: keeper.execution_scope
```

## Change

Add `\"execution_scope\"` to the canonical key list in `lib/keeper/keeper_types_profile.ml`.

## Verification

- [x] `dune build @install` passes

## Related

Follow-up to the canonical key audit in #9573.