### PR TITLE
fix(dashboard): 세션 활동 로그 시계열 정렬 및 TOOL_CALL 빈 상세 패널

### DIFF
--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -253,6 +253,11 @@ function ToolCallDetail({ event }: { event: UnifiedTraceEvent }) {
           거부: ${event.gate?.reason ?? ''}
         </div>
       ` : null}
+      ${!event.toolArgs && !resultText && !gateRejected ? html`
+        <div class="text-3xs text-[var(--text-dim)] italic px-2 py-1">
+          세부 정보가 기록되지 않았습니다.
+        </div>
+      ` : null}
       ${'' /* Metadata row */}
       ${event.cost_usd != null && event.cost_usd > 0 ? html`
         <div class="flex gap-3 text-3xs text-[var(--text-dim)]">

--- a/dashboard/src/components/session-trace/session-trace-state.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.ts
@@ -428,7 +428,8 @@ function timelineEventToTrace(evt: AgentTimelineEvent, index: number): UnifiedTr
 }
 
 function trajectoryEntryToTrace(entry: TrajectoryEntry, index: number): UnifiedTraceEvent {
-  const ts = typeof entry.ts === 'number' ? entry.ts : safeTimestamp(entry.ts_iso)
+  // Backend sends `ts` in seconds (Unix float); normalize to milliseconds for sorting.
+  const ts = typeof entry.ts === 'number' ? entry.ts * 1000 : safeTimestamp(entry.ts_iso)
 
   // Handle thinking entries (type === 'thinking')
   if (entry.type === 'thinking') {


### PR DESCRIPTION
## Summary

세션 활동 로그(\`SessionTraceView\`)에서 두 가지 버그를 수정합니다.

### 1. 시계열 정렬 오류

\`mergeTraceEvents\`가 timeline API(밀리초)와 trajectory API(초)의 \`ts\` 단위 불일치를 그대로 정렬했습니다. 결과적으로 trajectory 이벤트가 항상 timeline 이벤트보다 앞에 배치되어 실제 시간 순서와 무관하게 섞였습니다.

**Fix**: \`trajectoryEntryToTrace\`에서 백엔드가 본 \`ts\`(초)를 \`* 1000\`으로 밀리초로 정규화합니다.

### 2. TOOL_CALL 클릭 시 빈 상세 패널

\`toolArgs\`, \`toolResult\`, \`error\`가 모두 없는 trajectory 이벤트를 클릭하면 \`details\`가 열리지만 날이 텅 비어 보입니다.

**Fix**: \`ToolCallDetail\`에 fallback 메시지를 추가합니다.

## 변경 파일

- \`dashboard/src/components/session-trace/session-trace-state.ts\`
- \`dashboard/src/components/session-trace/session-trace-entry.ts\`

## 검증 방법

1. Keeper 상세 페이지 → 세션 활동 로그
2. 이벤트가 실제 시간 순서(최신 우선)로 정렬되는지 확인
3. TOOL_CALL 행을 클릭했을 때 "세부 정보가 기록되지 않았습니다" 메시지 또는 실제 상세 내용이 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)