### PR TITLE
[codex] remove legacy keeper config surface

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -268,7 +268,6 @@ describe('fetchKeeperConfig', () => {
         runtime_blocker_continue_gate: 'false',
       },
       coordination: {
-        room_scope: 'global',
         mention_targets: 'sangsu',
         joined_room_ids: 'default',
       },

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1279,7 +1279,6 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
               : null),
     },
     coordination: {
-      room_scope: asNullableString(coordination.room_scope) ?? 'current',
       mention_targets: normalizeStringList(coordination.mention_targets),
       joined_room_ids: normalizeStringList(coordination.joined_room_ids),
     },

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -114,7 +114,6 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
       presence_keepalive_sec: 30,
     },
     coordination: {
-      room_scope: 'global',
       mention_targets: ['sangsu'],
       joined_room_ids: ['default'],
     },

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -953,7 +953,6 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <span class="text-2xs text-text-body">이 keeper는 task completion_contract를 독립 실측하는 검증자 역할입니다.</span>
       </div>
       ` : null}
-      <${ConfigRow} label="프로젝트 범위" value=${c.coordination.room_scope || '--'} />
       ${c.coordination.mention_targets.length > 0 ? html`
       <div class="mt-1.5">
         <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1">멘션 대상</div>

--- a/dashboard/src/components/keeper-spawn/keeper-spawn-state.ts
+++ b/dashboard/src/components/keeper-spawn/keeper-spawn-state.ts
@@ -63,13 +63,12 @@ function formatKeeperSpawnError(message: string): string {
   return `${actor} 세션은 현재 키퍼 생성 권한이 없습니다. 이 프로젝트의 auth가 읽기 전용(default_role=reader)으로 열려 있거나 reader 토큰을 사용 중일 때 생기는 오류입니다. worker/admin Bearer token을 설정하거나 프로젝트 기본 권한을 올린 뒤 다시 시도하세요.`
 }
 
-export async function spawnKeeperFromPersona(personaName: string, opts?: { dryRun?: boolean; roomScope?: string }): Promise<void> {
+export async function spawnKeeperFromPersona(personaName: string, opts?: { dryRun?: boolean }): Promise<void> {
   spawning.value = true
   spawnResult.value = null
   try {
     const args: Record<string, unknown> = { persona_name: personaName }
     if (opts?.dryRun) args.dry_run = true
-    if (opts?.roomScope) args.room_scope = opts.roomScope
     const result = await callMcpTool('masc_keeper_create_from_persona', args)
     spawnResult.value = { success: true, message: result }
     if (!opts?.dryRun) showToast(`${personaName} 키퍼 생성 완료`, 'success')

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -879,7 +879,6 @@ interface KeeperConfigRuntime {
 }
 
 interface KeeperConfigCoordination {
-  room_scope: string
   mention_targets: string[]
   joined_room_ids: string[]
 }

--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -109,7 +109,6 @@ These may still be parsed today, but they are **not** the preferred place to enc
 | `work_discovery_*` | Compatibility-only | `keeper.toml` or runtime policy |
 | `telemetry_feedback_*` | Compatibility-only | `keeper.toml` or runtime policy |
 | `max_turns_per_call*` | Compatibility-only | `keeper.toml` |
-| `models` | Legacy / avoid | cascade config, not persona |
 
 ## 2. Keeper Declaration
 
@@ -159,7 +158,6 @@ These are still accepted by the loader, but for consistency they should be used 
 | `room_signal_prompt_enabled` | bool | Override room-signal prompt behavior |
 | `allowed_paths` | string array | Exceptional path override only; prefer empty and rely on the single sandbox root |
 | `tool_also_allow` | string array | Extra tool names added to the preset surface |
-| `also_allow` | string array | Backward-compat alias for `tool_also_allow` (will warn as "unknown key" after deprecation) |
 | `tool_denylist` | string array | Tool names blocked regardless of preset |
 | `work_discovery_enabled` | bool | Enable work discovery loop |
 | `work_discovery_sources` | string array | e.g. `["github_issues", "stale_tasks"]` |
@@ -207,6 +205,7 @@ These keys are **rejected at load time** with an `Error`. They are retained only
 
 | Field | Replacement / rationale |
 | --- | --- |
+| `also_allow` | Renamed to `tool_also_allow` in `keeper.toml`. Use `tool_access.also_allow` only inside the JSON `tool_access` object. |
 | `models`, `allowed_models`, `active_model` | Models are resolved at runtime from `cascade_name` → `cascade.json`. Do not pin per-keeper. |
 | `presence_keepalive`, `presence_keepalive_sec` | Use `paused` in runtime JSON; keepalive is managed by the keepalive fiber. |
 | `trigger_mode`, `policy_action_budget` | Removed with the legacy policy engine. |

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -802,7 +802,7 @@ materialize될 수 있지만, 정식 edit surface는 `profile.json`과 `keeper.t
 - **Canonical minimal**: `[keeper]` 테이블에 `persona_name`만. 나머지는 persona 기본값에서 해석.
 - **Overlay fields**: `goal`, `tool_preset`, `tool_also_allow`, `cascade_name`, `sandbox_profile`, `network_mode`, `shared_memory_scope` 등 배치별 override 전용.
 - **Allowed value sets**: `tool_preset ∈ {minimal, social, messaging, coding, research, delivery, full}`, `sandbox_profile ∈ {local, docker}`, `network_mode ∈ {none, inherit}`, `shared_memory_scope ∈ {disabled, room}`, `social_model ∈ {bdi_speech_v1, magentic_ledger_v1}`, `cascade_name`은 `cascade.json`에 `<name>_models` 키로 존재해야 함.
-- **Removed / hard-rejected**: `models`, `allowed_models`, `active_model`, `presence_keepalive*`, `trigger_mode`, `initiative_*`, `policy_mode`, `policy_shell_mode`. 로드 시 에러로 실패한다.
+- **Removed / hard-rejected**: `also_allow` (top-level TOML alias), `models`, `allowed_models`, `active_model`, `presence_keepalive*`, `trigger_mode`, `initiative_*`, `policy_mode`, `policy_shell_mode`. 로드 시 에러로 실패한다.
 - **Unknown keys**: canonical/removed 둘 다 아닌 key는 **boot 시 warning** 후 무시된다 (`keeper TOML <path> has unknown keys: ...`). 과거에 `room_scope`/`scope_kind` 같은 dead config가 축적된 적이 있으므로 warning을 발견하면 정리한다.
 
 Definitive source는 코드의 `canonical_keeper_toml_key_names` (`lib/keeper/keeper_types_profile.ml`)와 `removed_keeper_input_key_names` (`lib/keeper/keeper_config.ml`)다.

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -422,7 +422,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
   let strs key = Keeper_toml_loader.toml_string_list doc (k key) in
   let has key = List.mem_assoc (k key) doc in
   let removed_present =
-    removed_keeper_input_key_names
+    ("also_allow" :: removed_keeper_input_key_names)
     |> List.map k
     |> List.filter (fun key -> List.mem_assoc key doc)
   in
@@ -552,12 +552,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
           (match str "tool_preset" with
            | None -> None
            | Some raw -> normalize_tool_preset_raw raw);
-        tool_also_allow =
-          (match normalize_name_list_opt (strs "tool_also_allow") with
-           | Some _ as explicit -> explicit
-           | None ->
-               (* Backward-compat alias kept in some live keeper TOMLs. *)
-               normalize_name_list_opt (strs "also_allow"));
+        tool_also_allow = normalize_name_list_opt (strs "tool_also_allow");
         tool_denylist = normalize_name_list_opt (strs "tool_denylist");
         work_discovery_enabled = bool_ "work_discovery_enabled";
         work_discovery_sources =
@@ -573,10 +568,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
           int_ "max_turns_per_call_scheduled_autonomous";
         social_model = normalize_social_model_opt (str "social_model");
         cascade_name = normalize_cascade_name_opt (str "cascade_name");
-        models =
-          (match strs "models" with
-           | [] -> None
-           | xs -> Some xs);
+        models = None;
         oas_env = extract_oas_env_from_doc doc;
       })
     result
@@ -586,10 +578,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
     ignored by the loader, which historically let dead config accumulate
     (e.g. legacy [room_scope], [scope_kind]).  [warn_unknown_keeper_toml_keys]
     uses this list to surface drift on boot, symmetric with
-    [warn_unknown_keeper_meta_keys] on the JSON side.
-
-    [also_allow] is retained as a backward-compat alias for
-    [tool_also_allow] — see the fallback in [profile_defaults_of_toml]. *)
+    [warn_unknown_keeper_meta_keys] on the JSON side. *)
 let canonical_keeper_toml_key_names =
   [ "name"
   ; "persona_name"
@@ -617,7 +606,6 @@ let canonical_keeper_toml_key_names =
   ; "tool_access.kind"
   ; "tool_access.preset"
   ; "tool_also_allow"
-  ; "also_allow"
   ; "tool_denylist"
   ; "work_discovery_enabled"
   ; "work_discovery_sources"
@@ -629,7 +617,6 @@ let canonical_keeper_toml_key_names =
   ; "max_turns_per_call_scheduled_autonomous"
   ; "social_model"
   ; "cascade_name"
-  ; "models"
   ]
 
 (** Pure detector: returns TOML keys that [profile_defaults_of_toml] does not

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -287,7 +287,7 @@ let test_tool_policy_resync () =
 goal = "test"
 allowed_paths = ["workspace/example/project"]
 tool_preset = "social"
-also_allow = ["keeper_bash", "keeper_shell"]
+tool_also_allow = ["keeper_bash", "keeper_shell"]
 |};
   let config = Coord.default_config room_dir in
   let initial_meta =

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -511,6 +511,27 @@ models = ["llama:test"]
                 true
               with Not_found -> false))
 
+let test_profile_rejects_removed_also_allow_alias () =
+  let input = {|
+[keeper]
+goal = "test"
+also_allow = ["keeper_shell"]
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+      (match KTP.profile_defaults_of_toml doc with
+       | Ok _ -> fail "expected removed TOML alias error"
+       | Error msg ->
+           check bool "mentions removed also_allow alias" true
+             (try
+                ignore
+                  (Str.search_forward
+                     (Str.regexp_string "keeper.also_allow")
+                     msg 0);
+                true
+              with Not_found -> false))
+
 let test_profile_rejects_removed_initiative_keys () =
   let input = {|
 [keeper]
@@ -1080,7 +1101,7 @@ OAS_CODEX_SKIP_GIT = false
       check string "false → 0" "0"
         (List.assoc "OAS_CODEX_SKIP_GIT" d.oas_env)
 
-let test_detect_unknown_keys_accepts_also_allow_alias () =
+let test_detect_unknown_keys_flags_also_allow_alias () =
   let input = {|
 [keeper]
 goal = "g"
@@ -1090,7 +1111,8 @@ also_allow = ["x"]
   | Error e -> fail e
   | Ok doc ->
     let unknown = KTP.detect_unknown_keeper_toml_keys doc in
-    check (list string) "also_allow is recognized alias" [] unknown
+    check (list string) "also_allow alias is stale drift"
+      ["keeper.also_allow"] unknown
 
 (* ================================================================ *)
 (* Test suite                                                        *)
@@ -1160,8 +1182,10 @@ let () =
           test_case "full" `Quick test_profile_full;
           test_case "rejects invalid social_model" `Quick
             test_profile_rejects_invalid_social_model;
-          test_case "musician soul_profile maps to relationship" `Quick
+          test_case "rejects removed model keys" `Quick
             test_profile_rejects_removed_model_keys;
+          test_case "rejects removed also_allow alias" `Quick
+            test_profile_rejects_removed_also_allow_alias;
           test_case "rejects removed initiative keys" `Quick
             test_profile_rejects_removed_initiative_keys;
           test_case "legacy allowed_providers ignored" `Quick
@@ -1181,8 +1205,8 @@ let () =
             test_detect_unknown_keys_empty_when_all_canonical;
           test_case "flags legacy dead config" `Quick
             test_detect_unknown_keys_flags_legacy_dead_config;
-          test_case "also_allow alias accepted" `Quick
-            test_detect_unknown_keys_accepts_also_allow_alias;
+          test_case "also_allow alias flagged" `Quick
+            test_detect_unknown_keys_flags_also_allow_alias;
           test_case "oas_env keys not flagged as unknown" `Quick
             test_oas_env_not_flagged_as_unknown;
         ] );


### PR DESCRIPTION
## Summary

Remove remaining legacy keeper config surface in both the dashboard and keeper TOML handling.
The diff drops `room_scope` from dashboard config views and spawn args, removes top-level TOML `also_allow` alias acceptance, stops treating `models` as a canonical keeper TOML key, and updates docs/tests to match the stricter contract.

## Product impact

- Promise affected: `ops visibility`
- User-visible change: dashboard keeper config no longer shows stale `room_scope`; stale TOML keys like `also_allow` and `models` are rejected or surfaced as drift instead of being silently accepted.

## Evidence

- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint src`
- `pnpm exec vitest run src/components/keeper-config-panel.test.ts src/api/dashboard.test.ts src/components/keeper-spawn/keeper-spawn-state.test.ts`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/cleanup-keeper-legacy-surface test/test_keeper_toml.exe`
- `./_build/default/test/test_keeper_toml.exe`
- Additional note: `dune build @test/runtest-test_keeper_runtime_config_ssot` currently fails in this worktree with existing `no persistent meta` bootstrap failures; not addressed in this PR.

## Review evidence

- Local code review only in this pass.
- Cross-model review not requested for this change.

## Linked issue

- Closes # (not issue-driven)
- Relates # (none)
