### PR TITLE
fix(keeper): add Shell→keeper_bash alias

### DIFF
--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -13,6 +13,7 @@ let aliases : (string * string) list =
     "Edit", "keeper_fs_edit";
     "Grep", "keeper_shell";   (* op=rg routed at dispatch layer, Phase A.4 *)
     "Read", "keeper_fs_read";
+    "Shell", "keeper_bash";   (* LLM occasionally hallucinates "Shell" for bash *)
     "Write", "keeper_fs_edit"; (* create-vs-update collapsed at dispatch layer *)
   ]
 


### PR DESCRIPTION
## Problem
The Anthropic Code LLM occasionally hallucinates the tool name \"Shell\" instead of \"Bash\". When this happens on a turn that contains no other valid keeper tools, the turn validation in `keeper_agent_run.ml` hard-fails because `Shell` is not in the alias map.

## Fix
Add `"Shell", "keeper_bash"` to `Keeper_tool_alias.aliases` so that `canonicalize_observed` maps it to the internal `keeper_bash` tool, matching the existing tolerance for mixed valid+unexpected tools.

## Verification
- `dune build` passes.
- This is a follow-up to the dashboard timeline fixes in #9581.

🤖 Generated with [Claude Code](https://claude.com/claude-code)