### PR TITLE
[codex] remove stale room_scope docs

### DIFF
--- a/docs/MCP-READPATH-REVALIDATION-RUNBOOK.md
+++ b/docs/MCP-READPATH-REVALIDATION-RUNBOOK.md
@@ -29,7 +29,7 @@
 - `/api/v1/dashboard/execution`과 `/api/v1/dashboard/transport-health`의 `projection_diagnostics.cache_state`가 `fresh`다.
 - `/health.startup.pending_lazy_tasks`가 빈 배열이다.
 - keeper list `items`에 다음 필드가 존재한다.
-  - `room_scope`
+  - `joined_room_ids`
   - `proactive_enabled`
 - `keepalive_running=false` 이고 `proactive_enabled=true` 인 keeper는 `diagnostic.quiet_reason="disabled"`로 분류되지 않는다.
 

--- a/docs/design/oas-masc-state-boundary.md
+++ b/docs/design/oas-masc-state-boundary.md
@@ -54,7 +54,7 @@ State that describes the coordination domain — not how an agent thinks, but wh
 
 | Category | Data | Current Owner | Target Owner |
 |----------|------|---------------|--------------|
-| Room membership | `joined_room_ids`, `room_scope` (`current` only), agents.json | MASC | MASC (single-room compatibility state) |
+| Room membership | `joined_room_ids`, `last_seen_seq_by_room`, agents.json | MASC | MASC (single-room canonical state) |
 | Task claims | task files, `assignee`, `status` | MASC | MASC (correct) |
 | Board posts | `board_posts`, `board_comments`, `board_votes` | MASC | MASC (correct) |
 | Governance | petitions, cases, rulings, execution orders | MASC (`governance_v2`) | MASC (correct) |
@@ -94,8 +94,8 @@ So the flattened operational surface is roughly 83 fields. Approximately 29-30 o
 - `context_budget` — context window budget ratio
 
 **Domain state fields in keeper_meta (correct placement):**
-- `room_scope` (`current` only compatibility), `mention_targets`, `proactive_*` — operational coordination policy
-- `joined_room_ids`, `last_seen_seq_by_room` — current-room compatibility state (single-room canonical model)
+- `mention_targets`, `proactive_*` — operational coordination policy
+- `joined_room_ids`, `last_seen_seq_by_room` — room membership state under the single-room canonical model
 - `autonomy_level`, `active_goal_ids` — coordination state
 
 **Impact**: Every keeper turn reads the full keeper record, updates agent-runtime fields, and writes it back. This couples domain persistence (MASC JSONL/PG) with agent-runtime state that OAS should own.

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -95,7 +95,7 @@ Keeper의 전체 상태를 담는 레코드. `lib/keeper/keeper_types.ml`에 정
 - **Goal (3-horizon)**: `goal`, `short_goal`, `mid_goal`, `long_goal`
 - **Model**: `cascade_name`, `last_model_used`, derived `active_model`
 - **Capability**: `policy_voice_enabled`, `allowed_paths`
-- **Scope**: `room_scope` (`current` only compatibility field), `mention_targets`
+- **Scope**: `mention_targets`, `joined_room_ids`
 - **Proactive**: `proactive_enabled`, `proactive_idle_sec`, `proactive_cooldown_sec`
 - **Compaction**: `compaction_profile`, `compaction_ratio_gate`, `compaction_message_gate`
 - **Handoff**: `auto_handoff`, `handoff_threshold`, `handoff_cooldown_sec`
@@ -146,14 +146,11 @@ type session_context = {
 
 세션당 최대 3개 체크포인트가 유지된다(`max_checkpoints_retained = 3`). 세션 메시지는 `history.jsonl`에 영속화.
 
-### 3.4 Typed Coordination Enums (keeper_contract.ml)
+### 3.4 Coordination Boundary
 
-```ocaml
-type room_scope = Current | All  (* legacy alias retained, effective value is Current *)
-```
-
+Legacy `room_scope` typed aliases were removed during single-room flattening.
+JSON/MCP 경계에는 `mention_targets`, `joined_room_ids` 같은 coordination 값만 남고, 별도 scope enum은 더 이상 유지하지 않는다.
 `policy_mode`, `policy_shell_mode`, `trigger_mode`, `initiative_*`는 제거되었다.
-JSON/MCP 경계에는 `room_scope` 같은 coordination 값만 남는다. 다만 현재 room 모델은 single-room으로 평탄화되어 `room_scope`의 실효값은 항상 `current`다.
 
 ### 3.5 fiber_health
 


### PR DESCRIPTION
## Summary

Remove the remaining doc text that still described `room_scope` like a live keeper contract field.
The diff updates the readpath runbook, OAS state-boundary design doc, and keeper-agent spec so they describe the current single-room state shape (`joined_room_ids`, `last_seen_seq_by_room`, `mention_targets`) instead of the retired scope enum.

## Product impact

- Promise affected: `none/internal`
- User-visible change: docs and operator runbooks now match the live keeper/dashboard behavior and no longer suggest `room_scope` is still part of the active contract.

## Evidence

- `scripts/check-doc-code-refs.sh`
- `bash scripts/check-doc-truth.sh`

## Review evidence

- Local code/doc review only in this pass.
- Cross-model review not requested for this docs-only stacked follow-up.

## Linked issue

- Closes # (not issue-driven)
- Relates #9584
