### PR TITLE
[codex] fix(runtime): surface telemetry coverage gaps

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -472,17 +472,32 @@ describe('fetchRuntimeModelMetrics', () => {
           success_count: 1,
           usage_sample_count: 0,
           telemetry_sample_count: 0,
+          usage_missing_count: 1,
+          telemetry_missing_count: 1,
+          coverage_status: 'none',
+          primary_coverage_stage: 'oas',
+          primary_coverage_reason: 'missing_usage_and_inference',
+          coverage_reason_counts: [
+            { reason: 'missing_usage_and_inference', count: 1 },
+          ],
           avg_latency_ms: null,
           total_input_tokens: null,
           total_cost_usd: null,
           recent_entries: [
             {
               ts_unix: 1,
+              outcome: 'success',
+              stop_reason: 'turn_budget_exhausted(3/3)',
+              turn_lane: 'text_only',
               input_tokens: null,
               output_tokens: null,
               latency_ms: null,
               cost_usd: null,
               tools_count: 0,
+              usage_reported: false,
+              telemetry_reported: false,
+              coverage_reason: 'missing_usage_and_inference',
+              coverage_stage: 'oas',
             },
           ],
           buckets: [
@@ -515,10 +530,25 @@ describe('fetchRuntimeModelMetrics', () => {
 
     expect(metric.usage_sample_count).toBe(0)
     expect(metric.telemetry_sample_count).toBe(0)
+    expect(metric.usage_missing_count).toBe(1)
+    expect(metric.telemetry_missing_count).toBe(1)
+    expect(metric.coverage_status).toBe('none')
+    expect(metric.primary_coverage_stage).toBe('oas')
+    expect(metric.primary_coverage_reason).toBe('missing_usage_and_inference')
+    expect(metric.coverage_reason_counts).toEqual([
+      { reason: 'missing_usage_and_inference', count: 1 },
+    ])
     expect(metric.total_input_tokens).toBeNull()
     expect(metric.total_cost_usd).toBeNull()
+    expect(metric.recent_entries?.[0]?.outcome).toBe('success')
+    expect(metric.recent_entries?.[0]?.stop_reason).toBe('turn_budget_exhausted(3/3)')
+    expect(metric.recent_entries?.[0]?.turn_lane).toBe('text_only')
     expect(metric.recent_entries?.[0]?.input_tokens).toBeNull()
     expect(metric.recent_entries?.[0]?.latency_ms).toBeNull()
+    expect(metric.recent_entries?.[0]?.usage_reported).toBe(false)
+    expect(metric.recent_entries?.[0]?.telemetry_reported).toBe(false)
+    expect(metric.recent_entries?.[0]?.coverage_reason).toBe('missing_usage_and_inference')
+    expect(metric.recent_entries?.[0]?.coverage_stage).toBe('oas')
     expect(metric.buckets?.[0]?.p95_latency_ms).toBeNull()
     expect(metric.buckets?.[0]?.cache_hit_ratio).toBeNull()
   })

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -593,6 +593,12 @@ export interface DashboardRuntimeModelMetric {
   total_reasoning_tokens?: number | null
   usage_sample_count?: number | null
   telemetry_sample_count?: number | null
+  usage_missing_count?: number | null
+  telemetry_missing_count?: number | null
+  coverage_status?: 'full' | 'partial' | 'none' | 'error_only' | null
+  primary_coverage_stage?: string | null
+  primary_coverage_reason?: string | null
+  coverage_reason_counts?: Array<{ reason: string; count: number }> | null
   fallback_count?: number | null
   success_count?: number | null
   error_count?: number | null
@@ -602,6 +608,9 @@ export interface DashboardRuntimeModelMetric {
   top_tools?: Array<{ tool: string; count: number }> | null
   recent_entries?: Array<{
     ts_unix: number
+    outcome?: string | null
+    stop_reason?: string | null
+    turn_lane?: string | null
     input_tokens: number | null
     output_tokens: number | null
     latency_ms: number | null
@@ -609,6 +618,10 @@ export interface DashboardRuntimeModelMetric {
     peak_memory_gb?: number | null
     cost_usd: number | null
     tools_count: number
+    usage_reported?: boolean | null
+    telemetry_reported?: boolean | null
+    coverage_reason?: string | null
+    coverage_stage?: string | null
   }> | null
   buckets?: BucketMetric[] | null
 }
@@ -701,6 +714,17 @@ function decodeRuntimeModelMetric(raw: unknown): DashboardRuntimeModelMetric | n
     total_reasoning_tokens: asNumber(raw.total_reasoning_tokens) ?? null,
     usage_sample_count: asNumber(raw.usage_sample_count) ?? null,
     telemetry_sample_count: asNumber(raw.telemetry_sample_count) ?? null,
+    usage_missing_count: asNumber(raw.usage_missing_count) ?? null,
+    telemetry_missing_count: asNumber(raw.telemetry_missing_count) ?? null,
+    coverage_status: asNullableString(raw.coverage_status) as DashboardRuntimeModelMetric['coverage_status'],
+    primary_coverage_stage: asNullableString(raw.primary_coverage_stage),
+    primary_coverage_reason: asNullableString(raw.primary_coverage_reason),
+    coverage_reason_counts: Array.isArray(raw.coverage_reason_counts)
+      ? (raw.coverage_reason_counts as unknown[])
+          .filter(isRecord)
+          .map(item => ({ reason: asString(item.reason) ?? '', count: asNumber(item.count) ?? 0 }))
+          .filter(item => item.reason.length > 0)
+      : null,
     fallback_count: asNumber(raw.fallback_count) ?? null,
     success_count: asNumber(raw.success_count) ?? null,
     error_count: asNumber(raw.error_count) ?? null,
@@ -718,6 +742,9 @@ function decodeRuntimeModelMetric(raw: unknown): DashboardRuntimeModelMetric | n
           .filter(isRecord)
           .map(r => ({
             ts_unix: asNumber(r.ts_unix) ?? 0,
+            outcome: asNullableString(r.outcome),
+            stop_reason: asNullableString(r.stop_reason),
+            turn_lane: asNullableString(r.turn_lane),
             input_tokens: asNumber(r.input_tokens) ?? null,
             output_tokens: asNumber(r.output_tokens) ?? null,
             latency_ms: asNumber(r.latency_ms) ?? null,
@@ -725,6 +752,10 @@ function decodeRuntimeModelMetric(raw: unknown): DashboardRuntimeModelMetric | n
             peak_memory_gb: asNumber(r.peak_memory_gb) ?? null,
             cost_usd: asNumber(r.cost_usd) ?? null,
             tools_count: asNumber(r.tools_count) ?? 0,
+            usage_reported: asBoolean(r.usage_reported),
+            telemetry_reported: asBoolean(r.telemetry_reported),
+            coverage_reason: asNullableString(r.coverage_reason),
+            coverage_stage: asNullableString(r.coverage_stage),
           }))
       : null,
     buckets: Array.isArray(raw.buckets)

--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -208,12 +208,27 @@ describe('metricCoverageText', () => {
     expect(
       metricCoverageText(
         makeMetric({
+          coverage_status: 'partial',
+          primary_coverage_stage: 'oas',
+          primary_coverage_reason: 'missing_usage',
           success_count: 5,
           usage_sample_count: 0,
           telemetry_sample_count: 2,
         }),
       ),
-    ).toBe('usage 0/5 · telemetry 2/5')
+    ).toBe('coverage partial · OAS · usage missing · usage 0/5 · telemetry 2/5')
+  })
+
+  it('renders error-only windows explicitly', () => {
+    expect(
+      metricCoverageText(
+        makeMetric({
+          coverage_status: 'error_only',
+          success_count: 0,
+          error_count: 3,
+        }),
+      ),
+    ).toBe('error-only window')
   })
 })
 
@@ -298,6 +313,16 @@ describe('sortModelMetricsByUrgency', () => {
     ]
     const result = sortModelMetricsByUrgency(sample)
     expect(result.map(m => m.model_id)).toEqual(['busy', 'medium', 'idle'])
+  })
+
+  it('prioritizes coverage gaps ahead of healthy full-coverage models', () => {
+    const sample = [
+      makeMetric({ model_id: 'full', entry_count: 100, success_count: 100, coverage_status: 'full' }),
+      makeMetric({ model_id: 'partial', entry_count: 5, success_count: 5, coverage_status: 'partial' }),
+      makeMetric({ model_id: 'missing', entry_count: 2, success_count: 2, coverage_status: 'none' }),
+    ]
+    const result = sortModelMetricsByUrgency(sample)
+    expect(result.map(m => m.model_id)).toEqual(['missing', 'partial', 'full'])
   })
 
   it('falls back to model_id alpha order when everything else is equal', () => {

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -39,16 +39,20 @@ export function filterModelMetrics(
 }
 
 /**
- * Sorts model metrics so failing providers surface first. Order:
- * 1. error_count desc (a model with 11 errors appears before one with 0)
- * 2. entry_count desc (more-exercised models appear above idle ones)
- * 3. model_id asc (stable tiebreaker)
+ * Sorts model metrics so coverage gaps and failures surface first. Order:
+ * 1. coverage_status urgency (error_only → none → partial → full)
+ * 2. error_count desc
+ * 3. entry_count desc
+ * 4. model_id asc
  * Returns a new array; does not mutate the input.
  */
 export function sortModelMetricsByUrgency(
   models: readonly DashboardRuntimeModelMetric[],
 ): readonly DashboardRuntimeModelMetric[] {
   return [...models].sort((a, b) => {
+    const aCoverage = COVERAGE_PRIORITY[a.coverage_status ?? 'full'] ?? 3
+    const bCoverage = COVERAGE_PRIORITY[b.coverage_status ?? 'full'] ?? 3
+    if (aCoverage !== bCoverage) return aCoverage - bCoverage
     const ae = a.error_count ?? 0
     const be = b.error_count ?? 0
     if (ae !== be) return be - ae
@@ -62,6 +66,36 @@ export function sortModelMetricsByUrgency(
 interface RuntimeData {
   providers: DashboardRuntimeProvidersResponse | null
   metrics: DashboardRuntimeModelMetricsResponse | null
+}
+
+const COVERAGE_PRIORITY: Record<string, number> = {
+  error_only: 0,
+  none: 1,
+  partial: 2,
+  full: 3,
+}
+
+const COVERAGE_LABELS: Record<string, string> = {
+  error_only: 'error-only',
+  none: 'coverage missing',
+  partial: 'coverage partial',
+  full: 'coverage full',
+}
+
+const COVERAGE_REASON_LABELS: Record<string, string> = {
+  error_turn: 'error turn',
+  missing_usage_and_inference: 'usage/inference missing',
+  missing_usage: 'usage missing',
+  missing_inference: 'inference missing',
+  text_only_unmetered: 'text-only n/a',
+  unknown: 'unknown reason',
+}
+
+const COVERAGE_STAGE_LABELS: Record<string, string> = {
+  oas: 'OAS',
+  keeper: 'keeper',
+  projection: 'projection',
+  unknown: 'unknown stage',
 }
 
 async function loadRuntimeData(resource: ManagedAsyncResource<RuntimeData>, windowMinutes: number) {
@@ -166,13 +200,116 @@ function sumNullable(values: Array<number | null | undefined>): number | null {
   return sawNumber ? total : null
 }
 
+function coverageStatusLabel(status?: DashboardRuntimeModelMetric['coverage_status']): string | null {
+  if (!status) return null
+  return COVERAGE_LABELS[status] ?? status
+}
+
+function coverageReasonLabel(reason?: string | null): string | null {
+  if (!reason) return null
+  return COVERAGE_REASON_LABELS[reason] ?? reason
+}
+
+function coverageStageLabel(stage?: string | null): string | null {
+  if (!stage) return null
+  return COVERAGE_STAGE_LABELS[stage] ?? stage
+}
+
+function metricCoverageTone(metric: DashboardRuntimeModelMetric): string {
+  switch (metric.coverage_status) {
+    case 'full':
+      return 'ok'
+    case 'partial':
+      return 'warn'
+    case 'none':
+    case 'error_only':
+      return 'bad'
+    default:
+      return 'warn'
+  }
+}
+
+function metricMissingLabel(metric: DashboardRuntimeModelMetric): string {
+  if (metric.coverage_status === 'error_only') return 'error-only'
+  if (metric.primary_coverage_reason === 'text_only_unmetered') return 'n/a'
+  if (metric.coverage_status === 'none') return 'missing'
+  if (metric.coverage_status === 'partial') return 'partial'
+  return '--'
+}
+
+function fmtCoverageAwareNumber(
+  metric: DashboardRuntimeModelMetric,
+  value?: number | null,
+  digits = 0,
+): string {
+  const formatted = fmtNumber(value, digits)
+  return formatted !== '--' ? formatted : metricMissingLabel(metric)
+}
+
+function fmtCoverageAwareCost(metric: DashboardRuntimeModelMetric, value?: number | null): string {
+  const formatted = fmtCost(value)
+  return formatted !== '--' ? formatted : metricMissingLabel(metric)
+}
+
+function recentEntryMissingLabel(
+  entry: NonNullable<DashboardRuntimeModelMetric['recent_entries']>[number],
+): string {
+  if (entry.outcome === 'error') return 'error-only'
+  if (entry.coverage_reason === 'text_only_unmetered') return 'n/a'
+  if (entry.coverage_reason) return 'missing'
+  return '--'
+}
+
+function fmtRecentEntryNumber(
+  entry: NonNullable<DashboardRuntimeModelMetric['recent_entries']>[number],
+  value?: number | null,
+  digits = 0,
+): string {
+  const formatted = fmtNumber(value, digits)
+  return formatted !== '--' ? formatted : recentEntryMissingLabel(entry)
+}
+
+function fmtRecentEntryCost(
+  entry: NonNullable<DashboardRuntimeModelMetric['recent_entries']>[number],
+  value?: number | null,
+): string {
+  const formatted = fmtCost(value)
+  return formatted !== '--' ? formatted : recentEntryMissingLabel(entry)
+}
+
+function recentEntryDetail(
+  entry: NonNullable<DashboardRuntimeModelMetric['recent_entries']>[number],
+): string | null {
+  const parts = [
+    entry.outcome?.trim(),
+    coverageStageLabel(entry.coverage_stage),
+    coverageReasonLabel(entry.coverage_reason),
+    entry.turn_lane?.trim(),
+    entry.stop_reason?.trim(),
+  ].filter((value): value is string => Boolean(value))
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
 export function metricCoverageText(metric: DashboardRuntimeModelMetric): string | null {
+  if (metric.coverage_status === 'full' && metric.primary_coverage_reason == null) return null
+  if (metric.coverage_status === 'error_only') return 'error-only window'
   const successCount = metric.success_count ?? 0
   if (successCount <= 0) return null
   const usageCount = metric.usage_sample_count ?? 0
   const telemetryCount = metric.telemetry_sample_count ?? 0
-  if (usageCount >= successCount && telemetryCount >= successCount) return null
-  return `usage ${fmtNumber(usageCount)}/${fmtNumber(successCount)} · telemetry ${fmtNumber(telemetryCount)}/${fmtNumber(successCount)}`
+  if (
+    metric.coverage_status == null
+    && usageCount >= successCount
+    && telemetryCount >= successCount
+  ) return null
+  const parts = [
+    coverageStatusLabel(metric.coverage_status),
+    coverageStageLabel(metric.primary_coverage_stage),
+    coverageReasonLabel(metric.primary_coverage_reason),
+    `usage ${fmtNumber(usageCount)}/${fmtNumber(successCount)}`,
+    `telemetry ${fmtNumber(telemetryCount)}/${fmtNumber(successCount)}`,
+  ].filter((value): value is string => Boolean(value))
+  return parts.length > 0 ? parts.join(' · ') : null
 }
 
 export function RuntimeMonitor() {
@@ -311,8 +448,14 @@ export function RuntimeMonitor() {
           ${(metrics?.models ?? []).length > 0
             ? sortModelMetricsByUrgency(filterModelMetrics(metrics?.models ?? [], modelSearch.value)).map(metric => {
                 const isFailing = (metric.error_count ?? 0) > 0
+                const hasCoverageGap =
+                  metric.coverage_status === 'none'
+                  || metric.coverage_status === 'partial'
+                  || metric.coverage_status === 'error_only'
                 const articleClass = isFailing
                   ? 'p-4 rounded border border-[var(--status-bad)] bg-[var(--status-bad)]/5 backdrop-blur-sm shadow-sm flex flex-col gap-2'
+                  : hasCoverageGap
+                    ? 'p-4 rounded border border-[var(--status-warn)] bg-[var(--status-warn)]/5 backdrop-blur-sm shadow-sm flex flex-col gap-2'
                   : 'p-4 rounded border border-card-border bg-card/40 backdrop-blur-sm shadow-sm flex flex-col gap-2'
                 const ariaLabel = isFailing
                   ? `Provider failing: ${metric.model_id}, ${metric.error_count ?? 0} errors out of ${metric.entry_count ?? 0}`
@@ -329,18 +472,26 @@ export function RuntimeMonitor() {
                       <strong class="text-sm text-text-strong">${metric.model_id}</strong>
                       <span class="text-xs text-text-muted">entries ${fmtNumber(metric.entry_count)} · fallback ${fmtNumber(metric.fallback_count)}</span>
                       ${metricCoverageText(metric)
-                        ? html`<span class="text-2xs text-[var(--text-muted)]">${metricCoverageText(metric)}</span>`
+                        ? html`<span class="text-2xs ${hasCoverageGap ? 'text-[var(--status-warn)]' : 'text-[var(--text-muted)]'}">${metricCoverageText(metric)}</span>`
                         : null}
                     </div>
                     <div class="flex gap-2 items-center">
+                      ${metric.coverage_status
+                        ? html`<${StatusChip}
+                            label=${coverageStatusLabel(metric.coverage_status) ?? metric.coverage_status}
+                            tone=${metricCoverageTone(metric)}
+                          />`
+                        : null}
                       <${StatusChip}
                         label=${`${fmtSuccessRate(metric)}`}
                         tone=${modelMetricTone(metric)}
                       />
-                      <${StatusChip}
-                        label=${`${fmtNumber(metric.avg_tok_per_sec, 1)} tok/s wall`}
-                        tone=${'ok'}
-                      />
+                      ${metric.avg_tok_per_sec != null
+                        ? html`<${StatusChip}
+                            label=${`${fmtNumber(metric.avg_tok_per_sec, 1)} tok/s wall`}
+                            tone=${'ok'}
+                          />`
+                        : null}
                       ${metric.hw_decode_avg_tok_per_sec != null
                         ? html`<${StatusChip}
                             label=${`${fmtNumber(metric.hw_decode_avg_tok_per_sec, 1)} tok/s hw`}
@@ -356,11 +507,11 @@ export function RuntimeMonitor() {
                     </div>
                   </div>
                   <div class="grid grid-cols-3 gap-3 text-xs text-text-body">
-                    <div>latency avg/p95 · ${fmtNumber(metric.avg_latency_ms, 1)} / ${fmtNumber(metric.p95_latency_ms, 1)} ms</div>
-                    <div>wall tok/s p50/p95 · ${fmtNumber(metric.p50_tok_per_sec, 1)} / ${fmtNumber(metric.p95_tok_per_sec, 1)}</div>
-                    <div>cost · ${fmtCost(metric.total_cost_usd)}</div>
-                    <div>input/output · ${fmtNumber(metric.total_input_tokens)} / ${fmtNumber(metric.total_output_tokens)}</div>
-                    <div>reasoning/cache · ${fmtNumber(metric.total_reasoning_tokens)} / ${fmtNumber(metric.total_cache_read_tokens)}</div>
+                    <div>latency avg/p95 · ${fmtCoverageAwareNumber(metric, metric.avg_latency_ms, 1)} / ${fmtCoverageAwareNumber(metric, metric.p95_latency_ms, 1)} ms</div>
+                    <div>wall tok/s p50/p95 · ${fmtCoverageAwareNumber(metric, metric.p50_tok_per_sec, 1)} / ${fmtCoverageAwareNumber(metric, metric.p95_tok_per_sec, 1)}</div>
+                    <div>cost · ${fmtCoverageAwareCost(metric, metric.total_cost_usd)}</div>
+                    <div>input/output · ${fmtCoverageAwareNumber(metric, metric.total_input_tokens)} / ${fmtCoverageAwareNumber(metric, metric.total_output_tokens)}</div>
+                    <div>reasoning/cache · ${fmtCoverageAwareNumber(metric, metric.total_reasoning_tokens)} / ${fmtCoverageAwareNumber(metric, metric.total_cache_read_tokens)}</div>
                     <div>tools · ${fmtNumber(metric.avg_tool_calls_per_turn, 1)}/turn (${fmtNumber(metric.total_tool_calls)})</div>
                     ${metric.hw_decode_p50_tok_per_sec != null
                       ? html`<div class="col-span-3 text-text-muted">hw tok/s p50/p95 · ${fmtNumber(metric.hw_decode_p50_tok_per_sec, 1)} / ${fmtNumber(metric.hw_decode_p95_tok_per_sec, 1)} (decode-only; excludes queue/prefill/thinking)</div>`
@@ -396,7 +547,7 @@ export function RuntimeMonitor() {
                         ? cacheRead + inputTokens
                         : null
                     return html`<div class="text-2xs text-[var(--text-muted)] mt-1">
-                      cost ${fmtCost(metric.total_cost_usd)} · cache savings ${fmtPct(cacheRatio)} (${fmtNumber(cacheRead)} / ${fmtNumber(totalIn)} tokens)
+                      cost ${fmtCoverageAwareCost(metric, metric.total_cost_usd)} · cache savings ${fmtPct(cacheRatio)} (${fmtCoverageAwareNumber(metric, cacheRead)} / ${fmtCoverageAwareNumber(metric, totalIn)} tokens)
                     </div>`
                   })()}
                   ${(metric.error_count ?? 0) > 0
@@ -424,16 +575,24 @@ export function RuntimeMonitor() {
                             <div class="grid grid-cols-6 gap-1 text-3xs text-[var(--text-muted)] font-medium mb-1">
                               <div>time</div><div>in tok</div><div>out tok</div><div>latency</div><div>cost</div><div>tools</div>
                             </div>
-                            ${metric.recent_entries?.map(re => html`
-                              <div class="grid grid-cols-6 gap-1 text-2xs text-[var(--text-body)]">
-                              <div>${fmtTime(re.ts_unix)}</div>
-                              <div>${fmtNumber(re.input_tokens)}</div>
-                              <div>${fmtNumber(re.output_tokens)}</div>
-                                <div>${re.latency_ms == null ? '--' : `${fmtNumber(re.latency_ms, 0)}ms`}</div>
-                                <div>${fmtCost(re.cost_usd)}</div>
-                                <div>${re.tools_count}</div>
-                              </div>
-                            `)}
+                            ${metric.recent_entries?.map(re => {
+                              const detail = recentEntryDetail(re)
+                              return html`
+                                <div class="mb-1">
+                                  <div class="grid grid-cols-6 gap-1 text-2xs text-[var(--text-body)]">
+                                    <div>${fmtTime(re.ts_unix)}</div>
+                                    <div>${fmtRecentEntryNumber(re, re.input_tokens)}</div>
+                                    <div>${fmtRecentEntryNumber(re, re.output_tokens)}</div>
+                                    <div>${re.latency_ms == null ? recentEntryMissingLabel(re) : `${fmtNumber(re.latency_ms, 0)}ms`}</div>
+                                    <div>${fmtRecentEntryCost(re, re.cost_usd)}</div>
+                                    <div>${re.tools_count}</div>
+                                  </div>
+                                  ${detail
+                                    ? html`<div class="text-3xs text-[var(--text-muted)]">${detail}</div>`
+                                    : null}
+                                </div>
+                              `
+                            })}
                           </div>`
                         : null}
                     `

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -123,6 +123,38 @@ let visible_run_validation (result : Keeper_agent_run.run_result) :
   | Some v when v.ok && (v.evidence <> [] || v.has_file_write) -> Some v
   | _ -> None
 
+let telemetry_reported_of_result
+    (result : Keeper_agent_run.run_result) : bool =
+  Option.is_some result.inference_telemetry
+
+let structurally_unmetered_provider (provider : string) : bool =
+  List.mem provider [ "kimi_cli"; "codex_cli"; "gemini_cli" ]
+
+let coverage_reason_of_result
+    (result : Keeper_agent_run.run_result) : string option =
+  let telemetry_reported = telemetry_reported_of_result result in
+  if result.usage_reported && telemetry_reported then None
+  else
+    let provider =
+      Keeper_agent_run.surface_model_used result
+      |> Keeper_hooks_oas.provider_of_model
+    in
+    match result.usage_reported, telemetry_reported with
+    | false, false ->
+        if String.equal result.tool_surface.turn_lane "text_only"
+           && structurally_unmetered_provider provider
+        then Some "text_only_unmetered"
+        else Some "missing_usage_and_inference"
+    | false, true -> Some "missing_usage"
+    | true, false -> Some "missing_inference"
+    | true, true -> None
+
+let coverage_stage_of_result
+    (result : Keeper_agent_run.run_result) : string option =
+  if result.usage_reported && telemetry_reported_of_result result
+  then None
+  else Some "oas"
+
 let has_visible_tool_signal (result : Keeper_agent_run.run_result) : bool =
   has_substantive_tool_calls result.tools_used
   || Option.is_some (visible_run_validation result)
@@ -509,6 +541,9 @@ let append_decision_record
           match result with
           | Some r ->
               let surface_model_used = Keeper_agent_run.surface_model_used r in
+              let telemetry_reported = telemetry_reported_of_result r in
+              let coverage_reason = coverage_reason_of_result r in
+              let coverage_stage = coverage_stage_of_result r in
               let thinking_enabled_field =
                 match turn_thinking_enabled with
                 | Some b -> [("thinking_enabled", `Bool b)]
@@ -615,8 +650,19 @@ let append_decision_record
               in
               `Assoc ([
                 ("model_used", `String surface_model_used);
+                ("outcome", `String "success");
                 ("turn_count", `Int r.turn_count);
                 ("stop_reason", `String stop_reason_str);
+                ("usage_reported", `Bool r.usage_reported);
+                ("telemetry_reported", `Bool telemetry_reported);
+                ( "coverage_stage",
+                  match coverage_stage with
+                  | Some stage -> `String stage
+                  | None -> `Null );
+                ( "coverage_reason",
+                  match coverage_reason with
+                  | Some reason -> `String reason
+                  | None -> `Null );
               ] @ usage_fields @ thinking_enabled_field @ inference_fields @ cascade_fields @ tool_surface_fields)
           | None ->
               (* Partial telemetry for error turns: record what we know.
@@ -655,6 +701,10 @@ let append_decision_record
                 ("candidate_models", `List (List.map (fun s -> `String s) cascade_models));
                 ("error_category", `String error_category);
                 ("outcome", `String "error");
+                ("usage_reported", `Bool false);
+                ("telemetry_reported", `Bool false);
+                ("coverage_stage", `String "unknown");
+                ("coverage_reason", `String "error_turn");
               ] );
       ]
       @ social_fields)

--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -16,6 +16,9 @@ module IntMap = Map.Make (Int)
 type recent_entry = {
   re_ts_unix : float;
   re_provider : string option;
+  re_outcome : string;
+  re_stop_reason : string option;
+  re_turn_lane : string option;
   re_input_tokens : int option;
   re_output_tokens : int option;
   re_latency_ms : float option;
@@ -23,6 +26,15 @@ type recent_entry = {
   re_peak_memory_gb : float option;
   re_cost_usd : float option;
   re_tools_count : int;
+  re_usage_reported : bool option;
+  re_telemetry_reported : bool option;
+  re_coverage_reason : string option;
+  re_coverage_stage : string option;
+}
+
+type coverage_reason_count = {
+  crc_reason : string;
+  crc_count : int;
 }
 
 type bucket_metric = {
@@ -76,6 +88,12 @@ type model_stats = {
   total_reasoning_tokens : int option;
   usage_sample_count : int;
   telemetry_sample_count : int;
+  usage_missing_count : int;
+  telemetry_missing_count : int;
+  coverage_status : string;
+  primary_coverage_stage : string option;
+  primary_coverage_reason : string option;
+  coverage_reason_counts : coverage_reason_count list;
   fallback_count : int;
   success_count : int;
   error_count : int;
@@ -136,12 +154,27 @@ let json_int_field_opt key (fields : (string * Yojson.Safe.t) list) =
   | Some (`Int n) -> Some n
   | _ -> None
 
+let json_bool_field_opt key (fields : (string * Yojson.Safe.t) list) =
+  match List.assoc_opt key fields with
+  | Some (`Bool b) -> Some b
+  | _ -> None
+
+let json_string_field_opt key (fields : (string * Yojson.Safe.t) list) =
+  match List.assoc_opt key fields with
+  | Some (`String s) ->
+      let trimmed = String.trim s in
+      if trimmed = "" then None else Some trimmed
+  | _ -> None
+
 (* ── Parse telemetry from decisions.jsonl entries ────────── *)
 
 type raw_entry = {
   model : string;
   provider : string option;
   ts_unix : float;
+  outcome : string;
+  stop_reason : string option;
+  turn_lane : string option;
   tok_per_sec : float option;
   prompt_tok_per_sec : float option;
   (* Hardware decode rate when present in telemetry; None for legacy entries
@@ -160,6 +193,10 @@ type raw_entry = {
   cost_usd : float option;
   tool_call_count : int;
   tools_used : string list;
+  usage_reported : bool option;
+  telemetry_reported : bool option;
+  coverage_reason : string option;
+  coverage_stage : string option;
   is_error : bool;
 }
 
@@ -213,7 +250,11 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option 
                | _ -> "__error__"
            in
            let provider = provider_opt_of_fields ~model tfields in
-           Some { model; ts_unix = ts; tok_per_sec = None;
+           Some { model; ts_unix = ts;
+                  outcome = "error";
+                  stop_reason = json_string_field_opt "stop_reason" tfields;
+                  turn_lane = json_string_field_opt "turn_lane" tfields;
+                  tok_per_sec = None;
                   provider;
                   prompt_tok_per_sec = None;
                   hw_decode_tok_per_sec = None;
@@ -225,6 +266,10 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option 
                   fallback_applied = false; cost_usd = None;
                   tool_call_count = outer_tool_call_count;
                   tools_used = outer_tools_used;
+                  usage_reported = json_bool_field_opt "usage_reported" tfields;
+                  telemetry_reported = json_bool_field_opt "telemetry_reported" tfields;
+                  coverage_reason = json_string_field_opt "coverage_reason" tfields;
+                  coverage_stage = json_string_field_opt "coverage_stage" tfields;
                   is_error = true }
          else
            (* Success turns: full telemetry parsing *)
@@ -287,7 +332,38 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option 
              | Some (`Bool b) -> Some b
              | _ -> None
            in
-           Some { model; ts_unix = ts; tok_per_sec;
+           let usage_reported =
+             match json_bool_field_opt "usage_reported" tfields with
+             | Some _ as value -> value
+             | None ->
+                 if input_tokens <> None
+                    || output_tokens <> None
+                    || cache_read_tokens <> None
+                    || reasoning_tokens <> None
+                    || cost_usd <> None
+                 then Some true
+                 else None
+           in
+           let telemetry_reported =
+             match json_bool_field_opt "telemetry_reported" tfields with
+             | Some _ as value -> value
+             | None ->
+                 if tok_per_sec <> None
+                    || prompt_tok_per_sec <> None
+                    || hw_decode_tok_per_sec <> None
+                    || peak_memory_gb <> None
+                    || latency_ms <> None
+                 then Some true
+                 else None
+           in
+           Some { model; ts_unix = ts;
+                  outcome =
+                    Option.value
+                      ~default:"success"
+                      (json_string_field_opt "outcome" tfields);
+                  stop_reason = json_string_field_opt "stop_reason" tfields;
+                  turn_lane = json_string_field_opt "turn_lane" tfields;
+                  tok_per_sec;
                   provider;
                   prompt_tok_per_sec;
                   hw_decode_tok_per_sec;
@@ -297,7 +373,12 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option 
                   input_tokens; output_tokens;
                   cache_read_tokens; reasoning_tokens; fallback_applied;
                   cost_usd; tool_call_count = outer_tool_call_count;
-                  tools_used = outer_tools_used; is_error = false }
+                  tools_used = outer_tools_used;
+                  usage_reported;
+                  telemetry_reported;
+                  coverage_reason = json_string_field_opt "coverage_reason" tfields;
+                  coverage_stage = json_string_field_opt "coverage_stage" tfields;
+                  is_error = false }
        | _ -> None)
     | _ -> None
 
@@ -342,6 +423,107 @@ let read_all_decisions ~base_path ~since_unix : raw_entry list =
       | _ -> []
     ) files
 
+let usage_signal_present (entry : raw_entry) : bool =
+  entry.input_tokens <> None
+  || entry.output_tokens <> None
+  || entry.cache_read_tokens <> None
+  || entry.reasoning_tokens <> None
+  || entry.cost_usd <> None
+
+let telemetry_signal_present (entry : raw_entry) : bool =
+  entry.tok_per_sec <> None
+  || entry.prompt_tok_per_sec <> None
+  || entry.hw_decode_tok_per_sec <> None
+  || entry.peak_memory_gb <> None
+  || entry.latency_ms <> None
+
+let usage_reported_effective (entry : raw_entry) : bool =
+  match entry.usage_reported with
+  | Some reported -> reported
+  | None -> usage_signal_present entry
+
+let telemetry_reported_effective (entry : raw_entry) : bool =
+  match entry.telemetry_reported with
+  | Some reported -> reported
+  | None -> telemetry_signal_present entry
+
+let coverage_reason_of_entry (entry : raw_entry) : string option =
+  if entry.is_error then Some "error_turn"
+  else
+    match entry.coverage_reason with
+    | Some _ as reason -> reason
+    | None ->
+        let usage_reported = usage_reported_effective entry in
+        let telemetry_reported = telemetry_reported_effective entry in
+        match usage_reported, telemetry_reported with
+        | true, true -> None
+        | false, false -> Some "missing_usage_and_inference"
+        | false, true -> Some "missing_usage"
+        | true, false -> Some "missing_inference"
+
+let coverage_stage_of_entry (entry : raw_entry) : string option =
+  match entry.coverage_stage with
+  | Some _ as stage -> stage
+  | None ->
+      if entry.is_error then Some "unknown"
+      else
+        match entry.usage_reported, entry.telemetry_reported with
+        | Some false, _
+        | _, Some false -> Some "oas"
+        | _ ->
+            match coverage_reason_of_entry entry with
+            | Some _ -> Some "unknown"
+            | None -> None
+
+let coverage_reason_counts_of_entries
+    (entries : raw_entry list) : coverage_reason_count list =
+  let counts =
+    List.fold_left (fun acc entry ->
+      match coverage_reason_of_entry entry with
+      | Some reason when not entry.is_error ->
+          let prev =
+            match StringMap.find_opt reason acc with
+            | Some count -> count
+            | None -> 0
+          in
+          StringMap.add reason (prev + 1) acc
+      | _ -> acc
+    ) StringMap.empty entries
+  in
+  StringMap.bindings counts
+  |> List.map (fun (reason, count) ->
+       { crc_reason = reason; crc_count = count })
+  |> List.sort (fun a b ->
+       let by_count = compare b.crc_count a.crc_count in
+       if by_count <> 0 then by_count
+       else compare a.crc_reason b.crc_reason)
+
+let most_common_stage_of_entries (entries : raw_entry list) : string option =
+  let counts =
+    List.fold_left (fun acc entry ->
+      match coverage_stage_of_entry entry, coverage_reason_of_entry entry with
+      | Some stage, Some _ when not entry.is_error ->
+          let prev =
+            match StringMap.find_opt stage acc with
+            | Some count -> count
+            | None -> 0
+          in
+          StringMap.add stage (prev + 1) acc
+      | _ -> acc
+    ) StringMap.empty entries
+  in
+  match StringMap.bindings counts with
+  | [] -> None
+  | bindings ->
+      bindings
+      |> List.sort (fun (stage_a, count_a) (stage_b, count_b) ->
+           let by_count = compare count_b count_a in
+           if by_count <> 0 then by_count
+           else compare stage_a stage_b)
+      |> List.hd
+      |> fst
+      |> fun stage -> Some stage
+
 (* ── Aggregate by model ─────────────────────────────────── *)
 
 let aggregate_by_model (entries : raw_entry list) : model_stats list =
@@ -352,56 +534,78 @@ let aggregate_by_model (entries : raw_entry list) : model_stats list =
     ) StringMap.empty entries in
   StringMap.fold (fun model_id entries acc ->
     let n = List.length entries in
-    let tok_vals = List.filter_map (fun e -> e.tok_per_sec) entries |> Array.of_list in
+    let success_entries = List.filter (fun e -> not e.is_error) entries in
+    let tok_vals =
+      List.filter_map (fun e -> e.tok_per_sec) success_entries
+      |> Array.of_list
+    in
     Array.sort Float.compare tok_vals;
     let prompt_vals =
-      List.filter_map (fun e -> e.prompt_tok_per_sec) entries
+      List.filter_map (fun e -> e.prompt_tok_per_sec) success_entries
       |> Array.of_list
     in
     Array.sort Float.compare prompt_vals;
-    let hw_vals = List.filter_map (fun e -> e.hw_decode_tok_per_sec) entries
-                  |> Array.of_list in
+    let hw_vals =
+      List.filter_map (fun e -> e.hw_decode_tok_per_sec) success_entries
+      |> Array.of_list
+    in
     Array.sort Float.compare hw_vals;
     let peak_vals =
-      List.filter_map (fun e -> e.peak_memory_gb) entries
+      List.filter_map (fun e -> e.peak_memory_gb) success_entries
       |> Array.of_list
     in
     Array.sort Float.compare peak_vals;
-    let lat_vals = List.filter_map (fun e -> e.latency_ms) entries |> Array.of_list in
+    let lat_vals =
+      List.filter_map (fun e -> e.latency_ms) success_entries
+      |> Array.of_list
+    in
     Array.sort Float.compare lat_vals;
-    let success_count = List.length (List.filter (fun e -> not e.is_error) entries) in
+    let success_count = List.length success_entries in
     let error_count = List.length (List.filter (fun e -> e.is_error) entries) in
     let total_tool_calls = List.fold_left (fun acc e -> acc + e.tool_call_count) 0 entries in
     let usage_sample_count =
       List.fold_left
         (fun acc e ->
-          if e.input_tokens <> None
-             || e.output_tokens <> None
-             || e.cache_read_tokens <> None
-             || e.reasoning_tokens <> None
-             || e.cost_usd <> None
+          if usage_signal_present e
           then acc + 1
           else acc)
-        0 entries
+        0 success_entries
     in
     let telemetry_sample_count =
       List.fold_left
         (fun acc e ->
-          if e.tok_per_sec <> None
-             || e.prompt_tok_per_sec <> None
-             || e.hw_decode_tok_per_sec <> None
-             || e.peak_memory_gb <> None
-             || e.latency_ms <> None
+          if telemetry_signal_present e
           then acc + 1
           else acc)
-        0 entries
+        0 success_entries
+    in
+    let usage_missing_count = max 0 (success_count - usage_sample_count) in
+    let telemetry_missing_count = max 0 (success_count - telemetry_sample_count) in
+    let coverage_reason_counts =
+      coverage_reason_counts_of_entries success_entries
+    in
+    let primary_coverage_reason =
+      match coverage_reason_counts with
+      | first :: _ -> Some first.crc_reason
+      | [] -> None
+    in
+    let primary_coverage_stage =
+      most_common_stage_of_entries success_entries
+    in
+    let coverage_status =
+      if success_count = 0 && error_count > 0 then "error_only"
+      else if usage_missing_count = 0 && telemetry_missing_count = 0 then "full"
+      else if usage_sample_count = 0 && telemetry_sample_count = 0 then "none"
+      else "partial"
     in
     (* thinking_fraction: count of entries with thinking_enabled=true over
        entries that reported the field. Entries without the field (older jsonl
        rows, providers that don't expose it) are excluded from denominator —
        None when no reporter at all. *)
     let thinking_fraction =
-      let reported = List.filter_map (fun e -> e.thinking_enabled) entries in
+      let reported =
+        List.filter_map (fun e -> e.thinking_enabled) success_entries
+      in
       match reported with
       | [] -> None
       | xs ->
@@ -434,18 +638,27 @@ let aggregate_by_model (entries : raw_entry list) : model_stats list =
       avg_latency_ms = average_opt lat_vals;
       p50_latency_ms = percentile_opt lat_vals 50.0;
       p95_latency_ms = percentile_opt lat_vals 95.0;
-      total_input_tokens = sum_int_opt (List.filter_map (fun e -> e.input_tokens) entries);
-      total_output_tokens = sum_int_opt (List.filter_map (fun e -> e.output_tokens) entries);
+      total_input_tokens =
+        sum_int_opt (List.filter_map (fun e -> e.input_tokens) success_entries);
+      total_output_tokens =
+        sum_int_opt (List.filter_map (fun e -> e.output_tokens) success_entries);
       total_cache_read_tokens =
-        sum_int_opt (List.filter_map (fun e -> e.cache_read_tokens) entries);
+        sum_int_opt (List.filter_map (fun e -> e.cache_read_tokens) success_entries);
       total_reasoning_tokens =
-        sum_int_opt (List.filter_map (fun e -> e.reasoning_tokens) entries);
+        sum_int_opt (List.filter_map (fun e -> e.reasoning_tokens) success_entries);
       usage_sample_count;
       telemetry_sample_count;
+      usage_missing_count;
+      telemetry_missing_count;
+      coverage_status;
+      primary_coverage_stage;
+      primary_coverage_reason;
+      coverage_reason_counts;
       fallback_count = List.length (List.filter (fun e -> e.fallback_applied) entries);
       success_count;
       error_count;
-      total_cost_usd = sum_float_opt (List.filter_map (fun e -> e.cost_usd) entries);
+      total_cost_usd =
+        sum_float_opt (List.filter_map (fun e -> e.cost_usd) success_entries);
       total_tool_calls;
       avg_tool_calls_per_turn =
         if n = 0 then 0.0
@@ -463,13 +676,15 @@ let aggregate_by_model (entries : raw_entry list) : model_stats list =
         |> List.sort (fun (_, a) (_, b) -> compare b a)
         |> (fun l -> if List.length l > 10 then List.filteri (fun i _ -> i < 10) l else l));
       recent_entries =
-        entries
-        |> List.filter (fun e -> not e.is_error)
+        success_entries
         |> List.sort (fun a b -> Float.compare b.ts_unix a.ts_unix)
         |> (fun l -> if List.length l > 5 then List.filteri (fun i _ -> i < 5) l else l)
         |> List.map (fun e -> {
           re_ts_unix = e.ts_unix;
           re_provider = e.provider;
+          re_outcome = e.outcome;
+          re_stop_reason = e.stop_reason;
+          re_turn_lane = e.turn_lane;
           re_input_tokens = e.input_tokens;
           re_output_tokens = e.output_tokens;
           re_latency_ms = e.latency_ms;
@@ -477,6 +692,10 @@ let aggregate_by_model (entries : raw_entry list) : model_stats list =
           re_peak_memory_gb = e.peak_memory_gb;
           re_cost_usd = e.cost_usd;
           re_tools_count = e.tool_call_count;
+          re_usage_reported = e.usage_reported;
+          re_telemetry_reported = e.telemetry_reported;
+          re_coverage_reason = coverage_reason_of_entry e;
+          re_coverage_stage = coverage_stage_of_entry e;
         });
       buckets = [];
     } in
@@ -642,6 +861,17 @@ let model_stats_to_json (s : model_stats) : Yojson.Safe.t =
     ; ("total_reasoning_tokens", opt_int s.total_reasoning_tokens)
     ; ("usage_sample_count", `Int s.usage_sample_count)
     ; ("telemetry_sample_count", `Int s.telemetry_sample_count)
+    ; ("usage_missing_count", `Int s.usage_missing_count)
+    ; ("telemetry_missing_count", `Int s.telemetry_missing_count)
+    ; ("coverage_status", `String s.coverage_status)
+    ; ("primary_coverage_stage", opt_string s.primary_coverage_stage)
+    ; ("primary_coverage_reason", opt_string s.primary_coverage_reason)
+    ; ("coverage_reason_counts", `List (List.map (fun (c : coverage_reason_count) ->
+        `Assoc [
+          ("reason", `String c.crc_reason);
+          ("count", `Int c.crc_count);
+        ]
+      ) s.coverage_reason_counts))
     ; ("fallback_count", `Int s.fallback_count)
     ; ("success_count", `Int s.success_count)
     ; ("error_count", `Int s.error_count)
@@ -655,6 +885,9 @@ let model_stats_to_json (s : model_stats) : Yojson.Safe.t =
         `Assoc [
           ("ts_unix", `Float r.re_ts_unix);
           ("provider", opt_string r.re_provider);
+          ("outcome", `String r.re_outcome);
+          ("stop_reason", opt_string r.re_stop_reason);
+          ("turn_lane", opt_string r.re_turn_lane);
           ("input_tokens", opt_int r.re_input_tokens);
           ("output_tokens", opt_int r.re_output_tokens);
           ("latency_ms", opt_float r.re_latency_ms);
@@ -662,6 +895,12 @@ let model_stats_to_json (s : model_stats) : Yojson.Safe.t =
           ("peak_memory_gb", opt_float r.re_peak_memory_gb);
           ("cost_usd", opt_float r.re_cost_usd);
           ("tools_count", `Int r.re_tools_count);
+          ("usage_reported",
+            match r.re_usage_reported with Some value -> `Bool value | None -> `Null);
+          ("telemetry_reported",
+            match r.re_telemetry_reported with Some value -> `Bool value | None -> `Null);
+          ("coverage_reason", opt_string r.re_coverage_reason);
+          ("coverage_stage", opt_string r.re_coverage_stage);
         ]
       ) s.recent_entries))
     ; ("buckets", `List (List.map bucket_metric_to_json s.buckets))

--- a/lib/model_inference_metrics.mli
+++ b/lib/model_inference_metrics.mli
@@ -9,6 +9,9 @@
 type recent_entry = {
   re_ts_unix : float;
   re_provider : string option;
+  re_outcome : string;
+  re_stop_reason : string option;
+  re_turn_lane : string option;
   re_input_tokens : int option;
   re_output_tokens : int option;
   re_latency_ms : float option;
@@ -16,6 +19,15 @@ type recent_entry = {
   re_peak_memory_gb : float option;
   re_cost_usd : float option;
   re_tools_count : int;
+  re_usage_reported : bool option;
+  re_telemetry_reported : bool option;
+  re_coverage_reason : string option;
+  re_coverage_stage : string option;
+}
+
+type coverage_reason_count = {
+  crc_reason : string;
+  crc_count : int;
 }
 
 type bucket_metric = {
@@ -70,6 +82,12 @@ type model_stats = {
   total_reasoning_tokens : int option;
   usage_sample_count : int;
   telemetry_sample_count : int;
+  usage_missing_count : int;
+  telemetry_missing_count : int;
+  coverage_status : string;
+  primary_coverage_stage : string option;
+  primary_coverage_reason : string option;
+  coverage_reason_counts : coverage_reason_count list;
   fallback_count : int;
   success_count : int;
   error_count : int;

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2215,7 +2215,17 @@ let test_append_decision_record_nulls_unreported_usage () =
       check bool "cost_usd null when usage unreported" true
         (match telemetry |> member "cost_usd" with `Null -> true | _ -> false);
       check bool "tokens_per_second null when usage unreported" true
-        (match telemetry |> member "tokens_per_second" with `Null -> true | _ -> false))
+        (match telemetry |> member "tokens_per_second" with `Null -> true | _ -> false);
+      check string "outcome persisted" "success"
+        (telemetry |> member "outcome" |> to_string);
+      check bool "usage_reported false persisted" false
+        (telemetry |> member "usage_reported" |> to_bool);
+      check bool "telemetry_reported false persisted" false
+        (telemetry |> member "telemetry_reported" |> to_bool);
+      check string "coverage stage persisted" "oas"
+        (telemetry |> member "coverage_stage" |> to_string);
+      check string "coverage reason persisted" "missing_usage_and_inference"
+        (telemetry |> member "coverage_reason" |> to_string))
 
 let test_run_keeper_cycle_skips_non_executable_phase () =
   Eio_main.run @@ fun env ->

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -95,11 +95,32 @@ let error_entry ~cascade_name ~ts ?provider () =
     ]);
   ]
 
-let success_entry_without_usage ~model ~ts ?provider () =
+let success_entry_without_usage ~model ~ts ?provider
+    ?(telemetry_reported = false)
+    ?(coverage_reason = "missing_usage_and_inference")
+    ?(coverage_stage = "oas")
+    ?turn_lane
+    ?stop_reason
+    () =
   let extra_fields =
     match provider with
     | Some value -> [ ("provider", `String value) ]
     | None -> []
+  in
+  let diag_fields =
+    [ ("usage_reported", `Bool false)
+    ; ("telemetry_reported", `Bool telemetry_reported)
+    ; ("coverage_reason", `String coverage_reason)
+    ; ("coverage_stage", `String coverage_stage)
+    ]
+    @
+    (match turn_lane with
+     | Some value -> [ ("turn_lane", `String value) ]
+     | None -> [])
+    @
+    (match stop_reason with
+     | Some value -> [ ("stop_reason", `String value) ]
+     | None -> [])
   in
   `Assoc [
     ("ts_unix", `Float ts);
@@ -107,8 +128,9 @@ let success_entry_without_usage ~model ~ts ?provider () =
     ("tools_used", `List []);
     ("telemetry", `Assoc ([
       ("model_used", `String model);
+      ("outcome", `String "success");
       ("fallback_applied", `Bool false);
-    ] @ extra_fields));
+    ] @ extra_fields @ diag_fields));
   ]
 
 (* ── Tests ───────────────────────────────────────── *)
@@ -355,6 +377,75 @@ let test_missing_usage_serializes_unknowns () =
     check bool "recent json input null" true
       (match recent_json |> member "input_tokens" with `Null -> true | _ -> false))
 
+let test_coverage_diagnostics_survive_aggregation () =
+  let base = test_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+    let path = make_keeper_dir base "coverage_diag" in
+    let ts = now_unix () in
+    write_decisions path [
+      success_entry_without_usage ~model:"glm-coding-plan:glm-5"
+        ~ts:(ts -. 5.0)
+        ~provider:"glm-coding"
+        ~turn_lane:"text_only"
+        ~stop_reason:"turn_budget_exhausted(3/3)"
+        ();
+    ];
+    let agg = M.compute ~base_path:base ~window_minutes:60 in
+    let s = List.hd agg.models in
+    check string "coverage status" "none" s.coverage_status;
+    check int "usage missing count" 1 s.usage_missing_count;
+    check int "telemetry missing count" 1 s.telemetry_missing_count;
+    check (option string) "primary coverage reason"
+      (Some "missing_usage_and_inference")
+      s.primary_coverage_reason;
+    check (option string) "primary coverage stage"
+      (Some "oas")
+      s.primary_coverage_stage;
+    check int "coverage reason counts" 1 (List.length s.coverage_reason_counts);
+    let recent = List.hd s.recent_entries in
+    check string "recent outcome" "success" recent.re_outcome;
+    check (option string) "recent stop reason"
+      (Some "turn_budget_exhausted(3/3)")
+      recent.re_stop_reason;
+    check (option string) "recent turn lane"
+      (Some "text_only")
+      recent.re_turn_lane;
+    check (option bool) "recent usage_reported"
+      (Some false) recent.re_usage_reported;
+    check (option bool) "recent telemetry_reported"
+      (Some false) recent.re_telemetry_reported;
+    check (option string) "recent coverage reason"
+      (Some "missing_usage_and_inference")
+      recent.re_coverage_reason;
+    check (option string) "recent coverage stage"
+      (Some "oas")
+      recent.re_coverage_stage;
+    let json = M.to_json agg in
+    let open Yojson.Safe.Util in
+    let m = json |> member "models" |> to_list |> List.hd in
+    check string "json coverage status" "none"
+      (m |> member "coverage_status" |> to_string);
+    check int "json usage missing count" 1
+      (m |> member "usage_missing_count" |> to_int);
+    check int "json telemetry missing count" 1
+      (m |> member "telemetry_missing_count" |> to_int);
+    check string "json primary coverage reason"
+      "missing_usage_and_inference"
+      (m |> member "primary_coverage_reason" |> to_string);
+    check string "json primary coverage stage"
+      "oas"
+      (m |> member "primary_coverage_stage" |> to_string);
+    let reason_counts = m |> member "coverage_reason_counts" |> to_list in
+    check int "json reason count length" 1 (List.length reason_counts);
+    check string "json reason count reason"
+      "missing_usage_and_inference"
+      (List.hd reason_counts |> member "reason" |> to_string);
+    let recent_json = m |> member "recent_entries" |> to_list |> List.hd in
+    check string "recent json outcome" "success"
+      (recent_json |> member "outcome" |> to_string);
+    check string "recent json stage" "oas"
+      (recent_json |> member "coverage_stage" |> to_string))
+
 (* ── thinking_fraction tests ─────────────────────── *)
 
 let success_entry_with_thinking ~model ~ts ~thinking_enabled () =
@@ -548,6 +639,7 @@ let () =
       test_case "recent entries capped" `Quick test_recent_entries;
       test_case "prompt tps and peak memory aggregates" `Quick test_prompt_tps_and_peak_memory_aggregates;
       test_case "missing usage serializes unknowns" `Quick test_missing_usage_serializes_unknowns;
+      test_case "coverage diagnostics survive aggregation" `Quick test_coverage_diagnostics_survive_aggregation;
       test_case "json roundtrip" `Quick test_json_roundtrip;
     ];
     "thinking_fraction", [


### PR DESCRIPTION
## What changed
- preserve runtime telemetry coverage provenance in keeper decision records by recording outcome, usage/telemetry presence, coverage stage, and coverage reason
- extend model metrics aggregation and API payloads with coverage status, missing counts, reason histograms, and richer recent-entry diagnostics
- update the runtime monitor UI to surface coverage gaps explicitly instead of rendering null-heavy metrics as indistinguishable `--`

## Why
Successful OAS or keeper turns could reach the dashboard without enough usage or inference telemetry to explain why metrics were blank. The API and UI collapsed those cases into nulls, so operators could not tell whether data was missing at OAS, lost in keeper wiring, structurally unavailable, or simply error-only.

## Impact
- operators can distinguish `full`, `partial`, `none`, and `error-only` model windows
- recent turns expose outcome, stage, reason, turn lane, and stop reason for null-heavy rows
- backend payloads now carry enough provenance to audit where telemetry stopped flowing

## Validation
- `dune build`
- `./_build/default/test/test_model_inference_metrics.exe`
- `dashboard/node_modules/.bin/vitest run src/components/runtime-monitor.test.ts src/api/dashboard.test.ts`
- `dashboard/node_modules/.bin/tsc --noEmit --pretty -p dashboard/tsconfig.json`

## Notes
- `./_build/default/test/test_keeper_unified.exe` still reports an existing unrelated failure in `phase_gate` (`paused-state sync surfaces write failure`); the telemetry-specific keeper test coverage added in this change passed.
