### PR TITLE
[codex] Restore broken sandbox clone checkouts before worktree create

### DIFF
--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -129,6 +129,94 @@ let is_git_clone candidate =
   | `Directory | `File -> true
   | `Missing -> false
 
+let run_git_in_clone clone_path args =
+  run_argv_with_status ([ "git"; "-C"; clone_path; "--no-optional-locks" ] @ args)
+
+let trim_output_detail output =
+  let detail = String.trim output in
+  if detail = "" then "(no output)" else detail
+
+let first_nul_field output =
+  match String.index_opt output '\x00' with
+  | Some idx when idx > 0 -> Some (String.sub output 0 idx)
+  | Some _ -> None
+  | None ->
+      let trimmed = String.trim output in
+      if trimmed = "" then None else Some trimmed
+
+type sandbox_clone_state =
+  | Ready
+  | Needs_checkout of string
+  | Broken_git of string
+
+let inspect_sandbox_clone candidate =
+  let inside_status, inside_output =
+    run_git_in_clone candidate [ "rev-parse"; "--is-inside-work-tree" ]
+  in
+  if inside_status <> Unix.WEXITED 0 then
+    Broken_git
+      (Printf.sprintf "git rev-parse failed: %s"
+         (trim_output_detail inside_output))
+  else
+    let tracked_status, tracked_output =
+      run_git_in_clone candidate [ "ls-files"; "-z" ]
+    in
+    if tracked_status <> Unix.WEXITED 0 then
+      Broken_git
+        (Printf.sprintf "git ls-files failed: %s"
+           (trim_output_detail tracked_output))
+    else
+      match first_nul_field tracked_output with
+      | None -> Ready
+      | Some relpath ->
+          if safe_file_exists (Filename.concat candidate relpath) then Ready
+          else Needs_checkout relpath
+
+let restore_sandbox_clone_checkout candidate =
+  let checkout_status, checkout_output =
+    run_git_in_clone candidate [ "checkout"; "-f"; "HEAD"; "--"; "." ]
+  in
+  if checkout_status <> Unix.WEXITED 0 then
+    Error
+      (IoError
+         (Printf.sprintf
+            "sandbox_clone_checkout_restore_failed: could not restore tracked \
+             files in %s: %s"
+            candidate (trim_output_detail checkout_output)))
+  else
+    match inspect_sandbox_clone candidate with
+    | Ready ->
+        Ok
+          (Some
+             "Existing sandbox clone checkout was restored from HEAD before \
+              worktree creation.")
+    | Needs_checkout relpath ->
+        Error
+          (IoError
+             (Printf.sprintf
+                "sandbox_clone_checkout_restore_failed: %s is still missing \
+                 tracked path %s after checkout."
+                candidate relpath))
+    | Broken_git detail ->
+        Error
+          (IoError
+             (Printf.sprintf
+                "sandbox_clone_checkout_restore_failed: %s is still not a \
+                 usable git clone after checkout: %s"
+                candidate detail))
+
+let ensure_sandbox_clone_ready candidate =
+  match inspect_sandbox_clone candidate with
+  | Ready -> Ok None
+  | Needs_checkout _ -> restore_sandbox_clone_checkout candidate
+  | Broken_git detail ->
+      Error
+        (IoError
+           (Printf.sprintf
+              "sandbox_clone_invalid: %s has a .git marker but is not a usable \
+               git clone: %s"
+              candidate detail))
+
 let keeper_toml_path ~config ~agent_name =
   let keeper_name = Playground_paths.sanitize_keeper_name agent_name in
   Filename.concat
@@ -321,7 +409,9 @@ let auto_provision_sandbox_clone ~config ~agent_name ~repos_dir ~repo_name =
       Fs_compat.mkdir_p repos_dir;
       let clone_path = Filename.concat repos_dir repo_name in
       if safe_file_exists clone_path then
-        if is_git_clone clone_path then Ok (clone_path, None)
+        if is_git_clone clone_path then
+          ensure_sandbox_clone_ready clone_path
+          |> Result.map (fun repair_note -> (clone_path, repair_note))
         else
           Error
             (IoError
@@ -436,7 +526,9 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
         | Some name when not (safe_repo_name name) -> None
         | Some name ->
           let candidate = Filename.concat repos_dir name in
-          if is_git_clone candidate then Some candidate else None
+          if is_git_clone candidate
+          then Some (ensure_sandbox_clone_ready candidate |> Result.map (fun note -> (candidate, note)))
+          else None
       in
       let scan_first_git_repo dir =
         if not (safe_is_dir dir) then None
@@ -450,7 +542,10 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
             else
               let candidate = Filename.concat dir entries.(i) in
               if is_git_clone candidate
-              then Some candidate
+              then
+                Some
+                  (ensure_sandbox_clone_ready candidate
+                   |> Result.map (fun note -> (candidate, note)))
               else find (i + 1)
           in
           find 0
@@ -458,13 +553,13 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
       match repo_name with
       | Some name when String.trim name <> "" && safe_repo_name name -> (
           match explicit_repo with
-          | Some clone -> Ok (clone, None)
+          | Some result -> result
           | None ->
               auto_provision_sandbox_clone ~config ~agent_name ~repos_dir
                 ~repo_name:name)
       | _ -> (
           match scan_first_git_repo repos_dir with
-          | Some clone -> Ok (clone, None)
+          | Some result -> result
           | None ->
               Error
                 (missing_sandbox_clone_error ~agent_name ~repos_dir ~repo_name))

--- a/test/test_tool_worktree_coverage.ml
+++ b/test/test_tool_worktree_coverage.ml
@@ -67,6 +67,21 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
+let rec rm_path path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then (
+      Array.iter (fun name -> rm_path (Filename.concat path name))
+        (Sys.readdir path);
+      Unix.rmdir path)
+    else
+      Unix.unlink path
+
+let clear_checkout_but_keep_git_dir repo =
+  Array.iter
+    (fun name ->
+       if name <> ".git" then rm_path (Filename.concat repo name))
+    (Sys.readdir repo)
+
 let rec ensure_dir path =
   if path = "" || path = "." || path = "/" then ()
   else if Sys.file_exists path then ()
@@ -496,6 +511,57 @@ let test_dispatch_worktree_create_and_remove_use_docker_keeper_lane () =
           check bool "docker worktree removed" false
             (Sys.file_exists docker_worktree)
 
+let test_dispatch_worktree_create_repairs_existing_sandbox_clone_checkout () =
+  let base_path = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  init_process_eio env;
+  run_ok ~cwd:base_path "git init -q -b main";
+  let source_repo =
+    setup_nested_repo_with_remote ~base_path
+      ~repo_rel:"workspace/yousleepwhen/masc-mcp"
+  in
+  write_keeper_toml ~base_path ~name:"sangsu" ~sandbox_profile:"docker";
+  let sandbox_repos =
+    Filename.concat base_path ".masc/playground/docker/sangsu/repos"
+  in
+  ensure_dir sandbox_repos;
+  let sandbox_clone = Filename.concat sandbox_repos "masc-mcp" in
+  run_ok ~cwd:base_path
+    (Printf.sprintf "git clone -q %s %s"
+       (Filename.quote source_repo) (Filename.quote sandbox_clone));
+  clear_checkout_but_keep_git_dir sandbox_clone;
+  let config = Masc_mcp.Coord.default_config base_path in
+  ignore (Masc_mcp.Coord.init config ~agent_name:(Some "sangsu"));
+  let ctx : Tool_worktree.context = { config; agent_name = "sangsu" } in
+  let task_id = "task-restore-clone" in
+  let args = `Assoc [
+    ("task_id", `String task_id);
+    ("repo_name", `String "masc-mcp");
+    ("base_branch", `String "main");
+  ] in
+  let restored_readme = Filename.concat sandbox_clone "README.md" in
+  let docker_worktree =
+    Filename.concat sandbox_clone
+      (Filename.concat ".worktrees"
+         (Playground_paths.worktree_dir_name "sangsu" task_id))
+  in
+  match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
+  | None -> fail "dispatch returned None for masc_worktree_create"
+  | Some (false, msg) ->
+      fail
+        (Printf.sprintf
+           "expected broken sandbox clone checkout to be repaired, got error: %s"
+           msg)
+  | Some (true, msg) ->
+      check bool "message mentions checkout restore" true
+        (contains "restored from HEAD" msg);
+      check bool "sandbox clone checkout restored" true
+        (Sys.file_exists restored_readme);
+      check bool "docker worktree created after repair" true
+        (Sys.file_exists docker_worktree)
+
 (* ============================================================
    Test Runners
    ============================================================ *)
@@ -540,5 +606,7 @@ let () =
         test_dispatch_worktree_create_auto_provisions_before_wide_workspace_storm;
       test_case "docker keeper uses docker lane for create/remove" `Quick
         test_dispatch_worktree_create_and_remove_use_docker_keeper_lane;
+      test_case "broken sandbox clone checkout is restored" `Quick
+        test_dispatch_worktree_create_repairs_existing_sandbox_clone_checkout;
     ];
   ]


### PR DESCRIPTION
## Summary
- detect sandbox repo clones that still have a `.git` marker but no checked-out tracked files
- restore the clone checkout from `HEAD` before reusing it for keeper worktree creation
- add a regression test covering the docker keeper lane with an existing broken clone checkout

## Why
Follow-up to #9592. The previous fix removed the false `path_outside_sandbox` error, but live docker keepers could still fail on `repos/<repo>/...` reads when the sandbox clone existed with only `.git/` and no working tree files.

## Root cause
`Coord_worktree` treated `repos/<repo>` as reusable as soon as a `.git` marker existed. That let partially materialized clones pass through, so read-only tools hit `file not found` against the sandbox repo root.

## Validation
- `ocamlc -stop-after parsing -c lib/coord/coord_worktree.ml`
- `ocamlc -stop-after parsing -c test/test_tool_worktree_coverage.ml`
- `dune build --root . --build-dir _build_fix_provisioning3 test/test_tool_worktree_coverage.exe` is currently blocked by a pre-existing syntax error in `lib/tool_suspend.ml:73` tracked in #9600
