### PR TITLE
fix: resolve main drift after OAS pin bump

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -648,11 +648,7 @@ let batch_add_tasks_internal ?created_by config tasks =
              (List.length added_tasks)
              summary
          in
-         let _broadcast_result =
-           match broadcast config ~from_agent:actor ~content:msg with
-           | Ok _ -> ()
-           | Error err -> Log.Coord.warn "batch_add_tasks broadcast failed: %s" err
-         in
+         ignore (broadcast config ~from_agent:actor ~content:msg);
          Printf.sprintf "✅ Added %d tasks: %s" (List.length added_tasks) summary
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
@@ -736,16 +732,11 @@ let claim_task config ~agent_name ~task_id =
                   write_backlog config new_backlog;
                   update_local_agent_state config ~agent_name (fun agent ->
                     { agent with status = Busy; current_task = Some task_id });
-                  let _broadcast_result =
-                    match
-                      broadcast
-                        config
-                        ~from_agent:agent_name
-                        ~content:(Printf.sprintf "📋 Claimed %s" task_id)
-                    with
-                    | Ok _ -> ()
-                    | Error err -> Log.Coord.warn "claim_task broadcast failed: %s" err
-                  in
+                  ignore
+                    (broadcast
+                       config
+                       ~from_agent:agent_name
+                       ~content:(Printf.sprintf "📋 Claimed %s" task_id));
                   emit_task_activity
                     config
                     ~agent_name
@@ -883,16 +874,11 @@ let claim_task_r config ~agent_name ~task_id ?(agent_role = Types_core.Unassigne
            write_backlog config new_backlog;
            update_local_agent_state config ~agent_name (fun agent ->
              { agent with status = Busy; current_task = Some task_id });
-           let _broadcast_result =
-             match
-               broadcast
-                 config
-                 ~from_agent:agent_name
-                 ~content:(Printf.sprintf "📋 Claimed %s" task_id)
-             with
-             | Ok _ -> ()
-             | Error err -> Log.Coord.warn "claim_task broadcast failed: %s" err
-           in
+           ignore
+             (broadcast
+                config
+                ~from_agent:agent_name
+                ~content:(Printf.sprintf "📋 Claimed %s" task_id));
            emit_task_activity
              config
              ~agent_name
@@ -1521,11 +1507,7 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
                  then Printf.sprintf "🚫 Cancelled %s" task_id
                  else Printf.sprintf "🚫 Cancelled %s - %s" task_id reason
                in
-               let _broadcast_result =
-                 match broadcast config ~from_agent:agent_name ~content:msg with
-                 | Ok _ -> ()
-                 | Error err -> Log.Coord.warn "cancel_task broadcast failed: %s" err
-               in
+               ignore (broadcast config ~from_agent:agent_name ~content:msg);
                emit_task_activity
                  config
                  ~agent_name

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -160,6 +160,8 @@ let semaphore_wait_timeout_sec =
     ~default:60.0 ~min_v:5.0 ~max_v:600.0
 ;;
 
+exception Semaphore_wait_timeout of float
+
 (** Per-keeper record of the last autonomous turn completion timestamp.
     Used by the fairness cooldown to prevent a fast-cycling keeper from
     monopolizing the autonomous slot when peers are waiting.
@@ -366,31 +368,39 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
   Fun.protect
     ~finally:(fun () -> release_keeper_turn_slot ~keeper_name slot_state)
     (fun () ->
-      if is_autonomous then begin
-        (* Fairness cooldown: if this keeper recently completed a turn and
-           other keepers are waiting, yield before re-entering the FIFO
-           queue to give peers a chance to reach head-of-queue first.
-           See [maybe_yield_for_fairness] and #6810. *)
-        maybe_yield_for_fairness ~keeper_name;
-        let ticket = enqueue_autonomous_waiter ~keeper_name in
-        slot_state.autonomous_ticket := Some ticket;
-        match wait_for_autonomous_queue_head ~keeper_name ~ticket ~started_at:t0 with
-        | Error _ as e -> e
-        | Ok () ->
-          match acquire_bounded ~label:"autonomous" autonomous_turn_semaphore with
+      let autonomous_result =
+        if is_autonomous
+        then begin
+          (* Fairness cooldown: if this keeper recently completed a turn and
+             other keepers are waiting, yield before re-entering the FIFO
+             queue to give peers a chance to reach head-of-queue first.
+             See [maybe_yield_for_fairness] and #6810. *)
+          maybe_yield_for_fairness ~keeper_name;
+          let ticket = enqueue_autonomous_waiter ~keeper_name in
+          slot_state.autonomous_ticket := Some ticket;
+          match wait_for_autonomous_queue_head ~keeper_name ~ticket ~started_at:t0 with
           | Error _ as e -> e
           | Ok () ->
-            slot_state.acquired_autonomous := true;
-            drop_autonomous_waiter ~ticket;
-            slot_state.autonomous_ticket := None
-      end;
-      match acquire_bounded ~label:"turn" turn_semaphore with
+            match acquire_bounded ~label:"autonomous" autonomous_turn_semaphore with
+            | Error _ as e -> e
+            | Ok () ->
+              slot_state.acquired_autonomous := true;
+              drop_autonomous_waiter ~ticket;
+              slot_state.autonomous_ticket := None;
+              Ok ()
+        end
+        else Ok ()
+      in
+      match autonomous_result with
       | Error _ as e -> e
       | Ok () ->
-        slot_state.acquired_turn := true;
-        let semaphore_wait_ms =
-          int_of_float ((Time_compat.now () -. t0) *. 1000.0) in
-        Ok (f ~semaphore_wait_ms))
+        match acquire_bounded ~label:"turn" turn_semaphore with
+        | Error _ as e -> e
+        | Ok () ->
+          slot_state.acquired_turn := true;
+          let semaphore_wait_ms =
+            int_of_float ((Time_compat.now () -. t0) *. 1000.0) in
+          Ok (f ~semaphore_wait_ms))
 ;;
 
 let with_keeper_turn_slot_for_test ~keeper_name ~channel f =

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -72,7 +72,7 @@ val with_keeper_turn_slot_for_test :
   keeper_name:string ->
   channel:Keeper_world_observation.keeper_cycle_channel ->
   (semaphore_wait_ms:int -> 'a) ->
-  'a
+  ('a, [> `Semaphore_wait_timeout of float ]) result
 
 (** Keepalive loop meta selection. Disk wins when it changed; otherwise
     fall back to the latest registry snapshot instead of the original boot

--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -515,14 +515,15 @@ let most_common_stage_of_entries (entries : raw_entry list) : string option =
   match StringMap.bindings counts with
   | [] -> None
   | bindings ->
-      bindings
-      |> List.sort (fun (stage_a, count_a) (stage_b, count_b) ->
+      (match
+         List.sort (fun (stage_a, count_a) (stage_b, count_b) ->
            let by_count = compare count_b count_a in
            if by_count <> 0 then by_count
            else compare stage_a stage_b)
-      |> List.hd
-      |> fst
-      |> fun stage -> Some stage
+           bindings
+       with
+       | [] -> None
+       | (stage, _) :: _ -> Some stage)
 
 (* ── Aggregate by model ─────────────────────────────────── *)
 

--- a/lib/tool_suspend.ml
+++ b/lib/tool_suspend.ml
@@ -70,6 +70,7 @@ let force_leave config ~agent_id ~reason =
   in
   try
     let _ = Coord.broadcast config ~from_agent:"system" ~content:message in
+    ()
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn -> Log.Misc.error "broadcast (force leave) exception: %s" (Printexc.to_string exn)


### PR DESCRIPTION
## Summary
- align coord broadcast call sites with the current string-returning API
- fix keeper turn-slot result flow and keep the public test surface in sync
- remove the new health ratchet regression from model inference metrics

## Verification
- env OCAMLPARAM='_,warn-error=+a' opam exec -- dune build --root . @install --force
- bash scripts/health_snapshot.sh --skip-build --json-out .health/health-snapshot.fix-main-build-20260423-v3.json --baseline-ref origin/main --fail-on-lib-regression
- env -u DUNE_RPC opam exec -- dune runtest --root . test/test_keeper_semaphore_fairness.exe test/test_work_as_heartbeat.exe