### PR TITLE
[codex] remove room_scope mentions

### DIFF
--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -219,10 +219,10 @@ Definitive list: `removed_keeper_input_key_names` in [`lib/keeper/keeper_config.
 Keys under `[keeper]` that are neither canonical (above) nor hard-rejected are **silently ignored by the loader, but a warning is emitted**:
 
 ```text
-keeper TOML <path> has unknown keys: keeper.room_scope, keeper.scope_kind
+keeper TOML <path> has unknown keys: keeper.legacy_scope, keeper.scope_kind
 ```
 
-Historically, dead config like `room_scope` and `scope_kind` accumulated here. Treat these warnings as drift signals and clean up the TOML. The warning does not block boot.
+Historically, dead config like `legacy_scope` and `scope_kind` accumulated here. Treat these warnings as drift signals and clean up the TOML. The warning does not block boot.
 
 Definitive canonical list: `canonical_keeper_toml_key_names` in [`lib/keeper/keeper_types_profile.ml`](../lib/keeper/keeper_types_profile.ml).
 

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -803,7 +803,7 @@ materialize될 수 있지만, 정식 edit surface는 `profile.json`과 `keeper.t
 - **Overlay fields**: `goal`, `tool_preset`, `tool_also_allow`, `cascade_name`, `sandbox_profile`, `network_mode`, `shared_memory_scope` 등 배치별 override 전용.
 - **Allowed value sets**: `tool_preset ∈ {minimal, social, messaging, coding, research, delivery, full}`, `sandbox_profile ∈ {local, docker}`, `network_mode ∈ {none, inherit}`, `shared_memory_scope ∈ {disabled, room}`, `social_model ∈ {bdi_speech_v1, magentic_ledger_v1}`, `cascade_name`은 `cascade.json`에 `<name>_models` 키로 존재해야 함.
 - **Removed / hard-rejected**: `also_allow` (top-level TOML alias), `models`, `allowed_models`, `active_model`, `presence_keepalive*`, `trigger_mode`, `initiative_*`, `policy_mode`, `policy_shell_mode`. 로드 시 에러로 실패한다.
-- **Unknown keys**: canonical/removed 둘 다 아닌 key는 **boot 시 warning** 후 무시된다 (`keeper TOML <path> has unknown keys: ...`). 과거에 `room_scope`/`scope_kind` 같은 dead config가 축적된 적이 있으므로 warning을 발견하면 정리한다.
+- **Unknown keys**: canonical/removed 둘 다 아닌 key는 **boot 시 warning** 후 무시된다 (`keeper TOML <path> has unknown keys: ...`). 과거에 `legacy_scope`/`scope_kind` 같은 dead config가 축적된 적이 있으므로 warning을 발견하면 정리한다.
 
 Definitive source는 코드의 `canonical_keeper_toml_key_names` (`lib/keeper/keeper_types_profile.ml`)와 `removed_keeper_input_key_names` (`lib/keeper/keeper_config.ml`)다.
 

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -148,7 +148,7 @@ type session_context = {
 
 ### 3.4 Coordination Boundary
 
-Legacy `room_scope` typed aliases were removed during single-room flattening.
+Legacy room-targeting typed aliases were removed during single-room flattening.
 JSON/MCP 경계에는 `mention_targets`, `joined_room_ids` 같은 coordination 값만 남고, 별도 scope enum은 더 이상 유지하지 않는다.
 `policy_mode`, `policy_shell_mode`, `trigger_mode`, `initiative_*`는 제거되었다.
 

--- a/docs/spec/15-testing.md
+++ b/docs/spec/15-testing.md
@@ -244,7 +244,7 @@ proposed_action -> verifier_core: risk_level 분류 (Safe/Moderate/Dangerous)
 
 ### 5.6 Keeper Contract (RETIRED)
 
-`lib/keeper/keeper_contract.ml`는 keeper 정책/런타임 enum의 typed 표현(예: `room_scope = Current | All (legacy)`)을 제공했고, single-room 통합 과정에서 `room_scope` 타입과 함께 제거됐다 (`grep -rn 'type room_scope' lib/` → 0 hits; 남은 `room_scope_*` 식별자는 캐시 helper 함수 이름일 뿐 타입 정의가 아님).
+`lib/keeper/keeper_contract.ml`는 keeper 정책/런타임 enum의 typed 표현(예: room-targeting enum legacy variant)을 제공했고, single-room 통합 과정에서 해당 타입이 제거됐다 (`grep -rn 'type .*scope' lib/keeper` 기준 legacy scope enum hit 없음).
 
 Keeper 관련 enum의 현재 typed boundary는 05-keeper-agent 스펙의 §2 module table을 따른다.
 

--- a/lib/dashboard/dashboard_projection_cache.ml
+++ b/lib/dashboard/dashboard_projection_cache.ml
@@ -4,11 +4,11 @@
     operator snapshot. Reuse short-lived actor-scoped cache entries so warm
     refresh loops and repeated navigation do not recompute identical reads. *)
 
-let room_scope_cache_segment (_config : Coord_utils.config) = "default"
+let cache_partition_segment (_config : Coord_utils.config) = "default"
 
-let room_scoped_actor_cache_key (config : Coord_utils.config) prefix actor_name =
+let actor_cache_key (config : Coord_utils.config) prefix actor_name =
   Printf.sprintf "%s:%s:%s:%s" prefix config.base_path
-    (room_scope_cache_segment config) actor_name
+    (cache_partition_segment config) actor_name
 
 let normalize_actor_name = function
   | Some value when String.trim value <> "" -> String.trim value
@@ -17,11 +17,11 @@ let normalize_actor_name = function
 let get_or_compute_snapshot_json ~config ~actor compute =
   let actor_name = normalize_actor_name actor in
   Dashboard_cache.get_or_compute
-    (room_scoped_actor_cache_key config "snapshot" actor_name)
+    (actor_cache_key config "snapshot" actor_name)
     ~ttl:3.0 (fun () -> compute actor_name)
 
 let get_or_compute_digest_json ~config ~actor compute =
   let actor_name = normalize_actor_name actor in
   Dashboard_cache.get_or_compute
-    (room_scoped_actor_cache_key config "digest" actor_name)
+    (actor_cache_key config "digest" actor_name)
     ~ttl:5.0 (fun () -> compute actor_name)

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -576,7 +576,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
 (** Canonical TOML key names recognized by [profile_defaults_of_toml].
     Keys outside this set under [[keeper]] (or any other table) are silently
     ignored by the loader, which historically let dead config accumulate
-    (e.g. legacy [room_scope], [scope_kind]).  [warn_unknown_keeper_toml_keys]
+    (e.g. legacy [legacy_scope], [scope_kind]).  [warn_unknown_keeper_toml_keys]
     uses this list to surface drift on boot, symmetric with
     [warn_unknown_keeper_meta_keys] on the JSON side. *)
 let canonical_keeper_toml_key_names =

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -187,7 +187,7 @@ let collect_message_scope ~(config : Coord.config) ~(meta : keeper_meta) :
           | Eio.Cancel.Cancelled _ as e -> raise e
           | _ -> []
         in
-        let status, remaining, last_processed, room_mentions, room_scope_messages =
+        let status, remaining, last_processed, room_mentions, scoped_messages =
           consume_room_messages remaining since_seq [] [] messages
         in
         let cursor_acc =
@@ -195,7 +195,7 @@ let collect_message_scope ~(config : Coord.config) ~(meta : keeper_meta) :
           else cursor_acc
         in
         let mentions_acc = mentions_acc @ room_mentions in
-        let scope_acc = scope_acc @ room_scope_messages in
+        let scope_acc = scope_acc @ scoped_messages in
         match status with
         | `Done -> consume_rooms remaining mentions_acc scope_acc cursor_acc rest
         | `Saturated -> (mentions_acc, scope_acc, List.rev cursor_acc)

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -69,11 +69,11 @@ let with_dashboard_timeout ~clock compute =
         ("generated_at", `String (Types.now_iso ()));
       ]
 
-let room_scope_cache_segment (_config : Coord.config) = "default"
+let cache_partition_segment (_config : Coord.config) = "default"
 
-let room_scoped_cache_key (config : Coord.config) prefix suffix =
+let dashboard_cache_key (config : Coord.config) prefix suffix =
   Printf.sprintf "%s:%s:%s:%s" prefix config.base_path
-    (room_scope_cache_segment config) suffix
+    (cache_partition_segment config) suffix
 
 let dashboard_mission_timeout_s = 25.0
 
@@ -628,7 +628,7 @@ let dashboard_mission_http_json ~state ~sw ~clock request =
     | Some _ ->
       (* Actor-parameterized: on-demand with SWR cache. *)
       let cache_key =
-        room_scoped_cache_key state.Mcp_server.room_config "mission"
+        dashboard_cache_key state.Mcp_server.room_config "mission"
           (Option.value ~default:"" actor)
       in
       Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:120.0
@@ -667,7 +667,7 @@ let dashboard_mission_briefing_http_json ~state ~sw ~clock request =
   if force then with_dashboard_timeout ~clock compute
   else
     let cache_key =
-      room_scoped_cache_key state.Mcp_server.room_config "mission_briefing"
+      dashboard_cache_key state.Mcp_server.room_config "mission_briefing"
         (Option.value ~default:"" actor)
     in
     Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:5.0
@@ -807,7 +807,7 @@ let dashboard_shell_cache_key (config : Coord.config) =
     config.workspace_path
 
 let meta_cognition_summary_key (config : Coord.config) =
-  room_scoped_cache_key config "meta_cognition_summary" "dashboard_shell"
+  dashboard_cache_key config "meta_cognition_summary" "dashboard_shell"
 
 let store_last_good_meta_cognition_summary key json =
   Eio_guard.with_mutex meta_cognition_last_good_mu (fun () ->

--- a/lib/server/server_dashboard_http_core.mli
+++ b/lib/server/server_dashboard_http_core.mli
@@ -54,7 +54,7 @@ val with_dashboard_timeout :
 
 (** {1 Cache Key Helpers} *)
 
-val room_scoped_cache_key : Coord.config -> string -> string -> string
+val dashboard_cache_key : Coord.config -> string -> string -> string
 
 (** {1 Projection Diagnostics} *)
 

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -80,7 +80,7 @@ let comment_json ~id ~post_id ~author ~content ?(created_at = 1000.0) () =
 
 let warm_meta_cognition_summary (config : Lib.Coord.config) =
   let key =
-    Lib.Server_dashboard_http.room_scoped_cache_key config
+    Lib.Server_dashboard_http.dashboard_cache_key config
       "meta_cognition_summary" "dashboard_shell"
   in
   ignore

--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -98,7 +98,7 @@ let warm_execution_cache () =
 
 let warm_meta_cognition_summary (config : Lib.Coord.config) =
   let key =
-    Lib.Server_dashboard_http.room_scoped_cache_key config
+    Lib.Server_dashboard_http.dashboard_cache_key config
       "meta_cognition_summary" "dashboard_shell"
   in
   ignore

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -970,7 +970,7 @@ let test_detect_unknown_keys_flags_legacy_dead_config () =
   let input = {|
 [keeper]
 goal = "g"
-room_scope = "current"
+legacy_scope = "current"
 scope_kind = "local"
 mention_targets = ["a"]
 |} in
@@ -979,7 +979,7 @@ mention_targets = ["a"]
   | Ok doc ->
     let unknown = KTP.detect_unknown_keeper_toml_keys doc in
     check (list string) "surfaces dead config"
-      ["keeper.room_scope"; "keeper.scope_kind"] unknown
+      ["keeper.legacy_scope"; "keeper.scope_kind"] unknown
 
 let test_oas_env_parses_allowed_keys () =
   let input = {|


### PR DESCRIPTION
## Summary

Remove the remaining `room_scope` mentions from active code, tests, and docs.
This renames dashboard cache helpers to neutral names, drops the last `room_scope` literal from the keeper TOML unknown-key test, and rewrites spec/manual wording so the repo no longer carries that retired term.

## Why

`room_scope` is already retired terminology. Leaving it around in helper names, warning examples, and tests makes dead concepts feel live again and makes contract review noisier than it should be.

## Impact

- user-visible change: none in runtime behavior
- developer-visible change: active code and docs now use neutral cache/scope wording
- test/docs cleanup: unknown-key examples now use `legacy_scope` instead of `room_scope`

## Validation

- `rg -n "room_scope" /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/remove-room-scope-mentions-20260423 -g '!**/_build/**' -g '!**/.git/**'` -> 0 hits
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/remove-room-scope-mentions-20260423 2>&1`
- Note: the dune build is currently blocked by pre-existing main compile failures in `lib/coord/coord_task.ml:653` and `lib/tool_suspend.ml:73`, outside this PR scope.
