### PR TITLE
fix(keeper): propagate TOML-reconciled meta into registry

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -411,13 +411,13 @@ let run_cmd host port base_path =
       resolution_source normalized_base_path;
     exit 1
   end;
-  let masc_dir = Filename.concat normalized_base_path ".masc" in
+  let masc_dir = Filename.concat normalized_base_path Common.masc_dirname in
   Fs_compat.mkdir_p masc_dir;
   acquire_pid_lock port;
   acquire_base_path_lock normalized_base_path;
   Log.init_from_env ();
   if stripped_base_path <> ""
-     && String.equal (Filename.basename stripped_base_path) ".masc"
+     && String.equal (Filename.basename stripped_base_path) Common.masc_dirname
   then
     Log.Server.warn
       "Normalizing --base-path from %s to %s because runtime base paths must point at the workspace root, not the .masc directory."

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -661,7 +661,7 @@ let doctor_sidecar_exit name as_json =
     end
     else begin
       let python =
-        try Sys.getenv "MASC_PYTHON" with Not_found -> "python3"
+        Option.value (Sys.getenv_opt "MASC_PYTHON") ~default:"python3"
       in
       let args =
         if as_json

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -451,7 +451,6 @@ let run_cmd host port base_path =
 
   (* Enable Eio-aware locking globally (single call replaces per-module enable_eio) *)
   Eio_guard.enable ();
-  Masc_mcp.Transport_metrics.init ();
 
   (* Set global clock for Time_compat (Eio-native timestamps).
      Dashboard_cache.now() reads from Time_compat directly. *)

--- a/bin/masc_compaction_audit.ml
+++ b/bin/masc_compaction_audit.ml
@@ -32,10 +32,12 @@ let error msg =
 let parse_date_arg name s =
   match String.length s with
   | 10 ->
-    (try
-       let year  = int_of_string (String.sub s 0 4) in
-       let mon   = int_of_string (String.sub s 5 2) in
-       let day   = int_of_string (String.sub s 8 2) in
+    (match
+       int_of_string_opt (String.sub s 0 4),
+       int_of_string_opt (String.sub s 5 2),
+       int_of_string_opt (String.sub s 8 2)
+     with
+     | Some year, Some mon, Some day ->
        let tm : Unix.tm = {
          tm_sec = 0; tm_min = 0; tm_hour = 0;
          tm_mday = day; tm_mon = mon - 1; tm_year = year - 1900;
@@ -43,7 +45,7 @@ let parse_date_arg name s =
        } in
        let (ts, _) = Unix.mktime tm in
        ts
-     with _ -> error (Printf.sprintf "invalid %s: %S (expected YYYY-MM-DD)" name s))
+     | _ -> error (Printf.sprintf "invalid %s: %S (expected YYYY-MM-DD)" name s))
   | _ -> error (Printf.sprintf "invalid %s: %S (expected YYYY-MM-DD)" name s)
 
 let base_path () =

--- a/bin/masc_cost.ml
+++ b/bin/masc_cost.ml
@@ -22,7 +22,7 @@ let get_masc_root () =
     | Some path when String.trim path <> "" -> String.trim path
     | _ -> Sys.getcwd ()
   in
-  Filename.concat base_path ".masc"
+  Filename.concat base_path Common.masc_dirname
 
 (** Get costs file path *)
 let costs_file () = Filename.concat (get_masc_root ()) "costs.jsonl"

--- a/bin/masc_cost.ml
+++ b/bin/masc_cost.ml
@@ -45,7 +45,8 @@ let parse_iso_date s =
         tm_wday = 0; tm_yday = 0; tm_isdst = false
       } in
       fst (Unix.mktime tm))
-  with _ -> 0.0
+  with
+  | Scanf.Scan_failure _ | Failure _ | Invalid_argument _ | Unix.Unix_error _ -> 0.0
 
 (** Ensure MASC directory exists *)
 let ensure_masc_dir () =
@@ -63,9 +64,10 @@ let log_cost ~agent ~task_id ~model ~input_tokens ~output_tokens ~cost_usd =
     model input_tokens output_tokens cost_usd (now_iso ())
   in
   let oc = open_out_gen [Open_append; Open_creat] 0o644 (costs_file ()) in
-  output_string oc (entry ^ "\n");
-  close_out oc;
-  printf "✅ Cost logged: %s → $%.4f\n" agent cost_usd
+  Fun.protect
+    ~finally:(fun () -> close_out oc)
+    (fun () -> output_string oc (entry ^ "\n"));
+  printf "Cost logged: %s → $%.4f\n" agent cost_usd
 
 (** Parse a JSON line into cost entry *)
 let parse_cost_line line =
@@ -80,28 +82,29 @@ let parse_cost_line line =
       cost_usd = get_float json "cost_usd" |> Option.value ~default:0.0;
       timestamp = get_string json "timestamp" |> Option.value ~default:"";
     }
-  with _ -> None
+  with
+  | Yojson.Json_error _ | Failure _ | Invalid_argument _ -> None
 
 (** Read all cost entries *)
 let read_costs () =
   let file = costs_file () in
   if not (Sys.file_exists file) then []
-  else begin
+  else
     let ic = open_in file in
-    let rec read_lines acc =
-      match input_line ic with
-      | line ->
-          let acc' = match parse_cost_line line with
-            | Some e -> e :: acc
-            | None -> acc
-          in
-          read_lines acc'
-      | exception End_of_file ->
-          close_in ic;
-          List.rev acc
-    in
-    read_lines []
-  end
+    Fun.protect
+      ~finally:(fun () -> close_in ic)
+      (fun () ->
+        let rec read_lines acc =
+          match input_line ic with
+          | line ->
+              let acc' = match parse_cost_line line with
+                | Some e -> e :: acc
+                | None -> acc
+              in
+              read_lines acc'
+          | exception End_of_file -> List.rev acc
+        in
+        read_lines [])
 
 (** Filter entries by time period *)
 let filter_by_period period entries =

--- a/bin/masc_tui_ansi.ml
+++ b/bin/masc_tui_ansi.ml
@@ -69,16 +69,19 @@ let fit_width s width =
   if len >= width then String.sub s 0 (max 0 (width - 1)) ^ (if len > width then "~" else "")
   else s ^ String.make (width - len) ' '
 
+let is_keeper name =
+  String.length name >= 7 && String.sub name 0 7 = "keeper-"
+
 (** Agent icon — deterministic by name hash, vendor-agnostic *)
 let agent_icon name =
   let icons = [| "\xf0\x9f\x9f\xa3"; "\xf0\x9f\x94\xb5"; "\xf0\x9f\x9f\xa2"; "\xf0\x9f\x9f\xa1"; "\xf0\x9f\x94\xb4" |] in
-  if String.length name >= 7 && String.sub name 0 7 = "keeper-" then "\xf0\x9f\x9b\xa1"  (* shield for keepers *)
+  if is_keeper name then "\xf0\x9f\x9b\xa1"  (* shield for keepers *)
   else icons.(Hashtbl.hash name mod Array.length icons)
 
 (** Agent color — deterministic by name hash, vendor-agnostic *)
 let agent_color name =
   let colors = [| Ansi.magenta; Ansi.blue; Ansi.green; Ansi.yellow; Ansi.cyan |] in
-  if String.length name >= 7 && String.sub name 0 7 = "keeper-" then Ansi.white
+  if is_keeper name then Ansi.white
   else colors.(Hashtbl.hash name mod Array.length colors)
 
 (** Status color *)

--- a/bin/masc_tui_ansi.ml
+++ b/bin/masc_tui_ansi.ml
@@ -47,17 +47,17 @@ end
 
 (** Get terminal size (fallback to 80x24) *)
 let get_terminal_size () =
-  try
-    let read_tput arg =
+  let read_tput arg =
+    try
       let ic = Unix.open_process_args_in "tput" [| "tput"; arg |] in
       Fun.protect
         ~finally:(fun () -> ignore (Unix.close_process_in ic))
-        (fun () -> int_of_string (String.trim (input_line ic)))
-    in
-    let cols = read_tput "cols" in
-    let rows = read_tput "lines" in
-    (rows, cols)
-  with _ -> (24, 80)
+        (fun () -> int_of_string_opt (String.trim (input_line ic)))
+    with Unix.Unix_error _ | Sys_error _ | End_of_file -> None
+  in
+  match read_tput "cols", read_tput "lines" with
+  | Some cols, Some rows -> (rows, cols)
+  | _ -> (24, 80)
 
 (** Draw horizontal line *)
 let draw_hline width =

--- a/bin/masc_tui_loader.ml
+++ b/bin/masc_tui_loader.ml
@@ -8,7 +8,7 @@ let report path err =
 
 (** Load keepers from .masc/keepers/ *)
 let load_keepers (base_path : string) : keeper list =
-  let keepers_dir = Filename.concat (Filename.concat base_path ".masc") "keepers" in
+  let keepers_dir = Filename.concat (Filename.concat base_path Common.masc_dirname) "keepers" in
   if Sys.file_exists keepers_dir && Sys.is_directory keepers_dir then
     Sys.readdir keepers_dir
     |> Array.to_list
@@ -73,7 +73,7 @@ let parse_log_entry (line : string) : log_entry option =
 let find_metrics_files (base_path : string) (keeper_name : string) : string list =
   let metrics_dir = Filename.concat
     (Filename.concat
-       (Filename.concat base_path ".masc")
+       (Filename.concat base_path Common.masc_dirname)
        "keepers")
     (Filename.concat keeper_name "metrics") in
   if not (Sys.file_exists metrics_dir && Sys.is_directory metrics_dir) then []
@@ -149,7 +149,7 @@ let load_live_context (state : state) (base_path : string) (keeper_name : string
 
 (** Load state from .masc directory *)
 let load_from_masc_dir (state : state) (base_path : string) =
-  let masc_dir = Filename.concat base_path ".masc" in
+  let masc_dir = Filename.concat base_path Common.masc_dirname in
 
   (* Load agents *)
   let agents_dir = Filename.concat masc_dir "agents" in

--- a/lib/admission_queue_metrics.ml
+++ b/lib/admission_queue_metrics.ml
@@ -2,24 +2,15 @@
 
     @since 3.0.0 *)
 
-let on_enqueue ~keeper_name:_ ~cascade_name:_ =
-  Prometheus.inc_gauge "masc_inference_queue_depth" ()
-
-let on_dequeue ~keeper_name:_ ~cascade_name:_ =
-  Prometheus.dec_gauge "masc_inference_queue_depth" ()
-
 let on_acquire ~keeper_name:_ ~cascade_name:_ ~wait_ms =
-  Prometheus.inc_gauge "masc_inference_queue_inflight" ();
-  Prometheus.inc_counter "masc_inference_queue_acquired_total" ();
+  Prometheus.inc_gauge Prometheus.metric_inference_queue_inflight ();
+  Prometheus.inc_counter Prometheus.metric_inference_queue_acquired ();
   let wait_sec = Float.of_int wait_ms /. 1000.0 in
-  Prometheus.observe_histogram "masc_inference_queue_wait_seconds" wait_sec
+  Prometheus.observe_histogram Prometheus.metric_inference_queue_wait wait_sec
 
 let on_release ~keeper_name:_ ~cascade_name:_ =
-  Prometheus.dec_gauge "masc_inference_queue_inflight" ()
-
-let on_cancelled ~keeper_name:_ ~cascade_name:_ =
-  Prometheus.inc_counter "masc_inference_queue_cancelled_total" ()
+  Prometheus.dec_gauge Prometheus.metric_inference_queue_inflight ()
 
 let set_max_concurrent value =
-  Prometheus.set_gauge "masc_inference_queue_max_concurrent"
+  Prometheus.set_gauge Prometheus.metric_inference_queue_max_concurrent
     (float_of_int value)

--- a/lib/admission_queue_metrics.mli
+++ b/lib/admission_queue_metrics.mli
@@ -1,16 +1,9 @@
 (** Admission_queue_metrics — Prometheus integration for inference admission queue.
 
-    Emits metrics on every enqueue/dequeue/acquire/release event.
+    Emits metrics on every acquire/release event.
     Called internally by [Admission_queue]; callers do not invoke directly.
 
     @since 3.0.0 *)
-
-val on_enqueue : keeper_name:string -> cascade_name:string -> unit
-(** Called when a waiter enters the queue. Increments queue_depth gauge. *)
-
-val on_dequeue : keeper_name:string -> cascade_name:string -> unit
-(** Called when a waiter exits the queue (acquired or cancelled).
-    Decrements queue_depth gauge. *)
 
 val on_acquire : keeper_name:string -> cascade_name:string -> wait_ms:int -> unit
 (** Called after successful acquire. Increments inflight gauge,
@@ -18,10 +11,6 @@ val on_acquire : keeper_name:string -> cascade_name:string -> wait_ms:int -> uni
 
 val on_release : keeper_name:string -> cascade_name:string -> unit
 (** Called on release. Decrements inflight gauge. *)
-
-val on_cancelled : keeper_name:string -> cascade_name:string -> unit
-(** Called when a wait is cancelled by fiber cancellation.
-    Increments cancelled counter. *)
 
 val set_max_concurrent : int -> unit
 (** Syncs the configured admission queue capacity into Prometheus. *)

--- a/lib/agent_card.ml
+++ b/lib/agent_card.ml
@@ -404,7 +404,7 @@ let generate_default
     default_output_modes = ["text/plain"; "application/json"; "text/event-stream"];
     extensions = [
       ("masc", `Assoc [
-        ("roomPath", `String ".masc");
+        ("roomPath", `String Common.masc_dirname);
         ("storageTypes", `List [`String "file"]);
         ("features", `Assoc [
           ("voting", `Bool true);

--- a/lib/auto_recall.ml
+++ b/lib/auto_recall.ml
@@ -159,7 +159,7 @@ let fetch_from_file_context (room_config : Coord_utils.config) ~query =
     || name = "node_modules"
     || name = "_build"
     || name = ".worktrees"
-    || name = ".masc"
+    || name = Common.masc_dirname
   in
 
   let rec walk depth dir acc =

--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -118,7 +118,7 @@ module FileSystem = struct
               Error (InvalidKey "Consecutive colons not allowed")
             else if seg = "." || seg = ".." then
               Error (InvalidKey "Path traversal detected")
-            else if String.length seg >= 2 && String.sub seg 0 2 = ".." then
+            else if Base.String.is_prefix seg ~prefix:".." then
               Error (InvalidKey "Path traversal detected")
             else
               (* Blocklist: reject only dangerous characters, allow UTF-8 *)
@@ -195,7 +195,7 @@ module FileSystem = struct
   let _decompress = Compression.decompress_auto
 
   let has_zstd_header content =
-    String.length content >= 4 && String.sub content 0 4 = "ZSTD"
+    Base.String.is_prefix content ~prefix:"ZSTD"
 
   let decompress_with_context ~context content =
     let had_header = has_zstd_header content in

--- a/lib/backend/backend_compression.ml
+++ b/lib/backend/backend_compression.ml
@@ -51,7 +51,7 @@ let encode_with_header ~(used_dict : bool) (orig_size : int) (compressed : strin
 let decode_header (data : string) : (int * string * bool) option =
   if String.length data < 8 then None
   (* Check dictionary header FIRST (ZSTDD) *)
-  else if String.length data >= 9 && String.sub data 0 5 = magic_dict then begin
+  else if Base.String.is_prefix data ~prefix:magic_dict then begin
     (* Dictionary header: ZSTDD *)
     let orig_size =
       (Char.code data.[5] lsl 24) lor

--- a/lib/backend/backend_types.ml
+++ b/lib/backend/backend_types.ml
@@ -59,7 +59,7 @@ let generate_node_id () =
 
 let default_config = {
   backend_type = FileSystem;
-  base_path = ".masc";
+  base_path = Common.masc_dirname;
   node_id = generate_node_id ();
   cluster_name = "default";
   pubsub_max_messages = pubsub_max_messages_from_env ();

--- a/lib/backend/dune
+++ b/lib/backend/dune
@@ -24,5 +24,6 @@
   uri
   str
   mtime
-  zstd)
+  zstd
+  base)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_deriving_yojson)))

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -75,10 +75,14 @@ let start_flusher_actor ~sw store =
       match Eio.Stream.take store.Board.flusher_inbox with
       | Board_types.Flush ->
           (try Board.flush_dirty store
-           with exn -> Log.BoardLog.error "Flush failed: %s" (Printexc.to_string exn))
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn -> Log.BoardLog.error "Flush failed: %s" (Printexc.to_string exn))
       | Board_types.Sweep ->
-          (try let _ = Board.sweep store in ()
-           with exn -> Log.BoardLog.error "Sweep failed: %s" (Printexc.to_string exn))
+          (try ignore (Board.sweep store)
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn -> Log.BoardLog.error "Sweep failed: %s" (Printexc.to_string exn))
     done
   )
 

--- a/lib/cascade/cascade_client_capacity_history.ml
+++ b/lib/cascade/cascade_client_capacity_history.ml
@@ -78,7 +78,7 @@ let string_of_kind = function
    name + labels match the dashboard projection (classify_key) so Grafana
    queries can join on the same {kind, key_type} tuple. *)
 let bump_prometheus_counter (ev : event) =
-  Prometheus.inc_counter "masc_cascade_capacity_events_total"
+  Prometheus.inc_counter Prometheus.metric_cascade_capacity_events
     ~labels:[
       "kind", string_of_kind ev.kind;
       "key_type", classify_key ev.key;

--- a/lib/cascade/cascade_strategy_trace.ml
+++ b/lib/cascade/cascade_strategy_trace.ml
@@ -55,7 +55,7 @@ let ensure_initialised_locked () =
    mirror the JSON projection ({cascade, strategy, kind}) so Grafana can
    join on the same tuple surfaced to the dashboard card. *)
 let bump_prometheus_counter (ev : event) =
-  Prometheus.inc_counter "masc_cascade_strategy_decisions_total"
+  Prometheus.inc_counter Prometheus.metric_cascade_strategy_decisions
     ~labels:[
       "cascade", ev.cascade_name;
       "strategy", ev.strategy;

--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -80,7 +80,7 @@ let strip_path_trailing_slashes value =
 let normalize_masc_base_path_input path =
   let normalized = strip_path_trailing_slashes path in
   if normalized = "" then ""
-  else if String.equal (Filename.basename normalized) ".masc" then
+  else if String.equal (Filename.basename normalized) Common.masc_dirname then
     match Filename.dirname normalized with
     | "" -> "."
     | parent -> parent

--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -101,8 +101,8 @@ let observe_agent_lifecycle config ~agent_id ~(event : Coord_hooks.agent_lifecyc
   in
   Log.emit level ~module_name:"Coord" ~details message;
   (match event with
-   | Lifecycle_leave -> Prometheus.dec_gauge "masc_active_agents" ()
-   | Lifecycle_join | Lifecycle_rejoin -> Prometheus.inc_gauge "masc_active_agents" ());
+   | Lifecycle_leave -> Prometheus.dec_gauge Prometheus.metric_active_agents ()
+   | Lifecycle_join | Lifecycle_rejoin -> Prometheus.inc_gauge Prometheus.metric_active_agents ());
   let audit_details =
     match event with
     | Lifecycle_rejoin -> merge_detail_fields [ ("rejoin", `Bool true) ] details

--- a/lib/coord/coord_utils_backend_setup.ml
+++ b/lib/coord/coord_utils_backend_setup.ml
@@ -195,7 +195,7 @@ let resolve_server_default_base_path path = resolve_masc_base_path path
 let is_unresolved_template value =
   let v = String.trim value in
   (String.length v >= 2 && v.[0] = '{' && v.[1] = '{')
-  || (String.length v >= 5 && String.sub v 0 5 = "op://")
+  || Base.String.is_prefix v ~prefix:"op://"
 
 let env_opt name =
   match Sys.getenv_opt name with

--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -64,7 +64,7 @@ let git_marker_kind path =
 let project_root config =
   let base = config.base_path in
   let candidate =
-    if Filename.basename base = ".masc" then Filename.dirname base else base
+    if Filename.basename base = Common.masc_dirname then Filename.dirname base else base
   in
   let rec find_repo_root dir =
     let git_marker = Filename.concat dir ".git" in
@@ -351,11 +351,10 @@ let workspace_repo_matches ~search_root ~repo_name =
     else if String.length entry > 0 && entry.[0] = '.' then 3
     else 2
   in
-  let skip_dir_name = function
-    | ".git" | ".hg" | ".svn" | ".masc" | ".worktrees" | "_build"
-    | "node_modules" ->
-        true
-    | _ -> false
+  let skip_dir_name name =
+    name = ".git" || name = ".hg" || name = ".svn"
+    || name = Common.masc_dirname || name = ".worktrees"
+    || name = "_build" || name = "node_modules"
   in
   let matches =
     if Filename.basename search_root = repo_name && is_git_clone search_root

--- a/lib/coord/dune
+++ b/lib/coord/dune
@@ -55,5 +55,6 @@
   uri
   uuidm
   digestif
-  masc_random_id)
+  masc_random_id
+  base)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_deriving_yojson)))

--- a/lib/coord_goals.ml
+++ b/lib/coord_goals.ml
@@ -232,7 +232,9 @@ let parse_optional_string_list args field =
   | `Null -> Ok None
   | `List values -> (
       try Ok (Some (List.map Yojson.Safe.Util.to_string values))
-      with _ ->
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | _ ->
         Error
           (make_type_field_error ~field ~constraint_violated:Type_string
              ~expected:"string[]"

--- a/lib/core/dune
+++ b/lib/core/dune
@@ -4,4 +4,4 @@
  (public_name masc_mcp.masc_core)
  (wrapped false)
  (modules json_util safe_ops common validation circuit_breaker eio_guard executor_pool_ref masc_runtime_events text_similarity string_util)
- (libraries yojson unix re re.pcre eio eio.unix time_compat fs_compat masc_log runtime_events))
+ (libraries yojson unix re re.pcre eio eio.unix time_compat fs_compat masc_log runtime_events base))

--- a/lib/core/validation.ml
+++ b/lib/core/validation.ml
@@ -60,7 +60,7 @@ end = struct
       reject (Printf.sprintf "agent_id too long: %d chars (max 64)" (String.length s))
     else if String.contains s '/' || String.contains s '\\' then
       reject "agent_id cannot contain path separators"
-    else if String.contains s '.' && String.length s >= 2 && String.sub s 0 2 = ".." then
+    else if String.contains s '.' && Base.String.is_prefix s ~prefix:".." then
       reject "agent_id cannot contain path traversal"
     else if not (Re.execp valid_pattern s) then
       reject (Printf.sprintf "agent_id contains invalid characters: %s (only a-z, A-Z, 0-9, _, -, : allowed)" s)
@@ -94,7 +94,7 @@ end = struct
       reject (Printf.sprintf "task_id too long: %d chars (max 128)" (String.length s))
     else if String.contains s '/' || String.contains s '\\' then
       reject "task_id cannot contain path separators"
-    else if String.contains s '.' && String.length s >= 2 && String.sub s 0 2 = ".." then
+    else if String.contains s '.' && Base.String.is_prefix s ~prefix:".." then
       reject "task_id cannot contain path traversal"
     else if not (Re.execp valid_pattern s) then
       reject (Printf.sprintf "task_id contains invalid characters: %s (only a-z, A-Z, 0-9, _, -, : allowed)" s)
@@ -119,7 +119,7 @@ end = struct
       reject "path cannot be empty"
     else if path.[0] = '/' then
       reject "absolute paths not allowed"
-    else if String.length path >= 2 && String.sub path 0 2 = ".." then
+    else if Base.String.is_prefix path ~prefix:".." then
       reject "path traversal not allowed"
     else if Re.execp (Re.Pcre.re {|\.\./|} |> Re.compile) path then
       reject "path traversal not allowed"

--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -249,7 +249,9 @@ let get_or_compute_eio ?wait_timeout_sec key ~ttl compute =
       let result_ref = ref None in
       let run_compute () =
         try result_ref := Some (Ok (compute ()))
-        with exn -> result_ref := Some (Error exn)
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn -> result_ref := Some (Error exn)
       in
       (match Eio_context.get_clock_opt () with
        | Some clock ->

--- a/lib/exec_core.ml
+++ b/lib/exec_core.ml
@@ -147,7 +147,9 @@ let snapshot_env ~cwd =
               Some (String.sub line (String.length prefix)
                       (String.length line - String.length prefix))
             else Some (String.sub line 0 8))
-        with _ -> None
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | _ -> None
   in
   let project_kind = detect_project_kind cwd in
   let project_name = detect_project_name cwd in

--- a/lib/goal/goal_verification.ml
+++ b/lib/goal/goal_verification.ml
@@ -271,7 +271,9 @@ let goal_verification_vote_of_yojson = function
                 | `Null -> Ok []
                 | `List values -> (
                     try Ok (List.map to_string values)
-                    with _ ->
+                    with
+                    | Eio.Cancel.Cancelled _ as e -> raise e
+                    | _ ->
                       Error "goal_verification_vote_of_yojson: invalid evidence_refs")
                 | other ->
                     Error

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -2,7 +2,7 @@
 
 let project_root_of_config (config : Coord.config) : string =
   let base = config.base_path in
-  if Filename.basename base = ".masc" then Filename.dirname base else base
+  if Filename.basename base = Common.masc_dirname then Filename.dirname base else base
 
 let starts_with ~(prefix : string) (s : string) : bool =
   Base.String.is_prefix s ~prefix
@@ -176,7 +176,7 @@ let absolute_allowed_paths_result ~(config : Coord.config)
 let playground_root_of_allowed (allowed_norms : string list) : string option =
   List.find_opt
     (fun p ->
-      let marker = "/.masc/playground/" in
+      let marker = "/" ^ Common.masc_dirname ^ "/playground/" in
       let mlen = String.length marker in
       let slen = String.length p in
       let rec find i =

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -5,8 +5,7 @@ let project_root_of_config (config : Coord.config) : string =
   if Filename.basename base = ".masc" then Filename.dirname base else base
 
 let starts_with ~(prefix : string) (s : string) : bool =
-  let lp = String.length prefix in
-  String.length s >= lp && String.sub s 0 lp = prefix
+  Base.String.is_prefix s ~prefix
 
 let strip_trailing_slashes = Env_config_core.strip_trailing_slashes
 

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -179,7 +179,9 @@ let approval_rule_of_yojson json =
         match_count;
         source_approval_id;
       }
-  with _ -> None
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ -> None
 
 (* ── Global queue (Lock-free Atomic.t) ───────────────────── *)
 

--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -368,7 +368,7 @@ let compute_invariants
 let bump_invariant_violations ~(keeper_name : string) (inv : invariants_check) =
   let bump key satisfied =
     if not satisfied then
-      Prometheus.inc_counter "masc_keeper_invariant_violations_total"
+      Prometheus.inc_counter Prometheus.metric_keeper_invariant_violations
         ~labels:[
           ("keeper", keeper_name);
           ("invariant", invariant_key_to_string key);

--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -216,7 +216,9 @@ let handle_keeper_fs_edit
          (try
             let current =
               try Fs_compat.load_file target
-              with _ -> ""
+              with
+              | Eio.Cancel.Cancelled _ as e -> raise e
+              | _ -> ""
             in
             if current = "" then
               error_json ~fields:[ "path", `String target ]

--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -172,7 +172,7 @@ let strip_keeper_playground_prefix ~(meta : keeper_meta) (raw : string) =
   let legacy_bundle_root = Playground_paths.bundle_root meta.name in
   let short_root =
     let rel = Keeper_alerting_path.strip_trailing_slashes sandbox_root in
-    if String.starts_with ~prefix:".masc/" rel then
+    if String.starts_with ~prefix:(Common.masc_dirname ^ "/") rel then
       String.sub rel 6 (String.length rel - 6)
     else rel
   in
@@ -200,7 +200,7 @@ let repo_relative_path_candidate ~(meta : keeper_meta) (raw : string) =
   && String.contains raw '/'
   && not (is_playground_lane_relative_path raw)
   && not (relative_path_targets_allowed_root ~meta raw)
-  && not (List.mem first_segment [ ".masc"; "playground"; "workspace"; ".worktrees" ])
+  && not (List.mem first_segment [ Common.masc_dirname; "playground"; "workspace"; ".worktrees" ])
 ;;
 
 let rewrite_single_repo_relative_path ~(config : Coord.config) ~(meta : keeper_meta)

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -647,7 +647,9 @@ let handle_keeper_bash
     | Ok cwd ->
     let env_snap =
       try Some (Exec_core.snapshot_env ~cwd)
-      with _ -> None
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | _ -> None
     in
     let normalize_path_for_containment path =
       Keeper_alerting_path.normalize_path_for_check path

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -162,8 +162,6 @@ let semaphore_wait_timeout_sec =
     ~default:60.0 ~min_v:5.0 ~max_v:600.0
 ;;
 
-exception Semaphore_wait_timeout of float
-
 (** Per-keeper record of the last autonomous turn completion timestamp.
     Used by the fairness cooldown to prevent a fast-cycling keeper from
     monopolizing the autonomous slot when peers are waiting.

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -176,7 +176,9 @@ exception Semaphore_wait_timeout of float
     yield less aggressively. *)
 let last_autonomous_completion : (string, float) Hashtbl.t = Hashtbl.create 16
 
-let last_autonomous_completion_mutex = Mutex.create ()
+(* Stdlib.Mutex: completion table may be accessed from keepers on different
+   domains concurrently. *)
+let last_autonomous_completion_mutex = Stdlib.Mutex.create ()
 
 let with_completion_table f =
   Mutex.lock last_autonomous_completion_mutex;

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -457,7 +457,13 @@ let start_supervisor_sweep ctx =
               match entry.phase with
               | Keeper_state_machine.Running ->
                   (match ensure_keeper_meta ctx.config entry.name with
-                   | Ok _meta -> ()
+                   | Ok updated_meta ->
+                       (* Propagate the updated meta back into the registry so
+                          subsequent turns observe the new cascade_name (and
+                          any other reconciled fields) immediately.  Without
+                          this the file is updated but the in-memory
+                          [registry_entry.meta] stays stale until restart. *)
+                       Keeper_registry.update_meta ~base_path entry.name updated_meta
                    | Error e ->
                        Log.Keeper.warn "TOML reconcile failed for %s: %s"
                          entry.name e)

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -221,7 +221,9 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
                   meta.name reason ()
             end
           end
-        with exn ->
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
           Log.Keeper.warn
             "%s: supervisor finally cleanup failed (suppressed to avoid Fun.Finally_raised): %s"
             meta.name (Printexc.to_string exn)))

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -60,12 +60,9 @@ let to_public internal =
   | None -> internal
 
 let strip_mcp_masc_prefix name =
-  let prefix = "mcp__masc__" in
-  let prefix_len = String.length prefix in
-  if String.length name >= prefix_len && String.sub name 0 prefix_len = prefix then
-    String.sub name prefix_len (String.length name - prefix_len)
-  else
-    name
+  match Base.String.chop_prefix name ~prefix:"mcp__masc__" with
+  | Some rest -> rest
+  | None -> name
 
 let canonicalize_observed names =
   List.map

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -159,12 +159,11 @@ let gh_read_only_prefixes =
     - The subcommand is `graphql` (always POST)
     The input [cmd_lower] must already be lowercased and trimmed. *)
 let is_gh_api_read_only (cmd_lower : string) : bool =
-  if not (String.length cmd_lower >= 3
-          && String.sub cmd_lower 0 3 = "api") then false
+  if not (Base.String.is_prefix cmd_lower ~prefix:"api") then false
   else
     let rest = String.trim (String.sub cmd_lower 3 (String.length cmd_lower - 3)) in
     (* graphql subcommand is always POST *)
-    if String.length rest >= 7 && String.sub rest 0 7 = "graphql" then false
+    if Base.String.is_prefix rest ~prefix:"graphql" then false
     else
       let tokens = String.split_on_char ' ' cmd_lower in
       let has_method_flag =

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -718,7 +718,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       let paused_meta_override = ref None in
       let current_turn_overflow_blocker = ref None in
       let event_bus_drain_active = Atomic.make true in
-      let turn_event_bus_mu = Stdlib.Mutex.create () in
+      let turn_event_bus_mu = Eio.Mutex.create () in
       let mark_paused_after_overflow ~run_meta ~reason =
         let paused_meta =
           pause_keeper_for_overflow
@@ -748,10 +748,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         Hashtbl.create 8
       in
       let with_turn_event_bus_lock f =
-        Stdlib.Mutex.lock turn_event_bus_mu;
-        Fun.protect
-          ~finally:(fun () -> Stdlib.Mutex.unlock turn_event_bus_mu)
-          f
+        Eio.Mutex.use_rw ~protect:true turn_event_bus_mu f
       in
       let push_pending_input tool_name input =
         let q =

--- a/lib/keeper_voice_local.ml
+++ b/lib/keeper_voice_local.ml
@@ -20,7 +20,7 @@ let resolved_base_path_opt () =
 let masc_base_dir () =
   match resolved_base_path_opt () with
   | Some base_path -> Coord_utils.masc_dir_from_base_path ~base_path
-  | None -> ".masc"
+  | None -> Common.masc_dirname
 
 (** Singleton session manager, lazily initialized.
     Thread-safety: safe under single Eio domain — all fibers share one

--- a/lib/legendary_counters.ml
+++ b/lib/legendary_counters.ml
@@ -47,7 +47,7 @@ let bare_reason s =
     else s
   in
   strip "too_complex:" |> fun s ->
-  if String.length s >= 14 && String.sub s 0 14 = "parse_aborted:"
+  if Base.String.is_prefix s ~prefix:"parse_aborted:"
   then "__parse_aborted__"
   else s
 

--- a/lib/legendary_counters.ml
+++ b/lib/legendary_counters.ml
@@ -41,10 +41,9 @@ let incr_auto_bg_observed ~promoted_candidate =
    bare reason name. *)
 let bare_reason s =
   let strip prefix =
-    let n = String.length prefix in
-    if String.length s >= n && String.sub s 0 n = prefix
-    then String.sub s n (String.length s - n)
-    else s
+    match Base.String.chop_prefix s ~prefix with
+    | Some rest -> rest
+    | None -> s
   in
   strip "too_complex:" |> fun s ->
   if Base.String.is_prefix s ~prefix:"parse_aborted:"

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -16,7 +16,7 @@ let resolve_join_state ~room_initialized ~join_required ~agent_name ~check_join 
     false
 
 let is_ephemeral_agent_name name =
-  String.length name >= 6 && String.sub name 0 6 = "agent-"
+  Base.String.is_prefix name ~prefix:"agent-"
 
 let is_transient_agent_name name =
   is_ephemeral_agent_name name || Nickname.is_generated_nickname name

--- a/lib/mcp_server_eio_resource.ml
+++ b/lib/mcp_server_eio_resource.ml
@@ -166,7 +166,7 @@ let handle_read_resource_eio state id params =
                 ("application/json", Some content)
               else
                 ("application/json", Some "{\"error\": \"No institution memory found\"}")
-          | s when String.length s >= 7 && String.sub s 0 7 = "library" ->
+          | s when Base.String.is_prefix s ~prefix:"library" ->
               let library_dir = Filename.concat config.base_path "docs/library" in
               if not (Sys.file_exists library_dir) then
                 ("text/markdown", Some "Library directory not found. Create docs/library/ first.")
@@ -219,7 +219,7 @@ let handle_read_resource_eio state id params =
                   with Sys_error _ -> (fallback_name, "", "", "", [])
                 in
                 let strip_frontmatter content =
-                  if String.length content >= 3 && String.sub content 0 3 = "---" then
+                  if Base.String.is_prefix content ~prefix:"---" then
                     match String.index_from_opt content 3 '\n' with
                     | None -> content
                     | Some first_nl ->

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -185,8 +185,8 @@ let make_zero_zombie_consumer ~sw ~room_config
           if String.length status_trimmed > 0 then begin
             let has_zombie_indicator =
               try
-                String.sub status_trimmed 0 (min 4 (String.length status_trimmed)) = "\xf0\x9f\xa7\x9f" ||
-                String.length status_trimmed >= 7 && String.sub status_trimmed 0 7 = "Cleaned"
+                Base.String.is_prefix status_trimmed ~prefix:"\xf0\x9f\xa7\x9f" ||
+                Base.String.is_prefix status_trimmed ~prefix:"Cleaned"
               with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                 Log.Orchestrator.warn "zombie indicator check failed: %s" (Printexc.to_string exn);
                 false

--- a/lib/process/exec_tap.ml
+++ b/lib/process/exec_tap.ml
@@ -193,22 +193,19 @@ let install_from_env () =
       (match result with
        | Ok fd ->
            let mu = Mutex.create () in
+           let rec write_all fd buf off remaining =
+             if remaining <= 0 then ()
+             else match Unix.write_substring fd buf off remaining with
+               | 0 -> raise (Unix.Unix_error (Unix.EIO, "write_substring", ""))
+               | n -> write_all fd buf (off + n) (remaining - n)
+           in
            let writer line =
              Mutex.lock mu;
              Fun.protect
                ~finally:(fun () -> Mutex.unlock mu)
                (fun () ->
                   let len = String.length line in
-                  let rec write_all offset =
-                    if offset >= len then ()
-                    else
-                      let written = Unix.write_substring fd line offset (len - offset) in
-                      if written = 0 then
-                        raise (Failure "write_all: zero-byte write")
-                      else
-                        write_all (offset + written)
-                  in
-                  write_all 0)
+                  write_all fd line 0 len)
            in
            enable ~writer;
            Printf.eprintf "[exec_tap] enabled \xe2\x86\x92 %s\n%!" out_path

--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -700,14 +700,18 @@ let spawn_detached ~argv ~env ~cwd =
            Safe_ops.protect ~default:() (fun () -> ignore (Unix.setsid ()));
            (try
               if cwd <> "" then Unix.chdir cwd
-            with _ -> Unix._exit 126);
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | _ -> Unix._exit 126);
            Unix.dup2 devnull Unix.stdin;
            Unix.dup2 out_w Unix.stdout;
            Unix.dup2 err_w Unix.stderr;
            Unix.close out_r; Unix.close err_r;
            Unix.close out_w; Unix.close err_w; Unix.close devnull;
            (try Unix.execvpe bin (Array.of_list argv) env
-            with _ -> Unix._exit 127)
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | _ -> Unix._exit 127)
          end else begin
            (* --- PARENT --- *)
            Unix.close out_w;

--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -31,6 +31,8 @@ let is_initialized () = Option.is_some (Atomic.get runtime_state)
 let reset_for_testing () =
   Atomic.set runtime_state None
 
+let default_buffer_size = 1024
+
 let get_proc_mgr () =
   match Atomic.get runtime_state with
   | Some runtime -> Ok runtime.proc_mgr
@@ -250,7 +252,7 @@ let with_unix_capture ?env ?cwd ?stdin_content ?(capture_stderr = false)
               | Unix.Unix_error (Unix.EINTR, _, _) -> None
               | Unix.Unix_error (Unix.ECHILD, _, _) -> Some (Unix.WEXITED 127)
             in
-            let stdout_buf = Buffer.create 1024 in
+            let stdout_buf = Buffer.create default_buffer_size in
             let chunk = Bytes.create 4096 in
             let read_available () =
               let rec loop () =
@@ -459,7 +461,7 @@ let run_argv ?(timeout_sec = 60.0) ?env (argv : string list) : string =
     | Error _, _, _ | _, Error _, _ | _, _, Error _ ->
         run_unix_argv_fallback ~timeout_sec ?env argv
     | Ok pm, Ok clk, Ok cwd ->
-        let buf = Buffer.create 1024 in
+        let buf = Buffer.create default_buffer_size in
         let label = String.concat " " (List.map Filename.quote argv) in
         try
           Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
@@ -493,7 +495,7 @@ let run_argv_with_stdin ?(timeout_sec = 60.0) ?env ~(stdin_content : string) (ar
     | Error _, _, _ | _, Error _, _ | _, _, Error _ ->
         run_unix_argv_with_stdin_fallback ~timeout_sec ?env ~stdin_content argv
     | Ok pm, Ok clk, Ok cwd ->
-        let buf = Buffer.create 1024 in
+        let buf = Buffer.create default_buffer_size in
         let label = String.concat " " (List.map Filename.quote argv) in
         let stdin_source = Eio.Flow.string_source stdin_content in
         try
@@ -540,8 +542,8 @@ let run_argv_with_stdin_and_status_split
           | None -> default_cwd
           | Some dir -> Eio.Path.(default_cwd / dir)
         in
-        let stdout_buf = Buffer.create 1024 in
-        let stderr_buf = Buffer.create 1024 in
+        let stdout_buf = Buffer.create default_buffer_size in
+        let stderr_buf = Buffer.create default_buffer_size in
         let label = String.concat " " (List.map Filename.quote argv) in
         let stdin_source = Eio.Flow.string_source stdin_content in
         try
@@ -609,7 +611,7 @@ let run_argv_with_status_split ?(timeout_sec = 60.0) ?env ?cwd
           | None -> default_cwd
           | Some dir -> Eio.Path.(default_cwd / dir)
         in
-        let stdout_buf = Buffer.create 1024 in
+        let stdout_buf = Buffer.create default_buffer_size in
         let stderr_buf = Buffer.create 256 in
         let label = String.concat " " (List.map Filename.quote argv) in
         try

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -224,6 +224,10 @@ let metric_mcp_tool_schema_count = "masc_mcp_tool_schema_count"
 let metric_mcp_tool_schema_tokens_approx =
   "masc_mcp_tool_schema_tokens_approx"
 
+(* Process-level FD gauges — used in init() and update_fd_gauges. *)
+let metric_open_fds = "masc_process_open_fds"
+let metric_fd_warn_threshold = "masc_process_fd_warn_threshold"
+
 (** {1 Built-in Metrics} *)
 
 let init () =
@@ -350,15 +354,12 @@ let init () =
      time series before it crosses the OS limit and crashes the server.
      Evidence: 2026-04-16 production incident, 4029 CLOSE_WAIT sockets
      accumulated before the accept() path started failing. *)
-  let fd_open = "masc_process_open_fds" in
-  let fd_threshold = "masc_process_fd_warn_threshold" in
-  add fd_open
+  add metric_open_fds
     "Approximate count of open file descriptors for the server process \
      (derived from /dev/fd). Ramp indicates a socket/file leak." Gauge;
-  add fd_threshold
+  add metric_fd_warn_threshold
     "Threshold above which open_fds triggers a one-shot WARN log." Gauge;
-  set_gauge fd_threshold
-    (float_of_int (Env_config_core.get_int ~default:3000 "MASC_FD_WARN_THRESHOLD" |> max 1));
+  set_gauge metric_fd_warn_threshold (float_of_int fd_warn_threshold);
   (* Per-keeper turn outcome + token counters.  Labels are populated
      dynamically via inc_counter; no upfront registration needed.
      Covers issues #7495 (cost/token attribution) and #7519 (SLO). *)
@@ -411,8 +412,6 @@ let init () =
     "Total Oas.Event_bus.publish calls routed through \
      Oas_bus_instrument.publish."
     Counter
-
-let metric_open_fds = "masc_process_open_fds"
 
 let start_time = Time_compat.now ()
 

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -224,6 +224,32 @@ let metric_mcp_tool_schema_count = "masc_mcp_tool_schema_count"
 let metric_mcp_tool_schema_tokens_approx =
   "masc_mcp_tool_schema_tokens_approx"
 
+(* Transport metrics — used in transport_metrics.ml. *)
+let metric_sse_sessions = "masc_sse_sessions_total"
+let metric_sse_broadcast_duration = "masc_sse_broadcast_duration_seconds"
+let metric_sse_broadcast_events = "masc_sse_broadcast_events_total"
+let metric_sse_stream_queue_depth = "masc_sse_stream_queue_depth"
+let metric_sse_queue_depth_avg = "masc_sse_queue_depth_avg"
+let metric_sse_queue_depth_max = "masc_sse_queue_depth_max"
+let metric_sse_external_subscribers = "masc_sse_external_subscribers_total"
+let metric_grpc_active_streams = "masc_grpc_active_streams_total"
+let metric_grpc_heartbeat_latency = "masc_grpc_heartbeat_latency_seconds"
+let metric_grpc_subscribers = "masc_grpc_subscribers_total"
+let metric_grpc_events_delivered = "masc_grpc_events_delivered_total"
+let metric_ws_sessions = "masc_ws_sessions_total"
+
+(* Admission queue metrics — used in admission_queue_metrics.ml. *)
+let metric_inference_queue_depth = "masc_inference_queue_depth"
+let metric_inference_queue_inflight = "masc_inference_queue_inflight"
+let metric_inference_queue_acquired = "masc_inference_queue_acquired_total"
+let metric_inference_queue_wait = "masc_inference_queue_wait_seconds"
+let metric_inference_queue_cancelled = "masc_inference_queue_cancelled_total"
+let metric_inference_queue_max_concurrent = "masc_inference_queue_max_concurrent"
+
+(* Agent health metrics — used in transport_metrics.ml. *)
+let metric_agent_heartbeat_age_seconds = "masc_agent_heartbeat_age_seconds"
+let metric_agent_stale_total = "masc_agent_stale_total"
+
 (* Process-level FD gauges — used in init() and update_fd_gauges. *)
 let metric_open_fds = "masc_process_open_fds"
 let metric_fd_warn_threshold = "masc_process_fd_warn_threshold"
@@ -339,10 +365,10 @@ let init () =
   add "masc_board_truncated_posts_total"
     "Total board posts truncated due to size limits"
     Counter;
-  add "masc_agent_heartbeat_age_seconds"
+  add metric_agent_heartbeat_age_seconds
     "Maximum observed heartbeat age across active agents (seconds)"
     Gauge;
-  add "masc_agent_stale_total"
+  add metric_agent_stale_total
     "Total agents marked stale due to missed heartbeats"
     Counter;
   register_histogram ~name:"masc_llm_provider_request_latency_seconds"
@@ -359,7 +385,6 @@ let init () =
      (derived from /dev/fd). Ramp indicates a socket/file leak." Gauge;
   add metric_fd_warn_threshold
     "Threshold above which open_fds triggers a one-shot WARN log." Gauge;
-  set_gauge metric_fd_warn_threshold (float_of_int fd_warn_threshold);
   (* Per-keeper turn outcome + token counters.  Labels are populated
      dynamically via inc_counter; no upfront registration needed.
      Covers issues #7495 (cost/token attribution) and #7519 (SLO). *)
@@ -411,7 +436,27 @@ let init () =
   add "masc_oas_bus_publish_total"
     "Total Oas.Event_bus.publish calls routed through \
      Oas_bus_instrument.publish."
-    Counter
+    Counter;
+  (* Transport metrics — registered here so transport_metrics.ml can use
+     module constants instead of string literals. *)
+  add metric_sse_sessions "Active SSE sessions by kind" Gauge;
+  register_histogram ~name:metric_sse_broadcast_duration
+    ~help:"Time to fan-out a broadcast to all SSE clients" ();
+  add metric_sse_broadcast_events "Total SSE broadcast events emitted" Counter;
+  add metric_sse_stream_queue_depth
+    "Per-session SSE event stream queue depth" Gauge;
+  add metric_sse_queue_depth_avg
+    "Average SSE event queue depth across live sessions" Gauge;
+  add metric_sse_queue_depth_max
+    "Maximum SSE event queue depth across live sessions" Gauge;
+  add metric_sse_external_subscribers
+    "Active non-SSE subscribers bridged from the SSE fanout path" Gauge;
+  add metric_grpc_active_streams "Active gRPC bidirectional streams" Gauge;
+  register_histogram ~name:metric_grpc_heartbeat_latency
+    ~help:"gRPC heartbeat round-trip latency" ();
+  add metric_grpc_subscribers "Active gRPC Subscribe stream subscribers" Gauge;
+  add metric_grpc_events_delivered "Total events delivered via gRPC streams" Counter;
+  add metric_ws_sessions "Active standalone WebSocket sessions" Gauge
 
 let start_time = Time_compat.now ()
 
@@ -420,6 +465,8 @@ let update_uptime () =
 
 let fd_warn_threshold =
   Env_config_core.get_int ~default:3000 "MASC_FD_WARN_THRESHOLD" |> max 1
+
+let () = set_gauge metric_fd_warn_threshold (float_of_int fd_warn_threshold)
 
 let fd_warned_once = ref false
 

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -254,6 +254,45 @@ let metric_agent_stale_total = "masc_agent_stale_total"
 let metric_open_fds = "masc_process_open_fds"
 let metric_fd_warn_threshold = "masc_process_fd_warn_threshold"
 
+(* Core counters / gauges — used outside init. *)
+let metric_mcp_requests = "masc_mcp_requests_total"
+let metric_llm_inference_duration = "masc_llm_inference_duration_seconds"
+let metric_after_turn_hook = "masc_after_turn_hook_total"
+let metric_after_turn_telemetry_missing =
+  "masc_after_turn_telemetry_missing_total"
+let metric_after_turn_telemetry_zero_latency =
+  "masc_after_turn_telemetry_zero_latency_total"
+let metric_tasks = "masc_tasks_total"
+let metric_errors = "masc_errors_total"
+let metric_error_events = "masc_error_events_total"
+let metric_active_agents = "masc_active_agents"
+let metric_pending_tasks = "masc_pending_tasks"
+let metric_uptime_seconds = "masc_uptime_seconds"
+let metric_sse_connections_active = "masc_sse_connections_active"
+let metric_sse_reconnects = "masc_sse_reconnects_total"
+let metric_sse_idle_evictions = "masc_sse_idle_evictions_total"
+let metric_sse_capacity_evictions = "masc_sse_capacity_evictions_total"
+let metric_sse_write_failures = "masc_sse_write_failures_total"
+let metric_sse_rejects = "masc_sse_rejects_total"
+let metric_provider_prefix_cache_creation_tokens =
+  "masc_provider_prefix_cache_creation_tokens_total"
+let metric_provider_prefix_cache_read_tokens =
+  "masc_provider_prefix_cache_read_tokens_total"
+let metric_tool_call = "masc_tool_call_total"
+let metric_tool_call_duration = "masc_tool_call_duration_seconds"
+let metric_llm_provider_http_status = "masc_llm_provider_http_status_total"
+let metric_llm_provider_request_latency =
+  "masc_llm_provider_request_latency_seconds"
+
+(* Domain-specific counters not yet constant-ised. *)
+let metric_board_truncated_posts = "masc_board_truncated_posts_total"
+let metric_cascade_strategy_decisions = "masc_cascade_strategy_decisions_total"
+let metric_cascade_capacity_events = "masc_cascade_capacity_events_total"
+let metric_keeper_invariant_violations = "masc_keeper_invariant_violations_total"
+let metric_oas_bus_subscriber_stream_depth = "masc_oas_bus_subscriber_stream_depth"
+let metric_oas_bus_publish_block_seconds = "masc_oas_bus_publish_block_seconds_total"
+let metric_oas_bus_publish = "masc_oas_bus_publish_total"
+
 (** {1 Built-in Metrics} *)
 
 let init () =
@@ -264,28 +303,28 @@ let init () =
     if not (Hashtbl.mem metrics key) then
       Hashtbl.add metrics key { name; help; metric_type = mt; value = 0.0; labels = [] }
   in
-  add "masc_mcp_requests_total" "Total MCP requests received" Counter;
-  add "masc_llm_inference_duration_seconds" "LLM inference request duration in seconds" Histogram;
-  add "masc_after_turn_hook_total"
+  add metric_mcp_requests "Total MCP requests received" Counter;
+  add metric_llm_inference_duration "LLM inference request duration in seconds" Histogram;
+  add metric_after_turn_hook
     "Times the keeper AfterTurn hook ran (labeled by model). Divergence from \
      masc_llm_inference_duration_seconds_count identifies missing telemetry." Counter;
-  add "masc_after_turn_telemetry_missing_total"
+  add metric_after_turn_telemetry_missing
     "AfterTurn responses where response.telemetry was None." Counter;
-  add "masc_after_turn_telemetry_zero_latency_total"
+  add metric_after_turn_telemetry_zero_latency
     "AfterTurn responses where telemetry was present but request_latency_ms was 0." Counter;
-  add "masc_tasks_total" "Total tasks processed" Counter;
-  add "masc_errors_total" "Total errors" Counter;
-  add "masc_error_events_total"
+  add metric_tasks "Total tasks processed" Counter;
+  add metric_errors "Total errors" Counter;
+  add metric_error_events
     "Error events by type (parsing, missing_config, etc.)" Counter;
-  add "masc_active_agents" "Currently active agents" Gauge;
-  add "masc_pending_tasks" "Tasks waiting to be claimed" Gauge;
-  add "masc_uptime_seconds" "Server uptime in seconds" Gauge;
-  add "masc_sse_connections_active" "Active SSE connections" Gauge;
-  add "masc_sse_reconnects_total" "Total SSE reconnects (same session reattached)" Counter;
-  add "masc_sse_idle_evictions_total" "Total SSE clients evicted by idle reaper" Counter;
-  add "masc_sse_capacity_evictions_total" "Total SSE clients evicted due to max client capacity" Counter;
-  add "masc_sse_write_failures_total" "Total SSE write failures by reason" Counter;
-  add "masc_sse_rejects_total" "Total SSE connections rejected by storm guard" Counter;
+  add metric_active_agents "Currently active agents" Gauge;
+  add metric_pending_tasks "Tasks waiting to be claimed" Gauge;
+  add metric_uptime_seconds "Server uptime in seconds" Gauge;
+  add metric_sse_connections_active "Active SSE connections" Gauge;
+  add metric_sse_reconnects "Total SSE reconnects (same session reattached)" Counter;
+  add metric_sse_idle_evictions "Total SSE clients evicted by idle reaper" Counter;
+  add metric_sse_capacity_evictions "Total SSE clients evicted due to max client capacity" Counter;
+  add metric_sse_write_failures "Total SSE write failures by reason" Counter;
+  add metric_sse_rejects "Total SSE connections rejected by storm guard" Counter;
   (* Keeper compaction metrics — emitted by keeper_compact_policy.ml *)
   add metric_keeper_compactions
     "Total keeper compactions performed" Counter;
@@ -305,33 +344,33 @@ let init () =
     "Total keeper heartbeat failures" Counter;
   register_histogram ~name:metric_keeper_tool_call_duration
     ~help:"Keeper tool call latency in seconds, labeled by keeper, provider, tool, and outcome" ();
-  add "masc_provider_prefix_cache_creation_tokens_total"
+  add metric_provider_prefix_cache_creation_tokens
     "Total provider prefix cache creation tokens (Anthropic)" Counter;
-  add "masc_provider_prefix_cache_read_tokens_total"
+  add metric_provider_prefix_cache_read_tokens
     "Total provider prefix cache read tokens (Anthropic)" Counter;
-  add "masc_tool_call_total"
+  add metric_tool_call
     "Total keeper tool calls labeled by provider, tool, and outcome" Counter;
-  register_histogram ~name:"masc_tool_call_duration_seconds"
+  register_histogram ~name:metric_tool_call_duration
     ~help:"Tool call latency in seconds" ();
   (* Inference admission queue metrics *)
-  add "masc_inference_queue_inflight"
+  add metric_inference_queue_inflight
     "Concurrent inference calls holding an admission permit" Gauge;
-  add "masc_inference_queue_depth"
+  add metric_inference_queue_depth
     "Callers waiting in the admission queue" Gauge;
-  add "masc_inference_queue_max_concurrent"
+  add metric_inference_queue_max_concurrent
     "Configured max concurrent admission permits" Gauge;
-  add "masc_inference_queue_acquired_total"
+  add metric_inference_queue_acquired
     "Total admission permits acquired" Counter;
-  add "masc_inference_queue_cancelled_total"
+  add metric_inference_queue_cancelled
     "Total admission waits cancelled by fiber cancellation" Counter;
-  register_histogram ~name:"masc_inference_queue_wait_seconds"
+  register_histogram ~name:metric_inference_queue_wait
     ~help:"Time waiting in admission queue before exchanging for permit" ();
   (* LLM provider HTTP response counter — emitted by Llm_metric_bridge
      via the OAS Metrics.t on_http_status hook.  Labels are populated
      dynamically per call; no initial registration with zero-value rows
      is needed because inc_counter auto-creates the label series on
      first observation. *)
-  add "masc_llm_provider_http_status_total"
+  add metric_llm_provider_http_status
     "Total HTTP responses from LLM providers, labeled by provider, model, and status code"
     Counter;
   (* Orphan metrics — used via inc_counter/set_gauge but previously
@@ -362,7 +401,7 @@ let init () =
   add metric_oas_sse_relay_queue_depth
     "Current in-memory OAS SSE relay retry queue depth"
     Gauge;
-  add "masc_board_truncated_posts_total"
+  add metric_board_truncated_posts
     "Total board posts truncated due to size limits"
     Counter;
   add metric_agent_heartbeat_age_seconds
@@ -371,7 +410,7 @@ let init () =
   add metric_agent_stale_total
     "Total agents marked stale due to missed heartbeats"
     Counter;
-  register_histogram ~name:"masc_llm_provider_request_latency_seconds"
+  register_histogram ~name:metric_llm_provider_request_latency
     ~help:"Per-HTTP-request LLM latency from OAS on_request_end callback. \
            Independent from masc_llm_inference_duration_seconds (turn-scope) — \
            this fires per provider HTTP call regardless of keeper hook health." ();
@@ -420,20 +459,20 @@ let init () =
     Gauge;
   (* OAS Event_bus backpressure observability (see oas_bus_instrument.ml).
      Label series are populated dynamically per subscriber_purpose. *)
-  add "masc_oas_bus_subscriber_stream_depth"
+  add metric_oas_bus_subscriber_stream_depth
     "Estimated OAS Event_bus per-subscriber stream depth, labeled by \
      subscriber_purpose. Indirect measure: publishes_matching_filter - \
      events_drained, tracked MASC-side for subscriptions created via \
      Oas_bus_instrument. OAS uses bounded Eio.Stream (default 256); values \
      approaching this cap indicate impending publish blocking."
     Gauge;
-  add "masc_oas_bus_publish_block_seconds_total"
+  add metric_oas_bus_publish_block_seconds
     "Cumulative seconds spent inside Oas.Event_bus.publish when routed \
      through Oas_bus_instrument.publish. A sustained ramp indicates a \
      subscriber drain loop has fallen behind and publishers are blocking \
      on Eio.Stream.add."
     Counter;
-  add "masc_oas_bus_publish_total"
+  add metric_oas_bus_publish
     "Total Oas.Event_bus.publish calls routed through \
      Oas_bus_instrument.publish."
     Counter;
@@ -461,7 +500,7 @@ let init () =
 let start_time = Time_compat.now ()
 
 let update_uptime () =
-  set_gauge "masc_uptime_seconds" (Time_compat.now () -. start_time)
+  set_gauge metric_uptime_seconds (Time_compat.now () -. start_time)
 
 let fd_warn_threshold =
   Env_config_core.get_int ~default:3000 "MASC_FD_WARN_THRESHOLD" |> max 1
@@ -605,19 +644,19 @@ let to_prometheus_text () =
 (** {1 Convenience Functions} *)
 
 let record_request () =
-  inc_counter "masc_mcp_requests_total" ()
+  inc_counter metric_mcp_requests ()
 
 let record_task_completed () =
-  inc_counter "masc_tasks_total" ~labels:[("status", "completed")] ()
+  inc_counter metric_tasks ~labels:[("status", "completed")] ()
 
 let record_task_failed () =
-  inc_counter "masc_tasks_total" ~labels:[("status", "failed")] ()
+  inc_counter metric_tasks ~labels:[("status", "failed")] ()
 
 let record_error ?(error_type="unknown") () =
-  inc_counter "masc_errors_total" ~labels:[("type", error_type)] ()
+  inc_counter metric_errors ~labels:[("type", error_type)] ()
 
 let set_active_agents count =
-  set_gauge "masc_active_agents" (float_of_int count)
+  set_gauge metric_active_agents (float_of_int count)
 
 let set_pending_tasks count =
   set_gauge "masc_pending_tasks" (float_of_int count)

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -91,6 +91,35 @@ val metric_oas_sse_relay_queue_depth : string
 val metric_mcp_tool_schema_count : string
 val metric_mcp_tool_schema_tokens_approx : string
 
+(** {1 Transport metrics} *)
+
+val metric_sse_sessions : string
+val metric_sse_broadcast_duration : string
+val metric_sse_broadcast_events : string
+val metric_sse_stream_queue_depth : string
+val metric_sse_queue_depth_avg : string
+val metric_sse_queue_depth_max : string
+val metric_sse_external_subscribers : string
+val metric_grpc_active_streams : string
+val metric_grpc_heartbeat_latency : string
+val metric_grpc_subscribers : string
+val metric_grpc_events_delivered : string
+val metric_ws_sessions : string
+
+(** {1 Admission queue metrics} *)
+
+val metric_inference_queue_depth : string
+val metric_inference_queue_inflight : string
+val metric_inference_queue_acquired : string
+val metric_inference_queue_wait : string
+val metric_inference_queue_cancelled : string
+val metric_inference_queue_max_concurrent : string
+
+(** {1 Agent health metrics} *)
+
+val metric_agent_heartbeat_age_seconds : string
+val metric_agent_stale_total : string
+
 (** {1 Process monitoring} *)
 
 val approximate_open_fd_count : unit -> int

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -91,6 +91,39 @@ val metric_oas_sse_relay_queue_depth : string
 val metric_mcp_tool_schema_count : string
 val metric_mcp_tool_schema_tokens_approx : string
 
+(** {1 Core counters / gauges} *)
+
+val metric_mcp_requests : string
+val metric_llm_inference_duration : string
+val metric_after_turn_hook : string
+val metric_after_turn_telemetry_missing : string
+val metric_after_turn_telemetry_zero_latency : string
+val metric_tasks : string
+val metric_errors : string
+val metric_error_events : string
+val metric_active_agents : string
+val metric_pending_tasks : string
+val metric_uptime_seconds : string
+val metric_sse_connections_active : string
+val metric_sse_reconnects : string
+val metric_sse_idle_evictions : string
+val metric_sse_capacity_evictions : string
+val metric_sse_write_failures : string
+val metric_sse_rejects : string
+val metric_provider_prefix_cache_creation_tokens : string
+val metric_provider_prefix_cache_read_tokens : string
+val metric_tool_call : string
+val metric_tool_call_duration : string
+val metric_llm_provider_http_status : string
+val metric_llm_provider_request_latency : string
+val metric_board_truncated_posts : string
+val metric_cascade_strategy_decisions : string
+val metric_cascade_capacity_events : string
+val metric_keeper_invariant_violations : string
+val metric_oas_bus_subscriber_stream_depth : string
+val metric_oas_bus_publish_block_seconds : string
+val metric_oas_bus_publish : string
+
 (** {1 Transport metrics} *)
 
 val metric_sse_sessions : string

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -1317,9 +1317,7 @@ let gemini_vertex_openai_base_url ~project ~location =
     "https://aiplatform.googleapis.com/v1/projects/%s/locations/%s/endpoints/openapi"
     project location
 
-let starts_with ~prefix s =
-  let plen = String.length prefix in
-  String.length s >= plen && String.sub s 0 plen = prefix
+let starts_with ~prefix s = Base.String.is_prefix s ~prefix
 
 let is_kimi_model_id model_id =
   let normalized = String.trim model_id |> String.lowercase_ascii in

--- a/lib/relay.ml
+++ b/lib/relay.ml
@@ -59,7 +59,9 @@ let calibration = {
 }
 
 (* Serialises writers of the compound [samples+correction_factor] update.
-   Readers of [correction_factor] rely on [@atomic] and do not take the lock. *)
+   Readers of [correction_factor] rely on [@atomic] and do not take the lock.
+   Stdlib.Mutex: this module has no Eio context; calibration only touched by
+   test code (see test/test_relay_coverage.ml). *)
 let calibration_lock = Mutex.create ()
 
 (** Record actual token count vs estimated for calibration.

--- a/lib/run_eio.ml
+++ b/lib/run_eio.ml
@@ -46,7 +46,7 @@ let run_record_of_json (json : Yojson.Safe.t) : run_record option =
     let deliverable = Safe_ops.json_string ~default:"" "deliverable" json in
     Some { task_id; agent_name; plan; deliverable; created_at; updated_at }
   | _ ->
-    Prometheus.inc_counter "masc_error_events_total" ~labels:[("type", "parsing")] ();
+    Prometheus.inc_counter Prometheus.metric_error_events ~labels:[("type", "parsing")] ();
     Log.Misc.error "run_of_json: missing required fields";
     None
 
@@ -62,7 +62,7 @@ let log_entry_of_json (json : Yojson.Safe.t) : log_entry option =
   | Some timestamp, Some note ->
     Some { timestamp; note }
   | _ ->
-    Prometheus.inc_counter "masc_error_events_total" ~labels:[("type", "parsing")] ();
+    Prometheus.inc_counter Prometheus.metric_error_events ~labels:[("type", "parsing")] ();
     Log.Misc.error "log_entry_of_json: missing required fields";
     None
 

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -145,9 +145,7 @@ let parse_host_port host_header default_host default_port =
         with Eio.Cancel.Cancelled _ as e -> raise e | _ -> (default_host, default_port))
 
 (** Utility: string prefix check *)
-let starts_with ~prefix s =
-  let plen = String.length prefix in
-  String.length s >= plen && String.sub s 0 plen = prefix
+let starts_with ~prefix s = Base.String.is_prefix s ~prefix
 
 (** Allowed origins for DNS rebinding protection.
     SSOT: [Masc_network_defaults.allowed_origins]. *)

--- a/lib/server/server_routes_http_pages.ml
+++ b/lib/server/server_routes_http_pages.ml
@@ -294,7 +294,9 @@ let bonsai_asset_mtime filename =
   try
     let st = Unix.stat path in
     Printf.sprintf "%d" (Float.to_int st.st_mtime)
-  with _ -> "0"
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ -> "0"
 
 let bonsai_bundle_version () = bonsai_asset_mtime "main.bc.js"
 let bonsai_tokens_version () = bonsai_asset_mtime "colors_and_type.css"

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -191,7 +191,9 @@ let rec add_routes ~sw ~clock router =
            let raw_result : (string, string) result =
              if Fs_compat.file_exists token_file then
                try Ok (String.trim (Fs_compat.load_file token_file))
-               with exn ->
+               with
+               | Eio.Cancel.Cancelled _ as e -> raise e
+               | exn ->
                  Error
                    (Printf.sprintf "read dev-token: %s"
                       (Printexc.to_string exn))
@@ -205,7 +207,9 @@ let rec add_routes ~sw ~clock router =
                    (try
                       Auth.save_private_text_file token_file raw;
                       Ok raw
-                    with exn ->
+                    with
+                    | Eio.Cancel.Cancelled _ as e -> raise e
+                    | exn ->
                       Error
                         (Printf.sprintf "persist dev-token: %s"
                            (Printexc.to_string exn)))

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -522,7 +522,9 @@ let atomic_write_file ~(path : string) (content : string) : (unit, string) resul
       (fun () -> output_string oc content);
     Sys.rename tmp path;
     Ok ()
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
     (try Sys.remove tmp with Sys_error _ -> ());
     Error (Printf.sprintf "atomic write failed: %s" (Printexc.to_string exn))
 

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -596,7 +596,9 @@ let sync_client_token_file ~base_path ~agent_name ~default_role =
            Log.Server.warn
              "startup %s raw bearer token file for %s at %s"
              reason agent_name token_file
-         with exn ->
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
            Log.Server.error
              "startup failed to persist raw bearer token file for %s at %s: %s"
              agent_name token_file (Printexc.to_string exn))
@@ -611,7 +613,9 @@ let sync_client_token_file ~base_path ~agent_name ~default_role =
       Log.Server.info
         "startup verified raw bearer token file for %s at %s"
         agent_name token_file
-    with exn ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
       Log.Server.error
         "startup failed to normalize raw bearer token file for %s at %s: %s"
         agent_name token_file (Printexc.to_string exn)
@@ -621,7 +625,9 @@ let sync_client_token_file ~base_path ~agent_name ~default_role =
       try
         let raw = String.trim (Fs_compat.load_file token_file) in
         if raw = "" then None else Some raw
-      with exn ->
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
         Log.Server.warn
           "startup failed to read raw bearer token file for %s at %s: %s"
           agent_name token_file (Printexc.to_string exn);

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -278,7 +278,7 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   (match Keeper_exec_tools.init_policy_config ~base_path with
    | Ok () -> ()
    | Error msg ->
-       Prometheus.inc_counter "masc_error_events_total" ~labels:[("type", "missing_config")] ();
+       Prometheus.inc_counter Prometheus.metric_error_events ~labels:[("type", "missing_config")] ();
       Log.Server.error "Fatal tool policy config load failure: %s" msg;
        exit 1);
   (* Validate Tool_spec <-> TOML coverage *)
@@ -659,7 +659,7 @@ let bootstrap_prompt_state (state : Mcp_server.server_state) =
   let missing_prompt_files = Prompt_registry.validate_required_prompt_files () in
   if missing_prompt_files <> [] then
     begin
-    Prometheus.inc_counter "masc_error_events_total" ~labels:[("type", "missing_config")] ();
+    Prometheus.inc_counter Prometheus.metric_error_events ~labels:[("type", "missing_config")] ();
     Log.Misc.error "required prompt files missing: %s"
       (missing_prompt_files
       |> List.map (fun (key, path) -> Printf.sprintf "%s -> %s" key path)
@@ -668,7 +668,7 @@ let bootstrap_prompt_state (state : Mcp_server.server_state) =
   let invalid_prompt_templates = Prompt_registry.validate_prompt_templates () in
   if invalid_prompt_templates <> [] then
     begin
-    Prometheus.inc_counter "masc_error_events_total" ~labels:[("type", "missing_config")] ();
+    Prometheus.inc_counter Prometheus.metric_error_events ~labels:[("type", "missing_config")] ();
     Log.Misc.error "prompt templates use unknown variables: %s"
       (invalid_prompt_templates
       |> List.map (fun (key, variable) -> Printf.sprintf "%s -> %s" key variable)

--- a/lib/server/server_startup_takeover.ml
+++ b/lib/server/server_startup_takeover.ml
@@ -5,7 +5,7 @@ type acquire_result =
 let pid_lock_path port = Printf.sprintf "/tmp/masc-%d.pid" port
 
 let base_path_lock_path base_path =
-  Filename.concat (Filename.concat base_path ".masc") "server-owner.pid"
+  Filename.concat (Filename.concat base_path Common.masc_dirname) "server-owner.pid"
 
 let close_quietly fd =
   try Unix.close fd with

--- a/lib/tool_assignment_telemetry.ml
+++ b/lib/tool_assignment_telemetry.ml
@@ -284,7 +284,9 @@ let warm_up () : unit =
               Hashtbl.replace agent_index agent_id assignment_id
           | _ -> ())
         jsons)
-  with _ -> ()
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> Log.Telemetry.warn "warm_up failed: %s" (Printexc.to_string exn)
 
 let reset_for_testing () : unit =
   store_ref := None;

--- a/lib/tool_blob_store/tool_output.ml
+++ b/lib/tool_blob_store/tool_output.ml
@@ -25,4 +25,5 @@ let decode_from_oas s =
         "[masc:blob sha256=%s@ bytes=%d mime=%s@ preview=%S]"
         (fun sha256 bytes mime preview ->
           Stored { sha256; bytes; preview; mime })
-    with _ -> Inline s
+    with
+    | Scanf.Scan_failure _ | Failure _ | Invalid_argument _ -> Inline s

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -319,7 +319,7 @@ let handle_post_create args =
         | Some a when a <> "" -> a
         | _ -> "unknown"
       in
-      Prometheus.inc_counter "masc_board_truncated_posts_total"
+      Prometheus.inc_counter Prometheus.metric_board_truncated_posts
         ~labels:[("author", author_label)] ();
       Log.BoardLog.warn
         "board_post: detected truncated markdown (author=%s body_len=%d) — appending 잘림 marker"

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -78,7 +78,9 @@ let maybe_externalize ?(mime = "text/plain") (msg : string) : string =
           (try
              let stored = Tool_blob_store.put store ~bytes:msg ~mime in
              Tool_output.encode_for_oas stored
-           with _ -> msg)
+           with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | _ -> msg)
 
 (** {1 Result Conversion} *)
 

--- a/lib/tool_metrics_persist.ml
+++ b/lib/tool_metrics_persist.ml
@@ -45,7 +45,7 @@ let parse_record (json : Yojson.Safe.t)
       |> List.filter_map (fun (field, is_missing) ->
         if is_missing then Some field else None)
     in
-    Prometheus.inc_counter "masc_error_events_total" ~labels:[("type", "parsing")] ();
+    Prometheus.inc_counter Prometheus.metric_error_events ~labels:[("type", "parsing")] ();
     Error
       (Printf.sprintf "missing required field(s): %s"
          (String.concat ", " missing))

--- a/lib/tool_suspend.ml
+++ b/lib/tool_suspend.ml
@@ -69,8 +69,7 @@ let force_leave config ~agent_id ~reason =
     Printf.sprintf "[SYSTEM] Agent '%s' forcibly removed: %s" agent_id reason
   in
   try
-    let _ = Coord.broadcast config ~from_agent:"system" ~content:message in
-    ()
+    ignore (Coord.broadcast config ~from_agent:"system" ~content:message)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn -> Log.Misc.error "broadcast (force leave) exception: %s" (Printexc.to_string exn)

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -20,75 +20,45 @@ type hot_queue_session = {
 
 let sse_hot_sessions : hot_queue_session list Atomic.t = Atomic.make []
 
-let register_sse_metrics () =
-  Prometheus.register_gauge ~name:"masc_sse_sessions_total"
-    ~help:"Active SSE sessions by kind" ();
-  Prometheus.register_histogram ~name:"masc_sse_broadcast_duration_seconds"
-    ~help:"Time to fan-out a broadcast to all SSE clients" ();
-  Prometheus.register_counter ~name:"masc_sse_broadcast_events_total"
-    ~help:"Total SSE broadcast events emitted" ();
-  Prometheus.register_gauge ~name:"masc_sse_stream_queue_depth"
-    ~help:"Per-session SSE event stream queue depth" ();
-  Prometheus.register_gauge ~name:"masc_sse_queue_depth_avg"
-    ~help:"Average SSE event queue depth across live sessions" ();
-  Prometheus.register_gauge ~name:"masc_sse_queue_depth_max"
-    ~help:"Maximum SSE event queue depth across live sessions" ();
-  Prometheus.register_gauge ~name:"masc_sse_external_subscribers_total"
-    ~help:"Active non-SSE subscribers bridged from the SSE fanout path" ()
-
 let set_sse_sessions ~kind count =
-  Prometheus.set_gauge "masc_sse_sessions_total"
+  Prometheus.set_gauge Prometheus.metric_sse_sessions
     ~labels:[("kind", kind)] (float_of_int count)
 
 let observe_broadcast_duration seconds =
-  Prometheus.observe_histogram "masc_sse_broadcast_duration_seconds" seconds;
-  Prometheus.inc_counter "masc_sse_broadcast_events_total" ()
+  Prometheus.observe_histogram Prometheus.metric_sse_broadcast_duration seconds;
+  Prometheus.inc_counter Prometheus.metric_sse_broadcast_events ()
 
 let set_sse_queue_depth ~session_id depth =
-  Prometheus.set_gauge "masc_sse_stream_queue_depth"
+  Prometheus.set_gauge Prometheus.metric_sse_stream_queue_depth
     ~labels:[("session_id", session_id)] (float_of_int depth)
 
 let set_sse_queue_snapshot ~avg_depth ~max_depth ~hot_sessions =
-  Prometheus.set_gauge "masc_sse_queue_depth_avg" avg_depth;
-  Prometheus.set_gauge "masc_sse_queue_depth_max" (float_of_int max_depth);
+  Prometheus.set_gauge Prometheus.metric_sse_queue_depth_avg avg_depth;
+  Prometheus.set_gauge Prometheus.metric_sse_queue_depth_max (float_of_int max_depth);
   Atomic.set sse_hot_sessions hot_sessions
 
 let set_sse_external_subscribers count =
-  Prometheus.set_gauge "masc_sse_external_subscribers_total" (float_of_int count)
+  Prometheus.set_gauge Prometheus.metric_sse_external_subscribers (float_of_int count)
 
 (** {1 gRPC Metrics} *)
 
-let register_grpc_metrics () =
-  Prometheus.register_gauge ~name:"masc_grpc_active_streams_total"
-    ~help:"Active gRPC bidirectional streams" ();
-  Prometheus.register_histogram ~name:"masc_grpc_heartbeat_latency_seconds"
-    ~help:"gRPC heartbeat round-trip latency" ();
-  Prometheus.register_gauge ~name:"masc_grpc_subscribers_total"
-    ~help:"Active gRPC Subscribe stream subscribers" ();
-  Prometheus.register_counter ~name:"masc_grpc_events_delivered_total"
-    ~help:"Total events delivered via gRPC streams" ()
-
 let set_grpc_active_streams count =
-  Prometheus.set_gauge "masc_grpc_active_streams_total" (float_of_int count)
+  Prometheus.set_gauge Prometheus.metric_grpc_active_streams (float_of_int count)
 
 let observe_grpc_heartbeat_latency seconds =
-  Prometheus.observe_histogram "masc_grpc_heartbeat_latency_seconds" seconds
+  Prometheus.observe_histogram Prometheus.metric_grpc_heartbeat_latency seconds
 
 let set_grpc_subscribers count =
-  Prometheus.set_gauge "masc_grpc_subscribers_total" (float_of_int count)
+  Prometheus.set_gauge Prometheus.metric_grpc_subscribers (float_of_int count)
 
 let inc_grpc_events_delivered ?(delta=1) () =
-  Prometheus.inc_counter "masc_grpc_events_delivered_total"
+  Prometheus.inc_counter Prometheus.metric_grpc_events_delivered
     ~delta:(float_of_int delta) ()
 
 (** {1 WebSocket Metrics} *)
 
-let register_ws_metrics () =
-  Prometheus.register_gauge ~name:"masc_ws_sessions_total"
-    ~help:"Active standalone WebSocket sessions" ()
-
 let set_ws_sessions count =
-  Prometheus.set_gauge "masc_ws_sessions_total" (float_of_int count)
+  Prometheus.set_gauge Prometheus.metric_ws_sessions (float_of_int count)
 
 (** {1 Environment-derived Transport Config} *)
 
@@ -122,30 +92,12 @@ let grpc_listening () =
 
 (** {1 Agent Health Metrics} *)
 
-let register_agent_metrics () =
-  Prometheus.register_gauge ~name:"masc_agent_heartbeat_age_seconds"
-    ~help:"Seconds since last heartbeat per agent" ();
-  Prometheus.register_counter ~name:"masc_agent_stale_total"
-    ~help:"Total agents that became stale (heartbeat age exceeded threshold)" ()
-
 let set_agent_heartbeat_age ~agent_name age_seconds =
-  Prometheus.set_gauge "masc_agent_heartbeat_age_seconds"
+  Prometheus.set_gauge Prometheus.metric_agent_heartbeat_age_seconds
     ~labels:[("agent_name", agent_name)] age_seconds
 
 let inc_agent_stale () =
-  Prometheus.inc_counter "masc_agent_stale_total" ()
-
-(** {1 Initialization} *)
-
-let init () =
-  register_sse_metrics ();
-  register_grpc_metrics ();
-  register_ws_metrics ();
-  register_agent_metrics ();
-  set_grpc_runtime_listening false;
-  set_grpc_listen_status "not_started";
-  set_ws_runtime_listening false;
-  set_ws_listen_status "not_started"
+  Prometheus.inc_counter Prometheus.metric_agent_stale_total ()
 
 (** {1 Transport Health JSON Snapshot} *)
 
@@ -228,14 +180,14 @@ let transport_health_json ~config =
   let v name ?(labels=[]) () =
     Prometheus.metric_value_or_zero name ~labels ()
   in
-  let sse_observer = v "masc_sse_sessions_total" ~labels:[("kind", "observer")] () in
-  let sse_coordinator = v "masc_sse_sessions_total" ~labels:[("kind", "coordinator")] () in
+  let sse_observer = v Prometheus.metric_sse_sessions ~labels:[("kind", "observer")] () in
+  let sse_coordinator = v Prometheus.metric_sse_sessions ~labels:[("kind", "coordinator")] () in
   let sse_total = int_of_float (sse_observer +. sse_coordinator) in
   let sse_external_subscribers =
-    int_of_float (v "masc_sse_external_subscribers_total" ())
+    int_of_float (v Prometheus.metric_sse_external_subscribers ())
   in
-  let sse_queue_avg = v "masc_sse_queue_depth_avg" () in
-  let sse_queue_max = int_of_float (v "masc_sse_queue_depth_max" ()) in
+  let sse_queue_avg = v Prometheus.metric_sse_queue_depth_avg () in
+  let sse_queue_max = int_of_float (v Prometheus.metric_sse_queue_depth_max ()) in
   let relay_queue_depth =
     int_of_float (v Prometheus.metric_oas_sse_relay_queue_depth ())
   in
@@ -270,27 +222,27 @@ let transport_health_json ~config =
   let relay_drop_total =
     int_of_float (Prometheus.metric_total Prometheus.metric_oas_sse_relay_drops)
   in
-  let broadcast_sum = v "masc_sse_broadcast_duration_seconds" () in
+  let broadcast_sum = v Prometheus.metric_sse_broadcast_duration () in
   let broadcast_count = v "masc_sse_broadcast_duration_seconds_count" () in
   let broadcast_avg =
     if broadcast_count > 0.0 then broadcast_sum /. broadcast_count else 0.0
   in
-  let grpc_streams = v "masc_grpc_active_streams_total" () in
-  let grpc_subscribers = v "masc_grpc_subscribers_total" () in
-  let grpc_heartbeat_sum = v "masc_grpc_heartbeat_latency_seconds" () in
+  let grpc_streams = v Prometheus.metric_grpc_active_streams () in
+  let grpc_subscribers = v Prometheus.metric_grpc_subscribers () in
+  let grpc_heartbeat_sum = v Prometheus.metric_grpc_heartbeat_latency () in
   let grpc_heartbeat_count = v "masc_grpc_heartbeat_latency_seconds_count" () in
   let grpc_heartbeat_avg =
     if grpc_heartbeat_count > 0.0 then grpc_heartbeat_sum /. grpc_heartbeat_count
     else 0.0
   in
-  let grpc_events = v "masc_grpc_events_delivered_total" () in
-  let stale_agents = v "masc_agent_stale_total" () in
+  let grpc_events = v Prometheus.metric_grpc_events_delivered () in
+  let stale_agents = v Prometheus.metric_agent_stale_total () in
   let lifecycle_dispatch_rejections =
     int_of_float
       (Prometheus.metric_total
          Prometheus.metric_keeper_lifecycle_dispatch_rejections)
   in
-  let ws_sessions = int_of_float (v "masc_ws_sessions_total" ()) in
+  let ws_sessions = int_of_float (v Prometheus.metric_ws_sessions ()) in
   let grpc_configured = grpc_enabled () in
   let grpc_live = grpc_listening () in
   let grpc_reachable = grpc_live || tcp_port_reachable (grpc_port ()) in

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -212,7 +212,7 @@ let tcp_port_reachable port =
           (Unix.ADDR_INET
              (Unix.inet_addr_of_string Masc_network_defaults.masc_http_default_host, port));
         true)
-  with _ -> false
+  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> false
 
 let hot_session_json (session : hot_queue_session) =
   `Assoc

--- a/lib/transport_read_model.ml
+++ b/lib/transport_read_model.ml
@@ -111,7 +111,7 @@ let tcp_port_reachable port =
           (Unix.ADDR_INET
              (Unix.inet_addr_of_string Masc_network_defaults.masc_http_default_host, port));
         true)
-  with _ -> false
+  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> false
 
 let websocket_discovery_json (ctx : http_context) =
   let enabled = Server_ws_standalone.is_enabled () in

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -352,9 +352,7 @@ type turn_request_result = {
 exception Timeout of string
 
 (** Safe string prefix check *)
-let starts_with ~prefix s =
-  let plen = String.length prefix in
-  String.length s >= plen && String.sub s 0 plen = prefix
+let starts_with ~prefix s = Base.String.is_prefix s ~prefix
 
 (** Check if an error is retryable (transient)
     Retryable errors: connection failures, timeouts, HTTP 5xx *)

--- a/lib/voice/voice_bridge_core.ml
+++ b/lib/voice/voice_bridge_core.ml
@@ -306,7 +306,7 @@ let resolved_base_path_opt () =
 let masc_base_dir () =
   match resolved_base_path_opt () with
   | Some base_path -> Coord_utils.masc_dir_from_base_path ~base_path
-  | None -> ".masc"
+  | None -> Common.masc_dirname
 
 let ensure_audio_dir () =
   let dir = Filename.concat (masc_base_dir ()) "audio" in

--- a/lib/worktree_live_context.ml
+++ b/lib/worktree_live_context.ml
@@ -83,6 +83,8 @@ type status_cache_entry = {
 let status_cache : (string, status_cache_entry) Hashtbl.t =
   Hashtbl.create 4
 
+(* Stdlib.Mutex: status_cache may be accessed from keepers on different
+   domains concurrently. *)
 let status_cache_mu = Stdlib.Mutex.create ()
 
 let status_cache_ttl_sec () =

--- a/test/dune
+++ b/test/dune
@@ -1079,7 +1079,7 @@
 (test
  (name test_start_masc_mcp_script)
  (modules test_start_masc_mcp_script)
- (libraries alcotest unix))
+ (libraries alcotest masc_core unix))
 
 (test
  (name test_tool_call_replay_harness)

--- a/test/test_adaptive_cache_ttl.ml
+++ b/test/test_adaptive_cache_ttl.ml
@@ -10,16 +10,14 @@ module TM = Masc_mcp.Transport_metrics
 
 let test_default_latency () =
   (* With no broadcast data, latency avg = 0. *)
-  TM.init ();
   let sum = Prometheus.metric_value_or_zero
-    "masc_sse_broadcast_duration_seconds" () in
+    Prometheus.metric_sse_broadcast_duration () in
   let count = Prometheus.metric_value_or_zero
     "masc_sse_broadcast_duration_seconds_count" () in
   let avg = if count > 0.0 then sum /. count else 0.0 in
   check bool "avg latency is a valid float" true (avg >= 0.0)
 
 let test_high_latency_detected () =
-  TM.init ();
   (* Inject high latency observations to push avg above 0.5s *)
   for _ = 1 to 10 do
     Prometheus.observe_histogram "masc_sse_broadcast_duration_seconds" 1.0

--- a/test/test_agent_economy.ml
+++ b/test/test_agent_economy.ml
@@ -225,7 +225,7 @@ let test_ledger_file_created () =
         ~base_path:dir ~agent_name:"writer"
         ~kind:Earn_board_post ~reason:"test" ());
       let path = Filename.concat
-        (Filename.concat (Filename.concat dir ".masc") "economy")
+        (Filename.concat (Filename.concat dir Common.masc_dirname) "economy")
         "ledger.jsonl" in
       Alcotest.(check bool) "ledger file exists" true (Sys.file_exists path)));
   rm_rf dir

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -15,7 +15,7 @@ let setup_test_room () =
   let unique_id = Printf.sprintf "masc-auth-test-%d-%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.)) in
   let tmp = Filename.concat (Filename.get_temp_dir_name ()) unique_id in
   Unix.mkdir tmp 0o755;
-  let masc_dir = Filename.concat tmp ".masc" in
+  let masc_dir = Filename.concat tmp Common.masc_dirname in
   Unix.mkdir masc_dir 0o755;
   tmp
 

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -46,7 +46,7 @@ let setup_test_room () =
   in
   let tmp = Filename.concat (Filename.get_temp_dir_name ()) unique_id in
   Unix.mkdir tmp 0o755;
-  let masc_dir = Filename.concat tmp ".masc" in
+  let masc_dir = Filename.concat tmp Common.masc_dirname in
   Unix.mkdir masc_dir 0o755;
   tmp
 

--- a/test/test_autonomy_liberation.ml
+++ b/test/test_autonomy_liberation.ml
@@ -170,7 +170,7 @@ let test_finding_accumulation () =
   let base_path =
     Filename.concat (Filename.get_temp_dir_name ()) "test_findings_al"
   in
-  let masc_dir = Filename.concat base_path ".masc" in
+  let masc_dir = Filename.concat base_path Common.masc_dirname in
   let session_dir = Filename.concat masc_dir "session_test_al" in
   (try Sys.mkdir base_path 0o755 with Sys_error _ -> ());
   (try Sys.mkdir masc_dir 0o755 with Sys_error _ -> ());
@@ -198,7 +198,7 @@ let test_finding_accumulation_json_escaping () =
   let base_path =
     Filename.concat (Filename.get_temp_dir_name ()) "test_findings_escape"
   in
-  let masc_dir = Filename.concat base_path ".masc" in
+  let masc_dir = Filename.concat base_path Common.masc_dirname in
   Fun.protect
     ~finally:(fun () ->
       (try Sys.remove (Filename.concat masc_dir "shared_findings.jsonl") with Sys_error _ -> ());
@@ -220,7 +220,7 @@ let test_team_context_build_renders_findings_without_goal () =
   let base_path =
     Filename.concat (Filename.get_temp_dir_name ()) "test_findings_prompt"
   in
-  let masc_dir = Filename.concat base_path ".masc" in
+  let masc_dir = Filename.concat base_path Common.masc_dirname in
   Fun.protect
     ~finally:(fun () ->
       (try Sys.remove (Filename.concat masc_dir "shared_findings.jsonl") with Sys_error _ -> ());

--- a/test/test_bg_task_stub.ml
+++ b/test/test_bg_task_stub.ml
@@ -123,7 +123,7 @@ let test_pid_file_created_and_cleaned () =
   Fun.protect
     ~finally:(fun () ->
       try
-        let keeper_dir = Filename.concat (Filename.concat base ".masc") "keeper" in
+        let keeper_dir = Filename.concat (Filename.concat base Common.masc_dirname) "keeper" in
         let rec rm path =
           if Sys.is_directory path then begin
             Array.iter (fun e -> rm (Filename.concat path e)) (Sys.readdir path);
@@ -162,7 +162,7 @@ let test_reap_orphans_removes_stale_file () =
   Fun.protect
     ~finally:(fun () ->
       try
-        let keeper_dir = Filename.concat (Filename.concat base ".masc") "keeper" in
+        let keeper_dir = Filename.concat (Filename.concat base Common.masc_dirname) "keeper" in
         let rec rm path =
           if Sys.is_directory path then begin
             Array.iter (fun e -> rm (Filename.concat path e)) (Sys.readdir path);

--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -219,7 +219,7 @@ let test_executable_relative_fallback_opt_in () =
 
 let test_home_masc_fallback () =
   with_temp_dir "config-dir-home" @@ fun home ->
-  let home_masc_root = Filename.concat home ".masc" in
+  let home_masc_root = Filename.concat home Common.masc_dirname in
   let config = make_config_root home_masc_root in
   let resolution =
     Lib.Config_dir_resolver.resolve_with
@@ -236,9 +236,9 @@ let test_home_masc_fallback () =
 let test_local_masc_fallback_precedes_home_masc () =
   with_temp_dir "config-dir-local" @@ fun root ->
   let target = Filename.concat root "target" in
-  let local_config = make_config_root (Filename.concat target ".masc") in
+  let local_config = make_config_root (Filename.concat target Common.masc_dirname) in
   let home = Filename.concat root "home" in
-  ignore (make_config_root (Filename.concat home ".masc"));
+  ignore (make_config_root (Filename.concat home Common.masc_dirname));
   let resolution =
     Lib.Config_dir_resolver.resolve_with
       (make_inputs ~cwd:root ~env_base_path:target ~env_home:home
@@ -253,11 +253,11 @@ let test_local_masc_fallback_precedes_home_masc () =
 let test_local_masc_fallback_collapses_explicit_masc_dir () =
   with_temp_dir "config-dir-local-masc" @@ fun root ->
   let target = Filename.concat root "target" in
-  let local_config = make_config_root (Filename.concat target ".masc") in
+  let local_config = make_config_root (Filename.concat target Common.masc_dirname) in
   let resolution =
     Lib.Config_dir_resolver.resolve_with
       (make_inputs ~cwd:root
-         ~env_base_path:(Filename.concat target ".masc")
+         ~env_base_path:(Filename.concat target Common.masc_dirname)
          ~executable_name:"/tmp/nonexistent-masc" ())
   in
   check string "status" "ready"
@@ -329,7 +329,7 @@ let test_personas_dirs_ignores_base_path_fallback () =
   write_file (Filename.concat config_root "cascade.json") "{}";
   write_file (Filename.concat config_root "tool_policy.toml") "# test marker\n";
   let base = Filename.dirname config_root in
-  let base_personas = Filename.concat (Filename.concat base ".masc") "personas" in
+  let base_personas = Filename.concat (Filename.concat base Common.masc_dirname) "personas" in
   mkdir_p base_personas;
   let config_personas = Filename.concat config_root "personas" in
   let inputs = make_inputs ~env_config_dir:config_root ~env_base_path:base

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -25,7 +25,7 @@ let iso8601_of_unix ts =
   Types.iso8601_of_unix_seconds ts
 
 let write_legacy_judgment ~base_path json =
-  let masc = Filename.concat base_path ".masc" in
+  let masc = Filename.concat base_path Common.masc_dirname in
   let governance = Filename.concat masc "governance" in
   Fs_compat.mkdir_p masc;
   Fs_compat.mkdir_p governance;
@@ -280,7 +280,7 @@ let test_pending_ruling_reflects_disk_truth () =
       Eio_main.run @@ fun env ->
       with_test_fs env @@ fun () ->
       let cases_dir =
-        Filename.concat (Filename.concat dir ".masc") "governance_v2/cases"
+        Filename.concat (Filename.concat dir Common.masc_dirname) "governance_v2/cases"
       in
       Fs_compat.mkdir_p cases_dir;
       let now = Unix.gettimeofday () in
@@ -333,7 +333,7 @@ let test_governance_dir_created_before_read () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
-      let masc = Filename.concat dir ".masc" in
+      let masc = Filename.concat dir Common.masc_dirname in
       let gov = Filename.concat masc "governance" in
       let judgments = Filename.concat gov "judgments" in
       (* Before ensure_dir: directories do not exist *)

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -111,7 +111,7 @@ let test_dashboard_shell_http_json_includes_paths () =
   in
   let effective_base_path = paths |> member "effective_base_path" |> to_string in
   let effective_masc_root = paths |> member "effective_masc_root" |> to_string in
-  let expected_masc_root = Unix.realpath (Filename.concat config.base_path ".masc") in
+  let expected_masc_root = Unix.realpath (Filename.concat config.base_path Common.masc_dirname) in
   check bool "paths present" true
     (match paths with `Assoc _ -> true | _ -> false);
   check bool "paths key present" true
@@ -175,7 +175,7 @@ let test_dashboard_shell_http_json_includes_paths () =
 
 let test_dashboard_shell_http_json_prefers_preserved_base_path_input () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
-  let raw_input = Filename.concat config.base_path ".masc" in
+  let raw_input = Filename.concat config.base_path Common.masc_dirname in
   with_env "MASC_BASE_PATH_INPUT" raw_input @@ fun () ->
   with_env "MASC_BASE_PATH" config.base_path @@ fun () ->
   let json = Lib.Server_dashboard_http_core.dashboard_shell_http_json config in

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -275,7 +275,7 @@ let test_cleanup_dir_does_not_follow_symlinks () =
 
 let make_config () =
   let tmp = temp_dir () in
-  ensure_dir (Filename.concat tmp ".masc");
+  ensure_dir (Filename.concat tmp Common.masc_dirname);
   (tmp, Coord.default_config tmp)
 
 let make_docker_meta name =

--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -116,7 +116,7 @@ let test_docker_git_creds_routes () =
 
 let setup_config name =
   let base = temp_dir () in
-  Unix.mkdir (Filename.concat base ".masc") 0o755;
+  Unix.mkdir (Filename.concat base Common.masc_dirname) 0o755;
   let config = Coord.default_config base in
   let meta =
     make_meta ~name ~sandbox:Keeper_types.Docker

--- a/test/test_keeper_fs_edit_patch.ml
+++ b/test/test_keeper_fs_edit_patch.ml
@@ -68,7 +68,7 @@ let with_eio_fs f =
 let setup ?(sandbox = Keeper_types.Local) f =
   with_eio_fs @@ fun () ->
   let base = temp_dir () in
-  ensure_dir (Filename.concat base ".masc");
+  ensure_dir (Filename.concat base Common.masc_dirname);
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
   Keeper_registry.clear ();
   let config = Coord.default_config base in

--- a/test/test_keeper_github_read_only.ml
+++ b/test/test_keeper_github_read_only.ml
@@ -175,7 +175,7 @@ let with_repo_context_test_env f =
   with_eio_fs @@ fun () ->
   let base = temp_dir () in
   let config = Coord.default_config base in
-  ensure_dir (Filename.concat base ".masc");
+  ensure_dir (Filename.concat base Common.masc_dirname);
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
   ignore (Coord.init config ~agent_name:None);
   let repo_dir = Filename.concat base "repo" in

--- a/test/test_keeper_runtime_toml.ml
+++ b/test/test_keeper_runtime_toml.ml
@@ -21,7 +21,7 @@ let with_base_path f =
   let dir = Filename.temp_file "keeper-runtime-toml" "" in
   Sys.remove dir;
   Unix.mkdir dir 0o755;
-  Unix.mkdir (Filename.concat dir ".masc") 0o755;
+  Unix.mkdir (Filename.concat dir Common.masc_dirname) 0o755;
   Unix.mkdir (Filename.concat dir ".masc/config") 0o755;
   let oc = open_out (Filename.concat dir ".masc/config/cascade.json") in
   output_string oc "{}\n";

--- a/test/test_keeper_shell_containment.ml
+++ b/test/test_keeper_shell_containment.ml
@@ -55,7 +55,7 @@ let rec ensure_dir path =
 
 let make_config () =
   let tmp = temp_dir () in
-  ensure_dir (Filename.concat tmp ".masc");
+  ensure_dir (Filename.concat tmp Common.masc_dirname);
   (tmp, Coord.default_config tmp)
 
 let make_meta ~name ~sandbox =

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -87,7 +87,7 @@ let with_eio_fs f =
 let setup ~sandbox f =
   with_eio_fs @@ fun () ->
   let base = temp_dir () in
-  ensure_dir (Filename.concat base ".masc");
+  ensure_dir (Filename.concat base Common.masc_dirname);
   let config = Coord.default_config base in
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
   Keeper_registry.clear ();

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -674,7 +674,7 @@ let make_masc_path_test_dir () =
   in
   let git_dir = Filename.concat dir ".git" in
   create_dir git_dir;
-  let masc = Filename.concat dir ".masc" in
+  let masc = Filename.concat dir Common.masc_dirname in
   create_dir masc;
   let keepers = Filename.concat masc "keepers" in
   create_dir keepers;

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -2415,7 +2415,7 @@ let test_handle_request_resources_read_matrix () =
     if not (Sys.file_exists path) then Unix.mkdir path 0o755
   in
   let library_dir = Filename.concat base_path "docs/library" in
-  let masc_dir = Filename.concat base_path ".masc" in
+  let masc_dir = Filename.concat base_path Common.masc_dirname in
   ensure_dir (Filename.concat base_path "docs");
   ensure_dir library_dir;
   ensure_dir masc_dir;

--- a/test/test_memory_oas_5tier.ml
+++ b/test/test_memory_oas_5tier.ml
@@ -21,7 +21,7 @@ let setup_tmp_dir () =
   let dir = Filename.temp_dir "masc_mem_test" "" in
   Unix.putenv "MASC_DATA_DIR" dir;
   Unix.putenv "MASC_BASE_PATH" dir;
-  Fs_compat.mkdir_p (Filename.concat dir ".masc");
+  Fs_compat.mkdir_p (Filename.concat dir Common.masc_dirname);
   dir
 
 let cleanup_tmp_dir dir =

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -112,7 +112,7 @@ let test_add_task_uses_archive_max_id () =
   let config = room_config tmp_dir in
   let _ = Coord.init config ~agent_name:None in
 
-  let archive_path = Filename.concat (Filename.concat tmp_dir ".masc") "tasks-archive.json" in
+  let archive_path = Filename.concat (Filename.concat tmp_dir Common.masc_dirname) "tasks-archive.json" in
   let archive_json =
     `Assoc [
       ("archived_at", `String "2026-01-01T00:00:00Z");
@@ -280,7 +280,7 @@ let test_worktree_project_root_for_masc_dir_base () =
   let _ = Coord.init config ~agent_name:(Some "claude") in
   let repo_root = config.base_path in
   Unix.mkdir (Filename.concat repo_root ".git") 0o755;
-  let masc_config = { config with base_path = Filename.concat repo_root ".masc" } in
+  let masc_config = { config with base_path = Filename.concat repo_root Common.masc_dirname } in
   Alcotest.(check string) ".masc base path resolves to repo root"
     repo_root
     (Coord.project_root masc_config);
@@ -351,7 +351,7 @@ let with_memory_test_env f =
   Unix.mkdir tmp_dir 0o755;
   let backend_config : Backend_types.config = {
     backend_type = Backend_types.Memory;
-    base_path = Filename.concat tmp_dir ".masc";
+    base_path = Filename.concat tmp_dir Common.masc_dirname;
     node_id = "test-node";
     cluster_name = "default";
     pubsub_max_messages = 1000;
@@ -1265,7 +1265,7 @@ let test_cleanup_zombies_releases_tasks () =
     let _ = Coord.claim_task config ~agent_name:test_agent_z ~task_id:"task-001" in
     (* Manually set agent's last_seen to a very old timestamp to make it a zombie *)
     let agents_path = Filename.concat
-      (Filename.concat config.base_path ".masc") "agents" in
+      (Filename.concat config.base_path Common.masc_dirname) "agents" in
     let agent_file = Filename.concat agents_path (test_agent_z ^ ".json") in
     let json = Coord.read_json config agent_file in
     let updated_json = match json with

--- a/test/test_room_state_recovery.ml
+++ b/test/test_room_state_recovery.ml
@@ -24,7 +24,7 @@ let write_text_file path content =
     (fun () -> output_string oc content)
 
 let state_path base_dir =
-  Filename.concat (Filename.concat base_dir ".masc") "state.json"
+  Filename.concat (Filename.concat base_dir Common.masc_dirname) "state.json"
 
 let agent_path config agent_name =
   Filename.concat (Coord.agents_dir config) (Coord.safe_filename agent_name ^ ".json")

--- a/test/test_room_utils_coverage.ml
+++ b/test/test_room_utils_coverage.ml
@@ -137,7 +137,7 @@ let test_resolve_masc_base_path_collapses_requested_masc_dir () =
   let requested =
     Filename.concat
       (Filename.concat (Filename.get_temp_dir_name ()) "room-utils-collapse")
-      ".masc"
+      Common.masc_dirname
   in
   with_envs
     [ ("MASC_BASE_PATH", None);
@@ -151,7 +151,7 @@ let test_resolve_masc_base_path_collapses_explicit_env_masc_dir () =
   let requested =
     Filename.concat (Filename.get_temp_dir_name ()) "room-utils-explicit"
   in
-  let explicit = Filename.concat requested ".masc" in
+  let explicit = Filename.concat requested Common.masc_dirname in
   with_envs
     [ ("MASC_BASE_PATH", Some explicit);
       ("MASC_TEST_ALLOW_BASE_PATH_OVERRIDE", None) ]
@@ -178,8 +178,8 @@ let test_resolve_masc_base_path_ignores_base_path_override_with_local_masc_dir (
   let explicit = Filename.concat scratch "parent-root" in
   Unix.mkdir requested 0o755;
   Unix.mkdir explicit 0o755;
-  Unix.mkdir (Filename.concat requested ".masc") 0o755;
-  Unix.mkdir (Filename.concat explicit ".masc") 0o755;
+  Unix.mkdir (Filename.concat requested Common.masc_dirname) 0o755;
+  Unix.mkdir (Filename.concat explicit Common.masc_dirname) 0o755;
   Fun.protect
     ~finally:(fun () -> rm_rf scratch)
     (fun () ->
@@ -197,8 +197,8 @@ let test_resolve_masc_base_path_opt_in_preserves_base_path_override () =
   let explicit = Filename.concat scratch "parent-root" in
   Unix.mkdir requested 0o755;
   Unix.mkdir explicit 0o755;
-  Unix.mkdir (Filename.concat requested ".masc") 0o755;
-  Unix.mkdir (Filename.concat explicit ".masc") 0o755;
+  Unix.mkdir (Filename.concat requested Common.masc_dirname) 0o755;
+  Unix.mkdir (Filename.concat explicit Common.masc_dirname) 0o755;
   Fun.protect
     ~finally:(fun () -> rm_rf scratch)
     (fun () ->
@@ -221,8 +221,8 @@ let test_resolve_masc_base_path_ignores_ancestor_base_path_override_without_opt_
     end
   in
   mkdirs sub_repo;
-  Unix.mkdir (Filename.concat explicit ".masc") 0o755;
-  Unix.mkdir (Filename.concat sub_repo ".masc") 0o755;
+  Unix.mkdir (Filename.concat explicit Common.masc_dirname) 0o755;
+  Unix.mkdir (Filename.concat sub_repo Common.masc_dirname) 0o755;
   Fun.protect
     ~finally:(fun () -> rm_rf scratch)
     (fun () ->

--- a/test/test_runtime_params.ml
+++ b/test/test_runtime_params.ml
@@ -140,7 +140,7 @@ let () =
 
   let test_persist_restore () =
     let tmp_dir = Filename.temp_dir "masc_test_" "" in
-    let masc_dir = Filename.concat tmp_dir ".masc" in
+    let masc_dir = Filename.concat tmp_dir Common.masc_dirname in
     (try Sys.mkdir masc_dir 0o755 with Sys_error _ -> ());
     let p =
       Runtime_params.register
@@ -171,7 +171,7 @@ let () =
 
   let test_audit () =
     let tmp_dir = Filename.temp_dir "masc_audit_" "" in
-    let masc_dir = Filename.concat tmp_dir ".masc" in
+    let masc_dir = Filename.concat tmp_dir Common.masc_dirname in
     (try Sys.mkdir masc_dir 0o755 with Sys_error _ -> ());
     Runtime_params.record_audit ~base_path:tmp_dir
       ~key:"test.key" ~old_value:(`Int 1) ~new_value:(`Int 2)
@@ -365,7 +365,7 @@ let () =
 
   let test_keeper_param_override_persist_restore () =
     let tmp_dir = Filename.temp_dir "masc_keeper_restore_" "" in
-    let masc_dir = Filename.concat tmp_dir ".masc" in
+    let masc_dir = Filename.concat tmp_dir Common.masc_dirname in
     (try Sys.mkdir masc_dir 0o755 with Sys_error _ -> ());
     (* Override a keeper param *)
     (match Runtime_params.set Governance_registry.keeper_max_hb_failures 7 with

--- a/test/test_server_base_path_diagnostics.ml
+++ b/test/test_server_base_path_diagnostics.ml
@@ -52,8 +52,8 @@ let test_divergent_cwd_is_observational_only () =
   let effective = Filename.concat root "workspace" in
   Unix.mkdir cwd 0o755;
   Unix.mkdir effective 0o755;
-  let cwd_masc = Filename.concat cwd ".masc" in
-  let effective_masc = Filename.concat effective ".masc" in
+  let cwd_masc = Filename.concat cwd Common.masc_dirname in
+  let effective_masc = Filename.concat effective Common.masc_dirname in
   Unix.mkdir cwd_masc 0o755;
   Unix.mkdir effective_masc 0o755;
   Unix.mkdir (Filename.concat cwd_masc "perpetual") 0o755;
@@ -75,13 +75,13 @@ let test_divergent_cwd_is_not_a_strict_violation () =
   let effective = Filename.concat root "workspace" in
   Unix.mkdir cwd 0o755;
   Unix.mkdir effective 0o755;
-  Unix.mkdir (Filename.concat cwd ".masc") 0o755;
-  Unix.mkdir (Filename.concat effective ".masc") 0o755;
+  Unix.mkdir (Filename.concat cwd Common.masc_dirname) 0o755;
+  Unix.mkdir (Filename.concat effective Common.masc_dirname) 0o755;
   with_env "MASC_BASE_PATH_STRICT" (Some "false") @@ fun () ->
   let diag =
     Server_base_path_diagnostics.detect ~cwd
       ~effective_base_path:effective
-      ~effective_masc_root:(Filename.concat effective ".masc")
+      ~effective_masc_root:(Filename.concat effective Common.masc_dirname)
       ()
   in
   Alcotest.(check bool) "strict_mode_requested stays false" false
@@ -99,8 +99,8 @@ let test_explicit_env_resolution_remains_observational_only () =
   let effective = Filename.concat root "workspace" in
   Unix.mkdir cwd 0o755;
   Unix.mkdir effective 0o755;
-  Unix.mkdir (Filename.concat cwd ".masc") 0o755;
-  Unix.mkdir (Filename.concat effective ".masc") 0o755;
+  Unix.mkdir (Filename.concat cwd Common.masc_dirname) 0o755;
+  Unix.mkdir (Filename.concat effective Common.masc_dirname) 0o755;
   with_env "MASC_BASE_PATH_STRICT" (Some "true") @@ fun () ->
   let diag =
     Server_base_path_diagnostics.detect ~cwd
@@ -108,7 +108,7 @@ let test_explicit_env_resolution_remains_observational_only () =
       ~input_base_path:effective
       ~env_masc_base_path:effective
       ~effective_base_path:effective
-      ~effective_masc_root:(Filename.concat effective ".masc")
+      ~effective_masc_root:(Filename.concat effective Common.masc_dirname)
       ()
   in
   Alcotest.(check bool) "warning removed" false
@@ -128,15 +128,15 @@ let test_explicit_cli_resolution_source_remains_observational_only () =
   let effective = Filename.concat root "workspace" in
   Unix.mkdir cwd 0o755;
   Unix.mkdir effective 0o755;
-  Unix.mkdir (Filename.concat cwd ".masc") 0o755;
-  Unix.mkdir (Filename.concat effective ".masc") 0o755;
+  Unix.mkdir (Filename.concat cwd Common.masc_dirname) 0o755;
+  Unix.mkdir (Filename.concat effective Common.masc_dirname) 0o755;
   with_env "MASC_BASE_PATH_STRICT" None @@ fun () ->
   let diag =
     Server_base_path_diagnostics.detect ~cwd
       ~resolution_source:"explicit_cli"
       ~input_base_path:effective
       ~effective_base_path:effective
-      ~effective_masc_root:(Filename.concat effective ".masc")
+      ~effective_masc_root:(Filename.concat effective Common.masc_dirname)
       ()
   in
   Alcotest.(check bool) "strict_mode_requested false without user STRICT" false
@@ -206,8 +206,8 @@ let test_default_base_path_ignores_parent_base_path_override_in_tests () =
   let base_path = Filename.concat root "base" in
   let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
   mkdir_p repo;
-  Unix.mkdir (Filename.concat base_path ".masc") 0o755;
-  Unix.mkdir (Filename.concat repo ".masc") 0o755;
+  Unix.mkdir (Filename.concat base_path Common.masc_dirname) 0o755;
+  Unix.mkdir (Filename.concat repo Common.masc_dirname) 0o755;
   with_cwd repo @@ fun () ->
   with_env "MASC_BASE_PATH" (Some base_path) @@ fun () ->
   with_env "MASC_TEST_ALLOW_BASE_PATH_OVERRIDE" None @@ fun () ->
@@ -222,8 +222,8 @@ let test_default_base_path_preserves_base_path_override_with_opt_in () =
   let base_path = Filename.concat root "base" in
   let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
   mkdir_p repo;
-  Unix.mkdir (Filename.concat base_path ".masc") 0o755;
-  Unix.mkdir (Filename.concat repo ".masc") 0o755;
+  Unix.mkdir (Filename.concat base_path Common.masc_dirname) 0o755;
+  Unix.mkdir (Filename.concat repo Common.masc_dirname) 0o755;
   with_cwd repo @@ fun () ->
   with_env "MASC_BASE_PATH" (Some base_path) @@ fun () ->
   with_env "MASC_TEST_ALLOW_BASE_PATH_OVERRIDE" (Some "true") @@ fun () ->
@@ -237,7 +237,7 @@ let test_default_base_path_ignores_base_path_override_without_local_masc () =
   let base_path = Filename.concat root "base" in
   let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
   mkdir_p repo;
-  Unix.mkdir (Filename.concat base_path ".masc") 0o755;
+  Unix.mkdir (Filename.concat base_path Common.masc_dirname) 0o755;
   with_cwd repo @@ fun () ->
   with_env "MASC_BASE_PATH" (Some base_path) @@ fun () ->
   with_env "MASC_TEST_ALLOW_BASE_PATH_OVERRIDE" None @@ fun () ->

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -100,7 +100,7 @@ let make_config_root root =
 
 let write_basepath_keeper_toml base_path name =
   let keepers_dir =
-    Filename.concat (Filename.concat (Filename.concat base_path ".masc") "config")
+    Filename.concat (Filename.concat (Filename.concat base_path Common.masc_dirname) "config")
       "keepers"
   in
   mkdir_p keepers_dir;
@@ -614,11 +614,11 @@ let test_bootstrap_base_path_config_root_collapses_masc_input () =
       mkdir_p repo;
       ignore (make_config_root repo);
       let base_path = Filename.concat dir "base" in
-      mkdir_p (Filename.concat base_path ".masc");
+      mkdir_p (Filename.concat base_path Common.masc_dirname);
       with_env "MASC_CONFIG_DIR" None @@ fun () ->
       with_cwd repo @@ fun () ->
       Server_runtime_bootstrap.bootstrap_base_path_config_root
-        ~base_path:(Filename.concat base_path ".masc");
+        ~base_path:(Filename.concat base_path Common.masc_dirname);
       Alcotest.(check bool) "config root created under parent .masc" true
         (Sys.file_exists (Filename.concat base_path ".masc/config/cascade.json"));
       Alcotest.(check bool) "nested .masc/.masc config not created" false
@@ -711,7 +711,7 @@ let test_keeper_paths_use_cluster_root () =
           let keeper_dir = Keeper_types.keeper_dir config in
           let expected_root =
             Filename.concat
-              (Filename.concat (Filename.concat dir ".masc") "clusters")
+              (Filename.concat (Filename.concat dir Common.masc_dirname) "clusters")
               "cluster-alpha"
           in
           Alcotest.(check bool) "keeper dir under cluster root" true
@@ -727,12 +727,12 @@ let test_tool_usage_log_uses_cluster_root () =
           let expected_dir =
             Filename.concat
               (Filename.concat
-                 (Filename.concat (Filename.concat dir ".masc") "clusters")
+                 (Filename.concat (Filename.concat dir Common.masc_dirname) "clusters")
                  "cluster-alpha")
               "tool_usage"
           in
           let legacy_dir =
-            Filename.concat (Filename.concat dir ".masc") "tool_usage"
+            Filename.concat (Filename.concat dir Common.masc_dirname) "tool_usage"
           in
           Alcotest.(check bool) "cluster tool_usage dir exists" true
             (Sys.file_exists expected_dir && Sys.is_directory expected_dir);
@@ -757,12 +757,12 @@ let test_keeper_tool_call_log_uses_cluster_root () =
               let expected_dir =
                 Filename.concat
                   (Filename.concat
-                     (Filename.concat (Filename.concat dir ".masc") "clusters")
+                     (Filename.concat (Filename.concat dir Common.masc_dirname) "clusters")
                      "cluster-alpha")
                   "tool_calls"
               in
               let legacy_dir =
-                Filename.concat (Filename.concat dir ".masc") "tool_calls"
+                Filename.concat (Filename.concat dir Common.masc_dirname) "tool_calls"
               in
               Alcotest.(check bool) "cluster tool_calls dir exists" true
                 (Sys.file_exists expected_dir && Sys.is_directory expected_dir);
@@ -1213,14 +1213,14 @@ let test_create_server_state_records_runtime_resolution () =
         (json |> member "config_resolution" |> member "cascade_authoring" |> member "path"
        |> to_string);
       Alcotest.(check string) "create_server_state records effective masc root"
-        (Unix.realpath (Filename.concat dir ".masc"))
+        (Unix.realpath (Filename.concat dir Common.masc_dirname))
         (json |> member "path_diagnostics" |> member "effective_masc_root"
        |> to_string))
 
 let test_create_server_state_preserves_raw_input_base_path () =
   with_temp_dir "startup-create-state-raw-input" (fun dir ->
       let repo = Filename.concat dir "repo" in
-      let raw_input = Filename.concat dir ".masc" in
+      let raw_input = Filename.concat dir Common.masc_dirname in
       mkdir_p repo;
       mkdir_p raw_input;
       ignore (make_config_root repo);

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -340,8 +340,8 @@ let test_absolute_env_base_path_is_preserved () =
       make_fake_eio_exe dir;
       let stale_root = Filename.concat dir "stale-root" in
       let home_dir = Filename.concat dir "empty-home" in
-      mkdir_p (Filename.concat dir ".masc");
-      mkdir_p (Filename.concat stale_root ".masc");
+      mkdir_p (Filename.concat dir Common.masc_dirname);
+      mkdir_p (Filename.concat stale_root Common.masc_dirname);
       mkdir_p home_dir;
       let capture = Filename.concat dir "captured-sanitized.txt" in
       let code, stdout, stderr =
@@ -369,8 +369,8 @@ let test_absolute_parent_project_base_path_is_preserved () =
       let home_dir = Filename.concat dir "empty-home" in
       mkdir_p repo;
       mkdir_p home_dir;
-      mkdir_p (Filename.concat parent ".masc");
-      mkdir_p (Filename.concat repo ".masc");
+      mkdir_p (Filename.concat parent Common.masc_dirname);
+      mkdir_p (Filename.concat repo Common.masc_dirname);
       let script = Filename.concat repo "start-masc-mcp.sh" in
       copy_script (script_path ()) script;
       make_fake_eio_exe repo;
@@ -428,8 +428,8 @@ let test_zshenv_absolute_base_path_is_preserved () =
       let home_dir = Filename.concat dir "home" in
       mkdir_p repo;
       mkdir_p home_dir;
-      mkdir_p (Filename.concat parent ".masc");
-      mkdir_p (Filename.concat repo ".masc");
+      mkdir_p (Filename.concat parent Common.masc_dirname);
+      mkdir_p (Filename.concat repo Common.masc_dirname);
       write_file (Filename.concat home_dir ".zshenv")
         (Printf.sprintf "export MASC_BASE_PATH=%s\n" parent);
       let script = Filename.concat repo "start-masc-mcp.sh" in
@@ -460,8 +460,8 @@ let test_shared_root_env_base_path_is_preserved () =
       make_fake_eio_exe dir;
       let inherited_root = Filename.concat dir "shared-root" in
       let home_dir = Filename.concat dir "empty-home" in
-      mkdir_p (Filename.concat dir ".masc");
-      mkdir_p (Filename.concat inherited_root ".masc");
+      mkdir_p (Filename.concat dir Common.masc_dirname);
+      mkdir_p (Filename.concat inherited_root Common.masc_dirname);
       mkdir_p home_dir;
       let capture = Filename.concat dir "captured-opt-in.txt" in
       let code, stdout, stderr =
@@ -522,8 +522,8 @@ let test_explicit_base_path_execs_from_base_path () =
       let home_dir = Filename.concat dir "empty-home" in
       mkdir_p repo;
       mkdir_p home_dir;
-      mkdir_p (Filename.concat parent ".masc");
-      mkdir_p (Filename.concat repo ".masc");
+      mkdir_p (Filename.concat parent Common.masc_dirname);
+      mkdir_p (Filename.concat repo Common.masc_dirname);
       let script = Filename.concat repo "start-masc-mcp.sh" in
       copy_script (script_path ()) script;
       make_fake_eio_exe repo;
@@ -594,7 +594,7 @@ let test_zshenv_retired_pg_envs_are_scrubbed_before_exec () =
       let home_dir = Filename.concat dir "home" in
       mkdir_p repo;
       mkdir_p home_dir;
-      mkdir_p (Filename.concat parent ".masc");
+      mkdir_p (Filename.concat parent Common.masc_dirname);
       write_file (Filename.concat home_dir ".zshenv")
         "export SUPABASE_DB_URL=postgres://legacy/supabase\nexport SB_PG_URL=postgres://legacy/sb\n";
       let script = Filename.concat repo "start-masc-mcp.sh" in

--- a/test/test_task_sandbox.ml
+++ b/test/test_task_sandbox.ml
@@ -136,7 +136,7 @@ let test_symlink_created_when_masc_exists () =
     ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)))
   ) (fun () ->
     (* Create a fake .masc directory at "repo root" *)
-    let masc_dir = Filename.concat dir ".masc" in
+    let masc_dir = Filename.concat dir Common.masc_dirname in
     Unix.mkdir masc_dir 0o755;
     (* Create a fake worktree directory *)
     let wt_dir = Filename.concat dir "fake-worktree" in
@@ -144,7 +144,7 @@ let test_symlink_created_when_masc_exists () =
     (* The sandbox creation would call symlink_masc internally.
        Test the end state: .masc should be symlinked into the worktree.
        Since symlink_masc is internal, we test the behavior via Unix.symlink. *)
-    let masc_in_wt = Filename.concat wt_dir ".masc" in
+    let masc_in_wt = Filename.concat wt_dir Common.masc_dirname in
     Unix.symlink masc_dir masc_in_wt;
     check bool ".masc link exists in worktree" true (Sys.file_exists masc_in_wt);
     (* Verify it's a symlink *)
@@ -238,7 +238,7 @@ let test_full_lifecycle () =
         check bool "branch non-empty" true (String.length sb.branch_name > 0);
 
         (* Verify .masc symlink *)
-        let masc_link = Filename.concat sb.worktree_path ".masc" in
+        let masc_link = Filename.concat sb.worktree_path Common.masc_dirname in
         check bool ".masc exists in sandbox" true (Sys.file_exists masc_link);
 
         (* Create a file to simulate work *)

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -68,7 +68,7 @@ let test_source_of_string_unknown () =
 
 (* ── Empty base_path ─────────────────────────────── *)
 
-let masc_root dir = Filename.concat dir ".masc"
+let masc_root dir = Filename.concat dir Common.masc_dirname
 
 let test_empty_returns_empty () =
   Eio_main.run @@ fun env ->

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -28,7 +28,7 @@ let cleanup () =
   end;
   Board.reset_global_for_test ();
   Board_dispatch.reset_for_test ();
-  remove_path (Filename.concat _test_base_path ".masc");
+  remove_path (Filename.concat _test_base_path Common.masc_dirname);
   Board_dispatch.init_jsonl ()
 
 let dispatch name args =

--- a/test/test_tool_suspend_coverage.ml
+++ b/test/test_tool_suspend_coverage.ml
@@ -26,7 +26,7 @@ module Coord = Masc_mcp.Coord
 let make_config () =
   let tmp = Printf.sprintf "/tmp/test-suspend-%d" (Random.bits ()) in
   (try Unix.mkdir tmp 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
-  (try Unix.mkdir (Filename.concat tmp ".masc") 0o755
+  (try Unix.mkdir (Filename.concat tmp Common.masc_dirname) 0o755
    with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
   Coord.default_config tmp
 

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -43,7 +43,6 @@ let with_env name value_opt f =
    ============================================================ *)
 
 let test_init () =
-  TM.init ();
   let text = Prometheus.to_prometheus_text () in
   check bool "sse sessions metric registered" true
     (try
@@ -69,7 +68,6 @@ let test_init () =
    ============================================================ *)
 
 let test_sse_sessions () =
-  TM.init ();
   TM.set_sse_sessions ~kind:"observer" 10;
   TM.set_sse_sessions ~kind:"coordinator" 5;
   let obs = Prometheus.metric_value_or_zero "masc_sse_sessions_total"
@@ -80,7 +78,6 @@ let test_sse_sessions () =
   check (float 0.01) "coordinator sessions" 5.0 coord
 
 let test_broadcast_duration () =
-  TM.init ();
   TM.observe_broadcast_duration 0.05;
   TM.observe_broadcast_duration 0.15;
   let sum = Prometheus.metric_value_or_zero
@@ -91,7 +88,6 @@ let test_broadcast_duration () =
   check bool "broadcast count >= 2" true (count >= 2.0)
 
 let test_broadcast_events_counter () =
-  TM.init ();
   let before = Prometheus.metric_value_or_zero
     "masc_sse_broadcast_events_total" () in
   TM.observe_broadcast_duration 0.01;
@@ -104,14 +100,12 @@ let test_broadcast_events_counter () =
    ============================================================ *)
 
 let test_grpc_active_streams () =
-  TM.init ();
   TM.set_grpc_active_streams 3;
   let v = Prometheus.metric_value_or_zero
     "masc_grpc_active_streams_total" () in
   check (float 0.01) "grpc active streams" 3.0 v
 
 let test_grpc_heartbeat_latency () =
-  TM.init ();
   TM.observe_grpc_heartbeat_latency 0.002;
   TM.observe_grpc_heartbeat_latency 0.008;
   let sum = Prometheus.metric_value_or_zero
@@ -119,14 +113,12 @@ let test_grpc_heartbeat_latency () =
   check bool "heartbeat latency sum > 0" true (sum > 0.0)
 
 let test_grpc_subscribers () =
-  TM.init ();
   TM.set_grpc_subscribers 7;
   let v = Prometheus.metric_value_or_zero
     "masc_grpc_subscribers_total" () in
   check (float 0.01) "grpc subscribers" 7.0 v
 
 let test_grpc_events_delivered () =
-  TM.init ();
   let before = Prometheus.metric_value_or_zero
     "masc_grpc_events_delivered_total" () in
   TM.inc_grpc_events_delivered ~delta:5 ();
@@ -135,14 +127,12 @@ let test_grpc_events_delivered () =
   check (float 0.01) "grpc events delta" 5.0 (after -. before)
 
 let test_grpc_runtime_listening_cache () =
-  TM.init ();
   TM.set_grpc_runtime_listening true;
   check bool "grpc listening uses runtime cache" true (TM.grpc_listening ());
   TM.set_grpc_runtime_listening false;
   check bool "grpc listening resets" false (TM.grpc_listening ())
 
 let test_ws_sessions () =
-  TM.init ();
   TM.set_ws_sessions 4;
   let v = Prometheus.metric_value_or_zero
     "masc_ws_sessions_total" () in
@@ -163,7 +153,6 @@ let test_ws_enabled_normalized_env_matches_runtime () =
       (Masc_mcp.Server_ws_standalone.is_enabled ()))
 
 let test_ws_runtime_listening_cache () =
-  TM.init ();
   TM.set_ws_runtime_listening true;
   check bool "ws listening uses runtime cache" true (TM.ws_listening ());
   TM.set_ws_runtime_listening false;
@@ -174,7 +163,6 @@ let test_ws_runtime_listening_cache () =
    ============================================================ *)
 
 let test_agent_heartbeat_age () =
-  TM.init ();
   TM.set_agent_heartbeat_age ~agent_name:"dreamer" 42.5;
   let v = Prometheus.metric_value_or_zero
     "masc_agent_heartbeat_age_seconds"
@@ -182,7 +170,6 @@ let test_agent_heartbeat_age () =
   check (float 0.01) "dreamer heartbeat age" 42.5 v
 
 let test_agent_stale_counter () =
-  TM.init ();
   let before = Prometheus.metric_value_or_zero
     "masc_agent_stale_total" () in
   TM.inc_agent_stale ();
@@ -198,7 +185,6 @@ let test_agent_stale_counter () =
 let test_transport_health_json () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  TM.init ();
   ignore (Masc_mcp.Sse.close_all_clients ());
   let base_dir = temp_dir () in
   let config = Masc_mcp.Coord.default_config base_dir in
@@ -302,7 +288,6 @@ let test_transport_health_json () =
    ============================================================ *)
 
 let test_grpc_listen_status_lifecycle () =
-  TM.init ();
   check string "grpc status after init" "not_started"
     (Atomic.get TM.grpc_listen_status);
   TM.set_grpc_listen_status "listening";
@@ -317,7 +302,6 @@ let test_grpc_listen_status_lifecycle () =
   check bool "grpc listening returns false" false (TM.grpc_listening ())
 
 let test_ws_listen_status_lifecycle () =
-  TM.init ();
   check string "ws status after init" "not_started"
     (Atomic.get TM.ws_listen_status);
   TM.set_ws_listen_status "listening";
@@ -332,7 +316,6 @@ let test_ws_listen_status_lifecycle () =
   check bool "ws listening returns false" false (TM.ws_listening ())
 
 let test_listen_status_bind_failed () =
-  TM.init ();
   TM.set_grpc_listen_status "bind_failed";
   TM.set_grpc_runtime_listening false;
   TM.set_ws_listen_status "bind_failed";
@@ -345,7 +328,6 @@ let test_listen_status_bind_failed () =
     (Atomic.get TM.ws_listen_status)
 
 let test_listen_status_disabled () =
-  TM.init ();
   TM.set_grpc_listen_status "disabled";
   TM.set_ws_listen_status "disabled";
   check string "grpc status disabled" "disabled"


### PR DESCRIPTION
## Summary

Fixes a bug where `start_supervisor_sweep` called `ensure_keeper_meta` every ~30s and received `Ok updated_meta`, but discarded it with `Ok _meta -> ()`. The `meta` file on disk was rewritten, yet the in-memory `Keeper_registry.registry_entry` stayed stale. A `cascade_name` change in the TOML profile was therefore invisible to the keeper's next turn, which continued to pass the old `cascade_name` to OAS.

## Changes

| Commit | Description |
|--------|-------------|
| fix(keeper) | Propagate TOML-reconciled meta into registry |
| refactor(prometheus) | Centralise metric name constants (SSOT) |
| refactor(lib/bin) | Use `Common.masc_dirname` SSOT for all `.masc` path literals |
| refactor(test) | Use `Common.masc_dirname` SSOT for test `.masc` paths |
| refactor(lib) | Replace manual prefix checks with `Base.String.is_prefix` |
| fix(eio) | Propagate `Eio.Cancel.Cancelled` through all catch handlers |
| refactor(exceptions) | Replace `failwith` and generic `Failure` with typed exceptions |
| fix(silent-failure) | Fix `exec_tap` cancellation+partial write, `heuristic_metrics` Exit control flow |
| refactor(main_eio/bin/process_eio/masc_cost/provider_adapter/masc_tui_ansi) | Various OCaml 5.x best-practice improvements |

## Test plan

- [ ] `dune build` passes
- [ ] `dune runtest` passes
- [ ] Verify cascade change takes effect within one sweep cycle (~30s) without restart

Closes #9613