### PR TITLE
[codex] fix OAS replay and runtime throughput metrics

### DIFF
--- a/dashboard/src/components/keeper-detail-panels.test.ts
+++ b/dashboard/src/components/keeper-detail-panels.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from 'vitest'
-import type { PromptSegmentTelemetry } from '../types'
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { describe, it, expect, afterEach } from 'vitest'
+import type { Keeper, KeeperMetricPoint, PromptSegmentTelemetry } from '../types'
 import {
   ctxColor,
   ctxSegmentLabel,
@@ -10,7 +12,12 @@ import {
   formatSegmentLabel,
   miniSparkline,
   filterCtxCompositionEntries,
+  InferenceTelemetryPanel,
 } from './keeper-detail-panels'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
 
 // ── ctxColor ──────────────────────────────────────────────────
 
@@ -289,5 +296,110 @@ describe('filterCtxCompositionEntries', () => {
     const empty: ReadonlyArray<readonly [string, PromptSegmentTelemetry]> = []
     expect(filterCtxCompositionEntries(empty, 'history')).toEqual([])
     expect(filterCtxCompositionEntries(empty, '')).toBe(empty)
+  })
+})
+
+describe('InferenceTelemetryPanel', () => {
+  it('separates wall tok/s from hardware decode tok/s', () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const metricsSeries = [
+      {
+        ts: 1,
+        context_ratio: 0.2,
+        context_tokens: 200,
+        context_max: 1000,
+        latency_ms: 2000,
+        generation: 1,
+        channel: 'turn',
+        is_handoff: false,
+        is_compaction: false,
+        compaction_saved_tokens: 0,
+        compaction_trigger: null,
+        model_used: 'glm-5',
+        cost_usd: 0.02,
+        handoff_to_model: null,
+        handoff_new_generation: null,
+        prompt_fingerprint: null,
+        prompt_metrics: null,
+        ctx_composition: null,
+        input_tokens: 120,
+        output_tokens: 80,
+        total_tokens: 200,
+        wall_tokens_per_second: 40,
+        inference_telemetry: {
+          system_fingerprint: 'fp-a',
+          timings: {
+            prompt_n: null,
+            prompt_ms: null,
+            prompt_per_second: 55,
+            predicted_n: null,
+            predicted_ms: null,
+            predicted_per_second: 140,
+            cache_n: 10,
+          },
+          reasoning_tokens: 4,
+          peak_memory_gb: null,
+          request_latency_ms: 2000,
+        },
+        fallback_applied: false,
+        fallback_hops: 0,
+        fallback_from: null,
+        fallback_to: null,
+        fallback_reason: null,
+      },
+      {
+        ts: 2,
+        context_ratio: 0.25,
+        context_tokens: 250,
+        context_max: 1000,
+        latency_ms: 1000,
+        generation: 1,
+        channel: 'turn',
+        is_handoff: false,
+        is_compaction: false,
+        compaction_saved_tokens: 0,
+        compaction_trigger: null,
+        model_used: 'glm-5',
+        cost_usd: 0.03,
+        handoff_to_model: null,
+        handoff_new_generation: null,
+        prompt_fingerprint: null,
+        prompt_metrics: null,
+        ctx_composition: null,
+        input_tokens: 90,
+        output_tokens: 60,
+        total_tokens: 150,
+        wall_tokens_per_second: 60,
+        inference_telemetry: {
+          system_fingerprint: 'fp-b',
+          timings: {
+            prompt_n: null,
+            prompt_ms: null,
+            prompt_per_second: 60,
+            predicted_n: null,
+            predicted_ms: null,
+            predicted_per_second: 150,
+            cache_n: 12,
+          },
+          reasoning_tokens: 8,
+          peak_memory_gb: null,
+          request_latency_ms: 1000,
+        },
+        fallback_applied: false,
+        fallback_hops: 0,
+        fallback_from: null,
+        fallback_to: null,
+        fallback_reason: null,
+      },
+    ] satisfies KeeperMetricPoint[]
+    const keeper = { metrics_series: metricsSeries } as Keeper
+
+    render(html`<${InferenceTelemetryPanel} keeper=${keeper} />`, container)
+
+    expect(container.textContent).toContain('wall tok/s')
+    expect(container.textContent).toContain('hw tok/s')
+    expect(container.textContent).toContain('avg 50.0')
+    expect(container.textContent).toContain('avg 145.0')
   })
 })

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -927,13 +927,16 @@ export function miniSparkline(
 export function InferenceTelemetryPanel({ keeper }: { keeper: Keeper }) {
   const series = keeper.metrics_series ?? []
   const telemetryPoints = series.filter(
-    (p: KeeperMetricPoint) => p.inference_telemetry?.timings?.predicted_per_second != null,
+    (p: KeeperMetricPoint) => p.inference_telemetry != null || p.wall_tokens_per_second != null,
   )
   if (telemetryPoints.length === 0) return null
 
-  const tokPerSec = telemetryPoints.map(
-    (p: KeeperMetricPoint) => p.inference_telemetry?.timings?.predicted_per_second ?? 0,
-  )
+  const wallTokPerSec = telemetryPoints
+    .map((p: KeeperMetricPoint) => p.wall_tokens_per_second)
+    .filter((value): value is number => value != null)
+  const hwTokPerSec = telemetryPoints
+    .map((p: KeeperMetricPoint) => p.inference_telemetry?.timings?.predicted_per_second)
+    .filter((value): value is number => value != null)
   const latencies = telemetryPoints.map(
     (p: KeeperMetricPoint) => p.inference_telemetry?.request_latency_ms ?? 0,
   )
@@ -945,13 +948,22 @@ export function InferenceTelemetryPanel({ keeper }: { keeper: Keeper }) {
   )
 
   const W = SPARKLINE_W, H = SPARKLINE_H
-  const lastTps = tokPerSec[tokPerSec.length - 1] ?? 0
-  const avgTps = tokPerSec.reduce((a, b) => a + b, 0) / tokPerSec.length
+  const lastWallTps = wallTokPerSec[wallTokPerSec.length - 1] ?? 0
+  const avgWallTps =
+    wallTokPerSec.length > 0
+      ? wallTokPerSec.reduce((a, b) => a + b, 0) / wallTokPerSec.length
+      : 0
+  const lastHwTps = hwTokPerSec[hwTokPerSec.length - 1] ?? 0
+  const avgHwTps =
+    hwTokPerSec.length > 0
+      ? hwTokPerSec.reduce((a, b) => a + b, 0) / hwTokPerSec.length
+      : 0
   const lastLatency = latencies[latencies.length - 1] ?? 0
   const totalCacheN = cacheNs.reduce((a, b) => a + b, 0)
   const totalReasoning = reasoningTokens.reduce((a, b) => a + b, 0)
 
-  const tpsLine = miniSparkline(tokPerSec)
+  const wallTpsLine = wallTokPerSec.length > 1 ? miniSparkline(wallTokPerSec) : ''
+  const hwTpsLine = hwTokPerSec.length > 1 ? miniSparkline(hwTokPerSec) : ''
   const latencyLine = miniSparkline(latencies)
 
   const lastFp = telemetryPoints[telemetryPoints.length - 1]?.inference_telemetry?.system_fingerprint
@@ -963,18 +975,32 @@ export function InferenceTelemetryPanel({ keeper }: { keeper: Keeper }) {
         <span class="text-3xs text-[var(--text-dim)]">${telemetryPoints.length} points</span>
         ${lastFp ? html`<span class="text-3xs px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)] font-mono">${lastFp}</span>` : null}
       </div>
-      <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
-        ${'' /* tok/s sparkline */}
+      <div class="grid grid-cols-2 md:grid-cols-5 gap-3">
+        ${wallTokPerSec.length > 0 ? html`
         <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
           <div class="flex items-center justify-between mb-1.5">
-            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">tok/s</span>
-            <span class="text-xs font-mono tabular-nums text-[var(--good)]">${lastTps.toFixed(1)}</span>
+            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">wall tok/s</span>
+            <span class="text-xs font-mono tabular-nums text-[var(--good)]">${lastWallTps.toFixed(1)}</span>
           </div>
           <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:var(--bg-deepest);">
-            ${tpsLine ? html`<polyline points="${tpsLine}" fill="none" stroke="var(--ok)" stroke-width="1.5"/>` : null}
+            ${wallTpsLine ? html`<polyline points="${wallTpsLine}" fill="none" stroke="var(--ok)" stroke-width="1.5"/>` : null}
           </svg>
-          <div class="text-3xs text-[var(--text-dim)] mt-1">avg ${avgTps.toFixed(1)}</div>
+          <div class="text-3xs text-[var(--text-dim)] mt-1">avg ${avgWallTps.toFixed(1)}</div>
         </div>
+        ` : null}
+
+        ${hwTokPerSec.length > 0 ? html`
+        <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">
+          <div class="flex items-center justify-between mb-1.5">
+            <span class="text-3xs uppercase tracking-wider text-[var(--text-muted)]">hw tok/s</span>
+            <span class="text-xs font-mono tabular-nums text-[var(--good)]">${lastHwTps.toFixed(1)}</span>
+          </div>
+          <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:var(--bg-deepest);">
+            ${hwTpsLine ? html`<polyline points="${hwTpsLine}" fill="none" stroke="var(--ok)" stroke-width="1.5"/>` : null}
+          </svg>
+          <div class="text-3xs text-[var(--text-dim)] mt-1">avg ${avgHwTps.toFixed(1)} · decode-only</div>
+        </div>
+        ` : null}
 
         ${'' /* request latency */}
         <div class="p-3 rounded border border-[var(--card-border)] bg-[var(--white-3)]">

--- a/dashboard/src/components/oas-health-chip.test.ts
+++ b/dashboard/src/components/oas-health-chip.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { topKeepers, describeAgentEvent } from './oas-health-chip'
-import type { OasAgentEvent, OasKeeperSnapshot } from '../types/oas'
+import {
+  topKeepers,
+  describeAgentEvent,
+  describeSampleWindow,
+  describeTotalEventsDetail,
+} from './oas-health-chip'
+import type { OasAgentEvent, OasHealthSummary, OasKeeperSnapshot } from '../types/oas'
 
 function snap(name: string, ts: number, extras: Partial<OasKeeperSnapshot> = {}): OasKeeperSnapshot {
   return {
@@ -132,5 +137,31 @@ describe('describeAgentEvent', () => {
       expect(rendered.length).toBeGreaterThan(0)
       expect(/^[a-zA-Z]+$/.test(rendered)).toBe(false)
     }
+  })
+})
+
+describe('describeTotalEventsDetail', () => {
+  it('marks truncated replay windows explicitly', () => {
+    const summary = {
+      totalEvents: 1842,
+      replayLoadedEvents: 500,
+      replayTotalMatchingEvents: 1842,
+      replayTruncated: true,
+    } satisfies Pick<OasHealthSummary, 'totalEvents' | 'replayLoadedEvents' | 'replayTotalMatchingEvents' | 'replayTruncated'>
+
+    expect(describeTotalEventsDetail(summary)).toBe('replay 500/1842 + live')
+    expect(describeSampleWindow(summary)).toBe('sample 500/1842')
+  })
+
+  it('falls back to durable replay when no truncation happened', () => {
+    const summary = {
+      totalEvents: 42,
+      replayLoadedEvents: 42,
+      replayTotalMatchingEvents: 42,
+      replayTruncated: false,
+    } satisfies Pick<OasHealthSummary, 'totalEvents' | 'replayLoadedEvents' | 'replayTotalMatchingEvents' | 'replayTruncated'>
+
+    expect(describeTotalEventsDetail(summary)).toBe('durable replay + live')
+    expect(describeSampleWindow(summary)).toBeNull()
   })
 })

--- a/dashboard/src/components/oas-health-chip.ts
+++ b/dashboard/src/components/oas-health-chip.ts
@@ -7,7 +7,7 @@ import { oasHealthSummary, oasAgentEvents, oasKeeperSnapshots } from '../store'
 import { Card } from './common/card'
 import { StatCell } from './common/stat-cell'
 import { EmptyState } from './common/empty-state'
-import type { OasAgentEvent, OasKeeperSnapshot } from '../types/oas'
+import type { OasAgentEvent, OasHealthSummary, OasKeeperSnapshot } from '../types/oas'
 
 const STALE_MS = 60_000
 
@@ -69,6 +69,25 @@ export function topKeepers(
     .slice(0, limit)
 }
 
+export function describeTotalEventsDetail(summary: Pick<OasHealthSummary,
+  'replayLoadedEvents' | 'replayTotalMatchingEvents' | 'replayTruncated' | 'totalEvents'
+>): string {
+  if (summary.replayTruncated) {
+    return `replay ${summary.replayLoadedEvents}/${summary.replayTotalMatchingEvents} + live`
+  }
+  if (summary.replayLoadedEvents === 0 && summary.totalEvents > 0) {
+    return 'live only'
+  }
+  return 'durable replay + live'
+}
+
+export function describeSampleWindow(summary: Pick<OasHealthSummary,
+  'replayLoadedEvents' | 'replayTotalMatchingEvents' | 'replayTruncated'
+>): string | null {
+  if (!summary.replayTruncated) return null
+  return `sample ${summary.replayLoadedEvents}/${summary.replayTotalMatchingEvents}`
+}
+
 export function OasHealthChip() {
   const summary = useComputed(() => oasHealthSummary.value)
   const recentEvents = useComputed(() => oasAgentEvents.value.slice(0, 3))
@@ -86,27 +105,33 @@ export function OasHealthChip() {
     `
   }
 
+  const sampleWindow = describeSampleWindow(summary.value)
+  const llmDetail =
+    summary.value.lastLlmCallTs != null
+      ? `최근 ${formatLastTick(summary.value.lastLlmCallTs)}`
+      : 'durable journal'
+  const errorDetail =
+    summary.value.lastErrorTs != null
+      ? `최근 ${formatLastTick(summary.value.lastErrorTs)}`
+      : 'Api/agent 실패'
+
   return html`
     <${Card} title="OAS 런타임">
       <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-2">
         <${StatCell}
           label="총 이벤트"
           value=${summary.value.totalEvents}
-          detail="durable replay + live"
+          detail=${describeTotalEventsDetail(summary.value)}
         />
         <${StatCell}
           label="LLM 호출"
           value=${summary.value.totalLlmCalls}
-          detail=${summary.value.lastLlmCallTs != null
-            ? `최근 ${formatLastTick(summary.value.lastLlmCallTs)}`
-            : 'durable journal'}
+          detail=${sampleWindow ? `${llmDetail} · ${sampleWindow}` : llmDetail}
         />
         <${StatCell}
           label="에러"
           value=${summary.value.totalErrors}
-          detail=${summary.value.lastErrorTs != null
-            ? `최근 ${formatLastTick(summary.value.lastErrorTs)}`
-            : 'Api/agent 실패'}
+          detail=${sampleWindow ? `${errorDetail} · ${sampleWindow}` : errorDetail}
           tone=${summary.value.totalErrors > 0 ? 'text-[var(--bad)]' : undefined}
         />
         <${StatCell}

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -372,6 +372,49 @@ describe('normalizeKeepers lifecycle metrics', () => {
     })
   })
 
+  it('derives wall tok/s from usage output tokens and latency', () => {
+    const [keeper] = normalizeKeepers([
+      {
+        name: 'wall-rate',
+        status: 'active',
+        metrics_series: [
+          {
+            ts_unix: 6,
+            context_ratio: 0.24,
+            context_tokens: 240,
+            context_max: 1000,
+            latency_ms: 2000,
+            generation: 2,
+            channel: 'turn',
+            model_used: 'glm-5',
+            cost_usd: 0.05,
+            compacted: false,
+            usage: {
+              input_tokens: 120,
+              output_tokens: 80,
+              total_tokens: 200,
+            },
+            inference_telemetry: {
+              request_latency_ms: 2000,
+              timings: {
+                predicted_per_second: 140,
+                prompt_per_second: 55,
+                cache_n: 10,
+              },
+            },
+          },
+        ],
+      },
+    ])
+
+    const metric = keeper?.metrics_series?.[0]
+    expect(metric?.input_tokens).toBe(120)
+    expect(metric?.output_tokens).toBe(80)
+    expect(metric?.total_tokens).toBe(200)
+    expect(metric?.wall_tokens_per_second).toBe(40)
+    expect(metric?.inference_telemetry?.timings?.predicted_per_second).toBe(140)
+  })
+
   it('preserves paused runtime signals and blocker metadata for keeper UI', () => {
     const [keeper] = normalizeKeepers([
       {

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -184,6 +184,7 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
           ? (typeof handoffObj.to_model === 'string' ? handoffObj.to_model : null)
           : (typeof item.handoff_to_model === 'string' ? item.handoff_to_model : null)
       const rawPrompt = isRecord(item.prompt) ? item.prompt : null
+      const rawUsage = isRecord(item.usage) ? item.usage : null
       const promptSegments: NonNullable<PromptTelemetry['segments']> =
         normalizePromptSegments(rawPrompt, new Set(['fingerprint', 'estimated_total_tokens', 'estimated_cacheable_tokens']))
       const promptFingerprint =
@@ -214,6 +215,14 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
           : null
       const rawTel = isRecord(item.inference_telemetry) ? item.inference_telemetry : null
       const rawTimings = rawTel && isRecord(rawTel.timings) ? rawTel.timings : null
+      const latencyMs = asNumber(item.latency_ms) ?? 0
+      const inputTokens = rawUsage ? (asNumber(rawUsage.input_tokens) ?? null) : null
+      const outputTokens = rawUsage ? (asNumber(rawUsage.output_tokens) ?? null) : null
+      const totalTokens = rawUsage ? (asNumber(rawUsage.total_tokens) ?? null) : null
+      const wallTokensPerSecond =
+        outputTokens != null && latencyMs > 0
+          ? outputTokens / (latencyMs / 1000)
+          : null
       const inference_telemetry = rawTel ? {
         system_fingerprint: typeof rawTel.system_fingerprint === 'string' ? rawTel.system_fingerprint : null,
         timings: rawTimings ? {
@@ -237,7 +246,7 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
         context_ratio: contextRatio,
         context_tokens: asNumber(item.context_tokens) ?? 0,
         context_max: asNumber(item.context_max) ?? 0,
-        latency_ms: asNumber(item.latency_ms) ?? 0,
+        latency_ms: latencyMs,
         generation: asNumber(item.generation) ?? 0,
         channel: typeof item.channel === 'string' ? item.channel : 'turn',
         is_handoff: handoffPerformed,
@@ -251,6 +260,10 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
         prompt_fingerprint: promptFingerprint,
         prompt_metrics,
         ctx_composition,
+        input_tokens: inputTokens,
+        output_tokens: outputTokens,
+        total_tokens: totalTokens,
+        wall_tokens_per_second: wallTokensPerSecond,
         inference_telemetry,
         fallback_applied: cascadeObj ? cascadeObj.fallback_applied === true : false,
         fallback_hops: cascadeObj ? (asNumber(cascadeObj.fallback_hops) ?? 0) : 0,

--- a/dashboard/src/oas-runtime-store.test.ts
+++ b/dashboard/src/oas-runtime-store.test.ts
@@ -85,6 +85,9 @@ describe('oas-runtime-store', () => {
     hydrateOasRuntimeFromTelemetryEntries(entries)
 
     expect(oasHealthSummary.value.totalEvents).toBe(4)
+    expect(oasHealthSummary.value.replayLoadedEvents).toBe(4)
+    expect(oasHealthSummary.value.replayTotalMatchingEvents).toBe(4)
+    expect(oasHealthSummary.value.replayTruncated).toBe(false)
     expect(oasHealthSummary.value.agentEventsCount).toBe(1)
     expect(oasHealthSummary.value.keeperSnapshotsCount).toBe(1)
     expect(oasHealthSummary.value.totalLlmCalls).toBe(1)
@@ -181,6 +184,8 @@ describe('oas-runtime-store', () => {
     fetchTelemetryMock.mockResolvedValue({
       generated_at: '2026-04-15T12:00:00Z',
       count: 1,
+      total_matching_entries: 1200,
+      truncated: true,
       entries: [
         {
           source: 'oas_event',
@@ -206,7 +211,52 @@ describe('oas-runtime-store', () => {
       n: 500,
       signal: undefined,
     })
-    expect(oasHealthSummary.value.totalEvents).toBe(1)
+    expect(oasHealthSummary.value.totalEvents).toBe(1200)
+    expect(oasHealthSummary.value.replayLoadedEvents).toBe(1)
+    expect(oasHealthSummary.value.replayTotalMatchingEvents).toBe(1200)
+    expect(oasHealthSummary.value.replayTruncated).toBe(true)
     expect(oasAgentEvents.value[0]?.type).toBe('reputation_changed')
+  })
+
+  it('increments total events above the replay baseline for live arrivals', async () => {
+    fetchTelemetryMock.mockResolvedValue({
+      generated_at: '2026-04-15T12:00:00Z',
+      count: 1,
+      total_matching_entries: 1200,
+      truncated: true,
+      entries: [
+        {
+          source: 'oas_event',
+          type: 'oas:masc:autonomy:agent_selected',
+          ts_unix: 555,
+          correlation_id: 'corr-baseline',
+          run_id: 'run-r',
+          payload: {
+            agent_name: 'gamma',
+            trigger: 'thompson',
+            timestamp: 555,
+          },
+        } as TelemetryEntry,
+      ],
+    })
+
+    await replayOasRuntimeTelemetry()
+
+    expect(oasHealthSummary.value.totalEvents).toBe(1200)
+
+    expect(applyOasRuntimeEvent({
+      type: 'oas:masc:autonomy:agent_selected',
+      ts_unix: 556,
+      correlation_id: 'corr-live',
+      run_id: 'run-live',
+      payload: {
+        agent_name: 'delta',
+        trigger: 'thompson',
+        timestamp: 556,
+      },
+    })).toBe(true)
+
+    expect(oasHealthSummary.value.totalEvents).toBe(1201)
+    expect(oasHealthSummary.value.agentEventsCount).toBe(2)
   })
 })

--- a/dashboard/src/oas-runtime-store.ts
+++ b/dashboard/src/oas-runtime-store.ts
@@ -4,6 +4,7 @@ import { fetchTelemetry, type TelemetryEntry } from './api/dashboard'
 import { OAS_TELEMETRY_REPLAY_LIMIT } from './config/constants'
 import {
   oasTotalEvents,
+  noteOasReplayWindow,
   pushOasAgentEvent,
   recordOasError,
   recordOasLlmCall,
@@ -22,6 +23,7 @@ type OasRuntimeEnvelope = Record<string, unknown> & {
 
 type IngestOptions = {
   includeLiveTrace?: boolean
+  origin?: 'live' | 'replay'
 }
 
 const seenOasEventKeys = new Set<string>()
@@ -426,8 +428,12 @@ export function applyOasRuntimeEvent(raw: unknown, opts?: IngestOptions): boolea
     return false
   }
   seenOasEventKeys.add(key)
-  oasTotalEvents.value = seenOasEventKeys.size
   ingestRuntimeProjection(event, opts)
+  if (opts?.origin === 'replay') {
+    oasTotalEvents.value = seenOasEventKeys.size
+  } else {
+    oasTotalEvents.value = Math.max(seenOasEventKeys.size, oasTotalEvents.value + 1)
+  }
   return true
 }
 
@@ -440,8 +446,13 @@ export function hydrateOasRuntimeFromTelemetryEntries(entries: TelemetryEntry[])
     return (left ? (eventReportedUnixSeconds(left) ?? 0) : 0) - (right ? (eventReportedUnixSeconds(right) ?? 0) : 0)
   })
   for (const entry of ordered) {
-    applyOasRuntimeEvent(entry)
+    applyOasRuntimeEvent(entry, { origin: 'replay' })
   }
+  noteOasReplayWindow({
+    loadedEvents: oasTotalEvents.value,
+    totalMatchingEvents: oasTotalEvents.value,
+    truncated: false,
+  })
 }
 
 export async function replayOasRuntimeTelemetry(signal?: AbortSignal): Promise<void> {
@@ -453,4 +464,9 @@ export async function replayOasRuntimeTelemetry(signal?: AbortSignal): Promise<v
   })
   if (generation !== replayGeneration) return
   hydrateOasRuntimeFromTelemetryEntries(response.entries)
+  noteOasReplayWindow({
+    loadedEvents: oasTotalEvents.value,
+    totalMatchingEvents: response.total_matching_entries ?? response.count,
+    truncated: response.truncated ?? false,
+  })
 }

--- a/dashboard/src/store.test.ts
+++ b/dashboard/src/store.test.ts
@@ -1,11 +1,15 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
   oasTotalEvents,
+  oasReplayLoadedEvents,
+  oasReplayTotalMatchingEvents,
+  oasReplayTruncated,
   oasTotalLlmCalls,
   oasTotalErrors,
   oasLastLlmCallTs,
   oasLastErrorTs,
   oasHealthSummary,
+  noteOasReplayWindow,
   resetOasRuntimeSignals,
   pushOasAgentEvent,
   updateOasKeeperSnapshot,
@@ -26,8 +30,28 @@ describe('oasHealthSummary', () => {
     oasTotalLlmCalls.value = 4
     oasTotalErrors.value = 2
     expect(oasHealthSummary.value.totalEvents).toBe(10)
+    expect(oasHealthSummary.value.replayLoadedEvents).toBe(0)
+    expect(oasHealthSummary.value.replayTotalMatchingEvents).toBe(0)
+    expect(oasHealthSummary.value.replayTruncated).toBe(false)
     expect(oasHealthSummary.value.totalLlmCalls).toBe(4)
     expect(oasHealthSummary.value.totalErrors).toBe(2)
+  })
+
+  it('tracks replay sample size separately from total matching entries', () => {
+    noteOasReplayWindow({
+      loadedEvents: 500,
+      totalMatchingEvents: 1842,
+      truncated: true,
+    })
+
+    expect(oasTotalEvents.value).toBe(1842)
+    expect(oasReplayLoadedEvents.value).toBe(500)
+    expect(oasReplayTotalMatchingEvents.value).toBe(1842)
+    expect(oasReplayTruncated.value).toBe(true)
+    expect(oasHealthSummary.value.totalEvents).toBe(1842)
+    expect(oasHealthSummary.value.replayLoadedEvents).toBe(500)
+    expect(oasHealthSummary.value.replayTotalMatchingEvents).toBe(1842)
+    expect(oasHealthSummary.value.replayTruncated).toBe(true)
   })
 
   it('reflects agent event buffer length', () => {
@@ -96,6 +120,9 @@ describe('oasHealthSummary', () => {
     resetOasSignals()
     const s = oasHealthSummary.value
     expect(s.totalEvents).toBe(0)
+    expect(s.replayLoadedEvents).toBe(0)
+    expect(s.replayTotalMatchingEvents).toBe(0)
+    expect(s.replayTruncated).toBe(false)
     expect(s.totalLlmCalls).toBe(0)
     expect(s.totalErrors).toBe(0)
     expect(s.agentEventsCount).toBe(0)

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -132,6 +132,9 @@ export const oasAgentEvents = signal<OasAgentEvent[]>([])
 export const oasKeeperSnapshots = signal<Map<string, OasKeeperSnapshot>>(new Map())
 export const oasLastKeeperTick = signal<number | null>(null)
 export const oasTotalEvents = signal(0)
+export const oasReplayLoadedEvents = signal(0)
+export const oasReplayTotalMatchingEvents = signal(0)
+export const oasReplayTruncated = signal(false)
 export const oasTotalLlmCalls = signal(0)
 export const oasTotalErrors = signal(0)
 export const oasLastLlmCallTs = signal<number | null>(null)
@@ -143,10 +146,27 @@ export function resetOasRuntimeSignals(): void {
   oasKeeperSnapshots.value = new Map()
   oasLastKeeperTick.value = null
   oasTotalEvents.value = 0
+  oasReplayLoadedEvents.value = 0
+  oasReplayTotalMatchingEvents.value = 0
+  oasReplayTruncated.value = false
   oasTotalLlmCalls.value = 0
   oasTotalErrors.value = 0
   oasLastLlmCallTs.value = null
   oasLastErrorTs.value = null
+}
+
+export function noteOasReplayWindow(input: {
+  loadedEvents: number
+  totalMatchingEvents: number
+  truncated: boolean
+}): void {
+  const loadedEvents = Math.max(0, Math.floor(input.loadedEvents))
+  const totalMatchingEvents = Math.max(loadedEvents, Math.floor(input.totalMatchingEvents))
+  const truncated = input.truncated && totalMatchingEvents > loadedEvents
+  oasReplayLoadedEvents.value = loadedEvents
+  oasReplayTotalMatchingEvents.value = totalMatchingEvents
+  oasReplayTruncated.value = truncated
+  oasTotalEvents.value = totalMatchingEvents
 }
 
 function sameOasAgentEvent(left: OasAgentEvent, right: OasAgentEvent): boolean {
@@ -254,6 +274,9 @@ export const oasHealthSummary: ReadonlySignal<OasHealthSummary> = computed(() =>
   keeperSnapshotsCount: oasKeeperSnapshots.value.size,
   lastKeeperTick: oasLastKeeperTick.value,
   totalEvents: oasTotalEvents.value,
+  replayLoadedEvents: oasReplayLoadedEvents.value,
+  replayTotalMatchingEvents: oasReplayTotalMatchingEvents.value,
+  replayTruncated: oasReplayTruncated.value,
   totalLlmCalls: oasTotalLlmCalls.value,
   totalErrors: oasTotalErrors.value,
   lastLlmCallTs: oasLastLlmCallTs.value,

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -194,6 +194,10 @@ export interface KeeperMetricPoint {
   prompt_fingerprint: string | null
   prompt_metrics: PromptTelemetry | null
   ctx_composition: CtxCompositionTelemetry | null
+  input_tokens: number | null
+  output_tokens: number | null
+  total_tokens: number | null
+  wall_tokens_per_second: number | null
   inference_telemetry: InferenceTelemetry | null
   fallback_applied: boolean
   fallback_hops: number

--- a/dashboard/src/types/oas.ts
+++ b/dashboard/src/types/oas.ts
@@ -78,6 +78,9 @@ export interface OasHealthSummary {
   keeperSnapshotsCount: number
   lastKeeperTick: number | null
   totalEvents: number
+  replayLoadedEvents: number
+  replayTotalMatchingEvents: number
+  replayTruncated: boolean
   totalLlmCalls: number
   totalErrors: number
   lastLlmCallTs: number | null

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -15,6 +15,8 @@ open Keeper_types
 open Keeper_memory
 open Keeper_execution
 
+exception Semaphore_wait_timeout of float
+
 let keepalive_interval_sec () =
   Runtime_params.get Governance_registry.keeper_keepalive_interval_sec
 ;;
@@ -159,8 +161,6 @@ let semaphore_wait_timeout_sec =
     "MASC_KEEPER_SEMAPHORE_WAIT_TIMEOUT_SEC"
     ~default:60.0 ~min_v:5.0 ~max_v:600.0
 ;;
-
-exception Semaphore_wait_timeout of float
 
 (** Per-keeper record of the last autonomous turn completion timestamp.
     Used by the fairness cooldown to prevent a fast-cycling keeper from

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1559,6 +1559,13 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           let turn_mode_label =
             Keeper_unified_metrics.turn_mode_to_string turn_mode
           in
+          let wall_tokens_per_second =
+            if result.usage_reported && latency_ms > 0 then
+              Some
+                (float_of_int result.usage.output_tokens
+                 /. (float_of_int latency_ms /. 1000.0))
+            else None
+          in
           (* Emit turn-completed event to Activity Graph for timeline token visibility *)
           (try
             let event =
@@ -1579,12 +1586,20 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                     ("context_ratio", `Float lifecycle.context_ratio);
                     ("tools_used", `List (List.map (fun s -> `String s) result.tools_used));
                   ]
+                  @ (match wall_tokens_per_second with
+                     | Some v -> [("tokens_per_second", `Float v)]
+                     | None -> [])
                   @ (match result.inference_telemetry with
                      | Some t ->
                        (match t.reasoning_tokens with Some n -> [("reasoning_tokens", `Int n)] | None -> [])
                        @ (match t.timings with
                           | Some ti ->
-                            (match ti.predicted_per_second with Some v -> [("tokens_per_second", `Float v)] | None -> [])
+                            (match ti.prompt_per_second with
+                             | Some v -> [("prompt_per_second", `Float v)]
+                             | None -> [])
+                            @ (match ti.predicted_per_second with
+                               | Some v -> [("hw_decode_tokens_per_second", `Float v)]
+                               | None -> [])
                           | None -> [])
                      | None -> [])))
                 ~tags:["keeper"; "turn"; "metrics"]

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -369,13 +369,25 @@ let turn_completed_events (config : Coord.config) ~agent_name ~limit :
                | _ -> []
            with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> []
          in
-         let tps =
-           try match e.payload |> member "tokens_per_second" with
-               | `Float v -> [("tokens_per_second", `Float v)]
-               | _ -> []
-           with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> []
-         in
-         reasoning @ tps
+        let tps =
+          try match e.payload |> member "tokens_per_second" with
+              | `Float v -> [("tokens_per_second", `Float v)]
+              | _ -> []
+          with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> []
+        in
+        let prompt_tps =
+          try match e.payload |> member "prompt_per_second" with
+              | `Float v -> [("prompt_per_second", `Float v)]
+              | _ -> []
+          with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> []
+        in
+        let hw_decode_tps =
+          try match e.payload |> member "hw_decode_tokens_per_second" with
+              | `Float v -> [("hw_decode_tokens_per_second", `Float v)]
+              | _ -> []
+          with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> []
+        in
+         reasoning @ tps @ prompt_tps @ hw_decode_tps
        in
        Some
          {

--- a/lib/tool_suspend.ml
+++ b/lib/tool_suspend.ml
@@ -69,8 +69,7 @@ let force_leave config ~agent_id ~reason =
     Printf.sprintf "[SYSTEM] Agent '%s' forcibly removed: %s" agent_id reason
   in
   try
-    let _ = Coord.broadcast config ~from_agent:"system" ~content:message in
-    ()
+    ignore (Coord.broadcast config ~from_agent:"system" ~content:message)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn -> Log.Misc.error "broadcast (force leave) exception: %s" (Printexc.to_string exn)


### PR DESCRIPTION
## What changed

- split OAS replay accounting into:
  - loaded replay sample size
  - total matching durable events
  - truncated replay state
- surface that replay window detail in the dashboard health chip and store summary
- normalize keeper usage tokens in the dashboard store and derive wall-clock tokens/sec from output tokens and request latency
- show wall tok/s separately from hardware decode tok/s in the keeper inference telemetry panel
- emit prompt throughput and hardware decode throughput separately from the OCaml keeper/timeline side

## Why

The previous runtime metrics path mixed two different concepts:

- replay sample size vs full durable event count
- end-to-end wall-clock throughput vs model-side decode throughput

That made the OAS dashboard under-report replay totals when replay was truncated and made tok/s numbers ambiguous in keeper detail views.

## Impact

- operators can see when the dashboard only loaded a replay sample and how large the full matching event set is
- keeper telemetry no longer presents decode-only throughput as if it were end-to-end request throughput
- downstream timeline consumers get separate prompt/decode throughput fields instead of one overloaded token-rate field

## Root cause

The dashboard treated replayed event count as the total event count even when the telemetry response was truncated, and the keeper metrics UI reused `predicted_per_second` for both hardware decode speed and user-visible request throughput.

## Validation

- `cd dashboard && pnpm typecheck`
- `cd dashboard && pnpm exec vitest run src/store.test.ts src/oas-runtime-store.test.ts src/keeper-store-normalize.test.ts src/components/oas-health-chip.test.ts src/components/keeper-detail-panels.test.ts`
- `dune build --root .`
