### PR TITLE
feat(exec): P10 structured output extraction

### DIFF
--- a/lib/exec/output_parse.ml
+++ b/lib/exec/output_parse.ml
@@ -55,7 +55,9 @@ let contains_substring s sub =
 (* --- git status --porcelain --- *)
 
 let parse_git_status_porcelean output =
-  let lines = split_lines (trim output) in
+  let lines =
+    split_lines output |> List.filter (fun line -> trim line <> "")
+  in
   if lines = [] then None
   else
     let staged = ref [] and unstaged = ref [] and untracked = ref [] in
@@ -131,28 +133,26 @@ let parse_git_diff_stat output =
     | last :: _ ->
         (* last line: " N files changed, M insertions(+), D deletions(-)" *)
         let lower = String.lowercase_ascii last in
-        if not (starts_with (trim lower) "file" || starts_with (trim lower) "files") then
+        if not (contains_substring lower " file changed"
+                || contains_substring lower " files changed")
+        then
           None
         else
           let files_changed = ref 0 and insertions = ref 0 and deletions = ref 0 in
+          let update_if_found target re =
+            try
+              ignore (Str.search_forward re last 0);
+              target := int_of_string (Str.matched_group 1 last)
+            with
+            | Not_found
+            | Failure _ -> ()
+          in
           (* parse "N file(s) changed" *)
-          (try
-             let re = Str.regexp {|\([0-9]+\) file|} in
-             if Str.string_match re (trim last) 0 then
-               files_changed := int_of_string (Str.matched_group 1 (trim last))
-           with _ -> ());
+          update_if_found files_changed (Str.regexp {|\([0-9]+\) file|});
           (* parse "M insertion(s)(+)" *)
-          (try
-             let re = Str.regexp {|\([0-9]+\) insertion|} in
-             if Str.string_match re (trim last) 0 then
-               insertions := int_of_string (Str.matched_group 1 (trim last))
-           with _ -> ());
+          update_if_found insertions (Str.regexp {|\([0-9]+\) insertion|});
           (* parse "D deletion(s)(-)" *)
-          (try
-             let re = Str.regexp {|\([0-9]+\) deletion|} in
-             if Str.string_match re (trim last) 0 then
-               deletions := int_of_string (Str.matched_group 1 (trim last))
-           with _ -> ());
+          update_if_found deletions (Str.regexp {|\([0-9]+\) deletion|});
           Some
             (`Assoc
                [
@@ -316,7 +316,7 @@ let classify_for_parsing ~cmd ~output =
       let base = Filename.basename bin |> String.lowercase_ascii in
       match base with
       | "git" ->
-          let sub = match rest with _first :: s :: _ -> Some s | _ -> None in
+          let sub = match rest with s :: _ -> Some s | _ -> None in
           (match sub with
           | Some "status" -> Some Git_status
           | Some "log" -> Some Git_log_oneline

--- a/test/test_exec_core.ml
+++ b/test/test_exec_core.ml
@@ -491,6 +491,21 @@ let test_wc_structured () =
   let so = json |> member "structured_output" in
   check int "lines" 120 (so |> member "lines" |> to_int)
 
+let test_git_diff_stat_structured () =
+  let json =
+    Masc_mcp.Exec_core.process_result_json
+      ~base_path:"/tmp"
+      ~keeper_name:"p10-test"
+      ~cmd:"git diff --stat"
+      ~status:(Unix.WEXITED 0)
+      ~output:" lib/foo.ml | 3 ++-\n 1 file changed, 2 insertions(+), 1 deletion(-)\n"
+      ()
+  in
+  let so = json |> member "structured_output" in
+  check int "files_changed" 1 (so |> member "files_changed" |> to_int);
+  check int "insertions" 2 (so |> member "insertions" |> to_int);
+  check int "deletions" 1 (so |> member "deletions" |> to_int)
+
 let test_unknown_cmd_no_structured () =
   let json =
     Masc_mcp.Exec_core.process_result_json
@@ -502,10 +517,9 @@ let test_unknown_cmd_no_structured () =
       ()
   in
   check bool "no structured_output for unknown" true
-    (try
-       let _ = json |> member "structured_output" in
-       false
-     with _ -> true)
+    (match json |> member "structured_output" with
+     | `Null -> true
+     | _ -> false)
 
 let test_dune_test_structured () =
   let output =
@@ -660,6 +674,8 @@ let () =
             test_git_log_structured;
           test_case "wc -l produces lines count" `Quick
             test_wc_structured;
+          test_case "git diff --stat produces summary counts" `Quick
+            test_git_diff_stat_structured;
           test_case "unknown cmd has no structured_output" `Quick
             test_unknown_cmd_no_structured;
           test_case "dune runtest produces passed/failed counts" `Quick


### PR DESCRIPTION
## Summary
- Add `lib/exec/output_parse.ml` — pure-function parsers for common command outputs (git status/log/diff, wc, ls, dune test)
- Wire `structured_output` field into `outcome_to_json` Executed branch
- 5 integration tests covering git status, git log, wc, dune test, and unknown command passthrough

## Design
- Fail-open: unrecognized commands produce no `structured_output` field
- Zero side effects: all parsers are pure functions
- Pattern-based classification: command string determines parser selection

## Test plan
- [x] `dune build` passes (2 pre-existing errors in docker/safety tests unrelated)
- [x] 5 test cases in `p10_structured_output` group
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)