### PR TITLE
[codex] harden keeper runtime MCP auth edges

### DIFF
--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -57,6 +57,7 @@ Worked examples (assuming a single allowed org `jeong-sik` and a single denied r
 Reading the policy:
 - `allowed_orgs` names the orgs you are *entitled to* clone from, not orgs you must ask permission for. If the task you claim names a repo under ALLOWED (and not in DENIED), clone it directly.
 - Only ask the board when the task does not name a repo and you cannot infer one from context. Do NOT post a "may I clone?" board question when the task already names a repo that passes the ALLOWED/DENIED check.
+- Never infer the GitHub owner from local workspace folders such as `workspace/<name>/...`; only trust the actual clone URL or a confirmed remote origin slug.
 
 Never invent an org or repo that is not in ALLOWED.
 

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -140,6 +140,9 @@ let credential_agent_name agent_name =
   | Some prefix when prefix <> agent_name -> prefix
   | _ -> agent_name
 
+let raw_token_file config agent_name =
+  Filename.concat (auth_dir config) (agent_name ^ ".token")
+
 let load_credential_from_path config agent_name path : agent_credential option =
   if file_exists path then
     try
@@ -185,6 +188,19 @@ let save_credential config (cred : agent_credential) =
   let file = credential_file config cred.agent_name in
   let json = agent_credential_to_yojson cred in
   save_private_text_file file (Yojson.Safe.pretty_to_string json)
+
+let load_raw_token config ~agent_name =
+  let file = raw_token_file config agent_name in
+  if file_exists file then
+    try
+      read_text_file file |> trim_nonempty
+    with Sys_error _ -> None
+  else
+    None
+
+let persist_raw_token config ~agent_name raw_token =
+  ensure_auth_dirs config;
+  save_private_text_file (raw_token_file config agent_name) raw_token
 
 (** Delete agent credential *)
 let delete_credential config agent_name =
@@ -300,19 +316,54 @@ let verify_token config ~agent_name ~token : (agent_credential, masc_error) resu
 let ensure_keeper_credential config ~agent_name :
     (string * agent_credential, masc_error) result =
   let target_agent_name = credential_agent_name agent_name in
+  let persist_verified_raw_token raw_token =
+    try persist_raw_token config ~agent_name:target_agent_name raw_token
+    with Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+           Log.Auth.warn
+             "[ensure_keeper_credential] failed to persist raw token for %s: %s"
+             target_agent_name (Printexc.to_string exn)
+  in
+  let verify_candidate raw_token =
+    match verify_token config ~agent_name ~token:raw_token with
+    | Ok cred ->
+        persist_verified_raw_token raw_token;
+        Ok (raw_token, cred)
+    | Error e -> Error e
+  in
+  let mint_and_persist () =
+    match create_token config ~agent_name:target_agent_name ~role:Admin with
+    | Ok (raw_token, cred) ->
+        persist_verified_raw_token raw_token;
+        Ok (raw_token, cred)
+    | Error e -> Error e
+  in
   let env_token =
     match Sys.getenv_opt "MASC_MCP_TOKEN" with
     | Some raw -> trim_nonempty raw
     | None -> None
   in
+  let persisted_token =
+    load_raw_token config ~agent_name:target_agent_name
+  in
   match env_token with
   | Some raw_token -> (
-      match verify_token config ~agent_name ~token:raw_token with
-      | Ok cred -> Ok (raw_token, cred)
-      | Error _ ->
-          create_token config ~agent_name:target_agent_name ~role:Admin)
-  | None ->
-      create_token config ~agent_name:target_agent_name ~role:Admin
+      match verify_candidate raw_token with
+      | Ok _ as ok -> ok
+      | Error _ -> (
+          match persisted_token with
+          | Some persisted_raw -> (
+              match verify_candidate persisted_raw with
+              | Ok _ as ok -> ok
+              | Error _ -> mint_and_persist ())
+          | None -> mint_and_persist ()))
+  | None -> (
+      match persisted_token with
+      | Some persisted_raw -> (
+          match verify_candidate persisted_raw with
+          | Ok _ as ok -> ok
+          | Error _ -> mint_and_persist ())
+      | None -> mint_and_persist ())
 
 (** Refresh a token (generate new one, update credential) *)
 let refresh_token config ~agent_name ~old_token : (string * agent_credential, masc_error) result =

--- a/lib/auth.mli
+++ b/lib/auth.mli
@@ -67,7 +67,8 @@ val ensure_keeper_credential :
   string -> agent_name:string ->
   (string * agent_credential, masc_error) result
 (** [ensure_keeper_credential config ~agent_name] returns a valid credential,
-    reusing [MASC_MCP_TOKEN] env or creating a new one. *)
+    reusing a valid [MASC_MCP_TOKEN], then any persisted raw token file, or
+    creating a new keeper-scoped token when neither is usable. *)
 
 (** {1 Token Lifecycle} *)
 

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -156,19 +156,36 @@ let runtime_mcp_policy_with_masc_agent_name
     in
     { policy with servers }
 
+let runtime_mcp_policy_without_http_headers
+    (policy : Llm_provider.Llm_transport.runtime_mcp_policy) =
+  let servers =
+    List.map
+      (function
+        | Llm_provider.Llm_transport.Http_server server ->
+            Llm_provider.Llm_transport.Http_server { server with headers = [] }
+        | server -> server)
+      policy.servers
+  in
+  { policy with servers }
+
 let runtime_mcp_policy_for_provider
     ~(provider_cfg : Llm_provider.Provider_config.t)
     ~(agent_name : string)
     (policy_opt : Llm_provider.Llm_transport.runtime_mcp_policy option) =
-  match policy_opt, provider_cfg.kind with
-  | Some policy, Llm_provider.Provider_config.Codex_cli ->
-      (* Codex CLI runtime MCP currently rejects inline HTTP headers, so
-         keep the runtime policy untouched until that transport supports
-         carrying per-request headers. *)
-      Some policy
-  | Some policy, _ ->
+  let agent_name =
+    let trimmed = String.trim agent_name in
+    if String.equal trimmed "" then None else Some trimmed
+  in
+  match policy_opt, provider_cfg.kind, agent_name with
+  | Some policy, Llm_provider.Provider_config.Codex_cli, _ ->
+      (* Codex CLI runtime MCP currently rejects per-request HTTP headers.
+         Keep the runtime lane, but strip request-scoped headers so ambient
+         env auth continues to work. *)
+      Some (runtime_mcp_policy_without_http_headers policy)
+  | Some policy, _, Some agent_name ->
       Some (runtime_mcp_policy_with_masc_agent_name ~agent_name policy)
-  | None, _ -> None
+  | Some policy, _, None -> Some policy
+  | None, _, _ -> None
 
 let kimi_cli_runtime_mcp_jsons
     ~(base : string list)
@@ -191,26 +208,46 @@ let public_mcp_tools_of_oas_tools (tools : Oas.Tool.t list) =
 let tool_names_are_public_mcp (tool_names : string list) =
   tool_names <> [] && List.for_all Tool_catalog.is_public_mcp tool_names
 
+let trim_nonempty_string raw =
+  let trimmed = String.trim raw in
+  if String.equal trimmed "" then None else Some trimmed
+
 let trim_nonempty value =
-  match value with
-  | Some raw ->
-      let trimmed = String.trim raw in
-      if String.equal trimmed "" then None else Some trimmed
-  | None -> None
+  Option.bind value trim_nonempty_string
 
 let first_nonempty_env names =
   List.find_map (fun name -> Sys.getenv_opt name |> trim_nonempty) names
 
-let public_mcp_runtime_policy_of_tool_names (tool_names : string list) :
+let bearer_token_headers token =
+  [ ("Authorization", "Bearer " ^ token) ]
+
+let fallback_public_mcp_headers () =
+  match first_nonempty_env [ "MASC_MCP_TOKEN" ] with
+  | Some token -> bearer_token_headers token
+  | None -> []
+
+let keeper_public_mcp_headers ~agent_name =
+  match Env_config_core.base_path_opt () with
+  | Some base_path -> (
+      match Auth.ensure_keeper_credential base_path ~agent_name with
+      | Ok (token, _) -> bearer_token_headers token
+      | Error err ->
+          Log.warn ~ctx:"oas_worker_exec"
+            "keeper MCP credential provisioning failed for %s: %s; falling back to MASC_MCP_TOKEN"
+            agent_name (Types.masc_error_to_string err);
+          fallback_public_mcp_headers ())
+  | None -> fallback_public_mcp_headers ()
+
+let public_mcp_runtime_policy_of_tool_names ?agent_name (tool_names : string list) :
     Llm_provider.Llm_transport.runtime_mcp_policy option =
   let tool_names = dedupe_preserve_order tool_names in
   if not (tool_names_are_public_mcp tool_names) then
     None
   else
     let masc_headers =
-      match first_nonempty_env [ "MASC_MCP_TOKEN" ] with
-      | Some token -> [ ("Authorization", "Bearer " ^ token) ]
-      | None -> []
+      match Option.bind agent_name trim_nonempty_string with
+      | Some agent_name -> keeper_public_mcp_headers ~agent_name
+      | None -> fallback_public_mcp_headers ()
     in
     Some
       {
@@ -300,17 +337,14 @@ let resolve_tool_lane_for_oas_tools
     result =
   let public_tools = public_mcp_tools_of_oas_tools tools in
   let public_tool_names = public_mcp_tool_names_of_oas_tools public_tools in
+  let requested_agent_name =
+    Option.bind agent_name trim_nonempty_string
+  in
   let runtime_mcp_policy =
-    match public_mcp_runtime_policy_of_tool_names public_tool_names with
-    | Some policy ->
-        let agent_name =
-          match agent_name with
-          | Some agent_name -> String.trim agent_name
-          | None -> ""
-        in
-        if agent_name = "" then Some policy
-        else Some (runtime_mcp_policy_with_masc_agent_name ~agent_name policy)
-    | None -> None
+    public_mcp_runtime_policy_of_tool_names
+      ?agent_name:requested_agent_name public_tool_names
+    |> runtime_mcp_policy_for_provider ~provider_cfg
+         ~agent_name:(Option.value ~default:"" requested_agent_name)
   in
   match runtime_mcp_policy with
   | Some runtime_mcp_policy

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -73,7 +73,8 @@ let runtime_mcp_policy_for_tools ~(keeper_name : string) (tools : Oas.Tool.t lis
     |> Oas_worker_exec.public_mcp_tool_names_of_oas_tools
   in
   match
-    Oas_worker_exec.public_mcp_runtime_policy_of_tool_names public_tool_names,
+    Oas_worker_exec.public_mcp_runtime_policy_of_tool_names
+      ?agent_name:(keeper_agent_name_opt keeper_name) public_tool_names,
     keeper_agent_name_opt keeper_name
   with
   | Some policy, Some agent_name ->

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -126,11 +126,14 @@ let git_rev_parse_short_cancel_refresh dir =
     ~finally:(fun () -> Stdlib.Mutex.unlock git_rev_parse_short_mu)
     (fun () -> Hashtbl.remove git_rev_parse_short_in_flight dir)
 
+let git_rev_parse_short_probe_argv dir =
+  [ "git"; "-C"; dir; "--no-optional-locks"; "rev-parse"; "--short"; "HEAD" ]
+
 let git_rev_parse_short_probe dir =
   match Atomic.get git_rev_parse_short_probe_hook_for_tests with
   | Some hook -> hook dir
   | None ->
-      let argv = [ "git"; "-C"; dir; "rev-parse"; "--short"; "HEAD" ] in
+      let argv = git_rev_parse_short_probe_argv dir in
       let raw_source = String.concat " " (List.map Filename.quote argv) in
       match
         Masc_exec.Exec_gate.run_argv_with_status

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -305,8 +305,10 @@ let validate_clone_url ~base_path url =
     | Some org ->
       let allowed_lc = List.map String.lowercase_ascii allowed in
       if not (List.mem org allowed_lc) then
-        Error (Printf.sprintf
-          "GitHub org '%s' not in allowed list: %s" org (String.concat ", " allowed))
+        Error
+          (Printf.sprintf
+             "GitHub org '%s' not in allowed list: %s. Use the actual GitHub owner from the clone URL; do not infer an org from local workspace path segments."
+             org (String.concat ", " allowed))
       else
         (* Check repo-level deny list *)
         let denied = load_clone_denied_repos ~base_path in

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -362,6 +362,45 @@ let test_ensure_keeper_credential_uses_keeper_middle_name () =
            "ensure_keeper_credential should mint a keeper-scoped token: %s"
            (Types.masc_error_to_string e))
 
+let test_ensure_keeper_credential_reuses_persisted_raw_token_when_env_mismatched () =
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      let first_result =
+        with_env "MASC_MCP_TOKEN" "" (fun () ->
+          Auth.ensure_keeper_credential dir ~agent_name:"keeper-masc-improver-agent")
+      in
+      let raw_token_path =
+        Filename.concat (Auth.auth_dir dir) "masc-improver.token"
+      in
+      let shared_raw_token = "shared-codex-token" in
+      let _ =
+        Auth.save_raw_token_credential dir ~agent_name:"codex-mcp-client"
+          ~role:Types.Admin ~raw_token:shared_raw_token
+      in
+      let reused_result =
+        with_env "MASC_MCP_TOKEN" shared_raw_token (fun () ->
+          Auth.ensure_keeper_credential dir ~agent_name:"keeper-masc-improver-agent")
+      in
+      match first_result, reused_result with
+      | Ok (first_raw_token, first_cred), Ok (reused_raw_token, reused_cred) ->
+          check bool "persisted raw token file created" true
+            (Sys.file_exists raw_token_path);
+          check int "persisted raw token file mode 0600" 0o600
+            (permission_bits raw_token_path);
+          check string "first credential uses keeper middle name" "masc-improver"
+            first_cred.agent_name;
+          check string "reused credential keeps keeper middle name" "masc-improver"
+            reused_cred.agent_name;
+          check string "persisted keeper raw token reused" first_raw_token
+            reused_raw_token
+      | Error e, _ | _, Error e ->
+          fail
+            (Printf.sprintf
+               "ensure_keeper_credential should reuse persisted keeper token: %s"
+               (Types.masc_error_to_string e)))
+
 (* ============================================ *)
 (* Permission tests                             *)
 (* ============================================ *)
@@ -631,6 +670,8 @@ let () =
         test_save_raw_token_credential_uses_provided_token;
       test_case "ensure_keeper_credential uses keeper middle name" `Quick
         test_ensure_keeper_credential_uses_keeper_middle_name;
+      test_case "ensure_keeper_credential reuses persisted raw token on env mismatch" `Quick
+        test_ensure_keeper_credential_reuses_persisted_raw_token_when_env_mismatched;
     ];
     "permissions", [
       test_case "reader permissions" `Quick test_reader_permissions;

--- a/test/test_dashboard_cache.ml
+++ b/test/test_dashboard_cache.ml
@@ -422,6 +422,13 @@ let test_runtime_git_cache_returns_stale_and_refreshes ~clock () =
           Alcotest.(check int) "single background probe" 1
             (Atomic.get probes)))
 
+let test_runtime_git_probe_argv_disables_optional_locks () =
+  let module Runtime = Server_dashboard_http_runtime_info in
+  Alcotest.(check (list string))
+    "runtime git probe argv uses no-optional-locks"
+    [ "git"; "-C"; "/tmp/demo"; "--no-optional-locks"; "rev-parse"; "--short"; "HEAD" ]
+    (Runtime.git_rev_parse_short_probe_argv "/tmp/demo")
+
 (* -- Harness ---------------------------------------------------------------- *)
 
 let () =
@@ -461,6 +468,8 @@ let () =
           test_case "stampede protection" `Quick test_stampede;
           test_case "runtime git cache stale-first refresh" `Quick
             (test_runtime_git_cache_returns_stale_and_refreshes ~clock);
+          test_case "runtime git probe disables optional locks" `Quick
+            test_runtime_git_probe_argv_disables_optional_locks;
         ] );
       ( "timeout",
         [

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1363,6 +1363,7 @@ let test_cascade_provider_labels_detect_kimi_from_model_and_base_url () =
 
 let test_resolve_tool_lane_for_codex_cli_public_tools_uses_runtime_mcp_policy () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "shared-codex-token" @@ fun () ->
   let tools =
     [ make_named_noop_tool "masc_status"; make_named_noop_tool "masc_tasks" ]
   in
@@ -1372,6 +1373,14 @@ let test_resolve_tool_lane_for_codex_cli_public_tools_uses_runtime_mcp_policy ()
       ~tools ()
   with
   | Ok (effective_tools, Some policy) ->
+      let masc_headers =
+        List.find_map
+          (function
+            | Llm_provider.Llm_transport.Http_server server
+              when String.equal server.name "masc" -> Some server.headers
+            | _ -> None)
+          policy.servers
+      in
       Alcotest.(check int) "runtime lane strips inline tools" 0
         (List.length effective_tools);
       Alcotest.(check (list string)) "allowed tool names preserve public MCP set"
@@ -1382,13 +1391,16 @@ let test_resolve_tool_lane_for_codex_cli_public_tools_uses_runtime_mcp_policy ()
         [ "masc" ]
         (List.map Llm_provider.Llm_transport.runtime_mcp_server_name policy.servers);
       Alcotest.(check bool) "strict runtime policy" true policy.strict;
-      Alcotest.(check bool) "builtins disabled" true policy.disable_builtin_tools
+      Alcotest.(check bool) "builtins disabled" true policy.disable_builtin_tools;
+      Alcotest.(check (option string)) "codex_cli runtime lane strips bearer header" None
+        (Option.bind masc_headers (List.assoc_opt "Authorization"))
   | Ok (_, None) ->
       Alcotest.fail "expected codex_cli public MCP tools to use runtime MCP lane"
   | Error err -> Alcotest.fail (Oas.Error.to_string err)
 
-let test_resolve_tool_lane_for_codex_cli_public_tools_with_agent_name_rejects_runtime_headers () =
+let test_resolve_tool_lane_for_codex_cli_public_tools_with_agent_name_strips_runtime_headers () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "shared-codex-token" @@ fun () ->
   let tools =
     [ make_named_noop_tool "masc_status"; make_named_noop_tool "masc_tasks" ]
   in
@@ -1398,13 +1410,24 @@ let test_resolve_tool_lane_for_codex_cli_public_tools_with_agent_name_rejects_ru
       ~provider_cfg:(make_codex_cli_provider_cfg ())
       ~tools ()
   with
-  | Ok _ ->
+  | Ok (effective_tools, Some policy) ->
+      let masc_headers =
+        List.find_map
+          (function
+            | Llm_provider.Llm_transport.Http_server server
+              when String.equal server.name "masc" -> Some server.headers
+            | _ -> None)
+          policy.servers
+      in
+      Alcotest.(check int) "runtime lane strips inline tools" 0
+        (List.length effective_tools);
+      Alcotest.(check (option string)) "codex_cli strips agent header" None
+        (Option.bind masc_headers (List.assoc_opt "x-masc-agent-name"));
+      Alcotest.(check (option string)) "codex_cli strips bearer header" None
+        (Option.bind masc_headers (List.assoc_opt "Authorization"))
+  | Ok (_, None) ->
       Alcotest.fail
-        "expected codex_cli to reject public MCP runtime lane when keeper headers are required"
-  | Error (Oas.Error.Config (Oas.Error.InvalidConfig { field; detail })) ->
-      Alcotest.(check string) "field" "tool_support" field;
-      Alcotest.(check bool) "detail mentions runtime MCP HTTP headers" true
-        (contains_substring ~needle:"runtime MCP HTTP headers" detail)
+        "expected codex_cli public MCP tools with agent_name to use runtime MCP lane"
   | Error err -> Alcotest.fail (Oas.Error.to_string err)
 
 let test_resolve_tool_lane_for_kimi_cli_public_tools_uses_runtime_mcp_policy () =
@@ -1623,6 +1646,60 @@ let test_runtime_mcp_policy_with_masc_agent_name_upserts_header () =
         (List.assoc_opt "x-masc-agent-name" other_headers)
   | _ -> Alcotest.fail "expected both masc and other HTTP servers"
 
+let test_public_mcp_runtime_policy_of_tool_names_uses_keeper_bearer_token () =
+  let base_path = temp_dir "public_mcp_keeper_auth" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+      let shared_raw_token = "shared-codex-token" in
+      match
+        Auth.save_raw_token_credential base_path ~agent_name:"codex-mcp-client"
+          ~role:Types.Admin ~raw_token:shared_raw_token
+      with
+      | Error err -> Alcotest.fail (Types.masc_error_to_string err)
+      | Ok _ ->
+          with_env "MASC_BASE_PATH" base_path @@ fun () ->
+          with_env "MASC_MCP_TOKEN" shared_raw_token @@ fun () ->
+          with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+          match
+            Oas_worker_exec.public_mcp_runtime_policy_of_tool_names
+              ~agent_name:"keeper-sangsu-agent" [ "masc_status" ]
+          with
+          | None -> Alcotest.fail "expected runtime MCP policy"
+          | Some policy ->
+              let masc_headers =
+                List.find_map
+                  (function
+                    | Llm_provider.Llm_transport.Http_server server
+                      when String.equal server.name "masc" -> Some server.headers
+                    | _ -> None)
+                  policy.servers
+              in
+              match Option.bind masc_headers (List.assoc_opt "Authorization") with
+              | None -> Alcotest.fail "expected keeper Authorization header"
+              | Some auth_header ->
+                  let prefix = "Bearer " in
+                  if not (String.starts_with ~prefix auth_header) then
+                    Alcotest.fail "expected Bearer auth header";
+                  let raw_token =
+                    String.sub auth_header (String.length prefix)
+                      (String.length auth_header - String.length prefix)
+                  in
+                  Alcotest.(check bool) "keeper token is not shared env token" true
+                    (raw_token <> shared_raw_token);
+                  match
+                    Auth.verify_token base_path
+                      ~agent_name:"keeper-sangsu-agent" ~token:raw_token
+                  with
+                  | Ok cred ->
+                      Alcotest.(check string) "keeper alias resolves minted credential"
+                        "sangsu" cred.agent_name
+                  | Error err ->
+                      Alcotest.fail
+                        (Printf.sprintf
+                           "expected keeper runtime bearer token to verify: %s"
+                           (Types.masc_error_to_string err)))
+
 let test_runtime_mcp_policy_for_provider_skips_codex_cli_header_injection () =
   let policy =
     {
@@ -1667,6 +1744,8 @@ let test_runtime_mcp_policy_for_provider_skips_codex_cli_header_injection () =
   | Some codex_headers, Some openai_headers ->
       Alcotest.(check (option string)) "codex_cli skips agent header" None
         (List.assoc_opt "x-masc-agent-name" codex_headers);
+      Alcotest.(check (option string)) "codex_cli strips bearer header" None
+        (List.assoc_opt "Authorization" codex_headers);
       Alcotest.(check (option string)) "openai_compat still injects agent header"
         (Some "keeper-sangsu-agent")
         (List.assoc_opt "x-masc-agent-name" openai_headers)
@@ -3010,9 +3089,9 @@ let () =
       Alcotest.test_case "public MCP tools on codex_cli use runtime MCP lane" `Quick
         test_resolve_tool_lane_for_codex_cli_public_tools_uses_runtime_mcp_policy;
       Alcotest.test_case
-        "public MCP tools on codex_cli reject unsupported runtime MCP headers"
+        "public MCP tools on codex_cli strip unsupported runtime MCP headers"
         `Quick
-        test_resolve_tool_lane_for_codex_cli_public_tools_with_agent_name_rejects_runtime_headers;
+        test_resolve_tool_lane_for_codex_cli_public_tools_with_agent_name_strips_runtime_headers;
       Alcotest.test_case "public MCP tools on kimi_cli use runtime MCP lane" `Quick
         test_resolve_tool_lane_for_kimi_cli_public_tools_uses_runtime_mcp_policy;
       Alcotest.test_case
@@ -3031,6 +3110,8 @@ let () =
         test_kimi_mcp_config_json_of_policy_filters_to_allowed_servers;
       Alcotest.test_case "runtime MCP policy injects keeper agent header for masc server" `Quick
         test_runtime_mcp_policy_with_masc_agent_name_upserts_header;
+      Alcotest.test_case "public MCP policy auto-mints keeper bearer token" `Quick
+        test_public_mcp_runtime_policy_of_tool_names_uses_keeper_bearer_token;
       Alcotest.test_case "provider-aware runtime MCP policy skips codex_cli agent header injection" `Quick
         test_runtime_mcp_policy_for_provider_skips_codex_cli_header_injection;
       Alcotest.test_case "kimi request runtime MCP config is merged" `Quick

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -146,6 +146,17 @@ let test_disallowed_org () =
   | Error _ -> ()
   | Ok () -> fail "expected error for disallowed org"
 
+let test_disallowed_org_mentions_workspace_path_hint () =
+  let bp = project_base_path () in
+  match Tool_code_write.validate_clone_url ~base_path:bp
+    "https://github.com/yousleepwhen/masc-mcp.git" with
+  | Error reason ->
+      check bool "error hints against workspace path inference" true
+        (msg_contains
+           ~needle:"do not infer an org from local workspace path segments"
+           reason)
+  | Ok () -> fail "expected error for disallowed org"
+
 let test_non_github_rejected () =
   let bp = project_base_path () in
   match Tool_code_write.validate_clone_url ~base_path:bp
@@ -472,6 +483,8 @@ let () =
     ("validate_clone_url", [
       test_case "allowed org" `Quick test_allowed_org;
       test_case "disallowed org" `Quick test_disallowed_org;
+      test_case "disallowed org hints against workspace path inference" `Quick
+        test_disallowed_org_mentions_workspace_path_hint;
       test_case "non-github rejected" `Quick test_non_github_rejected;
       test_case "ssh allowed" `Quick test_ssh_allowed;
       test_case "missing config fails closed" `Quick test_missing_base_path_without_config_fails_closed;


### PR DESCRIPTION
## What changed
- persist keeper-scoped raw bearer token files under the stable keeper credential name and reuse them before minting a new token
- make public MCP runtime policy provider-aware so header-capable providers keep keeper auth, while `codex_cli` strips unsupported request-scoped HTTP headers instead of rejecting the runtime lane
- harden the runtime git probe by using `git --no-optional-locks rev-parse --short HEAD`
- clarify clone policy guidance so GitHub owners are taken from the actual remote URL, not inferred from local workspace paths

## Why
Public MCP auth hardening exposed two edge cases:
- keeper raw token persistence could collapse to the wrong filename during alias normalization, so the intended keeper token was not reused reliably
- `codex_cli` cannot carry request-scoped MCP HTTP headers, so keeper/public MCP routing needed provider-aware normalization rather than a hard failure

The git probe and clone-url guidance changes close adjacent operational/logging pitfalls that surfaced while hardening these paths.

## Impact
- keeper-scoped MCP auth is more stable and avoids accidental reuse of a shared env bearer token
- `codex_cli` keepers can still use the public MCP runtime lane without per-request header breakage
- dashboard runtime info probing is less likely to contend on git locks
- clone validation errors point operators toward the real GitHub owner source of truth

## Validation
- `opam exec -- dune build --root . --stop-on-first-error`
- `env ALCOTEST_QUICK_TESTS=1 _build/default/test/test_auth.exe`
- `env ALCOTEST_QUICK_TESTS=1 _build/default/test/test_oas_worker.exe`
- `env ALCOTEST_QUICK_TESTS=1 _build/default/test/test_dashboard_cache.exe`
- `env ALCOTEST_QUICK_TESTS=1 _build/default/test/test_tool_code_write_coverage.exe`