### PR TITLE
[codex] fix dashboard dev token auth mismatch

### DIFF
--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -1,22 +1,59 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   ApiRequestError,
+  authHeaders,
+  clearStoredToken,
   confirmOperatorAction,
+  currentDashboardActor,
   defaultBoardVoter,
   extractApiError,
   get,
+  getStoredToken,
+  getStoredTokenMeta,
   post,
   runOperatorAction,
+  setStoredToken,
 } from './core'
 import { OperatorActionSchemaDriftError } from './schemas/operator-action'
 
 afterEach(() => {
   vi.unstubAllGlobals()
+  window.sessionStorage?.clear?.()
   try {
     window.history.replaceState({}, '', 'http://localhost/')
   } catch {
     // Ignore cleanup failures in the test environment.
   }
+})
+
+describe('stored token metadata', () => {
+  it('persists token metadata and prefers the managed dev actor', () => {
+    setStoredToken('loopback-dev-token', {
+      source: 'dev',
+      actor: 'dashboard-dev!!!',
+      scope: 'admin',
+    })
+
+    expect(getStoredToken()).toBe('loopback-dev-token')
+    expect(getStoredTokenMeta()).toEqual({
+      source: 'dev',
+      actor: 'dashboard-dev',
+      scope: 'admin',
+    })
+    expect(currentDashboardActor()).toBe('dashboard-dev')
+    expect(authHeaders()).toMatchObject({
+      Authorization: 'Bearer loopback-dev-token',
+      'X-MASC-Agent': 'dashboard-dev',
+    })
+  })
+
+  it('clears both the token and metadata together', () => {
+    setStoredToken('manual-token', { source: 'manual', actor: 'dashboard-user' })
+    clearStoredToken()
+
+    expect(getStoredToken()).toBeNull()
+    expect(getStoredTokenMeta()).toBeNull()
+  })
 })
 
 describe('post', () => {

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -19,12 +19,36 @@ function getQueryParams(): URLSearchParams {
 }
 
 const TOKEN_STORAGE_KEY = 'masc_bearer_token'
+const TOKEN_META_STORAGE_KEY = 'masc_bearer_token_meta'
+
+type StoredTokenSource = 'dev' | 'manual' | 'url'
+
+export interface StoredTokenMeta {
+  source: StoredTokenSource
+  actor?: string | null
+  scope?: string | null
+}
+
+function normalizeStoredTokenMeta(value: unknown): StoredTokenMeta | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  const source = typeof record.source === 'string' ? record.source : null
+  if (source !== 'dev' && source !== 'manual' && source !== 'url') return null
+  const actor = sanitizeDashboardActorName(
+    typeof record.actor === 'string' ? record.actor : null,
+  )
+  const scope =
+    typeof record.scope === 'string' && record.scope.trim() !== ''
+      ? record.scope.trim()
+      : null
+  return { source, actor, scope }
+}
 
 function initTokenFromUrl(): void {
   const params = new URLSearchParams(window.location.search)
   const urlToken = params.get('token')
   if (urlToken) {
-    sessionStorage.setItem(TOKEN_STORAGE_KEY, urlToken)
+    setStoredToken(urlToken, { source: 'url' })
     params.delete('token')
     const cleaned = params.toString()
     const newUrl = window.location.pathname + (cleaned ? `?${cleaned}` : '') + window.location.hash
@@ -35,15 +59,49 @@ function initTokenFromUrl(): void {
 initTokenFromUrl()
 
 export function getStoredToken(): string | null {
-  return sessionStorage.getItem(TOKEN_STORAGE_KEY)
+  try {
+    const token = sessionStorage.getItem(TOKEN_STORAGE_KEY)
+    return typeof token === 'string' && token.trim() !== '' ? token : null
+  } catch {
+    return null
+  }
 }
 
-export function setStoredToken(token: string): void {
-  sessionStorage.setItem(TOKEN_STORAGE_KEY, token)
+export function getStoredTokenMeta(): StoredTokenMeta | null {
+  try {
+    const raw = sessionStorage.getItem(TOKEN_META_STORAGE_KEY)
+    if (!raw) return null
+    return normalizeStoredTokenMeta(JSON.parse(raw))
+  } catch {
+    return null
+  }
+}
+
+export function setStoredToken(
+  token: string,
+  meta: Partial<StoredTokenMeta> & { source?: StoredTokenSource } = {},
+): void {
+  const normalizedToken = token.trim()
+  if (!normalizedToken) {
+    clearStoredToken()
+    return
+  }
+  const nextMeta = normalizeStoredTokenMeta({
+    source: meta.source ?? 'manual',
+    actor: meta.actor ?? null,
+    scope: meta.scope ?? null,
+  })
+  sessionStorage.setItem(TOKEN_STORAGE_KEY, normalizedToken)
+  if (nextMeta) {
+    sessionStorage.setItem(TOKEN_META_STORAGE_KEY, JSON.stringify(nextMeta))
+  } else {
+    sessionStorage.removeItem(TOKEN_META_STORAGE_KEY)
+  }
 }
 
 export function clearStoredToken(): void {
   sessionStorage.removeItem(TOKEN_STORAGE_KEY)
+  sessionStorage.removeItem(TOKEN_META_STORAGE_KEY)
 }
 
 export function isRemoteAccess(): boolean {
@@ -52,6 +110,11 @@ export function isRemoteAccess(): boolean {
 }
 
 export function currentDashboardActor(): string {
+  const meta = getStoredTokenMeta()
+  const managedActor = meta?.source === 'dev'
+    ? sanitizeDashboardActorName(meta.actor)
+    : null
+  if (managedActor) return managedActor
   return resolveDashboardActorName() || 'dashboard'
 }
 
@@ -65,7 +128,7 @@ export function authHeaders(options: HeaderOptions = {}): Record<string, string>
   const token = getStoredToken()
   const agent = options.actorName !== undefined
     ? sanitizeDashboardActorName(options.actorName)
-    : resolveDashboardActorName(window.location.search)
+    : currentDashboardActor()
   if (token) headers['Authorization'] = `Bearer ${token}`
   if (options.includeActor !== false && agent) {
     headers['X-MASC-Agent'] = agent

--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -5,8 +5,11 @@ const {
   fetchWithTimeout,
   reportToolHostFailure,
   authHeaders,
+  clearStoredToken,
   currentDashboardActor,
   getStoredToken,
+  getStoredTokenMeta,
+  isRemoteAccess,
   setStoredToken,
 } = vi.hoisted(() => ({
   apiRequestErrorFromResponse: vi.fn(async (method: string, path: string, res: Response) =>
@@ -14,11 +17,18 @@ const {
   fetchWithTimeout: vi.fn(),
   reportToolHostFailure: vi.fn().mockResolvedValue({ ok: true }),
   authHeaders: vi.fn().mockReturnValue({}),
+  clearStoredToken: vi.fn(),
   currentDashboardActor: vi.fn().mockReturnValue('dashboard'),
   // Default to a non-empty stored token so ensureDevToken() short-circuits
   // without consuming a fetchWithTimeout mock. Individual tests that want
   // to exercise the dev-token bootstrap can override this.
   getStoredToken: vi.fn().mockReturnValue('test-stored-token'),
+  getStoredTokenMeta: vi.fn().mockReturnValue({
+    source: 'manual',
+    actor: 'dashboard',
+    scope: null,
+  }),
+  isRemoteAccess: vi.fn().mockReturnValue(false),
   setStoredToken: vi.fn(),
 }))
 
@@ -27,8 +37,11 @@ vi.mock('./core', () => ({
   fetchWithTimeout,
   DEFAULT_MCP_TIMEOUT_MS: 30000,
   authHeaders,
+  clearStoredToken,
   currentDashboardActor,
   getStoredToken,
+  getStoredTokenMeta,
+  isRemoteAccess,
   setStoredToken,
 }))
 
@@ -43,6 +56,12 @@ beforeEach(() => {
   // test (e.g. authHeaders). The dev-token bootstrap must stay inert unless
   // a test explicitly exercises it.
   getStoredToken.mockReturnValue('test-stored-token')
+  getStoredTokenMeta.mockReturnValue({
+    source: 'manual',
+    actor: 'dashboard',
+    scope: null,
+  })
+  isRemoteAccess.mockReturnValue(false)
   authHeaders.mockReturnValue({})
 })
 
@@ -119,7 +138,11 @@ describe('dev-token bootstrap', () => {
     getStoredToken.mockReturnValue(null)
     fetchWithTimeout
       .mockResolvedValueOnce(
-        new Response(JSON.stringify({ token: 'loopback-dev-token' }), {
+        new Response(JSON.stringify({
+          token: 'loopback-dev-token',
+          actor: 'dashboard',
+          scope: 'admin',
+        }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
         }),
@@ -136,7 +159,11 @@ describe('dev-token bootstrap', () => {
     const { callMcpTool } = await import('./mcp')
     await callMcpTool('masc_status', {})
 
-    expect(setStoredToken).toHaveBeenCalledWith('loopback-dev-token')
+    expect(setStoredToken).toHaveBeenCalledWith('loopback-dev-token', {
+      source: 'dev',
+      actor: 'dashboard',
+      scope: 'admin',
+    })
     const calls = fetchWithTimeout.mock.calls as Array<[string, RequestInit]>
     expect(calls.length).toBeGreaterThanOrEqual(2)
     expect(calls[0]?.[0]).toBe('/api/v1/dashboard/dev-token')
@@ -161,6 +188,26 @@ describe('dev-token bootstrap', () => {
     expect(setStoredToken).not.toHaveBeenCalled()
     const initCall = findCallByMethod('initialize')
     expect(initCall).toBeDefined()
+  }, 60_000)
+
+  it('clears an old managed dev token when the loopback bootstrap endpoint disappears', async () => {
+    getStoredToken.mockReturnValue('stale-dev-token')
+    getStoredTokenMeta.mockReturnValue({ source: 'dev', actor: 'dashboard', scope: 'admin' })
+    fetchWithTimeout
+      .mockResolvedValueOnce(new Response('not found', { status: 404 }))
+      .mockResolvedValueOnce(
+        new Response('{}', { status: 200, headers: { 'Mcp-Session-Id': 'sess-dev-404' } }),
+      )
+      .mockResolvedValueOnce(new Response('', { status: 202 }))
+      .mockResolvedValueOnce(
+        new Response('data: {"result":{"content":[{"type":"text","text":"ok"}]}}\n', { status: 200 }),
+      )
+
+    const { callMcpTool } = await import('./mcp')
+    await callMcpTool('masc_status', {})
+
+    expect(clearStoredToken).toHaveBeenCalledTimes(1)
+    expect(setStoredToken).not.toHaveBeenCalled()
   }, 60_000)
 })
 

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -5,8 +5,11 @@ import {
   fetchWithTimeout,
   DEFAULT_MCP_TIMEOUT_MS,
   authHeaders,
+  clearStoredToken,
   currentDashboardActor,
   getStoredToken,
+  getStoredTokenMeta,
+  isRemoteAccess,
   setStoredToken,
 } from './core'
 import {
@@ -28,25 +31,65 @@ let initPromise: Promise<void> | null = null
 let initCooldownTimer: ReturnType<typeof setTimeout> | null = null
 let devTokenBootstrapPromise: Promise<void> | null = null
 
+interface DevTokenBootstrapPayload {
+  token?: unknown
+  actor?: unknown
+  scope?: unknown
+}
+
+function shouldRefreshDevToken(): boolean {
+  const token = getStoredToken()
+  const meta = getStoredTokenMeta()
+  if (!token) return true
+  if (meta?.source === 'dev') return true
+  // Legacy sessions only stored the raw token string. On loopback with the
+  // default dashboard actor, treat them as managed-token candidates so
+  // frequent restarts or base_path flips self-heal without manual clearing.
+  return meta == null && !isRemoteAccess() && currentDashboardActor() === 'dashboard'
+}
+
 /** Fetch the loopback-only dev token once per page load and stash it so
     subsequent `/mcp` requests include `Authorization: Bearer …`. The server
     only exposes `/api/v1/dashboard/dev-token` when bound to loopback with
     strict-auth overrides disabled; in every other case this quietly no-ops
     and existing flows (URL `?token=…`, manual paste) continue to work. */
 export async function ensureDevToken(): Promise<void> {
-  if (getStoredToken()) return
+  if (!shouldRefreshDevToken()) return
   if (devTokenBootstrapPromise) return devTokenBootstrapPromise
   devTokenBootstrapPromise = (async () => {
+    const storedMeta = getStoredTokenMeta()
+    const storedToken = getStoredToken()
     try {
       const res = await fetchWithTimeout(
         '/api/v1/dashboard/dev-token',
         { method: 'GET', headers: { Accept: 'application/json' } },
         DEV_TOKEN_FETCH_TIMEOUT_MS,
       )
-      if (!res.ok) return
-      const payload = (await res.json()) as { token?: unknown }
-      if (typeof payload.token === 'string' && payload.token.length > 0) {
-        setStoredToken(payload.token)
+      if (!res.ok) {
+        if (res.status === 404 && storedMeta?.source === 'dev') {
+          clearStoredToken()
+        }
+        return
+      }
+      const payload = (await res.json()) as DevTokenBootstrapPayload
+      const token = typeof payload.token === 'string' ? payload.token.trim() : ''
+      if (!token) return
+      const actor = typeof payload.actor === 'string' ? payload.actor.trim() : 'dashboard'
+      const scope =
+        typeof payload.scope === 'string' && payload.scope.trim() !== ''
+          ? payload.scope.trim()
+          : null
+      if (
+        token !== storedToken
+        || storedMeta?.source !== 'dev'
+        || storedMeta.actor !== actor
+        || (storedMeta.scope ?? null) !== scope
+      ) {
+        setStoredToken(token, {
+          source: 'dev',
+          actor,
+          scope,
+        })
       }
     } catch {
       /* Loopback endpoint unavailable (LAN bind, strict auth, offline).

--- a/dashboard/src/components/auth-status.ts
+++ b/dashboard/src/components/auth-status.ts
@@ -47,7 +47,7 @@ function AuthPopover({ authenticated }: { authenticated: boolean }) {
   const handleSetToken = () => {
     const value = tokenInput.value.trim()
     if (!value) return
-    setStoredToken(value)
+    setStoredToken(value, { source: 'manual' })
     resetMcpClientState()
     tokenInput.value = ''
     popoverOpen.value = false

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -143,6 +143,13 @@ let credential_agent_name agent_name =
 let raw_token_file config agent_name =
   Filename.concat (auth_dir config) (agent_name ^ ".token")
 
+(* Dashboard loopback dev-token was historically issued under
+   [dashboard-dev] while the UI defaults to [dashboard]. Keep the old
+   credential valid for [dashboard] requests so already-open browser
+   sessions survive restarts and token-file migration. *)
+let legacy_credential_aliases = function
+  | "dashboard" -> [ "dashboard-dev" ]
+  | _ -> []
 let load_credential_from_path config agent_name path : agent_credential option =
   if file_exists path then
     try
@@ -181,6 +188,13 @@ let load_credential config agent_name : agent_credential option =
         load_credential_from_path config prefix fallback
       | _ -> None
     else None
+
+let load_credential_with_aliases config agent_name : agent_credential option =
+  match load_credential config agent_name with
+  | Some _ as c -> c
+  | None ->
+      legacy_credential_aliases agent_name
+      |> List.find_map (load_credential config)
 
 (** Save agent credential *)
 let save_credential config (cred : agent_credential) =
@@ -295,7 +309,7 @@ let missing_credential_error config ~agent_name ~token : masc_error =
 
 (** Verify a token *)
 let verify_token config ~agent_name ~token : (agent_credential, masc_error) result =
-  match load_credential config agent_name with
+  match load_credential_with_aliases config agent_name with
   | None -> Error (missing_credential_error config ~agent_name ~token)
   | Some cred ->
       let token_hash = sha256_hash token in
@@ -370,7 +384,7 @@ let refresh_token config ~agent_name ~old_token : (string * agent_credential, ma
   match verify_token config ~agent_name ~token:old_token with
   | Error (TokenExpired _) ->
       (* Allow refresh even if expired *)
-      (match load_credential config agent_name with
+      (match load_credential_with_aliases config agent_name with
        | None -> Error (Unauthorized ("No credential found for " ^ agent_name))
        | Some old_cred -> create_token config ~agent_name ~role:old_cred.role)
   | Error e -> Error e

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -61,6 +61,100 @@ let available_cascade_profiles () : string list =
 let invalid_cascade_profiles () : (string * string list) list =
   (cascade_profile_gate ()).invalid_profiles
 
+let dashboard_dev_actor_name = "dashboard"
+
+let dashboard_dev_token_path base_path =
+  Filename.concat base_path ".masc/auth/dashboard.token"
+
+let legacy_dashboard_dev_token_path base_path =
+  Filename.concat base_path ".masc/auth/dashboard-dev.token"
+
+let remove_dashboard_dev_token_file_if_exists path =
+  if Fs_compat.file_exists path then
+    try Sys.remove path
+    with exn ->
+      Log.Server.warn
+        "dashboard dev-token cleanup skipped for %s: %s"
+        path (Printexc.to_string exn)
+
+type dashboard_dev_token_candidate =
+  | Reusable of string
+  | Rotate
+
+let classify_dashboard_dev_token_candidate ~base_path raw :
+    (dashboard_dev_token_candidate, string) result =
+  let trimmed = String.trim raw in
+  if String.equal trimmed "" then
+    Ok Rotate
+  else
+    match Auth.resolve_agent_from_token base_path ~token:trimmed with
+    | Ok owner when String.equal owner dashboard_dev_actor_name ->
+        Ok (Reusable trimmed)
+    | Ok _owner ->
+        Ok Rotate
+    | Error (Types.InvalidToken _ | Types.TokenExpired _ | Types.Unauthorized _) ->
+        Ok Rotate
+    | Error err ->
+        Error (Types.masc_error_to_string err)
+
+let read_reusable_dashboard_dev_token ~base_path path :
+    (string option, string) result =
+  if not (Fs_compat.file_exists path) then
+    Ok None
+  else
+    try
+      match classify_dashboard_dev_token_candidate ~base_path
+              (Fs_compat.load_file path) with
+      | Ok (Reusable raw) -> Ok (Some raw)
+      | Ok Rotate -> Ok None
+      | Error msg -> Error msg
+    with Eio.Cancel.Cancelled _ as e -> raise e
+    with exn ->
+      Log.Server.warn
+        "dashboard dev-token read skipped for %s: %s"
+        path (Printexc.to_string exn);
+      Ok None
+
+let persist_dashboard_dev_token ~base_path raw : (unit, string) result =
+  let token_path = dashboard_dev_token_path base_path in
+  let legacy_path = legacy_dashboard_dev_token_path base_path in
+  try
+    Auth.save_private_text_file token_path raw;
+    remove_dashboard_dev_token_file_if_exists legacy_path;
+    Ok ()
+  with Eio.Cancel.Cancelled _ as e -> raise e
+  with exn ->
+    Error (Printf.sprintf "persist dev-token: %s" (Printexc.to_string exn))
+
+let mint_dashboard_dev_token base_path : (string, string) result =
+  match
+    Auth.create_token base_path
+      ~agent_name:dashboard_dev_actor_name ~role:Types.Admin
+  with
+  | Ok (raw, _cred) ->
+      (match persist_dashboard_dev_token ~base_path raw with
+       | Ok () -> Ok raw
+       | Error msg -> Error msg)
+  | Error err ->
+      Error (Types.masc_error_to_string err)
+
+let ensure_dashboard_dev_token base_path : (string, string) result =
+  let token_path = dashboard_dev_token_path base_path in
+  let legacy_path = legacy_dashboard_dev_token_path base_path in
+  match read_reusable_dashboard_dev_token ~base_path token_path with
+  | Error msg -> Error msg
+  | Ok (Some raw) ->
+      remove_dashboard_dev_token_file_if_exists legacy_path;
+      Ok raw
+  | Ok None ->
+      (match read_reusable_dashboard_dev_token ~base_path legacy_path with
+       | Error msg -> Error msg
+       | Ok (Some raw) ->
+           (match persist_dashboard_dev_token ~base_path raw with
+            | Ok () -> Ok raw
+            | Error msg -> Error msg)
+       | Ok None -> mint_dashboard_dev_token base_path)
+
 (** Broadcast handler: parse JSON body, extract "message" string field, and
     relay via Coord.broadcast.  Error responses are encoded through Yojson so
     exception messages cannot break JSON framing via embedded quotes. *)
@@ -171,11 +265,11 @@ let rec add_routes ~sw ~clock router =
        ) request reqd)
   (* Dev-only shared bearer for the dashboard UI. Served exclusively when the
      server binds to loopback and strict-auth env overrides are disabled, so
-     that a LAN deployment never hands out a token over the wire. On first
-     hit the token is auto-provisioned via Auth.create_token (role=Admin) and
-     persisted to .masc/auth/dashboard-dev.token for reuse across restarts.
-     The dashboard fetches this once per page load and sends it as
-     Authorization: Bearer <token> on all /mcp calls. *)
+     that a LAN deployment never hands out a token over the wire. The token is
+     canonicalized to the [dashboard] actor and persisted at
+     [.masc/auth/dashboard.token]. Legacy [.masc/auth/dashboard-dev.token]
+     files are rotated or migrated automatically so restarts do not reintroduce
+     the dashboard/dashboard-dev auth mismatch. *)
   |> Http.Router.get "/api/v1/dashboard/dev-token" (fun request reqd ->
        if (not (http_auth_bind_is_loopback ()))
           || http_auth_strict_enabled () then
@@ -185,38 +279,7 @@ let rec add_routes ~sw ~clock router =
        else
          with_public_read (fun state req reqd ->
            let base_path = state.Mcp_server.room_config.base_path in
-           let token_file =
-             Filename.concat base_path ".masc/auth/dashboard-dev.token"
-           in
-           let raw_result : (string, string) result =
-             if Fs_compat.file_exists token_file then
-               try Ok (String.trim (Fs_compat.load_file token_file))
-               with
-               | Eio.Cancel.Cancelled _ as e -> raise e
-               | exn ->
-                 Error
-                   (Printf.sprintf "read dev-token: %s"
-                      (Printexc.to_string exn))
-             else
-               begin
-                 match
-                   Auth.create_token base_path
-                     ~agent_name:"dashboard-dev" ~role:Types.Admin
-                 with
-                 | Ok (raw, _cred) ->
-                   (try
-                      Auth.save_private_text_file token_file raw;
-                      Ok raw
-                    with
-                    | Eio.Cancel.Cancelled _ as e -> raise e
-                    | exn ->
-                      Error
-                        (Printf.sprintf "persist dev-token: %s"
-                           (Printexc.to_string exn)))
-                 | Error err ->
-                   Error (Types.masc_error_to_string err)
-               end
-           in
+           let raw_result = ensure_dashboard_dev_token base_path in
            begin
              match raw_result with
              | Ok raw ->

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -108,12 +108,13 @@ let read_reusable_dashboard_dev_token ~base_path path :
       | Ok (Reusable raw) -> Ok (Some raw)
       | Ok Rotate -> Ok None
       | Error msg -> Error msg
-    with Eio.Cancel.Cancelled _ as e -> raise e
-    with exn ->
-      Log.Server.warn
-        "dashboard dev-token read skipped for %s: %s"
-        path (Printexc.to_string exn);
-      Ok None
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+        Log.Server.warn
+          "dashboard dev-token read skipped for %s: %s"
+          path (Printexc.to_string exn);
+        Ok None
 
 let persist_dashboard_dev_token ~base_path raw : (unit, string) result =
   let token_path = dashboard_dev_token_path base_path in
@@ -122,9 +123,10 @@ let persist_dashboard_dev_token ~base_path raw : (unit, string) result =
     Auth.save_private_text_file token_path raw;
     remove_dashboard_dev_token_file_if_exists legacy_path;
     Ok ()
-  with Eio.Cancel.Cancelled _ as e -> raise e
-  with exn ->
-    Error (Printf.sprintf "persist dev-token: %s" (Printexc.to_string exn))
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Error (Printf.sprintf "persist dev-token: %s" (Printexc.to_string exn))
 
 let mint_dashboard_dev_token base_path : (string, string) result =
   match

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -313,6 +313,24 @@ let test_verify_token_keeper_alias_fallback () =
            "keeper alias should verify via fallback credential: %s"
            (Types.masc_error_to_string e))
 
+let test_verify_token_dashboard_legacy_alias_fallback () =
+  let dir = setup_test_room () in
+  let result =
+    match Auth.create_token dir ~agent_name:"dashboard-dev" ~role:Types.Admin with
+    | Ok (raw_token, _) ->
+        Auth.verify_token dir ~agent_name:"dashboard" ~token:raw_token
+    | Error e -> Error e
+  in
+  cleanup_test_room dir;
+  match result with
+  | Ok cred ->
+      check string "legacy dashboard token owner" "dashboard-dev" cred.agent_name
+  | Error e ->
+      fail
+        (Printf.sprintf
+           "dashboard should accept legacy dashboard-dev credential: %s"
+           (Types.masc_error_to_string e))
+
 let test_save_raw_token_credential_uses_provided_token () =
   let dir = setup_test_room () in
   let raw_token = "fixed-admin-token" in
@@ -666,6 +684,8 @@ let () =
         test_extract_agent_type_prefix_keeper_aliases;
       test_case "verify_token keeper alias fallback" `Quick
         test_verify_token_keeper_alias_fallback;
+      test_case "verify_token dashboard legacy alias fallback" `Quick
+        test_verify_token_dashboard_legacy_alias_fallback;
       test_case "save_raw_token_credential uses provided token" `Quick
         test_save_raw_token_credential_uses_provided_token;
       test_case "ensure_keeper_credential uses keeper middle name" `Quick

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -1,6 +1,8 @@
 open Alcotest
 module Routes = Masc_mcp.Server_routes_http_routes_dashboard
 module Keeper_api = Masc_mcp.Server_dashboard_http_keeper_api
+module Auth = Masc_mcp.Auth
+module Types = Types
 
 type http_result =
   { status : int option
@@ -1165,6 +1167,76 @@ let test_merge_keeper_trace_lines_includes_internal_history () =
   check int "thinking entries can still be filtered out" 1 (List.length tool_only))
 ;;
 
+let dashboard_dev_token_test_dir () =
+  let path = Filename.temp_file "masc-dashboard-dev-token-" ".tmp" in
+  Sys.remove path;
+  path
+;;
+
+let test_ensure_dashboard_dev_token_rotates_legacy_dashboard_dev_owner () =
+  let base_path = dashboard_dev_token_test_dir () in
+  mkdir_p (Filename.concat base_path ".masc/auth");
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_path)
+    (fun () ->
+       let legacy_raw =
+         match Auth.create_token base_path ~agent_name:"dashboard-dev"
+                 ~role:Types.Admin with
+         | Ok (raw, _cred) -> raw
+         | Error err -> fail (Types.masc_error_to_string err)
+       in
+       let legacy_path = Routes.legacy_dashboard_dev_token_path base_path in
+       let canonical_path = Routes.dashboard_dev_token_path base_path in
+       Auth.save_private_text_file legacy_path legacy_raw;
+       match Routes.ensure_dashboard_dev_token base_path with
+       | Error msg -> fail msg
+       | Ok raw ->
+           check bool "legacy token rotates to canonical owner" true
+             (not (String.equal raw legacy_raw));
+           check bool "canonical token file written" true
+             (Sys.file_exists canonical_path);
+           check bool "legacy token file removed" false
+             (Sys.file_exists legacy_path);
+           (match Auth.verify_token base_path ~agent_name:"dashboard" ~token:raw with
+            | Ok cred ->
+                check string "canonical credential owner" "dashboard"
+                  cred.agent_name
+            | Error err ->
+                fail (Types.masc_error_to_string err)))
+;;
+
+let test_ensure_dashboard_dev_token_reuses_canonical_dashboard_token () =
+  let base_path = dashboard_dev_token_test_dir () in
+  mkdir_p (Filename.concat base_path ".masc/auth");
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_path)
+    (fun () ->
+       let canonical_raw =
+         match Auth.create_token base_path ~agent_name:"dashboard"
+                 ~role:Types.Admin with
+         | Ok (raw, _cred) -> raw
+         | Error err -> fail (Types.masc_error_to_string err)
+       in
+       let legacy_raw =
+         match Auth.create_token base_path ~agent_name:"dashboard-dev"
+                 ~role:Types.Admin with
+         | Ok (raw, _cred) -> raw
+         | Error err -> fail (Types.masc_error_to_string err)
+       in
+       let legacy_path = Routes.legacy_dashboard_dev_token_path base_path in
+       let canonical_path = Routes.dashboard_dev_token_path base_path in
+       Auth.save_private_text_file canonical_path canonical_raw;
+       Auth.save_private_text_file legacy_path legacy_raw;
+       match Routes.ensure_dashboard_dev_token base_path with
+       | Error msg -> fail msg
+       | Ok raw ->
+           check string "canonical token reused" canonical_raw raw;
+           check bool "legacy token file cleaned up" false
+             (Sys.file_exists legacy_path);
+           check bool "canonical token file kept" true
+             (Sys.file_exists canonical_path))
+;;
+
 let () =
   run
     "dashboard_keeper_routes"
@@ -1201,6 +1273,14 @@ let () =
             "execution trust route surfaces latest receipt"
             `Slow
             test_execution_trust_route_surfaces_latest_receipt
+        ; test_case
+            "dashboard dev token rotates legacy dashboard-dev owner"
+            `Quick
+            test_ensure_dashboard_dev_token_rotates_legacy_dashboard_dev_owner
+        ; test_case
+            "dashboard dev token reuses canonical dashboard token"
+            `Quick
+            test_ensure_dashboard_dev_token_reuses_canonical_dashboard_token
         ; test_case
             "merge keeper trace lines includes internal history"
             `Quick


### PR DESCRIPTION
## What changed
- canonicalized dashboard loopback dev tokens to the `dashboard` actor and migrated legacy `dashboard-dev` token files
- stored token source/actor metadata in the dashboard client so managed dev tokens can refresh or clear safely
- updated dashboard auth tests and keeper route tests to cover legacy token fallback and canonical token reuse

## Why
The dashboard loopback bootstrap path could mint or reuse a `dashboard-dev` credential while the UI defaulted to the `dashboard` actor. That mismatch left already-open dashboard sessions with stale or mismatched auth after restarts or token-file migration.

## Impact
- loopback dashboard sessions self-heal more reliably across restarts
- legacy `dashboard-dev` credentials remain readable during migration
- manual and URL-provided tokens keep their existing behavior without being treated as managed dev tokens

## Root cause
The server and client disagreed on the effective actor for auto-provisioned dashboard dev tokens, and the browser only stored the raw bearer token without enough metadata to distinguish managed loopback credentials from manual tokens.

## Validation
- `pnpm typecheck`
- `pnpm exec vitest run src/api/*.test.ts src/lib/dashboard-actor.test.ts`
- `_build_verify/default/test/test_auth.exe`
- `_build_verify/default/test/test_dashboard_keeper_routes.exe`

## Notes
- `pnpm lint` still fails on a pre-existing unrelated `no-nested-ternary` issue in `dashboard/src/components/runtime-monitor.ts`.