### PR TITLE
[codex] fix dashboard vitest storage shims

### DIFF
--- a/dashboard/vitest-setup.ts
+++ b/dashboard/vitest-setup.ts
@@ -1,6 +1,61 @@
 import { vi } from 'vitest'
 import { html } from 'htm/preact'
 
+type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem' | 'clear' | 'key' | 'length'>
+
+function hasStorageApi(value: unknown): value is StorageLike {
+  return typeof value === 'object'
+    && value !== null
+    && typeof (value as StorageLike).getItem === 'function'
+    && typeof (value as StorageLike).setItem === 'function'
+    && typeof (value as StorageLike).removeItem === 'function'
+    && typeof (value as StorageLike).clear === 'function'
+    && typeof (value as StorageLike).key === 'function'
+    && typeof (value as StorageLike).length === 'number'
+}
+
+function createMemoryStorage(): Storage {
+  const store = new Map<string, string>()
+  return {
+    getItem(key: string): string | null {
+      return store.has(key) ? (store.get(key) ?? null) : null
+    },
+    setItem(key: string, value: string): void {
+      store.set(String(key), String(value))
+    },
+    removeItem(key: string): void {
+      store.delete(String(key))
+    },
+    clear(): void {
+      store.clear()
+    },
+    key(index: number): string | null {
+      return Array.from(store.keys())[index] ?? null
+    },
+    get length(): number {
+      return store.size
+    },
+  } as Storage
+}
+
+function installStorageShim(name: 'localStorage' | 'sessionStorage'): void {
+  let activeStorage = hasStorageApi(globalThis[name]) ? globalThis[name] : createMemoryStorage()
+  const host = typeof window !== 'undefined' ? window : globalThis
+  Object.defineProperty(host, name, {
+    configurable: true,
+    enumerable: true,
+    get: () => activeStorage,
+    set: (value: Storage | undefined) => {
+      activeStorage = value === undefined
+        ? undefined
+        : (hasStorageApi(value) ? value : createMemoryStorage())
+    },
+  })
+}
+
+installStorageShim('localStorage')
+installStorageShim('sessionStorage')
+
 // Mock all lucide-preact icons to a lightweight span to avoid happy-dom timeout issues
 // This drastically reduces mounting time during parallel test runs.
 vi.mock('lucide-preact', async (importOriginal) => {


### PR DESCRIPTION
## What changed

- add a small in-memory storage shim in `dashboard/vitest-setup.ts`
- patch both `localStorage` and `sessionStorage` only when the happy-dom-provided storage object does not satisfy the `Storage` API contract
- keep the shim configurable so tests can still stub or temporarily unset storage explicitly

## Why

Dashboard vitest runs were failing before real assertions because the test environment exposed a broken `localStorage` object. Storage-focused tests called `window.localStorage.clear()` in `beforeEach` / `afterEach` and crashed immediately.

## Impact

- `saved-signal` and `persistent-signal` tests can run again
- tests that stub `localStorage` manually still work
- session-storage-based tests keep a consistent contract in the same environment

## Root cause

The happy-dom environment in this test setup was starting with a `localStorage` object that did not fully behave like a browser `Storage` implementation, while the test suite assumed `clear`, `key`, and `length` existed and were callable.

Fixes #9616.

## Validation

- `cd dashboard && pnpm typecheck`
- `cd dashboard && pnpm exec vitest run src/lib/persistent-signal.test.ts src/lib/saved-signal.test.ts --reporter verbose`
- `cd dashboard && pnpm exec vitest run src/lib/persistent-signal.test.ts src/lib/saved-signal.test.ts src/components/keeper-shared.test.ts src/sse.test.ts src/api/core.test.ts --reporter verbose`

## Notes

- `cd dashboard && pnpm test` is not fully reliable in this sandbox because unrelated tests attempt localhost connections and hit sandbox `EPERM`.
- This PR is intentionally scoped to the broken storage test environment only and is separate from PR #9617.
