### PR TITLE
test(keeper): add negative-path tests for bash safety (task-034)

### DIFF
--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -553,6 +553,69 @@ let test_rewrite_turn_runtime_paths_to_host_is_noop_without_container_path () =
   Alcotest.(check string) "unrelated paths untouched" input
     (Keeper_exec_shell.rewrite_turn_runtime_paths_to_host ~config ~meta input)
 
+(* ── Negative / error-path tests (task-034) ──────────────────────── *)
+
+let test_bash_missing_cmd_field () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta = make_docker_meta "missing-cmd" in
+  let raw =
+    Keeper_exec_shell.handle_keeper_bash
+      ~turn_sandbox_runtime:None
+      ~turn_sandbox_runtime_git:None
+      ~config ~meta
+      ~args:(`Assoc [ ("run_in_background", `Bool false) ]) ()
+  in
+  match parse_error_field raw with
+  | Some err ->
+      Alcotest.(check bool) "error mentions cmd is required" true
+        (String_util.contains_substring err "cmd is required")
+  | None ->
+      Alcotest.fail ("expected error json for missing cmd field, got: " ^ raw)
+
+let test_shell_missing_op_field () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta = make_readonly_meta "missing-op" in
+  let raw =
+    Keeper_exec_shell.handle_keeper_shell
+      ~turn_sandbox_runtime:None
+      ~config ~meta
+      ~args:(`Assoc [ ("path", `String "/some/path") ])
+  in
+  match parse_error_field raw with
+  | Some err ->
+      Alcotest.(check bool) "error mentions unsupported op" true
+        (String_util.contains_substring err "unsupported_op")
+  | None ->
+      Alcotest.fail ("expected error json for missing op field, got: " ^ raw)
+
+let test_shell_unsupported_op () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta = make_readonly_meta "bad-op" in
+  let raw =
+    Keeper_exec_shell.handle_keeper_shell
+      ~turn_sandbox_runtime:None
+      ~config ~meta
+      ~args:(`Assoc [
+        ("op", `String "definitely_not_a_real_op");
+        ("path", `String "/some/path");
+      ])
+  in
+  match parse_error_field raw with
+  | Some err ->
+      Alcotest.(check bool) "error mentions unsupported op" true
+        (String_util.contains_substring err "unsupported_op")
+  | None ->
+      Alcotest.fail ("expected error json for unsupported op, got: " ^ raw)
+
 let () =
   Alcotest.run "Keeper bash safety" [
     ("allowlist", [


### PR DESCRIPTION
## Summary
Add missing negative-path / error-path test coverage for keeper bash safety gates.

## Changes
Three new test cases in `test/test_keeper_bash_safety.ml`:
1. `test_bash_missing_cmd_field` — verifies error JSON when `cmd` is absent from bash args
2. `test_shell_missing_op_field` — verifies error JSON when `op` is absent from shell args
3. `test_shell_unsupported_op` — verifies error JSON for unknown `op` values

## Verification
- [ ] `dune runtest test/test_keeper_bash_safety.ml` passes
- [ ] No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)