### PR TITLE
feat(exec): P7 pipeline-native dispatch

### DIFF
--- a/lib/exec/bash_history.ml
+++ b/lib/exec/bash_history.ml
@@ -1,0 +1,193 @@
+(* P11: Command History & Suggest
+   Append-only JSONL log of bash executions.  Each keeper gets its own
+   history file under [.masc/keeper/<name>/bash_history.jsonl].
+   Automatic compaction kicks in above 10 000 entries. *)
+
+type history_entry = {
+  ts : float;
+  cmd_hash : string;
+  cmd_prefix : string;
+  semantic_kind : string;
+  duration_ms : int;
+  success : bool;
+}
+
+(* --- helpers --- *)
+
+let close_out_no_err oc =
+  try close_out oc with _ -> ()
+
+let close_in_no_err ic =
+  try close_in ic with _ -> ()
+
+let mkdir_p path =
+  let rec aux built = function
+    | [] -> ()
+    | comp :: rest ->
+        let dir = built ^ "/" ^ comp in
+        if not (Sys.file_exists dir) then Unix.mkdir dir 0o755;
+        aux dir rest
+  in
+  let parts = String.split_on_char '/' path in
+  aux "" parts
+
+(* --- JSON codec --- *)
+
+let entry_to_json e =
+  `Assoc
+    [
+      ("ts", `Float e.ts);
+      ("cmd_hash", `String e.cmd_hash);
+      ("cmd_prefix", `String e.cmd_prefix);
+      ("semantic_kind", `String e.semantic_kind);
+      ("duration_ms", `Int e.duration_ms);
+      ("success", `Bool e.success);
+    ]
+
+let entry_of_json = function
+  | `Assoc fields ->
+      let get k default =
+        List.find_map
+          (fun (k', v) -> if k' = k then Some v else None)
+          fields
+        |> Option.value ~default
+      in
+      let ts =
+        match get "ts" (`Float 0.0) with
+        | `Float f -> f
+        | _ -> 0.0
+      in
+      let cmd_hash =
+        match get "cmd_hash" (`String "") with `String s -> s | _ -> ""
+      in
+      let cmd_prefix =
+        match get "cmd_prefix" (`String "") with `String s -> s | _ -> ""
+      in
+      let semantic_kind =
+        match get "semantic_kind" (`String "Unknown") with
+        | `String s -> s
+        | _ -> "Unknown"
+      in
+      let duration_ms =
+        match get "duration_ms" (`Int 0) with `Int i -> i | _ -> 0
+      in
+      let success =
+        match get "success" (`Bool true) with `Bool b -> b | _ -> true
+      in
+      Some { ts; cmd_hash; cmd_prefix; semantic_kind; duration_ms; success }
+  | _ -> None
+
+(* --- path resolution --- *)
+
+let history_path ~base_path ~keeper_name =
+  let dir =
+    Filename.concat
+      (Filename.concat base_path ".masc")
+      (Filename.concat "keeper" keeper_name)
+  in
+  ( Filename.concat dir "bash_history.jsonl",
+    fun () ->
+      if not (Sys.file_exists dir) then mkdir_p dir )
+
+(* --- hash --- *)
+
+let cmd_hash cmd =
+  let hex = Digest.to_hex (Digest.string cmd) in
+  String.sub hex 0 12
+
+(* --- I/O --- *)
+
+let max_entries = 10_000
+let compact_to = 1_000
+
+let append ~base_path ~keeper_name entry =
+  let path, ensure_dir = history_path ~base_path ~keeper_name in
+  ensure_dir ();
+  let oc = open_out_gen [ Open_wronly; Open_creat; Open_append ] 0o644 path in
+  output_string oc (Yojson.Safe.to_string (entry_to_json entry));
+  output_char oc '\n';
+  close_out_no_err oc
+
+let count_lines path =
+  let ic = open_in path in
+  let count = ref 0 in
+  (try while true do
+       let _ = input_line ic in
+       incr count
+     done
+   with End_of_file -> ());
+  close_in_no_err ic;
+  !count
+
+let load_entries path =
+  let ic = open_in path in
+  let entries = ref [] in
+  (try while true do
+       let line = input_line ic in
+       match Yojson.Safe.from_string line with
+       | exception _ -> ()
+       | json ->
+           match entry_of_json json with
+           | Some e -> entries := e :: !entries
+           | None -> ()
+     done
+   with End_of_file -> ());
+  close_in_no_err ic;
+  List.rev !entries
+
+let drop n xs =
+  let rec aux n = function
+    | [] -> []
+    | _ :: xs when n > 0 -> aux (n - 1) xs
+    | xs -> xs
+  in
+  aux n xs
+
+(* --- compaction --- *)
+
+let compact ~base_path ~keeper_name =
+  let path, _ = history_path ~base_path ~keeper_name in
+  if Sys.file_exists path then
+    let n = count_lines path in
+    if n > max_entries then begin
+      let entries = load_entries path in
+      let keep = drop (List.length entries - compact_to) entries in
+      let oc = open_out path in
+      List.iter
+        (fun e ->
+          output_string oc (Yojson.Safe.to_string (entry_to_json e));
+          output_char oc '\n')
+        keep;
+      close_out_no_err oc
+    end
+
+(* --- suggest (query) --- *)
+
+let suggest ~base_path ~keeper_name ~pattern ~limit =
+  let path, _ = history_path ~base_path ~keeper_name in
+  if not (Sys.file_exists path) then []
+  else begin
+    let entries = load_entries path in
+    let matches =
+      List.filter
+        (fun e ->
+          let plen = String.length pattern in
+          let prefix_match =
+            String.length e.cmd_prefix >= plen
+            && String.sub e.cmd_prefix 0 plen = pattern
+          in
+          let hash_match =
+            String.length e.cmd_hash >= plen
+            && String.sub e.cmd_hash 0 plen = pattern
+          in
+          prefix_match || hash_match)
+        entries
+    in
+    let rec last_n n = function
+      | [] -> []
+      | xs when n <= 0 -> []
+      | xs when List.length xs <= n -> xs
+      | _ :: xs -> last_n n xs
+    in
+    last_n limit matches
+  end

--- a/lib/exec/bash_history.mli
+++ b/lib/exec/bash_history.mli
@@ -1,0 +1,38 @@
+type history_entry = {
+  ts : float;
+  cmd_hash : string;
+  cmd_prefix : string;
+  semantic_kind : string;
+  duration_ms : int;
+  success : bool;
+}
+
+val entry_to_json : history_entry -> Yojson.Safe.t
+
+val append :
+  base_path:string ->
+  keeper_name:string ->
+  history_entry ->
+  unit
+(** Append one entry to the keeper's JSONL history file.  Creates the
+    directory and file if they don't exist. *)
+
+val compact :
+  base_path:string ->
+  keeper_name:string ->
+  unit
+(** When the file exceeds [max_entries] (10 000) lines, rewrite it
+    keeping only the last [compact_to] (1 000) entries.  Call
+    periodically (e.g. after each append). *)
+
+val suggest :
+  base_path:string ->
+  keeper_name:string ->
+  pattern:string ->
+  limit:int ->
+  history_entry list
+(** Return the last [limit] entries whose [cmd_prefix] or [cmd_hash]
+    starts with [pattern].  Returns [] when the file doesn't exist. *)
+
+val cmd_hash : string -> string
+(** Truncated SHA-256 (12 hex chars) of a command string. *)

--- a/lib/exec/dune
+++ b/lib/exec/dune
@@ -5,4 +5,4 @@
  (name masc_exec)
  (public_name masc_mcp.masc_exec)
  (wrapped true)
- (libraries masc_process eio unix))
+ (libraries masc_process eio unix yojson))

--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -1,0 +1,129 @@
+(* P7: Pipeline-Native Dispatch
+   Execute Shell_ir.t directly via Process_eio without going through
+   /bin/bash.  Simple commands use argv-based spawn; pipelines chain
+   stdout->stdin across stages.
+
+   Controlled by [MASC_BASH_NATIVE_DISPATCH] env var:
+   - "1" (default): native dispatch for Simple, bash fallback for Pipeline
+   - "0": always fall back to bash
+
+   This module is the first step toward eliminating shell injection
+   entirely.  Pipeline support is limited to stdout->stdin chaining. *)
+
+type dispatch_result = {
+  status : Unix.process_status;
+  stdout : string;
+  stderr : string;
+}
+
+(* --- arg resolution --- *)
+
+let rec resolve_arg = function
+  | Shell_ir.Lit s -> s
+  | Concat parts ->
+      let buf = Buffer.create 64 in
+      List.iter (fun a -> Buffer.add_string buf (resolve_arg a)) parts;
+      Buffer.contents buf
+  | Var name -> (
+      try Unix.getenv name
+      with Not_found -> "")
+
+let resolve_env env_bindings =
+  List.map
+    (fun (k, v) -> k ^ "=" ^ resolve_arg v)
+    env_bindings
+  |> Array.of_list
+
+(* --- simple command execution --- *)
+
+let dispatch_simple (s : Shell_ir.simple) =
+  let bin = Bin.to_string s.bin in
+  let argv = bin :: List.map resolve_arg s.args in
+  let env = resolve_env s.env in
+  let cwd =
+    match s.cwd with
+    | None -> None
+    | Some scope -> Some (Path_scope.raw scope)
+  in
+  match Process_eio.run_argv_with_status_split ~timeout_sec:120.0
+          ~env ?cwd argv with
+  | exception exn ->
+      { status = Unix.WEXITED 1;
+        stdout = "";
+        stderr = Printexc.to_string exn }
+  | (status, stdout, stderr) ->
+      { status; stdout; stderr }
+
+(* --- pipeline + entry point (mutually recursive) --- *)
+
+let rec dispatch_pipeline stages =
+  match stages with
+  | [] ->
+      { status = Unix.WEXITED 0; stdout = ""; stderr = "" }
+  | [ stage ] -> dispatch stage
+  | _ ->
+      let rec chain prev_stdout = function
+        | [] ->
+            { status = Unix.WEXITED 0; stdout = prev_stdout; stderr = "" }
+        | [ Shell_ir.Simple s ] ->
+            let bin = Bin.to_string s.bin in
+            let argv = bin :: List.map resolve_arg s.args in
+            let env = resolve_env s.env in
+            (match
+               Process_eio.run_argv_with_stdin_and_status_split
+                 ~timeout_sec:120.0 ~env
+                 ~stdin_content:prev_stdout argv
+             with
+            | exception exn ->
+                { status = Unix.WEXITED 1;
+                  stdout = "";
+                  stderr = Printexc.to_string exn }
+            | (status, stdout, stderr) ->
+                { status; stdout; stderr })
+        | Shell_ir.Simple s :: rest ->
+            let bin = Bin.to_string s.bin in
+            let argv = bin :: List.map resolve_arg s.args in
+            let env = resolve_env s.env in
+            (match
+               Process_eio.run_argv_with_stdin_and_status_split
+                 ~timeout_sec:120.0 ~env
+                 ~stdin_content:prev_stdout argv
+             with
+            | exception exn ->
+                { status = Unix.WEXITED 1;
+                  stdout = "";
+                  stderr = Printexc.to_string exn }
+            | (status, stdout, stderr) ->
+                let last_status = status in
+                let result = chain stdout rest in
+                let final_status =
+                  match last_status with
+                  | Unix.WEXITED 0 -> result.status
+                  | _ -> last_status
+                in
+                { result with status = final_status })
+        | Pipeline _ :: _ ->
+            { status = Unix.WEXITED 1;
+              stdout = "";
+              stderr = "nested pipeline not supported in native dispatch" }
+      in
+      let first = List.hd stages in
+      (match first with
+       | Shell_ir.Simple s ->
+           let result = dispatch_simple s in
+           chain result.stdout (List.tl stages)
+       | Pipeline _ ->
+           { status = Unix.WEXITED 1;
+             stdout = "";
+             stderr = "nested pipeline not supported" })
+
+and dispatch (ir : Shell_ir.t) =
+  match ir with
+  | Shell_ir.Simple s -> dispatch_simple s
+  | Pipeline stages -> dispatch_pipeline stages
+
+let native_dispatch_enabled () =
+  match Unix.getenv "MASC_BASH_NATIVE_DISPATCH" with
+  | exception Not_found -> true
+  | "0" -> false
+  | _ -> true

--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -107,15 +107,18 @@ let rec dispatch_pipeline stages =
               stdout = "";
               stderr = "nested pipeline not supported in native dispatch" }
       in
-      let first = List.hd stages in
-      (match first with
-       | Shell_ir.Simple s ->
-           let result = dispatch_simple s in
-           chain result.stdout (List.tl stages)
-       | Pipeline _ ->
-           { status = Unix.WEXITED 1;
-             stdout = "";
-             stderr = "nested pipeline not supported" })
+      (match stages with
+       | [] ->
+           { status = Unix.WEXITED 0; stdout = ""; stderr = "" }
+       | first :: rest ->
+           (match first with
+            | Shell_ir.Simple s ->
+                let result = dispatch_simple s in
+                chain result.stdout rest
+            | Pipeline _ ->
+                { status = Unix.WEXITED 1;
+                  stdout = "";
+                  stderr = "nested pipeline not supported" }))
 
 and dispatch (ir : Shell_ir.t) =
   match ir with

--- a/lib/exec/exec_dispatch.mli
+++ b/lib/exec/exec_dispatch.mli
@@ -1,0 +1,21 @@
+type dispatch_result = {
+  status : Unix.process_status;
+  stdout : string;
+  stderr : string;
+}
+
+val resolve_arg : Shell_ir.arg -> string
+(** Resolve a Shell_ir.arg to a concrete string value. *)
+
+val dispatch : Shell_ir.t -> dispatch_result
+(** Execute a [Shell_ir.t] AST directly via Process_eio without
+    going through /bin/bash.  Simple commands use argv-based spawn;
+    pipelines chain stdout to stdin across stages. *)
+
+val dispatch_simple : Shell_ir.simple -> dispatch_result
+(** Execute a simple command via argv-based spawn. *)
+
+val native_dispatch_enabled : unit -> bool
+(** Check [MASC_BASH_NATIVE_DISPATCH] env var.
+    - [Some "0"] -> false (always bash fallback)
+    - unset or any other value -> true *)

--- a/lib/exec/output_parse.ml
+++ b/lib/exec/output_parse.ml
@@ -1,0 +1,346 @@
+(* P10: Structured Output Extraction
+   Pure-function parsers that turn raw command output into machine-readable
+   JSON.  No side effects, no I/O.  Each parser returns [Some json] on a
+   confident match or [None] to decline (fail-open). *)
+
+(* --- helpers --- *)
+
+let split_lines s =
+  let len = String.length s in
+  if len = 0 then []
+  else
+    let buf = Buffer.create 64 in
+    let lines = ref [] in
+    String.iter
+      (fun ch ->
+        if ch = '\n' then (
+          lines := Buffer.contents buf :: !lines;
+          Buffer.clear buf)
+        else Buffer.add_char buf ch)
+      s;
+    let last = Buffer.contents buf in
+    if last <> "" then lines := last :: !lines;
+    List.rev !lines
+
+let trim s =
+  let len = String.length s in
+  let start = ref 0 in
+  while !start < len && (s.[!start] = ' ' || s.[!start] = '\t') do
+    incr start
+  done;
+  let stop = ref (len - 1) in
+  while !stop >= !start && (s.[!stop] = ' ' || s.[!stop] = '\t') do
+    decr stop
+  done;
+  String.sub s !start (!stop - !start + 1)
+
+let starts_with s prefix =
+  String.length s >= String.length prefix
+  && String.sub s 0 (String.length prefix) = prefix
+
+let contains_substring s sub =
+  let sub_len = String.length sub in
+  let s_len = String.length s in
+  if sub_len = 0 then true
+  else if sub_len > s_len then false
+  else
+    let found = ref false in
+    for i = 0 to s_len - sub_len do
+      if not !found
+         && String.sub s i sub_len = sub
+      then found := true
+    done;
+    !found
+
+(* --- git status --porcelain --- *)
+
+let parse_git_status_porcelean output =
+  let lines = split_lines (trim output) in
+  if lines = [] then None
+  else
+    let staged = ref [] and unstaged = ref [] and untracked = ref [] in
+    List.iter
+      (fun line ->
+        if String.length line < 2 then ()
+        else
+          let xy = String.sub line 0 2 in
+          let path = trim (String.sub line 2 (String.length line - 2)) in
+          (* XY format: X=index, Y=worktree *)
+          match xy.[0], xy.[1] with
+          | '?', '?' -> untracked := path :: !untracked
+          | ' ', ('M' | 'D' | 'A') -> unstaged := path :: !unstaged
+          | ('M' | 'A' | 'D' | 'R' | 'C'), _ ->
+              staged := path :: !staged;
+              if xy.[1] <> ' ' then unstaged := path :: !unstaged
+          | ' ', _ -> () (* clean in index, clean in worktree *)
+          | _ -> unstaged := path :: !unstaged)
+      lines;
+    let n_staged = List.length !staged in
+    let n_unstaged = List.length !unstaged in
+    let n_untracked = List.length !untracked in
+    if n_staged + n_unstaged + n_untracked = 0 then None
+    else
+      Some
+        (`Assoc
+           [
+             ("staged", `List (List.map (fun p -> `String p) (List.rev !staged)));
+             ("unstaged", `List (List.map (fun p -> `String p) (List.rev !unstaged)));
+             ( "untracked",
+               `List (List.map (fun p -> `String p) (List.rev !untracked)) );
+           ])
+
+(* --- git log --oneline --- *)
+
+let parse_git_log_oneline output =
+  let lines = split_lines (trim output) in
+  if lines = [] then None
+  else
+    let commits = ref [] in
+    List.iter
+      (fun line ->
+        (* format: "abc1234 commit message" *)
+        let len = String.length line in
+        if len < 8 then ()
+        else
+          (* find first space after hash *)
+          let rec find_space i =
+            if i >= len then len
+            else if line.[i] = ' ' then i
+            else find_space (i + 1)
+          in
+          let sp = find_space 0 in
+          if sp = 0 || sp >= len then ()
+          else
+            let hash = String.sub line 0 sp in
+            let msg = trim (String.sub line (sp + 1) (len - sp - 1)) in
+            commits := `Assoc [ ("hash", `String hash); ("message", `String msg) ]
+                       :: !commits)
+      lines;
+    let n = List.length !commits in
+    if n = 0 then None
+    else Some (`Assoc [ ("commits", `List (List.rev !commits)); ("count", `Int n) ])
+
+(* --- git diff --stat --- *)
+
+let parse_git_diff_stat output =
+  let lines = split_lines (trim output) in
+  if lines = [] then None
+  else
+    (* last line: " N files changed, M insertions(+), D deletions(-)" *)
+    let last = List.hd (List.rev lines) in
+    let lower = String.lowercase_ascii last in
+    if not (starts_with (trim lower) "file" || starts_with (trim lower) "files") then
+      None
+    else
+      let files_changed = ref 0 and insertions = ref 0 and deletions = ref 0 in
+      (* parse "N file(s) changed" *)
+      (try
+         let re = Str.regexp {|\([0-9]+\) file|} in
+         if Str.string_match re (trim last) 0 then
+           files_changed := int_of_string (Str.matched_group 1 (trim last))
+       with _ -> ());
+      (* parse "M insertion(s)(+)" *)
+      (try
+         let re = Str.regexp {|\([0-9]+\) insertion|} in
+         if Str.string_match re (trim last) 0 then
+           insertions := int_of_string (Str.matched_group 1 (trim last))
+       with _ -> ());
+      (* parse "D deletion(s)(-)" *)
+      (try
+         let re = Str.regexp {|\([0-9]+\) deletion|} in
+         if Str.string_match re (trim last) 0 then
+           deletions := int_of_string (Str.matched_group 1 (trim last))
+       with _ -> ());
+      Some
+        (`Assoc
+           [
+             ("files_changed", `Int !files_changed);
+             ("insertions", `Int !insertions);
+             ("deletions", `Int !deletions);
+           ])
+
+(* --- wc -l --- *)
+
+let parse_wc_lines output =
+  let line = trim output in
+  if line = "" then None
+  else
+    (* format: "    1234 filename" or just "1234" *)
+    let tokens = split_lines line in
+    match tokens with
+    | [] -> None
+    | first :: _ ->
+        let words =
+          let parts = ref [] in
+          let buf = Buffer.create 16 in
+          String.iter
+            (fun ch ->
+              if ch = ' ' || ch = '\t' then (
+                if Buffer.length buf > 0 then (
+                  parts := Buffer.contents buf :: !parts;
+                  Buffer.clear buf))
+              else Buffer.add_char buf ch)
+            first;
+          let last = Buffer.contents buf in
+          if last <> "" then parts := last :: !parts;
+          List.rev !parts
+        in
+        match words with
+        | [] -> None
+        | n_str :: _ ->
+            (try Some (`Assoc [ ("lines", `Int (int_of_string n_str)) ])
+             with _ -> None)
+
+(* --- ls -la --- *)
+
+let parse_ls_long output =
+  let lines = split_lines (trim output) in
+  if lines = [] then None
+  else
+    let entries = ref [] in
+    List.iter
+      (fun line ->
+        let line = trim line in
+        (* skip "total N" line *)
+        if starts_with line "total" then ()
+        else
+          (* format: "drwxr-xr-x  2 user group  4096 Jan 1 12:00 dirname" *)
+          let len = String.length line in
+          if len < 10 then ()
+          else
+            let perms = String.sub line 0 10 in
+            (* skip if perms doesn't look like drwx... or -rw... *)
+            if perms.[0] <> 'd' && perms.[0] <> '-' && perms.[0] <> 'l' then ()
+            else
+              let rest = trim (String.sub line 10 (len - 10)) in
+              let parts = ref [] in
+              let buf = Buffer.create 32 in
+              String.iter
+                (fun ch ->
+                  if ch = ' ' || ch = '\t' then (
+                    if Buffer.length buf > 0 then (
+                      parts := Buffer.contents buf :: !parts;
+                      Buffer.clear buf))
+                  else Buffer.add_char buf ch)
+                rest;
+              let last = Buffer.contents buf in
+              if last <> "" then parts := last :: !parts;
+              let parts = List.rev !parts in
+              (* parts: [nlink, user, group, size, month, day, time/year, name...] *)
+              (match parts with
+              | _nlink :: _user :: _group :: size_str :: _m :: _d :: _t :: name_parts ->
+                  let name = String.concat " " name_parts in
+                  (try
+                    entries :=
+                      `Assoc
+                        [ ("perms", `String perms); ("size", `Int (int_of_string size_str))
+                        ; ("name", `String name) ]
+                      :: !entries
+                  with _ -> ())
+              | _ -> ()))
+      lines;
+    let n = List.length !entries in
+    if n = 0 then None
+    else Some (`Assoc [ ("entries", `List (List.rev !entries)); ("count", `Int n) ])
+
+(* --- dune test output --- *)
+
+let parse_dune_test output =
+  let lower = String.lowercase_ascii output in
+  (* dune runtest outputs like:
+     "Test src/...: ok" or "...FAILED..."
+     Summary line may not exist, so count individual results. *)
+  let lines = split_lines (trim output) in
+  let passed = ref 0 and failed = ref 0 and skipped = ref 0 in
+  List.iter
+    (fun line ->
+      let trimmed = trim line in
+      let l = String.lowercase_ascii trimmed in
+      if starts_with l "test " && (starts_with (trim (String.sub l 5 (String.length l - 5))) "src/"
+                                   || starts_with (trim (String.sub l 5 (String.length l - 5))) "test/") then
+        if starts_with l "test " then
+          (* check for ok/failed at end *)
+          let len = String.length l in
+          if len >= 3 && String.sub l (len - 2) 2 = "ok" then incr passed
+          else if starts_with l "test " && String.length trimmed > 5 then begin
+            (* look for FAILED or ERROR in the line *)
+            if contains_substring l "failed" then incr failed
+            else if contains_substring l "error" then incr failed
+          end
+      else if starts_with l "  " then ()
+      else if starts_with l "error:" then incr failed
+      else ()
+    )
+    lines;
+  let total = !passed + !failed + !skipped in
+  if total = 0 then None
+  else
+    Some
+      (`Assoc
+         [
+           ("passed", `Int !passed);
+           ("failed", `Int !failed);
+           ("skipped", `Int !skipped);
+         ])
+
+(* --- dispatcher --- *)
+
+type parser_kind =
+  | Git_status
+  | Git_log_oneline
+  | Git_diff_stat
+  | Wc_lines
+  | Ls_long
+  | Dune_test
+
+let classify_for_parsing ~cmd ~output =
+  let tokens =
+    let parts = ref [] in
+    let buf = Buffer.create 32 in
+    String.iter
+      (fun ch ->
+        if ch = ' ' || ch = '\t' then (
+          if Buffer.length buf > 0 then (
+            parts := Buffer.contents buf :: !parts;
+            Buffer.clear buf))
+        else Buffer.add_char buf ch)
+      (trim cmd);
+    let last = Buffer.contents buf in
+    if last <> "" then parts := last :: !parts;
+    List.rev !parts
+  in
+  match tokens with
+  | [] -> None
+  | bin :: rest ->
+      let base = Filename.basename bin |> String.lowercase_ascii in
+      match base with
+      | "git" ->
+          let sub = match rest with _first :: s :: _ -> Some s | _ -> None in
+          (match sub with
+          | Some "status" -> Some Git_status
+          | Some "log" -> Some Git_log_oneline
+          | Some "diff" -> Some Git_diff_stat
+          | _ -> None)
+      | "wc" ->
+          if List.exists (fun t -> t = "-l" || t = "--lines") rest then
+            Some Wc_lines
+          else None
+      | "ls" ->
+          if List.exists (fun t -> t = "-l" || t = "-la" || t = "-al" || t = "-lah" || t = "-lha") rest then
+            Some Ls_long
+          else None
+      | "dune" ->
+          if List.exists (fun t -> t = "runtest" || t = "test") rest then
+            Some Dune_test
+          else None
+      | _ -> None
+
+let try_parse ~cmd ~output =
+  match classify_for_parsing ~cmd ~output with
+  | None -> None
+  | Some Git_status -> parse_git_status_porcelean output
+  | Some Git_log_oneline -> parse_git_log_oneline output
+  | Some Git_diff_stat -> parse_git_diff_stat output
+  | Some Wc_lines -> parse_wc_lines output
+  | Some Ls_long -> parse_ls_long output
+  | Some Dune_test -> parse_dune_test output

--- a/lib/exec/output_parse.ml
+++ b/lib/exec/output_parse.ml
@@ -246,7 +246,6 @@ let parse_ls_long output =
 (* --- dune test output --- *)
 
 let parse_dune_test output =
-  let lower = String.lowercase_ascii output in
   (* dune runtest outputs like:
      "Test src/...: ok" or "...FAILED..."
      Summary line may not exist, so count individual results. *)

--- a/lib/exec/output_parse.ml
+++ b/lib/exec/output_parse.ml
@@ -126,38 +126,40 @@ let parse_git_diff_stat output =
   let lines = split_lines (trim output) in
   if lines = [] then None
   else
-    (* last line: " N files changed, M insertions(+), D deletions(-)" *)
-    let last = List.hd (List.rev lines) in
-    let lower = String.lowercase_ascii last in
-    if not (starts_with (trim lower) "file" || starts_with (trim lower) "files") then
-      None
-    else
-      let files_changed = ref 0 and insertions = ref 0 and deletions = ref 0 in
-      (* parse "N file(s) changed" *)
-      (try
-         let re = Str.regexp {|\([0-9]+\) file|} in
-         if Str.string_match re (trim last) 0 then
-           files_changed := int_of_string (Str.matched_group 1 (trim last))
-       with _ -> ());
-      (* parse "M insertion(s)(+)" *)
-      (try
-         let re = Str.regexp {|\([0-9]+\) insertion|} in
-         if Str.string_match re (trim last) 0 then
-           insertions := int_of_string (Str.matched_group 1 (trim last))
-       with _ -> ());
-      (* parse "D deletion(s)(-)" *)
-      (try
-         let re = Str.regexp {|\([0-9]+\) deletion|} in
-         if Str.string_match re (trim last) 0 then
-           deletions := int_of_string (Str.matched_group 1 (trim last))
-       with _ -> ());
-      Some
-        (`Assoc
-           [
-             ("files_changed", `Int !files_changed);
-             ("insertions", `Int !insertions);
-             ("deletions", `Int !deletions);
-           ])
+    match List.rev lines with
+    | [] -> None
+    | last :: _ ->
+        (* last line: " N files changed, M insertions(+), D deletions(-)" *)
+        let lower = String.lowercase_ascii last in
+        if not (starts_with (trim lower) "file" || starts_with (trim lower) "files") then
+          None
+        else
+          let files_changed = ref 0 and insertions = ref 0 and deletions = ref 0 in
+          (* parse "N file(s) changed" *)
+          (try
+             let re = Str.regexp {|\([0-9]+\) file|} in
+             if Str.string_match re (trim last) 0 then
+               files_changed := int_of_string (Str.matched_group 1 (trim last))
+           with _ -> ());
+          (* parse "M insertion(s)(+)" *)
+          (try
+             let re = Str.regexp {|\([0-9]+\) insertion|} in
+             if Str.string_match re (trim last) 0 then
+               insertions := int_of_string (Str.matched_group 1 (trim last))
+           with _ -> ());
+          (* parse "D deletion(s)(-)" *)
+          (try
+             let re = Str.regexp {|\([0-9]+\) deletion|} in
+             if Str.string_match re (trim last) 0 then
+               deletions := int_of_string (Str.matched_group 1 (trim last))
+           with _ -> ());
+          Some
+            (`Assoc
+               [
+                 ("files_changed", `Int !files_changed);
+                 ("insertions", `Int !insertions);
+                 ("deletions", `Int !deletions);
+               ])
 
 (* --- wc -l --- *)
 

--- a/lib/exec/output_parse.mli
+++ b/lib/exec/output_parse.mli
@@ -1,0 +1,15 @@
+(** P10: Structured Output Extraction
+
+    Pure-function parsers that turn raw command output into
+    machine-readable JSON fields.  Every parser is total and returns
+    [Some json] on a confident match or [None] to decline (fail-open).
+
+    Inspired by OpenAI Codex harness blog posts ("harness-engineering"):
+    agents waste tokens on fragile regex parsing of raw text.  This
+    layer turns common outputs into typed JSON that the agent can
+    consume directly. *)
+
+val try_parse : cmd:string -> output:string -> Yojson.Safe.t option
+(** Top-level dispatcher.  Examines [cmd] to select a parser, then
+    feeds [output] through it.  Returns [None] when no parser matches
+    or when the output does not conform to the expected format. *)

--- a/lib/exec_core.ml
+++ b/lib/exec_core.ml
@@ -798,6 +798,10 @@ let outcome_to_json ?(extra = []) ?(env_snapshot = None) = function
            ]
          @ hint_fields
          @ semantic_fields_of_executed result
+         @ (match Masc_exec.Output_parse.try_parse ~cmd:result.command
+                                                 ~output:result.output with
+            | None -> []
+            | Some json -> [ ("structured_output", json) ])
          @ env_field)
   | Blocked_result result ->
       let alternatives_field =

--- a/test/dune
+++ b/test/dune
@@ -87,6 +87,7 @@
         test_keeper_tool_policy_config
         test_keeper_toml_config_validation
         test_exec_core
+        test_exec_dispatch
         test_keeper_bash_safety
         test_hitl_approval
         test_approval_callback_wired
@@ -201,6 +202,7 @@
           test_keeper_tool_policy_config
           test_keeper_toml_config_validation
           test_exec_core
+          test_exec_dispatch
           test_keeper_bash_safety
           test_hitl_approval
           test_approval_callback_wired

--- a/test/test_exec_core.ml
+++ b/test/test_exec_core.ml
@@ -524,6 +524,66 @@ let test_dune_test_structured () =
   check int "passed" 2 (so |> member "passed" |> to_int);
   check int "failed" 1 (so |> member "failed" |> to_int)
 
+(* --- P11: command history tests --- *)
+
+let tmp_dir_for_p11 = Filename.concat (Filename.get_temp_dir_name ()) "p11_test"
+
+let setup_p11 () =
+  if Sys.file_exists tmp_dir_for_p11 then
+    Array.iter (fun f ->
+      if Filename.check_suffix f ".jsonl" then
+        Sys.remove (Filename.concat tmp_dir_for_p11 f)
+    ) (Sys.readdir tmp_dir_for_p11)
+
+let test_history_append_and_read () =
+  setup_p11 ();
+  let module H = Masc_exec.Bash_history in
+  H.append ~base_path:tmp_dir_for_p11 ~keeper_name:"test-keeper"
+    { ts = 1000.0; cmd_hash = "abc123"; cmd_prefix = "git status";
+      semantic_kind = "Read"; duration_ms = 50; success = true };
+  H.append ~base_path:tmp_dir_for_p11 ~keeper_name:"test-keeper"
+    { ts = 2000.0; cmd_hash = "def456"; cmd_prefix = "dune build";
+      semantic_kind = "Build"; duration_ms = 5000; success = false };
+  let results =
+    H.suggest ~base_path:tmp_dir_for_p11 ~keeper_name:"test-keeper"
+      ~pattern:"git" ~limit:10
+  in
+  check int "found 1 git entry" 1 (List.length results);
+  let e = List.hd results in
+  check string "cmd_prefix" "git status" e.cmd_prefix;
+  check bool "success" true e.success
+
+let test_history_suggest_empty () =
+  setup_p11 ();
+  let module H = Masc_exec.Bash_history in
+  let results =
+    H.suggest ~base_path:tmp_dir_for_p11 ~keeper_name:"no-keeper"
+      ~pattern:"x" ~limit:5
+  in
+  check int "empty for nonexistent" 0 (List.length results)
+
+let test_history_cmd_hash () =
+  let module H = Masc_exec.Bash_history in
+  let h = H.cmd_hash "git status" in
+  check int "hash length 12" 12 (String.length h)
+
+let test_history_compaction () =
+  setup_p11 ();
+  let module H = Masc_exec.Bash_history in
+  for i = 1 to 15 do
+    H.append ~base_path:tmp_dir_for_p11 ~keeper_name:"compact-test"
+      { ts = float_of_int i; cmd_hash = string_of_int i;
+        cmd_prefix = "cmd" ^ string_of_int i;
+        semantic_kind = "Unknown"; duration_ms = 10; success = true }
+  done;
+  (* 15 entries is below max_entries (10000), so compact is a no-op *)
+  H.compact ~base_path:tmp_dir_for_p11 ~keeper_name:"compact-test";
+  let results =
+    H.suggest ~base_path:tmp_dir_for_p11 ~keeper_name:"compact-test"
+      ~pattern:"cmd" ~limit:100
+  in
+  check int "all 15 preserved" 15 (List.length results)
+
 
 let () =
   run "exec_core"
@@ -604,5 +664,16 @@ let () =
             test_unknown_cmd_no_structured;
           test_case "dune runtest produces passed/failed counts" `Quick
             test_dune_test_structured;
+        ] );
+      ( "p11_command_history",
+        [
+          test_case "append and read history entries" `Quick
+            test_history_append_and_read;
+          test_case "suggest returns empty for nonexistent" `Quick
+            test_history_suggest_empty;
+          test_case "cmd_hash produces 12-char hex" `Quick
+            test_history_cmd_hash;
+          test_case "compaction preserves entries below threshold"
+            `Quick test_history_compaction;
         ] );
     ]

--- a/test/test_exec_core.ml
+++ b/test/test_exec_core.ml
@@ -444,6 +444,86 @@ let test_blocked_diagnosis_both_rewrite_and_tool () =
   check string "tool_suggestion" "keeper_shell"
     (d |> member "tool_suggestion" |> to_string)
 
+(* --- P10: structured output tests --- *)
+
+let test_git_status_structured () =
+  let json =
+    Masc_mcp.Exec_core.process_result_json
+      ~base_path:"/tmp"
+      ~keeper_name:"p10-test"
+      ~cmd:"git status --porcelain"
+      ~status:(Unix.WEXITED 0)
+      ~output:" M lib/foo.ml\n?? new_file.txt\n"
+      ()
+  in
+  let so = json |> member "structured_output" in
+  let staged = so |> member "staged" |> to_list in
+  let unstaged = so |> member "unstaged" |> to_list in
+  let untracked = so |> member "untracked" |> to_list in
+  check int "staged empty" 0 (List.length staged);
+  check int "unstaged 1" 1 (List.length unstaged);
+  check int "untracked 1" 1 (List.length untracked)
+
+let test_git_log_structured () =
+  let json =
+    Masc_mcp.Exec_core.process_result_json
+      ~base_path:"/tmp"
+      ~keeper_name:"p10-test"
+      ~cmd:"git log --oneline -5"
+      ~status:(Unix.WEXITED 0)
+      ~output:"abc1234 fix bug\ndef5678 add feature\n"
+      ()
+  in
+  let so = json |> member "structured_output" in
+  let commits = so |> member "commits" |> to_list in
+  check int "commits count" 2 (List.length commits)
+
+let test_wc_structured () =
+  let json =
+    Masc_mcp.Exec_core.process_result_json
+      ~base_path:"/tmp"
+      ~keeper_name:"p10-test"
+      ~cmd:"wc -l lib/foo.ml"
+      ~status:(Unix.WEXITED 0)
+      ~output:"     120 lib/foo.ml"
+      ()
+  in
+  let so = json |> member "structured_output" in
+  check int "lines" 120 (so |> member "lines" |> to_int)
+
+let test_unknown_cmd_no_structured () =
+  let json =
+    Masc_mcp.Exec_core.process_result_json
+      ~base_path:"/tmp"
+      ~keeper_name:"p10-test"
+      ~cmd:"echo hello world"
+      ~status:(Unix.WEXITED 0)
+      ~output:"hello world"
+      ()
+  in
+  check bool "no structured_output for unknown" true
+    (try
+       let _ = json |> member "structured_output" in
+       false
+     with _ -> true)
+
+let test_dune_test_structured () =
+  let output =
+    "Test src/foo.ml: OK\nTest test/bar.ml: FAILED\nTest test/baz.ml: OK\n"
+  in
+  let json =
+    Masc_mcp.Exec_core.process_result_json
+      ~base_path:"/tmp"
+      ~keeper_name:"p10-test"
+      ~cmd:"dune runtest"
+      ~status:(Unix.WEXITED 1)
+      ~output
+      ()
+  in
+  let so = json |> member "structured_output" in
+  check int "passed" 2 (so |> member "passed" |> to_int);
+  check int "failed" 1 (so |> member "failed" |> to_int)
+
 
 let () =
   run "exec_core"
@@ -511,5 +591,18 @@ let () =
             test_blocked_with_tool_suggestion;
           test_case "diag with both rewrite and tool" `Quick
             test_blocked_diagnosis_both_rewrite_and_tool;
+        ] );
+      ( "p10_structured_output",
+        [
+          test_case "git status --porcelain produces structured fields"
+            `Quick test_git_status_structured;
+          test_case "git log --oneline produces commits array" `Quick
+            test_git_log_structured;
+          test_case "wc -l produces lines count" `Quick
+            test_wc_structured;
+          test_case "unknown cmd has no structured_output" `Quick
+            test_unknown_cmd_no_structured;
+          test_case "dune runtest produces passed/failed counts" `Quick
+            test_dune_test_structured;
         ] );
     ]

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -1,0 +1,109 @@
+let with_eio f =
+  Eio_main.run @@ fun env ->
+  Process_eio.init
+    ~cwd_default:(Eio.Stdenv.cwd env)
+    ~proc_mgr:(Eio.Stdenv.process_mgr env)
+    ~clock:(Eio.Stdenv.clock env);
+  f ()
+
+(* --- resolve_arg --- *)
+
+let () =
+  let open Masc_exec.Shell_ir in
+  let test_resolve_lit =
+    let result = Masc_exec.Exec_dispatch.(resolve_arg (Lit "hello")) in
+    assert (result = "hello")
+  in
+  test_resolve_lit
+
+let () =
+  let open Masc_exec.Shell_ir in
+  Unix.putenv "MASC_TEST_P7_VAR" "world";
+  let result = Masc_exec.Exec_dispatch.(resolve_arg (Var "MASC_TEST_P7_VAR")) in
+  assert (result = "world")
+
+let () =
+  let open Masc_exec.Shell_ir in
+  let result = Masc_exec.Exec_dispatch.(resolve_arg (Var "__MASC_NONEXISTENT_P7__")) in
+  assert (result = "")
+
+let () =
+  let open Masc_exec.Shell_ir in
+  Unix.putenv "MASC_TEST_P7_VAR" "world";
+  let result = Masc_exec.Exec_dispatch.(resolve_arg (Concat [Lit "prefix-"; Var "MASC_TEST_P7_VAR"; Lit "-suffix"])) in
+  assert (result = "prefix-world-suffix");
+  Unix.putenv "MASC_TEST_P7_VAR" ""
+
+(* --- native_dispatch_enabled --- *)
+
+let () =
+  Unix.putenv "MASC_BASH_NATIVE_DISPATCH" "0";
+  assert (not (Masc_exec.Exec_dispatch.native_dispatch_enabled ()));
+  Unix.putenv "MASC_BASH_NATIVE_DISPATCH" "1";
+  assert (Masc_exec.Exec_dispatch.native_dispatch_enabled ());
+  Unix.putenv "MASC_BASH_NATIVE_DISPATCH" "";
+  assert (Masc_exec.Exec_dispatch.native_dispatch_enabled ())
+
+(* --- dispatch_simple with real process --- *)
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let bin = Masc_exec.Bin.of_string "echo" |> Result.get_ok in
+  let ir = Simple { bin; args = [Lit "hello"; Lit "world"]; env = []; cwd = None; redirects = [] } in
+  let result = Masc_exec.Exec_dispatch.dispatch ir in
+  let stdout = String.trim result.stdout in
+  assert (stdout = "hello world");
+  assert (result.status = Unix.WEXITED 0)
+
+(* --- dispatch_simple captures stderr --- *)
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let bin = Masc_exec.Bin.of_string "cat" |> Result.get_ok in
+  let ir = Simple { bin; args = [Lit "/nonexistent_file_p7_test"]; env = []; cwd = None; redirects = [] } in
+  let result = Masc_exec.Exec_dispatch.dispatch ir in
+  assert (result.status <> Unix.WEXITED 0);
+  assert (String.length result.stderr > 0)
+
+(* --- dispatch pipeline --- *)
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let echo_bin = Masc_exec.Bin.of_string "echo" |> Result.get_ok in
+  let tr_bin = Masc_exec.Bin.of_string "tr" |> Result.get_ok in
+  let stages = [
+    Simple { bin = echo_bin; args = [Lit "hello world"]; env = []; cwd = None; redirects = [] };
+    Simple { bin = tr_bin; args = [Lit "a-z"; Lit "A-Z"]; env = []; cwd = None; redirects = [] };
+  ] in
+  let result = Masc_exec.Exec_dispatch.dispatch (Pipeline stages) in
+  let stdout = String.trim result.stdout in
+  assert (stdout = "HELLO WORLD");
+  assert (result.status = Unix.WEXITED 0)
+
+(* --- dispatch pipeline exit code: last nonzero wins --- *)
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let echo_bin = Masc_exec.Bin.of_string "echo" |> Result.get_ok in
+  let false_bin = Masc_exec.Bin.of_string "false" |> Result.get_ok in
+  let stages = [
+    Simple { bin = echo_bin; args = [Lit "ok"]; env = []; cwd = None; redirects = [] };
+    Simple { bin = false_bin; args = []; env = []; cwd = None; redirects = [] };
+  ] in
+  let result = Masc_exec.Exec_dispatch.dispatch (Pipeline stages) in
+  assert (result.status = Unix.WEXITED 1)
+
+(* --- dispatch empty pipeline --- *)
+
+let () =
+  with_eio @@ fun () ->
+  let result = Masc_exec.Exec_dispatch.dispatch (Masc_exec.Shell_ir.Pipeline []) in
+  assert (result.status = Unix.WEXITED 0);
+  assert (result.stdout = "")
+
+let () =
+  Printf.printf "p7_exec_dispatch: all tests passed.\n"


### PR DESCRIPTION
## Summary
- Execute `Shell_ir.t` AST directly via `Process_eio` without going through `/bin/bash`, eliminating shell injection attack surface
- Simple commands use argv-based spawn; pipelines chain stdout→stdin across stages with last-nonzero-wins exit code
- Controlled by `MASC_BASH_NATIVE_DISPATCH` env var (default: enabled, set `"0"` to always fall back to bash)
- Fix pre-existing erasable-optional-argument warnings in keeper_shell_docker and keeper_exec_shell

## Test plan
- [x] `test_exec_dispatch.ml`: resolve_arg (Lit/Var/Concat/missing), native_dispatch_enabled, dispatch_simple echo/cat, pipeline echo|tr, pipeline exit code, empty pipeline
- [ ] Manual verification: `dune exec test/test_exec_dispatch.exe` passes all 10 assertions
- [ ] Shadow mode comparison: run 50-command corpus through both native and bash paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)