### PR TITLE
[codex] relax worktree git status timeout for large repos

### DIFF
--- a/lib/worktree_live_context.ml
+++ b/lib/worktree_live_context.ml
@@ -12,18 +12,19 @@ let clear_git_capture_hook_for_tests () =
 
 (* `git status --porcelain` timeout budget.
 
-   The 5.0s default hit its ceiling 30x in a 45-minute fleet window on
-   2026-04-20 when the workdir was a Second Brain root with many
-   worktrees, thousands of untracked files, and concurrent indexer
-   activity. Each timeout falls through to stale cache (live context
-   goes quiet for the keeper) and emits a WARN.
+   The original 5.0s default hit its ceiling 30x in a 45-minute fleet
+   window on 2026-04-20 when the workdir was a Second Brain root with
+   many worktrees, thousands of untracked files, and concurrent indexer
+   activity. On 2026-04-23, the 15.0s follow-up budget still timed out
+   in `/Users/dancer/me` with 64 worktrees, which left operator
+   snapshots stale and generated recurring WARN noise (#9628).
 
-   15.0s covers p99 for large working trees without meaningfully
-   stretching keeper turn latency — the call is cached (see
-   [status_cache_ttl_sec] below) so the full budget is paid at most
+   30.0s keeps the capture bounded while giving large repos enough head
+   room for a cached status refresh. The call is still cached (see
+   [status_cache_ttl_sec] below), so the full budget is paid at most
    once per TTL window per repo. Env var stays the escape hatch for
-   unusually slow hosts. *)
-let default_git_status_timeout_sec = 15.0
+   unusually slow or unusually fast hosts. *)
+let default_git_status_timeout_sec = 30.0
 
 let git_status_timeout_sec () =
   Env_config_core.get_float ~default:default_git_status_timeout_sec

--- a/lib/worktree_live_context.mli
+++ b/lib/worktree_live_context.mli
@@ -37,6 +37,10 @@ val set_git_capture_hook_for_tests : git_capture_hook -> unit
     hook. *)
 val clear_git_capture_hook_for_tests : unit -> unit
 
+(** Effective timeout budget for the [git status --porcelain] capture,
+    after applying [MASC_WORKTREE_GIT_STATUS_TIMEOUT_SEC] if present. *)
+val git_status_timeout_sec : unit -> float
+
 (** Reset the in-memory per-repo status cache so tests observe a
     deterministic "no previous hash" state. *)
 val clear_status_cache_for_tests : unit -> unit

--- a/test/test_worktree_live_context.ml
+++ b/test/test_worktree_live_context.ml
@@ -37,6 +37,16 @@ let with_eio_runtime f =
 
 let quote = Filename.quote
 
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
 let run_ok ~cwd cmd =
   let wrapped = Printf.sprintf "cd %s && %s > /dev/null 2>&1" (quote cwd) cmd in
   let code = Sys.command wrapped in
@@ -146,6 +156,16 @@ let test_current_status_lines_caches_clean_status () =
         (Wlc.current_status_lines ~repo_root:"/tmp/repo");
       check int "clean status is cached" 1 !calls)
 
+let test_git_status_timeout_defaults_to_30_seconds () =
+  with_env "MASC_WORKTREE_GIT_STATUS_TIMEOUT_SEC" "" (fun () ->
+      check (float 0.01) "default git status timeout" 30.0
+        (Wlc.git_status_timeout_sec ()))
+
+let test_git_status_timeout_honors_env_override () =
+  with_env "MASC_WORKTREE_GIT_STATUS_TIMEOUT_SEC" "12.5" (fun () ->
+      check (float 0.01) "env override" 12.5
+        (Wlc.git_status_timeout_sec ()))
+
 let () =
   run "Worktree_live_context"
     [
@@ -160,5 +180,9 @@ let () =
             test_current_status_lines_uses_short_cache_and_no_optional_locks;
           test_case "status cache keeps clean status" `Quick
             test_current_status_lines_caches_clean_status;
+          test_case "git status timeout defaults to 30s" `Quick
+            test_git_status_timeout_defaults_to_30_seconds;
+          test_case "git status timeout honors env override" `Quick
+            test_git_status_timeout_honors_env_override;
         ] );
     ]


### PR DESCRIPTION
## Summary
- increase the default worktree live-context `git status --porcelain` timeout from 15s to 30s
- document the large-repo/worktree pressure that still reproduced timeout noise on 2026-04-23
- add regression coverage for the new default and the `MASC_WORKTREE_GIT_STATUS_TIMEOUT_SEC` override

## Why
- `git status --porcelain` was still timing out in large repos with many worktrees, which left operator snapshots stale and generated recurring WARN noise
- the live-context call is cached, so increasing the bounded refresh budget is lower risk than letting the status capture fail repeatedly

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/issue-9628 lib/worktree_live_context.ml lib/worktree_live_context.mli`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/issue-9628/_build/default/test/test_worktree_live_context.exe`

Fixes #9628