### PR TITLE
fix(spec): correct line refs in DashboardCacheStampede.tla

### DIFF
--- a/specs/bug-models/DashboardCacheStampede.tla
+++ b/specs/bug-models/DashboardCacheStampede.tla
@@ -10,8 +10,8 @@
 \*
 \* Actual code (verified 2026-04-20):
 \*   lib/dashboard/dashboard_cache.ml:60   let maybe_evict map
-\*   lib/dashboard/dashboard_cache.ml:148  let get_or_compute_eio
-\*   lib/dashboard/dashboard_cache.ml:237  | Eio.Cancel.Cancelled _ as e -> ...
+\*   lib/dashboard/dashboard_cache.ml:149  let get_or_compute_eio
+\*   lib/dashboard/dashboard_cache.ml:238  | Eio.Cancel.Cancelled _ as e -> ...
 \*
 \* (Path drift: lib/dashboard_cache.ml -> lib/dashboard/dashboard_cache.ml.
 \*  Line drift: 265 -> 216. Recorded for cross-reference.)


### PR DESCRIPTION
## Summary

Follow-up to #9630. Meta Guards `spec-line-refs` detected 2 drifts after the wildcard pattern fix shifted lines in `lib/dashboard/dashboard_cache.ml`.

## Changes

- `get_or_compute_eio`: 148 -> 149
- `Eio.Cancel.Cancelled _ as e` handler: 237 -> 238

## Verification

- [x] `spec-line-refs` validated locally
- [x] No code change — TLA+ comment update only