### PR TITLE
fix(test): register negative-path tests in bash safety runner

### DIFF
--- a/specs/bug-models/DashboardCacheStampede.tla
+++ b/specs/bug-models/DashboardCacheStampede.tla
@@ -9,9 +9,9 @@
 \*   - Result: permanent zombie slot returning stale data forever
 \*
 \* Actual code (verified 2026-04-20):
-\*   lib/dashboard/dashboard_cache.ml:maybe_evict
-\*   lib/dashboard/dashboard_cache.ml:get_or_compute_eio
-\*   lib/dashboard/dashboard_cache.ml:should_restore_stale_after_failure
+\*   lib/dashboard/dashboard_cache.ml:60   let maybe_evict map
+\*   lib/dashboard/dashboard_cache.ml:148  let get_or_compute_eio
+\*   lib/dashboard/dashboard_cache.ml:237  | Eio.Cancel.Cancelled _ as e -> ...
 \*
 \* (Path drift: lib/dashboard_cache.ml -> lib/dashboard/dashboard_cache.ml.
 \*  Line drift: 265 -> 216. Recorded for cross-reference.)

--- a/specs/bug-models/DashboardCacheStampede.tla
+++ b/specs/bug-models/DashboardCacheStampede.tla
@@ -9,9 +9,9 @@
 \*   - Result: permanent zombie slot returning stale data forever
 \*
 \* Actual code (verified 2026-04-20):
-\*   lib/dashboard/dashboard_cache.ml:60   let maybe_evict map
-\*   lib/dashboard/dashboard_cache.ml:148  let get_or_compute_eio
-\*   lib/dashboard/dashboard_cache.ml:237  | Eio.Cancel.Cancelled _ as e -> ...
+\*   lib/dashboard/dashboard_cache.ml:maybe_evict
+\*   lib/dashboard/dashboard_cache.ml:get_or_compute_eio
+\*   lib/dashboard/dashboard_cache.ml:should_restore_stale_after_failure
 \*
 \* (Path drift: lib/dashboard_cache.ml -> lib/dashboard/dashboard_cache.ml.
 \*  Line drift: 265 -> 216. Recorded for cross-reference.)

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -670,4 +670,9 @@ let () =
       Alcotest.test_case "unrelated paths remain unchanged" `Quick
         test_rewrite_turn_runtime_paths_to_host_is_noop_without_container_path;
     ]);
+    ("negative_path", [
+      Alcotest.test_case "missing cmd field" `Quick test_bash_missing_cmd_field;
+      Alcotest.test_case "missing op field" `Quick test_shell_missing_op_field;
+      Alcotest.test_case "unsupported op" `Quick test_shell_unsupported_op;
+    ]);
   ]


### PR DESCRIPTION
## Summary
PR #9626 added three negative-path test functions but did not register them in the Alcotest runner. This PR wires them up so they actually execute.

## Changes
- Register `test_bash_missing_cmd_field`, `test_shell_missing_op_field`, `test_shell_unsupported_op` under a new `negative_path` group in `test/test_keeper_bash_safety.ml`

## Verification
- [x] `dune runtest test/test_keeper_bash_safety.ml` passes (28 tests including the 3 new ones)

🤖 Generated with [Claude Code](https://claude.com/claude-code)