### PR TITLE
[codex] accept ISO board created_at values in activity feed

### DIFF
--- a/lib/activity_feed.ml
+++ b/lib/activity_feed.ml
@@ -100,6 +100,21 @@ let parse_created_at_or_fallback ~kind ~path raw =
           (Printexc.to_string exn);
         fallback ()
 
+let json_created_at_or_fallback ~kind ~path json =
+  match Safe_ops.json_float_opt "created_at" json with
+  | Some ts -> ts
+  | None ->
+      (match Safe_ops.json_string_opt "created_at" json with
+       | Some raw -> (
+           match Types.parse_iso8601_opt (String.trim raw) with
+           | Some ts -> ts
+           | None ->
+               Log.Feed.warn "%s missing/invalid created_at for %s" kind path;
+               timestamp_fallback)
+       | None ->
+           Log.Feed.warn "%s missing/invalid created_at for %s" kind path;
+           timestamp_fallback)
+
 (** {1 Source Readers} *)
 
 (** Read task activity from `.masc/tasks/` directory. *)
@@ -159,11 +174,7 @@ let board_post_activities (config : Coord.config) : activity_item list =
       let title = Safe_ops.json_string ~default:"" "title" json in
       let content = Safe_ops.json_string ~default:"" "content" json in
       let created_at =
-        match Safe_ops.json_float_opt "created_at" json with
-        | Some ts -> ts
-        | None ->
-            Log.Feed.warn "board post missing/invalid created_at for %s" path;
-            timestamp_fallback
+        json_created_at_or_fallback ~kind:"board post" ~path json
       in
       if id = "" then None
       else
@@ -192,11 +203,7 @@ let board_comment_activities (config : Coord.config) : activity_item list =
       let author = Safe_ops.json_string ~default:"" "author" json in
       let content = Safe_ops.json_string ~default:"" "content" json in
       let created_at =
-        match Safe_ops.json_float_opt "created_at" json with
-        | Some ts -> ts
-        | None ->
-            Log.Feed.warn "board comment missing/invalid created_at for %s" path;
-            timestamp_fallback
+        json_created_at_or_fallback ~kind:"board comment" ~path json
       in
       if id = "" then None
       else
@@ -224,11 +231,7 @@ let mention_activities (config : Coord.config) : activity_item list =
       let target_agent = Safe_ops.json_string ~default:"" "target_agent" json in
       let content_preview = Safe_ops.json_string ~default:"" "content_preview" json in
       let created_at =
-        match Safe_ops.json_float_opt "created_at" json with
-        | Some ts -> ts
-        | None ->
-            Log.Feed.warn "mention inbox missing/invalid created_at for %s" path;
-            timestamp_fallback
+        json_created_at_or_fallback ~kind:"mention inbox" ~path json
       in
       if id = "" then None
       else Some {

--- a/test/test_auto_recall_activity_coverage.ml
+++ b/test/test_auto_recall_activity_coverage.ml
@@ -316,6 +316,38 @@ let test_recent_activity_skips_malformed_jsonl_lines () =
       check (float 0.01) "timestamp preserved" 123.0 item.created_at
   | _ -> fail "expected one activity item"
 
+let test_recent_activity_accepts_iso_string_created_at_for_board_posts () =
+  with_temp_dir "activity-feed-jsonl-iso" @@ fun base_path ->
+  let config = Coord.default_config base_path in
+  let masc_dir = Coord.masc_dir config in
+  Fs_compat.mkdir_p masc_dir;
+  let board_posts_path = Filename.concat masc_dir "board_posts.jsonl" in
+  let iso_created_at = "2026-04-22T13:01:48Z" in
+  write_file board_posts_path
+    (Yojson.Safe.to_string
+       (`Assoc
+         [
+           ("id", `String "post-iso");
+           ("author", `String "alice");
+           ("title", `String "Hello");
+           ("content", `String "body");
+           ("created_at", `String iso_created_at);
+         ]) ^ "\n");
+  let stderr_output =
+    capture_stderr (fun () ->
+        ignore (Activity_feed.recent_activity config ~limit:10 ()))
+  in
+  check bool "does not warn for ISO created_at" false
+    (str_contains stderr_output "board post missing/invalid created_at");
+  let items = Activity_feed.recent_activity config ~limit:10 () in
+  check int "valid ISO board post survives" 1 (List.length items);
+  match items, Types.parse_iso8601_opt iso_created_at with
+  | [item], Some expected_ts ->
+      check string "summary preserved" "Posted: Hello" item.summary;
+      check (float 0.01) "ISO timestamp preserved" expected_ts item.created_at
+  | [ _ ], None -> fail "expected ISO fixture to parse"
+  | _ -> fail "expected one activity item"
+
 let test_recent_activity_skips_bad_task_file () =
   with_temp_dir "activity-feed-task" @@ fun base_path ->
   let config = Coord.default_config base_path in
@@ -441,6 +473,8 @@ let () =
     "activity_feed_fs", [
       test_case "skips malformed jsonl lines" `Quick
         test_recent_activity_skips_malformed_jsonl_lines;
+      test_case "accepts ISO string created_at for board posts" `Quick
+        test_recent_activity_accepts_iso_string_created_at_for_board_posts;
       test_case "skips bad task file" `Quick
         test_recent_activity_skips_bad_task_file;
       test_case "falls back from bad task timestamp" `Quick


### PR DESCRIPTION
## Summary
- accept ISO8601 `created_at` strings in board and mention activity JSONL readers
- keep the existing fallback path for records that are still missing or malformed
- add regression coverage that proves board posts with ISO timestamps stay visible without warning noise

## Why
- `activity_feed` only accepted numeric `created_at` values for board JSONL sources
- older or migrated records with ISO8601 timestamps triggered repeated `missing/invalid created_at` WARN logs and were forced to epoch fallback

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/issue-9586-main lib/activity_feed.ml test/test_auto_recall_activity_coverage.ml`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/issue-9586-main/_build_fresh_auto/default/test/test_auto_recall_activity_coverage.exe`

Fixes #9586