### PR TITLE
[codex] add auth doctor for admin bearer mismatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ cd dashboard && MASC_DASHBOARD_PROXY_TARGET="http://127.0.0.1:${PORT}" pnpm run 
 
 - For manual rebuilds, run `cd dashboard && pnpm run build`.
 - For local admin bearer bootstrap and dashboard keeper lifecycle control, see [docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md](docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md).
+- If dashboard save or keeper lifecycle calls fail with `Forbidden` or `cannot CanAdmin`, run `./_build/default/bin/main_eio.exe doctor auth --base-path "$PWD"` before editing auth files.
 
 ## Verification
 
@@ -346,6 +347,7 @@ CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
 - Binding to `0.0.0.0` or `::` enables strict auth; local `/mcp` fails closed unless `require_token=true`.
 - `/mcp/operator` is bearer-token only with a remote-safe surface. Do not expose full `/mcp` externally.
 - Command-plane compatibility is retired from the supported product contract. Historical docs may still mention it, but new callers must not depend on it.
+- `doctor auth` is the first proof surface for role/bearer mismatches such as `codex cannot CanAdmin`.
 - See [docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md](docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md) and [docs/spec/09-server-transport.md](docs/spec/09-server-transport.md).
 
 ## Product and Planning Docs
@@ -371,7 +373,7 @@ CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
 | [docs/KEEPER-USER-MANUAL.md](docs/KEEPER-USER-MANUAL.md) | Keeper lifecycle and troubleshooting |
 | [docs/SUPERVISOR-MODE.md](docs/SUPERVISOR-MODE.md) | Supervised execution / operator workflow |
 | [docs/OAS-MASC-BOUNDARY.md](docs/OAS-MASC-BOUNDARY.md) | OAS/MASC ownership boundary |
-| [docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md](docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md) | Dashboard auth bootstrap |
+| [docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md](docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md) | Dashboard auth bootstrap, `doctor auth`, and admin bearer runbook |
 | [docs/spec/SPEC-INDEX.md](docs/spec/SPEC-INDEX.md) | Spec suite (19 specs) |
 | [ROADMAP.md](ROADMAP.md) | Version, release truth, active tracks |
 | [docs/PRODUCT-OPERATING-PLAN.md](docs/PRODUCT-OPERATING-PLAN.md) | Product promise, execution tracks |

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -29,6 +29,7 @@ module Dashboard_mission = Masc_mcp.Dashboard_mission
 module Dashboard_mission_briefing = Masc_mcp.Dashboard_mission_briefing
 module Build_identity = Masc_mcp.Build_identity
 module Config_doctor = Masc_mcp.Config_doctor
+module Auth_doctor = Masc_mcp.Auth_doctor
 module Graphql_api = Masc_mcp.Graphql_api
 module Types = Types
 module Tempo = Masc_mcp.Tempo
@@ -637,6 +638,22 @@ let doctor_cmd_exit base_path as_json =
   print_endline output;
   Config_doctor.exit_code report
 
+let doctor_auth_cmd_exit base_path as_json =
+  let report =
+    Auth_doctor.analyze
+      ~base_path_input:base_path
+      ~default_base_path:(default_base_path ())
+      ()
+  in
+  let output =
+    if as_json then
+      Auth_doctor.to_yojson report |> Yojson.Safe.pretty_to_string
+    else
+      Auth_doctor.render_text report
+  in
+  print_endline output;
+  Auth_doctor.exit_code report
+
 let doctor_sidecar_exit name as_json =
   match Masc_mcp.Doctor_dispatch.sidecar_dir name with
   | None ->
@@ -711,6 +728,13 @@ let doctor_config_cmd =
   in
   let info = Cmd.info "config" ~doc in
   Cmd.v info Term.(const doctor_cmd_exit $ base_path $ doctor_json)
+
+let doctor_auth_cmd =
+  let doc =
+    "Diagnose auth mode, bearer readiness, and role/permission mismatches"
+  in
+  let info = Cmd.info "auth" ~doc in
+  Cmd.v info Term.(const doctor_auth_cmd_exit $ base_path $ doctor_json)
 
 let doctor_sidecar_cmd =
   let doc =
@@ -867,7 +891,7 @@ let doctor_cmd =
   Cmd.group
     ~default:Term.(const doctor_cmd_exit $ base_path $ doctor_json)
     info
-    [ doctor_config_cmd; doctor_sidecar_cmd; doctor_all_cmd ]
+    [ doctor_config_cmd; doctor_auth_cmd; doctor_sidecar_cmd; doctor_all_cmd ]
 
 let init_force =
   let doc = "Overwrite existing config files instead of skipping them" in

--- a/docs/CONFIG-DOCTOR.md
+++ b/docs/CONFIG-DOCTOR.md
@@ -1,6 +1,6 @@
 ---
 status: runbook
-last_verified: 2026-04-17
+last_verified: 2026-04-23
 code_refs:
   - bin/main_eio.ml
   - lib/config/
@@ -37,10 +37,13 @@ JSON output for automation:
 
 ```bash
 ./_build/default/bin/main_eio.exe doctor config --base-path "$PWD"
+./_build/default/bin/main_eio.exe doctor auth --base-path "$PWD"
 ./_build/default/bin/main_eio.exe doctor sidecar <discord|slack|telegram|imessage|cli>
 ```
 
 Sidecar dispatch 는 `docs/DOCTOR-ARCHITECTURE.md` 의 "Dispatch" 섹션 참조.
+`codex cannot CanAdmin` 같은 auth/bearer mismatch 는 이 문서 범위가 아니며,
+`doctor auth` + `docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md` 를 사용한다.
 
 Typical results:
 

--- a/docs/DOCTOR-ARCHITECTURE.md
+++ b/docs/DOCTOR-ARCHITECTURE.md
@@ -1,10 +1,11 @@
 ---
 status: design
-last_verified: 2026-04-19
+last_verified: 2026-04-23
 code_refs:
   - sidecars/shared/gate_shared/doctor.py
   - sidecars/discord-bot/src/doctor.py
   - bin/main_eio.ml
+  - lib/auth_doctor.ml
   - lib/doctor_dispatch.ml
   - lib/server/server_routes_http_routes_dashboard.ml
   - dashboard/src/components/doctor-panel.ts
@@ -129,6 +130,7 @@ class AutoFix:
 | 계층 | Doctor | 구현 상태 |
 |------|--------|-----------|
 | OCaml 서버 | `masc-mcp doctor config` — 베이스 경로 / 활성 config root | 운영 중 (`docs/CONFIG-DOCTOR.md`) |
+| OCaml 서버 | `masc-mcp doctor auth` — auth mode / admin bearer readiness / role mismatch | 운영 중 (`docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md`) |
 | Discord sidecar | `masc-mcp doctor sidecar discord` ↔ `python -m src doctor` | 운영 중 |
 | Slack sidecar | `masc-mcp doctor sidecar slack` ↔ `python -m src doctor` | 운영 중 |
 | Telegram sidecar | `masc-mcp doctor sidecar telegram` ↔ `python -m src doctor` | 운영 중 |
@@ -143,12 +145,17 @@ class AutoFix:
 ```
 masc-mcp doctor                     # default → config (backward-compat)
 masc-mcp doctor config              # base path / config root 진단
+masc-mcp doctor auth                # auth/bearer/role mismatch 진단
 masc-mcp doctor sidecar <name>      # python -m src doctor 를 해당 sidecar 디렉터리에서 실행
 masc-mcp doctor sidecar <name> --json
 masc-mcp doctor all                 # config + 5 sidecar 연쇄 실행 + aggregate 요약
 ```
 
 지원 sidecar 이름: `discord`, `slack`, `telegram`, `imessage`, `cli`.
+
+`doctor all` 은 현재 `config + registered sidecars` aggregate 만 포함한다.
+`auth` 는 로컬 operator 증상(`cannot CanAdmin`, dev-token bootstrap, worker/admin role drift)
+을 다루는 명시적 서브커맨드로 유지한다.
 
 구현은 `lib/doctor_dispatch.ml` (pure mapping + `aggregate_exit_code`) +
 `bin/main_eio.ml` 의 `doctor_sidecar_exit` / `doctor_all_exit`. Python 실행

--- a/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
+++ b/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
@@ -59,7 +59,34 @@ For dashboard-side keeper lifecycle control, the target shape is:
 }
 ```
 
-## 3. Supported Local Start
+## 3. Run `doctor auth`
+
+Use the auth doctor before editing tokens or role files:
+
+```bash
+BASE_PATH="${MASC_BASE_PATH:-$HOME}"
+./_build/default/bin/main_eio.exe doctor auth --base-path "$BASE_PATH"
+```
+
+Useful interpretations:
+
+- `codex is role=worker, so requests authenticated as codex cannot satisfy CanAdmin.`
+  - your bearer is valid, but it is the wrong role for admin-only routes
+- `codex-mcp-client is role=worker, so dashboard save flows using that bearer will fail on admin-only routes such as POST /api/v1/cascade/config/raw.`
+  - the dashboard is presenting a worker bearer, so raw cascade save is expected to 403
+- `token_bound_admin_http_ready: no`
+  - room auth may be enabled, but no usable admin bearer source was found
+- `dashboard_dev_token: available=yes`
+  - the easiest local bootstrap path is `GET /api/v1/dashboard/dev-token`
+
+If you want structured output for automation:
+
+```bash
+./_build/default/bin/main_eio.exe doctor auth --base-path "$BASE_PATH" --json \
+  | jq '{status,warnings,next_actions}'
+```
+
+## 4. Supported Local Start
 
 When running from a worktree but using a shared local coordination root, start the server with an explicit base path:
 
@@ -74,11 +101,20 @@ MASC_BASE_PATH="$BASE_PATH" \
 
 Then run `./_build/default/bin/main_eio.exe doctor --base-path "$BASE_PATH"` and re-check `/health` to confirm the effective base path is the path you intended.
 
-## 4. Bootstrap an Admin Bearer
+## 5. Bootstrap an Admin Bearer
 
-If you already have an admin bearer, skip to step 5.
+If you already have an admin bearer, skip to step 6.
 
-If you do not, the reliable local fallback is to seed the auth store directly.
+If `doctor auth` says `dashboard_dev_token: available=yes`, the easiest local path is the dev-token bootstrap:
+
+```bash
+TOKEN="$(curl -sS http://127.0.0.1:8935/api/v1/dashboard/dev-token | jq -r '.token')"
+printf 'token=%s\n' "$TOKEN"
+```
+
+This endpoint is loopback-only and disabled when HTTP strict auth is enabled.
+
+If you do not have that path, the reliable local fallback is to seed the auth store directly.
 
 1. Back up the auth config:
 
@@ -139,13 +175,15 @@ Notes:
 - keep the raw bearer outside the repo
 - this is for trusted local operator use, not a remote/public bootstrap path
 
-## 5. Open the Dashboard as Admin
+## 6. Open the Dashboard as Admin
 
 Pass the token once via query string. The dashboard moves it into `sessionStorage` and removes it from the URL.
 
 ```text
 http://127.0.0.1:8935/dashboard?agent=codex-tool-matrix&token=<raw-token>
 ```
+
+For a dev-token bootstrap, use `agent=dashboard-dev` instead.
 
 You can verify the session with:
 
@@ -162,9 +200,30 @@ Expected:
 - `effective_agent="codex-tool-matrix"`
 - `effective_role="admin"`
 
-## 6. Verify Keeper Lifecycle Routes
+## 7. Verify Admin-Only Routes
 
 Use a low-risk keeper first.
+
+Raw cascade save:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8935/api/v1/cascade/config/raw \
+  -H "Authorization: Bearer <raw-token>" \
+  -H "X-MASC-Agent: <admin-agent>" \
+  -H "Content-Type: application/json" \
+  -d @payload.json
+```
+
+`payload.json`:
+
+```json
+{
+  "source_text": "{ ...raw cascade json... }"
+}
+```
+
+If the request is authenticated as `codex` or `codex-mcp-client` with `role=worker`,
+this route should fail with a `CanAdmin` error by design.
 
 Boot:
 
@@ -191,7 +250,7 @@ curl -sS http://127.0.0.1:8935/api/v1/dashboard/execution \
   | jq '.keepers[] | select(.name=="<keeper>") | {name,status,paused,trace_id,active_model}'
 ```
 
-## 7. Rollback
+## 8. Rollback
 
 If you need to go back to anonymous loopback behavior:
 
@@ -207,7 +266,9 @@ mv "$BASE_PATH/.masc/auth/config.json.bak" "$BASE_PATH/.masc/auth/config.json"
 rm -f "$BASE_PATH/.masc/auth/agents/codex-tool-matrix.json"
 ```
 
-## 8. Known Failure Modes
+If you used only `dashboard-dev` dev-token bootstrap, there may be no auth files to roll back.
+
+## 9. Known Failure Modes
 
 - `effective_base_path` points somewhere else:
   you edited the wrong `.masc/auth` tree
@@ -215,5 +276,7 @@ rm -f "$BASE_PATH/.masc/auth/agents/codex-tool-matrix.json"
   dashboard keeper boot/config/shutdown remains blocked even with auth enabled
 - `effective_role=worker`:
   your bearer is valid but not admin
+- `codex cannot CanAdmin` or `codex-mcp-client is role=worker`:
+  the request is authenticated with a worker bearer; rerun `doctor auth` and switch to an admin bearer
 - `{"error":"not found"}` on keeper boot/shutdown:
   you may still be running an older server build without the fixed route classifier

--- a/lib/auth_doctor.ml
+++ b/lib/auth_doctor.ml
@@ -1,0 +1,513 @@
+open Types
+
+type status =
+  | Ok
+  | Warn
+  | Error
+
+type watched_agent = {
+  agent_name : string;
+  credential_present : bool;
+  credential_role : string option;
+  can_admin : bool option;
+  expires_at : string option;
+  raw_token_file_present : bool;
+}
+
+type t = {
+  status : status;
+  base_path : string;
+  auth_dir : string;
+  auth_config_path : string;
+  auth_enabled : bool;
+  require_token : bool;
+  default_role : string;
+  initial_admin : string option;
+  bind_host : string;
+  bind_is_loopback : bool;
+  http_auth_strict : bool;
+  dashboard_dev_token_available : bool;
+  dashboard_dev_token_file_present : bool;
+  admin_token_env_configured : bool;
+  admin_token_env_status : string;
+  admin_token_env_agent : string option;
+  admin_token_env_role : string option;
+  token_bound_admin_http_ready : bool;
+  admin_bearer_sources : string list;
+  credential_count : int;
+  role_counts : (string * int) list;
+  watched_agents : watched_agent list;
+  warnings : string list;
+  next_actions : string list;
+}
+
+type admin_token_env_state =
+  | Env_unset
+  | Env_invalid_or_expired
+  | Env_non_admin of agent_credential
+  | Env_admin of agent_credential
+
+let status_to_string = function
+  | Ok -> "ok"
+  | Warn -> "warn"
+  | Error -> "error"
+
+let canonicalize_path path =
+  try Unix.realpath path with
+  | Unix.Unix_error _ | Sys_error _ | Invalid_argument _ -> path
+
+let file_exists path =
+  try Sys.file_exists path with
+  | Sys_error _ -> false
+
+let dedupe_keep_order values =
+  let seen = Hashtbl.create (List.length values) in
+  List.filter
+    (fun value ->
+      if value = "" || Hashtbl.mem seen value then
+        false
+      else (
+        Hashtbl.replace seen value ();
+        true))
+    values
+
+let option_field name = function
+  | Some value -> (name, `String value)
+  | None -> (name, `Null)
+
+let raw_token_file_path ~auth_dir agent_name =
+  Filename.concat auth_dir (agent_name ^ ".token")
+
+let watched_agent_of_credential ~auth_dir agent_name credential_opt =
+  let raw_token_file_present =
+    file_exists (raw_token_file_path ~auth_dir agent_name)
+  in
+  match credential_opt with
+  | Some (cred : agent_credential) ->
+      {
+        agent_name;
+        credential_present = true;
+        credential_role = Some (agent_role_to_string cred.role);
+        can_admin = Some (has_permission cred.role CanAdmin);
+        expires_at = cred.expires_at;
+        raw_token_file_present;
+      }
+  | None ->
+      {
+        agent_name;
+        credential_present = false;
+        credential_role = None;
+        can_admin = None;
+        expires_at = None;
+        raw_token_file_present;
+      }
+
+let watched_agent_names ~initial_admin admin_token_env_agent =
+  [
+    Some "codex";
+    Some "codex-mcp-client";
+    Some "dashboard-dev";
+    Some "admin";
+    initial_admin;
+    admin_token_env_agent;
+  ]
+  |> List.filter_map Fun.id
+  |> dedupe_keep_order
+
+let admin_token_env_state ~base_path =
+  match Env_config_core.admin_token_opt () with
+  | None -> Env_unset
+  | Some raw_token -> (
+      match Auth.find_credential_by_token base_path ~token:raw_token with
+      | Ok cred ->
+          if has_permission cred.role CanAdmin then
+            Env_admin cred
+          else
+            Env_non_admin cred
+      | Error _ -> Env_invalid_or_expired)
+
+let admin_token_env_fields = function
+  | Env_unset -> ("unset", None, None)
+  | Env_invalid_or_expired -> ("invalid_or_expired", None, None)
+  | Env_non_admin cred ->
+      ( "non_admin",
+        Some cred.agent_name,
+        Some (agent_role_to_string cred.role) )
+  | Env_admin cred ->
+      ("admin", Some cred.agent_name, Some (agent_role_to_string cred.role))
+
+let role_counts_of_credentials credentials =
+  [ Reader; Worker; Admin ]
+  |> List.filter_map (fun role ->
+         let count =
+           List.fold_left
+             (fun acc cred -> if cred.role = role then acc + 1 else acc)
+             0 credentials
+         in
+         if count = 0 then
+           None
+         else
+           Some (agent_role_to_string role, count))
+
+let admin_bearer_sources ~auth_dir ~dashboard_dev_token_available
+    ~admin_token_env_state (credentials : agent_credential list) =
+  let env_sources =
+    match admin_token_env_state with
+    | Env_admin cred ->
+        [ Printf.sprintf "env:%s->%s"
+            Env_config_core.admin_token_env_key cred.agent_name ]
+    | Env_unset | Env_invalid_or_expired | Env_non_admin _ -> []
+  in
+  let dashboard_sources =
+    if dashboard_dev_token_available then
+      [ "dashboard_dev_endpoint" ]
+    else
+      []
+  in
+  let token_file_sources =
+    credentials
+    |> List.filter (fun (cred : agent_credential) ->
+           has_permission cred.role CanAdmin)
+    |> List.filter_map (fun (cred : agent_credential) ->
+           let token_file =
+             raw_token_file_path ~auth_dir cred.agent_name
+           in
+           if file_exists token_file then
+             Some (Printf.sprintf "token_file:%s" cred.agent_name)
+           else
+             None)
+  in
+  env_sources @ dashboard_sources @ token_file_sources
+  |> dedupe_keep_order
+
+let analyze ~base_path_input ~default_base_path () =
+  let normalized_base_path =
+    Env_config_core.normalize_masc_base_path_input base_path_input
+  in
+  let base_path =
+    let candidate =
+      if String.trim normalized_base_path = "" then
+        default_base_path
+      else
+        normalized_base_path
+    in
+    canonicalize_path candidate
+  in
+  let auth_dir = Auth.auth_dir base_path in
+  let auth_cfg = Auth.load_auth_config base_path in
+  let credentials = Auth.list_credentials base_path in
+  let initial_admin = Auth.read_initial_admin base_path in
+  let admin_token_env_state = admin_token_env_state ~base_path in
+  let admin_token_env_status, admin_token_env_agent, admin_token_env_role =
+    admin_token_env_fields admin_token_env_state
+  in
+  let bind_host = Server_auth.http_auth_bind_host () in
+  let bind_is_loopback = Server_auth.http_auth_bind_is_loopback () in
+  let http_auth_strict = Server_auth.http_auth_strict_enabled () in
+  let dashboard_dev_token_available =
+    bind_is_loopback && not http_auth_strict
+  in
+  let dashboard_dev_token_file_present =
+    file_exists (Filename.concat auth_dir "dashboard-dev.token")
+  in
+  let admin_bearer_sources =
+    admin_bearer_sources ~auth_dir ~dashboard_dev_token_available
+      ~admin_token_env_state credentials
+  in
+  let token_bound_admin_http_ready =
+    auth_cfg.enabled && auth_cfg.require_token && admin_bearer_sources <> []
+  in
+  let watched_agents =
+    watched_agent_names ~initial_admin admin_token_env_agent
+    |> List.map (fun agent_name ->
+           watched_agent_of_credential ~auth_dir agent_name
+             (Auth.load_credential base_path agent_name))
+  in
+  let admin_permission = show_permission CanAdmin in
+  let codex = Auth.load_credential base_path "codex" in
+  let codex_mcp_client =
+    Auth.load_credential base_path "codex-mcp-client"
+  in
+  let warnings =
+    [
+      (if not auth_cfg.enabled then
+         Some
+           "Room auth is disabled; token-bound admin HTTP mutation routes will reject until auth is enabled."
+       else
+         None);
+      (if auth_cfg.enabled && not auth_cfg.require_token then
+         Some
+           "Room auth does not require bearer tokens; token-bound admin HTTP mutation routes will reject until require_token=true."
+       else
+         None);
+      (match admin_token_env_state with
+       | Env_invalid_or_expired ->
+           Some
+             (Printf.sprintf
+                "%s is set, but it does not resolve to a live credential in this base path."
+                Env_config_core.admin_token_env_key)
+       | Env_non_admin cred ->
+           Some
+             (Printf.sprintf
+                "%s resolves to %s with role=%s, so it cannot satisfy %s."
+                Env_config_core.admin_token_env_key
+                cred.agent_name
+                (agent_role_to_string cred.role)
+                admin_permission)
+       | Env_unset | Env_admin _ -> None);
+      (if auth_cfg.enabled && auth_cfg.require_token
+          && not token_bound_admin_http_ready then
+         Some
+           "No usable admin bearer source was detected for token-bound admin HTTP mutation routes."
+       else
+         None);
+      (match codex with
+       | Some cred when not (has_permission cred.role CanAdmin) ->
+           Some
+             (Printf.sprintf
+                "codex is role=%s, so requests authenticated as codex cannot satisfy %s."
+                (agent_role_to_string cred.role)
+                admin_permission)
+       | _ -> None);
+      (match codex_mcp_client with
+       | Some cred when not (has_permission cred.role CanAdmin) ->
+           Some
+             (Printf.sprintf
+                "codex-mcp-client is role=%s, so dashboard save flows using that bearer will fail on admin-only routes such as POST /api/v1/cascade/config/raw."
+                (agent_role_to_string cred.role))
+       | _ -> None);
+      (if not dashboard_dev_token_available then
+         Some
+           "Dashboard dev-token bootstrap is unavailable because the bind host is non-loopback or HTTP strict auth is enabled."
+       else
+         None);
+    ]
+    |> List.filter_map Fun.id
+    |> dedupe_keep_order
+  in
+  let next_actions =
+    [
+      (if not auth_cfg.enabled then
+         Some
+           (Printf.sprintf
+              "Enable room auth and set require_token=true in %s before relying on admin HTTP mutation routes."
+              (Auth.auth_config_file base_path))
+       else
+         None);
+      (if auth_cfg.enabled && not auth_cfg.require_token then
+         Some
+           (Printf.sprintf
+              "Set require_token=true in %s so token-bound admin HTTP routes can authorize bearer tokens."
+              (Auth.auth_config_file base_path))
+       else
+         None);
+      (if auth_cfg.enabled && auth_cfg.require_token
+          && (match codex_mcp_client with
+              | Some cred -> not (has_permission cred.role CanAdmin)
+              | None -> false) then
+         Some
+           "Use dashboard-dev or another admin bearer for POST /api/v1/cascade/config/raw; the codex-mcp-client worker bearer cannot satisfy CanAdmin."
+       else
+         None);
+      (if auth_cfg.enabled && auth_cfg.require_token
+          && dashboard_dev_token_available then
+         Some
+           "On loopback dev setups, fetch an admin bearer from GET /api/v1/dashboard/dev-token before using admin-only dashboard actions."
+       else
+         None);
+      (if auth_cfg.enabled && auth_cfg.require_token
+          && not dashboard_dev_token_available then
+         Some
+           "Follow docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md to bootstrap an admin bearer under the live auth root."
+       else
+         None);
+      Some "Rerun `masc-mcp doctor auth` after editing auth files or rotating tokens.";
+    ]
+    |> List.filter_map Fun.id
+    |> dedupe_keep_order
+  in
+  let status =
+    if auth_cfg.enabled && auth_cfg.require_token
+       && not token_bound_admin_http_ready then
+      Error
+    else if warnings = [] then
+      Ok
+    else
+      Warn
+  in
+  {
+    status;
+    base_path;
+    auth_dir;
+    auth_config_path = Auth.auth_config_file base_path;
+    auth_enabled = auth_cfg.enabled;
+    require_token = auth_cfg.require_token;
+    default_role = agent_role_to_string auth_cfg.default_role;
+    initial_admin;
+    bind_host;
+    bind_is_loopback;
+    http_auth_strict;
+    dashboard_dev_token_available;
+    dashboard_dev_token_file_present;
+    admin_token_env_configured = Env_config_core.admin_token_opt () <> None;
+    admin_token_env_status;
+    admin_token_env_agent;
+    admin_token_env_role;
+    token_bound_admin_http_ready;
+    admin_bearer_sources;
+    credential_count = List.length credentials;
+    role_counts = role_counts_of_credentials credentials;
+    watched_agents;
+    warnings;
+    next_actions;
+  }
+
+let watched_agent_to_yojson agent =
+  `Assoc
+    [
+      ("agent_name", `String agent.agent_name);
+      ("credential_present", `Bool agent.credential_present);
+      (option_field "role" agent.credential_role);
+      ( "can_admin",
+        match agent.can_admin with
+        | Some value -> `Bool value
+        | None -> `Null );
+      (option_field "expires_at" agent.expires_at);
+      ("raw_token_file_present", `Bool agent.raw_token_file_present);
+    ]
+
+let to_yojson (report : t) =
+  `Assoc
+    [
+      ("status", `String (status_to_string report.status));
+      ("base_path", `String report.base_path);
+      ("auth_dir", `String report.auth_dir);
+      ("auth_config_path", `String report.auth_config_path);
+      ("auth_enabled", `Bool report.auth_enabled);
+      ("require_token", `Bool report.require_token);
+      ("default_role", `String report.default_role);
+      (option_field "initial_admin" report.initial_admin);
+      ("bind_host", `String report.bind_host);
+      ("bind_is_loopback", `Bool report.bind_is_loopback);
+      ("http_auth_strict", `Bool report.http_auth_strict);
+      ( "dashboard_dev_token",
+        `Assoc
+          [
+            ("available", `Bool report.dashboard_dev_token_available);
+            ("file_present", `Bool report.dashboard_dev_token_file_present);
+          ] );
+      ( "admin_token_env",
+        `Assoc
+          [
+            ("configured", `Bool report.admin_token_env_configured);
+            ("status", `String report.admin_token_env_status);
+            (option_field "agent" report.admin_token_env_agent);
+            (option_field "role" report.admin_token_env_role);
+          ] );
+      ("token_bound_admin_http_ready", `Bool report.token_bound_admin_http_ready);
+      ( "admin_bearer_sources",
+        `List (List.map (fun value -> `String value) report.admin_bearer_sources) );
+      ("credential_count", `Int report.credential_count);
+      ( "role_counts",
+        `Assoc
+          (List.map
+             (fun (role, count) -> (role, `Int count))
+             report.role_counts) );
+      ( "watched_agents",
+        `List (List.map watched_agent_to_yojson report.watched_agents) );
+      ("warnings", `List (List.map (fun value -> `String value) report.warnings));
+      ("next_actions", `List (List.map (fun value -> `String value) report.next_actions));
+    ]
+
+let render_text (report : t) =
+  let buf = Buffer.create 1024 in
+  let add_line line =
+    Buffer.add_string buf line;
+    Buffer.add_char buf '\n'
+  in
+  let yes_no value = if value then "yes" else "no" in
+  let option_value = Option.value ~default:"(unset)" in
+  add_line "MASC Auth Doctor";
+  add_line (Printf.sprintf "status: %s" (status_to_string report.status));
+  add_line (Printf.sprintf "base_path: %s" report.base_path);
+  add_line (Printf.sprintf "auth_dir: %s" report.auth_dir);
+  add_line (Printf.sprintf "auth_config_path: %s" report.auth_config_path);
+  add_line (Printf.sprintf "auth_enabled: %s" (yes_no report.auth_enabled));
+  add_line (Printf.sprintf "require_token: %s" (yes_no report.require_token));
+  add_line (Printf.sprintf "default_role: %s" report.default_role);
+  add_line
+    (Printf.sprintf "initial_admin: %s"
+       (option_value report.initial_admin));
+  add_line (Printf.sprintf "bind_host: %s" report.bind_host);
+  add_line
+    (Printf.sprintf "bind_is_loopback: %s"
+       (yes_no report.bind_is_loopback));
+  add_line
+    (Printf.sprintf "http_auth_strict: %s"
+       (yes_no report.http_auth_strict));
+  add_line
+    (Printf.sprintf "dashboard_dev_token: available=%s file_present=%s"
+       (yes_no report.dashboard_dev_token_available)
+       (yes_no report.dashboard_dev_token_file_present));
+  add_line
+    (Printf.sprintf
+       "admin_token_env: configured=%s status=%s agent=%s role=%s"
+       (yes_no report.admin_token_env_configured)
+       report.admin_token_env_status
+       (option_value report.admin_token_env_agent)
+       (option_value report.admin_token_env_role));
+  add_line
+    (Printf.sprintf "token_bound_admin_http_ready: %s"
+       (yes_no report.token_bound_admin_http_ready));
+  add_line
+    (Printf.sprintf "admin_bearer_sources: %s"
+       (match report.admin_bearer_sources with
+        | [] -> "(none)"
+        | values -> String.concat ", " values));
+  add_line
+    (Printf.sprintf "credential_count: %d" report.credential_count);
+  add_line
+    (Printf.sprintf "role_counts: %s"
+       (match report.role_counts with
+        | [] -> "(none)"
+        | values ->
+            values
+            |> List.map (fun (role, count) ->
+                   Printf.sprintf "%s=%d" role count)
+            |> String.concat ", "));
+  add_line "";
+  add_line "watched_agents:";
+  List.iter
+    (fun agent ->
+      add_line
+        (Printf.sprintf
+           "- %s: credential=%s role=%s can_admin=%s raw_token_file=%s expires_at=%s"
+           agent.agent_name
+           (yes_no agent.credential_present)
+           (option_value agent.credential_role)
+           (match agent.can_admin with
+            | Some value -> yes_no value
+            | None -> "(n/a)")
+           (yes_no agent.raw_token_file_present)
+           (option_value agent.expires_at)))
+    report.watched_agents;
+  if report.warnings <> [] then begin
+    add_line "";
+    add_line "warnings:";
+    List.iter
+      (fun warning -> add_line (Printf.sprintf "- %s" warning))
+      report.warnings
+  end;
+  if report.next_actions <> [] then begin
+    add_line "";
+    add_line "next_actions:";
+    List.iter
+      (fun action -> add_line (Printf.sprintf "- %s" action))
+      report.next_actions
+  end;
+  Buffer.contents buf |> String.trim
+
+let exit_code (report : t) =
+  match report.status with
+  | Ok -> 0
+  | Warn | Error -> 1

--- a/lib/auth_doctor.ml
+++ b/lib/auth_doctor.ml
@@ -60,6 +60,15 @@ let file_exists path =
   try Sys.file_exists path with
   | Sys_error _ -> false
 
+let read_nonempty_text_file path =
+  if not (file_exists path) then
+    None
+  else
+    try
+      let value = String.trim (Fs_compat.load_file path) in
+      if value = "" then None else Some value
+    with Sys_error _ -> None
+
 let dedupe_keep_order values =
   let seen = Hashtbl.create (List.length values) in
   List.filter
@@ -149,7 +158,19 @@ let role_counts_of_credentials credentials =
          else
            Some (agent_role_to_string role, count))
 
-let admin_bearer_sources ~auth_dir ~dashboard_dev_token_available
+let live_admin_token_file_source ~base_path ~auth_dir (cred : agent_credential) =
+  let token_file = raw_token_file_path ~auth_dir cred.agent_name in
+  match read_nonempty_text_file token_file with
+  | None -> None
+  | Some raw_token -> (
+      match Auth.find_credential_by_token base_path ~token:raw_token with
+      | Ok owner
+        when String.equal owner.agent_name cred.agent_name
+             && has_permission owner.role CanAdmin ->
+          Some (Printf.sprintf "token_file:%s" cred.agent_name)
+      | Ok _ | Error _ -> None)
+
+let admin_bearer_sources ~base_path ~auth_dir ~dashboard_dev_token_available
     ~admin_token_env_state (credentials : agent_credential list) =
   let env_sources =
     match admin_token_env_state with
@@ -168,14 +189,7 @@ let admin_bearer_sources ~auth_dir ~dashboard_dev_token_available
     credentials
     |> List.filter (fun (cred : agent_credential) ->
            has_permission cred.role CanAdmin)
-    |> List.filter_map (fun (cred : agent_credential) ->
-           let token_file =
-             raw_token_file_path ~auth_dir cred.agent_name
-           in
-           if file_exists token_file then
-             Some (Printf.sprintf "token_file:%s" cred.agent_name)
-           else
-             None)
+    |> List.filter_map (live_admin_token_file_source ~base_path ~auth_dir)
   in
   env_sources @ dashboard_sources @ token_file_sources
   |> dedupe_keep_order
@@ -211,8 +225,8 @@ let analyze ~base_path_input ~default_base_path () =
     file_exists (Filename.concat auth_dir "dashboard-dev.token")
   in
   let admin_bearer_sources =
-    admin_bearer_sources ~auth_dir ~dashboard_dev_token_available
-      ~admin_token_env_state credentials
+    admin_bearer_sources ~base_path ~auth_dir
+      ~dashboard_dev_token_available ~admin_token_env_state credentials
   in
   let token_bound_admin_http_ready =
     auth_cfg.enabled && auth_cfg.require_token && admin_bearer_sources <> []

--- a/lib/dune
+++ b/lib/dune
@@ -22,6 +22,7 @@
    auto_recall
    auto_responder
    auth
+   auth_doctor
    board
    board_core
    board_core_classify

--- a/test/dune
+++ b/test/dune
@@ -28,7 +28,7 @@
 ; Group 1: Pure synchronous tests
 ; ============================================================
 (tests
- (names test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_audit_log test_http_negotiation
+ (names test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_audit_log test_http_negotiation
         test_attempt_state
         test_sse test_cancellation test_graphql_api
         test_graphql_endpoint
@@ -142,7 +142,7 @@
         test_memory_hooks
         test_mid_turn_resume
         test_lockfree_atomic)
- (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_audit_log test_http_negotiation
+ (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_audit_log test_http_negotiation
           test_attempt_state
           test_sse test_cancellation test_graphql_api
           test_graphql_endpoint

--- a/test/test_auth_doctor.ml
+++ b/test/test_auth_doctor.ml
@@ -1,0 +1,146 @@
+open Alcotest
+open Masc_mcp
+
+let with_env key value f =
+  let prior = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match prior with
+      | Some v -> Unix.putenv key v
+      | None -> Unix.putenv key "")
+    f
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let contains_substring ~needle s =
+  let nl = String.length needle in
+  let sl = String.length s in
+  if nl = 0 || nl > sl then false
+  else
+    let limit = sl - nl in
+    let rec loop i =
+      if i > limit then false
+      else if String.sub s i nl = needle then true
+      else loop (i + 1)
+    in
+    loop 0
+
+let list_contains_substring ~needle values =
+  List.exists (contains_substring ~needle) values
+
+let save_credential_or_fail base_path ~agent_name ~role ~raw_token =
+  match
+    Auth.save_raw_token_credential base_path ~agent_name ~role ~raw_token
+  with
+  | Ok _ -> ()
+  | Error err ->
+      failf "failed to seed credential for %s: %s"
+        agent_name (Types.masc_error_to_string err)
+
+let test_warns_for_codex_worker_admin_route_mismatch () =
+  with_temp_dir "auth-doctor-warn" @@ fun base_path ->
+  let auth_cfg =
+    Types.
+      {
+        enabled = true;
+        room_secret_hash = None;
+        require_token = true;
+        default_role = Worker;
+        token_expiry_hours = 24;
+      }
+  in
+  Auth.save_auth_config base_path auth_cfg;
+  save_credential_or_fail base_path ~agent_name:"codex" ~role:Types.Worker
+    ~raw_token:"codex-token";
+  save_credential_or_fail base_path ~agent_name:"codex-mcp-client"
+    ~role:Types.Worker ~raw_token:"codex-mcp-token";
+  save_credential_or_fail base_path ~agent_name:"dashboard-dev"
+    ~role:Types.Admin ~raw_token:"dashboard-dev-token";
+  with_env "MASC_HOST" "127.0.0.1" @@ fun () ->
+  with_env "MASC_HTTP_AUTH_STRICT" "" @@ fun () ->
+  with_env "MASC_ADMIN_TOKEN" "" @@ fun () ->
+  let report =
+    Auth_doctor.analyze ~base_path_input:base_path
+      ~default_base_path:base_path ()
+  in
+  check string "status" "warn"
+    (Auth_doctor.status_to_string report.status);
+  check bool "token-bound admin ready" true
+    report.token_bound_admin_http_ready;
+  check bool "dashboard dev endpoint available" true
+    report.dashboard_dev_token_available;
+  check bool "warns on codex worker" true
+    (list_contains_substring
+       ~needle:"codex is role=worker"
+       report.warnings);
+  check bool "warns on codex-mcp-client worker" true
+    (list_contains_substring
+       ~needle:"codex-mcp-client is role=worker"
+       report.warnings);
+  check bool "suggests admin bearer for cascade save" true
+    (list_contains_substring
+       ~needle:"Use dashboard-dev or another admin bearer"
+       report.next_actions)
+
+let test_errors_when_no_admin_bearer_source_exists () =
+  with_temp_dir "auth-doctor-error" @@ fun base_path ->
+  let auth_cfg =
+    Types.
+      {
+        enabled = true;
+        room_secret_hash = None;
+        require_token = true;
+        default_role = Worker;
+        token_expiry_hours = 24;
+      }
+  in
+  Auth.save_auth_config base_path auth_cfg;
+  save_credential_or_fail base_path ~agent_name:"codex" ~role:Types.Worker
+    ~raw_token:"codex-token";
+  with_env "MASC_HOST" "0.0.0.0" @@ fun () ->
+  with_env "MASC_HTTP_AUTH_STRICT" "1" @@ fun () ->
+  with_env "MASC_ADMIN_TOKEN" "" @@ fun () ->
+  let report =
+    Auth_doctor.analyze ~base_path_input:base_path
+      ~default_base_path:base_path ()
+  in
+  check string "status" "error"
+    (Auth_doctor.status_to_string report.status);
+  check bool "token-bound admin not ready" false
+    report.token_bound_admin_http_ready;
+  check bool "dashboard dev endpoint unavailable" false
+    report.dashboard_dev_token_available;
+  check bool "warns about missing admin bearer" true
+    (list_contains_substring
+       ~needle:"No usable admin bearer source was detected"
+       report.warnings);
+  check bool "next action points to runbook" true
+    (list_contains_substring
+       ~needle:"LOCAL-DASHBOARD-AUTH-RUNBOOK"
+       report.next_actions)
+
+let () =
+  run "auth_doctor"
+    [
+      ( "doctor",
+        [
+          test_case "warns for codex worker admin mismatch" `Quick
+            test_warns_for_codex_worker_admin_route_mismatch;
+          test_case "errors when no admin bearer source exists" `Quick
+            test_errors_when_no_admin_bearer_source_exists;
+        ] );
+    ]

--- a/test/test_auth_doctor.ml
+++ b/test/test_auth_doctor.ml
@@ -51,6 +51,9 @@ let save_credential_or_fail base_path ~agent_name ~role ~raw_token =
       failf "failed to seed credential for %s: %s"
         agent_name (Types.masc_error_to_string err)
 
+let raw_token_file base_path agent_name =
+  Filename.concat (Auth.auth_dir base_path) (agent_name ^ ".token")
+
 let test_warns_for_codex_worker_admin_route_mismatch () =
   with_temp_dir "auth-doctor-warn" @@ fun base_path ->
   let auth_cfg =
@@ -133,6 +136,42 @@ let test_errors_when_no_admin_bearer_source_exists () =
        ~needle:"LOCAL-DASHBOARD-AUTH-RUNBOOK"
        report.next_actions)
 
+let test_ignores_stale_admin_raw_token_file () =
+  with_temp_dir "auth-doctor-stale" @@ fun base_path ->
+  let auth_cfg =
+    Types.
+      {
+        enabled = true;
+        room_secret_hash = None;
+        require_token = true;
+        default_role = Worker;
+        token_expiry_hours = 24;
+      }
+  in
+  Auth.save_auth_config base_path auth_cfg;
+  save_credential_or_fail base_path ~agent_name:"admin" ~role:Types.Admin
+    ~raw_token:"live-admin-token";
+  Auth.save_private_text_file (raw_token_file base_path "admin")
+    "stale-admin-token";
+  with_env "MASC_HOST" "0.0.0.0" @@ fun () ->
+  with_env "MASC_HTTP_AUTH_STRICT" "1" @@ fun () ->
+  with_env "MASC_ADMIN_TOKEN" "" @@ fun () ->
+  let report =
+    Auth_doctor.analyze ~base_path_input:base_path
+      ~default_base_path:base_path ()
+  in
+  check string "status" "error"
+    (Auth_doctor.status_to_string report.status);
+  check bool "stale token file not counted as ready" false
+    report.token_bound_admin_http_ready;
+  check bool "stale token file omitted from admin bearer sources" false
+    (list_contains_substring ~needle:"token_file:admin"
+       report.admin_bearer_sources);
+  check bool "warns about missing usable admin bearer" true
+    (list_contains_substring
+       ~needle:"No usable admin bearer source was detected"
+       report.warnings)
+
 let () =
   run "auth_doctor"
     [
@@ -142,5 +181,7 @@ let () =
             test_warns_for_codex_worker_admin_route_mismatch;
           test_case "errors when no admin bearer source exists" `Quick
             test_errors_when_no_admin_bearer_source_exists;
+          test_case "ignores stale admin raw token file" `Quick
+            test_ignores_stale_admin_raw_token_file;
         ] );
     ]


### PR DESCRIPTION
## What changed
- add `masc-mcp doctor auth` to diagnose auth mode, admin bearer readiness, and role/permission mismatches
- add targeted auth-doctor tests covering the `codex`/`codex-mcp-client` worker vs `CanAdmin` failure mode
- update README and auth runbooks with `doctor auth`, dev-token bootstrap, and raw cascade save examples

## Why
Dashboard save failures like `codex cannot CanAdmin` were diagnosable in code, but not from the normal operator workflow. This adds a first-class doctor surface that explains whether the failure is caused by role mismatch, missing admin bearer sources, or strict auth/bootstrap constraints.

## Impact
Operators can now run `masc-mcp doctor auth` before editing auth files, and the docs point them to the right recovery path instead of treating this as a config-doctor problem.

## Root cause
Admin-only routes such as `POST /api/v1/cascade/config/raw` require `CanAdmin`, but common local bearers like `codex` and `codex-mcp-client` can legitimately be `worker`. Without an auth-focused doctor command, the resulting 403 looked opaque.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/doctor-auth-rbac --sandbox none bin/main_eio.exe test/test_auth_doctor.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/doctor-auth-rbac --sandbox none test/test_auth.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/doctor-auth-rbac test/test_auth_doctor.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/doctor-auth-rbac/_build_doctor_auth/default/bin/main_eio.exe doctor auth --help`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/doctor-auth-rbac/_build_doctor_auth/default/bin/main_eio.exe doctor auth --base-path /Users/dancer/me --json`
