### PR TITLE
feat(keeper): add per-provider timeout for cascade fallback

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -2256,6 +2256,7 @@ let run_turn
               natural completion (max_turns or model end_turn). *)
            ?oas_checkpoint:raw_oas_checkpoint
            ?event_bus
+           ?per_provider_timeout_s:meta.per_provider_timeout_s
            ())
      with
      | Error e -> Error e

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -162,9 +162,14 @@ let ensure_keeper_meta config name =
 
     (* --- Per-Provider Timeout --- *)
     let target_per_provider_timeout =
-      normalize_per_provider_timeout_opt
-        ~source:(Printf.sprintf "keeper runtime %s" name)
-        (apply_default_opt defaults.per_provider_timeout meta.per_provider_timeout_s)
+      match defaults.per_provider_timeout_state with
+      | Keeper_types_profile.Per_provider_timeout_unset ->
+          normalize_per_provider_timeout_opt
+            ~source:(Printf.sprintf "keeper runtime %s" name)
+            meta.per_provider_timeout_s
+      | Keeper_types_profile.Per_provider_timeout_invalid -> None
+      | Keeper_types_profile.Per_provider_timeout_set ->
+          defaults.per_provider_timeout
     in
 
     (* --- Change detection by category --- *)

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -160,6 +160,10 @@ let ensure_keeper_meta config name =
     let target_tf_window =
       apply_default_opt defaults.telemetry_feedback_window_hours meta.telemetry_feedback_window_hours in
 
+    (* --- Per-Provider Timeout --- *)
+    let target_per_provider_timeout =
+      apply_default_opt defaults.per_provider_timeout meta.per_provider_timeout_s in
+
     (* --- Change detection by category --- *)
     let proactive_changed =
       meta.proactive.enabled <> target_proactive
@@ -204,12 +208,14 @@ let ensure_keeper_meta config name =
     let telemetry_changed =
       meta.telemetry_feedback_enabled <> target_tf_enabled
       || meta.telemetry_feedback_window_hours <> target_tf_window in
+    let timeout_policy_changed =
+      meta.per_provider_timeout_s <> target_per_provider_timeout in
     let any_changed =
       proactive_changed || signal_changed || denylist_changed || models_changed
       || social_model_changed
       || cascade_changed
       || personality_changed || policy_changed || discovery_changed
-      || telemetry_changed in
+      || telemetry_changed || timeout_policy_changed in
 
     if any_changed then begin
       let cats = List.filter_map Fun.id [
@@ -223,6 +229,7 @@ let ensure_keeper_meta config name =
         (if policy_changed then Some "policy" else None);
         (if discovery_changed then Some "discovery" else None);
         (if telemetry_changed then Some "telemetry" else None);
+        (if timeout_policy_changed then Some "timeout_policy" else None);
       ] in
       Log.Keeper.info
         "ensure_keeper_meta: re-syncing [%s] for %s"
@@ -268,6 +275,7 @@ let ensure_keeper_meta config name =
         work_discovery_guidance = target_wd_guidance;
         telemetry_feedback_enabled = target_tf_enabled;
         telemetry_feedback_window_hours = target_tf_window;
+        per_provider_timeout_s = target_per_provider_timeout;
         updated_at = now_iso ();
       } in
       match write_meta config updated with

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -162,7 +162,10 @@ let ensure_keeper_meta config name =
 
     (* --- Per-Provider Timeout --- *)
     let target_per_provider_timeout =
-      apply_default_opt defaults.per_provider_timeout meta.per_provider_timeout_s in
+      normalize_per_provider_timeout_opt
+        ~source:(Printf.sprintf "keeper runtime %s" name)
+        (apply_default_opt defaults.per_provider_timeout meta.per_provider_timeout_s)
+    in
 
     (* --- Change detection by category --- *)
     let proactive_changed =

--- a/lib/keeper/keeper_toml_loader.ml
+++ b/lib/keeper/keeper_toml_loader.ml
@@ -479,6 +479,12 @@ let toml_int_opt (doc : toml_doc) (key : string) : int option =
   | _ -> None
 ;;
 
+let toml_float_opt (doc : toml_doc) (key : string) : float option =
+  match List.assoc_opt key doc with
+  | Some (Toml_float f) -> Some f
+  | _ -> None
+;;
+
 let toml_bool_opt (doc : toml_doc) (key : string) : bool option =
   match List.assoc_opt key doc with
   | Some (Toml_bool b) -> Some b

--- a/lib/keeper/keeper_toml_loader.mli
+++ b/lib/keeper/keeper_toml_loader.mli
@@ -27,6 +27,7 @@ val parse_toml : string -> (toml_doc, string) result
 
 val toml_string_opt : toml_doc -> string -> string option
 val toml_int_opt : toml_doc -> string -> int option
+val toml_float_opt : toml_doc -> string -> float option
 val toml_bool_opt : toml_doc -> string -> bool option
 val toml_string_list : toml_doc -> string -> string list
 

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -376,6 +376,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         work_discovery_guidance = p.profile_defaults.work_discovery_guidance;
         telemetry_feedback_enabled = p.profile_defaults.telemetry_feedback_enabled;
         telemetry_feedback_window_hours = p.profile_defaults.telemetry_feedback_window_hours;
+        per_provider_timeout_s = p.profile_defaults.per_provider_timeout;
         runtime = {
           usage = {
             total_turns = 0;

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -249,6 +249,7 @@ type keeper_meta =
   ; work_discovery_guidance : string option
   ; telemetry_feedback_enabled : bool option
   ; telemetry_feedback_window_hours : int option
+  ; per_provider_timeout_s : float option
   ; (* -- Agent runtime state (usage, tracing, autonomy metrics) -- *)
     runtime : agent_runtime_state
   }
@@ -883,6 +884,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; "work_discovery_guidance", Json_util.string_opt_to_json m.work_discovery_guidance
     ; "telemetry_feedback_enabled", Json_util.bool_opt_to_json m.telemetry_feedback_enabled
     ; "telemetry_feedback_window_hours", Json_util.int_opt_to_json m.telemetry_feedback_window_hours
+    ; "per_provider_timeout_s", Json_util.float_opt_to_json m.per_provider_timeout_s
     ]
 ;;
 
@@ -925,6 +927,7 @@ type parsed_keeper_policy =
   ; pp_voice_enabled : bool
   ; pp_voice_channel : string
   ; pp_voice_agent_id : string
+  ; pp_per_provider_timeout_s : float option
   }
 
 type parsed_keeper_state =
@@ -1141,6 +1144,9 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
         "voice_agent_id"
         json
     in
+    let pp_per_provider_timeout_s =
+      Safe_ops.json_float_opt "per_provider_timeout_s" json
+    in
     Ok
       { pp_policy_voice_enabled
       ; pp_sandbox_profile
@@ -1173,6 +1179,7 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
       ; pp_voice_enabled
       ; pp_voice_channel
       ; pp_voice_agent_id
+      ; pp_per_provider_timeout_s
       }
 ;;
 
@@ -1405,6 +1412,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
              ; voice_enabled = policy.pp_voice_enabled
              ; voice_channel = policy.pp_voice_channel
              ; voice_agent_id = policy.pp_voice_agent_id
+             ; per_provider_timeout_s = policy.pp_per_provider_timeout_s
              ; created_at =
                  (if state.ps_created_at_raw = ""
                   then now_iso ()
@@ -1538,6 +1546,7 @@ let fallback_canonical_keeper_meta_key_names =
   ; "work_discovery_guidance"
   ; "telemetry_feedback_enabled"
   ; "telemetry_feedback_window_hours"
+  ; "per_provider_timeout_s"
   ]
 ;;
 

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -1145,9 +1145,10 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
         json
     in
     let pp_per_provider_timeout_s =
-      normalize_per_provider_timeout_opt
+      normalize_per_provider_timeout_json_field
         ~source:(Printf.sprintf "keeper meta %s" keeper_name)
-        (Safe_ops.json_float_opt "per_provider_timeout_s" json)
+        ~field:"per_provider_timeout_s"
+        json
     in
     Ok
       { pp_policy_voice_enabled

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -1145,7 +1145,9 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
         json
     in
     let pp_per_provider_timeout_s =
-      Safe_ops.json_float_opt "per_provider_timeout_s" json
+      normalize_per_provider_timeout_opt
+        ~source:(Printf.sprintf "keeper meta %s" keeper_name)
+        (Safe_ops.json_float_opt "per_provider_timeout_s" json)
     in
     Ok
       { pp_policy_voice_enabled

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -197,6 +197,7 @@ type keeper_meta = {
   work_discovery_guidance : string option;
   telemetry_feedback_enabled : bool option;
   telemetry_feedback_window_hours : int option;
+  per_provider_timeout_s : float option;
   runtime: agent_runtime_state;
 }
 

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -274,6 +274,7 @@ type keeper_profile_defaults = {
   (* Telemetry Feedback — inject behavioral stats into keeper context *)
   telemetry_feedback_enabled : bool option;
   telemetry_feedback_window_hours : int option;
+  per_provider_timeout_state : per_provider_timeout_state;
   (* Per-provider timeout for cascade fallback. None = use turn budget heuristic. *)
   per_provider_timeout : float option;
   social_model : string option;
@@ -291,6 +292,11 @@ type keeper_profile_defaults = {
      build_args picks them up.  Empty list = no overrides. *)
   oas_env : (string * string) list;
 }
+
+and per_provider_timeout_state =
+  | Per_provider_timeout_unset
+  | Per_provider_timeout_invalid
+  | Per_provider_timeout_set
 
 type persona_summary = {
   persona_name : string;
@@ -333,6 +339,7 @@ let empty_keeper_profile_defaults = {
   work_discovery_guidance = None;
   telemetry_feedback_enabled = None;
   telemetry_feedback_window_hours = None;
+  per_provider_timeout_state = Per_provider_timeout_unset;
   per_provider_timeout = None;
   social_model = None;
   max_turns_per_call = None;
@@ -357,6 +364,52 @@ let normalize_per_provider_timeout_opt ~(source : string)
         source (string_of_float f);
       None
   | None -> None
+;;
+
+let per_provider_timeout_of_declared_float_opt ~(source : string)
+    ~(declared : bool)
+    (value : float option)
+    : per_provider_timeout_state * float option =
+  if not declared then
+    Per_provider_timeout_unset, None
+  else
+    match value with
+    | None ->
+        Log.Keeper.warn
+          "%s per_provider_timeout has invalid type; ignoring"
+          source;
+        Per_provider_timeout_invalid, None
+    | Some _ ->
+        (match normalize_per_provider_timeout_opt ~source value with
+         | Some f -> Per_provider_timeout_set, Some f
+         | None -> Per_provider_timeout_invalid, None)
+;;
+
+let per_provider_timeout_of_toml ~(source : string)
+    (doc : Keeper_toml_loader.toml_doc)
+    (key : string)
+    : per_provider_timeout_state * float option =
+  per_provider_timeout_of_declared_float_opt
+    ~source
+    ~declared:(List.mem_assoc key doc)
+    (Keeper_toml_loader.toml_float_opt doc key)
+;;
+
+let per_provider_timeout_of_json_field ~(source : string)
+    ~(field : string)
+    (json : Yojson.Safe.t)
+    : per_provider_timeout_state * float option =
+  per_provider_timeout_of_declared_float_opt
+    ~source
+    ~declared:(Option.is_some (Safe_ops.json_member_opt field json))
+    (Safe_ops.json_float_opt field json)
+;;
+
+let normalize_per_provider_timeout_json_field ~(source : string)
+    ~(field : string)
+    (json : Yojson.Safe.t)
+    : float option =
+  per_provider_timeout_of_json_field ~source ~field json |> snd
 ;;
 
 let personas_root_opt () =
@@ -441,6 +494,12 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
   let int_ key = Keeper_toml_loader.toml_int_opt doc (k key) in
   let strs key = Keeper_toml_loader.toml_string_list doc (k key) in
   let has key = List.mem_assoc (k key) doc in
+  let per_provider_timeout_state, per_provider_timeout =
+    per_provider_timeout_of_toml
+      ~source:"keeper TOML"
+      doc
+      (k "per_provider_timeout")
+  in
   let removed_present =
     ("also_allow" :: removed_keeper_input_key_names)
     |> List.map k
@@ -583,10 +642,8 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         work_discovery_guidance = str "work_discovery_guidance";
         telemetry_feedback_enabled = bool_ "telemetry_feedback_enabled";
         telemetry_feedback_window_hours = int_ "telemetry_feedback_window_hours";
-        per_provider_timeout =
-          normalize_per_provider_timeout_opt
-            ~source:"keeper TOML"
-            (Keeper_toml_loader.toml_float_opt doc (k "per_provider_timeout"));
+        per_provider_timeout_state;
+        per_provider_timeout;
         max_turns_per_call = int_ "max_turns_per_call";
         max_turns_per_call_scheduled_autonomous =
           int_ "max_turns_per_call_scheduled_autonomous";
@@ -727,6 +784,12 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
       | None -> empty_keeper_profile_defaults
       | Some json ->
           let keeper_json = Yojson.Safe.Util.member "keeper" json in
+          let per_provider_timeout_state, per_provider_timeout =
+            per_provider_timeout_of_json_field
+              ~source:(Printf.sprintf "persona profile %s" path)
+              ~field:"per_provider_timeout"
+              keeper_json
+          in
           match keeper_json with
           | `Assoc _ ->
               {
@@ -798,10 +861,8 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                   Safe_ops.json_bool_opt "telemetry_feedback_enabled" keeper_json;
                 telemetry_feedback_window_hours =
                   Safe_ops.json_int_opt "telemetry_feedback_window_hours" keeper_json;
-                per_provider_timeout =
-                  normalize_per_provider_timeout_opt
-                    ~source:(Printf.sprintf "persona profile %s" path)
-                    (Safe_ops.json_float_opt "per_provider_timeout" keeper_json);
+                per_provider_timeout_state;
+                per_provider_timeout;
                 max_turns_per_call =
                   Safe_ops.json_int_opt "max_turns_per_call" keeper_json;
                 max_turns_per_call_scheduled_autonomous =
@@ -845,6 +906,15 @@ let merge_keeper_profile_defaults
     ~(overlay : keeper_profile_defaults) : keeper_profile_defaults =
   let prefer overlay_value base_value =
     match overlay_value with Some _ -> overlay_value | None -> base_value
+  in
+  let per_provider_timeout_state, per_provider_timeout =
+    match overlay.per_provider_timeout_state with
+    | Per_provider_timeout_unset ->
+        base.per_provider_timeout_state, base.per_provider_timeout
+    | Per_provider_timeout_invalid ->
+        Per_provider_timeout_invalid, None
+    | Per_provider_timeout_set ->
+        Per_provider_timeout_set, overlay.per_provider_timeout
   in
   {
     manifest_path = prefer overlay.manifest_path base.manifest_path;
@@ -890,7 +960,8 @@ let merge_keeper_profile_defaults
     telemetry_feedback_window_hours =
       prefer overlay.telemetry_feedback_window_hours
         base.telemetry_feedback_window_hours;
-    per_provider_timeout = prefer overlay.per_provider_timeout base.per_provider_timeout;
+    per_provider_timeout_state;
+    per_provider_timeout;
     social_model = prefer overlay.social_model base.social_model;
     cascade_name = prefer overlay.cascade_name base.cascade_name;
     models = prefer overlay.models base.models;

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -274,6 +274,8 @@ type keeper_profile_defaults = {
   (* Telemetry Feedback — inject behavioral stats into keeper context *)
   telemetry_feedback_enabled : bool option;
   telemetry_feedback_window_hours : int option;
+  (* Per-provider timeout for cascade fallback. None = use turn budget heuristic. *)
+  per_provider_timeout : float option;
   social_model : string option;
   cascade_name : string option;
   models : string list option;
@@ -331,6 +333,7 @@ let empty_keeper_profile_defaults = {
   work_discovery_guidance = None;
   telemetry_feedback_enabled = None;
   telemetry_feedback_window_hours = None;
+  per_provider_timeout = None;
   social_model = None;
   max_turns_per_call = None;
   max_turns_per_call_scheduled_autonomous = None;
@@ -563,6 +566,14 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         work_discovery_guidance = str "work_discovery_guidance";
         telemetry_feedback_enabled = bool_ "telemetry_feedback_enabled";
         telemetry_feedback_window_hours = int_ "telemetry_feedback_window_hours";
+        per_provider_timeout =
+          (match Keeper_toml_loader.toml_float_opt doc (k "per_provider_timeout") with
+           | Some f when f > 0.0 -> Some f
+           | Some f when f <= 0.0 ->
+               Log.Keeper.warn
+                 "keeper TOML per_provider_timeout=%.1f is non-positive; ignoring" f;
+               None
+           | _ -> None);
         max_turns_per_call = int_ "max_turns_per_call";
         max_turns_per_call_scheduled_autonomous =
           int_ "max_turns_per_call_scheduled_autonomous";
@@ -613,6 +624,7 @@ let canonical_keeper_toml_key_names =
   ; "work_discovery_guidance"
   ; "telemetry_feedback_enabled"
   ; "telemetry_feedback_window_hours"
+  ; "per_provider_timeout"
   ; "max_turns_per_call"
   ; "max_turns_per_call_scheduled_autonomous"
   ; "social_model"
@@ -773,6 +785,8 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                   Safe_ops.json_bool_opt "telemetry_feedback_enabled" keeper_json;
                 telemetry_feedback_window_hours =
                   Safe_ops.json_int_opt "telemetry_feedback_window_hours" keeper_json;
+                per_provider_timeout =
+                  Safe_ops.json_float_opt "per_provider_timeout" keeper_json;
                 max_turns_per_call =
                   Safe_ops.json_int_opt "max_turns_per_call" keeper_json;
                 max_turns_per_call_scheduled_autonomous =
@@ -861,6 +875,7 @@ let merge_keeper_profile_defaults
     telemetry_feedback_window_hours =
       prefer overlay.telemetry_feedback_window_hours
         base.telemetry_feedback_window_hours;
+    per_provider_timeout = prefer overlay.per_provider_timeout base.per_provider_timeout;
     social_model = prefer overlay.social_model base.social_model;
     cascade_name = prefer overlay.cascade_name base.cascade_name;
     models = prefer overlay.models base.models;

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -342,6 +342,23 @@ let empty_keeper_profile_defaults = {
   oas_env = [];
 }
 
+let normalize_per_provider_timeout_opt ~(source : string)
+    (value : float option) : float option =
+  match value with
+  | Some f when Float.is_finite f && f > 0.0 -> Some f
+  | Some f when not (Float.is_finite f) ->
+      Log.Keeper.warn
+        "%s per_provider_timeout=%s is non-finite; ignoring"
+        source (string_of_float f);
+      None
+  | Some f ->
+      Log.Keeper.warn
+        "%s per_provider_timeout=%s is non-positive; ignoring"
+        source (string_of_float f);
+      None
+  | None -> None
+;;
+
 let personas_root_opt () =
   try
     Config_dir_resolver.log_warnings ~context:"KeeperTypesProfile" ();
@@ -567,13 +584,9 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         telemetry_feedback_enabled = bool_ "telemetry_feedback_enabled";
         telemetry_feedback_window_hours = int_ "telemetry_feedback_window_hours";
         per_provider_timeout =
-          (match Keeper_toml_loader.toml_float_opt doc (k "per_provider_timeout") with
-           | Some f when f > 0.0 -> Some f
-           | Some f when f <= 0.0 ->
-               Log.Keeper.warn
-                 "keeper TOML per_provider_timeout=%.1f is non-positive; ignoring" f;
-               None
-           | _ -> None);
+          normalize_per_provider_timeout_opt
+            ~source:"keeper TOML"
+            (Keeper_toml_loader.toml_float_opt doc (k "per_provider_timeout"));
         max_turns_per_call = int_ "max_turns_per_call";
         max_turns_per_call_scheduled_autonomous =
           int_ "max_turns_per_call_scheduled_autonomous";
@@ -786,7 +799,9 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                 telemetry_feedback_window_hours =
                   Safe_ops.json_int_opt "telemetry_feedback_window_hours" keeper_json;
                 per_provider_timeout =
-                  Safe_ops.json_float_opt "per_provider_timeout" keeper_json;
+                  normalize_per_provider_timeout_opt
+                    ~source:(Printf.sprintf "persona profile %s" path)
+                    (Safe_ops.json_float_opt "per_provider_timeout" keeper_json);
                 max_turns_per_call =
                   Safe_ops.json_int_opt "max_turns_per_call" keeper_json;
                 max_turns_per_call_scheduled_autonomous =

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -138,6 +138,7 @@ val run_named :
   ?event_bus:Oas.Event_bus.t ->
   ?sw:Eio.Switch.t ->
   ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?per_provider_timeout_s:float ->
   unit ->
   (run_result, Oas.Error.sdk_error) result
 

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -930,7 +930,14 @@ let run_named
               match per_provider_timeout_s with
               | None -> run_fn ()
               | Some t ->
-                  let clock_opt = (Masc_eio_env.get ()).clock in
+                  let clock_opt =
+                    match Masc_eio_env.get_opt () with
+                    | Some env -> (
+                        match env.clock with
+                        | Some _ as clock_opt -> clock_opt
+                        | None -> Eio_context.get_clock_opt ())
+                    | None -> Eio_context.get_clock_opt ()
+                  in
                   (match clock_opt with
                    | Some clock ->
                        (try Eio.Time.with_timeout_exn clock t run_fn

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -779,6 +779,7 @@ let run_named
     ?event_bus
     ?sw
     ?net
+    ?per_provider_timeout_s
     ()
   : (Oas_worker_exec.run_result, Oas.Error.sdk_error) result =
   match require_eio ?sw ?net () with
@@ -845,7 +846,7 @@ let run_named
      Immutable checkpoint threading: try_provider returns both the result
      and the agent's checkpoint (if progress was made). try_cascade
      threads this checkpoint to the next provider without mutable state. *)
-  let try_provider ?resume_checkpoint (provider_cfg : Llm_provider.Provider_config.t) =
+  let try_provider ?resume_checkpoint ?per_provider_timeout_s (provider_cfg : Llm_provider.Provider_config.t) =
     let config_result =
       Oas_worker_exec.resolve_tool_lane_for_oas_tools
         ?agent_name:(keeper_agent_name_opt keeper_name)
@@ -919,11 +920,26 @@ let run_named
               | Some _ -> resume_checkpoint
               | None -> oas_checkpoint
             in
-            let result =
+            let run_fn () =
               Oas_worker_exec.run ~sw ~net ~config
                 ?oas_checkpoint:effective_checkpoint ?on_event
                 ?on_yield ?on_resume ~agent_ref:local_agent_ref ?proof_ref
                 ?contract goal
+            in
+            let result =
+              match per_provider_timeout_s with
+              | None -> run_fn ()
+              | Some t ->
+                  let clock_opt = (Masc_eio_env.get ()).clock in
+                  (match clock_opt with
+                   | Some clock ->
+                       (try Eio.Time.with_timeout_exn clock t run_fn
+                        with Eio.Time.Timeout ->
+                          Log.Misc.info
+                            "[cascade-fallback] cascade %s: provider %s per-provider timeout after %.1fs, falling back"
+                            cascade_name provider_cfg.model_id t;
+                          Error (Oas.Error.Api (Timeout { message = Printf.sprintf "Per-provider timeout after %.1fs" t })))
+                   | None -> run_fn ())
             in
             Ok result)
     with
@@ -951,7 +967,7 @@ let run_named
   in
   let rec try_cascade
       ?(on_success = fun ~provider_key:_ -> ())
-      ?resume_checkpoint remaining last_err =
+      ?resume_checkpoint ?per_provider_timeout_s remaining last_err =
     match remaining with
     | [] ->
       let reason : Keeper_types.cascade_exhaustion_reason = match last_err with
@@ -1001,7 +1017,8 @@ let run_named
     | (provider_cfg : Llm_provider.Provider_config.t) :: rest ->
       let is_last = rest = [] in
       Log.Misc.debug "cascade %s: trying %s (is_last=%b)" cascade_name provider_cfg.model_id is_last;
-      let (result, checkpoint_after) = try_provider ?resume_checkpoint provider_cfg in
+      let pp_timeout = if is_last then None else per_provider_timeout_s in
+      let (result, checkpoint_after) = try_provider ?resume_checkpoint ?per_provider_timeout_s:pp_timeout provider_cfg in
       (* Thread checkpoint forward: if this provider made progress,
          the next provider can resume from where this one left off. *)
       let next_resume = match checkpoint_after with
@@ -1291,7 +1308,7 @@ let run_named
       let on_success ~provider_key =
         Cascade_strategy.record_choice strategy ~ctx:signal_ctx ~provider_key
       in
-      (match try_cascade ~on_success ordered None with
+      (match try_cascade ~on_success ?per_provider_timeout_s ordered None with
        | Ok _ as ok -> ok
        | Error _ as err when last_cycle -> err
        | Error _ ->

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -561,8 +561,107 @@ tool_preset = "delivery"
         (option string)
         "tool_preset from toml overlay"
         (Some "delivery")
-        (Keeper_types.tool_access_preset updated.tool_access
+      (Keeper_types.tool_access_preset updated.tool_access
          |> Option.map Keeper_types.tool_preset_to_string)
+
+let test_toml_invalid_per_provider_timeout_clears_stale_runtime () =
+  with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
+  with_config_dir @@ fun config_dir ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let keeper_name = "timeout-invalid-toml-test" in
+  let keepers_toml_dir = Filename.concat config_dir "keepers" in
+  Unix.mkdir keepers_toml_dir 0o755;
+  write_file
+    (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
+    {|[keeper]
+goal = "test"
+per_provider_timeout = 0
+|};
+  let config = Coord.default_config room_dir in
+  let initial_meta =
+    match
+      Keeper_types.meta_of_json
+        (`Assoc
+          [
+            ("name", `String keeper_name);
+            ("agent_name", `String keeper_name);
+            ("trace_id", `String "trace-timeout-invalid-toml");
+            ("per_provider_timeout_s", `Float 12.5);
+          ])
+    with
+    | Ok meta -> meta
+    | Error e -> fail ("meta_of_json failed: " ^ e)
+  in
+  (match Keeper_types.write_meta ~force:true config initial_meta with
+  | Error e -> fail ("write_meta failed: " ^ e)
+  | Ok () -> ());
+  match Keeper_runtime.ensure_keeper_meta config keeper_name with
+  | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
+  | Ok updated ->
+      check (option (float 0.0001)) "invalid TOML clears stale timeout"
+        None updated.Keeper_types.per_provider_timeout_s
+
+let test_persona_invalid_per_provider_timeout_clears_stale_runtime () =
+  with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
+  with_config_dir @@ fun config_dir ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let keeper_name = "timeout-invalid-persona-test" in
+  let personas_dir = Filename.concat config_dir "personas" in
+  let persona_dir = Filename.concat personas_dir keeper_name in
+  Unix.mkdir personas_dir 0o755;
+  Unix.mkdir persona_dir 0o755;
+  write_file
+    (Filename.concat persona_dir "profile.json")
+    {|{
+  "name": "timeout invalid persona",
+  "keeper": {
+    "goal": "test",
+    "per_provider_timeout": "oops"
+  }
+}|};
+  let config = Coord.default_config room_dir in
+  let initial_meta =
+    match
+      Keeper_types.meta_of_json
+        (`Assoc
+          [
+            ("name", `String keeper_name);
+            ("agent_name", `String keeper_name);
+            ("trace_id", `String "trace-timeout-invalid-persona");
+            ("per_provider_timeout_s", `Float 8.0);
+          ])
+    with
+    | Ok meta -> meta
+    | Error e -> fail ("meta_of_json failed: " ^ e)
+  in
+  (match Keeper_types.write_meta ~force:true config initial_meta with
+  | Error e -> fail ("write_meta failed: " ^ e)
+  | Ok () -> ());
+  match Keeper_runtime.ensure_keeper_meta config keeper_name with
+  | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
+  | Ok updated ->
+      check (option (float 0.0001)) "invalid persona clears stale timeout"
+        None updated.Keeper_types.per_provider_timeout_s
+
+let test_meta_of_json_invalid_per_provider_timeout_is_ignored () =
+  match
+    Keeper_types.meta_of_json
+      (`Assoc
+        [
+          ("name", `String "meta-timeout-invalid-test");
+          ("agent_name", `String "meta-timeout-invalid-test");
+          ("trace_id", `String "trace-meta-timeout-invalid");
+          ("per_provider_timeout_s", `String "oops");
+        ])
+  with
+  | Error e -> fail ("meta_of_json failed: " ^ e)
+  | Ok meta ->
+      check (option (float 0.0001)) "invalid persisted meta timeout ignored"
+        None meta.Keeper_types.per_provider_timeout_s
 
 (** Test: fields absent from TOML (None) preserve runtime JSON values. *)
 let test_none_preserves_runtime () =
@@ -934,6 +1033,18 @@ let () =
             "persona defaults can be overlaid by keeper TOML"
             `Quick
             test_persona_overlay_resync;
+          test_case
+            "invalid TOML per_provider_timeout clears stale runtime JSON"
+            `Quick
+            test_toml_invalid_per_provider_timeout_clears_stale_runtime;
+          test_case
+            "invalid persona per_provider_timeout clears stale runtime JSON"
+            `Quick
+            test_persona_invalid_per_provider_timeout_clears_stale_runtime;
+          test_case
+            "invalid persisted per_provider_timeout is ignored on parse"
+            `Quick
+            test_meta_of_json_invalid_per_provider_timeout_is_ignored;
         ] );
       ( "none_preserve",
         [

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -189,6 +189,21 @@ let start_multi_mock ~sw ~net ~port (responses : string list) =
       Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
   Printf.sprintf "http://127.0.0.1:%d" port
 
+let start_delayed_mock ~sw ~net ~clock ~port ~delay_s response =
+  let handler _conn _req body =
+    let _ = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
+    if delay_s > 0.0 then Eio.Time.sleep clock delay_s;
+    Cohttp_eio.Server.respond_string ~status:`OK ~body:response ()
+  in
+  let socket =
+    Eio.Net.listen net ~sw ~backlog:8 ~reuse_addr:true
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+  in
+  let server = Cohttp_eio.Server.make ~callback:handler () in
+  Eio.Fiber.fork ~sw (fun () ->
+      Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+  Printf.sprintf "http://127.0.0.1:%d" port
+
 let find_free_port () =
   let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
   Fun.protect
@@ -834,6 +849,81 @@ let test_default_config_preserves_custom_local_request_path () =
   | _ ->
     Alcotest.fail
       "custom local OpenAI-compatible provider should stay OpenAICompat"
+
+let test_run_named_per_provider_timeout_uses_clock_fallback_and_exempts_last_provider () =
+  Alcotest.(check bool) "test requires no global Masc_eio_env"
+    true
+    (Option.is_none (Masc_eio_env.get_opt ()));
+  try
+    Eio.Switch.run @@ fun sw ->
+    let clock =
+      match Process_eio.get_clock () with
+      | Ok clock -> clock
+      | Error err -> Alcotest.fail err
+    in
+    Eio_context.set_clock clock;
+    let first_port =
+      match find_free_port () with Some port -> port | None -> Alcotest.skip ()
+    in
+    let second_port =
+      match find_free_port () with Some port -> port | None -> Alcotest.skip ()
+    in
+    let first_url =
+      try
+        start_delayed_mock
+          ~sw
+          ~net:(require_test_net ())
+          ~clock
+          ~port:first_port
+          ~delay_s:0.2
+          (openai_text_response "first provider should timeout")
+      with
+      | Unix.Unix_error (Unix.EPERM, "bind", _)
+      | Unix.Unix_error (Unix.EACCES, "bind", _) ->
+          Alcotest.skip ()
+    in
+    let second_url =
+      try
+        start_delayed_mock
+          ~sw
+          ~net:(require_test_net ())
+          ~clock
+          ~port:second_port
+          ~delay_s:0.2
+          (openai_text_response "last provider survived timeout")
+      with
+      | Unix.Unix_error (Unix.EPERM, "bind", _)
+      | Unix.Unix_error (Unix.EACCES, "bind", _) ->
+          Alcotest.skip ()
+    in
+    with_temp_masc_config
+      (Printf.sprintf
+         {|{
+  "timeout_probe_models": [
+    "custom:slow@%s",
+    "custom:last@%s"
+  ]
+}|}
+         first_url
+         second_url)
+    @@ fun () ->
+    match
+      Oas_worker_named.run_named
+        ~cascade_name:"timeout_probe"
+        ~goal:"say hello"
+        ~system_prompt:"system"
+        ~sw
+        ~net:(require_test_net ())
+        ~per_provider_timeout_s:0.05
+        ()
+    with
+    | Ok result ->
+        Alcotest.(check string) "last provider succeeds without timeout"
+          "last provider survived timeout"
+          (response_text result.response);
+        Eio.Switch.fail sw Exit
+    | Error err -> Alcotest.fail (Oas.Error.to_string err)
+  with Exit -> ()
 
 let make_worker_meta ?(effective_model = "local-qwen") () :
     Worker_container_types.worker_container_meta =
@@ -3048,6 +3138,8 @@ let () =
         test_enrich_sdk_error_for_openai_not_found_includes_endpoint_hint;
       Alcotest.test_case "default_config preserves custom local request_path" `Quick
         test_default_config_preserves_custom_local_request_path;
+      Alcotest.test_case "per-provider timeout uses context clock and exempts last provider" `Quick
+        test_run_named_per_provider_timeout_uses_clock_fallback_and_exempts_last_provider;
     ];
     "resume_config", [
       Alcotest.test_case "checkpoint model wins" `Quick


### PR DESCRIPTION
## Summary

Adds `per_provider_timeout_s` to `keeper_meta` so that each provider in a cascade has an individual deadline. When a provider hangs, the keeper falls back to the next tier within seconds instead of burning the entire 1200s turn budget.

## Problem

`Keeper_llm_bridge.run_with_timeout_and_fallback` wraps the *entire* OAS `Agent.run` with a single `timeout_s` (default 1200s). Inside OAS, `try_cascade` attempts providers sequentially, but if provider #1 hangs, the total budget is consumed by the first provider and the remaining providers never get a chance.

## Solution

Option A (MASC layer, before OAS entry):
- Add `per_provider_timeout_s : float option` to `keeper_meta` (TOML key: `per_provider_timeout`).
- `try_provider` in `oas_worker_named.ml` wraps `Oas_worker_exec.run` with `Eio.Time.with_timeout_exn` when the value is set.
- On timeout, return `Oas.Error.Api (Llm_provider.Retry.Timeout ...)` which `try_cascade` treats as a standard fallback trigger via `sdk_error_to_cascade_outcome` → `Cascade_fsm.Try_next`.
- The last provider in a cascade is exempt (`is_last`) so it can consume any remaining total budget (fail-open).

## Changes

| File | What |
|------|------|
| `keeper_types.mli/ml` | `per_provider_timeout_s` field + JSON round-trip |
| `keeper_types_profile.ml` | TOML parsing, merge, validation (>0) |
| `keeper_runtime.ml` | Re-sync `timeout_policy` in `ensure_keeper_meta` |
| `keeper_agent_run.ml` | Pass `per_provider_timeout_s` into `run_named` |
| `oas_worker_named.ml` | `try_provider` timeout wrapper; last provider exempt |

## Verification

- [x] `dune build` succeeds
- [x] `test_server_runtime_bootstrap` 48 tests pass
- [x] Code path audit: `None` path is identical to pre-change behavior (no regression)

## Test plan (post-merge e2e)

- [ ] Set `per_provider_timeout = 60.0` in keeper TOML, boot, verify `per_provider_timeout_s` appears in meta JSON
- [ ] Black-hole first provider in `big_three`, confirm fallback to second provider within ~65s
- [ ] Confirm log line: `[cascade-fallback] cascade big_three: provider <model> per-provider timeout after 60.0s, falling back`
- [ ] Confirm last provider consumes remaining total budget without per-provider cutoff