### PR TITLE
fix(startup): sync bootable keeper credentials

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -642,6 +642,34 @@ let sync_client_token_file ~base_path ~agent_name ~default_role =
       | Error _ -> create_and_persist ~reason:"repaired")
   | None -> create_and_persist ~reason:"created"
 
+let sync_bootable_keeper_credentials (state : Mcp_server.server_state) =
+  let base_path = state.Mcp_server.room_config.base_path in
+  let keeper_names =
+    Keeper_runtime.bootable_keeper_names state.Mcp_server.room_config
+  in
+  let synced_count, failed =
+    List.fold_left
+      (fun (synced_count, failed) keeper_name ->
+        let agent_name =
+          Keeper_types_profile.keeper_agent_name keeper_name
+        in
+        match Auth.ensure_keeper_credential base_path ~agent_name with
+        | Ok _ -> (synced_count + 1, failed)
+        | Error err ->
+            ( synced_count,
+              (keeper_name, Types.masc_error_to_string err) :: failed ))
+      (0, []) keeper_names
+  in
+  if synced_count > 0 then
+    Log.Server.info
+      "startup verified %d bootable keeper credential(s)"
+      synced_count;
+  List.rev failed
+  |> List.iter (fun (keeper_name, detail) ->
+         Log.Server.error
+           "startup keeper credential sync failed for %s: %s"
+           keeper_name detail)
+
 let bootstrap_prompt_state (state : Mcp_server.server_state) =
   Config_dir_resolver.log_warnings ~context:"ServerBootstrap" ();
   Config_dir_resolver.log_resolution ~context:"ServerBootstrap" ();
@@ -950,6 +978,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       sync_admin_token_env state;
       sync_client_token_file ~base_path ~agent_name:"codex-mcp-client"
         ~default_role:Types.Worker;
+      sync_bootable_keeper_credentials state;
       let path_diagnostics =
         runtime_path_diagnostics ~input_base_path:base_path state
       in

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -58,6 +58,7 @@ val migrate_legacy_dirs : Mcp_server.server_state -> unit
 val startup_prune_jsonl : Mcp_server.server_state -> unit
 val startup_prune_keeper_checkpoints : Mcp_server.server_state -> unit
 val startup_migrate_keeper_histories : Mcp_server.server_state -> unit
+val sync_bootable_keeper_credentials : Mcp_server.server_state -> unit
 
 (** {1 Main Entry Point} *)
 

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1627,6 +1627,51 @@ let test_main_eio_self_heals_codex_mcp_token_file () =
               Alcotest.failf "repaired raw token should verify: %s"
                 (Types.masc_error_to_string err)))
 
+let test_sync_bootable_keeper_credentials_mints_keeper_alias_token () =
+  with_temp_dir "startup-keeper-credential-sync" (fun dir ->
+      with_env "MASC_CONFIG_DIR" None @@ fun () ->
+      with_env "MASC_PERSONAS_DIR" None @@ fun () ->
+      with_cwd (project_root ()) @@ fun () ->
+      Server_runtime_bootstrap.bootstrap_base_path_config_root ~base_path:dir;
+      write_basepath_keeper_toml dir "masc-improver";
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let clock, mono_clock, net, _domain_mgr, proc_mgr, fs =
+        Server_runtime_bootstrap.init_runtime_context env
+      in
+      Eio.Switch.run @@ fun sw ->
+      let state =
+        Server_runtime_bootstrap.create_server_state ~sw ~base_path:dir ~clock
+          ~mono_clock ~net ~proc_mgr ~fs
+      in
+      Server_runtime_bootstrap.bootstrap_server_state_blocking state;
+      Server_runtime_bootstrap.sync_bootable_keeper_credentials state;
+      let token_path =
+        Filename.concat (Auth.auth_dir dir) "masc-improver.token"
+      in
+      let raw_token = String.trim (read_file token_path) in
+      let credential =
+        match Auth.load_credential dir "masc-improver" with
+        | Some cred -> cred
+        | None -> Alcotest.fail "missing masc-improver credential after startup sync"
+      in
+      Alcotest.(check bool) "keeper token file created" true
+        (Sys.file_exists token_path);
+      Alcotest.(check int) "keeper token file private" 0o600
+        ((Unix.stat token_path).Unix.st_perm land 0o777);
+      Alcotest.(check string) "raw token hashes to keeper credential"
+        credential.token (Auth.sha256_hash raw_token);
+      match
+        Auth.verify_token dir ~agent_name:"keeper-masc-improver-agent"
+          ~token:raw_token
+      with
+      | Ok alias_cred ->
+          Alcotest.(check string) "keeper alias resolves stored credential"
+            "masc-improver" alias_cred.agent_name
+      | Error err ->
+          Alcotest.failf "bootable keeper token should verify via alias: %s"
+            (Types.masc_error_to_string err))
+
 let test_main_eio_rejects_same_base_path_on_second_server () =
   with_temp_dir "startup-base-path-owner-lock" (fun dir ->
       let exe = find_main_eio_exe () in
@@ -2125,6 +2170,9 @@ let () =
           Alcotest.test_case
             "main_eio self-heals codex mcp token file"
             `Slow test_main_eio_self_heals_codex_mcp_token_file;
+          Alcotest.test_case
+            "startup sync mints bootable keeper credentials"
+            `Quick test_sync_bootable_keeper_credentials_mints_keeper_alias_token;
           Alcotest.test_case
             "main_eio rejects second server on same base path"
             `Slow test_main_eio_rejects_same_base_path_on_second_server;


### PR DESCRIPTION
## Summary

- sync bootable keeper credentials during server startup so keeper aliases have matching auth records before MCP calls begin
- add a regression test covering `masc-improver` bootstrap token minting and alias verification

## Product impact

- Promise affected: `delivery swarm`
- User-visible change: bootable keepers such as `masc-improver` no longer start with only the `codex-mcp-client` bearer token available, which prevents startup-time `401 Unauthorized` cascades on keeper MCP calls

## Evidence

- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/issue-9640 lib/server/server_runtime_bootstrap.ml lib/server/server_runtime_bootstrap.mli test/test_server_runtime_bootstrap.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/issue-9640 bin/main_eio.exe test/test_server_runtime_bootstrap.exe`
- `./_build/default/test/test_server_runtime_bootstrap.exe --quick-tests`
- `./_build/default/test/test_server_runtime_bootstrap.exe`

## Review evidence

- Local validation only in this pass; no external review run yet.

## Linked issue

- Closes #9640
- Relates #9646
