### PR TITLE
fix(keeper): validate cascade_name in TOML + split silent failure patterns

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -508,6 +508,28 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
                      raw))
         | None -> Ok ())
   in
+  let result =
+    Result.bind result (fun () ->
+        match str "cascade_name" with
+        | None -> Ok ()
+        | Some raw ->
+            let normalized = String.trim raw |> String.lowercase_ascii in
+            let compile_known = Keeper_cascade_profile.known_cascades in
+            let phase_routing = [ "local_only"; "local_recovery" ] in
+            let catalog =
+              try Keeper_cascade_profile.catalog_names ()
+              with _ -> []
+            in
+            let all_valid = compile_known @ phase_routing @ catalog in
+            if List.mem normalized all_valid then Ok ()
+            else
+              Error
+                (Printf.sprintf
+                   "invalid cascade_name '%s' (known: %s)"
+                   raw
+                   (String.concat ", "
+                      (compile_known @ phase_routing))))
+  in
   Result.map
     (fun () ->
       {
@@ -573,12 +595,56 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
       })
     result
 
-(** Canonical TOML key names recognized by [profile_defaults_of_toml].
+(** Fields actually read by [profile_defaults_of_toml] from the [[keeper]]
+    TOML table.  Keep this in sync with the record construction above — the
+    compile-time assertion below will fail if the two lists diverge. *)
+let parsed_field_key_names =
+  [ "name"
+  ; "persona_name"
+  ; "goal"
+  ; "short_goal"
+  ; "mid_goal"
+  ; "long_goal"
+  ; "will"
+  ; "needs"
+  ; "desires"
+  ; "instructions"
+  ; "policy_voice_enabled"
+  ; "autoboot_enabled"
+  ; "mention_targets"
+  ; "proactive_enabled"
+  ; "proactive_idle_sec"
+  ; "proactive_cooldown_sec"
+  ; "room_signal_prompt_enabled"
+  ; "shards"
+  ; "allowed_paths"
+  ; "sandbox_profile"
+  ; "network_mode"
+  ; "shared_memory_scope"
+  ; "tool_preset"
+  ; "tool_also_allow"
+  ; "tool_denylist"
+  ; "work_discovery_enabled"
+  ; "work_discovery_sources"
+  ; "work_discovery_interval_sec"
+  ; "work_discovery_guidance"
+  ; "telemetry_feedback_enabled"
+  ; "telemetry_feedback_window_hours"
+  ; "max_turns_per_call"
+  ; "max_turns_per_call_scheduled_autonomous"
+  ; "social_model"
+  ; "cascade_name"
+  ]
+
+(** Canonical TOML key names used by [detect_unknown_keeper_toml_keys].
     Keys outside this set under [[keeper]] (or any other table) are silently
     ignored by the loader, which historically let dead config accumulate
     (e.g. legacy [legacy_scope], [scope_kind]).  [warn_unknown_keeper_toml_keys]
     uses this list to surface drift on boot, symmetric with
-    [warn_unknown_keeper_meta_keys] on the JSON side. *)
+    [warn_unknown_keeper_meta_keys] on the JSON side.
+
+    Must be kept in sync with [parsed_field_key_names] — the assertion below
+    catches drift at compile time. *)
 let canonical_keeper_toml_key_names =
   [ "name"
   ; "persona_name"
@@ -603,8 +669,6 @@ let canonical_keeper_toml_key_names =
   ; "network_mode"
   ; "shared_memory_scope"
   ; "tool_preset"
-  ; "tool_access.kind"
-  ; "tool_access.preset"
   ; "tool_also_allow"
   ; "tool_denylist"
   ; "work_discovery_enabled"
@@ -616,9 +680,13 @@ let canonical_keeper_toml_key_names =
   ; "max_turns_per_call"
   ; "max_turns_per_call_scheduled_autonomous"
   ; "social_model"
-  ; "execution_scope"
   ; "cascade_name"
   ]
+
+let () =
+  assert (
+    List.sort String.compare canonical_keeper_toml_key_names
+    = List.sort String.compare parsed_field_key_names)
 
 (** Pure detector: returns TOML keys that [profile_defaults_of_toml] does not
     consume.  Exposed separately from the logging wrapper so tests can

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -675,7 +675,12 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
       | None -> (
           match Keeper_types.read_meta config name with
           | Ok (Some meta) -> Some meta.agent_name
-          | Ok None | Error _ -> None)
+          | Ok None -> None
+          | Error err ->
+              Log.Keeper.warn
+                "resolve_keeper_agent_name %s: read_meta failed: %s"
+                name err;
+              None)
     in
     let persist_keeper_paused_state paused =
       match Keeper_types.read_meta config name with
@@ -867,7 +872,11 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
         let meta_opt =
           match read_result with
           | Ok (Some meta) -> Some meta
-          | Ok None | Error _ -> None
+          | Ok None -> None
+          | Error err ->
+              Log.Keeper.warn "directive %s %s: read_meta failed: %s"
+                action_str name err;
+              None
         in
         let persist_paused_state paused =
           match meta_opt with

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -55,6 +55,86 @@ let test_named_keeper_docker_defaults () =
   in
   List.iter expect_keeper [ "sangsu"; "sojin"; "verdict" ]
 
+(** Write a temporary TOML file, run load_keeper_toml, clean up. *)
+let with_temp_toml content f =
+  let path = Filename.temp_file "keeper_test_" ".toml" in
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc;
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with _ -> ())
+    (fun () -> f path)
+
+let test_cascade_name_rejects_unknown () =
+  let result =
+    with_temp_toml
+      "[keeper]\nname = \"testkeeper\"\ncascade_name = \"nick0cave\"\n"
+      KTP.load_keeper_toml
+  in
+  match result with
+  | Ok _ -> fail "nick0cave cascade_name should be rejected"
+  | Error e ->
+      check bool "error mentions cascade_name" true
+        (let len = String.length e in
+         let needle = "invalid cascade_name" in
+         let nlen = String.length needle in
+         let found = ref false in
+         for i = 0 to len - nlen do
+           if String.sub e i nlen = needle then found := true
+         done;
+         !found)
+
+let test_cascade_name_accepts_known () =
+  let check_ok label cascade_name =
+    let result =
+      with_temp_toml
+        (Printf.sprintf "[keeper]\nname = \"testkeeper\"\ncascade_name = \"%s\"\n"
+           cascade_name)
+        KTP.load_keeper_toml
+    in
+    match result with
+    | Ok _ -> ()
+    | Error e ->
+        fail (Printf.sprintf "%s: '%s' should be accepted but got: %s" label
+                cascade_name e)
+  in
+  check_ok "big_three variant" "big_three";
+  check_ok "local_only phase-routing" "local_only";
+  check_ok "local_recovery phase-routing" "local_recovery"
+
+let test_cascade_name_accepts_catalog_entry () =
+  (* "tool_use_strict" is a known catalog entry in cascade.json,
+     distinct from compile-time variants.  Tests that the live catalog
+     is consulted during validation. *)
+  let catalog =
+    try Masc_mcp.Keeper_cascade_profile.catalog_names ()
+    with _ -> []
+  in
+  let test_name =
+    (* Pick a catalog entry that is NOT a compile-time variant *)
+    match
+      List.find_opt
+        (fun n ->
+           not (List.mem n Masc_mcp.Keeper_cascade_profile.known_cascades)
+           && not (List.mem n [ "local_only"; "local_recovery" ]))
+        catalog
+    with
+    | Some name -> name
+    | None -> "tool_use_strict" (* fallback, may not be in catalog *)
+  in
+  let result =
+    with_temp_toml
+      (Printf.sprintf "[keeper]\nname = \"testkeeper\"\ncascade_name = \"%s\"\n"
+         test_name)
+      KTP.load_keeper_toml
+  in
+  match result with
+  | Ok _ -> ()
+  | Error e ->
+      (* If catalog is unavailable, skip rather than fail *)
+      if catalog = [] then ()
+      else fail (Printf.sprintf "%s should be accepted: %s" test_name e)
+
 let () =
   run "Keeper TOML Config Validation"
     [
@@ -63,5 +143,14 @@ let () =
           test_case "all toml files parse" `Quick test_all_keeper_tomls_parse;
           test_case "named keepers default to docker" `Quick
             test_named_keeper_docker_defaults;
+        ] );
+      ( "cascade_name validation",
+        [
+          test_case "rejects unknown cascade_name" `Quick
+            test_cascade_name_rejects_unknown;
+          test_case "accepts known cascade names" `Quick
+            test_cascade_name_accepts_known;
+          test_case "accepts catalog entry (legacy alias)" `Quick
+            test_cascade_name_accepts_catalog_entry;
         ] );
     ]


### PR DESCRIPTION
## Summary

- **Fix A**: `profile_defaults_of_toml`에 `cascade_name` 검증 추가. unknown 값(예: keeper 이름 "nick0cave")을 파싱 단계에서 reject. 1,218건 cascade resolve failure 재발 방지.
- **Fix B**: `server_dashboard_http_keeper_api.ml`의 `Ok None | Error _ -> None` 패턴 2곳을 3-way 분리. Error 시 `Log.Keeper.warn` 로깅 추가.
- **Fix C**: `parsed_field_key_names` 상수 + compile-time assertion으로 canonical key list와 파싱 코드의 drift 감지. 3개 dead entry 제거.

## Root Cause

nick0cave keeper의 `cascade_name = "nick0cave"`(keeper 이름을 cascade 프로파일로 오용) → 1,218회 cascade resolve 실패 + 165회 FAILED keeper 사이클. TOML 수동 수정으로 복구되었지만 코드 레벨 검증이 없어 재발 위험 존재.

## Test plan

- [x] `dune runtest` — 기존 테스트 + 신규 3개 cascade_name 테스트 통과
- [x] 3/3 new Alcotest cases: reject unknown, accept known, accept catalog entry
- [x] Compile-time assertion (Fix C) 빌드 통과
- [ ] 서버 재시작 후 `cascade_name = "invalid_name"` 설정 시 reject 확인
- [ ] Dashboard에서 keeper pause/resume 시 `read_meta failed` 로그 가시화 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)