### PR TITLE
fix(dashboard): refresh borrowed loopback token

### DIFF
--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -55,6 +55,7 @@ beforeEach(() => {
   // mocks whose `vi.hoisted` defaults have been overwritten by an earlier
   // test (e.g. authHeaders). The dev-token bootstrap must stay inert unless
   // a test explicitly exercises it.
+  currentDashboardActor.mockReturnValue('dashboard')
   getStoredToken.mockReturnValue('test-stored-token')
   getStoredTokenMeta.mockReturnValue({
     source: 'manual',
@@ -168,6 +169,66 @@ describe('dev-token bootstrap', () => {
     expect(calls.length).toBeGreaterThanOrEqual(2)
     expect(calls[0]?.[0]).toBe('/api/v1/dashboard/dev-token')
     expect(calls[1]?.[0]).toBe('/mcp')
+  }, 60_000)
+
+  it('replaces a borrowed loopback token when the default dashboard actor is active', async () => {
+    getStoredToken.mockReturnValue('borrowed-codex-token')
+    getStoredTokenMeta.mockReturnValue({
+      source: 'manual',
+      actor: null,
+      scope: null,
+    })
+    fetchWithTimeout
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          token: 'loopback-dev-token',
+          actor: 'dashboard',
+          scope: 'admin',
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response('{}', { status: 200, headers: { 'Mcp-Session-Id': 'sess-borrowed' } }),
+      )
+      .mockResolvedValueOnce(new Response('', { status: 202 }))
+      .mockResolvedValueOnce(
+        new Response('data: {"result":{"content":[{"type":"text","text":"ok"}]}}\n', { status: 200 }),
+      )
+
+    const { callMcpTool } = await import('./mcp')
+    await callMcpTool('masc_status', {})
+
+    expect(setStoredToken).toHaveBeenCalledWith('loopback-dev-token', {
+      source: 'dev',
+      actor: 'dashboard',
+      scope: 'admin',
+    })
+    const calls = fetchWithTimeout.mock.calls as Array<[string, RequestInit]>
+    expect(calls[0]?.[0]).toBe('/api/v1/dashboard/dev-token')
+  }, 60_000)
+
+  it('keeps manual tokens for non-default dashboard actors', async () => {
+    currentDashboardActor.mockReturnValue('dashboard-manual-actor')
+    authHeaders.mockReturnValue({
+      'Authorization': 'Bearer manual-actor-token',
+      'X-MASC-Agent': 'dashboard-manual-actor',
+    })
+    getStoredToken.mockReturnValue('manual-actor-token')
+    getStoredTokenMeta.mockReturnValue({
+      source: 'manual',
+      actor: null,
+      scope: null,
+    })
+    setupMcpSessionMocks('sess-manual-actor')
+
+    const { callMcpTool } = await import('./mcp')
+    await callMcpTool('masc_status', {})
+
+    expect(setStoredToken).not.toHaveBeenCalled()
+    const calls = fetchWithTimeout.mock.calls as Array<[string, RequestInit]>
+    expect(calls[0]?.[0]).toBe('/mcp')
   }, 60_000)
 
   it('swallows dev-token fetch failures so strict-auth servers still reach the 401 path', async () => {

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -42,10 +42,11 @@ function shouldRefreshDevToken(): boolean {
   const meta = getStoredTokenMeta()
   if (!token) return true
   if (meta?.source === 'dev') return true
-  // Legacy sessions only stored the raw token string. On loopback with the
-  // default dashboard actor, treat them as managed-token candidates so
-  // frequent restarts or base_path flips self-heal without manual clearing.
-  return meta == null && !isRemoteAccess() && currentDashboardActor() === 'dashboard'
+  const actor = currentDashboardActor()
+  if (isRemoteAccess() || actor !== 'dashboard') return false
+  // Loopback dashboard sessions should self-heal if they are still holding
+  // a borrowed non-dashboard token (for example an old codex paste/URL token).
+  return meta == null || meta.actor == null || meta.actor !== actor
 }
 
 /** Fetch the loopback-only dev token once per page load and stash it so


### PR DESCRIPTION
## Summary

- refresh the loopback dashboard dev token when the default `dashboard` actor is still holding a borrowed non-dashboard token
- keep manual/custom-actor tokens unchanged so non-default dashboard sessions still respect explicit auth
- add regression tests for both the borrowed-token self-heal path and the custom-actor non-regression path

## Product impact

- Promise affected: `ops visibility`
- User-visible change: the default dashboard no longer keeps reusing a stale `codex` bearer token on loopback, so MCP calls like `masc_persona_list` and `masc_keeper_status` recover without manual token clearing

## Evidence

- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard exec vitest run src/api/mcp.test.ts --no-file-parallelism --maxWorkers=1 -t "dev-token bootstrap"`
- `pnpm --dir dashboard exec vitest run src/api/mcp.test.ts --no-file-parallelism --maxWorkers=1 -t "injects the dashboard actor into MCP tool arguments"`

## Review evidence

- Local validation only in this pass; no external review run yet.

## Linked issue

- Closes #9631
- Relates #9646
