### PR TITLE
[codex] Bind keeper GitHub identity bundles

### DIFF
--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -142,6 +142,9 @@ persona_name = "analyst"
 | `shared_memory_scope` | Optional | Typed shared-memory lane | `room` enables keeper-authorized `masc_team_memory_*` exchange on the flattened `default` namespace. |
 | `cascade_name` | Optional | Deployment-specific cascade override | Only when not using the default cascade. |
 | `tool_preset` | Optional | Deployment-specific policy override | Only when intentionally overriding persona default. |
+| `github_identity` | Optional | Bound GitHub CLI identity bundle | Resolves to `.masc/github-identities/<identity>/gh` for keeper-scoped `gh` auth. |
+| `git_identity_mode` | Optional | Commit identity policy | `keeper_alias` keeps git author separate from GitHub auth; `github_identity` is reserved for future explicit coupling. |
+| `active_goal_ids` | Optional | Goal-scoped claim filter | When set, `keeper_task_claim` only considers tasks linked to these goals. |
 
 ### Additional supported overlay fields
 
@@ -159,6 +162,7 @@ These are still accepted by the loader, but for consistency they should be used 
 | `allowed_paths` | string array | Exceptional path override only; prefer empty and rely on the single sandbox root |
 | `tool_also_allow` | string array | Extra tool names added to the preset surface |
 | `tool_denylist` | string array | Tool names blocked regardless of preset |
+| `active_goal_ids` | string array | Declarative goal scope for task claim eligibility |
 | `work_discovery_enabled` | bool | Enable work discovery loop |
 | `work_discovery_sources` | string array | e.g. `["github_issues", "stale_tasks"]` |
 | `work_discovery_interval_sec` | int | Scan interval |
@@ -177,6 +181,7 @@ Enumerated fields only accept the values below. The loader rejects invalid input
 | `sandbox_profile` | `local`, `docker` |
 | `network_mode` | `none`, `inherit` |
 | `shared_memory_scope` | `disabled`, `room` |
+| `git_identity_mode` | `keeper_alias`, `github_identity` |
 | `tool_preset` | `minimal`, `social`, `messaging`, `coding`, `research`, `delivery`, `full` |
 | `social_model` | `bdi_speech_v1`, `magentic_ledger_v1` (non-public: rejected when passed via tool args; TOML-only) |
 | `cascade_name` | any `<name>` such that `<name>_models` exists in `cascade.json` (e.g. `keeper_unified`, `nick0cave`) |
@@ -198,6 +203,7 @@ Operational intent:
 - shared lane: `masc_team_memory_read/write/search` only, on flattened `room="default"`
 - no arbitrary shared writable shell directory
 - `sandbox_profile=docker`는 `allowed_paths=["*"]`를 거부하고, private sandbox root 밖 경로도 허용하지 않는다
+- `github_identity`가 설정된 keeper는 `.masc/github-identities/<identity>/gh`가 없으면 fail-closed 된다. operator 개인 `gh` config로는 fallback 하지 않는다.
 
 ### Removed / forbidden fields (hard-rejected)
 

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -2250,11 +2250,13 @@ let handle_keeper_shell
               | Ok result -> Ok (result.status, result.output)
               | Error msg -> Error msg
             else
-              let env = Keeper_gh_env.process_env config in
-              let gh_argv =
-                "gh" :: Keeper_gh_shared.gh_simple_command_argv parsed_command
-              in
-              Ok (Process_eio.run_argv_with_status ?env ~cwd ~timeout_sec gh_argv)
+              (match Keeper_gh_env.keeper_process_env config ~keeper_name:meta.name with
+               | Error err -> Error err
+               | Ok env ->
+                   let gh_argv =
+                     "gh" :: Keeper_gh_shared.gh_simple_command_argv parsed_command
+                   in
+                   Ok (Process_eio.run_argv_with_status ?env ~cwd ~timeout_sec gh_argv))
           in
           match gh_process with
           | Error msg ->

--- a/lib/keeper/keeper_gh_env.ml
+++ b/lib/keeper/keeper_gh_env.ml
@@ -10,10 +10,62 @@
     keeper_exec_shared's interface stable (adding functions to it
     causes dune interface mismatch errors in the test suite). *)
 
-(** Resolve [$base_path/.masc/gh-auth/] if it exists. *)
+(** Resolve legacy [$base_path/.masc/gh-auth/] if it exists. *)
 let config_dir (config : Coord.config) : string option =
   let dir = Filename.concat config.Coord_utils.base_path ".masc/gh-auth" in
   if Sys.file_exists dir && Sys.is_directory dir then Some dir else None
+
+type keeper_binding = {
+  github_identity : string option;
+  git_identity_mode : string;
+  bundle_root : string option;
+  gh_config_dir : string option;
+}
+
+let bundle_root (config : Coord.config) ~(github_identity : string) =
+  Filename.concat
+    (Filename.concat (Coord.masc_dir config) "github-identities")
+    github_identity
+
+let gh_config_dir_of_bundle bundle_root =
+  Filename.concat bundle_root "gh"
+
+let keeper_binding (config : Coord.config) ~(keeper_name : string) :
+    (keeper_binding, string) result =
+  let defaults = Keeper_types_profile.load_keeper_profile_defaults keeper_name in
+  let git_identity_mode =
+    Option.value ~default:"keeper_alias" defaults.git_identity_mode
+  in
+  match defaults.github_identity with
+  | None ->
+      Ok
+        {
+          github_identity = None;
+          git_identity_mode;
+          bundle_root = None;
+          gh_config_dir = config_dir config;
+        }
+  | Some github_identity ->
+      let bundle_root = bundle_root config ~github_identity in
+      let gh_config_dir = gh_config_dir_of_bundle bundle_root in
+      if Sys.file_exists gh_config_dir && Sys.is_directory gh_config_dir then
+        Ok
+          {
+            github_identity = Some github_identity;
+            git_identity_mode;
+            bundle_root = Some bundle_root;
+            gh_config_dir = Some gh_config_dir;
+          }
+      else
+        Error
+          (Printf.sprintf
+             "keeper %s is bound to github_identity %s but GH config dir %s is missing. Run the operator GitHub identity login flow first."
+             keeper_name github_identity gh_config_dir)
+
+let keeper_config_dir (config : Coord.config) ~(keeper_name : string) :
+    (string option, string) result =
+  keeper_binding config ~keeper_name
+  |> Result.map (fun binding -> binding.gh_config_dir)
 
 (** Prepend [GH_CONFIG_DIR=<dir>] to a gh shell command when a
     keeper-scoped config exists. Scoped to the single subprocess
@@ -36,3 +88,18 @@ let process_env (config : Coord.config) : string array option =
         not (String.starts_with ~prefix:"GH_CONFIG_DIR=" entry))
     in
     Some (Array.of_list (gh_config :: base))
+
+let keeper_process_env (config : Coord.config) ~(keeper_name : string) :
+    (string array option, string) result =
+  keeper_config_dir config ~keeper_name
+  |> Result.map (function
+       | None -> None
+       | Some dir ->
+           let gh_config = "GH_CONFIG_DIR=" ^ dir in
+           let base =
+             Unix.environment ()
+             |> Array.to_list
+             |> List.filter (fun entry ->
+                  not (String.starts_with ~prefix:"GH_CONFIG_DIR=" entry))
+           in
+           Some (Array.of_list (gh_config :: base)))

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -135,6 +135,8 @@ let ensure_keeper_meta config name =
       apply_default defaults.autoboot_enabled meta.autoboot_enabled in
     let target_mention_targets =
       match defaults.mention_targets with [] -> meta.mention_targets | xs -> xs in
+    let target_active_goal_ids =
+      apply_default defaults.active_goal_ids meta.active_goal_ids in
     let target_sandbox_profile =
       apply_default defaults.sandbox_profile meta.sandbox_profile in
     let target_network_mode =
@@ -191,6 +193,7 @@ let ensure_keeper_meta config name =
       meta.policy_voice_enabled <> target_policy_voice_enabled
       || meta.autoboot_enabled <> target_autoboot_enabled
       || meta.mention_targets <> target_mention_targets
+      || meta.active_goal_ids <> target_active_goal_ids
       || meta.tool_access <> target_tool_access
       || meta.sandbox_profile <> target_sandbox_profile
       || meta.network_mode <> target_network_mode
@@ -257,6 +260,7 @@ let ensure_keeper_meta config name =
         policy_voice_enabled = target_policy_voice_enabled;
         autoboot_enabled = target_autoboot_enabled;
         mention_targets = target_mention_targets;
+        active_goal_ids = target_active_goal_ids;
         tool_access = target_tool_access;
         sandbox_profile = target_sandbox_profile;
         network_mode = target_network_mode;

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -157,9 +157,10 @@ let run_docker_shell_command_with_status
           | Network_inherit -> ([], network_mode_to_string network_mode)
       in
       let gh_creds =
-        match Keeper_gh_env.config_dir config with
-        | Some dir -> dir
-        | None -> Env_config_keeper.KeeperSandbox.gh_creds_host_path ()
+        match Keeper_gh_env.keeper_config_dir config ~keeper_name:meta.name with
+        | Ok (Some dir) -> dir
+        | Ok None -> Env_config_keeper.KeeperSandbox.gh_creds_host_path ()
+        | Error err -> raise (Failure err)
       in
       let gitconfig = Env_config_keeper.KeeperSandbox.gitconfig_host_path () in
       let ssh_dir = Env_config_keeper.KeeperSandbox.ssh_dir_host_path () in
@@ -213,18 +214,21 @@ let run_docker_shell_command_with_status
         @ token_env
         @ [ image; "bash"; "-lc"; cmd ]
       in
-      let status, output =
-        Process_eio.run_argv_with_status
-          ~cwd:(Sys.getcwd ()) ~timeout_sec argv
-      in
-      if status <> Unix.WEXITED 0 then
-        Keeper_registry.record_error ~base_path:config.base_path meta.name
-          (Printf.sprintf "sandbox docker exec failed (%s): %s"
-             image
-             (Worker_dev_tools.truncate_for_log output))
-      else
-        Keeper_registry.clear_error ~base_path:config.base_path meta.name;
-      Ok { status; output; image; network_label }
+      (try
+         let status, output =
+           Process_eio.run_argv_with_status
+             ~cwd:(Sys.getcwd ()) ~timeout_sec argv
+         in
+         if status <> Unix.WEXITED 0 then
+           Keeper_registry.record_error ~base_path:config.base_path meta.name
+             (Printf.sprintf "sandbox docker exec failed (%s): %s"
+                image
+                (Worker_dev_tools.truncate_for_log output))
+         else
+           Keeper_registry.clear_error ~base_path:config.base_path meta.name;
+         Ok { status; output; image; network_label }
+       with
+       | Failure err -> sandbox_error err)
 
 let run_docker_with_git_bash
     ~(turn_sandbox_runtime : Keeper_turn_sandbox_runtime.t option)

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -366,7 +366,8 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         updated_at = now_iso ();
         max_context_override = p.max_context_override_opt;
         continuity_summary = "";
-        active_goal_ids = [];
+        active_goal_ids =
+          Option.value ~default:[] p.profile_defaults.active_goal_ids;
         paused = false;
         autoboot_enabled;
         current_task_id = None;

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -184,6 +184,8 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     tool_access;
     tool_denylist;
     autoboot_enabled;
+    active_goal_ids =
+      Option.value ~default:old.active_goal_ids p.profile_defaults.active_goal_ids;
     voice_enabled =
       Option.value ~default:old.voice_enabled p.voice_enabled_opt;
     voice_channel =

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -177,6 +177,14 @@ let normalize_cascade_name_opt = function
   | None -> None
   | Some raw -> Some (Keeper_cascade_profile.normalize_declared_name raw)
 
+let normalize_git_identity_mode_opt = function
+  | None -> None
+  | Some raw -> (
+      match String.trim (String.lowercase_ascii raw) with
+      | "keeper_alias" -> Some "keeper_alias"
+      | "github_identity" -> Some "github_identity"
+      | _ -> None)
+
 let normalize_social_model_opt = function
   | None -> None
   | Some raw -> (
@@ -263,9 +271,12 @@ type keeper_profile_defaults = {
   sandbox_profile : sandbox_profile option;
   network_mode : network_mode option;
   shared_memory_scope : shared_memory_scope option;
+  github_identity : string option;
+  git_identity_mode : string option;
   tool_preset : string option;
   tool_also_allow : string list option;
   tool_denylist : string list option;
+  active_goal_ids : string list option;
   (* Work Discovery — config-driven proactive work scanning *)
   work_discovery_enabled : bool option;
   work_discovery_sources : string list option;
@@ -322,9 +333,12 @@ let empty_keeper_profile_defaults = {
   sandbox_profile = None;
   network_mode = None;
   shared_memory_scope = None;
+  github_identity = None;
+  git_identity_mode = None;
   tool_preset = None;
   tool_also_allow = None;
   tool_denylist = None;
+  active_goal_ids = None;
   work_discovery_enabled = None;
   work_discovery_sources = None;
   work_discovery_interval_sec = None;
@@ -444,6 +458,26 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
   in
   let result =
     Result.bind result (fun () ->
+        match str "github_identity" with
+        | Some raw when not (validate_name raw) ->
+            Error (Printf.sprintf "invalid github_identity '%s'" raw)
+        | _ -> Ok ())
+  in
+  let result =
+    Result.bind result (fun () ->
+        match str "git_identity_mode" with
+        | Some raw -> (
+            match normalize_git_identity_mode_opt (Some raw) with
+            | Some _ -> Ok ()
+            | None ->
+                Error
+                  (Printf.sprintf
+                     "invalid git_identity_mode '%s' (allowed: keeper_alias, github_identity)"
+                     raw))
+        | None -> Ok ())
+  in
+  let result =
+    Result.bind result (fun () ->
         match str "tool_preset" with
         | Some raw -> (
             match normalize_tool_preset_raw raw with
@@ -548,12 +582,19 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         shared_memory_scope =
           Option.bind (str "shared_memory_scope")
             shared_memory_scope_of_string;
+        github_identity = str "github_identity";
+        git_identity_mode =
+          normalize_git_identity_mode_opt (str "git_identity_mode");
         tool_preset =
           (match str "tool_preset" with
            | None -> None
            | Some raw -> normalize_tool_preset_raw raw);
         tool_also_allow = normalize_name_list_opt (strs "tool_also_allow");
         tool_denylist = normalize_name_list_opt (strs "tool_denylist");
+        active_goal_ids =
+          if has "active_goal_ids" then
+            Some (normalize_name_list (strs "active_goal_ids"))
+          else None;
         work_discovery_enabled = bool_ "work_discovery_enabled";
         work_discovery_sources =
           (match strs "work_discovery_sources" with
@@ -602,11 +643,14 @@ let canonical_keeper_toml_key_names =
   ; "sandbox_profile"
   ; "network_mode"
   ; "shared_memory_scope"
+  ; "github_identity"
+  ; "git_identity_mode"
   ; "tool_preset"
   ; "tool_access.kind"
   ; "tool_access.preset"
   ; "tool_also_allow"
   ; "tool_denylist"
+  ; "active_goal_ids"
   ; "work_discovery_enabled"
   ; "work_discovery_sources"
   ; "work_discovery_interval_sec"
@@ -742,6 +786,8 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                 sandbox_profile = None;
                 network_mode = None;
                 shared_memory_scope = None;
+                github_identity = None;
+                git_identity_mode = None;
                 tool_preset =
                   (match Safe_ops.json_string_opt "tool_preset" keeper_json with
                   | None -> None
@@ -759,6 +805,7 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                 tool_denylist =
                   normalize_name_list_opt
                     (Safe_ops.json_string_list "tool_denylist" keeper_json);
+                active_goal_ids = None;
                 work_discovery_enabled =
                   Safe_ops.json_bool_opt "work_discovery_enabled" keeper_json;
                 work_discovery_sources =
@@ -845,9 +892,13 @@ let merge_keeper_profile_defaults
     network_mode = prefer overlay.network_mode base.network_mode;
     shared_memory_scope =
       prefer overlay.shared_memory_scope base.shared_memory_scope;
+    github_identity = prefer overlay.github_identity base.github_identity;
+    git_identity_mode =
+      prefer overlay.git_identity_mode base.git_identity_mode;
     tool_preset = prefer overlay.tool_preset base.tool_preset;
     tool_also_allow = prefer overlay.tool_also_allow base.tool_also_allow;
     tool_denylist = prefer overlay.tool_denylist base.tool_denylist;
+    active_goal_ids = prefer overlay.active_goal_ids base.active_goal_ids;
     work_discovery_enabled =
       prefer overlay.work_discovery_enabled base.work_discovery_enabled;
     work_discovery_sources =

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -450,6 +450,9 @@ proactive_enabled = true
 room_signal_prompt_enabled = true
 policy_voice_enabled = false
 autoboot_enabled = false
+github_identity = "anyang-keepers"
+git_identity_mode = "keeper_alias"
+active_goal_ids = ["goal-runtime", "goal-masc-mcp"]
 |} in
   match TL.parse_toml input with
   | Error e -> fail e
@@ -467,7 +470,29 @@ autoboot_enabled = false
       check (option bool) "room signal prompt" (Some true)
         d.room_signal_prompt_enabled;
       check (option bool) "policy_voice" (Some false) d.policy_voice_enabled;
-      check (option bool) "autoboot_enabled" (Some false) d.autoboot_enabled
+      check (option bool) "autoboot_enabled" (Some false) d.autoboot_enabled;
+      check (option string) "github_identity" (Some "anyang-keepers")
+        d.github_identity;
+      check (option string) "git_identity_mode" (Some "keeper_alias")
+        d.git_identity_mode;
+      check (option (list string)) "active_goal_ids"
+        (Some [ "goal-runtime"; "goal-masc-mcp" ])
+        d.active_goal_ids
+
+let test_profile_rejects_invalid_git_identity_mode () =
+  let input = {|
+[keeper]
+goal = "test"
+git_identity_mode = "hot_switch"
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+      (match KTP.profile_defaults_of_toml doc with
+       | Ok _ -> fail "expected invalid git_identity_mode error"
+       | Error msg ->
+           check bool "mentions invalid git_identity_mode" true
+             (contains_substring msg "invalid git_identity_mode"))
 
 let test_profile_rejects_invalid_social_model () =
   let input = {|
@@ -959,6 +984,9 @@ tool_preset = "coding"
 tool_also_allow = ["x"]
 autoboot_enabled = false
 cascade_name = "big_three"
+github_identity = "anyang-keepers"
+git_identity_mode = "keeper_alias"
+active_goal_ids = ["goal-runtime"]
 |} in
   match TL.parse_toml input with
   | Error e -> fail e
@@ -1182,6 +1210,8 @@ let () =
           test_case "full" `Quick test_profile_full;
           test_case "rejects invalid social_model" `Quick
             test_profile_rejects_invalid_social_model;
+          test_case "rejects invalid git_identity_mode" `Quick
+            test_profile_rejects_invalid_git_identity_mode;
           test_case "rejects removed model keys" `Quick
             test_profile_rejects_removed_model_keys;
           test_case "rejects removed also_allow alias" `Quick


### PR DESCRIPTION
## Summary
This is PR 1 of a 3-PR keeper GitHub identity stack.

It adds keeper-scoped GitHub identity binding and the config/runtime plumbing needed to make keeper `gh` usage fail closed when a bound identity bundle is missing.

## What Changed
- added keeper profile fields: `github_identity`, `git_identity_mode`, and `active_goal_ids`
- resolved bound keeper auth from `.masc/github-identities/<identity>/gh`
- kept legacy `.masc/gh-auth` fallback only for unbound keepers
- propagated keeper-specific `GH_CONFIG_DIR` into local shell execution and Docker sandbox git/gh dispatch
- updated keeper file model docs and TOML coverage

## Why
The keeper needs a stable, auditable GitHub identity separate from the operator's personal CLI session before it can safely own clone/push/PR workflows.

## Validation
- `dune build --root . lib/keeper/keeper_exec_shell.ml lib/keeper/keeper_gh_env.ml lib/keeper/keeper_runtime.ml lib/keeper/keeper_shell_docker.ml lib/keeper/keeper_turn_up_create.ml lib/keeper/keeper_turn_up_update.ml lib/keeper/keeper_types_profile.ml test/test_keeper_toml.ml`
- `dune exec --root . ./test/test_keeper_toml.exe`

## Stack Context
- base: `main`
- next PR: goal-scoped verification workflow