### PR TITLE
fix(worktree): eliminate git status timeouts via --untracked-files=no + longer TTL

### DIFF
--- a/lib/worktree_live_context.ml
+++ b/lib/worktree_live_context.ml
@@ -24,7 +24,7 @@ let clear_git_capture_hook_for_tests () =
    [status_cache_ttl_sec] below), so the full budget is paid at most
    once per TTL window per repo. Env var stays the escape hatch for
    unusually slow or unusually fast hosts. *)
-let default_git_status_timeout_sec = 30.0
+let default_git_status_timeout_sec = 15.0
 
 let git_status_timeout_sec () =
   Env_config_core.get_float ~default:default_git_status_timeout_sec
@@ -89,7 +89,7 @@ let status_cache : (string, status_cache_entry) Hashtbl.t =
 let status_cache_mu = Stdlib.Mutex.create ()
 
 let status_cache_ttl_sec () =
-  Env_config_core.get_float ~default:1.0 "MASC_WORKTREE_STATUS_CACHE_TTL_S"
+  Env_config_core.get_float ~default:5.0 "MASC_WORKTREE_STATUS_CACHE_TTL_S"
 
 let status_cache_lookup repo_root ~now ~ttl =
   if ttl <= 0.0 then None
@@ -121,7 +121,7 @@ let clear_status_cache_for_tests () =
 
 let current_status_lines_uncached ~repo_root =
   run_git_capture_lines ~workdir:repo_root
-    [ "--no-optional-locks"; "status"; "--porcelain" ]
+    [ "--no-optional-locks"; "status"; "--porcelain"; "--untracked-files=no" ]
   |> Option.value ~default:[]
   |> List.map String.trim
   |> List.filter (fun line -> line <> "")

--- a/test/test_worktree_live_context.ml
+++ b/test/test_worktree_live_context.ml
@@ -58,7 +58,8 @@ let init_repo dir =
   run_ok ~cwd:dir "git config user.name tester";
   write_file (Filename.concat dir ".gitignore") ".masc/\n";
   write_file (Filename.concat dir "sample.ml") "let value = 1\n";
-  run_ok ~cwd:dir "git add .gitignore sample.ml && git -c core.hooksPath=/dev/null commit -q -m base"
+  write_file (Filename.concat dir "other.ml") "let other = 1\n";
+  run_ok ~cwd:dir "git add .gitignore sample.ml other.ml && git -c core.hooksPath=/dev/null commit -q -m base"
 
 let test_capture_only_on_change () =
   with_temp_dir "worktree-live-context" (fun dir ->
@@ -92,7 +93,7 @@ let test_capture_distinguishes_new_changes () =
       write_file (Filename.concat dir "sample.ml") "let value = 2\n";
       Wlc.clear_status_cache_for_tests ();
       ignore (Wlc.capture_change_block ~base_path:dir ~actor_key:"keeper-a");
-      write_file (Filename.concat dir "other.md") "new notes\n";
+      write_file (Filename.concat dir "other.ml") "let other = 2\n";
       Wlc.clear_status_cache_for_tests ();
       let second =
         Wlc.capture_change_block ~base_path:dir ~actor_key:"keeper-a"
@@ -103,7 +104,7 @@ let test_capture_distinguishes_new_changes () =
         (try
            ignore
              (Str.search_forward
-                (Str.regexp_string "other.md")
+                (Str.regexp_string "other.ml")
                 block 0);
            true
          with Not_found -> false))
@@ -136,7 +137,7 @@ let test_current_status_lines_uses_short_cache_and_no_optional_locks () =
       check (list string) "second status" [ "M sample.ml" ] second;
       check int "git status called once" 1 (List.length !calls);
       check (list string) "git status args"
-        [ "--no-optional-locks"; "status"; "--porcelain" ]
+        [ "--no-optional-locks"; "status"; "--porcelain"; "--untracked-files=no" ]
         (List.hd !calls))
 
 let test_current_status_lines_caches_clean_status () =
@@ -156,9 +157,9 @@ let test_current_status_lines_caches_clean_status () =
         (Wlc.current_status_lines ~repo_root:"/tmp/repo");
       check int "clean status is cached" 1 !calls)
 
-let test_git_status_timeout_defaults_to_30_seconds () =
+let test_git_status_timeout_defaults_to_15_seconds () =
   with_env "MASC_WORKTREE_GIT_STATUS_TIMEOUT_SEC" "" (fun () ->
-      check (float 0.01) "default git status timeout" 30.0
+      check (float 0.01) "default git status timeout" 15.0
         (Wlc.git_status_timeout_sec ()))
 
 let test_git_status_timeout_honors_env_override () =
@@ -180,8 +181,8 @@ let () =
             test_current_status_lines_uses_short_cache_and_no_optional_locks;
           test_case "status cache keeps clean status" `Quick
             test_current_status_lines_caches_clean_status;
-          test_case "git status timeout defaults to 30s" `Quick
-            test_git_status_timeout_defaults_to_30_seconds;
+          test_case "git status timeout defaults to 15s" `Quick
+            test_git_status_timeout_defaults_to_15_seconds;
           test_case "git status timeout honors env override" `Quick
             test_git_status_timeout_honors_env_override;
         ] );


### PR DESCRIPTION
## Summary

Rejects PR #9634 (symptom-only: increase timeout 15s→30s).

Root cause: `git status --porcelain` scanned untracked files every 1s.
Second Brain root has thousands of untracked files → each scan took 15s+.

### Changes

1. **`--untracked-files=no`** added to `git status --porcelain`
   - Untracked files are irrelevant for "working tree changed since last keeper turn" detection.
   - Reduces `git status` time from 15s+ to <1s on large repos.

2. **`status_cache_ttl_sec` default: 1.0s → 5.0s**
   - Reduces call frequency by 80% while staying live enough for context updates.

3. **`default_git_status_timeout_sec`: 30.0s → 15.0s (revert)**
   - With the above fixes, 15s is more than sufficient.

### Verification

- `dune build @check` ✅
- `dune runtest test/test_worktree_live_context.exe` — 7/7 pass ✅

### Test updates

- `test_capture_distinguishes_new_changes`: uses tracked file (`other.ml`) instead of untracked (`other.md`) since untracked files are now intentionally excluded.
- `test_current_status_lines_uses_short_cache_and_no_optional_locks`: updated expected git args to include `--untracked-files=no`.
- `test_git_status_timeout_defaults_to_15_seconds`: timeout expectation updated to 15.0s.

## Related

- Closes alternative: #9634