### PR TITLE
fix(lib): OCaml 5.x best practice batch — Atomic, accumulators, silent failures

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -24,7 +24,7 @@ type subscription = {
 let subscriptions : subscription SMap.t Atomic.t = Atomic.make SMap.empty
 
 (* Persistence file path - set by init *)
-let subscriptions_file = ref ""
+let subscriptions_file : string option ref = ref None
 
 (** Convert event_type to string for JSON *)
 let event_type_to_string = function
@@ -69,14 +69,15 @@ let subscription_of_json (json : Yojson.Safe.t) : subscription option =
 
 (** Save subscriptions to file *)
 let save_subscriptions () =
-  if !subscriptions_file = "" then ()
-  else
+  match !subscriptions_file with
+  | None -> ()
+  | Some path ->
     let subs =
       SMap.fold (fun _k v acc -> subscription_to_json v :: acc) (Atomic.get subscriptions) [] in
     let json = `Assoc [("subscriptions", `List subs)] in
     let content = Yojson.Safe.pretty_to_string json in
     try
-      Fs_compat.save_file !subscriptions_file content
+      Fs_compat.save_file path content
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | e ->
@@ -84,9 +85,11 @@ let save_subscriptions () =
 
 (** Load subscriptions from file *)
 let load_subscriptions () =
-  if !subscriptions_file = "" || not (Sys.file_exists !subscriptions_file) then ()
-  else
-    match Safe_ops.read_json_file_safe !subscriptions_file with
+  match !subscriptions_file with
+  | None -> ()
+  | Some path when not (Sys.file_exists path) -> ()
+  | Some path ->
+    match Safe_ops.read_json_file_safe path with
     | Error msg -> Log.Misc.warn "load_subscriptions: %s" msg
     | Ok json ->
       let module U = Yojson.Safe.Util in
@@ -101,7 +104,7 @@ let load_subscriptions () =
 
 (** Initialize A2A tools with MASC directory *)
 let init ~masc_dir =
-  subscriptions_file := Filename.concat masc_dir "subscriptions.json";
+  subscriptions_file := Some (Filename.concat masc_dir "subscriptions.json");
   load_subscriptions ()
 
 (** Event record for buffering *)
@@ -124,7 +127,9 @@ let uuid_rng_mutex = Stdlib.Mutex.create ()
 (** Generate stable UUIDv4 identifiers for subscriptions and delegated tasks.
     Uses a dedicated RNG so successive calls advance state instead of cloning
     the process-global Random state on every invocation.
-    Mutex-protected for fiber safety (Random.State is mutable). *)
+    [Stdlib.Mutex] (not [Eio.Mutex]) is required because [Random.State] is not
+    domain-safe; if keepers run on different domains the lock must be OS-level.
+    See feedback memory: OCaml5 Eio sync primitives — cross-domain = Stdlib.Mutex. *)
 let generate_uuid () =
   Stdlib.Mutex.protect uuid_rng_mutex (fun () ->
     let uuid = Uuidm.v4_gen uuid_rng () in

--- a/lib/agent_stress.ml
+++ b/lib/agent_stress.ml
@@ -56,7 +56,10 @@ let buffer_cap = 64
 let ensure_dir path =
   let dir = Filename.dirname path in
   if not (Sys.file_exists dir) then
-    (try Sys.mkdir dir 0o755 with Sys_error _ -> ())
+    try Sys.mkdir dir 0o755 with
+    | Sys_error msg when String.contains msg "exists" -> ()
+    | Sys_error msg ->
+      Log.warn ~ctx:"agent_stress" "cannot mkdir %s: %s" dir msg
 
 let do_flush () =
   match !store_path_ref with
@@ -71,7 +74,9 @@ let do_flush () =
           Log.warn ~ctx:"agent_stress" "cannot open %s: %s" path msg;
           None
       with
-      | None -> ()
+      | None ->
+          Log.warn ~ctx:"agent_stress" "flush skipped: %d records remain buffered"
+            (Queue.length buffer)
       | Some oc ->
         Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
           Queue.iter (fun json ->
@@ -126,4 +131,6 @@ let recent n =
         drop to_skip lines
         |> List.filter_map (fun line ->
           try Some (Yojson.Safe.from_string line)
-          with Yojson.Json_error _ -> None)
+          with Yojson.Json_error msg ->
+            Log.warn ~ctx:"agent_stress" "dropping malformed line: %s" msg;
+            None)

--- a/lib/agent_stress.ml
+++ b/lib/agent_stress.ml
@@ -57,7 +57,7 @@ let ensure_dir path =
   let dir = Filename.dirname path in
   if not (Sys.file_exists dir) then
     try Sys.mkdir dir 0o755 with
-    | Sys_error msg when String.contains msg "exists" -> ()
+    | Sys_error msg when String_util.contains_substring msg "exists" -> ()
     | Sys_error msg ->
       Log.warn ~ctx:"agent_stress" "cannot mkdir %s: %s" dir msg
 

--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -12,15 +12,15 @@ module SS = Set.Make (String)
 let unique_preserve_order = Json_util.dedupe_keep_order
 
 let dedupe_schemas (schemas : Types.tool_schema list) =
-  let seen = ref SS.empty in
-  List.filter
-    (fun (schema : Types.tool_schema) ->
-      if SS.mem schema.name !seen then
-        false
-      else (
-        seen := SS.add schema.name !seen;
-        true))
-    schemas
+  let unique, _ =
+    List.fold_left
+      (fun (acc, seen) (schema : Types.tool_schema) ->
+        if SS.mem schema.name seen then (acc, seen)
+        else (schema :: acc, SS.add schema.name seen))
+      ([], SS.empty)
+      schemas
+  in
+  List.rev unique
 
 let prefixed_tool_names names =
   names |> List.map (fun name -> "mcp__masc__" ^ name)

--- a/lib/autoresearch/autoresearch_git.ml
+++ b/lib/autoresearch/autoresearch_git.ml
@@ -149,9 +149,11 @@ let git_tag_best ~workdir ~cycle ~score =
   else
   let tag = Printf.sprintf "ar-best-c%d-%.4f" cycle score in
   (try
-     ignore
-       (run_git_with_status ~timeout_sec:10.0 ~workdir
-          [ "tag"; "-f"; tag ])
+     let (_status, _output) =
+       run_git_with_status ~timeout_sec:10.0 ~workdir
+         [ "tag"; "-f"; tag ]
+     in
+     ()
    with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Autoresearch.warn "git tag failed in %s: %s" workdir (Printexc.to_string exn))
 
 (** Get the git top-level directory for a workdir. *)

--- a/lib/autoresearch/autoresearch_git.ml
+++ b/lib/autoresearch/autoresearch_git.ml
@@ -195,13 +195,15 @@ let prepare_managed_worktree ~base_path ~source_workdir ~loop_id =
   match git_top_level ~workdir:source_workdir with
   | Error _ as err -> err
   | Ok repo_root ->
-      let warnings = ref [] in
-      if git_is_dirty ~workdir:source_workdir then
-        warnings := "source_workdir_dirty" :: !warnings;
-      (match git_current_branch ~workdir:source_workdir with
-      | Some branch when not (String.equal branch "main" || String.equal branch "master") ->
-          warnings := ("source_branch:" ^ branch) :: !warnings
-      | Some _ | None -> ());
+      let warnings =
+        if git_is_dirty ~workdir:source_workdir then ["source_workdir_dirty"] else []
+      in
+      let warnings =
+        match git_current_branch ~workdir:source_workdir with
+        | Some branch when not (String.equal branch "main" || String.equal branch "master") ->
+            ("source_branch:" ^ branch) :: warnings
+        | Some _ | None -> warnings
+      in
       let workdir = Autoresearch_storage.managed_worktree_dir ~base_path loop_id in
       if Sys.file_exists workdir then
         Result.error (Printf.sprintf "managed worktree already exists: %s" workdir)
@@ -213,7 +215,7 @@ let prepare_managed_worktree ~base_path ~source_workdir ~loop_id =
             [ "worktree"; "add"; "-b"; branch; workdir; "HEAD" ]
         with
         | Unix.WEXITED 0, _ ->
-            Result.ok (workdir, repo_root, List.rev !warnings)
+            Result.ok (workdir, repo_root, List.rev warnings)
         | _, lines ->
             Result.error
               (Printf.sprintf "failed to create managed worktree: %s"

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -149,7 +149,7 @@ let vote store ~voter ~post_id ~direction : (int, board_error) result =
               ~kind:Earn_upvote ~reason:"upvote on post" () with
             | Ok _ -> ()
             | Error e ->
-                Log.Board.warn "board_votes: economy earn failed for %s: %s" author_name e);
+                Log.BoardLog.warn "board_votes: economy earn failed for %s: %s" author_name e);
            Ok delta
        | Ok { delta; earn_upvote_for = None } -> Ok delta
        | Error _ as e -> e)

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -144,9 +144,12 @@ let vote store ~voter ~post_id ~direction : (int, board_error) result =
          contention with every other reader/writer. *)
       (match board_result with
        | Ok { delta; earn_upvote_for = Some author_name } ->
-           ignore (Agent_economy.earn
-             ~base_path:(board_base_path ()) ~agent_name:author_name
-             ~kind:Earn_upvote ~reason:"upvote on post" ());
+           (match Agent_economy.earn
+              ~base_path:(board_base_path ()) ~agent_name:author_name
+              ~kind:Earn_upvote ~reason:"upvote on post" () with
+            | Ok _ -> ()
+            | Error e ->
+                Log.Board.warn "board_votes: economy earn failed for %s: %s" author_name e);
            Ok delta
        | Ok { delta; earn_upvote_for = None } -> Ok delta
        | Error _ as e -> e)

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -3,15 +3,15 @@
 module StringSet = Set.Make (String)
 
 let dedupe_schemas (schemas : Types.tool_schema list) =
-  let seen = ref StringSet.empty in
-  List.filter
-    (fun (schema : Types.tool_schema) ->
-      if StringSet.mem schema.name !seen then
-        false
-      else (
-        seen := StringSet.add schema.name !seen;
-        true))
-    schemas
+  let unique, _ =
+    List.fold_left
+      (fun (acc, seen) (schema : Types.tool_schema) ->
+        if StringSet.mem schema.name seen then (acc, seen)
+        else (schema :: acc, StringSet.add schema.name seen))
+      ([], StringSet.empty)
+      schemas
+  in
+  List.rev unique
 
 let retired_front_door_schema_names =
   [

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -44,32 +44,40 @@ let raw_all_tool_schemas : Types.tool_schema list =
     Logs warnings for: duplicate names, empty names/descriptions,
     input_schema.type not "object". Does not block startup. *)
 let validate_schemas (schemas : Types.tool_schema list) =
-  let errors = ref [] in
-  let seen = ref StringSet.empty in
-  List.iter
-    (fun (schema : Types.tool_schema) ->
-      if StringSet.mem schema.name !seen then
-        errors :=
-          Printf.sprintf "Duplicate tool name: %s" schema.name :: !errors
-      else seen := StringSet.add schema.name !seen;
-      if schema.name = "" then
-        errors := "Empty tool name found" :: !errors;
-      if schema.description = "" then
-        errors :=
-          Printf.sprintf "Empty description for tool: %s" schema.name
-          :: !errors;
-      match Yojson.Safe.Util.member "type" schema.input_schema with
-      | `String "object" -> ()
-      | _ ->
-          errors :=
-            Printf.sprintf "Tool %s: input_schema.type is not 'object'"
-              schema.name
-            :: !errors)
-    schemas;
-  match !errors with
+  let errors, _ =
+    List.fold_left
+      (fun (errors, seen) (schema : Types.tool_schema) ->
+        let errors =
+          if StringSet.mem schema.name seen then
+            Printf.sprintf "Duplicate tool name: %s" schema.name :: errors
+          else errors
+        in
+        let seen = StringSet.add schema.name seen in
+        let errors =
+          if schema.name = "" then "Empty tool name found" :: errors
+          else errors
+        in
+        let errors =
+          if schema.description = "" then
+            Printf.sprintf "Empty description for tool: %s" schema.name
+            :: errors
+          else errors
+        in
+        let errors =
+          match Yojson.Safe.Util.member "type" schema.input_schema with
+          | `String "object" -> errors
+          | _ ->
+              Printf.sprintf "Tool %s: input_schema.type is not 'object'"
+                schema.name
+              :: errors
+        in
+        (errors, seen))
+      ([], StringSet.empty)
+      schemas
+  in
+  match errors with
   | [] -> ()
-  | errs ->
-      List.iter (fun e -> Log.Config.warn "%s" e) errs
+  | errs -> List.iter (fun e -> Log.Config.warn "%s" e) errs
 
 let all_tool_schemas : Types.tool_schema list =
   let schemas =

--- a/lib/coord/coord_gc.ml
+++ b/lib/coord/coord_gc.ml
@@ -161,7 +161,7 @@ let cleanup_zombies
 
       (* Phase 5: Update state — only remove successfully cleaned agents *)
       if !successfully_cleaned <> [] then begin
-        let _ = update_state config (fun s ->
+        let _state = update_state config (fun s ->
           { s with active_agents =
               List.filter (fun a -> not (List.mem a !successfully_cleaned)) s.active_agents }
         ) in

--- a/lib/coord/coord_lifecycle.ml
+++ b/lib/coord/coord_lifecycle.ml
@@ -101,10 +101,10 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
            let agents = nickname :: List.filter ((<>) nickname) s.active_agents in
            { s with active_agents = agents }
          ) in
-         (match broadcast config ~from_agent:nickname
-          ~content:(Printf.sprintf "👋 %s rejoined the namespace" nickname) with
-         | Ok _ -> ()
-         | Error e -> Log.Coord.warn "broadcast failed on rejoin for %s: %s" nickname e);
+         let _ =
+           broadcast config ~from_agent:nickname
+             ~content:(Printf.sprintf "👋 %s rejoined the namespace" nickname)
+         in
          log_event config (Printf.sprintf
            "{\"type\":\"agent_join\",\"agent\":\"%s\",\"agent_type\":\"%s\",\"session_id\":\"%s\",\"rejoin\":true,\"ts\":\"%s\"}"
            nickname agent_type new_session_id (now_iso ()));
@@ -162,9 +162,10 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
   ) in
 
   (* Broadcast join *)
-  (match broadcast config ~from_agent:nickname ~content:(Printf.sprintf "👋 %s joined the namespace" nickname) with
-  | Ok _ -> ()
-  | Error e -> Log.Coord.warn "broadcast failed on join for %s: %s" nickname e);
+  let _ =
+    broadcast config ~from_agent:nickname
+      ~content:(Printf.sprintf "👋 %s joined the namespace" nickname)
+  in
 
   (* Log event with metadata *)
   log_event config (Printf.sprintf
@@ -226,9 +227,10 @@ let leave config ~agent_name =
       { s with active_agents = List.filter ((<>) actual_name) s.active_agents }
     ) in
 
-    (match broadcast config ~from_agent:"system" ~content:(Printf.sprintf "👋 %s left the namespace" actual_name) with
-    | Ok _ -> ()
-    | Error e -> Log.Coord.warn "broadcast failed on leave for %s: %s" actual_name e);
+    let _ =
+      broadcast config ~from_agent:"system"
+        ~content:(Printf.sprintf "👋 %s left the namespace" actual_name)
+    in
 
     (* Log event *)
     log_event config (Printf.sprintf

--- a/lib/coord/coord_lifecycle.ml
+++ b/lib/coord/coord_lifecycle.ml
@@ -97,12 +97,14 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
        write_json config agent_file_dedup (agent_to_yojson updated);
        if is_inactive then begin
          (* Restore to active_agents on rejoin *)
-         let _ = update_state config (fun s ->
+         let _state = update_state config (fun s ->
            let agents = nickname :: List.filter ((<>) nickname) s.active_agents in
            { s with active_agents = agents }
          ) in
-         let _ = broadcast config ~from_agent:nickname
-          ~content:(Printf.sprintf "👋 %s rejoined the namespace" nickname) in
+         (match broadcast config ~from_agent:nickname
+          ~content:(Printf.sprintf "👋 %s rejoined the namespace" nickname) with
+         | Ok _ -> ()
+         | Error e -> Log.Coord.warn "broadcast failed on rejoin for %s: %s" nickname e);
          log_event config (Printf.sprintf
            "{\"type\":\"agent_join\",\"agent\":\"%s\",\"agent_type\":\"%s\",\"session_id\":\"%s\",\"rejoin\":true,\"ts\":\"%s\"}"
            nickname agent_type new_session_id (now_iso ()));
@@ -154,13 +156,15 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
   write_json config agent_file agent_json;
 
   (* Update state *)
-  let _ = update_state config (fun s ->
+  let _state = update_state config (fun s ->
     let agents = nickname :: (List.filter ((<>) nickname) s.active_agents) in
     { s with active_agents = agents }
   ) in
 
   (* Broadcast join *)
-  let _ = broadcast config ~from_agent:nickname ~content:(Printf.sprintf "👋 %s joined the namespace" nickname) in
+  (match broadcast config ~from_agent:nickname ~content:(Printf.sprintf "👋 %s joined the namespace" nickname) with
+  | Ok _ -> ()
+  | Error e -> Log.Coord.warn "broadcast failed on join for %s: %s" nickname e);
 
   (* Log event with metadata *)
   log_event config (Printf.sprintf
@@ -218,11 +222,13 @@ let leave config ~agent_name =
     (* Capture active agents before removal for relationship materialization *)
     let peers_before_leave = (read_state config).active_agents in
 
-    let _ = update_state config (fun s ->
+    let _state = update_state config (fun s ->
       { s with active_agents = List.filter ((<>) actual_name) s.active_agents }
     ) in
 
-    let _ = broadcast config ~from_agent:"system" ~content:(Printf.sprintf "👋 %s left the namespace" actual_name) in
+    (match broadcast config ~from_agent:"system" ~content:(Printf.sprintf "👋 %s left the namespace" actual_name) with
+    | Ok _ -> ()
+    | Error e -> Log.Coord.warn "broadcast failed on leave for %s: %s" actual_name e);
 
     (* Log event *)
     log_event config (Printf.sprintf

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -456,12 +456,13 @@ let add_task
                           | None -> false) )
                    ]);
            (Atomic.get Coord_hooks.on_task_mutation_fn) ();
-           let _ =
-             broadcast
+           (match broadcast
                config
                ~from_agent:actor
                ~content:(Printf.sprintf "📋 New quest: %s" title)
-           in
+            with
+            | Ok _ -> ()
+            | Error e -> Log.Coord.warn "broadcast failed on add_task: %s" e);
            Printf.sprintf "✅ Added %s: %s" task_id title))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -556,12 +557,13 @@ let add_task_with_role
                    ]);
            (Atomic.get Coord_hooks.on_task_mutation_fn) ();
            let role_str = Types_core.role_to_string required_role in
-           let _ =
-             broadcast
+           (match broadcast
                config
                ~from_agent:actor
                ~content:(Printf.sprintf "📋 New quest: %s (requires: %s)" title role_str)
-           in
+            with
+            | Ok _ -> ()
+            | Error e -> Log.Coord.warn "broadcast failed on add_task_with_role: %s" e);
            Printf.sprintf "✅ Added %s: %s (required_role: %s)" task_id title role_str))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -648,7 +650,9 @@ let batch_add_tasks_internal ?created_by config tasks =
              (List.length added_tasks)
              summary
          in
-         let _ = broadcast config ~from_agent:actor ~content:msg in
+         (match broadcast config ~from_agent:actor ~content:msg with
+          | Ok _ -> ()
+          | Error e -> Log.Coord.warn "broadcast failed on add_batch_tasks: %s" e);
          Printf.sprintf "✅ Added %d tasks: %s" (List.length added_tasks) summary
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
@@ -732,12 +736,13 @@ let claim_task config ~agent_name ~task_id =
                   write_backlog config new_backlog;
                   update_local_agent_state config ~agent_name (fun agent ->
                     { agent with status = Busy; current_task = Some task_id });
-                  let _ =
-                    broadcast
+                  (match broadcast
                       config
                       ~from_agent:agent_name
                       ~content:(Printf.sprintf "📋 Claimed %s" task_id)
-                  in
+                   with
+                   | Ok _ -> ()
+                   | Error e -> Log.Coord.warn "broadcast failed on claim: %s" e);
                   emit_task_activity
                     config
                     ~agent_name
@@ -875,12 +880,13 @@ let claim_task_r config ~agent_name ~task_id ?(agent_role = Types_core.Unassigne
            write_backlog config new_backlog;
            update_local_agent_state config ~agent_name (fun agent ->
              { agent with status = Busy; current_task = Some task_id });
-           let _ =
-             broadcast
+           (match broadcast
                config
                ~from_agent:agent_name
                ~content:(Printf.sprintf "📋 Claimed %s" task_id)
-           in
+            with
+            | Ok _ -> ()
+            | Error e -> Log.Coord.warn "broadcast failed on claim: %s" e);
            emit_task_activity
              config
              ~agent_name
@@ -1513,7 +1519,9 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
                  then Printf.sprintf "🚫 Cancelled %s" task_id
                  else Printf.sprintf "🚫 Cancelled %s - %s" task_id reason
                in
-               let _ = broadcast config ~from_agent:agent_name ~content:msg in
+               (match broadcast config ~from_agent:agent_name ~content:msg with
+                | Ok _ -> ()
+                | Error e -> Log.Coord.warn "broadcast failed on cancel: %s" e);
                emit_task_activity
                  config
                  ~agent_name

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -456,13 +456,12 @@ let add_task
                           | None -> false) )
                    ]);
            (Atomic.get Coord_hooks.on_task_mutation_fn) ();
-           (match broadcast
+           let _ =
+             broadcast
                config
                ~from_agent:actor
                ~content:(Printf.sprintf "📋 New quest: %s" title)
-            with
-            | Ok _ -> ()
-            | Error e -> Log.Coord.warn "broadcast failed on add_task: %s" e);
+           in
            Printf.sprintf "✅ Added %s: %s" task_id title))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -557,13 +556,12 @@ let add_task_with_role
                    ]);
            (Atomic.get Coord_hooks.on_task_mutation_fn) ();
            let role_str = Types_core.role_to_string required_role in
-           (match broadcast
+           let _ =
+             broadcast
                config
                ~from_agent:actor
                ~content:(Printf.sprintf "📋 New quest: %s (requires: %s)" title role_str)
-            with
-            | Ok _ -> ()
-            | Error e -> Log.Coord.warn "broadcast failed on add_task_with_role: %s" e);
+           in
            Printf.sprintf "✅ Added %s: %s (required_role: %s)" task_id title role_str))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -650,9 +648,7 @@ let batch_add_tasks_internal ?created_by config tasks =
              (List.length added_tasks)
              summary
          in
-         (match broadcast config ~from_agent:actor ~content:msg with
-          | Ok _ -> ()
-          | Error e -> Log.Coord.warn "broadcast failed on add_batch_tasks: %s" e);
+         let _ = broadcast config ~from_agent:actor ~content:msg in
          Printf.sprintf "✅ Added %d tasks: %s" (List.length added_tasks) summary
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
@@ -736,13 +732,12 @@ let claim_task config ~agent_name ~task_id =
                   write_backlog config new_backlog;
                   update_local_agent_state config ~agent_name (fun agent ->
                     { agent with status = Busy; current_task = Some task_id });
-                  (match broadcast
+                  let _ =
+                    broadcast
                       config
                       ~from_agent:agent_name
                       ~content:(Printf.sprintf "📋 Claimed %s" task_id)
-                   with
-                   | Ok _ -> ()
-                   | Error e -> Log.Coord.warn "broadcast failed on claim: %s" e);
+                  in
                   emit_task_activity
                     config
                     ~agent_name
@@ -880,13 +875,12 @@ let claim_task_r config ~agent_name ~task_id ?(agent_role = Types_core.Unassigne
            write_backlog config new_backlog;
            update_local_agent_state config ~agent_name (fun agent ->
              { agent with status = Busy; current_task = Some task_id });
-           (match broadcast
+           let _ =
+             broadcast
                config
                ~from_agent:agent_name
                ~content:(Printf.sprintf "📋 Claimed %s" task_id)
-            with
-            | Ok _ -> ()
-            | Error e -> Log.Coord.warn "broadcast failed on claim: %s" e);
+           in
            emit_task_activity
              config
              ~agent_name
@@ -1519,9 +1513,7 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
                  then Printf.sprintf "🚫 Cancelled %s" task_id
                  else Printf.sprintf "🚫 Cancelled %s - %s" task_id reason
                in
-               (match broadcast config ~from_agent:agent_name ~content:msg with
-                | Ok _ -> ()
-                | Error e -> Log.Coord.warn "broadcast failed on cancel: %s" e);
+               let _ = broadcast config ~from_agent:agent_name ~content:msg in
                emit_task_activity
                  config
                  ~agent_name

--- a/lib/coord_goals.ml
+++ b/lib/coord_goals.ml
@@ -545,28 +545,26 @@ let handle_goal_transition (ctx : context) args =
                                   effective_policy None );
                             ])
                   | Ok (Goal_phase.Move_to next_phase) ->
-                      let _ =
-                        match goal.active_verification_request_id, next_phase with
-                        | Some request_id, Goal_phase.Dropped
-                        | Some request_id, Goal_phase.Executing
-                          when goal.phase = Goal_phase.Awaiting_verification ->
-                            (match Goal_verification.cancel_request ctx.config ~request_id with
-                             | Ok _ ->
-                                 emit_goal_event ctx ~goal_id
-                                   ~event_type:"goal_verification_resolved"
-                                   ~payload:
-                                     (`Assoc
-                                       [
-                                         ("request_id", `String request_id);
-                                         ("status", `String "cancelled");
-                                       ])
-                             | Error msg ->
-                                 Log.Misc.warn
-                                   "goal verification cancel_request failed for %s: %s"
-                                   request_id msg)
-                        | None, _ -> ()
-                        | Some _, _ -> ()
-                      in
+                      (match goal.active_verification_request_id, next_phase with
+                       | Some request_id, Goal_phase.Dropped
+                       | Some request_id, Goal_phase.Executing
+                         when goal.phase = Goal_phase.Awaiting_verification ->
+                           (match Goal_verification.cancel_request ctx.config ~request_id with
+                            | Ok _ ->
+                                emit_goal_event ctx ~goal_id
+                                  ~event_type:"goal_verification_resolved"
+                                  ~payload:
+                                    (`Assoc
+                                      [
+                                        ("request_id", `String request_id);
+                                        ("status", `String "cancelled");
+                                      ])
+                            | Error msg ->
+                                Log.Misc.warn
+                                  "goal verification cancel_request failed for %s: %s"
+                                  request_id msg)
+                       | None, _ -> ()
+                       | Some _, _ -> ());
                       match
                         update_goal_phase ctx goal ~phase:next_phase ?note
                           ~clear_active_verification_request:

--- a/lib/core/text_similarity.ml
+++ b/lib/core/text_similarity.ml
@@ -33,11 +33,15 @@ let normalize_for_similarity (s : string) : string list =
     |> String.split_on_char ' '
     |> List.filter (fun w -> String.length w >= 2)
   in
-  let seen = ref StringSet.empty in
-  List.filter (fun w ->
-    if StringSet.mem w !seen then false
-    else (seen := StringSet.add w !seen; true)
-  ) words
+  let unique, _ =
+    List.fold_left
+      (fun (acc, seen) w ->
+        if StringSet.mem w seen then (acc, seen)
+        else (w :: acc, StringSet.add w seen))
+      ([], StringSet.empty)
+      words
+  in
+  List.rev unique
 
 (** Extract character n-grams from a cleaned string.
     For multibyte strings (Korean, CJK), each "character" may be multiple bytes.
@@ -55,16 +59,17 @@ let char_ngrams ~(n : int) (s : string) : string list =
   let len = String.length compact in
   if len < n then (if len > 0 then [compact] else [])
   else
-    let seen = ref StringSet.empty in
-    let acc = ref [] in
-    for i = 0 to len - n do
-      let gram = String.sub compact i n in
-      if not (StringSet.mem gram !seen) then begin
-        seen := StringSet.add gram !seen;
-        acc := gram :: !acc
-      end
-    done;
-    List.rev !acc
+    let indices = List.init (len - n + 1) Fun.id in
+    let acc, _ =
+      List.fold_left
+        (fun (acc, seen) i ->
+          let gram = String.sub compact i n in
+          if StringSet.mem gram seen then (acc, seen)
+          else (gram :: acc, StringSet.add gram seen))
+        ([], StringSet.empty)
+        indices
+    in
+    List.rev acc
 
 (** Jaccard similarity over a combined feature set: word tokens + character n-grams.
     Word tokens capture exact matches; n-grams capture partial/morphological overlap.

--- a/lib/dashboard/briefing_gaps.ml
+++ b/lib/dashboard/briefing_gaps.ml
@@ -66,15 +66,20 @@ let collect_metadata_gaps ~sessions ~keepers ~agents =
   in
   take 8 (session_gaps @ keeper_gaps @ agent_gaps)
 
-let gap_kinds_for_section = function
-  | "communication" ->
-      [ "session_communication_mode_missing"; "keeper_last_reply_missing" ]
-  | "alignment" ->
-      [ "session_goal_missing"; "agent_focus_missing" ]
-  | _ -> []
+type section =
+  | Communication
+  | Alignment
+  | Watch
 
-let count_metadata_gaps_for_section ~section_id gaps =
-  let allowed = gap_kinds_for_section section_id in
+let gap_kinds_for_section = function
+  | Communication ->
+      [ "session_communication_mode_missing"; "keeper_last_reply_missing" ]
+  | Alignment ->
+      [ "session_goal_missing"; "agent_focus_missing" ]
+  | Watch -> []
+
+let count_metadata_gaps_for_section ~section gaps =
+  let allowed = gap_kinds_for_section section in
   gaps
   |> List.fold_left
        (fun acc json ->
@@ -82,8 +87,8 @@ let count_metadata_gaps_for_section ~section_id gaps =
          if List.mem kind allowed then acc + 1 else acc)
        0
 
-let evidence_of_metadata_gaps ~section_id metadata_gaps =
-  let allowed = gap_kinds_for_section section_id in
+let evidence_of_metadata_gaps ~section metadata_gaps =
+  let allowed = gap_kinds_for_section section in
   metadata_gaps
   |> List.filter_map (fun json ->
          let kind = string_field "kind" json in

--- a/lib/dashboard/briefing_sections.ml
+++ b/lib/dashboard/briefing_sections.ml
@@ -83,9 +83,7 @@ let build_communication_section ~sessions ~recent_messages ~metadata_gaps
     count_matching_field "communication_mode" sessions ~predicate:(fun value ->
         value <> "" && value <> "unknown")
   in
-  let metadata_evidence =
-    evidence_of_metadata_gaps ~section_id:"communication" metadata_gaps
-  in
+  let metadata_evidence = evidence_of_metadata_gaps ~section:Communication metadata_gaps in
   let positive_signal =
     recent_message_count > 0 || broadcast_total > 0 || portal_total > 0
   in
@@ -152,9 +150,7 @@ let build_alignment_section ~sessions ~agents ~metadata_gaps =
         if String.equal (string_field "goal" json) "unassigned" then acc else acc + 1)
       0 sessions
   in
-  let metadata_evidence =
-    evidence_of_metadata_gaps ~section_id:"alignment" metadata_gaps
-  in
+  let metadata_evidence = evidence_of_metadata_gaps ~section:Alignment metadata_gaps in
   let evidence =
     []
     |> evidence_add_if (active_agent_count = 0) "Active agents count is zero"

--- a/lib/dashboard/briefing_sections.ml
+++ b/lib/dashboard/briefing_sections.ml
@@ -3,20 +3,29 @@
 open Briefing_json_helpers
 open Briefing_gaps
 
-let has_operational_signal ~section_id ~room_health ~incident_count ~recommended_action_count =
+let section_id_string = function
+  | Communication -> "communication"
+  | Alignment -> "alignment"
+  | Watch -> "watch"
+
+let section_label = function
+  | Communication -> "Communication"
+  | Alignment -> "Alignment"
+  | Watch -> "Watch Next"
+
+let has_operational_signal ~section ~room_health ~incident_count ~recommended_action_count =
   let room_risky =
     Dashboard_utils.is_health_at_risk (Dashboard_utils.health_level_of_string room_health)
   in
-  match section_id with
-  | "watch" -> room_risky || incident_count > 0 || recommended_action_count > 0
-  | "communication" | "alignment" -> room_risky || incident_count > 0
-  | _ -> false
+  match section with
+  | Watch -> room_risky || incident_count > 0 || recommended_action_count > 0
+  | Communication | Alignment -> room_risky || incident_count > 0
 
-let annotate_section ~section_id ~status ~summary ~evidence ~metadata_gaps
+let annotate_section ~section ~status ~summary ~evidence ~metadata_gaps
     ~room_health ~incident_count ~recommended_action_count =
-  let gap_count = count_metadata_gaps_for_section ~section_id metadata_gaps in
+  let gap_count = count_metadata_gaps_for_section ~section metadata_gaps in
   let operational =
-    has_operational_signal ~section_id ~room_health ~incident_count
+    has_operational_signal ~section ~room_health ~incident_count
       ~recommended_action_count
   in
   let signal_class, evidence_quality =
@@ -35,8 +44,8 @@ let annotate_section ~section_id ~status ~summary ~evidence ~metadata_gaps
   in
   `Assoc
     [
-      ("id", `String section_id);
-      ("label", `String (match section_id with "communication" -> "Communication" | "alignment" -> "Alignment" | _ -> "Watch Next"));
+      ("id", `String (section_id_string section));
+      ("label", `String (section_label section));
       ("status", `String status);
       ("summary", `String summary);
       ("evidence", `List (List.map (fun item -> `String item) evidence));
@@ -226,13 +235,13 @@ let build_briefing_sections ~mission_summary_json ~sessions ~agents ~recent_mess
   in
   ( watch_summary,
     [
-      annotate_section ~section_id:"communication" ~status:communication_status
+      annotate_section ~section:Communication ~status:communication_status
         ~summary:communication_summary ~evidence:communication_evidence
         ~metadata_gaps ~room_health ~incident_count ~recommended_action_count;
-      annotate_section ~section_id:"alignment" ~status:alignment_status
+      annotate_section ~section:Alignment ~status:alignment_status
         ~summary:alignment_summary ~evidence:alignment_evidence ~metadata_gaps
         ~room_health ~incident_count ~recommended_action_count;
-      annotate_section ~section_id:"watch" ~status:watch_status
+      annotate_section ~section:Watch ~status:watch_status
         ~summary:watch_summary ~evidence:watch_evidence ~metadata_gaps
         ~room_health ~incident_count ~recommended_action_count;
     ] )

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -335,7 +335,7 @@ let save_raw_config_json raw_json =
   | Cascade_toml_materializer.Json ->
       let parse_result =
         try
-          ignore (Yojson.Safe.from_string raw_json);
+          let (_ : Yojson.Safe.t) = Yojson.Safe.from_string raw_json in
           Ok ()
         with
         | Eio.Cancel.Cancelled _ as exn -> raise exn

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -225,26 +225,23 @@ let config_json () =
           "dashboard cascade config: validated catalog unavailable: %s"
           detail;
         let invalid_names = invalid_name_set config_path in
-        let seen = ref StringSet.empty in
-        let add_profile_name acc name =
+        let add_profile_name (acc, seen) name =
           let canonical = Keeper_cascade_profile.canonicalize name in
-          if StringSet.mem canonical invalid_names || StringSet.mem canonical !seen
-          then acc
-          else (
-            seen := StringSet.add canonical !seen;
-            canonical :: acc)
+          if StringSet.mem canonical invalid_names || StringSet.mem canonical seen
+          then (acc, seen)
+          else (canonical :: acc, StringSet.add canonical seen)
         in
-        let acc_after_catalog =
-          List.fold_left add_profile_name [] (live_profiles ?config_path ())
+        let acc_after_catalog, seen_after_catalog =
+          List.fold_left add_profile_name ([], StringSet.empty) (live_profiles ?config_path ())
         in
-        let names =
+        let names, _ =
           List.fold_left
-            (fun acc (e : Keeper_registry.registry_entry) ->
-               add_profile_name acc e.meta.cascade_name)
-            acc_after_catalog
+            (fun (acc, seen) (e : Keeper_registry.registry_entry) ->
+               add_profile_name (acc, seen) e.meta.cascade_name)
+            (acc_after_catalog, seen_after_catalog)
             keeper_entries
-          |> List.rev
         in
+        let names = List.rev names in
         List.map
           (profile_json_raw ~config_path ~keeper_assignable_names)
           names

--- a/lib/governance_registry.ml
+++ b/lib/governance_registry.ml
@@ -640,17 +640,17 @@ let surfaces =
 (** Force module initialization to guarantee all params are registered
     before [Runtime_params.restore]. Call from server bootstrap. *)
 let ensure_init () =
-  ignore (Runtime_params.get message_max_count);
-  ignore (Runtime_params.get dashboard_max_path_length);
-  ignore (Runtime_params.get dashboard_max_message_length);
-  ignore (Runtime_params.get dashboard_max_pending_tasks);
-  ignore (Runtime_params.get dashboard_max_recent_messages);
-  ignore (Runtime_params.get dashboard_min_border_length);
-  ignore (Runtime_params.get dashboard_agent_quiet_threshold_sec);
-  ignore (Runtime_params.get dashboard_agent_stuck_threshold_sec);
-  ignore (Runtime_params.get drift_factual_coverage_floor);
-  ignore (Runtime_params.get drift_factual_size_ratio_floor);
-  ignore (Runtime_params.get drift_structural_divergence_threshold);
+  let (_ : _) = Runtime_params.get message_max_count in
+  let (_ : _) = Runtime_params.get dashboard_max_path_length in
+  let (_ : _) = Runtime_params.get dashboard_max_message_length in
+  let (_ : _) = Runtime_params.get dashboard_max_pending_tasks in
+  let (_ : _) = Runtime_params.get dashboard_max_recent_messages in
+  let (_ : _) = Runtime_params.get dashboard_min_border_length in
+  let (_ : _) = Runtime_params.get dashboard_agent_quiet_threshold_sec in
+  let (_ : _) = Runtime_params.get dashboard_agent_stuck_threshold_sec in
+  let (_ : _) = Runtime_params.get drift_factual_coverage_floor in
+  let (_ : _) = Runtime_params.get drift_factual_size_ratio_floor in
+  let (_ : _) = Runtime_params.get drift_structural_divergence_threshold in
   Keeper_config.ensure_runtime_params_init ()
 
 let surfaces_json () =

--- a/lib/grpc/masc_grpc_client.ml
+++ b/lib/grpc/masc_grpc_client.ml
@@ -122,19 +122,30 @@ let subscribe t ~sw ~env ~agent_name ~session_id ~event_types ~since_seq =
       match Grpc_eio.Stream.take raw_stream with
       | Ok bytes ->
         (try
-          ignore (push_typed (Ok (T.Event.of_bytes bytes)))
+          match push_typed (Ok (T.Event.of_bytes bytes)) with
+          | `Added -> ()
+          | `Closed ->
+             Log.Transport.debug "gRPC subscribe: typed stream closed, skipping event"
+          | `Failed exn ->
+             Log.Transport.error "gRPC subscribe: push_typed failed: %s"
+               (Printexc.to_string exn)
         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-          ignore
-            (push_error
-               (Printf.sprintf "event decode error: %s"
-                  (Printexc.to_string exn))));
+          match push_error
+            (Printf.sprintf "event decode error: %s"
+               (Printexc.to_string exn)) with
+          | `Added -> ()
+          | `Closed | `Failed _ -> ());
         loop ()
       | Error status ->
         if not (Grpc_core.Status.is_ok status) then
-          ignore
-            (push_error
-               (Printf.sprintf "subscribe stream error: %s"
-                  (Grpc_core.Status.to_string status)));
+          (match push_error
+             (Printf.sprintf "subscribe stream error: %s"
+                (Grpc_core.Status.to_string status)) with
+           | `Added -> ()
+           | `Closed -> ()
+           | `Failed exn ->
+             Log.Transport.error "gRPC subscribe: push_error failed: %s"
+               (Printexc.to_string exn));
         close_typed ()
       | exception End_of_file ->
         close_typed ()

--- a/lib/heuristic_metrics.ml
+++ b/lib/heuristic_metrics.ml
@@ -83,7 +83,7 @@ let ensure_dir path =
   let dir = Filename.dirname path in
   if not (Sys.file_exists dir) then
     try Sys.mkdir dir 0o755 with
-    | Sys_error msg when String.contains msg "exists" -> ()
+    | Sys_error msg when String_util.contains_substring msg "exists" -> ()
     | Sys_error msg ->
       Log.warn ~ctx:"heuristic_metrics" "cannot mkdir %s: %s" dir msg
 

--- a/lib/heuristic_metrics.ml
+++ b/lib/heuristic_metrics.ml
@@ -82,7 +82,10 @@ let buffer_cap = 64
 let ensure_dir path =
   let dir = Filename.dirname path in
   if not (Sys.file_exists dir) then
-    (try Sys.mkdir dir 0o755 with Sys_error _ -> ())
+    try Sys.mkdir dir 0o755 with
+    | Sys_error msg when String.contains msg "exists" -> ()
+    | Sys_error msg ->
+      Log.warn ~ctx:"heuristic_metrics" "cannot mkdir %s: %s" dir msg
 
 let do_flush () =
   match !store_path_ref with
@@ -97,7 +100,9 @@ let do_flush () =
           Log.warn ~ctx:"heuristic_metrics" "cannot open %s: %s" path msg;
           Error msg
       with
-      | Error _ -> ()
+      | Error _ ->
+          Log.warn ~ctx:"heuristic_metrics" "flush skipped: %d records remain buffered"
+            (Queue.length buffer)
       | Ok oc ->
           Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
             Queue.iter (fun json ->
@@ -152,4 +157,6 @@ let recent n =
         drop to_skip lines
         |> List.filter_map (fun line ->
           try Some (Yojson.Safe.from_string line)
-          with Yojson.Json_error _ -> None)
+          with Yojson.Json_error msg ->
+            Log.warn ~ctx:"heuristic_metrics" "dropping malformed line: %s" msg;
+            None)

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -381,8 +381,11 @@ let update_playground_repo_cache
       "repos", `List updated;
       "last_updated", `String ts;
     ] in
-    ignore (Fs_compat.save_file_atomic cache_path
-      (Yojson.Safe.pretty_to_string json ^ "\n"))
+    (match Fs_compat.save_file_atomic cache_path
+       (Yojson.Safe.pretty_to_string json ^ "\n") with
+     | Ok () -> ()
+     | Error e ->
+         Logs.warn (fun f -> f "playground cache save failed: %s" e))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
@@ -2039,7 +2042,8 @@ let handle_keeper_shell
                ; "url", `String url
                ])
        | Ok () ->
-         ignore (Keeper_alerting_path.ensure_sandbox_bundle ~config ~meta);
+         let _bundle_paths = Keeper_alerting_path.ensure_sandbox_bundle ~config ~meta in
+         ignore (_bundle_paths : string list);
          let playground = keeper_playground_root ~config ~meta in
          let repos_dir = Filename.concat playground "repos" in
          Fs_compat.mkdir_p repos_dir;

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -136,10 +136,16 @@ let maybe_rotate_file path =
           for i = max_rotated downto 2 do
             let src = Printf.sprintf "%s.%d" path (i - 1) in
             let dst = Printf.sprintf "%s.%d" path i in
-            (try Fs_compat.rename src dst with Sys_error _ -> ())
+            try Fs_compat.rename src dst with
+            | Sys_error msg when String.contains msg "No such file" -> ()
+            | Sys_error msg ->
+              Log.Misc.warn "rotate: cannot rename %s -> %s: %s" src dst msg
           done;
           let rotated = Printf.sprintf "%s.1" path in
-          (try Fs_compat.rename path rotated with Sys_error _ -> ())
+          try Fs_compat.rename path rotated with
+          | Sys_error msg when String.contains msg "No such file" -> ()
+          | Sys_error msg ->
+            Log.Misc.warn "rotate: cannot rename %s -> %s: %s" path rotated msg
         end
 
 let append_jsonl_line path (json : Yojson.Safe.t) =

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -137,13 +137,13 @@ let maybe_rotate_file path =
             let src = Printf.sprintf "%s.%d" path (i - 1) in
             let dst = Printf.sprintf "%s.%d" path i in
             try Fs_compat.rename src dst with
-            | Sys_error msg when String.contains msg "No such file" -> ()
+            | Sys_error msg when String_util.contains_substring msg "No such file" -> ()
             | Sys_error msg ->
               Log.Misc.warn "rotate: cannot rename %s -> %s: %s" src dst msg
           done;
           let rotated = Printf.sprintf "%s.1" path in
           try Fs_compat.rename path rotated with
-          | Sys_error msg when String.contains msg "No such file" -> ()
+          | Sys_error msg when String_util.contains_substring msg "No such file" -> ()
           | Sys_error msg ->
             Log.Misc.warn "rotate: cannot rename %s -> %s: %s" path rotated msg
         end

--- a/lib/level4_config.ml
+++ b/lib/level4_config.ml
@@ -26,13 +26,13 @@ let get_env_int name default =
 (** {1 Random Number Generator} *)
 
 (** Initialize RNG with seed for reproducibility *)
-let rng_initialized = ref false
+let rng_initialized = Atomic.make false
 
 let ensure_rng_init () =
-  if not !rng_initialized then begin
+  if not (Atomic.get rng_initialized) then begin
     let seed = get_env_int "MASC_RANDOM_SEED" (int_of_float (Time_compat.now () *. 1000.0)) in
     Random.init seed;
-    rng_initialized := true
+    Atomic.set rng_initialized true
   end
 
 (** Get random float with guaranteed initialization *)

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -523,8 +523,7 @@ let create_state ~base_path =
 let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
   let config =
     Coord.default_config_eio ~sw
-      ~on_backend_ready:(fun backend ->
-        ignore backend;
+      ~on_backend_ready:(fun _backend ->
         Log.Backend.info "Board: JSONL default backend";
         Board_dispatch.init_jsonl ())
       base_path

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -274,8 +274,7 @@ let coerce_tool_timeout_sec (raw_timeout_sec : float option) : float option =
       Some (float_of_int (max 5 (min 300 raw_sec)))
 
 (** Optional per-tool timeout to prevent long calls from starving the request loop. *)
-let tool_timeout_sec_opt ~(tool_name : string) ~(arguments : Yojson.Safe.t) : float option =
-  ignore arguments;
+let tool_timeout_sec_opt ~(tool_name : string) ~(_arguments : Yojson.Safe.t) : float option =
   match tool_name with
   | "masc_keeper_msg" ->
       (* No fixed timeout for keeper_msg. Keeper has its own internal limits

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -337,7 +337,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     let local_timeout_hit = ref false in
     let result =
       try
-        match tool_timeout_sec_opt ~tool_name:name ~arguments with
+        match tool_timeout_sec_opt ~tool_name:name ~_arguments:arguments with
         | None ->
             execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~arguments
         | Some timeout_sec ->

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -404,7 +404,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         (* Persist nickname so subsequent calls can use it. *)
         write_mcp_session_agent nickname;
         write_term_session_agent nickname;
-        let (_ : Session.session) = Session.register registry ~agent_name:nickname in
+        ignore (Session.register registry ~agent_name:nickname);
         nickname
       end
     end else
@@ -413,7 +413,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
 
   (* Auto-register session for non-read-only tools *)
   if agent_name <> "unknown" && not is_read_only then
-    let (_ : Session.session) = Session.register registry ~agent_name in
+    ignore (Session.register registry ~agent_name);
 
   (* Log tool call *)
   Log.Mcp.debug "[%s] %s" agent_name name;
@@ -432,7 +432,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     in
     if (not skip_heartbeat) && !room_init_cached then
       try
-        let (_ : string) = Coord.heartbeat config ~agent_name in
+        ignore (Coord.heartbeat config ~agent_name)
       with
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn ->
@@ -464,7 +464,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
       (false, Printf.sprintf
          "❌ Join required: Call masc_join first before using %s.\n\n💡 Workflow: masc_join → masc_status → %s\n📚 See: @~/me/instructions/masc-workflow.md\n[DEBUG] agent_name=%s is_joined=%b"
          name name agent_name is_joined)
-  else
+  else (
 
   (* === Fix 1: Tag-based lazy context dispatch ===
      O(1) tag lookup determines which module handles this tool.
@@ -570,4 +570,4 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
            Log.Mcp.warn "registry inconsistency: %s minted but no tag" name;
            with_system_internal_audit ~agent_name
              (false,
-              Printf.sprintf "Unknown tool: %s (registry inconsistency)" name))
+              Printf.sprintf "Unknown tool: %s (registry inconsistency)" name)))

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -404,7 +404,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         (* Persist nickname so subsequent calls can use it. *)
         write_mcp_session_agent nickname;
         write_term_session_agent nickname;
-        ignore (Session.register registry ~agent_name:nickname);
+        let (_ : Session.session) = Session.register registry ~agent_name:nickname in
         nickname
       end
     end else
@@ -413,7 +413,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
 
   (* Auto-register session for non-read-only tools *)
   if agent_name <> "unknown" && not is_read_only then
-    ignore (Session.register registry ~agent_name);
+    let (_ : Session.session) = Session.register registry ~agent_name in
 
   (* Log tool call *)
   Log.Mcp.debug "[%s] %s" agent_name name;
@@ -432,7 +432,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     in
     if (not skip_heartbeat) && !room_init_cached then
       try
-        ignore (Coord.heartbeat config ~agent_name)
+        let (_ : string) = Coord.heartbeat config ~agent_name in
       with
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn ->

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -157,7 +157,10 @@ let make_orchestrator_check_consumer ~sw ~proc_mgr ?domain_mgr ~config ~room_con
         if should_orchestrate ~min_priority:config.min_priority room_config then
           Eio.Fiber.fork ~sw (fun () ->
             try
-              let (_ : Spawn.spawn_result) = spawn_orchestrator ~sw ~proc_mgr ?domain_mgr config room_config in
+              let (_ : Spawn.spawn_result) =
+                spawn_orchestrator ~sw ~proc_mgr ?domain_mgr config room_config
+              in
+              ()
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               Log.Orchestrator.error "spawn failed: %s" (Printexc.to_string exn));
         Ok ()

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -157,7 +157,7 @@ let make_orchestrator_check_consumer ~sw ~proc_mgr ?domain_mgr ~config ~room_con
         if should_orchestrate room_config then
           Eio.Fiber.fork ~sw (fun () ->
             try
-              ignore (spawn_orchestrator ~sw ~proc_mgr ?domain_mgr config room_config)
+              let (_ : Spawn.spawn_result) = spawn_orchestrator ~sw ~proc_mgr ?domain_mgr config room_config in
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               Log.Orchestrator.error "spawn failed: %s" (Printexc.to_string exn));
         Ok ()

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -29,7 +29,7 @@ let load_config () =
 let default_config = load_config ()
 
 (** Check if orchestration is needed *)
-let should_orchestrate room_config =
+let should_orchestrate ~min_priority room_config =
   (* Check if room is paused first *)
   if Coord.is_paused room_config then begin
     Log.Orchestrator.debug "room is paused, skipping";
@@ -43,7 +43,7 @@ let should_orchestrate room_config =
   | Ok backlog ->
       (* Get unclaimed tasks with priority <= min_priority *)
       let unclaimed_important = List.filter (fun (task: Types.task) ->
-        task.task_status = Types.Todo && task.priority <= 2
+        task.task_status = Types.Todo && task.priority <= min_priority
       ) backlog.tasks in
 
       (* Get active (non-zombie) agents *)
@@ -54,7 +54,7 @@ let should_orchestrate room_config =
 
       (* Need orchestration if: important tasks exist AND no active agents *)
       let needs_orchestration =
-        List.length unclaimed_important > 0 && List.length active_agents = 0
+        unclaimed_important <> [] && active_agents = []
       in
 
       if needs_orchestration then
@@ -154,7 +154,7 @@ let make_orchestrator_check_consumer ~sw ~proc_mgr ?domain_mgr ~config ~room_con
     let should_act _beat = config.enabled
     let on_beat _beat =
       try
-        if should_orchestrate room_config then
+        if should_orchestrate ~min_priority:config.min_priority room_config then
           Eio.Fiber.fork ~sw (fun () ->
             try
               let (_ : Spawn.spawn_result) = spawn_orchestrator ~sw ~proc_mgr ?domain_mgr config room_config in

--- a/lib/orchestrator.mli
+++ b/lib/orchestrator.mli
@@ -15,7 +15,7 @@ val default_config : config
 (** Load config from environment or use defaults *)
 val load_config : unit -> config
 val make_orchestrator_prompt : port:int -> string
-val should_orchestrate : Coord.config -> bool
+val should_orchestrate : min_priority:int -> Coord.config -> bool
 
 (** Start the orchestrator background services using Pulse.
     Returns a cancel function to gracefully stop both Pulse engines. *)

--- a/lib/otel/otel_spans.ml
+++ b/lib/otel/otel_spans.ml
@@ -54,12 +54,12 @@ let setup_exporter ~sw (env : Eio_unix.Stdenv.base) =
 (** Flush pending spans and remove the OTLP backend.
     Safe to call when disabled (no-op). *)
 let shutdown ?(enabled = Otel_config.enabled) () =
-  if enabled && !exporter_active then begin
+  if enabled && Atomic.get exporter_active then begin
     Opentelemetry_client_cohttp_eio.remove_backend ();
     Log.info ~ctx:"otel" "OTLP exporter stopped"
   end;
-  exporter_active := false;
-  initialized := false
+  Atomic.set exporter_active false;
+  Atomic.set initialized false
 
 (** Wrap a function in an OTel span. No-op when disabled.
     Returns the result of [f]. *)

--- a/lib/otel/otel_spans.ml
+++ b/lib/otel/otel_spans.ml
@@ -7,12 +7,12 @@
 
 module OT = Opentelemetry
 
-let initialized = ref false
-let exporter_active = ref false
+let initialized = Atomic.make false
+let exporter_active = Atomic.make false
 
 let init () =
-  if Otel_config.enabled && not !initialized then begin
-    initialized := true;
+  if Otel_config.enabled && not (Atomic.get initialized) then begin
+    Atomic.set initialized true;
     OT.Globals.service_name := Otel_config.service_name;
     (* ambient-context-eio storage is set automatically when the library is linked.
        Eio fiber-local context propagation works via Ambient_context_eio.storage. *)
@@ -23,19 +23,19 @@ let init () =
     metrics, and logs to the configured OTLP collector via HTTP/protobuf.
     Internally forks a 500ms tick fiber under [sw] for periodic batch flush.
     No-op when [MASC_OTEL_ENABLED] is not set. *)
-let is_exporter_active () = !exporter_active
+let is_exporter_active () = Atomic.get exporter_active
 
 let setup_exporter_with ?(enabled = Otel_config.enabled) ~endpoint ~setup () =
   if enabled then begin
     init ();
     try
       setup ();
-      exporter_active := true;
+      Atomic.set exporter_active true;
       Log.info ~ctx:"otel" "OTLP exporter started -> %s" endpoint
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->
-        exporter_active := false;
+        Atomic.set exporter_active false;
         Log.warn ~ctx:"otel"
           "OTLP exporter unavailable, continuing without export (%s): %s"
           endpoint (Printexc.to_string exn)

--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -124,10 +124,10 @@ let remove_temp_file_quietly path =
 
 let read_stderr_capture path =
   try In_channel.with_open_bin path In_channel.input_all with
-  | _exn ->
+  | Sys_error msg ->
       Printf.sprintf
-        "(stderr capture error) failed to read captured stderr file %s. Check temp-file permissions or available temp storage."
-        (Filename.basename path)
+        "(stderr capture error) %s: %s"
+        (Filename.basename path) msg
 
 let captured_stderr_or_empty path_opt =
   match path_opt with

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -507,7 +507,7 @@ let fd_warn_threshold =
 
 let () = set_gauge metric_fd_warn_threshold (float_of_int fd_warn_threshold)
 
-let fd_warned_once = ref false
+let fd_warned_once = Atomic.make false
 
 (** Returns 0 on non-Unix hosts where [/dev/fd] is unavailable. *)
 let approximate_open_fd_count () =
@@ -518,7 +518,7 @@ let approximate_open_fd_count () =
         (try Some (path, Sys.readdir path)
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
-         | _exn -> first_readable rest)
+         | Sys_error _ -> first_readable rest)
   in
   match first_readable candidates with
   | None -> 0
@@ -528,15 +528,15 @@ let approximate_open_fd_count () =
 let update_fd_gauges () =
   let count = approximate_open_fd_count () in
   set_gauge metric_open_fds (float_of_int count);
-  if count >= fd_warn_threshold && not !fd_warned_once then begin
-    fd_warned_once := true;
+  if count >= fd_warn_threshold && not (Atomic.get fd_warned_once) then begin
+    Atomic.set fd_warned_once true;
     Printf.eprintf
       "[WARN] [Server] process open fd count %d has reached warn \
        threshold %d — likely socket/file leak, investigate before \
        accept() starts failing with EMFILE.\n%!"
       count fd_warn_threshold
   end else if count < fd_warn_threshold / 2 then
-    fd_warned_once := false
+    Atomic.set fd_warned_once false
 
 let set_tool_schema_stats ~count ~approx_tokens =
   set_gauge metric_mcp_tool_schema_count (float_of_int count);

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -815,11 +815,11 @@ let normalize_base_url value =
   else
     trimmed
 
-let legacy_voice_env_warning_emitted = ref false
+let legacy_voice_env_warning_emitted = Atomic.make false
 
 let warn_legacy_voice_env_once () =
-  if not !legacy_voice_env_warning_emitted then (
-    legacy_voice_env_warning_emitted := true;
+  if not (Atomic.get legacy_voice_env_warning_emitted) then (
+    Atomic.set legacy_voice_env_warning_emitted true;
     Log.Misc.warn
       "VOICE_MCP_HOST/PORT fallback is deprecated; prefer .masc/voice_config.json \
        session.endpoints or MASC_HTTP_* listener settings.")

--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -355,4 +355,7 @@ let track_tool_assigned ?fs config ~agent_id ~profile ?preset ~tool_count ~assig
     Replaces the old rotate function; date-split makes rewriting unnecessary. *)
 let rotate ~fs:_ config ~max_age_days : unit =
   let store = get_telemetry_store config in
-  ignore (Dated_jsonl.prune store ~days:max_age_days)
+  let pruned = Dated_jsonl.prune store ~days:max_age_days in
+  if pruned > 0 then
+    Log.Metrics.info "telemetry_eio: pruned %d old day-files (max_age=%d days)"
+      pruned max_age_days

--- a/lib/tool_assignment_telemetry.ml
+++ b/lib/tool_assignment_telemetry.ml
@@ -269,7 +269,9 @@ let read_recent ~n : (tool_event list, string) result =
     in
     (* Dated_jsonl returns oldest-first; API promises newest-first. *)
     Ok (List.rev events)
-  with exn -> Error (Printexc.to_string exn)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> Error (Printexc.to_string exn)
 
 let warm_up () : unit =
   try

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -206,7 +206,7 @@ type module_tag =
   | Mod_shard
 
 let tag_registry : (string, module_tag) Hashtbl.t = Hashtbl.create 512
-let tag_registry_initialized = ref false
+let tag_registry_initialized = Atomic.make false
 
 (** Schema registry — maps tool name → input_schema JSON.
     Populated alongside tag_registry during server initialization.
@@ -229,8 +229,8 @@ let lookup_schema name = with_dispatch_ro (fun () -> Hashtbl.find_opt schema_reg
 
 let tag_registry_count () = with_dispatch_ro (fun () -> Hashtbl.length tag_registry)
 
-let mark_tag_registry_initialized () = with_dispatch_rw (fun () -> tag_registry_initialized := true)
-let is_tag_registry_initialized () = with_dispatch_ro (fun () -> !tag_registry_initialized)
+let mark_tag_registry_initialized () = with_dispatch_rw (fun () -> Atomic.set tag_registry_initialized true)
+let is_tag_registry_initialized () = with_dispatch_ro (fun () -> Atomic.get tag_registry_initialized)
 
 (** Mint a [Tool_token.t] validated against both registries.
     Protected by dispatch_mu for thread safety (Copilot review).

--- a/lib/tool_metrics_persist.ml
+++ b/lib/tool_metrics_persist.ml
@@ -62,7 +62,9 @@ let rec drain_queue_without_store dropped =
   | Some _ -> drain_queue_without_store (dropped + 1)
 
 let reset_for_testing () =
-  ignore (drain_queue_without_store 0);
+  let dropped = drain_queue_without_store 0 in
+  if dropped > 0 then
+    Log.Metrics.warn "tool_metrics_persist: reset dropped %d queued records" dropped;
   store_ref := None
 
 let get_or_create_store ~base_path : Dated_jsonl.t =

--- a/lib/tool_misc_web_search.ml
+++ b/lib/tool_misc_web_search.ml
@@ -750,7 +750,7 @@ let enforce_rate_limit now =
       while Queue.length request_times > 0
             && now -. Queue.peek request_times > window
       do
-        ignore (Queue.pop request_times)
+        let (_ : float) = Queue.pop request_times in ()
       done;
       if Queue.length request_times >= max_calls then
         Error "web search rate limit exceeded; retry shortly"

--- a/lib/tool_output_validation.ml
+++ b/lib/tool_output_validation.ml
@@ -41,10 +41,10 @@ let post_hook (result : Tool_result.t) : Tool_result.t =
 
 (* ── Installation ───────────────────────────────────────────── *)
 
-let installed = ref false
+let installed = Atomic.make false
 
 let install () =
-  if not !installed then begin
+  if not (Atomic.get installed) then begin
     Tool_dispatch.register_post_hook post_hook;
-    installed := true
+    Atomic.set installed true
   end

--- a/lib/transport_bridge.ml
+++ b/lib/transport_bridge.ml
@@ -20,12 +20,12 @@ end
    Reads from multiple fibers are safe because OCaml ref reads are
    atomic at the word level, and the list is never mutated post-seal. *)
 let registry : (module PROVIDER) list ref = ref []
-let sealed = ref false
+let sealed = Atomic.make false
 
-let seal () = sealed := true
+let seal () = Atomic.set sealed true
 
 let register_provider (p : (module PROVIDER)) =
-  if !sealed then
+  if Atomic.get sealed then
     invalid_arg "Transport_bridge.register_provider: registry sealed after bootstrap"
   else begin
     let module P = (val p : PROVIDER) in

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -119,7 +119,7 @@ let on_submit_for_verification ~(config : Coord.config)
     ("evidence_refs", `List (List.map (fun s -> `String s) evidence_refs));
     ("timestamp", `Float (Time_compat.now ()));
   ]);
-  ignore base_path
+  ()
 
 let on_approve_verification ~(config : Coord.config)
     ~task_id ~verifier ~verification_id ~notes =

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -82,16 +82,24 @@ let on_submit_for_verification ~(config : Coord.config)
     (match task.contract with
      | Some c -> c.completion_contract
      | None -> []) in
-  let _req =
-    Verification.create_request ~base_path ~task_id:task.id ~request_id:verification_id
-      ~output:(`Assoc [
-        ("evidence_refs", `List (List.map (fun s -> `String s) evidence_refs));
-        ("task_title", `String task.title);
-        ("request_kind", `String request_kind);
-        ("request_summary", `String request_summary);
-        ("next_action", `String next_action);
-      ])
-      ~criteria ~worker:assignee () in
+  let () =
+    match
+      Verification.create_request ~base_path ~task_id:task.id ~request_id:verification_id
+        ~output:(`Assoc [
+          ("evidence_refs", `List (List.map (fun s -> `String s) evidence_refs));
+          ("task_title", `String task.title);
+          ("request_kind", `String request_kind);
+          ("request_summary", `String request_summary);
+          ("next_action", `String next_action);
+        ])
+        ~criteria ~worker:assignee ()
+    with
+    | Ok _ -> ()
+    | Error e ->
+      Log.Task.error
+        "verification create_request failed (task=%s vrf=%s): %s"
+        task.id verification_id e
+  in
   let meta_json = `Assoc [
     ("type", `String board_type);
     ("task_id", `String task.id);
@@ -102,15 +110,23 @@ let on_submit_for_verification ~(config : Coord.config)
     ("request_kind", `String request_kind);
     ("next_action", `String next_action);
   ] in
-  let _post = Board_dispatch.create_post
-    ~author:"system"
-    ~content:board_content
-    ~title:board_title
-    ~post_kind:Board.System_post
-    ~meta_json
-    ~visibility:Board.Internal
-    ~hearth:"verification"
-    () in
+  let () =
+    match Board_dispatch.create_post
+      ~author:"system"
+      ~content:board_content
+      ~title:board_title
+      ~post_kind:Board.System_post
+      ~meta_json
+      ~visibility:Board.Internal
+      ~hearth:"verification"
+      ()
+    with
+    | Ok _ -> ()
+    | Error e ->
+      Log.Task.error
+        "board post failed (task=%s vrf=%s): %s"
+        task.id verification_id (Board_types.show_board_error e)
+  in
   Subscriptions.push_event_to_sessions (`Assoc [
     ("type", `String "masc/verification/requested");
     ("task_id", `String task.id);
@@ -143,16 +159,24 @@ let on_approve_verification ~(config : Coord.config)
     ("verification_id", `String verification_id);
     ("verdict", `String "approved");
   ] in
-  let _post = Board_dispatch.create_post
-    ~author:verifier
-    ~content:(Printf.sprintf "Approved task %s (vrf:%s)%s"
-      task_id verification_id
-      (if notes = "" then "" else " — " ^ notes))
-    ~post_kind:Board.System_post
-    ~meta_json
-    ~visibility:Board.Internal
-    ~hearth:"verification"
-    () in
+  let () =
+    match Board_dispatch.create_post
+      ~author:verifier
+      ~content:(Printf.sprintf "Approved task %s (vrf:%s)%s"
+        task_id verification_id
+        (if notes = "" then "" else " — " ^ notes))
+      ~post_kind:Board.System_post
+      ~meta_json
+      ~visibility:Board.Internal
+      ~hearth:"verification"
+      ()
+    with
+    | Ok _ -> ()
+    | Error e ->
+      Log.Task.error
+        "board post failed (task=%s vrf=%s): %s"
+        task_id verification_id (Board_types.show_board_error e)
+  in
   Subscriptions.push_event_to_sessions (`Assoc [
     ("type", `String "masc/verification/verdict");
     ("task_id", `String task_id);
@@ -185,15 +209,23 @@ let on_reject_verification ~(config : Coord.config)
     ("verification_id", `String verification_id);
     ("verdict", `String "rejected");
   ] in
-  let _post = Board_dispatch.create_post
-    ~author:verifier
-    ~content:(Printf.sprintf "Rejected task %s (vrf:%s): %s"
-      task_id verification_id reason)
-    ~post_kind:Board.System_post
-    ~meta_json
-    ~visibility:Board.Internal
-    ~hearth:"verification"
-    () in
+  let () =
+    match Board_dispatch.create_post
+      ~author:verifier
+      ~content:(Printf.sprintf "Rejected task %s (vrf:%s): %s"
+        task_id verification_id reason)
+      ~post_kind:Board.System_post
+      ~meta_json
+      ~visibility:Board.Internal
+      ~hearth:"verification"
+      ()
+    with
+    | Ok _ -> ()
+    | Error e ->
+      Log.Task.error
+        "board post failed (task=%s vrf=%s): %s"
+        task_id verification_id (Board_types.show_board_error e)
+  in
   Subscriptions.push_event_to_sessions (`Assoc [
     ("type", `String "masc/verification/rejected");
     ("task_id", `String task_id);
@@ -214,23 +246,31 @@ let check_timeouts ~(config : Coord.config) =
         | Types.AwaitingVerification { assignee; verification_id; deadline = Some dl; _ } ->
           (match Types.parse_iso8601_opt dl with
            | Some deadline_ts when now > deadline_ts ->
-             let _post = Board_dispatch.create_post
-               ~author:"system"
-               ~content:(Printf.sprintf
-                 "Verification timeout: task %s (%s) by %s — no verifier responded within deadline %s"
-                 task.id task.title assignee dl)
-               ~title:(Printf.sprintf "Timeout: %s" task.title)
-               ~post_kind:Board.System_post
-               ~meta_json:(`Assoc [
-                 ("type", `String "verification_timeout");
-                 ("task_id", `String task.id);
-                 ("verification_id", `String verification_id);
-                 ("assignee", `String assignee);
-                 ("deadline", `String dl);
-               ])
-               ~visibility:Board.Internal
-               ~hearth:"verification"
-               () in
+             let () =
+               match Board_dispatch.create_post
+                 ~author:"system"
+                 ~content:(Printf.sprintf
+                   "Verification timeout: task %s (%s) by %s — no verifier responded within deadline %s"
+                   task.id task.title assignee dl)
+                 ~title:(Printf.sprintf "Timeout: %s" task.title)
+                 ~post_kind:Board.System_post
+                 ~meta_json:(`Assoc [
+                   ("type", `String "verification_timeout");
+                   ("task_id", `String task.id);
+                   ("verification_id", `String verification_id);
+                   ("assignee", `String assignee);
+                   ("deadline", `String dl);
+                 ])
+                 ~visibility:Board.Internal
+                 ~hearth:"verification"
+                 ()
+               with
+               | Ok _ -> ()
+               | Error e ->
+                 Log.Task.error
+                   "board post failed (task=%s vrf=%s): %s"
+                   task.id verification_id (Board_types.show_board_error e)
+             in
              Subscriptions.push_event_to_sessions (`Assoc [
                ("type", `String "masc/verification/timeout");
                ("task_id", `String task.id);

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -93,14 +93,14 @@ let test_transition_has_no_fixed_timeout () =
     true
     (Masc_mcp.Mcp_server_eio_call_tool.tool_timeout_sec_opt
        ~tool_name:"masc_transition"
-       ~arguments:(`Assoc [])
+       ~_arguments:(`Assoc [])
      = None)
 
 let test_regular_tool_uses_default_timeout () =
   match
     Masc_mcp.Mcp_server_eio_call_tool.tool_timeout_sec_opt
       ~tool_name:"masc_status"
-      ~arguments:(`Assoc [])
+      ~_arguments:(`Assoc [])
   with
   | Some timeout_sec -> check bool "default timeout remains enabled" true (timeout_sec >= 5.)
   | None -> fail "expected masc_status to keep fixed timeout"

--- a/test/test_orchestrator_coverage.ml
+++ b/test/test_orchestrator_coverage.ml
@@ -201,7 +201,7 @@ let with_initialized_room f =
 let test_should_orchestrate_empty_room () =
   with_initialized_room @@ fun config ->
   (* Empty room with no tasks and no agents should return false *)
-  let result = Orchestrator.should_orchestrate config in
+  let result = Orchestrator.should_orchestrate ~min_priority:2 config in
   check bool "no orchestration needed" false result
 
 let test_should_orchestrate_with_task_no_agent () =
@@ -209,7 +209,7 @@ let test_should_orchestrate_with_task_no_agent () =
   (* Add a high priority task *)
   let _ = Coord.add_task config ~title:"Important Task" ~priority:1 ~description:"Test" in
   (* No active agents → should return true *)
-  let result = Orchestrator.should_orchestrate config in
+  let result = Orchestrator.should_orchestrate ~min_priority:2 config in
   check bool "orchestration needed" true result
 
 let test_should_orchestrate_with_task_and_agent () =
@@ -218,7 +218,7 @@ let test_should_orchestrate_with_task_and_agent () =
   let _ = Coord.add_task config ~title:"Task" ~priority:1 ~description:"Test" in
   let _ = Coord.join config ~agent_name:"active-agent" ~capabilities:[] () in
   (* Active agent exists → should return false *)
-  let result = Orchestrator.should_orchestrate config in
+  let result = Orchestrator.should_orchestrate ~min_priority:2 config in
   check bool "no orchestration with active agent" false result
 
 let test_should_orchestrate_paused_room () =
@@ -228,7 +228,7 @@ let test_should_orchestrate_paused_room () =
   (* Pause the room *)
   let _ = Coord.pause config ~by:"test" ~reason:"Testing" in
   (* Paused room should return false *)
-  let result = Orchestrator.should_orchestrate config in
+  let result = Orchestrator.should_orchestrate ~min_priority:2 config in
   check bool "no orchestration when paused" false result
 
 let test_should_orchestrate_low_priority_task () =
@@ -236,7 +236,7 @@ let test_should_orchestrate_low_priority_task () =
   (* Add low priority task (priority 5 > threshold 2) *)
   let _ = Coord.add_task config ~title:"Low Priority" ~priority:5 ~description:"Test" in
   (* Low priority tasks don't trigger orchestration *)
-  let result = Orchestrator.should_orchestrate config in
+  let result = Orchestrator.should_orchestrate ~min_priority:2 config in
   check bool "no orchestration for low priority" false result
 
 (* ============================================================


### PR DESCRIPTION
## Summary

OCaml 5.x + Eio best practice 적용 배치. 다음 4가지 카테고리를 수정합니다.

### 1. Cross-fiber once-only guards: `ref` → `Atomic`

`Stdlib.ref`는 도메인/파이버 경계에서 race condition에 취약합니다. `Atomic.make`로 교체:

- `lib/tool_output_validation.ml` — hook 설치 guard
- `lib/provider_adapter.ml` — deprecation warning throttle
- `lib/otel/otel_spans.ml` — exporter init flag
- `lib/level4_config.ml` — RNG init guard
- `lib/transport_bridge.ml` — bootstrap seal
- `lib/prometheus.ml` — FD warning throttle
- `lib/tool_dispatch.ml` — tag registry init flag

### 2. Pure computation: `ref` accumulator → `List.fold_left` tuple

`ref []` + mutation은 OCaml에서 anti-pattern. 순수 누적기로 교체:

- `lib/core/text_similarity.ml` — dedupe, n-gram
- `lib/config.ml` — schema dedupe + validation
- `lib/agent_tool_surfaces.ml` — schema dedupe
- `lib/autoresearch/autoresearch_git.ml` — warning list

### 3. Silent failure elimination

`(unit, string) result` 반환 함수의 `ignore`/`let _ =` 제거. 실패 시 로깅:

- `lib/keeper/keeper_exec_shell.ml` — cache save, sandbox bundle
- `lib/board_votes.ml` — economy earn
- `lib/dashboard_cascade.ml` — config materialization
- `lib/tool_assignment_telemetry.ml` — Cancelled re-raise

### 4. Catch-all tightening

`with _exn ->` 패턴에서 `Eio.Cancel.Cancelled`를 삼키지 않도록 `Sys_error` 등 구체적 예외로 제한:

- `lib/prometheus.ml` — FD approximation
- `lib/process/process_eio.ml` — stderr capture

## Test Plan

- [x] `dune build @all` passes
- [x] `dune runtest` (incremental) passes
- [ ] CI green

## Scope Exclusions

- Fake test audit → 별도 PR
- Remaining 150+ `ref` usages → 다음 배치 (대부분 로컬 mutable state로 적법)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)