### PR TITLE
[codex] fix(kimi): redact resumable session detail surfaces

### DIFF
--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -1138,8 +1138,18 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
   let is_scheduled_autonomous_cycle =
     is_scheduled_autonomous_cycle_of_observation observation
   in
+  let public_reason =
+    match sdk_error with
+    | Some err -> (
+        match Oas_worker_named.classify_masc_internal_error err with
+        | Some (Oas_worker_named.Resumable_cli_session { detail; _ }) ->
+            let trimmed = String.trim detail in
+            if trimmed = "" then reason else trimmed
+        | _ -> reason)
+    | None -> reason
+  in
   let preview =
-    let trimmed = String.trim reason in
+    let trimmed = String.trim public_reason in
     if trimmed = "" then "keeper cycle failed"
     else short_preview trimmed
   in
@@ -1170,7 +1180,7 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
           else meta.runtime.proactive_rt.last_outcome;
         last_reason =
           if is_scheduled_autonomous_cycle
-          then "unified:error:" ^ String.trim reason
+          then "unified:error:" ^ String.trim public_reason
           else meta.runtime.proactive_rt.last_reason;
         last_preview =
           if is_scheduled_autonomous_cycle then preview
@@ -1199,7 +1209,7 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
         (match social_state with
          | Some (state : Social.social_state) ->
              Option.value ~default:"" state.blocker
-         | None -> short_preview reason);
+         | None -> short_preview public_reason);
       last_blocker_class =
         (match sdk_error with
          | Some err ->

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -627,6 +627,16 @@ module Kimi_cli_transport_local = struct
     String.length text >= prefix_len
     && String.sub text 0 prefix_len = prefix
 
+  let should_log_stderr_line line =
+    let trimmed = String.trim line in
+    trimmed <> ""
+    && not (starts_with trimmed "To resume this session:")
+
+  let on_stderr_line line =
+    if should_log_stderr_line line then
+      Llm_provider.Cli_common_subprocess.default_on_stderr_line
+        ~name:"kimi" line
+
   let exit_code_of_message message =
     let prefix = "kimi exited with code " in
     if not (starts_with message prefix) then None
@@ -714,6 +724,7 @@ module Kimi_cli_transport_local = struct
           match
             Llm_provider.Cli_common_subprocess.run_stream_lines ~sw ~mgr
               ~name:"kimi" ~cwd:config.cwd ~extra_env:config.extra_env
+              ~on_stderr_line
               ?stdin_content:(stdin_for_prompt prompt)
               ~on_line ?cancel:config.cancel argv
           with
@@ -775,6 +786,7 @@ module Kimi_cli_transport_local = struct
             classify_cli_error
               (Llm_provider.Cli_common_subprocess.run_stream_lines ~sw ~mgr
                  ~name:"kimi" ~cwd:config.cwd ~extra_env:config.extra_env
+                 ~on_stderr_line
                  ?stdin_content:(stdin_for_prompt prompt)
                  ~on_line ?cancel:config.cancel argv)
           with

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -627,10 +627,23 @@ module Kimi_cli_transport_local = struct
     String.length text >= prefix_len
     && String.sub text 0 prefix_len = prefix
 
+  let resumable_session_detail =
+    "kimi_cli session limit exceeded (exit 75). Resumable session available via -r."
+
+  let resume_hint_marker = "to resume this session:"
+  let resumable_session_public_marker = "resumable session available via -r."
+  let legacy_resumable_session_public_marker =
+    "the session is resumable with -r flag."
+
+  let is_resume_hint_line line =
+    let trimmed = String.trim line in
+    trimmed <> ""
+    && String_util.contains_substring_ci trimmed resume_hint_marker
+
   let should_log_stderr_line line =
     let trimmed = String.trim line in
     trimmed <> ""
-    && not (starts_with trimmed "To resume this session:")
+    && not (is_resume_hint_line trimmed)
 
   let on_stderr_line line =
     if should_log_stderr_line line then
@@ -651,6 +664,29 @@ module Kimi_cli_transport_local = struct
           in
           int_of_string_opt raw
 
+  let text_looks_like_resumable_session text =
+    let trimmed = String.trim text in
+    let has_raw_resume_hint =
+      match exit_code_of_message trimmed with
+      | Some 75 -> is_resume_hint_line trimmed
+      | _ -> false
+    in
+    trimmed <> ""
+    &&
+    (has_raw_resume_hint
+    || String_util.contains_substring_ci trimmed resumable_session_public_marker
+    || String_util.contains_substring_ci trimmed legacy_resumable_session_public_marker)
+
+  let resumable_session_detail_of_text text =
+    if text_looks_like_resumable_session text then resumable_session_detail
+    else String.trim text
+
+  let resumable_session_exit_code_of_text text =
+    match exit_code_of_message text with
+    | Some 75 -> Some 75
+    | _ when text_looks_like_resumable_session text -> Some 75
+    | _ -> None
+
   let classify_cli_error = function
     | Error (Llm_provider.Http_client.NetworkError { message; _ }) as err -> (
         match exit_code_of_message message with
@@ -667,12 +703,7 @@ module Kimi_cli_transport_local = struct
         | Some 75 ->
             Error
               (Llm_provider.Http_client.AcceptRejected
-                 {
-                   reason =
-                     "kimi_cli session limit exceeded (exit 75). "
-                     ^ "The session is resumable with -r flag. "
-                     ^ message;
-                 })
+                 { reason = resumable_session_detail })
         | _ -> err)
     | other -> other
 

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -692,10 +692,16 @@ let exit_code_of_message (message : string) : int option =
               int_of_string_opt raw
 
 let message_looks_like_resumable_cli_session (message : string) : bool =
-  match exit_code_of_message message with
-  | Some 75 ->
-      String_util.contains_substring_ci message "to resume this session:"
-  | _ -> false
+  Oas_worker_exec.Kimi_cli_transport_local.text_looks_like_resumable_session
+    message
+
+let resumable_cli_session_detail (message : string) : string =
+  Oas_worker_exec.Kimi_cli_transport_local.resumable_session_detail_of_text
+    message
+
+let resumable_cli_session_exit_code (message : string) : int option =
+  Oas_worker_exec.Kimi_cli_transport_local.resumable_session_exit_code_of_text
+    message
 
 let sdk_error_is_hard_quota (err : Oas.Error.sdk_error) : bool =
   match err with
@@ -985,8 +991,17 @@ let run_named
               (Resumable_cli_session
                  {
                    cascade_name;
-                   detail = message;
-                   exit_code = exit_code_of_message message;
+                   detail = resumable_cli_session_detail message;
+                   exit_code = resumable_cli_session_exit_code message;
+                 })
+        | Some (Llm_provider.Http_client.AcceptRejected { reason })
+          when message_looks_like_resumable_cli_session reason ->
+            sdk_error_of_masc_internal_error
+              (Resumable_cli_session
+                 {
+                   cascade_name;
+                   detail = resumable_cli_session_detail reason;
+                   exit_code = resumable_cli_session_exit_code reason;
                  })
         | _ ->
             sdk_error_of_masc_internal_error

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -330,6 +330,56 @@ let test_runtime_surface_derives_cascade_exhausted_from_meta () =
     false
     (runtime |> member "runtime_blocker_continue_gate" |> to_bool)
 
+let test_runtime_surface_exposes_redacted_resumable_cli_session_blocker () =
+  KR.clear ();
+  let base = make_meta ~name:"runtime-resumable-cli-session-test" () in
+  let reason =
+    Masc_mcp.Oas_worker_exec.Kimi_cli_transport_local.resumable_session_detail
+  in
+  let meta =
+    {
+      base with
+      runtime =
+        {
+          base.runtime with
+          last_blocker = reason;
+          last_blocker_class =
+            Some (KT.Cascade_exhausted (KT.Other_detail reason));
+        };
+    }
+  in
+  let config =
+    Coord.default_config "/tmp/test-keeper-exec-status-resumable-cli-session"
+  in
+  ignore (KR.register ~base_path:config.base_path meta.name meta);
+  let runtime = KSB.runtime_surface_json config meta in
+  let contains_substring haystack needle =
+    let hay_len = String.length haystack in
+    let needle_len = String.length needle in
+    let rec loop i =
+      if i + needle_len > hay_len then false
+      else if String.sub haystack i needle_len = needle then true
+      else loop (i + 1)
+    in
+    needle_len = 0 || loop 0
+  in
+  let open Yojson.Safe.Util in
+  let summary = runtime |> member "runtime_blocker_summary" |> to_string in
+  check string "last blocker stays redacted"
+    reason
+    (runtime |> member "last_blocker" |> to_string);
+  check string "runtime blocker class"
+    "cascade_exhausted"
+    (runtime |> member "runtime_blocker_class" |> to_string);
+  check string "runtime blocker summary stays redacted"
+    reason
+    summary;
+  check bool "runtime blocker hides raw session command" false
+    (contains_substring summary "kimi -r");
+  check bool "runtime blocker continue gate stays false"
+    false
+    (runtime |> member "runtime_blocker_continue_gate" |> to_bool)
+
 let test_runtime_surface_derives_continue_gate_from_ambiguous_partial_commit () =
   KR.clear ();
   let meta = make_meta ~name:"runtime-continue-gate-test" () in
@@ -594,6 +644,9 @@ let () =
             test_runtime_surface_derives_autonomous_slot_wait_timeout_from_meta;
           test_case "runtime surface derives cascade exhausted blocker" `Quick
             test_runtime_surface_derives_cascade_exhausted_from_meta;
+          test_case "runtime surface keeps resumable CLI blocker redacted"
+            `Quick
+            test_runtime_surface_exposes_redacted_resumable_cli_session_blocker;
           test_case "runtime surface derives continue-gate blocker" `Quick
             test_runtime_surface_derives_continue_gate_from_ambiguous_partial_commit;
           test_case "runtime surface derives persisted continue-gate blocker"

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2661,6 +2661,46 @@ let test_metrics_failure_response () =
   check string "failure transition reason tracked" "failure:run_error"
     updated.runtime.last_social_transition_reason
 
+let test_metrics_failure_response_redacts_resumable_cli_session_detail () =
+  let raw_reason =
+    "kimi exited with code 75: \nTo resume this session: kimi -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc"
+  in
+  let canonical_detail =
+    Masc_mcp.Oas_worker_exec.Kimi_cli_transport_local.resumable_session_detail
+  in
+  let sdk_error =
+    Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
+      (Masc_mcp.Oas_worker_named.Resumable_cli_session
+         {
+           cascade_name = "kimi_cli_keeper";
+           detail = canonical_detail;
+           exit_code = Some 75;
+         })
+  in
+  let updated =
+    UM.update_metrics_from_failure minimal_meta ~latency_ms:250
+      ~observation:base_observation ~reason:raw_reason ~sdk_error
+      ~social_transition_reason:"failure:run_error" ()
+  in
+  check string "last reason is redacted"
+    ("unified:error:" ^ canonical_detail)
+    updated.runtime.proactive_rt.last_reason;
+  check string "last preview is redacted"
+    canonical_detail
+    updated.runtime.proactive_rt.last_preview;
+  check string "last blocker is redacted"
+    canonical_detail
+    updated.runtime.last_blocker;
+  check bool "raw resume hint removed from last blocker" false
+    (contains_substring updated.runtime.last_blocker "To resume this session:");
+  check bool "raw session token removed from last reason" false
+    (contains_substring updated.runtime.proactive_rt.last_reason "kimi -r");
+  match updated.runtime.last_blocker_class with
+  | Some (Keeper_types.Cascade_exhausted (Keeper_types.Other_detail detail)) ->
+      check string "blocker class detail preserved as canonical detail"
+        canonical_detail detail
+  | _ -> fail "expected resumable CLI session blocker class"
+
 let test_prompt_includes_board_activity_section () =
   let obs =
     { base_observation with
@@ -3095,7 +3135,7 @@ let test_auto_recoverable_turn_error_includes_resumable_cli_session_error () =
          {
            cascade_name = "kimi_cli_keeper";
            detail =
-             "kimi exited with code 75: \nTo resume this session: kimi -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc";
+             Masc_mcp.Oas_worker_exec.Kimi_cli_transport_local.resumable_session_detail;
            exit_code = Some 75;
          })
   in
@@ -3109,7 +3149,7 @@ let test_cascade_exhausted_error_includes_resumable_cli_session_error () =
          {
            cascade_name = "kimi_cli_keeper";
            detail =
-             "kimi exited with code 75: \nTo resume this session: kimi -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc";
+             Masc_mcp.Oas_worker_exec.Kimi_cli_transport_local.resumable_session_detail;
            exit_code = Some 75;
          })
   in
@@ -4330,6 +4370,8 @@ let () =
           test_case "social fields" `Quick
             test_metrics_persist_social_state_fields;
           test_case "failure response" `Quick test_metrics_failure_response;
+          test_case "failure response redacts resumable session detail" `Quick
+            test_metrics_failure_response_redacts_resumable_cli_session_detail;
           test_case "mixed response" `Quick test_metrics_mixed_response;
           test_case "normalize passthrough" `Quick
             test_normalize_response_text_passthrough;

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1825,6 +1825,20 @@ let test_kimi_cli_model_for_provider_keeps_explicit_model () =
     (Some "kimi-k2.5")
     (Oas_worker_exec.kimi_cli_model_for_provider provider_cfg)
 
+let test_kimi_cli_should_log_stderr_line_filters_resume_noise () =
+  let should_log =
+    Oas_worker_exec.Kimi_cli_transport_local.should_log_stderr_line
+  in
+  Alcotest.(check bool) "blank stderr line suppressed" false (should_log "");
+  Alcotest.(check bool) "whitespace stderr line suppressed" false
+    (should_log "   ");
+  Alcotest.(check bool) "resume hint suppressed" false
+    (should_log "To resume this session: kimi -r ff37febe");
+  Alcotest.(check bool) "unexpected stderr remains visible" true
+    (should_log "fatal: kimi auth missing");
+  Alcotest.(check bool) "other stderr guidance remains visible" true
+    (should_log "warning: upstream endpoint is slow")
+
 let test_codex_cli_prompt_preflight_uses_pipeline_context_window_fallback () =
   let provider_cfg = make_codex_cli_provider_cfg () in
   let config =
@@ -3122,6 +3136,8 @@ let () =
         test_kimi_cli_model_for_provider_keeps_transport_default_on_auto;
       Alcotest.test_case "kimi explicit model is preserved" `Quick
         test_kimi_cli_model_for_provider_keeps_explicit_model;
+      Alcotest.test_case "kimi stderr resume noise is filtered" `Quick
+        test_kimi_cli_should_log_stderr_line_filters_resume_noise;
       Alcotest.test_case "worker build_agent installs retry policy" `Quick
         test_worker_build_agent_uses_default_internal_retry_policy;
       Alcotest.test_case "resume config propagates retry policy" `Quick

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1277,16 +1277,20 @@ let test_classify_masc_internal_error_roundtrip () =
       (Oas_worker_named.Resumable_cli_session
          {
            cascade_name = "kimi_cli_keeper";
-           detail =
-             "kimi exited with code 75: \nTo resume this session: kimi -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc";
+           detail = Oas_worker_exec.Kimi_cli_transport_local.resumable_session_detail;
            exit_code = Some 75;
          })
   in
   match Oas_worker_named.classify_masc_internal_error resumable_err with
   | Some (Oas_worker_named.Resumable_cli_session { cascade_name; detail; exit_code }) ->
       Alcotest.(check string) "resumable cascade" "kimi_cli_keeper" cascade_name;
-      Alcotest.(check bool) "resumable detail preserved" true
+      Alcotest.(check string) "resumable detail redacted"
+        Oas_worker_exec.Kimi_cli_transport_local.resumable_session_detail
+        detail;
+      Alcotest.(check bool) "resumable detail hides raw resume hint" false
         (contains_substring ~needle:"To resume this session:" detail);
+      Alcotest.(check bool) "resumable detail hides session token" false
+        (contains_substring ~needle:"kimi -r" detail);
       Alcotest.(check (option int)) "resumable exit code" (Some 75) exit_code
   | _ -> Alcotest.fail "expected structured resumable CLI session error"
 
@@ -1834,10 +1838,35 @@ let test_kimi_cli_should_log_stderr_line_filters_resume_noise () =
     (should_log "   ");
   Alcotest.(check bool) "resume hint suppressed" false
     (should_log "To resume this session: kimi -r ff37febe");
+  Alcotest.(check bool) "case-insensitive resume hint suppressed" false
+    (should_log "  TO RESUME THIS SESSION: kimi -r ff37febe");
   Alcotest.(check bool) "unexpected stderr remains visible" true
     (should_log "fatal: kimi auth missing");
   Alcotest.(check bool) "other stderr guidance remains visible" true
     (should_log "warning: upstream endpoint is slow")
+
+let test_kimi_cli_classify_cli_error_redacts_resumable_session_detail () =
+  let raw_message =
+    "kimi exited with code 75: \nTo resume this session: kimi -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc"
+  in
+  match
+    Oas_worker_exec.Kimi_cli_transport_local.classify_cli_error
+      (Error
+         (Llm_provider.Http_client.NetworkError
+            {
+              message = raw_message;
+              kind = Llm_provider.Http_client.Unknown;
+            }))
+  with
+  | Error (Llm_provider.Http_client.AcceptRejected { reason }) ->
+      Alcotest.(check string) "canonical detail"
+        Oas_worker_exec.Kimi_cli_transport_local.resumable_session_detail
+        reason;
+      Alcotest.(check bool) "raw resume hint removed" false
+        (contains_substring ~needle:"To resume this session:" reason);
+      Alcotest.(check bool) "raw session id removed" false
+        (contains_substring ~needle:"ff37febe-2adb-4ac6-9dc6-cae23e672fbc" reason)
+  | _ -> Alcotest.fail "expected resumable session to map to AcceptRejected"
 
 let test_codex_cli_prompt_preflight_uses_pipeline_context_window_fallback () =
   let provider_cfg = make_codex_cli_provider_cfg () in
@@ -3138,6 +3167,8 @@ let () =
         test_kimi_cli_model_for_provider_keeps_explicit_model;
       Alcotest.test_case "kimi stderr resume noise is filtered" `Quick
         test_kimi_cli_should_log_stderr_line_filters_resume_noise;
+      Alcotest.test_case "kimi exit 75 detail is redacted" `Quick
+        test_kimi_cli_classify_cli_error_redacts_resumable_session_detail;
       Alcotest.test_case "worker build_agent installs retry policy" `Quick
         test_worker_build_agent_uses_default_internal_retry_policy;
       Alcotest.test_case "resume config propagates retry policy" `Quick


### PR DESCRIPTION
## Summary
- suppress Kimi resumable-session stderr noise with a shared redaction helper
- redact raw `kimi -r <session>` detail across structured resumable errors and keeper runtime blocker surfaces
- add regression coverage for transport classification, metrics surfaces, and runtime status rendering
- sync the branch with the latest `main`

## Verification
- `dune build --root . test/test_oas_worker.exe test/test_keeper_unified.exe test/test_keeper_exec_status.exe`
- `./_build/default/test/test_oas_worker.exe test --color=never resume_config 34,35`
- `./_build/default/test/test_keeper_unified.exe test --color=never metrics_observation 19,20`
- `./_build/default/test/test_keeper_unified.exe test --color=never transient_network_error 35,36`
- `./_build/default/test/test_keeper_exec_status.exe test --color=never surface_status 8`
- `git diff --check`