### PR TITLE
[codex] Canonicalize dashboard actor at auth gate

### DIFF
--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -15,7 +15,11 @@ import {
   setStoredToken,
 } from './core'
 import { OperatorActionSchemaDriftError } from './schemas/operator-action'
-import { resetDashboardSessionActorForTests } from '../lib/dashboard-session-actor'
+import {
+  currentCanonicalDashboardActor,
+  resetDashboardSessionActorForTests,
+  setCanonicalDashboardActor,
+} from '../lib/dashboard-session-actor'
 
 afterEach(() => {
   resetDashboardSessionActorForTests()
@@ -59,6 +63,22 @@ describe('stored token metadata', () => {
 })
 
 describe('post', () => {
+  it('clears the canonical actor immediately when replacing a stored token', () => {
+    setCanonicalDashboardActor('codex')
+
+    setStoredToken('next-token')
+
+    expect(currentCanonicalDashboardActor()).toBeNull()
+  })
+
+  it('clears the canonical actor immediately when clearing a stored token', () => {
+    setCanonicalDashboardActor('codex')
+
+    clearStoredToken()
+
+    expect(currentCanonicalDashboardActor()).toBeNull()
+  })
+
   it('sends a sanitized actor header without URL encoding', async () => {
     window.history.replaceState({}, '', '/?agent=dashboard-eager-manta%E3%85%8A')
 

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -9,7 +9,10 @@ import type {
 } from '../types'
 import { parseOperatorActionResult } from './schemas/operator-action'
 import { sanitizeDashboardActorName } from '../lib/dashboard-actor'
-import { currentDashboardActorName } from '../lib/dashboard-session-actor'
+import {
+  currentDashboardActorName,
+  setCanonicalDashboardActor,
+} from '../lib/dashboard-session-actor'
 
 // --- Auth ---
 // Token is read from ?token= on first load, moved to sessionStorage,
@@ -98,11 +101,13 @@ export function setStoredToken(
   } else {
     sessionStorage.removeItem(TOKEN_META_STORAGE_KEY)
   }
+  setCanonicalDashboardActor(null)
 }
 
 export function clearStoredToken(): void {
   sessionStorage.removeItem(TOKEN_STORAGE_KEY)
   sessionStorage.removeItem(TOKEN_META_STORAGE_KEY)
+  setCanonicalDashboardActor(null)
 }
 
 export function isRemoteAccess(): boolean {

--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -292,20 +292,41 @@ describe('callMcpTool', () => {
     })
   }, 60_000)
 
-  it('preserves an explicit agent_name field when the caller already set one', async () => {
+  it('treats legacy agent_name as payload when the session is token-authenticated', async () => {
     authHeaders.mockImplementation((opts?: { actorName?: string | null }) => (
       opts?.actorName ? { 'X-MASC-Agent': opts.actorName } : {}
     ))
     setupMcpSessionMocks('sess-explicit')
 
     const { callMcpTool } = await import('./mcp')
-    await callMcpTool('masc_join', { agent_name: 'codex-tool-matrix' })
+    await callMcpTool('masc_agent_fitness', { agent_name: 'codex-tool-matrix', days: 7 })
 
     const toolCall = findCallByMethod('tools/call')
     expect(toolCall).toBeDefined()
     const body = JSON.parse(toolCall![1].body as string)
     expect(body.params.arguments).toEqual({
       agent_name: 'codex-tool-matrix',
+      days: 7,
+      _agent_name: 'dashboard',
+    })
+    const headers = toolCall![1].headers as Record<string, string>
+    expect(headers['X-MASC-Agent']).toBe('dashboard')
+  }, 60_000)
+
+  it('still honors an explicit _agent_name override', async () => {
+    authHeaders.mockImplementation((opts?: { actorName?: string | null }) => (
+      opts?.actorName ? { 'X-MASC-Agent': opts.actorName } : {}
+    ))
+    setupMcpSessionMocks('sess-explicit-internal')
+
+    const { callMcpTool } = await import('./mcp')
+    await callMcpTool('masc_join', { _agent_name: 'codex-tool-matrix' })
+
+    const toolCall = findCallByMethod('tools/call')
+    expect(toolCall).toBeDefined()
+    const body = JSON.parse(toolCall![1].body as string)
+    expect(body.params.arguments).toEqual({
+      _agent_name: 'codex-tool-matrix',
     })
     const headers = toolCall![1].headers as Record<string, string>
     expect(headers['X-MASC-Agent']).toBe('codex-tool-matrix')
@@ -364,7 +385,7 @@ describe('callMcpTool', () => {
     expect(toolCalls).toHaveLength(1)
   })
 
-  it('does not retry explicit actor mismatches', async () => {
+  it('does not retry explicit _agent_name mismatches', async () => {
     authHeaders.mockImplementation((opts?: { actorName?: string | null }) => (
       opts?.actorName ? { 'X-MASC-Agent': opts.actorName } : {}
     ))
@@ -382,7 +403,7 @@ describe('callMcpTool', () => {
 
     const { callMcpTool } = await import('./mcp')
 
-    await expect(callMcpTool('masc_join', { agent_name: 'dashboard' })).rejects.toThrow(
+    await expect(callMcpTool('masc_join', { _agent_name: 'dashboard' })).rejects.toThrow(
       'No credential found for dashboard',
     )
   })

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -149,10 +149,15 @@ function mcpHeaders(extra?: Record<string, string>): Record<string, string> {
 }
 
 function explicitToolActor(args: Record<string, unknown>): string | null {
-  const raw =
-    (typeof args._agent_name === 'string' && args._agent_name.trim() !== '' ? args._agent_name : null)
-    ?? (typeof args.agent_name === 'string' && args.agent_name.trim() !== '' ? args.agent_name : null)
-  return raw?.trim() ?? null
+  const internalActor =
+    typeof args._agent_name === 'string' && args._agent_name.trim() !== ''
+      ? args._agent_name.trim()
+      : null
+  if (internalActor) return internalActor
+  if (getStoredToken()) return null
+  return typeof args.agent_name === 'string' && args.agent_name.trim() !== ''
+    ? args.agent_name.trim()
+    : null
 }
 
 function mcpHeadersForActor(
@@ -305,11 +310,11 @@ async function callMcpToolInternal(
 ): Promise<string> {
   const requestId = String(Math.floor(Date.now() % 1000000))
   let phase = mcpSessionId ? 'tools/call' : 'initialize'
-  const explicitActor = explicitToolActor(args)
-  const actor = explicitActor ?? currentDashboardActor()
   try {
     await ensureSession()
     phase = 'tools/call'
+    const explicitActor = explicitToolActor(args)
+    const actor = explicitActor ?? currentDashboardActor()
     const toolArgs =
       explicitActor == null && actor
         ? { ...args, _agent_name: actor }

--- a/dashboard/src/store-shell-auth.test.ts
+++ b/dashboard/src/store-shell-auth.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const apiMocks = vi.hoisted(() => ({
+  fetchDashboardExecution: vi.fn(),
+  fetchDashboardMemory: vi.fn(),
+  fetchDashboardPlanning: vi.fn(),
+  fetchDashboardShell: vi.fn(),
+}))
+
+const toastMocks = vi.hoisted(() => ({
+  showToast: vi.fn(),
+}))
+
+vi.mock('./api', () => apiMocks)
+vi.mock('./sse', () => ({
+  journal: {
+    log: vi.fn(),
+  },
+}))
+vi.mock('./components/common/toast', () => ({
+  showToast: toastMocks.showToast,
+}))
+
+afterEach(async () => {
+  vi.clearAllMocks()
+  vi.resetModules()
+})
+
+describe('refreshShell auth failure handling', () => {
+  it('clears canonical actor and auth summary when shell refresh fails', async () => {
+    apiMocks.fetchDashboardShell.mockRejectedValue(new Error('network down'))
+
+    const sessionActor = await import('./lib/dashboard-session-actor')
+    const store = await import('./store')
+
+    sessionActor.setCanonicalDashboardActor('codex')
+    store.shellAuthSummary.value = {
+      enabled: true,
+      require_token: true,
+      token_present: true,
+      requested_agent: 'dashboard',
+      effective_agent: 'codex',
+      effective_role: 'worker',
+      default_role: 'worker',
+      token_valid: true,
+      token_agent: 'codex',
+      auth_error_code: null,
+      auth_error_detail: null,
+      can_keeper_msg: true,
+      keeper_msg_error: null,
+    }
+
+    await store.refreshShell({ force: true })
+
+    expect(sessionActor.currentCanonicalDashboardActor()).toBeNull()
+    expect(store.shellAuthSummary.value).toBeNull()
+    expect(toastMocks.showToast).toHaveBeenCalledWith(
+      '서버 연결 실패 — 데이터를 불러올 수 없습니다',
+      'error',
+      6000,
+    )
+  })
+})

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -484,6 +484,8 @@ export async function refreshShell(opts?: RefreshOptions): Promise<void> {
       shellRuntimeResolution.value = normalizeDashboardRuntimeResolution(data.runtime_resolution)
       lastShellRefreshAt = Date.now()
     } catch (err) {
+      setCanonicalDashboardActor(null)
+      shellAuthSummary.value = null
       console.warn('[Dashboard] shell fetch error:', err)
       showToast('서버 연결 실패 — 데이터를 불러올 수 없습니다', 'error', 6000)
     } finally {

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -174,12 +174,6 @@ let dashboard_actor_for_request ~base_path request =
       | Error _ -> request_actor_hint request)
   | None -> request_actor_hint request
 
-let is_transient_actor_name name =
-  let normalized = String.trim name in
-  normalized <> ""
-  && (String.starts_with ~prefix:"agent-" normalized
-      || Nickname.is_generated_nickname normalized)
-
 (** Extract host and explicit port only.
     Host header carries no scheme, so inferring a default port from scheme
     (80 for http, 443 for https) causes mismatches when the browser Origin
@@ -460,29 +454,12 @@ let is_public_read_path path =
 
 let resolve_agent_name_for_auth ~base_path request ~token :
     (string option, Types.masc_error) result =
-  match agent_from_request request with
-  | Some raw when String.trim raw <> "" ->
-      let agent_name = String.trim raw in
-      if is_transient_actor_name agent_name then
-        (match token with
-         | Some t ->
-             (match Auth.resolve_agent_from_token base_path ~token:t with
-              | Ok resolved -> Ok (Some resolved)
-              | Error (Types.InvalidToken _ as e) -> Error e
-              | Error (Types.TokenExpired _ as e) -> Error e
-              | Error _ -> Ok (Some agent_name))
-         | None -> Ok (Some agent_name))
-      else
-        Ok (Some agent_name)
-  | _ ->
-      (match token with
-       | None -> Ok None
-       | Some t ->
-           (match Auth.resolve_agent_from_token base_path ~token:t with
-            | Ok agent_name -> Ok (Some agent_name)
-            | Error (Types.InvalidToken _ as e) -> Error e
-            | Error (Types.TokenExpired _ as e) -> Error e
-            | Error _ -> Ok None))
+  match token with
+  | Some t -> (
+      match Auth.resolve_agent_from_token base_path ~token:t with
+      | Ok agent_name -> Ok (Some agent_name)
+      | Error err -> Error err)
+  | None -> Ok (request_actor_hint request)
 
 let authorize_permission_request ~base_path ~permission request :
     (unit, Types.masc_error) result =

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -166,6 +166,18 @@ let request_actor_hint request =
       if String.equal agent_name "" then None else Some agent_name
   | None -> None
 
+let sanitize_dashboard_actor_name raw =
+  let value = String.trim raw in
+  let buf = Buffer.create (String.length value) in
+  String.iter
+    (fun c ->
+      match c with
+      | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' ->
+          Buffer.add_char buf c
+      | _ -> ())
+    value;
+  Buffer.contents buf
+
 let dashboard_actor_for_request ~base_path request =
   match auth_token_from_request request with
   | Some token -> (
@@ -173,6 +185,13 @@ let dashboard_actor_for_request ~base_path request =
       | Ok agent_name -> Some agent_name
       | Error _ -> request_actor_hint request)
   | None -> request_actor_hint request
+
+let sanitized_dashboard_actor_for_request ~base_path request =
+  match dashboard_actor_for_request ~base_path request with
+  | Some raw ->
+      let sanitized = sanitize_dashboard_actor_name raw in
+      if String.equal sanitized "" then None else Some sanitized
+  | None -> None
 
 (** Extract host and explicit port only.
     Host header carries no scheme, so inferring a default port from scheme

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -232,21 +232,10 @@ let dashboard_batch_json ?(compact = false) (config : Coord.config) : Yojson.Saf
     ("keepers", keepers_dashboard_json ~compact config);
   ]
 
-(** Strip non-ASCII characters from actor string.
-    Prevents IME artifacts (e.g. Korean ㅊ) from polluting cache keys. *)
-let sanitize_actor s =
-  let buf = Buffer.create (String.length s) in
-  String.iter (fun c ->
-    match c with
-    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' -> Buffer.add_char buf c
-    | '\000' .. '\255' -> ()
-  ) s;
-  Buffer.contents buf
-
 let operator_actor_hint request =
   match agent_from_request request with
   | Some raw ->
-      let sanitized = sanitize_actor (String.trim raw) in
+      let sanitized = sanitize_dashboard_actor_name raw in
       if sanitized = "" then None else Some sanitized
   | None -> None
 

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -81,6 +81,9 @@ let broadcast_cached_surface ~event_type (json : Yojson.Safe.t) : unit =
   end else
     Log.Dashboard.debug "%s: payload unchanged, skipping broadcast" event_type
 
+let execution_actor_for_request ~base_path request =
+  Server_auth.sanitized_dashboard_actor_for_request ~base_path request
+
 (* Wire operator broadcast refs now that Sse is in scope. *)
 let () =
   _operator_snapshot_broadcast_ref :=
@@ -398,7 +401,10 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
   let net = state.Mcp_server.net in
   let mono_clock = state.Mcp_server.mono_clock in
   let fixture = query_param request "fixture" in
-  let actor = operator_actor_hint request in
+  let actor =
+    execution_actor_for_request
+      ~base_path:state.Mcp_server.room_config.base_path request
+  in
   let full_mode = bool_query_param request "full" ~default:false in
   let light = not full_mode in
   let compute ?actor ?fixture ~light () =

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -108,11 +108,12 @@ let should_stream_post_tools_call request body_str accept_mode =
   | Some ("tools/call", true) -> true
   | _ -> false
 
-(** Inject _agent_name into MCP tools/call arguments if not already present.
-    This propagates the HTTP-resolved actor identity into the MCP protocol
-    so that tool execution uses the correct agent name instead of an
-    ephemeral session-derived identity. *)
-let inject_agent_name_into_body ~agent_name body_str =
+(** Inject or replace [_agent_name] in MCP [tools/call] arguments.
+    For authenticated dashboard sessions, the HTTP-layer token owner is the
+    canonical caller identity, so a stale browser-supplied [_agent_name]
+    must be overwritten. Legacy [agent_name] is left untouched because some
+    tools use it as a domain argument rather than caller identity. *)
+let inject_agent_name_into_body ?(rewrite_existing = false) ~agent_name body_str =
   try
     let json = Yojson.Safe.from_string body_str in
     let open Yojson.Safe.Util in
@@ -135,14 +136,27 @@ let inject_agent_name_into_body ~agent_name body_str =
                let trimmed = String.trim value in
                if String.equal trimmed "" then None else Some trimmed)
         in
-        if Option.is_some existing_agent || Option.is_some existing_legacy_agent
-        then body_str
-        else
-          let new_args = match args with
-            | `Assoc fields ->
-                `Assoc (("_agent_name", `String agent_name) :: fields)
-            | _ -> args
-          in
+        let new_args =
+          match args with
+          | `Assoc fields ->
+              let normalized_fields =
+                if rewrite_existing then
+                  List.filter (fun (key, _) -> not (String.equal key "_agent_name")) fields
+                else
+                  fields
+              in
+              let should_inject =
+                rewrite_existing
+                || (Option.is_none existing_agent
+                    && Option.is_none existing_legacy_agent)
+              in
+              if should_inject then
+                `Assoc (("_agent_name", `String agent_name) :: normalized_fields)
+              else
+                args
+          | _ -> args
+        in
+        if new_args = args then body_str else
           let new_params = match params with
             | `Assoc fields ->
                 `Assoc (List.map (fun (k, v) ->
@@ -329,7 +343,9 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
                                 match http_agent_name with
                                 | None -> body_str
                                 | Some agent ->
-                                    inject_agent_name_into_body ~agent_name:agent body_str
+                                    inject_agent_name_into_body
+                                      ~rewrite_existing:(Option.is_some auth_token)
+                                      ~agent_name:agent body_str
                               in
                               let response_json =
                                 runtime.handle_request ?auth_token ~profile

--- a/lib/server/server_mcp_transport_http.mli
+++ b/lib/server/server_mcp_transport_http.mli
@@ -43,6 +43,8 @@ val validate_mcp_session_profile :
 val validate_mcp_session_delete_profile :
   profile:tool_profile -> string -> (unit, string) result
 val method_from_body : string -> string option
+val inject_agent_name_into_body :
+  ?rewrite_existing:bool -> agent_name:string -> string -> string
 val validate_session_requirement :
   session_was_provided:bool -> string -> (unit, string) result
 val protocol_version_from_body : string -> string option

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -500,8 +500,10 @@ let add_routes ~sw ~clock router =
            try
              let args = Yojson.Safe.from_string body_str in
              let base_path = state.Mcp_server.room_config.base_path in
-             let actor = agent_from_request request
-               |> Option.value ~default:"dashboard" in
+             let actor =
+               sanitized_dashboard_actor_for_request ~base_path request
+               |> Option.value ~default:"dashboard"
+             in
              let param_key = Yojson.Safe.Util.(member "param_key" args
                |> to_string_option) |> Option.value ~default:"" |> String.trim in
              let value_json = match Yojson.Safe.Util.member "value" args with
@@ -579,8 +581,10 @@ let add_routes ~sw ~clock router =
              let param_key = Yojson.Safe.Util.(member "param_key" args
                |> to_string_option) |> Option.value ~default:"" in
              let base_path = state.Mcp_server.room_config.base_path in
-             let actor = agent_from_request request
-               |> Option.value ~default:"dashboard" in
+             let actor =
+               sanitized_dashboard_actor_for_request ~base_path request
+               |> Option.value ~default:"dashboard"
+             in
              if param_key = "" then
                respond_json_with_cors ~status:`Bad_request request reqd
                  (Yojson.Safe.to_string (`Assoc [

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -390,7 +390,8 @@ let handle_bind_for_connector ~sw ~clock state request reqd
                  (Channel_gate.error_json ("unknown keeper: " ^ keeper_name)))
         | Ok true -> (
             let actor_name =
-              agent_from_request request
+              sanitized_dashboard_actor_for_request
+                ~base_path:state.Mcp_server.room_config.base_path request
               |> Option.value ~default:"dashboard"
               |> String.trim
             in
@@ -407,7 +408,7 @@ let handle_bind_for_connector ~sw ~clock state request reqd
         (Yojson.Safe.to_string (Channel_gate.error_json "invalid json")))
 
 (** Shared unbind handler: parse body, dispatch to connector. *)
-let handle_unbind_for_connector request reqd
+let handle_unbind_for_connector state request reqd
     ~(unbind_fn :
        channel_id:string ->
        actor_name:string ->
@@ -427,7 +428,8 @@ let handle_unbind_for_connector request reqd
              (Channel_gate.error_json "channel_id is required"))
       else
         let actor_name =
-          agent_from_request request
+          sanitized_dashboard_actor_for_request
+            ~base_path:state.Mcp_server.room_config.base_path request
           |> Option.value ~default:"dashboard"
           |> String.trim
         in
@@ -490,7 +492,7 @@ let handle_gate_connector_unbind _state request reqd =
              (Channel_gate.error_json
                 ("unknown connector: " ^ connector_name)))
     | Some (module C) ->
-        handle_unbind_for_connector request reqd
+        handle_unbind_for_connector _state request reqd
           ~unbind_fn:C.unbind
 
 (** Register all gate routes on the router. *)

--- a/lib/server/server_routes_http_routes_verification.ml
+++ b/lib/server/server_routes_http_routes_verification.ml
@@ -14,7 +14,8 @@
       cfg coverage (see {!Dashboard_tla_specs}).
     - [POST /api/v1/verification/resolve] — dashboard-initiated approve/reject
       for a pending verification request. Requires bearer token auth; the
-      verifier identity is derived from the request's actor hint and
+      verifier identity is derived from the authenticated dashboard actor
+      when present (otherwise the request hint) and
       namespaced under "operator:" to distinguish from peer-agent verdicts. *)
 
 open Server_auth
@@ -31,10 +32,11 @@ let verification_error_json msg : Yojson.Safe.t =
 
 (* Compose the operator verifier identity. We always prefix with
    "operator:" so attribution/audit can distinguish dashboard verdicts
-   from peer-agent verdicts. The actor hint is already sanitised by
-   [operator_actor_hint] (alnum + '_' + '-' only). *)
-let verifier_of_request request =
-  match Server_dashboard_http_core.operator_actor_hint request with
+   from peer-agent verdicts. The actor is canonicalized to the bearer
+   owner for authenticated dashboard requests, then sanitized
+   (alnum + '_' + '-' only). *)
+let verifier_of_request ~base_path request =
+  match sanitized_dashboard_actor_for_request ~base_path request with
   | Some hint -> "operator:" ^ hint
   | None -> "operator:dashboard"
 
@@ -77,8 +79,8 @@ let add_routes router =
            Http.Request.read_body_async reqd (fun body_str ->
              try
                let args = Yojson.Safe.from_string body_str in
-               let verifier = verifier_of_request req in
                let config = state.Mcp_server.room_config in
+               let verifier = verifier_of_request ~base_path:config.base_path req in
                match
                  Server_dashboard_http.dashboard_verification_resolve_http_json
                    ~config ~verifier ~args

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -779,6 +779,30 @@ let test_resolve_agent_name_preserves_explicit_stable_actor () =
       | Ok None -> fail "expected token-bound actor"
       | Error e -> fail (Types.masc_error_to_string e))
 
+let test_sanitized_dashboard_actor_for_request_uses_token_owner () =
+  let module SA = Masc_mcp.Server_auth in
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      ignore (Auth.enable_auth dir ~require_token:true ~agent_name:"bootstrap-admin");
+      let raw_token =
+        match Auth.create_token dir ~agent_name:"stable-admin" ~role:Types.Admin with
+        | Ok (token, _cred) -> token
+        | Error e -> fail (Types.masc_error_to_string e)
+      in
+      let headers =
+        Httpun.Headers.of_list
+          [
+            ("authorization", "Bearer " ^ raw_token);
+            ("x-masc-agent", "dashboard-admin-ㅊ");
+          ]
+      in
+      let request = Httpun.Request.create ~headers `POST "/api/v1/gate/connector/bind" in
+      check (option string) "token owner wins and remains cache-safe"
+        (Some "stable-admin")
+        (SA.sanitized_dashboard_actor_for_request ~base_path:dir request))
+
 let test_resolve_agent_name_rejects_invalid_token () =
   let module SA = Masc_mcp.Server_auth in
   let dir = setup_test_room () in
@@ -960,6 +984,8 @@ let () =
         test_resolve_agent_name_prefers_token_for_generated_actor;
       test_case "stable actor canonicalizes to token owner" `Quick
         test_resolve_agent_name_preserves_explicit_stable_actor;
+      test_case "sanitized dashboard actor uses token owner" `Quick
+        test_sanitized_dashboard_actor_for_request_uses_token_owner;
       test_case "invalid token fails" `Quick
         test_resolve_agent_name_rejects_invalid_token;
       test_case "read request uses token owner" `Quick

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -775,8 +775,87 @@ let test_resolve_agent_name_preserves_explicit_stable_actor () =
       let request = Httpun.Request.create ~headers `POST "/mcp" in
       match SA.resolve_agent_name_for_auth ~base_path:dir request ~token:(Some raw_token) with
       | Ok (Some agent_name) ->
-          check string "stable actor preserved" "dashboard-admin" agent_name
-      | Ok None -> fail "expected explicit stable actor"
+          check string "token owner canonicalized" "stable-admin" agent_name
+      | Ok None -> fail "expected token-bound actor"
+      | Error e -> fail (Types.masc_error_to_string e))
+
+let test_resolve_agent_name_rejects_invalid_token () =
+  let module SA = Masc_mcp.Server_auth in
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      ignore (Auth.enable_auth dir ~require_token:true ~agent_name:"bootstrap-admin");
+      let invalid_token = "definitely-invalid-token" in
+      let headers =
+        Httpun.Headers.of_list
+          [
+            ("authorization", "Bearer " ^ invalid_token);
+            ("x-masc-agent", "dashboard-admin");
+          ]
+      in
+      let request = Httpun.Request.create ~headers `POST "/mcp" in
+      match
+        SA.resolve_agent_name_for_auth
+          ~base_path:dir request ~token:(Some invalid_token)
+      with
+      | Error (Types.InvalidToken _) -> ()
+      | Error e -> failf "expected InvalidToken, got %s" (Types.masc_error_to_string e)
+      | Ok _ -> fail "expected invalid token failure")
+
+let test_authorize_read_request_canonicalizes_token_owner () =
+  let module SA = Masc_mcp.Server_auth in
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      ignore (Auth.enable_auth dir ~require_token:true ~agent_name:"bootstrap-admin");
+      let raw_token =
+        match Auth.create_token dir ~agent_name:"stable-admin" ~role:Types.Admin with
+        | Ok (token, _cred) -> token
+        | Error e -> fail (Types.masc_error_to_string e)
+      in
+      let headers =
+        Httpun.Headers.of_list
+          [
+            ("authorization", "Bearer " ^ raw_token);
+            ("x-masc-agent", "dashboard-admin");
+          ]
+      in
+      let request =
+        Httpun.Request.create ~headers `GET "/api/v1/dashboard/shell"
+      in
+      match SA.authorize_read_request ~base_path:dir request with
+      | Ok () -> ()
+      | Error e -> fail (Types.masc_error_to_string e))
+
+let test_authorize_tool_request_canonicalizes_token_owner () =
+  let module SA = Masc_mcp.Server_auth in
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      ignore (Auth.enable_auth dir ~require_token:true ~agent_name:"bootstrap-admin");
+      let raw_token =
+        match Auth.create_token dir ~agent_name:"stable-admin" ~role:Types.Admin with
+        | Ok (token, _cred) -> token
+        | Error e -> fail (Types.masc_error_to_string e)
+      in
+      let headers =
+        Httpun.Headers.of_list
+          [
+            ("authorization", "Bearer " ^ raw_token);
+            ("x-masc-agent", "dashboard-admin");
+          ]
+      in
+      let request =
+        Httpun.Request.create ~headers `POST "/api/v1/operator/action"
+      in
+      match
+        SA.authorize_tool_request
+          ~base_path:dir ~tool_name:"masc_operator_action" request
+      with
+      | Ok () -> ()
       | Error e -> fail (Types.masc_error_to_string e))
 
 (* ============================================================
@@ -879,8 +958,14 @@ let () =
         test_observer_sse_auth_rejects_query_token_on_non_observer_path;
       test_case "generated actor prefers token subject" `Quick
         test_resolve_agent_name_prefers_token_for_generated_actor;
-      test_case "stable actor preserved" `Quick
+      test_case "stable actor canonicalizes to token owner" `Quick
         test_resolve_agent_name_preserves_explicit_stable_actor;
+      test_case "invalid token fails" `Quick
+        test_resolve_agent_name_rejects_invalid_token;
+      test_case "read request uses token owner" `Quick
+        test_authorize_read_request_canonicalizes_token_owner;
+      test_case "tool request uses token owner" `Quick
+        test_authorize_tool_request_canonicalizes_token_owner;
       test_case "same-origin rejects missing origin without token" `Quick
         test_same_origin_browser_request_rejects_missing_origin;
       test_case "same-origin allows matching origin" `Quick

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -304,6 +304,48 @@ let test_dashboard_shell_auth_json_reports_missing_token () =
   check string "missing token code surfaced" "missing_token"
     (auth |> member "auth_error_code" |> to_string)
 
+let test_execution_actor_for_request_canonicalizes_token_owner () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  let cfg =
+    { Types.default_auth_config with enabled = true; require_token = true; default_role = Types.Worker }
+  in
+  Auth.save_auth_config config.base_path cfg;
+  match Auth.create_token config.base_path ~agent_name:"codex" ~role:Types.Worker with
+  | Error e -> fail (Types.masc_error_to_string e)
+  | Ok (raw_token, _) ->
+      let actor =
+        Lib.Server_dashboard_http_execution_surfaces.execution_actor_for_request
+          ~base_path:config.base_path
+          (request_with_headers "/api/v1/dashboard/execution"
+             [
+               ("authorization", "Bearer " ^ raw_token);
+               ("x-masc-agent", "dashboard");
+             ])
+      in
+      check (option string) "execution actor canonicalized to token owner"
+        (Some "codex") actor
+
+let test_verifier_of_request_canonicalizes_token_owner () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  let cfg =
+    { Types.default_auth_config with enabled = true; require_token = true; default_role = Types.Worker }
+  in
+  Auth.save_auth_config config.base_path cfg;
+  match Auth.create_token config.base_path ~agent_name:"codex" ~role:Types.Worker with
+  | Error e -> fail (Types.masc_error_to_string e)
+  | Ok (raw_token, _) ->
+      let verifier =
+        Lib.Server_routes_http_routes_verification.verifier_of_request
+          ~base_path:config.base_path
+          (request_with_headers "/api/v1/verification/resolve"
+             [
+               ("authorization", "Bearer " ^ raw_token);
+               ("x-masc-agent", "dashboard");
+             ])
+      in
+      check string "verification verifier canonicalized to token owner"
+        "operator:codex" verifier
+
 let () =
   run "dashboard_http_core"
     [
@@ -325,5 +367,9 @@ let () =
             test_dashboard_shell_auth_json_canonicalizes_token_owner;
           test_case "shell auth reports missing token" `Quick
             test_dashboard_shell_auth_json_reports_missing_token;
+          test_case "execution actor canonicalizes token owner" `Quick
+            test_execution_actor_for_request_canonicalizes_token_owner;
+          test_case "verification verifier canonicalizes token owner" `Quick
+            test_verifier_of_request_canonicalizes_token_owner;
         ] );
     ]

--- a/test/test_mcp_session_coverage.ml
+++ b/test/test_mcp_session_coverage.ml
@@ -135,6 +135,55 @@ let test_get_or_generate_empty () =
   check bool "not empty" true (String.length result > 0);
   check bool "is valid" true (Mcp_session.is_valid result)
 
+let tool_arguments_of_body body =
+  let open Yojson.Safe.Util in
+  Yojson.Safe.from_string body
+  |> member "params"
+  |> member "arguments"
+
+let test_inject_agent_name_adds_internal_actor_when_missing () =
+  let body =
+    {|{"jsonrpc":"2.0","method":"tools/call","params":{"name":"masc_status","arguments":{"days":7}},"id":1}|}
+  in
+  let args =
+    Http_transport.inject_agent_name_into_body ~agent_name:"codex" body
+    |> tool_arguments_of_body
+  in
+  let open Yojson.Safe.Util in
+  check (option string) "injects _agent_name" (Some "codex")
+    (member "_agent_name" args |> to_string_option);
+  check (option int) "keeps other args" (Some 7)
+    (member "days" args |> to_int_option)
+
+let test_inject_agent_name_preserves_legacy_target_by_default () =
+  let body =
+    {|{"jsonrpc":"2.0","method":"tools/call","params":{"name":"masc_agent_fitness","arguments":{"agent_name":"target-keeper","days":7}},"id":1}|}
+  in
+  let args =
+    Http_transport.inject_agent_name_into_body ~agent_name:"codex" body
+    |> tool_arguments_of_body
+  in
+  let open Yojson.Safe.Util in
+  check (option string) "does not add _agent_name" None
+    (member "_agent_name" args |> to_string_option);
+  check (option string) "keeps legacy agent_name" (Some "target-keeper")
+    (member "agent_name" args |> to_string_option)
+
+let test_inject_agent_name_rewrites_internal_actor_only () =
+  let body =
+    {|{"jsonrpc":"2.0","method":"tools/call","params":{"name":"masc_agent_fitness","arguments":{"_agent_name":"dashboard","agent_name":"target-keeper","days":7}},"id":1}|}
+  in
+  let args =
+    Http_transport.inject_agent_name_into_body
+      ~rewrite_existing:true ~agent_name:"codex" body
+    |> tool_arguments_of_body
+  in
+  let open Yojson.Safe.Util in
+  check (option string) "rewrites _agent_name" (Some "codex")
+    (member "_agent_name" args |> to_string_option);
+  check (option string) "preserves target agent_name" (Some "target-keeper")
+    (member "agent_name" args |> to_string_option)
+
 (* ============================================================
    Test Runners
    ============================================================ *)
@@ -250,5 +299,13 @@ let () =
               && (try ignore (String.index msg 'S'); true
                   with Not_found -> false))
         | Ok () -> fail "expected error");
+    ];
+    "inject_agent_name", [
+      test_case "adds internal actor when missing" `Quick
+        test_inject_agent_name_adds_internal_actor_when_missing;
+      test_case "preserves legacy target by default" `Quick
+        test_inject_agent_name_preserves_legacy_target_by_default;
+      test_case "rewrite_existing only rewrites _agent_name" `Quick
+        test_inject_agent_name_rewrites_internal_actor_only;
     ];
   ]


### PR DESCRIPTION
## What changed
- canonicalized dashboard HTTP auth to the bearer token owner before route-level authorization runs
- rewrote authenticated MCP `tools/call` requests to force canonical `_agent_name` while preserving legacy `agent_name` payload fields
- tightened the dashboard MCP client so token-authenticated sessions only treat `_agent_name` as caller identity
- added regression coverage for auth-gate canonicalization and MCP actor injection semantics

## Why
The dashboard still failed on first load and first MCP calls when the browser sent a stale actor hint like `dashboard` while the bearer token belonged to another agent such as `codex`.

## Impact
- authenticated dashboard sessions now have a single actor truth: the token owner
- first `/api/v1/dashboard/shell`, operator actions, and implicit MCP tool calls no longer depend on client-side correction or retry to recover from stale actor state
- tools that use `agent_name` as a target argument keep their payload semantics

## Root cause
Server auth wrappers were still authorizing against request header actor hints before handler-level canonicalization ran, and MCP transport preserved stale browser `_agent_name` values in authenticated requests.

## Validation
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `./node_modules/.bin/vitest run src/api/mcp.test.ts`
- `dune build --root . test/test_auth_coverage.exe test/test_mcp_session_coverage.exe`
- `./_build/default/test/test_auth_coverage.exe`
- `./_build/default/test/test_mcp_session_coverage.exe`
