### PR TITLE
[codex] Make Agent Directory live-only and drop stale blocker state

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest'
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
+  AgentRoster,
   runtimeBadgeClass,
   stageBadgeClass,
   compactModelLabel,
@@ -12,6 +16,17 @@ import {
   filterAgentRoster,
 } from './agent-roster'
 import type { Agent, Keeper } from '../types'
+import {
+  agents,
+  keepers,
+  executionLoaded,
+  executionLoading,
+  executionError,
+  shellCounts,
+  serverStatus,
+} from '../store'
+import { missionSnapshot } from '../mission-signals'
+import { namespaceTruth } from '../namespace-truth-store'
 
 function makeAgent(overrides: Partial<Agent> = {}): Agent {
   return {
@@ -20,6 +35,12 @@ function makeAgent(overrides: Partial<Agent> = {}): Agent {
     current_task: null,
     ...overrides,
   }
+}
+
+async function flushUi(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+  })
 }
 
 describe('runtimeBadgeClass', () => {
@@ -207,7 +228,7 @@ describe('rosterStateNote', () => {
         runtime_blocker_summary: 'Turn wall-clock timeout after 1200s',
       } as Keeper, 'fallback hint'),
     ).toEqual({
-      label: '최근 차단',
+      label: '현재 차단',
       text: 'Turn wall-clock timeout after 1200s',
     })
   })
@@ -235,6 +256,17 @@ describe('rosterStateNote', () => {
       label: '상태 메모',
       text: '오래 응답이 없어 실제 상태 확인이 필요합니다.',
     })
+  })
+
+  it('ignores historical last_blocker text without a live runtime blocker', () => {
+    expect(
+      rosterStateNote(
+        {
+          last_blocker: 'old social-model blocker',
+        } as Keeper,
+        null,
+      ),
+    ).toBeNull()
   })
 
   it('returns null when no note source is available', () => {
@@ -343,6 +375,104 @@ describe('mergeRosterAgent', () => {
     const next: Agent = { ...nextAgent, capabilities: ['tool-b'] }
     const result = mergeRosterAgent(existing, next)
     expect(result.capabilities).toEqual(['tool-b'])
+  })
+})
+
+describe('AgentRoster live-only cards', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    agents.value = []
+    keepers.value = []
+    executionLoaded.value = true
+    executionLoading.value = false
+    executionError.value = null
+    shellCounts.value = null
+    serverStatus.value = null
+    namespaceTruth.value = null
+    missionSnapshot.value = null
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    agents.value = []
+    keepers.value = []
+    executionLoaded.value = false
+    executionLoading.value = false
+    executionError.value = null
+    shellCounts.value = null
+    serverStatus.value = null
+    namespaceTruth.value = null
+    missionSnapshot.value = null
+  })
+
+  it('renders keeper cards from live runtime data and ignores stale mission brief fields', async () => {
+    agents.value = [
+      makeAgent({
+        name: 'codex-mcp-client',
+        current_task: 'agent fallback task',
+        model: 'gpt-5.4',
+      }),
+    ]
+    keepers.value = [
+      {
+        name: 'nick0cave',
+        agent_name: 'codex-mcp-client',
+        status: 'idle',
+        last_heartbeat: '2026-04-23T09:59:00Z',
+        last_autonomous_action_at: '2026-04-23T09:58:00Z',
+        last_activity_ago_s: 75,
+        recent_output_preview: 'live runtime output preview',
+        recent_input_preview: 'live runtime input preview',
+        recent_tool_names: ['keeper_task_claim'],
+        latest_tool_call_count: 1,
+        tool_audit_at: '2026-04-23T09:58:30Z',
+        last_blocker: 'old blocker that should stay out of the roster',
+      } as Keeper,
+    ]
+    missionSnapshot.value = {
+      generated_at: '2026-04-23T09:00:00Z',
+      summary: {},
+      incidents: [],
+      recommended_actions: [],
+      command_focus: {},
+      operator_targets: {},
+      attention_queue: [],
+      sessions: [],
+      agent_briefs: [
+        {
+          agent_name: 'codex-mcp-client',
+          current_work: 'stale mission work',
+          recent_output_preview: 'stale mission preview',
+          last_activity_at: '2026-04-23T06:00:00Z',
+        },
+      ],
+      keeper_briefs: [
+        {
+          name: 'nick0cave',
+          agent_name: 'codex-mcp-client',
+          current_work: 'stale keeper brief work',
+          latest_tool_names: ['stale_tool'],
+          last_autonomous_action_at: '2026-04-23T06:00:00Z',
+        },
+      ],
+      internal_signals: [],
+    } as any
+
+    await act(async () => {
+      render(html`<${AgentRoster} />`, container)
+    })
+    await flushUi()
+
+    expect(container.textContent).toContain('live runtime output preview')
+    expect(container.textContent).toContain('keeper_task_claim')
+    expect(container.textContent).not.toContain('stale mission preview')
+    expect(container.textContent).not.toContain('stale keeper brief work')
+    expect(container.textContent).not.toContain('stale_tool')
+    expect(container.textContent).not.toContain('old blocker that should stay out of the roster')
   })
 })
 

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -5,10 +5,6 @@
 import { html } from 'htm/preact'
 import { useMemo, useState } from 'preact/hooks'
 import type { Agent, Keeper } from '../types'
-import type {
-  DashboardMissionAgentBrief,
-  DashboardMissionKeeperBrief,
-} from '../types/dashboard-mission'
 import {
   agents,
   keepers,
@@ -18,7 +14,6 @@ import {
   executionError,
   shellCounts,
 } from '../store'
-import { missionKeeperBriefs, missionAgentBriefs } from '../mission-signals'
 import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
 import { EmptyState } from './common/empty-state'
@@ -132,16 +127,12 @@ export function rosterContextMeta(
 export function rosterStateNote(
   keeper: {
     runtime_blocker_summary?: string | null
-    last_blocker?: string | null
     diagnostic?: { last_error?: string | null } | null
   } | null | undefined,
   monitoringHint?: string | null,
 ): { label: string; text: string } | null {
   const runtimeBlocker = keeper?.runtime_blocker_summary?.trim()
-  if (runtimeBlocker) return { label: '최근 차단', text: runtimeBlocker }
-
-  const lastBlocker = keeper?.last_blocker?.trim()
-  if (lastBlocker) return { label: '최근 차단', text: lastBlocker }
+  if (runtimeBlocker) return { label: '현재 차단', text: runtimeBlocker }
 
   const diagnosticError = keeper?.diagnostic?.last_error?.trim()
   if (diagnosticError) return { label: '최근 오류', text: diagnosticError }
@@ -151,22 +142,7 @@ export function rosterStateNote(
   return null
 }
 
-interface KeeperInfo {
-  name?: string
-  agent_name?: string | null
-  generation?: number | null
-  context_ratio?: number | null
-  model?: string | null
-  current_work?: string | null
-  last_turn_ago_s?: number | null
-  last_autonomous_action_at?: string | null
-  recent_tool_names?: string[]
-  latest_tool_names?: string[]
-  latest_tool_call_count?: number | null
-  tool_audit_at?: string | null
-}
-
-function registerKeeperLookup<T extends Pick<KeeperInfo, 'name' | 'agent_name'>>(
+function registerKeeperLookup<T extends Pick<Keeper, 'name' | 'agent_name'>>(
   lookup: Map<string, T>,
   source: T,
 ) {
@@ -178,49 +154,17 @@ function registerKeeperLookup<T extends Pick<KeeperInfo, 'name' | 'agent_name'>>
   }
 }
 
-function buildKeeperInfoLookup(
-  keeperList: Keeper[],
-  keeperBriefs: DashboardMissionKeeperBrief[],
-): Map<string, KeeperInfo> {
-  const lookup = new Map<string, KeeperInfo>()
-  for (const brief of keeperBriefs) registerKeeperLookup(lookup, brief)
-  for (const keeper of keeperList) registerKeeperLookup(lookup, keeper)
-  return lookup
-}
-
 function buildKeeperRuntimeLookup(keeperList: Keeper[]): Map<string, Keeper> {
   const lookup = new Map<string, Keeper>()
   for (const keeper of keeperList) registerKeeperLookup(lookup, keeper)
   return lookup
 }
 
-function findKeeper(agentName: string, keeperList: Keeper[], keeperBriefs: DashboardMissionKeeperBrief[]): KeeperInfo | null {
-  // Try keeper briefs first (richer data from mission snapshot)
-  for (const kb of keeperBriefs) {
-    if (kb.name === agentName || kb.agent_name === agentName
-        || agentName.includes(kb.name) || kb.name?.includes(agentName)) {
-      return kb
-    }
-  }
-  // Fallback to keeper signal store
+function findKeeperRuntime(agentName: string, keeperList: Keeper[]): Keeper | null {
   for (const k of keeperList) {
     if (k.name === agentName || k.agent_name === agentName
         || agentName.includes(k.name) || k.name?.includes(agentName)) {
       return k
-    }
-  }
-  return null
-}
-
-function findKeeperRuntime(agentName: string, keeperList: Keeper[]): Keeper | null {
-  for (const keeper of keeperList) {
-    if (
-      keeper.name === agentName
-      || keeper.agent_name === agentName
-      || agentName.includes(keeper.name)
-      || keeper.name.includes(agentName)
-    ) {
-      return keeper
     }
   }
   return null
@@ -305,51 +249,54 @@ export function uniqueToolNames(...groups: Array<string[] | null | undefined>): 
 function matchesKeeperFilter(
   agentName: string,
   keeperList: Keeper[],
-  keeperBriefs: DashboardMissionKeeperBrief[],
   keeperFilter: KeeperFilterMode,
 ): boolean {
   if (keeperFilter === 'all') return true
-  const isKeeper = findKeeper(agentName, keeperList, keeperBriefs) != null
+  const isKeeper = findKeeperRuntime(agentName, keeperList) != null
   return keeperFilter === 'keeper-only' ? isKeeper : !isKeeper
 }
 
 function scopeAgentsByKeeperFilter(
   agentList: Agent[],
   keeperList: Keeper[],
-  keeperBriefs: DashboardMissionKeeperBrief[],
   keeperFilter: KeeperFilterMode,
 ): Agent[] {
   return agentList.filter((agent: Agent) =>
-    matchesKeeperFilter(agent.name, keeperList, keeperBriefs, keeperFilter))
+    matchesKeeperFilter(agent.name, keeperList, keeperFilter))
 }
 
-export function keeperRuntimeName(source: Pick<Keeper, 'name' | 'agent_name'> | DashboardMissionKeeperBrief): string {
+export function keeperRuntimeName(source: Pick<Keeper, 'name' | 'agent_name'>): string {
   const runtimeName = source.agent_name?.trim()
   return runtimeName && runtimeName.length > 0 ? runtimeName : source.name
 }
 
-function synthesizeAgentFromKeeper(source: Keeper | DashboardMissionKeeperBrief): Agent | null {
+function synthesizeAgentFromKeeper(source: Keeper): Agent | null {
   const runtimeName = keeperRuntimeName(source)
   if (!runtimeName) return null
 
-  const typed = source as Keeper & DashboardMissionKeeperBrief
-  const linkedAgent = typed.agent
+  const linkedAgent = source.agent
+  const liveCurrentTask =
+    source.recent_output_preview
+    ?? source.recent_input_preview
+    ?? source.short_goal
+    ?? source.goal
+    ?? null
 
   return {
     name: runtimeName,
     agent_type: linkedAgent?.agent_type,
-    status: (linkedAgent?.status as Agent['status'] | undefined) ?? (typed.status as Agent['status'] | undefined),
-    current_task: linkedAgent?.current_task ?? typed.current_work ?? null,
-    context_ratio: typed.context_ratio ?? undefined,
+    status: (linkedAgent?.status as Agent['status'] | undefined) ?? (source.status as Agent['status'] | undefined),
+    current_task: linkedAgent?.current_task ?? liveCurrentTask,
+    context_ratio: source.context_ratio ?? undefined,
     joined_at: linkedAgent?.joined_at,
     last_seen: linkedAgent?.last_seen,
     capabilities: linkedAgent?.capabilities,
-    emoji: typed.emoji,
-    koreanName: typed.koreanName,
-    model: typed.model,
-    traits: typed.traits,
-    activityLevel: typed.activityLevel,
-    primaryValue: typed.primaryValue,
+    emoji: source.emoji,
+    koreanName: source.koreanName,
+    model: source.model,
+    traits: source.traits,
+    activityLevel: source.activityLevel,
+    primaryValue: source.primaryValue,
     synthetic: true,
   }
 }
@@ -377,7 +324,6 @@ export function mergeRosterAgent(existing: Agent | undefined, next: Agent): Agen
 function buildAgentRoster(
   agentList: Agent[],
   keeperList: Keeper[],
-  keeperBriefs: DashboardMissionKeeperBrief[],
 ): Agent[] {
   const roster = new Map<string, Agent>()
 
@@ -385,7 +331,7 @@ function buildAgentRoster(
     roster.set(agent.name, agent)
   }
 
-  for (const source of [...keeperList, ...keeperBriefs]) {
+  for (const source of keeperList) {
     const synthetic = synthesizeAgentFromKeeper(source)
     if (!synthetic) continue
     roster.set(synthetic.name, mergeRosterAgent(roster.get(synthetic.name), synthetic))
@@ -418,11 +364,10 @@ function countAgentsByStatus(
 export function countRuntimeKinds(
   agentList: Agent[],
   keeperList: Keeper[],
-  keeperBriefs: DashboardMissionKeeperBrief[],
 ): { agents: number; keepers: number; totalRuntimes: number } {
-  const rosterAgents = buildAgentRoster(agentList, keeperList, keeperBriefs)
-  const keeperCount = scopeAgentsByKeeperFilter(rosterAgents, keeperList, keeperBriefs, 'keeper-only').length
-  const agentCount = scopeAgentsByKeeperFilter(rosterAgents, keeperList, keeperBriefs, 'agent-only').length
+  const rosterAgents = buildAgentRoster(agentList, keeperList)
+  const keeperCount = scopeAgentsByKeeperFilter(rosterAgents, keeperList, 'keeper-only').length
+  const agentCount = scopeAgentsByKeeperFilter(rosterAgents, keeperList, 'agent-only').length
 
   return {
     agents: agentCount,
@@ -437,17 +382,13 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
   const agentList = agents.value
   const keeperList = keepers.value
-  const briefs = missionAgentBriefs.value
-  const keeperBriefs = missionKeeperBriefs.value
 
-  // Memoize roster and lookup Maps — these iterate full keeper/agent arrays
+  // Memoize roster and lookup Maps — these iterate full keeper/agent arrays.
+  // Directory cards are live-only: cached mission briefs are intentionally
+  // excluded so one card never mixes multiple freshness levels.
   const rosterAgents = useMemo(
-    () => buildAgentRoster(agentList, keeperList, keeperBriefs),
-    [agentList, keeperList, keeperBriefs],
-  )
-  const keeperInfoLookup = useMemo(
-    () => buildKeeperInfoLookup(keeperList, keeperBriefs),
-    [keeperList, keeperBriefs],
+    () => buildAgentRoster(agentList, keeperList),
+    [agentList, keeperList],
   )
   const keeperRuntimeLookup = useMemo(
     () => buildKeeperRuntimeLookup(keeperList),
@@ -456,10 +397,10 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
   // Derive runtime kind counts from memoized roster (avoids duplicate buildAgentRoster call)
   const liveRuntimeCounts = useMemo(() => {
-    const keeperCount = scopeAgentsByKeeperFilter(rosterAgents, keeperList, keeperBriefs, 'keeper-only').length
-    const agentCount = scopeAgentsByKeeperFilter(rosterAgents, keeperList, keeperBriefs, 'agent-only').length
+    const keeperCount = scopeAgentsByKeeperFilter(rosterAgents, keeperList, 'keeper-only').length
+    const agentCount = scopeAgentsByKeeperFilter(rosterAgents, keeperList, 'agent-only').length
     return { agents: agentCount, keepers: keeperCount, totalRuntimes: rosterAgents.length }
-  }, [rosterAgents, keeperList, keeperBriefs])
+  }, [rosterAgents, keeperList])
 
   const runtimeCounts = resolveRuntimeCounts({
     executionLoaded: executionLoaded.value,
@@ -475,15 +416,9 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   const namespaceStatus = namespaceTruth.value?.root.status ?? serverStatus.value
   const namespaceName = namespaceStatus?.project ?? 'default'
 
-  const briefMap = useMemo(
-    () => new Map<string, DashboardMissionAgentBrief>(
-      briefs.map(brief => [brief.agent_name, brief] as const),
-    ),
-    [briefs],
-  )
   const scopedAgents = useMemo(
-    () => scopeAgentsByKeeperFilter(rosterAgents, keeperList, keeperBriefs, keeperFilter),
-    [rosterAgents, keeperList, keeperBriefs, keeperFilter],
+    () => scopeAgentsByKeeperFilter(rosterAgents, keeperList, keeperFilter),
+    [rosterAgents, keeperList, keeperFilter],
   )
   const bandByAgent = useMemo(
     () => new Map(
@@ -501,7 +436,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   const searchTermsByAgent = useMemo(
     () => new Map(
       scopedAgents.map(agent => {
-        const keeper = keeperInfoLookup.get(agent.name) ?? findKeeper(agent.name, keeperList, keeperBriefs)
+        const keeper = keeperRuntimeLookup.get(agent.name) ?? findKeeperRuntime(agent.name, keeperList)
         return [
           agent.name,
           keeperIdentitySearchTerms(
@@ -511,13 +446,13 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
         ] as const
       }),
     ),
-    [scopedAgents, keeperInfoLookup, keeperList, keeperBriefs],
+    [scopedAgents, keeperRuntimeLookup, keeperList],
   )
   const pageDescription = keeperFilter === 'keeper-only'
-    ? '주 이름을 먼저 보고, 필요할 때만 상태와 최근 근거를 확인합니다.'
+    ? 'live runtime 기준으로 주 이름과 현재 상태를 먼저 훑습니다.'
     : keeperFilter === 'agent-only'
-      ? '키퍼가 연결되지 않은 일반 에이전트만 따로 봅니다.'
-      : '주 이름 기준으로 훑고, 최근 활동과 운영 상태가 필요한 카드만 열어봅니다.'
+      ? 'live execution 기준으로 키퍼가 연결되지 않은 일반 에이전트만 따로 봅니다.'
+      : 'live execution/runtime 기준으로 현재 상태를 보고, cached 조율 정보는 이 화면에 섞지 않습니다.'
 
   const filtered = scopedAgents
     .filter((a: Agent) => {
@@ -626,7 +561,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
               <div class="flex flex-col gap-1">
                 <div class="text-2xs font-semibold tracking-1 text-[var(--text-strong)] uppercase">운영 상태</div>
-                <p class="m-0 text-xs leading-normal text-[var(--text-muted)]">먼저 운영 상태로 걸러 보고, 필요할 때만 세부 상태와 최근 근거를 확인합니다.</p>
+                <p class="m-0 text-xs leading-normal text-[var(--text-muted)]">live runtime 신호로 먼저 걸러 보고, 필요할 때만 세부 상태와 최근 근거를 확인합니다.</p>
               </div>
               <${FilterChips}
                 chips=${statusChips}
@@ -660,31 +595,30 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
       <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
         ${filtered.map((agent: Agent) => {
-          const brief = briefMap.get(agent.name)
-          const keeper = keeperInfoLookup.get(agent.name) ?? findKeeper(agent.name, keeperList, keeperBriefs)
           const keeperRuntime = keeperRuntimeLookup.get(agent.name) ?? findKeeperRuntime(agent.name, keeperList)
           const band = bandByAgent.get(agent.name) ?? runtimeBandMeta('attention')
           const keeperMonitoring = keeperRuntime ? summarizeKeeperMonitoring(keeperRuntime) : null
           const monitoringEvidence = keeperMonitoring ? summarizeMonitoringEvidence(keeperMonitoring) : null
           const fsmPhase = keeperRuntime ? keeperPhaseForDisplay(keeperRuntime) : null
-          const isKeeper = keeper != null
-          const currentWork = keeper?.current_work ?? brief?.current_work ?? agent.current_task ?? null
-          const lastActivityAge = keeperRuntime?.last_activity_ago_s ?? keeper?.last_turn_ago_s ?? brief?.last_activity_age_sec ?? null
+          const isKeeper = keeperRuntime != null
+          const goalSummary = keeperRuntime?.short_goal ?? keeperRuntime?.goal ?? agent.current_task ?? null
+          const currentWork =
+            keeperRuntime?.recent_output_preview
+            ?? keeperRuntime?.recent_input_preview
+            ?? goalSummary
+            ?? null
+          const lastActivityAge = keeperRuntime?.last_activity_ago_s ?? null
           const lastActivityAt =
-            brief?.last_activity_at
-            ?? keeper?.last_autonomous_action_at
-            ?? keeperRuntime?.last_autonomous_action_at
+            keeperRuntime?.last_autonomous_action_at
             ?? keeperRuntime?.last_heartbeat
             ?? agent.last_seen
             ?? null
           const contextMeta =
-            rosterContextMeta(keeperRuntime ?? keeper ?? null)
+            rosterContextMeta(keeperRuntime ?? null)
           const workPreview =
-            trimText(currentWork, 140)
-            ?? trimText(brief?.recent_output_preview, 140)
-            ?? trimText(keeperRuntime?.recent_output_preview, 140)
-            ?? trimText(brief?.recent_input_preview, 140)
+            trimText(keeperRuntime?.recent_output_preview, 140)
             ?? trimText(keeperRuntime?.recent_input_preview, 140)
+            ?? trimText(goalSummary, 140)
             ?? '최근 활동 요약 없음'
           const summaryText = workPreview
           const stateNote =
@@ -692,33 +626,23 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
               ? rosterStateNote(keeperRuntime, band.key === 'active' ? null : keeperMonitoring?.hint ?? null)
               : null
           const recentTools = uniqueToolNames(
-            brief?.recent_tool_names,
-            brief?.latest_tool_names,
             keeperRuntime?.recent_tool_names,
             keeperRuntime?.latest_tool_names,
-            keeper?.recent_tool_names,
-            keeper?.latest_tool_names,
           )
           const visibleTools = recentTools.slice(0, 2)
           const primaryTool = visibleTools[0] ?? null
           const extraToolCount = Math.max(0, recentTools.length - (primaryTool ? 1 : 0))
           const toolCallCount =
-            brief?.latest_tool_call_count
-            ?? keeper?.latest_tool_call_count
-            ?? keeperRuntime?.latest_tool_call_count
+            keeperRuntime?.latest_tool_call_count
             ?? null
-          const toolAuditAt =
-            brief?.tool_audit_at
-            ?? keeper?.tool_audit_at
-            ?? keeperRuntime?.tool_audit_at
-            ?? null
+          const toolAuditAt = keeperRuntime?.tool_audit_at ?? null
           const displayName =
             keeperPrimaryName(
-              keeperRuntime?.name ?? keeper?.name ?? null,
-              keeperRuntime?.agent_name ?? keeper?.agent_name ?? agent.name,
+              keeperRuntime?.name ?? null,
+              keeperRuntime?.agent_name ?? agent.name,
             )
             ?? agent.name
-          const modelMeta = rosterModelMeta(keeperRuntime ?? keeper ?? null)
+          const modelMeta = rosterModelMeta(keeperRuntime ?? agent)
           const compactModel = compactModelLabel(modelMeta?.value)
           const fsmPhaseKey =
             keeperMonitoring?.phase.key && keeperMonitoring.phase.key !== 'unknown'

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -7,7 +7,6 @@ import { computed } from '@preact/signals'
 import { FilterChips } from './common/filter-chips'
 import { navigate, route } from '../router'
 import { agents, keepers, executionLoaded, shellCounts } from '../store'
-import { missionKeeperBriefs } from '../mission-signals'
 import { AgentRoster, countRuntimeKinds } from './agent-roster'
 import { AgentProfile } from './agent-profile'
 import { KeeperDetailPage } from './keeper-detail'
@@ -53,7 +52,7 @@ export function AgentsUnified() {
   const currentView = activeView.value
 
   // Compute counts for chip badges.
-  const liveRuntimeCounts = countRuntimeKinds(agents.value, keepers.value, missionKeeperBriefs.value)
+  const liveRuntimeCounts = countRuntimeKinds(agents.value, keepers.value)
   const runtimeCounts = resolveRuntimeCounts({
     executionLoaded: executionLoaded.value,
     agentsCount: liveRuntimeCounts.agents,
@@ -95,7 +94,7 @@ export function AgentsUnified() {
       ${currentView !== 'fsm' ? html`
         <div class="monitor-muted-panel flex flex-wrap items-center gap-2 px-4 py-3 text-xs text-[var(--text-muted)]">
           <span class="text-2xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">이 화면 밖</span>
-          <span>이벤트 로그, 도구 품질, 거버넌스</span>
+          <span>cached 조율 스냅샷, 이벤트 로그, 도구 품질, 거버넌스</span>
           <${RouteLink}
             tab="monitoring"
             params=${{ section: 'fleet-health' }}

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -452,11 +452,12 @@ export function RuntimeMonitor() {
                   metric.coverage_status === 'none'
                   || metric.coverage_status === 'partial'
                   || metric.coverage_status === 'error_only'
-                const articleClass = isFailing
-                  ? 'p-4 rounded border border-[var(--status-bad)] bg-[var(--status-bad)]/5 backdrop-blur-sm shadow-sm flex flex-col gap-2'
-                  : hasCoverageGap
-                    ? 'p-4 rounded border border-[var(--status-warn)] bg-[var(--status-warn)]/5 backdrop-blur-sm shadow-sm flex flex-col gap-2'
-                  : 'p-4 rounded border border-card-border bg-card/40 backdrop-blur-sm shadow-sm flex flex-col gap-2'
+                let articleClass = 'p-4 rounded border border-card-border bg-card/40 backdrop-blur-sm shadow-sm flex flex-col gap-2'
+                if (isFailing) {
+                  articleClass = 'p-4 rounded border border-[var(--status-bad)] bg-[var(--status-bad)]/5 backdrop-blur-sm shadow-sm flex flex-col gap-2'
+                } else if (hasCoverageGap) {
+                  articleClass = 'p-4 rounded border border-[var(--status-warn)] bg-[var(--status-warn)]/5 backdrop-blur-sm shadow-sm flex flex-col gap-2'
+                }
                 const ariaLabel = isFailing
                   ? `Provider failing: ${metric.model_id}, ${metric.error_count ?? 0} errors out of ${metric.entry_count ?? 0}`
                   : undefined

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -146,7 +146,7 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     {
       id: 'agents',
       label: '에이전트 디렉터리',
-      description: '누가 살아 있고 어떤 프로세스 위에 떠 있는지 빠르게 훑어봅니다. 이벤트, 도구, 거버넌스는 플릿 텔레메트리에서 봅니다.',
+      description: '누가 살아 있고 어떤 프로세스 위에 떠 있는지 live runtime 기준으로 빠르게 훑어봅니다. cached 조율 정보와 이벤트, 도구, 거버넌스는 다른 화면에서 봅니다.',
       params: { section: 'agents' },
     },
     {

--- a/dashboard/src/lib/monitoring-runtime.test.ts
+++ b/dashboard/src/lib/monitoring-runtime.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import {
   runtimeBandMeta,
+  summarizeKeeperMonitoring,
   summarizeMonitoringEvidence,
 } from './monitoring-runtime'
 import type { KeeperMonitoringSummary } from './monitoring-runtime'
+import type { Keeper } from '../types'
 
 function makeSummary(overrides: Partial<KeeperMonitoringSummary> = {}): KeeperMonitoringSummary {
   return {
@@ -105,5 +107,34 @@ describe('summarizeMonitoringEvidence', () => {
       phase: { key: 'unknown', label: '확인 필요', description: 'unknown' },
     }))
     expect(evidence.phase).toBeNull()
+  })
+})
+
+describe('summarizeKeeperMonitoring', () => {
+  it('ignores stale last_blocker text when no live runtime blocker is present', () => {
+    const summary = summarizeKeeperMonitoring({
+      name: 'keeper-a',
+      status: 'idle',
+      phase: 'Running',
+      last_heartbeat: new Date().toISOString(),
+      last_blocker: 'old blocker',
+    } as Keeper)
+
+    expect(summary.band.key).toBe('active')
+    expect(summary.hint).toBeNull()
+  })
+
+  it('keeps runtime blockers as live attention signals', () => {
+    const summary = summarizeKeeperMonitoring({
+      name: 'keeper-a',
+      status: 'idle',
+      phase: 'Running',
+      last_heartbeat: new Date().toISOString(),
+      runtime_blocker_class: 'turn_timeout',
+      runtime_blocker_summary: 'turn timed out after queue wait',
+    } as Keeper)
+
+    expect(summary.band.key).toBe('attention')
+    expect(summary.hint).toBe('turn timed out after queue wait')
   })
 })

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -226,7 +226,6 @@ function keeperBand(keeper: Keeper, phaseKey: string, lifecycleKey: string): Run
     ATTENTION_PHASES.has(phaseKey)
     || Boolean(keeper.runtime_blocker_class)
     || keeper.social_model_recognized === false
-    || Boolean(keeper.last_blocker?.trim())
     || isHeartbeatStale(keeper)
     || (typeof keeper.context_ratio === 'number' && keeper.context_ratio >= contextAttentionRatio(keeper))
   ) {
@@ -246,8 +245,6 @@ function keeperHint(keeper: Keeper, band: RuntimeBand, stage: StageMeta): string
     if (fallback) return `소셜 모델 fallback이 ${fallback}로 설정돼 있습니다.`
     return '미인식 소셜 모델 설정이 감지됐습니다.'
   }
-  const blocker = keeper.last_blocker?.trim()
-  if (blocker) return blocker
   if (band === 'paused') return '운영자가 멈춰 둔 상태입니다.'
   if (isHeartbeatStale(keeper)) return '오래 응답이 없어 실제 상태 확인이 필요합니다.'
   if (typeof keeper.context_ratio === 'number' && keeper.context_ratio >= contextAttentionRatio(keeper)) {


### PR DESCRIPTION
## Summary
- make Agent Directory cards use live `agents` and `keepers` runtime data only
- remove historical `last_blocker` from roster attention/current-blocker rendering
- fix the dashboard lint blocker in `runtime-monitor.ts` by removing the nested ternary
- update copy and tests so cached coordination snapshots are no longer presented as live operational truth

## Root Cause
Agent Directory cards were mixing live keeper runtime fields with cached mission snapshot / keeper brief data. That made stale work summaries, tools, and blocker text look like current runtime state. Historical `last_blocker` text could also keep a keeper in an attention-looking state after the live runtime blocker had already cleared. Separately, the dashboard lint run was blocked by an unrelated nested ternary in `runtime-monitor.ts`.

## Impact
- keeper cards now reflect current runtime state more faithfully
- `현재 차단` only appears when a live `runtime_blocker_summary` exists
- stale mission brief text no longer overrides live work previews, tools, or activity signals
- dashboard lint now runs cleanly for this branch

## Validation
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec vitest run src/components/agent-roster.test.ts src/lib/monitoring-runtime.test.ts src/config/navigation.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec vitest run src/components/runtime-monitor.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm lint`
