### PR TITLE
fix(keeper): sync canonical TOML timeout key list

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -806,6 +806,7 @@ let canonical_keeper_toml_key_names =
   ; "work_discovery_guidance"
   ; "telemetry_feedback_enabled"
   ; "telemetry_feedback_window_hours"
+  ; "per_provider_timeout"
   ; "max_turns_per_call"
   ; "max_turns_per_call_scheduled_autonomous"
   ; "social_model"


### PR DESCRIPTION
## Summary
- add  to 
- restore the compile-time key-list equality assertion on latest 
- unblock  startup so structured-output/history failures can be tested again

Closes #9671

## Verification
- 
- Testing `exec_core'.
This run has ID `MFFG8T14'.

  [OK]          semantic_status                0   rg no match is semantic su...
  [OK]          semantic_status                1   find partial is recoverabl...
  [OK]          semantic_status                2   find missing path is runti...
  [OK]          semantic_status                3   quoted regex pipe keeps no...
  [OK]          semantic_status                4   blocked json adds classifi...
  [OK]          semantic_status                5   unknown write is not git_w...
  [OK]          semantic_status                6   large output persists arti...
  [OK]          semantic_status                7   inline only keeps artifact...
  [OK]          semantic_exit                  0   explicit opt-out hides field.
  [OK]          semantic_exit                  1   ok kind on exit 0.
  [OK]          semantic_exit                  2   fail kind carries exit_code.
  [OK]          semantic_exit                  3   git exit 128 maps to git_n...
  [OK]          semantic_exit                  4   exit 127 maps to tool_miss...
  [OK]          semantic_exit                  5   flag flip isolates state.
  [OK]          verifiable_markers             0   absent when markers flag off.
  [OK]          verifiable_markers             1   absent when semantic flag ...
  [OK]          verifiable_markers             2   git_not_a_repo emits exact...
  [OK]          verifiable_markers             3   unknown output emits no ma...
  [OK]          output_cap                     0   absent by default.
  [OK]          output_cap                     1   small output unchanged, ca...
  [OK]          output_cap                     2   large output truncated wit...
  [OK]          p8_diagnosis                   0   no diag => diagnosis absent.
  [OK]          p8_diagnosis                   1   diag with rewrite => all f...
  [OK]          p8_diagnosis                   2   diag with tool_suggestion.
  [OK]          p8_diagnosis                   3   diag with both rewrite and...
> [FAIL]        p10_structured_output          0   git status --porcelain pro...
  [FAIL]        p10_structured_output          1   git log --oneline produces...
  [OK]          p10_structured_output          2   wc -l produces lines count.
  [FAIL]        p10_structured_output          3   unknown cmd has no structu...
  [OK]          p10_structured_output          4   dune runtest produces pass...
  [FAIL]        p11_command_history            0   append and read history en...
  [OK]          p11_command_history            1   suggest returns empty for ...
  [OK]          p11_command_history            2   cmd_hash produces 12-char ...
  [FAIL]        p11_command_history            3   compaction preserves entri...

┌──────────────────────────────────────────────────────────────────────────────┐
│ [FAIL]        p10_structured_output          0   git status --porcelain ...  │
└──────────────────────────────────────────────────────────────────────────────┘
[exception] Yojson__Safe.Util.Type_error("Can't get member 'staged' of non-object type null", 870828711)
            Raised at Yojson__Safe.Util.typerr in file "lib/read.ml", line 2901, characters 20-60
            Called from Dune__exe__Test_exec_core.test_git_status_structured in file "test/test_exec_core.ml", line 460, characters 15-36
            Called from Alcotest_engine__Core.Make.protect_test.(fun) in file "src/alcotest-engine/core.ml", line 186, characters 17-23
            Called from Alcotest_engine__Monad.Identity.catch in file "src/alcotest-engine/monad.ml", line 24, characters 31-35
            
Logs saved to `~/me/workspace/yousleepwhen/masc-mcp/.worktrees/main-assert-check-20260423/_build/_tests/exec_core/p10_structured_output.000.output'.
 ──────────────────────────────────────────────────────────────────────────────

Full test results in `~/me/workspace/yousleepwhen/masc-mcp/.worktrees/main-assert-check-20260423/_build/_tests/exec_core'.
5 failures! in 0.024s. 34 tests run.
  - startup assert is gone; execution proceeds to the expected P10/P11 test failures that  is addressing
