### PR TITLE
fix auth fallback for hyphenated generated aliases

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -111,11 +111,65 @@ let trim_nonempty value =
   let trimmed = String.trim value in
   if trimmed = "" then None else Some trimmed
 
+let nickname_adjectives = [|
+  "swift"; "brave"; "calm"; "eager"; "fierce";
+  "gentle"; "happy"; "jolly"; "keen"; "lucky";
+  "merry"; "noble"; "proud"; "quick"; "witty";
+  "bold"; "cool"; "deft"; "fair"; "grand";
+  "hale"; "jade"; "kind"; "lean"; "neat";
+  "pale"; "rare"; "sage"; "tame"; "warm";
+|]
+
+let nickname_animals = [|
+  "fox"; "bear"; "wolf"; "hawk"; "lion";
+  "tiger"; "eagle"; "otter"; "panda"; "koala";
+  "raven"; "falcon"; "badger"; "beaver"; "whale";
+  "shark"; "crane"; "heron"; "moose"; "viper";
+  "cobra"; "gecko"; "lemur"; "llama"; "manta";
+  "orca"; "rhino"; "sloth"; "tapir"; "zebra";
+|]
+
+let array_contains arr value =
+  let rec loop idx =
+    idx < Array.length arr
+    && (String.equal arr.(idx) value || loop (idx + 1))
+  in
+  loop 0
+
+let is_hex4 value =
+  String.length value = 4
+  && String.for_all
+       (function
+         | '0' .. '9' | 'a' .. 'f' -> true
+         | _ -> false)
+       value
+
+let extract_generated_nickname_prefix name =
+  let parts = String.split_on_char '-' name in
+  let join_prefix prefix_rev =
+    match List.rev prefix_rev with
+    | [] -> None
+    | prefix -> String.concat "-" prefix |> trim_nonempty
+  in
+  match List.rev parts with
+  | animal :: adjective :: prefix_rev
+    when array_contains nickname_animals animal
+         && array_contains nickname_adjectives adjective ->
+      join_prefix prefix_rev
+  | suffix :: animal :: adjective :: prefix_rev
+    when is_hex4 suffix
+         && array_contains nickname_animals animal
+         && array_contains nickname_adjectives adjective ->
+      join_prefix prefix_rev
+  | prefix :: _ when prefix <> "" -> Some prefix
+  | _ -> None
+
 (* Inline copy of Nickname.is_generated_nickname / extract_agent_type.
    Auth lives below masc_coord in the module graph and cannot depend on
-   it. The nickname pattern — three or more hyphen-separated segments,
-   first segment is the agent type — is small enough to duplicate here
-   without drift risk. Keeper aliases use a different canonical shape
+   it. The nickname pattern — stable-prefix + adjective + animal
+   [+ hex4] — is duplicated here so auth can canonicalize generated
+   aliases without depending on Nickname. Keeper aliases use a
+   different canonical shape
    (keeper-<name>-agent) and must resolve to the middle segment so
    keeper-scoped credentials can be stored under the stable keeper name
    rather than the transport alias. Covered by the nickname fallback
@@ -132,8 +186,7 @@ let extract_agent_type_prefix name =
           |> String.concat "-"
           |> trim_nonempty
       | _ -> Some "keeper")
-  | prefix :: _ when prefix <> "" -> Some prefix
-  | _ -> None
+  | _ -> extract_generated_nickname_prefix name
 
 let credential_agent_name agent_name =
   match extract_agent_type_prefix agent_name with

--- a/lib/coord/nickname.ml
+++ b/lib/coord/nickname.ml
@@ -30,6 +30,21 @@ let nickname_rng_mutex = Eio.Mutex.create ()
 let with_nickname_rng f =
   Eio.Mutex.use_ro nickname_rng_mutex (fun () -> f nickname_rng)
 
+let array_contains arr value =
+  let rec loop idx =
+    idx < Array.length arr
+    && (String.equal arr.(idx) value || loop (idx + 1))
+  in
+  loop 0
+
+let is_hex4 value =
+  String.length value = 4
+  && String.for_all
+       (function
+         | '0' .. '9' | 'a' .. 'f' -> true
+         | _ -> false)
+       value
+
 (** Generate a short random suffix (4 hex chars) for uniqueness *)
 let random_suffix () =
   Printf.sprintf "%04x"
@@ -59,11 +74,25 @@ let is_generated_nickname name =
   let parts = String.split_on_char '-' name in
   List.length parts >= 3
 
-(** Extract agent_type from a generated nickname.
+(** Extract the stable agent prefix from a generated nickname.
     "claude-swift-fox" -> Some "claude"
+    "qa-king-warm-heron" -> Some "qa-king"
     "claude" -> Some "claude" (legacy) *)
 let extract_agent_type name =
   let parts = String.split_on_char '-' name in
-  match parts with
+  let join_prefix prefix_rev =
+    match List.rev prefix_rev with
+    | [] -> None
+    | prefix -> Some (String.concat "-" prefix)
+  in
+  match List.rev parts with
+  | animal :: adjective :: prefix_rev
+    when array_contains animals animal && array_contains adjectives adjective ->
+      join_prefix prefix_rev
+  | suffix :: animal :: adjective :: prefix_rev
+    when is_hex4 suffix
+         && array_contains animals animal
+         && array_contains adjectives adjective ->
+      join_prefix prefix_rev
   | agent_type :: _ -> Some agent_type
   | [] -> None

--- a/lib/coord/nickname.mli
+++ b/lib/coord/nickname.mli
@@ -10,4 +10,4 @@ val generate_unique : string -> string
 (** [generate_unique agent_type] returns a nickname with a random hex suffix. *)
 
 val extract_agent_type : string -> string option
-(** [extract_agent_type name] extracts the agent_type prefix from a generated nickname. *)
+(** [extract_agent_type name] extracts the stable agent prefix from a generated nickname. *)

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -316,6 +316,10 @@ let test_extract_agent_type_prefix_keeper_aliases () =
     (Auth.extract_agent_type_prefix "keeper-masc-improver-agent");
   check (option string) "generated nickname" (Some "adversary")
     (Auth.extract_agent_type_prefix "adversary-fair-tapir");
+  check (option string) "hyphenated generated nickname" (Some "qa-king")
+    (Auth.extract_agent_type_prefix "qa-king-warm-heron");
+  check (option string) "hyphenated generated nickname unique" (Some "qa-king")
+    (Auth.extract_agent_type_prefix "qa-king-warm-heron-a3b2");
   check (option string) "plain name stays plain" (Some "sangsu")
     (Auth.extract_agent_type_prefix "sangsu");
   check (option string) "two segment keeper fallback unchanged" (Some "keeper")
@@ -336,6 +340,23 @@ let test_verify_token_keeper_alias_fallback () =
       fail
         (Printf.sprintf
            "keeper alias should verify via fallback credential: %s"
+           (Types.masc_error_to_string e))
+
+let test_verify_token_hyphenated_generated_nickname_fallback () =
+  let dir = setup_test_room () in
+  let result =
+    match Auth.create_token dir ~agent_name:"qa-king" ~role:Types.Admin with
+    | Ok (raw_token, _) ->
+        Auth.verify_token dir ~agent_name:"qa-king-warm-heron" ~token:raw_token
+    | Error e -> Error e
+  in
+  cleanup_test_room dir;
+  match result with
+  | Ok cred -> check string "fallback credential owner" "qa-king" cred.agent_name
+  | Error e ->
+      fail
+        (Printf.sprintf
+           "hyphenated generated alias should verify via fallback credential: %s"
            (Types.masc_error_to_string e))
 
 let test_load_credential_missing_keeper_alias_stays_quiet () =
@@ -727,6 +748,8 @@ let () =
         test_extract_agent_type_prefix_keeper_aliases;
       test_case "verify_token keeper alias fallback" `Quick
         test_verify_token_keeper_alias_fallback;
+      test_case "verify_token hyphenated generated nickname fallback" `Quick
+        test_verify_token_hyphenated_generated_nickname_fallback;
       test_case "load_credential missing keeper alias stays quiet" `Quick
         test_load_credential_missing_keeper_alias_stays_quiet;
       test_case "verify_token dashboard legacy alias fallback" `Quick

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1637,6 +1637,43 @@ let test_execute_tool_explicit_generated_alias_transition_not_rewritten_by_token
   check_task_still_todo state.room_config "task-001";
   cleanup_dir base_path
 
+let test_execute_tool_hyphenated_generated_alias_claim_next_reuses_base_token () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  ignore (Masc_mcp.Coord.init state.room_config ~agent_name:None);
+  ignore (Masc_mcp.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
+  let raw_token =
+    match Masc_mcp.Auth.create_token base_path ~agent_name:"qa-king" ~role:Types.Admin with
+    | Ok (token, _cred) -> token
+    | Error e -> Alcotest.fail (Types.masc_error_to_string e)
+  in
+  ignore
+    (Masc_mcp.Coord.add_task state.room_config ~title:"hyphenated-generated-alias-claim-next"
+       ~priority:2 ~description:"");
+  let ok, msg =
+    Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:"sid-hyphenated-generated-alias"
+      ~auth_token:raw_token state
+      ~name:"masc_claim_next"
+      ~arguments:(`Assoc [ ("agent_name", `String "qa-king-warm-heron") ])
+  in
+  Alcotest.(check bool) "claim_next succeeds" true ok;
+  Alcotest.(check bool) "claim_next reports claimed task" true
+    (contains_substring msg "task-001");
+  Alcotest.(check (option string)) "current task set after claim_next"
+    (Some "task-001")
+    (Masc_mcp.Planning_eio.get_current_task state.room_config);
+  Alcotest.(check bool) "explicit alias joined" true
+    (Masc_mcp.Coord.is_agent_joined state.room_config
+       ~agent_name:"qa-king-warm-heron");
+  cleanup_dir base_path
+
 let test_execute_tool_claim_next_requires_auth_before_mutation () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2783,6 +2820,8 @@ let eio_tests = [
     test_execute_tool_explicit_generated_alias_claim_next_not_rewritten_by_token;
   "explicit generated alias transition not rewritten by token", `Quick,
     test_execute_tool_explicit_generated_alias_transition_not_rewritten_by_token;
+  "hyphenated generated alias claim_next reuses base token", `Quick,
+    test_execute_tool_hyphenated_generated_alias_claim_next_reuses_base_token;
   "claim_next auth preflight blocks mutation", `Quick,
     test_execute_tool_claim_next_requires_auth_before_mutation;
   "transition auth preflight blocks mutation", `Quick,

--- a/test/test_nickname_coverage.ml
+++ b/test/test_nickname_coverage.ml
@@ -111,6 +111,17 @@ let test_extract_agent_type_unique () =
   | Some at -> check string "extracted codex" "codex" at
   | None -> fail "should extract from unique"
 
+let test_extract_agent_type_hyphenated_manual () =
+  match Nickname.extract_agent_type "qa-king-warm-heron" with
+  | Some at -> check string "extracted qa-king" "qa-king" at
+  | None -> fail "should extract hyphenated stable prefix"
+
+let test_extract_agent_type_hyphenated_unique () =
+  let nick = Nickname.generate_unique "qa-king" in
+  match Nickname.extract_agent_type nick with
+  | Some at -> check string "extracted qa-king from unique" "qa-king" at
+  | None -> fail "should extract hyphenated stable prefix from unique"
+
 (* ============================================================
    Test Runners
    ============================================================ *)
@@ -140,5 +151,7 @@ let () =
       test_case "legacy" `Quick test_extract_agent_type_legacy;
       test_case "empty" `Quick test_extract_agent_type_empty;
       test_case "unique" `Quick test_extract_agent_type_unique;
+      test_case "hyphenated manual" `Quick test_extract_agent_type_hyphenated_manual;
+      test_case "hyphenated unique" `Quick test_extract_agent_type_hyphenated_unique;
     ];
   ]


### PR DESCRIPTION
## Summary

- Fix generated nickname canonicalization so hyphenated stable keeper names like `qa-king` survive suffix extraction from aliases such as `qa-king-warm-heron`.
- Reuse the stable base credential for auth fallback, token verification, and keeper canonicalization instead of collapsing to the first hyphen segment.
- Add regression coverage in nickname parsing, auth fallback, and MCP claim-next flow compilation/tests.

## Product impact

- Prevents keeper sessions with generated aliases from being rejected as unauthorized when their bearer token belongs to the stable base identity.
- Removes a live failure mode where `masc_join` or `masc_claim_next` breaks for hyphenated keeper names after nickname generation.

## Evidence

- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-hyphenated-generated-alias-auth-fix _build/default/test/test_auth.exe _build/default/test/test_nickname_coverage.exe _build/default/test/test_mcp_server_eio.exe -j 1`
- `./_build/default/test/test_auth.exe`
- `./_build/default/test/test_nickname_coverage.exe`
- `./_build/default/test/test_mcp_server_eio.exe` currently aborts before suite execution due a pre-existing `lib/keeper/keeper_types_profile.ml` startup assertion unrelated to this diff.

## Review evidence

- Scope is limited to nickname/auth canonicalization and matching regression tests.
- Existing dashboard PR worktree was kept clean; this auth fix lives on a separate branch/worktree.

## Linked issue

- None
