### PR TITLE
[codex] Fix main exec structured output regression

### DIFF
--- a/lib/exec/output_parse.ml
+++ b/lib/exec/output_parse.ml
@@ -229,6 +229,29 @@ type parser_kind =
   | Ls_long
   | Dune_test
 
+let git_option_requires_arg = function
+  | "-C" | "-c" | "--git-dir" | "--work-tree" | "--namespace" | "--exec-path"
+  | "--super-prefix" | "--config-env" ->
+      true
+  | _ -> false
+
+let git_option_has_inline_arg opt =
+  starts_with opt "--git-dir=" || starts_with opt "--work-tree="
+  || starts_with opt "--namespace=" || starts_with opt "--exec-path="
+  || starts_with opt "--super-prefix=" || starts_with opt "--config-env="
+  || (String.length opt > 2 && (starts_with opt "-C" || starts_with opt "-c"))
+
+let git_subcommand tokens =
+  let rec loop = function
+    | [] -> None
+    | "--" :: _ -> None
+    | opt :: _value :: rest when git_option_requires_arg opt -> loop rest
+    | opt :: rest when git_option_has_inline_arg opt -> loop rest
+    | opt :: rest when starts_with opt "-" -> loop rest
+    | sub :: _ -> Some sub
+  in
+  loop tokens
+
 let classify_for_parsing ~cmd ~_output =
   let tokens =
     String.trim cmd
@@ -242,7 +265,7 @@ let classify_for_parsing ~cmd ~_output =
       let base = Filename.basename bin |> String.lowercase_ascii in
       match base with
       | "git" ->
-          let sub = match rest with s :: _ -> Some s | _ -> None in
+          let sub = git_subcommand rest in
           (match sub with
           | Some "status" -> Some Git_status
           | Some "log" -> Some Git_log_oneline

--- a/lib/exec/output_parse.ml
+++ b/lib/exec/output_parse.ml
@@ -236,10 +236,15 @@ let git_option_requires_arg = function
   | _ -> false
 
 let git_option_has_inline_arg opt =
-  starts_with opt "--git-dir=" || starts_with opt "--work-tree="
-  || starts_with opt "--namespace=" || starts_with opt "--exec-path="
-  || starts_with opt "--super-prefix=" || starts_with opt "--config-env="
-  || (String.length opt > 2 && (starts_with opt "-C" || starts_with opt "-c"))
+  String.starts_with ~prefix:"--git-dir=" opt
+  || String.starts_with ~prefix:"--work-tree=" opt
+  || String.starts_with ~prefix:"--namespace=" opt
+  || String.starts_with ~prefix:"--exec-path=" opt
+  || String.starts_with ~prefix:"--super-prefix=" opt
+  || String.starts_with ~prefix:"--config-env=" opt
+  || (String.length opt > 2
+      && (String.starts_with ~prefix:"-C" opt
+          || String.starts_with ~prefix:"-c" opt))
 
 let git_subcommand tokens =
   let rec loop = function
@@ -247,7 +252,7 @@ let git_subcommand tokens =
     | "--" :: _ -> None
     | opt :: _value :: rest when git_option_requires_arg opt -> loop rest
     | opt :: rest when git_option_has_inline_arg opt -> loop rest
-    | opt :: rest when starts_with opt "-" -> loop rest
+    | opt :: rest when String.starts_with ~prefix:"-" opt -> loop rest
     | sub :: _ -> Some sub
   in
   loop tokens

--- a/test/test_exec_core.ml
+++ b/test/test_exec_core.ml
@@ -464,6 +464,20 @@ let test_git_status_structured () =
   check int "unstaged 1" 1 (List.length unstaged);
   check int "untracked 1" 1 (List.length untracked)
 
+let test_git_status_with_global_option_structured () =
+  let json =
+    Masc_mcp.Exec_core.process_result_json
+      ~base_path:"/tmp"
+      ~keeper_name:"p10-test"
+      ~cmd:"git -C /tmp/repo status --porcelain"
+      ~status:(Unix.WEXITED 0)
+      ~output:" M lib/foo.ml\n"
+      ()
+  in
+  let so = json |> member "structured_output" in
+  let unstaged = so |> member "unstaged" |> to_list in
+  check int "unstaged via git -C" 1 (List.length unstaged)
+
 let test_git_log_structured () =
   let json =
     Masc_mcp.Exec_core.process_result_json
@@ -711,6 +725,8 @@ let () =
         [
           test_case "git status --porcelain produces structured fields"
             `Quick test_git_status_structured;
+          test_case "git status with global option produces structured fields"
+            `Quick test_git_status_with_global_option_structured;
           test_case "git log --oneline produces commits array" `Quick
             test_git_log_structured;
           test_case "failed git status has no structured_output" `Quick


### PR DESCRIPTION
## Summary

- Fix exec structured-output parsing for git commands by classifying the actual git subcommand instead of skipping past it.
- Preserve porcelain status columns instead of trimming away meaningful leading status fields.
- Avoid structured output for failed git commands while keeping the existing non-zero `dune test` parser behavior.
- Add regression coverage for failed git parsing, `git diff --stat`, and isolate P11 bash-history temp state to avoid stale cross-run failures.

## Root Cause

Main was still vulnerable to exec structured-output regressions after the keeper TOML key fix landed in #9672. The parser misclassified git commands, parsed failed git outputs too aggressively, and stripped status-column whitespace that `git status --porcelain` depends on.

## Validation

Latest rebase target: `cd181e72653b526a63ca4cb02a0960533b084d1f`.

- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-main-build-keeper-stack ./test/test_exec_core.exe`
- `git diff --check`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-main-build-keeper-stack @check`
