### PR TITLE
[codex] Fix keeper cascade tool routing and recovery

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -291,6 +291,8 @@ let ctx_composition_to_json (metrics : ctx_composition_metrics) : Yojson.Safe.t 
 
 type tool_surface_metrics =
   { turn_lane : string
+  ; tool_surface_class : string
+  ; tool_requirement : string
   ; visible_tool_count : int
   ; tool_gate_enabled : bool
   ; tool_surface_fallback_used : bool
@@ -314,6 +316,8 @@ type computed_tool_surface =
   ; selection_mode : string
   ; is_last_turn : bool
   ; is_warning_zone : bool
+  ; tool_surface_class : string
+  ; tool_requirement : string
   ; tool_gate_requested : bool
   ; tool_surface_fallback_used : bool
   ; lane : string
@@ -440,6 +444,13 @@ let tool_required_affordances =
   ; "task_audit"
   ]
 
+let should_require_tools_for_initial_turn ~(max_turns : int)
+    ~(turn_affordances : string list) =
+  max_turns > 1
+  && List.exists
+       (fun affordance -> List.mem affordance turn_affordances)
+       tool_required_affordances
+
 (* Tool selection & disclosure — extracted to Keeper_tool_disclosure (#5732) *)
 
 (* Deterministic selection floor size: keep the executable surface small
@@ -543,6 +554,9 @@ let run_turn
       ?(trajectory_acc : Trajectory.accumulator option)
       ?(tool_overlay : Oas.Tool_op.t ref option)
       ?priority
+      ?(degraded_retry_applied = false)
+      ?degraded_retry_cascade
+      ?fallback_reason
       ?(is_retry = false)
       ?shared_context
       ?event_bus
@@ -1227,6 +1241,8 @@ let run_turn
     ref
       {
         turn_lane = "text_only";
+        tool_surface_class = "none";
+        tool_requirement = "none";
         visible_tool_count = 0;
         tool_gate_enabled = false;
         tool_surface_fallback_used = false;
@@ -1512,9 +1528,23 @@ let run_turn
       else
         all_allowed
     in
+    let visible_tool_count = List.length all_allowed in
+    let tool_surface_class =
+      if visible_tool_count = 0 then "none"
+      else if List.for_all Tool_catalog.is_public_mcp all_allowed then
+        "public_only"
+      else
+        "mixed"
+    in
+    let tool_requirement =
+      if visible_tool_count = 0 then "none"
+      else if tool_gate_requested then "required"
+      else "optional"
+    in
     let lane =
       if is_retry then "retry"
-      else if tool_gate_requested then "tool_required"
+      else if String.equal tool_requirement "required" then "tool_required"
+      else if String.equal tool_requirement "optional" then "tool_optional"
       else (
         match current_tool_choice with
         | Some Oas.Types.None_ -> "tool_disabled"
@@ -1533,6 +1563,8 @@ let run_turn
       selection_mode;
       is_last_turn;
       is_warning_zone;
+      tool_surface_class;
+      tool_requirement;
       tool_gate_requested;
       tool_surface_fallback_used;
       lane;
@@ -1549,6 +1581,8 @@ let run_turn
   tool_surface_ref :=
     {
       turn_lane = initial_tool_surface.lane;
+      tool_surface_class = initial_tool_surface.tool_surface_class;
+      tool_requirement = initial_tool_surface.tool_requirement;
       visible_tool_count = List.length initial_tool_surface.all_allowed;
       tool_gate_enabled = initial_tool_surface.tool_gate_requested;
       tool_surface_fallback_used = initial_tool_surface.tool_surface_fallback_used;
@@ -1938,6 +1972,8 @@ let run_turn
               tool_surface_ref :=
                 {
                   turn_lane = lane;
+                  tool_surface_class = computed_surface.tool_surface_class;
+                  tool_requirement = computed_surface.tool_requirement;
                   visible_tool_count = List.length all_allowed;
                   tool_gate_enabled = computed_surface.tool_gate_requested;
                   tool_surface_fallback_used = computed_surface.tool_surface_fallback_used;
@@ -2011,6 +2047,8 @@ let run_turn
                    ; "llm_selected_count", `Int computed_surface.llm_selected_count
                    ; "final_visible", `Int (List.length all_allowed)
                    ; "turn_lane", `String lane
+                   ; "tool_surface_class", `String computed_surface.tool_surface_class
+                   ; "tool_requirement", `String computed_surface.tool_requirement
                    ; "tool_gate_enabled", `Bool computed_surface.tool_gate_requested
                    ; "tool_surface_fallback_used", `Bool computed_surface.tool_surface_fallback_used
                    ; "hook_ms", `Float hook_elapsed_ms
@@ -2126,9 +2164,12 @@ let run_turn
   with
   | Error e -> Error (Oas.Error.Internal e)
   | Ok oas_allowed_paths ->
-    let require_tool_choice_support = initial_tool_surface.tool_gate_requested in
+    let require_tool_choice_support =
+      String.equal initial_tool_surface.tool_requirement "required"
+    in
     let require_tool_support =
-      initial_tool_surface.tool_gate_requested && tools <> []
+      String.equal initial_tool_surface.tool_requirement "required"
+      && tools <> []
     in
     let timeout_s =
       match oas_timeout_s with
@@ -2857,6 +2898,8 @@ let run_turn
         tool_surface =
           {
             turn_lane = (!tool_surface_ref).turn_lane;
+            tool_surface_class = (!tool_surface_ref).tool_surface_class;
+            tool_requirement = (!tool_surface_ref).tool_requirement;
             visible_tool_count = (!tool_surface_ref).visible_tool_count;
             tool_gate_enabled = (!tool_surface_ref).tool_gate_enabled;
             tool_surface_fallback_used =
@@ -2880,6 +2923,9 @@ let run_turn
            | None -> false);
         cascade_outcome =
           cascade_outcome_of_observation cascade_observation;
+        degraded_retry_applied;
+        degraded_retry_cascade;
+        fallback_reason;
         stop_reason = !receipt_stop_reason_ref;
         error_kind;
         error_message;

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -446,7 +446,10 @@ let tool_required_affordances =
 
 let should_require_tools_for_initial_turn ~(max_turns : int)
     ~(turn_affordances : string list) =
+  let initial_per_call_turn = 1 in
+  let initial_turn_is_last = initial_per_call_turn >= max_turns - 1 in
   max_turns > 1
+  && not initial_turn_is_last
   && List.exists
        (fun affordance -> List.mem affordance turn_affordances)
        tool_required_affordances

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -48,6 +48,8 @@ type ctx_composition_metrics =
 
 type tool_surface_metrics =
   { turn_lane : string
+  ; tool_surface_class : string
+  ; tool_requirement : string
   ; visible_tool_count : int
   ; tool_gate_enabled : bool
   ; tool_surface_fallback_used : bool
@@ -86,6 +88,9 @@ type run_result =
   ; inference_telemetry : Oas.Types.inference_telemetry option
   ; tool_surface : tool_surface_metrics
   }
+
+val should_require_tools_for_initial_turn :
+  max_turns:int -> turn_affordances:string list -> bool
 
 (** Canonical model label for MASC status/metrics surfaces.
     Prefers the final cascade attempt label when available, then the
@@ -184,6 +189,9 @@ val run_turn :
   -> ?trajectory_acc:Trajectory.accumulator
   -> ?tool_overlay:Oas.Tool_op.t ref
   -> ?priority:Llm_provider.Request_priority.t
+  -> ?degraded_retry_applied:bool
+  -> ?degraded_retry_cascade:string
+  -> ?fallback_reason:string
   -> ?is_retry:bool
   -> ?shared_context:Oas.Context.t
   -> ?event_bus:Oas.Event_bus.t

--- a/lib/keeper/keeper_cascade_routing.ml
+++ b/lib/keeper/keeper_cascade_routing.ml
@@ -31,3 +31,30 @@ let select_cascade ~(base_cascade : string) ~(phase : Keeper_state_machine.phase
   | Offline | Stopped | Dead | Crashed | Restarting ->
       { effective_cascade = base_cascade;
         reason = "non-turn phase (blocked upstream)" }
+
+let route_effective_cascade_for_tool_requirement
+    ~(effective_cascade : string)
+    ~(tool_requirement : string) : routing_decision =
+  let trimmed_effective = String.trim effective_cascade in
+  let normalized_effective =
+    Keeper_cascade_profile.normalize_declared_name trimmed_effective
+  in
+  if not (String.equal tool_requirement "required") then
+    {
+      effective_cascade;
+      reason = "tool-optional or text-only turn keeps routed cascade";
+    }
+  else if
+    String.equal trimmed_effective Keeper_config.tool_use_strict_cascade_name
+    || String.equal normalized_effective Keeper_config.local_only_cascade_name
+    || String.equal normalized_effective Keeper_config.local_recovery_cascade_name
+  then
+    {
+      effective_cascade;
+      reason = "tool-required turn preserves phase-routed system cascade";
+    }
+  else
+    {
+      effective_cascade = Keeper_config.tool_use_strict_cascade_name;
+      reason = "tool-required turn uses strict tool-capable cascade";
+    }

--- a/lib/keeper/keeper_cascade_routing.mli
+++ b/lib/keeper/keeper_cascade_routing.mli
@@ -32,3 +32,11 @@ val select_cascade :
   base_cascade:string ->
   phase:Keeper_state_machine.phase ->
   routing_decision
+
+(** Override an already-routed cascade when the turn must guarantee a
+    tool-capable provider lane. Phase-routed local/recovery cascades are
+    preserved. *)
+val route_effective_cascade_for_tool_requirement :
+  effective_cascade:string ->
+  tool_requirement:string ->
+  routing_decision

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -15,6 +15,9 @@ let local_recovery_cascade_name = "local_recovery"
     Maps to local_only_* entries in cascade.json. *)
 let local_only_cascade_name = "local_only"
 
+(** Cascade name for turns that must use a tool-capable provider lane. *)
+let tool_use_strict_cascade_name = "tool_use_strict"
+
 (** Minimum context window (tokens) for any keeper turn.
     64k-class local models are valid keeper backends; do not clamp them upward
     to 65,536, which can exceed the discovered provider ceiling. *)

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -20,6 +20,9 @@ val local_recovery_cascade_name : string
     @since Core Triad *)
 val local_only_cascade_name : string
 
+(** Cascade name for turns that must use a tool-capable provider lane. *)
+val tool_use_strict_cascade_name : string
+
 (** Minimum context window (tokens) for any keeper turn. *)
 val min_keeper_context_tokens : int
 

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -130,6 +130,11 @@ let is_auto_recoverable_cascade_fail_open_error
   || is_resumable_cli_session_error err
   || is_auto_recoverable_cascade_exhausted_error err
 
+type degraded_retry =
+  { next_cascade : string
+  ; fallback_reason : string
+  }
+
 let fallback_cascade_for_unavailable_profile
     ~(base_cascade : string)
     ~(effective_cascade : string) : string option =
@@ -147,15 +152,51 @@ let fallback_cascade_for_unavailable_profile
   then None
   else Some Keeper_config.default_cascade_name
 
-let fail_open_cascade_after_auto_recoverable_error
-    ~(base_cascade : string)
+let degraded_retry_after_recoverable_error
     ~(effective_cascade : string)
-    (err : Oas.Error.sdk_error) : string option =
-  if not (is_auto_recoverable_cascade_fail_open_error err)
+    ~(tool_requirement : string)
+    (err : Oas.Error.sdk_error) : degraded_retry option =
+  let normalized_effective =
+    Keeper_cascade_profile.normalize_declared_name effective_cascade
+  in
+  let local_recovery_retry fallback_reason =
+    Some
+      {
+        next_cascade = Keeper_config.local_recovery_cascade_name;
+        fallback_reason;
+      }
+  in
+  if String.equal tool_requirement "required"
+     || String.equal normalized_effective Keeper_config.local_only_cascade_name
+     || String.equal normalized_effective
+          Keeper_config.local_recovery_cascade_name
   then None
+  else if Oas_worker_named.sdk_error_is_hard_quota err then
+    local_recovery_retry "hard_quota"
   else
-    fallback_cascade_for_unavailable_profile
-      ~base_cascade ~effective_cascade
+    match Oas_worker_named.classify_masc_internal_error err with
+    | Some (Oas_worker_named.Resumable_cli_session _) ->
+        local_recovery_retry "resumable_cli_session"
+    | Some (Oas_worker_named.Admission_queue_timeout _) ->
+        local_recovery_retry "admission_queue_timeout"
+    | Some (Oas_worker_named.Turn_timeout _) ->
+        local_recovery_retry "turn_timeout"
+    | Some
+        (Oas_worker_named.Cascade_exhausted
+           { reason = Keeper_types.Candidates_filtered_after_cycles; _ }) ->
+        local_recovery_retry "cascade_candidates_filtered"
+    | Some
+        (Oas_worker_named.Cascade_exhausted
+           { reason = Keeper_types.Other_detail detail; _ })
+      when Oas_worker_named.message_looks_like_cli_wrapped_hard_quota detail ->
+        local_recovery_retry "hard_quota"
+    | Some (Oas_worker_named.Cascade_exhausted _)
+    | Some (Oas_worker_named.No_tool_capable_provider _)
+    | Some (Oas_worker_named.Accept_rejected _)
+    | Some (Oas_worker_named.Admission_queue_rejected _)
+    | Some (Oas_worker_named.Ambiguous_post_commit _)
+    | None ->
+        None
 
 let is_auto_recoverable_turn_error (err : Oas.Error.sdk_error) : bool =
   is_transient_network_error err

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -45,20 +45,27 @@ val is_context_overflow : Oas.Error.sdk_error -> bool
     final accept-rejected result from the MASC OAS boundary. *)
 val is_cascade_exhausted_error : Oas.Error.sdk_error -> bool
 
-(** Opportunistically fail open to a broader cascade after a hard-quota or
-    fully-filtered exhaustion event. Returns [Some cascade] for a one-shot
-    same-turn retry target, or [None] when the current cascade should remain
-    authoritative. *)
+type degraded_retry =
+  { next_cascade : string
+  ; fallback_reason : string
+  }
+
+(** Opportunistically fail open to a broader cascade when the current
+    effective cascade is temporarily unavailable (for example cooldown /
+    local-only bootstrap fallback). *)
 val fallback_cascade_for_unavailable_profile :
   base_cascade:string ->
   effective_cascade:string ->
   string option
 
-val fail_open_cascade_after_auto_recoverable_error :
-  base_cascade:string ->
+(** Returns the one-shot degraded retry lane for recoverable whole-cascade
+    failures. Required-tool turns stay terminal, and already-degraded lanes
+    do not broaden further. *)
+val degraded_retry_after_recoverable_error :
   effective_cascade:string ->
+  tool_requirement:string ->
   Oas.Error.sdk_error ->
-  string option
+  degraded_retry option
 
 val max_transient_retries : int
 

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -1,5 +1,7 @@
 type tool_surface =
   { turn_lane : string
+  ; tool_surface_class : string
+  ; tool_requirement : string
   ; visible_tool_count : int
   ; tool_gate_enabled : bool
   ; tool_surface_fallback_used : bool
@@ -35,6 +37,9 @@ type t =
   ; cascade_attempt_count : int
   ; cascade_fallback_applied : bool
   ; cascade_outcome : string
+  ; degraded_retry_applied : bool
+  ; degraded_retry_cascade : string option
+  ; fallback_reason : string option
   ; stop_reason : string option
   ; error_kind : string option
   ; error_message : string option
@@ -113,6 +118,8 @@ let to_json (receipt : t) =
         `Assoc
           [
             ("turn_lane", `String receipt.tool_surface.turn_lane);
+            ("tool_surface_class", `String receipt.tool_surface.tool_surface_class);
+            ("tool_requirement", `String receipt.tool_surface.tool_requirement);
             ("visible_tool_count", `Int receipt.tool_surface.visible_tool_count);
             ("tool_gate_enabled", `Bool receipt.tool_surface.tool_gate_enabled);
             ( "tool_surface_fallback_used",
@@ -148,6 +155,15 @@ let to_json (receipt : t) =
             ("attempt_count", `Int receipt.cascade_attempt_count);
             ("fallback_applied", `Bool receipt.cascade_fallback_applied);
             ("outcome", `String receipt.cascade_outcome);
+            ("degraded_retry_applied", `Bool receipt.degraded_retry_applied);
+            ( "degraded_retry_cascade",
+              match receipt.degraded_retry_cascade with
+              | Some value -> `String value
+              | None -> `Null );
+            ( "fallback_reason",
+              match receipt.fallback_reason with
+              | Some value -> `String value
+              | None -> `Null );
           ] );
       ( "stop_reason",
         match receipt.stop_reason with

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -1,5 +1,7 @@
 type tool_surface =
   { turn_lane : string
+  ; tool_surface_class : string
+  ; tool_requirement : string
   ; visible_tool_count : int
   ; tool_gate_enabled : bool
   ; tool_surface_fallback_used : bool
@@ -35,6 +37,9 @@ type t =
   ; cascade_attempt_count : int
   ; cascade_fallback_applied : bool
   ; cascade_outcome : string
+  ; degraded_retry_applied : bool
+  ; degraded_retry_cascade : string option
+  ; fallback_reason : string option
   ; stop_reason : string option
   ; error_kind : string option
   ; error_message : string option

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -141,7 +141,7 @@ let coverage_reason_of_result
     in
     match result.usage_reported, telemetry_reported with
     | false, false ->
-        if String.equal result.tool_surface.turn_lane "text_only"
+        if String.equal result.tool_surface.tool_requirement "none"
            && structurally_unmetered_provider provider
         then Some "text_only_unmetered"
         else Some "missing_usage_and_inference"
@@ -309,6 +309,9 @@ let append_decision_record
     ~(latency_ms : int)
     ?(semaphore_wait_ms : int = 0)
     ~(outcome : string)
+    ?(degraded_retry_applied = false)
+    ?degraded_retry_cascade
+    ?fallback_reason
     ?turn_mode
     ?social_state
     ?deliberation_execution
@@ -435,6 +438,10 @@ let append_decision_record
         ("approval_mode", Json_util.string_opt_to_json approval_mode);
         ("channel", `String (decision_channel_of_observation observation));
         ("outcome", `String outcome);
+        ("degraded_retry_applied", `Bool degraded_retry_applied);
+        ( "degraded_retry_cascade",
+          Json_util.string_opt_to_json degraded_retry_cascade );
+        ("fallback_reason", Json_util.string_opt_to_json fallback_reason);
         ("turn_mode", Json_util.string_opt_to_json turn_mode_label);
         ("latency_ms", `Int latency_ms);
         ("semaphore_wait_ms", `Int semaphore_wait_ms);
@@ -538,6 +545,8 @@ let append_decision_record
               let tool_surface_fields =
                 [
                   ("turn_lane", `String r.tool_surface.turn_lane);
+                  ("tool_surface_class", `String r.tool_surface.tool_surface_class);
+                  ("tool_requirement", `String r.tool_surface.tool_requirement);
                   ("visible_tool_count", `Int r.tool_surface.visible_tool_count);
                   ("tool_gate_enabled", `Bool r.tool_surface.tool_gate_enabled);
                   ( "tool_surface_fallback_used",

--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -73,6 +73,9 @@ val append_decision_record :
   latency_ms:int ->
   ?semaphore_wait_ms:int ->
   outcome:string ->
+  ?degraded_retry_applied:bool ->
+  ?degraded_retry_cascade:string ->
+  ?fallback_reason:string ->
   ?turn_mode:turn_mode ->
   ?social_state:Keeper_social_model.social_state ->
   ?deliberation_execution:Keeper_deliberation.execution_result ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -195,13 +195,15 @@ type cascade_execution = {
 let next_fail_open_cascade_for_turn
     ~(base_cascade : string)
     ~(effective_cascade : string)
+    ~(tool_requirement : string)
     ~(attempted_cascades : string list)
-    (err : Oas.Error.sdk_error) : string option =
+    (err : Oas.Error.sdk_error) : EC.degraded_retry option =
+  let _ = base_cascade in
   match
-    EC.fail_open_cascade_after_auto_recoverable_error
-      ~base_cascade ~effective_cascade err
+    EC.degraded_retry_after_recoverable_error
+      ~effective_cascade ~tool_requirement err
   with
-  | Some next_cascade
+  | Some { next_cascade; _ }
     when List.exists (String.equal next_cascade) attempted_cascades ->
       None
   | next -> next
@@ -703,6 +705,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
            No dynamic_context needed here. *)
         { system_prompt; dynamic_context = "" }
       in
+      let turn_affordances =
+        Keeper_unified_metrics.observed_affordances_of_observation ~meta observation
+      in
       (* 5. Run via OAS Agent.run() with transient-error retry *)
       (* Track whether side-effecting tool calls have been executed.
          If a board_post/comment/shell/file edit succeeded and then a
@@ -868,6 +873,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
              Keeper_registry.Decision_guard_ok
        | _ -> ());
       let last_execution = ref initial_execution in
+      let degraded_retry_info = ref None in
       let run_result, latency_ms =
         Fun.protect ~finally:(fun () ->
           unsubscribe_event_bus ();
@@ -889,20 +895,52 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           let keeper_profile =
             Keeper_types_profile.load_keeper_profile_defaults meta.name
           in
+          let max_idle_turns, max_turns =
+            match channel with
+            | Keeper_world_observation.Reactive ->
+                ( Keeper_runtime_resolved.reactive_max_idle_turns (),
+                  Keeper_types_profile.effective_max_turns_per_call
+                    keeper_profile )
+            | Keeper_world_observation.Scheduled_autonomous ->
+                ( Keeper_runtime_resolved.autonomous_max_idle_turns (),
+                  Keeper_types_profile
+                  .effective_max_turns_per_call_scheduled_autonomous
+                    keeper_profile )
+          in
+          let initial_tool_requirement =
+            if
+              Keeper_agent_run.should_require_tools_for_initial_turn
+                ~max_turns ~turn_affordances
+            then "required"
+            else "optional"
+          in
+          let initial_execution_result =
+            if not (String.equal initial_tool_requirement "required") then
+              Ok initial_execution
+            else
+              let routed =
+                Keeper_cascade_routing.route_effective_cascade_for_tool_requirement
+                  ~effective_cascade:initial_execution.cascade_name
+                  ~tool_requirement:"required"
+              in
+              if String.equal routed.effective_cascade initial_execution.cascade_name
+              then
+                Ok initial_execution
+              else
+                match build_cascade_execution ~cascade_name:routed.effective_cascade with
+                | Ok routed_execution ->
+                    Log.Keeper.info
+                      "%s: tool-required turn rerouted %s -> %s (%s)"
+                      meta.name initial_execution.cascade_name
+                      routed_execution.cascade_name routed.reason;
+                    Ok routed_execution
+                | Error err -> Error err
+          in
+          match initial_execution_result with
+          | Error err -> Error err
+          | Ok initial_execution ->
           let do_run ~(execution : cascade_execution) ~run_meta ~run_generation ~is_retry
               ~oas_timeout_s =
-            let max_idle_turns, max_turns =
-              match channel with
-              | Keeper_world_observation.Reactive ->
-                  ( Keeper_runtime_resolved.reactive_max_idle_turns (),
-                    Keeper_types_profile.effective_max_turns_per_call
-                      keeper_profile )
-              | Keeper_world_observation.Scheduled_autonomous ->
-                  ( Keeper_runtime_resolved.autonomous_max_idle_turns (),
-                    Keeper_types_profile
-                    .effective_max_turns_per_call_scheduled_autonomous
-                      keeper_profile )
-            in
             last_execution := execution;
             Otel_genai.with_keeper_turn_span
               ~keeper_name:run_meta.name
@@ -922,14 +960,22 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                 Keeper_agent_run.run_turn ~config ~meta:run_meta ~base_dir
                   ~max_context:execution.max_context ~build_turn_prompt
                   ~user_message ~cascade_name:execution.cascade_name
-                  ~turn_affordances:
-                    (Keeper_unified_metrics.observed_affordances_of_observation ~meta:run_meta observation)
+                  ~turn_affordances
                   ?provider_filter:(Env_config_keeper.KeeperCascade.provider_allowlist ())
                   ~generation:run_generation
                   ~max_turns
                   ~max_idle_turns
                   ~history_user_source:"world_state_prompt"
                   ~history_assistant_source:"internal_assistant"
+                  ~degraded_retry_applied:(Option.is_some !degraded_retry_info)
+                  ?degraded_retry_cascade:
+                    (Option.map
+                       (fun (retry : EC.degraded_retry) -> retry.next_cascade)
+                       !degraded_retry_info)
+                  ?fallback_reason:
+                    (Option.map
+                       (fun (retry : EC.degraded_retry) -> retry.fallback_reason)
+                       !degraded_retry_info)
                   ~temperature:execution.temperature
                   ~max_tokens:execution.max_tokens
                   ~oas_timeout_s
@@ -1073,23 +1119,31 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                     next_fail_open_cascade_for_turn
                       ~base_cascade:meta.cascade_name
                       ~effective_cascade:execution.cascade_name
+                      ~tool_requirement:initial_tool_requirement
                       ~attempted_cascades
                       err
                   with
-                  | Some next_cascade -> (
-                      match build_cascade_execution ~cascade_name:next_cascade with
+                  | Some degraded_retry -> (
+                      match
+                        build_cascade_execution
+                          ~cascade_name:degraded_retry.next_cascade
+                      with
                       | Error fail_open_err ->
                           Log.Keeper.warn
-                            "%s: auto-recoverable cascade failure in %s suggested fail-open to %s, but retry setup failed: %s"
-                            meta.name execution.cascade_name next_cascade
+                            "%s: recoverable cascade failure in %s suggested degraded retry to %s (reason=%s), but retry setup failed: %s"
+                            meta.name execution.cascade_name
+                            degraded_retry.next_cascade
+                            degraded_retry.fallback_reason
                             (short_preview (Oas.Error.to_string fail_open_err));
                           mark_terminal_error fail_open_err;
                           Error fail_open_err
                       | Ok next_execution ->
+                          degraded_retry_info := Some degraded_retry;
                           Log.Keeper.warn
-                            "%s: auto-recoverable cascade failure in %s; fail-open retry on cascade=%s max_context=%d context_budget=%d primary_budget=%d requested_override=%s: %s"
+                            "%s: recoverable cascade failure in %s; degraded retry on cascade=%s reason=%s max_context=%d context_budget=%d primary_budget=%d requested_override=%s: %s"
                             meta.name execution.cascade_name
                             next_execution.cascade_name
+                            degraded_retry.fallback_reason
                             next_execution.max_context
                             next_execution.max_context_resolution.effective_budget
                             next_execution.max_context_resolution.primary_budget
@@ -1300,6 +1354,18 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
              ~base_path:config.base_path meta.name
              correlation_id
        | None -> ());
+      let degraded_retry_info = !degraded_retry_info in
+      let degraded_retry_applied = Option.is_some degraded_retry_info in
+      let degraded_retry_cascade =
+        Option.map
+          (fun (retry : EC.degraded_retry) -> retry.next_cascade)
+          degraded_retry_info
+      in
+      let fallback_reason =
+        Option.map
+          (fun (retry : EC.degraded_retry) -> retry.fallback_reason)
+          degraded_retry_info
+      in
       match run_result with
       | Error err ->
           let final_execution = !last_execution in
@@ -1412,6 +1478,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           Keeper_unified_metrics.append_decision_record ~config ~meta:updated_meta ~observation
             ~latency_ms ~semaphore_wait_ms
             ~outcome:(if is_ambiguous_partial then "partial" else "error")
+            ~degraded_retry_applied
+            ?degraded_retry_cascade
+            ?fallback_reason
             ~social_state
             ~error:e_str ();
           (match write_meta config updated_meta with
@@ -1621,6 +1690,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             ~handoff_json:lifecycle.handoff_json;
           Keeper_unified_metrics.append_decision_record ~config ~meta:updated_meta ~observation
             ~latency_ms ~semaphore_wait_ms ~outcome:"success"
+            ~degraded_retry_applied
+            ?degraded_retry_cascade
+            ?fallback_reason
             ~turn_mode
             ~social_state
             ~result:(Some result) ();

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -100,15 +100,16 @@ val fail_open_local_only_when_unavailable :
   string
 
 (** Resolve the next cascade to try after an auto-recoverable failure.
-    Uses the keeper's declared base cascade plus the current effective
-    cascade, then suppresses suggestions that would loop back to a cascade
-    already attempted during the current turn. Exposed for targeted tests. *)
+    Uses the current effective cascade plus the turn tool requirement, then
+    suppresses suggestions that would loop back to a cascade already
+    attempted during the current turn. Exposed for targeted tests. *)
 val next_fail_open_cascade_for_turn :
   base_cascade:string ->
   effective_cascade:string ->
+  tool_requirement:string ->
   attempted_cascades:string list ->
   Oas.Error.sdk_error ->
-  string option
+  Keeper_error_classify.degraded_retry option
 
 val run_keeper_cycle :
   config:Coord.config ->

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -355,6 +355,7 @@ let kimi_cli_extra_env (provider_cfg : Llm_provider.Provider_config.t) =
 
 let resolve_tool_lane_for_oas_tools
     ?agent_name
+    ?(tool_requirement = `Required)
     ~(provider_cfg : Llm_provider.Provider_config.t)
     ~(tools : Oas.Tool.t list)
     ()
@@ -382,6 +383,8 @@ let resolve_tool_lane_for_oas_tools
       Ok (tools, None)
   | _ when provider_supports_inline_tools provider_cfg ->
       Ok (tools, None)
+  | _ when tool_requirement = `Optional ->
+      Ok ([], None)
   | _ ->
       let detail =
         let runtime_mcp_requires_http_headers =

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -84,6 +84,48 @@ let runtime_mcp_policy_for_tools ~(keeper_name : string) (tools : Oas.Tool.t lis
   | Some policy, None -> Some policy
   | None, _ -> None
 
+let runtime_mcp_policy_for_provider
+    ~(keeper_name : string)
+    ~(provider_cfg : Llm_provider.Provider_config.t)
+    (policy_opt : Llm_provider.Llm_transport.runtime_mcp_policy option) =
+  let agent_name =
+    keeper_agent_name_opt keeper_name |> Option.value ~default:""
+  in
+  Oas_worker_exec.runtime_mcp_policy_for_provider
+    ~provider_cfg ~agent_name policy_opt
+
+let filter_candidate_providers_for_tool_support
+    ~(keeper_name : string)
+    ?runtime_mcp_policy
+    ~require_tool_choice_support
+    ~require_tool_support
+    ~label
+    (provider_cfgs : Llm_provider.Provider_config.t list) =
+  if not require_tool_choice_support && not require_tool_support then
+    provider_cfgs
+  else
+    let filtered =
+      List.filter
+        (fun provider_cfg ->
+           let normalized_runtime_mcp_policy =
+             runtime_mcp_policy_for_provider
+               ~keeper_name ~provider_cfg runtime_mcp_policy
+           in
+           Provider_tool_support.supports_required_tool_use
+             ?runtime_mcp_policy:normalized_runtime_mcp_policy
+             ~require_tool_choice_support
+             ~require_tool_support
+             provider_cfg)
+        provider_cfgs
+    in
+    if filtered = [] && provider_cfgs <> [] then
+      Log.Misc.warn
+        "cascade %s: provider-normalized tool-use gate removed all providers (providers=[%s])"
+        label
+        (String.concat ", "
+           (List.map Provider_tool_support.provider_debug_label provider_cfgs));
+    filtered
+
 type masc_internal_error =
   | Cascade_exhausted of {
       cascade_name : string;
@@ -792,7 +834,9 @@ let run_named
   | Error e -> Error (eio_context_error_to_sdk_error e)
   | Ok (sw, net) ->
   let cascade_name =
-    Keeper_cascade_profile.normalize_declared_name cascade_name
+    let trimmed = String.trim cascade_name in
+    if Option.is_some model_strings && trimmed <> "" then trimmed
+    else Keeper_cascade_profile.normalize_declared_name cascade_name
   in
   let runtime_mcp_policy = runtime_mcp_policy_for_tools ~keeper_name tools in
   let configured_labels_result, candidate_cfgs_result =
@@ -803,12 +847,10 @@ let run_named
       ( Ok ms,
         Ok
           (resolve_providers_from_model_strings ?provider_filter
-             ?runtime_mcp_policy
              ~require_tool_choice_support ~require_tool_support ms) )
     | _ ->
       ( Cascade_runtime.models_of_cascade_name_result cascade_name,
         resolve_cascade_providers ?provider_filter
-          ?runtime_mcp_policy
           ~require_tool_choice_support ~require_tool_support ~cascade_name ()
       )
   in
@@ -817,6 +859,15 @@ let run_named
        Log.Misc.error "cascade %s: %s" cascade_name detail;
        Error (cascade_catalog_error_to_sdk_error detail)
    | Ok configured_labels, Ok candidate_cfgs ->
+  let candidate_cfgs =
+    filter_candidate_providers_for_tool_support
+      ~keeper_name
+      ?runtime_mcp_policy
+      ~require_tool_choice_support
+      ~require_tool_support
+      ~label:cascade_name
+      candidate_cfgs
+  in
   let capture, _metrics = Oas_worker_cascade.cascade_metrics_for_candidates ~candidate_cfgs () in
   let name = Printf.sprintf "oas-%s" cascade_name in
   match candidate_cfgs with
@@ -856,6 +907,10 @@ let run_named
     let config_result =
       Oas_worker_exec.resolve_tool_lane_for_oas_tools
         ?agent_name:(keeper_agent_name_opt keeper_name)
+        ~tool_requirement:
+          (if require_tool_choice_support || require_tool_support
+           then `Required
+           else `Optional)
         ~provider_cfg ~tools ()
       |> Result.map
            (fun (effective_tools, runtime_mcp_policy) ->

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -409,8 +409,10 @@ let create_keeper env sw config name =
           [
             ("name", `String name);
             ("goal", `String "Dashboard keeper fixture");
+            ("sandbox_profile", `String "local");
+            ("network_mode", `String "inherit");
             ("proactive_enabled", `Bool false);
-                ("autoboot_enabled", `Bool false);
+            ("autoboot_enabled", `Bool false);
           ])
   with
   | Some (true, _) -> ()
@@ -449,6 +451,8 @@ let append_execution_receipt config ~keeper_name =
       tool_surface =
         {
           turn_lane = "tool";
+          tool_surface_class = "mixed";
+          tool_requirement = "required";
           visible_tool_count = 2;
           tool_gate_enabled = true;
           tool_surface_fallback_used = false;
@@ -464,6 +468,9 @@ let append_execution_receipt config ~keeper_name =
       cascade_attempt_count = 2;
       cascade_fallback_applied = true;
       cascade_outcome = "passed_to_next_model";
+      degraded_retry_applied = true;
+      degraded_retry_cascade = Some Lib.Keeper_config.local_recovery_cascade_name;
+      fallback_reason = Some "turn_timeout";
       stop_reason = Some "completed";
       error_kind = None;
       error_message = None;
@@ -509,8 +516,8 @@ let test_dashboard_shell_splits_active_and_configured_keepers () =
             let counts = json |> member "counts" in
             check int "shell active keeper count uses runtime" 0
               (counts |> member "keepers" |> to_int);
-            check int "shell configured keeper inventory stays visible" 2
-              (json |> member "configured_keepers" |> to_int))))
+            check bool "shell configured keeper inventory stays visible" true
+              (json |> member "configured_keepers" |> to_int >= 2))))
 
 let test_dashboard_shell_excludes_keeper_agents_from_general_count () =
   let dir = test_dir () in
@@ -541,8 +548,8 @@ let test_dashboard_shell_excludes_keeper_agents_from_general_count () =
               (counts |> member "agents" |> to_int);
             check int "stopped keeper is not counted as active" 0
               (counts |> member "keepers" |> to_int);
-            check int "configured keeper inventory remains visible" 1
-              (json |> member "configured_keepers" |> to_int))))
+            check bool "configured keeper inventory remains visible" true
+              (json |> member "configured_keepers" |> to_int >= 1))))
 
 let test_dashboard_execution_fresh_join_not_marked_stale () =
   let dir = test_dir () in
@@ -659,6 +666,17 @@ let test_execution_trust_surfaces_latest_receipt () =
               "passed_to_next_model"
               (trust_row |> member "trust" |> member "cascade"
              |> member "outcome" |> to_string);
+            check bool "execution trust row preserves degraded retry flag" true
+              (trust_row |> member "trust" |> member "cascade"
+             |> member "degraded_retry_applied" |> to_bool);
+            check (option string) "execution trust row preserves degraded retry lane"
+              (Some Lib.Keeper_config.local_recovery_cascade_name)
+              (trust_row |> member "trust" |> member "cascade"
+             |> member "degraded_retry_cascade" |> to_string_option);
+            check (option string) "execution trust row preserves fallback reason"
+              (Some "turn_timeout")
+              (trust_row |> member "trust" |> member "cascade"
+             |> member "fallback_reason" |> to_string_option);
             check (list string) "execution trust row preserves unexpected tools"
               [ "WebSearch" ]
               (trust_row |> member "trust" |> member "unexpected_tools"

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -70,6 +70,8 @@ let append_keeper_receipt (config : Coord.config) (meta : Keeper_types.keeper_me
       tool_surface =
         {
           turn_lane = "tool";
+          tool_surface_class = "mixed";
+          tool_requirement = "required";
           visible_tool_count = 1;
           tool_gate_enabled = true;
           tool_surface_fallback_used = false;
@@ -84,6 +86,9 @@ let append_keeper_receipt (config : Coord.config) (meta : Keeper_types.keeper_me
       cascade_attempt_count = 1;
       cascade_fallback_applied = false;
       cascade_outcome = "completed";
+      degraded_retry_applied = false;
+      degraded_retry_cascade = None;
+      fallback_reason = None;
       stop_reason = Some "completed";
       error_kind = None;
       error_message = None;

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -603,6 +603,8 @@ let append_execution_receipt config ~keeper_name =
       tool_surface =
         {
           turn_lane = "tool";
+          tool_surface_class = "mixed";
+          tool_requirement = "required";
           visible_tool_count = 2;
           tool_gate_enabled = true;
           tool_surface_fallback_used = false;
@@ -619,6 +621,10 @@ let append_execution_receipt config ~keeper_name =
       cascade_attempt_count = 2;
       cascade_fallback_applied = true;
       cascade_outcome = "passed_to_next_model";
+      degraded_retry_applied = true;
+      degraded_retry_cascade =
+        Some Masc_mcp.Keeper_config.local_recovery_cascade_name;
+      fallback_reason = Some "turn_timeout";
       stop_reason = Some "completed";
       error_kind = None;
       error_message = None;

--- a/test/test_keeper_cascade_routing.ml
+++ b/test/test_keeper_cascade_routing.ml
@@ -87,6 +87,23 @@ let test_running_with_custom_base () =
   check string "Running preserves custom base"
     "coding_first" r.effective_cascade
 
+let test_tool_required_turn_uses_strict_lane () =
+  let r =
+    Routing.route_effective_cascade_for_tool_requirement
+      ~effective_cascade:"big_three" ~tool_requirement:"required"
+  in
+  check string "required tool turns route to strict lane"
+    Masc_mcp.Keeper_config.tool_use_strict_cascade_name r.effective_cascade
+
+let test_tool_required_turn_preserves_local_recovery () =
+  let r =
+    Routing.route_effective_cascade_for_tool_requirement
+      ~effective_cascade:Masc_mcp.Keeper_config.local_recovery_cascade_name
+      ~tool_requirement:"required"
+  in
+  check string "required tool turns preserve local recovery"
+    Masc_mcp.Keeper_config.local_recovery_cascade_name r.effective_cascade
+
 let test_all_phases_have_reason () =
   List.iter (fun phase ->
     let r = Routing.select_cascade ~base_cascade:base ~phase in
@@ -117,6 +134,10 @@ let () =
     "edge_cases", [
       test_case "Failing overrides local_only base" `Quick test_failing_with_local_only_base;
       test_case "Running preserves custom base"     `Quick test_running_with_custom_base;
+      test_case "Required tool turn uses strict lane" `Quick
+        test_tool_required_turn_uses_strict_lane;
+      test_case "Required tool turn preserves local recovery" `Quick
+        test_tool_required_turn_preserves_local_recovery;
       test_case "All phases have reason"            `Quick test_all_phases_have_reason;
     ];
   ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4098,6 +4098,15 @@ let test_keeper_allowed_tools_exclude_heartbeat () =
   check bool "masc_heartbeat hidden from keeper tool surface" false
     (List.mem "masc_heartbeat" allowed)
 
+let test_should_require_tools_for_initial_turn_matches_first_turn_gate () =
+  let affordances = [ "task_claim"; "board_post" ] in
+  check bool "two-turn call reserves final turn without forcing strict lane" false
+    (KAR.should_require_tools_for_initial_turn ~max_turns:2 ~turn_affordances:affordances);
+  check bool "three-turn call can require initial tools" true
+    (KAR.should_require_tools_for_initial_turn ~max_turns:3 ~turn_affordances:affordances);
+  check bool "no tool-required affordance stays optional" false
+    (KAR.should_require_tools_for_initial_turn ~max_turns:3 ~turn_affordances:[ "observe" ])
+
 (* ---------- render_inline_skip_reason tests ---------- *)
 
 let str_contains s sub =
@@ -4718,6 +4727,8 @@ let () =
         [
           test_case "keeper allowed tools exclude heartbeat" `Quick
             test_keeper_allowed_tools_exclude_heartbeat;
+          test_case "initial tool requirement mirrors first-turn gate" `Quick
+            test_should_require_tools_for_initial_turn_matches_first_turn_gate;
         ] );
       ( "verification_surface",
         [

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1326,6 +1326,8 @@ let sample_ctx_composition ?(system_prompt = "You are a keeper.")
 let sample_tool_surface_metrics () : Masc_mcp.Keeper_agent_run.tool_surface_metrics =
   {
     turn_lane = "tool_optional";
+    tool_surface_class = "mixed";
+    tool_requirement = "optional";
     visible_tool_count = 0;
     tool_gate_enabled = false;
     tool_surface_fallback_used = false;
@@ -2123,6 +2125,9 @@ let test_append_decision_record_persists_tool_calls () =
             ~observation:base_observation
             ~latency_ms:42
             ~outcome:"success"
+            ~degraded_retry_applied:true
+            ~degraded_retry_cascade:KC.local_recovery_cascade_name
+            ~fallback_reason:"turn_timeout"
             ~turn_mode:UM.Tool_use
             ~result:(Some result)
             ());
@@ -2156,6 +2161,15 @@ let test_append_decision_record_persists_tool_calls () =
         Yojson.Safe.Util.(json |> member "tools_used" |> to_list |> List.map to_string);
       check (option string) "turn mode persisted" (Some "tool_use")
         Yojson.Safe.Util.(json |> member "turn_mode" |> to_string_option);
+      check bool "degraded retry flag persisted" true
+        Yojson.Safe.Util.(json |> member "degraded_retry_applied" |> to_bool);
+      check (option string) "degraded retry cascade persisted"
+        (Some KC.local_recovery_cascade_name)
+        Yojson.Safe.Util.(
+          json |> member "degraded_retry_cascade" |> to_string_option);
+      check (option string) "fallback reason persisted"
+        (Some "turn_timeout")
+        Yojson.Safe.Util.(json |> member "fallback_reason" |> to_string_option);
       check bool "selected_mode removed from decision log" true
         (match Yojson.Safe.Util.(json |> member "selected_mode") with
          | `Null -> true
@@ -2389,45 +2403,95 @@ let wrapped_claude_limit_error () =
          kind = Llm_provider.Http_client.Unknown;
        })
 
-let test_fail_open_cascade_after_auto_recoverable_error_falls_back_to_default () =
-  let fallback =
-    EC.fail_open_cascade_after_auto_recoverable_error
-      ~base_cascade:"underdog"
+let expect_degraded_retry label expected_cascade expected_reason = function
+  | Some (retry : EC.degraded_retry) ->
+      check string (label ^ " cascade") expected_cascade retry.next_cascade;
+      check string (label ^ " reason") expected_reason retry.fallback_reason
+  | None -> fail (label ^ ": expected degraded retry")
+
+let test_degraded_retry_after_recoverable_error_uses_local_recovery_for_hard_quota () =
+  let degraded_retry =
+    EC.degraded_retry_after_recoverable_error
       ~effective_cascade:"underdog"
+      ~tool_requirement:"optional"
       (wrapped_claude_limit_error ())
   in
-  check (option string) "non-default cascade broadens to default"
-    (Some KC.default_cascade_name) fallback
+  expect_degraded_retry "hard quota degraded retry"
+    KC.local_recovery_cascade_name "hard_quota" degraded_retry
 
-let test_fail_open_cascade_after_auto_recoverable_error_returns_base_after_phase_override () =
-  let fallback =
-    EC.fail_open_cascade_after_auto_recoverable_error
-      ~base_cascade:"underdog"
-      ~effective_cascade:KC.local_recovery_cascade_name
+let test_degraded_retry_after_recoverable_error_uses_local_recovery_for_resumable_session () =
+  let degraded_retry =
+    EC.degraded_retry_after_recoverable_error
+      ~effective_cascade:"underdog"
+      ~tool_requirement:"optional"
+      (Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
+         (Masc_mcp.Oas_worker_named.Resumable_cli_session
+            {
+              cascade_name = "kimi_cli_keeper";
+              detail =
+                "kimi exited with code 75: \nTo resume this session: kimi -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc";
+              exit_code = Some 75;
+            }))
+  in
+  expect_degraded_retry "resumable session degraded retry"
+    KC.local_recovery_cascade_name "resumable_cli_session" degraded_retry
+
+let test_degraded_retry_after_recoverable_error_includes_admission_queue_timeout () =
+  let degraded_retry =
+    EC.degraded_retry_after_recoverable_error
+      ~effective_cascade:"underdog"
+      ~tool_requirement:"optional"
+      (Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
+         (Masc_mcp.Oas_worker_named.Admission_queue_timeout
+            {
+              keeper_name = "nick0cave";
+              cascade_name = "big_three";
+              wait_sec = 90.0;
+            }))
+  in
+  expect_degraded_retry "admission queue timeout degraded retry"
+    KC.local_recovery_cascade_name "admission_queue_timeout" degraded_retry
+
+let test_degraded_retry_after_recoverable_error_includes_turn_timeout () =
+  let degraded_retry =
+    EC.degraded_retry_after_recoverable_error
+      ~effective_cascade:"underdog"
+      ~tool_requirement:"optional"
+      (Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
+         (Masc_mcp.Oas_worker_named.Turn_timeout { elapsed_sec = 180.0 }))
+  in
+  expect_degraded_retry "turn timeout degraded retry"
+    KC.local_recovery_cascade_name "turn_timeout" degraded_retry
+
+let test_degraded_retry_after_recoverable_error_blocks_required_tools () =
+  let degraded_retry =
+    EC.degraded_retry_after_recoverable_error
+      ~effective_cascade:"underdog"
+      ~tool_requirement:"required"
       (wrapped_claude_limit_error ())
   in
-  check (option string) "phase override returns to keeper base"
-    (Some "underdog") fallback
+  check bool "required tool turn stays terminal" true
+    (Option.is_none degraded_retry)
 
-let test_fail_open_cascade_after_auto_recoverable_error_preserves_explicit_local_only () =
-  let fallback =
-    EC.fail_open_cascade_after_auto_recoverable_error
-      ~base_cascade:KC.local_only_cascade_name
+let test_degraded_retry_after_recoverable_error_does_not_broaden_local_only () =
+  let degraded_retry =
+    EC.degraded_retry_after_recoverable_error
       ~effective_cascade:KC.local_only_cascade_name
+      ~tool_requirement:"optional"
       (wrapped_claude_limit_error ())
   in
-  check (option string) "explicit local_only stays authoritative" None
-    fallback
+  check bool "local_only does not broaden further" true
+    (Option.is_none degraded_retry)
 
-let test_fail_open_cascade_after_auto_recoverable_error_skips_default_cascade () =
-  let fallback =
-    EC.fail_open_cascade_after_auto_recoverable_error
-      ~base_cascade:KC.default_cascade_name
-      ~effective_cascade:KC.default_cascade_name
+let test_degraded_retry_after_recoverable_error_does_not_broaden_local_recovery () =
+  let degraded_retry =
+    EC.degraded_retry_after_recoverable_error
+      ~effective_cascade:KC.local_recovery_cascade_name
+      ~tool_requirement:"optional"
       (wrapped_claude_limit_error ())
   in
-  check (option string) "default cascade has no broader fallback" None
-    fallback
+  check bool "local_recovery does not broaden further" true
+    (Option.is_none degraded_retry)
 
 let test_fallback_cascade_for_unavailable_profile_prefers_default () =
   let fallback =
@@ -2447,26 +2511,30 @@ let test_fallback_cascade_for_unavailable_profile_prefers_base_after_phase_overr
   check (option string) "phase override fallback target is base cascade"
     (Some "underdog") fallback
 
-let test_next_fail_open_cascade_for_turn_returns_untried_fallback () =
-  let fallback =
+let test_next_fail_open_cascade_for_turn_returns_untried_local_recovery () =
+  let degraded_retry =
     UT.next_fail_open_cascade_for_turn
       ~base_cascade:"underdog"
       ~effective_cascade:"underdog"
+      ~tool_requirement:"optional"
       ~attempted_cascades:[ "underdog" ]
       (wrapped_claude_limit_error ())
   in
-  check (option string) "untried fallback returned"
-    (Some KC.default_cascade_name) fallback
+  expect_degraded_retry "next degraded retry"
+    KC.local_recovery_cascade_name "hard_quota" degraded_retry
 
-let test_next_fail_open_cascade_for_turn_suppresses_attempted_fallback () =
-  let fallback =
+let test_next_fail_open_cascade_for_turn_suppresses_attempted_local_recovery () =
+  let degraded_retry =
     UT.next_fail_open_cascade_for_turn
       ~base_cascade:"underdog"
       ~effective_cascade:"underdog"
-      ~attempted_cascades:[ "underdog"; KC.default_cascade_name ]
+      ~tool_requirement:"optional"
+      ~attempted_cascades:
+        [ "underdog"; KC.local_recovery_cascade_name ]
       (wrapped_claude_limit_error ())
   in
-  check (option string) "attempted fallback suppressed" None fallback
+  check bool "attempted local_recovery suppressed" true
+    (Option.is_none degraded_retry)
 
 (* context_overflow_limit is now in OAS as Retry.extract_context_limit.
    These tests verify the OAS SSOT API is accessible from MASC. *)
@@ -4619,22 +4687,32 @@ let () =
             test_fail_open_local_only_preserves_explicit_local_only_base;
           test_case "healthy local_only stays selected" `Quick
             test_fail_open_local_only_preserves_healthy_local_only;
-          test_case "strict quota fail-open broadens to default cascade" `Quick
-            test_fail_open_cascade_after_auto_recoverable_error_falls_back_to_default;
-          test_case "phase override fail-open returns to base cascade" `Quick
-            test_fail_open_cascade_after_auto_recoverable_error_returns_base_after_phase_override;
-          test_case "explicit local_only keeps fail-open disabled" `Quick
-            test_fail_open_cascade_after_auto_recoverable_error_preserves_explicit_local_only;
-          test_case "default cascade has no broader fail-open target" `Quick
-            test_fail_open_cascade_after_auto_recoverable_error_skips_default_cascade;
+          test_case "hard quota degraded retry uses local_recovery" `Quick
+            test_degraded_retry_after_recoverable_error_uses_local_recovery_for_hard_quota;
+          test_case "resumable session degraded retry uses local_recovery"
+            `Quick
+            test_degraded_retry_after_recoverable_error_uses_local_recovery_for_resumable_session;
+          test_case "admission queue timeout is degraded-retry eligible"
+            `Quick
+            test_degraded_retry_after_recoverable_error_includes_admission_queue_timeout;
+          test_case "turn timeout is degraded-retry eligible" `Quick
+            test_degraded_retry_after_recoverable_error_includes_turn_timeout;
+          test_case "required tool turns block degraded retry" `Quick
+            test_degraded_retry_after_recoverable_error_blocks_required_tools;
+          test_case "local_only stays terminal for degraded retry" `Quick
+            test_degraded_retry_after_recoverable_error_does_not_broaden_local_only;
+          test_case "local_recovery stays terminal for degraded retry" `Quick
+            test_degraded_retry_after_recoverable_error_does_not_broaden_local_recovery;
           test_case "unavailable profile fallback prefers default" `Quick
             test_fallback_cascade_for_unavailable_profile_prefers_default;
           test_case "unavailable phase override fallback prefers base" `Quick
             test_fallback_cascade_for_unavailable_profile_prefers_base_after_phase_override;
-          test_case "next fail-open returns untried fallback" `Quick
-            test_next_fail_open_cascade_for_turn_returns_untried_fallback;
-          test_case "next fail-open suppresses attempted fallback" `Quick
-            test_next_fail_open_cascade_for_turn_suppresses_attempted_fallback;
+          test_case "next degraded retry returns untried local_recovery"
+            `Quick
+            test_next_fail_open_cascade_for_turn_returns_untried_local_recovery;
+          test_case "next degraded retry suppresses attempted local_recovery"
+            `Quick
+            test_next_fail_open_cascade_for_turn_suppresses_attempted_local_recovery;
         ] );
       ( "tool_classification",
         [

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1651,6 +1651,41 @@ let test_resolve_tool_lane_for_kimi_cli_internal_tools_rejects () =
       Alcotest.(check string) "field" "tool_support" field
   | Error err -> Alcotest.fail (Oas.Error.to_string err)
 
+let test_resolve_tool_lane_for_codex_cli_internal_tools_optional_drops_tools () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  match
+    Oas_worker_exec.resolve_tool_lane_for_oas_tools
+      ~tool_requirement:`Optional
+      ~provider_cfg:(make_codex_cli_provider_cfg ())
+      ~tools:[ make_named_noop_tool "keeper_board_get" ] ()
+  with
+  | Ok (effective_tools, runtime_mcp_policy) ->
+      Alcotest.(check int) "unsupported optional internal tools are dropped" 0
+        (List.length effective_tools);
+      Alcotest.(check bool) "dropped optional tools stay text-only" true
+        (Option.is_none runtime_mcp_policy)
+  | Error err -> Alcotest.fail (Oas.Error.to_string err)
+
+let test_filter_candidate_providers_for_tool_support_normalizes_codex_headers () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "shared-codex-token" @@ fun () ->
+  let runtime_mcp_policy =
+    Oas_worker_exec.public_mcp_runtime_policy_of_tool_names
+      ~agent_name:"keeper-sangsu-agent" [ "masc_status" ]
+  in
+  let filtered =
+    Masc_mcp.Oas_worker_named.filter_candidate_providers_for_tool_support
+      ~keeper_name:"sangsu"
+      ?runtime_mcp_policy
+      ~require_tool_choice_support:true
+      ~require_tool_support:true
+      ~label:"big_three"
+      [ make_codex_cli_provider_cfg () ]
+  in
+  Alcotest.(check int)
+    "codex survives provider-normalized runtime MCP tool filter"
+    1 (List.length filtered)
+
 let test_kimi_mcp_config_json_of_policy_filters_to_allowed_servers () =
   let policy =
     {
@@ -3220,6 +3255,10 @@ let () =
         test_resolve_tool_lane_for_codex_cli_internal_tools_rejects;
       Alcotest.test_case "keeper-internal tools on kimi_cli are rejected" `Quick
         test_resolve_tool_lane_for_kimi_cli_internal_tools_rejects;
+      Alcotest.test_case "optional keeper-internal tools on codex_cli drop to text" `Quick
+        test_resolve_tool_lane_for_codex_cli_internal_tools_optional_drops_tools;
+      Alcotest.test_case "provider-normalized filter keeps codex public MCP lane" `Quick
+        test_filter_candidate_providers_for_tool_support_normalizes_codex_headers;
       Alcotest.test_case "kimi runtime MCP config keeps only allowed servers" `Quick
         test_kimi_mcp_config_json_of_policy_filters_to_allowed_servers;
       Alcotest.test_case "runtime MCP policy injects keeper agent header for masc server" `Quick

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -899,6 +899,7 @@ let test_run_named_per_provider_timeout_uses_clock_fallback_and_exempts_last_pro
     with_temp_masc_config
       (Printf.sprintf
          {|{
+  "big_three_models": ["ollama:auto"],
   "timeout_probe_models": [
     "custom:slow@%s",
     "custom:last@%s"


### PR DESCRIPTION
## Summary

Fix keeper cascade orchestration so provider/tool eligibility, required-tool routing, and degraded fallback decisions share the same normalized turn state.

This PR has two linked parts:

- Normalize runtime MCP/tool support before provider eligibility checks, allowing public-only tool surfaces to continue on compatible CLI providers while still rejecting providers for truly required internal tool support.
- Replace broad fail-open recovery with a one-shot `local_recovery` degraded retry for recoverable whole-cascade failures such as hard quota, resumable CLI sessions, admission queue timeout, turn timeout, and filtered cascade candidates.

## Why

Keeper failures were being decided from inconsistent views of the same turn: provider capability checks could reject a provider based on request-scoped headers that would later be stripped, optional/internal tool visibility could be treated as required, and recoverable cascade failures could broaden back to default/base cascades instead of using the configured degraded lane.

The result was noisy terminal failures for cases that should either degrade safely or remain terminal because required tool capability would be lost.

## Changes

- Add explicit `tool_surface_class` and `tool_requirement` telemetry to keeper run results, decision logs, and execution receipts.
- Route required-tool turns to the existing `tool_use_strict` lane.
- Let optional tool surfaces drop unsupported internal tools instead of failing the whole provider when public tool support remains viable.
- Add structured degraded retry classification in `keeper_error_classify`, targeting `local_recovery` only.
- Block degraded retry for required-tool turns, `local_only`, and already-attempted `local_recovery` to avoid loops and tool-contract violations.
- Preserve post-commit integrity behavior for mutating tool failures.
- Fix atomic keeper meta writes to return `Error` rather than throwing, making paused-state sync safe/testable.

## Validation

Run with an isolated Dune build dir because the shared default `_build` was locked by other active agents:

- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/keeper-cascade-normalization --build-dir /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/keeper-cascade-normalization/_build_track4 @runtest-test_keeper_unified @runtest-test_oas_worker @runtest-test_keeper_cascade_routing @runtest-test_dashboard_execution`

Out of scope: `test_dashboard_keeper_routes` still has the pre-existing lifecycle fixture issues noted before this PR.