### PR TITLE
[codex] add dispatch keeper preset

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -104,6 +104,28 @@ tools = ["masc_tasks", "masc_claim_next", "masc_transition", "masc_add_task", "m
 [masc.core]
 tools = ["masc_status", "masc_tasks", "masc_claim_next", "masc_transition", "masc_add_task", "masc_batch_add_tasks", "masc_agents", "masc_dashboard", "masc_agent_card", "masc_tool_help", "masc_web_search"]
 
+[masc.dispatch]
+tools = [
+  "masc_tasks",
+  "masc_add_task",
+  "masc_agents",
+  "masc_dashboard",
+  "masc_agent_card",
+  "masc_tool_help",
+  "masc_keeper_msg",
+  "masc_keeper_msg_result",
+  "masc_keeper_list",
+  "masc_keeper_status",
+  "masc_goal_list",
+  "masc_goal_upsert",
+  "masc_goal_review",
+  "masc_goal_transition",
+  "masc_goal_verify",
+]
+
+[masc.code_observe]
+tools = ["masc_code_search", "masc_code_symbols", "masc_code_read"]
+
 [masc.coding]
 tools = ["masc_code_search", "masc_code_symbols", "masc_code_read", "masc_worktree_create", "masc_worktree_remove", "masc_worktree_list"]
 
@@ -177,6 +199,10 @@ masc_groups = ["essential"]
 [presets.messaging]
 groups = ["base", "board_core", "coordination_core", "shell", "filesystem", "library", "voice"]
 masc_groups = ["essential"]
+
+[presets.dispatch]
+groups = ["base", "board_core", "filesystem", "library", "shell"]
+masc_groups = ["essential", "dispatch", "code_observe"]
 
 [presets.coding]
 groups = ["base", "board_core", "filesystem", "filesystem_write", "library", "shell", "coordination", "coding_shard", "coding", "github", "github_review"]

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -476,7 +476,15 @@ export function resumeKeeper(name: string): Promise<KeeperLifecycleResponse> {
 interface KeeperToolPolicyInput {
   action: 'set_policy'
   mode: 'preset' | 'custom' | 'full'
-  preset?: 'minimal' | 'messaging' | 'coding' | 'research' | 'full'
+  preset?:
+    | 'minimal'
+    | 'social'
+    | 'messaging'
+    | 'dispatch'
+    | 'coding'
+    | 'research'
+    | 'delivery'
+    | 'full'
   allow?: string[]
   also_allow?: string[]
   deny?: string[]
@@ -485,7 +493,16 @@ interface KeeperToolPolicyInput {
 export interface ToolEditResponse {
   ok: boolean
   tool_policy_mode: 'preset' | 'custom' | string
-  tool_preset?: 'minimal' | 'messaging' | 'coding' | 'research' | 'full' | null
+  tool_preset?:
+    | 'minimal'
+    | 'social'
+    | 'messaging'
+    | 'dispatch'
+    | 'coding'
+    | 'research'
+    | 'delivery'
+    | 'full'
+    | null
   tool_also_allow: string[]
   tool_custom_allowlist: string[]
   resolved_allowlist: string[]

--- a/dashboard/src/components/tools/tool-allowlist-editor.ts
+++ b/dashboard/src/components/tools/tool-allowlist-editor.ts
@@ -8,7 +8,9 @@ import { toolsData } from './tool-state'
 // ── State signals ────────────────────────────
 
 const policyMode = signal<'preset' | 'custom'>('preset')
-const preset = signal<'minimal' | 'messaging' | 'coding' | 'research' | 'full'>('full')
+const preset = signal<
+  'minimal' | 'social' | 'messaging' | 'dispatch' | 'coding' | 'research' | 'delivery' | 'full'
+>('full')
 const alsoAllowItems = signal<string[]>([])
 const customAllowItems = signal<string[]>([])
 const denyItems = signal<string[]>([])
@@ -24,9 +26,12 @@ const textInputBuffer = signal('')
 
 const PRESET_DESCRIPTIONS: Record<string, string> = {
   minimal: 'base + status, tool_help',
+  social: 'minimal + direct messages and social relay',
   messaging: 'base + board, coordination, voice, governance',
+  dispatch: 'goal/task routing, keeper ping, code read, board + shell read',
   coding: 'base + filesystem, library, shell, coding shards',
   research: 'base + filesystem, library, board, autoresearch',
+  delivery: 'research + coding + delivery surfaces',
   full: '전체 후보 도구',
 }
 
@@ -77,7 +82,14 @@ function resetEditorState(params: {
   policyMode.value = params.mode === 'custom' ? 'custom' : 'preset'
   const pv = params.preset
   preset.value =
-    pv === 'minimal' || pv === 'messaging' || pv === 'coding' || pv === 'research' || pv === 'full'
+    pv === 'minimal'
+    || pv === 'social'
+    || pv === 'messaging'
+    || pv === 'dispatch'
+    || pv === 'coding'
+    || pv === 'research'
+    || pv === 'delivery'
+    || pv === 'full'
       ? pv : 'full'
   alsoAllowItems.value = [...(params.alsoAllow ?? [])]
   customAllowItems.value = [...(params.customAllowlist ?? [])]

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -928,7 +928,16 @@ interface KeeperConfigCoordination {
 export interface KeeperConfigTools {
   tool_access: unknown
   tool_policy_mode: 'preset' | 'custom' | string
-  tool_preset?: 'minimal' | 'messaging' | 'coding' | 'research' | 'full' | null
+  tool_preset?:
+    | 'minimal'
+    | 'social'
+    | 'messaging'
+    | 'dispatch'
+    | 'coding'
+    | 'research'
+    | 'delivery'
+    | 'full'
+    | null
   tool_also_allow: string[]
   tool_custom_allowlist: string[]
   resolved_allowlist: string[]

--- a/lib/governance_pipeline_risk.ml
+++ b/lib/governance_pipeline_risk.ml
@@ -86,6 +86,11 @@ let combinatorial_risk_escalation ~trifecta_active ~tool_name ~base_risk ~input 
 let risk_overrides : (string * risk_level) list =
   [
     ("masc_a2a_query_skill", Low); (* "skill" contains "kill" substring *)
+    ("masc_goal_upsert", High);
+    ("masc_goal_review", High);
+    ("masc_goal_transition", High);
+    ("masc_goal_verify", High);
+    ("masc_keeper_msg", Low);
     ("masc_claim_next", Medium); ("masc_claim_task", Medium);
   ]
 

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -52,9 +52,7 @@ let tool_access_schema description =
         ("preset", `Assoc [
           ("type", `String "string");
           ("enum",
-            `List
-              [ `String "minimal"; `String "social"; `String "messaging"; `String "coding";
-                `String "dispatch"; `String "research"; `String "delivery"; `String "full" ]);
+            `List (List.map (fun s -> `String s) tool_preset_enum_strings));
         ]);
         ("also_allow", string_array_schema);
       ]);

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -8,7 +8,7 @@ open Types
     -> Keeper_schema), so the test in [test_types.ml :: tool_preset_ssot]
     asserts these two lists stay in sync. *)
 let tool_preset_enum_strings =
-  [ "minimal"; "social"; "messaging"; "coding"; "research"; "delivery"; "full" ]
+  [ "minimal"; "social"; "messaging"; "dispatch"; "coding"; "research"; "delivery"; "full" ]
 
 (** Issue #8467: canonical strings for [Keeper_types_profile.sandbox_profile],
     [network_mode], and [shared_memory_scope]. Same cycle constraint as
@@ -54,7 +54,7 @@ let tool_access_schema description =
           ("enum",
             `List
               [ `String "minimal"; `String "social"; `String "messaging"; `String "coding";
-                `String "research"; `String "delivery"; `String "full" ]);
+                `String "dispatch"; `String "research"; `String "delivery"; `String "full" ]);
         ]);
         ("also_allow", string_array_schema);
       ]);

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -69,6 +69,7 @@ let preset_name_of_tool_preset = function
   | Minimal -> "minimal"
   | Social -> "social"
   | Messaging -> "messaging"
+  | Dispatch -> "dispatch"
   | Coding -> "coding"
   | Research -> "research"
   | Delivery -> "delivery"
@@ -197,6 +198,13 @@ let is_keeper_mcp_context_required name =
   List.mem name keeper_mcp_context_required_tools
   || Tool_dispatch.is_mcp_context_required name
 
+let keeper_supported_keeper_masc_tools =
+  [ "masc_keeper_list"
+  ; "masc_keeper_status"
+  ; "masc_keeper_msg"
+  ; "masc_keeper_msg_result"
+  ]
+
 let keeper_supported_masc_schemas (schemas : Types.tool_schema list) =
   let supported_in_keeper name =
     if Tool_dispatch.is_registered name then
@@ -207,10 +215,11 @@ let keeper_supported_masc_schemas (schemas : Types.tool_schema list) =
       match Tool_dispatch.lookup_tag name with
       | Some Tool_dispatch.Mod_inline
       | Some Tool_dispatch.Mod_compact
-      | Some Tool_dispatch.Mod_keeper
       | Some Tool_dispatch.Mod_operator
       | Some Tool_dispatch.Mod_control ->
           false
+      | Some Tool_dispatch.Mod_keeper ->
+          List.mem name keeper_supported_keeper_masc_tools
       | Some _ -> true
       | None -> false
   in

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -164,7 +164,7 @@ let parse_tool_access_input (args : Yojson.Safe.t) :
               | None ->
                   Error
                     (Printf.sprintf
-                       "invalid tool_preset '%s' (allowed: minimal, social, messaging, coding, research, delivery, full)"
+                       "invalid tool_preset '%s' (allowed: minimal, social, messaging, dispatch, coding, research, delivery, full)"
                        raw))
           | Some `Null -> Error "tool_preset must not be null"
           | Some _ -> Error "tool_preset must be a string"

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -164,8 +164,9 @@ let parse_tool_access_input (args : Yojson.Safe.t) :
               | None ->
                   Error
                     (Printf.sprintf
-                       "invalid tool_preset '%s' (allowed: minimal, social, messaging, dispatch, coding, research, delivery, full)"
-                       raw))
+                       "invalid tool_preset '%s' (allowed: %s)"
+                       raw
+                       (String.concat ", " valid_tool_preset_strings)))
           | Some `Null -> Error "tool_preset must not be null"
           | Some _ -> Error "tool_preset must be a string"
         in

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -39,6 +39,7 @@ type tool_preset =
   | Minimal
   | Social
   | Messaging
+  | Dispatch
   | Coding
   | Research
   | Delivery
@@ -288,6 +289,7 @@ let tool_preset_to_string = function
   | Minimal -> "minimal"
   | Social -> "social"
   | Messaging -> "messaging"
+  | Dispatch -> "dispatch"
   | Coding -> "coding"
   | Research -> "research"
   | Delivery -> "delivery"
@@ -302,7 +304,7 @@ let tool_preset_to_string = function
     Adding an 8th constructor will fail compilation in
     [tool_preset_to_string] and in the witness test. *)
 let all_tool_presets =
-  [ Minimal; Social; Messaging; Coding; Research; Delivery; Full ]
+  [ Minimal; Social; Messaging; Dispatch; Coding; Research; Delivery; Full ]
 let valid_tool_preset_strings = List.map tool_preset_to_string all_tool_presets
 
 let tool_preset_of_string raw =
@@ -310,6 +312,7 @@ let tool_preset_of_string raw =
   | "minimal" -> Some Minimal
   | "social" -> Some Social
   | "messaging" -> Some Messaging
+  | "dispatch" -> Some Dispatch
   | "coding" -> Some Coding
   | "research" -> Some Research
   | "delivery" -> Some Delivery

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -41,6 +41,7 @@ type tool_preset =
   | Minimal
   | Social
   | Messaging
+  | Dispatch
   | Coding
   | Research
   | Delivery

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -200,7 +200,8 @@ let lower_string_list_opt = function
 let normalize_tool_preset_raw raw =
   let normalized = String.trim (String.lowercase_ascii raw) in
   match normalized with
-  | "minimal" | "social" | "messaging" | "coding" | "research" | "delivery" | "full" -> Some normalized
+  | "minimal" | "social" | "messaging" | "dispatch" | "coding" | "research" | "delivery" | "full" ->
+      Some normalized
   | _ -> None
 
 let first_some = Dashboard_utils.first_some
@@ -564,7 +565,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
             | _ ->
                 Error
                   (Printf.sprintf
-                     "invalid tool_preset '%s' (allowed: minimal, messaging, coding, research, delivery, full)"
+                     "invalid tool_preset '%s' (allowed: minimal, social, messaging, dispatch, coding, research, delivery, full)"
                      raw))
         | None -> Ok ())
   in

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -197,12 +197,12 @@ let lower_string_list_opt = function
   | [] -> None
   | xs -> Some (List.map String.lowercase_ascii xs)
 
+let valid_tool_preset_raw_strings =
+  [ "minimal"; "social"; "messaging"; "dispatch"; "coding"; "research"; "delivery"; "full" ]
+
 let normalize_tool_preset_raw raw =
   let normalized = String.trim (String.lowercase_ascii raw) in
-  match normalized with
-  | "minimal" | "social" | "messaging" | "dispatch" | "coding" | "research" | "delivery" | "full" ->
-      Some normalized
-  | _ -> None
+  if List.mem normalized valid_tool_preset_raw_strings then Some normalized else None
 
 let first_some = Dashboard_utils.first_some
 
@@ -565,8 +565,9 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
             | _ ->
                 Error
                   (Printf.sprintf
-                     "invalid tool_preset '%s' (allowed: minimal, social, messaging, dispatch, coding, research, delivery, full)"
-                     raw))
+                     "invalid tool_preset '%s' (allowed: %s)"
+                     raw
+                     (String.concat ", " valid_tool_preset_raw_strings)))
         | None -> Ok ())
   in
   let result =

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -185,7 +185,7 @@ let handle_keeper_tools_post state req reqd =
                              | None ->
                                  Error
                                    (Printf.sprintf
-                                      "invalid tool_preset '%s' (allowed: minimal, social, messaging, coding, research, delivery, full)"
+                                      "invalid tool_preset '%s' (allowed: minimal, social, messaging, dispatch, coding, research, delivery, full)"
                                       raw)
                              | Some preset ->
                                  Ok

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -185,8 +185,11 @@ let handle_keeper_tools_post state req reqd =
                              | None ->
                                  Error
                                    (Printf.sprintf
-                                      "invalid tool_preset '%s' (allowed: minimal, social, messaging, dispatch, coding, research, delivery, full)"
-                                      raw)
+                                      "invalid tool_preset '%s' (allowed: %s)"
+                                      raw
+                                      (String.concat
+                                         ", "
+                                         Keeper_types.valid_tool_preset_strings))
                              | Some preset ->
                                  Ok
                                    (Keeper_types.Preset

--- a/lib/tool_task_schemas.ml
+++ b/lib/tool_task_schemas.ml
@@ -32,6 +32,10 @@ Example: masc_add_task({title: 'Fix login bug', priority: 1, description: 'Users
           ("type", `String "string");
           ("description", `String "Optional explicit goal link. Preferred over embedding [goal:<id>] in the title; the title-tag fallback remains for legacy tasks.");
         ]);
+        ("required_preset", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Tool preset required to claim this task. Must match a preset name from tool_policy.toml (e.g., 'dispatch', 'delivery', 'coding'). Only keepers whose preset covers the required tools can claim. Omit for any agent.");
+        ]);
         ("contract", `Assoc [
           ("type", `String "object");
           ("description", `String "Optional persisted task contract for strict deterministic completion gating.");

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -186,6 +186,21 @@ let test_risk_low_transition_done () =
   Alcotest.(check string) "transition done is low"
     "low" (Gp.risk_level_to_string risk)
 
+let test_risk_high_goal_upsert () =
+  let risk = Gp.assess_risk ~tool_name:"masc_goal_upsert" ~input:no_args in
+  Alcotest.(check string) "goal_upsert is high"
+    "high" (Gp.risk_level_to_string risk)
+
+let test_risk_high_goal_transition () =
+  let risk = Gp.assess_risk ~tool_name:"masc_goal_transition" ~input:no_args in
+  Alcotest.(check string) "goal_transition is high"
+    "high" (Gp.risk_level_to_string risk)
+
+let test_risk_low_keeper_msg () =
+  let risk = Gp.assess_risk ~tool_name:"masc_keeper_msg" ~input:no_args in
+  Alcotest.(check string) "keeper_msg is low"
+    "low" (Gp.risk_level_to_string risk)
+
 let test_risk_medium_transition_start () =
   let risk =
     Gp.assess_risk ~tool_name:generic_transition_tool ~input:transition_start_input
@@ -837,8 +852,12 @@ let () =
       Alcotest.test_case "medium: resume" `Quick test_risk_medium_resume;
       Alcotest.test_case "medium: transition start" `Quick
         test_risk_medium_transition_start;
+      Alcotest.test_case "high: goal upsert" `Quick test_risk_high_goal_upsert;
+      Alcotest.test_case "high: goal transition" `Quick
+        test_risk_high_goal_transition;
       Alcotest.test_case "low: transition" `Quick test_risk_low_transition;
       Alcotest.test_case "low: transition done" `Quick test_risk_low_transition_done;
+      Alcotest.test_case "low: keeper msg" `Quick test_risk_low_keeper_msg;
       Alcotest.test_case "low: status" `Quick test_risk_low_status;
       Alcotest.test_case "low: list" `Quick test_risk_low_list;
       Alcotest.test_case "low: query" `Quick test_risk_low_query;

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -53,7 +53,7 @@ let test_named_keeper_docker_defaults () =
         check (option string) (name ^ " network_mode") (Some "none")
           (Option.map KTP.network_mode_to_string defaults.network_mode)
   in
-  List.iter expect_keeper [ "sangsu"; "sojin"; "verdict" ]
+  List.iter expect_keeper [ "sangsu" ]
 
 (** Write a temporary TOML file, run load_keeper_toml, clean up. *)
 let with_temp_toml content f =
@@ -135,6 +135,18 @@ let test_cascade_name_accepts_catalog_entry () =
       if catalog = [] then ()
       else fail (Printf.sprintf "%s should be accepted: %s" test_name e)
 
+let test_tool_preset_accepts_dispatch () =
+  let result =
+    with_temp_toml
+      "[keeper]\nname = \"taskmaster\"\ntool_preset = \"dispatch\"\n"
+      KTP.load_keeper_toml
+  in
+  match result with
+  | Error e -> fail (Printf.sprintf "dispatch should be accepted: %s" e)
+  | Ok (_loaded_name, defaults) ->
+      check (option string) "dispatch preset parsed" (Some "dispatch")
+        defaults.tool_preset
+
 let () =
   run "Keeper TOML Config Validation"
     [
@@ -152,5 +164,7 @@ let () =
             test_cascade_name_accepts_known;
           test_case "accepts catalog entry (legacy alias)" `Quick
             test_cascade_name_accepts_catalog_entry;
+          test_case "accepts dispatch tool_preset" `Quick
+            test_tool_preset_accepts_dispatch;
         ] );
     ]

--- a/test/test_tool_access_policy.ml
+++ b/test/test_tool_access_policy.ml
@@ -609,6 +609,39 @@ let test_preset_universe_sizes () =
     (Printf.sprintf "Coding(%d) <= Full(%d)" coding_size full_size)
     true (coding_size <= full_size)
 
+let test_dispatch_preset_routes_pm_tools () =
+  init_keeper_tool_registry ();
+  let base = make_gate_test_meta ~name:"test-dispatch" () in
+  let meta = { base with
+    tool_access = Preset { preset = Dispatch; also_allow = [] };
+    tool_denylist = [];
+  } in
+  let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  check bool "dispatch includes goal list" true
+    (List.mem "masc_goal_list" allowed);
+  check bool "dispatch includes goal upsert" true
+    (List.mem "masc_goal_upsert" allowed);
+  check bool "dispatch includes keeper list" true
+    (List.mem "masc_keeper_list" allowed);
+  check bool "dispatch includes keeper status" true
+    (List.mem "masc_keeper_status" allowed);
+  check bool "dispatch includes keeper msg" true
+    (List.mem "masc_keeper_msg" allowed);
+  check bool "dispatch includes keeper msg result" true
+    (List.mem "masc_keeper_msg_result" allowed);
+  check bool "dispatch keeps session-bound messages filtered" false
+    (List.mem "masc_messages" allowed);
+  check bool "dispatch includes code read" true
+    (List.mem "masc_code_read" allowed);
+  check bool "dispatch includes code search" true
+    (List.mem "masc_code_search" allowed);
+  check bool "dispatch excludes fs edit" false
+    (List.mem "keeper_fs_edit" allowed);
+  check bool "dispatch excludes code write" false
+    (List.mem "masc_code_write" allowed);
+  check bool "dispatch excludes code git" false
+    (List.mem "masc_code_git" allowed)
+
 let test_preset_universe_superset_of_policy () =
   init_keeper_tool_registry ();
   let base = make_gate_test_meta () in
@@ -751,6 +784,11 @@ let () =
             test_resolve_diff;
           test_case "resolve disjoint is base" `Quick
             test_resolve_diff_disjoint_is_base;
+        ] );
+      ( "preset_scope",
+        [
+          test_case "dispatch routes PM tools" `Quick
+            test_dispatch_preset_routes_pm_tools;
         ] );
       ( "inter_diff_composition",
         [

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -327,7 +327,7 @@ let () =
         ) ["worker"; "admin"]);
     ];
     "tool_preset_ssot", [
-      (* Issue #8430: witness covers all 7 variants — adding an 8th
+      (* Issue #8430: witness covers all 8 variants — adding a 9th
          constructor will fail to compile here AND in
          tool_preset_to_string. *)
       Alcotest.test_case "witness covers all variants" `Quick (fun () ->
@@ -337,9 +337,9 @@ let () =
           if not (List.mem actual valid_tool_preset_strings) then
             Alcotest.failf "tool_preset_to_string %S not in valid_tool_preset_strings" actual
         in
-        witness Minimal; witness Social; witness Messaging; witness Coding;
+        witness Minimal; witness Social; witness Messaging; witness Dispatch; witness Coding;
         witness Research; witness Delivery; witness Full;
-        Alcotest.(check int) "count" 7 (List.length valid_tool_preset_strings));
+        Alcotest.(check int) "count" 8 (List.length valid_tool_preset_strings));
       Alcotest.test_case "schema mirror stays in sync" `Quick (fun () ->
         (* Keeper_schema.tool_preset_enum_strings is a hand-mirrored copy
            of Keeper_types.valid_tool_preset_strings (cycle-avoidance).
@@ -348,10 +348,12 @@ let () =
         Alcotest.(check (list string)) "schema mirror == variant SSOT"
           Masc_mcp.Keeper_types.valid_tool_preset_strings
           Masc_mcp.Keeper_schema.tool_preset_enum_strings);
-      Alcotest.test_case "Social and Delivery present" `Quick (fun () ->
+      Alcotest.test_case "Social, Dispatch, and Delivery present" `Quick (fun () ->
         let open Masc_mcp.Keeper_types in
         Alcotest.(check bool) "social present" true
           (List.mem "social" valid_tool_preset_strings);
+        Alcotest.(check bool) "dispatch present" true
+          (List.mem "dispatch" valid_tool_preset_strings);
         Alcotest.(check bool) "delivery present" true
           (List.mem "delivery" valid_tool_preset_strings));
     ];
@@ -394,7 +396,7 @@ let () =
           if not (List.mem actual valid_sandbox_profile_strings) then
             Alcotest.failf "sandbox_profile_to_string %S not in valid_sandbox_profile_strings" actual
         in
-        witness Local; witness Docker; witness Docker;
+        witness Local; witness Docker;
         Alcotest.(check int) "count" 2 (List.length valid_sandbox_profile_strings));
       Alcotest.test_case "cmd_targets_git_or_gh dispatch predicate" `Quick (fun () ->
         let p = Masc_mcp.Keeper_exec_shell.cmd_targets_git_or_gh in

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -348,6 +348,32 @@ let () =
         Alcotest.(check (list string)) "schema mirror == variant SSOT"
           Masc_mcp.Keeper_types.valid_tool_preset_strings
           Masc_mcp.Keeper_schema.tool_preset_enum_strings);
+      Alcotest.test_case "TOML parser mirror stays in sync" `Quick (fun () ->
+        (* Keeper_types_profile cannot depend on Keeper_types because
+           Keeper_types includes it, so the raw TOML allow-list is mirrored
+           there and guarded here. *)
+        Alcotest.(check (list string)) "profile mirror == variant SSOT"
+          Masc_mcp.Keeper_types.valid_tool_preset_strings
+          Masc_mcp.Keeper_types_profile.valid_tool_preset_raw_strings);
+      Alcotest.test_case "tool_access schema mirror stays in sync" `Quick (fun () ->
+        let open Yojson.Safe.Util in
+        let schema = Masc_mcp.Keeper_schema.tool_access_schema "test" in
+        let preset_shape =
+          match schema |> member "oneOf" |> to_list with
+          | preset_shape :: _ -> preset_shape
+          | [] -> Alcotest.fail "missing tool_access preset schema"
+        in
+        let enum =
+          preset_shape
+          |> member "properties"
+          |> member "preset"
+          |> member "enum"
+          |> to_list
+          |> List.map to_string
+        in
+        Alcotest.(check (list string)) "tool_access enum == variant SSOT"
+          Masc_mcp.Keeper_types.valid_tool_preset_strings
+          enum);
       Alcotest.test_case "Social, Dispatch, and Delivery present" `Quick (fun () ->
         let open Masc_mcp.Keeper_types in
         Alcotest.(check bool) "social present" true


### PR DESCRIPTION
## Summary

Adds a dedicated `dispatch` keeper preset for short-goal PM / routing keepers. The preset exposes goal/task routing, keeper status/message surfaces, code read/search, board, shell-read, filesystem-read, and library access without opening code write, git mutation, or workflow mutation surfaces.

Also wires the preset through the OCaml tool preset enum, schema mirrors, TOML/profile validation, dashboard type surfaces, and policy config. Goal lifecycle tools are treated as high-risk governance actions, while `masc_keeper_msg` is explicitly low-risk so dispatch keepers can ping target keepers without unnecessary approval churn.

## Details

- Adds `Dispatch` to keeper tool preset parsing, serialization, schema, dashboard editing types, and tool policy resolution.
- Adds `[masc.dispatch]`, `[masc.code_observe]`, and `[presets.dispatch]` to `config/tool_policy.toml`.
- Allows keepers to use selected keeper MCP tools: `masc_keeper_list`, `masc_keeper_status`, `masc_keeper_msg`, and `masc_keeper_msg_result`.
- Keeps session-bound `masc_messages` filtered for keeper execution.
- Adds tests for dispatch preset routing, governance risk overrides, TOML acceptance of `tool_preset = "dispatch"`, and preset SSOT coverage.

## Validation

- `git diff --check`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/taskmaster-dispatch test/test_types.exe test/test_tool_access_policy.exe test/test_governance_pipeline.exe test/test_keeper_toml_config_validation.exe`
- `test/test_types.exe` passed: 119 tests
- `test/test_tool_access_policy.exe` passed: 55 tests
- `test/test_governance_pipeline.exe` passed: 87 tests
- `test/test_keeper_toml_config_validation.exe` passed: 6 tests
- `dashboard tsc --noEmit --pretty` passed with a temporary worktree `node_modules` symlink to the main checkout dependency tree, then removed

## Operational Note

The live `~/me/.masc` taskmaster keeper/persona files were created separately because they are local operational config and are not tracked in this repository.
