### PR TITLE
fix(task): require join before claim_next auto-join

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -1042,7 +1042,7 @@ let dispatch ctx ~name ~args : tool_result option =
 (* ================================================================ *)
 
 let _tool_spec_read_only = [ "masc_task_history"; "masc_tasks" ]
-let _tool_spec_requires_join = [ "masc_transition" ]
+let _tool_spec_requires_join = [ "masc_claim_next"; "masc_transition" ]
 
 let tool_required_permission = function
   | "masc_tasks" | "masc_task_history" ->

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1663,7 +1663,7 @@ let test_execute_tool_hyphenated_generated_alias_claim_next_reuses_base_token ()
       ~name:"masc_claim_next"
       ~arguments:(`Assoc [ ("agent_name", `String "qa-king-warm-heron") ])
   in
-  Alcotest.(check bool) "claim_next succeeds" true ok;
+  if not ok then Alcotest.failf "claim_next failed: %s" msg;
   Alcotest.(check bool) "claim_next reports claimed task" true
     (contains_substring msg "task-001");
   Alcotest.(check (option string)) "current task set after claim_next"

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -145,6 +145,8 @@ let () =
                 (Tool_dispatch.is_join_required "masc_who"));
           test_case "worktree list uses shipped registry policy" `Quick (fun () ->
               ignore (Mcp_eio.get_clock_opt ());
+              check bool "masc_claim_next join_required" true
+                (Tool_dispatch.is_join_required "masc_claim_next");
               check bool "masc_worktree_list read_only" true
                 (Tool_dispatch.is_read_only "masc_worktree_list");
               check bool "masc_worktree_list not join_required" false


### PR DESCRIPTION
## Summary
- Mark masc_claim_next as requires_join so server auto-join runs before the handler membership check.
- Add registry coverage for shipped claim_next join policy.
- Improve claim_next test failure output while preserving the hyphenated alias regression check.

## Verification
- dune build --root . test/test_auth.exe test/test_nickname_coverage.exe test/test_mcp_server_eio.exe test/test_tool_dispatch.exe
- ./_build/default/test/test_auth.exe
- ./_build/default/test/test_nickname_coverage.exe
- ./_build/default/test/test_tool_dispatch.exe
- ./_build/default/test/test_mcp_server_eio.exe (expected pre-existing state.002 eio context delegation failure; eio.048 passes)
- git diff --check origin/main...HEAD