### PR TITLE
[codex] Align dashboard parity surfaces

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -394,12 +394,18 @@ describe('normalizeGovernanceJudgeSummary', () => {
     const result = normalizeGovernanceJudgeSummary({
       judge_online: true,
       refreshing: false,
+      status: 'stale_visible',
+      degraded_reason: 'timeout',
+      cached_judgments_visible: true,
       model_used: 'gpt-4',
       keeper_name: 'janitor',
       last_error: null,
     })
     expect(result!.judge_online).toBe(true)
     expect(result!.refreshing).toBe(false)
+    expect(result!.status).toBe('stale_visible')
+    expect(result!.degraded_reason).toBe('timeout')
+    expect(result!.cached_judgments_visible).toBe(true)
     expect(result!.model_used).toBe('gpt-4')
     expect(result!.keeper_name).toBe('janitor')
     expect(result!.last_error).toBeNull()

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -229,6 +229,11 @@ export function normalizeGovernanceJudgeSummary(raw: unknown): GovernanceJudgeSu
   return {
     judge_online: typeof raw.judge_online === 'boolean' ? raw.judge_online : undefined,
     refreshing: typeof raw.refreshing === 'boolean' ? raw.refreshing : undefined,
+    status: asNullableString(raw.status) ?? undefined,
+    degraded_reason: asNullableString(raw.degraded_reason),
+    cached_judgments_visible: typeof raw.cached_judgments_visible === 'boolean'
+      ? raw.cached_judgments_visible
+      : undefined,
     generated_at: asNullableIsoTimestamp(raw.generated_at),
     expires_at: asNullableIsoTimestamp(raw.expires_at),
     model_used: asNullableString(raw.model_used),

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -633,16 +633,14 @@ export async function postRaw(
 
 // --- Operator ---
 
+const OPERATOR_ACTION_TIMEOUT_MS: Record<string, number> = {
+  keeper_message: KEEPER_MESSAGE_TIMEOUT_MS,
+  keeper_recover: KEEPER_MESSAGE_TIMEOUT_MS,
+  social_sweep: SOCIAL_SWEEP_TIMEOUT_MS,
+}
+
 function operatorActionTimeoutMs(body: OperatorActionRequest): number {
-  switch (body.action_type) {
-    case 'keeper_message':
-    case 'keeper_recover':
-      return KEEPER_MESSAGE_TIMEOUT_MS
-    case 'social_sweep':
-      return SOCIAL_SWEEP_TIMEOUT_MS
-    default:
-      return DEFAULT_POST_TIMEOUT_MS
-  }
+  return OPERATOR_ACTION_TIMEOUT_MS[body.action_type] ?? DEFAULT_POST_TIMEOUT_MS
 }
 
 export async function runOperatorAction(body: OperatorActionRequest): Promise<OperatorActionResult> {

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -525,6 +525,8 @@ describe('fetchKeeperConfig', () => {
       execution: {
         models: 'llama:test-balanced',
         active_model: 'llama:test-balanced',
+        per_provider_timeout_sec: 12.5,
+        per_provider_timeout_mode: 'override',
         verify: 'true',
         selected_cascade_name: 'keeper_unified',
         selected_cascade_canonical: 'keeper_unified',
@@ -657,6 +659,8 @@ describe('fetchKeeperConfig', () => {
     expect(result.execution.verify).toBe(true)
     expect(result.execution.selected_cascade_name).toBe('keeper_unified')
     expect(result.execution.selected_cascade_canonical).toBe('keeper_unified')
+    expect(result.execution.per_provider_timeout_sec).toBe(12.5)
+    expect(result.execution.per_provider_timeout_mode).toBe('override')
     expect(result.hooks?.destructive_check_tools).toEqual(['dynamic_boundary (Tool_dispatch.is_destructive)'])
     expect(result.hooks?.slots.pre_tool_use?.gates).toEqual(['keeper_deny_list'])
     expect(result.tools.tool_also_allow).toEqual(['keeper_board_post'])

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1577,6 +1577,7 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
   const sources = isRecord(data.sources) ? data.sources : {}
   const metrics = isRecord(data.metrics) ? data.metrics : {}
   const sandboxEnvironment = normalizeKeeperSandboxEnvironment(data.sandbox_environment)
+  const perProviderTimeoutSec = asLooseNullableNumber(execution.per_provider_timeout_sec)
 
   return {
     name: asNullableString(data.name) ?? requestedName,
@@ -1610,6 +1611,12 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
       active_model: asNullableString(execution.active_model) ?? '',
       active_model_label: asNullableString(execution.active_model_label),
       last_model_used_label: asNullableString(execution.last_model_used_label),
+      per_provider_timeout_sec: perProviderTimeoutSec,
+      per_provider_timeout_mode:
+        asNullableString(execution.per_provider_timeout_mode)
+        ?? (perProviderTimeoutSec != null
+            ? 'override'
+            : 'turn_budget_heuristic'),
       verify: asLooseBoolean(execution.verify),
       selected_cascade_name: asNullableString(execution.selected_cascade_name) ?? '',
       selected_cascade_canonical:

--- a/dashboard/src/components/governance.test.ts
+++ b/dashboard/src/components/governance.test.ts
@@ -247,6 +247,48 @@ describe('Governance surface', () => {
     expect(judgeStatus?.textContent).toContain('cascade failed')
   }, 20000)
 
+  it('renders stale-visible judge status without collapsing to offline error', async () => {
+    const staleVisible: DashboardGovernanceResponse = {
+      generated_at: '2026-04-23T00:00:00Z',
+      summary: { cases_open: 0, pending_ruling: 0, ready_auto_execute: 0, needs_human_gate: 0, executed: 0 },
+      items: [],
+      activity: [],
+      judge: {
+        judge_online: true,
+        refreshing: false,
+        status: 'stale_visible',
+        degraded_reason: 'timeout',
+        cached_judgments_visible: true,
+        last_error: 'Execution timed out after 60.0s',
+        keeper_name: 'governance-judge',
+        model_used: 'glm:test',
+        generated_at: '2026-04-23T00:00:00Z',
+      },
+      judgments: [],
+      pending_actions: [],
+      approval_queue: [],
+    }
+
+    const { Governance } = await loadComponentWithApi({
+      decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
+      fetchDashboardGovernance: Vitest.vi.fn().mockResolvedValue(staleVisible),
+      fetchGovernanceCaseStatus: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      resolveGovernanceApproval: Vitest.vi.fn().mockResolvedValue({ ok: true, id: 'appr-1', decision: 'approve' }),
+      submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
+    })
+
+    render(html`<${Governance} />`, container)
+    await flushUi()
+
+    const judgeStatus = container.querySelector('[data-testid="judge-status"]')
+    expect(judgeStatus).toBeTruthy()
+    expect(judgeStatus?.textContent).toContain('캐시 유지')
+    expect(judgeStatus?.textContent).toContain('Execution timed out')
+    expect(container.textContent).toContain('fresh judgment 캐시')
+    expect(container.textContent).not.toContain('AI Judge 오프라인')
+  }, 20000)
+
   it('renders keeper approval queue and resolves approval from the dashboard', async () => {
     const withApprovalQueue: DashboardGovernanceResponse = {
       generated_at: '2026-04-09T00:00:00Z',

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -2,7 +2,7 @@ import { html } from 'htm/preact'
 import { useSignal } from '@preact/signals'
 import { AlertTriangle } from 'lucide-preact'
 import { useEffect, useMemo } from 'preact/hooks'
-import type { KeeperApprovalQueueItem, KeeperApprovalRule } from '../types'
+import type { GovernanceJudgeSummary, KeeperApprovalQueueItem, KeeperApprovalRule } from '../types'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { Card } from './common/card'
@@ -26,6 +26,47 @@ import { formatAgeSummary } from './governance-utils'
 // Re-export for consumers that import from './governance'
 export { refreshGovernance } from './governance-store'
 
+function judgeRuntimeStatus(
+  judge?: GovernanceJudgeSummary,
+  summary?: { judge_online?: boolean },
+): string {
+  const status = judge?.status?.trim()
+  if (status) return status
+  if (judge?.refreshing) return 'refreshing'
+  const online = judge?.judge_online ?? summary?.judge_online
+  return online === true ? 'online' : 'offline'
+}
+
+function judgeStatusLabel(status: string, judge?: GovernanceJudgeSummary): string {
+  switch (status) {
+    case 'online':
+      return '온라인'
+    case 'refreshing':
+      return '갱신 중'
+    case 'stale_visible':
+      return '캐시 유지'
+    case 'backoff':
+      return 'backoff'
+    case 'offline':
+      return judge?.last_error ? '오류' : '오프라인'
+    default:
+      return status
+  }
+}
+
+function degradedReasonLabel(reason?: string | null): string {
+  switch (reason) {
+    case 'timeout':
+      return 'timeout'
+    case 'error':
+      return '오류'
+    case 'backoff':
+      return 'backoff'
+    default:
+      return reason?.trim() || 'degraded'
+  }
+}
+
 function GovernanceSummaryStrip() {
   const data = governanceData.value
   const summary = data?.summary
@@ -39,13 +80,11 @@ function GovernanceSummaryStrip() {
     approvalCount > 0
       ? `judge-only / 최근 판단 ${judgmentCount}건 / 승인 ${approvalCount}건`
       : `judge-only / 최근 판단 ${judgmentCount}건`
-  const liveJudgeState =
-    judge?.judge_online === true
-      ? (judge.refreshing ? '갱신 중' : '온라인')
-      : (judge?.last_error ? '오류' : '오프라인')
+  const status = judgeRuntimeStatus(judge, summary)
+  const liveJudgeState = judgeStatusLabel(status, judge)
   const liveJudgeModel = judge?.model_used?.trim() || judge?.keeper_name?.trim() || '-'
-  const judgeHealthy = judge?.judge_online === true && !judge?.last_error?.trim()
-  const judgeUnhealthy = judge?.judge_online === false || Boolean(judge?.last_error?.trim())
+  const judgeHealthy = status === 'online' || status === 'refreshing'
+  const judgeUnhealthy = status === 'offline' || status === 'stale_visible' || status === 'backoff'
 
   return html`
     ${isStale ? html`
@@ -105,11 +144,17 @@ function GovernanceSummaryStrip() {
 function JudgeStatusBar() {
   const judge = governanceData.value?.judge
   if (!judge) return null
-  const online = judge.judge_online === true
-  const dotClass = online ? 'bg-ok' : 'bg-text-dim'
-  const label = online
-    ? (judge.refreshing ? '갱신 중' : '온라인')
-    : (judge.last_error ? '오류' : '오프라인')
+  const status = judgeRuntimeStatus(judge, governanceData.value?.summary)
+  const dotClass =
+    status === 'online' || status === 'refreshing'
+      ? 'bg-ok'
+      : status === 'stale_visible' || status === 'backoff'
+        ? 'bg-warn'
+        : 'bg-text-dim'
+  const label = judgeStatusLabel(status, judge)
+  const errorTone = status === 'stale_visible' || status === 'backoff'
+    ? 'text-warn'
+    : 'text-bad/80'
   return html`
     <div class="mb-4 flex items-center gap-3 rounded border border-white/5 bg-white/3 px-3.5 py-2 text-xs" data-testid="judge-status">
       <span class="flex items-center gap-1.5">
@@ -124,7 +169,7 @@ function JudgeStatusBar() {
                 ? html`<span class="text-text-dim"><${TimeAgo} timestamp=${judge.generated_at} /></span>`
                 : null}
               ${judge.last_error
-                ? html`<span class="text-bad/80 truncate max-w-75">${judge.last_error}</span>`
+                ? html`<span class="${errorTone} truncate max-w-75">${judge.last_error}</span>`
                 : null}
             </span>
           `
@@ -136,12 +181,21 @@ function JudgeStatusBar() {
 function judgmentsEmptyStateMessage(): { message: string; tone: 'warn' | 'default' } {
   const judge = governanceData.value?.judge
   const summary = governanceData.value?.summary
+  const status = judgeRuntimeStatus(judge, summary)
+  if (status === 'stale_visible') {
+    return {
+      message: `AI Judge ${degradedReasonLabel(judge?.degraded_reason)} 이후 fresh judgment 캐시를 유지 중입니다. 새 판단은 복구 후 갱신됩니다.`,
+      tone: 'warn',
+    }
+  }
+  if (status === 'backoff') {
+    return { message: 'AI Judge backoff: local slots saturated. 새 판단은 local slot 확보 후 재개됩니다.', tone: 'warn' }
+  }
   const lastError = judge?.last_error?.trim()
   if (lastError) {
     return { message: `AI Judge 오류: ${lastError}`, tone: 'warn' }
   }
-  const judgeOnline = judge?.judge_online ?? summary?.judge_online
-  if (judgeOnline === false) {
+  if (status === 'offline') {
     return { message: 'AI Judge 오프라인 — keeper 기동 여부를 확인하세요.', tone: 'warn' }
   }
   const lastSeen = judge?.generated_at ?? summary?.judge_last_seen_at
@@ -357,6 +411,23 @@ function keeperHitlEmptyContext(): {
 } {
   const judge = governanceData.value?.judge
   const summary = governanceData.value?.summary
+  const status = judgeRuntimeStatus(judge, summary)
+  if (status === 'stale_visible') {
+    return {
+      primary: `AI Judge ${degradedReasonLabel(judge?.degraded_reason)} 이후 fresh judgment 캐시를 유지 중입니다.`,
+      secondary: '새 HITL 판정은 judge 복구 후 갱신됩니다.',
+      lastActivity: judge?.generated_at ?? summary?.judge_last_seen_at ?? null,
+      tone: 'warn',
+    }
+  }
+  if (status === 'backoff') {
+    return {
+      primary: 'AI Judge backoff: local slots saturated.',
+      secondary: 'local slot이 확보되면 HITL 판정 생성이 재개됩니다.',
+      lastActivity: judge?.generated_at ?? summary?.judge_last_seen_at ?? null,
+      tone: 'warn',
+    }
+  }
   const lastError = judge?.last_error?.trim()
   if (lastError) {
     return {
@@ -366,8 +437,7 @@ function keeperHitlEmptyContext(): {
       tone: 'warn',
     }
   }
-  const judgeOnline = judge?.judge_online ?? summary?.judge_online
-  if (judgeOnline === false) {
+  if (status === 'offline') {
     return {
       primary: 'AI Judge 오프라인 — HITL 판정 생성이 중단되었습니다.',
       secondary: 'keeper 기동 여부를 먼저 확인하세요.',

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -67,6 +67,8 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
     execution: {
       models: ['llama:test-balanced'],
       active_model: 'llama:test-balanced',
+      per_provider_timeout_sec: null,
+      per_provider_timeout_mode: 'turn_budget_heuristic',
       verify: true,
       selected_cascade_name: 'keeper_unified',
       selected_cascade_canonical: 'keeper_unified',
@@ -480,6 +482,8 @@ describe('KeeperConfigPanel', () => {
         execution: {
           models: ['llama:test-balanced'],
           active_model: 'llama:test-balanced',
+          per_provider_timeout_sec: null,
+          per_provider_timeout_mode: 'turn_budget_heuristic',
           verify: true,
           selected_cascade_name: 'resilient_breaker',
           selected_cascade_canonical: 'resilient_breaker',

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -261,6 +261,21 @@ function ConfigRow({ label, value }: { label: string; value: string }) {
   `
 }
 
+function formatSeconds(value: number): string {
+  if (!Number.isFinite(value)) return '--'
+  return value >= 60 ? `${(value / 60).toFixed(1)}m` : `${value.toFixed(value % 1 === 0 ? 0 : 1)}s`
+}
+
+function perProviderTimeoutLabel(execution: KeeperConfig['execution']): string {
+  if (
+    execution.per_provider_timeout_mode === 'override'
+    && typeof execution.per_provider_timeout_sec === 'number'
+  ) {
+    return formatSeconds(execution.per_provider_timeout_sec)
+  }
+  return 'turn budget heuristic'
+}
+
 function SectionHeader({ title }: { title: string }) {
   return html`
     <div class="text-2xs font-bold uppercase tracking-widest text-accent mt-6 mb-3 pb-1.5 border-b border-accent/20 flex items-center gap-2">
@@ -787,6 +802,10 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
 
       <${SectionHeader} title="실행" />
       <${ConfigRow} label="활성 모델" value=${c.execution.active_model || '--'} />
+      <${ConfigRow} label="provider timeout" value=${perProviderTimeoutLabel(c.execution)} />
+      <div class="mb-1.5 rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-2xs leading-relaxed text-[var(--text-muted)]">
+        cascade fallback 중 마지막 provider를 제외한 provider들에만 적용됩니다.
+      </div>
       <div class="flex items-center justify-between py-2 px-3 rounded bg-[var(--white-3)]">
         <span class="text-xs text-[var(--text-muted)]">검증</span>
         <${BoolBadge} value=${c.execution.verify} />

--- a/dashboard/src/components/ops/helpers.ts
+++ b/dashboard/src/components/ops/helpers.ts
@@ -64,6 +64,10 @@ export function actionTypeLabel(value?: string | null): string {
       return '키퍼 점검'
     case 'keeper_recover':
       return '키퍼 복구'
+    case 'keeper_github_identity_status':
+      return 'GitHub 인증 상태'
+    case 'keeper_github_identity_login_prepare':
+      return 'GitHub 로그인 준비'
     default:
       return value?.trim() || '액션'
   }
@@ -162,8 +166,8 @@ export function workflowTargetReady(
 }
 
 export async function executeAction(input: {
-  action_type: 'broadcast' | 'namespace_pause' | 'namespace_resume' | 'room_pause' | 'room_resume' | 'social_sweep' | 'task_inject' | 'keeper_message' | 'keeper_probe' | 'keeper_recover'
-  target_type: 'root' | 'namespace' | 'room' | 'keeper'
+  action_type: string
+  target_type: 'root' | 'namespace' | 'room' | 'keeper' | string
   target_id?: string
   payload: Record<string, unknown>
   successMessage: string

--- a/dashboard/src/components/ops/index.test.ts
+++ b/dashboard/src/components/ops/index.test.ts
@@ -138,6 +138,56 @@ describe('Ops surface', () => {
     expect(items[2]?.textContent).toContain('키퍼 메시지는 잠시 보류')
   }, 120000)
 
+  it('renders keeper utility actions from the server catalog', async () => {
+    const {
+      Ops,
+      route,
+      operatorActionLog,
+      operatorDigestError,
+      operatorError,
+      operatorRoomDigest,
+      operatorSnapshot,
+      hydratedWorkflowId,
+    } = await loadOps()
+
+    route.value = { tab: 'command', params: { section: 'operations' }, postId: null } as RouteState
+    hydratedWorkflowId.value = null
+    operatorError.value = null
+    operatorDigestError.value = null
+    operatorSnapshot.value = {
+      root: { paused: false, namespace: 'default' },
+      sessions: [],
+      keepers: [{ name: 'qa-king', status: 'online' }],
+      recent_messages: [],
+      pending_confirms: [],
+      available_actions: [
+        { action_type: 'keeper_probe', target_type: 'keeper', description: 'probe from server' },
+        { action_type: 'keeper_github_identity_status', target_type: 'keeper' },
+        { action_type: 'keeper_unknown_maintenance', target_type: 'keeper' },
+        { action_type: 'broadcast', target_type: 'root' },
+      ],
+    } as unknown as OperatorSnapshot
+    operatorRoomDigest.value = {
+      target_type: 'namespace',
+      attention_items: [],
+      recommended_actions: [],
+      recent_reviews: [],
+    } as unknown as OperatorDigest
+    operatorActionLog.value = []
+
+    render(html`<${Ops} />`, container)
+    await flushUi()
+
+    const panel = container.querySelector('[data-testid="keeper-utilities-panel"]')
+    expect(panel).toBeTruthy()
+    expect(panel?.textContent).toContain('키퍼 유틸리티')
+    expect(panel?.textContent).toContain('probe from server')
+    expect(panel?.textContent).toContain('GitHub 인증 상태')
+    expect(panel?.textContent).toContain('keeper_unknown_maintenance')
+    expect(panel?.textContent).toContain('UI adapter pending')
+    expect(panel?.textContent).not.toContain('전체 공지')
+  }, 60000)
+
   it('renders the same single surface when active review items are present (no 3-column unhealthy branch)', async () => {
     const {
       Ops,

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -19,6 +19,7 @@ import {
 } from '../../workflow-context'
 import type { OperatorActionLogEntry, OperatorReviewDecision } from '../../types'
 import { QuickIntervene } from './quick-intervene'
+import { KeeperUtilitiesPanel } from './keeper-utilities'
 import {
   actionTypeLabel,
   formatMessageContent,
@@ -233,6 +234,7 @@ export function Ops() {
       <section class="grid grid-cols-2 gap-4 max-[1200px]:grid-cols-1">
         <div class="grid gap-4 order-1 max-[1200px]:order-2">
           <${QuickIntervene} />
+          <${KeeperUtilitiesPanel} />
         </div>
 
         <section class="${CARD_STANDARD} grid gap-3 order-2 max-[1200px]:order-1">

--- a/dashboard/src/components/ops/keeper-utilities.ts
+++ b/dashboard/src/components/ops/keeper-utilities.ts
@@ -1,0 +1,131 @@
+import { html } from 'htm/preact'
+import { useSignal } from '@preact/signals'
+import { ActionButton } from '../common/button'
+import { CARD_STANDARD } from '../common/card'
+import { operatorActionBusy, operatorSnapshot } from '../../operator-store'
+import type { OperatorActionDescriptor } from '../../types'
+import { actionTypeLabel, executeAction, normalizeStatus } from './helpers'
+
+const ADAPTED_KEEPER_ACTIONS = new Set([
+  'keeper_probe',
+  'keeper_recover',
+  'keeper_github_identity_status',
+  'keeper_github_identity_login_prepare',
+])
+
+const HANDLED_ELSEWHERE_ACTIONS = new Set([
+  'broadcast',
+  'keeper_message',
+  'namespace_pause',
+  'namespace_resume',
+  'room_pause',
+  'room_resume',
+  'social_sweep',
+  'task_inject',
+])
+
+function visibleKeeperAction(action: OperatorActionDescriptor): boolean {
+  if (action.target_type !== 'keeper') return false
+  return ADAPTED_KEEPER_ACTIONS.has(action.action_type)
+    || !HANDLED_ELSEWHERE_ACTIONS.has(action.action_type)
+}
+
+function actionDescription(action: OperatorActionDescriptor): string {
+  const description = action.description?.trim()
+  if (description) return description
+  switch (action.action_type) {
+    case 'keeper_probe':
+      return '선택한 keeper의 상태와 진단 정보를 확인합니다.'
+    case 'keeper_recover':
+      return '선택한 keeper를 복구 플로우로 넘깁니다.'
+    case 'keeper_github_identity_status':
+      return '선택한 keeper의 GitHub identity 상태를 확인합니다.'
+    case 'keeper_github_identity_login_prepare':
+      return '선택한 keeper의 GitHub login 준비 정보를 생성합니다.'
+    default:
+      return '서버 catalog에는 있지만 아직 전용 UI adapter가 없습니다.'
+  }
+}
+
+export function KeeperUtilitiesPanel() {
+  const selectedKeeper = useSignal('')
+  const snapshot = operatorSnapshot.value
+  const busy = operatorActionBusy.value
+  const actions = (snapshot?.available_actions ?? []).filter(visibleKeeperAction)
+  if (actions.length === 0) return null
+
+  const onlineKeepers = (snapshot?.keepers ?? [])
+    .filter(keeper => normalizeStatus(keeper.status) !== 'offline')
+  const selectedName = onlineKeepers.some(keeper => keeper.name === selectedKeeper.value)
+    ? selectedKeeper.value
+    : (onlineKeepers[0]?.name ?? '')
+
+  async function runAction(action: OperatorActionDescriptor) {
+    if (!selectedName || !ADAPTED_KEEPER_ACTIONS.has(action.action_type)) return
+    await executeAction({
+      action_type: action.action_type,
+      target_type: 'keeper',
+      target_id: selectedName,
+      payload: {},
+      successMessage: `${selectedName} ${actionTypeLabel(action.action_type)} 실행을 요청했습니다`,
+    })
+  }
+
+  return html`
+    <section class="${CARD_STANDARD} flex flex-col gap-3" data-testid="keeper-utilities-panel">
+      <div class="flex items-start justify-between gap-3">
+        <div class="min-w-0">
+          <h3 class="text-sm font-semibold text-[var(--text-strong)]">키퍼 유틸리티</h3>
+          <p class="mt-1 text-xs leading-[1.45] text-[var(--text-muted)]">
+            서버 available_actions catalog 기준으로 노출합니다.
+          </p>
+        </div>
+        <select
+          class="shrink-0 rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-xs text-[var(--text-body)] transition-colors cursor-pointer min-w-36 focus-visible:outline-none focus-visible:border-[rgba(71,184,255,0.5)] focus-visible:ring-1 focus-visible:ring-[rgba(71,184,255,0.35)]"
+          aria-label="키퍼 유틸리티 대상"
+          value=${selectedName}
+          disabled=${busy || onlineKeepers.length === 0}
+          onChange=${(event: Event) => { selectedKeeper.value = (event.target as HTMLSelectElement).value }}
+        >
+          ${onlineKeepers.length === 0
+            ? html`<option value="">온라인 keeper 없음</option>`
+            : onlineKeepers.map(keeper => html`
+                <option key=${keeper.name} value=${keeper.name}>${keeper.name}</option>
+              `)}
+        </select>
+      </div>
+
+      <div class="grid gap-2">
+        ${actions.map(action => {
+          const adapted = ADAPTED_KEEPER_ACTIONS.has(action.action_type)
+          const disabled = busy || !selectedName || !adapted
+          return html`
+            <article
+              key=${`${action.target_type}:${action.action_type}`}
+              class="rounded border border-[var(--white-8)] bg-[var(--white-2)] p-3"
+              data-testid="keeper-utility-action"
+            >
+              <div class="flex items-start justify-between gap-3">
+                <div class="min-w-0">
+                  <div class="text-xs font-semibold text-[var(--text-strong)]">${actionTypeLabel(action.action_type)}</div>
+                  <div class="mt-1 text-2xs leading-[1.45] text-[var(--text-muted)]">${actionDescription(action)}</div>
+                  ${adapted
+                    ? null
+                    : html`<div class="mt-1 text-2xs font-medium text-warn">UI adapter pending</div>`}
+                </div>
+                <${ActionButton}
+                  variant=${adapted ? 'subtle' : 'ghost'}
+                  size="sm"
+                  disabled=${disabled}
+                  onClick=${() => { void runAction(action) }}
+                >
+                  ${adapted ? (action.confirm_required ? '요청' : '실행') : '대기'}
+                <//>
+              </div>
+            </article>
+          `
+        })}
+      </div>
+    </section>
+  `
+}

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -861,6 +861,8 @@ interface KeeperConfigExecution {
   active_model: string
   active_model_label?: string | null
   last_model_used_label?: string | null
+  per_provider_timeout_sec?: number | null
+  per_provider_timeout_mode: 'override' | 'turn_budget_heuristic' | string
   verify: boolean
   selected_cascade_name: string
   selected_cascade_canonical: string

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -527,19 +527,9 @@ export interface OperatorSnapshot {
   available_actions: OperatorActionDescriptor[]
 }
 
-type OperatorActionType =
-  | 'broadcast'
-  | 'namespace_pause'
-  | 'namespace_resume'
-  | 'room_pause'
-  | 'room_resume'
-  | 'social_sweep'
-  | 'task_inject'
-  | 'keeper_message'
-  | 'keeper_probe'
-  | 'keeper_recover'
+type OperatorActionType = string
 
-type OperatorTargetType = 'root' | 'namespace' | 'room' | 'keeper'
+type OperatorTargetType = string
 
 export interface OperatorActionRequest {
   actor: string

--- a/dashboard/src/types/governance.ts
+++ b/dashboard/src/types/governance.ts
@@ -147,6 +147,9 @@ export interface GovernanceTimelineEvent {
 export interface GovernanceJudgeSummary {
   judge_online?: boolean
   refreshing?: boolean
+  status?: 'online' | 'refreshing' | 'stale_visible' | 'offline' | 'backoff' | string
+  degraded_reason?: 'timeout' | 'error' | 'backoff' | string | null
+  cached_judgments_visible?: boolean
   generated_at?: string | null
   expires_at?: string | null
   model_used?: string | null

--- a/lib/dashboard/dashboard_governance.ml
+++ b/lib/dashboard/dashboard_governance.ml
@@ -17,6 +17,9 @@ let judge_json_of_runtime (runtime : Dashboard_governance_judge.runtime_snapshot
     [
       ("judge_online", `Bool runtime.judge_online);
       ("refreshing", `Bool runtime.refreshing);
+      ("status", `String runtime.status);
+      ("degraded_reason", string_option_json runtime.degraded_reason);
+      ("cached_judgments_visible", `Bool runtime.cached_judgments_visible);
       ("generated_at", timestamp_option_json runtime.generated_at runtime.generated_at_unix);
       ("expires_at", timestamp_option_json runtime.expires_at runtime.expires_at_unix);
       ("model_used", string_option_json runtime.model_used);

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -3,6 +3,9 @@ open Yojson.Safe.Util
 type runtime_snapshot = {
   judge_online : bool;
   refreshing : bool;
+  status : string;
+  degraded_reason : string option;
+  cached_judgments_visible : bool;
   generated_at : string option;
   generated_at_unix : float option;
   expires_at : string option;
@@ -17,6 +20,8 @@ type state = {
   mutable started : bool;
   mutable refreshing : bool;
   mutable judge_online : bool;
+  mutable runtime_status : string;
+  mutable degraded_reason : string option;
   mutable generated_at_unix : float option;
   mutable expires_at_unix : float option;
   mutable generated_at : string option;
@@ -80,6 +85,36 @@ let enabled () = Env_config.Dashboard_config.governance_judge_enabled
 let keeper_name = "governance-judge"
 let backoff_status = "Backoff: local slots saturated"
 
+let status_online = "online"
+let status_refreshing = "refreshing"
+let status_stale_visible = "stale_visible"
+let status_offline = "offline"
+let status_backoff = "backoff"
+
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  if needle_len = 0 then true
+  else if needle_len > haystack_len then false
+  else
+    let rec loop index =
+      if index + needle_len > haystack_len then false
+      else if String.sub haystack index needle_len = needle then true
+      else loop (index + 1)
+    in
+    loop 0
+
+let degraded_reason_of_error message =
+  let lower = String.lowercase_ascii message in
+  if
+    contains_substring lower "timeout"
+    || contains_substring lower "timed out"
+    || contains_substring lower "deadline"
+  then
+    "timeout"
+  else
+    "error"
+
 let cached_judgments_still_fresh ~now_ts (st : state) =
   match st.expires_at_unix with
   | Some expires_at -> expires_at > now_ts
@@ -90,7 +125,11 @@ let mark_refresh_failure ~now_ts (st : state) ~message =
   (* Preserve the last good snapshot while its TTL is still valid. A slow
      or timing-out judge should degrade to stale-but-visible rather than
      immediately flipping the dashboard offline. *)
-  st.judge_online <- cached_judgments_still_fresh ~now_ts st;
+  let cache_fresh = cached_judgments_still_fresh ~now_ts st in
+  st.judge_online <- cache_fresh;
+  st.runtime_status <-
+    (if cache_fresh then status_stale_visible else status_offline);
+  st.degraded_reason <- Some (degraded_reason_of_error message);
   st.last_error <- Some message
 
 let get_state base_path =
@@ -104,6 +143,8 @@ let get_state base_path =
             started = false;
             refreshing = false;
             judge_online = false;
+            runtime_status = status_offline;
+            degraded_reason = None;
             generated_at_unix = None;
             expires_at_unix = None;
             generated_at = None;
@@ -235,14 +276,42 @@ let fresh_judgments_json ~base_path ~limit =
 let runtime_status_at ~now_ts base_path =
   let st = get_state base_path in
   with_lock st (fun () ->
+      let cache_fresh = cached_judgments_still_fresh ~now_ts st in
+      let status =
+        if st.refreshing then status_refreshing
+        else
+          match st.runtime_status with
+          | value when value = status_online && cache_fresh -> status_online
+          | value when value = status_stale_visible && cache_fresh ->
+              status_stale_visible
+          | value when value = status_backoff -> status_backoff
+          | _ when st.judge_online && cache_fresh -> status_online
+          | _ -> status_offline
+      in
+      let judge_online =
+        match status with
+        | value when value = status_online || value = status_stale_visible -> true
+        | value when value = status_refreshing -> st.judge_online && cache_fresh
+        | _ -> false
+      in
+      let degraded_reason =
+        match status with
+        | value when value = status_backoff -> Some "backoff"
+        | value when value = status_stale_visible || value = status_offline ->
+            (match st.degraded_reason, st.last_error with
+             | Some reason, _ -> Some reason
+             | None, Some message -> Some (degraded_reason_of_error message)
+             | None, None -> None)
+        | _ -> None
+      in
       {
-        judge_online =
-          st.judge_online
-          &&
-          (match st.expires_at_unix with
-          | Some expires_at -> now_ts < expires_at
-          | None -> false);
+        judge_online;
         refreshing = st.refreshing;
+        status;
+        degraded_reason;
+        cached_judgments_visible =
+          cache_fresh
+          && (status = status_stale_visible || status = status_backoff);
         generated_at = st.generated_at;
         generated_at_unix = st.generated_at_unix;
         expires_at = st.expires_at;
@@ -458,6 +527,8 @@ let refresh_once ~sw ~net
           let was_online = st.judge_online in
           st.refreshing <- false;
           st.judge_online <- false;
+          st.runtime_status <- status_backoff;
+          st.degraded_reason <- Some "backoff";
           st.last_error <- Some backoff_status;
           was_online)
     in
@@ -467,7 +538,10 @@ let refresh_once ~sw ~net
       Log.Governance.debug "backoff: local slots saturated (first cycle)"
   end
   else begin
-    with_lock st (fun () -> st.refreshing <- true);
+    with_lock st (fun () ->
+        st.refreshing <- true;
+        st.runtime_status <- status_refreshing;
+        st.degraded_reason <- None);
     match compute_judgments ~masc_tools ~dispatch ~build_facts with
     | Ok (model_used, generated_at, expires_at, judgments) ->
         Log.Governance.info
@@ -477,6 +551,8 @@ let refresh_once ~sw ~net
         with_lock st (fun () ->
             st.refreshing <- false;
             st.judge_online <- true;
+            st.runtime_status <- status_online;
+            st.degraded_reason <- None;
             st.generated_at <- Some generated_at;
             st.generated_at_unix <- Some (Types.parse_iso8601 generated_at);
             st.expires_at <- Some expires_at;

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -1241,6 +1241,13 @@ let keeper_config_json (config : Coord.config) (name : string)
           ("active_model", `String active_model);
           ("active_model_label", Json_util.string_opt_to_json active_model_label);
           ("last_model_used_label", Json_util.string_opt_to_json last_model_used_label);
+          ( "per_provider_timeout_sec",
+            Json_util.float_opt_to_json m.per_provider_timeout_s );
+          ( "per_provider_timeout_mode",
+            `String
+              (match m.per_provider_timeout_s with
+               | Some _ -> "override"
+               | None -> "turn_budget_heuristic") );
           ("verify", `Bool false);
         ]
       in

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -85,6 +85,12 @@ let test_empty_governance_structure () =
       let judge = json |> member "judge" in
       check bool "judge_online is false when no judge started" false
         (judge |> member "judge_online" |> to_bool);
+      check string "judge status is offline when no judge started" "offline"
+        (judge |> member "status" |> to_string);
+      check bool "cached judgments are not visible initially" false
+        (judge |> member "cached_judgments_visible" |> to_bool);
+      check bool "degraded_reason is null initially" true
+        (judge |> member "degraded_reason" = `Null);
       check string "keeper_name is governance-judge" "governance-judge"
         (judge |> member "keeper_name" |> to_string);
       check bool "model_used is null when no judge started" true
@@ -157,6 +163,8 @@ let test_runtime_status_and_judgments_are_live () =
       let judge = json |> member "judge" in
       check bool "judge section online" true
         (judge |> member "judge_online" |> to_bool);
+      check string "judge status is online" "online"
+        (judge |> member "status" |> to_string);
       check string "judge model uses runtime" "llama:qwen3.5"
         (judge |> member "model_used" |> to_string);
       let judgments = json |> member "judgments" |> to_list in
@@ -275,6 +283,12 @@ let test_refresh_failure_keeps_fresh_cache_online () =
       check bool "judge remains online while cache fresh" true
         status.judge_online;
       check bool "refreshing cleared" false status.refreshing;
+      check string "runtime status is stale_visible" "stale_visible"
+        status.status;
+      check (option string) "degraded_reason is timeout" (Some "timeout")
+        status.degraded_reason;
+      check bool "cached judgments remain visible" true
+        status.cached_judgments_visible;
       check (option string) "last_error recorded"
         (Some "Execution timed out after 60.0s") status.last_error;
       check (option string) "model preserved" (Some "glm:test")
@@ -301,8 +315,40 @@ let test_refresh_failure_marks_expired_cache_offline () =
       in
       check bool "judge goes offline when cache expired" false
         status.judge_online;
+      check string "runtime status is offline" "offline"
+        status.status;
+      check (option string) "degraded_reason is timeout" (Some "timeout")
+        status.degraded_reason;
+      check bool "cached judgments are hidden after expiry" false
+        status.cached_judgments_visible;
       check (option string) "last_error recorded"
         (Some "Execution timed out after 60.0s") status.last_error)
+
+let test_backoff_runtime_status_is_structured () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      with_test_fs env @@ fun () ->
+      let st = Lib.Dashboard_governance_judge.get_state dir in
+      let now = Unix.gettimeofday () in
+      Lib.Dashboard_governance_judge.with_lock st (fun () ->
+        st.refreshing <- false;
+        st.judge_online <- false;
+        st.runtime_status <- "backoff";
+        st.degraded_reason <- Some "backoff";
+        st.expires_at_unix <- Some (now +. 300.0);
+        st.last_error <- Some "Backoff: local slots saturated");
+      let status =
+        Lib.Dashboard_governance_judge.runtime_status_at ~now_ts:now dir
+      in
+      check bool "backoff is not reported online" false status.judge_online;
+      check string "runtime status is backoff" "backoff" status.status;
+      check (option string) "degraded_reason is backoff" (Some "backoff")
+        status.degraded_reason;
+      check bool "fresh cached judgments remain visible during backoff" true
+        status.cached_judgments_visible)
 
 let test_governance_monitoring_uses_live_runtime () =
   let dir = test_dir () in
@@ -571,6 +617,8 @@ let () =
             test_refresh_failure_keeps_fresh_cache_online;
           test_case "refresh failure marks expired cache offline" `Quick
             test_refresh_failure_marks_expired_cache_offline;
+          test_case "backoff runtime status is structured" `Quick
+            test_backoff_runtime_status_is_structured;
           test_case "monitoring uses live runtime" `Quick
             test_governance_monitoring_uses_live_runtime;
           test_case "dashboard exposes keeper approval queue" `Quick

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -1160,6 +1160,12 @@ proactive_enabled = true
         expected_default_models
         (json |> member "execution" |> member "models" |> to_list
        |> List.map to_string);
+      Alcotest.(check bool) "per-provider timeout is null by default" true
+        (json |> member "execution" |> member "per_provider_timeout_sec" = `Null);
+      Alcotest.(check string) "per-provider timeout mode uses heuristic"
+        "turn_budget_heuristic"
+        (json |> member "execution" |> member "per_provider_timeout_mode"
+       |> to_string);
       Alcotest.(check string) "cascade catalog source kind" "json"
         (json |> member "sources" |> member "cascade_catalog_source_kind"
        |> to_string);


### PR DESCRIPTION
## Summary
- expose keeper per-provider timeout and timeout mode from backend SSOT through dashboard config UI
- add structured governance judge runtime status so stale-but-visible cache does not collapse into offline/error UI
- render keeper utility actions from the operator `available_actions` catalog, with unsupported adapters shown as pending

## Verification
- `git diff --check`
- `dune build --root . test/test_dashboard_governance.exe --display short`
- `./_build/default/test/test_dashboard_governance.exe`
- `env MASC_INCLUDE_OPERATOR_CONTROL=true dune build --root . test/test_operator_control.exe --display short`
- `env MASC_INCLUDE_OPERATOR_CONTROL=true ./_build/default/test/test_operator_control.exe test operator 37`
- `npx tsc --noEmit --pretty false`
- `npx vitest run src/api/board.test.ts src/api/dashboard.test.ts src/components/governance.test.ts src/components/keeper-config-panel.test.ts src/components/ops/index.test.ts`
