### PR TITLE
[codex] Keeper sandbox production readiness

### DIFF
--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -280,6 +280,9 @@ spawn 시 인자로 직접 설정하는 필드.
 | `sandbox_profile` | string | `local` | 실행 샌드박스 프로필 (`local`, `docker`). 기본 모드의 `docker` 프로필은 git/gh 명령에 대해서만 런타임에 network+credential 마운트를 올릴 수 있다. hard mode에서는 `docker`만 허용된다. | `masc_keeper_up`의 `sandbox_profile` 인자 |
 | `network_mode` | string | `inherit` 또는 `none` | 샌드박스 네트워크 정책. `docker`는 기본 `none` (기본 모드의 git/gh dispatch만 `inherit`으로 승격). hard mode에서는 `none`만 허용된다. | `masc_keeper_up`의 `network_mode` 인자 |
 | `shared_memory_scope` | string | `disabled` | typed shared-memory lane. `room`이면 keeper-authorized `masc_team_memory_*`를 flattened `default` namespace에서 사용 가능 | `masc_keeper_up`의 `shared_memory_scope` 인자 |
+| `github_identity` | string | 없음 | keeper에 바인딩된 GitHub CLI identity 이름. `.masc/github-identities/<identity>/gh` bundle을 사용한다. | `keeper.toml` 선언 |
+| `git_identity_mode` | string | `keeper_alias` | git author를 keeper alias로 유지할지, 향후 GitHub identity와 결합할지 결정 | `keeper.toml` 선언 |
+| `active_goal_ids` | string[] | 없음 | 설정 시 `keeper_task_claim`이 해당 goal에 링크된 task만 claim | `keeper.toml` 선언 |
 
 ### 3.1.1 Sandbox Core V1 사용법
 
@@ -301,7 +304,7 @@ spawn 시 인자로 직접 설정하는 필드.
 - keeper shell write는 자기 sandbox 안에서만 허용된다. 현재 local/docker backend의 디스크 구현은 `.masc/playground/<keeper>/`이지만 keeper-facing 경로는 `.` / `mind` / `repos`이다.
 - `sandbox_profile=docker`는 keeper identity 전체에 적용된다. `keeper_bash`뿐 아니라 `keeper_fs_read`, `keeper_fs_edit`, `keeper_shell`의 read/write/git/gh 흐름도 Docker로 라우팅된다. 기본은 read-only rootfs, tmpfs `/tmp`, `cap-drop=ALL`, `no-new-privileges`, `pids-limit`, memory limit, private sandbox mount, network=`none`이다.
 - Docker 내부에서 더 자유로운 부트스트랩/설치가 필요하면 `MASC_KEEPER_SANDBOX_RELAX_FS=true`로 rootfs writable + executable `/tmp` 조합을 켤 수 있다. 이 경우에도 host mount 범위, `cap-drop=ALL`, `no-new-privileges`, pids/memory limit은 유지된다. hard mode에서는 이 완화가 거부된다.
-- 기본 모드의 git/gh dispatch: `sandbox_profile=docker` 에서 network가 필요한 `git`/`gh` 계열 명령(`keeper_bash`, `keeper_shell op=gh`, `keeper_shell op=git_clone`)은 한 명령 단위로 network=bridge + keeper-scoped `GH_CONFIG_DIR` 또는 legacy `~/.config/gh` / `~/.gitconfig` read-only mount + `GH_TOKEN` env forward 경로를 사용할 수 있다. 그 외 명령은 계속 network=none 의 hardened container 또는 turn-scoped `docker exec` runtime 으로 실행된다. Docker 라우트 응답에는 `via: "docker"`가 들어오고, git credential dispatch가 켜진 경우 `git_creds_enabled: true`도 함께 들어온다. 비활성화하려면 `MASC_KEEPER_SANDBOX_GIT_DISPATCH=false`. `~/.ssh` mount 는 `MASC_KEEPER_SANDBOX_SSH_DIR` 환경 변수로 명시 opt-in 시에만 활성화된다.
+- 기본 모드의 git/gh dispatch: `sandbox_profile=docker`에서 network가 필요한 `git`/`gh` 계열 명령(`keeper_bash`, `keeper_shell op=gh`, `keeper_shell op=git_clone`)은 한 명령 단위로 network=bridge + read-only credential mount 경로를 사용할 수 있다. `github_identity`가 바인딩된 keeper는 `.masc/github-identities/<identity>/gh`만 사용하고, bundle이 없으면 fail-closed 된다. 바인딩이 없는 keeper만 legacy `.masc/gh-auth` / sandbox env fallback 경로를 쓴다. 그 외 명령은 계속 network=none의 hardened container 또는 turn-scoped `docker exec` runtime으로 실행된다. Docker 라우트 응답에는 `via: "docker"`가 들어오고, git credential dispatch가 켜진 경우 `git_creds_enabled: true`도 함께 들어온다. 비활성화하려면 `MASC_KEEPER_SANDBOX_GIT_DISPATCH=false`. `~/.ssh` mount는 `MASC_KEEPER_SANDBOX_SSH_DIR` 환경 변수로 명시 opt-in 시에만 활성화된다.
 - hard mode: `MASC_KEEPER_SANDBOX_HARD_MODE=true`는 `sandbox_profile=docker`, `network_mode=none`, `github_identity`를 강제한다. Docker container는 `git`/`gh` 때문에 bridge/host network로 승격되지 않고, host `~/.config/gh`, `~/.gitconfig`, `~/.ssh`, `GH_TOKEN` fallback도 비활성화된다. `keeper_bash`에서 raw `gh ...`는 구조화 오류로 막히며, `keeper_shell op=gh`와 `keeper_shell op=git_clone`만 host-side broker가 keeper-scoped `GH_CONFIG_DIR=$base_path/.masc/github-identities/<identity>/gh`로 검증 후 실행한다. hard mode 라우트 응답은 `via: "brokered"`를 노출한다.
 - hard mode runtime preflight는 Docker `SecurityOptions`에서 `rootless`와 `userns`를 모두 요구한다. 현재 Docker Desktop/rootful daemon처럼 둘 중 하나라도 없으면 `doctor`와 keeper startup에서 fail-closed 된다.
 - 기본 sandbox 이미지는 `masc-keeper-sandbox:local`이다. Docker keeper를 올리기 전에 `scripts/build-keeper-sandbox-image.sh`를 실행해 이미지를 만들고, smoke 검증은 `scripts/keeper-sandbox-smoke.sh`를 사용한다.
@@ -823,8 +826,8 @@ materialize될 수 있지만, 정식 edit surface는 `profile.json`과 `keeper.t
 [`docs/KEEPER-FILE-MODEL.md` §2 Keeper Declaration](./KEEPER-FILE-MODEL.md#2-keeper-declaration)을 참조한다. 요약:
 
 - **Canonical minimal**: `[keeper]` 테이블에 `persona_name`만. 나머지는 persona 기본값에서 해석.
-- **Overlay fields**: `goal`, `tool_preset`, `tool_also_allow`, `cascade_name`, `sandbox_profile`, `network_mode`, `shared_memory_scope` 등 배치별 override 전용.
-- **Allowed value sets**: `tool_preset ∈ {minimal, social, messaging, coding, research, delivery, full}`, `sandbox_profile ∈ {local, docker}`, `network_mode ∈ {none, inherit}`, `shared_memory_scope ∈ {disabled, room}`, `social_model ∈ {bdi_speech_v1, magentic_ledger_v1}`, `cascade_name`은 `cascade.json`에 `<name>_models` 키로 존재해야 함.
+- **Overlay fields**: `goal`, `tool_preset`, `tool_also_allow`, `cascade_name`, `sandbox_profile`, `network_mode`, `shared_memory_scope`, `github_identity`, `git_identity_mode`, `active_goal_ids` 등 배치별 override 전용.
+- **Allowed value sets**: `tool_preset ∈ {minimal, social, messaging, coding, research, delivery, full}`, `sandbox_profile ∈ {local, docker}`, `network_mode ∈ {none, inherit}`, `shared_memory_scope ∈ {disabled, room}`, `git_identity_mode ∈ {keeper_alias, github_identity}`, `social_model ∈ {bdi_speech_v1, magentic_ledger_v1}`, `cascade_name`은 `cascade.json`에 `<name>_models` 키로 존재해야 함.
 - **Removed / hard-rejected**: `also_allow` (top-level TOML alias), `models`, `allowed_models`, `active_model`, `presence_keepalive*`, `trigger_mode`, `initiative_*`, `policy_mode`, `policy_shell_mode`. 로드 시 에러로 실패한다.
 - **Unknown keys**: canonical/removed 둘 다 아닌 key는 **boot 시 warning** 후 무시된다 (`keeper TOML <path> has unknown keys: ...`). 과거에 `legacy_scope`/`scope_kind` 같은 dead config가 축적된 적이 있으므로 warning을 발견하면 정리한다.
 

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -308,6 +308,7 @@ spawn 시 인자로 직접 설정하는 필드.
 - hard mode: `MASC_KEEPER_SANDBOX_HARD_MODE=true`는 `sandbox_profile=docker`, `network_mode=none`, `github_identity`를 강제한다. Docker container는 `git`/`gh` 때문에 bridge/host network로 승격되지 않고, host `~/.config/gh`, `~/.gitconfig`, `~/.ssh`, `GH_TOKEN` fallback도 비활성화된다. `keeper_bash`에서 raw `gh ...`는 구조화 오류로 막히며, `keeper_shell op=gh`와 `keeper_shell op=git_clone`만 host-side broker가 keeper-scoped `GH_CONFIG_DIR=$base_path/.masc/github-identities/<identity>/gh`로 검증 후 실행한다. hard mode 라우트 응답은 `via: "brokered"`를 노출한다.
 - hard mode runtime preflight는 Docker `SecurityOptions`에서 `rootless`와 `userns`를 모두 요구한다. 현재 Docker Desktop/rootful daemon처럼 둘 중 하나라도 없으면 `doctor`와 keeper startup에서 fail-closed 된다.
 - 기본 sandbox 이미지는 `masc-keeper-sandbox:local`이다. Docker keeper를 올리기 전에 `scripts/build-keeper-sandbox-image.sh`를 실행해 이미지를 만들고, smoke 검증은 `scripts/keeper-sandbox-smoke.sh`를 사용한다.
+- keeper Docker 컨테이너에는 `masc.mcp.component=keeper-sandbox`와 base path hash 라벨이 붙는다. 새 컨테이너 시작 전 같은 base path 범위의 오래된 MASC keeper 컨테이너만 best-effort로 정리한다. 조정값은 `MASC_KEEPER_SANDBOX_CLEANUP_ENABLED`, `MASC_KEEPER_SANDBOX_CLEANUP_STALE_AFTER_SEC`, `MASC_KEEPER_SANDBOX_CLEANUP_INTERVAL_SEC`이다.
 - `shared_memory_scope=room`은 공용 writable mount가 아니라 flattened `default` namespace typed lane만 연다.
 - team memory 도구는 keeper tool surface에도 노출되어야 하므로 preset에 없다면 `tool_also_allow` 또는 `tool_access.also_allow`로 명시해야 한다.
 

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -603,6 +603,23 @@ module KeeperSandbox = struct
     hard_mode ()
     || get_bool ~default:false "MASC_KEEPER_SANDBOX_REQUIRE_USERNS"
 
+  (** Best-effort cleanup for stale keeper-owned Docker containers.
+      Containers are removed only when they carry the MASC keeper sandbox
+      labels, so this never prunes arbitrary operator containers. *)
+  let cleanup_enabled () =
+    get_bool ~default:true "MASC_KEEPER_SANDBOX_CLEANUP_ENABLED"
+
+  (** Stale running containers older than this threshold are eligible for
+      cleanup even if the recorded owner pid appears alive. *)
+  let cleanup_stale_after_sec () =
+    float_of_int
+      (max 60 (get_int ~default:21600 "MASC_KEEPER_SANDBOX_CLEANUP_STALE_AFTER_SEC"))
+
+  (** Minimum interval between automatic cleanup sweeps in one server process. *)
+  let cleanup_interval_sec () =
+    float_of_int
+      (max 10 (get_int ~default:300 "MASC_KEEPER_SANDBOX_CLEANUP_INTERVAL_SEC"))
+
   (** Docker git-credential dispatch: when true, keeper_bash commands
       beginning with "git " or "gh " run in a Docker container with
       network_mode=inherit and read-only mounts of ~/.config/gh and

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -548,6 +548,12 @@ let keeper_sandbox_entries =
       "Fail closed unless Docker reports userns support";
     entry ~default:"true" "MASC_KEEPER_SANDBOX_GIT_DISPATCH"
       "Enable legacy Docker git/gh bridge dispatch when hard mode is off";
+    entry ~default:"true" "MASC_KEEPER_SANDBOX_CLEANUP_ENABLED"
+      "Best-effort cleanup for stale MASC keeper sandbox containers";
+    entry ~default:"21600" "MASC_KEEPER_SANDBOX_CLEANUP_STALE_AFTER_SEC"
+      "Age threshold for stale keeper sandbox container cleanup";
+    entry ~default:"300" "MASC_KEEPER_SANDBOX_CLEANUP_INTERVAL_SEC"
+      "Minimum seconds between automatic keeper sandbox cleanup sweeps";
   ]
 
 let economy_entries =

--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -45,6 +45,131 @@ let first_nonempty_line output =
   |> List.map String.trim
   |> List.find_opt (fun s -> s <> "")
 
+let policy_string_array_of_line ~key line =
+  let trimmed = String.trim line in
+  let prefix = key ^ " =" in
+  if not (String.starts_with ~prefix trimmed) then
+    None
+  else
+    let raw =
+      String.sub trimmed (String.length prefix)
+        (String.length trimmed - String.length prefix)
+      |> String.trim
+    in
+    if String.length raw < 2 || raw.[0] <> '[' || raw.[String.length raw - 1] <> ']'
+    then
+      Some []
+    else
+      let body = String.sub raw 1 (String.length raw - 2) in
+      let items =
+        body
+        |> String.split_on_char ','
+        |> List.map String.trim
+        |> List.filter (fun s -> s <> "")
+        |> List.filter_map (fun token ->
+             let len = String.length token in
+             if len >= 2 && token.[0] = '"' && token.[len - 1] = '"' then
+               Some (String.sub token 1 (len - 2) |> String.lowercase_ascii)
+             else
+               None)
+      in
+      Some items
+
+let load_git_clone_policy ~base_path =
+  let path = Filename.concat (Filename.concat base_path "config") "tool_policy.toml" in
+  match Safe_ops.read_file_safe path with
+  | Error _ -> [], []
+  | Ok content ->
+      let rec loop in_git_clone allowed denied = function
+        | [] -> allowed, denied
+        | raw_line :: rest ->
+            let line = String.trim raw_line in
+            if line = "" || String.starts_with ~prefix:"#" line then
+              loop in_git_clone allowed denied rest
+            else if String.length line >= 2 && line.[0] = '[' && line.[String.length line - 1] = ']'
+            then
+              loop (String.equal line "[git_clone]") allowed denied rest
+            else if not in_git_clone then
+              loop in_git_clone allowed denied rest
+            else
+              let allowed =
+                match policy_string_array_of_line ~key:"allowed_orgs" line with
+                | Some items -> items
+                | None -> allowed
+              in
+              let denied =
+                match policy_string_array_of_line ~key:"denied_repos" line with
+                | Some items -> items
+                | None -> denied
+              in
+              loop in_git_clone allowed denied rest
+      in
+      loop false [] [] (String.split_on_char '\n' content)
+
+let extract_github_org_repo url =
+  let lc = String.lowercase_ascii (String.trim url) in
+  let prefixes =
+    [
+      "https://github.com/";
+      "git@github.com:";
+      "ssh://git@github.com/";
+    ]
+  in
+  let after_prefix =
+    List.find_map
+      (fun prefix ->
+         if String.starts_with ~prefix lc then
+           Some
+             (String.sub lc (String.length prefix)
+                (String.length lc - String.length prefix))
+         else None)
+      prefixes
+  in
+  match after_prefix with
+  | None -> None
+  | Some rest ->
+      let rest =
+        if String.ends_with ~suffix:"/" rest then
+          String.sub rest 0 (String.length rest - 1)
+        else rest
+      in
+      let stripped =
+        if String.ends_with ~suffix:".git" rest then
+          String.sub rest 0 (String.length rest - 4)
+        else rest
+      in
+      match String.split_on_char '/' stripped with
+      | [ org; repo ] when org <> "" && repo <> "" -> Some (org ^ "/" ^ repo)
+      | _ -> None
+
+let extract_github_org url =
+  match extract_github_org_repo url with
+  | Some org_repo -> (
+      match String.split_on_char '/' org_repo with
+      | org :: _ -> Some org
+      | [] -> None)
+  | None -> None
+
+let validate_clone_origin_url ~base_path url =
+  let allowed_orgs, denied_repos = load_git_clone_policy ~base_path in
+  if allowed_orgs = [] then
+    Error
+      "No allowed orgs configured for git clone (git_clone.allowed_orgs in tool_policy.toml)"
+  else
+    match extract_github_org url with
+    | None ->
+        Error (Printf.sprintf "Cannot parse GitHub org from URL: %s" url)
+    | Some org when not (List.mem org allowed_orgs) ->
+        Error
+          (Printf.sprintf
+             "GitHub org '%s' not in allowed list: %s. Use the actual GitHub owner from the clone URL; do not infer an org from local workspace path segments."
+             org (String.concat ", " allowed_orgs))
+    | Some _ -> (
+        match extract_github_org_repo url with
+        | Some org_repo when List.mem org_repo denied_repos ->
+            Error (Printf.sprintf "Repository '%s' is in the denied list" org_repo)
+        | _ -> Ok ())
+
 (** Check if directory is a git repository - delegates to Coord_git *)
 let is_git_repo config =
   Coord_git.is_git_repo ~base_path:config.base_path
@@ -463,52 +588,43 @@ let auto_provision_sandbox_clone ~config ~agent_name ~repos_dir ~repo_name =
                    op=git_clone explicitly."
                   repo_name repos_dir))
       else
-        let status, output =
-          run_argv_with_status [ "git"; "clone"; source_root; clone_path ]
-        in
-        if status <> Unix.WEXITED 0 then
-          Error
-            (partial_clone_error ~clone_path
-               ~msg:
-                 (Printf.sprintf
-                    "auto_provision_clone_failed: git clone from workspace repo %s \
-                     into %s failed: %s"
-                    source_root clone_path
-                    (let detail = String.trim output in
-                     if detail = "" then "(no output)" else detail)))
-        else (
-          match git_origin_url source_root with
-          | Some origin_url ->
-              let set_status, set_output =
-                run_argv_with_status
-                  [ "git"; "-C"; clone_path; "remote"; "set-url"; "origin";
-                    origin_url ]
-              in
-              if set_status <> Unix.WEXITED 0 then
-                Error
-                  (partial_clone_error ~clone_path
-                     ~msg:
-                       (Printf.sprintf
-                          "auto_provision_clone_failed: cloned %s into %s but \
-                           could not restore origin %s: %s"
-                          source_root clone_path origin_url
-                          (let detail = String.trim set_output in
-                           if detail = "" then "(no output)" else detail)))
-              else
-                Ok
-                  ( clone_path,
-                    Some
+        (match git_origin_url source_root with
+         | None ->
+             Error
+               (IoError
+                  (Printf.sprintf
+                     "auto_provision_clone_failed: workspace repo %s has no origin remote. \
+                      Sandbox auto-provision requires cloning from origin, not from the local checkout."
+                     source_root))
+         | Some origin_url -> (
+             match validate_clone_origin_url ~base_path:config.base_path origin_url with
+             | Error err ->
+                 Error
+                   (IoError
                       (Printf.sprintf
-                         "Sandbox clone auto-provisioned from workspace repo %s."
-                         source_root) )
-          | None ->
-              Ok
-                ( clone_path,
-                  Some
-                    (Printf.sprintf
-                       "Sandbox clone auto-provisioned from workspace repo %s \
-                        (origin remote unavailable on source clone)."
-                       source_root) ))
+                         "auto_provision_clone_failed: origin %s rejected by clone policy: %s"
+                         origin_url err))
+             | Ok () ->
+                 let status, output =
+                   run_argv_with_status [ "git"; "clone"; origin_url; clone_path ]
+                 in
+                 if status <> Unix.WEXITED 0 then
+                   Error
+                     (partial_clone_error ~clone_path
+                        ~msg:
+                          (Printf.sprintf
+                             "auto_provision_clone_failed: git clone from origin %s \
+                              into %s failed: %s"
+                             origin_url clone_path
+                             (let detail = String.trim output in
+                              if detail = "" then "(no output)" else detail)))
+                 else
+                   Ok
+                     ( clone_path,
+                       Some
+                         (Printf.sprintf
+                            "Sandbox clone auto-provisioned from origin %s (discovered via workspace repo %s)."
+                            origin_url source_root) )))
   | matches ->
       Error
         (workspace_repo_ambiguous_error ~repo_name ~search_root ~matches)

--- a/lib/keeper/keeper_docker_read.ml
+++ b/lib/keeper/keeper_docker_read.ml
@@ -60,7 +60,7 @@ let container_path_of_host ~config ~(meta : keeper_meta) ~host_path
 let build_docker_argv ~image ~container_name ~host_root ~croot
     ~uid ~gid ~seccomp_args ~command_argv =
   [
-    "docker";
+    Keeper_sandbox_runtime.docker_command ();
     "run";
     "--rm";
     "--name"; container_name;
@@ -123,6 +123,7 @@ let run_command_in_container_with_status ?turn_sandbox_runtime
         in
         let st, out =
           Process_eio.run_argv_with_status
+            ~env:(Unix.environment ())
             ~cwd:(Sys.getcwd ()) ~timeout_sec argv
         in
         let head_program =

--- a/lib/keeper/keeper_identity.ml
+++ b/lib/keeper/keeper_identity.ml
@@ -96,14 +96,15 @@ let canonical_keeper_name raw_name =
   let plen = String.length prefix in
   let alen = String.length trimmed in
   if trimmed = "" then None
+  else if is_keeper_agent_alias trimmed then
+    canonical_keeper_name_from_agent_name trimmed
+  else if alen > plen && String.sub trimmed 0 plen = prefix then
+    let candidate = String.sub trimmed plen (alen - plen) in
+    if Keeper_config.validate_name candidate then Some candidate else None
+  else if Keeper_config.validate_name trimmed then
+    Some trimmed
   else
-    match canonical_keeper_name_from_agent_name trimmed with
-    | Some _ as canonical -> canonical
-    | None when alen > plen && String.sub trimmed 0 plen = prefix ->
-        let candidate = String.sub trimmed plen (alen - plen) in
-        if Keeper_config.validate_name candidate then Some candidate else None
-    | None ->
-        if Keeper_config.validate_name trimmed then Some trimmed else None
+    canonical_keeper_name_from_agent_name trimmed
 
 type parsed_identity = {
   keeper_name : string;

--- a/lib/keeper/keeper_repo_readiness.ml
+++ b/lib/keeper/keeper_repo_readiness.ml
@@ -126,18 +126,52 @@ let inspect
     in
     (match workspace_matches with
      | [ source_root ] ->
-         common_fields "auto_provisionable" true
-           (Printf.sprintf
-              "Call masc_worktree_create with repo_name=%S; the sandbox clone \
-               will be auto-provisioned from workspace repo %s."
-              derived_repo_name source_root)
-           [
-             "exists", `Bool false;
-             "is_git_repo", `Bool false;
-             "has_origin", `Bool false;
-             "workspace_repo_match", `String source_root;
-             "auto_provision_on_worktree_create", `Bool true;
-           ]
+         (match Coord_worktree.git_origin_url source_root with
+          | Some origin_url -> (
+              match
+                Tool_code_write.validate_clone_url
+                  ~base_path:config.base_path origin_url
+              with
+              | Ok () ->
+                  common_fields "auto_provisionable" true
+                    (Printf.sprintf
+                       "Call masc_worktree_create with repo_name=%S; the sandbox clone \
+                        will be auto-provisioned from origin %s discovered via workspace repo %s."
+                       derived_repo_name origin_url source_root)
+                    [
+                      "exists", `Bool false;
+                      "is_git_repo", `Bool false;
+                      "has_origin", `Bool false;
+                      "workspace_repo_match", `String source_root;
+                      "workspace_repo_origin", `String origin_url;
+                      "auto_provision_on_worktree_create", `Bool true;
+                    ]
+              | Error err ->
+                  common_fields "workspace_origin_not_allowed" false
+                    (Printf.sprintf
+                       "Workspace repo %s points at origin %s, but clone policy rejected it: %s. \
+                        Update allowlist or use an approved repo."
+                       source_root origin_url err)
+                    [
+                      "exists", `Bool false;
+                      "is_git_repo", `Bool false;
+                      "has_origin", `Bool true;
+                      "workspace_repo_match", `String source_root;
+                      "workspace_repo_origin", `String origin_url;
+                      "auto_provision_on_worktree_create", `Bool false;
+                    ])
+          | None ->
+              common_fields "workspace_origin_unavailable" false
+                (Printf.sprintf
+                   "Workspace repo %s has no origin remote. Sandbox auto-provision requires cloning from origin."
+                   source_root)
+                [
+                  "exists", `Bool false;
+                  "is_git_repo", `Bool false;
+                  "has_origin", `Bool false;
+                  "workspace_repo_match", `String source_root;
+                  "auto_provision_on_worktree_create", `Bool false;
+                ])
      | _ :: _ as matches ->
          common_fields "ambiguous_workspace_repo" false
            (Printf.sprintf

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -1,9 +1,12 @@
 open Keeper_types
 
 let json_int_opt_member key json =
-  match Yojson.Safe.Util.member key json with
-  | `Int n -> Some n
-  | `Intlit raw -> int_of_string_opt raw
+  match json with
+  | `Assoc _ -> (
+      match Yojson.Safe.Util.member key json with
+      | `Int n -> Some n
+      | `Intlit raw -> int_of_string_opt raw
+      | _ -> None)
   | _ -> None
 
 let json_float_opt_member key json =
@@ -14,8 +17,11 @@ let json_float_opt_member key json =
   | _ -> None
 
 let json_string_opt_member key json =
-  match Yojson.Safe.Util.member key json with
-  | `String value when String.trim value <> "" -> Some value
+  match json with
+  | `Assoc _ -> (
+      match Yojson.Safe.Util.member key json with
+      | `String value when String.trim value <> "" -> Some value
+      | _ -> None)
   | _ -> None
 
 let json_string_opt_value = function

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -102,6 +102,259 @@ let dedupe_keep_order values =
         true))
     values
 
+type cleanup_result =
+  {
+    scanned : int;
+    removed : int;
+    errors : string list;
+  }
+
+let sandbox_component_label_key = "masc.mcp.component"
+let sandbox_component_label_value = "keeper-sandbox"
+let sandbox_base_path_hash_label_key = "masc.mcp.base_path_hash"
+let sandbox_keeper_label_key = "masc.mcp.keeper"
+let sandbox_kind_label_key = "masc.mcp.kind"
+let sandbox_owner_pid_label_key = "masc.mcp.owner_pid"
+let sandbox_started_at_label_key = "masc.mcp.started_at"
+let sandbox_network_label_key = "masc.mcp.network"
+
+let strip_trailing_slashes path =
+  let rec loop i =
+    if i > 0 && path.[i - 1] = '/' then loop (i - 1) else i
+  in
+  let len = loop (String.length path) in
+  if len = String.length path then path else String.sub path 0 len
+
+let normalize_base_path_for_hash base_path =
+  let abs =
+    if Filename.is_relative base_path then
+      Filename.concat (Sys.getcwd ()) base_path
+    else
+      base_path
+  in
+  strip_trailing_slashes abs
+
+let base_path_hash base_path =
+  Digest.to_hex (Digest.string (normalize_base_path_for_hash base_path))
+
+let sanitize_label_value value =
+  String.map
+    (function
+      | 'a' .. 'z'
+      | 'A' .. 'Z'
+      | '0' .. '9'
+      | '_'
+      | '-'
+      | '.' as c ->
+          c
+      | _ -> '_')
+    value
+
+let docker_label_args ~base_path ~keeper_name ~container_kind ~network_label () =
+  let label key value = [ "--label"; key ^ "=" ^ value ] in
+  label sandbox_component_label_key sandbox_component_label_value
+  @ label sandbox_base_path_hash_label_key (base_path_hash base_path)
+  @ label sandbox_keeper_label_key (sanitize_label_value keeper_name)
+  @ label sandbox_kind_label_key (sanitize_label_value container_kind)
+  @ label sandbox_owner_pid_label_key (string_of_int (Unix.getpid ()))
+  @ label sandbox_started_at_label_key
+      (Printf.sprintf "%.3f" (Unix.gettimeofday ()))
+  @ label sandbox_network_label_key (sanitize_label_value network_label)
+
+type inspected_container =
+  {
+    owner_pid : int option;
+    started_at : float option;
+    running : bool option;
+  }
+
+let nonempty_lines out =
+  out
+  |> String.split_on_char '\n'
+  |> List.map String.trim
+  |> List.filter (fun line -> line <> "")
+
+let int_opt text =
+  try Some (int_of_string (String.trim text)) with
+  | Failure _ -> None
+
+let float_opt text =
+  try Some (float_of_string (String.trim text)) with
+  | Failure _ -> None
+
+let bool_opt text =
+  match String.lowercase_ascii (String.trim text) with
+  | "true" -> Some true
+  | "false" -> Some false
+  | _ -> None
+
+let parse_inspect_line line =
+  match String.split_on_char '\t' line with
+  | [ owner_pid; started_at; running ] ->
+      Ok
+        {
+          owner_pid = int_opt owner_pid;
+          started_at = float_opt started_at;
+          running = bool_opt running;
+        }
+  | _ ->
+      Error
+        (Printf.sprintf "unexpected docker inspect cleanup payload: %s"
+           (Worker_dev_tools.truncate_for_log line))
+
+let pid_alive pid =
+  if pid <= 0 then
+    false
+  else
+    try
+      Unix.kill pid 0;
+      true
+    with
+    | Unix.Unix_error (Unix.ESRCH, _, _) -> false
+    | Unix.Unix_error (Unix.EPERM, _, _) -> true
+    | Unix.Unix_error _ -> false
+
+let should_remove_container ~now ~max_age_sec inspected =
+  let stopped =
+    match inspected.running with
+    | Some false -> true
+    | Some true | None -> false
+  in
+  let owner_dead =
+    match inspected.owner_pid with
+    | Some pid -> not (pid_alive pid)
+    | None -> false
+  in
+  let expired =
+    match inspected.started_at with
+    | Some started_at -> now -. started_at > max_age_sec
+    | None -> false
+  in
+  stopped || owner_dead || expired
+
+let inspect_cleanup_container ~container_id ~timeout_sec =
+  let format =
+    "{{ index .Config.Labels \""
+    ^ sandbox_owner_pid_label_key
+    ^ "\" }}\t{{ index .Config.Labels \""
+    ^ sandbox_started_at_label_key
+    ^ "\" }}\t{{ .State.Running }}"
+  in
+  let st, out =
+    Process_eio.run_argv_with_status
+      ~cwd:(Sys.getcwd ())
+      ~timeout_sec
+      [ "docker"; "inspect"; "--format"; format; container_id ]
+  in
+  if st <> Unix.WEXITED 0 then
+    Error
+      (Printf.sprintf "docker inspect failed for cleanup container %s: %s"
+         container_id
+         (Worker_dev_tools.truncate_for_log out))
+  else
+    match nonempty_lines out with
+    | line :: _ -> parse_inspect_line line
+    | [] ->
+        Error
+          (Printf.sprintf
+             "docker inspect returned no cleanup metadata for container %s"
+             container_id)
+
+let remove_cleanup_container ~container_id ~timeout_sec =
+  let st, out =
+    Process_eio.run_argv_with_status
+      ~cwd:(Sys.getcwd ())
+      ~timeout_sec
+      [ "docker"; "rm"; "-f"; container_id ]
+  in
+  if st = Unix.WEXITED 0 then
+    Ok ()
+  else
+    Error
+      (Printf.sprintf "docker rm -f failed for cleanup container %s: %s"
+         container_id
+         (Worker_dev_tools.truncate_for_log out))
+
+let cleanup_stale_containers ?(now = Unix.gettimeofday ())
+    ?(max_age_sec = Env_config_keeper.KeeperSandbox.cleanup_stale_after_sec ())
+    ~base_path ~timeout_sec () =
+  try
+    let st, out =
+      Process_eio.run_argv_with_status
+        ~cwd:(Sys.getcwd ())
+        ~timeout_sec
+        [
+          "docker";
+          "ps";
+          "-aq";
+          "--filter";
+          "label="
+          ^ sandbox_component_label_key
+          ^ "="
+          ^ sandbox_component_label_value;
+          "--filter";
+          "label="
+          ^ sandbox_base_path_hash_label_key
+          ^ "="
+          ^ base_path_hash base_path;
+        ]
+    in
+    if st <> Unix.WEXITED 0 then
+      {
+        scanned = 0;
+        removed = 0;
+        errors =
+          [
+            Printf.sprintf "docker ps failed during keeper sandbox cleanup: %s"
+              (Worker_dev_tools.truncate_for_log out);
+          ];
+      }
+    else
+      let container_ids = nonempty_lines out in
+      let scanned = List.length container_ids in
+      let removed, errors =
+        List.fold_left
+          (fun (removed, errors) container_id ->
+            match inspect_cleanup_container ~container_id ~timeout_sec with
+            | Error err -> (removed, err :: errors)
+            | Ok inspected ->
+                if should_remove_container ~now ~max_age_sec inspected then
+                  match remove_cleanup_container ~container_id ~timeout_sec with
+                  | Ok () -> (removed + 1, errors)
+                  | Error err -> (removed, err :: errors)
+                else
+                  (removed, errors))
+          (0, [])
+          container_ids
+      in
+      { scanned; removed; errors = List.rev errors }
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+      {
+        scanned = 0;
+        removed = 0;
+        errors =
+          [
+            Printf.sprintf "keeper sandbox cleanup failed: %s"
+              (Printexc.to_string exn);
+          ];
+      }
+
+let last_cleanup_at = ref 0.0
+
+let maybe_cleanup_stale_containers ~base_path ~timeout_sec () =
+  if not (Env_config_keeper.KeeperSandbox.cleanup_enabled ()) then
+    None
+  else
+    let now = Unix.gettimeofday () in
+    let interval = Env_config_keeper.KeeperSandbox.cleanup_interval_sec () in
+    if now -. !last_cleanup_at < interval then
+      None
+    else (
+      last_cleanup_at := now;
+      Some (cleanup_stale_containers ~now ~base_path ~timeout_sec ()))
+
 let docker_image_present ~image ~timeout_sec =
   if String.trim image = "" then
     Error "keeper sandbox docker image is not configured"

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -6,12 +6,31 @@
     configured hardening requirements without forming a module
     dependency cycle. *)
 
+let docker_command () =
+  let bin = "docker" in
+  match Sys.getenv_opt "PATH" with
+  | None -> bin
+  | Some path ->
+      let rec loop = function
+        | [] -> bin
+        | dir :: rest ->
+            let dir = if dir = "" then "." else dir in
+            let candidate = Filename.concat dir bin in
+            (try
+               Unix.access candidate [ Unix.X_OK ];
+               candidate
+             with
+             | Unix.Unix_error _ -> loop rest)
+      in
+      loop (String.split_on_char ':' path)
+
 let docker_info_security_options ~timeout_sec =
   let st, out =
     Process_eio.run_argv_with_status
+      ~env:(Unix.environment ())
       ~cwd:(Sys.getcwd ())
       ~timeout_sec
-      [ "docker"; "info"; "--format"; "{{json .SecurityOptions}}" ]
+      [ docker_command (); "info"; "--format"; "{{json .SecurityOptions}}" ]
   in
   if st <> Unix.WEXITED 0 then
     Error
@@ -242,9 +261,10 @@ let inspect_cleanup_container ~container_id ~timeout_sec =
   in
   let st, out =
     Process_eio.run_argv_with_status
+      ~env:(Unix.environment ())
       ~cwd:(Sys.getcwd ())
       ~timeout_sec
-      [ "docker"; "inspect"; "--format"; format; container_id ]
+      [ docker_command (); "inspect"; "--format"; format; container_id ]
   in
   if st <> Unix.WEXITED 0 then
     Error
@@ -263,9 +283,10 @@ let inspect_cleanup_container ~container_id ~timeout_sec =
 let remove_cleanup_container ~container_id ~timeout_sec =
   let st, out =
     Process_eio.run_argv_with_status
+      ~env:(Unix.environment ())
       ~cwd:(Sys.getcwd ())
       ~timeout_sec
-      [ "docker"; "rm"; "-f"; container_id ]
+      [ docker_command (); "rm"; "-f"; container_id ]
   in
   if st = Unix.WEXITED 0 then
     Ok ()
@@ -281,10 +302,11 @@ let cleanup_stale_containers ?(now = Unix.gettimeofday ())
   try
     let st, out =
       Process_eio.run_argv_with_status
+        ~env:(Unix.environment ())
         ~cwd:(Sys.getcwd ())
         ~timeout_sec
         [
-          "docker";
+          docker_command ();
           "ps";
           "-aq";
           "--filter";
@@ -361,9 +383,10 @@ let docker_image_present ~image ~timeout_sec =
   else
     let st, out =
       Process_eio.run_argv_with_status
+        ~env:(Unix.environment ())
         ~cwd:(Sys.getcwd ())
         ~timeout_sec
-        [ "docker"; "image"; "inspect"; image ]
+        [ docker_command (); "image"; "inspect"; image ]
     in
     if st = Unix.WEXITED 0 then
       Ok ()
@@ -385,9 +408,10 @@ let docker_image_required_commands ~image ~timeout_sec =
   in
   let st, out =
     Process_eio.run_argv_with_status
+      ~env:(Unix.environment ())
       ~cwd:(Sys.getcwd ())
       ~timeout_sec
-      [ "docker"; "run"; "--rm"; "--network"; "none"; "--entrypoint"; "sh";
+      [ docker_command (); "run"; "--rm"; "--network"; "none"; "--entrypoint"; "sh";
         image; "-lc"; script ]
   in
   if st = Unix.WEXITED 0 then

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -40,6 +40,11 @@ type cleanup_result =
     errors : string list;
   }
 
+val docker_command : unit -> string
+(** Resolve the Docker CLI from the current [PATH]. This keeps Docker
+    calls deterministic after the Eio process manager has been
+    initialized and tests inject a fake [docker] binary. *)
+
 val docker_label_args :
   base_path:string ->
   keeper_name:string ->

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -33,6 +33,38 @@ type docker_preflight =
     next_actions : string list;
   }
 
+type cleanup_result =
+  {
+    scanned : int;
+    removed : int;
+    errors : string list;
+  }
+
+val docker_label_args :
+  base_path:string ->
+  keeper_name:string ->
+  container_kind:string ->
+  network_label:string ->
+  unit ->
+  string list
+(** Docker [--label] argv fragment for containers owned by the keeper
+    sandbox runtime. *)
+
+val cleanup_stale_containers :
+  ?now:float ->
+  ?max_age_sec:float ->
+  base_path:string ->
+  timeout_sec:float ->
+  unit ->
+  cleanup_result
+(** Best-effort cleanup for stale MASC keeper sandbox containers under the
+    same base path. Only containers with the keeper sandbox labels are
+    considered. *)
+
+val maybe_cleanup_stale_containers :
+  base_path:string -> timeout_sec:float -> unit -> cleanup_result option
+(** Throttled wrapper used before launching keeper Docker containers. *)
+
 val docker_preflight :
   timeout_sec:float -> unit -> docker_preflight option
 (** Global keeper sandbox preflight used by [doctor], keeper startup,

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -146,6 +146,10 @@ let run_docker_shell_command_with_status
        else
          "sandbox_profile=docker blocks nested container runtimes and host socket references")
   else
+    let _cleanup =
+      Keeper_sandbox_runtime.maybe_cleanup_stale_containers
+        ~base_path:config.base_path ~timeout_sec:2.0 ()
+    in
     match ensure_keeper_sandbox_runtime ~timeout_sec with
     | Error err -> sandbox_error err
     | Ok seccomp_args ->
@@ -202,6 +206,13 @@ let run_docker_shell_command_with_status
           "--rm";
           "--name";
           container_name;
+        ]
+        @ Keeper_sandbox_runtime.docker_label_args
+            ~base_path:config.base_path
+            ~keeper_name:meta.name
+            ~container_kind:"oneshot"
+            ~network_label ()
+        @ [
           "-i";
           "--user";
           Printf.sprintf "%d:%d" uid gid;

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -201,7 +201,7 @@ let run_docker_shell_command_with_status
       in
       let argv =
         [
-          "docker";
+          Keeper_sandbox_runtime.docker_command ();
           "run";
           "--rm";
           "--name";
@@ -244,6 +244,7 @@ let run_docker_shell_command_with_status
       (try
          let status, output =
            Process_eio.run_argv_with_status
+             ~env:(Unix.environment ())
              ~cwd:(Sys.getcwd ()) ~timeout_sec argv
          in
          if status <> Unix.WEXITED 0 then

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -104,6 +104,7 @@ let direct_turn_observation (meta : keeper_meta) :
     unclaimed_task_count = 0;
     failed_task_count = 0;
     pending_verification_count = 0;
+    backlog_updated_since_last_scheduled_autonomous = false;
     active_agent_count = 0;
     last_turn_budget = None;
     last_tools_used = [];

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -131,10 +131,15 @@ let start_container (t : t) ~(timeout_sec : float) =
   if String.trim image = "" then
     Error "keeper sandbox docker image is not configured"
   else
+    let _cleanup =
+      Keeper_sandbox_runtime.maybe_cleanup_stale_containers
+        ~base_path:t.config.base_path ~timeout_sec:2.0 ()
+    in
     match Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime ~timeout_sec with
     | Error _ as err -> err
     | Ok seccomp_args ->
         let container_name = container_name_of t in
+        let network_label = network_mode_to_string t.network_mode in
         let argv =
           [
             "docker";
@@ -143,6 +148,13 @@ let start_container (t : t) ~(timeout_sec : float) =
             "--rm";
             "--name";
             container_name;
+          ]
+          @ Keeper_sandbox_runtime.docker_label_args
+              ~base_path:t.config.base_path
+              ~keeper_name:t.meta.name
+              ~container_kind:"turn"
+              ~network_label ()
+          @ [
             "--user";
             Printf.sprintf "%d:%d" t.uid t.gid;
           ]
@@ -165,7 +177,7 @@ let start_container (t : t) ~(timeout_sec : float) =
               "--workdir";
               t.container_root;
               "--network";
-              network_mode_to_string t.network_mode;
+              network_label;
               image;
               "sh";
               "-lc";

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -99,6 +99,7 @@ let run_argv_with_status_retry_eintr ~timeout_sec argv =
   let rec loop attempts_left =
     let st, out =
       Process_eio.run_argv_with_status
+        ~env:(Unix.environment ())
         ~cwd:(Sys.getcwd ()) ~timeout_sec argv
     in
     match st with
@@ -115,6 +116,7 @@ let run_argv_with_stdin_and_status_retry_eintr ~timeout_sec ~stdin_content argv 
   let rec loop attempts_left =
     let st, out =
       Process_eio.run_argv_with_stdin_and_status
+        ~env:(Unix.environment ())
         ~cwd:(Sys.getcwd ()) ~timeout_sec ~stdin_content argv
     in
     match st with
@@ -142,7 +144,7 @@ let start_container (t : t) ~(timeout_sec : float) =
         let network_label = network_mode_to_string t.network_mode in
         let argv =
           [
-            "docker";
+            Keeper_sandbox_runtime.docker_command ();
             "run";
             "-d";
             "--rm";
@@ -211,7 +213,7 @@ let run_exec_with_status_once
       let container_cwd = container_cwd_of_host t ~host_cwd:cwd in
       let argv =
         [
-          "docker";
+          Keeper_sandbox_runtime.docker_command ();
           "exec";
           "--user";
           Printf.sprintf "%d:%d" t.uid t.gid;
@@ -313,6 +315,8 @@ let cleanup (t : t) =
   | Not_started -> ()
   | Running { container_name } ->
       t.state <- Not_started;
-      let argv = [ "docker"; "rm"; "-f"; container_name ] in
+      let argv =
+        [ Keeper_sandbox_runtime.docker_command (); "rm"; "-f"; container_name ]
+      in
       let _st, _out = run_argv_with_status_retry_eintr ~timeout_sec:5.0 argv in
       ()

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -39,6 +39,7 @@ type world_observation = {
   unclaimed_task_count : int;
   failed_task_count : int;
   pending_verification_count : int;
+  backlog_updated_since_last_scheduled_autonomous : bool;
   active_agent_count : int;
   last_turn_budget : (int * int) option;
   last_tools_used : string list;
@@ -208,8 +209,19 @@ let apply_message_cursor_updates (meta : keeper_meta)
     (fun acc (room_id, seq) -> set_room_cursor acc room_id seq)
     meta updates
 
+let backlog_updated_since_last_scheduled_autonomous
+    ~(meta : keeper_meta)
+    ~(backlog : Types.backlog) : bool =
+  let last_ts = meta.runtime.proactive_rt.last_ts in
+  if last_ts <= 0.0 then backlog.tasks <> []
+  else
+    match Resilience.Time.parse_iso8601_opt backlog.last_updated with
+    | Some updated_at -> updated_at > last_ts
+    | None -> false
+
 (** Read room backlog counts. *)
-let read_backlog_counts ~(config : Coord.config) : int * int * int =
+let read_backlog_counts ~(config : Coord.config) ~(meta : keeper_meta) :
+    int * int * int * bool =
   try
     let backlog = Coord.read_backlog config in
     let unclaimed =
@@ -238,12 +250,18 @@ let read_backlog_counts ~(config : Coord.config) : int * int * int =
              | Types.Done _ | Types.Cancelled _ -> false)
            backlog.tasks)
     in
-    (unclaimed, failed, pending_verification)
+    let backlog_updated_since_last_scheduled_autonomous =
+      backlog_updated_since_last_scheduled_autonomous ~meta ~backlog
+    in
+    ( unclaimed,
+      failed,
+      pending_verification,
+      backlog_updated_since_last_scheduled_autonomous )
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | ex ->
       Log.Keeper.warn "read_backlog_counts failed: %s" (Printexc.to_string ex);
-      (0, 0, 0)
+      (0, 0, 0, false)
 
 (** Count active agents in room. *)
 let count_active_agents ~(config : Coord.config) : int =
@@ -673,8 +691,11 @@ let observe ~(pending_board_events : pending_board_event list option)
   let pending_mentions, pending_scope_messages, message_cursor_updates =
     collect_message_scope ~config ~meta
   in
-  let unclaimed_task_count, failed_task_count, pending_verification_count =
-    read_backlog_counts ~config
+  let ( unclaimed_task_count,
+        failed_task_count,
+        pending_verification_count,
+        backlog_updated_since_last_scheduled_autonomous ) =
+    read_backlog_counts ~config ~meta
   in
   let active_agent_count = count_active_agents ~config in
   let idle_seconds = compute_idle_seconds ~meta in
@@ -729,6 +750,7 @@ let observe ~(pending_board_events : pending_board_event list option)
     unclaimed_task_count;
     failed_task_count;
     pending_verification_count;
+    backlog_updated_since_last_scheduled_autonomous;
     active_agent_count;
     last_turn_budget = None;
     last_tools_used = [];
@@ -932,6 +954,10 @@ let keeper_cycle_decision
           has_actionable_tasks
           && since_last_scheduled_autonomous >= task_reactive_cooldown
         in
+        let backlog_fresh =
+          has_actionable_tasks
+          && observation.backlog_updated_since_last_scheduled_autonomous
+        in
         let proactive_work_ready =
           proactive_work_signal_present ~meta observation
         in
@@ -943,7 +969,8 @@ let keeper_cycle_decision
            is ready to fire. Ref: #7226 claim-first + idle_gate observation. *)
         let should_run =
           proactive_work_ready
-          && (backlog_elapsed
+          && (backlog_fresh
+              || backlog_elapsed
               || (idle_gate_elapsed && cooldown_elapsed))
         in
         let provider_cooldown_remaining_sec =
@@ -987,7 +1014,7 @@ let keeper_cycle_decision
                  then Some (Task_backlog
                               { unclaimed = observation.unclaimed_task_count;
                                 failed = observation.failed_task_count }) else None);
-                (if backlog_elapsed
+                (if backlog_fresh || backlog_elapsed
                  then Some Task_reactive_cooldown_elapsed else None);
               ]
               |> List.filter_map Fun.id

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -72,6 +72,11 @@ type world_observation = {
   pending_verification_count : int;
   (** Number of tasks awaiting cross-agent verification. *)
 
+  backlog_updated_since_last_scheduled_autonomous : bool;
+  (** [true] when the backlog changed after the keeper's last scheduled
+      autonomous attempt. Lets task-triggered wakeups bypass cooldown once
+      so newly added work is not delayed behind the previous turn's timer. *)
+
   active_agent_count : int;
   (** Number of agents currently active in the room. *)
 

--- a/test/test_keeper_agent_isolation.ml
+++ b/test/test_keeper_agent_isolation.ml
@@ -315,6 +315,12 @@ let test_canonical_keeper_name_from_legacy_keeper_name () =
     "legacy keeper-prefixed name normalizes" (Some "sangsu")
     (Keeper_types.canonical_keeper_name "keeper-sangsu")
 
+let test_canonical_keeper_name_preserves_plain_hyphenated_name () =
+  Alcotest.(check (option string))
+    "plain hyphenated keeper name is preserved"
+    (Some "masc-mcp-smoke")
+    (Keeper_types.canonical_keeper_name "masc-mcp-smoke")
+
 (* ============================================================
    Test runner
    ============================================================ *)
@@ -371,5 +377,7 @@ let () =
         test_canonical_keeper_name_from_keeper_agent_alias_preserves_full_name;
       Alcotest.test_case "legacy keeper name canonicalizes" `Quick
         test_canonical_keeper_name_from_legacy_keeper_name;
+      Alcotest.test_case "plain hyphenated name preserved" `Quick
+        test_canonical_keeper_name_preserves_plain_hyphenated_name;
     ]);
   ]

--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -373,6 +373,96 @@ esac\n\
 printf 'unexpected docker invocation\\n' >&2\n\
 exit 2\n"
 
+let fake_docker_cleanup_script =
+  "#!/bin/sh\n\
+log_file=${KEEPER_DOCKER_LOG:-}\n\
+if [ -n \"$log_file\" ]; then\n\
+  printf '%s\\n' \"$*\" >> \"$log_file\"\n\
+fi\n\
+case \"$1\" in\n\
+  ps)\n\
+    printf 'old-container\\nfresh-container\\n'\n\
+    exit 0\n\
+    ;;\n\
+  inspect)\n\
+    last=''\n\
+    for arg in \"$@\"; do last=\"$arg\"; done\n\
+    case \"$last\" in\n\
+      old-container)\n\
+        printf '999999\\t100.000\\ttrue\\n'\n\
+        exit 0\n\
+        ;;\n\
+      fresh-container)\n\
+        printf '%s\\t990.000\\ttrue\\n' \"${KEEPER_TEST_PID:-1}\"\n\
+        exit 0\n\
+        ;;\n\
+    esac\n\
+    printf 'unexpected inspect target: %s\\n' \"$last\" >&2\n\
+    exit 2\n\
+    ;;\n\
+  rm)\n\
+    if [ \"$2\" = \"-f\" ] && [ \"$3\" = \"old-container\" ]; then\n\
+      printf 'old-container\\n'\n\
+      exit 0\n\
+    fi\n\
+    printf 'unexpected rm target\\n' >&2\n\
+    exit 2\n\
+    ;;\n\
+esac\n\
+printf 'unexpected docker invocation\\n' >&2\n\
+exit 2\n"
+
+let test_sandbox_container_label_args_include_owner_scope () =
+  let args =
+    Keeper_sandbox_runtime.docker_label_args
+      ~base_path:"/tmp/masc"
+      ~keeper_name:"min/jae"
+      ~container_kind:"turn"
+      ~network_label:"none" ()
+  in
+  let has_label value = List.mem value args in
+  let has_label_prefix prefix =
+    List.exists (String.starts_with ~prefix) args
+  in
+  Alcotest.(check bool) "component label" true
+    (has_label "masc.mcp.component=keeper-sandbox");
+  Alcotest.(check bool) "base path hash label" true
+    (has_label_prefix "masc.mcp.base_path_hash=");
+  Alcotest.(check bool) "sanitized keeper label" true
+    (has_label "masc.mcp.keeper=min_jae");
+  Alcotest.(check bool) "kind label" true
+    (has_label "masc.mcp.kind=turn");
+  Alcotest.(check bool) "owner pid label" true
+    (has_label
+       ("masc.mcp.owner_pid=" ^ string_of_int (Unix.getpid ())));
+  Alcotest.(check bool) "started_at label" true
+    (has_label_prefix "masc.mcp.started_at=");
+  Alcotest.(check bool) "network label" true
+    (has_label "masc.mcp.network=none")
+
+let test_cleanup_stale_containers_removes_only_stale_masc_scope () =
+  with_fake_docker fake_docker_cleanup_script @@ fun () ->
+  let base = temp_dir () in
+  let log_path = Filename.concat base "docker.log" in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
+  with_env "KEEPER_TEST_PID" (string_of_int (Unix.getpid ())) @@ fun () ->
+  let result =
+    Keeper_sandbox_runtime.cleanup_stale_containers
+      ~now:1000.0
+      ~max_age_sec:60.0
+      ~base_path:base
+      ~timeout_sec:5.0 ()
+  in
+  Alcotest.(check int) "scanned labeled containers" 2 result.scanned;
+  Alcotest.(check int) "removed stale container" 1 result.removed;
+  Alcotest.(check (list string)) "no cleanup errors" [] result.errors;
+  let log = read_file log_path in
+  Alcotest.(check bool) "removes old container" true
+    (contains_substring log "rm -f old-container");
+  Alcotest.(check bool) "keeps fresh container" false
+    (contains_substring log "rm -f fresh-container")
+
 let test_docker_preflight_reports_ready_image () =
   with_fake_docker fake_docker_preflight_ok_script @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED" "true" @@ fun () ->
@@ -693,5 +783,12 @@ let () =
             test_docker_preflight_reports_ready_image;
           Alcotest.test_case "missing image surfaces remediation" `Quick
             test_docker_preflight_surfaces_missing_image_actions;
+        ] );
+      ( "docker_cleanup",
+        [
+          Alcotest.test_case "label args include owner scope" `Quick
+            test_sandbox_container_label_args_include_owner_scope;
+          Alcotest.test_case "cleanup removes stale scoped containers" `Quick
+            test_cleanup_stale_containers_removes_only_stale_masc_scope;
         ] );
     ]

--- a/test/test_keeper_repo_readiness.ml
+++ b/test/test_keeper_repo_readiness.ml
@@ -43,6 +43,16 @@ let mkdir_p path =
   in
   ensure path
 
+let write_tool_policy ~base_path =
+  let config_dir = Filename.concat base_path "config" in
+  mkdir_p config_dir;
+  let path = Filename.concat config_dir "tool_policy.toml" in
+  let oc = open_out path in
+  output_string oc
+    "[git_clone]\nallowed_orgs = [\"jeong-sik\"]\ndepth = 1\ndenied_repos = [\"jeong-sik/me\"]\n";
+  close_out oc;
+  Masc_mcp.Tool_code_write.reset_policy_config_cache ()
+
 let json_bool key json =
   Yojson.Safe.Util.(json |> member key |> to_bool)
 
@@ -120,8 +130,13 @@ let create_wide_workspace_storm ~base_path ~count =
     Unix.mkdir (Filename.concat root (Printf.sprintf "aa-%04d" i)) 0o755
   done
 
+let set_workspace_origin_to_github ~repo =
+  run_ok ~cwd:repo
+    "git remote set-url origin https://github.com/jeong-sik/masc-mcp.git"
+
 let test_auto_provisionable_workspace_repo () =
   let base_path = temp_dir "masc-repo-readiness" in
+  write_tool_policy ~base_path;
   let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
   let remote = Filename.concat base_path ".remote-masc-mcp.git" in
   mkdir_p (Filename.dirname repo);
@@ -140,6 +155,7 @@ let test_auto_provisionable_workspace_repo () =
   run_ok ~cwd:repo "git add README.md";
   run_ok ~cwd:repo "git commit -q -m init";
   run_ok ~cwd:repo "git push -q origin main";
+  set_workspace_origin_to_github ~repo;
   let config = Masc_mcp.Coord.default_config base_path in
   let meta = make_meta "keeper-one" in
   let json =
@@ -149,10 +165,18 @@ let test_auto_provisionable_workspace_repo () =
   check bool "ok" true (json_bool "ok" json);
   check string "state" "auto_provisionable" (json_string "state" json);
   check string "workspace repo match" repo
-    Yojson.Safe.Util.(json |> member "workspace_repo_match" |> to_string)
+    Yojson.Safe.Util.(json |> member "workspace_repo_match" |> to_string);
+  check string "workspace repo origin"
+    "jeong-sik/masc-mcp"
+    Yojson.Safe.Util.(
+      json |> member "workspace_repo_origin" |> to_string
+      |> fun url ->
+      Masc_mcp.Tool_code_write.extract_github_org_repo url
+      |> Option.value ~default:"")
 
 let test_auto_provisionable_workspace_repo_after_file_storm () =
   let base_path = temp_dir "masc-repo-readiness" in
+  write_tool_policy ~base_path;
   let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
   let remote = Filename.concat base_path ".remote-masc-mcp.git" in
   create_file_storm ~base_path ~count:4005;
@@ -172,6 +196,7 @@ let test_auto_provisionable_workspace_repo_after_file_storm () =
   run_ok ~cwd:repo "git add README.md";
   run_ok ~cwd:repo "git commit -q -m init";
   run_ok ~cwd:repo "git push -q origin main";
+  set_workspace_origin_to_github ~repo;
   let config = Masc_mcp.Coord.default_config base_path in
   let meta = make_meta "keeper-one" in
   let json =
@@ -185,6 +210,7 @@ let test_auto_provisionable_workspace_repo_after_file_storm () =
 
 let test_auto_provisionable_workspace_repo_before_hidden_dir_storm () =
   let base_path = temp_dir "masc-repo-readiness" in
+  write_tool_policy ~base_path;
   let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
   let remote = Filename.concat base_path ".remote-masc-mcp.git" in
   create_hidden_dir_storm ~base_path ~count:4005;
@@ -204,6 +230,7 @@ let test_auto_provisionable_workspace_repo_before_hidden_dir_storm () =
   run_ok ~cwd:repo "git add README.md";
   run_ok ~cwd:repo "git commit -q -m init";
   run_ok ~cwd:repo "git push -q origin main";
+  set_workspace_origin_to_github ~repo;
   let config = Masc_mcp.Coord.default_config base_path in
   let meta = make_meta "keeper-one" in
   let json =
@@ -217,6 +244,7 @@ let test_auto_provisionable_workspace_repo_before_hidden_dir_storm () =
 
 let test_auto_provisionable_workspace_repo_before_wide_workspace_storm () =
   let base_path = temp_dir "masc-repo-readiness" in
+  write_tool_policy ~base_path;
   let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
   let remote = Filename.concat base_path ".remote-masc-mcp.git" in
   create_wide_workspace_storm ~base_path ~count:4005;
@@ -236,6 +264,7 @@ let test_auto_provisionable_workspace_repo_before_wide_workspace_storm () =
   run_ok ~cwd:repo "git add README.md";
   run_ok ~cwd:repo "git commit -q -m init";
   run_ok ~cwd:repo "git push -q origin main";
+  set_workspace_origin_to_github ~repo;
   let config = Masc_mcp.Coord.default_config base_path in
   let meta = make_meta "keeper-one" in
   let json =

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -134,6 +134,7 @@ let base_observation : WO.world_observation =
     unclaimed_task_count = 0;
     failed_task_count = 0;
     pending_verification_count = 0;
+    backlog_updated_since_last_scheduled_autonomous = false;
     active_agent_count = 0;
     last_turn_budget = None;
     last_tools_used = [];
@@ -837,6 +838,56 @@ let test_task_reactive_cooldown_floor_never_hits_zero () =
     let decision = WO.keeper_cycle_decision ~meta obs in
     check (option int) "task reactive cooldown clamps to positive floor" (Some 300)
       decision.task_reactive_cooldown)
+
+let test_scheduled_turn_decision_runs_immediately_on_fresh_backlog_update () =
+  let meta =
+    {
+      minimal_meta with
+      proactive =
+        { enabled = true; idle_sec = 60; cooldown_sec = 60 };
+      runtime =
+        {
+          minimal_meta.runtime with
+          proactive_rt =
+            { minimal_meta.runtime.proactive_rt with
+              last_ts = Time_compat.now ();
+            };
+        };
+    }
+  in
+  let obs =
+    {
+      base_observation with
+      unclaimed_task_count = 1;
+      backlog_updated_since_last_scheduled_autonomous = true;
+    }
+  in
+  let decision = WO.keeper_cycle_decision ~meta obs in
+  check bool "fresh backlog bypasses cooldown" true decision.should_run;
+  check bool "backlog emits reactive cooldown tag" true
+    (match decision.verdict with
+     | WO.Run { reasons = (first, rest) } ->
+         List.mem WO.Task_reactive_cooldown_elapsed (first :: rest)
+     | WO.Skip _ -> false)
+
+let test_runtime_trust_snapshot_tolerates_null_telemetry () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Coord.default_config base_dir in
+      let keeper_name = "runtime-trust-null-telemetry" in
+      let meta = { minimal_meta with name = keeper_name } in
+      let decision_path = Keeper_types.keeper_decision_log_path config keeper_name in
+      Keeper_types.mkdir_p (Filename.dirname decision_path);
+      Masc_mcp.Keeper_types_support.append_jsonl_line
+        decision_path
+        (`Assoc [ ("telemetry", `Null) ]);
+      let snapshot =
+        Masc_mcp.Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta
+      in
+      check bool "selected model stays null" true
+        Yojson.Safe.Util.(snapshot |> member "selected_model" = `Null))
 
 let test_prompt_contains_identity () =
   let sys, _user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:base_observation () in
@@ -4330,6 +4381,10 @@ let () =
             test_pending_approval_blocks_turns_until_resolved;
           test_case "task reactive cooldown floor never hits zero" `Quick
             test_task_reactive_cooldown_floor_never_hits_zero;
+          test_case "fresh backlog update bypasses cooldown" `Quick
+            test_scheduled_turn_decision_runs_immediately_on_fresh_backlog_update;
+          test_case "runtime trust snapshot tolerates null telemetry" `Quick
+            test_runtime_trust_snapshot_tolerates_null_telemetry;
           test_case "with goals" `Quick test_observation_with_goals;
           test_case "economic modes" `Quick test_observation_economic_modes;
         ] );


### PR DESCRIPTION
## Summary

- Auto-provision keeper sandbox clones from allowed workspace origins instead of failing on missing clones.
- Add keeper-scoped Docker labels and best-effort stale container cleanup before sandbox launches.
- Tighten keeper production-readiness edge cases: hyphenated keeper identity resolution, safe atomic save errors, null telemetry parsing, and fresh backlog wakeups.

## Verification

- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feature-keeper-sandbox-production-ready test/test_keeper_docker_read.exe test/test_keeper_unified.exe test/test_keeper_agent_isolation.exe test/test_keeper_repo_readiness.exe bin/main_eio.exe`
- `./_build/default/test/test_keeper_docker_read.exe`
- `./_build/default/test/test_keeper_agent_isolation.exe`
- `./_build/default/test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_repo_readiness.exe`
- `/tmp/masc_keeper_live_smoke.sh`
- `scripts/keeper-sandbox-smoke.sh`
