### PR TITLE
[codex] Stabilize keeper truth-layer evidence

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -446,13 +446,22 @@ let audit_rule_event ~event_type (rule : approval_rule) =
     ~keeper_name:rule.keeper_name ~tool_name:rule.tool_name
     ~risk_level:rule.max_risk ?source_approval_id:rule.source_approval_id ()
 
+let audit_scan_window ?keeper_name n =
+  match keeper_name with
+  | None -> max n 1
+  | Some _ ->
+      (* Approval audit is global, but runtime trust asks for per-keeper
+         "latest" records. Scan a bounded wider window before filtering so a
+         busy fleet cannot hide the target keeper behind unrelated events. *)
+      max 500 (max n 1 * 64)
+
 let read_recent_audit ?keeper_name ?(n = 20) () : Yojson.Safe.t list =
   if n <= 0 then []
   else
     match get_audit_store () with
     | None -> []
     | Some store ->
-        let raw = Dated_jsonl.read_recent store (max n 1 * 6) in
+        let raw = Dated_jsonl.read_recent store (audit_scan_window ?keeper_name n) in
         let filtered =
           match keeper_name with
           | None -> raw
@@ -462,7 +471,13 @@ let read_recent_audit ?keeper_name ?(n = 20) () : Yojson.Safe.t list =
                      String.equal name
                        (Safe_ops.json_string ~default:"" "keeper" json))
         in
-        filtered |> List.filteri (fun idx _ -> idx < n)
+        filtered
+        |> List.rev
+        |> List.filteri (fun idx _ -> idx < n)
+
+module For_testing = struct
+  let reset_audit_store () = audit_store_ref := None
+end
 
 let generate_id () =
   make_generated_id "appr"

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -76,12 +76,17 @@ let keeper_turn_id_of_json json =
       | None -> json_int_opt_member "turn" json)
 
 let timeline_event_json ?trace_id ?keeper_turn_id ?task_id ?(goal_ids = [])
-    ?next_human_action ~ts_unix ~kind ~title ~summary ~severity () =
+    ?next_human_action ?observed_at_unix ?(observation_only = false)
+    ~ts_unix ~kind ~title ~summary ~severity () =
+  let observed_at_unix = Option.value ~default:ts_unix observed_at_unix in
   `Assoc
     [
       ("kind", `String kind);
       ("ts", `String (iso_of_unix_seconds ts_unix));
       ("ts_unix", `Float ts_unix);
+      ("observed_at", `String (iso_of_unix_seconds observed_at_unix));
+      ("observed_at_unix", `Float observed_at_unix);
+      ("observation_only", `Bool observation_only);
       ("trace_id", Json_util.string_opt_to_json trace_id);
       ("keeper_turn_id", Json_util.int_opt_to_json keeper_turn_id);
       ("task_id", Json_util.string_opt_to_json task_id);
@@ -315,7 +320,8 @@ let receipt_timeline_event receipt =
              ~severity ())
 
 let blocker_timeline_event ?task_id ?(goal_ids = []) ?trace_id
-    ~ts_unix ~runtime_blocker_fields ~next_human_action () =
+    ?observed_at_unix ~ts_unix ~runtime_blocker_fields
+    ~next_human_action () =
   let blocker_class = assoc_string_opt "runtime_blocker_class" runtime_blocker_fields in
   let blocker_summary =
     assoc_string_opt "runtime_blocker_summary" runtime_blocker_fields
@@ -326,6 +332,7 @@ let blocker_timeline_event ?task_id ?(goal_ids = []) ?trace_id
     when String.trim summary <> "" ->
       Some
         (timeline_event_json ?trace_id ?task_id ~goal_ids ?next_human_action
+           ?observed_at_unix ~observation_only:true
            ~ts_unix ~kind:"runtime_blocker"
            ~title:"Runtime Blocker"
            ~summary
@@ -338,12 +345,14 @@ let blocker_timeline_event ?task_id ?(goal_ids = []) ?trace_id
     when String.trim summary <> "" ->
       Some
         (timeline_event_json ?trace_id ?task_id ~goal_ids ?next_human_action
+           ?observed_at_unix ~observation_only:true
            ~ts_unix ~kind:"runtime_blocker"
            ~title:"Runtime Blocker"
            ~summary ~severity:"warn" ())
   | Some blocker_class, None ->
       Some
         (timeline_event_json ?trace_id ?task_id ~goal_ids ?next_human_action
+           ?observed_at_unix ~observation_only:true
            ~ts_unix ~kind:"runtime_blocker"
            ~title:"Runtime Blocker"
            ~summary:blocker_class ~severity:"warn" ())
@@ -441,10 +450,36 @@ let latest_receipt_json ~(config : Coord.config) ~(keeper_name : string) =
 let sort_timeline_events events =
   List.sort
     (fun left right ->
-      Float.compare
-        (json_float_opt_member "ts_unix" right |> Option.value ~default:0.0)
-        (json_float_opt_member "ts_unix" left |> Option.value ~default:0.0))
+      match
+        Bool.compare
+          (json_bool_opt_member "observation_only" left
+           |> Option.value ~default:false)
+          (json_bool_opt_member "observation_only" right
+           |> Option.value ~default:false)
+      with
+      | 0 ->
+          Float.compare
+            (json_float_opt_member "ts_unix" right |> Option.value ~default:0.0)
+            (json_float_opt_member "ts_unix" left |> Option.value ~default:0.0)
+      | cmp -> cmp)
     events
+
+let latest_causal_from_timeline = function
+  | `List items -> (
+      match
+        List.find_opt
+          (fun json ->
+             not
+               (json_bool_opt_member "observation_only" json
+                |> Option.value ~default:false))
+          items
+      with
+      | Some event -> event
+      | None -> (
+          match items with
+          | event :: _ -> event
+          | [] -> `Null))
+  | _ -> `Null
 
 let approval_state_json ~pending_approval_count ~latest_tool_call
     ~latest_approval_audit ~latest_receipt =
@@ -576,8 +611,9 @@ let causal_timeline_json ~meta ~latest_decision ~latest_receipt
     let task_id = Keeper_runtime_contract.current_task_id_opt meta in
     let goal_ids = meta.active_goal_ids in
     let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+    let observed_at_unix = Time_compat.now () in
     [
-      blocker_timeline_event ~ts_unix:(Time_compat.now ())
+      blocker_timeline_event ~ts_unix:observed_at_unix ~observed_at_unix
         ~runtime_blocker_fields ?task_id ~goal_ids
         ~trace_id ~next_human_action ()
     ]
@@ -677,9 +713,7 @@ let snapshot_json ~(config : Coord.config) ~(meta : keeper_meta) =
       ~runtime_blocker_fields ~next_human_action
   in
   let latest_causal_event =
-    match causal_timeline with
-    | `List (event :: _) -> event
-    | _ -> `Null
+    latest_causal_from_timeline causal_timeline
   in
   `Assoc
     [

--- a/lib/keeper/keeper_transition_audit.ml
+++ b/lib/keeper/keeper_transition_audit.ml
@@ -41,6 +41,12 @@ let completed_turn_outcome_to_json = function
   | Turn_failed -> `String "failed"
   | Turn_gate_rejected -> `String "gate_rejected"
 
+let completed_turn_outcome_of_json = function
+  | `String "substantive" -> Some Turn_substantive
+  | `String "failed" -> Some Turn_failed
+  | `String "gate_rejected" -> Some Turn_gate_rejected
+  | _ -> None
+
 let completed_turn_to_json (r : completed_turn_record) : Yojson.Safe.t =
   `Assoc
     [
@@ -49,6 +55,34 @@ let completed_turn_to_json (r : completed_turn_record) : Yojson.Safe.t =
       "ended_at", `Float r.ended_at;
       "outcome", completed_turn_outcome_to_json r.outcome;
     ]
+
+let completed_turn_of_json = function
+  | `Assoc fields -> (
+      match
+        List.assoc_opt "turn_id" fields,
+        List.assoc_opt "started_at" fields,
+        List.assoc_opt "ended_at" fields,
+        List.assoc_opt "outcome" fields
+      with
+      | Some (`Int turn_id), Some (`Float started_at), Some (`Float ended_at),
+        Some outcome_json -> (
+          match completed_turn_outcome_of_json outcome_json with
+          | Some outcome -> Some { turn_id; started_at; ended_at; outcome }
+          | None -> None)
+      | Some (`Int turn_id), Some (`Int started_at), Some (`Int ended_at),
+        Some outcome_json -> (
+          match completed_turn_outcome_of_json outcome_json with
+          | Some outcome ->
+              Some
+                {
+                  turn_id;
+                  started_at = float_of_int started_at;
+                  ended_at = float_of_int ended_at;
+                  outcome;
+                }
+          | None -> None)
+      | _ -> None)
+  | _ -> None
 
 (* ================================================================ *)
 (* In-memory ring buffer for recent transitions                     *)
@@ -165,6 +199,21 @@ let append_to_default_store ~keeper_name (rec_ : transition_record) =
       Safe_ops.protect ~default:() (fun () ->
           Dated_jsonl.append store json)
 
+let append_completed_turn_to_default_store ~keeper_name
+    (rec_ : completed_turn_record) =
+  match get_default_store () with
+  | None -> ()
+  | Some store ->
+      let json =
+        `Assoc
+          [
+            "keeper", `String keeper_name;
+            "completed_turn", completed_turn_to_json rec_;
+          ]
+      in
+      Safe_ops.protect ~default:() (fun () ->
+          Dated_jsonl.append store json)
+
 let record_transition ~keeper_name (rec_ : transition_record) =
   let ring = get_or_create_ring keeper_name in
   ring.buf.(ring.pos) <- Some rec_;
@@ -215,7 +264,7 @@ let record_completed_turn ~keeper_name (rec_ : completed_turn_record) =
   ring.pos <- (ring.pos + 1) mod ring_capacity;
   ring.count <- ring.count + 1;
   match sink_path () with
-  | None -> ()
+  | None -> append_completed_turn_to_default_store ~keeper_name rec_
   | Some path ->
       Safe_ops.protect ~default:() (fun () ->
           let line =
@@ -234,16 +283,47 @@ let record_completed_turn ~keeper_name (rec_ : completed_turn_record) =
               close_out_noerr oc)
             (fun () -> output_string oc (line ^ "\n")))
 
+let recent_completed_turns_from_store ~keeper_name ~limit =
+  match sink_path (), get_default_store () with
+  | Some _, _ | _, None -> []
+  | None, Some store ->
+      Dated_jsonl.read_recent store (max limit 1 * 8)
+      |> List.filter_map (function
+           | `Assoc fields -> (
+               match
+                 List.assoc_opt "keeper" fields,
+                 List.assoc_opt "completed_turn" fields
+               with
+               | Some (`String name), Some record
+                 when String.equal name keeper_name ->
+                   completed_turn_of_json record
+               | _ -> None)
+           | _ -> None)
+      |> List.rev
+      |> List.filteri (fun idx _ -> idx < limit)
+
 let recent_completed_turns ~keeper_name ~limit : completed_turn_record list =
   match Hashtbl.find_opt completed_turn_rings keeper_name with
-  | None -> []
+  | None -> recent_completed_turns_from_store ~keeper_name ~limit
   | Some ring ->
       let n = min limit (min ring.count ring_capacity) in
       let result = ref [] in
       for i = 0 to n - 1 do
         let idx = (ring.pos - 1 - i + ring_capacity) mod ring_capacity in
         match ring.buf.(idx) with
-        | Some r -> result := r :: !result
+        | Some r -> result := !result @ [ r ]
         | None -> ()
       done;
-      !result
+      match !result with
+      | [] -> recent_completed_turns_from_store ~keeper_name ~limit
+      | turns -> turns
+
+module For_testing = struct
+  let reset_state () =
+    Hashtbl.clear rings;
+    Hashtbl.clear completed_turn_rings;
+    default_store_ref := None
+
+  let clear_completed_turn_ring ~keeper_name =
+    Hashtbl.remove completed_turn_rings keeper_name
+end

--- a/lib/keeper/keeper_transition_audit.mli
+++ b/lib/keeper/keeper_transition_audit.mli
@@ -53,3 +53,8 @@ val record_completed_turn :
 (** Retrieve recent completed keeper turns for a keeper, newest first. *)
 val recent_completed_turns :
   keeper_name:string -> limit:int -> completed_turn_record list
+
+module For_testing : sig
+  val reset_state : unit -> unit
+  val clear_completed_turn_ring : keeper_name:string -> unit
+end

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -113,6 +113,18 @@ let blocker_class_to_string = function
   | Completion_contract_violation -> "completion_contract_violation"
   | No_tool_capable_provider -> "no_tool_capable_provider"
 
+let blocker_class_of_serialized_string = function
+  | "cascade_exhausted" -> Some (Cascade_exhausted (Other_detail "cascade_exhausted"))
+  | "ambiguous_post_commit_timeout" -> Some Ambiguous_post_commit_timeout
+  | "ambiguous_post_commit_failure" -> Some Ambiguous_post_commit_failure
+  | "autonomous_slot_wait_timeout" -> Some Autonomous_slot_wait_timeout
+  | "admission_queue_wait_timeout" -> Some Admission_queue_wait_timeout
+  | "turn_timeout_after_queue_wait" -> Some Turn_timeout_after_queue_wait
+  | "turn_timeout" -> Some Turn_timeout
+  | "completion_contract_violation" -> Some Completion_contract_violation
+  | "no_tool_capable_provider" -> Some No_tool_capable_provider
+  | _ -> None
+
 let cascade_exhaustion_summary = function
   | Connection_refused ->
       "Cascade exhausted after provider failures; local runtime connection refused."
@@ -1307,7 +1319,11 @@ let parse_keeper_state
   let last_blocker =
     cap_loaded (Safe_ops.json_string ~default:"" "last_blocker" json)
   in
-  let last_blocker_class = None in
+  let last_blocker_class =
+    match Safe_ops.json_string_opt "last_blocker_class" json with
+    | Some raw -> blocker_class_of_serialized_string raw
+    | None -> None
+  in
   let last_need =
     cap_loaded (Safe_ops.json_string ~default:"" "last_need" json)
   in

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -165,6 +165,54 @@ let test_goal_detail_surfaces_keeper_runtime_trust_and_blockers () =
         "execution_receipt"
         (linked_keeper |> member "latest_causal_event" |> member "kind" |> to_string)
 
+let test_goal_detail_does_not_promote_synthetic_blocker_over_receipt () =
+  with_room @@ fun config ->
+  let goal, _kind =
+    match Goal_store.upsert_goal config ~title:"Ship blocker ordering" () with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  let meta =
+    let base = make_keeper_meta ~name:"blocker-keeper" ~goal_id:goal.id in
+    {
+      base with
+      runtime =
+        {
+          base.runtime with
+          last_blocker = "turn timed out";
+          last_blocker_class = Some Keeper_types.Turn_timeout;
+        };
+    }
+  in
+  (match Keeper_types.write_meta ~force:true config meta with
+   | Ok () -> ()
+   | Error err -> fail ("write_meta failed: " ^ err));
+  append_keeper_receipt config meta;
+  match Dashboard_goals.goal_detail_json ~config ~goal_id:goal.id with
+  | Error msg -> fail msg
+  | Ok json ->
+      let linked_keeper =
+        match json |> member "linked_keepers" |> to_list with
+        | keeper :: _ -> keeper
+        | [] -> fail "expected linked keeper detail"
+      in
+      let runtime_trust = linked_keeper |> member "runtime_trust" in
+      check string "durable receipt remains latest causal event"
+        "execution_receipt"
+        (runtime_trust |> member "latest_causal_event" |> member "kind" |> to_string);
+      let timeline = runtime_trust |> member "causal_timeline" |> to_list in
+      let blocker =
+        timeline
+        |> List.find_opt (fun event ->
+               String.equal "runtime_blocker"
+                 (event |> member "kind" |> to_string))
+      in
+      match blocker with
+      | None -> fail "expected runtime_blocker observation in timeline"
+      | Some event ->
+          check bool "runtime blocker marked observation-only" true
+            (event |> member "observation_only" |> to_bool)
+
 let () =
   run "Dashboard_goals"
     [
@@ -175,5 +223,9 @@ let () =
           test_case "goal detail surfaces keeper runtime trust and blockers"
             `Quick
             test_goal_detail_surfaces_keeper_runtime_trust_and_blockers;
+          test_case
+            "goal detail keeps synthetic runtime blocker out of latest causal"
+            `Quick
+            test_goal_detail_does_not_promote_synthetic_blocker_over_receipt;
         ] );
     ]

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -72,6 +72,27 @@ let with_test_config f =
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
       f state.room_config)
 
+let with_temp_masc_base f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let old_base = Sys.getenv_opt "MASC_BASE_PATH" in
+  let old_base_input = Sys.getenv_opt "MASC_BASE_PATH_INPUT" in
+  let base_path = temp_dir () in
+  AQ.For_testing.reset_audit_store ();
+  Unix.putenv "MASC_BASE_PATH" base_path;
+  Unix.putenv "MASC_BASE_PATH_INPUT" base_path;
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_audit_store ();
+      (match old_base with
+       | Some value -> Unix.putenv "MASC_BASE_PATH" value
+       | None -> Unix.putenv "MASC_BASE_PATH" "");
+      (match old_base_input with
+       | Some value -> Unix.putenv "MASC_BASE_PATH_INPUT" value
+       | None -> Unix.putenv "MASC_BASE_PATH_INPUT" "");
+      cleanup_dir base_path)
+    f
+
 (* ── 1. Risk classification ──────────────────────────────── *)
 
 let test_risk_classification_critical () =
@@ -727,6 +748,28 @@ let test_callback_paranoid_medium_risk_uses_remembered_policy () =
       | Agent_sdk.Hooks.Edit _ ->
           Alcotest.fail "expected remembered approve, got edit")
 
+let test_read_recent_audit_filters_after_wide_scan () =
+  with_temp_masc_base @@ fun () ->
+  let keeper_name = "audit-target-keeper" in
+  AQ.audit_approval_event ~event_type:"resolved" ~id:"target-audit"
+    ~keeper_name ~tool_name:"keeper_shell" ~risk_level:AQ.Medium
+    ~decision:"approve" ();
+  for i = 1 to 32 do
+    AQ.audit_approval_event ~event_type:"resolved"
+      ~id:(Printf.sprintf "other-audit-%02d" i)
+      ~keeper_name:(Printf.sprintf "busy-keeper-%02d" i)
+      ~tool_name:"keeper_shell" ~risk_level:AQ.Medium
+      ~decision:"approve" ()
+  done;
+  match AQ.read_recent_audit ~keeper_name ~n:1 () with
+  | [ json ] ->
+      Alcotest.(check string) "target approval survives unrelated tail"
+        "target-audit"
+        Yojson.Safe.Util.(json |> member "id" |> to_string)
+  | items ->
+      Alcotest.fail
+        (Printf.sprintf "expected one target audit, got %d" (List.length items))
+
 (* ── Test runner ──────────────────────────────────────────── *)
 
 let () =
@@ -772,6 +815,8 @@ let () =
         test_resolve_with_policy_remembers_medium_allow;
       Alcotest.test_case "resolve_with_policy skips high allow memory" `Quick
         test_resolve_with_policy_does_not_remember_high_allow;
+      Alcotest.test_case "read_recent_audit scans before keeper filter" `Quick
+        test_read_recent_audit_filters_after_wide_scan;
     ]);
     ("callback_integration", [
       Alcotest.test_case "low risk auto-approved" `Quick test_callback_approves_low_risk;

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -239,6 +239,37 @@ let test_mark_turn_finished_records_completed_turn_outcome_once () =
         (Printf.sprintf "expected exactly one completed turn, got %d"
            (List.length turns))
 
+let test_completed_turns_replay_from_default_store () =
+  let base_path = temp_base_path "completed-turn-replay" in
+  Fun.protect
+    ~finally:(fun () ->
+      Audit.For_testing.reset_state ();
+      rm_rf base_path)
+    (fun () ->
+      with_env "MASC_BASE_PATH" base_path (fun () ->
+          Audit.For_testing.reset_state ();
+          let keeper_name = "k-completed-turn-replay" in
+          Audit.record_completed_turn ~keeper_name
+            {
+              Audit.turn_id = 42;
+              started_at = 100.0;
+              ended_at = 120.0;
+              outcome = Audit.Turn_substantive;
+            };
+          Audit.For_testing.clear_completed_turn_ring ~keeper_name;
+          match Audit.recent_completed_turns ~keeper_name ~limit:5 with
+          | [ turn ] ->
+              check int "turn_id replayed" 42 turn.turn_id;
+              check bool "substantive outcome replayed" true
+                (match turn.outcome with
+                 | Audit.Turn_substantive -> true
+                 | _ -> false)
+          | turns ->
+              fail
+                (Printf.sprintf
+                   "expected one replayed completed turn, got %d"
+                   (List.length turns))))
+
 let test_unregister () =
   R.clear ();
   let _entry = R.register ~base_path:bp "k2" (make_meta "k2") in
@@ -1046,6 +1077,8 @@ let () =
             test_dispatch_event_with_audit_preserves_snapshot;
           eio_test "mark_turn_finished records completed turn outcome once"
             test_mark_turn_finished_records_completed_turn_outcome_once;
+          eio_test "completed turns replay from default store"
+            test_completed_turns_replay_from_default_store;
           eio_test "unregister" test_unregister;
           eio_test "all" test_all;
           eio_test "update meta" test_update_meta;


### PR DESCRIPTION
## Summary

Stabilizes the MASC keeper truth layer so dashboard/runtime snapshots preserve durable causal history instead of letting synthetic runtime observations hide the latest causal event.

## Changes

- Mark runtime blocker timeline entries as observation-only and keep causal receipt/transition/approval/tool events as the source of `latest_causal_event`.
- Make per-keeper approval audit reads scan before filtering so busy global audit tails do not hide a keeper's latest audit entry.
- Persist and replay completed-turn evidence through the default transition audit store when no explicit sink is configured.
- Restore `last_blocker_class` parsing from serialized keeper state.
- Add regression coverage for synthetic blocker ordering, audit filtering, and completed-turn replay.

## Validation

- `dune build --root . --build-dir _build_verify_masc_check @check`
- `dune exec --root . --build-dir _build_verify_dashboard test/test_dashboard_goals.exe` (3 tests)
- `dune exec --root . --build-dir _build_verify_hitl test/test_hitl_approval.exe` (29 tests)
- `dune exec --root . --build-dir _build_verify_keeper test/test_keeper_registry.exe` (62 tests)
- `git diff --cached --check`