### PR TITLE
[codex] add worktree safety negative tests

### DIFF
--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -136,13 +136,20 @@ let is_git_clone candidate =
   | `Directory | `File -> true
   | `Missing -> false
 
+let same_realpath a b =
+  try String.equal (Unix.realpath a) (Unix.realpath b) with
+  | Unix.Unix_error _ -> String.equal a b
+
 let is_usable_git_worktree path =
   safe_is_dir path
   &&
   match run_argv_with_status
-          [ "git"; "-C"; path; "rev-parse"; "--is-inside-work-tree" ]
+          [ "git"; "-C"; path; "rev-parse"; "--show-toplevel" ]
   with
-  | Unix.WEXITED 0, output -> String.trim output = "true"
+  | Unix.WEXITED 0, output -> (
+      match first_nonempty_line output with
+      | Some top -> same_realpath top path
+      | None -> false)
   | _ -> false
 
 let run_git_in_clone clone_path args =
@@ -164,10 +171,6 @@ type sandbox_clone_state =
   | Ready
   | Needs_checkout of string
   | Broken_git of string
-
-let same_realpath a b =
-  try String.equal (Unix.realpath a) (Unix.realpath b) with
-  | Unix.Unix_error _ -> String.equal a b
 
 let inspect_sandbox_clone candidate =
   let inside_status, inside_output =

--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -122,12 +122,28 @@ let safe_repo_name name =
          || c = '.')
        name
 
+(* Git worktree mutations include Eio subprocess calls; use Eio.Mutex so
+   same-domain fibers serialize without blocking the scheduler. *)
+let worktree_mutation_mutex = Eio.Mutex.create ()
+
+let with_worktree_mutation_lock f =
+  Eio.Mutex.use_rw ~protect:true worktree_mutation_mutex f
+
 let is_git_clone candidate =
   safe_is_dir candidate
   &&
   match git_marker_kind (Filename.concat candidate ".git") with
   | `Directory | `File -> true
   | `Missing -> false
+
+let is_usable_git_worktree path =
+  safe_is_dir path
+  &&
+  match run_argv_with_status
+          [ "git"; "-C"; path; "rev-parse"; "--is-inside-work-tree" ]
+  with
+  | Unix.WEXITED 0, output -> String.trim output = "true"
+  | _ -> false
 
 let run_git_in_clone clone_path args =
   run_argv_with_status ([ "git"; "-C"; clone_path; "--no-optional-locks" ] @ args)
@@ -149,6 +165,10 @@ type sandbox_clone_state =
   | Needs_checkout of string
   | Broken_git of string
 
+let same_realpath a b =
+  try String.equal (Unix.realpath a) (Unix.realpath b) with
+  | Unix.Unix_error _ -> String.equal a b
+
 let inspect_sandbox_clone candidate =
   let inside_status, inside_output =
     run_git_in_clone candidate [ "rev-parse"; "--is-inside-work-tree" ]
@@ -158,19 +178,39 @@ let inspect_sandbox_clone candidate =
       (Printf.sprintf "git rev-parse failed: %s"
          (trim_output_detail inside_output))
   else
-    let tracked_status, tracked_output =
-      run_git_in_clone candidate [ "ls-files"; "-z" ]
+    let top_status, top_output =
+      run_git_in_clone candidate [ "rev-parse"; "--show-toplevel" ]
     in
-    if tracked_status <> Unix.WEXITED 0 then
+    if top_status <> Unix.WEXITED 0 then
       Broken_git
-        (Printf.sprintf "git ls-files failed: %s"
-           (trim_output_detail tracked_output))
+        (Printf.sprintf "git rev-parse --show-toplevel failed: %s"
+           (trim_output_detail top_output))
     else
-      match first_nul_field tracked_output with
-      | None -> Ready
-      | Some relpath ->
-          if safe_file_exists (Filename.concat candidate relpath) then Ready
-          else Needs_checkout relpath
+      match first_nonempty_line top_output with
+      | Some top ->
+          if not (same_realpath top candidate) then
+            Broken_git
+              (Printf.sprintf
+                 "git top-level mismatch: expected sandbox clone root %s but \
+                  git resolved %s"
+                 candidate top)
+          else
+            let tracked_status, tracked_output =
+              run_git_in_clone candidate [ "ls-files"; "-z" ]
+            in
+            if tracked_status <> Unix.WEXITED 0 then
+              Broken_git
+                (Printf.sprintf "git ls-files failed: %s"
+                   (trim_output_detail tracked_output))
+            else
+              (match first_nul_field tracked_output with
+              | None -> Ready
+              | Some relpath ->
+                  if safe_file_exists (Filename.concat candidate relpath) then
+                    Ready
+                  else Needs_checkout relpath)
+      | None ->
+          Broken_git "git rev-parse --show-toplevel returned no path"
 
 let restore_sandbox_clone_checkout candidate =
   let checkout_status, checkout_output =
@@ -511,6 +551,7 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
   | Error e, _ -> Error e
   | _, Error e -> Error e
   | Ok _, Ok _ ->
+    with_worktree_mutation_lock @@ fun () ->
     (* Prefer a keeper's sandbox repo clone under
        the keeper's backend-specific sandbox repo lane. If [repo_name]
        is supplied, target that clone directly; otherwise scan the
@@ -601,15 +642,36 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
             end else ""
           in
 
+          let existing_worktree_ok ?(created_concurrently=false) () =
+            update_agent_current_task ();
+            let race_note =
+              if created_concurrently then
+                "\n  Note: Worktree was created concurrently by another worker."
+              else ""
+            in
+            let link_note = maybe_link_task () in
+            Ok
+              (Printf.sprintf
+                 "✅ Worktree already exists:\n  Path: %s\n  Branch: %s\n  \
+                  Repo: %s%s%s\n\nNext: cd %s"
+                 worktree_path branch_name repo_name race_note link_note
+                 worktree_path)
+          in
+
           (* Create .worktrees directory if not exists *)
           Fs_compat.mkdir_p worktrees_dir;
 
           (* Check if worktree already exists *)
-          if Sys.file_exists worktree_path then begin
-            update_agent_current_task ();
-            let link_note = maybe_link_task () in
-            Ok (Printf.sprintf "✅ Worktree already exists:\n  Path: %s\n  Branch: %s\n  Repo: %s%s\n\nNext: cd %s"
-                worktree_path branch_name repo_name link_note worktree_path)
+          if safe_file_exists worktree_path then begin
+            if is_usable_git_worktree worktree_path then
+              existing_worktree_ok ()
+            else
+              Error
+                (IoError
+                   (Printf.sprintf
+                      "worktree_path_conflict: %s already exists but is not a \
+                       usable git worktree. Remove or repair it before retrying."
+                      worktree_path))
           end else begin
             (* Fetch origin first; stale remotes must be explicit, not hidden. *)
             let fetch_exit = run_argv_exit ["git"; "-C"; root; "fetch"; "origin"] in
@@ -674,10 +736,14 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
                       worktree_path branch_name repo_name note
                       (provision_note ^ link_note) worktree_path)
                 end
-                else
+                else if is_usable_git_worktree worktree_path then
+                  existing_worktree_ok ~created_concurrently:true ()
+                else begin
+                  rm_rf worktree_path;
                   let detail = String.trim git_output in
                   Error (IoError (Printf.sprintf "Failed to create worktree from origin/%s: %s"
                     resolved_base (if detail = "" then "(no output)" else detail)))
+                end
           end
   end
 

--- a/test/test_tool_worktree_coverage.ml
+++ b/test/test_tool_worktree_coverage.ml
@@ -230,6 +230,9 @@ let contains needle haystack =
     in
     loop 0
 
+let check_contains label needle haystack =
+  check bool label true (contains needle haystack)
+
 let test_dispatch_worktree_create_spoofed_agent_blocked () =
   let ctx = make_ctx () in
   let args = `Assoc [
@@ -562,6 +565,145 @@ let test_dispatch_worktree_create_repairs_existing_sandbox_clone_checkout () =
       check bool "docker worktree created after repair" true
         (Sys.file_exists docker_worktree)
 
+let test_dispatch_worktree_create_cleans_failed_auto_clone () =
+  let base_path = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  init_process_eio env;
+  run_ok ~cwd:base_path "git init -q -b main";
+  let broken_source =
+    Filename.concat base_path "workspace/yousleepwhen/masc-mcp"
+  in
+  ensure_dir (Filename.concat broken_source ".git");
+  let config = Masc_mcp.Coord.default_config base_path in
+  ignore (Masc_mcp.Coord.init config ~agent_name:(Some "test-agent"));
+  let ctx : Tool_worktree.context = { config; agent_name = "test-agent" } in
+  let args = `Assoc [
+    ("task_id", `String "task-clone-fail");
+    ("repo_name", `String "masc-mcp");
+    ("base_branch", `String "main");
+  ] in
+  let sandbox_clone =
+    Filename.concat base_path ".masc/playground/test-agent/repos/masc-mcp"
+  in
+  match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
+  | None -> fail "dispatch returned None for masc_worktree_create"
+  | Some (true, msg) ->
+      fail
+        (Printf.sprintf
+           "expected auto-provision clone failure, got success: %s"
+           msg)
+  | Some (false, msg) ->
+      check_contains "message mentions auto-provision failure"
+        "auto_provision_clone_failed" msg;
+      check bool "partial sandbox clone was cleaned" false
+        (Sys.file_exists sandbox_clone)
+
+let test_dispatch_worktree_create_rejects_invalid_sandbox_clone () =
+  let base_path = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  init_process_eio env;
+  run_ok ~cwd:base_path "git init -q -b main";
+  let sandbox_clone =
+    Filename.concat base_path ".masc/playground/test-agent/repos/masc-mcp"
+  in
+  ensure_dir (Filename.concat sandbox_clone ".git");
+  let config = Masc_mcp.Coord.default_config base_path in
+  ignore (Masc_mcp.Coord.init config ~agent_name:(Some "test-agent"));
+  let ctx : Tool_worktree.context = { config; agent_name = "test-agent" } in
+  let args = `Assoc [
+    ("task_id", `String "task-invalid-clone");
+    ("repo_name", `String "masc-mcp");
+    ("base_branch", `String "main");
+  ] in
+  match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
+  | None -> fail "dispatch returned None for masc_worktree_create"
+  | Some (true, msg) ->
+      fail
+        (Printf.sprintf
+           "expected invalid sandbox clone failure, got success: %s"
+           msg)
+  | Some (false, msg) ->
+      check_contains "message mentions invalid sandbox clone"
+        "sandbox_clone_invalid" msg;
+      check bool "invalid sandbox clone was preserved" true
+        (Sys.file_exists sandbox_clone)
+
+let test_worktree_path_rejects_traversal_name () =
+  let base_path = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  let root = Filename.concat base_path "repo" in
+  ensure_dir root;
+  match Masc_mcp.Coord.ensure_worktree_path root "../escape" with
+  | Ok (worktree_path, _) ->
+      fail ("expected invalid worktree path, got: " ^ worktree_path)
+  | Error (Types.IoError msg) ->
+      check_contains "message mentions invalid worktree path"
+        "Invalid worktree path" msg
+  | Error err ->
+      fail ("expected IoError, got: " ^ Types.masc_error_to_string err)
+
+let test_worktree_create_concurrent_same_name_converges () =
+  let base_path = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  init_process_eio env;
+  run_ok ~cwd:base_path "git init -q -b main";
+  let source_repo =
+    setup_nested_repo_with_remote ~base_path
+      ~repo_rel:"workspace/yousleepwhen/masc-mcp"
+  in
+  let sandbox_repos =
+    Filename.concat base_path ".masc/playground/race-agent/repos"
+  in
+  ensure_dir sandbox_repos;
+  let sandbox_clone = Filename.concat sandbox_repos "masc-mcp" in
+  run_ok ~cwd:base_path
+    (Printf.sprintf "git clone -q %s %s"
+       (Filename.quote source_repo) (Filename.quote sandbox_clone));
+  let config = Masc_mcp.Coord.default_config base_path in
+  ignore (Masc_mcp.Coord.init config ~agent_name:(Some "race-agent"));
+  let task_id = "task-race-create" in
+  let create_once () =
+    Masc_mcp.Coord.worktree_create_r ~link_task:false ~repo_name:"masc-mcp"
+      config ~agent_name:"race-agent" ~task_id ~base_branch:"main"
+  in
+  let left = ref None in
+  let right = ref None in
+  Eio.Fiber.both
+    (fun () -> left := Some (create_once ()))
+    (fun () -> right := Some (create_once ()));
+  let unwrap label = function
+    | Some (Ok msg) -> msg
+    | Some (Error err) ->
+        fail
+          (Printf.sprintf "%s failed: %s" label
+             (Types.masc_error_to_string err))
+    | None -> fail (label ^ " did not run")
+  in
+  let left_msg = unwrap "left create" !left in
+  let right_msg = unwrap "right create" !right in
+  let messages = [ left_msg; right_msg ] in
+  let count_matching needle =
+    List.fold_left
+      (fun count msg -> if contains needle msg then count + 1 else count)
+      0 messages
+  in
+  let worktree_path =
+    Filename.concat sandbox_clone
+      (Filename.concat ".worktrees"
+         (Playground_paths.worktree_dir_name "race-agent" task_id))
+  in
+  check bool "concurrent worktree exists" true
+    (Sys.file_exists worktree_path);
+  check int "one create wins" 1 (count_matching "Worktree created");
+  check int "one create observes existing" 1
+    (count_matching "Worktree already exists")
+
 (* ============================================================
    Test Runners
    ============================================================ *)
@@ -608,5 +750,13 @@ let () =
         test_dispatch_worktree_create_and_remove_use_docker_keeper_lane;
       test_case "broken sandbox clone checkout is restored" `Quick
         test_dispatch_worktree_create_repairs_existing_sandbox_clone_checkout;
+      test_case "failed auto-provision clone is cleaned" `Quick
+        test_dispatch_worktree_create_cleans_failed_auto_clone;
+      test_case "invalid sandbox clone is rejected" `Quick
+        test_dispatch_worktree_create_rejects_invalid_sandbox_clone;
+      test_case "worktree path traversal is rejected" `Quick
+        test_worktree_path_rejects_traversal_name;
+      test_case "concurrent same-name worktree create converges" `Quick
+        test_worktree_create_concurrent_same_name_converges;
     ];
   ]

--- a/test/test_tool_worktree_coverage.ml
+++ b/test/test_tool_worktree_coverage.ml
@@ -646,6 +646,53 @@ let test_worktree_path_rejects_traversal_name () =
   | Error err ->
       fail ("expected IoError, got: " ^ Types.masc_error_to_string err)
 
+let test_worktree_create_rejects_existing_non_git_worktree_path () =
+  let base_path = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  init_process_eio env;
+  run_ok ~cwd:base_path "git init -q -b main";
+  let source_repo =
+    setup_nested_repo_with_remote ~base_path
+      ~repo_rel:"workspace/yousleepwhen/masc-mcp"
+  in
+  let sandbox_repos =
+    Filename.concat base_path ".masc/playground/test-agent/repos"
+  in
+  ensure_dir sandbox_repos;
+  let sandbox_clone = Filename.concat sandbox_repos "masc-mcp" in
+  run_ok ~cwd:base_path
+    (Printf.sprintf "git clone -q %s %s"
+       (Filename.quote source_repo) (Filename.quote sandbox_clone));
+  let config = Masc_mcp.Coord.default_config base_path in
+  ignore (Masc_mcp.Coord.init config ~agent_name:(Some "test-agent"));
+  let ctx : Tool_worktree.context = { config; agent_name = "test-agent" } in
+  let task_id = "task-plain-dir-conflict" in
+  let worktree_path =
+    Filename.concat sandbox_clone
+      (Filename.concat ".worktrees"
+         (Playground_paths.worktree_dir_name "test-agent" task_id))
+  in
+  ensure_dir worktree_path;
+  let args = `Assoc [
+    ("task_id", `String task_id);
+    ("repo_name", `String "masc-mcp");
+    ("base_branch", `String "main");
+  ] in
+  match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
+  | None -> fail "dispatch returned None for masc_worktree_create"
+  | Some (true, msg) ->
+      fail
+        (Printf.sprintf
+           "expected existing non-git worktree path failure, got success: %s"
+           msg)
+  | Some (false, msg) ->
+      check_contains "message mentions worktree path conflict"
+        "worktree_path_conflict" msg;
+      check bool "plain directory conflict was preserved" true
+        (Sys.file_exists worktree_path)
+
 let test_worktree_create_concurrent_same_name_converges () =
   let base_path = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
@@ -756,6 +803,8 @@ let () =
         test_dispatch_worktree_create_rejects_invalid_sandbox_clone;
       test_case "worktree path traversal is rejected" `Quick
         test_worktree_path_rejects_traversal_name;
+      test_case "existing non-git worktree path is rejected" `Quick
+        test_worktree_create_rejects_existing_non_git_worktree_path;
       test_case "concurrent same-name worktree create converges" `Quick
         test_worktree_create_concurrent_same_name_converges;
     ];


### PR DESCRIPTION
## Summary

Adds failure-injection coverage for MASC worktree safety paths and hardens the implementation so unsafe or racy cases converge predictably.

## Changes

- Validate sandbox clone roots with `git rev-parse --show-toplevel` so nested non-clone directories are rejected instead of inheriting an ancestor repo.
- Serialize worktree creation with an `Eio.Mutex` and treat same-name concurrent creation as an idempotent existing-worktree result.
- Reject pre-existing non-git worktree paths and clean failed partial worktree add attempts.
- Add tests for failed auto-provision cleanup, invalid sandbox clones, traversal rejection, and concurrent same-name creation.

## Validation

- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/task-034-safety-tests ./test/test_tool_worktree_coverage.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/task-034-safety-tests`