### PR TITLE
feat(keeper): expose tool_preset_source and warn on persona/TOML conflict

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -1363,6 +1363,10 @@ let keeper_config_json (config : Coord.config) (name : string)
             match tool_preset with
             | Some preset -> `String (Keeper_types.tool_preset_to_string preset)
             | None -> `Null);
+          ("tool_preset_source",
+            match m.tool_preset_source with
+            | Some src -> `String src
+            | None -> `Null);
           ("tool_also_allow", `List (List.map (fun s -> `String s) tool_also_allow));
           ("tool_custom_allowlist",
             `List

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -117,6 +117,11 @@ let ensure_keeper_meta config name =
         Error msg
     | Ok resolved_target_cascade_name ->
     let target_tool_access = resynced_tool_access defaults meta in
+    let target_tool_preset_source =
+      match defaults.tool_preset_source with
+      | Some _ as s -> s
+      | None -> meta.tool_preset_source
+    in
 
     (* --- Personality --- *)
     let target_goal = apply_default defaults.goal meta.goal in
@@ -277,6 +282,7 @@ let ensure_keeper_meta config name =
         mention_targets = target_mention_targets;
         active_goal_ids = target_active_goal_ids;
         tool_access = target_tool_access;
+        tool_preset_source = target_tool_preset_source;
         sandbox_profile = target_sandbox_profile;
         network_mode = target_network_mode;
         shared_memory_scope = target_shared_memory_scope;

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -212,6 +212,7 @@ let ensure_keeper_meta config name =
       || meta.mention_targets <> target_mention_targets
       || meta.active_goal_ids <> target_active_goal_ids
       || meta.tool_access <> target_tool_access
+      || meta.tool_preset_source <> target_tool_preset_source
       || meta.sandbox_profile <> target_sandbox_profile
       || meta.network_mode <> target_network_mode
       || meta.shared_memory_scope <> target_shared_memory_scope

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -333,6 +333,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         shared_memory_scope;
         allowed_paths;
         tool_access;
+        tool_preset_source = p.profile_defaults.tool_preset_source;
         tool_denylist;
         voice_enabled;
         voice_channel;

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -183,6 +183,7 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     shared_memory_scope;
     tool_access;
     tool_denylist;
+    tool_preset_source = p.profile_defaults.tool_preset_source;
     autoboot_enabled;
     active_goal_ids =
       Option.value ~default:old.active_goal_ids p.profile_defaults.active_goal_ids;

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -215,6 +215,7 @@ type keeper_meta =
   ; shared_memory_scope : shared_memory_scope
   ; allowed_paths : string list
   ; tool_access : tool_access
+  ; tool_preset_source : string option
   ; tool_denylist : string list
   ; mention_targets : string list
   ; room_signal_prompt_enabled : bool
@@ -798,6 +799,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; "shared_memory_scope", `String (shared_memory_scope_to_string m.shared_memory_scope)
     ; "allowed_paths", `List (List.map (fun s -> `String s) m.allowed_paths)
     ; "tool_access", tool_access_to_json m.tool_access
+    ; "tool_preset_source", Json_util.string_opt_to_json m.tool_preset_source
     ; "tool_denylist", `List (List.map (fun s -> `String s) m.tool_denylist)
     ; "mention_targets", `List (List.map (fun s -> `String s) m.mention_targets)
     ; "room_signal_prompt_enabled", `Bool m.room_signal_prompt_enabled
@@ -1402,6 +1404,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
              ; shared_memory_scope = policy.pp_shared_memory_scope
              ; allowed_paths = policy.pp_allowed_paths
              ; tool_access = policy.pp_tool_access
+             ; tool_preset_source = Safe_ops.json_string_opt "tool_preset_source" json
              ; tool_denylist = policy.pp_tool_denylist
              ; mention_targets = policy.pp_mention_targets
              ; room_signal_prompt_enabled = policy.pp_room_signal_prompt_enabled

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -169,6 +169,7 @@ type keeper_meta = {
   shared_memory_scope: shared_memory_scope;
   allowed_paths: string list;
   tool_access: tool_access;
+  tool_preset_source: string option;
   tool_denylist: string list;
   mention_targets: string list;
   room_signal_prompt_enabled: bool;

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -274,6 +274,7 @@ type keeper_profile_defaults = {
   github_identity : string option;
   git_identity_mode : string option;
   tool_preset : string option;
+  tool_preset_source : string option;
   tool_also_allow : string list option;
   tool_denylist : string list option;
   active_goal_ids : string list option;
@@ -344,6 +345,7 @@ let empty_keeper_profile_defaults = {
   github_identity = None;
   git_identity_mode = None;
   tool_preset = None;
+  tool_preset_source = None;
   tool_also_allow = None;
   tool_denylist = None;
   active_goal_ids = None;
@@ -1021,11 +1023,24 @@ let merge_string_list ~base overlay =
   match overlay with [] -> base | xs -> xs
 
 let merge_keeper_profile_defaults
+    ~agent_name
     ~(base : keeper_profile_defaults)
     ~(overlay : keeper_profile_defaults) : keeper_profile_defaults =
   let prefer overlay_value base_value =
     match overlay_value with Some _ -> overlay_value | None -> base_value
   in
+  let warn_on_conflict ~field ~base_value ~overlay_value =
+    match base_value, overlay_value with
+    | Some b, Some o when b <> o ->
+        Log.Keeper.warn
+          "keeper %s config conflict: %s differs between persona (%S) and TOML (%S). \
+           TOML wins."
+          agent_name field b o
+    | _ -> ()
+  in
+  warn_on_conflict ~field:"tool_preset"
+    ~base_value:base.tool_preset ~overlay_value:overlay.tool_preset;
+
   let per_provider_timeout_state, per_provider_timeout =
     match overlay.per_provider_timeout_state with
     | Per_provider_timeout_unset ->
@@ -1067,6 +1082,13 @@ let merge_keeper_profile_defaults
     git_identity_mode =
       prefer overlay.git_identity_mode base.git_identity_mode;
     tool_preset = prefer overlay.tool_preset base.tool_preset;
+    tool_preset_source =
+      (match overlay.tool_preset with
+       | Some _ -> Some "toml"
+       | None ->
+           match base.tool_preset with
+           | Some _ -> Some "persona"
+           | None -> None);
     tool_also_allow = prefer overlay.tool_also_allow base.tool_also_allow;
     tool_denylist = prefer overlay.tool_denylist base.tool_denylist;
     active_goal_ids = prefer overlay.active_goal_ids base.active_goal_ids;
@@ -1208,7 +1230,7 @@ let load_keeper_profile_defaults name : keeper_profile_defaults =
              let persona_defaults =
                load_keeper_profile_defaults_from_persona persona_name
              in
-             merge_keeper_profile_defaults ~base:persona_defaults ~overlay:defaults
+             merge_keeper_profile_defaults ~agent_name:name ~base:persona_defaults ~overlay:defaults
          | None -> defaults)
      | Error e ->
        Log.Keeper.warn "toml config for %s failed (%s), falling back to persona" name e;

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -692,6 +692,11 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
           (match str "tool_preset" with
            | None -> None
            | Some raw -> normalize_tool_preset_raw raw);
+        tool_preset_source =
+          Option.bind (str "tool_preset") (fun raw ->
+              match normalize_tool_preset_raw raw with
+              | Some _ -> Some "toml"
+              | None -> None);
         tool_also_allow = normalize_name_list_opt (strs "tool_also_allow");
         tool_denylist = normalize_name_list_opt (strs "tool_denylist");
         active_goal_ids =
@@ -961,6 +966,13 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                             "persona profile %s has invalid tool_preset '%s'; ignoring"
                             path raw;
                           None));
+                tool_preset_source =
+                  (match Safe_ops.json_string_opt "tool_preset" keeper_json with
+                  | None -> None
+                  | Some raw -> (
+                      match normalize_tool_preset_raw raw with
+                      | Some _ -> Some "persona"
+                      | None -> None));
                 tool_also_allow =
                   normalize_name_list_opt
                     (Safe_ops.json_string_list "tool_also_allow" keeper_json);

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -28,6 +28,21 @@ let write_file path content =
   output_string oc content;
   close_out oc
 
+let rec mkdir_p path =
+  if path = "" || path = "." || path = "/" then ()
+  else if Sys.file_exists path then ()
+  else begin
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755
+  end
+
+let write_persisted_meta_file config meta =
+  let dir = Filename.concat (Coord.masc_root_dir config) "keepers" in
+  mkdir_p dir;
+  let path = Filename.concat dir (meta.Keeper_types.name ^ ".json") in
+  write_file path (Yojson.Safe.pretty_to_string (Keeper_types.meta_to_json meta));
+  path
+
 let contains_substring haystack needle =
   let haystack_len = String.length haystack in
   let needle_len = String.length needle in
@@ -332,7 +347,131 @@ tool_also_allow = ["keeper_bash", "keeper_shell"]
         (list string)
         "allowed_paths"
         [ "workspace/example/project" ]
-        updated.allowed_paths
+        updated.allowed_paths;
+      check
+        (option string)
+        "tool_preset_source"
+        (Some "toml")
+        updated.tool_preset_source
+
+let test_tool_preset_source_resyncs_from_toml_without_policy_delta () =
+  with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
+  with_config_dir @@ fun config_dir ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let keeper_name = "tool_source_toml_resync" in
+  let keepers_toml_dir = Filename.concat config_dir "keepers" in
+  Unix.mkdir keepers_toml_dir 0o755;
+  write_file
+    (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
+    {|[keeper]
+goal = "test"
+tool_preset = "social"
+|};
+  let config = Coord.default_config room_dir in
+  let initial_meta =
+    match
+      Keeper_types.meta_of_json
+        (`Assoc
+          [
+            ("name", `String keeper_name);
+            ("agent_name", `String keeper_name);
+            ("trace_id", `String "trace-tool-source-toml-resync");
+            ("goal", `String "test");
+            ( "tool_access",
+              `Assoc
+                [
+                  ("kind", `String "preset");
+                  ("preset", `String "social");
+                  ("also_allow", `List []);
+                ] );
+          ])
+    with
+    | Ok meta -> meta
+    | Error e -> fail ("meta_of_json failed: " ^ e)
+  in
+  let persisted_path = write_persisted_meta_file config initial_meta in
+  Fs_compat.clear_fs ();
+  check bool "persisted meta fixture exists" true (Sys.file_exists persisted_path);
+  (match Keeper_types.read_meta_file_path persisted_path with
+  | Ok (Some _) -> ()
+  | Ok None -> fail "persisted meta fixture was not readable"
+  | Error e -> fail ("persisted meta fixture read failed: " ^ e));
+  (match Keeper_types.read_meta config keeper_name with
+  | Ok (Some _) -> ()
+  | Ok None -> fail ("persisted meta fixture not found via read_meta: " ^ persisted_path)
+  | Error e -> fail ("persisted meta fixture read_meta failed: " ^ e));
+  match Keeper_runtime.ensure_keeper_meta config keeper_name with
+  | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
+  | Ok updated ->
+      check
+        (option string)
+        "tool_preset_source resynced from TOML"
+        (Some "toml")
+        updated.Keeper_types.tool_preset_source
+
+let test_tool_preset_source_resyncs_from_persona_without_policy_delta () =
+  with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
+  with_config_dir @@ fun config_dir ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let keeper_name = "tool_source_persona_resync" in
+  let personas_dir = Filename.concat config_dir "personas" in
+  let persona_dir = Filename.concat personas_dir keeper_name in
+  Unix.mkdir personas_dir 0o755;
+  Unix.mkdir persona_dir 0o755;
+  write_file
+    (Filename.concat persona_dir "profile.json")
+    {|{
+  "name": "source persona",
+  "keeper": {
+    "goal": "test",
+    "tool_preset": "research"
+  }
+}|};
+  let config = Coord.default_config room_dir in
+  let initial_meta =
+    match
+      Keeper_types.meta_of_json
+        (`Assoc
+          [
+            ("name", `String keeper_name);
+            ("agent_name", `String keeper_name);
+            ("trace_id", `String "trace-tool-source-persona-resync");
+            ("goal", `String "test");
+            ( "tool_access",
+              `Assoc
+                [
+                  ("kind", `String "preset");
+                  ("preset", `String "research");
+                  ("also_allow", `List []);
+                ] );
+          ])
+    with
+    | Ok meta -> meta
+    | Error e -> fail ("meta_of_json failed: " ^ e)
+  in
+  let persisted_path = write_persisted_meta_file config initial_meta in
+  Fs_compat.clear_fs ();
+  check bool "persisted meta fixture exists" true (Sys.file_exists persisted_path);
+  (match Keeper_types.read_meta_file_path persisted_path with
+  | Ok (Some _) -> ()
+  | Ok None -> fail "persisted meta fixture was not readable"
+  | Error e -> fail ("persisted meta fixture read failed: " ^ e));
+  (match Keeper_types.read_meta config keeper_name with
+  | Ok (Some _) -> ()
+  | Ok None -> fail ("persisted meta fixture not found via read_meta: " ^ persisted_path)
+  | Error e -> fail ("persisted meta fixture read_meta failed: " ^ e));
+  match Keeper_runtime.ensure_keeper_meta config keeper_name with
+  | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
+  | Ok updated ->
+      check
+        (option string)
+        "tool_preset_source resynced from persona"
+        (Some "persona")
+        updated.Keeper_types.tool_preset_source
 
 (** Test: explicit empty allowed_paths in TOML clears stale runtime JSON values. *)
 let test_allowed_paths_explicit_empty_clears_runtime () =
@@ -562,7 +701,12 @@ tool_preset = "delivery"
         "tool_preset from toml overlay"
         (Some "delivery")
       (Keeper_types.tool_access_preset updated.tool_access
-         |> Option.map Keeper_types.tool_preset_to_string)
+         |> Option.map Keeper_types.tool_preset_to_string);
+      check
+        (option string)
+        "tool_preset_source from toml overlay"
+        (Some "toml")
+        updated.tool_preset_source
 
 let test_toml_invalid_per_provider_timeout_clears_stale_runtime () =
   with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
@@ -1017,6 +1161,14 @@ let () =
             "TOML tool policy fields overwrite stale runtime JSON"
             `Quick
             test_tool_policy_resync;
+          test_case
+            "TOML tool_preset_source resyncs without policy delta"
+            `Quick
+            test_tool_preset_source_resyncs_from_toml_without_policy_delta;
+          test_case
+            "persona tool_preset_source resyncs without policy delta"
+            `Quick
+            test_tool_preset_source_resyncs_from_persona_without_policy_delta;
           test_case
             "custom tool_access is preserved when TOML omits preset"
             `Quick


### PR DESCRIPTION
## Summary

Adds transparency for tool_preset provenance so operators can see whether a keeper's effective preset came from its persona (base) or TOML overlay, and warns when the two conflict.

## Changes

- `keeper_types_profile.ml`: `tool_preset_source` field in profile defaults; conflict warning in `merge_keeper_profile_defaults`
- `keeper_types.mli` / `keeper_types.ml`: `tool_preset_source : string option` in `keeper_meta`; JSON serialization
- `keeper_runtime.ml`: wire `tool_preset_source` through `ensure_keeper_meta`
- `dashboard_http_keeper.ml`: expose `"tool_preset_source"` in config JSON

## Verification

- [ ] sangsu boot log shows `tool_preset conflict: persona=\"coding\" toml=\"delivery\"`
- [ ] Dashboard shows `"tool_preset_source": "toml"` for sangsu