### PR TITLE
[codex] Preserve structured MCP tool logs

### DIFF
--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -152,7 +152,10 @@ module Ring = struct
     details : Yojson.Safe.t;
   }
 
-  let capacity = 5000
+  (* Dashboard operators commonly inspect tool-call history over hours, not
+     minutes.  5k entries was too small for high-volume keeper/MCP traffic and
+     made recent MCP calls appear to disappear despite JSONL persistence. *)
+  let capacity = 50000
   let buf : entry array = Array.make capacity
     {
       seq = 0;
@@ -512,6 +515,16 @@ module Make (M : sig val name : string end) = struct
           ~module_name:M.name ~message:msg ()
       end
     ) fmt
+
+  let emit level ?(details = `Null) message =
+    if should_log_module level then begin
+      let level_str = level_to_string level in
+      let prefix = Printf.sprintf "[%s] [%s] [%s]"
+        (timestamp ()) level_str M.name in
+      Printf.eprintf "%s %s\n%!" prefix message;
+      Ring.push ~raw_level:level_str ~normalized_level:level_str
+        ~module_name:M.name ~message ~details ()
+    end
 
   let debug fmt = log_module Debug fmt
   let info fmt = log_module Info fmt

--- a/lib/masc_log/log.mli
+++ b/lib/masc_log/log.mli
@@ -100,6 +100,7 @@ val client_tool_host_error :
     [M.name] controls the env-var key MASC_LOG_{NAME}_LEVEL
     and the context prefix in log output. *)
 module Make (_ : sig val name : string end) : sig
+  val emit : level -> ?details:Yojson.Safe.t -> string -> unit
   val debug : ('a, unit, string, unit) format4 -> 'a
   val info : ('a, unit, string, unit) format4 -> 'a
   val warn : ('a, unit, string, unit) format4 -> 'a
@@ -109,7 +110,7 @@ end
 (** {1 Pre-defined module loggers} *)
 
 module Coord : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
-module Mcp : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
+module Mcp : sig val emit : level -> ?details:Yojson.Safe.t -> string -> unit val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
 module Auth : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
 module Retry : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end
 module Backend : sig val debug : ('a, unit, string, unit) format4 -> 'a val info : ('a, unit, string, unit) format4 -> 'a val warn : ('a, unit, string, unit) format4 -> 'a val error : ('a, unit, string, unit) format4 -> 'a end

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -389,6 +389,19 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   in
   let end_time = Eio.Time.now clock in
   let duration_ms = int_of_float ((end_time -. start_time) *. 1000.0) in
+  let jsonrpc_id_str =
+    match id with
+    | `String s -> s
+    | `Int i -> string_of_int i
+    | `Intlit s -> s
+    | `Float f -> Printf.sprintf "%0.0f" f
+    | _ -> "unknown"
+  in
+  let mcp_session_detail =
+    match mcp_session_id with
+    | Some session_id -> `String session_id
+    | None -> `Null
+  in
 
   (* Resolve agent_name: session identity > arguments > fallback *)
   let agent_name =
@@ -416,12 +429,16 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     ~agent_id:agent_name ~tool_name:name ~success ~error_msg:error_detail
     ?trace_id:otel_trace_id ();
   if not success then
-    Log.emit Log.Error ~module_name:"MCP"
+    Log.Mcp.emit Log.Error
       ~details:
         (`Assoc
           [
             ("event_family", `String "tool_call_failure");
             ("tool_name", `String name);
+            ("phase", `String "failure");
+            ("request_id", `String jsonrpc_id_str);
+            ("session_id", mcp_session_detail);
+            ("outcome", `String "error");
             ("agent_name", `String agent_name);
             ("duration_ms", `Int duration_ms);
             ("timeout_hit", `Bool !timeout_hit);
@@ -565,14 +582,6 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     log_mcp_exn ~label:"activity graph emit failed" exn);
 
-  let jsonrpc_id_str =
-    match id with
-    | `String s -> s
-    | `Int i -> string_of_int i
-    | `Intlit s -> s
-    | `Float f -> Printf.sprintf "%0.0f" f
-    | _ -> "unknown"
-  in
   let trace_id =
     match otel_trace_id with
     | Some tid -> tid
@@ -668,6 +677,22 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     String_util.utf8_safe ~max_bytes:83 ~suffix:"..." message |> String_util.to_string
   in
   let preview = String.map (function '\n' -> ' ' | c -> c) preview in
-  Log.Mcp.info "%s -> %s" name preview;
+  Log.Mcp.emit Log.Info
+    ~details:
+      (`Assoc
+        [
+          ("event_family", `String "tool_call");
+          ("tool_name", `String name);
+          ("phase", `String "result");
+          ("request_id", `String jsonrpc_id_str);
+          ("session_id", mcp_session_detail);
+          ("agent_name", `String agent_name);
+          ("outcome", `String (if success then "ok" else "error"));
+          ("success", `Bool success);
+          ("duration_ms", `Int duration_ms);
+          ("attempts", `Int attempts);
+          ("timeout_hit", `Bool !timeout_hit);
+        ])
+    (Printf.sprintf "%s -> %s" name preview);
 
   result

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -395,6 +395,37 @@ let tool_call_outcome (json : Yojson.Safe.t) =
           | _ -> "unknown"))
   | _ -> "unknown"
 
+let jsonrpc_id_label = function
+  | `String s -> s
+  | `Int i -> string_of_int i
+  | `Intlit s -> s
+  | `Float f -> Printf.sprintf "%0.0f" f
+  | _ -> "?"
+
+let tool_profile_label = function
+  | Full -> "full"
+  | Managed_agent -> "managed_agent"
+  | Operator_remote -> "operator_remote"
+
+let mcp_tool_call_log_details ?outcome ~phase ~profile ~tool_name ~id
+    ?mcp_session_id () =
+  `Assoc
+    ([
+       ("event_family", `String "tool_call");
+       ("tool_name", `String tool_name);
+       ("phase", `String phase);
+       ("request_id", `String (jsonrpc_id_label id));
+       ( "session_id",
+         match mcp_session_id with
+         | Some session_id -> `String session_id
+         | None -> `Null );
+       ("profile", `String (tool_profile_label profile));
+     ]
+    @
+    match outcome with
+    | Some value -> [ ("outcome", `String value) ]
+    | None -> [])
+
 (** Handle incoming JSON-RPC request - Pure Eio Native *)
 let handle_request
     ~handle_call_tool_eio
@@ -492,14 +523,27 @@ let handle_request
                                make_error ~id (-32601)
                                  (unavailable_tool_message name)
                              else (
-                               Log.Mcp.info "tools/call: %s (id=%s, session=%s)" name
-                                 (match id with `Int i -> string_of_int i | `String s -> s | _ -> "?")
-                                 (match mcp_session_id with Some s -> s | None -> "none");
+                               Log.Mcp.emit Log.Info
+                                 ~details:
+                                   (mcp_tool_call_log_details ~phase:"started"
+                                      ~profile:call_profile ~tool_name:name ~id
+                                      ?mcp_session_id ())
+                                 (Printf.sprintf
+                                    "tools/call: %s (id=%s, session=%s)"
+                                    name (jsonrpc_id_label id)
+                                    (match mcp_session_id with Some s -> s | None -> "none"));
                                let result =
                                  handle_call_tool_eio ~sw ~clock ~profile ?mcp_session_id ?auth_token state id params
                                in
-                               Log.Mcp.info "tools/call completed: %s (outcome=%s)"
-                                 name (tool_call_outcome result);
+                               let outcome = tool_call_outcome result in
+                               Log.Mcp.emit Log.Info
+                                 ~details:
+                                   (mcp_tool_call_log_details ~phase:"completed"
+                                      ~profile:call_profile ~tool_name:name ~id
+                                      ?mcp_session_id ~outcome ())
+                                 (Printf.sprintf
+                                    "tools/call completed: %s (outcome=%s)"
+                                    name outcome);
                                result)
                            with Yojson.Safe.Util.Type_error (_, _) ->
                              make_error ~id (-32602) "Invalid params: name must be a string")

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -11,6 +11,7 @@ module Tool_dispatch = Masc_mcp.Tool_dispatch
 module Tool_result = Masc_mcp.Tool_result
 module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_registry = Masc_mcp.Keeper_registry
+module Masc_log = Log
 
 let () = Mirage_crypto_rng_unix.use_default ()
 
@@ -137,6 +138,39 @@ let int_field_exn label fields name =
   match List.assoc_opt name fields with
   | Some (`Int value) -> value
   | _ -> Alcotest.failf "%s missing int field %s" label name
+
+let latest_log_seq () =
+  match Masc_log.Ring.recent ~limit:1 () with
+  | (entry : Masc_log.Ring.entry) :: _ -> entry.seq
+  | [] -> -1
+
+let json_string_field_exn label json field =
+  match Yojson.Safe.Util.(json |> member field |> to_string_option) with
+  | Some value -> value
+  | None ->
+      Alcotest.failf "%s missing string field %s: %s" label field
+        (Yojson.Safe.to_string json)
+
+let log_detail_string (entry : Masc_log.Ring.entry) field =
+  Yojson.Safe.Util.(entry.details |> member field |> to_string_option)
+
+let find_mcp_tool_log_exn ~phase ~tool_name ~request_id entries =
+  match
+    List.find_opt
+      (fun entry ->
+        Option.equal String.equal (log_detail_string entry "phase") (Some phase)
+        && Option.equal String.equal
+             (log_detail_string entry "tool_name")
+             (Some tool_name)
+        && Option.equal String.equal
+             (log_detail_string entry "request_id")
+             (Some request_id))
+      entries
+  with
+  | Some entry -> entry
+  | None ->
+      Alcotest.failf "MCP tool log missing phase=%s tool=%s request_id=%s"
+        phase tool_name request_id
 
 let test_resolve_join_state_skips_read_only_lookup () =
   let called = ref false in
@@ -1910,6 +1944,77 @@ let test_handle_request_tools_call_board_post_structured_content () =
     Yojson.Safe.Util.(structured |> member "author" |> to_string);
   cleanup_dir base_path
 
+let test_handle_request_tools_call_logs_structured_mcp_details () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  Eio_context.set_switch sw;
+
+  let baseline = latest_log_seq () in
+  let base_path = temp_dir () in
+  let request_id = "1201" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      ignore (Masc_mcp.Coord.init state.room_config ~agent_name:None);
+      let request =
+        Yojson.Safe.to_string
+          (`Assoc
+            [
+              ("jsonrpc", `String "2.0");
+              ("id", `Int 1201);
+              ("method", `String "tools/call");
+              ( "params",
+                `Assoc
+                  [
+                    ("name", `String "masc_board_post");
+                    ( "arguments",
+                      `Assoc
+                        [
+                          ("content", `String "log details parity");
+                          ("author", `String "tester");
+                        ] );
+                  ] );
+            ])
+      in
+      let response =
+        Mcp_eio.handle_request ~clock ~sw ~mcp_session_id:"session-log" state
+          request
+      in
+      ignore (result_fields_exn response);
+      let entries =
+        Masc_log.Ring.recent ~limit:20 ~module_filter:"MCP"
+          ~since_seq:baseline ~order:`Oldest_first ()
+      in
+      let started =
+        find_mcp_tool_log_exn ~phase:"started" ~tool_name:"masc_board_post"
+          ~request_id entries
+      in
+      let result =
+        find_mcp_tool_log_exn ~phase:"result" ~tool_name:"masc_board_post"
+          ~request_id entries
+      in
+      let completed =
+        find_mcp_tool_log_exn ~phase:"completed" ~tool_name:"masc_board_post"
+          ~request_id entries
+      in
+      let check_common label (entry : Masc_log.Ring.entry) =
+        let details = entry.details in
+        Alcotest.(check string) (label ^ " event_family") "tool_call"
+          (json_string_field_exn label details "event_family");
+        Alcotest.(check string) (label ^ " session") "session-log"
+          (json_string_field_exn label details "session_id")
+      in
+      check_common "started" started;
+      check_common "result" result;
+      check_common "completed" completed;
+      Alcotest.(check string) "completed outcome" "ok"
+        (json_string_field_exn "completed" completed.details "outcome");
+      Alcotest.(check string) "result outcome" "ok"
+        (json_string_field_exn "result" result.details "outcome"))
+
 let test_handle_request_tools_call_records_keeper_usage_for_public_mcp () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2801,6 +2906,8 @@ let eio_tests = [
   (* cache get structured content test removed: cache tools retired (#3640) *)
   "handle tools/call board post structured content", `Quick,
     test_handle_request_tools_call_board_post_structured_content;
+  "handle tools/call logs structured MCP details", `Quick,
+    test_handle_request_tools_call_logs_structured_mcp_details;
   "handle tools/call records keeper usage for public MCP tool", `Quick,
     test_handle_request_tools_call_records_keeper_usage_for_public_mcp;
   "handle tools/call blocks keeper internal tool", `Quick,


### PR DESCRIPTION
## Summary
- Preserve structured MCP tool-call details for started/result/completed/failure log rows so the dashboard can render tool/phase/session chips consistently.
- Keep the existing tool_call_failure event family while adding phase/request/session/outcome fields to failure details.
- Increase the in-memory dashboard log ring from 5,000 to 50,000 entries so high-volume keeper traffic does not make recent MCP tool rows appear to vanish while JSONL still has them.

## Why
Successful MCP tool-call rows were logged with details=null, while the dashboard log UI derives tool usage chips from details. Under keeper-heavy traffic, the 5k in-memory ring also evicted recent MCP rows quickly, making MCP tool usage appear to disappear from the dashboard even though disk JSONL persisted the messages.

## Verification
- git diff --check origin/main...HEAD
- dune build --root . test/test_mcp_server_eio.exe --display short
- dune exec --root . -- test/test_mcp_server_eio.exe test eio 38

## Notes
- A full local test_mcp_server_eio.exe run still has pre-existing unrelated failures in `state 2 eio context delegation` and `eio 49 hyphenated generated alias claim_next...`; the new structured-log test passes in isolation.