### PR TITLE
fix(runtime): make Ollama probe thinking adaptive

### DIFF
--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -34,6 +34,7 @@ let dashboard_runtime_probe_cache : dashboard_runtime_probe_cache_entry option A
 
 let dashboard_runtime_probe_cache_ttl_sec = 30.0
 let dashboard_runtime_probe_force_min_refresh_sec = 10.0
+let dashboard_runtime_probe_timeout_sec = 15
 let dashboard_runtime_probe_refresh_in_flight = Atomic.make false
 let dashboard_runtime_probe_runner_hook : (unit -> Yojson.Safe.t) option Atomic.t =
   Atomic.make None
@@ -277,7 +278,7 @@ let run_dashboard_runtime_probe () =
   | Some hook -> hook ()
   | None ->
       Tool_local_runtime.runtime_ollama_probe_json ~probe_runs:2 ~max_tokens:8
-        ~timeout_sec:6 ~ps_timeout_sec:2 ()
+        ~timeout_sec:dashboard_runtime_probe_timeout_sec ~ps_timeout_sec:2 ()
 
 let dashboard_runtime_probe_cached_value () =
   match Atomic.get dashboard_runtime_probe_cache with

--- a/lib/tool_local_runtime.ml
+++ b/lib/tool_local_runtime.ml
@@ -153,12 +153,17 @@ let handle_runtime_ollama_probe _ctx args : tool_result =
           (parse_int_opt value)
     | _ -> Tool_local_runtime_probe.default_probe_timeout_sec
   in
+  let think =
+    match member "think" args with
+    | `Bool value -> value
+    | _ -> false
+  in
   ( true,
     json_ok
       [
         ( "result",
           runtime_ollama_probe_json ?server_url ?model ?prompt ?keep_alive
-            ~probe_runs ~max_tokens ~timeout_sec () );
+            ~probe_runs ~max_tokens ~think ~timeout_sec () );
       ] )
 
 let dispatch ctx ~name ~args : tool_result option =
@@ -207,6 +212,14 @@ let schemas : tool_schema list =
                   ("keep_alive", `Assoc [ ("type", `String "string") ]);
                   ("probe_runs", `Assoc [ ("type", `String "integer") ]);
                   ("max_tokens", `Assoc [ ("type", `String "integer") ]);
+                  ( "think",
+                    `Assoc
+                      [
+                        ("type", `String "boolean");
+                        ( "description",
+                          `String
+                            "Enable Ollama thinking mode for reasoning models. Defaults to false so short probes can reach the response field." );
+                      ] );
                   ("timeout_sec", `Assoc [ ("type", `String "integer") ]);
                 ] );
           ];

--- a/lib/tool_local_runtime.ml
+++ b/lib/tool_local_runtime.ml
@@ -153,18 +153,30 @@ let handle_runtime_ollama_probe _ctx args : tool_result =
           (parse_int_opt value)
     | _ -> Tool_local_runtime_probe.default_probe_timeout_sec
   in
-  let think =
-    match member "think" args with
-    | `Bool value -> value
-    | _ -> false
+  let think_mode =
+    match member "think_mode" args with
+    | `String value -> (
+        match Tool_local_runtime_probe.ollama_probe_think_mode_of_string value with
+        | Some mode -> Ok mode
+        | None ->
+            Error
+              "think_mode must be one of auto, disabled, or enabled")
+    | _ -> (
+        match member "think" args with
+        | `Bool true -> Ok Tool_local_runtime_probe.Think_enabled
+        | `Bool false -> Ok Tool_local_runtime_probe.Think_disabled
+        | _ -> Ok Tool_local_runtime_probe.Think_auto)
   in
-  ( true,
-    json_ok
-      [
-        ( "result",
-          runtime_ollama_probe_json ?server_url ?model ?prompt ?keep_alive
-            ~probe_runs ~max_tokens ~think ~timeout_sec () );
-      ] )
+  match think_mode with
+  | Error msg -> (false, json_error msg)
+  | Ok think_mode ->
+      ( true,
+        json_ok
+          [
+            ( "result",
+              runtime_ollama_probe_json ?server_url ?model ?prompt ?keep_alive
+                ~probe_runs ~max_tokens ~think_mode ~timeout_sec () );
+          ] )
 
 let dispatch ctx ~name ~args : tool_result option =
   match name with
@@ -218,7 +230,16 @@ let schemas : tool_schema list =
                         ("type", `String "boolean");
                         ( "description",
                           `String
-                            "Enable Ollama thinking mode for reasoning models. Defaults to false so short probes can reach the response field." );
+                            "Boolean shorthand for think_mode. false disables reasoning-mode thinking; true enables it." );
+                      ] );
+                  ( "think_mode",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ("enum", `List [ `String "auto"; `String "disabled"; `String "enabled" ]);
+                        ( "description",
+                          `String
+                            "Adaptive thinking policy for Ollama reasoning models. auto defaults to response-oriented non-thinking probes; enabled measures thinking path explicitly." );
                       ] );
                   ("timeout_sec", `Assoc [ ("type", `String "integer") ]);
                 ] );

--- a/lib/tool_local_runtime_probe.ml
+++ b/lib/tool_local_runtime_probe.ml
@@ -381,12 +381,13 @@ let should_attempt_generate_probe ~before_status ~before_error =
   | _, Some _ -> false
   | _ -> true
 
-let request_body_json ~keep_alive ~model_id ~prompt ~max_tokens =
+let request_body_json ~think ~keep_alive ~model_id ~prompt ~max_tokens =
   let fields =
     [
       Some ("model", `String model_id);
       Some ("prompt", `String prompt);
       Some ("stream", `Bool false);
+      Some ("think", `Bool think);
       (match Option.bind keep_alive trim_to_option with
       | Some value -> Some ("keep_alive", `String value)
       | None -> None);
@@ -402,13 +403,14 @@ let request_body_json ~keep_alive ~model_id ~prompt ~max_tokens =
   in
   `Assoc fields |> Yojson.Safe.to_string
 
-let run_single_probe ~keep_alive ~server_url ~model_id ~prompt ~max_tokens ~timeout_sec
-    ~run_index =
+let run_single_probe ~think ~keep_alive ~server_url ~model_id ~prompt ~max_tokens
+    ~timeout_sec ~run_index =
   let url = ollama_generate_url server_url in
   let started = Time_compat.now () in
   match
     http_post_json_text_with_status ~timeout_sec ~url
-      ~body_json:(request_body_json ~keep_alive ~model_id ~prompt ~max_tokens)
+      ~body_json:
+        (request_body_json ~think ~keep_alive ~model_id ~prompt ~max_tokens)
   with
   | Error err ->
       failed_probe_run ~run_index ~http_status:None
@@ -435,7 +437,7 @@ let run_single_probe ~keep_alive ~server_url ~model_id ~prompt ~max_tokens ~time
               ~wall_clock_ms json
 
 let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
-    ?keep_alive ?(max_tokens = 16)
+    ?keep_alive ?(max_tokens = 16) ?(think = false)
     ?(timeout_sec = default_probe_timeout_sec)
     ?(ps_timeout_sec = default_ps_timeout_sec) () =
   let server_url =
@@ -463,7 +465,7 @@ let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
         let completed_runs =
           List.init probe_runs (fun idx -> idx + 1)
           |> List.map (fun run_index ->
-                 run_single_probe ~keep_alive ~server_url ~model_id ~prompt
+                 run_single_probe ~think ~keep_alive ~server_url ~model_id ~prompt
                    ~max_tokens ~timeout_sec ~run_index)
         in
         let run_errors =
@@ -538,6 +540,7 @@ let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
       ("probe_runs_completed", `Int (List.length runs));
       ("keep_alive", string_opt_to_json (Option.bind keep_alive trim_to_option));
       ("max_tokens", `Int max_tokens);
+      ("think", `Bool think);
       ("timeout_sec", `Int timeout_sec);
       ("ps_timeout_sec", `Int ps_timeout_sec);
       ("prompt_chars", `Int (String.length prompt));

--- a/lib/tool_local_runtime_probe.ml
+++ b/lib/tool_local_runtime_probe.ml
@@ -30,6 +30,11 @@ type ollama_probe_run = {
   error : string option;
 }
 
+type ollama_probe_think_mode =
+  | Think_auto
+  | Think_disabled
+  | Think_enabled
+
 let bool_opt_to_json = Json_util.bool_opt_to_json
 
 let clamp ~min_value ~max_value value = max min_value (min max_value value)
@@ -84,6 +89,22 @@ let truncate_text ?(max_len = 160) text =
 
 let default_probe_timeout_sec = 6
 let default_ps_timeout_sec = 2
+
+let ollama_probe_think_mode_to_string = function
+  | Think_auto -> "auto"
+  | Think_disabled -> "disabled"
+  | Think_enabled -> "enabled"
+
+let ollama_probe_think_mode_of_string raw =
+  match String.lowercase_ascii (String.trim raw) with
+  | "auto" -> Some Think_auto
+  | "false" | "disabled" | "off" | "no" -> Some Think_disabled
+  | "true" | "enabled" | "on" | "yes" -> Some Think_enabled
+  | _ -> None
+
+let effective_think_enabled = function
+  | Think_enabled -> true
+  | Think_auto | Think_disabled -> false
 
 let string_or_fallback candidates =
   let rec loop = function
@@ -381,13 +402,13 @@ let should_attempt_generate_probe ~before_status ~before_error =
   | _, Some _ -> false
   | _ -> true
 
-let request_body_json ~think ~keep_alive ~model_id ~prompt ~max_tokens =
+let request_body_json ~think_enabled ~keep_alive ~model_id ~prompt ~max_tokens =
   let fields =
     [
       Some ("model", `String model_id);
       Some ("prompt", `String prompt);
       Some ("stream", `Bool false);
-      Some ("think", `Bool think);
+      Some ("think", `Bool think_enabled);
       (match Option.bind keep_alive trim_to_option with
       | Some value -> Some ("keep_alive", `String value)
       | None -> None);
@@ -403,14 +424,15 @@ let request_body_json ~think ~keep_alive ~model_id ~prompt ~max_tokens =
   in
   `Assoc fields |> Yojson.Safe.to_string
 
-let run_single_probe ~think ~keep_alive ~server_url ~model_id ~prompt ~max_tokens
-    ~timeout_sec ~run_index =
+let run_single_probe ~think_enabled ~keep_alive ~server_url ~model_id ~prompt
+    ~max_tokens ~timeout_sec ~run_index =
   let url = ollama_generate_url server_url in
   let started = Time_compat.now () in
   match
     http_post_json_text_with_status ~timeout_sec ~url
       ~body_json:
-        (request_body_json ~think ~keep_alive ~model_id ~prompt ~max_tokens)
+        (request_body_json ~think_enabled ~keep_alive ~model_id ~prompt
+           ~max_tokens)
   with
   | Error err ->
       failed_probe_run ~run_index ~http_status:None
@@ -437,7 +459,7 @@ let run_single_probe ~think ~keep_alive ~server_url ~model_id ~prompt ~max_token
               ~wall_clock_ms json
 
 let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
-    ?keep_alive ?(max_tokens = 16) ?(think = false)
+    ?keep_alive ?(max_tokens = 16) ?(think_mode = Think_auto)
     ?(timeout_sec = default_probe_timeout_sec)
     ?(ps_timeout_sec = default_ps_timeout_sec) () =
   let server_url =
@@ -452,6 +474,7 @@ let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
   let max_tokens = clamp ~min_value:1 ~max_value:128 max_tokens in
   let timeout_sec = clamp ~min_value:3 ~max_value:300 timeout_sec in
   let ps_timeout_sec = clamp ~min_value:1 ~max_value:30 ps_timeout_sec in
+  let think_enabled = effective_think_enabled think_mode in
   let before_status, loaded_before, before_error =
     fetch_ollama_ps ~timeout_sec:ps_timeout_sec ~server_url ()
   in
@@ -465,8 +488,8 @@ let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
         let completed_runs =
           List.init probe_runs (fun idx -> idx + 1)
           |> List.map (fun run_index ->
-                 run_single_probe ~think ~keep_alive ~server_url ~model_id ~prompt
-                   ~max_tokens ~timeout_sec ~run_index)
+                 run_single_probe ~think_enabled ~keep_alive ~server_url
+                   ~model_id ~prompt ~max_tokens ~timeout_sec ~run_index)
         in
         let run_errors =
           completed_runs
@@ -540,7 +563,8 @@ let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
       ("probe_runs_completed", `Int (List.length runs));
       ("keep_alive", string_opt_to_json (Option.bind keep_alive trim_to_option));
       ("max_tokens", `Int max_tokens);
-      ("think", `Bool think);
+      ("think_mode", `String (ollama_probe_think_mode_to_string think_mode));
+      ("think", `Bool think_enabled);
       ("timeout_sec", `Int timeout_sec);
       ("ps_timeout_sec", `Int ps_timeout_sec);
       ("prompt_chars", `Int (String.length prompt));

--- a/test/test_tool_local_runtime_probe.ml
+++ b/test/test_tool_local_runtime_probe.ml
@@ -45,8 +45,8 @@ let test_ollama_generate_parser_computes_tok_per_second () =
 let test_request_body_omits_keep_alive_by_default () =
   let json =
     Masc_mcp.Tool_local_runtime_probe.request_body_json
-      ~think:false ~keep_alive:None ~model_id:"qwen3.5:35b-a3b-coding-nvfp4"
-      ~prompt:"READY" ~max_tokens:8
+      ~think_enabled:false ~keep_alive:None
+      ~model_id:"qwen3.5:35b-a3b-coding-nvfp4" ~prompt:"READY" ~max_tokens:8
     |> Yojson.Safe.from_string
   in
   let open Yojson.Safe.Util in
@@ -58,7 +58,7 @@ let test_request_body_omits_keep_alive_by_default () =
 
 let test_request_body_can_enable_thinking () =
   let json =
-    Masc_mcp.Tool_local_runtime_probe.request_body_json ~think:true
+    Masc_mcp.Tool_local_runtime_probe.request_body_json ~think_enabled:true
       ~keep_alive:None ~model_id:"qwen3.5:35b-a3b-coding-nvfp4" ~prompt:"READY"
       ~max_tokens:8
     |> Yojson.Safe.from_string
@@ -70,7 +70,7 @@ let test_request_body_can_enable_thinking () =
 let test_request_body_keeps_explicit_keep_alive () =
   let json =
     Masc_mcp.Tool_local_runtime_probe.request_body_json
-      ~think:false ~keep_alive:(Some "90s")
+      ~think_enabled:false ~keep_alive:(Some "90s")
       ~model_id:"qwen3.5:35b-a3b-coding-nvfp4" ~prompt:"READY" ~max_tokens:8
     |> Yojson.Safe.from_string
   in
@@ -78,6 +78,27 @@ let test_request_body_keeps_explicit_keep_alive () =
   check (option string) "keep_alive included"
     (Some "90s")
     (json |> member "keep_alive" |> to_string_option)
+
+let test_think_mode_parses_adaptive_policy () =
+  let parse raw =
+    Masc_mcp.Tool_local_runtime_probe.ollama_probe_think_mode_of_string raw
+    |> Option.map
+         Masc_mcp.Tool_local_runtime_probe.ollama_probe_think_mode_to_string
+  in
+  check (option string) "auto parsed" (Some "auto") (parse " auto ");
+  check (option string) "disabled alias parsed" (Some "disabled")
+    (parse "off");
+  check (option string) "enabled alias parsed" (Some "enabled")
+    (parse "YES");
+  check (option string) "invalid rejected" None (parse "maybe")
+
+let test_auto_think_policy_prioritizes_response () =
+  check bool "auto disables thinking for readiness" false
+    (Masc_mcp.Tool_local_runtime_probe.effective_think_enabled
+       Masc_mcp.Tool_local_runtime_probe.Think_auto);
+  check bool "enabled opts into thinking" true
+    (Masc_mcp.Tool_local_runtime_probe.effective_think_enabled
+       Masc_mcp.Tool_local_runtime_probe.Think_enabled)
 
 let test_normalize_server_url_strips_trailing_slashes () =
   check string "normalizes trailing slash" "http://127.0.0.1:11434"
@@ -168,6 +189,10 @@ let () =
             test_request_body_can_enable_thinking;
           test_case "keeps explicit keep_alive when requested" `Quick
             test_request_body_keeps_explicit_keep_alive;
+          test_case "parses adaptive think policy" `Quick
+            test_think_mode_parses_adaptive_policy;
+          test_case "auto think policy prioritizes response" `Quick
+            test_auto_think_policy_prioritizes_response;
           test_case "computes tok per second from generate response" `Quick
             test_ollama_generate_parser_computes_tok_per_second;
         ] );

--- a/test/test_tool_local_runtime_probe.ml
+++ b/test/test_tool_local_runtime_probe.ml
@@ -45,20 +45,33 @@ let test_ollama_generate_parser_computes_tok_per_second () =
 let test_request_body_omits_keep_alive_by_default () =
   let json =
     Masc_mcp.Tool_local_runtime_probe.request_body_json
-      ~keep_alive:None ~model_id:"qwen3.5:35b-a3b-coding-nvfp4" ~prompt:"READY"
-      ~max_tokens:8
+      ~think:false ~keep_alive:None ~model_id:"qwen3.5:35b-a3b-coding-nvfp4"
+      ~prompt:"READY" ~max_tokens:8
     |> Yojson.Safe.from_string
   in
   let open Yojson.Safe.Util in
   check (option string) "keep_alive omitted"
     None
-    (json |> member "keep_alive" |> to_string_option)
+    (json |> member "keep_alive" |> to_string_option);
+  check bool "thinking disabled by default" false
+    (json |> member "think" |> to_bool)
+
+let test_request_body_can_enable_thinking () =
+  let json =
+    Masc_mcp.Tool_local_runtime_probe.request_body_json ~think:true
+      ~keep_alive:None ~model_id:"qwen3.5:35b-a3b-coding-nvfp4" ~prompt:"READY"
+      ~max_tokens:8
+    |> Yojson.Safe.from_string
+  in
+  let open Yojson.Safe.Util in
+  check bool "thinking can be requested" true
+    (json |> member "think" |> to_bool)
 
 let test_request_body_keeps_explicit_keep_alive () =
   let json =
     Masc_mcp.Tool_local_runtime_probe.request_body_json
-      ~keep_alive:(Some "90s") ~model_id:"qwen3.5:35b-a3b-coding-nvfp4"
-      ~prompt:"READY" ~max_tokens:8
+      ~think:false ~keep_alive:(Some "90s")
+      ~model_id:"qwen3.5:35b-a3b-coding-nvfp4" ~prompt:"READY" ~max_tokens:8
     |> Yojson.Safe.from_string
   in
   let open Yojson.Safe.Util in
@@ -151,6 +164,8 @@ let () =
             test_ollama_ps_non_200_is_reported_as_error;
           test_case "omits keep_alive by default" `Quick
             test_request_body_omits_keep_alive_by_default;
+          test_case "can enable thinking explicitly" `Quick
+            test_request_body_can_enable_thinking;
           test_case "keeps explicit keep_alive when requested" `Quick
             test_request_body_keeps_explicit_keep_alive;
           test_case "computes tok per second from generate response" `Quick

--- a/test/test_tool_local_runtime_probe.ml
+++ b/test/test_tool_local_runtime_probe.ml
@@ -100,6 +100,24 @@ let test_auto_think_policy_prioritizes_response () =
     (Masc_mcp.Tool_local_runtime_probe.effective_think_enabled
        Masc_mcp.Tool_local_runtime_probe.Think_enabled)
 
+let test_runtime_probe_reports_effective_think_mode () =
+  let open Yojson.Safe.Util in
+  let run mode =
+    Masc_mcp.Tool_local_runtime_probe.runtime_ollama_probe_json
+      ~server_url:"http://127.0.0.1:1" ~model:"dummy-probe-model"
+      ~think_mode:mode ~timeout_sec:3 ~ps_timeout_sec:1 ()
+  in
+  let auto = run Masc_mcp.Tool_local_runtime_probe.Think_auto in
+  check string "auto mode reported" "auto"
+    (auto |> member "think_mode" |> to_string);
+  check bool "auto effective think false" false
+    (auto |> member "think" |> to_bool);
+  let enabled = run Masc_mcp.Tool_local_runtime_probe.Think_enabled in
+  check string "enabled mode reported" "enabled"
+    (enabled |> member "think_mode" |> to_string);
+  check bool "enabled effective think true" true
+    (enabled |> member "think" |> to_bool)
+
 let test_normalize_server_url_strips_trailing_slashes () =
   check string "normalizes trailing slash" "http://127.0.0.1:11434"
     (Masc_mcp.Tool_local_runtime_probe.normalize_ollama_server_url
@@ -193,6 +211,8 @@ let () =
             test_think_mode_parses_adaptive_policy;
           test_case "auto think policy prioritizes response" `Quick
             test_auto_think_policy_prioritizes_response;
+          test_case "runtime probe reports effective think mode" `Quick
+            test_runtime_probe_reports_effective_think_mode;
           test_case "computes tok per second from generate response" `Quick
             test_ollama_generate_parser_computes_tok_per_second;
         ] );


### PR DESCRIPTION
## Summary\n- add adaptive Ollama probe thinking policy: think_mode auto|disabled|enabled\n- keep dashboard/readiness probes response-oriented by sending think:false in auto mode\n- keep explicit reasoning-path diagnostics available with think_mode: enabled or think: true\n- raise dashboard runtime probe timeout from 6s to 15s for large local models\n\n## Why\nqwen3.6 reasoning models can spend a short num_predict budget entirely in the thinking field and return an empty response. The dashboard probe wants readiness/output, not reasoning quality, so auto mode prioritizes response emission while preserving explicit opt-in for thinking diagnostics.\n\n## Verification\n- dune build --root . test/test_tool_local_runtime_probe.exe\n- ./_build/default/test/test_tool_local_runtime_probe.exe (14 tests)\n- dune build --root . test/test_dashboard_cache.exe\n- ./_build/default/test/test_dashboard_cache.exe (19 tests)\n- dune build --root . test/tool_matrix_case_runner.exe test/test_mcp_tool_matrix.exe\n- ./_build/default/test/tool_matrix_case_runner.exe masc_runtime_ollama_probe\n- ./_build/default/test/test_mcp_tool_matrix.exe (2 tests, full registry tools/call matrix)\n\n## Runtime evidence\n- qwen3.6:27b-coding-bf16 without think:false returned only thinking after ~91.8s with empty response\n- same repeated-prefix generate payload with think:false returned response READY in ~2.9s