### PR TITLE
[codex] reduce keeper tool drift and cold probe noise

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1909,7 +1909,7 @@ let run_turn
                         work. Three escape hatches, in priority order: \
                         (1) call extend_turns if the task is almost finished and more \
                         turns will close it out; \
-                        (2) call masc_board_post to hand off the current task and ask \
+                        (2) call keeper_board_post to hand off the current task and ask \
                         another keeper or operator for judgment when the work needs a \
                         decision you cannot make alone; \
                         (3) if you claimed a task, close it NOW before session ends \
@@ -1936,7 +1936,7 @@ let run_turn
                         [STATE] block. If more turns will genuinely finish the task, \
                         call extend_turns. If you are blocked on a decision or \
                         external input, post a question to the board via \
-                        masc_board_post rather than burning turns retrying — that is \
+                        keeper_board_post rather than burning turns retrying — that is \
                         the intended judgment-escalation path."
                        computed_surface.per_call_turn
                        computed_surface.per_call_max_turns)

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -277,7 +277,7 @@ let run_dashboard_runtime_probe () =
   | Some hook -> hook ()
   | None ->
       Tool_local_runtime.runtime_ollama_probe_json ~probe_runs:2 ~max_tokens:8
-        ~timeout_sec:6 ~ps_timeout_sec:2 ()
+        ~timeout_sec:6 ~ps_timeout_sec:2 ~generate_when_unloaded:false ()
 
 let dashboard_runtime_probe_cached_value () =
   match Atomic.get dashboard_runtime_probe_cache with

--- a/lib/tool_local_runtime.ml
+++ b/lib/tool_local_runtime.ml
@@ -153,12 +153,17 @@ let handle_runtime_ollama_probe _ctx args : tool_result =
           (parse_int_opt value)
     | _ -> Tool_local_runtime_probe.default_probe_timeout_sec
   in
+  let generate_when_unloaded =
+    match member "generate_when_unloaded" args with
+    | `Bool flag -> flag
+    | _ -> true
+  in
   ( true,
     json_ok
       [
         ( "result",
           runtime_ollama_probe_json ?server_url ?model ?prompt ?keep_alive
-            ~probe_runs ~max_tokens ~timeout_sec () );
+            ~probe_runs ~max_tokens ~timeout_sec ~generate_when_unloaded () );
       ] )
 
 let dispatch ctx ~name ~args : tool_result option =
@@ -208,6 +213,7 @@ let schemas : tool_schema list =
                   ("probe_runs", `Assoc [ ("type", `String "integer") ]);
                   ("max_tokens", `Assoc [ ("type", `String "integer") ]);
                   ("timeout_sec", `Assoc [ ("type", `String "integer") ]);
+                  ("generate_when_unloaded", `Assoc [ ("type", `String "boolean") ]);
                 ] );
           ];
     };

--- a/lib/tool_local_runtime_probe.ml
+++ b/lib/tool_local_runtime_probe.ml
@@ -375,11 +375,12 @@ let model_is_loaded model_id loaded_models =
       | None -> false)
     loaded_models
 
-let should_attempt_generate_probe ~before_status ~before_error =
+let should_attempt_generate_probe ~before_status ~before_error
+    ~generate_when_unloaded ~effective_model_loaded_before =
   match before_status, before_error with
-  | Some 200, _ -> true
+  | Some 200, _ -> generate_when_unloaded || effective_model_loaded_before
   | _, Some _ -> false
-  | _ -> true
+  | _ -> generate_when_unloaded || effective_model_loaded_before
 
 let request_body_json ~keep_alive ~model_id ~prompt ~max_tokens =
   let fields =
@@ -437,7 +438,8 @@ let run_single_probe ~keep_alive ~server_url ~model_id ~prompt ~max_tokens ~time
 let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
     ?keep_alive ?(max_tokens = 16)
     ?(timeout_sec = default_probe_timeout_sec)
-    ?(ps_timeout_sec = default_ps_timeout_sec) () =
+    ?(ps_timeout_sec = default_ps_timeout_sec)
+    ?(generate_when_unloaded = true) () =
   let server_url =
     Option.bind server_url trim_to_option
     |> Option.value ~default:Env_config_runtime.Ollama.server_url
@@ -454,11 +456,30 @@ let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
     fetch_ollama_ps ~timeout_sec:ps_timeout_sec ~server_url ()
   in
   let effective_model = select_effective_model ~requested_model:model loaded_before in
-  let runs, run_errors =
+  let effective_model_loaded_before =
     match effective_model with
-    | None -> ([], [ "No Ollama model was requested, loaded, or configured via OLLAMA_DEFAULT_MODEL." ])
-    | Some _ when not (should_attempt_generate_probe ~before_status ~before_error) ->
-        ([], [])
+    | Some model_id -> model_is_loaded model_id loaded_before
+    | None -> false
+  in
+  let runs, run_errors, generate_skipped_unloaded_model =
+    match effective_model with
+    | None ->
+        ( [],
+          [
+            "No Ollama model was requested, loaded, or configured via OLLAMA_DEFAULT_MODEL.";
+          ],
+          false )
+    | Some _ when
+        not
+          (should_attempt_generate_probe ~before_status ~before_error
+             ~generate_when_unloaded ~effective_model_loaded_before) ->
+        let skipped_unloaded_model =
+          match before_status, before_error with
+          | Some 200, None ->
+              not generate_when_unloaded && not effective_model_loaded_before
+          | _ -> false
+        in
+        ([], [], skipped_unloaded_model)
     | Some model_id ->
         let completed_runs =
           List.init probe_runs (fun idx -> idx + 1)
@@ -470,18 +491,13 @@ let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
           completed_runs
           |> List.filter_map (fun run -> run.error)
         in
-        (completed_runs, run_errors)
+        (completed_runs, run_errors, false)
   in
   let after_status, loaded_after, after_error =
     fetch_ollama_ps ~timeout_sec:ps_timeout_sec ~server_url ()
   in
   let runs_json = List.map ollama_probe_run_to_yojson runs in
   let kv_cache_assessment = kv_cache_assessment_json runs_json in
-  let effective_model_loaded_before =
-    match effective_model with
-    | Some model_id -> model_is_loaded model_id loaded_before
-    | None -> false
-  in
   let effective_model_loaded_after =
     match effective_model with
     | Some model_id -> model_is_loaded model_id loaded_after
@@ -497,6 +513,11 @@ let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
     |> (fun items ->
          if not effective_model_loaded_before && effective_model_loaded_after then
            "Probe appears to have loaded the model into Ollama residency."
+           :: items
+         else items)
+    |> (fun items ->
+         if generate_skipped_unloaded_model then
+           "Skipped /api/generate because the effective model was not resident; dashboard probes avoid cold-loading Ollama models."
            :: items
          else items)
     |> (fun items ->
@@ -536,6 +557,8 @@ let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
       ("effective_model", string_opt_to_json effective_model);
       ("probe_runs_requested", `Int probe_runs);
       ("probe_runs_completed", `Int (List.length runs));
+      ("generate_when_unloaded", `Bool generate_when_unloaded);
+      ("generate_skipped_unloaded_model", `Bool generate_skipped_unloaded_model);
       ("keep_alive", string_opt_to_json (Option.bind keep_alive trim_to_option));
       ("max_tokens", `Int max_tokens);
       ("timeout_sec", `Int timeout_sec);

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -78,7 +78,7 @@ let test_no_overlap_alias_and_hallucinated () =
 
 let test_alias_table_is_stable () =
   let pairs = Alias.all_aliases () in
-  Alcotest.(check int) "five canonical aliases" 5 (List.length pairs);
+  Alcotest.(check int) "six canonical aliases" 6 (List.length pairs);
   (* Round-trip: every alias should round-trip via to_internal then to_public,
      except where collapse happens (Write -> keeper_fs_edit -> Edit). *)
   List.iter

--- a/test/test_tool_local_runtime_probe.ml
+++ b/test/test_tool_local_runtime_probe.ml
@@ -126,12 +126,20 @@ let test_kv_cache_assessment_requires_two_successful_runs () =
 let test_generate_probe_is_skipped_after_failed_preflight () =
   check bool "ps preflight error skips generate" false
     (Masc_mcp.Tool_local_runtime_probe.should_attempt_generate_probe
-       ~before_status:None
-       ~before_error:(Some "curl exit code 28"));
+       ~before_status:None ~before_error:(Some "curl exit code 28")
+       ~generate_when_unloaded:true ~effective_model_loaded_before:true);
   check bool "successful ps allows generate" true
     (Masc_mcp.Tool_local_runtime_probe.should_attempt_generate_probe
-       ~before_status:(Some 200)
-       ~before_error:None)
+       ~before_status:(Some 200) ~before_error:None
+       ~generate_when_unloaded:true ~effective_model_loaded_before:false);
+  check bool "successful ps skips cold model when disabled" false
+    (Masc_mcp.Tool_local_runtime_probe.should_attempt_generate_probe
+       ~before_status:(Some 200) ~before_error:None
+       ~generate_when_unloaded:false ~effective_model_loaded_before:false);
+  check bool "resident model can still be probed when cold load disabled" true
+    (Masc_mcp.Tool_local_runtime_probe.should_attempt_generate_probe
+       ~before_status:(Some 200) ~before_error:None
+       ~generate_when_unloaded:false ~effective_model_loaded_before:true)
 
 let () =
   run "tool_local_runtime_probe"


### PR DESCRIPTION
## Summary
- Replace keeper turn-pressure guidance references to keeper-owned board tools so taskmaster stops being nudged toward public `masc_board_post`.
- Add `generate_when_unloaded` to Ollama runtime probes and disable cold `/api/generate` from dashboard snapshots.
- Fix stale keeper alias-table test count for the existing `Shell -> keeper_bash` alias.

## Root Cause
Keeper guidance mixed public MASC tool names into keeper-only turns, which produced partial-tolerance warnings even though valid keeper tools existed. Separately, dashboard runtime snapshots called Ollama `/api/generate` even when `/api/ps` reported no resident model, causing repeated cold-load timeout noise.

## Validation
- `opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/keeper-tool-namespace-probe-noise @install`
- `opam exec -- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/keeper-tool-namespace-probe-noise -- ./test/test_tool_local_runtime_probe.exe`
- `opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/keeper-tool-namespace-probe-noise test/test_keeper_tool_alias.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/keeper-tool-namespace-probe-noise/_build/default/test/test_keeper_tool_alias.exe`
- `opam exec -- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/keeper-tool-namespace-probe-noise -- ./test/test_dashboard_tools.exe`
- `git diff --check`