### PR TITLE
[codex] Fix keeper roster identity matching

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -14,6 +14,7 @@ import {
   keeperRuntimeName,
   mergeRosterAgent,
   filterAgentRoster,
+  countRuntimeKinds,
 } from './agent-roster'
 import type { Agent, Keeper } from '../types'
 import {
@@ -323,6 +324,36 @@ describe('keeperRuntimeName', () => {
 
   it('falls back to name when agent_name is undefined', () => {
     expect(keeperRuntimeName({ name: 'keeper1' })).toBe('keeper1')
+  })
+})
+
+describe('countRuntimeKinds', () => {
+  it('does not classify generated taskmaster nicknames as the taskmaster keeper', () => {
+    const result = countRuntimeKinds(
+      [
+        makeAgent({
+          name: 'keeper-taskmaster-agent',
+          agent_type: 'agent',
+        }),
+        makeAgent({
+          name: 'taskmaster-proud-bear',
+          agent_type: 'taskmaster',
+        }),
+      ],
+      [
+        {
+          name: 'taskmaster',
+          agent_name: 'keeper-taskmaster-agent',
+          status: 'active',
+        } as Keeper,
+      ],
+    )
+
+    expect(result).toEqual({
+      agents: 1,
+      keepers: 1,
+      totalRuntimes: 2,
+    })
   })
 })
 

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -161,9 +161,12 @@ function buildKeeperRuntimeLookup(keeperList: Keeper[]): Map<string, Keeper> {
 }
 
 function findKeeperRuntime(agentName: string, keeperList: Keeper[]): Keeper | null {
+  const target = agentName.trim()
+  if (!target) return null
   for (const k of keeperList) {
-    if (k.name === agentName || k.agent_name === agentName
-        || agentName.includes(k.name) || k.name?.includes(agentName)) {
+    const keeperName = k.name?.trim()
+    const keeperAgentName = k.agent_name?.trim()
+    if (keeperName === target || keeperAgentName === target) {
       return k
     }
   }


### PR DESCRIPTION
## Summary
- tighten dashboard keeper runtime matching to exact keeper name or agent_name only
- prevent generated nicknames like taskmaster-proud-bear from being classified/displayed as the taskmaster keeper
- add a regression test for taskmaster keeper plus generated taskmaster agent counts

## Validation
- pnpm vitest run src/components/agent-roster.test.ts --no-file-parallelism --maxWorkers=1
- pnpm typecheck
- pnpm --dir dashboard exec eslint src/components/agent-roster.ts src/components/agent-roster.test.ts (exit 0, files ignored by current allowlist config)