### PR TITLE
fix(keeper): repair profile resync after tool preset provenance

### DIFF
--- a/lib/keeper/keeper_identity.ml
+++ b/lib/keeper/keeper_identity.ml
@@ -105,6 +105,18 @@ let canonical_keeper_name raw_name =
     | None ->
         if Keeper_config.validate_name trimmed then Some trimmed else None
 
+let explicit_keeper_name raw_name =
+  let trimmed = String.trim raw_name in
+  let prefix = "keeper-" in
+  let plen = String.length prefix in
+  let alen = String.length trimmed in
+  if trimmed = "" then None
+  else if alen > plen && String.sub trimmed 0 plen = prefix then
+    let candidate = String.sub trimmed plen (alen - plen) in
+    if Keeper_config.validate_name candidate then Some candidate else None
+  else if Keeper_config.validate_name trimmed then Some trimmed
+  else None
+
 type parsed_identity = {
   keeper_name : string;
   agent_name : string;
@@ -122,7 +134,7 @@ let parse_json_identity json =
   let keeper_name =
     match raw_keeper_name with
     | Some value when String.trim value <> "" ->
-        (match canonical_keeper_name value with
+        (match explicit_keeper_name value with
          | Some name -> name
          | None -> String.trim value)
     | _ ->

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -26,6 +26,25 @@ let apply_default opt current = match opt with Some v -> v | None -> current
 (** Same as [apply_default] but both TOML and meta are option-typed. *)
 let apply_default_opt opt current = match opt with Some _ -> opt | None -> current
 
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop idx =
+    if needle_len = 0 then true
+    else if idx + needle_len > haystack_len then false
+    else if String.sub haystack idx needle_len = needle then true
+    else loop (idx + 1)
+  in
+  loop 0
+
+let invalid_profile_defaults_error ~keeper_name detail =
+  if contains_substring detail "cascade_name" then
+    Printf.sprintf
+      "invalid profile.cascade_name for keeper %s: unknown cascade_name: %s"
+      keeper_name detail
+  else
+    Printf.sprintf "invalid keeper profile for keeper %s: %s" keeper_name detail
+
 let effective_declarative_cascade_name
     (defaults : Keeper_types_profile.keeper_profile_defaults)
     (meta : keeper_meta) =
@@ -66,7 +85,13 @@ let ensure_keeper_meta config name =
        Persisted meta may have stale values from a previous session;
        persona config (TOML) plus explicit env overrides are the source of truth.
        Fields where TOML has [Some v] are overwritten; [None] keeps runtime value. *)
-    let defaults = Keeper_types_profile.load_keeper_profile_defaults meta.name in
+    let defaults_result =
+      Keeper_types_profile.load_keeper_profile_defaults_result meta.name
+    in
+    match defaults_result with
+    | Error detail ->
+        Error (invalid_profile_defaults_error ~keeper_name:meta.name detail)
+    | Ok defaults ->
 
     (* --- Proactive --- *)
     let target_proactive =

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -630,7 +630,10 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         match str "cascade_name" with
         | None -> Ok ()
         | Some raw ->
-            let normalized = String.trim raw |> String.lowercase_ascii in
+            let normalized =
+              Keeper_cascade_profile.normalize_declared_name raw
+              |> String.lowercase_ascii
+            in
             let compile_known = Keeper_cascade_profile.known_cascades in
             let phase_routing = [ "local_only"; "local_recovery" ] in
             let catalog =

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -1234,7 +1234,8 @@ let resolved_persona_name ~keeper_name
   | Some name when String.trim name <> "" -> name
   | _ -> keeper_name
 
-let load_keeper_profile_defaults name : keeper_profile_defaults =
+let load_keeper_profile_defaults_result name :
+    (keeper_profile_defaults, string) result =
   (* Priority: TOML config/keepers/<name>.toml > persona profile.json.
      If TOML sets [persona_name], load that persona first and treat TOML as a
      thin overlay instead of duplicating the full keeper profile. *)
@@ -1247,12 +1248,22 @@ let load_keeper_profile_defaults name : keeper_profile_defaults =
              let persona_defaults =
                load_keeper_profile_defaults_from_persona persona_name
              in
-             merge_keeper_profile_defaults ~agent_name:name ~base:persona_defaults ~overlay:defaults
-         | None -> defaults)
-     | Error e ->
-       Log.Keeper.warn "toml config for %s failed (%s), falling back to persona" name e;
-       load_keeper_profile_defaults_from_persona name)
+             Ok
+               (merge_keeper_profile_defaults ~agent_name:name
+                  ~base:persona_defaults ~overlay:defaults)
+         | None -> Ok defaults)
+     | Error e -> Error e)
   | None ->
+    Ok (load_keeper_profile_defaults_from_persona name)
+
+let load_keeper_profile_defaults name : keeper_profile_defaults =
+  match load_keeper_profile_defaults_result name with
+  | Ok defaults -> defaults
+  | Error e ->
+    (match keeper_toml_path_opt name with
+     | Some _ ->
+       Log.Keeper.warn "toml config for %s failed (%s), falling back to persona" name e
+     | None -> ());
     load_keeper_profile_defaults_from_persona name
 
 (** Clamp a profile-provided max-turns override to [1, 50] — the same range

--- a/test/test_keeper_identity_parse.ml
+++ b/test/test_keeper_identity_parse.ml
@@ -21,6 +21,21 @@ let test_valid_trace_id () =
       check string "agent_name" "keeper-alice-agent" meta.agent_name
   | Error e -> fail ("expected Ok, got Error: " ^ e)
 
+let test_explicit_keeper_name_is_not_nickname_canonicalized () =
+  let json =
+    `Assoc
+      [ ("name", `String "personality-resync-test")
+      ; ("agent_name", `String "personality-resync-test")
+      ; ("trace_id", `String "personality-resync-test-001")
+      ; ("goal", `String "test")
+      ]
+  in
+  match Keeper_types.meta_of_json json with
+  | Ok meta ->
+      check string "explicit keeper name"
+        "personality-resync-test" meta.name
+  | Error e -> fail ("expected Ok, got Error: " ^ e)
+
 let test_legacy_keeper_cascade_alias_preserved_raw () =
   (* Parse should preserve the raw cascade_name as declared in JSON so the
      dashboard can surface config drift between the declared value and its
@@ -113,6 +128,8 @@ let () =
   run "keeper_identity_parse"
     [ ( "parse_keeper_identity"
       , [ test_case "valid trace_id" `Quick test_valid_trace_id
+        ; test_case "explicit keeper name is not nickname-canonicalized" `Quick
+            test_explicit_keeper_name_is_not_nickname_canonicalized
         ; test_case "legacy keeper cascade alias preserved raw" `Quick
             test_legacy_keeper_cascade_alias_preserved_raw
         ; test_case "unknown cascade name preserved raw" `Quick

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -43,6 +43,18 @@ let write_persisted_meta_file config meta =
   write_file path (Yojson.Safe.pretty_to_string (Keeper_types.meta_to_json meta));
   path
 
+let seed_persisted_meta config meta =
+  let path = write_persisted_meta_file config meta in
+  Fs_compat.clear_fs ();
+  match Keeper_types.read_meta_file_path path with
+  | Ok (Some _) -> (
+      match Keeper_types.read_meta config meta.Keeper_types.name with
+      | Ok (Some _) -> ()
+      | Ok None -> fail ("persisted meta fixture not found via read_meta: " ^ path)
+      | Error e -> fail ("persisted meta fixture read_meta failed: " ^ e))
+  | Ok None -> fail ("persisted meta fixture was not readable: " ^ path)
+  | Error e -> fail ("persisted meta fixture read failed: " ^ e)
+
 let contains_substring haystack needle =
   let haystack_len = String.length haystack in
   let needle_len = String.length needle in
@@ -126,9 +138,7 @@ instructions = "TOML instructions"
     | Ok meta -> meta
     | Error e -> fail ("meta_of_json failed: " ^ e)
   in
-  (match Keeper_types.write_meta ~force:true config initial_meta with
-  | Error e -> fail ("write_meta failed: " ^ e)
-  | Ok () -> ());
+  seed_persisted_meta config initial_meta;
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
@@ -172,9 +182,7 @@ policy_voice_enabled = false
     | Ok meta -> meta
     | Error e -> fail ("meta_of_json failed: " ^ e)
   in
-  (match Keeper_types.write_meta ~force:true config initial_meta with
-  | Error e -> fail ("write_meta failed: " ^ e)
-  | Ok () -> ());
+  seed_persisted_meta config initial_meta;
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
@@ -214,9 +222,7 @@ shared_memory_scope = "room"
     | Ok meta -> meta
     | Error e -> fail ("meta_of_json failed: " ^ e)
   in
-  (match Keeper_types.write_meta ~force:true config initial_meta with
-  | Error e -> fail ("write_meta failed: " ^ e)
-  | Ok () -> ());
+  seed_persisted_meta config initial_meta;
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
@@ -326,9 +332,7 @@ tool_also_allow = ["keeper_bash", "keeper_shell"]
     | Ok meta -> meta
     | Error e -> fail ("meta_of_json failed: " ^ e)
   in
-  (match Keeper_types.write_meta ~force:true config initial_meta with
-  | Error e -> fail ("write_meta failed: " ^ e)
-  | Ok () -> ());
+  seed_persisted_meta config initial_meta;
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
@@ -504,9 +508,7 @@ allowed_paths = []
     | Ok meta -> meta
     | Error e -> fail ("meta_of_json failed: " ^ e)
   in
-  (match Keeper_types.write_meta ~force:true config initial_meta with
-  | Error e -> fail ("write_meta failed: " ^ e)
-  | Ok () -> ());
+  seed_persisted_meta config initial_meta;
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
@@ -548,9 +550,7 @@ let test_persona_allowed_paths_is_ignored () =
     | Ok meta -> meta
     | Error e -> fail ("meta_of_json failed: " ^ e)
   in
-  (match Keeper_types.write_meta ~force:true config initial_meta with
-  | Error e -> fail ("write_meta failed: " ^ e)
-  | Ok () -> ());
+  seed_persisted_meta config initial_meta;
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
@@ -593,9 +593,7 @@ allowed_paths = ["workspace/example/project"]
     | Ok meta -> meta
     | Error e -> fail ("meta_of_json failed: " ^ e)
   in
-  (match Keeper_types.write_meta ~force:true config initial_meta with
-  | Error e -> fail ("write_meta failed: " ^ e)
-  | Ok () -> ());
+  seed_persisted_meta config initial_meta;
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
@@ -678,9 +676,7 @@ tool_preset = "delivery"
     | Ok meta -> meta
     | Error e -> fail ("meta_of_json failed: " ^ e)
   in
-  (match Keeper_types.write_meta ~force:true config initial_meta with
-  | Error e -> fail ("write_meta failed: " ^ e)
-  | Ok () -> ());
+  seed_persisted_meta config initial_meta;
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
@@ -738,9 +734,7 @@ per_provider_timeout = 0
     | Ok meta -> meta
     | Error e -> fail ("meta_of_json failed: " ^ e)
   in
-  (match Keeper_types.write_meta ~force:true config initial_meta with
-  | Error e -> fail ("write_meta failed: " ^ e)
-  | Ok () -> ());
+  seed_persisted_meta config initial_meta;
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
@@ -782,9 +776,7 @@ let test_persona_invalid_per_provider_timeout_clears_stale_runtime () =
     | Ok meta -> meta
     | Error e -> fail ("meta_of_json failed: " ^ e)
   in
-  (match Keeper_types.write_meta ~force:true config initial_meta with
-  | Error e -> fail ("write_meta failed: " ^ e)
-  | Ok () -> ());
+  seed_persisted_meta config initial_meta;
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
@@ -840,9 +832,7 @@ goal = "minimal TOML"
     | Ok meta -> meta
     | Error e -> fail ("meta_of_json failed: " ^ e)
   in
-  (match Keeper_types.write_meta ~force:true config initial_meta with
-  | Error e -> fail ("write_meta failed: " ^ e)
-  | Ok () -> ());
+  seed_persisted_meta config initial_meta;
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
@@ -888,9 +878,7 @@ work_discovery_guidance = "TOML guidance"
     | Ok meta -> meta
     | Error e -> fail ("meta_of_json failed: " ^ e)
   in
-  (match Keeper_types.write_meta ~force:true config initial_meta with
-  | Error e -> fail ("write_meta failed: " ^ e)
-  | Ok () -> ());
+  seed_persisted_meta config initial_meta;
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
@@ -934,9 +922,7 @@ tool_preset = "social"
     | Ok meta -> meta
     | Error e -> fail ("meta_of_json failed: " ^ e)
   in
-  (match Keeper_types.write_meta ~force:true config initial_meta with
-  | Error e -> fail ("write_meta failed: " ^ e)
-  | Ok () -> ());
+  seed_persisted_meta config initial_meta;
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
@@ -975,9 +961,7 @@ social_model = "magentic_ledger_v1"
     | Ok meta -> meta
     | Error e -> fail ("meta_of_json failed: " ^ e)
   in
-  (match Keeper_types.write_meta ~force:true config initial_meta with
-  | Error e -> fail ("write_meta failed: " ^ e)
-  | Ok () -> ());
+  seed_persisted_meta config initial_meta;
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
@@ -1016,9 +1000,7 @@ cascade_name = "missing_profile"
     | Ok meta -> meta
     | Error e -> fail ("meta_of_json failed: " ^ e)
   in
-  (match Keeper_types.write_meta ~force:true config initial_meta with
-  | Error e -> fail ("write_meta failed: " ^ e)
-  | Ok () -> ());
+  seed_persisted_meta config initial_meta;
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Ok updated ->
       failf "expected unknown cascade_name to be rejected, got %s"
@@ -1058,9 +1040,7 @@ let test_room_presence_syncs_capabilities () =
     | Ok meta -> meta
     | Error e -> fail ("meta_of_json failed: " ^ e)
   in
-  (match Keeper_types.write_meta ~force:true config initial_meta with
-  | Error e -> fail ("write_meta failed: " ^ e)
-  | Ok () -> ());
+  seed_persisted_meta config initial_meta;
   ignore
     (Coord.join config ~agent_name ~capabilities:[ "keeper"; "preset:minimal" ] ());
   let _synced = Keeper_exec_context.ensure_keeper_room_presence config initial_meta in


### PR DESCRIPTION
## Summary
- preserve explicit keeper names when reading persisted meta fixtures
- seed runtime SSOT tests through on-disk meta so post-merge #9688 no longer misses persisted meta
- validate legacy cascade aliases after normalization and surface invalid profile defaults in ensure_keeper_meta

## Verification
- env DUNE_CACHE=disabled timeout 600 dune exec --root . ./test/test_keeper_runtime_config_ssot.exe
- env DUNE_CACHE=disabled timeout 120 dune exec --root . ./test/test_keeper_identity_parse.exe
- env DUNE_CACHE=disabled timeout 600 dune exec --root . ./test/test_keeper_toml.exe
- env DUNE_CACHE=disabled timeout 600 dune exec --root . ./test/test_keeper_agent_isolation.exe
- env DUNE_CACHE=disabled timeout 900 dune build --root . @check