### PR TITLE
Repair existing keeper sandbox clone checkouts

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -2127,39 +2127,65 @@ let handle_keeper_shell
                Process_eio.run_argv_with_status ?env ~cwd ~timeout_sec argv
          in
          if Fs_compat.file_exists clone_path then
-           (* Already cloned — pull latest instead *)
-           let st, out =
-             if docker_hard_mode_brokered then
-               run_brokered_git ~cwd:repos_dir ~timeout_sec:60.0
-                 [ "git"; "-C"; clone_path; "pull"; "--ff-only" ]
-             else if meta.sandbox_profile = Docker then
-               match
-                 run_docker_shell_command_with_status ~config ~meta ~cwd:repos_dir
-                   ~timeout_sec:60.0
-                   ~cmd:(Printf.sprintf "git -C %s pull --ff-only"
-                           (Filename.quote repo_name))
-                   ~git_creds_enabled:true ~network_mode:Network_inherit
-               with
-               | Ok result -> (result.status, result.output)
-               | Error msg -> (Unix.WEXITED 127, msg)
-             else
-               Process_eio.run_argv_with_status ~timeout_sec:60.0
-                 [ "git"; "-C"; clone_path; "pull"; "--ff-only" ]
-           in
-           if st = Unix.WEXITED 0 then
-             update_playground_repo_cache
-               ~playground_dir:playground ~repo_name ~repo_path:clone_path
-               ~action:"pull" ~shallow:false;
-           Yojson.Safe.to_string
-             (`Assoc
-                 ([ "ok", `Bool (st = Unix.WEXITED 0)
-                  ; "op", `String op
-                  ; "action", `String "pull"
-                  ; "path", `String clone_path
-                  ; "status", Keeper_alerting_path.process_status_to_json st
-                  ; "output", `String out
-                  ]
-                 @ route_fields))
+           (* Existing sandbox clones may have a .git directory but no
+              checked-out files. Repair that locally before a pull, otherwise
+              git can report "Already up to date" while the worktree stays
+              unusable for read/search tools. *)
+           (match Coord_worktree.ensure_sandbox_clone_ready clone_path with
+            | Error err ->
+                Yojson.Safe.to_string
+                  (`Assoc
+                      ([ "ok", `Bool false
+                       ; "op", `String op
+                       ; "action", `String "repair_existing_clone"
+                       ; "path", `String clone_path
+                       ; "error", `String "sandbox_clone_not_ready"
+                       ; "status",
+                         Keeper_alerting_path.process_status_to_json
+                           (Unix.WEXITED 1)
+                       ; "output", `String (Types.masc_error_to_string err)
+                       ]
+                      @ route_fields))
+            | Ok repair_note ->
+                (* Already cloned — pull latest instead *)
+                let st, out =
+                  if docker_hard_mode_brokered then
+                    run_brokered_git ~cwd:repos_dir ~timeout_sec:60.0
+                      [ "git"; "-C"; clone_path; "pull"; "--ff-only" ]
+                  else if meta.sandbox_profile = Docker then
+                    match
+                      run_docker_shell_command_with_status ~config ~meta
+                        ~cwd:repos_dir ~timeout_sec:60.0
+                        ~cmd:(Printf.sprintf "git -C %s pull --ff-only"
+                                (Filename.quote repo_name))
+                        ~git_creds_enabled:true ~network_mode:Network_inherit
+                    with
+                    | Ok result -> (result.status, result.output)
+                    | Error msg -> (Unix.WEXITED 127, msg)
+                  else
+                    Process_eio.run_argv_with_status ~timeout_sec:60.0
+                      [ "git"; "-C"; clone_path; "pull"; "--ff-only" ]
+                in
+                if st = Unix.WEXITED 0 then
+                  update_playground_repo_cache
+                    ~playground_dir:playground ~repo_name ~repo_path:clone_path
+                    ~action:"pull" ~shallow:false;
+                let repair_fields =
+                  match repair_note with
+                  | None -> []
+                  | Some note -> [ "repair_note", `String note ]
+                in
+                Yojson.Safe.to_string
+                  (`Assoc
+                      ([ "ok", `Bool (st = Unix.WEXITED 0)
+                       ; "op", `String op
+                       ; "action", `String "pull"
+                       ; "path", `String clone_path
+                       ; "status", Keeper_alerting_path.process_status_to_json st
+                       ; "output", `String out
+                       ]
+                      @ repair_fields
+                      @ route_fields)))
          else
            let depth = Keeper_tool_policy.clone_depth () |> max 0 in
            let depth_args =

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -62,6 +62,19 @@ let rec ensure_dir path =
     if parent <> path then ensure_dir parent;
     Unix.mkdir path 0o755)
 
+let run_ok ~cwd cmd =
+  let wrapped =
+    Printf.sprintf "cd %s && %s > /dev/null 2>&1" (Filename.quote cwd) cmd
+  in
+  let code = Sys.command wrapped in
+  if code <> 0 then
+    Alcotest.failf "command failed (%d): %s" code cmd
+
+let clear_checkout_but_keep_git_dir root =
+  Sys.readdir root
+  |> Array.iter (fun name ->
+    if name <> ".git" then cleanup_dir (Filename.concat root name))
+
 let make_meta ~name ~sandbox =
   let json =
     `Assoc
@@ -412,6 +425,49 @@ done\n\
 printf 'stdout:%s\\n' \"$*\"\n\
 exit 0\n"
 
+let test_git_clone_repairs_existing_docker_clone_checkout () =
+  with_tool_policy_config @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_fake_docker fake_docker_echo_script @@ fun () ->
+  setup ~sandbox:Keeper_types.Docker
+  @@ fun ~config ~meta ~playground ->
+  let source_repo = Filename.concat playground "source-masc-mcp" in
+  ensure_dir source_repo;
+  run_ok ~cwd:source_repo "git init -q -b main";
+  run_ok ~cwd:source_repo "git config user.email test@example.com";
+  run_ok ~cwd:source_repo "git config user.name Test";
+  let source_readme = Filename.concat source_repo "README.md" in
+  write_file source_readme "# sandbox clone\n";
+  run_ok ~cwd:source_repo "git add README.md";
+  run_ok ~cwd:source_repo "git commit -q -m init";
+  let repos_dir = Filename.concat playground "repos" in
+  ensure_dir repos_dir;
+  let clone_path = Filename.concat repos_dir "masc-mcp" in
+  run_ok ~cwd:repos_dir
+    (Printf.sprintf "git clone -q %s masc-mcp" (Filename.quote source_repo));
+  let restored_readme = Filename.concat clone_path "README.md" in
+  clear_checkout_but_keep_git_dir clone_path;
+  Alcotest.(check bool) "checkout file removed before repair" false
+    (Sys.file_exists restored_readme);
+  let raw =
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
+      ~args:
+        (`Assoc
+          [
+            ("op", `String "git_clone");
+            ("url", `String "https://github.com/jeong-sik/masc-mcp.git");
+          ])
+  in
+  Alcotest.(check (option bool)) "git_clone succeeds after checkout repair"
+    (Some true)
+    (parse_bool_field raw "ok");
+  Alcotest.(check (option string)) "via=docker" (Some "docker")
+    (parse_string_field raw "via");
+  Alcotest.(check bool) "checkout restored" true
+    (Sys.file_exists restored_readme);
+  Alcotest.(check bool) "repair note surfaced" true
+    (response_mentions raw "repair_note" "checkout was restored")
+
 let test_bash_fake_docker_executes () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_echo_script @@ fun () ->
@@ -466,5 +522,7 @@ let () =
             test_git_clone_routes_through_docker;
           Alcotest.test_case "hard mode git_clone uses brokered route" `Quick
             test_hard_mode_git_clone_uses_brokered_route;
+          Alcotest.test_case "git_clone repairs existing docker clone checkout"
+            `Quick test_git_clone_repairs_existing_docker_clone_checkout;
         ] );
     ]


### PR DESCRIPTION
Fixes #9592. This patch reuses Coord_worktree.ensure_sandbox_clone_ready in keeper_shell op=git_clone before pulling an existing sandbox clone, so a repo that still has .git but lost checked-out files is restored from HEAD instead of being treated as ready. It also surfaces repair_note in the tool response and adds a docker-route regression test that deletes the checkout, reruns git_clone, and verifies the file is restored. Validation before rebase: dune build --root . --build-dir _build_verify_clone_guard test/test_keeper_shell_docker_route.exe; dune exec --root . --build-dir _build_verify_clone_guard test/test_keeper_shell_docker_route.exe; dune exec --root . --build-dir _build_verify_clone_guard test/test_keeper_repo_readiness.exe; dune build --root . --build-dir _build_verify_clone_guard @check; git diff --check. After rebase onto c8871b2b3: git diff --check origin/main..HEAD passed. Post-rebase dune reruns were blocked by unrelated long-running concurrent dune builds in other sessions, so they were stopped to avoid adding more contention.