### PR TITLE
fix(dashboard): canonicalize token-bound MCP actor

### DIFF
--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -292,6 +292,28 @@ describe('callMcpTool', () => {
     })
   }, 60_000)
 
+  it('omits implicit dashboard actor for token-bound sessions without actor metadata', async () => {
+    getStoredToken.mockReturnValue('codex-token')
+    getStoredTokenMeta.mockReturnValue(null)
+    isRemoteAccess.mockReturnValue(true)
+    authHeaders.mockImplementation((opts?: { actorName?: string | null }) => ({
+      Authorization: 'Bearer codex-token',
+      ...(opts?.actorName ? { 'X-MASC-Agent': opts.actorName } : {}),
+    }))
+    setupMcpSessionMocks('sess-token-owner')
+
+    const { callMcpTool } = await import('./mcp')
+    await callMcpTool('masc_persona_list', {})
+
+    const toolCall = findCallByMethod('tools/call')
+    expect(toolCall).toBeDefined()
+    const body = JSON.parse(toolCall![1].body as string)
+    expect(body.params.arguments).toEqual({})
+    const headers = toolCall![1].headers as Record<string, string>
+    expect(headers.Authorization).toBe('Bearer codex-token')
+    expect(headers['X-MASC-Agent']).toBeUndefined()
+  }, 60_000)
+
   it('treats legacy agent_name as payload when the session is token-authenticated', async () => {
     authHeaders.mockImplementation((opts?: { actorName?: string | null }) => (
       opts?.actorName ? { 'X-MASC-Agent': opts.actorName } : {}

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -160,6 +160,15 @@ function explicitToolActor(args: Record<string, unknown>): string | null {
     : null
 }
 
+function implicitToolActor(): string | null {
+  const actor = currentDashboardActor()
+  if (!actor) return null
+  if (!getStoredToken()) return actor
+  const meta = getStoredTokenMeta()
+  if (meta?.source === 'dev' || meta?.actor) return actor
+  return null
+}
+
 function mcpHeadersForActor(
   actorName?: string | null,
   extra?: Record<string, string>,
@@ -314,7 +323,7 @@ async function callMcpToolInternal(
     await ensureSession()
     phase = 'tools/call'
     const explicitActor = explicitToolActor(args)
-    const actor = explicitActor ?? currentDashboardActor()
+    const actor = explicitActor ?? implicitToolActor()
     const toolArgs =
       explicitActor == null && actor
         ? { ...args, _agent_name: actor }

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -173,6 +173,14 @@ let inject_agent_name_into_body ?(rewrite_existing = false) ~agent_name body_str
     | _ -> body_str
   with Eio.Cancel.Cancelled _ as e -> raise e | _ -> body_str
 
+let body_with_canonical_http_actor ~base_path ~auth_token request body_str =
+  match Server_auth.dashboard_actor_for_request ~base_path request with
+  | None -> body_str
+  | Some agent ->
+      inject_agent_name_into_body
+        ~rewrite_existing:(Option.is_some auth_token)
+        ~agent_name:agent body_str
+
 let handle_post_mcp ~deps ?(profile = Full) request reqd =
   (* Readiness gate: reject before session/auth if server state is not ready *)
   if not (deps.is_ready ()) then
@@ -189,9 +197,6 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
   let protocol_version = get_protocol_version_for_session ~session_id request in
   let origin = deps.get_origin request in
   let base_path = deps.get_base_path () in
-  let http_agent_name =
-    Server_auth.dashboard_actor_for_request ~base_path request
-  in
   let auth_result =
     match profile with
     | Full | Managed_agent ->
@@ -340,12 +345,8 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
                                 inline_sse := Some info;
                                 spawn_post_sse_keepalive ~sw ~clock info);
                               let body_with_agent =
-                                match http_agent_name with
-                                | None -> body_str
-                                | Some agent ->
-                                    inject_agent_name_into_body
-                                      ~rewrite_existing:(Option.is_some auth_token)
-                                      ~agent_name:agent body_str
+                                body_with_canonical_http_actor ~base_path
+                                  ~auth_token request body_str
                               in
                               let response_json =
                                 runtime.handle_request ?auth_token ~profile
@@ -715,9 +716,13 @@ let handle_post_messages ~deps request reqd =
               | Ok runtime ->
                   let sw = runtime.sw in
                   Eio.Fiber.fork ~sw (fun () ->
+                  let body_with_agent =
+                    body_with_canonical_http_actor ~base_path ~auth_token
+                      request body_str
+                  in
                   let response_json =
                     runtime.handle_request ~mcp_session_id:session_id
-                      ?auth_token body_str
+                      ?auth_token body_with_agent
                   in
                   (match response_json with
                   | `Null -> ()

--- a/lib/server/server_mcp_transport_http.mli
+++ b/lib/server/server_mcp_transport_http.mli
@@ -45,6 +45,12 @@ val validate_mcp_session_delete_profile :
 val method_from_body : string -> string option
 val inject_agent_name_into_body :
   ?rewrite_existing:bool -> agent_name:string -> string -> string
+val body_with_canonical_http_actor :
+  base_path:string ->
+  auth_token:string option ->
+  Httpun.Request.t ->
+  string ->
+  string
 val validate_session_requirement :
   session_was_provided:bool -> string -> (unit, string) result
 val protocol_version_from_body : string -> string option

--- a/test/test_mcp_session_coverage.ml
+++ b/test/test_mcp_session_coverage.ml
@@ -11,6 +11,26 @@
 open Alcotest
 
 module Http_transport = Masc_mcp.Server_mcp_transport_http
+module Auth = Masc_mcp.Auth
+
+let setup_test_room () =
+  let unique_id =
+    Printf.sprintf "masc-mcp-session-coverage-%d-%d"
+      (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))
+  in
+  let tmp = Filename.concat (Filename.get_temp_dir_name ()) unique_id in
+  Unix.mkdir tmp 0o755;
+  tmp
+
+let cleanup_test_room dir =
+  let rec rm_rf path =
+    if Sys.is_directory path then begin
+      Array.iter (fun f -> rm_rf (Filename.concat path f)) (Sys.readdir path);
+      Unix.rmdir path
+    end else
+      Sys.remove path
+  in
+  try rm_rf dir with _ -> ()
 
 (* ============================================================
    base62_chars Tests
@@ -184,6 +204,41 @@ let test_inject_agent_name_rewrites_internal_actor_only () =
   check (option string) "preserves target agent_name" (Some "target-keeper")
     (member "agent_name" args |> to_string_option)
 
+let test_body_with_canonical_http_actor_uses_token_owner () =
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      let raw_token = "codex-token" in
+      (match
+         Auth.save_raw_token_credential dir ~agent_name:"codex"
+           ~role:Types.Worker ~raw_token
+       with
+       | Ok _ -> ()
+       | Error e -> fail (Types.masc_error_to_string e));
+      let headers =
+        Httpun.Headers.of_list
+          [
+            ("authorization", "Bearer " ^ raw_token);
+            ("x-masc-agent", "dashboard");
+          ]
+      in
+      let request = Httpun.Request.create ~headers `POST "/messages" in
+      let body =
+        {|{"jsonrpc":"2.0","method":"tools/call","params":{"name":"masc_keeper_status","arguments":{"_agent_name":"dashboard","name":"sangsu"}},"id":1}|}
+      in
+      let args =
+        Http_transport.body_with_canonical_http_actor ~base_path:dir
+          ~auth_token:(Some raw_token) request body
+        |> tool_arguments_of_body
+      in
+      let open Yojson.Safe.Util in
+      check (option string) "token owner rewrites stale dashboard actor"
+        (Some "codex")
+        (member "_agent_name" args |> to_string_option);
+      check (option string) "tool target arg preserved" (Some "sangsu")
+        (member "name" args |> to_string_option))
+
 (* ============================================================
    Test Runners
    ============================================================ *)
@@ -307,5 +362,7 @@ let () =
         test_inject_agent_name_preserves_legacy_target_by_default;
       test_case "rewrite_existing only rewrites _agent_name" `Quick
         test_inject_agent_name_rewrites_internal_actor_only;
+      test_case "canonical http actor uses token owner" `Quick
+        test_body_with_canonical_http_actor_uses_token_owner;
     ];
   ]


### PR DESCRIPTION
## Summary

Fixes a dashboard MCP auth drift where a browser session could send a bearer token owned by one agent, while still injecting the default `dashboard` actor into MCP tool arguments. That produced errors such as `No credential found for dashboard (bearer token belongs to codex)` even though the token itself was valid.

## Changes

- Add a shared server helper that canonicalizes MCP tool-call bodies from the HTTP bearer token owner.
- Apply the same canonicalization to both streamable `/mcp` POSTs and legacy `/messages` POSTs.
- Stop the dashboard client from implicitly injecting `_agent_name: dashboard` when it has a non-dev bearer token without actor metadata, letting the server derive the actor from the token owner.
- Add OCaml and dashboard tests covering stale dashboard actor rewrite and token-bound client calls without actor metadata.

## Validation

- `git diff --check origin/main...HEAD`
- `dune build --root . test/test_mcp_session_coverage.exe test/test_mcp_post_sse_e2e.exe --display short`
- `dune exec --root . -- test/test_mcp_session_coverage.exe`
- `dune exec --root . -- test/test_mcp_post_sse_e2e.exe`
- `./node_modules/.bin/vitest run src/api/mcp.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm typecheck`

Note: targeted ESLint returned only existing configuration warnings because `src/api/mcp.ts` and `src/api/mcp.test.ts` are not included in the dashboard ESLint target file list.