### PR TITLE
fix(keeper): guard json member calls against non-object input

### DIFF
--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -10,10 +10,13 @@ let json_int_opt_member key json =
   | _ -> None
 
 let json_float_opt_member key json =
-  match Yojson.Safe.Util.member key json with
-  | `Float value -> Some value
-  | `Int value -> Some (float_of_int value)
-  | `Intlit raw -> float_of_string_opt raw
+  match json with
+  | `Assoc _ ->
+    (match Yojson.Safe.Util.member key json with
+     | `Float value -> Some value
+     | `Int value -> Some (float_of_int value)
+     | `Intlit raw -> float_of_string_opt raw
+     | _ -> None)
   | _ -> None
 
 let json_string_opt_member key json =
@@ -29,13 +32,19 @@ let json_string_opt_value = function
   | _ -> None
 
 let json_bool_opt_member key json =
-  match Yojson.Safe.Util.member key json with
-  | `Bool value -> Some value
+  match json with
+  | `Assoc _ ->
+    (match Yojson.Safe.Util.member key json with
+     | `Bool value -> Some value
+     | _ -> None)
   | _ -> None
 
 let json_list_member key json =
-  match Yojson.Safe.Util.member key json with
-  | `List items -> items
+  match json with
+  | `Assoc _ ->
+    (match Yojson.Safe.Util.member key json with
+     | `List items -> items
+     | _ -> [])
   | _ -> []
 
 let json_string_list_member key json =

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -157,8 +157,11 @@ let assoc_bool_opt key fields =
   | _ -> None
 
 let json_string_opt_member json key =
-  match Yojson.Safe.Util.member key json with
-  | `String value -> nonempty_trimmed value
+  match json with
+  | `Assoc _ ->
+    (match Yojson.Safe.Util.member key json with
+     | `String value -> nonempty_trimmed value
+     | _ -> None)
   | _ -> None
 
 let latest_metrics_json ~metrics_store ~metrics_path ~tail_bytes =


### PR DESCRIPTION
## Problem

Dashboard /api/v1/dashboard/goals returned 500 with:
Yojson__Safe.Util.Type_error(\"Can't get member 'selected_model' of non-object type null\", ...)

## Root Cause

json_string_opt_member and related helpers called Yojson.Safe.Util.member without checking if input JSON was an object. When a keeper decision had a missing or Null telemetry field, the helper crashed.

## Fix

Add Assoc pattern guard to all *_opt_member helpers. Non-object input returns fail-open default (None / []).

## Files Changed

- lib/keeper/keeper_runtime_trust_snapshot.ml
- lib/keeper/keeper_status_detail.ml

## Verification

- dune build @check passes