### PR TITLE
fix(dashboard): tolerate null keeper telemetry

### DIFF
--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -1,30 +1,25 @@
 open Keeper_types
 
+let json_member_opt key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+
 let json_int_opt_member key json =
-  match json with
-  | `Assoc _ -> (
-      match Yojson.Safe.Util.member key json with
-      | `Int n -> Some n
-      | `Intlit raw -> int_of_string_opt raw
-      | _ -> None)
+  match json_member_opt key json with
+  | Some (`Int n) -> Some n
+  | Some (`Intlit raw) -> int_of_string_opt raw
   | _ -> None
 
 let json_float_opt_member key json =
-  match json with
-  | `Assoc _ ->
-    (match Yojson.Safe.Util.member key json with
-     | `Float value -> Some value
-     | `Int value -> Some (float_of_int value)
-     | `Intlit raw -> float_of_string_opt raw
-     | _ -> None)
+  match json_member_opt key json with
+  | Some (`Float value) -> Some value
+  | Some (`Int value) -> Some (float_of_int value)
+  | Some (`Intlit raw) -> float_of_string_opt raw
   | _ -> None
 
 let json_string_opt_member key json =
-  match json with
-  | `Assoc _ -> (
-      match Yojson.Safe.Util.member key json with
-      | `String value when String.trim value <> "" -> Some value
-      | _ -> None)
+  match json_member_opt key json with
+  | Some (`String value) when String.trim value <> "" -> Some value
   | _ -> None
 
 let json_string_opt_value = function
@@ -32,19 +27,13 @@ let json_string_opt_value = function
   | _ -> None
 
 let json_bool_opt_member key json =
-  match json with
-  | `Assoc _ ->
-    (match Yojson.Safe.Util.member key json with
-     | `Bool value -> Some value
-     | _ -> None)
+  match json_member_opt key json with
+  | Some (`Bool value) -> Some value
   | _ -> None
 
 let json_list_member key json =
-  match json with
-  | `Assoc _ ->
-    (match Yojson.Safe.Util.member key json with
-     | `List items -> items
-     | _ -> [])
+  match json_member_opt key json with
+  | Some (`List items) -> items
   | _ -> []
 
 let json_string_list_member key json =

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -774,6 +774,14 @@ let parsed_field_key_names =
   ; "cascade_name"
   ]
 
+(** Accepted TOML keys that are not materialized by
+    [profile_defaults_of_toml], but are intentionally not treated as unknown
+    config drift. *)
+let accepted_non_materialized_key_names =
+  [ "tool_access.kind"
+  ; "tool_access.preset"
+  ]
+
 (** Canonical TOML key names used by [detect_unknown_keeper_toml_keys].
     Keys outside this set under [[keeper]] (or any other table) are silently
     ignored by the loader, which historically let dead config accumulate
@@ -781,8 +789,9 @@ let parsed_field_key_names =
     uses this list to surface drift on boot, symmetric with
     [warn_unknown_keeper_meta_keys] on the JSON side.
 
-    Must be kept in sync with [parsed_field_key_names] — the assertion below
-    catches drift at compile time. *)
+    Must be kept in sync with [parsed_field_key_names] plus
+    [accepted_non_materialized_key_names] — the assertion below catches drift at
+    compile time. *)
 let canonical_keeper_toml_key_names =
   [ "name"
   ; "persona_name"
@@ -830,7 +839,8 @@ let canonical_keeper_toml_key_names =
 let () =
   assert (
     List.sort String.compare canonical_keeper_toml_key_names
-    = List.sort String.compare parsed_field_key_names)
+    = List.sort String.compare
+        (parsed_field_key_names @ accepted_non_materialized_key_names))
 
 (** Pure detector: returns TOML keys that [profile_defaults_of_toml] does not
     consume.  Exposed separately from the logging wrapper so tests can

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -98,6 +98,18 @@ let append_keeper_receipt (config : Coord.config) (meta : Keeper_types.keeper_me
   in
   Keeper_execution_receipt.append config receipt
 
+let append_null_telemetry_decision (config : Coord.config)
+    (meta : Keeper_types.keeper_meta) =
+  Fs_compat.append_jsonl
+    (Keeper_types.keeper_decision_log_path config meta.name)
+    (`Assoc
+      [
+        ("turn_id", `Int 8);
+        ("turn_verdict", `String "run");
+        ("wall_clock_at_decision", `Float (Unix.gettimeofday ()));
+        ("telemetry", `Null);
+      ])
+
 let test_blocked_phase_projects_blocked_health () =
   with_room @@ fun config ->
   let _goal, _kind =
@@ -170,6 +182,32 @@ let test_goal_detail_surfaces_keeper_runtime_trust_and_blockers () =
         "execution_receipt"
         (linked_keeper |> member "latest_causal_event" |> member "kind" |> to_string)
 
+let test_goals_tree_tolerates_null_decision_telemetry () =
+  with_room @@ fun config ->
+  let goal, _kind =
+    match Goal_store.upsert_goal config ~title:"Ship null telemetry" () with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  let meta = make_keeper_meta ~name:"null-telemetry-keeper" ~goal_id:goal.id in
+  (match Keeper_types.write_meta ~force:true config meta with
+   | Ok () -> ()
+   | Error err -> fail ("write_meta failed: " ^ err));
+  append_null_telemetry_decision config meta;
+  let tree_json = Dashboard_goals.dashboard_goals_tree_json ~config in
+  ignore (tree_json |> member "tree" |> to_list);
+  match Dashboard_goals.goal_detail_json ~config ~goal_id:goal.id with
+  | Error msg -> fail msg
+  | Ok json ->
+      let linked_keeper =
+        match json |> member "linked_keepers" |> to_list with
+        | keeper :: _ -> keeper
+        | [] -> fail "expected linked keeper detail"
+      in
+      check bool "selected model remains null" true
+        (linked_keeper |> member "runtime_trust" |> member "selected_model"
+        = `Null)
+
 let test_goal_detail_does_not_promote_synthetic_blocker_over_receipt () =
   with_room @@ fun config ->
   let goal, _kind =
@@ -228,6 +266,8 @@ let () =
           test_case "goal detail surfaces keeper runtime trust and blockers"
             `Quick
             test_goal_detail_surfaces_keeper_runtime_trust_and_blockers;
+          test_case "goals tree tolerates null decision telemetry" `Quick
+            test_goals_tree_tolerates_null_decision_telemetry;
           test_case
             "goal detail keeps synthetic runtime blocker out of latest causal"
             `Quick

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -987,6 +987,9 @@ cascade_name = "big_three"
 github_identity = "anyang-keepers"
 git_identity_mode = "keeper_alias"
 active_goal_ids = ["goal-runtime"]
+[keeper.tool_access]
+kind = "preset"
+preset = "coding"
 |} in
   match TL.parse_toml input with
   | Error e -> fail e


### PR DESCRIPTION
## Summary
- make keeper runtime trust JSON member reads safe for null/non-object telemetry payloads
- add a dashboard goals regression test for decision logs with telemetry: null
- keep keeper TOML canonical-key assertions from treating accepted non-materialized tool_access keys as parsed fields

## Verification
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-goals-null-telemetry --build-dir /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-goals-null-telemetry/_build_goals_fix ./test/test_keeper_toml.exe
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-goals-null-telemetry --build-dir /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-goals-null-telemetry/_build_goals_fix ./test/test_dashboard_goals.exe
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-goals-null-telemetry --build-dir /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-goals-null-telemetry/_build_goals_fix @check
- git diff --check

Note: global @fmt reports pre-existing repo-wide formatting drift unrelated to this change.