### PR TITLE
[codex] Protect draft PRs from auto-ready by default

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -44,11 +44,19 @@ jobs:
               (process.env.AGENT_DRAFT_GUARD_BRANCH_RE || String.raw`^(codex[/-]|keeper[/-])`),
               "i"
             );
-            const bypassLabels = (process.env.AGENT_DRAFT_GUARD_BYPASS_LABELS || "human-approved-ready,allow-auto-merge")
+            const automationProneBypassLabels = new Set(["allow-auto-merge"]);
+            const bypassLabels = (process.env.AGENT_DRAFT_GUARD_BYPASS_LABELS || "human-approved-ready")
               .split(",")
               .map((s) => s.trim().toLowerCase())
+              .filter((label) => !automationProneBypassLabels.has(label))
               .filter(Boolean);
             const labels = (pr.labels || []).map((label) => label.name.toLowerCase());
+            const ignoredBypassLabels = labels.filter((label) =>
+              automationProneBypassLabels.has(label)
+            );
+            if (ignoredBypassLabels.length > 0) {
+              core.info(`Ignoring automation-prone bypass labels: ${ignoredBypassLabels.join(", ")}.`);
+            }
 
             const looksAgentAuthored =
               titlePattern.test(pr.title || "") ||
@@ -129,11 +137,13 @@ jobs:
             }
 
             const marker = "<!-- masc-agent-draft-guard -->";
+            const bypassLabelList =
+              bypassLabels.length > 0 ? bypassLabels.join(", ") : "(no configured bypass labels)";
             const body = [
               marker,
               `Draft PR guard reapplied: ${actions.join(", ")}.`,
               "",
-              `This repository treats draft PRs as draft-only until a human explicitly opts in by adding one of these labels: ${bypassLabels.join(", ")}.`
+              `This repository treats draft PRs as draft-only until a human explicitly opts in by adding one of these labels: ${bypassLabelList}.`
             ].join("\n");
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner,

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -22,7 +22,7 @@ jobs:
     name: Draft Auto-Merge Guard
     runs-on: ubuntu-latest
     steps:
-      - name: Keep agent PRs draft-only unless explicitly approved
+      - name: Keep draft PRs draft-only unless explicitly approved
         uses: actions/github-script@v9
         env:
           AGENT_DRAFT_GUARD_TITLE_RE: ${{ vars.AGENT_DRAFT_GUARD_TITLE_RE }}
@@ -50,15 +50,11 @@ jobs:
               .filter(Boolean);
             const labels = (pr.labels || []).map((label) => label.name.toLowerCase());
 
-            const guarded =
+            const looksAgentAuthored =
               titlePattern.test(pr.title || "") ||
               branchPattern.test(pr.head?.ref || "") ||
               labels.includes("agent-pr") ||
               labels.includes("codex");
-            if (!guarded) {
-              core.info("PR is not agent-guarded; skip draft auto-merge guard.");
-              return;
-            }
 
             const hasBypass = labels.some((label) => bypassLabels.includes(label));
             if (hasBypass) {
@@ -85,6 +81,20 @@ jobs:
               number: pullNumber
             });
             const current = result.repository.pullRequest;
+            const draftBoundaryAction =
+              action === "ready_for_review" ||
+              action === "auto_merge_enabled" ||
+              action === "converted_to_draft";
+            const guarded =
+              current.isDraft ||
+              Boolean(current.autoMergeRequest) ||
+              draftBoundaryAction ||
+              looksAgentAuthored;
+            if (!guarded) {
+              core.info("PR is not draft, auto-merge-enabled, draft-boundary, or agent-like; skip draft auto-merge guard.");
+              return;
+            }
+
             const actions = [];
 
             if (current.autoMergeRequest) {
@@ -114,16 +124,16 @@ jobs:
             }
 
             if (actions.length === 0) {
-              core.info("Guarded agent PR is already draft-only.");
+              core.info("Guarded PR is already draft-only.");
               return;
             }
 
             const marker = "<!-- masc-agent-draft-guard -->";
             const body = [
               marker,
-              `Agent draft guard reapplied: ${actions.join(", ")}.`,
+              `Draft PR guard reapplied: ${actions.join(", ")}.`,
               "",
-              `This repository treats agent-created PRs as draft-only until a human explicitly opts in by adding one of these labels: ${bypassLabels.join(", ")}.`
+              `This repository treats draft PRs as draft-only until a human explicitly opts in by adding one of these labels: ${bypassLabels.join(", ")}.`
             ].join("\n");
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner,
@@ -151,7 +161,7 @@ jobs:
             }
 
             if (action === "ready_for_review" || action === "auto_merge_enabled") {
-              core.setFailed(`Agent draft guard blocked ${action}: ${actions.join(", ")}.`);
+              core.setFailed(`Draft PR guard blocked ${action}: ${actions.join(", ")}.`);
             }
 
   label-and-review:


### PR DESCRIPTION
## Summary

This hardens the PR Automation draft guard after #9702 and #9707 showed that title/branch heuristics and the `allow-auto-merge` label are not safe enough.

- Treat current draft PRs, PRs with auto-merge enabled, and `ready_for_review` / `auto_merge_enabled` / `converted_to_draft` events as guarded by default.
- Keep the older agent-like title/branch/label hints as an additional safety net, but no longer rely on them as the only guard predicate.
- Ignore `allow-auto-merge` as an automation-prone bypass label, even if it appears in `AGENT_DRAFT_GUARD_BYPASS_LABELS`.
- Keep `human-approved-ready` as the default explicit human bypass label.

Refs #9690.

## Incident Evidence

- #9702 was manually restored to draft, then auto-merge was enabled again at 2026-04-23T15:14:42Z and it merged at 2026-04-23T15:17:30Z as `b7227b2c4abd505db7fe14d4bab77fb9462ce121`.
- #9707 itself was also auto-converted to ready and given `allow-auto-merge` before the second hardening commit, confirming that label-only bypass is not reliable.

## Validation

- `ruby -e 'require "yaml"; ...'` parsed `.github/workflows/pr-automation.yml` and verified both jobs exist.
- `node -e '...'` extracted the embedded `github-script` block and verified JavaScript syntax in an async wrapper.
- Local JS simulation verified the #9702/#9707-shaped `auto_merge_enabled` case disables auto-merge, converts back to draft, comments, and fails the guard job.
- Local JS simulation verified `ready_for_review` is converted back to draft without bypass, draft `opened` remains unchanged, and non-draft non-agent `opened` is skipped.
- Local JS simulation verified `allow-auto-merge` is ignored even when present in `AGENT_DRAFT_GUARD_BYPASS_LABELS`, while `human-approved-ready` still bypasses.
- `git diff --check`, `git diff --cached --check`, and post-rebase `git diff --check origin/main..HEAD`.