### PR TITLE
fix(keeper): Docker sandbox git freedom — safe.directory, SSH agent, keeper identity

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -198,7 +198,7 @@ let run_docker_shell_command_with_status
           in
           let git_author_name, git_author_email =
             match binding_result with
-            | Ok { github_identity = Some id; _ } ->
+            | Ok { github_identity = Some id; git_identity_mode = "github_identity"; _ } ->
                 id, id ^ "@users.noreply.github.com"
             | _ ->
                 ( Keeper_identity.keeper_git_author
@@ -234,12 +234,13 @@ let run_docker_shell_command_with_status
         else
           match ssh_auth_sock with
           | None -> empty
-          | Some path ->
+          | Some path when Sys.file_exists path ->
               let container_path =
                 Filename.concat cred_root "ssh-agent.sock"
               in
               ( [ "-v"; path ^ ":" ^ container_path ],
                 [ "-e"; "SSH_AUTH_SOCK=" ^ container_path ] )
+          | Some _ -> empty
       in
       let token_env =
         let gh_token =

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -171,15 +171,19 @@ let run_docker_shell_command_with_status
           | Network_none -> ([ "--network"; "none" ], "none")
           | Network_inherit -> ([], network_mode_to_string network_mode)
       in
+      let cred_root = "/tmp/keeper-creds" in
       let cred_mounts, cred_envs =
         if not git_creds_enabled then
           [], []
         else
-          let cred_root = "/tmp/keeper-creds" in
+          let binding_result =
+            Keeper_gh_env.keeper_binding config ~keeper_name:meta.name
+          in
           let gh_creds =
-            match Keeper_gh_env.keeper_config_dir config ~keeper_name:meta.name with
-            | Ok (Some dir) -> dir
-            | Ok None -> Env_config_keeper.KeeperSandbox.gh_creds_host_path ()
+            match binding_result with
+            | Ok { gh_config_dir = Some dir; _ } -> dir
+            | Ok { gh_config_dir = None; _ } ->
+                Env_config_keeper.KeeperSandbox.gh_creds_host_path ()
             | Error err -> raise (Failure err)
           in
           let gitconfig = Env_config_keeper.KeeperSandbox.gitconfig_host_path () in
@@ -193,10 +197,22 @@ let run_docker_shell_command_with_status
                 ~container:(Filename.concat cred_root ".ssh")
           in
           let git_author_name, git_author_email =
-            match Keeper_gh_env.keeper_binding config ~keeper_name:meta.name with
+            match binding_result with
             | Ok { github_identity = Some id; _ } ->
                 id, id ^ "@users.noreply.github.com"
-            | _ -> "MASC Keeper", "keeper@masc.local"
+            | _ ->
+                ( Keeper_identity.keeper_git_author
+                    ~keeper_name:meta.name,
+                  Keeper_identity.keeper_git_email
+                    ~keeper_name:meta.name )
+          in
+          let git_identity_env ~name ~email =
+            [
+              "-e"; "GIT_AUTHOR_NAME=" ^ name;
+              "-e"; "GIT_AUTHOR_EMAIL=" ^ email;
+              "-e"; "GIT_COMMITTER_NAME=" ^ name;
+              "-e"; "GIT_COMMITTER_EMAIL=" ^ email;
+            ]
           in
           let envs =
             [
@@ -206,30 +222,24 @@ let run_docker_shell_command_with_status
               "-e"; "GIT_CONFIG_COUNT=1";
               "-e"; "GIT_CONFIG_KEY_0=safe.directory";
               "-e"; "GIT_CONFIG_VALUE_0=*";
-              "-e"; "GIT_AUTHOR_NAME=" ^ git_author_name;
-              "-e"; "GIT_AUTHOR_EMAIL=" ^ git_author_email;
-              "-e"; "GIT_COMMITTER_NAME=" ^ git_author_name;
-              "-e"; "GIT_COMMITTER_EMAIL=" ^ git_author_email;
             ]
+            @ git_identity_env ~name:git_author_name ~email:git_author_email
           in
           mounts, envs
       in
       let ssh_auth_sock = Sys.getenv_opt "SSH_AUTH_SOCK" in
       let ssh_auth_mount, ssh_auth_env =
-        if not git_creds_enabled then
-          [], []
+        let empty = ([], []) in
+        if not git_creds_enabled then empty
         else
           match ssh_auth_sock with
-          | None -> [], []
+          | None -> empty
           | Some path ->
-              if Sys.file_exists path then
-                let container_path =
-                  Filename.concat cred_root "ssh-agent.sock"
-                in
-                ( [ "-v"; path ^ ":" ^ container_path ],
-                  [ "-e"; "SSH_AUTH_SOCK=" ^ container_path ] )
-              else
-                [], []
+              let container_path =
+                Filename.concat cred_root "ssh-agent.sock"
+              in
+              ( [ "-v"; path ^ ":" ^ container_path ],
+                [ "-e"; "SSH_AUTH_SOCK=" ^ container_path ] )
       in
       let token_env =
         let gh_token =

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -192,18 +192,44 @@ let run_docker_shell_command_with_status
             @ optional_ro_mount ~host:ssh_dir
                 ~container:(Filename.concat cred_root ".ssh")
           in
+          let git_author_name, git_author_email =
+            match Keeper_gh_env.keeper_binding config ~keeper_name:meta.name with
+            | Ok { github_identity = Some id; _ } ->
+                id, id ^ "@users.noreply.github.com"
+            | _ -> "MASC Keeper", "keeper@masc.local"
+          in
           let envs =
             [
               "-e"; "HOME=" ^ cred_root;
               "-e"; "GH_CONFIG_DIR=" ^ Filename.concat cred_root ".config/gh";
               "-e"; "GIT_CONFIG_GLOBAL=" ^ Filename.concat cred_root ".gitconfig";
-              "-e"; "GIT_AUTHOR_NAME=MASC Keeper";
-              "-e"; "GIT_AUTHOR_EMAIL=keeper@masc.local";
-              "-e"; "GIT_COMMITTER_NAME=MASC Keeper";
-              "-e"; "GIT_COMMITTER_EMAIL=keeper@masc.local";
+              "-e"; "GIT_CONFIG_COUNT=1";
+              "-e"; "GIT_CONFIG_KEY_0=safe.directory";
+              "-e"; "GIT_CONFIG_VALUE_0=*";
+              "-e"; "GIT_AUTHOR_NAME=" ^ git_author_name;
+              "-e"; "GIT_AUTHOR_EMAIL=" ^ git_author_email;
+              "-e"; "GIT_COMMITTER_NAME=" ^ git_author_name;
+              "-e"; "GIT_COMMITTER_EMAIL=" ^ git_author_email;
             ]
           in
           mounts, envs
+      in
+      let ssh_auth_sock = Sys.getenv_opt "SSH_AUTH_SOCK" in
+      let ssh_auth_mount, ssh_auth_env =
+        if not git_creds_enabled then
+          [], []
+        else
+          match ssh_auth_sock with
+          | None -> [], []
+          | Some path ->
+              if Sys.file_exists path then
+                let container_path =
+                  Filename.concat cred_root "ssh-agent.sock"
+                in
+                ( [ "-v"; path ^ ":" ^ container_path ],
+                  [ "-e"; "SSH_AUTH_SOCK=" ^ container_path ] )
+              else
+                [], []
       in
       let token_env =
         let gh_token =
@@ -257,6 +283,8 @@ let run_docker_shell_command_with_status
         @ network_args
         @ cred_mounts
         @ cred_envs
+        @ ssh_auth_mount
+        @ ssh_auth_env
         @ token_env
         @ [ image; "bash"; "-lc"; cmd ]
       in

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -12,6 +12,7 @@ module Coord = Masc_mcp.Coord
 module Keeper_exec_shell = Masc_mcp.Keeper_exec_shell
 module Keeper_registry = Masc_mcp.Keeper_registry
 module Keeper_sandbox = Masc_mcp.Keeper_sandbox
+module Keeper_shell_docker = Masc_mcp.Keeper_shell_docker
 module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_alerting_path = Masc_mcp.Keeper_alerting_path
 module Tool_code_write = Masc_mcp.Tool_code_write
@@ -53,6 +54,21 @@ let write_file path content =
   let oc = open_out_bin path in
   Fun.protect ~finally:(fun () -> close_out oc) @@ fun () ->
   output_string oc content
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect ~finally:(fun () -> close_in ic) @@ fun () ->
+  really_input_string ic (in_channel_length ic)
+
+let contains_substring haystack needle =
+  let len = String.length needle in
+  let n = String.length haystack in
+  let rec loop i =
+    if i + len > n then false
+    else if String.sub haystack i len = needle then true
+    else loop (i + 1)
+  in
+  loop 0
 
 let rec ensure_dir path =
   if path = "" || path = "." || path = "/" then ()
@@ -129,6 +145,40 @@ let with_tool_policy_config f =
   Tool_code_write.reset_policy_config_cache ();
   with_env "MASC_CONFIG_DIR" config_dir @@ fun () ->
   Fun.protect ~finally:Tool_code_write.reset_policy_config_cache f
+
+let with_config_dir config_dir f =
+  let prior = Sys.getenv_opt "MASC_CONFIG_DIR" in
+  Fun.protect
+    ~finally:(fun () ->
+      (match prior with
+       | Some value -> Unix.putenv "MASC_CONFIG_DIR" value
+       | None -> Unix.putenv "MASC_CONFIG_DIR" "");
+      Masc_mcp.Config_dir_resolver.reset ())
+    (fun () ->
+      Unix.putenv "MASC_CONFIG_DIR" config_dir;
+      Masc_mcp.Config_dir_resolver.reset ();
+      f ())
+
+let with_keeper_identity_toml ~config ~keeper_name ~github_identity
+    ~git_identity_mode f =
+  let masc_dir = Filename.concat config.Coord.base_path Common.masc_dirname in
+  let config_dir = Filename.concat masc_dir "config" in
+  let keepers_dir = Filename.concat config_dir "keepers" in
+  let gh_dir =
+    Filename.concat
+      (Filename.concat
+         (Filename.concat masc_dir "github-identities")
+         github_identity)
+      "gh"
+  in
+  ensure_dir keepers_dir;
+  ensure_dir gh_dir;
+  write_file
+    (Filename.concat keepers_dir (keeper_name ^ ".toml"))
+    (Printf.sprintf
+       "[keeper]\ngithub_identity = %S\ngit_identity_mode = %S\n"
+       github_identity git_identity_mode);
+  with_config_dir config_dir f
 
 let parse_field raw field =
   Yojson.Safe.from_string raw |> Json.member field
@@ -425,6 +475,115 @@ done\n\
 printf 'stdout:%s\\n' \"$*\"\n\
 exit 0\n"
 
+let fake_docker_log_args_script =
+  "#!/bin/sh\n\
+log_file=${KEEPER_DOCKER_LOG:-}\n\
+if [ -n \"$log_file\" ]; then\n\
+  printf '%s\\n' \"$*\" >> \"$log_file\"\n\
+fi\n\
+case \"$1\" in\n\
+  info)\n\
+    printf '[]\\n'\n\
+    exit 0\n\
+    ;;\n\
+  ps)\n\
+    exit 0\n\
+    ;;\n\
+  image)\n\
+    printf '[]\\n'\n\
+    exit 0\n\
+    ;;\n\
+  run)\n\
+    printf 'ok\\n'\n\
+    exit 0\n\
+    ;;\n\
+esac\n\
+printf 'unexpected docker invocation: %s\\n' \"$1\" >&2\n\
+exit 2\n"
+
+let docker_run_line log_path =
+  read_file log_path
+  |> String.split_on_char '\n'
+  |> List.find_opt (String.starts_with ~prefix:"run ")
+  |> function
+  | Some line -> line
+  | None -> Alcotest.fail "expected docker run log line"
+
+let run_git_creds_docker_shell ~config ~meta ~playground ~log_path =
+  with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE" "" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS" "false" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_REQUIRE_USERNS" "false" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_CLEANUP_ENABLED" "false" @@ fun () ->
+  match
+    Keeper_shell_docker.run_docker_shell_command_with_status
+      ~config ~meta ~cwd:playground ~timeout_sec:5.0
+      ~cmd:"git status" ~git_creds_enabled:true
+      ~network_mode:Keeper_types.Network_inherit
+  with
+  | Error msg ->
+      Alcotest.failf "expected fake docker git-creds run, got %s" msg
+  | Ok result ->
+      Alcotest.(check (pair string int)) "fake docker exits cleanly"
+        ("exit", 0)
+        (match result.Keeper_shell_docker.status with
+         | Unix.WEXITED code -> ("exit", code)
+         | Unix.WSIGNALED code -> ("signaled", code)
+         | Unix.WSTOPPED code -> ("stopped", code));
+      docker_run_line log_path
+
+let test_git_creds_skips_missing_ssh_auth_sock () =
+  with_fake_docker fake_docker_log_args_script @@ fun () ->
+  setup ~sandbox:Keeper_types.Docker
+  @@ fun ~config ~meta ~playground ->
+  Masc_mcp.Config_dir_resolver.reset ();
+  let log_path = Filename.concat config.Coord.base_path "docker.log" in
+  let missing_sock =
+    Filename.concat config.Coord.base_path "missing-agent.sock"
+  in
+  with_env "SSH_AUTH_SOCK" missing_sock @@ fun () ->
+  let line =
+    run_git_creds_docker_shell ~config ~meta ~playground ~log_path
+  in
+  Alcotest.(check bool) "missing ssh-agent socket is not mounted" false
+    (contains_substring line missing_sock);
+  Alcotest.(check bool) "missing ssh-agent env is not forwarded" false
+    (contains_substring line "SSH_AUTH_SOCK=/tmp/keeper-creds/ssh-agent.sock")
+
+let test_git_creds_respects_keeper_alias_identity_mode () =
+  with_fake_docker fake_docker_log_args_script @@ fun () ->
+  setup ~sandbox:Keeper_types.Docker
+  @@ fun ~config ~meta ~playground ->
+  with_keeper_identity_toml ~config ~keeper_name:meta.name
+    ~github_identity:"anyang-keepers" ~git_identity_mode:"keeper_alias"
+  @@ fun () ->
+  let log_path = Filename.concat config.Coord.base_path "docker.log" in
+  let line =
+    run_git_creds_docker_shell ~config ~meta ~playground ~log_path
+  in
+  Alcotest.(check bool) "keeper_alias keeps keeper author" true
+    (contains_substring line "GIT_AUTHOR_NAME=minjae (MASC Keeper)");
+  Alcotest.(check bool) "keeper_alias does not force GitHub identity author" false
+    (contains_substring line "GIT_AUTHOR_NAME=anyang-keepers")
+
+let test_git_creds_uses_github_identity_mode () =
+  with_fake_docker fake_docker_log_args_script @@ fun () ->
+  setup ~sandbox:Keeper_types.Docker
+  @@ fun ~config ~meta ~playground ->
+  with_keeper_identity_toml ~config ~keeper_name:meta.name
+    ~github_identity:"anyang-keepers" ~git_identity_mode:"github_identity"
+  @@ fun () ->
+  let log_path = Filename.concat config.Coord.base_path "docker.log" in
+  let line =
+    run_git_creds_docker_shell ~config ~meta ~playground ~log_path
+  in
+  Alcotest.(check bool) "github_identity mode uses GitHub author" true
+    (contains_substring line "GIT_AUTHOR_NAME=anyang-keepers");
+  Alcotest.(check bool) "github_identity mode uses noreply email" true
+    (contains_substring line
+       "GIT_AUTHOR_EMAIL=anyang-keepers@users.noreply.github.com")
+
 let test_git_clone_repairs_existing_docker_clone_checkout () =
   with_tool_policy_config @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
@@ -520,6 +679,15 @@ let () =
             test_rg_no_match_remains_successful_in_docker_route;
           Alcotest.test_case "git_clone routes through docker" `Quick
             test_git_clone_routes_through_docker;
+          Alcotest.test_case
+            "git-creds skips missing SSH_AUTH_SOCK"
+            `Quick test_git_creds_skips_missing_ssh_auth_sock;
+          Alcotest.test_case
+            "git-creds respects keeper_alias git identity mode"
+            `Quick test_git_creds_respects_keeper_alias_identity_mode;
+          Alcotest.test_case
+            "git-creds uses GitHub author only in github_identity mode"
+            `Quick test_git_creds_uses_github_identity_mode;
           Alcotest.test_case "hard mode git_clone uses brokered route" `Quick
             test_hard_mode_git_clone_uses_brokered_route;
           Alcotest.test_case "git_clone repairs existing docker clone checkout"

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -136,6 +136,7 @@ let with_fake_docker script f =
     | _ -> dir
   in
   Fun.protect ~finally:(fun () -> cleanup_dir dir) @@ fun () ->
+  with_env "MASC_TEST_FAKE_DOCKER_PATH" docker_path @@ fun () ->
   with_env "PATH" path f
 
 let with_tool_policy_config f =
@@ -456,6 +457,10 @@ let test_hard_mode_blocks_raw_gh_bash () =
 
 let fake_docker_echo_script =
   "#!/bin/sh\n\
+log_file=${KEEPER_DOCKER_LOG:-}\n\
+if [ -n \"$log_file\" ]; then\n\
+  printf '%s\\n' \"$*\" >> \"$log_file\"\n\
+fi\n\
 if [ \"$1\" = \"info\" ]; then\n\
   printf '[]\\n'\n\
   exit 0\n\
@@ -475,32 +480,6 @@ done\n\
 printf 'stdout:%s\\n' \"$*\"\n\
 exit 0\n"
 
-let fake_docker_log_args_script =
-  "#!/bin/sh\n\
-log_file=${KEEPER_DOCKER_LOG:-}\n\
-if [ -n \"$log_file\" ]; then\n\
-  printf '%s\\n' \"$*\" >> \"$log_file\"\n\
-fi\n\
-case \"$1\" in\n\
-  info)\n\
-    printf '[]\\n'\n\
-    exit 0\n\
-    ;;\n\
-  ps)\n\
-    exit 0\n\
-    ;;\n\
-  image)\n\
-    printf '[]\\n'\n\
-    exit 0\n\
-    ;;\n\
-  run)\n\
-    printf 'ok\\n'\n\
-    exit 0\n\
-    ;;\n\
-esac\n\
-printf 'unexpected docker invocation: %s\\n' \"$1\" >&2\n\
-exit 2\n"
-
 let docker_run_line log_path =
   read_file log_path
   |> String.split_on_char '\n'
@@ -516,6 +495,11 @@ let run_git_creds_docker_shell ~config ~meta ~playground ~log_path =
   with_env "MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS" "false" @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_REQUIRE_USERNS" "false" @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_CLEANUP_ENABLED" "false" @@ fun () ->
+  (match Sys.getenv_opt "MASC_TEST_FAKE_DOCKER_PATH" with
+   | Some expected ->
+       Alcotest.(check string) "fake docker command selected" expected
+         (Masc_mcp.Keeper_sandbox_runtime.docker_command ())
+   | None -> ());
   match
     Keeper_shell_docker.run_docker_shell_command_with_status
       ~config ~meta ~cwd:playground ~timeout_sec:5.0
@@ -525,16 +509,20 @@ let run_git_creds_docker_shell ~config ~meta ~playground ~log_path =
   | Error msg ->
       Alcotest.failf "expected fake docker git-creds run, got %s" msg
   | Ok result ->
-      Alcotest.(check (pair string int)) "fake docker exits cleanly"
-        ("exit", 0)
-        (match result.Keeper_shell_docker.status with
-         | Unix.WEXITED code -> ("exit", code)
-         | Unix.WSIGNALED code -> ("signaled", code)
-         | Unix.WSTOPPED code -> ("stopped", code));
+      let observed =
+        match result.Keeper_shell_docker.status with
+        | Unix.WEXITED code -> ("exit", code)
+        | Unix.WSIGNALED code -> ("signaled", code)
+        | Unix.WSTOPPED code -> ("stopped", code)
+      in
+      if observed <> ("exit", 0) then
+        Alcotest.failf "expected fake docker exit 0, got %s %d; log=%S; output=%S"
+          (fst observed) (snd observed) (read_file log_path)
+          result.Keeper_shell_docker.output;
       docker_run_line log_path
 
 let test_git_creds_skips_missing_ssh_auth_sock () =
-  with_fake_docker fake_docker_log_args_script @@ fun () ->
+  with_fake_docker fake_docker_echo_script @@ fun () ->
   setup ~sandbox:Keeper_types.Docker
   @@ fun ~config ~meta ~playground ->
   Masc_mcp.Config_dir_resolver.reset ();
@@ -552,7 +540,7 @@ let test_git_creds_skips_missing_ssh_auth_sock () =
     (contains_substring line "SSH_AUTH_SOCK=/tmp/keeper-creds/ssh-agent.sock")
 
 let test_git_creds_respects_keeper_alias_identity_mode () =
-  with_fake_docker fake_docker_log_args_script @@ fun () ->
+  with_fake_docker fake_docker_echo_script @@ fun () ->
   setup ~sandbox:Keeper_types.Docker
   @@ fun ~config ~meta ~playground ->
   with_keeper_identity_toml ~config ~keeper_name:meta.name
@@ -568,7 +556,7 @@ let test_git_creds_respects_keeper_alias_identity_mode () =
     (contains_substring line "GIT_AUTHOR_NAME=anyang-keepers")
 
 let test_git_creds_uses_github_identity_mode () =
-  with_fake_docker fake_docker_log_args_script @@ fun () ->
+  with_fake_docker fake_docker_echo_script @@ fun () ->
   setup ~sandbox:Keeper_types.Docker
   @@ fun ~config ~meta ~playground ->
   with_keeper_identity_toml ~config ~keeper_name:meta.name


### PR DESCRIPTION
## Context
Follow-up to #9701. Makes the Docker sandbox a true "free space" for keeper git operations.

## Changes
1. **Git safe directory** — `GIT_CONFIG_COUNT/KEY/VALUE` env vars inject `safe.directory=*` so git never throws "dubious ownership" inside the container.
2. **SSH agent forwarding** — `SSH_AUTH_SOCK` is volume-mounted into the container when available, allowing passphrase-protected SSH keys to work for `git push`.
3. **Keeper-scoped git identity** — reads the keeper's `github_identity` (e.g. `anyang-keepers`) from `~/me/.masc/github-identities/` and sets `GIT_AUTHOR_NAME/EMAIL` accordingly instead of a hardcoded fallback.

## Verification
- `dune build` passes

## Test plan
- [ ] `git status` inside an existing repo in the sandbox (no dubious ownership error)
- [ ] `git commit` uses the keeper's GitHub identity
- [ ] `git push` via SSH with agent forwarding

🤖 Generated with [Claude Code](https://claude.com/code)