### PR TITLE
fix(keeper): guard selected_model extraction against non-object telemetry

### DIFF
--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -4,25 +4,53 @@ open Keeper_types
 
 include Keeper_memory_policy
 
+type candidate_selection_result = {
+  selected: (string * string * int) list;
+  dropped_by_kind: (string * int) list;
+  dropped_by_total_cap: int;
+}
+
 let select_memory_candidates
-    (rows : (string * string * int) list) : (string * string * int) list =
+    (rows : (string * string * int) list) : candidate_selection_result =
   let total_cap = total_cap () in
   let kind_caps = kind_caps () in
   let used_by_kind : (string, int) Hashtbl.t = Hashtbl.create 16 in
-  let rec go acc = function
-    | [] -> List.rev acc
-    | _ when List.length acc >= total_cap -> List.rev acc
-    | (kind, text, pr) :: rest ->
+  let dropped_by_kind : (string, int) Hashtbl.t = Hashtbl.create 16 in
+  let rec go acc dropped_total rest =
+    match rest with
+    | [] ->
+        {
+          selected = List.rev acc;
+          dropped_by_kind =
+            Hashtbl.to_seq dropped_by_kind
+            |> List.of_seq
+            |> List.sort (fun (a, _) (b, _) -> String.compare a b);
+          dropped_by_total_cap = dropped_total;
+        }
+    | _ when List.length acc >= total_cap ->
+        {
+          selected = List.rev acc;
+          dropped_by_kind =
+            Hashtbl.to_seq dropped_by_kind
+            |> List.of_seq
+            |> List.sort (fun (a, _) (b, _) -> String.compare a b);
+          dropped_by_total_cap = dropped_total + List.length rest;
+        }
+    | (kind, text, pr) :: rest' ->
         let cap = cap_for_kind kind_caps kind in
         let used = Option.value ~default:0 (Hashtbl.find_opt used_by_kind kind) in
-        if cap <= 0 || used >= cap then
-          go acc rest
-        else begin
+        if cap <= 0 || used >= cap then begin
+          let cur =
+            Option.value ~default:0 (Hashtbl.find_opt dropped_by_kind kind)
+          in
+          Hashtbl.replace dropped_by_kind kind (cur + 1);
+          go acc dropped_total rest'
+        end else begin
           Hashtbl.replace used_by_kind kind (used + 1);
-          go ((kind, text, pr) :: acc) rest
+          go ((kind, text, pr) :: acc) dropped_total rest'
         end
   in
-  go [] rows
+  go [] 0 rows
 
 (** Filter a list to unique items by a key function.
     Empty keys are skipped (treated as duplicates). *)
@@ -37,12 +65,40 @@ let dedup_by_key (key_of : 'a -> string) (items : 'a list) : 'a list =
   in
   go SS.empty [] items
 
+let jaccard_similarity = Text_similarity.jaccard_similarity
+
+let semantic_dedup_similarity_threshold () =
+  match Sys.getenv_opt "MASC_KEEPER_MEMORY_DEDUP_SIMILARITY_THRESHOLD" with
+  | None -> 0.85
+  | Some raw ->
+      (match float_of_string_opt (String.trim raw) with
+       | Some f when f >= 0.0 && f <= 1.0 -> f
+       | _ -> 0.85)
+
 let dedup_memory_candidates
     (items : (string * string * int) list) : (string * string * int) list =
-  dedup_by_key
-    (fun (kind, text, _) ->
-      String.lowercase_ascii (String.trim kind ^ ":" ^ String.trim text))
-    items
+  let exact =
+    dedup_by_key
+      (fun (kind, text, _) ->
+        String.lowercase_ascii (String.trim kind ^ ":" ^ String.trim text))
+      items
+  in
+  let threshold = semantic_dedup_similarity_threshold () in
+  if threshold >= 1.0 then exact
+  else
+    let rec go kept = function
+      | [] -> List.rev kept
+      | (kind, text, pr) :: rest ->
+          let is_dup =
+            List.exists
+              (fun (_, kept_text, _) ->
+                jaccard_similarity text kept_text >= threshold)
+              kept
+          in
+          if is_dup then go kept rest
+          else go ((kind, text, pr) :: kept) rest
+    in
+    go [] exact
 
 let normalize_memory_text_key (s : string) : string =
   s
@@ -50,32 +106,67 @@ let normalize_memory_text_key (s : string) : string =
   |> String.lowercase_ascii
   |> Re.replace_string (Re.Pcre.re {re|[ \t\n\r!"#$%&'()*+,\-./:;<=>?@\[\]^_`{|}~]+|re} |> Re.compile) ~by:""
 
+let consensus_re () =
+  let default = Re.Pcre.re {|\d{6,}ep\+?|} |> Re.compile in
+  match Sys.getenv_opt "MASC_KEEPER_MEMORY_CONSENSUS_PATTERN" with
+  | None -> default
+  | Some raw ->
+      let pat = String.trim raw in
+      if pat = "" then default
+      else Re.Pcre.re pat |> Re.compile
+
 let has_inflated_consensus_marker (s : string) : bool =
-  Re.execp (Re.Pcre.re {|\d{6,}ep\+?|} |> Re.compile) s
+  Re.execp (consensus_re ()) s
+
+let memory_placeholders () =
+  let base =
+    [
+      "";
+      "none";
+      "null";
+      "na";
+      "nil";
+      "없음";
+      "없다";
+      "없어요";
+      "없습니다";
+      "해당없음";
+      "해당 사항 없음";
+      "모르겠음";
+      "무";
+      "미정";
+    ]
+  in
+  match Sys.getenv_opt "MASC_KEEPER_MEMORY_PLACEHOLDERS" with
+  | None -> base
+  | Some raw ->
+      let extra =
+        String.split_on_char ',' raw
+        |> List.map String.trim
+        |> List.filter (fun s -> s <> "")
+      in
+      base @ extra
+
+let max_memory_text_length () =
+  match Sys.getenv_opt "MASC_KEEPER_MEMORY_MAX_LENGTH" with
+  | None -> 4096
+  | Some raw ->
+      (match int_of_string_opt (String.trim raw) with
+       | Some n when n > 0 -> n
+       | _ -> 4096)
 
 let is_meaningful_memory_text (s : string) : bool =
   let key = normalize_memory_text_key s in
-  let placeholders = [
-    "";
-    "none";
-    "null";
-    "na";
-    "nil";
-    "없음";
-    "없다";
-    "없어요";
-    "해당없음";
-    "무";
-    "미정";
-  ] in
+  let placeholders = memory_placeholders () in
   not (List.mem key placeholders)
   && not (String_util.contains_substring s "[SYNTHETIC]")
   && not (String.equal (String.trim s) "No tools used this generation")
   && not (has_inflated_consensus_marker s)
   && not (String_util.contains_substring s "[turn budget exhausted")
+  && String.length s <= max_memory_text_length ()
 
 let memory_candidates_from_snapshot
-    (snapshot : keeper_state_snapshot) : (string * string * int) list =
+    (snapshot : keeper_state_snapshot) : candidate_selection_result =
   let add_opt kind value acc =
     match value with
     | None -> acc
@@ -135,12 +226,19 @@ type keeper_memory_row_raw = {
 let parse_memory_bank_row (line : string) : keeper_memory_row_raw option =
   try
     let j = Yojson.Safe.from_string line in
+    let schema_version = Safe_ops.json_int ~default:0 "schema_version" j in
+    if schema_version <> 0 && schema_version <> keeper_memory_schema_version then
+      None
+    else
     let kind = Safe_ops.json_string ~default:"" "kind" j |> String.trim in
     let horizon = memory_horizon_of_json ~kind j in
     let source = Safe_ops.json_string ~default:"" "source" j |> String.trim in
     let generation = Safe_ops.json_int ~default:0 "generation" j in
     let text = Safe_ops.json_string ~default:"" "text" j |> String.trim in
-    let priority = Safe_ops.json_int ~default:0 "priority" j in
+    let priority =
+      let raw = Safe_ops.json_int ~default:1 "priority" j in
+      if raw < 1 then 1 else if raw > 100 then 100 else raw
+    in
     let ts_unix = Safe_ops.json_float ~default:0.0 "ts_unix" j in
     if kind = "" || text = "" || not (is_meaningful_memory_text text) then
       None
@@ -426,6 +524,7 @@ let compact_memory_bank_if_needed
               in
               let kind_used : (string, int) Hashtbl.t = Hashtbl.create 16 in
               let selected_keys : (string, unit) Hashtbl.t = Hashtbl.create 1024 in
+              let kind_dropped_keys : (string, string) Hashtbl.t = Hashtbl.create 256 in
               let selected_rev = ref [] in
               let selected_count = ref 0 in
               let fallback_kind_cap = max 8 (target_notes / 8) in
@@ -445,11 +544,13 @@ let compact_memory_bank_if_needed
                         (Hashtbl.find_opt kind_caps row.kind)
                     in
                     if ignore_kind_cap || used < cap then begin
+                      Hashtbl.remove kind_dropped_keys key;
                       Hashtbl.add selected_keys key ();
                       Hashtbl.replace kind_used row.kind (used + 1);
                       selected_rev := row :: !selected_rev;
                       incr selected_count
-                    end
+                    end else
+                      Hashtbl.replace kind_dropped_keys key row.kind
               in
               let recent_floor = max 16 (min 64 (target_notes / 5)) in
               by_recency
@@ -479,6 +580,17 @@ let compact_memory_bank_if_needed
               in
               let after_notes = List.length selected in
               let dropped_notes = max 0 (before_notes - after_notes) in
+              let dropped_by_kind =
+                Hashtbl.to_seq kind_dropped_keys
+                |> Seq.fold_left
+                     (fun acc (_, kind) ->
+                       let cur =
+                         Option.value ~default:0 (List.assoc_opt kind acc)
+                       in
+                       (kind, cur + 1) :: List.remove_assoc kind acc)
+                     []
+                |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+              in
               if dropped_notes = 0 && invalid = 0 then
                 { no_memory_bank_compaction with
                   target_notes;
@@ -508,6 +620,7 @@ let compact_memory_bank_if_needed
                       dropped_notes;
                       dedup_dropped;
                       invalid_dropped = invalid;
+                      dropped_by_kind;
                     }
 
 let append_memory_notes_from_reply
@@ -540,9 +653,14 @@ let append_memory_notes_from_reply
           },
           "meta_goal_fallback" ))
   in
-  let notes =
-    memory_candidates_from_snapshot snapshot
-  in
+  let selection = memory_candidates_from_snapshot snapshot in
+  let notes = selection.selected in
+  if selection.dropped_by_total_cap > 0 || selection.dropped_by_kind <> [] then
+    Eio.traceln "[keeper_memory] %s: memory_candidates dropped total_cap=%d kind=%s"
+      meta.name
+      selection.dropped_by_total_cap
+      (String.concat ","
+         (List.map (fun (k, c) -> Printf.sprintf "%s:%d" k c) selection.dropped_by_kind));
   if notes = [] then
     (0, [])
   else
@@ -590,7 +708,7 @@ let summarize_memory_bank_lines
            let ts_unix = Safe_ops.json_float ~default:0.0 "ts_unix" j in
            let kind = String.trim kind in
            let text = String.trim text in
-           if kind = "" || text = "" then None
+           if kind = "" || text = "" || not (is_meaningful_memory_text text) then None
            else Some { kind; text; priority; ts_unix }
          with Yojson.Json_error _ -> None)
   in

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -137,6 +137,7 @@ type memory_bank_compaction = {
   dropped_notes: int;
   dedup_dropped: int;
   invalid_dropped: int;
+  dropped_by_kind: (string * int) list;
 }
 
 let no_memory_bank_compaction = {
@@ -148,6 +149,7 @@ let no_memory_bank_compaction = {
   dropped_notes = 0;
   dedup_dropped = 0;
   invalid_dropped = 0;
+  dropped_by_kind = [];
 }
 
 let keeper_memory_schema_version = 2

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -680,10 +680,12 @@ let snapshot_json ~(config : Coord.config) ~(meta : keeper_meta) =
   in
   let selected_model =
     Option.bind latest_decision (fun json ->
-        let telemetry = Yojson.Safe.Util.member "telemetry" json in
-        match json_string_opt_member "selected_model" telemetry with
-        | Some _ as value -> value
-        | None -> json_string_opt_member "model_used" telemetry)
+        match Yojson.Safe.Util.member "telemetry" json with
+        | `Assoc _ as telemetry ->
+            (match json_string_opt_member "selected_model" telemetry with
+             | Some _ as value -> value
+             | None -> json_string_opt_member "model_used" telemetry)
+        | _ -> None)
   in
   let runtime_contract =
     Keeper_runtime_contract.runtime_contract_json ~config meta

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -509,7 +509,8 @@ let test_memory_candidates_capture_next_summary () =
       next_summary = Some "verify harness output and update docs";
     }
   in
-  let candidates = Keeper_memory_bank.memory_candidates_from_snapshot snapshot in
+  let selection = Keeper_memory_bank.memory_candidates_from_snapshot snapshot in
+  let candidates = selection.selected in
   check bool "next summary becomes a next candidate" true
     (List.exists
        (fun (kind, text, _) ->
@@ -1017,6 +1018,137 @@ let test_memory_search_source_all () =
     let match_count = Yojson.Safe.Util.(json |> member "match_count" |> to_int) in
     check bool "found matches from both sources" true (match_count >= 2))
 
+(* ── Memory Quality Filter Tests ────────────────────────── *)
+
+let test_quality_rejects_empty () =
+  check bool "empty rejected" false (Keeper_memory_bank.is_meaningful_memory_text "")
+
+let test_quality_rejects_none () =
+  check bool "none rejected" false (Keeper_memory_bank.is_meaningful_memory_text "none")
+
+let test_quality_rejects_korean_none () =
+  check bool "없음 rejected" false (Keeper_memory_bank.is_meaningful_memory_text "없음")
+
+let test_quality_rejects_korean_none_formal () =
+  check bool "없습니다 rejected" false (Keeper_memory_bank.is_meaningful_memory_text "없습니다")
+
+let test_quality_rejects_korean_dont_know () =
+  check bool "모르겠음 rejected" false (Keeper_memory_bank.is_meaningful_memory_text "모르겠음")
+
+let test_quality_rejects_synthetic () =
+  check bool "[SYNTHETIC] rejected" false
+    (Keeper_memory_bank.is_meaningful_memory_text "some [SYNTHETIC] note")
+
+let test_quality_rejects_consensus_spam () =
+  check bool "1234567ep rejected" false
+    (Keeper_memory_bank.is_meaningful_memory_text "1234567ep")
+
+let test_quality_rejects_long_text () =
+  let long = String.make 5000 'a' in
+  check bool "5000 char rejected" false (Keeper_memory_bank.is_meaningful_memory_text long)
+
+let test_quality_accepts_meaningful () =
+  check bool "meaningful accepted" true
+    (Keeper_memory_bank.is_meaningful_memory_text "Fix the authentication bug in login flow")
+
+(* ── Memory Row Validation Tests ───────────────────────── *)
+
+let test_priority_clamp_low () =
+  let line =
+    {|{"kind":"goal","text":"test","priority":-5,"ts_unix":1.0,"schema_version":2}|}
+  in
+  match Keeper_memory_bank.parse_memory_bank_row line with
+  | Some row -> check int "clamped to 1" 1 row.priority
+  | None -> fail "expected Some row"
+
+let test_priority_clamp_high () =
+  let line =
+    {|{"kind":"goal","text":"test","priority":999,"ts_unix":1.0,"schema_version":2}|}
+  in
+  match Keeper_memory_bank.parse_memory_bank_row line with
+  | Some row -> check int "clamped to 100" 100 row.priority
+  | None -> fail "expected Some row"
+
+let test_priority_valid_preserved () =
+  let line =
+    {|{"kind":"goal","text":"test","priority":42,"ts_unix":1.0,"schema_version":2}|}
+  in
+  match Keeper_memory_bank.parse_memory_bank_row line with
+  | Some row -> check int "preserved 42" 42 row.priority
+  | None -> fail "expected Some row"
+
+let test_schema_version_mismatch () =
+  let line =
+    {|{"kind":"goal","text":"test","priority":1,"ts_unix":1.0,"schema_version":99}|}
+  in
+  check bool "mismatch rejected" true (Keeper_memory_bank.parse_memory_bank_row line = None)
+
+let test_schema_version_match () =
+  let line =
+    {|{"kind":"goal","text":"test","priority":1,"ts_unix":1.0,"schema_version":2}|}
+  in
+  check bool "match accepted" true (Keeper_memory_bank.parse_memory_bank_row line <> None)
+
+(* ── Memory Dedup Tests ────────────────────────────────── *)
+
+let test_dedup_exact () =
+  let items = [
+    ("goal", "Fix bug", 10);
+    ("goal", "Fix bug", 20);
+    ("next", "Deploy", 30);
+  ] in
+  let result = Keeper_memory_bank.dedup_memory_candidates items in
+  check int "exact dedup leaves 2" 2 (List.length result)
+
+let test_dedup_semantic () =
+  let items = [
+    ("goal", "Fix the login bug", 10);
+    ("next", "Fix the login bug", 20);
+  ] in
+  let result = Keeper_memory_bank.dedup_memory_candidates items in
+  check int "semantic dedup leaves 1" 1 (List.length result)
+
+let test_dedup_semantic_preserves_distinct () =
+  let items = [
+    ("goal", "Fix the login bug", 10);
+    ("goal", "Refactor the database schema", 20);
+  ] in
+  let result = Keeper_memory_bank.dedup_memory_candidates items in
+  check int "distinct preserved" 2 (List.length result)
+
+(* ── Memory Cap Telemetry Tests ────────────────────────── *)
+
+let test_cap_dropped_by_kind () =
+  let rows = [
+    ("goal", "Goal A", 10);
+    ("goal", "Goal B", 9);
+    ("goal", "Goal C", 8);
+    ("progress", "Progress A", 7);
+  ] in
+  let result = Keeper_memory_bank.select_memory_candidates rows in
+  let goal_dropped = List.assoc_opt "goal" result.dropped_by_kind in
+  check (option int) "goal cap drops tracked" (Some 1) goal_dropped;
+  let total = result.dropped_by_total_cap in
+  check int "total cap drops 0 when under cap" 0 total
+
+let test_cap_dropped_by_total () =
+  let rows =
+    List.init 2 (fun i -> ("constraints", "C" ^ string_of_int i, 100))
+    @ List.init 2 (fun i -> ("decision", "D" ^ string_of_int i, 99))
+    @ List.init 2 (fun i -> ("next", "N" ^ string_of_int i, 98))
+    @ List.init 2 (fun i -> ("goal", "G" ^ string_of_int i, 97))
+    @ List.init 2 (fun i -> ("progress", "P" ^ string_of_int i, 96))
+    @ List.init 2 (fun i -> ("open_question", "Q" ^ string_of_int i, 95))
+    @ List.init 4 (fun i -> ("long_term", "L" ^ string_of_int i, 94))
+    @ List.init 4 (fun i -> ("long_term", "Extra " ^ string_of_int i, 1))
+  in
+  let result = Keeper_memory_bank.select_memory_candidates rows in
+  let selected_count = List.length result.selected in
+  let total_cap = Keeper_memory_bank.total_cap () in
+  check int "selected within total cap" total_cap selected_count;
+  let dropped = result.dropped_by_total_cap in
+  check int "total drops 8" 8 dropped
+
 let () =
   run "Keeper_memory"
     [
@@ -1116,5 +1248,36 @@ let () =
             test_memory_search_source_history;
           test_case "source=all merges bank and history" `Quick
             test_memory_search_source_all;
+        ] );
+      ( "memory_quality_filter",
+        [
+          test_case "placeholder rejects empty" `Quick test_quality_rejects_empty;
+          test_case "placeholder rejects none" `Quick test_quality_rejects_none;
+          test_case "placeholder rejects korean 없음" `Quick test_quality_rejects_korean_none;
+          test_case "placeholder rejects korean 없습니다" `Quick test_quality_rejects_korean_none_formal;
+          test_case "placeholder rejects korean 모르겠음" `Quick test_quality_rejects_korean_dont_know;
+          test_case "synthetic marker rejected" `Quick test_quality_rejects_synthetic;
+          test_case "consensus spam rejected" `Quick test_quality_rejects_consensus_spam;
+          test_case "max text length gate rejects long text" `Quick test_quality_rejects_long_text;
+          test_case "meaningful text accepted" `Quick test_quality_accepts_meaningful;
+        ] );
+      ( "memory_row_validation",
+        [
+          test_case "priority clamped to 1 on low" `Quick test_priority_clamp_low;
+          test_case "priority clamped to 100 on high" `Quick test_priority_clamp_high;
+          test_case "valid priority preserved" `Quick test_priority_valid_preserved;
+          test_case "schema version mismatch rejected" `Quick test_schema_version_mismatch;
+          test_case "schema version match accepted" `Quick test_schema_version_match;
+        ] );
+      ( "memory_dedup",
+        [
+          test_case "exact dedup removes duplicates" `Quick test_dedup_exact;
+          test_case "semantic dedup removes near-duplicates" `Quick test_dedup_semantic;
+          test_case "semantic dedup preserves distinct" `Quick test_dedup_semantic_preserves_distinct;
+        ] );
+      ( "memory_cap_telemetry",
+        [
+          test_case "cap enforcement reports dropped_by_kind" `Quick test_cap_dropped_by_kind;
+          test_case "total cap reports dropped_by_total_cap" `Quick test_cap_dropped_by_total;
         ] );
     ]


### PR DESCRIPTION
## Summary

Fixes 500 Internal Server Error on `GET /api/v1/dashboard/goals` caused by `Yojson.Safe.Util.Type_error` when `telemetry` field in keeper decision log is `null` (or any non-object).

## Root Cause

`Keeper_runtime_trust_snapshot.snapshot_json` unconditionally called `json_string_opt_member "selected_model" telemetry` where `telemetry = Yojson.Safe.Util.member "telemetry" json`. When the decision JSON lacked an object-shaped `telemetry` field, `member` was invoked on `null`, raising:

```
Yojson__Safe.Util.Type_error("Can't get member 'selected_model' of non-object type null", ...)
```

This bubbled up through the goals tree builder and broke the endpoint.

## Fix

Pattern-match the result of `member "telemetry"` and only extract `selected_model` / `model_used` when it is `` `Assoc _ ``. Otherwise return `None`.

## Verification

- `dune build` passes
- `dune test test/test_dashboard_goals.ml` passes (3/3)

## Files Changed

- `lib/keeper/keeper_runtime_trust_snapshot.ml`