### PR TITLE
[codex] quiet keeper runtime probe noise

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -85,6 +85,22 @@ type ctx_composition_metrics =
   ; segments : (string * prompt_segment_metrics) list
   }
 
+let unexpected_tool_partial_warned : (string, unit) Hashtbl.t =
+  Hashtbl.create 32
+
+let unexpected_tool_partial_warn_mu = Eio.Mutex.create ()
+
+let should_log_unexpected_tool_partial_once ~keeper_name ~unexpected_tool_names =
+  let key =
+    String.concat "\000" (keeper_name :: List.sort String.compare unexpected_tool_names)
+  in
+  Eio_guard.with_mutex unexpected_tool_partial_warn_mu (fun () ->
+      if Hashtbl.mem unexpected_tool_partial_warned key then
+        false
+      else (
+        Hashtbl.replace unexpected_tool_partial_warned key ();
+        true))
+
 let empty_prompt_segment_metrics =
   { bytes = 0; estimated_tokens = 0; fingerprint = None }
 
@@ -2412,7 +2428,7 @@ let run_turn
           no cognate (Skill/Agent/WebSearch) remain unexpected and may
           still trigger a teaching error — see Keeper_tool_alias.is_hallucinated_builtin. *)
        let canonical_tool_names =
-         Keeper_tool_alias.canonicalize_observed tool_names
+         Keeper_tool_alias.canonicalize_observed_with_telemetry tool_names
        in
        canonical_tool_names_ref := canonical_tool_names;
        let unexpected_tool_names =
@@ -2446,7 +2462,21 @@ let run_turn
          Log.Keeper.error "keeper:%s %s" meta.name reason;
          Error (Oas.Error.Internal reason)
        else (
+         let should_log_unexpected_tool_partial =
+           unexpected_tool_names <> []
+           && should_log_unexpected_tool_partial_once ~keeper_name:meta.name
+                ~unexpected_tool_names
+         in
          if unexpected_tool_names <> [] then
+           Prometheus.inc_counter
+             Prometheus.metric_keeper_unexpected_tool_partial_tolerance
+             ~labels:
+               [
+                 ("keeper_name", meta.name);
+                 ("logged", string_of_bool should_log_unexpected_tool_partial);
+               ]
+             ();
+         if should_log_unexpected_tool_partial then
            Log.Keeper.warn
              "keeper:%s unexpected_tool_partial_tolerance tools=%s (cycle continues; valid tools present)"
              meta.name

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -52,10 +52,16 @@ let string_contains_substring ~(needle : string) (haystack : string) : bool =
 (** Detect transient network errors that warrant retry with short backoff.
     Uses structured [Oas.Error.sdk_error] pattern matching instead of
     substring matching on stringified error messages. *)
+let is_structural_oas_timeout_message message =
+  let lower = String.lowercase_ascii message in
+  string_contains_substring ~needle:"(budget=" lower
+  || string_contains_substring ~needle:"turn wall-clock budget exhausted" lower
+
 let is_transient_network_error (err : Oas.Error.sdk_error) : bool =
   match err with
   | Oas.Error.Api (NetworkError _) -> true
-  | Oas.Error.Api (Timeout _) -> true
+  | Oas.Error.Api (Timeout { message }) ->
+      not (is_structural_oas_timeout_message message)
   | Oas.Error.Api (Overloaded _) -> true
   | Oas.Error.Api (ServerError { status = 503; _ }) -> true
   | _ -> false

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -9,6 +9,10 @@
     Uses structured [Oas.Error.sdk_error] pattern matching. *)
 val is_transient_network_error : Oas.Error.sdk_error -> bool
 
+(** [true] when an OAS timeout message describes an execution budget expiry,
+    not a transport-level timeout. *)
+val is_structural_oas_timeout_message : string -> bool
+
 (** Detect server-side request body parse errors (e.g. Ollama yyjson
     rejecting a malformed request body).  The LLM never
     processed the request, so committed tool results are not at risk

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -59,16 +59,67 @@ let to_public internal =
   | Some public -> public
   | None -> internal
 
+let public_masc_to_internal_tbl =
+  let t = Hashtbl.create 16 in
+  List.iter
+    (fun internal ->
+      match Tool_catalog_surfaces.keeper_internal_replacement internal with
+      | Some public -> Hashtbl.replace t public internal
+      | None -> ())
+    Tool_catalog_surfaces.keeper_internal_tools;
+  t
+
+let public_masc_to_internal name =
+  Hashtbl.find_opt public_masc_to_internal_tbl name
+
 let strip_mcp_masc_prefix name =
   match Base.String.chop_prefix name ~prefix:"mcp__masc__" with
   | Some rest -> rest
   | None -> name
 
+let canonicalize_one_observed name =
+  let stripped = strip_mcp_masc_prefix name in
+  let was_mcp_prefixed = not (String.equal stripped name) in
+  match to_internal stripped with
+  | Some internal ->
+      ( internal,
+        Some
+          (if was_mcp_prefixed then "mcp_prefixed_anthropic_code"
+           else "anthropic_code") )
+  | None -> (
+      match public_masc_to_internal stripped with
+      | Some internal ->
+          ( internal,
+            Some
+              (if was_mcp_prefixed then "mcp_prefixed_public_masc"
+               else "public_masc") )
+      | None ->
+          (stripped, if was_mcp_prefixed then Some "mcp_prefix" else None))
+
 let canonicalize_observed names =
   List.map
     (fun n ->
-      let stripped = strip_mcp_masc_prefix n in
-      match to_internal stripped with Some i -> i | None -> stripped)
+      let canonical, _alias_kind = canonicalize_one_observed n in
+      canonical)
+    names
+
+let canonicalize_observed_with_telemetry names =
+  List.map
+    (fun n ->
+      let canonical, alias_kind = canonicalize_one_observed n in
+      (match alias_kind with
+       | Some kind when not (String.equal n canonical) ->
+           Prometheus.inc_counter
+             Prometheus.metric_keeper_tool_alias_canonicalizations
+             ~labels:
+               [
+                 ("alias_kind", kind);
+                 ("public_tool", n);
+                 ("canonical_tool", canonical);
+               ]
+             ()
+       | _ -> ());
+      canonical)
     names
 
 let hallucinated_set =

--- a/lib/keeper/keeper_tool_alias.mli
+++ b/lib/keeper/keeper_tool_alias.mli
@@ -24,6 +24,12 @@ val to_public : string -> string
     counting unexpected tools. *)
 val canonicalize_observed : string list -> string list
 
+(** [canonicalize_observed_with_telemetry names] is the runtime variant of
+    [canonicalize_observed]. It returns the same canonical names and increments
+    [masc_keeper_tool_alias_canonicalizations_total] for every observed public
+    or MCP-prefixed name rewritten to a keeper-facing name. *)
+val canonicalize_observed_with_telemetry : string list -> string list
+
 (** [hallucinated_builtins] lists the public names from the Anthropic
     Code surface that have **no** cognate in the keeper surface
     (e.g. [Skill], [Agent], [WebSearch]). These should be flagged with

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -1039,6 +1039,21 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
 let merge_string_list ~base overlay =
   match overlay with [] -> base | xs -> xs
 
+let profile_conflict_warned : (string, unit) Hashtbl.t = Hashtbl.create 32
+let profile_conflict_warn_mu = Eio.Mutex.create ()
+
+let should_log_profile_conflict_once ~agent_name ~field ~base_value
+    ~overlay_value =
+  let key =
+    String.concat "\000" [ agent_name; field; base_value; overlay_value ]
+  in
+  Eio_guard.with_mutex profile_conflict_warn_mu (fun () ->
+      if Hashtbl.mem profile_conflict_warned key then
+        false
+      else (
+        Hashtbl.replace profile_conflict_warned key ();
+        true))
+
 let merge_keeper_profile_defaults
     ~agent_name
     ~(base : keeper_profile_defaults)
@@ -1049,10 +1064,23 @@ let merge_keeper_profile_defaults
   let warn_on_conflict ~field ~base_value ~overlay_value =
     match base_value, overlay_value with
     | Some b, Some o when b <> o ->
-        Log.Keeper.warn
-          "keeper %s config conflict: %s differs between persona (%S) and TOML (%S). \
-           TOML wins."
-          agent_name field b o
+        let should_log =
+          should_log_profile_conflict_once ~agent_name ~field ~base_value:b
+            ~overlay_value:o
+        in
+        Prometheus.inc_counter Prometheus.metric_keeper_profile_config_conflicts
+          ~labels:
+            [
+              ("field", field);
+              ("resolution", "toml_wins");
+              ("logged", string_of_bool should_log);
+            ]
+          ();
+        if should_log then
+          Log.Keeper.warn
+            "keeper %s config conflict: %s differs between persona (%S) and TOML (%S). \
+             TOML wins."
+            agent_name field b o
     | _ -> ()
   in
   warn_on_conflict ~field:"tool_preset"

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1373,6 +1373,18 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             (Trajectory.Failed (Oas.Error.to_string err));
           let e_str = Oas.Error.to_string err in
           let is_transient = EC.is_transient_network_error err in
+          (match err with
+           | Oas.Error.Api (Timeout { message }) ->
+               let classification =
+                 if is_transient then "transient_network"
+                 else if EC.is_structural_oas_timeout_message message then
+                   "structural_budget"
+                 else "other_timeout"
+               in
+               Prometheus.inc_counter
+                 Prometheus.metric_keeper_oas_timeout_classifications
+                 ~labels:[("classification", classification)] ()
+           | _ -> ());
           let is_server_parse_rejection = EC.is_server_rejected_parse_error err in
           let is_auto_recoverable = EC.is_auto_recoverable_turn_error err in
           let is_ambiguous_partial = EC.is_ambiguous_side_effect_error err in

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -207,6 +207,14 @@ let metric_keeper_lifecycle_dispatch_rejections =
   "masc_keeper_lifecycle_dispatch_rejections_total"
 let metric_keeper_paused_state_persist_errors =
   "masc_keeper_paused_state_persist_errors_total"
+let metric_keeper_unexpected_tool_partial_tolerance =
+  "masc_keeper_unexpected_tool_partial_tolerance_total"
+let metric_keeper_tool_alias_canonicalizations =
+  "masc_keeper_tool_alias_canonicalizations_total"
+let metric_keeper_profile_config_conflicts =
+  "masc_keeper_profile_config_conflicts_total"
+let metric_keeper_oas_timeout_classifications =
+  "masc_keeper_oas_timeout_classifications_total"
 let metric_persistence_read_drops =
   "masc_persistence_read_drops_total"
 
@@ -292,6 +300,8 @@ let metric_keeper_invariant_violations = "masc_keeper_invariant_violations_total
 let metric_oas_bus_subscriber_stream_depth = "masc_oas_bus_subscriber_stream_depth"
 let metric_oas_bus_publish_block_seconds = "masc_oas_bus_publish_block_seconds_total"
 let metric_oas_bus_publish = "masc_oas_bus_publish_total"
+let metric_runtime_ollama_probe_generate_skips =
+  "masc_runtime_ollama_probe_generate_skips_total"
 
 (** {1 Built-in Metrics} *)
 
@@ -388,6 +398,23 @@ let init () =
     "Total keeper paused-state persistence failures, labeled by phase \
      (boot_resume_check|boot_resume_persist) and reason (read_meta_error|meta_missing)"
     Counter;
+  add metric_keeper_unexpected_tool_partial_tolerance
+    "Total keeper turns that tolerated unexpected tool names because at least \
+     one valid keeper tool call was present. Labeled by keeper_name and \
+     logged=true|false so WARN suppression remains observable."
+    Counter;
+  add metric_keeper_tool_alias_canonicalizations
+    "Total observed LLM-facing tool names canonicalized to keeper internal \
+     tool names. Labeled by alias_kind, public_tool, and canonical_tool."
+    Counter;
+  add metric_keeper_profile_config_conflicts
+    "Total keeper profile config conflicts between persona defaults and TOML \
+     overlays. Labeled by field, resolution, and logged=true|false."
+    Counter;
+  add metric_keeper_oas_timeout_classifications
+    "Total keeper OAS timeout classifications. Labeled by \
+     classification=transient_network|structural_budget|other_timeout."
+    Counter;
   add metric_persistence_read_drops
     "Total persisted read-model entries dropped during filesystem scans, \
      labeled by surface and reason"
@@ -475,6 +502,10 @@ let init () =
   add metric_oas_bus_publish
     "Total Oas.Event_bus.publish calls routed through \
      Oas_bus_instrument.publish."
+    Counter;
+  add metric_runtime_ollama_probe_generate_skips
+    "Total Ollama runtime probes that intentionally skipped /api/generate. \
+     Labeled by reason=status_only|model_unloaded|ps_error|no_effective_model|policy_skip."
     Counter;
   (* Transport metrics — registered here so transport_metrics.ml can use
      module constants instead of string literals. *)

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -84,6 +84,10 @@ val metric_keeper_tool_call_duration : string
 val metric_keeper_write_meta_failures : string
 val metric_keeper_lifecycle_dispatch_rejections : string
 val metric_keeper_paused_state_persist_errors : string
+val metric_keeper_unexpected_tool_partial_tolerance : string
+val metric_keeper_tool_alias_canonicalizations : string
+val metric_keeper_profile_config_conflicts : string
+val metric_keeper_oas_timeout_classifications : string
 val metric_persistence_read_drops : string
 val metric_oas_sse_relay_retries : string
 val metric_oas_sse_relay_drops : string
@@ -123,6 +127,7 @@ val metric_keeper_invariant_violations : string
 val metric_oas_bus_subscriber_stream_depth : string
 val metric_oas_bus_publish_block_seconds : string
 val metric_oas_bus_publish : string
+val metric_runtime_ollama_probe_generate_skips : string
 
 (** {1 Transport metrics} *)
 

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -279,7 +279,7 @@ let run_dashboard_runtime_probe () =
   | None ->
       Tool_local_runtime.runtime_ollama_probe_json ~probe_runs:2 ~max_tokens:8
         ~timeout_sec:dashboard_runtime_probe_timeout_sec ~ps_timeout_sec:2
-        ~generate_when_unloaded:false ()
+        ~generate_when_unloaded:false ~run_generate:false ()
 
 let dashboard_runtime_probe_cached_value () =
   match Atomic.get dashboard_runtime_probe_cache with

--- a/lib/tool_local_runtime.ml
+++ b/lib/tool_local_runtime.ml
@@ -172,6 +172,11 @@ let handle_runtime_ollama_probe _ctx args : tool_result =
     | `Bool flag -> flag
     | _ -> true
   in
+  let run_generate =
+    match member "run_generate" args with
+    | `Bool flag -> flag
+    | _ -> true
+  in
   match think_mode with
   | Error msg -> (false, json_error msg)
   | Ok think_mode ->
@@ -181,7 +186,7 @@ let handle_runtime_ollama_probe _ctx args : tool_result =
             ( "result",
               runtime_ollama_probe_json ?server_url ?model ?prompt ?keep_alive
                 ~probe_runs ~max_tokens ~think_mode ~timeout_sec
-                ~generate_when_unloaded () );
+                ~generate_when_unloaded ~run_generate () );
           ] )
 
 let dispatch ctx ~name ~args : tool_result option =
@@ -249,6 +254,7 @@ let schemas : tool_schema list =
                       ] );
                   ("timeout_sec", `Assoc [ ("type", `String "integer") ]);
                   ("generate_when_unloaded", `Assoc [ ("type", `String "boolean") ]);
+                  ("run_generate", `Assoc [ ("type", `String "boolean") ]);
                 ] );
           ];
     };

--- a/lib/tool_local_runtime_probe.ml
+++ b/lib/tool_local_runtime_probe.ml
@@ -396,8 +396,11 @@ let model_is_loaded model_id loaded_models =
       | None -> false)
     loaded_models
 
-let should_attempt_generate_probe ~before_status ~before_error
+let should_attempt_generate_probe ~before_status ~before_error ~run_generate
     ~generate_when_unloaded ~effective_model_loaded_before =
+  if not run_generate then
+    false
+  else
   match before_status, before_error with
   | Some 200, _ -> generate_when_unloaded || effective_model_loaded_before
   | _, Some _ -> false
@@ -463,7 +466,8 @@ let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
     ?keep_alive ?(max_tokens = 16) ?(think_mode = Think_auto)
     ?(timeout_sec = default_probe_timeout_sec)
     ?(ps_timeout_sec = default_ps_timeout_sec)
-    ?(generate_when_unloaded = true) () =
+    ?(generate_when_unloaded = true)
+    ?(run_generate = true) () =
   let server_url =
     Option.bind server_url trim_to_option
     |> Option.value ~default:Env_config_runtime.Ollama.server_url
@@ -497,6 +501,7 @@ let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
     | Some _ when
         not
           (should_attempt_generate_probe ~before_status ~before_error
+             ~run_generate
              ~generate_when_unloaded ~effective_model_loaded_before) ->
         let skipped_unloaded_model =
           match before_status, before_error with
@@ -518,6 +523,21 @@ let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
         in
         (completed_runs, run_errors, false)
   in
+  let generate_skip_reason =
+    match effective_model, runs with
+    | None, [] -> Some "no_effective_model"
+    | Some _, [] when not run_generate -> Some "status_only"
+    | Some _, [] when Option.is_some before_error -> Some "ps_error"
+    | Some _, [] when generate_skipped_unloaded_model -> Some "model_unloaded"
+    | Some _, [] -> Some "policy_skip"
+    | _ -> None
+  in
+  (match generate_skip_reason with
+   | Some reason ->
+       Prometheus.inc_counter
+         Prometheus.metric_runtime_ollama_probe_generate_skips
+         ~labels:[("reason", reason)] ()
+   | None -> ());
   let after_status, loaded_after, after_error =
     fetch_ollama_ps ~timeout_sec:ps_timeout_sec ~server_url ()
   in
@@ -543,6 +563,11 @@ let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
     |> (fun items ->
          if generate_skipped_unloaded_model then
            "Skipped /api/generate because the effective model was not resident; dashboard probes avoid cold-loading Ollama models."
+           :: items
+         else items)
+    |> (fun items ->
+         if not run_generate then
+           "Skipped /api/generate because run_generate=false; this is a status-only Ollama residency probe."
            :: items
          else items)
     |> (fun items ->
@@ -582,7 +607,9 @@ let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
       ("effective_model", string_opt_to_json effective_model);
       ("probe_runs_requested", `Int probe_runs);
       ("probe_runs_completed", `Int (List.length runs));
+      ("run_generate", `Bool run_generate);
       ("generate_when_unloaded", `Bool generate_when_unloaded);
+      ("generate_skip_reason", string_opt_to_json generate_skip_reason);
       ("generate_skipped_unloaded_model", `Bool generate_skipped_unloaded_model);
       ("keep_alive", string_opt_to_json (Option.bind keep_alive trim_to_option));
       ("max_tokens", `Int max_tokens);
@@ -610,5 +637,5 @@ let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
             `String
               "A repeated-prefix signal is inference from prompt_eval_duration_ms, not a stable Ollama-native cache metric.";
           ] );
-      ("probe_ok", `Bool (errors = [] && runs <> []));
+      ("probe_ok", `Bool (errors = [] && (runs <> [] || not run_generate)));
     ]

--- a/lib/tool_local_runtime_probe.ml
+++ b/lib/tool_local_runtime_probe.ml
@@ -401,10 +401,10 @@ let should_attempt_generate_probe ~before_status ~before_error ~run_generate
   if not run_generate then
     false
   else
-  match before_status, before_error with
-  | Some 200, _ -> generate_when_unloaded || effective_model_loaded_before
-  | _, Some _ -> false
-  | _ -> generate_when_unloaded || effective_model_loaded_before
+  match before_error, before_status with
+  | Some _, _ -> false
+  | None, Some 200 -> generate_when_unloaded || effective_model_loaded_before
+  | None, _ -> generate_when_unloaded || effective_model_loaded_before
 
 let request_body_json ~think_enabled ~keep_alive ~model_id ~prompt ~max_tokens =
   let fields =

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -48,12 +48,47 @@ let test_to_public_pass_through () =
     "anything" (Alias.to_public "anything")
 
 let test_canonicalize_observed () =
-  let input = [ "Bash"; "keeper_board_post"; "Read"; "Skill"; "Write" ] in
+  let input =
+    [ "Bash"; "keeper_board_post"; "masc_board_post"; "Read"; "Skill"; "Write" ]
+  in
   let expected =
-    [ "keeper_bash"; "keeper_board_post"; "keeper_fs_read"; "Skill"; "keeper_fs_edit" ]
+    [
+      "keeper_bash";
+      "keeper_board_post";
+      "keeper_board_post";
+      "keeper_fs_read";
+      "Skill";
+      "keeper_fs_edit";
+    ]
   in
   Alcotest.(check (list string)) "mixed list canonicalizes only known aliases"
     expected (Alias.canonicalize_observed input)
+
+let test_canonicalize_observed_with_telemetry_records_public_masc () =
+  let labels =
+    [
+      ("alias_kind", "public_masc");
+      ("public_tool", "masc_board_post");
+      ("canonical_tool", "keeper_board_post");
+    ]
+  in
+  let before =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_keeper_tool_alias_canonicalizations
+      ~labels ()
+  in
+  let canonical =
+    Alias.canonicalize_observed_with_telemetry [ "masc_board_post" ]
+  in
+  let after =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_keeper_tool_alias_canonicalizations
+      ~labels ()
+  in
+  Alcotest.(check (list string)) "public MASC tool canonicalized"
+    [ "keeper_board_post" ] canonical;
+  Alcotest.(check (float 0.001)) "telemetry counter incremented"
+    (before +. 1.0) after
 
 let test_hallucinated_builtins () =
   Alcotest.(check bool) "Skill is hallucinated"
@@ -436,6 +471,8 @@ let () =
           Alcotest.test_case "to_public round-trip" `Quick test_to_public_round_trip;
           Alcotest.test_case "to_public pass-through" `Quick test_to_public_pass_through;
           Alcotest.test_case "canonicalize_observed" `Quick test_canonicalize_observed;
+          Alcotest.test_case "canonicalize_observed telemetry" `Quick
+            test_canonicalize_observed_with_telemetry_records_public_masc;
           Alcotest.test_case "hallucinated builtins" `Quick test_hallucinated_builtins;
           Alcotest.test_case "no overlap" `Quick test_no_overlap_alias_and_hallucinated;
           Alcotest.test_case "table is stable" `Quick test_alias_table_is_stable;

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4612,6 +4612,11 @@ let () =
             check bool "timeout" true
               (EC.is_transient_network_error
                  (Agent_sdk.Error.Api (Timeout { message = "connection timed out" }))));
+          test_case "structural OAS timeout is not network transient" `Quick (fun () ->
+            check bool "oas budget timeout" false
+              (EC.is_transient_network_error
+                 (Agent_sdk.Error.Api
+                    (Timeout { message = "Timeout after 573.2s (budget=573s)" }))));
           test_case "Overloaded detected" `Quick (fun () ->
             check bool "overloaded" true
               (EC.is_transient_network_error

--- a/test/test_tool_local_runtime_probe.ml
+++ b/test/test_tool_local_runtime_probe.ml
@@ -118,6 +118,30 @@ let test_runtime_probe_reports_effective_think_mode () =
   check bool "enabled effective think true" true
     (enabled |> member "think" |> to_bool)
 
+let test_runtime_probe_status_only_skip_is_telemetry () =
+  let labels = [ ("reason", "status_only") ] in
+  let before =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_runtime_ollama_probe_generate_skips
+      ~labels ()
+  in
+  let json =
+    Masc_mcp.Tool_local_runtime_probe.runtime_ollama_probe_json
+      ~server_url:"http://127.0.0.1:1" ~model:"dummy-probe-model"
+      ~run_generate:false ~timeout_sec:3 ~ps_timeout_sec:1 ()
+  in
+  let after =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_runtime_ollama_probe_generate_skips
+      ~labels ()
+  in
+  let open Yojson.Safe.Util in
+  check string "skip reason reported" "status_only"
+    (json |> member "generate_skip_reason" |> to_string);
+  check bool "status-only flag reported" false
+    (json |> member "run_generate" |> to_bool);
+  check_float_close "skip counter incremented" (before +. 1.0) after
+
 let test_normalize_server_url_strips_trailing_slashes () =
   check string "normalizes trailing slash" "http://127.0.0.1:11434"
     (Masc_mcp.Tool_local_runtime_probe.normalize_ollama_server_url
@@ -179,19 +203,28 @@ let test_generate_probe_is_skipped_after_failed_preflight () =
   check bool "ps preflight error skips generate" false
     (Masc_mcp.Tool_local_runtime_probe.should_attempt_generate_probe
        ~before_status:None ~before_error:(Some "curl exit code 28")
+       ~run_generate:true
        ~generate_when_unloaded:true ~effective_model_loaded_before:true);
   check bool "successful ps allows generate" true
     (Masc_mcp.Tool_local_runtime_probe.should_attempt_generate_probe
        ~before_status:(Some 200) ~before_error:None
+       ~run_generate:true
        ~generate_when_unloaded:true ~effective_model_loaded_before:false);
   check bool "successful ps skips cold model when disabled" false
     (Masc_mcp.Tool_local_runtime_probe.should_attempt_generate_probe
        ~before_status:(Some 200) ~before_error:None
+       ~run_generate:true
        ~generate_when_unloaded:false ~effective_model_loaded_before:false);
   check bool "resident model can still be probed when cold load disabled" true
     (Masc_mcp.Tool_local_runtime_probe.should_attempt_generate_probe
        ~before_status:(Some 200) ~before_error:None
-       ~generate_when_unloaded:false ~effective_model_loaded_before:true)
+       ~run_generate:true
+       ~generate_when_unloaded:false ~effective_model_loaded_before:true);
+  check bool "status-only probe skips generate even when resident" false
+    (Masc_mcp.Tool_local_runtime_probe.should_attempt_generate_probe
+       ~before_status:(Some 200) ~before_error:None
+       ~run_generate:false
+       ~generate_when_unloaded:true ~effective_model_loaded_before:true)
 
 let () =
   run "tool_local_runtime_probe"
@@ -221,6 +254,8 @@ let () =
             test_auto_think_policy_prioritizes_response;
           test_case "runtime probe reports effective think mode" `Quick
             test_runtime_probe_reports_effective_think_mode;
+          test_case "status-only skip is telemetry" `Quick
+            test_runtime_probe_status_only_skip_is_telemetry;
           test_case "computes tok per second from generate response" `Quick
             test_ollama_generate_parser_computes_tok_per_second;
         ] );

--- a/test/test_tool_local_runtime_probe.ml
+++ b/test/test_tool_local_runtime_probe.ml
@@ -205,6 +205,11 @@ let test_generate_probe_is_skipped_after_failed_preflight () =
        ~before_status:None ~before_error:(Some "curl exit code 28")
        ~run_generate:true
        ~generate_when_unloaded:true ~effective_model_loaded_before:true);
+  check bool "ps preflight error dominates successful status" false
+    (Masc_mcp.Tool_local_runtime_probe.should_attempt_generate_probe
+       ~before_status:(Some 200) ~before_error:(Some "invalid ps payload")
+       ~run_generate:true
+       ~generate_when_unloaded:true ~effective_model_loaded_before:true);
   check bool "successful ps allows generate" true
     (Masc_mcp.Tool_local_runtime_probe.should_attempt_generate_probe
        ~before_status:(Some 200) ~before_error:None
@@ -224,7 +229,17 @@ let test_generate_probe_is_skipped_after_failed_preflight () =
     (Masc_mcp.Tool_local_runtime_probe.should_attempt_generate_probe
        ~before_status:(Some 200) ~before_error:None
        ~run_generate:false
-       ~generate_when_unloaded:true ~effective_model_loaded_before:true)
+       ~generate_when_unloaded:true ~effective_model_loaded_before:true);
+  check bool "default path with no status allows generate when enabled" true
+    (Masc_mcp.Tool_local_runtime_probe.should_attempt_generate_probe
+       ~before_status:None ~before_error:None
+       ~run_generate:true
+       ~generate_when_unloaded:true ~effective_model_loaded_before:false);
+  check bool "default path blocks when disabled and not resident" false
+    (Masc_mcp.Tool_local_runtime_probe.should_attempt_generate_probe
+       ~before_status:None ~before_error:None
+       ~run_generate:true
+       ~generate_when_unloaded:false ~effective_model_loaded_before:false)
 
 let () =
   run "tool_local_runtime_probe"


### PR DESCRIPTION
## What changed

- Added a `run_generate` switch to the Ollama runtime probe and made dashboard runtime info use a status-only probe.
- Canonicalized public MASC keeper tool names, such as `masc_board_post`, back to their internal keeper tool names before partial-tolerance checks.
- Deduplicated repeated keeper config-conflict and unexpected-tool partial-tolerance warnings per identical key.
- Classified structural OAS wall-clock budget timeouts as non-transient so keeper does not retry them as network errors.

## Why

The live logs showed repeated dashboard `/api/generate` probe timeouts, repeated TOML/persona conflict warnings, public/internal keeper tool-name drift, and OAS budget timeouts being logged as transient network retries.

## Validation

- `git diff --check`
- `DUNE_BUILD_DIR=/tmp/masc-mcp-fix-build dune build --root . test/test_tool_local_runtime_probe.exe`
- `DUNE_BUILD_DIR=/tmp/masc-mcp-fix-build dune build --root . test/test_keeper_tool_alias.exe`
- `DUNE_BUILD_DIR=/tmp/masc-mcp-fix-build dune build --root . test/test_keeper_unified.exe`
- `/tmp/masc-mcp-fix-build/default/test/test_tool_local_runtime_probe.exe` (10 tests)
- `/tmp/masc-mcp-fix-build/default/test/test_keeper_tool_alias.exe` (30 tests)
- `/tmp/masc-mcp-fix-build/default/test/test_keeper_unified.exe` (218 tests)