### PR TITLE
fix(test): stabilize keeper TOML key checks

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -809,8 +809,6 @@ let canonical_keeper_toml_key_names =
   ; "github_identity"
   ; "git_identity_mode"
   ; "tool_preset"
-  ; "tool_access.kind"
-  ; "tool_access.preset"
   ; "tool_also_allow"
   ; "tool_denylist"
   ; "active_goal_ids"

--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -723,7 +723,7 @@ let test_turn_runtime_relaxed_fs_omits_readonly_and_noexec () =
       Alcotest.(check bool) "relaxed runtime keeps tmpfs mount" true
         (contains_substring line "/tmp:rw,nosuid,nodev,size=")
 
-let () =
+let run_tests () =
   Alcotest.run "Keeper_docker_read"
     [
       ( "should_route_read",
@@ -792,3 +792,11 @@ let () =
             test_cleanup_stale_containers_removes_only_stale_masc_scope;
         ] );
     ]
+
+let () =
+  Eio_main.run @@ fun env ->
+  Process_eio.init
+    ~cwd_default:Eio.Path.(Eio.Stdenv.fs env / Sys.getcwd ())
+    ~proc_mgr:(Eio.Stdenv.process_mgr env)
+    ~clock:(Eio.Stdenv.clock env);
+  run_tests ()

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1009,6 +1009,22 @@ mention_targets = ["a"]
     check (list string) "surfaces dead config"
       ["keeper.legacy_scope"; "keeper.scope_kind"] unknown
 
+let test_detect_unknown_keys_flags_unparsed_tool_access_table () =
+  let input = {|
+[keeper]
+goal = "g"
+
+[keeper.tool_access]
+kind = "preset"
+preset = "coding"
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    let unknown = KTP.detect_unknown_keeper_toml_keys doc in
+    check (list string) "tool_access TOML table is not silently accepted"
+      ["keeper.tool_access.kind"; "keeper.tool_access.preset"] unknown
+
 let test_oas_env_parses_allowed_keys () =
   let input = {|
 [keeper]
@@ -1235,6 +1251,8 @@ let () =
             test_detect_unknown_keys_empty_when_all_canonical;
           test_case "flags legacy dead config" `Quick
             test_detect_unknown_keys_flags_legacy_dead_config;
+          test_case "flags unparsed tool_access table" `Quick
+            test_detect_unknown_keys_flags_unparsed_tool_access_table;
           test_case "also_allow alias flagged" `Quick
             test_detect_unknown_keys_flags_also_allow_alias;
           test_case "oas_env keys not flagged as unknown" `Quick


### PR DESCRIPTION
## Summary
- remove unparsed keeper.tool_access TOML keys from the canonical parsed-key list
- add coverage that a [keeper.tool_access] TOML table is reported as unknown instead of silently accepted
- initialize the Eio process manager before keeper docker-read tests resolve the docker CLI

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-toml-unknown-tool-access --display short -j 2 test/test_keeper_toml.exe test/test_keeper_docker_read.exe bin/main_eio.exe
- ./_build/default/test/test_keeper_toml.exe
- ./_build/default/test/test_keeper_docker_read.exe