### PR TITLE
chore(release): bump version to 0.12.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.12.6] - 2026-04-24
+
+### Changed
+- Bump version to 0.12.6.
+
 ## [0.12.3] - 2026-04-21
 
 ### Added

--- a/dune-project
+++ b/dune-project
@@ -3,7 +3,7 @@
 (using menhir 3.0)
 
 (name masc_mcp)
-(version 0.12.5)
+(version 0.12.6)
 
 (generate_opam_files true)
 (implicit_transitive_deps false)


### PR DESCRIPTION
## Summary
Bump project version from 0.12.5 to 0.12.6.

## Changes
- `dune-project`: `(version 0.12.5)` → `(version 0.12.6)`
- `CHANGELOG.md`: Add `[0.12.6] - 2026-04-24` section

## Checklist
- [x] Version bumped in dune-project
- [x] CHANGELOG updated
- [ ] opam files regenerated (CI)
- [ ] Remaining SSOT docs synced (ROADMAP, PRODUCT-OPERATING-PLAN, SPEC-INDEX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)