### PR TITLE
fix(dashboard): invalidate keeper projection cache on lifecycle updates

### DIFF
--- a/lib/dashboard/dashboard_projection_cache.ml
+++ b/lib/dashboard/dashboard_projection_cache.ml
@@ -20,6 +20,9 @@ let get_or_compute_snapshot_json ~config ~actor compute =
     (actor_cache_key config "snapshot" actor_name)
     ~ttl:3.0 (fun () -> compute actor_name)
 
+let invalidate_snapshot_json ~config =
+  Dashboard_cache.invalidate_prefix (actor_cache_key config "snapshot" "")
+
 let get_or_compute_digest_json ~config ~actor compute =
   let actor_name = normalize_actor_name actor in
   Dashboard_cache.get_or_compute

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -544,8 +544,9 @@ let extract_keeper_name_for_post req_path suffix =
   in
   if is_valid_keeper_name raw then raw else ""
 
-let refresh_keeper_execution_surfaces ~name event =
+let refresh_keeper_execution_surfaces ~config ~name event =
   Operator_control_snapshot.invalidate_snapshot_cache ();
+  Dashboard_projection_cache.invalidate_snapshot_json ~config;
   (try Dashboard_cache.invalidate "execution:default:light" with
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn ->
@@ -555,8 +556,9 @@ let refresh_keeper_execution_surfaces ~name event =
   Server_dashboard_http_execution_surfaces.patch_keeper_dependent_caches
     ~keeper_name:name ~event
 
-let invalidate_keeper_execution_surfaces () =
+let invalidate_keeper_execution_surfaces ~config () =
   Operator_control_snapshot.invalidate_snapshot_cache ();
+  Dashboard_projection_cache.invalidate_snapshot_json ~config;
   Server_dashboard_http_execution_surfaces.invalidate_execution_cache ()
 
 let handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str =
@@ -807,8 +809,8 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
         if String.equal action "boot"
         then (
           resume_booted_keeper_if_needed ();
-          refresh_keeper_execution_surfaces ~name "started")
-        else invalidate_keeper_execution_surfaces ();
+          refresh_keeper_execution_surfaces ~config ~name "started")
+        else invalidate_keeper_execution_surfaces ~config ();
         Http.Response.json ~compress:true ~request:req
           (Printf.sprintf {|{"ok":true,"action":"%s","name":"%s","detail":%s}|}
              (String.escaped action)
@@ -817,8 +819,8 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
           reqd
     | Some (true, _body) ->
         (match action with
-         | "shutdown" -> refresh_keeper_execution_surfaces ~name "stopped"
-         | _ -> invalidate_keeper_execution_surfaces ());
+         | "shutdown" -> refresh_keeper_execution_surfaces ~config ~name "stopped"
+         | _ -> invalidate_keeper_execution_surfaces ~config ());
         Http.Response.json ~compress:true ~request:req
           (Printf.sprintf {|{"ok":true,"action":"%s","name":"%s"}|}
              (String.escaped action)
@@ -918,10 +920,10 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
           Keeper_keepalive.process_directive
             ~agent_name:resolved_agent_name action_str;
           (match action_str with
-           | "pause" -> refresh_keeper_execution_surfaces ~name "paused"
-           | "resume" -> refresh_keeper_execution_surfaces ~name "resumed"
-           | "wakeup" -> invalidate_keeper_execution_surfaces ()
-           | _ -> invalidate_keeper_execution_surfaces ());
+           | "pause" -> refresh_keeper_execution_surfaces ~config ~name "paused"
+           | "resume" -> refresh_keeper_execution_surfaces ~config ~name "resumed"
+           | "wakeup" -> invalidate_keeper_execution_surfaces ~config ()
+           | _ -> invalidate_keeper_execution_surfaces ~config ());
           Http.Response.json ~compress:true ~request:req
             (Printf.sprintf {|{"ok":true,"action":"%s","name":"%s"}|}
                (String.escaped action_str) (String.escaped name))

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -354,7 +354,7 @@ let run_curl_post ?body ?token ~port ~path () =
     ; "-sS"
     ; "--http1.1"
     ; "--max-time"
-    ; "3"
+    ; "10"
     ; "-X"
     ; "POST"
     ; "-o"
@@ -420,7 +420,7 @@ let run_curl_get ?token ~port ~path () =
     ; "-sS"
     ; "--http1.1"
     ; "--max-time"
-    ; "3"
+    ; "10"
     ; "-X"
     ; "GET"
     ; "-o"
@@ -702,7 +702,7 @@ let with_seeded_server ?(env_overrides = []) f =
       rm_rf log_file;
       rm_rf base_path
     in
-    if not (wait_for_health ~port ~timeout_s:20.0)
+    if not (wait_for_health ~port ~timeout_s:45.0)
     then (
       let logs = read_file log_file in
       cleanup ();


### PR DESCRIPTION
## Summary
- sync keeper TOML canonical key allowlist with the actual TOML parser to stop module-load assertion crashes
- invalidate actor-scoped dashboard projection snapshots after keeper lifecycle/directive changes
- harden dashboard keeper route test timeouts for slow local/CI startup

## Validation
- PASS: git diff --check
- PASS: scripts/check-pr-hygiene.sh --base origin/main --head HEAD --recent-main 50 --duplicate-policy warn
- PARTIAL: dune exec ./test/test_keeper_runtime_config_ssot.exe ran 22/23 tests, then failed on Docker sandbox preflight timeout in the existing keeper_up docker-path test
- BLOCKED local full build: disk is at ~100%, and bin/main_eio.exe linking hit local opam/disk availability during validation; draft PR left for CI on a clean runner