### PR TITLE
fix(dashboard): tolerate null keeper decision telemetry

### DIFF
--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -1,30 +1,25 @@
 open Keeper_types
 
+let json_member key = function
+  | `Assoc _ as json -> Yojson.Safe.Util.member key json
+  | _ -> `Null
+
 let json_int_opt_member key json =
-  match json with
-  | `Assoc _ -> (
-      match Yojson.Safe.Util.member key json with
-      | `Int n -> Some n
-      | `Intlit raw -> int_of_string_opt raw
-      | _ -> None)
+  match json_member key json with
+  | `Int n -> Some n
+  | `Intlit raw -> int_of_string_opt raw
   | _ -> None
 
 let json_float_opt_member key json =
-  match json with
-  | `Assoc _ ->
-    (match Yojson.Safe.Util.member key json with
-     | `Float value -> Some value
-     | `Int value -> Some (float_of_int value)
-     | `Intlit raw -> float_of_string_opt raw
-     | _ -> None)
+  match json_member key json with
+  | `Float value -> Some value
+  | `Int value -> Some (float_of_int value)
+  | `Intlit raw -> float_of_string_opt raw
   | _ -> None
 
 let json_string_opt_member key json =
-  match json with
-  | `Assoc _ -> (
-      match Yojson.Safe.Util.member key json with
-      | `String value when String.trim value <> "" -> Some value
-      | _ -> None)
+  match json_member key json with
+  | `String value when String.trim value <> "" -> Some value
   | _ -> None
 
 let json_string_opt_value = function
@@ -32,19 +27,13 @@ let json_string_opt_value = function
   | _ -> None
 
 let json_bool_opt_member key json =
-  match json with
-  | `Assoc _ ->
-    (match Yojson.Safe.Util.member key json with
-     | `Bool value -> Some value
-     | _ -> None)
+  match json_member key json with
+  | `Bool value -> Some value
   | _ -> None
 
 let json_list_member key json =
-  match json with
-  | `Assoc _ ->
-    (match Yojson.Safe.Util.member key json with
-     | `List items -> items
-     | _ -> [])
+  match json_member key json with
+  | `List items -> items
   | _ -> []
 
 let json_string_list_member key json =

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -98,6 +98,19 @@ let append_keeper_receipt (config : Coord.config) (meta : Keeper_types.keeper_me
   in
   Keeper_execution_receipt.append config receipt
 
+let append_keeper_decision_with_null_telemetry
+    (config : Coord.config) (meta : Keeper_types.keeper_meta) =
+  Fs_compat.append_jsonl
+    (Keeper_types.keeper_decision_log_path config meta.name)
+    (`Assoc
+      [
+        ("turn_id", `Int 9);
+        ("turn_verdict", `String "run");
+        ("turn_reasons", `List [ `String "test_fixture" ]);
+        ("wall_clock", `Float (Unix.gettimeofday ()));
+        ("telemetry", `Null);
+      ])
+
 let test_blocked_phase_projects_blocked_health () =
   with_room @@ fun config ->
   let _goal, _kind =
@@ -170,6 +183,38 @@ let test_goal_detail_surfaces_keeper_runtime_trust_and_blockers () =
         "execution_receipt"
         (linked_keeper |> member "latest_causal_event" |> member "kind" |> to_string)
 
+let test_goal_tree_tolerates_null_decision_telemetry () =
+  with_room @@ fun config ->
+  let goal, _kind =
+    match Goal_store.upsert_goal config ~title:"Show resilient goal tree" () with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  let meta = make_keeper_meta ~name:"null-telemetry-keeper" ~goal_id:goal.id in
+  (match Keeper_types.write_meta ~force:true config meta with
+   | Ok () -> ()
+   | Error err -> fail ("write_meta failed: " ^ err));
+  append_keeper_decision_with_null_telemetry config meta;
+  let tree_json = Dashboard_goals.dashboard_goals_tree_json ~config in
+  let node =
+    match tree_json |> member "tree" |> to_list with
+    | node :: _ -> node
+    | [] -> fail "expected one goal in tree"
+  in
+  check string "linked keeper still surfaced" meta.name
+    (node |> member "latest_keeper_ref" |> to_string);
+  match Dashboard_goals.goal_detail_json ~config ~goal_id:goal.id with
+  | Error msg -> fail msg
+  | Ok json ->
+      let linked_keeper =
+        match json |> member "linked_keepers" |> to_list with
+        | keeper :: _ -> keeper
+        | [] -> fail "expected linked keeper detail"
+      in
+      check (option string) "null telemetry selected_model stays absent" None
+        (linked_keeper |> member "runtime_trust" |> member "selected_model"
+        |> to_string_option)
+
 let test_goal_detail_does_not_promote_synthetic_blocker_over_receipt () =
   with_room @@ fun config ->
   let goal, _kind =
@@ -228,6 +273,8 @@ let () =
           test_case "goal detail surfaces keeper runtime trust and blockers"
             `Quick
             test_goal_detail_surfaces_keeper_runtime_trust_and_blockers;
+          test_case "goal tree tolerates null decision telemetry" `Quick
+            test_goal_tree_tolerates_null_decision_telemetry;
           test_case
             "goal detail keeps synthetic runtime blocker out of latest causal"
             `Quick

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1158,22 +1158,6 @@ also_allow = ["x"]
     check (list string) "also_allow alias is stale drift"
       ["keeper.also_allow"] unknown
 
-let test_detect_unknown_keys_flags_unparsed_tool_access_table () =
-  let input = {|
-[keeper]
-goal = "g"
-[keeper.tool_access]
-kind = "preset"
-preset = "coding"
-|} in
-  match TL.parse_toml input with
-  | Error e -> fail e
-  | Ok doc ->
-    let unknown = KTP.detect_unknown_keeper_toml_keys doc in
-    check (list string) "tool_access table is not a parsed TOML surface"
-      [ "keeper.tool_access.kind"; "keeper.tool_access.preset" ]
-      unknown
-
 (* ================================================================ *)
 (* Test suite                                                        *)
 (* ================================================================ *)
@@ -1271,8 +1255,6 @@ let () =
             test_detect_unknown_keys_flags_unparsed_tool_access_table;
           test_case "also_allow alias flagged" `Quick
             test_detect_unknown_keys_flags_also_allow_alias;
-          test_case "unparsed tool_access table flagged" `Quick
-            test_detect_unknown_keys_flags_unparsed_tool_access_table;
           test_case "oas_env keys not flagged as unknown" `Quick
             test_oas_env_not_flagged_as_unknown;
         ] );

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1158,6 +1158,22 @@ also_allow = ["x"]
     check (list string) "also_allow alias is stale drift"
       ["keeper.also_allow"] unknown
 
+let test_detect_unknown_keys_flags_unparsed_tool_access_table () =
+  let input = {|
+[keeper]
+goal = "g"
+[keeper.tool_access]
+kind = "preset"
+preset = "coding"
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    let unknown = KTP.detect_unknown_keeper_toml_keys doc in
+    check (list string) "tool_access table is not a parsed TOML surface"
+      [ "keeper.tool_access.kind"; "keeper.tool_access.preset" ]
+      unknown
+
 (* ================================================================ *)
 (* Test suite                                                        *)
 (* ================================================================ *)
@@ -1255,6 +1271,8 @@ let () =
             test_detect_unknown_keys_flags_unparsed_tool_access_table;
           test_case "also_allow alias flagged" `Quick
             test_detect_unknown_keys_flags_also_allow_alias;
+          test_case "unparsed tool_access table flagged" `Quick
+            test_detect_unknown_keys_flags_unparsed_tool_access_table;
           test_case "oas_env keys not flagged as unknown" `Quick
             test_oas_env_not_flagged_as_unknown;
         ] );


### PR DESCRIPTION
## Summary
- Guard runtime trust snapshot JSON member reads when decision telemetry is non-object/null.
- Add a dashboard goals regression covering null keeper decision telemetry.

## Verification
- git diff --check origin/main...HEAD
- Local OCaml test run was attempted earlier but did not complete in this low-disk/OPAM environment; relying on GitHub CI for full validation.