### PR TITLE
fix(ci): harden OAS artifact build diagnostics

### DIFF
--- a/scripts/check-oas-pin.sh
+++ b/scripts/check-oas-pin.sh
@@ -180,6 +180,63 @@ version_gte() {
   return 0
 }
 
+ocamlfind_query_dir() {
+  local package="$1"
+  if command -v ocamlfind >/dev/null 2>&1; then
+    ocamlfind query "${package}" 2>/dev/null
+  elif command -v opam >/dev/null 2>&1; then
+    opam exec -- ocamlfind query "${package}" 2>/dev/null
+  else
+    return 127
+  fi
+}
+
+agent_sdk_artifact_repair_guidance() {
+  echo "repair: df -h . \"\${OPAM_SWITCH_PREFIX:-\${HOME}/.opam}\" /tmp" >&2
+  echo "repair: bash scripts/disk-hygiene.sh --fix" >&2
+  echo "repair: bash scripts/opam-pin-external-deps.sh --install" >&2
+  echo "repair: opam reinstall agent_sdk -y" >&2
+}
+
+verify_agent_sdk_artifact() {
+  local package="$1"
+  local package_dir="$2"
+  local artifact="$3"
+  local artifact_path="${package_dir%/}/${artifact}"
+
+  if [[ ! -r "${artifact_path}" ]]; then
+    echo "agent_sdk opam switch artifact missing: ${artifact_path}" >&2
+    echo "  package: ${package}" >&2
+    echo "  likely cause: interrupted opam rebuild/install or a full disk during native archive installation" >&2
+    agent_sdk_artifact_repair_guidance
+    exit 1
+  fi
+}
+
+verify_agent_sdk_switch_artifacts() {
+  local agent_sdk_dir
+  local llm_provider_dir
+
+  if ! agent_sdk_dir="$(ocamlfind_query_dir agent_sdk)"; then
+    echo "agent_sdk findlib package is unavailable in the current opam switch" >&2
+    agent_sdk_artifact_repair_guidance
+    exit 1
+  fi
+
+  if ! llm_provider_dir="$(ocamlfind_query_dir agent_sdk.llm_provider)"; then
+    echo "agent_sdk.llm_provider findlib package is unavailable in the current opam switch" >&2
+    agent_sdk_artifact_repair_guidance
+    exit 1
+  fi
+
+  verify_agent_sdk_artifact "agent_sdk" "${agent_sdk_dir}" "agent_sdk.cmi"
+  verify_agent_sdk_artifact "agent_sdk" "${agent_sdk_dir}" "agent_sdk.cmxa"
+  verify_agent_sdk_artifact "agent_sdk" "${agent_sdk_dir}" "agent_sdk.a"
+  verify_agent_sdk_artifact "agent_sdk.llm_provider" "${llm_provider_dir}" "llm_provider.cmi"
+  verify_agent_sdk_artifact "agent_sdk.llm_provider" "${llm_provider_dir}" "llm_provider.cmxa"
+  verify_agent_sdk_artifact "agent_sdk.llm_provider" "${llm_provider_dir}" "llm_provider.a"
+}
+
 if command -v opam >/dev/null 2>&1; then
   # Refresh switch environment — opam install may have changed the switch
   # state on disk without updating the current shell's env vars.
@@ -206,6 +263,7 @@ if command -v opam >/dev/null 2>&1; then
     echo "repair: bash scripts/opam-pin-external-deps.sh && opam install . --deps-only --with-test -y" >&2
     exit 1
   fi
+  verify_agent_sdk_switch_artifacts
 
   pin_list_output="$(OPAMCOLOR=never opam pin list 2>/dev/null || true)"
   pin_line="$(awk '$1 ~ /^agent_sdk\./ { print }' <<<"${pin_list_output}")"

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -27,6 +27,7 @@ CI_TEST_ALLOW_RPC_RETRY="${CI_TEST_ALLOW_RPC_RETRY:-1}"
 CI_TEST_RPC_RETRY_DONE=0
 CI_TEST_ALLOW_FLAKY_RETRY="${CI_TEST_ALLOW_FLAKY_RETRY:-1}"
 CI_TEST_FLAKY_RETRY_DONE=0
+CI_TEST_DISK_FULL_GUIDANCE_DONE=0
 CI_TEST_ISOLATED_BUILD_DIR="${CI_TEST_ISOLATED_BUILD_DIR:-.ci_build}"
 CI_CONTRACT_HARNESS_ENABLED="${CI_CONTRACT_HARNESS_ENABLED:-0}"
 CI_CONTRACT_HARNESS_CMD="${CI_CONTRACT_HARNESS_CMD:-scripts/harness/contract/run_all.sh}"
@@ -50,6 +51,12 @@ elapsed_sec() {
 log_line() {
   local line="$1"
   printf '%s\n' "${line}" | tee -a "${TEST_LOG_FILE}"
+}
+
+tmpdir_disk_usage() {
+  local tmp_dir="${TMPDIR:-/tmp}"
+  df -h "${tmp_dir}" 2>/dev/null \
+    | awk 'NR == 2 { print "size=" $2 " used=" $3 " avail=" $4 " capacity=" $5; found=1 } END { if (!found) print "unknown" }'
 }
 
 active_cmd_tree_pids() {
@@ -135,7 +142,7 @@ diag_dump() {
   echo "[ci-diag] env DUNE_RPC=${DUNE_RPC:-<unset>}"
 
   echo "[ci-diag] ulimit -n (open files): $(ulimit -n 2>/dev/null || echo unknown)"
-  echo "[ci-diag] tmpdir usage: $(du -sh "${TMPDIR:-/tmp}" 2>/dev/null | cut -f1 || echo unknown)"
+  echo "[ci-diag] tmpdir usage: $(tmpdir_disk_usage)"
   echo "[ci-diag] process snapshot (dune/ocaml/test):"
   ps -eo pid,ppid,etime,%cpu,%mem,comm,args \
     | grep -Ei 'dune|ocaml|alcotest|test_' \
@@ -249,8 +256,27 @@ cache_disabled_cmd() {
 agent_sdk_interface_mismatch_detected() {
   [[ -f "${TEST_LOG_FILE}" ]] || return 1
   grep -Eq \
-    'Unbound module Agent_sdk|module Oas is an alias for module Agent_sdk|inconsistent assumptions over interface Agent_sdk' \
+    'Unbound module Agent_sdk|Unbound module Llm_provider|module Oas is an alias for module Agent_sdk|inconsistent assumptions over interface Agent_sdk|/lib/agent_sdk/[^[:space:]]+[.]cmxa' \
     "${TEST_LOG_FILE}"
+}
+
+disk_full_detected() {
+  [[ -f "${TEST_LOG_FILE}" ]] || return 1
+  grep -Eiq 'No space left on device|dune_trace_write[(][)]|ENOSPC' \
+    "${TEST_LOG_FILE}"
+}
+
+log_disk_full_guidance() {
+  if [[ "${CI_TEST_DISK_FULL_GUIDANCE_DONE}" -eq 1 ]]; then
+    return 0
+  fi
+
+  CI_TEST_DISK_FULL_GUIDANCE_DONE=1
+  local opam_path="${OPAM_SWITCH_PREFIX:-${HOME:-}/.opam}"
+  log_line "[ci-run] ERROR: detected disk exhaustion during dune build"
+  log_line "[ci-run] repair: df -h . ${opam_path} /tmp"
+  log_line "[ci-run] repair: bash scripts/disk-hygiene.sh --fix"
+  log_line "[ci-run] repair: bash scripts/disk-hygiene.sh --fix --reset-dune-cache # if dune cache artifacts remain inconsistent"
 }
 
 rpc_server_not_running_detected() {
@@ -261,19 +287,16 @@ rpc_server_not_running_detected() {
 clean_current_build_dir() {
   if [[ "${ACTIVE_TEST_BUILD_DIR}" != "_build" ]]; then
     env DUNE_BUILD_DIR="${ACTIVE_TEST_BUILD_DIR}" dune clean --root . \
-      > >(tee -a "${TEST_LOG_FILE}") \
-      2> >(tee -a "${TEST_LOG_FILE}" >&2)
+      >> "${TEST_LOG_FILE}" 2>&1
   else
-    dune clean --root . \
-      > >(tee -a "${TEST_LOG_FILE}") \
-      2> >(tee -a "${TEST_LOG_FILE}" >&2)
+    dune clean --root . >> "${TEST_LOG_FILE}" 2>&1
   fi
 }
 
 run_agent_sdk_clean_retry() {
   CI_TEST_CLEAN_RETRY_DONE=1
   run_cmd="$(cache_disabled_cmd "${run_cmd}")"
-  log_line "[ci-run] WARN: detected Agent_sdk interface mismatch; running dune clean and retrying once with DUNE_CACHE=disabled"
+  log_line "[ci-run] WARN: detected Agent_sdk/OAS artifact or interface mismatch; running dune clean and retrying once with DUNE_CACHE=disabled"
   log_line "[ci-run] retry_command: ${run_cmd}"
   clean_current_build_dir
   log_line "[ci-run] retry_started_at=$(iso_now)"
@@ -374,6 +397,10 @@ run_with_timeout "${run_cmd}"
 status=$?
 set -e
 
+if [[ "${status}" -ne 0 ]] && disk_full_detected; then
+  log_disk_full_guidance
+fi
+
 if [[ "${status}" -ne 0 ]] \
   && [[ "${CI_TEST_ALLOW_RPC_RETRY}" = "1" ]] \
   && [[ "${CI_TEST_RPC_RETRY_DONE}" -eq 0 ]] \
@@ -418,7 +445,8 @@ if [[ "${status}" -ne 0 ]] \
   && [[ "${CI_TEST_FLAKY_RETRY_DONE}" -eq 0 ]] \
   && [[ "${CI_TEST_RPC_RETRY_DONE}" -eq 0 ]] \
   && [[ "${CI_TEST_CLEAN_RETRY_DONE}" -eq 0 ]] \
-  && test_cmd_needs_dune_sanitization; then
+  && test_cmd_needs_dune_sanitization \
+  && ! disk_full_detected; then
   CI_TEST_FLAKY_RETRY_DONE=1
   diag_dump "flaky_pre_retry_${status}"
   ACTIVE_TEST_BUILD_DIR="${CI_TEST_ISOLATED_BUILD_DIR}_flaky"
@@ -429,6 +457,10 @@ if [[ "${status}" -ne 0 ]] \
   run_with_timeout "${run_cmd}"
   status=$?
   set -e
+
+  if [[ "${status}" -ne 0 ]] && disk_full_detected; then
+    log_disk_full_guidance
+  fi
 fi
 
 if [[ "${status}" -ne 0 ]] \
@@ -440,6 +472,9 @@ if [[ "${status}" -ne 0 ]] \
 fi
 
 if [[ "${status}" -ne 0 ]]; then
+  if disk_full_detected; then
+    log_disk_full_guidance
+  fi
   diag_dump "nonzero_exit_${status}"
   log_line "[ci-run] ERROR: test command failed with exit=${status}"
   exit "${status}"

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -67,35 +67,62 @@ done
 # --install mode can rebuild exactly the set that changed, nothing more.
 pinned_pkgs=()
 
+opam_pin_add() {
+  local package="$1"
+  local source="$2"
+  shift 2
+
+  local max_attempts="${OPAM_PIN_RETRIES:-4}"
+  local retry_delay_sec="${OPAM_PIN_RETRY_DELAY_SEC:-5}"
+  local attempt=1
+  local status=0
+
+  while true; do
+    if opam pin add "${package}" "${source}" "$@"; then
+      return 0
+    fi
+
+    status=$?
+    if [[ "${attempt}" -ge "${max_attempts}" ]]; then
+      echo "[opam-pin] ERROR: opam pin add failed after ${attempt} attempts: ${package} ${source}" >&2
+      return "${status}"
+    fi
+
+    echo "[opam-pin] WARN: opam pin add failed for ${package} (attempt ${attempt}/${max_attempts}, exit=${status}); retrying in ${retry_delay_sec}s" >&2
+    sleep "${retry_delay_sec}"
+    attempt=$((attempt + 1))
+  done
+}
+
 if $include_compact_protocol; then
-  opam pin add compact-protocol https://github.com/jeong-sik/compact-protocol.git#main -n -y
+  opam_pin_add compact-protocol https://github.com/jeong-sik/compact-protocol.git#main -n -y
   pinned_pkgs+=("compact-protocol")
 fi
 
 # mcp_protocol_eio and mcp_protocol_http merged into mcp_protocol
 # as sub-libraries (mcp-protocol-sdk#60). Pin the released single-package line.
-opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#v1.3.0 -n -y
+opam_pin_add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#v1.3.0 -n -y
 pinned_pkgs+=("mcp_protocol")
-opam pin add agent_sdk "${agent_sdk_pin_source}" -n -y
+opam_pin_add agent_sdk "${agent_sdk_pin_source}" -n -y
 pinned_pkgs+=("agent_sdk")
-opam pin add ocaml-webrtc "https://github.com/jeong-sik/ocaml-webrtc.git#${WEBRTC_SHA}" -n -y
+opam_pin_add ocaml-webrtc "https://github.com/jeong-sik/ocaml-webrtc.git#${WEBRTC_SHA}" -n -y
 pinned_pkgs+=("ocaml-webrtc")
-opam pin add grpc-direct-core "https://github.com/jeong-sik/grpc-direct.git#${GRPC_DIRECT_SHA}" -n -y
+opam_pin_add grpc-direct-core "https://github.com/jeong-sik/grpc-direct.git#${GRPC_DIRECT_SHA}" -n -y
 pinned_pkgs+=("grpc-direct-core")
-opam pin add grpc-direct "https://github.com/jeong-sik/grpc-direct.git#${GRPC_DIRECT_SHA}" -n -y
+opam_pin_add grpc-direct "https://github.com/jeong-sik/grpc-direct.git#${GRPC_DIRECT_SHA}" -n -y
 pinned_pkgs+=("grpc-direct")
-opam pin add neo4j_packstream "https://github.com/jeong-sik/ocaml-neo4j-bolt.git#${NEO4J_BOLT_SHA}" -n -y
+opam_pin_add neo4j_packstream "https://github.com/jeong-sik/ocaml-neo4j-bolt.git#${NEO4J_BOLT_SHA}" -n -y
 pinned_pkgs+=("neo4j_packstream")
-opam pin add neo4j_bolt_common "https://github.com/jeong-sik/ocaml-neo4j-bolt.git#${NEO4J_BOLT_SHA}" -n -y
+opam_pin_add neo4j_bolt_common "https://github.com/jeong-sik/ocaml-neo4j-bolt.git#${NEO4J_BOLT_SHA}" -n -y
 pinned_pkgs+=("neo4j_bolt_common")
-opam pin add neo4j_bolt "https://github.com/jeong-sik/ocaml-neo4j-bolt.git#${NEO4J_BOLT_SHA}" -n -y
+opam_pin_add neo4j_bolt "https://github.com/jeong-sik/ocaml-neo4j-bolt.git#${NEO4J_BOLT_SHA}" -n -y
 pinned_pkgs+=("neo4j_bolt")
-opam pin add neo4j_bolt_eio "https://github.com/jeong-sik/ocaml-neo4j-bolt.git#${NEO4J_BOLT_SHA}" -n -y
+opam_pin_add neo4j_bolt_eio "https://github.com/jeong-sik/ocaml-neo4j-bolt.git#${NEO4J_BOLT_SHA}" -n -y
 pinned_pkgs+=("neo4j_bolt_eio")
 
 if $include_bisect; then
   # bisect_ppx opam constraints lag newer compilers; keep CI solvable under OCaml 5.4 by pinning.
-  opam pin add bisect_ppx git+https://github.com/patricoferris/bisect_ppx.git#5.2 -n -y
+  opam_pin_add bisect_ppx git+https://github.com/patricoferris/bisect_ppx.git#5.2 -n -y
   pinned_pkgs+=("bisect_ppx")
 fi
 

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -75,6 +75,18 @@ let test_health_and_ci_runner_diagnostics () =
   check bool "ci runner retries dune rpc lock failures in isolated build dir" true
     (file_contains_pattern "scripts/ci-run-tests.sh"
        "detected dune RPC/lock failure; retrying once with isolated build dir");
+  check bool "ci runner detects native archive loss" true
+    (file_contains_pattern "scripts/ci-run-tests.sh" "Unbound module Llm_provider");
+  check bool "ci runner detects disk full failures" true
+    (file_contains_pattern "scripts/ci-run-tests.sh" "No space left on device");
+  check bool "ci runner prints disk hygiene repair guidance" true
+    (file_contains_pattern "scripts/ci-run-tests.sh"
+       "bash scripts/disk-hygiene.sh --fix");
+  check bool "ci runner avoids recursive tmpdir du in diagnostics" true
+    (file_not_contains_pattern "scripts/ci-run-tests.sh"
+       "du -sh \"${TMPDIR:-/tmp}\"");
+  check bool "ci runner avoids process substitution in clean retry" true
+    (file_not_contains_pattern "scripts/ci-run-tests.sh" "> >(tee");
   check bool "ci runner tracks active build dir for diagnostics" true
     (file_contains_pattern "scripts/ci-run-tests.sh" "ACTIVE_TEST_BUILD_DIR");
   check bool "quick suite excludes operator control from monolithic dune test" true
@@ -152,7 +164,16 @@ let test_oas_pin_source_contracts () =
        "local_pin_path_from_source()");
   check bool "oas pin check accepts both git file pins and plain file pins" true
     (file_contains_pattern "scripts/check-oas-pin.sh"
-       "git+file://*|file://*)")
+       "git+file://*|file://*)");
+  check bool "oas pin check validates findlib artifact directories" true
+    (file_contains_pattern "scripts/check-oas-pin.sh" "ocamlfind query");
+  check bool "oas pin check validates agent sdk native archive" true
+    (file_contains_pattern "scripts/check-oas-pin.sh" "agent_sdk.cmxa");
+  check bool "oas pin check validates llm provider native archive" true
+    (file_contains_pattern "scripts/check-oas-pin.sh" "llm_provider.cmxa");
+  check bool "oas pin check gives rebuild guidance" true
+    (file_contains_pattern "scripts/check-oas-pin.sh"
+       "scripts/opam-pin-external-deps.sh --install")
 
 let test_doc_truth_guard_contracts () =
   check bool "doc truth script protects spec index front door wording" true

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -154,6 +154,12 @@ let test_release_truth_contracts () =
     (file_contains_pattern "mk/release.mk" "release-evidence:")
 
 let test_oas_pin_source_contracts () =
+  check bool "external opam pins retry transient git fetch failures" true
+    (file_contains_pattern "scripts/opam-pin-external-deps.sh"
+       "OPAM_PIN_RETRIES");
+  check bool "external opam pins use retry wrapper" true
+    (file_contains_pattern "scripts/opam-pin-external-deps.sh"
+       "opam_pin_add mcp_protocol");
   check bool "oas pin check parses local file pins from opam output" true
     (file_contains_pattern "scripts/check-oas-pin.sh"
        "extract_opam_pin_source()");

--- a/test/test_ci_run_tests_script.ml
+++ b/test/test_ci_run_tests_script.ml
@@ -98,7 +98,7 @@ exit 0
   Unix.chmod dune_path 0o755;
   bin_dir
 
-let make_fake_dune_flaky_then_interface_mismatch dir =
+let make_fake_dune_flaky_then_agent_sdk_artifact_failure dir =
   let bin_dir = Filename.concat dir "bin-interface" in
   Unix.mkdir bin_dir 0o755;
   let dune_path = Filename.concat bin_dir "dune" in
@@ -119,15 +119,38 @@ if [ -z "${DUNE_BUILD_DIR:-}" ] || [ "${DUNE_BUILD_DIR}" = "_build" ]; then
   exit 1
 fi
 if [ "${DUNE_BUILD_DIR}" = ".ci_build_flaky" ] && [ "${DUNE_CACHE:-}" != "disabled" ]; then
-  printf 'Error: Files lib/autoresearch/masc_autoresearch.cmxa\n' >&2
-  printf '       and /tmp/agent_sdk.cmxa\n' >&2
-  printf '       make inconsistent assumptions over interface Agent_sdk__Event_bus\n' >&2
+  printf 'Error: File unavailable:\n' >&2
+  printf '/tmp/opam/lib/agent_sdk/llm_provider/llm_provider.cmxa\n' >&2
+  printf 'Error: Unbound module Llm_provider\n' >&2
   exit 1
 fi
 mkdir -p "${DUNE_BUILD_DIR}/default/test/_build/_tests"
 printf 'fake ok\n' > "${DUNE_BUILD_DIR}/default/test/_build/_tests/fake.output"
 printf 'Testing `fake`.\n'
 exit 0
+|}
+  ;
+  Unix.chmod dune_path 0o755;
+  bin_dir
+
+let make_fake_dune_disk_full dir =
+  let bin_dir = Filename.concat dir "bin-disk-full" in
+  Unix.mkdir bin_dir 0o755;
+  let dune_path = Filename.concat bin_dir "dune" in
+  write_file dune_path
+    {|#!/bin/sh
+set -eu
+log_file="${FAKE_DUNE_LOG:?}"
+printf '%s|%s|%s\n' "${1:-}" "${DUNE_BUILD_DIR:-}" "$(pwd)" >>"$log_file"
+if [ "${1:-}" = "--version" ]; then
+  printf '3.21.0\n'
+  exit 0
+fi
+if [ "${1:-}" = "clean" ]; then
+  exit 0
+fi
+printf 'Error: dune_trace_write(): No space left on device\n' >&2
+exit 1
 |}
   ;
   Unix.chmod dune_path 0o755;
@@ -193,13 +216,13 @@ let test_rpc_retry_uses_isolated_build_dir () =
           failf "expected exactly two dune invocations, got:\n%s"
             (String.concat "\n" log_lines))
 
-let test_interface_mismatch_after_flaky_retry_disables_cache () =
+let test_agent_sdk_artifact_failure_after_flaky_retry_disables_cache () =
   with_temp_dir "ci-run-tests-interface" (fun dir ->
       let repo_dir = Filename.concat dir "repo" in
       Unix.mkdir repo_dir 0o755;
       let fake_log = Filename.concat dir "fake-dune.log" in
       let ci_log = Filename.concat dir "ci-run-tests.log" in
-      let fake_bin = make_fake_dune_flaky_then_interface_mismatch dir in
+      let fake_bin = make_fake_dune_flaky_then_agent_sdk_artifact_failure dir in
       let path =
         Printf.sprintf "%s:%s" fake_bin
           (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
@@ -231,9 +254,9 @@ let test_interface_mismatch_after_flaky_retry_disables_cache () =
       check bool "flaky retry warning present" true
         (contains_substring observed_output
            "test failed (exit=1); retrying once with isolated build dir .ci_build_flaky");
-      check bool "interface mismatch warning present" true
+      check bool "agent sdk artifact warning present" true
         (contains_substring observed_output
-           "detected Agent_sdk interface mismatch; running dune clean and retrying once with DUNE_CACHE=disabled");
+           "detected Agent_sdk/OAS artifact or interface mismatch; running dune clean and retrying once with DUNE_CACHE=disabled");
       check bool "retry command disables cache" true
         (contains_substring observed_output
            "retry_command: export DUNE_CACHE=disabled; export DUNE_BUILD_DIR=.ci_build_flaky; unset DUNE_RPC;");
@@ -258,6 +281,62 @@ let test_interface_mismatch_after_flaky_retry_disables_cache () =
             fourth
       | _ ->
           failf "expected exactly four dune invocations, got:\n%s"
+            (String.concat "\n" log_lines))
+
+let test_disk_full_failure_skips_flaky_retry () =
+  with_temp_dir "ci-run-tests-disk-full" (fun dir ->
+      let repo_dir = Filename.concat dir "repo" in
+      Unix.mkdir repo_dir 0o755;
+      let fake_log = Filename.concat dir "fake-dune.log" in
+      let ci_log = Filename.concat dir "ci-run-tests.log" in
+      let fake_bin = make_fake_dune_disk_full dir in
+      let path =
+        Printf.sprintf "%s:%s" fake_bin
+          (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
+      in
+      let env =
+        [
+          ("PATH", path);
+          ("DUNE_BUILD_DIR", "");
+          ("FAKE_DUNE_LOG", fake_log);
+          ("CI_TEST_HEARTBEAT_SEC", "1");
+          ("CI_TEST_TIMEOUT_SEC", "30");
+          ("CI_TEST_LOG_FILE", ci_log);
+          ("CI_CONTRACT_HARNESS_ENABLED", "0");
+          ("CI_TEST_ALLOW_FLAKY_RETRY", "1");
+        ]
+      in
+      let code, stdout, stderr =
+        run_shell ~cwd:dir ~env
+          (Printf.sprintf "%s %s" (quote (script_path ()))
+             (quote
+                (Printf.sprintf "cd %s && dune test --root ." (quote repo_dir))))
+      in
+      check int "disk full exit code" 1 code;
+      let ci_log_contents = read_file ci_log in
+      let observed_output =
+        String.concat "\n" [ ci_log_contents; stdout; stderr ]
+      in
+      check bool "disk guidance present" true
+        (contains_substring observed_output
+           "detected disk exhaustion during dune build");
+      check bool "disk hygiene repair present" true
+        (contains_substring observed_output
+           "bash scripts/disk-hygiene.sh --fix");
+      check bool "flaky retry skipped" false
+        (contains_substring observed_output "flaky-test mitigation");
+      let log_lines =
+        read_file fake_log
+        |> String.split_on_char '\n'
+        |> List.filter (fun line -> String.trim line <> "")
+      in
+      match log_lines with
+      | [ first ] ->
+          check string "single attempt uses repo cwd"
+            (Printf.sprintf "test||%s" repo_dir)
+            first
+      | _ ->
+          failf "expected exactly one dune invocation, got:\n%s"
             (String.concat "\n" log_lines))
 
 let test_timeout_diagnostics_capture_active_process_group () =
@@ -301,9 +380,11 @@ let () =
         [
           test_case "rpc retry uses isolated build dir" `Quick
             test_rpc_retry_uses_isolated_build_dir;
-          test_case "interface mismatch after flaky retry disables cache"
+          test_case "agent sdk artifact failure after flaky retry disables cache"
             `Quick
-            test_interface_mismatch_after_flaky_retry_disables_cache;
+            test_agent_sdk_artifact_failure_after_flaky_retry_disables_cache;
+          test_case "disk full failure skips flaky retry" `Quick
+            test_disk_full_failure_skips_flaky_retry;
           test_case "timeout diagnostics capture active process group" `Quick
             test_timeout_diagnostics_capture_active_process_group;
         ] );


### PR DESCRIPTION
## Summary
- validate required agent_sdk and llm_provider native artifacts in check-oas-pin
- detect missing OAS artifacts and disk-full dune failures in ci-run-tests
- avoid slow recursive TMPDIR du and /dev/fd process substitution in CI diagnostics

## Verification
- bash -n scripts/ci-run-tests.sh scripts/check-oas-pin.sh
- DUNE_CACHE=disabled DUNE_BUILD_DIR=.ci_verify_build dune build --root . test/test_ci_run_tests_script.exe test/test_ci_hardening_source.exe
- ./.ci_verify_build/default/test/test_ci_run_tests_script.exe
- ./.ci_verify_build/default/test/test_ci_hardening_source.exe

## Notes
- bash scripts/check-oas-pin.sh --local-only now fails locally because the current opam pin is 031c7e6bb5ebb25069174502bafc828c7a2df7a4 while repo expects 8b5bf30ac632cea97e46b2da9a7e81c117eaa2ae.