### PR TITLE
[codex] Retry transient CI base fetch failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           head_ref="${GITHUB_SHA}"
 
           if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
-            git fetch origin "${GITHUB_BASE_REF}" --depth=200
+            bash scripts/ci/git-fetch-retry.sh origin "${GITHUB_BASE_REF}" --depth=200
             base_ref="origin/${GITHUB_BASE_REF}"
             head_ref="${GITHUB_HEAD_SHA}"
           elif [ -n "${GITHUB_BEFORE}" ] && [ "${GITHUB_BEFORE}" != "0000000000000000000000000000000000000000" ]; then
@@ -215,7 +215,7 @@ jobs:
           HEAD_REF: ${{ github.event.pull_request.head.sha }}
         run: |
           chmod +x scripts/check-release-train-guard.sh
-          git fetch origin "${{ github.base_ref }}" --depth=100 --tags
+          bash scripts/ci/git-fetch-retry.sh origin "${{ github.base_ref }}" --depth=100 --tags
           scripts/check-release-train-guard.sh \
             --base "$BASE_REF" \
             --head "$HEAD_REF"
@@ -227,7 +227,7 @@ jobs:
           HEAD_REF: ${{ github.event.pull_request.head.sha }}
         run: |
           chmod +x scripts/check-pr-hygiene.sh
-          git fetch origin "${{ github.base_ref }}" --depth=100
+          bash scripts/ci/git-fetch-retry.sh origin "${{ github.base_ref }}" --depth=100
           scripts/check-pr-hygiene.sh \
             --base "$BASE_REF" \
             --head "$HEAD_REF" \
@@ -319,7 +319,7 @@ jobs:
 
       - name: Fetch base branch for health ratchet
         if: github.event_name == 'pull_request' && needs.changes.outputs.health_snapshot == 'true'
-        run: git fetch origin "${{ github.base_ref }}" --depth=1
+        run: bash scripts/ci/git-fetch-retry.sh origin "${{ github.base_ref }}" --depth=1
 
       - name: Run health snapshot
         if: needs.changes.outputs.health_snapshot == 'true'

--- a/scripts/ci/git-fetch-retry.sh
+++ b/scripts/ci/git-fetch-retry.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <remote> <refspec> [git-fetch-args...]" >&2
+  exit 64
+fi
+
+attempts=${GIT_FETCH_RETRY_ATTEMPTS:-3}
+delay=${GIT_FETCH_RETRY_DELAY_SECONDS:-2}
+max_delay=${GIT_FETCH_RETRY_MAX_DELAY_SECONDS:-10}
+
+for value_name in attempts delay max_delay; do
+  value=${!value_name}
+  if [[ -z "$value" || "$value" =~ [^0-9] ]]; then
+    echo "invalid ${value_name}: ${value}" >&2
+    exit 64
+  fi
+done
+
+if (( attempts < 1 )); then
+  echo "invalid attempts: ${attempts}" >&2
+  exit 64
+fi
+
+attempt=1
+while (( attempt <= attempts )); do
+  if git fetch "$@"; then
+    exit 0
+  else
+    status=$?
+  fi
+
+  if (( attempt == attempts )); then
+    echo "git fetch failed after ${attempts} attempt(s)" >&2
+    exit "$status"
+  fi
+
+  echo "::warning::git fetch attempt ${attempt}/${attempts} failed with exit ${status}; retrying in ${delay}s" >&2
+  sleep "$delay"
+  if (( delay < max_delay )); then
+    delay=$(( delay * 2 ))
+    if (( delay > max_delay )); then
+      delay=$max_delay
+    fi
+  fi
+  attempt=$(( attempt + 1 ))
+done

--- a/scripts/lib_dep_delta_ci.sh
+++ b/scripts/lib_dep_delta_ci.sh
@@ -18,7 +18,7 @@ baseline_tree=""
 if [[ -n "${GITHUB_BASE_REF:-}" && "${GITHUB_EVENT_NAME:-}" == "pull_request" ]]; then
   baseline_tree=$(mktemp -d)
   rm -rf "$baseline_tree"
-  git fetch origin "$GITHUB_BASE_REF" --depth=200
+  bash scripts/ci/git-fetch-retry.sh origin "$GITHUB_BASE_REF" --depth=200
   base_ref="origin/$GITHUB_BASE_REF"
   if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
     base_ref="FETCH_HEAD"


### PR DESCRIPTION
Fixes #9731.

This adds a small `scripts/ci/git-fetch-retry.sh` wrapper and uses it for CI base-branch fetches that currently fail hard on transient GitHub 5xx responses. Existing fetch arguments and depths are preserved; the wrapper retries three times by default with short bounded backoff.

Validation:
- `bash -n scripts/ci/git-fetch-retry.sh`
- `bash -n scripts/lib_dep_delta_ci.sh`
- `ruby -ryaml -e 'YAML.load_file(".github/workflows/ci.yml")'`\n- `git diff --check`\n- invalid retry config fail-fast check\n- fake `git fetch` retry scenario: two failures then success on third attempt\n\nDraft until checks complete and human review/approval is explicit.