### PR TITLE
feat(auth,keeper): UUID-based identity system Phase 3

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -273,18 +273,37 @@ let load_credential_from_path config agent_name path : agent_credential option =
     Without this fallback, Coord.join's nickname output caused a
     chronic "No credential found for <type>-<adj>-<animal>" noise band
     at ~0.3/min on the live fleet (2026-04-20). *)
+let load_credential_from_path_raw config agent_name path : agent_credential option =
+  if file_exists path then
+    try
+      let content = read_text_file path in
+      let json = Yojson.Safe.from_string content in
+      match agent_credential_of_yojson json with
+      | Ok cred -> Some cred
+      | Error msg ->
+          Log.Auth.warn "[load_credential] parse error for %s: %s" agent_name msg;
+          None
+    with Sys_error _ | Yojson.Json_error _ -> None
+  else
+    None
+
 let load_credential config agent_name : agent_credential option =
   let file = credential_file config agent_name in
-  match load_credential_from_path config agent_name file with
-  | Some _ as c -> c
-  | None ->
-    if is_generated_nickname_shape agent_name then
-      match extract_agent_type_prefix agent_name with
-      | Some prefix when prefix <> agent_name ->
-        let fallback = credential_file config prefix in
-        load_credential_from_path config prefix fallback
-      | _ -> None
-    else None
+  if not (file_exists file) then None
+  else
+    try
+      let content = read_text_file file in
+      let json = Yojson.Safe.from_string content in
+      (* Redirect stub: { "redirect_to": "<uuid>.json" } *)
+      match json with
+      | `Assoc fields when List.mem_assoc "redirect_to" fields -> (
+          match List.assoc "redirect_to" fields with
+          | `String target ->
+              let redirect_path = Filename.concat (agents_dir config) target in
+              load_credential_from_path_raw config agent_name redirect_path
+          | _ -> None)
+      | _ -> load_credential_from_path_raw config agent_name file
+    with Sys_error _ | Yojson.Json_error _ -> None
 
 let load_credential_with_aliases config agent_name : agent_credential option =
   match load_credential config agent_name with
@@ -293,12 +312,25 @@ let load_credential_with_aliases config agent_name : agent_credential option =
       legacy_credential_aliases agent_name
       |> List.find_map (load_credential config)
 
-(** Save agent credential *)
+(** Save agent credential.
+
+    When [cred.id] is present the credential is stored under
+    [{uuid}.json] and a redirect stub [{agent_name}.json] is written so
+    legacy lookup paths still resolve. *)
 let save_credential config (cred : agent_credential) =
   ensure_auth_dirs config;
-  let file = credential_file config cred.agent_name in
   let json = agent_credential_to_yojson cred in
-  save_private_text_file file (Yojson.Safe.pretty_to_string json)
+  let json_str = Yojson.Safe.pretty_to_string json in
+  (match cred.id with
+  | Some cid ->
+      let uuid_file = Filename.concat (agents_dir config) (Credential_id.to_string cid ^ ".json") in
+      save_private_text_file uuid_file json_str;
+      let stub = `Assoc [("redirect_to", `String (Credential_id.to_string cid ^ ".json"))] in
+      let stub_file = credential_file config cred.agent_name in
+      save_private_text_file stub_file (Yojson.Safe.pretty_to_string stub)
+  | None ->
+      let file = credential_file config cred.agent_name in
+      save_private_text_file file json_str)
 
 let load_raw_token config ~agent_name =
   let file = raw_token_file config agent_name in
@@ -318,7 +350,10 @@ let delete_credential config agent_name =
   let file = credential_file config agent_name in
   if file_exists file then remove_file file
 
-(** List all credentials *)
+(** List all credentials.
+
+    De-duplicates by [agent_name] so that a UUID-backed credential
+    plus its redirect stub do not appear twice in the result. *)
 let list_credentials config : agent_credential list =
   let dir = agents_dir config in
   if file_exists dir then
@@ -327,8 +362,15 @@ let list_credentials config : agent_credential list =
     |> List.filter (fun f -> Filename.check_suffix f ".json")
     |> List.filter_map (fun f ->
         let name = Filename.chop_suffix f ".json" in
-        load_credential config name
-      )
+        load_credential config name)
+    |> List.fold_left
+         (fun acc cred ->
+            if List.exists (fun c -> c.agent_name = cred.agent_name) acc then
+              acc
+            else
+              cred :: acc)
+         []
+    |> List.rev
   else
     []
 
@@ -366,6 +408,8 @@ let save_raw_token_credential config ~agent_name ~role ~raw_token :
   let auth_cfg = load_auth_config config in
   let cred =
     {
+      id = None;
+      agent_id = None;
       agent_name;
       token = sha256_hash raw_token;
       role;
@@ -404,9 +448,22 @@ let missing_credential_error config ~agent_name ~token : masc_error =
            agent_name owner.agent_name)
   | _ -> Unauthorized ("No credential found for " ^ agent_name)
 
-(** Verify a token *)
+(** Verify a token.
+
+    Looks up the credential by exact [agent_name] match first.  Only
+    hard-coded legacy aliases (dashboard → dashboard-dev) are accepted
+    as a fallback.  The old nickname-prefix collapse
+    ([extract_agent_type_prefix]) has been removed from the verify
+    path entirely — UUID-based storage makes it unnecessary. *)
 let verify_token config ~agent_name ~token : (agent_credential, masc_error) result =
-  match load_credential_with_aliases config agent_name with
+  let cred_opt =
+    match load_credential config agent_name with
+    | Some _ as c -> c
+    | None ->
+        legacy_credential_aliases agent_name
+        |> List.find_map (load_credential config)
+  in
+  match cred_opt with
   | None -> Error (missing_credential_error config ~agent_name ~token)
   | Some cred ->
       let token_hash = sha256_hash token in
@@ -427,23 +484,28 @@ let verify_token config ~agent_name ~token : (agent_credential, masc_error) resu
 let ensure_keeper_credential config ~agent_name :
     (string * agent_credential, masc_error) result =
   let raw_token = ensure_internal_keeper_token config in
-  let target_agent_name = credential_agent_name agent_name in
+  let id = Credential_id.generate () in
   let cred =
     {
-      agent_name = target_agent_name;
+      id = Some id;
+      agent_id = None;
+      agent_name;
       token = sha256_hash raw_token;
       role = Worker;
       created_at = now_iso ();
       expires_at = None;
     }
   in
-  let file = credential_file config target_agent_name in
-  if not (file_exists file) then (
-    Log.Auth.info "[ensure_keeper_credential] auto-generating credential file for %s"
-      target_agent_name;
-    save_credential config cred
-  );
-  Ok (raw_token, cred)
+  try
+    save_credential config cred;
+    Ok (raw_token, cred)
+  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+    let msg =
+      Printf.sprintf "Failed to save keeper credential: %s"
+        (Printexc.to_string exn)
+    in
+    Log.Auth.error "%s" msg;
+    Error (IoError msg)
 
 (** Refresh a token (generate new one, update credential) *)
 let refresh_token config ~agent_name ~old_token : (string * agent_credential, masc_error) result =

--- a/lib/coord/coord_lifecycle.ml
+++ b/lib/coord/coord_lifecycle.ml
@@ -142,6 +142,7 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
 
   let agent_file = Filename.concat (agents_dir config) (safe_filename nickname ^ ".json") in
   let agent = {
+    id = None;
     name = nickname;
     agent_type;
     status = Active;

--- a/lib/coord/coord_query.ml
+++ b/lib/coord/coord_query.ml
@@ -15,14 +15,14 @@ let update_priority config ~task_id ~priority =
     try
       let backlog = read_backlog config in
 
-      let task_opt = List.find_opt (fun t -> t.id = task_id) backlog.tasks in
+      let task_opt = List.find_opt (fun (t : task) -> t.id = task_id) backlog.tasks in
 
       match task_opt with
       | None ->
           Printf.sprintf "❌ Task %s not found" task_id
       | Some task ->
           let old_priority = task.priority in
-          let new_tasks = List.map (fun t ->
+          let new_tasks = List.map (fun (t : task) ->
             if t.id = task_id then { t with priority }
             else t
           ) backlog.tasks in

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -370,7 +370,7 @@ let find_duplicate_task (backlog : backlog) ~(title : string) ~(goal_id : string
          && Option.equal String.equal t.goal_id goal_id
          && not (Types.task_status_is_terminal t.task_status))
       backlog.tasks
-    |> Option.map (fun t -> t.id)
+    |> Option.map (fun (t : task) -> t.id)
 ;;
 
 (** Add task — file-locked to prevent task ID collision under concurrency.
@@ -583,7 +583,7 @@ let claim_task config ~agent_name ~task_id =
            let blocked_reason = ref None in
            let new_tasks =
              List.map
-               (fun task ->
+               (fun (task : task) ->
                   if task.id = task_id
                   then (
                     found := true;
@@ -694,7 +694,7 @@ let claim_task_r config ~agent_name ~task_id ()
     | Ok backlog ->
       (try
          (* Check role constraint before attempting claim *)
-         let target_task = List.find_opt (fun t -> t.id = task_id) backlog.tasks in
+         let target_task = List.find_opt (fun (t : task) -> t.id = task_id) backlog.tasks in
          let* task =
            match target_task with
            | None -> Error (Types.TaskNotFound task_id)
@@ -715,7 +715,7 @@ let claim_task_r config ~agent_name ~task_id ()
          Uses polymorphic variants for inline state tracking. *)
          let claim_state, new_tasks =
            List.fold_left
-             (fun (state, acc) t ->
+             (fun (state, acc) (t : task) ->
                 if t.id = task_id
                 then (
                   match t.task_status with
@@ -904,7 +904,7 @@ let transition_task_r
                     backlog.version))
           | _ -> Ok ()
         in
-        let task_opt = List.find_opt (fun t -> t.id = task_id) backlog.tasks in
+        let task_opt = List.find_opt (fun (t : task) -> t.id = task_id) backlog.tasks in
         let* task =
           match task_opt with
           | None -> Error (Types.TaskNotFound task_id)
@@ -1049,7 +1049,7 @@ let transition_task_r
         else (
           let new_tasks =
             List.map
-              (fun t ->
+              (fun (t : task) ->
                  if t.id = task_id
                  then (
                    let cycle_count, do_not_reclaim_reason =
@@ -1320,7 +1320,7 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
         match read_backlog_r config with
         | Error msg -> Error (Types.IoError msg)
         | Ok backlog ->
-          let task_opt = List.find_opt (fun t -> t.id = task_id) backlog.tasks in
+          let task_opt = List.find_opt (fun (t : task) -> t.id = task_id) backlog.tasks in
           (match task_opt with
            | None -> Error (Types.TaskNotFound task_id)
            | Some task ->
@@ -1344,7 +1344,7 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
              else (
                let new_tasks =
                  List.map
-                   (fun t ->
+                   (fun (t : task) ->
                       if t.id = task_id
                       then (
                         let new_cycle = t.cycle_count + 1 in
@@ -1496,7 +1496,7 @@ let link_task_execution_artifacts_r
         match read_backlog_r config with
         | Error msg -> Error (Types.IoError msg)
         | Ok backlog ->
-          (match List.find_opt (fun task -> task.id = task_id) backlog.tasks with
+          (match List.find_opt (fun (task : task) -> task.id = task_id) backlog.tasks with
            | None -> Error (Types.TaskNotFound task_id)
            | Some task ->
              let existing_contract =
@@ -1518,7 +1518,7 @@ let link_task_execution_artifacts_r
              in
              let new_tasks =
                List.map
-                 (fun candidate ->
+                 (fun (candidate : task) ->
                     if candidate.id = task_id
                     then { candidate with contract = Some updated_contract }
                     else candidate)

--- a/lib/coord/coord_task_id.ml
+++ b/lib/coord/coord_task_id.ml
@@ -70,8 +70,8 @@ let append_archive_tasks config (tasks : task list) =
       ] in
       write_json config arch_path archive_json)
 
-let next_task_number config backlog =
-  let backlog_ids = List.filter_map (fun task -> task_id_to_int task.id) backlog.tasks in
+let next_task_number config (backlog : backlog) =
+  let backlog_ids = List.filter_map (fun (task : task) -> task_id_to_int task.id) backlog.tasks in
   let archive_ids = read_archive_task_ids config in
   let max_id = List.fold_left max 0 (backlog_ids @ archive_ids) in
   max_id + 1

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -214,12 +214,12 @@ let claim_next_r
       in
       let task_filter_excluded =
         List.filter
-          (fun t -> (not (List.mem t.id all_excluded)) && not (task_filter t))
+          (fun (t : task) -> (not (List.mem t.id all_excluded)) && not (task_filter t))
           unclaimed
       in
       let eligible =
         List.filter
-          (fun t -> (not (List.mem t.id all_excluded)) && task_filter t)
+          (fun (t : task) -> (not (List.mem t.id all_excluded)) && task_filter t)
           unclaimed
       in
 
@@ -271,7 +271,7 @@ let claim_next_r
             }
       | _ :: _, task :: _ ->
           (* Claim this task *)
-          let new_tasks = List.map (fun t ->
+          let new_tasks = List.map (fun (t : task) ->
             if t.id = task.id then
               { t with task_status = Claimed {
                   assignee = agent_name;

--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -641,7 +641,7 @@ let link_worktree_to_task config ~task_id ~worktree_info =
         Error (IoError "Backlog not found")
       else
         let found = ref false in
-        let new_tasks = List.map (fun task ->
+        let new_tasks = List.map (fun (task : task) ->
           if task.id = task_id then begin
             found := true;
             { task with worktree = Some worktree_info }

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -328,6 +328,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
       in
       let ctx0 = Keeper_exec_context.create ~system_prompt ~max_tokens:primary_max_context in
       let meta = {
+        id = None;
         name = p.name;
         agent_name = keeper_agent_name p.name;
         goal;

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -208,7 +208,8 @@ type agent_runtime_state =
 
 type keeper_meta =
   { (* -- Identity & profile -- *)
-    name : string
+    id : Ids.Keeper_id.t option [@default None]
+  ; name : string
   ; agent_name : string
   ; goal : string
   ; short_goal : string
@@ -1408,7 +1409,8 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
          then Error "invalid keeper meta (bad trace_id)"
          else
            Ok
-             { name = identity.pk_name
+             { id = None
+             ; name = identity.pk_name
              ; agent_name =
                  (if identity.pk_agent_name = ""
                   then keeper_agent_name identity.pk_name

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -151,6 +151,7 @@ type agent_runtime_state = {
 (** {1 Keeper meta} *)
 
 type keeper_meta = {
+  id: Ids.Keeper_id.t option;
   name: string;
   agent_name: string;
   goal: string;

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -250,6 +250,7 @@ let room_seq_map_of_json (json : Yojson.Safe.t) : (string * int) list =
 
 
 type keeper_profile_defaults = {
+  id : Ids.Keeper_id.t option; [@default None]
   manifest_path : string option;
   persona_name : string option;
   goal : string option;
@@ -321,6 +322,7 @@ type persona_summary = {
 }
 
 let empty_keeper_profile_defaults = {
+  id = None;
   manifest_path = None;
   persona_name = None;
   goal = None;
@@ -653,6 +655,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
   Result.map
     (fun () ->
       {
+        id = None;
         manifest_path = None;
         persona_name = str "persona_name";
         goal = str "goal";
@@ -881,7 +884,8 @@ let load_keeper_toml (path : string)
         if not (validate_name name) then
           Error (Printf.sprintf "%s: invalid keeper name '%s'" path name)
         else
-          Ok (name, { defaults with manifest_path = Some path })
+          let id = Ids.Keeper_id.generate ~name ~path in
+          Ok (name, { defaults with manifest_path = Some path; id = Some id })
 
 let discover_keepers_toml (dir : string)
     : (string * keeper_profile_defaults) list =
@@ -921,6 +925,7 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
           match keeper_json with
           | `Assoc _ ->
               {
+                id = Some (Ids.Keeper_id.generate ~name ~path);
                 manifest_path = Some path;
                 persona_name = Some name;
                 goal = Safe_ops.json_string_opt "goal" keeper_json;
@@ -1096,6 +1101,7 @@ let merge_keeper_profile_defaults
         Per_provider_timeout_set, overlay.per_provider_timeout
   in
   {
+    id = prefer overlay.id base.id;
     manifest_path = prefer overlay.manifest_path base.manifest_path;
     persona_name = prefer overlay.persona_name base.persona_name;
     goal = prefer overlay.goal base.goal;

--- a/lib/types/dune
+++ b/lib/types/dune
@@ -4,5 +4,5 @@
  (public_name masc_mcp.masc_types)
  (wrapped false)
  (modules ids types_core types_auth error types task_stage severity)
- (libraries yojson unix time_compat masc_core)
+ (libraries yojson unix time_compat masc_core base64 uuidm)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_deriving_yojson)))

--- a/lib/types/ids.ml
+++ b/lib/types/ids.ml
@@ -6,6 +6,8 @@ module Agent_id : sig
   val of_string : string -> t
   val to_string : t -> string
   val equal : t -> t -> bool
+  val pp : Format.formatter -> t -> unit
+  val generate : unit -> t
   val to_yojson : t -> Yojson.Safe.t
   val of_yojson : Yojson.Safe.t -> (t, string) result
 end = struct
@@ -13,6 +15,10 @@ end = struct
   let of_string s = s
   let to_string t = t
   let equal = String.equal
+  let pp fmt t = Format.fprintf fmt "%s" t
+  let generate () =
+    let rng = Random.State.make_self_init () in
+    Uuidm.v4_gen rng () |> Uuidm.to_string |> of_string
   let to_yojson t = `String t
   let of_yojson = function
     | `String s -> Ok s
@@ -25,6 +31,7 @@ module Task_id : sig
   val of_string : string -> t
   val to_string : t -> string
   val equal : t -> t -> bool
+  val pp : Format.formatter -> t -> unit
   val generate : unit -> t  (* Auto-generate unique ID *)
   val to_yojson : t -> Yojson.Safe.t
   val of_yojson : Yojson.Safe.t -> (t, string) result
@@ -33,6 +40,7 @@ end = struct
   let of_string s = s
   let to_string t = t
   let equal = String.equal
+  let pp fmt t = Format.fprintf fmt "%s" t
   let _id_counter = Atomic.make 0
   let generate () =
     let timestamp = int_of_float (Time_compat.now () *. 1000.0) in
@@ -53,6 +61,7 @@ module Thread_id : sig
   val of_string : string -> t
   val to_string : t -> string
   val equal : t -> t -> bool
+  val pp : Format.formatter -> t -> unit
   val generate : unit -> t
   val to_yojson : t -> Yojson.Safe.t
   val of_yojson : Yojson.Safe.t -> (t, string) result
@@ -61,6 +70,7 @@ end = struct
   let of_string s = s
   let to_string t = t
   let equal = String.equal
+  let pp fmt t = Format.fprintf fmt "%s" t
   let _id_counter = Atomic.make 0
   let generate () =
     let timestamp = int_of_float (Time_compat.now () *. 1000.0) in
@@ -81,6 +91,7 @@ module Turn_id : sig
   val of_string : string -> t
   val to_string : t -> string
   val equal : t -> t -> bool
+  val pp : Format.formatter -> t -> unit
   val generate : thread_id:string -> seq:int -> t
   val to_yojson : t -> Yojson.Safe.t
   val of_yojson : Yojson.Safe.t -> (t, string) result
@@ -89,6 +100,7 @@ end = struct
   let of_string s = s
   let to_string t = t
   let equal = String.equal
+  let pp fmt t = Format.fprintf fmt "%s" t
   let generate ~thread_id ~seq =
     Printf.sprintf "%s-turn-%04d" thread_id seq
   let to_yojson t = `String t
@@ -96,3 +108,116 @@ end = struct
     | `String s -> Ok s
     | _ -> Error "Expected string for Turn_id"
 end
+
+(** Keeper identifier - deterministic UUIDv5 from namespace + name + path *)
+module Keeper_id : sig
+  type t
+  val of_string : string -> t
+  val to_string : t -> string
+  val equal : t -> t -> bool
+  val pp : Format.formatter -> t -> unit
+  val generate : name:string -> path:string -> t
+  val to_yojson : t -> Yojson.Safe.t
+  val of_yojson : Yojson.Safe.t -> (t, string) result
+  module Trace_id : sig
+    type t
+    val of_string : string -> (t, string) result
+    val to_string : t -> string
+    val equal : t -> t -> bool
+  end
+  module Task_id : sig
+    type t
+    val of_string : string -> (t, string) result
+    val to_string : t -> string
+    val equal : t -> t -> bool
+  end
+end = struct
+  type t = string
+  let of_string s = s
+  let to_string t = t
+  let equal = String.equal
+  let pp fmt t = Format.fprintf fmt "%s" t
+  let generate ~name ~path =
+    (* DNS namespace UUID from RFC 4122; used as the v5 namespace seed. *)
+    let namespace =
+      match Uuidm.of_string "6ba7b810-9dad-11d1-80b4-00c04fd430c8" with
+      | Some ns -> ns
+      | None -> failwith "Invalid DNS namespace UUID"
+    in
+    let input = Printf.sprintf "masc-keeper:%s:%s" name path in
+    Uuidm.v5 namespace input |> Uuidm.to_string |> of_string
+  let to_yojson t = `String t
+  let of_yojson = function
+    | `String s -> Ok s
+    | _ -> Error "Expected string for Keeper_id"
+  module Keeper_name = struct
+    type t = string
+    let is_valid s =
+      let len = String.length s in
+      len > 0 && len <= 64 &&
+      let rec check i =
+        if i = len then true
+        else
+          let c = s.[i] in
+          match c with
+          | 'a'..'z' | 'A'..'Z' | '0'..'9' | '-' | '_' -> check (i + 1)
+          | _ -> false
+      in check 0
+  end
+  module Trace_id = struct
+    type t = string
+    let is_valid s = s <> "." && s <> ".." && Keeper_name.is_valid s
+    let of_string s =
+      if is_valid s then Ok s
+      else Error "Invalid trace_id"
+    let to_string s = s
+    let equal = String.equal
+  end
+  module Task_id = struct
+    type t = string
+    let is_valid s = String.length s > 0
+    let of_string s =
+      if is_valid s then Ok s
+      else Error "Invalid task_id"
+    let to_string s = s
+    let equal = String.equal
+  end
+end
+
+(** Credential identifier - random UUIDv4 *)
+module Credential_id : sig
+  type t
+  val of_string : string -> t
+  val to_string : t -> string
+  val equal : t -> t -> bool
+  val pp : Format.formatter -> t -> unit
+  val generate : unit -> t
+  val to_yojson : t -> Yojson.Safe.t
+  val of_yojson : Yojson.Safe.t -> (t, string) result
+end = struct
+  type t = string
+  let of_string s = s
+  let to_string t = t
+  let equal = String.equal
+  let pp fmt t = Format.fprintf fmt "%s" t
+  let generate () =
+    let rng = Random.State.make_self_init () in
+    Uuidm.v4_gen rng () |> Uuidm.to_string |> of_string
+  let to_yojson t = `String t
+  let of_yojson = function
+    | `String s -> Ok s
+    | _ -> Error "Expected string for Credential_id"
+end
+
+(** Relay GraphQL-style global ID: base64("type:uuid") *)
+let make_global_id ~type_ id =
+  let raw = Printf.sprintf "%s:%s" type_ id in
+  Base64.encode_string raw
+
+let decode_global_id s =
+  match Base64.decode s with
+  | Ok decoded -> (
+      match String.split_on_char ':' decoded with
+      | type_ :: rest -> Ok (type_, String.concat ":" rest)
+      | _ -> Error "Invalid global ID format")
+  | Error _ -> Error "Invalid base64"

--- a/lib/types/types_auth.ml
+++ b/lib/types/types_auth.ml
@@ -1,3 +1,5 @@
+open Ids
+
 (** Rate limit config *)
 type rate_limit_config = {
   per_minute: int;
@@ -231,6 +233,8 @@ let agent_role_of_yojson = function
 
 (** Agent credential - stored in .masc/auth/ *)
 type agent_credential = {
+  id: Credential_id.t option; [@default None]
+  agent_id: Agent_id.t option; [@default None]
   agent_name: string;
   token: string;        (* SHA256 hash of secret *)
   role: agent_role;
@@ -245,6 +249,14 @@ let agent_credential_to_yojson c =
     ("admin", `Bool (c.role = Admin));
     ("created_at", `String c.created_at);
   ] in
+  let base = match c.id with
+    | Some id -> ("id", `String (Credential_id.to_string id)) :: base
+    | None -> base
+  in
+  let base = match c.agent_id with
+    | Some aid -> ("agent_id", `String (Agent_id.to_string aid)) :: base
+    | None -> base
+  in
   match c.expires_at with
   | Some exp -> `Assoc (base @ [("expires_at", `String exp)])
   | None -> `Assoc base
@@ -252,6 +264,8 @@ let agent_credential_to_yojson c =
 let agent_credential_of_yojson json =
   let open Yojson.Safe.Util in
   try
+    let id = json |> member "id" |> to_string_option |> Option.map Credential_id.of_string in
+    let agent_id = json |> member "agent_id" |> to_string_option |> Option.map Agent_id.of_string in
     let agent_name = json |> member "agent_name" |> to_string in
     let token = json |> member "token" |> to_string in
     let created_at = json |> member "created_at" |> to_string in
@@ -262,7 +276,7 @@ let agent_credential_of_yojson json =
       | Some false -> Worker
       | None -> Worker
     in
-    Ok { agent_name; token; role; created_at; expires_at }
+    Ok { id; agent_id; agent_name; token; role; created_at; expires_at }
   with e -> Error (Printexc.to_string e)
 
 (** Auth config - room-level settings *)

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -100,6 +100,7 @@ type agent_meta = {
 
 (** Agent info *)
 type agent = {
+  id: Agent_id.t option; [@default None]  (* permanent UUID *)
   name: string;                           (* unique nickname: claude-swift-fox *)
   agent_type: string; [@default "unknown"] (* original type: claude, gemini, codex *)
   status: agent_status;

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -273,25 +273,32 @@ let test_delete_credential () =
   cleanup_test_room dir;
   check int "0 credentials after delete" 0 (List.length creds)
 
-let test_load_credential_nickname_fallback () =
-  (* Exact-name misses fall through to the agent-type prefix so a single
-     credential (e.g. "adversary.json") covers dynamically generated
-     nicknames ("adversary-fair-tapir"). *)
+let test_load_credential_redirect_stub () =
+  (* UUID-backed credentials write a redirect stub so legacy exact-name
+     lookups continue to work after Phase-3 migration. *)
   let dir = setup_test_room () in
-  let _ = Auth.create_token dir ~agent_name:"adversary" ~role:Types.Worker in
-  let hit = Auth.load_credential dir "adversary-fair-tapir" in
-  let miss_non_nickname = Auth.load_credential dir "unknown_plain" in
-  let miss_different_family = Auth.load_credential dir "stranger-fair-tapir" in
+  let id = Types.Credential_id.generate () in
+  let cred : Types.agent_credential =
+    {
+      id = Some id;
+      agent_id = None;
+      agent_name = "adversary";
+      token = "hashed-token";
+      role = Types.Worker;
+      created_at = "2026-01-01T00:00:00Z";
+      expires_at = None;
+    }
+  in
+  Auth.save_credential dir cred;
+  let stub_hit = Auth.load_credential dir "adversary" in
+  let uuid_hit = Auth.load_credential dir (Types.Credential_id.to_string id) in
   cleanup_test_room dir;
-  (match hit with
-   | Some cred when cred.agent_name = "adversary" -> ()
-   | _ -> fail "nickname 'adversary-fair-tapir' should resolve via prefix");
-  (match miss_non_nickname with
-   | None -> ()
-   | Some _ -> fail "plain unknown names must not fall through");
-  (match miss_different_family with
-   | None -> ()
-   | Some _ -> fail "unrelated agent_type must not reuse another keeper's cred")
+  (match stub_hit with
+   | Some loaded when loaded.agent_name = "adversary" -> ()
+   | _ -> fail "redirect stub should resolve to UUID-backed credential");
+  (match uuid_hit with
+   | Some loaded when loaded.agent_name = "adversary" -> ()
+   | _ -> fail "direct UUID lookup should resolve")
 
 let test_load_credential_exact_wins_over_fallback () =
   (* If both the nickname file and the prefix file exist, the exact
@@ -324,38 +331,24 @@ let test_extract_agent_type_prefix_keeper_aliases () =
   check (option string) "two segment keeper fallback unchanged" (Some "keeper")
     (Auth.extract_agent_type_prefix "keeper-sangsu")
 
-let test_verify_token_keeper_alias_fallback () =
+let test_verify_token_keeper_exact_match () =
+  (* UUID-based storage removes nickname-prefix collapse.  Keeper
+     credentials must be looked up by their exact agent_name. *)
   let dir = setup_test_room () in
   let result =
-    match Auth.create_token dir ~agent_name:"sangsu" ~role:Types.Admin with
+    match Auth.ensure_keeper_credential dir ~agent_name:"keeper-sangsu-agent" with
     | Ok (raw_token, _) ->
         Auth.verify_token dir ~agent_name:"keeper-sangsu-agent" ~token:raw_token
     | Error e -> Error e
   in
   cleanup_test_room dir;
   match result with
-  | Ok cred -> check string "fallback credential owner" "sangsu" cred.agent_name
+  | Ok cred ->
+      check string "keeper credential exact match" "keeper-sangsu-agent" cred.agent_name
   | Error e ->
       fail
         (Printf.sprintf
-           "keeper alias should verify via fallback credential: %s"
-           (Types.masc_error_to_string e))
-
-let test_verify_token_hyphenated_generated_nickname_fallback () =
-  let dir = setup_test_room () in
-  let result =
-    match Auth.create_token dir ~agent_name:"qa-king" ~role:Types.Admin with
-    | Ok (raw_token, _) ->
-        Auth.verify_token dir ~agent_name:"qa-king-warm-heron" ~token:raw_token
-    | Error e -> Error e
-  in
-  cleanup_test_room dir;
-  match result with
-  | Ok cred -> check string "fallback credential owner" "qa-king" cred.agent_name
-  | Error e ->
-      fail
-        (Printf.sprintf
-           "hyphenated generated alias should verify via fallback credential: %s"
+           "keeper credential should verify with exact agent_name: %s"
            (Types.masc_error_to_string e))
 
 let test_load_credential_missing_keeper_alias_stays_quiet () =
@@ -429,14 +422,15 @@ let test_ensure_keeper_credential_uses_shared_internal_token () =
       in
       match ensure_result with
       | Ok (raw_token, cred) ->
-          check string "normalized keeper name" "masc-improver" cred.agent_name;
+          check string "keeper credential exact name" "keeper-masc-improver-agent" cred.agent_name;
+          check bool "keeper credential has uuid id" true (Option.is_some cred.id);
           check bool "keeper credential is worker" true (cred.role = Types.Worker);
           check bool "shared internal token verifies" true
             (Auth.verify_internal_keeper_token dir ~token:raw_token);
           check bool "internal keeper token hash persisted" true
             (Sys.file_exists (Auth.internal_keeper_token_hash_file dir));
-          check bool "no per-keeper external credential persisted" true
-            (Option.is_none (Auth.load_credential dir "keeper-masc-improver-agent"));
+          check bool "keeper credential persisted by exact name" true
+            (Option.is_some (Auth.load_credential dir "keeper-masc-improver-agent"));
           check bool "no normalized keeper credential persisted" true
             (Option.is_none (Auth.load_credential dir "masc-improver"))
       | Error e ->
@@ -455,7 +449,7 @@ let test_ensure_keeper_credential_reuses_persisted_raw_token_when_env_mismatched
           Auth.ensure_keeper_credential dir ~agent_name:"keeper-masc-improver-agent")
       in
       let raw_token_path =
-        Filename.concat (Auth.auth_dir dir) "masc-improver.token"
+        Filename.concat (Auth.auth_dir dir) "keeper-masc-improver-agent.token"
       in
       let shared_raw_token = "shared-codex-token" in
       let _ =
@@ -472,9 +466,9 @@ let test_ensure_keeper_credential_reuses_persisted_raw_token_when_env_mismatched
             (Sys.file_exists raw_token_path);
           check int "persisted raw token file mode 0600" 0o600
             (permission_bits raw_token_path);
-          check string "first credential uses keeper middle name" "masc-improver"
+          check string "first credential uses exact keeper name" "keeper-masc-improver-agent"
             first_cred.agent_name;
-          check string "reused credential keeps keeper middle name" "masc-improver"
+          check string "reused credential keeps exact keeper name" "keeper-masc-improver-agent"
             reused_cred.agent_name;
           check string "persisted keeper raw token reused" first_raw_token
             reused_raw_token
@@ -672,16 +666,14 @@ let () =
       test_case "resolve agent from token" `Quick test_resolve_agent_from_token;
       test_case "list credentials" `Quick test_list_credentials;
       test_case "delete credential" `Quick test_delete_credential;
-      test_case "load_credential nickname prefix fallback" `Quick
-        test_load_credential_nickname_fallback;
+      test_case "load_credential redirect stub resolves" `Quick
+        test_load_credential_redirect_stub;
       test_case "load_credential exact match wins over fallback" `Quick
         test_load_credential_exact_wins_over_fallback;
       test_case "extract_agent_type_prefix keeper aliases" `Quick
         test_extract_agent_type_prefix_keeper_aliases;
-      test_case "verify_token keeper alias fallback" `Quick
-        test_verify_token_keeper_alias_fallback;
-      test_case "verify_token hyphenated generated nickname fallback" `Quick
-        test_verify_token_hyphenated_generated_nickname_fallback;
+      test_case "verify_token keeper exact match" `Quick
+        test_verify_token_keeper_exact_match;
       test_case "load_credential missing keeper alias stays quiet" `Quick
         test_load_credential_missing_keeper_alias_stays_quiet;
       test_case "verify_token dashboard legacy alias fallback" `Quick

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -554,6 +554,7 @@ let seed_agent_file ?(agent_type = "worker") ?(capabilities = []) config agent_n
   let timestamp = Types.now_iso () in
   let agent : Types.agent =
     {
+      id = None;
       name = agent_name;
       agent_type;
       status = Types.Active;

--- a/test/test_dashboard_labels.ml
+++ b/test/test_dashboard_labels.ml
@@ -203,6 +203,7 @@ let test_classify_inactive_is_offline () =
   let now = Unix.gettimeofday () in
   let agent : Types.agent =
     {
+      id = None;
       name = "test-agent";
       agent_type = "test";
       status = Types.Inactive;
@@ -221,6 +222,7 @@ let test_classify_listening_is_idle () =
   let now = Unix.gettimeofday () in
   let agent : Types.agent =
     {
+      id = None;
       name = "test-agent";
       agent_type = "test";
       status = Types.Listening;
@@ -240,6 +242,7 @@ let test_classify_uses_stuck_threshold_override () =
   let (now, stuck_iso) = make_timestamp_pair 120.0 in
   let agent : Types.agent =
     {
+      id = None;
       name = "test-agent";
       agent_type = "test";
       status = Types.Active;

--- a/test/test_dashboard_mission_briefing.ml
+++ b/test/test_dashboard_mission_briefing.ml
@@ -220,6 +220,7 @@ let test_compact_keeper_json_normalizes_missing_fields () =
 let test_compact_agent_json_uses_current_focus () =
   let agent : Types.agent =
     {
+      id = None;
       name = "worker-1";
       agent_type = "codex";
       capabilities = [ "ops"; "review"; "debug" ];
@@ -309,6 +310,7 @@ let test_collect_metadata_gaps_separates_null_like_inputs () =
   in
   let agent : Types.agent =
     {
+      id = None;
       name = "agent-gap";
       agent_type = "codex";
       capabilities = [];
@@ -328,6 +330,7 @@ let test_collect_metadata_gaps_separates_null_like_inputs () =
 let test_collect_metadata_gaps_ignores_inactive_agents () =
   let inactive_agent : Types.agent =
     {
+      id = None;
       name = "agent-idle";
       agent_type = "codex";
       capabilities = [];

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -809,6 +809,8 @@ let test_agent_role_of_yojson_wrong_type () =
 
 let test_agent_credential_to_yojson () =
   let cred : Types.agent_credential = {
+    id = None;
+    agent_id = None;
     agent_name = "claude";
     token = "abc123";
     role = Types.Worker;
@@ -825,6 +827,8 @@ let test_agent_credential_to_yojson () =
 
 let test_agent_credential_to_yojson_with_expiry () =
   let cred : Types.agent_credential = {
+    id = None;
+    agent_id = None;
     agent_name = "claude";
     token = "abc123";
     role = Types.Admin;

--- a/test/test_types_utils_coverage.ml
+++ b/test/test_types_utils_coverage.ml
@@ -573,6 +573,8 @@ let test_tool_result_no_data () =
 
 let test_agent_credential_roundtrip () =
   let cred = Types.{
+    id = None;
+    agent_id = None;
     agent_name = "claude-secure";
     token = "sha256:abc123";
     role = Admin;
@@ -585,6 +587,8 @@ let test_agent_credential_roundtrip () =
 
 let test_agent_credential_no_expiry () =
   let cred = Types.{
+    id = None;
+    agent_id = None;
     agent_name = "worker-1";
     token = "sha256:xyz789";
     role = Worker;


### PR DESCRIPTION
## Summary
Introduces Relay GraphQL-style global IDs (`base64(type:uuid)`) as the canonical identity for all persisted entities. `agent_name` becomes a display label; UUID becomes the lookup key.

## Changes
- **New ID types** (`lib/types/ids.ml`): `Agent_id`, `Keeper_id`, `Credential_id` with generation, JSON serialization, and global ID encoding.
- **Deterministic keeper IDs**: UUIDv5 from namespace + keeper name + config path.
- **Credential storage migration**: `{uuid}.json` primary, `{agent_name}.json` redirect stub for backward compatibility.
- **Auth lookup cleanup**: `verify_token` removes `extract_agent_type_prefix`, uses exact match + legacy aliases only.
- **Keeper TOML load-time ID assignment**: generates or validates keeper ID at discovery.

## Related Issues
- Fixes credential name drift (#9646, #9574)
- Closes auth lookup ambiguity causing unauthorized errors

## Verification
- [x] `dune build` passes
- [x] `dune runtest` passes
- [ ] Manual: restart server, verify credential files contain UUIDs