### PR TITLE
fix(auth): clean up uuid credential targets

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -287,6 +287,31 @@ let load_credential_from_path_raw config agent_name path : agent_credential opti
   else
     None
 
+let credential_uuid_file config cid =
+  Filename.concat (agents_dir config) (Credential_id.to_string cid ^ ".json")
+
+let redirect_target_file config target =
+  if Filename.basename target = target && Filename.check_suffix target ".json" then
+    Some (Filename.concat (agents_dir config) target)
+  else
+    None
+
+let load_redirect_target config path =
+  if not (file_exists path) then
+    None
+  else
+    try
+      match Yojson.Safe.from_string (read_text_file path) with
+      | `Assoc fields -> (
+          match List.assoc_opt "redirect_to" fields with
+          | Some (`String target) -> redirect_target_file config target
+          | _ -> None)
+      | _ -> None
+    with Sys_error _ | Yojson.Json_error _ -> None
+
+let remove_file_if_exists path =
+  if file_exists path then remove_file path
+
 let load_credential config agent_name : agent_credential option =
   let file = credential_file config agent_name in
   if not (file_exists file) then None
@@ -298,9 +323,11 @@ let load_credential config agent_name : agent_credential option =
       match json with
       | `Assoc fields when List.mem_assoc "redirect_to" fields -> (
           match List.assoc "redirect_to" fields with
-          | `String target ->
-              let redirect_path = Filename.concat (agents_dir config) target in
-              load_credential_from_path_raw config agent_name redirect_path
+          | `String target -> (
+              match redirect_target_file config target with
+              | Some redirect_path ->
+                  load_credential_from_path_raw config agent_name redirect_path
+              | None -> None)
           | _ -> None)
       | _ -> load_credential_from_path_raw config agent_name file
     with Sys_error _ | Yojson.Json_error _ -> None
@@ -321,16 +348,20 @@ let save_credential config (cred : agent_credential) =
   ensure_auth_dirs config;
   let json = agent_credential_to_yojson cred in
   let json_str = Yojson.Safe.pretty_to_string json in
+  let stub_file = credential_file config cred.agent_name in
+  let previous_target = load_redirect_target config stub_file in
   (match cred.id with
   | Some cid ->
-      let uuid_file = Filename.concat (agents_dir config) (Credential_id.to_string cid ^ ".json") in
+      let uuid_file = credential_uuid_file config cid in
+      (match previous_target with
+       | Some old_file when old_file <> uuid_file -> remove_file_if_exists old_file
+       | _ -> ());
       save_private_text_file uuid_file json_str;
       let stub = `Assoc [("redirect_to", `String (Credential_id.to_string cid ^ ".json"))] in
-      let stub_file = credential_file config cred.agent_name in
       save_private_text_file stub_file (Yojson.Safe.pretty_to_string stub)
   | None ->
-      let file = credential_file config cred.agent_name in
-      save_private_text_file file json_str)
+      Option.iter remove_file_if_exists previous_target;
+      save_private_text_file stub_file json_str)
 
 let load_raw_token config ~agent_name =
   let file = raw_token_file config agent_name in
@@ -348,7 +379,15 @@ let persist_raw_token config ~agent_name raw_token =
 (** Delete agent credential *)
 let delete_credential config agent_name =
   let file = credential_file config agent_name in
-  if file_exists file then remove_file file
+  let redirect_target = load_redirect_target config file in
+  let credential_target =
+    match load_credential config agent_name with
+    | Some { id = Some cid; _ } -> Some (credential_uuid_file config cid)
+    | _ -> None
+  in
+  remove_file_if_exists file;
+  Option.iter remove_file_if_exists redirect_target;
+  Option.iter remove_file_if_exists credential_target
 
 (** List all credentials.
 

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -300,6 +300,116 @@ let test_load_credential_redirect_stub () =
    | Some loaded when loaded.agent_name = "adversary" -> ()
    | _ -> fail "direct UUID lookup should resolve")
 
+let test_delete_uuid_backed_credential_removes_redirect_target () =
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      let id = Types.Credential_id.generate () in
+      let raw_token = "uuid-backed-secret" in
+      let cred : Types.agent_credential =
+        {
+          id = Some id;
+          agent_id = None;
+          agent_name = "adversary";
+          token = Auth.sha256_hash raw_token;
+          role = Types.Worker;
+          created_at = "2026-01-01T00:00:00Z";
+          expires_at = None;
+        }
+      in
+      Auth.save_credential dir cred;
+      (match Auth.verify_token dir ~agent_name:"adversary" ~token:raw_token with
+       | Ok _ -> ()
+       | Error e ->
+           fail
+             (Printf.sprintf
+                "uuid-backed credential should verify before delete: %s"
+                (Types.masc_error_to_string e)));
+      Auth.delete_credential dir "adversary";
+      check bool "agent stub removed" true
+        (Option.is_none (Auth.load_credential dir "adversary"));
+      check bool "uuid target removed" true
+        (Option.is_none
+           (Auth.load_credential dir (Types.Credential_id.to_string id)));
+      (match Auth.find_credential_by_token dir ~token:raw_token with
+       | Error (Types.InvalidToken _) -> ()
+       | Error e ->
+           fail
+             (Printf.sprintf
+                "expected deleted token to be invalid: %s"
+                (Types.masc_error_to_string e))
+       | Ok cred ->
+           fail (Printf.sprintf "deleted token still resolves to %s" cred.agent_name));
+      check int "0 credentials after uuid-backed delete" 0
+        (List.length (Auth.list_credentials dir)))
+
+let test_plain_credential_replaces_uuid_redirect_target () =
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      let id = Types.Credential_id.generate () in
+      let old_token = "old-uuid-backed-secret" in
+      let new_token = "new-plain-secret" in
+      let uuid_file =
+        Filename.concat
+          (Filename.concat (Auth.auth_dir dir) "agents")
+          (Types.Credential_id.to_string id ^ ".json")
+      in
+      let cred : Types.agent_credential =
+        {
+          id = Some id;
+          agent_id = None;
+          agent_name = "adversary";
+          token = Auth.sha256_hash old_token;
+          role = Types.Worker;
+          created_at = "2026-01-01T00:00:00Z";
+          expires_at = None;
+        }
+      in
+      Auth.save_credential dir cred;
+      check bool "uuid target exists before replacement" true
+        (Sys.file_exists uuid_file);
+      let save_result =
+        Auth.save_raw_token_credential dir ~agent_name:"adversary"
+          ~role:Types.Admin ~raw_token:new_token
+      in
+      let old_token_result = Auth.find_credential_by_token dir ~token:old_token in
+      let new_token_result =
+        Auth.verify_token dir ~agent_name:"adversary" ~token:new_token
+      in
+      check bool "old uuid target removed after replacement" false
+        (Sys.file_exists uuid_file);
+      (match save_result with
+       | Ok _ -> ()
+       | Error e ->
+           fail
+             (Printf.sprintf
+                "replacement credential should save: %s"
+                (Types.masc_error_to_string e)));
+      (match old_token_result with
+       | Error (Types.InvalidToken _) -> ()
+       | Error e ->
+           fail
+             (Printf.sprintf
+                "expected old token mismatch after replacement: %s"
+                (Types.masc_error_to_string e))
+       | Ok stale ->
+           fail
+             (Printf.sprintf
+                "old token should not resolve after replacement, got %s"
+                stale.agent_name));
+      (match new_token_result with
+       | Ok loaded ->
+           check bool "replacement credential role is admin" true
+             (loaded.role = Types.Admin)
+       | Error e ->
+           fail
+             (Printf.sprintf
+                "replacement token should verify: %s"
+                (Types.masc_error_to_string e))))
+
 let test_load_credential_exact_wins_over_fallback () =
   (* If both the nickname file and the prefix file exist, the exact
      match wins so a per-nickname override remains possible. *)
@@ -720,6 +830,10 @@ let () =
       test_case "delete credential" `Quick test_delete_credential;
       test_case "load_credential redirect stub resolves" `Quick
         test_load_credential_redirect_stub;
+      test_case "delete uuid-backed credential removes target" `Quick
+        test_delete_uuid_backed_credential_removes_redirect_target;
+      test_case "plain credential replaces uuid redirect target" `Quick
+        test_plain_credential_replaces_uuid_redirect_target;
       test_case "load_credential exact match wins over fallback" `Quick
         test_load_credential_exact_wins_over_fallback;
       test_case "extract_agent_type_prefix keeper aliases" `Quick


### PR DESCRIPTION
## Summary

- remove stale UUID-backed credential target files when deleting an agent credential
- clean up prior redirect targets when a UUID-backed credential is overwritten or replaced by a non-UUID credential
- validate redirect target filenames before resolving them under the auth agents directory

## Why

UUID-backed credentials are stored as `{uuid}.json` with an `{agent_name}.json` redirect stub. Deleting or replacing only the stub can leave the UUID target behind, which keeps the old token discoverable through `list_credentials` / `find_credential_by_token`.

## Validation

- `git diff --check`
- `dune exec --root . --display=quiet test/test_auth.exe` (37 tests passed)

Note: local Dune emitted cache store warnings during the first build in this fresh worktree, but the build and test run completed successfully.