### PR TITLE
[codex] Guard keeper sandbox writes

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -2191,6 +2191,7 @@ let run_turn
     else None
   in
   ignore (Keeper_alerting_path.ensure_sandbox_bundle ~config ~meta);
+  let keeper_sandbox_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   let effective_allowed_paths = Keeper_alerting_path.effective_allowed_paths ~meta in
   match
     Keeper_alerting_path.absolute_allowed_paths_result
@@ -2215,7 +2216,7 @@ let run_turn
     let cli_transport_overrides =
       Some
         ({
-          cwd = None;
+          cwd = Some keeper_sandbox_root;
           claude_mcp_config = keeper_oas_context.claude_mcp_config;
           claude_allowed_tools = None;
           claude_permission_mode = None;
@@ -2955,7 +2956,7 @@ let run_turn
               (!tool_surface_ref).tool_surface_fallback_used;
           };
         sandbox_kind = Keeper_execution_receipt.sandbox_kind_of_meta meta;
-        sandbox_root = Some config.base_path;
+        sandbox_root = Some keeper_sandbox_root;
         network_mode = Keeper_types.network_mode_to_string meta.network_mode;
         approval_profile = (!tool_surface_ref).approval_mode_effective;
         approval_profile_derived = (!tool_surface_ref).approval_mode_derived;

--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -176,6 +176,13 @@ exception Fs_edit_error of string
 let raise_fs_edit_error ?fields message =
   raise (Fs_edit_error (error_json ?fields message))
 
+let validate_write_target ~config ~meta ~target =
+  match
+    Keeper_sandbox_containment.check_write_target ~config ~meta ~target
+  with
+  | Ok () -> Ok ()
+  | Error e -> Error (error_json ~fields:[ "path", `String target ] e)
+
 let handle_keeper_fs_edit
       ~(turn_sandbox_runtime : Keeper_turn_sandbox_runtime.t option)
       ~(config : Coord.config)
@@ -213,6 +220,9 @@ let handle_keeper_fs_edit
       (match resolve_keeper_path ~config ~meta ~raw_path:path with
        | Error e -> error_json e
        | Ok target ->
+         (match validate_write_target ~config ~meta ~target with
+          | Error json -> json
+          | Ok () ->
          (try
             let current =
               try Fs_compat.load_file target
@@ -266,7 +276,7 @@ let handle_keeper_fs_edit
           | Sys_error e -> error_json ~fields:[ "path", `String target ] e
           | Unix.Unix_error (err, _, _) ->
             error_json ~fields:[ "path", `String target ]
-              (Unix.error_message err)))
+              (Unix.error_message err))))
   | Some ((Overwrite | Append) as mode) ->
   let mode_label = fs_write_mode_to_string mode in
   if String.trim content = "" then
@@ -275,6 +285,9 @@ let handle_keeper_fs_edit
   match resolve_keeper_path ~config ~meta ~raw_path:path with
   | Error e -> error_json e
   | Ok target ->
+    (match validate_write_target ~config ~meta ~target with
+     | Error json -> json
+     | Ok () ->
     (try
        let write_result =
          match turn_sandbox_runtime with
@@ -318,5 +331,5 @@ let handle_keeper_fs_edit
     | Invalid_argument e -> error_json ~fields:[ "path", `String target ] e
      | Sys_error e -> error_json ~fields:[ "path", `String target ] e
      | Unix.Unix_error (err, _, _) ->
-       error_json ~fields:[ "path", `String target ] (Unix.error_message err))
+       error_json ~fields:[ "path", `String target ] (Unix.error_message err)))
 ;;

--- a/lib/keeper/keeper_sandbox_containment.ml
+++ b/lib/keeper/keeper_sandbox_containment.ml
@@ -21,7 +21,7 @@ let is_hardened_profile = function
   | Keeper_types.Docker -> true
   | Keeper_types.Local -> false
 
-let check_read_target ~config ~meta ~target =
+let check_target ~operation ~config ~meta ~target =
   if not (is_hardened_profile meta.Keeper_types.sandbox_profile) then
     Ok ()
   else
@@ -32,7 +32,13 @@ let check_read_target ~config ~meta ~target =
       Error
         (Printf.sprintf
            "symmetric_sandbox_blocked: target %s is outside keeper playground \
-            %s. Keepers with sandbox_profile=docker may only read inside \
+            %s. Keepers with sandbox_profile=docker may only %s inside \
             their playground. Clone the source into your playground via \
             keeper_shell op=git_clone, or operate inside %s/repos/."
-           target_norm playground playground)
+           target_norm playground operation playground)
+
+let check_read_target ~config ~meta ~target =
+  check_target ~operation:"read" ~config ~meta ~target
+
+let check_write_target ~config ~meta ~target =
+  check_target ~operation:"write" ~config ~meta ~target

--- a/lib/keeper/keeper_sandbox_containment.mli
+++ b/lib/keeper/keeper_sandbox_containment.mli
@@ -3,14 +3,14 @@
 
     The keeper sandbox boundary historically followed the tool name:
     [keeper_bash] for [sandbox_profile=Docker] keepers ran in a
-    container, but [keeper_fs_read] / [keeper_shell] read directly
-    from the host. The result was a one-way leak — write was gated,
-    read was not.
+    container, but [keeper_fs_read] / [keeper_fs_edit] / [keeper_shell]
+    could touch the host directly. The result was a cross-tool leak:
+    different tools enforced different boundaries for the same keeper.
 
     This module enforces "whichever profile decides one tool, decides
     every tool" on the host side without spinning up a per-call
-    container. When the keeper's profile is [Docker], read targets
-    must lie within the keeper's playground bundle
+    container. When the keeper's profile is [Docker], read and write
+    targets must lie within the keeper's playground bundle
     ([.masc/playground/<keeper>/]).
 
     Phase B-2 will route the same tools through [docker exec] so the
@@ -27,6 +27,15 @@
 
     A no-op (always [Ok ()]) for local keepers. *)
 val check_read_target :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  target:string ->
+  (unit, string) result
+
+(** [check_write_target] is the write-side counterpart to
+    [check_read_target]. A no-op for local keepers; for Docker keepers,
+    host writes are limited to the keeper playground bundle. *)
+val check_write_target :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   target:string ->

--- a/lib/types/ids.ml
+++ b/lib/types/ids.ml
@@ -138,14 +138,8 @@ end = struct
   let equal = String.equal
   let pp fmt t = Format.fprintf fmt "%s" t
   let generate ~name ~path =
-    (* DNS namespace UUID from RFC 4122; used as the v5 namespace seed. *)
-    let namespace =
-      match Uuidm.of_string "6ba7b810-9dad-11d1-80b4-00c04fd430c8" with
-      | Some ns -> ns
-      | None -> failwith "Invalid DNS namespace UUID"
-    in
     let input = Printf.sprintf "masc-keeper:%s:%s" name path in
-    Uuidm.v5 namespace input |> Uuidm.to_string |> of_string
+    Uuidm.v5 Uuidm.ns_dns input |> Uuidm.to_string |> of_string
   let to_yojson t = `String t
   let of_yojson = function
     | `String s -> Ok s

--- a/test/dune
+++ b/test/dune
@@ -1046,6 +1046,16 @@
  (libraries alcotest unix str))
 
 (test
+ (name test_keeper_agent_run_sandbox_source)
+ (modules test_keeper_agent_run_sandbox_source)
+ (libraries alcotest unix))
+
+(test
+ (name test_keeper_fs_write_containment)
+ (modules test_keeper_fs_write_containment)
+ (libraries masc_test_deps))
+
+(test
  (name test_channel_gate)
  (modules test_channel_gate)
  (libraries masc_test_deps))

--- a/test/test_keeper_agent_run_sandbox_source.ml
+++ b/test/test_keeper_agent_run_sandbox_source.ml
@@ -1,0 +1,88 @@
+(** Structural guard for keeper provider-CLI sandbox cwd.
+
+    Keeper-internal tools are sandbox-aware, but provider-native CLI tools
+    such as Shell/ReadFile inherit the CLI transport cwd. If that cwd falls
+    back to the server process cwd, Docker-profile keepers can dirty the repo
+    root instead of their playground. This pins the handoff point into OAS. *)
+
+open Alcotest
+
+let target_file = "lib/keeper/keeper_agent_run.ml"
+
+let load_source rel =
+  let source_root =
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some root -> root
+    | None -> Sys.getcwd ()
+  in
+  let path = Filename.concat source_root rel in
+  if not (Sys.file_exists path)
+  then failwith (Printf.sprintf "source file not found: %s" path)
+  else (
+    let ic = open_in path in
+    Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () -> In_channel.input_all ic))
+;;
+
+let count_occurrences ~needle haystack =
+  let nlen = String.length needle in
+  if nlen = 0
+  then 0
+  else (
+    let rec loop pos acc =
+      if pos + nlen > String.length haystack
+      then acc
+      else if String.sub haystack pos nlen = needle
+      then loop (pos + nlen) (acc + 1)
+      else loop (pos + 1) acc
+    in
+    loop 0 0)
+;;
+
+let contains ~needle haystack = count_occurrences ~needle haystack > 0
+
+let test_cli_transport_cwd_is_keeper_sandbox_root () =
+  let src = load_source target_file in
+  check
+    bool
+    "keeper_sandbox_root is derived from keeper meta"
+    true
+    (contains
+       ~needle:
+         "let keeper_sandbox_root = Keeper_sandbox.host_root_abs_of_meta ~config meta"
+       src);
+  check
+    bool
+    "CLI transport cwd uses keeper sandbox root"
+    true
+    (contains ~needle:"cwd = Some keeper_sandbox_root" src);
+  check
+    int
+    "CLI transport cwd must not fall back to process cwd"
+    0
+    (count_occurrences ~needle:"cwd = None" src)
+;;
+
+let test_execution_receipt_reports_same_sandbox_root () =
+  let src = load_source target_file in
+  check
+    bool
+    "receipt reports keeper sandbox root"
+    true
+    (contains ~needle:"sandbox_root = Some keeper_sandbox_root" src)
+;;
+
+let () =
+  run
+    "keeper_agent_run_sandbox_source"
+    [ ( "provider_cli_sandbox"
+      , [ test_case
+            "CLI transport cwd is keeper sandbox root"
+            `Quick
+            test_cli_transport_cwd_is_keeper_sandbox_root
+        ; test_case
+            "receipt reports same sandbox root"
+            `Quick
+            test_execution_receipt_reports_same_sandbox_root
+        ] )
+    ]
+;;

--- a/test/test_keeper_fs_write_containment.ml
+++ b/test/test_keeper_fs_write_containment.ml
@@ -1,0 +1,173 @@
+(** Focused standalone regression for Docker-profile keeper_fs_edit writes.
+
+    This avoids the large shared [tests] stanza while still exercising the
+    real handler path that used to rely only on allowed_paths resolution. *)
+
+module Coord = Masc_mcp.Coord
+module Fs_compat = Fs_compat
+module Json = Yojson.Safe.Util
+module Keeper_exec_fs = Masc_mcp.Keeper_exec_fs
+module Keeper_registry = Masc_mcp.Keeper_registry
+module Keeper_sandbox = Masc_mcp.Keeper_sandbox
+module Keeper_types = Masc_mcp.Keeper_types
+
+let temp_dir () =
+  let d = Filename.temp_file "keeper_fs_write_containment_" "" in
+  Unix.unlink d;
+  Unix.mkdir d 0o755;
+  d
+;;
+
+let cleanup_dir dir =
+  let rec rm path =
+    match Unix.lstat path with
+    | { Unix.st_kind = Unix.S_DIR; _ } ->
+      Array.iter (fun n -> rm (Filename.concat path n)) (Sys.readdir path);
+      Unix.rmdir path
+    | _ -> Unix.unlink path
+    | exception Unix.Unix_error _ -> ()
+  in
+  try rm dir with
+  | _ -> ()
+;;
+
+let rec ensure_dir path =
+  if path = "" || path = "." || path = "/"
+  then ()
+  else if Sys.file_exists path
+  then ()
+  else (
+    let parent = Filename.dirname path in
+    if parent <> path then ensure_dir parent;
+    Unix.mkdir path 0o755)
+;;
+
+let make_meta name =
+  let json =
+    `Assoc
+      [ "name", `String name
+      ; "agent_name", `String ("agent-" ^ name)
+      ; "trace_id", `String ("trace-" ^ name)
+      ; "goal", `String "write containment test"
+      ; "sandbox_profile", `String "docker"
+      ]
+  in
+  match Keeper_types.meta_of_json json with
+  | Ok meta -> meta
+  | Error e -> Alcotest.fail e
+;;
+
+let with_eio_fs f =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Process_eio.init
+    ~cwd_default:(Eio.Stdenv.cwd env)
+    ~proc_mgr:(Eio.Stdenv.process_mgr env)
+    ~clock:(Eio.Stdenv.clock env);
+  f ()
+;;
+
+let setup f =
+  with_eio_fs
+  @@ fun () ->
+  let base = temp_dir () in
+  ensure_dir (Filename.concat base Common.masc_dirname);
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base)
+    (fun () ->
+       Keeper_registry.clear ();
+       let config = Coord.default_config base in
+       let meta = make_meta "tester" in
+       let playground = Keeper_sandbox.host_root_abs_of_meta ~config meta in
+       ensure_dir playground;
+       f ~config ~meta ~playground)
+;;
+
+let parse raw = Yojson.Safe.from_string raw
+
+let parse_ok raw =
+  parse raw |> Json.member "ok" |> Json.to_bool_option |> Option.value ~default:false
+;;
+
+let parse_error raw = parse raw |> Json.member "error" |> Json.to_string_option
+
+let contains_substring ~needle text =
+  let nlen = String.length needle in
+  let tlen = String.length text in
+  let rec loop i =
+    if nlen = 0
+    then true
+    else if i + nlen > tlen
+    then false
+    else if String.sub text i nlen = needle
+    then true
+    else loop (i + 1)
+  in
+  loop 0
+;;
+
+let test_docker_write_blocks_project_root_even_if_allowlisted () =
+  setup
+  @@ fun ~config ~meta ~playground:_ ->
+  let meta = { meta with allowed_paths = [ config.base_path ] } in
+  let path = Filename.concat config.base_path "root-write.txt" in
+  let raw =
+    Keeper_exec_fs.handle_keeper_fs_edit
+      ~turn_sandbox_runtime:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+            [ "path", `String path
+            ; "mode", `String "overwrite"
+            ; "content", `String "must not land"
+            ])
+  in
+  Alcotest.(check bool) "ok=false" false (parse_ok raw);
+  (match parse_error raw with
+   | None -> Alcotest.fail "expected containment error"
+   | Some msg ->
+     Alcotest.(check bool)
+       "error mentions symmetric sandbox guard"
+       true
+       (contains_substring ~needle:"symmetric_sandbox_blocked" msg));
+  Alcotest.(check bool) "root file not created" false (Fs_compat.file_exists path)
+;;
+
+let test_docker_write_allows_playground () =
+  setup
+  @@ fun ~config ~meta ~playground ->
+  let path = Filename.concat playground "mind/allowed.txt" in
+  ensure_dir (Filename.dirname path);
+  let raw =
+    Keeper_exec_fs.handle_keeper_fs_edit
+      ~turn_sandbox_runtime:None
+      ~config
+      ~meta
+      ~args:
+        (`Assoc
+            [ "path", `String path
+            ; "mode", `String "overwrite"
+            ; "content", `String "allowed"
+            ])
+  in
+  if not (parse_ok raw) then Alcotest.failf "expected ok response, got: %s" raw;
+  Alcotest.(check string) "content landed" "allowed" (Fs_compat.load_file path)
+;;
+
+let () =
+  Alcotest.run
+    "Keeper_fs_write_containment"
+    [ ( "fs_edit"
+      , [ Alcotest.test_case
+            "docker write blocks project root even if allowlisted"
+            `Quick
+            test_docker_write_blocks_project_root_even_if_allowlisted
+        ; Alcotest.test_case
+            "docker write allows playground"
+            `Quick
+            test_docker_write_allows_playground
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- Force keeper OAS CLI transports to run from the keeper sandbox root instead of process cwd.
- Report the same keeper sandbox root in execution receipts.
- Add Docker-profile write containment to `keeper_fs_edit` before patch/overwrite/append writes.
- Add standalone regression tests for provider CLI cwd wiring and Docker write containment.

## Why
Docker-profile keepers could still dirty the repo root when provider-native CLI tools inherited the server cwd. `keeper_fs_edit` also needed the same playground containment guard as `keeper_fs_read`.

## Validation
- `dune build --cache=disabled --root . --build-dir _build_codex_verify lib/masc_mcp.cmxa`
- `dune exec --cache=disabled --root . --build-dir _build_codex_verify ./test/test_keeper_agent_run_sandbox_source.exe`
- `dune exec --cache=disabled --root . --build-dir _build_codex_verify ./test/test_keeper_fs_write_containment.exe`
- `ocamlformat --check test/test_keeper_agent_run_sandbox_source.ml test/test_keeper_fs_write_containment.ml`