### PR TITLE
[codex] Clear keeper id health ratchet

### DIFF
--- a/lib/types/ids.ml
+++ b/lib/types/ids.ml
@@ -138,14 +138,8 @@ end = struct
   let equal = String.equal
   let pp fmt t = Format.fprintf fmt "%s" t
   let generate ~name ~path =
-    (* DNS namespace UUID from RFC 4122; used as the v5 namespace seed. *)
-    let namespace =
-      match Uuidm.of_string "6ba7b810-9dad-11d1-80b4-00c04fd430c8" with
-      | Some ns -> ns
-      | None -> failwith "Invalid DNS namespace UUID"
-    in
     let input = Printf.sprintf "masc-keeper:%s:%s" name path in
-    Uuidm.v5 namespace input |> Uuidm.to_string |> of_string
+    Uuidm.v5 Uuidm.ns_dns input |> Uuidm.to_string |> of_string
   let to_yojson t = `String t
   let of_yojson = function
     | `String s -> Ok s


### PR DESCRIPTION
Fixes the Health ratchet failure seen in main CI run 24847245799 by replacing the hard-coded DNS namespace UUID parse/failwith path with Uuidm.ns_dns.

Validation:
- bash scripts/health_snapshot.sh --skip-build --json-out /tmp/masc-health-9741-fix.json --fail-on-lib-regression
- dune build --root . @check
- git diff --check

Notes:
- Health now reports lib_failwith=0 and Ratchet: pass.
- PR is draft per workspace guardrails.