### PR TITLE
[codex] Fix dashboard cascade sync and task verification flow

### DIFF
--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -61,6 +61,35 @@ let available_cascade_profiles () : string list =
 let invalid_cascade_profiles () : (string * string list) list =
   (cascade_profile_gate ()).invalid_profiles
 
+let sync_keeper_cascade_meta ~(config : Coord.config) ~(name : string)
+    ~(cascade_name : string) : (bool, string) result =
+  let updated_at = Keeper_types.now_iso () in
+  match Keeper_types.read_meta config name with
+  | Error msg -> Error ("read_meta failed after TOML update: " ^ msg)
+  | Ok (Some meta) ->
+      let updated = { meta with cascade_name; updated_at } in
+      (match Keeper_types.write_meta ~force:true config updated with
+       | Ok () ->
+           let registered =
+             Option.is_some
+               (Keeper_registry.get ~base_path:config.base_path name)
+           in
+           Keeper_registry.update_meta ~base_path:config.base_path name updated;
+           Ok registered
+       | Error msg -> Error ("write_meta failed after TOML update: " ^ msg))
+  | Ok None ->
+      (match Keeper_registry.get ~base_path:config.base_path name with
+       | None -> Ok false
+       | Some entry ->
+           let updated = { entry.meta with cascade_name; updated_at } in
+           (match Keeper_types.write_meta ~force:true config updated with
+            | Ok () ->
+                Keeper_registry.update_meta ~base_path:config.base_path name
+                  updated;
+                Ok true
+            | Error msg ->
+                Error ("write_meta failed after TOML update: " ^ msg)))
+
 let dashboard_dev_actor_name = "dashboard"
 
 let dashboard_dev_token_path base_path =
@@ -1115,7 +1144,7 @@ and add_autoresearch_routes router =
   |> Http.Router.post "/api/v1/keeper/cascade" (fun request reqd ->
        with_tool_auth
          ~tool_name:(Tool_name.Masc.to_string Tool_name.Masc.Status)
-         (fun _state req reqd ->
+         (fun state req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            match Yojson.Safe.from_string body_str with
            | exception Yojson.Json_error _ ->
@@ -1165,10 +1194,26 @@ and add_autoresearch_routes router =
                        (String.escaped e))
                      reqd
                  | Ok () ->
-                   Http.Response.json ~request:req
-                     (Printf.sprintf
-                       {|{"ok":true,"keeper":"%s","cascade_name":"%s","source":"toml"}|}
-                       (String.escaped name) (String.escaped cascade))
-                     reqd)
+                   let config = state.Mcp_server.room_config in
+                   (match sync_keeper_cascade_meta ~config ~name
+                            ~cascade_name:cascade with
+                    | Error e ->
+                      Http.Response.json ~status:`Internal_server_error ~request:req
+                        (Printf.sprintf
+                           {|{"ok":false,"error":"%s"}|}
+                           (String.escaped e))
+                        reqd
+                    | Ok live_meta_synced ->
+                      Http.Response.json ~request:req
+                        (Yojson.Safe.to_string
+                           (`Assoc
+                              [
+                                ("ok", `Bool true);
+                                ("keeper", `String name);
+                                ("cascade_name", `String cascade);
+                                ("source", `String "toml");
+                                ("live_meta_synced", `Bool live_meta_synced);
+                              ]))
+                        reqd))
          )
        ) request reqd)

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -501,6 +501,19 @@ let invalid_profile_names body =
   | _ -> []
 ;;
 
+let keeper_profile_cascade_name body keeper_name =
+  let open Yojson.Safe.Util in
+  let json = Yojson.Safe.from_string body in
+  let rows = json |> member "keeper_profiles" |> to_list in
+  match
+    List.find_opt
+      (fun row -> row |> member "keeper" |> to_string = keeper_name)
+      rows
+  with
+  | Some row -> row |> member "cascade_name" |> to_string
+  | None -> fail ("keeper profile missing from cascade config: " ^ keeper_name)
+;;
+
 let make_keeper_meta_json ?(name = "route_shadow_demo") () =
   match
     Masc_mcp.Keeper_types.meta_of_json
@@ -1081,6 +1094,63 @@ let test_keeper_cascade_routes_filter_invalid_catalog_entries () =
     (contains_substr "invalid in active cascade.json" assign_invalid_result.body)
 ;;
 
+let test_keeper_cascade_assignment_updates_dashboard_projection () =
+  with_mock_model @@ fun valid_model ->
+  with_temp_config_root
+    (Printf.sprintf
+       {|{"default_models":["%s"],"keeper_unified_models":["%s"]}|}
+       valid_model
+       valid_model)
+  @@ fun config_root ->
+  let seeded_keeper_name = "route_shadow_demo" in
+  write_keeper_toml_fixture ~config_root ~keeper_name:seeded_keeper_name;
+  with_seeded_server
+    ~env_overrides:[ "MASC_CONFIG_DIR", config_root ]
+  @@ fun ~port ~config ~admin_token ~keeper_name ->
+  check string "fixture keeper name" seeded_keeper_name keeper_name;
+  let boot_path = Printf.sprintf "/api/v1/keepers/%s/boot" keeper_name in
+  let boot_result =
+    run_curl_post ~body:"{}" ~token:admin_token ~port ~path:boot_path ()
+  in
+  require_status "boot route registers keeper" 200 boot_result;
+  let before =
+    run_curl_get ~port ~path:"/api/v1/cascade/config" ()
+  in
+  require_status "cascade config GET before assignment returns 200" 200 before;
+  check string "dashboard starts with seeded meta cascade"
+    Masc_mcp.Keeper_config.default_cascade_name
+    (keeper_profile_cascade_name before.body keeper_name);
+  let assign_result =
+    run_curl_post
+      ~body:
+        (Printf.sprintf
+           {|{"keeper":"%s","cascade_name":"keeper_unified"}|}
+           keeper_name)
+      ~token:admin_token
+      ~port
+      ~path:"/api/v1/keeper/cascade"
+      ()
+  in
+  require_status "valid cascade assignment returns 200" 200 assign_result;
+  let open Yojson.Safe.Util in
+  let assign_json = Yojson.Safe.from_string assign_result.body in
+  check bool "assignment synced live meta" true
+    (assign_json |> member "live_meta_synced" |> to_bool);
+  let after =
+    run_curl_get ~port ~path:"/api/v1/cascade/config" ()
+  in
+  require_status "cascade config GET after assignment returns 200" 200 after;
+  check string "dashboard projection reflects assigned cascade"
+    "keeper_unified"
+    (keeper_profile_cascade_name after.body keeper_name);
+  (match Masc_mcp.Keeper_types.read_meta config keeper_name with
+   | Ok (Some meta) ->
+       check string "persistent meta cascade updated"
+         "keeper_unified" meta.cascade_name
+   | Ok None -> fail "keeper meta missing after cascade assignment"
+   | Error msg -> fail ("read_meta failed after cascade assignment: " ^ msg))
+;;
+
 let test_execution_trust_route_surfaces_trust_summary_fields () =
   with_seeded_server
   @@ fun ~port ~config ~admin_token:_ ~keeper_name ->
@@ -1296,6 +1366,10 @@ let () =
             "keeper cascade routes filter invalid catalog entries"
             `Slow
             test_keeper_cascade_routes_filter_invalid_catalog_entries
+        ; test_case
+            "keeper cascade assignment updates dashboard projection"
+            `Slow
+            test_keeper_cascade_assignment_updates_dashboard_projection
         ; test_case
             "execution trust route surfaces trust summary fields"
             `Slow


### PR DESCRIPTION
## Summary
- sync keeper cascade_name apply into the live dashboard projection and registry state
- attach a default advisory verification contract when creating tasks from the dashboard
- prevent dashboard-created tasks from going straight to done when verification FSM is enabled

## Verification
- env DUNE_CACHE=disabled dune build --root .
- env DUNE_CACHE=disabled dune exec --root . ./test/test_dashboard_keeper_routes.exe
- pnpm exec vitest run src/components/task-manage/task-manage-state.test.ts --environment node --reporter=verbose
- npx tsc --noEmit --pretty
- pnpm lint