### PR TITLE
fix(task): default tasks into verification flow

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -118,6 +118,56 @@ let empty_task_contract =
   }
 ;;
 
+let default_verification_evidence_refs =
+  [ "completion_notes"; "pr_url_or_artifact_ref" ]
+;;
+
+let first_line text =
+  match String.index_opt text '\n' with
+  | Some idx -> String.sub text 0 idx
+  | None -> text
+;;
+
+let truncate ~max_len text =
+  if String.length text <= max_len then text
+  else String.sub text 0 max_len ^ "..."
+;;
+
+let default_completion_contract_text ~title ~description =
+  let title = String.trim title in
+  let description = description |> String.trim |> first_line in
+  if description = ""
+  then Printf.sprintf "Task scope satisfied: %s" title
+  else
+    truncate ~max_len:220
+      (Printf.sprintf "Task scope satisfied: %s - %s" title description)
+;;
+
+let ensure_task_contract_for_verification ?contract ~title ~description () =
+  let base =
+    match contract with
+    | Some contract -> normalize_task_contract contract
+    | None -> empty_task_contract
+  in
+  let completion_contract =
+    if base.completion_contract <> []
+    then base.completion_contract
+    else [ default_completion_contract_text ~title ~description ]
+  in
+  let required_evidence =
+    if base.required_evidence <> []
+    then base.required_evidence
+    else default_verification_evidence_refs
+  in
+  let verify_gate_evidence =
+    if base.verify_gate_evidence <> []
+    then base.verify_gate_evidence
+    else default_verification_evidence_refs
+  in
+  normalize_task_contract
+    { base with completion_contract; required_evidence; verify_gate_evidence }
+;;
+
 let merge_execution_links
       (existing : Types.task_execution_links)
       ?session_id
@@ -403,7 +453,14 @@ let add_task
              existing_id
          | None ->
            let task_id = Printf.sprintf "task-%03d" (next_task_number config backlog) in
-           let contract = Option.map normalize_task_contract contract in
+           let contract =
+             Some
+               (ensure_task_contract_for_verification
+                  ?contract
+                  ~title
+                  ~description
+                  ())
+           in
            let new_task =
              { id = task_id
              ; title
@@ -481,7 +538,14 @@ let batch_add_tasks_internal ?created_by config tasks =
              (fun (title, priority, description, contract, goal_id) ->
                 let task_id = Printf.sprintf "task-%03d" !next_num in
                 incr next_num;
-                let contract = Option.map normalize_task_contract contract in
+                let contract =
+                  Some
+                    (ensure_task_contract_for_verification
+                       ?contract
+                       ~title
+                       ~description
+                       ())
+                in
                 { id = task_id
                 ; title
                 ; description
@@ -1500,9 +1564,11 @@ let link_task_execution_artifacts_r
            | None -> Error (Types.TaskNotFound task_id)
            | Some task ->
              let existing_contract =
-               match task.contract with
-               | Some contract -> normalize_task_contract contract
-               | None -> empty_task_contract
+               ensure_task_contract_for_verification
+                 ?contract:task.contract
+                 ~title:task.title
+                 ~description:task.description
+                 ()
              in
              let updated_contract =
                { existing_contract with

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -161,6 +161,13 @@ let can_review_completion ~(task_opt : Types.task option) ~(agent_name : string)
        | Types.Cancelled _ -> false)
   | None -> false
 
+let persisted_completion_contract ~(task_opt : Types.task option) =
+  match task_opt with
+  | Some ({ contract = Some contract; _ } : Types.task)
+    when contract.completion_contract <> [] ->
+      Some contract.completion_contract
+  | _ -> None
+
 (* Concrete example handed to the keeper when the anti-rationalization
    gate rejects a completion. Prior form said only "describe actual
    work"; small-LLM keepers retried the same perfunctory notes
@@ -709,15 +716,31 @@ and handle_transition ctx args =
   let completion_owned_by_caller =
     force || can_review_completion ~task_opt ~agent_name:ctx.agent_name
   in
-  let gate_rejection =
+  let persisted_gate_rejection =
     if action = Types.Done_action && not force then
       if not completion_owned_by_caller then
         None
       else if task_has_persisted_contract task_opt then
         persisted_contract_rejection ~ctx ~task_opt ~notes
+      else
+        None
+    else
+      None
+  in
+  match persisted_gate_rejection with
+  | Some reason ->
+    (false, reason)
+  | None ->
+  let review_gate_rejection =
+    if action = Types.Done_action && not force then
+      if not completion_owned_by_caller then
+        None
       else if can_review_completion ~task_opt ~agent_name:ctx.agent_name then
         review_completion_notes
-          ~completion_contract
+          ~completion_contract:
+            (match persisted_completion_contract ~task_opt with
+             | Some persisted -> Some persisted
+             | None -> completion_contract)
           ~evaluator_cascade
           ~ctx
           ~task_opt
@@ -728,12 +751,9 @@ and handle_transition ctx args =
     else
       None
   in
-  match gate_rejection with
+  match review_gate_rejection with
   | Some reason ->
-    if task_has_persisted_contract task_opt then
-      (false, reason)
-    else
-      (false, completion_rejection_message ~allow_force:true reason)
+    (false, completion_rejection_message ~allow_force:true reason)
   | None ->
   (* Verifier gate: if the task has a completion_contract and the
      verification FSM is enabled, redirect Done → Submit_for_verification

--- a/lib/tool_task_schemas.ml
+++ b/lib/tool_task_schemas.ml
@@ -8,7 +8,8 @@ let schemas : Types.tool_schema list = [
   {
     name = "masc_add_task";
     description = "Add a new task to the backlog for agents to claim. \
-Tasks have status flow: todo → claimed → done/cancelled. \
+Tasks default to an advisory verification contract with completion/evidence requirements. \
+Normal status flow is todo → claimed → awaiting_verification → done/cancelled when verification FSM is enabled. \
 Priority 1=urgent, 5=low (default 3). \
 Returns task-XXX ID for tracking. \
 Example: masc_add_task({title: 'Fix login bug', priority: 1, description: 'Users cannot login with SSO'})";
@@ -63,6 +64,7 @@ Example: masc_add_task({title: 'Fix login bug', priority: 1, description: 'Users
     name = "masc_batch_add_tasks";
     description = "Add multiple tasks in one call (more efficient than repeated masc_add_task). \
 Use when: loading sprint backlog, importing from JIRA, creating related tasks. \
+Tasks default to the same advisory verification contract/evidence requirements as masc_add_task. \
 Each task gets unique ID (task-XXX). Atomic: all succeed or all fail. \
 Example: masc_batch_add_tasks({tasks: [{title: 'Task A', priority: 2}, {title: 'Task B'}]})";
     input_schema = `Assoc [
@@ -196,7 +198,8 @@ Tip: Look for status='todo' tasks to claim.";
 submit_for_verification, approve, or reject. \
 Call when you pick up, finish, or abandon a task. Supports CAS via expected_version. \
 After masc_add_task or masc_claim_next; pair with masc_deliver before action='done'. \
-Use submit_for_verification to request cross-agent review; approve/reject for verifier actions.";
+Use submit_for_verification to request cross-agent review; approve/reject for verifier actions. \
+Tasks created through masc_add_task normally route action='done' into awaiting_verification rather than final done.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -276,6 +276,68 @@ let test_done_redirects_to_verification_fsm () =
                   (Types.string_of_task_status status)))
         | _ -> fail "expected keeper_task_done to redirect into verification FSM")))
 
+let test_done_redirects_default_contract_task_to_verification_fsm () =
+  ensure_rng ();
+  with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
+    with_room (fun config ->
+      let meta = make_test_meta () in
+      let _ =
+        Coord.add_task config ~title:"Default verification task" ~priority:1
+          ~description:"created without explicit contract"
+      in
+      let task_id = (only_task config).id in
+      ignore (call_tool config meta "keeper_task_claim" (`Assoc []));
+      let result =
+        call_tool config meta "keeper_task_done"
+          (`Assoc
+             [
+               ("task_id", `String task_id);
+               ("result", `String "Implemented change and ran focused checks.");
+             ])
+      in
+      let json = parse_json result in
+      match Yojson.Safe.Util.member "ok" json with
+      | `Bool true ->
+        let task = only_task config in
+        (match task.task_status with
+         | Types.AwaitingVerification _ -> ()
+         | status ->
+           fail
+             (Printf.sprintf
+                "expected awaiting_verification, got %s"
+                (Types.string_of_task_status status)));
+        (match task.contract with
+         | Some contract ->
+           check bool "default completion contract present" true
+             (contract.completion_contract <> []);
+           check bool "default evidence contract present" true
+             (contract.verify_gate_evidence <> [])
+         | None -> fail "expected default verification contract");
+        let reqs = Verification.list_requests config.Coord.base_path in
+        let req =
+          List.find_opt
+            (fun (req : Verification.verification_request) ->
+               String.equal req.task_id task_id)
+            reqs
+        in
+        (match req with
+         | Some req ->
+           check bool "criteria populated" true (req.criteria <> []);
+           let evidence_refs =
+             match req.output with
+             | `Assoc fields -> (
+                 match List.assoc_opt "evidence_refs" fields with
+                 | Some (`List refs) ->
+                   List.filter_map
+                     (function `String s -> Some s | _ -> None)
+                     refs
+                 | _ -> [])
+             | _ -> []
+           in
+           check bool "evidence refs populated" true (evidence_refs <> [])
+         | None -> fail "expected verification request for default contract task")
+      | _ -> fail "expected keeper_task_done to redirect into verification FSM"))
+
 let test_submit_for_verification_requires_pr_url () =
   with_room (fun config ->
     let meta = make_test_meta () in
@@ -434,6 +496,8 @@ let () =
         test_done_respects_persisted_cdal_gate;
       test_case "done redirects to verification FSM" `Quick
         test_done_redirects_to_verification_fsm;
+      test_case "default contract redirects to verification FSM" `Quick
+        test_done_redirects_default_contract_task_to_verification_fsm;
     ];
     "submit_for_verification", [
       test_case "requires pr_url" `Quick

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -312,6 +312,60 @@ let () = test "handle_add_task_persists_contract" (fun () ->
   | _ -> failwith "expected exactly one task"
 )
 
+let () = test "handle_add_task_injects_default_verification_contract" (fun () ->
+  let ctx = make_test_ctx () in
+  let (success, result) =
+    Tool_task.handle_add_task ctx
+      (`Assoc
+        [
+          ("title", `String "Default verification task");
+          ("description", `String "Need verifier-visible evidence.");
+        ])
+  in
+  if not success then failwith result;
+  match Coord.get_tasks_raw ctx.config with
+  | [ task ] -> (
+      match task.contract with
+      | Some contract ->
+          assert (not contract.strict);
+          assert (contract.completion_contract <> []);
+          assert (List.mem "completion_notes" contract.required_evidence);
+          assert (List.mem "pr_url_or_artifact_ref" contract.required_evidence);
+          assert (List.mem "completion_notes" contract.verify_gate_evidence);
+          assert (List.mem "pr_url_or_artifact_ref" contract.verify_gate_evidence);
+          assert (str_contains (List.hd contract.completion_contract)
+                    "Default verification task")
+      | None -> failwith "expected default verification contract")
+  | _ -> failwith "expected exactly one task"
+)
+
+let () = test "handle_batch_add_tasks_injects_default_verification_contracts" (fun () ->
+  let ctx = make_test_ctx () in
+  let (success, result) =
+    Tool_task.handle_batch_add_tasks ctx
+      (`Assoc
+        [
+          ( "tasks",
+            `List
+              [
+                `Assoc [ ("title", `String "Batch task A") ];
+                `Assoc [ ("title", `String "Batch task B") ];
+              ] );
+        ])
+  in
+  if not success then failwith result;
+  let tasks = Coord.get_tasks_raw ctx.config in
+  assert (List.length tasks = 2);
+  List.iter
+    (fun (task : Types.task) ->
+       match task.contract with
+       | Some contract ->
+           assert (contract.completion_contract <> []);
+           assert (contract.verify_gate_evidence <> [])
+       | None -> failwith "expected default verification contract for batch task")
+    tasks
+)
+
 let () = test "handle_done_uses_persisted_contract_gate" (fun () ->
   (* MASC_CDAL_GATE_ENABLED default flipped to [true] in v0.9.5 (PR #7579).
      With gate enabled + strict contract + no persisted verdict, handle_done
@@ -807,7 +861,7 @@ let () = test "transition_release_clears_planning_current_task" (fun () ->
   assert (Planning_eio.get_current_task ctx.config = None)
 )
 
-let () = test "transition_done_clears_planning_current_task" (fun () ->
+let () = test "transition_done_redirects_to_verification_and_keeps_planning_current_task" (fun () ->
   let ctx = make_test_ctx () in
   let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Transition done")]) in
   let (success_claim, _result) =
@@ -826,7 +880,13 @@ let () = test "transition_done_clears_planning_current_task" (fun () ->
   in
   assert success_done;
   assert (not (str_contains result "rejected"));
-  assert (Planning_eio.get_current_task ctx.config = None)
+  assert (Planning_eio.get_current_task ctx.config = Some "task-001");
+  match Coord.get_tasks_raw ctx.config with
+  | [ task ] -> (
+      match task.task_status with
+      | Types.AwaitingVerification _ -> ()
+      | _ -> failwith "expected task to be awaiting_verification after done")
+  | _ -> failwith "expected exactly one task after done transition"
 )
 
 let () = test "transition_accepts_underscore_prefixed_internal_markers" (fun () ->


### PR DESCRIPTION
## Summary

- persist an advisory verification contract for tasks created without an explicit contract
- route default task completion through `awaiting_verification` instead of immediate final completion
- keep anti-rationalization review active for persisted default contracts and add coverage for tool and keeper dispatch paths

## Product impact

- Promise affected: `repo coordination`
- User-visible change: newly added tasks now carry verifier-visible completion/evidence requirements by default, and `done` normally transitions into verification instead of final `completed`

## Evidence

- `dune exec --root . --display=quiet test/test_tool_task_coverage.exe`
- `dune exec --root . --display=quiet test/test_keeper_task_dispatch.exe`
- `dune build --root . --display=quiet @check`

## Review evidence

- Self-review completed after rebase onto `origin/main`
- No external review model was invoked in this pass

## Linked issue

- Closes #none
- Relates #none
