### PR TITLE
fix(keeper): restore oas_env field and fix turn budget chain

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -357,7 +357,7 @@ module KeeperKeepalive = struct
       leaving only 1 productive action per cycle.
       Env: [MASC_KEEPER_OAS_MAX_TURNS_PER_CALL]. Default: 15. Range: [1, 50]. *)
   let oas_max_turns_per_call =
-    max 1 (min 50 (get_int ~default:15 "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL"))
+    max 1 (min 50 (get_int ~default:30 "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL"))
 
   (** Smaller turn budget for scheduled autonomous cycles so one keeper does
       not monopolize the autonomous semaphore for minutes at a time.
@@ -374,7 +374,7 @@ module KeeperKeepalive = struct
       Env: [MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS].
       Default: min(global, 2). Range: [1, global]. *)
   let oas_max_turns_per_call_scheduled_autonomous =
-    let default = min oas_max_turns_per_call 2 in
+    let default = min oas_max_turns_per_call 10 in
     max 1
       (min oas_max_turns_per_call
          (min 50

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -211,7 +211,12 @@ let ensure_keeper_meta config name =
     let target_always_approve =
       apply_default_opt defaults.always_approve meta.always_approve
     in
-
+    (* --- OAS Env --- *)
+    let target_oas_env =
+      match defaults.oas_env with
+      | [] -> meta.oas_env
+      | env -> env
+    in
     (* --- Change detection by category --- *)
     let proactive_changed =
       meta.proactive.enabled <> target_proactive
@@ -261,12 +266,13 @@ let ensure_keeper_meta config name =
       || meta.telemetry_feedback_window_hours <> target_tf_window in
     let timeout_policy_changed =
       meta.per_provider_timeout_s <> target_per_provider_timeout in
+    let oas_env_changed = meta.oas_env <> target_oas_env in
     let any_changed =
       proactive_changed || signal_changed || denylist_changed || models_changed
       || social_model_changed
       || cascade_changed
       || personality_changed || policy_changed || discovery_changed
-      || telemetry_changed || timeout_policy_changed in
+      || telemetry_changed || timeout_policy_changed || oas_env_changed in
 
     if any_changed then begin
       let cats = List.filter_map Fun.id [
@@ -281,6 +287,7 @@ let ensure_keeper_meta config name =
         (if discovery_changed then Some "discovery" else None);
         (if telemetry_changed then Some "telemetry" else None);
         (if timeout_policy_changed then Some "timeout_policy" else None);
+        (if oas_env_changed then Some "oas_env" else None);
       ] in
       Log.Keeper.info
         "ensure_keeper_meta: re-syncing [%s] for %s"
@@ -330,6 +337,7 @@ let ensure_keeper_meta config name =
         telemetry_feedback_window_hours = target_tf_window;
         per_provider_timeout_s = target_per_provider_timeout;
         always_approve = target_always_approve;
+        oas_env = target_oas_env;
         updated_at = now_iso ();
       } in
       match write_meta config updated with

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -458,7 +458,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           last_need = "";
         };
       keeper_id = None;
-      oas_env = Option.value ~default:[] p.profile_defaults.oas_env;
+      oas_env = p.profile_defaults.oas_env;
       meta_version = 0;
       } in
       Progress.Tracker.step tracker ~message:"Saving initial checkpoint" ();

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -458,6 +458,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           last_need = "";
         };
       keeper_id = None;
+      oas_env = Option.value ~default:[] p.profile_defaults.oas_env;
       meta_version = 0;
       } in
       Progress.Tracker.step tracker ~message:"Saving initial checkpoint" ();
@@ -552,5 +553,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           ("max_context_override", Json_util.int_opt_to_json meta.max_context_override);
           ("auto_handoff", `Bool meta.auto_handoff);
           ("handoff_threshold", `Float meta.handoff_threshold);
+          ("oas_env", `Assoc (List.map (fun (k, v) -> (k, `String v)) meta.oas_env));
         ] in
         (true, Yojson.Safe.to_string json)

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -270,6 +270,7 @@ type keeper_meta =
     runtime : agent_runtime_state
   ; (* -- Identity & concurrency -- *)
     keeper_id : Keeper_id.Uid.t option
+  ; oas_env : (string * string) list
   ; meta_version : int
   }
 
@@ -911,6 +912,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; "keeper_id", (match m.keeper_id with
       | Some uid -> Keeper_id.uid_to_yojson uid
       | None -> `Null)
+    ; "oas_env", `Assoc (List.map (fun (k, v) -> (k, `String v)) m.oas_env)
     ; "meta_version", `Int m.meta_version
     ]
 ;;
@@ -1484,6 +1486,13 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
              ; telemetry_feedback_enabled = Safe_ops.json_bool_opt "telemetry_feedback_enabled" json
              ; telemetry_feedback_window_hours = Safe_ops.json_int_opt "telemetry_feedback_window_hours" json
              ; runtime = state.ps_runtime
+             ; oas_env =
+                 (match Yojson.Safe.Util.member "oas_env" json with
+                  | `Assoc fields ->
+                    List.filter_map (function
+                      | (k, `String v) -> Some (k, v)
+                      | _ -> None) fields
+                  | _ -> [])
              ; keeper_id =
                  (match Safe_ops.json_string_opt "keeper_id" json with
                   | Some s ->
@@ -1600,6 +1609,7 @@ let fallback_canonical_keeper_meta_key_names =
   ; "telemetry_feedback_enabled"
   ; "telemetry_feedback_window_hours"
   ; "per_provider_timeout_s"
+  ; "oas_env"
   ]
 ;;
 

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -204,6 +204,7 @@ type keeper_meta = {
   always_approve : bool option;
   runtime: agent_runtime_state;
   keeper_id : Keeper_id.Uid.t option;
+  oas_env: (string * string) list;
   meta_version : int;
 }
 

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -1313,7 +1313,7 @@ let load_keeper_profile_defaults name : keeper_profile_defaults =
     Values outside the range are rejected so a typo in TOML cannot silently
     bypass the budget envelope. *)
 let clamp_max_turns_override : int option -> int option = function
-  | Some n when n >= 1 && n <= 50 -> Some n
+  | Some n when n >= 1 && n <= 100 -> Some n
   | _ -> None
 
 let effective_max_turns_per_call (profile : keeper_profile_defaults) : int =

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -105,6 +105,8 @@ let allowlisted_env_pairs () =
       Env_config_core.storage_type_env_key;
       Env_config_core.base_path_env_key;
       Env_config_core.config_dir_env_key;
+      "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL";
+      "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS";
     ]
   in
   let inherited =


### PR DESCRIPTION
## Summary

Fixes the keeper Bash execution failure chain caused by `oas_env` being silently dropped during server reconcile.

### Root Cause
- `keeper_meta` type was missing the `oas_env` field
- `[keeper.oas_env]` from TOML was parsed into `keeper_profile_defaults` but never propagated to runtime `keeper_meta`
- `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL` never reached Docker containers
- Turn budget exhaustion caused fallback to silent/noop cycles

### Changes
- Added `oas_env: (string * string) list` to `keeper_meta` record type
- Added JSON serialization/deserialization in `meta_to_json` / `meta_of_json`
- Added `oas_env` to `create_keeper` initialization and response JSON
- Added `target_oas_env` resync in `ensure_keeper_meta` server reconcile
- Added `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL` and `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS` to Docker env allowlist
- Bumped reactive default 15→30, autonomous default min(global,2)→min(global,10)
- Raised clamp ceiling from 50 to 100

### Verification
- [x] `dune build @install` compiles
- [x] Server restarted with new binary (PID 91498)
- [ ] Keeper Bash tool usage after autoboot
- [ ] `oas_env` persists across reconcile cycles

### Related
- Fixes turn budget exhaustion causing silent keeper failures