### PR TITLE
fix(telemetry): add error_preview to decisions.jsonl

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -245,6 +245,7 @@ let make_keeper_tool_handler
                 "duration_ms", `Int duration_ms;
                 "result_bytes", `Int (String.length normalized_error);
                 "ok", `Bool false;
+                "error_preview", `String detail;
               ])
           with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
           Keeper_tool_call_log.set_truncation_info


### PR DESCRIPTION
## Summary
- Add `error_preview` field to `tool_exec` decisions.jsonl records for keeper tool error results (path 1 of 3-path recording)
- Previously only `ok: false` + `result_bytes` were recorded, making systematic failure diagnosis impossible
- SSE broadcast already included `error_text`; exception path already included `error` field — this aligns path 1 with the same observability standard

## Context
During keeper_bash failure investigation (PR #9742 follow-up), discovered that 69% of masc-improver's bash calls fail with `result_bytes=565` repeating 10 times — but the actual error text was not persisted anywhere queryable. This 1-line fix closes the telemetry gap.

## Test plan
- [ ] Verify `decisions.jsonl` now contains `error_preview` field on failed tool_exec entries
- [ ] Existing dune build passes (type-safe: `detail` is `string`, `\`String` is Yojson string constructor)
- [ ] Existing tests pass