### PR TITLE
fix(ssot): KIMI env var, spawn docs, schema dedup

### DIFF
--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -80,14 +80,9 @@ let local_worker_compat_passthrough_schemas : Types.tool_schema list =
     local_worker_compat_passthrough_tool_names
 
 let local_worker_internal_schemas : Types.tool_schema list =
-  [
-    { Types.name = "masc_heartbeat";
-      description =
-        "Update the worker heartbeat timestamp so long-running local tasks are not reaped as zombies.";
-      input_schema =
-        `Assoc [ ("type", `String "object"); ("properties", `Assoc []) ];
-    };
-  ]
+  List.filter
+    (fun (schema : Types.tool_schema) -> schema.name = "masc_heartbeat")
+    Tool_schemas_coord_core.schemas
 
 let local_worker_code_schemas : Types.tool_schema list =
   [

--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -140,47 +140,7 @@ let local_worker_code_schemas : Types.tool_schema list =
   ]
 
 let local_worker_worktree_schemas : Types.tool_schema list =
-  [
-    {
-      Types.name = "masc_worktree_create";
-      description = "Create an isolated Git worktree under .worktrees/{agent}-{task}/ with a new branch. Use when starting a task that modifies files, so other agents' work is not affected.";
-      input_schema =
-        `Assoc
-          [
-            ("type", `String "object");
-            ( "properties",
-              `Assoc
-                [
-                  ("agent_name", `Assoc [ ("type", `String "string") ]);
-                  ("task_id", `Assoc [ ("type", `String "string") ]);
-                  ("base_branch", `Assoc [ ("type", `String "string") ]);
-                ] );
-            ("required", `List [ `String "agent_name"; `String "task_id" ]);
-          ];
-    };
-    {
-      Types.name = "masc_worktree_remove";
-      description = "Remove a worktree and its local branch after your work is merged. Use when your PR has been merged and the isolated worktree is no longer needed.";
-      input_schema =
-        `Assoc
-          [
-            ("type", `String "object");
-            ( "properties",
-              `Assoc
-                [
-                  ("agent_name", `Assoc [ ("type", `String "string") ]);
-                  ("task_id", `Assoc [ ("type", `String "string") ]);
-                ] );
-            ("required", `List [ `String "agent_name"; `String "task_id" ]);
-          ];
-    };
-    {
-      Types.name = "masc_worktree_list";
-      description = "List all active worktrees in the project with agent and task mappings. Use when checking for stale worktrees or seeing who is working in parallel.";
-      input_schema =
-        `Assoc [ ("type", `String "object"); ("properties", `Assoc []) ];
-    };
-  ]
+  Tool_schemas_worktree.schemas
 
 let local_worker_run_schemas : Types.tool_schema list =
   [

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -912,7 +912,8 @@ let expand_model_strings_for_execution ?rotation_scope (items : string list) =
   |> dedupe_stable
 
 (* Filter providers by kind name (exact, case-insensitive).
-   Valid filter values: "ollama", "glm", "anthropic", "gemini", "openai_compat", "claude_code".
+   Valid filter values: "ollama", "glm", "anthropic", "gemini", "openai_compat",
+   "claude_code", "kimi", "kimi_cli", "gemini_cli", "codex_cli".
    Empty/None filter passes through unchanged. No-match falls back to unfiltered. *)
 let apply_provider_filter ~provider_filter ~label providers =
   match provider_filter with

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -714,7 +714,7 @@ let resolve_direct_canonical_name label =
   Option.map (fun (adapter : adapter) -> adapter.canonical_name) (resolve_direct_adapter label)
 
 (** Resolve spawn_key for an agent label.
-    Returns the key to look up in Spawn.default_configs. *)
+    Returns the key to look up in Spawn.spawn_config_of_key. *)
 let resolve_spawn_key label =
   match resolve_direct_adapter label with
   | Some adapter -> adapter.spawn_key

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -1409,7 +1409,7 @@ let auth_detail_of_provider provider =
   | Some adapter ->
     let auth_kind_base =
       if adapter.canonical_name = cn_kimi_api then
-        "api_key:KIMI_API_KEY_SB|KIMI_API_KEY"
+        "api_key:KIMI_API_KEY"
       else
         string_of_auth_mode adapter.auth_mode
     in

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -60,7 +60,7 @@ type adapter = {
   runtime_kind : runtime_kind;
   auth_mode : auth_mode;
   aliases : string list;
-  spawn_key : string option;       (** Key into Spawn.default_configs. None = not spawnable via CLI. *)
+  spawn_key : string option;       (** Key for CLI spawn lookup in Spawn.spawn_config_of_key. None = not spawnable via CLI. *)
   cascade_prefix : string;         (** MASC cascade model prefix (e.g. "claude", "openai").
                                        CONTRACT: Must match the prefix used by the local
                                        [Cascade_config] parser and Provider_registry-compatible

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -770,7 +770,7 @@ let test_enrich_sdk_error_for_moonshot_auth_includes_env_hint () =
   with_temp_masc_config
     {|{
   "default_api_key_env": {
-    "kimi": "KIMI_API_KEY_SB"
+    "kimi": "KIMI_API_KEY"
   }
 }|}
   @@ fun () ->
@@ -794,7 +794,7 @@ let test_enrich_sdk_error_for_moonshot_auth_includes_env_hint () =
     |> Oas.Error.to_string
   in
   Alcotest.(check bool) "env hint included" true
-    (contains_substring ~needle:"KIMI_API_KEY_SB" rendered);
+    (contains_substring ~needle:"KIMI_API_KEY" rendered);
   Alcotest.(check bool) "key presence hint included" true
     (contains_substring ~needle:"auth header was populated" rendered)
 

--- a/test/test_provider_kind_resolution.ml
+++ b/test/test_provider_kind_resolution.ml
@@ -144,9 +144,9 @@ let test_cascade_parse_custom_v1_base_url_dedupes_request_path () =
       "http://127.0.0.1:18080/v1" cfg.base_url
 
 let test_cascade_parse_kimi_legacy_alias_maps_to_k2_5 () =
-  with_env "KIMI_API_KEY_SB" (Some "dummy-key") (fun () ->
+  with_env "KIMI_API_KEY" (Some "dummy-key") (fun () ->
       match Cascade.parse_model_string "kimi:kimi-for-coding" with
-      | None -> fail "kimi legacy alias should parse when KIMI_API_KEY_SB is set"
+      | None -> fail "kimi legacy alias should parse when KIMI_API_KEY is set"
       | Some cfg ->
         check kind_testable "cfg.kind is OpenAI_compat"
           Pk.OpenAI_compat cfg.kind;


### PR DESCRIPTION
## Summary
SSOT drift remediation batch: KIMI env var alignment, spawn key doc fix, and tool schema deduplication.

## Changes
- **provider_adapter.ml**: Remove KIMI_API_KEY_SB fallback, fix spawn_key comment (Spawn.spawn_config_of_key)
- **cascade_config.ml**: Sync moonshot_api_key_env to KIMI_API_KEY, update cascade filter docs
- **agent_tool_surfaces.ml**: Dedupe heartbeat schema via Tool_schemas_coord_core, dedupe worktree schemas via Tool_schemas_worktree
- **test_oas_worker.ml**: Update KIMI test env var reference
- **test_provider_kind_resolution.ml**: Update KIMI test env var reference

## Verification
- [x] dune build @install passes
- [x] Cross-repo verified against OAS provider_registry.ml

Depends on: oas#1159