### PR TITLE
refactor(lib): OCaml 5.x best-practice audit batch

### DIFF
--- a/lib/cascade/cascade_client_capacity.ml
+++ b/lib/cascade/cascade_client_capacity.ml
@@ -6,13 +6,13 @@ type entry = {
 }
 
 let registry : (string, entry) Hashtbl.t = Hashtbl.create 4
-let registry_mu = Mutex.create ()
+let registry_mu = Eio.Mutex.create ()
 
 let clamp_max n = if n < 1 then 1 else n
 
 let register ~url ~max_concurrent =
   let max_concurrent = clamp_max max_concurrent in
-  Mutex.protect registry_mu (fun () ->
+  Eio.Mutex.use_rw ~protect:true registry_mu (fun () ->
       match Hashtbl.find_opt registry url with
       | None ->
         let e = { max_concurrent; active = Atomic.make 0 } in
@@ -24,11 +24,11 @@ let register ~url ~max_concurrent =
             { max_concurrent; active = existing.active })
 
 let registered_urls () =
-  Mutex.protect registry_mu (fun () ->
+  Eio.Mutex.use_rw ~protect:true registry_mu (fun () ->
       Hashtbl.fold (fun url _ acc -> url :: acc) registry [])
 
 let snapshot () =
-  Mutex.protect registry_mu (fun () ->
+  Eio.Mutex.use_rw ~protect:true registry_mu (fun () ->
       Hashtbl.fold
         (fun url e acc ->
            let active = Atomic.get e.active in
@@ -44,10 +44,10 @@ let snapshot () =
         registry [])
 
 let unregister_all () =
-  Mutex.protect registry_mu (fun () -> Hashtbl.clear registry)
+  Eio.Mutex.use_rw ~protect:true registry_mu (fun () -> Hashtbl.clear registry)
 
 let lookup url =
-  Mutex.protect registry_mu (fun () -> Hashtbl.find_opt registry url)
+  Eio.Mutex.use_rw ~protect:true registry_mu (fun () -> Hashtbl.find_opt registry url)
 
 let is_registered url = lookup url <> None
 

--- a/lib/cascade/cascade_client_capacity_history.ml
+++ b/lib/cascade/cascade_client_capacity_history.ml
@@ -54,7 +54,7 @@ let cap_ref = ref 0
 let buf : event option array ref = ref [||]
 let head = ref 0
 let count = ref 0
-let mu = Mutex.create ()
+let mu = Eio.Mutex.create ()
 
 (* Lazy init: resolve capacity + allocate buffer on first use.  We
    do this outside [record] so [clear] / [capacity] can be called
@@ -85,7 +85,7 @@ let bump_prometheus_counter (ev : event) =
     ] ()
 
 let record ev =
-  Mutex.protect mu (fun () ->
+  Eio.Mutex.use_rw ~protect:true mu (fun () ->
       ensure_initialised_locked ();
       let cap = !cap_ref in
       (!buf).(!head) <- Some ev;
@@ -94,17 +94,17 @@ let record ev =
   bump_prometheus_counter ev
 
 let clear () =
-  Mutex.protect mu (fun () ->
+  Eio.Mutex.use_rw ~protect:true mu (fun () ->
       ensure_initialised_locked ();
       let cap = !cap_ref in
       for i = 0 to cap - 1 do (!buf).(i) <- None done;
       head := 0;
       count := 0)
 
-let size () = Mutex.protect mu (fun () -> !count)
+let size () = Eio.Mutex.use_rw ~protect:true mu (fun () -> !count)
 
 let capacity () =
-  Mutex.protect mu (fun () ->
+  Eio.Mutex.use_rw ~protect:true mu (fun () ->
       ensure_initialised_locked ();
       !cap_ref)
 
@@ -138,7 +138,7 @@ let collect_newest_first_locked () =
 
 let snapshot ?(limit = 100) ?kind ?since_ts () =
   let events =
-    Mutex.protect mu (fun () ->
+    Eio.Mutex.use_rw ~protect:true mu (fun () ->
         ensure_initialised_locked ();
         collect_newest_first_locked ())
   in

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -627,14 +627,14 @@ type cascade_source = Named | Default_fallback | Hardcoded_defaults
     3. Selected item becomes first; rest sorted by weight desc
 
     @since 0.137.0 *)
-(* Shared weighted-shuffle RNG.  Protect draws with Stdlib.Mutex because
+(* Shared weighted-shuffle RNG.  Protect draws with Eio.Mutex because
    [Random.State.int] mutates the state and this path can be hit from
-   concurrent server fibers. *)
+   concurrent server fibers on the same domain. *)
 let weighted_shuffle_rng = Random.State.make_self_init ()
-let weighted_shuffle_rng_mu = Mutex.create ()
+let weighted_shuffle_rng_mu = Eio.Mutex.create ()
 
 let weighted_random_int bound =
-  Mutex.protect weighted_shuffle_rng_mu (fun () ->
+  Eio.Mutex.use_rw ~protect:true weighted_shuffle_rng_mu (fun () ->
     Random.State.int weighted_shuffle_rng bound)
 
 let weighted_shuffle

--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -149,19 +149,18 @@ type provider_state = {
 
 type t = {
   providers: (string, provider_state) Hashtbl.t;
-  mu: Mutex.t;
+  mu: Eio.Mutex.t;
 }
 
 (* ── Constructor ──────────────────────────────── *)
 
 let create () : t = {
   providers = Hashtbl.create 8;
-  mu = Mutex.create ();
+  mu = Eio.Mutex.create ();
 }
 
 let with_lock t f =
-  Mutex.lock t.mu;
-  Fun.protect ~finally:(fun () -> Mutex.unlock t.mu) f
+  Eio.Mutex.use_rw ~protect:true t.mu (fun () -> f ())
 
 let get_or_create_state t key =
   match Hashtbl.find_opt t.providers key with

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -203,11 +203,10 @@ let make_generated_id prefix =
   let digest = Digestif.SHA256.(digest_string entropy |> to_hex) in
   prefix ^ "_" ^ String.sub digest 0 12
 
-let rules_mu = Mutex.create ()
+let rules_mu = Eio.Mutex.create ()
 
 let with_rules_lock f =
-  Mutex.lock rules_mu;
-  Fun.protect f ~finally:(fun () -> Mutex.unlock rules_mu)
+  Eio.Mutex.use_rw ~protect:true rules_mu (fun () -> f ())
 
 let rules_path ?base_path () =
   let base_path =

--- a/lib/keeper/keeper_compact_audit.ml
+++ b/lib/keeper/keeper_compact_audit.ml
@@ -313,19 +313,17 @@ let pair_events rows : pair_result list =
    Needed because OAS events don't carry a compaction-scoped correlation. *)
 module Pending = struct
   let tbl : (string, string * float) Hashtbl.t = Hashtbl.create 16
-  let mu = Mutex.create ()
+  let mu = Eio.Mutex.create ()
 
   let stash ~keeper_name ~compaction_id ~ts =
-    Mutex.lock mu;
-    Hashtbl.replace tbl keeper_name (compaction_id, ts);
-    Mutex.unlock mu
+    Eio.Mutex.use_rw ~protect:true mu (fun () ->
+      Hashtbl.replace tbl keeper_name (compaction_id, ts))
 
   let take ~keeper_name =
-    Mutex.lock mu;
-    let r = Hashtbl.find_opt tbl keeper_name in
-    (match r with Some _ -> Hashtbl.remove tbl keeper_name | None -> ());
-    Mutex.unlock mu;
-    r
+    Eio.Mutex.use_rw ~protect:true mu (fun () ->
+      let r = Hashtbl.find_opt tbl keeper_name in
+      (match r with Some _ -> Hashtbl.remove tbl keeper_name | None -> ());
+      r)
 end
 
 (* Translate one OAS event into zero or one persist_* effect. *)

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -85,7 +85,7 @@ type autonomous_waiter =
     keeper_name : string;
   }
 
-let autonomous_wait_queue_mutex = Mutex.create ()
+let autonomous_wait_queue_mutex = Eio.Mutex.create ()
 
 let autonomous_wait_queue : autonomous_waiter list ref = ref []
 
@@ -94,8 +94,7 @@ let autonomous_wait_queue_next_ticket = ref 0
 let autonomous_queue_poll_sec = 0.05
 
 let with_autonomous_wait_queue f =
-  Mutex.lock autonomous_wait_queue_mutex;
-  Fun.protect ~finally:(fun () -> Mutex.unlock autonomous_wait_queue_mutex) f
+  Eio.Mutex.use_rw ~protect:true autonomous_wait_queue_mutex (fun () -> f ())
 
 let reset_autonomous_turn_queue_for_test () =
   with_autonomous_wait_queue (fun () ->

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -144,10 +144,18 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
            Keeper_keepalive.run_heartbeat_loop ~proactive_warmup_sec
              ctx meta reg.fiber_stop ~wakeup:reg.fiber_wakeup;
            (* Normal exit: stop flag was set — dispatch typed events *)
-           ignore (Keeper_registry.dispatch_event ~base_path meta.name
-             Keeper_state_machine.Stop_requested);
-           ignore (Keeper_registry.dispatch_event ~base_path meta.name
-             Keeper_state_machine.Drain_complete);
+           (match Keeper_registry.dispatch_event ~base_path meta.name
+              Keeper_state_machine.Stop_requested with
+            | Ok _ -> ()
+            | Error e ->
+                Log.Keeper.warn "supervisor: Stop_requested dispatch failed: %s"
+                  (Keeper_state_machine.transition_error_to_string e));
+           (match Keeper_registry.dispatch_event ~base_path meta.name
+              Keeper_state_machine.Drain_complete with
+            | Ok _ -> ()
+            | Error e ->
+                Log.Keeper.warn "supervisor: Drain_complete dispatch failed: %s"
+                  (Keeper_state_machine.transition_error_to_string e));
            if resolve_done `Stopped then
              publish_phase_lifecycle ~phase:Keeper_state_machine.Stopped
                meta.name "normal exit" ()
@@ -171,8 +179,12 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
              in
              let reason = Keeper_registry.failure_reason_to_string fr in
              Keeper_registry.set_failure_reason ~base_path meta.name (Some fr);
-             ignore (Keeper_registry.dispatch_event ~base_path meta.name
-               (Keeper_state_machine.Fiber_terminated { outcome = reason }));
+             (match Keeper_registry.dispatch_event ~base_path meta.name
+                (Keeper_state_machine.Fiber_terminated { outcome = reason }) with
+              | Ok _ -> ()
+              | Error e ->
+                  Log.Keeper.warn "supervisor: Fiber_terminated dispatch failed: %s"
+                    (Keeper_state_machine.transition_error_to_string e));
              let ts = Time_compat.now () in
              Keeper_registry.record_crash ~base_path
                meta.name ts reason;

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -199,7 +199,6 @@ let dashboard_governance_http_json request ~base_path : Yojson.Safe.t =
   let limit = int_query_param request "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
   let offset = int_query_param request "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
   let status_filter = None in
-  ignore (query_param request "status");
   Dashboard_governance.dashboard_json ~base_path ~limit ~offset
     ~status_filter
 

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -415,8 +415,9 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
   let message_id = Printf.sprintf "keeper-msg-%d" (now_id ()) in
   ignore (keeper_stream_send_raw writer mutex closed "retry: 1500\n\n");
   Eio.Fiber.fork ~sw (fun () ->
-      Eio.Switch.run @@ fun stream_sw ->
-      Eio.Switch.on_release stream_sw close_stream;
+      ignore
+        (Eio.Switch.run @@ fun stream_sw ->
+           Eio.Switch.on_release stream_sw close_stream;
           (* --- 1. Lifecycle: Run_started + Text_message_start --- *)
           ignore
             (keeper_stream_send_event writer mutex closed
@@ -545,6 +546,6 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
               | Eio.Cancel.Cancelled _ as e -> raise e
               | exn ->
                 send_keeper_error writer mutex closed ~thread_id ~run_id
-                  (Printexc.to_string exn)))
+                  (Printexc.to_string exn))))
 
 (** Build routes for MCP server *)

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -451,76 +451,9 @@ let handle_keeper_repair ctx args : tool_result =
       if String.trim task_spec = "" then
         (false, "task_spec is required")
       else
-        let target_mode = get_string args "target_mode" "snippet" in
-        let working_dir_arg = get_string args "working_dir" "" in
-        let plugin_id = get_string args "plugin_id" "ocaml" in
-        let target_file_opt = get_string_opt args "target_file" in
-        (* #6641 iter10 — narrow working_dir to caller's playground.
-           Default (empty arg) resolves to the caller's own playground
-           bundle root, not [Sys.getcwd ()]. Cross-keeper targets are
-           rejected. Shares the resolver with tool_repair_loop so the
-           same fix applies to both dispatchers. *)
-        match
-          resolve_playground_working_dir
-            ~agent_name:ctx.agent_name
-            ~base_path:ctx.config.base_path
-            ~working_dir_arg
-        with
-        | Error msg -> (false, msg)
-        | Ok working_dir ->
-            match
-              validate_target_file ~working_dir
-                ~target_file:target_file_opt
-            with
-            | Error msg -> (false, msg)
-            | Ok validated_target_file ->
-                  let validator_profile =
-                    get_string args "validator_profile"
-                      (if
-                         String.equal (String.lowercase_ascii target_mode)
-                           "repo"
-                       then
-                         "repo_dune_build"
-                       else
-                         "snippet_ocamlc")
-                  in
-                  let max_attempts =
-                    min 10 (max 1 (get_int args "max_attempts" 2))
-                  in
-                  let fields =
-                    [
-                      ("plugin_id", `String plugin_id);
-                      ("task_spec", `String task_spec);
-                      ("target_mode", `String target_mode);
-                      ("working_dir", `String working_dir);
-                      ("validator_profile", `String validator_profile);
-                      ( "model_label",
-                        `String
-                          (get_string args "model_label"
-                             (default_keeper_model_label meta)) );
-                      ("max_attempts", `Int max_attempts);
-                      ("artifact_session_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id));
-                    ]
-                  in
-                  let fields =
-                    match validated_target_file with
-                    | Some target_file ->
-                        ("target_file", `String target_file) :: fields
-                    | None -> fields
-                  in
-                  let fields =
-                    match get_string_opt args "source_text" with
-                    | Some source_text ->
-                        ("source_text", `String source_text) :: fields
-                    | None -> fields
-                  in
-                  let ok, body =
-                    (* Team_session_oas_bridge removed *)
-                    ignore (ctx.sw, ctx.clock, ctx.config, fields);
-                    (false, {|{"error":"team session oas bridge removed"}|})
-                  in
-                  invalidate_status_cache meta.name;
-                  (ok, annotate_keeper_repair_json ~keeper_name:meta.name body)
+        let body = {|{"error":"team session oas bridge removed"}|} in
+        invalidate_status_cache meta.name;
+        (false, annotate_keeper_repair_json ~keeper_name:meta.name body)
 
 let handle_keeper_down ctx args : tool_result =
   invalidate_keeper_list_cache ();

--- a/test/test_graphql_api_coverage.ml
+++ b/test/test_graphql_api_coverage.ml
@@ -135,30 +135,6 @@ let test_take_preserves_order () =
   check (list int) "order preserved" [1; 2; 3] result
 
 (* ============================================================
-   Type Tests
-   ============================================================ *)
-
-let test_page_info_has_next_page () =
-  let _ : bool = true in
-  ()
-
-let test_page_info_end_cursor () =
-  let _ : string option = None in
-  ()
-
-let test_edge_node () =
-  let _ : int = 42 in
-  ()
-
-let test_edge_cursor () =
-  let _ : string = "cursor" in
-  ()
-
-let test_connection_total_count () =
-  let _ : int = 100 in
-  ()
-
-(* ============================================================
    Test Runners
    ============================================================ *)
 
@@ -197,12 +173,5 @@ let () =
       test_case "zero" `Quick test_take_zero;
       test_case "negative" `Quick test_take_negative;
       test_case "order" `Quick test_take_preserves_order;
-    ];
-    "types", [
-      test_case "page_info has_next_page" `Quick test_page_info_has_next_page;
-      test_case "page_info end_cursor" `Quick test_page_info_end_cursor;
-      test_case "edge node" `Quick test_edge_node;
-      test_case "edge cursor" `Quick test_edge_cursor;
-      test_case "connection total_count" `Quick test_connection_total_count;
     ];
   ]

--- a/test/test_mcp_server_eio_coverage.ml
+++ b/test/test_mcp_server_eio_coverage.ml
@@ -8,18 +8,6 @@ open Alcotest
 module Mcp_server_eio = Masc_mcp.Mcp_server_eio
 module Mcp_server = Masc_mcp.Mcp_server
 (* ============================================================
-   Type Tests
-   ============================================================ *)
-
-let test_server_state_type () =
-  let _ : Mcp_server_eio.server_state option = None in
-  ()
-
-let test_jsonrpc_request_type () =
-  let _ : Mcp_server_eio.jsonrpc_request option = None in
-  ()
-
-(* ============================================================
    is_jsonrpc_v2 Tests
    ============================================================ *)
 
@@ -471,10 +459,6 @@ let test_mcp_session_roundtrip () =
 
 let () =
   run "MCP Server Eio Coverage" [
-    "types", [
-      test_case "server_state" `Quick test_server_state_type;
-      test_case "jsonrpc_request" `Quick test_jsonrpc_request_type;
-    ];
     "is_jsonrpc_v2", [
       test_case "valid" `Quick test_is_jsonrpc_v2_valid;
       test_case "invalid" `Quick test_is_jsonrpc_v2_invalid;

--- a/test/test_orchestrator_coverage.ml
+++ b/test/test_orchestrator_coverage.ml
@@ -67,40 +67,6 @@ let test_load_config_port_valid () =
   check bool "valid port" true (cfg.port > 0 && cfg.port < 65536)
 
 (* ============================================================
-   config Record Tests
-   ============================================================ *)
-
-let test_config_check_interval_type () =
-  let cfg = Orchestrator.default_config in
-  let _ : float = cfg.check_interval_s in
-  ()
-
-let test_config_min_priority_type () =
-  let cfg = Orchestrator.default_config in
-  let _ : int = cfg.min_priority in
-  ()
-
-let test_config_agent_timeout_type () =
-  let cfg = Orchestrator.default_config in
-  let _ : int = cfg.agent_timeout_s in
-  ()
-
-let test_config_orchestrator_agent_type () =
-  let cfg = Orchestrator.default_config in
-  let _ : string = cfg.orchestrator_agent in
-  ()
-
-let test_config_enabled_type () =
-  let cfg = Orchestrator.default_config in
-  let _ : bool = cfg.enabled in
-  ()
-
-let test_config_port_type () =
-  let cfg = Orchestrator.default_config in
-  let _ : int = cfg.port in
-  ()
-
-(* ============================================================
    make_orchestrator_prompt Tests
    ============================================================ *)
 
@@ -261,14 +227,6 @@ let () =
       test_case "timeout positive" `Quick test_load_config_agent_timeout_positive;
       test_case "agent nonempty" `Quick test_load_config_agent_nonempty;
       test_case "port valid" `Quick test_load_config_port_valid;
-    ];
-    "config_types", [
-      test_case "check_interval_s" `Quick test_config_check_interval_type;
-      test_case "min_priority" `Quick test_config_min_priority_type;
-      test_case "agent_timeout_s" `Quick test_config_agent_timeout_type;
-      test_case "orchestrator_agent" `Quick test_config_orchestrator_agent_type;
-      test_case "enabled" `Quick test_config_enabled_type;
-      test_case "port" `Quick test_config_port_type;
     ];
     "make_orchestrator_prompt", [
       test_case "basic" `Quick test_make_orchestrator_prompt_basic;


### PR DESCRIPTION
## Summary

Comprehensive OCaml 5.x best-practice audit across the codebase.

### Changes

#### 1. Concurrency & Atomic Safety
- Convert module-level `ref` to `Atomic.t` for cross-fiber state (level4_config, otel_spans, prometheus, tool_dispatch, transport_bridge, channel_gate_metrics, http_server_eio, validation, cdal)
- Re-raise `Eio.Cancel.Cancelled` instead of swallowing in `read_recent`
- Replace signal-handler shared refs with `Atomic.t`
- Use `fold_left` accumulators instead of `ref` in pure functions (agent_tool_surfaces, config, text_similarity)
- Replace `List.length` with O(1) empty list checks

#### 2. Silent Failure Elimination
- Eliminate wildcard `catch-all` exception swallowing in metrics and telemetry paths
- Stop ignoring `Result` returns (`let _ = ...`) across coord and verification paths
- Fix `Result.discard` patterns in dashboard, keeper, and tool modules

#### 3. Type Safety & Parse Don't Validate
- Introduce `sidecar_id` variant type (replace string dispatch in sidecar routes)
- Replace generic `Failure` with `Lexical_error` in bash lexer
- Remove `ignore` on stream send results in keeper stream

#### 4. API Cleanup
- Remove `get_server_state` and its `Failure` raise from HTTP pages
- Migrate h2 gateway to `get_server_state_result`
- Replace ref accumulation with `In_channel.input_lines` in model inference metrics

#### 5. Mutex Migration (Eio Fiber Contexts)
- Migrate `Stdlib.Mutex` to `Eio.Mutex` in fiber contexts:
  - `cascade_client_capacity.ml`, `cascade_config.ml`, `cascade_health_tracker.ml`
  - `keeper_approval_queue.ml`, `keeper_compact_audit.ml`, `keeper_keepalive.ml`
  - `cascade_client_capacity_history.ml`
- Fix exception-unsafe manual lock/unlock in `keeper_compact_audit.Pending`

#### 6. Fake Test Removal
- Remove type-check-only fake tests from:
  - `test_orchestrator_coverage.ml`
  - `test_graphql_api_coverage.ml`
  - `test_mcp_server_eio_coverage.ml`
  - `test_env_config_coverage.ml`

#### 7. Build Fixes
- Fix `String.contains` substring misuse (3 files)
- Fix Log submodule typo `Log.Board` -> `Log.BoardLog`
- Resolve pre-existing compilation errors across config, dashboard, provider
- Fix OCaml syntax errors in `mcp_server_eio_execute.ml` and `keeper_stream.ml`
- Eliminate string sentinel in `a2a_tools.ml`

### Verification
- `dune build @check` passes
- Full `dune runtest` in progress

### Stats
443 files changed, +4,606 / -19,871 lines