### PR TITLE
fix(agent_tool_surfaces): deduplicate masc_spawn schema to SSOT

### DIFF
--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -229,27 +229,9 @@ let local_worker_run_schemas : Types.tool_schema list =
   ]
 
 let local_worker_spawn_schemas : Types.tool_schema list =
-  [
-    {
-      Types.name = "masc_spawn";
-      description = "Spawn a new agent to execute a specific task with configurable model and prompt. Use when work decomposition requires parallel execution by a dedicated worker.";
-      input_schema =
-        `Assoc
-          [
-            ("type", `String "object");
-            ( "properties",
-              `Assoc
-                [
-                  ("agent_name", `Assoc [ ("type", `String "string") ]);
-                  ("model", `Assoc [ ("type", `String "string") ]);
-                  ("prompt", `Assoc [ ("type", `String "string") ]);
-                  ("timeout_seconds", `Assoc [ ("type", `String "integer") ]);
-                  ("working_dir", `Assoc [ ("type", `String "string") ]);
-                ] );
-            ("required", `List [ `String "agent_name"; `String "prompt" ]);
-          ];
-    };
-  ]
+  List.filter
+    (fun (schema : Types.tool_schema) -> schema.name = "masc_spawn")
+    Tool_schemas_inline_infra.schemas
 
 let select_public_local_worker_schemas () =
   let wanted = local_worker_public_tool_names in

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -734,7 +734,8 @@ end
 module KeeperCascade = struct
   (** Comma-separated provider kind allowlist for every keeper cascade call.
       Values are OAS [Provider_config.string_of_provider_kind]:
-      [ollama], [glm], [anthropic], [gemini], [openai_compat], [claude_code].
+      [ollama], [glm], [anthropic], [gemini], [openai_compat], [claude_code],
+      [kimi], [kimi_cli], [gemini_cli], [codex_cli].
       Matching is case-insensitive; empty entries are dropped.
 
       Semantics: when set, keeper turns pass this list as [provider_filter]


### PR DESCRIPTION
## Summary
Replace inline `local_worker_spawn_schemas` definition with filtered reference to `Tool_schemas_inline_infra.schemas`.

The inline copy had drifted from SSOT:
- Missing `default: 300` on `timeout_seconds`
- Missing per-property `description` fields
- Different description string

## Pattern
Matches existing deduplication:
- `local_worker_internal_schemas` → `Tool_schemas_coord_core.schemas`
- `local_worker_worktree_schemas` → `Tool_schemas_worktree.schemas`

## Verification
- `dune build @install` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)