### PR TITLE
feat(exec): P14 output parsers + CJK-safe UTF-8 truncation

### DIFF
--- a/lib/exec/exec_buffer.ml
+++ b/lib/exec/exec_buffer.ml
@@ -88,6 +88,41 @@ let add_bytes t buf off len =
 let add_string t s =
   add_bytes_inner t (Bytes.unsafe_of_string s) 0 (String.length s)
 
+(** Walk backwards from [pos] to find the start of the last complete
+    UTF-8 character that begins at or before [pos].  Continuation
+    bytes have the bit pattern 10xxxxxx (0x80..0xBF); a leading byte
+    never matches, so the scan stops as soon as one is found. *)
+(** Length of the UTF-8 character whose leading byte is at position [i].
+    0xxxxxxx → 1 byte (ASCII)
+    110xxxxx → 2 bytes
+    1110xxxx → 3 bytes
+    11110xxx → 4 bytes *)
+let utf8_char_len s i =
+  let b = Char.code s.[i] in
+  if b land 0x80 = 0 then 1
+  else if b land 0xE0 = 0xC0 then 2
+  else if b land 0xF0 = 0xE0 then 3
+  else 4
+
+let utf8_find_char_start s pos =
+  let rec loop i =
+    if i <= 0 then 0
+    else if Char.code s.[i] land 0xC0 <> 0x80 then i
+    else loop (i - 1)
+  in
+  loop (min pos (String.length s - 1))
+
+(** Truncate [s] to at most [max_bytes], breaking only at UTF-8
+    character boundaries.  Returns [s] unchanged if it already fits. *)
+let utf8_truncate s max_bytes =
+  let len = String.length s in
+  if len <= max_bytes then s
+  else
+    let boundary = utf8_find_char_start s (max_bytes - 1) in
+    let char_end = boundary + utf8_char_len s boundary in
+    if char_end <= max_bytes then String.sub s 0 char_end
+    else String.sub s 0 boundary
+
 let head t = Buffer.contents t.head_buf
 
 let tail t =
@@ -124,5 +159,15 @@ let render t =
     head_s ^ extra
   else
     let dropped = bytes_dropped t in
+    let head_s = utf8_truncate (head t) t.head_cap in
+    let tail_raw = tail t in
+    let tail_s =
+      if String.length tail_raw > t.tail_cap then
+        let skip = String.length tail_raw - t.tail_cap in
+        utf8_truncate
+          (String.sub tail_raw skip (String.length tail_raw - skip))
+          t.tail_cap
+      else tail_raw
+    in
     Printf.sprintf "%s\n...(truncated %d bytes)...\n%s"
-      (head t) dropped (tail t)
+      head_s dropped tail_s

--- a/lib/exec/exec_buffer.mli
+++ b/lib/exec/exec_buffer.mli
@@ -40,4 +40,13 @@ val render : t -> string
     [head ^ separator ^ tail] where separator is a single-line
     [\n...(truncated N bytes)...\n] marker.  The separator is only
     present when [bytes_dropped > 0] so golden tests on small outputs
-    remain byte-identical to the raw stream. *)
+    remain byte-identical to the raw stream.
+
+    When truncation occurs, both head and tail are trimmed to UTF-8
+    character boundaries so CJK and emoji output is never split mid-byte. *)
+
+val utf8_truncate : string -> int -> string
+(** [utf8_truncate s max_bytes] returns the prefix of [s] that fits
+    within [max_bytes], breaking only at UTF-8 character boundaries.
+    Returns [s] unchanged if it already fits.  Safe for CJK, emoji,
+    and other multi-byte sequences. *)

--- a/lib/exec/output_parse.ml
+++ b/lib/exec/output_parse.ml
@@ -219,6 +219,161 @@ let parse_dune_test output =
            ("skipped", `Int !skipped);
          ])
 
+(* --- gh pr list (tabular) --- *)
+
+let parse_gh_pr_list output =
+  let lines = String.split_on_char '\n' (String.trim output) in
+  match lines with
+  | [] -> None
+  | header :: body ->
+      let cols =
+        let h = String.trim header in
+        if String.length h = 0 then [||]
+        else Array.of_list (String.split_on_char '\t' h)
+      in
+      if Array.length cols < 2 then None
+      else
+        let prs = ref [] in
+        List.iter
+          (fun line ->
+            let fields = String.split_on_char '\t' (String.trim line) in
+            match fields with
+            | [] -> ()
+            | number :: rest ->
+                let n = String.trim number in
+                if n <> "" && String.for_all (fun c -> c >= '0' && c <= '9') n then
+                  let title =
+                    match rest with [] -> "" | t :: _ -> String.trim t
+                  in
+                  let state =
+                    let state_idx = Array.length cols - 1 in
+                    match List.nth_opt rest (state_idx - 1) with
+                    | Some s -> String.trim s
+                    | None -> ""
+                  in
+                  prs := `Assoc [
+                    ("number", `String n);
+                    ("title", `String title);
+                    ("state", `String state);
+                  ] :: !prs)
+          body;
+        let n = List.length !prs in
+        if n = 0 then None
+        else Some (`Assoc [("prs", `List (List.rev !prs)); ("count", `Int n)])
+
+(* --- pytest output --- *)
+
+let parse_pytest output =
+  let lines = String.split_on_char '\n' (String.trim output) in
+  let passed = ref 0 and failed = ref 0
+  and errors = ref 0 and skipped = ref 0 in
+  List.iter
+    (fun line ->
+      let l = String.trim line in
+      if String.length l < 5 then ()
+      else
+        (* Summary line: "X passed, Y failed, Z errors, W skipped" *)
+        let extract_count prefix =
+          match Re.execp (Re.compile (Re.Pcre.re
+            (Printf.sprintf "(\\d+) %s" prefix))) l with
+          | true ->
+              (match Re.exec (Re.compile (Re.Pcre.re
+                (Printf.sprintf "(\\d+) %s" prefix))) l with
+               | exception _ -> ()
+               | m ->
+                   match int_of_string_opt (Re.Group.get m 1) with
+                   | Some n ->
+                       if prefix = "passed" then passed := n
+                       else if prefix = "failed" then failed := n
+                       else if prefix = "error" then errors := n
+                       else if prefix = "skipped" then skipped := n
+                       else ()
+                   | None -> ())
+          | false -> ()
+        in
+        if String_util.contains_substring l "passed"
+           || String_util.contains_substring l "failed"
+           || String_util.contains_substring l "error"
+        then begin
+          extract_count "passed";
+          extract_count "failed";
+          extract_count "error";
+          extract_count "skipped"
+        end)
+    lines;
+  let total = !passed + !failed + !errors + !skipped in
+  if total = 0 then None
+  else Some (`Assoc [
+    ("passed", `Int !passed);
+    ("failed", `Int !failed);
+    ("errors", `Int !errors);
+    ("skipped", `Int !skipped);
+  ])
+
+(* --- cargo test output --- *)
+
+let parse_cargo_test output =
+  let lines = String.split_on_char '\n' (String.trim output) in
+  let passed = ref 0 and failed = ref 0 in
+  List.iter
+    (fun line ->
+      let l = String.trim line in
+      if String_util.contains_substring l "test result:" then begin
+        (* "test result: ok. X passed; 0 failed; ..." *)
+        let extract re =
+          match Re.exec (Re.compile (Re.Pcre.re re)) l with
+          | exception _ -> 0
+          | m ->
+              match int_of_string_opt (Re.Group.get m 1) with
+              | Some n -> n
+              | None -> 0
+        in
+        passed := !passed + extract "(\\d+) passed";
+        failed := !failed + extract "(\\d+) failed"
+      end)
+    lines;
+  let total = !passed + !failed in
+  if total = 0 then None
+  else Some (`Assoc [
+    ("passed", `Int !passed);
+    ("failed", `Int !failed);
+  ])
+
+(* --- UTF-8 boundary helper --- *)
+
+(** Length of the UTF-8 character whose leading byte is at position [i]. *)
+let utf8_char_len s i =
+  let b = Char.code s.[i] in
+  if b land 0x80 = 0 then 1
+  else if b land 0xE0 = 0xC0 then 2
+  else if b land 0xF0 = 0xE0 then 3
+  else 4
+
+(** Find the start offset of the last complete UTF-8 character
+    that begins at or before byte position [pos] in [s].
+    UTF-8 continuation bytes have the pattern 10xxxxxx (0x80..0xBF).
+    A leading byte never matches that pattern, so we walk backwards
+    until we find one.  Returns [pos] if [pos] is already at a
+    character boundary. *)
+let utf8_find_char_start s pos =
+  let rec loop i =
+    if i <= 0 then 0
+    else if Char.code s.[i] land 0xC0 <> 0x80 then i
+    else loop (i - 1)
+  in
+  loop (min pos (String.length s - 1))
+
+(** Truncate string [s] to at most [max_bytes], breaking only at
+    UTF-8 character boundaries.  Returns the safe prefix. *)
+let utf8_truncate s max_bytes =
+  let len = String.length s in
+  if len <= max_bytes then s
+  else
+    let boundary = utf8_find_char_start s (max_bytes - 1) in
+    let char_end = boundary + utf8_char_len s boundary in
+    if char_end <= max_bytes then String.sub s 0 char_end
+    else String.sub s 0 boundary
+
 (* --- dispatcher --- *)
 
 type parser_kind =
@@ -228,6 +383,9 @@ type parser_kind =
   | Wc_lines
   | Ls_long
   | Dune_test
+  | Gh_pr_list
+  | Pytest
+  | Cargo_test
 
 let git_option_requires_arg = function
   | "-C" | "-c" | "--git-dir" | "--work-tree" | "--namespace" | "--exec-path"
@@ -290,11 +448,29 @@ let classify_for_parsing ~cmd ~_output =
           if List.exists (fun t -> t = "runtest" || t = "test") rest then
             Some Dune_test
           else None
+      | "gh" ->
+          (match rest with
+           | "pr" :: rest' ->
+               if List.exists (fun t -> t = "list") rest' then
+                 Some Gh_pr_list
+               else None
+           | _ -> None)
+      | "pytest" | "py.test" ->
+          Some Pytest
+      | "python" | "python3" ->
+          if List.exists (fun t -> t = "pytest") rest then
+            Some Pytest
+          else None
+      | "cargo" ->
+          if List.exists (fun t -> t = "test") rest then
+            Some Cargo_test
+          else None
       | _ -> None
 
 let parser_allows_nonzero = function
-  | Dune_test -> true
-  | Git_status | Git_log_oneline | Git_diff_stat | Wc_lines | Ls_long -> false
+  | Dune_test | Pytest | Cargo_test -> true
+  | Git_status | Git_log_oneline | Git_diff_stat | Wc_lines
+  | Ls_long | Gh_pr_list -> false
 
 let try_parse ~cmd ~status ~output =
   match classify_for_parsing ~cmd ~_output:output with
@@ -314,3 +490,6 @@ let try_parse ~cmd ~status ~output =
         | Wc_lines -> parse_wc_lines output
         | Ls_long -> parse_ls_long output
         | Dune_test -> parse_dune_test output
+        | Gh_pr_list -> parse_gh_pr_list output
+        | Pytest -> parse_pytest output
+        | Cargo_test -> parse_cargo_test output

--- a/lib/exec/output_parse.mli
+++ b/lib/exec/output_parse.mli
@@ -14,3 +14,8 @@ val try_parse :
 (** Top-level dispatcher.  Examines [cmd] to select a parser, then
     feeds [output] through it.  Returns [None] when no parser matches
     or when the output does not conform to the expected format. *)
+
+val utf8_truncate : string -> int -> string
+(** [utf8_truncate s max_bytes] truncates [s] at a UTF-8 character
+    boundary.  Exported for consumers that need safe truncation
+    outside of [Exec_buffer.render]. *)

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -2,6 +2,6 @@
  (names test_exec_types test_capability_check test_bash_parser
         test_approval_policy test_approval_context test_approval_config
         test_exec_gate_runtime test_exec_semantic test_exec_buffer
-        test_exec_run test_exec_run_json test_exit_code)
+        test_exec_run test_exec_run_json test_exit_code test_output_parse_p14)
  (libraries masc_exec masc_exec_bash_parser masc_process
             masc_core alcotest eio eio_main yojson unix base re))

--- a/lib/exec/test/test_output_parse_p14.ml
+++ b/lib/exec/test/test_output_parse_p14.ml
@@ -1,0 +1,170 @@
+(* P14 tests: new parsers + UTF-8 boundary truncation *)
+
+let ck_int ctx expected actual = Alcotest.(check int) ctx expected actual
+let ck_str ctx expected actual = Alcotest.(check string) ctx expected actual
+
+(* --- UTF-8 truncation tests --- *)
+
+let test_utf8_ascii () =
+  let s = "hello world" in
+  let truncated = Masc_exec.Exec_buffer.utf8_truncate s 5 in
+  ck_str "ascii" "hello" truncated
+
+let test_utf8_korean () =
+  (* "안녕하세요" = 5 Korean chars, each 3 bytes = 15 bytes total *)
+  let s = "안녕하세요" in
+  ck_int "korean_bytes" 15 (String.length s);
+  (* Truncate at 7 bytes — would split "하" (bytes 6-8).
+     Should yield "안녕" (6 bytes) to avoid splitting. *)
+  let truncated = Masc_exec.Exec_buffer.utf8_truncate s 7 in
+  ck_int "korean_truncated_bytes" 6 (String.length truncated);
+  ck_str "korean_truncated" "안녕" truncated
+
+let test_utf8_mixed () =
+  (* "hi안" = 2 ASCII + 1 Korean = 2 + 3 = 5 bytes *)
+  let s = "hi안" in
+  ck_int "mixed_bytes" 5 (String.length s);
+  (* Truncate at 4 bytes — "hi" + incomplete "안" *)
+  let truncated = Masc_exec.Exec_buffer.utf8_truncate s 4 in
+  ck_str "mixed_truncated" "hi" truncated
+
+let test_utf8_no_truncation () =
+  let s = "abc" in
+  let truncated = Masc_exec.Exec_buffer.utf8_truncate s 10 in
+  ck_str "no_trunc" "abc" truncated
+
+let test_utf8_emoji () =
+  (* "🎉" = U+1F389 = 4 bytes in UTF-8 *)
+  let s = "hi🎉" in
+  ck_int "emoji_bytes" 6 (String.length s);
+  let truncated = Masc_exec.Exec_buffer.utf8_truncate s 3 in
+  ck_str "emoji_truncated" "hi" truncated
+
+(* --- gh pr list parser tests --- *)
+
+let test_gh_pr_list_basic () =
+  let output = "NUMBER\tTITLE\tSTATE\n123\tFix bug\tOPEN\n456\tAdd feature\tMERGED\n" in
+  (match Masc_exec.Output_parse.try_parse
+     ~cmd:"gh pr list"
+     ~status:(Unix.WEXITED 0)
+     ~output
+   with
+   | None -> Alcotest.fail "gh pr list should parse"
+   | Some json ->
+     (match json with
+      | `Assoc l ->
+        let count = List.assoc_opt "count" l in
+        (match count with
+         | Some (`Int 2) -> ()
+         | v -> Alcotest.fail (Printf.sprintf "expected count 2, got %s"
+             (Yojson.Safe.to_string (Option.value ~default:(`String "none") v))))
+      | _ -> Alcotest.fail "expected assoc"))
+
+let test_gh_pr_list_empty () =
+  let output = "NUMBER\tTITLE\tSTATE\n" in
+  (match Masc_exec.Output_parse.try_parse
+     ~cmd:"gh pr list"
+     ~status:(Unix.WEXITED 0)
+     ~output
+   with
+   | None -> ()  (* no PRs = None, correct *)
+   | Some _ -> Alcotest.fail "empty gh pr list should return None")
+
+(* --- pytest parser tests --- *)
+
+let test_pytest_passed_failed () =
+  let output = "test_api.py ....F.\n\n2 passed, 1 failed in 1.23s\n" in
+  (match Masc_exec.Output_parse.try_parse
+     ~cmd:"pytest"
+     ~status:(Unix.WEXITED 1)
+     ~output
+   with
+   | None -> Alcotest.fail "pytest should parse"
+   | Some json ->
+     (match json with
+      | `Assoc l ->
+        (match List.assoc_opt "passed" l, List.assoc_opt "failed" l with
+         | Some (`Int 2), Some (`Int 1) -> ()
+         | _ -> Alcotest.fail "pytest counts mismatch")
+      | _ -> Alcotest.fail "expected assoc"))
+
+let test_pytest_all_passed () =
+  let output = "test_main.py ....\n4 passed in 0.5s\n" in
+  (match Masc_exec.Output_parse.try_parse
+     ~cmd:"pytest"
+     ~status:(Unix.WEXITED 0)
+     ~output
+   with
+   | None -> Alcotest.fail "pytest should parse all passed"
+   | Some json ->
+     (match json with
+      | `Assoc l ->
+        (match List.assoc_opt "passed" l with
+         | Some (`Int 4) -> ()
+         | _ -> Alcotest.fail "pytest passed count mismatch")
+      | _ -> Alcotest.fail "expected assoc"))
+
+(* --- cargo test parser tests --- *)
+
+let test_cargo_test_ok () =
+  let output = "running 3 tests\ntest test_a ... ok\ntest test_b ... ok\ntest test_c ... ok\n\ntest result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n" in
+  (match Masc_exec.Output_parse.try_parse
+     ~cmd:"cargo test"
+     ~status:(Unix.WEXITED 0)
+     ~output
+   with
+   | None -> Alcotest.fail "cargo test should parse"
+   | Some json ->
+     (match json with
+      | `Assoc l ->
+        (match List.assoc_opt "passed" l, List.assoc_opt "failed" l with
+         | Some (`Int 3), Some (`Int 0) -> ()
+         | _ -> Alcotest.fail "cargo test counts mismatch")
+      | _ -> Alcotest.fail "expected assoc"))
+
+let test_cargo_test_failures () =
+  let output = "test result: FAILED. 2 passed; 1 failed; 0 ignored\n" in
+  (match Masc_exec.Output_parse.try_parse
+     ~cmd:"cargo test"
+     ~status:(Unix.WEXITED 101)
+     ~output
+   with
+   | None -> Alcotest.fail "cargo test should parse with failures"
+   | Some json ->
+     (match json with
+      | `Assoc l ->
+        (match List.assoc_opt "passed" l, List.assoc_opt "failed" l with
+         | Some (`Int 2), Some (`Int 1) -> ()
+         | _ -> Alcotest.fail "cargo test failure counts mismatch")
+      | _ -> Alcotest.fail "expected assoc"))
+
+(* --- existing parsers still work --- *)
+
+let test_git_status_unchanged () =
+  let output = "M lib/foo.ml\n?? lib/bar.ml\n" in
+  (match Masc_exec.Output_parse.try_parse
+     ~cmd:"git status --porcelain"
+     ~status:(Unix.WEXITED 0)
+     ~output
+   with
+   | None -> Alcotest.fail "git status should still parse"
+   | Some (`Assoc l) ->
+     (match List.assoc_opt "untracked" l with
+      | Some (`List xs) -> ck_int "untracked_count" 1 (List.length xs)
+      | _ -> Alcotest.fail "untracked missing")
+   | Some _ -> Alcotest.fail "expected assoc")
+
+let () =
+  test_utf8_ascii ();
+  test_utf8_korean ();
+  test_utf8_mixed ();
+  test_utf8_no_truncation ();
+  test_utf8_emoji ();
+  test_gh_pr_list_basic ();
+  test_gh_pr_list_empty ();
+  test_pytest_passed_failed ();
+  test_pytest_all_passed ();
+  test_cargo_test_ok ();
+  test_cargo_test_failures ();
+  test_git_status_unchanged ();
+  print_endline "test_output_parse_p14: 12/12 passed"


### PR DESCRIPTION
## Summary
- Add 3 structured output parsers: `gh pr list`, `pytest`, `cargo test`
- Fix `Exec_buffer.render` UTF-8 truncation — head/tail now break only at character boundaries, preventing mojibake for CJK (3-byte) and emoji (4-byte) characters
- Add `utf8_truncate` helper to both `Exec_buffer` and `Output_parse` (no circular dependency)

## Test plan
- [x] 12 new unit tests: 5 UTF-8 boundary (ASCII/Korean/mixed/emoji/no-trunc), 6 parser (gh pr list basic+empty, pytest passed+failed, cargo test ok+failures), 1 regression (git status unchanged)
- [x] All existing exec tests pass (test_exec_buffer, test_exec_run, test_exec_semantic, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)