### PR TITLE
refactor(lib): OCaml best-practice audit batch 2 — silent failures and exceptions

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -178,61 +178,63 @@ let run_docker_shell_command_with_status
           | Network_inherit -> ([], network_mode_to_string network_mode)
       in
       let cred_root = "/tmp/keeper-creds" in
-      let cred_mounts, cred_envs =
+      let cred_result =
         if not git_creds_enabled then
-          [], []
+          Ok ([], [])
         else
-          let binding_result =
-            Keeper_gh_env.keeper_binding config ~keeper_name:meta.name
-          in
-          let gh_creds =
-            match binding_result with
-            | Ok { gh_config_dir = Some dir; _ } -> dir
-            | Ok { gh_config_dir = None; _ } ->
-                Env_config_keeper.KeeperSandbox.gh_creds_host_path ()
-            | Error err -> raise (Failure err)
-          in
-          let gitconfig = Env_config_keeper.KeeperSandbox.gitconfig_host_path () in
-          let ssh_dir = Env_config_keeper.KeeperSandbox.ssh_dir_host_path () in
-          let mounts =
-            optional_ro_mount ~host:gh_creds
-              ~container:(Filename.concat cred_root ".config/gh")
-            @ optional_ro_mount ~host:gitconfig
-                ~container:(Filename.concat cred_root ".gitconfig")
-            @ optional_ro_mount ~host:ssh_dir
-                ~container:(Filename.concat cred_root ".ssh")
-          in
-          let git_author_name, git_author_email =
-            match binding_result with
-            | Ok { github_identity = Some id; git_identity_mode = "github_identity"; _ } ->
-                id, id ^ "@users.noreply.github.com"
-            | _ ->
-                ( Keeper_identity.keeper_git_author
-                    ~keeper_name:meta.name,
-                  Keeper_identity.keeper_git_email
-                    ~keeper_name:meta.name )
-          in
-          let git_identity_env ~name ~email =
-            [
-              "-e"; "GIT_AUTHOR_NAME=" ^ name;
-              "-e"; "GIT_AUTHOR_EMAIL=" ^ email;
-              "-e"; "GIT_COMMITTER_NAME=" ^ name;
-              "-e"; "GIT_COMMITTER_EMAIL=" ^ email;
-            ]
-          in
-          let envs =
-            [
-              "-e"; "HOME=" ^ cred_root;
-              "-e"; "GH_CONFIG_DIR=" ^ Filename.concat cred_root ".config/gh";
-              "-e"; "GIT_CONFIG_GLOBAL=" ^ Filename.concat cred_root ".gitconfig";
-              "-e"; "GIT_CONFIG_COUNT=1";
-              "-e"; "GIT_CONFIG_KEY_0=safe.directory";
-              "-e"; "GIT_CONFIG_VALUE_0=*";
-            ]
-            @ git_identity_env ~name:git_author_name ~email:git_author_email
-          in
-          mounts, envs
+          match Keeper_gh_env.keeper_binding config ~keeper_name:meta.name with
+          | Error err -> Error err
+          | Ok binding ->
+            let gh_creds =
+              match binding.gh_config_dir with
+              | Some dir -> dir
+              | None ->
+                  Env_config_keeper.KeeperSandbox.gh_creds_host_path ()
+            in
+            let gitconfig = Env_config_keeper.KeeperSandbox.gitconfig_host_path () in
+            let ssh_dir = Env_config_keeper.KeeperSandbox.ssh_dir_host_path () in
+            let mounts =
+              optional_ro_mount ~host:gh_creds
+                ~container:(Filename.concat cred_root ".config/gh")
+              @ optional_ro_mount ~host:gitconfig
+                  ~container:(Filename.concat cred_root ".gitconfig")
+              @ optional_ro_mount ~host:ssh_dir
+                  ~container:(Filename.concat cred_root ".ssh")
+            in
+            let git_author_name, git_author_email =
+              match binding with
+              | { github_identity = Some id; git_identity_mode = "github_identity"; _ } ->
+                  id, id ^ "@users.noreply.github.com"
+              | _ ->
+                  ( Keeper_identity.keeper_git_author
+                      ~keeper_name:meta.name,
+                    Keeper_identity.keeper_git_email
+                      ~keeper_name:meta.name )
+            in
+            let git_identity_env ~name ~email =
+              [
+                "-e"; "GIT_AUTHOR_NAME=" ^ name;
+                "-e"; "GIT_AUTHOR_EMAIL=" ^ email;
+                "-e"; "GIT_COMMITTER_NAME=" ^ name;
+                "-e"; "GIT_COMMITTER_EMAIL=" ^ email;
+              ]
+            in
+            let envs =
+              [
+                "-e"; "HOME=" ^ cred_root;
+                "-e"; "GH_CONFIG_DIR=" ^ Filename.concat cred_root ".config/gh";
+                "-e"; "GIT_CONFIG_GLOBAL=" ^ Filename.concat cred_root ".gitconfig";
+                "-e"; "GIT_CONFIG_COUNT=1";
+                "-e"; "GIT_CONFIG_KEY_0=safe.directory";
+                "-e"; "GIT_CONFIG_VALUE_0=*";
+              ]
+              @ git_identity_env ~name:git_author_name ~email:git_author_email
+            in
+            Ok (mounts, envs)
       in
+      match cred_result with
+      | Error err -> sandbox_error err
+      | Ok (cred_mounts, cred_envs) ->
       let ssh_auth_sock = Sys.getenv_opt "SSH_AUTH_SOCK" in
       let ssh_auth_mount, ssh_auth_env =
         let empty = ([], []) in

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -69,7 +69,8 @@ let stream_post_sse_start ~deps ~origin ~session_id ~protocol_version
   let response = Httpun.Response.create ~headers `OK in
   let writer = Httpun.Reqd.respond_with_streaming reqd response in
   let info = make_inline_sse_conn ~session_id writer in
-  ignore (send_raw info (sse_prime_event ()));
+  if not (send_raw info (sse_prime_event ())) then
+    Log.Server.debug "SSE prime send failed for session %s" info.session_id;
   info
 
 let spawn_post_sse_keepalive ~sw ~clock info =
@@ -84,7 +85,9 @@ let spawn_post_sse_keepalive ~sw ~clock info =
           if info.closed then
             close_sse_conn info
           else if not !(info.stop) then
-            ignore (send_raw info ": keepalive\n\n");
+            if not (send_raw info ": keepalive\n\n") then
+              Log.Server.debug "SSE keepalive send failed for session %s"
+                info.session_id;
           loop ())
       in
       try loop ()
@@ -95,9 +98,10 @@ let spawn_post_sse_keepalive ~sw ~clock info =
 let stream_post_sse_finish info = close_sse_conn info
 
 let stream_post_sse_json info (json : Yojson.Safe.t) =
-  ignore
-    (send_raw info
-       (Sse.format_event ~event_type:"message" (Yojson.Safe.to_string json)))
+  if not (send_raw info
+            (Sse.format_event ~event_type:"message" (Yojson.Safe.to_string json)))
+  then
+    Log.Server.debug "SSE json send failed for session %s" info.session_id
 
 let should_stream_post_tools_call request body_str accept_mode =
   should_use_sse_for_body request body_str accept_mode
@@ -552,7 +556,9 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
           let push event =
             match !info_ref with
             | None -> ()
-            | Some info -> ignore (send_raw info event)
+            | Some info ->
+                if not (send_raw info event) then
+                  Log.Server.debug "SSE push failed for session %s" info.session_id
           in
           let client_id, event_stream, evicted =
             Sse.register ~kind:sse_kind session_id ~push
@@ -573,18 +579,25 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
           in
           info_ref := Some info;
           register_sse_conn ~session_id ~info;
-          ignore (send_raw info (sse_prime_event ()));
+          if not (send_raw info (sse_prime_event ())) then
+            Log.Server.debug "SSE prime send failed for session %s" info.session_id;
           (match legacy_messages_endpoint with
           | None -> ()
           | Some f ->
               let endpoint_url = f session_id in
-              ignore
-                (send_raw info
-                   (Sse.format_event ~event_type:"endpoint" endpoint_url)));
+              if not (send_raw info
+                        (Sse.format_event ~event_type:"endpoint" endpoint_url))
+              then
+                Log.Server.debug "SSE endpoint send failed for session %s"
+                  info.session_id);
           (match last_event_id with
           | Some last_id ->
               let missed = Sse.get_events_after last_id in
-              List.iter (fun ev -> ignore (send_raw info ev)) missed
+              List.iter (fun ev ->
+                if not (send_raw info ev) then
+                  Log.Server.debug "SSE replay send failed for session %s"
+                    info.session_id
+              ) missed
           | None -> ());
           (match deps.get_runtime_result () with
           | Ok runtime ->
@@ -595,7 +608,9 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
                     let event = Eio.Stream.take event_stream in
                     (try
                       if not (info.closed || !(info.stop)) then
-                        ignore (send_raw info event)
+                        if not (send_raw info event) then
+                          Log.Server.debug "SSE drain send failed for session %s"
+                            info.session_id
                     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                       Log.Server.error "drain write error: %s"
                         (Printexc.to_string exn);
@@ -624,7 +639,9 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
                          if info.closed then
                            stop_sse_session info.session_id
                          else if not !(info.stop) then
-                           ignore (send_raw info ": ping\n\n")
+                           if not (send_raw info ": ping\n\n") then
+                             Log.Server.debug "SSE ping send failed for session %s"
+                               info.session_id
                        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                          if is_cancelled exn then raise exn;
                          Log.Server.error "ping send error: %s"

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -57,7 +57,9 @@ let handle_ag_ui_events ~deps request reqd =
       let push event =
         match !info_ref with
         | None -> ()
-        | Some info -> ignore (send_raw info (ag_ui_event_of_masc_event event))
+        | Some info ->
+            if not (send_raw info (ag_ui_event_of_masc_event event)) then
+              Log.Server.debug "ag-ui push failed for session %s" info.session_id
       in
       let client_id, event_stream, evicted =
         Sse.register session_id ~push
@@ -83,11 +85,15 @@ let handle_ag_ui_events ~deps request reqd =
           make_event ~thread_id:default_thread_id ~run_id:(Some session_id) Run_started
           |> event_to_sse)
       in
-      ignore (send_raw info prime);
+      if not (send_raw info prime) then
+        Log.Server.debug "ag-ui prime send failed for session %s" info.session_id;
       (match last_event_id with
       | Some last_id ->
           let missed = Sse.get_events_after last_id in
-          List.iter (fun ev -> ignore (send_raw info ev)) missed
+          List.iter (fun ev ->
+            if not (send_raw info ev) then
+              Log.Server.debug "ag-ui replay send failed for session %s" info.session_id
+          ) missed
       | None -> ());
       (match deps.get_runtime_result () with
       | Ok runtime ->
@@ -99,7 +105,9 @@ let handle_ag_ui_events ~deps request reqd =
                 let event = Eio.Stream.take event_stream in
                 (try
                   if not (info.closed || !(info.stop)) then
-                    ignore (send_raw info event)
+                    if not (send_raw info event) then
+                      Log.Server.debug "ag-ui drain send failed for session %s"
+                        info.session_id
                 with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                   Log.Server.error "ag-ui drain write error: %s"
                     (Printexc.to_string exn);
@@ -122,7 +130,9 @@ let handle_ag_ui_events ~deps request reqd =
                      if info.closed then
                        stop_sse_session_preserve_guard info.session_id
                      else if not !(info.stop) then
-                       ignore (send_raw info ": ping\n\n")
+                       if not (send_raw info ": ping\n\n") then
+                         Log.Server.debug "ag-ui ping send failed for session %s"
+                           info.session_id
                    with Eio.Cancel.Cancelled _ as exn -> raise exn
                       | exn ->
                           Log.Server.warn "SSE ping send failed for session %s: %s" info.session_id (Printexc.to_string exn);


### PR DESCRIPTION
## Summary

Batch 2 of the OCaml 5.x best-practice audit focused on silent failure patterns and exception anti-patterns.

## Changes

### keeper_shell_docker.ml
- Replace `raise (Failure err)` with `Result` propagation when git credential binding fails
- Previously crashed the Docker fiber; now returns `sandbox_error` with the binding failure message

### server_mcp_transport_http_agui.ml  
- Replace 4 `ignore (send_raw ...)` with explicit debug logging when SSE transmission fails

### server_mcp_transport_http.ml
- Replace 7 `ignore (send_raw ...)` with explicit debug logging across push callback, prime event, endpoint event, replay events, drain fiber, and ping fiber

## Tracking

- Issue #9793 created for `get_server_state ()` refactor (22 callers, too large for this batch)

## Test Plan

- [x] `dune build @check` passes
- [ ] CI green

---
*Part of the OCaml best-practice audit series*