### PR TITLE
feat(keeper): P16 failure insight injection into bash execution

### DIFF
--- a/lib/exec/bash_history.ml
+++ b/lib/exec/bash_history.ml
@@ -1,7 +1,12 @@
 (* P11: Command History & Suggest
    Append-only JSONL log of bash executions.  Each keeper gets its own
    history file under [.masc/keeper/<name>/bash_history.jsonl].
-   Automatic compaction kicks in above 10 000 entries. *)
+   Automatic compaction kicks in above 10 000 entries.
+
+   P15: Repeated Failure Detection
+   Analyzes recent history for stuck-loop patterns — same command
+   failing repeatedly, high failure rates, or timeout clusters.
+   Returns structured JSON that the agent can use to self-correct. *)
 
 type history_entry = {
   ts : float;
@@ -11,6 +16,41 @@ type history_entry = {
   duration_ms : int;
   success : bool;
 }
+
+type failure_pattern =
+  | Repeated_failure of { cmd_prefix : string; count : int }
+  | High_failure_rate of { recent : int; failures : int; rate : float }
+  | Timeout_cluster of { cmd_prefix : string; count : int }
+
+let failure_pattern_to_json = function
+  | Repeated_failure { cmd_prefix; count } ->
+      `Assoc [
+        ("kind", `String "repeated_failure");
+        ("cmd_prefix", `String cmd_prefix);
+        ("count", `Int count);
+        ("suggestion", `String (Printf.sprintf
+          "\"%s\" failed %d times in a row — consider a different approach"
+          cmd_prefix count));
+      ]
+  | High_failure_rate { recent; failures; rate } ->
+      `Assoc [
+        ("kind", `String "high_failure_rate");
+        ("recent", `Int recent);
+        ("failures", `Int failures);
+        ("rate", `Float rate);
+        ("suggestion", `String (Printf.sprintf
+          "%d/%d recent commands failed (%.0f%%) — review approach"
+          failures recent (rate *. 100.0)));
+      ]
+  | Timeout_cluster { cmd_prefix; count } ->
+      `Assoc [
+        ("kind", `String "timeout_cluster");
+        ("cmd_prefix", `String cmd_prefix);
+        ("count", `Int count);
+        ("suggestion", `String (Printf.sprintf
+          "\"%s\" timed out %d times — increase budget or simplify"
+          cmd_prefix count));
+      ]
 
 (* --- helpers --- *)
 
@@ -191,3 +231,93 @@ let suggest ~base_path ~keeper_name ~pattern ~limit =
     in
     last_n limit matches
   end
+
+(* --- P15: failure pattern detection --- *)
+
+(** Minimum consecutive failures on the same command prefix to trigger
+    a [Repeated_failure] warning. *)
+let repeated_threshold = 3
+
+(** How many recent entries to consider for rate-based analysis. *)
+let rate_window = 20
+
+(** Failure rate above which [High_failure_rate] triggers (0.0–1.0). *)
+let rate_threshold = 0.6
+
+(** Minimum consecutive entries with [duration_ms] exceeding 30 000
+    (30 s) to flag as [Timeout_cluster]. *)
+let timeout_ms = 30_000
+let timeout_threshold = 2
+
+let take_last n lst =
+  let len = List.length lst in
+  if len <= n then lst
+  else drop (len - n) lst
+
+(** Check if [prefix] appears to be a test runner command. *)
+let is_test_prefix prefix =
+  let l = String.lowercase_ascii prefix in
+  String_util.contains_substring l "test"
+  || String_util.contains_substring l "pytest"
+  || String_util.contains_substring l "cargo test"
+  || String_util.contains_substring l "dune runtest"
+  || String_util.contains_substring l "npm test"
+
+(** Walk the most recent entries and return all detected failure patterns.
+    Returns [] when there is nothing to report (no file, empty, or healthy). *)
+let failure_insight ~base_path ~keeper_name =
+  let path, _ = history_path ~base_path ~keeper_name in
+  if not (Sys.file_exists path) then []
+  else
+    let entries = load_entries path in
+    let recent = take_last rate_window entries in
+    if recent = [] then []
+    else begin
+      let patterns = ref [] in
+
+      (* 1. Repeated failure: same cmd_prefix, consecutive failures *)
+      let rec count_consecutive_failures prefix = function
+        | [] -> 0
+        | e :: rest when e.cmd_prefix = prefix && not e.success ->
+            1 + count_consecutive_failures prefix rest
+        | _ -> 0
+      in
+      let rev_recent = List.rev recent in
+      (match rev_recent with
+       | e :: _ when not e.success ->
+           let n = count_consecutive_failures e.cmd_prefix rev_recent in
+           if n >= repeated_threshold then
+             patterns :=
+               Repeated_failure { cmd_prefix = e.cmd_prefix; count = n }
+               :: !patterns
+       | _ -> ());
+
+      (* 2. High failure rate across recent window *)
+      let total = List.length recent in
+      let failures = List.length (List.filter (fun e -> not e.success) recent) in
+      let rate = float_of_int failures /. float_of_int total in
+      if total >= 5 && rate >= rate_threshold then
+        patterns :=
+          High_failure_rate { recent = total; failures; rate }
+          :: !patterns;
+
+      (* 3. Timeout cluster: same prefix, consecutive slow entries *)
+      let rec count_consecutive_timeouts prefix = function
+        | [] -> 0
+        | e :: rest
+          when e.cmd_prefix = prefix
+               && e.duration_ms >= timeout_ms ->
+            1 + count_consecutive_timeouts prefix rest
+        | _ -> 0
+      in
+      (match rev_recent with
+       | e :: _ when e.duration_ms >= timeout_ms ->
+           let n = count_consecutive_timeouts e.cmd_prefix rev_recent in
+           if n >= timeout_threshold then
+             patterns :=
+               Timeout_cluster { cmd_prefix = e.cmd_prefix; count = n }
+               :: !patterns
+       | _ -> ());
+
+      List.rev !patterns
+    end

--- a/lib/exec/bash_history.mli
+++ b/lib/exec/bash_history.mli
@@ -7,6 +7,15 @@ type history_entry = {
   success : bool;
 }
 
+(** Detected failure pattern for P15: Repeated Failure Detection. *)
+type failure_pattern =
+  | Repeated_failure of { cmd_prefix : string; count : int }
+  | High_failure_rate of { recent : int; failures : int; rate : float }
+  | Timeout_cluster of { cmd_prefix : string; count : int }
+
+val failure_pattern_to_json : failure_pattern -> Yojson.Safe.t
+(** Serialize a failure pattern to JSON for consumption by the agent. *)
+
 val entry_to_json : history_entry -> Yojson.Safe.t
 
 val append :
@@ -33,6 +42,16 @@ val suggest :
   history_entry list
 (** Return the last [limit] entries whose [cmd_prefix] or [cmd_hash]
     starts with [pattern].  Returns [] when the file doesn't exist. *)
+
+val failure_insight :
+  base_path:string ->
+  keeper_name:string ->
+  failure_pattern list
+(** Analyze recent history for stuck-loop patterns:
+    - [Repeated_failure]: same command failed N times consecutively
+    - [High_failure_rate]: overall failure rate exceeds threshold
+    - [Timeout_cluster]: same command timed out N times consecutively
+    Returns [] when no patterns are detected or file doesn't exist. *)
 
 val cmd_hash : string -> string
 (** Truncated SHA-256 (12 hex chars) of a command string. *)

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -2,6 +2,7 @@
  (names test_exec_types test_capability_check test_bash_parser
         test_approval_policy test_approval_context test_approval_config
         test_exec_gate_runtime test_exec_semantic test_exec_buffer
-        test_exec_run test_exec_run_json test_exit_code test_output_parse_p14)
+        test_exec_run test_exec_run_json test_exit_code test_output_parse_p14
+        test_history_insight)
  (libraries masc_exec masc_exec_bash_parser masc_process
             masc_core alcotest eio eio_main yojson unix base re))

--- a/lib/exec/test/test_history_insight.ml
+++ b/lib/exec/test/test_history_insight.ml
@@ -1,0 +1,153 @@
+(* P15 tests: failure pattern detection *)
+
+module BH = Masc_exec.Bash_history
+
+(* --- helpers --- *)
+
+let tmp_dir = Filename.get_temp_dir_name () ^ "/test_history_insight_" ^ (string_of_int (Unix.getpid ()))
+
+let setup () =
+  if not (Sys.file_exists tmp_dir) then Unix.mkdir tmp_dir 0o755;
+  tmp_dir
+
+let teardown () =
+  let rec rm_rf path =
+    if Sys.is_directory path then begin
+      let entries = Sys.readdir path in
+      Array.iter (fun e -> rm_rf (Filename.concat path e)) entries;
+      Unix.rmdir path
+    end else Unix.unlink path
+  in
+  if Sys.file_exists tmp_dir then rm_rf tmp_dir
+
+let make_entry ~cmd ~success ~duration =
+  { BH.ts = Unix.time ();
+    BH.cmd_hash = BH.cmd_hash cmd;
+    BH.cmd_prefix =
+      (* take first word as prefix *)
+      (match String.split_on_char ' ' cmd with
+       | [] -> cmd | w :: _ -> w);
+    BH.semantic_kind = "Unknown";
+    BH.duration_ms = duration;
+    BH.success }
+
+let append_entries dir name entries =
+  List.iter (BH.append ~base_path:dir ~keeper_name:name) entries
+
+(* --- tests --- *)
+
+let test_no_history_file () =
+  let dir = setup () in
+  let patterns = BH.failure_insight ~base_path:dir ~keeper_name:"nobody" in
+  Alcotest.(check int) "no patterns" 0 (List.length patterns);
+  teardown ()
+
+let test_healthy_history () =
+  let dir = setup () in
+  let entries =
+    List.init 10 (fun i ->
+      make_entry ~cmd:("cmd" ^ string_of_int i) ~success:true ~duration:100)
+  in
+  append_entries dir "healthy" entries;
+  let patterns = BH.failure_insight ~base_path:dir ~keeper_name:"healthy" in
+  Alcotest.(check int) "no patterns when healthy" 0 (List.length patterns);
+  teardown ()
+
+let test_repeated_failure () =
+  let dir = setup () in
+  let entries = [
+    make_entry ~cmd:"npm test" ~success:true ~duration:500;
+    make_entry ~cmd:"npm test" ~success:false ~duration:200;
+    make_entry ~cmd:"npm test" ~success:false ~duration:200;
+    make_entry ~cmd:"npm test" ~success:false ~duration:200;
+  ] in
+  append_entries dir "stuck" entries;
+  let patterns = BH.failure_insight ~base_path:dir ~keeper_name:"stuck" in
+  let repeated = List.filter (function
+    | BH.Repeated_failure _ -> true | _ -> false
+  ) patterns in
+  Alcotest.(check int) "one repeated pattern" 1 (List.length repeated);
+  (match repeated with
+   | [BH.Repeated_failure { cmd_prefix; count }] ->
+       Alcotest.(check string) "prefix" "npm" cmd_prefix;
+       Alcotest.(check int) "count" 3 count
+   | _ -> Alcotest.fail "unexpected repeated pattern shape");
+  teardown ()
+
+let test_high_failure_rate () =
+  let dir = setup () in
+  (* 6 failures out of 8 recent = 75% > 60% threshold *)
+  let entries = [
+    make_entry ~cmd:"a" ~success:false ~duration:100;
+    make_entry ~cmd:"b" ~success:false ~duration:100;
+    make_entry ~cmd:"c" ~success:true  ~duration:100;
+    make_entry ~cmd:"d" ~success:false ~duration:100;
+    make_entry ~cmd:"e" ~success:false ~duration:100;
+    make_entry ~cmd:"f" ~success:true  ~duration:100;
+    make_entry ~cmd:"g" ~success:false ~duration:100;
+    make_entry ~cmd:"h" ~success:false ~duration:100;
+  ] in
+  append_entries dir "flaky" entries;
+  let patterns = BH.failure_insight ~base_path:dir ~keeper_name:"flaky" in
+  let rate_pat = List.filter (function
+    | BH.High_failure_rate _ -> true | _ -> false
+  ) patterns in
+  Alcotest.(check int) "one rate pattern" 1 (List.length rate_pat);
+  (match rate_pat with
+   | [BH.High_failure_rate { recent; failures; rate }] ->
+       Alcotest.(check int) "recent" 8 recent;
+       Alcotest.(check int) "failures" 6 failures;
+       (* 6/8 = 0.75 *)
+       Alcotest.(check bool) "rate >= 0.6" true (rate >= 0.6)
+   | _ -> Alcotest.fail "unexpected rate pattern shape");
+  teardown ()
+
+let test_timeout_cluster () =
+  let dir = setup () in
+  let entries = [
+    make_entry ~cmd:"dune build" ~success:true ~duration:5000;
+    make_entry ~cmd:"dune build" ~success:false ~duration:35000;
+    make_entry ~cmd:"dune build" ~success:false ~duration:32000;
+  ] in
+  append_entries dir "slow" entries;
+  let patterns = BH.failure_insight ~base_path:dir ~keeper_name:"slow" in
+  let timeouts = List.filter (function
+    | BH.Timeout_cluster _ -> true | _ -> false
+  ) patterns in
+  Alcotest.(check int) "one timeout pattern" 1 (List.length timeouts);
+  (match timeouts with
+   | [BH.Timeout_cluster { cmd_prefix; count }] ->
+       Alcotest.(check string) "prefix" "dune" cmd_prefix;
+       Alcotest.(check int) "count" 2 count
+   | _ -> Alcotest.fail "unexpected timeout pattern shape");
+  teardown ()
+
+let test_json_output () =
+  let dir = setup () in
+  let entries = [
+    make_entry ~cmd:"cargo test" ~success:false ~duration:100;
+    make_entry ~cmd:"cargo test" ~success:false ~duration:100;
+    make_entry ~cmd:"cargo test" ~success:false ~duration:100;
+  ] in
+  append_entries dir "json_test" entries;
+  let patterns = BH.failure_insight ~base_path:dir ~keeper_name:"json_test" in
+  (match patterns with
+   | [BH.Repeated_failure _ as pat] ->
+     let json = BH.failure_pattern_to_json pat in
+     (match json with
+      | `Assoc fields ->
+        (match List.assoc_opt "kind" fields with
+         | Some (`String "repeated_failure") -> ()
+         | _ -> Alcotest.fail "kind field missing or wrong")
+      | _ -> Alcotest.fail "expected assoc json")
+   | _ -> Alcotest.fail "expected exactly one repeated pattern");
+  teardown ()
+
+let () =
+  test_no_history_file ();
+  test_healthy_history ();
+  test_repeated_failure ();
+  test_high_failure_rate ();
+  test_timeout_cluster ();
+  test_json_output ();
+  print_endline "test_history_insight: 6/6 passed"

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -1254,6 +1254,31 @@ let handle_keeper_shell
     let st, out =
       run_argv_with_status_retry_eintr ?cwd ~timeout_sec:io_timeout_sec argv
     in
+    (* P16: Record execution in history for failure pattern detection *)
+    let success = st = Unix.WEXITED 0 in
+    let cmd_prefix =
+      match String.split_on_char ' ' cmd with
+      | [] -> cmd | w :: _ -> w
+    in
+    let entry = Masc_exec.Bash_history.{
+      ts = Unix.time ();
+      cmd_hash = Masc_exec.Bash_history.cmd_hash cmd;
+      cmd_prefix;
+      semantic_kind = op;
+      duration_ms = 0;
+      success;
+    } in
+    Masc_exec.Bash_history.append ~base_path:root ~keeper_name:meta.name entry;
+    let insight_extra =
+      let patterns = Masc_exec.Bash_history.failure_insight
+        ~base_path:root ~keeper_name:meta.name
+      in
+      if patterns = [] then []
+      else [
+        "failure_insight", `List (
+          List.map Masc_exec.Bash_history.failure_pattern_to_json patterns)
+      ]
+    in
     Yojson.Safe.to_string
       (Exec_core.process_result_json
          ~artifact_policy:Exec_core.Inline_only
@@ -1261,19 +1286,51 @@ let handle_keeper_shell
          ~keeper_name:meta.name
          ~cmd
          ~extra:
-           [
+           ([
              "op", `String op;
              "cmd", `String cmd;
              ( "cwd",
                match cwd with
                | Some dir -> `String dir
                | None -> `Null );
-           ]
+           ] @ insight_extra)
          ~status:st
          ~output:out
          ())
   in
   let render_completed_process_result ?cwd ~cmd ?(extra = []) st out =
+    (* P16: Record execution in history for failure pattern detection *)
+    let success = st = Unix.WEXITED 0 in
+    let cmd_prefix =
+      match String.split_on_char ' ' cmd with
+      | [] -> cmd | w :: _ -> w
+    in
+    let elapsed_ms =
+      List.find_map (fun (k, v) ->
+        if k = "execution_time_ms" then
+          match v with `Int n -> Some n | _ -> None
+        else None) extra
+      |> Option.value ~default:0
+    in
+    let entry = Masc_exec.Bash_history.{
+      ts = Unix.time ();
+      cmd_hash = Masc_exec.Bash_history.cmd_hash cmd;
+      cmd_prefix;
+      semantic_kind = op;
+      duration_ms = elapsed_ms;
+      success;
+    } in
+    Masc_exec.Bash_history.append ~base_path:root ~keeper_name:meta.name entry;
+    let insight_extra =
+      let patterns = Masc_exec.Bash_history.failure_insight
+        ~base_path:root ~keeper_name:meta.name
+      in
+      if patterns = [] then []
+      else [
+        "failure_insight", `List (
+          List.map Masc_exec.Bash_history.failure_pattern_to_json patterns)
+      ]
+    in
     Yojson.Safe.to_string
       (Exec_core.process_result_json
          ~artifact_policy:Exec_core.Inline_only
@@ -1287,7 +1344,7 @@ let handle_keeper_shell
                match cwd with
                | Some dir -> `String dir
                | None -> `Null );
-           ] @ extra)
+           ] @ extra @ insight_extra)
          ~status:st
          ~output:out
          ())


### PR DESCRIPTION
## Summary
- Wire `Bash_history.append` into both `render_process_result` and `render_completed_process_result` so every bash execution is recorded
- Call `failure_insight` after each append and inject detected patterns as `"failure_insight"` field in the response JSON
- Agents receive real-time stuck-loop feedback ("npm failed 3 times in a row") directly in the tool response

## Changes
- `keeper_exec_shell.ml`: History recording + insight injection in 2 execution helpers

## Depends on
- P15 PR #9799 (failure_pattern types + failure_insight function)

## Test plan
- [x] `dune runtest lib/exec/test/` passes
- [x] `dune build` succeeds
- [ ] Integration test: run 3+ failing commands, verify `failure_insight` appears in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)