### PR TITLE
feat(exec): P17 turn execution budget guard

### DIFF
--- a/lib/exec/exec_budget.ml
+++ b/lib/exec/exec_budget.ml
@@ -1,0 +1,76 @@
+(* P17: Turn Execution Budget
+   Per-turn counter that tracks bash invocations and emits structured
+   warnings when the agent approaches or exceeds the configured limit.
+   Soft limit = warning in response; hard limit = execution blocked.
+
+   Inspired by OpenAI Codex Harness "loop budget" — one of the top-3
+   safety requirements for autonomous agents. *)
+
+type t = {
+  mutable count : int;
+  mutable cumulative_ms : int;
+  limit : int;
+  soft_limit : int;
+}
+
+let default_limit = 30
+let default_soft_limit = 20
+
+let create ?(limit = default_limit) ?(soft_limit = default_soft_limit) () =
+  { count = 0; cumulative_ms = 0; limit; soft_limit }
+
+let reset t =
+  t.count <- 0;
+  t.cumulative_ms <- 0
+
+let record t ~duration_ms =
+  t.count <- t.count + 1;
+  t.cumulative_ms <- t.cumulative_ms + duration_ms
+
+type budget_status =
+  | Ok of { remaining : int }
+  | Soft_warning of { remaining : int; limit : int }
+  | Hard_stop of { count : int; limit : int; cumulative_ms : int }
+
+let check t =
+  if t.count >= t.limit then
+    Hard_stop { count = t.count; limit = t.limit; cumulative_ms = t.cumulative_ms }
+  else if t.count >= t.soft_limit then
+    Soft_warning { remaining = t.limit - t.count; limit = t.limit }
+  else
+    Ok { remaining = t.soft_limit - t.count }
+
+let status_to_json = function
+  | Ok _ -> `Null
+  | Soft_warning { remaining; limit } ->
+      `Assoc [
+        ("level", `String "soft_warning");
+        ("message", `String (Printf.sprintf
+          "Approaching execution budget: %d commands remaining (limit %d)"
+          remaining limit));
+        ("remaining", `Int remaining);
+        ("limit", `Int limit);
+        ("suggestion", `String
+          "Consider consolidating commands or summarizing progress");
+      ]
+  | Hard_stop { count; limit; cumulative_ms } ->
+      `Assoc [
+        ("level", `String "hard_stop");
+        ("message", `String (Printf.sprintf
+          "Execution budget exhausted: %d/%d commands used this turn"
+          count limit));
+        ("count", `Int count);
+        ("limit", `Int limit);
+        ("cumulative_ms", `Int cumulative_ms);
+        ("suggestion", `String
+          "Turn execution budget reached. Report progress and wait for next turn.");
+      ]
+
+let to_json t =
+  `Assoc [
+    ("count", `Int t.count);
+    ("limit", `Int t.limit);
+    ("soft_limit", `Int t.soft_limit);
+    ("remaining", `Int (t.limit - t.count));
+    ("cumulative_ms", `Int t.cumulative_ms);
+  ]

--- a/lib/exec/exec_budget.mli
+++ b/lib/exec/exec_budget.mli
@@ -1,0 +1,31 @@
+(** P17: Turn Execution Budget *)
+
+type t
+(** Mutable budget tracker.  Thread-safe via single-owner: one per keeper
+    turn, never shared across fibers. *)
+
+val create : ?limit:int -> ?soft_limit:int -> unit -> t
+(** Create a fresh budget.  Default [limit=30], [soft_limit=20]. *)
+
+val reset : t -> unit
+(** Reset counters to zero (call at turn start). *)
+
+val record : t -> duration_ms:int -> unit
+(** Increment command count and accumulate duration. *)
+
+type budget_status =
+  | Ok of { remaining : int }
+  | Soft_warning of { remaining : int; limit : int }
+  | Hard_stop of { count : int; limit : int; cumulative_ms : int }
+(** Result of [check]: still under soft limit, approaching limit, or
+    exceeded hard limit. *)
+
+val check : t -> budget_status
+(** Check current budget status.  Does not mutate. *)
+
+val status_to_json : budget_status -> Yojson.Safe.t
+(** Serialize status to JSON.  [Ok] returns [Null]; warnings include
+    human-readable [message] and [suggestion] fields. *)
+
+val to_json : t -> Yojson.Safe.t
+(** Full budget snapshot as JSON. *)

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -3,6 +3,6 @@
         test_approval_policy test_approval_context test_approval_config
         test_exec_gate_runtime test_exec_semantic test_exec_buffer
         test_exec_run test_exec_run_json test_exit_code test_output_parse_p14
-        test_history_insight test_exec_cache)
+        test_history_insight test_exec_cache test_exec_budget)
  (libraries masc_exec masc_exec_bash_parser masc_process
             masc_core alcotest eio eio_main yojson unix base re))

--- a/lib/exec/test/test_exec_budget.ml
+++ b/lib/exec/test/test_exec_budget.ml
@@ -1,0 +1,117 @@
+(* P17 tests: turn execution budget *)
+
+module EB = Masc_exec.Exec_budget
+
+(* --- tests --- *)
+
+let test_create_default () =
+  let t = EB.create () in
+  let json = EB.to_json t in
+  (match json with
+   | `Assoc fields ->
+     (match List.assoc_opt "count" fields with
+      | Some (`Int 0) -> ()
+      | _ -> Alcotest.fail "count should be 0");
+     (match List.assoc_opt "limit" fields with
+      | Some (`Int 30) -> ()
+      | _ -> Alcotest.fail "limit should be 30");
+     (match List.assoc_opt "soft_limit" fields with
+      | Some (`Int 20) -> ()
+      | _ -> Alcotest.fail "soft_limit should be 20")
+   | _ -> Alcotest.fail "expected assoc")
+
+let test_create_custom () =
+  let t = EB.create ~limit:10 ~soft_limit:5 () in
+  let json = EB.to_json t in
+  (match json with
+   | `Assoc fields ->
+     (match List.assoc_opt "limit" fields with
+      | Some (`Int 10) -> ()
+      | _ -> Alcotest.fail "limit should be 10")
+   | _ -> Alcotest.fail "expected assoc")
+
+let test_record_increments () =
+  let t = EB.create ~limit:10 ~soft_limit:5 () in
+  EB.record t ~duration_ms:100;
+  EB.record t ~duration_ms:200;
+  EB.record t ~duration_ms:300;
+  let json = EB.to_json t in
+  (match json with
+   | `Assoc fields ->
+     (match List.assoc_opt "count" fields with
+      | Some (`Int 3) -> ()
+      | _ -> Alcotest.fail "count should be 3");
+     (match List.assoc_opt "cumulative_ms" fields with
+      | Some (`Int 600) -> ()
+      | _ -> Alcotest.fail "cumulative_ms should be 600")
+   | _ -> Alcotest.fail "expected assoc")
+
+let test_check_ok () =
+  let t = EB.create ~limit:10 ~soft_limit:5 () in
+  (match EB.check t with
+   | EB.Ok { remaining } -> Alcotest.(check int) "remaining" 5 remaining
+   | _ -> Alcotest.fail "should be Ok")
+
+let test_check_soft_warning () =
+  let t = EB.create ~limit:10 ~soft_limit:5 () in
+  for _ = 1 to 5 do EB.record t ~duration_ms:100 done;
+  (match EB.check t with
+   | EB.Soft_warning { remaining; limit } ->
+       Alcotest.(check int) "remaining" 5 remaining;
+       Alcotest.(check int) "limit" 10 limit
+   | _ -> Alcotest.fail "should be Soft_warning at count=5")
+
+let test_check_hard_stop () =
+  let t = EB.create ~limit:10 ~soft_limit:5 () in
+  for _ = 1 to 10 do EB.record t ~duration_ms:100 done;
+  (match EB.check t with
+   | EB.Hard_stop { count; limit; cumulative_ms } ->
+       Alcotest.(check int) "count" 10 count;
+       Alcotest.(check int) "limit" 10 limit;
+       Alcotest.(check int) "cumulative_ms" 1000 cumulative_ms
+   | _ -> Alcotest.fail "should be Hard_stop at count=10")
+
+let test_reset () =
+  let t = EB.create ~limit:10 ~soft_limit:5 () in
+  for _ = 1 to 8 do EB.record t ~duration_ms:50 done;
+  EB.reset t;
+  (match EB.check t with
+   | EB.Ok { remaining } -> Alcotest.(check int) "remaining" 5 remaining
+   | _ -> Alcotest.fail "should be Ok after reset")
+
+let test_status_json_soft () =
+  let t = EB.create ~limit:10 ~soft_limit:5 () in
+  for _ = 1 to 5 do EB.record t ~duration_ms:100 done;
+  (match EB.check t with
+   | EB.Soft_warning _ as status ->
+     let json = EB.status_to_json status in
+     (match json with
+      | `Assoc fields ->
+        (match List.assoc_opt "level" fields with
+         | Some (`String "soft_warning") -> ()
+         | _ -> Alcotest.fail "level should be soft_warning");
+        (match List.assoc_opt "suggestion" fields with
+         | Some (`String _) -> ()
+         | _ -> Alcotest.fail "should have suggestion")
+      | _ -> Alcotest.fail "expected assoc")
+   | _ -> Alcotest.fail "wrong status")
+
+let test_status_json_null_when_ok () =
+  let t = EB.create () in
+  (match EB.check t with
+   | Ok _ as status ->
+     let json = EB.status_to_json status in
+     (match json with `Null -> () | _ -> Alcotest.fail "should be Null")
+   | _ -> Alcotest.fail "should be Ok")
+
+let () =
+  test_create_default ();
+  test_create_custom ();
+  test_record_increments ();
+  test_check_ok ();
+  test_check_soft_warning ();
+  test_check_hard_stop ();
+  test_reset ();
+  test_status_json_soft ();
+  test_status_json_null_when_ok ();
+  print_endline "test_exec_budget: 9/9 passed"


### PR DESCRIPTION
## Summary
- Per-turn mutable counter tracking bash invocations with soft/hard limits
- Soft limit (default 20): warning with remaining budget in response JSON
- Hard limit (default 30): blocks further execution with structured message
- Inspired by OpenAI Codex Harness "loop budget" — top-3 safety requirement

## Changes
- `exec_budget.ml`: Budget tracker with `create`, `record`, `check`, `reset`
- `exec_budget.mli`: Public interface
- `test/test_exec_budget.ml`: 9 tests (create, record, check variants, reset, JSON)

## Test plan
- [x] `dune runtest lib/exec/test/` passes (9/9 P17 + all existing exec tests)
- [ ] Wire into keeper turn lifecycle (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)