### PR TITLE
feat(exec): P18 adaptive timeout from execution history

### DIFF
--- a/lib/exec/exec_adaptive_timeout.ml
+++ b/lib/exec/exec_adaptive_timeout.ml
@@ -1,0 +1,80 @@
+(* P18: Adaptive Timeout
+   Per-command timeout estimation from execution history.
+   Uses p95 of successful runs with a safety multiplier.
+
+   Rationale: a fixed 120s timeout is too aggressive for builds and
+   too generous for quick lookups.  History-driven p95 adapts to
+   actual command behavior. *)
+
+module BH = Bash_history
+
+type timeout_config = {
+  default_ms : int;
+  min_ms : int;
+  max_ms : int;
+  multiplier : float;
+  min_samples : int;
+}
+
+let default_config = {
+  default_ms = 120_000;
+  min_ms = 30_000;
+  max_ms = 600_000;
+  multiplier = 1.5;
+  min_samples = 3;
+}
+
+let compute config entries =
+  let success_durations =
+    List.filter_map (fun (e : BH.history_entry) ->
+      if e.success then Some e.duration_ms else None
+    ) entries
+  in
+  let n = List.length success_durations in
+  if n < config.min_samples then config.default_ms
+  else begin
+    let sorted = List.sort Int.compare success_durations in
+    let p95_idx = min (n - 1) (int_of_float (float_of_int n *. 0.95)) in
+    let p95 = List.nth sorted p95_idx in
+    let raw = int_of_float (float_of_int p95 *. config.multiplier) in
+    let clamped = min config.max_ms (max config.min_ms raw) in
+    clamped
+  end
+
+type stats_result =
+  | Adapted of { p95_ms : int; recommended_ms : int; sample_count : int }
+  | Default of { reason : string }
+
+let stats config entries =
+  let success_durations =
+    List.filter_map (fun (e : BH.history_entry) ->
+      if e.success then Some e.duration_ms else None
+    ) entries
+  in
+  let n = List.length success_durations in
+  if n < config.min_samples then
+    Default { reason = Printf.sprintf
+      "only %d successful runs (need %d)" n config.min_samples }
+  else begin
+    let sorted = List.sort Int.compare success_durations in
+    let p95_idx = min (n - 1) (int_of_float (float_of_int n *. 0.95)) in
+    let p95 = List.nth sorted p95_idx in
+    let raw = int_of_float (float_of_int p95 *. config.multiplier) in
+    let recommended = min config.max_ms (max config.min_ms raw) in
+    Adapted { p95_ms = p95; recommended_ms = recommended; sample_count = n }
+  end
+
+let stats_to_json = function
+  | Adapted { p95_ms; recommended_ms; sample_count } ->
+      `Assoc [
+        ("adapted", `Bool true);
+        ("p95_ms", `Int p95_ms);
+        ("recommended_ms", `Int recommended_ms);
+        ("sample_count", `Int sample_count);
+      ]
+  | Default { reason } ->
+      `Assoc [
+        ("adapted", `Bool false);
+        ("reason", `String reason);
+        ("recommended_ms", `Int default_config.default_ms);
+      ]

--- a/lib/exec/exec_adaptive_timeout.ml
+++ b/lib/exec/exec_adaptive_timeout.ml
@@ -43,7 +43,7 @@ let compute config entries =
 
 type stats_result =
   | Adapted of { p95_ms : int; recommended_ms : int; sample_count : int }
-  | Default of { reason : string }
+  | Default of { reason : string; recommended_ms : int }
 
 let stats config entries =
   let success_durations =
@@ -54,7 +54,8 @@ let stats config entries =
   let n = List.length success_durations in
   if n < config.min_samples then
     Default { reason = Printf.sprintf
-      "only %d successful runs (need %d)" n config.min_samples }
+      "only %d successful runs (need %d)" n config.min_samples;
+      recommended_ms = config.default_ms }
   else begin
     let sorted = List.sort Int.compare success_durations in
     let p95_idx = min (n - 1) (int_of_float (float_of_int n *. 0.95)) in
@@ -72,9 +73,9 @@ let stats_to_json = function
         ("recommended_ms", `Int recommended_ms);
         ("sample_count", `Int sample_count);
       ]
-  | Default { reason } ->
+  | Default { reason; recommended_ms } ->
       `Assoc [
         ("adapted", `Bool false);
         ("reason", `String reason);
-        ("recommended_ms", `Int default_config.default_ms);
+        ("recommended_ms", `Int recommended_ms);
       ]

--- a/lib/exec/exec_adaptive_timeout.mli
+++ b/lib/exec/exec_adaptive_timeout.mli
@@ -25,7 +25,7 @@ val compute :
 
 type stats_result =
   | Adapted of { p95_ms : int; recommended_ms : int; sample_count : int }
-  | Default of { reason : string }
+  | Default of { reason : string; recommended_ms : int }
 (** Detailed stats for observability.  Returns whether adaptation
     kicked in and why. *)
 

--- a/lib/exec/exec_adaptive_timeout.mli
+++ b/lib/exec/exec_adaptive_timeout.mli
@@ -1,0 +1,38 @@
+(** P18: Adaptive Timeout
+
+    Computes per-command timeouts from execution history using p95
+    estimation.  New commands get the default; well-known commands get
+    a dynamically adjusted timeout based on observed execution times. *)
+
+type timeout_config = {
+  default_ms : int;     (** Fallback for unseen commands.  120 000 ms. *)
+  min_ms : int;         (** Floor for any timeout.  30 000 ms. *)
+  max_ms : int;         (** Ceiling for any timeout.  600 000 ms. *)
+  multiplier : float;   (** Safety factor applied to p95.  1.5. *)
+  min_samples : int;    (** Minimum successful runs before adapting.  3. *)
+}
+
+val default_config : timeout_config
+
+val compute :
+  timeout_config ->
+  Bash_history.history_entry list ->
+  int
+(** Compute a recommended timeout in milliseconds from a set of history
+    entries.  Only [success = true] entries contribute to the p95 estimate.
+    Returns [default_ms] when fewer than [min_samples] successful runs
+    are available. *)
+
+type stats_result =
+  | Adapted of { p95_ms : int; recommended_ms : int; sample_count : int }
+  | Default of { reason : string }
+(** Detailed stats for observability.  Returns whether adaptation
+    kicked in and why. *)
+
+val stats :
+  timeout_config ->
+  Bash_history.history_entry list ->
+  stats_result
+
+val stats_to_json : stats_result -> Yojson.Safe.t
+(** Serialize stats to JSON. *)

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -3,6 +3,7 @@
         test_approval_policy test_approval_context test_approval_config
         test_exec_gate_runtime test_exec_semantic test_exec_buffer
         test_exec_run test_exec_run_json test_exit_code test_output_parse_p14
-        test_history_insight test_exec_cache test_exec_budget)
+        test_history_insight test_exec_cache test_exec_budget
+        test_exec_adaptive_timeout)
  (libraries masc_exec masc_exec_bash_parser masc_process
             masc_core alcotest eio eio_main yojson unix base re))

--- a/lib/exec/test/test_exec_adaptive_timeout.ml
+++ b/lib/exec/test/test_exec_adaptive_timeout.ml
@@ -63,8 +63,9 @@ let test_compute_ignores_failures () =
 let test_stats_default () =
   let entries = [ entry ~duration_ms:100 "ls" ] in
   (match AT.stats AT.default_config entries with
-   | AT.Default { reason } ->
-     Alcotest.(check bool) "reason is non-empty" true (String.length reason > 0)
+   | AT.Default { reason; recommended_ms } ->
+     Alcotest.(check bool) "reason is non-empty" true (String.length reason > 0);
+     Alcotest.(check int) "recommended from config default" 120_000 recommended_ms
    | _ -> Alcotest.fail "should be Default")
 
 let test_stats_adapted () =
@@ -110,6 +111,17 @@ let test_stats_json_default () =
       | _ -> Alcotest.fail "should have default recommended_ms")
    | _ -> Alcotest.fail "expected assoc")
 
+let test_stats_json_default_uses_config_default () =
+  let config = { AT.default_config with default_ms = 45_000 } in
+  let s = AT.stats config [] in
+  let json = AT.stats_to_json s in
+  (match json with
+   | `Assoc fields ->
+     (match List.assoc_opt "recommended_ms" fields with
+      | Some (`Int 45_000) -> ()
+      | _ -> Alcotest.fail "should use configured default_ms")
+   | _ -> Alcotest.fail "expected assoc")
+
 let () =
   test_default_config ();
   test_compute_empty ();
@@ -122,4 +134,5 @@ let () =
   test_stats_adapted ();
   test_stats_json_adapted ();
   test_stats_json_default ();
-  print_endline "test_exec_adaptive_timeout: 11/11 passed"
+  test_stats_json_default_uses_config_default ();
+  print_endline "test_exec_adaptive_timeout: 12/12 passed"

--- a/lib/exec/test/test_exec_adaptive_timeout.ml
+++ b/lib/exec/test/test_exec_adaptive_timeout.ml
@@ -1,0 +1,125 @@
+(* P18 tests: adaptive timeout *)
+
+module AT = Masc_exec.Exec_adaptive_timeout
+module BH = Masc_exec.Bash_history
+
+let entry ?(success = true) ~duration_ms prefix =
+  BH.{ ts = 0.0; cmd_hash = "x"; cmd_prefix = prefix;
+       semantic_kind = "read"; duration_ms; success }
+
+let test_default_config () =
+  let c = AT.default_config in
+  Alcotest.(check int) "default_ms" 120_000 c.default_ms;
+  Alcotest.(check int) "min_ms" 30_000 c.min_ms;
+  Alcotest.(check int) "max_ms" 600_000 c.max_ms;
+  Alcotest.(check (float 0.01)) "multiplier" 1.5 c.multiplier;
+  Alcotest.(check int) "min_samples" 3 c.min_samples
+
+let test_compute_empty () =
+  let t = AT.compute AT.default_config [] in
+  Alcotest.(check int) "empty returns default" 120_000 t
+
+let test_compute_few_samples () =
+  let entries = [ entry ~duration_ms:100 "ls"; entry ~duration_ms:200 "ls" ] in
+  let t = AT.compute AT.default_config entries in
+  Alcotest.(check int) "2 samples < 3 => default" 120_000 t
+
+let test_compute_adapts () =
+  let config = { AT.default_config with min_ms = 50; multiplier = 1.5 } in
+  let entries = List.init 10 (fun i ->
+    entry ~duration_ms:(100 + i * 10) "dune")
+  in
+  let t = AT.compute config entries in
+  (* sorted: 100,110,...,190. p95 idx = min(9, 9) = 9 => p95 = 190 *)
+  (* recommended = 190 * 1.5 = 285, clamped by min=50 *)
+  Alcotest.(check int) "adapted" 285 t
+
+let test_compute_min_clamp () =
+  let config = { AT.default_config with min_ms = 500; multiplier = 1.5 } in
+  let entries = List.init 5 (fun _ -> entry ~duration_ms:10 "fast") in
+  let t = AT.compute config entries in
+  (* p95=10 * 1.5=15, clamped to min=500 *)
+  Alcotest.(check int) "clamped to min" 500 t
+
+let test_compute_max_clamp () =
+  let config = { AT.default_config with max_ms = 200; multiplier = 1.5 } in
+  let entries = List.init 5 (fun _ -> entry ~duration_ms:500_000 "slow") in
+  let t = AT.compute config entries in
+  (* p95=500000 * 1.5=750000, clamped to max=200 *)
+  Alcotest.(check int) "clamped to max" 200 t
+
+let test_compute_ignores_failures () =
+  let config = { AT.default_config with min_ms = 50; multiplier = 1.5 } in
+  let entries = [
+    entry ~duration_ms:100 "ls";
+    entry ~duration_ms:50_000 ~success:false "ls";
+    entry ~duration_ms:110 "ls";
+    entry ~duration_ms:120 "ls";
+  ] in
+  let t = AT.compute config entries in
+  (* only 3 successes: 100,110,120. p95 idx=2 => p95=120. 120*1.5=180 *)
+  Alcotest.(check int) "ignores failures" 180 t
+
+let test_stats_default () =
+  let entries = [ entry ~duration_ms:100 "ls" ] in
+  (match AT.stats AT.default_config entries with
+   | AT.Default { reason } ->
+     Alcotest.(check bool) "reason is non-empty" true (String.length reason > 0)
+   | _ -> Alcotest.fail "should be Default")
+
+let test_stats_adapted () =
+  let config = { AT.default_config with min_ms = 50; multiplier = 1.5 } in
+  let entries = List.init 5 (fun i ->
+    entry ~duration_ms:(100 + i * 50) "build")
+  in
+  (match AT.stats config entries with
+   | AT.Adapted { p95_ms; recommended_ms; sample_count } ->
+     (* sorted: 100,150,200,250,300. p95 idx=4 => 300 *)
+     Alcotest.(check int) "p95" 300 p95_ms;
+     Alcotest.(check int) "recommended" 450 recommended_ms;
+     Alcotest.(check int) "sample_count" 5 sample_count
+   | _ -> Alcotest.fail "should be Adapted")
+
+let test_stats_json_adapted () =
+  let entries = List.init 5 (fun i ->
+    entry ~duration_ms:(100 + i * 50) "build")
+  in
+  let config = { AT.default_config with min_ms = 50; multiplier = 1.5 } in
+  let s = AT.stats config entries in
+  let json = AT.stats_to_json s in
+  (match json with
+   | `Assoc fields ->
+     (match List.assoc_opt "adapted" fields with
+      | Some (`Bool true) -> ()
+      | _ -> Alcotest.fail "adapted should be true");
+     (match List.assoc_opt "p95_ms" fields with
+      | Some (`Int 300) -> ()
+      | _ -> Alcotest.fail "p95_ms should be 300")
+   | _ -> Alcotest.fail "expected assoc")
+
+let test_stats_json_default () =
+  let s = AT.stats AT.default_config [] in
+  let json = AT.stats_to_json s in
+  (match json with
+   | `Assoc fields ->
+     (match List.assoc_opt "adapted" fields with
+      | Some (`Bool false) -> ()
+      | _ -> Alcotest.fail "adapted should be false");
+     (match List.assoc_opt "recommended_ms" fields with
+      | Some (`Int 120_000) -> ()
+      | _ -> Alcotest.fail "should have default recommended_ms")
+   | _ -> Alcotest.fail "expected assoc")
+
+let () =
+  test_default_config ();
+  test_compute_empty ();
+  test_compute_few_samples ();
+  test_compute_adapts ();
+  test_compute_min_clamp ();
+  test_compute_max_clamp ();
+  test_compute_ignores_failures ();
+  test_stats_default ();
+  test_stats_adapted ();
+  test_stats_json_adapted ();
+  test_stats_json_default ();
+  print_endline "test_exec_adaptive_timeout: 11/11 passed"


### PR DESCRIPTION
## Summary
- New `Exec_adaptive_timeout` module computes per-command timeouts from bash execution history
- Uses p95 of successful runs with 1.5x safety multiplier (range: 30s-600s)
- Falls back to 120s default for new commands (fewer than 3 successful runs)
- Observability via `stats` function returning `Adapted` (p95 + recommended) or `Default` (reason)

## Test plan
- [x] 11 unit tests: default config, empty/few samples, p95 adaptation, min/max clamping, failure filtering, stats variants, JSON serialization
- [x] `dune exec lib/exec/test/test_exec_adaptive_timeout.exe` — 11/11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)