### PR TITLE
[codex] fix keeper sandbox docker wiring

### DIFF
--- a/lib/dashboard/dashboard_safe_autonomy.ml
+++ b/lib/dashboard/dashboard_safe_autonomy.ml
@@ -767,6 +767,11 @@ let keeper_snapshot_json ~(config : Coord.config) (snapshot : keeper_snapshot) =
   let meta = snapshot.meta in
   let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
   let sandbox = snapshot.sandbox in
+  let sandbox_live =
+    Keeper_sandbox_control.live_status_json
+      ~include_preflight:false
+      ~config ~meta ~timeout_sec:3.0 ~verbose:false ()
+  in
   let domains =
     [
       snapshot.tool_domain;
@@ -790,6 +795,7 @@ let keeper_snapshot_json ~(config : Coord.config) (snapshot : keeper_snapshot) =
       ("network_mode", `String sandbox.network_mode);
       ("sandbox_root", `String sandbox.host_root_abs);
       ("container_root", string_opt_to_json sandbox.container_root);
+      ("sandbox_live", sandbox_live);
       ("goal", `String meta.goal);
       ("goal_horizons",
        `Assoc

--- a/lib/dune
+++ b/lib/dune
@@ -428,6 +428,7 @@
    keeper_memory_recall
    keeper_skill_routing
    keeper_sandbox
+   keeper_sandbox_control
    keeper_repo_readiness
    keeper_alerting
    keeper_alerting_path
@@ -704,6 +705,7 @@
   tool_autoresearch_cycle
   keeper_skill_routing
   keeper_sandbox
+  keeper_sandbox_control
   keeper_alerting_path
   keeper_sandbox_containment
   keeper_sandbox_runtime

--- a/lib/keeper/keeper_docker_read.ml
+++ b/lib/keeper/keeper_docker_read.ml
@@ -59,14 +59,16 @@ let container_path_of_host ~config ~(meta : keeper_meta) ~host_path
    [build_docker_argv ~command_argv]. *)
 let build_docker_argv ~image ~container_name ~host_root ~croot
     ~uid ~gid ~seccomp_args ~command_argv =
-  [
-    Keeper_sandbox_runtime.docker_command ();
-    "run";
-    "--rm";
-    "--name"; container_name;
-    "-i";
-    "--user"; Printf.sprintf "%d:%d" uid gid;
-  ]
+  Keeper_sandbox_runtime.docker_command_argv ()
+  @ [
+      "run";
+      "--rm";
+      "--name";
+      container_name;
+      "-i";
+      "--user";
+      Printf.sprintf "%d:%d" uid gid;
+    ]
   @ Env_config_keeper.KeeperSandbox.read_only_rootfs_args ()
   @ [
     "--tmpfs";

--- a/lib/keeper/keeper_exec_memory.ml
+++ b/lib/keeper/keeper_exec_memory.ml
@@ -380,6 +380,11 @@ let keeper_context_status_json
   in
   let playground_mind = sandbox_root ^ "/mind/" in
   let playground_repos = sandbox_root ^ "/repos/" in
+  let sandbox_live =
+    Keeper_sandbox_control.live_status_json
+      ~include_preflight:true
+      ~config ~meta ~timeout_sec:3.0 ~verbose:false ()
+  in
   Yojson.Safe.to_string
     (`Assoc
         ([ "name", `String meta.name
@@ -393,7 +398,8 @@ let keeper_context_status_json
         ]
         @ Keeper_sandbox.context_status_fields sandbox
         @
-        [ (* Legacy aliases kept for one release. Prompts use sandbox_*.
+        [ "sandbox_live", sandbox_live
+        ; (* Legacy aliases kept for one release. Prompts use sandbox_*.
              Values are still present for old keeper continuations. *)
           "playground_bundle", `String playground_bundle
         ; "playground_mind", `String playground_mind

--- a/lib/keeper/keeper_identity.ml
+++ b/lib/keeper/keeper_identity.ml
@@ -47,8 +47,7 @@ let git_env_for_keeper ~(keeper_name : string) : string array =
   in
   Array.of_list (filtered @ overrides)
 
-let keeper_name_from_agent_name agent_name =
-  let prefix = "keeper-" and suffix = "-agent" in
+let parse_keeper_agent_name ~prefix ~suffix agent_name =
   let plen = String.length prefix and slen = String.length suffix in
   let alen = String.length agent_name in
   if alen > plen + slen
@@ -57,20 +56,46 @@ let keeper_name_from_agent_name agent_name =
   then
     let keeper_name = String.sub agent_name plen (alen - plen - slen) in
     if Keeper_config.validate_name keeper_name then Some keeper_name else None
-  else if Nickname.is_generated_nickname agent_name
-          && Keeper_config.validate_name agent_name
-  then
-    Some agent_name
   else
     None
 
+let keeper_name_from_agent_name agent_name =
+  match
+    parse_keeper_agent_name ~prefix:"keeper-" ~suffix:"-agent" agent_name
+  with
+  | Some keeper_name -> Some keeper_name
+  | None -> (
+      match
+        parse_keeper_agent_name ~prefix:"keeper_" ~suffix:"_agent" agent_name
+      with
+      | Some keeper_name -> Some keeper_name
+      | None -> (
+          match
+            parse_keeper_agent_name ~prefix:"keeper-" ~suffix:"_agent" agent_name
+          with
+          | Some keeper_name -> Some keeper_name
+          | None -> (
+              match
+                parse_keeper_agent_name ~prefix:"keeper_" ~suffix:"-agent" agent_name
+              with
+              | Some keeper_name -> Some keeper_name
+              | None ->
+                  if Nickname.is_generated_nickname agent_name
+                     && Keeper_config.validate_name agent_name
+                  then
+                    Some agent_name
+                  else
+                    None)))
+
 let is_keeper_agent_alias agent_name =
-  let prefix = "keeper-" and suffix = "-agent" in
-  let plen = String.length prefix and slen = String.length suffix in
-  let alen = String.length agent_name in
-  alen > plen + slen
-  && String.sub agent_name 0 plen = prefix
-  && String.sub agent_name (alen - slen) slen = suffix
+  Option.is_some
+    (parse_keeper_agent_name ~prefix:"keeper-" ~suffix:"-agent" agent_name)
+  || Option.is_some
+       (parse_keeper_agent_name ~prefix:"keeper_" ~suffix:"_agent" agent_name)
+  || Option.is_some
+       (parse_keeper_agent_name ~prefix:"keeper-" ~suffix:"_agent" agent_name)
+  || Option.is_some
+       (parse_keeper_agent_name ~prefix:"keeper_" ~suffix:"-agent" agent_name)
 
 let canonical_keeper_name_from_agent_name agent_name =
   let trimmed = String.trim agent_name in

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -1,0 +1,335 @@
+(** Operator-facing keeper sandbox control.
+
+    This module keeps Docker lifecycle operations scoped to MASC keeper labels
+    and the active base path.  It deliberately manages only containers with
+    [container_kind=managed]; turn/oneshot containers remain owned by their
+    existing execution paths and stale cleanup. *)
+
+open Keeper_types
+
+let managed_kind = "managed"
+
+let now_ms () =
+  int_of_float (Unix.gettimeofday () *. 1000.0)
+
+let normalize_path path =
+  Keeper_alerting_path.normalize_path_for_check path
+  |> Keeper_alerting_path.strip_trailing_slashes
+
+let rec ensure_dir path =
+  if path = "" || path = "." || path = "/" then
+    ()
+  else if Sys.file_exists path then
+    ()
+  else (
+    let parent = Filename.dirname path in
+    if parent <> path then ensure_dir parent;
+    Unix.mkdir path 0o755)
+
+let managed_container_name ~(meta : keeper_meta) ~(network_label : string) =
+  Printf.sprintf "masc-keeper-managed-%s-%s-%d-%d"
+    (Coord_utils.safe_filename meta.name)
+    (Coord_utils.safe_filename network_label)
+    (Unix.getpid ())
+    (now_ms ())
+
+let configured_effective_network network_mode =
+  if Env_config_keeper.KeeperSandbox.hard_mode () then
+    Network_none
+  else
+    network_mode
+
+let live_containers ~config ~meta ~timeout_sec =
+  Keeper_sandbox_runtime.list_containers
+    ~keeper_name:meta.name
+    ~base_path:config.Coord.base_path
+    ~timeout_sec
+    ()
+
+let running_managed_container ~network_label containers =
+  List.find_opt
+    (fun (c : Keeper_sandbox_runtime.live_container) ->
+      c.container_kind = Some managed_kind
+      && c.running = Some true
+      && c.network_label = Some network_label)
+    containers
+
+let start_managed_container
+    ~(config : Coord.config)
+    ~(meta : keeper_meta)
+    ~(network_mode : network_mode)
+    ~(ttl_sec : float)
+    ~(timeout_sec : float)
+    () =
+  if meta.sandbox_profile <> Docker then
+    Error "keeper sandbox start requires sandbox_profile=docker"
+  else
+    let network_mode = configured_effective_network network_mode in
+    let network_args, network_label =
+      Keeper_sandbox_runtime.docker_network_args network_mode
+    in
+    match live_containers ~config ~meta ~timeout_sec:2.0 with
+    | Ok containers -> (
+        match running_managed_container ~network_label containers with
+        | Some container ->
+            Ok
+              (`Assoc
+                 [
+                   ("started", `Bool false);
+                   ("already_running", `Bool true);
+                   ("container",
+                    Keeper_sandbox_runtime.live_container_to_yojson container);
+                 ])
+        | None ->
+            let image = Env_config_keeper.KeeperSandbox.docker_image () in
+            if String.trim image = "" then
+              Error "keeper sandbox docker image is not configured"
+            else
+              let _cleanup =
+                Keeper_sandbox_runtime.maybe_cleanup_stale_containers
+                  ~base_path:config.base_path ~timeout_sec:2.0 ()
+              in
+              match
+                Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime
+                  ~timeout_sec
+              with
+              | Error _ as err -> err
+              | Ok seccomp_args ->
+                  let host_root =
+                    Keeper_sandbox.host_root_abs_of_meta ~config meta
+                    |> normalize_path
+                  in
+                  ensure_dir host_root;
+                  let container_root =
+                    Keeper_sandbox.container_root meta.name
+                    |> Keeper_alerting_path.strip_trailing_slashes
+                  in
+                  let uid = Unix.getuid () in
+                  let gid = Unix.getgid () in
+                  let container_name =
+                    managed_container_name ~meta ~network_label
+                  in
+                  let argv =
+                    Keeper_sandbox_runtime.docker_command_argv ()
+                    @ [
+                        "run";
+                        "-d";
+                        "--rm";
+                        "--name";
+                        container_name;
+                      ]
+                    @ Keeper_sandbox_runtime.docker_label_args
+                        ~ttl_sec
+                        ~base_path:config.base_path
+                        ~keeper_name:meta.name
+                        ~container_kind:managed_kind
+                        ~network_label ()
+                    @ [
+                      "--user";
+                      Printf.sprintf "%d:%d" uid gid;
+                    ]
+                    @ Env_config_keeper.KeeperSandbox.read_only_rootfs_args ()
+                    @ [
+                      "--tmpfs";
+                      Env_config_keeper.KeeperSandbox.tmpfs_mount ();
+                      "--cap-drop=ALL";
+                      "--security-opt";
+                      "no-new-privileges";
+                    ]
+                    @ seccomp_args
+                    @ [
+                      "--pids-limit";
+                      string_of_int
+                        (Env_config_keeper.KeeperSandbox.pids_limit ());
+                      "--memory";
+                      Env_config_keeper.KeeperSandbox.memory ();
+                      "-v";
+                      host_root ^ ":" ^ container_root ^ ":rw";
+                      "--workdir";
+                      container_root;
+                    ]
+                    @ network_args
+                    @ [
+                      image;
+                      "sh";
+                      "-lc";
+                      "trap : TERM INT; while :; do sleep 3600; done";
+                    ]
+                  in
+                  let st, out =
+                    Process_eio.run_argv_with_status
+                      ~env:(Unix.environment ())
+                      ~cwd:(Sys.getcwd ())
+                      ~timeout_sec
+                      argv
+                  in
+                  if st = Unix.WEXITED 0 then (
+                    Keeper_registry.clear_error
+                      ~base_path:config.base_path meta.name;
+                    Ok
+                      (`Assoc
+                         [
+                           ("started", `Bool true);
+                           ("already_running", `Bool false);
+                           ("container_id", `String (String.trim out));
+                           ("container_name", `String container_name);
+                           ("container_kind", `String managed_kind);
+                           ("network_label", `String network_label);
+                           ("ttl_sec", `Float ttl_sec);
+                           ("image", `String image);
+                         ]))
+                  else (
+                    let message =
+                      Printf.sprintf "docker_managed_container_start_failed: %s"
+                        (Worker_dev_tools.truncate_for_log out)
+                    in
+                    Keeper_registry.record_error
+                      ~base_path:config.base_path meta.name message;
+                    Error message))
+    | Error err -> Error err
+
+let stop_managed_containers ?keeper_name ~(config : Coord.config)
+    ~(timeout_sec : float) () =
+  Keeper_sandbox_runtime.stop_containers
+    ?keeper_name
+    ~container_kind:managed_kind
+    ~base_path:config.base_path
+    ~timeout_sec
+    ()
+
+let cleanup_stale ~(config : Coord.config) ~(timeout_sec : float) () =
+  Keeper_sandbox_runtime.cleanup_stale_containers
+    ~base_path:config.base_path
+    ~timeout_sec
+    ()
+
+let json_string_list values =
+  `List (List.map (fun value -> `String value) values)
+
+let preflight_status_json ~timeout_sec =
+  Keeper_sandbox_runtime.docker_preflight ~timeout_sec ()
+  |> Option.map Keeper_sandbox_runtime.docker_preflight_to_yojson
+
+let preflight_ok = function
+  | Some (`Assoc fields) -> (
+      match List.assoc_opt "ok" fields with
+      | Some (`Bool value) -> Some value
+      | _ -> None)
+  | _ -> None
+
+let container_mode (meta : keeper_meta) containers =
+  if meta.sandbox_profile = Local then
+    "local"
+  else if
+    List.exists
+      (fun (c : Keeper_sandbox_runtime.live_container) ->
+        c.container_kind = Some managed_kind && c.running = Some true)
+      containers
+  then
+    "managed_running"
+  else
+    match meta.network_mode with
+    | Network_none -> "turn_scoped_or_managed_none"
+    | Network_inherit -> "oneshot_or_managed_inherit"
+
+let why_no_container (meta : keeper_meta) ~preflight containers =
+  if meta.sandbox_profile = Local then
+    Some "sandbox_profile=local"
+  else if containers <> [] then
+    None
+  else
+    match preflight_ok preflight with
+    | Some false -> Some "docker_preflight_failed"
+    | _ -> (
+        match meta.network_mode with
+        | Network_inherit ->
+            Some
+              "network_mode=inherit uses one-shot Docker containers unless a managed sandbox is explicitly started"
+        | Network_none ->
+            Some
+              "no active turn or managed sandbox container; Docker containers start on sandboxed tool calls or via masc_keeper_sandbox_start")
+
+let recommendation (meta : keeper_meta) ~preflight containers =
+  if meta.sandbox_profile = Local then
+    Some "No Docker container is expected for sandbox_profile=local."
+  else if containers <> [] then
+    None
+  else
+    match preflight_ok preflight with
+    | Some false ->
+        Some
+          "Fix Docker preflight first, then rerun masc_keeper_sandbox_status."
+    | _ ->
+        Some
+          (Printf.sprintf
+             "Run masc_keeper_sandbox_start with name=%S to prewarm a visible managed container."
+             meta.name)
+
+let identity_json (meta : keeper_meta) =
+  let expected_agent_name = Keeper_types.keeper_agent_name meta.name in
+  let agent_name_matches = String.equal expected_agent_name meta.agent_name in
+  `Assoc
+    [
+      ("agent_name", `String meta.agent_name);
+      ("expected_agent_name", `String expected_agent_name);
+      ("agent_name_matches", `Bool agent_name_matches);
+      ("trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id));
+      ( "warnings",
+        if agent_name_matches then
+          `List []
+        else
+          `List
+            [
+              `String
+                "keeper agent_name does not match the canonical keeper name; repair or recreate this keeper trace before relying on scheduling evidence";
+            ] );
+    ]
+
+let live_status_json ?(include_preflight = true)
+    ~(config : Coord.config)
+    ~(meta : keeper_meta)
+    ~(timeout_sec : float)
+    ~(verbose : bool)
+    () =
+  let preflight =
+    if include_preflight && meta.sandbox_profile = Docker then
+      preflight_status_json ~timeout_sec
+    else
+      None
+  in
+  let containers, container_error =
+    if meta.sandbox_profile = Docker then
+      match live_containers ~config ~meta ~timeout_sec with
+      | Ok containers -> (containers, None)
+      | Error err -> ([], Some err)
+    else
+      ([], None)
+  in
+  let why_no_container =
+    match container_error with
+    | Some _ -> Some "docker_container_listing_failed"
+    | None -> why_no_container meta ~preflight containers
+  in
+  let recommendation =
+    match container_error with
+    | Some _ ->
+        Some "Check Docker daemon availability and retry sandbox status."
+    | None -> recommendation meta ~preflight containers
+  in
+  `Assoc
+    [
+      ("keeper", `String meta.name);
+      ("sandbox_profile", `String (sandbox_profile_to_string meta.sandbox_profile));
+      ("configured_network_mode", `String (network_mode_to_string meta.network_mode));
+      ("effective_mode", `String (container_mode meta containers));
+      ("managed_container_kind", `String managed_kind);
+      ("container_count", `Int (List.length containers));
+      ("containers",
+       `List (List.map Keeper_sandbox_runtime.live_container_to_yojson containers));
+      ( "preflight",
+        if verbose then Json_util.option_to_yojson Fun.id preflight else `Null );
+      ("container_error", Json_util.string_opt_to_json container_error);
+      ("why_no_container", Json_util.string_opt_to_json why_no_container);
+      ("recommendation", Json_util.string_opt_to_json recommendation);
+      ("identity", identity_json meta);
+    ]

--- a/lib/keeper/keeper_sandbox_control.mli
+++ b/lib/keeper/keeper_sandbox_control.mli
@@ -1,0 +1,34 @@
+open Keeper_types
+
+val managed_kind : string
+
+val start_managed_container :
+  config:Coord.config ->
+  meta:keeper_meta ->
+  network_mode:network_mode ->
+  ttl_sec:float ->
+  timeout_sec:float ->
+  unit ->
+  (Yojson.Safe.t, string) result
+
+val stop_managed_containers :
+  ?keeper_name:string ->
+  config:Coord.config ->
+  timeout_sec:float ->
+  unit ->
+  Keeper_sandbox_runtime.stop_result
+
+val cleanup_stale :
+  config:Coord.config ->
+  timeout_sec:float ->
+  unit ->
+  Keeper_sandbox_runtime.cleanup_result
+
+val live_status_json :
+  ?include_preflight:bool ->
+  config:Coord.config ->
+  meta:keeper_meta ->
+  timeout_sec:float ->
+  verbose:bool ->
+  unit ->
+  Yojson.Safe.t

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -7,22 +7,30 @@
     dependency cycle. *)
 
 let docker_command () =
-  let bin = "docker" in
-  match Sys.getenv_opt "PATH" with
-  | None -> bin
-  | Some path ->
-      let rec loop = function
-        | [] -> bin
-        | dir :: rest ->
-            let dir = if dir = "" then "." else dir in
-            let candidate = Filename.concat dir bin in
-            (try
-               Unix.access candidate [ Unix.X_OK ];
-               candidate
-             with
-             | Unix.Unix_error _ -> loop rest)
-      in
-      loop (String.split_on_char ':' path)
+  match Sys.getenv_opt "MASC_TEST_FAKE_DOCKER_PATH" with
+  | Some path when String.trim path <> "" -> path
+  | _ ->
+      let bin = "docker" in
+      match Sys.getenv_opt "PATH" with
+      | None -> bin
+      | Some path ->
+          let rec loop = function
+            | [] -> bin
+            | dir :: rest ->
+                let dir = if dir = "" then "." else dir in
+                let candidate = Filename.concat dir bin in
+                (try
+                   Unix.access candidate [ Unix.X_OK ];
+                   candidate
+                 with
+                 | Unix.Unix_error _ -> loop rest)
+          in
+          loop (String.split_on_char ':' path)
+
+let docker_command_argv () =
+  match Sys.getenv_opt "MASC_TEST_FAKE_DOCKER_PATH" with
+  | Some path when String.trim path <> "" -> [ "/bin/sh"; path ]
+  | _ -> [ docker_command () ]
 
 let docker_info_security_options ~timeout_sec =
   let st, out =
@@ -30,7 +38,7 @@ let docker_info_security_options ~timeout_sec =
       ~env:(Unix.environment ())
       ~cwd:(Sys.getcwd ())
       ~timeout_sec
-      [ docker_command (); "info"; "--format"; "{{json .SecurityOptions}}" ]
+      (docker_command_argv () @ [ "info"; "--format"; "{{json .SecurityOptions}}" ])
   in
   if st <> Unix.WEXITED 0 then
     Error
@@ -136,6 +144,7 @@ let sandbox_kind_label_key = "masc.mcp.kind"
 let sandbox_owner_pid_label_key = "masc.mcp.owner_pid"
 let sandbox_started_at_label_key = "masc.mcp.started_at"
 let sandbox_network_label_key = "masc.mcp.network"
+let sandbox_ttl_sec_label_key = "masc.mcp.ttl_sec"
 
 let strip_trailing_slashes path =
   let rec loop i =
@@ -169,7 +178,7 @@ let sanitize_label_value value =
       | _ -> '_')
     value
 
-let docker_label_args ~base_path ~keeper_name ~container_kind ~network_label () =
+let docker_label_args ?ttl_sec ~base_path ~keeper_name ~container_kind ~network_label () =
   let label key value = [ "--label"; key ^ "=" ^ value ] in
   label sandbox_component_label_key sandbox_component_label_value
   @ label sandbox_base_path_hash_label_key (base_path_hash base_path)
@@ -179,12 +188,45 @@ let docker_label_args ~base_path ~keeper_name ~container_kind ~network_label () 
   @ label sandbox_started_at_label_key
       (Printf.sprintf "%.3f" (Unix.gettimeofday ()))
   @ label sandbox_network_label_key (sanitize_label_value network_label)
+  @
+  match ttl_sec with
+  | Some value when value > 0.0 ->
+      label sandbox_ttl_sec_label_key (Printf.sprintf "%.0f" value)
+  | _ -> []
+
+let docker_network_args = function
+  | Keeper_types.Network_none -> ([ "--network"; "none" ], "none")
+  | Keeper_types.Network_inherit -> ([], "inherit")
 
 type inspected_container =
   {
     owner_pid : int option;
     started_at : float option;
     running : bool option;
+    ttl_sec : float option;
+  }
+
+type live_container =
+  {
+    id : string;
+    name : string;
+    image : string;
+    status : string;
+    running : bool option;
+    created_at : string option;
+    keeper_name : string option;
+    container_kind : string option;
+    network_label : string option;
+    owner_pid : int option;
+    started_at : float option;
+    ttl_sec : float option;
+  }
+
+type stop_result =
+  {
+    matched : int;
+    removed : int;
+    errors : string list;
   }
 
 let nonempty_lines out =
@@ -207,18 +249,67 @@ let bool_opt text =
   | "false" -> Some false
   | _ -> None
 
+let string_opt text =
+  match String.trim text with
+  | "" | "<no value>" -> None
+  | value -> Some value
+
+let strip_leading_slash text =
+  let text = String.trim text in
+  if String.length text > 0 && text.[0] = '/' then
+    String.sub text 1 (String.length text - 1)
+  else
+    text
+
 let parse_inspect_line line =
   match String.split_on_char '\t' line with
-  | [ owner_pid; started_at; running ] ->
+  | [ owner_pid; started_at; running; ttl_sec ] ->
       Ok
         {
           owner_pid = int_opt owner_pid;
           started_at = float_opt started_at;
           running = bool_opt running;
+          ttl_sec = float_opt ttl_sec;
         }
   | _ ->
       Error
         (Printf.sprintf "unexpected docker inspect cleanup payload: %s"
+           (Worker_dev_tools.truncate_for_log line))
+
+let parse_live_container_line line =
+  match String.split_on_char '\t' line with
+  | [
+      id;
+      name;
+      image;
+      status;
+      running;
+      created_at;
+      keeper_name;
+      container_kind;
+      network_label;
+      owner_pid;
+      started_at;
+      ttl_sec;
+    ] ->
+      Ok
+        {
+          id = String.trim id;
+          name = strip_leading_slash name;
+          image = String.trim image;
+          status = String.trim status;
+          running = bool_opt running;
+          created_at = string_opt created_at;
+          keeper_name = string_opt keeper_name;
+          container_kind = string_opt container_kind;
+          network_label = string_opt network_label;
+          owner_pid = int_opt owner_pid;
+          started_at = float_opt started_at;
+          ttl_sec = float_opt ttl_sec;
+        }
+  | _ ->
+      Error
+        (Printf.sprintf "unexpected docker inspect container payload: %s"
            (Worker_dev_tools.truncate_for_log line))
 
 let pid_alive pid =
@@ -233,7 +324,8 @@ let pid_alive pid =
     | Unix.Unix_error (Unix.EPERM, _, _) -> true
     | Unix.Unix_error _ -> false
 
-let should_remove_container ~now ~max_age_sec inspected =
+let should_remove_container ~now ~max_age_sec
+    (inspected : inspected_container) =
   let stopped =
     match inspected.running with
     | Some false -> true
@@ -244,9 +336,14 @@ let should_remove_container ~now ~max_age_sec inspected =
     | Some pid -> not (pid_alive pid)
     | None -> false
   in
+  let age_limit =
+    match inspected.ttl_sec with
+    | Some ttl when ttl > 0.0 -> min max_age_sec ttl
+    | _ -> max_age_sec
+  in
   let expired =
     match inspected.started_at with
-    | Some started_at -> now -. started_at > max_age_sec
+    | Some started_at -> now -. started_at > age_limit
     | None -> false
   in
   stopped || owner_dead || expired
@@ -257,14 +354,16 @@ let inspect_cleanup_container ~container_id ~timeout_sec =
     ^ sandbox_owner_pid_label_key
     ^ "\" }}\t{{ index .Config.Labels \""
     ^ sandbox_started_at_label_key
-    ^ "\" }}\t{{ .State.Running }}"
+    ^ "\" }}\t{{ .State.Running }}\t{{ index .Config.Labels \""
+    ^ sandbox_ttl_sec_label_key
+    ^ "\" }}"
   in
   let st, out =
     Process_eio.run_argv_with_status
       ~env:(Unix.environment ())
       ~cwd:(Sys.getcwd ())
       ~timeout_sec
-      [ docker_command (); "inspect"; "--format"; format; container_id ]
+      (docker_command_argv () @ [ "inspect"; "--format"; format; container_id ])
   in
   if st <> Unix.WEXITED 0 then
     Error
@@ -286,7 +385,7 @@ let remove_cleanup_container ~container_id ~timeout_sec =
       ~env:(Unix.environment ())
       ~cwd:(Sys.getcwd ())
       ~timeout_sec
-      [ docker_command (); "rm"; "-f"; container_id ]
+      (docker_command_argv () @ [ "rm"; "-f"; container_id ])
   in
   if st = Unix.WEXITED 0 then
     Ok ()
@@ -305,21 +404,21 @@ let cleanup_stale_containers ?(now = Unix.gettimeofday ())
         ~env:(Unix.environment ())
         ~cwd:(Sys.getcwd ())
         ~timeout_sec
-        [
-          docker_command ();
-          "ps";
-          "-aq";
-          "--filter";
-          "label="
-          ^ sandbox_component_label_key
-          ^ "="
-          ^ sandbox_component_label_value;
-          "--filter";
-          "label="
-          ^ sandbox_base_path_hash_label_key
-          ^ "="
-          ^ base_path_hash base_path;
-        ]
+        (docker_command_argv ()
+        @ [
+            "ps";
+            "-aq";
+            "--filter";
+            "label="
+            ^ sandbox_component_label_key
+            ^ "="
+            ^ sandbox_component_label_value;
+            "--filter";
+            "label="
+            ^ sandbox_base_path_hash_label_key
+            ^ "="
+            ^ base_path_hash base_path;
+          ])
     in
     if st <> Unix.WEXITED 0 then
       {
@@ -363,6 +462,139 @@ let cleanup_stale_containers ?(now = Unix.gettimeofday ())
           ];
       }
 
+let docker_filter_args ?keeper_name ?container_kind ~base_path () =
+  let label_filter key value = [ "--filter"; "label=" ^ key ^ "=" ^ value ] in
+  label_filter sandbox_component_label_key sandbox_component_label_value
+  @ label_filter sandbox_base_path_hash_label_key (base_path_hash base_path)
+  @
+  (match keeper_name with
+   | Some name when String.trim name <> "" ->
+       label_filter sandbox_keeper_label_key (sanitize_label_value name)
+   | _ -> [])
+  @
+  match container_kind with
+  | Some kind when String.trim kind <> "" ->
+      label_filter sandbox_kind_label_key (sanitize_label_value kind)
+  | _ -> []
+
+let list_container_ids ?keeper_name ?container_kind ~base_path ~timeout_sec () =
+  try
+    let st, out =
+      Process_eio.run_argv_with_status
+        ~env:(Unix.environment ())
+        ~cwd:(Sys.getcwd ())
+        ~timeout_sec
+        (docker_command_argv () @ [ "ps"; "-aq" ]
+         @ docker_filter_args ?keeper_name ?container_kind ~base_path ())
+    in
+    if st = Unix.WEXITED 0 then
+      Ok (nonempty_lines out)
+    else
+      Error
+        (Printf.sprintf "docker ps failed while listing keeper sandbox containers: %s"
+           (Worker_dev_tools.truncate_for_log out))
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+      Error
+        (Printf.sprintf "keeper sandbox container listing failed: %s"
+           (Printexc.to_string exn))
+
+let live_inspect_format =
+  "{{ .Id }}\t{{ .Name }}\t{{ .Config.Image }}\t{{ .State.Status }}\t{{ .State.Running }}\t{{ .Created }}\t{{ index .Config.Labels \""
+  ^ sandbox_keeper_label_key
+  ^ "\" }}\t{{ index .Config.Labels \""
+  ^ sandbox_kind_label_key
+  ^ "\" }}\t{{ index .Config.Labels \""
+  ^ sandbox_network_label_key
+  ^ "\" }}\t{{ index .Config.Labels \""
+  ^ sandbox_owner_pid_label_key
+  ^ "\" }}\t{{ index .Config.Labels \""
+  ^ sandbox_started_at_label_key
+  ^ "\" }}\t{{ index .Config.Labels \""
+  ^ sandbox_ttl_sec_label_key
+  ^ "\" }}"
+
+let list_containers ?keeper_name ?container_kind ~base_path ~timeout_sec () =
+  match list_container_ids ?keeper_name ?container_kind ~base_path ~timeout_sec () with
+  | Error _ as err -> err
+  | Ok [] -> Ok []
+  | Ok ids ->
+      let st, out =
+        Process_eio.run_argv_with_status
+          ~env:(Unix.environment ())
+          ~cwd:(Sys.getcwd ())
+          ~timeout_sec
+          (docker_command_argv () @ [ "inspect"; "--format"; live_inspect_format ] @ ids)
+      in
+      if st <> Unix.WEXITED 0 then
+        Error
+          (Printf.sprintf "docker inspect failed while listing keeper sandbox containers: %s"
+             (Worker_dev_tools.truncate_for_log out))
+      else
+        let parsed =
+          nonempty_lines out
+          |> List.map parse_live_container_line
+        in
+        let errors =
+          parsed
+          |> List.filter_map (function Error err -> Some err | Ok _ -> None)
+        in
+        if errors <> [] then
+          Error (String.concat "; " errors)
+        else
+          Ok
+            (parsed
+             |> List.filter_map (function Ok item -> Some item | Error _ -> None))
+
+let option_string_field name = function
+  | Some value -> (name, `String value)
+  | None -> (name, `Null)
+
+let option_float_field name = function
+  | Some value -> (name, `Float value)
+  | None -> (name, `Null)
+
+let option_int_field name = function
+  | Some value -> (name, `Int value)
+  | None -> (name, `Null)
+
+let option_bool_field name = function
+  | Some value -> (name, `Bool value)
+  | None -> (name, `Null)
+
+let live_container_to_yojson (c : live_container) =
+  `Assoc
+    [
+      ("id", `String c.id);
+      ("name", `String c.name);
+      ("image", `String c.image);
+      ("status", `String c.status);
+      option_bool_field "running" c.running;
+      option_string_field "created_at" c.created_at;
+      option_string_field "keeper_name" c.keeper_name;
+      option_string_field "container_kind" c.container_kind;
+      option_string_field "network_label" c.network_label;
+      option_int_field "owner_pid" c.owner_pid;
+      option_float_field "started_at" c.started_at;
+      option_float_field "ttl_sec" c.ttl_sec;
+    ]
+
+let stop_containers ?keeper_name ?container_kind ~base_path ~timeout_sec () =
+  match list_container_ids ?keeper_name ?container_kind ~base_path ~timeout_sec () with
+  | Error err -> { matched = 0; removed = 0; errors = [ err ] }
+  | Ok ids ->
+      let removed, errors =
+        List.fold_left
+          (fun (removed, errors) container_id ->
+            match remove_cleanup_container ~container_id ~timeout_sec with
+            | Ok () -> (removed + 1, errors)
+            | Error err -> (removed, err :: errors))
+          (0, [])
+          ids
+      in
+      { matched = List.length ids; removed; errors = List.rev errors }
+
 let last_cleanup_at = ref 0.0
 
 let maybe_cleanup_stale_containers ~base_path ~timeout_sec () =
@@ -386,7 +618,7 @@ let docker_image_present ~image ~timeout_sec =
         ~env:(Unix.environment ())
         ~cwd:(Sys.getcwd ())
         ~timeout_sec
-        [ docker_command (); "image"; "inspect"; image ]
+        (docker_command_argv () @ [ "image"; "inspect"; image ])
     in
     if st = Unix.WEXITED 0 then
       Ok ()
@@ -411,8 +643,18 @@ let docker_image_required_commands ~image ~timeout_sec =
       ~env:(Unix.environment ())
       ~cwd:(Sys.getcwd ())
       ~timeout_sec
-      [ docker_command (); "run"; "--rm"; "--network"; "none"; "--entrypoint"; "sh";
-        image; "-lc"; script ]
+      (docker_command_argv ()
+      @ [
+          "run";
+          "--rm";
+          "--network";
+          "none";
+          "--entrypoint";
+          "sh";
+          image;
+          "-lc";
+          script;
+        ])
   in
   if st = Unix.WEXITED 0 then
     let missing =

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -40,12 +40,42 @@ type cleanup_result =
     errors : string list;
   }
 
+type live_container =
+  {
+    id : string;
+    name : string;
+    image : string;
+    status : string;
+    running : bool option;
+    created_at : string option;
+    keeper_name : string option;
+    container_kind : string option;
+    network_label : string option;
+    owner_pid : int option;
+    started_at : float option;
+    ttl_sec : float option;
+  }
+
+type stop_result =
+  {
+    matched : int;
+    removed : int;
+    errors : string list;
+  }
+
 val docker_command : unit -> string
 (** Resolve the Docker CLI from the current [PATH]. This keeps Docker
     calls deterministic after the Eio process manager has been
     initialized and tests inject a fake [docker] binary. *)
 
+val docker_command_argv : unit -> string list
+(** Process argv prefix for invoking Docker. Tests may inject a shell
+    script fake [docker] binary; this helper wraps that path via
+    [/bin/sh] so direct script execution does not depend on host shebang
+    handling. *)
+
 val docker_label_args :
+  ?ttl_sec:float ->
   base_path:string ->
   keeper_name:string ->
   container_kind:string ->
@@ -54,6 +84,35 @@ val docker_label_args :
   string list
 (** Docker [--label] argv fragment for containers owned by the keeper
     sandbox runtime. *)
+
+val docker_network_args :
+  Keeper_types.network_mode -> string list * string
+(** Docker network argv fragment and the MASC network label.  In
+    particular, [Network_inherit] intentionally maps to no Docker
+    [--network] argument; Docker has no network named ["inherit"]. *)
+
+val list_containers :
+  ?keeper_name:string ->
+  ?container_kind:string ->
+  base_path:string ->
+  timeout_sec:float ->
+  unit ->
+  (live_container list, string) result
+(** List MASC keeper sandbox containers scoped to the same [base_path].
+    Optional filters are implemented via Docker labels, not name matching. *)
+
+val live_container_to_yojson :
+  live_container -> Yojson.Safe.t
+
+val stop_containers :
+  ?keeper_name:string ->
+  ?container_kind:string ->
+  base_path:string ->
+  timeout_sec:float ->
+  unit ->
+  stop_result
+(** Stop containers scoped to this base path and optional keeper/kind
+    labels.  This never targets containers lacking MASC keeper labels. *)
 
 val cleanup_stale_containers :
   ?now:float ->

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -381,6 +381,82 @@ let keeper_schemas : tool_schema list = [
   };
 
   {
+    name = "masc_keeper_sandbox_status";
+    description = "Inspect Docker sandbox state for one keeper or all keepers. Reports Docker preflight, visible containers, why no container is present, and identity drift warnings.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Keeper handle. When omitted, return sandbox status for all registered keepers.");
+        ]);
+        ("verbose", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "Include full Docker preflight details in each result.");
+        ]);
+        ("include_preflight", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "When true, include Docker preflight status for docker keepers.");
+        ]);
+        ("timeout_sec", `Assoc [
+          ("type", `String "number");
+          ("description", `String "Docker command timeout in seconds (default: 5).");
+        ]);
+      ]);
+    ];
+  };
+
+  {
+    name = "masc_keeper_sandbox_start";
+    description = "Start a visible managed Docker sandbox container for a keeper. Only applies to sandbox_profile=docker keepers.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Keeper handle.");
+        ]);
+        ("network_mode", `Assoc [
+          ("type", `String "string");
+          ("enum", `List (List.map (fun s -> `String s) network_mode_enum_strings));
+          ("description", `String "Managed container network policy. Defaults to the keeper's configured network_mode.");
+        ]);
+        ("ttl_sec", `Assoc [
+          ("type", `String "number");
+          ("description", `String "Managed container TTL in seconds before stale cleanup removes it (default: 1800).");
+        ]);
+        ("timeout_sec", `Assoc [
+          ("type", `String "number");
+          ("description", `String "Docker command timeout in seconds (default: 10).");
+        ]);
+      ]);
+      ("required", `List [`String "name"]);
+    ];
+  };
+
+  {
+    name = "masc_keeper_sandbox_stop";
+    description = "Stop managed keeper sandbox containers. By default stops all managed keeper sandbox containers in the current base path.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional keeper handle. When omitted, stop all managed keeper sandbox containers for this base path.");
+        ]);
+        ("prune_stale", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "Also run stale keeper sandbox cleanup after stopping managed containers.");
+        ]);
+        ("timeout_sec", `Assoc [
+          ("type", `String "number");
+          ("description", `String "Docker command timeout in seconds (default: 10).");
+        ]);
+      ]);
+    ];
+  };
+
+  {
     name = "masc_keeper_msg";
     description = "Send a message to a keeper (async). Returns immediately with a request_id. Poll masc_keeper_msg_result for the response.";
     input_schema = `Assoc [

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -167,9 +167,7 @@ let run_docker_shell_command_with_status
         if git_creds_enabled then
           ([ "--network"; "bridge" ], "bridge")
         else
-          match network_mode with
-          | Network_none -> ([ "--network"; "none" ], "none")
-          | Network_inherit -> ([], network_mode_to_string network_mode)
+          Keeper_sandbox_runtime.docker_network_args network_mode
       in
       let cred_root = "/tmp/keeper-creds" in
       let cred_mounts, cred_envs =
@@ -255,13 +253,13 @@ let run_docker_shell_command_with_status
           [ "-e"; "GH_TOKEN=" ^ gh_token ]
       in
       let argv =
-        [
-          Keeper_sandbox_runtime.docker_command ();
-          "run";
-          "--rm";
-          "--name";
-          container_name;
-        ]
+        Keeper_sandbox_runtime.docker_command_argv ()
+        @ [
+            "run";
+            "--rm";
+            "--name";
+            container_name;
+          ]
         @ Keeper_sandbox_runtime.docker_label_args
             ~base_path:config.base_path
             ~keeper_name:meta.name

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -964,6 +964,11 @@ let handle_keeper_status ctx args : tool_result =
            | Some _, Some preflight -> Some preflight
            | _ -> None
          in
+         let sandbox_live =
+           Keeper_sandbox_control.live_status_json
+             ~include_preflight:false
+             ~config:ctx.config ~meta:m ~timeout_sec:5.0 ~verbose:false ()
+         in
          let runtime_blocker_fields =
           runtime_blocker_fields_json ctx.config m
          in
@@ -1049,6 +1054,7 @@ let handle_keeper_status ctx args : tool_result =
              Json_util.string_opt_to_json sandbox_last_error);
            ("sandbox_preflight",
              Json_util.option_to_yojson Fun.id sandbox_preflight);
+           ("sandbox_live", sandbox_live);
            ("effective_sandbox_image",
              Json_util.string_opt_to_json effective_sandbox_image);
            ("tool_policy_mode",
@@ -1255,6 +1261,7 @@ let handle_keeper_status ctx args : tool_result =
                Json_util.string_opt_to_json sandbox_last_error);
              ("sandbox_preflight",
                Json_util.option_to_yojson Fun.id sandbox_preflight);
+             ("sandbox_live", sandbox_live);
              ("effective_sandbox_image",
                Json_util.string_opt_to_json effective_sandbox_image);
              ("allowed_paths", string_list_to_json m.allowed_paths);

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -141,16 +141,18 @@ let start_container (t : t) ~(timeout_sec : float) =
     | Error _ as err -> err
     | Ok seccomp_args ->
         let container_name = container_name_of t in
-        let network_label = network_mode_to_string t.network_mode in
+        let network_args, network_label =
+          Keeper_sandbox_runtime.docker_network_args t.network_mode
+        in
         let argv =
-          [
-            Keeper_sandbox_runtime.docker_command ();
-            "run";
-            "-d";
-            "--rm";
-            "--name";
-            container_name;
-          ]
+          Keeper_sandbox_runtime.docker_command_argv ()
+          @ [
+              "run";
+              "-d";
+              "--rm";
+              "--name";
+              container_name;
+            ]
           @ Keeper_sandbox_runtime.docker_label_args
               ~base_path:t.config.base_path
               ~keeper_name:t.meta.name
@@ -178,8 +180,9 @@ let start_container (t : t) ~(timeout_sec : float) =
               t.host_root ^ ":" ^ t.container_root ^ ":rw";
               "--workdir";
               t.container_root;
-              "--network";
-              network_label;
+            ]
+          @ network_args
+          @ [
               image;
               "sh";
               "-lc";
@@ -212,14 +215,14 @@ let run_exec_with_status_once
   | Ok container_name ->
       let container_cwd = container_cwd_of_host t ~host_cwd:cwd in
       let argv =
-        [
-          Keeper_sandbox_runtime.docker_command ();
-          "exec";
-          "--user";
-          Printf.sprintf "%d:%d" t.uid t.gid;
-          "-w";
-          container_cwd;
-        ]
+        Keeper_sandbox_runtime.docker_command_argv ()
+        @ [
+            "exec";
+            "--user";
+            Printf.sprintf "%d:%d" t.uid t.gid;
+            "-w";
+            container_cwd;
+          ]
         @ (match stdin_content with Some _ -> [ "-i" ] | None -> [])
         @ (container_name :: command_argv)
       in
@@ -316,7 +319,8 @@ let cleanup (t : t) =
   | Running { container_name } ->
       t.state <- Not_started;
       let argv =
-        [ Keeper_sandbox_runtime.docker_command (); "rm"; "-f"; container_name ]
+        Keeper_sandbox_runtime.docker_command_argv ()
+        @ [ "rm"; "-f"; container_name ]
       in
       let _st, _out = run_argv_with_status_retry_eintr ~timeout_sec:5.0 argv in
       ()

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -1758,23 +1758,37 @@ let canonical_keeper_name_from_agent_name =
 
 let canonical_keeper_name = Keeper_identity.canonical_keeper_name
 
+let separator_alias_variants name =
+  let map_sep ~from_ch ~to_ch value =
+    String.map (fun c -> if c = from_ch then to_ch else c) value
+  in
+  Json_util.dedupe_keep_order
+    [ name; map_sep ~from_ch:'_' ~to_ch:'-' name; map_sep ~from_ch:'-' ~to_ch:'_' name ]
+
 let read_meta_resolved config name : ((string * keeper_meta) option, string) result =
   let requested_name = String.trim name in
   let read_candidate candidate =
     read_meta_file_path (keeper_meta_path config candidate)
     |> Result.map (Option.map (fun meta -> (candidate, meta)))
   in
+  let rec read_first = function
+    | [] -> Ok None
+    | candidate :: rest -> (
+        match read_candidate candidate with
+        | Ok None -> read_first rest
+        | Ok (Some _) as ok -> ok
+        | Error _ as err -> err)
+  in
   if requested_name = "" then
     Ok None
   else
-    match read_candidate requested_name with
-    | Ok None -> (
-        match keeper_name_from_agent_name requested_name with
-        | Some alias_name when not (String.equal alias_name requested_name) ->
-            read_candidate alias_name
-        | _ -> Ok None)
-    | Ok (Some _) as ok -> ok
-    | Error _ as err -> err
+    let alias_candidates =
+      match keeper_name_from_agent_name requested_name with
+      | Some alias_name when not (String.equal alias_name requested_name) ->
+          separator_alias_variants alias_name
+      | _ -> []
+    in
+    read_first (separator_alias_variants requested_name @ alias_candidates)
 ;;
 
 let read_meta config name : (keeper_meta option, string) result =

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -229,6 +229,9 @@ let custom_tool_titles : (string * string) list = [
   ("masc_keeper_msg", "Send Keeper Message");
   ("masc_keeper_repair", "Keeper Repair");
   ("masc_keeper_status", "Keeper Status");
+  ("masc_keeper_sandbox_status", "Keeper Sandbox Status");
+  ("masc_keeper_sandbox_start", "Start Keeper Sandbox");
+  ("masc_keeper_sandbox_stop", "Stop Keeper Sandbox");
   ("masc_keeper_down", "Stop Keeper");
   ("masc_keeper_compact", "Compact Keeper Context");
   ("masc_keeper_clear", "Clear Keeper Context");

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -129,6 +129,7 @@ let public_mcp_surface_tools =
     "masc_heartbeat";
     (* Keeper interaction *)
     "masc_keeper_msg"; "masc_keeper_msg_result"; "masc_keeper_list"; "masc_keeper_status";
+    "masc_keeper_sandbox_status"; "masc_keeper_sandbox_start"; "masc_keeper_sandbox_stop";
     "masc_keeper_up"; "masc_keeper_repair"; "masc_keeper_reset";
     "masc_keeper_down";
     "masc_persona_list";

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -69,6 +69,85 @@ let annotate_keeper_json ~runtime_class json =
       `Assoc (("runtime_class", `String runtime_class) :: fields)
   | other -> other
 
+let attach_assoc_field key value = function
+  | `Assoc fields -> `Assoc ((key, value) :: fields)
+  | other -> other
+
+let maybe_reseed_keeper_identity ctx (meta : keeper_meta) =
+  let expected_agent_name = Keeper_types.keeper_agent_name meta.name in
+  if String.equal expected_agent_name meta.agent_name then
+    Ok (meta, None)
+  else
+    let previous_trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+    let new_trace_id_raw = Keeper_identity.generate_trace_id () in
+    match Keeper_id.Trace_id.of_string new_trace_id_raw with
+    | Error err ->
+        Error
+          (Printf.sprintf
+             "failed to reseed keeper identity for %s: invalid trace_id %s (%s)"
+             meta.name new_trace_id_raw err)
+    | Ok new_trace_id ->
+        let base_dir = Keeper_types.session_base_dir ctx.config in
+        let _session =
+          Keeper_exec_context.create_session ~session_id:new_trace_id_raw
+            ~base_dir
+        in
+        let updated_meta =
+          {
+            meta with
+            agent_name = expected_agent_name;
+            updated_at = Keeper_types.now_iso ();
+            runtime =
+              {
+                meta.runtime with
+                trace_id = new_trace_id;
+                trace_history =
+                  Json_util.dedupe_keep_order
+                    (previous_trace_id :: meta.runtime.trace_history);
+                generation = meta.runtime.generation + 1;
+              };
+          }
+        in
+        (match Keeper_types.write_meta ~force:true ctx.config updated_meta with
+         | Ok () ->
+             Keeper_status_detail.invalidate_status_cache_for updated_meta.name;
+             Ok
+               ( updated_meta,
+                 Some
+                   (`Assoc
+                      [
+                        ("reason", `String "agent_name_mismatch");
+                        ("keeper_name", `String updated_meta.name);
+                        ("previous_agent_name", `String meta.agent_name);
+                        ("expected_agent_name", `String expected_agent_name);
+                        ("previous_trace_id", `String previous_trace_id);
+                        ("new_trace_id", `String new_trace_id_raw);
+                      ]) )
+         | Error err ->
+             Error
+               (Printf.sprintf
+                  "failed to persist reseeded keeper identity for %s: %s"
+                  meta.name err))
+
+let prepare_keeper_up_identity ctx args =
+  let name = String.trim (get_string args "name" "") in
+  match read_meta_resolved ctx.config name with
+  | Ok (Some (_resolved_name, meta)) -> (
+      match maybe_reseed_keeper_identity ctx meta with
+      | Ok (updated_meta, identity_reseed) ->
+          let prepared_args =
+            match args with
+            | `Assoc fields ->
+                `Assoc
+                  (("name", `String updated_meta.name)
+                  :: List.remove_assoc "name" fields)
+            | other -> other
+          in
+          Ok (prepared_args, identity_reseed)
+      | Error _ as err -> err)
+  | Ok None -> Ok (args, None)
+  | Error err -> Error (Printf.sprintf "❌ %s" err)
+
 let startup_not_ready_error_json elapsed =
   `Assoc
     [
@@ -91,17 +170,27 @@ let with_keeper_startup_gate f =
     f ()
 
 let execute_keeper_up ctx args : tool_result =
-  let ok, body = Turn.handle_keeper_up ctx args in
-  if not ok then (ok, body)
-  else
-    let json =
-      try Yojson.Safe.from_string body with Yojson.Json_error _ -> `String body
-    in
-    invalidate_keeper_list_cache ();
-    Keeper_status_detail.invalidate_status_cache_for (get_string args "name" "");
-    (true,
-     Yojson.Safe.pretty_to_string
-       (annotate_keeper_json ~runtime_class:"keeper" json))
+  match prepare_keeper_up_identity ctx args with
+  | Error err -> (false, err)
+  | Ok (prepared_args, identity_reseed) ->
+      let ok, body = Turn.handle_keeper_up ctx prepared_args in
+      if not ok then
+        (ok, body)
+      else
+        let json =
+          try Yojson.Safe.from_string body with Yojson.Json_error _ -> `String body
+        in
+        let json =
+          match identity_reseed with
+          | Some note -> attach_assoc_field "identity_reseed" note json
+          | None -> json
+        in
+        invalidate_keeper_list_cache ();
+        Keeper_status_detail.invalidate_status_cache_for
+          (get_string prepared_args "name" "");
+        (true,
+         Yojson.Safe.pretty_to_string
+           (annotate_keeper_json ~runtime_class:"keeper" json))
 
 let keeper_brief_meta_json (meta : keeper_meta) =
   `Assoc
@@ -359,7 +448,7 @@ let default_keeper_model_label (meta : keeper_meta) =
       | _ -> Env_config.Local_runtime.default_model)
   | model -> model
 
-let annotate_keeper_repair_json ~(keeper_name : string) body =
+let annotate_keeper_repair_json ?identity_reseed ~(keeper_name : string) body =
   let parsed =
     try Some (Yojson.Safe.from_string body) with Yojson.Json_error _ -> None
   in
@@ -367,10 +456,15 @@ let annotate_keeper_repair_json ~(keeper_name : string) body =
   | Some (`Assoc fields) ->
       Yojson.Safe.pretty_to_string
         (`Assoc
-          ( ("runtime_class", `String "keeper")
-          :: ("keeper_name", `String keeper_name)
-          :: ("delegated_tool", `String "masc_keeper_repair")
-          :: fields ))
+          ((match identity_reseed with
+            | Some note -> [ ("identity_reseed", note) ]
+            | None -> [])
+          @ [
+              ("runtime_class", `String "keeper");
+              ("keeper_name", `String keeper_name);
+              ("delegated_tool", `String "masc_keeper_repair");
+            ]
+          @ fields))
   | _ -> body
 
 (* Playground path containment helpers (inlined from deleted Tool_repair_loop). *)
@@ -446,7 +540,10 @@ let resolve_playground_working_dir ~agent_name ~base_path ~working_dir_arg =
 let handle_keeper_repair ctx args : tool_result =
   match resolve_keeper_meta ctx args with
   | Error err -> (false, err)
-  | Ok meta ->
+  | Ok meta -> (
+      match maybe_reseed_keeper_identity ctx meta with
+      | Error err -> (false, err)
+      | Ok (meta, identity_reseed) ->
       let task_spec = get_string args "task_spec" "" in
       if String.trim task_spec = "" then
         (false, "task_spec is required")
@@ -520,7 +617,9 @@ let handle_keeper_repair ctx args : tool_result =
                     (false, {|{"error":"team session oas bridge removed"}|})
                   in
                   invalidate_status_cache meta.name;
-                  (ok, annotate_keeper_repair_json ~keeper_name:meta.name body)
+                  ( ok,
+                    annotate_keeper_repair_json ?identity_reseed
+                      ~keeper_name:meta.name body ))
 
 let handle_keeper_down ctx args : tool_result =
   invalidate_keeper_list_cache ();
@@ -567,6 +666,136 @@ let handle_keeper_list ctx args : tool_result =
         Yojson.Safe.pretty_to_string json)
   in
   (true, body)
+
+let parse_network_mode_or_error raw =
+  match network_mode_of_string raw with
+  | Some mode -> Ok mode
+  | None ->
+      Error
+        (Printf.sprintf "invalid network_mode %S (allowed: %s)" raw
+           (String.concat ", " valid_network_mode_strings))
+
+let handle_keeper_sandbox_status ctx args : tool_result =
+  let verbose = get_bool args "verbose" false in
+  let include_preflight = get_bool args "include_preflight" true in
+  let timeout_sec = min 20.0 (max 1.0 (get_float args "timeout_sec" 5.0)) in
+  let render_item (meta : keeper_meta) =
+    Keeper_sandbox_control.live_status_json
+      ~include_preflight ~config:ctx.config ~meta ~timeout_sec ~verbose ()
+  in
+  match String.trim (get_string args "name" "") with
+  | "" ->
+      let items =
+        Keeper_registry.all ~base_path:ctx.config.base_path ()
+        |> List.sort (fun (a : Keeper_registry.registry_entry)
+                          (b : Keeper_registry.registry_entry) ->
+             String.compare a.name b.name)
+        |> List.filter_map (fun (entry : Keeper_registry.registry_entry) ->
+             match read_meta ctx.config entry.name with
+             | Ok (Some meta) -> Some (render_item meta)
+             | Ok None | Error _ -> None)
+      in
+      ( true,
+        Yojson.Safe.pretty_to_string
+          (`Assoc
+             [
+               ("count", `Int (List.length items));
+               ("items", `List items);
+             ]) )
+  | _ ->
+      (match resolve_keeper_meta ctx args with
+       | Error err -> (false, err)
+       | Ok meta ->
+           ( true,
+             Yojson.Safe.pretty_to_string
+               (`Assoc
+                  [
+                    ("keeper", `String meta.name);
+                    ("sandbox", render_item meta);
+                  ]) ))
+
+let handle_keeper_sandbox_start ctx args : tool_result =
+  match resolve_keeper_meta ctx args with
+  | Error err -> (false, err)
+  | Ok meta ->
+      let timeout_sec = min 30.0 (max 1.0 (get_float args "timeout_sec" 10.0)) in
+      let ttl_sec = min 86_400.0 (max 1.0 (get_float args "ttl_sec" 1800.0)) in
+      let network_mode_raw =
+        String.trim
+          (get_string args "network_mode"
+             (network_mode_to_string meta.network_mode))
+      in
+      (match parse_network_mode_or_error network_mode_raw with
+       | Error err -> (false, err)
+       | Ok network_mode -> (
+           match
+             Keeper_sandbox_control.start_managed_container
+               ~config:ctx.config ~meta ~network_mode ~ttl_sec ~timeout_sec ()
+           with
+           | Error err -> (false, err)
+           | Ok result ->
+               invalidate_status_cache meta.name;
+               ( true,
+                 Yojson.Safe.pretty_to_string
+                   (`Assoc
+                      [
+                        ("keeper", `String meta.name);
+                        ("action", `String "start");
+                        ("sandbox", result);
+                      ]) )))
+
+let handle_keeper_sandbox_stop ctx args : tool_result =
+  let timeout_sec = min 30.0 (max 1.0 (get_float args "timeout_sec" 10.0)) in
+  let prune_stale = get_bool args "prune_stale" false in
+  let keeper_name =
+    match String.trim (get_string args "name" "") with
+    | "" -> None
+    | name -> Some name
+  in
+  let stop_result =
+    Keeper_sandbox_control.stop_managed_containers
+      ?keeper_name ~config:ctx.config ~timeout_sec ()
+  in
+  let stale_cleanup =
+    if prune_stale then
+      Some
+        (Keeper_sandbox_control.cleanup_stale ~config:ctx.config
+           ~timeout_sec:(min timeout_sec 5.0) ())
+    else
+      None
+  in
+  (match keeper_name with
+   | Some name -> invalidate_status_cache name
+   | None -> Keeper_status_detail.invalidate_status_cache_all ());
+  let stop_json =
+    `Assoc
+      [
+        ("matched", `Int stop_result.matched);
+        ("removed", `Int stop_result.removed);
+        ("errors", `List (List.map (fun err -> `String err) stop_result.errors));
+      ]
+  in
+  let stale_json =
+    match stale_cleanup with
+    | None -> `Null
+    | Some cleanup ->
+        `Assoc
+          [
+            ("scanned", `Int cleanup.scanned);
+            ("removed", `Int cleanup.removed);
+            ("errors",
+             `List (List.map (fun err -> `String err) cleanup.errors));
+          ]
+  in
+  ( true,
+    Yojson.Safe.pretty_to_string
+      (`Assoc
+         [
+           ("action", `String "stop");
+           ("keeper", Json_util.string_opt_to_json keeper_name);
+           ("stop_result", stop_json);
+           ("stale_cleanup", stale_json);
+         ]) )
 
 (* masc_keeper_reconcile tool removed along with the manual_reconcile
    blocker mechanism. Failed turns record evidence via Keeper_registry;
@@ -914,6 +1143,9 @@ let dispatch ctx ~name ~args : tool_result option =
   | "masc_keeper_repair" -> Some (handle_keeper_repair ctx args)
   | "masc_keeper_down" -> Some (handle_keeper_down ctx args)
   | "masc_keeper_list" -> Some (handle_keeper_list ctx args)
+  | "masc_keeper_sandbox_status" -> Some (handle_keeper_sandbox_status ctx args)
+  | "masc_keeper_sandbox_start" -> Some (handle_keeper_sandbox_start ctx args)
+  | "masc_keeper_sandbox_stop" -> Some (handle_keeper_sandbox_stop ctx args)
   | "masc_keeper_reset" -> Some (handle_keeper_reset ctx args)
   | "masc_keeper_compact" -> Some (handle_keeper_compact ctx args)
   | "masc_keeper_clear" -> Some (handle_keeper_clear ctx args)
@@ -934,14 +1166,17 @@ let dispatch_stream ~on_text_delta ctx ~name ~args : tool_result option =
 (* Tool_spec registration                                           *)
 (* ================================================================ *)
 
-let _tool_spec_read_only = [ "masc_keeper_list"; "masc_keeper_status" ]
+let _tool_spec_read_only =
+  [ "masc_keeper_list"; "masc_keeper_status"; "masc_keeper_sandbox_status" ]
 
 let tool_required_permission = function
-  | "masc_persona_list" | "masc_keeper_list" | "masc_keeper_status" ->
+  | "masc_persona_list" | "masc_keeper_list" | "masc_keeper_status"
+  | "masc_keeper_sandbox_status" ->
       Some Types.CanReadState
   | "masc_keeper_create_from_persona" | "masc_keeper_up"
   | "masc_keeper_msg" | "masc_keeper_msg_result"
   | "masc_keeper_repair"
+  | "masc_keeper_sandbox_start" | "masc_keeper_sandbox_stop"
   | "masc_keeper_down" | "masc_keeper_reset"
   | "masc_keeper_compact" | "masc_keeper_clear" ->
       Some Types.CanBroadcast

--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -134,6 +134,7 @@ let with_fake_docker script f =
     | _ -> dir
   in
   Fun.protect ~finally:(fun () -> cleanup_dir dir) @@ fun () ->
+  with_env "MASC_TEST_FAKE_DOCKER_PATH" docker_path @@ fun () ->
   with_env "PATH" path f
 
 let test_container_path_root_maps () =
@@ -389,11 +390,11 @@ case \"$1\" in\n\
     for arg in \"$@\"; do last=\"$arg\"; done\n\
     case \"$last\" in\n\
       old-container)\n\
-        printf '999999\\t100.000\\ttrue\\n'\n\
+        printf '999999\\t100.000\\ttrue\\t600\\n'\n\
         exit 0\n\
         ;;\n\
       fresh-container)\n\
-        printf '%s\\t990.000\\ttrue\\n' \"${KEEPER_TEST_PID:-1}\"\n\
+        printf '%s\\t990.000\\ttrue\\t600\\n' \"${KEEPER_TEST_PID:-1}\"\n\
         exit 0\n\
         ;;\n\
     esac\n\
@@ -439,6 +440,37 @@ let test_sandbox_container_label_args_include_owner_scope () =
     (has_label_prefix "masc.mcp.started_at=");
   Alcotest.(check bool) "network label" true
     (has_label "masc.mcp.network=none")
+
+let test_sandbox_container_label_args_include_managed_ttl () =
+  let args =
+    Keeper_sandbox_runtime.docker_label_args
+      ~ttl_sec:90.0
+      ~base_path:"/tmp/masc"
+      ~keeper_name:"issue-king"
+      ~container_kind:"managed"
+      ~network_label:"inherit" ()
+  in
+  let has_label value = List.mem value args in
+  Alcotest.(check bool) "managed kind label" true
+    (has_label "masc.mcp.kind=managed");
+  Alcotest.(check bool) "ttl label" true
+    (has_label "masc.mcp.ttl_sec=90");
+  Alcotest.(check bool) "inherit network label" true
+    (has_label "masc.mcp.network=inherit")
+
+let test_docker_network_args_follow_masc_policy () =
+  let args_none, label_none =
+    Keeper_sandbox_runtime.docker_network_args Keeper_types.Network_none
+  in
+  Alcotest.(check (list string)) "network none passes docker flag"
+    [ "--network"; "none" ] args_none;
+  Alcotest.(check string) "network none label" "none" label_none;
+  let args_inherit, label_inherit =
+    Keeper_sandbox_runtime.docker_network_args Keeper_types.Network_inherit
+  in
+  Alcotest.(check (list string)) "network inherit omits docker flag"
+    [] args_inherit;
+  Alcotest.(check string) "network inherit label" "inherit" label_inherit
 
 let test_cleanup_stale_containers_removes_only_stale_masc_scope () =
   with_fake_docker fake_docker_cleanup_script @@ fun () ->
@@ -737,6 +769,12 @@ let run_tests () =
         ] );
       ( "container_path_of_host",
         [
+          Alcotest.test_case "docker network args follow policy" `Quick
+            test_docker_network_args_follow_masc_policy;
+          Alcotest.test_case "managed label args include ttl" `Quick
+            test_sandbox_container_label_args_include_managed_ttl;
+          Alcotest.test_case "sandbox label args include owner scope" `Quick
+            test_sandbox_container_label_args_include_owner_scope;
           Alcotest.test_case "playground root maps to container root"
             `Quick test_container_path_root_maps;
           Alcotest.test_case "nested host path maps with suffix" `Quick

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -539,6 +539,17 @@ let test_git_creds_skips_missing_ssh_auth_sock () =
   Alcotest.(check bool) "missing ssh-agent env is not forwarded" false
     (contains_substring line "SSH_AUTH_SOCK=/tmp/keeper-creds/ssh-agent.sock")
 
+let test_git_creds_inherit_network_omits_invalid_network_flag () =
+  with_fake_docker fake_docker_echo_script @@ fun () ->
+  setup ~sandbox:Keeper_types.Docker
+  @@ fun ~config ~meta ~playground ->
+  let log_path = Filename.concat config.Coord.base_path "docker.log" in
+  let line =
+    run_git_creds_docker_shell ~config ~meta ~playground ~log_path
+  in
+  Alcotest.(check bool) "network inherit never uses invalid flag value" false
+    (contains_substring line "--network inherit")
+
 let test_git_creds_respects_keeper_alias_identity_mode () =
   with_fake_docker fake_docker_echo_script @@ fun () ->
   setup ~sandbox:Keeper_types.Docker
@@ -670,6 +681,9 @@ let () =
           Alcotest.test_case
             "git-creds skips missing SSH_AUTH_SOCK"
             `Quick test_git_creds_skips_missing_ssh_auth_sock;
+          Alcotest.test_case
+            "git-creds inherit network omits invalid docker flag"
+            `Quick test_git_creds_inherit_network_omits_invalid_network_flag;
           Alcotest.test_case
             "git-creds respects keeper_alias git identity mode"
             `Quick test_git_creds_respects_keeper_alias_identity_mode;

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -109,6 +109,14 @@ let () =
           Alcotest.test_case "keeper status accepts agent alias" `Quick
             Test_operator_control_keeper
             .test_keeper_status_accepts_agent_name_alias;
+          Alcotest.test_case
+            "keeper status accepts legacy separator agent alias"
+            `Quick
+            Test_operator_control_keeper
+            .test_keeper_status_accepts_legacy_separator_agent_alias;
+          Alcotest.test_case "keeper up reseeds identity drift" `Quick
+            Test_operator_control_keeper
+            .test_keeper_up_reseeds_identity_drift;
           Alcotest.test_case "keeper status exposes model observability"
             `Quick
             Test_operator_control_keeper
@@ -142,10 +150,26 @@ let () =
           Alcotest.test_case "keeper status schema makes name optional" `Quick
             Test_operator_control_keeper
             .test_keeper_status_schema_makes_name_optional;
+          Alcotest.test_case "keeper sandbox tools are public and titled"
+            `Quick
+            Test_operator_control_keeper
+            .test_keeper_sandbox_tools_are_public_and_titled;
+          Alcotest.test_case "keeper sandbox status exposes local summary"
+            `Quick
+            Test_operator_control_keeper
+            .test_keeper_sandbox_status_exposes_local_summary;
+          Alcotest.test_case
+            "keeper sandbox start status stop works with fake docker"
+            `Quick
+            Test_operator_control_keeper
+            .test_keeper_sandbox_start_status_stop_with_fake_docker;
           Alcotest.test_case "keeper config exposes live runtime and sources"
             `Quick
             Test_operator_control_keeper
             .test_keeper_config_exposes_live_runtime_and_sources;
+          Alcotest.test_case "keeper repair reseeds identity drift" `Quick
+            Test_operator_control_keeper
+            .test_keeper_repair_reseeds_identity_drift;
           Alcotest.test_case "snapshot keeper tool audit fallback" `Quick
             Test_operator_control_keeper.test_snapshot_keeper_tool_audit_fallback;
           Alcotest.test_case "snapshot keeper tool audit uses decision log"

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -11,6 +11,415 @@ let contains_substring s needle =
   in
   if n_len = 0 then true else loop 0
 
+let with_env key value f =
+  let prior = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match prior with
+      | Some v -> Unix.putenv key v
+      | None -> Unix.putenv key "")
+    f
+
+let rec ensure_dir path =
+  if path = "" || path = "." || path = "/" then
+    ()
+  else if Sys.file_exists path then
+    ()
+  else (
+    let parent = Filename.dirname path in
+    if parent <> path then ensure_dir parent;
+    Unix.mkdir path 0o755)
+
+let write_file path content =
+  let oc = open_out_bin path in
+  Fun.protect ~finally:(fun () -> close_out oc) @@ fun () ->
+  output_string oc content
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect ~finally:(fun () -> close_in ic) @@ fun () ->
+  really_input_string ic (in_channel_length ic)
+
+let read_keeper_meta_exn config keeper_name =
+  match Keeper_types.read_meta config keeper_name with
+  | Ok (Some meta) -> meta
+  | Ok None -> Alcotest.fail ("keeper meta missing: " ^ keeper_name)
+  | Error err -> Alcotest.fail ("keeper meta read failed: " ^ err)
+
+let with_fake_docker script f =
+  let dir = temp_dir () in
+  let docker_path = Filename.concat dir "docker" in
+  write_file docker_path script;
+  Unix.chmod docker_path 0o755;
+  let path =
+    match Sys.getenv_opt "PATH" with
+    | Some prior when String.trim prior <> "" -> dir ^ ":" ^ prior
+    | _ -> dir
+  in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) @@ fun () ->
+  with_env "MASC_TEST_FAKE_DOCKER_PATH" docker_path @@ fun () ->
+  with_env "PATH" path f
+
+let update_keeper_sandbox_mode config keeper_name ~sandbox_profile ~network_mode =
+  let meta = read_keeper_meta_exn config keeper_name in
+  match
+    Keeper_types.write_meta config
+      { meta with sandbox_profile; network_mode }
+  with
+  | Ok () -> ()
+  | Error err -> Alcotest.fail ("keeper meta write failed: " ^ err)
+
+let drift_keeper_identity config keeper_name ~agent_name =
+  let meta = read_keeper_meta_exn config keeper_name in
+  let previous_trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+  match
+    Keeper_types.write_meta ~force:true config
+      { meta with agent_name; updated_at = Keeper_types.now_iso () }
+  with
+  | Ok () -> previous_trace_id
+  | Error err -> Alcotest.fail ("keeper identity drift write failed: " ^ err)
+
+let fake_docker_managed_sandbox_script =
+  "#!/bin/sh\n\
+state_file=${KEEPER_DOCKER_STATE_FILE:?}\n\
+log_file=${KEEPER_DOCKER_LOG:-}\n\
+tab=$(printf '\\t')\n\
+read_state() {\n\
+  if [ ! -s \"$state_file\" ]; then\n\
+    return 1\n\
+  fi\n\
+  IFS=$tab read -r cid name image status running created_at keeper kind network owner_pid started_at ttl_sec < \"$state_file\"\n\
+}\n\
+if [ -n \"$log_file\" ]; then\n\
+  printf '%s\\n' \"$1 $*\" >> \"$log_file\"\n\
+fi\n\
+cmd=$1\n\
+shift\n\
+case \"$cmd\" in\n\
+  info)\n\
+    printf '[]\\n'\n\
+    exit 0\n\
+    ;;\n\
+  ps)\n\
+    if read_state; then\n\
+      printf '%s\\n' \"$cid\"\n\
+    fi\n\
+    exit 0\n\
+    ;;\n\
+  run)\n\
+    name=''\n\
+    keeper=''\n\
+    kind=''\n\
+    network=''\n\
+    owner_pid=''\n\
+    started_at=''\n\
+    ttl_sec=''\n\
+    image=''\n\
+    while [ \"$#\" -gt 0 ]; do\n\
+      case \"$1\" in\n\
+        --name)\n\
+          name=$2\n\
+          shift 2\n\
+          ;;\n\
+        --label)\n\
+          case \"$2\" in\n\
+            masc.mcp.keeper=*) keeper=${2#masc.mcp.keeper=} ;;\n\
+            masc.mcp.kind=*) kind=${2#masc.mcp.kind=} ;;\n\
+            masc.mcp.network=*) network=${2#masc.mcp.network=} ;;\n\
+            masc.mcp.owner_pid=*) owner_pid=${2#masc.mcp.owner_pid=} ;;\n\
+            masc.mcp.started_at=*) started_at=${2#masc.mcp.started_at=} ;;\n\
+            masc.mcp.ttl_sec=*) ttl_sec=${2#masc.mcp.ttl_sec=} ;;\n\
+          esac\n\
+          shift 2\n\
+          ;;\n\
+        --user|--tmpfs|-v|--workdir|--pids-limit|--memory|--network|--security-opt)\n\
+          shift 2\n\
+          ;;\n\
+        -d|--rm|--read-only|--cap-drop=ALL)\n\
+          shift\n\
+          ;;\n\
+        alpine:test)\n\
+          image=$1\n\
+          break\n\
+          ;;\n\
+        *)\n\
+          shift\n\
+          ;;\n\
+      esac\n\
+    done\n\
+    printf 'managed-1\\t%s\\t%s\\trunning\\ttrue\\t2026-04-24T00:00:00Z\\t%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n' \\\n\
+      \"$name\" \"$image\" \"$keeper\" \"$kind\" \"$network\" \"$owner_pid\" \"$started_at\" \"$ttl_sec\" > \"$state_file\"\n\
+    printf 'managed-1\\n'\n\
+    exit 0\n\
+    ;;\n\
+  inspect)\n\
+    format=''\n\
+    if [ \"$1\" = \"--format\" ]; then\n\
+      format=$2\n\
+      shift 2\n\
+    fi\n\
+    if ! read_state; then\n\
+      exit 0\n\
+    fi\n\
+    case \"$format\" in\n\
+      *'.Config.Image'*)\n\
+        printf '%s\\t/%s\\t%s\\t%s\\t%s\\t%s\\t%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n' \\\n\
+          \"$cid\" \"$name\" \"$image\" \"$status\" \"$running\" \"$created_at\" \"$keeper\" \"$kind\" \"$network\" \"$owner_pid\" \"$started_at\" \"$ttl_sec\"\n\
+        ;;\n\
+      *)\n\
+        printf '%s\\t%s\\t%s\\t%s\\n' \"$owner_pid\" \"$started_at\" \"$running\" \"$ttl_sec\"\n\
+        ;;\n\
+    esac\n\
+    exit 0\n\
+    ;;\n\
+  rm)\n\
+    if [ \"$1\" = \"-f\" ]; then\n\
+      shift\n\
+    fi\n\
+    : > \"$state_file\"\n\
+    printf '%s\\n' \"$@\"\n\
+    exit 0\n\
+    ;;\n\
+esac\n\
+printf 'unexpected docker invocation: %s\\n' \"$cmd\" >&2\n\
+exit 2\n"
+
+let test_keeper_sandbox_tools_are_public_and_titled () =
+  let checks =
+    [
+      ("masc_keeper_sandbox_status", "Keeper Sandbox Status");
+      ("masc_keeper_sandbox_start", "Start Keeper Sandbox");
+      ("masc_keeper_sandbox_stop", "Stop Keeper Sandbox");
+    ]
+  in
+  List.iter
+    (fun (name, expected_title) ->
+      let schema_present =
+        List.exists
+          (fun (schema : Types.tool_schema) -> String.equal schema.name name)
+          Config.raw_all_tool_schemas
+      in
+      Alcotest.(check bool) (name ^ " schema present") true schema_present;
+      Alcotest.(check bool) (name ^ " public mcp") true
+        (List.mem name Tool_catalog.public_mcp_tools);
+      Alcotest.(check string) (name ^ " title") expected_title
+        (Mcp_server_eio_tool_profile.tool_title_of_name name))
+    checks
+
+let test_keeper_sandbox_status_exposes_local_summary () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "sandbox-local" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Inspect local sandbox summary");
+                ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      let ok, body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_sandbox_status"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("include_preflight", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "sandbox status ok" true ok;
+      let sandbox_json =
+        parse_json_exn body |> Yojson.Safe.Util.member "sandbox"
+      in
+      let open Yojson.Safe.Util in
+      Alcotest.(check string) "sandbox profile local" "local"
+        (sandbox_json |> member "sandbox_profile" |> to_string);
+      Alcotest.(check string) "effective mode local" "local"
+        (sandbox_json |> member "effective_mode" |> to_string);
+      Alcotest.(check int) "no live containers" 0
+        (sandbox_json |> member "container_count" |> to_int);
+      Alcotest.(check (option string)) "local why_no_container"
+        (Some "sandbox_profile=local")
+        (sandbox_json |> member "why_no_container" |> to_string_option);
+      Alcotest.(check bool) "identity matches canonical agent" true
+        (sandbox_json |> member "identity" |> member "agent_name_matches"
+       |> to_bool);
+      let ok, status_body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_status"
+          ~args:(`Assoc [ ("name", `String keeper_name); ("fast", `Bool true) ])
+      in
+      Alcotest.(check bool) "keeper status ok" true ok;
+      let status_json = parse_json_exn status_body in
+      Alcotest.(check string) "status surfaces sandbox_live local" "local"
+        Yojson.Safe.Util.(
+          status_json |> member "sandbox_live" |> member "effective_mode"
+          |> to_string))
+
+let test_keeper_sandbox_start_status_stop_with_fake_docker () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "sandbox-docker" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let state_dir = Filename.concat base_dir "fake-docker" in
+      let state_file = Filename.concat state_dir "containers.tsv" in
+      let log_path = Filename.concat state_dir "docker.log" in
+      ensure_dir state_dir;
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Prewarm managed sandbox container");
+                ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      update_keeper_sandbox_mode config keeper_name
+        ~sandbox_profile:Keeper_types.Docker
+        ~network_mode:Keeper_types.Network_none;
+      Keeper_status_detail.invalidate_status_cache_for keeper_name;
+      with_fake_docker fake_docker_managed_sandbox_script @@ fun () ->
+      (match Sys.getenv_opt "MASC_TEST_FAKE_DOCKER_PATH" with
+       | Some expected ->
+           Alcotest.(check string) "fake docker path selected" expected
+             (Masc_mcp.Keeper_sandbox_runtime.docker_command ())
+       | None -> Alcotest.fail "fake docker path missing");
+      with_env "KEEPER_DOCKER_STATE_FILE" state_file @@ fun () ->
+      with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
+      with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+      with_env "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE" "" @@ fun () ->
+      with_env "MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS" "false" @@ fun () ->
+      with_env "MASC_KEEPER_SANDBOX_REQUIRE_USERNS" "false" @@ fun () ->
+      with_env "MASC_KEEPER_SANDBOX_CLEANUP_ENABLED" "false" @@ fun () ->
+      let ok, start_body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_sandbox_start"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("ttl_sec", `Float 90.0);
+              ])
+      in
+      if not ok then
+        Alcotest.failf "sandbox start failed: %s" start_body;
+      Alcotest.(check bool) "sandbox start ok" true ok;
+      let start_json = parse_json_exn start_body in
+      let open Yojson.Safe.Util in
+      Alcotest.(check bool) "sandbox start created container" true
+        (start_json |> member "sandbox" |> member "started" |> to_bool);
+      Alcotest.(check string) "sandbox start network none" "none"
+        (start_json |> member "sandbox" |> member "network_label" |> to_string);
+      Alcotest.(check (option (float 0.0001))) "sandbox start ttl preserved"
+        (Some 90.0)
+        (start_json |> member "sandbox" |> member "ttl_sec" |> to_float_option);
+      let log = read_file log_path in
+      Alcotest.(check bool) "managed container kind label present" true
+        (contains_substring log "masc.mcp.kind=managed");
+      Alcotest.(check bool) "managed ttl label present" true
+        (contains_substring log "masc.mcp.ttl_sec=90");
+      Alcotest.(check bool) "network none passed to docker" true
+        (contains_substring log "--network none");
+      let ok, status_body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_sandbox_status"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("include_preflight", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "sandbox status after start ok" true ok;
+      let sandbox_json = parse_json_exn status_body |> member "sandbox" in
+      Alcotest.(check string) "effective mode managed" "managed_running"
+        (sandbox_json |> member "effective_mode" |> to_string);
+      Alcotest.(check int) "one live container" 1
+        (sandbox_json |> member "container_count" |> to_int);
+      Alcotest.(check (option string)) "no why_no_container while running" None
+        (sandbox_json |> member "why_no_container" |> to_string_option);
+      let container =
+        sandbox_json |> member "containers" |> to_list |> List.hd
+      in
+      Alcotest.(check (option string)) "managed kind surfaced"
+        (Some "managed")
+        (container |> member "container_kind" |> to_string_option);
+      Alcotest.(check (option string)) "container network surfaced"
+        (Some "none")
+        (container |> member "network_label" |> to_string_option);
+      let ok, stop_body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_sandbox_stop"
+          ~args:(`Assoc [ ("name", `String keeper_name) ])
+      in
+      Alcotest.(check bool) "sandbox stop ok" true ok;
+      let stop_json = parse_json_exn stop_body in
+      Alcotest.(check int) "stop matched one" 1
+        (stop_json |> member "stop_result" |> member "matched" |> to_int);
+      Alcotest.(check int) "stop removed one" 1
+        (stop_json |> member "stop_result" |> member "removed" |> to_int);
+      let ok, final_status_body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_sandbox_status"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("include_preflight", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "sandbox status after stop ok" true ok;
+      let final_sandbox = parse_json_exn final_status_body |> member "sandbox" in
+      Alcotest.(check int) "no containers after stop" 0
+        (final_sandbox |> member "container_count" |> to_int);
+      Alcotest.(check bool) "why_no_container restored" true
+        (Option.is_some
+           (final_sandbox |> member "why_no_container" |> to_string_option)))
+
 let test_snapshot_exposes_keeper_and_social_actions () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -309,6 +718,175 @@ let test_keeper_status_accepts_agent_name_alias () =
       let status_json = parse_json_exn body in
       Alcotest.(check string) "status resolves canonical keeper name" keeper_name
         Yojson.Safe.Util.(status_json |> member "name" |> to_string))
+
+let test_keeper_status_accepts_legacy_separator_agent_alias () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "issue-king" in
+  let keeper_agent_name = "keeper_issue_king_agent" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Probe keeper runtime");
+                ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      let ok, body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_status"
+          ~args:(`Assoc [ ("name", `String keeper_agent_name); ("fast", `Bool true) ])
+      in
+      Alcotest.(check bool) "status ok via legacy separator alias" true ok;
+      let status_json = parse_json_exn body in
+      Alcotest.(check string) "legacy alias resolves canonical keeper name"
+        keeper_name Yojson.Safe.Util.(status_json |> member "name" |> to_string))
+
+let test_keeper_up_reseeds_identity_drift () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "issue-king" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let up_args =
+        `Assoc
+          [
+            ("name", `String keeper_name);
+            ("goal", `String "Repair identity drift");
+            ("proactive_enabled", `Bool false);
+            ("autoboot_enabled", `Bool false);
+          ]
+      in
+      let ok, _ = dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up" ~args:up_args in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      let previous_trace_id =
+        drift_keeper_identity config keeper_name
+          ~agent_name:"keeper_issue_king_agent"
+      in
+      let ok, body = dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up" ~args:up_args in
+      Alcotest.(check bool) "keeper up after drift ok" true ok;
+      let body_json = parse_json_exn body in
+      let identity_reseed = Yojson.Safe.Util.member "identity_reseed" body_json in
+      Alcotest.(check string) "identity reseed reason" "agent_name_mismatch"
+        Yojson.Safe.Util.(identity_reseed |> member "reason" |> to_string);
+      let meta = read_keeper_meta_exn config keeper_name in
+      let current_trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+      Alcotest.(check string) "agent name restored to canonical"
+        (Keeper_types.keeper_agent_name keeper_name) meta.agent_name;
+      Alcotest.(check bool) "trace id rotated" true
+        (not (String.equal current_trace_id previous_trace_id));
+      Alcotest.(check bool) "previous trace retained in history" true
+        (List.mem previous_trace_id meta.runtime.trace_history))
+
+let test_keeper_repair_reseeds_identity_drift () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "issue-king-repair" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some keeper_name));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = keeper_name;
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Repair identity drift");
+                ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      let meta_before = read_keeper_meta_exn config keeper_name in
+      let working_dir =
+        Keeper_sandbox.host_root_abs_of_meta ~config meta_before
+      in
+      let previous_trace_id =
+        drift_keeper_identity config keeper_name
+          ~agent_name:"keeper_issue_king_repair_agent"
+      in
+      let ok, body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_repair"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("task_spec", `String "repair drift");
+                ("working_dir", `String working_dir);
+              ])
+      in
+      Alcotest.(check bool) "keeper repair currently returns removed bridge" false ok;
+      let body_json = parse_json_exn body in
+      let identity_reseed = Yojson.Safe.Util.member "identity_reseed" body_json in
+      Alcotest.(check string) "repair reseed reason" "agent_name_mismatch"
+        Yojson.Safe.Util.(identity_reseed |> member "reason" |> to_string);
+      let meta_after = read_keeper_meta_exn config keeper_name in
+      let current_trace_id = Keeper_id.Trace_id.to_string meta_after.runtime.trace_id in
+      Alcotest.(check string) "repair restores canonical agent name"
+        (Keeper_types.keeper_agent_name keeper_name) meta_after.agent_name;
+      Alcotest.(check bool) "repair rotates trace id" true
+        (not (String.equal current_trace_id previous_trace_id)))
 
 let test_keeper_status_exposes_model_observability () =
   Eio_main.run @@ fun env ->
@@ -1258,8 +1836,15 @@ proactive_enabled = true
         (contains_substring effective_system_prompt ("Goal: " ^ mutated.goal));
       Alcotest.(check bool) "effective system prompt includes world block" true
         (contains_substring effective_system_prompt "<world>");
+      let stale_base =
+        match Masc_mcp.Keeper_types.read_meta config keeper_name with
+        | Ok (Some meta) -> meta
+        | Ok None -> Alcotest.fail "keeper meta missing before stale write"
+        | Error err ->
+            Alcotest.fail ("keeper meta reload failed before stale write: " ^ err)
+      in
       let stale_meta =
-        { mutated with
+        { stale_base with
           cascade_name = "vendor_mix_balanced";
           updated_at = Types.now_iso ();
         }


### PR DESCRIPTION
## What changed
- add keeper sandbox control primitives so operators can inspect live sandbox state and explicitly start or stop managed keeper containers
- surface `sandbox_live` details through keeper status, keeper context, and dashboard snapshots
- unify Docker command/network wiring so `inherit` stops emitting an invalid `--network inherit` flag and fake-docker test paths work consistently
- reseed keeper identity on `keeper_up` and `keeper_repair` when persisted `agent_name` drifts from the canonical keeper name, while still resolving legacy underscore/hyphen aliases
- extend operator and docker-route tests for sandbox lifecycle, legacy alias lookup, and identity drift recovery

## Why
Keeper Docker behavior was effectively opaque: many runs were turn-scoped or one-shot, there was no direct status/start/stop surface, and identity drift could leave a keeper pointing at the wrong trace/session lineage. This change makes sandbox state observable and controllable, and repairs the drift path instead of silently continuing with mismatched identity.

## Impact
Operators can now tell why a keeper has no visible container, start a managed sandbox when they need one, stop it safely by keeper label, and see sandbox/live-container state in the existing status surfaces. Keeper recovery also self-heals canonical identity mismatches before reusing runtime state.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/keeper-docker-wiring --build-dir /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/keeper-docker-wiring/_build_codex @check --display=quiet`
- `./_build/default/test/test_operator_control.exe`
- `./_build/default/test/test_keeper_shell_docker_route.exe`
- `./_build/default/test/test_keeper_docker_read.exe` (via fake-docker dispatch shim for the new argv wrapper path)
