### PR TITLE
[codex] Reduce OCaml code smells

### DIFF
--- a/lib/dashboard/dashboard_verification.ml
+++ b/lib/dashboard/dashboard_verification.ml
@@ -86,20 +86,36 @@ let next_action_of_output (output : Yojson.Safe.t) : string option =
 
 (** Status + verdict + approver triple. Keeps all three derivations in one
     place so the match is exhaustive over the Verification state machine. *)
+type status_bucket =
+  | Pending
+  | Approved
+  | Rejected
+
+let status_bucket_of_request (req : V.verification_request) : status_bucket =
+  match req.status with
+  | V.Pending | V.Assigned _ -> Pending
+  | V.Completed V.Pass -> Approved
+  | V.Completed (V.Fail _ | V.Partial _) -> Rejected
+
+let status_bucket_to_string = function
+  | Pending -> "pending"
+  | Approved -> "approved"
+  | Rejected -> "rejected"
+
 let derive_status_fields (req : V.verification_request)
   : string * string option * string * string option =
   (* returns (status, verdict_opt, verdict_reason, approved_by_opt) *)
   match req.status with
   | V.Pending ->
-      "pending", None, "", None
+      status_bucket_to_string Pending, None, "", None
   | V.Assigned _ ->
-      "pending", None, "", None
+      status_bucket_to_string Pending, None, "", None
   | V.Completed V.Pass ->
-      "approved", Some "pass", "", req.verifier
+      status_bucket_to_string Approved, Some "pass", "", req.verifier
   | V.Completed (V.Fail reason) ->
-      "rejected", Some "fail", reason, req.verifier
+      status_bucket_to_string Rejected, Some "fail", reason, req.verifier
   | V.Completed (V.Partial (_, reason)) ->
-      "rejected", Some "partial", reason, req.verifier
+      status_bucket_to_string Rejected, Some "partial", reason, req.verifier
 
 (** Per-request JSON row. *)
 let request_to_json (req : V.verification_request) : Yojson.Safe.t =
@@ -238,8 +254,7 @@ let is_rejected (req : V.verification_request) : bool =
   | _ -> false
 
 let bucket_of_status (req : V.verification_request) : string =
-  let status, _, _, _ = derive_status_fields req in
-  status
+  req |> status_bucket_of_request |> status_bucket_to_string
 
 let summary_json ?recent () : Yojson.Safe.t =
   let recent = clamp_recent recent in
@@ -249,11 +264,10 @@ let summary_json ?recent () : Yojson.Safe.t =
   let approved = ref 0 in
   let rejected = ref 0 in
   List.iter (fun req ->
-    match bucket_of_status req with
-    | "pending" -> incr pending
-    | "approved" -> incr approved
-    | "rejected" -> incr rejected
-    | _ -> assert false
+    match status_bucket_of_request req with
+    | Pending -> incr pending
+    | Approved -> incr approved
+    | Rejected -> incr rejected
   ) all;
   let recent_rejections =
     all

--- a/lib/keeper/keeper_shell_bg_task.ml
+++ b/lib/keeper/keeper_shell_bg_task.ml
@@ -36,7 +36,9 @@ let handle_keeper_bash_output
     error_json
       "task_id is required. Example: task_id='bgt-<timestamp>-<seq>-<pid>'."
   else
-    let tid = Bg_task.task_id_of_string_exn raw_id in
+    match Bg_task.task_id_of_string raw_id with
+    | Error msg -> error_json (Printf.sprintf "invalid task_id: %s" msg)
+    | Ok tid -> (
     match Bg_task.read tid ~since_stdout ~since_stderr with
     | Error (Bg_task.Unknown_task _) ->
         error_json
@@ -79,7 +81,7 @@ let handle_keeper_bash_output
                ("bytes_dropped_stdout", `Int snap.bytes_dropped_stdout);
                ("bytes_dropped_stderr", `Int snap.bytes_dropped_stderr);
              ]
-             @ semantic_fields))
+             @ semantic_fields)))
 
 (* ── Kill ─────────────────────────────────────────────────── *)
 
@@ -100,7 +102,9 @@ let handle_keeper_bash_kill
     error_json
       "task_id is required. Example: task_id='bgt-<timestamp>-<seq>-<pid>'."
   else
-    let tid = Bg_task.task_id_of_string_exn raw_id in
+    match Bg_task.task_id_of_string raw_id with
+    | Error msg -> error_json (Printf.sprintf "invalid task_id: %s" msg)
+    | Ok tid -> (
     match Bg_task.kill tid ~signal ~grace_sec with
     | Error (Bg_task.Unknown_task_kill _) ->
         error_json
@@ -121,4 +125,4 @@ let handle_keeper_bash_kill
               ("task_id", `String tid_str);
               ("signal", `Int signal);
               ("grace_sec", `Float grace_sec);
-            ])
+            ]))

--- a/lib/process/bg_task.ml
+++ b/lib/process/bg_task.ml
@@ -23,9 +23,13 @@ type task_id = string
 
 let task_id_to_string t = t
 
+let task_id_of_string s =
+  if s = "" then Error "empty handle" else Ok s
+
 let task_id_of_string_exn s =
-  if s = "" then invalid_arg "Bg_task.task_id_of_string_exn: empty handle";
-  s
+  match task_id_of_string s with
+  | Ok task_id -> task_id
+  | Error msg -> invalid_arg ("Bg_task.task_id_of_string_exn: " ^ msg)
 
 type snapshot = {
   stdout_since : string;

--- a/lib/process/bg_task.mli
+++ b/lib/process/bg_task.mli
@@ -23,6 +23,9 @@ type task_id = private string
 
 val task_id_to_string : task_id -> string
 
+val task_id_of_string : string -> (task_id, string) result
+(** Rehydrate a task_id from JSON at the MCP boundary without raising. *)
+
 val task_id_of_string_exn : string -> task_id
 (** Rehydrate a task_id from JSON at the MCP boundary. Raises
     [Invalid_argument] on a syntactically invalid handle — callers must

--- a/scripts/ocaml-north-star-health.sh
+++ b/scripts/ocaml-north-star-health.sh
@@ -51,11 +51,12 @@ fi
 count_pattern() {
   local scope="$1"
   local pattern="$2"
-  rg -n "$pattern" $scope -g '*.{ml,mli}' 2>/dev/null | awk 'END {print NR+0}'
+  shift 2
+  rg -n "$pattern" $scope -g '*.{ml,mli}' "$@" 2>/dev/null | awk 'END {print NR+0}' || true
 }
 
 count_prod() {
-  count_pattern "lib bin" "$1"
+  count_pattern "lib bin" "$1" -g '!**/test/**'
 }
 
 count_all() {

--- a/test/test_bg_task_stub.ml
+++ b/test/test_bg_task_stub.ml
@@ -39,6 +39,10 @@ let poll_for_closed tid =
     | Error _ -> false)
 
 let test_task_id_empty_rejected () =
+  (match Bg_task.task_id_of_string "" with
+   | Error "empty handle" -> ()
+   | Error msg -> failf "unexpected error message: %s" msg
+   | Ok _ -> fail "empty id must return Error");
   match Bg_task.task_id_of_string_exn "" with
   | exception Invalid_argument _ -> ()
   | _ -> fail "empty id must raise"


### PR DESCRIPTION
## Summary

This PR performs a focused OCaml code-smell cleanup found during a repository-wide sweep.

- Replaces a production `assert false` path in dashboard verification summary counting with an explicit typed status bucket.
- Adds non-raising `Bg_task.task_id_of_string` and uses it at keeper background-task tool boundaries so invalid task ids return structured JSON errors instead of raising.
- Fixes the OCaml north-star health script so no-match ripgrep scans stay warn-only and production scans exclude nested `**/test/**` directories.
- Extends the background task stub test to cover the new non-raising task id parser.

## Why

The sweep found two concrete low-risk cleanup targets: an avoidable `assert false` in production code and exception-based task-id parsing at an external boundary. The health script also overstated production smell counts because nested test directories under `lib/` were included.

## Validation

- `dune build --root .`
- `dune exec --root . test/test_dashboard_verification.exe`
- `dune exec --root . test/test_bg_task_stub.exe`
- `git diff --check`
- `scripts/ocaml-north-star-health.sh --json-out .health/ocaml-north-star-health-after.json`

Note: `dune fmt --root . --preview` is not clean repo-wide due existing large `dune` formatting diffs and docstring warnings; no repo-wide formatting was applied.