### PR TITLE
[codex] Collapse keeper identities and separate timeout budgets

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1532,6 +1532,7 @@ function normalizeRuntimeBlockerClass(value: unknown): KeeperConfig['runtime']['
     case 'autonomous_slot_wait_timeout':
     case 'admission_queue_wait_timeout':
     case 'turn_timeout_after_queue_wait':
+    case 'oas_timeout_budget':
     case 'turn_timeout':
     case 'completion_contract_violation':
     case 'cascade_exhausted':

--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -328,7 +328,34 @@ describe('keeperRuntimeName', () => {
 })
 
 describe('countRuntimeKinds', () => {
-  it('does not classify generated taskmaster nicknames as the taskmaster keeper', () => {
+  it('collapses keeper-owned generated sub-op aliases when agent meta carries keeper identity', () => {
+    const result = countRuntimeKinds(
+      [
+        makeAgent({
+          name: 'ramarama-fierce-panda',
+          agent_type: 'ramarama',
+          keeper_name: 'ramarama',
+          keeper_id: 'keeper-uuid-1',
+        }),
+      ],
+      [
+        {
+          name: 'ramarama',
+          keeper_id: 'keeper-uuid-1',
+          agent_name: 'keeper-ramarama-agent',
+          status: 'active',
+        } as Keeper,
+      ],
+    )
+
+    expect(result).toEqual({
+      agents: 0,
+      keepers: 1,
+      totalRuntimes: 1,
+    })
+  })
+
+  it('classifies generated keeper nicknames as the canonical keeper when names match', () => {
     const result = countRuntimeKinds(
       [
         makeAgent({
@@ -350,9 +377,9 @@ describe('countRuntimeKinds', () => {
     )
 
     expect(result).toEqual({
-      agents: 1,
+      agents: 0,
       keepers: 1,
-      totalRuntimes: 2,
+      totalRuntimes: 1,
     })
   })
 })

--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -382,6 +382,30 @@ describe('countRuntimeKinds', () => {
       totalRuntimes: 1,
     })
   })
+
+  it('does not classify arbitrary hyphenated agents as matching keeper prefixes', () => {
+    const result = countRuntimeKinds(
+      [
+        makeAgent({
+          name: 'foo-bar',
+          agent_type: 'agent',
+        }),
+      ],
+      [
+        {
+          name: 'foo',
+          agent_name: 'keeper-foo-agent',
+          status: 'active',
+        } as Keeper,
+      ],
+    )
+
+    expect(result).toEqual({
+      agents: 1,
+      keepers: 1,
+      totalRuntimes: 2,
+    })
+  })
 })
 
 describe('mergeRosterAgent', () => {

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -19,7 +19,9 @@ import { TextInput } from './common/input'
 import { EmptyState } from './common/empty-state'
 import { TimeAgo } from './common/time-ago'
 import {
+  keeperIdentityKeys,
   keeperIdentitySearchTerms,
+  keeperPrincipalKey,
   keeperPrimaryName,
 } from './common/keeper-identity'
 import { AgentAvatar } from './overview/agent-avatar'
@@ -142,11 +144,11 @@ export function rosterStateNote(
   return null
 }
 
-function registerKeeperLookup<T extends Pick<Keeper, 'name' | 'agent_name'>>(
+function registerKeeperLookup<T extends Pick<Keeper, 'keeper_id' | 'name' | 'agent_name'>>(
   lookup: Map<string, T>,
   source: T,
 ) {
-  const candidates = [source.agent_name, source.name]
+  const candidates = keeperIdentityKeys(source.keeper_id ?? null, source.name, source.agent_name)
   for (const candidate of candidates) {
     const key = candidate?.trim()
     if (!key || lookup.has(key)) continue
@@ -163,12 +165,22 @@ function buildKeeperRuntimeLookup(keeperList: Keeper[]): Map<string, Keeper> {
 function findKeeperRuntime(agentName: string, keeperList: Keeper[]): Keeper | null {
   const target = agentName.trim()
   if (!target) return null
-  for (const k of keeperList) {
-    const keeperName = k.name?.trim()
-    const keeperAgentName = k.agent_name?.trim()
-    if (keeperName === target || keeperAgentName === target) {
-      return k
-    }
+  const lookup = buildKeeperRuntimeLookup(keeperList)
+  return lookup.get(target) ?? lookup.get(target.toLowerCase()) ?? null
+}
+
+function findKeeperRuntimeForAgent(
+  agent: Pick<Agent, 'name' | 'keeper_id' | 'keeper_name'>,
+  lookup: Map<string, Keeper>,
+): Keeper | null {
+  const candidates = keeperIdentityKeys(
+    agent.keeper_id ?? null,
+    agent.keeper_name ?? null,
+    agent.name,
+  )
+  for (const candidate of candidates) {
+    const keeper = lookup.get(candidate)
+    if (keeper) return keeper
   }
   return null
 }
@@ -250,12 +262,12 @@ export function uniqueToolNames(...groups: Array<string[] | null | undefined>): 
 }
 
 function matchesKeeperFilter(
-  agentName: string,
-  keeperList: Keeper[],
+  agent: Pick<Agent, 'name' | 'keeper_id' | 'keeper_name'>,
+  keeperLookup: Map<string, Keeper>,
   keeperFilter: KeeperFilterMode,
 ): boolean {
   if (keeperFilter === 'all') return true
-  const isKeeper = findKeeperRuntime(agentName, keeperList) != null
+  const isKeeper = findKeeperRuntimeForAgent(agent, keeperLookup) != null
   return keeperFilter === 'keeper-only' ? isKeeper : !isKeeper
 }
 
@@ -263,9 +275,10 @@ function scopeAgentsByKeeperFilter(
   agentList: Agent[],
   keeperList: Keeper[],
   keeperFilter: KeeperFilterMode,
+  keeperLookup: Map<string, Keeper> = buildKeeperRuntimeLookup(keeperList),
 ): Agent[] {
   return agentList.filter((agent: Agent) =>
-    matchesKeeperFilter(agent.name, keeperList, keeperFilter))
+    matchesKeeperFilter(agent, keeperLookup, keeperFilter))
 }
 
 export function keeperRuntimeName(source: Pick<Keeper, 'name' | 'agent_name'>): string {
@@ -274,8 +287,8 @@ export function keeperRuntimeName(source: Pick<Keeper, 'name' | 'agent_name'>): 
 }
 
 function synthesizeAgentFromKeeper(source: Keeper): Agent | null {
-  const runtimeName = keeperRuntimeName(source)
-  if (!runtimeName) return null
+  const displayName = keeperPrimaryName(source.name, source.agent_name) ?? keeperRuntimeName(source)
+  if (!displayName) return null
 
   const linkedAgent = source.agent
   const liveCurrentTask =
@@ -286,7 +299,9 @@ function synthesizeAgentFromKeeper(source: Keeper): Agent | null {
     ?? null
 
   return {
-    name: runtimeName,
+    name: displayName,
+    keeper_name: source.name,
+    keeper_id: source.keeper_id ?? null,
     agent_type: linkedAgent?.agent_type,
     status: (linkedAgent?.status as Agent['status'] | undefined) ?? (source.status as Agent['status'] | undefined),
     current_task: linkedAgent?.current_task ?? liveCurrentTask,
@@ -308,6 +323,9 @@ export function mergeRosterAgent(existing: Agent | undefined, next: Agent): Agen
   if (!existing) return next
   return {
     ...existing,
+    name: next.synthetic && !existing.synthetic ? next.name : existing.name,
+    keeper_name: existing.keeper_name ?? next.keeper_name ?? null,
+    keeper_id: existing.keeper_id ?? next.keeper_id ?? null,
     agent_type: existing.agent_type ?? next.agent_type,
     status: existing.status ?? next.status,
     current_task: existing.current_task ?? next.current_task,
@@ -328,16 +346,34 @@ function buildAgentRoster(
   agentList: Agent[],
   keeperList: Keeper[],
 ): Agent[] {
+  const keeperLookup = buildKeeperRuntimeLookup(keeperList)
   const roster = new Map<string, Agent>()
 
   for (const agent of agentList) {
-    roster.set(agent.name, agent)
+    const keeper = findKeeperRuntimeForAgent(agent, keeperLookup)
+    const key =
+      keeperPrincipalKey(
+        keeper?.keeper_id ?? agent.keeper_id ?? null,
+        keeper?.name ?? agent.keeper_name ?? null,
+        keeper?.agent_name ?? agent.name,
+      )
+      ?? agent.name
+    const normalizedAgent =
+      keeper != null
+        ? {
+            ...agent,
+            keeper_name: agent.keeper_name ?? keeper.name,
+            keeper_id: agent.keeper_id ?? keeper.keeper_id ?? null,
+          }
+        : agent
+    roster.set(key, mergeRosterAgent(roster.get(key), normalizedAgent))
   }
 
   for (const source of keeperList) {
     const synthetic = synthesizeAgentFromKeeper(source)
     if (!synthetic) continue
-    roster.set(synthetic.name, mergeRosterAgent(roster.get(synthetic.name), synthetic))
+    const key = keeperPrincipalKey(source.keeper_id ?? null, source.name, source.agent_name) ?? synthetic.name
+    roster.set(key, mergeRosterAgent(roster.get(key), synthetic))
   }
 
   return Array.from(roster.values())
@@ -347,6 +383,7 @@ function countAgentsByStatus(
   agentList: Agent[],
   keeperList: Keeper[],
 ): Record<StatusFilter, number> {
+  const keeperLookup = buildKeeperRuntimeLookup(keeperList)
   const counts: Record<StatusFilter, number> = {
     all: agentList.length,
     active: 0,
@@ -356,7 +393,7 @@ function countAgentsByStatus(
   }
 
   for (const agent of agentList) {
-    const keeperRuntime = findKeeperRuntime(agent.name, keeperList)
+    const keeperRuntime = findKeeperRuntimeForAgent(agent, keeperLookup)
     const band = runtimeBandMetaForAgent(agent, keeperRuntime).key
     counts[band] += 1
   }
@@ -369,8 +406,9 @@ export function countRuntimeKinds(
   keeperList: Keeper[],
 ): { agents: number; keepers: number; totalRuntimes: number } {
   const rosterAgents = buildAgentRoster(agentList, keeperList)
-  const keeperCount = scopeAgentsByKeeperFilter(rosterAgents, keeperList, 'keeper-only').length
-  const agentCount = scopeAgentsByKeeperFilter(rosterAgents, keeperList, 'agent-only').length
+  const keeperLookup = buildKeeperRuntimeLookup(keeperList)
+  const keeperCount = scopeAgentsByKeeperFilter(rosterAgents, keeperList, 'keeper-only', keeperLookup).length
+  const agentCount = scopeAgentsByKeeperFilter(rosterAgents, keeperList, 'agent-only', keeperLookup).length
 
   return {
     agents: agentCount,
@@ -400,10 +438,10 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
   // Derive runtime kind counts from memoized roster (avoids duplicate buildAgentRoster call)
   const liveRuntimeCounts = useMemo(() => {
-    const keeperCount = scopeAgentsByKeeperFilter(rosterAgents, keeperList, 'keeper-only').length
-    const agentCount = scopeAgentsByKeeperFilter(rosterAgents, keeperList, 'agent-only').length
+    const keeperCount = scopeAgentsByKeeperFilter(rosterAgents, keeperList, 'keeper-only', keeperRuntimeLookup).length
+    const agentCount = scopeAgentsByKeeperFilter(rosterAgents, keeperList, 'agent-only', keeperRuntimeLookup).length
     return { agents: agentCount, keepers: keeperCount, totalRuntimes: rosterAgents.length }
-  }, [rosterAgents, keeperList])
+  }, [rosterAgents, keeperList, keeperRuntimeLookup])
 
   const runtimeCounts = resolveRuntimeCounts({
     executionLoaded: executionLoaded.value,
@@ -420,16 +458,18 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   const namespaceName = namespaceStatus?.project ?? 'default'
 
   const scopedAgents = useMemo(
-    () => scopeAgentsByKeeperFilter(rosterAgents, keeperList, keeperFilter),
-    [rosterAgents, keeperList, keeperFilter],
+    () => scopeAgentsByKeeperFilter(rosterAgents, keeperList, keeperFilter, keeperRuntimeLookup),
+    [rosterAgents, keeperList, keeperFilter, keeperRuntimeLookup],
   )
   const bandByAgent = useMemo(
     () => new Map(
       scopedAgents.map(agent => [
         agent.name,
         runtimeBandMetaForAgent(
-          agent,
-          keeperRuntimeLookup.get(agent.name) ?? findKeeperRuntime(agent.name, keeperList),
+        agent,
+          keeperRuntimeLookup.get(agent.name)
+            ?? findKeeperRuntimeForAgent(agent, keeperRuntimeLookup)
+            ?? findKeeperRuntime(agent.name, keeperList),
         ),
       ] as const),
     ),
@@ -439,7 +479,10 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   const searchTermsByAgent = useMemo(
     () => new Map(
       scopedAgents.map(agent => {
-        const keeper = keeperRuntimeLookup.get(agent.name) ?? findKeeperRuntime(agent.name, keeperList)
+        const keeper =
+          keeperRuntimeLookup.get(agent.name)
+          ?? findKeeperRuntimeForAgent(agent, keeperRuntimeLookup)
+          ?? findKeeperRuntime(agent.name, keeperList)
         return [
           agent.name,
           keeperIdentitySearchTerms(
@@ -598,7 +641,10 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
       <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
         ${filtered.map((agent: Agent) => {
-          const keeperRuntime = keeperRuntimeLookup.get(agent.name) ?? findKeeperRuntime(agent.name, keeperList)
+          const keeperRuntime =
+            keeperRuntimeLookup.get(agent.name)
+            ?? findKeeperRuntimeForAgent(agent, keeperRuntimeLookup)
+            ?? findKeeperRuntime(agent.name, keeperList)
           const band = bandByAgent.get(agent.name) ?? runtimeBandMeta('attention')
           const keeperMonitoring = keeperRuntime ? summarizeKeeperMonitoring(keeperRuntime) : null
           const monitoringEvidence = keeperMonitoring ? summarizeMonitoringEvidence(keeperMonitoring) : null

--- a/dashboard/src/components/common/keeper-identity.test.ts
+++ b/dashboard/src/components/common/keeper-identity.test.ts
@@ -30,6 +30,11 @@ describe('keeper identity helpers', () => {
     expect(canonicalKeeperNameFromAgentName('ramarama-fierce-panda')).toBe('ramarama')
   })
 
+  it('does not canonicalize arbitrary hyphenated runtime names', () => {
+    expect(canonicalKeeperNameFromAgentName('foo-bar')).toBeNull()
+    expect(keeperPrimaryName(null, 'foo-bar')).toBe('foo-bar')
+  })
+
   it('canonicalizes keeper alias names', () => {
     expect(canonicalKeeperName('keeper-sangsu-agent')).toBe('sangsu')
   })
@@ -44,5 +49,13 @@ describe('keeper identity helpers', () => {
       'ramarama',
       'ramarama-fierce-panda',
     ])
+  })
+
+  it('does not add the first segment as a keeper lookup key for arbitrary hyphenated runtime names', () => {
+    const keys = keeperIdentityKeys(null, null, 'foo-bar')
+
+    expect(keys).toContain('foo-bar')
+    expect(keys).not.toContain('foo')
+    expect(keys).not.toContain('keeper:foo')
   })
 })

--- a/dashboard/src/components/common/keeper-identity.test.ts
+++ b/dashboard/src/components/common/keeper-identity.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  canonicalKeeperName,
+  canonicalKeeperNameFromAgentName,
+  keeperIdentityKeys,
+  keeperPrincipalKey,
   keeperIdentitySearchTerms,
   keeperPrimaryName,
   runtimeAgentName,
@@ -19,6 +23,26 @@ describe('keeper identity helpers', () => {
     expect(keeperIdentitySearchTerms('sangsu', 'keeper-sangsu-agent')).toEqual([
       'sangsu',
       'keeper-sangsu-agent',
+    ])
+  })
+
+  it('canonicalizes generated keeper-owned sub-op aliases to the stable keeper name', () => {
+    expect(canonicalKeeperNameFromAgentName('ramarama-fierce-panda')).toBe('ramarama')
+  })
+
+  it('canonicalizes keeper alias names', () => {
+    expect(canonicalKeeperName('keeper-sangsu-agent')).toBe('sangsu')
+  })
+
+  it('prefers keeper_id for principal keys', () => {
+    expect(keeperPrincipalKey('uuid-1', 'ramarama', 'ramarama-fierce-panda')).toBe('keeper_id:uuid-1')
+  })
+
+  it('emits lookup keys for keeper id, canonical keeper name, and runtime alias', () => {
+    expect(keeperIdentityKeys('uuid-1', 'ramarama', 'ramarama-fierce-panda')).toEqual([
+      'keeper_id:uuid-1',
+      'ramarama',
+      'ramarama-fierce-panda',
     ])
   })
 })

--- a/dashboard/src/components/common/keeper-identity.ts
+++ b/dashboard/src/components/common/keeper-identity.ts
@@ -55,7 +55,7 @@ function extractGeneratedNicknamePrefix(name: string): string | null {
     return uniquePrefix || null
   }
 
-  return parts[0] ?? null
+  return null
 }
 
 export function keeperNameFromAgentName(agentName: string | null | undefined): string | null {

--- a/dashboard/src/components/common/keeper-identity.ts
+++ b/dashboard/src/components/common/keeper-identity.ts
@@ -1,9 +1,108 @@
+const adjectives = new Set([
+  'swift', 'brave', 'calm', 'eager', 'fierce',
+  'gentle', 'happy', 'jolly', 'keen', 'lucky',
+  'merry', 'noble', 'proud', 'quick', 'witty',
+  'bold', 'cool', 'deft', 'fair', 'grand',
+  'hale', 'jade', 'kind', 'lean', 'neat',
+  'pale', 'rare', 'sage', 'tame', 'warm',
+])
+
+const animals = new Set([
+  'fox', 'bear', 'wolf', 'hawk', 'lion',
+  'tiger', 'eagle', 'otter', 'panda', 'koala',
+  'raven', 'falcon', 'badger', 'beaver', 'whale',
+  'shark', 'crane', 'heron', 'moose', 'viper',
+  'cobra', 'gecko', 'lemur', 'llama', 'manta',
+  'orca', 'rhino', 'sloth', 'tapir', 'zebra',
+])
+
+function trimmedOrNull(value: string | null | undefined): string | null {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}
+
+function isValidKeeperName(value: string): boolean {
+  return /^[A-Za-z0-9._-]+$/.test(value)
+}
+
+function isHex4(value: string): boolean {
+  return /^[0-9a-f]{4}$/.test(value)
+}
+
+function extractGeneratedNicknamePrefix(name: string): string | null {
+  const parts = name.split('-')
+  if (parts.length === 0) return null
+
+  const directPrefix = parts.slice(0, -2).join('-')
+  const adjective = parts.length >= 2 ? parts[parts.length - 2] : undefined
+  const animal = parts.length >= 1 ? parts[parts.length - 1] : undefined
+  if (adjective && animal && adjectives.has(adjective) && animals.has(animal)) {
+    return directPrefix || null
+  }
+
+  const uniquePrefix = parts.slice(0, -3).join('-')
+  const uniqueAdjective = parts.length >= 3 ? parts[parts.length - 3] : undefined
+  const uniqueAnimal = parts.length >= 2 ? parts[parts.length - 2] : undefined
+  const suffix = parts.length >= 1 ? parts[parts.length - 1] : undefined
+  if (
+    suffix
+    && uniqueAdjective
+    && uniqueAnimal
+    && isHex4(suffix)
+    && adjectives.has(uniqueAdjective)
+    && animals.has(uniqueAnimal)
+  ) {
+    return uniquePrefix || null
+  }
+
+  return parts[0] ?? null
+}
+
+export function keeperNameFromAgentName(agentName: string | null | undefined): string | null {
+  const trimmed = trimmedOrNull(agentName)
+  if (!trimmed) return null
+
+  if (trimmed.startsWith('keeper-') && trimmed.endsWith('-agent') && trimmed.length > 13) {
+    const candidate = trimmed.slice(7, -6)
+    return isValidKeeperName(candidate) ? candidate : null
+  }
+
+  return null
+}
+
+export function canonicalKeeperNameFromAgentName(agentName: string | null | undefined): string | null {
+  const trimmed = trimmedOrNull(agentName)
+  if (!trimmed) return null
+
+  const aliasName = keeperNameFromAgentName(trimmed)
+  if (aliasName) return aliasName
+
+  const generatedPrefix = extractGeneratedNicknamePrefix(trimmed)
+  return generatedPrefix && isValidKeeperName(generatedPrefix) ? generatedPrefix : null
+}
+
+export function canonicalKeeperName(rawName: string | null | undefined): string | null {
+  const trimmed = trimmedOrNull(rawName)
+  if (!trimmed) return null
+
+  const aliasName = canonicalKeeperNameFromAgentName(trimmed)
+  if (aliasName) return aliasName
+
+  if (trimmed.startsWith('keeper-') && !trimmed.endsWith('-agent') && trimmed.length > 7) {
+    const candidate = trimmed.slice(7)
+    return isValidKeeperName(candidate) ? candidate : null
+  }
+
+  if (isValidKeeperName(trimmed)) return trimmed
+  return null
+}
+
 export function runtimeAgentName(
   keeperName: string | null | undefined,
   agentName: string | null | undefined,
 ): string | null {
-  const keeper = keeperName?.trim()
-  const agent = agentName?.trim()
+  const keeper = keeperPrimaryName(keeperName, agentName)
+  const agent = trimmedOrNull(agentName)
   if (!agent) return null
   if (!keeper) return agent
   return agent === keeper ? null : agent
@@ -13,10 +112,41 @@ export function keeperPrimaryName(
   keeperName: string | null | undefined,
   agentName: string | null | undefined,
 ): string | null {
-  const keeper = keeperName?.trim()
-  if (keeper) return keeper
-  const agent = agentName?.trim()
-  return agent || null
+  const explicitKeeper = canonicalKeeperName(keeperName)
+  if (explicitKeeper) return explicitKeeper
+  return canonicalKeeperNameFromAgentName(agentName) ?? trimmedOrNull(agentName)
+}
+
+export function keeperPrincipalKey(
+  keeperId: string | null | undefined,
+  keeperName: string | null | undefined,
+  agentName: string | null | undefined,
+): string | null {
+  const trimmedKeeperId = trimmedOrNull(keeperId)
+  if (trimmedKeeperId) return `keeper_id:${trimmedKeeperId}`
+
+  const canonicalName = keeperPrimaryName(keeperName, agentName)
+  if (canonicalName) return `keeper:${canonicalName.toLowerCase()}`
+
+  const runtime = trimmedOrNull(agentName)
+  return runtime ? `agent:${runtime.toLowerCase()}` : null
+}
+
+export function keeperIdentityKeys(
+  keeperId: string | null | undefined,
+  keeperName: string | null | undefined,
+  agentName: string | null | undefined,
+): string[] {
+  const values = [
+    keeperPrincipalKey(keeperId, keeperName, agentName),
+    trimmedOrNull(keeperId) ? `keeper_id:${trimmedOrNull(keeperId)}` : null,
+    keeperPrimaryName(keeperName, agentName)?.toLowerCase() ?? null,
+    canonicalKeeperName(keeperName)?.toLowerCase() ?? null,
+    trimmedOrNull(keeperName)?.toLowerCase() ?? null,
+    trimmedOrNull(agentName)?.toLowerCase() ?? null,
+  ]
+
+  return Array.from(new Set(values.filter((value): value is string => Boolean(value))))
 }
 
 export function keeperIdentitySearchTerms(
@@ -32,7 +162,7 @@ export function keeperIdentityHint(
   keeperName: string | null | undefined,
   agentName: string | null | undefined,
 ): string | null {
-  const keeper = keeperName?.trim()
+  const keeper = keeperPrimaryName(keeperName, agentName)
   const runtime = runtimeAgentName(keeper, agentName)
   if (!keeper) return null
   if (!runtime) return `키퍼 · ${keeper}`

--- a/dashboard/src/components/keeper-detail-panels.test.ts
+++ b/dashboard/src/components/keeper-detail-panels.test.ts
@@ -347,6 +347,7 @@ describe('InferenceTelemetryPanel', () => {
         fallback_from: null,
         fallback_to: null,
         fallback_reason: null,
+        timeout_budget: null,
       },
       {
         ts: 2,
@@ -391,6 +392,7 @@ describe('InferenceTelemetryPanel', () => {
         fallback_from: null,
         fallback_to: null,
         fallback_reason: null,
+        timeout_budget: null,
       },
     ] satisfies KeeperMetricPoint[]
     const keeper = { metrics_series: metricsSeries } as Keeper

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -653,6 +653,7 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
   )
   const latestTotal = latestPrompt?.estimated_total_tokens ?? null
   const latestCacheable = latestPrompt?.estimated_cacheable_tokens ?? null
+  const latestTimeoutBudget = latest?.timeout_budget ?? null
   const cacheableRatio =
     latestTotal && latestCacheable != null && latestTotal > 0
       ? latestCacheable / latestTotal
@@ -697,6 +698,18 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
             <span>latest ${latestTotal != null ? formatTokens(latestTotal) : '-'}</span>
             <span>cacheable ${latestCacheable != null ? formatTokens(latestCacheable) : '-'}</span>
             ${cacheableRatio != null ? html`<span>${Math.round(cacheableRatio * 100)}% cacheable</span>` : null}
+            ${latestTimeoutBudget?.oas_timeout_sec != null
+              ? html`<span>OAS ${Math.round(latestTimeoutBudget.oas_timeout_sec)}s</span>`
+              : null}
+            ${latestTimeoutBudget?.keeper_turn_timeout_sec != null
+              ? html`<span>keeper cap ${Math.round(latestTimeoutBudget.keeper_turn_timeout_sec)}s</span>`
+              : null}
+            ${latestTimeoutBudget?.source
+              ? html`<span>${latestTimeoutBudget.source}</span>`
+              : null}
+            ${latest?.cascade_strategy
+              ? html`<span>strategy ${latest.cascade_strategy}</span>`
+              : null}
           </div>
         </div>
 

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -216,6 +216,7 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
         autonomous_slot_wait_timeout: 'Autonomous slot wait timeout',
         admission_queue_wait_timeout: 'Admission queue wait timeout',
         turn_timeout_after_queue_wait: 'Turn timeout after queue wait',
+        oas_timeout_budget: 'OAS timeout budget',
         turn_timeout: 'Turn timeout',
         completion_contract_violation: 'Completion contract violation',
         cascade_exhausted: 'Cascade exhausted',

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -296,7 +296,7 @@ const KEEPER_RUNTIME_ROWS: Array<{
   { key: 'turn_timeout_sec', label: 'turn timeout', fmt: 'duration' },
   { key: 'admission_wait_timeout_sec', label: 'admission wait timeout', fmt: 'duration' },
   { key: 'oas_timeout_override_sec', label: 'OAS timeout override', fmt: 'duration' },
-  { key: 'oas_timeout_per_1k', label: 'OAS timeout per 1k ctx', fmt: 'float' },
+  { key: 'oas_timeout_per_1k', label: 'OAS timeout per 1k est input', fmt: 'float' },
   { key: 'oas_timeout_per_turn', label: 'OAS timeout per turn', fmt: 'duration' },
 ]
 

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -251,6 +251,19 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
               segments: promptSegments,
             }
           : null
+      const rawTimeoutBudget = isRecord(item.timeout_budget) ? item.timeout_budget : null
+      const timeout_budget =
+        rawTimeoutBudget != null
+          ? {
+              oas_timeout_sec: asNumber(rawTimeoutBudget.oas_timeout_sec) ?? null,
+              adaptive_timeout_sec: asNumber(rawTimeoutBudget.adaptive_timeout_sec) ?? null,
+              keeper_turn_timeout_sec: asNumber(rawTimeoutBudget.keeper_turn_timeout_sec) ?? null,
+              remaining_turn_budget_sec: asNumber(rawTimeoutBudget.remaining_turn_budget_sec) ?? null,
+              estimated_input_tokens: asNumber(rawTimeoutBudget.estimated_input_tokens) ?? null,
+              max_turns: asNumber(rawTimeoutBudget.max_turns) ?? null,
+              source: typeof rawTimeoutBudget.source === 'string' ? rawTimeoutBudget.source : null,
+            }
+          : null
       const rawCtxComposition = isRecord(item.ctx_composition) ? item.ctx_composition : null
       const rawCtxSegments =
         rawCtxComposition && isRecord(rawCtxComposition.segments) ? rawCtxComposition.segments : null
@@ -311,12 +324,14 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
         handoff_new_generation: handoffNewGeneration,
         prompt_fingerprint: promptFingerprint,
         prompt_metrics,
+        timeout_budget,
         ctx_composition,
         input_tokens: inputTokens,
         output_tokens: outputTokens,
         total_tokens: totalTokens,
         wall_tokens_per_second: wallTokensPerSecond,
         inference_telemetry,
+        cascade_strategy: cascadeObj && typeof cascadeObj.strategy === 'string' ? cascadeObj.strategy : null,
         fallback_applied: cascadeObj ? cascadeObj.fallback_applied === true : false,
         fallback_hops: cascadeObj ? (asNumber(cascadeObj.fallback_hops) ?? 0) : 0,
         fallback_from: firstFallback && typeof firstFallback.from_model_id === 'string' ? firstFallback.from_model_id : null,
@@ -437,6 +452,7 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         reconcile_status: asString(row.reconcile_status) ?? null,
         emoji: asString(row.emoji),
         koreanName: asString(row.koreanName) ?? asString(row.korean_name),
+        keeper_id: asString(row.keeper_id) ?? null,
         agent_name: asString(row.agent_name),
         trace_id: asString(row.trace_id),
         model,

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -97,6 +97,9 @@ export function keeperRuntimeBlockerHint(keeper: Keeper | null | undefined): str
   if (blockerClass === 'turn_timeout_after_queue_wait') {
     return '대기 후 실행된 턴이 전체 제한 시간을 초과했습니다.'
   }
+  if (blockerClass === 'oas_timeout_budget') {
+    return 'OAS 실행 예산이 먼저 소진되었습니다.'
+  }
   if (blockerClass === 'turn_timeout') {
     return '턴 실행 시간이 제한 시간을 초과했습니다.'
   }

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -61,6 +61,8 @@ export function normalizeAgent(raw: unknown): Agent | null {
   return {
     name,
     agent_type: asString(raw.agent_type),
+    keeper_name: asString(raw.keeper_name) ?? null,
+    keeper_id: asString(raw.keeper_id) ?? null,
     status: normalizeAgentStatus(raw.status),
     current_task: asString(raw.current_task) ?? null,
     joined_at: asString(raw.joined_at),
@@ -276,6 +278,8 @@ export function normalizeExecutionWorkerSupportBrief(raw: unknown): DashboardExe
   return {
     name,
     agent_name: asString(raw.agent_name),
+    keeper_name: asString(raw.keeper_name) ?? null,
+    keeper_id: asString(raw.keeper_id) ?? null,
     status: asString(raw.status),
     tone: normalizeExecutionTone(raw.tone),
     state,
@@ -307,6 +311,7 @@ export function normalizeExecutionContinuityBrief(raw: unknown): DashboardExecut
   }
   return {
     name,
+    keeper_id: asString(raw.keeper_id) ?? null,
     agent_name: asString(raw.agent_name) ?? null,
     status: asString(raw.status),
     tone: normalizeExecutionTone(raw.tone),

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -5,6 +5,8 @@
 export interface Agent {
   name: string
   agent_type?: string
+  keeper_name?: string | null
+  keeper_id?: string | null
   status?: 'active' | 'busy' | 'listening' | 'idle' | 'inactive' | 'offline'
   current_task: string | null
   context_ratio?: number
@@ -168,6 +170,16 @@ export interface PromptTelemetry {
   segments: Record<string, PromptSegmentTelemetry>
 }
 
+export interface TimeoutBudgetTelemetry {
+  oas_timeout_sec: number | null
+  adaptive_timeout_sec: number | null
+  keeper_turn_timeout_sec: number | null
+  remaining_turn_budget_sec: number | null
+  estimated_input_tokens: number | null
+  max_turns: number | null
+  source: string | null
+}
+
 export interface CtxCompositionTelemetry {
   actual_input_tokens: number | null
   display_total_tokens: number
@@ -193,12 +205,14 @@ export interface KeeperMetricPoint {
   handoff_new_generation: number | null
   prompt_fingerprint: string | null
   prompt_metrics: PromptTelemetry | null
+  timeout_budget: TimeoutBudgetTelemetry | null
   ctx_composition: CtxCompositionTelemetry | null
   input_tokens: number | null
   output_tokens: number | null
   total_tokens: number | null
   wall_tokens_per_second: number | null
   inference_telemetry: InferenceTelemetry | null
+  cascade_strategy?: string | null
   fallback_applied: boolean
   fallback_hops: number
   fallback_from: string | null
@@ -561,6 +575,7 @@ export type KeeperPhase =
 
 export interface Keeper {
   name: string
+  keeper_id?: string | null
   pipeline_stage?: PipelineStage
   phase?: KeeperPhase | null
   runtime_class?: 'keeper'
@@ -594,6 +609,7 @@ export interface Keeper {
     | 'autonomous_slot_wait_timeout'
     | 'admission_queue_wait_timeout'
     | 'turn_timeout_after_queue_wait'
+    | 'oas_timeout_budget'
     | 'turn_timeout'
     | 'completion_contract_violation'
     | 'cascade_exhausted'
@@ -912,6 +928,7 @@ interface KeeperConfigRuntime {
     | 'autonomous_slot_wait_timeout'
     | 'admission_queue_wait_timeout'
     | 'turn_timeout_after_queue_wait'
+    | 'oas_timeout_budget'
     | 'turn_timeout'
     | 'completion_contract_violation'
     | 'cascade_exhausted'

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -322,6 +322,8 @@ export interface DashboardExecutionSessionBrief {
 export interface DashboardExecutionWorkerSupportBrief {
   name: string
   agent_name?: string
+  keeper_name?: string | null
+  keeper_id?: string | null
   status?: Agent['status'] | string
   tone?: DashboardExecutionTone
   state: DashboardExecutionWorkerState
@@ -343,6 +345,7 @@ export interface DashboardExecutionWorkerSupportBrief {
 
 export interface DashboardExecutionContinuityBrief {
   name: string
+  keeper_id?: string | null
   agent_name?: string | null
   status?: string
   tone?: DashboardExecutionTone

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -1003,33 +1003,52 @@ let local_capacity_for_selections ~sw ~net ?config_path selections =
    strategy fields do not flood the log on every keeper turn. *)
 let strategy_warned : (string * string, unit) Hashtbl.t = Hashtbl.create 4
 
-let warn_unknown_strategy ~name ~raw ~msg =
+let warn_unknown_strategy ~name ~raw ~msg ~fallback_kind =
   let key = (name, raw) in
   if not (Hashtbl.mem strategy_warned key) then begin
     Hashtbl.add strategy_warned key ();
     Printf.eprintf
-      "[warn] cascade %s: %s; falling back to failover\n%!" name msg
+      "[warn] cascade %s: %s; falling back to %s\n%!"
+      name msg (Cascade_strategy.kind_to_string fallback_kind)
   end
 
 let invalid_priority_tier_warned : (string * string, unit) Hashtbl.t =
   Hashtbl.create 4
 
-let warn_invalid_priority_tier ~name ~msg =
+let warn_invalid_priority_tier ~name ~msg ~fallback_kind =
   let key = (name, msg) in
   if not (Hashtbl.mem invalid_priority_tier_warned key) then begin
     Hashtbl.add invalid_priority_tier_warned key ();
     Printf.eprintf
-      "[warn] cascade %s: %s; falling back to failover\n%!" name msg
+      "[warn] cascade %s: %s; falling back to %s\n%!"
+      name msg (Cascade_strategy.kind_to_string fallback_kind)
   end
 
-let parse_kind_or_default ~name = function
+let default_strategy_kind ?config_path ~name () =
+  match config_path with
   | None -> Cascade_strategy.Failover
+  | Some path ->
+    (match Cascade_config_loader.load_catalog ~config_path:path with
+     | Ok entries ->
+       (match
+          List.find_opt
+            (fun (entry : Cascade_config_loader.catalog_entry) ->
+               String.equal entry.name name)
+            entries
+        with
+        | Some entry when entry.keeper_assignable ->
+            Cascade_strategy.Round_robin
+        | _ -> Cascade_strategy.Failover)
+     | Error _ -> Cascade_strategy.Failover)
+
+let parse_kind_or_default ~name ~default_kind = function
+  | None -> default_kind
   | Some raw ->
     match Cascade_strategy.parse_kind raw with
     | Ok k -> k
     | Error msg ->
-      warn_unknown_strategy ~name ~raw ~msg;
-      Cascade_strategy.Failover
+      warn_unknown_strategy ~name ~raw ~msg ~fallback_kind:default_kind;
+      default_kind
 
 let cycle_policy_from_loader (cfg : Cascade_config_loader.strategy_config) =
   let d = Cascade_strategy.default_cycle_policy in
@@ -1086,9 +1105,12 @@ let resolve_strategy ?config_path ~name () =
   match config_path with
   | None -> Cascade_strategy.failover
   | Some path ->
+    let default_kind = default_strategy_kind ~config_path:path ~name () in
     let cfg = Cascade_config_loader.resolve_strategy_config
                 ~config_path:path ~name in
-    let parsed_kind = parse_kind_or_default ~name cfg.kind in
+    let parsed_kind =
+      parse_kind_or_default ~name ~default_kind cfg.kind
+    in
     let cycle = cycle_policy_from_loader cfg in
     let kind, tiers =
       match parsed_kind with
@@ -1104,8 +1126,9 @@ let resolve_strategy ?config_path ~name () =
           (match result with
            | Ok tiers -> (parsed_kind, tiers)
            | Error msg ->
-               warn_invalid_priority_tier ~name ~msg;
-               (Cascade_strategy.Failover, []))
+               warn_invalid_priority_tier
+                 ~name ~msg ~fallback_kind:default_kind;
+               (default_kind, []))
       | _ -> (parsed_kind, [])
     in
     let sticky_ttl_ms =

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -326,8 +326,9 @@ module KeeperKeepalive = struct
       Guards against indefinite LLM response waits within a turn.
 
       When [MASC_KEEPER_OAS_TIMEOUT_SEC] is set, that value is used directly.
-      Otherwise, {!oas_timeout_for_context} computes an adaptive timeout:
-        base + ctx/1K × per_1k + min(max_turns, 40) × per_turn
+      Otherwise, {!oas_timeout_for_estimated_input_tokens} computes an
+      adaptive timeout:
+        base + estimated_input_tokens/1K × per_1k + min(max_turns, 40) × per_turn
       References {!oas_max_turns_per_call} (default 15) directly to avoid
       default drift.  Previous formula used 4× headroom on a default of 5,
       producing min(5, 40)=5 effective turns.  Using the actual per-call
@@ -381,8 +382,8 @@ module KeeperKeepalive = struct
             (get_int ~default
                "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS")))
 
-  let oas_timeout_for_context_with_turn_budget ~(max_context : int)
-      ~(max_turns : int) : float =
+  let oas_timeout_for_estimated_input_tokens_with_turn_budget
+      ~(estimated_input_tokens : int) ~(max_turns : int) : float =
     match oas_timeout_sec_override with
     | Some v -> v
     | None ->
@@ -393,7 +394,9 @@ module KeeperKeepalive = struct
       let per_turn =
         get_float ~default:30.0 "MASC_KEEPER_OAS_TIMEOUT_PER_TURN"
       in
-      let context_time = Float.of_int max_context /. 1000.0 *. per_1k in
+      let input_time =
+        Float.of_int (max 0 estimated_input_tokens) /. 1000.0 *. per_1k
+      in
       (* Cap at 40 effective turns even if the configured per-call turn
          budget is higher. This is a deliberate safety cap: with
          per_turn=30s, 40 turns alone consume 1200s — the entire
@@ -404,14 +407,17 @@ module KeeperKeepalive = struct
       in
       let turn_time = effective_turns *. per_turn in
       Float.max 30.0
-        (Float.min turn_timeout_sec (base +. context_time +. turn_time))
+        (Float.min turn_timeout_sec (base +. input_time +. turn_time))
 
-  let oas_timeout_for_context ~(max_context : int) : float =
-    oas_timeout_for_context_with_turn_budget ~max_context
+  let oas_timeout_for_estimated_input_tokens
+      ~(estimated_input_tokens : int) : float =
+    oas_timeout_for_estimated_input_tokens_with_turn_budget
+      ~estimated_input_tokens
       ~max_turns:oas_max_turns_per_call
 
   (** Backward-compatible accessor: returns the env override or 300s default.
-      Prefer {!oas_timeout_for_context} when max_context is available. *)
+      Prefer {!oas_timeout_for_estimated_input_tokens} when a live prompt
+      estimate is available. *)
   let oas_timeout_sec =
     Option.value ~default:300.0 oas_timeout_sec_override
 

--- a/lib/coord/coord_lifecycle.ml
+++ b/lib/coord/coord_lifecycle.ml
@@ -30,7 +30,8 @@ let agent_parse_error_snapshot ~agent_name ~agent_file =
 
 (** Join room - with auto-generated nickname and metadata *)
 let join config ~agent_name ?(agent_type_override=None) ~capabilities
-    ?(pid=None) ?(hostname=None) ?(tty=None) ?(worktree=None) ?(parent_task=None) () =
+    ?(pid=None) ?(hostname=None) ?(tty=None) ?(worktree=None)
+    ?(parent_task=None) ?(keeper_name=None) ?(keeper_id=None) () =
   ensure_initialized config;
 
   (* Determine if this is a legacy call (agent_name = type) or new style *)
@@ -87,6 +88,8 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
          tty = (match tty with Some t -> Some t | None -> get_tty ());
          worktree;
          parent_task;
+         keeper_name;
+         keeper_id;
        } in
        let updated = { existing_agent with
          status = Active;
@@ -138,6 +141,8 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
     tty = (match tty with Some t -> Some t | None -> get_tty ());
     worktree;
     parent_task;
+    keeper_name;
+    keeper_id;
   } in
 
   let agent_file = Filename.concat (agents_dir config) (safe_filename nickname ^ ".json") in

--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -168,6 +168,14 @@ let worker_state_of_agent
         [
           ("name", `String agent.name);
           ("agent_name", `String agent.name);
+          ("keeper_name",
+            match agent.meta with
+            | Some meta -> json_string_option meta.keeper_name
+            | None -> `Null);
+          ("keeper_id",
+            match agent.meta with
+            | Some meta -> json_string_option meta.keeper_id
+            | None -> `Null);
           ("status", `String status_string);
           ("tone", `String (string_of_tone tone));
           ("state", `String state);
@@ -311,6 +319,7 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
         ([
            ("name", `String name);
            ("agent_name", member_assoc "agent_name" keeper);
+           ("keeper_id", member_assoc "keeper_id" keeper);
            ("status", `String status);
            ("tone", `String (string_of_tone tone));
            ("state", `String (keeper_exec_state_to_string state));

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -894,6 +894,11 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
             ] @ runtime_blocker_fields @ attention_fields @ [
               ("supervisor_diagnostics", supervisor_diagnostics);
               ("agent_name", `String m.agent_name);
+              ( "keeper_id",
+                match m.keeper_id with
+                | Some keeper_id ->
+                    `String (Keeper_id.Uid.to_string keeper_id)
+                | None -> `Null );
               ("emoji", `String (let (e, _) = get_agent_identity m.name in e));
               ("koreanName", `String (let (_, k) = get_agent_identity m.name in k));
               ("trace_id", `String (Keeper_id.Trace_id.to_string m.runtime.trace_id));
@@ -1150,6 +1155,7 @@ let execution_trust_dashboard_json (config : Coord.config) : Yojson.Safe.t =
                    [
                      ("name", Yojson.Safe.Util.member "name" row);
                      ("agent_name", Yojson.Safe.Util.member "agent_name" row);
+                     ("keeper_id", Yojson.Safe.Util.member "keeper_id" row);
                      ("phase", Yojson.Safe.Util.member "phase" row);
                      ( "pipeline_stage",
                        Yojson.Safe.Util.member "pipeline_stage" row );

--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -450,11 +450,12 @@ let compute_metrics_window
               ("memory_note_kinds", `List (List.map (fun s -> `String s) memory_note_kinds));
               ("memory_compaction_performed", `Bool memory_compaction_performed_now);
               ("memory_compaction_before_notes", `Int memory_compaction_before_notes_now);
-              ("memory_compaction_dropped_notes", `Int memory_compaction_dropped_notes_now);
-              ("memory_compaction_invalid_dropped", `Int memory_compaction_invalid_dropped_now);
-              ("memory_expected_topic", Json_util.string_opt_to_json memory_expected_topic);
-              ("inference_telemetry", j |> member "inference_telemetry");
-            ])
+	              ("memory_compaction_dropped_notes", `Int memory_compaction_dropped_notes_now);
+	              ("memory_compaction_invalid_dropped", `Int memory_compaction_invalid_dropped_now);
+	              ("memory_expected_topic", Json_util.string_opt_to_json memory_expected_topic);
+	              ("timeout_budget", j |> member "timeout_budget");
+	              ("inference_telemetry", j |> member "inference_telemetry");
+	            ])
         in
         match output_item with
         | Some i -> (acc, i :: items)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -769,6 +769,14 @@ let run_turn
     Keeper_context_core.repair_broken_tool_call_pairs
       (Keeper_exec_context.messages_of_context ctx_work)
   in
+  let estimated_input_tokens =
+    let composition =
+      build_ctx_composition_metrics ~system_prompt:turn_system_prompt
+        ~dynamic_context ~memory_context ~temporal_context ~user_message
+        ~history_messages ~actual_input_tokens:0
+    in
+    max prompt_metrics.estimated_total_tokens composition.display_total_tokens
+  in
   let ctx_work = Keeper_exec_context.append ctx_work user_msg in
   if not is_retry
   then Keeper_exec_context.persist_message ~source:history_user_source session user_msg;
@@ -2211,7 +2219,8 @@ let run_turn
       match oas_timeout_s with
       | Some value -> value
       | None ->
-          Keeper_runtime_resolved.oas_timeout_for_context ~max_context
+          Keeper_runtime_resolved.oas_timeout_for_estimated_input_tokens
+            ~estimated_input_tokens
     in
     let cli_transport_overrides =
       Some

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -113,6 +113,7 @@ let is_auto_recoverable_cascade_exhausted_error (err : Oas.Error.sdk_error) : bo
   | Some (Oas_worker_named.Admission_queue_rejected _)
   | Some (Oas_worker_named.Admission_queue_timeout _)
   | Some (Oas_worker_named.Turn_timeout _)
+  | Some (Oas_worker_named.Oas_timeout_budget _)
   | Some (Oas_worker_named.Ambiguous_post_commit _)
   | None ->
       false
@@ -126,6 +127,7 @@ let is_resumable_cli_session_error (err : Oas.Error.sdk_error) : bool =
   | Some (Oas_worker_named.Admission_queue_timeout _)
   | Some (Oas_worker_named.Admission_queue_rejected _)
   | Some (Oas_worker_named.Turn_timeout _)
+  | Some (Oas_worker_named.Oas_timeout_budget _)
   | Some (Oas_worker_named.Ambiguous_post_commit _)
   | None ->
       false
@@ -185,6 +187,8 @@ let degraded_retry_after_recoverable_error
         local_recovery_retry "resumable_cli_session"
     | Some (Oas_worker_named.Admission_queue_timeout _) ->
         local_recovery_retry "admission_queue_timeout"
+    | Some (Oas_worker_named.Oas_timeout_budget _) ->
+        local_recovery_retry "oas_timeout_budget"
     | Some (Oas_worker_named.Turn_timeout _) ->
         local_recovery_retry "turn_timeout"
     | Some
@@ -322,6 +326,7 @@ let is_cascade_exhausted_error (err : Oas.Error.sdk_error) : bool =
   | Some (Oas_worker_named.Accept_rejected _) -> true
   | Some (Oas_worker_named.Admission_queue_timeout _)
   | Some (Oas_worker_named.Admission_queue_rejected _)
+  | Some (Oas_worker_named.Oas_timeout_budget _)
   | Some (Oas_worker_named.Turn_timeout _)
   | Some (Oas_worker_named.Ambiguous_post_commit _) -> false
   | None -> false

--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -224,23 +224,27 @@ let turn_timeout_sec () =
 let admission_wait_timeout_sec () =
   (current ()).admission_wait_timeout_sec.value
 
-let oas_timeout_for_context_with_turn_budget ~(max_context : int)
-    ~(max_turns : int) : float =
+let oas_timeout_for_estimated_input_tokens_with_turn_budget
+    ~(estimated_input_tokens : int) ~(max_turns : int) : float =
   let runtime = current () in
   match runtime.oas_timeout_override_sec.value with
   | Some value -> value
   | None ->
       let base = 120.0 in
-      let context_time =
-        Float.of_int max_context /. 1000.0 *. runtime.oas_timeout_per_1k.value
+      let input_time =
+        Float.of_int (max 0 estimated_input_tokens) /. 1000.0
+        *. runtime.oas_timeout_per_1k.value
       in
       let effective_turns =
         Float.of_int (min max_turns 40)
       in
       let turn_time = effective_turns *. runtime.oas_timeout_per_turn.value in
       Float.max 30.0
-        (Float.min runtime.turn_timeout_sec.value (base +. context_time +. turn_time))
+        (Float.min runtime.turn_timeout_sec.value
+           (base +. input_time +. turn_time))
 
-let oas_timeout_for_context ~(max_context : int) : float =
-  oas_timeout_for_context_with_turn_budget ~max_context
+let oas_timeout_for_estimated_input_tokens ~(estimated_input_tokens : int) :
+    float =
+  oas_timeout_for_estimated_input_tokens_with_turn_budget
+    ~estimated_input_tokens
     ~max_turns:(reactive_max_turns_per_call ())

--- a/lib/keeper/keeper_runtime_resolved.mli
+++ b/lib/keeper/keeper_runtime_resolved.mli
@@ -45,11 +45,11 @@ val reactive_max_idle_turns : unit -> int
 val autonomous_max_idle_turns : unit -> int
 val turn_timeout_sec : unit -> float
 val admission_wait_timeout_sec : unit -> float
-val oas_timeout_for_context_with_turn_budget :
-  max_context:int ->
+val oas_timeout_for_estimated_input_tokens_with_turn_budget :
+  estimated_input_tokens:int ->
   max_turns:int ->
   float
 
-val oas_timeout_for_context :
-  max_context:int ->
+val oas_timeout_for_estimated_input_tokens :
+  estimated_input_tokens:int ->
   float

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -174,6 +174,9 @@ let blocker_class_of_string (reason : string) : blocker_class option =
   else if String_util.contains_substring_ci trimmed "admission queue wait timeout"
   then
     Some Admission_queue_wait_timeout
+  else if String_util.contains_substring_ci trimmed "oas budget timeout"
+  then
+    Some Oas_timeout_budget
   else if String_util.contains_substring_ci trimmed "turn wall-clock timeout"
   then
     Some Turn_timeout
@@ -194,6 +197,8 @@ let blocker_class_of_sdk_error (err : Oas.Error.sdk_error) : blocker_class optio
       Some Admission_queue_wait_timeout
   | Some (Oas_worker_named.Admission_queue_rejected _) ->
       None
+  | Some (Oas_worker_named.Oas_timeout_budget _) ->
+      Some Oas_timeout_budget
   | Some (Oas_worker_named.Turn_timeout _) ->
       Some Turn_timeout
   | Some (Oas_worker_named.Ambiguous_post_commit { is_timeout; _ }) ->
@@ -220,6 +225,10 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
   let summary = match cls with
     | Cascade_exhausted reason ->
         if summary = "" then cascade_exhaustion_summary reason else summary
+    | Oas_timeout_budget ->
+        if summary = "" then
+          "OAS budget timeout fired before the keeper hard timeout."
+        else summary
     | _ -> if summary = "" then str else summary
   in
   { blocker_class = str; summary; continue_gate }

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -99,6 +99,7 @@ type blocker_class =
   | Autonomous_slot_wait_timeout
   | Admission_queue_wait_timeout
   | Turn_timeout_after_queue_wait
+  | Oas_timeout_budget
   | Turn_timeout
   | Completion_contract_violation
   | No_tool_capable_provider
@@ -110,6 +111,7 @@ let blocker_class_to_string = function
   | Autonomous_slot_wait_timeout -> "autonomous_slot_wait_timeout"
   | Admission_queue_wait_timeout -> "admission_queue_wait_timeout"
   | Turn_timeout_after_queue_wait -> "turn_timeout_after_queue_wait"
+  | Oas_timeout_budget -> "oas_timeout_budget"
   | Turn_timeout -> "turn_timeout"
   | Completion_contract_violation -> "completion_contract_violation"
   | No_tool_capable_provider -> "no_tool_capable_provider"
@@ -121,6 +123,7 @@ let blocker_class_of_serialized_string = function
   | "autonomous_slot_wait_timeout" -> Some Autonomous_slot_wait_timeout
   | "admission_queue_wait_timeout" -> Some Admission_queue_wait_timeout
   | "turn_timeout_after_queue_wait" -> Some Turn_timeout_after_queue_wait
+  | "oas_timeout_budget" -> Some Oas_timeout_budget
   | "turn_timeout" -> Some Turn_timeout
   | "completion_contract_violation" -> Some Completion_contract_violation
   | "no_tool_capable_provider" -> Some No_tool_capable_provider

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -111,6 +111,7 @@ type blocker_class =
   | Autonomous_slot_wait_timeout
   | Admission_queue_wait_timeout
   | Turn_timeout_after_queue_wait
+  | Oas_timeout_budget
   | Turn_timeout
   | Completion_contract_violation
   | No_tool_capable_provider

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -544,6 +544,7 @@ let append_decision_record
                 | Some co ->
                     [
                       ("cascade_name", `String co.cascade_name);
+                      ("strategy", Json_util.string_opt_to_json co.strategy);
                       ("primary_model", match co.primary_model with Some m -> `String m | None -> `Null);
                       ("selected_model", match co.selected_model with Some m -> `String m | None -> `Null);
                       ("fallback_applied", `Bool co.fallback_applied);
@@ -925,7 +926,7 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
     ~(message_count : int)
     ~(compaction : Keeper_exec_context.compaction_event)
     ~(handoff_json : Yojson.Safe.t option)
-    ?deliberation_execution () : unit =
+    ?timeout_budget_json ?deliberation_execution () : unit =
   let now_ts = Time_compat.now () in
   let _observation = observation in
   let turn_mode = turn_mode_of_result result in
@@ -969,6 +970,10 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
         ("model_used", `String surface_model_used);
         ("prompt_fingerprint", `String result.prompt_metrics.fingerprint);
         ("prompt", Keeper_agent_run.prompt_metrics_to_json result.prompt_metrics);
+        ( "timeout_budget",
+          match timeout_budget_json with
+          | Some value -> value
+          | None -> `Null );
         ("ctx_composition", Keeper_agent_run.ctx_composition_to_json result.ctx_composition);
         ("usage", usage_json);
         ("latency_ms", `Int latency_ms);
@@ -1139,6 +1144,17 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
         | Some (Oas_worker_named.Resumable_cli_session { detail; _ }) ->
             let trimmed = String.trim detail in
             if trimmed = "" then reason else trimmed
+        | Some
+            (Oas_worker_named.Oas_timeout_budget
+               {
+                 budget_sec;
+                 keeper_turn_timeout_sec;
+                 estimated_input_tokens;
+                 source;
+               }) ->
+            Printf.sprintf
+              "OAS budget timeout after %.1fs (%s, estimated input %d tokens, keeper hard cap %.1fs)"
+              budget_sec source estimated_input_tokens keeper_turn_timeout_sec
         | _ -> reason)
     | None -> reason
   in

--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -62,6 +62,7 @@ val append_metrics_snapshot :
   message_count:int ->
   compaction:Keeper_exec_context.compaction_event ->
   handoff_json:Yojson.Safe.t option ->
+  ?timeout_budget_json:Yojson.Safe.t ->
   ?deliberation_execution:Keeper_deliberation.execution_result ->
   unit ->
   unit

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -212,23 +212,76 @@ let oas_timeout_guard_sec = 1.0
 
 let min_oas_timeout_budget_sec = 30.0
 
-let bounded_oas_timeout_for_turn_budget_with_turn_budget ~(max_context : int)
-    ~(max_turns : int)
-    ~(remaining_turn_budget_s : float) : float option =
+type oas_timeout_budget_resolution = {
+  effective_timeout_sec : float;
+  adaptive_timeout_sec : float;
+  keeper_turn_timeout_sec : float;
+  remaining_turn_budget_sec : float;
+  estimated_input_tokens : int;
+  max_turns : int;
+  source : string;
+}
+
+let oas_timeout_budget_resolution_to_yojson
+    (budget : oas_timeout_budget_resolution) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("oas_timeout_sec", `Float budget.effective_timeout_sec);
+      ("adaptive_timeout_sec", `Float budget.adaptive_timeout_sec);
+      ("keeper_turn_timeout_sec", `Float budget.keeper_turn_timeout_sec);
+      ("remaining_turn_budget_sec", `Float budget.remaining_turn_budget_sec);
+      ("estimated_input_tokens", `Int budget.estimated_input_tokens);
+      ("max_turns", `Int budget.max_turns);
+      ("source", `String budget.source);
+    ]
+
+let resolve_bounded_oas_timeout_budget_with_turn_budget
+    ~(estimated_input_tokens : int) ~(max_turns : int)
+    ~(remaining_turn_budget_s : float) : oas_timeout_budget_resolution option =
   let usable_budget = remaining_turn_budget_s -. oas_timeout_guard_sec in
   if usable_budget < min_oas_timeout_budget_sec
   then None
   else
-    let adaptive_timeout =
-      Env_config_keeper.KeeperKeepalive.oas_timeout_for_context_with_turn_budget
-        ~max_context ~max_turns
+    let runtime = Keeper_runtime_resolved.current () in
+    let adaptive_timeout_sec =
+      Keeper_runtime_resolved
+      .oas_timeout_for_estimated_input_tokens_with_turn_budget
+        ~estimated_input_tokens ~max_turns
+    in
+    let effective_timeout_sec =
+      Float.min adaptive_timeout_sec usable_budget
+    in
+    let source =
+      match runtime.oas_timeout_override_sec.value with
+      | Some _ when effective_timeout_sec < adaptive_timeout_sec ->
+          "override_capped_by_turn_budget"
+      | Some _ -> "override"
+      | None when effective_timeout_sec < adaptive_timeout_sec ->
+          "adaptive_estimated_input_tokens_capped_by_turn_budget"
+      | None -> "adaptive_estimated_input_tokens"
     in
     Some
-      (Float.min adaptive_timeout usable_budget)
+      {
+        effective_timeout_sec;
+        adaptive_timeout_sec;
+        keeper_turn_timeout_sec = runtime.turn_timeout_sec.value;
+        remaining_turn_budget_sec = usable_budget;
+        estimated_input_tokens = max 0 estimated_input_tokens;
+        max_turns;
+        source;
+      }
 
-let bounded_oas_timeout_for_turn_budget ~(max_context : int)
+let bounded_oas_timeout_for_turn_budget_with_turn_budget
+    ~(estimated_input_tokens : int) ~(max_turns : int)
     ~(remaining_turn_budget_s : float) : float option =
-  bounded_oas_timeout_for_turn_budget_with_turn_budget ~max_context
+  Option.map
+    (fun (budget : oas_timeout_budget_resolution) -> budget.effective_timeout_sec)
+    (resolve_bounded_oas_timeout_budget_with_turn_budget
+       ~estimated_input_tokens ~max_turns ~remaining_turn_budget_s)
+
+let bounded_oas_timeout_for_turn_budget ~(estimated_input_tokens : int)
+    ~(remaining_turn_budget_s : float) : float option =
+  bounded_oas_timeout_for_turn_budget_with_turn_budget ~estimated_input_tokens
     ~max_turns:(Keeper_runtime_resolved.reactive_max_turns_per_call ())
     ~remaining_turn_budget_s
 
@@ -705,6 +758,13 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
            No dynamic_context needed here. *)
         { system_prompt; dynamic_context = "" }
       in
+      let prompt_timeout_metrics =
+        Keeper_agent_run.build_prompt_metrics ~system_prompt
+          ~dynamic_context:"" ~user_message
+      in
+      let prompt_timeout_estimate_tokens =
+        max 1 prompt_timeout_metrics.estimated_total_tokens
+      in
       let turn_affordances =
         Keeper_unified_metrics.observed_affordances_of_observation ~meta observation
       in
@@ -873,6 +933,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
              Keeper_registry.Decision_guard_ok
        | _ -> ());
       let last_execution = ref initial_execution in
+      let last_timeout_budget : oas_timeout_budget_resolution option ref = ref None in
       let degraded_retry_info = ref None in
       let run_result, latency_ms =
         Fun.protect ~finally:(fun () ->
@@ -1013,9 +1074,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             in
             let attempt_result =
               match
-                bounded_oas_timeout_for_turn_budget_with_turn_budget
+                resolve_bounded_oas_timeout_budget_with_turn_budget
                   ~max_turns
-                  ~max_context:execution.max_context
+                  ~estimated_input_tokens:prompt_timeout_estimate_tokens
                   ~remaining_turn_budget_s:(remaining_turn_budget_s ())
               with
               | None ->
@@ -1028,12 +1089,13 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                                 "Turn wall-clock budget exhausted before retry (remaining=%.1fs)"
                                 (remaining_turn_budget_s ());
                           }))
-              | Some oas_timeout_s ->
+              | Some timeout_budget ->
+                  last_timeout_budget := Some timeout_budget;
                   Keeper_registry.set_turn_cascade_state
                     ~base_path:config.base_path meta.name
                     Keeper_registry.Cascade_trying;
                   do_run ~execution ~run_meta ~run_generation ~is_retry
-                    ~oas_timeout_s
+                    ~oas_timeout_s:timeout_budget.effective_timeout_sec
             in
             match attempt_result with
             | Ok result ->
@@ -1050,6 +1112,22 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   Keeper_registry.Cascade_done;
                 Ok result
             | Error err ->
+                let err =
+                  match err, !last_timeout_budget with
+                  | Oas.Error.Api (Timeout { message }), Some timeout_budget
+                    when EC.is_structural_oas_timeout_message message ->
+                      Oas_worker_named.sdk_error_of_masc_internal_error
+                        (Oas_worker_named.Oas_timeout_budget
+                           {
+                             budget_sec = timeout_budget.effective_timeout_sec;
+                             keeper_turn_timeout_sec =
+                               timeout_budget.keeper_turn_timeout_sec;
+                             estimated_input_tokens =
+                               timeout_budget.estimated_input_tokens;
+                             source = timeout_budget.source;
+                           })
+                  | _ -> err
+                in
                 let _ = drain_turn_event_bus () in
                 let committed_tools = committed_mutating_tools_snapshot () in
                 if committed_tools <> []
@@ -1373,8 +1451,18 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             (Trajectory.Failed (Oas.Error.to_string err));
           let e_str = Oas.Error.to_string err in
           let is_transient = EC.is_transient_network_error err in
-          (match err with
-           | Oas.Error.Api (Timeout { message }) ->
+          (match Oas_worker_named.classify_masc_internal_error err with
+           | Some (Oas_worker_named.Oas_timeout_budget _) ->
+               Prometheus.inc_counter
+                 Prometheus.metric_keeper_oas_timeout_classifications
+                 ~labels:[("classification", "structural_budget")] ()
+           | Some (Oas_worker_named.Turn_timeout _) ->
+               Prometheus.inc_counter
+                 Prometheus.metric_keeper_oas_timeout_classifications
+                 ~labels:[("classification", "turn_wall_clock")] ()
+           | _ -> (
+               match err with
+               | Oas.Error.Api (Timeout { message }) ->
                let classification =
                  if is_transient then "transient_network"
                  else if EC.is_structural_oas_timeout_message message then
@@ -1384,7 +1472,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                Prometheus.inc_counter
                  Prometheus.metric_keeper_oas_timeout_classifications
                  ~labels:[("classification", classification)] ()
-           | _ -> ());
+               | _ -> ()));
           let is_server_parse_rejection = EC.is_server_rejected_parse_error err in
           let is_auto_recoverable = EC.is_auto_recoverable_turn_error err in
           let is_ambiguous_partial = EC.is_ambiguous_side_effect_error err in
@@ -1628,6 +1716,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                ~message_count:lifecycle.message_count
                ~compaction:lifecycle.compaction
                ~handoff_json:lifecycle.handoff_json
+               ?timeout_budget_json:
+                 (Option.map oas_timeout_budget_resolution_to_yojson
+                    !last_timeout_budget)
                ()
           with
            | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -27,10 +27,10 @@
     wall-clock budget. Returns [None] when too little budget remains to
     schedule another call safely. *)
 val bounded_oas_timeout_for_turn_budget :
-  max_context:int -> remaining_turn_budget_s:float -> float option
+  estimated_input_tokens:int -> remaining_turn_budget_s:float -> float option
 
 val bounded_oas_timeout_for_turn_budget_with_turn_budget :
-  max_context:int ->
+  estimated_input_tokens:int ->
   max_turns:int ->
   remaining_turn_budget_s:float ->
   float option

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -135,23 +135,45 @@ let scope_message_feed_enabled (meta : keeper_meta) : bool =
 let message_feed_targets (meta : keeper_meta) =
   if meta.mention_targets <> [] then meta.mention_targets else [ meta.name ]
 
+let normalized_identity_token value =
+  let trimmed = String.lowercase_ascii (String.trim value) in
+  if trimmed = "" then None else Some trimmed
+
+let identity_tokens_of_value value =
+  let trimmed = String.trim value in
+  [
+    normalized_identity_token trimmed;
+    Option.bind
+      (Keeper_identity.canonical_keeper_name_from_agent_name trimmed)
+      normalized_identity_token;
+    Option.bind (Keeper_identity.canonical_keeper_name trimmed)
+      normalized_identity_token;
+  ]
+  |> List.filter_map (fun value -> value)
+  |> List.sort_uniq String.compare
+
+let self_identity_tokens (meta : keeper_meta) =
+  [ meta.name; meta.agent_name ]
+  |> List.map identity_tokens_of_value
+  |> List.flatten
+  |> List.sort_uniq String.compare
+
 let collect_message_scope ~(config : Coord.config) ~(meta : keeper_meta) :
     ((string * string) list * (string * string) list * (string * int) list) =
   let targets = message_feed_targets meta in
   let broad_scope = scope_message_feed_enabled meta in
-  let self_tokens =
-    [ meta.name; meta.agent_name ]
-    |> List.map (fun value -> String.lowercase_ascii (String.trim value))
-  in
+  let self_tokens = self_identity_tokens meta in
   let batch_limit = Keeper_config.keeper_batch_limit () in
   let rec consume_room_messages remaining last_processed mentions scope_messages =
     function
     | [] -> (`Done, remaining, last_processed, List.rev mentions, List.rev scope_messages)
     | (msg : Types.message) :: rest ->
-        let author =
-          String.lowercase_ascii (String.trim msg.from_agent)
-        in
-        if author = "" || List.mem author self_tokens then
+        let author = String.trim msg.from_agent in
+        if author = ""
+           || List.exists
+                (fun author_token -> List.mem author_token self_tokens)
+                (identity_tokens_of_value author)
+        then
           consume_room_messages remaining msg.seq mentions scope_messages rest
         else if exact_direct_mention_present ~targets msg.content then
           if remaining <= 0 then
@@ -326,12 +348,12 @@ let board_signal_match
     ~continuity_summary:(_ : string)
     ~(meta : keeper_meta)
     ~(signal : Board_dispatch.keeper_board_signal) : board_signal_match =
-  let author = String.lowercase_ascii (String.trim signal.author) in
-  let self_tokens =
-    [ meta.name; meta.agent_name ]
-    |> List.map (fun value -> String.lowercase_ascii (String.trim value))
-  in
-  if List.mem author self_tokens then
+  let self_tokens = self_identity_tokens meta in
+  if
+    List.exists
+      (fun author_token -> List.mem author_token self_tokens)
+      (identity_tokens_of_value signal.author)
+  then
     { explicit_mention = false; matched_targets = []; score = 0 }
   else
     let targets =
@@ -445,7 +467,8 @@ let read_continuity_summary ~(config : Coord.config) ~(meta : keeper_meta)
 let bootstrap_window_sec = Env_config.InternalTimers.bootstrap_window_sec
 
 let is_self_author ~self_tokens (author : string) : bool =
-  List.mem (String.lowercase_ascii (String.trim author)) self_tokens
+  identity_tokens_of_value author
+  |> List.exists (fun author_token -> List.mem author_token self_tokens)
 
 (** Check whether this keeper has commented on a post, and whether new
     external comments arrived after the keeper's latest comment.
@@ -501,10 +524,7 @@ let board_signal_wake_reason
   else if scope_message_feed_enabled meta then
     Some "board_activity"
   else
-    let self_tokens =
-      [ meta.name; meta.agent_name ]
-      |> List.map (fun value -> String.lowercase_ascii (String.trim value))
-    in
+    let self_tokens = self_identity_tokens meta in
     match signal.kind with
     | Board_dispatch.Board_comment_added ->
         (match check_self_comment_status ~self_tokens ~post_id:signal.post_id with
@@ -535,10 +555,7 @@ let collect_board_events ~(base_path : string) ~(continuity_summary : string)
         (Time_compat.now () -. bootstrap_window_sec, None)
     in
     let posts = list_board_posts_after_cursor base_cursor in
-    let self_tokens =
-      [ meta.name; meta.agent_name ]
-      |> List.map (fun value -> String.lowercase_ascii (String.trim value))
-    in
+    let self_tokens = self_identity_tokens meta in
     let recent =
       List.filter
         (fun (p : Board.post) ->

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -157,6 +157,40 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     | None -> auth_token
   in
 
+  let resolve_owner_keeper_identity owner_name =
+    let candidates =
+      [
+        Keeper_types.canonical_keeper_name owner_name;
+        Keeper_types.canonical_keeper_name_from_agent_name owner_name;
+      ]
+      |> List.filter_map (function
+           | Some value when String.trim value <> "" -> Some (String.trim value)
+           | _ -> None)
+      |> List.sort_uniq String.compare
+    in
+    let rec loop = function
+      | [] -> None
+      | candidate :: rest -> (
+          match Keeper_types.read_meta_resolved config candidate with
+          | Ok (Some (resolved_name, meta)) ->
+              Some
+                ( resolved_name,
+                  Option.map Keeper_id.Uid.to_string meta.Keeper_types.keeper_id )
+          | Ok None -> loop rest
+          | Error _ -> loop rest)
+    in
+    loop candidates
+  in
+
+  let owner_keeper_identity =
+    match token with
+    | None -> None
+    | Some raw -> (
+        match Auth.resolve_agent_from_token config.base_path ~token:raw with
+        | Ok owner_name -> resolve_owner_keeper_identity owner_name
+        | Error _ -> None)
+  in
+
   let mode_gate_error =
     if not (Tool_catalog.allow_direct_call name) then
       Some (direct_call_block_message name)
@@ -398,7 +432,12 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
       if is_joined then
         agent_name
       else begin
-        let join_result = Coord.join config ~agent_name ~capabilities:[] () in
+        let join_result =
+          Coord.join config ~agent_name ~capabilities:[]
+            ~keeper_name:(Option.map fst owner_keeper_identity)
+            ~keeper_id:(Option.bind owner_keeper_identity snd)
+            ()
+        in
         let nickname = extract_nickname_from_join_result ~fallback:agent_name join_result in
         Log.Mcp.info "Auto-joined for %s: %s -> %s" name agent_name nickname;
         (* Persist nickname so subsequent calls can use it. *)
@@ -410,6 +449,39 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     end else
       agent_name
   in
+
+  (match owner_keeper_identity with
+   | Some (keeper_name, keeper_id) when agent_name <> "unknown" && !room_init_cached ->
+       (try
+          Coord_task.update_local_agent_state config ~agent_name (fun agent ->
+              let meta =
+                match agent.meta with
+                | Some existing ->
+                    {
+                      existing with
+                      keeper_name = Some keeper_name;
+                      keeper_id;
+                    }
+                | None ->
+                    {
+                      session_id = "";
+                      agent_type = agent.agent_type;
+                      pid = None;
+                      hostname = None;
+                      tty = None;
+                      worktree = None;
+                      parent_task = None;
+                      keeper_name = Some keeper_name;
+                      keeper_id;
+                    }
+              in
+              { agent with meta = Some meta })
+        with
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
+        | exn ->
+            Log.Mcp.warn "keeper owner stamp skipped for %s: %s"
+              agent_name (Printexc.to_string exn))
+   | Some _ | None -> ());
 
   (* Auto-register session for non-read-only tools *)
   if agent_name <> "unknown" && not is_read_only then begin

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -34,6 +34,7 @@ type cascade_fallback_event = {
 
 type cascade_observation = {
   cascade_name : string;
+  strategy : string option;
   configured_labels : string list;
   candidate_models : string list;
   primary_model : string option;

--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -40,6 +40,7 @@ let worker_max_tool_calls_per_turn = 12
 
 type cascade_observation = {
   cascade_name : string;
+  strategy : string option;
   configured_labels : string list;
   candidate_models : string list;
   primary_model : string option;
@@ -221,7 +222,7 @@ let normalized_selected_model ~(selected_model_raw : string option)
 (* Observation building                                              *)
 (* ================================================================ *)
 
-let cascade_observation_of_candidates ~cascade_name ~configured_labels
+let cascade_observation_of_candidates ~cascade_name ?strategy ~configured_labels
     ~(candidate_cfgs : Llm_provider.Provider_config.t list)
     ~(selected_model_raw : string option)
     ?(attempts = [])
@@ -246,6 +247,7 @@ let cascade_observation_of_candidates ~cascade_name ~configured_labels
   in
   {
     cascade_name;
+    strategy;
     configured_labels;
     candidate_models;
     primary_model;
@@ -386,10 +388,10 @@ let cascade_metrics_for_candidates
   in
   (capture, metrics)
 
-let cascade_observation_with_metrics ~cascade_name ~configured_labels
+let cascade_observation_with_metrics ~cascade_name ?strategy ~configured_labels
     ~(candidate_cfgs : Llm_provider.Provider_config.t list)
-    ~(selected_model_raw : string option) ~(capture : cascade_metrics_capture) =
-  cascade_observation_of_candidates ~cascade_name ~configured_labels
+    ~(selected_model_raw : string option) ~(capture : cascade_metrics_capture) () =
+  cascade_observation_of_candidates ~cascade_name ?strategy ~configured_labels
     ~candidate_cfgs ~selected_model_raw
     ~attempts:(List.rev capture.attempts_rev)
     ~fallback_events:(List.rev capture.fallback_events_rev)
@@ -405,6 +407,7 @@ let cascade_observation_to_json (obs : cascade_observation) : Yojson.Safe.t =
   `Assoc
     [
       ("cascade_name", `String obs.cascade_name);
+      ("strategy", Json_util.string_opt_to_json obs.strategy);
       ( "configured_labels",
         `List (List.map (fun label -> `String label) obs.configured_labels) );
       ( "candidate_models",

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -157,6 +157,12 @@ type masc_internal_error =
   | Turn_timeout of {
       elapsed_sec : float;
     }
+  | Oas_timeout_budget of {
+      budget_sec : float;
+      keeper_turn_timeout_sec : float;
+      estimated_input_tokens : int;
+      source : string;
+    }
   | Ambiguous_post_commit of {
       is_timeout : bool;
       tools : string list;
@@ -224,6 +230,21 @@ let masc_internal_error_to_json = function
       [
         ("kind", `String "turn_timeout");
         ("elapsed_sec", `Float elapsed_sec);
+      ]
+  | Oas_timeout_budget
+      {
+        budget_sec;
+        keeper_turn_timeout_sec;
+        estimated_input_tokens;
+        source;
+      } ->
+    `Assoc
+      [
+        ("kind", `String "oas_timeout_budget");
+        ("budget_sec", `Float budget_sec);
+        ("keeper_turn_timeout_sec", `Float keeper_turn_timeout_sec);
+        ("estimated_input_tokens", `Int estimated_input_tokens);
+        ("source", `String source);
       ]
   | Ambiguous_post_commit { is_timeout; tools; original_error } ->
     `Assoc
@@ -366,6 +387,29 @@ let classify_masc_internal_error (err : Oas.Error.sdk_error) :
                    match List.assoc_opt "elapsed_sec" fields with
                    | Some (`Float v) ->
                      Some (Turn_timeout { elapsed_sec = v })
+                   | _ -> None)
+               | _ -> None)
+           | Some (`String "oas_timeout_budget") -> (
+               match json with
+               | `Assoc fields -> (
+                   match
+                     List.assoc_opt "budget_sec" fields,
+                     List.assoc_opt "keeper_turn_timeout_sec" fields,
+                     List.assoc_opt "estimated_input_tokens" fields,
+                     List.assoc_opt "source" fields
+                   with
+                   | Some (`Float budget_sec),
+                     Some (`Float keeper_turn_timeout_sec),
+                     Some (`Int estimated_input_tokens),
+                     Some (`String source) ->
+                       Some
+                         (Oas_timeout_budget
+                            {
+                              budget_sec;
+                              keeper_turn_timeout_sec;
+                              estimated_input_tokens;
+                              source;
+                            })
                    | _ -> None)
                | _ -> None)
            | Some (`String "ambiguous_post_commit") -> (
@@ -869,6 +913,7 @@ let run_named
       candidate_cfgs
   in
   let capture, _metrics = Oas_worker_cascade.cascade_metrics_for_candidates ~candidate_cfgs () in
+  let cascade_strategy_name_ref = ref None in
   let name = Printf.sprintf "oas-%s" cascade_name in
   match candidate_cfgs with
   | [] ->
@@ -1057,8 +1102,9 @@ let run_named
         | None -> Keeper_types.No_providers_available
       in
       let observation =
-        Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name ~configured_labels
-          ~candidate_cfgs ~selected_model_raw:None ~capture
+        Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name
+          ?strategy:!cascade_strategy_name_ref ~configured_labels
+          ~candidate_cfgs ~selected_model_raw:None ~capture ()
       in
       Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Failure ~observation:(Some observation);
       let terminal_error =
@@ -1112,8 +1158,10 @@ let run_named
         Cascade_health_tracker.(record_success global ~provider_key:provider_cfg.model_id);
         (* FSM: Call_ok → Accept *)
         let observation =
-          Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name ~configured_labels
-            ~candidate_cfgs ~selected_model_raw:(Some result.response.model) ~capture
+          Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name
+            ?strategy:!cascade_strategy_name_ref ~configured_labels
+            ~candidate_cfgs ~selected_model_raw:(Some result.response.model)
+            ~capture ()
         in
         let result = { result with cascade_observation = Some observation } in
         Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Success ~observation:(Some observation);
@@ -1136,8 +1184,10 @@ let run_named
         (match Cascade_fsm.decide ~accept_on_exhaustion:false ~is_last outcome with
          | Cascade_fsm.Accept_on_exhaustion { response; _ } ->
            let observation =
-             Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name ~configured_labels
-               ~candidate_cfgs ~selected_model_raw:(Some response.model) ~capture
+             Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name
+               ?strategy:!cascade_strategy_name_ref ~configured_labels
+               ~candidate_cfgs ~selected_model_raw:(Some response.model)
+               ~capture ()
            in
            let result = { result with cascade_observation = Some observation } in
            Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Success ~observation:(Some observation);
@@ -1153,8 +1203,10 @@ let run_named
            try_cascade ?resume_checkpoint:next_resume rest new_err
          | Cascade_fsm.Exhausted _ ->
            let observation =
-             Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name ~configured_labels
-               ~candidate_cfgs ~selected_model_raw:(Some result.response.model) ~capture
+             Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name
+               ?strategy:!cascade_strategy_name_ref ~configured_labels
+               ~candidate_cfgs ~selected_model_raw:(Some result.response.model)
+               ~capture ()
            in
            Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Rejected ~observation:(Some observation);
            Log.Misc.error "cascade %s exhausted: all tiers rejected by accept predicate (last model=%s, reason=%s)"
@@ -1171,8 +1223,9 @@ let run_named
            (* Should be unreachable with accept_on_exhaustion:false, but handle gracefully *)
            Log.Misc.warn "cascade %s: unexpected Accept in Accept_rejected branch (model=%s)" cascade_name resp.model;
            let observation =
-             Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name ~configured_labels
-               ~candidate_cfgs ~selected_model_raw:(Some resp.model) ~capture
+             Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name
+               ?strategy:!cascade_strategy_name_ref ~configured_labels
+               ~candidate_cfgs ~selected_model_raw:(Some resp.model) ~capture ()
            in
            let result = { result with cascade_observation = Some observation } in
            Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Success ~observation:(Some observation);
@@ -1209,8 +1262,9 @@ let run_named
               try_cascade ?resume_checkpoint:next_resume rest new_err
             | Cascade_fsm.Exhausted _ ->
               let observation =
-                Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name ~configured_labels
-                  ~candidate_cfgs ~selected_model_raw:None ~capture
+                Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name
+                  ?strategy:!cascade_strategy_name_ref ~configured_labels
+                  ~candidate_cfgs ~selected_model_raw:None ~capture ()
               in
               Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Failure ~observation:(Some observation);
               Log.Misc.error "cascade %s exhausted: all tiers failed (last model=%s, error=%s)"
@@ -1220,8 +1274,9 @@ let run_named
          | None ->
            (* Non-API error (agent, config, etc.) — not cascadeable *)
            let observation =
-             Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name ~configured_labels
-               ~candidate_cfgs ~selected_model_raw:None ~capture
+             Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name
+               ?strategy:!cascade_strategy_name_ref ~configured_labels
+               ~candidate_cfgs ~selected_model_raw:None ~capture ()
            in
            Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Failure ~observation:(Some observation);
            Log.Misc.error "cascade %s: non-cascadable error from %s: %s"
@@ -1242,6 +1297,8 @@ let run_named
         Log.Misc.error "cascade %s: %s" cascade_name detail;
         Error (cascade_catalog_error_to_sdk_error detail)
   in
+  let strategy_name = Cascade_strategy.kind_to_string strategy.kind in
+  let () = cascade_strategy_name_ref := Some strategy_name in
   let* ollama_max =
     match
       Cascade_catalog_runtime.resolve_ollama_max_concurrent ~name:cascade_name ()
@@ -1340,7 +1397,8 @@ let run_named
   let cascade_exhausted_after_filter ~cycle =
     let observation =
       Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name
-        ~configured_labels ~candidate_cfgs ~selected_model_raw:None ~capture
+        ?strategy:!cascade_strategy_name_ref ~configured_labels
+        ~candidate_cfgs ~selected_model_raw:None ~capture ()
     in
     Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Failure
       ~observation:(Some observation);
@@ -1352,7 +1410,7 @@ let run_named
     Cascade_strategy_trace.record {
       ts = Unix.gettimeofday ();
       cascade_name;
-      strategy = Cascade_strategy.kind_to_string strategy.kind;
+      strategy = strategy_name;
       cycle;
       candidates_in = List.length candidate_cfgs;
       candidates_out;
@@ -1376,7 +1434,7 @@ let run_named
         ~kind:Filtered_empty;
       Log.Misc.info
         "cascade %s: cycle %d (%s) filtered all candidates, retrying"
-        cascade_name n (Cascade_strategy.kind_to_string strategy.kind);
+        cascade_name n strategy_name;
       do_backoff (n + 1);
       cycle_loop (n + 1)
     | _ ->
@@ -1391,7 +1449,7 @@ let run_named
        | Error _ ->
          Log.Misc.info
            "cascade %s: cycle %d exhausted, backoff before retry (strategy=%s)"
-           cascade_name n (Cascade_strategy.kind_to_string strategy.kind);
+           cascade_name n strategy_name;
          do_backoff (n + 1);
          cycle_loop (n + 1))
   in

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -725,10 +725,13 @@ let dashboard_task_json config (task : Types.task) =
 
 let dashboard_agent_json (agent : Types.agent) =
   let profile = Dashboard_execution_helpers.get_agent_profile agent.name in
+  let meta = agent.meta in
   `Assoc
     [
       ("name", `String agent.name);
       ("agent_type", `String agent.agent_type);
+      ("keeper_name", Json_util.string_opt_to_json (Option.bind meta (fun m -> m.keeper_name)));
+      ("keeper_id", Json_util.string_opt_to_json (Option.bind meta (fun m -> m.keeper_id)));
       ("status", `String (Types.string_of_agent_status agent.status));
       ("current_task", Json_util.string_opt_to_json agent.current_task);
       ("joined_at", `String agent.joined_at);

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -96,6 +96,8 @@ type agent_meta = {
   tty: string option; [@default None]     (* terminal identifier *)
   worktree: string option; [@default None] (* git worktree path *)
   parent_task: string option; [@default None] (* task that spawned this agent *)
+  keeper_name: string option; [@default None] (* stable keeper owner, when this runtime is keeper-owned *)
+  keeper_id: string option; [@default None] (* stable keeper UUID, when available *)
 } [@@deriving yojson { strict = false }, show]
 
 (** Agent info *)

--- a/test/test_cascade_config_validity.ml
+++ b/test/test_cascade_config_validity.ml
@@ -215,7 +215,7 @@ let test_priority_tier_label_tiers_normalize_to_model_ids () =
     [ [ "claude-haiku-4-5-20251001" ]; [ "gemini-3-flash-preview" ] ]
     strategy.tiers
 
-let test_priority_tier_invalid_tiers_fall_back_to_failover () =
+let test_priority_tier_invalid_tiers_fall_back_to_default_strategy () =
   with_temp_cascade_json @@ fun tmp ->
   let oc = open_out tmp in
   Fun.protect
@@ -235,10 +235,54 @@ let test_priority_tier_invalid_tiers_fall_back_to_failover () =
     Masc_mcp.Cascade_config.resolve_strategy
       ~config_path:tmp ~name:"regression" ()
   in
-  check string "invalid tiers demote to failover"
-    "failover"
+  check string "invalid tiers demote to default strategy"
+    "round_robin"
     (Masc_mcp.Cascade_strategy.kind_to_string strategy.kind);
-  check (list (list string)) "failover carries no tiers" [] strategy.tiers
+  check (list (list string)) "default strategy carries no tiers" [] strategy.tiers
+
+let test_keeper_assignable_profile_defaults_to_round_robin () =
+  with_temp_cascade_json @@ fun tmp ->
+  let oc = open_out tmp in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      output_string oc
+        {|{
+  "regression_models": [
+    "claude_code:claude-haiku-4-5-20251001",
+    "gemini_cli:gemini-3-flash-preview"
+  ],
+  "regression_keeper_assignable": true
+}|});
+  let strategy =
+    Masc_mcp.Cascade_config.resolve_strategy
+      ~config_path:tmp ~name:"regression" ()
+  in
+  check string "keeper assignable defaults to round_robin"
+    "round_robin"
+    (Masc_mcp.Cascade_strategy.kind_to_string strategy.kind)
+
+let test_non_keeper_assignable_profile_defaults_to_failover () =
+  with_temp_cascade_json @@ fun tmp ->
+  let oc = open_out tmp in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      output_string oc
+        {|{
+  "regression_models": [
+    "claude_code:claude-haiku-4-5-20251001",
+    "gemini_cli:gemini-3-flash-preview"
+  ],
+  "regression_keeper_assignable": false
+}|});
+  let strategy =
+    Masc_mcp.Cascade_config.resolve_strategy
+      ~config_path:tmp ~name:"regression" ()
+  in
+  check string "non-keeper profile stays failover"
+    "failover"
+    (Masc_mcp.Cascade_strategy.kind_to_string strategy.kind)
 
 let () =
   let path = cascade_path () in
@@ -266,8 +310,16 @@ let () =
             `Quick
             test_priority_tier_label_tiers_normalize_to_model_ids;
           test_case
-            "priority_tier invalid tiers fall back to failover"
+            "priority_tier invalid tiers fall back to default strategy"
             `Quick
-            test_priority_tier_invalid_tiers_fall_back_to_failover;
+            test_priority_tier_invalid_tiers_fall_back_to_default_strategy;
+          test_case
+            "keeper-assignable profile defaults to round_robin"
+            `Quick
+            test_keeper_assignable_profile_defaults_to_round_robin;
+          test_case
+            "non-keeper-assignable profile defaults to failover"
+            `Quick
+            test_non_keeper_assignable_profile_defaults_to_failover;
         ] );
     ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -366,6 +366,65 @@ let test_collect_board_events_keeps_external_replies_after_self_comment () =
             (Option.value ~default:"" event.latest_external_author)
       | _ -> fail "expected one follow-up board event")
 
+let test_collect_board_events_treats_generated_alias_as_self_comment () =
+  let base_dir = temp_dir () in
+  let meta =
+    {
+      (make_meta "ramarama") with
+      agent_name = "keeper-ramarama-agent";
+    }
+  in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      Unix.putenv "MASC_BASE_PATH" base_dir;
+      Masc_mcp.Board.reset_global_for_test ();
+      Masc_mcp.Board_dispatch.reset_for_test ();
+      Masc_mcp.Board_dispatch.init_jsonl ();
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+      let post_id =
+        match
+          Masc_mcp.Board_dispatch.create_post ~author:"alice"
+            ~title:"General update" ~content:"No direct mention here"
+            ~post_kind:Masc_mcp.Board.Human_post ()
+        with
+        | Ok post -> Masc_mcp.Board.Post_id.to_string post.id
+        | Error e -> fail ("create_post failed: " ^ Masc_mcp.Board.show_board_error e)
+      in
+      (match
+         Masc_mcp.Board_dispatch.add_comment ~post_id
+           ~author:"ramarama-fierce-panda"
+           ~content:"I am following this thread."
+           ()
+       with
+      | Ok _ -> ()
+      | Error e -> fail ("add_comment failed: " ^ Masc_mcp.Board.show_board_error e));
+      Unix.sleepf 0.02;
+      (match
+         Masc_mcp.Board_dispatch.add_comment ~post_id ~author:"bob"
+           ~content:"Thanks, there is a new question for you."
+           ()
+       with
+      | Ok _ -> ()
+      | Error e -> fail ("add_comment failed: " ^ Masc_mcp.Board.show_board_error e));
+      let events, new_count, mention_count =
+        WO.collect_board_events ~base_path:base_dir
+          ~continuity_summary:"goal ramarama"
+          ~meta
+      in
+      check int "new count still tracks recent post" 1 new_count;
+      check int "mention count stays zero" 0 mention_count;
+      match events with
+      | [ event ] ->
+          check bool "generated alias counts as self comment" true event.self_commented;
+          check int "external reply count" 1 event.new_external_since;
+          check string "latest external author" "bob"
+            (Option.value ~default:"" event.latest_external_author)
+      | _ -> fail "expected one follow-up board event")
+
 let test_observe_ignores_scope_messages_without_room_signal_opt_in () =
   let base_dir = temp_dir () in
   Fun.protect
@@ -1506,6 +1565,7 @@ let test_metrics_surface_model_prefers_successful_cascade_label () =
       ~cascade_observation:
         {
           Masc_mcp.Oas_worker.cascade_name = Masc_mcp.Keeper_config.default_cascade_name;
+          strategy = Some "round_robin";
           configured_labels = [ "llama:auto" ];
           candidate_models =
             [ "llama:qwen3.5-35b-a3b-ud-q8-xl"; selected_label ];
@@ -1862,6 +1922,7 @@ let test_append_metrics_snapshot_includes_cascade_observation () =
             Some
               {
                 Masc_mcp.Oas_worker.cascade_name = Masc_mcp.Keeper_config.default_cascade_name;
+                strategy = Some "round_robin";
                 configured_labels = [ "llama:auto" ];
                 candidate_models =
                   [
@@ -2618,6 +2679,23 @@ let test_degraded_retry_after_recoverable_error_includes_turn_timeout () =
   in
   expect_degraded_retry "turn timeout degraded retry"
     KC.local_recovery_cascade_name "turn_timeout" degraded_retry
+
+let test_degraded_retry_after_recoverable_error_includes_oas_timeout_budget () =
+  let degraded_retry =
+    EC.degraded_retry_after_recoverable_error
+      ~effective_cascade:"underdog"
+      ~tool_requirement:"optional"
+      (Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
+         (Masc_mcp.Oas_worker_named.Oas_timeout_budget
+            {
+              budget_sec = 273.0;
+              keeper_turn_timeout_sec = 1200.0;
+              estimated_input_tokens = 2_000;
+              source = "adaptive_estimated_input_tokens";
+            }))
+  in
+  expect_degraded_retry "oas timeout budget degraded retry"
+    KC.local_recovery_cascade_name "oas_timeout_budget" degraded_retry
 
 let test_degraded_retry_after_recoverable_error_blocks_required_tools () =
   let degraded_retry =
@@ -3381,22 +3459,36 @@ let test_cascade_exhausted_error_includes_resumable_cli_session_error () =
     (EC.is_cascade_exhausted_error err)
 
 let test_bounded_oas_timeout_uses_adaptive_when_budget_is_large () =
+  let estimated_input_tokens = 2_000 in
   let expected =
-    Env_config.KeeperKeepalive.oas_timeout_for_context ~max_context:262_144
+    Env_config.KeeperKeepalive.oas_timeout_for_estimated_input_tokens
+      ~estimated_input_tokens
   in
   match
     UT.bounded_oas_timeout_for_turn_budget
-      ~max_context:262_144 ~remaining_turn_budget_s:1200.0
+      ~estimated_input_tokens ~remaining_turn_budget_s:1200.0
   with
   | Some timeout_s ->
       check (float 0.01) "adaptive timeout kept under full budget"
         expected timeout_s
   | None -> fail "expected bounded timeout"
 
+let test_bounded_oas_timeout_scales_with_estimated_input_tokens () =
+  match
+    ( UT.bounded_oas_timeout_for_turn_budget
+        ~estimated_input_tokens:2_000 ~remaining_turn_budget_s:1200.0,
+      UT.bounded_oas_timeout_for_turn_budget
+        ~estimated_input_tokens:262_144 ~remaining_turn_budget_s:1200.0 )
+  with
+  | Some low_prompt_timeout, Some high_prompt_timeout ->
+      check bool "smaller prompt gets smaller budget" true
+        (low_prompt_timeout < high_prompt_timeout)
+  | _ -> fail "expected bounded timeouts for both prompt sizes"
+
 let test_bounded_oas_timeout_caps_to_remaining_turn_budget () =
   match
     UT.bounded_oas_timeout_for_turn_budget
-      ~max_context:262_144 ~remaining_turn_budget_s:235.7
+      ~estimated_input_tokens:2_000 ~remaining_turn_budget_s:235.7
   with
   | Some timeout_s ->
       check (float 0.01) "remaining budget cap applies" 234.7 timeout_s
@@ -3406,13 +3498,15 @@ let test_bounded_oas_timeout_uses_channel_turn_budget_override () =
   let max_turns =
     Env_config.KeeperKeepalive.oas_max_turns_per_call_scheduled_autonomous
   in
+  let estimated_input_tokens = 2_000 in
   let expected =
-    Env_config.KeeperKeepalive.oas_timeout_for_context_with_turn_budget
-      ~max_context:262_144 ~max_turns
+    Env_config.KeeperKeepalive
+    .oas_timeout_for_estimated_input_tokens_with_turn_budget
+      ~estimated_input_tokens ~max_turns
   in
   match
     UT.bounded_oas_timeout_for_turn_budget_with_turn_budget
-      ~max_turns ~max_context:262_144 ~remaining_turn_budget_s:1200.0
+      ~max_turns ~estimated_input_tokens ~remaining_turn_budget_s:1200.0
   with
   | Some timeout_s ->
       check (float 0.01) "scheduled autonomous turn budget lowers adaptive timeout"
@@ -3422,7 +3516,7 @@ let test_bounded_oas_timeout_uses_channel_turn_budget_override () =
 let test_bounded_oas_timeout_refuses_too_little_budget () =
   check (option (float 0.01)) "insufficient budget returns none" None
     (UT.bounded_oas_timeout_for_turn_budget
-       ~max_context:262_144 ~remaining_turn_budget_s:20.0)
+       ~estimated_input_tokens:2_000 ~remaining_turn_budget_s:20.0)
 
 let test_pure_local_labels_detection () =
   check bool "ollama-only cascade is pure local" true
@@ -4436,6 +4530,8 @@ let () =
             test_collect_board_events_keeps_non_mentions_for_room_signal_keepers;
           test_case "keeps external replies after self comment" `Quick
             test_collect_board_events_keeps_external_replies_after_self_comment;
+          test_case "treats generated alias as self comment" `Quick
+            test_collect_board_events_treats_generated_alias_as_self_comment;
           test_case "default keepers ignore scope messages" `Quick
             test_observe_ignores_scope_messages_without_room_signal_opt_in;
           test_case "room-signal keepers collect scope messages" `Quick
@@ -4810,6 +4906,8 @@ let () =
             test_cascade_exhausted_error_includes_resumable_cli_session_error;
           test_case "bounded OAS timeout keeps adaptive timeout under full budget" `Quick
             test_bounded_oas_timeout_uses_adaptive_when_budget_is_large;
+          test_case "bounded OAS timeout scales with estimated input tokens" `Quick
+            test_bounded_oas_timeout_scales_with_estimated_input_tokens;
           test_case "bounded OAS timeout caps to remaining turn budget" `Quick
             test_bounded_oas_timeout_caps_to_remaining_turn_budget;
           test_case "bounded OAS timeout respects channel turn budget override" `Quick
@@ -4873,6 +4971,8 @@ let () =
             test_degraded_retry_after_recoverable_error_includes_admission_queue_timeout;
           test_case "turn timeout is degraded-retry eligible" `Quick
             test_degraded_retry_after_recoverable_error_includes_turn_timeout;
+          test_case "OAS timeout budget is degraded-retry eligible" `Quick
+            test_degraded_retry_after_recoverable_error_includes_oas_timeout_budget;
           test_case "required tool turns block degraded retry" `Quick
             test_degraded_retry_after_recoverable_error_blocks_required_tools;
           test_case "local_only stays terminal for degraded retry" `Quick

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -433,6 +433,7 @@ let test_cascade_observation_json_includes_fallback_fields () =
   let observation : Oas_worker.cascade_observation =
     {
       cascade_name = Masc_mcp.Keeper_config.default_cascade_name;
+      strategy = Some "round_robin";
       configured_labels = [ "glm:auto"; "llama:auto" ];
       candidate_models = [ "glm:glm-5.1"; "openai:qwen3.5-35b" ];
       primary_model = Some "glm:glm-5.1";
@@ -588,6 +589,7 @@ let test_cascade_audit_persists_observation () =
       let observation : Masc_mcp.Oas_worker_cascade.cascade_observation =
         {
           cascade_name = "audit-cascade";
+          strategy = Some "round_robin";
           configured_labels = [ "glm:auto"; "openai:auto" ];
           candidate_models = [ "glm:glm-5.1"; "openai:qwen3.5-35b" ];
           primary_model = Some "glm:glm-5.1";

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -69,27 +69,27 @@ let test_keepalive_jitter_range () =
 
 (* ── OAS adaptive timeout tests ───────────────────────── *)
 
-let adaptive = Cfg.KeeperKeepalive.oas_timeout_for_context
+let adaptive = Cfg.KeeperKeepalive.oas_timeout_for_estimated_input_tokens
 
 let test_oas_timeout_32k () =
-  let v = adaptive ~max_context:32_000 in
+  let v = adaptive ~estimated_input_tokens:32_000 in
   (* 120 + 32*1.5 + min(15,40)*30 = 120+48+450 = 618 *)
   check (float 1.0) "32K → 618s" 618.0 v
 
 let test_oas_timeout_128k () =
-  let v = adaptive ~max_context:128_000 in
+  let v = adaptive ~estimated_input_tokens:128_000 in
   (* 120 + 128*1.5 + 450 = 762 *)
   check (float 1.0) "128K → 762s" 762.0 v
 
 let test_oas_timeout_262k () =
-  let v = adaptive ~max_context:262_144 in
+  let v = adaptive ~estimated_input_tokens:262_144 in
   (* 120 + 262.144*1.5 + min(15,40)*30 = 120+393.216+450 = 963.216 *)
   check bool "262K → [960, 970]" true (v >= 960.0 && v <= 970.0)
 
 let test_oas_timeout_262k_scheduled_autonomous () =
   let v =
-    Cfg.KeeperKeepalive.oas_timeout_for_context_with_turn_budget
-      ~max_context:262_144
+    Cfg.KeeperKeepalive.oas_timeout_for_estimated_input_tokens_with_turn_budget
+      ~estimated_input_tokens:262_144
       ~max_turns:Cfg.KeeperKeepalive.oas_max_turns_per_call_scheduled_autonomous
   in
   (* #6810: default lowered 5→2 to keep semaphore hold under wait timeout.
@@ -98,20 +98,20 @@ let test_oas_timeout_262k_scheduled_autonomous () =
     (v >= 570.0 && v <= 580.0)
 
 let test_oas_timeout_zero () =
-  let v = adaptive ~max_context:0 in
+  let v = adaptive ~estimated_input_tokens:0 in
   (* 120 + 0 + min(15,40)*30 = 570 *)
   check (float 1.0) "0 context → base+turn budget 570s" 570.0 v
 
 let test_oas_timeout_monotonic () =
-  let v1 = adaptive ~max_context:32_000 in
-  let v2 = adaptive ~max_context:128_000 in
-  let v3 = adaptive ~max_context:262_144 in
+  let v1 = adaptive ~estimated_input_tokens:32_000 in
+  let v2 = adaptive ~estimated_input_tokens:128_000 in
+  let v3 = adaptive ~estimated_input_tokens:262_144 in
   check bool "32K < 128K" true (v1 < v2);
   check bool "128K < 262K" true (v2 < v3)
 
 let test_oas_timeout_cap () =
-  let v = adaptive ~max_context:1_000_000 in
-  check (float 0.1) "1M context → capped at turn timeout 1200" 1200.0 v
+  let v = adaptive ~estimated_input_tokens:1_000_000 in
+  check (float 0.1) "1M estimated input tokens → capped at turn timeout 1200" 1200.0 v
 
 let test_turn_timeout_default () =
   check (float 0.1) "default turn timeout 1200s" 1200.0


### PR DESCRIPTION
## Summary
- propagate `keeper_id` and canonical keeper identity through keeper execution and dashboard payloads
- collapse keeper and sub-op aliases into one principal in the roster and self-follow-up logic
- compute OAS timeout budgets from live estimated input size, and distinguish OAS budget timeout from keeper wall-clock timeout in telemetry
- default keeper-facing healthy cascades to `round_robin` and surface the resolved strategy in telemetry/dashboard

## Root Cause
Identity comparisons were still string-based in several paths, so generated sub-op aliases such as `ramarama-fierce-panda` were treated as separate actors from the owning keeper. Timeout budgeting also scaled from model max-context instead of the current prompt size, which inflated budgets on large-context models even when the live turn was small. Keeper-facing cascades were still effectively first-candidate sticky because the default strategy stayed on failover.

## Impact
The dashboard should stop showing the same keeper as multiple principals, board follow-up logic should stop creating self-vs-self loops, timeout errors should be classified more clearly, and healthy multi-candidate keeper cascades should rotate instead of pinning one model.

## Validation
- `dune build --root . --build-dir _build_codex_verify test/test_keeper_unified.exe`
- `./_build_codex_verify/default/test/test_keeper_unified.exe`
- `./_build_codex_verify/default/test/test_work_as_heartbeat.exe`
- `./_build_codex_verify/default/test/test_oas_worker.exe`
- `MASC_CASCADE_JSON_PATH=$PWD/config/cascade.json ./_build_codex_verify/default/test/test_cascade_config_validity.exe`
- `pnpm typecheck`
- `pnpm vitest run src/components/common/keeper-identity.test.ts src/components/agent-roster.test.ts src/components/keeper-detail-panels.test.ts --no-file-parallelism --maxWorkers=1`

## Notes
- the full dashboard test suite still has unrelated pre-existing failures in `src/components/common/time-ago.test.ts`