### PR TITLE
fix(agent_identity): tolerate non-object MCP payload (#9788)

### DIFF
--- a/lib/agent_identity.ml
+++ b/lib/agent_identity.ml
@@ -110,6 +110,9 @@ let generate_session_key () =
 (** Create identity from MCP request params *)
 let from_mcp_params params =
   let module U = Yojson.Safe.Util in
+  (* #9788: normalize null/non-object payloads to empty assoc so U.member
+     below cannot raise Type_error and crash tools/call dispatch. *)
+  let params = match params with `Assoc _ -> params | _ -> `Assoc [] in
   let get_opt key =
     match U.member key params with
     | `String s -> Some s

--- a/test/test_identity_edge_cases.ml
+++ b/test/test_identity_edge_cases.ml
@@ -83,6 +83,31 @@ let test_invalid_capabilities () =
   let identity = Agent_registry_eio.get_or_create_identity params in
   check int "ignores invalid" 0 (List.length identity.capabilities)
 
+(* #9788: tools/call payload arrives as `Null instead of an object.
+   Previously crashed inside Yojson.Safe.Util.member; must degrade
+   to anonymous identity. *)
+let test_null_payload () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Agent_registry_eio.reset_for_testing ();
+  let identity = Agent_registry_eio.get_or_create_identity `Null in
+  check bool "has agent_name" true (String.length identity.agent_name > 0);
+  check bool "starts with agent-" true
+    (String.length identity.agent_name >= 6
+     && String.sub identity.agent_name 0 6 = "agent-")
+
+(* Same defensive behavior for non-object scalars. *)
+let test_scalar_payload () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Agent_registry_eio.reset_for_testing ();
+  let identity_string = Agent_registry_eio.get_or_create_identity (`String "garbage") in
+  let identity_int = Agent_registry_eio.get_or_create_identity (`Int 42) in
+  let identity_list = Agent_registry_eio.get_or_create_identity (`List []) in
+  check bool "string payload tolerated" true (String.length identity_string.agent_name > 0);
+  check bool "int payload tolerated" true (String.length identity_int.agent_name > 0);
+  check bool "list payload tolerated" true (String.length identity_list.agent_name > 0)
+
 (* Rapid session creation *)
 let test_rapid_creation () =
   Eio_main.run @@ fun env ->
@@ -100,6 +125,8 @@ let () =
     "params", [
       test_case "empty" `Quick test_empty_params;
       test_case "null_values" `Quick test_null_values;
+      test_case "null_payload" `Quick test_null_payload;
+      test_case "scalar_payload" `Quick test_scalar_payload;
       test_case "long_name" `Quick test_long_agent_name;
       test_case "special_chars" `Quick test_special_chars;
     ];


### PR DESCRIPTION
## Summary

`tools/call` requests that omit `arguments` (or send `arguments: null`) reach `Agent_identity.from_mcp_params` as `\`Null`. The previous code called `Yojson.Safe.Util.member` directly on the payload, which raises `Type_error` for any non-object value and crashes the entire dispatch path before the dispatcher can return a helpful error.

This PR normalizes any non-object payload to an empty `\`Assoc` at the entry of `from_mcp_params`. Every subsequent member lookup then degrades to the existing "no parameters supplied" branch (anonymous identity with synthesized session key) instead of raising.

## Why this is the right scope

- **Single guard, full coverage**: a normalize at the entry of `from_mcp_params` covers both the `_session_key`/`_agent_name` lookups (line 114) and the later `_capabilities` lookup (line 145). A `get_opt`-only fix would leave `_capabilities` exposed.
- **Behavior-preserving for valid input**: when `params` is already `\`Assoc _`, the match arm returns it unchanged. Existing tests (19 in `test_agent_identity`, 11 in `test_agent_registry_eio`) pass without modification.
- **Crash → silent recovery, not silent acceptance**: this only converts a *server crash* into the same identity an empty object would produce. It does not bypass any policy or auth check.

## Test plan

- [x] `dune build --root=. lib/` — clean
- [x] `dune exec test/test_identity_edge_cases.exe` — 10/10 pass (including new `null_payload` and `scalar_payload` cases)
- [x] `dune exec test/test_agent_identity.exe` — 19/19 pass (no regression)
- [x] `dune exec test/test_agent_registry_eio.exe` — 11/11 pass (no regression)

Closes #9788