### PR TITLE
fix(auth): parse canonical "role" field in agent_credential

### DIFF
--- a/lib/types/types_auth.ml
+++ b/lib/types/types_auth.ml
@@ -243,9 +243,14 @@ type agent_credential = {
 } [@@deriving show]
 
 let agent_credential_to_yojson c =
+  (* Canonical role representation is ["role": "admin"|"worker"] (string).
+     Legacy ["admin": bool] is emitted alongside for backward compatibility
+     with older readers that only inspect the bool field. Both fields always
+     agree by construction. *)
   let base = [
     ("agent_name", `String c.agent_name);
     ("token", `String c.token);
+    ("role", `String (agent_role_to_string c.role));
     ("admin", `Bool (c.role = Admin));
     ("created_at", `String c.created_at);
   ] in
@@ -270,11 +275,30 @@ let agent_credential_of_yojson json =
     let token = json |> member "token" |> to_string in
     let created_at = json |> member "created_at" |> to_string in
     let expires_at = json |> member "expires_at" |> to_string_option in
+    (* Role resolution: canonical field is ["role"] (string),
+       legacy fallback is ["admin"] (bool).
+
+       Writer drift history — pre-#9767 keeper credential files on the live
+       fleet were stored as [{"role": "admin", ...}] while the canonical
+       [agent_credential_to_yojson] only emitted [{"admin": bool, ...}].
+       A parser that looked only at ["admin"] silently downgraded every
+       such credential to Worker, causing masc_board_delete and other
+       CanAdmin tools to return Forbidden for janitor / dashboard / qa-king
+       even though their credential files explicitly declared "role":"admin".
+
+       Both fields are read now. ["role"] wins when both are present.
+       Unknown role strings fall back to Worker (fail-closed, least
+       privilege). Missing both fields also defaults to Worker. *)
     let role =
-      match json |> member "admin" |> to_bool_option with
-      | Some true -> Admin
-      | Some false -> Worker
-      | None -> Worker
+      match json |> member "role" |> to_string_option with
+      | Some s ->
+          (match agent_role_of_string s with
+           | Ok r -> r
+           | Error _ -> Worker)
+      | None ->
+          (match json |> member "admin" |> to_bool_option with
+           | Some true -> Admin
+           | Some false | None -> Worker)
     in
     Ok { id; agent_id; agent_name; token; role; created_at; expires_at }
   with e -> Error (Printexc.to_string e)

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -859,6 +859,100 @@ let test_agent_credential_of_yojson_error () =
   | Error _ -> ()
   | Ok _ -> fail "expected Error"
 
+(* Regression: live fleet credential files stored role as a string field
+   (["role": "admin"|"worker"]) while the original parser only inspected
+   the legacy bool field (["admin"]). Missing lookup silently downgraded
+   admin credentials to Worker, producing Forbidden on CanAdmin tools
+   such as masc_board_delete for janitor / dashboard / qa-king. The
+   parser now reads the canonical string first, falling back to the
+   legacy bool. *)
+let test_agent_credential_of_yojson_role_string_admin () =
+  let json = `Assoc [
+    ("agent_name", `String "janitor");
+    ("token", `String "t");
+    ("role", `String "admin");
+    ("created_at", `String "2026-04-23T12:50:47Z");
+  ] in
+  match Types.agent_credential_of_yojson json with
+  | Ok cred ->
+    check bool "role:\"admin\" parses to Admin" true (cred.role = Types.Admin)
+  | Error e -> fail ("expected Ok, got: " ^ e)
+
+let test_agent_credential_of_yojson_role_string_worker () =
+  let json = `Assoc [
+    ("agent_name", `String "nick0cave");
+    ("token", `String "t");
+    ("role", `String "worker");
+    ("created_at", `String "2026-04-23T08:07:00Z");
+  ] in
+  match Types.agent_credential_of_yojson json with
+  | Ok cred ->
+    check bool "role:\"worker\" parses to Worker" true (cred.role = Types.Worker)
+  | Error e -> fail ("expected Ok, got: " ^ e)
+
+let test_agent_credential_of_yojson_role_string_wins_over_admin_bool () =
+  (* If a file has both fields, the canonical string wins. This covers the
+     transitional period where writers emit both. *)
+  let json = `Assoc [
+    ("agent_name", `String "mixed");
+    ("token", `String "t");
+    ("role", `String "admin");
+    ("admin", `Bool false);
+    ("created_at", `String "2026-04-23T00:00:00Z");
+  ] in
+  match Types.agent_credential_of_yojson json with
+  | Ok cred ->
+    check bool "role string wins" true (cred.role = Types.Admin)
+  | Error e -> fail ("expected Ok, got: " ^ e)
+
+let test_agent_credential_of_yojson_admin_bool_legacy () =
+  (* Older admin.json files use only the bool field; must still parse. *)
+  let json = `Assoc [
+    ("agent_name", `String "admin");
+    ("token", `String "t");
+    ("admin", `Bool true);
+    ("created_at", `String "2026-04-24T01:00:11Z");
+  ] in
+  match Types.agent_credential_of_yojson json with
+  | Ok cred ->
+    check bool "admin:true legacy parses to Admin" true (cred.role = Types.Admin)
+  | Error e -> fail ("expected Ok, got: " ^ e)
+
+let test_agent_credential_of_yojson_unknown_role_fails_closed () =
+  (* Fail-closed: unknown role strings downgrade to Worker, never Admin. *)
+  let json = `Assoc [
+    ("agent_name", `String "evil");
+    ("token", `String "t");
+    ("role", `String "root");
+    ("created_at", `String "2026-04-23T00:00:00Z");
+  ] in
+  match Types.agent_credential_of_yojson json with
+  | Ok cred ->
+    check bool "unknown role falls back to Worker" true (cred.role = Types.Worker)
+  | Error e -> fail ("expected Ok, got: " ^ e)
+
+let test_agent_credential_to_yojson_emits_role_and_admin () =
+  (* Writer emits both fields during the transition so downstream readers
+     in either vintage see a consistent role. *)
+  let cred : Types.agent_credential = {
+    id = None;
+    agent_id = None;
+    agent_name = "dual";
+    token = "t";
+    role = Types.Admin;
+    created_at = "2026-04-23T00:00:00Z";
+    expires_at = None;
+  } in
+  match Types.agent_credential_to_yojson cred with
+  | `Assoc fields ->
+    check bool "has role" true (List.mem_assoc "role" fields);
+    check bool "has admin" true (List.mem_assoc "admin" fields);
+    let role_val = List.assoc "role" fields in
+    let admin_val = List.assoc "admin" fields in
+    check bool "role=\"admin\"" true (role_val = `String "admin");
+    check bool "admin=true" true (admin_val = `Bool true)
+  | _ -> fail "expected Assoc"
+
 (* ============================================================
    auth_config Tests
    ============================================================ *)
@@ -1619,6 +1713,18 @@ let () =
       test_case "to_yojson with expiry" `Quick test_agent_credential_to_yojson_with_expiry;
       test_case "of_yojson ok" `Quick test_agent_credential_of_yojson_ok;
       test_case "of_yojson error" `Quick test_agent_credential_of_yojson_error;
+      test_case "of_yojson role=\"admin\" -> Admin" `Quick
+        test_agent_credential_of_yojson_role_string_admin;
+      test_case "of_yojson role=\"worker\" -> Worker" `Quick
+        test_agent_credential_of_yojson_role_string_worker;
+      test_case "of_yojson role string wins over admin bool" `Quick
+        test_agent_credential_of_yojson_role_string_wins_over_admin_bool;
+      test_case "of_yojson legacy admin=true -> Admin" `Quick
+        test_agent_credential_of_yojson_admin_bool_legacy;
+      test_case "of_yojson unknown role fails closed to Worker" `Quick
+        test_agent_credential_of_yojson_unknown_role_fails_closed;
+      test_case "to_yojson emits both role and admin fields" `Quick
+        test_agent_credential_to_yojson_emits_role_and_admin;
     ];
     "auth_config", [
       test_case "to_yojson" `Quick test_auth_config_to_yojson;


### PR DESCRIPTION
## Summary

`agent_credential_of_yojson` 파서가 legacy `"admin": bool` 필드만 읽었던 탓에, 실제 live-fleet credential 파일들에 기록된 canonical `"role": "admin"` 문자열이 무시되어 모든 keeper가 Worker로 강등되었습니다. `masc_board_delete` 등 `CanAdmin` 권한 도구가 janitor / dashboard / qa-king / sangsu / issue_king / masc-improver 에서 Forbidden을 반환하던 사건의 root cause입니다.

## Root cause

`~/me/.masc/auth/agents/` 실사 조사:
- `janitor.json`, `dashboard.json`, `qa-king.json`, `sangsu.json`, `issue_king.json`, `masc-improver.json`, `nick0cave.json` — `"role"` 문자열 포맷 (7건)
- `admin.json` + UUID-backed 파일 — legacy `"admin": true` bool 포맷

Serializer(`agent_credential_to_yojson:249`)는 `"admin": bool`만 emit했는데, 운영 중 어딘가 다른 writer가 `"role"` 문자열을 써왔고 두 포맷 사이의 asymmetric serialization drift가 누적됨. Parser는 `"admin"` bool만 보다 `"role": "admin"`을 매번 None → Worker 기본값으로 귀결시켜 조용히 권한을 박탈.

## Changes

- `lib/types/types_auth.ml`
  - `agent_credential_of_yojson`: `"role"` 문자열 우선, `"admin"` bool fallback, unknown role은 fail-closed Worker
  - `agent_credential_to_yojson`: `"role"`과 `"admin"` 두 필드 동시 emit (전환기 양쪽 reader 호환)
- `test/test_types_coverage.ml`: 회귀 테스트 6건

## Testing

- `test_types_coverage`: 190/190 (신규 6건 포함)
- `test_types_utils_coverage`: 90/90
- `test_auth`: 36/36, `test_auth_coverage`: 98/98, `test_auth_doctor`: 3/3

## Rollout

- 코드 fix 병합 후 다음 deploy에서 근본 해결
- 즉시 운영 복구를 위해 live credential 9개 파일에 `"admin": bool` 필드를 jq로 backfill 완료. 기존 parser가 bool fallback만으로도 admin role을 올바로 읽도록 해 현재 running server에서 이미 권한이 회복되어야 함 (load_credential은 매 호출 파일 재독이라 cache invalidation 불필요).
- 백업: `~/me/.tmp/auth-hotpatch-20260424-102804/`

## Why do-not-merge

이 브랜치는 live running fleet의 auth 동작을 건드리므로, reviewer가 각 vintage credential 파일의 파싱 behavior를 직접 확인하고 Ready 전환하도록 draft + label로 auto-merge flip을 차단합니다 (관련 메모리: auto-merge overrides Draft 사고).