### PR TITLE
fix(validation): sound-partial quote stripping for Agent_id and Task_id (#9787)

### DIFF
--- a/lib/core/validation.ml
+++ b/lib/core/validation.ml
@@ -35,6 +35,14 @@ let log_rejection ~validator ~input ~reason =
   Log.Misc.warn "%s rejected input '%s': %s"
     validator safe_input reason
 
+(* #9787: LLMs emit ids wrapped in stray ASCII quotes ('task-031'). Caller
+   re-runs strict validation on the inner; smart quotes left untouched. *)
+let try_strip_outer_quotes s =
+  let len = String.length s in
+  if len >= 2 && s.[0] = s.[len - 1] && (s.[0] = '\'' || s.[0] = '"') then
+    Some (String.sub s 1 (len - 2))
+  else None
+
 (** Agent ID validation *)
 module Agent_id : sig
   type t
@@ -49,23 +57,40 @@ end = struct
      are rejected. *)
   let valid_pattern = Re.Pcre.re {|^[a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)?$|} |> Re.compile
 
+  let strict s =
+    if String.length s = 0 then
+      Error "agent_id cannot be empty"
+    else if String.length s > 64 then
+      Error (Printf.sprintf "agent_id too long: %d chars (max 64)" (String.length s))
+    else if String.contains s '/' || String.contains s '\\' then
+      Error "agent_id cannot contain path separators"
+    else if String.contains s '.' && Base.String.is_prefix s ~prefix:".." then
+      Error "agent_id cannot contain path traversal"
+    else if not (Re.execp valid_pattern s) then
+      Error (Printf.sprintf "agent_id contains invalid characters: %s (only a-z, A-Z, 0-9, _, -, : allowed)" s)
+    else
+      Ok s
+
   let validate s =
-    let reject reason =
+    let log_and_err reason =
       log_rejection ~validator:"Agent_id" ~input:s ~reason;
       Error reason
     in
-    if String.length s = 0 then
-      reject "agent_id cannot be empty"
-    else if String.length s > 64 then
-      reject (Printf.sprintf "agent_id too long: %d chars (max 64)" (String.length s))
-    else if String.contains s '/' || String.contains s '\\' then
-      reject "agent_id cannot contain path separators"
-    else if String.contains s '.' && Base.String.is_prefix s ~prefix:".." then
-      reject "agent_id cannot contain path traversal"
-    else if not (Re.execp valid_pattern s) then
-      reject (Printf.sprintf "agent_id contains invalid characters: %s (only a-z, A-Z, 0-9, _, -, : allowed)" s)
-    else
-      Ok s
+    match strict s with
+    | Ok t -> Ok t
+    | Error orig_reason ->
+        match try_strip_outer_quotes s with
+        | Some inner ->
+            (match strict inner with
+             | Ok t ->
+                 Log.Misc.info
+                   "Agent_id: stripped surrounding quotes (#9787): '%s' -> '%s'"
+                   s inner;
+                 Ok t
+             | Error _ ->
+                 log_and_err
+                   "agent_id appears wrapped in surrounding quotes; supply the bare id without quotes")
+        | None -> log_and_err orig_reason
 
   let to_string t = t
   let of_string_unsafe s = s
@@ -83,23 +108,40 @@ end = struct
   (* Allow alphanumeric, dash, underscore, colon (for namespacing) *)
   let valid_pattern = Re.Pcre.re {|^[a-zA-Z0-9_:-]+$|} |> Re.compile
 
+  let strict s =
+    if String.length s = 0 then
+      Error "task_id cannot be empty"
+    else if String.length s > 128 then
+      Error (Printf.sprintf "task_id too long: %d chars (max 128)" (String.length s))
+    else if String.contains s '/' || String.contains s '\\' then
+      Error "task_id cannot contain path separators"
+    else if String.contains s '.' && Base.String.is_prefix s ~prefix:".." then
+      Error "task_id cannot contain path traversal"
+    else if not (Re.execp valid_pattern s) then
+      Error (Printf.sprintf "task_id contains invalid characters: %s (only a-z, A-Z, 0-9, _, -, : allowed)" s)
+    else
+      Ok s
+
   let validate s =
-    let reject reason =
+    let log_and_err reason =
       log_rejection ~validator:"Task_id" ~input:s ~reason;
       Error reason
     in
-    if String.length s = 0 then
-      reject "task_id cannot be empty"
-    else if String.length s > 128 then
-      reject (Printf.sprintf "task_id too long: %d chars (max 128)" (String.length s))
-    else if String.contains s '/' || String.contains s '\\' then
-      reject "task_id cannot contain path separators"
-    else if String.contains s '.' && Base.String.is_prefix s ~prefix:".." then
-      reject "task_id cannot contain path traversal"
-    else if not (Re.execp valid_pattern s) then
-      reject (Printf.sprintf "task_id contains invalid characters: %s (only a-z, A-Z, 0-9, _, -, : allowed)" s)
-    else
-      Ok s
+    match strict s with
+    | Ok t -> Ok t
+    | Error orig_reason ->
+        match try_strip_outer_quotes s with
+        | Some inner ->
+            (match strict inner with
+             | Ok t ->
+                 Log.Misc.info
+                   "Task_id: stripped surrounding quotes (#9787): '%s' -> '%s'"
+                   s inner;
+                 Ok t
+             | Error _ ->
+                 log_and_err
+                   "task_id appears wrapped in surrounding quotes; supply the bare id without quotes")
+        | None -> log_and_err orig_reason
 
   let to_string t = t
   let of_string_unsafe s = s

--- a/test/test_validation_coverage.ml
+++ b/test/test_validation_coverage.ml
@@ -237,6 +237,54 @@ let test_agent_id_double_dot () =
   | Error _ -> ()
 
 (* ============================================================
+   Sound-partial quote stripping (#9787)
+   ============================================================ *)
+
+let test_task_id_single_quoted_recoverable () =
+  match Validation.Task_id.validate "'task-031'" with
+  | Ok t -> check string "stripped to inner" "task-031" (Validation.Task_id.to_string t)
+  | Error msg -> failf "expected recovery, got: %s" msg
+
+let test_task_id_double_quoted_recoverable () =
+  match Validation.Task_id.validate "\"task-041\"" with
+  | Ok t -> check string "stripped to inner" "task-041" (Validation.Task_id.to_string t)
+  | Error msg -> failf "expected recovery, got: %s" msg
+
+let test_task_id_quoted_inner_invalid () =
+  (* Outer quotes match but inner contains invalid char — must surface a
+     quote-aware error and not silently accept the inner. *)
+  match Validation.Task_id.validate "'bad/id'" with
+  | Ok _ -> fail "should reject quoted but invalid inner"
+  | Error msg ->
+      check bool "mentions quotes" true
+        (try ignore (Re.exec (Re.Pcre.re "quotes" |> Re.compile) msg); true
+         with Not_found -> false)
+
+let test_task_id_mismatched_quotes_not_stripped () =
+  (* Single + double mismatch must NOT be stripped — keep strict error. *)
+  match Validation.Task_id.validate "'task-031\"" with
+  | Ok _ -> fail "should reject mismatched outer quotes"
+  | Error _ -> ()
+
+let test_task_id_unquoted_still_works () =
+  match Validation.Task_id.validate "task-099" with
+  | Ok t -> check string "preserved" "task-099" (Validation.Task_id.to_string t)
+  | Error msg -> failf "should accept bare id: %s" msg
+
+let test_agent_id_single_quoted_recoverable () =
+  match Validation.Agent_id.validate "'keeper'" with
+  | Ok t -> check string "stripped to inner" "keeper" (Validation.Agent_id.to_string t)
+  | Error msg -> failf "expected recovery, got: %s" msg
+
+let test_agent_id_quoted_inner_invalid () =
+  match Validation.Agent_id.validate "'has space'" with
+  | Ok _ -> fail "should reject quoted but invalid inner"
+  | Error msg ->
+      check bool "mentions quotes" true
+        (try ignore (Re.exec (Re.Pcre.re "quotes" |> Re.compile) msg); true
+         with Not_found -> false)
+
+(* ============================================================
    Test Runners
    ============================================================ *)
 
@@ -297,5 +345,14 @@ let () =
       test_case "agent dot only" `Quick test_agent_id_dot_only;
       test_case "agent single dot" `Quick test_agent_id_single_dot;
       test_case "agent double dot" `Quick test_agent_id_double_dot;
+    ];
+    "quote_stripping_9787", [
+      test_case "task single-quoted recoverable" `Quick test_task_id_single_quoted_recoverable;
+      test_case "task double-quoted recoverable" `Quick test_task_id_double_quoted_recoverable;
+      test_case "task quoted inner invalid" `Quick test_task_id_quoted_inner_invalid;
+      test_case "task mismatched quotes" `Quick test_task_id_mismatched_quotes_not_stripped;
+      test_case "task unquoted still works" `Quick test_task_id_unquoted_still_works;
+      test_case "agent single-quoted recoverable" `Quick test_agent_id_single_quoted_recoverable;
+      test_case "agent quoted inner invalid" `Quick test_agent_id_quoted_inner_invalid;
     ];
   ]


### PR DESCRIPTION
## Summary

LLMs frequently emit identifier arguments wrapped in stray surrounding quotes:

```
masc_transition  task_id='task-031'
                          ^^^^^^^^^^
```

The literal string `'task-031'` reaches the server and the strict validator rejects it with the unhelpful `task_id contains invalid characters`. The agent receives no hint that the **wrapping quotes** are the actual problem (#9787, observed in seq 57745–57747, 57754–57756, 57763–57765, blocking task workflow for multiple keepers).

## Root cause

This is a **parse-don't-validate** boundary problem, not a content problem. The validator returns the same opaque error regardless of whether the input is malformed (`task<script>`) or merely quote-wrapped (`'task-031'`).

## Fix

Sound-partial repair at the validator boundary, applied identically to `Agent_id` and `Task_id` (same root cause, same module):

1. Factor each validator into a pure `strict` decision and a logging `validate` wrapper.
2. If `strict s` fails AND `s` is wrapped in matched outer ASCII quotes AND `strict inner` succeeds → accept `inner` and emit an INFO log so the offending client can be tracked.
3. Otherwise reject. If outer quotes were present but the inner is still invalid, surface a **quote-aware error** so the LLM can self-correct on the next turn — per the validated `tool-error-messages-teach-llm` pattern (memory ref) and `gate-response-llm-readable` principle.

Smart/typographic quotes are intentionally **not** stripped to keep the repair surface narrow and the parser sound.

## Why "sound-partial" not "tolerant"

Postel's law often degenerates into silently accepting garbage. The repair here is bounded:

- Only matched outer ASCII single/double quotes
- Only when stripping yields strict-valid input
- Mismatched quotes (`'foo\"`), nested quotes (`''foo''`), or any other pattern → rejected with the same strict error path
- Path traversal protection unchanged: `'../etc/passwd'` strips to `../etc/passwd` which still fails the `..` prefix check

## Test plan

- [x] `dune build --root=. lib/` — clean
- [x] `dune exec test/test_validation_coverage.exe` — 47/47 pass (40 existing + 7 new for `quote_stripping_9787`)
- [x] `dune exec test/test_validation.exe` — 17/17 pass (no regression in legacy validation suite)

New regression coverage:
- task/agent: single- and double-quoted recoverable input → `Ok inner`
- task/agent: quoted but inner invalid → quote-aware `Error`
- task: mismatched outer quotes (`'foo\"`) → strict `Error`
- task: bare unquoted id continues to validate as before

Closes #9787