### PR TITLE
[codex] Refactor dashboard async resource hooks

### DIFF
--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -8,7 +8,7 @@
 // Pattern mirrors RuntimeMonitor: managed async resource + manual refresh.
 
 import { html } from 'htm/preact'
-import { useEffect, useRef } from 'preact/hooks'
+import { useEffect } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
 import { fetchGateKeepers, type GateKeeperInfo } from '../api/gate'
 import {
@@ -47,7 +47,8 @@ import { ErrorState, LoadingState } from './common/feedback-state'
 import { TextInput } from './common/input'
 import { StatCell } from './common/stat-cell'
 import { StatusChip } from './common/status-chip'
-import { createManagedAsyncResource, type ManagedAsyncResource } from '../lib/async-state'
+import type { ManagedAsyncResource } from '../lib/async-state'
+import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 
 interface CascadeData {
   config: CascadeConfigResponse | null
@@ -1108,11 +1109,7 @@ function CascadeRawConfigEditor({
 export function CascadeConfigPanel() {
   const traceSearch = useSignal('')
   const healthSearch = useSignal('')
-  const resourceRef = useRef<ManagedAsyncResource<CascadeData> | null>(null)
-  if (resourceRef.current === null) {
-    resourceRef.current = createManagedAsyncResource<CascadeData>()
-  }
-  const resource = resourceRef.current
+  const resource = useManagedAsyncResource<CascadeData>()
 
   useEffect(() => {
     void loadCascadeData(resource)

--- a/dashboard/src/components/governance-monitor.ts
+++ b/dashboard/src/components/governance-monitor.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { useEffect, useMemo, useRef } from 'preact/hooks'
+import { useEffect, useMemo } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
 import { Card } from './common/card'
 import { EmptyState } from './common/empty-state'
@@ -7,9 +7,9 @@ import { ErrorState, LoadingState } from './common/feedback-state'
 import { StatCell } from './common/stat-cell'
 import { StatusChip } from './common/status-chip'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
-import { createManagedAsyncResource, type ManagedAsyncResource } from '../lib/async-state'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { useSavedSignal } from '../lib/saved-signal'
+import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { get, type GetOptions } from '../api/core'
 
 export interface ToolRejection {
@@ -104,11 +104,7 @@ function queueTone(depth: number, oldest: number | null): string {
 }
 
 export function GovernanceMonitor() {
-  const resourceRef = useRef<ManagedAsyncResource<GovernanceToolEvents> | null>(null)
-  if (resourceRef.current === null) {
-    resourceRef.current = createManagedAsyncResource<GovernanceToolEvents>()
-  }
-  const resource = resourceRef.current
+  const resource = useManagedAsyncResource<GovernanceToolEvents>()
   const windowMinutes = useSignal(60)
   const [query] = useSavedSignal('dash:filter:governance-monitor:query', '')
 

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -39,7 +39,11 @@ function KeeperToolPresetChip({ keeperName }: { keeperName: string }) {
 
 function KeeperCascadeSelector({ keeper }: { keeper: Keeper }) {
   const [cascadeProfiles, setCascadeProfiles] = useState<Awaited<ReturnType<typeof fetchCascadeProfiles>> | null>(null)
-  const [currentCascade, setCurrentCascade] = useState(keeper.cascade_name || 'default')
+  const [draftCascade, setDraftCascade] = useState<{
+    keeperName: string
+    from: string
+    cascade: string
+  } | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -53,10 +57,10 @@ function KeeperCascadeSelector({ keeper }: { keeper: Keeper }) {
     }
   }, [])
 
-  useEffect(() => {
-    setCurrentCascade(keeper.cascade_name || 'default')
-  }, [keeper.name, keeper.cascade_name])
-
+  const fallbackCascade = keeper.cascade_name || 'default'
+  const currentCascade = draftCascade?.keeperName === keeper.name && draftCascade.from === fallbackCascade
+    ? draftCascade.cascade
+    : fallbackCascade
   const profiles = cascadeProfiles?.profiles ?? []
   const invalidProfiles = cascadeProfiles?.invalid_profiles ?? []
   if (profiles.length + invalidProfiles.length <= 1) return null
@@ -79,13 +83,14 @@ function KeeperCascadeSelector({ keeper }: { keeper: Keeper }) {
         value=${currentCascade}
         onChange=${(e: Event) => {
           const val = (e.target as HTMLSelectElement).value
-          setCurrentCascade(val)
+          const draft = { keeperName: keeper.name, from: fallbackCascade, cascade: val }
+          setDraftCascade(draft)
           updateKeeperCascade(keeper.name, val)
             .then(() => {
               refreshDashboard()
             })
             .catch((err) => {
-              setCurrentCascade(keeper.cascade_name || 'default')
+              setDraftCascade((current) => current === draft ? null : current)
               const msg = err instanceof Error ? err.message : 'Cascade 변경 실패'
               showToast(msg, 'error')
             })

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -2,7 +2,7 @@
 // Fetches from GET /api/v1/keepers/:name/tool-calls
 
 import { html } from 'htm/preact'
-import { useEffect, useRef } from 'preact/hooks'
+import { useEffect } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
 import { fetchKeeperToolCalls } from '../api/dashboard'
 import type { ToolCallEntry } from '../api/dashboard'
@@ -10,7 +10,7 @@ import { formatTimeHms } from '../lib/format-time'
 import { LoadingState } from './common/feedback-state'
 import { SectionCap } from './common/section-cap'
 import { toolCategory, formatDuration, durationColor } from './tool-call-shared'
-import { createManagedAsyncResource, type ManagedAsyncResource } from '../lib/async-state'
+import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { parseToolBlobMarker } from '../lib/tool-blob-marker'
 
 // Delegated to lib/format-time (SSOT)
@@ -110,11 +110,7 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
 // ── Main component ──────────────────────────────────────
 
 export function KeeperToolCallInspector({ keeperName }: { keeperName: string }) {
-  const resourceRef = useRef<ManagedAsyncResource<ToolCallEntry[]> | null>(null)
-  if (resourceRef.current === null) {
-    resourceRef.current = createManagedAsyncResource<ToolCallEntry[]>([])
-  }
-  const resource = resourceRef.current
+  const resource = useManagedAsyncResource<ToolCallEntry[]>([])
   const filterTool = useSignal('')
 
   useEffect(() => {

--- a/dashboard/src/components/keeper-tool-telemetry.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.ts
@@ -3,11 +3,11 @@
 // cross-trace aggregation, and hourly timeline sparklines.
 
 import { html } from 'htm/preact'
-import { useEffect, useRef, useState } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 import { fetchKeeperToolStats } from '../api/dashboard'
 import type { ToolStat, HourlyBucket, ToolStatsResponse } from '../api/dashboard'
 import { toolCategory, formatDuration, durationColor } from './tool-call-shared'
-import { createManagedAsyncResource, type ManagedAsyncResource } from '../lib/async-state'
+import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { SectionCap } from './common/section-cap'
 
 // ── Types ─────────────────────────────────────────────
@@ -124,16 +124,12 @@ interface KeeperToolTelemetryProps {
 }
 
 export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
-  const resourceRef = useRef<ManagedAsyncResource<TelemetryState> | null>(null)
-  if (resourceRef.current === null) {
-    resourceRef.current = createManagedAsyncResource<TelemetryState>({
-      tools: [],
-      timeline: [],
-      totalEntries: 0,
-      windowHours: 24,
-    })
-  }
-  const resource = resourceRef.current
+  const resource = useManagedAsyncResource<TelemetryState>({
+    tools: [],
+    timeline: [],
+    totalEntries: 0,
+    windowHours: 24,
+  })
   const [query, setQuery] = useState('')
 
   useEffect(() => {

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { useEffect, useRef } from 'preact/hooks'
+import { useEffect } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
 import {
   fetchRuntimeModelMetrics,
@@ -15,7 +15,8 @@ import { ErrorState, LoadingState } from './common/feedback-state'
 import { StatCell } from './common/stat-cell'
 import { StatusChip } from './common/status-chip'
 import { TextInput } from './common/input'
-import { createManagedAsyncResource, type ManagedAsyncResource } from '../lib/async-state'
+import type { ManagedAsyncResource } from '../lib/async-state'
+import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 
 /**
  * Filters model metrics by case-insensitive substring match against
@@ -313,11 +314,7 @@ export function metricCoverageText(metric: DashboardRuntimeModelMetric): string 
 }
 
 export function RuntimeMonitor() {
-  const resourceRef = useRef<ManagedAsyncResource<RuntimeData> | null>(null)
-  if (resourceRef.current === null) {
-    resourceRef.current = createManagedAsyncResource<RuntimeData>()
-  }
-  const resource = resourceRef.current
+  const resource = useManagedAsyncResource<RuntimeData>()
   const windowMinutes = useSignal(30)
   const expandedModel = useSignal<string | null>(null)
   const modelSearch = useSignal('')

--- a/dashboard/src/components/verification-requests-panel.ts
+++ b/dashboard/src/components/verification-requests-panel.ts
@@ -12,7 +12,7 @@
 // in-flight state is held in a per-row signal map.
 
 import { html } from 'htm/preact'
-import { useEffect, useMemo, useRef } from 'preact/hooks'
+import { useEffect, useMemo } from 'preact/hooks'
 import { signal } from '@preact/signals'
 import {
   fetchVerificationRequests,
@@ -28,10 +28,8 @@ import { ErrorState, LoadingState } from './common/feedback-state'
 import { StatusChip } from './common/status-chip'
 import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
-import {
-  createManagedAsyncResource,
-  type ManagedAsyncResource,
-} from '../lib/async-state'
+import type { ManagedAsyncResource } from '../lib/async-state'
+import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { route } from '../router'
 
 const AUTO_REFRESH_MS = 15_000
@@ -527,13 +525,7 @@ function RequestsTable({
 // ── Panel ─────────────────────────────────────────────
 
 export function VerificationRequestsPanel() {
-  const resourceRef = useRef<
-    ManagedAsyncResource<VerificationRequestsResponse> | null
-  >(null)
-  if (resourceRef.current === null) {
-    resourceRef.current = createManagedAsyncResource<VerificationRequestsResponse>()
-  }
-  const resource = resourceRef.current
+  const resource = useManagedAsyncResource<VerificationRequestsResponse>()
 
   useEffect(() => {
     void loadData(resource)

--- a/dashboard/src/components/verification-specs-panel.ts
+++ b/dashboard/src/components/verification-specs-panel.ts
@@ -10,7 +10,7 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { useEffect, useRef } from 'preact/hooks'
+import { useEffect } from 'preact/hooks'
 import {
   fetchTlaSpecs,
   type TlaSpecCategory,
@@ -23,7 +23,8 @@ import { ErrorState, LoadingState } from './common/feedback-state'
 import { StatusChip } from './common/status-chip'
 import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
-import { createManagedAsyncResource, type ManagedAsyncResource } from '../lib/async-state'
+import type { ManagedAsyncResource } from '../lib/async-state'
+import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 
 type CategoryFilter = 'all' | TlaSpecCategory
 const categoryFilter = signal<CategoryFilter>('all')
@@ -109,11 +110,7 @@ function SpecsTable({ entries }: { entries: TlaSpecEntry[] }) {
 }
 
 export function VerificationSpecsPanel() {
-  const resourceRef = useRef<ManagedAsyncResource<TlaSpecsResponse> | null>(null)
-  if (resourceRef.current === null) {
-    resourceRef.current = createManagedAsyncResource<TlaSpecsResponse>()
-  }
-  const resource = resourceRef.current
+  const resource = useManagedAsyncResource<TlaSpecsResponse>()
 
   useEffect(() => {
     void loadSpecs(resource)

--- a/dashboard/src/lib/use-managed-async-resource.ts
+++ b/dashboard/src/lib/use-managed-async-resource.ts
@@ -1,0 +1,14 @@
+import { useState } from 'preact/hooks'
+import {
+  createManagedAsyncResource,
+  type ManagedAsyncResource,
+} from './async-state'
+
+export function useManagedAsyncResource<T>(
+  initialData: T | null = null,
+): ManagedAsyncResource<T> {
+  const [resource] = useState<ManagedAsyncResource<T>>(() =>
+    createManagedAsyncResource<T>(initialData),
+  )
+  return resource
+}


### PR DESCRIPTION
## Summary

- Add `useManagedAsyncResource` to centralize one-time managed resource creation in dashboard components.
- Replace repeated `useRef + createManagedAsyncResource` boilerplate across runtime, cascade, governance, verification, and keeper tool panels.
- Remove prop-to-state synchronization from the keeper cascade selector and keep optimistic edits scoped to the keeper/base cascade they were made against.

## Why

Several dashboard panels repeated the same managed async resource setup and cleanup shape. Centralizing the setup reduces copy/paste surface while preserving each panel's existing load and cancel behavior. The keeper cascade selector also copied `keeper.cascade_name` into local state through an effect, which made prop-derived state harder to reason about; it now derives from props and overlays only the active optimistic draft.

## Validation

- `pnpm install --frozen-lockfile --offline`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm vitest run --no-file-parallelism --maxWorkers=1 src/components/verification-requests-panel.test.ts src/components/verification-specs-panel.test.ts src/components/keeper-tool-telemetry.test.ts src/components/governance-monitor.test.ts src/components/runtime-monitor.test.ts src/components/cascade-config-panel.test.ts src/components/keeper-tool-call-inspector.test.ts` — 177 passed
- `pnpm vitest run --no-file-parallelism --maxWorkers=1 src/components/keeper-detail-source.test.ts src/components/keeper-detail-panels.test.ts src/components/keeper-detail-runtime.test.ts src/components/keeper-detail.test.ts` — 105 passed
- `git diff --check`