### PR TITLE
feat(telemetry): emit per-turn prompt/decode tok_s to Prometheus

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -95,6 +95,49 @@ let record_keeper_tool_duration_metric
       ]
     (summary.duration_ms /. 1000.0)
 
+(** Emit prompt/decode tokens-per-second histograms from an OAS turn
+    response.  Safe to call with [telemetry = None] (no-op) and with
+    positive [None] timing fields (per-metric no-op).  The histograms are
+    labelled by [model], the coarse [provider] string derived from the
+    model id, and the finer [provider_kind] reported by OAS.  Split from
+    [masc_llm_inference_duration_seconds] because wall-clock latency
+    mixes prefill and decode phases.
+
+    Extracted so the after_turn hook is unit-testable without
+    constructing a full [Oas.Hooks.AfterTurn] event. *)
+let record_llm_tok_s_metrics
+    ~(model : string)
+    ~(telemetry : Oas.Types.inference_telemetry option)
+  : unit =
+  let prompt_tok_s_opt, decode_tok_s_opt =
+    match telemetry with
+    | Some { timings = Some t; _ } ->
+      t.prompt_per_second, t.predicted_per_second
+    | _ -> None, None
+  in
+  let provider_kind_label =
+    match telemetry with
+    | Some { provider_kind = Some pk; _ } ->
+      Llm_provider.Provider_kind.to_string pk
+    | _ -> "unknown"
+  in
+  let labels =
+    [ "model", model
+    ; "provider", provider_of_model model
+    ; "provider_kind", provider_kind_label
+    ]
+  in
+  (match prompt_tok_s_opt with
+   | Some v when v > 0.0 ->
+     Prometheus.observe_histogram
+       Prometheus.metric_llm_prompt_tok_per_sec ~labels v
+   | _ -> ());
+  (match decode_tok_s_opt with
+   | Some v when v > 0.0 ->
+     Prometheus.observe_histogram
+       Prometheus.metric_llm_decode_tok_per_sec ~labels v
+   | _ -> ())
+
 (** Append a cost event to .masc/costs.jsonl for per-task cost attribution.
     Schema matches bin/masc_cost.ml with an additional "source" field to
     distinguish automatic entries from manual CLI entries.
@@ -398,14 +441,26 @@ let make_hooks
           | Some v -> Printf.sprintf "%.1f" v
           | None -> "-"
         in
-        let prompt_tok_s, decode_tok_s, latency_ms =
+        (* Capture each telemetry projection independently.  Anthropic and
+           Gemini populate [request_latency_ms] (patched in OAS api.ml) but
+           leave [timings = None]; the previous single-match folded those
+           three fields together and surfaced [latency_ms=0] whenever tok/s
+           were missing, which hid Anthropic/Gemini latency on the log line
+           and in downstream dashboards. *)
+        let prompt_tok_s_opt, decode_tok_s_opt =
           match response.telemetry with
-          | Some { timings = Some t; request_latency_ms; _ } ->
-              fmt_tok_s t.prompt_per_second,
-              fmt_tok_s t.predicted_per_second,
-              request_latency_ms
-          | _ -> "-", "-", 0
+          | Some { timings = Some t; _ } ->
+              t.prompt_per_second, t.predicted_per_second
+          | _ -> None, None
         in
+        let latency_ms =
+          match response.telemetry with
+          | Some t -> t.request_latency_ms
+          | None -> 0
+        in
+        record_llm_tok_s_metrics ~model ~telemetry:response.telemetry;
+        let prompt_tok_s = fmt_tok_s prompt_tok_s_opt in
+        let decode_tok_s = fmt_tok_s decode_tok_s_opt in
         Log.Keeper.info
           "keeper:%s turn=%d total_turns=%d model=%s tokens=%d prompt_tok_s=%s decode_tok_s=%s latency_ms=%d"
           meta.name turn meta.runtime.usage.total_turns model total_tok

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -265,6 +265,13 @@ let metric_fd_warn_threshold = "masc_process_fd_warn_threshold"
 (* Core counters / gauges — used outside init. *)
 let metric_mcp_requests = "masc_mcp_requests_total"
 let metric_llm_inference_duration = "masc_llm_inference_duration_seconds"
+(* Throughput histograms — derived from Agent_sdk inference_telemetry.timings.
+   Split from masc_llm_inference_duration_seconds because wall-clock latency
+   mixes prefill and decode phases; operators need them separately to tell
+   "prompt ingestion is slow" apart from "generation is slow". Silent when
+   the backend does not emit timings (Anthropic/Gemini). *)
+let metric_llm_prompt_tok_per_sec = "masc_llm_prompt_tok_per_sec"
+let metric_llm_decode_tok_per_sec = "masc_llm_decode_tok_per_sec"
 let metric_after_turn_hook = "masc_after_turn_hook_total"
 let metric_after_turn_telemetry_missing =
   "masc_after_turn_telemetry_missing_total"
@@ -315,6 +322,18 @@ let init () =
   in
   add metric_mcp_requests "Total MCP requests received" Counter;
   add metric_llm_inference_duration "LLM inference request duration in seconds" Histogram;
+  add metric_llm_prompt_tok_per_sec
+    "LLM prefill (prompt_eval) throughput in tokens/second from \
+     inference_telemetry.timings.prompt_per_second. Per-turn observation \
+     labelled by model and provider_kind. Silent for providers that do not \
+     emit timings (Anthropic/Gemini); use masc_after_turn_telemetry_missing_total \
+     to detect that." Histogram;
+  add metric_llm_decode_tok_per_sec
+    "LLM decode (predicted) throughput in tokens/second from \
+     inference_telemetry.timings.predicted_per_second. Per-turn observation \
+     labelled by model and provider_kind. Distinct from \
+     masc_llm_prompt_tok_per_sec: decode rate is the hardware generation \
+     speed, prompt rate is the prefill ingestion speed." Histogram;
   add metric_after_turn_hook
     "Times the keeper AfterTurn hook ran (labeled by model). Divergence from \
      masc_llm_inference_duration_seconds_count identifies missing telemetry." Counter;

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -99,6 +99,19 @@ val metric_mcp_tool_schema_tokens_approx : string
 
 val metric_mcp_requests : string
 val metric_llm_inference_duration : string
+
+val metric_llm_prompt_tok_per_sec : string
+(** [masc_llm_prompt_tok_per_sec] — prefill throughput histogram.
+    Observed in [Keeper_hooks_oas] after_turn when [response.telemetry.timings]
+    is [Some] and [prompt_per_second] is positive. Labels: [model], [provider_kind]. *)
+
+val metric_llm_decode_tok_per_sec : string
+(** [masc_llm_decode_tok_per_sec] — decode throughput histogram.
+    Observed alongside {!metric_llm_prompt_tok_per_sec} from the same turn
+    when [predicted_per_second] is positive. Silent for providers that do
+    not emit timings; inspect [masc_after_turn_telemetry_missing_total] to
+    tell absence apart from zero. *)
+
 val metric_after_turn_hook : string
 val metric_after_turn_telemetry_missing : string
 val metric_after_turn_telemetry_zero_latency : string

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -117,6 +117,173 @@ let test_record_keeper_tool_duration_metric_tracks_labels () =
   check (float 0.0001) "sum delta" 0.25 (sum_after -. sum_before);
   check (float 0.0001) "count delta" 1.0 (count_after -. count_before)
 
+let make_telemetry
+    ?(prompt_per_second : float option = None)
+    ?(predicted_per_second : float option = None)
+    ?(request_latency_ms = 0)
+    ?(provider_kind : Llm_provider.Provider_kind.t option = None)
+    ?(include_timings = true)
+    () : Agent_sdk.Types.inference_telemetry =
+  let timings : Agent_sdk.Types.inference_timings option =
+    if include_timings then
+      Some {
+        prompt_n = None;
+        prompt_ms = None;
+        prompt_per_second;
+        predicted_n = None;
+        predicted_ms = None;
+        predicted_per_second;
+        cache_n = None;
+      }
+    else None
+  in
+  {
+    system_fingerprint = None;
+    timings;
+    reasoning_tokens = None;
+    request_latency_ms;
+    peak_memory_gb = None;
+    provider_kind;
+    reasoning_effort = None;
+    canonical_model_id = None;
+    effective_context_window = None;
+    provider_internal_action_count = None;
+  }
+
+let histogram_snapshot metric ~labels =
+  let sum =
+    Masc_mcp.Prometheus.metric_value_or_zero metric ~labels ()
+  in
+  let count =
+    Masc_mcp.Prometheus.metric_value_or_zero (metric ^ "_count") ~labels ()
+  in
+  sum, count
+
+let test_record_llm_tok_s_metrics_both_histograms_observe () =
+  let telemetry =
+    make_telemetry
+      ~prompt_per_second:(Some 123.5)
+      ~predicted_per_second:(Some 87.25)
+      ~request_latency_ms:42
+      ~provider_kind:(Some Llm_provider.Provider_kind.Ollama)
+      () in
+  let labels =
+    [ "model", "ollama:qwen3.6"
+    ; "provider", "ollama"
+    ; "provider_kind", "ollama"
+    ]
+  in
+  let prompt_sum_before, prompt_count_before =
+    histogram_snapshot Masc_mcp.Prometheus.metric_llm_prompt_tok_per_sec
+      ~labels in
+  let decode_sum_before, decode_count_before =
+    histogram_snapshot Masc_mcp.Prometheus.metric_llm_decode_tok_per_sec
+      ~labels in
+  Hooks.record_llm_tok_s_metrics ~model:"ollama:qwen3.6"
+    ~telemetry:(Some telemetry);
+  let prompt_sum_after, prompt_count_after =
+    histogram_snapshot Masc_mcp.Prometheus.metric_llm_prompt_tok_per_sec
+      ~labels in
+  let decode_sum_after, decode_count_after =
+    histogram_snapshot Masc_mcp.Prometheus.metric_llm_decode_tok_per_sec
+      ~labels in
+  check (float 0.001) "prompt sum delta" 123.5
+    (prompt_sum_after -. prompt_sum_before);
+  check (float 0.001) "prompt count delta" 1.0
+    (prompt_count_after -. prompt_count_before);
+  check (float 0.001) "decode sum delta" 87.25
+    (decode_sum_after -. decode_sum_before);
+  check (float 0.001) "decode count delta" 1.0
+    (decode_count_after -. decode_count_before)
+
+let test_record_llm_tok_s_metrics_timings_none_is_noop () =
+  (* Anthropic/Gemini path: backends populate request_latency_ms but leave
+     timings = None.  The helper must not touch the tok/s histograms in
+     that case — otherwise the histogram would be polluted with zeros. *)
+  let telemetry =
+    make_telemetry ~include_timings:false ~request_latency_ms:250
+      ~provider_kind:(Some Llm_provider.Provider_kind.Anthropic) ()
+  in
+  let labels =
+    [ "model", "claude:claude-haiku-4-5-20251001"
+    ; "provider", "claude"
+    ; "provider_kind", "anthropic"
+    ]
+  in
+  let _, prompt_count_before =
+    histogram_snapshot Masc_mcp.Prometheus.metric_llm_prompt_tok_per_sec
+      ~labels in
+  let _, decode_count_before =
+    histogram_snapshot Masc_mcp.Prometheus.metric_llm_decode_tok_per_sec
+      ~labels in
+  Hooks.record_llm_tok_s_metrics
+    ~model:"claude:claude-haiku-4-5-20251001"
+    ~telemetry:(Some telemetry);
+  let _, prompt_count_after =
+    histogram_snapshot Masc_mcp.Prometheus.metric_llm_prompt_tok_per_sec
+      ~labels in
+  let _, decode_count_after =
+    histogram_snapshot Masc_mcp.Prometheus.metric_llm_decode_tok_per_sec
+      ~labels in
+  check (float 0.001) "prompt count unchanged" 0.0
+    (prompt_count_after -. prompt_count_before);
+  check (float 0.001) "decode count unchanged" 0.0
+    (decode_count_after -. decode_count_before)
+
+let test_record_llm_tok_s_metrics_zero_value_is_skipped () =
+  (* Guard: a backend that reports prompt_per_second = Some 0.0 (e.g. a
+     very short prompt processed in sub-millisecond time that rounds to
+     zero) should not observe 0 into the histogram, which would skew the
+     p50/p95 buckets. *)
+  let telemetry =
+    make_telemetry
+      ~prompt_per_second:(Some 0.0)
+      ~predicted_per_second:(Some 55.0)
+      ~provider_kind:(Some Llm_provider.Provider_kind.OpenAI_compat) ()
+  in
+  let labels =
+    [ "model", "openai:gpt-5.4"
+    ; "provider", "unknown"
+    ; "provider_kind", "openai_compat"
+    ]
+  in
+  let _, prompt_count_before =
+    histogram_snapshot Masc_mcp.Prometheus.metric_llm_prompt_tok_per_sec
+      ~labels in
+  let _, decode_count_before =
+    histogram_snapshot Masc_mcp.Prometheus.metric_llm_decode_tok_per_sec
+      ~labels in
+  Hooks.record_llm_tok_s_metrics ~model:"openai:gpt-5.4"
+    ~telemetry:(Some telemetry);
+  let _, prompt_count_after =
+    histogram_snapshot Masc_mcp.Prometheus.metric_llm_prompt_tok_per_sec
+      ~labels in
+  let _, decode_count_after =
+    histogram_snapshot Masc_mcp.Prometheus.metric_llm_decode_tok_per_sec
+      ~labels in
+  check (float 0.001) "prompt zero skipped" 0.0
+    (prompt_count_after -. prompt_count_before);
+  check (float 0.001) "decode positive observed" 1.0
+    (decode_count_after -. decode_count_before)
+
+let test_record_llm_tok_s_metrics_none_telemetry_is_noop () =
+  (* Belt and braces: explicitly None telemetry must not raise or emit. *)
+  let labels =
+    [ "model", "unknown:nothing"
+    ; "provider", "unknown"
+    ; "provider_kind", "unknown"
+    ]
+  in
+  let _, prompt_count_before =
+    histogram_snapshot Masc_mcp.Prometheus.metric_llm_prompt_tok_per_sec
+      ~labels in
+  Hooks.record_llm_tok_s_metrics ~model:"unknown:nothing" ~telemetry:None;
+  let _, prompt_count_after =
+    histogram_snapshot Masc_mcp.Prometheus.metric_llm_prompt_tok_per_sec
+      ~labels in
+  check (float 0.001) "prompt count unchanged" 0.0
+    (prompt_count_after -. prompt_count_before)
+
 let () =
   run "keeper_hooks_oas/telemetry"
     [ ( "costs_jsonl",
@@ -127,5 +294,15 @@ let () =
             test_tool_execution_summary_derives_provider_and_outcome
         ; test_case "keeper tool duration metric tracks labels" `Quick
             test_record_keeper_tool_duration_metric_tracks_labels
+        ] )
+    ; ( "llm_tok_s_metrics",
+        [ test_case "both histograms observe when timings present" `Quick
+            test_record_llm_tok_s_metrics_both_histograms_observe
+        ; test_case "timings=None is no-op (Anthropic/Gemini path)" `Quick
+            test_record_llm_tok_s_metrics_timings_none_is_noop
+        ; test_case "Some 0.0 prompt rate is skipped (no bucket poisoning)" `Quick
+            test_record_llm_tok_s_metrics_zero_value_is_skipped
+        ; test_case "telemetry=None is a safe no-op" `Quick
+            test_record_llm_tok_s_metrics_none_telemetry_is_noop
         ] )
     ]


### PR DESCRIPTION
## 요약

`keeper_hooks_oas` after_turn에서 캡처하는 텔레메트리 pattern match를 3개 독립 projection으로 분리하고, 누락되어 있던 prompt/decode throughput 히스토그램을 Prometheus에 추가로 emit합니다.

- `masc_llm_prompt_tok_per_sec` — prefill throughput
- `masc_llm_decode_tok_per_sec` — decode throughput

두 히스토그램 모두 `model`, 모델 id에서 파생한 coarse `provider`, OAS가 넘겨주는 canonical `provider_kind`로 라벨링됩니다. Positive 값일 때만 observe — `Some 0.0`/`None`은 no-op이라 퍼센타일이 오염되지 않습니다. Anthropic/Gemini 경로는 OAS backend에서 `timings = None`으로 내보내므로 histogram은 silent이고, 이미 있는 `masc_after_turn_telemetry_missing_total` counter로 "없음"/"0" 구분이 가능합니다.

## 기존 버그 (한 cf. lines `lib/keeper/keeper_hooks_oas.ml:401-407` before this PR)

```ocaml
let prompt_tok_s, decode_tok_s, latency_ms =
  match response.telemetry with
  | Some { timings = Some t; request_latency_ms; _ } -> ...
  | _ -> "-", "-", 0
in
```

`timings = None`일 때 `latency_ms`까지 0으로 삼켰던 부분을 분리해 `request_latency_ms`는 독립적으로 `response.telemetry` 만 있으면 캡처하도록 수정. Anthropic/Gemini에서 keeper turn 로그에 `latency_ms=0`만 찍히던 증상을 해결합니다.

## 변경된 파일

- `lib/keeper/keeper_hooks_oas.ml` — pattern match 3-way 분리 + `record_llm_tok_s_metrics` 헬퍼 추출 + hook에서 호출
- `lib/prometheus.ml`, `lib/prometheus.mli` — 2개 metric 이름 상수 + init 등록
- `test/test_keeper_hooks_oas_telemetry.ml` — 새 4 테스트 케이스 추가 (happy, timings=None, Some 0.0 skip, telemetry=None)

## 테스트

```
dune runtest test/test_keeper_hooks_oas_telemetry.ml  # 7/7 pass
dune runtest test/test_keeper_hooks_oas_provider.ml   # 3/3 pass (unchanged)
```

## 배경 — 7-PR 파이프라인 복구의 1단계

cascade 대시보드 provider 화면이 per-provider tok/s / latency_ms를 `--` / 0으로 표시하는 증상을 역추적해서 6개의 독립 drop 지점을 찾았습니다. 이 PR은 그 중 MASC 백엔드에서 **데이터를 Prometheus로 보내는 송신부**를 막는 2개 지점(pattern match collapse + tok_s emit 미구현)을 고칩니다. 후속 PR:

- PR 2: Frontend가 이미 fetch해놓고도 렌더를 안 하는 `prompt_{avg,p50,p95}_tok_per_sec` 컬럼 추가
- PR 3: `Health.provider_info`에 perf 필드 추가 + 집계
- PR 4: Frontend provider 요약 카드에 perf 수치 렌더
- PR 5: cascade.json에 선언됐지만 미호출된 candidate 가시성 복구
- PR 6 (oas 레포): `Pipeline.IdleSkipped` outer 경로 `telemetry = None` 합성 버그 수정
- PR 7: OAS pin bump + end-to-end 검증

Plan 전문: `planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-b-giggly-gadget.md`.

관련: masc-mcp#8968 (tok/s telemetry drop).

## Do-not-merge 사유

단독으로도 안전하지만 전체 파이프라인이 사용자에게 보이기까지는 PR 2-7이 같이 필요합니다. 한 번에 검증하고 싶어 `do-not-merge` 라벨로 auto-merge 억제. CI green + reviewer OK 후 수동으로 Ready 전환합니다.

## 검증 체크리스트

- [x] `dune build --root . @check` green
- [x] `dune runtest` (해당 테스트 파일) green
- [x] Conventional commits 규격
- [ ] 로컬 서버 재기동 후 `curl -s localhost:8935/metrics | rg 'masc_llm_(prompt|decode)_tok_per_sec'` 시리즈 존재 확인 (PR Ready 전환 직전에)

🤖 Generated with [Claude Code](https://claude.com/claude-code)