### PR TITLE
fix(tool_dispatch): did-you-mean suggestions for Unknown tool errors (#9784)

### DIFF
--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -552,13 +552,25 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         Tool_inline_dispatch.dispatch inline_ctx ~name
   in
 
+  (* #9784: enrich Unknown tool errors with closest-name suggestions so the
+     LLM can self-correct on the next turn rather than re-emit the same
+     hallucinated name. Suggestions come from a similarity scan of the
+     full tool registry. *)
+  let format_unknown_tool_error ~reason =
+    let suggestions = Tool_dispatch.find_similar_names ~query:name () in
+    match suggestions with
+    | [] -> Printf.sprintf "Unknown tool: %s (%s)" name reason
+    | xs ->
+        Printf.sprintf "Unknown tool: %s — did you mean: %s? (%s)"
+          name (String.concat ", " xs) reason
+  in
   (* Primary dispatch: mint token at I/O boundary, then O(1) tag lookup.
      Tool_token validates the name exists in the tag registry (Parse, Don't
      Validate). If mint fails, the tool is truly unknown. *)
   match Tool_dispatch.mint_token ~name with
   | Error reason ->
       with_system_internal_audit ~agent_name
-        (false, Printf.sprintf "Unknown tool: %s (%s)" name reason)
+        (false, format_unknown_tool_error ~reason)
   | Ok _token ->
       (* Token proves the name is registered in at least one registry.
          lookup_tag None after mint is a registry inconsistency (tool in

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -242,3 +242,40 @@ let mint_token ~name =
     Tool_token.mint_with
       ~validate:(fun n -> Hashtbl.mem tag_registry n || Hashtbl.mem registry n)
       ~name)
+
+(** Enumerate every tool name registered in either the tag_registry (primary)
+    or the handler registry (fallback). Used by [find_similar_names] to
+    drive "did you mean" suggestions for Unknown tool errors (#9784). *)
+let all_registered_names () =
+  with_dispatch_ro (fun () ->
+    let acc =
+      Hashtbl.fold (fun n _ a -> n :: a) tag_registry []
+    in
+    Hashtbl.fold
+      (fun n _ a -> if List.mem n a then a else n :: a)
+      registry acc)
+
+(* #9784: Unknown tool errors must include closest-name suggestions so the
+   LLM can self-correct on the next turn. Jaccard works well for snake_case
+   tool names because Text_similarity tokenizes on non-alphanumeric and
+   captures shared morphemes via byte n-grams. The default min_score 0.4
+   excludes unrelated names while accepting near-misses like
+   masc_claim_task -> masc_claim_next (Jaccard >= 0.5). *)
+let find_similar_names ?(limit = 3) ?(min_score = 0.4) ~query () =
+  let candidates = all_registered_names () in
+  let scored =
+    List.filter_map
+      (fun n ->
+        let s = Text_similarity.jaccard_similarity query n in
+        if s >= min_score then Some (s, n) else None)
+      candidates
+  in
+  let sorted =
+    List.sort (fun (a, _) (b, _) -> Float.compare b a) scored
+  in
+  let rec take k = function
+    | _ when k <= 0 -> []
+    | [] -> []
+    | (_, n) :: rest -> n :: take (k - 1) rest
+  in
+  take limit sorted

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -138,3 +138,16 @@ val tag_registry_count : unit -> int
 
 val mark_tag_registry_initialized : unit -> unit
 val is_tag_registry_initialized : unit -> bool
+
+(** {1 Did-you-mean Suggestions (#9784)} *)
+
+val all_registered_names : unit -> string list
+(** Every tool name registered in either the tag_registry or the
+    handler registry, deduplicated. Iteration order is unspecified. *)
+
+val find_similar_names :
+  ?limit:int -> ?min_score:float -> query:string -> unit -> string list
+(** Return up to [limit] (default 3) tool names from the registries with
+    [Text_similarity.jaccard_similarity] to [query] >= [min_score]
+    (default 0.4), sorted by similarity descending. Used to enrich
+    Unknown tool errors with self-correction hints for LLM clients. *)

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -198,4 +198,42 @@ let () =
               check bool "contains error info" true
                 (String.length msg > 0 && Astring.String.is_infix ~affix:"boom" msg));
         ] );
+      ( "did_you_mean_9784",
+        [
+          test_case "find_similar_names returns close match" `Quick (fun () ->
+              register_full ~tool_name:"__sim_masc_claim_next" ~handler:echo_handler;
+              register_full ~tool_name:"__sim_masc_add_task" ~handler:echo_handler;
+              register_full ~tool_name:"__sim_masc_join" ~handler:echo_handler;
+              let suggestions =
+                Tool_dispatch.find_similar_names
+                  ~query:"__sim_masc_claim_task" ()
+              in
+              check bool "non-empty suggestions" true
+                (List.length suggestions >= 1);
+              check bool "top suggestion is closest" true
+                (List.hd suggestions = "__sim_masc_claim_next"));
+          test_case "find_similar_names empty when nothing close" `Quick (fun () ->
+              let suggestions =
+                Tool_dispatch.find_similar_names
+                  ~query:"completely_different_xyzqq_unrelated" ()
+              in
+              check int "no suggestions" 0 (List.length suggestions));
+          test_case "find_similar_names respects limit" `Quick (fun () ->
+              for i = 1 to 5 do
+                register_full
+                  ~tool_name:(Printf.sprintf "__limit_test_tool_%d" i)
+                  ~handler:echo_handler
+              done;
+              let suggestions =
+                Tool_dispatch.find_similar_names ~limit:2
+                  ~query:"__limit_test_tool_1" ()
+              in
+              check bool "at most 2 returned" true
+                (List.length suggestions <= 2));
+          test_case "all_registered_names enumerates registry" `Quick (fun () ->
+              register_full ~tool_name:"__enum_check_xyz" ~handler:echo_handler;
+              let all = Tool_dispatch.all_registered_names () in
+              check bool "contains registered name" true
+                (List.mem "__enum_check_xyz" all));
+        ] );
     ]


### PR DESCRIPTION
## Summary

When an LLM hallucinates a tool name (e.g. `masc_claim_task` instead of `masc_claim_next`, observed in #9784 seq 55937), the server returns a terse `Unknown tool: <name>` message. The agent has no signal toward the correct name and typically retries the same hallucination next turn.

## Fix

Enrich the Unknown tool dispatch error with closest-name suggestions from the registry, sorted by Jaccard similarity over word tokens + 3/6-byte n-grams (existing `Text_similarity` module). Suggestions appear **inline in the error string** so the LLM sees them as part of the failed tool call result, per the validated `gate-response-llm-readable` and `tool-error-messages-teach-llm` patterns.

Example response transformation:

| Before | After |
|--------|-------|
| `Unknown tool: masc_claim_task (not in registry)` | `Unknown tool: masc_claim_task — did you mean: masc_claim_next, masc_add_task? (not in registry)` |
| `Unknown tool: masc_post (not in registry)` | `Unknown tool: masc_post — did you mean: masc_board_post, masc_post_message? (not in registry)` |

## Why Jaccard, why these thresholds

Looked at `git`-style Levenshtein but Jaccard via the existing `Text_similarity` module fits better for snake_case tool names: tokenizing on `_` captures shared morphemes (`masc`, `claim`) and the 3/6-byte n-grams catch substring overlaps. The module is already used in the codebase (Korean morpheme matching), so this PR adds no new dependency or string-distance implementation.

Tunables:
- **min_score 0.4** — captures `masc_claim_task` -> `masc_claim_next` (≈0.55) and `masc_post` -> `masc_board_post` (≈0.45) while excluding unrelated names.
- **limit 3** — bounded list keeps the error short.
- **descending similarity order** — best match first.

## API surface added (in `lib/tool_dispatch.mli`)

```ocaml
val all_registered_names : unit -> string list
val find_similar_names :
  ?limit:int -> ?min_score:float -> query:string -> unit -> string list
```

Both delegate to the existing `dispatch_mu`-protected registries — no new global state, no new locks.

## Test plan

- [x] `dune build --root=. lib/` — clean
- [x] `dune exec test/test_tool_dispatch.exe` — 22/22 pass (18 existing + 4 new in `did_you_mean_9784` group)
- [x] verified closest-match: registered `__sim_masc_claim_next`, `__sim_masc_add_task`, `__sim_masc_join`; queried `__sim_masc_claim_task` -> top suggestion is `__sim_masc_claim_next`
- [x] verified threshold: query `completely_different_xyzqq_unrelated` against the same registry returns `[]`
- [x] verified limit: 5 similar tools registered, `~limit:2` returns at most 2

Closes #9784

## Follow-ups (not in this PR)

- #9785 (param name mismatch like `name` vs `tool_name`) is the same root pattern at the schema level. A follow-up PR can wire similar suggestions into `Tool_input_validation` for missing-required-param errors.