### PR TITLE
fix(dashboard): restore mission_briefing TTL, cache transport-health, memoize board

### DIFF
--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -33,52 +33,60 @@ let dashboard_memory_http_json request : Yojson.Safe.t =
   in
   let limit = int_query_param request "limit" ~default:100 |> clamp ~min_v:1 ~max_v:500 in
   let offset = int_query_param request "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
-  let base_fetch = board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset in
-  (* Fetch one extra beyond the requested page so we can answer has_more
-     without a second query. total is only emitted when the result fits
-     entirely inside the fetched window — otherwise null (unknown). *)
-  let probe_fetch = base_fetch + 1 in
-  let posts =
-    Board_dispatch.list_posts ?hearth ~sort_by ~exclude_system
-      ~exclude_automation ?author_filter ~limit:probe_fetch ()
+  let cache_key =
+    Printf.sprintf "board:memory:%s;%s;%s;%b;%b;%d;%d"
+      (Option.value ~default:"-" hearth)
+      (Option.value ~default:"-" author_filter)
+      (board_sort_label sort_by)
+      exclude_system exclude_automation limit offset
   in
-  let karma_map = Board_dispatch.get_all_karma () in
-  let get_karma author =
-    Option.value ~default:0 (List.assoc_opt author karma_map)
-  in
-  let fetched_len = List.length posts in
-  let window_end = offset + limit in
-  let has_more = fetched_len > window_end in
-  let total_json : Yojson.Safe.t =
-    if has_more then `Null else `Int fetched_len
-  in
-  let paged = posts |> drop offset |> take limit in
-  let posts_json =
-    List.map
-      (fun (post : Board.post) ->
-        let author = Board.Agent_id.to_string post.author in
-        board_post_dashboard_json ~author_karma:(get_karma author) post)
-      paged
-  in
-  `Assoc
-    [
-      ("generated_at", `String (Types.now_iso ()));
-      ( "summary",
-        `Assoc
-          [
-            ("visible_posts", `Int (List.length posts_json));
-            ("sort_by", `String (board_sort_label sort_by));
-            ("exclude_system", `Bool exclude_system);
-            ("exclude_automation", `Bool exclude_automation);
-          ] );
-      ("posts", `List posts_json);
-      ("count", `Int (List.length posts_json));
-      ("limit", `Int limit);
-      ("offset", `Int offset);
-      ("has_more", `Bool has_more);
-      ("total", total_json);
-      ("sort_by", `String (board_sort_label sort_by));
-    ]
+  Dashboard_cache.get_or_compute cache_key ~ttl:10.0 (fun () ->
+    let base_fetch = board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset in
+    (* Fetch one extra beyond the requested page so we can answer has_more
+       without a second query. total is only emitted when the result fits
+       entirely inside the fetched window — otherwise null (unknown). *)
+    let probe_fetch = base_fetch + 1 in
+    let posts =
+      Board_dispatch.list_posts ?hearth ~sort_by ~exclude_system
+        ~exclude_automation ?author_filter ~limit:probe_fetch ()
+    in
+    let karma_map = Board_dispatch.get_all_karma () in
+    let get_karma author =
+      Option.value ~default:0 (List.assoc_opt author karma_map)
+    in
+    let fetched_len = List.length posts in
+    let window_end = offset + limit in
+    let has_more = fetched_len > window_end in
+    let total_json : Yojson.Safe.t =
+      if has_more then `Null else `Int fetched_len
+    in
+    let paged = posts |> drop offset |> take limit in
+    let posts_json =
+      List.map
+        (fun (post : Board.post) ->
+          let author = Board.Agent_id.to_string post.author in
+          board_post_dashboard_json ~author_karma:(get_karma author) post)
+        paged
+    in
+    `Assoc
+      [
+        ("generated_at", `String (Types.now_iso ()));
+        ( "summary",
+          `Assoc
+            [
+              ("visible_posts", `Int (List.length posts_json));
+              ("sort_by", `String (board_sort_label sort_by));
+              ("exclude_system", `Bool exclude_system);
+              ("exclude_automation", `Bool exclude_automation);
+            ] );
+        ("posts", `List posts_json);
+        ("count", `Int (List.length posts_json));
+        ("limit", `Int limit);
+        ("offset", `Int offset);
+        ("has_more", `Bool has_more);
+        ("total", total_json);
+        ("sort_by", `String (board_sort_label sort_by));
+      ])
 
 let dashboard_memory_subsystems_http_json ~(config : Coord_utils.config) request
     : Yojson.Safe.t =

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -674,7 +674,7 @@ let dashboard_mission_briefing_http_json ~state ~sw ~clock request =
       dashboard_cache_key state.Mcp_server.room_config "mission_briefing"
         (Option.value ~default:"" actor)
     in
-    Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:5.0
+    Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:120.0
       ~clock ~timeout_sec:dashboard_mission_timeout_s compute
 
 let dashboard_shell_status_json (config : Coord.config) : Yojson.Safe.t =

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -474,9 +474,7 @@ let transport_health_cache_diagnostics () =
       | _ -> [])
   | _ -> []
 
-let dashboard_transport_health_http_json ~state =
-  let live_json =
-    Transport_metrics.transport_health_json ~config:state.Mcp_server.room_config
-  in
-  extend_projection_diagnostics live_json
-    (("source", `String "live_metrics") :: transport_health_cache_diagnostics ())
+let dashboard_transport_health_http_json ~state:_ =
+  let json = cached_surface_json _transport_health_cache in
+  extend_projection_diagnostics json
+    (("source", `String "cached_surface") :: transport_health_cache_diagnostics ())

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -658,10 +658,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
 
       | `GET, "/api/v1/dashboard/transport-health" ->
           let state = get_server_state () in
-          let json =
-            Transport_metrics.transport_health_json
-              ~config:state.Mcp_server.room_config
-          in
+          let json = dashboard_transport_health_http_json ~state in
           h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
 
       | `GET, "/api/v1/dashboard/perf" ->


### PR DESCRIPTION
## 요약

`base_path=~/me`(2.6GB / 116K 파일) 환경에서 대시보드 페이지 로딩이 25초 가까이 멈추는 증상을 만드는 Tier 1 3건을 한 PR에서 처리. 코드 변경은 모두 엔드포인트 한 개씩 blast radius가 국한되며 `DashboardCacheStampede.tla` 불변식과 `stale_factor` 상수는 건드리지 않음.

### 증상 (실측)

| 엔드포인트 | Before |
|-----------|--------|
| `/api/v1/dashboard/mission/briefing` | **20s HTTP 000 (timeout)** |
| `/api/v1/dashboard/board` | 2.2s / 467KB |
| `/api/v1/dashboard/transport-health` | 3.2s / 2.6KB |

서버 로그에 `WARN cache compute timeout: mission_briefing:...:default: (25s)` 와 `ERROR cache revalidation failed: Compute_timeout` 이 반복.

## 변경 내역 (3 커밋)

### 1) `fix(dashboard): restore mission_briefing external cache TTL to 120s`
`server_dashboard_http_core.ml:677` 의 `~ttl:5.0` 을 `~ttl:120.0` 으로 복원 (동 파일 다른 mission 엔드포인트와 동일). 내부 `cache_state`(`briefing_cache_ttl_sec=300` 기본값)가 이미 compute를 흡수하고 있으나 외부 5s 미스가 이를 무력화하고 매 요청을 25s timeout에 태우고 있었음.

### 2) `fix(dashboard): serve transport-health from cached_surface`
`dashboard_transport_health_http_json` 과 H2 gateway 경로가 `Transport_metrics.transport_health_json` 을 매 요청마다 라이브 호출. 내부의 `tcp_port_reachable` 은 gRPC + WS 두 포트에 대해 동기 `Unix.connect` — 포트 unreachable 시 OS SYN timeout 까지 Eio domain 블록.

`start_transport_health_refresh_loop` 가 이미 30s 주기로 `_transport_health_cache` 를 채우고 있음에도 핸들러가 이를 무시. 두 핸들러 모두 `cached_surface_json` 패턴(execution/operator 캐시와 동일)으로 전환.

### 3) `perf(dashboard): memoize board memory handler with 10s SWR`
`dashboard_memory_http_json` 이 매 요청마다 동일한 ~467KB payload 재직렬화. `Dashboard_cache.get_or_compute ~ttl:10.0` 로 wrap, 정규화된 query 파라미터로 키 구성. 10s staleness는 후속 PR의 `Coord_hooks` board-mutation invalidator(Tier 2.2)로 해소 예정.

## 기대 효과

| 엔드포인트 | After (warm) |
|-----------|--------------|
| `/api/v1/dashboard/mission/briefing` | 첫 호출 < 25s, warm < 100ms |
| `/api/v1/dashboard/board` | warm < 50ms |
| `/api/v1/dashboard/transport-health` | < 50ms |

Tier 2 (proactive mission_briefing warm loop + board mutation invalidation) 는 별 PR로 분리. Tier 3 (`tcp_port_reachable` async 리팩토링, board payload pruning) 는 별도 이슈로 추적.

## 검증

- `dune build @check --root .` no warnings/errors.
- `test_dashboard_mission_briefing`: 12/12 pass.
- `test_dashboard_cache`: 19/19 pass (stampede protection, timeout-safety 포함).
- `test_board_dispatch`: 27/27 pass.

## 위험 / 롤백

- **Stampede 스펙**: TTL 숫자만 변경, `Dashboard_cache.get_or_compute*` API 만 사용. 토큰/eviction 불변식 미변경.
- **`stale_factor = 3.0` 전역 상수**: 미변경.
- **force refresh 경로 (`?force=1`)**: Tier 1.1 변경과 무관, `with_dashboard_timeout` 직접 호출 경로 보존.
- **Board staleness 10s**: 쓰기 직후 노출 지연 — 후속 `on_board_mutation_fn` 훅(Tier 2.2)으로 해소.
- 각 커밋은 독립적으로 revert 가능.

## 후속 계획 (별도 PR)

- **Tier 2.1**: `start_mission_briefing_refresh_loop` 등록 (120s interval, 180s warm_delay).
- **Tier 2.2**: `Coord_hooks.on_board_mutation_fn` Atomic + board write 경로 훅.
- **Tier 3.1**: `Transport_metrics.tcp_port_reachable` async probe + 30s 캐시.

Plan 문서: `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-generic-lake.md`

## Test Plan

- [ ] 로컬 서버 재기동 후 curl 3종 실측 (`mission/briefing`, `board`, `transport-health`).
- [ ] 200s 대기 후 warm 상태 curl 각 3회, p95 < 100ms 확인.
- [ ] 로그에서 `mission_briefing.*Compute_timeout` 빈도 0 확인.
- [ ] 브라우저 dashboard 페이지 로딩 체감 개선 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)