### PR TITLE
[codex] fix MCP auth token binding

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -489,11 +489,12 @@ let missing_credential_error config ~agent_name ~token : masc_error =
 
 (** Verify a token.
 
-    Looks up the credential by exact [agent_name] match first.  Only
-    hard-coded legacy aliases (dashboard → dashboard-dev) are accepted
-    as a fallback.  The old nickname-prefix collapse
-    ([extract_agent_type_prefix]) has been removed from the verify
-    path entirely — UUID-based storage makes it unnecessary. *)
+    Looks up the credential by exact [agent_name] match first. If that
+    misses, hard-coded legacy aliases (dashboard → dashboard-dev) are
+    accepted. Generated nicknames may also use a token owned by their
+    stable prefix, but only when the supplied token itself resolves to
+    that prefix. This keeps joined nickname continuity without letting an
+    unrelated bearer token impersonate another generated family. *)
 let verify_token config ~agent_name ~token : (agent_credential, masc_error) result =
   let cred_opt =
     match load_credential config agent_name with
@@ -503,7 +504,18 @@ let verify_token config ~agent_name ~token : (agent_credential, masc_error) resu
         |> List.find_map (load_credential config)
   in
   match cred_opt with
-  | None -> Error (missing_credential_error config ~agent_name ~token)
+  | None -> (
+      match find_credential_by_token config ~token with
+      | Ok owner
+        when String.equal owner.agent_name (credential_agent_name agent_name) ->
+          Ok owner
+      | Ok owner ->
+          Error
+            (Unauthorized
+               (Printf.sprintf
+                  "No credential found for %s (bearer token belongs to %s)"
+                  agent_name owner.agent_name))
+      | Error e -> Error e)
   | Some cred ->
       let token_hash = sha256_hash token in
       if cred.token <> token_hash then

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -152,9 +152,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   in
 
   let token =
-    match arg_get_string_opt "token" with
-    | Some t -> Some t
-    | None -> auth_token
+    match auth_token with
+    | Some _ as token -> token
+    | None -> arg_get_string_opt "token"
   in
 
   let mode_gate_error =

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -175,12 +175,15 @@ let runtime_mcp_policy_with_masc_agent_name
                   ~value:agent_name headers
               in
               let headers =
-                match first_nonempty_env [ "MASC_INTERNAL_MCP_TOKEN" ] with
-                | Some token ->
+                match
+                  ( first_nonempty_env [ "MASC_INTERNAL_MCP_TOKEN" ],
+                    keeper_name_of_agent_name agent_name )
+                with
+                | Some token, Some _ ->
                     upsert_http_header
                       ~key:"x-masc-internal-token"
                       ~value:token headers
-                | None -> headers
+                | _ -> headers
               in
               let headers =
                 match keeper_name_of_agent_name agent_name with
@@ -252,6 +255,15 @@ let public_mcp_tools_of_oas_tools (tools : Oas.Tool.t list) =
 let tool_names_are_public_mcp (tool_names : string list) =
   tool_names <> [] && List.for_all Tool_catalog.is_public_mcp tool_names
 
+let public_mcp_tool_requires_bound_actor = function
+  | "masc_claim_next"
+  | "masc_transition"
+  | "masc_join"
+  | "masc_leave"
+  | "masc_plan_set_task" ->
+      true
+  | _ -> false
+
 let trim_nonempty_string raw =
   let trimmed = String.trim raw in
   if String.equal trimmed "" then None else Some trimmed
@@ -262,16 +274,28 @@ let trim_nonempty value =
 let first_nonempty_env names =
   List.find_map (fun name -> Sys.getenv_opt name |> trim_nonempty) names
 
-let public_mcp_runtime_policy_of_tool_names ?agent_name:_ (tool_names : string list) :
+let public_mcp_runtime_policy_of_tool_names ?agent_name (tool_names : string list) :
     Llm_provider.Llm_transport.runtime_mcp_policy option =
   let tool_names = dedupe_preserve_order tool_names in
   if not (tool_names_are_public_mcp tool_names) then
     None
   else
+    let agent_name = Option.bind agent_name trim_nonempty_string in
+    let keeper_name = Option.bind agent_name keeper_name_of_agent_name in
     let masc_headers =
-      match first_nonempty_env [ "MASC_INTERNAL_MCP_TOKEN" ] with
-      | Some token -> [ ("x-masc-internal-token", token) ]
-      | None ->
+      match
+        (keeper_name, first_nonempty_env [ "MASC_INTERNAL_MCP_TOKEN" ])
+      with
+      | Some keeper_name, Some token ->
+          let agent_header =
+            match agent_name with
+            | Some agent_name -> [ ("x-masc-agent-name", agent_name) ]
+            | None -> []
+          in
+          ("x-masc-internal-token", token)
+          :: ("x-masc-keeper-name", keeper_name)
+          :: agent_header
+      | _ ->
           (match first_nonempty_env [ "MASC_MCP_TOKEN" ] with
            | Some token -> [ ("Authorization", "Bearer " ^ token) ]
            | None -> [])
@@ -367,6 +391,30 @@ let resolve_tool_lane_for_oas_tools
   let public_tool_names = public_mcp_tool_names_of_oas_tools public_tools in
   let requested_agent_name =
     Option.bind agent_name trim_nonempty_string
+  in
+  let codex_keeper_bound_actor_tools =
+    match provider_cfg.kind, requested_agent_name with
+    | Llm_provider.Provider_config.Codex_cli, Some agent_name
+      when Option.is_some (keeper_name_of_agent_name agent_name) ->
+        List.filter public_mcp_tool_requires_bound_actor public_tool_names
+    | _ -> []
+  in
+  match codex_keeper_bound_actor_tools, tool_requirement with
+  | _ :: _ as bound_actor_tools, `Required ->
+      let detail =
+        Printf.sprintf
+          "codex_cli runtime MCP cannot carry keeper-bound auth headers for: %s"
+          (String.concat ", " bound_actor_tools)
+      in
+      Error (invalid_runtime_config "runtime_mcp_auth" detail)
+  | _ ->
+  let public_tool_names =
+    if codex_keeper_bound_actor_tools = [] then
+      public_tool_names
+    else
+      List.filter
+        (fun tool_name -> not (public_mcp_tool_requires_bound_actor tool_name))
+        public_tool_names
   in
   let runtime_mcp_policy =
     public_mcp_runtime_policy_of_tool_names

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -115,9 +115,12 @@ let should_stream_post_tools_call request body_str accept_mode =
 (** Inject or replace [_agent_name] in MCP [tools/call] arguments.
     For authenticated dashboard sessions, the HTTP-layer token owner is the
     canonical caller identity, so a stale browser-supplied [_agent_name]
-    must be overwritten. Legacy [agent_name] is left untouched because some
-    tools use it as a domain argument rather than caller identity. *)
-let inject_agent_name_into_body ?(rewrite_existing = false) ~agent_name body_str =
+    must be overwritten. The legacy argument-scoped [token] is also removed
+    when HTTP auth is present so stale MCP bodies cannot override the
+    transport token. Legacy [agent_name] is left untouched because some tools
+    use it as a domain argument rather than caller identity. *)
+let inject_agent_name_into_body ?(rewrite_existing = false) ?(strip_token = false)
+    ~agent_name body_str =
   try
     let json = Yojson.Safe.from_string body_str in
     let open Yojson.Safe.Util in
@@ -144,8 +147,17 @@ let inject_agent_name_into_body ?(rewrite_existing = false) ~agent_name body_str
           match args with
           | `Assoc fields ->
               let normalized_fields =
-                if rewrite_existing then
-                  List.filter (fun (key, _) -> not (String.equal key "_agent_name")) fields
+                let fields =
+                  if rewrite_existing then
+                    List.filter
+                      (fun (key, _) -> not (String.equal key "_agent_name"))
+                      fields
+                  else
+                    fields
+                in
+                if strip_token then
+                  List.filter (fun (key, _) -> not (String.equal key "token"))
+                    fields
                 else
                   fields
               in
@@ -183,6 +195,7 @@ let body_with_canonical_http_actor ~base_path ~auth_token request body_str =
   | Some agent ->
       inject_agent_name_into_body
         ~rewrite_existing:(Option.is_some auth_token)
+        ~strip_token:(Option.is_some auth_token)
         ~agent_name:agent body_str
 
 let handle_post_mcp ~deps ?(profile = Full) request reqd =

--- a/lib/server/server_mcp_transport_http.mli
+++ b/lib/server/server_mcp_transport_http.mli
@@ -44,7 +44,11 @@ val validate_mcp_session_delete_profile :
   profile:tool_profile -> string -> (unit, string) result
 val method_from_body : string -> string option
 val inject_agent_name_into_body :
-  ?rewrite_existing:bool -> agent_name:string -> string -> string
+  ?rewrite_existing:bool ->
+  ?strip_token:bool ->
+  agent_name:string ->
+  string ->
+  string
 val body_with_canonical_http_actor :
   base_path:string ->
   auth_token:string option ->

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -243,6 +243,27 @@ let test_verify_token_reports_token_owner_on_agent_mismatch () =
   | Error _, _ ->
       fail "create_token should succeed"
 
+let test_verify_token_allows_generated_alias_for_token_owner_prefix () =
+  let dir = setup_test_room () in
+  let create_result = Auth.create_token dir ~agent_name:"qa-king" ~role:Types.Worker in
+  let verify_result =
+    match create_result with
+    | Ok (raw_token, _) ->
+        Auth.verify_token dir ~agent_name:"qa-king-warm-heron" ~token:raw_token
+    | Error e -> Error e
+  in
+  cleanup_test_room dir;
+  match create_result, verify_result with
+  | Ok _, Ok cred ->
+      check string "token owner credential returned" "qa-king" cred.agent_name;
+      check bool "role preserved" true (cred.role = Types.Worker)
+  | Ok _, Error e ->
+      fail
+        (Printf.sprintf "generated alias should reuse owner token: %s"
+           (Types.masc_error_to_string e))
+  | Error _, _ ->
+      fail "create_token should succeed"
+
 let test_resolve_agent_from_token () =
   let dir = setup_test_room () in
   let create_result = Auth.create_token dir ~agent_name:"resolver" ~role:Types.Worker in
@@ -742,6 +763,8 @@ let () =
       test_case "verify wrong token" `Quick test_verify_wrong_token;
       test_case "verify token reports token owner on agent mismatch" `Quick
         test_verify_token_reports_token_owner_on_agent_mismatch;
+      test_case "verify token allows generated alias for owner prefix" `Quick
+        test_verify_token_allows_generated_alias_for_token_owner_prefix;
       test_case "resolve agent from token" `Quick test_resolve_agent_from_token;
       test_case "list credentials" `Quick test_list_credentials;
       test_case "delete credential" `Quick test_delete_credential;

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1811,6 +1811,68 @@ let test_execute_tool_add_task_with_admin_token_without_join () =
     (Types.task_status_to_string task.task_status);
   cleanup_dir base_path
 
+let test_execute_tool_http_auth_token_overrides_stale_argument_token () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  ignore (Masc_mcp.Coord.init state.room_config ~agent_name:None);
+  ignore (Masc_mcp.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
+  let raw_token =
+    match Masc_mcp.Auth.create_token base_path ~agent_name:"stable-admin" ~role:Types.Admin with
+    | Ok (token, _cred) -> token
+    | Error e -> Alcotest.fail (Types.masc_error_to_string e)
+  in
+  let ok, msg =
+    Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
+      ~name:"masc_status"
+      ~arguments:
+        (`Assoc
+          [
+            ("token", `String "stale-argument-token");
+          ])
+  in
+  Alcotest.(check bool) "status succeeds" true ok;
+  Alcotest.(check bool) "does not report stale token mismatch" false
+    (contains_substring msg "Token mismatch");
+  cleanup_dir base_path
+
+let test_execute_tool_legacy_argument_token_still_authorizes_without_http_auth () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  ignore (Masc_mcp.Coord.init state.room_config ~agent_name:None);
+  ignore (Masc_mcp.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
+  let raw_token =
+    match Masc_mcp.Auth.create_token base_path ~agent_name:"stable-admin" ~role:Types.Admin with
+    | Ok (token, _cred) -> token
+    | Error e -> Alcotest.fail (Types.masc_error_to_string e)
+  in
+  let ok, msg =
+    Mcp_eio.execute_tool_eio ~sw ~clock state
+      ~name:"masc_status"
+      ~arguments:
+        (`Assoc
+          [
+            ("token", `String raw_token);
+          ])
+  in
+  Alcotest.(check bool) "status succeeds" true ok;
+  Alcotest.(check bool) "status response returned" true
+    (String.length msg > 0);
+  cleanup_dir base_path
+
 let test_execute_tool_mcp_session_ignores_term_persistence () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2935,6 +2997,10 @@ let eio_tests = [
     test_execute_tool_transition_requires_auth_before_mutation;
   "add_task admin token works without join", `Quick,
     test_execute_tool_add_task_with_admin_token_without_join;
+  "http auth token overrides stale argument token", `Quick,
+    test_execute_tool_http_auth_token_overrides_stale_argument_token;
+  "legacy argument token still authorizes without http auth", `Quick,
+    test_execute_tool_legacy_argument_token_still_authorizes_without_http_auth;
   "mcp session ignores term persistence", `Quick, test_execute_tool_mcp_session_ignores_term_persistence;
   (* Legacy governance convo room test removed *)
 ]

--- a/test/test_mcp_session_coverage.ml
+++ b/test/test_mcp_session_coverage.ml
@@ -225,7 +225,7 @@ let test_body_with_canonical_http_actor_uses_token_owner () =
       in
       let request = Httpun.Request.create ~headers `POST "/messages" in
       let body =
-        {|{"jsonrpc":"2.0","method":"tools/call","params":{"name":"masc_keeper_status","arguments":{"_agent_name":"dashboard","name":"sangsu"}},"id":1}|}
+        {|{"jsonrpc":"2.0","method":"tools/call","params":{"name":"masc_keeper_status","arguments":{"_agent_name":"dashboard","token":"stale-token","name":"sangsu"}},"id":1}|}
       in
       let args =
         Http_transport.body_with_canonical_http_actor ~base_path:dir
@@ -236,6 +236,8 @@ let test_body_with_canonical_http_actor_uses_token_owner () =
       check (option string) "token owner rewrites stale dashboard actor"
         (Some "codex")
         (member "_agent_name" args |> to_string_option);
+      check (option string) "http auth strips stale argument token" None
+        (member "token" args |> to_string_option);
       check (option string) "tool target arg preserved" (Some "sangsu")
         (member "name" args |> to_string_option))
 

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1527,6 +1527,27 @@ let test_resolve_tool_lane_for_codex_cli_public_tools_with_agent_name_strips_run
         "expected codex_cli public MCP tools with agent_name to use runtime MCP lane"
   | Error err -> Alcotest.fail (Oas.Error.to_string err)
 
+let test_resolve_tool_lane_for_codex_cli_keeper_bound_public_tools_rejects () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  let tools =
+    [ make_named_noop_tool "masc_status"; make_named_noop_tool "masc_claim_next" ]
+  in
+  match
+    Oas_worker_exec.resolve_tool_lane_for_oas_tools
+      ~agent_name:"keeper-sangsu-agent"
+      ~provider_cfg:(make_codex_cli_provider_cfg ())
+      ~tools ()
+  with
+  | Ok _ ->
+      Alcotest.fail
+        "expected codex_cli keeper-bound public MCP tools to reject runtime lane"
+  | Error (Oas.Error.Config (Oas.Error.InvalidConfig { field; detail })) ->
+      Alcotest.(check string) "field" "runtime_mcp_auth" field;
+      Alcotest.(check bool) "detail mentions bound tool" true
+        (contains_substring ~needle:"masc_claim_next" detail)
+  | Error err -> Alcotest.fail (Oas.Error.to_string err)
+
 let test_resolve_tool_lane_for_kimi_cli_public_tools_uses_runtime_mcp_policy () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
   let tools =
@@ -1810,6 +1831,33 @@ let test_runtime_mcp_policy_with_masc_agent_name_prefers_internal_keeper_token (
             (Some "sangsu")
             (List.assoc_opt "x-masc-keeper-name" server.headers)
       | _ -> Alcotest.fail "expected single masc runtime server")
+
+let test_public_mcp_runtime_policy_binds_keeper_internal_headers () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "ambient-bearer-token" @@ fun () ->
+  match
+    Oas_worker_exec.public_mcp_runtime_policy_of_tool_names
+      ~agent_name:"keeper-sangsu-agent" [ "masc_status" ]
+  with
+  | Some policy -> (
+      match policy.servers with
+      | [ Llm_provider.Llm_transport.Http_server server ] ->
+          Alcotest.(check (option string)) "internal token injected"
+            (Some "internal-keeper-token")
+            (List.assoc_opt "x-masc-internal-token" server.headers);
+          Alcotest.(check (option string)) "keeper name injected"
+            (Some "sangsu")
+            (List.assoc_opt "x-masc-keeper-name" server.headers);
+          Alcotest.(check (option string)) "agent name injected"
+            (Some "keeper-sangsu-agent")
+            (List.assoc_opt "x-masc-agent-name" server.headers);
+          Alcotest.(check (option string)) "ambient bearer not mixed with internal"
+            None
+            (List.assoc_opt "Authorization" server.headers)
+      | _ -> Alcotest.fail "expected single masc runtime server")
+  | None -> Alcotest.fail "expected public MCP runtime policy"
+
 let test_runtime_mcp_policy_for_provider_skips_codex_cli_header_injection () =
   let policy =
     {
@@ -3242,6 +3290,10 @@ let () =
         "public MCP tools on codex_cli strip unsupported runtime MCP headers"
         `Quick
         test_resolve_tool_lane_for_codex_cli_public_tools_with_agent_name_strips_runtime_headers;
+      Alcotest.test_case
+        "keeper-bound public MCP tools on codex_cli reject runtime MCP lane"
+        `Quick
+        test_resolve_tool_lane_for_codex_cli_keeper_bound_public_tools_rejects;
       Alcotest.test_case "public MCP tools on kimi_cli use runtime MCP lane" `Quick
         test_resolve_tool_lane_for_kimi_cli_public_tools_uses_runtime_mcp_policy;
       Alcotest.test_case
@@ -3266,6 +3318,8 @@ let () =
         test_runtime_mcp_policy_with_masc_agent_name_upserts_header;
       Alcotest.test_case "runtime MCP policy injects internal keeper token when configured" `Quick
         test_runtime_mcp_policy_with_masc_agent_name_prefers_internal_keeper_token;
+      Alcotest.test_case "public MCP policy binds keeper internal headers" `Quick
+        test_public_mcp_runtime_policy_binds_keeper_internal_headers;
       Alcotest.test_case "provider-aware runtime MCP policy skips codex_cli agent header injection" `Quick
         test_runtime_mcp_policy_for_provider_skips_codex_cli_header_injection;
       Alcotest.test_case "kimi request runtime MCP config is merged" `Quick


### PR DESCRIPTION
## Summary
- Make HTTP MCP auth the source of truth for authenticated tool calls by stripping stale `arguments.token` values and preferring transport `auth_token` in execution.
- Allow generated aliases only when the bearer token resolves to the same stable owner prefix, while preserving owner-mismatch errors for unrelated tokens.
- Bind keeper runtime MCP calls to `x-masc-internal-token`, `x-masc-keeper-name`, and `x-masc-agent-name` when provider headers are supported; reject keeper-bound lifecycle tools on Codex CLI instead of silently dropping required headers.

## Root Cause
Internal MCP calls were authenticated twice. The HTTP layer could accept a valid bearer/internal token and canonicalize `_agent_name`, but tool execution still allowed stale JSON-RPC `arguments.token` or generated alias identity to drive the final auth check. That produced intermittent `Invalid token: Token mismatch` and owner-mismatch failures depending on which runtime path supplied headers or body arguments.

## Validation
- `dune build --cache disabled --root . --build-dir _build_auth_token_binding test/test_auth.exe test/test_mcp_session_coverage.exe test/test_mcp_server_eio.exe test/test_oas_worker.exe`
- `./_build_auth_token_binding/default/test/test_auth.exe`
- `./_build_auth_token_binding/default/test/test_mcp_session_coverage.exe`
- `./_build_auth_token_binding/default/test/test_oas_worker.exe`
- `./_build_auth_token_binding/default/test/test_mcp_server_eio.exe test eio 49,53-54`

## Notes
Full `test_mcp_server_eio.exe` still has two pre-existing failures outside this patch: the Eio context delegation check and a stale `done` message expectation after verifier redirect.