### PR TITLE
feat(exec): P21 keeper wiring — exec_cache integration

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -591,6 +591,7 @@ let run_docker_hardened_bash = Keeper_shell_docker.run_docker_hardened_bash
 let handle_keeper_bash
       ~(turn_sandbox_runtime : Keeper_turn_sandbox_runtime.t option)
       ~(turn_sandbox_runtime_git : Keeper_turn_sandbox_runtime.t option)
+      ~(exec_cache : Masc_exec.Exec_cache.t option)
       ~(config : Coord.config)
       ~(meta : keeper_meta)
       ~(args : Yojson.Safe.t)
@@ -1202,6 +1203,7 @@ let resolve_gh_repo_context = Keeper_shell_gh_context.resolve_gh_repo_context
 
 let handle_keeper_shell
       ~(turn_sandbox_runtime : Keeper_turn_sandbox_runtime.t option)
+      ~(exec_cache : Masc_exec.Exec_cache.t option)
       ~(config : Coord.config)
       ~(meta : keeper_meta)
       ~(args : Yojson.Safe.t)
@@ -2070,53 +2072,135 @@ let handle_keeper_shell
            (match Worker_dev_tools.validate_command_paths ~workdir:cwd cmd_str with
             | Error e -> path_error e
             | Ok () ->
-              let st, out =
-                match turn_sandbox_runtime with
-                | Some runtime ->
-                  (match
-                     Keeper_turn_sandbox_runtime.run_bash_with_status runtime
-                       ~cwd ~cmd:cmd_str ~timeout_sec ()
-                   with
-                   | Ok payload -> payload
-                   | Error msg -> (Unix.WEXITED 127, msg))
-                | None ->
-                  run_argv_with_status_retry_eintr ~cwd ~timeout_sec
-                    [ "bash"; "-lc"; cmd_str ^ " 2>&1" ]
-              in
-              if process_status_is_timeout st then
-                Yojson.Safe.to_string
-                  (Exec_core.process_result_json
-                     ~artifact_policy:Exec_core.Inline_only
-                     ~base_path:root
-                     ~keeper_name:meta.name
-                     ~cmd:cmd_str
-                     ~extra:
-                       [
-                         "op", `String op;
-                         "cwd", `String cwd;
-                         "command", `String cmd_str;
-                         "error", `String "command_timed_out";
-                         "timeout_sec", `Float timeout_sec;
-                       ]
-                     ~status:st
-                     ~output:out
-                     ())
-              else
-                Yojson.Safe.to_string
-                  (Exec_core.process_result_json
-                     ~artifact_policy:Exec_core.Inline_only
-                     ~base_path:root
-                     ~keeper_name:meta.name
-                     ~cmd:cmd_str
-                     ~extra:
-                       [
-                         "op", `String op;
-                         "cwd", `String cwd;
-                         "command", `String cmd_str;
-                       ]
-                     ~status:st
-                     ~output:out
-                     ()))))
+              (* P21: exec cache — skip execution on hit, store on miss *)
+              (match exec_cache with
+               | Some cache ->
+                 (match Masc_exec.Exec_cache.lookup cache cmd_str with
+                  | Some entry ->
+                    let st = Unix.WEXITED entry.exit_code in
+                    Yojson.Safe.to_string
+                      (Exec_core.process_result_json
+                         ~artifact_policy:Exec_core.Inline_only
+                         ~base_path:root
+                         ~keeper_name:meta.name
+                         ~cmd:cmd_str
+                         ~extra:
+                           [ "op", `String op
+                           ; "cwd", `String cwd
+                           ; "command", `String cmd_str
+                           ; "cached", `Bool true
+                           ; "cache_age_ms",
+                               `Int (int_of_float
+                                       ((Unix.time () -. entry.cached_at) *. 1000.))
+                           ]
+                         ~status:st
+                         ~output:entry.output
+                         ())
+                  | None ->
+                    let t0 = Unix.gettimeofday () in
+                    let st, out =
+                      match turn_sandbox_runtime with
+                      | Some runtime ->
+                        (match
+                           Keeper_turn_sandbox_runtime.run_bash_with_status runtime
+                             ~cwd ~cmd:cmd_str ~timeout_sec ()
+                         with
+                         | Ok payload -> payload
+                         | Error msg -> (Unix.WEXITED 127, msg))
+                      | None ->
+                        run_argv_with_status_retry_eintr ~cwd ~timeout_sec
+                          [ "bash"; "-lc"; cmd_str ^ " 2>&1" ]
+                    in
+                    let elapsed_ms =
+                      int_of_float ((Unix.gettimeofday () -. t0) *. 1000.)
+                    in
+                    if not (process_status_is_timeout st) then begin
+                      let exit_code = match st with
+                        | Unix.WEXITED n -> n
+                        | Unix.WSIGNALED n -> 128 + n
+                        | Unix.WSTOPPED n -> 256 + n
+                      in
+                      Masc_exec.Exec_cache.store cache
+                        ~cmd:cmd_str ~exit_code ~output:out ~duration_ms:elapsed_ms
+                    end;
+                    if process_status_is_timeout st then
+                      Yojson.Safe.to_string
+                        (Exec_core.process_result_json
+                           ~artifact_policy:Exec_core.Inline_only
+                           ~base_path:root
+                           ~keeper_name:meta.name
+                           ~cmd:cmd_str
+                           ~extra:
+                             [ "op", `String op
+                             ; "cwd", `String cwd
+                             ; "command", `String cmd_str
+                             ; "error", `String "command_timed_out"
+                             ; "timeout_sec", `Float timeout_sec
+                             ]
+                           ~status:st
+                           ~output:out
+                           ())
+                    else
+                      Yojson.Safe.to_string
+                        (Exec_core.process_result_json
+                           ~artifact_policy:Exec_core.Inline_only
+                           ~base_path:root
+                           ~keeper_name:meta.name
+                           ~cmd:cmd_str
+                           ~extra:
+                             [ "op", `String op
+                             ; "cwd", `String cwd
+                             ; "command", `String cmd_str
+                             ]
+                           ~status:st
+                           ~output:out
+                           ()))
+               | None ->
+                 let st, out =
+                   match turn_sandbox_runtime with
+                   | Some runtime ->
+                     (match
+                        Keeper_turn_sandbox_runtime.run_bash_with_status runtime
+                          ~cwd ~cmd:cmd_str ~timeout_sec ()
+                      with
+                      | Ok payload -> payload
+                      | Error msg -> (Unix.WEXITED 127, msg))
+                   | None ->
+                     run_argv_with_status_retry_eintr ~cwd ~timeout_sec
+                       [ "bash"; "-lc"; cmd_str ^ " 2>&1" ]
+                 in
+                 if process_status_is_timeout st then
+                   Yojson.Safe.to_string
+                     (Exec_core.process_result_json
+                        ~artifact_policy:Exec_core.Inline_only
+                        ~base_path:root
+                        ~keeper_name:meta.name
+                        ~cmd:cmd_str
+                        ~extra:
+                          [ "op", `String op
+                          ; "cwd", `String cwd
+                          ; "command", `String cmd_str
+                          ; "error", `String "command_timed_out"
+                          ; "timeout_sec", `Float timeout_sec
+                          ]
+                        ~status:st
+                        ~output:out
+                        ())
+                 else
+                   Yojson.Safe.to_string
+                     (Exec_core.process_result_json
+                        ~artifact_policy:Exec_core.Inline_only
+                        ~base_path:root
+                        ~keeper_name:meta.name
+                        ~cmd:cmd_str
+                        ~extra:
+                          [ "op", `String op
+                          ; "cwd", `String cwd
+                          ; "command", `String cmd_str
+                          ]
+                        ~status:st
+                        ~output:out
+                        ())))))
   | "git_clone" ->
     (* Clone a repo into this keeper's playground repos directory.
        Sandboxed: always targets .masc/playground/<keeper_name>/repos/<repo_name>.

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -1041,6 +1041,77 @@ let handle_keeper_bash
                    else None
                  with
                  | None ->
+                   (* P21: exec cache for foreground path *)
+                   (match exec_cache with
+                    | Some cache ->
+                      (match Masc_exec.Exec_cache.lookup cache cmd with
+                       | Some entry ->
+                         let st = Unix.WEXITED entry.exit_code in
+                         Yojson.Safe.to_string
+                           (Exec_core.process_result_json
+                              ~base_path:root
+                              ~keeper_name:meta.name
+                              ~cmd
+                              ~extra:[
+                                "cwd", `String cwd;
+                                "execution_time_ms", `Int entry.duration_ms;
+                                "cached", `Bool true;
+                                "cache_age_ms",
+                                  `Int (int_of_float
+                                          ((Unix.time () -. entry.cached_at) *. 1000.));
+                              ]
+                              ~status:st
+                              ~output:entry.output
+                              ~env_snapshot:env_snap
+                              ())
+                       | None ->
+                         let t0 = Unix.gettimeofday () in
+                         let st, out =
+                           Process_eio.run_argv_with_status
+                             ~cwd ~timeout_sec argv_merged
+                         in
+                         let elapsed_ms =
+                           int_of_float ((Unix.gettimeofday () -. t0) *. 1000.)
+                         in
+                         if not (process_status_is_timeout st) then begin
+                           let exit_code = match st with
+                             | Unix.WEXITED n -> n
+                             | Unix.WSIGNALED n -> 128 + n
+                             | Unix.WSTOPPED n -> 256 + n
+                           in
+                           Masc_exec.Exec_cache.store cache
+                             ~cmd ~exit_code ~output:out ~duration_ms:elapsed_ms
+                         end;
+                         (if auto_bg_observe_enabled then begin
+                            let budget_ms =
+                              Masc_exec.Exec_run.default_budget_ms ()
+                            in
+                            let promoted_candidate = elapsed_ms >= budget_ms in
+                            Legendary_counters.incr_auto_bg_observed
+                              ~promoted_candidate;
+                            if promoted_candidate then
+                              Log.Keeper.info
+                                "auto_bg_would_have_promoted keeper=%s \
+                                 cmd_hash=%s duration_ms=%d budget_ms=%d"
+                                meta.name
+                                (Worker_dev_tools.cmd_hash_for_log cmd)
+                                elapsed_ms
+                                budget_ms
+                          end);
+                         Yojson.Safe.to_string
+                           (Exec_core.process_result_json
+                              ~base_path:root
+                              ~keeper_name:meta.name
+                              ~cmd
+                              ~extra:[
+                                "cwd", `String cwd;
+                                "execution_time_ms", `Int elapsed_ms;
+                              ]
+                              ~status:st
+                              ~output:out
+                              ~env_snapshot:env_snap
+                              ()))
+                    | None ->
                    let t0 = Unix.gettimeofday () in
                    let st, out =
                      Process_eio.run_argv_with_status
@@ -1077,7 +1148,7 @@ let handle_keeper_bash
                         ~status:st
                         ~output:out
                         ~env_snapshot:env_snap
-                        ())
+                        ()))
                  | Some clock ->
                    let budget_ms = Masc_exec.Exec_run.default_budget_ms () in
                    let t0_bg = Unix.gettimeofday () in
@@ -1098,6 +1169,18 @@ let handle_keeper_bash
                       let elapsed_ms =
                         int_of_float ((Unix.gettimeofday () -. t0_bg) *. 1000.)
                       in
+                      (* P21: store in exec cache if not a timeout *)
+                      if not (process_status_is_timeout r.status) then
+                        (match exec_cache with
+                         | Some cache ->
+                           let exit_code = match r.status with
+                             | Unix.WEXITED n -> n
+                             | Unix.WSIGNALED n -> 128 + n
+                             | Unix.WSTOPPED n -> 256 + n
+                           in
+                           Masc_exec.Exec_cache.store cache
+                             ~cmd ~exit_code ~output:r.stdout ~duration_ms:elapsed_ms
+                         | None -> ());
                       Yojson.Safe.to_string
                         (Exec_core.process_result_json
                            ~base_path:root

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -51,6 +51,7 @@ val cmd_targets_git_or_gh : string -> bool
 val handle_keeper_bash :
   turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
   turn_sandbox_runtime_git:Keeper_turn_sandbox_runtime.t option ->
+  exec_cache:Masc_exec.Exec_cache.t option ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   args:Yojson.Safe.t ->
@@ -75,6 +76,7 @@ val handle_keeper_bash_kill :
 
 val handle_keeper_shell :
   turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
+  exec_cache:Masc_exec.Exec_cache.t option ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   args:Yojson.Safe.t ->

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -114,6 +114,7 @@ let execute_keeper_tool_call_with_outcome
       ~(ctx_work : working_context)
       ?turn_sandbox_runtime
       ?turn_sandbox_runtime_git
+      ~(exec_cache : Masc_exec.Exec_cache.t option)
       ?search_fn
       ~(name : string)
       ~(input : Yojson.Safe.t)
@@ -248,7 +249,7 @@ let execute_keeper_tool_call_with_outcome
     | "keeper_bash" ->
       make_executed_tool_result
         (Keeper_exec_shell.handle_keeper_bash
-           ~turn_sandbox_runtime ~turn_sandbox_runtime_git ~config ~meta ~args
+           ~turn_sandbox_runtime ~turn_sandbox_runtime_git ~exec_cache ~config ~meta ~args
            ())
     | "keeper_bash_output" ->
       make_executed_tool_result
@@ -258,7 +259,7 @@ let execute_keeper_tool_call_with_outcome
         (Keeper_exec_shell.handle_keeper_bash_kill ~config ~meta ~args)
     | "keeper_shell" ->
       make_executed_tool_result
-        (Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime ~config ~meta ~args)
+        (Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime ~exec_cache ~config ~meta ~args)
     | "keeper_voice_speak"
     | "keeper_voice_listen"
     | "keeper_voice_agent"
@@ -358,6 +359,7 @@ let execute_keeper_tool_call
       ~(ctx_work : working_context)
       ?turn_sandbox_runtime
       ?turn_sandbox_runtime_git
+      ~(exec_cache : Masc_exec.Exec_cache.t option)
       ?search_fn
       ~(name : string)
       ~(input : Yojson.Safe.t)
@@ -367,6 +369,6 @@ let execute_keeper_tool_call
   let result =
     execute_keeper_tool_call_with_outcome
       ~config ~meta ~ctx_work ?turn_sandbox_runtime ?turn_sandbox_runtime_git
-      ?search_fn ~name ~input ()
+      ~exec_cache ?search_fn ~name ~input ()
   in
   result.raw_output

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -158,6 +158,7 @@ val execute_keeper_tool_call_with_outcome :
   ctx_work:working_context ->
   ?turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t ->
   ?turn_sandbox_runtime_git:Keeper_turn_sandbox_runtime.t ->
+  exec_cache:Masc_exec.Exec_cache.t option ->
   ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t) ->
   name:string ->
   input:Yojson.Safe.t ->
@@ -170,6 +171,7 @@ val execute_keeper_tool_call :
   ctx_work:working_context ->
   ?turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t ->
   ?turn_sandbox_runtime_git:Keeper_turn_sandbox_runtime.t ->
+  exec_cache:Masc_exec.Exec_cache.t option ->
   ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t) ->
   name:string ->
   input:Yojson.Safe.t ->

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -159,6 +159,7 @@ let make_keeper_tool_handler
     ~(ctx_snapshot : Keeper_types.working_context)
     ?turn_sandbox_runtime
     ?turn_sandbox_runtime_git
+    ~(exec_cache : Masc_exec.Exec_cache.t option)
     ?search_fn
     ?on_tool_called
     ?(translate_input = fun j -> j)
@@ -192,6 +193,7 @@ let make_keeper_tool_handler
               ~config ~meta ~ctx_work:ctx_snapshot
               ?turn_sandbox_runtime
               ?turn_sandbox_runtime_git
+              ~exec_cache
               ?search_fn
               ~name ~input ())
         in
@@ -400,6 +402,7 @@ let make_tool_bundle
         Some (Keeper_turn_sandbox_runtime.create ~config ~meta ~network_mode:Network_inherit ())
     | Keeper_types.Local -> None
   in
+  let exec_cache = Some (Masc_exec.Exec_cache.create ()) in
   (* Build Tool.t for the full universe so BM25 and Tool_op can
      discover tools beyond the active preset.  Progressive disclosure
      (AllowList filter in before_turn_hook) controls LLM visibility;
@@ -441,6 +444,7 @@ let make_tool_bundle
           (make_keeper_tool_handler ~name:td.name ~config ~meta ~ctx_snapshot
              ?turn_sandbox_runtime
              ?turn_sandbox_runtime_git
+             ~exec_cache
              ?search_fn ?on_tool_called ~failure_counts ()))
       else None
     ) tool_defs
@@ -472,6 +476,7 @@ let make_tool_bundle
             (make_keeper_tool_handler ~name:internal ~config ~meta ~ctx_snapshot
                ?turn_sandbox_runtime
                ?turn_sandbox_runtime_git
+               ~exec_cache
                ?search_fn ?on_tool_called
                ~translate_input:(fun j ->
                  Keeper_tool_alias.translate_input ~public j)

--- a/test/dune
+++ b/test/dune
@@ -13,7 +13,10 @@
    ; Avoid non-deterministic external network calls during unit tests.
    (GRAPHQL_API_KEY "")
    (ZAI_API_KEY "")
-   (MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED false))))
+   (MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED false)
+   ; Docker playground upgrades Local→Docker in effective_sandbox_profile.
+   ; Disable to ensure keeper_bash tests run through the local path.
+   (MASC_KEEPER_DOCKER_PLAYGROUND false))))
 
 ; ============================================================
 ; All standard tests share the masc_test_deps wrapper library

--- a/test/test_keeper_accountability.ml
+++ b/test/test_keeper_accountability.ml
@@ -403,7 +403,7 @@ let test_claim_tool_exposes_routing_warning_for_high_risk_keeper () =
       ignore (Coord.add_task config ~title:"Task to claim" ~priority:1 ~description:"desc");
       let result =
         Keeper_exec_tools.execute_keeper_tool_call
-          ~config ~meta ~ctx_work:(make_ctx_work ())
+          ~config ~meta ~ctx_work:(make_ctx_work ()) ~exec_cache:None
           ~name:"keeper_task_claim" ~input:(`Assoc []) ()
         |> Yojson.Safe.from_string
       in
@@ -433,7 +433,7 @@ let test_preflight_exposes_routing_hint_for_high_risk_keeper () =
            ]);
       let result =
         Keeper_exec_tools.execute_keeper_tool_call
-          ~config ~meta ~ctx_work:(make_ctx_work ())
+          ~config ~meta ~ctx_work:(make_ctx_work ()) ~exec_cache:None
           ~name:"keeper_preflight_check" ~input:(`Assoc []) ()
         |> Yojson.Safe.from_string
       in

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -321,7 +321,7 @@ let test_docker_blocks_nested_docker_command () =
   let raw =
     Keeper_exec_shell.handle_keeper_bash
       ~turn_sandbox_runtime:None
-      ~turn_sandbox_runtime_git:None
+      ~turn_sandbox_runtime_git:None ~exec_cache:None
       ~config ~meta
       ~args:(`Assoc [ ("cmd", `String "docker run --rm alpine true") ]) ()
   in
@@ -342,7 +342,7 @@ let test_docker_blocks_docker_socket_reference () =
   let raw =
     Keeper_exec_shell.handle_keeper_bash
       ~turn_sandbox_runtime:None
-      ~turn_sandbox_runtime_git:None
+      ~turn_sandbox_runtime_git:None ~exec_cache:None
       ~config ~meta
       ~args:(`Assoc [ ("cmd", `String "cat /var/run/docker.sock") ]) ()
   in
@@ -366,7 +366,7 @@ let test_docker_missing_seccomp_profile_fails_closed () =
       let raw =
         Keeper_exec_shell.handle_keeper_bash
           ~turn_sandbox_runtime:None
-          ~turn_sandbox_runtime_git:None
+          ~turn_sandbox_runtime_git:None ~exec_cache:None
           ~config ~meta
           ~args:(`Assoc [ ("cmd", `String "pwd") ]) ()
       in
@@ -440,7 +440,7 @@ let test_keeper_shell_ls_recovers_doubled_playground_prefix () =
   in
   let raw =
     Keeper_exec_shell.handle_keeper_shell
-      ~turn_sandbox_runtime:None
+      ~turn_sandbox_runtime:None ~exec_cache:None
       ~config ~meta
       ~args:(`Assoc [
         ("op", `String "ls");
@@ -463,7 +463,7 @@ let test_readonly_chaining_hint_lists_subops () =
   let meta = make_readonly_meta "chain-hint" in
   let raw =
     Keeper_exec_shell.handle_keeper_shell
-      ~turn_sandbox_runtime:None
+      ~turn_sandbox_runtime:None ~exec_cache:None
       ~config ~meta
       ~args:(`Assoc [
         ("op", `String "bash");
@@ -492,7 +492,7 @@ let test_readonly_redirect_hint_points_at_fs_edit () =
   let meta = make_readonly_meta "redirect-hint" in
   let raw =
     Keeper_exec_shell.handle_keeper_shell
-      ~turn_sandbox_runtime:None
+      ~turn_sandbox_runtime:None ~exec_cache:None
       ~config ~meta
       ~args:(`Assoc [
         ("op", `String "bash");
@@ -564,7 +564,7 @@ let test_bash_missing_cmd_field () =
   let raw =
     Keeper_exec_shell.handle_keeper_bash
       ~turn_sandbox_runtime:None
-      ~turn_sandbox_runtime_git:None
+      ~turn_sandbox_runtime_git:None ~exec_cache:None
       ~config ~meta
       ~args:(`Assoc [ ("run_in_background", `Bool false) ]) ()
   in
@@ -583,7 +583,7 @@ let test_shell_missing_op_field () =
   let meta = make_readonly_meta "missing-op" in
   let raw =
     Keeper_exec_shell.handle_keeper_shell
-      ~turn_sandbox_runtime:None
+      ~turn_sandbox_runtime:None ~exec_cache:None
       ~config ~meta
       ~args:(`Assoc [ ("path", `String "/some/path") ])
   in
@@ -602,7 +602,7 @@ let test_shell_unsupported_op () =
   let meta = make_readonly_meta "bad-op" in
   let raw =
     Keeper_exec_shell.handle_keeper_shell
-      ~turn_sandbox_runtime:None
+      ~turn_sandbox_runtime:None ~exec_cache:None
       ~config ~meta
       ~args:(`Assoc [
         ("op", `String "definitely_not_a_real_op");

--- a/test/test_keeper_exec_tools.ml
+++ b/test/test_keeper_exec_tools.ml
@@ -114,7 +114,7 @@ let test_execute_with_outcome_policy_gate_is_non_failure () =
     (fun ~config ~meta ~ctx_work ->
       let result =
         KET.execute_keeper_tool_call_with_outcome
-          ~config ~meta ~ctx_work
+          ~config ~meta ~ctx_work ~exec_cache:None
           ~name:"keeper_fs_read"
           ~input:(`Assoc [ ("path", `String "blocked.txt") ])
           ()
@@ -132,7 +132,7 @@ let test_execute_with_outcome_missing_file_is_failure () =
     (fun ~config ~meta ~ctx_work ->
       let result =
         KET.execute_keeper_tool_call_with_outcome
-          ~config ~meta ~ctx_work
+          ~config ~meta ~ctx_work ~exec_cache:None
           ~name:"keeper_fs_read"
           ~input:(`Assoc [ ("path", `String "missing.txt") ])
           ()
@@ -147,7 +147,7 @@ let test_execute_with_outcome_bad_query_is_failure () =
     (fun ~config ~meta ~ctx_work ->
       let result =
         KET.execute_keeper_tool_call_with_outcome
-          ~config ~meta ~ctx_work
+          ~config ~meta ~ctx_work ~exec_cache:None
           ~name:"keeper_tool_search"
           ~input:(`Assoc [ ("query", `String "") ])
           ()

--- a/test/test_keeper_exec_tools.ml
+++ b/test/test_keeper_exec_tools.ml
@@ -157,6 +157,98 @@ let test_execute_with_outcome_bad_query_is_failure () =
       check string "bad query payload shape" "structured_error"
         (payload_kind result.payload_shape))
 
+(* ── Exec cache integration tests ──────────────────────────── *)
+
+let test_exec_cache_miss_then_hit () =
+  with_exec_fixture "keeper_exec_cache_hit"
+    (fun ~config ~meta ~ctx_work ->
+      let cache = Masc_exec.Exec_cache.create () in
+      let result1 =
+        KET.execute_keeper_tool_call
+          ~config ~meta ~ctx_work ~exec_cache:(Some cache)
+          ~name:"keeper_bash"
+          ~input:(`Assoc [ ("cmd", `String "echo hello_cache_test") ])
+          ()
+      in
+      let json1 = Yojson.Safe.from_string result1 in
+      (* First call: no cached field *)
+      check bool "first call not cached"
+        true
+        (match Yojson.Safe.Util.member "cached" json1 with
+         | `Bool true -> false
+         | _ -> true);
+      (* Second call with same command: should hit cache *)
+      let result2 =
+        KET.execute_keeper_tool_call
+          ~config ~meta ~ctx_work ~exec_cache:(Some cache)
+          ~name:"keeper_bash"
+          ~input:(`Assoc [ ("cmd", `String "echo hello_cache_test") ])
+          ()
+      in
+      let json2 = Yojson.Safe.from_string result2 in
+      check bool "second call cached"
+        true
+        (match Yojson.Safe.Util.member "cached" json2 with
+         | `Bool true -> true
+         | _ -> false);
+      (* Cache stats: 1 hit, 1 miss *)
+      let hits, misses = Masc_exec.Exec_cache.stats cache in
+      check int "cache hits" 1 hits;
+      check int "cache misses" 1 misses)
+
+let test_exec_cache_none_no_caching () =
+  with_exec_fixture "keeper_exec_cache_none"
+    (fun ~config ~meta ~ctx_work ->
+      (* With exec_cache=None, two identical calls both execute *)
+      let result1 =
+        KET.execute_keeper_tool_call
+          ~config ~meta ~ctx_work ~exec_cache:None
+          ~name:"keeper_bash"
+          ~input:(`Assoc [ ("cmd", `String "echo no_cache_test") ])
+          ()
+      in
+      let json1 = Yojson.Safe.from_string result1 in
+      let result2 =
+        KET.execute_keeper_tool_call
+          ~config ~meta ~ctx_work ~exec_cache:None
+          ~name:"keeper_bash"
+          ~input:(`Assoc [ ("cmd", `String "echo no_cache_test") ])
+          ()
+      in
+      let json2 = Yojson.Safe.from_string result2 in
+      (* Neither should have cached:true *)
+      check bool "first call not cached"
+        true
+        (match Yojson.Safe.Util.member "cached" json1 with
+         | `Bool true -> false
+         | _ -> true);
+      check bool "second call not cached"
+        true
+        (match Yojson.Safe.Util.member "cached" json2 with
+         | `Bool true -> false
+         | _ -> true))
+
+let test_exec_cache_stats_json () =
+  let cache = Masc_exec.Exec_cache.create () in
+  let json = Masc_exec.Exec_cache.to_json cache in
+  check int "initial hit_count" 0
+    Yojson.Safe.Util.(member "hit_count" json |> to_int);
+  check int "initial miss_count" 0
+    Yojson.Safe.Util.(member "miss_count" json |> to_int);
+  check int "initial entry_count" 0
+    Yojson.Safe.Util.(member "entry_count" json |> to_int);
+  (* Store an entry and check *)
+  Masc_exec.Exec_cache.store cache ~cmd:"test_cmd" ~exit_code:0
+    ~output:"test output" ~duration_ms:100;
+  let json2 = Masc_exec.Exec_cache.to_json cache in
+  check int "after store entry_count" 1
+    Yojson.Safe.Util.(member "entry_count" json2 |> to_int);
+  (* Lookup triggers a hit *)
+  ignore (Masc_exec.Exec_cache.lookup cache "test_cmd");
+  let json3 = Masc_exec.Exec_cache.to_json cache in
+  check int "after lookup hit_count" 1
+    Yojson.Safe.Util.(member "hit_count" json3 |> to_int)
+
 let () =
   Masc_test_deps.init_keeper_tool_registry ();
   ignore
@@ -183,5 +275,10 @@ let () =
         test_execute_with_outcome_missing_file_is_failure;
       test_case "bad query is failure" `Quick
         test_execute_with_outcome_bad_query_is_failure;
+    ]);
+    ("exec_cache", [
+      test_case "miss then hit" `Quick test_exec_cache_miss_then_hit;
+      test_case "no cache when None" `Quick test_exec_cache_none_no_caching;
+      test_case "stats json" `Quick test_exec_cache_stats_json;
     ]);
   ]

--- a/test/test_keeper_github_read_only.ml
+++ b/test/test_keeper_github_read_only.ml
@@ -528,7 +528,7 @@ let test_keeper_shell_gh_without_current_task_uses_sandbox_context () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
   let meta = make_meta ~sandbox_profile:Keeper_types.Docker () in
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
           [

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -685,7 +685,7 @@ let test_memory_search_cross_generation () =
     let ctx_work = KEC.append ctx_work
       (Agent_sdk.Types.text_message Agent_sdk.Types.User "hello keeper") in
     (* Search for "canary" — only exists in history.jsonl *)
-    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work
+    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work ~exec_cache:None
       ~name:"keeper_memory_search"
       ~input:(`Assoc [ ("query", `String "canary"); ("limit", `Int 5); ("source", `String "history") ])
       () in
@@ -707,7 +707,7 @@ let test_memory_search_checkpoint_only () =
     let ctx_work = KEC.create ~system_prompt:"test" ~max_tokens:4096 in
     let ctx_work = KEC.append ctx_work
       (Agent_sdk.Types.text_message Agent_sdk.Types.User "optimize the database query") in
-    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work
+    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work ~exec_cache:None
       ~name:"keeper_memory_search"
       ~input:(`Assoc [ ("query", `String "database"); ("limit", `Int 5); ("source", `String "history") ])
       () in
@@ -730,7 +730,7 @@ let test_memory_search_dedup () =
     let ctx_work = KEC.create ~system_prompt:"test" ~max_tokens:4096 in
     let ctx_work = KEC.append ctx_work
       (Agent_sdk.Types.text_message Agent_sdk.Types.User "shared needle message") in
-    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work
+    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work ~exec_cache:None
       ~name:"keeper_memory_search"
       ~input:(`Assoc [ ("query", `String "needle"); ("limit", `Int 10); ("source", `String "history") ])
       () in
@@ -768,7 +768,7 @@ let test_memory_search_prev_generation () =
     let ctx_work = KEC.append ctx_work
       (Agent_sdk.Types.text_message Agent_sdk.Types.User "status report") in
     (* Search for "postgres" — only in previous generation's history *)
-    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work
+    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work ~exec_cache:None
       ~name:"keeper_memory_search"
       ~input:(`Assoc [ ("query", `String "postgres"); ("limit", `Int 5); ("source", `String "history") ])
       () in
@@ -780,7 +780,7 @@ let test_memory_search_prev_generation () =
     check bool "match references schema migration" true
       (List.exists (fun m -> Re.execp (Re.str "postgres" |> Re.compile) m) matches);
     (* Also verify current generation is searchable *)
-    let result2 = KET.execute_keeper_tool_call ~config ~meta ~ctx_work
+    let result2 = KET.execute_keeper_tool_call ~config ~meta ~ctx_work ~exec_cache:None
       ~name:"keeper_memory_search"
       ~input:(`Assoc [ ("query", `String "cluster"); ("limit", `Int 5); ("source", `String "history") ])
       () in
@@ -836,7 +836,7 @@ let test_memory_search_bank_basic () =
         ~priority:66 ~generation:2 ~turn:5 ~ts_unix:1100.0 ();
     ];
     let ctx_work = KEC.create ~system_prompt:"test" ~max_tokens:4096 in
-    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work
+    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work ~exec_cache:None
       ~name:"keeper_memory_search"
       ~input:(`Assoc [ ("query", `String "Postgres") ])
       () in
@@ -864,7 +864,7 @@ let test_memory_search_bank_kind_filter () =
     ];
     let ctx_work = KEC.create ~system_prompt:"test" ~max_tokens:4096 in
     (* Search with kind=goal — should only return "use Redis" *)
-    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work
+    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work ~exec_cache:None
       ~name:"keeper_memory_search"
       ~input:(`Assoc [ ("query", `String "use"); ("kind", `String "goal") ])
       () in
@@ -886,7 +886,7 @@ let test_memory_search_bank_scored_order () =
       memory_note ~kind:"decision" ~text:"task alpha upgrade" ~priority:90 ~generation:2 ~turn:3 ~ts_unix:200.0 ();
     ];
     let ctx_work = KEC.create ~system_prompt:"test" ~max_tokens:4096 in
-    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work
+    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work ~exec_cache:None
       ~name:"keeper_memory_search"
       ~input:(`Assoc [ ("query", `String "alpha"); ("limit", `Int 5) ])
       () in
@@ -923,7 +923,7 @@ let test_memory_search_bank_prefers_long_term_over_stale_short_term () =
         ~priority:95 ~generation:1 ~turn:2 ~ts_unix:1000.0 ();
     ];
     let ctx_work = KEC.create ~system_prompt:"test" ~max_tokens:4096 in
-    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work
+    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work ~exec_cache:None
       ~name:"keeper_memory_search"
       ~input:(`Assoc [ ("query", `String "postgres evidence trail") ])
       () in
@@ -941,7 +941,7 @@ let test_memory_search_bank_empty () =
     let config = make_test_room_config dir in
     let meta = keeper_meta ~name:"empty-keeper" ~mention_targets:["empty-keeper"] () in
     let ctx_work = KEC.create ~system_prompt:"test" ~max_tokens:4096 in
-    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work
+    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work ~exec_cache:None
       ~name:"keeper_memory_search"
       ~input:(`Assoc [ ("query", `String "anything") ])
       () in
@@ -961,7 +961,7 @@ let test_memory_search_bank_no_match () =
       memory_note ~kind:"decision" ~text:"deploy to staging" ~priority:86 ~generation:1 ~turn:1 ~ts_unix:1000.0 ();
     ];
     let ctx_work = KEC.create ~system_prompt:"test" ~max_tokens:4096 in
-    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work
+    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work ~exec_cache:None
       ~name:"keeper_memory_search"
       ~input:(`Assoc [ ("query", `String "nonexistent_keyword_xyz") ])
       () in
@@ -981,7 +981,7 @@ let test_memory_search_source_history () =
       {|{"role":"user","content":"deploy the legacy service"}|};
     ];
     let ctx_work = KEC.create ~system_prompt:"test" ~max_tokens:4096 in
-    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work
+    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work ~exec_cache:None
       ~name:"keeper_memory_search"
       ~input:(`Assoc [ ("query", `String "legacy"); ("source", `String "history") ])
       () in
@@ -1008,7 +1008,7 @@ let test_memory_search_source_all () =
       {|{"role":"user","content":"alpha from history"}|};
     ];
     let ctx_work = KEC.create ~system_prompt:"test" ~max_tokens:4096 in
-    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work
+    let result = KET.execute_keeper_tool_call ~config ~meta ~ctx_work ~exec_cache:None
       ~name:"keeper_memory_search"
       ~input:(`Assoc [ ("query", `String "alpha"); ("source", `String "all"); ("limit", `Int 10) ])
       () in

--- a/test/test_keeper_shell_containment.ml
+++ b/test/test_keeper_shell_containment.ml
@@ -209,7 +209,7 @@ let test_legacy_keeper_unaffected () =
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside = outside_in_root ~base "secret.txt" in
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "cat"); ("path", `String outside) ])
   in
   Alcotest.(check bool) "legacy bypasses symmetric containment" false
@@ -221,7 +221,7 @@ let test_docker_keeper_blocks_ls_outside () =
   let outside_dir = Filename.concat base "outside_playground" in
   ensure_dir outside_dir;
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc [ ("op", `String "ls"); ("path", `String outside_dir) ])
   in
@@ -233,7 +233,7 @@ let test_docker_keeper_blocks_cat_outside () =
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside = outside_in_root ~base "host_secret.txt" in
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "cat"); ("path", `String outside) ])
   in
   Alcotest.(check bool) "cat outside playground blocked" true
@@ -249,7 +249,7 @@ let test_docker_keeper_blocks_rg_outside () =
        (Filename.concat outside_dir "leak.txt")
        "secret-token");
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -267,7 +267,7 @@ let test_docker_keeper_blocks_find_outside () =
   let outside_dir = Filename.concat base "outside_playground" in
   ensure_dir outside_dir;
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -285,7 +285,7 @@ let test_docker_keeper_allows_inside_playground () =
   let demo = Filename.concat playground "demo.txt" in
   ignore (Fs_compat.save_file_atomic demo "hello inside playground");
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "cat"); ("path", `String demo) ])
   in
   (* Goal: containment did not block. Whether `cat` succeeds depends on
@@ -299,7 +299,7 @@ let test_docker_git_creds_contained () =
   @@ fun ~base ~config ~meta ~playground:_ ->
   let outside = outside_in_root ~base "git_secret.txt" in
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "cat"); ("path", `String outside) ])
   in
   Alcotest.(check bool) "docker git-creds also contained" true
@@ -338,7 +338,7 @@ let test_gh_binds_repo_from_active_task_worktree () =
   with_env "GH_PWD_FILE" gh_pwd_file @@ fun () ->
   with_env "PATH" (bin_dir ^ ":" ^ existing_path ()) @@ fun () ->
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -379,7 +379,7 @@ let test_gh_missing_worktree_returns_typed_error () =
   in
   let meta = { meta with current_task_id = Some current_task_id } in
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "gh"); ("cmd", `String "pr list") ])
   in
   Alcotest.(check (option string)) "typed gh error"

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -261,7 +261,7 @@ let assert_docker_route_fires ~config ~meta ~playground =
   List.iter
     (fun (op, args) ->
       let raw =
-        Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta ~args
+        Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta ~args
       in
       Alcotest.(check bool)
         (Printf.sprintf "%s surfaces docker image config error (docker route fired)" op)
@@ -285,7 +285,7 @@ let test_cat_legacy_keeper_skips_docker () =
   ensure_dir (Filename.dirname host_path);
   ignore (Fs_compat.save_file_atomic host_path "matrix");
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "cat"); ("path", `String host_path) ])
   in
   Alcotest.(check bool)
@@ -326,7 +326,7 @@ let test_rg_no_match_remains_successful_in_docker_route () =
   ensure_dir (Filename.dirname host_path);
   ignore (Fs_compat.save_file_atomic host_path "alpha\nbeta\ngamma\n");
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
             [
@@ -348,7 +348,7 @@ let test_git_clone_routes_through_docker () =
   setup ~sandbox:Keeper_types.Docker
   @@ fun ~config ~meta ~playground ->
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -373,7 +373,7 @@ let test_hard_mode_git_clone_uses_brokered_route () =
   setup ~sandbox:Keeper_types.Docker
   @@ fun ~config ~meta ~playground ->
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -398,7 +398,7 @@ let test_bash_routes_through_docker () =
   @@ fun ~config ~meta ~playground ->
   let raw =
     Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_runtime:None
-      ~turn_sandbox_runtime_git:None ~config ~meta
+      ~turn_sandbox_runtime_git:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("cmd", `String "echo hello"); ("cwd", `String playground) ])
       ()
   in
@@ -415,7 +415,7 @@ let test_bash_legacy_skips_docker () =
   Fun.protect ~finally:(fun () -> cleanup_dir outside_cwd) @@ fun () ->
   let raw =
     Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_runtime:None
-      ~turn_sandbox_runtime_git:None ~config ~meta
+      ~turn_sandbox_runtime_git:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("cmd", `String "echo hello"); ("cwd", `String outside_cwd) ])
       ()
   in
@@ -430,7 +430,7 @@ let test_bash_git_creds_routes_through_docker () =
   @@ fun ~config ~meta ~playground ->
   let raw =
     Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_runtime:None
-      ~turn_sandbox_runtime_git:None ~config ~meta
+      ~turn_sandbox_runtime_git:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("cmd", `String "git status"); ("cwd", `String playground) ])
       ()
   in
@@ -445,7 +445,7 @@ let test_hard_mode_blocks_raw_gh_bash () =
   @@ fun ~config ~meta ~playground:_ ->
   let raw =
     Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_runtime:None
-      ~turn_sandbox_runtime_git:None ~config ~meta
+      ~turn_sandbox_runtime_git:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("cmd", `String "gh pr list") ])
       ()
   in
@@ -597,7 +597,7 @@ let test_git_clone_repairs_existing_docker_clone_checkout () =
   Alcotest.(check bool) "checkout file removed before repair" false
     (Sys.file_exists restored_readme);
   let raw =
-    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~config ~meta
+    Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_runtime:None ~exec_cache:None ~config ~meta
       ~args:
         (`Assoc
           [
@@ -622,7 +622,7 @@ let test_bash_fake_docker_executes () =
   @@ fun ~config ~meta ~playground ->
   let raw =
     Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_runtime:None
-      ~turn_sandbox_runtime_git:None ~config ~meta
+      ~turn_sandbox_runtime_git:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("cmd", `String "echo hello"); ("cwd", `String playground) ])
       ()
   in

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -98,12 +98,12 @@ let with_room f =
 let call_tool config meta name input =
   let ctx_work = make_ctx_work () in
   Keeper_exec_tools.execute_keeper_tool_call
-    ~config ~meta ~ctx_work ~name ~input ()
+    ~config ~meta ~ctx_work ~exec_cache:None ~name ~input ()
 
 let call_tool_with_search config meta name input search_fn =
   let ctx_work = make_ctx_work () in
   Keeper_exec_tools.execute_keeper_tool_call
-    ~config ~meta ~ctx_work ~search_fn ~name ~input ()
+    ~config ~meta ~ctx_work ~exec_cache:None ~search_fn ~name ~input ()
 
 let parse_json s =
   try Yojson.Safe.from_string s


### PR DESCRIPTION
## Summary

- Wire P19 `Masc_exec.Exec_cache` through the full keeper tool dispatch chain
- Thread `~exec_cache:T option` as labeled parameter (matches `turn_sandbox_runtime` pattern)
- `handle_keeper_shell` "bash" op: cache lookup → hit returns with `cached:true` + `cache_age_ms`, miss → execute + store
- Cache lifecycle: created per-turn in `make_tool_bundle`, passed to all shell/bash handlers
- All 8 test files updated to pass `~exec_cache:None`

## Dependencies

- [x] P19 Exec_cache (#9803) — **MERGED**
- [ ] P17 Exec_budget (#9801) — CI pending
- [ ] P18 Adaptive_timeout (#9802) — CI pending
- [ ] P20 Risk_classifier (#9804) — CI pending

P17/P18/P20 merge 후 rebase 필요.

## Test plan

- [x] `dune build` passes (0 errors, 0 warnings)
- [x] `test_keeper_exec_tools` — 3 tests pass
- [x] `test_keeper_bash_safety` — 28 tests pass
- [x] `test_keeper_task_dispatch` — 17 tests pass
- [x] `test_keeper_accountability` — 14 tests pass
- [x] `test_keeper_memory` — 20 tests pass
- [x] Docker sandbox tests fail identically on main (pre-existing, no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)