### PR TITLE
fix(tool_input_validation): suggest closest arg key for missing required params (#9785)

### DIFF
--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -100,6 +100,74 @@ let normalize_transition_args (args : Yojson.Safe.t) : Yojson.Safe.t =
         `Assoc with_notes
   | _ -> args
 
+(* #9785: OAS validation messages list missing required fields as
+   `  "<field>": MISSING (required: <type>)`. When the LLM emitted a
+   similarly-named key (e.g. sent "name" while the schema requires
+   "tool_name"), surface the closest match so the next turn can self-
+   correct in one shot. Pure string transformation over the OAS-emitted
+   message — no OAS API change needed. *)
+let missing_field_re =
+  Re.Pcre.re {|"([^"]+)":\s*MISSING|} |> Re.compile
+
+(* Substring containment in either direction is a strong signal for
+   parameter-name confusion ("name" ⊂ "tool_name"). For short identifiers
+   pure Jaccard underweights this case (tool_name ↔ name ≈ 0.36) so we
+   blend the two with a containment bonus. *)
+let string_contains haystack needle =
+  let nlen = String.length needle in
+  let hlen = String.length haystack in
+  if nlen = 0 || nlen > hlen then false
+  else
+    let rec scan i =
+      if i + nlen > hlen then false
+      else if String.sub haystack i nlen = needle then true
+      else scan (i + 1)
+    in
+    scan 0
+
+let param_name_similarity a b =
+  let la = String.lowercase_ascii a and lb = String.lowercase_ascii b in
+  if la = lb then 1.0
+  else if string_contains la lb || string_contains lb la then
+    (* one contained in the other — very likely the LLM confusion case *)
+    0.8
+  else Text_similarity.jaccard_similarity a b
+
+let augment_missing_param_hint ~(args : Yojson.Safe.t) (oas_message : string) =
+  let arg_keys =
+    match args with
+    | `Assoc fields -> List.map fst fields
+    | _ -> []
+  in
+  if arg_keys = [] then oas_message
+  else
+    let suggestions =
+      Re.all missing_field_re oas_message
+      |> List.filter_map (fun g ->
+        let missing = Re.Group.get g 1 in
+        if List.mem missing arg_keys then None
+        else
+          let scored =
+            List.filter_map
+              (fun k ->
+                let s = param_name_similarity missing k in
+                if s >= 0.4 then Some (s, k) else None)
+              arg_keys
+          in
+          let sorted =
+            List.sort (fun (a, _) (b, _) -> Float.compare b a) scored
+          in
+          match sorted with
+          | (_, closest) :: _ ->
+            Some
+              (Printf.sprintf
+                 "  hint: you sent \"%s\"; rename it to \"%s\""
+                 closest missing)
+          | [] -> None)
+    in
+    if suggestions = [] then oas_message
+    else oas_message ^ "\n\nDid you mean:\n" ^ String.concat "\n" suggestions
+
 let register_pre_hook () =
   let lookup name =
     Option.map
@@ -125,11 +193,12 @@ let register_pre_hook () =
       Log.info "tool_input_validation coerced args for %s" name;
       Proceed coerced
     | Oas.Tool_middleware.Reject { message; _ } ->
-      Log.info "tool_input_validation rejected %s: %s" name message;
+      let augmented = augment_missing_param_hint ~args:compat_args message in
+      Log.info "tool_input_validation rejected %s: %s" name augmented;
       Reject {
         Tool_result.success = false;
         data = `Assoc [
-          ("error", `String message);
+          ("error", `String augmented);
           ("validation", `String "oas_tool_middleware");
         ];
         tool_name = name;

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -389,6 +389,63 @@ let test_registered_hook_transition_strips_internal_agent_marker () =
     (assoc_string "agent_name" forwarded)
 
 (* ================================================================ *)
+(* #9785: missing-required-param hint augmentation                   *)
+(* ================================================================ *)
+
+let test_augment_suggests_closest_arg_key () =
+  (* Schema requires "tool_name" but LLM sent "name". *)
+  let oas_msg =
+    "Your call to \"masc_tool_help\":\n{\"name\":\"masc_board_post\"}\n\n\
+     Errors (fix these and call again):\n\
+    \  \"tool_name\": MISSING (required: string)"
+  in
+  let args = `Assoc [("name", `String "masc_board_post")] in
+  let augmented = Tool_input_validation.augment_missing_param_hint ~args oas_msg in
+  Alcotest.(check bool) "appends Did you mean section" true
+    (string_contains augmented "Did you mean:");
+  Alcotest.(check bool) "names actual key sent" true
+    (string_contains augmented "you sent \"name\"");
+  Alcotest.(check bool) "names required key" true
+    (string_contains augmented "rename it to \"tool_name\"")
+
+let test_augment_skips_when_missing_field_present_in_args () =
+  (* Field is missing because the value is wrong type, not absent. *)
+  let oas_msg =
+    "Your call to \"x\":\n{\"task_id\":\"...\"}\n\n\
+     Errors (fix these and call again):\n\
+    \  \"task_id\": MISSING (required: string)"
+  in
+  let args = `Assoc [("task_id", `String "abc")] in
+  let augmented = Tool_input_validation.augment_missing_param_hint ~args oas_msg in
+  Alcotest.(check string) "message is unchanged" oas_msg augmented
+
+let test_augment_skips_when_no_similar_arg_key () =
+  let oas_msg =
+    "Errors (fix these and call again):\n\
+    \  \"tool_name\": MISSING (required: string)"
+  in
+  let args = `Assoc [("zzzz_unrelated_xyzqq", `String "value")] in
+  let augmented = Tool_input_validation.augment_missing_param_hint ~args oas_msg in
+  Alcotest.(check string) "message is unchanged when nothing similar" oas_msg augmented
+
+let test_augment_handles_non_object_args () =
+  let oas_msg =
+    "Errors (fix these and call again):\n\
+    \  \"x\": MISSING (required: string)"
+  in
+  let augmented = Tool_input_validation.augment_missing_param_hint ~args:`Null oas_msg in
+  Alcotest.(check string) "message unchanged for null args" oas_msg augmented
+
+let test_augment_handles_no_missing_section () =
+  let oas_msg =
+    "Errors (fix these and call again):\n\
+    \  \"x\": wrong type — expected: integer, got: string"
+  in
+  let args = `Assoc [("x", `String "abc")] in
+  let augmented = Tool_input_validation.augment_missing_param_hint ~args oas_msg in
+  Alcotest.(check string) "message unchanged when nothing MISSING" oas_msg augmented
+
+(* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
 
@@ -434,5 +491,17 @@ let () =
         test_registered_hook_transition_compat_status_action;
       Alcotest.test_case "masc_transition strips internal markers" `Quick
         test_registered_hook_transition_strips_internal_agent_marker;
+    ]);
+    ("missing_param_hint_9785", [
+      Alcotest.test_case "suggests closest arg key as rename target" `Quick
+        test_augment_suggests_closest_arg_key;
+      Alcotest.test_case "skips when missing field is already present" `Quick
+        test_augment_skips_when_missing_field_present_in_args;
+      Alcotest.test_case "skips when no arg key is similar" `Quick
+        test_augment_skips_when_no_similar_arg_key;
+      Alcotest.test_case "handles non-object args" `Quick
+        test_augment_handles_non_object_args;
+      Alcotest.test_case "ignores wrong-type errors with no MISSING" `Quick
+        test_augment_handles_no_missing_section;
     ]);
   ]


### PR DESCRIPTION
## Summary

When a schema requires `tool_name` but the LLM emits `name` (observed in #9785 across seq 57450, 57455, 57462, 57467, 57478, 57511 — six rejections in one window), the OAS validation hook returns:

```
"tool_name": MISSING (required: string)
```

The agent has no signal that it sent a similarly-named key in the wrong slot, so it retries with the same wrong key and burns turns.

This is the same root pattern as #9784 (Unknown tool hallucination, fixed in #9815) **one schema-level deeper**: tool name is right, parameter name is hallucinated. Same shape of fix.

## Fix

Augment the OAS-emitted `Reject` message in MASC's pre-hook wrapper at `lib/tool_input_validation.ml`:

1. Parse the message for `"<field>": MISSING` lines.
2. For each missing field, scan the args' actual keys for the closest match using a **containment-aware similarity**:
   - exact case-insensitive match -> 1.0
   - **substring containment in either direction -> 0.8** (covers `name` subset of `tool_name`, the dominant case)
   - otherwise fall back to `Text_similarity.jaccard_similarity`
3. If a match scores ≥ 0.4, append a `Did you mean` block naming the actual key sent and the rename target.

Example response transformation:

| Before | After |
|--------|-------|
| `"tool_name": MISSING (required: string)` | `"tool_name": MISSING (required: string)`<br>`Did you mean:`<br>&nbsp;&nbsp;`hint: you sent "name"; rename it to "tool_name"` |

## Why containment, not pure Jaccard

I tried pure Jaccard first and the test failed: `tool_name` ↔ `name` scores ≈ 0.36 with the existing `Text_similarity` module — below any useful threshold. Short identifiers naturally underperform on n-gram set similarity. Substring containment is the actual signal for the prefix/suffix-stripping mistake LLMs make (`name`, `id`, `path` etc. are common short keys that LLMs strip prefixes from).

## Layer boundary respected

This is a **pure string transformation in MASC's wrapper**. OAS receives no new dependencies and emits no new structured field, honoring the `OAS must not know MASC` invariant from prior feedback memory.

## Test plan

- [x] `dune build --root=. lib/` — clean
- [x] `dune exec test/test_tool_input_validation.exe` — 29/29 pass (24 existing + 5 new in `missing_param_hint_9785` group)

New regression coverage:
- closest arg key suggested as rename target (tool_name + name -> hint)
- skipped when missing field is already present in args (wrong type, not absent)
- skipped when no arg key is similar (no false positives)
- non-object args handled (no crash)
- wrong-type errors with no `MISSING` left untouched

Closes #9785

## Sibling PRs in this theme

- #9809 (merged) — null-safe MCP payload guard for #9788
- #9812 — sound-partial quote stripping for Agent_id/Task_id (#9787)
- #9815 — did-you-mean for Unknown tool errors (#9784)
- This PR — did-you-mean for missing required params (#9785)

Together they harden the MCP tool boundary against the four most common LLM emission patterns (null payload, stray quotes, hallucinated tool name, hallucinated param name).