### PR TITLE
fix(keeper): restore sandbox network + work_discovery for 3 keepers

### DIFF
--- a/config/keepers/issue_king.toml
+++ b/config/keepers/issue_king.toml
@@ -1,4 +1,9 @@
 [keeper]
 persona_name = "issue_king"
 sandbox_profile = "docker"
-network_mode = "host"
+network_mode = "inherit"
+tool_preset = "delivery"
+work_discovery_enabled = true
+work_discovery_sources = ["unclaimed_tasks", "stale_tasks"]
+github_identity = "anyang-keepers"
+git_identity_mode = "github_identity"

--- a/config/keepers/masc-improver.toml
+++ b/config/keepers/masc-improver.toml
@@ -1,4 +1,9 @@
 [keeper]
 persona_name = "analyst"
 sandbox_profile = "docker"
-network_mode = "host"
+network_mode = "inherit"
+tool_preset = "delivery"
+work_discovery_enabled = true
+work_discovery_sources = ["unclaimed_tasks", "stale_tasks"]
+github_identity = "anyang-keepers"
+git_identity_mode = "github_identity"

--- a/config/keepers/sangsu.toml
+++ b/config/keepers/sangsu.toml
@@ -1,4 +1,9 @@
 [keeper]
-persona_name = "sangsu"
+persona_name = "executor"
 sandbox_profile = "docker"
-network_mode = "host"
+network_mode = "inherit"
+tool_preset = "messaging"
+work_discovery_enabled = true
+work_discovery_sources = ["unclaimed_tasks"]
+github_identity = "anyang-keepers"
+git_identity_mode = "github_identity"

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -758,9 +758,16 @@ let handle_keeper_bash
            ; "cmd", `String cmd_for_log
            ]))
     else if sandbox_profile = Docker && git_creds_enabled then (
+      let detected_tool = if cmd_targets_gh cmd then "gh" else "git" in
       Log.Keeper.info
-        "DOCKER_GIT_EXEC: keeper=%s cwd=%s cmd=%s"
-        meta.name cwd cmd_for_log;
+        "DOCKER_GIT_EXEC: keeper=%s cwd=%s cmd=%s detected_tool=%s \
+         base_network=%s upgraded_to=inherit"
+        meta.name cwd cmd_for_log detected_tool
+        (network_mode_to_string base_network_mode);
+      Prometheus.inc_counter
+        "masc_keeper_bash_network_upgrade_total"
+        ~labels:[ ("keeper", meta.name); ("detected_tool", detected_tool) ]
+        ();
       run_docker_with_git_bash
         ~turn_sandbox_runtime:turn_sandbox_runtime_git
         ~config ~meta ~cwd ~timeout_sec ~cmd ())

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -85,6 +85,11 @@ let network_mode_of_string raw =
   match String.trim (String.lowercase_ascii raw) with
   | "none" -> Some Network_none
   | "inherit" -> Some Network_inherit
+  | "host" ->
+      Log.Keeper.warn
+        "network_mode=\"host\" is a deprecated alias for \"inherit\"; \
+         update TOML to use \"inherit\"";
+      Some Network_inherit
   | _ -> None
 
 (* Issue #8467: Variant SSOT for [network_mode]. *)
@@ -612,7 +617,8 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
             | None ->
                 Error
                   (Printf.sprintf
-                     "invalid network_mode '%s' (allowed: none, inherit)"
+                     "invalid network_mode '%s' (allowed: none, inherit; \
+                      deprecated alias: host)"
                      raw))
         | None -> Ok ())
   in
@@ -1298,13 +1304,42 @@ let load_keeper_profile_defaults_result name :
   | None ->
     Ok (load_keeper_profile_defaults_from_persona name)
 
+(* Classify a [load_keeper_toml] failure message into a low-cardinality
+   label suitable for Prometheus. The raw error string embeds user input
+   (invalid enum values etc.) and would blow up metric cardinality. *)
+let classify_toml_failure_reason (err : string) : string =
+  let err_lc = String.lowercase_ascii err in
+  let contains needle =
+    let nl = String.length needle in
+    let hl = String.length err_lc in
+    if nl = 0 then true
+    else if nl > hl then false
+    else
+      let rec loop i =
+        if i + nl > hl then false
+        else if String.sub err_lc i nl = needle then true
+        else loop (i + 1)
+      in
+      loop 0
+  in
+  if contains "invalid network_mode" then "invalid_network_mode"
+  else if contains "invalid sandbox_profile" then "invalid_sandbox_profile"
+  else if contains "invalid shared_memory_scope" then "invalid_shared_memory_scope"
+  else if contains "invalid" then "invalid_enum"
+  else if contains "unknown" || contains "unexpected field" then "unknown_field"
+  else if contains "parse" || contains "syntax" then "parse_error"
+  else "other"
+
 let load_keeper_profile_defaults name : keeper_profile_defaults =
   match load_keeper_profile_defaults_result name with
   | Ok defaults -> defaults
   | Error e ->
     (match keeper_toml_path_opt name with
      | Some _ ->
-       Log.Keeper.warn "toml config for %s failed (%s), falling back to persona" name e
+       Log.Keeper.warn "toml config for %s failed (%s), falling back to persona" name e;
+       Prometheus.inc_counter "masc_keeper_toml_invalid_total"
+         ~labels:[ ("keeper", name); ("reason", classify_toml_failure_reason e) ]
+         ()
      | None -> ());
     load_keeper_profile_defaults_from_persona name
 

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -41,19 +41,25 @@ let test_named_keeper_docker_defaults () =
     | Some repo_root -> Filename.concat repo_root "config/keepers"
     | None -> "config/keepers"
   in
-  let expect_keeper name =
+  let expect_keeper ~name ~persona =
     let path = Filename.concat config_dir (name ^ ".toml") in
     match KTP.load_keeper_toml path with
     | Error e -> fail (Printf.sprintf "%s: %s" name e)
     | Ok (_loaded_name, defaults) ->
-        check (option string) (name ^ " persona_name") (Some name)
+        check (option string) (name ^ " persona_name") (Some persona)
           defaults.persona_name;
         check (option string) (name ^ " sandbox_profile") (Some "docker")
           (Option.map KTP.sandbox_profile_to_string defaults.sandbox_profile);
-        check (option string) (name ^ " network_mode") (Some "none")
-          (Option.map KTP.network_mode_to_string defaults.network_mode)
+        (* After the host→inherit alias migration, all three docker keepers
+           request [Network_inherit] so keeper_bash can dispatch git/gh. *)
+        check (option string) (name ^ " network_mode") (Some "inherit")
+          (Option.map KTP.network_mode_to_string defaults.network_mode);
+        check (option string) (name ^ " github_identity")
+          (Some "anyang-keepers") defaults.github_identity
   in
-  List.iter expect_keeper [ "sangsu" ]
+  expect_keeper ~name:"issue_king" ~persona:"issue_king";
+  expect_keeper ~name:"masc-improver" ~persona:"analyst";
+  expect_keeper ~name:"sangsu" ~persona:"executor"
 
 (** Write a temporary TOML file, run load_keeper_toml, clean up. *)
 let with_temp_toml content f =
@@ -147,6 +153,64 @@ let test_tool_preset_accepts_dispatch () =
       check (option string) "dispatch preset parsed" (Some "dispatch")
         defaults.tool_preset
 
+(** Reject [network_mode = "bogus"] at TOML load time so invalid strings
+    do not silently fall back to persona defaults. *)
+let test_network_mode_rejects_unknown () =
+  let result =
+    with_temp_toml
+      "[keeper]\nname = \"nettest\"\nnetwork_mode = \"bogus\"\n"
+      KTP.load_keeper_toml
+  in
+  match result with
+  | Ok _ -> fail "network_mode=bogus should be rejected"
+  | Error e ->
+      let lowered = String.lowercase_ascii e in
+      let contains needle =
+        let nl = String.length needle in
+        let hl = String.length lowered in
+        let found = ref false in
+        if nl <= hl then
+          for i = 0 to hl - nl do
+            if String.sub lowered i nl = needle then found := true
+          done;
+        !found
+      in
+      check bool "error mentions invalid network_mode" true
+        (contains "invalid network_mode");
+      check bool "error mentions deprecated alias" true
+        (contains "host")
+
+(** Accept [network_mode = "host"] as a deprecated alias for "inherit".
+    Ensures operators migrating from docker-run terminology are not
+    silently dropped to persona defaults.  The loader emits a warning and
+    the parsed value equals [Network_inherit]. *)
+let test_network_mode_accepts_host_alias () =
+  let result =
+    with_temp_toml
+      "[keeper]\nname = \"hosttest\"\nsandbox_profile = \"docker\"\n\
+       network_mode = \"host\"\n"
+      KTP.load_keeper_toml
+  in
+  match result with
+  | Error e -> fail (Printf.sprintf "host alias should be accepted: %s" e)
+  | Ok (_loaded_name, defaults) ->
+      check (option string) "host alias maps to inherit" (Some "inherit")
+        (Option.map KTP.network_mode_to_string defaults.network_mode)
+
+(** Regression: classify_toml_failure_reason must bucket raw error strings
+    into a small cardinality set so the Prometheus label set stays bounded. *)
+let test_classify_toml_failure_reason_buckets () =
+  let f = KTP.classify_toml_failure_reason in
+  check string "invalid network_mode" "invalid_network_mode"
+    (f "invalid network_mode 'bogus' (allowed: none, inherit)");
+  check string "invalid sandbox_profile" "invalid_sandbox_profile"
+    (f "invalid sandbox_profile 'lol' (allowed: local, docker)");
+  check string "unknown field" "unknown_field"
+    (f "unknown field 'legacy_scope'");
+  check string "parse error" "parse_error"
+    (f "parse error at line 3");
+  check string "uncategorized" "other" (f "completely novel problem")
+
 let () =
   run "Keeper TOML Config Validation"
     [
@@ -166,5 +230,14 @@ let () =
             test_cascade_name_accepts_catalog_entry;
           test_case "accepts dispatch tool_preset" `Quick
             test_tool_preset_accepts_dispatch;
+        ] );
+      ( "network_mode validation",
+        [
+          test_case "rejects unknown network_mode" `Quick
+            test_network_mode_rejects_unknown;
+          test_case "accepts host as deprecated alias for inherit" `Quick
+            test_network_mode_accepts_host_alias;
+          test_case "classifies failures into bounded label set" `Quick
+            test_classify_toml_failure_reason_buckets;
         ] );
     ]


### PR DESCRIPTION
## Summary

- 2026-04-20 이후 계속된 "16 keeper 100% board_comment, git 작업 0건" 증상의 잔여 원인을 3-layer로 분해해 수정.
- issue_king / masc-improver / sangsu TOML이 enum 불일치(`network_mode = \"host\"`)로 전량 무효화되어 persona default로 silent fallback 중이었음. Docker sandbox + tool_preset + work_discovery + github_identity 모두 미적용 상태.
- `network_mode=\"host\"`를 `\"inherit\"` deprecated alias로 수용 (backward-compat hotfix), silent fallback 시 Prometheus metric으로 관측, `keeper_bash`의 git/gh auto-upgrade에 structured log + metric 추가.

## Root Cause (3 Layers)

| 레이어 | 증상 | 수정 방식 |
|--------|------|----------|
| L1 Config | `network_mode=\"host\"` → load_keeper_toml Error → `load_keeper_profile_defaults` silent fallback (`keeper_types_profile.ml:1301-1309`) | TOML 3개를 `inherit` + 실제 필드 지정으로 업데이트. `\"host\"` alias 추가로 기존 운영 TOML 비파괴 수용. |
| L2 Material | `work_discovery_sources` 미지정 → `discover_work_nudge` chunks=[] → keeper가 unclaimed task를 모름 | TOML에 `work_discovery_enabled = true` + `sources = [\"unclaimed_tasks\", \"stale_tasks\"]` 명시. |
| L3 Persona | `sangsu.toml`의 `persona_name=\"sangsu\"` 참조 대상 `config/personas/sangsu/` 부재 → blank fallback | `persona_name = \"executor\"` 로 매핑. sangsu persona JSON 신규 생성은 별도 티켓. |

### Code
- `lib/keeper/keeper_types_profile.ml`
  - `network_mode_of_string`: `\"host\" → Some Network_inherit` + deprecation warn
  - error message에 `deprecated alias: host` 힌트 추가
  - `load_keeper_profile_defaults` silent fallback 지점에 `Prometheus.inc_counter \"masc_keeper_toml_invalid_total\"` + `classify_toml_failure_reason` (3-bucket, cardinality-safe)
- `lib/keeper/keeper_exec_shell.ml`
  - `git_creds_enabled=true` 분기에서 감지된 tool(git/gh) + base_network을 structured log로 남기고 `masc_keeper_bash_network_upgrade_total` 카운터 증가

### Config
- `config/keepers/issue_king.toml` / `masc-improver.toml` / `sangsu.toml` 완전 재작성 — `network_mode = \"inherit\"`, `tool_preset`, `work_discovery_*`, `github_identity = \"anyang-keepers\"`, `git_identity_mode = \"github_identity\"`.

### Tests
- `test/test_keeper_toml_config_validation.ml`
  - 기존 `test_named_keeper_docker_defaults`를 새 TOML 형상 + 3 keeper 모두 커버하도록 업데이트
  - `test_network_mode_rejects_unknown` / `test_network_mode_accepts_host_alias` / `test_classify_toml_failure_reason_buckets` 3개 신규 추가

## Verification

- Local build: \`dune build --root . && echo EXIT=\$?\` → EXIT=0
- TOML validation 바이너리: 9 tests run, 새 3개 전부 ✅. 기존 실패 1건(`rejects unknown cascade_name: nick0cave`)은 live `~/me/.masc/config/cascade.json`이 test에 노출되는 pre-existing 환경 리크로 이 PR 범위 밖.
- `test_keeper_runtime_toml` (15/15), `test_keeper_runtime_config_ssot` (23/23), `test_keeper_shell_docker_route` (14/14) 전부 통과.

## Test plan (reviewer-verifiable)

- [ ] \`dune build --root .\`
- [ ] \`DUNE_SOURCEROOT=\"\$(pwd)\" dune exec --root . test/test_keeper_toml_config_validation.exe\` 에서 network_mode validation 섹션 3 테스트 green
- [ ] Keeper 재기동 후 \`curl -s localhost:\${MASC_PORT:-8935}/api/keeper/issue_king/snapshot\`에서 \`network_mode=\"inherit\"\`, \`tool_preset=\"delivery\"\`, \`work_discovery_sources=[\"unclaimed_tasks\",\"stale_tasks\"]\`, \`github_identity=\"anyang-keepers\"\` 확인
- [ ] 3개 keeper에 smoke task 할당 후 24h 내 \`keeper_shell op=git_clone\` exit code 0 관찰
- [ ] Prometheus \`masc_keeper_toml_invalid_total\` / \`masc_keeper_bash_network_upgrade_total\` 노출 확인

## Out of scope (deferred)

- board_comment cost rebalancing (\`lib/trajectory.ml\`)
- \`force_tool_call\` / \`tool_required\` schema (#8778 후속)
- sangsu persona JSON 신규 생성
- 나머지 13 keeper TOML의 유사 결함 — 같은 패턴이면 동일 fix 적용 가능하나 blast radius 제한을 위해 이 PR은 3개로

Plan file: \`planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-keep-crispy-cook.md\`

Related: masc-mcp #8773 (CLOSED), #8778 (CLOSED), #9807 (MERGED). 이 PR은 위 3건에서 해결되지 않고 남은 설정·enum·관측성 축을 복구.