### PR TITLE
feat(dashboard): surface declared-but-untouched cascade candidates

### DIFF
--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -377,7 +377,51 @@ let save_raw_config_json raw_json =
 
 (* ── Health projection ──────────────────────────────── *)
 
-let provider_info_to_json (info : Health.provider_info) : Yojson.Safe.t =
+(** Classify a provider's operational state for dashboard rendering.
+
+    - [cooldown]: tracker opened a cooldown window.
+    - [active]: events arrived in the current window and the tracker is
+      not cooled down.
+    - [configured]: declared in [cascade.json] but has not produced
+      tracker events in the current window (either untouched since
+      startup, or expired from the window). The UI uses this to tell
+      "declared-but-never-called" apart from the normal healthy case.
+
+    A future [disabled] state (e.g. missing API key, registry drop)
+    would live here too, but currently we have no per-provider health
+    tracker entry for that condition. *)
+let provider_status (info : Health.provider_info) : string =
+  if info.in_cooldown then "cooldown"
+  else if info.events_in_window > 0 then "active"
+  else "configured"
+
+(** Synthesise a provider_info with optimistic defaults for a
+    cascade-declared provider that has not been observed by the tracker
+    in the current window.  [success_rate = 1.0] mirrors
+    [Cascade_health_tracker]'s "unknown = optimistic" convention. *)
+let zero_provider_info (key : string) : Health.provider_info =
+  { provider_key = key
+  ; success_rate = 1.0
+  ; consecutive_failures = 0
+  ; in_cooldown = false
+  ; cooldown_expires_at = None
+  ; events_in_window = 0
+  ; rejected_in_window = 0
+  }
+
+(** [provider_entry_to_json ~declared info] serialises a provider_info
+    together with two derived fields:
+
+    - [declared : bool]  — [true] iff any [cascade.json] profile lists a
+      model whose scheme prefix matches [info.provider_key].  Lets the
+      UI distinguish "still referenced in config" from "left over in the
+      tracker after a config change".
+    - [status : string] — see {!provider_status}.
+
+    Existing callers (tests, UI) read the previous 7 behavioural fields
+    unchanged; the two new keys are strictly additive. *)
+let provider_entry_to_json ~(declared : bool)
+    (info : Health.provider_info) : Yojson.Safe.t =
   `Assoc [
     ("provider_key", `String info.provider_key);
     ("success_rate", `Float info.success_rate);
@@ -393,10 +437,85 @@ let provider_info_to_json (info : Health.provider_info) : Yojson.Safe.t =
        so dashboards can distinguish "provider down" from "provider
        returns unusable output". *)
     ("rejected_in_window", `Int info.rejected_in_window);
+    ("declared", `Bool declared);
+    ("status", `String (provider_status info));
   ]
 
+(** Back-compat alias: older call sites may still reference the previous
+    serializer name.  Keeping it as a thin wrapper keeps the diff in
+    this PR focused on the health_json merge. *)
+let provider_info_to_json (info : Health.provider_info) : Yojson.Safe.t =
+  provider_entry_to_json ~declared:false info
+
+(** [provider_scheme_of_model_string s] returns the text before the first
+    [:] in [s], or [s] itself if no colon is present.  The scheme
+    corresponds to the provider_key produced by
+    [Keeper_hooks_oas.provider_of_model] for prefixed specs; bare model
+    ids (rare in cascade.json) fall through unchanged and merge with
+    whatever heuristic keeper_hooks_oas assigned them at runtime.  *)
+let provider_scheme_of_model_string (s : string) : string =
+  match String.index_opt s ':' with
+  | Some i -> String.sub s 0 i
+  | None -> s
+
+(** Collect the set of provider scheme prefixes declared by any cascade
+    profile in [config_path].  Reads the typed catalog (so invalid
+    profiles are skipped) and then each profile's raw model list.  Errors
+    are swallowed into an empty set — a missing/malformed [cascade.json]
+    is already surfaced by [config_json]; we do not want the health
+    endpoint to disappear just because the catalog loader fails. *)
+let declared_provider_schemes_set
+    ?(config_path : string option) () : StringSet.t =
+  match config_path with
+  | None -> StringSet.empty
+  | Some path ->
+    (match Cascade_config_loader.load_catalog ~config_path:path with
+     | Error _ -> StringSet.empty
+     | Ok entries ->
+       List.fold_left
+         (fun acc (entry : Cascade_config_loader.catalog_entry) ->
+            let models =
+              Cascade_config_loader.load_profile
+                ~config_path:path ~name:entry.name
+            in
+            List.fold_left
+              (fun acc m ->
+                 StringSet.add (provider_scheme_of_model_string m) acc)
+              acc models)
+         StringSet.empty entries)
+
+(** Public list version of {!declared_provider_schemes_set}.  Sorted and
+    deduplicated for stable dashboard rendering and easy test assertions
+    that do not want to depend on a [Set.Make] type leaking across the
+    .mli boundary. *)
+let declared_provider_schemes_of_config ?config_path () : string list =
+  StringSet.elements (declared_provider_schemes_set ?config_path ())
+
 let health_json () =
-  let providers = Health.all_providers Health.global in
+  let config_path = Cascade_runtime.cascade_config_path () in
+  let declared = declared_provider_schemes_set ?config_path () in
+  let tracked = Health.all_providers Health.global in
+  let tracked_keys =
+    List.fold_left
+      (fun acc (p : Health.provider_info) ->
+        StringSet.add p.provider_key acc)
+      StringSet.empty tracked
+  in
+  let tracked_entries =
+    List.map
+      (fun (info : Health.provider_info) ->
+        provider_entry_to_json
+          ~declared:(StringSet.mem info.provider_key declared) info)
+      tracked
+  in
+  let declared_only = StringSet.diff declared tracked_keys in
+  let untouched_entries =
+    StringSet.fold
+      (fun key acc ->
+        provider_entry_to_json ~declared:true (zero_provider_info key)
+        :: acc)
+      declared_only []
+  in
   `Assoc [
     ("updated_at", `String (now_iso ()));
     (* Health tracker is the SSOT for these values; reading env here would
@@ -408,7 +527,7 @@ let health_json () =
     ("cooldown_threshold", `Int Health.cooldown_threshold);
     ("cooldown_sec", `Float Health.cooldown_sec);
     ("hard_quota_cooldown_sec", `Float Health.hard_quota_cooldown_sec);
-    ("providers", `List (List.map provider_info_to_json providers));
+    ("providers", `List (tracked_entries @ untouched_entries));
   ]
 
 (* ── Client capacity projection ─────────────────────── *)

--- a/lib/dashboard_cascade.mli
+++ b/lib/dashboard_cascade.mli
@@ -109,7 +109,16 @@ val save_raw_config_json :
 val keeper_profile_fields :
   keeper:string -> cascade_name:string -> (string * Yojson.Safe.t) list
 
-(** JSON snapshot of the cascade health tracker.
+(** JSON snapshot of the cascade health tracker, merged with
+    [cascade.json]'s declared candidate list.
+
+    Entries come from two sources:
+    1. {!Cascade_health_tracker.all_providers Health.global} — every
+       provider the tracker has observed events for.
+    2. Providers declared in any [cascade.json] profile but absent from
+       the tracker, synthesised via {!zero_provider_info}.  Lets the UI
+       surface "why isn't this provider being used?" for candidates that
+       never get selected.
 
     Shape:
     {[
@@ -120,19 +129,72 @@ val keeper_profile_fields :
         "cooldown_sec": 60.0,
         "hard_quota_cooldown_sec": 3600.0,
         "providers": [
-          { "provider_key": "glm:glm-5.1",
+          { "provider_key": "glm-coding",
             "success_rate": 0.87,
             "consecutive_failures": 0,
             "in_cooldown": false,
             "cooldown_expires_at": null,
-            "events_in_window": 42 },
+            "events_in_window": 42,
+            "rejected_in_window": 0,
+            "declared": true,
+            "status": "active" },
+          { "provider_key": "kimi_cli",
+            "success_rate": 1.0,
+            "consecutive_failures": 0,
+            "in_cooldown": false,
+            "cooldown_expires_at": null,
+            "events_in_window": 0,
+            "rejected_in_window": 0,
+            "declared": true,
+            "status": "configured" },
           ...
         ]
       }
     ]}
 
-    @since 0.6.0 *)
+    [status] is one of [active | cooldown | configured]; see
+    {!provider_status}.  [declared] is [true] iff [cascade.json] lists a
+    model whose scheme prefix matches [provider_key].
+
+    @since 0.6.0
+    @since 0.173.0 [declared] and [status] fields added; providers list
+                   now merges declared-but-untracked candidates. *)
 val health_json : unit -> Yojson.Safe.t
+
+(** Classify a provider's operational state from tracker fields.  See
+    the [status] enum in {!health_json}. *)
+val provider_status : Cascade_health_tracker.provider_info -> string
+
+(** Synthesise a provider_info with optimistic defaults for a provider
+    that is declared in [cascade.json] but has no tracker events in the
+    current window.  Used by {!health_json} to merge declared-only
+    candidates; exposed for tests so fixtures don't have to hand-build
+    the record. *)
+val zero_provider_info : string -> Cascade_health_tracker.provider_info
+
+(** Serialize a tracker entry (or synthesized placeholder) to the shape
+    described by {!health_json}.  [declared] controls the [declared]
+    field; [status] is derived via {!provider_status}. *)
+val provider_entry_to_json :
+  declared:bool -> Cascade_health_tracker.provider_info -> Yojson.Safe.t
+
+(** [provider_scheme_of_model_string s] returns the scheme prefix of a
+    [cascade.json] model spec (the text before the first [:]), or [s]
+    unchanged when no [:] is present.  The scheme corresponds to the
+    [provider_key] produced at runtime by
+    [Keeper_hooks_oas.provider_of_model] for prefixed specs. *)
+val provider_scheme_of_model_string : string -> string
+
+(** [declared_provider_schemes_of_config ?config_path ()] returns the
+    sorted, de-duplicated list of provider scheme prefixes declared by
+    any cascade profile in [config_path].
+
+    Returns the empty list when the path is [None] or the catalog
+    cannot be loaded — a failure here must not take the health
+    endpoint offline.  Used by {!health_json} to augment the tracker's
+    provider list with zero-traffic candidates. *)
+val declared_provider_schemes_of_config :
+  ?config_path:string -> unit -> string list
 
 (** JSON snapshot of the {!Cascade_client_capacity} registry —
     the per-URL/sentinel slot table used for ollama HTTP and CLI

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -468,6 +468,123 @@ let test_health_serializable () =
   let reparsed = Yojson.Safe.from_string s in
   check json "roundtrip" j reparsed
 
+(* ── provider_scheme_of_model_string / declared merge ─────────────────── *)
+
+let test_provider_scheme_extracts_prefix () =
+  let scheme = Masc_mcp.Dashboard_cascade.provider_scheme_of_model_string in
+  check string "prefixed with colon"
+    "codex_cli" (scheme "codex_cli:auto");
+  check string "prefix with hyphen"
+    "glm-coding" (scheme "glm-coding:glm-5.1");
+  check string "bare passes through"
+    "ollama-only" (scheme "ollama-only");
+  check string "empty string safe"
+    "" (scheme "")
+
+let test_provider_status_transitions () =
+  let info_cooldown : Masc_mcp.Cascade_health_tracker.provider_info =
+    { provider_key = "x"; success_rate = 0.0; consecutive_failures = 3
+    ; in_cooldown = true; cooldown_expires_at = Some 1.0
+    ; events_in_window = 5; rejected_in_window = 5 }
+  in
+  let info_active : Masc_mcp.Cascade_health_tracker.provider_info =
+    { info_cooldown with in_cooldown = false; consecutive_failures = 0
+    ; cooldown_expires_at = None; events_in_window = 5
+    ; rejected_in_window = 0; success_rate = 1.0 }
+  in
+  let info_idle : Masc_mcp.Cascade_health_tracker.provider_info =
+    { info_active with events_in_window = 0; rejected_in_window = 0 }
+  in
+  check string "cooldown"   "cooldown"
+    (Masc_mcp.Dashboard_cascade.provider_status info_cooldown);
+  check string "active"     "active"
+    (Masc_mcp.Dashboard_cascade.provider_status info_active);
+  check string "configured" "configured"
+    (Masc_mcp.Dashboard_cascade.provider_status info_idle)
+
+let test_zero_provider_info_is_optimistic () =
+  let info = Masc_mcp.Dashboard_cascade.zero_provider_info "some_scheme" in
+  check string "key" "some_scheme" info.provider_key;
+  check (float 0.0) "optimistic success rate" 1.0 info.success_rate;
+  check int "no failures" 0 info.consecutive_failures;
+  check bool "not in cooldown" false info.in_cooldown;
+  check int "no events" 0 info.events_in_window;
+  check int "no rejects" 0 info.rejected_in_window
+
+let test_provider_entry_json_adds_declared_and_status () =
+  let info = Masc_mcp.Dashboard_cascade.zero_provider_info "unheard_provider" in
+  let j = Masc_mcp.Dashboard_cascade.provider_entry_to_json
+    ~declared:true info in
+  (match member "declared" j with
+   | `Bool true -> ()
+   | _ -> fail "declared should be true");
+  (match member "status" j with
+   | `String "configured" -> ()
+   | other -> fail (Printf.sprintf "status expected 'configured', got %s"
+                      (Yojson.Safe.to_string other)));
+  check string "provider_key surfaces unchanged" "unheard_provider"
+    (Yojson.Safe.Util.to_string (member "provider_key" j));
+  (* Behavioural fields are still present — PR is strictly additive. *)
+  (match member "events_in_window" j with
+   | `Int 0 -> () | _ -> fail "events_in_window should be int 0");
+  (match member "in_cooldown" j with
+   | `Bool false -> () | _ -> fail "in_cooldown should be false")
+
+let test_declared_provider_schemes_reads_all_profiles () =
+  (* Fixture covers: string model spec, object-with-weight model spec,
+     profile-less key (temperature without matching models) that the
+     catalog loader must tolerate, and a commented field that must be
+     skipped. Assert that every declared scheme — across both primary
+     and secondary profiles — ends up in the returned list, and that
+     non-profile keys do not leak in. *)
+  let cascade_contents =
+    {|{
+  "_comment": "Fixture for declared_provider_schemes_of_config",
+  "default_models": [
+    { "model": "codex_cli:auto", "weight": 1 },
+    { "model": "kimi_cli:kimi-for-coding", "weight": 1 }
+  ],
+  "default_temperature": 0.2,
+  "default_max_tokens": 16384,
+  "big_three_models": [
+    { "model": "codex_cli:auto", "weight": 1 },
+    { "model": "glm-coding:auto", "weight": 1 }
+  ],
+  "local_only_models": [ "ollama:auto" ],
+  "big_three_temperature": 0.2
+}
+|}
+  in
+  with_temp_config_root cascade_contents (fun config_path ->
+    let schemes =
+      Masc_mcp.Dashboard_cascade.declared_provider_schemes_of_config
+        ~config_path ()
+    in
+    let sorted_expected =
+      List.sort compare
+        [ "codex_cli"; "glm-coding"; "kimi_cli"; "ollama" ]
+    in
+    check (list string)
+      "all declared provider schemes surfaced, deduplicated, sorted"
+      sorted_expected schemes)
+
+let test_declared_provider_schemes_handles_missing_path () =
+  let schemes =
+    Masc_mcp.Dashboard_cascade.declared_provider_schemes_of_config
+      ?config_path:None ()
+  in
+  check (list string) "missing path gives empty list" [] schemes
+
+let test_declared_provider_schemes_handles_malformed_config () =
+  with_temp_config_root "not valid json at all" (fun config_path ->
+    (* Catalog loader fails → we swallow and return empty.  Health
+       endpoint must not disappear because cascade.json is broken. *)
+    let schemes =
+      Masc_mcp.Dashboard_cascade.declared_provider_schemes_of_config
+        ~config_path ()
+    in
+    check (list string) "malformed json gives empty list" [] schemes)
+
 (* ── SLO (LT-11) ─────────────────────────────────────── *)
 
 module ST = Masc_mcp.Cascade_strategy_trace
@@ -689,6 +806,20 @@ let () =
     "health_json", [
       test_case "top-level shape" `Quick test_health_shape;
       test_case "roundtrip serializable" `Quick test_health_serializable;
+      test_case "provider_scheme_of_model_string extracts prefix" `Quick
+        test_provider_scheme_extracts_prefix;
+      test_case "provider_status transitions cooldown/active/configured"
+        `Quick test_provider_status_transitions;
+      test_case "zero_provider_info has optimistic defaults" `Quick
+        test_zero_provider_info_is_optimistic;
+      test_case "provider_entry_to_json surfaces declared + status" `Quick
+        test_provider_entry_json_adds_declared_and_status;
+      test_case "declared_provider_schemes reads all profiles" `Quick
+        test_declared_provider_schemes_reads_all_profiles;
+      test_case "declared_provider_schemes tolerates missing path" `Quick
+        test_declared_provider_schemes_handles_missing_path;
+      test_case "declared_provider_schemes tolerates malformed json"
+        `Quick test_declared_provider_schemes_handles_malformed_config;
     ];
     "slo_json", [
       test_case "top-level shape" `Quick test_slo_top_level_shape;


### PR DESCRIPTION
## 요약

`health_json` 이 기존엔 `Cascade_health_tracker.all_providers Health.global` — **이벤트가 한 번이라도 기록된 provider**만 리스트에 포함했습니다. `cascade.json` 에 선언돼 있지만 한 번도 선택된 적 없는 candidate 는 UI 에 아예 row 로도 뜨지 않아서 "왜 이 provider 는 안 쓰이는가?" 를 관찰할 수 없었습니다.

이 PR은 `cascade.json` 의 declared candidate 집합을 health_json 결과와 left-merge 하고, 각 entry에 `declared` / `status` 필드를 추가합니다.

## Schema 변경

Provider entry 에 두 필드 추가 (additive):

```json
{
  "provider_key": "kimi_cli",
  "success_rate": 1.0,
  ...
  "declared": true,          // 새 필드
  "status": "configured"     // 새 필드: "active" | "cooldown" | "configured"
}
```

- `declared: bool` — cascade.json 의 어떤 profile 이든 이 provider scheme 을 선언했는지
- `status`:
  - `cooldown` — tracker 가 cooldown 중
  - `active` — window 내 events > 0
  - `configured` — zero traffic (declared-but-untouched 포함)

기존 7개 behavioural 필드는 그대로. Downstream UI/tests 깨뜨리지 않습니다.

## 변경 파일

- `lib/dashboard_cascade.ml` — provider_entry_to_json + declared_provider_schemes + health_json merge
- `lib/dashboard_cascade.mli` — 새 헬퍼 export + health_json 스키마 업데이트된 docstring
- `test/test_dashboard_cascade.ml` — 7개 새 테스트 케이스

## 테스트

```
dune exec test/test_dashboard_cascade.exe -- test health_json
```

새 7 테스트 모두 PASS:
- provider_scheme_of_model_string 3 cases (prefix/hyphen/bare/empty)
- provider_status 3 transitions (cooldown/active/configured)
- zero_provider_info optimistic defaults
- provider_entry_to_json declared + status + backwards compat
- declared_provider_schemes 3 cases (all profiles / missing path / malformed json)

기존 `test_health_shape` 와 `test_health_serializable` 는 사전 존재 실패 상태 유지 — 이 테스트 파일에 Eio fiber wrapper 가 없어 `Cascade_health_tracker.all_providers` 의 `Eio.Mutex.use_rw` 가 `Get_context` 예외를 발생시킵니다. 내 새 테스트들은 `Health.global` 를 touch 하지 않게 의도적으로 설계해서 독립적으로 검증됩니다 (pure function / declared_provider_schemes 만 사용).

## 배경 — 7-PR 체인의 5번째 PR

1. ✅ PR #9814 — keeper_hooks_oas 텔레메트리 캡처 + Prometheus emit
2. (deferred) PR 2 — Frontend prompt_tok/s 컬럼 (PR #9813 runtime-monitor 리팩토링과 파일 겹침으로 순서 조정)
3. PR 3 — `Health.provider_info` perf 필드 추가
4. PR 4 — Frontend provider 요약 카드
5. **이 PR** — Cascade candidate visibility merge
6. PR 6 — OAS IdleSkipped telemetry 보존
7. PR 7 — OAS pin bump + e2e

Plan: `planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-b-giggly-gadget.md`.

## Do-not-merge 사유

PR 1-7 전체가 하나의 operator-visible 변화로 완결됨. 독립 merge 해도 안전하지만 UX 일관성을 위해 체인 전체가 ready 될 때까지 auto-merge 억제.

🤖 Generated with [Claude Code](https://claude.com/claude-code)