### PR TITLE
fix(keeper): RMW retry for write_meta CAS conflict on cycle completion (#9764, #9733, #9769)

### DIFF
--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -1940,6 +1940,54 @@ let write_meta ?(force = false) config (m : keeper_meta) : (unit, string) result
       Error (Printf.sprintf "failed to read existing meta for CAS %s: %s" path msg))
 ;;
 
+let is_version_conflict_error msg =
+  let re = Re.Pcre.re "meta version conflict" |> Re.compile in
+  try ignore (Re.exec re msg); true with Not_found -> false
+
+(* #9764/#9733/#9769: cycle-completion writes lose data when a heartbeat or
+   supervisor fiber bumps meta_version between the cycle's read and its
+   write. Bounded retry that re-reads the latest disk version, lifts the
+   caller's payload onto it, and writes again.
+
+   Trade-off: the caller's payload wins at the field level — concurrent
+   updates from heartbeat (last_seen, cursor) are overwritten. This is
+   acceptable for cycle completion because (a) heartbeat fields are
+   ephemeral and resync on the next heartbeat tick, while (b) cycle
+   payload (usage tokens, trace_history, generation) is non-recoverable.
+   Heartbeat itself must NOT use this helper (it would cause the inverse
+   problem). *)
+let write_meta_with_retry
+      ?(max_retries = 3)
+      config
+      (m : keeper_meta)
+  : (unit, string) result
+  =
+  let path = keeper_meta_path config m.name in
+  let rec attempt n m =
+    match write_meta config m with
+    | Ok () -> Ok ()
+    | Error msg when n >= max_retries -> Error msg
+    | Error msg when not (is_version_conflict_error msg) -> Error msg
+    | Error _ ->
+      (* Version conflict — read latest disk state, lift caller's payload
+         onto its version, and try again. *)
+      (match read_meta_file_path path with
+       | Ok (Some latest) ->
+         Log.Keeper.warn
+           "write_meta CAS retry %d/%d for %s (caller had %d, disk %d)"
+           (n + 1) max_retries m.name m.meta_version latest.meta_version;
+         attempt (n + 1) { m with meta_version = latest.meta_version }
+       | Ok None ->
+         (* Disk file vanished between attempts; fall back to fresh write. *)
+         attempt (n + 1) { m with meta_version = 0 }
+       | Error read_msg ->
+         Error
+           (Printf.sprintf
+              "write_meta retry: failed to re-read for CAS: %s" read_msg))
+  in
+  attempt 0 m
+;;
+
 (** Fiber-level health for keeper supervisor monitoring.
     Defined here (not in Keeper_supervisor) to avoid circular
     dependencies between keeper_exec_status and the keeper supervisor. *)

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -281,6 +281,27 @@ val keeper_names : Coord.config -> string list
 val keepalive_keeper_names : Coord.config -> string list
 val persistent_agent_names : Coord.config -> string list
 val write_meta : ?force:bool -> Coord.config -> keeper_meta -> (unit, string) result
+
+val write_meta_with_retry :
+  ?max_retries:int -> Coord.config -> keeper_meta -> (unit, string) result
+(** CAS write with bounded retry on version conflict.
+
+    On version conflict, re-reads disk to learn the latest version,
+    lifts the caller's payload onto it, and writes again. Retries up
+    to [max_retries] (default 3) times. Non-conflict errors fail
+    immediately.
+
+    Trade-off: payload-wins-at-field-level. Concurrent writes from
+    other fibers (e.g. heartbeat updating last_seen) are overwritten
+    by this caller's payload. Use only when the caller's data is
+    less recoverable than the concurrent writer's (cycle completion
+    qualifies; heartbeat does NOT — it should keep using {!write_meta}
+    and tolerate occasional CAS conflicts). See #9764 / #9733 / #9769. *)
+
+val is_version_conflict_error : string -> bool
+(** True when [write_meta] returned an error caused by CAS version
+    mismatch (vs an actual I/O failure). Useful for callers that want
+    to log conflicts at WARN and other failures at ERROR. *)
 val keeper_name_from_agent_name : string -> string option
 val canonical_keeper_name_from_agent_name : string -> string option
 val canonical_keeper_name : string -> string option

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1495,11 +1495,15 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             ?fallback_reason
             ~social_state
             ~error:e_str ();
-          (match write_meta config updated_meta with
+          (match write_meta_with_retry config updated_meta with
            | Ok () -> ()
            | Error msg ->
-               Log.Keeper.error
-                 "write_meta failed after unified turn failure: %s" msg);
+               if is_version_conflict_error msg then
+                 Log.Keeper.warn
+                   "write_meta lost CAS race after retries (turn failure path): %s" msg
+               else
+                 Log.Keeper.error
+                   "write_meta failed after unified turn failure: %s" msg);
           if is_ambiguous_partial then begin
             let failure_reason =
               Option.value
@@ -1785,10 +1789,18 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             latency_ms
             turn_mode_label
             outcome_str;
-          (* 7. Persist updated meta *)
-          (match write_meta config updated_meta with
+          (* 7. Persist updated meta — RMW retry to avoid losing the cycle's
+             usage/trace data when a heartbeat fiber bumps meta_version
+             between the cycle's read and its write. See #9764. *)
+          (match write_meta_with_retry config updated_meta with
            | Ok () -> ()
-           | Error msg -> Log.Keeper.error "write_meta failed after keeper cycle: %s" msg);
+           | Error msg ->
+               if is_version_conflict_error msg then
+                 Log.Keeper.warn
+                   "write_meta lost CAS race after retries (keeper cycle): %s" msg
+               else
+                 Log.Keeper.error
+                   "write_meta failed after keeper cycle: %s" msg);
           (* 8. Handle stop reason *)
           (match result.stop_reason with
            | Oas_worker.TurnBudgetExhausted { turns_used; limit } ->

--- a/test/dune
+++ b/test/dune
@@ -334,6 +334,7 @@
         test_server_base_path_diagnostics
         test_server_startup_takeover
         test_keeper_meta_listing
+        test_keeper_meta_cas_retry
         test_keeper_identity_parse
         test_worker_runtime
         test_capability_registry
@@ -499,6 +500,7 @@
         test_server_base_path_diagnostics
         test_server_startup_takeover
         test_keeper_meta_listing
+        test_keeper_meta_cas_retry
         test_keeper_identity_parse
         test_worker_runtime
         test_capability_registry

--- a/test/test_keeper_meta_cas_retry.ml
+++ b/test/test_keeper_meta_cas_retry.ml
@@ -1,0 +1,138 @@
+(** #9764/#9733/#9769: write_meta CAS retry semantics.
+
+    Verifies that [Keeper_types.write_meta_with_retry]:
+      - succeeds when no concurrent writer interferes
+      - succeeds after N attempts when the disk version has advanced
+      - distinguishes version conflicts from real I/O errors via
+        [is_version_conflict_error] *)
+
+open Alcotest
+open Masc_mcp
+
+let () = Server_startup_state.mark_state_ready ~backend_mode:"test"
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_keeper_meta_cas_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let ensure_fs env =
+  if not (Fs_compat.has_fs ()) then
+    Fs_compat.set_fs (Eio.Stdenv.fs env)
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else
+        Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let make_meta ~name =
+  match
+    Keeper_types.meta_of_json
+      (`Assoc
+        [
+          ("name", `String name);
+          ("agent_name", `String ("keeper-" ^ name ^ "-agent"));
+          ("trace_id", `String ("trace-" ^ name));
+          ("goal", `String "test keeper");
+          ("autoboot_enabled", `Bool false);
+        ])
+  with
+  | Ok m -> m
+  | Error e -> fail ("meta_of_json failed: " ^ e)
+
+let test_no_conflict_writes_first_attempt () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) (fun () ->
+    let config = Coord.default_config base_dir in
+    ignore (Coord.init config ~agent_name:(Some "operator"));
+    let m0 = make_meta ~name:"alpha" in
+    (* Initial write — no existing file. *)
+    (match Keeper_types.write_meta_with_retry config m0 with
+     | Ok () -> ()
+     | Error e -> fail ("first write failed: " ^ e));
+    (* Read what landed on disk and bump caller's version to match. *)
+    let disk = match Keeper_types.read_meta config "alpha" with
+      | Ok (Some m) -> m
+      | _ -> fail "disk read failed"
+    in
+    let m1 = { disk with goal = "updated goal" } in
+    match Keeper_types.write_meta_with_retry config m1 with
+    | Ok () ->
+      let after = match Keeper_types.read_meta config "alpha" with
+        | Ok (Some m) -> m
+        | _ -> fail "read after write failed"
+      in
+      check string "goal updated" "updated goal" after.goal
+    | Error e -> fail ("second write failed: " ^ e))
+
+let test_retry_succeeds_after_concurrent_bump () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) (fun () ->
+    let config = Coord.default_config base_dir in
+    ignore (Coord.init config ~agent_name:(Some "operator"));
+    let m0 = make_meta ~name:"beta" in
+    (match Keeper_types.write_meta ~force:true config m0 with
+     | Ok () -> ()
+     | Error e -> fail ("seed write failed: " ^ e));
+    let caller_view = match Keeper_types.read_meta config "beta" with
+      | Ok (Some m) -> m
+      | _ -> fail "seed read failed"
+    in
+    (* Simulate a concurrent writer bumping the disk version while
+       [caller_view] is held by the cycle-completion fiber. *)
+    let racing = { caller_view with goal = "racing writer" } in
+    (match Keeper_types.write_meta config racing with
+     | Ok () -> ()
+     | Error e -> fail ("racing write failed: " ^ e));
+    (* Now the cycle attempts to write its own payload. CAS would fail
+       once; write_meta_with_retry must lift the payload onto the new
+       disk version and succeed. *)
+    let cycle_payload = { caller_view with goal = "cycle payload" } in
+    (match Keeper_types.write_meta_with_retry config cycle_payload with
+     | Ok () -> ()
+     | Error e -> fail ("retry write failed: " ^ e));
+    let final = match Keeper_types.read_meta config "beta" with
+      | Ok (Some m) -> m
+      | _ -> fail "final read failed"
+    in
+    check string "cycle payload wins (last writer)" "cycle payload" final.goal;
+    check bool "version moved past racing write" true
+      (final.meta_version > racing.meta_version + 1))
+
+let test_is_version_conflict_error_classifies () =
+  let conflict_msg = "meta version conflict for foo: expected 3, disk has 4" in
+  let other_msg = "failed to write meta /tmp/x: Permission denied" in
+  check bool "classifies version conflict" true
+    (Keeper_types.is_version_conflict_error conflict_msg);
+  check bool "rejects unrelated error" false
+    (Keeper_types.is_version_conflict_error other_msg)
+
+let () =
+  run "Keeper_types CAS retry (#9764/#9733/#9769)"
+    [
+      ( "write_meta_with_retry",
+        [
+          test_case "writes on first attempt when no conflict" `Quick
+            test_no_conflict_writes_first_attempt;
+          test_case "lifts payload onto disk version after concurrent bump" `Quick
+            test_retry_succeeds_after_concurrent_bump;
+        ] );
+      ( "is_version_conflict_error",
+        [
+          test_case "classifies conflict vs I/O error" `Quick
+            test_is_version_conflict_error_classifies;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Three live-issue reports reduce to one root cause: cycle-completion `write_meta` is CAS-gated on `meta_version`, but heartbeat/supervisor fibers can bump the disk version between the cycle's read and write. The losing fiber loses the entire cycle payload (usage tokens, trace_history, generation) and logs at ERROR, polluting failure signals.

```
[ERROR] write_meta failed after keeper cycle: meta version conflict
        for nick0cave: expected 13, disk has 14
```

This is a textbook optimistic-concurrency-control problem. Standard remedy: bounded read-modify-write retry, used by Patroni (PostgreSQL HA via etcd CAS), Apache Curator (ZooKeeper `DistributedAtomicLong`), and `java.util.concurrent.atomic.AtomicReference#compareAndSet`.

## Changes

**`lib/keeper/keeper_types.{ml,mli}`** — new helpers:
- `write_meta_with_retry ?max_retries config m` — on version conflict, re-reads disk, lifts the caller's payload onto the latest version, retries (bounded, default 3). Non-conflict errors fail fast.
- `is_version_conflict_error msg : bool` — classifier so callers can split conflicts (WARN, recoverable) from actual I/O failures (ERROR).

**`lib/keeper/keeper_unified_turn.ml`** — two cycle-completion writes:
- Switch to `write_meta_with_retry`.
- Downgrade exhausted-retry conflict logs from ERROR to WARN (per #9764).
- ERROR retained for real I/O failures (disk full, perm denied).

## Trade-off (explicit)

`write_meta_with_retry` is **payload-wins-at-field-level**. Concurrent updates from other fibers (e.g. heartbeat's `last_seen`) are overwritten by this caller's payload.

This is the right choice for **cycle completion** because:
- heartbeat fields are ephemeral and resync within ~5 s
- cycle payload (usage tokens, trace history, generation) is non-recoverable

Heartbeat itself must NOT use the new helper (it would cause the inverse loss). The .mli docstring states this explicitly. Keepalive paths continue to use plain `write_meta` and tolerate occasional CAS conflicts (already logged at WARN, not ERROR).

## Why this isn't a band-aid

Two alternatives I considered and rejected:

| Alternative | Reason rejected |
|------------|-----------------|
| `force=true` no retry, no read | Loses every concurrent write blindly; no audit trail of conflict frequency |
| Strict field-level merge (read disk + diff fields + merge) | Right long-term, but requires field-level taxonomy (which fields are owned by which writer). Out of scope for one PR. Tracked as future work. |

The bounded RMW with documented payload-wins semantics is the smallest correct fix that reaches all three issues.

## Test plan

- [x] `dune build --root=. lib/` — clean
- [x] `dune exec test/test_keeper_meta_cas_retry.exe` — 3/3 pass:
  - clean first-attempt write
  - **successful lift-and-retry after simulated concurrent disk bump** (reproduces the exact production race)
  - classifier rejects unrelated I/O error messages
- [x] `dune exec test/test_keeper_unified.exe` — 16 pre-existing failures on `origin/main` baseline (verified via stash); my changes introduce zero new failures.

## Closes

- #9764 (downgrade ERROR + add retry — both done here)
- #9733 (suggested fix `add optimistic concurrency retry with backoff` — implemented as bounded RMW)
- #9769 (write_meta CAS conflict after timeout — same root cause)

## Followups (out of scope)

- supervisor presence sync (`keeper_supervisor.ml:263`) and other writers can opt into `write_meta_with_retry` if logs show similar conflicts; deliberately not included here to keep blast radius small.
- Strict field-level merge would eliminate the payload-wins trade-off entirely; worth a separate RFC if logs show heartbeat data loss after this lands.