### PR TITLE
feat(dashboard): render prefill tok_s and make missing labels observable

### DIFF
--- a/dashboard/src/components/runtime-monitor.test.ts
+++ b/dashboard/src/components/runtime-monitor.test.ts
@@ -1,6 +1,19 @@
 import { describe, it, expect } from 'vitest'
-import { runtimeProviderTone, modelMetricTone, fmtCost, fmtSuccessRate, fmtNumber, filterModelMetrics, sortModelMetricsByUrgency, metricCoverageText } from './runtime-monitor'
+import { runtimeProviderTone, modelMetricTone, fmtCost, fmtSuccessRate, fmtNumber, filterModelMetrics, sortModelMetricsByUrgency, metricCoverageText, recentEntryMissingLabel } from './runtime-monitor'
 import type { DashboardRuntimeProviderSnapshot, DashboardRuntimeModelMetric } from '../api/dashboard'
+
+type RecentEntry = NonNullable<DashboardRuntimeModelMetric['recent_entries']>[number]
+function makeRecentEntry(overrides: Partial<RecentEntry> = {}): RecentEntry {
+  return {
+    ts_unix: 0,
+    input_tokens: null,
+    output_tokens: null,
+    latency_ms: null,
+    cost_usd: null,
+    tools_count: 0,
+    ...overrides,
+  }
+}
 
 function makeProvider(overrides: Partial<DashboardRuntimeProviderSnapshot> = {}): DashboardRuntimeProviderSnapshot {
   return {
@@ -351,5 +364,88 @@ describe('sortModelMetricsByUrgency', () => {
     ]
     const result = sortModelMetricsByUrgency(sample)
     expect(result.map(m => m.model_id)).toEqual(['with-errors', 'unknown'])
+  })
+})
+
+// ── recentEntryMissingLabel ──
+//
+// The default fallback for "this cell has no value" used to be `--`, which
+// hides *why* the cell is empty. Operators need to tell "backend never
+// emitted this field" apart from "backend emitted an explicit zero" apart
+// from "the whole turn errored out". The label picks the most specific
+// signal the entry provides.
+
+describe('recentEntryMissingLabel', () => {
+  it('surfaces error-only when the turn outcome itself was an error', () => {
+    expect(recentEntryMissingLabel(makeRecentEntry({ outcome: 'error' })))
+      .toBe('error-only')
+  })
+
+  it('flags text_only_unmetered as n/a (expected shape for tool-only turns)', () => {
+    expect(
+      recentEntryMissingLabel(
+        makeRecentEntry({ coverage_reason: 'text_only_unmetered' }),
+      ),
+    ).toBe('n/a')
+  })
+
+  it('reports no-telemetry when both flags are false', () => {
+    expect(
+      recentEntryMissingLabel(
+        makeRecentEntry({
+          telemetry_reported: false,
+          usage_reported: false,
+        }),
+      ),
+    ).toBe('no-telemetry')
+  })
+
+  it('reports no-timings when only telemetry_reported is false', () => {
+    expect(
+      recentEntryMissingLabel(
+        makeRecentEntry({
+          telemetry_reported: false,
+          usage_reported: true,
+        }),
+      ),
+    ).toBe('no-timings')
+  })
+
+  it('reports no-usage when only usage_reported is false', () => {
+    expect(
+      recentEntryMissingLabel(
+        makeRecentEntry({
+          telemetry_reported: true,
+          usage_reported: false,
+        }),
+      ),
+    ).toBe('no-usage')
+  })
+
+  it('falls back to "missing" when only a coverage_reason is present', () => {
+    expect(
+      recentEntryMissingLabel(
+        makeRecentEntry({ coverage_reason: 'latency_missing' }),
+      ),
+    ).toBe('missing')
+  })
+
+  it('renders an em-dash when nothing is known about the absence', () => {
+    expect(recentEntryMissingLabel(makeRecentEntry())).toBe('—')
+  })
+
+  it('keeps error-only priority over the reporting-flag signals', () => {
+    // An errored turn should show error-only even if telemetry flags are
+    // false for unrelated reasons; the user should not have to decode a
+    // no-timings label when the real story is that the turn failed.
+    expect(
+      recentEntryMissingLabel(
+        makeRecentEntry({
+          outcome: 'error',
+          telemetry_reported: false,
+          usage_reported: false,
+        }),
+      ),
+    ).toBe('error-only')
   })
 })

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -252,13 +252,23 @@ function fmtCoverageAwareCost(metric: DashboardRuntimeModelMetric, value?: numbe
   return formatted !== '--' ? formatted : metricMissingLabel(metric)
 }
 
-function recentEntryMissingLabel(
+export function recentEntryMissingLabel(
   entry: NonNullable<DashboardRuntimeModelMetric['recent_entries']>[number],
 ): string {
+  // Order: most-specific to least-specific.
+  // Goal: make "why is this cell empty?" observable instead of rendering an
+  // opaque `--`. The `telemetry_reported`/`usage_reported` flags land earlier
+  // in the response than `coverage_reason`, so they give the most direct
+  // signal when the cell is empty due to missing OAS timings vs. missing
+  // per-turn usage accounting.
   if (entry.outcome === 'error') return 'error-only'
   if (entry.coverage_reason === 'text_only_unmetered') return 'n/a'
+  if (entry.telemetry_reported === false && entry.usage_reported === false)
+    return 'no-telemetry'
+  if (entry.telemetry_reported === false) return 'no-timings'
+  if (entry.usage_reported === false) return 'no-usage'
   if (entry.coverage_reason) return 'missing'
-  return '--'
+  return '—'
 }
 
 function fmtRecentEntryNumber(
@@ -490,6 +500,12 @@ export function RuntimeMonitor() {
                             tone=${'ok'}
                           />`
                         : null}
+                      ${metric.prompt_avg_tok_per_sec != null
+                        ? html`<${StatusChip}
+                            label=${`${fmtNumber(metric.prompt_avg_tok_per_sec, 1)} tok/s prefill`}
+                            tone=${'ok'}
+                          />`
+                        : null}
                       ${metric.hw_decode_avg_tok_per_sec != null
                         ? html`<${StatusChip}
                             label=${`${fmtNumber(metric.hw_decode_avg_tok_per_sec, 1)} tok/s hw`}
@@ -511,6 +527,9 @@ export function RuntimeMonitor() {
                     <div>input/output · ${fmtCoverageAwareNumber(metric, metric.total_input_tokens)} / ${fmtCoverageAwareNumber(metric, metric.total_output_tokens)}</div>
                     <div>reasoning/cache · ${fmtCoverageAwareNumber(metric, metric.total_reasoning_tokens)} / ${fmtCoverageAwareNumber(metric, metric.total_cache_read_tokens)}</div>
                     <div>tools · ${fmtNumber(metric.avg_tool_calls_per_turn, 1)}/turn (${fmtNumber(metric.total_tool_calls)})</div>
+                    ${metric.prompt_p50_tok_per_sec != null || metric.prompt_p95_tok_per_sec != null
+                      ? html`<div class="col-span-3 text-text-muted">prefill tok/s p50/p95 · ${fmtNumber(metric.prompt_p50_tok_per_sec, 1)} / ${fmtNumber(metric.prompt_p95_tok_per_sec, 1)} (prompt_eval only; complements wall + hw rows)</div>`
+                      : null}
                     ${metric.hw_decode_p50_tok_per_sec != null
                       ? html`<div class="col-span-3 text-text-muted">hw tok/s p50/p95 · ${fmtNumber(metric.hw_decode_p50_tok_per_sec, 1)} / ${fmtNumber(metric.hw_decode_p95_tok_per_sec, 1)} (decode-only; excludes queue/prefill/thinking)</div>`
                       : null}
@@ -570,18 +589,19 @@ export function RuntimeMonitor() {
                       </button>
                       ${expandedModel.value === metric.model_id
                         ? html`<div class="mt-1 border-t border-card-border/50 pt-2">
-                            <div class="grid grid-cols-6 gap-1 text-3xs text-[var(--text-muted)] font-medium mb-1">
-                              <div>time</div><div>in tok</div><div>out tok</div><div>latency</div><div>cost</div><div>tools</div>
+                            <div class="grid grid-cols-7 gap-1 text-3xs text-[var(--text-muted)] font-medium mb-1">
+                              <div>time</div><div>in tok</div><div>out tok</div><div>latency</div><div>prefill tok/s</div><div>cost</div><div>tools</div>
                             </div>
                             ${metric.recent_entries?.map(re => {
                               const detail = recentEntryDetail(re)
                               return html`
                                 <div class="mb-1">
-                                  <div class="grid grid-cols-6 gap-1 text-2xs text-[var(--text-body)]">
+                                  <div class="grid grid-cols-7 gap-1 text-2xs text-[var(--text-body)]">
                                     <div>${fmtTime(re.ts_unix)}</div>
                                     <div>${fmtRecentEntryNumber(re, re.input_tokens)}</div>
                                     <div>${fmtRecentEntryNumber(re, re.output_tokens)}</div>
                                     <div>${re.latency_ms == null ? recentEntryMissingLabel(re) : `${fmtNumber(re.latency_ms, 0)}ms`}</div>
+                                    <div>${fmtRecentEntryNumber(re, re.prompt_tok_per_sec, 1)}</div>
                                     <div>${fmtRecentEntryCost(re, re.cost_usd)}</div>
                                     <div>${re.tools_count}</div>
                                   </div>


### PR DESCRIPTION
## 요약

Runtime monitor 는 `prompt_avg_tok_per_sec` / `prompt_p50_tok_per_sec` / `prompt_p95_tok_per_sec` 와 `recent_entries[].prompt_tok_per_sec` 를 이미 `dashboard.ts` 에서 decode 했지만 **어디에도 렌더하지 않았습니다**. 사용자가 "prefill 이 느림" 과 "decode 가 느림" 을 구분할 수 없어 Ollama prefill 병목/cloud 큐 대기를 진단할 수 없는 구멍.

3 곳에 prefill rate 를 노출합니다:
- **헤더 StatusChip 줄**: 기존 `wall` / `hw` 칩 옆에 `tok/s prefill` 칩.
- **3-column 그리드**: `prefill tok/s p50/p95` 줄을 `hw tok/s p50/p95` 옆에 (값이 있을 때만).
- **Recent entries grid**: 6→7 컬럼. `prefill tok/s` 추가 (`recent_entries[].prompt_tok_per_sec`).

## 누락 사유 가시화 (`recentEntryMissingLabel`)

기존 default `--` 는 "데이터가 0" 과 "백엔드가 emit 안 함" 을 구분 못 했습니다. `telemetry_reported` / `usage_reported` 플래그를 사용해 명시적 label:

| 조건 | label |
|------|-------|
| outcome === 'error' | `error-only` |
| coverage_reason === 'text_only_unmetered' | `n/a` |
| telemetry_reported=false AND usage_reported=false | `no-telemetry` |
| telemetry_reported=false only | `no-timings` |
| usage_reported=false only | `no-usage` |
| coverage_reason present (no richer signal) | `missing` |
| 아무 정보 없음 | `—` |

`error-only`/`n/a` 가 새 flag 기반 label 보다 우선순위 높음 — errored turn 은 여전히 error-only 로 읽힘.

## 변경 파일

- `dashboard/src/components/runtime-monitor.ts` (30줄) — 렌더 사이트 3곳 + `recentEntryMissingLabel` 로직 + export
- `dashboard/src/components/runtime-monitor.test.ts` (98줄) — 8 신규 vitest 케이스

## 테스트

```
pnpm exec vitest run src/components/runtime-monitor.test.ts  # 60/60 pass (+8 new)
pnpm exec tsc --noEmit                                         # green
pnpm exec vite build                                           # ✓ built in 20.70s
```

무관한 pre-existing 실패 2 케이스 (`time-ago.test.ts` 한국어 locale, `quick-intervene.test.ts` timeout) 는 이 PR 과 상관 없음.

## 배경 — 7-PR 체인의 2번째 PR (unblocked)

이전 순서에서 PR #9813 (codex: `useManagedAsyncResource` refactor) 와 파일 겹침으로 연기됐었음. #9813 이 2026-04-24T01:55:37Z merged 돼서 unblock 되었고, 같은 hook 패턴 기반으로 새 컬럼을 추가합니다.

1. ✅ PR #9814 — keeper_hooks_oas 텔레메트리 캡처 + Prometheus emit (CI green, do-not-merge 유지)
2. **이 PR** — Frontend prefill 컬럼 + 누락 사유 가시화
3. PR 3 — `Health.provider_info` perf 필드 추가 (backend)
4. PR 4 — Frontend provider 요약 카드
5. PR #9822 — Cascade candidate visibility merge (backend, CI 진행 중)
6. PR 6 — OAS IdleSkipped telemetry 보존
7. PR 7 — OAS pin bump + e2e

Plan: `planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-b-giggly-gadget.md`.

## Do-not-merge 사유

체인 전체가 ready 될 때까지 auto-merge 억제. 단독 merge 해도 안전하지만 UX 일관성을 위해 묶음 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)