### PR TITLE
Scope approval always rules to rooms

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -333,6 +333,7 @@ let to_oas_approval_callback
       in
       if (not forbidden) && always_approve then (
         Keeper_approval_queue.audit_approval_event
+          ?base_path
           ~event_type:"auto_approved_always"
           ~id:(Printf.sprintf "auto_always_%s_%s" keeper_name tool_name)
           ~keeper_name ~tool_name ~risk_level ?turn_id ?task_id ?goal_id
@@ -344,6 +345,7 @@ let to_oas_approval_callback
         match rule_match with
         | Some matched ->
             Keeper_approval_queue.audit_approval_event
+              ?base_path
               ~event_type:"auto_approved_rule_match"
               ~id:(Printf.sprintf "auto_%s_%s" keeper_name matched.rule_id)
               ~keeper_name ~tool_name ~risk_level ?turn_id ?task_id ?goal_id

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -203,10 +203,10 @@ let make_generated_id prefix =
   let digest = Digestif.SHA256.(digest_string entropy |> to_hex) in
   prefix ^ "_" ^ String.sub digest 0 12
 
-let rules_mu = Eio.Mutex.create ()
+let rules_mu = Stdlib.Mutex.create ()
 
 let with_rules_lock f =
-  Eio.Mutex.use_rw ~protect:true rules_mu (fun () -> f ())
+  Stdlib.Mutex.protect rules_mu f
 
 let rules_path ?base_path () =
   let base_path =
@@ -320,16 +320,16 @@ let upsert_rule ?base_path ~keeper_name ~tool_name ~input ~risk_level
            Log.Keeper.warn "upsert_rule: save failed: %s" msg);
         (candidate, true))
 
-let delete_rule ~id =
+let delete_rule ?base_path ~id () =
   with_rules_lock (fun () ->
-    let rules = load_rules_unlocked () in
+    let rules = load_rules_unlocked ?base_path () in
     match List.find_opt (fun rule -> String.equal rule.id id) rules with
     | None -> Error (Printf.sprintf "approval rule %s not found" id)
     | Some deleted ->
         let remaining =
           List.filter (fun rule -> not (String.equal rule.id id)) rules
         in
-        (match save_rules_unlocked remaining with
+        (match save_rules_unlocked ?base_path remaining with
          | Ok () -> Ok deleted
          | Error msg -> Error msg))
 
@@ -376,30 +376,46 @@ let find_matching_rule ?base_path ~keeper_name ~tool_name ~input ~risk_level
 
 (** Dated JSONL audit trail for approval events.
     Stored at [<base_path>/.masc/audit-approvals/YYYY-MM/DD.jsonl].
-    Independent of Coord.config — approval is a global resource. *)
-let audit_store_ref : Dated_jsonl.t option ref = ref None
+    Dashboard and room-scoped keeper runs pass [base_path] explicitly so approval
+    history stays with the room that made the decision. *)
+let audit_stores_mu = Stdlib.Mutex.create ()
+let audit_io_mu = Stdlib.Mutex.create ()
+let audit_stores : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 4
 
-let get_audit_store () =
-  match !audit_store_ref with
-  | Some s -> Some s
-  | None ->
-    let base = Env_config_core.base_path () in
-    let dir = Filename.concat base ".masc/audit-approvals" in
-    (match Dated_jsonl.create ~base_dir:dir () with
-     | store ->
-       audit_store_ref := Some store;
-       Some store
-     | exception (Eio.Cancel.Cancelled _ as e) -> raise e
-     | exception exn ->
-       Log.Keeper.warn "approval_queue: audit store creation failed: %s"
-         (Printexc.to_string exn);
-       None)
+let audit_today_path base_dir =
+  let open Unix in
+  let tm = gmtime (gettimeofday ()) in
+  let month =
+    Printf.sprintf "%04d-%02d" (tm.tm_year + 1900) (tm.tm_mon + 1)
+  in
+  let day = Printf.sprintf "%02d.jsonl" tm.tm_mday in
+  let dir = Filename.concat base_dir month in
+  Fs_compat.mkdir_p dir;
+  Filename.concat dir day
 
-let audit_approval_event ~event_type ~id ~keeper_name ~tool_name
+let get_audit_store ?base_path () =
+  let base = Option.value ~default:(Env_config_core.base_path ()) base_path in
+  try
+    Stdlib.Mutex.protect audit_stores_mu (fun () ->
+      match Hashtbl.find_opt audit_stores base with
+      | Some store -> Some store
+      | None ->
+          let dir = Filename.concat base ".masc/audit-approvals" in
+          let store = Dated_jsonl.create ~base_dir:dir () in
+          Hashtbl.replace audit_stores base store;
+          Some store)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Log.Keeper.warn "approval_queue: audit store creation failed: %s"
+        (Printexc.to_string exn);
+      None
+
+let audit_approval_event ?base_path ~event_type ~id ~keeper_name ~tool_name
     ~risk_level ?turn_id ?task_id ?goal_id ?(goal_ids = [])
     ?runtime_contract ?selected_model ?disposition ?disposition_reason
     ?rule_match ?source_approval_id ?auto_approved ?(decision = "") () =
-  match get_audit_store () with
+  match get_audit_store ?base_path () with
   | None -> ()
   | Some store ->
     let json =
@@ -438,10 +454,13 @@ let audit_approval_event ~event_type ~id ~keeper_name ~tool_name
          | None -> []))
     in
     Safe_ops.protect ~default:() (fun () ->
-      Dated_jsonl.append store json)
+      Stdlib.Mutex.protect audit_io_mu (fun () ->
+        Fs_compat.append_jsonl
+          (audit_today_path (Dated_jsonl.base_dir store))
+          json))
 
-let audit_rule_event ~event_type (rule : approval_rule) =
-  audit_approval_event ~event_type ~id:rule.id
+let audit_rule_event ?base_path ~event_type (rule : approval_rule) =
+  audit_approval_event ?base_path ~event_type ~id:rule.id
     ~keeper_name:rule.keeper_name ~tool_name:rule.tool_name
     ~risk_level:rule.max_risk ?source_approval_id:rule.source_approval_id ()
 
@@ -454,10 +473,10 @@ let audit_scan_window ?keeper_name n =
          busy fleet cannot hide the target keeper behind unrelated events. *)
       max 500 (max n 1 * 64)
 
-let read_recent_audit ?keeper_name ?(n = 20) () : Yojson.Safe.t list =
+let read_recent_audit ?base_path ?keeper_name ?(n = 20) () : Yojson.Safe.t list =
   if n <= 0 then []
   else
-    match get_audit_store () with
+    match get_audit_store ?base_path () with
     | None -> []
     | Some store ->
         let raw = Dated_jsonl.read_recent store (audit_scan_window ?keeper_name n) in
@@ -475,7 +494,9 @@ let read_recent_audit ?keeper_name ?(n = 20) () : Yojson.Safe.t list =
         |> List.filteri (fun idx _ -> idx < n)
 
 module For_testing = struct
-  let reset_audit_store () = audit_store_ref := None
+  let reset_audit_store () =
+    Stdlib.Mutex.protect audit_stores_mu (fun () ->
+      Hashtbl.clear audit_stores)
 end
 
 let generate_id () =
@@ -632,7 +653,7 @@ let record_pending (entry : pending_approval) =
     ?disposition_reason:entry.disposition_reason ();
   broadcast_pending entry
 
-let resolve_entry (entry : pending_approval) (decision : decision) =
+let resolve_entry ?base_path (entry : pending_approval) (decision : decision) =
   let decision_str = match decision with
     | Oas.Hooks.Approve -> "approve"
     | Oas.Hooks.Reject reason -> "reject:" ^ reason
@@ -641,7 +662,7 @@ let resolve_entry (entry : pending_approval) (decision : decision) =
   Log.Keeper.info
     "HITL_APPROVAL_RESOLVED: id=%s keeper=%s tool=%s decision=%s"
     entry.id entry.keeper_name entry.tool_name decision_str;
-  audit_approval_event ~event_type:"resolved" ~id:entry.id
+  audit_approval_event ?base_path ~event_type:"resolved" ~id:entry.id
     ~keeper_name:entry.keeper_name ~tool_name:entry.tool_name
     ~risk_level:entry.risk_level ?turn_id:entry.turn_id ?task_id:entry.task_id
     ?goal_id:entry.goal_id ~goal_ids:entry.goal_ids
@@ -797,7 +818,7 @@ let remember_rule_for_entry ?base_path ?created_by (entry : pending_approval) =
         ?runtime_contract:entry.runtime_contract ?created_by
         ~source_approval_id:entry.id ()
     in
-    if created then audit_rule_event ~event_type:"rule_created" rule;
+    if created then audit_rule_event ?base_path ~event_type:"rule_created" rule;
     Some rule
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -826,7 +847,7 @@ let resolve_with_policy ?base_path ~id ~(decision : Oas.Hooks.approval_decision)
             remember_rule_for_entry ?base_path ?created_by entry
         | _ -> None
       in
-      resolve_entry entry decision;
+      resolve_entry ?base_path entry decision;
       Ok { remembered_rule }
 
 (** Resolve a pending approval. Returns [Ok ()] if found and resolved,

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -116,7 +116,7 @@ let severity_of_approval_event event decision =
       match decision with
       | Some raw when String_util.contains_substring_ci raw "reject" -> "bad"
       | _ -> "ok")
-  | "auto_approved_rule_match" | "rule_created" -> "ok"
+  | "auto_approved_rule_match" | "auto_approved_always" | "rule_created" -> "ok"
   | _ -> "warn"
 
 let severity_of_transition_type event_type =
@@ -197,6 +197,11 @@ let approval_event_timeline_event json =
             ( "approval_rule_match",
               Printf.sprintf "Approval Rule · %s" tool_name,
               Printf.sprintf "auto-approved by %s" matched_by,
+              None )
+        | "auto_approved_always" ->
+            ( "approval_always_flag",
+              Printf.sprintf "Approval Always · %s" tool_name,
+              "auto-approved by keeper always_approve flag",
               None )
         | "rule_created" ->
             ( "approval_rule_created",
@@ -508,6 +513,7 @@ let approval_state_json ~pending_approval_count ~latest_tool_call
     if pending_approval_count > 0 then "pending"
     else
       match latest_event_kind with
+      | Some "auto_approved_always" -> "always_flag"
       | Some "auto_approved_rule_match" -> "always_rule"
       | Some "resolved" -> "resolved"
       | Some "expired" -> "expired"
@@ -582,7 +588,7 @@ let execution_summary_json ~meta ~latest_receipt =
         | None -> `Null );
     ]
 
-let causal_timeline_json ~meta ~latest_decision ~latest_receipt
+let causal_timeline_json ~base_path ~meta ~latest_decision ~latest_receipt
     ~latest_tool_call ~latest_approval_audit ~runtime_blocker_fields
     ~next_human_action =
   let tool_events =
@@ -590,7 +596,8 @@ let causal_timeline_json ~meta ~latest_decision ~latest_receipt
     |> List.filter_map tool_call_timeline_event
   in
   let approval_events =
-    Keeper_approval_queue.read_recent_audit ~keeper_name:meta.name ~n:8 ()
+    Keeper_approval_queue.read_recent_audit ~base_path ~keeper_name:meta.name
+      ~n:8 ()
     |> List.filter_map approval_event_timeline_event
   in
   let transition_events =
@@ -661,7 +668,10 @@ let snapshot_json ~(config : Coord.config) ~(meta : keeper_meta) =
   let latest_tool_call = latest_tool_call_json ~keeper_name:meta.name in
   let latest_receipt = latest_receipt_json ~config ~keeper_name:meta.name in
   let latest_approval_audit =
-    match Keeper_approval_queue.read_recent_audit ~keeper_name:meta.name ~n:1 () with
+    match
+      Keeper_approval_queue.read_recent_audit ~base_path:config.base_path
+        ~keeper_name:meta.name ~n:1 ()
+    with
     | json :: _ -> Some json
     | [] -> None
   in
@@ -714,7 +724,8 @@ let snapshot_json ~(config : Coord.config) ~(meta : keeper_meta) =
     execution_summary_json ~meta ~latest_receipt
   in
   let causal_timeline =
-    causal_timeline_json ~meta ~latest_decision ~latest_receipt
+    causal_timeline_json ~base_path:config.base_path ~meta ~latest_decision
+      ~latest_receipt
       ~latest_tool_call ~latest_approval_audit
       ~runtime_blocker_fields ~next_human_action
   in

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -227,7 +227,8 @@ let approval_resolve_http_error_to_string = function
   | Bad_request msg -> msg
   | Gone err -> Keeper_approval_queue.resolve_error_to_string err
 
-let dashboard_governance_approval_resolve_http_json ~(args : Yojson.Safe.t) :
+let dashboard_governance_approval_resolve_http_json ~base_path
+    ~(args : Yojson.Safe.t) :
     (Yojson.Safe.t, approval_resolve_http_error) result =
   match Safe_ops.json_string_opt "id" args with
   | None ->
@@ -260,7 +261,7 @@ let dashboard_governance_approval_resolve_http_json ~(args : Yojson.Safe.t) :
       | Ok decision ->
           (match
              Keeper_approval_queue.resolve_with_policy ~id ~decision
-               ~remember_rule ~created_by:"dashboard" ()
+               ~base_path ~remember_rule ~created_by:"dashboard" ()
            with
            | Ok result ->
                Ok
@@ -277,14 +278,15 @@ let dashboard_governance_approval_resolve_http_json ~(args : Yojson.Safe.t) :
            | Error err ->
                Error (Gone err))
 
-let dashboard_governance_approval_rule_delete_http_json ~(args : Yojson.Safe.t) :
+let dashboard_governance_approval_rule_delete_http_json ~base_path
+    ~(args : Yojson.Safe.t) :
     (Yojson.Safe.t, string) result =
   match Safe_ops.json_string_opt "id" args with
   | None -> Error "id is required"
   | Some id -> (
-      match Keeper_approval_queue.delete_rule ~id with
+      match Keeper_approval_queue.delete_rule ~base_path ~id () with
       | Ok deleted ->
-          Keeper_approval_queue.audit_rule_event ~event_type:"rule_deleted"
+          Keeper_approval_queue.audit_rule_event ~base_path ~event_type:"rule_deleted"
             deleted;
           Ok
             (`Assoc

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -517,11 +517,12 @@ let rec add_routes ~sw ~clock router =
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.post "/api/v1/dashboard/governance/approvals/resolve" (fun request reqd ->
-       with_tool_auth ~tool_name:"masc_operator_confirm" (fun _state _req reqd ->
+       with_tool_auth ~tool_name:"masc_operator_confirm" (fun state _req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let args = Yojson.Safe.from_string body_str in
-             match dashboard_governance_approval_resolve_http_json ~args with
+             let base_path = state.Mcp_server.room_config.base_path in
+             match dashboard_governance_approval_resolve_http_json ~base_path ~args with
              | Ok json ->
                  respond_json_with_cors request reqd (Yojson.Safe.to_string json)
              | Error (Gone _ as err) ->
@@ -539,12 +540,13 @@ let rec add_routes ~sw ~clock router =
          )
        ) request reqd)
   |> Http.Router.post "/api/v1/dashboard/governance/approvals/rules/delete" (fun request reqd ->
-       with_tool_auth ~tool_name:"masc_operator_confirm" (fun _state _req reqd ->
+       with_tool_auth ~tool_name:"masc_operator_confirm" (fun state _req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let args = Yojson.Safe.from_string body_str in
+             let base_path = state.Mcp_server.room_config.base_path in
              match
-               dashboard_governance_approval_rule_delete_http_json ~args
+               dashboard_governance_approval_rule_delete_http_json ~base_path ~args
              with
              | Ok json ->
                  respond_json_with_cors request reqd (Yojson.Safe.to_string json)

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -10,6 +10,7 @@
 module GP = Masc_mcp.Governance_pipeline
 module AQ = Masc_mcp.Keeper_approval_queue
 module KT = Masc_mcp.Keeper_types
+module SDH = Masc_mcp.Server_dashboard_http
 module Mcp_eio = Masc_mcp.Mcp_server_eio
 
 let check = Alcotest.(check string)
@@ -607,6 +608,73 @@ let test_resolve_with_policy_does_not_remember_high_allow () =
       | Error err ->
           Alcotest.fail ("resolve_with_policy failed: " ^ AQ.resolve_error_to_string err))
 
+let test_dashboard_resolve_and_delete_rules_use_room_base_path () =
+  let env_base = temp_dir () in
+  let room_base = temp_dir () in
+  let old_base = Sys.getenv_opt "MASC_BASE_PATH" in
+  let old_base_input = Sys.getenv_opt "MASC_BASE_PATH_INPUT" in
+  AQ.For_testing.reset_audit_store ();
+  Unix.putenv "MASC_BASE_PATH" env_base;
+  Unix.putenv "MASC_BASE_PATH_INPUT" env_base;
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_audit_store ();
+      (match old_base with
+       | Some value -> Unix.putenv "MASC_BASE_PATH" value
+       | None -> Unix.putenv "MASC_BASE_PATH" "");
+      (match old_base_input with
+       | Some value -> Unix.putenv "MASC_BASE_PATH_INPUT" value
+       | None -> Unix.putenv "MASC_BASE_PATH_INPUT" "");
+      cleanup_dir env_base;
+      cleanup_dir room_base)
+    (fun () ->
+      let id =
+        AQ.submit_pending
+          ~keeper_name:"dashboard-room-keeper"
+          ~tool_name:"masc_claim_task"
+          ~input:(`Assoc [ ("task_id", `String "task-room") ])
+          ~risk_level:AQ.Medium
+          ~on_resolution:(fun _ -> ())
+          ()
+      in
+      let resolve_args =
+        `Assoc
+          [
+            ("id", `String id);
+            ("decision", `String "approve");
+            ("remember_rule", `Bool true);
+          ]
+      in
+      let rule_id =
+        match
+          SDH.dashboard_governance_approval_resolve_http_json ~base_path:room_base
+            ~args:resolve_args
+        with
+        | Ok json ->
+            let open Yojson.Safe.Util in
+            json |> member "rule_id" |> to_string
+        | Error err ->
+            Alcotest.fail
+              ("dashboard resolve failed: "
+              ^ SDH.approval_resolve_http_error_to_string err)
+      in
+      Alcotest.(check int) "room rule persisted" 1
+        (List.length (AQ.list_rules ~base_path:room_base ()));
+      Alcotest.(check int) "env fallback has no rule" 0
+        (List.length (AQ.list_rules ~base_path:env_base ()));
+      (match
+         SDH.dashboard_governance_approval_rule_delete_http_json
+           ~base_path:room_base
+           ~args:(`Assoc [ ("id", `String rule_id) ])
+       with
+       | Ok _ -> ()
+       | Error message ->
+           Alcotest.fail ("dashboard rule delete failed: " ^ message));
+      Alcotest.(check int) "room rule deleted" 0
+        (List.length (AQ.list_rules ~base_path:room_base ()));
+      Alcotest.(check int) "env fallback still empty" 0
+        (List.length (AQ.list_rules ~base_path:env_base ())))
+
 let test_approval_get_dispatch_missing_id () =
   let ok, msg = execute_approval_get (`Assoc [("id", `String "")]) in
   Alcotest.(check bool) "missing id fails" false ok;
@@ -778,6 +846,36 @@ let test_callback_always_approve_bypasses_threshold () =
     Alcotest.fail ("expected Approve with always_approve, got Reject: " ^ r)
   | _ -> Alcotest.fail "unexpected decision"
 
+let test_runtime_trust_classifies_always_approve_flag () =
+  with_test_config @@ fun config ->
+  AQ.For_testing.reset_audit_store ();
+  Fun.protect
+    ~finally:AQ.For_testing.reset_audit_store
+    (fun () ->
+      let keeper_name = "always-flag-keeper" in
+      let meta =
+        meta_from_json
+          (`Assoc [
+            ("name", `String keeper_name);
+            ("trace_id", `String "trace-always-flag");
+            ("always_approve", `Bool true);
+          ])
+      in
+      AQ.audit_approval_event ~base_path:config.base_path
+        ~event_type:"auto_approved_always" ~id:"auto-always-flag-test"
+        ~keeper_name ~tool_name:"masc_create_task" ~risk_level:AQ.Medium
+        ~auto_approved:true ();
+      let snapshot =
+        Masc_mcp.Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta
+      in
+      let open Yojson.Safe.Util in
+      let approval = snapshot |> member "approval" in
+      Alcotest.(check string) "runtime trust always flag state" "always_flag"
+        (approval |> member "state" |> to_string);
+      Alcotest.(check string) "runtime trust latest event kind"
+        "auto_approved_always"
+        (approval |> member "latest_event_kind" |> to_string))
+
 let test_callback_always_approve_respects_forbidden () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -899,6 +997,8 @@ let () =
         test_resolve_with_policy_remembers_medium_allow;
       Alcotest.test_case "resolve_with_policy skips high allow memory" `Quick
         test_resolve_with_policy_does_not_remember_high_allow;
+      Alcotest.test_case "dashboard approve-always rules use room base_path" `Quick
+        test_dashboard_resolve_and_delete_rules_use_room_base_path;
       Alcotest.test_case "read_recent_audit scans before keeper filter" `Quick
         test_read_recent_audit_filters_after_wide_scan;
     ]);
@@ -912,6 +1012,8 @@ let () =
         test_callback_paranoid_medium_risk_uses_remembered_policy;
       Alcotest.test_case "always_approve bypasses threshold" `Quick
         test_callback_always_approve_bypasses_threshold;
+      Alcotest.test_case "runtime trust classifies always_approve flag" `Quick
+        test_runtime_trust_classifies_always_approve_flag;
       Alcotest.test_case "always_approve respects forbidden" `Quick
         test_callback_always_approve_respects_forbidden;
     ]);


### PR DESCRIPTION
Summary: route dashboard approve-always resolve/delete through the authenticated room base_path, keep approval audit per room, and expose auto_approved_always as approval.state=always_flag in runtime trust. Tests: dune build focused approval/router test executables; test_hitl_approval.exe; test_dashboard_keeper_routes.exe.