### PR TITLE
[codex] Improve dashboard telemetry performance

### DIFF
--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { TelemetryResponse, TelemetrySummaryResponse } from '../api/dashboard'
 
 void vi
+vi.setConfig({ testTimeout: 120_000 })
 
 const baseTelemetry: TelemetryResponse = {
   generated_at: '2026-04-09T05:10:00Z',
@@ -117,6 +118,52 @@ describe('TelemetryUnified', () => {
 
     expect(fetchTelemetry).toHaveBeenCalledTimes(2)
     expect(fetchTelemetrySummary).toHaveBeenCalledTimes(2)
+  })
+
+  it('debounces server-side telemetry filter changes', async () => {
+    const fetchTelemetry = vi.fn().mockResolvedValue(baseTelemetry)
+    const fetchTelemetrySummary = vi.fn().mockResolvedValue(baseSummary)
+    const { TelemetryUnified } = await loadPanel(fetchTelemetry, fetchTelemetrySummary)
+
+    await act(async () => {
+      render(html`<${TelemetryUnified} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(fetchTelemetry).toHaveBeenCalledTimes(1)
+
+    const keeperInput = container.querySelector<HTMLInputElement>('input[aria-label="키퍼 이름 필터"]')
+    expect(keeperInput).toBeTruthy()
+
+    await act(async () => {
+      if (!keeperInput) return
+      keeperInput.value = 's'
+      keeperInput.dispatchEvent(new Event('input', { bubbles: true }))
+      keeperInput.value = 'sa'
+      keeperInput.dispatchEvent(new Event('input', { bubbles: true }))
+      keeperInput.value = 'sangsu'
+      keeperInput.dispatchEvent(new Event('input', { bubbles: true }))
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(fetchTelemetry).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(249)
+    })
+    await flushUi()
+
+    expect(fetchTelemetry).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    await flushUi()
+
+    expect(fetchTelemetry).toHaveBeenCalledTimes(2)
+    expect(fetchTelemetry.mock.calls[1]?.[0]).toMatchObject({ keeper: 'sangsu' })
   })
 
   it('surfaces summary fetch errors to the panel error banner (regression: Phase 0 fleet-data-core)', async () => {

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -1,7 +1,7 @@
 // Telemetry Unified — MASC runtime diagnosis view.
 
 import { html } from 'htm/preact'
-import { useEffect, useRef } from 'preact/hooks'
+import { useEffect, useMemo, useRef } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
 import {
   fetchDashboardShell,
@@ -458,7 +458,10 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
   const scopeBadges = telemetryScopeBadges(entry)
 
   return html`
-    <div class="border-b border-[var(--card-border)] hover:bg-[var(--bg-panel-hover)] transition-colors">
+    <div
+      class="border-b border-[var(--card-border)] hover:bg-[var(--bg-panel-hover)] transition-colors"
+      style="content-visibility:auto;contain-intrinsic-size:36px"
+    >
       <button
         type="button"
         class="w-full flex items-center gap-2 px-3 py-1.5 text-xs cursor-pointer select-none text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
@@ -507,7 +510,10 @@ function GroupRow({ item }: { item: Extract<TelemetryDisplayItem, { kind: 'group
   const contentId = `telemetry-group-${item.key.replace(/[^a-zA-Z0-9_-]/g, '-')}`
 
   return html`
-    <div class="border-b border-[var(--card-border)] bg-[rgba(255,255,255,0.015)] hover:bg-[var(--bg-panel-hover)] transition-colors">
+    <div
+      class="border-b border-[var(--card-border)] bg-[rgba(255,255,255,0.015)] hover:bg-[var(--bg-panel-hover)] transition-colors"
+      style="content-visibility:auto;contain-intrinsic-size:36px"
+    >
       <button
         type="button"
         class="w-full flex items-center gap-2 px-3 py-1.5 text-xs cursor-pointer select-none text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
@@ -566,6 +572,7 @@ export function TelemetryUnified() {
   const params = route.value.params
   const latestRequestId = useRef(0)
   const activeController = useRef<AbortController | null>(null)
+  const initialLoadDone = useRef(false)
   const autoRefreshLoadRef = useRef<() => Promise<void>>(async () => undefined)
   const state = useSignal<TelemetryState>({
     entries: [],
@@ -680,7 +687,17 @@ export function TelemetryUnified() {
   autoRefreshLoadRef.current = load
 
   useEffect(() => {
-    void load()
+    if (!initialLoadDone.current) {
+      initialLoadDone.current = true
+      void autoRefreshLoadRef.current()
+      return
+    }
+    const timeoutId = window.setTimeout(() => {
+      void autoRefreshLoadRef.current()
+    }, 250)
+    return () => {
+      window.clearTimeout(timeoutId)
+    }
   }, [
     sourceFilter.value,
     keeperFilter.value,
@@ -700,10 +717,14 @@ export function TelemetryUnified() {
   }, [])
 
   const { entries, summary, totalEntries, store, loading, error } = state.value
-  const allDisplayItems = buildTelemetryDisplayItems(entries)
-  const displayItems = filterTelemetryDisplayItems(allDisplayItems, entrySearch.value)
-  const isFilteringEntries = entrySearch.value.trim() !== ''
-  const condensed = condensedStats(displayItems)
+  const entrySearchQuery = entrySearch.value
+  const allDisplayItems = useMemo(() => buildTelemetryDisplayItems(entries), [entries])
+  const displayItems = useMemo(
+    () => filterTelemetryDisplayItems(allDisplayItems, entrySearchQuery),
+    [allDisplayItems, entrySearchQuery],
+  )
+  const isFilteringEntries = entrySearchQuery.trim() !== ''
+  const condensed = useMemo(() => condensedStats(displayItems), [displayItems])
 
   return html`
     <div class="flex flex-col gap-4">

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -61,6 +61,10 @@ let available_cascade_profiles () : string list =
 let invalid_cascade_profiles () : (string * string list) list =
   (cascade_profile_gate ()).invalid_profiles
 
+let telemetry_summary_cache_key ~base_path ~masc_root =
+  let digest = Digest.string (base_path ^ "\000" ^ masc_root) |> Digest.to_hex in
+  "dashboard:telemetry_summary:" ^ digest
+
 let sync_keeper_cascade_meta ~(config : Coord.config) ~(name : string)
     ~(cascade_name : string) : (bool, string) result =
   let updated_at = Keeper_types.now_iso () in
@@ -845,7 +849,11 @@ let rec add_routes ~sw ~clock router =
          let config = state.Mcp_server.room_config in
          let base_path = config.base_path in
          let masc_root = Coord.masc_root_dir config in
-         let json = Telemetry_unified.summary_json ~base_path ~masc_root () in
+         let cache_key = telemetry_summary_cache_key ~base_path ~masc_root in
+         let json =
+           Dashboard_cache.get_or_compute cache_key ~ttl:30.0 (fun () ->
+               Telemetry_unified.summary_json ~base_path ~masc_root ())
+         in
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)

--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -169,6 +169,13 @@ let latest_store_ts dir label : float option =
         (Printexc.to_string exn);
       None
 
+let sort_newest_first entries =
+  List.sort (fun a b -> Float.compare (extract_ts b) (extract_ts a)) entries
+
+let take_first n entries =
+  if n <= 0 then []
+  else List.filteri (fun i _ -> i < n) entries
+
 let freshness_fields ~now latest_ts =
   match latest_ts with
   | Some ts ->
@@ -263,19 +270,64 @@ let read_keeper_metrics ~masc_root ?keeper_name ?since_ts ?until_ts ~n () :
     read_fixed_source dir Keeper_metric ~n ?since_ts ?until_ts ()
   ) dirs
 
+let read_keeper_metrics_fast_top ~masc_root ~n () : Yojson.Safe.t list =
+  let target = n + 1 in
+  let probe_limit = min 64 target in
+  let dirs = discover_keeper_metric_dirs masc_root in
+  let probes =
+    List.filter_map
+      (fun (name, dir) ->
+        let entries = read_fixed_source dir Keeper_metric ~n:probe_limit () in
+        match latest_ts_of_entries entries with
+        | None -> None
+        | Some latest_ts -> Some (name, dir, latest_ts, entries))
+      dirs
+    |> List.sort (fun (_, _, a, _) (_, _, b, _) -> Float.compare b a)
+  in
+  let rec loop acc = function
+    | [] -> acc
+    | (_name, dir, latest_ts, probe_entries) :: rest ->
+      let acc = sort_newest_first acc |> take_first target in
+      let cutoff =
+        if List.length acc < target then None
+        else List.nth_opt acc (target - 1) |> Option.map extract_ts
+      in
+      (match cutoff with
+       | Some ts when latest_ts < ts -> acc
+       | _ ->
+         let entries =
+           if target <= probe_limit then probe_entries
+           else read_fixed_source dir Keeper_metric ~n:target ()
+         in
+         loop (sort_newest_first (entries @ acc) |> take_first target) rest)
+  in
+  loop [] probes
+
 (* ── Unified read ───────────────────────────────────── *)
 
 let read_unified_result ~base_path ~masc_root ?(sources = all_sources)
     ?keeper_name ?session_id ?operation_id ?worker_run_id ?since_ts ?until_ts
     ?(n = 100) () : read_result =
   let limited = n > 0 in
-  let per_source = if limited then max n (n * 2) else 0 in
+  let has_filter =
+    Option.is_some keeper_name || Option.is_some session_id
+    || Option.is_some operation_id || Option.is_some worker_run_id
+    || Option.is_some since_ts || Option.is_some until_ts
+  in
+  let per_source =
+    if not limited then 0
+    else if has_filter then max n (n * 2)
+    else n + 1
+  in
   let all_entries =
     List.concat_map (fun source ->
       match source with
       | Keeper_metric ->
-        read_keeper_metrics ~masc_root ?keeper_name ?since_ts ?until_ts
-          ~n:per_source ()
+        if limited && Option.is_none keeper_name && not has_filter then
+          read_keeper_metrics_fast_top ~masc_root ~n ()
+        else
+          read_keeper_metrics ~masc_root ?keeper_name ?since_ts ?until_ts
+            ~n:per_source ()
       | _ ->
         match fixed_store_dir ~masc_root ~base_path source with
         | Some dir ->
@@ -302,13 +354,11 @@ let read_unified_result ~base_path ~masc_root ?(sources = all_sources)
       filtered
   in
   (* Sort by timestamp descending (newest first) *)
-  let sorted = List.sort (fun a b ->
-    Float.compare (extract_ts b) (extract_ts a)
-  ) filtered in
+  let sorted = sort_newest_first filtered in
   let total_matching_entries = List.length sorted in
   let entries =
     if not limited || total_matching_entries <= n then sorted
-    else List.filteri (fun i _ -> i < n) sorted
+    else take_first n sorted
   in
   { entries; total_matching_entries; truncated = limited && total_matching_entries > n }
 

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -52,6 +52,20 @@ let append_jsonl_entry_for_ts dir ts json =
   let path = jsonl_path_for_unix_seconds dir ts in
   Fs_compat.append_file path (Yojson.Safe.to_string json ^ "\n")
 
+let json_int_field name = function
+  | `Assoc fields -> (
+      match List.assoc_opt name fields with
+      | Some (`Int value) -> value
+      | _ -> -1)
+  | _ -> -1
+
+let json_string_field name = function
+  | `Assoc fields -> (
+      match List.assoc_opt name fields with
+      | Some (`String value) -> value
+      | _ -> "")
+  | _ -> ""
+
 (* ── Source roundtrip ────────────────────────────── *)
 
 let test_source_roundtrip () =
@@ -183,6 +197,77 @@ let test_keeper_metrics_per_keeper () =
       ~sources:[Telemetry_unified.Keeper_metric]
       ~keeper_name:"cheolsu" () in
   Alcotest.(check int) "one cheolsu entry" 1 (List.length cheolsu_only)
+
+let test_keeper_metrics_fast_path_preserves_noisy_keeper_top_n () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_keeper_fast_top" in
+  let hot_dir = Filename.concat dir ".masc/keepers/hot/metrics" in
+  let old_dir = Filename.concat dir ".masc/keepers/old/metrics" in
+  Fs_compat.mkdir_p hot_dir;
+  Fs_compat.mkdir_p old_dir;
+  write_jsonl hot_dir
+    (List.init 120 (fun i ->
+         `Assoc
+           [
+             ("ts_unix", `Float (1_000.0 +. Float.of_int i));
+             ("name", `String "hot");
+             ("i", `Int i);
+           ]));
+  write_jsonl old_dir
+    (List.init 50 (fun i ->
+         `Assoc
+           [
+             ("ts_unix", `Float (Float.of_int i));
+             ("name", `String "old");
+             ("i", `Int i);
+           ]));
+  let result =
+    Telemetry_unified.read_unified_result ~base_path:dir
+      ~masc_root:(masc_root dir) ~sources:[ Telemetry_unified.Keeper_metric ]
+      ~n:100 ()
+  in
+  Alcotest.(check int) "limited result" 100 (List.length result.entries);
+  Alcotest.(check int) "sentinel total" 101 result.total_matching_entries;
+  Alcotest.(check bool) "truncated" true result.truncated;
+  let indices = List.map (json_int_field "i") result.entries in
+  Alcotest.(check int) "newest hot entry first" 119 (List.hd indices);
+  Alcotest.(check int) "oldest returned hot entry last" 20 (List.nth indices 99);
+  Alcotest.(check (list string)) "only hot top entries returned"
+    (List.init 100 (fun _ -> "hot"))
+    (List.map (json_string_field "name") result.entries)
+
+let test_keeper_metrics_fast_path_sets_truncated_with_sentinel () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_keeper_fast_sentinel" in
+  let write_keeper name ts =
+    let metrics_dir = Filename.concat dir (".masc/keepers/" ^ name ^ "/metrics") in
+    Fs_compat.mkdir_p metrics_dir;
+    write_jsonl metrics_dir
+      [
+        `Assoc
+          [
+            ("ts_unix", `Float ts);
+            ("name", `String name);
+            ("channel", `String "turn");
+          ];
+      ]
+  in
+  write_keeper "alpha" 3_000.0;
+  write_keeper "beta" 2_000.0;
+  write_keeper "gamma" 1_000.0;
+  let result =
+    Telemetry_unified.read_unified_result ~base_path:dir
+      ~masc_root:(masc_root dir) ~sources:[ Telemetry_unified.Keeper_metric ]
+      ~n:2 ()
+  in
+  Alcotest.(check int) "returned limit" 2 (List.length result.entries);
+  Alcotest.(check int) "sentinel total" 3 result.total_matching_entries;
+  Alcotest.(check bool) "truncated" true result.truncated;
+  Alcotest.(check (list string)) "newest keepers"
+    [ "alpha"; "beta" ]
+    (List.map (json_string_field "name") result.entries)
 
 (* ── Sorting (newest first) ──────────────────────── *)
 
@@ -455,6 +540,10 @@ let () =
           Alcotest.test_case "oas events + scope filter" `Quick
             test_oas_event_source_and_scope_filter;
           Alcotest.test_case "keeper metrics" `Quick test_keeper_metrics_per_keeper;
+          Alcotest.test_case "keeper metrics fast path keeps noisy top n" `Quick
+            test_keeper_metrics_fast_path_preserves_noisy_keeper_top_n;
+          Alcotest.test_case "keeper metrics fast path sentinel" `Quick
+            test_keeper_metrics_fast_path_sets_truncated_with_sentinel;
           Alcotest.test_case "sorted newest first" `Quick test_sorted_newest_first;
           Alcotest.test_case "n limits output" `Quick test_n_limits_output;
           Alcotest.test_case "time window reports total before limit" `Quick


### PR DESCRIPTION
## Summary
- Bound unfiltered telemetry reads with n+1 sentinel behavior and added a keeper-metric top-N fast path.
- Cached the dashboard telemetry summary endpoint through Dashboard_cache.
- Reduced dashboard telemetry panel churn with debounced server-side filters, memoized display derivations, and row render containment.

## Validation
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/perf-telemetry-fast-path --build-dir /tmp/masc-perf-telemetry-build-rebase bin/main_eio.exe test/test_telemetry_unified.exe
- /tmp/masc-perf-telemetry-build-rebase/default/test/test_telemetry_unified.exe
- cd dashboard && pnpm exec vitest run src/components/telemetry-unified.test.ts --no-file-parallelism --maxWorkers=1
- cd dashboard && pnpm typecheck
- cd dashboard && pnpm lint

## Live check
Patched local server on port 8936 returned ready and measured: keeper_metric n=100 0.273s, telemetry n=100 0.313s, summary cold 0.332s, summary warm 0.0007s.