### PR TITLE
fix(dashboard): include raw preview in judge Lenient_json fallback errors (#9774)

### DIFF
--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -484,8 +484,13 @@ let compute_judgments
         let raw_text = Oas_response.text_of_response response in
         let parsed = Llm_provider.Lenient_json.parse raw_text in
         match parsed with
-        | `Assoc [("raw", `String _)] ->
-            Error "Governance judge returned unparseable response (Lenient_json fallback hit)"
+        | `Assoc [("raw", `String raw)] ->
+            (* #9774: surface a preview of the raw text so the next
+               diagnostic pass can see what shape the LLM is producing
+               without having to enable raw provider logging. *)
+            let msg = Judge_diagnostics.format_lenient_fallback ~judge_label:"Governance" raw in
+            Log.Governance.warn "%s" msg;
+            Error msg
         | _ ->
             let generated_at = now_iso () in
             let expires_at = iso_of_unix (Unix.gettimeofday () +. cache_ttl_sec ()) in

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -214,8 +214,12 @@ let compute_judgments
            fences and applies other deterministic recovery transforms. *)
         let raw_text = Oas_response.text_of_response response in
         match Llm_provider.Lenient_json.parse raw_text with
-        | `Assoc [("raw", `String _)] ->
-            Error "Operator judge returned unparseable response (Lenient_json fallback hit)"
+        | `Assoc [("raw", `String raw)] ->
+            (* #9774: include a preview so the failure diagnostic doesn't
+               require enabling raw provider logging. *)
+            let msg = Judge_diagnostics.format_lenient_fallback ~judge_label:"Operator" raw in
+            Log.Governance.warn "%s" msg;
+            Error msg
         | parsed -> Ok (response.model, parsed)
       with
       | Yojson.Json_error msg ->

--- a/lib/dashboard/judge_diagnostics.ml
+++ b/lib/dashboard/judge_diagnostics.ml
@@ -1,0 +1,22 @@
+(* #9774: shared helpers for governance / operator judge LLM-output
+   diagnostics. Pure string transforms — no logging, no I/O. *)
+
+(* Truncate a string to at most [max_bytes] bytes, appending an ellipsis
+   marker that records how many bytes were dropped. Byte-count is
+   acceptable here because the consumer is a log line, not a UI surface. *)
+let truncate_with_marker ?(max_bytes = 500) s =
+  let len = String.length s in
+  if len <= max_bytes then s
+  else String.sub s 0 max_bytes ^ Printf.sprintf "…[+%d chars]" (len - max_bytes)
+
+(* When a judge's [Lenient_json.parse] returns the [`Assoc [("raw", _)]]
+   fallback, format a single message that names the judge, the raw size,
+   and a bounded preview. The same string is used both as the warn log
+   payload and as the [Error] returned upstream so any consumer sees the
+   diagnostic without enabling raw provider logging. *)
+let format_lenient_fallback ~judge_label raw =
+  Printf.sprintf
+    "%s judge returned unparseable response (Lenient_json fallback hit; %d chars; preview: %s)"
+    judge_label
+    (String.length raw)
+    (truncate_with_marker raw)

--- a/lib/dashboard/judge_diagnostics.mli
+++ b/lib/dashboard/judge_diagnostics.mli
@@ -1,0 +1,11 @@
+(** #9774: shared formatters for governance / operator judge diagnostics. *)
+
+val truncate_with_marker : ?max_bytes:int -> string -> string
+(** Trim [s] to [max_bytes] bytes (default 500), appending an ellipsis
+    marker recording how many bytes were dropped. *)
+
+val format_lenient_fallback : judge_label:string -> string -> string
+(** Format the unparseable-response error string for a judge that hit
+    the [Lenient_json.parse] [\`Assoc [("raw", _)]] fallback. The
+    output is consumed both as the warn log payload and as the [Error]
+    returned upstream. *)

--- a/lib/dune
+++ b/lib/dune
@@ -69,6 +69,7 @@
    dashboard_governance_judge
    dashboard_governance_metrics
    dashboard_operator_judge
+   judge_diagnostics
    dashboard_safe_autonomy
    dashboard_surface_readiness
    dashboard_execution

--- a/test/dune
+++ b/test/dune
@@ -338,6 +338,7 @@
         test_server_startup_takeover
         test_keeper_meta_listing
         test_keeper_meta_cas_retry
+        test_judge_diagnostics
         test_keeper_identity_parse
         test_worker_runtime
         test_capability_registry
@@ -504,6 +505,7 @@
         test_server_startup_takeover
         test_keeper_meta_listing
         test_keeper_meta_cas_retry
+        test_judge_diagnostics
         test_keeper_identity_parse
         test_worker_runtime
         test_capability_registry

--- a/test/test_judge_diagnostics.ml
+++ b/test/test_judge_diagnostics.ml
@@ -1,0 +1,70 @@
+(** #9774: regression tests for the judge fallback diagnostic formatter. *)
+
+open Alcotest
+open Masc_mcp
+
+let test_short_input_passes_through () =
+  let raw = "{\"items\":[]}" in
+  let out = Judge_diagnostics.truncate_with_marker raw in
+  check string "short string preserved" raw out
+
+let test_long_input_truncated_with_marker () =
+  let raw = String.make 1200 'a' in
+  let out = Judge_diagnostics.truncate_with_marker raw in
+  check bool "result shorter than input" true (String.length out < String.length raw);
+  check bool "preserves prefix" true
+    (String.length out >= 500 && String.sub out 0 500 = String.make 500 'a');
+  check bool "ends with chars marker" true
+    (try
+       let re = Re.Pcre.re {|\+\d+ chars\]$|} |> Re.compile in
+       ignore (Re.exec re out); true
+     with Not_found -> false)
+
+let test_custom_max_bytes_respected () =
+  let raw = String.make 100 'x' in
+  let out = Judge_diagnostics.truncate_with_marker ~max_bytes:30 raw in
+  check bool "first 30 chars preserved" true
+    (String.length out >= 30 && String.sub out 0 30 = String.make 30 'x')
+
+let test_format_lenient_fallback_includes_label () =
+  let raw = "garbage that is not json" in
+  let out = Judge_diagnostics.format_lenient_fallback ~judge_label:"Governance" raw in
+  let contains needle =
+    try
+      let re = Re.Pcre.re (Re.Pcre.quote needle) |> Re.compile in
+      ignore (Re.exec re out); true
+    with Not_found -> false
+  in
+  check bool "names judge label" true (contains "Governance judge");
+  check bool "names byte size" true (contains "24 chars");
+  check bool "embeds raw preview" true (contains raw);
+  check bool "names fallback class" true (contains "Lenient_json fallback hit")
+
+let test_format_lenient_fallback_truncates_huge_raw () =
+  let raw = String.make 2000 'z' in
+  let out = Judge_diagnostics.format_lenient_fallback ~judge_label:"Operator" raw in
+  check bool "embeds size in chars" true
+    (try
+       let re = Re.Pcre.re {|2000 chars|} |> Re.compile in
+       ignore (Re.exec re out); true
+     with Not_found -> false);
+  check bool "preview is bounded" true
+    (String.length out < 1500)
+
+let () =
+  run "judge_diagnostics (#9774)"
+    [
+      ( "truncate_with_marker",
+        [
+          test_case "short input passes through" `Quick test_short_input_passes_through;
+          test_case "long input truncated with marker" `Quick test_long_input_truncated_with_marker;
+          test_case "custom max_bytes respected" `Quick test_custom_max_bytes_respected;
+        ] );
+      ( "format_lenient_fallback",
+        [
+          test_case "includes judge label, size, preview, class" `Quick
+            test_format_lenient_fallback_includes_label;
+          test_case "preview is bounded for huge raw" `Quick
+            test_format_lenient_fallback_truncates_huge_raw;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

When the governance or operator judge LLM emits text that even the OAS `Lenient_json` 6-step recovery cannot parse, MASC currently surfaces:

```
Governance judge returned unparseable response (Lenient_json fallback hit)
```

The raw text is dropped on the floor, so debugging the next occurrence requires enabling raw provider logging on a live keeper (#9774, observed 2026-04-23 18:49:55Z, seq=52537).

## Fix

Add a shared formatter `Judge_diagnostics.format_lenient_fallback` that includes:

- **byte length** of the raw response
- **bounded preview** (first 500 bytes plus a `+N chars` marker)
- **judge label** (Governance vs Operator) so logs are greppable

The same formatted string is used as both the WARN log payload and the `Error` returned to the caller, so the diagnostic is visible in log-level filters AND structured error consumers without divergence.

## Why a shared helper

The fallback handling was duplicated across `dashboard_governance_judge.ml` and `dashboard_operator_judge.ml`. Extracting `Judge_diagnostics` removes that duplication AND gives the truncation logic a stable testable surface (the LLM-call functions themselves are difficult to mock without a fake provider; the helper is pure).

## What this is NOT

This is **observability only**. Behavior is unchanged on the happy path (parseable JSON). When the fallback IS hit, the output shape becomes self-explaining instead of opaque — the next debugger can see the LLM's actual emission and decide whether the right fix is a prompt tweak or an additional OAS recovery transform.

## Test plan

- [x] `dune build --root=. lib/` — clean
- [x] `dune exec test/test_judge_diagnostics.exe` — 5/5 pass
  - short input passes through (no truncation)
  - long input truncated with `+N chars` marker
  - custom `max_bytes` respected
  - format includes judge label, byte size, raw preview, fallback class name
  - bounded preview for huge raw

## Followup (not in this PR)

Once preview samples accumulate, OAS `Lenient_json` may benefit from a 7th recovery step — "largest valid JSON object substring" — to handle prose-surrounded JSON (the pattern used by `json-repair`, `instructor`, `outlines`). That belongs in OAS, not MASC, and should be informed by actual production samples that this PR makes visible.

Closes #9774