### PR TITLE
fix(tool_board): broaden truncated-markdown detection and surface signal (#9777)

### DIFF
--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -280,10 +280,12 @@ let normalize_board_post_meta args =
 
     The detector walks the string once with a small state machine that is
     aware of fenced code blocks (so markdown markers inside ```...```
-    don't count). It returns the FIRST signal it finds, which is also
-    surfaced in the WARN log so future audits can see WHICH pattern
-    triggered the marker. New signals are added conservatively — only
-    those whose false-positive surface is small for prose + code (#9777).
+    don't count). Inline code spans outside fences are also tracked so
+    bold markers inside `...` don't count as unclosed emphasis. It returns
+    the FIRST signal it finds, which is also surfaced in the WARN log so
+    future audits can see WHICH pattern triggered the marker. New signals
+    are added conservatively — only those whose false-positive surface is
+    small for prose + code (#9777).
 
     Evidence:
     - ani1999 p-c0494a2e body_len=467 ending in a lone '`' (Odd_inline_tick)
@@ -310,6 +312,7 @@ let truncation_signal_to_string = function
 let detect_truncated_markdown_with_reason (text : string) : truncation_signal option =
   let len = String.length text in
   let in_fence = ref false in
+  let in_inline = ref false in
   let inline_outside = ref 0 in
   let fences = ref 0 in
   let double_ast_outside = ref 0 in
@@ -322,12 +325,18 @@ let detect_truncated_markdown_with_reason (text : string) : truncation_signal op
       in_fence := not !in_fence;
       i := !i + 3
     end else if !i + 1 < len
-                && text.[!i] = '*' && text.[!i + 1] = '*' && not !in_fence
+                && text.[!i] = '*'
+                && text.[!i + 1] = '*'
+                && (not !in_fence)
+                && not !in_inline
     then begin
       incr double_ast_outside;
       i := !i + 2
     end else begin
-      if text.[!i] = '`' && not !in_fence then incr inline_outside;
+      if text.[!i] = '`' && not !in_fence then begin
+        incr inline_outside;
+        in_inline := not !in_inline
+      end;
       incr i
     end
   done;

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -277,16 +277,42 @@ let normalize_board_post_meta args =
   if base_fields = [] then None else Some (`Assoc base_fields)
 
 (** Detect markdown that was cut mid-write by an LLM max_tokens limit.
-    Symptoms: odd count of triple-backtick fences (unclosed ```code```
-    block), or odd count of single backticks outside fenced regions.
-    Evidence: ani1999 board post p-c0494a2e body_len=467 ending in a
-    lone '`'. Walks the string once with a tiny state machine so
-    backticks inside a fenced block don't count. *)
-let detect_truncated_markdown (text : string) : bool =
+
+    The detector walks the string once with a small state machine that is
+    aware of fenced code blocks (so markdown markers inside ```...```
+    don't count). It returns the FIRST signal it finds, which is also
+    surfaced in the WARN log so future audits can see WHICH pattern
+    triggered the marker. New signals are added conservatively — only
+    those whose false-positive surface is small for prose + code (#9777).
+
+    Evidence:
+    - ani1999 p-c0494a2e body_len=467 ending in a lone '`' (Odd_inline_tick)
+    - keeper-qa-king-agent body_len=3575 (#9777, Odd_fence) *)
+
+type truncation_signal =
+  | Odd_fence              (** odd count of triple-backtick code fences *)
+  | Odd_inline_tick        (** odd count of single backticks outside fences *)
+  | Unfinished_link        (** trailing [text]( with no closing ) *)
+  | Unfinished_image       (** trailing ![alt]( with no closing ) *)
+  | Odd_double_asterisk    (** odd count of ** outside fences (unclosed bold) *)
+
+let truncation_signal_to_string = function
+  | Odd_fence -> "odd_fence"
+  | Odd_inline_tick -> "odd_inline_tick"
+  | Unfinished_link -> "unfinished_link"
+  | Unfinished_image -> "unfinished_image"
+  | Odd_double_asterisk -> "odd_double_asterisk"
+
+(* Walk the text once collecting structural counters and trailing-shape
+   evidence. Underscore- and single-asterisk-based emphasis are NOT
+   counted because identifiers, file paths, and inline math frequently
+   carry odd counts and would yield false positives. *)
+let detect_truncated_markdown_with_reason (text : string) : truncation_signal option =
   let len = String.length text in
   let in_fence = ref false in
   let inline_outside = ref 0 in
   let fences = ref 0 in
+  let double_ast_outside = ref 0 in
   let i = ref 0 in
   while !i < len do
     if !i + 2 < len
@@ -295,12 +321,59 @@ let detect_truncated_markdown (text : string) : bool =
       incr fences;
       in_fence := not !in_fence;
       i := !i + 3
+    end else if !i + 1 < len
+                && text.[!i] = '*' && text.[!i + 1] = '*' && not !in_fence
+    then begin
+      incr double_ast_outside;
+      i := !i + 2
     end else begin
       if text.[!i] = '`' && not !in_fence then incr inline_outside;
       incr i
     end
   done;
-  !fences mod 2 = 1 || !inline_outside mod 2 = 1
+  let odd n = n mod 2 = 1 in
+  if odd !fences then Some Odd_fence
+  else if odd !inline_outside then Some Odd_inline_tick
+  else if odd !double_ast_outside then Some Odd_double_asterisk
+  else
+    (* Look at the trailing fragment for unfinished link / image syntax.
+       Markdown link is [text](url); if we see [text]( with no closing )
+       before EOF, that's a strong truncation signal. Walk backwards from
+       the end looking for the last '(' on a line that has '[' before it
+       and no matching ')'. *)
+    let last_open_paren = ref (-1) in
+    let last_close_paren = ref (-1) in
+    for j = len - 1 downto 0 do
+      if !last_open_paren < 0 && text.[j] = '(' then last_open_paren := j;
+      if !last_close_paren < 0 && text.[j] = ')' then last_close_paren := j
+    done;
+    if !last_open_paren > !last_close_paren && !last_open_paren > 0 then
+      (* Check the byte just before for ']'; that distinguishes
+         a markdown link/image truncation from arbitrary parens in prose. *)
+      let bracket_pos = !last_open_paren - 1 in
+      if bracket_pos >= 0 && text.[bracket_pos] = ']' then
+        (* Image is ![alt](url) — distinguished from link by '!' before '['. *)
+        let is_image =
+          let scan = ref (bracket_pos - 1) in
+          let saw_image = ref false in
+          (* find the matching '[' for this ']'; bail if we leave a line. *)
+          while !scan >= 0 && text.[!scan] <> '[' && text.[!scan] <> '\n' do
+            decr scan
+          done;
+          if !scan >= 0 && text.[!scan] = '[' && !scan > 0
+             && text.[!scan - 1] = '!'
+          then saw_image := true;
+          !saw_image
+        in
+        Some (if is_image then Unfinished_image else Unfinished_link)
+      else
+        None
+    else
+      None
+
+(* Backwards-compatible boolean wrapper. *)
+let detect_truncated_markdown (text : string) : bool =
+  detect_truncated_markdown_with_reason text <> None
 
 let handle_post_create args =
   let title = get_string_opt args "title" in
@@ -313,7 +386,8 @@ let handle_post_create args =
   let raw_content = match body with Some value -> value | None -> get_string args "content" "" in
   let content =
     let stripped = strip_state_blocks_text raw_content in
-    if detect_truncated_markdown stripped then begin
+    match detect_truncated_markdown_with_reason stripped with
+    | Some reason ->
       let author_label =
         match get_string_opt args "author" |> Option.map String.trim with
         | Some a when a <> "" -> a
@@ -321,11 +395,15 @@ let handle_post_create args =
       in
       Prometheus.inc_counter Prometheus.metric_board_truncated_posts
         ~labels:[("author", author_label)] ();
+      (* #9777: body_len is the LLM's own output length AFTER state-block
+         stripping, not a MASC-imposed limit. The signal name explains
+         which structural pattern triggered the marker. *)
       Log.BoardLog.warn
-        "board_post: detected truncated markdown (author=%s body_len=%d) — appending 잘림 marker"
-        author_label (String.length stripped);
+        "board_post: detected truncated markdown (author=%s body_len=%d signal=%s) — appending 잘림 marker"
+        author_label (String.length stripped)
+        (truncation_signal_to_string reason);
       stripped ^ "\n\n_…[잘림 — LLM 출력이 중간에 끊겼습니다]_"
-    end else
+    | None ->
       stripped
   in
   let author = get_string_opt args "author" |> Option.map String.trim in

--- a/test/dune
+++ b/test/dune
@@ -421,6 +421,7 @@
         test_eval_harness
         test_tool_board_coverage
         test_anti_rationalization_fail_mode
+        test_board_truncation_detection
         ; test_proof_criteria removed (team session cleanup)
         test_tool_registration_consistency
         ; test_tree_index removed (CP purge)
@@ -589,6 +590,7 @@
         test_eval_harness
         test_tool_board_coverage
         test_anti_rationalization_fail_mode
+        test_board_truncation_detection
         ; test_proof_criteria removed (team session cleanup)
         test_tool_registration_consistency
         ; test_tree_index removed (CP purge)

--- a/test/test_board_truncation_detection.ml
+++ b/test/test_board_truncation_detection.ml
@@ -33,6 +33,10 @@ let test_balanced_inline_tick_no_signal () =
   check (option signal_t) "balanced inline `let x` ticks"
     None (detect "Use `let` and `in` together.")
 
+let test_double_asterisk_in_inline_code_no_signal () =
+  check (option signal_t) "glob in balanced inline code"
+    None (detect "Run `ls **/*.ml` before submitting.")
+
 let test_underscore_in_identifier_not_truncation () =
   (* Identifiers with underscores must NOT trigger detection
      (the original detector was deliberately conservative on _). *)
@@ -60,6 +64,11 @@ let test_odd_double_asterisk_triggers () =
   check (option signal_t) "unclosed bold"
     (Some Tool_board.Odd_double_asterisk)
     (detect "This is **important and never closed")
+
+let test_odd_double_asterisk_outside_inline_code_triggers () =
+  check (option signal_t) "unclosed bold after inline glob"
+    (Some Tool_board.Odd_double_asterisk)
+    (detect "Run `ls **/*.ml`, then write **summary")
 
 let test_unfinished_link_triggers () =
   check (option signal_t) "trailing [text]( with no )"
@@ -101,6 +110,7 @@ let () =
           test_case "complete text" `Quick test_complete_text_no_signal;
           test_case "balanced fence" `Quick test_balanced_fence_no_signal;
           test_case "balanced inline tick" `Quick test_balanced_inline_tick_no_signal;
+          test_case "double asterisk in inline code" `Quick test_double_asterisk_in_inline_code_no_signal;
           test_case "underscore identifier" `Quick test_underscore_in_identifier_not_truncation;
           test_case "prose paren" `Quick test_paren_in_prose_not_unfinished_link;
         ] );
@@ -109,6 +119,7 @@ let () =
           test_case "odd fence" `Quick test_odd_fence_triggers;
           test_case "odd inline tick" `Quick test_odd_inline_tick_triggers;
           test_case "odd double asterisk" `Quick test_odd_double_asterisk_triggers;
+          test_case "odd double asterisk outside inline code" `Quick test_odd_double_asterisk_outside_inline_code_triggers;
           test_case "unfinished link" `Quick test_unfinished_link_triggers;
           test_case "unfinished image" `Quick test_unfinished_image_triggers;
         ] );

--- a/test/test_board_truncation_detection.ml
+++ b/test/test_board_truncation_detection.ml
@@ -1,0 +1,123 @@
+(** #9777: regression tests for [Tool_board.detect_truncated_markdown_with_reason].
+
+    Each case names the truncation pattern under test and asserts both
+    that detection fires and that the FIRST signal returned is the
+    expected one — so we lock in the priority order at the structural
+    level (fence > inline tick > double-asterisk > unfinished link/image). *)
+
+open Alcotest
+open Masc_mcp
+
+let signal_eq a b =
+  Tool_board.truncation_signal_to_string a
+  = Tool_board.truncation_signal_to_string b
+
+let signal_pp ppf s =
+  Format.fprintf ppf "%s" (Tool_board.truncation_signal_to_string s)
+
+let signal_t = testable signal_pp signal_eq
+
+let detect = Tool_board.detect_truncated_markdown_with_reason
+
+(* ---- Negative cases (should NOT trigger detection) ----------------- *)
+
+let test_complete_text_no_signal () =
+  check (option signal_t) "complete sentence"
+    None (detect "Hello, this is a complete sentence.")
+
+let test_balanced_fence_no_signal () =
+  check (option signal_t) "balanced ``` fence"
+    None (detect "Look:\n```ocaml\nlet x = 1\n```\nDone.")
+
+let test_balanced_inline_tick_no_signal () =
+  check (option signal_t) "balanced inline `let x` ticks"
+    None (detect "Use `let` and `in` together.")
+
+let test_underscore_in_identifier_not_truncation () =
+  (* Identifiers with underscores must NOT trigger detection
+     (the original detector was deliberately conservative on _). *)
+  check (option signal_t) "snake_case identifier"
+    None (detect "See snake_case_var and another_one.")
+
+let test_paren_in_prose_not_unfinished_link () =
+  (* Plain parens in prose without [text] before should not trigger. *)
+  check (option signal_t) "trailing prose paren"
+    None (detect "(this is a parenthetical aside)")
+
+(* ---- Positive cases (must trigger with the right signal) ----------- *)
+
+let test_odd_fence_triggers () =
+  check (option signal_t) "unclosed code fence"
+    (Some Tool_board.Odd_fence)
+    (detect "Here is code:\n```python\nprint('hello')")
+
+let test_odd_inline_tick_triggers () =
+  check (option signal_t) "trailing lone backtick"
+    (Some Tool_board.Odd_inline_tick)
+    (detect "Use the `read function")
+
+let test_odd_double_asterisk_triggers () =
+  check (option signal_t) "unclosed bold"
+    (Some Tool_board.Odd_double_asterisk)
+    (detect "This is **important and never closed")
+
+let test_unfinished_link_triggers () =
+  check (option signal_t) "trailing [text]( with no )"
+    (Some Tool_board.Unfinished_link)
+    (detect "See the docs at [reference](https://example.com/path")
+
+let test_unfinished_image_triggers () =
+  check (option signal_t) "trailing ![alt]( with no )"
+    (Some Tool_board.Unfinished_image)
+    (detect "Diagram: ![overview](http://example.com/img.png")
+
+(* ---- Priority order: fence wins over later signals ----------------- *)
+
+let test_fence_priority_over_link () =
+  (* Both an unclosed fence AND an unfinished link present — fence wins. *)
+  let s = "```\ntext\nlink: [foo](http://x" in
+  check (option signal_t) "fence has higher priority"
+    (Some Tool_board.Odd_fence) (detect s)
+
+(* ---- Boolean wrapper agrees with reason API ------------------------ *)
+
+let test_bool_wrapper_agrees () =
+  let cases = [
+    ("complete.", false);
+    ("```\nopen", true);
+    ("trailing `code", true);
+    ("trailing [link](url", true);
+  ] in
+  List.iter (fun (input, expected) ->
+    check bool (Printf.sprintf "case %S" input) expected
+      (Tool_board.detect_truncated_markdown input)
+  ) cases
+
+let () =
+  run "board truncation detection (#9777)"
+    [
+      ( "negative",
+        [
+          test_case "complete text" `Quick test_complete_text_no_signal;
+          test_case "balanced fence" `Quick test_balanced_fence_no_signal;
+          test_case "balanced inline tick" `Quick test_balanced_inline_tick_no_signal;
+          test_case "underscore identifier" `Quick test_underscore_in_identifier_not_truncation;
+          test_case "prose paren" `Quick test_paren_in_prose_not_unfinished_link;
+        ] );
+      ( "positive",
+        [
+          test_case "odd fence" `Quick test_odd_fence_triggers;
+          test_case "odd inline tick" `Quick test_odd_inline_tick_triggers;
+          test_case "odd double asterisk" `Quick test_odd_double_asterisk_triggers;
+          test_case "unfinished link" `Quick test_unfinished_link_triggers;
+          test_case "unfinished image" `Quick test_unfinished_image_triggers;
+        ] );
+      ( "priority",
+        [
+          test_case "fence wins over link" `Quick test_fence_priority_over_link;
+        ] );
+      ( "compat",
+        [
+          test_case "bool wrapper agrees with reason" `Quick test_bool_wrapper_agrees;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

The board's truncation detector only checked for **odd backticks** (triple-fence or inline). Other very common LLM truncation shapes — unclosed bold (`**...`), unfinished link (`[text](...`), unfinished image (`![alt](...`) — slipped through silently and the warn marker was never appended.

The original report (#9777, seq=53552) also misread `body_len=3575` as a MASC-imposed cap — it is the LLM's own output length **after state-block stripping**, not a hard limit anywhere in MASC code. The log message now states this explicitly.

## What changed

### 1. Detection — three new signals (conservative)

Added on top of the two existing ones:

| Signal | What it catches |
|--------|-----------------|
| `Odd_double_asterisk` | `**...` outside fenced code (unclosed bold) |
| `Unfinished_link` | trailing `[text](` with no closing `)` |
| `Unfinished_image` | trailing `![alt](` with no closing `)` |

**Deliberately NOT added**:
- Underscore-based emphasis (`_...`) — identifiers like `snake_case_var`, file paths like `dir_name`, and inline math frequently carry odd `_` counts and would yield false positives on legitimate prose.
- Single-asterisk emphasis (`*...`) — same reason; markdown allows `*x*` for italic but `*` is also used in bullet lists.

### 2. Diagnostics — surface which signal fired

`detect_truncated_markdown` was a bare `bool`; now `detect_truncated_markdown_with_reason` returns the first signal hit, and the WARN log includes it:

```
board_post: detected truncated markdown
  (author=keeper-qa-king-agent body_len=3575 signal=odd_fence)
```

The bare `bool` API is preserved as a one-line wrapper so every existing caller compiles unchanged.

## Test plan

- [x] `dune build --root=. lib/` — clean
- [x] `dune exec test/test_board_truncation_detection.exe` — 12/12 pass
  - **negative (5)**: complete text, balanced fence, balanced inline ticks, snake_case identifiers, prose parens must NOT trigger (no false positives).
  - **positive (5)**: each of the 5 signals fires individually.
  - **priority (1)**: when multiple signals coexist, structural (fence) wins over trailing-shape (link) so the log signal is deterministic.
  - **compat (1)**: bool wrapper stays in sync with the reason API.
- [x] `dune exec test/test_tool_board_coverage.exe` — 56/56 pass (no regression).

Closes #9777

## Followups not in this PR

- The marker text is currently Korean (`잘림 — LLM 출력이 중간에 끊겼습니다`). The issue questions whether marker language should be consistent across log messages — that's a separate localization decision and out of scope.
- The retrieval-then-retry pattern (Outlines / Instructor) — re-call the LLM with a higher `max_tokens` after detection — is the right long-term fix for repeated truncation but needs cascade integration; tracked separately.