### PR TITLE
fix(anti_rationalization): make verifier-unavailable fallback configurable (#9794)

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -475,10 +475,42 @@ let review
             req.agent_name req.task_title evaluator_cascade);
        emit { verdict = v; evaluator_cascade; generator_cascade; gate; fallback_reason }
      | Error err ->
-       (* Liveness > correctness: if LLM is unavailable, approve *)
+       (* #9794: when the verifier LLM is unavailable, the operator picks
+          between liveness (Open: approve, original behavior) and safety
+          (Closed: reject so the action stays gated). The choice is config-
+          driven; see Env_config.AntiRationalization. Both paths emit the
+          same Prometheus counter so monitoring sees the fallback rate
+          regardless of the chosen policy. *)
        let msg = Oas.Error.to_string err in
-       Log.Task.warn "[anti-rationalization] LLM unavailable: %s (approving by default)" msg;
-       emit { verdict = Approve; evaluator_cascade; generator_cascade; gate = Fallback; fallback_reason = Some msg })
+       let mode = Env_config.AntiRationalization.fail_mode in
+       let mode_str = Env_config.AntiRationalization.fail_mode_to_string mode in
+       Prometheus.inc_counter
+         Prometheus.metric_anti_rationalization_fallback
+         ~labels:[ ("mode", mode_str); ("cascade", evaluator_cascade) ]
+         ();
+       (match mode with
+        | Env_config.AntiRationalization.Open ->
+          Log.Task.warn
+            "[anti-rationalization] LLM unavailable: %s (approving by default; mode=open MASC_ANTI_RATIONALIZATION_FAIL_MODE=open)"
+            msg;
+          emit
+            { verdict = Approve
+            ; evaluator_cascade
+            ; generator_cascade
+            ; gate = Fallback
+            ; fallback_reason = Some msg
+            }
+        | Env_config.AntiRationalization.Closed ->
+          Log.Task.warn
+            "[anti-rationalization] LLM unavailable: %s (rejecting by default; mode=closed MASC_ANTI_RATIONALIZATION_FAIL_MODE=closed)"
+            msg;
+          emit
+            { verdict = Reject (sprintf "verifier unavailable (fail-closed): %s" msg)
+            ; evaluator_cascade
+            ; generator_cascade
+            ; gate = Fallback
+            ; fallback_reason = Some msg
+            }))
 
 (** Backward-compatible wrapper that returns only the verdict.
     Use [review] directly for structured results with audit metadata. *)

--- a/lib/config/env_config_governance.ml
+++ b/lib/config/env_config_governance.ml
@@ -212,4 +212,31 @@ module Model_defaults = struct
     get_string ~default:"task" "MASC_GOAL_DISPATCH_RUNTIME"
 end
 
+(** {1 Anti-Rationalization Configuration}
+    Primary env vars: MASC_ANTI_RATIONALIZATION_*. *)
+
+module AntiRationalization = struct
+  (* #9794: when the verifier LLM is unavailable, the historical behavior
+     is to approve by default (favor liveness). Operators that want stronger
+     governance can flip to fail-closed (favor safety) via env var.
+     Default stays Open for backward compatibility. *)
+  type fail_mode =
+    | Open
+    | Closed
+
+  let fail_mode_of_string raw =
+    let s = String.lowercase_ascii (String.trim raw) in
+    match s with
+    | "closed" | "reject" | "fail_closed" | "deny" -> Closed
+    | _ -> Open
+
+  let fail_mode_to_string = function
+    | Open -> "open"
+    | Closed -> "closed"
+
+  let fail_mode =
+    fail_mode_of_string
+      (get_string ~default:"open" "MASC_ANTI_RATIONALIZATION_FAIL_MODE")
+end
+
 (** {1 Endpoint Configuration} *)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -300,6 +300,8 @@ let metric_llm_provider_request_latency =
   "masc_llm_provider_request_latency_seconds"
 
 (* Domain-specific counters not yet constant-ised. *)
+let metric_anti_rationalization_fallback =
+  "masc_anti_rationalization_fallback_total"
 let metric_board_truncated_posts = "masc_board_truncated_posts_total"
 let metric_cascade_strategy_decisions = "masc_cascade_strategy_decisions_total"
 let metric_cascade_capacity_events = "masc_cascade_capacity_events_total"
@@ -449,6 +451,9 @@ let init () =
     Gauge;
   add metric_board_truncated_posts
     "Total board posts truncated due to size limits"
+    Counter;
+  add metric_anti_rationalization_fallback
+    "Total anti-rationalization fallbacks fired (verifier LLM unavailable), labeled by mode and cascade"
     Counter;
   add metric_agent_heartbeat_age_seconds
     "Maximum observed heartbeat age across active agents (seconds)"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -134,6 +134,7 @@ val metric_tool_call_duration : string
 val metric_llm_provider_http_status : string
 val metric_llm_provider_request_latency : string
 val metric_board_truncated_posts : string
+val metric_anti_rationalization_fallback : string
 val metric_cascade_strategy_decisions : string
 val metric_cascade_capacity_events : string
 val metric_keeper_invariant_violations : string

--- a/test/dune
+++ b/test/dune
@@ -419,6 +419,7 @@
         test_eval_gate
         test_eval_harness
         test_tool_board_coverage
+        test_anti_rationalization_fail_mode
         ; test_proof_criteria removed (team session cleanup)
         test_tool_registration_consistency
         ; test_tree_index removed (CP purge)
@@ -585,6 +586,7 @@
         test_eval_gate
         test_eval_harness
         test_tool_board_coverage
+        test_anti_rationalization_fail_mode
         ; test_proof_criteria removed (team session cleanup)
         test_tool_registration_consistency
         ; test_tree_index removed (CP purge)

--- a/test/test_anti_rationalization_fail_mode.ml
+++ b/test/test_anti_rationalization_fail_mode.ml
@@ -1,0 +1,66 @@
+(** #9794: regression tests for [Env_config.AntiRationalization.fail_mode_of_string].
+
+    The fail_mode config decides whether the verifier-unavailable path in
+    [Anti_rationalization.review] approves (liveness-favored, original
+    behavior) or rejects (safety-favored). This test pins the parsing
+    contract — synonyms, casing, defaulting — so a future refactor that
+    accidentally narrows or widens the recognized aliases surfaces here
+    rather than as a silently-flipped policy in production. *)
+
+open Alcotest
+
+module AR = Env_config.AntiRationalization
+
+let mode = testable
+  (fun ppf m -> Format.fprintf ppf "%s" (AR.fail_mode_to_string m))
+  (fun a b -> AR.fail_mode_to_string a = AR.fail_mode_to_string b)
+
+let test_open_default_for_unknown () =
+  check mode "garbage -> Open" AR.Open (AR.fail_mode_of_string "garbage");
+  check mode "empty string -> Open" AR.Open (AR.fail_mode_of_string "");
+  check mode "whitespace-only -> Open" AR.Open (AR.fail_mode_of_string "  \t ")
+
+let test_open_explicit () =
+  check mode "open -> Open" AR.Open (AR.fail_mode_of_string "open");
+  check mode "OPEN -> Open" AR.Open (AR.fail_mode_of_string "OPEN");
+  check mode "Open trimmed" AR.Open (AR.fail_mode_of_string "  open  ")
+
+let test_closed_synonyms () =
+  check mode "closed -> Closed" AR.Closed (AR.fail_mode_of_string "closed");
+  check mode "reject -> Closed" AR.Closed (AR.fail_mode_of_string "reject");
+  check mode "fail_closed -> Closed" AR.Closed (AR.fail_mode_of_string "fail_closed");
+  check mode "deny -> Closed" AR.Closed (AR.fail_mode_of_string "deny")
+
+let test_closed_case_and_whitespace () =
+  check mode "CLOSED uppercase -> Closed"
+    AR.Closed (AR.fail_mode_of_string "CLOSED");
+  check mode "  Closed  trimmed -> Closed"
+    AR.Closed (AR.fail_mode_of_string "  Closed  ");
+  check mode "Reject mixed case -> Closed"
+    AR.Closed (AR.fail_mode_of_string "Reject")
+
+let test_round_trip () =
+  check mode "Open round-trip"
+    AR.Open (AR.fail_mode_of_string (AR.fail_mode_to_string AR.Open));
+  check mode "Closed round-trip"
+    AR.Closed (AR.fail_mode_of_string (AR.fail_mode_to_string AR.Closed))
+
+let () =
+  run "anti_rationalization fail_mode (#9794)" [
+    ("default", [
+       test_case "unknown values default to Open (liveness)" `Quick
+         test_open_default_for_unknown;
+     ]);
+    ("explicit_open", [
+       test_case "open keyword and case variants" `Quick test_open_explicit;
+     ]);
+    ("closed_synonyms", [
+       test_case "closed/reject/fail_closed/deny all map to Closed" `Quick
+         test_closed_synonyms;
+       test_case "casing and whitespace tolerated" `Quick
+         test_closed_case_and_whitespace;
+     ]);
+    ("invariants", [
+       test_case "to_string then of_string is identity" `Quick test_round_trip;
+     ]);
+  ]


### PR DESCRIPTION
## Summary

When the verifier LLM is unavailable, anti-rationalization currently approves by default (liveness over correctness). #9794 reports this as a governance-bypass risk.

The reporter is right that this is fail-open. **But globally flipping to fail-closed breaks operators who depend on agents continuing during verifier downtime.** This is a real liveness-vs-safety trade-off, not a bug fix.

Resolution: turn the trade-off into an explicit operator policy switch with the necessary observability to monitor either choice.

## What changed

### 1. New configurable mode (default = Open, current behavior)

```bash
export MASC_ANTI_RATIONALIZATION_FAIL_MODE=closed   # safety
export MASC_ANTI_RATIONALIZATION_FAIL_MODE=open     # liveness (default)
```

Closed-side synonyms: `reject`, `fail_closed`, `deny`. Case-insensitive. Whitespace-tolerant.

### 2. Behavior

| Mode | Verifier unavailable → |
|------|--------------------------|
| `open` (default) | Approve, log warn, emit counter |
| `closed` | Reject `"verifier unavailable (fail-closed): <error>"`, log warn, emit counter |

The Reject path goes through the existing rejection pipeline — no new error class.

### 3. Telemetry (both modes)

```
masc_anti_rationalization_fallback_total{mode="open|closed", cascade="<name>"}
```

So an operator can:
- alert when fallback rate spikes (verifier flapping)
- decide whether to flip to Closed based on observed rate
- distinguish Open-fallbacks (silent governance bypass) from Closed-fallbacks (visible reject)

## Why not just flip the default to Closed

Two reasons:
- The original liveness choice was deliberate (see comment at line 478 in main). Flipping it would silently break workflows that depend on agents continuing during verifier downtime.
- Without telemetry, operators have no way to gauge how often this fires before deciding. This PR ships telemetry first; a follow-up can flip the default once production logs show fallback is rare.

## Test plan

- [x] `dune build --root=. lib/` — clean
- [x] `dune exec test/test_anti_rationalization_fail_mode.exe` — 5/5 pass:
  - unknown values default to Open (liveness)
  - explicit `open` keyword + casing variants
  - 4 Closed synonyms (closed / reject / fail_closed / deny)
  - casing and whitespace tolerated
  - to_string ∘ of_string round-trip is identity
- [x] `dune exec test/test_anti_rationalization_empty_liveness.exe` — 2/2 pass (no regression)
- [x] `dune exec test/test_anti_rationalization_coverage.exe` — pass

Closes #9794

## Followup not in this PR

Once production logs accumulate counter samples, propose a default flip to `Closed` if fallback rate is low (< 0.1% of verifier calls) and operator confirms tolerance.