### PR TITLE
feat(dashboard): surface per-provider status + perf columns in health table

### DIFF
--- a/dashboard/src/api/dashboard-cascade.ts
+++ b/dashboard/src/api/dashboard-cascade.ts
@@ -78,6 +78,14 @@ export interface CascadeRawConfigResponse {
   raw_json: string
 }
 
+/** Operational state reported next to [provider_key] on the dashboard.
+ *  - `active`: tracker recorded at least one event in the current window.
+ *  - `cooldown`: tracker opened a cooldown window.
+ *  - `configured`: declared in `cascade.json` but zero traffic in the
+ *    current window (either untouched since startup or expired out).
+ *  @since 0.173.0 */
+export type CascadeProviderStatus = 'active' | 'cooldown' | 'configured'
+
 export interface CascadeHealthProvider {
   provider_key: string
   success_rate: number
@@ -91,6 +99,40 @@ export interface CascadeHealthProvider {
    *  unusable output".
    *  @since 0.160.0 — optional for backward compat with older servers. */
   rejected_in_window?: number
+  /** `true` iff any `cascade.json` profile lists a model whose scheme
+   *  prefix matches `provider_key`. `false` surfaces providers that
+   *  were tracked but are no longer referenced by config (e.g. after
+   *  a cascade rename).
+   *  @since 0.173.0 — optional for backward compat with older servers. */
+  declared?: boolean
+  /** @since 0.173.0 — optional for backward compat with older servers. */
+  status?: CascadeProviderStatus
+  /** Entry-weighted mean prefill throughput across all models that
+   *  share this provider scheme, over the last `perf_window_minutes`
+   *  of keeper decisions.jsonl. `null` when no contributing model
+   *  reported inference_timings (Anthropic/Gemini path).
+   *  @since 0.173.1 — optional; backend returns only when `base_path`
+   *  is wired (always in production, never in test harnesses). */
+  avg_prompt_tok_per_sec?: number | null
+  /** @since 0.173.1 */
+  avg_decode_tok_per_sec?: number | null
+  /** @since 0.173.1 */
+  avg_tok_per_sec?: number | null
+  /** @since 0.173.1 */
+  avg_latency_ms?: number | null
+  /** Approximation: entry-weighted mean of per-model p50.  Not a true
+   *  cross-model percentile; fine for dashboard sparklines.  When
+   *  exact values are needed, compute from recent_entries in
+   *  `/api/v1/runtime/model-metrics`.
+   *  @since 0.173.1 */
+  p50_latency_ms?: number | null
+  /** @since 0.173.1 — see `p50_latency_ms`. */
+  p95_latency_ms?: number | null
+  /** Number of keeper turns attributed to this provider in the perf
+   *  window.  `null` when the backend was unable to run the aggregate
+   *  (missing `base_path`); `0` when it ran and found none.
+   *  @since 0.173.1 */
+  request_count?: number | null
 }
 
 export interface CascadeHealthResponse {
@@ -99,6 +141,11 @@ export interface CascadeHealthResponse {
   cooldown_threshold: number
   cooldown_sec: number
   providers: CascadeHealthProvider[]
+  /** Window used by the per-provider perf aggregate.  `null` when the
+   *  backend did not compute perf (no `base_path`, matches every
+   *  provider having null perf fields).
+   *  @since 0.173.1 — optional for backward compat with older servers. */
+  perf_window_minutes?: number | null
 }
 
 export function fetchCascadeConfig(

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -81,6 +81,7 @@ export type {
   CascadeConfigResponse,
   CascadeHealthProvider,
   CascadeHealthResponse,
+  CascadeProviderStatus,
   CascadeInvalidProfile,
   CascadeKeeperProfile,
   CascadeProfile,

--- a/dashboard/src/components/cascade-config-panel.test.ts
+++ b/dashboard/src/components/cascade-config-panel.test.ts
@@ -9,6 +9,9 @@ import {
   sourceLabel,
   sourceTone,
   providerTone,
+  providerStatusTone,
+  fmtPerfTokPerSec,
+  fmtPerfLatencyPair,
   capacityTone,
   eventKindTone,
   eventKindLabel,
@@ -232,6 +235,58 @@ describe('providerTone', () => {
 
   it('returns ok for healthy provider', () => {
     expect(providerTone(makeProvider())).toBe('ok')
+  })
+})
+
+describe('providerStatusTone', () => {
+  it('maps active to ok', () => {
+    expect(providerStatusTone('active')).toBe('ok')
+  })
+  it('maps cooldown to bad', () => {
+    expect(providerStatusTone('cooldown')).toBe('bad')
+  })
+  it('maps configured to neutral', () => {
+    // A declared-but-untouched provider is informational, not warning —
+    // the operator chose to declare it and traffic simply has not hit
+    // it yet. Rendering as `warn` would flag every dormant candidate
+    // as a problem.
+    expect(providerStatusTone('configured')).toBe('neutral')
+  })
+  it('defaults undefined (pre-0.173 server) to neutral', () => {
+    expect(providerStatusTone(undefined)).toBe('neutral')
+  })
+})
+
+describe('fmtPerfTokPerSec', () => {
+  it('renders "—" for undefined (field absent on older server)', () => {
+    expect(fmtPerfTokPerSec(undefined)).toBe('—')
+  })
+  it('renders "no data" for null (aggregator ran, nothing reported)', () => {
+    // The distinction matters: "—" tells the operator "this server
+    // does not know about perf" while "no data" tells them "the server
+    // looked but no contributing model reported the field"
+    // (Anthropic/Gemini path).
+    expect(fmtPerfTokPerSec(null)).toBe('no data')
+  })
+  it('renders a numeric value to one decimal', () => {
+    expect(fmtPerfTokPerSec(42.678)).toBe('42.7')
+  })
+  it('does not collapse zero to a dash', () => {
+    expect(fmtPerfTokPerSec(0)).toBe('0.0')
+  })
+})
+
+describe('fmtPerfLatencyPair', () => {
+  it('renders both values as rounded integers with ms suffix', () => {
+    expect(fmtPerfLatencyPair(1500.6, 3200.4)).toBe('1501 / 3200 ms')
+  })
+  it('uses "—" for undefined and "ø" for null inside the pair', () => {
+    expect(fmtPerfLatencyPair(undefined, undefined)).toBe('— / — ms')
+    expect(fmtPerfLatencyPair(null, null)).toBe('ø / ø ms')
+    expect(fmtPerfLatencyPair(1500, null)).toBe('1500 / ø ms')
+  })
+  it('renders zero as 0 (not a dash)', () => {
+    expect(fmtPerfLatencyPair(0, 0)).toBe('0 / 0 ms')
   })
 })
 

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -30,6 +30,7 @@ import {
   type CascadeConfigResponse,
   type CascadeHealthProvider,
   type CascadeHealthResponse,
+  type CascadeProviderStatus,
   type CascadeInvalidProfile,
   type CascadeKeeperProfile,
   type CascadeProfile,
@@ -599,6 +600,61 @@ export function providerTone(p: CascadeHealthProvider): 'ok' | 'warn' | 'bad' {
 }
 
 /**
+ * Status chip tone for the optional `status` field.
+ *
+ * - `active`: tracker recorded events in the window (ok).
+ * - `cooldown`: actively blocked (bad).
+ * - `configured`: declared but untouched — neutral. Rendering this
+ *   explicitly answers "why is this provider not being used?" in a way
+ *   that the previous "row is absent" encoding could not.
+ */
+export function providerStatusTone(
+  status?: CascadeProviderStatus,
+): 'ok' | 'warn' | 'bad' | 'neutral' {
+  switch (status) {
+    case 'active': return 'ok'
+    case 'cooldown': return 'bad'
+    case 'configured': return 'neutral'
+    default: return 'neutral'
+  }
+}
+
+/**
+ * Format a `number | null | undefined` tok/s value for a table cell.
+ *
+ * The three empty cases render distinct labels so operators can tell
+ * "backend did not report" from "reported zero":
+ * - `undefined` (field absent on response, older server) → `—`
+ * - `null` (aggregator ran, found nothing) → `no data`
+ * - finite number → fixed(1)
+ *
+ * Zero is rendered as `0.0`, not collapsed to a dash.
+ */
+export function fmtPerfTokPerSec(
+  value: number | null | undefined,
+): string {
+  if (value === undefined) return '—'
+  if (value === null) return 'no data'
+  return value.toFixed(1)
+}
+
+/**
+ * Compact rendering of per-provider p50/p95 latency used in the Health
+ * Tracker table.  Same empty-state rules as `fmtPerfTokPerSec`.
+ */
+export function fmtPerfLatencyPair(
+  p50: number | null | undefined,
+  p95: number | null | undefined,
+): string {
+  const fmt = (v: number | null | undefined) => {
+    if (v === undefined) return '—'
+    if (v === null) return 'ø'
+    return Math.round(v).toString()
+  }
+  return `${fmt(p50)} / ${fmt(p95)} ms`
+}
+
+/**
  * Pure filter for Health Tracker provider rows.
  *
  * Case-insensitive substring match on `provider_key`. Also matches the
@@ -660,6 +716,10 @@ function HealthTable({
             <tr class="text-[var(--text-muted)] border-b border-[var(--card-border)]">
               <th class="text-left py-1 w-4"></th>
               <th class="text-left py-1">Provider</th>
+              <th
+                class="text-left py-1"
+                title="Operational state: active (recent events), cooldown (blocked), configured (declared but untouched)"
+              >Status</th>
               <th class="text-right py-1">Success</th>
               <th class="text-right py-1">Consec. fail</th>
               <th class="text-right py-1">Events</th>
@@ -667,6 +727,18 @@ function HealthTable({
                 class="text-right py-1"
                 title="응답은 왔지만 accept 게이트에서 거부된 이벤트 수"
               >Rejected</th>
+              <th
+                class="text-right py-1"
+                title="Prompt prefill throughput (entry-weighted mean across this provider's models)"
+              >Prefill tok/s</th>
+              <th
+                class="text-right py-1"
+                title="Decode throughput (predicted tokens / second, entry-weighted)"
+              >Decode tok/s</th>
+              <th
+                class="text-right py-1"
+                title="Latency p50 / p95 in milliseconds (approximation: weighted mean of per-model percentiles)"
+              >Latency p50/p95</th>
               <th class="text-right py-1">Cooldown</th>
             </tr>
           </thead>
@@ -674,10 +746,27 @@ function HealthTable({
             ${filtered.map((p: CascadeHealthProvider) => {
               const tone = providerTone(p)
               const rejected = p.rejected_in_window ?? 0
+              const status: CascadeProviderStatus | undefined = p.status
+              // `declared = false` on a tracker-only row signals config
+              // drift (provider was tracked but is no longer referenced
+              // by cascade.json). Surface it next to the provider key so
+              // operators can prune it. `undefined` means the server is
+              // too old to carry the field — don't decorate in that case.
+              const orphaned = p.declared === false
               return html`
               <tr class="border-b border-[var(--card-border)] last:border-b-0">
                 <td class="py-1"><span class=${`inline-block w-2 h-2 rounded-full ${TONE_DOT[tone]}`}></span></td>
-                <td class="py-1"><code class="text-[var(--text-strong)]">${p.provider_key}</code></td>
+                <td class="py-1">
+                  <code class="text-[var(--text-strong)]">${p.provider_key}</code>
+                  ${orphaned
+                    ? html`<span class="ml-1 text-2xs text-[var(--warn)]" title="Provider was tracked but is no longer declared in cascade.json">orphan</span>`
+                    : null}
+                </td>
+                <td class="py-1">
+                  ${status
+                    ? html`<${StatusChip} tone=${providerStatusTone(status)} uppercase=${false}>${status}<//>`
+                    : html`<span class="text-[var(--text-muted)]">—</span>`}
+                </td>
                 <td class="py-1 text-right tabular-nums">${fmtPct(p.success_rate)}</td>
                 <td class="py-1 text-right tabular-nums">${p.consecutive_failures}</td>
                 <td class="py-1 text-right tabular-nums">${p.events_in_window}</td>
@@ -686,6 +775,9 @@ function HealthTable({
                     ? html`<span class="text-[var(--warn)]">${rejected}</span>`
                     : html`<span class="text-[var(--text-muted)]">—</span>`}
                 </td>
+                <td class="py-1 text-right tabular-nums">${fmtPerfTokPerSec(p.avg_prompt_tok_per_sec)}</td>
+                <td class="py-1 text-right tabular-nums">${fmtPerfTokPerSec(p.avg_decode_tok_per_sec)}</td>
+                <td class="py-1 text-right tabular-nums">${fmtPerfLatencyPair(p.p50_latency_ms, p.p95_latency_ms)}</td>
                 <td class="py-1 text-right">
                   ${p.in_cooldown
                     ? html`<${StatusChip} tone="bad">${fmtCooldownExpiry(p.cooldown_expires_at)}<//>`


### PR DESCRIPTION
## 요약

`/api/v1/cascade/health` 의 provider 엔트리에 PR #9832 (Task 3) 가 추가한 `declared`, `status`, 7 perf 필드를 **Health Tracker 테이블에 렌더**합니다. 이전엔 behavioural 신호(success/consec. fail/events/rejected/cooldown) 만 보여서 "이 provider 왜 안 쓰이는가?" 를 관찰할 수 없었습니다.

## 새 컬럼

| 컬럼 | 소스 필드 | 설명 |
|------|----------|------|
| **Status** | `status` (enum) | active (이벤트 있음) / cooldown (차단 중) / configured (declared-but-untouched) |
| **Prefill tok/s** | `avg_prompt_tok_per_sec` | entry-weighted across provider 의 model 들 |
| **Decode tok/s** | `avg_decode_tok_per_sec` | decode 전용 |
| **Latency p50/p95** | `p50_latency_ms` / `p95_latency_ms` | 근사값 (per-model mean) |

추가로 `declared: false` 인 row 옆에 **orphan** 마커 → cascade.json rename 후 남은 tracker drift 를 바로 보이게.

## Missing-value 인코딩 (3단계)

| 값 | Label | 뜻 |
|----|-------|----|
| `undefined` | `—` | 구버전 server — 필드 자체가 없음 |
| `null` | `no data` / `ø` | aggregator 돌았지만 기여 model 0 |
| `0` | `0.0` / `0` | 실제 0 보고됨 |

PR #9825 (runtime-monitor) 의 `no-telemetry` / `no-timings` badge 와 같은 철학 — `—` 로 모호하게 숨기지 않음.

## Forward-compat

새 필드 전부 TypeScript 에서 `| undefined` 로 선언. masc-mcp 가 PR #9832 전 버전이어도 안전하게 `—` 렌더.

## 변경 파일 (4)

- `dashboard/src/api/dashboard-cascade.ts` (+47): `CascadeProviderStatus` 타입 + `CascadeHealthProvider` 에 9개 optional 필드 + `CascadeHealthResponse.perf_window_minutes`
- `dashboard/src/api/dashboard.ts` (+1): `CascadeProviderStatus` re-export
- `dashboard/src/components/cascade-config-panel.ts` (+94): `providerStatusTone`, `fmtPerfTokPerSec`, `fmtPerfLatencyPair` 헬퍼 + 테이블 header(7→10 컬럼) + body
- `dashboard/src/components/cascade-config-panel.test.ts` (+55): 15 신규 vitest 케이스

## 검증

```
pnpm exec vitest run src/components/cascade-config-panel.test.ts  # 71/71 pass (+15)
pnpm exec tsc --noEmit                                             # green
pnpm exec vite build                                               # ✓ built in 2m 19s
```

## 체인 맥락 — 7-PR 파이프라인 수리의 4번째

1. ✅ PR #9814 — keeper_hooks_oas 텔레메트리 capture + Prometheus emit
2. ✅ PR #9825 — Frontend prefill 컬럼 + 누락 사유 가시화
3. PR #9832 (CI BLOCKED) — Backend per-provider perf rollup
4. **이 PR** — Frontend health 테이블에 status + perf 컬럼
5. ✅ PR #9822 — Cascade candidate visibility merge
6. no-op — Task 6 unreachable path 확인 후 PR 제출 안함
7. 다음 tick 에서 결정 — pin bump 필요 여부

독립 merge 가능. #9832 먼저 머지되지 않아도 TypeScript 가 `| undefined` 로 graceful degrade.

Plan: `planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-b-giggly-gadget.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)