### PR TITLE
docs(rfc): RFC-0007 rev.3 + RFC-0008 — op=gh harness + CredentialProvider (pragmatic)

### DIFF
--- a/docs/rfc/RFC-0007-op-gh-harness-audit.md
+++ b/docs/rfc/RFC-0007-op-gh-harness-audit.md
@@ -1,9 +1,11 @@
 # RFC-0007: Pragmatic `keeper_shell op=gh` Hardening
 
-- **Status**: Draft (rev.2)
+- **Status**: Draft (rev.3)
 - **Author**: vincent (with Claude)
 - **Created**: 2026-04-24
-- **Revised**: 2026-04-24 — replaced Samchon 4-layer big-bang with a claude-code-inspired 3-PR phasing (rev.1 sketch preserved in §8 Appendix)
+- **Revised**:
+  - 2026-04-24 rev.2 — replaced Samchon 4-layer big-bang with a claude-code-inspired 3-PR phasing (rev.1 sketch preserved in §8 Appendix).
+  - 2026-04-24 rev.3 — evidence correction: `GIT_ASKPASS` / `GIT_TERMINAL_PROMPT` are **absent** in the current codebase, not "scattered" as rev.2 claimed. PR-1 cost estimate bumped 80 → 120 lines accordingly.
 - **Related**: RFC-0005 (typed capability substrate), RFC-0006 (surface + symmetric sandbox), RFC-0008 (CredentialProvider — same review cycle), #8773, #6814
 - **Drives**: reduce LLM-facing tool error rate without rewriting the gh surface; keep every change landable in a single PR
 
@@ -12,7 +14,7 @@
 Two concrete failures observed on 2026-04-24 (evidence record `memory/procedural-memory/2026-04-24-keeper-docker-github-provider-evidence-record.md` on the `me` repo, decision id `keeper-docker-gh-provider-audit-2026-04-24`):
 
 1. **Tool error shape is a single string.** `lib/gh_command_validation.ml:215-251` returns `Error "<message>"`. An LLM can read the message but cannot programmatically distinguish *transient* input errors (typo, wrong flag type) from *policy* errors (R2 irreversible, out-of-org repo). No retry contract exists.
-2. **Non-interactive defaults are not enforced in every caller.** `lib/keeper/keeper_shell_docker.ml` sets `GIT_ASKPASS=''` and `GIT_TERMINAL_PROMPT=0` inline; the same constants are scattered across other callers. A new callsite that forgets one of these hangs the container on a credential prompt — silent timeout.
+2. **Non-interactive defaults are absent, not scattered** (evidence correction in rev.3 — `rg -n 'GIT_ASKPASS|GIT_TERMINAL_PROMPT' lib/ test/ scripts/` returned zero hits on commit `0e408ffc1d5b34badb0cc1b9f3704a9e725fb8c6`). `lib/keeper/keeper_shell_docker.ml:234-245` composes the docker `-e` env list inline — `HOME`, `GH_CONFIG_DIR`, `GIT_CONFIG_GLOBAL`, `GIT_CONFIG_COUNT=1`, `GIT_CONFIG_KEY_0=safe.directory`, `GIT_CONFIG_VALUE_0=*`, and the `GIT_AUTHOR_*`/`GIT_COMMITTER_*` pair — but never sets `GIT_ASKPASS=''` or `GIT_TERMINAL_PROMPT=0`. A keeper `git push` inside the container can, in principle, block indefinitely on a credential prompt; the only thing saving us today is that the RO-mounted `hosts.yml` (F-1) answers gh's auth query before git falls through to a prompt.
 
 Both are fixable without the Samchon 4-layer rewrite proposed in rev.1. Splitting the rewrite into 3 PRs keeps every step reviewable and reversible.
 
@@ -30,12 +32,12 @@ These principles are the whole RFC. Everything below is mechanical execution.
 
 ## 3. Three-PR phasing
 
-### PR-1 — `env_git_noninteractive` + scrub list (≈80 lines + tests)
+### PR-1 — `env_git_noninteractive` + scrub list (≈120 lines + tests)
 
-- **What**: new `lib/env_git_noninteractive.mli` exposing a single value `val env : (string * string) list`. Callers in `keeper_shell_docker.ml`, `keeper_exec_shell.ml` (op=gh / op=git_clone branches) replace their local inline `("GIT_ASKPASS","")` pairs with `@ Env_git_noninteractive.env`.
+- **What**: new `lib/env_git_noninteractive.mli` exposing `val env : (string * string) list = [("GIT_ASKPASS",""); ("GIT_TERMINAL_PROMPT","0")]`. These constants do not exist anywhere in `lib/`/`test/`/`scripts/` today (verified rev.3); PR-1 introduces them and wires them into `keeper_shell_docker.ml:234-245` alongside the existing `HOME`/`GH_CONFIG_DIR`/`GIT_CONFIG_*` block. `keeper_exec_shell.ml` is currently free of git env (verified), so there is a single callsite for this PR.
 - **Also**: `lib/env_keeper_scrub.ml` with two lists `scrub : string list` (Anthropic keys, AWS creds, OIDC tokens — copy from claude-code) and `pass : string list` (`GH_TOKEN`, `GITHUB_TOKEN`, `SSH_AUTH_SOCK`, `GIT_*`). docker run argv construction uses both.
-- **Why safe**: additive; any missed callsite is caught by `test_env_git_noninteractive.ml` that greps for forgotten `GIT_ASKPASS` literals under `lib/`.
-- **Observability**: metric `keeper_shell_docker.git_prompt_env_missing_total` (should be 0 after PR).
+- **Why safe**: additive — we are introducing constants that currently don't exist, not deleting or refactoring an existing pattern. A regression test asserts that every docker `-e` argv produced by `keeper_shell_docker.run_docker_shell_command_with_status` contains both keys.
+- **Observability**: metric `keeper_shell_docker.git_prompt_env_missing_total` (should be 0 after PR, and is effectively undefined before PR — the test is the more reliable gate).
 
 ### PR-2 — structured `gh_result.t` (≈120 lines)
 
@@ -106,12 +108,12 @@ No circular dependency; both RFCs can be reviewed in parallel and merged in the 
 
 | Item                           | Lines changed (est.) | Test added (est.) | Risk                          |
 |--------------------------------|---------------------:|------------------:|-------------------------------|
-| PR-1 env constants             |                   80 |                60 | low                           |
+| PR-1 env constants             |                  120 |                80 | low                           |
 | PR-2 structured result         |                  120 |               100 | medium (alias maintained)     |
 | PR-3 typed `Api_*`             |                  200 |               150 | medium (new module)           |
-| **Total**                      |              **400** |           **310** | —                             |
+| **Total**                      |              **440** |           **330** | —                             |
 
-Compare to rev.1's estimated 1200+ lines in a single cycle; 3-PR split is ~a third of the surface and reversible per step.
+Compare to rev.1's estimated 1200+ lines in a single cycle; 3-PR split is still ~a third of the surface and reversible per step. (rev.3 bumped PR-1 by 40 lines: the constants are being *introduced*, not refactored, so the mli + ml + wiring + the new regression test add more than the rev.2 "deduplication" framing implied.)
 
 ## 8. Appendix — original aspirational sketch (rev.1, retained for discussion)
 

--- a/docs/rfc/RFC-0007-op-gh-harness-audit.md
+++ b/docs/rfc/RFC-0007-op-gh-harness-audit.md
@@ -1,0 +1,135 @@
+# RFC-0007: `keeper_shell op=gh` Harness Audit (Samchon 4-layer)
+
+- **Status**: Draft
+- **Author**: vincent (with Claude)
+- **Created**: 2026-04-24
+- **Related**: RFC-0005 (typed capability substrate), RFC-0006 (surface + symmetric sandbox), #8773, #6814
+- **Drives**: tighter keeper GitHub surface so LLM errors become repairable (not silent), plus clarifies identity boundary vs. label
+
+## 1. Problem
+
+Two observations from a 2026-04-24 audit of the keeper × docker × GitHub path (evidence record: `memory/procedural-memory/2026-04-24-keeper-docker-github-provider-evidence-record.md` on the `me` repo) reframe what is currently shipped.
+
+| # | Symptom | Mechanism |
+|---|---------|-----------|
+| A | The "keeper-scoped" identity `anyang-keepers` holds the same token as the operator host. SHA-256 prefixes match (`406d098bd41b`). | `scripts/rotate-keeper-gh-token.sh` targets legacy `~/.masc/gh-auth`, which no longer exists; the running code reads `~/.masc/github-identities/<identity>/gh`; operators manually seed the bundle by copying the operator PAT. |
+| B | LLM calls of `keeper_shell op=gh` have no compile-time shape; a malformed `cmd` string reaches `validate_gh_command` which returns a single-line `Error string` that does not point to a specific flag or token. | `lib/gh_command_validation.ml:215-251` accepts a raw `string` and splits by whitespace (`extract_gh_command_pair`, line 184-213). Validate layer is strong on allowlist; Type/Parse/Feedback layers are thin. |
+
+Framed in the harness vocabulary from Samchon's 2025 function-calling study (dev.to/samchon/qwen-meetup-function-calling-harness, 6.75% → 100% via a 4-layer harness):
+
+| Layer | masc-mcp today | Gap |
+|-------|----------------|-----|
+| Type | `cmd: string` | No per-subcommand record; LLM emits free-form strings. |
+| Parse | whitespace split → `(command, subcommand)` | No shell-quote / JSON-body / heredoc support. No markdown/backtick strip. |
+| Validate | `forbidden_shell_chars` + top-level allowlist + `(command, subcommand)` blocklist + `allowed_orgs`; R0/R1/R2 taxonomy. | No flag-value type coercion (`--limit` int, `--state` enum); no flag-combination rules (`--jq` only on `gh api`). |
+| Feedback | Single `Error <printf string>`; some include Good/Bad examples. | No structured `{code, path, expected, received, hint}` object; no retry contract in keeper prompt. |
+
+Both observations share one root: **the harness collapses several concerns (identity, command shape, retry) into opaque strings.** Below, the RFC separates them.
+
+## 2. Goals / Non-Goals
+
+**Goals**
+- G1. Typed `gh_request.t` variant that every caller emits; a string façade is kept for one migration window.
+- G2. Lenient JSON-aware parser that accepts markdown-fenced, trailing-comma, and double-stringified bodies, and unwinds them to typed fields.
+- G3. Flag-value coercion (integer limits, enum states) and flag-combination rules as a compile-time check on the typed variant.
+- G4. Structured `gh_error.t` returned to the caller so the keeper prompt can implement a bounded retry loop (capped like Samchon's 10 iterations).
+- G5. Document `CredentialProvider.bootstrap_finalize` as the hook responsible for `hosts.yml:user` rewrite after `gh auth login --with-token` (Option B path).
+
+**Non-Goals**
+- Introduce a `CredentialProvider` trait in OCaml — scoped to a follow-up RFC-0008 that carves Option A/B into one module. This RFC only links the requirement.
+- Replace `gh_command_validation.ml`'s R0/R1/R2 taxonomy — it is kept verbatim; Validate layer is strengthened additively.
+- Touch `op=git_clone`; a parallel audit belongs in its own RFC.
+- Extend coverage to kepeer actions beyond `keeper_shell op=gh`.
+
+## 3. Design
+
+### 3.1 Type layer — `gh_request.t`
+
+```ocaml
+(* lib/gh_request.mli *)
+type pr_state = Open | Closed | Merged | All
+type gh_request =
+  | Pr_list  of { repo : string option; limit : int option; state : pr_state option; json_fields : string list }
+  | Pr_view  of { repo : string option; pr_number : int;  json_fields : string list }
+  | Issue_list of { repo : string option; state : pr_state option; json_fields : string list }
+  | Issue_view of { repo : string option; issue_number : int; json_fields : string list }
+  | Api_get  of { path : string; jq : string option }
+  | Api_graphql_query of { query_name : string; variables : (string * string) list }
+  (* extend as allowlist grows *)
+```
+
+- Each constructor corresponds to a `(command, subcommand)` pair already in `gh_allowed_commands` / `gh_blocked_operations`.
+- Free-form R1 mutations keep arriving through a **`Mutation_raw` variant** until we typed-gate them in RFC-0007-follow-up; this preserves hot-path availability without weakening Validate.
+
+### 3.2 Parse layer — `gh_cmd_parse.ml`
+
+- Accept three input shapes: typed JSON (preferred), quoted shell string (legacy), markdown-fenced code block (lenient).
+- Strip triple-backtick fences (`gh` language tag or no tag) before parsing.
+- Handle double-quoted segments and `--flag='{"x":1}'` bodies so JSON body values survive.
+- Unwind double-stringified union values (`"{\"type\":\"...\"}"`) once.
+- Output: `(gh_request, parse_warnings list)`; never throw.
+
+### 3.3 Validate layer — additive checks on top of R0/R1/R2
+
+- Int parsing for `limit`, `pr_number`, `issue_number` with range (1…1000 for limit, 1…2^31-1 for numbers).
+- Enum membership for `state`.
+- `json_fields` intersected against a per-resource allowlist (curated at boot from a small TOML in `config/tool_policy.toml`; RFC's non-goal to hit GitHub for schema discovery).
+- Flag combination rules (e.g., `Api_get.jq` requires `path` starting with `/`).
+- Reuse of existing `allowed_orgs`, `gh_blocked_operations`, `gh_graphql_r2_mutations` verbatim.
+
+### 3.4 Feedback layer — `gh_error.t`
+
+```ocaml
+type gh_error = {
+  code     : string;  (* FORBIDDEN_CHARS | BLOCKED_OP | TYPE_MISMATCH | UNKNOWN_FLAG | OUT_OF_ORG *)
+  path     : string;  (* "$input.flags.limit" *)
+  expected : string;  (* "integer in [1, 1000]" *)
+  received : string;  (* "one thousand" *)
+  hint     : string;  (* ready-to-paste replacement *)
+}
+```
+
+Serialized as JSON to the keeper. Human-readable string (`code: path – expected, got received (hint)`) is computed once at the edge for backwards compatibility.
+
+### 3.5 Retry contract (keeper prompt section)
+
+Add to `config/prompts/keeper.capabilities.md`:
+
+- On `gh_error.code ∈ {TYPE_MISMATCH, UNKNOWN_FLAG, PARSE_WARNING}`: emit a corrected `gh_request` up to 3 times (hard cap).
+- On `gh_error.code ∈ {BLOCKED_OP, FORBIDDEN_CHARS, OUT_OF_ORG}`: **do not retry.** These are policy.
+- `R2_Irreversible` commands are *never* auto-retried regardless of error code.
+
+### 3.6 Identity boundary (cross-link to CredentialProvider RFC-0008)
+
+- Findings F-1 and F-2 (evidence record) show identity separation is cosmetic today. Fix belongs in the provider, not the harness.
+- This RFC only specifies the hook name (`bootstrap_finalize`) and obligation ("after `gh auth login --with-token`, rewrite `hosts.yml:user`") so future RFC-0008 can land against a stable contract.
+
+## 4. Migration plan
+
+| Step | PR size | Observability |
+|------|---------|---------------|
+| 1. Add `gh_request.ml` + façade `validate_gh_command_of_string` | small | no behavior change |
+| 2. Typed-build `Api_get`/`Api_graphql_query` (highest-leverage for LLM retry) | small | metric: retry count per `op=gh` invocation |
+| 3. Migrate `Pr_list`/`Pr_view`/`Issue_list`/`Issue_view` | medium | same |
+| 4. Keeper prompt updates (retry contract) | small | metric: `unexpected tool names` should stay at 0 (RFC-0006 goal) |
+| 5. Remove string façade after two keeper generations without legacy callers | small | deprecation warning first |
+
+Each step is a separate Draft PR that rebases onto main, gated by CI + Keeper Sandbox Integration Test.
+
+## 5. Risks
+
+- **Typed JSON increases prompt tokens** marginally. Mitigation: keeper prompt caches the tool schema block via Anthropic prompt caching.
+- **Legacy callers** in scripts (if any) that build raw `gh pr list --limit X` strings. Addressed by string façade retaining behavior until step 5.
+- **Parse leniency is security risk surface.** Mitigation: lenient → typed pipeline; strict schema check runs *after* recovery; never route raw string to docker exec.
+
+## 6. Open questions
+
+- Q1. Does a `JSON_fields` curated allowlist drift with GitHub API changes? How often do we refresh it?
+- Q2. Do we generate `gh_request` JSON schema and inject it into the keeper system prompt, or only into tool description? Prompt-cache interaction differs.
+- Q3. Should `R1_Reversible` commands be typed in this RFC's scope, or deferred? Current sketch keeps `Mutation_raw` to cap blast radius.
+
+## Appendix — audit trail
+
+- PoC shim: `/Users/dancer/me/.tmp/keeper-docker-gh/provider-shim.sh` (Option A vs Option B traversing identical `main(provider, …)` signature).
+- Evidence record: `memory/procedural-memory/2026-04-24-keeper-docker-github-provider-evidence-record.md` (on the `me` repo), decision ID `keeper-docker-gh-provider-audit-2026-04-24`.
+- masc-mcp commit used for static audit: `0e408ffc1d5b34badb0cc1b9f3704a9e725fb8c6`.

--- a/docs/rfc/RFC-0007-op-gh-harness-audit.md
+++ b/docs/rfc/RFC-0007-op-gh-harness-audit.md
@@ -1,135 +1,129 @@
-# RFC-0007: `keeper_shell op=gh` Harness Audit (Samchon 4-layer)
+# RFC-0007: Pragmatic `keeper_shell op=gh` Hardening
 
-- **Status**: Draft
+- **Status**: Draft (rev.2)
 - **Author**: vincent (with Claude)
 - **Created**: 2026-04-24
-- **Related**: RFC-0005 (typed capability substrate), RFC-0006 (surface + symmetric sandbox), #8773, #6814
-- **Drives**: tighter keeper GitHub surface so LLM errors become repairable (not silent), plus clarifies identity boundary vs. label
+- **Revised**: 2026-04-24 — replaced Samchon 4-layer big-bang with a claude-code-inspired 3-PR phasing (rev.1 sketch preserved in §8 Appendix)
+- **Related**: RFC-0005 (typed capability substrate), RFC-0006 (surface + symmetric sandbox), RFC-0008 (CredentialProvider — same review cycle), #8773, #6814
+- **Drives**: reduce LLM-facing tool error rate without rewriting the gh surface; keep every change landable in a single PR
 
 ## 1. Problem
 
-Two observations from a 2026-04-24 audit of the keeper × docker × GitHub path (evidence record: `memory/procedural-memory/2026-04-24-keeper-docker-github-provider-evidence-record.md` on the `me` repo) reframe what is currently shipped.
+Two concrete failures observed on 2026-04-24 (evidence record `memory/procedural-memory/2026-04-24-keeper-docker-github-provider-evidence-record.md` on the `me` repo, decision id `keeper-docker-gh-provider-audit-2026-04-24`):
 
-| # | Symptom | Mechanism |
-|---|---------|-----------|
-| A | The "keeper-scoped" identity `anyang-keepers` holds the same token as the operator host. SHA-256 prefixes match (`406d098bd41b`). | `scripts/rotate-keeper-gh-token.sh` targets legacy `~/.masc/gh-auth`, which no longer exists; the running code reads `~/.masc/github-identities/<identity>/gh`; operators manually seed the bundle by copying the operator PAT. |
-| B | LLM calls of `keeper_shell op=gh` have no compile-time shape; a malformed `cmd` string reaches `validate_gh_command` which returns a single-line `Error string` that does not point to a specific flag or token. | `lib/gh_command_validation.ml:215-251` accepts a raw `string` and splits by whitespace (`extract_gh_command_pair`, line 184-213). Validate layer is strong on allowlist; Type/Parse/Feedback layers are thin. |
+1. **Tool error shape is a single string.** `lib/gh_command_validation.ml:215-251` returns `Error "<message>"`. An LLM can read the message but cannot programmatically distinguish *transient* input errors (typo, wrong flag type) from *policy* errors (R2 irreversible, out-of-org repo). No retry contract exists.
+2. **Non-interactive defaults are not enforced in every caller.** `lib/keeper/keeper_shell_docker.ml` sets `GIT_ASKPASS=''` and `GIT_TERMINAL_PROMPT=0` inline; the same constants are scattered across other callers. A new callsite that forgets one of these hangs the container on a credential prompt — silent timeout.
 
-Framed in the harness vocabulary from Samchon's 2025 function-calling study (dev.to/samchon/qwen-meetup-function-calling-harness, 6.75% → 100% via a 4-layer harness):
+Both are fixable without the Samchon 4-layer rewrite proposed in rev.1. Splitting the rewrite into 3 PRs keeps every step reviewable and reversible.
 
-| Layer | masc-mcp today | Gap |
-|-------|----------------|-----|
-| Type | `cmd: string` | No per-subcommand record; LLM emits free-form strings. |
-| Parse | whitespace split → `(command, subcommand)` | No shell-quote / JSON-body / heredoc support. No markdown/backtick strip. |
-| Validate | `forbidden_shell_chars` + top-level allowlist + `(command, subcommand)` blocklist + `allowed_orgs`; R0/R1/R2 taxonomy. | No flag-value type coercion (`--limit` int, `--state` enum); no flag-combination rules (`--jq` only on `gh api`). |
-| Feedback | Single `Error <printf string>`; some include Good/Bad examples. | No structured `{code, path, expected, received, hint}` object; no retry contract in keeper prompt. |
+## 2. Design principles (directly borrowed from `~/me/workspace/yousleepwhen/claude-code`)
 
-Both observations share one root: **the harness collapses several concerns (identity, command shape, retry) into opaque strings.** Below, the RFC separates them.
+| # | Principle | claude-code source | masc-mcp analog |
+|---|-----------|--------------------|-----------------|
+| P1 | **Permission → Sandbox → Exec, strictly serial.** Any gate must be in front of subprocess spawn. | `src/tools/BashTool/BashTool.tsx:540, 881` — `checkPermissions() → runShellCommand(shouldUseSandbox(), subprocessEnv())` | `validate_gh_command → effective_sandbox_profile → run_docker_shell_command_with_status`. Preserve. |
+| P2 | **Scrub vs pass-through is decided by token scoping.** Long-lived host secrets are scrubbed; job-scoped tokens pass through. | `src/utils/subprocessEnv.ts:15-53` — `GHA_SUBPROCESS_SCRUB` list; `GH_TOKEN` explicitly NOT scrubbed | Curate `KEEPER_ENV_SCRUB` and `KEEPER_ENV_PASS` as a single file. |
+| P3 | **Non-interactive defaults are a constant, not an opinion.** | `src/utils/worktree.ts:199-202` — `GIT_NO_PROMPT_ENV = { GIT_TERMINAL_PROMPT:'0', GIT_ASKPASS:'' }` | Introduce `lib/env_git_noninteractive.ml` with the same record. All docker/exec callsites read from it. |
+| P4 | **Errors have shape.** Structured result ≠ scripting nightmare; `{stdout, stderr, exit_code, interpretation?}` is enough to drive LLM retry. | `src/tools/BashTool/BashTool.tsx:280` — `outputSchema` Zod with `returnCodeInterpretation` | `type gh_result = { stdout; stderr; exit_code; class_; interpretation : string option; reversibility }`. Interpretation is a lookup on `(exit_code × class)`, not a parser. |
+| P5 | **Do not reinvent parsers or sandbox runtimes.** claude-code wraps tree-sitter and `@anthropic-ai/sandbox-runtime`; it does **not** write its own. | `src/utils/bash/bashParser.ts` (tree-sitter wrapper), `src/utils/sandbox/sandbox-adapter.ts` (external runtime wrapper) | Keep `extract_gh_command_pair` and the docker CLI exactly as is; no lenient parser, no custom daemon. |
 
-## 2. Goals / Non-Goals
+These principles are the whole RFC. Everything below is mechanical execution.
 
-**Goals**
-- G1. Typed `gh_request.t` variant that every caller emits; a string façade is kept for one migration window.
-- G2. Lenient JSON-aware parser that accepts markdown-fenced, trailing-comma, and double-stringified bodies, and unwinds them to typed fields.
-- G3. Flag-value coercion (integer limits, enum states) and flag-combination rules as a compile-time check on the typed variant.
-- G4. Structured `gh_error.t` returned to the caller so the keeper prompt can implement a bounded retry loop (capped like Samchon's 10 iterations).
-- G5. Document `CredentialProvider.bootstrap_finalize` as the hook responsible for `hosts.yml:user` rewrite after `gh auth login --with-token` (Option B path).
+## 3. Three-PR phasing
 
-**Non-Goals**
-- Introduce a `CredentialProvider` trait in OCaml — scoped to a follow-up RFC-0008 that carves Option A/B into one module. This RFC only links the requirement.
-- Replace `gh_command_validation.ml`'s R0/R1/R2 taxonomy — it is kept verbatim; Validate layer is strengthened additively.
-- Touch `op=git_clone`; a parallel audit belongs in its own RFC.
-- Extend coverage to kepeer actions beyond `keeper_shell op=gh`.
+### PR-1 — `env_git_noninteractive` + scrub list (≈80 lines + tests)
 
-## 3. Design
+- **What**: new `lib/env_git_noninteractive.mli` exposing a single value `val env : (string * string) list`. Callers in `keeper_shell_docker.ml`, `keeper_exec_shell.ml` (op=gh / op=git_clone branches) replace their local inline `("GIT_ASKPASS","")` pairs with `@ Env_git_noninteractive.env`.
+- **Also**: `lib/env_keeper_scrub.ml` with two lists `scrub : string list` (Anthropic keys, AWS creds, OIDC tokens — copy from claude-code) and `pass : string list` (`GH_TOKEN`, `GITHUB_TOKEN`, `SSH_AUTH_SOCK`, `GIT_*`). docker run argv construction uses both.
+- **Why safe**: additive; any missed callsite is caught by `test_env_git_noninteractive.ml` that greps for forgotten `GIT_ASKPASS` literals under `lib/`.
+- **Observability**: metric `keeper_shell_docker.git_prompt_env_missing_total` (should be 0 after PR).
 
-### 3.1 Type layer — `gh_request.t`
+### PR-2 — structured `gh_result.t` (≈120 lines)
 
-```ocaml
-(* lib/gh_request.mli *)
-type pr_state = Open | Closed | Merged | All
-type gh_request =
-  | Pr_list  of { repo : string option; limit : int option; state : pr_state option; json_fields : string list }
-  | Pr_view  of { repo : string option; pr_number : int;  json_fields : string list }
-  | Issue_list of { repo : string option; state : pr_state option; json_fields : string list }
-  | Issue_view of { repo : string option; issue_number : int; json_fields : string list }
-  | Api_get  of { path : string; jq : string option }
-  | Api_graphql_query of { query_name : string; variables : (string * string) list }
-  (* extend as allowlist grows *)
-```
+- **What**: new type in `lib/gh_command_validation.ml` (or a sibling for clarity):
+  ```ocaml
+  type gh_exit_class =
+    | Ok_0
+    | Policy_blocked       (* 1xxN internal — matches R1/R2 blocks *)
+    | Type_mismatch        (* argparse failure shape *)
+    | Auth_failed          (* gh auth error surface *)
+    | Network              (* curl/tls *)
+    | Unknown
+  type gh_result = {
+    stdout         : string;
+    stderr         : string;
+    exit_code      : int;
+    class_         : gh_exit_class;
+    reversibility  : gh_reversibility;  (* already exists *)
+    interpretation : string option;     (* ready-to-show hint *)
+  }
+  ```
+  Exit-class classifier is a lookup on `(exit_code, stderr-pattern)` stored in `config/tool_policy.toml` — **no regex over stdout**, just a small table.
+- **Why safe**: wraps existing call paths; a backward-compat alias `Error string` stays one release cycle, derived from the new record.
+- **Observability**: metric `keeper_shell_gh_result_class_total{class=Policy_blocked|Type_mismatch|…}` gives the rollup we don't currently have.
+- **Unlocks**: the keeper prompt can say "retry only when class=Type_mismatch" without extra context.
 
-- Each constructor corresponds to a `(command, subcommand)` pair already in `gh_allowed_commands` / `gh_blocked_operations`.
-- Free-form R1 mutations keep arriving through a **`Mutation_raw` variant** until we typed-gate them in RFC-0007-follow-up; this preserves hot-path availability without weakening Validate.
+### PR-3 — typed `Api_get` / `Api_graphql_query` only (≈200 lines)
 
-### 3.2 Parse layer — `gh_cmd_parse.ml`
+- **What**: introduce `gh_request.t` with **two** constructors (not the full sum type from rev.1):
+  ```ocaml
+  type gh_request =
+    | Api_get           of { path : string; jq : string option }
+    | Api_graphql_query of { query_name : string; variables : (string * string) list }
+    | Raw_string        of string    (* everything else keeps flowing through as before *)
+  ```
+  Parsing a raw string into the typed variants happens in `gh_request_parse.ml` with **no lenient recovery** — if the input is not an exact match for the typed shape, it falls through to `Raw_string` and the current string validator runs.
+- **Why `gh api` first**: highest-leverage call for LLM retry (jq path, variables), the most likely to benefit from type-directed retry later.
+- **Why safe**: `Raw_string` is literally a compile-time constant that means "behave like 2026-04-24". Zero behavior change for R1/R2 mutations.
+- **Observability**: metrics `keeper_shell_gh_request_typed_total` / `keeper_shell_gh_request_raw_total` tell us whether callers are migrating.
 
-- Accept three input shapes: typed JSON (preferred), quoted shell string (legacy), markdown-fenced code block (lenient).
-- Strip triple-backtick fences (`gh` language tag or no tag) before parsing.
-- Handle double-quoted segments and `--flag='{"x":1}'` bodies so JSON body values survive.
-- Unwind double-stringified union values (`"{\"type\":\"...\"}"`) once.
-- Output: `(gh_request, parse_warnings list)`; never throw.
+All three PRs rebase onto `main`, gate on the Keeper Sandbox Integration Test + existing CI matrix, and are independently revertable.
 
-### 3.3 Validate layer — additive checks on top of R0/R1/R2
+## 4. Hard non-goals (this RFC will not do these)
 
-- Int parsing for `limit`, `pr_number`, `issue_number` with range (1…1000 for limit, 1…2^31-1 for numbers).
-- Enum membership for `state`.
-- `json_fields` intersected against a per-resource allowlist (curated at boot from a small TOML in `config/tool_policy.toml`; RFC's non-goal to hit GitHub for schema discovery).
-- Flag combination rules (e.g., `Api_get.jq` requires `path` starting with `/`).
-- Reuse of existing `allowed_orgs`, `gh_blocked_operations`, `gh_graphql_r2_mutations` verbatim.
+1. **Full `gh_request.t` sum type with every subcommand** — deferred indefinitely until PR-3 metrics justify it. Without concrete retry-loop data, typing `pr view` / `pr list` / `issue ...` gives low marginal value over string + validator.
+2. **Lenient JSON-aware parser** — explicitly disallowed in this RFC's timeline. A leniency layer that strips markdown fences and unwinds double-stringified bodies is attractive but is new attack surface. Samchon's lenient parser protects *correctness*, not *safety*; masc-mcp needs safety first.
+3. **Retry contract embedded in keeper prompt** — deferred to the PR after PR-2 lands. The retry contract has teeth only when `class_` is populated; adding the prompt text earlier is cargo-cult.
+4. **Self-written shell parser** (tree-sitter, OCaml Menhir, regex-based) — forbidden. If we ever need quoted-string / heredoc awareness, the path is to call `bash -n` or `tree-sitter-bash` via FFI in a dedicated RFC.
+5. **Touching `op=git_clone`** — separate audit. Only PR-1 (env constant) crosses that boundary.
 
-### 3.4 Feedback layer — `gh_error.t`
+## 5. Risks and open questions
 
-```ocaml
-type gh_error = {
-  code     : string;  (* FORBIDDEN_CHARS | BLOCKED_OP | TYPE_MISMATCH | UNKNOWN_FLAG | OUT_OF_ORG *)
-  path     : string;  (* "$input.flags.limit" *)
-  expected : string;  (* "integer in [1, 1000]" *)
-  received : string;  (* "one thousand" *)
-  hint     : string;  (* ready-to-paste replacement *)
-}
-```
+1. **PR-2's exit-class table drift.** If GitHub or the `gh` CLI changes exit-code semantics, the table goes stale. Mitigation: the table lives in `config/tool_policy.toml` (non-code), unknown codes bucket to `Unknown` rather than misclassify.
+2. **PR-3 being worthless.** If no keeper actually calls `gh api` today, PR-3 has zero telemetry value and should be deprioritized. Sanity check before merging PR-3: grep `keeper_shell op=gh cmd="api ` in the last 7 days of logs.
+3. **Scrub list false positives.** If the operator depends on a scrubbed env var reaching the sandbox (unlikely for keepers, more likely for experimental tooling), they must explicitly add it to `pass`. Documented in `config/tool_policy.toml` commentary.
 
-Serialized as JSON to the keeper. Human-readable string (`code: path – expected, got received (hint)`) is computed once at the edge for backwards compatibility.
+## 6. Cross-link to RFC-0008 (CredentialProvider)
 
-### 3.5 Retry contract (keeper prompt section)
+`keeper_shell_docker.ml`'s env composition in PR-1 becomes consumable by `CredentialProvider.binding.env` once RFC-0008 lands. Merge order:
 
-Add to `config/prompts/keeper.capabilities.md`:
+1. This RFC's PR-1 (env constants) — does **not** depend on RFC-0008.
+2. RFC-0008 PR-1 (`Credential_provider` module + `Host_config_provider`) — reads `Env_git_noninteractive.env` from this RFC's PR-1.
+3. This RFC's PR-2 and PR-3 can land independently once PR-1 is in.
 
-- On `gh_error.code ∈ {TYPE_MISMATCH, UNKNOWN_FLAG, PARSE_WARNING}`: emit a corrected `gh_request` up to 3 times (hard cap).
-- On `gh_error.code ∈ {BLOCKED_OP, FORBIDDEN_CHARS, OUT_OF_ORG}`: **do not retry.** These are policy.
-- `R2_Irreversible` commands are *never* auto-retried regardless of error code.
+No circular dependency; both RFCs can be reviewed in parallel and merged in the above order.
 
-### 3.6 Identity boundary (cross-link to CredentialProvider RFC-0008)
+## 7. Migration cost
 
-- Findings F-1 and F-2 (evidence record) show identity separation is cosmetic today. Fix belongs in the provider, not the harness.
-- This RFC only specifies the hook name (`bootstrap_finalize`) and obligation ("after `gh auth login --with-token`, rewrite `hosts.yml:user`") so future RFC-0008 can land against a stable contract.
+| Item                           | Lines changed (est.) | Test added (est.) | Risk                          |
+|--------------------------------|---------------------:|------------------:|-------------------------------|
+| PR-1 env constants             |                   80 |                60 | low                           |
+| PR-2 structured result         |                  120 |               100 | medium (alias maintained)     |
+| PR-3 typed `Api_*`             |                  200 |               150 | medium (new module)           |
+| **Total**                      |              **400** |           **310** | —                             |
 
-## 4. Migration plan
+Compare to rev.1's estimated 1200+ lines in a single cycle; 3-PR split is ~a third of the surface and reversible per step.
 
-| Step | PR size | Observability |
-|------|---------|---------------|
-| 1. Add `gh_request.ml` + façade `validate_gh_command_of_string` | small | no behavior change |
-| 2. Typed-build `Api_get`/`Api_graphql_query` (highest-leverage for LLM retry) | small | metric: retry count per `op=gh` invocation |
-| 3. Migrate `Pr_list`/`Pr_view`/`Issue_list`/`Issue_view` | medium | same |
-| 4. Keeper prompt updates (retry contract) | small | metric: `unexpected tool names` should stay at 0 (RFC-0006 goal) |
-| 5. Remove string façade after two keeper generations without legacy callers | small | deprecation warning first |
+## 8. Appendix — original aspirational sketch (rev.1, retained for discussion)
 
-Each step is a separate Draft PR that rebases onto main, gated by CI + Keeper Sandbox Integration Test.
+The rev.1 Samchon 4-layer design (typed `gh_request.t` with full subcommand coverage, lenient JSON-aware parser, structured error with `{code, path, expected, received, hint}`, retry contract in keeper prompt) is kept in commit `aa8cab475` on this branch and in the PR discussion thread. It remains the aspirational target *if* PR-2/PR-3 telemetry shows LLM retry failures justify further typing work. Until then, this RFC supersedes it.
 
-## 5. Risks
+## Appendix B — evidence
 
-- **Typed JSON increases prompt tokens** marginally. Mitigation: keeper prompt caches the tool schema block via Anthropic prompt caching.
-- **Legacy callers** in scripts (if any) that build raw `gh pr list --limit X` strings. Addressed by string façade retaining behavior until step 5.
-- **Parse leniency is security risk surface.** Mitigation: lenient → typed pipeline; strict schema check runs *after* recovery; never route raw string to docker exec.
-
-## 6. Open questions
-
-- Q1. Does a `JSON_fields` curated allowlist drift with GitHub API changes? How often do we refresh it?
-- Q2. Do we generate `gh_request` JSON schema and inject it into the keeper system prompt, or only into tool description? Prompt-cache interaction differs.
-- Q3. Should `R1_Reversible` commands be typed in this RFC's scope, or deferred? Current sketch keeps `Mutation_raw` to cap blast radius.
-
-## Appendix — audit trail
-
-- PoC shim: `/Users/dancer/me/.tmp/keeper-docker-gh/provider-shim.sh` (Option A vs Option B traversing identical `main(provider, …)` signature).
-- Evidence record: `memory/procedural-memory/2026-04-24-keeper-docker-github-provider-evidence-record.md` (on the `me` repo), decision ID `keeper-docker-gh-provider-audit-2026-04-24`.
-- masc-mcp commit used for static audit: `0e408ffc1d5b34badb0cc1b9f3704a9e725fb8c6`.
+- PoC artifacts: `~/me/.tmp/keeper-docker-gh/` — Option A (RO mount) and Option B (`gh auth login --with-token`) both passed end-to-end.
+- Evidence record: `~/me/memory/procedural-memory/2026-04-24-keeper-docker-github-provider-evidence-record.md`.
+- masc-mcp commit audited: `0e408ffc1d5b34badb0cc1b9f3704a9e725fb8c6`.
+- claude-code reference points (read-only observation):
+  - `src/tools/BashTool/BashTool.tsx:540, 881` — execute pipeline order.
+  - `src/tools/BashTool/shouldUseSandbox.ts:18-20, 130-153` — "sandbox permission is the actual security control" (contrast: our docker-is-primary).
+  - `src/utils/subprocessEnv.ts:15-53` — scrub/pass lists.
+  - `src/utils/worktree.ts:199-202` — `GIT_NO_PROMPT_ENV` record.

--- a/docs/rfc/RFC-0008-credential-provider.md
+++ b/docs/rfc/RFC-0008-credential-provider.md
@@ -1,0 +1,130 @@
+# RFC-0008: `CredentialProvider` Trait (Minimum Viable)
+
+- **Status**: Draft
+- **Author**: vincent (with Claude)
+- **Created**: 2026-04-24
+- **Related**: RFC-0007 rev.2 (shares a review cycle), F-1 (#9843), F-2 (#9844), F-4 (#9847)
+- **Drives**: convert the "keeper-scoped identity" label into an actual capability boundary; make credential lifecycle explicit so Option B (in-container login) can ship later without rewiring the caller
+
+## 1. Problem (field-verified 2026-04-24)
+
+Three observations from `~/me/memory/procedural-memory/2026-04-24-keeper-docker-github-provider-evidence-record.md`:
+
+- **F-1**: `~/.masc/github-identities/anyang-keepers/gh/hosts.yml` stores the same OAuth token as `gh auth token` on the operator host (SHA-256 prefix `406d098bd41b` matches both sides). Identity separation is cosmetic.
+- **F-2**: `gh auth login --with-token` (Option B path) rewrites `hosts.yml:user` to the real token owner. Any downstream code that reads `user:` loses the identity label.
+- **F-4**: `scripts/rotate-keeper-gh-token.sh` defaults `GH_CONFIG_DIR` to a legacy path (`~/.masc/gh-auth`) that no longer exists. PAT rotation happens off-path, which is how F-1 drifted in.
+
+All three share one failure mode: credential lifecycle (issuance → installation → consumption → rotation → teardown) is implicit. The runtime reads a fixed filesystem location; the rotation script writes to a different fixed location; there is no single object that says "this identity currently has this credential, with this finalize hook, and tears down this way."
+
+## 2. Design principles
+
+| # | Principle | claude-code analog |
+|---|-----------|--------------------|
+| P1 | **The credential boundary IS the token.** If two identities share a token, they share capabilities, regardless of labels. Enforce by issuance policy (one fine-grained PAT per identity), not by cosmetic overlays. | `subprocessEnv`'s pass-list contains only job-scoped tokens; long-lived host secrets are scrubbed. |
+| P2 | **Provider owns lifecycle.** `resolve → finalize → tear_down` is the complete cycle. Any step that needs to run (e.g. identity relabel after `gh auth login --with-token`) is a method on the provider, not a global hook. | `PermissionPromptToolResultSchema` returns `{behavior, updatedPermissions, decisionClassification}` — decision + side effects in one object. |
+| P3 | **Ship Option A first, gate Option B.** Host-mounted bundle works today (G3 PASS in evidence record). In-container login requires per-identity fine-grained PATs (F-1 must be resolved first). Shipping both together couples two unrelated risks. | claude-code ships sandbox-off defaults and hardens per-command later. Same ordering. |
+| P4 | **Reuse `keeper_binding`.** It already returns `(path, env, metadata)` via `Result`. Wrap it; do not replace it. | claude-code wraps external `sandbox-runtime` rather than reimplementing isolation. Same discipline. |
+
+## 3. Signature
+
+```ocaml
+(* lib/keeper/credential_provider.mli *)
+
+type ro_mount = { host : string; container : string }
+
+type binding = {
+  identity  : string;                    (* keeper-scoped identity, e.g. "anyang-keepers" *)
+  env       : (string * string) list;    (* GH_CONFIG_DIR, HOME, GIT_ASKPASS='', GIT_TERMINAL_PROMPT=0, ... *)
+  ro_mounts : ro_mount list;             (* host paths mounted read-only (Option A); empty for Option B *)
+  bootstrap : string list option;        (* argv executed inside container after start; None for Option A *)
+  metadata  : (string * string) list;    (* audit: source, issued_at, ttl_seconds, sha256_prefix *)
+}
+
+type error =
+  | Missing_bundle   of { identity : string; path : string }
+  | Invalid_token    of { identity : string; reason : string }
+  | Finalize_failed  of { identity : string; reason : string }
+  | Tear_down_failed of { identity : string; reason : string }
+
+(** Must be total. Pure up to filesystem read; no network. *)
+val resolve : config:Coord.config -> identity:string -> (binding, error) result
+
+(** Called once per keeper session, after the container is up and (for Option B)
+    after bootstrap argv has executed. Implementations MUST rewrite [hosts.yml:user]
+    to [binding.identity] when that file exists in any writable mount. *)
+val finalize : binding -> container_id:string -> (unit, error) result
+
+(** Idempotent; safe to call even if finalize was never called. Caller runs this from
+    [Eio.Switch.on_release] or equivalent so crashes still hit it. *)
+val tear_down : binding -> container_id:string option -> unit
+```
+
+Two concrete modules:
+
+```ocaml
+module Host_config_provider : sig
+  include module type of Credential_provider
+end
+
+module In_container_login_provider : sig
+  include module type of Credential_provider
+  (** Refuses to resolve if the identity's token SHA-256 matches [gh auth token] on the
+      operator host (i.e. F-1 is not yet resolved for this identity). *)
+  val provider_gate : identity:string -> (unit, string) result
+end
+```
+
+`provider_gate` is the fuse enforcing P3. A keeper that requests the in-container provider while its identity's token still matches the operator's will be refused at `resolve` time with `Invalid_token`.
+
+## 4. Two-PR phasing
+
+### PR-1 — module + `Host_config_provider` only (≈150 lines + tests)
+
+- **New files**: `lib/keeper/credential_provider.ml(i)`, `lib/keeper/host_config_provider.ml(i)`, `test/test_credential_provider.ml`.
+- **Caller change**: `lib/keeper/keeper_shell_docker.ml` swaps its inline `Keeper_gh_env.keeper_binding` call for `Host_config_provider.resolve` and reads `binding.env @ Env_git_noninteractive.env` for docker env flags (depends on RFC-0007 PR-1).
+- **`finalize` in PR-1**: a noop (RO mount does not need user rewrite; the label in the host's `hosts.yml` is whatever the operator wrote). The method exists so PR-2 drops in without interface churn.
+- **Why safe**: behaviorally identical to today. All tests green pre/post.
+
+### PR-2 — fine-grained PAT issuance + rotate script fix (≈100 lines, mostly script)
+
+- **Files**: rewrite `scripts/rotate-keeper-gh-token.sh` (in the `me` repo, branch `feat/rotate-keeper-gh-token`) to:
+  - require `IDENTITY=<name>` argument,
+  - target `$HOME/me/.masc/github-identities/$IDENTITY/gh` (drop `$HOME/me/.masc/gh-auth` default),
+  - verify the new token's SHA-256 **differs** from `gh auth token` (F-1 gate — `provider_gate` equivalent at rotation time).
+- **`Host_config_provider` update**: `resolve` adds a metadata line `sha256_prefix=<first 12>` and surfaces it in `binding.metadata` so `provider_gate` in PR-3 can consult it without re-reading the file.
+- **Why safe**: script is operator-facing; a mismatched identity × PAT never reaches the runtime.
+
+### PR-3 (gated on PR-2 operational proof) — `In_container_login_provider`
+
+- **Files**: new `lib/keeper/in_container_login_provider.ml`, a `bootstrap` argv that runs `gh auth login --with-token`, a `finalize` that rewrites `hosts.yml:user` inside the container, `provider_gate` that refuses if the token SHA matches the operator's.
+- **Merge condition**: PR-2 has been running for ≥2 weeks with zero `provider_gate` violations in telemetry (every active keeper identity has its own fine-grained PAT).
+
+## 5. What we explicitly do not do in this RFC
+
+1. **Vault / 1Password / macOS Keychain integration.** The `binding.metadata.source` field is free-form today; integrations become separate RFCs that add new `source` values.
+2. **PAT TTL tracking dashboard.** `ttl_seconds` metadata is recorded for future use; a dashboard belongs in masc-mcp dashboards, not here.
+3. **Rewriting `keeper_gh_env.ml`.** We wrap it (`Host_config_provider.resolve` calls `Keeper_gh_env.keeper_binding` internally and maps fields). Deprecating it is a post-PR-3 cleanup.
+4. **Changing hard-mode semantics.** `MASC_KEEPER_SANDBOX_HARD_MODE=true` still requires a keeper identity; it just now goes through the trait.
+
+## 6. Risks
+
+1. **`finalize` is a cross-cutting concern.** Implementations may forget to call it. Mitigation: the caller in `keeper_shell_docker.ml` is the one call site; `finalize` is invoked from the same `Eio.Switch.on_release` as `tear_down`.
+2. **`provider_gate` false positive.** If the operator rotates *both* the operator token and the keeper token from the same fine-grained ancestor, SHA-256 will differ but intent might still be "shared". Mitigation: the gate returns `error` rather than panic; the operator can set `MASC_KEEPER_ALLOW_SHARED_TOKEN=true` to override with an audit log line.
+3. **Option B's container-local `hosts.yml` rewrite needs write permission to a named volume.** The RO mount in Option A does not, so `finalize` in Option A is truly a noop; an asymmetry worth encoding in `test_credential_provider.ml`.
+
+## 7. Telemetry contract
+
+Per resolve:
+- `keeper_credential_provider_resolve_total{provider=host|container_login,result=ok|error}`
+- `keeper_credential_provider_gate_blocked_total{reason=token_sha_match|missing_bundle|...}`
+
+Per finalize:
+- `keeper_credential_provider_finalize_relabel_total{result=ok|error}`
+
+No schema change to the existing Prom registry; these are new keys only.
+
+## 8. Evidence
+
+- PoC trait shim proving symmetry between the two concrete implementations: `~/me/.tmp/keeper-docker-gh/provider-shim.sh`.
+- Evidence record: `~/me/memory/procedural-memory/2026-04-24-keeper-docker-github-provider-evidence-record.md`.
+- masc-mcp commit audited: `0e408ffc1d5b34badb0cc1b9f3704a9e725fb8c6`.

--- a/docs/rfc/RFC-0008-credential-provider.md
+++ b/docs/rfc/RFC-0008-credential-provider.md
@@ -3,7 +3,8 @@
 - **Status**: Draft
 - **Author**: vincent (with Claude)
 - **Created**: 2026-04-24
-- **Related**: RFC-0007 rev.2 (shares a review cycle), F-1 (#9843), F-2 (#9844), F-4 (#9847)
+- **Revised**: 2026-04-24 — §3 binding.env description clarified: the list is composed **inside** `Host_config_provider.resolve` from bundle paths + `Env_git_noninteractive.env` from RFC-0007 PR-1, not forwarded from an `env` field on the upstream `Keeper_gh_env.keeper_binding` (which has no such field).
+- **Related**: RFC-0007 rev.3 (shares a review cycle), F-1 (#9843), F-2 (#9844), F-4 (#9847)
 - **Drives**: convert the "keeper-scoped identity" label into an actual capability boundary; make credential lifecycle explicit so Option B (in-container login) can ship later without rewiring the caller
 
 ## 1. Problem (field-verified 2026-04-24)
@@ -34,7 +35,7 @@ type ro_mount = { host : string; container : string }
 
 type binding = {
   identity  : string;                    (* keeper-scoped identity, e.g. "anyang-keepers" *)
-  env       : (string * string) list;    (* GH_CONFIG_DIR, HOME, GIT_ASKPASS='', GIT_TERMINAL_PROMPT=0, ... *)
+  env       : (string * string) list;    (* composed inside resolve; see note below *)
   ro_mounts : ro_mount list;             (* host paths mounted read-only (Option A); empty for Option B *)
   bootstrap : string list option;        (* argv executed inside container after start; None for Option A *)
   metadata  : (string * string) list;    (* audit: source, issued_at, ttl_seconds, sha256_prefix *)
@@ -58,6 +59,8 @@ val finalize : binding -> container_id:string -> (unit, error) result
     [Eio.Switch.on_release] or equivalent so crashes still hit it. *)
 val tear_down : binding -> container_id:string option -> unit
 ```
+
+> **Evidence note (rev.1 cross-correction, 2026-04-24)**: The upstream `Keeper_gh_env.keeper_binding` exposes only `{github_identity; git_identity_mode; bundle_root; gh_config_dir}` (see `lib/keeper/keeper_gh_env.ml:18-23`). The `binding.env` list in this signature is therefore **composed inside `Host_config_provider.resolve`** from (a) the path-derived entries already built inline at `keeper_shell_docker.ml:234-245` today — `HOME=<cred_root>`, `GH_CONFIG_DIR=<cred_root>/.config/gh`, `GIT_CONFIG_GLOBAL=<cred_root>/.gitconfig`, the `GIT_CONFIG_*` safe.directory block, `GIT_AUTHOR_*`/`GIT_COMMITTER_*` — plus (b) `Env_git_noninteractive.env` added by RFC-0007 PR-1. The trait concentrates this composition in one place; it does not introduce new env keys beyond what PR-1 adds.
 
 Two concrete modules:
 


### PR DESCRIPTION
## Update 2026-04-24 — rev.3 evidence correction (commit `07abab94b`)

Self-critique during PR-1 implementation prep turned up a factual error in rev.2:

- **rev.2 Problem #2 claimed** `GIT_ASKPASS=''` / `GIT_TERMINAL_PROMPT=0` were set inline in `keeper_shell_docker.ml` and scattered across callers.
- **Verified** on commit `0e408ffc1d5b34badb0cc1b9f3704a9e725fb8c6` with `rg -n 'GIT_ASKPASS|GIT_TERMINAL_PROMPT' lib/ test/ scripts/` — zero hits. The constants are **absent**, not scattered.
- **Impact**: PR-1 is "introduce missing safety constants" rather than "deduplicate scattered literals". Scope bumped ~80 → ~120 lines. Design intent unchanged.
- **RFC-0008 §3** also corrected: `binding.env` is composed inside `Host_config_provider.resolve` from bundle paths + `Env_git_noninteractive.env`, not forwarded from `Keeper_gh_env.keeper_binding` (which has no `env` field).

Keeping this as a rev.3 amendment rather than a rewrite so the audit trail (rev.1 Samchon, rev.2 3-PR, rev.3 evidence correction) remains legible.

---

## Summary

This PR now carries **two companion RFCs** that replace the rev.1 Samchon big-bang with a pragmatic, claude-code-inspired phasing. Both are Draft for design review only; no code is touched.

### RFC-0007 rev.3 — `keeper_shell op=gh` Hardening

- Five design principles lifted directly from `~/me/workspace/yousleepwhen/claude-code` (Permission→Sandbox→Exec serial, scrub vs pass by token scoping, `GIT_NO_PROMPT_ENV` as constant, errors with shape, no reinvented parsers/runtimes).
- **Three-PR phasing** (~440 lines total, each independently revertable):
  - **PR-1** `lib/env_git_noninteractive` + `lib/env_keeper_scrub` (~120 lines) — **introduces** the missing `GIT_ASKPASS=''`/`GIT_TERMINAL_PROMPT=0` constants and wires them into the single callsite at `keeper_shell_docker.ml:234-245`.
  - **PR-2** structured `gh_result.t` with exit-class lookup table in `config/tool_policy.toml` (~120 lines) — backward-compat `Error string` alias for one release.
  - **PR-3** typed `Api_get` / `Api_graphql_query` only, everything else passes through `Raw_string` (~200 lines) — no lenient recovery.
- **Hard non-goals**: full typed sum type, lenient JSON parser, retry contract in keeper prompt, self-written shell parser, `op=git_clone` refactor.
- rev.1 Samchon 4-layer design preserved in §8 Appendix as the aspirational target if telemetry later justifies it.

### RFC-0008 — `CredentialProvider` Trait (minimum viable)

- Trait with three methods: `resolve → finalize → tear_down`. Two concrete providers:
  - `Host_config_provider` (ship in PR-1, wraps existing `Keeper_gh_env.keeper_binding`, composes `binding.env` from bundle paths + `Env_git_noninteractive.env`, `finalize` is a noop — RO mount).
  - `In_container_login_provider` (gated on PR-2 fine-grained PAT migration; `provider_gate` refuses when identity's token SHA-256 matches `gh auth token` on operator).
- Addresses F-1 / F-2 / F-4 from the evidence record: shared OAuth token across identities, `hosts.yml:user` rewrite on `gh auth login --with-token`, and off-path PAT rotation.
- Telemetry contract: `keeper_credential_provider_resolve_total`, `_gate_blocked_total`, `_finalize_relabel_total`.
- Non-goals: Vault/Keychain/1Password, PAT-TTL dashboard, `keeper_gh_env.ml` rewrite, hard-mode semantics change.

### Cross-link

- RFC-0007 PR-1 lands first (no dependency on RFC-0008).
- RFC-0008 PR-1 consumes `Env_git_noninteractive.env` from RFC-0007 PR-1.
- RFC-0007 PR-2 and PR-3 can land independently once PR-1 is in.
- No circular dependency; both RFCs can be reviewed in parallel.

## Evidence

- Record: `~/me/memory/procedural-memory/2026-04-24-keeper-docker-github-provider-evidence-record.md` (decision id `keeper-docker-gh-provider-audit-2026-04-24`).
- PoC artifacts: `~/me/.tmp/keeper-docker-gh/` (Option A RO mount + Option B `gh auth login --with-token` both passed end-to-end).
- masc-mcp commit audited: `0e408ffc1d5b34badb0cc1b9f3704a9e725fb8c6`.
- claude-code read-only reference points: `src/tools/BashTool/BashTool.tsx:540,881`, `shouldUseSandbox.ts:18-20,130-153`, `subprocessEnv.ts:15-53`, `worktree.ts:199-202`.
- rev.3 re-grep verification (zero hits): `rg -n 'GIT_ASKPASS|GIT_TERMINAL_PROMPT' lib/ test/ scripts/`.

## Review focus

Please critique the **phasing** and **non-goals** more than the content of individual PRs. The goal of this RFC round is to agree that:
1. Three-PR phasing (RFC-0007) is the right risk reduction vs. the rev.1 4-layer approach.
2. `CredentialProvider` as a wrapping trait (not a replacement of `keeper_binding`) is the right boundary.
3. The `provider_gate`-based ordering (ship Option A, gate Option B on F-1 resolution) is acceptable.

## Do not merge — design review only

This PR intentionally carries the `do-not-merge` label and is kept Draft. It is for design alignment on RFCs 0007 rev.3 and 0008; implementation will land in separate PRs (PR-1/PR-2/PR-3 per RFC).
