### PR TITLE
[codex] Throttle local Dune workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ cd masc-mcp
 # Pin private dependencies (OAS, mcp_protocol, etc.)
 scripts/opam-pin-external-deps.sh
 opam install . --deps-only
-dune build
+scripts/dune-local.sh build bin/main_eio.exe
 
 scripts/run-local.sh --target-dir "$PWD"
 PORT="$(scripts/run-local.sh --print-port --target-dir "$PWD")"
@@ -337,8 +337,11 @@ To reproduce CI-style test output with heartbeat logs locally:
 
 ```bash
 CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
-  scripts/ci-run-tests.sh "opam exec -- dune test --root ."
+  scripts/ci-run-tests.sh "scripts/dune-local.sh test"
 ```
+
+Use raw `opam exec -- dune ...` only for intentional CI-parity checks; normal local
+development should stay on focused targets and the throttled wrapper.
 
 ## Transport and Auth
 

--- a/mk/build.mk
+++ b/mk/build.mk
@@ -5,7 +5,7 @@ all: build-all
 
 # Build OCaml + dashboard (dashboard rebuilds only when sources changed)
 build: doctor-oas-pin
-	dune build --root .
+	scripts/dune-local.sh build
 	@scripts/build-dashboard-if-needed.sh
 
 # Build dashboard SPA (Vite) — force rebuild
@@ -68,7 +68,7 @@ build-all: build bonsai-dashboard-if-available
 
 # Generate documentation
 doc:
-	dune build --root . @doc
+	scripts/dune-local.sh build @doc
 	@echo "Documentation generated at _build/default/_doc/_html/index.html"
 
 # Install dependencies

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -5,7 +5,7 @@ test: test-unit
 
 # Unit tests only (no server required)
 test-unit: doctor-oas-pin
-	scripts/ci-run-tests.sh "opam exec -- dune test --root ."
+	scripts/ci-run-tests.sh "scripts/dune-local.sh test"
 
 # Contract harness (self-bootstrapping, hermetic local server)
 test-contract:
@@ -39,7 +39,7 @@ clean-tlc-artifacts:
 coverage:
 	rm -rf _coverage
 	mkdir -p _coverage
-	CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 scripts/ci-run-tests.sh "BISECT_FILE=$(CURDIR)/_coverage/bisect opam exec -- dune test --root . --instrument-with bisect_ppx --force"
+	CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 scripts/ci-run-tests.sh "BISECT_FILE=$(CURDIR)/_coverage/bisect scripts/dune-local.sh test --instrument-with bisect_ppx --force"
 
 # Print coverage summary to stdout
 coverage-summary: coverage

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -42,8 +42,8 @@ echo "  README.md badge updated"
 
 # 3) opam metadata (if tracked)
 if [ -f "$ROOT_DIR/masc_mcp.opam" ]; then
-  dune build masc_mcp.opam --root "$ROOT_DIR"
-  echo "  masc_mcp.opam updated (via dune build)"
+  "$ROOT_DIR/scripts/dune-local.sh" build masc_mcp.opam
+  echo "  masc_mcp.opam updated (via scripts/dune-local.sh)"
 fi
 
 # 4) CHANGELOG stub (prepend if missing)

--- a/scripts/check-memory-leak.sh
+++ b/scripts/check-memory-leak.sh
@@ -183,9 +183,9 @@ require_cmd python3
 require_cmd "${VALGRIND_BIN}"
 
 if [[ "${BUILD_FIRST}" -eq 1 ]]; then
-  require_cmd dune
+  require_cmd "${REPO_ROOT}/scripts/dune-local.sh"
   echo "[memory-leak] building bin/main_eio.exe" >&2
-  dune build --root "${REPO_ROOT}" bin/main_eio.exe
+  "${REPO_ROOT}/scripts/dune-local.sh" build bin/main_eio.exe
 fi
 
 SERVER_EXE="$(harness_find_server_exe "${REPO_ROOT}" "${MASC_MAIN_EIO_EXE:-}")"

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -16,7 +16,13 @@ mktemp_ci_log() {
   fi
 }
 
-TEST_CMD="${1:-opam exec -- dune test}"
+if [[ -n "${1:-}" ]]; then
+  TEST_CMD="$1"
+elif [[ "${GITHUB_ACTIONS:-}" != "true" && -x "scripts/dune-local.sh" ]]; then
+  TEST_CMD="scripts/dune-local.sh test"
+else
+  TEST_CMD="opam exec -- dune test"
+fi
 TEST_TIMEOUT_SEC="${CI_TEST_TIMEOUT_SEC:-1200}"
 HEARTBEAT_SEC="${CI_TEST_HEARTBEAT_SEC:-30}"
 START_EPOCH="$(date +%s)"
@@ -224,7 +230,8 @@ heartbeat() {
 }
 
 test_cmd_needs_dune_sanitization() {
-  [[ "${TEST_CMD}" == *"dune "* ]] && [[ "${TEST_CMD}" != *"unset DUNE_RPC"* ]]
+  ([[ "${TEST_CMD}" == *"dune "* ]] || [[ "${TEST_CMD}" == *"dune-local.sh"* ]]) \
+    && [[ "${TEST_CMD}" != *"unset DUNE_RPC"* ]]
 }
 
 test_cmd_has_explicit_build_dir() {

--- a/scripts/coverage_percent.sh
+++ b/scripts/coverage_percent.sh
@@ -24,7 +24,7 @@ if ! $reuse_existing; then
     cd "$root_dir"
     CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
       ./scripts/ci-run-tests.sh \
-      "BISECT_FILE='$coverage_dir/bisect' opam exec -- dune test --root . --instrument-with bisect_ppx --force"
+      "BISECT_FILE='$coverage_dir/bisect' ./scripts/dune-local.sh test --instrument-with bisect_ppx --force"
   )
 fi
 

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+lock_path="${DUNE_LOCAL_LOCK:-/tmp/me-dune-local.lock}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/dune-local.sh [dune-subcommand] [args...]
+
+Local Dune wrapper for multi-agent development:
+  - serializes local Dune invocations with a machine-wide lock
+  - defaults local concurrency to DUNE_LOCAL_JOBS, or 2
+  - injects --root <repo-root> unless --root is already present
+
+Set MASC_DUNE_THROTTLE=0 to bypass the local lock.
+Set MASC_DUNE_DRY_RUN=1 to print the command without running it.
+USAGE
+}
+
+args=("$@")
+if [[ "${#args[@]}" -eq 0 ]]; then
+  args=(build)
+fi
+
+case "${args[0]}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+esac
+
+has_root=0
+for arg in "${args[@]}"; do
+  case "$arg" in
+    --root|--root=*)
+      has_root=1
+      break
+      ;;
+  esac
+done
+if [[ -n "${DUNE_ROOT:-}" ]]; then
+  has_root=1
+fi
+
+cmd=(dune)
+if [[ "$has_root" -eq 0 && "${args[0]}" != -* ]]; then
+  cmd+=("${args[0]}" --root "$repo_root")
+  if [[ "${#args[@]}" -gt 1 ]]; then
+    cmd+=("${args[@]:1}")
+  fi
+else
+  cmd+=("${args[@]}")
+fi
+
+if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
+  export DUNE_JOBS="${DUNE_JOBS:-${DUNE_LOCAL_JOBS:-2}}"
+  export DUNE_BUILD_DIR="${DUNE_BUILD_DIR:-$repo_root/_build}"
+fi
+
+printf '[dune-local] DUNE_JOBS=%s DUNE_BUILD_DIR=%s\n' \
+  "${DUNE_JOBS:-auto}" "${DUNE_BUILD_DIR:-_build}" >&2
+printf '[dune-local] command:' >&2
+printf ' %q' "${cmd[@]}" >&2
+printf '\n' >&2
+
+if [[ "${MASC_DUNE_DRY_RUN:-0}" = "1" ]]; then
+  exit 0
+fi
+
+if [[ "${GITHUB_ACTIONS:-}" = "true" || "${MASC_DUNE_THROTTLE:-1}" = "0" ]]; then
+  exec "${cmd[@]}"
+fi
+
+printf '[dune-local] waiting for lock %s\n' "$lock_path" >&2
+if command -v lockf >/dev/null 2>&1; then
+  exec lockf "$lock_path" "${cmd[@]}"
+elif command -v flock >/dev/null 2>&1; then
+  exec flock "$lock_path" "${cmd[@]}"
+else
+  printf '[dune-local] warning: neither lockf nor flock found; running unlocked\n' >&2
+  exec "${cmd[@]}"
+fi

--- a/scripts/feedback-loop.sh
+++ b/scripts/feedback-loop.sh
@@ -12,6 +12,8 @@ TARGET=${2:-"mitosis"}
 LOG_DIR="logs/feedback-loop"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 LOG_FILE="${LOG_DIR}/${TARGET}_${TIMESTAMP}.jsonl"
+DUNE_BUILD_TARGET="${MASC_LOCAL_DUNE_TARGET:-bin/main_eio.exe}"
+RUN_FULL_TESTS="${MASC_LOCAL_FULL_DUNE_TESTS:-0}"
 
 mkdir -p "$LOG_DIR"
 
@@ -26,23 +28,30 @@ for i in $(seq 1 $ITERATIONS); do
   
   START_TIME=$(date +%s%3N)
   
-  # 1. Build
-  echo "🔨 Building..."
-  if ! opam exec -- dune build --root "$REPO_DIR" 2>&1; then
+  # 1. Build a focused target by default. Full-suite validation belongs in CI
+  # unless this local loop explicitly opts in.
+  echo "🔨 Building $DUNE_BUILD_TARGET..."
+  if ! "$REPO_DIR/scripts/dune-local.sh" build "$DUNE_BUILD_TARGET" 2>&1; then
     echo "{\"iteration\":$i,\"phase\":\"build\",\"status\":\"failed\"}" >> "$LOG_FILE"
     echo "❌ Build failed at iteration $i"
     continue
   fi
   
   # 2. Test
-  echo "🧪 Testing..."
-  TEST_OUTPUT=$(
-    CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
-      "$REPO_DIR/scripts/ci-run-tests.sh" \
-      "opam exec -- dune test --root \"$REPO_DIR\"" 2>&1 || true
-  )
-  TEST_PASSED=$(echo "$TEST_OUTPUT" | grep -c "Test Successful" || echo "0")
-  TEST_FAILED=$(echo "$TEST_OUTPUT" | grep -c "FAILED\|Error" || echo "0")
+  if [ "$RUN_FULL_TESTS" = "1" ]; then
+    echo "🧪 Testing full suite..."
+    TEST_OUTPUT=$(
+      CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
+        "$REPO_DIR/scripts/ci-run-tests.sh" \
+        "$REPO_DIR/scripts/dune-local.sh test" 2>&1 || true
+    )
+    TEST_PASSED=$(echo "$TEST_OUTPUT" | grep -c "Test Successful" || echo "0")
+    TEST_FAILED=$(echo "$TEST_OUTPUT" | grep -c "FAILED\|Error" || echo "0")
+  else
+    echo "🧪 Skipping full local test suite. Set MASC_LOCAL_FULL_DUNE_TESTS=1 to opt in."
+    TEST_PASSED=0
+    TEST_FAILED=0
+  fi
   
   # 3. Measure (run metrics if available)
   echo "📊 Measuring..."

--- a/scripts/harness_repo_synthesis_benchmark.sh
+++ b/scripts/harness_repo_synthesis_benchmark.sh
@@ -11,7 +11,7 @@ mkdir -p "${OUT_DIR}"
 (
   cd "${ROOT_DIR}"
   if [ "${REPO_SYNTHESIS_SKIP_BUILD:-0}" != "1" ] || [ ! -x "${BENCH_EXE}" ]; then
-    dune build --root . ./test/test_repo_synthesis_benchmark.exe >/dev/null
+    scripts/dune-local.sh build ./test/test_repo_synthesis_benchmark.exe >/dev/null
   fi
   "${BENCH_EXE}" >"${SUMMARY_PATH}"
 )

--- a/scripts/harness_tool_call_quality.sh
+++ b/scripts/harness_tool_call_quality.sh
@@ -107,7 +107,7 @@ ensure_cli_built() {
   (
     cd "${ROOT_DIR}"
     if [[ "${TOOL_CALL_QUALITY_SKIP_BUILD:-0}" != "1" || ! -x "${CLI_EXE}" ]]; then
-      dune build --root . ./test/tool_call_quality_benchmark_cli.exe >/dev/null
+      scripts/dune-local.sh build ./test/tool_call_quality_benchmark_cli.exe >/dev/null
     fi
   )
 }

--- a/scripts/health_snapshot.sh
+++ b/scripts/health_snapshot.sh
@@ -163,10 +163,10 @@ PY
 
 echo "=== Health Snapshot ==="
 if [ "$SKIP_BUILD" -eq 0 ]; then
-  echo "Running dune build --root . @check"
-  dune build --root . @check
+  echo "Running scripts/dune-local.sh build @check"
+  scripts/dune-local.sh build @check
 else
-  echo "Skipping dune build --root . @check"
+  echo "Skipping scripts/dune-local.sh build @check"
 fi
 
 anti_fake_output=""

--- a/scripts/improve.sh
+++ b/scripts/improve.sh
@@ -10,6 +10,8 @@ REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 IMPROVEMENT_ID=${1:-"unknown"}
 DESCRIPTION=${2:-"No description"}
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+DUNE_BUILD_TARGET="${MASC_LOCAL_DUNE_TARGET:-bin/main_eio.exe}"
+RUN_FULL_TESTS="${MASC_LOCAL_FULL_DUNE_TESTS:-0}"
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "🔧 Improvement: $IMPROVEMENT_ID"
@@ -18,30 +20,41 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 
 # 1. Pre-check
 echo "1️⃣ Pre-check..."
-BEFORE_TESTS=$(
-  CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
-    "$REPO_DIR/scripts/ci-run-tests.sh" \
-    "opam exec -- dune test --root \"$REPO_DIR\"" 2>&1 | grep -c "Test Successful" || echo "0"
-)
-echo "   Tests before: $BEFORE_TESTS passing"
+BEFORE_TESTS=0
+if [ "$RUN_FULL_TESTS" = "1" ]; then
+  BEFORE_TESTS=$(
+    CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
+      "$REPO_DIR/scripts/ci-run-tests.sh" \
+      "$REPO_DIR/scripts/dune-local.sh test" 2>&1 | grep -c "Test Successful" || echo "0"
+  )
+  echo "   Tests before: $BEFORE_TESTS passing"
+else
+  echo "   Skipping full local pre-check. Set MASC_LOCAL_FULL_DUNE_TESTS=1 to opt in."
+fi
 
 # 2. Build
-echo "2️⃣ Building..."
-if ! opam exec -- dune build --root "$REPO_DIR" 2>&1; then
+echo "2️⃣ Building $DUNE_BUILD_TARGET..."
+if ! "$REPO_DIR/scripts/dune-local.sh" build "$DUNE_BUILD_TARGET" 2>&1; then
   echo "❌ Build failed!"
   exit 1
 fi
 echo "   ✅ Build OK"
 
 # 3. Test
-echo "3️⃣ Testing..."
-TEST_OUTPUT=$(
-  CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
-    "$REPO_DIR/scripts/ci-run-tests.sh" \
-    "opam exec -- dune test --root \"$REPO_DIR\"" 2>&1 || true
-)
-AFTER_TESTS=$(echo "$TEST_OUTPUT" | grep -c "Test Successful" || echo "0")
-FAILED=$(echo "$TEST_OUTPUT" | grep -c "FAILED\|Error" || echo "0")
+AFTER_TESTS=0
+FAILED=0
+if [ "$RUN_FULL_TESTS" = "1" ]; then
+  echo "3️⃣ Testing full suite..."
+  TEST_OUTPUT=$(
+    CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
+      "$REPO_DIR/scripts/ci-run-tests.sh" \
+      "$REPO_DIR/scripts/dune-local.sh test" 2>&1 || true
+  )
+  AFTER_TESTS=$(echo "$TEST_OUTPUT" | grep -c "Test Successful" || echo "0")
+  FAILED=$(echo "$TEST_OUTPUT" | grep -c "FAILED\|Error" || echo "0")
+else
+  echo "3️⃣ Skipping full local test suite. Set MASC_LOCAL_FULL_DUNE_TESTS=1 to opt in."
+fi
 
 echo "   Tests after: $AFTER_TESTS passing, $FAILED failed"
 
@@ -52,7 +65,7 @@ if [ "$FAILED" -gt "0" ]; then
   exit 1
 fi
 
-if [ "$AFTER_TESTS" -lt "$BEFORE_TESTS" ]; then
+if [ "$RUN_FULL_TESTS" = "1" ] && [ "$AFTER_TESTS" -lt "$BEFORE_TESTS" ]; then
   echo "⚠️  Warning: Test count decreased"
 fi
 

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -15,7 +15,6 @@ PRINT_PORT_ONLY=0
 BOOTSTRAP_ONLY=0
 BUILD_DASHBOARD=0
 BOOTSTRAP_KEEPERS=0
-DUNE_JOBS="${MASC_DUNE_JOBS:-8}"
 
 git_common_root() {
   if ! command -v git >/dev/null 2>&1; then
@@ -243,7 +242,7 @@ EXE="$(resolve_built_exe)"
 
 if binary_is_stale "$EXE"; then
   echo "[local-run] Building local binary..." >&2
-  dune build -j "$DUNE_JOBS" --root "$REPO_ROOT" bin/main_eio.exe
+  "$REPO_ROOT/scripts/dune-local.sh" build bin/main_eio.exe
 fi
 
 if [ ! -x "$EXE" ]; then

--- a/scripts/sync-version-truth.sh
+++ b/scripts/sync-version-truth.sh
@@ -92,9 +92,9 @@ if $opam_drift; then
   # dune regenerates masc_mcp.opam from dune-project when the (generate_opam_files true)
   # stanza is present. We don't hand-edit the file — that's what the "generated"
   # header tells every tool to expect.
-  info "running: dune build masc_mcp.opam"
-  if ! dune build --root . masc_mcp.opam 2>/dev/null; then
-    echo "sync-version-truth: 'dune build masc_mcp.opam' failed" >&2
+  info "running: scripts/dune-local.sh build masc_mcp.opam"
+  if ! scripts/dune-local.sh build masc_mcp.opam 2>/dev/null; then
+    echo "sync-version-truth: 'scripts/dune-local.sh build masc_mcp.opam' failed" >&2
     exit 1
   fi
 fi

--- a/scripts/verify-refactor.sh
+++ b/scripts/verify-refactor.sh
@@ -24,7 +24,7 @@ echo "=== verify-refactor ==="
 
 # 1. Build check
 echo "[1/3] Building..."
-if dune build --root . @install 2>&1 | tail -3; then
+if scripts/dune-local.sh build @install 2>&1 | tail -3; then
   printf "  PASS  build\n"
   PASS=$((PASS + 1))
 else


### PR DESCRIPTION
## Summary
- add `scripts/dune-local.sh` to serialize local Dune runs and default to low concurrency
- route local make, run-local, coverage, health, version, and loop scripts through the wrapper
- keep full-suite loop testing opt-in with `MASC_LOCAL_FULL_DUNE_TESTS=1`

## Validation
- `bash -n scripts/dune-local.sh scripts/ci-run-tests.sh scripts/run-local.sh scripts/feedback-loop.sh scripts/improve.sh scripts/coverage_percent.sh scripts/health_snapshot.sh scripts/verify-refactor.sh scripts/harness_repo_synthesis_benchmark.sh scripts/harness_tool_call_quality.sh scripts/check-memory-leak.sh scripts/bump-version.sh scripts/sync-version-truth.sh`
- `MASC_DUNE_DRY_RUN=1 scripts/dune-local.sh build ./bin/main_eio.exe`
- `MASC_DUNE_DRY_RUN=1 scripts/dune-local.sh test`
- `MASC_DUNE_DRY_RUN=1 CI_TEST_TIMEOUT_SEC=5 CI_TEST_HEARTBEAT_SEC=1 scripts/ci-run-tests.sh`
- `make -n build test-unit coverage`
- `git diff --check`
