### PR TITLE
[codex] clarify keeper goal and cascade control signals

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -303,6 +303,15 @@ let keeper_trust_json ?(include_receipt = false)
         match latest_receipt with
         | Some receipt -> Yojson.Safe.Util.member "terminal_reason_code" receipt
         | None -> `String "no_receipt" );
+      ( "operator_disposition",
+        match latest_receipt with
+        | Some receipt -> Yojson.Safe.Util.member "operator_disposition" receipt
+        | None -> `String "not_run" );
+      ( "operator_disposition_reason",
+        match latest_receipt with
+        | Some receipt ->
+            Yojson.Safe.Util.member "operator_disposition_reason" receipt
+        | None -> `String "no_receipt" );
       ( "tool_contract_result",
         match latest_receipt with
         | Some receipt -> Yojson.Safe.Util.member "tool_contract_result" receipt

--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -39,6 +39,33 @@ let resolve_task_create_goal_id ~config ~(meta : keeper_meta) args =
                 (String.concat ", " goal_ids)))
 ;;
 
+let active_goal_scope_json ~(meta : keeper_meta) ?matched_goal_id
+    ?excluded_count () =
+  let scoped = meta.active_goal_ids <> [] in
+  let fields =
+    [
+      ("mode", `String (if scoped then "active_goal_ids" else "all_tasks"));
+      ("scoped", `Bool scoped);
+      ( "active_goal_ids",
+        `List (List.map (fun goal_id -> `String goal_id) meta.active_goal_ids)
+      );
+      ("matched_goal_id", Json_util.string_opt_to_json matched_goal_id);
+    ]
+  in
+  let fields =
+    match excluded_count with
+    | Some count -> fields @ [ ("excluded_count", `Int count) ]
+    | None -> fields
+  in
+  `Assoc fields
+;;
+
+let find_task_goal_id config task_id =
+  Coord.get_tasks_raw config
+  |> List.find_map (fun (task : Types.task) ->
+         if String.equal task.id task_id then task.goal_id else None)
+;;
+
 let handle_keeper_task_tool
       ~(config : Coord.config)
       ~(meta : keeper_meta)
@@ -167,7 +194,8 @@ let handle_keeper_task_tool
       else
         None
     in
-    let message = match result with
+    let message =
+      match result with
       | Coord.Claim_next_claimed { message; _ } -> message
       | Coord.Claim_next_no_unclaimed -> "📋 No unclaimed tasks. ACTION: Stop task-checking — nothing to claim."
       | Coord.Claim_next_no_eligible { excluded_count; _ } ->
@@ -184,11 +212,36 @@ let handle_keeper_task_tool
           scope_suffix excluded_count
       | Coord.Claim_next_error e -> Printf.sprintf "❌ Error: %s" e
     in
+    let claim_scope, claimed_task_fields =
+      match result with
+      | Coord.Claim_next_claimed { task_id; title; priority; released_task_id; _ } ->
+          let matched_goal_id = find_task_goal_id config task_id in
+          ( active_goal_scope_json ~meta ?matched_goal_id ()
+          , [
+              ( "claimed_task",
+                `Assoc
+                  [
+                    ("task_id", `String task_id);
+                    ("title", `String title);
+                    ("priority", `Int priority);
+                    ( "goal_id",
+                      Json_util.string_opt_to_json matched_goal_id );
+                    ( "released_task_id",
+                      Json_util.string_opt_to_json released_task_id );
+                  ] );
+            ] )
+      | Coord.Claim_next_no_eligible { excluded_count } ->
+          (active_goal_scope_json ~meta ~excluded_count (), [])
+      | Coord.Claim_next_no_unclaimed | Coord.Claim_next_error _ ->
+          (active_goal_scope_json ~meta (), [])
+    in
     Yojson.Safe.to_string
       (`Assoc
          ([
             ("result", `String message);
+            ("claim_scope", claim_scope);
           ]
+         @ claimed_task_fields
          @
          match accountability_warning with
          | Some warning -> [ ("routing_warning", `String warning) ]

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -93,7 +93,58 @@ let cascade_rotation_attempt_to_json attempt =
       ("recorded_at", `String attempt.recorded_at);
     ]
 
+let string_contains_ci haystack needle =
+  let haystack = String.lowercase_ascii haystack in
+  let needle = String.lowercase_ascii needle in
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop i =
+    if needle_len = 0 then true
+    else if i + needle_len > haystack_len then false
+    else if String.sub haystack i needle_len = needle then true
+    else loop (i + 1)
+  in
+  loop 0
+
+let operator_disposition (receipt : t) =
+  let cascade_outcome = String.lowercase_ascii receipt.cascade_outcome in
+  let terminal_reason = String.lowercase_ascii receipt.terminal_reason_code in
+  let error_kind =
+    Option.map String.lowercase_ascii receipt.error_kind
+  in
+  if
+    String.equal terminal_reason "cascade_exhausted"
+    || String.equal cascade_outcome "cascade_exhausted"
+    || String.equal cascade_outcome "exhausted"
+  then ("alert_exhausted", "cascade_exhausted")
+  else if
+    String.equal receipt.tool_surface.tool_requirement "required"
+    && (String.equal receipt.tool_contract_result "violated"
+        || receipt.tools_used = [])
+  then ("pause_human", "tool_required_no_tools")
+  else if
+    match error_kind with
+    | Some kind ->
+        string_contains_ci kind "config"
+        || string_contains_ci kind "auth"
+        || string_contains_ci terminal_reason "config"
+        || string_contains_ci terminal_reason "auth"
+    | None ->
+        string_contains_ci terminal_reason "config"
+        || string_contains_ci terminal_reason "auth"
+  then ("pause_human", "preflight_config_error")
+  else if receipt.degraded_retry_applied || Option.is_some receipt.degraded_retry_cascade
+  then ("fail_open_next_cascade", "degraded_retry")
+  else if
+    receipt.cascade_fallback_applied
+    || String.equal cascade_outcome "passed_to_next_model"
+  then ("pass_next_model", "cascade_fallback")
+  else ("pass", "healthy")
+
 let to_json (receipt : t) =
+  let operator_disposition, operator_disposition_reason =
+    operator_disposition receipt
+  in
   let error_json =
     match receipt.error_kind, receipt.error_message with
     | None, None -> `Null
@@ -129,6 +180,8 @@ let to_json (receipt : t) =
       ("goal_ids", list_json receipt.goal_ids);
       ("outcome", `String receipt.outcome);
       ("terminal_reason_code", `String receipt.terminal_reason_code);
+      ("operator_disposition", `String operator_disposition);
+      ("operator_disposition_reason", `String operator_disposition_reason);
       ("response_text_present", `Bool receipt.response_text_present);
       ( "model_used",
         match receipt.model_used with

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -707,6 +707,28 @@ let snapshot_json ~(config : Coord.config) ~(meta : keeper_meta) =
   let disposition, disposition_reason =
     disposition_of_snapshot ~pending_approval_count ~runtime_blocker_fields
   in
+  let operator_disposition, operator_disposition_reason =
+    match latest_receipt with
+    | Some receipt -> (
+        let open Yojson.Safe.Util in
+        match
+          ( member "operator_disposition" receipt
+          , member "operator_disposition_reason" receipt )
+        with
+        | `String disposition, `String reason -> (disposition, reason)
+        | _ -> (
+            match disposition with
+            | "Pass" -> ("pass", disposition_reason)
+            | "Pause" -> ("pause_human", disposition_reason)
+            | "Alert" -> ("alert_exhausted", disposition_reason)
+            | _ -> ("pause_human", disposition_reason)))
+    | None -> (
+        match disposition with
+        | "Pass" -> ("pass", disposition_reason)
+        | "Pause" -> ("pause_human", disposition_reason)
+        | "Alert" -> ("alert_exhausted", disposition_reason)
+        | _ -> ("pause_human", disposition_reason))
+  in
   let needs_attention =
     assoc_bool_default "needs_attention" ~default:false attention_fields
   in
@@ -754,6 +776,8 @@ let snapshot_json ~(config : Coord.config) ~(meta : keeper_meta) =
       ("runtime_blockers", `Assoc runtime_blocker_fields);
       ("disposition", `String disposition);
       ("disposition_reason", `String disposition_reason);
+      ("operator_disposition", `String operator_disposition);
+      ("operator_disposition_reason", `String operator_disposition_reason);
       ("needs_attention", `Bool needs_attention);
       ("attention_reason", Json_util.string_opt_to_json attention_reason);
       ("next_human_action", Json_util.string_opt_to_json next_human_action);

--- a/lib/tool_schemas/tool_schemas_coord_extra.ml
+++ b/lib/tool_schemas/tool_schemas_coord_extra.ml
@@ -161,6 +161,14 @@ The actor field records who initiated the transition.";
                   ("action", enum_schema goal_transition_action_enum);
                   ("actor", goal_principal_schema);
                   ("note", `Assoc [ ("type", `String "string") ]);
+                  ( "override_note",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ( "description",
+                          `String
+                            "Operator rationale for forcing request_complete when linked task evidence is incomplete." );
+                      ] );
                 ] );
             ("required", `List [ `String "goal_id"; `String "action"; `String "actor" ]);
           ];

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -678,6 +678,14 @@ let test_execution_trust_surfaces_latest_receipt () =
               "passed_to_next_model"
               (trust_row |> member "trust" |> member "cascade"
              |> member "outcome" |> to_string);
+            check string "execution trust row exposes operator disposition"
+              "fail_open_next_cascade"
+              (trust_row |> member "trust" |> member "operator_disposition"
+             |> to_string);
+            check string "execution trust row exposes operator disposition reason"
+              "degraded_retry"
+              (trust_row |> member "trust" |> member "operator_disposition_reason"
+             |> to_string);
             check bool "execution trust row preserves degraded retry flag" true
               (trust_row |> member "trust" |> member "cascade"
              |> member "degraded_retry_applied" |> to_bool);

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -268,6 +268,8 @@ let test_goal_detail_surfaces_keeper_runtime_trust_and_blockers () =
       let runtime_trust = linked_keeper |> member "runtime_trust" in
       check string "disposition ok" "Pass"
         (runtime_trust |> member "disposition" |> to_string);
+      check string "operator disposition ok" "pass"
+        (runtime_trust |> member "operator_disposition" |> to_string);
       check string "approval idle" "idle"
         (runtime_trust |> member "approval" |> member "state" |> to_string);
       check string "execution receipt latest event" "execution_receipt"

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -147,23 +147,43 @@ let test_claim_empty_room () =
 
 let test_claim_respects_active_goal_ids () =
   with_room (fun config ->
-    let meta = make_goal_scoped_meta [ "goal-masc" ] in
+    let goal, _ =
+      match Goal_store.upsert_goal config ~title:"Masc goal" () with
+      | Ok payload -> payload
+      | Error msg -> fail msg
+    in
+    let other_goal, _ =
+      match Goal_store.upsert_goal config ~title:"Other goal" () with
+      | Ok payload -> payload
+      | Error msg -> fail msg
+    in
+    let meta = make_goal_scoped_meta [ goal.id ] in
     let _ =
-      Coord_task.add_task ~goal_id:"goal-other" config
+      Coord_task.add_task ~goal_id:other_goal.id config
         ~title:"Other goal task" ~priority:1 ~description:"desc"
     in
     let _ =
-      Coord_task.add_task ~goal_id:"goal-masc" config
+      Coord_task.add_task ~goal_id:goal.id config
         ~title:"Masc goal task" ~priority:5 ~description:"desc"
     in
-    let _result = call_tool config meta "keeper_task_claim" (`Assoc []) in
+    let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
+    let json = parse_json result in
     let claimed_task =
       Coord.get_tasks_raw config
       |> List.find_opt (fun (task : Types.task) ->
            Types.task_assignee_of_status task.task_status = Some meta.agent_name)
     in
     match claimed_task with
-    | Some task -> check string "claimed scoped task" "Masc goal task" task.title
+    | Some task ->
+      check string "claimed scoped task" "Masc goal task" task.title;
+      let scope = Yojson.Safe.Util.member "claim_scope" json in
+      check string "claim scope mode" "active_goal_ids"
+        Yojson.Safe.Util.(scope |> member "mode" |> to_string);
+      check string "claim scope matched goal" goal.id
+        Yojson.Safe.Util.(scope |> member "matched_goal_id" |> to_string);
+      check string "claimed task goal" goal.id
+        Yojson.Safe.Util.(
+          json |> member "claimed_task" |> member "goal_id" |> to_string)
     | None -> fail "expected a claimed task")
 
 let test_create_defaults_single_active_goal_id () =

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -271,7 +271,9 @@ let test_masc_goal_transition_schema () =
           Alcotest.(check bool) "has actor" true
             (List.mem_assoc "actor" props);
           Alcotest.(check bool) "has note" true
-            (List.mem_assoc "note" props)
+            (List.mem_assoc "note" props);
+          Alcotest.(check bool) "has override_note" true
+            (List.mem_assoc "override_note" props)
       | None -> Alcotest.fail "masc_goal_transition missing properties");
       match get_json_list "required" schema.input_schema with
       | Some reqs ->


### PR DESCRIPTION
## Summary
- add `override_note` to the `masc_goal_transition` tool schema so the public contract matches the Goal FSM implementation
- include goal-scope and claimed-task metadata in `keeper_task_claim` responses
- add normalized operator dispositions to execution receipts, runtime-trust snapshots, and keeper dashboard trust JSON

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/product-control-plane-clarity --build-dir /tmp/masc-product-control-plane-clarity-pr-build`
- `/tmp/masc-product-control-plane-clarity-pr-build/default/test/test_tools_coverage.exe` (55 tests)
- `/tmp/masc-product-control-plane-clarity-pr-build/default/test/test_keeper_task_dispatch.exe` (20 tests)
- `/tmp/masc-product-control-plane-clarity-pr-build/default/test/test_dashboard_execution.exe` (14 tests)
- `/tmp/masc-product-control-plane-clarity-pr-build/default/test/test_dashboard_goals.exe` (8 tests)
- `/tmp/masc-product-control-plane-clarity-pr-build/default/test/test_dashboard_keeper_routes.exe` (4 tests, 8 skipped)
- `/tmp/masc-product-control-plane-clarity-pr-build/default/test/test_keeper_agent_run_sandbox_source.exe` (2 tests)
- `git diff --check`