### PR TITLE
[codex] Rotate recoverable keeper cascade failures

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -576,6 +576,7 @@ let run_turn
       ?(degraded_retry_applied = false)
       ?degraded_retry_cascade
       ?fallback_reason
+      ?(cascade_rotation_attempts = [])
       ?(is_retry = false)
       ?shared_context
       ?event_bus
@@ -3037,6 +3038,7 @@ let run_turn
         degraded_retry_applied;
         degraded_retry_cascade;
         fallback_reason;
+        cascade_rotation_attempts;
         stop_reason = !receipt_stop_reason_ref;
         error_kind;
         error_message;

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -192,6 +192,8 @@ val run_turn :
   -> ?degraded_retry_applied:bool
   -> ?degraded_retry_cascade:string
   -> ?fallback_reason:string
+  -> ?cascade_rotation_attempts:
+       Keeper_execution_receipt.cascade_rotation_attempt list
   -> ?is_retry:bool
   -> ?shared_context:Oas.Context.t
   -> ?event_bus:Oas.Event_bus.t

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -208,6 +208,100 @@ let degraded_retry_after_recoverable_error
     | None ->
         None
 
+let recoverable_cascade_failure_reason (err : Oas.Error.sdk_error) =
+  if Oas_worker_named.sdk_error_is_hard_quota err then
+    Some "hard_quota"
+  else
+    match Oas_worker_named.classify_masc_internal_error err with
+    | Some (Oas_worker_named.Resumable_cli_session _) ->
+        Some "resumable_cli_session"
+    | Some (Oas_worker_named.Admission_queue_timeout _) ->
+        Some "admission_queue_timeout"
+    | Some (Oas_worker_named.Oas_timeout_budget _) ->
+        Some "oas_timeout_budget"
+    | Some (Oas_worker_named.Turn_timeout _) ->
+        Some "turn_timeout"
+    | Some
+        (Oas_worker_named.Cascade_exhausted
+           { reason = Keeper_types.Candidates_filtered_after_cycles; _ }) ->
+        Some "cascade_candidates_filtered"
+    | Some
+        (Oas_worker_named.Cascade_exhausted
+           { reason = Keeper_types.Other_detail detail; _ })
+      when Oas_worker_named.message_looks_like_cli_wrapped_hard_quota detail ->
+        Some "hard_quota"
+    | Some (Oas_worker_named.Cascade_exhausted _)
+    | Some (Oas_worker_named.No_tool_capable_provider _)
+    | Some (Oas_worker_named.Accept_rejected _)
+    | Some (Oas_worker_named.Admission_queue_rejected _)
+    | Some (Oas_worker_named.Ambiguous_post_commit _)
+    | None ->
+        None
+
+let normalized_cascade_name name =
+  let trimmed = String.trim name in
+  if
+    String.equal trimmed Keeper_config.local_only_cascade_name
+    || String.equal trimmed Keeper_config.local_recovery_cascade_name
+    || String.equal trimmed Keeper_config.tool_use_strict_cascade_name
+  then trimmed
+  else Keeper_cascade_profile.normalize_declared_name trimmed
+
+let required_tool_rotation_candidate name =
+  let normalized = normalized_cascade_name name in
+  not
+    (String.equal normalized Keeper_config.local_only_cascade_name
+     || String.equal normalized Keeper_config.local_recovery_cascade_name)
+
+let degraded_rotation_candidates
+    ~(base_cascade : string)
+    ~(effective_cascade : string)
+    ~(tool_requirement : string) =
+  let normalized_base = normalized_cascade_name base_cascade in
+  let normalized_effective = normalized_cascade_name effective_cascade in
+  let candidates =
+    if String.equal tool_requirement "required" then
+      [
+        Keeper_config.tool_use_strict_cascade_name;
+        normalized_base;
+        Keeper_config.default_cascade_name;
+      ]
+    else
+      [
+        normalized_base;
+        Keeper_config.default_cascade_name;
+        Keeper_config.local_recovery_cascade_name;
+        Keeper_config.tool_use_strict_cascade_name;
+      ]
+  in
+  candidates
+  |> List.map normalized_cascade_name
+  |> dedupe_keep_order
+  |> List.filter (fun candidate ->
+         (not (String.equal candidate normalized_effective))
+         && (not (String.equal tool_requirement "required")
+             || required_tool_rotation_candidate candidate))
+
+let degraded_rotation_after_recoverable_error
+    ~(base_cascade : string)
+    ~(effective_cascade : string)
+    ~(tool_requirement : string)
+    ~(attempted_cascades : string list)
+    (err : Oas.Error.sdk_error) : degraded_retry option =
+  match recoverable_cascade_failure_reason err with
+  | None -> None
+  | Some fallback_reason ->
+      let attempted =
+        attempted_cascades
+        |> List.map normalized_cascade_name
+        |> dedupe_keep_order
+      in
+      degraded_rotation_candidates
+        ~base_cascade ~effective_cascade ~tool_requirement
+      |> List.find_opt (fun candidate ->
+             not (List.exists (String.equal candidate) attempted))
+      |> Option.map (fun next_cascade -> { next_cascade; fallback_reason })
+
 let is_auto_recoverable_turn_error (err : Oas.Error.sdk_error) : bool =
   is_transient_network_error err
   || is_server_rejected_parse_error err

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -71,6 +71,18 @@ val degraded_retry_after_recoverable_error :
   Oas.Error.sdk_error ->
   degraded_retry option
 
+(** Returns the next untried cascade in the same-turn recovery group for a
+    whole-cascade failure. This broadens beyond the legacy one-hop
+    local_recovery fallback, while keeping required-tool turns on lanes that
+    can still be filtered for tool-capable providers. *)
+val degraded_rotation_after_recoverable_error :
+  base_cascade:string ->
+  effective_cascade:string ->
+  tool_requirement:string ->
+  attempted_cascades:string list ->
+  Oas.Error.sdk_error ->
+  degraded_retry option
+
 val max_transient_retries : int
 
 val transient_backoff_sec : int -> float

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -7,6 +7,16 @@ type tool_surface =
   ; tool_surface_fallback_used : bool
   }
 
+type cascade_rotation_attempt =
+  { from_cascade : string
+  ; to_cascade : string
+  ; reason : string
+  ; outcome : string
+  ; error_kind : string option
+  ; error_message : string option
+  ; recorded_at : string
+  }
+
 type t =
   { keeper_name : string
   ; agent_name : string
@@ -40,6 +50,7 @@ type t =
   ; degraded_retry_applied : bool
   ; degraded_retry_cascade : string option
   ; fallback_reason : string option
+  ; cascade_rotation_attempts : cascade_rotation_attempt list
   ; stop_reason : string option
   ; error_kind : string option
   ; error_message : string option
@@ -65,6 +76,22 @@ let sandbox_kind_of_meta (meta : Keeper_types.keeper_meta) =
 
 let list_json values =
   `List (List.map (fun value -> `String value) values)
+
+let string_opt_json = function
+  | Some value -> `String value
+  | None -> `Null
+
+let cascade_rotation_attempt_to_json attempt =
+  `Assoc
+    [
+      ("from_cascade", `String attempt.from_cascade);
+      ("to_cascade", `String attempt.to_cascade);
+      ("reason", `String attempt.reason);
+      ("outcome", `String attempt.outcome);
+      ("error_kind", string_opt_json attempt.error_kind);
+      ("error_message", string_opt_json attempt.error_message);
+      ("recorded_at", `String attempt.recorded_at);
+    ]
 
 let to_json (receipt : t) =
   let error_json =
@@ -164,6 +191,10 @@ let to_json (receipt : t) =
               match receipt.fallback_reason with
               | Some value -> `String value
               | None -> `Null );
+            ( "rotation_attempts",
+              `List
+                (List.map cascade_rotation_attempt_to_json
+                   receipt.cascade_rotation_attempts) );
           ] );
       ( "stop_reason",
         match receipt.stop_reason with

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -7,6 +7,16 @@ type tool_surface =
   ; tool_surface_fallback_used : bool
   }
 
+type cascade_rotation_attempt =
+  { from_cascade : string
+  ; to_cascade : string
+  ; reason : string
+  ; outcome : string
+  ; error_kind : string option
+  ; error_message : string option
+  ; recorded_at : string
+  }
+
 type t =
   { keeper_name : string
   ; agent_name : string
@@ -40,6 +50,7 @@ type t =
   ; degraded_retry_applied : bool
   ; degraded_retry_cascade : string option
   ; fallback_reason : string option
+  ; cascade_rotation_attempts : cascade_rotation_attempt list
   ; stop_reason : string option
   ; error_kind : string option
   ; error_message : string option

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -198,15 +198,20 @@ let next_fail_open_cascade_for_turn
     ~(tool_requirement : string)
     ~(attempted_cascades : string list)
     (err : Oas.Error.sdk_error) : EC.degraded_retry option =
-  let _ = base_cascade in
-  match
-    EC.degraded_retry_after_recoverable_error
-      ~effective_cascade ~tool_requirement err
-  with
-  | Some { next_cascade; _ }
-    when List.exists (String.equal next_cascade) attempted_cascades ->
-      None
-  | next -> next
+  EC.degraded_rotation_after_recoverable_error
+    ~base_cascade ~effective_cascade ~tool_requirement
+    ~attempted_cascades err
+
+let sdk_error_kind = function
+  | Oas.Error.Api _ -> "api"
+  | Oas.Error.Agent _ -> "agent"
+  | Oas.Error.Mcp _ -> "mcp"
+  | Oas.Error.Config _ -> "config"
+  | Oas.Error.Serialization _ -> "serialization"
+  | Oas.Error.Io _ -> "io"
+  | Oas.Error.Orchestration _ -> "orchestration"
+  | Oas.Error.A2a _ -> "a2a"
+  | Oas.Error.Internal _ -> "internal"
 
 let oas_timeout_guard_sec = 1.0
 
@@ -935,6 +940,25 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       let last_execution = ref initial_execution in
       let last_timeout_budget : oas_timeout_budget_resolution option ref = ref None in
       let degraded_retry_info = ref None in
+      let cascade_rotation_attempts = ref [] in
+      let record_cascade_rotation_attempt
+          ~(from_cascade : string)
+          ~(retry : EC.degraded_retry)
+          ~(outcome : string)
+          (err : Oas.Error.sdk_error) =
+        let attempt : Keeper_execution_receipt.cascade_rotation_attempt =
+          {
+            from_cascade;
+            to_cascade = retry.next_cascade;
+            reason = retry.fallback_reason;
+            outcome;
+            error_kind = Some (sdk_error_kind err);
+            error_message = Some (Oas.Error.to_string err);
+            recorded_at = now_iso ();
+          }
+        in
+        cascade_rotation_attempts := attempt :: !cascade_rotation_attempts
+      in
       let run_result, latency_ms =
         Fun.protect ~finally:(fun () ->
           unsubscribe_event_bus ();
@@ -1037,6 +1061,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                     (Option.map
                        (fun (retry : EC.degraded_retry) -> retry.fallback_reason)
                        !degraded_retry_info)
+                  ~cascade_rotation_attempts:
+                    (List.rev !cascade_rotation_attempts)
                   ~temperature:execution.temperature
                   ~max_tokens:execution.max_tokens
                   ~oas_timeout_s
@@ -1207,6 +1233,11 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                           ~cascade_name:degraded_retry.next_cascade
                       with
                       | Error fail_open_err ->
+                          record_cascade_rotation_attempt
+                            ~from_cascade:execution.cascade_name
+                            ~retry:degraded_retry
+                            ~outcome:"setup_failed"
+                            fail_open_err;
                           Log.Keeper.warn
                             "%s: recoverable cascade failure in %s suggested degraded retry to %s (reason=%s), but retry setup failed: %s"
                             meta.name execution.cascade_name
@@ -1216,9 +1247,14 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                           mark_terminal_error fail_open_err;
                           Error fail_open_err
                       | Ok next_execution ->
+                          record_cascade_rotation_attempt
+                            ~from_cascade:execution.cascade_name
+                            ~retry:degraded_retry
+                            ~outcome:"retry_scheduled"
+                            err;
                           degraded_retry_info := Some degraded_retry;
                           Log.Keeper.warn
-                            "%s: recoverable cascade failure in %s; degraded retry on cascade=%s reason=%s max_context=%d context_budget=%d primary_budget=%d requested_override=%s: %s"
+                            "%s: recoverable cascade failure in %s; rotation retry on cascade=%s reason=%s max_context=%d context_budget=%d primary_budget=%d requested_override=%s: %s"
                             meta.name execution.cascade_name
                             next_execution.cascade_name
                             degraded_retry.fallback_reason

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -471,6 +471,18 @@ let append_execution_receipt config ~keeper_name =
       degraded_retry_applied = true;
       degraded_retry_cascade = Some Lib.Keeper_config.local_recovery_cascade_name;
       fallback_reason = Some "turn_timeout";
+      cascade_rotation_attempts =
+        [
+          {
+            from_cascade = Lib.Keeper_config.default_cascade_name;
+            to_cascade = Lib.Keeper_config.local_recovery_cascade_name;
+            reason = "turn_timeout";
+            outcome = "retry_scheduled";
+            error_kind = Some "internal";
+            error_message = Some "turn timeout";
+            recorded_at = ended_at;
+          };
+        ];
       stop_reason = Some "completed";
       error_kind = None;
       error_message = None;
@@ -677,6 +689,11 @@ let test_execution_trust_surfaces_latest_receipt () =
               (Some "turn_timeout")
               (trust_row |> member "trust" |> member "cascade"
              |> member "fallback_reason" |> to_string_option);
+            check string "execution trust row preserves rotation target"
+              Lib.Keeper_config.local_recovery_cascade_name
+              (trust_row |> member "trust" |> member "cascade"
+             |> member "rotation_attempts" |> to_list |> List.hd
+             |> member "to_cascade" |> to_string);
             check (list string) "execution trust row preserves unexpected tools"
               [ "WebSearch" ]
               (trust_row |> member "trust" |> member "unexpected_tools"

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -89,6 +89,7 @@ let append_keeper_receipt (config : Coord.config) (meta : Keeper_types.keeper_me
       degraded_retry_applied = false;
       degraded_retry_cascade = None;
       fallback_reason = None;
+      cascade_rotation_attempts = [];
       stop_reason = Some "completed";
       error_kind = None;
       error_message = None;

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -639,6 +639,18 @@ let append_execution_receipt config ~keeper_name =
       degraded_retry_cascade =
         Some Masc_mcp.Keeper_config.local_recovery_cascade_name;
       fallback_reason = Some "turn_timeout";
+      cascade_rotation_attempts =
+        [
+          {
+            from_cascade = meta.cascade_name;
+            to_cascade = Masc_mcp.Keeper_config.local_recovery_cascade_name;
+            reason = "turn_timeout";
+            outcome = "retry_scheduled";
+            error_kind = Some "internal";
+            error_message = Some "turn timeout";
+            recorded_at = ended_at;
+          };
+        ];
       stop_reason = Some "completed";
       error_kind = None;
       error_message = None;

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2745,30 +2745,60 @@ let test_fallback_cascade_for_unavailable_profile_prefers_base_after_phase_overr
   check (option string) "phase override fallback target is base cascade"
     (Some "tool_rerank") fallback
 
-let test_next_fail_open_cascade_for_turn_returns_untried_local_recovery () =
+let test_next_fail_open_cascade_for_turn_returns_untried_default_cascade () =
   let degraded_retry =
     UT.next_fail_open_cascade_for_turn
-      ~base_cascade:"underdog"
-      ~effective_cascade:"underdog"
+      ~base_cascade:"tool_rerank"
+      ~effective_cascade:"tool_rerank"
       ~tool_requirement:"optional"
-      ~attempted_cascades:[ "underdog" ]
+      ~attempted_cascades:[ "tool_rerank" ]
       (wrapped_claude_limit_error ())
   in
   expect_degraded_retry "next degraded retry"
-    KC.local_recovery_cascade_name "hard_quota" degraded_retry
+    KC.default_cascade_name "hard_quota" degraded_retry
 
-let test_next_fail_open_cascade_for_turn_suppresses_attempted_local_recovery () =
+let test_next_fail_open_cascade_for_turn_continues_to_local_recovery () =
   let degraded_retry =
     UT.next_fail_open_cascade_for_turn
-      ~base_cascade:"underdog"
-      ~effective_cascade:"underdog"
+      ~base_cascade:"tool_rerank"
+      ~effective_cascade:"tool_rerank"
       ~tool_requirement:"optional"
       ~attempted_cascades:
-        [ "underdog"; KC.local_recovery_cascade_name ]
+        [ "tool_rerank"; KC.default_cascade_name ]
       (wrapped_claude_limit_error ())
   in
-  check bool "attempted local_recovery suppressed" true
+  expect_degraded_retry "next degraded retry after default"
+    KC.local_recovery_cascade_name "hard_quota" degraded_retry
+
+let test_next_fail_open_cascade_for_turn_suppresses_exhausted_rotation_group () =
+  let degraded_retry =
+    UT.next_fail_open_cascade_for_turn
+      ~base_cascade:"tool_rerank"
+      ~effective_cascade:"tool_rerank"
+      ~tool_requirement:"optional"
+      ~attempted_cascades:
+        [
+          "tool_rerank";
+          KC.default_cascade_name;
+          KC.local_recovery_cascade_name;
+          KC.tool_use_strict_cascade_name;
+        ]
+      (wrapped_claude_limit_error ())
+  in
+  check bool "exhausted rotation group suppressed" true
     (Option.is_none degraded_retry)
+
+let test_next_fail_open_cascade_for_turn_allows_required_tool_rotation () =
+  let degraded_retry =
+    UT.next_fail_open_cascade_for_turn
+      ~base_cascade:"tool_rerank"
+      ~effective_cascade:KC.tool_use_strict_cascade_name
+      ~tool_requirement:"required"
+      ~attempted_cascades:[ KC.tool_use_strict_cascade_name ]
+      (wrapped_claude_limit_error ())
+  in
+  expect_degraded_retry "required tool degraded retry"
+    "tool_rerank" "hard_quota" degraded_retry
 
 (* context_overflow_limit is now in OAS as Retry.extract_context_limit.
    These tests verify the OAS SSOT API is accessible from MASC. *)
@@ -4983,12 +5013,18 @@ let () =
             test_fallback_cascade_for_unavailable_profile_prefers_default;
           test_case "unavailable phase override fallback prefers base" `Quick
             test_fallback_cascade_for_unavailable_profile_prefers_base_after_phase_override;
-          test_case "next degraded retry returns untried local_recovery"
+          test_case "next degraded retry returns untried default cascade"
             `Quick
-            test_next_fail_open_cascade_for_turn_returns_untried_local_recovery;
-          test_case "next degraded retry suppresses attempted local_recovery"
+            test_next_fail_open_cascade_for_turn_returns_untried_default_cascade;
+          test_case "next degraded retry continues to local_recovery"
             `Quick
-            test_next_fail_open_cascade_for_turn_suppresses_attempted_local_recovery;
+            test_next_fail_open_cascade_for_turn_continues_to_local_recovery;
+          test_case "next degraded retry suppresses exhausted rotation group"
+            `Quick
+            test_next_fail_open_cascade_for_turn_suppresses_exhausted_rotation_group;
+          test_case "required tool turns rotate without dropping requirement"
+            `Quick
+            test_next_fail_open_cascade_for_turn_allows_required_tool_rotation;
         ] );
       ( "tool_classification",
         [


### PR DESCRIPTION
## Summary

- Rotate recoverable keeper cascade failures across untried cascades instead of stopping after same-lane recovery.
- Preserve required-tool turns by excluding local-only/local-recovery lanes when the tool requirement is required.
- Record `cascade.rotation_attempts` in keeper execution receipts and keep dashboard execution-trust fixtures/tests aligned.

## Why

Keeper turns already classify hard quota, timeout-budget, turn-timeout, and filtered-candidate cascade failures as recoverable, but the unified turn path could still terminate after exhausting the active cascade. This lets keepers continue a job through another safe cascade while preserving telemetry for every rotation transition.

## Validation

- `dune build --root . ./test/test_keeper_unified.exe ./test/test_dashboard_execution.exe ./test/test_dashboard_keeper_routes.exe ./test/test_dashboard_goals.exe`
- `dune exec --root . ./test/test_keeper_unified.exe -- test phase_gate 18-21 --show-errors`
- `dune exec --root . ./test/test_dashboard_execution.exe -- --show-errors`
- `dune exec --root . ./test/test_dashboard_keeper_routes.exe -- --show-errors`
- `dune exec --root . ./test/test_dashboard_goals.exe -- --show-errors`
- `git diff --check HEAD`