### PR TITLE
[codex] Reduce keeper dashboard latency

### DIFF
--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -1158,6 +1158,22 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
         | _ -> reason)
     | None -> reason
   in
+  let failure_counts_for_proactive_backoff =
+    is_scheduled_autonomous_cycle
+    &&
+    match sdk_error with
+    | Some err -> (
+        match Oas_worker_named.classify_masc_internal_error err with
+        | Some
+            (Oas_worker_named.Oas_timeout_budget _
+            | Oas_worker_named.Turn_timeout _
+            | Oas_worker_named.Admission_queue_timeout _
+            | Oas_worker_named.Admission_queue_rejected _
+            | Oas_worker_named.Resumable_cli_session _) ->
+            true
+        | Some _ | None -> false)
+    | None -> false
+  in
   let preview =
     let trimmed = String.trim public_reason in
     if trimmed = "" then "keeper cycle failed"
@@ -1195,6 +1211,10 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
         last_preview =
           if is_scheduled_autonomous_cycle then preview
           else meta.runtime.proactive_rt.last_preview;
+        consecutive_noop_count =
+          (if failure_counts_for_proactive_backoff then
+             meta.runtime.proactive_rt.consecutive_noop_count + 1
+           else meta.runtime.proactive_rt.consecutive_noop_count);
       };
       last_speech_act =
         (match social_state with

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -654,6 +654,13 @@ let sdk_error_to_cascade_outcome (err : Oas.Error.sdk_error)
   | Oas.Error.Agent (Oas.Error.UnrecognizedStopReason { reason }) ->
     Some (Cascade_fsm.Call_err
       (Llm_provider.Http_client.AcceptRejected { reason }))
+  | Oas.Error.Config
+      (Oas.Error.InvalidConfig { field = "runtime_mcp_auth"; detail })
+  | Oas.Error.Config
+      (Oas.Error.InvalidConfig { field = "tool_support"; detail }) ->
+    Some
+      (Cascade_fsm.Call_err
+         (Llm_provider.Http_client.AcceptRejected { reason = detail }))
   | _ -> None
 
 let moonshot_auth_hint_marker = "Moonshot returned 401"

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -430,9 +430,37 @@ let keeper_tool_audit_fields ?(include_allowed_tools = true) config
         fallback_snapshot.tool_audit_source,
         fallback_snapshot.tool_audit_at )
 
-let cached_tool_audit_json ~lightweight config (meta : Keeper_types.keeper_meta) =
-  let cache_key = "kta:" ^ meta.name in
-  Dashboard_cache.get_or_compute cache_key ~ttl:2.0 (fun () ->
+let lightweight_tool_audit_fallback_json (meta : Keeper_types.keeper_meta) =
+  let last_autonomous = String.trim meta.runtime.last_autonomous_action_at in
+  let has_runtime_activity =
+    last_autonomous <> ""
+    || meta.runtime.autonomous_turn_count > 0
+    || meta.runtime.autonomous_action_count > 0
+  in
+  `Assoc [
+    ("allowed_tool_names", `List []);
+    ("recent_tool_names", `List []);
+    ("latest_tool_names", `List []);
+    ( "latest_tool_call_count",
+      if has_runtime_activity then `Int 0 else `Null );
+    ("latest_action_source", `Null);
+    ( "tool_audit_source",
+      if has_runtime_activity then `String "keeper_runtime_meta" else `Null );
+    ( "tool_audit_at",
+      if last_autonomous <> "" then `String last_autonomous
+      else if has_runtime_activity then `String meta.updated_at
+      else `Null );
+  ]
+
+let cached_tool_audit_json ~lightweight (config : Coord.config)
+    (meta : Keeper_types.keeper_meta) =
+  let base_hash = Digest.to_hex (Digest.string config.base_path) in
+  let cache_key = "kta:" ^ base_hash ^ ":" ^ meta.name in
+  if lightweight then
+    Dashboard_cache.seed_stale_if_missing cache_key ~stale_for:120.0
+      (lightweight_tool_audit_fallback_json meta);
+  let ttl = if lightweight then 30.0 else 2.0 in
+  Dashboard_cache.get_or_compute cache_key ~ttl (fun () ->
     let allowed_tool_names, recent_tool_names, latest_tool_names,
         latest_tool_call_count, latest_action_source,
         tool_audit_source, tool_audit_at =
@@ -701,7 +729,10 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                    | Some p -> `String (Keeper_state_machine.phase_to_string p)
                    | None -> `Null
                  in
-                 let context_snapshot = keeper_context_snapshot_of_meta config meta in
+                 let context_snapshot =
+                   if lightweight then fallback_keeper_context_snapshot meta
+                   else keeper_context_snapshot_of_meta config meta
+                 in
                  emit_timing_log (Time_compat.now () -. t_work_start);
                  Some
                    (`Assoc

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2993,6 +2993,27 @@ let test_metrics_failure_response () =
   check string "failure transition reason tracked" "failure:run_error"
     updated.runtime.last_social_transition_reason
 
+let test_metrics_failure_timeout_increments_proactive_backoff () =
+  let sdk_error =
+    Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
+      (Masc_mcp.Oas_worker_named.Oas_timeout_budget
+         {
+           budget_sec = 90.0;
+           keeper_turn_timeout_sec = 90.0;
+           estimated_input_tokens = 42_000;
+           source = "test";
+         })
+  in
+  let updated =
+    UM.update_metrics_from_failure minimal_meta ~latency_ms:90
+      ~observation:base_observation
+      ~reason:"OAS budget timeout after 90s" ~sdk_error
+      ~social_transition_reason:"failure:run_error" ()
+  in
+  check int "proactive timeout backoff count +1"
+    (minimal_meta.runtime.proactive_rt.consecutive_noop_count + 1)
+    updated.runtime.proactive_rt.consecutive_noop_count
+
 let test_metrics_failure_response_redacts_resumable_cli_session_detail () =
   let raw_reason =
     "kimi exited with code 75: \nTo resume this session: kimi -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc"
@@ -4735,6 +4756,8 @@ let () =
           test_case "social fields" `Quick
             test_metrics_persist_social_state_fields;
           test_case "failure response" `Quick test_metrics_failure_response;
+          test_case "timeout failure increments proactive backoff" `Quick
+            test_metrics_failure_timeout_increments_proactive_backoff;
           test_case "failure response redacts resumable session detail" `Quick
             test_metrics_failure_response_redacts_resumable_cli_session_detail;
           test_case "mixed response" `Quick test_metrics_mixed_response;

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -754,6 +754,27 @@ let test_sdk_error_to_cascade_outcome_keeps_invalid_request_as_400 () =
          | Some Cascade_fsm.Slot_full -> "some-slot-full"
          | None -> "none")
 
+let test_sdk_error_to_cascade_outcome_cascades_runtime_mcp_auth_config () =
+  let detail = "codex_cli runtime MCP cannot carry keeper-bound auth headers" in
+  let err =
+    Oas.Error.Config
+      (Oas.Error.InvalidConfig { field = "runtime_mcp_auth"; detail })
+  in
+  match Oas_worker_named.sdk_error_to_cascade_outcome err with
+  | Some
+      (Cascade_fsm.Call_err
+         (Llm_provider.Http_client.AcceptRejected { reason })) ->
+      Alcotest.(check string) "reason preserved" detail reason
+  | outcome ->
+      Alcotest.failf
+        "expected runtime_mcp_auth InvalidConfig to cascade as AcceptRejected, got %s"
+        (match outcome with
+         | Some (Cascade_fsm.Call_err _) -> "some-call-err"
+         | Some (Cascade_fsm.Accept_rejected _) -> "some-accept-rejected"
+         | Some (Cascade_fsm.Call_ok _) -> "some-call-ok"
+         | Some Cascade_fsm.Slot_full -> "some-slot-full"
+         | None -> "none")
+
 let make_openai_compat_provider_cfg ?(model_id = "mock-model")
     ?(base_url = "http://127.0.0.1:18080/v1")
     ?(request_path = "/chat/completions") ?(api_key = "") () =
@@ -3240,6 +3261,8 @@ let () =
         test_sdk_error_to_cascade_outcome_maps_not_found_to_404;
       Alcotest.test_case "sdk_error_to_cascade_outcome keeps ordinary InvalidRequest at 400" `Quick
         test_sdk_error_to_cascade_outcome_keeps_invalid_request_as_400;
+      Alcotest.test_case "sdk_error_to_cascade_outcome cascades runtime MCP auth config" `Quick
+        test_sdk_error_to_cascade_outcome_cascades_runtime_mcp_auth_config;
       Alcotest.test_case "Moonshot auth errors include configured env hint" `Quick
         test_enrich_sdk_error_for_moonshot_auth_includes_env_hint;
       Alcotest.test_case "OpenAI-compatible 404 errors include endpoint hint" `Quick

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -183,7 +183,6 @@ let test_snapshot_prefers_metrics_context_truth_over_usage_counters () =
       let json =
         Operator_control.snapshot_json ~view:"summary"
           ~include_keepers:true ~include_messages:false
-          ~lightweight_summary:true
           (operator_ctx env sw config "owner")
       in
       let keeper =
@@ -427,10 +426,14 @@ let test_snapshot_lightweight_summary_omits_heavy_activity () =
 let test_snapshot_lightweight_summary_keeps_tool_audit () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
+  Eio_guard.enable ();
+  Dashboard_cache.invalidate_all ();
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
+      Dashboard_cache.invalidate_all ();
+      Eio_guard.disable ();
       Keeper_keepalive.stop_keepalive "lightweight-audit";
       Keeper_registry.clear ();
       Keeper_runtime.reset_test_state base_dir;
@@ -483,6 +486,32 @@ let test_snapshot_lightweight_summary_keeps_tool_audit () =
             ("tool_call_count", `Int 0);
             ("tools_used", `List []);
           ]);
+      let meta =
+        match Keeper_types.read_meta config keeper_name with
+        | Ok (Some meta) -> meta
+        | Ok None -> Alcotest.fail "expected keeper meta"
+        | Error err -> Alcotest.fail err
+      in
+      let first_audit =
+        Operator_control_snapshot.cached_tool_audit_json ~lightweight:true
+          config meta
+      in
+      Alcotest.(check bool) "lightweight audit returns fallback immediately" true
+        (Yojson.Safe.Util.member "tool_audit_source" first_audit = `Null);
+      let rec wait_for_metrics attempts =
+        let audit =
+          Operator_control_snapshot.cached_tool_audit_json ~lightweight:true
+            config meta
+        in
+        match Yojson.Safe.Util.member "tool_audit_source" audit with
+        | `String "keeper_metrics" -> audit
+        | _ when attempts > 0 ->
+            Eio.Time.sleep (Eio.Stdenv.clock env) 0.05;
+            wait_for_metrics (attempts - 1)
+        | _ -> Alcotest.fail "expected refreshed lightweight tool audit"
+      in
+      ignore (wait_for_metrics 20);
+      Operator_control.invalidate_snapshot_cache ();
       let json =
         Operator_control.snapshot_json ~view:"summary"
           ~include_keepers:true ~include_messages:false
@@ -511,10 +540,15 @@ let test_snapshot_lightweight_summary_keeps_tool_audit () =
 let test_snapshot_lightweight_summary_keeps_recent_tools_distinct_from_latest () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
+  Eio_guard.enable ();
+  Dashboard_cache.invalidate_all ();
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   Fun.protect
-    ~finally:(fun () -> cleanup_dir base_dir)
+    ~finally:(fun () ->
+      Dashboard_cache.invalidate_all ();
+      Eio_guard.disable ();
+      cleanup_dir base_dir)
     (fun () ->
       let config = Coord.default_config base_dir in
       ignore (Coord.init config ~agent_name:(Some "owner"));
@@ -562,6 +596,31 @@ let test_snapshot_lightweight_summary_keeps_recent_tools_distinct_from_latest ()
               ("tools_used", `List []);
             ])
       done;
+      let meta =
+        match Keeper_types.read_meta config keeper_name with
+        | Ok (Some meta) -> meta
+        | Ok None -> Alcotest.fail "expected keeper meta"
+        | Error err -> Alcotest.fail err
+      in
+      ignore
+        (Operator_control_snapshot.cached_tool_audit_json ~lightweight:true
+           config meta);
+      let rec wait_for_recent_tools attempts =
+        let audit =
+          Operator_control_snapshot.cached_tool_audit_json ~lightweight:true
+            config meta
+        in
+        let recent =
+          Yojson.Safe.Util.(audit |> member "recent_tool_names" |> to_list)
+        in
+        if recent <> [] then audit
+        else if attempts > 0 then (
+          Eio.Time.sleep (Eio.Stdenv.clock env) 0.05;
+          wait_for_recent_tools (attempts - 1))
+        else Alcotest.fail "expected refreshed lightweight recent tools"
+      in
+      ignore (wait_for_recent_tools 20);
+      Operator_control.invalidate_snapshot_cache ();
       let json =
         Operator_control.snapshot_json ~view:"summary"
           ~include_keepers:true ~include_messages:false


### PR DESCRIPTION
## Summary

- return lightweight dashboard keeper snapshots from fallback data immediately, then refresh metrics-backed tool audits in the background
- key keeper tool-audit cache entries by `base_path` to avoid cross-worktree/runtime cache bleed
- make runtime MCP auth/tool-support config mismatches cascadeable and add proactive backoff accounting for long timeout failures

## Validation

- `dune build @check --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/perf-basepath-latency-20260424`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/perf-basepath-latency-20260424 ./test/test_oas_worker.exe -- test cascade_config 19-21`
- `env MASC_INCLUDE_OPERATOR_CONTROL=true dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/perf-basepath-latency-20260424 ./test/test_operator_control.exe -- test operator 11,12`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/perf-basepath-latency-20260424 ./test/test_keeper_unified.exe -- test metrics_observation 21`
