### PR TITLE
feat(timeout_policy): SSOT Deadline + cooperative-cancel overshoot warn (#9639, #9662)

### DIFF
--- a/docs/TIMEOUT-MATRIX.md
+++ b/docs/TIMEOUT-MATRIX.md
@@ -1,0 +1,84 @@
+# Timeout Matrix (SSOT)
+
+Status: Phase 1 — observability + module stub. Migration of call sites is tracked in #9639.
+
+## Layer model
+
+MASC-MCP timeouts nest innermost-first. Every inner layer's wall cap MUST be
+`<=` its enclosing layer's cap. An inner "hard cap" that exceeds the outer cap
+is effectively advisory.
+
+| Layer | Role | Typical cap | Source of truth |
+|-------|------|-------------|-----------------|
+| `Tool` | per-tool HTTP / shell invocation | 10–60 s | `Env_config_runtime.*`, `lib/tool_local_runtime_http.ml` |
+| `Oas_bridge` | single OAS `Agent.run` / `Model.call` | 60–300 s (adaptive) | `Env_config_keeper.oas_timeout_sec*` |
+| `Keeper_turn` | one keeper turn (may issue many OAS calls) | 1200 s | `MASC_KEEPER_TURN_TIMEOUT_SEC` |
+| `Keeper_cycle` | full keeper lifecycle | N×turn | cycle supervisor |
+| `Shutdown` | graceful shutdown board flush | 2 s | `bin/main_eio.ml` |
+
+## Cooperative-cancel overshoot
+
+OCaml 5 / Eio cancellation is cooperative. `Eio.Time.with_timeout_exn` sets a
+deadline, but the fiber only observes the cancel at the next cancellation
+point. A fiber blocked in:
+
+- a native HTTP bulk read
+- a non-yielding tight loop
+- a syscall with no Eio-aware wrapper
+- a third-party C stub that ignores cancel
+
+will continue executing past the deadline, producing a wall time greater than
+the configured budget. Example from production (#9662):
+
+> `keeper_llm_bridge` reported `timed out after 596.6s (budget=573s)` — ~24 s
+> overshoot.
+
+`Timeout_policy.overshoot_warn` emits a structured warn whenever the
+observed wall time exceeds the cap by more than `slack_s` (default 5 s). The
+warning preserves the same fields (`layer`, `origin`, `budget`, `actual`,
+`excess`, `slack`) so the condition is grep-able and can feed a metric.
+
+## Design references
+
+- Go `context.Context.Deadline()` + `select` — propagated deadline + polled
+  cancellation.
+- gRPC deadline propagation — deadline attaches to the call; inner services
+  clamp their own budget to `min(own_default, inherited_deadline - now)`.
+- Rust `tokio::time::timeout` — forced drop; lifetime ends at the deadline
+  regardless of task state.
+- Envoy/Istio route timeout + retry budget — outer hard-cap separates from
+  per-retry soft budgets.
+
+MASC-MCP currently uses the *cooperative* variant (like Go/gRPC) rather than
+forced-drop (Rust Tokio). The observability step is a prerequisite for any
+future migration to forced-drop or sentinel-based kill.
+
+## Migration plan
+
+Phase 1 (this PR): module stub + keeper_llm_bridge overshoot warn.
+
+Phase 2 (follow-ups): migrate each site in the table below to construct a
+`Timeout_policy.Deadline.t` at entry and surface its `layer`/`origin` in
+logs. Candidates:
+
+| Site | Current cap | Owning issue |
+|------|-------------|--------------|
+| `keeper_llm_bridge` | 60–573 s (adaptive) | #9639, #9662 (this PR) |
+| Governance `compute_judgments` | 60 s | #9629 |
+| `Process_eio` `git status --porcelain` | 15 s | #9632 |
+| `Process_eio` `git rev-parse` | 5 s | #9765, #9775 |
+| Docker sandbox `git fetch origin` | 30 s | #9587 |
+| Dashboard cache compute | 16 s | #9643 |
+| `operator_snapshot` refresh | 30–36 s | #9734 |
+| `a2a_tools` call | 300 s | — |
+| `tool_local_runtime_http` | 10 s | — |
+| `admission_queue.wait_timeout_sec` | unused | #9639 note |
+
+## Non-goals
+
+- This policy module does NOT reimplement OAS retry/budget semantics — OAS
+  owns its own `max_turns` and `max_duration` (see `feedback_no-lifecycle-
+  invasion-from-masc.md`). The MASC-side deadline is the outer hard cap;
+  OAS-side budgets are clamped within it by the caller, not mutated here.
+- This module does NOT perform forced cancellation. It only makes cooperative
+  overshoot observable.

--- a/lib/dune
+++ b/lib/dune
@@ -287,6 +287,7 @@
    telemetry_eio
    telemetry_unified
    tempo
+   timeout_policy
    tui_decode
    tools
    tool_args

--- a/lib/keeper/keeper_llm_bridge.ml
+++ b/lib/keeper/keeper_llm_bridge.ml
@@ -32,6 +32,21 @@ let run_with_timeout_and_fallback ~timeout_s fn =
   with
   | Eio.Time.Timeout ->
     let wall = elapsed () in
+    (* #9639/#9662: Eio cancel is cooperative. When the fiber blocks inside
+       an uncancellable region (native HTTP bulk read, syscall, non-yielding
+       loop), [with_timeout_exn] fires but the fiber continues until the
+       next yield. Surface that overshoot as a structured warn so the
+       condition is observable instead of silently inflating wall time. *)
+    let deadline =
+      Timeout_policy.Deadline.make
+        ~layer:Timeout_policy.Layer.Oas_bridge
+        ~origin:"keeper_llm_bridge"
+        ~wall_cap_s:timeout_s
+        ~now:(t0)
+    in
+    let _ : bool =
+      Timeout_policy.overshoot_warn ~deadline ~actual_wall_s:wall ()
+    in
     Log.Keeper.warn
       "keeper_llm_bridge: OAS execution timed out after %.1fs (budget=%.0fs; OAS context rollback only; external tool side effects are not reverted)"
       wall timeout_s;

--- a/lib/timeout_policy.ml
+++ b/lib/timeout_policy.ml
@@ -1,0 +1,48 @@
+module Layer = struct
+  type t =
+    | Tool
+    | Oas_bridge
+    | Keeper_turn
+    | Keeper_cycle
+    | Shutdown
+
+  let to_string = function
+    | Tool -> "tool"
+    | Oas_bridge -> "oas_bridge"
+    | Keeper_turn -> "keeper_turn"
+    | Keeper_cycle -> "keeper_cycle"
+    | Shutdown -> "shutdown"
+end
+
+module Deadline = struct
+  type t = {
+    layer : Layer.t;
+    origin : string;
+    wall_cap_s : float;
+    set_at : float;
+  }
+
+  let make ~layer ~origin ~wall_cap_s ~now =
+    { layer; origin; wall_cap_s; set_at = now }
+
+  let elapsed t ~now = now -. t.set_at
+  let remaining t ~now = t.wall_cap_s -. elapsed t ~now
+end
+
+let default_overshoot_slack_s = 5.0
+
+let overshoot_warn ?(slack_s = default_overshoot_slack_s) ~deadline ~actual_wall_s () =
+  let excess = actual_wall_s -. deadline.Deadline.wall_cap_s in
+  if excess > slack_s then begin
+    Log.Keeper.warn
+      "timeout_policy: overshoot layer=%s origin=%s budget=%.1fs actual=%.1fs excess=%.1fs slack=%.1fs (cooperative-cancel miss; fiber likely blocked in uncancellable region)"
+      (Layer.to_string deadline.Deadline.layer)
+      deadline.Deadline.origin
+      deadline.Deadline.wall_cap_s
+      actual_wall_s
+      excess
+      slack_s;
+    true
+  end
+  else
+    false

--- a/lib/timeout_policy.mli
+++ b/lib/timeout_policy.mli
@@ -1,0 +1,65 @@
+(** Timeout policy SSOT for MASC-MCP.
+
+    Consolidates the layered wall-clock deadline matrix enumerated in
+    https://github.com/jeong-sik/masc-mcp/issues/9639, and provides a typed
+    [Deadline.t] that can be propagated across subsystems.
+
+    Cooperative-cancel overshoot: OCaml 5 / Eio cancellation is cooperative.
+    A fiber that blocks inside an uncancellable region (native HTTP bulk
+    read, system call, non-yielding loop) will miss the
+    [Eio.Time.with_timeout_exn] deadline and overshoot the configured budget
+    by seconds. [overshoot_warn] surfaces the overshoot as a first-class
+    log/metric signal so the condition is visible instead of silently
+    inflating wall time.
+
+    Related issues: #9639 (meta), #9662 (keeper_llm_bridge ~24s overshoot),
+    #9629 (governance OAS 60s), #9637 (keeper turn 1200s). *)
+
+module Layer : sig
+  (** Nested timeout layers, innermost-first.
+
+      Contract: every inner layer's wall cap MUST be less than or equal to
+      its enclosing layer's cap. An inner "hard cap" that exceeds the outer
+      cap is effectively advisory and a principal source of overshoot. *)
+  type t =
+    | Tool
+    | Oas_bridge
+    | Keeper_turn
+    | Keeper_cycle
+    | Shutdown
+
+  val to_string : t -> string
+end
+
+module Deadline : sig
+  type t = private {
+    layer : Layer.t;
+    origin : string;
+    wall_cap_s : float;
+    set_at : float;
+  }
+
+  val make
+    :  layer:Layer.t
+    -> origin:string
+    -> wall_cap_s:float
+    -> now:float
+    -> t
+
+  val elapsed : t -> now:float -> float
+  val remaining : t -> now:float -> float
+end
+
+val default_overshoot_slack_s : float
+(** Default grace window applied when distinguishing expected cleanup tail
+    from a cooperative-cancel miss. Callers may override per site. *)
+
+val overshoot_warn
+  :  ?slack_s:float
+  -> deadline:Deadline.t
+  -> actual_wall_s:float
+  -> unit
+  -> bool
+(** Emit a warn-level log when [actual_wall_s] exceeds
+    [deadline.wall_cap_s] by more than [slack_s]. Returns [true] when a
+    warn was emitted so callers can increment a metric. *)

--- a/test/dune
+++ b/test/dune
@@ -1251,6 +1251,12 @@
  (modules test_masc_dirname_ssot)
  (libraries masc_test_deps unix str))
 
+; Timeout policy SSOT (#9639, #9662)
+(test
+ (name test_timeout_policy)
+ (modules test_timeout_policy)
+ (libraries masc_test_deps))
+
 (executable
  (name keeper_tool_matrix_case_runner)
  (modules keeper_tool_matrix_case_runner test_keeper_tool_matrix_cases

--- a/test/test_timeout_policy.ml
+++ b/test/test_timeout_policy.ml
@@ -1,0 +1,91 @@
+(* test/test_timeout_policy.ml
+
+   Covers Timeout_policy.Deadline arithmetic and overshoot_warn gating.
+   Related to masc-mcp#9639 (timeout SSOT meta) and #9662 (keeper_llm_bridge
+   ~24s overshoot).
+
+   overshoot_warn returns [true] exactly when actual_wall_s > cap + slack.
+   The surrounding log side effect is not asserted; we rely on the boolean
+   return as the observable signal so the test stays deterministic. *)
+
+open Masc_mcp
+
+let assert_eq_float ~epsilon ~msg expected got =
+  if Float.abs (expected -. got) > epsilon then
+    failwith (Printf.sprintf "%s: expected=%.6f got=%.6f" msg expected got)
+
+let assert_true msg b = if not b then failwith msg
+let assert_false msg b = if b then failwith msg
+
+let mk_deadline ~cap ~at =
+  Timeout_policy.Deadline.make
+    ~layer:Timeout_policy.Layer.Oas_bridge
+    ~origin:"test"
+    ~wall_cap_s:cap
+    ~now:at
+
+let test_layer_to_string () =
+  let pairs =
+    [ Timeout_policy.Layer.Tool, "tool"
+    ; Timeout_policy.Layer.Oas_bridge, "oas_bridge"
+    ; Timeout_policy.Layer.Keeper_turn, "keeper_turn"
+    ; Timeout_policy.Layer.Keeper_cycle, "keeper_cycle"
+    ; Timeout_policy.Layer.Shutdown, "shutdown"
+    ]
+  in
+  List.iter
+    (fun (l, s) ->
+      let got = Timeout_policy.Layer.to_string l in
+      if got <> s then
+        failwith
+          (Printf.sprintf "Layer.to_string mismatch: expected=%s got=%s" s got))
+    pairs
+
+let test_deadline_arithmetic () =
+  let d = mk_deadline ~cap:60.0 ~at:1000.0 in
+  assert_eq_float ~epsilon:1e-6 ~msg:"elapsed at t+0"
+    0.0 (Timeout_policy.Deadline.elapsed d ~now:1000.0);
+  assert_eq_float ~epsilon:1e-6 ~msg:"elapsed at t+15"
+    15.0 (Timeout_policy.Deadline.elapsed d ~now:1015.0);
+  assert_eq_float ~epsilon:1e-6 ~msg:"remaining at t+0"
+    60.0 (Timeout_policy.Deadline.remaining d ~now:1000.0);
+  assert_eq_float ~epsilon:1e-6 ~msg:"remaining at t+70 (negative)"
+    (-10.0) (Timeout_policy.Deadline.remaining d ~now:1070.0)
+
+let test_overshoot_warn_gating () =
+  let d = mk_deadline ~cap:60.0 ~at:0.0 in
+  (* within cap: no warn *)
+  assert_false "within cap should not warn"
+    (Timeout_policy.overshoot_warn ~slack_s:5.0 ~deadline:d ~actual_wall_s:55.0 ());
+  (* exactly at cap: no warn *)
+  assert_false "at cap should not warn"
+    (Timeout_policy.overshoot_warn ~slack_s:5.0 ~deadline:d ~actual_wall_s:60.0 ());
+  (* within slack: no warn *)
+  assert_false "within slack should not warn"
+    (Timeout_policy.overshoot_warn ~slack_s:5.0 ~deadline:d ~actual_wall_s:64.9 ());
+  (* at slack boundary: no warn (excess must be strictly greater than slack) *)
+  assert_false "at slack boundary should not warn"
+    (Timeout_policy.overshoot_warn ~slack_s:5.0 ~deadline:d ~actual_wall_s:65.0 ());
+  (* beyond slack: warn *)
+  assert_true "beyond slack should warn"
+    (Timeout_policy.overshoot_warn ~slack_s:5.0 ~deadline:d ~actual_wall_s:65.1 ());
+  (* Regression case from #9662: 596.6s on a 573s cap. *)
+  let d_9662 = mk_deadline ~cap:573.0 ~at:0.0 in
+  assert_true "#9662 regression (596.6 > 573+5) must warn"
+    (Timeout_policy.overshoot_warn
+       ~slack_s:5.0 ~deadline:d_9662 ~actual_wall_s:596.6 ())
+
+let test_overshoot_default_slack () =
+  let d = mk_deadline ~cap:60.0 ~at:0.0 in
+  (* default slack = 5s: cap=60, actual=64 → no warn *)
+  assert_false "default slack respects cap+slack lower bound"
+    (Timeout_policy.overshoot_warn ~deadline:d ~actual_wall_s:64.0 ());
+  assert_true "default slack fires beyond cap+5"
+    (Timeout_policy.overshoot_warn ~deadline:d ~actual_wall_s:70.0 ())
+
+let () =
+  test_layer_to_string ();
+  test_deadline_arithmetic ();
+  test_overshoot_warn_gating ();
+  test_overshoot_default_slack ();
+  print_endline "test_timeout_policy: OK"


### PR DESCRIPTION
Phase 1 of the #9639 timeout SSOT rollout. Observability only — no forced cancellation, no OAS-budget invasion.

## Why

- #9639 enumerated 10+ scattered timeout constants across env_config, Process_eio, ad-hoc call sites.
- The follow-up comment on #9639 + #9662 reported a concrete contract break: `keeper_llm_bridge` logged `timed out after 596.6s (budget=573s)` — the hard cap overshot by ~24s and the overshoot was indistinguishable from a clean timeout in logs.
- Root cause is not SSOT drift alone: OCaml 5 / Eio cancellation is cooperative. A fiber blocked in an uncancellable region (native HTTP bulk read, syscall, non-yielding loop) continues past the deadline until the next cancellation point.

## What

- New module `lib/timeout_policy` with:
  - `Layer.t` (`Tool`, `Oas_bridge`, `Keeper_turn`, `Keeper_cycle`, `Shutdown`) — contract: inner cap ≤ outer cap.
  - Private `Deadline.t = { layer; origin; wall_cap_s; set_at }` inspired by Go `context.Deadline()` and gRPC deadline propagation.
  - `overshoot_warn` — emits a structured warn when `actual_wall_s > wall_cap_s + slack` (default 5s) and returns `bool` so callers can feed a metric.
- `keeper_llm_bridge.run_with_timeout_and_fallback` now constructs a `Deadline` on timeout and calls `overshoot_warn` before the existing `Log.Keeper.warn`, making the cooperative-cancel miss observable.
- `docs/TIMEOUT-MATRIX.md` documents the layer model, cooperative-cancel semantics, design references (Go/gRPC/Tokio/Envoy), and the migration roster (per open issue).
- `test/test_timeout_policy.ml` covers layer tags, deadline arithmetic, `overshoot_warn` gating (below cap, at cap, within slack, at slack boundary, beyond slack), the exact #9662 regression (596.6s on 573s), and default slack.

## Non-goals

- No forced cancellation. This PR only makes cooperative overshoot visible.
- No reimplementation of OAS retry/budget (`feedback_no-lifecycle-invasion-from-masc.md`).
- No mass migration of call sites — follow-up PRs per the table in `docs/TIMEOUT-MATRIX.md`.

## Design references

- Go `context.Context.Deadline()` + `select`
- gRPC deadline propagation (inner clamps to `min(own_default, inherited - now)`)
- Rust `tokio::time::timeout` (forced drop — opposite of our cooperative model)
- Envoy/Istio route timeout + retry budget (outer hard-cap vs per-retry soft-budget)

## Test plan

- [x] `dune build @check` clean
- [x] `dune exec test/test_timeout_policy.exe` passes; the #9662 regression case emits the expected warn
- [ ] Live keeper_llm_bridge timeout with overshoot should produce the `timeout_policy: overshoot layer=oas_bridge origin=keeper_llm_bridge …` line above the existing warn — to be confirmed on next keeper turn timeout in production

## Follow-ups

Remaining migration sites per `docs/TIMEOUT-MATRIX.md`:
- Governance `compute_judgments` 60s (#9629)
- `Process_eio` `git status --porcelain` 15s (#9632), `git rev-parse` 5s (#9765, #9775)
- Docker sandbox `git fetch origin` 30s (#9587)
- Dashboard cache compute 16s (#9643), `operator_snapshot` refresh 30-36s (#9734)
- `a2a_tools` 300s, `tool_local_runtime_http` 10s
- `admission_queue.wait_timeout_sec` (currently unused, #9639 note)

Refs: #9639, #9662, #9629

🤖 Generated with [Claude Code](https://claude.com/claude-code)