### PR TITLE
fix(mcp-server): advertise masc_start as primary recovery in join guard (#9770)

### DIFF
--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -533,12 +533,12 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   if join_required && not room_initialized then
     with_system_internal_audit ~agent_name
       (false, Printf.sprintf
-         "⚠️ MASC room not initialized.\n\n💡 Workflow: masc_init → masc_join → masc_status → %s\n📚 See: @~/me/instructions/masc-workflow.md\n[DEBUG] agent_name=%s room_initialized=%b"
-         name agent_name room_initialized)
+         "⚠️ MASC room not initialized.\n\n💡 Fastest: masc_start(path=\"<project>\") — one-step init+join, then call %s.\n💡 Alternative: masc_init → masc_join → masc_status → %s\n📚 See: @~/me/instructions/masc-workflow.md\n[DEBUG] agent_name=%s room_initialized=%b"
+         name name agent_name room_initialized)
   else if join_required && not is_joined then
     with_system_internal_audit ~agent_name
       (false, Printf.sprintf
-         "❌ Join required: Call masc_join first before using %s.\n\n💡 Workflow: masc_join → masc_status → %s\n📚 See: @~/me/instructions/masc-workflow.md\n[DEBUG] agent_name=%s is_joined=%b"
+         "❌ Join required before using %s.\n\n💡 Fastest: masc_start(path=\"<project>\") — one-step join with room scope.\n💡 Alternative: masc_join → masc_status → %s\n📚 See: @~/me/instructions/masc-workflow.md\n[DEBUG] agent_name=%s is_joined=%b"
          name name agent_name is_joined)
   else (
 


### PR DESCRIPTION
## 목표

Issue #9770 — `masc_claim_next` 등 가드 실패 시 반복되는 workflow violation을 줄이기 위해, 가드 에러 메시지가 3-step 복구(`masc_join → masc_status → claim`) 대신 **1-step `masc_start`를 primary**로 안내하도록 수정.

## 변경 내용

`lib/mcp_server_eio_execute.ml` line 533-545의 두 가드 메시지:

- `room_initialized=false`: "Fastest: masc_start(path=...)" 를 최상단에 배치, 기존 3-step은 "Alternative"로 보존.
- `is_joined=false`: 동일 구조로 재작성. "Call masc_join first before using X" 문구 제거(명령조 대신 remediation 제시).

## 왜 이게 근본 수정인가

이슈 #9770의 반복 패턴 원인은 가드 자체가 아니라 **가드가 LLM에게 긴 경로를 가르친 것**. Memory `Tool error messages teach LLM`:

> terse "X not allowed" → LLM retry 루프. 실패 사유별 redirect/context/search-hint로 수렴.

현재 에러 메시지는 `masc_error_recovery.ml:16`이 이미 알고 있던 1-step `masc_start` hint를 노출하지 않았음. 이번 변경은 가드 계층에서 직접 1-step 경로를 제시해 primary effect(첫 예시 선호 복제)를 활용.

## 로컬 검증

- `dune build @check` exit 0 (Printf arity type-check 통과)
- `dune exec test/test_mcp_server_eio.exe`: 67/69 pass
- Pre-existing failures 2건(`state 2 eio context delegation`, `eio 45 explicit alias reuses joined nickname`)은 origin/main에도 동일 발생 → 본 PR 무관
- 기존 테스트가 변경된 문자열에 의존하지 않음을 `grep` 확인

## 가드 동작 변경 없음

- `resolve_join_state` 로직 그대로
- 거부 + audit 그대로
- 메시지 문자열만 교체

## 미검증 / Follow-up

- 풀 `dune runtest` 미실행 (범위 밖)
- CI green 여부는 GitHub Actions 결과 대기
- Pre-existing 테스트 실패 2건은 별도 이슈로 분리 후보
- LLM 행동 변화 실측(`masc_start` 호출 비율)은 production 관측 필요

## 관련

- Refs #9770
- 설계 근거 코멘트: https://github.com/jeong-sik/masc-mcp/issues/9770#issuecomment-4310890527

---

_/loop masc-mcp issues 하나씩 근본 해결 — cycle 3 PR_