### PR TITLE
[codex] Filter codex bound actor tool lane

### DIFF
--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -151,6 +151,9 @@ let dedupe_preserve_order =
 let public_mcp_tool_names_of_oas_tools =
   Oas_worker_exec_transport.public_mcp_tool_names_of_oas_tools
 
+let public_mcp_tool_requires_bound_actor =
+  Oas_worker_exec_transport.public_mcp_tool_requires_bound_actor
+
 let runtime_mcp_policy_with_masc_agent_name =
   Oas_worker_exec_transport.runtime_mcp_policy_with_masc_agent_name
 

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -94,6 +94,18 @@ let runtime_mcp_policy_for_provider
   Oas_worker_exec.runtime_mcp_policy_for_provider
     ~provider_cfg ~agent_name policy_opt
 
+let codex_cli_cannot_carry_keeper_bound_runtime_mcp
+    ~(keeper_name : string)
+    ~(provider_cfg : Llm_provider.Provider_config.t)
+    (policy_opt : Llm_provider.Llm_transport.runtime_mcp_policy option) =
+  match provider_cfg.kind, keeper_agent_name_opt keeper_name, policy_opt with
+  | Llm_provider.Provider_config.Codex_cli, Some agent_name, Some policy
+    when Option.is_some (Keeper_identity.keeper_name_from_agent_name agent_name)
+    ->
+      List.exists Oas_worker_exec.public_mcp_tool_requires_bound_actor
+        policy.allowed_tool_names
+  | _ -> false
+
 let filter_candidate_providers_for_tool_support
     ~(keeper_name : string)
     ?runtime_mcp_policy
@@ -111,7 +123,10 @@ let filter_candidate_providers_for_tool_support
              runtime_mcp_policy_for_provider
                ~keeper_name ~provider_cfg runtime_mcp_policy
            in
-           Provider_tool_support.supports_required_tool_use
+           (not
+              (codex_cli_cannot_carry_keeper_bound_runtime_mcp
+                 ~keeper_name ~provider_cfg normalized_runtime_mcp_policy))
+           && Provider_tool_support.supports_required_tool_use
              ?runtime_mcp_policy:normalized_runtime_mcp_policy
              ~require_tool_choice_support
              ~require_tool_support

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1710,6 +1710,31 @@ let test_filter_candidate_providers_for_tool_support_normalizes_codex_headers ()
     "codex survives provider-normalized runtime MCP tool filter"
     1 (List.length filtered)
 
+let test_filter_candidate_providers_for_tool_support_drops_codex_cli_keeper_bound_actor_tools
+    () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  let runtime_mcp_policy =
+    Oas_worker_exec.public_mcp_runtime_policy_of_tool_names
+      ~agent_name:"keeper-sangsu-agent" [ "masc_status"; "masc_claim_next" ]
+  in
+  let filtered =
+    Masc_mcp.Oas_worker_named.filter_candidate_providers_for_tool_support
+      ~keeper_name:"sangsu"
+      ?runtime_mcp_policy
+      ~require_tool_choice_support:true
+      ~require_tool_support:true
+      ~label:"tool_use_strict"
+      [ make_codex_cli_provider_cfg (); make_kimi_cli_provider_cfg () ]
+  in
+  match filtered with
+  | [ provider_cfg ] ->
+      Alcotest.(check bool) "kimi remains after codex bound-actor filter" true
+        (provider_cfg.kind = Llm_provider.Provider_config.Kimi_cli)
+  | _ ->
+      Alcotest.failf "expected only kimi_cli provider to remain, got %d"
+        (List.length filtered)
+
 let test_kimi_mcp_config_json_of_policy_filters_to_allowed_servers () =
   let policy =
     {
@@ -3314,6 +3339,10 @@ let () =
         test_resolve_tool_lane_for_codex_cli_internal_tools_optional_drops_tools;
       Alcotest.test_case "provider-normalized filter keeps codex public MCP lane" `Quick
         test_filter_candidate_providers_for_tool_support_normalizes_codex_headers;
+      Alcotest.test_case
+        "provider-normalized filter drops codex keeper-bound actor tools"
+        `Quick
+        test_filter_candidate_providers_for_tool_support_drops_codex_cli_keeper_bound_actor_tools;
       Alcotest.test_case "kimi runtime MCP config keeps only allowed servers" `Quick
         test_kimi_mcp_config_json_of_policy_filters_to_allowed_servers;
       Alcotest.test_case "runtime MCP policy injects keeper agent header for masc server" `Quick


### PR DESCRIPTION
## What changed

- Filter `codex_cli` out of required tool-use cascade candidates when the runtime MCP policy includes keeper-bound public tools such as `masc_claim_next`, `masc_transition`, or `masc_plan_set_task`.
- Expose the existing bound-actor tool predicate through `Oas_worker_exec` so the named-cascade provider filter uses the same contract as the execution-time lane resolver.
- Add a regression test proving `codex_cli` is dropped while a runtime-MCP-capable provider such as `kimi_cli` remains available.

## Why

`tool_use_strict` could pass `codex_cli` through the provider capability filter, then fail immediately during per-provider lane resolution with `Invalid config 'runtime_mcp_auth'`. That made a provider capability mismatch surface as a keeper cycle failure instead of falling through to the next valid strict tool-capable provider.

## Validation

- `git diff --check`
- `opam exec -- dune build --root . --stop-on-first-error test/test_oas_worker.exe`
- `env ALCOTEST_QUICK_TESTS=1 _build/default/test/test_oas_worker.exe` (103 tests)
- `opam exec -- dune build --root . --stop-on-first-error`