### PR TITLE
fix(keeper): cancel-safe turn cleanup — replace Fun.protect that swallowed Cancelled (#9747)

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -960,11 +960,29 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         cascade_rotation_attempts := attempt :: !cascade_rotation_attempts
       in
       let run_result, latency_ms =
-        Fun.protect ~finally:(fun () ->
-          unsubscribe_event_bus ();
-          Keeper_registry.mark_turn_finished
-            ~base_path:config.base_path meta.name)
-        (fun () ->
+        (* Cancel-safe cleanup (#9747): stdlib [Fun.protect] wraps cleanup
+           exceptions in [Fun.Finally_raised], losing the outer
+           [Eio.Cancel.Cancelled]. Cleanup here swallows Cancelled (the
+           outer one is already in flight) and logs non-cancel exceptions
+           instead of propagating them. *)
+        let cleanup () =
+          (try unsubscribe_event_bus () with
+           | Eio.Cancel.Cancelled _ -> ()
+           | e ->
+             Log.Keeper.warn
+               "%s: unsubscribe_event_bus in turn cleanup raised: %s"
+               meta.name (Printexc.to_string e));
+          (try
+             Keeper_registry.mark_turn_finished
+               ~base_path:config.base_path meta.name
+           with
+           | Eio.Cancel.Cancelled _ -> ()
+           | e ->
+             Log.Keeper.warn
+               "%s: mark_turn_finished in turn cleanup raised: %s"
+               meta.name (Printexc.to_string e))
+        in
+        match
         Keeper_exec_context.timed (fun () ->
           match Eio_context.get_clock () with
           | Error msg -> Error (Oas.Error.Internal msg)
@@ -1459,7 +1477,10 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                 (Oas_worker_named.sdk_error_of_masc_internal_error
                    (Oas_worker_named.Turn_timeout
                       { elapsed_sec = timeout_sec }))
-            end)))
+            end))
+        with
+        | result -> cleanup (); result
+        | exception e -> cleanup (); raise e
       in
       let turn_event_bus = drain_turn_event_bus () in
       (match turn_event_bus.correlation_id with


### PR DESCRIPTION
## 목표

Issue #9747 — keeper turn cycle에서 발생하는 `Fun.Finally_raised: Cancelled: Eio__core__Fiber.Not_first` crash를 제거. 5 synchronized batch × 16 keepers에 걸친 crash 로그(2026-04-23)의 직접 원인인 cleanup propagation 버그를 수정한다.

## 변경 내용

`lib/keeper/keeper_unified_turn.ml:962` 의 turn body wrapper를 stdlib `Fun.protect` → OCaml 5 `match/exception` 패턴으로 교체.

### Before
```ocaml
let run_result, latency_ms =
  Fun.protect ~finally:(fun () ->
    unsubscribe_event_bus ();
    Keeper_registry.mark_turn_finished
      ~base_path:config.base_path meta.name)
  (fun () ->
    Keeper_exec_context.timed (fun () -> body))
```

### After
```ocaml
let run_result, latency_ms =
  let cleanup () =
    (try unsubscribe_event_bus () with
     | Eio.Cancel.Cancelled _ -> ()
     | e -> Log.Keeper.warn "... %s" (Printexc.to_string e));
    (try Keeper_registry.mark_turn_finished ... with
     | Eio.Cancel.Cancelled _ -> ()
     | e -> Log.Keeper.warn "... %s" (Printexc.to_string e))
  in
  match Keeper_exec_context.timed (fun () -> body) with
  | result -> cleanup (); result
  | exception e -> cleanup (); raise e
```

## 왜 이게 근본 수정인가

`Fun.protect`는 finally가 raise하면 `Fun.Finally_raised`로 감싸 **원본 예외를 덮는다**. Turn body가 `Fiber.first`에 져서 `Eio.Cancel.Cancelled (Not_first)`을 던지면, finally에서 호출되는 `unsubscribe_event_bus` / `mark_turn_finished`가 cancellation 상태의 Eio 자원을 건드려 또 `Cancelled`을 raise 하고 결과적으로 원본 Cancelled가 소실된다.

Memory `ocaml5-mutex-selection` / `ocaml-dev-guide.md`에 기록된 "Fun.protect in fiber context considered harmful" 안티패턴이 여기 남아있던 마지막 lib/ 발생 지점이다 (`lib/model_inference_metrics.ml:401`의 단일 도메인 close_in 용도는 무관).

교체 패턴:
- cleanup 안에서만 Cancelled를 swallow — 바깥쪽 Cancelled는 `raise e`로 정상 전파
- 비-cancel 예외는 `Log.Keeper.warn`으로 가시화 (silent failure 방지)
- `match ... | exception e -> ...`는 OCaml 5 표준 idiom으로 try/finally를 cancel-safe하게 대체

## 로컬 검증

- `dune build @check --root=.` exit 0
- `dune exec test/test_keeper_unified.exe`: 214/226 pass, 12 failures는 origin/main에도 동일하게 발생 (`Stdlib.Effect.Unhandled(Eio__core__Cancel.Get_context)` in `keeper_world_observation.provider_cooldown_remaining_sec_for_cascade` — 본 PR 무관)
- Diff는 단일 파일 +27 / -6 line, 순수 wrapper 교체

## 동작 변경 없음

- Turn body, `Keeper_exec_context.timed`, `Eio_context.get_clock` 호출 그대로
- cleanup 내용도 동일 (unsubscribe + mark_turn_finished)
- 예외 전파 순서 동일 (cleanup → raise)
- 정상 경로: cleanup 실행 후 tuple return

## 미해결 / Follow-up

이번 수정은 **crash visibility + cleanup 보장** 문제만 해결한다. Issue #9747의 진짜 원인인 **fleet-wide synchronized cancellation**(같은 초에 4-6 keeper가 동시에 Cancelled를 맞는 패턴)은 상위 공유 `Fiber.first`/semaphore 구조의 별개 문제. 본 PR 머지 후에도:

- Cancellation 발생 빈도는 동일
- 다만 각 keeper가 올바른 `Cancelled`를 받아 agent state machine이 restart 처리 가능
- `Fun.Finally_raised` crash 로그는 사라지거나 non-cancel 예외의 `Log.Keeper.warn` 라인으로 전환

관련 상류 원인은 #9771 (fleet-wide semaphore wait > 60s) 또는 별도 조사 이슈로 추적.

Test infrastructure 이슈 (test_keeper_unified의 12 pre-existing failures)는 별도 이슈로 분리 후보.

## 관련

- Refs #9747
- Root cause 분석: https://github.com/jeong-sik/masc-mcp/issues/9747#issuecomment-4310871392
- Memory: `feedback_ocaml5-mutex-selection.md`, `ocaml-dev-guide.md` (Fun.protect in fiber context → use match/exception)

---

_/loop masc-mcp issues 하나씩 근본 해결 — cycle 4 PR_
