### PR TITLE
feat(cascade): log runtime-declared provider divergence in resolve_named_providers

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -798,8 +798,42 @@ let resolve_named_providers ?sw ?net ?clock ?provider_filter
           (Printf.sprintf
              "cascade %s resolved to no callable providers"
              normalized)
-      else
-        Ok providers
+      else (
+        (* Observability for cascade-name -> runtime-provider divergence.
+           If the returned provider set ever disagrees with the declared
+           weighted_entries of the profile (e.g. under snapshot staleness
+           or cache leak across cascades), the mismatch shows up here.
+           See memory/handoff-2026-04-24-masc-runtime-mcp-auth-resolved.md *)
+        let declared =
+          List.map
+            (fun (e : Cascade_config_loader.weighted_entry) ->
+              String.trim e.model)
+            profile.weighted_entries
+        in
+        let returned =
+          List.map
+            (fun (c : Llm_provider.Provider_config.t) ->
+              Printf.sprintf "%s:%s"
+                (Llm_provider.Provider_config.string_of_provider_kind c.kind)
+                (String.trim c.model_id))
+            providers
+        in
+        let leaked =
+          List.filter (fun m -> not (List.mem m declared)) returned
+        in
+        (if leaked <> [] then
+           Log.warn ~ctx:"CascadeCatalog"
+             "resolve_named_providers(%s): %d providers NOT in declared \
+              profile (declared=[%s] returned=[%s] leaked=[%s])"
+             normalized (List.length leaked)
+             (String.concat ", " declared)
+             (String.concat ", " returned)
+             (String.concat ", " leaked)
+         else
+           Log.debug ~ctx:"CascadeCatalog"
+             "resolve_named_providers(%s) -> [%s]" normalized
+             (String.concat ", " returned));
+        Ok providers)
 
 let resolve_inference_params ?sw ?net ?clock ~name () =
   match lookup_active_profile ?sw ?net ?clock name with


### PR DESCRIPTION
## Context

2026-04-24 04:02~04:17Z 구간, masc-mcp keeper fleet이 `cascade=tool_use_strict` 아래에서 `Invalid config 'runtime_mcp_auth': codex_cli runtime MCP cannot carry keeper-bound auth headers` 에러로 29분간 194건 실패했다.

- 현재 `tool_use_strict`의 선언: `[claude_code:auto, kimi_cli:kimi-for-coding]`
- 그런데 런타임에 실제 시도된 provider는 `codex_cli:gpt-5.3-codex-spark | gpt-5.4 | gpt-5.4-mini | gpt-5.3-codex | gpt-5.2` — 선언에 없는 5개 provider
- Startup validated catalog 로그는 정확한 선언을 보여줬고, 코드 경로 검토(cascade_runtime → cascade_catalog_runtime → lookup_active_profile)에서는 reroute가 cascade_name만 label-level로 바꾸고 provider resolve는 순수하게 cascade_name 기반이어야 한다.
- 후속 재시작(commit `0e408ffc1`)으로 에러는 사라졌지만 attribution 미해결. 재현 조건 모름.

전체 분석: `memory/handoff-2026-04-24-masc-runtime-mcp-auth-resolved.md`

## Change

`Cascade_catalog_runtime.resolve_named_providers`에 관찰성 추가:

- 반환 시 `profile.weighted_entries`의 declared list와 실제 provider들의 `kind:model_id`를 비교
- leaked(선언에 없는) provider가 있으면 `Log.warn "resolve_named_providers(<cascade>): N providers NOT in declared profile (declared=[...] returned=[...] leaked=[...])"`
- 없으면 `Log.debug` (볼륨 관리)

## Why here

이 함수는 cascade_name → 실제 provider list 변환의 단일 지점이다. 어떤 상위 레이어 버그(snapshot staleness, cache leak, reroute 미반영 등)든 결과는 여기서 "선언 vs 반환" 불일치로 나타난다. 따라서 이 하나의 invariant가 다양한 원인을 일관되게 포착한다.

## No behavior change

- 반환 시그니처/값 동일 (`Ok providers`)
- 순수 로깅만 추가
- `Log.debug`는 정상 경로, `Log.warn`은 invariant 위반 시만

## If this had been in place at 04:02

Tick 1에서 첫 에러 1건 로그에 declared=[claude_code:auto, kimi_cli] / returned=[codex_cli:gpt-5.3-codex-spark, ...] / leaked=[5개 codex_cli] 가 즉시 드러났을 것. 194건의 반복 없이 근본원인을 곧바로 좁혔을 수 있다.

## Test plan

- [ ] `dune build @check` pass (로컬 확인 완료)
- [ ] 로컬 서버 재기동 후 `grep resolve_named_providers ~/me/.masc/logs/system_log_*.jsonl` — tool_use_strict resolve 시 debug/warn 로그 확인
- [ ] 레어한 mismatch 재현 시 warn 로그로 현상 캡처 (이 PR로는 재현 자체는 해결 안 함 — 재발 시 다음 fix 근거 확보가 목표)

## Follow-up

- Attribution이 확정되면 근본원인 fix는 별도 PR
- `cascade exhausted` 자동 pause/alert 이슈 `#9798`과 연계해 warn 이벤트를 dashboard alert에 hook 가능

## Risk

- 성능: 정상 경로 `Log.debug` + List.filter O(n*m) (n=returned, m=declared). cascade 후보 수 ≤ 12, cost 미미.
- 가시성: warn이 트리거되면 대량 로그 가능 (각 resolve 호출마다). 하지만 이는 정상 상태에서 0이어야 하는 invariant — 발생 시 보고 싶은 신호.

Ref: `memory/handoff-2026-04-24-masc-runtime-mcp-auth-resolved.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)