### PR TITLE
[codex] Raise MASC nofile defaults

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -561,6 +561,10 @@ module KeeperSandbox = struct
   let pids_limit () =
     max 32 (get_int ~default:128 "MASC_KEEPER_SANDBOX_PIDS_LIMIT")
 
+  (** Open file descriptor limit inside keeper Docker containers. *)
+  let nofile_limit () =
+    max 1024 (get_int ~default:245_760 "MASC_KEEPER_SANDBOX_NOFILE_LIMIT")
+
   (** Docker memory limit string, e.g. 2g / 512m. *)
   let memory () =
     get_string ~default:"2g" "MASC_KEEPER_SANDBOX_MEMORY"

--- a/lib/keeper/keeper_docker_read.ml
+++ b/lib/keeper/keeper_docker_read.ml
@@ -69,6 +69,7 @@ let build_docker_argv ~image ~container_name ~host_root ~croot
       "--user";
       Printf.sprintf "%d:%d" uid gid;
     ]
+  @ Keeper_sandbox_runtime.docker_nofile_args ()
   @ Env_config_keeper.KeeperSandbox.read_only_rootfs_args ()
   @ [
     "--tmpfs";

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -198,6 +198,10 @@ let docker_network_args = function
   | Keeper_types.Network_none -> ([ "--network"; "none" ], "none")
   | Keeper_types.Network_inherit -> ([], "inherit")
 
+let docker_nofile_args () =
+  let limit = Env_config_keeper.KeeperSandbox.nofile_limit () in
+  [ "--ulimit"; Printf.sprintf "nofile=%d:%d" limit limit ]
+
 type inspected_container =
   {
     owner_pid : int option;

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -91,6 +91,10 @@ val docker_network_args :
     particular, [Network_inherit] intentionally maps to no Docker
     [--network] argument; Docker has no network named ["inherit"]. *)
 
+val docker_nofile_args : unit -> string list
+(** Docker [--ulimit nofile=<soft>:<hard>] argv fragment for keeper
+    sandbox containers. *)
+
 val list_containers :
   ?keeper_name:string ->
   ?container_kind:string ->

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -292,6 +292,7 @@ let run_docker_shell_command_with_status
           "--user";
           Printf.sprintf "%d:%d" uid gid;
         ]
+        @ Keeper_sandbox_runtime.docker_nofile_args ()
         @ Env_config_keeper.KeeperSandbox.read_only_rootfs_args ()
         @ [
           "--tmpfs";

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -162,6 +162,7 @@ let start_container (t : t) ~(timeout_sec : float) =
             "--user";
             Printf.sprintf "%d:%d" t.uid t.gid;
           ]
+          @ Keeper_sandbox_runtime.docker_nofile_args ()
           @ Env_config_keeper.KeeperSandbox.read_only_rootfs_args ()
           @ [
             "--tmpfs";

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -451,8 +451,26 @@ if [ -n "${MASC_BASE_PATH:-}" ]; then
 fi
 
 raise_open_file_limit() {
-    local desired="${MASC_NOFILE_TARGET:-4096}"
+    # Multi-keeper local runs can fan out across many LLM/provider CLIs,
+    # sockets, logs, and watcher handles. Keep the default high enough for
+    # 50-ish concurrent sessions while still allowing operators to override.
+    local desired="${MASC_NOFILE_TARGET:-245760}"
     local current hard target
+
+    case "$desired" in
+        max|hard)
+            desired=""
+            ;;
+    esac
+
+    if [ -z "$desired" ]; then
+        hard="$(ulimit -Hn 2>/dev/null || echo "")"
+        if [[ "$hard" =~ ^[0-9]+$ ]]; then
+            desired="$hard"
+        else
+            desired="${MASC_NOFILE_UNLIMITED_TARGET:-245760}"
+        fi
+    fi
 
     if ! [[ "$desired" =~ ^[0-9]+$ ]]; then
         echo "Warning: ignoring invalid MASC_NOFILE_TARGET=$desired" >&2
@@ -460,7 +478,6 @@ raise_open_file_limit() {
     fi
 
     current="$(ulimit -Sn 2>/dev/null || ulimit -n 2>/dev/null || echo "")"
-    hard="$(ulimit -Hn 2>/dev/null || echo "")"
     if ! [[ "$current" =~ ^[0-9]+$ ]]; then
         return 0
     fi

--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -472,6 +472,20 @@ let test_docker_network_args_follow_masc_policy () =
     [] args_inherit;
   Alcotest.(check string) "network inherit label" "inherit" label_inherit
 
+let test_docker_nofile_args_follow_config () =
+  with_env "MASC_KEEPER_SANDBOX_NOFILE_LIMIT" "not-a-number" @@ fun () ->
+  Alcotest.(check (list string)) "default nofile limit"
+    [ "--ulimit"; "nofile=245760:245760" ]
+    (Keeper_sandbox_runtime.docker_nofile_args ());
+  with_env "MASC_KEEPER_SANDBOX_NOFILE_LIMIT" "8192" @@ fun () ->
+  Alcotest.(check (list string)) "configured nofile limit"
+    [ "--ulimit"; "nofile=8192:8192" ]
+    (Keeper_sandbox_runtime.docker_nofile_args ());
+  with_env "MASC_KEEPER_SANDBOX_NOFILE_LIMIT" "256" @@ fun () ->
+  Alcotest.(check (list string)) "nofile floor"
+    [ "--ulimit"; "nofile=1024:1024" ]
+    (Keeper_sandbox_runtime.docker_nofile_args ())
+
 let test_cleanup_stale_containers_removes_only_stale_masc_scope () =
   with_fake_docker fake_docker_cleanup_script @@ fun () ->
   let base = temp_dir () in
@@ -771,6 +785,8 @@ let run_tests () =
         [
           Alcotest.test_case "docker network args follow policy" `Quick
             test_docker_network_args_follow_masc_policy;
+          Alcotest.test_case "docker nofile args follow config" `Quick
+            test_docker_nofile_args_follow_config;
           Alcotest.test_case "managed label args include ttl" `Quick
             test_sandbox_container_label_args_include_managed_ttl;
           Alcotest.test_case "sandbox label args include owner scope" `Quick


### PR DESCRIPTION
## Summary

- raise the MASC launcher default `nofile` target from `4096` to `245760`
- add `MASC_NOFILE_TARGET=max|hard` support for host launcher processes
- pass `--ulimit nofile=245760:245760` to keeper Docker containers by default
- add `MASC_KEEPER_SANDBOX_NOFILE_LIMIT` for container-level override

## Why

Large local keeper runs fan out across multiple provider CLIs, Docker containers, logs, sockets, and watcher handles. The old launcher default was too low for 50-ish concurrent sessions, and Docker keepers also needed an explicit container `nofile` limit instead of relying only on the host process limit.

## Validation

- `bash -n start-masc-mcp.sh`
- `dune build --root=. -j 1 test/test_keeper_docker_read.exe`
- `dune exec --root=. -j 1 ./test/test_keeper_docker_read.exe`
- `dune exec --root=. -j 1 ./test/test_keeper_shell_docker_route.exe`
