### PR TITLE
feat(env): RFC-0007 PR-1 — non-interactive git env SSOT + subprocess scrub list

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -288,6 +288,8 @@
    telemetry_unified
    tempo
    timeout_policy
+   env_git_noninteractive
+   env_keeper_scrub
    tui_decode
    tools
    tool_args

--- a/lib/env_git_noninteractive.ml
+++ b/lib/env_git_noninteractive.ml
@@ -1,8 +1,45 @@
-let env =
+(* Canonical pairs. Keep this list short and justified — each entry is a
+   promise that the named subsystem is documented to honor it.
+
+   GIT_TERMINAL_PROMPT=0 — git/libcurl credential helpers must not open
+     /dev/tty. Documented at https://git-scm.com/docs/git-config under
+     [core.askPass] and git-credential(1).
+   GIT_ASKPASS="" — explicitly empty disables any configured askpass
+     helper for this subprocess without relying on unset semantics.
+   GCM_INTERACTIVE=Never — git credential manager (Microsoft) honors this
+     on Linux/macOS containers to refuse interactive dialogs.
+   SSH_ASKPASS="" — same rationale for SSH-over-git URLs. *)
+
+let env : (string * string) list =
   [
-    ("GIT_ASKPASS", "");
-    ("GIT_TERMINAL_PROMPT", "0");
+    "GIT_TERMINAL_PROMPT", "0";
+    "GIT_ASKPASS", "";
+    "GCM_INTERACTIVE", "Never";
+    "SSH_ASKPASS", "";
   ]
 
-let docker_env_args =
+let env_pairs =
+  List.map (fun (k, v) -> k ^ "=" ^ v) env
+
+let docker_args =
   List.concat_map (fun (k, v) -> [ "-e"; k ^ "=" ^ v ]) env
+
+let docker_env_args = docker_args
+
+let key_of_entry entry =
+  match String.index_opt entry '=' with
+  | None -> entry
+  | Some i -> String.sub entry 0 i
+
+let inject_into_environment existing =
+  let override_keys =
+    let t = Hashtbl.create (List.length env) in
+    List.iter (fun (k, _) -> Hashtbl.replace t k ()) env;
+    t
+  in
+  let filtered =
+    Array.to_list existing
+    |> List.filter (fun e ->
+         not (Hashtbl.mem override_keys (key_of_entry e)))
+  in
+  Array.of_list (env_pairs @ filtered)

--- a/lib/env_git_noninteractive.mli
+++ b/lib/env_git_noninteractive.mli
@@ -1,27 +1,31 @@
-(** Non-interactive git environment — RFC-0007 rev.3 PR-1.
+(** Non-interactive git subprocess environment (RFC-0007 PR-1 / #9639 Cluster B).
 
-    Centralised constants that force git subprocesses (invoked inside
-    the keeper docker sandbox or via [Unix.execve]) to fail fast rather
-    than block on a credential prompt.
+    SSOT for the env-var pairs that must be set whenever MASC spawns [git]
+    or [gh] in a non-tty subprocess (Docker sandbox or direct [Process_eio]
+    call). Missing these constants silently hangs the subprocess on a
+    credential prompt — the container has no tty to display it, so the
+    timeout trips only after the outer wall-clock cap fires.
 
-    Evidence (2026-04-24, commit 0e408ffc1d5b34badb0cc1b9f3704a9e725fb8c6):
-    [rg -n 'GIT_ASKPASS|GIT_TERMINAL_PROMPT' lib/ test/ scripts/] returned
-    zero hits. A keeper [git push] inside docker could, in principle,
-    hang indefinitely if the RO-mounted [hosts.yml] auth path failed
-    before git fell through to a prompt. This module is the centralised
-    fix (RFC-0007 PR-1, one callsite today: [keeper_shell_docker.ml:234-245]).
-
-    Consumers MUST prefer these constants over open-coding the pairs,
-    so future callsites inherit the safety guarantee by construction. *)
+    Design reference: [GIT_NO_PROMPT_ENV] record in claude-code at
+    [src/utils/worktree.ts:199-202] and [src/utils/plugins/marketplaceManager.ts:510-512].
+    Principle P3 of RFC-0007: "Non-interactive defaults are a constant,
+    not an opinion." *)
 
 val env : (string * string) list
-(** The two canonical pairs:
-    - [("GIT_ASKPASS", "")]       — empty helper, git raises instead of prompting
-    - [("GIT_TERMINAL_PROMPT", "0")] — disables the git-core prompt fallback *)
+(** Canonical non-interactive env pairs. Must be merged into every
+    subprocess environment that may invoke git/gh without a tty. *)
+
+val env_pairs : string list
+(** Flattened [K=V] strings suitable for prepending to a [Unix.environment]
+    array. *)
+
+val docker_args : string list
+(** Flattened ["-e"; "K=V"; ...] pairs for direct [docker run] argv. *)
 
 val docker_env_args : string list
-(** [env] flattened as docker [run -e KEY=VALUE] argv tokens.
+(** Backwards-compatible alias for {!docker_args}. *)
 
-    Each pair [(k, v)] produces two tokens [\["-e"; k ^ "=" ^ v\]], matching
-    the existing inline style in [keeper_shell_docker.ml]. Callers append
-    this to their existing [-e] list. *)
+val inject_into_environment : string array -> string array
+(** Prepend {!env_pairs} to [env], stripping any pre-existing entries
+    with matching keys so the canonical value wins. Preserves the order of
+    non-matching entries. *)

--- a/lib/env_keeper_scrub.ml
+++ b/lib/env_keeper_scrub.ml
@@ -1,0 +1,81 @@
+(* Exact keys copied from claude-code's GHA_SUBPROCESS_SCRUB list at
+   src/utils/subprocessEnv.ts:15-53.
+
+   Each group is documented in the reference. Rationale preserved so a
+   future reader can justify additions or removals. *)
+
+let scrub : string list =
+  [
+    (* Anthropic auth — MASC re-reads these per-request, subprocesses don't
+       need them and leaking them into a sandboxed container creates an
+       escape surface. *)
+    "ANTHROPIC_API_KEY";
+    "CLAUDE_CODE_OAUTH_TOKEN";
+    "ANTHROPIC_AUTH_TOKEN";
+    "ANTHROPIC_FOUNDRY_API_KEY";
+    "ANTHROPIC_CUSTOM_HEADERS";
+
+    (* OTLP exporter headers — documented to carry Authorization: Bearer
+       tokens for monitoring backends; read in-process by the OTEL SDK. *)
+    "OTEL_EXPORTER_OTLP_HEADERS";
+    "OTEL_EXPORTER_OTLP_LOGS_HEADERS";
+    "OTEL_EXPORTER_OTLP_METRICS_HEADERS";
+    "OTEL_EXPORTER_OTLP_TRACES_HEADERS";
+
+    (* Cloud provider creds — same pattern (lazy SDK reads). *)
+    "AWS_SECRET_ACCESS_KEY";
+    "AWS_SESSION_TOKEN";
+    "AWS_BEARER_TOKEN_BEDROCK";
+    "GOOGLE_APPLICATION_CREDENTIALS";
+    "AZURE_CLIENT_SECRET";
+    "AZURE_CLIENT_CERTIFICATE_PATH";
+
+    (* GitHub Actions OIDC — consumed by the action's JS before the keeper
+       spawns; leaking these allows minting an App installation token. *)
+    "ACTIONS_ID_TOKEN_REQUEST_TOKEN";
+    "ACTIONS_ID_TOKEN_REQUEST_URL";
+
+    (* GitHub Actions artifact/cache API — cache poisoning pivot. *)
+    "ACTIONS_RUNTIME_TOKEN";
+    "ACTIONS_RUNTIME_URL";
+
+    (* Workflow-level duplicates — ALL_INPUTS contains api keys as JSON. *)
+    "ALL_INPUTS";
+    "OVERRIDE_GITHUB_TOKEN";
+    "DEFAULT_WORKFLOW_TOKEN";
+    "SSH_SIGNING_KEY";
+  ]
+
+let pass : string list =
+  [
+    (* Job-scoped GitHub tokens — documented consumer is gh/git. *)
+    "GH_TOKEN";
+    "GITHUB_TOKEN";
+    (* SSH agent forwarding socket — short-lived, per-session. *)
+    "SSH_AUTH_SOCK";
+    (* Git user identity + config wiring; SSOT'd elsewhere but allowed to
+       pass when set by host. *)
+    "GIT_AUTHOR_NAME";
+    "GIT_AUTHOR_EMAIL";
+    "GIT_COMMITTER_NAME";
+    "GIT_COMMITTER_EMAIL";
+    "GIT_CONFIG_GLOBAL";
+    "GIT_CONFIG_COUNT";
+  ]
+
+let scrub_table =
+  let t = Hashtbl.create (List.length scrub) in
+  List.iter (fun k -> Hashtbl.replace t k ()) scrub;
+  t
+
+let is_scrubbed key = Hashtbl.mem scrub_table key
+
+let key_of_entry entry =
+  match String.index_opt entry '=' with
+  | None -> entry
+  | Some i -> String.sub entry 0 i
+
+let filter_environment existing =
+  Array.to_list existing
+  |> List.filter (fun e -> not (is_scrubbed (key_of_entry e)))
+  |> Array.of_list

--- a/lib/env_keeper_scrub.mli
+++ b/lib/env_keeper_scrub.mli
@@ -1,0 +1,34 @@
+(** Keeper subprocess env scrub / pass policy (RFC-0007 PR-1 / #9639 Cluster B).
+
+    Long-lived host credentials (Anthropic API keys, AWS secrets, OIDC
+    request tokens, OTel exporter bearer headers) MUST NOT cross the
+    keeper subprocess boundary. They are consumed by the host process
+    (MASC server) and are not needed inside the keeper container or shell
+    subprocess.
+
+    Job-scoped tokens ([GH_TOKEN], [GITHUB_TOKEN], [SSH_AUTH_SOCK], and
+    other [GIT_*]) are explicitly passed through — they are expected
+    consumers of gh/git operations and expire with the job.
+
+    Design reference: [GHA_SUBPROCESS_SCRUB] in claude-code at
+    [src/utils/subprocessEnv.ts:15-53]. Principle P2 of RFC-0007:
+    "Scrub vs pass-through is decided by token scoping." *)
+
+val scrub : string list
+(** Env-var keys stripped before spawning a keeper subprocess. *)
+
+val pass : string list
+(** Env-var keys explicitly allowed through, documented for callers. Does
+    not participate in [filter_environment]'s positive list (everything
+    not on [scrub] is already allowed); serves as an assertion against
+    accidental future additions to [scrub]. *)
+
+val is_scrubbed : string -> bool
+(** [is_scrubbed key] returns [true] if the given env-var key is on the
+    scrub list. Prefix-based entries (e.g. future [ANTHROPIC_*]) are not
+    supported yet — exact match only. *)
+
+val filter_environment : string array -> string array
+(** Return a copy of the given [Unix.environment]-shaped array with
+    scrubbed keys removed. Entries that do not contain ['='] are kept
+    as-is. *)

--- a/lib/keeper/keeper_gh_env.ml
+++ b/lib/keeper/keeper_gh_env.ml
@@ -82,30 +82,40 @@ let with_env (config : Coord.config) (gh_cmd : string) : string =
   | Some dir ->
     Printf.sprintf "GH_CONFIG_DIR=%s %s" (Filename.quote dir) gh_cmd
 
+(* RFC-0007 PR-1: compose base env for a gh/git subprocess.
+
+   Order of operations (inside-out):
+     1. Start from [Unix.environment ()].
+     2. Scrub long-lived host credentials that are consumed by MASC
+        in-process and MUST NOT cross into a keeper subprocess or
+        sandboxed container.
+     3. Prepend the non-interactive git constants so credential prompts
+        cannot hang the subprocess on a missing tty.
+     4. Strip any pre-existing [GH_CONFIG_DIR=] entry and prepend the
+        keeper-scoped value so the keeper's GH identity wins over any
+        operator config present in the process env.
+
+   See [Env_keeper_scrub] and [Env_git_noninteractive] for the
+   canonical lists and their rationale. *)
+let compose_base_with_gh_config ~dir =
+  let scrubbed = Env_keeper_scrub.filter_environment (Unix.environment ()) in
+  let with_noprompt = Env_git_noninteractive.inject_into_environment scrubbed in
+  let without_existing_gh =
+    Array.to_list with_noprompt
+    |> List.filter (fun entry ->
+         not (String.starts_with ~prefix:"GH_CONFIG_DIR=" entry))
+  in
+  let gh_config = "GH_CONFIG_DIR=" ^ dir in
+  Array.of_list (gh_config :: without_existing_gh)
+
 let process_env (config : Coord.config) : string array option =
   match config_dir config with
   | None -> None
-  | Some dir ->
-    let gh_config = "GH_CONFIG_DIR=" ^ dir in
-    let base =
-      Unix.environment ()
-      |> Array.to_list
-      |> List.filter (fun entry ->
-        not (String.starts_with ~prefix:"GH_CONFIG_DIR=" entry))
-    in
-    Some (Array.of_list (gh_config :: base))
+  | Some dir -> Some (compose_base_with_gh_config ~dir)
 
 let keeper_process_env (config : Coord.config) ~(keeper_name : string) :
     (string array option, string) result =
   keeper_config_dir config ~keeper_name
   |> Result.map (function
        | None -> None
-       | Some dir ->
-           let gh_config = "GH_CONFIG_DIR=" ^ dir in
-           let base =
-             Unix.environment ()
-             |> Array.to_list
-             |> List.filter (fun entry ->
-                  not (String.starts_with ~prefix:"GH_CONFIG_DIR=" entry))
-           in
-           Some (Array.of_list (gh_config :: base)))
+       | Some dir -> Some (compose_base_with_gh_config ~dir))

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -240,7 +240,11 @@ let run_docker_shell_command_with_status
                 "-e"; "GIT_CONFIG_KEY_0=safe.directory";
                 "-e"; "GIT_CONFIG_VALUE_0=*";
               ]
-              @ Env_git_noninteractive.docker_env_args
+              (* RFC-0007 PR-1: non-interactive git constants must reach the
+                 container. Without these, git's credential helpers can
+                 open /dev/tty inside a sandbox that has no tty and hang
+                 until the outer wall-clock timeout trips silently. *)
+              @ Env_git_noninteractive.docker_args
               @ git_identity_env ~name:git_author_name ~email:git_author_email
             in
             Ok (mounts, envs)

--- a/test/dune
+++ b/test/dune
@@ -975,6 +975,7 @@
 ; Keeper Tool Matrix — shared case modules as a library
 (library
  (name keeper_tool_matrix_cases_lib)
+ (wrapped false)
  (modules test_keeper_tool_matrix_cases test_mcp_tool_matrix_cases)
  (libraries masc_test_deps))
 

--- a/test/test_env_git_noninteractive.ml
+++ b/test/test_env_git_noninteractive.ml
@@ -1,38 +1,192 @@
-(** Unit tests for [Env_git_noninteractive] — RFC-0007 rev.3 PR-1.
+(* test/test_env_git_noninteractive.ml
 
-    Asserts the exact pairs and docker argv flattening. Any change to the
-    constants breaks these tests and forces a deliberate review (there is
-    no reason to change them outside of a separate RFC). *)
+   Covers RFC-0007 PR-1 / #9639 Cluster B:
+   - [Env_git_noninteractive] canonical env pairs (presence + format)
+   - [Env_git_noninteractive.inject_into_environment] override semantics
+   - [Env_keeper_scrub] scrub list membership and exact-match rule
+   - [Env_keeper_scrub.filter_environment] strips scrubbed keys while
+     preserving pass-through entries and entries without ['='] *)
 
-module Env_git_noninteractive = Masc_mcp.Env_git_noninteractive
+open Masc_mcp
 
-let test_env_pairs_are_exact () =
-  Alcotest.(check (list (pair string string)))
-    "env list matches the canonical two pairs"
-    [ ("GIT_ASKPASS", ""); ("GIT_TERMINAL_PROMPT", "0") ]
-    Env_git_noninteractive.env
+let fail msg = failwith msg
+let assert_true msg b = if not b then fail msg
+let assert_false msg b = if b then fail msg
 
-let test_docker_env_args_flatten () =
-  Alcotest.(check (list string))
-    "docker_env_args is -e K=V for each pair, in order"
-    [ "-e"; "GIT_ASKPASS="; "-e"; "GIT_TERMINAL_PROMPT=0" ]
-    Env_git_noninteractive.docker_env_args
+let assert_list_eq ~msg expected got =
+  if List.length expected <> List.length got
+     || List.exists2 (fun a b -> a <> b) expected got
+  then
+    fail
+      (Printf.sprintf "%s: expected=[%s] got=[%s]" msg
+         (String.concat ";" expected) (String.concat ";" got))
 
-let test_docker_env_args_even_length () =
-  (* Structural: each docker [-e KEY=VALUE] is exactly two argv tokens.
-     Breaking this invariant breaks [keeper_shell_docker]'s inline argv. *)
-  Alcotest.(check int)
-    "docker_env_args length is 2x the env pair count"
-    (2 * List.length Env_git_noninteractive.env)
-    (List.length Env_git_noninteractive.docker_env_args)
+let assert_contains ~msg xs needle =
+  if not (List.mem needle xs) then
+    fail (Printf.sprintf "%s: %s not in list" msg needle)
+
+let test_env_has_required_keys () =
+  let keys = List.map fst Env_git_noninteractive.env in
+  assert_contains ~msg:"GIT_TERMINAL_PROMPT present" keys "GIT_TERMINAL_PROMPT";
+  assert_contains ~msg:"GIT_ASKPASS present" keys "GIT_ASKPASS";
+  assert_contains ~msg:"GCM_INTERACTIVE present" keys "GCM_INTERACTIVE";
+  assert_contains ~msg:"SSH_ASKPASS present" keys "SSH_ASKPASS"
+
+let test_env_values_enforce_noninteractive () =
+  let lookup k = List.assoc_opt k Env_git_noninteractive.env in
+  assert_true "GIT_TERMINAL_PROMPT = 0" (lookup "GIT_TERMINAL_PROMPT" = Some "0");
+  assert_true "GIT_ASKPASS empty string" (lookup "GIT_ASKPASS" = Some "");
+  assert_true "GCM_INTERACTIVE = Never" (lookup "GCM_INTERACTIVE" = Some "Never");
+  assert_true "SSH_ASKPASS empty string" (lookup "SSH_ASKPASS" = Some "")
+
+let test_env_pairs_serialized () =
+  assert_contains ~msg:"env_pairs has GIT_TERMINAL_PROMPT=0"
+    Env_git_noninteractive.env_pairs "GIT_TERMINAL_PROMPT=0";
+  assert_contains ~msg:"env_pairs has GIT_ASKPASS="
+    Env_git_noninteractive.env_pairs "GIT_ASKPASS="
+
+let test_docker_args_pair_structure () =
+  let args = Env_git_noninteractive.docker_args in
+  (* Each (K, V) produces exactly two argv tokens: "-e", "K=V". *)
+  let expected_len = List.length Env_git_noninteractive.env * 2 in
+  if List.length args <> expected_len then
+    fail
+      (Printf.sprintf "docker_args length = %d, expected %d"
+         (List.length args) expected_len);
+  (* Verify alternation: indexes 0, 2, 4, ... are always "-e". *)
+  List.iteri
+    (fun i token ->
+      if i mod 2 = 0 && token <> "-e" then
+        fail (Printf.sprintf "docker_args[%d] = %s, expected -e" i token))
+    args
+
+let test_inject_override_existing () =
+  let existing = [| "GIT_TERMINAL_PROMPT=1"; "PATH=/usr/bin"; "FOO=bar" |] in
+  let out = Env_git_noninteractive.inject_into_environment existing in
+  let out_list = Array.to_list out in
+  assert_contains ~msg:"canonical value wins" out_list "GIT_TERMINAL_PROMPT=0";
+  assert_false "pre-existing GIT_TERMINAL_PROMPT=1 evicted"
+    (List.mem "GIT_TERMINAL_PROMPT=1" out_list);
+  assert_contains ~msg:"unrelated PATH preserved" out_list "PATH=/usr/bin";
+  assert_contains ~msg:"unrelated FOO preserved" out_list "FOO=bar"
+
+let test_inject_injects_when_missing () =
+  let existing = [| "PATH=/bin" |] in
+  let out = Env_git_noninteractive.inject_into_environment existing in
+  let out_list = Array.to_list out in
+  assert_contains ~msg:"injects GIT_TERMINAL_PROMPT=0 when absent"
+    out_list "GIT_TERMINAL_PROMPT=0";
+  assert_contains ~msg:"injects GIT_ASKPASS= when absent"
+    out_list "GIT_ASKPASS="
+
+let test_scrub_membership () =
+  assert_true "ANTHROPIC_API_KEY scrubbed"
+    (Env_keeper_scrub.is_scrubbed "ANTHROPIC_API_KEY");
+  assert_true "AWS_SECRET_ACCESS_KEY scrubbed"
+    (Env_keeper_scrub.is_scrubbed "AWS_SECRET_ACCESS_KEY");
+  assert_true "ACTIONS_ID_TOKEN_REQUEST_TOKEN scrubbed"
+    (Env_keeper_scrub.is_scrubbed "ACTIONS_ID_TOKEN_REQUEST_TOKEN");
+  assert_true "OTEL_EXPORTER_OTLP_HEADERS scrubbed"
+    (Env_keeper_scrub.is_scrubbed "OTEL_EXPORTER_OTLP_HEADERS");
+  assert_false "GH_TOKEN NOT scrubbed (pass-through)"
+    (Env_keeper_scrub.is_scrubbed "GH_TOKEN");
+  assert_false "GITHUB_TOKEN NOT scrubbed (pass-through)"
+    (Env_keeper_scrub.is_scrubbed "GITHUB_TOKEN");
+  assert_false "SSH_AUTH_SOCK NOT scrubbed (pass-through)"
+    (Env_keeper_scrub.is_scrubbed "SSH_AUTH_SOCK");
+  assert_false "PATH NOT scrubbed (neutral)"
+    (Env_keeper_scrub.is_scrubbed "PATH")
+
+let test_scrub_exact_match_only () =
+  (* Prefix match is explicitly a non-goal. *)
+  assert_false "ANTHROPIC_API_KEY_SUFFIX not scrubbed (exact match)"
+    (Env_keeper_scrub.is_scrubbed "ANTHROPIC_API_KEY_SUFFIX");
+  assert_false "PREFIX_ANTHROPIC_API_KEY not scrubbed (exact match)"
+    (Env_keeper_scrub.is_scrubbed "PREFIX_ANTHROPIC_API_KEY")
+
+let test_scrub_and_pass_disjoint () =
+  List.iter
+    (fun p ->
+      assert_false
+        (Printf.sprintf "pass-list entry %s must not be on scrub list" p)
+        (Env_keeper_scrub.is_scrubbed p))
+    Env_keeper_scrub.pass
+
+let test_filter_environment () =
+  let env = [|
+    "PATH=/usr/bin";
+    "ANTHROPIC_API_KEY=sk-ant-xxx";
+    "GH_TOKEN=ghp_yyy";
+    "AWS_SECRET_ACCESS_KEY=zzz";
+    "SSH_AUTH_SOCK=/tmp/sock";
+    "FOO=bar";
+    "malformed_entry_no_equals";  (* no '=' — key equals the whole entry *)
+  |] in
+  let out = Env_keeper_scrub.filter_environment env in
+  let out_list = Array.to_list out in
+  assert_contains ~msg:"PATH preserved" out_list "PATH=/usr/bin";
+  assert_contains ~msg:"GH_TOKEN preserved (pass)" out_list "GH_TOKEN=ghp_yyy";
+  assert_contains ~msg:"SSH_AUTH_SOCK preserved" out_list "SSH_AUTH_SOCK=/tmp/sock";
+  assert_contains ~msg:"FOO preserved (neutral)" out_list "FOO=bar";
+  assert_contains ~msg:"entries without = are kept"
+    out_list "malformed_entry_no_equals";
+  assert_false "ANTHROPIC_API_KEY stripped"
+    (List.exists (fun e -> String.starts_with ~prefix:"ANTHROPIC_API_KEY=" e) out_list);
+  assert_false "AWS_SECRET_ACCESS_KEY stripped"
+    (List.exists (fun e -> String.starts_with ~prefix:"AWS_SECRET_ACCESS_KEY=" e) out_list)
+
+let test_no_forgotten_git_askpass_literals () =
+  (* Enforcement grep: outside of the SSOT module itself, [lib/] must not
+     contain inline "GIT_ASKPASS" / "GIT_TERMINAL_PROMPT" literals. If this
+     test fails, route the new call site through
+     [Env_git_noninteractive.docker_args] or
+     [Env_git_noninteractive.inject_into_environment] instead. *)
+  let root =
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some d -> d
+    | None -> Sys.getcwd ()
+  in
+  let lib_dir = Filename.concat root "lib" in
+  let cmd =
+    Printf.sprintf
+      "rg --no-messages -l 'GIT_ASKPASS|GIT_TERMINAL_PROMPT' %s \
+       --glob '!env_git_noninteractive.*' \
+       --glob '*.ml' --glob '*.mli' || true"
+      (Filename.quote lib_dir)
+  in
+  let ic = Unix.open_process_in cmd in
+  let rec drain acc =
+    try drain (input_line ic :: acc)
+    with End_of_file -> List.rev acc
+  in
+  let lines = drain [] in
+  let _ = Unix.close_process_in ic in
+  let offenders =
+    List.filter
+      (fun line ->
+        let base = Filename.basename line in
+        base <> "env_git_noninteractive.ml"
+        && base <> "env_git_noninteractive.mli")
+      lines
+  in
+  if offenders <> [] then
+    fail
+      (Printf.sprintf
+         "Found inline GIT_ASKPASS/GIT_TERMINAL_PROMPT outside SSOT: %s"
+         (String.concat "; " offenders))
 
 let () =
-  Alcotest.run "env_git_noninteractive"
-    [
-      ( "constants",
-        [
-          Alcotest.test_case "env pairs exact" `Quick test_env_pairs_are_exact;
-          Alcotest.test_case "docker argv flatten" `Quick test_docker_env_args_flatten;
-          Alcotest.test_case "docker argv length invariant" `Quick test_docker_env_args_even_length;
-        ] );
-    ]
+  test_env_has_required_keys ();
+  test_env_values_enforce_noninteractive ();
+  test_env_pairs_serialized ();
+  test_docker_args_pair_structure ();
+  test_inject_override_existing ();
+  test_inject_injects_when_missing ();
+  test_scrub_membership ();
+  test_scrub_exact_match_only ();
+  test_scrub_and_pass_disjoint ();
+  test_filter_environment ();
+  test_no_forgotten_git_askpass_literals ();
+  (* Silence unused-value warning if a helper is unused in a future edit. *)
+  let _ = assert_list_eq in
+  print_endline "test_env_git_noninteractive: OK"


### PR DESCRIPTION
RFC-0007 PR-1 lands first. Two SSOT modules + wiring into the two keeper subprocess env paths. RFC-0008 PR-1 (`CredentialProvider`) consumes `Env_git_noninteractive.env` next.

## Why

RFC-0007 §1 documented two concrete failures observed on 2026-04-24:

1. **Non-interactive git defaults not enforced.** Git credential helpers open `/dev/tty` to prompt. A Docker sandbox or background subprocess has no tty, so the call hangs until the outer wall-clock timeout fires silently. Compounds with the cooperative-cancel overshoot surfaced by #9860.
2. **Long-lived host credentials leak into subprocess env.** `ANTHROPIC_API_KEY`, `AWS_SECRET_ACCESS_KEY`, `OTEL_EXPORTER_OTLP_*` bearer headers, `ACTIONS_ID_TOKEN_REQUEST_TOKEN` etc are read in-process by MASC and are not needed by gh/git inside a sandboxed container. Leaking them creates an escape surface.

Both fall under RFC-0007 principles **P2** (scrub vs pass by token scoping) and **P3** (non-interactive defaults are a constant, not an opinion).

## What

- `lib/env_git_noninteractive.{ml,mli}` — canonical pairs `GIT_TERMINAL_PROMPT=0`, `GIT_ASKPASS=\"\"`, `GCM_INTERACTIVE=Never`, `SSH_ASKPASS=\"\"`. Exposes three shapes: assoc list, flat `K=V` list for `Unix.environment`, and `[\"-e\"; \"K=V\"; ...]` for direct `docker run` argv. `inject_into_environment` overrides any pre-existing entries so the canonical value wins.
- `lib/env_keeper_scrub.{ml,mli}` — exact-match scrub list copied from claude-code `src/utils/subprocessEnv.ts:15-53` (`GHA_SUBPROCESS_SCRUB`), plus a documentation pass list (`GH_TOKEN`, `GITHUB_TOKEN`, `SSH_AUTH_SOCK`, `GIT_*`) asserted to be disjoint from scrub.
- `lib/keeper/keeper_gh_env.ml` — `process_env` and `keeper_process_env` now compose: `Unix.environment()` → `Env_keeper_scrub.filter_environment` → `Env_git_noninteractive.inject_into_environment` → strip existing `GH_CONFIG_DIR=` → prepend keeper-scoped value.
- `lib/keeper/keeper_shell_docker.ml` — appends `Env_git_noninteractive.docker_args` to the Docker `-e` list so git inside the sandbox observes the same defaults.
- `test/test_env_git_noninteractive.ml` — 11 assertions including an enforcement grep under `lib/` that fails on any future inline `GIT_ASKPASS`/`GIT_TERMINAL_PROMPT` literal outside the SSOT module.

## Design references

- claude-code `src/utils/worktree.ts:199-202` — `GIT_NO_PROMPT_ENV` record (exact copy of the pattern, not just the idea).
- claude-code `src/utils/subprocessEnv.ts:15-53` — `GHA_SUBPROCESS_SCRUB` list (copied key-by-key with rationale comments preserved).
- RFC-0007 rev.2 §2 (design principles P2 + P3) in PR #9842.

## Non-goals

- No Docker sandbox runtime change, no seccomp delta, no `keeper_binding` shape change.
- No `gh_result.t` (RFC-0007 PR-2), no typed `gh_request.t` (RFC-0007 PR-3).
- No cross-repo changes. OAS is untouched.
- RFC-0008 PR-1 (`CredentialProvider` trait) depends on this PR's `Env_git_noninteractive.env` and lands separately.

## Test plan

- [x] `dune build @check` clean
- [x] `dune exec test/test_env_git_noninteractive.exe` — all 11 assertions pass
- [x] Enforcement grep test passes on current main (no inline `GIT_ASKPASS` outside SSOT)
- [ ] Live verification: next keeper turn that spawns a Docker sandbox should show `-e GIT_TERMINAL_PROMPT=0` etc in the argv; any credential prompt scenario that previously hung silently should now fail fast with a clean git error

## Cluster B issues addressed or contextualized

- **#9843** ('anyang-keepers' shares operator PAT) — RFC-0008 territory; this PR lays the env groundwork so RFC-0008 can ship without touching host-env scatter.
- **#9844** (`gh auth login --with-token` rewrites `hosts.yml:user`) — RFC-0008 territory, same as above.
- **#9786** (bearer token mismatch across agents) — same.
- **#9728** (approval bypass cannot be human-proof while agents share creds) — architectural; RFC-0008.
- This PR does NOT claim to close any of the above. It is a necessary pre-requisite per RFC-0007 §6 (merge order).

Refs: #9842 (RFC design review), #9860 (prior tick — timeout SSOT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)