### PR TITLE
[codex] fix keeper autonomy recovery gates

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -221,7 +221,7 @@ let extract_generated_nickname_prefix name =
 let is_generated_nickname_shape name =
   List.length (String.split_on_char '-' name) >= 3
 
-let extract_agent_type_prefix name =
+let keeper_transport_alias_stable_name name =
   match String.split_on_char '-' name with
   | "keeper" :: rest -> (
       match List.rev rest with
@@ -229,8 +229,16 @@ let extract_agent_type_prefix name =
           List.rev middle_rev
           |> String.concat "-"
           |> trim_nonempty
-      | _ -> Some "keeper")
-  | _ -> extract_generated_nickname_prefix name
+      | _ -> None)
+  | _ -> None
+
+let extract_agent_type_prefix name =
+  match keeper_transport_alias_stable_name name with
+  | Some stable_name -> Some stable_name
+  | None -> (
+      match String.split_on_char '-' name with
+      | "keeper" :: _ -> Some "keeper"
+      | _ -> extract_generated_nickname_prefix name)
 
 let credential_agent_name agent_name =
   match extract_agent_type_prefix agent_name with
@@ -494,7 +502,23 @@ let missing_credential_error config ~agent_name ~token : masc_error =
     accepted. Generated nicknames may also use a token owned by their
     stable prefix, but only when the supplied token itself resolves to
     that prefix. This keeps joined nickname continuity without letting an
-    unrelated bearer token impersonate another generated family. *)
+    unrelated bearer token impersonate another generated family. Keeper
+    transport aliases (keeper-<name>-agent) additionally accept an
+    existing stable keeper token even after an exact alias credential has
+    been bootstrapped, because these aliases are transport identity, not
+    separate runtime actors. *)
+let verify_token_owner_alias config ~agent_name ~token =
+  match find_credential_by_token config ~token with
+  | Ok owner when String.equal owner.agent_name (credential_agent_name agent_name) ->
+      Ok owner
+  | Ok owner ->
+      Error
+        (Unauthorized
+           (Printf.sprintf
+              "No credential found for %s (bearer token belongs to %s)"
+              agent_name owner.agent_name))
+  | Error e -> Error e
+
 let verify_token config ~agent_name ~token : (agent_credential, masc_error) result =
   let cred_opt =
     match load_credential config agent_name with
@@ -504,22 +528,14 @@ let verify_token config ~agent_name ~token : (agent_credential, masc_error) resu
         |> List.find_map (load_credential config)
   in
   match cred_opt with
-  | None -> (
-      match find_credential_by_token config ~token with
-      | Ok owner
-        when String.equal owner.agent_name (credential_agent_name agent_name) ->
-          Ok owner
-      | Ok owner ->
-          Error
-            (Unauthorized
-               (Printf.sprintf
-                  "No credential found for %s (bearer token belongs to %s)"
-                  agent_name owner.agent_name))
-      | Error e -> Error e)
+  | None -> verify_token_owner_alias config ~agent_name ~token
   | Some cred ->
       let token_hash = sha256_hash token in
       if cred.token <> token_hash then
-        Error (InvalidToken "Token mismatch")
+        if Option.is_some (keeper_transport_alias_stable_name agent_name) then
+          verify_token_owner_alias config ~agent_name ~token
+        else
+          Error (InvalidToken "Token mismatch")
       else
         (* Check expiry *)
         match cred.expires_at with

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -2577,6 +2577,64 @@ let run_turn
              ~history_messages
              ~actual_input_tokens:usage.input_tokens
          in
+         let has_positive_count_after_marker haystack marker =
+           let haystack = String.lowercase_ascii haystack in
+           let marker = String.lowercase_ascii marker in
+           let hay_len = String.length haystack in
+           let marker_len = String.length marker in
+           let is_digit c = c >= '0' && c <= '9' in
+           let rec parse_digits idx acc =
+             if idx >= hay_len || not (is_digit haystack.[idx]) then acc
+             else
+               parse_digits (idx + 1)
+                 ((acc * 10) + Char.code haystack.[idx] - Char.code '0')
+           in
+           let rec skip_to_digit start idx =
+             if idx >= hay_len || idx - start > 32 then false
+             else if is_digit haystack.[idx] then
+               parse_digits idx 0 > 0
+             else
+               skip_to_digit start (idx + 1)
+           in
+           let rec search idx =
+             if marker_len = 0 || idx + marker_len > hay_len then false
+             else if String.sub haystack idx marker_len = marker then
+               skip_to_digit (idx + marker_len) (idx + marker_len)
+             else
+               search (idx + 1)
+           in
+           search 0
+         in
+         let actionable_signal_context =
+           let haystack = user_message ^ "\n" ^ dynamic_context in
+           String_util.contains_substring_ci haystack "## Discovered Work"
+           || has_positive_count_after_marker haystack "### Board Activity"
+           || has_positive_count_after_marker haystack "Unclaimed tasks"
+         in
+         let passive_status_tool_name = function
+           | "masc_status"
+           | "keeper_context_status"
+           | "masc_plan_get"
+           | "keeper_time_now"
+           | "keeper_board_list"
+           | "keeper_board_get"
+           | "keeper_tasks_list"
+           | "masc_tasks" ->
+               true
+           | _ -> false
+         in
+         let passive_only_actionable_turn_reason =
+           if actionable_signal_context
+              && actual_keeper_tool_names <> []
+              && List.for_all passive_status_tool_name actual_keeper_tool_names
+           then
+             Some
+               (Printf.sprintf
+                  "actionable keeper signal was present, but the model only used passive status/read tools: %s"
+                  (String.concat ", " actual_keeper_tool_names))
+           else
+             None
+         in
          (* Required-tool turns are filtered onto providers that declare
             tool support plus tool_choice support. If a text-only response
             still reaches this point, treat it as a contract failure. *)
@@ -2590,31 +2648,48 @@ let run_turn
              Keeper_tool_disclosure.validate_completion_contract_presence
                ~contract:effective_completion_contract
                ~tool_present:!keeper_surface_tool_used_ref
+             , passive_only_actionable_turn_reason
            with
-           | Ok () ->
-             receipt_tool_contract_result_ref := "satisfied";
-             Ok text
-           | Error reason ->
-             receipt_tool_contract_result_ref := "violated";
-             let contract_str =
-               match effective_completion_contract with
-               | Keeper_tool_disclosure.Allow_text_or_tool -> "Allow_text_or_tool"
-               | Keeper_tool_disclosure.Require_tool_use -> "Require_tool_use"
-             in
-             Log.Keeper.error
-               "keeper:%s required tool contract violated \
-                (turn=%d, tools=%d, contract=%s). \
-                Rejecting text-only response. Reason: %s"
-               meta.name result.turns
-               (List.length actual_keeper_tool_names)
-               contract_str reason;
-             Error
-               (Oas.Error.Agent
-                  (Oas.Error.CompletionContractViolation
-                     {
-                       contract = Oas.Completion_contract_id.Require_tool_use;
-                       reason;
-                     }))
+           | Ok (), Some reason ->
+               receipt_tool_contract_result_ref := "violated";
+               Log.Keeper.error
+                 "keeper:%s required tool contract violated \
+                  (turn=%d, tools=%d). Rejecting passive-only actionable turn. \
+                  Reason: %s"
+                 meta.name result.turns
+                 (List.length actual_keeper_tool_names)
+                 reason;
+               Error
+                 (Oas.Error.Agent
+                    (Oas.Error.CompletionContractViolation
+                       {
+                         contract = Oas.Completion_contract_id.Require_tool_use;
+                         reason;
+                       }))
+           | Ok (), None ->
+               receipt_tool_contract_result_ref := "satisfied";
+               Ok text
+           | Error reason, _ ->
+               receipt_tool_contract_result_ref := "violated";
+               let contract_str =
+                 match effective_completion_contract with
+                 | Keeper_tool_disclosure.Allow_text_or_tool -> "Allow_text_or_tool"
+                 | Keeper_tool_disclosure.Require_tool_use -> "Require_tool_use"
+               in
+               Log.Keeper.error
+                 "keeper:%s required tool contract violated \
+                  (turn=%d, tools=%d, contract=%s). \
+                  Rejecting text-only response. Reason: %s"
+                 meta.name result.turns
+                 (List.length actual_keeper_tool_names)
+                 contract_str reason;
+               Error
+                 (Oas.Error.Agent
+                    (Oas.Error.CompletionContractViolation
+                       {
+                         contract = Oas.Completion_contract_id.Require_tool_use;
+                         reason;
+                       }))
          in
          let finalize_response_text raw_response_text =
            let stop_reason_str =

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -100,11 +100,16 @@ let ensure_keeper_meta config name =
       apply_default defaults.proactive_idle_sec Keeper_config.default_proactive_idle_sec in
     let target_cooldown_sec =
       apply_default defaults.proactive_cooldown_sec Keeper_config.default_proactive_cooldown_sec in
+    let target_tool_access = resynced_tool_access defaults meta in
     let target_room_signal_prompt_enabled =
       match Keeper_config.keeper_room_signal_prompt_enabled_override () with
       | Some override -> override
       | None ->
-          Option.value ~default:Keeper_config.default_room_signal_prompt_enabled
+          Option.value
+            ~default:
+              (tool_access_default_room_signal_prompt_enabled
+                 ~default:Keeper_config.default_room_signal_prompt_enabled
+                 target_tool_access)
             defaults.room_signal_prompt_enabled
     in
     let target_denylist = apply_default defaults.tool_denylist meta.tool_denylist in
@@ -141,7 +146,6 @@ let ensure_keeper_meta config name =
         Log.Keeper.error "%s" msg;
         Error msg
     | Ok resolved_target_cascade_name ->
-    let target_tool_access = resynced_tool_access defaults meta in
     let target_tool_preset_source =
       match defaults.tool_preset_source with
       | Some _ as s -> s

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -79,14 +79,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
       ~fallback_targets:p.profile_defaults.mention_targets
       ~name:p.name
   in
-  let room_signal_prompt_enabled =
-    match keeper_room_signal_prompt_enabled_override () with
-    | Some value -> value
-    | None ->
-        Option.value
-          ~default:default_room_signal_prompt_enabled
-          p.profile_defaults.room_signal_prompt_enabled
-  in
   if goal = "" then begin
     Log.Keeper.warn "create_keeper failed: goal is required (name=%s)" p.name;
     (false, "goal is required when creating a keeper")
@@ -180,6 +172,17 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                         ~fallback:p.profile_defaults.tool_also_allow
                     in
                     Preset { preset = tool_preset; also_allow = tool_also_allow }
+              in
+              let room_signal_prompt_enabled =
+                match keeper_room_signal_prompt_enabled_override () with
+                | Some value -> value
+                | None ->
+                    Option.value
+                      ~default:
+                        (tool_access_default_room_signal_prompt_enabled
+                           ~default:default_room_signal_prompt_enabled
+                           tool_access)
+                      p.profile_defaults.room_signal_prompt_enabled
               in
               let tool_denylist =
                 resolve_tool_name_list

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -75,14 +75,6 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
          else p.profile_defaults.mention_targets)
       ~name:p.name
   in
-  let room_signal_prompt_enabled =
-    match keeper_room_signal_prompt_enabled_override () with
-    | Some value -> value
-    | None ->
-        Option.value
-          ~default:default_room_signal_prompt_enabled
-          p.profile_defaults.room_signal_prompt_enabled
-  in
   let (compaction_profile, compaction_ratio_gate, compaction_message_gate, compaction_token_gate) =
     resolve_compaction_policy
       ~profile_opt:p.compaction_profile_opt
@@ -117,6 +109,17 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
                 in
                 Preset { preset; also_allow }
             | None -> Custom names)
+  in
+  let room_signal_prompt_enabled =
+    match keeper_room_signal_prompt_enabled_override () with
+    | Some value -> value
+    | None ->
+        Option.value
+          ~default:
+            (tool_access_default_room_signal_prompt_enabled
+               ~default:default_room_signal_prompt_enabled
+               tool_access)
+          p.profile_defaults.room_signal_prompt_enabled
   in
   let tool_denylist =
     let profile_or_old =

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -52,6 +52,19 @@ type tool_access =
       }
   | Custom of string list
 
+let tool_names_include_board name_list =
+  List.exists
+    (fun name ->
+       String.starts_with ~prefix:"keeper_board_" name
+       || String.starts_with ~prefix:"masc_board_" name)
+    name_list
+
+let tool_access_default_room_signal_prompt_enabled ~default = function
+  | Preset { preset = Minimal; also_allow } ->
+      default || tool_names_include_board also_allow
+  | Preset _ -> true
+  | Custom tool_names -> tool_names_include_board tool_names
+
 (* -- Runtime types (moved into agent_runtime_state) -- *)
 
 type compaction_runtime =

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -54,6 +54,9 @@ type tool_access =
     }
   | Custom of string list
 
+val tool_access_default_room_signal_prompt_enabled :
+  default:bool -> tool_access -> bool
+
 (** {1 Runtime types (embedded in agent_runtime_state)} *)
 
 type compaction_runtime = {

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -399,15 +399,10 @@ let resolve_tool_lane_for_oas_tools
         List.filter public_mcp_tool_requires_bound_actor public_tool_names
     | _ -> []
   in
-  match codex_keeper_bound_actor_tools, tool_requirement with
-  | _ :: _ as bound_actor_tools, `Required ->
-      let detail =
-        Printf.sprintf
-          "codex_cli runtime MCP cannot carry keeper-bound auth headers for: %s"
-          (String.concat ", " bound_actor_tools)
-      in
-      Error (invalid_runtime_config "runtime_mcp_auth" detail)
-  | _ ->
+  if codex_keeper_bound_actor_tools <> [] then
+    Log.warn ~ctx:"oas_worker_exec"
+      "codex_cli omitting keeper-bound runtime MCP tool(s) that require request-scoped auth headers: %s"
+      (String.concat ", " codex_keeper_bound_actor_tools);
   let public_tool_names =
     if codex_keeper_bound_actor_tools = [] then
       public_tool_names

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -416,6 +416,42 @@ let test_verify_token_keeper_exact_match () =
            "keeper credential should verify with exact agent_name: %s"
            (Types.masc_error_to_string e))
 
+let test_verify_token_keeper_alias_accepts_stable_owner_after_bootstrap () =
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      match Auth.create_token dir ~agent_name:"sangsu" ~role:Types.Worker with
+      | Error e ->
+          fail
+            (Printf.sprintf "stable keeper token creation failed: %s"
+               (Types.masc_error_to_string e))
+      | Ok (stable_raw_token, _) -> (
+          match
+            Auth.ensure_keeper_credential dir
+              ~agent_name:"keeper-sangsu-agent"
+          with
+          | Error e ->
+              fail
+                (Printf.sprintf "keeper credential bootstrap failed: %s"
+                   (Types.masc_error_to_string e))
+          | Ok _ -> (
+              check bool "exact alias credential exists" true
+                (Option.is_some
+                   (Auth.load_credential dir "keeper-sangsu-agent"));
+              match
+                Auth.verify_token dir ~agent_name:"keeper-sangsu-agent"
+                  ~token:stable_raw_token
+              with
+              | Ok cred ->
+                  check string "stable keeper owner accepted" "sangsu"
+                    cred.agent_name
+              | Error e ->
+                  fail
+                    (Printf.sprintf
+                       "keeper alias should accept stable owner token after bootstrap: %s"
+                       (Types.masc_error_to_string e)))))
+
 let test_load_credential_missing_keeper_alias_stays_quiet () =
   let dir = setup_test_room () in
   let resolved, stderr_output =
@@ -778,6 +814,8 @@ let () =
         test_extract_agent_type_prefix_keeper_aliases;
       test_case "verify_token keeper exact match" `Quick
         test_verify_token_keeper_exact_match;
+      test_case "verify_token keeper alias accepts stable owner after bootstrap" `Quick
+        test_verify_token_keeper_alias_accepts_stable_owner_after_bootstrap;
       test_case "load_credential missing keeper alias stays quiet" `Quick
         test_load_credential_missing_keeper_alias_stays_quiet;
       test_case "verify_token dashboard legacy alias fallback" `Quick

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1529,7 +1529,7 @@ let test_resolve_tool_lane_for_codex_cli_public_tools_with_agent_name_strips_run
         "expected codex_cli public MCP tools with agent_name to use runtime MCP lane"
   | Error err -> Alcotest.fail (Oas.Error.to_string err)
 
-let test_resolve_tool_lane_for_codex_cli_keeper_bound_public_tools_rejects () =
+let test_resolve_tool_lane_for_codex_cli_keeper_bound_public_tools_omits_bound_tools () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
   with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
   let tools =
@@ -1541,13 +1541,26 @@ let test_resolve_tool_lane_for_codex_cli_keeper_bound_public_tools_rejects () =
       ~provider_cfg:(make_codex_cli_provider_cfg ())
       ~tools ()
   with
-  | Ok _ ->
+  | Ok (effective_tools, Some policy) ->
+      let masc_headers =
+        List.find_map
+          (function
+            | Llm_provider.Llm_transport.Http_server server
+              when String.equal server.name "masc" -> Some server.headers
+            | _ -> None)
+          policy.servers
+      in
+      Alcotest.(check int) "runtime lane strips inline tools" 0
+        (List.length effective_tools);
+      Alcotest.(check (list string)) "keeper-bound tool omitted for codex_cli"
+        [ "masc_status" ] policy.allowed_tool_names;
+      Alcotest.(check (option string)) "codex_cli strips keeper header" None
+        (Option.bind masc_headers (List.assoc_opt "x-masc-keeper-name"));
+      Alcotest.(check (option string)) "codex_cli strips internal token" None
+        (Option.bind masc_headers (List.assoc_opt "x-masc-internal-token"))
+  | Ok (_, None) ->
       Alcotest.fail
-        "expected codex_cli keeper-bound public MCP tools to reject runtime lane"
-  | Error (Oas.Error.Config (Oas.Error.InvalidConfig { field; detail })) ->
-      Alcotest.(check string) "field" "runtime_mcp_auth" field;
-      Alcotest.(check bool) "detail mentions bound tool" true
-        (contains_substring ~needle:"masc_claim_next" detail)
+        "expected codex_cli keeper-bound public MCP tools to keep safe runtime lane"
   | Error err -> Alcotest.fail (Oas.Error.to_string err)
 
 let test_resolve_tool_lane_for_kimi_cli_public_tools_uses_runtime_mcp_policy () =
@@ -3293,9 +3306,9 @@ let () =
         `Quick
         test_resolve_tool_lane_for_codex_cli_public_tools_with_agent_name_strips_runtime_headers;
       Alcotest.test_case
-        "keeper-bound public MCP tools on codex_cli reject runtime MCP lane"
+        "keeper-bound public MCP tools on codex_cli omit request-scoped tools"
         `Quick
-        test_resolve_tool_lane_for_codex_cli_keeper_bound_public_tools_rejects;
+        test_resolve_tool_lane_for_codex_cli_keeper_bound_public_tools_omits_bound_tools;
       Alcotest.test_case "public MCP tools on kimi_cli use runtime MCP lane" `Quick
         test_resolve_tool_lane_for_kimi_cli_public_tools_uses_runtime_mcp_policy;
       Alcotest.test_case

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -371,9 +371,29 @@ let () =
           |> to_list
           |> List.map to_string
         in
-        Alcotest.(check (list string)) "tool_access enum == variant SSOT"
-          Masc_mcp.Keeper_types.valid_tool_preset_strings
-          enum);
+      Alcotest.(check (list string)) "tool_access enum == variant SSOT"
+        Masc_mcp.Keeper_types.valid_tool_preset_strings
+        enum);
+      Alcotest.test_case "room signal defaults follow keeper tool access" `Quick (fun () ->
+        let open Masc_mcp.Keeper_types in
+        let check_access label expected access =
+          Alcotest.(check bool) label expected
+            (tool_access_default_room_signal_prompt_enabled
+               ~default:false
+               access)
+        in
+        check_access "minimal stays quiet by default" false
+          (Preset { preset = Minimal; also_allow = [] });
+        check_access "minimal board opt-in listens" true
+          (Preset { preset = Minimal; also_allow = [ "keeper_board_post" ] });
+        check_access "delivery listens to board by default" true
+          (Preset { preset = Delivery; also_allow = [] });
+        check_access "messaging listens to board by default" true
+          (Preset { preset = Messaging; also_allow = [] });
+        check_access "custom without board stays quiet" false
+          (Custom [ "keeper_time_now" ]);
+        check_access "custom board allowlist listens" true
+          (Custom [ "keeper_board_post" ]));
       Alcotest.test_case "Social, Dispatch, and Delivery present" `Quick (fun () ->
         let open Masc_mcp.Keeper_types in
         Alcotest.(check bool) "social present" true


### PR DESCRIPTION
## Summary

Fixes several keeper autonomy blockers observed in live runtime:

- allow keeper transport aliases like `keeper-sangsu-agent` to authenticate with the stable keeper token owner after alias credential bootstrap
- stop Codex CLI runtime MCP from hard-failing the whole lane when keeper-bound public tools require request-scoped auth headers
- derive default room-signal listening from keeper tool access so board-capable presets react to board activity by default
- reject actionable turns where the model only used passive/read tools, allowing the completion contract path to recover instead of ending as a status-only turn

## Root Cause

The live fleet had multiple independent choke points:

- exact keeper alias credentials could shadow the stable keeper token owner and return `InvalidToken`
- Codex CLI request-scoped MCP auth was treated as a terminal config error for required tools
- board-capable keepers could still default to `room_signal_prompt_enabled=false`
- `tool_required` accepted passive observation tools as satisfying work even when actionable board/task signals were present

## Validation

- `dune build --root . --build-dir /tmp/masc-keeper-autonomy-recovery-build test/test_auth.exe test/test_types.exe test/test_oas_worker.exe test/test_auth_doctor.exe test/test_auth_coverage.exe test/test_tool_access_role.exe test/test_tool_token.exe`
- `dune build --root . --build-dir /tmp/masc-keeper-autonomy-recovery-auth-build @test/runtest-test_auth`
- `dune build --root . --build-dir /tmp/masc-keeper-autonomy-recovery-build @test/runtest-test_types`
- `dune build --root . --build-dir /tmp/masc-keeper-autonomy-recovery-oas-build @test/runtest-test_oas_worker`
- `git diff --check -- '*.ml' '*.mli'`
