### PR TITLE
feat(keeper): introduce Env_git_noninteractive (RFC-0007 rev.3 PR-1)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -564,6 +564,7 @@
    oas_bus_instrument
    oas_sse_bridge
    env_config_introspect
+   env_git_noninteractive
    runtime_params
    governance_registry
    governance_pipeline_types

--- a/lib/env_git_noninteractive.ml
+++ b/lib/env_git_noninteractive.ml
@@ -1,0 +1,8 @@
+let env =
+  [
+    ("GIT_ASKPASS", "");
+    ("GIT_TERMINAL_PROMPT", "0");
+  ]
+
+let docker_env_args =
+  List.concat_map (fun (k, v) -> [ "-e"; k ^ "=" ^ v ]) env

--- a/lib/env_git_noninteractive.mli
+++ b/lib/env_git_noninteractive.mli
@@ -1,0 +1,27 @@
+(** Non-interactive git environment — RFC-0007 rev.3 PR-1.
+
+    Centralised constants that force git subprocesses (invoked inside
+    the keeper docker sandbox or via [Unix.execve]) to fail fast rather
+    than block on a credential prompt.
+
+    Evidence (2026-04-24, commit 0e408ffc1d5b34badb0cc1b9f3704a9e725fb8c6):
+    [rg -n 'GIT_ASKPASS|GIT_TERMINAL_PROMPT' lib/ test/ scripts/] returned
+    zero hits. A keeper [git push] inside docker could, in principle,
+    hang indefinitely if the RO-mounted [hosts.yml] auth path failed
+    before git fell through to a prompt. This module is the centralised
+    fix (RFC-0007 PR-1, one callsite today: [keeper_shell_docker.ml:234-245]).
+
+    Consumers MUST prefer these constants over open-coding the pairs,
+    so future callsites inherit the safety guarantee by construction. *)
+
+val env : (string * string) list
+(** The two canonical pairs:
+    - [("GIT_ASKPASS", "")]       — empty helper, git raises instead of prompting
+    - [("GIT_TERMINAL_PROMPT", "0")] — disables the git-core prompt fallback *)
+
+val docker_env_args : string list
+(** [env] flattened as docker [run -e KEY=VALUE] argv tokens.
+
+    Each pair [(k, v)] produces two tokens [\["-e"; k ^ "=" ^ v\]], matching
+    the existing inline style in [keeper_shell_docker.ml]. Callers append
+    this to their existing [-e] list. *)

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -240,6 +240,7 @@ let run_docker_shell_command_with_status
                 "-e"; "GIT_CONFIG_KEY_0=safe.directory";
                 "-e"; "GIT_CONFIG_VALUE_0=*";
               ]
+              @ Env_git_noninteractive.docker_env_args
               @ git_identity_env ~name:git_author_name ~email:git_author_email
             in
             Ok (mounts, envs)

--- a/test/dune
+++ b/test/dune
@@ -102,6 +102,7 @@
         test_keeper_transition_audit
         test_keeper_shell_containment
         test_keeper_shell_docker_route
+        test_env_git_noninteractive
         test_keeper_fs_edit_patch
         test_keeper_docker_read
         test_keeper_github_read_only
@@ -219,6 +220,7 @@
           test_keeper_transition_audit
           test_keeper_shell_containment
           test_keeper_shell_docker_route
+          test_env_git_noninteractive
           test_keeper_fs_edit_patch
           test_keeper_docker_read
           test_keeper_github_read_only

--- a/test/test_env_git_noninteractive.ml
+++ b/test/test_env_git_noninteractive.ml
@@ -1,0 +1,38 @@
+(** Unit tests for [Env_git_noninteractive] — RFC-0007 rev.3 PR-1.
+
+    Asserts the exact pairs and docker argv flattening. Any change to the
+    constants breaks these tests and forces a deliberate review (there is
+    no reason to change them outside of a separate RFC). *)
+
+module Env_git_noninteractive = Masc_mcp.Env_git_noninteractive
+
+let test_env_pairs_are_exact () =
+  Alcotest.(check (list (pair string string)))
+    "env list matches the canonical two pairs"
+    [ ("GIT_ASKPASS", ""); ("GIT_TERMINAL_PROMPT", "0") ]
+    Env_git_noninteractive.env
+
+let test_docker_env_args_flatten () =
+  Alcotest.(check (list string))
+    "docker_env_args is -e K=V for each pair, in order"
+    [ "-e"; "GIT_ASKPASS="; "-e"; "GIT_TERMINAL_PROMPT=0" ]
+    Env_git_noninteractive.docker_env_args
+
+let test_docker_env_args_even_length () =
+  (* Structural: each docker [-e KEY=VALUE] is exactly two argv tokens.
+     Breaking this invariant breaks [keeper_shell_docker]'s inline argv. *)
+  Alcotest.(check int)
+    "docker_env_args length is 2x the env pair count"
+    (2 * List.length Env_git_noninteractive.env)
+    (List.length Env_git_noninteractive.docker_env_args)
+
+let () =
+  Alcotest.run "env_git_noninteractive"
+    [
+      ( "constants",
+        [
+          Alcotest.test_case "env pairs exact" `Quick test_env_pairs_are_exact;
+          Alcotest.test_case "docker argv flatten" `Quick test_docker_env_args_flatten;
+          Alcotest.test_case "docker argv length invariant" `Quick test_docker_env_args_even_length;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

First implementation step for **RFC-0007 rev.3 PR-1**. Introduces `lib/env_git_noninteractive.{ml,mli}` as the SSOT for the non-interactive git environment pair and wires it into the single docker env composition site at `lib/keeper/keeper_shell_docker.ml:234-245`.

Companion design PR: #9842 (RFC-0007 rev.3 + RFC-0008, design review only).

## Why

`rg -n 'GIT_ASKPASS|GIT_TERMINAL_PROMPT' lib/ test/ scripts/` on the pre-PR commit `0e408ffc1d5b34badb0cc1b9f3704a9e725fb8c6` returns **zero hits**. Without these constants, a keeper `git push` inside the docker sandbox can hang indefinitely on a credential prompt if the RO-mounted `hosts.yml` auth path fails before `gh` answers. The container is built from scratch via `-e` flags, so the only thing saving us today is that `gh` auth resolves before `git` falls through to a prompt — a fragile coupling with no local safety net.

## What changed

| File | Change |
|------|--------|
| `lib/env_git_noninteractive.mli` | **new** — public `val env` / `val docker_env_args` + evidence-anchored doc comment |
| `lib/env_git_noninteractive.ml` | **new** — `env = [("GIT_ASKPASS",""); ("GIT_TERMINAL_PROMPT","0")]`, `docker_env_args` = `[-e K=V]` flatten |
| `lib/dune` | +1 line — register module alphabetically |
| `lib/keeper/keeper_shell_docker.ml` | +1 line — `@ Env_git_noninteractive.docker_env_args` in the env composition |
| `test/test_env_git_noninteractive.ml` | **new** — 3 Alcotest cases (pair exactness, argv flatten, 2x-length invariant) |
| `test/dune` | +2 lines — register the test in both `(names …)` and `(modules …)` |

Net diff: **77 insertions**, 0 deletions, 6 files.

## Deferred from RFC-0007 rev.3 PR-1 (YAGNI)

- `lib/env_keeper_scrub.{ml,mli}` (scrub + pass lists). The current docker invocation builds env from scratch via positive `-e KEY=VALUE` flags; **there is no host-env-iteration consumer today** for a scrub list. Introducing unused scaffolding violates CLAUDE.md "Simplicity First". Will land in a separate follow-up PR when a consumer pathway emerges (e.g. when `keeper_exec_shell.ml` gains a local-exec code path that forwards host env).
- **Full integration regression test** asserting the produced docker argv contains both keys. Requires instantiating the sandbox config/identity paths and is larger than PR-1's scope. Shipping with three unit tests + the single-callsite review discipline; regression check moves with the scrub-list consumer PR.

## Verification

```
dune build @check --root .                        # passes, no warnings
dune exec --root . test/test_env_git_noninteractive.exe
  constants  0  env pairs exact             OK
  constants  1  docker argv flatten         OK
  constants  2  docker argv length invariant OK
  Test Successful in 0.000s. 3 tests run.
```

## Review focus

1. **Wiring site** (`keeper_shell_docker.ml`): the `@ Env_git_noninteractive.docker_env_args` append is placed between the existing `-e HOME/GH_CONFIG_DIR/GIT_CONFIG_*` block and `git_identity_env`. Is this the right order, or should it precede `HOME` so the prompt guard is the first thing set?
2. **mli doc comment**: it calls out the evidence record and single-callsite invariant. Anything future contributors need that isn't there?
3. **Deferred scrub list**: agreement that YAGNI beats scaffolding for PR-1?

## Do not merge label

Carrying `do-not-merge` until the review above is addressed. Remove the label to allow merge after review; auto-merge will then engage on CI green.
