### PR TITLE
[codex] Fix keeper credential bootstrap and status gating

### DIFF
--- a/lib/auth.mli
+++ b/lib/auth.mli
@@ -28,6 +28,7 @@ val room_secret_file : string -> string
 val auth_config_file : string -> string
 val credential_file : string -> string -> string
 val internal_keeper_token_hash_file : string -> string
+val internal_keeper_token_env_key : string
 
 (** {1 Auth Config} *)
 

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -166,6 +166,9 @@ let kimi_cli_runtime_mcp_jsons =
 let public_mcp_tools_of_oas_tools =
   Oas_worker_exec_transport.public_mcp_tools_of_oas_tools
 
+let public_mcp_tool_requires_bound_actor =
+  Oas_worker_exec_transport.public_mcp_tool_requires_bound_actor
+
 let tool_names_are_public_mcp =
   Oas_worker_exec_transport.tool_names_are_public_mcp
 

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -166,9 +166,6 @@ let kimi_cli_runtime_mcp_jsons =
 let public_mcp_tools_of_oas_tools =
   Oas_worker_exec_transport.public_mcp_tools_of_oas_tools
 
-let public_mcp_tool_requires_bound_actor =
-  Oas_worker_exec_transport.public_mcp_tool_requires_bound_actor
-
 let tool_names_are_public_mcp =
   Oas_worker_exec_transport.tool_names_are_public_mcp
 

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1173,6 +1173,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       bootstrap_server_state_blocking state;
       sync_admin_token_env state;
       sync_internal_keeper_token_env state;
+      sync_bootable_keeper_credentials state;
       sync_client_token_file ~base_path ~agent_name:"codex-mcp-client"
         ~role:Types.Worker;
       let path_diagnostics =

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -102,6 +102,17 @@ let credential_state (ctx : context) ~actual_name =
   let auth_cfg = Auth.load_auth_config ctx.config.base_path in
   let credential_required = auth_cfg.enabled && auth_cfg.require_token in
   let credential_candidates = unique_strings [ ctx.agent_name; actual_name ] in
+  let internal_keeper_credential_available name =
+    match
+      ( Keeper_identity.keeper_name_from_agent_name name,
+        Sys.getenv_opt Auth.internal_keeper_token_env_key )
+    with
+    | Some _, Some raw ->
+        let token = String.trim raw in
+        token <> ""
+        && Auth.verify_internal_keeper_token ctx.config.base_path ~token
+    | _ -> false
+  in
   let is_initial_admin name =
     match Auth.read_initial_admin ctx.config.base_path with
     | Some admin -> String.equal name admin
@@ -112,6 +123,7 @@ let credential_state (ctx : context) ~actual_name =
     || List.exists
          (fun name ->
            is_initial_admin name
+           || internal_keeper_credential_available name
            || Option.is_some (Auth.load_credential ctx.config.base_path name))
          credential_candidates
   in

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1696,19 +1696,20 @@ let test_sync_bootable_keeper_credentials_mints_keeper_alias_token () =
       in
       Server_runtime_bootstrap.bootstrap_server_state_blocking state;
       Server_runtime_bootstrap.sync_bootable_keeper_credentials state;
-      let token_path =
-        Filename.concat (Auth.auth_dir dir) "masc-improver.token"
+      let raw_token =
+        match Sys.getenv_opt "MASC_INTERNAL_MCP_TOKEN" with
+        | Some raw when String.trim raw <> "" -> String.trim raw
+        | _ -> Alcotest.fail "missing internal keeper token after startup sync"
       in
-      let raw_token = String.trim (read_file token_path) in
       let credential =
-        match Auth.load_credential dir "masc-improver" with
+        match Auth.load_credential dir "keeper-masc-improver-agent" with
         | Some cred -> cred
-        | None -> Alcotest.fail "missing masc-improver credential after startup sync"
+        | None ->
+            Alcotest.fail
+              "missing keeper-masc-improver-agent credential after startup sync"
       in
-      Alcotest.(check bool) "keeper token file created" true
-        (Sys.file_exists token_path);
-      Alcotest.(check int) "keeper token file private" 0o600
-        ((Unix.stat token_path).Unix.st_perm land 0o777);
+      Alcotest.(check bool) "internal keeper token hash persisted" true
+        (Sys.file_exists (Auth.internal_keeper_token_hash_file dir));
       Alcotest.(check string) "raw token hashes to keeper credential"
         credential.token (Auth.sha256_hash raw_token);
       match
@@ -1716,10 +1717,10 @@ let test_sync_bootable_keeper_credentials_mints_keeper_alias_token () =
           ~token:raw_token
       with
       | Ok alias_cred ->
-          Alcotest.(check string) "keeper alias resolves stored credential"
-            "masc-improver" alias_cred.agent_name
+          Alcotest.(check string) "keeper credential resolves exact agent"
+            "keeper-masc-improver-agent" alias_cred.agent_name
       | Error err ->
-          Alcotest.failf "bootable keeper token should verify via alias: %s"
+          Alcotest.failf "bootable keeper token should verify exactly: %s"
             (Types.masc_error_to_string err))
 
 let test_main_eio_rejects_same_base_path_on_second_server () =

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -310,6 +310,30 @@ let () = test "dispatch_status_suppresses_lifecycle_guidance_without_credential"
   | None -> failwith "dispatch returned None"
 )
 
+let () = test "dispatch_status_treats_keeper_internal_auth_as_credential" (fun () ->
+  Fun.protect ~finally:Fs_compat.clear_fs @@ fun () ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let ctx = { (make_test_ctx ()) with agent_name = "keeper-sangsu-agent" } in
+  let _ = Coord.init ctx.config ~agent_name:(Some "keeper-sangsu-agent") in
+  ignore (Auth.enable_auth ctx.config.base_path ~require_token:true ~agent_name:"admin");
+  ignore (Auth.ensure_internal_keeper_token ctx.config.base_path);
+  ignore (Coord.add_task ctx.config ~title:"Keeper work" ~priority:3 ~description:"");
+  Planning_eio.set_current_task ctx.config ~task_id:"task-001";
+  match Tool_coord.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
+  | Some (success, result) ->
+      assert success;
+      assert (
+        str_contains result
+          "🔐 Credential: required=yes | available=yes | candidates=keeper-sangsu-agent");
+      assert (
+        not
+          (str_contains result
+             "Lifecycle actions are credential-blocked for keeper-sangsu-agent"));
+      assert (str_contains result "💡 Suggested next:")
+  | None -> failwith "dispatch returned None"
+)
+
 let () = test "dispatch_status_no_owned_prefers_claim_next_over_transition" (fun () ->
   Fun.protect ~finally:Fs_compat.clear_fs @@ fun () ->
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
## Summary

- ensure bootable keeper credentials are synced during server startup
- expose the bound-actor MCP tool classifier needed by the latest provider filter path on `main`
- treat a valid internal keeper token as an available credential in keeper `masc_status`
- add regression coverage for startup credential sync and internal keeper credential status

## Root Cause

Keeper autonomous turns could be guided as lifecycle-blocked even when the internal keeper token path was valid, and startup did not guarantee canonical `keeper-<name>-agent` credentials. That left keepers such as `keeper-sangsu-agent` with missing credential state after restart and misleading `masc_status` guidance.

The Codex CLI keeper-bound MCP lane filter is now already present on `main`; this PR keeps the remaining credential/bootstrap/status fix and the small export required by that filter path.

## Validation

- `dune build --root . ./test/test_tool_coord_coverage.exe ./test/test_oas_worker.exe ./test/test_server_runtime_bootstrap.exe ./bin/main_eio.exe`
- `./_build/default/test/test_tool_coord_coverage.exe --compact --show-errors`
- `./_build/default/test/test_oas_worker.exe test resume_config 28,29 --compact --show-errors`
- `./_build/default/test/test_server_runtime_bootstrap.exe test bootstrap 46 --compact --show-errors`

## Live Check

- ran the patched binary against base path `/Users/dancer/me`
- confirmed startup verified 9 bootable keeper credentials
- confirmed direct MCP `masc_status` as `keeper-sangsu-agent` reports credential availability and no lifecycle-blocked guidance

## Follow-up

The remaining live blocker observed after this patch line is provider-side `kimi_cli` exit 1 on tool-required turns.