### PR TITLE
[codex] expose goal task runtime trust

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -537,6 +537,7 @@ describe('fetchKeeperConfig', () => {
   it('normalizes singleton string, numeric string, and boolean string fields', async () => {
     const rawResponse = {
       name: 'keeper-sangsu',
+      active_goal_ids: ['goal-runtime'],
       sandbox_profile: 'docker',
       network_mode: 'none',
       shared_memory_scope: 'room',
@@ -633,9 +634,20 @@ describe('fetchKeeperConfig', () => {
         presence_keepalive_sec: '30',
         runtime_blocker_continue_gate: 'false',
       },
+      runtime_trust: {
+        disposition: 'Pass',
+        disposition_reason: 'healthy',
+        needs_attention: false,
+      },
       coordination: {
         mention_targets: 'sangsu',
         joined_room_ids: 'default',
+        active_goal_ids: ['goal-runtime'],
+        active_goals: [
+          { id: 'goal-runtime', title: 'Ship runtime clarity', horizon: 'mid' },
+        ],
+        active_goal_count: '1',
+        missing_active_goal_ids: [],
       },
       tools: {
         tool_access: { kind: 'preset', preset: 'coding' },
@@ -724,6 +736,10 @@ describe('fetchKeeperConfig', () => {
     expect(result.sources.cascade_runtime_json_editable).toBe(false)
     expect(result.metrics.total_cost_usd).toBe(0.12)
     expect(result.runtime.presence_keepalive_sec).toBe(30)
+    expect(result.active_goal_ids).toEqual(['goal-runtime'])
+    expect(result.coordination.active_goal_ids).toEqual(['goal-runtime'])
+    expect(result.coordination.active_goals[0]?.title).toBe('Ship runtime clarity')
+    expect(result.runtime_trust?.disposition).toBe('Pass')
   })
 })
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1474,6 +1474,18 @@ function normalizeKeeperHookSlots(raw: unknown): Record<string, KeeperHookSlot> 
   return slots
 }
 
+function normalizeKeeperConfigActiveGoals(raw: unknown): KeeperConfig['coordination']['active_goals'] {
+  return asRecordArray(raw)
+    .map((item) => {
+      const id = asNullableString(item.id)
+      const title = asNullableString(item.title)
+      const horizon = asNullableString(item.horizon)
+      if (!id || !title || !horizon) return null
+      return { id, title, horizon }
+    })
+    .filter((item): item is KeeperConfig['coordination']['active_goals'][number] => item !== null)
+}
+
 function normalizePromptBlock(raw: unknown, fallbackKey: string): { key: string; source: string; text: string } {
   if (!isRecord(raw)) {
     return {
@@ -1576,6 +1588,7 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
   const handoff = isRecord(data.handoff) ? data.handoff : {}
   const hooks = isRecord(data.hooks) ? data.hooks : null
   const runtime = isRecord(data.runtime) ? data.runtime : {}
+  const runtimeTrust = isRecord(data.runtime_trust) ? data.runtime_trust : null
   const coordination = isRecord(data.coordination) ? data.coordination : {}
   const tools = isRecord(data.tools) ? data.tools : {}
   const sources = isRecord(data.sources) ? data.sources : {}
@@ -1585,6 +1598,7 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
 
   return {
     name: asNullableString(data.name) ?? requestedName,
+    active_goal_ids: normalizeStringList(data.active_goal_ids),
     sandbox_profile: asNullableString(data.sandbox_profile) ?? 'local',
     network_mode: asNullableString(data.network_mode) ?? 'inherit',
     shared_memory_scope: asNullableString(data.shared_memory_scope) ?? 'disabled',
@@ -1688,9 +1702,14 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
               ? asLooseBoolean(runtime.runtime_blocker_continue_gate)
               : null),
     },
+    runtime_trust: runtimeTrust,
     coordination: {
       mention_targets: normalizeStringList(coordination.mention_targets),
       joined_room_ids: normalizeStringList(coordination.joined_room_ids),
+      active_goal_ids: normalizeStringList(coordination.active_goal_ids),
+      active_goals: normalizeKeeperConfigActiveGoals(coordination.active_goals),
+      active_goal_count: asInt(coordination.active_goal_count) ?? 0,
+      missing_active_goal_ids: normalizeStringList(coordination.missing_active_goal_ids),
     },
     tools: {
       tool_access: tools.tool_access ?? {},
@@ -1753,6 +1772,7 @@ export type SandboxNetworkMode = 'none' | 'inherit'
 export type SharedMemoryScope = 'disabled' | 'room'
 
 export type KeeperConfigUpdatePayload = {
+  active_goal_ids?: string[]
   allowed_paths?: string[]
   // Sandbox
   sandbox_profile?: SandboxProfile

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -26,6 +26,7 @@ function makeSlot(overrides: Partial<KeeperHookSlot> = {}): KeeperHookSlot {
 function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
   return {
     name: 'keeper-sangsu',
+    active_goal_ids: ['goal-runtime'],
     sandbox_profile: 'local',
     network_mode: 'inherit',
     shared_memory_scope: 'disabled',
@@ -118,6 +119,12 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
     coordination: {
       mention_targets: ['sangsu'],
       joined_room_ids: ['default'],
+      active_goal_ids: ['goal-runtime'],
+      active_goals: [
+        { id: 'goal-runtime', title: 'Ship runtime clarity', horizon: 'mid' },
+      ],
+      active_goal_count: 1,
+      missing_active_goal_ids: [],
     },
     sources: {
       live_meta_path: '/tmp/.masc/keepers/keeper-sangsu/live.json',
@@ -254,6 +261,7 @@ describe('sandbox coerce helpers', () => {
 function makeKeeperConfigForSandbox(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
   const base: KeeperConfig = {
     name: 'test-keeper',
+    active_goal_ids: [],
     sandbox_profile: 'local',
     network_mode: 'inherit',
     shared_memory_scope: 'disabled',
@@ -279,7 +287,14 @@ function makeKeeperConfigForSandbox(overrides: Partial<KeeperConfig> = {}): Keep
       cooldown_sec: 0,
     } as KeeperConfig['handoff'],
     runtime: {} as KeeperConfig['runtime'],
-    coordination: {} as KeeperConfig['coordination'],
+    coordination: {
+      mention_targets: [],
+      joined_room_ids: [],
+      active_goal_ids: [],
+      active_goals: [],
+      active_goal_count: 0,
+      missing_active_goal_ids: [],
+    },
     tools: {} as KeeperConfig['tools'],
     sources: {} as KeeperConfig['sources'],
     metrics: {} as KeeperConfig['metrics'],
@@ -383,10 +398,94 @@ describe('buildRuntimePayload — sandbox diffing', () => {
     const payload = buildRuntimePayload(draft, c)
     expect(payload.sandbox_profile).toBeUndefined()
   })
+
+  it('emits active_goal_ids when goal bindings change', () => {
+    const c = makeKeeperConfigForSandbox({
+      active_goal_ids: ['goal-a'],
+      coordination: {
+        mention_targets: [],
+        joined_room_ids: [],
+        active_goal_ids: ['goal-a'],
+        active_goals: [{ id: 'goal-a', title: 'Goal A', horizon: 'short' }],
+        active_goal_count: 1,
+        missing_active_goal_ids: [],
+      },
+    })
+    const payload = buildRuntimePayload(draftFrom(c, {
+      active_goal_ids: ['goal-b', 'goal-c'],
+    }), c)
+    expect(payload.active_goal_ids).toEqual(['goal-b', 'goal-c'])
+  })
 })
 
 const mocks = vi.hoisted(() => ({
   fetchKeeperConfig: vi.fn(async () => makeKeeperConfig()),
+  fetchDashboardGoalsTree: vi.fn(async () => ({
+    tree: [
+      {
+        id: 'goal-runtime',
+        title: 'Ship runtime clarity',
+        horizon: 'mid',
+        status: 'active',
+        status_color: '#4ade80',
+        phase: 'executing',
+        phase_color: '#4ade80',
+        health: 'on_track',
+        health_color: '#4ade80',
+        badges: [],
+        status_reason: '',
+        priority: 2,
+        metric: null,
+        target_value: null,
+        due_date: null,
+        parent_goal_id: null,
+        convergence: 0,
+        convergence_pct: 0,
+        tasks: [],
+        task_count: 0,
+        task_done_count: 0,
+        verification_summary: {
+          required_votes: 0,
+          approve_votes: 0,
+          reject_votes: 0,
+          pending_votes: 0,
+          quorum_met: false,
+          rejected: false,
+          votes: [],
+        },
+        pending_verification_count: 0,
+        timeline_events: [],
+        children: [],
+        child_count: 0,
+        last_activity_at: '',
+        stagnation_seconds: 0,
+        linked_keeper_names: [],
+        pending_approval_count: 0,
+        infra_risk_count: 0,
+        linkage_source: 'none',
+        linkage_warning_count: 0,
+        blocking_source: 'none',
+        blocking_reason: '',
+        created_at: '',
+        updated_at: '',
+      },
+    ],
+    summary: {
+      total_goals: 1,
+      active_goals: 1,
+      on_track_goals: 1,
+      done_goals: 0,
+      paused_goals: 0,
+      at_risk_goals: 0,
+      blocked_goals: 0,
+      total_tasks: 0,
+      done_tasks: 0,
+      pending_approvals: 0,
+      infra_risk_count: 0,
+      overall_convergence: 0,
+      overall_convergence_pct: 0,
+    },
+  })),
   fetchCascadeProfiles: vi.fn(async () => ({
     profiles: ['keeper_unified', 'resilient_breaker'],
     invalid_profiles: [
@@ -402,6 +501,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('../api/dashboard', () => ({
   fetchCascadeProfiles: mocks.fetchCascadeProfiles,
+  fetchDashboardGoalsTree: mocks.fetchDashboardGoalsTree,
   fetchKeeperConfig: mocks.fetchKeeperConfig,
   patchKeeperConfig: mocks.patchKeeperConfig,
   updateKeeperCascade: mocks.updateKeeperCascade,
@@ -421,6 +521,7 @@ describe('KeeperConfigPanel', () => {
     document.body.appendChild(container)
     resetKeeperConfig()
     mocks.fetchKeeperConfig.mockClear()
+    mocks.fetchDashboardGoalsTree.mockClear()
     mocks.fetchCascadeProfiles.mockClear()
     mocks.patchKeeperConfig.mockClear()
     mocks.updateKeeperCascade.mockClear()
@@ -438,6 +539,7 @@ describe('KeeperConfigPanel', () => {
     await flush()
 
     expect(mocks.fetchKeeperConfig).toHaveBeenCalledTimes(1)
+    expect(mocks.fetchDashboardGoalsTree).toHaveBeenCalledTimes(1)
     expect(mocks.fetchCascadeProfiles).toHaveBeenCalledTimes(1)
     expect(container.textContent).toContain('편집 가능 범위')
     expect(container.textContent).toContain('keeper TOML의 cascade_name')
@@ -448,6 +550,8 @@ describe('KeeperConfigPanel', () => {
     expect(container.textContent).toContain('/tmp/config/cascade.toml')
     expect(container.textContent).toContain('/tmp/config/cascade.json')
     expect(container.textContent).toContain('런타임 설정')
+    expect(container.textContent).toContain('active_goal_ids')
+    expect(container.textContent).toContain('Ship runtime clarity')
     expect(container.textContent).toContain('/tmp/.masc/keepers/keeper-sangsu/live.json')
     expect(container.textContent).toContain('활성 모델')
     expect(container.textContent).toContain('레지스트리 상태')

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -6,13 +6,14 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import {
   fetchCascadeProfiles,
+  fetchDashboardGoalsTree,
   fetchKeeperConfig,
   patchKeeperConfig,
   updateKeeperCascade,
   type CascadeInvalidProfile,
 } from '../api/dashboard'
 import type { KeeperConfigUpdatePayload } from '../api/dashboard'
-import type { KeeperConfig, KeeperHookSlot } from '../types'
+import type { GoalTreeNode, KeeperConfig, KeeperHookSlot } from '../types'
 import type { KeeperConfigLoadStatus } from './keeper-detail-source'
 import { formatTokens } from '../lib/format-number'
 import { isVerifierRoleKeeper } from '../lib/keeper-utils'
@@ -32,6 +33,8 @@ type CascadeProfileCatalog = {
 }
 const cascadeProfilesResource = createAsyncResource<CascadeProfileCatalog>()
 const cascadeProfilesState = cascadeProfilesResource.state
+const goalOptionsResource = createAsyncResource<GoalTreeNode[]>()
+const goalOptionsState = goalOptionsResource.state
 const editMode = signal(false)
 const saving = signal(false)
 const saveError = signal<string | null>(null)
@@ -119,6 +122,7 @@ export type SharedMemoryScope = 'disabled' | 'room'
 
 export type RuntimeDraft = {
   sandbox_profile: SandboxProfile
+  active_goal_ids: string[]
   network_mode: SandboxNetworkMode
   shared_memory_scope: SharedMemoryScope
   allowed_paths_text: string
@@ -152,6 +156,9 @@ export function coerceSharedMemoryScope(raw: string | undefined): SharedMemorySc
 export function initRuntimeDraftFromConfig(c: KeeperConfig): RuntimeDraft {
   return {
     sandbox_profile: coerceSandboxProfile(c.sandbox_profile),
+    active_goal_ids: c.coordination.active_goal_ids.length > 0
+      ? c.coordination.active_goal_ids
+      : c.active_goal_ids,
     network_mode: coerceNetworkMode(c.network_mode),
     shared_memory_scope: coerceSharedMemoryScope(c.shared_memory_scope),
     allowed_paths_text: (c.allowed_paths ?? []).join('\n'),
@@ -172,6 +179,10 @@ export function buildRuntimePayload(draft: RuntimeDraft, orig: KeeperConfig): Ke
   const payload: KeeperConfigUpdatePayload = {}
   const newPaths = draft.allowed_paths_text.split('\n').map(s => s.trim()).filter(Boolean)
   const origPaths = orig.allowed_paths ?? []
+  const origActiveGoalIds = orig.coordination.active_goal_ids.length > 0
+    ? orig.coordination.active_goal_ids
+    : orig.active_goal_ids
+  if (!sameStringArray(draft.active_goal_ids, origActiveGoalIds)) payload.active_goal_ids = draft.active_goal_ids
   if (JSON.stringify(newPaths) !== JSON.stringify(origPaths)) payload.allowed_paths = newPaths
   if (draft.sandbox_profile !== coerceSandboxProfile(orig.sandbox_profile)) payload.sandbox_profile = draft.sandbox_profile
   if (draft.network_mode !== coerceNetworkMode(orig.network_mode)) payload.network_mode = draft.network_mode
@@ -202,6 +213,38 @@ function updateRuntimeDraft(field: keyof RuntimeDraft, value: boolean | number |
   runtimeDraft.value = next
 }
 
+function sameStringArray(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false
+  return a.every((value, index) => value === b[index])
+}
+
+function dedupeStrings(values: readonly string[]): string[] {
+  const seen = new Set<string>()
+  const next: string[] = []
+  for (const raw of values) {
+    const value = raw.trim()
+    if (!value || seen.has(value)) continue
+    seen.add(value)
+    next.push(value)
+  }
+  return next
+}
+
+function updateRuntimeActiveGoalIds(values: readonly string[]) {
+  const d = runtimeDraft.value
+  if (!d) return
+  runtimeDraft.value = { ...d, active_goal_ids: dedupeStrings(values) }
+}
+
+function toggleRuntimeActiveGoal(goalId: string, checked: boolean) {
+  const d = runtimeDraft.value
+  if (!d) return
+  const next = checked
+    ? [...d.active_goal_ids, goalId]
+    : d.active_goal_ids.filter((id) => id !== goalId)
+  updateRuntimeActiveGoalIds(next)
+}
+
 export async function loadKeeperConfig(
   name: string,
   options?: { force?: boolean },
@@ -218,6 +261,7 @@ export async function loadKeeperConfig(
 export function resetKeeperConfig(): void {
   configResource.reset()
   cascadeProfilesResource.reset()
+  goalOptionsResource.reset()
   configKeeperName.value = ''
   editMode.value = false
   editDraft.value = null
@@ -248,6 +292,25 @@ async function loadCascadeProfiles(options?: { force?: boolean }): Promise<void>
   if (!force && cascadeProfilesState.value.status === 'loaded') return
   if (force) cascadeProfilesResource.reset()
   await cascadeProfilesResource.load(() => fetchCascadeProfiles())
+}
+
+function flattenGoalTree(nodes: readonly GoalTreeNode[]): GoalTreeNode[] {
+  const out: GoalTreeNode[] = []
+  for (const node of nodes) {
+    out.push(node)
+    out.push(...flattenGoalTree(node.children ?? []))
+  }
+  return out
+}
+
+async function loadGoalOptions(options?: { force?: boolean }): Promise<void> {
+  const force = options?.force === true
+  if (!force && goalOptionsState.value.status === 'loaded') return
+  if (force) goalOptionsResource.reset()
+  await goalOptionsResource.load(async () => {
+    const response = await fetchDashboardGoalsTree()
+    return flattenGoalTree(response.tree)
+  })
 }
 
 // ── Helpers ──────────────────────────────────────────────
@@ -518,6 +581,9 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
   if (cascadeState.status === 'idle') {
     void loadCascadeProfiles()
   }
+  if (goalOptionsState.value.status === 'idle') {
+    void loadGoalOptions()
+  }
 
   if (state.status === 'loading') {
     return html`<${LoadingState}>설정 불러오는 중...<//>`
@@ -697,6 +763,16 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
   const invalidCascadeSummary = invalidCascadeProfiles
     .map((profile) => `${profile.name}: ${profile.errors.join('; ')}`)
     .join(' | ')
+  const goalState = goalOptionsState.value
+  const goalOptionsLoaded = goalState.status === 'loaded'
+  const goalOptions: GoalTreeNode[] = goalOptionsLoaded ? goalState.data : []
+  const selectedActiveGoalIds = rd
+    ? rd.active_goal_ids
+    : (c.coordination.active_goal_ids.length > 0 ? c.coordination.active_goal_ids : c.active_goal_ids)
+  const knownGoalIds = new Set(goalOptions.map((goal) => goal.id))
+  const unknownSelectedGoalIds = goalOptionsLoaded
+    ? selectedActiveGoalIds.filter((goalId) => !knownGoalIds.has(goalId))
+    : []
 
   return html`
     <div class="flex flex-col gap-1.5">
@@ -966,6 +1042,46 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       <${ConfigRow} label="프레즌스 간격" value=${c.runtime.presence_keepalive_sec + 's'} />
 
       <${SectionHeader} title="네임스페이스 조율" />
+      <div class="py-2 px-3 rounded border border-card-border/50 bg-card/20 backdrop-blur-sm mb-1.5">
+        <div class="flex items-center justify-between gap-3 mb-2">
+          <span class="text-xs font-medium text-text-muted">active_goal_ids</span>
+          <span class="text-3xs text-[var(--text-muted)]">${selectedActiveGoalIds.length}개 선택</span>
+        </div>
+        ${goalState.status === 'loading' ? html`
+          <div class="text-2xs text-[var(--text-muted)]">목표 목록 로딩 중...</div>
+        ` : goalState.status === 'error' ? html`
+          <div class="text-2xs text-[var(--bad)]">${goalState.message}</div>
+        ` : goalOptions.length > 0 && rd ? html`
+          <div class="grid gap-1.5">
+            ${goalOptions.map((goal) => {
+              const checked = rd.active_goal_ids.includes(goal.id)
+              return html`
+                <label class="flex items-center gap-2 rounded bg-[var(--white-3)] px-2 py-1.5 text-xs text-[var(--text-body)]">
+                  <input
+                    type="checkbox"
+                    checked=${checked}
+                    onChange=${(event: Event) => {
+                      toggleRuntimeActiveGoal(goal.id, (event.currentTarget as HTMLInputElement).checked)
+                    }}
+                  />
+                  <span class="min-w-[4.5rem] font-mono text-3xs text-[var(--text-muted)]">${goal.horizon}</span>
+                  <span class="flex-1 truncate">${goal.title}</span>
+                  <span class="font-mono text-3xs text-[var(--text-dim)]">${goal.id}</span>
+                </label>
+              `
+            })}
+          </div>
+        ` : selectedActiveGoalIds.length > 0 ? html`
+          <${ModelList} models=${selectedActiveGoalIds} />
+        ` : html`
+          <div class="text-2xs text-[var(--text-muted)]">활성 목표가 연결되어 있지 않습니다.</div>
+        `}
+        ${unknownSelectedGoalIds.length > 0 ? html`
+          <div class="mt-2 text-2xs text-[var(--warn)]">
+            Goal Store에서 찾을 수 없는 연결: ${unknownSelectedGoalIds.join(', ')}
+          </div>
+        ` : null}
+      </div>
       ${isVerifierRoleKeeper(c.coordination.mention_targets) ? html`
       <div class="mb-2 flex items-center gap-2 rounded border border-accent/30 bg-[var(--accent-10)] px-3 py-2">
         <span class="rounded border border-accent/40 bg-[var(--accent-5)] px-2 py-0.5 text-3xs font-semibold uppercase tracking-1 text-accent">Verifier</span>

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -914,6 +914,23 @@ interface KeeperConfigHandoff {
   cooldown_sec: number
 }
 
+export interface KeeperConfigActiveGoal {
+  id: string
+  title: string
+  horizon: string
+}
+
+export interface KeeperConfigRuntimeTrust {
+  disposition?: string | null
+  disposition_reason?: string | null
+  needs_attention?: boolean | null
+  attention_reason?: string | null
+  next_human_action?: string | null
+  approval?: unknown
+  execution?: unknown
+  latest_causal_event?: unknown
+}
+
 interface KeeperConfigRuntime {
   paused: boolean
   registered: boolean
@@ -942,6 +959,10 @@ interface KeeperConfigRuntime {
 interface KeeperConfigCoordination {
   mention_targets: string[]
   joined_room_ids: string[]
+  active_goal_ids: string[]
+  active_goals: KeeperConfigActiveGoal[]
+  active_goal_count: number
+  missing_active_goal_ids: string[]
 }
 
 export interface KeeperConfigTools {
@@ -1029,6 +1050,7 @@ interface KeeperHookIntrospection {
 
 export interface KeeperConfig {
   name: string
+  active_goal_ids: string[]
   sandbox_profile?: 'local' | 'docker' | string
   network_mode?: 'none' | 'inherit' | string
   shared_memory_scope?: 'disabled' | 'room' | string
@@ -1046,6 +1068,7 @@ export interface KeeperConfig {
   handoff: KeeperConfigHandoff
   hooks?: KeeperHookIntrospection
   runtime: KeeperConfigRuntime
+  runtime_trust?: KeeperConfigRuntimeTrust | null
   coordination: KeeperConfigCoordination
   tools: KeeperConfigTools
   sources: KeeperConfigSources

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -1216,8 +1216,50 @@ let keeper_config_json (config : Coord.config) (name : string)
                    | Goal_store.Long -> "long"
                  in
                  Some (id, title, horizon_str)
-             | None -> None)
+               | None -> None)
           m.active_goal_ids
+      in
+      let active_goal_ids_json =
+        `List (List.map (fun goal_id -> `String goal_id) m.active_goal_ids)
+      in
+      let active_goals_json =
+        `List
+          (List.map
+             (fun (id, title, horizon) ->
+                `Assoc [
+                  ("id", `String id);
+                  ("title", `String title);
+                  ("horizon", `String horizon);
+                ])
+             active_goals)
+      in
+      let resolved_active_goal_ids =
+        List.map (fun (id, _, _) -> id) active_goals
+      in
+      let missing_active_goal_ids =
+        m.active_goal_ids
+        |> List.filter (fun goal_id ->
+               not (List.mem goal_id resolved_active_goal_ids))
+      in
+      let coordination =
+        match coordination_surface_json m with
+        | `Assoc fields ->
+            `Assoc
+              (fields
+               @ [
+                   ("active_goal_ids", active_goal_ids_json);
+                   ("active_goals", active_goals_json);
+                   ("active_goal_count", `Int (List.length m.active_goal_ids));
+                   ( "missing_active_goal_ids",
+                     `List
+                       (List.map
+                          (fun goal_id -> `String goal_id)
+                          missing_active_goal_ids) );
+                 ])
+        | other -> other
+      in
+      let runtime_trust =
+        Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta:m
       in
       let effective_system_prompt =
         Keeper_prompt.build_keeper_system_prompt
@@ -1479,6 +1521,7 @@ let keeper_config_json (config : Coord.config) (name : string)
       (`OK,
        `Assoc [
          ("name", `String m.name);
+         ("active_goal_ids", active_goal_ids_json);
          ("sandbox_profile", `String (Keeper_types.sandbox_profile_to_string m.sandbox_profile));
          ("network_mode", `String (Keeper_types.network_mode_to_string m.network_mode));
          ("shared_memory_scope",
@@ -1508,7 +1551,8 @@ let keeper_config_json (config : Coord.config) (name : string)
          ("tools", tools_access);
          ("hooks", Keeper_hooks_oas.hook_introspection_json ());
          ("runtime", runtime_surface_json config m);
-         ("coordination", coordination_surface_json m);
+         ("runtime_trust", runtime_trust);
+         ("coordination", coordination);
          ("sources", source_provenance_json config m);
          ("metrics", metrics);
        ])

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -123,6 +123,11 @@ let keeper_schemas : tool_schema list = [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
         ]);
+        ("active_goal_ids", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+          ("description", `String "Goal IDs this keeper is allowed to claim work for. Empty clears goal scoping.");
+        ]);
         ("autoboot_enabled", `Assoc [
           ("type", `String "boolean");
           ("description", `String "If false, persist the keeper but skip auto-start on future server boots.");
@@ -214,6 +219,11 @@ let keeper_schemas : tool_schema list = [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
           ("description", `String "Exact direct-mention tokens that can wake the keeper in room traffic (for example ['sangsu']).");
+        ]);
+        ("active_goal_ids", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+          ("description", `String "Goal IDs this keeper is allowed to claim work for. Empty clears goal scoping.");
         ]);
         ("autoboot_enabled", `Assoc [
           ("type", `String "boolean");

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -24,6 +24,7 @@ type parsed_args = {
   voice_channel_opt : string option;
   voice_agent_id_opt : string option;
   mention_targets_in : string list;
+  active_goal_ids_opt : string list option;
   max_context_override_opt : int option;
   proactive_enabled_opt : bool option;
   proactive_idle_sec_opt : int option;
@@ -194,6 +195,7 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     in
     let tool_access_input_res = parse_tool_access_input args in
     let allowed_paths_opt_res = parse_present_string_list_opt args "allowed_paths" in
+    let active_goal_ids_opt_res = parse_present_string_list_opt args "active_goal_ids" in
     let sandbox_profile_opt_res =
       parse_enum_string_opt args "sandbox_profile" sandbox_profile_of_string
         ~allowed_values:(String.concat ", " valid_sandbox_profile_strings)
@@ -209,17 +211,20 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     in
     match
       compaction_profile_opt_res, tool_access_input_res, allowed_paths_opt_res,
-      sandbox_profile_opt_res, network_mode_opt_res, shared_memory_scope_opt_res
+      active_goal_ids_opt_res, sandbox_profile_opt_res, network_mode_opt_res,
+      shared_memory_scope_opt_res
     with
-    | Error e, _, _, _, _, _
-    | _, Error e, _, _, _, _
-    | _, _, Error e, _, _, _
-    | _, _, _, Error e, _, _
-    | _, _, _, _, Error e, _
-    | _, _, _, _, _, Error e -> Error (false, e)
+    | Error e, _, _, _, _, _, _
+    | _, Error e, _, _, _, _, _
+    | _, _, Error e, _, _, _, _
+    | _, _, _, Error e, _, _, _
+    | _, _, _, _, Error e, _, _
+    | _, _, _, _, _, Error e, _
+    | _, _, _, _, _, _, Error e -> Error (false, e)
     | Ok compaction_profile_opt,
       Ok (tool_access_opt, tool_preset_opt, tool_also_allow_opt),
       Ok allowed_paths_opt,
+      Ok active_goal_ids_opt,
       Ok sandbox_profile_opt,
       Ok network_mode_opt,
       Ok shared_memory_scope_opt ->
@@ -310,6 +315,7 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
       long_goal_opt;
       policy_voice_enabled_opt;
       allowed_paths_opt;
+      active_goal_ids_opt;
       autoboot_enabled_opt;
       sandbox_profile_opt;
       network_mode_opt;

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -46,6 +46,26 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     | Some paths -> paths
     | None -> Option.value ~default:[] p.profile_defaults.allowed_paths
   in
+  let active_goal_ids =
+    match p.active_goal_ids_opt with
+    | Some ids -> ids
+    | None -> Option.value ~default:[] p.profile_defaults.active_goal_ids
+  in
+  let active_goal_ids_error =
+    match p.active_goal_ids_opt with
+    | None -> None
+    | Some _ ->
+        let missing =
+          List.filter
+            (fun goal_id -> Option.is_none (Goal_store.get_goal ctx.config ~goal_id))
+            active_goal_ids
+        in
+        if missing = [] then None
+        else
+          Some
+            (Printf.sprintf "unknown active_goal_ids: %s"
+               (String.concat ", " missing))
+  in
   let sandbox_profile =
     resolve_sandbox_profile
       ~preferred:p.sandbox_profile_opt
@@ -91,7 +111,9 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     Log.Keeper.warn "create_keeper failed: goal is required (name=%s)" p.name;
     (false, "goal is required when creating a keeper")
   end
-  else
+  else match active_goal_ids_error with
+  | Some msg -> (false, msg)
+  | None ->
     match
       validate_sandbox_settings
         ~config:ctx.config
@@ -291,9 +313,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           |> Keeper_types_profile.load_persona_extended
           |> Option.value ~default:""
         in
-        let active_goal_ids =
-          Option.value ~default:[] p.profile_defaults.active_goal_ids
-        in
         let active_goals =
           List.filter_map
             (fun goal_id ->
@@ -389,7 +408,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         max_context_override = p.max_context_override_opt;
         continuity_summary = "";
         active_goal_ids =
-          Option.value ~default:[] p.profile_defaults.active_goal_ids;
+          active_goal_ids;
         paused = false;
         autoboot_enabled;
         current_task_id = None;

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -8,11 +8,35 @@ open Keeper_types
 open Keeper_keepalive
 open Keeper_turn_up_args
 
+let resolve_active_goal_ids config p old_ids =
+  let active_goal_ids =
+    match p.active_goal_ids_opt with
+    | Some ids -> ids
+    | None ->
+        Option.value ~default:old_ids p.profile_defaults.active_goal_ids
+  in
+  match p.active_goal_ids_opt with
+  | None -> Ok active_goal_ids
+  | Some _ ->
+      let missing =
+        List.filter
+          (fun goal_id -> Option.is_none (Goal_store.get_goal config ~goal_id))
+          active_goal_ids
+      in
+      if missing = [] then Ok active_goal_ids
+      else
+        Error
+          (Printf.sprintf "unknown active_goal_ids: %s"
+             (String.concat ", " missing))
+
 let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool_result =
   match p.tool_access_opt, old.tool_access, p.tool_preset_opt, p.tool_also_allow_opt with
   | None, Custom _, None, Some _ ->
       (false, "tool_also_allow requires a preset-based keeper policy; set tool_preset first")
   | _ ->
+  match resolve_active_goal_ids ctx.config p old.active_goal_ids with
+  | Error msg -> (false, msg)
+  | Ok active_goal_ids ->
   let goal_provided = Option.is_some p.goal_opt in
   let goal =
     match p.goal_opt with
@@ -185,8 +209,7 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     tool_denylist;
     tool_preset_source = p.profile_defaults.tool_preset_source;
     autoboot_enabled;
-    active_goal_ids =
-      Option.value ~default:old.active_goal_ids p.profile_defaults.active_goal_ids;
+    active_goal_ids;
     voice_enabled =
       Option.value ~default:old.voice_enabled p.voice_enabled_opt;
     voice_channel =

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -1656,6 +1656,14 @@ proactive_enabled = true
 |};
       let config = Coord.default_config base_dir in
       ignore (Coord.init config ~agent_name:(Some "operator"));
+      let linked_goal =
+        match
+          Goal_store.upsert_goal config ~id:"goal-runtime"
+            ~title:"Ship runtime clarity" ~horizon:Goal_store.Mid ()
+        with
+        | Ok (goal, _) -> goal
+        | Error err -> Alcotest.fail ("goal upsert failed: " ^ err)
+      in
       let keeper_ctx : _ Tool_keeper.context =
         {
           config;
@@ -1682,6 +1690,41 @@ proactive_enabled = true
         | Ok None -> Alcotest.fail "keeper meta missing"
         | Error err -> Alcotest.fail ("meta read failed: " ^ err)
       in
+      let parsed_goal_update =
+        match
+          Keeper_turn_up_args.parse keeper_ctx
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("active_goal_ids", `List [ `String linked_goal.id ]);
+              ])
+        with
+        | Ok parsed -> parsed
+        | Error (_ok, msg) -> Alcotest.fail ("active_goal_ids parse failed: " ^ msg)
+      in
+      let ok, msg =
+        Keeper_turn_up_update.update_keeper keeper_ctx parsed_goal_update meta
+      in
+      Alcotest.(check bool) ("active_goal_ids update ok: " ^ msg) true ok;
+      let meta = read_keeper_meta_exn config keeper_name in
+      let parsed_bad_goal_update =
+        match
+          Keeper_turn_up_args.parse keeper_ctx
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("active_goal_ids", `List [ `String "goal-missing" ]);
+              ])
+        with
+        | Ok parsed -> parsed
+        | Error (_ok, msg) -> Alcotest.fail ("bad active_goal_ids parse failed: " ^ msg)
+      in
+      let ok, msg =
+        Keeper_turn_up_update.update_keeper keeper_ctx parsed_bad_goal_update meta
+      in
+      Alcotest.(check bool) "unknown active goal rejected" false ok;
+      Alcotest.(check bool) "unknown active goal names surfaced" true
+        (contains_substring msg "goal-missing");
       let mutated =
         {
           meta with
@@ -1716,6 +1759,20 @@ proactive_enabled = true
       let open Yojson.Safe.Util in
       Alcotest.(check bool) "trigger_mode removed from config surface" true
         (json |> member "coordination" |> member "trigger_mode" = `Null);
+      Alcotest.(check (list string)) "active_goal_ids top-level"
+        [ linked_goal.id ]
+        (json |> member "active_goal_ids" |> to_list |> List.map to_string);
+      Alcotest.(check (list string)) "active_goal_ids in coordination"
+        [ linked_goal.id ]
+        (json |> member "coordination" |> member "active_goal_ids"
+         |> to_list |> List.map to_string);
+      Alcotest.(check string) "active goal title resolved"
+        linked_goal.title
+        (json |> member "coordination" |> member "active_goals"
+         |> index 0 |> member "title" |> to_string);
+      Alcotest.(check string) "runtime trust disposition surfaced"
+        "Pass"
+        (json |> member "runtime_trust" |> member "disposition" |> to_string);
       Alcotest.(check bool) "runtime paused from live meta" true
         (json |> member "runtime" |> member "paused" |> to_bool);
       Alcotest.(check bool) "proactive enabled from live meta" false


### PR DESCRIPTION
## Summary
- Add `active_goal_ids` to keeper create/update schemas and persist explicit goal scoping after validating ids against the Goal Store.
- Surface keeper goal bindings, resolved active goals, missing goal ids, and runtime trust in the keeper config API.
- Add dashboard normalization and keeper config panel controls so active goal bindings are visible and editable alongside runtime settings.

## Why
The keeper runtime surfaces did not make the Goal -> Task -> Keeper relationship explicit enough. Operators could not clearly see or update which goals a keeper was scoped to, and the detailed config endpoint did not carry the runtime trust disposition next to the sandbox/runtime state.

## Validation
- `dune build --root .`
- `env MASC_INCLUDE_OPERATOR_CONTROL=true dune exec --root . ./test/test_operator_control.exe`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec vitest run src/api/dashboard.test.ts src/components/keeper-config-panel.test.ts --no-file-parallelism --maxWorkers=1`
- `git diff --check`