### PR TITLE
[codex] Deduplicate shadow telemetry tool calls

### DIFF
--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -188,6 +188,106 @@ let freshness_fields ~now latest_ts =
   | None ->
     [ ("latest_ts_unix", `Null); ("latest_ts_iso", `Null); ("latest_age_s", `Null) ]
 
+(* ── Semantic duplicate suppression ───────────────── *)
+
+let assoc_field name = function
+  | `Assoc fields -> List.assoc_opt name fields
+  | _ -> None
+
+let string_field name json =
+  match assoc_field name json with
+  | Some (`String value) ->
+    let value = String.trim value in
+    if value = "" then None else Some value
+  | _ -> None
+
+let bool_field name json =
+  match assoc_field name json with
+  | Some (`Bool value) -> Some value
+  | _ -> None
+
+let drop_prefix prefix value =
+  if String.starts_with ~prefix value then
+    String.sub value (String.length prefix)
+      (String.length value - String.length prefix)
+  else value
+
+let drop_suffix suffix value =
+  if String.ends_with ~suffix value then
+    String.sub value 0 (String.length value - String.length suffix)
+  else value
+
+let canonical_actor_name value =
+  value
+  |> String.trim
+  |> drop_prefix "keeper-"
+  |> drop_suffix "-agent"
+
+type tool_call_signature = {
+  actor : string;
+  tool : string;
+  success : bool option;
+  ts : float;
+}
+
+let tool_call_signature ?success ~actor ~tool ~ts () =
+  let actor = canonical_actor_name actor in
+  let tool = String.trim tool in
+  if actor = "" || tool = "" || ts <= 0.0 then None
+  else Some { actor; tool; success; ts }
+
+let tool_call_io_signature json =
+  match string_field "source" json with
+  | Some "tool_call_io" ->
+    (match string_field "keeper" json, string_field "tool" json with
+     | Some actor, Some tool ->
+       tool_call_signature ?success:(bool_field "success" json) ~actor ~tool
+         ~ts:(extract_ts json) ()
+     | _ -> None)
+  | _ -> None
+
+let tool_called_event_detail json =
+  match string_field "source" json, assoc_field "event" json with
+  | Some "agent_event", Some (`List (`String tag :: detail :: _))
+    when tag = "Tool_called" || tag = "tool_called" -> (
+      match detail with
+      | `Assoc _ -> Some detail
+      | _ -> None)
+  | _ -> None
+
+let agent_tool_called_signature json =
+  match tool_called_event_detail json with
+  | None -> None
+  | Some detail ->
+    (match string_field "agent_id" detail, string_field "tool_name" detail with
+     | Some actor, Some tool ->
+       tool_call_signature ?success:(bool_field "success" detail) ~actor ~tool
+         ~ts:(extract_ts json) ()
+     | _ -> None)
+
+let same_tool_call_signature left right =
+  String.equal left.actor right.actor
+  && String.equal left.tool right.tool
+  &&
+  (match left.success, right.success with
+   | Some a, Some b -> Bool.equal a b
+   | _ -> true)
+  && abs_float (left.ts -. right.ts) <= 5.0
+
+let suppress_shadow_agent_tool_events entries =
+  let tool_call_io =
+    List.filter_map tool_call_io_signature entries
+  in
+  if tool_call_io = [] then entries
+  else
+    List.filter
+      (fun json ->
+        match agent_tool_called_signature json with
+        | None -> true
+        | Some signature ->
+          not (List.exists (same_tool_call_signature signature) tool_call_io))
+      entries
+
 (* ── Entry tagging ──────────────────────────────────── *)
 
 let tag_entry source (json : Yojson.Safe.t) : Yojson.Safe.t =
@@ -352,6 +452,11 @@ let read_unified_result ~base_path ~masc_root ?(sources = all_sources)
     List.filter
       (fun json -> matches_scope ?session_id ?operation_id ?worker_run_id json)
       filtered
+  in
+  let filtered =
+    if List.mem Agent_event sources && List.mem Tool_call_io sources then
+      suppress_shadow_agent_tool_events filtered
+    else filtered
   in
   (* Sort by timestamp descending (newest first) *)
   let sorted = sort_newest_first filtered in

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -170,6 +170,61 @@ let test_oas_event_source_and_scope_filter () =
     Alcotest.(check string) "event type preserved" "turn_completed" event_type
   | _ -> Alcotest.fail "expected Assoc"
 
+let test_shadow_agent_tool_called_deduped_from_unified_view () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_shadow_tool_called" in
+  let telemetry_dir = Filename.concat dir ".masc/telemetry" in
+  let tool_calls_dir = Filename.concat dir ".masc/tool_calls" in
+  Fs_compat.mkdir_p telemetry_dir;
+  Fs_compat.mkdir_p tool_calls_dir;
+  write_jsonl telemetry_dir [
+    `Assoc
+      [
+        ("timestamp", `Float 1000.2);
+        ( "event",
+          `List
+            [
+              `String "Tool_called";
+              `Assoc
+                [
+                  ("tool_name", `String "masc_status");
+                  ("success", `Bool true);
+                  ("duration_ms", `Int 12);
+                  ("agent_id", `String "keeper-sangsu-agent");
+                ];
+            ] );
+      ];
+  ];
+  write_jsonl tool_calls_dir [
+    `Assoc
+      [
+        ("ts", `Float 1000.0);
+        ("keeper", `String "sangsu");
+        ("tool", `String "masc_status");
+        ("success", `Bool true);
+        ("duration_ms", `Float 12.0);
+      ];
+  ];
+  let result =
+    Telemetry_unified.read_unified_result ~base_path:dir
+      ~masc_root:(masc_root dir)
+      ~sources:[ Telemetry_unified.Agent_event; Telemetry_unified.Tool_call_io ]
+      ()
+  in
+  Alcotest.(check int) "shadow agent event removed" 1
+    (List.length result.entries);
+  Alcotest.(check int) "total reflects visible unified entries" 1
+    result.total_matching_entries;
+  Alcotest.(check string) "full tool call row preserved" "tool_call_io"
+    (json_string_field "source" (List.hd result.entries));
+  let raw_agent_entries =
+    Telemetry_unified.read_unified ~base_path:dir ~masc_root:(masc_root dir)
+      ~sources:[ Telemetry_unified.Agent_event ] ()
+  in
+  Alcotest.(check int) "source-filtered agent event remains available" 1
+    (List.length raw_agent_entries)
+
 (* ── Keeper metrics discovery ────────────────────── *)
 
 let test_keeper_metrics_per_keeper () =
@@ -539,6 +594,8 @@ let () =
           Alcotest.test_case "agent events" `Quick test_agent_event_source;
           Alcotest.test_case "oas events + scope filter" `Quick
             test_oas_event_source_and_scope_filter;
+          Alcotest.test_case "dedupe shadow agent tool_called" `Quick
+            test_shadow_agent_tool_called_deduped_from_unified_view;
           Alcotest.test_case "keeper metrics" `Quick test_keeper_metrics_per_keeper;
           Alcotest.test_case "keeper metrics fast path keeps noisy top n" `Quick
             test_keeper_metrics_fast_path_preserves_noisy_keeper_top_n;


### PR DESCRIPTION
## Summary

- Hide duplicate `agent_event` `Tool_called` rows from the unified telemetry view when a matching `tool_call_io` row is present.
- Keep raw source-filtered `agent_event` reads unchanged so original telemetry remains inspectable.
- Add a regression test for the `keeper-sangsu-agent` / `sangsu` `masc_status` shadow-event case.

## Root Cause

The unified dashboard telemetry reader merges independent raw stores. A keeper tool call can be represented both as an `agent_event` lifecycle event and as a richer `tool_call_io` record, so the all-source timeline showed the same action twice.

## Validation

- `dune exec --root . ./test/test_telemetry_unified.exe`
- `dune build --root .`