### PR TITLE
feat(heuristic_metrics): diagnostics module for instrumentation-theatre guard (#7718)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -365,6 +365,8 @@
    activity_feed
    ;; RFC-0001 Gate A: Det/NonDet boundary instrumentation
    heuristic_metrics
+   ;; Instrumentation theatre guard (#7718): variance + coverage over recent records
+   heuristic_metrics_diagnostics
    agent_stress
    transport
    transport_bridge

--- a/lib/heuristic_metrics_diagnostics.ml
+++ b/lib/heuristic_metrics_diagnostics.ml
@@ -1,0 +1,191 @@
+type site = string
+
+type tuple_key = {
+  raw_value : float;
+  threshold : float;
+  triggered : bool;
+}
+
+let make_tuple_key ~raw_value ~threshold ~triggered =
+  { raw_value; threshold; triggered }
+
+type site_stat = {
+  site : site;
+  count : int;
+  unique_tuples : int;
+  latest_timestamp : float option;
+  triggered_true_count : int;
+  triggered_false_count : int;
+}
+
+type report = {
+  total_records : int;
+  sites : site_stat list;
+  degenerate_sites : site list;
+  one_sided_sites : site list;
+}
+
+(* Chosen empirically from #7718 evidence: 51 records formed the
+   regression signal; 20 is a conservative lower bound that still
+   lets early-life sites avoid false positives. *)
+let degenerate_min_records = 20
+
+(* --- JSON extraction --------------------------------------------- *)
+
+let json_field name (j : Yojson.Safe.t) =
+  match j with
+  | `Assoc pairs -> List.assoc_opt name pairs
+  | _ -> None
+
+let as_string = function `String s -> Some s | _ -> None
+
+let as_float = function
+  | `Float f -> Some f
+  | `Int i -> Some (float_of_int i)
+  | _ -> None
+
+let as_bool = function `Bool b -> Some b | _ -> None
+
+type parsed = {
+  site : site;
+  key : tuple_key;
+  timestamp : float option;
+}
+
+let bind_field name conv j = Option.bind (json_field name j) conv
+
+let parse_record (j : Yojson.Safe.t) : parsed option =
+  let ( let* ) = Option.bind in
+  let* site = bind_field "site" as_string j in
+  let* raw = bind_field "raw_value" as_float j in
+  let* thr = bind_field "threshold" as_float j in
+  let* trig = bind_field "triggered" as_bool j in
+  let ts = bind_field "timestamp" as_float j in
+  Some
+    {
+      site;
+      key = make_tuple_key ~raw_value:raw ~threshold:thr ~triggered:trig;
+      timestamp = ts;
+    }
+
+(* --- Aggregation ------------------------------------------------- *)
+
+module SiteTbl = Hashtbl.Make (struct
+  type t = site
+  let equal = String.equal
+  let hash = Hashtbl.hash
+end)
+
+module KeySet = Set.Make (struct
+  type t = tuple_key
+  let compare (a : tuple_key) b =
+    let c = Float.compare a.raw_value b.raw_value in
+    if c <> 0 then c
+    else
+      let c = Float.compare a.threshold b.threshold in
+      if c <> 0 then c else Bool.compare a.triggered b.triggered
+end)
+
+type accum = {
+  mutable count : int;
+  mutable keys : KeySet.t;
+  mutable latest_ts : float option;
+  mutable t_count : int;
+  mutable f_count : int;
+}
+
+let fresh_accum () =
+  { count = 0; keys = KeySet.empty; latest_ts = None; t_count = 0; f_count = 0 }
+
+let merge_accum acc p =
+  acc.count <- acc.count + 1;
+  acc.keys <- KeySet.add p.key acc.keys;
+  (match p.timestamp with
+   | None -> ()
+   | Some ts ->
+     (match acc.latest_ts with
+      | None -> acc.latest_ts <- Some ts
+      | Some prev -> if ts > prev then acc.latest_ts <- Some ts));
+  if p.key.triggered then acc.t_count <- acc.t_count + 1
+  else acc.f_count <- acc.f_count + 1
+
+let analyze (records : Yojson.Safe.t list) : report =
+  let tbl : accum SiteTbl.t = SiteTbl.create 16 in
+  let total = ref 0 in
+  List.iter
+    (fun r ->
+      match parse_record r with
+      | None -> ()
+      | Some p ->
+        incr total;
+        let acc =
+          match SiteTbl.find_opt tbl p.site with
+          | Some a -> a
+          | None ->
+            let a = fresh_accum () in
+            SiteTbl.add tbl p.site a;
+            a
+        in
+        merge_accum acc p)
+    records;
+  let stats =
+    SiteTbl.fold
+      (fun site acc xs ->
+        {
+          site;
+          count = acc.count;
+          unique_tuples = KeySet.cardinal acc.keys;
+          latest_timestamp = acc.latest_ts;
+          triggered_true_count = acc.t_count;
+          triggered_false_count = acc.f_count;
+        }
+        :: xs)
+      tbl []
+  in
+  let stats =
+    List.sort (fun (a : site_stat) (b : site_stat) ->
+      String.compare a.site b.site) stats
+  in
+  let degenerate_sites =
+    List.filter_map
+      (fun (s : site_stat) ->
+        if s.count >= degenerate_min_records && s.unique_tuples <= 1 then
+          Some s.site
+        else None)
+      stats
+  in
+  let one_sided_sites =
+    List.filter_map
+      (fun (s : site_stat) ->
+        if s.count < degenerate_min_records then None
+        else if s.triggered_true_count = s.count
+             || s.triggered_false_count = s.count
+        then Some s.site
+        else None)
+      stats
+  in
+  {
+    total_records = !total;
+    sites = stats;
+    degenerate_sites;
+    one_sided_sites;
+  }
+
+let pretty_summary r =
+  let site_lines =
+    List.map
+      (fun (s : site_stat) ->
+        Printf.sprintf
+          "  site=%s count=%d unique_tuples=%d triggered_true=%d triggered_false=%d"
+          s.site s.count s.unique_tuples s.triggered_true_count
+          s.triggered_false_count)
+      r.sites
+  in
+  let header =
+    Printf.sprintf
+      "heuristic_metrics diagnostics: total=%d sites=%d degenerate=%d one_sided=%d"
+      r.total_records (List.length r.sites)
+      (List.length r.degenerate_sites)
+      (List.length r.one_sided_sites)
+  in
+  String.concat "\n" (header :: site_lines)

--- a/lib/heuristic_metrics_diagnostics.mli
+++ b/lib/heuristic_metrics_diagnostics.mli
@@ -1,0 +1,73 @@
+(** Heuristic_metrics diagnostics — instrumentation-theatre guard (#7718).
+
+    Pure functions over a list of JSONL records. Computes coverage
+    (per-site counts), value-tuple variance (unique
+    [(raw_value, threshold, triggered)] tuples per site), and flags
+    degenerate sites where a site has accumulated records but produced
+    no variance in the gated inputs/outputs.
+
+    Background: #7718 reopen showed 51 consecutive records of the
+    identical tuple [("post_tool_use_failure", 1.0, 0.0, true)]. The
+    predicate [1.0 > 0.0] is a tautology — a metric that only emits
+    [triggered=true] on a trivially-satisfied threshold is not
+    observing a heuristic, it is counting invocations.
+
+    This module makes that condition detectable without changing the
+    record/write path. SRE reference: Prometheus
+    [absent_over_time]/[changes()] idiom — "presence of a series is
+    not health; change over time is". *)
+
+type site = string
+(** JSON ["site"] field of a record. *)
+
+type tuple_key = private {
+  raw_value : float;
+  threshold : float;
+  triggered : bool;
+}
+
+val make_tuple_key : raw_value:float -> threshold:float -> triggered:bool -> tuple_key
+(** Constructor used by tests and callers that want to query
+    [per_site_unique_tuples] directly. *)
+
+type site_stat = {
+  site : site;
+  count : int;
+  unique_tuples : int;
+  (** Count of distinct [tuple_key] values seen at this site. *)
+  latest_timestamp : float option;
+  (** Max [timestamp] across this site's records, or [None] when no
+      record carried a parseable timestamp. *)
+  triggered_true_count : int;
+  triggered_false_count : int;
+}
+
+type report = {
+  total_records : int;
+  sites : site_stat list;
+  degenerate_sites : site list;
+  (** Sites with [count >= degenerate_min_records] and
+      [unique_tuples <= 1] — the "instrumentation theatre" signature:
+      enough volume to be meaningful, zero variance across the
+      threshold-gated fields. *)
+  one_sided_sites : site list;
+  (** Sites where every record has [triggered=true] OR every record has
+      [triggered=false] and [count >= degenerate_min_records].
+      [triggered=true] saturation is the #7718 symptom directly;
+      [triggered=false] saturation is the unreachable-branch case. *)
+}
+
+val degenerate_min_records : int
+(** Minimum [count] at which a site is eligible to be flagged as
+    degenerate. Below this threshold a site is treated as
+    [insufficient_data] and omitted from flags. *)
+
+val analyze : Yojson.Safe.t list -> report
+(** Run diagnostics over a list of raw JSON records produced by
+    {!Heuristic_metrics.recent}. Records missing required fields are
+    ignored silently (they can be malformed past records; the live
+    writer emits the full shape). *)
+
+val pretty_summary : report -> string
+(** One-line-per-site human-readable summary intended for logs and
+    boot-time health output. *)

--- a/test/dune
+++ b/test/dune
@@ -1273,6 +1273,12 @@
  (modules test_keeper_meta_merge)
  (libraries masc_test_deps))
 
+; Instrumentation-theatre guard (#7718)
+(test
+ (name test_heuristic_metrics_diagnostics)
+ (modules test_heuristic_metrics_diagnostics)
+ (libraries masc_test_deps))
+
 (executable
  (name keeper_tool_matrix_case_runner)
  (modules keeper_tool_matrix_case_runner)

--- a/test/test_heuristic_metrics_diagnostics.ml
+++ b/test/test_heuristic_metrics_diagnostics.ml
@@ -1,0 +1,225 @@
+(* test/test_heuristic_metrics_diagnostics.ml
+
+   Covers Heuristic_metrics_diagnostics.analyze semantics.
+   Related: #7718 reopen (instrumentation theatre regression — 51 records
+   all [("post_tool_use_failure", 1.0, 0.0, true)]). *)
+
+open Masc_mcp
+module D = Heuristic_metrics_diagnostics
+
+let fail msg = failwith msg
+let assert_true msg b = if not b then fail msg
+let assert_false msg b = if b then fail msg
+
+let assert_eq_int ~msg expected got =
+  if expected <> got then
+    fail (Printf.sprintf "%s: expected=%d got=%d" msg expected got)
+
+let assert_list_equal ~msg expected got =
+  let e = List.sort String.compare expected in
+  let g = List.sort String.compare got in
+  if e <> g then
+    fail
+      (Printf.sprintf "%s: expected=[%s] got=[%s]" msg
+         (String.concat ";" e) (String.concat ";" g))
+
+let record ?(ts = 1.0) ~site ~raw ~thr ~trig () : Yojson.Safe.t =
+  `Assoc
+    [
+      "module", `String "test";
+      "site", `String site;
+      "raw_value", `Float raw;
+      "threshold", `Float thr;
+      "triggered", `Bool trig;
+      "timestamp", `Float ts;
+    ]
+
+let repeat n f = List.init n f
+
+(* --- Parsing robustness ----------------------------------------- *)
+
+let test_ignores_malformed_records () =
+  let records : Yojson.Safe.t list =
+    [
+      `Assoc [ "site", `String "ok"; "raw_value", `Float 0.5;
+               "threshold", `Float 0.3; "triggered", `Bool true;
+               "timestamp", `Float 1.0 ];
+      `Null;
+      `Assoc [ "site", `String "missing_threshold"; "raw_value", `Float 0.5;
+               "triggered", `Bool true ];
+      `Assoc [ "site", `String "bad_types"; "raw_value", `String "oops";
+               "threshold", `Float 0.3; "triggered", `Bool true ];
+    ]
+  in
+  let r = D.analyze records in
+  assert_eq_int ~msg:"only the well-formed record is counted"
+    1 r.total_records;
+  (match r.sites with
+   | [ s ] -> assert_true "good site name parsed" (s.site = "ok")
+   | other ->
+       fail
+         (Printf.sprintf "expected one site, got %d" (List.length other)))
+
+(* --- #7718 regression reproduction ------------------------------ *)
+
+let test_degenerate_site_flagged () =
+  (* 51 copies of the exact tuple from #7718 reopen evidence. *)
+  let records =
+    repeat 51 (fun i ->
+      record ~ts:(float_of_int i)
+        ~site:"post_tool_use_failure" ~raw:1.0 ~thr:0.0 ~trig:true ())
+  in
+  let r = D.analyze records in
+  assert_eq_int ~msg:"51 records observed" 51 r.total_records;
+  (match r.sites with
+   | [ s ] ->
+     assert_eq_int ~msg:"single site count" 51 s.count;
+     assert_eq_int ~msg:"exactly one unique tuple" 1 s.unique_tuples;
+     assert_eq_int ~msg:"all triggered=true" 51 s.triggered_true_count
+   | _ -> fail "expected one site");
+  assert_list_equal ~msg:"post_tool_use_failure flagged degenerate"
+    [ "post_tool_use_failure" ] r.degenerate_sites;
+  assert_list_equal ~msg:"one-sided (100% triggered=true)"
+    [ "post_tool_use_failure" ] r.one_sided_sites
+
+let test_below_min_records_not_flagged () =
+  (* Identical-tuple stream but only degenerate_min_records - 1 records:
+     intentionally treated as insufficient data. *)
+  let n = D.degenerate_min_records - 1 in
+  let records =
+    repeat n (fun i ->
+      record ~ts:(float_of_int i) ~site:"tiny" ~raw:1.0 ~thr:0.0 ~trig:true ())
+  in
+  let r = D.analyze records in
+  assert_false "below-threshold site NOT flagged degenerate"
+    (List.mem "tiny" r.degenerate_sites);
+  assert_false "below-threshold site NOT flagged one-sided"
+    (List.mem "tiny" r.one_sided_sites)
+
+let test_variance_prevents_flag () =
+  (* Same site, but raw_value varies — healthy signal. *)
+  let records =
+    List.init 30 (fun i ->
+      record ~ts:(float_of_int i)
+        ~site:"healthy"
+        ~raw:(float_of_int i /. 100.0)
+        ~thr:0.5
+        ~trig:(i mod 2 = 0)
+        ())
+  in
+  let r = D.analyze records in
+  assert_false "varying site NOT degenerate"
+    (List.mem "healthy" r.degenerate_sites);
+  assert_false "varying site NOT one-sided"
+    (List.mem "healthy" r.one_sided_sites);
+  (match r.sites with
+   | [ s ] ->
+     assert_true "multiple unique tuples" (s.unique_tuples > 1);
+     assert_true "triggered counts split" (s.triggered_true_count > 0 && s.triggered_false_count > 0)
+   | _ -> fail "expected one site")
+
+(* --- Mixed-site report ----------------------------------------- *)
+
+let test_mixed_workload () =
+  let degenerate =
+    repeat 25 (fun i ->
+      record ~ts:(float_of_int i)
+        ~site:"theatre" ~raw:1.0 ~thr:0.0 ~trig:true ())
+  in
+  let healthy =
+    List.init 25 (fun i ->
+      record ~ts:(100.0 +. float_of_int i)
+        ~site:"real"
+        ~raw:(float_of_int i /. 100.0)
+        ~thr:0.5
+        ~trig:(i mod 3 = 0)
+        ())
+  in
+  let cold =
+    repeat 3 (fun _ ->
+      record ~site:"cold" ~raw:0.1 ~thr:0.9 ~trig:false ())
+  in
+  let r = D.analyze (degenerate @ healthy @ cold) in
+  assert_eq_int ~msg:"total records" 53 r.total_records;
+  assert_list_equal ~msg:"only theatre flagged degenerate"
+    [ "theatre" ] r.degenerate_sites;
+  assert_list_equal ~msg:"only theatre one-sided"
+    [ "theatre" ] r.one_sided_sites
+
+let test_all_triggered_false_flagged () =
+  (* Unreachable-branch case: site always records triggered=false but
+     raw/threshold differ → variance > 1 so not degenerate, but is
+     one-sided. *)
+  let records =
+    List.init 25 (fun i ->
+      record ~ts:(float_of_int i)
+        ~site:"unreachable"
+        ~raw:(float_of_int i /. 100.0)
+        ~thr:1.0
+        ~trig:false
+        ())
+  in
+  let r = D.analyze records in
+  assert_false "not degenerate (variance present)"
+    (List.mem "unreachable" r.degenerate_sites);
+  assert_list_equal ~msg:"one-sided (all triggered=false)"
+    [ "unreachable" ] r.one_sided_sites
+
+(* --- Timestamp + pretty ---------------------------------------- *)
+
+let test_latest_timestamp_is_max () =
+  let records =
+    [
+      record ~ts:3.0 ~site:"s" ~raw:1.0 ~thr:0.5 ~trig:true ();
+      record ~ts:1.0 ~site:"s" ~raw:1.0 ~thr:0.5 ~trig:true ();
+      record ~ts:5.0 ~site:"s" ~raw:1.0 ~thr:0.5 ~trig:true ();
+      record ~ts:2.0 ~site:"s" ~raw:1.0 ~thr:0.5 ~trig:true ();
+    ]
+  in
+  let r = D.analyze records in
+  match r.sites with
+  | [ s ] -> (
+      match s.latest_timestamp with
+      | Some 5.0 -> ()
+      | Some f ->
+          fail (Printf.sprintf "latest_timestamp should be 5.0, got %.3f" f)
+      | None -> fail "expected latest_timestamp")
+  | _ -> fail "expected one site"
+
+let contains_substring s sub =
+  let ls = String.length s and lsub = String.length sub in
+  if lsub = 0 then true
+  else if lsub > ls then false
+  else
+    let last = ls - lsub in
+    let rec loop i =
+      if i > last then false
+      else if String.sub s i lsub = sub then true
+      else loop (i + 1)
+    in
+    loop 0
+
+let test_pretty_summary_contains_header () =
+  let records =
+    repeat 25 (fun _ ->
+      record ~site:"x" ~raw:1.0 ~thr:0.0 ~trig:true ())
+  in
+  let r = D.analyze records in
+  let s = D.pretty_summary r in
+  assert_true "header line present"
+    (contains_substring s "heuristic_metrics diagnostics:");
+  assert_true "degenerate count surfaces"
+    (contains_substring s "degenerate=1");
+  assert_true "site line present"
+    (contains_substring s "site=x")
+
+let () =
+  test_ignores_malformed_records ();
+  test_degenerate_site_flagged ();
+  test_below_min_records_not_flagged ();
+  test_variance_prevents_flag ();
+  test_mixed_workload ();
+  test_all_triggered_false_flagged ();
+  test_latest_timestamp_is_max ();
+  test_pretty_summary_contains_header ();
+  print_endline "test_heuristic_metrics_diagnostics: OK"


### PR DESCRIPTION
Makes the \"instrumentation theatre\" state that re-opened #7718 detectable without touching the write path.

## Why

#7718 was closed 2026-04-20 (tracked by #8391, also closed). The reopen comment shows regression:

\`\`\`
$ jq -c '[.site, .raw_value, .threshold, .triggered]' ~/.masc/heuristic_metrics.jsonl | sort -u | wc -l
1
$ jq -c '[.site, .raw_value, .threshold, .triggered]' ~/.masc/heuristic_metrics.jsonl | sort -u
[\"post_tool_use_failure\", 1.0, 0.0, true]
\`\`\`

51 consecutive records, identical 4-tuple. The predicate \`1.0 > 0.0\` is a tautology — the subsystem is counting invocations and calling them a heuristic. File grows, dashboard line exists, site is registered — but nothing is observed.

## Root cause

Two read-side blind spots, both orthogonal to the existing unconditional enqueue:

1. **No coverage report.** Of 8 registered call sites, only 1 has ever emitted (original #7718 body). The reader cannot ask \"which registered sites are silent today?\"
2. **No variance signal.** A site that emits an identical tuple forever is indistinguishable from a rich-signal site — the writer accepts both at the same rate.

## What

- \`lib/heuristic_metrics_diagnostics.{ml,mli}\` — **pure** functions over a JSON record list (shape returned by \`Heuristic_metrics.recent\`). No I/O, no mutex, no side effects.
- \`analyze records\` returns \`{ total_records; sites; degenerate_sites; one_sided_sites }\`:
  - \`sites\`: per-site \`{ count, unique_tuples, latest_timestamp, triggered_true/false_count }\`
  - \`degenerate_sites\`: count ≥ 20 and unique_tuples ≤ 1 (the #7718 signature — enough volume to be meaningful, zero variance across the threshold-gated fields)
  - \`one_sided_sites\`: count ≥ 20 and 100% \`triggered=true\` (the #7718 symptom) OR 100% \`triggered=false\` (the unreachable-inner-branch case raised in iter-24 triage)
- \`degenerate_min_records = 20\` is deliberately lower than the 51 observed in the reopen evidence — false-positive tolerant for young sites while still flagging the regression.

## Design references

- Prometheus \`absent_over_time\` / \`changes()\` idiom — \"presence of a series is not health; change over time is\".
- OpenTelemetry stale-metrics guidance — periodic readout of metric activity separate from the metric itself.
- Google SRE workbook §\"Monitoring fake signals\" — a saturated \`triggered=true\` with a trivial threshold is the textbook fake-signal pattern.

## Test plan

- [x] 8 tests in \`test_heuristic_metrics_diagnostics\` — all pass
  - [x] Malformed record tolerance (missing field, Null, wrong type)
  - [x] **#7718 regression exactly reproduced**: 51 identical tuples → flagged as both degenerate and one-sided
  - [x] Below-threshold count NOT flagged (insufficient data)
  - [x] Varying raw_value / triggered prevents both flags (healthy site)
  - [x] Mixed workload (degenerate + healthy + cold): only the degenerate site flagged
  - [x] All \`triggered=false\` flagged as one-sided even with variance (unreachable-branch case)
  - [x] \`latest_timestamp\` is max across records, not last-seen
  - [x] \`pretty_summary\` contains header, degenerate count, and per-site line
- [x] \`dune build @check\` clean
- [ ] Live hook-in to boot-time log or dashboard — deferred to a follow-up PR once this module's output shape has review. Intent: \`Heuristic_metrics.recent 5000 |> Heuristic_metrics_diagnostics.analyze |> pretty_summary\` on boot.

## Non-goals

- No change to \`Heuristic_metrics.record\` / the write path. The issue body quotes it as an unconditional enqueue and explicitly says the asymmetry is at the call sites, not the writer.
- No decision about what to DO with a flagged site (remove, re-threshold, also record \`triggered=false\`). Per-site review.
- No closure of #7718. That should happen after (a) this diagnostics runs on live data for a day, and (b) the decision on \`post_tool_use_failure\` is made.

Refs: #7718 (reopened), #8391 (prior close that did not catch this class), #9860 #9870 (prior ticks in the same loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)