### PR TITLE
refactor(server): introduce with_server_state helper, migrate 11 dashboard GETs (#9793)

### DIFF
--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -137,6 +137,19 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
       | Some o -> o | None -> "*"
     in
     let cors = cors_headers origin in
+    (* [with_server_state] (#9793): HTTP-layer replacement for the
+       [get_server_state] raise-wrapper. Returns a controlled 500 JSON
+       error when server state is not initialized, instead of raising
+       [Failure] and crashing the request fiber. Mirrors the pattern
+       [handle_post_graphql] already uses via [get_server_state_result]. *)
+    let with_server_state h2_reqd f =
+      match get_server_state_result () with
+      | Ok state -> f state
+      | Error message ->
+          h2_respond_json h2_reqd
+            (server_state_error_json message)
+            ~status:`Internal_server_error ~extra_headers:cors
+    in
     let session_id_opt = get_session_id_any httpun_request in
     let h2_respond_dashboard_index () =
       let index_path = dashboard_index_path () in
@@ -550,52 +563,52 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
       | `GET, "/api/v1/dashboard/project-snapshot"
       | `GET, "/api/v1/dashboard/namespace-truth"
       | `GET, "/api/v1/dashboard/room-truth" ->
-          let state = get_server_state () in
-          let json =
-            dashboard_namespace_truth_http_json ~state ~sw ~clock httpun_request
-          in
-          h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+          with_server_state h2_reqd (fun state ->
+            let json =
+              dashboard_namespace_truth_http_json ~state ~sw ~clock httpun_request
+            in
+            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/execution" ->
-          let state = get_server_state () in
-          let json = dashboard_execution_http_json ~state ~sw ~clock httpun_request in
-          h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+          with_server_state h2_reqd (fun state ->
+            let json = dashboard_execution_http_json ~state ~sw ~clock httpun_request in
+            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/execution-trust" ->
-          let state = get_server_state () in
-          let json =
-            dashboard_execution_trust_http_json ~state ~sw ~clock
-              httpun_request
-          in
-          h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+          with_server_state h2_reqd (fun state ->
+            let json =
+              dashboard_execution_trust_http_json ~state ~sw ~clock
+                httpun_request
+            in
+            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/board" ->
           let json = dashboard_memory_http_json httpun_request in
           h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
 
       | `GET, "/api/v1/dashboard/governance" ->
-          let state = get_server_state () in
-          let json =
-            dashboard_governance_http_json httpun_request
-              ~base_path:state.Mcp_server.room_config.base_path
-          in
-          h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+          with_server_state h2_reqd (fun state ->
+            let json =
+              dashboard_governance_http_json httpun_request
+                ~base_path:state.Mcp_server.room_config.base_path
+            in
+            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/planning" ->
-          let state = get_server_state () in
-          let json =
-            dashboard_planning_http_json
-              ~config:state.Mcp_server.room_config
-          in
-          h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+          with_server_state h2_reqd (fun state ->
+            let json =
+              dashboard_planning_http_json
+                ~config:state.Mcp_server.room_config
+            in
+            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/goals" ->
-          let state = get_server_state () in
-          let json =
-            dashboard_goals_tree_http_json
-              ~config:state.Mcp_server.room_config
-          in
-          h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+          with_server_state h2_reqd (fun state ->
+            let json =
+              dashboard_goals_tree_http_json
+                ~config:state.Mcp_server.room_config
+            in
+            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/goals/detail" ->
           let state = get_server_state () in
@@ -639,32 +652,32 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
               ~extra_headers:cors
 
       | `GET, "/api/v1/dashboard/mission" ->
-          let state = get_server_state () in
-          let json = dashboard_mission_http_json ~state ~sw ~clock httpun_request in
-          h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+          with_server_state h2_reqd (fun state ->
+            let json = dashboard_mission_http_json ~state ~sw ~clock httpun_request in
+            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/session" ->
-          let state = get_server_state () in
-          let json = dashboard_session_http_json ~state ~sw ~clock httpun_request in
-          h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+          with_server_state h2_reqd (fun state ->
+            let json = dashboard_session_http_json ~state ~sw ~clock httpun_request in
+            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/mission/briefing" ->
-          let state = get_server_state () in
-          let json =
-            dashboard_mission_briefing_http_json ~state ~sw ~clock
-              httpun_request
-          in
-          h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+          with_server_state h2_reqd (fun state ->
+            let json =
+              dashboard_mission_briefing_http_json ~state ~sw ~clock
+                httpun_request
+            in
+            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/transport-health" ->
-          let state = get_server_state () in
-          let json = dashboard_transport_health_http_json ~state in
-          h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+          with_server_state h2_reqd (fun state ->
+            let json = dashboard_transport_health_http_json ~state in
+            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/perf" ->
-          let state = get_server_state () in
-          let json = dashboard_perf_http_json state.Mcp_server.room_config in
-          h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+          with_server_state h2_reqd (fun state ->
+            let json = dashboard_perf_http_json state.Mcp_server.room_config in
+            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
 
       | `GET, "/api/v1/autoresearch/loops" ->
           let state = get_server_state () in


### PR DESCRIPTION
## 목표

Issue #9793 — `get_server_state` raise-wrapper가 초기화되지 않은 서버 상태에서 request fiber를 crash시키는 문제. HTTP-layer에서 `get_server_state_result` 기반 helper로 전환해 controlled 500 JSON 에러로 대응.

## 변경 내용

### `lib/server/server_h2_gateway.ml` (단일 파일, +63 / -50)

1. **`with_server_state` helper 추가** (line 140 부근, `make_request_handler` 내부 per-request 스코프):

   ```ocaml
   let with_server_state h2_reqd f =
     match get_server_state_result () with
     | Ok state -> f state
     | Error message ->
         h2_respond_json h2_reqd
           (server_state_error_json message)
           ~status:`Internal_server_error ~extra_headers:cors
   in
   ```

2. **11 dashboard GET handlers 이전**: `let state = get_server_state () in <body>` → `with_server_state h2_reqd (fun state -> <body>)`

| Endpoint | 
|----------|
| `/api/v1/dashboard/project-snapshot` (+ namespace-truth + room-truth) |
| `/api/v1/dashboard/execution` |
| `/api/v1/dashboard/execution-trust` |
| `/api/v1/dashboard/governance` |
| `/api/v1/dashboard/planning` |
| `/api/v1/dashboard/goals` |
| `/api/v1/dashboard/mission` |
| `/api/v1/dashboard/session` |
| `/api/v1/dashboard/mission/briefing` |
| `/api/v1/dashboard/transport-health` |
| `/api/v1/dashboard/perf` |

## 왜 Strategy C (helper)인가

Issue #9793 조사 코멘트(2026-04-24)에서 Strategy A/B/C 비교:
- **A**: 22 callers 전부 `match get_server_state_result() with | Error -> respond 500 | Ok state -> ...`로 전환 → 4 lines × 22 = 88 lines of boilerplate
- **B**: H2 dispatcher boundary에서 `try/with Failure`로 catch → scope-wise 가장 작지만 raise-wrapper 자체는 그대로 두는 symptom 치료
- **C**: helper + caller 이전 → primacy pattern 보존 + 1줄 shape 유지, 최종적으로 `get_server_state` 삭제 가능

C가 근본 수정 방향이면서 A의 반복을 피한다.

## 동작 변경

Before (11 endpoints):
- 서버 state 미초기화 시 `Failure "server state not initialized"` raise
- H2 request fiber crash → 클라이언트는 connection drop

After (11 endpoints, 이 PR):
- 서버 state 미초기화 시 HTTP 500 + `{"error":"server state not initialized"}` JSON body
- Fiber 정상 완료, CORS 헤더 유지

## 로컬 검증

- `dune build @check --root=.` exit 0 (rebase 후 .cmi 재생성 1회 필요했으나 최종 pass)
- Printf arity + OCaml type inference가 helper shape 전체 검증
- 남은 11 callers는 여전히 raise-wrapper 사용 — Iter 2에서 마이그레이션 예정

## 남은 작업 (Iter 2, 다음 PR)

11 callers 남음:
- POST /webrtc/offer, /webrtc/answer (nested `else (` 구조)
- /api/v1/dashboard/goals/detail (inner if/else 분기)
- /api/v1/dashboard/tasks/history (inner if/else + query param 분기)
- /api/v1/autoresearch/* 계열 (2건)
- 기타 5 callers

Iter 2 완료 후 `get_server_state` 래퍼 자체를 `server_routes_http_pages.ml`에서 삭제하면 근본 수정 완료.

## Follow-up

- Iter 2 PR에서 나머지 11 callers + 래퍼 삭제 + `.mli` 업데이트
- `handle_post_graphql` (server_routes_http_pages.ml:517)는 이미 Result 기반 패턴이라 그대로

## 관련

- Refs #9793
- 설계 분석: https://github.com/jeong-sik/masc-mcp/issues/9793#issuecomment-4310878422

---

_/loop masc-mcp issues 하나씩 근본 해결 — cycle 6 PR (Iter 1/2)_
