### PR TITLE
fix(dashboard): raise git rev-parse --short probe timeout 5s→15s for large repos (#9765, #9775)

### DIFF
--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -130,6 +130,16 @@ let git_rev_parse_short_cancel_refresh dir =
 let git_rev_parse_short_probe_argv dir =
   [ "git"; "-C"; dir; "--no-optional-locks"; "rev-parse"; "--short"; "HEAD" ]
 
+(* Bumped 5s → 15s for large repos (#9765, #9775).
+   `~/me` repeatedly trips the 5s budget on first probe after TTL
+   expiry (3 occurrences in issue #9775 logs at 18:29/18:41/18:50).
+   The probe runs on a background fiber via
+   [maybe_refresh_git_rev_parse_short_in_background], so the extra
+   wall-time does not affect the hot dashboard path — cached values
+   keep serving during the refresh. Matches the sibling
+   [dashboard_runtime_probe_timeout_sec = 15] at the top of this module. *)
+let git_rev_parse_short_probe_timeout_sec = 15.0
+
 let git_rev_parse_short_probe dir =
   match Atomic.get git_rev_parse_short_probe_hook_for_tests with
   | Some hook -> hook dir
@@ -141,7 +151,7 @@ let git_rev_parse_short_probe dir =
           ~actor:"system/runtime_info"
           ~raw_source
           ~summary:"dashboard runtime git probe"
-          ~timeout_sec:5.0
+          ~timeout_sec:git_rev_parse_short_probe_timeout_sec
           argv
       with
       | Unix.WEXITED 0, output -> trim_to_option output


### PR DESCRIPTION
## 목표

Issues #9765, #9775 — `~/me` 같은 대형 레포에서 `git rev-parse --short HEAD` 백그라운드 probe가 5초 budget을 반복적으로 초과해 warning 로그 누적. 두 이슈 같은 root cause.

## 변경 내용

`lib/server/server_dashboard_http_runtime_info.ml`:
- `git_rev_parse_short_probe` 의 `~timeout_sec` 을 `5.0` → `15.0` 으로 상향
- magic literal 대신 named constant `git_rev_parse_short_probe_timeout_sec` 도입

Diff: +11 / -1, 단일 파일.

## 근거

### 이슈 #9775 로그
```
[Process_eio] Timeout after 5s: 'git' '-C' '/Users/dancer/me' '--no-optional-locks' 'rev-parse' '--short' 'HEAD'
```
- 18:29:50Z (seq=50980)
- 18:41:38Z (seq=51852)
- 18:50:46Z (seq=52615)

22분 내 3회 — 주기적으로 5초를 초과하는 대형 레포 I/O 패턴.

### 왜 안전한가

1. **백그라운드 fiber에서 실행** (`maybe_refresh_git_rev_parse_short_in_background`, line 161) — hot path가 아님
2. **60초 TTL cache**가 refresh 진행 중에도 stale value 서빙
3. **In-flight dedup** (`git_rev_parse_short_try_begin_refresh`)으로 동시 refresh 방지
4. **이미 모듈 상단에 동일 카테고리 probe의 15s 상수** 존재:
   ```ocaml
   let dashboard_runtime_probe_timeout_sec = 15
   ```
   같은 read-only git probe류를 같은 budget으로 통일.

### 왜 cache TTL 확장이 아닌 timeout 확장인가

#9765 제안 2 (TTL 확장)는 **이미 구현**됨 — 60s TTL이 존재. 지금 실패하는 건 TTL 만료 후 첫 refresh 시도가 5s 안에 완료 안 되는 경우. TTL을 더 키우면 git SHA가 더 stale해질 뿐 — dashboard에서 최근 commit 반영이 지연됨.

Timeout 확장은 **첫 refresh 성공률**을 높여 cache가 더 최신 값으로 채워지게 한다. 대형 레포에서 5s는 디스크 I/O + git internal lock에 너무 빠듯함.

## 로컬 검증

- `dune build @check --root=.` exit 0
- 변경 부위가 단일 상수 + 한 호출 사이트라 semantics 영향 최소

## 동작 변경

Before:
- TTL 만료 후 refresh probe가 5s 안에 끝나지 않으면 timeout → `None` 반환 → cache에 `None` 저장 → dashboard가 SHA 없음
- WARN 로그 반복 노출

After:
- Refresh probe가 최대 15s까지 대기 → 대형 레포에서도 정상 완료 가능성 훨씬 높음
- Cache에 정상 SHA 저장 → dashboard에 SHA 노출
- WARN 로그 감소

## 해결되지 않는 것

- **다른 경로의 git rev-parse 호출**은 별도 timeout 적용 (본 PR 범위 외):
  - `lib/build_identity.ml:48` (`timeout_sec:5.0`) — 빌드 시 1회 호출, hot path 아니나 SHA가 필요하면 같은 패턴 적용 가능
  - `lib/keeper/keeper_repo_readiness.ml:219` (`timeout_sec:5.0`) — keeper readiness check
  - `lib/coord/coord_identity.ml:26` (`timeout_sec:5.0`)
  - `lib/tool_local_runtime_core.ml:118` (`timeout_sec:5.0`)

만약 동일 증상이 다른 경로에서 재발하면 같은 approach (`15s + named constant`) 또는 공통 상수로 리팩토링 고려.

## 관련

- Refs #9765 (원 이슈, proposed fix 제안)
- Refs #9775 (같은 증상, repeated I/O delay 추적)

---

_/loop masc-mcp issues 하나씩 근본 해결 — cycle 7 PR_
