### PR TITLE
refactor(provider_adapter): centralize vendor classification predicates

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -30,41 +30,12 @@ let keeper_denied_tools =
 
 (** Derive a provider label from a model id.
 
-    Benchmarking downstream (e.g. 15-keeper cascade weighted_random turns)
-    needs to group costs.jsonl rows by provider. The raw [model] field
-    mixes two conventions:
-    - prefixed: [glm-coding:glm-5-turbo], [claude:claude-haiku-4-5-20251001]
-    - bare: [glm-5-turbo], [claude-haiku-4-5-20251001] (emitted by some
-      OAS transports that strip the scheme before reporting)
-
-    Prefer the prefix when present; otherwise fall back to a minimal
-    heuristic over known bare-name shapes. Returns [unknown] rather
-    than guessing when no rule fits, so analysis queries can filter
-    those rows out rather than miscount them. *)
-let known_providers = [
-  "glm-coding"; "glm"; "claude"; "claude_code";
-  "gemini"; "gemini_cli"; "codex_cli"; "ollama";
-]
-
+    Delegates to {!Provider_adapter.provider_of_model_label}. Kept as a
+    thin alias so existing callers in keeper_* and dashboard_* modules
+    do not need to update, while the vendor-name vocabulary lives with
+    the other provider-classification helpers. *)
 let provider_of_model (model : string) : string =
-  let bare_heuristic () =
-    let starts_with prefix =
-      String.length model >= String.length prefix
-      && String.sub model 0 (String.length prefix) = prefix
-    in
-    if starts_with "glm-" then "glm-coding"
-    else if starts_with "claude-" then "claude"
-    else if starts_with "gemini-" then "gemini"
-    else if starts_with "gpt-" then "openai"
-    else if starts_with "qwen" || starts_with "llama" then "ollama"
-    else "unknown"
-  in
-  match String.index_opt model ':' with
-  | Some i ->
-    let prefix = String.sub model 0 i in
-    if List.mem prefix known_providers then prefix
-    else bare_heuristic ()
-  | None -> bare_heuristic ()
+  Provider_adapter.provider_of_model_label model
 
 type tool_execution_summary =
   { tool_name : string

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -138,7 +138,7 @@ let telemetry_reported_of_result
   Option.is_some result.inference_telemetry
 
 let structurally_unmetered_provider (provider : string) : bool =
-  List.mem provider [ "kimi_cli"; "codex_cli"; "gemini_cli" ]
+  Provider_adapter.is_structurally_unmetered_provider provider
 
 let coverage_reason_of_result
     (result : Keeper_agent_run.run_result) : string option =

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -1261,6 +1261,55 @@ let provider_prefix_of_label_result label =
            "Default model label must be provider:model, got: %s"
            normalized)
 
+(** Provider names recognised as prefix tokens in "<provider>:<model>" labels.
+
+    Used by {!provider_of_model_label} when a label carries an explicit
+    prefix, so telemetry groups costs.jsonl rows without misclassifying
+    idiosyncratic or private vendor names. *)
+let prefix_classification_vocabulary = [
+  "glm-coding"; "glm"; "claude"; "claude_code";
+  "gemini"; "gemini_cli"; "codex_cli"; "ollama";
+]
+
+(** Classify a raw model label to a provider name for telemetry grouping.
+
+    Callers feed heterogeneous model strings — OAS transports may emit
+    either prefixed (["glm-coding:glm-5-turbo"]) or bare
+    (["claude-haiku-4-5-20251001"]) labels. Prefer the explicit prefix
+    when present; fall back to a minimal heuristic over known bare-name
+    shapes. Returns ["unknown"] rather than guessing when no rule fits
+    so analysis queries can filter those rows out rather than miscount
+    them. *)
+let provider_of_model_label (model : string) : string =
+  let bare_heuristic () =
+    let starts_with prefix =
+      String.length model >= String.length prefix
+      && String.sub model 0 (String.length prefix) = prefix
+    in
+    if starts_with "glm-" then "glm-coding"
+    else if starts_with "claude-" then "claude"
+    else if starts_with "gemini-" then "gemini"
+    else if starts_with "gpt-" then "openai"
+    else if starts_with "qwen" || starts_with "llama" then "ollama"
+    else "unknown"
+  in
+  match String.index_opt model ':' with
+  | Some i ->
+      let prefix = String.sub model 0 i in
+      if List.mem prefix prefix_classification_vocabulary then prefix
+      else bare_heuristic ()
+  | None -> bare_heuristic ()
+
+(** Whether a provider emits no usage tokens in its standard response.
+
+    Used by metrics coverage gating: a text-only turn against one of
+    these providers cannot produce a usage_reported=true record even on
+    success, so we don't count that as a coverage gap. The set matches
+    the CLI-class providers where the CLI strips or elides usage before
+    returning to the caller. *)
+let is_structurally_unmetered_provider (provider : string) : bool =
+  List.mem provider [ "kimi_cli"; "codex_cli"; "gemini_cli" ]
+
 let default_model_provider_prefix_result () =
   match default_model_label_result () with
   | Ok label -> provider_prefix_of_label_result label

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -294,6 +294,16 @@ val default_model_label_result : unit -> (string, string) result
 (** Extract provider prefix from a "provider:model" label. *)
 val provider_prefix_of_label_result : string -> (string, string) result
 
+(** Classify a raw model label (prefixed or bare) to a provider name for
+    telemetry grouping. Returns ["unknown"] when no rule fits, so analysis
+    queries can filter rather than miscount. *)
+val provider_of_model_label : string -> string
+
+(** True when the provider emits no usage tokens in its standard response.
+    Used by metrics coverage gating so text-only turns against CLI-class
+    providers that strip usage do not count as coverage gaps. *)
+val is_structurally_unmetered_provider : string -> bool
+
 (** Provider prefix of the default model label. *)
 val default_model_provider_prefix_result : unit -> (string, string) result
 


### PR DESCRIPTION
## Context

Vendor 경계 audit 결과 `keeper/` 하위에 흩어져 있던 provider-name 하드코딩을 정리. MASC 레이어 모듈은 가능한 vendor-agnostic을 유지하라는 `MEMORY.md` 원칙(`MASC model-agnostic`, `MASC-OAS Layer Boundary`)에 따라 단일 facade(`Provider_adapter`)로 vendor vocabulary를 모음.

관련 audit 발견:
- `lib/keeper/keeper_hooks_oas.ml` — `known_providers` list + `provider_of_model` bare-name heuristic 하드코딩
- `lib/keeper/keeper_unified_metrics.ml:141` — `structurally_unmetered_provider` vendor list

## Change

`Provider_adapter`에 두 helper 추가:

- `provider_of_model_label : string -> string` — prefixed/bare model label을 provider 이름으로 분류. `"unknown"` fail-open
- `is_structurally_unmetered_provider : string -> bool` — 표준 응답에 usage tokens가 없는 CLI provider 판정

기존 호출부는 건드리지 않음 — `Keeper_hooks_oas.provider_of_model`, `Keeper_unified_metrics.structurally_unmetered_provider`는 thin delegator로 유지. 실제로 옮긴 것은 **literal 문자열 vocabulary**뿐 (`["glm-coding"; "glm"; "claude"; ...]`, `["kimi_cli"; "codex_cli"; "gemini_cli"]`).

## No behavior change

- 3개 기존 call site(`dashboard_cascade.ml`, `model_inference_metrics.ml`, `keeper_unified_metrics.ml`) 미변경
- `test_keeper_hooks_oas_provider.exe` 3 cases 모두 pass (delegator 경유)

## Follow-up (out of scope)

`is_structurally_unmetered_provider`는 궁극적으로 OAS `Llm_provider.Capabilities`에 `emits_usage_tokens : bool` 같은 flag로 이전되는 것이 correct한 방향. SDK pin bump 필요해서 이 PR에는 포함 안 함.

## Test plan

- [x] `dune build @check` pass
- [x] `dune build test/test_keeper_hooks_oas_provider.exe && run` — 3 OK
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)