### PR TITLE
[codex] fix runtime truth regressions

### DIFF
--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -37,8 +37,18 @@ type t = {
   keeper_runtime_toml_present : bool;
   warnings : string list;
   next_actions : string list;
+  persona_tool_preset_conflicts : persona_tool_preset_conflict list;
   catalog_validation : Yojson.Safe.t option;
   sandbox_preflight : Yojson.Safe.t option;
+}
+
+and persona_tool_preset_conflict = {
+  keeper_name : string;
+  persona_name : string;
+  toml_path : string;
+  persona_path : string;
+  toml_tool_preset : string;
+  persona_tool_preset : string;
 }
 
 type catalog_issue_severity = Cascade_catalog_validator.severity =
@@ -161,6 +171,122 @@ let cascade_catalog_next_actions ~config_path issues =
       primary_action;
       "Rerun `masc-mcp doctor config` after editing cascade.json.";
     ]
+
+let normalize_tool_preset_opt raw =
+  match raw with
+  | None -> None
+  | Some value ->
+      let normalized = String.trim (String.lowercase_ascii value) in
+      if normalized = "" then
+        None
+      else
+        Some normalized
+
+let non_empty_trimmed_opt raw =
+  match raw with
+  | None -> None
+  | Some value ->
+      let trimmed = String.trim value in
+      if trimmed = "" then
+        None
+      else
+        Some trimmed
+
+let persona_tool_preset_conflict_to_warning conflict =
+  Printf.sprintf
+    "Keeper %s TOML tool_preset %S overrides persona %s tool_preset %S (toml=%s persona=%s)."
+    conflict.keeper_name
+    conflict.toml_tool_preset
+    conflict.persona_name
+    conflict.persona_tool_preset
+    conflict.toml_path
+    conflict.persona_path
+
+let persona_tool_preset_conflict_to_action conflict =
+  Printf.sprintf
+    "Remove tool_preset from %s unless the override is intentional; TOML wins until fixed."
+    conflict.toml_path
+
+let persona_tool_preset_conflict_to_yojson conflict =
+  `Assoc
+    [
+      ("keeper_name", `String conflict.keeper_name);
+      ("persona_name", `String conflict.persona_name);
+      ("toml_path", `String conflict.toml_path);
+      ("persona_path", `String conflict.persona_path);
+      ("toml_tool_preset", `String conflict.toml_tool_preset);
+      ("persona_tool_preset", `String conflict.persona_tool_preset);
+    ]
+
+let discover_persona_tool_preset_conflicts ~active_config_root
+    ~active_personas_root =
+  let keepers_dir = Filename.concat active_config_root "keepers" in
+  if not (Env_config_core.existing_dir keepers_dir) then
+    []
+  else
+    Sys.readdir keepers_dir
+    |> Array.to_list
+    |> List.filter (fun name -> Filename.check_suffix name ".toml")
+    |> List.filter_map (fun filename ->
+           let toml_path = Filename.concat keepers_dir filename in
+           match Safe_ops.read_file_safe toml_path with
+           | Error _ -> None
+           | Ok content -> (
+               match Keeper_toml_loader.parse_toml content with
+               | Error _ -> None
+               | Ok doc ->
+                   let keeper_name =
+                     Keeper_toml_loader.toml_string_opt doc "keeper.name"
+                     |> non_empty_trimmed_opt
+                     |> Option.value
+                          ~default:(Filename.chop_suffix filename ".toml")
+                   in
+                   let persona_name =
+                     Keeper_toml_loader.toml_string_opt doc
+                       "keeper.persona_name"
+                     |> non_empty_trimmed_opt
+                     |> Option.value ~default:keeper_name
+                   in
+                   let toml_tool_preset =
+                     Keeper_toml_loader.toml_string_opt doc
+                       "keeper.tool_preset"
+                     |> normalize_tool_preset_opt
+                   in
+                   match toml_tool_preset with
+                   | None -> None
+                   | Some toml_tool_preset ->
+                       let persona_path =
+                         Filename.concat
+                           (Filename.concat active_personas_root persona_name)
+                           "profile.json"
+                       in
+                       if not (Env_config_core.existing_file persona_path) then
+                         None
+                       else
+                         match Safe_ops.read_json_file_logged
+                                 ~label:"config_doctor_persona" persona_path
+                         with
+                         | None -> None
+                         | Some json ->
+                             let persona_tool_preset =
+                               json
+                               |> Yojson.Safe.Util.member "keeper"
+                               |> Safe_ops.json_string_opt "tool_preset"
+                               |> normalize_tool_preset_opt
+                             in
+                             match persona_tool_preset with
+                             | Some persona_tool_preset
+                               when persona_tool_preset <> toml_tool_preset ->
+                                 Some
+                                   {
+                                     keeper_name;
+                                     persona_name;
+                                     toml_path;
+                                     persona_path;
+                                     toml_tool_preset;
+                                     persona_tool_preset;
+                                   }
+                             | _ -> None))
 
 let current_inputs ~base_path_input ~default_base_path () =
   let normalized_base_path =
@@ -292,6 +418,11 @@ let analyze_with (inputs : inputs) =
   let cascade_catalog_issues =
     diagnose_cascade_catalog ~active_config_root
   in
+  let persona_tool_preset_conflicts =
+    discover_persona_tool_preset_conflicts
+      ~active_config_root
+      ~active_personas_root
+  in
   let cascade_config_path =
     Filename.concat active_config_root Config_dir_resolver.cascade_json_filename
   in
@@ -349,6 +480,8 @@ let analyze_with (inputs : inputs) =
     |> List.filter_map (fun warning -> warning)
     |> fun base_warnings ->
     base_warnings
+    @ List.map persona_tool_preset_conflict_to_warning
+        persona_tool_preset_conflicts
     @ List.map (fun issue -> issue.message) cascade_catalog_issues
     |> dedupe_keep_order
   in
@@ -425,7 +558,11 @@ let analyze_with (inputs : inputs) =
            | _ ->
                "No further action needed.");
         ]
-    |> fun base_actions -> base_actions @ cascade_actions
+    |> fun base_actions ->
+    base_actions
+    @ List.map persona_tool_preset_conflict_to_action
+        persona_tool_preset_conflicts
+    @ cascade_actions
     |> dedupe_keep_order
   in
   let has_catalog_errors =
@@ -439,6 +576,7 @@ let analyze_with (inputs : inputs) =
     | Shadowed -> Warn
     | Initialized ->
         if has_catalog_errors then Error
+        else if persona_tool_preset_conflicts <> [] then Warn
         else if warnings = [] then Ok else Warn
   in
   {
@@ -458,6 +596,7 @@ let analyze_with (inputs : inputs) =
     keeper_runtime_toml_present;
     warnings;
     next_actions;
+    persona_tool_preset_conflicts;
     catalog_validation = None;
     sandbox_preflight = None;
   }
@@ -595,6 +734,10 @@ let to_yojson (report : t) =
       ("keeper_runtime_toml_present", `Bool report.keeper_runtime_toml_present);
       ("warnings", `List (List.map (fun value -> `String value) report.warnings));
       ("next_actions", `List (List.map (fun value -> `String value) report.next_actions));
+      ( "persona_tool_preset_conflicts",
+        `List
+          (List.map persona_tool_preset_conflict_to_yojson
+             report.persona_tool_preset_conflicts) );
       ( "catalog_validation",
         match report.catalog_validation with
         | Some value -> value
@@ -643,6 +786,19 @@ let render_text (report : t) =
   add_line
     (Printf.sprintf "keeper_runtime.toml: %s"
        (if report.keeper_runtime_toml_present then "present" else "missing"));
+  if report.persona_tool_preset_conflicts <> [] then begin
+    add_line "";
+    add_line "persona_tool_preset_conflicts:";
+    List.iter
+      (fun conflict ->
+         add_line
+           (Printf.sprintf "- keeper=%s persona=%s toml=%s persona_profile=%s"
+              conflict.keeper_name
+              conflict.persona_name
+              conflict.toml_path
+              conflict.persona_path))
+      report.persona_tool_preset_conflicts
+  end;
   (match report.catalog_validation with
    | Some validation ->
        add_line "";

--- a/lib/heuristic_metrics.ml
+++ b/lib/heuristic_metrics.ml
@@ -27,6 +27,19 @@ type event = {
   timestamp : float;
 }
 
+type coverage_site = {
+  module_name : string;
+  site : string;
+  count : int;
+  triggered_count : int;
+}
+
+type coverage_report = {
+  total_events : int;
+  sites : coverage_site list;
+  unique_decision_tuples : int;
+}
+
 (* ================================================================ *)
 (* Serialization                                                    *)
 (* ================================================================ *)
@@ -160,3 +173,93 @@ let recent n =
           with Yojson.Json_error msg ->
             Log.warn ~ctx:"heuristic_metrics" "dropping malformed line: %s" msg;
             None)
+
+let coverage_report_of_events events =
+  let site_counts : ((string * string), (int * int) ref) Hashtbl.t =
+    Hashtbl.create 16
+  in
+  let unique_tuples : (string, unit) Hashtbl.t = Hashtbl.create 16 in
+  let json_string_field name json =
+    match Yojson.Safe.Util.member name json with
+    | `String value -> Some value
+    | _ -> None
+  in
+  let json_float_field name json =
+    match Yojson.Safe.Util.member name json with
+    | `Float value -> Some value
+    | `Int value -> Some (Float.of_int value)
+    | _ -> None
+  in
+  let json_bool_field name json =
+    match Yojson.Safe.Util.member name json with
+    | `Bool value -> Some value
+    | _ -> None
+  in
+  List.iter
+    (fun json ->
+       match json_string_field "module" json, json_string_field "site" json with
+       | Some module_name, Some site ->
+           let triggered =
+             Option.value ~default:false (json_bool_field "triggered" json)
+           in
+           let key = (module_name, site) in
+           let slot =
+             match Hashtbl.find_opt site_counts key with
+             | Some slot -> slot
+             | None ->
+                 let slot = ref (0, 0) in
+                 Hashtbl.add site_counts key slot;
+                 slot
+           in
+           let count, triggered_count = !slot in
+           slot :=
+             (count + 1, triggered_count + if triggered then 1 else 0);
+           let tuple_key =
+             Printf.sprintf "%s\000%s\000%.12g\000%.12g\000%b"
+               module_name
+               site
+               (Option.value ~default:Float.nan
+                  (json_float_field "raw_value" json))
+               (Option.value ~default:Float.nan
+                  (json_float_field "threshold" json))
+               triggered
+           in
+           Hashtbl.replace unique_tuples tuple_key ()
+       | _ -> ())
+    events;
+  let sites =
+    site_counts
+    |> Hashtbl.to_seq
+    |> List.of_seq
+    |> List.map (fun ((module_name, site), counts) ->
+           let count, triggered_count = !counts in
+           { module_name; site; count; triggered_count })
+    |> List.sort (fun a b ->
+           let c = String.compare a.module_name b.module_name in
+           if c <> 0 then c else String.compare a.site b.site)
+  in
+  {
+    total_events = List.length events;
+    sites;
+    unique_decision_tuples = Hashtbl.length unique_tuples;
+  }
+
+let recent_coverage n =
+  recent n |> coverage_report_of_events
+
+let coverage_site_to_json site =
+  `Assoc
+    [
+      ("module", `String site.module_name);
+      ("site", `String site.site);
+      ("count", `Int site.count);
+      ("triggered_count", `Int site.triggered_count);
+    ]
+
+let coverage_report_to_json report =
+  `Assoc
+    [
+      ("total_events", `Int report.total_events);
+      ("unique_decision_tuples", `Int report.unique_decision_tuples);
+      ("sites", `List (List.map coverage_site_to_json report.sites));
+    ]

--- a/lib/heuristic_metrics.mli
+++ b/lib/heuristic_metrics.mli
@@ -32,6 +32,19 @@ type event = {
   timestamp : float;
 }
 
+type coverage_site = {
+  module_name : string;
+  site : string;
+  count : int;
+  triggered_count : int;
+}
+
+type coverage_report = {
+  total_events : int;
+  sites : coverage_site list;
+  unique_decision_tuples : int;
+}
+
 val record : event -> unit
 (** Append a metric event.  Thread-safe.  No-op if storage is not initialized. *)
 
@@ -44,6 +57,16 @@ val flush : unit -> unit
 
 val recent : int -> Yojson.Safe.t list
 (** Read the N most recent events as JSON objects. *)
+
+val coverage_report_of_events : Yojson.Safe.t list -> coverage_report
+(** Summarize event coverage by module/site and count distinct
+    raw/threshold/triggered tuples. *)
+
+val recent_coverage : int -> coverage_report
+(** Read recent events and summarize their coverage. *)
+
+val coverage_report_to_json : coverage_report -> Yojson.Safe.t
+(** Serialize a coverage report for diagnostics. *)
 
 val event_to_json : event -> Yojson.Safe.t
 (** Serialize an event for external consumption (dashboard, tests). *)

--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -182,11 +182,14 @@ let signal_bonus_multi_tool = 0.06
 let handoff_pressure_threshold () =
   Runtime_params.get Governance_registry.keeper_handoff_pressure_threshold
 (** Goal alignment below which low-alignment signal fires. *)
-let goal_alignment_floor = 0.20
+let goal_alignment_floor = 0.05
 (** Response alignment below which low-alignment signal fires. *)
 let response_alignment_floor = 0.16
 (** Minimum tool call count to trigger multi-tool signal. *)
 let multi_tool_min_count = 2
+
+let alert_emit_threshold () =
+  max 0.0 (min 1.0 Env_config.KeeperAlert.min_score)
 
 let keeper_alert_signal
     ~(message : string)
@@ -229,12 +232,13 @@ let keeper_alert_signal
   end;
   let score = max 0.0 (min 1.0 !score) in
   let keywords = keyword_hits |> List.map fst |> dedup_strings in
+  let threshold = alert_emit_threshold () in
   Heuristic_metrics.record {
     module_name = "keeper_alerting";
     site = "keeper_alert_signal";
     raw_value = score;
-    threshold = 0.0;
-    triggered = score > 0.0;
+    threshold;
+    triggered = score >= threshold;
     provenance = Alert_scoring (String.concat "," (List.rev !reasons));
     timestamp = Unix.gettimeofday ();
   };
@@ -467,7 +471,7 @@ let maybe_emit_interesting_alert
     ~(response_alignment : float)
     ~(auto_rules : keeper_auto_rule_eval) : interesting_alert_result =
   let enabled = Env_config.KeeperAlert.enabled in
-  let threshold = max 0.0 (min 1.0 Env_config.KeeperAlert.min_score) in
+  let threshold = alert_emit_threshold () in
   if not enabled then
     { empty_interesting_alert_result with enabled = false; threshold }
   else

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -37,6 +37,45 @@ let keeper_denied_tools =
 let provider_of_model (model : string) : string =
   Provider_adapter.provider_of_model_label model
 
+let structurally_unmetered_provider provider =
+  List.mem provider
+    [ "ollama"; "codex_cli"; "gemini_cli"; "claude_code"; "kimi_cli" ]
+
+let usage_has_tokens (usage : Oas.Types.api_usage) =
+  usage.input_tokens > 0
+  || usage.output_tokens > 0
+  || usage.cache_creation_input_tokens > 0
+  || usage.cache_read_input_tokens > 0
+
+let estimate_usage_cost_usd ~(model : string) (usage : Oas.Types.api_usage)
+    : float =
+  let pricing = Llm_provider.Pricing.pricing_for_model model in
+  Llm_provider.Pricing.estimate_cost ~pricing
+    ~input_tokens:usage.input_tokens
+    ~output_tokens:usage.output_tokens ()
+
+let cost_usd_for_usage ~(model : string) (usage : Oas.Types.api_usage)
+    : float =
+  let provider = provider_of_model model in
+  match usage.cost_usd with
+  | Some cost when cost > 0.0 -> cost
+  | Some cost ->
+      if
+        usage_has_tokens usage
+        && not (structurally_unmetered_provider provider)
+      then
+        estimate_usage_cost_usd ~model usage
+      else
+        cost
+  | None ->
+      if
+        usage_has_tokens usage
+        && not (structurally_unmetered_provider provider)
+      then
+        estimate_usage_cost_usd ~model usage
+      else
+        0.0
+
 type tool_execution_summary =
   { tool_name : string
   ; provider : string
@@ -122,6 +161,7 @@ let emit_cost_event
     ~(input_tokens : int)
     ~(output_tokens : int)
     ~(cost_usd : float)
+    ?(usage_missing : bool = false)
     ?(telemetry : Oas.Types.inference_telemetry option)
     () : unit =
   let path = Filename.concat masc_root "costs.jsonl" in
@@ -155,6 +195,7 @@ let emit_cost_event
     ("input_tokens", `Int input_tokens);
     ("output_tokens", `Int output_tokens);
     ("cost_usd", `Float cost_usd);
+    ("usage_missing", `Bool usage_missing);
     ("timestamp", `String (Types.now_iso ()));
     ("source", `String "auto_trajectory");
   ] @ telemetry_fields) in
@@ -365,10 +406,11 @@ let make_hooks
       | Oas.Hooks.AfterTurn { turn; response } ->
         let meta = !meta_ref in
         let model = response.model in
-        let input_tok, output_tok, turn_cost_usd = match response.usage with
-          | Some u -> (u.input_tokens, u.output_tokens,
-                       Option.value ~default:0.0 u.cost_usd)
-          | None -> (0, 0, 0.0)
+        let input_tok, output_tok, turn_cost_usd, usage_missing =
+          match response.usage with
+          | Some u ->
+              (u.input_tokens, u.output_tokens, cost_usd_for_usage ~model u, false)
+          | None -> (0, 0, 0.0, true)
         in
         let total_tok = input_tok + output_tok in
         (* Provider prefix cache token tracking (Anthropic).
@@ -443,7 +485,8 @@ let make_hooks
            emit_cost_event ~masc_root:acc.masc_root
              ~agent_name:meta.name ~task_id:acc.task_id
              ~model ~input_tokens:input_tok ~output_tokens:output_tok
-             ~cost_usd:turn_cost_usd ?telemetry:response.telemetry ()
+             ~cost_usd:turn_cost_usd ~usage_missing
+             ?telemetry:response.telemetry ()
          | None -> ());
         let text = Oas.Types.text_of_content response.content in
         let has_state_block =
@@ -628,13 +671,16 @@ let make_hooks
            trace for hook-chain readers; the metric below still records. *)
         Log.Keeper.debug "keeper:%s tool_use_failure: %s — %s"
           meta.name tool_name error;
+        let error_detail_len =
+          String.length (String.trim error) |> Float.of_int
+        in
         Heuristic_metrics.record {
           module_name = "keeper_hooks_oas";
           site = "post_tool_use_failure";
-          raw_value = 1.0;
-          threshold = 0.0;
-          triggered = true;
-          provenance = Pipeline_stage "post_tool_use_failure";
+          raw_value = error_detail_len;
+          threshold = 1.0;
+          triggered = error_detail_len >= 1.0;
+          provenance = Pipeline_stage ("post_tool_use_failure:" ^ tool_name);
           timestamp = Unix.gettimeofday ();
         };
         Oas.Hooks.Continue

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -106,10 +106,6 @@ let work_kind_of_turn_mode = function
   | Noop -> "noop"
   | Text_response | Skip_text -> "text_turn"
 
-let has_substantive_tool_calls (tools_used : string list) : bool =
-  let stay_silent = Tool_name.Keeper.to_string Tool_name.Keeper.Stay_silent in
-  List.exists (fun name -> not (String.equal name stay_silent)) tools_used
-
 (** Observation-only tools that do not constitute productive work.
     A cycle using only these tools (or none) is a "noop" and triggers
     exponential cooldown backoff to prevent token waste. *)
@@ -120,12 +116,19 @@ let observation_only_tool_strings =
   ; Tool_name.Keeper.to_string Tool_name.Keeper.Tool_search
   ]
 
+let is_observation_only_tool_name name =
+  List.mem name observation_only_tool_strings
+
+let has_substantive_tool_calls (tools_used : string list) : bool =
+  List.exists
+    (fun name -> not (is_observation_only_tool_name name))
+    tools_used
+
 (** A cycle is noop when it produced no text AND all tools used (if any)
     are observation-only.  Productive cycles reset consecutive_noop_count. *)
 let is_noop_cycle ~has_text ~(tools_used : string list) : bool =
   not has_text
-  && List.for_all (fun name ->
-       List.mem name observation_only_tool_strings) tools_used
+  && List.for_all is_observation_only_tool_name tools_used
 
 let visible_run_validation (result : Keeper_agent_run.run_result) :
     Oas.Raw_trace.run_validation option =
@@ -732,11 +735,9 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
       ~input_tokens:result.usage.input_tokens
       ~output_tokens:result.usage.output_tokens ()
   in
-  let stay_silent = Tool_name.Keeper.to_string Tool_name.Keeper.Stay_silent in
   let substantive_tool_call_count =
     result.tools_used
-    |> List.filter (fun name ->
-         not (String.equal name stay_silent))
+    |> List.filter (fun name -> not (is_observation_only_tool_name name))
     |> List.length
   in
   let has_substantive_tools = has_substantive_tool_calls result.tools_used in

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -329,6 +329,7 @@ let run
       config.name (Masc_grpc_transport.to_string t));
   Option.iter (fun bus ->
     publish_lifecycle bus ~name:config.name ~event:"build" ~detail:goal
+      ()
   ) config.event_bus;
   let agent_result = match oas_checkpoint with
     | Some checkpoint ->
@@ -346,6 +347,10 @@ let run
     Option.iter (fun bus ->
       publish_lifecycle bus ~name:config.name ~event:"build_error"
         ~detail:(Oas.Error.to_string e)
+        ~error:(Oas.Error.to_string e)
+        ~status:"build_error"
+        ~session_id
+        ()
     ) config.event_bus;
     Error e
   | Ok agent ->
@@ -380,8 +385,17 @@ let run
     in
     Option.iter (fun bus ->
       let status = match result with Ok _ -> "completed" | Error _ -> "failed" in
+      let error =
+        match result with
+        | Ok _ -> None
+        | Error e -> Some (Oas.Error.to_string e)
+      in
       publish_lifecycle bus ~name:config.name ~event:status
         ~detail:(Printf.sprintf "session=%s" session_id)
+        ?error
+        ~session_id
+        ~status
+        ()
     ) config.event_bus;
     let turns = (Oas.Agent.state agent).turn_count in
     let trace_ref = Oas.Agent.last_raw_trace_run agent in

--- a/lib/oas_worker_exec_checkpoint.ml
+++ b/lib/oas_worker_exec_checkpoint.ml
@@ -3,20 +3,27 @@
     Keeps side-effecting run helpers separate from the main build/resume/run
     orchestration in {!Oas_worker_exec}. *)
 
-let publish_lifecycle _bus ~name ~event ~detail =
+let publish_lifecycle _bus ~name ~event ~detail ?error ?session_id ?status () =
   match Masc_event_bus.get () with
   | None -> ()
   | Some mb ->
+      let optional_string_field key = function
+        | Some value when String.trim value <> "" -> [ (key, `String value) ]
+        | _ -> []
+      in
       Oas_bus_instrument.publish mb
         (Oas.Event_bus.mk_event
            (Custom
               ( Printf.sprintf "masc.oas_worker.%s" event,
                 `Assoc
-                  [
-                    ("agent", `String name);
-                    ("detail", `String detail);
-                    ("timestamp", `Float (Time_compat.now ()));
-                  ] )))
+                  ([
+                     ("agent", `String name);
+                     ("detail", `String detail);
+                     ("timestamp", `Float (Time_compat.now ()));
+                   ]
+                   @ optional_string_field "error" error
+                   @ optional_string_field "session_id" session_id
+                   @ optional_string_field "status" status) )))
 
 let persist_checkpoint ~dir ~session_id (ckpt : Oas.Checkpoint.t) =
   let path = Filename.concat dir (session_id ^ ".json") in

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -1269,6 +1269,7 @@ let provider_prefix_of_label_result label =
 let prefix_classification_vocabulary = [
   "glm-coding"; "glm"; "claude"; "claude_code";
   "gemini"; "gemini_cli"; "codex_cli"; "ollama";
+  "openai"; "kimi"; "kimi_cli";
 ]
 
 (** Classify a raw model label to a provider name for telemetry grouping.

--- a/test/test_config_doctor.ml
+++ b/test/test_config_doctor.ml
@@ -163,6 +163,43 @@ let test_initialized_local_base_config () =
   check bool "keeper runtime optional" false report.keeper_runtime_toml_present;
   check (list string) "no warnings" [] report.warnings
 
+let test_persona_tool_preset_conflict_warns () =
+  with_temp_dir "config-doctor-persona-conflict" @@ fun dir ->
+  let base_path = Filename.concat dir "base" in
+  let config_root = Filename.concat base_path ".masc/config" in
+  initialize_config_root config_root;
+  write_file
+    (Filename.concat config_root "keepers/sangsu.toml")
+    {|
+[keeper]
+name = "sangsu"
+persona_name = "sangsu"
+tool_preset = "delivery"
+|};
+  write_file
+    (Filename.concat config_root "personas/sangsu/profile.json")
+    {|{"keeper":{"tool_preset":"coding"}}|};
+  let report =
+    Config_doctor.analyze_with
+      (make_inputs ~cwd:dir ~base_path_input:base_path ())
+  in
+  check string "status warns" "warn" (status report.status);
+  check int "one conflict" 1
+    (List.length report.persona_tool_preset_conflicts);
+  check bool "warning names keeper" true
+    (list_contains_substring
+       ~needle:"Keeper sangsu TOML tool_preset \"delivery\" overrides persona sangsu tool_preset \"coding\""
+       report.warnings);
+  check bool "next action tells operator to remove override" true
+    (list_contains_substring
+       ~needle:"Remove tool_preset from"
+       report.next_actions);
+  let json = Config_doctor.to_yojson report in
+  let conflicts =
+    Yojson.Safe.Util.(json |> member "persona_tool_preset_conflicts" |> to_list)
+  in
+  check int "json conflict count" 1 (List.length conflicts)
+
 let test_shadowed_explicit_config_dir () =
   with_temp_dir "config-doctor-shadowed" @@ fun dir ->
   let base_path = Filename.concat dir "base" in
@@ -325,6 +362,8 @@ let () =
              test_missing_init_without_explicit_config;
            test_case "initialized local base config" `Quick
              test_initialized_local_base_config;
+           test_case "persona/TOML tool_preset conflict warns" `Quick
+             test_persona_tool_preset_conflict_warns;
            test_case "shadowed explicit config dir" `Quick
            test_shadowed_explicit_config_dir;
            test_case "broken cascade catalog surfaces errors" `Quick

--- a/test/test_keeper_hooks_oas_provider.ml
+++ b/test/test_keeper_hooks_oas_provider.ml
@@ -15,6 +15,9 @@ let cases_prefix = [
   "gemini:gemini-2.5-flash",               "gemini";
   "gemini_cli:gemini-2.5-flash",           "gemini_cli";
   "codex_cli:gpt-5.4",                     "codex_cli";
+  "openai:gpt-5.4",                        "openai";
+  "kimi:kimi-k2.5",                        "kimi";
+  "kimi_cli:kimi-for-coding",              "kimi_cli";
   "ollama:qwen3.5:35b-a3b-nvfp4",          "ollama";
 ]
 

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -19,6 +19,16 @@ let read_jsonl_line path =
   Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
       input_line ic |> Yojson.Safe.from_string)
 
+let make_usage ?cost_usd ~input_tokens ~output_tokens ()
+    : Agent_sdk.Types.api_usage =
+  {
+    input_tokens;
+    output_tokens;
+    cache_creation_input_tokens = 0;
+    cache_read_input_tokens = 0;
+    cost_usd;
+  }
+
 let test_emit_cost_event_writes_inference_telemetry () =
   let root = temp_dir () in
   let telemetry : Agent_sdk.Types.inference_telemetry = {
@@ -58,6 +68,37 @@ let test_emit_cost_event_writes_inference_telemetry () =
     (json |> member "hw_decode_tokens_per_second" |> to_float);
   check (float 0.001) "peak_memory_gb" 52.66
     (json |> member "peak_memory_gb" |> to_float)
+
+let test_emit_cost_event_marks_usage_missing () =
+  let root = temp_dir () in
+  Hooks.emit_cost_event ~masc_root:root ~agent_name:"keeper"
+    ~task_id:None ~model:"kimi_cli:kimi-for-coding"
+    ~input_tokens:0 ~output_tokens:0 ~cost_usd:0.0
+    ~usage_missing:true ();
+  let json = read_jsonl_line (Filename.concat root "costs.jsonl") in
+  check bool "usage_missing" true
+    (json |> member "usage_missing" |> to_bool)
+
+let test_cost_usd_for_usage_falls_back_for_paid_provider () =
+  let model = "openai:gpt-4.1" in
+  let usage = make_usage ~input_tokens:1000 ~output_tokens:500 () in
+  let expected = Hooks.estimate_usage_cost_usd ~model usage in
+  check (float 0.000001) "estimated fallback" expected
+    (Hooks.cost_usd_for_usage ~model usage)
+
+let test_cost_usd_for_usage_preserves_reported_cost () =
+  let model = "openai:gpt-4.1" in
+  let usage =
+    make_usage ~cost_usd:0.42 ~input_tokens:1000 ~output_tokens:500 ()
+  in
+  check (float 0.000001) "reported cost" 0.42
+    (Hooks.cost_usd_for_usage ~model usage)
+
+let test_cost_usd_for_usage_keeps_cli_provider_zero () =
+  let model = "kimi_cli:kimi-for-coding" in
+  let usage = make_usage ~input_tokens:1000 ~output_tokens:500 () in
+  check (float 0.000001) "cli cost stays zero" 0.0
+    (Hooks.cost_usd_for_usage ~model usage)
 
 let test_tool_execution_summary_derives_provider_and_outcome () =
   let summary =
@@ -243,7 +284,7 @@ let test_record_llm_tok_s_metrics_zero_value_is_skipped () =
   in
   let labels =
     [ "model", "openai:gpt-5.4"
-    ; "provider", "unknown"
+    ; "provider", "openai"
     ; "provider_kind", "openai_compat"
     ]
   in
@@ -288,7 +329,16 @@ let () =
   run "keeper_hooks_oas/telemetry"
     [ ( "costs_jsonl",
         [ test_case "emit_cost_event keeps throughput and memory fields" `Quick
-            test_emit_cost_event_writes_inference_telemetry ] )
+            test_emit_cost_event_writes_inference_telemetry
+        ; test_case "emit_cost_event marks usage_missing" `Quick
+            test_emit_cost_event_marks_usage_missing
+        ; test_case "cost fallback estimates paid provider usage" `Quick
+            test_cost_usd_for_usage_falls_back_for_paid_provider
+        ; test_case "cost fallback preserves reported cost" `Quick
+            test_cost_usd_for_usage_preserves_reported_cost
+        ; test_case "cost fallback keeps CLI provider zero" `Quick
+            test_cost_usd_for_usage_keeps_cli_provider_zero
+        ] )
     ; ( "tool_telemetry",
         [ test_case "tool execution summary derives provider and outcome" `Quick
             test_tool_execution_summary_derives_provider_and_outcome

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1661,6 +1661,39 @@ let test_metrics_noop_response () =
     updated.runtime.autonomous_action_count;
   check int "total_turns +1" (minimal_meta.runtime.usage.total_turns + 1) updated.runtime.usage.total_turns
 
+let test_metrics_observation_only_tools_are_noop () =
+  let observation_only =
+    [
+      Masc_mcp.Tool_name.Keeper.to_string Masc_mcp.Tool_name.Keeper.Board_list;
+      Masc_mcp.Tool_name.Keeper.to_string
+        Masc_mcp.Tool_name.Keeper.Context_status;
+      Masc_mcp.Tool_name.Keeper.to_string
+        Masc_mcp.Tool_name.Keeper.Tool_search;
+    ]
+  in
+  let result =
+    make_run_result ~text:"" ~tools:observation_only
+      ~model:"test-model" ~input_tok:50 ~output_tok:10 ()
+  in
+  let updated =
+    UM.update_metrics_from_result minimal_meta ~latency_ms:100
+      ~observation:base_observation result
+  in
+  check bool "tools are not substantive" false
+    (UM.has_substantive_tool_calls observation_only);
+  check int "proactive visible_count unchanged"
+    minimal_meta.runtime.proactive_rt.visible_count_total
+    updated.runtime.proactive_rt.visible_count_total;
+  check int "autonomous action unchanged"
+    minimal_meta.runtime.autonomous_action_count
+    updated.runtime.autonomous_action_count;
+  check int "autonomous tool turn unchanged"
+    minimal_meta.runtime.autonomous_tool_turn_count
+    updated.runtime.autonomous_tool_turn_count;
+  check int "noop turn increments"
+    (minimal_meta.runtime.noop_turn_count + 1)
+    updated.runtime.noop_turn_count
+
 let sample_run_ref : Agent_sdk.Raw_trace.run_ref = {
   worker_run_id = "test-run"; path = "/tmp/test.jsonl";
   start_seq = 0; end_seq = 5; agent_name = "test"; session_id = None;
@@ -4725,6 +4758,8 @@ let () =
             test_metrics_surface_model_prefers_successful_cascade_label;
           test_case "tool response" `Quick test_metrics_tool_response;
           test_case "noop response" `Quick test_metrics_noop_response;
+          test_case "observation-only tools are noop" `Quick
+            test_metrics_observation_only_tools_are_noop;
           test_case "validated evidence counts as visible" `Quick
             test_metrics_validated_evidence_counts_as_visible;
           test_case "failed validation does not count as visible" `Quick

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -94,6 +94,35 @@ let test_event_bus_heartbeat () =
     Alcotest.(check int) "turn" 5 turn
   | _ -> Alcotest.fail "expected Custom masc.heartbeat event"
 
+let test_oas_worker_failed_lifecycle_includes_error () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let bus = Event_bus.create () in
+  Masc_event_bus.set bus;
+  let sub = Event_bus.subscribe bus in
+  Oas_worker_exec.publish_lifecycle bus
+    ~name:"worker-a"
+    ~event:"failed"
+    ~detail:"session=session-1"
+    ~error:"tool call rejected"
+    ~session_id:"session-1"
+    ~status:"failed"
+    ();
+  let events = Event_bus.drain sub in
+  Alcotest.(check int) "one event" 1 (List.length events);
+  match (List.hd events : Event_bus.event).payload with
+  | Event_bus.Custom ("masc.oas_worker.failed", payload) ->
+      let open Yojson.Safe.Util in
+      Alcotest.(check string) "agent" "worker-a"
+        (payload |> member "agent" |> to_string);
+      Alcotest.(check string) "error" "tool call rejected"
+        (payload |> member "error" |> to_string);
+      Alcotest.(check string) "session_id" "session-1"
+        (payload |> member "session_id" |> to_string);
+      Alcotest.(check string) "status" "failed"
+        (payload |> member "status" |> to_string)
+  | _ -> Alcotest.fail "expected Custom masc.oas_worker.failed event"
+
 let test_event_bus_task_transition () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -752,6 +781,8 @@ let () =
     "oas_events", [
       Alcotest.test_case "broadcast event" `Quick test_event_bus_broadcast;
       Alcotest.test_case "heartbeat event" `Quick test_event_bus_heartbeat;
+      Alcotest.test_case "oas worker failed lifecycle includes error" `Quick
+        test_oas_worker_failed_lifecycle_includes_error;
       Alcotest.test_case "task transition event" `Quick
         test_event_bus_task_transition;
       Alcotest.test_case "keeper lifecycle includes phase" `Quick

--- a/test/test_post_verifier.ml
+++ b/test/test_post_verifier.ml
@@ -3,6 +3,7 @@
     All tests are pure (no Eio needed) since Post_verifier has no IO. *)
 
 module Pv = Masc_mcp.Post_verifier
+module Hm = Masc_mcp.Heuristic_metrics
 
 open Alcotest
 
@@ -152,6 +153,55 @@ let test_to_dimension_results () =
   check bool "has quality" true (List.mem "quality" dim_names);
   check bool "has safety" true (List.mem "safety" dim_names)
 
+let test_heuristic_coverage_report_groups_sites () =
+  let events =
+    [
+      Hm.event_to_json
+        {
+          module_name = "post_verifier";
+          site = "relevance";
+          raw_value = 0.7;
+          threshold = 0.5;
+          triggered = true;
+          provenance = Hm.Post_verifier "relevance";
+          timestamp = 1.0;
+        };
+      Hm.event_to_json
+        {
+          module_name = "post_verifier";
+          site = "relevance";
+          raw_value = 0.2;
+          threshold = 0.5;
+          triggered = false;
+          provenance = Hm.Post_verifier "relevance";
+          timestamp = 2.0;
+        };
+      Hm.event_to_json
+        {
+          module_name = "keeper_alerting";
+          site = "keeper_alert_signal";
+          raw_value = 0.6;
+          threshold = 0.4;
+          triggered = true;
+          provenance = Hm.Alert_scoring "keyword";
+          timestamp = 3.0;
+        };
+    ]
+  in
+  let report = Hm.coverage_report_of_events events in
+  check int "total events" 3 report.total_events;
+  check int "two sites" 2 (List.length report.sites);
+  check int "three distinct tuples" 3 report.unique_decision_tuples;
+  let post_verifier_site =
+    List.find
+      (fun (site : Hm.coverage_site) ->
+         site.module_name = "post_verifier"
+         && site.site = "relevance")
+      report.sites
+  in
+  check int "site count" 2 post_verifier_site.count;
+  check int "site triggered count" 1 post_verifier_site.triggered_count
+
 (* ================================================================ *)
 (* Runner                                                           *)
 (* ================================================================ *)
@@ -189,5 +239,9 @@ let () =
       test_case "dimension_to_string" `Quick test_dimension_to_string;
       test_case "result_to_json" `Quick test_result_to_json;
       test_case "to_dimension_results" `Quick test_to_dimension_results;
+    ];
+    "heuristic_metrics", [
+      test_case "coverage report groups sites" `Quick
+        test_heuristic_coverage_report_groups_sites;
     ];
   ]


### PR DESCRIPTION
## Summary

This PR fixes the runtime-truth regression bundle across config doctor, OAS worker lifecycle, heuristic telemetry, keeper metrics, alert thresholds, and costs attribution.

- Detect persona profile vs keeper TOML `tool_preset` conflicts in `doctor config`, expose structured JSON, and warn with actionable remediation.
- Preserve OAS worker failure context in lifecycle events via `error`, `session_id`, and `status` fields.
- Add heuristic coverage reporting so theatre-style metrics can be audited by module/site/decision tuple.
- Calibrate keeper alert metrics to the actual emit threshold and lower the goal-alignment floor.
- Treat observation-only tools as noop for keeper unified metrics.
- Classify `openai`, `kimi`, and `kimi_cli` provider prefixes, mark missing usage in `costs.jsonl`, and estimate paid-provider cost when token usage exists but reported cost is zero/missing while keeping CLI providers structurally unmetered.

Fixes #9735
Fixes #9850
Fixes #7718
Fixes #9855
Fixes #9857
Fixes #9858
Fixes #9859
Fixes #9868

## Validation

- `dune build --root . --build-dir _build_runtime_truth`
- `./_build_runtime_truth/default/test/test_config_doctor.exe`
- `./_build_runtime_truth/default/test/test_oas_integration.exe`
- `./_build_runtime_truth/default/test/test_post_verifier.exe`
- `./_build_runtime_truth/default/test/test_keeper_hooks_oas_provider.exe`
- `./_build_runtime_truth/default/test/test_keeper_hooks_oas_telemetry.exe`
- `./_build_runtime_truth/default/test/test_keeper_unified.exe test metrics_observation 5`
- `./_build_runtime_truth/default/test/test_oas_worker.exe`

## Live Runtime Config

Also repaired the active local config under `/Users/dancer/me/.masc/config/keepers` by backing up and removing stale `tool_preset = "delivery"` / `tool_also_allow = []` overrides from `sangsu.toml` and `taskmaster.toml`. A live `doctor config --base-path=/Users/dancer/me --json` check now reports `persona_tool_preset_conflicts: []`; it still exits warn because Docker sandbox preflight cannot access the local Docker socket in this shell.