### PR TITLE
[codex] Preserve local cascades for keeper tool turns

### DIFF
--- a/lib/keeper/keeper_cascade_routing.ml
+++ b/lib/keeper/keeper_cascade_routing.ml
@@ -32,7 +32,8 @@ let select_cascade ~(base_cascade : string) ~(phase : Keeper_state_machine.phase
       { effective_cascade = base_cascade;
         reason = "non-turn phase (blocked upstream)" }
 
-let route_effective_cascade_for_tool_requirement
+let route_effective_cascade_for_tool_requirement_with_model_labels
+    ~(model_labels_of_cascade : string -> string list)
     ~(effective_cascade : string)
     ~(tool_requirement : string) : routing_decision =
   let trimmed_effective = String.trim effective_cascade in
@@ -44,17 +45,28 @@ let route_effective_cascade_for_tool_requirement
       effective_cascade;
       reason = "tool-optional or text-only turn keeps routed cascade";
     }
-  else if
-    String.equal trimmed_effective Keeper_config.tool_use_strict_cascade_name
-    || String.equal normalized_effective Keeper_config.local_only_cascade_name
-    || String.equal normalized_effective Keeper_config.local_recovery_cascade_name
-  then
-    {
-      effective_cascade;
-      reason = "tool-required turn preserves phase-routed system cascade";
-    }
-  else
-    {
-      effective_cascade = Keeper_config.tool_use_strict_cascade_name;
-      reason = "tool-required turn uses strict tool-capable cascade";
-    }
+  else (
+    let effective_is_pure_local =
+      trimmed_effective <> ""
+      && model_labels_of_cascade trimmed_effective
+         |> Cascade_runtime.labels_are_pure_local
+    in
+    if
+      String.equal trimmed_effective Keeper_config.tool_use_strict_cascade_name
+      || String.equal normalized_effective Keeper_config.local_only_cascade_name
+      || String.equal normalized_effective Keeper_config.local_recovery_cascade_name
+      || effective_is_pure_local
+    then
+      {
+        effective_cascade;
+        reason = "tool-required turn preserves local or phase-routed cascade";
+      }
+    else
+      {
+        effective_cascade = Keeper_config.tool_use_strict_cascade_name;
+        reason = "tool-required turn uses strict tool-capable cascade";
+      })
+
+let route_effective_cascade_for_tool_requirement =
+  route_effective_cascade_for_tool_requirement_with_model_labels
+    ~model_labels_of_cascade:Cascade_runtime.models_of_cascade_name

--- a/lib/keeper/keeper_cascade_routing.mli
+++ b/lib/keeper/keeper_cascade_routing.mli
@@ -35,8 +35,17 @@ val select_cascade :
 
 (** Override an already-routed cascade when the turn must guarantee a
     tool-capable provider lane. Phase-routed local/recovery cascades are
-    preserved. *)
+    preserved. Pure-local configured cascades are also preserved, regardless
+    of their profile name. *)
 val route_effective_cascade_for_tool_requirement :
+  effective_cascade:string ->
+  tool_requirement:string ->
+  routing_decision
+
+(** Same as {!route_effective_cascade_for_tool_requirement}, with model-label
+    resolution injected for deterministic tests. *)
+val route_effective_cascade_for_tool_requirement_with_model_labels :
+  model_labels_of_cascade:(string -> string list) ->
   effective_cascade:string ->
   tool_requirement:string ->
   routing_decision

--- a/test/test_keeper_cascade_routing.ml
+++ b/test/test_keeper_cascade_routing.ml
@@ -89,11 +89,23 @@ let test_running_with_custom_base () =
 
 let test_tool_required_turn_uses_strict_lane () =
   let r =
-    Routing.route_effective_cascade_for_tool_requirement
+    Routing.route_effective_cascade_for_tool_requirement_with_model_labels
+      ~model_labels_of_cascade:(fun _ -> [ "claude_code:auto" ])
       ~effective_cascade:"big_three" ~tool_requirement:"required"
   in
   check string "required tool turns route to strict lane"
     Masc_mcp.Keeper_config.tool_use_strict_cascade_name r.effective_cascade
+
+let test_tool_required_turn_preserves_pure_local_cascade () =
+  let r =
+    Routing.route_effective_cascade_for_tool_requirement_with_model_labels
+      ~model_labels_of_cascade:(function
+        | "ollama_only" -> [ "ollama:auto" ]
+        | _ -> [])
+      ~effective_cascade:"ollama_only" ~tool_requirement:"required"
+  in
+  check string "required tool turns preserve pure-local cascade"
+    "ollama_only" r.effective_cascade
 
 let test_tool_required_turn_preserves_local_recovery () =
   let r =
@@ -136,6 +148,8 @@ let () =
       test_case "Running preserves custom base"     `Quick test_running_with_custom_base;
       test_case "Required tool turn uses strict lane" `Quick
         test_tool_required_turn_uses_strict_lane;
+      test_case "Required tool turn preserves pure-local cascade" `Quick
+        test_tool_required_turn_preserves_pure_local_cascade;
       test_case "Required tool turn preserves local recovery" `Quick
         test_tool_required_turn_preserves_local_recovery;
       test_case "All phases have reason"            `Quick test_all_phases_have_reason;


### PR DESCRIPTION
## Summary
- preserve pure-local configured keeper cascades during tool-required routing
- keep non-local tool-required turns on the strict tool-capable lane
- add a regression test for ollama_only using ollama:auto

## Root Cause
Live keepers configured with pure-local cascades such as ollama_only were being rerouted to tool_use_strict whenever the turn required tools. That pushed local keepers into the Kimi/CLI strict lane before they could claim or execute work.

## Validation
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-ollama-only-tool-required test/test_keeper_cascade_routing.exe
- _build/default/test/test_keeper_cascade_routing.exe
- git diff --check