### PR TITLE
[codex] surface keeper transition operator signals

### DIFF
--- a/dashboard/src/api/schemas/keeper-transitions.test.ts
+++ b/dashboard/src/api/schemas/keeper-transitions.test.ts
@@ -10,6 +10,7 @@ function validTransition(overrides: Record<string, unknown> = {}): Record<string
     prev_phase: 'Running',
     new_phase: 'Compacting',
     selected_event: null,
+    event_type: 'operator_pause',
     wall_clock_at_decision: 1_712_000_000.5,
     transition_outcome: 'ok',
     ...overrides,
@@ -44,6 +45,33 @@ describe('parseKeeperTransitionsResponse', () => {
     })
     expect(out.transitions).toHaveLength(2)
     expect(out.transitions[1]!.new_phase).toBe('Running')
+  })
+
+  it('keeps operator signal fields for dashboard urgency cues', () => {
+    const out = parseKeeperTransitionsResponse({
+      keeper: 'greeter',
+      current_phase: 'Paused',
+      count: 1,
+      transitions: [
+        validTransition({
+          new_phase: 'Paused',
+          operator_signal: {
+            class: 'operator_gate',
+            severity: 'warn',
+            requires_operator_decision: true,
+            next_human_action: 'resume_or_update_policy',
+            summary: 'keeper paused; operator decision is required',
+          },
+        }),
+      ],
+    })
+    expect(out.transitions[0]!.event_type).toBe('operator_pause')
+    expect(out.transitions[0]!.operator_signal).toMatchObject({
+      class: 'operator_gate',
+      severity: 'warn',
+      requires_operator_decision: true,
+      next_human_action: 'resume_or_update_policy',
+    })
   })
 
   it('accepts null current_phase', () => {

--- a/dashboard/src/api/schemas/keeper-transitions.ts
+++ b/dashboard/src/api/schemas/keeper-transitions.ts
@@ -7,9 +7,11 @@
 
 import {
   array,
+  boolean,
   nullable,
   number,
   object,
+  optional,
   safeParse,
   string,
   unknown,
@@ -17,12 +19,22 @@ import {
   type InferOutput,
 } from 'valibot'
 
+const KeeperTransitionOperatorSignalSchema = object({
+  class: string(),
+  severity: string(),
+  requires_operator_decision: boolean(),
+  next_human_action: nullable(string()),
+  summary: string(),
+})
+
 const KeeperTransitionSchema = object({
   prev_phase: string(),
   new_phase: string(),
   selected_event: unknown(),
+  event_type: optional(string()),
   wall_clock_at_decision: number(),
   transition_outcome: string(),
+  operator_signal: optional(KeeperTransitionOperatorSignalSchema),
 })
 
 const KeeperTransitionsResponseSchema = object({
@@ -33,6 +45,9 @@ const KeeperTransitionsResponseSchema = object({
 })
 
 export type KeeperTransition = InferOutput<typeof KeeperTransitionSchema>
+export type KeeperTransitionOperatorSignal = InferOutput<
+  typeof KeeperTransitionOperatorSignalSchema
+>
 export type KeeperTransitionsResponse = InferOutput<typeof KeeperTransitionsResponseSchema>
 
 export class KeeperTransitionsSchemaDriftError extends Error {

--- a/dashboard/src/components/keeper-phase-strip.ts
+++ b/dashboard/src/components/keeper-phase-strip.ts
@@ -28,6 +28,13 @@ function phaseInlineStyle(phase: string): string {
   return `color: ${style.color}; background: ${style.bg}; border: 1px solid ${style.border};`
 }
 
+function signalColor(t: KeeperTransition): string {
+  const severity = t.operator_signal?.severity
+  if (severity === 'bad') return 'var(--bad)'
+  if (severity === 'warn') return 'var(--warn)'
+  return phaseColor(t.new_phase)
+}
+
 /** selected_event comes as object {type: "...", ...} from the server */
 export function eventLabel(event: unknown): string {
   if (typeof event === 'string') return event
@@ -58,7 +65,8 @@ async function loadAll() {
 }
 
 function TransitionDot({ t, idx }: { t: KeeperTransition; idx: number }) {
-  const color = phaseColor(t.new_phase)
+  const color = signalColor(t)
+  const signal = t.operator_signal
   return html`
     <div class="group relative flex flex-col items-center" key=${idx}>
       <div
@@ -68,7 +76,15 @@ function TransitionDot({ t, idx }: { t: KeeperTransition; idx: number }) {
       <div class="absolute bottom-full mb-2 hidden group-hover:flex flex-col items-center z-10">
         <div class="rounded border border-[var(--card-border)] bg-[var(--card)] px-3 py-2 shadow-sm text-2xs whitespace-nowrap">
           <div class="font-semibold">${t.prev_phase} → ${t.new_phase}</div>
-          <div class="text-[var(--text-muted)] mt-0.5">${eventLabel(t.selected_event)}</div>
+          <div class="text-[var(--text-muted)] mt-0.5">${t.event_type ?? eventLabel(t.selected_event)}</div>
+          ${signal ? html`
+            <div class="mt-1 text-[var(--text-body)]">${signal.summary}</div>
+            ${signal.requires_operator_decision ? html`
+              <div class="mt-1 font-semibold text-[var(--warn)]">
+                decision required${signal.next_human_action ? ` · ${signal.next_human_action}` : ''}
+              </div>
+            ` : null}
+          ` : null}
           <div class="text-[var(--text-muted)]"><${TimeAgo} timestamp=${t.wall_clock_at_decision * 1000} /></div>
         </div>
       </div>

--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -67,6 +67,17 @@ function transitionType(selectedEvent: unknown): string {
   return 'event'
 }
 
+function signalTone(severity: string | null | undefined): string {
+  switch (severity) {
+    case 'bad':
+      return 'border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--bad)]'
+    case 'warn':
+      return 'border-[var(--warn-24)] bg-[var(--warn-8)] text-[var(--warn)]'
+    default:
+      return 'border-[rgba(34,197,94,0.24)] bg-[var(--emerald-8)] text-[var(--ok)]'
+  }
+}
+
 function badgeTone(ok: boolean): string {
   return ok
     ? 'border-[rgba(34,197,94,0.24)] bg-[var(--emerald-8)] text-[var(--ok)]'
@@ -208,9 +219,22 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
                 <span class="text-[var(--text-dim)]">→</span>
                 <span class="font-mono text-[var(--accent)]">${normalizePhase(transition.new_phase) ?? transition.new_phase}</span>
                 <span class="rounded-sm border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5 text-3xs text-[var(--text-muted)]">
-                  ${transitionType(transition.selected_event)}
+                  ${transition.event_type ?? transitionType(transition.selected_event)}
                 </span>
+                ${transition.operator_signal ? html`
+                  <span class=${`rounded-sm border px-2 py-0.5 text-3xs ${signalTone(transition.operator_signal.severity)}`}>
+                    ${transition.operator_signal.requires_operator_decision ? 'decision required' : transition.operator_signal.class}
+                  </span>
+                ` : null}
               </div>
+              ${transition.operator_signal ? html`
+                <div class="mt-1 text-[var(--text-muted)]">
+                  ${transition.operator_signal.summary}
+                  ${transition.operator_signal.next_human_action
+                    ? html`<span class="text-[var(--warn)]"> · ${transition.operator_signal.next_human_action}</span>`
+                    : null}
+                </div>
+              ` : null}
             </div>
           `)}
         </div>

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -250,6 +250,19 @@ let transition_timeline_event json =
   match json_float_opt_member "wall_clock_at_decision" json with
   | None -> None
   | Some ts_unix ->
+      let operator_signal =
+        match json |> Yojson.Safe.Util.member "operator_signal" with
+        | `Assoc fields -> Some fields
+        | _ -> None
+      in
+      let signal_string key =
+        Option.bind operator_signal (assoc_string_opt key)
+      in
+      let signal_bool key =
+        Option.map
+          (fun fields -> assoc_bool_default key ~default:false fields)
+          operator_signal
+      in
       let prev_phase =
         json |> Yojson.Safe.Util.member "prev_phase"
         |> json_string_opt_value
@@ -262,18 +275,36 @@ let transition_timeline_event json =
         json |> Yojson.Safe.Util.member "selected_event"
       in
       let event_type =
-        json_string_opt_member "type" selected_event
+        (match json_string_opt_member "event_type" json with
+         | Some _ as value -> value
+         | None -> json_string_opt_member "type" selected_event)
         |> Option.value ~default:"transition"
       in
       let prev_phase = Option.value ~default:"unknown" prev_phase in
       let new_phase = Option.value ~default:"unknown" new_phase in
+      let signal_summary = signal_string "summary" in
+      let next_human_action =
+        match signal_bool "requires_operator_decision" with
+        | Some true -> signal_string "next_human_action"
+        | _ -> None
+      in
+      let summary =
+        match signal_summary with
+        | Some signal when String.trim signal <> "" ->
+            Printf.sprintf "%s -> %s via %s · %s"
+              prev_phase new_phase event_type signal
+        | _ ->
+            Printf.sprintf "%s -> %s via %s"
+              prev_phase new_phase event_type
+      in
+      let severity =
+        signal_string "severity"
+        |> Option.value ~default:(severity_of_transition_type event_type)
+      in
       Some
-        (timeline_event_json ~ts_unix ~kind:"transition"
+        (timeline_event_json ?next_human_action ~ts_unix ~kind:"transition"
            ~title:(Printf.sprintf "Transition · %s" event_type)
-           ~summary:
-             (Printf.sprintf "%s -> %s via %s"
-                prev_phase new_phase event_type)
-           ~severity:(severity_of_transition_type event_type) ())
+           ~summary ~severity ())
 
 let receipt_timeline_event receipt =
   match json_string_opt_member "ended_at" receipt with

--- a/lib/keeper/keeper_transition_audit.ml
+++ b/lib/keeper/keeper_transition_audit.ml
@@ -10,7 +10,134 @@ type transition_record = {
   wall_clock_at_decision : float;
 }
 
+type operator_signal = {
+  signal_class : string;
+  severity : string;
+  requires_operator_decision : bool;
+  next_human_action : string option;
+  summary : string;
+}
+
+let event_type_of_event event =
+  match Keeper_state_machine.event_to_json event with
+  | `Assoc fields -> (
+      match List.assoc_opt "type" fields with
+      | Some (`String value) -> value
+      | _ -> Keeper_state_machine.event_to_string event)
+  | _ -> Keeper_state_machine.event_to_string event
+
+let operator_signal ?next_human_action ~signal_class ~severity
+    ~requires_operator_decision summary =
+  {
+    signal_class;
+    severity;
+    requires_operator_decision;
+    next_human_action;
+    summary;
+  }
+
+let operator_signal_to_json signal =
+  `Assoc
+    [
+      ("class", `String signal.signal_class);
+      ("severity", `String signal.severity);
+      ("requires_operator_decision", `Bool signal.requires_operator_decision);
+      ("next_human_action", Json_util.string_opt_to_json signal.next_human_action);
+      ("summary", `String signal.summary);
+    ]
+
+let operator_signal_of_transition (r : transition_record) =
+  let open Keeper_state_machine in
+  let phase_name = Keeper_state_machine.phase_to_string in
+  match r.selected_event with
+  | Operator_pause ->
+      operator_signal ~signal_class:"operator_gate" ~severity:"warn"
+        ~requires_operator_decision:true
+        ~next_human_action:"resume_or_update_policy"
+        "keeper paused; operator decision is required"
+  | Operator_resume ->
+      operator_signal ~signal_class:"operator_gate" ~severity:"ok"
+        ~requires_operator_decision:false "keeper resumed by operator"
+  | Operator_stop _ | Stop_requested ->
+      operator_signal ~signal_class:"operator_stop" ~severity:"warn"
+        ~requires_operator_decision:false "keeper stop requested"
+  | Restart_budget_exhausted ->
+      operator_signal ~signal_class:"runtime_alert" ~severity:"bad"
+        ~requires_operator_decision:true
+        ~next_human_action:"inspect_or_restart_keeper"
+        "restart budget exhausted; operator must choose recovery"
+  | Guardrail_stop { reason } ->
+      operator_signal ~signal_class:"runtime_alert" ~severity:"bad"
+        ~requires_operator_decision:true
+        ~next_human_action:"inspect_guardrail_and_resume"
+        (Printf.sprintf "guardrail stopped keeper: %s" reason)
+  | Compact_retry_exhausted ->
+      operator_signal ~signal_class:"context_management" ~severity:"bad"
+        ~requires_operator_decision:true
+        ~next_human_action:"approve_handoff_or_reduce_context"
+        "auto-compact retry budget exhausted"
+  | Compaction_failed { reason } ->
+      operator_signal ~signal_class:"context_management" ~severity:"bad"
+        ~requires_operator_decision:true
+        ~next_human_action:"retry_compaction_or_handoff"
+        (Printf.sprintf "compaction failed: %s" reason)
+  | Handoff_failed { reason } ->
+      operator_signal ~signal_class:"handoff" ~severity:"bad"
+        ~requires_operator_decision:true
+        ~next_human_action:"retry_handoff_or_resume"
+        (Printf.sprintf "handoff failed: %s" reason)
+  | Context_overflow_detected _ ->
+      operator_signal ~signal_class:"context_management" ~severity:"warn"
+        ~requires_operator_decision:false
+        "context overflow detected; recovery path should continue"
+  | _ -> (
+      match r.new_phase with
+      | Paused ->
+          operator_signal ~signal_class:"operator_gate" ~severity:"warn"
+            ~requires_operator_decision:true
+            ~next_human_action:"resume_or_update_policy"
+            (Printf.sprintf "%s -> paused; operator decision is required"
+               (phase_name r.prev_phase))
+      | Crashed ->
+          operator_signal ~signal_class:"runtime_alert" ~severity:"bad"
+            ~requires_operator_decision:true
+            ~next_human_action:"inspect_or_restart_keeper"
+            "keeper crashed; operator must inspect recovery"
+      | Dead ->
+          operator_signal ~signal_class:"runtime_alert" ~severity:"bad"
+            ~requires_operator_decision:true
+            ~next_human_action:"inspect_or_recreate_keeper"
+            "keeper reached dead phase"
+      | Failing ->
+          operator_signal ~signal_class:"runtime_recovery" ~severity:"warn"
+            ~requires_operator_decision:false
+            "keeper entered failing recovery lane"
+      | Overflowed ->
+          operator_signal ~signal_class:"context_management" ~severity:"warn"
+            ~requires_operator_decision:false
+            "keeper overflowed context and should compact or hand off"
+      | Compacting ->
+          operator_signal ~signal_class:"context_management" ~severity:"warn"
+            ~requires_operator_decision:false "keeper is compacting context"
+      | HandingOff ->
+          operator_signal ~signal_class:"handoff" ~severity:"warn"
+            ~requires_operator_decision:false "keeper handoff is in progress"
+      | Draining ->
+          operator_signal ~signal_class:"operator_stop" ~severity:"warn"
+            ~requires_operator_decision:false "keeper is draining toward stop"
+      | Restarting ->
+          operator_signal ~signal_class:"runtime_recovery" ~severity:"warn"
+            ~requires_operator_decision:false "keeper restart is scheduled"
+      | Running when r.prev_phase <> Running ->
+          operator_signal ~signal_class:"healthy" ~severity:"ok"
+            ~requires_operator_decision:false "keeper recovered to running"
+      | Offline | Running | Stopped ->
+          operator_signal ~signal_class:"healthy" ~severity:"ok"
+            ~requires_operator_decision:false "phase transition observed")
+
 let to_json (r : transition_record) : Yojson.Safe.t =
+  let event_type = event_type_of_event r.selected_event in
+  let operator_signal = operator_signal_of_transition r in
   `Assoc [
     "snapshot", (match r.snapshot with
       | Some s -> Keeper_measurement.measurement_snapshot_to_json s
@@ -18,9 +145,11 @@ let to_json (r : transition_record) : Yojson.Safe.t =
     "events_fired",
       `List (List.map Keeper_state_machine.event_to_json r.events_fired);
     "selected_event", Keeper_state_machine.event_to_json r.selected_event;
+    "event_type", `String event_type;
     "prev_phase", Keeper_state_machine.phase_to_json r.prev_phase;
     "new_phase", Keeper_state_machine.phase_to_json r.new_phase;
     "transition_outcome", `String r.transition_outcome;
+    "operator_signal", operator_signal_to_json operator_signal;
     "wall_clock_at_decision", `Float r.wall_clock_at_decision;
   ]
 

--- a/test/test_keeper_transition_audit.ml
+++ b/test/test_keeper_transition_audit.ml
@@ -4,8 +4,63 @@
 open Alcotest
 
 module Audit = Masc_mcp.Keeper_transition_audit
+module KSM = Masc_mcp.Keeper_state_machine
 
 let fail = Alcotest.fail
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_keeper_transition_audit_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else
+        Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let with_env key value f =
+  let old_value = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match old_value with
+      | Some old -> Unix.putenv key old
+      | None -> Unix.putenv key "")
+    f
+
+let keeper_meta name =
+  match
+    Masc_mcp.Keeper_types.meta_of_json
+      (`Assoc
+        [
+          ("name", `String name);
+          ("agent_name", `String (name ^ "-agent"));
+          ("trace_id", `String ("trace-" ^ name));
+          ("goal", `String "transition-audit-test");
+          ("cascade_name", `String Masc_mcp.Keeper_config.default_cascade_name);
+        ])
+  with
+  | Ok meta -> meta
+  | Error err -> fail ("meta_of_json failed: " ^ err)
+
+let transition ?(prev_phase = KSM.Running) ?(new_phase = KSM.Paused)
+    ?(selected_event = KSM.Operator_pause) () : Audit.transition_record =
+  {
+    Audit.snapshot = None;
+    events_fired = [ selected_event ];
+    selected_event;
+    prev_phase;
+    new_phase;
+    transition_outcome = "applied";
+    wall_clock_at_decision = 1_712_000_000.5;
+  }
 
 (* ── Helpers to exercise the JSON round-trip via store ─────────── *)
 
@@ -80,6 +135,63 @@ let test_limit_respected () =
   check int "limit respected" 3 (List.length turns);
   check int "newest within limit" 10 (List.hd turns).Audit.turn_id
 
+let test_operator_pause_signal_requires_decision () =
+  let json = Audit.to_json (transition ()) in
+  let open Yojson.Safe.Util in
+  check string "event type" "operator_pause"
+    (json |> member "event_type" |> to_string);
+  let signal = json |> member "operator_signal" in
+  check string "class" "operator_gate" (signal |> member "class" |> to_string);
+  check string "severity" "warn" (signal |> member "severity" |> to_string);
+  check bool "requires decision" true
+    (signal |> member "requires_operator_decision" |> to_bool);
+  check string "next action" "resume_or_update_policy"
+    (signal |> member "next_human_action" |> to_string)
+
+let test_compact_retry_exhausted_signal_is_alerting () =
+  let json =
+    Audit.to_json
+      (transition ~new_phase:KSM.Paused
+         ~selected_event:KSM.Compact_retry_exhausted ())
+  in
+  let open Yojson.Safe.Util in
+  let signal = json |> member "operator_signal" in
+  check string "event type" "compact_retry_exhausted"
+    (json |> member "event_type" |> to_string);
+  check string "class" "context_management"
+    (signal |> member "class" |> to_string);
+  check string "severity" "bad" (signal |> member "severity" |> to_string);
+  check bool "requires decision" true
+    (signal |> member "requires_operator_decision" |> to_bool);
+  check string "next action" "approve_handoff_or_reduce_context"
+    (signal |> member "next_human_action" |> to_string)
+
+let test_runtime_trust_timeline_carries_transition_operator_signal () =
+  Audit.For_testing.reset_state ();
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Audit.For_testing.reset_state ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let sink = Filename.concat base_dir "transition-audit.jsonl" in
+      with_env "MASC_KEEPER_TRANSITION_LOG" sink (fun () ->
+          let keeper_name = "runtime-trust-transition-signal" in
+          let config = Masc_mcp.Coord.default_config base_dir in
+          let meta = keeper_meta keeper_name in
+          Audit.record_transition ~keeper_name (transition ());
+          let snapshot =
+            Masc_mcp.Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta
+          in
+          let open Yojson.Safe.Util in
+          let event = snapshot |> member "latest_causal_event" in
+          check string "latest event kind" "transition"
+            (event |> member "kind" |> to_string);
+          check string "transition next action" "resume_or_update_policy"
+            (event |> member "next_human_action" |> to_string);
+          check string "transition severity" "warn"
+            (event |> member "severity" |> to_string)))
+
 (* ── Run ───────────────────────────────────────────────────────── *)
 
 let () =
@@ -92,5 +204,14 @@ let () =
           test_case "ring capacity limit" `Quick test_ring_capacity_limit;
           test_case "ring ordering newest first" `Quick test_ring_ordering_is_newest_first;
           test_case "limit respected" `Quick test_limit_respected;
+        ] );
+      ( "transition_operator_signal",
+        [
+          test_case "operator pause requires decision" `Quick
+            test_operator_pause_signal_requires_decision;
+          test_case "compact retry exhausted is alerting" `Quick
+            test_compact_retry_exhausted_signal_is_alerting;
+          test_case "runtime trust timeline carries signal" `Quick
+            test_runtime_trust_timeline_carries_transition_operator_signal;
         ] );
     ]


### PR DESCRIPTION
## Summary

- add structured `operator_signal` metadata to keeper FSM transition audit records
- thread transition urgency and next-human-action hints into runtime-trust causal timelines
- render transition urgency cues in the keeper phase strip and composite lifecycle panel

## Why

Raw phase transitions were recorded, but the operator still had to infer whether a transition needed action. This makes pause, retry-exhausted, guardrail, crash, handoff, and compaction failure transitions carry explicit severity and decision-required state while preserving the raw FSM event.

## Validation

- `dune build --root .`
- `./_build/default/test/test_keeper_transition_audit.exe`
- `./_build/default/test/test_dashboard_goals.exe`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec vitest run src/api/schemas/keeper-transitions.test.ts --no-file-parallelism --maxWorkers=1`
- `git diff --check`
