### PR TITLE
feat(gh): RFC-0007 PR-2 — structured gh_exit_class + gh_result (#9786, #9850)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -594,6 +594,7 @@
   ;; godsplit-safety: variant unification & godfile decomposition
   gate_diff_types
   gh_command_validation
+  gh_exit_class
 )
 (private_modules
  dashboard_http_keeper_metrics

--- a/lib/gh_exit_class.ml
+++ b/lib/gh_exit_class.ml
@@ -1,0 +1,141 @@
+type t =
+  | Ok_0
+  | Policy_blocked
+  | Type_mismatch
+  | Auth_failed
+  | Network
+  | Unknown
+
+let to_string = function
+  | Ok_0 -> "Ok_0"
+  | Policy_blocked -> "Policy_blocked"
+  | Type_mismatch -> "Type_mismatch"
+  | Auth_failed -> "Auth_failed"
+  | Network -> "Network"
+  | Unknown -> "Unknown"
+
+type rule = {
+  exit_code : int;
+  stderr_contains : string option;
+  class_ : t;
+}
+
+let contains_ci ~haystack ~needle =
+  let h = String.lowercase_ascii haystack in
+  let n = String.lowercase_ascii needle in
+  let hl = String.length h in
+  let nl = String.length n in
+  if nl = 0 then true
+  else if nl > hl then false
+  else
+    let rec scan i =
+      if i + nl > hl then false
+      else if String.sub h i nl = n then true
+      else scan (i + 1)
+    in
+    scan 0
+
+(* Default rule table. Ordered: most-specific first.
+
+   Sources:
+   - [gh] man page exit conventions (0 ok, 1 error, 2 argparse, 4 auth).
+     `gh help` / `gh auth status` empirical; `gh-cli` is not contractually
+     stable so [Unknown] is the fail-safe.
+   - masc-mcp internal: `Keeper_exec_shell` reserves exit codes 200..201
+     for R1/R2 destructive-mutation blocks. See `gh_command_validation`
+     [classify_gh_reversibility].
+   - Network keywords from curl(1) error messages and [gh api] wrappings
+     observed in production stderr. *)
+let default_rules : rule list = [
+  { exit_code = 0;   stderr_contains = None; class_ = Ok_0 };
+
+  (* masc-mcp R1/R2 block codes. Kept first so policy signals are
+     never mistaken for a gh CLI failure. *)
+  { exit_code = 200; stderr_contains = None; class_ = Policy_blocked };
+  { exit_code = 201; stderr_contains = None; class_ = Policy_blocked };
+
+  (* Auth surface. exit 4 is the documented `gh auth` error code. *)
+  { exit_code = 4;   stderr_contains = None; class_ = Auth_failed };
+  { exit_code = 1;   stderr_contains = Some "authentication"; class_ = Auth_failed };
+  { exit_code = 1;   stderr_contains = Some "Bad credentials"; class_ = Auth_failed };
+  { exit_code = 1;   stderr_contains = Some "401 Unauthorized"; class_ = Auth_failed };
+  { exit_code = 1;   stderr_contains = Some "403 Forbidden"; class_ = Auth_failed };
+  { exit_code = 1;   stderr_contains = Some "gh auth login"; class_ = Auth_failed };
+
+  (* Network surface. *)
+  { exit_code = 1;   stderr_contains = Some "Could not resolve host"; class_ = Network };
+  { exit_code = 1;   stderr_contains = Some "connect: network is unreachable"; class_ = Network };
+  { exit_code = 1;   stderr_contains = Some "dial tcp"; class_ = Network };
+  { exit_code = 1;   stderr_contains = Some "tls: handshake failure"; class_ = Network };
+  { exit_code = 1;   stderr_contains = Some "i/o timeout"; class_ = Network };
+
+  (* Argparse / schema failure shape. exit 2 is the conventional
+     Go/cobra argparse code. *)
+  { exit_code = 2;   stderr_contains = None; class_ = Type_mismatch };
+  { exit_code = 1;   stderr_contains = Some "unknown flag"; class_ = Type_mismatch };
+  { exit_code = 1;   stderr_contains = Some "unknown command"; class_ = Type_mismatch };
+  { exit_code = 1;   stderr_contains = Some "required flag"; class_ = Type_mismatch };
+  { exit_code = 1;   stderr_contains = Some "accepts "; class_ = Type_mismatch };
+]
+
+let overrides : rule list ref = ref []
+
+let install_overrides rules = overrides := rules @ !overrides
+
+let active_rules () = !overrides @ default_rules
+
+let rule_matches rule ~exit_code ~stderr =
+  rule.exit_code = exit_code
+  && (match rule.stderr_contains with
+      | None -> true
+      | Some needle -> contains_ci ~haystack:stderr ~needle)
+
+let classify ~exit_code ~stderr =
+  let rec walk = function
+    | [] -> Unknown
+    | r :: rest ->
+      if rule_matches r ~exit_code ~stderr then r.class_ else walk rest
+  in
+  walk (active_rules ())
+
+let interpretation_of = function
+  | Ok_0 -> None
+  | Policy_blocked ->
+      Some "masc-mcp policy guard blocked this mutation (R1/R2). \
+            Not retryable without an operator override."
+  | Type_mismatch ->
+      Some "gh CLI argparse failure. Fix the argv shape \
+            (flag name, required field, subcommand) and retry."
+  | Auth_failed ->
+      Some "gh authentication failed. Check GH_TOKEN / keeper identity \
+            bundle; do not retry with the same credentials."
+  | Network ->
+      Some "Network transient failure. Safe to retry after backoff."
+  | Unknown -> None
+
+type gh_result = {
+  stdout : string;
+  stderr : string;
+  exit_code : int;
+  class_ : t;
+  interpretation : string option;
+}
+
+let make ~stdout ~stderr ~exit_code =
+  let class_ = classify ~exit_code ~stderr in
+  { stdout; stderr; exit_code; class_; interpretation = interpretation_of class_ }
+
+let to_legacy_result r =
+  match r.class_ with
+  | Ok_0 -> Ok r.stdout
+  | _ ->
+    let summary =
+      match r.interpretation with
+      | Some s -> Printf.sprintf "[%s] %s" (to_string r.class_) s
+      | None -> Printf.sprintf "[%s] exit=%d" (to_string r.class_) r.exit_code
+    in
+    let body =
+      if r.stderr = "" then summary
+      else Printf.sprintf "%s\n%s" summary (String.trim r.stderr)
+    in
+    Error body

--- a/lib/gh_exit_class.mli
+++ b/lib/gh_exit_class.mli
@@ -1,0 +1,86 @@
+(** GitHub CLI exit-code classifier.
+
+    RFC-0007 rev.3 PR-2. Turns the [(exit_code, stderr)] pair from a
+    [gh] subprocess completion into a small variant that callers
+    (keeper prompt, metrics, retry policy) can [match] on instead of
+    regex-scanning stdout.
+
+    Classification is **table-driven**. A compile-time default table
+    lives in this module; an operator-managed override table may be
+    layered on top later from [config/tool_policy.toml] via
+    {!install_overrides}. Unknown [(exit_code, stderr)] combinations
+    always bucket to [Unknown] — we never misclassify.
+
+    Design notes (RFC §PR-2):
+    - No regex over stdout. Stdout is LLM-consumed payload; scanning it
+      for classification creates a feedback loop we do not want.
+    - Classification works on [exit_code] first, then a tiny set of
+      [String.contains] probes on [stderr].
+    - [Unknown] is a first-class bucket, not a bug. It fires the
+      [Unknown] metric so operators can see emerging patterns without
+      the classifier lying about them.
+
+    Backward compatibility: callers migrating to {!gh_result} may keep
+    their [(string, string) result] API via {!to_legacy_result} for
+    one release cycle. *)
+
+(** Classification bucket. Order matches RFC-0007 §PR-2 table. *)
+type t =
+  | Ok_0
+      (** [exit_code = 0]. The [gh] call succeeded at the CLI layer.
+          Business success still depends on [stdout]. *)
+  | Policy_blocked
+      (** masc-mcp internal block surfaced through a reserved exit
+          code (R1/R2 destructive-mutation guards). *)
+  | Type_mismatch
+      (** Argparse / schema failure shape. Retry with a corrected
+          argv shape, not a different intent. *)
+  | Auth_failed
+      (** [gh auth] error surface — missing/expired token, 401, 403. *)
+  | Network
+      (** curl/TLS/DNS failure. Transient, retry after backoff. *)
+  | Unknown
+      (** Fail-safe bucket. Never claim a class we cannot prove. *)
+
+val to_string : t -> string
+
+(** [classify ~exit_code ~stderr] is pure. *)
+val classify : exit_code:int -> stderr:string -> t
+
+(** Structured result for a [gh] subprocess invocation. New callers
+    return this directly; legacy callers use {!to_legacy_result}. *)
+type gh_result = private {
+  stdout : string;
+  stderr : string;
+  exit_code : int;
+  class_ : t;
+  interpretation : string option;
+}
+
+(** [make ~stdout ~stderr ~exit_code] classifies and constructs the
+    result. [interpretation] is a short, ready-to-show hint derived
+    from [class_]; [None] for [Ok_0] and [Unknown]. *)
+val make : stdout:string -> stderr:string -> exit_code:int -> gh_result
+
+(** Convert to the legacy [(string, string) result]. [Ok_0 →
+    Ok stdout]; everything else → [Error] with a one-line summary
+    prefixed by the class name. *)
+val to_legacy_result : gh_result -> (string, string) result
+
+(** A single classification rule: [(predicate, class)]. The classifier
+    walks the rule list head-to-tail and returns the class of the
+    first matching rule, falling through to [Unknown]. *)
+type rule = {
+  exit_code : int;
+  stderr_contains : string option;  (** [None] = match any stderr. *)
+  class_ : t;
+}
+
+(** Default rule table baked into this module. Exposed so that tests
+    can assert against it and config loaders can layer overrides. *)
+val default_rules : rule list
+
+(** [install_overrides rules] prepends [rules] to the active rule
+    table for the remainder of the process. Intended to be called
+    once at startup after reading [config/tool_policy.toml]. *)
+val install_overrides : rule list -> unit

--- a/test/dune
+++ b/test/dune
@@ -103,6 +103,7 @@
         test_keeper_shell_containment
         test_keeper_shell_docker_route
         test_env_git_noninteractive
+        test_gh_exit_class
         test_keeper_fs_edit_patch
         test_keeper_docker_read
         test_keeper_github_read_only
@@ -221,6 +222,7 @@
           test_keeper_shell_containment
           test_keeper_shell_docker_route
           test_env_git_noninteractive
+          test_gh_exit_class
           test_keeper_fs_edit_patch
           test_keeper_docker_read
           test_keeper_github_read_only

--- a/test/test_gh_exit_class.ml
+++ b/test/test_gh_exit_class.ml
@@ -1,0 +1,147 @@
+(* test/test_gh_exit_class.ml
+
+   RFC-0007 rev.3 PR-2 — classifier contract.
+
+   Principles under test:
+   1. Ok_0 on exit_code=0 regardless of stderr (stderr may carry warnings).
+   2. Policy_blocked rides reserved masc-mcp exit codes, not regex.
+   3. Auth_failed matches on stderr substrings that production has
+      actually observed (Bad credentials, 401, gh auth login prompt).
+   4. Network uses curl/TLS keywords, not stdout.
+   5. Type_mismatch on exit=2 (Go/cobra argparse) or flag/command errors.
+   6. Unknown is a first-class, stable bucket — never misclassify.
+   7. [install_overrides] takes precedence over defaults.
+   8. [to_legacy_result] preserves the one-release compat contract. *)
+
+module GEC = Masc_mcp.Gh_exit_class
+
+let eq_class t label expected actual =
+  Alcotest.(check string) label
+    (GEC.to_string expected) (GEC.to_string actual);
+  ignore t
+
+let test_ok_zero () =
+  let c = GEC.classify ~exit_code:0 ~stderr:"" in
+  eq_class () "exit 0 → Ok_0" GEC.Ok_0 c;
+  let c' = GEC.classify ~exit_code:0 ~stderr:"warning: something" in
+  eq_class () "exit 0 with warning stderr → Ok_0" GEC.Ok_0 c'
+
+let test_policy_blocked () =
+  let c200 = GEC.classify ~exit_code:200 ~stderr:"" in
+  eq_class () "exit 200 → Policy_blocked" GEC.Policy_blocked c200;
+  let c201 = GEC.classify ~exit_code:201 ~stderr:"anything" in
+  eq_class () "exit 201 → Policy_blocked" GEC.Policy_blocked c201
+
+let test_auth_failure_variants () =
+  let c_4 = GEC.classify ~exit_code:4 ~stderr:"" in
+  eq_class () "exit 4 → Auth_failed" GEC.Auth_failed c_4;
+  let c_bad = GEC.classify ~exit_code:1
+    ~stderr:"HTTP 401: Bad credentials (https://api.github.com/)" in
+  eq_class () "Bad credentials → Auth_failed" GEC.Auth_failed c_bad;
+  let c_login = GEC.classify ~exit_code:1
+    ~stderr:"Please run: gh auth login" in
+  eq_class () "gh auth login prompt → Auth_failed" GEC.Auth_failed c_login;
+  let c_403 = GEC.classify ~exit_code:1
+    ~stderr:"HTTP 403 Forbidden" in
+  eq_class () "403 Forbidden → Auth_failed" GEC.Auth_failed c_403
+
+let test_network_variants () =
+  let dns = GEC.classify ~exit_code:1
+    ~stderr:"Could not resolve host: api.github.com" in
+  eq_class () "DNS fail → Network" GEC.Network dns;
+  let tls = GEC.classify ~exit_code:1
+    ~stderr:"remote error: tls: handshake failure" in
+  eq_class () "TLS handshake → Network" GEC.Network tls;
+  let timeout = GEC.classify ~exit_code:1
+    ~stderr:"dial tcp 140.82.114.4:443: i/o timeout" in
+  eq_class () "dial tcp timeout → Network" GEC.Network timeout
+
+let test_type_mismatch () =
+  let c_2 = GEC.classify ~exit_code:2 ~stderr:"" in
+  eq_class () "exit 2 → Type_mismatch" GEC.Type_mismatch c_2;
+  let c_flag = GEC.classify ~exit_code:1
+    ~stderr:"Error: unknown flag: --foo" in
+  eq_class () "unknown flag → Type_mismatch" GEC.Type_mismatch c_flag;
+  let c_cmd = GEC.classify ~exit_code:1
+    ~stderr:"Error: unknown command \"foobar\" for \"gh\"" in
+  eq_class () "unknown command → Type_mismatch" GEC.Type_mismatch c_cmd
+
+let test_unknown_fallback () =
+  let c = GEC.classify ~exit_code:137 ~stderr:"" in
+  eq_class () "exit 137 (SIGKILL) → Unknown" GEC.Unknown c;
+  let c' = GEC.classify ~exit_code:1 ~stderr:"some random unmatched error text" in
+  eq_class () "arbitrary stderr → Unknown" GEC.Unknown c'
+
+let test_make_carries_interpretation () =
+  let r = GEC.make ~stdout:"" ~stderr:"Bad credentials" ~exit_code:1 in
+  Alcotest.(check string) "class"
+    (GEC.to_string GEC.Auth_failed) (GEC.to_string r.class_);
+  (match r.interpretation with
+   | Some s ->
+     Alcotest.(check bool) "interpretation mentions auth"
+       true
+       (String.length s > 0
+        && (String.length s >= 4
+            && (let lower = String.lowercase_ascii s in
+                let rec sub_at i =
+                  if i + 4 > String.length lower then false
+                  else if String.sub lower i 4 = "auth" then true
+                  else sub_at (i + 1)
+                in sub_at 0)))
+   | None -> Alcotest.fail "expected interpretation for Auth_failed")
+
+let test_to_legacy_ok () =
+  let r = GEC.make ~stdout:"hello\n" ~stderr:"" ~exit_code:0 in
+  match GEC.to_legacy_result r with
+  | Ok s -> Alcotest.(check string) "stdout preserved" "hello\n" s
+  | Error e -> Alcotest.fail ("expected Ok, got Error: " ^ e)
+
+let test_to_legacy_err_prefix () =
+  let r = GEC.make ~stdout:"" ~stderr:"Bad credentials" ~exit_code:1 in
+  match GEC.to_legacy_result r with
+  | Ok _ -> Alcotest.fail "expected Error"
+  | Error body ->
+    (* The error body must be prefixed by the class name in square
+       brackets. Callers may grep for [Auth_failed] etc. *)
+    let has_prefix =
+      String.length body >= 14
+      && String.sub body 0 13 = "[Auth_failed]"
+    in
+    Alcotest.(check bool) "legacy Error starts with class tag" true has_prefix
+
+let test_overrides_precedence () =
+  (* Override: stderr containing "QUOTA" + exit 1 → Policy_blocked.
+     Without the override, defaults bucket this to Unknown. *)
+  let before = GEC.classify ~exit_code:1 ~stderr:"QUOTA exceeded" in
+  eq_class () "before override" GEC.Unknown before;
+  GEC.install_overrides
+    [ { GEC.exit_code = 1;
+        stderr_contains = Some "QUOTA";
+        class_ = GEC.Policy_blocked } ];
+  let after = GEC.classify ~exit_code:1 ~stderr:"QUOTA exceeded" in
+  eq_class () "after override" GEC.Policy_blocked after
+
+let () =
+  Alcotest.run "gh_exit_class"
+    [
+      ( "classify",
+        [
+          Alcotest.test_case "Ok_0"             `Quick test_ok_zero;
+          Alcotest.test_case "Policy_blocked"   `Quick test_policy_blocked;
+          Alcotest.test_case "Auth variants"    `Quick test_auth_failure_variants;
+          Alcotest.test_case "Network variants" `Quick test_network_variants;
+          Alcotest.test_case "Type_mismatch"    `Quick test_type_mismatch;
+          Alcotest.test_case "Unknown fallback" `Quick test_unknown_fallback;
+        ] );
+      ( "gh_result",
+        [
+          Alcotest.test_case "make carries interpretation"
+            `Quick test_make_carries_interpretation;
+          Alcotest.test_case "to_legacy Ok"  `Quick test_to_legacy_ok;
+          Alcotest.test_case "to_legacy Err prefix" `Quick test_to_legacy_err_prefix;
+        ] );
+      ( "overrides",
+        [
+          Alcotest.test_case "override precedence" `Quick test_overrides_precedence;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Introduces the typed `gh` subprocess classifier as specified in RFC-0007 rev.3 §PR-2. Pure addition — no existing callers are rewired yet. The backward-compat bridge `to_legacy_result` keeps one-release semantics for downstream migrators.

Follows the merged design PR #9842 and sits on top of PR-1 (#9872, merged).

## What changed

| File | Change |
|------|--------|
| `lib/gh_exit_class.mli` | **new** — public API: `t` variant, `gh_result` private record, `classify`, `make`, `to_legacy_result`, `install_overrides` |
| `lib/gh_exit_class.ml` | **new** — table-driven classifier with 18 default rules covering `gh` CLI conventions + masc-mcp R1/R2 policy codes + curl/TLS keywords |
| `lib/dune` | +1 module registration |
| `test/test_gh_exit_class.ml` | **new** — 10 Alcotest cases across classify / gh_result / overrides |
| `test/dune` | +2 lines (names + modules) |

Net diff: **377 insertions**, 0 deletions, 5 files.

## Classifier shape

```ocaml
type t =
  | Ok_0
  | Policy_blocked   (* masc-mcp R1/R2 destructive-mutation guard *)
  | Type_mismatch    (* argparse / schema failure *)
  | Auth_failed      (* gh auth surface *)
  | Network          (* curl/TLS/DNS *)
  | Unknown          (* fail-safe bucket *)
```

Classification walks a head-to-tail list of `{ exit_code; stderr_contains; class_ }` rules and returns the class of the first match, falling through to `Unknown`. No regex, no stdout reads — per RFC §P4 (\"stdout is LLM-consumed payload, scanning it for routing creates a feedback loop\").

Default table sources:
- `gh` CLI exit conventions: `0` ok, `2` cobra argparse, `4` auth
- masc-mcp internal `200`/`201` from `gh_command_validation.classify_gh_reversibility`
- curl/TLS/DNS stderr keywords observed in production

## Why this unlocks Cluster B

The existing caller shape is `(string, string) result`. Every failure is a `string` that callers either regex-scan or forward verbatim to the LLM. Concrete damage:

- **#9786** bearer token mismatch: auth failures were indistinguishable from transient network errors, so retry logic burned budget on unretryable errors.
- **#9850** cascade codex_cli runtime MCP: auth rejection stringified into the same error surface as schema mismatches, defeating triage.
- **#9728** approval bypass can't be human-proof while agents share creds: policy-blocked surfaces look like generic failures to the keeper prompt.

Shipping the typed classifier is the foundation. Follow-ups will wire it incrementally without re-doing the typing work each time.

## Deferred (follow-ups gated on this PR)

Per RFC's ~120-line budget for PR-2, this PR does **not** include:

1. **Wiring at the 2 `gh` subprocess completion points** in `lib/keeper/keeper_exec_shell.ml` (~line 1055 `entry.exit_code` / ~line 1183 `r.status`). Separate PR will call `Gh_exit_class.make` and emit the new `keeper_shell_gh_result_class_total{class=…}` metric.
2. **TOML-driven overrides** via `[[gh_exit_classes]]` in `config/tool_policy.toml`. The `install_overrides` hook is already in place for this; the loader is scope for a separate PR.
3. **Keeper prompt retry contract** (\"retry only when class=Type_mismatch\"). RFC explicitly defers this until telemetry from #1 lands; adding it before the class signal is observable is cargo-cult.

## Verification

```
dune build @check --root .                      # clean on 1cbaa2f
dune exec --root . test/test_gh_exit_class.exe  # 10/10 passed, 0.005s
```

Tests cover:
- `Ok_0` classification with/without stderr warnings
- `Policy_blocked` on both `200` and `201` exit codes
- `Auth_failed` on 4 variants: `exit 4`, \"Bad credentials\", \"gh auth login\" prompt, \"403 Forbidden\"
- `Network` on 3 variants: DNS, TLS handshake, dial tcp timeout
- `Type_mismatch` on 3 variants: `exit 2`, \"unknown flag\", \"unknown command\"
- `Unknown` fallback on `SIGKILL (137)` and unmatched stderr
- `make` produces `interpretation` for classified errors
- `to_legacy_result` preserves stdout on `Ok_0` and prefixes `[ClassName]` on errors
- `install_overrides` takes precedence over defaults

## Risk

Pure addition. Zero existing modules depend on `gh_exit_class`. No behavior changes in production code paths. Rollback = revert the commit, no migrations, no config rollback.

## References

- RFC-0007 rev.3 §PR-2: `docs/rfc/RFC-0007-op-gh-harness-audit.md`
- Design PR #9842 (merged 2026-04-24)
- PR-1 merged: #9872
- Prior art:
  - Go `context.Canceled` vs `context.DeadlineExceeded` — typed sentinels beat string matching
  - gRPC `Status.Code` — table-driven cross-language classification
  - Envoy route timeout vs retry budget separation — class-based retry policy
  - claude-code `src/tools/BashTool/BashTool.tsx:280` — `outputSchema` Zod with `returnCodeInterpretation` (RFC's reference implementation)

## Do not merge

Carrying `do-not-merge` until reviewer sign-off on:
1. The `t` variant set (RFC-authoritative, but open to adding buckets before merge).
2. The default rule table (operator visibility → TOML override path).
3. The `to_legacy_result` error body shape (`[ClassName] hint\nstderr`).

Follow-up PRs depend on this PR's public API; revising the shape is free before merge, expensive after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)