### PR TITLE
Fix Kimi resumable CLI classification

### DIFF
--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -701,7 +701,7 @@ module Kimi_cli_transport_local = struct
     && String.sub text 0 prefix_len = prefix
 
   let resumable_session_detail =
-    "kimi_cli session limit exceeded (exit 75). Resumable session available via -r."
+    "kimi_cli reported a resumable CLI session. Resumable session available via -r."
 
   let resume_hint_marker = "to resume this session:"
   let resumable_session_public_marker = "resumable session available via -r."
@@ -735,6 +735,24 @@ module Kimi_cli_transport_local = struct
             |> String.trim
           in
           int_of_string_opt raw
+
+  let exit_code_marker_of_text text =
+    let marker = "(exit " in
+    let lower = String.lowercase_ascii text in
+    let marker_len = String.length marker in
+    let text_len = String.length lower in
+    let rec find_marker index =
+      if index + marker_len > text_len then None
+      else if String.sub lower index marker_len = marker then
+        let number_start = index + marker_len in
+        match String.index_from_opt lower number_start ')' with
+        | Some number_end when number_end > number_start ->
+            String.sub lower number_start (number_end - number_start)
+            |> String.trim |> int_of_string_opt
+        | _ -> None
+      else find_marker (index + 1)
+    in
+    find_marker 0
 
   let exit_payload_of_message message =
     let prefix = "kimi exited with code " in
@@ -773,14 +791,26 @@ module Kimi_cli_transport_local = struct
     || String_util.contains_substring_ci trimmed legacy_resumable_session_public_marker)
 
   let resumable_session_detail_of_text text =
-    if text_looks_like_resumable_session text then resumable_session_detail
+    if text_looks_like_resumable_session text then
+      let trimmed = String.trim text in
+      match
+        match exit_code_of_message trimmed with
+        | Some code -> Some code
+        | None -> exit_code_marker_of_text trimmed
+      with
+      | Some code ->
+          Printf.sprintf
+            "kimi_cli reported a resumable CLI session (exit %d). \
+             Resumable session available via -r."
+            code
+      | None -> resumable_session_detail
     else String.trim text
 
   let resumable_session_exit_code_of_text text =
     match exit_code_of_message text with
     | Some (75 as code) -> Some code
     | Some (1 as code) when text_looks_like_resumable_session text -> Some code
-    | _ when text_looks_like_resumable_session text -> Some 75
+    | _ when text_looks_like_resumable_session text -> exit_code_marker_of_text text
     | _ -> None
 
   let classify_cli_error = function
@@ -788,7 +818,7 @@ module Kimi_cli_transport_local = struct
         if text_looks_like_resumable_session message then
           Error
             (Llm_provider.Http_client.AcceptRejected
-               { reason = resumable_session_detail })
+               { reason = resumable_session_detail_of_text message })
         else
           match exit_code_of_message message with
         | Some 1 ->
@@ -804,7 +834,7 @@ module Kimi_cli_transport_local = struct
         | Some 75 ->
             Error
               (Llm_provider.Http_client.AcceptRejected
-                 { reason = resumable_session_detail })
+                 { reason = resumable_session_detail_of_text message })
         | _ -> err)
     | other -> other
 

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -811,6 +811,23 @@ let resumable_cli_session_exit_code (message : string) : int option =
   Oas_worker_exec.Kimi_cli_transport_local.resumable_session_exit_code_of_text
     message
 
+let sdk_error_to_resumable_cli_session ~cascade_name
+    (err : Oas.Error.sdk_error) =
+  match classify_masc_internal_error err with
+  | Some (Resumable_cli_session _) -> Some err
+  | _ ->
+      let message = Oas.Error.to_string err in
+      if message_looks_like_resumable_cli_session message then
+        Some
+          (sdk_error_of_masc_internal_error
+             (Resumable_cli_session
+                {
+                  cascade_name;
+                  detail = resumable_cli_session_detail message;
+                  exit_code = resumable_cli_session_exit_code message;
+                }))
+      else None
+
 let sdk_error_is_hard_quota (err : Oas.Error.sdk_error) : bool =
   match err with
   | Oas.Error.Api api_err ->
@@ -1254,6 +1271,11 @@ let run_named
            on_success ~provider_key:provider_cfg.model_id;
            Ok result)
       | Error sdk_err ->
+        let sdk_err =
+          match sdk_error_to_resumable_cli_session ~cascade_name sdk_err with
+          | Some err -> err
+          | None -> sdk_err
+        in
         (* Classify hard-quota (account-level exhaustion) distinctly from
            transient failures.  Hard quota (e.g. Anthropic multi-day usage
            limit, ZAI balance 0) will not recover within the 60s

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -2064,6 +2064,10 @@ let test_kimi_cli_classify_cli_error_redacts_resumable_session_detail () =
   let raw_message =
     "kimi exited with code 75: \nTo resume this session: kimi -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc"
   in
+  let canonical_detail =
+    Oas_worker_exec.Kimi_cli_transport_local.resumable_session_detail_of_text
+      raw_message
+  in
   match
     Oas_worker_exec.Kimi_cli_transport_local.classify_cli_error
       (Error
@@ -2074,9 +2078,7 @@ let test_kimi_cli_classify_cli_error_redacts_resumable_session_detail () =
             }))
   with
   | Error (Llm_provider.Http_client.AcceptRejected { reason }) ->
-      Alcotest.(check string) "canonical detail"
-        Oas_worker_exec.Kimi_cli_transport_local.resumable_session_detail
-        reason;
+      Alcotest.(check string) "canonical detail" canonical_detail reason;
       Alcotest.(check bool) "raw resume hint removed" false
         (contains_substring ~needle:"To resume this session:" reason);
       Alcotest.(check bool) "raw session id removed" false
@@ -2086,6 +2088,10 @@ let test_kimi_cli_classify_cli_error_redacts_resumable_session_detail () =
 let test_kimi_cli_classify_cli_error_treats_exit_1_resume_hint_as_resumable () =
   let raw_message =
     "kimi exited with code 1: \nTo resume this session: kimi -r 5de0f199-6bd7-4509-bfa6-3308e0ebd97f"
+  in
+  let canonical_detail =
+    Oas_worker_exec.Kimi_cli_transport_local.resumable_session_detail_of_text
+      raw_message
   in
   Alcotest.(check bool) "exit 1 resume hint is resumable" true
     (Oas_worker_exec.Kimi_cli_transport_local.text_looks_like_resumable_session
@@ -2103,14 +2109,40 @@ let test_kimi_cli_classify_cli_error_treats_exit_1_resume_hint_as_resumable () =
             }))
   with
   | Error (Llm_provider.Http_client.AcceptRejected { reason }) ->
-      Alcotest.(check string) "canonical detail"
-        Oas_worker_exec.Kimi_cli_transport_local.resumable_session_detail
-        reason;
+      Alcotest.(check string) "canonical detail" canonical_detail reason;
+      Alcotest.(check bool) "does not claim exit 75" false
+        (contains_substring ~needle:"exit 75" reason);
       Alcotest.(check bool) "raw resume hint removed" false
         (contains_substring ~needle:"To resume this session:" reason);
       Alcotest.(check bool) "raw session id removed" false
         (contains_substring ~needle:"5de0f199-6bd7-4509-bfa6-3308e0ebd97f" reason)
   | _ -> Alcotest.fail "expected exit 1 resume hint to map to resumable session"
+
+let test_kimi_cli_resumable_invalid_request_reclassifies_as_structured () =
+  let raw_message =
+    "kimi exited with code 1: \nTo resume this session: kimi -r 5de0f199-6bd7-4509-bfa6-3308e0ebd97f"
+  in
+  let detail =
+    Oas_worker_exec.Kimi_cli_transport_local.resumable_session_detail_of_text
+      raw_message
+  in
+  let sdk_error =
+    Oas.Error.Api (Llm_provider.Retry.InvalidRequest { message = detail })
+  in
+  match
+    Oas_worker_named.sdk_error_to_resumable_cli_session
+      ~cascade_name:"kimi_cli_keeper" sdk_error
+  with
+  | Some structured -> (
+      match Oas_worker_named.classify_masc_internal_error structured with
+      | Some
+          (Oas_worker_named.Resumable_cli_session
+             { cascade_name; detail = structured_detail; exit_code }) ->
+          Alcotest.(check string) "cascade" "kimi_cli_keeper" cascade_name;
+          Alcotest.(check string) "detail" detail structured_detail;
+          Alcotest.(check (option int)) "exit code" (Some 1) exit_code
+      | _ -> Alcotest.fail "expected structured resumable CLI session")
+  | None -> Alcotest.fail "expected InvalidRequest detail to reclassify"
 
 let test_kimi_cli_classify_cli_error_keeps_exit_1_with_error_as_reject () =
   let raw_message =
@@ -3456,6 +3488,8 @@ let () =
         test_kimi_cli_classify_cli_error_redacts_resumable_session_detail;
       Alcotest.test_case "kimi exit 1 resume hint is resumable" `Quick
         test_kimi_cli_classify_cli_error_treats_exit_1_resume_hint_as_resumable;
+      Alcotest.test_case "kimi resumable InvalidRequest is structured" `Quick
+        test_kimi_cli_resumable_invalid_request_reclassifies_as_structured;
       Alcotest.test_case "kimi exit 1 with stderr remains rejected" `Quick
         test_kimi_cli_classify_cli_error_keeps_exit_1_with_error_as_reject;
       Alcotest.test_case "worker build_agent installs retry policy" `Quick


### PR DESCRIPTION
## Summary
- stop labeling Kimi resume-only exit 1 as an exit-75 session-limit case
- preserve the observed Kimi exit code in redacted resumable details
- reclassify OAS-wrapped InvalidRequest resumable details back into structured Resumable_cli_session so keeper recovery paths can see them

## Validation
- dune build --root . ./test/test_oas_worker.exe ./test/test_keeper_unified.exe
- ./_build/default/test/test_oas_worker.exe test resume_config --compact --show-errors
- ./_build/default/test/test_keeper_unified.exe test metrics_observation 22 --compact --show-errors
- ./_build/default/test/test_keeper_unified.exe test phase_gate 9 --compact --show-errors
- ./_build/default/test/test_keeper_unified.exe test transient_network_error 36 --compact --show-errors