### PR TITLE
fix(oas_compat): cascade AcceptRejected on capability-mismatch marker (#9850)

### DIFF
--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -25,6 +25,28 @@ module Http_client = struct
   let is_provider_parse_error body =
     contains_ci ~haystack:body ~needle:"can't find closing" ()
 
+  (* AcceptRejected is raised by OAS for multiple distinct conditions:
+     (a) permanent provider failures (kimi_cli exit 1 is explicitly labeled
+         "permanent auth/config/model error") — must NOT cascade.
+     (b) provider capability mismatches wrapped by MASC's worker layer at
+         [oas_worker_named.ml:672-678] (InvalidConfig runtime_mcp_auth /
+         tool_support). The worker comment at line 661-665 documents explicit
+         cascade intent. The detail string is built in
+         [oas_worker_exec_transport.ml:444-452] and consistently starts with
+         "<provider> does not support ...".
+     This filter whitelists only markers from class (b). Class (a) has no
+     matching marker and falls through to false. CompletionContractViolation
+     and UnrecognizedStopReason use free-form [reason] and are not whitelisted
+     here — their cascade intent is tracked separately. See masc-mcp #9850. *)
+  let accept_rejected_cascadable_markers = [
+    "does not support";
+  ]
+
+  let accept_rejected_is_cascadable reason =
+    List.exists
+      (fun needle -> contains_ci ~haystack:reason ~needle ())
+      accept_rejected_cascadable_markers
+
   let should_cascade (err : Llm_provider.Http_client.http_error) : bool =
     if Llm_provider.Http_client.is_local_resource_exhaustion err then false
     else
@@ -36,7 +58,8 @@ module Http_client = struct
           true
       | Llm_provider.Http_client.HttpError { code; _ } ->
           List.mem code Llm_provider.Constants.Http.cascadable_codes
-      | Llm_provider.Http_client.AcceptRejected _ -> false
+      | Llm_provider.Http_client.AcceptRejected { reason } ->
+          accept_rejected_is_cascadable reason
       | Llm_provider.Http_client.CliTransportRequired _ -> true
       | Llm_provider.Http_client.NetworkError _ -> true
 end

--- a/lib/oas_compat/oas_compat.mli
+++ b/lib/oas_compat/oas_compat.mli
@@ -32,8 +32,14 @@ module Http_client : sig
       signals context overflow / provider parse error.
       [CliTransportRequired] cascades — the CLI provider cannot serve
       this request over HTTP, so the next provider must.
-      [AcceptRejected] does not cascade — the upstream contract has
-      already decided this payload is inadmissible. *)
+      [AcceptRejected] cascades only when the [reason] string carries a
+      provider-capability-mismatch marker (e.g. "does not support"). This
+      covers MASC's worker-layer wrapping of OAS [InvalidConfig] errors
+      for [runtime_mcp_auth] and [tool_support], whose cascade intent is
+      documented at [oas_worker_named.ml:661-678]. Permanent provider
+      failures such as [kimi_cli] exit 1 ("permanent auth/config/model
+      error") do not match any marker and remain non-cascading. See
+      masc-mcp #9850 for the motivating codex_cli case. *)
 end
 
 module Metrics : sig


### PR DESCRIPTION
## 요약

`lib/oas_compat/oas_compat.ml:39`의 `AcceptRejected _ -> false`가 cascade FSM에서 codex_cli `runtime_mcp_auth` 거부를 permanent 실패로 오분류하여, cascade 계속이 가능한 capability mismatch에도 전체 cascade를 종료시켰습니다. 이는 `lib/oas_worker_named.ml:661-678`에서 worker가 wrapping 시점에 명시한 cascade 의도("Model-capability errors: the next provider may handle these")와 충돌합니다.

Closes #9850.

## 근본 원인

`AcceptRejected { reason }`는 서로 다른 두 클래스의 실패를 표현하는 데 혼용되고 있습니다:

| 클래스 | 예시 소스 | cascade 의도 |
|--------|-----------|--------------|
| (a) permanent provider 실패 | `transport_kimi_cli.ml:267-272` ("kimi_cli rejected the request (exit 1). permanent auth/config/model error") | **false** |
| (b) capability mismatch | `oas_worker_named.ml:672-678` (InvalidConfig `runtime_mcp_auth`/`tool_support`, detail from `oas_worker_exec_transport.ml:444-452`) | **true** |

기존 필터는 (a)·(b)를 구분하지 않고 모두 `false`를 반환하여, 9850에서 보고된 codex_cli 지속 실패가 cascade 다음 provider로 넘어가지 못했습니다.

## 변경 내용

`lib/oas_compat/oas_compat.ml`의 `should_cascade`가 `AcceptRejected { reason }`에 대해 reason 문자열 마커 기반 whitelist를 적용합니다.

- 마커 `"does not support"` — `oas_worker_exec_transport.ml:444-452`의 세 detail 템플릿 전부 포함 (runtime MCP HTTP headers / inline tools or runtime MCP / inline tools)
- 마커 불일치 시 기존대로 `false` 반환 → kimi_cli exit-1 및 `CompletionContractViolation` / `UnrecognizedStopReason` 동작 변화 없음

구현은 `contains_ci` 기존 헬퍼 재사용 (case-insensitive substring, 512 byte scan cap).

## 회귀 리스크

| 경로 | before | after | 비고 |
|------|--------|-------|------|
| kimi_cli exit 1 | cascade=false | cascade=false | `"permanent"` 포함, `"does not support"` 미포함 |
| CompletionContractViolation (free-form reason) | cascade=false | cascade=false | 마커 미포함 (별도 follow-up 대상) |
| UnrecognizedStopReason (free-form reason) | cascade=false | cascade=false | 마커 미포함 (별도 follow-up 대상) |
| codex_cli keeper-bound runtime MCP | cascade=false ❌ | cascade=true ✅ | #9850 본 PR 대상 |
| `tool_support` InvalidConfig | cascade=false ❌ | cascade=true ✅ | 같은 detail 템플릿 공유 |

## 테스트

- [x] `dune build @check --root=.` 통과 (로컬)
- [ ] CI (lint/test)
- [ ] Telemetry: cycle 8에서 확인된 "provider rejected — cascade exhausted" 에러 이벤트 (158건/24h)가 실제로 다음 provider로 넘어가는지는 머지 후 관측

## 검증하지 못한 항목

- 실환경 codex_cli 호출 경로 수동 재현은 수행하지 않았습니다. 본 PR은 결정성 있는 조건 분기 수정으로 unit level에서 검증 가능하나, `transport_kimi_cli.ml`의 기존 테스트는 OAS 레포 소속이므로 masc-mcp CI에서 재실행되지 않습니다.

## 참고

- Cycle 8 분석 코멘트: https://github.com/jeong-sik/masc-mcp/issues/9850#issuecomment-4311313435
- `AcceptRejected` 두 의미 혼용의 장기 해결책(Strategy B `CapabilityMismatch` 별도 variant)은 OAS 타입 확장을 필요로 하여 별도 PR로 분리합니다.
