### PR TITLE
fix(cost): surface pricing-catalog misses instead of silent $0 (#9868)

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -47,12 +47,32 @@ let usage_has_tokens (usage : Oas.Types.api_usage) =
   || usage.cache_creation_input_tokens > 0
   || usage.cache_read_input_tokens > 0
 
+(* #9868: use [pricing_for_model_opt] so unknown models surface as
+   [None] and get a loud catalog-miss signal instead of silently
+   returning $0. [pricing_for_model] (non-opt) collapses unknown into
+   [zero_pricing], which is the exact "Unknown -> Permissive Default"
+   anti-pattern called out in `instructions/software-development.md`
+   (OAS #555 parallel). Paid providers (openai gpt-5 family, glm
+   family) are missing from the upstream OAS catalog today, so this
+   path is the only place the miss becomes observable. *)
 let estimate_usage_cost_usd ~(model : string) (usage : Oas.Types.api_usage)
     : float =
-  let pricing = Llm_provider.Pricing.pricing_for_model model in
-  Llm_provider.Pricing.estimate_cost ~pricing
-    ~input_tokens:usage.input_tokens
-    ~output_tokens:usage.output_tokens ()
+  match Llm_provider.Pricing.pricing_for_model_opt model with
+  | Some pricing ->
+    Llm_provider.Pricing.estimate_cost ~pricing
+      ~input_tokens:usage.input_tokens
+      ~output_tokens:usage.output_tokens ()
+  | None ->
+    Prometheus.inc_counter
+      "masc_pricing_catalog_miss_total"
+      ~labels:[("model", model)] ();
+    Log.Keeper.warn
+      "pricing_catalog_miss model=%s input_tokens=%d output_tokens=%d \
+       — no pricing entry in Llm_provider.Pricing catalog; cost recorded \
+       as 0.0 (not a true zero). Add the entry upstream in \
+       agent_sdk/llm_provider/pricing.ml, then bump the OAS pin."
+      model usage.input_tokens usage.output_tokens;
+    0.0
 
 let cost_usd_for_usage ~(model : string) (usage : Oas.Types.api_usage)
     : float =

--- a/test/dune
+++ b/test/dune
@@ -52,6 +52,7 @@
         test_post_verifier
         test_keeper_cascade_profile
         test_keeper_hooks_oas_provider
+        test_keeper_hooks_oas_pricing
         test_keeper_hooks_oas_telemetry
         test_keeper_wake_telemetry
         test_keeper_memory
@@ -170,6 +171,7 @@
           test_post_verifier
           test_keeper_cascade_profile
           test_keeper_hooks_oas_provider
+          test_keeper_hooks_oas_pricing
           test_keeper_hooks_oas_telemetry
           test_keeper_wake_telemetry
           test_keeper_memory

--- a/test/test_keeper_hooks_oas_pricing.ml
+++ b/test/test_keeper_hooks_oas_pricing.ml
@@ -1,0 +1,120 @@
+(* test/test_keeper_hooks_oas_pricing.ml
+
+   #9868 — [estimate_usage_cost_usd] must NOT silently claim $0 for
+   unknown paid-provider models. The previous implementation used
+   [pricing_for_model] which returns [zero_pricing] on miss; the fix
+   switches to [pricing_for_model_opt] + explicit [None] handling that
+   fires the [masc_pricing_catalog_miss_total] metric.
+
+   Known-model cases exercise the happy path (pricing catalog hit →
+   non-zero cost for non-zero tokens). *)
+
+module Hooks = Masc_mcp.Keeper_hooks_oas
+module Oas = Masc_mcp.Oas
+module Pricing = Llm_provider.Pricing
+module Prom = Masc_mcp.Prometheus
+
+let mk_usage
+    ?(cache_creation = 0) ?(cache_read = 0) ?(cost_usd = None)
+    ~input ~output () : Oas.Types.api_usage =
+  {
+    input_tokens = input;
+    output_tokens = output;
+    cache_creation_input_tokens = cache_creation;
+    cache_read_input_tokens = cache_read;
+    cost_usd;
+  }
+
+let catalog_miss_for model =
+  Prom.metric_value_or_zero
+    "masc_pricing_catalog_miss_total"
+    ~labels:[("model", model)] ()
+
+let test_known_model_returns_nonzero_cost () =
+  let usage = mk_usage ~input:1_000_000 ~output:100_000 () in
+  let cost = Hooks.estimate_usage_cost_usd
+    ~model:"claude-sonnet-4-6" usage in
+  (* $3/M input + $15/M output = $3 + $1.5 = $4.5. Exact arithmetic;
+     any pricing regression in the catalog will shift this. *)
+  Alcotest.(check bool)
+    "sonnet-4-6 priced > 0"
+    true (cost > 0.0);
+  Alcotest.(check (float 0.01))
+    "sonnet-4-6 exact"
+    4.5 cost
+
+let test_unknown_model_emits_catalog_miss () =
+  let sentinel_model = "pricing-test-unknown-xyz-2026-04-24" in
+  let before = catalog_miss_for sentinel_model in
+  let usage = mk_usage ~input:1_000_000 ~output:500_000 () in
+  let cost = Hooks.estimate_usage_cost_usd ~model:sentinel_model usage in
+  let after = catalog_miss_for sentinel_model in
+  Alcotest.(check (float 0.0001))
+    "unknown model falls through to 0.0 (not a genuine free price)"
+    0.0 cost;
+  (* The critical assertion: the miss must be observable. Raw $0 with
+     no signal is the #9868 failure mode. *)
+  Alcotest.(check (float 0.0001))
+    "catalog miss metric incremented by exactly 1"
+    1.0 (after -. before)
+
+let test_unknown_model_repeated_calls_accumulate () =
+  let sentinel_model = "pricing-test-unknown-accum-2026-04-24" in
+  let before = catalog_miss_for sentinel_model in
+  let usage = mk_usage ~input:100 ~output:50 () in
+  for _ = 1 to 3 do
+    let _ = Hooks.estimate_usage_cost_usd ~model:sentinel_model usage in
+    ()
+  done;
+  let after = catalog_miss_for sentinel_model in
+  Alcotest.(check (float 0.0001))
+    "3 calls → delta 3"
+    3.0 (after -. before)
+
+let test_ollama_model_known_free_no_catalog_miss () =
+  (* Ollama is in the catalog as free ($0/M). This must NOT be treated
+     as a miss — the classifier is "unknown catalog entry", not "zero
+     cost". Without this check, the metric would flood on every local
+     turn. *)
+  let model = "qwen3.6:35b-a3b-mlx-bf16-64k" in
+  let before = catalog_miss_for model in
+  let usage = mk_usage ~input:10_000 ~output:2_000 () in
+  let cost = Hooks.estimate_usage_cost_usd ~model usage in
+  let after = catalog_miss_for model in
+  Alcotest.(check (float 0.0001)) "known-free → 0.0" 0.0 cost;
+  Alcotest.(check (float 0.0001))
+    "known-free → NO catalog miss"
+    0.0 (after -. before)
+
+let test_pricing_for_model_opt_contract () =
+  (* Direct contract check against the upstream API we now rely on.
+     If OAS changes [pricing_for_model_opt] semantics, this test
+     catches it before the silent $0 re-regresses. *)
+  Alcotest.(check bool)
+    "sonnet-4-6 in catalog"
+    true (Option.is_some (Pricing.pricing_for_model_opt "claude-sonnet-4-6"));
+  Alcotest.(check bool)
+    "totally-unknown not in catalog"
+    true (Option.is_none
+            (Pricing.pricing_for_model_opt "totally-unknown-pricing-probe"))
+
+let () =
+  Alcotest.run "keeper_hooks_oas_pricing"
+    [
+      ( "pricing_for_model_opt contract",
+        [
+          Alcotest.test_case "upstream opt-API semantics"
+            `Quick test_pricing_for_model_opt_contract;
+        ] );
+      ( "estimate_usage_cost_usd",
+        [
+          Alcotest.test_case "known model → non-zero cost"
+            `Quick test_known_model_returns_nonzero_cost;
+          Alcotest.test_case "unknown model → catalog miss metric"
+            `Quick test_unknown_model_emits_catalog_miss;
+          Alcotest.test_case "repeated miss accumulates"
+            `Quick test_unknown_model_repeated_calls_accumulate;
+          Alcotest.test_case "known free (ollama) does NOT trip miss"
+            `Quick test_ollama_model_known_free_no_catalog_miss;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

`costs.jsonl` shows 1183 rows at \$0.00 despite ~228M input tokens of real spend on paid providers (openai gpt-5.*, glm-*). Root cause: `estimate_usage_cost_usd` calls `Llm_provider.Pricing.pricing_for_model` which upstream silently collapses unknown models to `zero_pricing`. The classic "Unknown → Permissive Default" anti-pattern called out in `instructions/software-development.md`.

Closes #9868 (cost side; Kimi zero-token signal is §Secondary and a distinct follow-up).

## Root cause

```ocaml
(* OAS upstream lib/llm_provider/pricing.ml *)
let pricing_for_model model_id =
  Option.value ~default:zero_pricing (pricing_for_model_opt model_id)
```

Every unknown model → `zero_pricing` → `estimate_cost = 0.0`. Two layers participate: OAS upstream (catalog missing `gpt-5.*`/`glm-*`/`kimi-*`) and masc-mcp caller (uses non-opt API). This PR fixes the caller so the miss becomes observable; a separate upstream OAS issue will file the catalog expansion.

## Fix (one function, 12 LOC added / 5 removed)

```ocaml
match Llm_provider.Pricing.pricing_for_model_opt model with
| Some pricing ->
  Llm_provider.Pricing.estimate_cost ~pricing
    ~input_tokens:usage.input_tokens
    ~output_tokens:usage.output_tokens ()
| None ->
  Prometheus.inc_counter
    \"masc_pricing_catalog_miss_total\"
    ~labels:[(\"model\", model)] ();
  Log.Keeper.warn
    \"pricing_catalog_miss model=%s input_tokens=%d output_tokens=%d ...\"
    model usage.input_tokens usage.output_tokens;
  0.0
```

The `0.0` return preserves the writer contract (no type change) but is no longer silent: `masc_pricing_catalog_miss_total{model=X}` counter + warn log make the gap explicit.

## Why the existing guard wasn't enough

`cost_usd_for_usage` already filters ollama/codex_cli/gemini_cli/claude_code/kimi_cli via `structurally_unmetered_provider`. That correctly routes known-free providers around pricing. The remaining paid providers (openai, glm, anthropic, gemini, kimi, anything else) all funnel into `estimate_usage_cost_usd` — which was the silent-fallback path. This PR surgically fixes that path; the surrounding guard stays untouched.

## Tests (5/5 pass, 0.002s)

1. **upstream opt-API semantics** — catches OAS API drift if `pricing_for_model_opt` changes shape
2. **known model → non-zero** — exact \$4.50 for 1M input + 100k output on `claude-sonnet-4-6` (catches pricing-catalog regression)
3. **unknown sentinel → 0.0 cost + catalog miss metric delta = 1**
4. **repeated misses accumulate** — 3 calls → metric delta 3
5. **ollama known-free → 0.0 cost but NO catalog miss** — critical discipline check; \"known free\" and \"unknown\" must not collapse into the same bucket

Case 5 is the invariant that makes the new metric useful in practice. Without it the counter would flood on every local turn.

## Scope

- 1 function changed (`estimate_usage_cost_usd`)
- 1 test file added (5 cases, ~100 lines)
- No public API change, no caller migration needed
- Metric and log are additive

## Follow-ups

- **OAS upstream** (separate issue): add `gpt-5.*`, `glm-*`, `kimi-*` entries to `agent_sdk/llm_provider/pricing.ml:pricing_for_model_opt`. Once merged upstream, bump the OAS pin and the catalog-miss counter should drop to zero.
- **Dashboard**: surface `masc_pricing_catalog_miss_total` in the cost panel.
- **#9520** (meta: telemetry enforcement): this PR is a concrete instance of the silent-metric structural problem #9520 names.
- **Kimi zero-token signal** (issue §Secondary): distinct root cause — Kimi provider integration does not populate `response.usage` at all. Requires Kimi CLI bridge work, not a pricing fix.

## References

- `instructions/software-development.md` — AI Code Generation Anti-Patterns §2 \"Unknown → Permissive Default\" (+ OAS #555 as parallel precedent).
- OAS upstream `pricing.ml:88-89` — the two-line upstream miss.
- Prior art: Prometheus `absent_over_time` / OpenTelemetry \"stale metrics\" guidance — observable-fallback beats silent-fallback.

## Do not merge

Carrying `do-not-merge` until reviewer sign-off on:
1. The `0.0` fallback is OK as long as the metric fires (operator can bucket misses via the metric).
2. Metric name `masc_pricing_catalog_miss_total` — alternatives welcome if there's a naming convention I'm missing.
3. Test-case 5 (known-free must not trip miss) is the right invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)