### PR TITLE
[codex] fix keeper catalog cascade names

### DIFF
--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -37,7 +37,6 @@ let of_string_opt (raw : string) : t option =
   | "tool_rerank" -> Some Tool_rerank
   (* Legacy aliases → Big_three *)
   | "default"
-  | "keeper_unified"
   | "oas-keeper_unified"
   | "coding_first"
   | "oas-coding_first"
@@ -45,13 +44,13 @@ let of_string_opt (raw : string) : t option =
   | "sangsu" | "local_mlx_vlm_qwen36"
   | "nick0cave" | "capacity_queue_trio" | "vendor_mix_balanced"
   | "cost_tier_ladder" | "oauth_cli_rotate" | "quality_sticky_glm51"
-  | "tool_use_strict" | "resilient_breaker"
   | "underdog" | "local"
     -> Some Big_three
-  (* Phase-routing names: NOT variants.  Returning None lets
+  (* Catalog-routed names: NOT variants.  Returning None lets
      [canonicalize_with_catalog] preserve them as catalog names so
-     keeper phase-routing code (local_only, local_recovery) continues
-     to resolve cascade.json keys correctly. *)
+     keeper phase-routing and tool-routing code continues to resolve
+     cascade.json keys correctly. *)
+  | "keeper_unified" | "tool_use_strict" | "resilient_breaker"
   | "local_only" | "local_recovery" -> None
   | _ -> None
 

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -7,7 +7,8 @@
 
     One keeper-assignable bootstrap profile (Big_three) and one system-only
     profile (Tool_rerank).
-    Phase-routing names ("local_only", "local_recovery") are NOT variants —
+    Catalog-routed names ("keeper_unified", "tool_use_strict",
+    "resilient_breaker", "local_only", "local_recovery") are NOT variants —
     they pass through [canonicalize_with_catalog] as catalog names.
 
     @since 0.9.5 *)
@@ -35,7 +36,8 @@ val to_string : t -> string
 val of_string_opt : string -> t option
 (** Parse a raw cascade name into the variant. Handles legacy aliases
     by collapsing them to [Big_three]. Returns [None] for unknown names
-    and phase-routing names ("local_only", "local_recovery"). *)
+    and catalog-routed names ("keeper_unified", "tool_use_strict",
+    "resilient_breaker", "local_only", "local_recovery"). *)
 
 val canonical : string -> t
 (** [canonical raw] = [of_string_opt raw |> Option.value ~default]. *)

--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -202,14 +202,22 @@ let test_valid_catalog_skips_live_probes_at_bootstrap () =
   init_config_root config_dir;
   with_config_dir config_dir @@ fun () ->
   let shared_model = Printf.sprintf "custom:mock@%s/v1" dummy_base_url in
+  let keeper_unified_model =
+    Printf.sprintf "custom:keeper-unified@%s/v1" dummy_base_url
+  in
+  let strict_model =
+    Printf.sprintf "custom:tool-use-strict@%s/v1" dummy_base_url
+  in
   ignore
     (write_cascade_json config_dir
        (Printf.sprintf
           {|{
   "big_three_models": ["%s"],
-  "tool_rerank_models": ["%s"]
+  "keeper_unified_models": ["%s"],
+  "tool_rerank_models": ["%s"],
+  "tool_use_strict_models": ["%s"]
 }|}
-          shared_model shared_model));
+          shared_model keeper_unified_model shared_model strict_model));
   let snapshot =
     match Cascade_catalog_runtime.inspect_active () with
     | Ok (Cascade_catalog_runtime.Validated snapshot) -> snapshot
@@ -223,7 +231,7 @@ let test_valid_catalog_skips_live_probes_at_bootstrap () =
              (Cascade_catalog_runtime.rejection_to_yojson rejection))
   in
   let snapshot_json = Cascade_catalog_runtime.snapshot_to_yojson snapshot in
-  check int "profile_count" 2 (json_int_field "profile_count" snapshot_json);
+  check int "profile_count" 4 (json_int_field "profile_count" snapshot_json);
   check bool "bootstrap probe status is skipped" true
     (contains_substring (Yojson.Safe.to_string snapshot_json) "\"status\":\"skipped\"");
   let blank_name =
@@ -232,6 +240,28 @@ let test_valid_catalog_skips_live_probes_at_bootstrap () =
   in
   check string "blank name defaults to big_three"
     Keeper_config.default_cascade_name blank_name;
+  let keeper_unified_name =
+    require_ok
+      (Cascade_catalog_runtime.resolve_declared_name
+         ~raw_name:"keeper_unified" ())
+  in
+  check string "keeper_unified resolves to catalog profile"
+    "keeper_unified" keeper_unified_name;
+  check (list string) "keeper_unified models use exact catalog profile"
+    [ keeper_unified_model ]
+    (require_ok
+       (Cascade_catalog_runtime.models_of_cascade_name "keeper_unified"));
+  let strict_name =
+    require_ok
+      (Cascade_catalog_runtime.resolve_declared_name
+         ~raw_name:"tool_use_strict" ())
+  in
+  check string "tool_use_strict resolves to catalog profile"
+    "tool_use_strict" strict_name;
+  check (list string) "tool_use_strict models use exact catalog profile"
+    [ strict_model ]
+    (require_ok
+       (Cascade_catalog_runtime.models_of_cascade_name "tool_use_strict"));
   match
     Cascade_catalog_runtime.resolve_declared_name ~raw_name:"missing_profile" ()
   with
@@ -411,7 +441,10 @@ let test_partial_catalog_keeps_validated_subset_available () =
                 "uses unregistered provider scheme")
            reasons
      | None -> false);
-  let config_json = Masc_mcp.Dashboard_cascade.config_json () in
+  let config_json =
+    with_eio @@ fun ~sw:_ ~net:_ ~clock:_ ~fs:_ ~proc_mgr:_ ->
+    Masc_mcp.Dashboard_cascade.config_json ()
+  in
   let profile_names =
     json_list_field "profiles" config_json
     |> List.map (json_string_field "name")

--- a/test/test_keeper_cascade_profile.ml
+++ b/test/test_keeper_cascade_profile.ml
@@ -2,9 +2,9 @@ open Alcotest
 
 module Profile = Masc_mcp.Keeper_cascade_profile
 
-(* Only the 4 SSOT variants round-trip through [of_string_opt] -> [to_string].
+(* Only the SSOT variants round-trip through [of_string_opt] -> [to_string].
    Legacy aliases collapse to Big_three; phase-routing names return None. *)
-let variant_names = [ "big_three"; "underdog"; "local"; "tool_rerank" ]
+let variant_names = [ "big_three"; "tool_rerank" ]
 
 let write_file path contents =
   let oc = open_out path in
@@ -47,11 +47,23 @@ let test_legacy_aliases_collapse_to_big_three () =
                   "tool_use_strict"; "resilient_breaker"; "" ] in
   List.iter
     (fun raw ->
-      let canon = Profile.canonicalize raw in
+      let canon = Profile.canonicalize_with_catalog ~catalog:[] raw in
       check string ("alias " ^ raw ^ " -> big_three") "big_three" canon)
     aliases
 
-let test_phase_routing_returns_none () =
+let test_catalog_routed_names_return_none () =
+  check (option (testable (fun fmt _ -> Format.fprintf fmt "<profile>") (=)))
+    "keeper_unified returns None"
+    None
+    (Profile.of_string_opt "keeper_unified");
+  check (option (testable (fun fmt _ -> Format.fprintf fmt "<profile>") (=)))
+    "tool_use_strict returns None"
+    None
+    (Profile.of_string_opt "tool_use_strict");
+  check (option (testable (fun fmt _ -> Format.fprintf fmt "<profile>") (=)))
+    "resilient_breaker returns None"
+    None
+    (Profile.of_string_opt "resilient_breaker");
   check (option (testable (fun fmt _ -> Format.fprintf fmt "<profile>") (=)))
     "local_only returns None"
     None
@@ -76,6 +88,8 @@ let test_catalog_names_follow_live_config () =
       {
         "default_models": ["ollama:auto"],
         "custom_live_models": ["ollama:auto"],
+        "keeper_unified_models": ["ollama:auto"],
+        "tool_use_strict_models": ["ollama:auto"],
         "tool_rerank_temperature": 0.0,
         "tool_rerank_max_tokens": 200,
         "tool_rerank_keeper_assignable": false,
@@ -86,10 +100,17 @@ let test_catalog_names_follow_live_config () =
     (fun path ->
       let catalog = Profile.catalog_names ~config_path:path () in
       check (list string) "catalog_names follows cascade schema keys"
-        [ "custom_live"; "default"; "governance_judge"; "tool_rerank" ]
+        [
+          "custom_live";
+          "default";
+          "governance_judge";
+          "keeper_unified";
+          "tool_rerank";
+          "tool_use_strict";
+        ]
         catalog;
       check (list string) "keeper catalog excludes system-only cascades"
-        [ "custom_live"; "default" ]
+        [ "custom_live"; "default"; "keeper_unified"; "tool_use_strict" ]
         (Profile.keeper_catalog_names ~config_path:path ());
       check (list string) "system catalog follows explicit metadata"
         [ "governance_judge"; "tool_rerank" ]
@@ -97,6 +118,12 @@ let test_catalog_names_follow_live_config () =
       check string "dynamic live profile survives canonicalization"
         "custom_live"
         (Profile.canonicalize_with_catalog ~catalog "custom_live");
+      check string "keeper_unified catalog profile survives canonicalization"
+        "keeper_unified"
+        (Profile.canonicalize_with_catalog ~catalog "keeper_unified");
+      check string "tool_use_strict catalog profile survives canonicalization"
+        "tool_use_strict"
+        (Profile.canonicalize_with_catalog ~catalog "tool_use_strict");
       check string "dynamic live profile requires exact match"
         "big_three"
         (Profile.canonicalize_with_catalog ~catalog "Custom_Live");
@@ -109,7 +136,9 @@ let test_resolve_live_with_catalog_requires_active_membership () =
     {|
       {
         "default_models": ["ollama:auto"],
-        "custom_live_models": ["ollama:auto"]
+        "custom_live_models": ["ollama:auto"],
+        "keeper_unified_models": ["ollama:auto"],
+        "tool_use_strict_models": ["ollama:auto"]
       }
     |}
     (fun path ->
@@ -117,6 +146,12 @@ let test_resolve_live_with_catalog_requires_active_membership () =
       check string "active custom profile survives live resolution"
         "custom_live"
         (Profile.resolve_live_with_catalog ~catalog "custom_live");
+      check string "keeper_unified catalog profile survives live resolution"
+        "keeper_unified"
+        (Profile.resolve_live_with_catalog ~catalog "keeper_unified");
+      check string "tool_use_strict catalog profile survives live resolution"
+        "tool_use_strict"
+        (Profile.resolve_live_with_catalog ~catalog "tool_use_strict");
       check string "legacy alias resolves through active default"
         "big_three"
         (Profile.resolve_live_with_catalog ~catalog "oas-keeper_unified");
@@ -145,7 +180,8 @@ let () =
         [ test_case "active names round-trip" `Quick test_round_trip;
           test_case "known_cascades covers active" `Quick test_known_cascades_covers_variants;
           test_case "legacy aliases collapse" `Quick test_legacy_aliases_collapse_to_big_three;
-          test_case "phase routing returns None" `Quick test_phase_routing_returns_none;
+          test_case "catalog-routed names return None" `Quick
+            test_catalog_routed_names_return_none;
           test_case "unknown falls back to default" `Quick test_unknown_falls_back_to_default;
           test_case "catalog_names follow live config" `Quick test_catalog_names_follow_live_config;
           test_case "resolve_live_with_catalog requires active membership" `Quick


### PR DESCRIPTION
## Summary
- Preserve catalog-routed keeper cascade names such as `keeper_unified`, `tool_use_strict`, and `resilient_breaker` instead of collapsing them to `big_three` before runtime lookup.
- Add regression coverage proving catalog-defined `keeper_unified` and `tool_use_strict` resolve to their exact profiles and model lists.
- Wrap the cascade dashboard config projection assertion in an Eio context so the focused runtime test can read cascade health state safely.

## Root Cause
`Keeper_cascade_profile.of_string_opt` treated `tool_use_strict` and `keeper_unified` as legacy aliases for `big_three`. Runtime lookup calls normalized names before consulting the active catalog, so a live catalog profile named `tool_use_strict` was silently resolved through `big_three`.

## Validation
- `./scripts/dune-local.sh build test/test_keeper_cascade_profile.exe test/test_cascade_catalog_runtime.exe`
- `./_build/default/test/test_keeper_cascade_profile.exe`
- `./_build/default/test/test_cascade_catalog_runtime.exe`