### PR TITLE
fix(keeper): map unmapped cascade state to unknown, not healthy (#9900)

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -139,7 +139,16 @@ let operator_disposition (receipt : t) =
     receipt.cascade_fallback_applied
     || String.equal cascade_outcome "passed_to_next_model"
   then ("pass_next_model", "cascade_fallback")
-  else ("pass", "healthy")
+  (* "healthy" requires an explicit success signal: turn completed without
+     error AND cascade reached the configured terminal. Any other fallthrough
+     is an unmapped state — surface it as "unknown" so a new cascade_outcome
+     or terminal_reason_code does not silently display as "healthy" on the
+     dashboard. See #9900 and CLAUDE.md anti-pattern #2. *)
+  else if
+    String.equal receipt.outcome "ok"
+    && String.equal cascade_outcome "completed"
+  then ("pass", "healthy")
+  else ("unknown", "unmapped_cascade_state")
 
 let to_json (receipt : t) =
   let operator_disposition, operator_disposition_reason =


### PR DESCRIPTION
## 요약

`operator_disposition`의 최종 fallthrough 브랜치가 모든 미분류 cascade 상태를 `("pass", "healthy")`로 매핑하여, 새로운 `cascade_outcome` 또는 `terminal_reason_code` 값이 추가될 때 dashboard에 조용히 "healthy"로 표시되는 드리프트를 야기할 수 있습니다. CLAUDE.md 안티패턴 #2 (**Unknown → Permissive Default**)의 직접 사례입니다.

Closes #9900.

## 변경 내용

`lib/keeper/keeper_execution_receipt.ml:142` — fallthrough 브랜치를 명시적 healthy 매치로 교체:

```diff
-  else ("pass", "healthy")
+  else if String.equal receipt.outcome "ok"
+          && String.equal cascade_outcome "completed"
+  then ("pass", "healthy")
+  else ("unknown", "unmapped_cascade_state")
```

**healthy 판정 기준**:
- `receipt.outcome = "ok"` — turn 결과가 Ok (`keeper_agent_run.ml:3072`에서 설정)
- `cascade_outcome = "completed"` — cascade가 정상 완료 (`keeper_unified_turn.ml:1903`에서 `Oas_worker.Completed`만 이 값을 생성)

두 조건 모두 참일 때만 healthy. 한쪽이라도 새 값으로 벗어나면 `"unknown" / "unmapped_cascade_state"`.

## 회귀 리스크

| 경로 | before | after | 비고 |
|------|--------|-------|------|
| Turn 정상 완료 (fixture: outcome=ok, cascade=completed) | ("pass", "healthy") | ("pass", "healthy") | unchanged |
| Cascade exhausted | ("alert_exhausted", "cascade_exhausted") | unchanged | 기존 분기 우선 |
| Tool required + 미실행 | ("pause_human", "tool_required_no_tools") | unchanged | 기존 분기 우선 |
| Preflight auth/config 에러 | ("pause_human", "preflight_config_error") | unchanged | 기존 분기 우선 |
| Degraded retry | ("fail_open_next_cascade", "degraded_retry") | unchanged | 기존 분기 우선 |
| Cascade fallback applied | ("pass_next_model", "cascade_fallback") | unchanged | 기존 분기 우선 |
| **미분류 신규 상태** | ("pass", "healthy") ❌ | ("unknown", "unmapped_cascade_state") ✅ | 본 PR 핵심 변경 |

## 테스트 영향

- `test/test_dashboard_goals.ml:271` — fixture의 `outcome="ok"` + `cascade_outcome="completed"`로 새 healthy 분기 매칭. 기존 assertion 유지, 별도 수정 불필요.
- `test/test_dashboard_execution.ml:683` — `"fail_open_next_cascade"` assertion. 기존 분기 우선으로 영향 없음.
- `test/test_operator_control_keeper.ml:1045` — capitalized `disposition` (pending_approvals 기반). 본 함수와 무관.

## Dashboard follow-up

Dashboard 프론트엔드는 현재 `operator_disposition = "unknown"`을 별도 톤으로 렌더링하지 않습니다. 중립 톤 (warn 또는 info) 렌더링은 별도 UI PR에서 처리. 본 PR은 서버 측 오분류만 수정합니다.

## 검증하지 못한 항목

- 실환경에서 "unknown" fallthrough가 실제로 얼마나 자주 발생하는지 telemetry 측정은 수행하지 않았습니다. 이론적으로는 known 6개 분기 중 어디에도 속하지 않는 receipt가 나타날 때만 활성화됩니다.

## 참고

- Issue #9894 — same family (`signalTone` default green, dashboard side)
- PR #9853 tick 6 review (finding A, 미해소된 채 머지됨)
- PR #9877 tick 6 cross-PR chain review (B 섹션)
- CLAUDE.md: AI 코드 생성 안티패턴 #2 (**Unknown → Permissive Default**)
