### PR TITLE
feat(dashboard): stream route-scoped websocket snapshots

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  fetchDashboardShell,
   fetchDashboardGovernance,
   fetchDashboardGoalDetail,
   fetchDashboardGoalsTree,
@@ -57,6 +58,27 @@ function makeRawGoalNode(overrides: Record<string, unknown> = {}) {
     ...overrides,
   }
 }
+
+describe('fetchDashboardShell', () => {
+  it('uses the light shell query when requested', async () => {
+    const rawResponse = {
+      status: { project: 'default' },
+      counts: { agents: 1, tasks: 2, keepers: 3 },
+    }
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchDashboardShell({ light: true })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/shell?light=true')
+  })
+})
 
 describe('fetchDashboardTools', () => {
   it('fills missing category and tier with defaults', async () => {

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -100,8 +100,13 @@ type AbortableRequestOptions = {
   signal?: AbortSignal
 }
 
-export function fetchDashboardShell(opts?: AbortableRequestOptions): Promise<DashboardShellResponse> {
-  return get('/api/v1/dashboard/shell', { signal: opts?.signal })
+type DashboardShellRequestOptions = AbortableRequestOptions & {
+  light?: boolean
+}
+
+export function fetchDashboardShell(opts?: DashboardShellRequestOptions): Promise<DashboardShellResponse> {
+  const qs = opts?.light ? '?light=true' : ''
+  return get(`/api/v1/dashboard/shell${qs}`, { signal: opts?.signal })
 }
 
 // --- System logs ---

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -3,6 +3,7 @@
 
 import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
+import { lazy, Suspense } from 'preact/compat'
 import { signal } from '@preact/signals'
 import { persistentSignal } from './lib/persistent-signal'
 import { route, initRouter } from './router'
@@ -14,10 +15,10 @@ import {
 } from './sse'
 import { requestNamespaceTruthNow, disposeNamespaceTruthScheduler } from './namespace-truth-store'
 import { cancelPendingSSERefreshes, registerMissionRefresh, setupSSEReaction, startPeriodicRefresh, stopPeriodicRefresh } from './sse-store'
-import { refreshForRoute } from './tab-refresh'
 import { refreshMissionSnapshot } from './mission-store'
 import { replayOasRuntimeTelemetry } from './oas-runtime-store'
 import { refreshShell } from './store'
+import { connectDashboardWS, disconnectDashboardWS, subscribeDashboardRoute } from './dashboard-ws'
 import { ensureDevToken } from './api/mcp'
 import {
   BuildIdentityBadge,
@@ -27,13 +28,13 @@ import {
   SideRail,
 } from './components/dashboard-shell'
 import { ThemeSwitch } from './components/theme-switch'
-import { AgentDetailOverlay } from './components/agent-detail'
-import { TaskDetailOverlay } from './components/goals/task-detail-overlay'
+import { selectedAgentName } from './components/agent-detail-selection'
+import { selectedTask } from './components/goals/task-detail-selection'
 import { ToastContainer } from './components/common/toast'
 import { ConfirmDialogOverlay } from './components/common/confirm-dialog'
 import { CommandPalette } from './components/common/command-palette'
 import { AuthStatus, RemoteWarningBanner } from './components/auth-status'
-import { startErrorCleanup, stopErrorCleanup } from './components/common/error-notification'
+import { startErrorCleanup, stopErrorCleanup } from './components/common/error-notification-state'
 import { DASHBOARD_NAV_ITEMS, currentSectionForRoute } from './config/navigation'
 import { Menu, X } from 'lucide-preact'
 
@@ -45,6 +46,23 @@ const sidebarCollapsed = persistentSignal<boolean>({
   defaultValue: false,
 })
 const mobileMenuOpen = signal(false)
+const LazyAgentDetailOverlay = lazy(async () => ({
+  default: (await import('./components/agent-detail')).AgentDetailOverlay,
+}))
+const LazyTaskDetailOverlay = lazy(async () => ({
+  default: (await import('./components/goals/task-detail-overlay')).TaskDetailOverlay,
+}))
+
+function refreshCurrentRoute(options?: { recordVisit?: boolean }): void {
+  const routeState = route.value
+  void import('./tab-refresh')
+    .then(({ refreshForRoute }) => {
+      refreshForRoute(routeState, options)
+    })
+    .catch(err => {
+      console.warn('[app] route refresh unavailable', err instanceof Error ? err.message : err)
+    })
+}
 
 export function App() {
   useEffect(() => {
@@ -55,7 +73,7 @@ export function App() {
 
     // Prime the lightweight shell status first so build/version metadata lands
     // while the project snapshot warms heavier execution/command projections.
-    void refreshShell()
+    void refreshShell({ light: true })
     requestNamespaceTruthNow()
 
     // Replay durable OAS state before opening the live SSE tail.
@@ -72,6 +90,7 @@ export function App() {
           })
           .finally(() => {
             if (cancelled) return
+            void connectDashboardWS(route.value)
             connectSSE()
             resumeQueuedOasRuntimeIngress()
           })
@@ -92,6 +111,7 @@ export function App() {
 
     return () => {
       cancelled = true
+      disconnectDashboardWS()
       disconnectSSE()
       unsubSSE()
       stopPeriodicRefresh()
@@ -104,8 +124,9 @@ export function App() {
     // Cancel any pending SSE-triggered refreshes from the previous tab
     // to prevent stale fetch results arriving after navigation (C-4/M-12).
     cancelPendingSSERefreshes()
-    refreshForRoute(route.value, { recordVisit: true })
-  }, [route.value.tab, route.value.params.section, route.value.params.q])
+    void subscribeDashboardRoute(route.value)
+    refreshCurrentRoute({ recordVisit: true })
+  }, [route.value.tab, route.value.params.section, route.value.params.view, route.value.params.q])
 
   const currentTab = route.value.tab
   const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === currentTab)
@@ -171,8 +192,12 @@ export function App() {
         </main>
       </div>
 
-      <${AgentDetailOverlay} />
-      <${TaskDetailOverlay} />
+      ${selectedAgentName.value
+        ? html`<${Suspense} fallback=${null}><${LazyAgentDetailOverlay} /><//>`
+        : null}
+      ${selectedTask.value
+        ? html`<${Suspense} fallback=${null}><${LazyTaskDetailOverlay} /><//>`
+        : null}
       <${ToastContainer} />
       <${ConfirmDialogOverlay} />
       <${CommandPalette} />

--- a/dashboard/src/components/agent-detail-selection.ts
+++ b/dashboard/src/components/agent-detail-selection.ts
@@ -1,0 +1,3 @@
+import { signal } from '@preact/signals'
+
+export const selectedAgentName = signal<string | null>(null)

--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -1,6 +1,7 @@
 // Agent detail shared state, selectors, data fetching, and utility functions
 
 import { signal } from '@preact/signals'
+import { selectedAgentName } from './agent-detail-selection'
 import { showToast } from './common/toast'
 import {
   agents,
@@ -26,10 +27,10 @@ export type TaskHistoryRow = {
   taskId: string
   text: string
 }
+export { selectedAgentName } from './agent-detail-selection'
 
 // --- Signals ---
 
-export const selectedAgentName = signal<string | null>(null)
 export const loading = signal(false)
 export const detailError = signal('')
 export const namespaceActivity = signal<string[]>([])
@@ -116,6 +117,19 @@ export function setKeeperRedirect(fn: (agentName: string) => boolean): void {
 
 export function openAgentDetail(agentName: string): void {
   if (_keeperRedirect && _keeperRedirect(agentName)) return
+  const keeper = keeperForAgent(agentName)
+  if (keeper) {
+    void import('./keeper-detail')
+      .then(({ openKeeperDetail }) => {
+        openKeeperDetail(keeper)
+      })
+      .catch(err => {
+        console.warn('[agent-detail] keeper redirect failed', err instanceof Error ? err.message : err)
+        selectedAgentName.value = agentName
+        void refreshAgentDetail()
+      })
+    return
+  }
   selectedAgentName.value = agentName
   void refreshAgentDetail()
 }

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -25,7 +25,7 @@ import {
   keeperPrimaryName,
 } from './common/keeper-identity'
 import { AgentAvatar } from './overview/agent-avatar'
-import { openAgentDetail } from './agent-detail'
+import { openAgentDetail } from './agent-detail-state'
 import { openKeeperDetail } from './keeper-detail'
 import { formatDuration, trimText } from './mission-utils'
 import { formatTokens } from '../lib/format-number'

--- a/dashboard/src/components/common/error-notification-state.ts
+++ b/dashboard/src/components/common/error-notification-state.ts
@@ -1,0 +1,43 @@
+import { signal, computed } from '@preact/signals'
+import type { DashboardError } from '../../types/error'
+
+const ACKNOWLEDGED_TTL_MS = 5 * 60 * 1000
+
+export const errors = signal<DashboardError[]>([])
+export const unacknowledgedErrors = computed(() =>
+  errors.value.filter(e => !e.acknowledged),
+)
+export const unacknowledgedCount = computed(() => unacknowledgedErrors.value.length)
+
+export function acknowledgeError(id: string): void {
+  errors.value = errors.value.map(e =>
+    e.id === id ? { ...e, acknowledged: true } : e,
+  )
+}
+
+export function clearAllErrors(): void {
+  errors.value = errors.value.map(e => ({ ...e, acknowledged: true }))
+}
+
+/** Periodic cleanup — remove acknowledged errors older than TTL. */
+let _cleanupTimer: ReturnType<typeof setInterval> | null = null
+
+export function startErrorCleanup(): void {
+  if (_cleanupTimer) return
+  _cleanupTimer = setInterval(() => {
+    const cutoff = Date.now() - ACKNOWLEDGED_TTL_MS
+    const remaining = errors.value.filter(
+      e => !e.acknowledged || e.lastSeen > cutoff,
+    )
+    if (remaining.length !== errors.value.length) {
+      errors.value = remaining
+    }
+  }, 60 * 1000)
+}
+
+export function stopErrorCleanup(): void {
+  if (_cleanupTimer) {
+    clearInterval(_cleanupTimer)
+    _cleanupTimer = null
+  }
+}

--- a/dashboard/src/components/common/error-notification.ts
+++ b/dashboard/src/components/common/error-notification.ts
@@ -1,19 +1,19 @@
-// Error notification signal — dedup, toast integration, acknowledgment
+// Error notification action handler — dedup + toast integration.
 
-import { signal, computed } from '@preact/signals'
 import { showToast } from './toast'
 import type { DashboardError, ErrorCode } from '../../types/error'
 import { classifyErrorCode, severityForCode } from '../../types/error'
+import {
+  errors,
+  unacknowledgedErrors,
+  unacknowledgedCount,
+  acknowledgeError,
+  clearAllErrors,
+  startErrorCleanup,
+  stopErrorCleanup,
+} from './error-notification-state'
 
 const DEDUP_WINDOW_MS = 5 * 60 * 1000 // 5 minutes
-const CLEANUP_INTERVAL_MS = 60 * 1000
-const ACKNOWLEDGED_TTL_MS = 5 * 60 * 1000
-
-export const errors = signal<DashboardError[]>([])
-export const unacknowledgedErrors = computed(() =>
-  errors.value.filter(e => !e.acknowledged),
-)
-export const unacknowledgedCount = computed(() => unacknowledgedErrors.value.length)
 
 let _nextId = 0
 
@@ -77,41 +77,18 @@ export function handleAgentFailed(params: {
   showToast(`${agentName}${taskLabel}: ${error}`, severity === 'info' ? 'warning' : 'error')
 }
 
-export function acknowledgeError(id: string): void {
-  errors.value = errors.value.map(e =>
-    e.id === id ? { ...e, acknowledged: true } : e,
-  )
-}
-
-export function clearAllErrors(): void {
-  errors.value = errors.value.map(e => ({ ...e, acknowledged: true }))
-}
-
-/** Periodic cleanup — remove acknowledged errors older than TTL. */
-let _cleanupTimer: ReturnType<typeof setInterval> | null = null
-
-export function startErrorCleanup(): void {
-  if (_cleanupTimer) return
-  _cleanupTimer = setInterval(() => {
-    const cutoff = Date.now() - ACKNOWLEDGED_TTL_MS
-    const remaining = errors.value.filter(
-      e => !e.acknowledged || e.lastSeen > cutoff,
-    )
-    if (remaining.length !== errors.value.length) {
-      errors.value = remaining
-    }
-  }, CLEANUP_INTERVAL_MS)
-}
-
-export function stopErrorCleanup(): void {
-  if (_cleanupTimer) {
-    clearInterval(_cleanupTimer)
-    _cleanupTimer = null
-  }
-}
-
 /** Test-only: reset error state. */
 export function _testResetErrors(): void {
   errors.value = []
   _nextId = 0
+}
+
+export {
+  errors,
+  unacknowledgedErrors,
+  unacknowledgedCount,
+  acknowledgeError,
+  clearAllErrors,
+  startErrorCleanup,
+  stopErrorCleanup,
 }

--- a/dashboard/src/components/common/error-panel.ts
+++ b/dashboard/src/components/common/error-panel.ts
@@ -6,7 +6,7 @@ import {
   unacknowledgedErrors,
   acknowledgeError,
   clearAllErrors,
-} from './error-notification'
+} from './error-notification-state'
 import type { ErrorCode, ErrorSeverity } from '../../types/error'
 import { formatElapsedCompact } from '../../lib/format-time'
 

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -23,7 +23,7 @@ import { ChevronRight, ChevronLeft } from 'lucide-preact'
 import { ScrollToTopButton } from './common/scroll-to-top'
 import { CopyIdButton } from './common/copy-id-button'
 import { formatElapsedCompact } from '../lib/format-time'
-import { unacknowledgedCount } from './common/error-notification'
+import { unacknowledgedCount } from './common/error-notification-state'
 import { ErrorPanel } from './common/error-panel'
 import { Bell } from 'lucide-preact'
 

--- a/dashboard/src/components/goals/task-detail-selection.ts
+++ b/dashboard/src/components/goals/task-detail-selection.ts
@@ -1,0 +1,4 @@
+import { signal } from '@preact/signals'
+import type { Task } from '../../types'
+
+export const selectedTask = signal<Task | null>(null)

--- a/dashboard/src/components/goals/task-detail-state.ts
+++ b/dashboard/src/components/goals/task-detail-state.ts
@@ -1,6 +1,7 @@
 // Task detail overlay state — signals, fetch, normalization
 
 import { signal } from '@preact/signals'
+import { selectedTask } from './task-detail-selection'
 import { fetchTaskEvents } from '../../api/actions'
 import { extractApiError } from '../../api/core'
 import { fetchAgentTimeline, fetchKeeperTrajectory } from '../../api/dashboard'
@@ -8,6 +9,7 @@ import { buildTraceEvents, type UnifiedTraceEvent } from '../session-trace/sessi
 import { findKeeper } from '../../lib/keeper-utils'
 import { goalById } from './goal-helpers'
 import type { Goal, Task } from '../../types'
+export { selectedTask } from './task-detail-selection'
 
 // -- Activity filter (owned here, consumed by task-activity-list) ---
 
@@ -127,7 +129,6 @@ export function filterGoalRelations(
 
 // -- Overlay signals ------------------------------------------------
 
-export const selectedTask = signal<Task | null>(null)
 export const taskEvents = signal<NormalizedTaskEvent[]>([])
 export const taskEventsLoading = signal(false)
 export const taskEventsError = signal<string | null>(null)

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -21,8 +21,9 @@ import {
 import { TimeAgo } from './common/time-ago'
 import type { Keeper } from '../types'
 import { invalidateDashboardCache, refreshDashboard } from '../store'
-import { selectKeeper } from '../keeper-runtime'
-import { keeperStatusDetails } from '../keeper-state'
+import { hydrateKeeperStatus, selectKeeper } from '../keeper-runtime'
+import { activeKeeperName, keeperStatusDetails } from '../keeper-state'
+import { registerKeeperTurnRefresh } from '../sse-store'
 import { findKeeper } from '../lib/keeper-utils'
 import {
   KeeperConversationPanel,
@@ -86,6 +87,18 @@ export {
 // ── Route state / fallback selection ──────────────────────
 
 export const selectedKeeper = signal<Keeper | null>(null)
+
+registerKeeperTurnRefresh((keeperName: string) => {
+  if (keeperName !== activeKeeperName.value) return
+  void hydrateKeeperStatus(keeperName, true)
+  void import('./keeper-trajectory-timeline')
+    .then(({ loadTrajectory }) => {
+      void loadTrajectory(keeperName)
+    })
+    .catch(err => {
+      console.debug('[keeper] trajectory refresh unavailable', err instanceof Error ? err.message : '')
+    })
+})
 
 function selectedKeeperMatches(keeperName: string): boolean {
   const selected = selectedKeeper.value

--- a/dashboard/src/components/live/focus-sidebar.ts
+++ b/dashboard/src/components/live/focus-sidebar.ts
@@ -2,7 +2,7 @@
 
 import { html } from 'htm/preact'
 import { focusAgents } from '../../live-store'
-import { openAgentDetail, selectedAgentName } from '../agent-detail'
+import { openAgentDetail, selectedAgentName } from '../agent-detail-state'
 import { TimeAgo } from '../common/time-ago'
 
 function pressureClass(pressure: 'calm' | 'normal' | 'hot'): string {

--- a/dashboard/src/components/live/pulse-strip.ts
+++ b/dashboard/src/components/live/pulse-strip.ts
@@ -2,7 +2,7 @@
 
 import { html } from 'htm/preact'
 import { agentPulses, type PulseState } from '../../live-store'
-import { openAgentDetail, selectedAgentName } from '../agent-detail'
+import { openAgentDetail, selectedAgentName } from '../agent-detail-state'
 
 function pulseStateClass(state: PulseState): string {
   switch (state) {

--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -57,7 +57,7 @@ async function loadPanel(
   fetchTelemetry: (opts?: { signal?: AbortSignal }) => Promise<TelemetryResponse>,
   fetchTelemetrySummary: (opts?: { signal?: AbortSignal }) => Promise<TelemetrySummaryResponse>,
   opts?: {
-    fetchDashboardShell?: (args?: { signal?: AbortSignal }) => Promise<unknown>
+    fetchDashboardShell?: (args?: { light?: boolean; signal?: AbortSignal }) => Promise<unknown>
     fetchDashboardTools?: (args?: { signal?: AbortSignal }) => Promise<unknown>
     fetchDashboardNamespaceTruth?: (args?: { signal?: AbortSignal }) => Promise<unknown>
   },

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -613,7 +613,7 @@ export function TelemetryUnified() {
           return null
         })
       const storePromise = Promise.all([
-        catchStoreFailure(fetchDashboardShell({ signal: controller.signal })),
+        catchStoreFailure(fetchDashboardShell({ light: true, signal: controller.signal })),
         catchStoreFailure(fetchDashboardTools({ signal: controller.signal })),
         catchStoreFailure(fetchDashboardNamespaceTruth({ signal: controller.signal })),
       ]).then(([shell, tools, truth]) => {

--- a/dashboard/src/dashboard-ws-state.ts
+++ b/dashboard/src/dashboard-ws-state.ts
@@ -1,0 +1,6 @@
+import { signal } from '@preact/signals'
+
+export const dashboardWsConnected = signal(false)
+export const dashboardWsReady = signal(false)
+export const dashboardWsLastError = signal<string | null>(null)
+export const dashboardWsLastSeq = signal(0)

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { dashboardSlicesForRoute } from './dashboard-ws'
+
+describe('dashboardSlicesForRoute', () => {
+  it('keeps global shell namespace and transport slices on every route', () => {
+    expect(dashboardSlicesForRoute({ tab: 'overview', params: {} })).toEqual([
+      'namespace',
+      'shell',
+      'transport',
+    ])
+  })
+
+  it('subscribes execution for execution-heavy monitoring and planning routes', () => {
+    expect(dashboardSlicesForRoute({ tab: 'workspace', params: { section: 'planning' } }))
+      .toContain('execution')
+    expect(dashboardSlicesForRoute({ tab: 'monitoring', params: { section: 'observatory' } }))
+      .toContain('execution')
+    expect(dashboardSlicesForRoute({
+      tab: 'monitoring',
+      params: { section: 'fleet-health', view: 'comparison' },
+    })).toContain('execution')
+  })
+
+  it('subscribes operator only for the active command surface', () => {
+    expect(dashboardSlicesForRoute({ tab: 'command', params: {} })).toContain('operator')
+    expect(dashboardSlicesForRoute({ tab: 'command', params: { view: 'inspector' } }))
+      .not.toContain('operator')
+  })
+})

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -1,0 +1,290 @@
+import type { RouteState, SSEEvent } from './types'
+import { parseSSEMessage } from './schemas/sse'
+import { hydrateDashboardSlice, hydrateServerPushEvent } from './sse-store'
+import {
+  dashboardWsConnected,
+  dashboardWsLastError,
+  dashboardWsLastSeq,
+  dashboardWsReady,
+} from './dashboard-ws-state'
+
+type JsonObject = Record<string, unknown>
+type PendingRpc = {
+  resolve: (value: unknown) => void
+  reject: (err: Error) => void
+}
+
+interface DashboardWsDiscovery {
+  enabled?: boolean
+  listening?: boolean
+  ws_url?: string
+}
+
+let socket: WebSocket | null = null
+let rpcId = 0
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+let reconnectAttempts = 0
+let lastSubscribeKey = ''
+let shouldReconnect = true
+const pending = new Map<number, PendingRpc>()
+
+function routeKey(routeState: Pick<RouteState, 'tab' | 'params'>): string {
+  const params = routeState.params
+  return [
+    routeState.tab,
+    params.section ?? '',
+    params.view ?? '',
+    params.q ?? '',
+  ].join(':')
+}
+
+export function dashboardSlicesForRoute(routeState: Pick<RouteState, 'tab' | 'params'>): string[] {
+  const slices = new Set(['shell', 'namespace', 'transport'])
+
+  if (routeState.tab === 'workspace' && routeState.params.section === 'planning') {
+    slices.add('execution')
+  }
+  if (routeState.tab === 'monitoring') {
+    const section = routeState.params.section
+    if (section === 'observatory' || section === 'journey' || section === 'agents') {
+      slices.add('execution')
+    }
+    if (section === 'fleet-health' && routeState.params.view === 'comparison') {
+      slices.add('execution')
+      slices.add('transport')
+    }
+  }
+  if (routeState.tab === 'command' && routeState.params.view !== 'inspector') {
+    slices.add('operator')
+  }
+
+  return Array.from(slices).sort()
+}
+
+function clearReconnectTimer(): void {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer)
+    reconnectTimer = null
+  }
+}
+
+function scheduleReconnect(): void {
+  if (!shouldReconnect) return
+  if (reconnectTimer) return
+  reconnectAttempts += 1
+  const delay = Math.min(15_000, 500 * Math.pow(2, Math.min(reconnectAttempts, 5)))
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null
+    void connectDashboardWS()
+  }, delay)
+}
+
+function closeSocket(): void {
+  if (socket) {
+    socket.onopen = null
+    socket.onclose = null
+    socket.onerror = null
+    socket.onmessage = null
+    socket.close()
+    socket = null
+  }
+  for (const { reject } of pending.values()) {
+    reject(new Error('dashboard websocket closed'))
+  }
+  pending.clear()
+}
+
+async function discoverWsUrl(): Promise<string | null> {
+  const response = await fetch('/ws', { credentials: 'same-origin' })
+  if (!response.ok) return null
+  const data = await response.json() as DashboardWsDiscovery
+  if (data.enabled !== true || data.listening !== true || typeof data.ws_url !== 'string') {
+    return null
+  }
+  return data.ws_url
+}
+
+function sendRpc(method: string, params: JsonObject): Promise<unknown> {
+  if (!socket || socket.readyState !== WebSocket.OPEN) {
+    return Promise.reject(new Error('dashboard websocket is not open'))
+  }
+  const id = ++rpcId
+  const payload = { jsonrpc: '2.0', id, method, params }
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject })
+    socket?.send(JSON.stringify(payload))
+  })
+}
+
+function handleRpcResponse(raw: JsonObject): boolean {
+  if (typeof raw.id !== 'number') return false
+  const pendingRpc = pending.get(raw.id)
+  if (!pendingRpc) return true
+  pending.delete(raw.id)
+  const error = raw.error as { message?: unknown } | undefined
+  if (error) {
+    pendingRpc.reject(new Error(typeof error.message === 'string' ? error.message : 'dashboard websocket rpc failed'))
+  } else {
+    pendingRpc.resolve(raw.result)
+  }
+  return true
+}
+
+function applySnapshot(raw: unknown): void {
+  const snapshot = raw as { slices?: unknown; seq?: unknown }
+  if (typeof snapshot.seq === 'number') {
+    dashboardWsLastSeq.value = snapshot.seq
+  }
+  const slices = snapshot.slices as Record<string, unknown> | undefined
+  if (!slices || typeof slices !== 'object') return
+  for (const [slice, payload] of Object.entries(slices)) {
+    hydrateDashboardSlice(slice, payload)
+  }
+}
+
+function applySubscribeResult(raw: unknown): void {
+  const result = raw as { snapshot?: unknown }
+  if (result.snapshot) applySnapshot(result.snapshot)
+}
+
+function applyDelta(raw: unknown): void {
+  const delta = raw as {
+    seq?: unknown
+    slice?: unknown
+    event_type?: unknown
+    payload?: unknown
+  }
+  if (typeof delta.seq === 'number') {
+    dashboardWsLastSeq.value = delta.seq
+    void sendRpc('dashboard/ack', {
+      seq: delta.seq,
+      bufferedAmount: socket?.bufferedAmount ?? 0,
+    }).catch(() => {})
+  }
+  if (typeof delta.slice !== 'string') return
+  hydrateDashboardSlice(
+    delta.slice,
+    delta.payload,
+    typeof delta.event_type === 'string' ? delta.event_type : undefined,
+  )
+}
+
+function handleNotification(raw: JsonObject): boolean {
+  if (raw.method === 'dashboard/delta') {
+    applyDelta(raw.params)
+    return true
+  }
+  if (raw.method === 'dashboard/snapshot') {
+    applySnapshot(raw.params)
+    return true
+  }
+  return false
+}
+
+function unwrapSseCandidate(raw: JsonObject): unknown {
+  const params = raw.params as { type?: unknown } | undefined
+  if (raw.jsonrpc && params?.type) return params
+  return raw
+}
+
+function handleRawPush(raw: unknown): void {
+  if (!raw || typeof raw !== 'object') return
+  const candidate = unwrapSseCandidate(raw as JsonObject)
+  const parsed = parseSSEMessage(candidate)
+  if (!parsed) return
+  hydrateServerPushEvent(parsed as unknown as SSEEvent)
+}
+
+function handleMessage(data: unknown): void {
+  if (typeof data !== 'string') return
+  let raw: unknown
+  try {
+    raw = JSON.parse(data)
+  } catch {
+    return
+  }
+  if (!raw || typeof raw !== 'object') return
+  const record = raw as JsonObject
+  if (handleRpcResponse(record)) return
+  if (handleNotification(record)) return
+  handleRawPush(record)
+}
+
+export async function subscribeDashboardRoute(routeState: Pick<RouteState, 'tab' | 'params'>): Promise<void> {
+  if (!dashboardWsReady.value) return
+  const slices = dashboardSlicesForRoute(routeState)
+  const key = `${routeKey(routeState)}|${slices.join(',')}`
+  if (key === lastSubscribeKey) return
+  lastSubscribeKey = key
+  const result = await sendRpc('dashboard/subscribe', {
+    route: routeKey(routeState),
+    slices,
+  })
+  applySubscribeResult(result)
+}
+
+export async function connectDashboardWS(routeState?: Pick<RouteState, 'tab' | 'params'>): Promise<void> {
+  if (typeof WebSocket === 'undefined') return
+  if (socket && (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING)) {
+    return
+  }
+
+  shouldReconnect = true
+  clearReconnectTimer()
+  const wsUrl = await discoverWsUrl().catch(err => {
+    dashboardWsLastError.value = err instanceof Error ? err.message : String(err)
+    return null
+  })
+  if (!wsUrl) return
+
+  closeSocket()
+  const ws = new WebSocket(wsUrl)
+  socket = ws
+  ws.onopen = () => {
+    if (socket !== ws) return
+    dashboardWsConnected.value = true
+    reconnectAttempts = 0
+    const token = sessionStorage.getItem('masc_bearer_token')
+    void sendRpc('dashboard/hello', {
+      protocol: 'dashboard-ws.v1',
+      token: token ?? undefined,
+      features: ['snapshot', 'delta', 'mode_snapshot'],
+    })
+      .then(() => {
+        dashboardWsReady.value = true
+        dashboardWsLastError.value = null
+        if (routeState) {
+          void subscribeDashboardRoute(routeState)
+        }
+      })
+      .catch(err => {
+        dashboardWsReady.value = false
+        dashboardWsLastError.value = err instanceof Error ? err.message : String(err)
+      })
+  }
+  ws.onmessage = (event) => {
+    if (socket !== ws) return
+    handleMessage(event.data)
+  }
+  ws.onerror = () => {
+    if (socket !== ws) return
+    dashboardWsLastError.value = 'dashboard websocket error'
+  }
+  ws.onclose = () => {
+    if (socket !== ws) return
+    dashboardWsConnected.value = false
+    dashboardWsReady.value = false
+    lastSubscribeKey = ''
+    socket = null
+    scheduleReconnect()
+  }
+}
+
+export function disconnectDashboardWS(): void {
+  shouldReconnect = false
+  clearReconnectTimer()
+  dashboardWsConnected.value = false
+  dashboardWsReady.value = false
+  lastSubscribeKey = ''
+  closeSocket()
+}

--- a/dashboard/src/operator-actions.ts
+++ b/dashboard/src/operator-actions.ts
@@ -192,6 +192,6 @@ export async function confirmOperatorPendingAction(
 }
 
 registerOperatorRefresh(() => {
-  void refreshOperatorSnapshot({ force: true })
-  void refreshOperatorRoomDigest({ force: true })
+  void refreshOperatorSnapshot()
+  void refreshOperatorRoomDigest()
 })

--- a/dashboard/src/refresh-scope.test.ts
+++ b/dashboard/src/refresh-scope.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { routeWantsRefreshTarget } from './refresh-scope'
+import type { RouteState } from './types'
+
+function route(tab: RouteState['tab'], params: Record<string, string> = {}): Pick<RouteState, 'tab' | 'params'> {
+  return { tab, params }
+}
+
+describe('routeWantsRefreshTarget', () => {
+  it('does not wake hidden heavy surfaces from the overview route', () => {
+    const current = route('overview')
+
+    expect(routeWantsRefreshTarget(current, 'execution')).toBe(false)
+    expect(routeWantsRefreshTarget(current, 'operator')).toBe(false)
+    expect(routeWantsRefreshTarget(current, 'board')).toBe(false)
+    expect(routeWantsRefreshTarget(current, 'activity')).toBe(false)
+  })
+
+  it('matches execution-backed routes without broadening fleet-health defaults', () => {
+    expect(routeWantsRefreshTarget(route('monitoring', { section: 'agents' }), 'execution')).toBe(true)
+    expect(routeWantsRefreshTarget(route('monitoring', { section: 'journey' }), 'execution')).toBe(true)
+    expect(routeWantsRefreshTarget(route('workspace', { section: 'planning' }), 'execution')).toBe(true)
+    expect(routeWantsRefreshTarget(route('monitoring', { section: 'fleet-health' }), 'execution')).toBe(false)
+    expect(routeWantsRefreshTarget(route('monitoring', { section: 'fleet-health', view: 'comparison' }), 'execution')).toBe(true)
+  })
+
+  it('keeps operator, board, and activity refreshes scoped to their visible surfaces', () => {
+    expect(routeWantsRefreshTarget(route('command'), 'operator')).toBe(true)
+    expect(routeWantsRefreshTarget(route('command', { view: 'inspector' }), 'operator')).toBe(false)
+    expect(routeWantsRefreshTarget(route('workspace', { section: 'board' }), 'board')).toBe(true)
+    expect(routeWantsRefreshTarget(route('monitoring', { section: 'observatory' }), 'activity')).toBe(true)
+    expect(routeWantsRefreshTarget(route('monitoring', { section: 'fleet-health' }), 'activity')).toBe(false)
+  })
+})

--- a/dashboard/src/refresh-scope.ts
+++ b/dashboard/src/refresh-scope.ts
@@ -1,0 +1,34 @@
+import type { RouteState } from './types'
+
+export type RouteRefreshTarget = 'execution' | 'board' | 'operator' | 'activity'
+
+export function routeWantsRefreshTarget(
+  routeState: Pick<RouteState, 'tab' | 'params'>,
+  target: RouteRefreshTarget,
+): boolean {
+  switch (target) {
+    case 'execution':
+      return routeWantsExecution(routeState)
+    case 'board':
+      return routeState.tab === 'workspace' && routeState.params.section === 'board'
+    case 'operator':
+      return routeState.tab === 'command' && routeState.params.view !== 'inspector'
+    case 'activity':
+      return routeState.tab === 'monitoring' && routeState.params.section === 'observatory'
+  }
+}
+
+function routeWantsExecution(routeState: Pick<RouteState, 'tab' | 'params'>): boolean {
+  if (routeState.tab === 'workspace') {
+    return routeState.params.section === 'planning'
+  }
+
+  if (routeState.tab !== 'monitoring') return false
+
+  const section = routeState.params.section
+  if (section === 'observatory' || section === 'journey' || section === 'agents') {
+    return true
+  }
+
+  return section === 'fleet-health' && routeState.params.view === 'comparison'
+}

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -1,10 +1,11 @@
 import { signal } from '@preact/signals'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RouteState } from './types'
 
 void vi
 
-const route = {
-  value: { tab: 'overview' as const, params: {}, postId: null },
+const route: { value: RouteState } = {
+  value: { tab: 'overview', params: {}, postId: null },
 }
 type CurrentRoute = typeof route.value
 
@@ -20,6 +21,7 @@ const refreshDashboard = vi.fn<() => Promise<void>>(async () => {})
 const refreshExecution = vi.fn<() => Promise<void>>(async () => {})
 const refreshBoard = vi.fn<() => void>(() => {})
 const invalidateDashboardCache = vi.fn<() => void>(() => {})
+const hydrateShellSnapshot = vi.fn<(payload: unknown) => void>(() => {})
 const hydrateExecutionSnapshot = vi.fn<(payload: unknown) => void>(() => {})
 const removeBoardPost = vi.fn<(postId?: string) => void>(() => {})
 const refreshForRoute = vi.fn<(nextRoute: CurrentRoute) => void>()
@@ -38,6 +40,7 @@ async function loadSseStore() {
   vi.doMock('./store', () => ({
     keeperHeartbeats,
     invalidateDashboardCache,
+    hydrateShellSnapshot,
     hydrateExecutionSnapshot,
     refreshDashboard,
     refreshExecution,
@@ -76,6 +79,7 @@ describe('setupSSEReaction reconnect hydration', () => {
     refreshExecution.mockClear()
     refreshBoard.mockClear()
     invalidateDashboardCache.mockClear()
+    hydrateShellSnapshot.mockClear()
     hydrateExecutionSnapshot.mockClear()
     removeBoardPost.mockClear()
     refreshForRoute.mockClear()
@@ -145,6 +149,69 @@ describe('setupSSEReaction reconnect hydration', () => {
       },
     })
     expect(requestNamespaceTruthNow).not.toHaveBeenCalled()
+
+    cleanup()
+  })
+
+  it('does not refresh hidden heavy surfaces for keeper lifecycle events on overview', async () => {
+    const { sseStore, sse } = await loadSseStore()
+    const refreshOperator = vi.fn()
+    sseStore.registerOperatorRefresh(refreshOperator)
+    route.value = { tab: 'overview', params: {}, postId: null }
+    const cleanup = sseStore.setupSSEReaction()
+
+    sse.lastEvent.value = {
+      type: 'keeper_phase_changed',
+      name: 'qa-king',
+      prev_phase: 'running',
+      new_phase: 'failing',
+    }
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(refreshExecution).not.toHaveBeenCalled()
+    expect(refreshOperator).not.toHaveBeenCalled()
+
+    cleanup()
+  })
+
+  it('routes execution SSE refreshes only when the current route needs execution data', async () => {
+    const { sseStore, sse } = await loadSseStore()
+    route.value = { tab: 'monitoring', params: { section: 'agents' }, postId: null }
+    const cleanup = sseStore.setupSSEReaction()
+
+    sse.lastEvent.value = {
+      type: 'keeper_phase_changed',
+      name: 'qa-king',
+      prev_phase: 'running',
+      new_phase: 'failing',
+    }
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(refreshExecution).toHaveBeenCalledTimes(1)
+    expect(refreshExecution).toHaveBeenCalledWith()
+
+    cleanup()
+  })
+
+  it('keeps operator lifecycle refreshes scoped to the command route', async () => {
+    const { sseStore, sse } = await loadSseStore()
+    const refreshOperator = vi.fn()
+    sseStore.registerOperatorRefresh(refreshOperator)
+    route.value = { tab: 'command', params: {}, postId: null }
+    const cleanup = sseStore.setupSSEReaction()
+
+    sse.lastEvent.value = {
+      type: 'keeper_turn_complete',
+      name: 'qa-king',
+      turn: 42,
+    }
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(refreshOperator).toHaveBeenCalledTimes(1)
+    expect(refreshExecution).not.toHaveBeenCalled()
 
     cleanup()
   })

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -13,10 +13,11 @@ import {
   pauseQueuedOasRuntimeIngress,
   resumeQueuedOasRuntimeIngress,
 } from './sse'
-import type { BoardPost, DashboardExecutionResponse, SSEEvent } from './types'
+import type { BoardPost, DashboardExecutionResponse, DashboardShellResponse, SSEEvent } from './types'
 import {
   keeperHeartbeats,
   invalidateDashboardCache,
+  hydrateShellSnapshot,
   hydrateExecutionSnapshot,
   refreshDashboard,
   refreshExecution,
@@ -37,12 +38,10 @@ import { mergeServerStatus } from './store-normalizers'
 import { normalizeOperatorSnapshot, normalizeOperatorDigest } from './operator-normalizers'
 import { operatorSnapshot, operatorRoomDigest } from './operator-signals'
 import { compositeTick } from './composite-signals'
-import { hydrateTransportHealthFromSSE } from './components/transport-health'
-import { activeKeeperName, hydrateKeeperStatus } from './keeper-runtime'
 import { showToast } from './components/common/toast'
-import { handleAgentFailed } from './components/common/error-notification'
 import type { ErrorCode } from './types/error'
 import { route } from './router'
+import { routeWantsRefreshTarget } from './refresh-scope'
 import {
   PERIODIC_REFRESH_DEV_MS,
   PERIODIC_REFRESH_PROD_MS,
@@ -69,6 +68,11 @@ export function registerOperatorRefresh(fn: () => void): void {
 let _refreshMissionFn: (() => void) | null = null
 export function registerMissionRefresh(fn: () => void): void {
   _refreshMissionFn = fn
+}
+
+let _keeperTurnRefreshFn: ((keeperName: string) => void) | null = null
+export function registerKeeperTurnRefresh(fn: (keeperName: string) => void): void {
+  _keeperTurnRefreshFn = fn
 }
 
 const _refreshActivityFns = new Set<() => void>()
@@ -137,12 +141,21 @@ const PREFIX_ROUTES: Array<{ prefix: string; target: RefreshTarget }> = [
 ]
 
 const REFRESH_FNS: Record<RefreshTarget, () => void> = {
-  execution: () => { void refreshExecution({ force: true }) },
+  execution: () => { void refreshExecution() },
   board:     refreshBoard,
   operator:  () => _refreshOperatorFn?.(),
   activity:  () => {
     for (const fn of _refreshActivityFns) fn()
   },
+}
+
+function scheduleTargetRefresh(
+  target: RefreshTarget,
+  fn: () => void,
+  delayMs?: number,
+): void {
+  if (!routeWantsRefreshTarget(route.value, target)) return
+  scheduleRefresh(target, fn, delayMs)
 }
 
 // --- Named handlers for complex events ---
@@ -201,11 +214,13 @@ function handleOperatorDigest(payload: unknown): void {
 }
 
 function handleTransportHealth(payload: unknown): void {
-  try {
-    hydrateTransportHealthFromSSE(payload)
-  } catch (err) {
-    console.debug('[SSE] transport health hydration failed', err instanceof Error ? err.message : '')
-  }
+  void import('./components/transport-health')
+    .then(({ hydrateTransportHealthFromSSE }) => {
+      hydrateTransportHealthFromSSE(payload)
+    })
+    .catch(err => {
+      console.debug('[SSE] transport health hydration failed', err instanceof Error ? err.message : '')
+    })
 }
 
 function handleKeeperHeartbeat(event: { name?: string; ts_unix?: number }): void {
@@ -219,21 +234,20 @@ function handleKeeperHeartbeat(event: { name?: string; ts_unix?: number }): void
 }
 
 function handleKeeperLifecycle(event: { type: string; name?: string }): void {
-  // All keeper lifecycle events trigger operator refresh
-  scheduleRefresh('operator', () => _refreshOperatorFn?.(), SSE_KEEPER_OPERATOR_DEBOUNCE_MS)
+  if (routeWantsRefreshTarget(route.value, 'operator')) {
+    scheduleRefresh('operator', () => _refreshOperatorFn?.(), SSE_KEEPER_OPERATOR_DEBOUNCE_MS)
+  }
 
   // keeper_turn_complete: re-hydrate active keeper's conversation + trajectory
   if (normalizeMascEventType(event.type) === 'keeper_turn_complete') {
     const keeperName = event.name ?? ''
-    const viewing = activeKeeperName.value
-    if (keeperName && keeperName === viewing) {
-      scheduleRefresh(`keeper_thread_${keeperName}`, () => {
-        void hydrateKeeperStatus(keeperName, true)
-      }, SSE_KEEPER_THREAD_DEBOUNCE_MS)
-      scheduleRefresh(`keeper_trajectory_${keeperName}`, async () => {
-        const { loadTrajectory } = await import('./components/keeper-trajectory-timeline')
-        void loadTrajectory(keeperName)
-      }, SSE_KEEPER_THREAD_DEBOUNCE_MS)
+    if (!keeperName) return
+    if (_keeperTurnRefreshFn) {
+      scheduleRefresh(
+        `keeper_thread_${keeperName}`,
+        () => _keeperTurnRefreshFn?.(keeperName),
+        SSE_KEEPER_THREAD_DEBOUNCE_MS,
+      )
     }
   }
 }
@@ -341,6 +355,109 @@ function handleBoardPostCreated(event: SSEEvent): boolean {
   return true
 }
 
+export function hydrateServerPushEvent(event: SSEEvent): boolean {
+  if ((event.type === 'project_snapshot' || event.type === 'namespace_truth_snapshot' || event.type === 'room_truth_snapshot') && event.payload) {
+    handleNamespaceTruthSnapshot(event.payload)
+    return true
+  }
+
+  if (event.type === 'execution_snapshot' && event.payload) {
+    handleExecutionSnapshot(event.payload)
+    return true
+  }
+
+  if (event.type === 'operator_snapshot' && event.payload) {
+    handleOperatorSnapshot(event.payload)
+    return true
+  }
+  if (event.type === 'operator_digest' && event.payload) {
+    handleOperatorDigest(event.payload)
+    return true
+  }
+  if (event.type === 'transport_health_snapshot' && event.payload) {
+    handleTransportHealth(event.payload)
+    return true
+  }
+
+  if (event.type === 'oas:agent_failed') {
+    const p = (event.payload ?? {}) as Record<string, unknown>
+    const rawCode = typeof p.error_code === 'string' ? p.error_code : undefined
+    void import('./components/common/error-notification')
+      .then(({ handleAgentFailed }) => {
+        handleAgentFailed({
+          agentName: typeof p.agent_name === 'string' ? p.agent_name
+            : event.agent_name ?? 'unknown',
+          taskId: typeof p.task_id === 'string' ? p.task_id : undefined,
+          errorCode: rawCode as ErrorCode | undefined,
+          error: typeof p.error === 'string' ? p.error
+            : event.error_text ?? '알 수 없는 오류',
+        })
+      })
+      .catch(err => {
+        console.debug('[SSE] agent-failed notification unavailable', err instanceof Error ? err.message : '')
+      })
+    return false
+  }
+
+  if (event.type === 'keeper_heartbeat') {
+    handleKeeperHeartbeat(event)
+    return true
+  }
+
+  if (event.type === 'keeper_composite_changed') {
+    const payload = event as unknown as { name?: string; ts_unix?: number }
+    const name = typeof payload.name === 'string' ? payload.name : ''
+    const ts_unix = typeof payload.ts_unix === 'number' ? payload.ts_unix : Date.now() / 1000
+    compositeTick.value = { name, ts_unix }
+    return true
+  }
+
+  if (event.type === 'post_created' && handleBoardPostCreated(event)) {
+    return true
+  }
+
+  return false
+}
+
+export function hydrateDashboardSlice(slice: string, payload: unknown, eventType?: string): void {
+  switch (eventType) {
+    case 'project_snapshot':
+    case 'namespace_truth_snapshot':
+    case 'room_truth_snapshot':
+    case 'execution_snapshot':
+    case 'operator_snapshot':
+    case 'operator_digest':
+    case 'transport_health_snapshot':
+      hydrateServerPushEvent({ type: eventType, payload } as SSEEvent)
+      return
+  }
+
+  switch (slice) {
+    case 'shell':
+      hydrateShellSnapshot(payload as DashboardShellResponse, { light: true })
+      return
+    case 'namespace':
+      hydrateServerPushEvent({ type: 'project_snapshot', payload } as SSEEvent)
+      return
+    case 'execution':
+      hydrateServerPushEvent({ type: 'execution_snapshot', payload } as SSEEvent)
+      return
+    case 'operator': {
+      const record = payload as { snapshot?: unknown; digest?: unknown }
+      if (record.snapshot) {
+        hydrateServerPushEvent({ type: 'operator_snapshot', payload: record.snapshot } as SSEEvent)
+      }
+      if (record.digest) {
+        hydrateServerPushEvent({ type: 'operator_digest', payload: record.digest } as SSEEvent)
+      }
+      return
+    }
+    case 'transport':
+      hydrateServerPushEvent({ type: 'transport_health_snapshot', payload } as SSEEvent)
+      return
+  }
+}
+
 // --- SSE reaction setup ---
 
 export function setupSSEReaction(): () => void {
@@ -354,73 +471,14 @@ export function setupSSEReaction(): () => void {
   const unsubscribe = lastEvent.subscribe((event) => {
     if (!event) return
 
-    // 0. Project snapshot — server push, no HTTP fetch needed
-    if ((event.type === 'project_snapshot' || event.type === 'namespace_truth_snapshot' || event.type === 'room_truth_snapshot') && event.payload) {
-      handleNamespaceTruthSnapshot(event.payload)
-      return
-    }
-
-    // 0b. Execution snapshot — server push, no HTTP fetch needed
-    if (event.type === 'execution_snapshot' && event.payload) {
-      handleExecutionSnapshot(event.payload)
-      return
-    }
-
-    // 0c. Operator/transport snapshots — server push, no HTTP fetch needed
-    if (event.type === 'operator_snapshot' && event.payload) {
-      handleOperatorSnapshot(event.payload)
-      return
-    }
-    if (event.type === 'operator_digest' && event.payload) {
-      handleOperatorDigest(event.payload)
-      return
-    }
-    if (event.type === 'transport_health_snapshot' && event.payload) {
-      handleTransportHealth(event.payload)
-      return
-    }
-
-    // 0d. Agent error notification — signal + toast, no fetch
-    if (event.type === 'oas:agent_failed') {
-      const p = (event.payload ?? {}) as Record<string, unknown>
-      const rawCode = typeof p.error_code === 'string' ? p.error_code : undefined
-      handleAgentFailed({
-        agentName: typeof p.agent_name === 'string' ? p.agent_name
-          : event.agent_name ?? 'unknown',
-        taskId: typeof p.task_id === 'string' ? p.task_id : undefined,
-        errorCode: rawCode as ErrorCode | undefined,
-        error: typeof p.error === 'string' ? p.error
-          : event.error_text ?? '알 수 없는 오류',
-      })
-    }
-
-    // 1. Keeper heartbeat — signal-only, zero network calls
-    if (event.type === 'keeper_heartbeat') {
-      handleKeeperHeartbeat(event)
-      return
-    }
-
-    // Composite lifecycle tick — signal-only; consumers (FSM Hub) re-fetch
-    // /composite themselves. Envelope carries {name, ts_unix} per RFC-0003.
-    if (event.type === 'keeper_composite_changed') {
-      const payload = event as unknown as { name?: string; ts_unix?: number }
-      const name = typeof payload.name === 'string' ? payload.name : ''
-      const ts_unix = typeof payload.ts_unix === 'number' ? payload.ts_unix : Date.now() / 1000
-      compositeTick.value = { name, ts_unix }
-      return
-    }
-
-    // 1b. Board post incremental hydration — when enriched payload is
-    // available and sort=recent, prepend directly and skip the full refresh.
-    if (event.type === 'post_created' && handleBoardPostCreated(event)) {
-      // Hydrated from SSE payload — no HTTP fetch needed.
+    if (hydrateServerPushEvent(event)) {
       return
     }
 
     // 2. Simple route: exact match
     const simpleRoute = SIMPLE_ROUTES[event.type]
     if (simpleRoute) {
-      scheduleRefresh(
+      scheduleTargetRefresh(
         simpleRoute.target,
         REFRESH_FNS[simpleRoute.target],
         simpleRoute.debounceMs,
@@ -430,7 +488,7 @@ export function setupSSEReaction(): () => void {
     // 4. Simple route: prefix match
     for (const { prefix, target } of PREFIX_ROUTES) {
       if (event.type.startsWith(prefix)) {
-        scheduleRefresh(target, REFRESH_FNS[target])
+        scheduleTargetRefresh(target, REFRESH_FNS[target])
         break
       }
     }

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -20,6 +20,7 @@ import type {
   DashboardRuntimeResolution,
   DashboardShellAuthSummary,
   DashboardShellMetaCognitionSummary,
+  DashboardShellResponse,
 } from './types'
 import {
   fetchDashboardExecution,
@@ -368,12 +369,14 @@ export const staleKeepers: ReadonlySignal<Set<string>> = computed(() => {
 
 interface RefreshOptions {
   force?: boolean
+  light?: boolean
 }
 
 // TTL values from config/constants.ts
 
 let inflightDashboardRefresh: Promise<void> | null = null
 let inflightShellRefresh: Promise<void> | null = null
+let inflightShellRefreshLight = false
 let lastShellRefreshAt = 0
 
 export function invalidateDashboardCache(): void {
@@ -452,37 +455,52 @@ function normalizeShellAuthSummary(raw: unknown): DashboardShellAuthSummary | nu
   }
 }
 
+export function hydrateShellSnapshot(data: DashboardShellResponse, opts?: { light?: boolean }): void {
+  const wantsLight = opts?.light === true
+  const normalizedAuth = normalizeShellAuthSummary(data.auth)
+  setCanonicalDashboardActor(
+    normalizedAuth?.token_valid
+      ? normalizedAuth.effective_agent ?? normalizedAuth.token_agent ?? null
+      : null,
+  )
+  const normalizedStatus = normalizeServerStatus(data.status, data.generated_at)
+  if (normalizedStatus) {
+    serverStatus.value = mergeServerStatus(serverStatus.value, normalizedStatus)
+  }
+  if (data.counts) {
+    shellCounts.value = {
+      agents: data.counts.agents ?? 0,
+      tasks: data.counts.tasks ?? 0,
+      keepers: data.counts.keepers ?? 0,
+      total_runtimes: data.counts.total_runtimes ?? ((data.counts.agents ?? 0) + (data.counts.keepers ?? 0)),
+      configured_keepers: data.configured_keepers ?? 0,
+    }
+  }
+  shellMetaCognition.value = normalizeShellMetaCognitionSummary(data.meta_cognition)
+  shellAuthSummary.value = normalizedAuth
+  const normalizedConfigResolution = normalizeDashboardConfigResolution(data.config_resolution)
+  const normalizedRuntimeResolution = normalizeDashboardRuntimeResolution(data.runtime_resolution)
+  if (!wantsLight || normalizedConfigResolution) {
+    shellConfigResolution.value = normalizedConfigResolution
+  }
+  if (!wantsLight || normalizedRuntimeResolution) {
+    shellRuntimeResolution.value = normalizedRuntimeResolution
+  }
+  lastShellRefreshAt = Date.now()
+}
+
 export async function refreshShell(opts?: RefreshOptions): Promise<void> {
-  if (inflightShellRefresh) return inflightShellRefresh
+  const wantsLight = opts?.light === true
+  if (inflightShellRefresh) {
+    if (wantsLight || !inflightShellRefreshLight) return inflightShellRefresh
+    await inflightShellRefresh
+  }
   if (!opts?.force && Date.now() - lastShellRefreshAt < SHELL_TTL_MS) return
+  inflightShellRefreshLight = wantsLight
   inflightShellRefresh = (async () => {
     try {
-      const data = await fetchDashboardShell()
-      const normalizedAuth = normalizeShellAuthSummary(data.auth)
-      setCanonicalDashboardActor(
-        normalizedAuth?.token_valid
-          ? normalizedAuth.effective_agent ?? normalizedAuth.token_agent ?? null
-          : null,
-      )
-      const normalizedStatus = normalizeServerStatus(data.status, data.generated_at)
-      if (normalizedStatus) {
-        serverStatus.value = mergeServerStatus(serverStatus.value, normalizedStatus)
-      }
-      // Extract lightweight counts for fast initial render (before execution loads)
-      if (data.counts) {
-        shellCounts.value = {
-          agents: data.counts.agents ?? 0,
-          tasks: data.counts.tasks ?? 0,
-          keepers: data.counts.keepers ?? 0,
-          total_runtimes: data.counts.total_runtimes ?? ((data.counts.agents ?? 0) + (data.counts.keepers ?? 0)),
-          configured_keepers: data.configured_keepers ?? 0,
-        }
-      }
-      shellMetaCognition.value = normalizeShellMetaCognitionSummary(data.meta_cognition)
-      shellAuthSummary.value = normalizedAuth
-      shellConfigResolution.value = normalizeDashboardConfigResolution(data.config_resolution)
-      shellRuntimeResolution.value = normalizeDashboardRuntimeResolution(data.runtime_resolution)
-      lastShellRefreshAt = Date.now()
+      const data = await fetchDashboardShell({ light: wantsLight })
+      hydrateShellSnapshot(data, { light: wantsLight })
     } catch (err) {
       setCanonicalDashboardActor(null)
       shellAuthSummary.value = null
@@ -490,6 +508,7 @@ export async function refreshShell(opts?: RefreshOptions): Promise<void> {
       showToast('서버 연결 실패 — 데이터를 불러올 수 없습니다', 'error', 6000)
     } finally {
       inflightShellRefresh = null
+      inflightShellRefreshLight = false
     }
   })()
   return inflightShellRefresh

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -145,7 +145,7 @@ describe('refreshPlanForRoute', () => {
       params: {},
     })
 
-    expect(refreshShell).toHaveBeenCalledWith()
+    expect(refreshShell).toHaveBeenCalledWith({ light: true })
   })
 
   it('uses the scheduler-backed execution refresh path on monitoring navigation', () => {

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -113,7 +113,7 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
 const REFRESHERS: Record<RefreshTask, (routeState: Pick<RouteState, 'tab' | 'params'>) => void> = {
   // Route visits should reuse the existing shell TTL instead of forcing a
   // fresh projection on every navigation.
-  shell: () => { void refreshShell() },
+  shell: () => { void refreshShell({ light: true }) },
   namespaceTruth: () => { requestNamespaceTruth() },
   missionSnapshot: () => { void refreshMissionSnapshot() },
   // Execution already has a fetch scheduler; route refreshes should enqueue

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig(({ command }) => {
             '/api': proxyTarget,
             '/mcp': { target: proxyTarget },
             '/sse': { target: proxyTarget },
+            '/ws': { target: proxyTarget },
           },
         }
       : undefined,

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -378,6 +378,85 @@ let handle_resources_unsubscribe_eio id ?mcp_session_id params =
   | Some _, None -> make_error ~id (-32602) "Missing params"
   | Some _, Some _ -> make_error ~id (-32602) "Invalid params: expected object"
 
+let optional_string_member key fields =
+  match List.assoc_opt key fields with
+  | Some (`String value) ->
+      let trimmed = String.trim value in
+      if trimmed = "" then None else Some trimmed
+  | Some `Null | None -> None
+  | Some _ -> None
+
+let string_list_member key fields =
+  match List.assoc_opt key fields with
+  | Some (`List values) ->
+      values
+      |> List.filter_map (function
+        | `String value ->
+            let trimmed = String.trim value in
+            if trimmed = "" then None else Some trimmed
+        | _ -> None)
+  | _ -> []
+
+let dashboard_response_or_error id = function
+  | Ok result -> make_response ~id result
+  | Error msg -> make_error ~id (-32600) msg
+
+let handle_dashboard_hello_eio state id ?mcp_session_id params =
+  match (mcp_session_id, params) with
+  | None, _ -> make_error ~id (-32600) "dashboard/hello requires a WebSocket session"
+  | Some session_id, Some (`Assoc fields) ->
+      let token = optional_string_member "token" fields in
+      Server_mcp_transport_ws.dashboard_hello
+        ~base_path:state.Mcp_server.room_config.base_path ~session_id ?token ()
+      |> dashboard_response_or_error id
+  | Some _, None -> make_error ~id (-32602) "Missing params"
+  | Some _, Some _ -> make_error ~id (-32602) "Invalid params: expected object"
+
+let handle_dashboard_subscribe_eio state id ?mcp_session_id params =
+  match (mcp_session_id, params) with
+  | None, _ ->
+      make_error ~id (-32600) "dashboard/subscribe requires a WebSocket session"
+  | Some session_id, Some (`Assoc fields) ->
+      let route = optional_string_member "route" fields in
+      let slices = string_list_member "slices" fields in
+      let slices =
+        if slices = [] then [ "shell"; "namespace"; "transport" ] else slices
+      in
+      ignore state;
+      Server_mcp_transport_ws.dashboard_subscribe ~session_id ?route ~slices ()
+      |> dashboard_response_or_error id
+  | Some _, None -> make_error ~id (-32602) "Missing params"
+  | Some _, Some _ -> make_error ~id (-32602) "Invalid params: expected object"
+
+let handle_dashboard_unsubscribe_eio id ?mcp_session_id params =
+  match (mcp_session_id, params) with
+  | None, _ ->
+      make_error ~id (-32600) "dashboard/unsubscribe requires a WebSocket session"
+  | Some session_id, Some (`Assoc fields) ->
+      let slices = string_list_member "slices" fields in
+      let slices_opt = if slices = [] then None else Some slices in
+      Server_mcp_transport_ws.dashboard_unsubscribe ~session_id ?slices:slices_opt
+        ()
+      |> dashboard_response_or_error id
+  | Some session_id, None ->
+      Server_mcp_transport_ws.dashboard_unsubscribe ~session_id ()
+      |> dashboard_response_or_error id
+  | Some _, Some _ -> make_error ~id (-32602) "Invalid params: expected object"
+
+let handle_dashboard_ack_eio id ?mcp_session_id params =
+  match (mcp_session_id, params) with
+  | None, _ -> make_error ~id (-32600) "dashboard/ack requires a WebSocket session"
+  | Some session_id, Some (`Assoc fields) ->
+      let seq =
+        match List.assoc_opt "seq" fields with
+        | Some (`Int n) -> n
+        | _ -> 0
+      in
+      Server_mcp_transport_ws.dashboard_ack ~session_id ~seq
+      |> dashboard_response_or_error id
+  | Some _, None -> make_error ~id (-32602) "Missing params"
+  | Some _, Some _ -> make_error ~id (-32602) "Invalid params: expected object"
+
 let contains_casefold = Mcp_server_eio_call_tool.contains_casefold
 
 let tool_call_outcome (json : Yojson.Safe.t) =
@@ -487,6 +566,17 @@ let handle_request
                        handle_resources_subscribe_eio id ?mcp_session_id req.params
                    | "resources/unsubscribe" ->
                        handle_resources_unsubscribe_eio id ?mcp_session_id req.params
+                   | "dashboard/hello" ->
+                       handle_dashboard_hello_eio state id ?mcp_session_id
+                         req.params
+                   | "dashboard/subscribe" ->
+                       handle_dashboard_subscribe_eio state id ?mcp_session_id
+                         req.params
+                   | "dashboard/unsubscribe" ->
+                       handle_dashboard_unsubscribe_eio id ?mcp_session_id
+                         req.params
+                   | "dashboard/ack" ->
+                       handle_dashboard_ack_eio id ?mcp_session_id req.params
                    | "prompts/list" -> (
                        match TP.parse_cursor_only_params req.params with
                        | Error msg -> make_error ~id (-32602) msg

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -808,10 +808,11 @@ let meta_cognition_summary_empty_json =
 let dashboard_shell_cache_prefix (config : Coord.config) =
   Printf.sprintf "shell:coord=%s:" config.base_path
 
-let dashboard_shell_cache_key (config : Coord.config) =
-  Printf.sprintf "%sworkspace=%s"
+let dashboard_shell_cache_key ?(light = false) (config : Coord.config) =
+  Printf.sprintf "%sworkspace=%s:mode=%s"
     (dashboard_shell_cache_prefix config)
     config.workspace_path
+    (if light then "light" else "full")
 
 let meta_cognition_summary_key (config : Coord.config) =
   dashboard_cache_key config "meta_cognition_summary" "dashboard_shell"
@@ -951,7 +952,7 @@ let is_dashboard_cache_timeout_json = function
       | _ -> false)
   | _ -> false
 
-let dashboard_shell_payload_json (config : Coord.config) : Yojson.Safe.t =
+let dashboard_shell_payload_json ?(light = false) (config : Coord.config) : Yojson.Safe.t =
   let cluster = Env_config_core.cluster_name () in
   let started_at = Unix.gettimeofday () in
   let measure_ms f =
@@ -984,21 +985,26 @@ let dashboard_shell_payload_json (config : Coord.config) : Yojson.Safe.t =
   let meta_cognition_r = ref (`Null, 0) in
   let config_resolution_r = ref (`Null, 0) in
   let runtime_resolution_r = ref (`Null, 0) in
-  Eio.Fiber.all
-    [
-      (fun () ->
-        meta_cognition_r :=
-          measure_json_projection "meta_cognition" (fun () ->
-              meta_cognition_summary_cached config));
-      (fun () ->
-        config_resolution_r :=
-          measure_json_projection "config_resolution" (fun () ->
-              Config_dir_resolver.(resolve () |> to_json)));
-      (fun () ->
-        runtime_resolution_r :=
-          measure_json_projection "runtime_resolution" (fun () ->
-              Server_dashboard_http_runtime_info.runtime_resolution_json config));
-    ];
+  if light then
+    meta_cognition_r :=
+      measure_json_projection "meta_cognition" (fun () ->
+          meta_cognition_summary_cached config)
+  else
+    Eio.Fiber.all
+      [
+        (fun () ->
+          meta_cognition_r :=
+            measure_json_projection "meta_cognition" (fun () ->
+                meta_cognition_summary_cached config));
+        (fun () ->
+          config_resolution_r :=
+            measure_json_projection "config_resolution" (fun () ->
+                Config_dir_resolver.(resolve () |> to_json)));
+        (fun () ->
+          runtime_resolution_r :=
+            measure_json_projection "runtime_resolution" (fun () ->
+                Server_dashboard_http_runtime_info.runtime_resolution_json config));
+      ];
   let meta_cognition_json, meta_cognition_ms = !meta_cognition_r in
   let config_resolution_json, config_resolution_ms = !config_resolution_r in
   let runtime_resolution_json, runtime_resolution_ms = !runtime_resolution_r in
@@ -1037,6 +1043,7 @@ let dashboard_shell_payload_json (config : Coord.config) : Yojson.Safe.t =
            ("meta_cognition_ms", `Int meta_cognition_ms);
            ("config_resolution_ms", `Int config_resolution_ms);
            ("runtime_resolution_ms", `Int runtime_resolution_ms);
+           ("light", `Bool light);
          ]
 
 let dashboard_shell_auth_json ~(request : Httpun.Request.t) (config : Coord.config) :
@@ -1186,12 +1193,12 @@ let dashboard_shell_auth_json ~(request : Httpun.Request.t) (config : Coord.conf
       ("keeper_msg_error", Json_util.string_opt_to_json keeper_msg_error);
     ]
 
-let dashboard_shell_http_json ?clock ?request (config : Coord.config) : Yojson.Safe.t =
-  let cache_key = dashboard_shell_cache_key config in
+let dashboard_shell_http_json ?clock ?request ?(light = false) (config : Coord.config) : Yojson.Safe.t =
+  let cache_key = dashboard_shell_cache_key ~light config in
   let compute () =
     (* Shell endpoint is read-only; use config directly without isolation
        since state is not available in this context. *)
-    dashboard_shell_payload_json config
+    dashboard_shell_payload_json ~light config
   in
   let clock_opt =
     match clock with

--- a/lib/server/server_dashboard_http_core.mli
+++ b/lib/server/server_dashboard_http_core.mli
@@ -146,10 +146,17 @@ val provider_capacity_json : unit -> Yojson.Safe.t
 val dashboard_shell_http_json :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   ?request:Httpun.Request.t ->
+  ?light:bool ->
   Coord.config ->
   Yojson.Safe.t
 
+val dashboard_shell_cache_key :
+  ?light:bool ->
+  Coord.config ->
+  string
+
 val dashboard_shell_payload_json :
+  ?light:bool ->
   Coord.config -> Yojson.Safe.t
 
 val is_dashboard_cache_timeout_json :

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -13,11 +13,7 @@ let warm_shell_cache (state : Mcp_server.server_state) =
     (fun () ->
       let t0 = Time_compat.now () in
       (try
-         let cache_key =
-           Printf.sprintf "shell:coord=%s:workspace=%s"
-             state.Mcp_server.room_config.base_path
-             state.Mcp_server.room_config.workspace_path
-         in
+         let cache_key = dashboard_shell_cache_key state.Mcp_server.room_config in
          let compute () =
            dashboard_shell_payload_json state.Mcp_server.room_config
          in
@@ -136,6 +132,12 @@ let _transport_health_cache =
           `String "Transport health data is warming up. Refresh in a few seconds."
         );
       ])
+
+let dashboard_execution_snapshot_json () =
+  cached_surface_json _execution_cache
+
+let dashboard_transport_health_snapshot_json () =
+  cached_surface_json _transport_health_cache
 
 (* Issue #8396: cache patchers used to recognise only 7 lifecycle event
    names while [Keeper_lifecycle_events.all_event_names] now publishes

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -520,9 +520,12 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
 
       | `GET, "/api/v1/dashboard/shell" ->
           let state = get_server_state () in
+          let light =
+            Server_utils.bool_query_param httpun_request "light" ~default:false
+          in
           let json =
             dashboard_shell_http_json ?clock:state.Mcp_server.clock
-              ~request:httpun_request
+              ~request:httpun_request ~light
               state.Mcp_server.room_config
           in
           h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -22,6 +22,12 @@ type ws_session = {
   id: string;
   wsd: Httpun_ws.Wsd.t;
   mutable closed: bool;
+  mutable dashboard_authenticated: bool;
+  mutable dashboard_agent: string option;
+  mutable dashboard_route: string option;
+  dashboard_slices: (string, unit) Hashtbl.t;
+  mutable dashboard_seq: int;
+  mutable inbound_partial_text: Buffer.t option;
 }
 
 (** Registry of active WebSocket sessions. *)
@@ -39,6 +45,19 @@ let next_id =
 
 let log_ws_delivery_dropped ~context session_id =
   Log.Transport.warn "WS %s not delivered for session=%s" context session_id
+
+let new_session ~id ~wsd =
+  {
+    id;
+    wsd;
+    closed = false;
+    dashboard_authenticated = false;
+    dashboard_agent = None;
+    dashboard_route = None;
+    dashboard_slices = Hashtbl.create 8;
+    dashboard_seq = 0;
+    inbound_partial_text = None;
+  }
 
 (** Send a text frame to a WebSocket client. *)
 let send_text session text =
@@ -65,21 +84,313 @@ let send_text_checked ~context session text =
   if not sent then log_ws_delivery_dropped ~context session.id;
   sent
 
+let send_json_checked ~context session json =
+  send_text_checked ~context session (Yojson.Safe.to_string json)
+
+let jsonrpc_notification method_ params =
+  `Assoc
+    [
+      ("jsonrpc", `String "2.0");
+      ("method", `String method_);
+      ("params", params);
+    ]
+
+let next_dashboard_seq session =
+  session.dashboard_seq <- session.dashboard_seq + 1;
+  session.dashboard_seq
+
+let valid_dashboard_slice = function
+  | "shell"
+  | "execution"
+  | "operator"
+  | "transport"
+  | "namespace"
+  | "composite"
+  | "board"
+  | "goals" ->
+      true
+  | _ -> false
+
+let dashboard_slice_for_sse_type = function
+  | "project_snapshot" | "namespace_truth_snapshot" | "room_truth_snapshot" ->
+      Some "namespace"
+  | "execution_snapshot" ->
+      Some "execution"
+  | "operator_snapshot" | "operator_digest" ->
+      Some "operator"
+  | "transport_health_snapshot" ->
+      Some "transport"
+  | _ -> None
+
+let dashboard_session_result session =
+  let slices =
+    Hashtbl.fold (fun slice () acc -> `String slice :: acc)
+      session.dashboard_slices []
+    |> List.sort compare
+  in
+  `Assoc
+    [
+      ("protocol", `String "dashboard-ws.v1");
+      ("session_id", `String session.id);
+      ("authenticated", `Bool session.dashboard_authenticated);
+      ( "agent",
+        match session.dashboard_agent with
+        | Some agent -> `String agent
+        | None -> `Null );
+      ( "route",
+        match session.dashboard_route with
+        | Some route -> `String route
+        | None -> `Null );
+      ("slices", `List slices);
+      ("seq", `Int session.dashboard_seq);
+    ]
+
+let find_session session_id =
+  with_sessions_rw (fun () -> Hashtbl.find_opt sessions session_id)
+
+let dashboard_snapshot_provider : (string -> Yojson.Safe.t option) ref =
+  ref (fun _slice -> None)
+
+let set_dashboard_snapshot_provider provider =
+  dashboard_snapshot_provider := provider
+
+let dashboard_auth_success_payload session =
+  `Assoc
+    [
+      ("protocol", `String "dashboard-ws.v1");
+      ("session", dashboard_session_result session);
+      ( "capabilities",
+        `Assoc
+          [
+            ("snapshot", `Bool true);
+            ("delta", `Bool true);
+            ("mode_snapshot", `Bool true);
+          ] );
+    ]
+
+let verify_dashboard_token ~base_path token =
+  let auth_cfg = Auth.load_auth_config base_path in
+  if not auth_cfg.Types.enabled then
+    Ok None
+  else
+    match token with
+    | None when not auth_cfg.require_token ->
+        (match Auth.check_permission base_path ~agent_name:"dashboard"
+                 ~token:None ~permission:Types.CanReadState with
+         | Ok () -> Ok None
+         | Error err -> Error (Types.masc_error_to_string err))
+    | None ->
+        Error "dashboard/hello requires a bearer token"
+    | Some raw_token -> (
+        match Auth.find_credential_by_token base_path ~token:raw_token with
+        | Error err -> Error (Types.masc_error_to_string err)
+        | Ok cred -> (
+            match
+              Auth.check_permission base_path ~agent_name:cred.Types.agent_name
+                ~token:(Some raw_token) ~permission:Types.CanReadState
+            with
+            | Ok () -> Ok (Some cred.Types.agent_name)
+            | Error err -> Error (Types.masc_error_to_string err)))
+
+let dashboard_hello ~base_path ~session_id ?token () =
+  match find_session session_id with
+  | None -> Error "WebSocket session not found"
+  | Some session -> (
+      match verify_dashboard_token ~base_path token with
+      | Error msg -> Error msg
+      | Ok agent ->
+          session.dashboard_authenticated <- true;
+          session.dashboard_agent <- agent;
+          Ok (dashboard_auth_success_payload session))
+
+let dashboard_snapshot session =
+  let slices =
+    Hashtbl.fold
+      (fun slice () acc ->
+        match !dashboard_snapshot_provider slice with
+        | Some json -> (slice, json) :: acc
+        | None -> acc)
+      session.dashboard_slices []
+    |> List.sort (fun (a, _) (b, _) -> compare a b)
+    |> List.map (fun (slice, json) -> (slice, json))
+  in
+  `Assoc
+    [
+      ("protocol", `String "dashboard-ws.v1");
+      ("seq", `Int (next_dashboard_seq session));
+      ( "route",
+        match session.dashboard_route with
+        | Some route -> `String route
+        | None -> `Null );
+      ("slices", `Assoc slices);
+    ]
+
+let dashboard_subscribe ~session_id ?route ~slices () =
+  match find_session session_id with
+  | None -> Error "WebSocket session not found"
+  | Some session ->
+      if not session.dashboard_authenticated then
+        Error "dashboard/subscribe requires dashboard/hello first"
+      else begin
+        let invalid =
+          List.filter (fun slice -> not (valid_dashboard_slice slice)) slices
+        in
+        match invalid with
+        | bad :: _ ->
+            Error (Printf.sprintf "unsupported dashboard slice: %s" bad)
+        | [] ->
+            Hashtbl.clear session.dashboard_slices;
+            List.iter
+              (fun slice -> Hashtbl.replace session.dashboard_slices slice ())
+              slices;
+            session.dashboard_route <- route;
+            Ok
+              (`Assoc
+                [
+                  ("session", dashboard_session_result session);
+                  ("snapshot", dashboard_snapshot session);
+                ])
+      end
+
+let dashboard_unsubscribe ~session_id ?slices () =
+  match find_session session_id with
+  | None -> Error "WebSocket session not found"
+  | Some session ->
+      if not session.dashboard_authenticated then
+        Error "dashboard/unsubscribe requires dashboard/hello first"
+      else begin
+        (match slices with
+         | None -> Hashtbl.clear session.dashboard_slices
+         | Some slices ->
+             List.iter (fun slice -> Hashtbl.remove session.dashboard_slices slice)
+               slices);
+        Ok (`Assoc [ ("session", dashboard_session_result session) ])
+      end
+
+let dashboard_ack ~session_id ~seq =
+  match find_session session_id with
+  | None -> Error "WebSocket session not found"
+  | Some session ->
+      if not session.dashboard_authenticated then
+        Error "dashboard/ack requires dashboard/hello first"
+      else
+        Ok
+          (`Assoc
+            [
+              ("session_id", `String session.id);
+              ("ack", `Int seq);
+            ])
+
+let dashboard_delta_for_sse session sse_event =
+  match Yojson.Safe.from_string sse_event with
+  | exception _ -> None
+  | `Assoc fields as event_json -> (
+      match List.assoc_opt "type" fields with
+      | Some (`String event_type) -> (
+          match dashboard_slice_for_sse_type event_type with
+          | Some slice when Hashtbl.mem session.dashboard_slices slice ->
+              let payload =
+                match List.assoc_opt "payload" fields with
+                | Some payload -> payload
+                | None -> event_json
+              in
+              Some
+                (jsonrpc_notification "dashboard/delta"
+                   (`Assoc
+                     [
+                       ("protocol", `String "dashboard-ws.v1");
+                       ("seq", `Int (next_dashboard_seq session));
+                       ("slice", `String slice);
+                       ("event_type", `String event_type);
+                       ("mode", `String "snapshot");
+                       ("payload", payload);
+                       ("ts_unix", `Float (Time_compat.now ()));
+                     ]))
+          | _ -> None)
+      | _ -> None)
+  | _ -> None
+
+let send_dashboard_or_raw_sse session sse_event =
+  if session.dashboard_authenticated then
+    match dashboard_delta_for_sse session sse_event with
+    | Some delta ->
+        send_json_checked ~context:"dashboard-delta" session delta
+    | None ->
+        send_text_checked ~context:"sse-forward" session sse_event
+  else
+    send_text_checked ~context:"sse-forward" session sse_event
+
+let read_payload_string payload ~len ~on_complete =
+  let buffer = Bytes.create len in
+  let offset = ref 0 in
+  let completed = ref false in
+  let complete () =
+    if not !completed then begin
+      completed := true;
+      let text =
+        if !offset = len then Bytes.unsafe_to_string buffer
+        else Bytes.sub_string buffer 0 !offset
+      in
+      on_complete text
+    end
+  in
+  let rec schedule () =
+    if !completed then ()
+    else if !offset >= len then complete ()
+    else
+      Httpun_ws.Payload.schedule_read payload
+        ~on_eof:complete
+        ~on_read:(fun bs ~off ~len:chunk_len ->
+          let remaining = len - !offset in
+          let copy_len = min chunk_len remaining in
+          Bigstringaf.blit_to_bytes bs ~src_off:off buffer
+            ~dst_off:!offset ~len:copy_len;
+          offset := !offset + copy_len;
+          if !offset >= len then complete () else schedule ())
+  in
+  if len = 0 then complete () else schedule ()
+
+let handle_inbound_text session ~on_message ~is_fin text =
+  match session.inbound_partial_text, is_fin with
+  | None, true ->
+      if String.length text > 0 then
+        on_message session.id text
+  | None, false ->
+      let buffer = Buffer.create (max 16 (String.length text * 2)) in
+      Buffer.add_string buffer text;
+      session.inbound_partial_text <- Some buffer
+  | Some buffer, _ ->
+      Buffer.add_string buffer text;
+      if is_fin then begin
+        session.inbound_partial_text <- None;
+        let message = Buffer.contents buffer in
+        if String.length message > 0 then
+          on_message session.id message
+      end
+
+let read_inbound_message_frame session ~on_message ~is_fin ~len payload =
+  read_payload_string payload ~len ~on_complete:(fun text ->
+      handle_inbound_text session ~on_message ~is_fin text)
+
 (** Remove a session and unsubscribe from SSE. *)
 let cleanup_session session_id =
-  with_sessions_rw (fun () ->
-    match Hashtbl.find_opt sessions session_id with
-    | None -> ()
-    | Some session ->
-      session.closed <- true;
-      (try Httpun_ws.Wsd.close session.wsd
-       with Eio.Cancel.Cancelled _ as e -> raise e
-          | exn -> Log.Server.warn "WS close failed for %s: %s" session_id (Printexc.to_string exn));
-      Hashtbl.remove sessions session_id);
+  let removed =
+    with_sessions_rw (fun () ->
+        match Hashtbl.find_opt sessions session_id with
+        | None -> false
+        | Some session ->
+            session.closed <- true;
+            (try Httpun_ws.Wsd.close session.wsd
+             with Eio.Cancel.Cancelled _ as e -> raise e
+                | exn -> Log.Server.warn "WS close failed for %s: %s" session_id (Printexc.to_string exn));
+            Hashtbl.remove sessions session_id;
+            true)
+  in
   Transport_metrics.set_ws_sessions
     (with_sessions_rw (fun () -> Hashtbl.length sessions));
   Sse.unsubscribe_external session_id;
-  Log.Server.info "WebSocket session %s closed" session_id
+  if removed then
+    Log.Server.info "WebSocket session %s closed" session_id
 
 (** Number of active WebSocket sessions. *)
 let session_count () =
@@ -105,7 +416,7 @@ let upgrade_connection
     let ws_conn =
       Httpun_ws.Server_connection.create_websocket
         (fun wsd ->
-          let session = { id = session_id; wsd; closed = false } in
+          let session = new_session ~id:session_id ~wsd in
           with_sessions_rw (fun () ->
             Hashtbl.replace sessions session_id session);
           Transport_metrics.set_ws_sessions
@@ -116,32 +427,24 @@ let upgrade_connection
               not session.closed && not (Httpun_ws.Wsd.is_closed session.wsd))
             ~callback:(fun sse_event ->
               if not session.closed
-                 && not (send_text_checked ~context:"sse-forward" session sse_event)
+                 && not (send_dashboard_or_raw_sse session sse_event)
               then
                 cleanup_session session_id)
             ();
           Log.Server.info "WebSocket session %s connected" session_id;
-          let buf = Buffer.create 4096 in
           { Httpun_ws.Websocket_connection.
-            frame = (fun ~opcode ~is_fin:_ ~len:_ payload ->
+            frame = (fun ~opcode ~is_fin ~len payload ->
               match opcode with
-              | `Text | `Binary ->
-                Buffer.clear buf;
-                Httpun_ws.Payload.schedule_read payload
-                  ~on_eof:(fun () ->
-                    let text = Buffer.contents buf in
-                    if String.length text > 0 then
-                      on_message session_id text)
-                  ~on_read:(fun bs ~off ~len ->
-                    Buffer.add_string buf
-                      (Bigstringaf.substring bs ~off ~len))
+              | `Text | `Binary | `Continuation ->
+                read_inbound_message_frame session ~on_message ~is_fin ~len
+                  payload
               | `Ping ->
                 Httpun_ws.Wsd.send_pong wsd;
                 Httpun_ws.Payload.close payload
               | `Connection_close ->
                 cleanup_session session_id;
                 Httpun_ws.Payload.close payload
-              | `Pong | `Continuation | `Other _ ->
+              | `Pong | `Other _ ->
                 Httpun_ws.Payload.close payload
             );
             eof = (fun ?error:_ () ->

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -292,8 +292,9 @@ let rec add_routes ~sw ~clock router =
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/shell" (fun request reqd ->
        with_public_read (fun state req reqd ->
+         let light = Server_utils.bool_query_param req "light" ~default:false in
          let json =
-           dashboard_shell_http_json ?clock:state.Mcp_server.clock ~request:req
+           dashboard_shell_http_json ?clock:state.Mcp_server.clock ~request:req ~light
              state.Mcp_server.room_config
          in
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1304,6 +1304,32 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
               Log.Server.warn "gRPC keeper client init failed: %s"
                 (Printexc.to_string exn))
        | Http | Ws | Webrtc | Local -> ());
+      Server_mcp_transport_ws.set_dashboard_snapshot_provider (function
+        | "shell" ->
+            Some
+              (Server_dashboard_http.dashboard_shell_payload_json ~light:true
+                 state.Mcp_server.room_config)
+        | "execution" ->
+            Some (Server_dashboard_http.dashboard_execution_snapshot_json ())
+        | "operator" ->
+            Some
+              (`Assoc
+                [
+                  ( "snapshot",
+                    Server_dashboard_http.cached_surface_json
+                      Server_dashboard_http._operator_snapshot_cache );
+                  ( "digest",
+                    Server_dashboard_http.cached_surface_json
+                      Server_dashboard_http._operator_digest_cache );
+                ])
+        | "transport" ->
+            Some (Server_dashboard_http.dashboard_transport_health_snapshot_json ())
+        | "namespace" ->
+            Server_dashboard_http.namespace_truth_snapshot_from_caches state
+        | "composite" | "board" | "goals" ->
+            None
+        | _ ->
+            None);
       (* Standalone WebSocket transport (enabled by default, opt-out via MASC_WS_ENABLED=0) *)
       Server_ws_standalone.start ~sw ~env
         ~on_message:(fun ws_session_id body_str ->

--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -34,9 +34,7 @@ let is_enabled () =
 let make_websocket_handler ~on_message _client_addr (wsd : Ws.Wsd.t) :
     Ws.Websocket_connection.input_handlers =
   let session_id = Server_mcp_transport_ws.next_id () in
-  let session : Server_mcp_transport_ws.ws_session =
-    { id = session_id; wsd; closed = false }
-  in
+  let session = Server_mcp_transport_ws.new_session ~id:session_id ~wsd in
   Server_mcp_transport_ws.with_sessions_rw (fun () ->
     Hashtbl.replace Server_mcp_transport_ws.sessions session_id session);
   Transport_metrics.set_ws_sessions
@@ -49,33 +47,25 @@ let make_websocket_handler ~on_message _client_addr (wsd : Ws.Wsd.t) :
     ~callback:(fun sse_event ->
       if not session.closed
          && not
-              (Server_mcp_transport_ws.send_text_checked ~context:"sse-forward"
-                 session sse_event)
+              (Server_mcp_transport_ws.send_dashboard_or_raw_sse session
+                 sse_event)
       then
         Server_mcp_transport_ws.cleanup_session session_id)
     ();
   Log.Server.info "WebSocket session %s connected (standalone port)" session_id;
-  let buf = Buffer.create 4096 in
   { Ws.Websocket_connection.
-    frame = (fun ~opcode ~is_fin:_ ~len:_ payload ->
+    frame = (fun ~opcode ~is_fin ~len payload ->
       match opcode with
-      | `Text | `Binary ->
-        Buffer.clear buf;
-        Ws.Payload.schedule_read payload
-          ~on_eof:(fun () ->
-            let text = Buffer.contents buf in
-            if String.length text > 0 then
-              on_message session_id text)
-          ~on_read:(fun bs ~off ~len ->
-            Buffer.add_string buf
-              (Bigstringaf.substring bs ~off ~len))
+      | `Text | `Binary | `Continuation ->
+        Server_mcp_transport_ws.read_inbound_message_frame session
+          ~on_message ~is_fin ~len payload
       | `Ping ->
         Ws.Wsd.send_pong wsd;
         Ws.Payload.close payload
       | `Connection_close ->
         Server_mcp_transport_ws.cleanup_session session_id;
         Ws.Payload.close payload
-      | `Pong | `Continuation | `Other _ ->
+      | `Pong | `Other _ ->
         Ws.Payload.close payload
     );
     eof = (fun ?error:_ () ->


### PR DESCRIPTION
## Summary
- add authenticated dashboard WebSocket JSON-RPC methods for hello, route subscriptions, snapshots, deltas, and ack flow
- gate frontend refresh work by active route and hydrate shell/server-push snapshots instead of broad hidden-tab refresh fanout
- lazy-load detail overlays and split dashboard state modules so the first route bundle is much smaller

## Validation
- scripts/dune-local.sh build bin/main_eio.exe
- pnpm exec tsc --noEmit --pretty
- pnpm exec vitest run src/components/agent-detail.test.ts src/components/agent-detail-state.test.ts src/components/goals/task-detail-state.test.ts src/components/common/error-notification.test.ts src/sse-store.test.ts src/tab-refresh.test.ts src/dashboard-ws.test.ts
- pnpm build
- git diff --check origin/main...HEAD

Refs #9898