### PR TITLE
fix(dashboard): render unknown signal severity as warn, not green (#9894)

### DIFF
--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -68,13 +68,25 @@ function transitionType(selectedEvent: unknown): string {
 }
 
 function signalTone(severity: string | null | undefined): string {
+  // Unknown severity → treat as warn (fail-closed). Only an explicit "ok" from
+  // the backend renders as green. See issue #9894 (Unknown → Permissive Default
+  // anti-pattern; CLAUDE.md #2). Backend emits 'ok' | 'warn' | 'bad' today via
+  // lib/keeper/keeper_transition_audit.ml; any new severity must be mapped
+  // here explicitly before it is allowed to show as healthy.
   switch (severity) {
     case 'bad':
       return 'border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--bad)]'
     case 'warn':
       return 'border-[var(--warn-24)] bg-[var(--warn-8)] text-[var(--warn)]'
-    default:
+    case 'ok':
       return 'border-[rgba(34,197,94,0.24)] bg-[var(--emerald-8)] text-[var(--ok)]'
+    default:
+      // Client-side observability: record unexpected severities so future
+      // backend additions are noticed before they regress to silent-OK.
+      if (typeof console !== 'undefined' && severity != null && severity !== '') {
+        console.warn('[signalTone] unknown severity; rendering as warn', { severity })
+      }
+      return 'border-[var(--warn-24)] bg-[var(--warn-8)] text-[var(--warn)]'
   }
 }
 


### PR DESCRIPTION
## 요약

`dashboard/src/components/keeper-state-diagram.ts`의 `signalTone`가 모든 미분류 severity 값을 green(`--ok`/`--emerald-8`)으로 매핑하여, backend가 새로운 severity level을 추가하는 순간 UI에 silent-OK가 노출됩니다. CLAUDE.md 안티패턴 #2 (**Unknown → Permissive Default**)의 직접 사례입니다.

Closes #9894.

## 변경 내용

`dashboard/src/components/keeper-state-diagram.ts:68-92` — `signalTone`를 명시적 whitelist로 전환:

- `'bad'`, `'warn'`, `'ok'` 세 severity만 명시 매핑
- default → warn 팔레트 (fail-closed)
- default 경로에서 `console.warn`으로 unknown severity 기록 (devtools에서 backend 드리프트 감지)

Backend 발신 값 (`lib/keeper/keeper_transition_audit.ml`)은 `"ok" | "warn" | "bad"` 3종만 존재하며, 본 PR의 명시적 whitelist와 완전 일치합니다.

## 회귀 리스크

| severity | before | after |
|----------|--------|-------|
| `"bad"` | bad 팔레트 | bad 팔레트 (unchanged) |
| `"warn"` | warn 팔레트 | warn 팔레트 (unchanged) |
| `"ok"` | emerald 팔레트 | emerald 팔레트 (unchanged, 명시 case) |
| `null` / `undefined` / `""` / 기타 | emerald 팔레트 ❌ | warn 팔레트 ✅ + console.warn |

현재 backend가 보내는 값은 3종 전부 매핑되므로 실환경 UI 변화 없음. 새 severity가 backend에 추가될 때에만 warn으로 표시되어 드리프트를 감지합니다.

## 테스트

- [x] `npx tsc --noEmit` 통과 (로컬, dashboard/)
- [ ] CI (dashboard build + lint)

## 검증하지 못한 항목

- 브라우저에서 실제 렌더링 확인은 수행하지 않았습니다. 타입 시그니처와 팔레트 토큰은 기존 값을 그대로 사용.

## 참고

- Issue #9900 (#9915 PR) — same family의 서버 측 대응 (`operator_disposition` fallthrough → unknown)
- PR #9891 tick 10 review comment (pre-merge finding, 미해소 머지)
- CLAUDE.md: AI 코드 생성 안티패턴 #2 (**Unknown → Permissive Default**)
- Backend severity enum: `lib/keeper/keeper_transition_audit.ml:54-135` (`"ok" | "warn" | "bad"`)
