### PR TITLE
[codex] Move keeper tool grouping to typed catalog metadata

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -453,12 +453,28 @@ let cascade_outcome_of_observation = function
   | Some _ -> "completed"
   | None -> "not_observed"
 
-let tool_required_affordances =
-  [ "board_post_or_comment"
-  ; "message_sweep"
-  ; "task_claim"
-  ; "task_audit"
-  ]
+type turn_affordance =
+  | Board_post_or_comment
+  | Message_sweep
+  | Task_claim
+  | Task_audit
+
+let turn_affordance_of_string = function
+  | "board_post_or_comment" -> Some Board_post_or_comment
+  | "message_sweep" -> Some Message_sweep
+  | "task_claim" -> Some Task_claim
+  | "task_audit" -> Some Task_audit
+  | _ -> None
+
+let should_tool_gate_affordance = function
+  | Board_post_or_comment | Message_sweep | Task_claim | Task_audit -> true
+
+let turn_affordances_require_tool_gate turn_affordances =
+  List.exists
+    (function
+      | Some affordance -> should_tool_gate_affordance affordance
+      | None -> false)
+    (List.map turn_affordance_of_string turn_affordances)
 
 let should_require_tools_for_initial_turn ~(max_turns : int)
     ~(turn_affordances : string list) =
@@ -466,9 +482,39 @@ let should_require_tools_for_initial_turn ~(max_turns : int)
   let initial_turn_is_last = initial_per_call_turn >= max_turns - 1 in
   max_turns > 1
   && not initial_turn_is_last
-  && List.exists
-       (fun affordance -> List.mem affordance turn_affordances)
-       tool_required_affordances
+  && turn_affordances_require_tool_gate turn_affordances
+
+let tool_names =
+  List.map Tool_name.to_string
+
+let fallback_floor_tool_names =
+  tool_names
+    Tool_name.[
+      Keeper Context_status;
+      Keeper Task_claim;
+      Keeper Tasks_list;
+      Keeper Board_list;
+      Keeper Board_get;
+    ]
+
+let fallback_repo_probe_tool_names =
+  tool_names Tool_name.[ Keeper Fs_read; Keeper Shell; Keeper Bash ]
+
+let is_claim_tool_name name =
+  match Tool_name.of_string name with
+  | Some (Keeper Task_claim) | Some (Masc Claim_next) -> true
+  | _ -> false
+
+let is_claim_context_tool_name name =
+  match Tool_name.of_string name with
+  | Some (Keeper Task_claim)
+  | Some (Keeper Tasks_list)
+  | Some (Keeper Context_status)
+  | Some (Masc Claim_next)
+  | Some (Masc Tasks)
+  | Some (Masc Status) ->
+      true
+  | _ -> false
 
 (* Tool selection & disclosure — extracted to Keeper_tool_disclosure (#5732) *)
 
@@ -486,26 +532,8 @@ let tool_index_entry_of_tool
     (t : Oas.Tool.t) : Oas.Tool_index.entry =
   let name = t.schema.name in
   let group =
-    if String.starts_with ~prefix:"keeper_board_" name then Some "board"
-    else if String.starts_with ~prefix:"keeper_memory_" name
-         || String.starts_with ~prefix:"keeper_library_" name then Some "knowledge"
-    else if String.starts_with ~prefix:"keeper_task" name then Some "tasks"
-    else if String.starts_with ~prefix:"keeper_voice_" name then Some "voice"
-    else if String.starts_with ~prefix:"keeper_fs_" name
-         || name = "keeper_shell"
-         || name = "keeper_bash"
-         || name = "keeper_write" then Some "filesystem"
-    else if String.starts_with ~prefix:"masc_board_" name then Some "masc_board"
-    else if String.starts_with ~prefix:"masc_keeper_" name then Some "masc_keeper"
-    else if String.starts_with ~prefix:"masc_plan_" name then Some "masc_plan"
-    else if String.starts_with ~prefix:"masc_worktree_" name then Some "masc_worktree"
-    else if String.starts_with ~prefix:"masc_code_" name then Some "masc_code"
-    else if String.starts_with ~prefix:"masc_governance_" name then Some "masc_governance"
-    else if String.starts_with ~prefix:"masc_autoresearch_" name then Some "masc_autoresearch"
-    else if String.starts_with ~prefix:"masc_agent_" name
-         || name = "masc_agents" then Some "masc_agent"
-    else if String.starts_with ~prefix:"masc_" name then Some "masc_core"
-    else None
+    Tool_catalog.tool_group name
+    |> Option.map Tool_catalog.tool_group_to_string
   in
   let aliases =
     match Hashtbl.find_opt korean_kw_tbl name with
@@ -1341,22 +1369,14 @@ let run_turn
     validated
   in
   let fallback_tool_surface ~turn =
-    let floor =
-      [ "keeper_context_status"
-      ; "keeper_task_claim"
-      ; "keeper_tasks_list"
-      ; "keeper_board_list"
-      ; "keeper_board_get"
-      ]
-    in
     let repo_probe =
-      [ "keeper_fs_read"; "keeper_shell"; "keeper_bash" ]
+      fallback_repo_probe_tool_names
       |> List.find_opt (fun name ->
            Keeper_tool_policy.StringSet.mem name universe_set
            && Keeper_tool_policy.StringSet.mem name allowed_exec_set)
       |> Option.to_list
     in
-    validate_allow_list ~turn (floor @ repo_probe)
+    validate_allow_list ~turn (fallback_floor_tool_names @ repo_probe)
   in
   let tool_gate_requested_for_turn ~current_tool_choice ~is_last_turn =
     let caller_requires_tools =
@@ -1366,10 +1386,7 @@ let run_turn
     in
     max_turns > 1
     && not is_last_turn
-    && (caller_requires_tools
-        || List.exists
-             (fun affordance -> List.mem affordance turn_affordances)
-             tool_required_affordances)
+    && (caller_requires_tools || turn_affordances_require_tool_gate turn_affordances)
   in
   let compute_tool_surface ~turn ~messages ~current_tool_choice ~decay_discovered
       : computed_tool_surface =
@@ -1928,18 +1945,8 @@ let run_turn
                       scan rev
                     in
                     let is_claim_only_turn =
-                      List.exists (fun n ->
-                        String.equal n "keeper_task_claim"
-                        || String.equal n "masc_claim_next"
-                      ) last_tool_names
-                      && List.for_all (fun n ->
-                        String.equal n "keeper_task_claim"
-                        || String.equal n "masc_claim_next"
-                        || String.equal n "keeper_tasks_list"
-                        || String.equal n "masc_tasks"
-                        || String.equal n "masc_status"
-                        || String.equal n "keeper_context_status"
-                      ) last_tool_names
+                      List.exists is_claim_tool_name last_tool_names
+                      && List.for_all is_claim_context_tool_name last_tool_names
                     in
                     if is_claim_only_turn then
                       let nudge =

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -34,6 +34,21 @@ type effect_domain =
   | Playground_write
   | Main_worktree_write
 
+type tool_group =
+  | Board
+  | Knowledge
+  | Tasks
+  | Voice
+  | Filesystem
+  | Masc_board
+  | Masc_keeper
+  | Masc_plan
+  | Masc_worktree
+  | Masc_code
+  | Masc_autoresearch
+  | Masc_agent
+  | Masc_core
+
 include (Tool_catalog_surfaces : sig
   type surface = Tool_catalog_surfaces.surface =
     | Public_mcp | Spawned_agent | Local_worker | Session_min
@@ -330,6 +345,21 @@ let effect_domain_to_string = function
   | Playground_write -> "playground_write"
   | Main_worktree_write -> "main_worktree_write"
 
+let tool_group_to_string = function
+  | Board -> "board"
+  | Knowledge -> "knowledge"
+  | Tasks -> "tasks"
+  | Voice -> "voice"
+  | Filesystem -> "filesystem"
+  | Masc_board -> "masc_board"
+  | Masc_keeper -> "masc_keeper"
+  | Masc_plan -> "masc_plan"
+  | Masc_worktree -> "masc_worktree"
+  | Masc_code -> "masc_code"
+  | Masc_autoresearch -> "masc_autoresearch"
+  | Masc_agent -> "masc_agent"
+  | Masc_core -> "masc_core"
+
 let implementation_allows_public_visibility = function
   | Real | Adapter -> true
   | Simulation | Placeholder -> false
@@ -515,6 +545,174 @@ let inferred_effect_domain name =
   | Some typed_name -> inferred_effect_domain_of_typed_tool_name typed_name
   | None -> None
 
+let tool_group_of_typed_tool_name = function
+  | TN.Keeper
+      ( TK.Board_cleanup
+      | TK.Board_comment
+      | TK.Board_comment_vote
+      | TK.Board_delete
+      | TK.Board_get
+      | TK.Board_list
+      | TK.Board_post
+      | TK.Board_search
+      | TK.Board_stats
+      | TK.Board_vote ) ->
+      Some Board
+  | TN.Keeper (TK.Memory_search | TK.Library_read | TK.Library_search) ->
+      Some Knowledge
+  | TN.Keeper
+      ( TK.Task_claim
+      | TK.Task_create
+      | TK.Task_done
+      | TK.Task_force_done
+      | TK.Task_force_release
+      | TK.Task_submit_for_verification
+      | TK.Tasks_audit
+      | TK.Tasks_list ) ->
+      Some Tasks
+  | TN.Keeper
+      ( TK.Voice_agent
+      | TK.Voice_listen
+      | TK.Voice_session_end
+      | TK.Voice_session_start
+      | TK.Voice_sessions
+      | TK.Voice_speak ) ->
+      Some Voice
+  | TN.Keeper (TK.Bash | TK.Fs_edit | TK.Fs_read | TK.Shell | TK.Write) ->
+      Some Filesystem
+  | TN.Keeper
+      ( TK.Bash_kill
+      | TK.Bash_output
+      | TK.Broadcast
+      | TK.Code_read
+      | TK.Context_status
+      | TK.Discovery
+      | TK.Handoff
+      | TK.Pr_review_comment
+      | TK.Pr_review_read
+      | TK.Pr_review_reply
+      | TK.Preflight_check
+      | TK.Stay_silent
+      | TK.Time_now
+      | TK.Tool_search
+      | TK.Tools_list ) ->
+      None
+  | TN.Masc
+      ( TM.Board_cleanup
+      | TM.Board_comment
+      | TM.Board_comment_vote
+      | TM.Board_delete
+      | TM.Board_get
+      | TM.Board_hearths
+      | TM.Board_list
+      | TM.Board_post
+      | TM.Board_profile
+      | TM.Board_search
+      | TM.Board_stats
+      | TM.Board_vote ) ->
+      Some Masc_board
+  | TN.Masc_keeper _ -> Some Masc_keeper
+  | TN.Masc
+      ( TM.Plan_clear_task
+      | TM.Plan_get
+      | TM.Plan_get_task
+      | TM.Plan_init
+      | TM.Plan_set_task
+      | TM.Plan_update ) ->
+      Some Masc_plan
+  | TN.Masc (TM.Worktree_create | TM.Worktree_list | TM.Worktree_remove) ->
+      Some Masc_worktree
+  | TN.Masc
+      ( TM.Code_delete
+      | TM.Code_edit
+      | TM.Code_git
+      | TM.Code_read
+      | TM.Code_search
+      | TM.Code_shell
+      | TM.Code_symbols
+      | TM.Code_write ) ->
+      Some Masc_code
+  | TN.Masc
+      ( TM.Autoresearch_cycle
+      | TM.Autoresearch_inject
+      | TM.Autoresearch_start
+      | TM.Autoresearch_status
+      | TM.Autoresearch_stop ) ->
+      Some Masc_autoresearch
+  | TN.Masc (TM.Agent_card | TM.Agent_fitness | TM.Agent_update | TM.Agents) ->
+      Some Masc_agent
+  | TN.Masc
+      ( TM.A2a_delegate
+      | TM.Add_task
+      | TM.Approval_get
+      | TM.Batch_add_tasks
+      | TM.Broadcast
+      | TM.Cancel_task
+      | TM.Check
+      | TM.Claim_next
+      | TM.Claim_task
+      | TM.Cleanup_zombies
+      | TM.Collaboration_graph
+      | TM.Complete_task
+      | TM.Config
+      | TM.Coord_status
+      | TM.Dashboard
+      | TM.Deliver
+      | TM.Dispatch_plan
+      | TM.Gc
+      | TM.Get_metrics
+      | TM.Goal_list
+      | TM.Goal_review
+      | TM.Goal_transition
+      | TM.Goal_upsert
+      | TM.Goal_verify
+      | TM.Heartbeat
+      | TM.Join
+      | TM.Leave
+      | TM.List_tasks
+      | TM.Mcp_session
+      | TM.Messages
+      | TM.Note_add
+      | TM.Operation_pause
+      | TM.Operation_start
+      | TM.Operation_status
+      | TM.Operation_stop
+      | TM.Operator_action
+      | TM.Operator_confirm
+      | TM.Operator_digest
+      | TM.Operator_snapshot
+      | TM.Pause
+      | TM.Register_capabilities
+      | TM.Release_task
+      | TM.Reset
+      | TM.Resume
+      | TM.Set_current_task
+      | TM.Spawn
+      | TM.Start
+      | TM.Status
+      | TM.Task_history
+      | TM.Tasks
+      | TM.Tool_admin_snapshot
+      | TM.Tool_admin_update
+      | TM.Tool_grant
+      | TM.Tool_help
+      | TM.Tool_list
+      | TM.Tool_revoke
+      | TM.Tool_stats
+      | TM.Transition
+      | TM.Update_priority
+      | TM.Web_search
+      | TM.Webrtc_answer
+      | TM.Webrtc_offer
+      | TM.Who
+      | TM.Workflow_guide ) ->
+      Some Masc_core
+
+let tool_group name =
+  match Tool_name.of_string name with
+  | Some typed_name -> tool_group_of_typed_tool_name typed_name
+  | None -> None
+
 let attach_inferred_effect_domain name (meta : metadata) =
   match meta.effect_domain with
   | Some _ -> meta
@@ -648,11 +846,17 @@ let metadata_to_fields name =
         :: with_reason
     | None -> with_reason
   in
+  let with_tool_group =
+    match tool_group name with
+    | Some group ->
+        ("toolGroup", `String (tool_group_to_string group)) :: with_effect_domain
+    | None -> with_effect_domain
+  in
   match meta.required_permission with
   | Some permission ->
       ("requiredPermission", `String (Types.show_permission permission))
-      :: with_effect_domain
-  | None -> with_effect_domain
+      :: with_tool_group
+  | None -> with_tool_group
 
 let public_contract_fields name =
   let meta = metadata name in

--- a/lib/tool_catalog.mli
+++ b/lib/tool_catalog.mli
@@ -21,6 +21,21 @@ type effect_domain =
   | Playground_write
   | Main_worktree_write
 
+type tool_group =
+  | Board
+  | Knowledge
+  | Tasks
+  | Voice
+  | Filesystem
+  | Masc_board
+  | Masc_keeper
+  | Masc_plan
+  | Masc_worktree
+  | Masc_code
+  | Masc_autoresearch
+  | Masc_agent
+  | Masc_core
+
 type metadata = {
   visibility : visibility;
   lifecycle : lifecycle;
@@ -70,6 +85,7 @@ val metadata : string -> metadata
 val implementation_status : string -> implementation_status
 val effect_domain : string -> effect_domain option
 val is_main_worktree_boundary_exempt : string -> bool option
+val tool_group : string -> tool_group option
 val canonical_tool_name : string -> string
 val is_placeholder : string -> bool
 val is_visible : ?include_hidden:bool -> ?include_deprecated:bool -> string -> bool
@@ -81,6 +97,7 @@ val visibility_to_string : visibility -> string
 val lifecycle_to_string : lifecycle -> string
 val implementation_status_to_string : implementation_status -> string
 val effect_domain_to_string : effect_domain -> string
+val tool_group_to_string : tool_group -> string
 
 (** {1 JSON metadata} *)
 

--- a/scripts/audit-hardcoding-truth.sh
+++ b/scripts/audit-hardcoding-truth.sh
@@ -88,7 +88,7 @@ section "Confirmed String/Heuristic Semantics"
 print_matches \
   "keeper agent surface still derives affordance groups from tool-name strings" \
   lib/keeper/keeper_agent_run.ml \
-  'tool_required_affordances|String\.starts_with|fallback_tool_surface|is_claim_only_turn'
+  'tool_required_affordances|String\.starts_with|String\.equal[[:space:]]+[a-zA-Z_]+[[:space:]]+"(keeper|masc)_[^"]+"|List\.mem[[:space:]]+[a-zA-Z_]+[[:space:]]+turn_affordances'
 
 print_matches \
   "provider adapter still has model-label/provider heuristics" \

--- a/test/test_tool_spec.ml
+++ b/test/test_tool_spec.ml
@@ -211,6 +211,41 @@ let () =
             check string "name" "__test_spec_schema_conv" schema.Types.name;
             check string "description" "schema conv test" schema.description);
         ] );
+      ( "tool_catalog_groups",
+        [
+          test_case "typed tool groups are exposed without string-prefix routing" `Quick
+            (fun () ->
+              let check_group name expected =
+                check (option string) name (Some expected)
+                  (Option.map Tool_catalog.tool_group_to_string
+                     (Tool_catalog.tool_group name))
+              in
+              check_group "keeper_board_post" "board";
+              check_group "keeper_memory_search" "knowledge";
+              check_group "keeper_library_read" "knowledge";
+              check_group "keeper_task_claim" "tasks";
+              check_group "keeper_voice_speak" "voice";
+              check_group "keeper_fs_read" "filesystem";
+              check_group "keeper_bash" "filesystem";
+              check_group "masc_board_post" "masc_board";
+              check_group "masc_keeper_status" "masc_keeper";
+              check_group "masc_plan_get" "masc_plan";
+              check_group "masc_worktree_list" "masc_worktree";
+              check_group "masc_code_write" "masc_code";
+              check_group "masc_autoresearch_status" "masc_autoresearch";
+              check_group "masc_agents" "masc_agent";
+              check_group "masc_status" "masc_core";
+              check (option string) "unknown" None
+                (Option.map Tool_catalog.tool_group_to_string
+                   (Tool_catalog.tool_group "__unknown_tool")));
+          test_case "metadata fields include typed tool group" `Quick (fun () ->
+            let fields = Tool_catalog.metadata_to_fields "keeper_board_post" in
+            check bool "toolGroup=board" true
+              (List.mem ("toolGroup", `String "board") fields);
+            check bool "unknown has no toolGroup" false
+              (Tool_catalog.metadata_to_fields "__unknown_tool"
+              |> List.exists (fun (key, _) -> String.equal key "toolGroup")));
+        ] );
       ( "verify_handler_coverage",
         [
           test_case "Tag_dispatch binding not in verify missing" `Quick (fun () ->


### PR DESCRIPTION
## Summary
- Move keeper tool group classification from prefix/equality checks in `keeper_agent_run.ml` into typed `Tool_catalog.tool_group` metadata derived from `Tool_name` variants.
- Use typed `Tool_name` constants for fallback tool surfaces and claim-only detection.
- Add `toolGroup` metadata output and tests covering keeper/masc group mappings.
- Narrow the hardcoding audit so it flags real keeper string routing rather than typed helper function names.

## Validation
- `rg 'String\.starts_with|String\.equal n "(keeper|masc)_|tool_required_affordances|List\.mem affordance turn_affordances' lib/keeper/keeper_agent_run.ml -n` (no matches)
- `bash scripts/audit-hardcoding-truth.sh` (keeper-agent confirmed finding removed; remaining findings are existing provider adapter heuristics and CI advisory gates)
- `bash scripts/lint/no-unknown-permissive-default.sh`
- `bash scripts/ci/check-enum-string-safety.sh` (PASS with existing warnings)
- `scripts/dune-local.sh exec ./test/test_tool_spec.exe`
- `scripts/dune-local.sh exec ./test/test_keeper_unified.exe -- test tool_classification`
- `scripts/dune-local.sh build @check`

## Note
- Full `scripts/dune-local.sh exec ./test/test_keeper_unified.exe` still fails in existing world-observation cases with `Stdlib.Effect.Unhandled(Eio__core__Cancel.Get_context)` from `keeper_world_observation.ml`; the focused changed group passes.