### PR TITLE
[codex] reject passive keeper tool-required turns

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -411,6 +411,22 @@ let maybe_rotate_auto_models ?rotation_scope ~spec models =
     rotate_list_by cursor models
   | _ -> models
 
+let maybe_rotate_weighted_entries
+    ?rotation_scope
+    (entries : Cascade_config_loader.weighted_entry list) =
+  match rotation_scope, entries with
+  | Some scope, _ :: _ :: _
+    when List.for_all
+        (fun (e : Cascade_config_loader.weighted_entry) -> e.weight = 1)
+        entries ->
+    let cursor =
+      Cascade_state.rotate_round_robin
+        ~cascade:(Printf.sprintf "entry-order:%s" scope)
+        ~bound:(List.length entries)
+    in
+    rotate_list_by cursor entries
+  | _ -> entries
+
 let expand_provider_auto ?rotation_scope ~spec provider models =
   maybe_rotate_auto_models ?rotation_scope ~spec models
   |> List.map (fun model -> provider ^ ":" ^ model)
@@ -682,6 +698,7 @@ let order_weighted_entries
     ?(rand_int = weighted_random_int)
     ?rotation_scope
     (entries : Cascade_config_loader.weighted_entry list) =
+  let entries = maybe_rotate_weighted_entries ?rotation_scope entries in
   let entries = expand_weighted_auto_entries ?rotation_scope entries in
   let has_weights = List.exists
       (fun (e : Cascade_config_loader.weighted_entry) -> e.weight <> 1)

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -125,9 +125,10 @@ val order_weighted_entries :
     snapshots can preserve dynamic health ordering without rereading raw
     [cascade.json].
 
-    When [rotation_scope] is provided, each [provider:auto] expansion is
-    round-robined independently within that scope before the usual
-    weight/health ordering is applied. *)
+    When [rotation_scope] is provided, equal-weight top-level provider entries
+    are round-robined within that scope, and each [provider:auto] expansion is
+    round-robined independently before the usual weight/health ordering is
+    applied. *)
 
 (** Like {!parse_model_string} but returns a [Result] with a diagnostic
     error message explaining why parsing failed (unknown provider, missing

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -2611,29 +2611,10 @@ let run_turn
            || has_positive_count_after_marker haystack "### Board Activity"
            || has_positive_count_after_marker haystack "Unclaimed tasks"
          in
-         let passive_status_tool_name = function
-           | "masc_status"
-           | "keeper_context_status"
-           | "masc_plan_get"
-           | "keeper_time_now"
-           | "keeper_board_list"
-           | "keeper_board_get"
-           | "keeper_tasks_list"
-           | "masc_tasks" ->
-               true
-           | _ -> false
-         in
-         let passive_only_actionable_turn_reason =
-           if actionable_signal_context
-              && actual_keeper_tool_names <> []
-              && List.for_all passive_status_tool_name actual_keeper_tool_names
-           then
-             Some
-               (Printf.sprintf
-                  "actionable keeper signal was present, but the model only used passive status/read tools: %s"
-                  (String.concat ", " actual_keeper_tool_names))
-           else
-             None
+         let actionable_tool_contract_violation_reason =
+           Keeper_tool_disclosure.actionable_tool_contract_violation_reason
+             ~actionable_signal_context
+             ~tool_names:actual_keeper_tool_names
          in
          (* Required-tool turns are filtered onto providers that declare
             tool support plus tool_choice support. If a text-only response
@@ -2648,13 +2629,13 @@ let run_turn
              Keeper_tool_disclosure.validate_completion_contract_presence
                ~contract:effective_completion_contract
                ~tool_present:!keeper_surface_tool_used_ref
-             , passive_only_actionable_turn_reason
+             , actionable_tool_contract_violation_reason
            with
            | Ok (), Some reason ->
                receipt_tool_contract_result_ref := "violated";
                Log.Keeper.error
                  "keeper:%s required tool contract violated \
-                  (turn=%d, tools=%d). Rejecting passive-only actionable turn. \
+                  (turn=%d, tools=%d). Rejecting no-op/passive actionable turn. \
                   Reason: %s"
                  meta.name result.turns
                  (List.length actual_keeper_tool_names)

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -209,7 +209,9 @@ let degraded_retry_after_recoverable_error
         None
 
 let recoverable_cascade_failure_reason (err : Oas.Error.sdk_error) =
-  if Oas_worker_named.sdk_error_is_hard_quota err then
+  if is_required_tool_contract_violation err then
+    Some "required_tool_contract_violation"
+  else if Oas_worker_named.sdk_error_is_hard_quota err then
     Some "hard_quota"
   else
     match Oas_worker_named.classify_masc_internal_error err with

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -152,6 +152,36 @@ let validate_completion_contract
        Error
          "keeper turn violated required tool contract: no tools were called")
 
+let is_passive_status_tool_name = function
+  | "masc_status"
+  | "keeper_context_status"
+  | "masc_plan_get"
+  | "keeper_time_now"
+  | "keeper_board_list"
+  | "keeper_board_get"
+  | "keeper_tasks_list"
+  | "masc_tasks" ->
+      true
+  | _ -> false
+
+let actionable_tool_contract_violation_reason
+      ~(actionable_signal_context : bool)
+      ~(tool_names : string list)
+  : string option
+  =
+  if not actionable_signal_context then None
+  else
+    match tool_names with
+    | [] ->
+      Some
+        "actionable keeper signal was present, but the model called no keeper tools"
+    | names when List.for_all is_passive_status_tool_name names ->
+      Some
+        (Printf.sprintf
+           "actionable keeper signal was present, but the model only used passive status/read tools: %s"
+           (String.concat ", " names))
+    | _ -> None
+
 let normalize_response_text ~(text : string) ~(tool_names : string list) ()
   : (string, string) result
   =

--- a/test/test_cascade_model_resolve.ml
+++ b/test/test_cascade_model_resolve.ml
@@ -238,6 +238,56 @@ let test_order_weighted_entries_rotation_scope_rotates_generically () =
       "codex_cli:gpt-5.2"
       (List.hd other_scope))
 
+let test_order_weighted_entries_rotation_scope_rotates_top_level_providers () =
+  with_clean_env (fun () ->
+    State.clear_all ();
+    let entry model =
+      {
+        Masc_mcp.Cascade_config_loader.model = model;
+        weight = 1;
+        supports_tool_choice = None;
+      }
+    in
+    let entries =
+      [
+        entry "claude_code:auto";
+        entry "codex_cli:auto";
+        entry "gemini_cli:auto";
+      ]
+    in
+    let first =
+      C.order_weighted_entries ~rotation_scope:"big_three" entries
+      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) ->
+             e.model)
+    in
+    let second =
+      C.order_weighted_entries ~rotation_scope:"big_three" entries
+      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) ->
+             e.model)
+    in
+    let third =
+      C.order_weighted_entries ~rotation_scope:"big_three" entries
+      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) ->
+             e.model)
+    in
+    let other_scope =
+      C.order_weighted_entries ~rotation_scope:"tool_rerank" entries
+      |> List.map (fun (e : Masc_mcp.Cascade_config_loader.weighted_entry) ->
+             e.model)
+    in
+    check string "first call starts with declared provider"
+      "claude_code:auto"
+      (List.hd first);
+    check string "second call rotates to codex provider"
+      "codex_cli:gpt-5.3-codex-spark"
+      (List.hd second);
+    check string "third call rotates to gemini provider"
+      "gemini_cli:gemini-2.5-flash"
+      (List.hd third);
+    check string "different scope restarts top-level provider order"
+      "claude_code:auto"
+      (List.hd other_scope))
+
 let () =
   run "Cascade_model_resolve" [
     "gemini auto", [
@@ -269,5 +319,8 @@ let () =
         `Quick test_expand_model_strings_for_execution_rotation_scope_rotates;
       test_case "weighted ordering rotates auto by scope"
         `Quick test_order_weighted_entries_rotation_scope_rotates_generically;
+      test_case "weighted ordering rotates provider order by scope"
+        `Quick
+        test_order_weighted_entries_rotation_scope_rotates_top_level_providers;
     ];
   ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2653,6 +2653,15 @@ let wrapped_claude_limit_error () =
          kind = Llm_provider.Http_client.Unknown;
        })
 
+let required_tool_contract_violation_error () =
+  Agent_sdk.Error.Agent
+    (CompletionContractViolation
+       {
+         contract = Agent_sdk.Completion_contract_id.Require_tool_use;
+         reason =
+           "required tool contract unsatisfied: tool_choice requested tool use, but the model returned no ToolUse block";
+       })
+
 let expect_degraded_retry label expected_cascade expected_reason = function
   | Some (retry : EC.degraded_retry) ->
       check string (label ^ " cascade") expected_cascade retry.next_cascade;
@@ -2832,6 +2841,18 @@ let test_next_fail_open_cascade_for_turn_allows_required_tool_rotation () =
   in
   expect_degraded_retry "required tool degraded retry"
     "tool_rerank" "hard_quota" degraded_retry
+
+let test_next_fail_open_cascade_for_turn_retries_required_tool_contract_violation () =
+  let degraded_retry =
+    UT.next_fail_open_cascade_for_turn
+      ~base_cascade:KC.default_cascade_name
+      ~effective_cascade:KC.tool_use_strict_cascade_name
+      ~tool_requirement:"required"
+      ~attempted_cascades:[ KC.tool_use_strict_cascade_name ]
+      (required_tool_contract_violation_error ())
+  in
+  expect_degraded_retry "required contract degraded retry"
+    KC.default_cascade_name "required_tool_contract_violation" degraded_retry
 
 (* context_overflow_limit is now in OAS as Retry.extract_context_limit.
    These tests verify the OAS SSOT API is accessible from MASC. *)
@@ -3841,6 +3862,39 @@ let test_validate_completion_contract_presence_requires_keeper_surface_tool () =
   | Error e ->
     check bool "error mentions keeper-surface tools" true
       (contains_substring e "keeper-surface tools")
+
+let test_actionable_tool_contract_flags_no_tools () =
+  match
+    KTD.actionable_tool_contract_violation_reason
+      ~actionable_signal_context:true
+      ~tool_names:[]
+  with
+  | Some reason ->
+      check bool "reason mentions no keeper tools" true
+        (contains_substring reason "no keeper tools")
+  | None -> fail "expected actionable no-tool violation"
+
+let test_actionable_tool_contract_flags_passive_only_tools () =
+  match
+    KTD.actionable_tool_contract_violation_reason
+      ~actionable_signal_context:true
+      ~tool_names:[ "keeper_board_get"; "masc_status" ]
+  with
+  | Some reason ->
+      check bool "reason mentions passive tools" true
+        (contains_substring reason "passive status/read tools")
+  | None -> fail "expected actionable passive-only violation"
+
+let test_actionable_tool_contract_allows_execution_tools () =
+  check (option string) "execution tool satisfies actionable signal" None
+    (KTD.actionable_tool_contract_violation_reason
+       ~actionable_signal_context:true
+       ~tool_names:[ "keeper_bash"; "masc_status" ]);
+  check (option string) "non-actionable no-op remains allowed" None
+    (KTD.actionable_tool_contract_violation_reason
+       ~actionable_signal_context:false
+       ~tool_names:[])
+
 let test_tool_usage_delta_uses_registry_counts () =
   let before =
     [
@@ -4822,6 +4876,12 @@ let () =
             "completion contract presence requires keeper-surface tool"
             `Quick
             test_validate_completion_contract_presence_requires_keeper_surface_tool;
+          test_case "actionable signal rejects no tools" `Quick
+            test_actionable_tool_contract_flags_no_tools;
+          test_case "actionable signal rejects passive-only tools" `Quick
+            test_actionable_tool_contract_flags_passive_only_tools;
+          test_case "actionable signal allows execution tools" `Quick
+            test_actionable_tool_contract_allows_execution_tools;
           test_case "tool usage delta uses registry counts" `Quick
             test_tool_usage_delta_uses_registry_counts;
           test_case "tool usage delta ignores removed tools" `Quick
@@ -5083,6 +5143,9 @@ let () =
           test_case "required tool turns rotate without dropping requirement"
             `Quick
             test_next_fail_open_cascade_for_turn_allows_required_tool_rotation;
+          test_case "required tool contract violations rotate retry lane"
+            `Quick
+            test_next_fail_open_cascade_for_turn_retries_required_tool_contract_violation;
         ] );
       ( "tool_classification",
         [


### PR DESCRIPTION
## Summary
- rotate equal-weight top-level cascade providers when a rotation scope is present, not just provider:auto model expansions
- reject actionable keeper turns that call no tools or only passive read/status tools
- allow required-tool contract failures to retry the next eligible cascade lane

## Validation
- ./scripts/dune-local.sh build test/test_cascade_model_resolve.exe test/test_keeper_unified.exe test/test_keeper_cascade_profile.exe test/test_cascade_catalog_runtime.exe
- ./_build/default/test/test_cascade_model_resolve.exe
- ./_build/default/test/test_keeper_unified.exe test metrics_observation 37-39
- ./_build/default/test/test_keeper_unified.exe test phase_gate 22
- ./_build/default/test/test_keeper_cascade_profile.exe
- ./_build/default/test/test_cascade_catalog_runtime.exe
- git diff --check

Note: direct full ./_build/default/test/test_keeper_unified.exe still hits existing unrelated Eio context failures in world_observation cases.