### PR TITLE
[codex] fix keeper auto reclaim soft latch

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -628,6 +628,41 @@ let batch_add_tasks_with_contracts ?created_by config tasks =
   batch_add_tasks_internal ?created_by config tasks
 ;;
 
+let is_legacy_auto_cycle_do_not_reclaim_reason reason =
+  let trimmed = String.trim reason in
+  let prefix = "auto: " in
+  let parse_suffix suffix =
+    let prefix_len = String.length prefix in
+    let suffix_len = String.length suffix in
+    let len = String.length trimmed in
+    if
+      len > prefix_len + suffix_len
+      && String.starts_with ~prefix trimmed
+      && String.ends_with ~suffix trimmed
+    then
+      let raw_count = String.sub trimmed prefix_len (len - prefix_len - suffix_len) in
+      match int_of_string_opt raw_count with
+      | Some count -> count >= 3
+      | None -> false
+    else
+      false
+  in
+  parse_suffix " releases" || parse_suffix " cancellations"
+;;
+
+let do_not_reclaim_reason_blocks_claim = function
+  | Some reason when is_legacy_auto_cycle_do_not_reclaim_reason reason -> None
+  | Some _ as reason -> reason
+  | None -> None
+;;
+
+let clear_soft_do_not_reclaim_reason (task : Types.task) =
+  match task.do_not_reclaim_reason with
+  | Some reason when is_legacy_auto_cycle_do_not_reclaim_reason reason ->
+    { task with do_not_reclaim_reason = None }
+  | Some _ | None -> task
+;;
+
 (** Claim task with file locking (TOCTOU prevention) *)
 let claim_task config ~agent_name ~task_id =
   ensure_initialized config;
@@ -652,12 +687,13 @@ let claim_task config ~agent_name ~task_id =
                   then (
                     found := true;
                     (* Cycle-prevention gate: see _r variant below for rationale. *)
-                    (match task.do_not_reclaim_reason with
+                    (match do_not_reclaim_reason_blocks_claim task.do_not_reclaim_reason with
                      | Some r -> blocked_reason := Some r
                      | None -> ());
                     match task.task_status with
                     | _ when !blocked_reason <> None -> task
                     | Todo ->
+                      let task = clear_soft_do_not_reclaim_reason task in
                       { task with
                         task_status =
                           Claimed { assignee = agent_name; claimed_at = now_iso () }
@@ -768,7 +804,7 @@ let claim_task_r config ~agent_name ~task_id ()
          The reason can come from cancel/release hard-stop logic or be applied
          directly by an operator. See PRs #7794 (schema), #7798 (cancel hook). *)
          let* () =
-           match task.do_not_reclaim_reason with
+           match do_not_reclaim_reason_blocks_claim task.do_not_reclaim_reason with
            | None -> Ok ()
            | Some r ->
              Error
@@ -784,6 +820,7 @@ let claim_task_r config ~agent_name ~task_id ()
                 then (
                   match t.task_status with
                   | Todo ->
+                    let t = clear_soft_do_not_reclaim_reason t in
                     let t' =
                       { t with
                         task_status =
@@ -906,10 +943,9 @@ let release_should_block_reclaim handoff_context =
 ;;
 
 let derive_release_do_not_reclaim_reason (task : Types.task) handoff_context =
-  match task.do_not_reclaim_reason with
+  match do_not_reclaim_reason_blocks_claim task.do_not_reclaim_reason with
   | Some _ as existing -> existing
   | None ->
-    let next_cycle = task.cycle_count + 1 in
     let first_text =
       match release_handoff_texts handoff_context with
       | text :: _ -> Some text
@@ -918,9 +954,7 @@ let derive_release_do_not_reclaim_reason (task : Types.task) handoff_context =
     if release_should_block_reclaim handoff_context
     then
       Some
-        (Option.value first_text ~default:(Printf.sprintf "auto: %d releases" next_cycle))
-    else if next_cycle >= 3
-    then Some (Printf.sprintf "auto: %d releases" next_cycle)
+        (Option.value first_text ~default:"release hard-stop requested")
     else None
 ;;
 
@@ -973,6 +1007,14 @@ let transition_task_r
           match task_opt with
           | None -> Error (Types.TaskNotFound task_id)
           | Some task -> Ok task
+        in
+        let* () =
+          match action, do_not_reclaim_reason_blocks_claim task.do_not_reclaim_reason with
+          | Types.Claim, Some r ->
+            Error
+              (Types.TaskInvalidState
+                 (Printf.sprintf "Task %s is blocked from re-claim: %s" task_id r))
+          | _ -> Ok ()
         in
         let now = now_iso () in
         let now_ts = Time_compat.now () in
@@ -1116,6 +1158,17 @@ let transition_task_r
               (fun (t : task) ->
                  if t.id = task_id
                  then (
+                   let t =
+                     match action with
+                     | Types.Claim -> clear_soft_do_not_reclaim_reason t
+                     | Types.Release
+                     | Types.Start
+                     | Types.Done_action
+                     | Types.Cancel
+                     | Types.Submit_for_verification
+                     | Types.Approve_verification
+                     | Types.Reject_verification -> t
+                   in
                    let cycle_count, do_not_reclaim_reason =
                      match action with
                      | Types.Release ->
@@ -1412,11 +1465,12 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
                       if t.id = task_id
                       then (
                         let new_cycle = t.cycle_count + 1 in
-                        (* Auto-set do_not_reclaim_reason when the operator flags
-                     a hard stop in the cancel reason, or after 3 cycles. *)
+                        (* Set do_not_reclaim_reason only when the operator flags
+                     an explicit hard stop in the cancel reason. *)
                         let auto_dnr =
                           match t.do_not_reclaim_reason with
-                          | Some _ as existing -> existing
+                          | Some _ as existing ->
+                            do_not_reclaim_reason_blocks_claim existing
                           | None ->
                             let lower = String.lowercase_ascii reason in
                             let flagged =
@@ -1425,8 +1479,6 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
                             in
                             if flagged && reason <> ""
                             then Some reason
-                            else if new_cycle >= 3
-                            then Some (Printf.sprintf "auto: %d cancellations" new_cycle)
                             else None
                         in
                         { t with

--- a/lib/coord/coord_task.mli
+++ b/lib/coord/coord_task.mli
@@ -90,6 +90,14 @@ val claim_task :
 val claim_task_r :
   config -> agent_name:string -> task_id:string -> unit -> string Types.masc_result
 
+val do_not_reclaim_reason_blocks_claim : string option -> string option
+(** Returns [Some reason] only when [reason] is an explicit hard-stop that
+    should still block claiming. Legacy automatic cycle reasons such as
+    ["auto: 3 releases"] are treated as soft and return [None]. *)
+
+val clear_soft_do_not_reclaim_reason : Types.task -> Types.task
+(** Clears legacy automatic cycle block reasons before a task is claimed. *)
+
 (** {1 Task transitions} *)
 
 val transition_task_r :

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -9,8 +9,28 @@ include Coord_state
 
 let task_is_claim_pool_candidate (task : Types.task) =
   match task.task_status with
+  | Todo ->
+      Option.is_none
+        (Coord_task.do_not_reclaim_reason_blocks_claim task.do_not_reclaim_reason)
+  | Claimed _ | InProgress _ | AwaitingVerification _ | Done _ | Cancelled _ ->
+      false
+
+let task_is_primary_claim_pool_candidate (task : Types.task) =
+  match task.task_status with
   | Todo -> Option.is_none task.do_not_reclaim_reason
   | Claimed _ | InProgress _ | AwaitingVerification _ | Done _ | Cancelled _ ->
+      false
+
+let task_is_soft_reclaim_candidate (task : Types.task) =
+  match task.task_status, task.do_not_reclaim_reason with
+  | Todo, Some reason ->
+      Option.is_none (Coord_task.do_not_reclaim_reason_blocks_claim (Some reason))
+  | Todo, None
+  | Claimed _, _
+  | InProgress _, _
+  | AwaitingVerification _, _
+  | Done _, _
+  | Cancelled _, _ ->
       false
 
 type verification_claim_state =
@@ -183,7 +203,8 @@ let claim_next_r
         t.task_status = Types.Todo
       ) sorted in
       let blocked_todo = List.filter (fun (t : Types.task) ->
-        Option.is_some t.do_not_reclaim_reason
+        Option.is_some
+          (Coord_task.do_not_reclaim_reason_blocks_claim t.do_not_reclaim_reason)
       ) all_todo in
       let latest_verification_status = latest_verification_status_by_task config in
       let verification_blocked_todo =
@@ -200,7 +221,15 @@ let claim_next_r
              "{\"type\":\"task_claim_next_skip_verification\",\"agent\":\"%s\",\"blocked\":%d,\"ts\":\"%s\"}"
              agent_name (List.length verification_blocked_todo) (now_iso ()));
 
-      let unclaimed = List.filter task_is_claim_pool_candidate sorted in
+      let primary_unclaimed =
+        List.filter task_is_primary_claim_pool_candidate sorted
+      in
+      let soft_unclaimed =
+        List.filter task_is_soft_reclaim_candidate sorted
+      in
+      let unclaimed =
+        List.filter task_is_claim_pool_candidate sorted
+      in
       (* Also exclude the just-released task: the agent is moving on,
          re-claiming the same task would be a no-op loop. *)
       let blocked_ids =
@@ -217,10 +246,16 @@ let claim_next_r
           (fun (t : task) -> (not (List.mem t.id all_excluded)) && not (task_filter t))
           unclaimed
       in
-      let eligible =
+      let eligible_from candidates =
         List.filter
           (fun (t : task) -> (not (List.mem t.id all_excluded)) && task_filter t)
-          unclaimed
+          candidates
+      in
+      let primary_eligible = eligible_from primary_unclaimed in
+      let eligible =
+        match primary_eligible with
+        | _ :: _ -> primary_eligible
+        | [] -> eligible_from soft_unclaimed
       in
 
       (* Helper: clear agent current_task and reset status after auto-release
@@ -273,10 +308,11 @@ let claim_next_r
           (* Claim this task *)
           let new_tasks = List.map (fun (t : task) ->
             if t.id = task.id then
-              { t with task_status = Claimed {
-                  assignee = agent_name;
-                  claimed_at = now_iso ()
-                }
+              let t = Coord_task.clear_soft_do_not_reclaim_reason t in
+              {
+                t with
+                task_status =
+                  Claimed { assignee = agent_name; claimed_at = now_iso () };
               }
             else t
           ) working_tasks in

--- a/lib/tool_task_schemas.ml
+++ b/lib/tool_task_schemas.ml
@@ -33,10 +33,6 @@ Example: masc_add_task({title: 'Fix login bug', goal_id: 'g-123', priority: 1, d
           ("type", `String "string");
           ("description", `String "REQUIRED for goal rollup visibility. Set this to one of the active_goal_ids from your system prompt <available_goals> block. Tasks without a goal_id are orphaned and do not contribute to goal progress tracking.");
         ]);
-        ("required_preset", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Tool preset required to claim this task. Must match a preset name from tool_policy.toml (e.g., 'dispatch', 'delivery', 'coding'). Only keepers whose preset covers the required tools can claim. Omit for any agent.");
-        ]);
         ("contract", `Assoc [
           ("type", `String "object");
           ("description", `String "Optional persisted task contract for strict deterministic completion gating.");

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -453,6 +453,113 @@ let test_release_hard_stop_blocks_direct_reclaim () =
           ("expected TaskInvalidState, got " ^ Types.masc_error_to_string e)
     | Ok _ -> Alcotest.fail "direct claim should be blocked after hard-stop release")
 
+let write_tasks config tasks =
+  let backlog = Coord.read_backlog config in
+  let updated : Types.backlog =
+    { tasks; last_updated = Types.now_iso (); version = backlog.version + 1 }
+  in
+  Coord.write_backlog config updated
+
+let task_by_id config task_id =
+  match
+    List.find_opt
+      (fun (t : Types.task) -> String.equal t.id task_id)
+      (Coord.get_tasks_raw config)
+  with
+  | Some task -> task
+  | None -> Alcotest.failf "%s not found" task_id
+
+let test_claim_next_uses_legacy_auto_cycle_as_fallback () =
+  with_test_env (fun config ->
+    let claude = find_agent_name_by_prefix config "claude" in
+    let _ =
+      Coord.add_task config ~title:"Legacy soft-blocked task" ~priority:1
+        ~description:""
+    in
+    let backlog = Coord.read_backlog config in
+    let tasks =
+      List.map
+        (fun (t : Types.task) ->
+           if String.equal t.id "task-001"
+           then
+             { t with
+               cycle_count = 3
+             ; do_not_reclaim_reason = Some "auto: 3 releases"
+             }
+           else t)
+        backlog.tasks
+    in
+    write_tasks config tasks;
+    match Coord.claim_next_r config ~agent_name:claude () with
+    | Coord.Claim_next_claimed { task_id; _ } ->
+      Alcotest.(check string) "fallback claim" "task-001" task_id;
+      let task = task_by_id config task_id in
+      Alcotest.(check (option string)) "legacy soft block cleared" None
+        task.do_not_reclaim_reason
+    | Coord.Claim_next_no_eligible _ ->
+      Alcotest.fail "legacy auto-cycle reason should be fallback claimable"
+    | Coord.Claim_next_no_unclaimed ->
+      Alcotest.fail "expected one fallback-claimable task"
+    | Coord.Claim_next_error msg -> Alcotest.fail msg)
+
+let test_claim_next_prefers_unblocked_over_legacy_auto_cycle () =
+  with_test_env (fun config ->
+    let claude = find_agent_name_by_prefix config "claude" in
+    let _ =
+      Coord.add_task config ~title:"Legacy soft-blocked urgent" ~priority:1
+        ~description:""
+    in
+    let _ =
+      Coord.add_task config ~title:"Normal lower-priority work" ~priority:5
+        ~description:""
+    in
+    let backlog = Coord.read_backlog config in
+    let tasks =
+      List.map
+        (fun (t : Types.task) ->
+           if String.equal t.id "task-001"
+           then
+             { t with
+               cycle_count = 3
+             ; do_not_reclaim_reason = Some "auto: 3 releases"
+             }
+           else t)
+        backlog.tasks
+    in
+    write_tasks config tasks;
+    match Coord.claim_next_r config ~agent_name:claude () with
+    | Coord.Claim_next_claimed { task_id; _ } ->
+      Alcotest.(check string) "unblocked work is primary" "task-002" task_id
+    | Coord.Claim_next_no_eligible _ ->
+      Alcotest.fail "normal unblocked task should be claimed before fallback"
+    | Coord.Claim_next_no_unclaimed ->
+      Alcotest.fail "expected claimable tasks"
+    | Coord.Claim_next_error msg -> Alcotest.fail msg)
+
+let test_release_cycles_do_not_create_auto_do_not_reclaim () =
+  with_test_env (fun config ->
+    let claude = find_agent_name_by_prefix config "claude" in
+    let _ =
+      Coord.add_task config ~title:"Retryable task" ~priority:1 ~description:""
+    in
+    for _ = 1 to 3 do
+      (match Coord.claim_task_r config ~agent_name:claude ~task_id:"task-001" () with
+       | Ok _ -> ()
+       | Error e -> Alcotest.fail (Types.masc_error_to_string e));
+      (match Coord.release_task_r config ~agent_name:claude ~task_id:"task-001" () with
+       | Ok _ -> ()
+       | Error e -> Alcotest.fail (Types.masc_error_to_string e))
+    done;
+    let task = task_by_id config "task-001" in
+    Alcotest.(check int) "release cycles still tracked" 3 task.cycle_count;
+    Alcotest.(check (option string)) "no auto hard stop" None
+      task.do_not_reclaim_reason;
+    match Coord.claim_task_r config ~agent_name:claude ~task_id:"task-001" () with
+    | Ok _ -> ()
+    | Error e ->
+      Alcotest.fail
+        ("retryable task should remain claimable: " ^ Types.masc_error_to_string e))
+
 (* ============================================================ *)
 (* Update Priority Tests                                         *)
 (* ============================================================ *)
@@ -1207,6 +1314,12 @@ let () =
         test_release_hard_stop_blocks_future_claim_next;
       Alcotest.test_case "release hard-stop blocks direct reclaim" `Quick
         test_release_hard_stop_blocks_direct_reclaim;
+      Alcotest.test_case "legacy auto-cycle block is fallback claimable" `Quick
+        test_claim_next_uses_legacy_auto_cycle_as_fallback;
+      Alcotest.test_case "unblocked tasks beat legacy auto-cycle fallback" `Quick
+        test_claim_next_prefers_unblocked_over_legacy_auto_cycle;
+      Alcotest.test_case "release cycles do not create auto block" `Quick
+        test_release_cycles_do_not_create_auto_do_not_reclaim;
     ];
 
     (* === Update Priority === *)

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -761,6 +761,22 @@ let () = test "handle_add_task_rejects_removed_required_preset_argument" (fun ()
   assert (str_contains result "Unknown argument")
 )
 
+let () = test "add_task_schema_omits_removed_required_preset_argument" (fun () ->
+  let schema =
+    match
+      List.find_opt
+        (fun (schema : Types.tool_schema) ->
+           String.equal schema.name "masc_add_task")
+        Tool_task_schemas.schemas
+    with
+    | Some schema -> schema
+    | None -> failwith "masc_add_task schema not found"
+  in
+  let properties =
+    Yojson.Safe.Util.(schema.input_schema |> member "properties")
+  in
+  assert (Yojson.Safe.Util.member "required_preset" properties = `Null))
+
 let () = test "handle_claim_rejects_removed_agent_role_argument" (fun () ->
   let ctx = make_test_ctx () in
   let _ =


### PR DESCRIPTION
## Summary
- Treat legacy automatic cycle do-not-reclaim reasons such as `auto: 3 releases` / `auto: 3 cancellations` as soft fallback claim candidates instead of permanent hard blocks.
- Keep explicit operator hard-stop `do_not_reclaim_reason` values blocking both `claim_next` and direct claim transitions.
- Stop generating new automatic do-not-reclaim latches from release/cancel cycle counts, and remove the stale `required_preset` field from the `masc_add_task` schema.

## Root Cause
Live backlog inspection showed 11 todo tasks and all 11 had `do_not_reclaim_reason="auto: 3 releases"`, leaving the keeper claim pool empty even though tasks were still open. This made keepers look idle or passive independent of MCP auth/tool exposure.

## Validation
- `scripts/dune-local.sh build ./test/test_room_coverage.exe ./test/test_tool_task_coverage.exe`
- `./_build/default/test/test_room_coverage.exe test claim_next --compact --show-errors`
- `./_build/default/test/test_tool_task_coverage.exe --compact --show-errors`
- `git diff --check`

## Follow-up
- Recorded separate identity/continuity drift follow-up in #9923 for `issue_king` sandbox identity mismatch and stale continuity tool-surface hints.