### PR TITLE
fix(ci): draft guard stops flagging safe converted_to_draft as policy violation (#9910)

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -149,7 +149,19 @@ jobs:
             const policyFailures = bypassPolicyFailures.map((failure) =>
               `unverified bypass label ${failure}`
             );
-            const missingVerifiedApproval = looksAgentAuthored && verifiedBypassLabels.length === 0;
+            // When an agent PR is being explicitly converted back to draft and
+            // has landed in the safe invariant (draft=true, no auto-merge),
+            // treating "missing approval" as a policy violation is a false
+            // positive — the guard has nothing left to enforce because the PR
+            // is already draft-only. See #9910 follow-up evidence.
+            const safeDraftEndState =
+              action === "converted_to_draft" &&
+              current.isDraft &&
+              !current.autoMergeRequest;
+            const missingVerifiedApproval =
+              looksAgentAuthored &&
+              verifiedBypassLabels.length === 0 &&
+              !safeDraftEndState;
             if (missingVerifiedApproval) {
               const expected =
                 bypassLabels.length > 0 ? bypassLabels.join(", ") : "(no configured bypass labels)";


### PR DESCRIPTION
## 요약

Draft Auto-Merge Guard가 `converted_to_draft` action에서 PR이 이미 안전한 draft 상태로 전환된 경우에도 `missing verified human approval label`을 policy failure로 처리하여 workflow를 하드 페일시켰습니다. 이 PR은 안전한 최종 상태(isDraft=true, no auto-merge)에서 `converted_to_draft` action에만 `missingVerifiedApproval` 체크를 스킵합니다.

Closes #9910.

## 근본 원인

`.github/workflows/pr-automation.yml:152` — `missingVerifiedApproval`이 action 타입이나 최종 상태를 고려하지 않고 항상 policy failure를 추가합니다. `converted_to_draft` event는 PR을 draft-only 상태로 되돌리는 **안전 방향** action이지만, 기존 로직은 `ready_for_review` / `auto_merge_enabled` (안전 밖으로 나가는 방향)와 동일하게 취급합니다.

#9910 follow-up evidence (PR #9918):
1. Agent가 Draft PR 생성 → guard pass
2. `label-and-review` action이 `ready_for_review`로 flip → auto-merge 활성
3. 사용자가 draft로 복구 (`converted_to_draft`) + auto-merge 비활성
4. Guard가 `converted_to_draft` action에서 다시 실행되어 `missing approval` false failure

## 변경 내용

```yaml
# .github/workflows/pr-automation.yml:152
+const safeDraftEndState =
+  action === "converted_to_draft" &&
+  current.isDraft &&
+  !current.autoMergeRequest;
 const missingVerifiedApproval =
   looksAgentAuthored &&
-  verifiedBypassLabels.length === 0;
+  verifiedBypassLabels.length === 0 &&
+  !safeDraftEndState;
```

## 회귀 리스크

| Action | PR 상태 | bypass label | before | after | 비고 |
|--------|---------|--------------|--------|-------|------|
| `opened` (agent PR) | draft, no auto-merge | absent | hardFail | hardFail | 새 agent PR은 여전히 label 요구 |
| `ready_for_review` (agent PR) | ready | absent | hardFail | hardFail | flip 시도는 여전히 차단 |
| `auto_merge_enabled` (agent PR) | draft | absent | hardFail | hardFail | 차단 유지 |
| `converted_to_draft` (agent PR) | **draft, no auto-merge** | absent | hardFail ❌ | skip ✅ | 안전 방향 false-positive 제거 |
| `converted_to_draft` (agent PR) | draft, auto-merge enabled | absent | hardFail | hardFail | auto-merge 남아있으면 여전히 실패 (guard가 disable 처리 후 판단) |

**불변 유지**: "Agent PR은 bypass label 없이는 머지될 수 없다"는 핵심 정책은 유지. flip 방향 action(`ready_for_review`, `auto_merge_enabled`)은 그대로 차단. 단지 **draft로 되돌리는 action이 hardFail을 일으키지 않도록** 예외 추가.

## 테스트

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-automation.yml'))"` 통과
- [ ] 실제 workflow 동작 검증은 머지 후 다음 agent PR에서 관찰

## 검증하지 못한 항목

- GitHub Actions workflow는 로컬 실행이 어려워 runtime 검증은 머지 후에만 가능. JS 로직 자체는 변경이 작고 boolean 추가라 syntax/논리 오류 가능성 낮음.

## 참고

- Issue #9910 — 원 evidence 및 follow-up comments
- PR #9908 — 이전 fix (permission failure 경로) 머지됨
- PR #9918 — 본 false failure의 구체 사례
- Memory feedback `masc-mcp auto-merge pipeline deadlock` — 본 guard의 반복된 이슈 기록
