### PR TITLE
fix(config): include Tool_shard.base_tools in raw_all_tool_schemas (#9912)

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -38,7 +38,16 @@ let raw_all_tool_schemas : Types.tool_schema list =
        @ Tool_autoresearch.schemas
        @ Tool_compact.schemas
        @ Tool_agent_timeline.schemas
-       @ Tool_shard.schemas))
+       @ Tool_shard.schemas
+       (* Base shard tools (keeper_stay_silent, keeper_time_now,
+          keeper_context_status, keeper_memory_search, keeper_tools_list)
+          are always-present for every keeper but were only declared in
+          [Tool_shard.base_tools] — a shard definition — and never reached
+          the authoritative registry consumed by [Tool_help_registry.find_entry].
+          Without them here, keepers that requested help on these tools
+          received "unknown tool" despite the dispatcher handling them.
+          See #9912. *)
+       @ Tool_shard.base_tools))
 
 (** Validate tool schemas at module initialization time.
     Logs warnings for: duplicate names, empty names/descriptions,

--- a/test/test_config_coverage.ml
+++ b/test/test_config_coverage.ml
@@ -8,6 +8,8 @@ open Alcotest
 module Config = Masc_mcp.Config
 module Auth = Masc_mcp.Auth
 module Tool_catalog = Masc_mcp.Tool_catalog
+module Tool_help_registry = Masc_mcp.Tool_help_registry
+module Tool_shard = Masc_mcp.Tool_shard
 
 let dummy_schema name : Types.tool_schema =
   {
@@ -41,6 +43,21 @@ let test_all_tool_names_contains_pause () =
 let test_all_tool_names_contains_approval_get () =
   check bool "masc_approval_get registered" true
     (List.mem "masc_approval_get" (Config.all_tool_names ()))
+
+let test_shard_base_tools_registered_for_help () =
+  List.iter
+    (fun (tool : Types.tool_schema) ->
+      let registered =
+        Config.raw_all_tool_schemas
+        |> List.exists (fun (schema : Types.tool_schema) ->
+               String.equal schema.name tool.name)
+      in
+      check bool (tool.name ^ " in raw schemas") true registered;
+      match Tool_help_registry.find_entry Config.raw_all_tool_schemas tool.name with
+      | Some entry ->
+          check string (tool.name ^ " help name") tool.name entry.name
+      | None -> failf "%s missing from tool help registry" tool.name)
+    Tool_shard.base_tools
 
 let test_approval_get_requires_admin_permission () =
   check bool "approval_get admin-only" true
@@ -81,6 +98,8 @@ let () =
             test_all_tool_names_contains_pause;
           test_case "all_tool_names contains approval_get" `Quick
             test_all_tool_names_contains_approval_get;
+          test_case "shard base tools registered for help" `Quick
+            test_shard_base_tools_registered_for_help;
           test_case "approval get requires admin permission" `Quick
             test_approval_get_requires_admin_permission;
           test_case "removed mode tools omitted" `Quick


### PR DESCRIPTION
## 요약

Keeper가 `keeper_stay_silent` 같은 shard base tool에 대해 `keeper_tool_help` 또는 유사한 help registry 조회 시 `❌ unknown tool: keeper_stay_silent` 응답을 받았습니다. 해당 tool schema가 `Tool_shard.base_tools`(shard-grant 정의)에만 있고 `Config.raw_all_tool_schemas`(authoritative registry)에 merge되지 않아 Layer 1 (catalog) ↔ Layer 2 (runtime dispatcher) 드리프트가 발생했습니다.

Closes #9912.

## 근본 원인

`Config.raw_all_tool_schemas`는 다음 schema list들의 union:

```ocaml
Tools.raw_schemas
@ Tool_schemas_control.schemas
@ ...
@ Tool_shard.schemas   (* <-- masc_tool_grant, masc_tool_revoke, masc_tool_list만 *)
```

`Tool_shard.schemas`(line 984)는 **shard-management 메타 도구**만 내보냅니다. 실제 shard에 포함된 tool 들 — `keeper_stay_silent`, `keeper_time_now`, `keeper_context_status`, `keeper_memory_search`, `keeper_tools_list` — 은 `Tool_shard.base_tools`(line 91)에만 정의되어 있습니다.

결과:
- `keeper_exec_tools.ml:203` dispatcher는 `keeper_stay_silent`를 정상 처리 ✅
- `Tool_help_registry.find_entry Config.raw_all_tool_schemas "keeper_stay_silent"` → None ❌
- `tool_misc.ml:81` → `❌ unknown tool: keeper_stay_silent`
- 24일 로그 fingerprint: `{"tool":"keeper_stay_silent","output":"❌ unknown tool: keeper_stay_silent","success":false}`

## 변경 내용

`lib/config.ml`의 `raw_all_tool_schemas`에 `Tool_shard.base_tools` append:

```diff
        @ Tool_compact.schemas
        @ Tool_agent_timeline.schemas
-       @ Tool_shard.schemas))
+       @ Tool_shard.schemas
+       @ Tool_shard.base_tools))
```

`dedupe_schemas`가 중복을 제거하므로 Tool_shard.schemas의 메타 도구와 base_tools 사이에 overlap이 있어도 안전.

## 회귀 리스크

| 소비자 | before | after |
|--------|--------|-------|
| `Tool_help_registry.find_entry` | None for base shard tools ❌ | resolves ✅ |
| `tool_misc.handle_tool_help` | "unknown tool" error | proper help entry |
| `transport.ml:263` metadata | fallback generic schema | proper schema |
| Keeper dispatcher (runtime) | unchanged | unchanged |
| Shard grant 로직 | unchanged | unchanged |
| 중복 schema 처리 | `dedupe_schemas` by name | 동일하게 처리 |

추가된 5개 base shard tool은 모든 keeper가 항상 사용 가능한 "always present" 세트이므로 raw_all_tool_schemas에 포함되는 것이 정상 불변.

## 테스트

- [x] `dune build @check --root .` 통과 (로컬, exit 0)
- [ ] CI (lint/test)

## 검증하지 못한 항목

- `tool_catalog_surfaces.ml`에 등록된 다른 "always_include" 슬롯이 같은 드리프트를 가지는지 전수 확인은 수행하지 않았습니다. 본 PR은 #9912의 구체 fingerprint만 해결. Issue에서 제안된 property test(`#6527` trilogy 스타일)는 별도 follow-up.

## 참고

- Issue #9912 — fingerprint 및 24일 최초 발생
- Memory: `feedback_cascade-declared-vs-runtime-two-filter-layers.md` — 2-filter drift 패턴
- CLAUDE.md 섹션 "AI 페어 프로그래밍 검증 규칙" — 2번째 fix → 근본 수정 강제
