### PR TITLE
fix(keeper): log world prompt render fallback instead of swallowing error (#9893)

### DIFF
--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -29,7 +29,8 @@ let format_list_for_prompt (items : string list) : string =
     [Keeper_tool_policy]); keeping them as arguments avoids a dependency
     cycle between [Keeper_prompt] and [Keeper_tool_policy].  Falls back
     to the raw template text if rendering fails so that prompt wiring
-    bugs do not brick keepers. *)
+    bugs do not brick keepers — but the fallback is now logged loudly so
+    the silent-degradation case documented in #9893 becomes observable. *)
 let render_world_prompt ~allowed_orgs ~denied_repos : string =
   let vars =
     [
@@ -41,7 +42,12 @@ let render_world_prompt ~allowed_orgs ~denied_repos : string =
     Prompt_registry.render_prompt_template Keeper_prompt_names.world vars
   with
   | Ok rendered -> rendered
-  | Error _ -> Prompt_registry.get_prompt Keeper_prompt_names.world
+  | Error msg ->
+      Log.Keeper.warn
+        "render_world_prompt: template render failed, falling back to raw \
+         template (keepers may see unrendered placeholders): %s"
+        msg;
+      Prompt_registry.get_prompt Keeper_prompt_names.world
 
 let build_keeper_system_prompt
     ~goal ~short_goal ~mid_goal ~long_goal ~will ~needs ~desires


### PR DESCRIPTION
## 요약

`render_world_prompt`(`lib/keeper/keeper_prompt.ml:27-44`)는 `Prompt_registry.render_prompt_template`가 `Error _`를 반환할 때 에러 메시지를 버리고 raw template을 반환해, keeper들이 unrendered `{{allowed_orgs}}` placeholder가 박힌 system prompt를 받아도 로그 / 카운터 / trajectory 어디에도 흔적이 남지 않는 silent degradation이었습니다.

Closes #9893.

## 근본 원인

```ocaml
(* lib/keeper/keeper_prompt.ml:40-44 — before *)
match Prompt_registry.render_prompt_template ...
with
| Ok rendered -> rendered
| Error _ -> Prompt_registry.get_prompt Keeper_prompt_names.world
```

`prompt_registry.ml:414`가 만든 `"Unresolved variables in template"` 메시지가 `Error _` 패턴으로 즉시 소실됩니다. Fallback 의도는 "wiring bug에 keeper brick 방지"지만, 호출부가 observability 없이 묵묵히 raw template을 반환.

`~/me/.masc/trajectories/*/trace-*.jsonl`에도 system prompt 필드가 없어(`["ended_at","generation","keeper_name","outcome","started_at","task_id","total_cost_usd","total_tool_calls","total_turns","trace_id","type"]`) post-hoc 재구성 불가.

## 변경 내용

`Error _`를 `Error msg`로 바꾸고 `Log.Keeper.warn`으로 기록:

```diff
- | Error _ -> Prompt_registry.get_prompt Keeper_prompt_names.world
+ | Error msg ->
+     Log.Keeper.warn
+       "render_world_prompt: template render failed, falling back to raw \
+        template (keepers may see unrendered placeholders): %s"
+       msg;
+     Prompt_registry.get_prompt Keeper_prompt_names.world
```

Fallback 동작은 유지 (keeper brick 방지), 단지 관측 가능하게 만듭니다.

## 회귀 리스크

| 경로 | before | after |
|------|--------|-------|
| 정상 render | rendered string 반환 | unchanged |
| template render 실패 | raw template 반환 (silent) | raw template 반환 + warn log |
| keeper 행동 | 동일 | 동일 (fallback path 유지) |
| 로그 볼륨 | — | render 실패 시에만 warn 1건 |

log 볼륨 증가는 문제 발생 시에만(noisy-by-default 원칙, #9517) — 정상 경로에는 영향 없음.

## 테스트

- [x] `dune build @check --root .` 통과 (exit 0)
- [ ] CI

## 검증하지 못한 항목

- 실제 template render 실패를 유발하는 e2e 테스트는 추가하지 않았습니다. 코드 변경이 단일 `Log.Keeper.warn` 호출 추가라 결정적 동작만 바뀝니다.
- Counter emission (`masc_prompt_render_fallback_total`) 및 rendered-prompt snapshot 캡처(issue 제안 2, 4)는 별도 PR로 분리. 본 PR은 "silent → observable"의 최소 1단계.

## 참고

- Issue #9893 — 증거 및 제안 1 (log 추가) 구현
- Meta #9517 — Silent Failure 근본 차단 (noisy-by-default 계약)
- Meta #9520 — 텔레메트리 100% 계측 (trajectory system_prompt 캡처는 별도)
- CLAUDE.md AI 안티패턴 #2 (Unknown → Permissive Default) — render 실패를 silent 처리하는 것도 유사 패턴
