### PR TITLE
feat(keeper): stay_silent loop detector — observability for preset-mismatch burn (#9926)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -507,6 +507,7 @@
    keeper_behavioral_regime_observer
    keeper_unified_prompt
    keeper_unified_metrics
+   keeper_stay_silent_loop_detector
    keeper_error_classify
    keeper_unified_turn
 

--- a/lib/keeper/keeper_stay_silent_loop_detector.ml
+++ b/lib/keeper/keeper_stay_silent_loop_detector.ml
@@ -1,0 +1,79 @@
+let default_threshold = 10
+
+let threshold () =
+  match Sys.getenv_opt "MASC_STAY_SILENT_LOOP_THRESHOLD" with
+  | Some v when v <> "" ->
+      (match int_of_string_opt v with
+       | Some n when n >= 1 -> n
+       | _ -> default_threshold)
+  | _ -> default_threshold
+
+(* Per-keeper state: current streak + latched flag so the
+   detected-counter only bumps once per loop episode, not on every
+   turn while the keeper is stuck. *)
+type keeper_state = {
+  mutable streak : int;
+  mutable detected_latched : bool;
+}
+
+let state : (string, keeper_state) Hashtbl.t = Hashtbl.create 16
+let mutex = Stdlib.Mutex.create ()
+
+let with_lock f =
+  Stdlib.Mutex.lock mutex;
+  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock mutex) f
+
+let get_or_create keeper_name =
+  match Hashtbl.find_opt state keeper_name with
+  | Some s -> s
+  | None ->
+      let s = { streak = 0; detected_latched = false } in
+      Hashtbl.replace state keeper_name s;
+      s
+
+let update_streak_gauge keeper_name value =
+  Prometheus.set_gauge
+    "masc_keeper_stay_silent_streak"
+    ~labels:[ ("keeper", keeper_name) ]
+    (Float.of_int value)
+
+let record_turn ~keeper_name ~speech_act =
+  with_lock (fun () ->
+    let s = get_or_create keeper_name in
+    if speech_act = "stay_silent" then begin
+      s.streak <- s.streak + 1;
+      update_streak_gauge keeper_name s.streak;
+      let t = threshold () in
+      if s.streak >= t && not s.detected_latched then begin
+        s.detected_latched <- true;
+        Prometheus.inc_counter
+          "masc_keeper_stay_silent_loop_detected_total"
+          ~labels:[ ("keeper", keeper_name) ] ();
+        Log.Keeper.warn
+          "#9926 stay_silent loop detected keeper=%s streak=%d threshold=%d \
+           — keeper is returning stay_silent repeatedly. Check preset \
+           mismatch (#9926 proposal 1) or scheduler/backlog drift. \
+           Counter will not re-fire until the streak resets via any \
+           non-stay_silent speech act."
+          keeper_name s.streak t
+      end
+    end else begin
+      if s.streak > 0 then
+        update_streak_gauge keeper_name 0;
+      s.streak <- 0;
+      s.detected_latched <- false
+    end)
+
+let current_streak ~keeper_name =
+  with_lock (fun () ->
+    match Hashtbl.find_opt state keeper_name with
+    | Some s -> s.streak
+    | None -> 0)
+
+let reset ~keeper_name =
+  with_lock (fun () ->
+    Hashtbl.remove state keeper_name;
+    update_streak_gauge keeper_name 0)
+
+let reset_all_for_test () =
+  with_lock (fun () -> Hashtbl.clear state)

--- a/lib/keeper/keeper_stay_silent_loop_detector.mli
+++ b/lib/keeper/keeper_stay_silent_loop_detector.mli
@@ -1,0 +1,50 @@
+(** Stay-silent loop detector for keeper lifecycle (#9926).
+
+    masc-improver evidence from 2026-04-24: a single keeper spent
+    13.3 hours of LLM time and burned 4.19M tokens across 40+
+    consecutive [stay_silent] turns, because the scheduler kept
+    firing ticks on a keeper whose preset could not satisfy any
+    backlog task.
+
+    The scheduler-side fix (O(1) preset gate, quarantine, backlog
+    routing) is large and belongs in a follow-up. This module
+    closes the **observability** half so runtime can detect the
+    loop instead of letting it burn silently in the background.
+
+    Pure in-memory; no file I/O. Single-domain Mutex since the
+    keeper lifecycle is serialised through the after-turn hook.
+
+    Threshold source: env [MASC_STAY_SILENT_LOOP_THRESHOLD] with
+    default 10 (#9926 proposal 2).
+
+    Observability contract:
+    - [masc_keeper_stay_silent_streak{keeper=X}] gauge carries the
+      current streak length (0..N).
+    - [masc_keeper_stay_silent_loop_detected_total{keeper=X}]
+      counter increments each time the streak crosses the
+      threshold. Latched: does not increment again until the
+      streak resets to 0.
+    - A [Log.Keeper.warn] fires on first crossing, tagged [#9926].
+      Subsequent crossings only bump the metric. *)
+
+(** Update streak for [keeper_name] based on [speech_act] from the
+    latest turn. [speech_act] is the string form already emitted by
+    {!Masc_mcp.Keeper_social_model_types.speech_act_to_string} —
+    we match on the literal ["stay_silent"] rather than the variant
+    so this module does not couple to the social-model type. *)
+val record_turn : keeper_name:string -> speech_act:string -> unit
+
+(** Current consecutive stay_silent count for [keeper_name]. *)
+val current_streak : keeper_name:string -> int
+
+(** Reset streak for [keeper_name] — used on keeper restart or
+    operator-triggered unstick. *)
+val reset : keeper_name:string -> unit
+
+(** Reset all per-keeper state. Test-only. *)
+val reset_all_for_test : unit -> unit
+
+(** Threshold from env var [MASC_STAY_SILENT_LOOP_THRESHOLD]
+    (default 10). Re-read on every call; safe for test-time
+    [Unix.putenv]. *)
+val threshold : unit -> int

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1765,6 +1765,14 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               ~update_proactive_rt:true
               result
           in
+          (* #9926: observe consecutive stay_silent turns to detect the
+             masc-improver-style loop that burned 13.3h of LLM time on
+             unclaimable backlog. Pure in-memory counter; fires a latched
+             warn + counter metric when the streak crosses
+             MASC_STAY_SILENT_LOOP_THRESHOLD (default 10). *)
+          Keeper_stay_silent_loop_detector.record_turn
+            ~keeper_name:updated_meta.Keeper_types.name
+            ~speech_act:updated_meta.Keeper_types.runtime.last_speech_act;
           (try
              let channel =
                if observation.pending_mentions <> []

--- a/test/dune
+++ b/test/dune
@@ -105,6 +105,7 @@
         test_keeper_shell_docker_route
         test_env_git_noninteractive
         test_gh_exit_class
+        test_stay_silent_loop_detector
         test_keeper_fs_edit_patch
         test_keeper_docker_read
         test_keeper_github_read_only
@@ -225,6 +226,7 @@
           test_keeper_shell_docker_route
           test_env_git_noninteractive
           test_gh_exit_class
+          test_stay_silent_loop_detector
           test_keeper_fs_edit_patch
           test_keeper_docker_read
           test_keeper_github_read_only

--- a/test/test_stay_silent_loop_detector.ml
+++ b/test/test_stay_silent_loop_detector.ml
@@ -1,0 +1,175 @@
+(* test/test_stay_silent_loop_detector.ml
+
+   #9926: detector observability contract. Pins:
+   - Streak increments on consecutive "stay_silent" speech_act
+   - Streak resets to 0 on any non-stay_silent act
+   - Detected-counter only bumps once per loop episode (latched)
+   - Reset latches on streak reset
+   - Threshold env var honored
+   - Per-keeper isolation *)
+
+module D = Masc_mcp.Keeper_stay_silent_loop_detector
+module Prom = Masc_mcp.Prometheus
+
+let detected_count keeper =
+  Prom.metric_value_or_zero
+    "masc_keeper_stay_silent_loop_detected_total"
+    ~labels:[ ("keeper", keeper) ] ()
+
+let set_threshold n =
+  Unix.putenv "MASC_STAY_SILENT_LOOP_THRESHOLD" (string_of_int n)
+
+let clear_threshold () =
+  Unix.putenv "MASC_STAY_SILENT_LOOP_THRESHOLD" ""
+
+let test_streak_increments () =
+  D.reset_all_for_test ();
+  let k = "test-keeper-increments" in
+  D.record_turn ~keeper_name:k ~speech_act:"stay_silent";
+  Alcotest.(check int) "after 1" 1 (D.current_streak ~keeper_name:k);
+  D.record_turn ~keeper_name:k ~speech_act:"stay_silent";
+  D.record_turn ~keeper_name:k ~speech_act:"stay_silent";
+  Alcotest.(check int) "after 3" 3 (D.current_streak ~keeper_name:k)
+
+let test_any_other_act_resets () =
+  D.reset_all_for_test ();
+  let k = "test-keeper-resets" in
+  for _ = 1 to 5 do
+    D.record_turn ~keeper_name:k ~speech_act:"stay_silent"
+  done;
+  Alcotest.(check int) "pre-reset" 5 (D.current_streak ~keeper_name:k);
+  D.record_turn ~keeper_name:k ~speech_act:"declare";
+  Alcotest.(check int) "after declare" 0 (D.current_streak ~keeper_name:k);
+  D.record_turn ~keeper_name:k ~speech_act:"stay_silent";
+  Alcotest.(check int) "after new stay_silent" 1
+    (D.current_streak ~keeper_name:k)
+
+let test_threshold_crossing_fires_counter () =
+  D.reset_all_for_test ();
+  let k = "test-keeper-threshold-fires" in
+  set_threshold 3;
+  let before = detected_count k in
+  for _ = 1 to 2 do
+    D.record_turn ~keeper_name:k ~speech_act:"stay_silent"
+  done;
+  Alcotest.(check (float 0.0001)) "no fire at 2" before
+    (detected_count k);
+  D.record_turn ~keeper_name:k ~speech_act:"stay_silent";
+  Alcotest.(check (float 0.0001)) "fires at 3"
+    (before +. 1.0) (detected_count k);
+  clear_threshold ()
+
+let test_latched_no_repeat_while_streak_grows () =
+  D.reset_all_for_test ();
+  let k = "test-keeper-latched" in
+  set_threshold 3;
+  let before = detected_count k in
+  for _ = 1 to 10 do
+    D.record_turn ~keeper_name:k ~speech_act:"stay_silent"
+  done;
+  Alcotest.(check (float 0.0001)) "latched: exactly +1 across 10 stay_silent"
+    (before +. 1.0) (detected_count k);
+  clear_threshold ()
+
+let test_latch_releases_on_reset_then_refires () =
+  D.reset_all_for_test ();
+  let k = "test-keeper-relatch" in
+  set_threshold 3;
+  let before = detected_count k in
+  for _ = 1 to 5 do
+    D.record_turn ~keeper_name:k ~speech_act:"stay_silent"
+  done;
+  Alcotest.(check (float 0.0001)) "first loop fires once"
+    (before +. 1.0) (detected_count k);
+  (* Break the loop with a non-stay_silent act. *)
+  D.record_turn ~keeper_name:k ~speech_act:"declare";
+  (* Start a second loop. *)
+  for _ = 1 to 5 do
+    D.record_turn ~keeper_name:k ~speech_act:"stay_silent"
+  done;
+  Alcotest.(check (float 0.0001)) "second loop fires once more"
+    (before +. 2.0) (detected_count k);
+  clear_threshold ()
+
+let test_per_keeper_isolation () =
+  D.reset_all_for_test ();
+  let a = "test-keeper-A" in
+  let b = "test-keeper-B" in
+  for _ = 1 to 4 do
+    D.record_turn ~keeper_name:a ~speech_act:"stay_silent"
+  done;
+  D.record_turn ~keeper_name:b ~speech_act:"stay_silent";
+  Alcotest.(check int) "A streak" 4 (D.current_streak ~keeper_name:a);
+  Alcotest.(check int) "B streak" 1 (D.current_streak ~keeper_name:b);
+  (* Resetting A's streak does not touch B. *)
+  D.record_turn ~keeper_name:a ~speech_act:"declare";
+  Alcotest.(check int) "A reset" 0 (D.current_streak ~keeper_name:a);
+  Alcotest.(check int) "B unchanged" 1 (D.current_streak ~keeper_name:b)
+
+let test_threshold_env_default_is_10 () =
+  clear_threshold ();
+  Alcotest.(check int) "default threshold" 10 (D.threshold ())
+
+let test_threshold_env_custom () =
+  set_threshold 25;
+  Alcotest.(check int) "custom 25" 25 (D.threshold ());
+  set_threshold 1;
+  Alcotest.(check int) "custom 1" 1 (D.threshold ());
+  clear_threshold ()
+
+let test_threshold_env_invalid_falls_through_to_default () =
+  Unix.putenv "MASC_STAY_SILENT_LOOP_THRESHOLD" "notanumber";
+  Alcotest.(check int) "non-numeric → default" 10 (D.threshold ());
+  Unix.putenv "MASC_STAY_SILENT_LOOP_THRESHOLD" "0";
+  Alcotest.(check int) "0 → default (not useful)" 10 (D.threshold ());
+  Unix.putenv "MASC_STAY_SILENT_LOOP_THRESHOLD" "-1";
+  Alcotest.(check int) "-1 → default" 10 (D.threshold ());
+  clear_threshold ()
+
+let test_explicit_reset () =
+  D.reset_all_for_test ();
+  let k = "test-keeper-explicit-reset" in
+  for _ = 1 to 5 do
+    D.record_turn ~keeper_name:k ~speech_act:"stay_silent"
+  done;
+  Alcotest.(check int) "pre explicit reset" 5
+    (D.current_streak ~keeper_name:k);
+  D.reset ~keeper_name:k;
+  Alcotest.(check int) "post explicit reset" 0
+    (D.current_streak ~keeper_name:k)
+
+let () =
+  Alcotest.run "keeper_stay_silent_loop_detector"
+    [
+      ( "streak semantics",
+        [
+          Alcotest.test_case "increments on stay_silent"
+            `Quick test_streak_increments;
+          Alcotest.test_case "any other act resets"
+            `Quick test_any_other_act_resets;
+          Alcotest.test_case "explicit reset" `Quick test_explicit_reset;
+        ] );
+      ( "threshold crossing",
+        [
+          Alcotest.test_case "fires counter at threshold"
+            `Quick test_threshold_crossing_fires_counter;
+          Alcotest.test_case "latched: no repeat while streak grows"
+            `Quick test_latched_no_repeat_while_streak_grows;
+          Alcotest.test_case "latch releases on reset, then re-fires"
+            `Quick test_latch_releases_on_reset_then_refires;
+        ] );
+      ( "per-keeper isolation",
+        [
+          Alcotest.test_case "A and B independent"
+            `Quick test_per_keeper_isolation;
+        ] );
+      ( "threshold env var",
+        [
+          Alcotest.test_case "default 10" `Quick
+            test_threshold_env_default_is_10;
+          Alcotest.test_case "custom values" `Quick
+            test_threshold_env_custom;
+          Alcotest.test_case "invalid falls to default"
+            `Quick test_threshold_env_invalid_falls_through_to_default;
+        ] );
+    ]


### PR DESCRIPTION
## Problem

`masc-improver` keeper on 2026-04-24 spent **13.3 hours of LLM time** and burned **4.19M tokens** across 40+ consecutive `stay_silent` turns. The scheduler kept firing ticks on a keeper whose `masc_*`-only preset could not satisfy any of the 11 unclaimed backlog tasks (all required `coding` preset).

The loop ran silently until #9926 filer manually `jq`'d the decisions ledger. **Runtime had no metric an operator could alert on.**

## Scope — observability only

This PR adds detection, **not** scheduler correction. The structural fixes named in #9926 (O(1) preset gate before LLM call, scheduler quarantine, backlog routing) are larger and will land in follow-up PRs.

Shipping the counter first:
1. Other keepers in the same loop become visible immediately
2. Phase 2 scheduler gate has a measurable signal to trigger on
3. Future regressions are caught by the counter crossing the threshold, not by another manual audit

This PR intentionally **does not** pause or skip turns. That's a scheduler decision and belongs in Phase 2.

## Module

`lib/keeper/keeper_stay_silent_loop_detector.{ml,mli}` — pure in-memory per-keeper state + latched threshold counter.

- `record_turn ~keeper_name ~speech_act`: called from the existing after-turn path. Increments streak on `"stay_silent"`, resets on any other act.
- `masc_keeper_stay_silent_streak{keeper=X}` **gauge** — current streak length
- `masc_keeper_stay_silent_loop_detected_total{keeper=X}` **counter** — latched. Fires ONCE per loop episode when the streak crosses `MASC_STAY_SILENT_LOOP_THRESHOLD` (default 10). Re-arms when the streak resets.
- `Log.Keeper.warn` tagged `#9926` on first crossing only — no log flood

Single-domain `Stdlib.Mutex` since the keeper lifecycle is serialized through the after-turn hook (rationale: `~/me/memory/feedback_ocaml5-mutex-selection.md`).

## Integration point

`lib/keeper/keeper_unified_turn.ml` at the existing `update_metrics_from_result` call site (~line 1760). Uses the already-computed `updated_meta.runtime.last_speech_act` — no extra computation or record manipulation. One function call, pure side effect.

## Why latched counter + gauge (not per-turn counter)

A keeper stuck at streak 40 without a latch would increment the counter on every turn 10-40, producing 30 identical spikes that make "new episode started" unreadable. The split follows the canonical Google SRE §6 pattern:

- **Counter**: "How many loop episodes has this keeper entered?" — alert on `rate(...) > 0`
- **Gauge**: "What is the current streak?" — read-time snapshot

## Tests (10/10 pass, 0.002s)

```
streak semantics       0  increments on stay_silent
streak semantics       1  any other act resets
streak semantics       2  explicit reset
threshold crossing     0  fires counter at threshold
threshold crossing     1  latched: no repeat while streak grows
threshold crossing     2  latch releases on reset, then re-fires
per-keeper isolation   0  A and B independent
threshold env var      0  default 10
threshold env var      1  custom values
threshold env var      2  invalid falls to default
```

The latched-counter invariant is the most important — it's the contract that makes alerting usable.

## Scope

| File | Change |
|------|--------|
| `lib/keeper/keeper_stay_silent_loop_detector.{ml,mli}` | **new** (125 lines total) |
| `lib/dune` | +1 module registration |
| `lib/keeper/keeper_unified_turn.ml` | +7 (one function call + doc) |
| `test/test_stay_silent_loop_detector.ml` | **new** (156 lines, 10 cases) |
| `test/dune` | +2 lines |

**Total: 6 files, ~290 insertions, 0 deletions**. No public API change outside the new module.

## Follow-ups (gated on this PR)

- **O(1) preset gate before LLM call** (#9926 proposal 1) — larger, touches `before_turn` hook + backlog fetcher, worth an RFC
- **Scheduler quarantine** (#9926 proposal 2 action half) — reads the gauge + counter this PR installs
- **Backlog routing** (#9926 proposal 3) — orthogonal scheduler concern
- **Per-keeper LLM budget** (#9926 proposal 4) — economic concern, separate

## References

- #9926 issue body: 674-decision audit → 93% claim miss + 13.3h LLM time
- Google SRE §6: SLO + latched error counters
- `instructions/software-development.md` § "Silent Failure" — the loop was silent for hours; this PR makes it loud
- `~/me/memory/feedback_ocaml5-mutex-selection.md` for Mutex choice

## Do not merge

Carrying `do-not-merge` until reviewer sign-off on:

1. **Observability-only scope** — OK to land without the scheduler gate?
2. **Threshold default 10** — matches #9926 proposal 2; open to alternatives.
3. **Latch semantics** — per-episode counter + current-streak gauge. Alternative: unlatched per-turn counter with rate alerting.
4. **Module location** — `lib/keeper/` or top-level `lib/observability/`?

🤖 Generated with [Claude Code](https://claude.com/claude-code)