### PR TITLE
fix(keeper): steer model off passive-only tool sets on actionable turns (#9913)

### DIFF
--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -112,8 +112,17 @@ let build_keeper_system_prompt
        - The scheduler should open proactive turns only when structured work exists (claimed task, backlog, work discovery, worktree delta, or external signal). If a proactive turn still arrives without a real signal, do not fabricate activity; use keeper_stay_silent only as a safety valve.\n\
        - Heartbeat is server-managed. Do not plan or request heartbeat tool calls.\n\
        - ACTION TOOLS: For productive turns, use these: keeper_task_claim (claim work), keeper_fs_read + keeper_fs_edit/keeper_write (read then modify files), keeper_bash (run commands inside your sandbox; use for git add/commit/push, file ops, rg, etc.), keeper_shell op=gh (ALL GitHub CLI ops - gh pr create/view/review, gh issue list, gh api, etc. NEVER use keeper_bash for gh commands), keeper_shell op=git_clone (clone repos into your workspace), keeper_board_post (share findings), keeper_stay_silent (nothing to do). Reading without acting is not productive — if you read a file, follow up with keeper_fs_edit, keeper_bash, or the appropriate gh step.\n\
-       \n\
-       - SANDBOX PATHS: keeper_bash runs inside a Docker container. Your workspace is /home/keeper/playground/<your-name>/. Do NOT use host paths (e.g. /Users/...) in keeper_bash - use relative paths or the container workspace path. Repos cloned via keeper_shell op=git_clone appear under this workspace. For any operation needing network access (gh, curl, git push/pull), use keeper_shell op=gh or keeper_shell op=git_clone instead of keeper_bash.\n\
+       \n";
+      Printf.sprintf
+        "       - PASSIVE READS ALONE ARE NOT ENOUGH on actionable-signal turns. \
+         If the tools you called this turn are all within this read/status set \
+         {%s}, the strict tool-use contract will reject the turn. Follow up with \
+         an active tool (keeper_task_claim, keeper_fs_edit, keeper_bash, \
+         keeper_shell op=gh, keeper_board_post, or similar state-changing tool) \
+         OR call keeper_stay_silent to explicitly skip the turn.\n\
+         \n"
+        (String.concat ", " Keeper_tool_disclosure.passive_status_tool_names);
+      "       - SANDBOX PATHS: keeper_bash runs inside a Docker container. Your workspace is /home/keeper/playground/<your-name>/. Do NOT use host paths (e.g. /Users/...) in keeper_bash - use relative paths or the container workspace path. Repos cloned via keeper_shell op=git_clone appear under this workspace. For any operation needing network access (gh, curl, git push/pull), use keeper_shell op=gh or keeper_shell op=git_clone instead of keeper_bash.\n\
        - TASK LIFECYCLE: When you claim a task (keeper_task_claim), you MUST close it before ending the work. For normal terminal work, call keeper_task_done. For code/PR work that needs review, call keeper_task_submit_for_verification with notes + pr_url instead of done. If active_goal_ids are configured, keeper_task_claim only returns goal-linked tasks.\n\
        - Do not ask for conversational permission before routine low-risk work. For high-risk or destructive operations, operator approval may be required by the runtime. Do not assume risky actions are pre-approved.\n\
        - GITHUB IDENTITY: keeper_shell op=gh runs under a keeper-scoped gh identity. A keeper bound to github_identity uses $base_path/.masc/github-identities/<identity>/gh and MUST NOT fall back to the operator's personal gh config. In hard sandbox mode, github_identity is mandatory and raw `gh` through keeper_bash is blocked; use keeper_shell op=gh. Outside hard mode, unbound keepers may still use the legacy $base_path/.masc/gh-auth/ bundle when present. You can review and approve peer PRs via `gh pr review <n> --approve` — this is the intended workflow for unblocking human-merge bottlenecks on MASC-originated PRs. Use judgement: do NOT rubber-stamp; read the diff, check CI, and leave a substantive review body.\n\

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -152,17 +152,25 @@ let validate_completion_contract
        Error
          "keeper turn violated required tool contract: no tools were called")
 
-let is_passive_status_tool_name = function
-  | "masc_status"
-  | "keeper_context_status"
-  | "masc_plan_get"
-  | "keeper_time_now"
-  | "keeper_board_list"
-  | "keeper_board_get"
-  | "keeper_tasks_list"
-  | "masc_tasks" ->
-      true
-  | _ -> false
+(** Tools that report state without changing it. A turn whose tool calls
+    are entirely within this set on an actionable signal is rejected by
+    [actionable_tool_contract_violation_reason]; the same list is rendered
+    into the keeper prompt (see [Keeper_prompt]) so the model sees the
+    same definition the contract enforces. *)
+let passive_status_tool_names : string list =
+  [
+    "masc_status";
+    "keeper_context_status";
+    "masc_plan_get";
+    "keeper_time_now";
+    "keeper_board_list";
+    "keeper_board_get";
+    "keeper_tasks_list";
+    "masc_tasks";
+  ]
+
+let is_passive_status_tool_name name =
+  List.mem name passive_status_tool_names
 
 let actionable_tool_contract_violation_reason
       ~(actionable_signal_context : bool)


### PR DESCRIPTION
## 요약

`actionable_tool_contract_violation_reason`(`lib/keeper/keeper_tool_disclosure.ml:167`)는 turn 내 모든 tool call이 passive status/read 세트에 속하면 contract violation으로 거부하지만, keeper 프롬프트는 이 rule이나 passive 세트를 명시한 적이 없습니다. 모델은 `masc_status`, `keeper_board_list` 만 부르고 turn을 끝내다가 반복 실패했습니다 (2026-04-24 런타임에서 sangsu / janitor / masc-improver 전부 관측).

Closes #9913.

## 변경 내용

1. `Keeper_tool_disclosure.passive_status_tool_names : string list` 상수 추출 — contract match 경로는 `List.mem`으로 동일하게 delegate (런타임 동작 불변).
2. `Keeper_prompt.build_keeper_system_prompt`의 Autonomous behavior 블록에 새 bullet 추가:

```
- PASSIVE READS ALONE ARE NOT ENOUGH on actionable-signal turns.
  If the tools you called this turn are all within this read/status set
  {masc_status, keeper_context_status, masc_plan_get, keeper_time_now,
   keeper_board_list, keeper_board_get, keeper_tasks_list, masc_tasks},
  the strict tool-use contract will reject the turn. Follow up with an
  active tool (keeper_task_claim, keeper_fs_edit, keeper_bash,
  keeper_shell op=gh, keeper_board_post, or similar state-changing tool)
  OR call keeper_stay_silent to explicitly skip the turn.
```

List는 `Printf.sprintf`로 `passive_status_tool_names`에서 렌더링 — SSOT 유지, 향후 세트가 바뀌면 프롬프트와 contract가 동시에 갱신.

## 회귀 리스크

| 경로 | before | after |
|------|--------|-------|
| Contract match 로직 | match 8-case | `List.mem` 동일 결과 |
| 정상 active tool turn | pass | pass (unchanged) |
| Mixed passive + active turn | pass (`List.for_all` false) | pass (unchanged) |
| Passive-only turn on actionable signal | 거부 | 거부 (unchanged) — 프롬프트가 사전 예방 |
| 프롬프트 길이 | — | ~5 lines 추가 |

KV-cache 공유 prefix 위치 유지 (profile/persona 앞). 런타임 비결정적 부분은 건드리지 않음.

## 검증

- [x] `dune build @check --root .` exit 0
- [ ] 실 keeper 동작 변화는 observational — 머지 후 contract violation 발생 빈도 감소로 확인

## 검증하지 못한 항목

- 다른 passive 패턴(예: `keeper_memory_search`만 단독 호출) 추가 여부는 별도 판단 필요. 본 PR은 기존 contract가 이미 분류한 세트만 노출 — 확장은 follow-up.
- 프롬프트 토큰 증가분(~60 tokens) 측정 없음. KV-cache hit 영향 미미 예상 (정적 prefix 부분).

## 참고

- Issue #9913 — 증상/재현 조건
- PR #9911 — cascade-name preservation 별도 fix
- CLAUDE.md 안티패턴 #1 (하드코딩 산포) — 본 PR이 list 상수 추출로 완화 (ml/prompt 2 곳에 리터럴 박기 회피)
