### PR TITLE
feat(server): wire heuristic_metrics_diagnostics into boot-time health log (#9919)

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -273,6 +273,46 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   Keeper_runtime_resolved.init ();
   (* RFC-0001 Gate A: initialize instrumentation stores *)
   Heuristic_metrics.init ~base_path;
+  (* #9919: boot-time diagnostics for the instrumentation-theatre
+     signature (#7718). The diagnostics module flags sites where a
+     large number of records collapse to a single [(raw_value,
+     threshold, triggered)] tuple — the #9919 symptom was 51 rows,
+     all [(1.0, 0.0, true)] at [post_tool_use_failure], making the
+     whole ledger equivalent to a 1-bit "a failure happened".
+
+     We run this once at startup over a recent slice rather than on
+     a periodic fiber: the degenerate shape persists across
+     restarts, so one observation at boot is enough to make
+     operators see the problem, and an ongoing poll would compete
+     with the live writer without adding diagnostic value. *)
+  (try
+     let recent = Heuristic_metrics.recent 500 in
+     let report = Heuristic_metrics_diagnostics.analyze recent in
+     if report.total_records > 0 then begin
+       Log.Server.info "heuristic_metrics diagnostics: %s"
+         (Heuristic_metrics_diagnostics.pretty_summary report);
+       if report.degenerate_sites <> [] then
+         Log.Server.warn
+           "#9919 heuristic_metrics degenerate sites detected: [%s] \
+            — each site accumulated >= %d records with exactly one \
+            distinct (raw_value, threshold, triggered) tuple, which \
+            is the #7718 instrumentation-theatre signature. Check \
+            the site emitters for hardcoded thresholds/values."
+           (String.concat ", " report.degenerate_sites)
+           Heuristic_metrics_diagnostics.degenerate_min_records;
+       if report.one_sided_sites <> [] then
+         Log.Server.warn
+           "#9919 heuristic_metrics one-sided sites: [%s] — every \
+            record at these sites had the same [triggered] value, \
+            meaning the threshold gate never flipped. Either the \
+            threshold is trivial or the branch is unreachable."
+           (String.concat ", " report.one_sided_sites)
+     end
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+     Log.Server.warn "#9919 heuristic_metrics diagnostics failed: %s"
+       (Printexc.to_string exn));
   Agent_stress.init ~base_path;
   (* Load tool policy presets from config/tool_policy.toml *)
   (match Keeper_exec_tools.init_policy_config ~base_path with

--- a/test/dune
+++ b/test/dune
@@ -106,6 +106,7 @@
         test_env_git_noninteractive
         test_gh_exit_class
         test_stay_silent_loop_detector
+        test_heuristic_metrics_boot_wireup
         test_keeper_fs_edit_patch
         test_keeper_docker_read
         test_keeper_github_read_only
@@ -227,6 +228,7 @@
           test_env_git_noninteractive
           test_gh_exit_class
           test_stay_silent_loop_detector
+          test_heuristic_metrics_boot_wireup
           test_keeper_fs_edit_patch
           test_keeper_docker_read
           test_keeper_github_read_only

--- a/test/test_heuristic_metrics_boot_wireup.ml
+++ b/test/test_heuristic_metrics_boot_wireup.ml
@@ -1,0 +1,105 @@
+(* test/test_heuristic_metrics_boot_wireup.ml
+
+   #9919: pin the boot-time diagnostics wiring contract. The
+   bootstrap block in [lib/server/server_runtime_bootstrap.ml]
+   wraps [Heuristic_metrics_diagnostics.analyze] around the
+   live [Heuristic_metrics.recent] slice; this test exercises
+   the same analyze-over-recent-slice flow without spinning up
+   the full server, so a regression that removes the wiring or
+   changes the diagnostics signature is caught by CI.
+
+   The #9919 regression signature itself is exercised in
+   [test_heuristic_metrics_diagnostics.ml] (merged via PR #9879);
+   this test only verifies the boot-time consumption shape.  *)
+
+module HM = Masc_mcp.Heuristic_metrics
+module HD = Masc_mcp.Heuristic_metrics_diagnostics
+
+let tmp_base_path () =
+  Filename.concat
+    (Filename.get_temp_dir_name ())
+    (Printf.sprintf "masc-heuristic-wireup-%d-%06x"
+       (Unix.getpid ()) (Random.bits ()))
+
+let with_fresh_store f =
+  let base = tmp_base_path () in
+  Unix.mkdir base 0o755;
+  HM.init ~base_path:base;
+  Fun.protect
+    ~finally:(fun () ->
+      try HM.flush () with _ -> ();
+      let rec rm_rf p =
+        if Sys.file_exists p then
+          if Sys.is_directory p then begin
+            Sys.readdir p
+            |> Array.iter (fun c -> rm_rf (Filename.concat p c));
+            Unix.rmdir p
+          end else Sys.remove p
+      in
+      rm_rf base)
+    f
+
+let record_failure_event () =
+  HM.record {
+    module_name = "keeper_hooks_oas";
+    site = "post_tool_use_failure";
+    raw_value = 1.0;
+    threshold = 0.0;
+    triggered = true;
+    provenance = HM.Pipeline_stage "post_tool_use_failure";
+    timestamp = Unix.gettimeofday ();
+  }
+
+let test_empty_store_produces_zero_report () =
+  with_fresh_store (fun () ->
+    let recent = HM.recent 500 in
+    let report = HD.analyze recent in
+    Alcotest.(check int) "empty → 0 total" 0 report.total_records;
+    Alcotest.(check int) "empty → 0 degenerate" 0
+      (List.length report.degenerate_sites);
+    Alcotest.(check int) "empty → 0 one_sided" 0
+      (List.length report.one_sided_sites))
+
+let test_degenerate_signature_flagged_by_wireup_flow () =
+  with_fresh_store (fun () ->
+    (* Emit exactly the #9919 signature — 25 identical records,
+       all [(1.0, 0.0, true)] at post_tool_use_failure. 25 clears
+       the [degenerate_min_records] threshold (20). *)
+    for _ = 1 to 25 do record_failure_event () done;
+    HM.flush ();
+    let recent = HM.recent 500 in
+    let report = HD.analyze recent in
+    Alcotest.(check int) "25 records ingested" 25 report.total_records;
+    Alcotest.(check bool)
+      "post_tool_use_failure flagged as degenerate"
+      true
+      (List.mem "post_tool_use_failure" report.degenerate_sites);
+    Alcotest.(check bool)
+      "post_tool_use_failure flagged as one_sided (always triggered=true)"
+      true
+      (List.mem "post_tool_use_failure" report.one_sided_sites);
+    let summary = HD.pretty_summary report in
+    Alcotest.(check bool)
+      "summary mentions the site"
+      true
+      (let s = String.lowercase_ascii summary in
+       let n = "post_tool_use_failure" in
+       let nl = String.length n in
+       let sl = String.length s in
+       let rec scan i =
+         if i + nl > sl then false
+         else if String.sub s i nl = n then true
+         else scan (i + 1)
+       in scan 0))
+
+let () =
+  Alcotest.run "heuristic_metrics_boot_wireup"
+    [
+      ( "boot-time consumption shape",
+        [
+          Alcotest.test_case "empty store → empty report" `Quick
+            test_empty_store_produces_zero_report;
+          Alcotest.test_case "#9919 signature → both flags fire" `Quick
+            test_degenerate_signature_flagged_by_wireup_flow;
+        ] );
+    ]


### PR DESCRIPTION
## TL;DR

PR #9879 (merged) gave us a `Heuristic_metrics_diagnostics` module that detects exactly the #9919 signature (51 identical `post_tool_use_failure` records, all `(1.0, 0.0, true)`). The module had **no caller**. This PR wires it into the server bootstrap so the contamination surfaces at startup instead of waiting for a manual `jq` over the ledger.

## Fix

One call block in `lib/server/server_runtime_bootstrap.ml` immediately after `Heuristic_metrics.init`:

- Reads the last 500 records via `Heuristic_metrics.recent`
- Runs `Heuristic_metrics_diagnostics.analyze`
- Logs `pretty_summary` at info level (baseline health)
- Emits `#9919`-tagged warn when `degenerate_sites` or `one_sided_sites` is non-empty

Wrapped in try/with — a diagnostic failure must never prevent server startup.

## Example boot log when #9919 is present

```
[Server][warn] #9919 heuristic_metrics degenerate sites detected: \
  [post_tool_use_failure] — each site accumulated >= 20 records \
  with exactly one distinct (raw_value, threshold, triggered) \
  tuple, which is the #7718 instrumentation-theatre signature. \
  Check the site emitters for hardcoded thresholds/values.

[Server][warn] #9919 heuristic_metrics one-sided sites: \
  [post_tool_use_failure] — every record at these sites had the \
  same [triggered] value, meaning the threshold gate never \
  flipped. Either the threshold is trivial or the branch is \
  unreachable.
```

Two messages are independent: a site can be one-sided without being degenerate (many distinct raw values, all above threshold) and vice versa.

## Why boot-time, not periodic

The degenerate shape persists across restarts — 51 rows accumulated over 2+ days at the time of #9919 filing. One observation at boot is sufficient to make operators see the problem. An ongoing poll would compete with the live writer without adding diagnostic value.

Contrast with #9914 Hebbian consolidation fiber where the work itself is periodic decay/pruning.

## Tests (2/2 pass, 0.001s)

1. **Empty store → empty report** (no false positives on fresh boot)
2. **#9919 signature → both flags fire** — 25 identical `post_tool_use_failure` records through `Heuristic_metrics.record` → `recent` → `analyze` flags both `degenerate_sites` and `one_sided_sites`, and `pretty_summary` mentions the site

The second test exercises the same `Heuristic_metrics.recent → Heuristic_metrics_diagnostics.analyze` path the boot block uses, so a regression that detaches the two fails CI.

## Scope

| File | Change |
|------|--------|
| `lib/server/server_runtime_bootstrap.ml` | +40 (one block + try/with) |
| `test/test_heuristic_metrics_boot_wireup.ml` | **new** (104 lines, 2 cases) |
| `test/dune` | +2 lines |

**Total: 3 files, ~147 insertions, 0 deletions**. No public API change. Only boot log gains 1 info line + 0-2 warn lines.

## Relation to other PRs

- **#9879** (merged): diagnostics module definition + 8 direct tests. This PR is the deferred "boot-time wire-up" from #9879 body.
- **#9926 / #9931** (stay_silent loop detector): parallel Phase-1 observability pattern — observe first, control later
- **#9914** (Hebbian fiber): periodic observation. This PR is boot-only because the signal is stable across restarts.

## Follow-ups (not in this PR)

- #9919 proposal 1: schema extension (`keeper_name`, `session_id`, `tool`, `turn`, `task_id`) — RFC scope
- #9919 proposal 2: dynamic threshold — touches every emitter
- #9919 proposal 3: awaken dormant sites (turn_stall, cost_spike, tool_timeout)
- Prometheus alert on `rate of #9919 log lines > 0`

## Do not merge

Carrying `do-not-merge` until reviewer sign-off on:

1. **Boot-only cadence** — OK without a periodic re-check?
2. **500-record slice size** — enough to catch degenerate sites (`degenerate_min_records=20` in the module), small enough to parse quickly at boot. Open to alternatives.
3. **Warn vs error level** — `warn` follows existing `Log.Server.warn` conventions, but if #9919 should block startup, `error` is the right choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)