### PR TITLE
fix(config): warn when HOME fallback masks MASC_BASE_PATH propagation (#9896)

### DIFF
--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -249,7 +249,26 @@ let config_root_resolution (inputs : inputs) =
       | Some path -> ({ path; exists = true; source = Local_masc }, [])
       | None ->
           match path_from_home_masc inputs with
-          | Some path -> ({ path; exists = true; source = Home_masc }, [])
+          | Some path ->
+              (* Warn only when MASC_BASE_PATH was set but local resolution
+                 still failed — that is the #9896 drift signature (harness
+                 subprocess has env set or is meant to, yet Local_masc
+                 didn't resolve so we slid into HOME). If env_base_path is
+                 empty the user deliberately runs without an explicit base
+                 path and HOME is the intended root; no warning needed. *)
+              let warnings =
+                match trim_opt inputs.env_base_path with
+                | None -> []
+                | Some _ ->
+                    [
+                      Printf.sprintf
+                        "MASC_BASE_PATH is set but its .masc/config was \
+                         not found; falling back to HOME (%s). Check \
+                         subprocess env propagation. See #9896."
+                        path;
+                    ]
+              in
+              ({ path; exists = true; source = Home_masc }, warnings)
           | None ->
               if repo_config_fallback_enabled () then
                 match path_from_cwd inputs.cwd with


### PR DESCRIPTION
## 요약

Harness/subprocess가 `MASC_BASE_PATH`를 상속받지 못하면 `Config_dir_resolver`가 silent하게 `$HOME/.masc`로 fallback, production 서버의 basepath와 병렬 state (board_posts, keeper credential, keeper config)를 만들어 split-brain 발생. 본 PR은 `MASC_BASE_PATH`가 설정되어 있음에도 `path_from_local_masc`가 실패하고 HOME fallback으로 떨어질 때에만 경고를 발화하여 해당 drift 시그니처만 노출합니다.

Closes #9896.

## 근본 원인

`lib/config_dir_resolver.ml`의 `config_root_resolution`은 우선순위:

1. `MASC_CONFIG_DIR` (explicit env override)
2. `path_from_local_masc` — MASC_BASE_PATH/.masc/config 존재 시
3. `path_from_home_masc` — $HOME/.masc/config 존재 시
4. (옵션) cwd / exe-relative / missing

주로 harness가 `MASC_BASE_PATH`를 env에서 잃고 다른 프로세스의 `$HOME/.masc`에 기록할 때 2번은 path가 없어서 실패, 3번으로 silent 이동. 관측 결과:
- `~/.masc/board_posts.jsonl`: 128 lines (harness bot / test / persist 계열)
- `~/me/.masc/board_posts.jsonl`: 264 lines (production keeper 계열)
- 두 디렉터리 모두 최근 48h 내 mtime.

## 변경 내용

`path_from_home_masc`가 Some을 반환할 때, `env_base_path`의 유무에 따라 warning 조건화:

```diff
          match path_from_home_masc inputs with
-         | Some path -> ({ path; exists = true; source = Home_masc }, [])
+         | Some path ->
+             let warnings =
+               match trim_opt inputs.env_base_path with
+               | None -> []
+               | Some _ ->
+                   [ Printf.sprintf
+                       "MASC_BASE_PATH is set but its .masc/config was \
+                        not found; falling back to HOME (%s). Check \
+                        subprocess env propagation. See #9896."
+                       path ]
+             in
+             ({ path; exists = true; source = Home_masc }, warnings)
```

**발화 조건의 정밀화**: `env_base_path=None`인 경우는 HOME을 의도한 설정이므로 조용히 유지. `env_base_path=Some _`인데 local resolution 실패한 경우만 drift 증거로 기록.

## 회귀 리스크

| 시나리오 | before | after |
|----------|--------|-------|
| 명시적 MASC_CONFIG_DIR | Env source | unchanged |
| MASC_BASE_PATH + local .masc/config 존재 | Local_masc | unchanged |
| env_base_path 없음 + HOME/.masc/config | Home_masc, warnings=[] | unchanged |
| **env_base_path 있음 + local 실패 → HOME 매치** | Home_masc, warnings=[] ❌ | Home_masc + 1 warning, status=Warn ✅ |
| Missing 전부 | Missing | unchanged |

`log_warnings` 기존 경로가 자동으로 signature dedup + Log.warn emit 처리. 추가 plumbing 없음.

## 테스트

- [x] `dune build @check --root .` exit 0
- [x] `dune runtest test/test_config_dir_resolver.exe --root .` — 17/17 passed (home_masc_fallback 케이스는 `env_base_path=None`이라 경고 없이 통과, 기존 assertion 유지)

## 검증하지 못한 항목

- 실환경 harness 프로세스 재현은 하지 않았습니다. 이 PR은 resolver의 warning 경로만 수정 — 실제로 harness가 warning을 emit하는지는 머지 후 관측으로 확인.
- Issue 제안 #3 (xxwritecheck source 식별) 및 #4 (harness tmp dir 분리)는 별도 PR 대상.
- `personas_dirs` 관련 fallback은 같은 파일의 `personas_item`에서 처리 — 본 PR은 `config_root_resolution` 범위만 수정.

## 참고

- Issue #9896 — 증상, 제안 #1 (warning 발화) 구현
- PR #9920 — 부분 safeguard (Env_config_core.base_path HOME raise)
- `feedback_masc-cascade-config-basepath.md` — live config=basepath SSOT 규약
- CLAUDE.md 안티패턴 #2 — Unknown → Permissive Default의 env 버전
