### PR TITLE
fix(blocker): preserve structured masc_oas_error payloads (#9933)

### DIFF
--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -1354,8 +1354,17 @@ let parse_keeper_state
   let last_current_intention =
     cap_loaded (Safe_ops.json_string ~default:"" "last_current_intention" json)
   in
+  (* #9933: blocker may carry a structured [masc_oas_error] JSON
+     payload. cap_loaded (narrative budget = 200 chars) would slice
+     the JSON mid-key and lose diagnostic fields (budget_sec,
+     keeper_turn_timeout_sec, estimated_input_tokens, source).
+     cap_blocker preserves structured payloads up to
+     masc_oas_error_max_chars and falls through to the narrative
+     budget for plain text. Symmetric with the write side in
+     Keeper_social_model_types.cap_social_state. *)
   let last_blocker =
-    cap_loaded (Safe_ops.json_string ~default:"" "last_blocker" json)
+    Keeper_social_model_types.cap_blocker
+      (Safe_ops.json_string ~default:"" "last_blocker" json)
   in
   let last_blocker_class =
     match Safe_ops.json_string_opt "last_blocker_class" json with

--- a/lib/keeper/social_model/keeper_social_model_types.ml
+++ b/lib/keeper/social_model/keeper_social_model_types.ml
@@ -163,6 +163,23 @@ let transition_reason_to_string = function
 let default_belief_summary_max_chars = 400
 let default_option_field_max_chars = 200
 
+(* #9933: structured error payloads (e.g. [masc_oas_error] JSON) must
+   NOT be truncated at the narrative budget, or the JSON body is cut
+   mid-key and downstream consumers (dashboard, retry classifier, log
+   search) see a partial kind=oas_timeout_budget record with the
+   budget-underscore value missing, and cannot recover the diagnostic
+   fields. The operator ends up re-filing the same triage ticket
+   because the budget value, elapsed time, and source field never
+   reach them. *)
+let masc_oas_error_prefix = "[masc_oas_error]"
+
+(** Safety cap for structured payloads. ~2000 chars fits a
+    Yojson-encoded [masc_internal_error] record of any current variant
+    plus the wrapping prefix, with headroom for future fields. Past
+    this the payload is pathological and we re-apply the narrative
+    budget rather than store unbounded blobs. *)
+let masc_oas_error_max_chars = 2000
+
 let truncate_string ~max_chars s =
   String_util.utf8_safe ~max_bytes:(max_chars + 3) ~suffix:"…" s |> String_util.to_string
 
@@ -171,6 +188,30 @@ let truncate_option ~max_chars = function
   | Some s ->
       Some (String_util.utf8_safe ~max_bytes:(max_chars + 3) ~suffix:"…" s
             |> String_util.to_string)
+
+(** [cap_blocker s] returns [s] unchanged when it is a structured
+    [masc_oas_error] payload that fits inside [masc_oas_error_max_chars].
+    Narrative strings fall through to the normal option-field cap so
+    dashboards / logs still see bounded text. This is the #9933 fix
+    for budget-underscore truncation. Idempotent. *)
+let cap_blocker
+    ?(option_max_chars = default_option_field_max_chars)
+    (s : string) : string =
+  let trimmed = String.trim s in
+  let has_prefix =
+    let pl = String.length masc_oas_error_prefix in
+    String.length trimmed >= pl
+    && String.sub trimmed 0 pl = masc_oas_error_prefix
+  in
+  if has_prefix && String.length s <= masc_oas_error_max_chars then s
+  else if has_prefix then
+    truncate_string ~max_chars:masc_oas_error_max_chars s
+  else
+    truncate_string ~max_chars:option_max_chars s
+
+let cap_blocker_option ?option_max_chars = function
+  | None -> None
+  | Some s -> Some (cap_blocker ?option_max_chars s)
 
 let cap_social_state
     ?(belief_max_chars = default_belief_summary_max_chars)
@@ -184,6 +225,7 @@ let cap_social_state
       truncate_option ~max_chars:option_max_chars state.active_desire;
     current_intention =
       truncate_option ~max_chars:option_max_chars state.current_intention;
-    blocker = truncate_option ~max_chars:option_max_chars state.blocker;
+    blocker =
+      cap_blocker_option ~option_max_chars state.blocker;
     need = truncate_option ~max_chars:option_max_chars state.need;
   }

--- a/lib/keeper/social_model/keeper_social_model_types.ml
+++ b/lib/keeper/social_model/keeper_social_model_types.ml
@@ -163,21 +163,23 @@ let transition_reason_to_string = function
 let default_belief_summary_max_chars = 400
 let default_option_field_max_chars = 200
 
-(* #9933: structured error payloads (e.g. [masc_oas_error] JSON) must
-   NOT be truncated at the narrative budget, or the JSON body is cut
-   mid-key and downstream consumers (dashboard, retry classifier, log
-   search) see a partial kind=oas_timeout_budget record with the
+(* #9933: structured error payloads (e.g. [masc_oas_error] JSON, or
+   Oas.Error.to_string's "Internal error: [masc_oas_error]" wrapper)
+   must NOT be truncated at the narrative budget, or the JSON body is
+   cut mid-key and downstream consumers (dashboard, retry classifier,
+   log search) see a partial kind=oas_timeout_budget record with the
    budget-underscore value missing, and cannot recover the diagnostic
    fields. The operator ends up re-filing the same triage ticket
    because the budget value, elapsed time, and source field never
    reach them. *)
 let masc_oas_error_prefix = "[masc_oas_error]"
+let masc_oas_error_wrapped_prefix = "Internal error: " ^ masc_oas_error_prefix
 
 (** Safety cap for structured payloads. ~2000 chars fits a
     Yojson-encoded [masc_internal_error] record of any current variant
     plus the wrapping prefix, with headroom for future fields. Past
-    this the payload is pathological and we re-apply the narrative
-    budget rather than store unbounded blobs. *)
+    this the payload is pathological and we still cap it rather than
+    store unbounded blobs. *)
 let masc_oas_error_max_chars = 2000
 
 let truncate_string ~max_chars s =
@@ -189,6 +191,14 @@ let truncate_option ~max_chars = function
       Some (String_util.utf8_safe ~max_bytes:(max_chars + 3) ~suffix:"…" s
             |> String_util.to_string)
 
+let has_masc_oas_error_prefix (s : string) : bool =
+  let has_prefix prefix =
+    let pl = String.length prefix in
+    String.length s >= pl && String.sub s 0 pl = prefix
+  in
+  has_prefix masc_oas_error_prefix
+  || has_prefix masc_oas_error_wrapped_prefix
+
 (** [cap_blocker s] returns [s] unchanged when it is a structured
     [masc_oas_error] payload that fits inside [masc_oas_error_max_chars].
     Narrative strings fall through to the normal option-field cap so
@@ -198,11 +208,7 @@ let cap_blocker
     ?(option_max_chars = default_option_field_max_chars)
     (s : string) : string =
   let trimmed = String.trim s in
-  let has_prefix =
-    let pl = String.length masc_oas_error_prefix in
-    String.length trimmed >= pl
-    && String.sub trimmed 0 pl = masc_oas_error_prefix
-  in
+  let has_prefix = has_masc_oas_error_prefix trimmed in
   if has_prefix && String.length s <= masc_oas_error_max_chars then s
   else if has_prefix then
     truncate_string ~max_chars:masc_oas_error_max_chars s

--- a/lib/keeper/social_model/keeper_social_model_types.mli
+++ b/lib/keeper/social_model/keeper_social_model_types.mli
@@ -64,15 +64,34 @@ val transition_reason_to_string : transition_reason -> string
 val default_belief_summary_max_chars : int
 val default_option_field_max_chars : int
 
+(** #9933: safety cap for structured [masc_oas_error] payloads. Larger
+    than the narrative cap so JSON bodies survive intact. *)
+val masc_oas_error_max_chars : int
+
+(** Prefix the structured-payload branch of {!cap_blocker} matches. *)
+val masc_oas_error_prefix : string
+
 (** Truncate a string to [max_chars] characters; append "…" when the
     limit bites. Shared by [cap_social_state] and the checkpoint load
     path so both directions honour the same budget. Idempotent. *)
 val truncate_string : max_chars:int -> string -> string
 
+(** [cap_blocker s] preserves structured [masc_oas_error] payloads up
+    to {!masc_oas_error_max_chars} so downstream diagnostics (dashboard,
+    retry classifier, log search) can read the JSON body intact.
+    Narrative strings fall through to {!default_option_field_max_chars}.
+    Idempotent. See #9933. *)
+val cap_blocker : ?option_max_chars:int -> string -> string
+
+(** Option-aware variant of {!cap_blocker}. *)
+val cap_blocker_option : ?option_max_chars:int -> string option -> string option
+
 (** Bound the narrative fields of a [social_state] before it leaves the
     speech model. Caps [belief_summary] and each option field with an
-    ellipsis marker when they exceed the budget. Other fields pass
-    through unchanged. Idempotent. *)
+    ellipsis marker when they exceed the budget. The [blocker] field
+    is special-cased via {!cap_blocker} so structured
+    [masc_oas_error] payloads are preserved intact (#9933).
+    Idempotent. *)
 val cap_social_state :
   ?belief_max_chars:int ->
   ?option_max_chars:int ->

--- a/lib/keeper/social_model/keeper_social_model_types.mli
+++ b/lib/keeper/social_model/keeper_social_model_types.mli
@@ -77,9 +77,11 @@ val masc_oas_error_prefix : string
 val truncate_string : max_chars:int -> string -> string
 
 (** [cap_blocker s] preserves structured [masc_oas_error] payloads up
-    to {!masc_oas_error_max_chars} so downstream diagnostics (dashboard,
-    retry classifier, log search) can read the JSON body intact.
-    Narrative strings fall through to {!default_option_field_max_chars}.
+    to {!masc_oas_error_max_chars}, including the
+    ["Internal error: [masc_oas_error]"] wrapper emitted by
+    [Oas.Error.to_string], so downstream diagnostics (dashboard, retry
+    classifier, log search) can read the JSON body intact. Narrative
+    strings fall through to {!default_option_field_max_chars}.
     Idempotent. See #9933. *)
 val cap_blocker : ?option_max_chars:int -> string -> string
 

--- a/test/dune
+++ b/test/dune
@@ -107,6 +107,7 @@
         test_gh_exit_class
         test_stay_silent_loop_detector
         test_heuristic_metrics_boot_wireup
+        test_cap_blocker_structured_error
         test_keeper_fs_edit_patch
         test_keeper_docker_read
         test_keeper_github_read_only
@@ -229,6 +230,7 @@
           test_gh_exit_class
           test_stay_silent_loop_detector
           test_heuristic_metrics_boot_wireup
+          test_cap_blocker_structured_error
           test_keeper_fs_edit_patch
           test_keeper_docker_read
           test_keeper_github_read_only

--- a/test/test_cap_blocker_structured_error.ml
+++ b/test/test_cap_blocker_structured_error.ml
@@ -3,9 +3,9 @@
    #9933: blocker field must preserve structured masc_oas_error
    JSON payloads. The pre-fix behaviour truncated at 200 chars,
    slicing payloads like
-   "[masc_oas_error] {\"kind\":\"oas_timeout_budget\",\"budget_sec\":30.0,...}"
-   mid-key and leaving operators with "budget_" as the trailing
-   evidence.
+   "Internal error: [masc_oas_error] {\"kind\":\"oas_timeout_budget\",\
+   \"budget_sec\":30.0,...}" mid-key and leaving operators with
+   "budget_" as the trailing evidence.
 
    Pinned invariants:
    1. Structured payload ≤ 2000 chars → identity (no ellipsis)
@@ -23,6 +23,8 @@ let oas_error_payload_small =
   "[masc_oas_error] {\"kind\":\"oas_timeout_budget\",\
    \"budget_sec\":30.0,\"keeper_turn_timeout_sec\":120.0,\
    \"estimated_input_tokens\":45000,\"source\":\"tool_list_build\"}"
+
+let wrapped_oas_error_payload_small = "Internal error: " ^ oas_error_payload_small
 
 let oas_error_payload_huge =
   let buf = Buffer.create 2500 in
@@ -75,19 +77,14 @@ let test_plain_narrative_short_preserved () =
     "short narrative unchanged"
     narrative_short (T.cap_blocker narrative_short)
 
-(* The on-wire stored form emitted by Oas_worker_named and consumed by
-   Keeper_supervisor is [masc_oas_error] with no outer "Internal error:"
-   wrapper (see keeper_supervisor.ml:63). This pins that contract — if a
-   future logging layer ever prepends "Internal error: ", the detector
-   needs to be updated in parallel. *)
-let test_wrapped_internal_error_is_treated_as_narrative () =
-  let wrapped = "Internal error: " ^ oas_error_payload_small in
-  let result = T.cap_blocker wrapped in
+let test_wrapped_internal_error_preserved () =
+  let result = T.cap_blocker wrapped_oas_error_payload_small in
+  Alcotest.(check string)
+    "wrapped structured payload unchanged"
+    wrapped_oas_error_payload_small result;
   Alcotest.(check bool)
-    "wrapped form without [masc_oas_error] prefix → narrative cap"
-    true
-    (String.length result <= T.default_option_field_max_chars + 8
-     (* ellipsis byte-padding budget *))
+    "no ellipsis added to wrapped structured payload"
+    false (ends_with_ellipsis result)
 
 let test_plain_narrative_long_truncated () =
   let result = T.cap_blocker narrative_long in
@@ -109,6 +106,7 @@ let test_idempotence () =
       (Printf.sprintf "idempotent: %s" label) once twice
   in
   check "small structured" oas_error_payload_small;
+  check "wrapped structured" wrapped_oas_error_payload_small;
   check "huge structured" oas_error_payload_huge;
   check "short narrative" narrative_short;
   check "long narrative" narrative_long
@@ -174,8 +172,8 @@ let () =
             test_plain_narrative_short_preserved;
           Alcotest.test_case "long truncated at narrative cap" `Quick
             test_plain_narrative_long_truncated;
-          Alcotest.test_case "wrapped 'Internal error:' → narrative" `Quick
-            test_wrapped_internal_error_is_treated_as_narrative;
+          Alcotest.test_case "wrapped 'Internal error:' preserved" `Quick
+            test_wrapped_internal_error_preserved;
         ] );
       ( "idempotence",
         [ Alcotest.test_case "four shapes" `Quick test_idempotence ] );

--- a/test/test_cap_blocker_structured_error.ml
+++ b/test/test_cap_blocker_structured_error.ml
@@ -75,6 +75,20 @@ let test_plain_narrative_short_preserved () =
     "short narrative unchanged"
     narrative_short (T.cap_blocker narrative_short)
 
+(* The on-wire stored form emitted by Oas_worker_named and consumed by
+   Keeper_supervisor is [masc_oas_error] with no outer "Internal error:"
+   wrapper (see keeper_supervisor.ml:63). This pins that contract — if a
+   future logging layer ever prepends "Internal error: ", the detector
+   needs to be updated in parallel. *)
+let test_wrapped_internal_error_is_treated_as_narrative () =
+  let wrapped = "Internal error: " ^ oas_error_payload_small in
+  let result = T.cap_blocker wrapped in
+  Alcotest.(check bool)
+    "wrapped form without [masc_oas_error] prefix → narrative cap"
+    true
+    (String.length result <= T.default_option_field_max_chars + 8
+     (* ellipsis byte-padding budget *))
+
 let test_plain_narrative_long_truncated () =
   let result = T.cap_blocker narrative_long in
   Alcotest.(check bool)
@@ -160,6 +174,8 @@ let () =
             test_plain_narrative_short_preserved;
           Alcotest.test_case "long truncated at narrative cap" `Quick
             test_plain_narrative_long_truncated;
+          Alcotest.test_case "wrapped 'Internal error:' → narrative" `Quick
+            test_wrapped_internal_error_is_treated_as_narrative;
         ] );
       ( "idempotence",
         [ Alcotest.test_case "four shapes" `Quick test_idempotence ] );

--- a/test/test_cap_blocker_structured_error.ml
+++ b/test/test_cap_blocker_structured_error.ml
@@ -1,0 +1,173 @@
+(* test/test_cap_blocker_structured_error.ml
+
+   #9933: blocker field must preserve structured masc_oas_error
+   JSON payloads. The pre-fix behaviour truncated at 200 chars,
+   slicing payloads like
+   "[masc_oas_error] {\"kind\":\"oas_timeout_budget\",\"budget_sec\":30.0,...}"
+   mid-key and leaving operators with "budget_" as the trailing
+   evidence.
+
+   Pinned invariants:
+   1. Structured payload ≤ 2000 chars → identity (no ellipsis)
+   2. Structured payload > 2000 chars → truncated at the safety cap,
+      not the narrative cap
+   3. Plain narrative > 200 chars → truncated at the narrative cap
+   4. Plain narrative ≤ 200 chars → identity
+   5. Idempotence: cap(cap(s)) = cap(s) for every case
+   6. cap_social_state routes blocker through cap_blocker but leaves
+      every other option field on the narrative cap *)
+
+module T = Masc_mcp.Keeper_social_model_types
+
+let oas_error_payload_small =
+  "[masc_oas_error] {\"kind\":\"oas_timeout_budget\",\
+   \"budget_sec\":30.0,\"keeper_turn_timeout_sec\":120.0,\
+   \"estimated_input_tokens\":45000,\"source\":\"tool_list_build\"}"
+
+let oas_error_payload_huge =
+  let buf = Buffer.create 2500 in
+  Buffer.add_string buf "[masc_oas_error] {\"kind\":\"oas_timeout_budget\",\"extra\":\"";
+  for _ = 1 to 2500 do Buffer.add_char buf 'x' done;
+  Buffer.add_string buf "\"}";
+  Buffer.contents buf
+
+let narrative_short = "keeper cannot claim; preset mismatch on all 11 tasks"
+
+let narrative_long =
+  let buf = Buffer.create 400 in
+  Buffer.add_string buf "keeper blocker narrative: ";
+  for _ = 1 to 400 do Buffer.add_char buf 'a' done;
+  Buffer.contents buf
+
+let ends_with_ellipsis s =
+  let needle = "…" in
+  let nl = String.length needle in
+  let sl = String.length s in
+  sl >= nl && String.sub s (sl - nl) nl = needle
+
+let test_small_structured_payload_preserved () =
+  let result = T.cap_blocker oas_error_payload_small in
+  Alcotest.(check string)
+    "small structured payload unchanged"
+    oas_error_payload_small result;
+  Alcotest.(check bool)
+    "no ellipsis added to structured payload"
+    false (ends_with_ellipsis result)
+
+let test_huge_structured_payload_safety_capped () =
+  let result = T.cap_blocker oas_error_payload_huge in
+  (* The payload is > 2000 chars, so it must be shorter than the
+     input but still ≥ the narrative cap (otherwise we'd be
+     applying the narrative budget). *)
+  Alcotest.(check bool)
+    "pathological payload truncated"
+    true
+    (String.length result < String.length oas_error_payload_huge);
+  Alcotest.(check bool)
+    "but kept above narrative budget"
+    true
+    (String.length result > T.default_option_field_max_chars * 2);
+  Alcotest.(check bool) "ends with ellipsis" true
+    (ends_with_ellipsis result)
+
+let test_plain_narrative_short_preserved () =
+  Alcotest.(check string)
+    "short narrative unchanged"
+    narrative_short (T.cap_blocker narrative_short)
+
+let test_plain_narrative_long_truncated () =
+  let result = T.cap_blocker narrative_long in
+  Alcotest.(check bool)
+    "long narrative shorter than input"
+    true (String.length result < String.length narrative_long);
+  Alcotest.(check bool)
+    "long narrative truncated near option cap (not structured cap)"
+    true
+    (String.length result < T.masc_oas_error_max_chars / 4);
+  Alcotest.(check bool) "ends with ellipsis" true
+    (ends_with_ellipsis result)
+
+let test_idempotence () =
+  let check label s =
+    let once = T.cap_blocker s in
+    let twice = T.cap_blocker once in
+    Alcotest.(check string)
+      (Printf.sprintf "idempotent: %s" label) once twice
+  in
+  check "small structured" oas_error_payload_small;
+  check "huge structured" oas_error_payload_huge;
+  check "short narrative" narrative_short;
+  check "long narrative" narrative_long
+
+let test_cap_social_state_routes_blocker_through_cap_blocker () =
+  let state : T.social_state = {
+    social_model = "magentic_ledger_v1";
+    speech_act = T.Stay_silent;
+    delivery_surface = T.Silent;
+    belief_summary = "bs";
+    active_desire = Some "ad";
+    current_intention = Some "ci";
+    blocker = Some oas_error_payload_small;
+    need = Some "nd";
+  } in
+  let capped = T.cap_social_state state in
+  Alcotest.(check (option string))
+    "blocker preserved through cap_social_state"
+    (Some oas_error_payload_small)
+    capped.blocker
+
+let test_cap_social_state_narrative_fields_still_truncated () =
+  let state : T.social_state = {
+    social_model = "magentic_ledger_v1";
+    speech_act = T.Stay_silent;
+    delivery_surface = T.Silent;
+    belief_summary = narrative_long;
+    active_desire = Some narrative_long;
+    current_intention = Some narrative_long;
+    blocker = None;
+    need = Some narrative_long;
+  } in
+  let capped = T.cap_social_state state in
+  Alcotest.(check bool)
+    "belief_summary truncated"
+    true
+    (String.length capped.belief_summary < String.length narrative_long);
+  let check_opt label = function
+    | None -> Alcotest.fail (Printf.sprintf "expected Some for %s" label)
+    | Some s ->
+      Alcotest.(check bool)
+        (Printf.sprintf "%s truncated" label)
+        true
+        (String.length s < String.length narrative_long)
+  in
+  check_opt "active_desire" capped.active_desire;
+  check_opt "current_intention" capped.current_intention;
+  check_opt "need" capped.need
+
+let () =
+  Alcotest.run "cap_blocker_structured_error"
+    [
+      ( "structured payload",
+        [
+          Alcotest.test_case "small preserved" `Quick
+            test_small_structured_payload_preserved;
+          Alcotest.test_case "huge safety-capped" `Quick
+            test_huge_structured_payload_safety_capped;
+        ] );
+      ( "plain narrative",
+        [
+          Alcotest.test_case "short preserved" `Quick
+            test_plain_narrative_short_preserved;
+          Alcotest.test_case "long truncated at narrative cap" `Quick
+            test_plain_narrative_long_truncated;
+        ] );
+      ( "idempotence",
+        [ Alcotest.test_case "four shapes" `Quick test_idempotence ] );
+      ( "cap_social_state integration",
+        [
+          Alcotest.test_case "blocker via cap_blocker" `Quick
+            test_cap_social_state_routes_blocker_through_cap_blocker;
+          Alcotest.test_case "narrative fields unchanged policy" `Quick
+            test_cap_social_state_narrative_fields_still_truncated;
+        ] );
+    ]


### PR DESCRIPTION
Summary: preserves structured [masc_oas_error] blocker payloads through social-state write/read caps, and also preserves the observed wrapped form Internal error: [masc_oas_error]. Plain narrative fields keep the existing narrative cap. Validation: git diff --check origin/main...HEAD; env MASC_BASE_PATH=/tmp/masc-pr-9939 ./_build/default/test/test_cap_blocker_structured_error.exe --compact --show-errors passed 8/8. Local focused dune build produced the test binary but the dune command stalled during exit under the shared local lock; GitHub CI remains the merge gate.