### PR TITLE
[codex] Add persona authoring wizard

### DIFF
--- a/dashboard/src/components/keeper-spawn/keeper-spawn-panel.ts
+++ b/dashboard/src/components/keeper-spawn/keeper-spawn-panel.ts
@@ -2,9 +2,10 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { ActionButton } from '../common/button'
 import { PersonaBrowser } from './persona-browser'
+import { PersonaGenerator } from './persona-generator'
 import { showSpawnPanel } from './keeper-spawn-state'
 
-type SpawnMode = 'persona' | 'direct'
+type SpawnMode = 'persona' | 'generate' | 'direct'
 const spawnMode = signal<SpawnMode>('persona')
 
 export function KeeperSpawnPanel() {
@@ -22,11 +23,15 @@ export function KeeperSpawnPanel() {
       <div class="flex gap-2 mb-3">
         <${ActionButton} variant=${spawnMode.value === 'persona' ? 'primary' : 'ghost'} size="sm"
           onClick=${() => { spawnMode.value = 'persona' }}>페르소나에서 생성<//>
+        <${ActionButton} variant=${spawnMode.value === 'generate' ? 'primary' : 'ghost'} size="sm"
+          onClick=${() => { spawnMode.value = 'generate' }}>새 페르소나<//>
         <${ActionButton} variant=${spawnMode.value === 'direct' ? 'primary' : 'ghost'} size="sm"
           onClick=${() => { spawnMode.value = 'direct' }}>직접 생성<//>
       </div>
       ${spawnMode.value === 'persona'
         ? html`<${PersonaBrowser} />`
+        : spawnMode.value === 'generate'
+          ? html`<${PersonaGenerator} />`
         : html`<p class="text-xs text-[var(--text-muted)]">직접 생성은 도구 실행기에서 <code class="text-[var(--accent)]">masc_keeper_up</code>을 사용하세요.</p>`}
     </div>
   `

--- a/dashboard/src/components/keeper-spawn/keeper-spawn-state.test.ts
+++ b/dashboard/src/components/keeper-spawn/keeper-spawn-state.test.ts
@@ -19,14 +19,25 @@ vi.mock('../../store', () => ({
 }))
 
 import {
+  generatePersonaDraft,
+  normalizePersonaDraft,
+  normalizePersonaSaveResult,
+  normalizePersonaSchema,
   normalizePersonaSummaries,
   normalizePersonaSummary,
+  personaAuthoringResult,
+  personaDraft,
+  personaSaveResult,
+  savePersonaDraft,
   spawnKeeperFromPersona,
   spawnResult,
 } from './keeper-spawn-state'
 
 afterEach(() => {
   spawnResult.value = null
+  personaDraft.value = null
+  personaSaveResult.value = null
+  personaAuthoringResult.value = null
   vi.clearAllMocks()
 })
 
@@ -85,6 +96,123 @@ describe('normalizePersonaSummaries', () => {
         description: undefined,
       },
     ])
+  })
+})
+
+describe('persona authoring normalization', () => {
+  it('normalizes schema field catalog and archetype axes', () => {
+    expect(
+      normalizePersonaSchema({
+        personas_root: '/Users/dancer/me/.masc/config/personas',
+        handle_rules: 'rules',
+        field_catalog: [
+          { path: 'keeper.goal', type: 'string', required: true, effect: 'required' },
+          { nope: true },
+        ],
+        archetype_axes: [
+          { name: 'alignment', choices: ['helpful', 'chaotic'], effect: 'draft only' },
+        ],
+      }),
+    ).toEqual({
+      personasRoot: '/Users/dancer/me/.masc/config/personas',
+      profilePathPattern: undefined,
+      handleRules: 'rules',
+      fieldCatalog: [
+        {
+          path: 'keeper.goal',
+          type: 'string',
+          required: true,
+          defaultValue: undefined,
+          choices: undefined,
+          effect: 'required',
+        },
+      ],
+      archetypeAxes: [
+        { name: 'alignment', choices: ['helpful', 'chaotic'], effect: 'draft only' },
+      ],
+    })
+  })
+
+  it('normalizes generated draft and save results', () => {
+    expect(
+      normalizePersonaDraft({
+        handle: 'chaos-researcher',
+        profile: { name: 'Chaos Researcher', keeper: { goal: 'test' } },
+        field_explanations: [{ path: 'keeper.goal', effect: 'creates keeper purpose' }],
+      }),
+    ).toEqual({
+      handle: 'chaos-researcher',
+      profile: { name: 'Chaos Researcher', keeper: { goal: 'test' } },
+      fieldExplanations: [{ path: 'keeper.goal', value: undefined, effect: 'creates keeper purpose' }],
+      rawModel: undefined,
+    })
+
+    expect(
+      normalizePersonaSaveResult({
+        handle: 'chaos-researcher',
+        profile_path: '/tmp/personas/chaos-researcher/profile.json',
+        saved: true,
+        dry_run: false,
+      }),
+    ).toEqual({
+      handle: 'chaos-researcher',
+      personasRoot: undefined,
+      profilePath: '/tmp/personas/chaos-researcher/profile.json',
+      saved: true,
+      dryRun: false,
+      profile: undefined,
+    })
+  })
+})
+
+describe('persona authoring actions', () => {
+  it('generates a persona draft through masc_persona_generate', async () => {
+    callMcpTool.mockResolvedValueOnce(JSON.stringify({
+      handle: 'chaos-researcher',
+      profile: { name: 'Chaos Researcher', keeper: { goal: 'test' } },
+      field_explanations: [],
+    }))
+
+    await generatePersonaDraft({
+      concept: 'good evil chaos',
+      handle: 'chaos-researcher',
+      toolPreset: 'research',
+      proactiveEnabled: true,
+    })
+
+    expect(callMcpTool).toHaveBeenCalledWith('masc_persona_generate', {
+      concept: 'good evil chaos',
+      language: 'ko',
+      tool_preset: 'research',
+      proactive_enabled: true,
+      handle: 'chaos-researcher',
+    })
+    expect(personaDraft.value?.handle).toBe('chaos-researcher')
+    expect(showToast).toHaveBeenCalledWith('chaos-researcher 페르소나 초안 생성', 'success')
+  })
+
+  it('saves the current draft through masc_persona_save dry-run', async () => {
+    personaDraft.value = {
+      handle: 'chaos-researcher',
+      profile: { name: 'Chaos Researcher', keeper: { goal: 'test' } },
+      fieldExplanations: [],
+    }
+    callMcpTool.mockResolvedValueOnce(JSON.stringify({
+      handle: 'chaos-researcher',
+      profile_path: '/tmp/personas/chaos-researcher/profile.json',
+      saved: false,
+      dry_run: true,
+    }))
+
+    await savePersonaDraft({ dryRun: true })
+
+    expect(callMcpTool).toHaveBeenCalledWith('masc_persona_save', {
+      handle: 'chaos-researcher',
+      profile: { name: 'Chaos Researcher', keeper: { goal: 'test' } },
+      overwrite: false,
+      dry_run: true,
+    })
+    expect(personaSaveResult.value?.dryRun).toBe(true)
   })
 })
 

--- a/dashboard/src/components/keeper-spawn/keeper-spawn-state.ts
+++ b/dashboard/src/components/keeper-spawn/keeper-spawn-state.ts
@@ -1,6 +1,6 @@
 import { signal, computed } from '@preact/signals'
 import { callMcpTool } from '../../api/mcp'
-import { asString, extractArray, isRecord } from '../common/normalize'
+import { asBoolean, asString, asStringArray, extractArray, isRecord } from '../common/normalize'
 import { showToast } from '../common/toast'
 import { createAsyncResource, getData } from '../../lib/async-state'
 import { shellAuthSummary } from '../../store'
@@ -12,6 +12,45 @@ export interface PersonaSummary {
   role?: string
   mode?: string
   description?: string
+}
+
+export interface PersonaFieldCatalogEntry {
+  path: string
+  type?: string
+  required?: boolean
+  defaultValue?: unknown
+  choices?: unknown
+  effect?: string
+}
+
+export interface PersonaSchema {
+  personasRoot?: string
+  profilePathPattern?: string
+  handleRules?: string
+  fieldCatalog: PersonaFieldCatalogEntry[]
+  archetypeAxes: Array<{ name: string; choices: string[]; effect?: string }>
+}
+
+export interface PersonaFieldExplanation {
+  path: string
+  value?: unknown
+  effect?: string
+}
+
+export interface PersonaDraft {
+  handle: string
+  profile: Record<string, unknown>
+  fieldExplanations: PersonaFieldExplanation[]
+  rawModel?: string
+}
+
+export interface PersonaSaveResult {
+  handle: string
+  personasRoot?: string
+  profilePath?: string
+  saved: boolean
+  dryRun: boolean
+  profile?: Record<string, unknown>
 }
 
 export function normalizePersonaSummary(raw: unknown): PersonaSummary | null {
@@ -35,7 +74,91 @@ export function normalizePersonaSummaries(raw: unknown): PersonaSummary[] {
     .filter((persona): persona is PersonaSummary => persona !== null)
 }
 
+function parseToolJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return raw
+  }
+}
+
+function normalizeFieldCatalogEntry(raw: unknown): PersonaFieldCatalogEntry | null {
+  if (!isRecord(raw)) return null
+  const path = asString(raw.path)
+  if (!path) return null
+  return {
+    path,
+    type: asString(raw.type),
+    required: asBoolean(raw.required),
+    defaultValue: raw.default,
+    choices: raw.choices,
+    effect: asString(raw.effect),
+  }
+}
+
+export function normalizePersonaSchema(raw: unknown): PersonaSchema {
+  if (!isRecord(raw)) {
+    return { fieldCatalog: [], archetypeAxes: [] }
+  }
+  const axes = extractArray(raw, ['archetype_axes']).flatMap(axis => {
+    if (!isRecord(axis)) return []
+    const name = asString(axis.name)
+    if (!name) return []
+    return [{ name, choices: asStringArray(axis.choices), effect: asString(axis.effect) }]
+  })
+  return {
+    personasRoot: asString(raw.personas_root),
+    profilePathPattern: asString(raw.profile_path_pattern),
+    handleRules: asString(raw.handle_rules),
+    fieldCatalog: extractArray(raw, ['field_catalog'])
+      .map(normalizeFieldCatalogEntry)
+      .filter((entry): entry is PersonaFieldCatalogEntry => entry !== null),
+    archetypeAxes: axes,
+  }
+}
+
+function normalizePersonaFieldExplanation(raw: unknown): PersonaFieldExplanation | null {
+  if (!isRecord(raw)) return null
+  const path = asString(raw.path)
+  if (!path) return null
+  return {
+    path,
+    value: raw.value,
+    effect: asString(raw.effect),
+  }
+}
+
+export function normalizePersonaDraft(raw: unknown): PersonaDraft | null {
+  if (!isRecord(raw)) return null
+  const handle = asString(raw.handle)
+  const profile = raw.profile
+  if (!handle || !isRecord(profile)) return null
+  return {
+    handle,
+    profile,
+    fieldExplanations: extractArray(raw, ['field_explanations'])
+      .map(normalizePersonaFieldExplanation)
+      .filter((entry): entry is PersonaFieldExplanation => entry !== null),
+    rawModel: asString(raw.raw_model),
+  }
+}
+
+export function normalizePersonaSaveResult(raw: unknown): PersonaSaveResult | null {
+  if (!isRecord(raw)) return null
+  const handle = asString(raw.handle)
+  if (!handle) return null
+  return {
+    handle,
+    personasRoot: asString(raw.personas_root),
+    profilePath: asString(raw.profile_path),
+    saved: asBoolean(raw.saved, false),
+    dryRun: asBoolean(raw.dry_run, false),
+    profile: isRecord(raw.profile) ? raw.profile : undefined,
+  }
+}
+
 const personasResource = createAsyncResource<PersonaSummary[]>()
+const personaSchemaResource = createAsyncResource<PersonaSchema>()
 
 export const personas = computed(() => getData(personasResource.state.value) ?? [])
 export const personasLoading = computed(() => personasResource.state.value.status === 'loading')
@@ -53,9 +176,30 @@ export async function loadPersonas(): Promise<void> {
   })
 }
 
+export const personaSchema = computed(() => getData(personaSchemaResource.state.value) ?? null)
+export const personaSchemaLoading = computed(() => personaSchemaResource.state.value.status === 'loading')
+export const personaSchemaError = computed<string | null>(() => {
+  const s = personaSchemaResource.state.value
+  return s.status === 'error' ? s.message : null
+})
+
+export async function loadPersonaSchema(): Promise<void> {
+  await personaSchemaResource.load(async () => {
+    const raw = await callMcpTool('masc_persona_schema', {})
+    return normalizePersonaSchema(parseToolJson(raw))
+  }).catch(() => {
+    showToast('페르소나 스키마 로드 실패', 'error')
+  })
+}
+
 export const spawning = signal(false)
 export const spawnResult = signal<{ success: boolean; message: string } | null>(null)
 export const showSpawnPanel = signal(false)
+export const personaGenerating = signal(false)
+export const personaSaving = signal(false)
+export const personaDraft = signal<PersonaDraft | null>(null)
+export const personaSaveResult = signal<PersonaSaveResult | null>(null)
+export const personaAuthoringResult = signal<{ success: boolean; message: string } | null>(null)
 
 function formatKeeperSpawnError(message: string): string {
   const forbiddenMatch = message.match(/Forbidden:\s+([^\s]+)\s+cannot\s+masc_keeper_create_from_persona/i)
@@ -87,6 +231,98 @@ export async function spawnKeeperFromPersona(personaName: string, opts?: { dryRu
     showToast(`키퍼 생성 실패: ${message}`, 'error')
   } finally {
     spawning.value = false
+  }
+}
+
+export interface GeneratePersonaDraftInput {
+  concept: string
+  handle?: string
+  displayName?: string
+  language?: string
+  toolPreset?: string
+  proactiveEnabled?: boolean
+}
+
+export async function generatePersonaDraft(input: GeneratePersonaDraftInput): Promise<void> {
+  const access = dashboardAuthAccess(shellAuthSummary.value, 'worker')
+  if (!access.allowed) {
+    const message = access.reason ?? '페르소나 생성 권한이 없습니다.'
+    personaAuthoringResult.value = { success: false, message }
+    showToast(message, 'error', 6000)
+    return
+  }
+  const concept = input.concept.trim()
+  if (!concept) {
+    personaAuthoringResult.value = { success: false, message: '컨셉을 입력하세요.' }
+    showToast('컨셉을 입력하세요.', 'error')
+    return
+  }
+  personaGenerating.value = true
+  personaAuthoringResult.value = null
+  try {
+    const args: Record<string, unknown> = {
+      concept,
+      language: input.language?.trim() || 'ko',
+      tool_preset: input.toolPreset || 'research',
+      proactive_enabled: input.proactiveEnabled === true,
+    }
+    if (input.handle?.trim()) args.handle = input.handle.trim()
+    if (input.displayName?.trim()) args.display_name = input.displayName.trim()
+    const result = await callMcpTool('masc_persona_generate', args)
+    const draft = normalizePersonaDraft(parseToolJson(result))
+    if (!draft) throw new Error('페르소나 생성 결과를 해석할 수 없습니다.')
+    personaDraft.value = draft
+    personaSaveResult.value = null
+    personaAuthoringResult.value = { success: true, message: result }
+    showToast(`${draft.handle} 페르소나 초안 생성`, 'success')
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    personaAuthoringResult.value = { success: false, message }
+    showToast(`페르소나 생성 실패: ${message}`, 'error')
+  } finally {
+    personaGenerating.value = false
+  }
+}
+
+export async function savePersonaDraft(opts?: { overwrite?: boolean; dryRun?: boolean }): Promise<void> {
+  const access = dashboardAuthAccess(shellAuthSummary.value, 'worker')
+  if (!access.allowed) {
+    const message = access.reason ?? '페르소나 저장 권한이 없습니다.'
+    personaAuthoringResult.value = { success: false, message }
+    showToast(message, 'error', 6000)
+    return
+  }
+  const draft = personaDraft.value
+  if (!draft) {
+    personaAuthoringResult.value = { success: false, message: '저장할 페르소나 초안이 없습니다.' }
+    showToast('저장할 페르소나 초안이 없습니다.', 'error')
+    return
+  }
+  personaSaving.value = true
+  personaAuthoringResult.value = null
+  try {
+    const result = await callMcpTool('masc_persona_save', {
+      handle: draft.handle,
+      profile: draft.profile,
+      overwrite: opts?.overwrite === true,
+      dry_run: opts?.dryRun === true,
+    })
+    const normalized = normalizePersonaSaveResult(parseToolJson(result))
+    if (!normalized) throw new Error('페르소나 저장 결과를 해석할 수 없습니다.')
+    personaSaveResult.value = normalized
+    personaAuthoringResult.value = { success: true, message: result }
+    if (normalized.saved) {
+      await loadPersonas()
+      showToast(`${draft.handle} 페르소나 저장 완료`, 'success')
+    } else {
+      showToast(`${draft.handle} 페르소나 저장 dry-run 완료`, 'success')
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    personaAuthoringResult.value = { success: false, message }
+    showToast(`페르소나 저장 실패: ${message}`, 'error')
+  } finally {
+    personaSaving.value = false
   }
 }
 

--- a/dashboard/src/components/keeper-spawn/persona-generator.ts
+++ b/dashboard/src/components/keeper-spawn/persona-generator.ts
@@ -1,0 +1,264 @@
+import { html } from 'htm/preact'
+import { useEffect } from 'preact/hooks'
+import { signal } from '@preact/signals'
+import { ActionButton } from '../common/button'
+import { showToast } from '../common/toast'
+import {
+  generatePersonaDraft,
+  loadPersonaSchema,
+  personaAuthoringResult,
+  personaDraft,
+  personaGenerating,
+  personaSaveResult,
+  personaSaving,
+  personaSchema,
+  personaSchemaLoading,
+  savePersonaDraft,
+  spawnKeeperFromPersona,
+  spawning,
+} from './keeper-spawn-state'
+
+const concept = signal('')
+const handle = signal('')
+const displayName = signal('')
+const toolPreset = signal('research')
+const proactiveEnabled = signal(false)
+const overwrite = signal(false)
+const profileText = signal('')
+
+function syncProfileText() {
+  const draft = personaDraft.value
+  profileText.value = draft ? JSON.stringify(draft.profile, null, 2) : ''
+}
+
+function appendConceptToken(token: string) {
+  const current = concept.value.trim()
+  concept.value = current ? `${current}, ${token}` : token
+}
+
+function applyProfileText(): boolean {
+  const draft = personaDraft.value
+  if (!draft) return false
+  try {
+    const parsed = JSON.parse(profileText.value)
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new Error('profile JSON must be an object')
+    }
+    personaDraft.value = { ...draft, profile: parsed as Record<string, unknown> }
+    return true
+  } catch (err) {
+    showToast(err instanceof Error ? err.message : 'profile JSON parse failed', 'error')
+    return false
+  }
+}
+
+async function generateDraft() {
+  await generatePersonaDraft({
+    concept: concept.value,
+    handle: handle.value,
+    displayName: displayName.value,
+    toolPreset: toolPreset.value,
+    proactiveEnabled: proactiveEnabled.value,
+  })
+  syncProfileText()
+}
+
+async function saveDraft(dryRun: boolean) {
+  if (!applyProfileText()) return
+  await savePersonaDraft({ overwrite: overwrite.value, dryRun })
+}
+
+function prettyValue(value: unknown): string {
+  if (value === undefined || value === null) return ''
+  if (typeof value === 'string') return value
+  return JSON.stringify(value)
+}
+
+export function PersonaGenerator() {
+  useEffect(() => {
+    if (!personaSchema.value && !personaSchemaLoading.value) void loadPersonaSchema()
+  }, [])
+  const schema = personaSchema.value
+  const draft = personaDraft.value
+  const saveResult = personaSaveResult.value
+  const savedForDraft = Boolean(draft && saveResult?.handle === draft.handle && saveResult.saved)
+  const presets = schema?.fieldCatalog
+    .find(field => field.path === 'keeper.tool_preset')
+    ?.choices
+  const presetChoices = Array.isArray(presets)
+    ? presets.filter((item): item is string => typeof item === 'string')
+    : ['minimal', 'social', 'messaging', 'dispatch', 'coding', 'research', 'delivery', 'full']
+
+  return html`
+    <div class="grid gap-4 lg:grid-cols-[minmax(260px,0.9fr)_minmax(360px,1.2fr)]">
+      <div class="space-y-3">
+        <div class="grid gap-2">
+          <label class="text-3xs text-[var(--text-muted)]" for="persona-concept">컨셉</label>
+          <textarea
+            id="persona-concept"
+            rows=${5}
+            value=${concept.value}
+            placeholder="good evil chaos research keeper"
+            onInput=${(e: Event) => { concept.value = (e.target as HTMLTextAreaElement).value }}
+            class="w-full rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-2 text-2xs text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          />
+        </div>
+
+        ${schema?.archetypeAxes.length ? html`
+          <div class="flex flex-wrap gap-1.5">
+            ${schema.archetypeAxes.flatMap(axis => axis.choices.slice(0, 5).map(choice => html`
+              <${ActionButton}
+                key=${`${axis.name}:${choice}`}
+                variant="ghost"
+                size="sm"
+                title=${axis.effect}
+                onClick=${() => appendConceptToken(choice)}
+              >${choice}<//>
+            `))}
+          </div>
+        ` : null}
+
+        <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          <label class="grid gap-1 text-3xs text-[var(--text-muted)]">
+            handle
+            <input
+              value=${handle.value}
+              placeholder="auto"
+              onInput=${(e: Event) => { handle.value = (e.target as HTMLInputElement).value }}
+              class="rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1.5 text-2xs text-[var(--text-body)] focus:outline-none focus:border-[var(--accent)]"
+            />
+          </label>
+          <label class="grid gap-1 text-3xs text-[var(--text-muted)]">
+            display
+            <input
+              value=${displayName.value}
+              placeholder="auto"
+              onInput=${(e: Event) => { displayName.value = (e.target as HTMLInputElement).value }}
+              class="rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1.5 text-2xs text-[var(--text-body)] focus:outline-none focus:border-[var(--accent)]"
+            />
+          </label>
+          <label class="grid gap-1 text-3xs text-[var(--text-muted)]">
+            preset
+            <select
+              value=${toolPreset.value}
+              onChange=${(e: Event) => { toolPreset.value = (e.target as HTMLSelectElement).value }}
+              class="rounded border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1.5 text-2xs text-[var(--text-body)] focus:outline-none focus:border-[var(--accent)]"
+            >
+              ${presetChoices.map(choice => html`<option key=${choice} value=${choice}>${choice}</option>`)}
+            </select>
+          </label>
+          <label class="flex items-center gap-2 pt-5 text-2xs text-[var(--text-body)]">
+            <input
+              type="checkbox"
+              checked=${proactiveEnabled.value}
+              onChange=${(e: Event) => { proactiveEnabled.value = (e.target as HTMLInputElement).checked }}
+            />
+            proactive
+          </label>
+        </div>
+
+        <div class="flex flex-wrap gap-2">
+          <${ActionButton}
+            variant="primary"
+            size="sm"
+            disabled=${personaGenerating.value}
+            ariaBusy=${personaGenerating.value}
+            onClick=${() => void generateDraft()}
+          >${personaGenerating.value ? '생성 중...' : '초안 생성'}<//>
+          <${ActionButton}
+            variant="ghost"
+            size="sm"
+            disabled=${!draft || personaSaving.value}
+            onClick=${() => void saveDraft(true)}
+          >저장 dry-run<//>
+          <${ActionButton}
+            variant="primary"
+            size="sm"
+            disabled=${!draft || personaSaving.value}
+            ariaBusy=${personaSaving.value}
+            onClick=${() => void saveDraft(false)}
+          >${personaSaving.value ? '저장 중...' : '저장'}<//>
+          <label class="flex items-center gap-1.5 text-3xs text-[var(--text-muted)]">
+            <input
+              type="checkbox"
+              checked=${overwrite.value}
+              onChange=${(e: Event) => { overwrite.value = (e.target as HTMLInputElement).checked }}
+            />
+            overwrite
+          </label>
+        </div>
+
+        ${schema ? html`
+          <div class="rounded border border-[var(--white-10)] bg-[var(--white-4)]">
+            <div class="border-b border-[var(--white-10)] px-2 py-1.5 text-3xs text-[var(--text-muted)]">
+              ${schema.personasRoot ?? ''} · ${schema.handleRules ?? ''}
+            </div>
+            <div class="max-h-56 overflow-auto">
+              <table class="w-full text-left text-3xs">
+                <tbody>
+                  ${schema.fieldCatalog.map(field => html`
+                    <tr key=${field.path} class="border-b border-[var(--white-6)] align-top">
+                      <td class="px-2 py-1.5 font-mono text-[var(--accent)] whitespace-nowrap">${field.path}</td>
+                      <td class="px-2 py-1.5 text-[var(--text-muted)]">${field.type ?? ''}${field.required ? ' *' : ''}</td>
+                      <td class="px-2 py-1.5 text-[var(--text-body)]">${field.effect ?? ''}</td>
+                    </tr>
+                  `)}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        ` : null}
+      </div>
+
+      <div class="space-y-3">
+        <div class="grid gap-2">
+          <div class="flex items-center justify-between">
+            <label class="text-3xs text-[var(--text-muted)]" for="persona-profile-json">profile.json</label>
+            ${draft ? html`<span class="text-3xs text-[var(--text-muted)]">${draft.handle}</span>` : null}
+          </div>
+          <textarea
+            id="persona-profile-json"
+            rows=${18}
+            value=${profileText.value}
+            placeholder="초안을 생성하면 profile.json이 표시됩니다"
+            onInput=${(e: Event) => { profileText.value = (e.target as HTMLTextAreaElement).value }}
+            class="w-full rounded border border-[var(--white-10)] bg-[var(--bg-0)] px-2 py-2 font-mono text-3xs leading-5 text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          />
+        </div>
+
+        ${draft?.fieldExplanations.length ? html`
+          <div class="rounded border border-[var(--white-10)] bg-[var(--white-4)]">
+            ${draft.fieldExplanations.map(item => html`
+              <div key=${item.path} class="grid grid-cols-[minmax(120px,0.35fr)_1fr] gap-2 border-b border-[var(--white-6)] px-2 py-1.5 text-3xs">
+                <span class="font-mono text-[var(--accent)]">${item.path}</span>
+                <span class="text-[var(--text-body)]">${item.effect ?? prettyValue(item.value)}</span>
+              </div>
+            `)}
+          </div>
+        ` : null}
+
+        <div class="flex flex-wrap gap-2">
+          <${ActionButton}
+            variant="ghost"
+            size="sm"
+            disabled=${!savedForDraft || spawning.value}
+            onClick=${() => draft && void spawnKeeperFromPersona(draft.handle, { dryRun: true })}
+          >키퍼 dry-run<//>
+          <${ActionButton}
+            variant="primary"
+            size="sm"
+            disabled=${!savedForDraft || spawning.value}
+            onClick=${() => draft && void spawnKeeperFromPersona(draft.handle)}
+          >키퍼 시작<//>
+          ${saveResult?.profilePath ? html`
+            <span class="self-center text-3xs text-[var(--text-muted)]">${saveResult.profilePath}</span>
+          ` : null}
+        </div>
+
+        ${personaAuthoringResult.value ? html`
+          <pre class="max-h-48 overflow-auto rounded border border-[var(--white-10)] bg-[var(--white-4)] p-2 text-3xs ${personaAuthoringResult.value.success ? 'text-[var(--text-body)]' : 'text-[var(--bad)]'}">${personaAuthoringResult.value.message}</pre>
+        ` : null}
+      </div>
+    </div>
+  `
+}

--- a/lib/dune
+++ b/lib/dune
@@ -472,6 +472,7 @@
    keeper_exec_status_metrics
    keeper_exec_status
    keeper_exec_persona
+   keeper_persona_authoring
    keeper_model_labels
    keeper_fs
    keeper_identity

--- a/lib/keeper/keeper_persona.ml
+++ b/lib/keeper/keeper_persona.ml
@@ -5,6 +5,7 @@ open Keeper_types
 open Keeper_exec_persona
 
 module Turn = Keeper_turn
+module Authoring = Keeper_persona_authoring
 type tool_result = Keeper_types.tool_result
 
 let handle_persona_list _ctx args : tool_result =
@@ -24,6 +25,12 @@ let handle_persona_list _ctx args : tool_result =
       ]
   in
   (true, Yojson.Safe.to_string json)
+
+let handle_persona_schema = Authoring.handle_persona_schema
+
+let handle_persona_generate = Authoring.handle_persona_generate
+
+let handle_persona_save = Authoring.handle_persona_save
 
 let handle_keeper_create_from_persona ctx args : tool_result =
   match resolved_keeper_args_from_persona args with

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -1,0 +1,936 @@
+(** Persona authoring tools.
+
+    The existing persona loader is the source of truth for how profile.json
+    turns into keeper defaults. This module exposes that shape explicitly and
+    keeps writes constrained to the resolved personas root. *)
+
+open Tool_args
+
+type save_result =
+  { handle : string
+  ; personas_root : string
+  ; profile_path : string
+  ; profile : Yojson.Safe.t
+  ; warnings : string list
+  }
+
+let string_list_to_json values = `List (List.map (fun value -> `String value) values)
+
+let option_field name value =
+  match value with
+  | Some json -> [ name, json ]
+  | None -> []
+;;
+
+let assoc_without key fields =
+  List.filter (fun (candidate, _) -> not (String.equal candidate key)) fields
+;;
+
+let assoc_set key value fields = (key, value) :: assoc_without key fields
+
+let assoc_get key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+;;
+
+let assoc_keys = function
+  | `Assoc fields -> List.map fst fields
+  | _ -> []
+;;
+
+let trim_nonempty_opt = function
+  | Some raw ->
+    let value = String.trim raw in
+    if value = "" then None else Some value
+  | None -> None
+;;
+
+let json_trimmed_string_opt key json =
+  Safe_ops.json_string_opt key json |> trim_nonempty_opt
+;;
+
+let json_string_list_normalized key json =
+  Safe_ops.json_string_list key json |> Keeper_types_profile.normalize_name_list
+;;
+
+let allowed_keeper_fields =
+  [ "goal"
+  ; "short_goal"
+  ; "mid_goal"
+  ; "long_goal"
+  ; "will"
+  ; "needs"
+  ; "desires"
+  ; "instructions"
+  ; "policy_voice_enabled"
+  ; "mention_targets"
+  ; "proactive_enabled"
+  ; "proactive_idle_sec"
+  ; "proactive_cooldown_sec"
+  ; "room_signal_prompt_enabled"
+  ; "shards"
+  ; "tool_preset"
+  ; "tool_also_allow"
+  ; "tool_denylist"
+  ; "work_discovery_enabled"
+  ; "work_discovery_sources"
+  ; "work_discovery_interval_sec"
+  ; "work_discovery_guidance"
+  ; "telemetry_feedback_enabled"
+  ; "telemetry_feedback_window_hours"
+  ; "per_provider_timeout"
+  ; "always_approve"
+  ; "max_turns_per_call"
+  ; "max_turns_per_call_scheduled_autonomous"
+  ; "social_model"
+  ; "cascade_name"
+  ]
+;;
+
+let field_catalog_entry ?default ?choices ?(required = false) ~path ~typ ~field_effect () =
+  `Assoc
+    ([ "path", `String path
+     ; "type", `String typ
+     ; "required", `Bool required
+     ; "effect", `String field_effect
+     ]
+     @ option_field "default" default
+     @ option_field "choices" choices)
+;;
+
+let tool_preset_choices_json =
+  string_list_to_json Keeper_types_profile.valid_tool_preset_raw_strings
+;;
+
+let social_model_choices_json =
+  string_list_to_json [ "bdi_speech_v1"; "magentic_ledger_v1" ]
+;;
+
+let field_catalog_json () =
+  `List
+    [ field_catalog_entry
+        ~path:"name"
+        ~typ:"string"
+        ~default:(`String "<handle>")
+        ~field_effect:
+          "Display label in persona lists. It does not change keeper execution by itself."
+        ()
+    ; field_catalog_entry
+        ~path:"role"
+        ~typ:"string"
+        ~field_effect:"Human-readable role metadata shown in discovery surfaces."
+        ()
+    ; field_catalog_entry
+        ~path:"trait"
+        ~typ:"string"
+        ~field_effect:
+          "Short personality or operating-style metadata shown in discovery surfaces."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.goal"
+        ~typ:"string"
+        ~required:true
+        ~field_effect:
+          "Required keeper purpose. masc_keeper_create_from_persona refuses \
+           materialization when this is empty."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.short_goal"
+        ~typ:"string"
+        ~default:(`String "<keeper.goal>")
+        ~field_effect:"Near-term goal horizon used when the keeper is created."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.mid_goal"
+        ~typ:"string"
+        ~default:(`String "<keeper.goal>")
+        ~field_effect:"Medium-term goal horizon used when the keeper is created."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.long_goal"
+        ~typ:"string"
+        ~default:(`String "<keeper.goal>")
+        ~field_effect:"Long-term goal horizon used when the keeper is created."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.instructions"
+        ~typ:"string"
+        ~field_effect:"Additional instructions copied into the keeper creation args."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.will"
+        ~typ:"string"
+        ~field_effect:
+          "Self-model will statement. Overrides the keeper environment default."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.needs"
+        ~typ:"string"
+        ~field_effect:
+          "Self-model needs statement. Overrides the keeper environment default."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.desires"
+        ~typ:"string"
+        ~field_effect:
+          "Self-model desires statement. Overrides the keeper environment default."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.mention_targets"
+        ~typ:"string[]"
+        ~default:(`String "[<handle>]")
+        ~field_effect:"Names that wake or target this persona-backed keeper."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.tool_preset"
+        ~typ:"enum"
+        ~default:(`String "research")
+        ~choices:tool_preset_choices_json
+        ~field_effect:"Preset used to derive the keeper tool policy during creation."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.tool_also_allow"
+        ~typ:"string[]"
+        ~field_effect:"Extra tools added on top of keeper.tool_preset."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.tool_denylist"
+        ~typ:"string[]"
+        ~field_effect:"Tools removed from the derived keeper tool policy."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.proactive_enabled"
+        ~typ:"boolean"
+        ~default:(`Bool false)
+        ~field_effect:"Whether the created keeper should run proactive turns."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.proactive_idle_sec"
+        ~typ:"integer"
+        ~field_effect:"Idle delay before proactive work becomes eligible."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.proactive_cooldown_sec"
+        ~typ:"integer"
+        ~field_effect:"Cooldown between proactive turns."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.room_signal_prompt_enabled"
+        ~typ:"boolean"
+        ~field_effect:"Whether room signal context is injected into keeper prompts."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.shards"
+        ~typ:"string[]"
+        ~field_effect:"Persona-specific prompt shards applied after keeper creation."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.work_discovery_enabled"
+        ~typ:"boolean"
+        ~field_effect:"Enables config-driven proactive work scanning for the keeper."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.work_discovery_sources"
+        ~typ:"string[]"
+        ~field_effect:"Named work discovery sources considered by proactive scanning."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.work_discovery_interval_sec"
+        ~typ:"integer"
+        ~field_effect:"Interval for proactive work discovery checks."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.work_discovery_guidance"
+        ~typ:"string"
+        ~field_effect:"Additional guidance used during proactive work discovery."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.telemetry_feedback_enabled"
+        ~typ:"boolean"
+        ~field_effect:"Injects recent keeper telemetry into future turns."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.telemetry_feedback_window_hours"
+        ~typ:"integer"
+        ~field_effect:"Lookback window for telemetry feedback."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.per_provider_timeout"
+        ~typ:"number"
+        ~field_effect:"Per-provider cascade timeout override for this keeper."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.always_approve"
+        ~typ:"boolean"
+        ~field_effect:
+          "Allows eligible keeper actions to auto-approve according to runtime policy."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.max_turns_per_call"
+        ~typ:"integer"
+        ~field_effect:"Turn budget for direct keeper calls."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.max_turns_per_call_scheduled_autonomous"
+        ~typ:"integer"
+        ~field_effect:"Turn budget for scheduled autonomous turns."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.social_model"
+        ~typ:"enum"
+        ~choices:social_model_choices_json
+        ~field_effect:"Optional social-model runtime for speech or ledger behavior."
+        ()
+    ; field_catalog_entry
+        ~path:"keeper.cascade_name"
+        ~typ:"string"
+        ~field_effect:
+          "Optional named cascade override. Must resolve to a known cascade at runtime."
+        ()
+    ]
+;;
+
+let archetype_axes_json () =
+  `List
+    [ `Assoc
+        [ "name", `String "alignment"
+        ; ( "choices"
+          , string_list_to_json
+              [ "helpful"; "skeptical"; "protective"; "chaotic"; "ruthless" ] )
+        ; ( "effect"
+          , `String
+              "Generation prompt input only. The saved effect appears through role, \
+               trait, goal, and instructions." )
+        ]
+    ; `Assoc
+        [ "name", `String "operating_style"
+        ; ( "choices"
+          , string_list_to_json [ "research"; "coding"; "dispatch"; "social"; "delivery" ]
+          )
+        ; ( "effect"
+          , `String
+              "Maps naturally to keeper.tool_preset and instructions when drafting a \
+               persona." )
+        ]
+    ; `Assoc
+        [ "name", `String "risk_posture"
+        ; "choices", string_list_to_json [ "cautious"; "balanced"; "high-autonomy" ]
+        ; ( "effect"
+          , `String
+              "Generation prompt input only. Save still validates concrete keeper fields."
+          )
+        ]
+    ]
+;;
+
+let personas_root_candidate () =
+  let resolution = Config_dir_resolver.resolve () in
+  resolution.personas.path
+;;
+
+let persona_profile_path ~root ~handle =
+  Filename.concat (Filename.concat root handle) "profile.json"
+;;
+
+let schema_json ?(include_examples = false) () =
+  let root = personas_root_candidate () in
+  let examples =
+    if not include_examples
+    then []
+    else
+      [ ( "examples"
+        , `Assoc
+            [ ( "minimal_profile"
+              , `Assoc
+                  [ "name", `String "Sharp Researcher"
+                  ; "role", `String "skeptical research keeper"
+                  ; "trait", `String "concise, evidence-first, mildly chaotic"
+                  ; ( "keeper"
+                    , `Assoc
+                        [ ( "goal"
+                          , `String
+                              "Find weak assumptions and turn them into actionable tasks."
+                          )
+                        ; "tool_preset", `String "research"
+                        ; "mention_targets", string_list_to_json [ "sharp-researcher" ]
+                        ] )
+                  ] )
+            ] )
+      ]
+  in
+  `Assoc
+    ([ "personas_root", `String root
+     ; ( "profile_path_pattern"
+       , `String (Filename.concat (Filename.concat root "<handle>") "profile.json") )
+     ; ( "handle_rules"
+       , `String
+           "Non-empty [A-Za-z0-9._-]+. The handle is the directory name and the default \
+            keeper name." )
+     ; "field_catalog", field_catalog_json ()
+     ; ( "choice_sets"
+       , `Assoc
+           [ "tool_preset", tool_preset_choices_json
+           ; "social_model", social_model_choices_json
+           ; ( "proactive_enabled"
+             , `Assoc
+                 [ "false", `String "Keeper stays passive unless called."
+                 ; "true", `String "Keeper may run proactive scheduled turns."
+                 ] )
+           ] )
+     ; "archetype_axes", archetype_axes_json ()
+     ; ( "keeperization"
+       , `Assoc
+           [ "dry_run_tool", `String "masc_keeper_create_from_persona"
+           ; "start_tool", `String "masc_keeper_create_from_persona"
+           ; ( "dry_run_args"
+             , `Assoc [ "persona_name", `String "<handle>"; "dry_run", `Bool true ] )
+           ] )
+     ]
+     @ examples)
+;;
+
+let handle_persona_schema _ctx args =
+  let include_examples = get_bool args "include_examples" false in
+  true, Yojson.Safe.to_string (schema_json ~include_examples ())
+;;
+
+let validate_unknown_keeper_fields keeper_json =
+  assoc_keys keeper_json
+  |> List.filter (fun key -> not (List.mem key allowed_keeper_fields))
+;;
+
+let normalize_tool_preset raw =
+  match Keeper_types_profile.normalize_tool_preset_raw raw with
+  | Some value -> Ok value
+  | None ->
+    Error
+      (Printf.sprintf
+         "invalid keeper.tool_preset '%s' (allowed: %s)"
+         raw
+         (String.concat ", " Keeper_types_profile.valid_tool_preset_raw_strings))
+;;
+
+let normalize_social_model raw =
+  match Keeper_types_profile.normalize_social_model_opt (Some raw) with
+  | Some value -> Ok value
+  | None ->
+    Error
+      (Printf.sprintf
+         "invalid keeper.social_model '%s' (allowed: bdi_speech_v1, magentic_ledger_v1)"
+         raw)
+;;
+
+let normalize_cascade_name raw =
+  let normalized = Keeper_cascade_profile.normalize_declared_name raw in
+  let catalog =
+    try Keeper_cascade_profile.catalog_names () with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | _ -> []
+  in
+  let known =
+    Keeper_cascade_profile.known_cascades @ [ "local_only"; "local_recovery" ] @ catalog
+  in
+  if List.mem (String.lowercase_ascii normalized) known
+  then Ok normalized
+  else
+    Error
+      (Printf.sprintf
+         "invalid keeper.cascade_name '%s' (known: %s)"
+         raw
+         (String.concat ", " known))
+;;
+
+let add_optional_string key fields keeper_json =
+  match json_trimmed_string_opt key keeper_json with
+  | Some value -> assoc_set key (`String value) fields
+  | None -> assoc_without key fields
+;;
+
+let add_optional_bool key fields keeper_json =
+  match Safe_ops.json_bool_opt key keeper_json with
+  | Some value -> assoc_set key (`Bool value) fields
+  | None -> assoc_without key fields
+;;
+
+let add_optional_int key fields keeper_json =
+  match Safe_ops.json_int_opt key keeper_json with
+  | Some value -> assoc_set key (`Int value) fields
+  | None -> assoc_without key fields
+;;
+
+let add_optional_float key fields keeper_json =
+  match Safe_ops.json_float_opt key keeper_json with
+  | Some value -> assoc_set key (`Float value) fields
+  | None -> assoc_without key fields
+;;
+
+let add_optional_string_list key fields keeper_json =
+  match json_string_list_normalized key keeper_json with
+  | [] -> assoc_without key fields
+  | values -> assoc_set key (string_list_to_json values) fields
+;;
+
+let normalize_keeper_json ~handle keeper_json =
+  match keeper_json with
+  | `Assoc _ ->
+    let unknown = validate_unknown_keeper_fields keeper_json in
+    if unknown <> []
+    then
+      Error
+        (Printf.sprintf
+           "unknown keeper fields: %s. Call masc_persona_schema for supported fields."
+           (String.concat ", " unknown))
+    else (
+      let goal = json_trimmed_string_opt "goal" keeper_json in
+      let result =
+        match goal with
+        | None -> Error "keeper.goal is required"
+        | Some goal -> Ok goal
+      in
+      Result.bind result (fun goal ->
+        let tool_preset_result =
+          match json_trimmed_string_opt "tool_preset" keeper_json with
+          | None -> Ok "research"
+          | Some raw -> normalize_tool_preset raw
+        in
+        Result.bind tool_preset_result (fun tool_preset ->
+          let social_model_result =
+            match json_trimmed_string_opt "social_model" keeper_json with
+            | None -> Ok None
+            | Some raw ->
+              Result.map (fun value -> Some value) (normalize_social_model raw)
+          in
+          Result.bind social_model_result (fun social_model ->
+            let cascade_name_result =
+              match json_trimmed_string_opt "cascade_name" keeper_json with
+              | None -> Ok None
+              | Some raw ->
+                Result.map (fun value -> Some value) (normalize_cascade_name raw)
+            in
+            Result.map
+              (fun cascade_name ->
+                 let mention_targets =
+                   match json_string_list_normalized "mention_targets" keeper_json with
+                   | [] -> [ handle ]
+                   | xs -> xs
+                 in
+                 let get_goal_horizon key =
+                   json_trimmed_string_opt key keeper_json |> Option.value ~default:goal
+                 in
+                 let fields =
+                   [ "goal", `String goal
+                   ; "short_goal", `String (get_goal_horizon "short_goal")
+                   ; "mid_goal", `String (get_goal_horizon "mid_goal")
+                   ; "long_goal", `String (get_goal_horizon "long_goal")
+                   ; "mention_targets", string_list_to_json mention_targets
+                   ; "tool_preset", `String tool_preset
+                   ; ( "proactive_enabled"
+                     , `Bool
+                         (Safe_ops.json_bool
+                            ~default:false
+                            "proactive_enabled"
+                            keeper_json) )
+                   ]
+                 in
+                 let fields =
+                   [ "will"
+                   ; "needs"
+                   ; "desires"
+                   ; "instructions"
+                   ; "work_discovery_guidance"
+                   ]
+                   |> List.fold_left
+                        (fun acc key -> add_optional_string key acc keeper_json)
+                        fields
+                 in
+                 let fields =
+                   [ "policy_voice_enabled"
+                   ; "room_signal_prompt_enabled"
+                   ; "work_discovery_enabled"
+                   ; "telemetry_feedback_enabled"
+                   ; "always_approve"
+                   ]
+                   |> List.fold_left
+                        (fun acc key -> add_optional_bool key acc keeper_json)
+                        fields
+                 in
+                 let fields =
+                   [ "proactive_idle_sec"
+                   ; "proactive_cooldown_sec"
+                   ; "work_discovery_interval_sec"
+                   ; "telemetry_feedback_window_hours"
+                   ; "max_turns_per_call"
+                   ; "max_turns_per_call_scheduled_autonomous"
+                   ]
+                   |> List.fold_left
+                        (fun acc key -> add_optional_int key acc keeper_json)
+                        fields
+                 in
+                 let fields =
+                   add_optional_float "per_provider_timeout" fields keeper_json
+                 in
+                 let fields =
+                   [ "tool_also_allow"
+                   ; "tool_denylist"
+                   ; "shards"
+                   ; "work_discovery_sources"
+                   ]
+                   |> List.fold_left
+                        (fun acc key -> add_optional_string_list key acc keeper_json)
+                        fields
+                 in
+                 let fields =
+                   match social_model with
+                   | Some value -> assoc_set "social_model" (`String value) fields
+                   | None -> assoc_without "social_model" fields
+                 in
+                 let fields =
+                   match cascade_name with
+                   | Some value -> assoc_set "cascade_name" (`String value) fields
+                   | None -> assoc_without "cascade_name" fields
+                 in
+                 `Assoc (List.rev fields))
+              cascade_name_result))))
+  | _ -> Error "profile.keeper must be an object"
+;;
+
+let normalize_profile ~handle profile =
+  if not (Keeper_config.validate_name handle)
+  then Error "handle must match [A-Za-z0-9._-]+"
+  else (
+    match profile with
+    | `Assoc top_fields ->
+      let keeper_json = assoc_get "keeper" profile |> Option.value ~default:`Null in
+      (match normalize_keeper_json ~handle keeper_json with
+       | Error msg -> Error msg
+       | Ok keeper ->
+         let display_name =
+           json_trimmed_string_opt "name" profile |> Option.value ~default:handle
+         in
+         let top_fields =
+           top_fields
+           |> assoc_without "keeper"
+           |> assoc_set "handle" (`String handle)
+           |> assoc_set "name" (`String display_name)
+           |> assoc_set "keeper" keeper
+         in
+         Ok (`Assoc (List.rev top_fields)))
+    | _ -> Error "profile must be a JSON object")
+;;
+
+let ensure_personas_root root =
+  try
+    ignore (Keeper_fs.ensure_dir root);
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printexc.to_string exn)
+;;
+
+let save_persona ?(overwrite = false) ?(dry_run = false) ~handle profile
+  : (save_result, string) result
+  =
+  Result.bind (normalize_profile ~handle profile) (fun normalized ->
+    let root = personas_root_candidate () in
+    let profile_path = persona_profile_path ~root ~handle in
+    let exists = Fs_compat.file_exists profile_path in
+    if exists && not overwrite
+    then
+      Error
+        (Printf.sprintf
+           "persona '%s' already exists at %s (set overwrite=true to replace)"
+           handle
+           profile_path)
+    else if dry_run
+    then
+      Ok
+        { handle
+        ; personas_root = root
+        ; profile_path
+        ; profile = normalized
+        ; warnings = []
+        }
+    else
+      Result.bind (ensure_personas_root root) (fun () ->
+        match Keeper_fs.save_json_atomic profile_path normalized with
+        | Error msg -> Error msg
+        | Ok () ->
+          Config_dir_resolver.reset ();
+          Ok
+            { handle
+            ; personas_root = root
+            ; profile_path
+            ; profile = normalized
+            ; warnings = []
+            }))
+;;
+
+let save_result_to_json ?(dry_run = false) result =
+  `Assoc
+    [ "handle", `String result.handle
+    ; "personas_root", `String result.personas_root
+    ; "profile_path", `String result.profile_path
+    ; "dry_run", `Bool dry_run
+    ; "saved", `Bool (not dry_run)
+    ; "profile", result.profile
+    ; "warnings", string_list_to_json result.warnings
+    ; ( "keeper_create_preview_args"
+      , `Assoc [ "persona_name", `String result.handle; "dry_run", `Bool true ] )
+    ]
+;;
+
+let handle_persona_save _ctx args =
+  let handle = get_string args "handle" "" |> String.trim in
+  let overwrite = get_bool args "overwrite" false in
+  let dry_run = get_bool args "dry_run" false in
+  match assoc_get "profile" args with
+  | None -> false, error_response_typed ~code:Validation_error "profile is required"
+  | Some profile ->
+    (match save_persona ~overwrite ~dry_run ~handle profile with
+     | Error msg -> false, error_response_typed ~code:Validation_error msg
+     | Ok result -> true, Yojson.Safe.to_string (save_result_to_json ~dry_run result))
+;;
+
+let ascii_slug_char = function
+  | 'A' .. 'Z' as c -> Some (Char.lowercase_ascii c)
+  | 'a' .. 'z' as c -> Some c
+  | '0' .. '9' as c -> Some c
+  | ('.' | '_' | '-') as c -> Some c
+  | ' ' | '\t' | '\n' | '\r' -> Some '-'
+  | _ -> None
+;;
+
+let collapse_dashes raw =
+  let b = Buffer.create (String.length raw) in
+  let last_dash = ref false in
+  String.iter
+    (fun c ->
+       if Char.equal c '-'
+       then (
+         if not !last_dash then Buffer.add_char b c;
+         last_dash := true)
+       else (
+         Buffer.add_char b c;
+         last_dash := false))
+    raw;
+  Buffer.contents b
+;;
+
+let trim_dashes raw =
+  let len = String.length raw in
+  let rec left i =
+    if i >= len then len else if Char.equal raw.[i] '-' then left (i + 1) else i
+  in
+  let rec right i =
+    if i < 0 then -1 else if Char.equal raw.[i] '-' then right (i - 1) else i
+  in
+  let l = left 0 in
+  let r = right (len - 1) in
+  if l > r then "" else String.sub raw l (r - l + 1)
+;;
+
+let handle_from_concept concept =
+  let b = Buffer.create (String.length concept) in
+  String.iter
+    (fun c ->
+       match ascii_slug_char c with
+       | Some normalized -> Buffer.add_char b normalized
+       | None -> ())
+    concept;
+  let candidate = Buffer.contents b |> collapse_dashes |> trim_dashes in
+  let candidate =
+    if String.length candidate > 48
+    then String.sub candidate 0 48 |> trim_dashes
+    else candidate
+  in
+  if Keeper_config.validate_name candidate
+  then candidate
+  else "persona-" ^ String.sub (Digest.to_hex (Digest.string concept)) 0 8
+;;
+
+let generation_prompt
+      ~concept
+      ~handle
+      ~display_name_opt
+      ~tool_preset
+      ~proactive_enabled
+      ~language
+  =
+  Printf.sprintf
+    {|
+You are drafting a MASC persona profile.json.
+
+Return one JSON object only. Do not wrap it in markdown.
+The JSON shape must be:
+{
+  "handle": "%s",
+  "profile": {
+    "name": "...",
+    "role": "...",
+    "trait": "...",
+    "keeper": {
+      "goal": "...",
+      "short_goal": "...",
+      "mid_goal": "...",
+      "long_goal": "...",
+      "instructions": "...",
+      "will": "...",
+      "needs": "...",
+      "desires": "...",
+      "mention_targets": ["%s"],
+      "tool_preset": "%s",
+      "proactive_enabled": %b
+    }
+  },
+  "field_explanations": [
+    {"path": "keeper.goal", "value": "...", "effect": "..."}
+  ]
+}
+
+Concept:
+%s
+
+Preferred display name: %s
+Output language: %s
+
+Supported field catalog:
+%s
+
+Constraints:
+- keeper.goal is required and must be concrete enough to create a keeper.
+- Do not include unsupported keeper fields.
+- Keep the result useful for a real long-running keeper, not a marketing character sheet.
+- Give field_explanations for every non-empty keeper.* field you set.
+|}
+    handle
+    handle
+    tool_preset
+    proactive_enabled
+    concept
+    (Option.value ~default:"(choose one)" display_name_opt)
+    language
+    (Yojson.Safe.pretty_to_string (field_catalog_json ()))
+;;
+
+let parsed_profile_payload json =
+  match assoc_get "profile" json with
+  | Some (`Assoc _ as profile) -> profile
+  | _ -> json
+;;
+
+let parsed_handle_payload fallback json =
+  let candidate =
+    match assoc_get "handle" json with
+    | Some (`String s) -> Some (String.trim s)
+    | _ -> None
+  in
+  match candidate with
+  | Some value when Keeper_config.validate_name value -> value
+  | _ -> fallback
+;;
+
+let field_explanations_payload json =
+  match assoc_get "field_explanations" json with
+  | Some (`List _ as xs) -> xs
+  | _ -> `List []
+;;
+
+let handle_persona_generate ctx args =
+  match get_string_required args "concept" with
+  | Error error_json -> false, error_json
+  | Ok concept ->
+    let requested_handle =
+      match get_string_opt args "handle" with
+      | Some raw ->
+        let value = String.trim raw in
+        if value = "" then None else Some value
+      | None -> None
+    in
+    let fallback_handle =
+      requested_handle |> Option.value ~default:(handle_from_concept concept)
+    in
+    if not (Keeper_config.validate_name fallback_handle)
+    then
+      ( false
+      , error_response_typed ~code:Validation_error "handle must match [A-Za-z0-9._-]+" )
+    else (
+      let tool_preset =
+        match get_string_opt args "tool_preset" with
+        | Some raw ->
+          (match Keeper_types_profile.normalize_tool_preset_raw raw with
+           | Some value -> value
+           | None -> "research")
+        | None -> "research"
+      in
+      let cascade_name = get_string args "cascade_name" "operator_judge" |> String.trim in
+      let cascade_name = if cascade_name = "" then "operator_judge" else cascade_name in
+      let temperature = get_float_opt args "temperature" |> Option.value ~default:0.7 in
+      let max_tokens = get_int_opt args "max_tokens" |> Option.value ~default:2500 in
+      let proactive_enabled = get_bool args "proactive_enabled" false in
+      let language = get_string args "language" "ko" |> String.trim in
+      let display_name_opt = get_string_opt args "display_name" in
+      let prompt =
+        generation_prompt
+          ~concept
+          ~handle:fallback_handle
+          ~display_name_opt
+          ~tool_preset
+          ~proactive_enabled
+          ~language
+      in
+      match
+        Masc_oas_bridge.run_safe ~timeout_s:120.0 (fun () ->
+          Oas_worker.run_named
+            ~cascade_name
+            ~goal:prompt
+            ~max_turns:1
+            ~temperature
+            ~max_tokens
+            ~approval:Approval_callbacks.auto_approve
+            ~sw:ctx.Keeper_types.sw
+            ?net:ctx.Keeper_types.net
+            ())
+      with
+      | Error err ->
+        ( false
+        , error_response_typed
+            ~code:Internal_error
+            (Printf.sprintf "persona generation failed: %s" (Oas.Error.to_string err)) )
+      | Ok result ->
+        let raw_text = Oas_response.text_of_response result.Oas_worker.response in
+        (try
+           let parsed = Llm_provider.Lenient_json.parse raw_text in
+           let handle = parsed_handle_payload fallback_handle parsed in
+           let profile = parsed_profile_payload parsed in
+           match normalize_profile ~handle profile with
+           | Error msg ->
+             ( false
+             , error_response_typed
+                 ~code:Validation_error
+                 (Printf.sprintf "generated profile is invalid: %s" msg) )
+           | Ok normalized ->
+             let json =
+               `Assoc
+                 [ "handle", `String handle
+                 ; "profile", normalized
+                 ; "field_explanations", field_explanations_payload parsed
+                 ; "raw_model", `String raw_text
+                 ; ( "save_args"
+                   , `Assoc
+                       [ "handle", `String handle
+                       ; "profile", normalized
+                       ; "overwrite", `Bool false
+                       ; "dry_run", `Bool false
+                       ] )
+                 ; ( "keeper_create_preview_args"
+                   , `Assoc [ "persona_name", `String handle; "dry_run", `Bool true ] )
+                 ]
+             in
+             true, Yojson.Safe.to_string json
+         with
+         | Yojson.Json_error msg ->
+           ( false
+           , error_response_typed
+               ~code:Validation_error
+               (Printf.sprintf "generation did not return parseable JSON: %s" msg) )))
+;;

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -94,6 +94,99 @@ let keeper_schemas : tool_schema list = [
     ];
   };
   {
+    name = "masc_persona_schema";
+    description = "Explain persona profile.json fields, allowed values, and how each field affects persona-backed keeper creation.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("include_examples", `Assoc [
+          ("type", `String "boolean");
+          ("default", `Bool false);
+          ("description", `String "If true, include a minimal profile.json example.");
+        ]);
+      ]);
+    ];
+  };
+  {
+    name = "masc_persona_generate";
+    description = "Draft a persona profile.json from a natural-language concept. This does not write files; use masc_persona_save to persist it.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("concept", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Freeform character/operator concept, e.g. 'good evil chaos research keeper'.");
+        ]);
+        ("handle", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional stable persona handle. Must match [A-Za-z0-9._-]+.");
+        ]);
+        ("display_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional display label for the persona.");
+        ]);
+        ("language", `Assoc [
+          ("type", `String "string");
+          ("default", `String "ko");
+          ("description", `String "Preferred language for generated text.");
+        ]);
+        ("tool_preset", `Assoc [
+          ("type", `String "string");
+          ("default", `String "research");
+          ("enum", `List (List.map (fun s -> `String s) tool_preset_enum_strings));
+          ("description", `String "Default keeper.tool_preset for the draft.");
+        ]);
+        ("proactive_enabled", `Assoc [
+          ("type", `String "boolean");
+          ("default", `Bool false);
+          ("description", `String "Default keeper.proactive_enabled for the draft.");
+        ]);
+        ("cascade_name", `Assoc [
+          ("type", `String "string");
+          ("default", `String "operator_judge");
+          ("description", `String "Named cascade used to draft the persona.");
+        ]);
+        ("temperature", `Assoc [
+          ("type", `String "number");
+          ("default", `Float 0.7);
+        ]);
+        ("max_tokens", `Assoc [
+          ("type", `String "integer");
+          ("default", `Int 2500);
+        ]);
+      ]);
+      ("required", `List [`String "concept"]);
+    ];
+  };
+  {
+    name = "masc_persona_save";
+    description = "Validate and atomically write a generated persona profile.json under the resolved personas root.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("handle", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Persona handle and directory name. Must match [A-Za-z0-9._-]+.");
+        ]);
+        ("profile", `Assoc [
+          ("type", `String "object");
+          ("description", `String "Persona profile.json object to validate and save.");
+        ]);
+        ("overwrite", `Assoc [
+          ("type", `String "boolean");
+          ("default", `Bool false);
+          ("description", `String "If false, reject when the persona already exists.");
+        ]);
+        ("dry_run", `Assoc [
+          ("type", `String "boolean");
+          ("default", `Bool false);
+          ("description", `String "If true, validate and return the target path without writing.");
+        ]);
+      ]);
+      ("required", `List [`String "handle"; `String "profile"]);
+    ];
+  };
+  {
     name = "masc_keeper_create_from_persona";
     description = "Create or dry-run a keeper configuration from a persona profile.json. Keepers are durable and auto-start on server boot.";
     input_schema = `Assoc [

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -132,7 +132,7 @@ let public_mcp_surface_tools =
     "masc_keeper_sandbox_status"; "masc_keeper_sandbox_start"; "masc_keeper_sandbox_stop";
     "masc_keeper_up"; "masc_keeper_repair"; "masc_keeper_reset";
     "masc_keeper_down";
-    "masc_persona_list";
+    "masc_persona_list"; "masc_persona_schema";
     (* Board *)
     "masc_board_post"; "masc_board_list"; "masc_board_get";
     "masc_board_comment"; "masc_board_vote";
@@ -203,6 +203,7 @@ let admin_surface_tools =
     "masc_tool_admin_snapshot";
     "masc_config";
     (* Phase 2: surface SSOT *)
+    "masc_persona_generate"; "masc_persona_save";
     "masc_keeper_create_from_persona"; "masc_keeper_reset";
     "masc_pause"; "masc_resume";
     "masc_runtime_ollama_probe"; "masc_tool_list";
@@ -227,6 +228,8 @@ let keeper_denied_surface_tools =
     "masc_tool_admin_update";
     "masc_tool_admin_snapshot";
     "masc_config";
+    "masc_persona_generate";
+    "masc_persona_save";
     "masc_keeper_create_from_persona";
     (* NOTE: masc_keeper_reset is on public_mcp_surface_tools (line 126),
        so it cannot be added to Keeper_denied without violating the

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -1139,6 +1139,9 @@ let dispatch ctx ~name ~args : tool_result option =
   let ctx = resolve_ctx ctx ~name args in
   match name with
   | "masc_persona_list" -> Some (Persona.handle_persona_list ctx args)
+  | "masc_persona_schema" -> Some (Persona.handle_persona_schema ctx args)
+  | "masc_persona_generate" -> Some (Persona.handle_persona_generate ctx args)
+  | "masc_persona_save" -> Some (Persona.handle_persona_save ctx args)
   | "masc_keeper_create_from_persona" -> Some (handle_keeper_create_from_persona ctx args)
   | "masc_keeper_up" -> Some (handle_keeper_up ctx args)
   | "masc_keeper_status" -> Some (handle_keeper_status ctx args)
@@ -1171,12 +1174,14 @@ let dispatch_stream ~on_text_delta ctx ~name ~args : tool_result option =
 (* ================================================================ *)
 
 let _tool_spec_read_only =
-  [ "masc_keeper_list"; "masc_keeper_status"; "masc_keeper_sandbox_status" ]
+  [ "masc_persona_list"; "masc_persona_schema"; "masc_keeper_list";
+    "masc_keeper_status"; "masc_keeper_sandbox_status" ]
 
 let tool_required_permission = function
-  | "masc_persona_list" | "masc_keeper_list" | "masc_keeper_status"
-  | "masc_keeper_sandbox_status" ->
+  | "masc_persona_list" | "masc_persona_schema" | "masc_keeper_list"
+  | "masc_keeper_status" | "masc_keeper_sandbox_status" ->
       Some Types.CanReadState
+  | "masc_persona_generate" | "masc_persona_save"
   | "masc_keeper_create_from_persona" | "masc_keeper_up"
   | "masc_keeper_msg" | "masc_keeper_msg_result"
   | "masc_keeper_repair"

--- a/lib/tool_permission_map.ml
+++ b/lib/tool_permission_map.ml
@@ -20,6 +20,7 @@ let legacy_permission_entries : (string * permission) list =
     ("masc_operator_snapshot", CanReadState);
     ("masc_operator_digest", CanReadState);
     ("masc_surface_audit", CanReadState);
+    ("masc_persona_schema", CanReadState);
     ("masc_keeper_status", CanReadState);
     ("masc_keeper_list", CanReadState);
     ("masc_runtime_verify", CanReadState);
@@ -64,6 +65,8 @@ let legacy_permission_entries : (string * permission) list =
     ("masc_keeper_reset", CanBroadcast);
     ("masc_keeper_compact", CanBroadcast);
     ("masc_keeper_clear", CanBroadcast);
+    ("masc_persona_generate", CanBroadcast);
+    ("masc_persona_save", CanBroadcast);
     ("masc_keeper_create_from_persona", CanBroadcast);
     ("masc_approval_resolve", CanAdmin);
     ("masc_operator_confirm", CanBroadcast);

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -2,6 +2,7 @@ open Alcotest
 
 module TL = Masc_mcp.Keeper_toml_loader
 module KTP = Masc_mcp.Keeper_types_profile
+module KPA = Masc_mcp.Keeper_persona_authoring
 
 let contains_substring s needle =
   let s_len = String.length s in
@@ -989,6 +990,92 @@ let test_persona_resolver_preserves_canonical_tool_access_and_allowed_paths () =
          | `String _ -> true
          | _ -> false)
 
+let authoring_minimal_profile =
+  `Assoc
+    [
+      ("name", `String "Probe");
+      ("role", `String "research critic");
+      ("trait", `String "skeptical and concise");
+      ( "keeper",
+        `Assoc
+          [
+            ("goal", `String "Find weak assumptions and make concrete tasks.");
+          ] );
+    ]
+
+let test_persona_authoring_schema_explains_effects () =
+  let json = KPA.schema_json () in
+  let rendered = Yojson.Safe.to_string json in
+  check bool "documents keeper.goal" true
+    (contains_substring rendered "keeper.goal");
+  check bool "documents tool presets" true
+    (contains_substring rendered "tool_preset");
+  check bool "documents archetype axes" true
+    (contains_substring rendered "archetype_axes")
+
+let test_persona_authoring_normalizes_keeper_defaults () =
+  match KPA.normalize_profile ~handle:"probe" authoring_minimal_profile with
+  | Error e -> fail e
+  | Ok json ->
+      let keeper = Yojson.Safe.Util.member "keeper" json in
+      check string "handle written" "probe"
+        (Yojson.Safe.Util.member "handle" json |> Yojson.Safe.Util.to_string);
+      check string "goal preserved"
+        "Find weak assumptions and make concrete tasks."
+        (Yojson.Safe.Util.member "goal" keeper |> Yojson.Safe.Util.to_string);
+      check string "short_goal defaults to goal"
+        "Find weak assumptions and make concrete tasks."
+        (Yojson.Safe.Util.member "short_goal" keeper
+         |> Yojson.Safe.Util.to_string);
+      check (list string) "mention target defaults to handle" [ "probe" ]
+        (Yojson.Safe.Util.member "mention_targets" keeper
+         |> Yojson.Safe.Util.to_list
+         |> List.map Yojson.Safe.Util.to_string);
+      check string "tool preset defaults to research" "research"
+        (Yojson.Safe.Util.member "tool_preset" keeper
+         |> Yojson.Safe.Util.to_string)
+
+let test_persona_authoring_rejects_unknown_keeper_fields () =
+  let profile =
+    `Assoc
+      [
+        ( "keeper",
+          `Assoc
+            [
+              ("goal", `String "test");
+              ("evil_chaos_knob", `String "11");
+            ] );
+      ]
+  in
+  match KPA.normalize_profile ~handle:"probe" profile with
+  | Ok _ -> fail "expected unknown keeper field rejection"
+  | Error e ->
+      check bool "mentions unknown keeper fields" true
+        (contains_substring e "unknown keeper fields");
+      check bool "mentions schema tool" true
+        (contains_substring e "masc_persona_schema")
+
+let test_persona_authoring_save_dry_run_does_not_write () =
+  with_personas_dir @@ fun personas_dir ->
+  match KPA.save_persona ~dry_run:true ~handle:"probe" authoring_minimal_profile with
+  | Error e -> fail e
+  | Ok result ->
+      check string "root" personas_dir result.personas_root;
+      check bool "profile not written" false (Sys.file_exists result.profile_path)
+
+let test_persona_authoring_save_writes_profile_and_loader_reads_it () =
+  with_personas_dir @@ fun _personas_dir ->
+  match KPA.save_persona ~handle:"probe" authoring_minimal_profile with
+  | Error e -> fail e
+  | Ok result ->
+      check bool "profile written" true (Sys.file_exists result.profile_path);
+      (match KTP.load_persona_summary "probe" with
+       | None -> fail "saved persona summary not loaded"
+       | Some summary ->
+           check string "loaded persona name" "probe" summary.persona_name;
+           check string "loaded display" "Probe" summary.display_name;
+           check bool "has keeper defaults" true summary.has_keeper_defaults)
+
 (* ================================================================ *)
 (* Unknown-key detection                                             *)
 (* ================================================================ *)
@@ -1313,5 +1400,15 @@ let () =
             test_persona_resolver_preserves_autoboot_enabled_arg;
           test_case "persona resolver preserves canonical tool_access and allowed_paths" `Quick
             test_persona_resolver_preserves_canonical_tool_access_and_allowed_paths;
+          test_case "persona authoring schema explains effects" `Quick
+            test_persona_authoring_schema_explains_effects;
+          test_case "persona authoring normalizes defaults" `Quick
+            test_persona_authoring_normalizes_keeper_defaults;
+          test_case "persona authoring rejects unknown keeper fields" `Quick
+            test_persona_authoring_rejects_unknown_keeper_fields;
+          test_case "persona authoring dry-run does not write" `Quick
+            test_persona_authoring_save_dry_run_does_not_write;
+          test_case "persona authoring save is loader-visible" `Quick
+            test_persona_authoring_save_writes_profile_and_loader_reads_it;
         ] );
     ]

--- a/test/test_tool_access_role.ml
+++ b/test/test_tool_access_role.ml
@@ -153,6 +153,9 @@ let test_permissions_promoted_to_metadata_ssot () =
       ("masc_tool_admin_snapshot", Types.CanAdmin);
       ("masc_runtime_verify", Types.CanReadState);
       ("masc_persona_list", Types.CanReadState);
+      ("masc_persona_schema", Types.CanReadState);
+      ("masc_persona_generate", Types.CanBroadcast);
+      ("masc_persona_save", Types.CanBroadcast);
       ("masc_keeper_reset", Types.CanBroadcast);
       ("masc_join", Types.CanJoin);
       ("masc_broadcast", Types.CanBroadcast);

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -505,6 +505,33 @@ let test_masc_spawn_schema () =
 
 (* test_masc_persona_list_schema removed: persona list coverage is trivial. *)
 
+let test_masc_persona_authoring_schemas () =
+  (match find_tool "masc_persona_schema" with
+  | None -> Alcotest.fail "masc_persona_schema not found"
+  | Some _ -> ());
+  (match find_tool "masc_persona_generate" with
+  | None -> Alcotest.fail "masc_persona_generate not found"
+  | Some schema -> (
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "generate has concept" true
+            (List.mem_assoc "concept" props);
+          Alcotest.(check bool) "generate has tool_preset" true
+            (List.mem_assoc "tool_preset" props)
+      | None -> Alcotest.fail "masc_persona_generate missing properties"));
+  match find_tool "masc_persona_save" with
+  | None -> Alcotest.fail "masc_persona_save not found"
+  | Some schema -> (
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "save has handle" true
+            (List.mem_assoc "handle" props);
+          Alcotest.(check bool) "save has profile" true
+            (List.mem_assoc "profile" props);
+          Alcotest.(check bool) "save has dry_run" true
+            (List.mem_assoc "dry_run" props)
+      | None -> Alcotest.fail "masc_persona_save missing properties")
+
 let test_masc_keeper_create_from_persona_schema () =
   match find_tool "masc_keeper_create_from_persona" with
   | None -> Alcotest.fail "masc_keeper_create_from_persona not found"
@@ -858,6 +885,8 @@ let () =
       Alcotest.test_case "spawn" `Quick test_masc_spawn_schema;
     ];
     "keeper_runtime_tools", [
+      Alcotest.test_case "persona-authoring" `Quick
+        test_masc_persona_authoring_schemas;
       Alcotest.test_case "keeper-create-from-persona" `Quick
         test_masc_keeper_create_from_persona_schema;
       Alcotest.test_case "keeper-up" `Quick


### PR DESCRIPTION
## Summary
- Add MCP persona authoring tools for schema discovery, draft generation, and validated saves into the active runtime persona root.
- Wire the new tools into keeper schemas, permission metadata, catalog surfaces, and backend dispatch.
- Add a dashboard `새 페르소나` flow for concept-based persona drafting, profile JSON review/save, and keeper creation from the saved persona.

## Impact
- Operators can create persona drafts without adding checked-in repo personas.
- Saved profiles go through the active `Config_dir_resolver` persona path and can be keeperized through the existing `masc_keeper_create_from_persona` flow.
- The tool schema exposes field effects and available choices so persona creation is no longer a black-box field-editing task.

## Validation
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_toml.exe test/test_tools_coverage.exe test/test_tool_access_role.exe`
- `_build/default/test/test_keeper_toml.exe`
- `_build/default/test/test_tools_coverage.exe`
- `_build/default/test/test_tool_access_role.exe`
- `pnpm --dir dashboard typecheck`
- `node_modules/.bin/vitest run --no-file-parallelism --maxWorkers=1 src/components/keeper-spawn/keeper-spawn-state.test.ts src/components/keeper-spawn/persona-browser.test.ts`