### PR TITLE
fix(a11y): re-apply WCAG AA improvements lost in #9862 merge

### DIFF
--- a/dashboard_bonsai/src/archive_runs_view.ml
+++ b/dashboard_bonsai/src/archive_runs_view.ml
@@ -142,7 +142,7 @@ stylesheet
   .pill_failed {
     color: var(--accent-blood);
     border-color: var(--accent-blood-dim);
-    background: rgba(160,24,24,0.14);
+    background: rgba(232,80,80,0.14);
   }
   .pill_stopped {
     color: var(--text-dim);

--- a/dashboard_bonsai/src/ctx_chart.ml
+++ b/dashboard_bonsai/src/ctx_chart.ml
@@ -49,8 +49,8 @@ stylesheet
     position: relative;
     height: 120px;
     background: linear-gradient(180deg,
-      rgba(160,24,24,0.04) 0%,
-      rgba(160,24,24,0.02) 10%,
+      rgba(232,80,80,0.04) 0%,
+      rgba(232,80,80,0.02) 10%,
       transparent 25%,
       transparent 100%);
   }

--- a/dashboard_bonsai/src/ctx_chart.ml
+++ b/dashboard_bonsai/src/ctx_chart.ml
@@ -59,7 +59,7 @@ stylesheet
     position: absolute;
     right: 8px;
     font-family: 'JetBrains Mono', ui-monospace, monospace;
-    font-size: 9px;
+    font-size: 10px;
     color: var(--text-dim);
     pointer-events: none;
   }

--- a/dashboard_bonsai/src/dead_keepers_view.ml
+++ b/dashboard_bonsai/src/dead_keepers_view.ml
@@ -26,7 +26,7 @@ stylesheet
     min-height: 100vh;
     background:
       radial-gradient(ellipse 60% 40% at 12% 8%, rgba(212,169,64,0.06), transparent 55%),
-      radial-gradient(ellipse 40% 50% at 92% 95%, rgba(160,24,24,0.08), transparent 60%),
+      radial-gradient(ellipse 40% 50% at 92% 95%, rgba(232,80,80,0.08), transparent 60%),
       linear-gradient(170deg, #0e0a08 0%, #140c08 60%, #080504 100%);
     color: var(--text-primary);
     font-family: 'Noto Sans KR', 'EB Garamond', sans-serif;

--- a/dashboard_bonsai/src/flame.ml
+++ b/dashboard_bonsai/src/flame.ml
@@ -98,7 +98,7 @@ let view_mini ~(segments : (kind * int) list) =
       (List.map segments ~f:(fun (kind, pct) ->
          Node.span
            ~attrs:[ Style.flame_item ]
-           [ Node.span ~attrs:[ Style.flame_chip; seg_class kind ] []
+           [ Node.span ~attrs:[ Style.flame_chip; seg_class kind; Attr.create "aria-hidden" "true" ] []
            ; Node.span ~attrs:[ Style.flame_lbl ] [ Node.text (label kind) ]
            ; Node.span
                ~attrs:[ Style.flame_pct ]

--- a/dashboard_bonsai/src/hello_view.ml
+++ b/dashboard_bonsai/src/hello_view.ml
@@ -1,11 +1,7 @@
 (** Landing view — placeholder at [/dashboard/b] until a real home page lands.
 
-    Styling follows the MASC Design System (dark-fantasy theme). Tokens are
-    inlined here instead of referenced via CSS variables because [ppx_css]
-    generates scoped class names and we are not sharing the system's
-    stylesheet yet. When [colors_and_type.css] ships into
-    [assets/dashboard_bonsai/], switch the raw values below for
-    [var(--bg-deep)] / [var(--accent-brass)] / etc. *)
+    Styling follows the MASC Design System (dark-fantasy theme). Tokens
+    reference CSS variables from [colors_and_type.css] via [var(--*)]. *)
 
 open! Core
 open! Bonsai_web
@@ -17,8 +13,8 @@ stylesheet
   {|
   .root {
     min-height: 100vh;
-    background: #0a0706;
-    color: #b8a488;
+    background: var(--bg-deep);
+    color: var(--text-primary);
     font-family: 'EB Garamond', 'Noto Sans KR', Georgia, serif;
     padding: 3rem 4rem;
     display: flex;
@@ -31,7 +27,7 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.3em;
     text-transform: uppercase;
-    color: #6a5848;
+    color: var(--text-dim);
     margin: 0;
   }
 
@@ -41,7 +37,7 @@ stylesheet
     font-size: 2.25rem;
     letter-spacing: 0.2em;
     text-transform: uppercase;
-    color: #e8d8b8;
+    color: var(--text-bright);
     margin: 0;
     text-shadow: 0 0 40px rgba(160, 24, 24, 0.28);
   }
@@ -49,7 +45,7 @@ stylesheet
   .sub {
     font-family: 'EB Garamond', Georgia, serif;
     font-size: 1rem;
-    color: #b8a488;
+    color: var(--text-primary);
     margin: 0;
     max-width: 38rem;
     line-height: 1.55;
@@ -57,7 +53,7 @@ stylesheet
 
   .divider {
     border: 0;
-    border-top: 1px solid #2a1a14;
+    border-top: 1px solid var(--border-main);
     margin: 1rem 0;
   }
 
@@ -65,7 +61,7 @@ stylesheet
     font-family: 'JetBrains Mono', ui-monospace, Menlo, Consolas, monospace;
     font-variant-numeric: tabular-nums;
     font-size: 0.75rem;
-    color: #6a5848;
+    color: var(--text-dim);
   }
 |}]
 
@@ -76,7 +72,7 @@ let component (_graph @ local) =
        [ Node.p ~attrs:[ Style.eyebrow ] [ Node.text "masc · runtime" ]
        ; Node.h1 ~attrs:[ Style.title ] [ Node.text "dark manor · bonsai" ]
        ; Node.p
-           ~attrs:[ Style.sub ]
+           ~attrs:[ Style.sub; Attr.create "lang" "ko" ]
            [ Node.text
                "네 명의 키퍼, 폭풍 속의 저택. Bonsai 섬은 조용히 숨쉬는 \
                 관찰자이다. 이 페이지는 런타임 입구를 지킬 뿐, 곧 관조 \

--- a/dashboard_bonsai/src/hello_view.ml
+++ b/dashboard_bonsai/src/hello_view.ml
@@ -39,7 +39,7 @@ stylesheet
     text-transform: uppercase;
     color: var(--text-bright);
     margin: 0;
-    text-shadow: 0 0 40px rgba(160, 24, 24, 0.28);
+    text-shadow: 0 0 40px rgba(232, 80, 80, 0.28);
   }
 
   .sub {

--- a/dashboard_bonsai/src/hero.ml
+++ b/dashboard_bonsai/src/hero.ml
@@ -24,7 +24,7 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.3em;
     text-transform: uppercase;
-    color: var(--text-dim, #6a5848);
+    color: var(--text-dim, #9a846e);
     margin: 0;
   }
 

--- a/dashboard_bonsai/src/hero.ml
+++ b/dashboard_bonsai/src/hero.ml
@@ -44,7 +44,7 @@ stylesheet
   }
 
   .tail_blood {
-    color: var(--accent-blood, #a01818);
+    color: var(--accent-blood, #e85050);
     font-size: 18px;
     margin-left: 14px;
   }

--- a/dashboard_bonsai/src/hero.ml
+++ b/dashboard_bonsai/src/hero.ml
@@ -38,7 +38,7 @@ stylesheet
   }
 
   .tail_brass {
-    color: var(--accent-brass, #8a6a28);
+    color: var(--accent-brass, #968228);
     font-size: 18px;
     margin-left: 14px;
   }

--- a/dashboard_bonsai/src/keepers_directory.ml
+++ b/dashboard_bonsai/src/keepers_directory.ml
@@ -240,8 +240,8 @@ stylesheet
   }
 
   .vial_fill_bad {
-    background: linear-gradient(90deg, #5a0f0f, #a01818);
-    box-shadow: 0 0 6px rgba(160, 24, 24, 0.35);
+    background: linear-gradient(90deg, #8a2828, #e85050);
+    box-shadow: 0 0 6px rgba(232, 80, 80, 0.35);
   }
 
   .meta_strip {

--- a/dashboard_bonsai/src/keepers_directory.ml
+++ b/dashboard_bonsai/src/keepers_directory.ml
@@ -1324,7 +1324,7 @@ let focus_card row =
                     ]
                 ; Node.div
                     ~attrs:[ Shell_view.Style.vial ]
-                    [ Node.span ~attrs:vial_fill_attrs [] ]
+                    [ Node.span ~attrs:(Attr.create "aria-hidden" "true" :: vial_fill_attrs) [] ]
                 ]
             ; Node.div
                 ~attrs:[ Shell_view.Style.stats ]

--- a/dashboard_bonsai/src/keepers_view.ml
+++ b/dashboard_bonsai/src/keepers_view.ml
@@ -24,7 +24,7 @@ stylesheet
     min-height: 100vh;
     background:
       radial-gradient(ellipse 60% 40% at 12% 8%, rgba(212,169,64,0.06), transparent 55%),
-      radial-gradient(ellipse 40% 50% at 92% 95%, rgba(160,24,24,0.08), transparent 60%),
+      radial-gradient(ellipse 40% 50% at 92% 95%, rgba(232,80,80,0.08), transparent 60%),
       linear-gradient(170deg, #0e0a08 0%, #140c08 60%, #080504 100%);
     color: var(--text-primary);
     font-family: 'Noto Sans KR', 'EB Garamond', sans-serif;

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1678,18 +1678,14 @@ let render_response
     Node.div
       ~attrs:[ Style.toolbar ]
       [ (let filter_chip ~level ~label =
-           let click =
-             Attr.on_click (fun _ev ->
-               let effect =
-                 Effect.of_sync_fun
-                   (fun () ->
-                     let doc = Js_of_ocaml.Dom_html.document in
-                     doc##.documentElement##setAttribute
-                       (Js_of_ocaml.Js.string "data-log-level")
-                       (Js_of_ocaml.Js.string level))
-                   ()
-               in
-               effect)
+           let fire () =
+             Effect.of_sync_fun
+               (fun () ->
+                 let doc = Js_of_ocaml.Dom_html.document in
+                 doc##.documentElement##setAttribute
+                   (Js_of_ocaml.Js.string "data-log-level")
+                   (Js_of_ocaml.Js.string level))
+               ()
            in
            Node.span
              ~attrs:
@@ -1697,7 +1693,13 @@ let render_response
                ; Attr.create "data-filter-level" level
                ; Attr.role "button"
                ; Attr.tabindex 0
-               ; click
+               ; Attr.on_click (fun _ev -> fire ())
+               ; Attr.on_key_down (fun ev ->
+                   let open Virtual_dom.Vdom.Event.Keyboard in
+                   if Key.equal ev.key Key.Enter
+                      || Key.equal ev.key (Key.of_string " ")
+                   then fire ()
+                   else Effect.of_sync_fun (fun () -> ()) ())
                ]
              [ Node.text label ]
          in
@@ -1836,18 +1838,26 @@ let render_response
          nav_link Dead_keepers ~tail)
       ; nav_link Archive_runs
       ; (let chip name label =
+           let fire () =
+             Effect.of_sync_fun
+               (fun () ->
+                 Dom_html.window##.location##.hash
+                 := Js.string ("#" ^ name))
+               ()
+           in
            Node.div
              ~attrs:
                [ Style.theme_chip
                ; Attr.create "data-chip-theme" name
                ; Attr.role "button"
                ; Attr.tabindex 0
-               ; Attr.on_click (fun _ ->
-                   Effect.of_sync_fun
-                     (fun () ->
-                       Dom_html.window##.location##.hash
-                       := Js.string ("#" ^ name))
-                     ())
+               ; Attr.on_click (fun _ -> fire ())
+               ; Attr.on_key_down (fun ev ->
+                   let open Virtual_dom.Vdom.Event.Keyboard in
+                   if Key.equal ev.key Key.Enter
+                      || Key.equal ev.key (Key.of_string " ")
+                   then fire ()
+                   else Effect.of_sync_fun (fun () -> ()) ())
                ]
              [ Node.text label ]
          in

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -341,6 +341,7 @@ stylesheet
     transition: color 0.18s, border-color 0.18s;
   }
   .btn_ghost:hover { color: var(--accent-brass); border-color: var(--border-highlight); }
+  .btn_ghost:focus-visible { outline: 2px solid var(--accent-brass); outline-offset: -2px; }
 
   .header {
     display: flex;
@@ -1177,6 +1178,7 @@ stylesheet
     border-color: var(--accent-brass);
     color: var(--accent-brass);
   }
+  .pbtn:focus-visible { outline: 2px solid var(--accent-brass); outline-offset: -2px; }
   .pbtn_primary {
     background: linear-gradient(180deg, #3a2a16 0%, #241810 100%);
     border-color: var(--accent-brass);
@@ -1737,7 +1739,7 @@ let render_response
   let moonrise =
     Node.div
       ~attrs:[ Style.moonrise ]
-      [ Node.span ~attrs:[ Style.moon_glyph ] []
+      [ Node.span ~attrs:[ Style.moon_glyph; Attr.create "aria-hidden" "true" ] []
       ; Node.span ~attrs:[ Style.moon_lead ] [ Node.text moon_lead_text ]
       ; Node.span ~attrs:[ Style.moon_sep ] [ Node.text "·" ]
       ; Node.span [ Node.text "lit by a half moon" ]
@@ -2116,12 +2118,16 @@ let render_response
             ~attrs:[ Style.page_actions ]
             [ Node.button
                 ~attrs:[ Style.pbtn ]
-                [ Node.span ~attrs:[ Style.pbtn_glyph ] []
+                [ Node.span
+                    ~attrs:[ Style.pbtn_glyph; Attr.create "aria-hidden" "true" ]
+                    []
                 ; Node.text "preflight"
                 ]
             ; Node.button
                 ~attrs:[ Style.pbtn; Style.pbtn_primary ]
-                [ Node.span ~attrs:[ Style.pbtn_glyph ] []
+                [ Node.span
+                    ~attrs:[ Style.pbtn_glyph; Attr.create "aria-hidden" "true" ]
+                    []
                 ; Node.text "advance round"
                 ]
             ]
@@ -2137,7 +2143,7 @@ let render_response
                 ~attrs:[ Style.title ]
                 [ Node.span ~attrs:[ Style.versal ] [ Node.text "J" ]
                 ; Node.span ~attrs:[ Style.title_rest ] [ Node.text "ournal" ]
-                ; Node.span ~attrs:[ Style.title_rule ] []
+                ; Node.span ~attrs:[ Style.title_rule; Attr.create "aria-hidden" "true" ] []
                 ; Node.span
                     ~attrs:[ Style.folio ]
                     [ Node.text "folio xii · recto" ]
@@ -2149,12 +2155,12 @@ let render_response
         ]
     ; Node.div
         ~attrs:[ Style.sec ]
-        [ Node.span ~attrs:[ Style.sec_glyph ] []
+        [ Node.span ~attrs:[ Style.sec_glyph; Attr.create "aria-hidden" "true" ] []
         ; Node.div ~attrs:[ Style.sec_h ] [ Node.text "log ring" ]
         ; Node.span
             ~attrs:[ Style.sec_sub ]
             [ Node.text "in-memory journal · newest on top" ]
-        ; Node.span ~attrs:[ Style.sec_hr ] []
+        ; Node.span ~attrs:[ Style.sec_hr; Attr.create "aria-hidden" "true" ] []
         ; Node.span
             ~attrs:[ Style.sec_r ]
             [ Node.text "rows "
@@ -2173,12 +2179,12 @@ let render_response
     ; tape
     ; Node.div
         ~attrs:[ Style.sec ]
-        [ Node.span ~attrs:[ Style.sec_glyph ] []
+        [ Node.span ~attrs:[ Style.sec_glyph; Attr.create "aria-hidden" "true" ] []
         ; Node.div ~attrs:[ Style.sec_h ] [ Node.text "keepers" ]
         ; Node.span
             ~attrs:[ Style.sec_sub ]
             [ Node.text "sorted by heartbeat · ctx spark = last 10 min" ]
-        ; Node.span ~attrs:[ Style.sec_hr ] []
+        ; Node.span ~attrs:[ Style.sec_hr; Attr.create "aria-hidden" "true" ] []
         ; Node.span
             ~attrs:[ Style.sec_r ]
             [ Node.text "slot "
@@ -2194,12 +2200,12 @@ let render_response
     ; Roster.view ~keepers ()
     ; Node.div
         ~attrs:[ Style.sec ]
-        [ Node.span ~attrs:[ Style.sec_glyph ] []
+        [ Node.span ~attrs:[ Style.sec_glyph; Attr.create "aria-hidden" "true" ] []
         ; Node.div ~attrs:[ Style.sec_h ] [ Node.text "cycle activity" ]
         ; Node.span
             ~attrs:[ Style.sec_sub ]
             [ Node.text "last 60 minutes · one lane per keeper" ]
-        ; Node.span ~attrs:[ Style.sec_hr ] []
+        ; Node.span ~attrs:[ Style.sec_hr; Attr.create "aria-hidden" "true" ] []
         ; Node.span
             ~attrs:[ Style.sec_r ]
             [ Node.text "mock · trace endpoint "
@@ -2209,12 +2215,12 @@ let render_response
     ; Swim.view ~keepers ()
     ; Node.div
         ~attrs:[ Style.sec ]
-        [ Node.span ~attrs:[ Style.sec_glyph ] []
+        [ Node.span ~attrs:[ Style.sec_glyph; Attr.create "aria-hidden" "true" ] []
         ; Node.div ~attrs:[ Style.sec_h ] [ Node.text "context pressure" ]
         ; Node.span
             ~attrs:[ Style.sec_sub ]
             [ Node.text "60m rolling · % of window · warn 75 / danger 90" ]
-        ; Node.span ~attrs:[ Style.sec_hr ] []
+        ; Node.span ~attrs:[ Style.sec_hr; Attr.create "aria-hidden" "true" ] []
         ; Node.span
             ~attrs:[ Style.sec_r ]
             [ Node.text "mock · keepers endpoint "
@@ -2224,12 +2230,12 @@ let render_response
     ; Ctx_chart.view ~keepers ()
     ; Node.div
         ~attrs:[ Style.sec ]
-        [ Node.span ~attrs:[ Style.sec_glyph ] []
+        [ Node.span ~attrs:[ Style.sec_glyph; Attr.create "aria-hidden" "true" ] []
         ; Node.div ~attrs:[ Style.sec_h ] [ Node.text "keeper rites · 12 states" ]
         ; Node.span
             ~attrs:[ Style.sec_sub ]
             [ Node.text "Offline → Running → {Failing · Overflowed · Compacting · Draining} → Paused / Stopped / Crashed → Restarting → Dead" ]
-        ; Node.span ~attrs:[ Style.sec_hr ] []
+        ; Node.span ~attrs:[ Style.sec_hr; Attr.create "aria-hidden" "true" ] []
         ; Node.span
             ~attrs:[ Style.sec_r ]
             [ Node.text "mock · keeper phase wire "

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1669,7 +1669,7 @@ let render_response
            head @ runtime_seg @ tail)
       ; Node.div
           ~attrs:[ Style.pulse_slot ]
-          [ Node.span ~attrs:[ Style.pulse ] []
+          [ Node.span ~attrs:[ Style.pulse; Attr.create "aria-hidden" "true" ] []
           ; Node.span ~attrs:[ Style.pulse_label ] [ Node.text "live · 3s" ]
           ]
       ]
@@ -1783,7 +1783,7 @@ let render_response
     in
     Node.a
       ~attrs:(Attr.href (Route.path route) :: base)
-      ([ Node.span ~attrs:[ Style.nav_link_glyph ] []
+      ([ Node.span ~attrs:[ Style.nav_link_glyph; Attr.create "aria-hidden" "true" ] []
        ; Node.text (Route.label route)
        ]
        @ tail_node)
@@ -1945,7 +1945,7 @@ let render_response
               ]
           ; Node.div
               ~attrs:[ Style.vial ]
-              [ Node.span ~attrs:[ Style.vial_fill; vial_style ] [] ]
+              [ Node.span ~attrs:[ Style.vial_fill; vial_style; Attr.create "aria-hidden" "true" ] [] ]
           ]
       ; Node.div
           ~attrs:[ Style.focus_stats ]

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1366,7 +1366,7 @@ let view_entry ~is_first (e : Logs_types.entry) =
     ; Node.div ~attrs:[ Style.mod_col ] [ Node.text e.module_ ]
     ; Node.div
         ~attrs:[ Style.source_badge ]
-        [ Node.span ~attrs:[ Style.dot; dot_class e.normalized_level ] []
+        [ Node.span ~attrs:[ Style.dot; dot_class e.normalized_level; Attr.create "aria-hidden" "true" ] []
         ; Node.text e.source
         ]
     ; Node.div message_block

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -26,7 +26,7 @@ stylesheet
     min-height: 100vh;
     background:
       radial-gradient(circle at 88% 14%, rgba(138, 106, 40, 0.10), transparent 22%),
-      radial-gradient(circle at 8% 88%, rgba(160, 24, 24, 0.05), transparent 28%),
+      radial-gradient(circle at 8% 88%, rgba(232, 80, 80, 0.05), transparent 28%),
       var(--bg-deep);
     color: var(--text-primary);
     font-family: 'EB Garamond', 'Noto Sans KR', Georgia, serif;
@@ -186,7 +186,7 @@ stylesheet
   }
 
   .heartbeat_bar_warn  { background: linear-gradient(180deg, var(--status-warn) 0%, #6a3c10 100%); }
-  .heartbeat_bar_error { background: linear-gradient(180deg, #e84848 0%, #8a1010 100%); box-shadow: 0 0 6px rgba(160, 24, 24, 0.45); }
+  .heartbeat_bar_error { background: linear-gradient(180deg, var(--accent-blood) 0%, var(--accent-blood-dim) 100%); box-shadow: 0 0 6px rgba(232, 80, 80, 0.45); }
   .heartbeat_bar_idle  { background: var(--border-main); opacity: 0.6; }
 
   /* hud CSS → Hud 모듈로 이관 (shell 추출 Phase 2.A) */
@@ -203,7 +203,7 @@ stylesheet
       linear-gradient(90deg,
         rgba(138, 106, 40, 0.10) 0%,
         transparent 45%,
-        rgba(160, 24, 24, 0.06) 100%),
+        rgba(232, 80, 80, 0.06) 100%),
       #0f0b09;
     border: 1px solid var(--border-main);
     border-radius: 2px;
@@ -511,7 +511,7 @@ stylesheet
   }
 
   .sigil_warn  { color: var(--status-warn); border-color: var(--status-warn); box-shadow: inset 0 0 0 1px rgba(232,216,184,0.06), 0 0 8px rgba(160, 106, 26, 0.35); }
-  .sigil_error { color: var(--text-bright); border-color: var(--accent-blood); background: radial-gradient(circle at 35% 30%, rgba(232,216,184,0.28), transparent 55%), #3a1410; box-shadow: inset 0 0 0 1px rgba(232,216,184,0.08), 0 0 10px rgba(160, 24, 24, 0.45); }
+  .sigil_error { color: var(--text-bright); border-color: var(--accent-blood); background: radial-gradient(circle at 35% 30%, rgba(232,216,184,0.28), transparent 55%), #3a1410; box-shadow: inset 0 0 0 1px rgba(232,216,184,0.08), 0 0 10px rgba(232, 80, 80, 0.45); }
 
   .message_lead::first-letter {
     font-family: 'Cinzel', 'EB Garamond', serif;
@@ -538,13 +538,13 @@ stylesheet
   }
 
   .row_error {
-    background: linear-gradient(90deg, rgba(160, 24, 24, 0.08) 0%, transparent 60%);
+    background: linear-gradient(90deg, rgba(232, 80, 80, 0.08) 0%, transparent 60%);
     border-left-color: var(--accent-blood);
   }
 
   .row_error:hover {
-    background: linear-gradient(90deg, rgba(160, 24, 24, 0.18) 0%, transparent 65%);
-    box-shadow: inset 1px 0 0 0 rgba(160, 24, 24, 0.55);
+    background: linear-gradient(90deg, rgba(232, 80, 80, 0.18) 0%, transparent 65%);
+    box-shadow: inset 1px 0 0 0 rgba(232, 80, 80, 0.55);
     border-left-color: #c94a3a;
   }
 
@@ -588,7 +588,7 @@ stylesheet
   .level_debug { color: var(--text-dim); }
   .level_info  { color: var(--text-primary); }
   .level_warn  { color: var(--status-warn); }
-  .level_error { color: var(--accent-blood); text-shadow: 0 0 12px rgba(160, 24, 24, 0.32); }
+  .level_error { color: var(--accent-blood); text-shadow: 0 0 12px rgba(232, 80, 80, 0.32); }
 
   .mod_col {
     font-family: 'JetBrains Mono', ui-monospace, Menlo, Consolas, monospace;
@@ -684,7 +684,7 @@ stylesheet
       inset 0 0 0 1px rgba(232, 216, 184, 0.18),
       inset -6px -8px 14px rgba(0, 0, 0, 0.55),
       inset 5px 4px 10px rgba(232, 216, 184, 0.15),
-      0 6px 14px rgba(160, 24, 24, 0.35),
+      0 6px 14px rgba(232, 80, 80, 0.35),
       0 0 22px rgba(138, 106, 40, 0.22);
     transform: rotate(-14deg);
     z-index: 4;
@@ -1088,7 +1088,7 @@ stylesheet
   }
   .evrow_bad .evrow_b_code {
     color: var(--accent-blood);
-    background: rgba(160, 24, 24, 0.08);
+    background: rgba(232, 80, 80, 0.08);
   }
 
   /* ─── page-head (hero) ───

--- a/dashboard_bonsai/src/meta.ml
+++ b/dashboard_bonsai/src/meta.ml
@@ -48,7 +48,7 @@ stylesheet
 
   .v_ok    { color: var(--status-ok, #4a7a2a); font-variant-numeric: tabular-nums; }
   .v_brass { color: var(--accent-brass, #8a6a28); font-variant-numeric: tabular-nums; }
-  .v_blood { color: var(--accent-blood, #a01818); font-variant-numeric: tabular-nums; }
+  .v_blood { color: var(--accent-blood, #e85050); font-variant-numeric: tabular-nums; }
 |}]
 
 type value_color = [ `Default | `Ok | `Brass | `Blood ]

--- a/dashboard_bonsai/src/meta.ml
+++ b/dashboard_bonsai/src/meta.ml
@@ -28,7 +28,7 @@ stylesheet
     );
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     font-size: 11px;
-    color: var(--text-dim, #6a5848);
+    color: var(--text-dim, #9a846e);
   }
 
   .item { display: flex; align-items: baseline; gap: 8px; }
@@ -38,7 +38,7 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.2em;
     text-transform: uppercase;
-    color: var(--text-dim, #6a5848);
+    color: var(--text-dim, #9a846e);
   }
 
   .v {

--- a/dashboard_bonsai/src/meta.ml
+++ b/dashboard_bonsai/src/meta.ml
@@ -46,8 +46,8 @@ stylesheet
     color: var(--text-bright, #e8d9b0);
   }
 
-  .v_ok    { color: var(--status-ok, #4a7a2a); font-variant-numeric: tabular-nums; }
-  .v_brass { color: var(--accent-brass, #8a6a28); font-variant-numeric: tabular-nums; }
+  .v_ok    { color: var(--status-ok, #6a9a4a); font-variant-numeric: tabular-nums; }
+  .v_brass { color: var(--accent-brass, #968228); font-variant-numeric: tabular-nums; }
   .v_blood { color: var(--accent-blood, #e85050); font-variant-numeric: tabular-nums; }
 |}]
 

--- a/dashboard_bonsai/src/overview_view.ml
+++ b/dashboard_bonsai/src/overview_view.ml
@@ -368,7 +368,7 @@ let view_meta_panel (r : Overview_types.response) =
     match m.dominant_belief with
     | Some b ->
       Node.div
-        ~attrs:[ Style.belief ]
+        ~attrs:[ Style.belief; Attr.role "note"; Attr.arialabel ("dominant belief: " ^ b.status) ]
         [ Node.span
             ~attrs:[ Style.belief_tag ]
             [ Node.text b.status ]

--- a/dashboard_bonsai/src/pill.ml
+++ b/dashboard_bonsai/src/pill.ml
@@ -49,10 +49,10 @@ stylesheet
     color: var(--text-dim, #9a846e);
   }
 
-  .c_ok      { color: var(--status-ok, #4a7a2a); border-color: var(--status-ok, #4a7a2a); }
-  .c_warn    { color: var(--status-warn, #c08828); border-color: var(--status-warn, #c08828); }
+  .c_ok      { color: var(--status-ok, #6a9a4a); border-color: var(--status-ok, #6a9a4a); }
+  .c_warn    { color: var(--status-warn, #b87828); border-color: var(--status-warn, #b87828); }
   .c_bad     { color: var(--accent-blood, #e85050); border-color: var(--accent-blood, #e85050); }
-  .c_brass   { color: var(--accent-brass, #8a6a28); border-color: var(--accent-brass, #8a6a28); }
+  .c_brass   { color: var(--accent-brass, #968228); border-color: var(--accent-brass, #968228); }
   .c_paused  { color: var(--text-dim, #9a846e); border-color: var(--border-main, #3a2e20); }
   .c_neutral { color: var(--text-dim, #9a846e); border-color: var(--border-main, #3a2e20); }
 |}]

--- a/dashboard_bonsai/src/pill.ml
+++ b/dashboard_bonsai/src/pill.ml
@@ -35,7 +35,7 @@ stylesheet
     text-align: center;
     border: 1px solid var(--border-main, #3a2e20);
     font-variant-numeric: tabular-nums;
-    color: var(--text-dim, #6a5848);
+    color: var(--text-dim, #9a846e);
   }
 
   .pill_sm {
@@ -46,15 +46,15 @@ stylesheet
     padding: 2px 6px;
     border: 1px solid var(--border-main, #3a2e20);
     text-align: center;
-    color: var(--text-dim, #6a5848);
+    color: var(--text-dim, #9a846e);
   }
 
   .c_ok      { color: var(--status-ok, #4a7a2a); border-color: var(--status-ok, #4a7a2a); }
   .c_warn    { color: var(--status-warn, #c08828); border-color: var(--status-warn, #c08828); }
   .c_bad     { color: var(--accent-blood, #a01818); border-color: var(--accent-blood, #a01818); }
   .c_brass   { color: var(--accent-brass, #8a6a28); border-color: var(--accent-brass, #8a6a28); }
-  .c_paused  { color: var(--text-dim, #6a5848); border-color: var(--border-main, #3a2e20); }
-  .c_neutral { color: var(--text-dim, #6a5848); border-color: var(--border-main, #3a2e20); }
+  .c_paused  { color: var(--text-dim, #9a846e); border-color: var(--border-main, #3a2e20); }
+  .c_neutral { color: var(--text-dim, #9a846e); border-color: var(--border-main, #3a2e20); }
 |}]
 
 type size = [ `Sm | `Md ]

--- a/dashboard_bonsai/src/pill.ml
+++ b/dashboard_bonsai/src/pill.ml
@@ -51,7 +51,7 @@ stylesheet
 
   .c_ok      { color: var(--status-ok, #4a7a2a); border-color: var(--status-ok, #4a7a2a); }
   .c_warn    { color: var(--status-warn, #c08828); border-color: var(--status-warn, #c08828); }
-  .c_bad     { color: var(--accent-blood, #a01818); border-color: var(--accent-blood, #a01818); }
+  .c_bad     { color: var(--accent-blood, #e85050); border-color: var(--accent-blood, #e85050); }
   .c_brass   { color: var(--accent-brass, #8a6a28); border-color: var(--accent-brass, #8a6a28); }
   .c_paused  { color: var(--text-dim, #9a846e); border-color: var(--border-main, #3a2e20); }
   .c_neutral { color: var(--text-dim, #9a846e); border-color: var(--border-main, #3a2e20); }

--- a/dashboard_bonsai/src/placeholder_view.ml
+++ b/dashboard_bonsai/src/placeholder_view.ml
@@ -77,7 +77,7 @@ stylesheet
     background: linear-gradient(180deg, #241a12, #14100a);
     color: var(--text-primary);
     font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
-    font-size: 10px;
+    font-size: 11px;
     letter-spacing: 0.24em;
     text-transform: uppercase;
     text-decoration: none;
@@ -87,6 +87,7 @@ stylesheet
     color: var(--accent-brass);
     border-color: var(--accent-brass);
   }
+  .btn:focus-visible { outline: 2px solid var(--accent-brass); outline-offset: -2px; }
 
   .btn_primary {
     color: var(--accent-brass);
@@ -215,7 +216,7 @@ let blueprint_of_route : Route.t -> blueprint = function
 
 let panel ~title ~text ~code =
   Node.div
-    ~attrs:[ Style.panel ]
+    ~attrs:[ Style.panel; Attr.role "listitem"; Attr.arialabel title ]
     [ Node.h4 ~attrs:[ Style.panel_title ] [ Node.text title ]
     ; Node.p ~attrs:[ Style.panel_text ] [ Node.text text ]
     ; Node.div ~attrs:[ Style.panel_code ] [ Node.text code ]
@@ -242,7 +243,7 @@ let component ~(route : Route.t) (_graph @ local) =
           ]
       ; Sec.view ~title:"operator contract" ~sub:"target · measure · next" ()
       ; Node.div
-          ~attrs:[ Style.grid ]
+          ~attrs:[ Style.grid; Attr.role "list" ]
           [ panel ~title:"measure" ~text:bp.measure ~code:"what must stay visible"
           ; panel ~title:"next" ~text:bp.next_step ~code:bp.endpoint
           ; panel

--- a/dashboard_bonsai/src/roster.ml
+++ b/dashboard_bonsai/src/roster.ml
@@ -115,7 +115,7 @@ stylesheet
 
   .dot_live     { background: var(--status-ok); box-shadow: 0 0 6px var(--status-ok); animation: roster_pulse 1.8s ease-in-out infinite; }
   .dot_thinking { background: var(--accent-brass); box-shadow: 0 0 6px var(--accent-brass); animation: roster_pulse 1.2s ease-in-out infinite; }
-  .dot_idle     { background: #4a3a32; }
+  .dot_idle     { background: var(--text-dim); }
   .dot_failed   { background: var(--accent-blood); box-shadow: 0 0 8px var(--accent-blood); }
 
   .when_ {

--- a/dashboard_bonsai/src/sec.ml
+++ b/dashboard_bonsai/src/sec.ml
@@ -34,7 +34,7 @@ stylesheet
   .sec_sub {
     font-family: var(--font-body, 'EB Garamond', serif);
     font-style: italic;
-    color: var(--text-dim, #6a5848);
+    color: var(--text-dim, #9a846e);
     font-size: 13px;
     flex-shrink: 0;
   }
@@ -51,7 +51,7 @@ stylesheet
   .sec_right {
     font-family: var(--font-mono, 'JetBrains Mono', monospace);
     font-size: 11px;
-    color: var(--text-dim, #6a5848);
+    color: var(--text-dim, #9a846e);
     font-variant-numeric: tabular-nums;
     flex-shrink: 0;
   }

--- a/dashboard_bonsai/src/sec.ml
+++ b/dashboard_bonsai/src/sec.ml
@@ -26,7 +26,7 @@ stylesheet
     font-family: var(--font-display, 'Cinzel', serif);
     font-size: 13px;
     letter-spacing: 0.26em;
-    color: var(--accent-brass, #8a6a28);
+    color: var(--accent-brass, #968228);
     text-transform: uppercase;
     margin: 0;
     flex-shrink: 0;

--- a/dashboard_bonsai/src/shell_view.ml
+++ b/dashboard_bonsai/src/shell_view.ml
@@ -22,7 +22,7 @@ stylesheet
     color: var(--text-primary);
     background:
       radial-gradient(ellipse 60% 40% at 12% 8%, rgba(212,169,64,0.06), transparent 55%),
-      radial-gradient(ellipse 40% 50% at 92% 95%, rgba(160,24,24,0.08), transparent 60%),
+      radial-gradient(ellipse 40% 50% at 92% 95%, rgba(232,80,80,0.08), transparent 60%),
       linear-gradient(170deg, #0e0a08 0%, #140c08 60%, #080504 100%);
     font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
   }

--- a/dashboard_bonsai/src/shell_view.ml
+++ b/dashboard_bonsai/src/shell_view.ml
@@ -669,7 +669,7 @@ let nav_link ~(active : Route.t) (route : Route.t) =
   in
   Node.a
     ~attrs
-    ([ Node.span ~attrs:[ Style.nav_glyph ] []
+    ([ Node.span ~attrs:[ Style.nav_glyph; Attr.create "aria-hidden" "true" ] []
      ; Node.text (label route)
      ]
      @ tail)

--- a/dashboard_bonsai/src/shell_view.ml
+++ b/dashboard_bonsai/src/shell_view.ml
@@ -707,7 +707,7 @@ let pill ?(tone : tone = `Neutral) text =
   in
   Node.span
     ~attrs
-    [ Node.span ~attrs:[ Style.dot ] []
+    [ Node.span ~attrs:[ Style.dot; Attr.create "aria-hidden" "true" ] []
     ; Node.text text
     ]
 ;;

--- a/dashboard_bonsai/src/shell_view.ml
+++ b/dashboard_bonsai/src/shell_view.ml
@@ -863,7 +863,7 @@ let focus_card ~(shell : Overview_types.response) ~(active : Route.t) =
                         ; Node.text focus_detail
                         ]
                     ]
-                ; Node.div ~attrs:[ Style.vial ] [ Node.span ~attrs:[ vial_style ] [] ]
+                ; Node.div ~attrs:[ Style.vial ] [ Node.span ~attrs:[ vial_style; Attr.create "aria-hidden" "true" ] [] ]
                 ]
             ; Node.div
                 ~attrs:[ Style.stats ]
@@ -944,7 +944,7 @@ let watch_feed () =
     Node.div
       ~attrs:[ Style.event ]
       [ Node.span ~attrs:[ Style.event_time ] [ Node.text time ]
-      ; Node.span ~attrs:mark_attrs []
+      ; Node.span ~attrs:(Attr.create "aria-hidden" "true" :: mark_attrs) []
       ; Node.span ~attrs:[ Style.event_body ] body
       ]
   in

--- a/dashboard_bonsai/src/swim.ml
+++ b/dashboard_bonsai/src/swim.ml
@@ -204,7 +204,7 @@ let view_lane ~name ~stat ~(status : lane_status) ~frames =
     ~attrs:[ Style.lane; Attr.role "listitem"; Attr.arialabel (name ^ ": " ^ stat) ]
     [ Node.div
         ~attrs:[ Style.lane_meta ]
-        [ Node.span ~attrs:[ Style.dot; dot_cls ] []
+        [ Node.span ~attrs:[ Style.dot; dot_cls; Attr.create "aria-hidden" "true" ] []
         ; Node.span ~attrs:nm_attrs [ Node.text name ]
         ; Node.span ~attrs:[ Style.stat ] [ Node.text stat ]
         ]

--- a/dashboard_bonsai/static/colors_and_type.css
+++ b/dashboard_bonsai/static/colors_and_type.css
@@ -32,8 +32,8 @@
   --text-dim:     #9a846e;       /* mold dust — WCAG AA compliant */
 
   /* Accents — blood is primary now; brass demoted to warning */
-  --accent-blood:    #a01818;    /* fresh arterial */
-  --accent-blood-dim:#5a0f0f;    /* dried clot */
+  --accent-blood:    #e85050;    /* WCAG AA compliant on all surfaces */
+  --accent-blood-dim:#8a2828;    /* dried clot — dim companion */
   --accent-viscera:  #c94a3a;    /* raw flesh / inflamed */
   --accent-bile:     #6a7a3a;    /* sickly yellow-green */
   --accent-mold:     #3a5a48;    /* cold mold */
@@ -42,8 +42,8 @@
   --accent-bone:     #d8c8a0;
   --accent-ink:      #3a2a5a;    /* arcane violet, rarer */
   --accent-ember:    #c4461a;    /* dying ember */
-  --accent-glow:     rgba(160, 24, 24, 0.28);
-  --accent-blood-glow: rgba(201, 74, 58, 0.32);
+  --accent-glow:     rgba(232, 80, 80, 0.28);
+  --accent-blood-glow: rgba(232, 80, 80, 0.32);
 
   /* Status — blood, bile, mold */
   --status-ok:    #5a7a3a;       /* bile / queasy green */

--- a/dashboard_bonsai/static/colors_and_type.css
+++ b/dashboard_bonsai/static/colors_and_type.css
@@ -29,7 +29,7 @@
   /* Text — bone and bandage */
   --text-bright:  #e8d8b8;       /* clean bone */
   --text-primary: #b8a488;       /* dirty bandage */
-  --text-dim:     #6a5848;       /* mold dust */
+  --text-dim:     #9a846e;       /* mold dust — WCAG AA compliant */
 
   /* Accents — blood is primary now; brass demoted to warning */
   --accent-blood:    #a01818;    /* fresh arterial */

--- a/dashboard_bonsai/static/colors_and_type.css
+++ b/dashboard_bonsai/static/colors_and_type.css
@@ -37,8 +37,8 @@
   --accent-viscera:  #c94a3a;    /* raw flesh / inflamed */
   --accent-bile:     #6a7a3a;    /* sickly yellow-green */
   --accent-mold:     #3a5a48;    /* cold mold */
-  --accent-brass:    #8a6a28;    /* tarnished gold, rare */
-  --accent-brass-dim:#5a4618;
+  --accent-brass:    #968228;    /* WCAG AA compliant on all surfaces */
+  --accent-brass-dim:#6a5620;
   --accent-bone:     #d8c8a0;
   --accent-ink:      #3a2a5a;    /* arcane violet, rarer */
   --accent-ember:    #c4461a;    /* dying ember */
@@ -46,9 +46,9 @@
   --accent-blood-glow: rgba(232, 80, 80, 0.32);
 
   /* Status — blood, bile, mold */
-  --status-ok:    #5a7a3a;       /* bile / queasy green */
-  --status-warn:  #a06a1a;       /* burnt ember */
-  --status-bad:   #a01818;       /* blood */
+  --status-ok:    #6a9a4a;       /* WCAG AA compliant on all surfaces */
+  --status-warn:  #b87828;       /* WCAG AA compliant on all surfaces */
+  --status-bad:   #e85050;       /* WCAG AA — synced with --accent-blood */
   --status-idle:  #4a3a32;       /* dried mold */
 
   /* Trace frame palette — swimlane / flame / tool-category bars */


### PR DESCRIPTION
## Summary
- Restores the WCAG AA accessibility changes lost during the #9862 merge conflict resolution.
- Re-applies dashboard contrast, focus-visible, ARIA semantics, lang attributes, and CSS variable updates.

## Validation
- CI run 24887070772 passed: Dashboard, Lint, Health, Build and Test, TLA+ Model Checking, Meta Guards, and CI Gate.
