### PR TITLE
[codex] Make cascade routing capability-driven

### DIFF
--- a/lib/cascade/cascade_health_filter.ml
+++ b/lib/cascade/cascade_health_filter.ml
@@ -14,6 +14,20 @@
     variants lives in exactly one place. When OAS adds a new error
     variant, only [lib/oas_compat] fails to compile, not this module
     and every other consumer. *)
+type cascade_failure_class =
+  Oas_compat.Http_client.cascade_failure_class =
+  | Local_resource_exhaustion
+  | Context_overflow
+  | Provider_parse_error
+  | Transient_http of int
+  | Terminal_http of int
+  | Accept_rejected_capability_mismatch
+  | Accept_rejected_terminal
+  | Cli_transport_required
+  | Network_error
+
+let classify_failure err = Oas_compat.Http_client.classify err
+
 let should_cascade_to_next err = Oas_compat.Http_client.should_cascade err
 
 (* ── Local provider detection ──────────────────────────── *)

--- a/lib/keeper/keeper_cascade_routing.ml
+++ b/lib/keeper/keeper_cascade_routing.ml
@@ -36,36 +36,18 @@ let route_effective_cascade_for_tool_requirement_with_model_labels
     ~(model_labels_of_cascade : string -> string list)
     ~(effective_cascade : string)
     ~(tool_requirement : string) : routing_decision =
-  let trimmed_effective = String.trim effective_cascade in
-  let normalized_effective =
-    Keeper_cascade_profile.normalize_declared_name trimmed_effective
-  in
+  ignore model_labels_of_cascade;
   if not (String.equal tool_requirement "required") then
     {
       effective_cascade;
       reason = "tool-optional or text-only turn keeps routed cascade";
     }
-  else (
-    let effective_is_pure_local =
-      trimmed_effective <> ""
-      && model_labels_of_cascade trimmed_effective
-         |> Cascade_runtime.labels_are_pure_local
-    in
-    if
-      String.equal trimmed_effective Keeper_config.tool_use_strict_cascade_name
-      || String.equal normalized_effective Keeper_config.local_only_cascade_name
-      || String.equal normalized_effective Keeper_config.local_recovery_cascade_name
-      || effective_is_pure_local
-    then
-      {
-        effective_cascade;
-        reason = "tool-required turn preserves local or phase-routed cascade";
-      }
-    else
-      {
-        effective_cascade = Keeper_config.tool_use_strict_cascade_name;
-        reason = "tool-required turn uses strict tool-capable cascade";
-      })
+  else
+    {
+      effective_cascade;
+      reason =
+        "tool-required turn keeps routed cascade; provider capability filter enforces tool support";
+    }
 
 let route_effective_cascade_for_tool_requirement =
   route_effective_cascade_for_tool_requirement_with_model_labels

--- a/lib/keeper/keeper_cascade_routing.mli
+++ b/lib/keeper/keeper_cascade_routing.mli
@@ -33,10 +33,10 @@ val select_cascade :
   phase:Keeper_state_machine.phase ->
   routing_decision
 
-(** Override an already-routed cascade when the turn must guarantee a
-    tool-capable provider lane. Phase-routed local/recovery cascades are
-    preserved. Pure-local configured cascades are also preserved, regardless
-    of their profile name. *)
+(** Preserve an already-routed cascade while carrying the tool requirement
+    forward to provider capability filtering. Tool-required turns must not
+    rewrite profile names such as ["tool_use_strict"]; the cascade resolver
+    and provider capability gate own the concrete candidate set. *)
 val route_effective_cascade_for_tool_requirement :
   effective_cascade:string ->
   tool_requirement:string ->

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -264,7 +264,6 @@ let degraded_rotation_candidates
   let candidates =
     if String.equal tool_requirement "required" then
       [
-        Keeper_config.tool_use_strict_cascade_name;
         normalized_base;
         Keeper_config.default_cascade_name;
       ]
@@ -273,7 +272,6 @@ let degraded_rotation_candidates
         normalized_base;
         Keeper_config.default_cascade_name;
         Keeper_config.local_recovery_cascade_name;
-        Keeper_config.tool_use_strict_cascade_name;
       ]
   in
   candidates

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1017,31 +1017,6 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             then "required"
             else "optional"
           in
-          let initial_execution_result =
-            if not (String.equal initial_tool_requirement "required") then
-              Ok initial_execution
-            else
-              let routed =
-                Keeper_cascade_routing.route_effective_cascade_for_tool_requirement
-                  ~effective_cascade:initial_execution.cascade_name
-                  ~tool_requirement:"required"
-              in
-              if String.equal routed.effective_cascade initial_execution.cascade_name
-              then
-                Ok initial_execution
-              else
-                match build_cascade_execution ~cascade_name:routed.effective_cascade with
-                | Ok routed_execution ->
-                    Log.Keeper.info
-                      "%s: tool-required turn rerouted %s -> %s (%s)"
-                      meta.name initial_execution.cascade_name
-                      routed_execution.cascade_name routed.reason;
-                    Ok routed_execution
-                | Error err -> Error err
-          in
-          match initial_execution_result with
-          | Error err -> Error err
-          | Ok initial_execution ->
           let do_run ~(execution : cascade_execution) ~run_meta ~run_generation ~is_retry
               ~oas_timeout_s =
             last_execution := execution;

--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -1,6 +1,17 @@
 (* See oas_compat.mli for module rationale. *)
 
 module Http_client = struct
+  type cascade_failure_class =
+    | Local_resource_exhaustion
+    | Context_overflow
+    | Provider_parse_error
+    | Transient_http of int
+    | Terminal_http of int
+    | Accept_rejected_capability_mismatch
+    | Accept_rejected_terminal
+    | Cli_transport_required
+    | Network_error
+
   (* Case-insensitive substring check, mirroring [cascade_health_filter]. *)
   let contains_ci ?(max_scan = 512) ~haystack ~needle () =
     let h =
@@ -47,21 +58,46 @@ module Http_client = struct
       (fun needle -> contains_ci ~haystack:reason ~needle ())
       accept_rejected_cascadable_markers
 
-  let should_cascade (err : Llm_provider.Http_client.http_error) : bool =
-    if Llm_provider.Http_client.is_local_resource_exhaustion err then false
+  let classify (err : Llm_provider.Http_client.http_error) :
+      cascade_failure_class =
+    if Llm_provider.Http_client.is_local_resource_exhaustion err then
+      Local_resource_exhaustion
     else
       match err with
       | Llm_provider.Http_client.HttpError { code; body }
         when List.mem code [ 400; 422 ]
-             && (Llm_provider.Retry.is_context_overflow_message body
-                || is_provider_parse_error body) ->
-          true
+             && Llm_provider.Retry.is_context_overflow_message body ->
+          Context_overflow
+      | Llm_provider.Http_client.HttpError { code; body }
+        when List.mem code [ 400; 422 ] && is_provider_parse_error body ->
+          Provider_parse_error
       | Llm_provider.Http_client.HttpError { code; _ } ->
-          List.mem code Llm_provider.Constants.Http.cascadable_codes
+          if List.mem code Llm_provider.Constants.Http.cascadable_codes then
+            Transient_http code
+          else
+            Terminal_http code
       | Llm_provider.Http_client.AcceptRejected { reason } ->
-          accept_rejected_is_cascadable reason
-      | Llm_provider.Http_client.CliTransportRequired _ -> true
-      | Llm_provider.Http_client.NetworkError _ -> true
+          if accept_rejected_is_cascadable reason then
+            Accept_rejected_capability_mismatch
+          else
+            Accept_rejected_terminal
+      | Llm_provider.Http_client.CliTransportRequired _ ->
+          Cli_transport_required
+      | Llm_provider.Http_client.NetworkError _ -> Network_error
+
+  let should_cascade (err : Llm_provider.Http_client.http_error) : bool =
+    match classify err with
+    | Local_resource_exhaustion
+    | Terminal_http _
+    | Accept_rejected_terminal ->
+        false
+    | Context_overflow
+    | Provider_parse_error
+    | Transient_http _
+    | Accept_rejected_capability_mismatch
+    | Cli_transport_required
+    | Network_error ->
+        true
 end
 
 module Metrics = struct

--- a/lib/oas_compat/oas_compat.mli
+++ b/lib/oas_compat/oas_compat.mli
@@ -21,6 +21,24 @@
     regression risk that should not ride this foundational PR. *)
 
 module Http_client : sig
+  type cascade_failure_class =
+    | Local_resource_exhaustion
+    | Context_overflow
+    | Provider_parse_error
+    | Transient_http of int
+    | Terminal_http of int
+    | Accept_rejected_capability_mismatch
+    | Accept_rejected_terminal
+    | Cli_transport_required
+    | Network_error
+
+  val classify : Llm_provider.Http_client.http_error -> cascade_failure_class
+  (** Classify an OAS HTTP/client failure into MASC's typed cascade boundary.
+
+      Compatibility string checks remain quarantined in this adapter. Downstream
+      cascade/FSM code should branch on this class rather than reparsing
+      provider error text. *)
+
   val should_cascade : Llm_provider.Http_client.http_error -> bool
   (** Decide whether an error should cascade to the next provider.
 

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -255,14 +255,8 @@ let public_mcp_tools_of_oas_tools (tools : Oas.Tool.t list) =
 let tool_names_are_public_mcp (tool_names : string list) =
   tool_names <> [] && List.for_all Tool_catalog.is_public_mcp tool_names
 
-let public_mcp_tool_requires_bound_actor = function
-  | "masc_claim_next"
-  | "masc_transition"
-  | "masc_join"
-  | "masc_leave"
-  | "masc_plan_set_task" ->
-      true
-  | _ -> false
+let public_mcp_tool_requires_bound_actor tool_name =
+  Tool_catalog.requires_actor_binding tool_name
 
 let trim_nonempty_string raw =
   let trimmed = String.trim raw in

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -68,6 +68,7 @@ type metadata = {
   idempotent : bool option;
   required_permission : Types.permission option;
   effect_domain : effect_domain option;
+  requires_actor_binding : bool option;
 }
 
 (* ================================================================ *)
@@ -88,6 +89,7 @@ let default_metadata =
     idempotent = None;
     required_permission = None;
     effect_domain = None;
+    requires_actor_binding = None;
   }
 
 (* Runtime-readable like MASC_FULL_SURFACE so tests and local admin flows can
@@ -114,6 +116,7 @@ let deprecated ?canonical_name ?replacement ?(allow_direct_call_when_hidden = fa
     idempotent = None;
     required_permission = None;
     effect_domain = None;
+    requires_actor_binding = None;
   }
 
 let hidden_active ?canonical_name ?replacement ?(allow_direct_call_when_hidden = true)
@@ -131,9 +134,11 @@ let hidden_active ?canonical_name ?replacement ?(allow_direct_call_when_hidden =
     idempotent = None;
     required_permission = None;
     effect_domain = None;
+    requires_actor_binding = None;
   }
 
-let with_semantic_flags ?readonly ?destructive ?idempotent ?effect_domain meta =
+let with_semantic_flags ?readonly ?destructive ?idempotent ?effect_domain
+    ?requires_actor_binding meta =
   {
     meta with
     readonly =
@@ -146,6 +151,10 @@ let with_semantic_flags ?readonly ?destructive ?idempotent ?effect_domain meta =
       (match effect_domain with
       | Some value -> Some value
       | None -> meta.effect_domain);
+    requires_actor_binding =
+      (match requires_actor_binding with
+      | Some value -> Some value
+      | None -> meta.requires_actor_binding);
   }
 
 let readonly_tool =
@@ -157,6 +166,9 @@ let destructive_tool =
 
 let masc_coordination_tool =
   with_semantic_flags ~effect_domain:Masc_coordination default_metadata
+
+let actor_bound_masc_coordination_tool =
+  with_semantic_flags ~requires_actor_binding:true masc_coordination_tool
 
 (* ================================================================ *)
 (* Explicit metadata registry                                       *)
@@ -187,9 +199,12 @@ let explicit_metadata : (string * metadata) list =
     ("masc_plan_get", readonly_tool);
     ("masc_worktree_list", readonly_tool);
     ( "masc_join",
-      { masc_coordination_tool with required_permission = Some Types.CanJoin } );
+      { actor_bound_masc_coordination_tool with required_permission = Some Types.CanJoin } );
     ( "masc_leave",
-      { masc_coordination_tool with required_permission = Some Types.CanLeave } );
+      { actor_bound_masc_coordination_tool with required_permission = Some Types.CanLeave } );
+    ("masc_claim_next", actor_bound_masc_coordination_tool);
+    ("masc_transition", actor_bound_masc_coordination_tool);
+    ("masc_plan_set_task", actor_bound_masc_coordination_tool);
     ( "masc_broadcast",
       { masc_coordination_tool with required_permission = Some Types.CanBroadcast } );
     ( "masc_messages",
@@ -768,6 +783,11 @@ let effect_domain name =
   let meta = metadata name in
   meta.effect_domain
 
+let requires_actor_binding name =
+  match (metadata name).requires_actor_binding with
+  | Some value -> value
+  | None -> false
+
 let is_main_worktree_boundary_exempt name =
   match effect_domain name with
   | Some Read_only | Some Masc_coordination | Some Playground_write -> Some true
@@ -852,11 +872,16 @@ let metadata_to_fields name =
         ("toolGroup", `String (tool_group_to_string group)) :: with_effect_domain
     | None -> with_effect_domain
   in
+  let with_actor_binding =
+    match meta.requires_actor_binding with
+    | Some value -> ("requiresActorBinding", `Bool value) :: with_tool_group
+    | None -> with_tool_group
+  in
   match meta.required_permission with
   | Some permission ->
       ("requiredPermission", `String (Types.show_permission permission))
-      :: with_tool_group
-  | None -> with_tool_group
+      :: with_actor_binding
+  | None -> with_actor_binding
 
 let public_contract_fields name =
   let meta = metadata name in
@@ -873,9 +898,14 @@ let public_contract_fields name =
         :: base
     | None -> base
   in
+  let with_actor_binding =
+    match meta.requires_actor_binding with
+    | Some value -> ("requiresActorBinding", `Bool value) :: with_effect_domain
+    | None -> with_effect_domain
+  in
   match meta.canonical_name with
-  | Some canonical_name -> ("canonicalName", `String canonical_name) :: with_effect_domain
-  | None -> with_effect_domain
+  | Some canonical_name -> ("canonicalName", `String canonical_name) :: with_actor_binding
+  | None -> with_actor_binding
 
 let allow_direct_call name =
   let meta = metadata name in

--- a/lib/tool_catalog.mli
+++ b/lib/tool_catalog.mli
@@ -49,6 +49,7 @@ type metadata = {
   idempotent : bool option;
   required_permission : Types.permission option;
   effect_domain : effect_domain option;
+  requires_actor_binding : bool option;
 }
 
 (** {1 Configuration} *)
@@ -84,6 +85,7 @@ val full_surface_override : unit -> bool
 val metadata : string -> metadata
 val implementation_status : string -> implementation_status
 val effect_domain : string -> effect_domain option
+val requires_actor_binding : string -> bool
 val is_main_worktree_boundary_exempt : string -> bool option
 val tool_group : string -> tool_group option
 val canonical_tool_name : string -> string

--- a/lib/tool_spec.ml
+++ b/lib/tool_spec.ml
@@ -30,6 +30,7 @@ type t = {
   title : string option;
   required_permission : Types.permission option;
   effect_domain : Tool_catalog.effect_domain option;
+  requires_actor_binding : bool option;
 }
 
 (* ================================================================ *)
@@ -56,12 +57,14 @@ let create
     ?title
     ?required_permission
     ?effect_domain
+    ?requires_actor_binding
     () =
   { name; description; module_tag; input_schema; handler_binding;
     is_read_only; requires_join; is_destructive; is_idempotent;
     visibility; lifecycle; implementation_status;
     canonical_name; replacement; reason;
-    allow_direct_call_when_hidden; title; required_permission; effect_domain }
+    allow_direct_call_when_hidden; title; required_permission; effect_domain;
+    requires_actor_binding }
 
 (* ================================================================ *)
 (* Conversion                                                       *)
@@ -126,7 +129,8 @@ let register (spec : t) =
       destructive = Some spec.is_destructive;
       idempotent = Some spec.is_idempotent;
       required_permission = spec.required_permission;
-      effect_domain = spec.effect_domain };
+      effect_domain = spec.effect_domain;
+      requires_actor_binding = spec.requires_actor_binding };
   (* 5. Handler binding — auto-register Direct/Shared into Tool_dispatch *)
   (match spec.handler_binding with
    | Direct h | Shared h ->

--- a/lib/tool_spec.mli
+++ b/lib/tool_spec.mli
@@ -49,6 +49,7 @@ type t = {
   title : string option;
   required_permission : Types.permission option;
   effect_domain : Tool_catalog.effect_domain option;
+  requires_actor_binding : bool option;
 }
 
 (** {1 Builder} *)
@@ -73,6 +74,7 @@ val create :
   ?title:string ->
   ?required_permission:Types.permission ->
   ?effect_domain:Tool_catalog.effect_domain ->
+  ?requires_actor_binding:bool ->
   unit -> t
 (** Build a tool spec. The first five arguments are required (compile error
     if omitted). All optional arguments default to fail-closed values:

--- a/test/test_cascade_runtime.ml
+++ b/test/test_cascade_runtime.ml
@@ -143,6 +143,34 @@ let test_required_tool_support_filter_drops_runtime_mcp_providers_without_header
   check bool "keeps claude_code with runtime MCP header support" true
     (List.mem "claude_code" (provider_kinds providers))
 
+let test_oas_http_error_classification_is_typed () =
+  let module H = Masc_mcp.Cascade_health_filter in
+  let context_overflow =
+    Llm_provider.Http_client.HttpError
+      { code = 400; body = "maximum context length exceeded" }
+  in
+  let provider_parse =
+    Llm_provider.Http_client.HttpError
+      { code = 400; body = "can't find closing '}'" }
+  in
+  let capability_mismatch =
+    Llm_provider.Http_client.AcceptRejected
+      { reason = "openai_compat:model does not support inline tools" }
+  in
+  check bool "context overflow class cascades" true
+    (match H.classify_failure context_overflow with
+    | H.Context_overflow -> H.should_cascade_to_next context_overflow
+    | _ -> false);
+  check bool "provider parse class cascades" true
+    (match H.classify_failure provider_parse with
+    | H.Provider_parse_error -> H.should_cascade_to_next provider_parse
+    | _ -> false);
+  check bool "capability mismatch class cascades" true
+    (match H.classify_failure capability_mismatch with
+    | H.Accept_rejected_capability_mismatch ->
+        H.should_cascade_to_next capability_mismatch
+    | _ -> false)
+
 let () =
   run "Cascade_runtime"
     [
@@ -164,5 +192,7 @@ let () =
           test_case "runtime MCP header requirement drops unsupported providers"
             `Quick
             test_required_tool_support_filter_drops_runtime_mcp_providers_without_header_support;
+          test_case "OAS HTTP errors classify before cascade boolean" `Quick
+            test_oas_http_error_classification_is_typed;
         ] );
     ]

--- a/test/test_keeper_cascade_routing.ml
+++ b/test/test_keeper_cascade_routing.ml
@@ -87,14 +87,14 @@ let test_running_with_custom_base () =
   check string "Running preserves custom base"
     "coding_first" r.effective_cascade
 
-let test_tool_required_turn_uses_strict_lane () =
+let test_tool_required_turn_preserves_routed_cascade () =
   let r =
     Routing.route_effective_cascade_for_tool_requirement_with_model_labels
       ~model_labels_of_cascade:(fun _ -> [ "claude_code:auto" ])
       ~effective_cascade:"big_three" ~tool_requirement:"required"
   in
-  check string "required tool turns route to strict lane"
-    Masc_mcp.Keeper_config.tool_use_strict_cascade_name r.effective_cascade
+  check string "required tool turns preserve routed cascade"
+    "big_three" r.effective_cascade
 
 let test_tool_required_turn_preserves_pure_local_cascade () =
   let r =
@@ -146,8 +146,8 @@ let () =
     "edge_cases", [
       test_case "Failing overrides local_only base" `Quick test_failing_with_local_only_base;
       test_case "Running preserves custom base"     `Quick test_running_with_custom_base;
-      test_case "Required tool turn uses strict lane" `Quick
-        test_tool_required_turn_uses_strict_lane;
+      test_case "Required tool turn preserves routed cascade" `Quick
+        test_tool_required_turn_preserves_routed_cascade;
       test_case "Required tool turn preserves pure-local cascade" `Quick
         test_tool_required_turn_preserves_pure_local_cascade;
       test_case "Required tool turn preserves local recovery" `Quick

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2876,7 +2876,6 @@ let test_next_fail_open_cascade_for_turn_suppresses_exhausted_rotation_group () 
           "tool_rerank";
           KC.default_cascade_name;
           KC.local_recovery_cascade_name;
-          KC.tool_use_strict_cascade_name;
         ]
       (wrapped_claude_limit_error ())
   in

--- a/test/test_tool_spec.ml
+++ b/test/test_tool_spec.ml
@@ -37,6 +37,8 @@ let () =
             check bool "reason default" true (Option.is_none spec.reason);
             check bool "effect_domain default" true
               (Option.is_none spec.effect_domain);
+            check bool "requires_actor_binding default" true
+              (Option.is_none spec.requires_actor_binding);
             check bool "title default" true (Option.is_none spec.title));
           test_case "create with optional args" `Quick (fun () ->
             let spec =
@@ -51,6 +53,7 @@ let () =
                 ~visibility:Tool_catalog.Hidden
                 ~required_permission:Types.CanAdmin
                 ~effect_domain:Tool_catalog.Masc_coordination
+                ~requires_actor_binding:true
                 ~reason:"hidden for test"
                 ~title:"Test Tool"
                 ()
@@ -61,6 +64,8 @@ let () =
               (spec.required_permission = Some Types.CanAdmin);
             check bool "effect_domain" true
               (spec.effect_domain = Some Tool_catalog.Masc_coordination);
+            check bool "requires_actor_binding" true
+              (spec.requires_actor_binding = Some true);
             check bool "reason present" true (Option.is_some spec.reason);
             check bool "title present" true (Option.is_some spec.title));
         ] );
@@ -147,6 +152,7 @@ let () =
                 ~is_destructive:true
                 ~required_permission:Types.CanAdmin
                 ~effect_domain:Tool_catalog.Main_worktree_write
+                ~requires_actor_binding:true
                 ~visibility:Tool_catalog.Hidden
                 ~reason:"test hidden"
                 ()
@@ -158,6 +164,8 @@ let () =
               (meta.required_permission = Some Types.CanAdmin);
             check bool "effect_domain" true
               (meta.effect_domain = Some Tool_catalog.Main_worktree_write);
+            check bool "requires_actor_binding" true
+              (meta.requires_actor_binding = Some true);
             check bool "hidden" true (meta.visibility = Tool_catalog.Hidden);
             check bool "reason" true (meta.reason = Some "test hidden"));
           test_case "empty name rejected" `Quick (fun () ->


### PR DESCRIPTION
## Summary
- Move public MCP actor-binding requirements from a hardcoded transport allowlist into Tool_catalog/Tool_spec metadata.
- Stop rewriting required-tool keeper turns to the `tool_use_strict` cascade; preserve the routed cascade and let provider capability filtering enforce tool support.
- Add typed OAS HTTP/client cascade failure classification and expose it through Cascade_health_filter.

## Why
The previous path mixed deterministic orchestration policy with model/provider/cascade fallback behavior. Required-tool turns could silently override the selected cascade to `tool_use_strict`, and public MCP actor-binding lived as a string match in the transport layer. This makes model/provider/cascade behavior look more deterministic and hardcoded than it should be.

## Validation
- `git diff --check origin/main..HEAD`
- `scripts/dune-local.sh build test/test_cascade_runtime.exe test/test_keeper_cascade_routing.exe test/test_tool_spec.exe test/test_keeper_unified.exe test/test_oas_worker.exe`
- `./_build/default/test/test_cascade_runtime.exe` - 8 tests
- `./_build/default/test/test_keeper_cascade_routing.exe` - 18 tests
- `./_build/default/test/test_tool_spec.exe` - 16 tests
- `./_build/default/test/test_oas_worker.exe test resume_config 18-26,34-35` - 11 tests
- `env MASC_BASE_PATH=/tmp/masc-test-keeper-unified-cascade-boundary ./_build/default/test/test_keeper_unified.exe test phase_gate 8-21` - 14 tests

Note: `test_keeper_unified` now needs an explicit non-HOME `MASC_BASE_PATH` when run directly because main added the #9903 production-base-path test guard.