### PR TITLE
fix(cascade): per-provider CLI rejection must trigger fallback (#9932)

### DIFF
--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -25,21 +25,30 @@ module Http_client = struct
   let is_provider_parse_error body =
     contains_ci ~haystack:body ~needle:"can't find closing" ()
 
-  (* AcceptRejected is raised by OAS for multiple distinct conditions:
-     (a) permanent provider failures (kimi_cli exit 1 is explicitly labeled
-         "permanent auth/config/model error") — must NOT cascade.
-     (b) provider capability mismatches wrapped by MASC's worker layer at
+  (* AcceptRejected is raised by OAS for multiple distinct conditions, all
+     of which are per-provider rather than cascade-wide. A different provider
+     in the cascade may handle the request even when the current one rejects:
+     (a) Per-provider permanent failures from subprocess CLI transports.
+         - kimi_cli exit 1: [transport_kimi_cli.ml] labels this
+           "permanent auth/config/model error". The auth/config is specific
+           to Moonshot; claude/gpt/ollama providers are unaffected.
+         - gemini_cli startup crash: [transport_gemini_cli.ml] explicitly
+           marks the AcceptRejected with "rejecting without retry so the
+           cascade can move on".
+     (b) Provider capability mismatches wrapped by MASC's worker layer at
          [oas_worker_named.ml:672-678] (InvalidConfig runtime_mcp_auth /
-         tool_support). The worker comment at line 661-665 documents explicit
-         cascade intent. The detail string is built in
-         [oas_worker_exec_transport.ml:444-452] and consistently starts with
-         "<provider> does not support ...".
-     This filter whitelists only markers from class (b). Class (a) has no
-     matching marker and falls through to false. CompletionContractViolation
-     and UnrecognizedStopReason use free-form [reason] and are not whitelisted
-     here — their cascade intent is tracked separately. See masc-mcp #9850. *)
+         tool_support). The detail string is built in
+         [oas_worker_exec_transport.ml] and starts with "<provider> does not
+         support ...". Another provider with matching capability can succeed.
+     The markers below cover (a) and (b). CompletionContractViolation and
+     UnrecognizedStopReason use free-form [reason] and are not whitelisted
+     here — their cascade intent is tracked at their own call sites in
+     [oas_worker_named.ml:673-678]. See masc-mcp #9932 (kimi fallback),
+     #9850 (codex_cli runtime_mcp_auth). *)
   let accept_rejected_cascadable_markers = [
     "does not support";
+    "rejected the request";  (* kimi_cli exit 1 — #9932 *)
+    "startup crash";          (* gemini_cli top-level await / yoga_wasm *)
   ]
 
   let accept_rejected_is_cascadable reason =

--- a/lib/oas_compat/oas_compat.mli
+++ b/lib/oas_compat/oas_compat.mli
@@ -32,14 +32,18 @@ module Http_client : sig
       signals context overflow / provider parse error.
       [CliTransportRequired] cascades — the CLI provider cannot serve
       this request over HTTP, so the next provider must.
-      [AcceptRejected] cascades only when the [reason] string carries a
-      provider-capability-mismatch marker (e.g. "does not support"). This
-      covers MASC's worker-layer wrapping of OAS [InvalidConfig] errors
-      for [runtime_mcp_auth] and [tool_support], whose cascade intent is
-      documented at [oas_worker_named.ml:661-678]. Permanent provider
-      failures such as [kimi_cli] exit 1 ("permanent auth/config/model
-      error") do not match any marker and remain non-cascading. See
-      masc-mcp #9850 for the motivating codex_cli case. *)
+      [AcceptRejected] cascades when the [reason] string carries a
+      per-provider failure marker:
+      - "does not support" — MASC's worker-layer wrapping of OAS
+        [InvalidConfig] errors for [runtime_mcp_auth] and [tool_support]
+        (documented at [oas_worker_named.ml:661-678]).
+      - "rejected the request" — kimi_cli exit 1. The auth/config error
+        is Moonshot-specific; another provider can succeed.
+      - "startup crash" — gemini_cli top-level await / yoga_wasm. The
+        CLI source explicitly marks this "so the cascade can move on".
+      All of these are per-provider, not cascade-wide; a fallback provider
+      may succeed where the current one rejected. See masc-mcp #9932
+      (kimi fallback), #9850 (codex_cli runtime_mcp_auth). *)
 end
 
 module Metrics : sig

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -27,6 +27,7 @@
    (re_export masc_eio_context)
    (re_export masc_log)
    (re_export masc_mcp)
+   (re_export masc_mcp.oas_compat)
    (re_export masc_mcp.activity_graph)
    (re_export masc_mcp.ag_ui)
    (re_export masc_mcp.config)

--- a/test/dune
+++ b/test/dune
@@ -106,6 +106,7 @@
         test_env_git_noninteractive
         test_gh_exit_class
         test_stay_silent_loop_detector
+        test_oas_compat_cascade_fallback
         test_heuristic_metrics_boot_wireup
         test_keeper_fs_edit_patch
         test_keeper_docker_read
@@ -228,6 +229,7 @@
           test_env_git_noninteractive
           test_gh_exit_class
           test_stay_silent_loop_detector
+          test_oas_compat_cascade_fallback
           test_heuristic_metrics_boot_wireup
           test_keeper_fs_edit_patch
           test_keeper_docker_read

--- a/test/test_oas_compat_cascade_fallback.ml
+++ b/test/test_oas_compat_cascade_fallback.ml
@@ -1,0 +1,107 @@
+(* test/test_oas_compat_cascade_fallback.ml
+
+   #9932: kimi_cli permanent failure blocks 5 keepers (409 BDI blockers) —
+   big_three cascade fallback was not firing because
+   [Oas_compat.Http_client.should_cascade] classified per-provider CLI
+   rejections as non-cascadable. The correct policy: a permanent error
+   specific to one provider (kimi auth/config, gemini startup crash) still
+   cascades because the NEXT hop is a different provider that may succeed.
+
+   This test pins the should_cascade policy for AcceptRejected reasons. The
+   FSM call site is [lib/cascade/cascade_fsm.ml:43-48]: Call_err -> Try_next
+   iff should_cascade_to_next returns true; otherwise Exhausted.  A false
+   return here terminates the cascade at the first hop, producing
+   fallback_applied=None in the observation. *)
+
+module Http_client = Llm_provider.Http_client
+
+let test_kimi_cli_exit_1_cascades () =
+  let reason =
+    "kimi_cli rejected the request (exit 1). "
+    ^ "This is usually a permanent auth/config/model error rather "
+    ^ "than a transient transport failure. "
+    ^ "kimi exited with code 1: To resume this session…"
+  in
+  let err = Http_client.AcceptRejected { reason } in
+  Alcotest.(check bool)
+    "kimi_cli exit 1 must cascade — permanent error is Moonshot-specific, \
+     next cascade hop (claude/gpt/ollama) unaffected"
+    true
+    (Oas_compat.Http_client.should_cascade err)
+
+let test_gemini_cli_startup_crash_cascades () =
+  let reason =
+    "gemini_cli startup crash detected (unsettled top-level await / \
+     yoga_wasm). Known bad CLI runtime; rejecting without retry so the \
+     cascade can move on."
+  in
+  let err = Http_client.AcceptRejected { reason } in
+  Alcotest.(check bool)
+    "gemini_cli startup crash must cascade — OAS source labels intent \
+     explicitly ('so the cascade can move on')"
+    true
+    (Oas_compat.Http_client.should_cascade err)
+
+let test_does_not_support_still_cascades () =
+  (* Regression pin for #9850: the provider-capability-mismatch marker
+     added by codex_cli runtime_mcp_auth / tool_support must keep
+     cascading. *)
+  let err =
+    Http_client.AcceptRejected
+      {
+        reason =
+          "codex_cli does not support runtime_mcp_auth headers for \
+           masc_plan_set_task, masc_claim_next, masc_transition";
+      }
+  in
+  Alcotest.(check bool)
+    "'does not support' cascades (pre-existing behaviour, #9850)"
+    true
+    (Oas_compat.Http_client.should_cascade err)
+
+let test_unknown_reason_does_not_cascade () =
+  (* The whitelist is additive — reasons that do not match any marker
+     stay non-cascadable. This pins that the fix is narrow and does
+     not accidentally cascade every AcceptRejected. *)
+  let err =
+    Http_client.AcceptRejected
+      { reason = "output_schema violation: value is not a string" }
+  in
+  Alcotest.(check bool)
+    "AcceptRejected with no marker does not cascade"
+    false
+    (Oas_compat.Http_client.should_cascade err)
+
+let test_http_429_cascades () =
+  (* Smoke test: HTTP-level cascadable codes are untouched by this fix. *)
+  let err = Http_client.HttpError { code = 429; body = "rate limited" } in
+  Alcotest.(check bool)
+    "HTTP 429 cascades (baseline)"
+    true
+    (Oas_compat.Http_client.should_cascade err)
+
+let () =
+  Alcotest.run "oas_compat_cascade_fallback"
+    [
+      ( "AcceptRejected — per-provider failure cascades (#9932)",
+        [
+          Alcotest.test_case "kimi_cli exit 1 cascades"
+            `Quick test_kimi_cli_exit_1_cascades;
+          Alcotest.test_case "gemini_cli startup crash cascades"
+            `Quick test_gemini_cli_startup_crash_cascades;
+        ] );
+      ( "AcceptRejected — capability mismatch still cascades (#9850)",
+        [
+          Alcotest.test_case "'does not support' cascades"
+            `Quick test_does_not_support_still_cascades;
+        ] );
+      ( "AcceptRejected — unrelated reasons do not cascade",
+        [
+          Alcotest.test_case "unknown reason stays non-cascadable"
+            `Quick test_unknown_reason_does_not_cascade;
+        ] );
+      ( "Baseline: HTTP errors unaffected",
+        [
+          Alcotest.test_case "HTTP 429 cascades" `Quick test_http_429_cascades;
+        ] );
+    ]


### PR DESCRIPTION
Summary: allow per-provider CLI rejection/startup-crash AcceptRejected reasons to cascade so one failed provider does not terminate the whole cascade. CI is green on head f1a6b0b14ec7893ed47b509c0931e07ac38718a8: Build and Test, TLA+, Health, Lint, Meta Guards, and CI Gate passed. Ready per operator approval.