### PR TITLE
[codex] repair keeper identity drift on status

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -44,6 +44,58 @@ let effective_keepalive_meta
       | Some entry -> entry.meta
       | None -> fallback)
 
+let repair_identity_drift_for_keepalive ~(ctx : _ context) (meta : keeper_meta) :
+    keeper_meta option =
+  let expected_agent_name = keeper_agent_name meta.name in
+  if String.equal expected_agent_name meta.agent_name then
+    Some meta
+  else
+    let previous_trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+    let new_trace_id_raw = Keeper_identity.generate_trace_id () in
+    match Keeper_id.Trace_id.of_string new_trace_id_raw with
+    | Error err ->
+        Log.Keeper.error
+          "keepalive identity repair failed for %s: invalid trace_id %s (%s)"
+          meta.name new_trace_id_raw err;
+        None
+    | Ok new_trace_id ->
+        let base_dir = session_base_dir ctx.config in
+        let _session =
+          Keeper_exec_context.create_session ~session_id:new_trace_id_raw
+            ~base_dir
+        in
+        let repaired =
+          {
+            meta with
+            agent_name = expected_agent_name;
+            updated_at = now_iso ();
+            runtime =
+              {
+                meta.runtime with
+                trace_id = new_trace_id;
+                trace_history =
+                  Json_util.dedupe_keep_order
+                    (previous_trace_id :: meta.runtime.trace_history);
+                generation = meta.runtime.generation + 1;
+              };
+          }
+        in
+        (match write_meta ~force:true ctx.config repaired with
+         | Ok () ->
+             Log.Keeper.warn
+               "keepalive repaired identity drift for %s: %s -> %s"
+               meta.name meta.agent_name expected_agent_name;
+             Some repaired
+         | Error err ->
+             Prometheus.inc_counter
+               Prometheus.metric_keeper_write_meta_failures
+               ~labels:[ ("keeper", meta.name); ("phase", "identity_repair") ]
+               ();
+             Log.Keeper.error
+               "keepalive identity repair failed for %s: write_meta failed: %s"
+               meta.name err;
+             None)
+
 (* Global turn slot cap. Safety ceiling for ALL keeper turns (autonomous
    + reactive). Default 12 = headroom for up to 12 keepers. *)
 let keeper_turn_throttle_limit =
@@ -1531,6 +1583,11 @@ let run_heartbeat_loop
           ~fallback:m
           ~disk_meta_opt
       in
+      let meta_current =
+        match repair_identity_drift_for_keepalive ~ctx meta_current with
+        | Some repaired -> repaired
+        | None -> meta_current
+      in
       (* Sync disk meta to registry so dashboard reads live values.  #5364.
          When disk meta is unchanged we still prefer the registry copy because
          runtime writes update it via the write_meta hook. This keeps
@@ -1998,6 +2055,11 @@ let bootstrap_live_keeper_meta ~(ctx : _ context) (m : keeper_meta) : keeper_met
     then (
       let (_init_msg : string) = Coord.init ctx.config ~agent_name:None in
       ());
+    let m =
+      match repair_identity_drift_for_keepalive ~ctx m with
+      | Some repaired -> repaired
+      | None -> m
+    in
     let synced = ensure_keeper_room_presence ctx.config m in
     (match write_meta ~force:true ctx.config synced with
      | Ok () -> ()
@@ -2110,6 +2172,12 @@ let record_keeper_crashed
 
 let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_meta) : unit
   =
+  match repair_identity_drift_for_keepalive ~ctx m with
+  | None ->
+      Log.Keeper.error
+        "start_keepalive skipped %s: identity drift could not be repaired"
+        m.name
+  | Some m -> (
   let existing_entry =
     Keeper_registry.get ~base_path:ctx.config.base_path m.name
   in
@@ -2196,6 +2264,7 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
             end)
         ~finally:(fun () ->
           Keeper_registry.cleanup_tracking ~base_path:ctx.config.base_path live_meta.name)))
+  )
 ;;
 
 let stop_keepalive ?base_path name =

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -460,6 +460,16 @@ let filter_forward_looking_summary (summary : string) : string =
       "아무것도 하지";
     ]
   in
+  let stale_tool_surface_markers =
+    [
+      "masc_* only";
+      "mcp__masc__ only";
+      "no keeper_* tools";
+      "no keeper tools";
+      "tool surface: masc";
+      "tool-surface: masc";
+    ]
+  in
   let strip_labeled_value ~prefixes line =
     let trimmed = String.trim line in
     let rec loop = function
@@ -490,11 +500,25 @@ let filter_forward_looking_summary (summary : string) : string =
              (fun marker -> String_util.contains_substring_ci payload marker)
              inert_next_markers
   in
+  let is_stale_tool_surface_line line =
+    let payload = String.trim line in
+    String_util.contains_substring_ci payload "tool"
+    && (List.exists
+          (fun marker -> String_util.contains_substring_ci payload marker)
+          stale_tool_surface_markers
+        || (String_util.contains_substring_ci payload "only"
+            && (String_util.contains_substring_ci payload "allowed tool"
+                || String_util.contains_substring_ci payload "available tool"
+                || String_util.contains_substring_ci payload "visible tool"
+                || String_util.contains_substring_ci payload "tool surface"
+                || String_util.contains_substring_ci payload "tool-surface")))
+  in
   let kept =
     summary
     |> String.split_on_char '\n'
     |> List.filter (fun line -> not (is_backward_line line))
     |> List.filter (fun line -> not (is_inert_next_line line))
+    |> List.filter (fun line -> not (is_stale_tool_surface_line line))
     |> List.filter (fun line -> String.trim line <> "")
   in
   match kept with

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -312,6 +312,29 @@ let with_keeper_name args name =
       `Assoc (("name", `String name) :: List.remove_assoc "name" fields)
   | other -> other
 
+let prepare_passive_keeper_identity ctx args =
+  let requested_name =
+    match String.trim (get_string args "name" "") with
+    | "" -> String.trim ctx.agent_name
+    | name -> name
+  in
+  if String.equal requested_name "" then
+    Ok (args, None)
+  else
+    match read_meta_resolved ctx.config requested_name with
+    | Ok (Some (_resolved_name, meta)) -> (
+        match maybe_reseed_keeper_identity ctx meta with
+        | Ok (updated_meta, identity_reseed) ->
+            Ok (with_keeper_name args updated_meta.name, identity_reseed)
+        | Error _ as err -> err)
+    | Ok None -> Ok (args, None)
+    | Error err -> Error (Printf.sprintf "❌ %s" err)
+
+let attach_identity_reseed ?identity_reseed json =
+  match identity_reseed with
+  | None -> json
+  | Some note -> attach_assoc_field "identity_reseed" note json
+
 let handle_keeper_create_from_persona ctx args : tool_result =
   if not Server_startup_state.((!state).state_ready) then begin
     let elapsed = Server_startup_state.elapsed_since_start () in
@@ -357,15 +380,21 @@ let handle_keeper_up ctx args : tool_result =
   with_keeper_startup_gate (fun () -> execute_keeper_up ctx args)
 
 let handle_keeper_status ctx args : tool_result =
-  let ok, body = Status.handle_keeper_status ctx args in
-  if not ok then (ok, body)
-  else
-    let json =
-      try Yojson.Safe.from_string body with Yojson.Json_error _ -> `String body
-    in
-    (true,
-     Yojson.Safe.pretty_to_string
-       (annotate_keeper_json ~runtime_class:"keeper" json))
+  match prepare_passive_keeper_identity ctx args with
+  | Error err -> (false, err)
+  | Ok (prepared_args, identity_reseed) ->
+      let ok, body = Status.handle_keeper_status ctx prepared_args in
+      if not ok then (ok, body)
+      else
+        let json =
+          try Yojson.Safe.from_string body with Yojson.Json_error _ -> `String body
+        in
+        let json =
+          json
+          |> annotate_keeper_json ~runtime_class:"keeper"
+          |> attach_identity_reseed ?identity_reseed
+        in
+        (true, Yojson.Safe.pretty_to_string json)
 
 let resolve_keeper_name ctx args =
   let name = String.trim (get_string args "name" "") in
@@ -707,16 +736,21 @@ let handle_keeper_sandbox_status ctx args : tool_result =
                ("items", `List items);
              ]) )
   | _ ->
-      (match resolve_keeper_meta ctx args with
+      (match prepare_passive_keeper_identity ctx args with
        | Error err -> (false, err)
-       | Ok meta ->
-           ( true,
-             Yojson.Safe.pretty_to_string
-               (`Assoc
-                  [
-                    ("keeper", `String meta.name);
-                    ("sandbox", render_item meta);
-                  ]) ))
+       | Ok (prepared_args, identity_reseed) -> (
+           match resolve_keeper_meta ctx prepared_args with
+           | Error err -> (false, err)
+           | Ok meta ->
+               let json =
+                 `Assoc
+                   [
+                     ("keeper", `String meta.name);
+                     ("sandbox", render_item meta);
+                   ]
+                 |> attach_identity_reseed ?identity_reseed
+               in
+               (true, Yojson.Safe.pretty_to_string json)))
 
 let handle_keeper_sandbox_start ctx args : tool_result =
   match resolve_keeper_meta ctx args with

--- a/test/test_continuity_forward_filter.ml
+++ b/test/test_continuity_forward_filter.ml
@@ -24,6 +24,12 @@ Next: 대기 유지; all non-destructive actions exhausted
 OpenQuestions: none
 Constraints: repos/ empty|}
 
+let stale_tool_surface_summary =
+  {|Goal: verify live tool policy
+Next plan: use keeper_task_claim after checking live policy
+Constraints: tool surface: masc_* only; no keeper_* tools visible
+OpenQuestions: why did the previous turn see stale tools?|}
+
 let test_strips_backward () =
   let filtered =
     Masc_mcp.Keeper_memory_policy.filter_forward_looking_summary full_summary
@@ -93,6 +99,20 @@ let test_drops_inert_idle_directives () =
   Alcotest.(check bool) "constraints still kept"
     true (Astring.String.is_infix ~affix:"Constraints:" filtered)
 
+let test_drops_stale_tool_surface_claims () =
+  let filtered =
+    Masc_mcp.Keeper_memory_policy.filter_forward_looking_summary
+      stale_tool_surface_summary
+  in
+  Alcotest.(check bool) "stale masc-only claim removed"
+    false (Astring.String.is_infix ~affix:"masc_* only" filtered);
+  Alcotest.(check bool) "stale missing keeper tools removed"
+    false (Astring.String.is_infix ~affix:"no keeper_* tools" filtered);
+  Alcotest.(check bool) "goal still kept"
+    true (Astring.String.is_infix ~affix:"Goal:" filtered);
+  Alcotest.(check bool) "live-policy action still kept"
+    true (Astring.String.is_infix ~affix:"keeper_task_claim" filtered)
+
 let () =
   Alcotest.run "continuity forward filter"
     [ ( "filter_forward_looking_summary",
@@ -106,5 +126,7 @@ let () =
             test_preserves_line_order;
           Alcotest.test_case "drops inert idle directives" `Quick
             test_drops_inert_idle_directives;
+          Alcotest.test_case "drops stale tool surface claims" `Quick
+            test_drops_stale_tool_surface_claims;
         ] );
     ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1185,6 +1185,33 @@ let test_prompt_continuity_drops_inert_idle_directives () =
   check bool "constraints preserved" true
     (contains_substring user "Constraints: repos/ empty")
 
+let test_prompt_continuity_drops_stale_tool_surface_claims () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let obs =
+    {
+      base_observation with
+      continuity_summary =
+        "Goal: restore autonomous tool use\n\
+         Next plan: call keeper_task_claim after checking live policy\n\
+         Constraints: tool surface: masc_* only; no keeper_* tools visible";
+      unclaimed_task_count = 3;
+    }
+  in
+  let _sys, user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
+  in
+  check bool "continuity section present" true
+    (contains_substring user "### Continuity");
+  check bool "stale masc-only surface removed" false
+    (contains_substring user "masc_* only");
+  check bool "stale missing keeper tools removed" false
+    (contains_substring user "no keeper_* tools");
+  check bool "goal preserved" true
+    (contains_substring user "Goal: restore autonomous tool use");
+  check bool "live policy action preserved" true
+    (contains_substring user "keeper_task_claim")
+
 let test_prompt_includes_mentions_section () =
   let obs =
     { base_observation with
@@ -4803,6 +4830,8 @@ let () =
           test_case "omits empty sections" `Quick test_prompt_omits_empty_sections;
           test_case "continuity drops inert idle directives" `Quick
             test_prompt_continuity_drops_inert_idle_directives;
+          test_case "continuity drops stale tool surface claims" `Quick
+            test_prompt_continuity_drops_stale_tool_surface_claims;
           test_case "includes mentions" `Quick test_prompt_includes_mentions_section;
           test_case "includes board activity" `Quick
             test_prompt_includes_board_activity_section;

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -121,6 +121,10 @@ let () =
           Alcotest.test_case "keeper up reseeds identity drift" `Quick
             Test_operator_control_keeper
             .test_keeper_up_reseeds_identity_drift;
+          Alcotest.test_case
+            "keeper status reseeds separator identity drift" `Quick
+            Test_operator_control_keeper
+            .test_keeper_status_reseeds_separator_identity_drift;
           Alcotest.test_case "keeper status exposes model observability"
             `Quick
             Test_operator_control_keeper
@@ -162,6 +166,10 @@ let () =
             `Quick
             Test_operator_control_keeper
             .test_keeper_sandbox_status_exposes_local_summary;
+          Alcotest.test_case
+            "keeper sandbox status reseeds separator identity drift" `Quick
+            Test_operator_control_keeper
+            .test_keeper_sandbox_status_reseeds_separator_identity_drift;
           Alcotest.test_case
             "keeper sandbox start status stop works with fake docker"
             `Quick

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -80,6 +80,20 @@ let drift_keeper_identity config keeper_name ~agent_name =
   | Ok () -> previous_trace_id
   | Error err -> Alcotest.fail ("keeper identity drift write failed: " ^ err)
 
+let check_identity_reseed_reason label json =
+  Alcotest.(check string) label "agent_name_mismatch"
+    Yojson.Safe.Util.(json |> member "identity_reseed" |> member "reason" |> to_string)
+
+let check_keeper_identity_repaired config keeper_name previous_trace_id =
+  let meta = read_keeper_meta_exn config keeper_name in
+  let current_trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+  Alcotest.(check string) "agent name restored to canonical"
+    (Keeper_types.keeper_agent_name keeper_name) meta.agent_name;
+  Alcotest.(check bool) "trace id rotated" true
+    (not (String.equal current_trace_id previous_trace_id));
+  Alcotest.(check bool) "previous trace retained in history" true
+    (List.mem previous_trace_id meta.runtime.trace_history)
+
 let fake_docker_managed_sandbox_script =
   "#!/bin/sh\n\
 state_file=${KEEPER_DOCKER_STATE_FILE:?}\n\
@@ -820,6 +834,121 @@ let test_keeper_up_reseeds_identity_drift () =
         (not (String.equal current_trace_id previous_trace_id));
       Alcotest.(check bool) "previous trace retained in history" true
         (List.mem previous_trace_id meta.runtime.trace_history))
+
+let test_keeper_status_reseeds_separator_identity_drift () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "issue_king" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Repair status identity drift");
+                ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      let previous_trace_id =
+        drift_keeper_identity config keeper_name
+          ~agent_name:"keeper-issue-king-agent"
+      in
+      let ok, body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_status"
+          ~args:(`Assoc [ ("name", `String keeper_name); ("fast", `Bool true) ])
+      in
+      Alcotest.(check bool) "keeper status repairs identity drift" true ok;
+      let status_json = parse_json_exn body in
+      check_identity_reseed_reason "status reseed reason" status_json;
+      Alcotest.(check string) "status keeps canonical keeper name" keeper_name
+        Yojson.Safe.Util.(status_json |> member "name" |> to_string);
+      check_keeper_identity_repaired config keeper_name previous_trace_id)
+
+let test_keeper_sandbox_status_reseeds_separator_identity_drift () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "sandbox_issue_king" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Repair sandbox identity drift");
+                ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      let previous_trace_id =
+        drift_keeper_identity config keeper_name
+          ~agent_name:"keeper-sandbox-issue-king-agent"
+      in
+      let ok, body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_sandbox_status"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("include_preflight", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "sandbox status repairs identity drift" true ok;
+      let body_json = parse_json_exn body in
+      check_identity_reseed_reason "sandbox status reseed reason" body_json;
+      let sandbox_json = Yojson.Safe.Util.member "sandbox" body_json in
+      let open Yojson.Safe.Util in
+      Alcotest.(check bool) "sandbox identity matches canonical agent" true
+        (sandbox_json |> member "identity" |> member "agent_name_matches"
+       |> to_bool);
+      Alcotest.(check string) "sandbox expected canonical agent"
+        (Keeper_types.keeper_agent_name keeper_name)
+        (sandbox_json |> member "identity" |> member "agent_name" |> to_string);
+      check_keeper_identity_repaired config keeper_name previous_trace_id)
 
 let test_keeper_repair_reseeds_identity_drift () =
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
## Summary
- Repair keeper `agent_name` drift before named `masc_keeper_status` / `masc_keeper_sandbox_status` responses are trusted.
- Repair drift during keepalive bootstrap/loop startup so autonomous scheduling does not continue with a stale sandbox identity.
- Strip stale continuity claims that say only `masc_*` tools are visible when prompt continuity is regenerated.

Fixes #9923.

## Validation
- `env DUNE_JOBS=2 DUNE_BUILD_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/keeper-identity-continuity-fix/_build dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/keeper-identity-continuity-fix ./test/test_operator_control.exe ./test/test_continuity_forward_filter.exe ./test/test_keeper_unified.exe`
- `./_build/default/test/test_continuity_forward_filter.exe --compact --show-errors`
- `env MASC_BASE_PATH=/tmp/masc-codex-test-base ./_build/default/test/test_keeper_unified.exe test unified_prompt 11 --compact --show-errors`
- `env MASC_BASE_PATH=/tmp/masc-codex-test-base ./_build/default/test/test_operator_control.exe test operator 31,43 --compact --show-errors`
- `git diff --check`