### PR TITLE
fix(keepalive): emit status_tick compaction fields as 0 (#9943)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -892,8 +892,18 @@ let write_heartbeat_snapshot
             | Some s -> keeper_state_snapshot_to_json s )
         ; "continuity_summary", `String continuity_summary
         ; "compacted", `Bool false
-        ; "compaction_before_tokens", `Int token_count_v
-        ; "compaction_after_tokens", `Int token_count_v
+        ; (* #9943: status_tick is a snapshot, not a compaction
+             event. Emitting [before = after = token_count_v]
+             caused 956/972 (98.4%) of daily metric entries to
+             look like compaction attempts with zero savings —
+             a false signal that drowned actual compactions.
+             Zero marks the record as "not a compaction event";
+             the dashboard already skips records with
+             compacted=false, but analysts running ad-hoc jq over
+             the ledger no longer mistake status_tick for a
+             failed compaction. *)
+          "compaction_before_tokens", `Int 0
+        ; "compaction_after_tokens", `Int 0
         ; "work_kind", `String "status_tick"
         ; "tool_call_count", `Int 0
         ; "tools_used", `List []


### PR DESCRIPTION
## Symptom

Daily fleet metrics show **956/972 (98.4%)** entries with `compaction_before_tokens == compaction_after_tokens > 0` — apparent "compaction attempts with zero savings". Issue headline: "compaction is noop".

## Root cause — schema semantics, not an execution bug

At `lib/keeper/keeper_keepalive.ml:894-897` the **status_tick** snapshot (a keeper heartbeat, NOT an attempted compaction) emits the current context token count into BOTH `compaction_before_tokens` AND `compaction_after_tokens`:

```ocaml
; "compacted", `Bool false
; "compaction_before_tokens", `Int token_count_v   (* THE BUG *)
; "compaction_after_tokens", `Int token_count_v    (* THE BUG *)
; "work_kind", `String "status_tick"
```

This creates an inadvertent "before == after > 0" record that mimics a failed compaction.

Dashboard aggregator at `dashboard_http_keeper_detail.ml:237` already filters on `compacted=true`, so the inflated stats never poison the ratio chart. The real damage is to analysts:

```
jq 'select(.compaction_before_tokens == .compaction_after_tokens
           and .compaction_before_tokens > 0) | .work_kind' *.jsonl
```

returns mostly `status_tick`. The issue's "98.4% noop" headline comes from exactly this filter.

## Fix

Emit `0` on both fields. Dashboard behavior unchanged (gated on `compacted=true`). Ad-hoc ledger analysis now shows status_tick as "not a compaction event" instead of "failed compaction".

```ocaml
; "compacted", `Bool false
; "compaction_before_tokens", `Int 0   (* #9943 *)
; "compaction_after_tokens", `Int 0    (* #9943 *)
; "work_kind", `String "status_tick"
```

Inline comment documents the "0 ≡ not a compaction event" contract at the write site.

## What this does NOT fix

Issue has 5 proposals; this PR addresses **proposal 5** (compacted=true invariant) only. Others remain separate concerns:

- **Proposal 1** (warn on real compaction noop): genuine anomaly when compaction actually ran + produced no savings. Out of scope here.
- **Proposal 2** (claude_code:auto context_max=64000 too small): provider registry mis-config. Separate PR.
- **Proposal 3** (`is_local` gate on compaction path): requires reading the compaction path itself. Separate PR.
- **Proposal 4** (20-minute turn alert): intersects #9933 budget work.

## Why surgical over broader

Dropping compaction_* fields entirely or making them nullable risks breaking downstream log indexers and the aggregator's default-0 coercion at lines 125-126. Emitting 0 preserves JSON shape — every record still has the field, readers still get an `int`, and numeric semantics match the existing `compacted=false` flag.

## Verification

- `dune build @check` clean on `ed9ee2105` + this patch
- No test changes: `append_metrics_snapshot`'s status_tick arm has 15+ input dependencies (meta, context, continuity, auto rules, timing ring) and is not isolated enough for a unit test without disproportionate fixture setup. The structural change is a 2-value constant swap; a bad revert would be caught by any fleet-wide re-scan of the `compaction_*` distribution post-deploy.

## Scope

| File | Change |
|------|--------|
| `lib/keeper/keeper_keepalive.ml` | 2 constant changes (token_count_v → 0) + inline comment |

**Total: 1 file, 12 insertions, 2 deletions**. No test changes. No public API change.

## Do not merge

Carrying `do-not-merge` until reviewer sign-off on:

1. **Surgical vs broader** — OK to land the write-side fix and file proposals 1-4 as separate PRs?
2. **Test scope** — acceptable to forgo a unit test here given the fixture cost, and rely on fleet metric re-scan for post-deploy confirmation?

🤖 Generated with [Claude Code](https://claude.com/claude-code)