### PR TITLE
fix(keeper): replace raw Util.member with guarded json_member in trust snapshot (#9669)

### DIFF
--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -190,7 +190,7 @@ let approval_event_timeline_event json =
               Some "retry_or_rerun" )
         | "auto_approved_rule_match" ->
             let matched_by =
-              json |> Yojson.Safe.Util.member "rule_match"
+              json |> json_member "rule_match"
               |> json_string_opt_member "matched_by"
               |> Option.value ~default:"always_rule"
             in
@@ -251,7 +251,7 @@ let transition_timeline_event json =
   | None -> None
   | Some ts_unix ->
       let operator_signal =
-        match json |> Yojson.Safe.Util.member "operator_signal" with
+        match json |> json_member "operator_signal" with
         | `Assoc fields -> Some fields
         | _ -> None
       in
@@ -264,15 +264,15 @@ let transition_timeline_event json =
           operator_signal
       in
       let prev_phase =
-        json |> Yojson.Safe.Util.member "prev_phase"
+        json |> json_member "prev_phase"
         |> json_string_opt_value
       in
       let new_phase =
-        json |> Yojson.Safe.Util.member "new_phase"
+        json |> json_member "new_phase"
         |> json_string_opt_value
       in
       let selected_event =
-        json |> Yojson.Safe.Util.member "selected_event"
+        json |> json_member "selected_event"
       in
       let event_type =
         (match json_string_opt_member "event_type" json with
@@ -324,12 +324,12 @@ let receipt_timeline_event receipt =
           |> Option.value ~default:"unknown"
         in
         let cascade_outcome =
-          receipt |> Yojson.Safe.Util.member "cascade"
+          receipt |> json_member "cascade"
           |> json_string_opt_member "outcome"
           |> Option.value ~default:"not_observed"
         in
         let error_kind =
-          match Yojson.Safe.Util.member "error" receipt with
+          match json_member "error" receipt with
           | `Assoc _ as error -> json_string_opt_member "kind" error
           | _ -> None
         in
@@ -340,7 +340,7 @@ let receipt_timeline_event receipt =
               if String.equal tool_contract_result "violated" then "bad"
               else if
                 String.equal cascade_outcome "passed_to_next_model"
-                || (receipt |> Yojson.Safe.Util.member "cascade"
+                || (receipt |> json_member "cascade"
                     |> json_bool_opt_member "fallback_applied"
                     |> Option.value ~default:false)
               then "warn"
@@ -525,7 +525,7 @@ let approval_state_json ~pending_approval_count ~latest_tool_call
     ~latest_approval_audit ~latest_receipt =
   let latest_rule_match =
     Option.bind latest_approval_audit (fun json ->
-        match Yojson.Safe.Util.member "rule_match" json with
+        match json_member "rule_match" json with
         | `Assoc _ as rule_match -> Some rule_match
         | _ -> None)
   in
@@ -537,7 +537,7 @@ let approval_state_json ~pending_approval_count ~latest_tool_call
   in
   let approval_profile =
     Option.bind latest_receipt (fun receipt ->
-        receipt |> Yojson.Safe.Util.member "approval"
+        receipt |> json_member "approval"
         |> json_string_opt_member "profile")
   in
   let state =
@@ -582,14 +582,14 @@ let execution_summary_json ~meta ~latest_receipt =
   let sandbox_kind =
     match latest_receipt with
     | Some receipt ->
-        receipt |> Yojson.Safe.Util.member "sandbox"
+        receipt |> json_member "sandbox"
         |> json_string_opt_member "kind"
     | None -> Some (Keeper_types.sandbox_profile_to_string meta.sandbox_profile)
   in
   let network_mode =
     match latest_receipt with
     | Some receipt ->
-        receipt |> Yojson.Safe.Util.member "sandbox"
+        receipt |> json_member "sandbox"
         |> json_string_opt_member "network_mode"
     | None -> Some (Keeper_types.network_mode_to_string meta.network_mode)
   in
@@ -725,7 +725,7 @@ let snapshot_json ~(config : Coord.config) ~(meta : keeper_meta) =
   in
   let selected_model =
     Option.bind latest_decision (fun json ->
-        match Yojson.Safe.Util.member "telemetry" json with
+        match json_member "telemetry" json with
         | `Assoc _ as telemetry ->
             (match json_string_opt_member "selected_model" telemetry with
              | Some _ as value -> value


### PR DESCRIPTION
## 요약

`lib/keeper/keeper_runtime_trust_snapshot.ml`이 `json_member` 가드 헬퍼를 정의해놓고도 같은 파일 내 13개 사이트가 raw `Yojson.Safe.Util.member`를 직접 호출해, 입력 json이 null/non-object일 때 `"Can't get member 'X' of non-object type null"` 타입 에러로 크래시합니다. 본 PR은 13개 사이트를 전부 guarded 헬퍼로 전환합니다.

Closes #9669.

## 근본 원인

파일 상단의 헬퍼는 이미 non-`Assoc` 입력을 `Null`로 흡수:

```ocaml
let json_member key = function
  | `Assoc _ as json -> Yojson.Safe.Util.member key json
  | _ -> `Null
```

하지만 파일 전반의 13개 사이트가 이 헬퍼를 우회해 raw `Yojson.Safe.Util.member`를 직접 호출:

| 라인 | 컨텍스트 |
|------|----------|
| 193 | `json_member "rule_match"` (approval rule 매칭) |
| 254 | operator_signal 추출 |
| 267, 271 | prev_phase / new_phase 추출 |
| 275 | selected_event 추출 |
| 327, 343 | cascade 정보 |
| 332 | error 필드 |
| 528 | rule_match 재조회 |
| 540 | approval 필드 |
| 585, 592 | sandbox 필드 |
| 728 | telemetry 매칭 (이미 `Assoc _` 가드 존재) |

일부 사이트는 상위 `match ... with Assoc _ ->` 흐름 덕에 실질적으로 안전하지만, 다수(prev_phase, approval, sandbox 추출)는 decision/receipt가 null이면 바로 크래시. 이슈가 보고한 `masc_keeper_status(name="masc-mcp-smoke", fast=true)` 시 "Can't get member 'selected_model' of non-object type null" 크래시가 이 패턴.

## 변경 내용

13개 사이트를 전부 `json_member`로 전환. 라인 4의 헬퍼 정의는 재귀 방지를 위해 raw call 유지.

```diff
- json |> Yojson.Safe.Util.member "rule_match"
+ json |> json_member "rule_match"

- match Yojson.Safe.Util.member "error" receipt with
+ match json_member "error" receipt with

... (13 sites total)
```

시그니처가 동일(`key -> t -> t`)해서 pipe 형태(`json |> ...`)와 prefix 형태(`... json`) 모두 호출부 변경 없이 교체됩니다.

## 회귀 리스크

| 입력 | before | after |
|------|--------|-------|
| `Assoc` json + 존재하는 key | 값 반환 | 값 반환 (unchanged) |
| `Assoc` json + missing key | `Null` 반환 | `Null` 반환 (unchanged) |
| Non-object json (Null, String, etc.) | Type_error crash ❌ | `Null` 반환 ✅ |

오버헤드: 사이트당 pattern match 1회 추가. 스냅샷 경로에서 무시 가능.

## 테스트

- [x] `dune build @check --root .` exit 0
- [x] `dune runtest test/test_dashboard_goals.exe --root .` — 8/8 passed, 특히 `tree 6: goal tree tolerates null decision telemetry` 확인

## 검증하지 못한 항목

- 실환경 재현 (`masc_keeper_status(name="masc-mcp-smoke", fast=true)` + 빈 decision log)는 수행하지 않았습니다. 본 PR은 crash 경로를 type-level에서 전부 막습니다.
- 다른 파일(`keeper_status_detail.ml` 등)에 유사 raw `Util.member` 패턴이 남아있을 수 있습니다. 본 PR은 이슈 지목 파일 범위만 수정.

## 참고

- Issue #9669 — 재현 조건 및 suggested fix 
- PR #9705 — 이전 partial fix (json_member 헬퍼 도입)
- PR #9710 — 이전 partial fix (selected_model 특정 경로)
- 본 PR은 #9705/#9710의 sweep 완료판
