### PR TITLE
[codex] Address cascade boundary review findings

### DIFF
--- a/lib/keeper/keeper_cascade_routing.ml
+++ b/lib/keeper/keeper_cascade_routing.ml
@@ -32,11 +32,9 @@ let select_cascade ~(base_cascade : string) ~(phase : Keeper_state_machine.phase
       { effective_cascade = base_cascade;
         reason = "non-turn phase (blocked upstream)" }
 
-let route_effective_cascade_for_tool_requirement_with_model_labels
-    ~(model_labels_of_cascade : string -> string list)
-    ~(effective_cascade : string)
-    ~(tool_requirement : string) : routing_decision =
-  ignore model_labels_of_cascade;
+let route_effective_cascade_for_tool_requirement
+    ~(effective_cascade : string) ~(tool_requirement : string) :
+    routing_decision =
   if not (String.equal tool_requirement "required") then
     {
       effective_cascade;
@@ -48,7 +46,3 @@ let route_effective_cascade_for_tool_requirement_with_model_labels
       reason =
         "tool-required turn keeps routed cascade; provider capability filter enforces tool support";
     }
-
-let route_effective_cascade_for_tool_requirement =
-  route_effective_cascade_for_tool_requirement_with_model_labels
-    ~model_labels_of_cascade:Cascade_runtime.models_of_cascade_name

--- a/lib/keeper/keeper_cascade_routing.mli
+++ b/lib/keeper/keeper_cascade_routing.mli
@@ -41,11 +41,3 @@ val route_effective_cascade_for_tool_requirement :
   effective_cascade:string ->
   tool_requirement:string ->
   routing_decision
-
-(** Same as {!route_effective_cascade_for_tool_requirement}, with model-label
-    resolution injected for deterministic tests. *)
-val route_effective_cascade_for_tool_requirement_with_model_labels :
-  model_labels_of_cascade:(string -> string list) ->
-  effective_cascade:string ->
-  tool_requirement:string ->
-  routing_decision

--- a/test/test_cascade_runtime.ml
+++ b/test/test_cascade_runtime.ml
@@ -171,6 +171,39 @@ let test_oas_http_error_classification_is_typed () =
         H.should_cascade_to_next capability_mismatch
     | _ -> false)
 
+let test_oas_failure_classification_keeps_terminal_branches_non_cascading () =
+  let module H = Masc_mcp.Cascade_health_filter in
+  let terminal_http =
+    Llm_provider.Http_client.HttpError
+      { code = 418; body = "terminal provider refusal" }
+  in
+  let accept_terminal =
+    Llm_provider.Http_client.AcceptRejected
+      { reason = "provider authentication failed" }
+  in
+  let local_resource =
+    Llm_provider.Http_client.NetworkError
+      {
+        message = "too many open files";
+        kind = Llm_provider.Http_client.Local_resource_exhaustion;
+      }
+  in
+  (match H.classify_failure terminal_http with
+  | H.Terminal_http 418 ->
+      check bool "terminal HTTP class does not cascade" false
+        (H.should_cascade_to_next terminal_http)
+  | _ -> fail "expected terminal HTTP classification");
+  (match H.classify_failure accept_terminal with
+  | H.Accept_rejected_terminal ->
+      check bool "terminal accept rejection does not cascade" false
+        (H.should_cascade_to_next accept_terminal)
+  | _ -> fail "expected terminal accept rejection classification");
+  match H.classify_failure local_resource with
+  | H.Local_resource_exhaustion ->
+      check bool "local resource exhaustion does not cascade" false
+        (H.should_cascade_to_next local_resource)
+  | _ -> fail "expected local resource exhaustion classification"
+
 let () =
   run "Cascade_runtime"
     [
@@ -194,5 +227,7 @@ let () =
             test_required_tool_support_filter_drops_runtime_mcp_providers_without_header_support;
           test_case "OAS HTTP errors classify before cascade boolean" `Quick
             test_oas_http_error_classification_is_typed;
+          test_case "OAS terminal classes stay non-cascading" `Quick
+            test_oas_failure_classification_keeps_terminal_branches_non_cascading;
         ] );
     ]

--- a/test/test_keeper_cascade_routing.ml
+++ b/test/test_keeper_cascade_routing.ml
@@ -89,23 +89,14 @@ let test_running_with_custom_base () =
 
 let test_tool_required_turn_preserves_routed_cascade () =
   let r =
-    Routing.route_effective_cascade_for_tool_requirement_with_model_labels
-      ~model_labels_of_cascade:(fun _ -> [ "claude_code:auto" ])
+    Routing.route_effective_cascade_for_tool_requirement
       ~effective_cascade:"big_three" ~tool_requirement:"required"
   in
   check string "required tool turns preserve routed cascade"
-    "big_three" r.effective_cascade
-
-let test_tool_required_turn_preserves_pure_local_cascade () =
-  let r =
-    Routing.route_effective_cascade_for_tool_requirement_with_model_labels
-      ~model_labels_of_cascade:(function
-        | "ollama_only" -> [ "ollama:auto" ]
-        | _ -> [])
-      ~effective_cascade:"ollama_only" ~tool_requirement:"required"
-  in
-  check string "required tool turns preserve pure-local cascade"
-    "ollama_only" r.effective_cascade
+    "big_three" r.effective_cascade;
+  check bool "required tool turns do not rewrite to strict cascade" false
+    (String.equal Masc_mcp.Keeper_config.tool_use_strict_cascade_name
+       r.effective_cascade)
 
 let test_tool_required_turn_preserves_local_recovery () =
   let r =
@@ -148,8 +139,6 @@ let () =
       test_case "Running preserves custom base"     `Quick test_running_with_custom_base;
       test_case "Required tool turn preserves routed cascade" `Quick
         test_tool_required_turn_preserves_routed_cascade;
-      test_case "Required tool turn preserves pure-local cascade" `Quick
-        test_tool_required_turn_preserves_pure_local_cascade;
       test_case "Required tool turn preserves local recovery" `Quick
         test_tool_required_turn_preserves_local_recovery;
       test_case "All phases have reason"            `Quick test_all_phases_have_reason;

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2882,6 +2882,18 @@ let test_next_fail_open_cascade_for_turn_suppresses_exhausted_rotation_group () 
   check bool "exhausted rotation group suppressed" true
     (Option.is_none degraded_retry)
 
+let test_next_fail_open_cascade_for_required_tool_uses_default_not_strict () =
+  let degraded_retry =
+    UT.next_fail_open_cascade_for_turn
+      ~base_cascade:"tool_rerank"
+      ~effective_cascade:"tool_rerank"
+      ~tool_requirement:"required"
+      ~attempted_cascades:[ "tool_rerank" ]
+      (wrapped_claude_limit_error ())
+  in
+  expect_degraded_retry "required tool degraded retry skips strict injection"
+    KC.default_cascade_name "hard_quota" degraded_retry
+
 let test_next_fail_open_cascade_for_turn_allows_required_tool_rotation () =
   let degraded_retry =
     UT.next_fail_open_cascade_for_turn
@@ -5237,6 +5249,9 @@ let () =
           test_case "next degraded retry suppresses exhausted rotation group"
             `Quick
             test_next_fail_open_cascade_for_turn_suppresses_exhausted_rotation_group;
+          test_case "required-tool rotation uses default without strict injection"
+            `Quick
+            test_next_fail_open_cascade_for_required_tool_uses_default_not_strict;
           test_case "required tool turns rotate without dropping requirement"
             `Quick
             test_next_fail_open_cascade_for_turn_allows_required_tool_rotation;


### PR DESCRIPTION
## Summary
- remove the stale injected model-label test hook from keeper cascade routing
- lock required-tool fallback behavior so strict cascade is not silently injected on retry
- expand typed OAS failure classification coverage for terminal, accept-rejected, and local resource exhaustion branches

## Verification
- `git diff --check`
- `scripts/dune-local.sh build test/test_cascade_runtime.exe test/test_keeper_cascade_routing.exe test/test_keeper_unified.exe`
- `./_build/default/test/test_cascade_runtime.exe`
- `./_build/default/test/test_keeper_cascade_routing.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-keeper-unified-cascade-boundary-review ./_build/default/test/test_keeper_unified.exe test phase_gate 21-23`
- `env MASC_BASE_PATH=/tmp/masc-test-keeper-unified-cascade-boundary-review-tool ./_build/default/test/test_keeper_unified.exe test tool_classification 0-2`

## Cross-model review
- Initial GLM pass found brittle source-grep coverage and weak terminal-branch tests; patched and amended.
- Final `scripts/review/local-review.sh --base origin/main --head HEAD --format markdown --no-cache` with `glm-direct-no-thinking`: `No findings.`

Note: the local Ollama OpenAI-compatible endpoint returned empty/timed-out reviewer output earlier, so this review evidence uses direct `sb glm-text --no-thinking` through `MASC_LOCAL_REVIEW_COMMAND`.