### PR TITLE
feat(oas): pair context_overflow_imminent with action signal (#9935)

### DIFF
--- a/lib/context_overflow_action_tracker.ml
+++ b/lib/context_overflow_action_tracker.ml
@@ -1,0 +1,99 @@
+let default_grace_window_sec = 60.0
+
+let grace_window_seconds () =
+  match Sys.getenv_opt "MASC_CONTEXT_OVERFLOW_GRACE_SEC" with
+  | Some v when v <> "" ->
+    (match float_of_string_opt v with
+     | Some f when f > 0.0 -> f
+     | _ -> default_grace_window_sec)
+  | _ -> default_grace_window_sec
+
+(* Per-keeper state.
+
+   [pending_since]: timestamp of the current unanswered imminent,
+   or None if no imminent is pending (either never happened or the
+   last one was cleared by an action).
+
+   [no_action_fired_for_pending]: latches the no_action counter
+   so multiple late-arriving imminent events for the same
+   unanswered episode only fire once. Resets when pending clears. *)
+type keeper_state = {
+  mutable pending_since : float option;
+  mutable no_action_fired_for_pending : bool;
+}
+
+let state : (string, keeper_state) Hashtbl.t = Hashtbl.create 16
+let mu = Stdlib.Mutex.create ()
+
+let with_lock f =
+  Stdlib.Mutex.lock mu;
+  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock mu) f
+
+let get_or_create keeper_name =
+  match Hashtbl.find_opt state keeper_name with
+  | Some s -> s
+  | None ->
+    let s = { pending_since = None; no_action_fired_for_pending = false } in
+    Hashtbl.replace state keeper_name s;
+    s
+
+let record_imminent ~keeper_name ~ts =
+  with_lock (fun () ->
+    let s = get_or_create keeper_name in
+    Prometheus.inc_counter
+      "masc_context_overflow_imminent_total"
+      ~labels:[ ("keeper", keeper_name) ] ();
+    let grace = grace_window_seconds () in
+    match s.pending_since with
+    | None ->
+      (* Fresh episode — no prior pending, so the latch starts in
+         the not-fired state. *)
+      s.pending_since <- Some ts;
+      s.no_action_fired_for_pending <- false
+    | Some prior_ts
+      when ts -. prior_ts > grace
+        && not s.no_action_fired_for_pending ->
+      (* Prior imminent went unanswered past the grace window.
+         Fire no-action once per episode, latch engaged, and
+         advance the pending marker so subsequent action-pairing
+         still works for the same episode. Crucially, do NOT
+         reset the latch — this is still the same stuck episode
+         until record_action clears it. *)
+      s.no_action_fired_for_pending <- true;
+      s.pending_since <- Some ts;
+      Prometheus.inc_counter
+        "masc_context_overflow_no_action_total"
+        ~labels:[ ("keeper", keeper_name) ] ();
+      Log.Server.warn
+        "#9935 context_overflow_imminent with no reduction action \
+         keeper=%s prior_imminent_age_sec=%.1f grace_sec=%.1f \
+         — OAS issued context_overflow_imminent but no \
+         context_compact_started / context_compacted event \
+         followed within the grace window. Check compaction \
+         gating (#9943), keeper turn budget (#9933), or the \
+         OAS compact planner." keeper_name (ts -. prior_ts) grace
+    | Some _ ->
+      (* Within grace, or latch already engaged. Advance the
+         pending marker but preserve the latch state so we do
+         not re-fire the no-action counter on every imminent. *)
+      s.pending_since <- Some ts)
+
+let record_action ~keeper_name =
+  with_lock (fun () ->
+    match Hashtbl.find_opt state keeper_name with
+    | Some s when Option.is_some s.pending_since ->
+      Prometheus.inc_counter
+        "masc_context_overflow_action_taken_total"
+        ~labels:[ ("keeper", keeper_name) ] ();
+      s.pending_since <- None;
+      s.no_action_fired_for_pending <- false
+    | _ -> ())
+
+let current_pending_since ~keeper_name =
+  with_lock (fun () ->
+    match Hashtbl.find_opt state keeper_name with
+    | Some s -> s.pending_since
+    | None -> None)
+
+let reset_all_for_test () =
+  with_lock (fun () -> Hashtbl.clear state)

--- a/lib/context_overflow_action_tracker.mli
+++ b/lib/context_overflow_action_tracker.mli
@@ -1,0 +1,57 @@
+(** Context overflow imminent → action detector (#9935).
+
+    OAS emits three related events per keeper:
+    - [ContextOverflowImminent] when context ≥ threshold (e.g. 95%)
+    - [ContextCompactStarted] when compaction begins
+    - [ContextCompacted] when compaction completes
+
+    Issue #9935 evidence: 45 imminent events per day fleet-wide
+    with no observability on whether any reduction action followed.
+    The scheduler can continue firing turns on an overflowed
+    keeper, which then burns out on the oas_timeout_budget
+    (#9933). This module closes the loop by tracking per-keeper
+    state and emitting metrics when an imminent event goes
+    unanswered within a grace window.
+
+    Design: pure in-memory per-keeper state, single-domain
+    Stdlib.Mutex (no Eio dependency — matches
+    Cascade_health_tracker after #9873). Called from the
+    oas_sse_bridge event translation path, which is serialized
+    per-agent.
+
+    Observability contract:
+    - [masc_context_overflow_imminent_total{keeper=X}] counter
+    - [masc_context_overflow_action_taken_total{keeper=X}] —
+      increments when an action (compact_started or compacted)
+      is observed within [grace_window_seconds ()] of imminent.
+    - [masc_context_overflow_no_action_total{keeper=X}] —
+      increments once when a new imminent arrives with a
+      previous pending imminent still unanswered past the
+      grace window. Latched per episode: re-arms when an
+      action event clears the pending.
+    - A [Log.Server.warn] tagged [#9935] fires on first
+      unanswered episode only. *)
+
+val grace_window_seconds : unit -> float
+(** Time window after [ContextOverflowImminent] during which a
+    compaction/reduction action must land to count as "action
+    taken". Read from [MASC_CONTEXT_OVERFLOW_GRACE_SEC] (default
+    60.0). Re-read on each call; safe for test-time [putenv]. *)
+
+val record_imminent : keeper_name:string -> ts:float -> unit
+(** Call on [ContextOverflowImminent]. Increments the imminent
+    counter and starts the grace timer. If a prior imminent was
+    still pending past the grace window at [ts], fires the
+    no-action counter + warn log (latched so repeated imminent
+    spam does not flood alerts). *)
+
+val record_action : keeper_name:string -> unit
+(** Call on [ContextCompactStarted] or [ContextCompacted]. Clears
+    the pending imminent and increments the action-taken
+    counter. Calls with no pending imminent are silent. *)
+
+val current_pending_since : keeper_name:string -> float option
+(** [Some ts] if there is an unanswered imminent for this keeper;
+    [None] otherwise. Used by tests. *)
+
+val reset_all_for_test : unit -> unit

--- a/lib/dune
+++ b/lib/dune
@@ -51,6 +51,7 @@
    cascade_strategy_trace
    cascade_throttle
    cancellation
+   context_overflow_action_tracker
    gate_keeper_backend
    config
    config_doctor

--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -231,6 +231,9 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
         (wrap ~event_type:"handoff_completed" ~payload ~agent_name:from_agent ())
   | Oas.Event_bus.ContextCompacted
       { agent_name; before_tokens; after_tokens; phase } ->
+      (* #9935: compaction completed — clears any pending
+         imminent and fires action-taken counter. *)
+      Context_overflow_action_tracker.record_action ~keeper_name:agent_name;
       let payload =
         `Assoc
           [
@@ -245,6 +248,13 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
     None  (* Internal; no SSE relay needed *)
   | Oas.Event_bus.ContextOverflowImminent
         { agent_name; estimated_tokens; limit_tokens; ratio } ->
+      (* #9935: track imminent→action pairing so an unanswered
+         overflow (no compact_started/compacted within grace
+         window) is observable via metric + warn log, rather
+         than silently burning out on oas_timeout_budget. *)
+      Context_overflow_action_tracker.record_imminent
+        ~keeper_name:agent_name
+        ~ts:(Time_compat.now ());
       let payload =
         `Assoc [
           ("agent_name", `String agent_name);
@@ -256,6 +266,9 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
       Some (wrap ~event_type:"context_overflow_imminent" ~payload
               ~agent_name ())
   | Oas.Event_bus.ContextCompactStarted { agent_name; trigger } ->
+      (* #9935: compaction started — clears pending imminent
+         and fires action-taken counter. *)
+      Context_overflow_action_tracker.record_action ~keeper_name:agent_name;
       let payload =
         `Assoc [
           ("agent_name", `String agent_name);

--- a/test/dune
+++ b/test/dune
@@ -109,6 +109,7 @@
         test_oas_compat_cascade_fallback
         test_heuristic_metrics_boot_wireup
         test_cap_blocker_structured_error
+        test_context_overflow_action_tracker
         test_keeper_fs_edit_patch
         test_keeper_docker_read
         test_keeper_github_read_only
@@ -233,6 +234,7 @@
           test_oas_compat_cascade_fallback
           test_heuristic_metrics_boot_wireup
           test_cap_blocker_structured_error
+          test_context_overflow_action_tracker
           test_keeper_fs_edit_patch
           test_keeper_docker_read
           test_keeper_github_read_only

--- a/test/test_context_overflow_action_tracker.ml
+++ b/test/test_context_overflow_action_tracker.ml
@@ -1,0 +1,200 @@
+(* test/test_context_overflow_action_tracker.ml
+
+   #9935: detector for imminent→action pairing on context
+   overflow events. Mirrors the #9931 stay_silent detector
+   pattern (latched per-episode counter + per-keeper state).
+
+   Invariants:
+   1. record_imminent increments imminent counter
+   2. record_action within grace → action_taken counter,
+      pending cleared
+   3. New imminent past grace window with prior unanswered →
+      no_action counter (latched once per episode)
+   4. Latch releases when record_action is called → next
+      no-action episode can fire again
+   5. Per-keeper isolation
+   6. Grace window env var honored *)
+
+module T = Masc_mcp.Context_overflow_action_tracker
+module Prom = Masc_mcp.Prometheus
+
+let imminent_count k =
+  Prom.metric_value_or_zero
+    "masc_context_overflow_imminent_total"
+    ~labels:[ ("keeper", k) ] ()
+
+let action_count k =
+  Prom.metric_value_or_zero
+    "masc_context_overflow_action_taken_total"
+    ~labels:[ ("keeper", k) ] ()
+
+let no_action_count k =
+  Prom.metric_value_or_zero
+    "masc_context_overflow_no_action_total"
+    ~labels:[ ("keeper", k) ] ()
+
+let set_grace sec =
+  Unix.putenv "MASC_CONTEXT_OVERFLOW_GRACE_SEC" (Printf.sprintf "%.3f" sec)
+
+let clear_grace () =
+  Unix.putenv "MASC_CONTEXT_OVERFLOW_GRACE_SEC" ""
+
+let test_imminent_increments_counter () =
+  T.reset_all_for_test ();
+  let k = "test-keeper-increments" in
+  let before = imminent_count k in
+  T.record_imminent ~keeper_name:k ~ts:100.0;
+  Alcotest.(check (float 0.0001))
+    "imminent counter +1"
+    (before +. 1.0) (imminent_count k);
+  Alcotest.(check (option (float 0.0001)))
+    "pending_since set"
+    (Some 100.0) (T.current_pending_since ~keeper_name:k)
+
+let test_action_within_grace_clears_pending () =
+  T.reset_all_for_test ();
+  let k = "test-keeper-action-within-grace" in
+  let action_before = action_count k in
+  T.record_imminent ~keeper_name:k ~ts:100.0;
+  T.record_action ~keeper_name:k;
+  Alcotest.(check (option (float 0.0001)))
+    "pending cleared"
+    None (T.current_pending_since ~keeper_name:k);
+  Alcotest.(check (float 0.0001))
+    "action counter +1"
+    (action_before +. 1.0) (action_count k)
+
+let test_action_with_no_pending_is_silent () =
+  T.reset_all_for_test ();
+  let k = "test-keeper-action-no-pending" in
+  let before = action_count k in
+  T.record_action ~keeper_name:k;
+  Alcotest.(check (float 0.0001))
+    "action counter unchanged (no pending)"
+    before (action_count k)
+
+let test_no_action_past_grace_fires_latched () =
+  T.reset_all_for_test ();
+  let k = "test-keeper-no-action-latch" in
+  set_grace 10.0;
+  let before = no_action_count k in
+  (* First imminent at t=100 *)
+  T.record_imminent ~keeper_name:k ~ts:100.0;
+  Alcotest.(check (float 0.0001))
+    "no no-action fire yet (no new imminent arrived)"
+    before (no_action_count k);
+  (* Second imminent at t=115, grace=10 → prior is 15s old *)
+  T.record_imminent ~keeper_name:k ~ts:115.0;
+  Alcotest.(check (float 0.0001))
+    "no-action counter +1"
+    (before +. 1.0) (no_action_count k);
+  (* Third imminent at t=130, still same unanswered episode *)
+  T.record_imminent ~keeper_name:k ~ts:130.0;
+  Alcotest.(check (float 0.0001))
+    "latched: no-action does NOT re-fire"
+    (before +. 1.0) (no_action_count k);
+  clear_grace ()
+
+let test_latch_releases_on_action () =
+  T.reset_all_for_test ();
+  let k = "test-keeper-latch-release" in
+  set_grace 10.0;
+  let before = no_action_count k in
+  (* Episode 1: imminent -> no action -> late imminent fires counter *)
+  T.record_imminent ~keeper_name:k ~ts:100.0;
+  T.record_imminent ~keeper_name:k ~ts:115.0;
+  Alcotest.(check (float 0.0001))
+    "episode 1 fired"
+    (before +. 1.0) (no_action_count k);
+  (* Action arrives — latch should release *)
+  T.record_action ~keeper_name:k;
+  (* Episode 2: imminent, then another past-grace imminent *)
+  T.record_imminent ~keeper_name:k ~ts:200.0;
+  T.record_imminent ~keeper_name:k ~ts:215.0;
+  Alcotest.(check (float 0.0001))
+    "episode 2 fires once more"
+    (before +. 2.0) (no_action_count k);
+  clear_grace ()
+
+let test_action_within_grace_does_not_fire_no_action () =
+  T.reset_all_for_test ();
+  let k = "test-keeper-within-grace-clean" in
+  set_grace 30.0;
+  let before = no_action_count k in
+  T.record_imminent ~keeper_name:k ~ts:100.0;
+  (* Action arrives within grace, then a fresh imminent much later *)
+  T.record_action ~keeper_name:k;
+  T.record_imminent ~keeper_name:k ~ts:300.0;
+  Alcotest.(check (float 0.0001))
+    "no_action NOT fired (prior was cleared)"
+    before (no_action_count k);
+  clear_grace ()
+
+let test_per_keeper_isolation () =
+  T.reset_all_for_test ();
+  let a = "test-keeper-A" in
+  let b = "test-keeper-B" in
+  set_grace 10.0;
+  T.record_imminent ~keeper_name:a ~ts:100.0;
+  T.record_imminent ~keeper_name:b ~ts:100.0;
+  T.record_action ~keeper_name:a;
+  Alcotest.(check (option (float 0.0001)))
+    "A cleared" None (T.current_pending_since ~keeper_name:a);
+  Alcotest.(check (option (float 0.0001)))
+    "B still pending"
+    (Some 100.0) (T.current_pending_since ~keeper_name:b);
+  clear_grace ()
+
+let test_grace_default () =
+  clear_grace ();
+  Alcotest.(check (float 0.01)) "default 60s" 60.0
+    (T.grace_window_seconds ())
+
+let test_grace_custom () =
+  set_grace 15.0;
+  Alcotest.(check (float 0.01)) "custom 15s" 15.0
+    (T.grace_window_seconds ());
+  Unix.putenv "MASC_CONTEXT_OVERFLOW_GRACE_SEC" "bogus";
+  Alcotest.(check (float 0.01))
+    "invalid → default" 60.0 (T.grace_window_seconds ());
+  Unix.putenv "MASC_CONTEXT_OVERFLOW_GRACE_SEC" "-5";
+  Alcotest.(check (float 0.01))
+    "negative → default" 60.0 (T.grace_window_seconds ());
+  clear_grace ()
+
+let () =
+  Alcotest.run "context_overflow_action_tracker"
+    [
+      ( "imminent",
+        [
+          Alcotest.test_case "increments counter" `Quick
+            test_imminent_increments_counter;
+        ] );
+      ( "action pairing",
+        [
+          Alcotest.test_case "within grace clears pending" `Quick
+            test_action_within_grace_clears_pending;
+          Alcotest.test_case "no pending → silent" `Quick
+            test_action_with_no_pending_is_silent;
+          Alcotest.test_case "action within grace does NOT fire no-action"
+            `Quick test_action_within_grace_does_not_fire_no_action;
+        ] );
+      ( "no-action latch",
+        [
+          Alcotest.test_case "past grace fires once" `Quick
+            test_no_action_past_grace_fires_latched;
+          Alcotest.test_case "latch releases on action" `Quick
+            test_latch_releases_on_action;
+        ] );
+      ( "per-keeper isolation",
+        [
+          Alcotest.test_case "A and B independent" `Quick
+            test_per_keeper_isolation;
+        ] );
+      ( "grace env var",
+        [
+          Alcotest.test_case "default 60s" `Quick test_grace_default;
+          Alcotest.test_case "custom + invalid fallback" `Quick
+            test_grace_custom;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- Adds phase-1 observability for pairing `context_overflow_imminent` with compaction action signals.
- Wires the event-bus bridge to record imminent, compact-started, and compacted events without changing SSE payload shape.
- Adds latched per-keeper counters to avoid repeated no-action floods for the same stuck episode.

## Validation
- CI run 24887136042 passed: Build and Test, Health, Lint, Meta Guards, TLA+ Model Checking, and CI Gate.
- Dashboard was skipped by changed-surface detection.
