### PR TITLE
test(mcp-server-eio): compare clock resources, not Result wrappers (#9709)

### DIFF
--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -386,11 +386,20 @@ let test_eio_context_delegation () =
   Mcp_eio.set_net net;
   Mcp_eio.set_clock clock;
   let delegated_net = Eio_context.get_net_opt () in
+  (* Compare the underlying clock resource, not the Result wrappers.
+     Each call to get_clock allocates a fresh [Ok _] box, so
+     [Ok a] == [Ok b] is always false even when [a == b]. See #9709. *)
+  let direct_clock = Eio_context.get_clock () in
   let alias_clock = Mcp_eio.get_clock () in
+  let clock_delegated =
+    match direct_clock, alias_clock with
+    | Ok a, Ok b -> a == b
+    | _, _ -> false
+  in
   Alcotest.(check bool) "net delegated to shared Eio_context" true
     (Option.is_some delegated_net);
   Alcotest.(check bool) "clock delegated to shared Eio_context" true
-    (Eio_context.get_clock () == alias_clock)
+    clock_delegated
 
 let option_ref_equal left right =
   match left, right with


### PR DESCRIPTION
## 요약

`test_eio_context_delegation`가 `Eio_context.get_clock ()`와 `Mcp_eio.get_clock ()`의 반환값을 `==`로 비교했습니다. 두 함수 모두 `(clock, string) result` 타입을 반환하고, 각 호출마다 새 `Ok _` wrapper를 allocate하므로 내부 clock이 동일해도 `[Ok a] == [Ok b]`는 항상 false. 실제 delegation은 정상 동작하는데도 테스트만 실패했습니다.

Closes #9709.

## 변경 내용

```diff
  let direct_clock = Eio_context.get_clock () in
  let alias_clock = Mcp_eio.get_clock () in
+ let clock_delegated =
+   match direct_clock, alias_clock with
+   | Ok a, Ok b -> a == b
+   | _, _ -> false
+ in
  Alcotest.(check bool) "clock delegated to shared Eio_context" true
-   (Eio_context.get_clock () == alias_clock)
+   clock_delegated
```

Result를 분해해 내부 resource만 `==` 비교. 의도한 assertion을 그대로 검증.

## 검증

로컬 실행 (test isolation guard bypass 사용):

```bash
MASC_BASE_PATH=/tmp/masc-test-$$ MASC_TEST_ALLOW_HOME_BASE_PATH=1 \
  dune exec --root . test/test_mcp_server_eio.exe
```

결과:
- `[OK] state 2 eio context delegation` ✅ (이전: FAIL)
- 남은 실패 `eio 45 explicit alias reuses joined nickname`은 별도 이슈 #9874 범위.

## 회귀 리스크

매우 낮음 — 테스트 조건 한 줄의 로직만 변경. production code 수정 없음. 다른 테스트에 영향 없음.

## 참고

- Issue #9709 — 증상 및 suggested cause
- 관련 이슈 #9874 — 같은 파일의 다른 pre-existing failure (`eio 45`), 별도 PR 대상
