### PR TITLE
fix(mcp): align persona generation timeout

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -287,6 +287,11 @@ let tool_timeout_sec_opt ~(tool_name : string) ~(_arguments : Yojson.Safe.t) : f
          mutation continues in the background, leaving caller-visible status
          out of sync with persisted task state. *)
       None
+  | "masc_persona_generate" ->
+      (* Persona generation runs an OAS worker with its own 120s budget. Keep
+         the outer MCP tools/call timeout above that budget so callers see the
+         generation result or the OAS error instead of a premature MCP timeout. *)
+      Some 150.0
   | _ ->
       let global_default_sec =
         float_of_int

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -96,6 +96,17 @@ let test_transition_has_no_fixed_timeout () =
        ~_arguments:(`Assoc [])
      = None)
 
+let test_persona_generate_timeout_exceeds_oas_budget () =
+  match
+    Masc_mcp.Mcp_server_eio_call_tool.tool_timeout_sec_opt
+      ~tool_name:"masc_persona_generate"
+      ~_arguments:(`Assoc [])
+  with
+  | Some timeout_sec ->
+      check bool "persona generate timeout exceeds internal OAS budget" true
+        (timeout_sec > 120.)
+  | None -> fail "expected persona generation to keep a bounded outer timeout"
+
 let test_regular_tool_uses_default_timeout () =
   match
     Masc_mcp.Mcp_server_eio_call_tool.tool_timeout_sec_opt
@@ -245,6 +256,8 @@ let () =
           test_case "generic failure is error" `Quick test_generic_failure_quality_is_error;
           test_case "success has no issues" `Quick test_success_quality_has_no_issues;
           test_case "transition has no fixed timeout" `Quick test_transition_has_no_fixed_timeout;
+          test_case "persona generate timeout exceeds OAS budget" `Quick
+            test_persona_generate_timeout_exceeds_oas_budget;
           test_case "regular tool keeps default timeout" `Quick test_regular_tool_uses_default_timeout;
           test_case "runtime MCP log context uses keeper trace/current turn" `Quick
             test_runtime_mcp_keeper_log_context_uses_keeper_trace_and_current_turn;


### PR DESCRIPTION
## Summary
- raise the outer tools/call timeout for masc_persona_generate above its internal 120s OAS generation budget
- add a focused regression covering the persona generation timeout policy

## Verification
- DUNE_LOCAL_JOBS=2 scripts/dune-local.sh build test/test_mcp_server_eio_call_tool.exe
- env MASC_BASE_PATH=/tmp/masc-test-mcp-call-tool _build/default/test/test_mcp_server_eio_call_tool.exe