### PR TITLE
perf(dashboard): defer status and hot-path modules

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -7,7 +7,6 @@ import type {
   OperatorDigest,
   OperatorSnapshot,
 } from '../types'
-import { parseOperatorActionResult } from './schemas/operator-action'
 import { sanitizeDashboardActorName } from '../lib/dashboard-actor'
 import {
   currentDashboardActorName,
@@ -650,6 +649,7 @@ export async function runOperatorAction(body: OperatorActionRequest): Promise<Op
     authHeaders({ actorName: body.actor }),
     operatorActionTimeoutMs(body),
   )
+  const { parseOperatorActionResult } = await import('./schemas/operator-action')
   return parseOperatorActionResult(raw)
 }
 
@@ -667,6 +667,7 @@ export async function confirmOperatorAction(
     },
     authHeaders({ actorName: actor }),
   )
+  const { parseOperatorActionResult } = await import('./schemas/operator-action')
   return parseOperatorActionResult(raw)
 }
 

--- a/dashboard/src/api/dashboard-hot.ts
+++ b/dashboard/src/api/dashboard-hot.ts
@@ -1,0 +1,27 @@
+import { get, NAMESPACE_TRUTH_GET_TIMEOUT_MS } from './core'
+import type {
+  DashboardNamespaceTruthResponse,
+  DashboardShellResponse,
+} from '../types'
+
+type AbortableRequestOptions = {
+  signal?: AbortSignal
+}
+
+type DashboardShellRequestOptions = AbortableRequestOptions & {
+  light?: boolean
+}
+
+export function fetchDashboardShell(opts?: DashboardShellRequestOptions): Promise<DashboardShellResponse> {
+  const qs = opts?.light ? '?light=true' : ''
+  return get(`/api/v1/dashboard/shell${qs}`, { signal: opts?.signal })
+}
+
+export function fetchDashboardNamespaceTruth(
+  opts?: AbortableRequestOptions,
+): Promise<DashboardNamespaceTruthResponse> {
+  return get('/api/v1/dashboard/project-snapshot', {
+    timeoutMs: NAMESPACE_TRUTH_GET_TIMEOUT_MS,
+    signal: opts?.signal,
+  })
+}

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -93,6 +93,7 @@ export type {
   CascadeStrategyTraceResponse,
   CascadeValidationStatus,
 } from './dashboard-cascade'
+export { reportToolHostFailure } from './tool-host-failure'
 
 // --- Dashboard projections ---
 
@@ -130,25 +131,6 @@ export async function fetchLogs(opts?: {
   const qs = params.toString()
   const raw = await get<unknown>(`/api/v1/dashboard/logs${qs ? `?${qs}` : ''}`)
   return parseLogsResponse(raw)
-}
-
-interface ToolHostFailureReport {
-  agent_name?: string
-  client_name?: string
-  tool_name: string
-  transport?: string
-  phase?: string
-  message: string
-  request_id?: string
-  session_id?: string
-  trace_id?: string
-  timeout_ms?: number
-}
-
-export function reportToolHostFailure(
-  report: ToolHostFailureReport,
-): Promise<{ ok: boolean }> {
-  return post('/api/v1/dashboard/logs/tool-host-failures', report, undefined, 3000)
 }
 
 export type { AgentTimelineEvent, AgentTimelineResponse }

--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -45,7 +45,7 @@ vi.mock('./core', () => ({
   setStoredToken,
 }))
 
-vi.mock('./dashboard', () => ({
+vi.mock('./tool-host-failure', () => ({
   reportToolHostFailure,
 }))
 

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -17,7 +17,7 @@ import {
   MCP_INITIALIZE_TIMEOUT_MS,
   MCP_INITIALIZED_NOTIFY_TIMEOUT_MS,
 } from '../config/constants'
-import { reportToolHostFailure } from './dashboard'
+import { reportToolHostFailure } from './tool-host-failure'
 import { showActionToast } from '../components/common/toast'
 
 // --- MCP Session Management ---

--- a/dashboard/src/api/tool-host-failure.ts
+++ b/dashboard/src/api/tool-host-failure.ts
@@ -1,0 +1,20 @@
+import { post } from './core'
+
+interface ToolHostFailureReport {
+  agent_name?: string
+  client_name?: string
+  tool_name: string
+  transport?: string
+  phase?: string
+  message: string
+  request_id?: string
+  session_id?: string
+  trace_id?: string
+  timeout_ms?: number
+}
+
+export function reportToolHostFailure(
+  report: ToolHostFailureReport,
+): Promise<{ ok: boolean }> {
+  return post('/api/v1/dashboard/logs/tool-host-failures', report, undefined, 3000)
+}

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -16,7 +16,6 @@ import {
 import { requestNamespaceTruthNow, disposeNamespaceTruthScheduler } from './namespace-truth-store'
 import { cancelPendingSSERefreshes, registerMissionRefresh, setupSSEReaction, startPeriodicRefresh, stopPeriodicRefresh } from './sse-store'
 import { refreshMissionSnapshot } from './mission-store'
-import { replayOasRuntimeTelemetry } from './oas-runtime-store'
 import { refreshShell } from './store'
 import { connectDashboardWS, disconnectDashboardWS, subscribeDashboardRoute } from './dashboard-ws'
 import { ensureDevToken } from './api/mcp'
@@ -32,7 +31,6 @@ import { selectedAgentName } from './components/agent-detail-selection'
 import { selectedTask } from './components/goals/task-detail-selection'
 import { ToastContainer } from './components/common/toast'
 import { ConfirmDialogOverlay } from './components/common/confirm-dialog'
-import { CommandPalette } from './components/common/command-palette'
 import { AuthStatus, RemoteWarningBanner } from './components/auth-status'
 import { startErrorCleanup, stopErrorCleanup } from './components/common/error-notification-state'
 import { DASHBOARD_NAV_ITEMS, currentSectionForRoute } from './config/navigation'
@@ -51,6 +49,9 @@ const LazyAgentDetailOverlay = lazy(async () => ({
 }))
 const LazyTaskDetailOverlay = lazy(async () => ({
   default: (await import('./components/goals/task-detail-overlay')).TaskDetailOverlay,
+}))
+const LazyCommandPalette = lazy(async () => ({
+  default: (await import('./components/common/command-palette')).CommandPalette,
 }))
 
 function refreshCurrentRoute(options?: { recordVisit?: boolean }): void {
@@ -78,7 +79,8 @@ export function App() {
 
     // Replay durable OAS state before opening the live SSE tail.
     pauseQueuedOasRuntimeIngress()
-    void replayOasRuntimeTelemetry()
+    void import('./oas-runtime-store')
+      .then(({ replayOasRuntimeTelemetry }) => replayOasRuntimeTelemetry())
       .catch(err => {
         console.warn('[app] OAS runtime replay failed', err instanceof Error ? err.message : err)
       })
@@ -200,7 +202,9 @@ export function App() {
         : null}
       <${ToastContainer} />
       <${ConfirmDialogOverlay} />
-      <${CommandPalette} />
+      <${Suspense} fallback=${null}>
+        <${LazyCommandPalette} />
+      <//>
     </div>
   `
 }

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -7,7 +7,6 @@ import { connected, reconnectCount, lastDisconnectedAt } from '../sse'
 import { dashboardLoading, serverStatus } from '../store'
 import { missionSnapshot, missionLoading } from '../mission-store'
 import { namespaceTruthInitializing } from '../namespace-truth-store'
-import { Overview } from './overview/overview'
 import { ErrorBoundary } from './common/error-boundary'
 import { TimeAgo } from './common/time-ago'
 import { LoadingState } from './common/feedback-state'
@@ -29,6 +28,7 @@ import { Bell } from 'lucide-preact'
 
 const buildIdentityOpen = signal(false)
 
+const LazyOverview = lazy(async () => ({ default: (await import('./overview/overview')).Overview }))
 const LazyStatus = lazy(async () => ({ default: (await import('./status')).Status }))
 const LazyWork = lazy(async () => ({ default: (await import('./work')).Work }))
 const LazyOperations = lazy(async () => ({ default: (await import('./control')).Operations }))
@@ -467,7 +467,11 @@ function TabContent() {
 
   switch (tab) {
     case 'overview':
-      return html`<${Overview} />`
+      return html`
+        <${Suspense} fallback=${lazyTabFallback('개요 화면')}>
+          <${LazyOverview} />
+        <//>
+      `
     case 'monitoring':
       return html`
         <${Suspense} fallback=${lazyTabFallback('모니터링 화면')}>
@@ -505,7 +509,11 @@ function TabContent() {
         <//>
       `
     default:
-      return html`<${Overview} />`
+      return html`
+        <${Suspense} fallback=${lazyTabFallback('개요 화면')}>
+          <${LazyOverview} />
+        <//>
+      `
   }
 }
 

--- a/dashboard/src/components/observatory/observatory.test.ts
+++ b/dashboard/src/components/observatory/observatory.test.ts
@@ -2,6 +2,7 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
 import { signal } from '@preact/signals'
+import { waitFor } from '@testing-library/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const fetchTelemetry = vi.fn().mockResolvedValue({
@@ -102,7 +103,9 @@ describe('Observatory', () => {
 
     expect(fetchTelemetry).toHaveBeenCalledTimes(1)
     expect(fetchToolQuality).toHaveBeenCalledTimes(1)
-    expect(container.textContent).toContain('activity-panels-stub')
+    await waitFor(() => {
+      expect(container.textContent).toContain('activity-panels-stub')
+    })
     expect(container.textContent).not.toContain('live-monitor-stub')
     expect(container.textContent).toContain('최근 1시간')
     expect(container.textContent).toContain('자동 갱신')
@@ -129,7 +132,9 @@ describe('Observatory', () => {
     })
     await flushUi()
 
-    expect(container.textContent).toContain('live-monitor-stub')
+    await waitFor(() => {
+      expect(container.textContent).toContain('live-monitor-stub')
+    })
     expect(container.textContent).not.toContain('activity-panels-stub')
     expect(container.textContent).toContain('실시간 스트림과 에이전트 상태를 한곳에서 봅니다.')
 

--- a/dashboard/src/components/observatory/observatory.ts
+++ b/dashboard/src/components/observatory/observatory.ts
@@ -14,6 +14,7 @@
 
 import { html } from 'htm/preact'
 import { signal, useSignal } from '@preact/signals'
+import { lazy, Suspense } from 'preact/compat'
 import { useEffect, useRef } from 'preact/hooks'
 import {
   currentKeeperFilter,
@@ -40,12 +41,21 @@ import { CrossSignalReadout } from './cross-signal-readout'
 import { DetailPane } from './detail-pane'
 import { cursorPosition } from './cursor-store'
 import { LoadingState } from '../common/feedback-state'
-import { Live } from '../live'
-import { ObservatoryActivityPanels } from '../activity-graph'
 
 const DEFAULT_RANGE: TimeRangePreset = '1h'
 const observatoryRefreshVersion = signal(0)
 type ObservatoryView = 'timeline' | 'live'
+
+const LazyLive = lazy(async () => ({
+  default: (await import('../live')).Live,
+}))
+const LazyObservatoryActivityPanels = lazy(async () => ({
+  default: (await import('../activity-graph')).ObservatoryActivityPanels,
+}))
+
+function lazyObservatoryFallback(label: string) {
+  return html`<${LoadingState}>${label} 불러오는 중...<//>`
+}
 
 // --- Observatory state ---
 
@@ -311,7 +321,11 @@ export function Observatory() {
       ` : null}
 
       ${activeView.value === 'live'
-        ? html`<${Live} variant="observatory" />`
+        ? html`
+            <${Suspense} fallback=${lazyObservatoryFallback('라이브 모니터')}>
+              <${LazyLive} variant="observatory" />
+            <//>
+          `
         : !hasTrackData && data.loading
         ? html`<${LoadingState}>관찰소 데이터 불러오는 중...<//>`
         : html`
@@ -348,7 +362,13 @@ export function Observatory() {
             <${DetailPane} />
           `}
 
-      ${activeView.value === 'timeline' ? html`<${ObservatoryActivityPanels} />` : null}
+      ${activeView.value === 'timeline'
+        ? html`
+            <${Suspense} fallback=${lazyObservatoryFallback('활동 분석 패널')}>
+              <${LazyObservatoryActivityPanels} />
+            <//>
+          `
+        : null}
 
       ${activeView.value === 'timeline' ? html`
         <p class="text-3xs text-text-dim italic">

--- a/dashboard/src/components/session-trace/session-trace-live-store.ts
+++ b/dashboard/src/components/session-trace/session-trace-live-store.ts
@@ -1,0 +1,94 @@
+import { signal } from '@preact/signals'
+import type { UnifiedTraceEvent } from './session-trace-state'
+
+export const liveTraceFeeds = signal<Record<string, UnifiedTraceEvent[]>>({})
+
+const LIVE_TRACE_LIMIT = 120
+let liveTraceSeq = 0
+let traceOpenProvider: ((agentName: string) => boolean) | null = null
+let historicalIdsProvider: ((agentName: string) => string[]) | null = null
+
+export function registerLiveTraceSlotProvider(
+  provider: (agentName: string) => boolean,
+): void {
+  traceOpenProvider = provider
+}
+
+export function registerLiveTraceHistoricalIdsProvider(
+  provider: (agentName: string) => string[],
+): void {
+  historicalIdsProvider = provider
+}
+
+export function ensureLiveTraceSlot(agentName: string): void {
+  if (liveTraceFeeds.value[agentName]) return
+  liveTraceFeeds.value = { ...liveTraceFeeds.value, [agentName]: [] }
+}
+
+export function deleteLiveTraceSlot(agentName: string): void {
+  const feeds = { ...liveTraceFeeds.value }
+  delete feeds[agentName]
+  liveTraceFeeds.value = feeds
+}
+
+/** Append a live MASC tool call event from SSE into the trace feed. */
+export function appendLiveToolCall(
+  agentName: string,
+  evt: {
+    toolName: string
+    durationMs: number
+    success: boolean
+    error: string | null
+    tsUnix: number
+  },
+): void {
+  const tsMs = evt.tsUnix * 1000
+  appendLiveTraceEvent(agentName, {
+    id: `live-masc-tool-${tsMs}-${evt.toolName}`,
+    ts: tsMs,
+    ts_iso: new Date(tsMs).toISOString(),
+    kind: 'tool_call',
+    sourceLane: 'masc',
+    summary: evt.toolName,
+    detail: {},
+    agentName,
+    toolName: evt.toolName,
+    duration_ms: evt.durationMs,
+    error: evt.error,
+  })
+}
+
+/** Append a live OAS runtime event from SSE into the trace feed. */
+export function appendLiveOasEvent(
+  agentName: string,
+  event: Omit<UnifiedTraceEvent, 'sourceLane' | 'agentName'>,
+): void {
+  appendLiveTraceEvent(agentName, {
+    ...event,
+    sourceLane: 'oas',
+    agentName,
+  })
+}
+
+function appendLiveTraceEvent(agentName: string, event: UnifiedTraceEvent): void {
+  if (!liveTraceFeeds.value[agentName]) {
+    if (!traceOpenProvider?.(agentName)) return
+    ensureLiveTraceSlot(agentName)
+  }
+  const prev = liveTraceFeeds.value[agentName] ?? []
+  const historicalIds = historicalIdsProvider?.(agentName) ?? []
+  const seenIds = new Set([
+    ...historicalIds,
+    ...prev.map(item => item.id),
+  ])
+  const uniqueEvent =
+    seenIds.has(event.id)
+      ? { ...event, id: `${event.id}-${++liveTraceSeq}` }
+      : event
+  const next = [...prev, uniqueEvent]
+  const pruned =
+    next.length > LIVE_TRACE_LIMIT
+      ? next.slice(next.length - LIVE_TRACE_LIMIT)
+      : next
+  liveTraceFeeds.value = { ...liveTraceFeeds.value, [agentName]: pruned }
+}

--- a/dashboard/src/components/session-trace/session-trace-state.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.ts
@@ -11,6 +11,13 @@ import {
   fetchKeeperToolCalls,
   fetchKeeperTrajectory,
 } from '../../api/dashboard'
+import {
+  deleteLiveTraceSlot,
+  ensureLiveTraceSlot,
+  liveTraceFeeds,
+  registerLiveTraceHistoricalIdsProvider,
+  registerLiveTraceSlotProvider,
+} from './session-trace-live-store'
 import type {
   AgentTimelineEvent,
   AgentTimelineResponse,
@@ -97,13 +104,15 @@ interface TraceSlot {
 // ── Per-agent state map ────────────────────────────────
 
 const traceSlots = signal<Record<string, TraceSlot>>({})
-const liveTraceFeeds = signal<Record<string, UnifiedTraceEvent[]>>({})
 
 const EMPTY_SLOT: TraceSlot = { events: [], loading: false, error: null, filter: 'all', statusFilter: 'all', searchQuery: '', fetchToken: 0 }
 
-const LIVE_TRACE_LIMIT = 120
 const TOOL_CALL_MATCH_WINDOW_MS = 2000
-let liveTraceSeq = 0
+
+registerLiveTraceHistoricalIdsProvider((agentName) =>
+  traceSlots.value[agentName]?.events.map(item => item.id) ?? [],
+)
+registerLiveTraceSlotProvider((agentName) => traceSlots.value[agentName] != null)
 
 function getSlot(agent: string): TraceSlot {
   return traceSlots.value[agent] ?? EMPTY_SLOT
@@ -769,9 +778,7 @@ export async function loadSessionTrace(agentName: string, isKeeper: boolean): Pr
   const prevSlot = getSlot(agentName)
   const token = prevSlot.fetchToken + 1
   patchSlot(agentName, { loading: true, error: null, fetchToken: token })
-  if (!liveTraceFeeds.value[agentName]) {
-    liveTraceFeeds.value = { ...liveTraceFeeds.value, [agentName]: [] }
-  }
+  ensureLiveTraceSlot(agentName)
 
   try {
     const timelinePromise = fetchAgentTimeline(agentName, TIMELINE_HOURS, TIMELINE_LIMIT)
@@ -808,70 +815,11 @@ export async function loadSessionTrace(agentName: string, isKeeper: boolean): Pr
   }
 }
 
-/** Append a live MASC tool call event from SSE into the trace feed. */
-export function appendLiveToolCall(
-  agentName: string,
-  evt: {
-    toolName: string
-    durationMs: number
-    success: boolean
-    error: string | null
-    tsUnix: number
-  },
-): void {
-  const tsMs = evt.tsUnix * 1000
-  appendLiveTraceEvent(agentName, {
-    id: `live-masc-tool-${tsMs}-${evt.toolName}`,
-    ts: tsMs,
-    ts_iso: new Date(tsMs).toISOString(),
-    kind: 'tool_call',
-    sourceLane: 'masc',
-    summary: evt.toolName,
-    detail: {},
-    agentName,
-    toolName: evt.toolName,
-    duration_ms: evt.durationMs,
-    error: evt.error,
-  })
-}
-
-/** Append a live OAS runtime event from SSE into the trace feed. */
-export function appendLiveOasEvent(
-  agentName: string,
-  event: Omit<UnifiedTraceEvent, 'sourceLane' | 'agentName'>,
-): void {
-  appendLiveTraceEvent(agentName, {
-    ...event,
-    sourceLane: 'oas',
-    agentName,
-  })
-}
-
-function appendLiveTraceEvent(agentName: string, event: UnifiedTraceEvent): void {
-  if (!traceSlots.value[agentName] && !liveTraceFeeds.value[agentName]) return
-  const prev = liveTraceFeeds.value[agentName] ?? []
-  const historical = traceSlots.value[agentName]?.events ?? []
-  const seenIds = new Set([
-    ...historical.map(item => item.id),
-    ...prev.map(item => item.id),
-  ])
-  const uniqueEvent =
-    seenIds.has(event.id)
-      ? { ...event, id: `${event.id}-${++liveTraceSeq}` }
-      : event
-  const next = [...prev, uniqueEvent]
-  const pruned =
-    next.length > LIVE_TRACE_LIMIT
-      ? next.slice(next.length - LIVE_TRACE_LIMIT)
-      : next
-  liveTraceFeeds.value = { ...liveTraceFeeds.value, [agentName]: pruned }
-}
+export { appendLiveOasEvent, appendLiveToolCall } from './session-trace-live-store'
 
 export function closeSessionTrace(agentName: string): void {
   const next = { ...traceSlots.value }
   delete next[agentName]
   traceSlots.value = next
-  const feeds = { ...liveTraceFeeds.value }
-  delete feeds[agentName]
-  liveTraceFeeds.value = feeds
+  deleteLiveTraceSlot(agentName)
 }

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -3,20 +3,85 @@
 // fleet-health (FilterChips unified panel), memory-subsystems.
 
 import { html } from 'htm/preact'
+import { lazy, Suspense } from 'preact/compat'
 import { route } from '../router'
-import { AgentsUnified } from './agents-unified'
-import { RuntimePanel } from './runtime-panel'
-import { MemorySubsystems } from './memory-subsystems'
-import { FleetHealthPanel } from './fleet-health-panel'
-import { Observatory } from './observatory/observatory'
-import { AttributionPanel } from './attribution-panel'
-import { JourneyPanel } from './journey-panel'
-import { SafeAutonomyPanel } from './safe-autonomy'
+import { LoadingState } from './common/feedback-state'
 
 type StatusSection =
   | 'observatory' | 'journey' | 'agents' | 'runtime' | 'fleet-health'
   | 'safe-autonomy'
   | 'memory-subsystems' | 'attribution'
+
+const LazyAgentsUnified = lazy(async () => ({
+  default: (await import('./agents-unified')).AgentsUnified,
+}))
+const LazyRuntimePanel = lazy(async () => ({
+  default: (await import('./runtime-panel')).RuntimePanel,
+}))
+const LazyMemorySubsystems = lazy(async () => ({
+  default: (await import('./memory-subsystems')).MemorySubsystems,
+}))
+const LazyFleetHealthPanel = lazy(async () => ({
+  default: (await import('./fleet-health-panel')).FleetHealthPanel,
+}))
+const LazyObservatory = lazy(async () => ({
+  default: (await import('./observatory/observatory')).Observatory,
+}))
+const LazyAttributionPanel = lazy(async () => ({
+  default: (await import('./attribution-panel')).AttributionPanel,
+}))
+const LazyJourneyPanel = lazy(async () => ({
+  default: (await import('./journey-panel')).JourneyPanel,
+}))
+const LazySafeAutonomyPanel = lazy(async () => ({
+  default: (await import('./safe-autonomy')).SafeAutonomyPanel,
+}))
+
+function sectionFallback(label: string) {
+  return html`<${LoadingState}>${label} 불러오는 중...<//>`
+}
+
+function sectionLabel(section: StatusSection): string {
+  switch (section) {
+    case 'observatory':
+      return '관찰소'
+    case 'journey':
+      return '여정'
+    case 'runtime':
+      return '런타임'
+    case 'fleet-health':
+      return 'Fleet Health'
+    case 'safe-autonomy':
+      return 'Safe Autonomy'
+    case 'memory-subsystems':
+      return '메모리 서브시스템'
+    case 'attribution':
+      return '기여 분석'
+    case 'agents':
+      return '에이전트 상태'
+  }
+}
+
+function renderSection(section: StatusSection) {
+  switch (section) {
+    case 'observatory':
+      return html`<${LazyObservatory} />`
+    case 'journey':
+      return html`<${LazyJourneyPanel} />`
+    case 'runtime':
+      return html`<${LazyRuntimePanel} />`
+    case 'fleet-health':
+      return html`<${LazyFleetHealthPanel} />`
+    case 'safe-autonomy':
+      return html`<${LazySafeAutonomyPanel} />`
+    case 'memory-subsystems':
+      return html`<${LazyMemorySubsystems} />`
+    case 'attribution':
+      return html`<${LazyAttributionPanel} />`
+    case 'agents':
+      return html`<${LazyAgentsUnified} />`
+  }
+}
 
 function currentSection(): StatusSection {
   const section = route.value.params.section
@@ -38,21 +103,9 @@ export function Status() {
   return html`
     <div class="flex flex-col gap-5">
       <div class="transition-opacity duration-300">
-        ${section === 'observatory'
-          ? html`<${Observatory} />`
-          : section === 'journey'
-            ? html`<${JourneyPanel} />`
-          : section === 'runtime'
-            ? html`<${RuntimePanel} />`
-          : section === 'fleet-health'
-            ? html`<${FleetHealthPanel} />`
-          : section === 'safe-autonomy'
-            ? html`<${SafeAutonomyPanel} />`
-          : section === 'memory-subsystems'
-            ? html`<${MemorySubsystems} />`
-          : section === 'attribution'
-            ? html`<${AttributionPanel} />`
-            : html`<${AgentsUnified} />`}
+        <${Suspense} fallback=${sectionFallback(sectionLabel(section))}>
+          ${renderSection(section)}
+        <//>
       </div>
     </div>
   `

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -1,9 +1,9 @@
+import { callMcpTool } from './api/mcp'
+import { runOperatorAction } from './api/core'
 import {
-  callMcpTool,
-  runOperatorAction,
   sendKeeperMessageDetailed,
   streamKeeperMessage,
-} from './api'
+} from './api/keeper'
 import { invalidateDashboardCache, refreshDashboard } from './store'
 import type {
   KeeperConversationDelivery,

--- a/dashboard/src/mission-actions.test.ts
+++ b/dashboard/src/mission-actions.test.ts
@@ -7,6 +7,7 @@ const apiMocks = vi.hoisted(() => ({
 }))
 
 vi.mock('./api', () => apiMocks)
+vi.mock('./api/dashboard', () => apiMocks)
 
 const missionPayload = {
   generated_at: '2026-03-25T09:00:00Z',

--- a/dashboard/src/mission-actions.ts
+++ b/dashboard/src/mission-actions.ts
@@ -1,8 +1,3 @@
-import {
-  fetchDashboardMission,
-  fetchDashboardMissionBriefing,
-  fetchDashboardMissionSession,
-} from './api'
 import { isAbortError } from './lib/async-state'
 import {
   missionSnapshot,
@@ -55,6 +50,7 @@ export async function refreshMissionSnapshot(
   missionError.value = null
   inflightMissionSnapshotRefresh = (async () => {
     try {
+      const { fetchDashboardMission } = await import('./api/dashboard')
       const raw = await fetchDashboardMission()
       const normalized = normalizeMission(raw)
       if (isMissionInitializingPayload(normalized) && missionSnapshot.value) {
@@ -86,6 +82,7 @@ export async function refreshMissionSessionDetail(
   missionSessionDetailLoading.value = true
   missionSessionDetailError.value = null
   try {
+    const { fetchDashboardMissionSession } = await import('./api/dashboard')
     const raw = await fetchDashboardMissionSession(sessionId, { signal: opts?.signal })
     if (opts?.signal?.aborted) return
     missionSessionDetail.value = normalizeMissionSessionDetail(raw)
@@ -106,6 +103,7 @@ export async function refreshMissionBriefing(
   missionBriefingLoading.value = true
   missionBriefingError.value = null
   try {
+    const { fetchDashboardMissionBriefing } = await import('./api/dashboard')
     const raw = await fetchDashboardMissionBriefing(force, { signal: opts?.signal })
     if (opts?.signal?.aborted) return
     const normalized = normalizeMissionBriefing(raw)

--- a/dashboard/src/namespace-truth-actions.ts
+++ b/dashboard/src/namespace-truth-actions.ts
@@ -1,4 +1,4 @@
-import { fetchDashboardNamespaceTruth } from './api'
+import { fetchDashboardNamespaceTruth } from './api/dashboard-hot'
 import { asString, isRecord } from './components/common/normalize'
 import { serverStatus } from './store'
 import {

--- a/dashboard/src/namespace-truth-store.test.ts
+++ b/dashboard/src/namespace-truth-store.test.ts
@@ -9,6 +9,10 @@ const apiMocks = vi.hoisted(() => ({
 }))
 
 vi.mock('./api', () => apiMocks)
+vi.mock('./api/dashboard-hot', () => ({
+  fetchDashboardNamespaceTruth: apiMocks.fetchDashboardNamespaceTruth,
+  fetchDashboardShell: apiMocks.fetchDashboardShell,
+}))
 vi.mock('./api/dashboard', () => ({
   fetchDashboardNamespaceTruth: apiMocks.fetchDashboardNamespaceTruth,
 }))

--- a/dashboard/src/oas-runtime-store.ts
+++ b/dashboard/src/oas-runtime-store.ts
@@ -1,4 +1,4 @@
-import { appendLiveOasEvent } from './components/session-trace/session-trace-state'
+import { appendLiveOasEvent } from './components/session-trace/session-trace-live-store'
 import { isRecord, asNumber, asString } from './components/common/normalize'
 import { fetchTelemetry, type TelemetryEntry } from './api/dashboard'
 import { OAS_TELEMETRY_REPLAY_LIMIT } from './config/constants'

--- a/dashboard/src/operator-actions.ts
+++ b/dashboard/src/operator-actions.ts
@@ -1,5 +1,10 @@
-import { confirmOperatorAction, fetchOperatorDigest, fetchOperatorSnapshot, runOperatorAction } from './api'
-import { extractApiError } from './api/core'
+import {
+  confirmOperatorAction,
+  extractApiError,
+  fetchOperatorDigest,
+  fetchOperatorSnapshot,
+  runOperatorAction,
+} from './api/core'
 import type {
   OperatorActionLogEntry,
   OperatorActionRequest,

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -1,23 +1,28 @@
-// Zod schema-at-boundary for SSE events from the MCP server.
+// Lightweight schema-at-boundary for SSE events from the MCP server.
 //
-// Parse gate: the top-level `type` discriminator is validated against a
-// closed enum so unknown event names surface as drift instead of becoming
-// silent no-ops. All other fields are declared as optional (mirrors the
-// existing `SSEEvent` interface) so new backend payload shapes don't hard-
-// fail the dashboard — but the field types are still checked when present.
-//
-// TypeScript SSOT: src/types/sse.ts (SSEEvent interface).
-// Phase 1 goal: eliminate the `as SSEEvent` cast in src/sse.ts by giving
-// onmessage a checked parse boundary. Phase 2 will split this into a
-// per-variant z.discriminatedUnion so handlers can switch exhaustively.
+// This module intentionally avoids pulling a generic schema runtime into the
+// dashboard hot path. SSE and WebSocket push streams import this parser during
+// boot, so keep validation direct and limited to the boundary guarantees the
+// handlers rely on.
 
-import { z } from 'zod'
+import type {
+  Attribution,
+  AttributionOutcome,
+  SSEEvent,
+  SSEEventType,
+} from '../types/sse'
 
-// --- Type discriminator (closed enum) -------------------------------------
-// Mirror of the non-OAS literals in `SSEEventType` in ../types/sse.ts.
-// OAS bridge events stay open by prefix so a newer server does not get
-// parse-dropped the moment it adds a new `oas:*` event family.
-const FixedSSEEventTypeSchema = z.enum([
+type SchemaIssue = { path?: string; message: string }
+type SafeParseSuccess<T> = { success: true; data: T }
+type SafeParseFailure = { success: false; error: { issues: SchemaIssue[] } }
+type SafeParseResult<T> = SafeParseSuccess<T> | SafeParseFailure
+
+type SchemaLike<T> = {
+  parse(value: unknown): T
+  safeParse(value: unknown): SafeParseResult<T>
+}
+
+const FIXED_SSE_EVENT_TYPES = new Set([
   'agent_joined',
   'agent_left',
   'broadcast',
@@ -62,135 +67,208 @@ const FixedSSEEventTypeSchema = z.enum([
   'transport_health_snapshot',
 ])
 
-const OasPrefixedEventTypeSchema = z
-  .string()
-  .regex(/^oas:/, 'Expected an oas:* event type')
-
-export const SSEEventTypeSchema = z.union([
-  FixedSSEEventTypeSchema,
-  OasPrefixedEventTypeSchema,
+const STRING_FIELDS = new Set([
+  'severity',
+  'source',
+  'agent',
+  'from',
+  'from_agent',
+  'message',
+  'content',
+  'task_id',
+  'status',
+  'post_id',
+  'comment_id',
+  'title',
+  'author',
+  'voter',
+  'direction',
+  'hearth',
+  'agent_name',
+  'keeper_name',
+  'event_type',
+  'name',
+  'from_model',
+  'to_model',
+  'trigger',
+  'reason',
+  'prev_phase',
+  'new_phase',
+  'event',
+  'tool_name',
+  'error_text',
+  'reason_code',
+  'phase',
+  'from_state',
+  'to_state',
+  'session_id',
+  'operation_id',
+  'worker_run_id',
+  'model_used',
+  'correlation_id',
+  'run_id',
 ])
 
-export type SSEEventType = z.infer<typeof SSEEventTypeSchema>
-
-// --- Attribution envelope (nested discriminated union) --------------------
-// OCaml SSOT: lib/attribution.mli. Structurally mirrors AttributionOutcome
-// which is a discriminated union on `kind`. Zod's discriminatedUnion
-// matches exactly — unknown `kind` fails parse.
-
-const AttributionOutcomeSchema = z.discriminatedUnion('kind', [
-  z.object({ kind: z.literal('passed') }),
-  z.object({
-    kind: z.literal('policy_failed'),
-    reason: z.string(),
-  }),
-  z.object({
-    kind: z.literal('transition_blocked'),
-    from_state: z.string(),
-    to_state: z.string(),
-    reason: z.string(),
-  }),
-  z.object({
-    kind: z.literal('partial_pass'),
-    score: z.number(),
-    rationale: z.string(),
-  }),
+const NUMBER_FIELDS = new Set([
+  'generation',
+  'context_ratio',
+  'ts_unix',
+  'from_generation',
+  'to_generation',
+  'before_tokens',
+  'after_tokens',
+  'saved_tokens',
+  'duration_ms',
+  'turn',
+  'input_tokens',
+  'output_tokens',
+  'cost_usd',
+  'tool_calls_made',
+  'total_turns',
 ])
 
-export const AttributionSchema = z.object({
-  origin: z.enum(['det', 'nondet']),
-  // `gate` is intentionally open: known canonical names are documented in
-  // the TS SSEEvent AttributionGate union but new gates must not break
-  // existing clients.
-  gate: z.string(),
-  evidence: z.record(z.string(), z.unknown()),
-  outcome: AttributionOutcomeSchema,
+const BOOLEAN_FIELDS = new Set(['success'])
+
+function ok<T>(data: T): SafeParseSuccess<T> {
+  return { success: true, data }
+}
+
+function fail<T = never>(path: string | undefined, message: string): SafeParseResult<T> {
+  return { success: false, error: { issues: [{ path, message }] } }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isSSEEventType(value: unknown): value is SSEEventType {
+  return typeof value === 'string' && (
+    FIXED_SSE_EVENT_TYPES.has(value) || value.startsWith('oas:')
+  )
+}
+
+function schema<T>(
+  safeParse: (value: unknown) => SafeParseResult<T>,
+): SchemaLike<T> {
+  return {
+    parse(value: unknown): T {
+      const result = safeParse(value)
+      if (result.success) return result.data
+      throw new Error(result.error.issues.map(issue => issue.message).join('; '))
+    },
+    safeParse,
+  }
+}
+
+export const SSEEventTypeSchema = schema<SSEEventType>((value) => {
+  if (isSSEEventType(value)) return ok(value)
+  return fail(undefined, 'Expected a known SSE event type or an oas:* event type')
 })
 
-export type Attribution = z.infer<typeof AttributionSchema>
+export type { SSEEventType }
 
-// --- SSE envelope --------------------------------------------------------
-// Strict on discriminator (`type`), permissive on payload (every other
-// field optional). Unknown fields pass through to preserve forward-
-// compat: a newer server emitting a new payload field must not crash
-// a slightly older dashboard. Typed fields still reject wrong-type values.
-export const SSEMessageSchema = z
-  .object({
-    type: SSEEventTypeSchema,
-    severity: z.string().optional(),
-    source: z.string().optional(),
-    agent: z.string().optional(),
-    from: z.string().optional(),
-    from_agent: z.string().optional(),
-    message: z.string().optional(),
-    content: z.string().optional(),
-    task_id: z.string().optional(),
-    status: z.string().optional(),
-    post_id: z.string().optional(),
-    comment_id: z.string().optional(),
-    title: z.string().optional(),
-    author: z.string().optional(),
-    voter: z.string().optional(),
-    direction: z.string().optional(),
-    hearth: z.string().optional(),
-    agent_name: z.string().optional(),
-    keeper_name: z.string().optional(),
-    event_type: z.string().optional(),
-    // Keeper event fields
-    name: z.string().optional(),
-    generation: z.number().optional(),
-    context_ratio: z.number().optional(),
-    ts_unix: z.number().optional(),
-    from_generation: z.number().optional(),
-    to_generation: z.number().optional(),
-    from_model: z.string().optional(),
-    to_model: z.string().optional(),
-    before_tokens: z.number().optional(),
-    after_tokens: z.number().optional(),
-    saved_tokens: z.number().optional(),
-    trigger: z.string().optional(),
-    reason: z.string().optional(),
-    // Phase transitions
-    prev_phase: z.string().optional(),
-    new_phase: z.string().optional(),
-    event: z.string().optional(),
-    // Tool call / skip fields
-    tool_name: z.string().optional(),
-    duration_ms: z.number().optional(),
-    success: z.boolean().optional(),
-    error_text: z.string().optional(),
-    reason_code: z.string().optional(),
-    turn: z.number().optional(),
-    phase: z.string().optional(),
-    from_state: z.string().optional(),
-    to_state: z.string().optional(),
-    session_id: z.string().optional(),
-    operation_id: z.string().optional(),
-    worker_run_id: z.string().optional(),
-    // Turn complete enrichment
-    model_used: z.string().optional(),
-    input_tokens: z.number().optional(),
-    output_tokens: z.number().optional(),
-    cost_usd: z.number().optional(),
-    tool_calls_made: z.number().optional(),
-    total_turns: z.number().optional(),
-    // Generic OAS payload container
-    payload: z.record(z.string(), z.unknown()).optional(),
-    // OAS envelope
-    correlation_id: z.string().optional(),
-    run_id: z.string().optional(),
-    // Gate attribution envelope
-    attribution: AttributionSchema.optional(),
+function validateAttributionOutcome(value: unknown): SafeParseResult<AttributionOutcome> {
+  if (!isRecord(value)) return fail('outcome', 'Expected attribution outcome object')
+  const kind = value.kind
+  switch (kind) {
+    case 'passed':
+      return ok({ kind })
+    case 'policy_failed':
+      return typeof value.reason === 'string'
+        ? ok({ kind, reason: value.reason })
+        : fail('outcome.reason', 'Expected string reason')
+    case 'transition_blocked':
+      return (
+        typeof value.from_state === 'string'
+        && typeof value.to_state === 'string'
+        && typeof value.reason === 'string'
+      )
+        ? ok({
+            kind,
+            from_state: value.from_state,
+            to_state: value.to_state,
+            reason: value.reason,
+          })
+        : fail('outcome', 'Expected transition fields')
+    case 'partial_pass':
+      return (
+        typeof value.score === 'number'
+        && Number.isFinite(value.score)
+        && typeof value.rationale === 'string'
+      )
+        ? ok({ kind, score: value.score, rationale: value.rationale })
+        : fail('outcome', 'Expected partial_pass score and rationale')
+    default:
+      return fail('outcome.kind', 'Expected known attribution outcome kind')
+  }
+}
+
+export const AttributionSchema = schema<Attribution>((value) => {
+  if (!isRecord(value)) return fail(undefined, 'Expected attribution object')
+  if (value.origin !== 'det' && value.origin !== 'nondet') {
+    return fail('origin', 'Expected attribution origin')
+  }
+  if (typeof value.gate !== 'string') {
+    return fail('gate', 'Expected attribution gate')
+  }
+  if (!isRecord(value.evidence)) {
+    return fail('evidence', 'Expected attribution evidence object')
+  }
+  const outcome = validateAttributionOutcome(value.outcome)
+  if (!outcome.success) return outcome
+  return ok({
+    origin: value.origin,
+    gate: value.gate,
+    evidence: value.evidence,
+    outcome: outcome.data,
   })
-  .passthrough()
+})
 
-export type SSEMessage = z.infer<typeof SSEMessageSchema>
+export type { Attribution }
+
+export type SSEMessage = SSEEvent
+
+export const SSEMessageSchema = schema<SSEMessage>((value) => {
+  if (!isRecord(value)) return fail(undefined, 'Expected SSE message object')
+  if (!isSSEEventType(value.type)) {
+    return fail('type', 'Expected known SSE event type or oas:* event type')
+  }
+
+  for (const key of STRING_FIELDS) {
+    const field = value[key]
+    if (field != null && typeof field !== 'string') {
+      return fail(key, `Expected ${key} to be a string`)
+    }
+  }
+  for (const key of NUMBER_FIELDS) {
+    const field = value[key]
+    if (field != null && (typeof field !== 'number' || !Number.isFinite(field))) {
+      return fail(key, `Expected ${key} to be a number`)
+    }
+  }
+  for (const key of BOOLEAN_FIELDS) {
+    const field = value[key]
+    if (field != null && typeof field !== 'boolean') {
+      return fail(key, `Expected ${key} to be a boolean`)
+    }
+  }
+
+  if (value.payload != null && !isRecord(value.payload)) {
+    return fail('payload', 'Expected payload object')
+  }
+  if (value.attribution != null) {
+    const attribution = AttributionSchema.safeParse(value.attribution)
+    if (!attribution.success) return attribution
+  }
+
+  return ok(value as unknown as SSEMessage)
+})
 
 /** Schema drift error for SSE boundary.
  *  Matches the GateStatusSchemaDriftError pattern used by Valibot schemas. */
 export class SSESchemaDriftError extends Error {
   constructor(
-    public readonly issues: readonly { path?: string; message: string }[],
+    public readonly issues: readonly SchemaIssue[],
     public readonly raw: unknown,
   ) {
     super(`SSE schema drift: ${issues.map((i) => i.message).join('; ')}`)
@@ -206,11 +284,9 @@ export function parseSSEMessage(raw: unknown): SSEMessage | null {
   if (result.success) return result.data
   // Surface drift in dev tools without crashing the stream. Aggregate issues
   // into one warn; keep payload visible so operators can diff server output.
-  const issues = result.error.issues.map((i) => ({
-    path: i.path.join('.'),
-    message: i.message,
-  }))
-  // eslint-disable-next-line no-console
-  console.warn('[SSE] schema drift, event dropped', { issues, raw })
+  console.warn('[SSE] schema drift, event dropped', {
+    issues: result.error.issues,
+    raw,
+  })
   return null
 }

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -31,8 +31,10 @@ const showToast = vi.fn<(message: string, kind?: string, durationMs?: number) =>
 const replayOasRuntimeTelemetry = vi.fn<() => Promise<void>>(async () => {})
 
 async function flushAsyncWork(): Promise<void> {
-  await Promise.resolve()
-  await Promise.resolve()
+  await vi.dynamicImportSettled()
+  for (let i = 0; i < 6; i += 1) {
+    await Promise.resolve()
+  }
 }
 
 async function loadSseStore() {

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -51,7 +51,6 @@ import {
   SSE_KEEPER_THREAD_DEBOUNCE_MS,
   SSE_RECONNECT_RETRY_MS,
 } from './config/constants'
-import { replayOasRuntimeTelemetry } from './oas-runtime-store'
 
 // --- Refresh function registration (avoids circular imports) ---
 
@@ -294,6 +293,7 @@ function handleReconnect(): void {
 
 async function hydrateAfterReconnect(): Promise<void> {
   try {
+    const { replayOasRuntimeTelemetry } = await import('./oas-runtime-store')
     await replayOasRuntimeTelemetry()
   } catch (err) {
     console.warn('[SSE] reconnect OAS replay failed', err instanceof Error ? err.message : err)

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -11,8 +11,7 @@ import {
   normalizeJournalSeverity,
   normalizeJournalSource,
 } from './journal-entry'
-import { appendLiveToolCall } from './components/session-trace/session-trace-state'
-import { applyOasRuntimeEvent } from './oas-runtime-store'
+import { appendLiveToolCall } from './components/session-trace/session-trace-live-store'
 import { parseSSEMessage } from './schemas/sse'
 import { RingBuffer } from './lib/ring-buffer'
 
@@ -23,6 +22,12 @@ import {
 } from './config/constants'
 
 const SSE_SESSION_KEY = 'masc_dashboard_sse_session_id'
+let oasRuntimeStorePromise: Promise<typeof import('./oas-runtime-store')> | null = null
+
+function loadOasRuntimeStore(): Promise<typeof import('./oas-runtime-store')> {
+  oasRuntimeStorePromise ??= import('./oas-runtime-store')
+  return oasRuntimeStorePromise
+}
 
 // --- Signals ---
 
@@ -297,7 +302,13 @@ function handleEvent(event: SSEEvent): void {
       : rawType
   const agent = event.agent ?? event.author ?? event.from ?? event.from_agent ?? ''
   if (rawType.startsWith('oas:')) {
-    applyOasRuntimeEvent(event, { includeLiveTrace: true })
+    void loadOasRuntimeStore()
+      .then(({ applyOasRuntimeEvent }) => {
+        applyOasRuntimeEvent(event, { includeLiveTrace: true })
+      })
+      .catch(err => {
+        console.warn('[SSE] OAS runtime handler unavailable', err instanceof Error ? err.message : err)
+      })
   }
 
   switch (type) {

--- a/dashboard/src/store-shell-auth.test.ts
+++ b/dashboard/src/store-shell-auth.test.ts
@@ -12,6 +12,9 @@ const toastMocks = vi.hoisted(() => ({
 }))
 
 vi.mock('./api', () => apiMocks)
+vi.mock('./api/dashboard-hot', () => ({
+  fetchDashboardShell: apiMocks.fetchDashboardShell,
+}))
 vi.mock('./sse', () => ({
   journal: {
     log: vi.fn(),

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -22,12 +22,7 @@ import type {
   DashboardShellMetaCognitionSummary,
   DashboardShellResponse,
 } from './types'
-import {
-  fetchDashboardExecution,
-  fetchDashboardMemory,
-  fetchDashboardPlanning,
-  fetchDashboardShell,
-} from './api'
+import { fetchDashboardShell } from './api/dashboard-hot'
 import { journal } from './sse'
 import { showToast } from './components/common/toast'
 import {
@@ -554,6 +549,7 @@ async function doFetchExecution(): Promise<void> {
   executionLoading.value = true
   executionError.value = null
   try {
+    const { fetchDashboardExecution } = await import('./api/dashboard')
     const data = await fetchDashboardExecution()
     hydrateExecutionSnapshot(data)
   } catch (err) {
@@ -651,6 +647,7 @@ function boardPageSize(): number {
 export async function refreshBoard(): Promise<void> {
   boardLoading.value = true
   try {
+    const { fetchDashboardMemory } = await import('./api/dashboard')
     const limit = boardPageSize()
     const data = await fetchDashboardMemory(boardSortMode.value, {
       excludeSystem: boardExcludeSystem.value,
@@ -682,6 +679,7 @@ export async function loadMoreBoardPosts(): Promise<void> {
   if (!boardHasMore.value) return
   boardLoadingMore.value = true
   try {
+    const { fetchDashboardMemory } = await import('./api/dashboard')
     const limit = boardPageSize()
     const offset = boardOffset.value
     const data = await fetchDashboardMemory(boardSortMode.value, {
@@ -712,6 +710,7 @@ export async function loadMoreBoardPosts(): Promise<void> {
 export async function refreshGoals(): Promise<void> {
   goalsLoading.value = true
   try {
+    const { fetchDashboardPlanning } = await import('./api/dashboard')
     const data = await fetchDashboardPlanning()
     applyPlanningEnvelope(data)
     lastGoalsRefreshAt.value = new Date().toISOString()


### PR DESCRIPTION
## Summary
- lazy-load dashboard status sections, overview, command palette, observatory live/activity panels, and OAS runtime replay paths
- split shell/namespace-truth and tool-host failure API hot paths away from the full dashboard API barrel
- replace SSE hot-path zod parser with a lightweight boundary parser and move session-trace live append into a small store
- break initial ./api barrel fan-in from mission/operator/keeper actions and defer operator-action schema validation

## Performance notes
- main dashboard JS after this PR: 199.68 kB / gzip 60.13 kB
- status chunk after this PR: 4.96 kB / gzip 1.96 kB
- source map check: api/dashboard, zod, and valibot are no longer in the initial index chunk

## Validation
- pnpm exec tsc --noEmit --pretty
- pnpm exec vitest run --no-file-parallelism --maxWorkers=1 src/api/core.test.ts src/api/schemas/operator-action.test.ts src/schemas/sse.test.ts src/sse-store.test.ts src/api/mcp.test.ts src/store-shell-auth.test.ts src/namespace-truth-store.test.ts src/components/session-trace/session-trace-state.test.ts src/components/observatory/observatory.test.ts src/components/common/command-palette.test.ts src/tab-refresh.test.ts
- pnpm build
- git diff --check origin/main...HEAD