### PR TITLE
[codex] Collect wall tok/sec from cost telemetry

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -177,6 +177,19 @@ let record_llm_tok_s_metrics
        Prometheus.metric_llm_decode_tok_per_sec ~labels v
    | _ -> ())
 
+let wall_tokens_per_second
+    ~(usage_missing : bool)
+    ~(output_tokens : int)
+    ~(telemetry : Oas.Types.inference_telemetry option)
+  : float option =
+  match telemetry with
+  | Some t when not usage_missing && output_tokens > 0
+                && t.request_latency_ms > 0 ->
+      Some
+        (Float.of_int output_tokens
+         /. (Float.of_int t.request_latency_ms /. 1000.0))
+  | _ -> None
+
 (** Append a cost event to .masc/costs.jsonl for per-task cost attribution.
     Schema matches bin/masc_cost.ml with an additional "source" field to
     distinguish automatic entries from manual CLI entries.
@@ -216,6 +229,10 @@ let emit_cost_event
       @ [("request_latency_ms", `Int t.request_latency_ms)]
     | None -> []
   in
+  let wall_tok_s_fields =
+    float_field "tokens_per_second"
+      (wall_tokens_per_second ~usage_missing ~output_tokens ~telemetry)
+  in
   let entry = `Assoc ([
     ("agent", `String agent_name);
     ("task_id", Json_util.string_opt_to_json task_id);
@@ -228,7 +245,7 @@ let emit_cost_event
     ("usage_missing", `Bool usage_missing);
     ("timestamp", `String (Types.now_iso ()));
     ("source", `String "auto_trajectory");
-  ] @ telemetry_fields) in
+  ] @ wall_tok_s_fields @ telemetry_fields) in
   let line = Yojson.Safe.to_string entry ^ "\n" in
   (try Fs_compat.append_file path line
    with Eio.Cancel.Cancelled _ as e -> raise e
@@ -505,13 +522,18 @@ let make_hooks
           | Some t -> t.request_latency_ms
           | None -> 0
         in
+        let wall_tok_s_opt =
+          wall_tokens_per_second ~usage_missing ~output_tokens:output_tok
+            ~telemetry:response.telemetry
+        in
         record_llm_tok_s_metrics ~model ~telemetry:response.telemetry;
+        let wall_tok_s = fmt_tok_s wall_tok_s_opt in
         let prompt_tok_s = fmt_tok_s prompt_tok_s_opt in
         let decode_tok_s = fmt_tok_s decode_tok_s_opt in
         Log.Keeper.info
-          "keeper:%s turn=%d total_turns=%d model=%s tokens=%d prompt_tok_s=%s decode_tok_s=%s latency_ms=%d"
+          "keeper:%s turn=%d total_turns=%d model=%s tokens=%d wall_tok_s=%s prompt_tok_s=%s decode_tok_s=%s latency_ms=%d"
           meta.name turn meta.runtime.usage.total_turns model total_tok
-          prompt_tok_s decode_tok_s latency_ms;
+          wall_tok_s prompt_tok_s decode_tok_s latency_ms;
         (* Emit per-turn cost event for task attribution.
            cost_usd from OAS Pricing.annotate_response_cost (oas#393 resolved). *)
         (match trajectory_acc with

--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -3,8 +3,9 @@ module IntMap = Map.Make (Int)
 
 (** Model_inference_metrics — per-model aggregate inference statistics.
 
-    Reads keeper decisions.jsonl files, extracts telemetry entries within
-    a configurable time window, and computes per-model aggregates:
+    Reads keeper decisions.jsonl files plus inference-level costs.jsonl
+    samples, extracts telemetry entries within a configurable time window,
+    and computes per-model aggregates:
     avg/p50/p95 tok/s, avg/p50/p95 latency, total reasoning tokens,
     cost attribution, tool usage, and success/error rates.
 
@@ -382,6 +383,125 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option 
        | _ -> None)
     | _ -> None
 
+let read_hw_decode_tok_per_sec (fields : (string * Yojson.Safe.t) list) =
+  let read key =
+    match List.assoc_opt key fields with
+    | Some (`Float f) when f > 0.0 -> Some f
+    | Some (`Int n) when n > 0 -> Some (Float.of_int n)
+    | _ -> None
+  in
+  match read "hw_decode_tokens_per_second" with
+  | Some _ as v -> v
+  | None -> read "provider_tokens_per_second"
+
+let starts_with ~prefix s =
+  let plen = String.length prefix in
+  String.length s >= plen && String.sub s 0 plen = prefix
+
+let canonical_cost_model_id ~(provider : string option) model =
+  match provider with
+  | Some "ollama" when not (starts_with ~prefix:"ollama:" model) ->
+      "ollama:" ^ model
+  | _ -> model
+
+let parse_cost_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option =
+  match json with
+  | `Assoc fields ->
+      let ts =
+        match Safe_ops.json_float_opt "ts_unix" json with
+        | Some v -> Some v
+        | None ->
+            (match List.assoc_opt "timestamp" fields with
+             | Some (`String s) -> Types.parse_iso8601_opt s
+             | _ -> None)
+      in
+      (match ts with
+       | Some ts when ts >= since_unix ->
+           (match json_string_field_opt "model" fields with
+            | None -> None
+            | Some raw_model ->
+                let provider = provider_opt_of_fields ~model:raw_model fields in
+                let model = canonical_cost_model_id ~provider raw_model in
+                let usage_missing =
+                  json_bool_field_opt "usage_missing" fields
+                  |> Option.value ~default:false
+                in
+                let input_tokens =
+                  if usage_missing then None
+                  else json_int_field_opt "input_tokens" fields
+                in
+                let output_tokens =
+                  if usage_missing then None
+                  else json_int_field_opt "output_tokens" fields
+                in
+                let cache_read_tokens =
+                  match json_int_field_opt "cache_read_tokens" fields with
+                  | Some _ as v -> v
+                  | None -> json_int_field_opt "cache_read_input_tokens" fields
+                in
+                let latency_ms =
+                  json_float_field_opt "request_latency_ms" fields
+                in
+                let tok_per_sec =
+                  match json_float_field_opt "tokens_per_second" fields with
+                  | Some v when v > 0.0 -> Some v
+                  | _ ->
+                      (match output_tokens, latency_ms with
+                       | Some out, Some latency when out > 0 && latency > 0.0 ->
+                           Some (Float.of_int out /. (latency /. 1000.0))
+                       | _ -> None)
+                in
+                let prompt_tok_per_sec =
+                  match List.assoc_opt "prompt_per_second" fields with
+                  | Some (`Float f) when f > 0.0 -> Some f
+                  | Some (`Int n) when n > 0 -> Some (Float.of_int n)
+                  | _ -> None
+                in
+                let hw_decode_tok_per_sec =
+                  read_hw_decode_tok_per_sec fields
+                in
+                let peak_memory_gb =
+                  match json_float_field_opt "peak_memory_gb" fields with
+                  | Some v when v > 0.0 -> Some v
+                  | _ -> None
+                in
+                let telemetry_reported =
+                  tok_per_sec <> None
+                  || prompt_tok_per_sec <> None
+                  || hw_decode_tok_per_sec <> None
+                  || peak_memory_gb <> None
+                  || latency_ms <> None
+                in
+                Some
+                  { model
+                  ; ts_unix = ts
+                  ; outcome = "success"
+                  ; stop_reason = None
+                  ; turn_lane = None
+                  ; tok_per_sec
+                  ; provider
+                  ; prompt_tok_per_sec
+                  ; hw_decode_tok_per_sec
+                  ; peak_memory_gb
+                  ; thinking_enabled = None
+                  ; latency_ms
+                  ; input_tokens
+                  ; output_tokens
+                  ; cache_read_tokens
+                  ; reasoning_tokens = json_int_field_opt "reasoning_tokens" fields
+                  ; fallback_applied = false
+                  ; cost_usd = json_float_field_opt "cost_usd" fields
+                  ; tool_call_count = 0
+                  ; tools_used = []
+                  ; usage_reported = Some (not usage_missing)
+                  ; telemetry_reported = Some telemetry_reported
+                  ; coverage_reason = None
+                  ; coverage_stage = Some "costs_jsonl"
+                  ; is_error = false
+                  })
+       | _ -> None)
+  | _ -> None
+
 (* ── Read decisions.jsonl files ─────────────────────────── *)
 
 let read_all_decisions ~base_path ~since_unix : raw_entry list =
@@ -422,6 +542,70 @@ let read_all_decisions ~base_path ~since_unix : raw_entry list =
         Printexc.raise_with_backtrace exn bt
       | _ -> []
     ) files
+
+let read_cost_entries ~base_path ~since_unix : raw_entry list =
+  let path = Filename.concat base_path ".masc/costs.jsonl" in
+  if not (Sys.file_exists path) then []
+  else
+    try
+      let ic = open_in path in
+      let entries = ref [] in
+      Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+        (try
+           while true do
+             let line = input_line ic in
+             if String.length line > 2 then
+               match Yojson.Safe.from_string line with
+               | json ->
+                 (match parse_cost_entry json ~since_unix with
+                  | Some e -> entries := e :: !entries
+                  | None -> ())
+               | exception (Eio.Cancel.Cancelled _ as exn) ->
+                 let bt = Printexc.get_raw_backtrace () in
+                 Printexc.raise_with_backtrace exn bt
+               | exception Yojson.Json_error _ -> ()
+           done
+         with End_of_file -> ());
+        !entries)
+    with
+    | Eio.Cancel.Cancelled _ as exn ->
+        let bt = Printexc.get_raw_backtrace () in
+        Printexc.raise_with_backtrace exn bt
+    | _ -> []
+
+let same_int_opt a b =
+  match a, b with
+  | Some x, Some y -> x = y
+  | _ -> false
+
+let same_inference_sample a b =
+  String.equal a.model b.model
+  && Float.abs (a.ts_unix -. b.ts_unix) <= 5.0
+  && same_int_opt a.input_tokens b.input_tokens
+  && same_int_opt a.output_tokens b.output_tokens
+
+let merge_decision_and_cost_entries decisions costs =
+  let decision_shadowed_by_cost d =
+    d.tok_per_sec = None
+    && List.exists
+         (fun c -> c.tok_per_sec <> None && same_inference_sample d c)
+         costs
+  in
+  let decisions_kept =
+    List.filter (fun d -> not (decision_shadowed_by_cost d)) decisions
+  in
+  let cost_duplicate_of_decision c =
+    List.exists
+      (fun d -> d.tok_per_sec <> None && same_inference_sample d c)
+      decisions
+  in
+  decisions_kept
+  @ List.filter (fun c -> not (cost_duplicate_of_decision c)) costs
+
+let read_all_entries ~base_path ~since_unix =
+  let decisions = read_all_decisions ~base_path ~since_unix in
+  let costs = read_cost_entries ~base_path ~since_unix in
+  merge_decision_and_cost_entries decisions costs
 
 let usage_signal_present (entry : raw_entry) : bool =
   entry.input_tokens <> None
@@ -770,7 +954,7 @@ let group_entries_by_model (entries : raw_entry list)
 
 let compute ~base_path ~window_minutes : aggregate =
   let since_unix = Time_compat.now () -. (Float.of_int window_minutes *. 60.0) in
-  let entries = read_all_decisions ~base_path ~since_unix in
+  let entries = read_all_entries ~base_path ~since_unix in
   let models = aggregate_by_model entries in
   let total_error_entries =
     List.length (List.filter (fun e -> e.is_error) entries)
@@ -782,7 +966,7 @@ let compute ~base_path ~window_minutes : aggregate =
 let compute_with_buckets ~base_path ~window_minutes ~bucket_minutes : aggregate =
   let bucket_minutes = max 1 bucket_minutes in
   let since_unix = Time_compat.now () -. (Float.of_int window_minutes *. 60.0) in
-  let entries = read_all_decisions ~base_path ~since_unix in
+  let entries = read_all_entries ~base_path ~since_unix in
   let models = aggregate_by_model entries in
   let bucket_sec = bucket_minutes * 60 in
   let by_model_map : raw_entry list StringMap.t =
@@ -809,7 +993,7 @@ let compute_with_buckets ~base_path ~window_minutes ~bucket_minutes : aggregate 
 
 let aggregate_buckets ~base_path ~window_min ~bucket_min : model_bucketed list =
   let since_unix = Time_compat.now () -. (Float.of_int window_min *. 60.0) in
-  let entries = read_all_decisions ~base_path ~since_unix in
+  let entries = read_all_entries ~base_path ~since_unix in
   let bucket_sec = if bucket_min <= 0 then 60 else bucket_min * 60 in
   let by_model = group_entries_by_model entries in
   List.map (fun (model_id, es) ->

--- a/lib/model_inference_metrics.mli
+++ b/lib/model_inference_metrics.mli
@@ -1,7 +1,8 @@
 (** Model_inference_metrics — per-model aggregate inference statistics.
 
-    Reads keeper decisions.jsonl files and computes per-model aggregates
-    within a configurable time window.
+    Reads keeper decisions.jsonl files plus inference-level costs.jsonl
+    samples and computes per-model aggregates within a configurable time
+    window.
 
     @since 2.259.0
     Extended with cost/tool/error metrics: @since 2.270.0 *)

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -60,6 +60,8 @@ let test_emit_cost_event_writes_inference_telemetry () =
   check int "reasoning_tokens" 3 (json |> member "reasoning_tokens" |> to_int);
   check int "cache_n" 7 (json |> member "cache_n" |> to_int);
   check int "request_latency_ms" 42 (json |> member "request_latency_ms" |> to_int);
+  check (float 0.001) "tokens_per_second" (5.0 /. 0.042)
+    (json |> member "tokens_per_second" |> to_float);
   check (float 0.001) "prompt_per_second" 21.55
     (json |> member "prompt_per_second" |> to_float);
   check (float 0.001) "provider_tokens_per_second" 81.56
@@ -102,6 +104,34 @@ let test_emit_cost_event_uses_typed_provider_kind_for_bare_model () =
   let json = read_jsonl_line (Filename.concat root "costs.jsonl") in
   check string "provider from provider_kind" "kimi_cli"
     (json |> member "provider" |> to_string)
+
+let test_emit_cost_event_writes_wall_tok_s_without_provider_timings () =
+  let root = temp_dir () in
+  let telemetry : Agent_sdk.Types.inference_telemetry = {
+    system_fingerprint = None;
+    timings = None;
+    reasoning_tokens = None;
+    request_latency_ms = 250;
+    peak_memory_gb = None;
+    provider_kind = Some Llm_provider.Provider_kind.OpenAI_compat;
+    reasoning_effort = None;
+    canonical_model_id = Some "auto";
+    effective_context_window = Some 128000;
+    provider_internal_action_count = None;
+  } in
+  Hooks.emit_cost_event ~masc_root:root ~agent_name:"keeper"
+    ~task_id:None ~model:"ollama:qwen3.6:27b-coding-nvfp4"
+    ~input_tokens:100 ~output_tokens:50 ~cost_usd:0.0
+    ~telemetry ();
+  let json = read_jsonl_line (Filename.concat root "costs.jsonl") in
+  check (float 0.001) "wall tokens_per_second" 200.0
+    (json |> member "tokens_per_second" |> to_float);
+  check bool "native prompt timing absent" true
+    (match json |> member "prompt_per_second" with `Null -> true | _ -> false);
+  check bool "native decode timing absent" true
+    (match json |> member "hw_decode_tokens_per_second" with
+     | `Null -> true
+     | _ -> false)
 
 let test_cost_usd_for_usage_falls_back_for_paid_provider () =
   let model = "openai:gpt-4.1" in
@@ -366,6 +396,8 @@ let () =
             test_emit_cost_event_marks_usage_missing
         ; test_case "emit_cost_event uses typed provider kind for bare model" `Quick
             test_emit_cost_event_uses_typed_provider_kind_for_bare_model
+        ; test_case "emit_cost_event computes wall tok/s without native timings" `Quick
+            test_emit_cost_event_writes_wall_tok_s_without_provider_timings
         ; test_case "cost fallback estimates paid provider usage" `Quick
             test_cost_usd_for_usage_falls_back_for_paid_provider
         ; test_case "cost fallback preserves reported cost" `Quick

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -43,6 +43,30 @@ let write_decisions path entries =
     ) entries
   )
 
+let iso_of_unix ts =
+  let tm = Unix.gmtime ts in
+  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+    (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
+    tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+
+let write_costs base entries =
+  let masc_dir = Filename.concat base ".masc" in
+  let rec mkdir_p dir =
+    if not (Sys.file_exists dir) then begin
+      mkdir_p (Filename.dirname dir);
+      Unix.mkdir dir 0o755
+    end
+  in
+  mkdir_p masc_dir;
+  let path = Filename.concat masc_dir "costs.jsonl" in
+  let oc = open_out path in
+  Fun.protect ~finally:(fun () -> close_out oc) (fun () ->
+    List.iter (fun json ->
+      output_string oc (Yojson.Safe.to_string json);
+      output_char oc '\n'
+    ) entries
+  )
+
 let now_unix () = Unix.gettimeofday ()
 
 let success_entry ~model ~ts ?(input_tokens=100) ?(output_tokens=50)
@@ -77,6 +101,26 @@ let success_entry ~model ~ts ?(input_tokens=100) ?(output_tokens=50)
       ("cost_usd", `Float cost_usd);
     ] @ extra_telemetry_fields));
   ]
+
+let cost_entry ~model ~ts ?(input_tokens=100) ?(output_tokens=50)
+    ?(latency_ms=500) ?tokens_per_second ?(provider="ollama") () =
+  let tok_fields =
+    match tokens_per_second with
+    | Some v -> [("tokens_per_second", `Float v)]
+    | None -> []
+  in
+  `Assoc ([
+    ("timestamp", `String (iso_of_unix ts));
+    ("agent", `String "keeper");
+    ("provider", `String provider);
+    ("model", `String model);
+    ("input_tokens", `Int input_tokens);
+    ("output_tokens", `Int output_tokens);
+    ("cost_usd", `Float 0.0);
+    ("usage_missing", `Bool false);
+    ("source", `String "auto_trajectory");
+    ("request_latency_ms", `Int latency_ms);
+  ] @ tok_fields)
 
 let error_entry ~cascade_name ~ts ?provider () =
   `Assoc [
@@ -446,6 +490,43 @@ let test_coverage_diagnostics_survive_aggregation () =
     check string "recent json stage" "oas"
       (recent_json |> member "coverage_stage" |> to_string))
 
+let test_costs_jsonl_backfills_wall_tok_per_sec () =
+  let base = test_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+    let ts = now_unix () in
+    write_costs base [
+      cost_entry ~model:"qwen3.6:27b-coding-nvfp4" ~ts
+        ~input_tokens:100 ~output_tokens:50 ~latency_ms:250 ();
+    ];
+    let agg = M.compute ~base_path:base ~window_minutes:60 in
+    let s = List.hd agg.models in
+    check string "cost model"
+      "ollama:qwen3.6:27b-coding-nvfp4" s.model_id;
+    check int "one cost entry" 1 s.entry_count;
+    check (option (float 0.001)) "wall tok/sec from cost latency"
+      (Some 200.0) s.avg_tok_per_sec;
+    check int "usage sample" 1 s.usage_sample_count;
+    check int "telemetry sample" 1 s.telemetry_sample_count)
+
+let test_costs_jsonl_dedupes_matching_decision_sample () =
+  let base = test_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+    let path = make_keeper_dir base "dedupe" in
+    let ts = now_unix () in
+    write_decisions path [
+      success_entry ~model:"ollama:qwen3.6:27b-coding-nvfp4" ~ts
+        ~input_tokens:100 ~output_tokens:50 ~latency_ms:500 ();
+    ];
+    write_costs base [
+      cost_entry ~model:"ollama:qwen3.6:27b-coding-nvfp4" ~ts
+        ~input_tokens:100 ~output_tokens:50 ~latency_ms:250 ();
+    ];
+    let agg = M.compute ~base_path:base ~window_minutes:60 in
+    let s = List.hd agg.models in
+    check int "matching cost sample deduped" 1 s.entry_count;
+    check (option (float 0.001)) "decision tok/sec preserved"
+      (Some 100.0) s.avg_tok_per_sec)
+
 (* ── thinking_fraction tests ─────────────────────── *)
 
 let success_entry_with_thinking ~model ~ts ~thinking_enabled () =
@@ -802,6 +883,8 @@ let () =
       test_case "prompt tps and peak memory aggregates" `Quick test_prompt_tps_and_peak_memory_aggregates;
       test_case "missing usage serializes unknowns" `Quick test_missing_usage_serializes_unknowns;
       test_case "coverage diagnostics survive aggregation" `Quick test_coverage_diagnostics_survive_aggregation;
+      test_case "costs.jsonl backfills wall tok/sec" `Quick test_costs_jsonl_backfills_wall_tok_per_sec;
+      test_case "costs.jsonl dedupes matching decision sample" `Quick test_costs_jsonl_dedupes_matching_decision_sample;
       test_case "json roundtrip" `Quick test_json_roundtrip;
     ];
     "thinking_fraction", [


### PR DESCRIPTION
## Summary

- emit wall-clock `tokens_per_second` into keeper cost events when usage and request latency are available
- teach model inference metrics to read `.masc/costs.jsonl`, backfill wall tok/sec from output tokens and latency, and dedupe matching decision samples
- canonicalize Ollama cost-stream model IDs so raw `qwen...` cost samples land in the existing `ollama:...` model bucket
- extend telemetry and metrics tests for cost-stream wall tok/sec collection and dedupe behavior

## Root Cause

Provider timing fields are often absent on the OpenAI-compatible/Ollama path, so prompt/decode tok/sec never got populated for those runs. The cost stream already had enough raw data (`output_tokens` + `request_latency_ms`) to compute wall tok/sec, but it was not persisted as `tokens_per_second` and the metrics reader ignored `.masc/costs.jsonl`.

Live old-server evidence matched the gap: `/api/v1/cascade/health` showed `ollama.avg_tok_per_sec=null` while recent `.masc/costs.jsonl` rows had computable output-token and latency samples.

## Validation

- `git diff --check`
- rebased onto latest `origin/main`; resolved the test conflict by keeping both the upstream typed-provider-kind coverage and the new wall tok/sec coverage
- `scripts/dune-local.sh build test/test_keeper_hooks_oas_telemetry.exe test/test_model_inference_metrics.exe` passed before the final Ollama model-ID canonicalization tweak
- `./_build/default/test/test_keeper_hooks_oas_telemetry.exe` passed: 12 tests
- `./_build/default/test/test_model_inference_metrics.exe` passed: 27 tests

Note: after the final canonicalization tweak and later rebase conflict resolution, a focused rerun was attempted but blocked by shared `/tmp/me-dune-local.lock`, currently held by another repo/worktree build. The queued local rerun was cleaned up rather than interrupting unrelated work.
