### PR TITLE
[codex] Strengthen keeper required-turn progress contract

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -506,8 +506,8 @@ let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
      && has_task_claim_affordance turn_affordances
      && List.mem "keeper_task_claim" allowed_tool_names
   then Oas.Types.Tool "keeper_task_claim"
-  else if (has_task_claim_affordance turn_affordances
-           || has_task_audit_affordance turn_affordances)
+  else if (not has_current_task)
+          && has_task_audit_affordance turn_affordances
           && List.mem "keeper_tasks_list" allowed_tool_names
   then Oas.Types.Tool "keeper_tasks_list"
   else Oas.Types.Any
@@ -617,20 +617,10 @@ let fallback_repo_probe_tool_names =
   tool_names Tool_name.[ Keeper Fs_read; Keeper Shell; Keeper Bash ]
 
 let is_claim_tool_name name =
-  match Tool_name.of_string name with
-  | Some (Keeper Task_claim) | Some (Masc Claim_next) -> true
-  | _ -> false
+  Keeper_tool_disclosure.is_claim_tool_name name
 
 let is_claim_context_tool_name name =
-  match Tool_name.of_string name with
-  | Some (Keeper Task_claim)
-  | Some (Keeper Tasks_list)
-  | Some (Keeper Context_status)
-  | Some (Masc Claim_next)
-  | Some (Masc Tasks)
-  | Some (Masc Status) ->
-      true
-  | _ -> false
+  Keeper_tool_disclosure.is_claim_context_tool_name name
 
 (* Tool selection & disclosure — extracted to Keeper_tool_disclosure (#5732) *)
 
@@ -2478,6 +2468,7 @@ let run_turn
             meta.name (Printexc.to_string exn)
     in
     let deterministic_required_tool_fallback ~reason ~trigger =
+      let has_current_task = keeper_has_owned_active_task () in
       let available name =
         List.mem name !requested_tool_names_ref
         || (Keeper_tool_policy.StringSet.mem name universe_set
@@ -2485,12 +2476,11 @@ let run_turn
             && Tool_portal.filter_visible_tool_names portal_ctx [ name ] <> [])
       in
       let fallback_tool =
-        if (not (keeper_has_owned_active_task ()))
-           && has_task_claim_affordance turn_affordances
+        if (not has_current_task) && has_task_claim_affordance turn_affordances
            && available "keeper_task_claim"
         then Some ("keeper_task_claim", `Assoc [])
-        else if (has_task_claim_affordance turn_affordances
-                 || has_task_audit_affordance turn_affordances)
+        else if (not has_current_task)
+                && has_task_audit_affordance turn_affordances
                 && available "keeper_tasks_list"
         then
           Some
@@ -2548,7 +2538,12 @@ let run_turn
                "keeper:%s deterministic claim fallback log failed: %s" meta.name
                (Printexc.to_string exn));
         receipt_tool_contract_result_ref :=
-          "satisfied_by_deterministic_fallback";
+          (match Keeper_tool_disclosure.classify_tool_progress tool_name with
+           | Keeper_tool_disclosure.Passive_status
+           | Keeper_tool_disclosure.Claim_context -> "needs_execution_progress"
+           | Keeper_tool_disclosure.Execution
+           | Keeper_tool_disclosure.Completion ->
+             "satisfied_by_deterministic_fallback");
         Log.Keeper.warn
           "keeper:%s required tool contract fallback called %s after %s (reason=%s)"
           meta.name tool_name trigger reason;
@@ -2890,6 +2885,7 @@ let run_turn
          in
          let actionable_tool_contract_violation_reason =
            Keeper_tool_disclosure.actionable_tool_contract_violation_reason
+             ~claim_context_allowed:(not (keeper_has_owned_active_task ()))
              ~actionable_signal_context
              ~tool_names:actual_keeper_tool_names
          in

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -152,27 +152,110 @@ let validate_completion_contract
        Error
          "keeper turn violated required tool contract: no tools were called")
 
+(** Keeper tool progress classes are the shared contract between prompt
+    disclosure, required-tool validation, runtime receipts, and liveness
+    metrics.  Keep these classes conservative: state/reporting tools do not
+    count as productive progress, and claim tools only bind work; execution
+    or completion tools are what prove the keeper is alive past task pickup. *)
+type tool_progress_class =
+  | Passive_status
+  | Claim_context
+  | Execution
+  | Completion
+
+let tool_progress_class_to_string = function
+  | Passive_status -> "passive_status"
+  | Claim_context -> "claim_context"
+  | Execution -> "execution"
+  | Completion -> "completion"
+
 (** Tools that report state without changing it. A turn whose tool calls
     are entirely within this set on an actionable signal is rejected by
     [actionable_tool_contract_violation_reason]; the same list is rendered
     into the keeper prompt (see [Keeper_prompt]) so the model sees the
     same definition the contract enforces. *)
 let passive_status_tool_names : string list =
-  [
-    "masc_status";
-    "keeper_context_status";
-    "masc_plan_get";
-    "keeper_time_now";
-    "keeper_board_list";
-    "keeper_board_get";
-    "keeper_tasks_list";
-    "masc_tasks";
-  ]
+  Tool_name.
+    [
+      Masc Status;
+      Masc Plan_get;
+      Masc Tasks;
+      Keeper Stay_silent;
+      Keeper Context_status;
+      Keeper Time_now;
+      Keeper Board_list;
+      Keeper Board_get;
+      Keeper Board_search;
+      Keeper Board_stats;
+      Keeper Tasks_list;
+      Keeper Tasks_audit;
+      Keeper Tool_search;
+      Keeper Tools_list;
+    ]
+  |> List.map Tool_name.to_string
+
+let claim_context_tool_names : string list =
+  Tool_name.
+    [
+      Masc Add_task;
+      Masc Batch_add_tasks;
+      Masc Claim_next;
+      Masc Claim_task;
+      Keeper Task_claim;
+      Keeper Task_create;
+      Keeper Task_force_release;
+    ]
+  |> List.map Tool_name.to_string
+
+let completion_tool_names : string list =
+  Tool_name.
+    [
+      Masc Cancel_task;
+      Masc Complete_task;
+      Masc Deliver;
+      Masc Release_task;
+      Keeper Task_done;
+      Keeper Task_force_done;
+      Keeper Task_submit_for_verification;
+    ]
+  |> List.map Tool_name.to_string
+
+let classify_tool_progress name =
+  let canonical_name =
+    match Tool_name.of_string name with
+    | Some tool -> Tool_name.to_string tool
+    | None -> name
+  in
+  if List.mem canonical_name passive_status_tool_names
+  then Passive_status
+  else if List.mem canonical_name claim_context_tool_names
+  then Claim_context
+  else if List.mem canonical_name completion_tool_names
+  then Completion
+  else Execution
 
 let is_passive_status_tool_name name =
-  List.mem name passive_status_tool_names
+  match classify_tool_progress name with
+  | Passive_status -> true
+  | Claim_context | Execution | Completion -> false
+
+let is_claim_tool_name name =
+  match Tool_name.of_string name with
+  | Some (Keeper Task_claim) | Some (Masc Claim_next) -> true
+  | _ -> false
+
+let is_claim_context_tool_name name =
+  match classify_tool_progress name with
+  | Passive_status | Claim_context -> true
+  | Execution | Completion -> false
+
+let is_execution_progress_tool_name name =
+  match classify_tool_progress name with
+  | Execution | Completion -> true
+  | Passive_status | Claim_context -> false
 
 let actionable_tool_contract_violation_reason
+      ~(claim_context_allowed : bool)
       ~(actionable_signal_context : bool)
       ~(tool_names : string list)
   : string option
@@ -187,6 +270,13 @@ let actionable_tool_contract_violation_reason
       Some
         (Printf.sprintf
            "actionable keeper signal was present, but the model only used passive status/read tools: %s"
+           (String.concat ", " names))
+    | names
+      when (not claim_context_allowed)
+           && List.for_all is_claim_context_tool_name names ->
+      Some
+        (Printf.sprintf
+           "actionable keeper signal was present, but the model only used claim/context tools without execution progress: %s"
            (String.concat ", " names))
     | _ -> None
 

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -106,23 +106,20 @@ let work_kind_of_turn_mode = function
   | Noop -> "noop"
   | Text_response | Skip_text -> "text_turn"
 
-(** Observation-only tools that do not constitute productive work.
+(** Observation/claim-context tools do not constitute productive work.
     A cycle using only these tools (or none) is a "noop" and triggers
-    exponential cooldown backoff to prevent token waste. *)
+    exponential cooldown backoff to prevent token waste.  The classification
+    is shared with required-tool contract validation so receipts and liveness
+    metrics agree on what counts as progress. *)
 let observation_only_tool_strings =
-  [ Tool_name.Keeper.to_string Tool_name.Keeper.Stay_silent
-  ; Tool_name.Keeper.to_string Tool_name.Keeper.Board_list
-  ; Tool_name.Keeper.to_string Tool_name.Keeper.Context_status
-  ; Tool_name.Keeper.to_string Tool_name.Keeper.Tool_search
-  ]
+  Keeper_tool_disclosure.passive_status_tool_names
+  @ Keeper_tool_disclosure.claim_context_tool_names
 
 let is_observation_only_tool_name name =
-  List.mem name observation_only_tool_strings
+  not (Keeper_tool_disclosure.is_execution_progress_tool_name name)
 
 let has_substantive_tool_calls (tools_used : string list) : bool =
-  List.exists
-    (fun name -> not (is_observation_only_tool_name name))
-    tools_used
+  List.exists Keeper_tool_disclosure.is_execution_progress_tool_name tools_used
 
 (** A cycle is noop when it produced no text AND all tools used (if any)
     are observation-only.  Productive cycles reset consecutive_noop_count. *)

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1093,10 +1093,10 @@ let test_system_prompt_prefers_bash_and_gh_pr_lane () =
   in
   check bool "mentions git path via keeper_bash" true
     (contains_substring sys
-       "keeper_bash (run commands, including git add/commit/push inside worktrees)");
+       "keeper_bash (run commands inside your sandbox; use for git add/commit/push");
   check bool "mentions gh create path" true
     (contains_substring sys
-       "keeper_shell op=gh (PR/issues via gh CLI; after git push");
+       "keeper_shell op=gh (ALL GitHub CLI ops - gh pr create/view/review");
   check bool "does not advertise removed keeper_github" false
     (contains_substring sys "keeper_github");
   check bool "legacy pr workflow removed" false
@@ -1749,6 +1749,8 @@ let test_metrics_observation_only_tools_are_noop () =
         Masc_mcp.Tool_name.Keeper.Context_status;
       Masc_mcp.Tool_name.Keeper.to_string
         Masc_mcp.Tool_name.Keeper.Tool_search;
+      Masc_mcp.Tool_name.Keeper.to_string Masc_mcp.Tool_name.Keeper.Tasks_list;
+      Masc_mcp.Tool_name.Keeper.to_string Masc_mcp.Tool_name.Keeper.Task_claim;
     ]
   in
   let result =
@@ -1773,6 +1775,16 @@ let test_metrics_observation_only_tools_are_noop () =
   check int "noop turn increments"
     (minimal_meta.runtime.noop_turn_count + 1)
     updated.runtime.noop_turn_count
+
+let test_metrics_execution_tools_are_substantive () =
+  check bool "claim alone is not execution progress" false
+    (UM.has_substantive_tool_calls [ "keeper_task_claim" ]);
+  check bool "task listing is not execution progress" false
+    (UM.has_substantive_tool_calls [ "keeper_tasks_list" ]);
+  check bool "bash is execution progress" true
+    (UM.has_substantive_tool_calls [ "keeper_bash" ]);
+  check bool "completion is execution progress" true
+    (UM.has_substantive_tool_calls [ "keeper_task_submit_for_verification" ])
 
 let sample_run_ref : Agent_sdk.Raw_trace.run_ref = {
   worker_run_id = "test-run"; path = "/tmp/test.jsonl";
@@ -3957,6 +3969,7 @@ let test_validate_completion_contract_presence_requires_keeper_surface_tool () =
 let test_actionable_tool_contract_flags_no_tools () =
   match
     KTD.actionable_tool_contract_violation_reason
+      ~claim_context_allowed:true
       ~actionable_signal_context:true
       ~tool_names:[]
   with
@@ -3968,6 +3981,7 @@ let test_actionable_tool_contract_flags_no_tools () =
 let test_actionable_tool_contract_flags_passive_only_tools () =
   match
     KTD.actionable_tool_contract_violation_reason
+      ~claim_context_allowed:true
       ~actionable_signal_context:true
       ~tool_names:[ "keeper_board_get"; "masc_status" ]
   with
@@ -3976,13 +3990,34 @@ let test_actionable_tool_contract_flags_passive_only_tools () =
         (contains_substring reason "passive status/read tools")
   | None -> fail "expected actionable passive-only violation"
 
+let test_actionable_tool_contract_rejects_claim_context_when_already_claimed () =
+  let () =
+    match
+      KTD.actionable_tool_contract_violation_reason
+        ~claim_context_allowed:false
+        ~actionable_signal_context:true
+        ~tool_names:[ "keeper_task_claim" ]
+    with
+    | Some reason ->
+        check bool "reason mentions execution progress" true
+          (contains_substring reason "without execution progress")
+    | None -> fail "expected actionable claim-context-only violation"
+  in
+  check (option string) "claim context is allowed before ownership" None
+    (KTD.actionable_tool_contract_violation_reason
+       ~claim_context_allowed:true
+       ~actionable_signal_context:true
+       ~tool_names:[ "keeper_task_claim" ])
+
 let test_actionable_tool_contract_allows_execution_tools () =
   check (option string) "execution tool satisfies actionable signal" None
     (KTD.actionable_tool_contract_violation_reason
+       ~claim_context_allowed:true
        ~actionable_signal_context:true
        ~tool_names:[ "keeper_bash"; "masc_status" ]);
   check (option string) "non-actionable no-op remains allowed" None
     (KTD.actionable_tool_contract_violation_reason
+       ~claim_context_allowed:true
        ~actionable_signal_context:false
        ~tool_names:[])
 
@@ -4602,13 +4637,11 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
          (Printf.sprintf "expected Tool keeper_task_claim, got %s"
             (Agent_sdk.Types.show_tool_choice other)));
   (match choose ~has_current_task:true () with
-   | Agent_sdk.Types.Tool name ->
-       check string "falls back to task listing when already owning work"
-         "keeper_tasks_list" name
+   | Agent_sdk.Types.Any -> ()
    | other ->
        fail
          (Printf.sprintf
-            "expected Tool keeper_tasks_list when already owning work, got %s"
+            "expected Any when already owning work, got %s"
             (Agent_sdk.Types.show_tool_choice other)));
   (match
      choose
@@ -4952,6 +4985,8 @@ let () =
           test_case "noop response" `Quick test_metrics_noop_response;
           test_case "observation-only tools are noop" `Quick
             test_metrics_observation_only_tools_are_noop;
+          test_case "execution tools are substantive" `Quick
+            test_metrics_execution_tools_are_substantive;
           test_case "validated evidence counts as visible" `Quick
             test_metrics_validated_evidence_counts_as_visible;
           test_case "failed validation does not count as visible" `Quick
@@ -5018,6 +5053,10 @@ let () =
             test_actionable_tool_contract_flags_no_tools;
           test_case "actionable signal rejects passive-only tools" `Quick
             test_actionable_tool_contract_flags_passive_only_tools;
+          test_case
+            "actionable signal rejects claim context after ownership"
+            `Quick
+            test_actionable_tool_contract_rejects_claim_context_when_already_claimed;
           test_case "actionable signal allows execution tools" `Quick
             test_actionable_tool_contract_allows_execution_tools;
           test_case "tool usage delta uses registry counts" `Quick


### PR DESCRIPTION
## Summary
- classify keeper tools into passive/status, claim-context, execution, and completion progress classes
- stop required turns with an active task from being forced back into keeper_tasks_list
- treat passive or claim-context deterministic fallbacks as needing execution progress instead of satisfied work

## Validation
- git diff --check
- DUNE_BUILD_DIR=_build_codex_check DUNE_JOBS=1 dune build --root . -j 1 test/test_keeper_unified.exe test/test_keeper_task_dispatch.exe
- MASC_BASE_PATH=$(mktemp -d /tmp/masc-task-dispatch-test.XXXXXX) _build_codex_check/default/test/test_keeper_task_dispatch.exe
- MASC_BASE_PATH=$(mktemp -d /tmp/masc-unified-test.XXXXXX) _build_codex_check/default/test/test_keeper_unified.exe