### PR TITLE
feat(metrics): emit resolved_model_id alongside cascade label (#9953)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -395,6 +395,32 @@ let surface_model_used (result : run_result) : string =
   | Some model -> model
   | None -> Option.value ~default:"" (nonempty_trimmed result.model_used)
 
+let surface_resolved_model_id (result : run_result) : string =
+  (* Always prefer the concrete resolved model_id over any cascade label.
+     The final attempt's model_id is authoritative — cascade attempts are
+     recorded in order, so [List.rev |> find_map] picks the last attempt
+     that actually ran. Falls back to selected/primary observation fields
+     when attempts are unavailable, then to the raw provider-reported
+     [model_used]. See #9953. *)
+  let attempt_resolved_id (attempt : Oas_worker.cascade_attempt) =
+    nonempty_trimmed attempt.model_id
+  in
+  let observation_resolved_id (obs : Oas_worker.cascade_observation) =
+    match
+      obs.attempts
+      |> List.rev
+      |> List.find_map attempt_resolved_id
+    with
+    | Some model -> Some model
+    | None -> (
+        match Option.bind obs.selected_model nonempty_trimmed with
+        | Some model -> Some model
+        | None -> Option.bind obs.primary_model nonempty_trimmed)
+  in
+  match Option.bind result.cascade_observation observation_resolved_id with
+  | Some model -> model
+  | None -> Option.value ~default:"" (nonempty_trimmed result.model_used)
+
 type keeper_internal_error =
   | Keeper_tool_surface_empty of
       { keeper_name : string

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -104,6 +104,23 @@ val preferred_tool_choice_for_required_turn :
     raw provider-reported [model_used]. *)
 val surface_model_used : run_result -> string
 
+(** Resolved concrete model id for MASC status/metrics surfaces.
+
+    Unlike {!surface_model_used}, this always returns the resolved provider
+    model id (e.g. ["claude-opus-4-6"]) regardless of whether a cascade
+    label (e.g. ["claude_code:auto"]) was present. Falls back to the raw
+    [model_used] when no cascade observation is available, and to the empty
+    string when neither source has a value.
+
+    Rationale (#9953): the [claude_code:auto] label resolves to different
+    concrete variants per turn (sonnet / opus / haiku) and each variant has
+    a different [max_context_tokens]. Recording only the label hides the
+    drift source — analysts cannot correlate ["context_max"] with the
+    actual resolved variant. Emitting both [model_used] (label) and
+    [resolved_model_id] (concrete id) in the metric line makes the
+    drift observable. *)
+val surface_resolved_model_id : run_result -> string
+
 (** {1 Telemetry serialisation} *)
 
 val build_prompt_metrics :

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -932,6 +932,7 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
   let _observation = observation in
   let turn_mode = turn_mode_of_result result in
   let surface_model_used = Keeper_agent_run.surface_model_used result in
+  let resolved_model_id = Keeper_agent_run.surface_resolved_model_id result in
   let scheduled_autonomous_outcome =
     if is_scheduled_autonomous_channel channel then
       Some (scheduled_autonomous_outcome_for_result result)
@@ -969,6 +970,7 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
         ("trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id));
         ("generation", `Int turn_generation);
         ("model_used", `String surface_model_used);
+        ("resolved_model_id", `String resolved_model_id);
         ("prompt_fingerprint", `String result.prompt_metrics.fingerprint);
         ("prompt", Keeper_agent_run.prompt_metrics_to_json result.prompt_metrics);
         ( "timeout_budget",

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1696,6 +1696,67 @@ let test_metrics_surface_model_prefers_successful_cascade_label () =
   check string "last_model_used stores canonical surface label" selected_label
     updated.runtime.usage.last_model_used
 
+(* #9953: [surface_resolved_model_id] returns the concrete model_id from
+   the last cascade attempt, even when [model_label] is populated. This
+   lets analysts correlate ["context_max"] with the actual resolved
+   variant instead of the auto label. *)
+let test_metrics_resolved_model_id_prefers_last_attempt_id () =
+  let result =
+    make_run_result ~text:"I checked the board." ~tools:[]
+      ~model:"claude-opus-4-6" ~input_tok:100 ~output_tok:50
+      ~cascade_observation:
+        {
+          Masc_mcp.Oas_worker.cascade_name =
+            Masc_mcp.Keeper_config.default_cascade_name;
+          strategy = Some "round_robin";
+          configured_labels = [ "claude_code:auto" ];
+          candidate_models =
+            [ "claude-sonnet-4-6"; "claude-opus-4-6" ];
+          primary_model = Some "claude-sonnet-4-6";
+          selected_model = Some "claude-opus-4-6";
+          selected_model_raw = Some "claude-opus-4-6";
+          selected_index = None;
+          fallback_hops = Some 1;
+          fallback_applied = true;
+          attempts =
+            [
+              {
+                Masc_mcp.Oas_worker.attempt_index = 0;
+                model_id = "claude-sonnet-4-6";
+                model_label = Some "claude_code:auto";
+                latency_ms = None;
+                error = Some "HTTP 503";
+              };
+              {
+                attempt_index = 1;
+                model_id = "claude-opus-4-6";
+                model_label = Some "claude_code:auto";
+                latency_ms = Some 187;
+                error = None;
+              };
+            ];
+          fallback_events = [];
+          attempt_details_available = true;
+          attempt_details_source = "oas_metrics_callbacks";
+        }
+      ()
+  in
+  check string "surface_model_used returns cascade label"
+    "claude_code:auto" (KAR.surface_model_used result);
+  check string "surface_resolved_model_id returns concrete variant id"
+    "claude-opus-4-6" (KAR.surface_resolved_model_id result)
+
+(* #9953: when no cascade observation is available, resolved id falls
+   back to the raw [model_used] reported by the provider, not to the
+   empty string. This preserves signal for non-cascade keeper turns. *)
+let test_metrics_resolved_model_id_fallback_to_model_used () =
+  let result =
+    make_run_result ~text:"ok" ~tools:[] ~model:"claude-opus-4-6"
+      ~input_tok:10 ~output_tok:5 ()
+  in
+  check string "surface_resolved_model_id falls back to model_used"
+    "claude-opus-4-6" (KAR.surface_resolved_model_id result)
+
 let test_metrics_tool_response () =
   let result =
     make_run_result ~text:"" ~tools:["keeper_board_post"; "keeper_board_comment"]
@@ -4948,6 +5009,11 @@ let () =
           test_case "text response" `Quick test_metrics_text_response;
           test_case "surface model prefers successful cascade label" `Quick
             test_metrics_surface_model_prefers_successful_cascade_label;
+          test_case "resolved_model_id prefers last attempt id (#9953)"
+            `Quick
+            test_metrics_resolved_model_id_prefers_last_attempt_id;
+          test_case "resolved_model_id falls back to model_used (#9953)"
+            `Quick test_metrics_resolved_model_id_fallback_to_model_used;
           test_case "tool response" `Quick test_metrics_tool_response;
           test_case "noop response" `Quick test_metrics_noop_response;
           test_case "observation-only tools are noop" `Quick


### PR DESCRIPTION
## 요약

`keeper_unified_metrics` 출력에 `resolved_model_id` 필드를 `model_used` 옆에 나란히 기록.

#9953 은 동일한 `claude_code:auto` label 이 turn 마다 **3가지 다른 `context_max`** (64k/262k/1M) 로 기록되는 drift 를 보고. 원인은 auto label → 서로 다른 concrete variant (sonnet/opus/haiku) 로 resolve, 각 variant 의 `max_context_tokens` 가 다르기 때문. Metric line 에는 label 만 남아 어느 variant 가 돌았는지 추적 불가.

이 PR 은 **Resolver 스택은 건드리지 않고** observability 만 추가. Drift source 를 dashboard/analyst 관점에 노출해 실제 해결(SSOT 통합, cascade override 명시 등) 을 데이터 기반으로 이어가기 위한 Phase 1.

## 변경 파일

- `lib/keeper/keeper_agent_run.{ml,mli}` — `surface_resolved_model_id` 신규 helper. 항상 concrete provider `model_id` 를 반환 (label 무시). Cascade observation 없을 시 raw `model_used` fallback, 전부 없으면 empty string.
- `lib/keeper/keeper_unified_metrics.ml` — `append_metrics_snapshot` 에서 `surface_resolved_model_id` 호출 후 JSON 의 `("resolved_model_id", ...)` 필드를 `model_used` 직후에 추가.
- `test/test_keeper_unified.ml` — 2 신규 테스트:
  - `resolved_model_id prefers last attempt id (#9953)`: `claude_code:auto` label 하에서 last attempt = `claude-opus-4-6` resolve 시, `surface_model_used` 는 label, `surface_resolved_model_id` 는 `claude-opus-4-6` 반환.
  - `resolved_model_id falls back to model_used (#9953)`: cascade observation 없는 turn 은 raw `model_used` 로 fallback.

## 로컬 검증

- `MASC_BASE_PATH=/tmp/masc-test-9953 dune exec test/test_keeper_unified.exe -- test metrics_observation` — 2 new cases PASS, 회귀 없음.
- `dune build` — clean.

## 미검증

- 실제 서버에서 metric line 이 resolved_model_id 를 정확히 포함하는지는 머지 후 dashboard/jq 로 확인. (observability-only 변경이라 runtime behavior 에는 영향 없음.)
- `context_max_source` 태깅 (이슈 제안 #3) 은 cascade_config 내부 resolver 변경이 필요해 별도 PR.

## 관련

- #9943 (compaction noop) / #9935 (context_ratio > 1.0) — context_max drift 가 이들의 근본 원인 중 하나일 가능성. 이 PR 이 분석의 전제조건인 resolved variant visibility 를 제공.
- Issue 제안 #1 (Provider_registry SSOT) 과 #2 (3개 ceiling 통합 — `keeper_config.ml:732` 는 max_tokens 이라 실제 drift 와 무관) 은 resolver 단 개선으로 후속.

## 주의

do-not-merge 라벨 부착. Resolver 변경 없이 observability 만 추가하므로 리스크는 낮으나, 운영자가 dashboard 반영/Grafana 쿼리 업데이트를 선택적으로 진행한 뒤 merge 결정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)