### PR TITLE
feat(dashboard): expand websocket route slices

### DIFF
--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -25,6 +25,7 @@ import type {
   FleetCompositeSnapshot,
   KeeperCompositeSnapshot,
 } from '../api/keeper'
+import { fleetCompositeSnapshot } from '../composite-signals'
 import {
   displayState,
   extractLaneValue,
@@ -237,6 +238,7 @@ interface FleetFsmMatrixProps {
 
 export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
   const fetcher = props.fetcher ?? fetchKeepersComposite
+  const allowStreamedData = props.fetcher == null
   const intervalMs = props.pollIntervalMs ?? POLL_INTERVAL_MS
   const [data, setData] = useState<FleetCompositeSnapshot | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -246,6 +248,23 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
   // returns a fresh record per tick and we pair it with a setData call
   // which triggers the re-render — avoids a redundant state subscription.
   const historyRef = useRef<KeeperFleetHistory>({})
+
+  useEffect(() => {
+    if (!allowStreamedData) return
+    const applyStreamedSnapshot = (snap: FleetCompositeSnapshot | null) => {
+      if (!snap) return
+      historyRef.current = pushObservation(
+        historyRef.current,
+        snap.snapshots,
+        FLEET_HISTORY_LEN,
+      )
+      setData(snap)
+      setError(null)
+      setLoading(false)
+    }
+    applyStreamedSnapshot(fleetCompositeSnapshot.value)
+    return fleetCompositeSnapshot.subscribe(applyStreamedSnapshot)
+  }, [allowStreamedData])
 
   useEffect(() => {
     let cancelled = false

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -4,6 +4,12 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useEffect, useMemo } from 'preact/hooks'
 import { fetchDashboardGoalDetail, fetchDashboardGoalsTree } from '../../api/dashboard'
+import {
+  goalTreeData as treeData,
+  goalTreeError as treeError,
+  goalTreeLoading as treeLoading,
+  hydrateGoalTreeSnapshot,
+} from '../../goal-tree-state'
 import { EmptyState, ErrorState, LoadingState } from '../common/feedback-state'
 import { ActionButton } from '../common/button'
 import { FilterChips } from '../common/filter-chips'
@@ -12,7 +18,6 @@ import { TimeAgo } from '../common/time-ago'
 import { TaskCreateForm } from '../task-manage/task-create-form'
 import type {
   DashboardGoalDetailResponse,
-  DashboardGoalsTreeResponse,
   GoalDetailKeeper,
   GoalDetailTimelineEvent,
   GoalTreeNode,
@@ -228,9 +233,6 @@ function timelineSeverityClass(severity: GoalDetailTimelineEvent['severity']): s
   }
 }
 
-const treeData = signal<DashboardGoalsTreeResponse | null>(null)
-const treeLoading = signal(false)
-const treeError = signal<string | null>(null)
 const expandedNodes = signal<Set<string>>(new Set())
 const filterQuery = signal('')
 const treePhaseFilter = signal<GoalPhaseFilter>('all')
@@ -280,7 +282,7 @@ async function refreshTree() {
   treeLoading.value = true
   treeError.value = null
   try {
-    treeData.value = await fetchDashboardGoalsTree()
+    hydrateGoalTreeSnapshot(await fetchDashboardGoalsTree())
   } catch (err) {
     treeError.value = err instanceof Error ? err.message : String(err)
   } finally {

--- a/dashboard/src/composite-signals.ts
+++ b/dashboard/src/composite-signals.ts
@@ -8,6 +8,11 @@
 
 import { signal } from '@preact/signals'
 
+import {
+  parseFleetCompositeSnapshot,
+  type FleetCompositeSnapshot,
+} from './api/keeper'
+
 interface CompositeTickEnvelope {
   name: string
   ts_unix: number
@@ -17,3 +22,15 @@ export const compositeTick = signal<CompositeTickEnvelope>({
   name: '',
   ts_unix: 0,
 })
+
+export const fleetCompositeSnapshot = signal<FleetCompositeSnapshot | null>(null)
+
+export function hydrateFleetCompositeSnapshot(payload: unknown): boolean {
+  try {
+    fleetCompositeSnapshot.value = parseFleetCompositeSnapshot(payload)
+    return true
+  } catch (err) {
+    console.debug('[Composite] fleet snapshot hydration failed', err instanceof Error ? err.message : '')
+    return false
+  }
+}

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { dashboardSlicesForRoute } from './dashboard-ws'
+import { dashboardSlicesForRoute, parseWebSocketSseFrames } from './dashboard-ws'
 
 describe('dashboardSlicesForRoute', () => {
   it('keeps global shell namespace and transport slices on every route', () => {
@@ -22,9 +22,36 @@ describe('dashboardSlicesForRoute', () => {
     })).toContain('execution')
   })
 
+  it('subscribes route-local dashboard slices for board, goals, and fleet FSM routes', () => {
+    expect(dashboardSlicesForRoute({ tab: 'workspace', params: { section: 'board' } }))
+      .toContain('board')
+    expect(dashboardSlicesForRoute({ tab: 'workspace', params: { section: 'planning' } }))
+      .toContain('goals')
+    expect(dashboardSlicesForRoute({ tab: 'monitoring', params: { section: 'agents' } }))
+      .toContain('composite')
+  })
+
   it('subscribes operator only for the active command surface', () => {
     expect(dashboardSlicesForRoute({ tab: 'command', params: {} })).toContain('operator')
     expect(dashboardSlicesForRoute({ tab: 'command', params: { view: 'inspector' } }))
       .not.toContain('operator')
+  })
+})
+
+describe('parseWebSocketSseFrames', () => {
+  it('extracts JSON payloads from raw SSE frames forwarded over websocket', () => {
+    expect(parseWebSocketSseFrames([
+      'id: 1',
+      'data: {"type":"post_created","post_id":"p1"}',
+      '',
+      'id: 2',
+      'event: message',
+      'data: {"type":"keeper_composite_changed","name":"qa-king"}',
+      '',
+      '',
+    ].join('\n'))).toEqual([
+      { type: 'post_created', post_id: 'p1' },
+      { type: 'keeper_composite_changed', name: 'qa-king' },
+    ])
   })
 })

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -43,11 +43,18 @@ export function dashboardSlicesForRoute(routeState: Pick<RouteState, 'tab' | 'pa
 
   if (routeState.tab === 'workspace' && routeState.params.section === 'planning') {
     slices.add('execution')
+    slices.add('goals')
+  }
+  if (routeState.tab === 'workspace' && routeState.params.section === 'board') {
+    slices.add('board')
   }
   if (routeState.tab === 'monitoring') {
     const section = routeState.params.section
     if (section === 'observatory' || section === 'journey' || section === 'agents') {
       slices.add('execution')
+    }
+    if (section === 'agents') {
+      slices.add('composite')
     }
     if (section === 'fleet-health' && routeState.params.view === 'comparison') {
       slices.add('execution')
@@ -108,11 +115,17 @@ function sendRpc(method: string, params: JsonObject): Promise<unknown> {
   if (!socket || socket.readyState !== WebSocket.OPEN) {
     return Promise.reject(new Error('dashboard websocket is not open'))
   }
+  const currentSocket = socket
   const id = ++rpcId
   const payload = { jsonrpc: '2.0', id, method, params }
   return new Promise((resolve, reject) => {
     pending.set(id, { resolve, reject })
-    socket?.send(JSON.stringify(payload))
+    try {
+      currentSocket.send(JSON.stringify(payload))
+    } catch (err) {
+      pending.delete(id)
+      reject(err instanceof Error ? err : new Error(String(err)))
+    }
   })
 }
 
@@ -195,12 +208,37 @@ function handleRawPush(raw: unknown): void {
   hydrateServerPushEvent(parsed as unknown as SSEEvent)
 }
 
+export function parseWebSocketSseFrames(data: string): unknown[] {
+  const payloads: unknown[] = []
+  const frames = data.split(/\r?\n\r?\n/)
+  for (const frame of frames) {
+    const dataLines: string[] = []
+    for (const line of frame.split(/\r?\n/)) {
+      if (!line.startsWith('data:')) continue
+      const value = line.slice('data:'.length)
+      dataLines.push(value.startsWith(' ') ? value.slice(1) : value)
+    }
+    if (dataLines.length === 0) continue
+    const body = dataLines.join('\n').trim()
+    if (!body || body === '[DONE]') continue
+    try {
+      payloads.push(JSON.parse(body))
+    } catch {
+      // Non-JSON SSE frames are ignored; dashboard pushes are JSON.
+    }
+  }
+  return payloads
+}
+
 function handleMessage(data: unknown): void {
   if (typeof data !== 'string') return
   let raw: unknown
   try {
     raw = JSON.parse(data)
   } catch {
+    for (const payload of parseWebSocketSseFrames(data)) {
+      handleRawPush(payload)
+    }
     return
   }
   if (!raw || typeof raw !== 'object') return
@@ -216,11 +254,16 @@ export async function subscribeDashboardRoute(routeState: Pick<RouteState, 'tab'
   const key = `${routeKey(routeState)}|${slices.join(',')}`
   if (key === lastSubscribeKey) return
   lastSubscribeKey = key
-  const result = await sendRpc('dashboard/subscribe', {
-    route: routeKey(routeState),
-    slices,
-  })
-  applySubscribeResult(result)
+  try {
+    const result = await sendRpc('dashboard/subscribe', {
+      route: routeKey(routeState),
+      slices,
+    })
+    applySubscribeResult(result)
+  } catch (err) {
+    if (lastSubscribeKey === key) lastSubscribeKey = ''
+    throw err
+  }
 }
 
 export async function connectDashboardWS(routeState?: Pick<RouteState, 'tab' | 'params'>): Promise<void> {

--- a/dashboard/src/goal-tree-state.ts
+++ b/dashboard/src/goal-tree-state.ts
@@ -1,0 +1,19 @@
+import { signal } from '@preact/signals'
+
+import type { DashboardGoalsTreeResponse } from './types'
+
+export const goalTreeData = signal<DashboardGoalsTreeResponse | null>(null)
+export const goalTreeLoading = signal(false)
+export const goalTreeError = signal<string | null>(null)
+
+export function hydrateGoalTreeSnapshot(payload: unknown): boolean {
+  if (!payload || typeof payload !== 'object') return false
+  const candidate = payload as Partial<DashboardGoalsTreeResponse>
+  if (!Array.isArray(candidate.tree) || !candidate.summary || typeof candidate.summary !== 'object') {
+    return false
+  }
+  goalTreeData.value = candidate as DashboardGoalsTreeResponse
+  goalTreeError.value = null
+  goalTreeLoading.value = false
+  return true
+}

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -21,14 +21,18 @@ const refreshDashboard = vi.fn<() => Promise<void>>(async () => {})
 const refreshExecution = vi.fn<() => Promise<void>>(async () => {})
 const refreshBoard = vi.fn<() => void>(() => {})
 const invalidateDashboardCache = vi.fn<() => void>(() => {})
+const hydrateBoardSnapshot = vi.fn<(payload: unknown) => void>(() => {})
 const hydrateShellSnapshot = vi.fn<(payload: unknown) => void>(() => {})
 const hydrateExecutionSnapshot = vi.fn<(payload: unknown) => void>(() => {})
+const hydratePlanningSnapshot = vi.fn<(payload: unknown) => void>(() => {})
 const removeBoardPost = vi.fn<(postId?: string) => void>(() => {})
 const refreshForRoute = vi.fn<(nextRoute: CurrentRoute) => void>()
 const requestNamespaceTruthNow = vi.fn<() => void>()
 const requestNamespaceTruth = vi.fn<() => void>()
 const showToast = vi.fn<(message: string, kind?: string, durationMs?: number) => void>()
 const replayOasRuntimeTelemetry = vi.fn<() => Promise<void>>(async () => {})
+const hydrateFleetCompositeSnapshot = vi.fn<(payload: unknown) => boolean>(() => true)
+const hydrateGoalTreeSnapshot = vi.fn<(payload: unknown) => boolean>(() => true)
 
 async function flushAsyncWork(): Promise<void> {
   await Promise.resolve()
@@ -40,8 +44,10 @@ async function loadSseStore() {
   vi.doMock('./store', () => ({
     keeperHeartbeats,
     invalidateDashboardCache,
+    hydrateBoardSnapshot,
     hydrateShellSnapshot,
     hydrateExecutionSnapshot,
+    hydratePlanningSnapshot,
     refreshDashboard,
     refreshExecution,
     refreshBoard,
@@ -64,6 +70,13 @@ async function loadSseStore() {
     replayOasRuntimeTelemetry,
     applyOasRuntimeEvent: vi.fn(),
   }))
+  vi.doMock('./composite-signals', () => ({
+    compositeTick: signal({ name: '', ts_unix: 0 }),
+    hydrateFleetCompositeSnapshot,
+  }))
+  vi.doMock('./goal-tree-state', () => ({
+    hydrateGoalTreeSnapshot,
+  }))
   vi.doMock('./router', () => ({ route }))
   const sseStore = await import('./sse-store')
   const sse = await import('./sse')
@@ -79,8 +92,10 @@ describe('setupSSEReaction reconnect hydration', () => {
     refreshExecution.mockClear()
     refreshBoard.mockClear()
     invalidateDashboardCache.mockClear()
+    hydrateBoardSnapshot.mockClear()
     hydrateShellSnapshot.mockClear()
     hydrateExecutionSnapshot.mockClear()
+    hydratePlanningSnapshot.mockClear()
     removeBoardPost.mockClear()
     refreshForRoute.mockClear()
     requestNamespaceTruthNow.mockClear()
@@ -88,6 +103,10 @@ describe('setupSSEReaction reconnect hydration', () => {
     showToast.mockClear()
     replayOasRuntimeTelemetry.mockClear()
     replayOasRuntimeTelemetry.mockResolvedValue(undefined)
+    hydrateFleetCompositeSnapshot.mockClear()
+    hydrateFleetCompositeSnapshot.mockReturnValue(true)
+    hydrateGoalTreeSnapshot.mockClear()
+    hydrateGoalTreeSnapshot.mockReturnValue(true)
     namespaceTruth.value = null
     namespaceTruthError.value = null
     boardPosts.value = []
@@ -104,6 +123,8 @@ describe('setupSSEReaction reconnect hydration', () => {
     vi.doUnmock('./tab-refresh')
     vi.doUnmock('./components/common/toast')
     vi.doUnmock('./oas-runtime-store')
+    vi.doUnmock('./composite-signals')
+    vi.doUnmock('./goal-tree-state')
     vi.doUnmock('./router')
   })
 
@@ -214,5 +235,29 @@ describe('setupSSEReaction reconnect hydration', () => {
     expect(refreshExecution).not.toHaveBeenCalled()
 
     cleanup()
+  })
+
+  it('hydrates websocket dashboard snapshots for board, goals, and composite slices', async () => {
+    const { sseStore } = await loadSseStore()
+
+    sseStore.hydrateDashboardSlice('board', { posts: [], generated_at: 'now' })
+    sseStore.hydrateDashboardSlice('goals', {
+      planning: { goals: [], generated_at: 'now' },
+      tree: { tree: [], summary: { total_goals: 0 } },
+    })
+    sseStore.hydrateDashboardSlice('composite', {
+      generated_at: 1,
+      count: 0,
+      snapshots: [],
+    })
+
+    expect(hydrateBoardSnapshot).toHaveBeenCalledWith({ posts: [], generated_at: 'now' })
+    expect(hydratePlanningSnapshot).toHaveBeenCalledWith({ goals: [], generated_at: 'now' })
+    expect(hydrateGoalTreeSnapshot).toHaveBeenCalledWith({ tree: [], summary: { total_goals: 0 } })
+    expect(hydrateFleetCompositeSnapshot).toHaveBeenCalledWith({
+      generated_at: 1,
+      count: 0,
+      snapshots: [],
+    })
   })
 })

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -13,12 +13,21 @@ import {
   pauseQueuedOasRuntimeIngress,
   resumeQueuedOasRuntimeIngress,
 } from './sse'
-import type { BoardPost, DashboardExecutionResponse, DashboardShellResponse, SSEEvent } from './types'
+import type {
+  BoardPost,
+  DashboardExecutionResponse,
+  DashboardMemoryResponse,
+  DashboardPlanningResponse,
+  DashboardShellResponse,
+  SSEEvent,
+} from './types'
 import {
   keeperHeartbeats,
   invalidateDashboardCache,
+  hydrateBoardSnapshot,
   hydrateShellSnapshot,
   hydrateExecutionSnapshot,
+  hydratePlanningSnapshot,
   refreshDashboard,
   refreshExecution,
   refreshBoard,
@@ -37,7 +46,8 @@ import {
 import { mergeServerStatus } from './store-normalizers'
 import { normalizeOperatorSnapshot, normalizeOperatorDigest } from './operator-normalizers'
 import { operatorSnapshot, operatorRoomDigest } from './operator-signals'
-import { compositeTick } from './composite-signals'
+import { compositeTick, hydrateFleetCompositeSnapshot } from './composite-signals'
+import { hydrateGoalTreeSnapshot } from './goal-tree-state'
 import { showToast } from './components/common/toast'
 import type { ErrorCode } from './types/error'
 import { route } from './router'
@@ -454,6 +464,23 @@ export function hydrateDashboardSlice(slice: string, payload: unknown, eventType
     }
     case 'transport':
       hydrateServerPushEvent({ type: 'transport_health_snapshot', payload } as SSEEvent)
+      return
+    case 'board':
+      hydrateBoardSnapshot(payload as DashboardMemoryResponse)
+      return
+    case 'goals': {
+      if (!payload || typeof payload !== 'object') return
+      const record = payload as { planning?: unknown; tree?: unknown }
+      if (record.planning) {
+        hydratePlanningSnapshot(record.planning as DashboardPlanningResponse)
+      }
+      if (record.tree) {
+        hydrateGoalTreeSnapshot(record.tree)
+      }
+      return
+    }
+    case 'composite':
+      hydrateFleetCompositeSnapshot(payload)
       return
   }
 }

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -16,6 +16,8 @@ import type {
   DashboardExecutionWorkerSupportBrief,
   DashboardExecutionContinuityBrief,
   DashboardExecutionResponse,
+  DashboardMemoryResponse,
+  DashboardPlanningResponse,
   DashboardConfigResolution,
   DashboardRuntimeResolution,
   DashboardShellAuthSummary,
@@ -399,9 +401,7 @@ export async function refreshDashboard(opts?: RefreshOptions): Promise<void> {
   return inflightDashboardRefresh
 }
 
-function applyPlanningEnvelope(data: {
-  goals?: unknown[]
-}): void {
+function applyPlanningEnvelope(data: DashboardPlanningResponse): void {
   goals.value = (Array.isArray(data.goals) ? data.goals : [])
     .map((row): Goal | null => {
       if (!isRecord(row)) return null
@@ -434,6 +434,11 @@ function applyPlanningEnvelope(data: {
       }
     })
     .filter((row): row is Goal => row !== null)
+}
+
+export function hydratePlanningSnapshot(data: DashboardPlanningResponse): void {
+  applyPlanningEnvelope(data)
+  lastGoalsRefreshAt.value = data.generated_at ?? new Date().toISOString()
 }
 
 function normalizeShellAuthSummary(raw: unknown): DashboardShellAuthSummary | null {
@@ -675,6 +680,19 @@ export async function refreshBoard(): Promise<void> {
   }
 }
 
+export function hydrateBoardSnapshot(data: DashboardMemoryResponse): void {
+  const next = data.posts ?? []
+  boardPosts.value = reconcileBoardPosts(boardPosts.value, next)
+  const offset = typeof data.offset === 'number' ? data.offset : 0
+  const limit = typeof data.limit === 'number' ? data.limit : boardPageSize()
+  boardOffset.value = offset + next.length
+  boardHasMore.value = typeof data.has_more === 'boolean'
+    ? data.has_more
+    : next.length >= limit
+  boardTotal.value = typeof data.total === 'number' ? data.total : null
+  lastBoardRefreshAt.value = data.generated_at ?? new Date().toISOString()
+}
+
 /** Append the next page of board posts onto boardPosts. Noop if a request is
  *  already in flight or the server indicated no more pages. */
 export async function loadMoreBoardPosts(): Promise<void> {
@@ -713,8 +731,7 @@ export async function refreshGoals(): Promise<void> {
   goalsLoading.value = true
   try {
     const data = await fetchDashboardPlanning()
-    applyPlanningEnvelope(data)
-    lastGoalsRefreshAt.value = new Date().toISOString()
+    hydratePlanningSnapshot(data)
   } catch (err) {
     console.warn('[Planning] fetch error:', err)
   } finally {

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -19,20 +19,12 @@ let dashboard_namespace_truth_focus_json =
 let dashboard_namespace_truth_http_json =
   Server_dashboard_http_namespace_truth.dashboard_namespace_truth_http_json
 
-let dashboard_memory_http_json request : Yojson.Safe.t =
-  let hearth = query_param request "hearth" in
-  let author_filter =
-    query_param request "author"
-    |> Option.map String.trim
-    |> Fun.flip Option.bind (fun s -> if s = "" then None else Some s)
-  in
-  let sort_by = board_sort_order_of_request request in
-  let exclude_system = bool_query_param request "exclude_system" ~default:false in
-  let exclude_automation =
-    bool_query_param request "exclude_automation" ~default:false
-  in
-  let limit = int_query_param request "limit" ~default:100 |> clamp ~min_v:1 ~max_v:500 in
-  let offset = int_query_param request "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
+let dashboard_board_json ?hearth ?author_filter
+    ?(sort_by = Board_dispatch.Hot) ?(exclude_system = false)
+    ?(exclude_automation = false) ?(limit = 100) ?(offset = 0) () :
+    Yojson.Safe.t =
+  let limit = clamp ~min_v:1 ~max_v:500 limit in
+  let offset = clamp ~min_v:0 ~max_v:5000 offset in
   let cache_key =
     Printf.sprintf "board:memory:%s;%s;%s;%b;%b;%d;%d"
       (Option.value ~default:"-" hearth)
@@ -87,6 +79,27 @@ let dashboard_memory_http_json request : Yojson.Safe.t =
         ("total", total_json);
         ("sort_by", `String (board_sort_label sort_by));
       ])
+
+let dashboard_memory_http_json request : Yojson.Safe.t =
+  let hearth = query_param request "hearth" in
+  let author_filter =
+    query_param request "author"
+    |> Option.map String.trim
+    |> Fun.flip Option.bind (fun s -> if s = "" then None else Some s)
+  in
+  let sort_by = board_sort_order_of_request request in
+  let exclude_system = bool_query_param request "exclude_system" ~default:false in
+  let exclude_automation =
+    bool_query_param request "exclude_automation" ~default:false
+  in
+  let limit =
+    int_query_param request "limit" ~default:100 |> clamp ~min_v:1 ~max_v:500
+  in
+  let offset =
+    int_query_param request "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000
+  in
+  dashboard_board_json ?hearth ?author_filter ~sort_by ~exclude_system
+    ~exclude_automation ~limit ~offset ()
 
 let dashboard_memory_subsystems_http_json ~(config : Coord_utils.config) request
     : Yojson.Safe.t =
@@ -399,6 +412,24 @@ let dashboard_planning_http_json ~(config : Coord.config) : Yojson.Safe.t =
 
 let dashboard_goals_tree_http_json ~(config : Coord.config) : Yojson.Safe.t =
   Dashboard_goals.dashboard_goals_tree_json ~config
+
+let dashboard_goals_snapshot_json ~(config : Coord.config) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("planning", dashboard_planning_http_json ~config);
+      ("tree", dashboard_goals_tree_http_json ~config);
+    ]
+
+let dashboard_fleet_composite_json ~(base_path : string) () : Yojson.Safe.t =
+  let snapshots = Keeper_composite_observer.all_snapshots ~base_path () in
+  `Assoc
+    [
+      ("generated_at", `Float (Unix.gettimeofday ()));
+      ("count", `Int (List.length snapshots));
+      ( "snapshots",
+        `List (List.map Keeper_composite_observer.snapshot_to_json snapshots)
+      );
+    ]
 
 let dashboard_goal_detail_http_json ~(config : Coord.config) ~goal_id :
     Yojson.Safe.t =

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1446,18 +1446,8 @@ let handle_keeper_get_subroutes state req request reqd =
        Consumed by [dashboard/src/components/fleet-fsm-matrix.ts]
        (LT-16b, upcoming). *)
     let base_path = state.Mcp_server.room_config.base_path in
-    let snapshots =
-      Keeper_composite_observer.all_snapshots ~base_path ()
-    in
     let json =
-      `Assoc [
-        "generated_at", `Float (Unix.gettimeofday ());
-        "count", `Int (List.length snapshots);
-        "snapshots",
-          `List
-            (List.map
-               Keeper_composite_observer.snapshot_to_json snapshots);
-      ]
+      Server_dashboard_http.dashboard_fleet_composite_json ~base_path ()
     in
     Http.Response.json ~compress:true ~request:req
       (Yojson.Safe.to_string json) reqd

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1366,8 +1366,19 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
             Some (Server_dashboard_http.dashboard_transport_health_snapshot_json ())
         | "namespace" ->
             Server_dashboard_http.namespace_truth_snapshot_from_caches state
-        | "composite" | "board" | "goals" ->
-            None
+        | "composite" ->
+            Some
+              (Server_dashboard_http.dashboard_fleet_composite_json
+                 ~base_path:state.Mcp_server.room_config.base_path ())
+        | "board" ->
+            Some
+              (Server_dashboard_http.dashboard_board_json
+                 ~sort_by:Board_dispatch.Recent ~exclude_system:true
+                 ~limit:100 ~offset:0 ())
+        | "goals" ->
+            Some
+              (Server_dashboard_http.dashboard_goals_snapshot_json
+                 ~config:state.Mcp_server.room_config)
         | _ ->
             None);
       (* Standalone WebSocket transport (enabled by default, opt-out via MASC_WS_ENABLED=0) *)

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -35,6 +35,17 @@ let test_sha1_different_inputs () =
   let r2 = Digestif.SHA1.(digest_string "b" |> to_raw_string) in
   Alcotest.(check bool) "different inputs different hashes" true (r1 <> r2)
 
+(* ====== Dashboard route-scoped slices ====== *)
+
+let test_dashboard_route_scoped_slices_are_valid () =
+  List.iter
+    (fun slice ->
+      Alcotest.(check bool)
+        (Printf.sprintf "%s is accepted" slice)
+        true
+        (Ws.valid_dashboard_slice slice))
+    [ "board"; "goals"; "composite" ]
+
 (* ====== External Subscriber Broadcast (WS delivery path) ====== *)
 
 let test_ws_external_subscriber_receives_broadcast () =
@@ -124,6 +135,10 @@ let () =
       Alcotest.test_case "produces 20 bytes" `Quick test_sha1_produces_20_bytes;
       Alcotest.test_case "deterministic" `Quick test_sha1_deterministic;
       Alcotest.test_case "different inputs" `Quick test_sha1_different_inputs;
+    ]);
+    ("dashboard", [
+      Alcotest.test_case "route scoped slices are valid" `Quick
+        test_dashboard_route_scoped_slices_are_valid;
     ]);
     ("external_subscriber", [
       Alcotest.test_case "single subscriber receives broadcast" `Quick


### PR DESCRIPTION
## Summary

Expand the route-scoped dashboard WebSocket path beyond the core shell/namespace/execution slices.

- provide backend snapshot payloads for `board`, `goals`, and `composite`
- hydrate those slices into board posts, planning/goals, goal tree, and fleet composite UI state
- parse raw SSE frames forwarded over WebSocket so unmapped push events are no longer dropped
- harden WebSocket RPC send/subscribe failure handling so retries are not suppressed

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `./scripts/dune-local.sh build test/test_ws_transport.exe`
- `./_build/default/test/test_ws_transport.exe`

## Notes

- `pnpm test -- dashboard-ws.test.ts sse-store.test.ts` was attempted, but this local sandbox repeatedly spawned Vitest workers with `--localstorage-file` warnings and did not reach test execution; the runaway process was stopped. The new route/hydration tests are included for CI.
- A final post-rebase Dune wrapper retry was attempted but blocked for several minutes behind unrelated shared Dune lock users; the focused OCaml build/test above passed before the final clean rebase, and CI should be treated as the final OCaml authority.
