### PR TITLE
[codex] Separate local-only liveness decision

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -131,12 +131,19 @@ let ensure_local_discovery_ready
              (String.concat ", " labels)
              (Printexc.to_string exn))
 
-let fail_open_local_only_when_unavailable
+type local_only_liveness_decision =
+  | Keep_effective_cascade of string
+  | Probe_local_only_urls of {
+      effective_cascade : string;
+      fallback_cascade : string;
+      ollama_base_urls : string list;
+    }
+
+let decide_local_only_liveness
     ?resolve_label
-    ?probe_ollama_base_url
     ~(base_cascade : string)
     ~(effective_cascade : string)
-    (labels : string list) : string =
+    (labels : string list) : local_only_liveness_decision =
   let resolve_label =
     match resolve_label with
     | Some resolve_label -> resolve_label
@@ -150,7 +157,7 @@ let fail_open_local_only_when_unavailable
   in
   if not (String.equal normalized_effective Keeper_config.local_only_cascade_name)
      || String.equal normalized_base Keeper_config.local_only_cascade_name
-  then normalized_effective
+  then Keep_effective_cascade normalized_effective
   else
     let ollama_urls =
       labels
@@ -162,8 +169,28 @@ let fail_open_local_only_when_unavailable
       |> dedupe_keep_order
     in
     match ollama_urls with
-    | [] -> normalized_effective
-    | _ ->
+    | [] -> Keep_effective_cascade normalized_effective
+    | ollama_base_urls ->
+        Probe_local_only_urls
+          {
+            effective_cascade = normalized_effective;
+            fallback_cascade = normalized_base;
+            ollama_base_urls;
+          }
+
+let fail_open_local_only_when_unavailable
+    ?resolve_label
+    ?probe_ollama_base_url
+    ~(base_cascade : string)
+    ~(effective_cascade : string)
+    (labels : string list) : string =
+  match
+    decide_local_only_liveness ?resolve_label ~base_cascade ~effective_cascade
+      labels
+  with
+  | Keep_effective_cascade cascade -> cascade
+  | Probe_local_only_urls
+      { effective_cascade; fallback_cascade; ollama_base_urls } ->
       let probe_ollama_base_url =
         match probe_ollama_base_url with
         | Some probe -> Some probe
@@ -175,10 +202,10 @@ let fail_open_local_only_when_unavailable
            | _ -> None)
       in
       (match probe_ollama_base_url with
-       | None -> normalized_effective
+       | None -> effective_cascade
        | Some probe ->
-         if List.exists probe ollama_urls then normalized_effective
-         else normalized_base)
+         if List.exists probe ollama_base_urls then effective_cascade
+         else fallback_cascade)
 
 (* Extracted to Keeper_error_classify — see keeper_error_classify.ml *)
 

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -87,6 +87,24 @@ val ensure_local_discovery_ready :
   string list ->
   (unit, string) result
 
+(** Deterministic decision for the local-only phase fallback boundary. This
+    does not probe runtime liveness; it only decides whether the selected
+    labels warrant an Ollama liveness check before preserving [local_only]. *)
+type local_only_liveness_decision =
+  | Keep_effective_cascade of string
+  | Probe_local_only_urls of {
+      effective_cascade : string;
+      fallback_cascade : string;
+      ollama_base_urls : string list;
+    }
+
+val decide_local_only_liveness :
+  ?resolve_label:(string -> Llm_provider.Provider_config.t option) ->
+  base_cascade:string ->
+  effective_cascade:string ->
+  string list ->
+  local_only_liveness_decision
+
 (** When phase routing temporarily forces [local_only], fail open to the
     keeper's configured base cascade if the local Ollama endpoint is
     unavailable. Explicit [local_only] keepers are preserved. Exposed for

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2706,6 +2706,52 @@ let test_ensure_local_discovery_ready_surfaces_refresh_failure () =
       check bool "error includes label" true
         (contains_substring msg "llama:auto")
 
+let provider_config_of_label label =
+  match Masc_mcp.Cascade_config.parse_model_string label with
+  | Some cfg -> cfg
+  | None -> fail ("expected model label to parse: " ^ label)
+
+let test_decide_local_only_liveness_keeps_non_local_effective () =
+  match
+    UT.decide_local_only_liveness
+      ~resolve_label:(fun _ -> fail "resolver should not run")
+      ~base_cascade:"keeper_unified"
+      ~effective_cascade:"default"
+      [ "not-a-real-label" ]
+  with
+  | UT.Keep_effective_cascade cascade ->
+      check string "keeps selected cascade" KC.default_cascade_name cascade
+  | UT.Probe_local_only_urls _ -> fail "unexpected local-only probe decision"
+
+let test_decide_local_only_liveness_keeps_explicit_local_only () =
+  match
+    UT.decide_local_only_liveness
+      ~resolve_label:(fun _ -> fail "resolver should not run")
+      ~base_cascade:"local_only"
+      ~effective_cascade:"local_only"
+      [ "not-a-real-label" ]
+  with
+  | UT.Keep_effective_cascade cascade ->
+      check string "keeps explicit local_only" "local_only" cascade
+  | UT.Probe_local_only_urls _ -> fail "unexpected local-only probe decision"
+
+let test_decide_local_only_liveness_requests_deduped_ollama_probe () =
+  let label = "ollama:qwen3.6:35b-a3b-mlx-bf16" in
+  let cfg = provider_config_of_label label in
+  match
+    UT.decide_local_only_liveness
+      ~base_cascade:"keeper_unified"
+      ~effective_cascade:"local_only"
+      [ label; label ]
+  with
+  | UT.Keep_effective_cascade _ -> fail "expected Ollama liveness probe"
+  | UT.Probe_local_only_urls
+      { effective_cascade; fallback_cascade; ollama_base_urls } ->
+      check string "effective cascade" "local_only" effective_cascade;
+      check string "fallback cascade" "keeper_unified" fallback_cascade;
+      check (list string) "deduped probe URLs" [ cfg.base_url ]
+        ollama_base_urls
+
 let test_fail_open_local_only_when_probe_fails () =
   let cascade =
     UT.fail_open_local_only_when_unavailable
@@ -2717,13 +2763,17 @@ let test_fail_open_local_only_when_probe_fails () =
   check string "falls back to base cascade" "tool_rerank" cascade
 
 let test_fail_open_local_only_preserves_explicit_local_only_base () =
+  let probe_calls = ref 0 in
   let cascade =
     UT.fail_open_local_only_when_unavailable
-      ~probe_ollama_base_url:(fun _ -> false)
+      ~probe_ollama_base_url:(fun _ ->
+        incr probe_calls;
+        false)
       ~base_cascade:"local_only"
       ~effective_cascade:"local_only"
       [ "ollama:qwen3.6:35b-a3b-mlx-bf16" ]
   in
+  check int "probe not called" 0 !probe_calls;
   check string "explicit local_only stays local_only" "local_only" cascade
 
 let test_fail_open_local_only_preserves_healthy_local_only () =
@@ -5280,6 +5330,14 @@ let () =
             test_sync_keeper_paused_state_surfaces_write_failure_without_mutating_registry;
           test_case "local discovery guard surfaces refresh failure" `Quick
             test_ensure_local_discovery_ready_surfaces_refresh_failure;
+          test_case "local_only liveness decision keeps non-local route" `Quick
+            test_decide_local_only_liveness_keeps_non_local_effective;
+          test_case "local_only liveness decision keeps explicit local base"
+            `Quick
+            test_decide_local_only_liveness_keeps_explicit_local_only;
+          test_case "local_only liveness decision requests deduped probe"
+            `Quick
+            test_decide_local_only_liveness_requests_deduped_ollama_probe;
           test_case "local_only fail-open falls back when ollama is down" `Quick
             test_fail_open_local_only_when_probe_fails;
           test_case "explicit local_only does not fail-open" `Quick


### PR DESCRIPTION
## Summary
- Add a typed `local_only_liveness_decision` contract for the local-only phase fallback boundary.
- Keep deterministic cascade selection separate from the nondeterministic Ollama liveness probe adapter.
- Add focused `phase_gate` tests for non-local routes, explicit `local_only`, deduped probe URLs, and no-probe explicit local-only behavior.

## Why
The local-only fail-open path previously mixed three concerns in one function: cascade-name normalization, label-to-provider resolution, and live Ollama probing. This made the deterministic routing contract hard to inspect and easy to mistake for ordinary cascade selection. The new decision type makes the pure boundary explicit while preserving the existing runtime behavior.

## Validation
- `git diff --check HEAD~1..HEAD`
- `scripts/dune-local.sh build test/test_keeper_unified.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-local-only-liveness-boundary-rebase2 ./_build/default/test/test_keeper_unified.exe test phase_gate 5-10`
- `scripts/review/local-review.sh --base origin/main --head HEAD --format markdown --no-cache` with GLM direct reviewer: `No findings.`