### PR TITLE
fix(cascade): resolve Kimi max_context from OAS SSOT (#9953 follow-up)

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -150,7 +150,44 @@ let kimi_provider_name = "kimi"
 let moonshot_base_url_env = "KIMI_BASE_URL"
 let moonshot_api_key_env = "KIMI_API_KEY_SB"
 let moonshot_default_base_url = "https://api.moonshot.ai/v1"
-let kimi_default_max_context = 256_000
+
+(* #9953: Resolve Kimi max_context from the OAS capabilities SSOT.
+
+   Prior code hard-coded [256_000] here, which drifted from the
+   OAS [Capabilities.kimi_capabilities.max_context_tokens] value
+   of [262_144] (the canonical 256 KiB binary context window).
+   Same-label [kimi] turns therefore recorded two different
+   [context_max] values depending on which config builder ran —
+   one symptom of the 3-way [claude_code:auto] drift documented
+   in the issue.
+
+   Resolution order:
+   1. Per-model capabilities override ({!Capabilities.for_model_id}
+      resolved id) — allows future per-variant overrides to take
+      effect without touching this file.
+   2. Provider-level [kimi_capabilities.max_context_tokens] from
+      the OAS SSOT.
+   3. Registry entry default (safety net for exotic configs).
+*)
+let resolve_kimi_max_context resolved_model_id =
+  let open Llm_provider in
+  let from_model =
+    Option.bind
+      (Capabilities.for_model_id resolved_model_id)
+      (fun c -> c.Capabilities.max_context_tokens)
+  in
+  match from_model with
+  | Some n -> n
+  | None ->
+    (match Capabilities.kimi_capabilities.max_context_tokens with
+     | Some n -> n
+     | None ->
+       (* OAS SSOT has always populated this; fall through to
+          registry entry only if OAS removes the field. *)
+       (match Provider_registry.find (Provider_registry.default ())
+                kimi_provider_name with
+        | Some entry -> entry.Provider_registry.max_context
+        | None -> 0))
 
 let is_kimi_provider provider_name =
   String.equal provider_name kimi_provider_name
@@ -201,7 +238,7 @@ let make_kimi_config ~temperature ~max_tokens ?system_prompt
     ~request_path:(moonshot_request_path ())
     ~temperature
     ~max_tokens
-    ~max_context:kimi_default_max_context
+    ~max_context:(resolve_kimi_max_context resolved_model_id)
     ?system_prompt
     ?supports_tool_choice_override
     ()

--- a/test/dune
+++ b/test/dune
@@ -710,6 +710,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_cascade_kimi_max_context_ssot)
+ (modules test_cascade_kimi_max_context_ssot)
+ (libraries masc_test_deps))
+
+(test
  (name test_cascade_catalog_runtime)
  (modules test_cascade_catalog_runtime)
  (libraries masc_test_deps))

--- a/test/test_cascade_kimi_max_context_ssot.ml
+++ b/test/test_cascade_kimi_max_context_ssot.ml
@@ -1,0 +1,70 @@
+(* test/test_cascade_kimi_max_context_ssot.ml
+
+   #9953: Verify [Cascade_config.make_kimi_config] resolves
+   [max_context] from the OAS [Llm_provider.Capabilities] SSOT
+   rather than a drifted local constant.
+
+   Prior code hard-coded [256_000] in cascade_config, while the
+   OAS capabilities SSOT records [262_144] — same "256k" concept
+   in two encodings, causing per-turn [context_max] drift. *)
+
+module CC = Masc_mcp.Cascade_config
+module Caps = Llm_provider.Capabilities
+
+let oas_kimi_max_context () =
+  match Caps.kimi_capabilities.max_context_tokens with
+  | Some n -> n
+  | None -> Alcotest.fail "OAS kimi_capabilities missing max_context_tokens"
+
+(* Sanity: the OAS SSOT still publishes a numeric cap. This pins
+   the reference the resolver reads from — if the OAS pin bumps
+   and kimi max_context changes, this test documents the coupling. *)
+let test_oas_ssot_publishes_max_context () =
+  let n = oas_kimi_max_context () in
+  Alcotest.(check bool) "positive" true (n > 0)
+
+(* Parse a kimi model string and verify the produced Provider_config
+   reports the OAS SSOT value. *)
+let test_parse_model_string_uses_oas_ssot () =
+  let expected = oas_kimi_max_context () in
+  Unix.putenv "KIMI_API_KEY" "sk-test-9953";
+  match CC.parse_model_string "kimi:kimi-for-coding" with
+  | None ->
+    Alcotest.fail
+      "parse_model_string returned None for 'kimi:kimi-for-coding' \
+       (expected a Provider_config with max_context from OAS SSOT)"
+  | Some cfg ->
+    Alcotest.(check (option int))
+      "make_kimi_config resolves max_context from OAS capabilities SSOT \
+       (no local 256_000 drift)"
+      (Some expected) cfg.max_context
+
+(* Regression guard: the drifted constant must be gone. If a
+   future refactor re-introduces a literal 256_000 in this
+   resolver path, the [make_kimi_config] output would disagree
+   with OAS and reopen #9953. *)
+let test_no_local_256000_literal () =
+  Unix.putenv "KIMI_API_KEY" "sk-test-9953";
+  match CC.parse_model_string "kimi:auto" with
+  | None -> Alcotest.fail "parse_model_string None for 'kimi:auto'"
+  | Some cfg ->
+    Alcotest.(check bool)
+      "max_context must not be the legacy decimal literal 256_000"
+      true (cfg.max_context <> Some 256_000)
+
+let () =
+  Alcotest.run "cascade_kimi_max_context_ssot_9953"
+    [
+      ( "oas_ssot",
+        [
+          Alcotest.test_case "publishes max_context" `Quick
+            test_oas_ssot_publishes_max_context;
+        ] );
+      ( "make_kimi_config",
+        [
+          Alcotest.test_case "uses OAS SSOT value" `Quick
+            test_parse_model_string_uses_oas_ssot;
+          Alcotest.test_case "no legacy 256_000 literal" `Quick
+            test_no_local_256000_literal;
+        ] );
+    ]


### PR DESCRIPTION
## 요약

`Cascade_config.make_kimi_config` 가 로컬 상수 `kimi_default_max_context = 256_000` 를 사용했음. OAS `Llm_provider.Capabilities.kimi_capabilities.max_context_tokens` SSOT 는 `262_144` — 같은 "256k" 개념의 두 인코딩 (decimal vs binary 2^18). 이 드리프트가 #9953 이 보고하는 per-turn [context_max] drift 의 원인 한 가닥.

이 PR 은 local constant 를 제거하고 OAS SSOT 를 참조하도록 전환. `make_registry_config` (line 258-266) 이 이미 사용하는 resolution order 를 그대로 따름:

1. `Capabilities.for_model_id resolved_model_id` — per-model override 우선.
2. `Capabilities.kimi_capabilities.max_context_tokens` — provider-level OAS SSOT.
3. `Provider_registry.find "kimi"` entry default — OAS 가 필드를 제거할 경우 safety net.

## 변경 파일

- `lib/cascade/cascade_config.ml`
  - `kimi_default_max_context = 256_000` 제거.
  - `resolve_kimi_max_context` helper 신규 — 위 3-tier resolution.
  - `make_kimi_config` 의 `~max_context:kimi_default_max_context` → `~max_context:(resolve_kimi_max_context resolved_model_id)`.
- `test/test_cascade_kimi_max_context_ssot.ml` (신규) — 3 테스트:
  - OAS SSOT 가 양수 값 publish 함 (sanity).
  - `parse_model_string \"kimi:kimi-for-coding\"` 가 OAS SSOT 값 반환.
  - 262144 변경 자체가 회귀되지 않도록 literal 256_000 을 금지하는 regression guard.
- `test/dune` — 새 test stanza 등록.

## 로컬 검증

```
$ MASC_BASE_PATH=/tmp/masc-test-9953b dune exec test/test_cascade_kimi_max_context_ssot.exe
Testing 'cascade_kimi_max_context_ssot_9953'.
  [OK] oas_ssot 0   publishes max_context.
  [OK] make_kimi_config 0 uses OAS SSOT value.
  [OK] make_kimi_config 1 no legacy 256_000 literal.
Test Successful in 0.002s. 3 tests run.
```

`dune build` clean.

## 왜 근원 fix 인가

- `feedback_masc-oas-layer-boundary.md`: raw provider capabilities 는 OAS 영역, MASC 는 소비자. Local constant 는 이 boundary 위반.
- 262_144 로 단순 변경 (하드코드 교체) 이 아니라 OAS 를 SSOT 로 선언 — 향후 OAS pin 업데이트 시 (`feedback_oas-pin-bump-drift-gate.md`) 자동 동기화.
- #9953 의 3-way drift 근본 원인 중 label→variant 파트는 관찰자 PR #9962 로 가시화했고, 본 PR 은 provider 단 SSOT 위반 한 가닥을 실제로 제거.

## 미검증 / 후속

- 실제 Kimi CLI 가 262_144 token input 을 허용하는지는 moonshot API 문서 확인 필요. 단 OAS SSOT 가 이미 그렇게 공표한 상태이고, 이 PR 은 MASC 가 해당 값에 정렬되도록 하는 것일 뿐.
- `oas_worker_exec_transport.ml:361` 의 하드코드 262_144 는 OAS SSOT 와 이미 일치 — 현재 틀림 없음. 단 향후 자동 동기화하려면 같은 resolver 를 사용하도록 리팩터링 가능 (별도 PR).
- #9953 본문의 3-way `claude_code:auto` drift 는 auto-resolution 동역학 문제로 별도 해결 (resolved_model_id 는 #9962 로 가시화).

## 관련

- #9953 (root issue).
- #9962 (tick #16, `resolved_model_id` observability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)