### PR TITLE
test(mcp-server-eio): accept verifier-gate redirect in alias-reuse test (#9874)

### DIFF
--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1565,7 +1565,15 @@ let test_execute_tool_explicit_alias_reuses_joined_nickname () =
       "done"
   in
   Alcotest.(check bool) "done success with same explicit alias" true ok_done;
-  Alcotest.(check bool) "done message has done" true (contains_substring done_msg "done");
+  (* The verifier-gate redirects Done → Submit_for_verification when no
+     CDAL verdict is present, producing the terminal status
+     [awaiting_verification]. Either [done] (no gate) or
+     [awaiting_verification] (gate active) is a valid terminal outcome;
+     the alias-reuse intent is covered by [ok_done = true] plus the
+     stable agent alias used across all three transitions. *)
+  Alcotest.(check bool) "done or awaiting_verification reached" true
+    (contains_substring done_msg "done"
+     || contains_substring done_msg "awaiting_verification");
 
   cleanup_dir base_path
 


### PR DESCRIPTION
## 요약

`test_execute_tool_explicit_alias_reuses_joined_nickname` (eio 45)가 done-transition 메시지에 `"done"` 서브스트링이 있기를 기대했지만, 최근 추가된 verifier-gate가 `Done → Submit_for_verification`으로 redirect하면서 실제 terminal status가 `awaiting_verification`이 됨. 테스트의 진짜 의도(explicit alias 재사용)는 그대로인데 surface substring 어서션이 gate 동작에 취약해서 깨진 것.

Partially closes #9874 (Failure 2). Failure 1 (clock delegation)은 #9955에서 이미 수정.

## 재현

```bash
dune exec --root . test/test_mcp_server_eio.exe -- test eio 45
```

Before:
```
DEBUG done_msg="✅ task-001 in_progress → awaiting_verification"
FAIL done message has done
   Expected: `true'
   Received: `false'
```

## 근본 원인

- Verifier-gate가 `Done` transition을 가로채 CDAL verdict가 없을 때 `Submit_for_verification`으로 redirect (`contract_items=3` 감지 시).
- 결과 status: `awaiting_verification` (task status), 메시지는 `"in_progress → awaiting_verification"`.
- 로그 확인: `task task-001 submit_for_verification by alpha-agent-grand-koala` — **alias는 재사용 정상** (의도는 통과).

## 변경 내용

```diff
  Alcotest.(check bool) "done success with same explicit alias" true ok_done;
- Alcotest.(check bool) "done message has done" true (contains_substring done_msg "done");
+ Alcotest.(check bool) "done or awaiting_verification reached" true
+   (contains_substring done_msg "done"
+    || contains_substring done_msg "awaiting_verification");
```

주석으로 verifier-gate redirect 동작을 기록. alias 재사용 어서션은 `ok_done = true` + 3개 transition에서 같은 `alpha-agent` alias 사용 일관성으로 커버됨.

## 검증

```bash
MASC_BASE_PATH=/tmp/masc-test-$$ MASC_TEST_ALLOW_HOME_BASE_PATH=1 \
  dune exec --root . test/test_mcp_server_eio.exe -- test eio 45
# → Test Successful in 0.052s. 1 test run.
```

## 회귀 리스크

매우 낮음 — 테스트 어서션 한 줄. production 코드 변경 없음. 기존 `"done"` 경로도 여전히 허용하므로 verifier-gate가 비활성인 경로에서도 호환.

## 참고

- Issue #9874 — 2 pre-existing failures (Failure 1: fixed by #9955, Failure 2: this PR)
- Verifier-gate redirect: `[verifier-gate] redirecting Done→Submit_for_verification task=task-001 agent=alpha-agent-* contract_items=3`
