### PR TITLE
[codex] Gate keeper task claims by required tools

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -101,6 +101,7 @@ let normalize_execution_links (links : Types.task_execution_links) =
 let normalize_task_contract (contract : Types.task_contract) =
   { contract with
     completion_contract = normalized_string_list contract.completion_contract
+  ; required_tools = normalized_string_list contract.required_tools
   ; required_evidence = normalized_string_list contract.required_evidence
   ; inspect_gate_evidence = normalized_string_list contract.inspect_gate_evidence
   ; verify_gate_evidence = normalized_string_list contract.verify_gate_evidence
@@ -111,6 +112,7 @@ let normalize_task_contract (contract : Types.task_contract) =
 let empty_task_contract =
   { strict = false
   ; completion_contract = []
+  ; required_tools = []
   ; required_evidence = []
   ; inspect_gate_evidence = []
   ; verify_gate_evidence = []

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -65,6 +65,180 @@ let verification_blocks_claim latest_status_by_task (task : Types.task) =
   | Some (_, `Passed)
   | None -> false
 
+let task_required_tools (task : Types.task) =
+  match task.contract with
+  | Some contract -> contract.required_tools
+  | None -> []
+
+let string_list_contains all value =
+  List.exists (String.equal value) all
+
+let required_tools_allowed ?agent_tool_names required_tools =
+  match required_tools, agent_tool_names with
+  | [], _ -> true
+  | _ :: _, None -> true
+  | required, Some allowed ->
+      List.for_all (string_list_contains allowed) required
+
+let underscore_name name =
+  String.map (function '-' -> '_' | c -> c) name
+
+let hyphen_name name =
+  String.map (function '_' -> '-' | c -> c) name
+
+let keeper_name_from_agent_name agent_name =
+  let trimmed = String.trim agent_name in
+  if
+    String.starts_with ~prefix:"keeper-" trimmed
+    && String.ends_with ~suffix:"-agent" trimmed
+    && String.length trimmed > 13
+  then Some (String.sub trimmed 7 (String.length trimmed - 13))
+  else if String.ends_with ~suffix:"-agent" trimmed && String.length trimmed > 6
+  then Some (String.sub trimmed 0 (String.length trimmed - 6))
+  else None
+
+let agent_record_keeper_name config ~agent_name =
+  let agent_file =
+    Filename.concat (agents_dir config) (safe_filename agent_name ^ ".json")
+  in
+  if path_exists config agent_file then
+    match read_agent_with_repair config agent_file with
+    | Ok { meta = Some { keeper_name = Some name; _ }; _ } ->
+        let name = String.trim name in
+        if name = "" then None else Some name
+    | Ok _ | Error _ -> None
+  else None
+
+let keeper_receipt_candidate_names config ~agent_name =
+  let base =
+    [ agent_record_keeper_name config ~agent_name
+    ; keeper_name_from_agent_name agent_name
+    ; Some agent_name
+    ]
+    |> List.filter_map Fun.id
+  in
+  base
+  |> List.concat_map (fun name ->
+       let trimmed = String.trim name in
+       if trimmed = "" then []
+       else
+         [ trimmed; safe_filename trimmed; underscore_name trimmed; hyphen_name trimmed ])
+  |> List.sort_uniq String.compare
+
+let directory_exists path =
+  try Sys.file_exists path && Sys.is_directory path with _ -> false
+
+let directory_entries path =
+  try Sys.readdir path |> Array.to_list with _ -> []
+
+let jsonl_files_under base_dir =
+  if not (directory_exists base_dir) then []
+  else
+    directory_entries base_dir
+    |> List.filter_map (fun month ->
+         let month_dir = Filename.concat base_dir month in
+         if directory_exists month_dir then Some month_dir else None)
+    |> List.concat_map (fun month_dir ->
+         directory_entries month_dir
+         |> List.filter (String.ends_with ~suffix:".jsonl")
+         |> List.map (Filename.concat month_dir))
+
+let last_nonempty_line path =
+  try
+    let input = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr input)
+      (fun () ->
+         let rec loop last =
+           match input_line input with
+           | line ->
+               let trimmed = String.trim line in
+               loop (if trimmed = "" then last else Some trimmed)
+           | exception End_of_file -> last
+         in
+         loop None)
+  with _ -> None
+
+let latest_json_in_receipt_dir base_dir =
+  jsonl_files_under base_dir
+  |> List.sort (fun a b -> compare b a)
+  |> List.find_map (fun path ->
+       match last_nonempty_line path with
+       | None -> None
+       | Some line -> (
+           try Some (Yojson.Safe.from_string line)
+           with Yojson.Json_error _ -> None))
+
+let json_member_path path json =
+  List.fold_left
+    (fun current key -> Yojson.Safe.Util.member key current)
+    json
+    path
+
+let json_raw_string_path path json =
+  match json_member_path path json with
+  | `String value -> Some (String.trim value)
+  | _ -> None
+
+let json_string_path path json =
+  json_raw_string_path path json
+  |> Option.map String.lowercase_ascii
+
+let receipt_sort_key json =
+  match json_raw_string_path [ "recorded_at" ] json with
+  | Some value -> value
+  | None ->
+      Option.value ~default:"" (json_raw_string_path [ "ended_at" ] json)
+
+let latest_execution_receipt_json config ~agent_name =
+  let keeper_root = Filename.concat (masc_root_dir config) "keepers" in
+  keeper_receipt_candidate_names config ~agent_name
+  |> List.filter_map (fun keeper_name ->
+       let base_dir =
+         Filename.concat
+           (Filename.concat keeper_root keeper_name)
+           "execution-receipts"
+       in
+       latest_json_in_receipt_dir base_dir)
+  |> List.sort (fun a b -> compare (receipt_sort_key b) (receipt_sort_key a))
+  |> List.find_opt (fun _ -> true)
+
+let json_string_list key json =
+  match Yojson.Safe.Util.member key json with
+  | `List items ->
+      List.filter_map
+        (function
+          | `String value ->
+              let trimmed = String.trim value in
+              if trimmed = "" then None else Some trimmed
+          | _ -> None)
+        items
+  | _ -> []
+
+let latest_receipt_blocks_required_tool_claim config ~agent_name =
+  match latest_execution_receipt_json config ~agent_name with
+  | None -> false
+  | Some receipt ->
+      let operator_reason =
+        json_string_path [ "operator_disposition_reason" ] receipt
+      in
+      let tool_contract_result =
+        json_string_path [ "tool_contract_result" ] receipt
+      in
+      let tool_requirement =
+        json_string_path [ "tool_surface"; "tool_requirement" ] receipt
+      in
+      let tools_used = json_string_list "tools_used" receipt in
+      let degraded_contract =
+        match tool_contract_result with
+        | Some ("violated" | "unknown" | "satisfied_by_deterministic_fallback") ->
+            true
+        | Some _ | None -> false
+      in
+      operator_reason = Some "tool_required_no_tools"
+      || degraded_contract
+      || (tool_requirement = Some "required" && tools_used = [])
+
 let agent_current_task_matches_backlog backlog ~agent_name task_id =
   match
     List.find_opt
@@ -126,6 +300,7 @@ let reconcile_agent_current_task_with_backlog config ~agent_name backlog =
 let claim_next_r
       config
       ~agent_name
+      ?agent_tool_names
       ?(exclude_task_ids = [])
       ?(task_filter = fun _ -> true)
       ()
@@ -241,6 +416,35 @@ let claim_next_r
         | Some rid -> rid :: (blocked_ids @ exclude_task_ids)
         | None -> blocked_ids @ exclude_task_ids
       in
+      let required_tool_receipt_blocked =
+        List.exists (fun task -> task_required_tools task <> []) unclaimed
+        && latest_receipt_blocks_required_tool_claim config ~agent_name
+      in
+      let required_tool_claim_allowed (task : task) =
+        let required_tools = task_required_tools task in
+        required_tools_allowed ?agent_tool_names required_tools
+        && (required_tools = [] || not required_tool_receipt_blocked)
+      in
+      let required_tool_excluded =
+        List.filter
+          (fun (t : task) ->
+             (not (List.mem t.id all_excluded))
+             && task_filter t
+             && not (required_tool_claim_allowed t))
+          unclaimed
+      in
+      if required_tool_excluded <> [] then
+        log_event config
+          (Printf.sprintf
+             "{\"type\":\"task_claim_next_skip_required_tools\",\"agent\":\"%s\",\"blocked\":%d,\"receipt_blocked\":%b,\"agent_tool_names_known\":%b,\"ts\":\"%s\"}"
+             agent_name
+             (List.length required_tool_excluded)
+             required_tool_receipt_blocked
+             (Option.is_some agent_tool_names)
+             (now_iso ()));
+      let effective_task_filter task =
+        task_filter task && required_tool_claim_allowed task
+      in
       let task_filter_excluded =
         List.filter
           (fun (t : task) -> (not (List.mem t.id all_excluded)) && not (task_filter t))
@@ -248,7 +452,8 @@ let claim_next_r
       in
       let eligible_from candidates =
         List.filter
-          (fun (t : task) -> (not (List.mem t.id all_excluded)) && task_filter t)
+          (fun (t : task) ->
+             (not (List.mem t.id all_excluded)) && effective_task_filter t)
           candidates
       in
       let primary_eligible = eligible_from primary_unclaimed in
@@ -302,7 +507,9 @@ let claim_next_r
           Claim_next_no_eligible
             {
               excluded_count =
-                List.length all_excluded + List.length task_filter_excluded;
+                List.length all_excluded
+                + List.length task_filter_excluded
+                + List.length required_tool_excluded;
             }
       | _ :: _, task :: _ ->
           (* Claim this task *)

--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -39,6 +39,17 @@ let resolve_task_create_goal_id ~config ~(meta : keeper_meta) args =
                 (String.concat ", " goal_ids)))
 ;;
 
+let parse_task_contract_arg args =
+  match Yojson.Safe.Util.member "contract" args with
+  | `Null -> Ok None
+  | (`Assoc _ as json) -> (
+      match Types.task_contract_of_yojson json with
+      | Ok contract -> Ok (Some contract)
+      | Error message ->
+          Error (Printf.sprintf "Invalid contract payload: %s" message))
+  | _ -> Error "contract must be an object when provided"
+;;
+
 let active_goal_scope_json ~(meta : keeper_meta) ?matched_goal_id
     ?excluded_count () =
   let scoped = meta.active_goal_ids <> [] in
@@ -197,16 +208,20 @@ let handle_keeper_task_tool
       match resolve_task_create_goal_id ~config ~meta args with
       | Error message -> error_json message
       | Ok goal_id ->
-          let result =
-            Coord_task.add_task ?goal_id config ~title ~priority ~description
-          in
-          Yojson.Safe.to_string
-            (`Assoc
-              [
-                "ok", `Bool true;
-                "result", `String result;
-                "goal_id", Json_util.string_opt_to_json goal_id;
-              ]))
+          (match parse_task_contract_arg args with
+           | Error message -> error_json message
+           | Ok contract ->
+              let result =
+                Coord_task.add_task ?contract ?goal_id config ~title ~priority
+                  ~description
+              in
+              Yojson.Safe.to_string
+                (`Assoc
+                  [
+                    "ok", `Bool true;
+                    "result", `String result;
+                    "goal_id", Json_util.string_opt_to_json goal_id;
+                  ])))
   | "keeper_task_claim" ->
     let task_filter =
       match meta.active_goal_ids with
@@ -214,8 +229,10 @@ let handle_keeper_task_tool
       | goal_ids ->
         fun task -> Keeper_runtime_contract.task_is_linked_to_keeper_goals goal_ids task
     in
+    let agent_tool_names = Keeper_tool_policy.keeper_allowed_tool_names meta in
     let result =
-      Coord.claim_next_r config ~agent_name:meta.agent_name ~task_filter ()
+      Coord.claim_next_r config ~agent_name:meta.agent_name ~agent_tool_names
+        ~task_filter ()
     in
     (match result with
      | Coord.Claim_next_claimed { task_id; _ } ->

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -773,6 +773,22 @@ Duplicate titles are rejected automatically (dedup by normalized title).";
           ("type", `String "string");
           ("description", `String "Optional structured goal linkage. Preferred over relying only on [goal:<id>] in the title.");
         ]);
+        ("contract", `Assoc [
+          ("type", `String "object");
+          ("description", `String "Optional persisted task contract. Use required_tools to prevent routing execution work to keepers without needed tools.");
+          ("properties", `Assoc [
+            ("strict", `Assoc [ ("type", `String "boolean") ]);
+            ("completion_contract", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
+            ("required_tools", `Assoc [
+              ("type", `String "array");
+              ("items", `Assoc [ ("type", `String "string") ]);
+              ("description", `String "Tool names required to claim this task, e.g. keeper_bash or masc_code_git.");
+            ]);
+            ("required_evidence", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
+            ("inspect_gate_evidence", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
+            ("verify_gate_evidence", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
+          ]);
+        ]);
       ]);
       ("required", `List [`String "title"; `String "description"]);
     ];

--- a/lib/tool_task_schemas.ml
+++ b/lib/tool_task_schemas.ml
@@ -39,6 +39,11 @@ Example: masc_add_task({title: 'Fix login bug', goal_id: 'g-123', priority: 1, d
           ("properties", `Assoc [
             ("strict", `Assoc [ ("type", `String "boolean") ]);
             ("completion_contract", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
+            ("required_tools", `Assoc [
+              ("type", `String "array");
+              ("items", `Assoc [ ("type", `String "string") ]);
+              ("description", `String "Tool names required to claim this task, e.g. keeper_bash or masc_code_git.");
+            ]);
             ("required_evidence", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
             ("inspect_gate_evidence", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
             ("verify_gate_evidence", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
@@ -94,6 +99,11 @@ Example: masc_batch_add_tasks({tasks: [{title: 'Task A', goal_id: 'g-123', prior
                 ("properties", `Assoc [
                   ("strict", `Assoc [ ("type", `String "boolean") ]);
                   ("completion_contract", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
+                  ("required_tools", `Assoc [
+                    ("type", `String "array");
+                    ("items", `Assoc [ ("type", `String "string") ]);
+                    ("description", `String "Tool names required to claim this task, e.g. keeper_bash or masc_code_git.");
+                  ]);
                   ("required_evidence", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
                   ("inspect_gate_evidence", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
                   ("verify_gate_evidence", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -491,6 +491,7 @@ let task_execution_links_of_yojson json =
 type task_contract = {
   strict : bool;
   completion_contract : string list;
+  required_tools : string list;
   required_evidence : string list;
   inspect_gate_evidence : string list;
   verify_gate_evidence : string list;
@@ -518,6 +519,7 @@ let task_contract_to_yojson (contract : task_contract) =
       ("strict", `Bool contract.strict);
       ( "completion_contract",
         string_list_to_yojson contract.completion_contract );
+      ("required_tools", string_list_to_yojson contract.required_tools);
       ("required_evidence", string_list_to_yojson contract.required_evidence);
       ( "inspect_gate_evidence",
         string_list_to_yojson contract.inspect_gate_evidence );
@@ -554,6 +556,7 @@ let task_contract_of_yojson json =
       {
         strict;
         completion_contract = task_contract_string_list json "completion_contract";
+        required_tools = task_contract_string_list json "required_tools";
         required_evidence = task_contract_string_list json "required_evidence";
         inspect_gate_evidence =
           task_contract_string_list json "inspect_gate_evidence";

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -13,6 +13,9 @@ let make_test_meta ?(name = "test-keeper") () : Keeper_types.keeper_meta =
 let make_goal_scoped_meta goal_ids =
   { (make_test_meta ()) with active_goal_ids = goal_ids }
 
+let make_meta_with_tools tools =
+  { (make_test_meta ()) with tool_access = Keeper_types.Custom tools }
+
 let make_ctx_work () =
   Keeper_exec_context.create ~system_prompt:"test" ~max_tokens:4000
 
@@ -47,9 +50,26 @@ let strict_contract ?(verify_gate_evidence = []) () : Types.task_contract =
   {
     strict = true;
     completion_contract = [ "tests pass" ];
+    required_tools = [];
     required_evidence = [];
     inspect_gate_evidence = [];
     verify_gate_evidence;
+    links =
+      {
+        operation_id = None;
+        session_id = None;
+        autoresearch_loop_id = None;
+      };
+  }
+
+let contract_requiring_tools required_tools : Types.task_contract =
+  {
+    strict = false;
+    completion_contract = [];
+    required_tools;
+    required_evidence = [];
+    inspect_gate_evidence = [];
+    verify_gate_evidence = [];
     links =
       {
         operation_id = None;
@@ -229,6 +249,59 @@ let test_claim_respects_active_goal_ids () =
         Yojson.Safe.Util.(
           json |> member "claimed_task" |> member "goal_id" |> to_string)
     | None -> fail "expected a claimed task")
+
+let test_claim_skips_required_tools_without_access () =
+  with_room (fun config ->
+    let meta = make_meta_with_tools [ "keeper_task_claim"; "keeper_tasks_list" ] in
+    let _ =
+      Coord.add_task
+        ~contract:(contract_requiring_tools [ "keeper_bash" ])
+        config
+        ~title:"Needs bash"
+        ~priority:1
+        ~description:"requires shell execution"
+    in
+    let _ =
+      Coord.add_task config ~title:"Readable fallback" ~priority:2
+        ~description:"does not require shell"
+    in
+    ignore (call_tool config meta "keeper_task_claim" (`Assoc []));
+    let claimed =
+      Coord.get_tasks_raw config
+      |> List.find_opt (fun (task : Types.task) ->
+           Types.task_assignee_of_status task.task_status = Some meta.agent_name)
+    in
+    match claimed with
+    | Some task -> check string "claimed fallback" "Readable fallback" task.title
+    | None -> fail "expected fallback task to be claimed")
+
+let test_claim_allows_required_tools_with_access () =
+  with_room (fun config ->
+    let meta =
+      make_meta_with_tools
+        [ "keeper_task_claim"; "keeper_tasks_list"; "keeper_bash" ]
+    in
+    let _ =
+      Coord.add_task
+        ~contract:(contract_requiring_tools [ "keeper_bash" ])
+        config
+        ~title:"Needs bash"
+        ~priority:1
+        ~description:"requires shell execution"
+    in
+    let _ =
+      Coord.add_task config ~title:"Readable fallback" ~priority:2
+        ~description:"does not require shell"
+    in
+    ignore (call_tool config meta "keeper_task_claim" (`Assoc []));
+    let claimed =
+      Coord.get_tasks_raw config
+      |> List.find_opt (fun (task : Types.task) ->
+           Types.task_assignee_of_status task.task_status = Some meta.agent_name)
+    in
+    match claimed with
+    | Some task -> check string "claimed required-tool task" "Needs bash" task.title
+    | None -> fail "expected required-tool task to be claimed")
 
 let test_create_defaults_single_active_goal_id () =
   with_room (fun config ->
@@ -624,6 +697,10 @@ let () =
       test_case "claim empty room" `Quick test_claim_empty_room;
       test_case "claim respects active_goal_ids" `Quick
         test_claim_respects_active_goal_ids;
+      test_case "claim skips tasks requiring missing tools" `Quick
+        test_claim_skips_required_tools_without_access;
+      test_case "claim allows tasks requiring available tools" `Quick
+        test_claim_allows_required_tools_with_access;
       test_case "create defaults single active goal_id" `Quick
         test_create_defaults_single_active_goal_id;
       test_case "create requires explicit goal_id for multiple active goals" `Quick

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -218,6 +218,7 @@ let test_backlog_parse_live_shape_with_null_optional_nested_fields () =
                     [
                       ("strict", `Bool false);
                       ("completion_contract", `List []);
+                      ("required_tools", `List [ `String "keeper_bash" ]);
                       ("required_evidence", `List []);
                       ("inspect_gate_evidence", `List []);
                       ("verify_gate_evidence", `List []);
@@ -263,7 +264,9 @@ let test_backlog_parse_live_shape_with_null_optional_nested_fields () =
              contract.links.session_id;
            Alcotest.(check (option string))
              "autoresearch_loop_id null -> None" None
-             contract.links.autoresearch_loop_id)
+             contract.links.autoresearch_loop_id;
+           Alcotest.(check (list string)) "required_tools parsed"
+             [ "keeper_bash" ] contract.required_tools)
 
 let () =
   Alcotest.run "Types" [

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -50,6 +50,7 @@ let add_strict_task config =
   let contract : Types.task_contract = {
     strict = true;
     completion_contract = ["tests pass"];
+    required_tools = [];
     required_evidence = [];
     inspect_gate_evidence = [];
     verify_gate_evidence = ["output.json"];


### PR DESCRIPTION
## Summary
- add `contract.required_tools` to task contracts and expose it through task creation schemas
- route keeper task claims through the keeper's allowed tool surface
- skip required-tool tasks when the keeper lacks the needed tools or its latest execution receipt shows an unhealthy required tool lane

## Root Cause
Shell-bound tasks were only described in prose. Keepers without shell/bash access could claim them, fail to execute, release or re-claim them, and clog the task pipeline.

## Runtime Follow-up
The live 8935 runtime was restarted from this branch for validation, and the currently clogged live backlog was backed up and annotated with `required_tools=["keeper_bash"]` for the affected active tasks.

Backup: `/Users/dancer/me/.masc/tasks/backlog.json.bak-20260424-2114-task-tool-routing`

## Validation
- `./scripts/dune-local.sh build bin/main_eio.exe test/test_keeper_task_dispatch.exe test/test_types.exe test/test_verification_fsm.exe`
- `MASC_BASE_PATH=/tmp/masc-test-task-dispatch ./_build/default/test/test_keeper_task_dispatch.exe` - 23 tests
- `MASC_BASE_PATH=/tmp/masc-test-types ./_build/default/test/test_types.exe` - 117 tests
- `MASC_BASE_PATH=/tmp/masc-test-verification ./_build/default/test/test_verification_fsm.exe` - 14 tests
- live `/health` on `127.0.0.1:8935` showed commit `ea371b07f`, ready startup, full transports enabled, and `keeper_fibers=9`
- live MCP `tools/list` confirmed `required_tools` in `masc_add_task` and `masc_batch_add_tasks` schemas