### PR TITLE
fix(keeper): bump read-only git probe timeout 5s → 15s (#9775)

### DIFF
--- a/lib/keeper/keeper_repo_readiness.ml
+++ b/lib/keeper/keeper_repo_readiness.ml
@@ -12,6 +12,12 @@ type command_result =
   ; status : Unix.process_status
   }
 
+(* Read-only git probe timeout. Large monorepos (~/me, kidsnote-backend)
+   repeatedly trip a 5 s budget on first probe after filesystem cache
+   eviction; 15 s matches [server_dashboard_http_runtime_info]'s sibling
+   probe that was bumped for the same reason in #9765/#9775. *)
+let read_only_probe_timeout_sec = 15.0
+
 let run_git ~timeout_sec ~clone_path args =
   let argv = [ "git"; "-C"; clone_path; "--no-optional-locks" ] @ args in
   let status, output =
@@ -195,7 +201,7 @@ let inspect
            ])
   else
     let inside =
-      run_git ~timeout_sec:5.0 ~clone_path [ "rev-parse"; "--is-inside-work-tree" ]
+      run_git ~timeout_sec:read_only_probe_timeout_sec ~clone_path [ "rev-parse"; "--is-inside-work-tree" ]
     in
     if not inside.ok then
       common_fields "not_git_repo" false
@@ -212,15 +218,15 @@ let inspect
       in
       let dirty = status.ok && String.trim status.output <> "" in
       let branch =
-        run_git ~timeout_sec:5.0 ~clone_path [ "branch"; "--show-current" ]
+        run_git ~timeout_sec:read_only_probe_timeout_sec ~clone_path [ "branch"; "--show-current" ]
         |> fun r -> if r.ok then first_line_opt r.output else None
       in
       let head =
-        run_git ~timeout_sec:5.0 ~clone_path [ "rev-parse"; "--short"; "HEAD" ]
+        run_git ~timeout_sec:read_only_probe_timeout_sec ~clone_path [ "rev-parse"; "--short"; "HEAD" ]
         |> fun r -> if r.ok then first_line_opt r.output else None
       in
       let upstream =
-        run_git ~timeout_sec:5.0 ~clone_path
+        run_git ~timeout_sec:read_only_probe_timeout_sec ~clone_path
           [ "rev-parse"; "--abbrev-ref"; "--symbolic-full-name"; "@{upstream}" ]
       in
       let upstream_name = if upstream.ok then first_line_opt upstream.output else None in
@@ -239,7 +245,7 @@ let inspect
             else None, None)
       in
       let origin =
-        run_git ~timeout_sec:5.0 ~clone_path [ "remote"; "get-url"; "origin" ]
+        run_git ~timeout_sec:read_only_probe_timeout_sec ~clone_path [ "remote"; "get-url"; "origin" ]
       in
       let has_origin = origin.ok && String.trim origin.output <> "" in
       let state, ok, next_action =


### PR DESCRIPTION
## 요약

`keeper_repo_readiness.inspect`의 5개 read-only git subprobe가 5s timeout을 써서 `~/me` 같은 대형 monorepo에서 filesystem cache 방출 직후 첫 probe가 반복적으로 타임아웃.

Closes #9775.

## 증상

```
[WARN] [Process_eio] Timeout after 5s: 'git' '-C' '/Users/dancer/me' '--no-optional-locks' 'rev-parse' '--short' 'HEAD'
```
- 18:29:50Z, 18:41:38Z, 18:50:46Z (3 occurrences, periodic)

## 근본 원인

`lib/keeper/keeper_repo_readiness.ml` 5개 read-only probe 사이트:

| 라인 | 커맨드 | 기존 timeout |
|------|--------|-------------|
| 198 | `rev-parse --is-inside-work-tree` | 5s |
| 215 | `branch --show-current` | 5s |
| 219 | `rev-parse --short HEAD` | 5s |
| 223 | `rev-parse --abbrev-ref @{upstream}` | 5s |
| 242 | `remote get-url origin` | 5s |

`--no-optional-locks`는 이미 적용되어 있지만 I/O 부하 하에서 충분치 않음. 자매 probe `server_dashboard_http_runtime_info`는 동일 증상으로 #9765에서 이미 5s → 15s 범프됨.

## 변경 내용

```diff
+(* Read-only git probe timeout. Large monorepos (~/me, kidsnote-backend)
+   repeatedly trip a 5 s budget on first probe after filesystem cache
+   eviction; 15 s matches [server_dashboard_http_runtime_info]'s sibling
+   probe that was bumped for the same reason in #9765/#9775. *)
+let read_only_probe_timeout_sec = 15.0

- run_git ~timeout_sec:5.0 ~clone_path [ "rev-parse"; "--is-inside-work-tree" ]
+ run_git ~timeout_sec:read_only_probe_timeout_sec ~clone_path [ "rev-parse"; "--is-inside-work-tree" ]
... (5 sites)
```

## 변경하지 않은 것

- `status --porcelain` (10s, line 211) — 작업트리 전체 스캔이라 더 무거움, 이미 여유 있음
- `rev-list --left-right --count @{upstream}...HEAD` (10s, line 232) — commit count 계산이라 유사, 이미 여유 있음
- Mutation 경로 없음 — 전 파일이 read-only probe

## 검증

```bash
dune exec --root . test/test_keeper_repo_readiness.exe
# → Test Successful in 6.034s. 7 tests run.
```

`dune build @check` exit 0.

## 회귀 리스크

매우 낮음 — timeout 값 완화만. 정상 경로는 빠르게 성공하므로 영향 없고, 병적 케이스에서 fiber가 추가로 10s 대기할 수 있음. Keeper 주기는 수분 단위라 허용 범위.

## 참고

- Issue #9775 — 증상 및 suggested cause
- PR #9765 — 같은 이유로 dashboard probe bump (sibling pattern)
- `--no-optional-locks`는 이미 적용 (issue Notes 기재)
