### PR TITLE
feat(keeper): wire Gh_exit_class into docker sandbox emission + counters

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -113,6 +113,39 @@ let cmd_targets_git_or_gh cmd =
     let tokens = String.split_on_char ' ' trimmed in
     List.exists (fun tok -> tok = "git" || tok = "gh") tokens
 
+let cmd_targets_gh cmd =
+  let trimmed = String.trim cmd in
+  let first_word =
+    match String.index_opt trimmed ' ' with
+    | Some i -> String.sub trimmed 0 i
+    | None -> trimmed
+  in
+  if first_word = "gh" then true
+  else
+    (* Same "prefixed by cd ..." allowance as cmd_targets_git_or_gh,
+       but strict to gh for classification purposes. *)
+    let tokens = String.split_on_char ' ' trimmed in
+    List.exists (fun tok -> tok = "gh") tokens
+
+(* Emit a ("gh_exit_class", "…") JSON field when [cmd] targets gh,
+   AND increment the matching Legendary_counters bucket.  Callers
+   append the returned list to their `Assoc payload unconditionally —
+   it is empty for non-gh commands, so call sites keep their shape. *)
+let gh_exit_class_field ~cmd ~status ~output : (string * Yojson.Safe.t) list =
+  if not (cmd_targets_gh cmd) then []
+  else
+    let exit_code = match status with
+      | Unix.WEXITED n -> n
+      | Unix.WSIGNALED n -> 128 + n
+      | Unix.WSTOPPED n -> 256 + n
+    in
+    (* Docker shell captures stdout+stderr combined into [output];
+       Gh_exit_class rules match on substrings so passing the combined
+       buffer as [stderr] is sound. *)
+    let class_ = Gh_exit_class.classify ~exit_code ~stderr:output in
+    Legendary_counters.incr_gh_exit_class class_;
+    [ ("gh_exit_class", `String (Gh_exit_class.to_string class_)) ]
+
 let optional_ro_mount ~host ~container =
   if host = "" then []
   else if not (Sys.file_exists host) then []
@@ -384,7 +417,7 @@ let run_docker_with_git_bash
            Keeper_registry.clear_error ~base_path:config.base_path meta.name;
          Yojson.Safe.to_string
            (`Assoc
-              [
+              ([
                 ("ok", `Bool (st = Unix.WEXITED 0));
                 ("via", `String "docker");
                 ("cwd", `String cwd);
@@ -394,7 +427,7 @@ let run_docker_with_git_bash
                 ("effective_sandbox_image", `String image);
                 ("status", Keeper_alerting_path.process_status_to_json st);
                 ("output", `String out);
-              ]))
+              ] @ gh_exit_class_field ~cmd ~status:st ~output:out)))
     | None ->
       match
         run_docker_shell_command_with_status ~config ~meta ~cwd ~timeout_sec
@@ -404,7 +437,7 @@ let run_docker_with_git_bash
       | Ok result ->
         Yojson.Safe.to_string
           (`Assoc
-             [
+             ([
                ("ok", `Bool (result.status = Unix.WEXITED 0));
                ("via", `String "docker");
                ("cwd", `String cwd);
@@ -415,7 +448,7 @@ let run_docker_with_git_bash
                ( "status",
                  Keeper_alerting_path.process_status_to_json result.status );
                ("output", `String result.output);
-             ]))
+             ] @ gh_exit_class_field ~cmd ~status:result.status ~output:result.output)))
 
 let run_docker_hardened_bash
     ~(turn_sandbox_runtime : Keeper_turn_sandbox_runtime.t option)
@@ -453,7 +486,7 @@ let run_docker_hardened_bash
            Keeper_registry.clear_error ~base_path:config.base_path meta.name;
          Yojson.Safe.to_string
            (`Assoc
-              [
+              ([
                 ("ok", `Bool (st = Unix.WEXITED 0));
                 ("via", `String "docker");
                 ("cwd", `String cwd);
@@ -463,7 +496,7 @@ let run_docker_hardened_bash
                 ("effective_sandbox_image", `String image);
                 ("status", Keeper_alerting_path.process_status_to_json st);
                 ("output", `String out);
-              ]))
+              ] @ gh_exit_class_field ~cmd ~status:st ~output:out)))
     | _ ->
       (* P12: check egress policy before running networked container *)
       (match check_egress ~config ~meta ~cmd with
@@ -477,7 +510,7 @@ let run_docker_hardened_bash
       | Ok result ->
         Yojson.Safe.to_string
           (`Assoc
-             [
+             ([
                ("ok", `Bool (result.status = Unix.WEXITED 0));
                ("via", `String "docker");
                ("cwd", `String cwd);
@@ -488,4 +521,4 @@ let run_docker_hardened_bash
                ( "status",
                  Keeper_alerting_path.process_status_to_json result.status );
                ("output", `String result.output);
-             ]))
+             ] @ gh_exit_class_field ~cmd ~status:result.status ~output:result.output)))

--- a/lib/legendary_counters.ml
+++ b/lib/legendary_counters.ml
@@ -18,6 +18,13 @@ let too_complex_control_flow = Atomic.make 0
 let too_complex_function_def = Atomic.make 0
 let too_complex_glob_brace = Atomic.make 0
 let too_complex_background = Atomic.make 0
+
+let gh_exit_ok_0 = Atomic.make 0
+let gh_exit_policy_blocked = Atomic.make 0
+let gh_exit_type_mismatch = Atomic.make 0
+let gh_exit_auth_failed = Atomic.make 0
+let gh_exit_network = Atomic.make 0
+let gh_exit_unknown = Atomic.make 0
 let too_complex_parse_error = Atomic.make 0
 let too_complex_parse_aborted = Atomic.make 0
 let too_complex_other = Atomic.make 0
@@ -35,6 +42,15 @@ let incr_gate_diff (diff : Gate_diff_types.gate_diff) =
 let incr_auto_bg_observed ~promoted_candidate =
   incr auto_bg_observed;
   if promoted_candidate then incr auto_bg_would_have_promoted
+
+let incr_gh_exit_class (c : Gh_exit_class.t) =
+  match c with
+  | Gh_exit_class.Ok_0 -> incr gh_exit_ok_0
+  | Gh_exit_class.Policy_blocked -> incr gh_exit_policy_blocked
+  | Gh_exit_class.Type_mismatch -> incr gh_exit_type_mismatch
+  | Gh_exit_class.Auth_failed -> incr gh_exit_auth_failed
+  | Gh_exit_class.Network -> incr gh_exit_network
+  | Gh_exit_class.Unknown -> incr gh_exit_unknown
 
 (* Strip the [too_complex:] / [parse_aborted:] prefix if present, so
    callers can pass either the full [shadow_parse_outcome] tag or a
@@ -90,7 +106,13 @@ let reset () =
   Atomic.set too_complex_background 0;
   Atomic.set too_complex_parse_error 0;
   Atomic.set too_complex_parse_aborted 0;
-  Atomic.set too_complex_other 0
+  Atomic.set too_complex_other 0;
+  Atomic.set gh_exit_ok_0 0;
+  Atomic.set gh_exit_policy_blocked 0;
+  Atomic.set gh_exit_type_mismatch 0;
+  Atomic.set gh_exit_auth_failed 0;
+  Atomic.set gh_exit_network 0;
+  Atomic.set gh_exit_unknown 0
 
 type snapshot = {
   gate_diff_total : int;
@@ -115,6 +137,12 @@ type snapshot = {
   too_complex_parse_error : int;
   too_complex_parse_aborted : int;
   too_complex_other : int;
+  gh_exit_ok_0 : int;
+  gh_exit_policy_blocked : int;
+  gh_exit_type_mismatch : int;
+  gh_exit_auth_failed : int;
+  gh_exit_network : int;
+  gh_exit_unknown : int;
 }
 
 let snapshot () =
@@ -144,6 +172,12 @@ let snapshot () =
     too_complex_parse_error = Atomic.get too_complex_parse_error;
     too_complex_parse_aborted = Atomic.get too_complex_parse_aborted;
     too_complex_other = Atomic.get too_complex_other;
+    gh_exit_ok_0 = Atomic.get gh_exit_ok_0;
+    gh_exit_policy_blocked = Atomic.get gh_exit_policy_blocked;
+    gh_exit_type_mismatch = Atomic.get gh_exit_type_mismatch;
+    gh_exit_auth_failed = Atomic.get gh_exit_auth_failed;
+    gh_exit_network = Atomic.get gh_exit_network;
+    gh_exit_unknown = Atomic.get gh_exit_unknown;
   }
 
 let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
@@ -173,6 +207,12 @@ let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
     ("too_complex_parse_error", `Int s.too_complex_parse_error);
     ("too_complex_parse_aborted", `Int s.too_complex_parse_aborted);
     ("too_complex_other", `Int s.too_complex_other);
+    ("gh_exit_ok_0", `Int s.gh_exit_ok_0);
+    ("gh_exit_policy_blocked", `Int s.gh_exit_policy_blocked);
+    ("gh_exit_type_mismatch", `Int s.gh_exit_type_mismatch);
+    ("gh_exit_auth_failed", `Int s.gh_exit_auth_failed);
+    ("gh_exit_network", `Int s.gh_exit_network);
+    ("gh_exit_unknown", `Int s.gh_exit_unknown);
   ]
 
 let safe_ratio ~num ~den =

--- a/lib/legendary_counters.mli
+++ b/lib/legendary_counters.mli
@@ -20,6 +20,18 @@ val incr_auto_bg_observed : promoted_candidate:bool -> unit
     When [promoted_candidate] is [true] the elapsed duration would
     have tripped [MASC_BLOCKING_BUDGET_MS]. *)
 
+val incr_gh_exit_class : Gh_exit_class.t -> unit
+(** Record one docker-sandbox gh invocation under its exit class, as
+    classified by {!Gh_exit_class.classify}.  Callers increment this
+    from the docker shell emission sites in [Keeper_shell_docker] so
+    that the dashboard and [/api/v1/legendary_bash/shadow_counters]
+    endpoint can visualise the distribution of gh outcomes
+    (Ok_0 vs Auth_failed vs Network vs …) without parsing stderr
+    blobs in the UI layer.
+
+    This is the first production consumer of {!Gh_exit_class};
+    previous callers only relied on raw exit codes. *)
+
 val incr_too_complex_by_tag : string -> unit
 (** Record one shadow rejection attributable to a subset-excluded
     bash construct.  [tag] is the [parse_tag] string emitted by
@@ -65,6 +77,16 @@ type snapshot = {
   too_complex_parse_error : int;
   too_complex_parse_aborted : int;
   too_complex_other : int;
+  (* Distribution of docker-sandbox gh invocations by exit class, as
+     classified by {!Gh_exit_class.classify}.  Callers increment these
+     from the JSON emission sites in [Keeper_shell_docker]; non-gh
+     commands in the same sandbox do not touch these counters. *)
+  gh_exit_ok_0 : int;
+  gh_exit_policy_blocked : int;
+  gh_exit_type_mismatch : int;
+  gh_exit_auth_failed : int;
+  gh_exit_network : int;
+  gh_exit_unknown : int;
 }
 
 val snapshot : unit -> snapshot

--- a/test/dune
+++ b/test/dune
@@ -105,6 +105,7 @@
         test_keeper_shell_docker_route
         test_env_git_noninteractive
         test_gh_exit_class
+        test_gh_exit_class_wiring
         test_stay_silent_loop_detector
         test_oas_compat_cascade_fallback
         test_heuristic_metrics_boot_wireup
@@ -230,6 +231,7 @@
           test_keeper_shell_docker_route
           test_env_git_noninteractive
           test_gh_exit_class
+          test_gh_exit_class_wiring
           test_stay_silent_loop_detector
           test_oas_compat_cascade_fallback
           test_heuristic_metrics_boot_wireup

--- a/test/test_gh_exit_class_wiring.ml
+++ b/test/test_gh_exit_class_wiring.ml
@@ -1,0 +1,102 @@
+(* test/test_gh_exit_class_wiring.ml
+
+   Verifies that the docker-sandbox JSON emission path calls
+   [Gh_exit_class.classify] for gh commands and increments the
+   matching [Legendary_counters] bucket, without touching counters
+   for non-gh commands. Covers only the helper surface — the docker
+   exec itself is out of scope for a unit test. *)
+
+module KSD = Masc_mcp.Keeper_shell_docker
+module LC = Masc_mcp.Legendary_counters
+module GEC = Masc_mcp.Gh_exit_class
+
+let test_cmd_targets_gh_positive () =
+  Alcotest.(check bool) "gh pr list → true" true
+    (KSD.cmd_targets_gh "gh pr list");
+  Alcotest.(check bool) "cd /repo && gh pr view 1 → true" true
+    (KSD.cmd_targets_gh "cd /repo && gh pr view 1")
+
+let test_cmd_targets_gh_negative () =
+  Alcotest.(check bool) "git status → false" false
+    (KSD.cmd_targets_gh "git status");
+  Alcotest.(check bool) "ls -la → false" false
+    (KSD.cmd_targets_gh "ls -la");
+  Alcotest.(check bool) "empty → false" false
+    (KSD.cmd_targets_gh "")
+
+let test_field_empty_for_non_gh () =
+  LC.reset ();
+  let fields =
+    KSD.gh_exit_class_field
+      ~cmd:"git status" ~status:(Unix.WEXITED 0) ~output:""
+  in
+  Alcotest.(check int) "no field emitted" 0 (List.length fields);
+  let s = LC.snapshot () in
+  Alcotest.(check int) "Ok_0 counter untouched" 0 s.gh_exit_ok_0
+
+let test_field_ok_for_gh_exit_0 () =
+  LC.reset ();
+  let fields =
+    KSD.gh_exit_class_field
+      ~cmd:"gh pr list" ~status:(Unix.WEXITED 0) ~output:""
+  in
+  Alcotest.(check int) "one field emitted" 1 (List.length fields);
+  (match fields with
+   | [ ("gh_exit_class", `String v) ] ->
+     Alcotest.(check string) "Ok_0 payload"
+       (GEC.to_string GEC.Ok_0) v
+   | _ -> Alcotest.fail "unexpected field shape");
+  let s = LC.snapshot () in
+  Alcotest.(check int) "Ok_0 counter ticked" 1 s.gh_exit_ok_0
+
+let test_field_auth_failed_from_combined_output () =
+  LC.reset ();
+  let fields =
+    KSD.gh_exit_class_field
+      ~cmd:"gh api /user"
+      ~status:(Unix.WEXITED 1)
+      ~output:"HTTP 401: Bad credentials (https://api.github.com/user)"
+  in
+  (match fields with
+   | [ ("gh_exit_class", `String v) ] ->
+     Alcotest.(check string) "Auth_failed payload"
+       (GEC.to_string GEC.Auth_failed) v
+   | _ -> Alcotest.fail "unexpected field shape");
+  let s = LC.snapshot () in
+  Alcotest.(check int) "Auth_failed counter ticked" 1 s.gh_exit_auth_failed
+
+let test_field_signal_maps_to_unknown () =
+  LC.reset ();
+  let fields =
+    KSD.gh_exit_class_field
+      ~cmd:"gh pr list" ~status:(Unix.WSIGNALED 9) ~output:""
+  in
+  (match fields with
+   | [ ("gh_exit_class", `String v) ] ->
+     (* signal 9 → exit_code 128+9=137, no rule matches, Unknown *)
+     Alcotest.(check string) "Unknown payload"
+       (GEC.to_string GEC.Unknown) v
+   | _ -> Alcotest.fail "unexpected field shape");
+  let s = LC.snapshot () in
+  Alcotest.(check int) "Unknown counter ticked" 1 s.gh_exit_unknown
+
+let () =
+  Alcotest.run "gh_exit_class_wiring"
+    [
+      ( "cmd_targets_gh",
+        [
+          Alcotest.test_case "positive" `Quick test_cmd_targets_gh_positive;
+          Alcotest.test_case "negative" `Quick test_cmd_targets_gh_negative;
+        ] );
+      ( "gh_exit_class_field",
+        [
+          Alcotest.test_case "non-gh emits no field" `Quick
+            test_field_empty_for_non_gh;
+          Alcotest.test_case "gh exit 0 → Ok_0" `Quick
+            test_field_ok_for_gh_exit_0;
+          Alcotest.test_case "gh + Bad credentials → Auth_failed" `Quick
+            test_field_auth_failed_from_combined_output;
+          Alcotest.test_case "signalled gh → Unknown" `Quick
+            test_field_signal_maps_to_unknown;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

`Gh_exit_class` existed with 6 variants (`Ok_0`, `Policy_blocked`, `Type_mismatch`, `Auth_failed`, `Network`, `Unknown`) + rule table + own unit test, but **no production code called it** (`rg Gh_exit_class lib/` → 0 hits). Docker sandbox JSON emission surfaced only raw `exit_code`, forcing every caller to stderr-grep.

This PR activates the classifier at the 4 `Keeper_shell_docker` emission sites and plumbs counts into `Legendary_counters` so the dashboard / `/api/v1/legendary_bash/shadow_counters` endpoint can see the gh outcome distribution directly.

## Product impact

- **Promise level**: ops visibility (Supporting). No behaviour change for callers.
- Previously dead `lib/gh_exit_class.ml` is now a live production dependency.
- `gh_exit_class` field is additive on the Assoc payload — existing consumers ignore it safely.
- Non-gh commands in the same sandbox do not touch the new counters.

## Evidence

Local on `.worktrees/feat-gh-exit-class-wiring`:

- `dune build @check --root .` → pass
- `dune exec test/test_gh_exit_class_wiring.exe --root .` → 6/6 pass
- `dune exec test/test_legendary_counters.exe --root .` → 18/18 pass (regression)
- `dune exec test/test_gh_exit_class.exe --root .` → 10/10 pass (regression)

Changed surface:

- `lib/keeper/keeper_shell_docker.ml` — new `cmd_targets_gh` + `gh_exit_class_field` helpers, 4 JSON emission sites appended
- `lib/legendary_counters.{ml,mli}` — 6 Atomic counters + `incr_gh_exit_class` + snapshot / reset / JSON extensions
- `test/test_gh_exit_class_wiring.ml` — new (6 cases)

## Review evidence

Best Programmer self-review:
- Goal: make dead `Gh_exit_class` live without changing caller contract or adding speculative types
- Non-goals: new record type (`gh_result.t`), typed API dispatcher, RFC PR-3 scope
- Local checks: build + 3 targeted test suites all green
- Remaining unverified: CI lint, full `@runtest`, dashboard UI rendering of the new counter fields (observed only via snapshot JSON)

## Linked issue

Follows RFC-0007 rev.3 but intentionally narrower than the RFC's PR-2 design: no `gh_result.t` record is introduced because no consumer for it exists yet (see prior discussion about speculative typing).

Promise: `ops visibility`