### PR TITLE
[codex] Expose persona authoring in MCP discovery

### DIFF
--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -378,6 +378,26 @@ let schema_json ?(include_examples = false) () =
                  ] )
            ] )
      ; "archetype_axes", archetype_axes_json ()
+     ; ( "authoring_flow"
+       , `Assoc
+           [ "draft_tool", `String "masc_persona_generate"
+           ; "save_tool", `String "masc_persona_save"
+           ; "dry_run_keeper_tool", `String "masc_keeper_create_from_persona"
+           ; "start_keeper_tool", `String "masc_keeper_create_from_persona"
+           ; ( "draft_args"
+             , `Assoc
+                 [ "concept", `String "<natural-language persona concept>"
+                 ; "tool_preset", `String "<optional preset>"
+                 ] )
+           ; ( "save_args"
+             , `Assoc
+                 [ "handle", `String "<handle>"
+                 ; "profile", `String "<profile JSON from draft or hand-authored>"
+                 ; "dry_run", `Bool true
+                 ] )
+           ; ( "keeper_dry_run_args"
+             , `Assoc [ "persona_name", `String "<handle>"; "dry_run", `Bool true ] )
+           ] )
      ; ( "keeperization"
        , `Assoc
            [ "dry_run_tool", `String "masc_keeper_create_from_persona"

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -132,7 +132,10 @@ let public_mcp_surface_tools =
     "masc_keeper_sandbox_status"; "masc_keeper_sandbox_start"; "masc_keeper_sandbox_stop";
     "masc_keeper_up"; "masc_keeper_repair"; "masc_keeper_reset";
     "masc_keeper_down";
-    "masc_persona_list"; "masc_persona_schema";
+    (* Persona authoring is operator-visible, but these materialization tools
+       remain on Keeper_denied so managed keepers never receive them. *)
+    "masc_persona_list"; "masc_persona_schema"; "masc_persona_generate";
+    "masc_persona_save"; "masc_keeper_create_from_persona";
     (* Board *)
     "masc_board_post"; "masc_board_list"; "masc_board_get";
     "masc_board_comment"; "masc_board_vote";
@@ -231,11 +234,9 @@ let keeper_denied_surface_tools =
     "masc_persona_generate";
     "masc_persona_save";
     "masc_keeper_create_from_persona";
-    (* NOTE: masc_keeper_reset is on public_mcp_surface_tools (line 126),
-       so it cannot be added to Keeper_denied without violating the
-       Keeper_denied ∩ Public_mcp = ∅ invariant (test_tool_surface_ssot.ml:90).
-       Keepers don't see the public_mcp surface at discovery, so no filter
-       is needed here. Admin permission still blocks execution. *)
+    (* NOTE: masc_keeper_reset is on public_mcp_surface_tools. Keepers don't
+       see the public_mcp surface at discovery, so no filter is needed here.
+       Admin permission still blocks execution. *)
     "masc_pause";
     "masc_resume";
   ]

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1011,7 +1011,15 @@ let test_persona_authoring_schema_explains_effects () =
   check bool "documents tool presets" true
     (contains_substring rendered "tool_preset");
   check bool "documents archetype axes" true
-    (contains_substring rendered "archetype_axes")
+    (contains_substring rendered "archetype_axes");
+  check string "draft tool" "masc_persona_generate"
+    (Yojson.Safe.Util.member "authoring_flow" json
+     |> Yojson.Safe.Util.member "draft_tool"
+     |> Yojson.Safe.Util.to_string);
+  check string "save tool" "masc_persona_save"
+    (Yojson.Safe.Util.member "authoring_flow" json
+     |> Yojson.Safe.Util.member "save_tool"
+     |> Yojson.Safe.Util.to_string)
 
 let test_persona_authoring_normalizes_keeper_defaults () =
   match KPA.normalize_profile ~handle:"probe" authoring_minimal_profile with

--- a/test/test_tool_surface_ssot.ml
+++ b/test/test_tool_surface_ssot.ml
@@ -85,15 +85,28 @@ let test_session_min_and_local_worker_share_core () =
       (String.concat ", " (SS.elements missing));
   Alcotest.(check bool) "shared core present" true (SS.is_empty missing)
 
-let test_keeper_denied_disjoint_from_public_mcp () =
+let public_keeper_denied_overlap_allowed =
+  set_of
+    [
+      "masc_persona_generate";
+      "masc_persona_save";
+      "masc_keeper_create_from_persona";
+    ]
+
+let test_keeper_denied_public_mcp_overlap_is_explicit () =
   let denied = set_of (Tool_catalog.tools_for_surface Tool_catalog.Keeper_denied) in
   let public = set_of (Tool_catalog.tools_for_surface Tool_catalog.Public_mcp) in
   let overlap = SS.inter denied public in
-  if not (SS.is_empty overlap) then
-    Alcotest.failf "Keeper_denied overlaps with Public_mcp: {%s}"
-      (String.concat ", " (SS.elements overlap));
-  Alcotest.(check bool) "Keeper_denied disjoint from Public_mcp" true
-    (SS.is_empty overlap)
+  let unexpected = SS.diff overlap public_keeper_denied_overlap_allowed in
+  let missing = SS.diff public_keeper_denied_overlap_allowed overlap in
+  if not (SS.is_empty unexpected) then
+    Alcotest.failf "Unexpected Keeper_denied/Public_mcp overlap: {%s}"
+      (String.concat ", " (SS.elements unexpected));
+  if not (SS.is_empty missing) then
+    Alcotest.failf "Expected Keeper_denied/Public_mcp overlap missing: {%s}"
+      (String.concat ", " (SS.elements missing));
+  Alcotest.(check bool) "Keeper_denied/Public_mcp overlap explicit" true
+    (SS.is_empty unexpected && SS.is_empty missing)
 
 let test_keeper_internal_disjoint_from_public_mcp () =
   let internal = set_of (Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal) in
@@ -367,8 +380,8 @@ let () =
         [
           Alcotest.test_case "Session_min ∩ Local_worker shared core" `Quick
             test_session_min_and_local_worker_share_core;
-          Alcotest.test_case "Keeper_denied ∩ Public_mcp = ∅" `Quick
-            test_keeper_denied_disjoint_from_public_mcp;
+          Alcotest.test_case "Keeper_denied/Public_mcp overlap is explicit" `Quick
+            test_keeper_denied_public_mcp_overlap_is_explicit;
           Alcotest.test_case "Keeper_internal ∩ Public_mcp = ∅" `Quick
             test_keeper_internal_disjoint_from_public_mcp;
           Alcotest.test_case "Keeper_internal contains known tools" `Quick


### PR DESCRIPTION
## Summary

- Expose `masc_persona_generate`, `masc_persona_save`, and `masc_keeper_create_from_persona` on the public MCP tool surface so operator clients can discover the full persona authoring flow through `tools/list`.
- Keep those materialization tools on `Keeper_denied`, with an explicit surface invariant so managed keepers still do not receive or execute them.
- Add `authoring_flow` to `masc_persona_schema` so clients can discover the draft, save, and keeper dry-run sequence from the schema response too.

Closes #9964.

## Validation

- `env DUNE_LOCAL_JOBS=2 scripts/dune-local.sh build test/test_keeper_toml.exe test/test_tool_surface_ssot.exe`
- `./_build/default/test/test_keeper_toml.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-tool-surface-9964 ./_build/default/test/test_tool_surface_ssot.exe`