### PR TITLE
fix(dashboard): route websocket raw push refreshes

### DIFF
--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -1,6 +1,6 @@
 import type { RouteState, SSEEvent } from './types'
 import { parseSSEMessage } from './schemas/sse'
-import { hydrateDashboardSlice, hydrateServerPushEvent } from './sse-store'
+import { hydrateDashboardSlice, routeServerPushEvent } from './sse-store'
 import {
   dashboardWsConnected,
   dashboardWsLastError,
@@ -205,7 +205,7 @@ function handleRawPush(raw: unknown): void {
   const candidate = unwrapSseCandidate(raw as JsonObject)
   const parsed = parseSSEMessage(candidate)
   if (!parsed) return
-  hydrateServerPushEvent(parsed as unknown as SSEEvent)
+  routeServerPushEvent(parsed as unknown as SSEEvent)
 }
 
 export function parseWebSocketSseFrames(data: string): unknown[] {

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -239,6 +239,36 @@ describe('setupSSEReaction reconnect hydration', () => {
     cleanup()
   })
 
+  it('routes websocket raw push events through the same route-scoped refresh budget', async () => {
+    const { sseStore } = await loadSseStore()
+    route.value = { tab: 'workspace', params: { section: 'board' }, postId: null }
+
+    sseStore.routeServerPushEvent({
+      type: 'comment_added',
+      post_id: 'post-1',
+      comment_id: 'comment-1',
+    })
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(refreshBoard).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps websocket raw push refreshes hidden when the route does not need that surface', async () => {
+    const { sseStore } = await loadSseStore()
+    route.value = { tab: 'overview', params: {}, postId: null }
+
+    sseStore.routeServerPushEvent({
+      type: 'comment_added',
+      post_id: 'post-1',
+      comment_id: 'comment-1',
+    })
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(refreshBoard).not.toHaveBeenCalled()
+  })
+
   it('hydrates websocket dashboard snapshots for board, goals, and composite slices', async () => {
     const { sseStore } = await loadSseStore()
 
@@ -261,5 +291,20 @@ describe('setupSSEReaction reconnect hydration', () => {
       count: 0,
       snapshots: [],
     })
+  })
+
+  it('routes websocket dashboard delta event types without treating payloads as snapshots', async () => {
+    const { sseStore } = await loadSseStore()
+    route.value = { tab: 'workspace', params: { section: 'board' }, postId: null }
+
+    sseStore.hydrateDashboardSlice('board', {
+      post_id: 'post-1',
+      comment_id: 'comment-1',
+    }, 'comment_added')
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(hydrateBoardSnapshot).not.toHaveBeenCalled()
+    expect(refreshBoard).toHaveBeenCalledTimes(1)
   })
 })

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -365,6 +365,54 @@ function handleBoardPostCreated(event: SSEEvent): boolean {
   return true
 }
 
+export function routeServerPushEvent(event: SSEEvent): void {
+  if (hydrateServerPushEvent(event)) {
+    return
+  }
+
+  const simpleRoute = SIMPLE_ROUTES[event.type]
+  if (simpleRoute) {
+    scheduleTargetRefresh(
+      simpleRoute.target,
+      REFRESH_FNS[simpleRoute.target],
+      simpleRoute.debounceMs,
+    )
+  }
+
+  for (const { prefix, target } of PREFIX_ROUTES) {
+    if (event.type.startsWith(prefix)) {
+      scheduleTargetRefresh(target, REFRESH_FNS[target])
+      break
+    }
+  }
+
+  if (KEEPER_LIFECYCLE_EVENTS.has(normalizeMascEventType(event.type))) {
+    handleKeeperLifecycle(event)
+  }
+
+  if (AUTORESEARCH_EVENTS.has(event.type) && activeAutoresearchRoute()) {
+    scheduleRefresh('autoresearch_route', () => {
+      void refreshActiveRoute()
+    }, SSE_DEFAULT_DEBOUNCE_MS)
+  }
+
+  if (
+    event.type.startsWith('decision_')
+    || event.type === 'governance_param_changed'
+    || event.type === 'approval:pending'
+    || event.type === 'approval:resolved'
+  ) {
+    if (route.value.tab === 'command') {
+      scheduleRefresh('command_route', () => {
+        void refreshActiveRoute()
+      })
+    }
+    if (_refreshGovernanceFn) {
+      scheduleRefresh('governance', () => void handleGovernance())
+    }
+  }
+}
+
 export function hydrateServerPushEvent(event: SSEEvent): boolean {
   if ((event.type === 'project_snapshot' || event.type === 'namespace_truth_snapshot' || event.type === 'room_truth_snapshot') && event.payload) {
     handleNamespaceTruthSnapshot(event.payload)
@@ -429,6 +477,12 @@ export function hydrateServerPushEvent(event: SSEEvent): boolean {
   return false
 }
 
+function eventPayloadRecord(payload: unknown): Record<string, unknown> {
+  return payload && typeof payload === 'object' && !Array.isArray(payload)
+    ? payload as Record<string, unknown>
+    : { payload }
+}
+
 export function hydrateDashboardSlice(slice: string, payload: unknown, eventType?: string): void {
   switch (eventType) {
     case 'project_snapshot':
@@ -440,6 +494,13 @@ export function hydrateDashboardSlice(slice: string, payload: unknown, eventType
     case 'transport_health_snapshot':
       hydrateServerPushEvent({ type: eventType, payload } as SSEEvent)
       return
+  }
+  if (eventType) {
+    routeServerPushEvent({
+      type: eventType,
+      ...eventPayloadRecord(payload),
+    } as SSEEvent)
+    return
   }
 
   switch (slice) {
@@ -497,56 +558,7 @@ export function setupSSEReaction(): () => void {
 
   const unsubscribe = lastEvent.subscribe((event) => {
     if (!event) return
-
-    if (hydrateServerPushEvent(event)) {
-      return
-    }
-
-    // 2. Simple route: exact match
-    const simpleRoute = SIMPLE_ROUTES[event.type]
-    if (simpleRoute) {
-      scheduleTargetRefresh(
-        simpleRoute.target,
-        REFRESH_FNS[simpleRoute.target],
-        simpleRoute.debounceMs,
-      )
-    }
-
-    // 4. Simple route: prefix match
-    for (const { prefix, target } of PREFIX_ROUTES) {
-      if (event.type.startsWith(prefix)) {
-        scheduleTargetRefresh(target, REFRESH_FNS[target])
-        break
-      }
-    }
-
-    // 5. Keeper lifecycle — additional operator refresh + thread hydration
-    if (KEEPER_LIFECYCLE_EVENTS.has(normalizeMascEventType(event.type))) {
-      handleKeeperLifecycle(event)
-    }
-
-    if (AUTORESEARCH_EVENTS.has(event.type) && activeAutoresearchRoute()) {
-      scheduleRefresh('autoresearch_route', () => {
-        void refreshActiveRoute()
-      }, SSE_DEFAULT_DEBOUNCE_MS)
-    }
-
-    // 6. Governance events
-    if (
-      event.type.startsWith('decision_')
-      || event.type === 'governance_param_changed'
-      || event.type === 'approval:pending'
-      || event.type === 'approval:resolved'
-    ) {
-      if (route.value.tab === 'command') {
-        scheduleRefresh('command_route', () => {
-          void refreshActiveRoute()
-        })
-      }
-      if (_refreshGovernanceFn) {
-        scheduleRefresh('governance', () => void handleGovernance())
-      }
-    }
+    routeServerPushEvent(event)
   })
 
   return () => {


### PR DESCRIPTION
## Summary

- route WebSocket raw push events through the same dashboard refresh router used by SSE
- keep snapshot hydration fast-path behavior intact while routing non-snapshot dashboard delta event types by event name
- add focused coverage for route-scoped board refreshes and delta payload handling

## Root Cause

The SSE path hydrated push events and then fell back to route-scoped refresh scheduling, but the WebSocket raw push path only attempted hydration. Events such as `comment_added` could therefore be ignored when transported over WebSocket even though the SSE transport refreshed the active board route.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `env PATH=/Users/dancer/.nvm/versions/node/v22.22.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin pnpm exec vitest run src/sse-store.test.ts --no-file-parallelism --maxWorkers=1 -t "websocket" --reporter=verbose`
- `env PATH=/Users/dancer/.nvm/versions/node/v22.22.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin pnpm exec vitest run src/dashboard-ws.test.ts --no-file-parallelism --maxWorkers=1 --reporter=verbose`

Note: the package-script form `pnpm test -- sse-store.test.ts dashboard-ws.test.ts` was not used as validation because, under the default shell Node v25.9.0, it repeatedly spawned workers with `--localstorage-file` warnings; direct Vitest invocation under the project NVM Node v22.22.0 completed successfully.