### PR TITLE
[codex] Fix keeper progress taxonomy for task creation

### DIFF
--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -196,15 +196,7 @@ let passive_status_tool_names : string list =
 
 let claim_context_tool_names : string list =
   Tool_name.
-    [
-      Masc Add_task;
-      Masc Batch_add_tasks;
-      Masc Claim_next;
-      Masc Claim_task;
-      Keeper Task_claim;
-      Keeper Task_create;
-      Keeper Task_force_release;
-    ]
+    [ Masc Claim_next; Masc Claim_task; Keeper Task_claim ]
   |> List.map Tool_name.to_string
 
 let completion_tool_names : string list =
@@ -216,6 +208,7 @@ let completion_tool_names : string list =
       Masc Release_task;
       Keeper Task_done;
       Keeper Task_force_done;
+      Keeper Task_force_release;
       Keeper Task_submit_for_verification;
     ]
   |> List.map Tool_name.to_string

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1842,6 +1842,14 @@ let test_metrics_execution_tools_are_substantive () =
     (UM.has_substantive_tool_calls [ "keeper_task_claim" ]);
   check bool "task listing is not execution progress" false
     (UM.has_substantive_tool_calls [ "keeper_tasks_list" ]);
+  check bool "task creation is execution progress" true
+    (UM.has_substantive_tool_calls [ "keeper_task_create" ]);
+  check bool "masc task creation is execution progress" true
+    (UM.has_substantive_tool_calls [ "masc_add_task" ]);
+  check bool "masc batch task creation is execution progress" true
+    (UM.has_substantive_tool_calls [ "masc_batch_add_tasks" ]);
+  check bool "force release is execution progress" true
+    (UM.has_substantive_tool_calls [ "keeper_task_force_release" ]);
   check bool "bash is execution progress" true
     (UM.has_substantive_tool_calls [ "keeper_bash" ]);
   check bool "completion is execution progress" true


### PR DESCRIPTION
## Summary
- narrow claim-context progress classification to actual task claim tools
- count task creation and forced release as substantive keeper progress
- add regression coverage for task creation and release progress metrics

## Root Cause
The follow-up required-turn progress taxonomy was too broad: task creation and force-release tools were grouped with claim-context tools, so they could be treated as observation-only/noop progress even though they mutate keeper/task state.

## Validation
- git diff --check
- DUNE_BUILD_DIR=_build_codex_check DUNE_JOBS=1 dune build --root . -j 1 test/test_keeper_unified.exe
- MASC_BASE_PATH=$(mktemp -d /tmp/masc-unified-test.XXXXXX) _build_codex_check/default/test/test_keeper_unified.exe