### PR TITLE
fix(dashboard): show time-since-last-action next to paused pill

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -249,6 +249,9 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
       <div class="rounded border ${toneClass} px-4 py-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-[var(--text-body)]">
         ${keeper.paused
           ? html`<span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--warn-14)] text-[var(--warn)]">일시정지</span>
+            ${keeper.last_autonomous_action_at
+              ? html`<span class="text-[var(--text-muted)]">마지막 행동 이후 <${TimeAgo} timestamp=${keeper.last_autonomous_action_at} /></span>`
+              : null}
             <button
               class="inline-flex items-center rounded px-2 py-0.5 text-2xs font-medium bg-[var(--white-6)] hover:bg-[var(--white-8)] text-[var(--text-strong)] transition-colors disabled:opacity-50"
               disabled=${directiveLoading.value}


### PR DESCRIPTION
## Why

Observed in-session: a keeper was rendered with

- "일시정지" pill (red)
- "Heartbeat stale" pill (red)
- "차단 요인 · Completion contract [require_tool_use] violated: …"

and the operator (me, as a dogfooding user) read it as a **fresh** violation needing urgent investigation. The pause had actually happened **52 minutes earlier** — the fix chain for `require_tool_use` (#9937, #9949, #9961, `ea371b07f`) had all landed since, and the running binary was on a commit that included them. The violation itself had been prevented for every turn after the fixes shipped; this was a residual paused keeper from an earlier binary.

The temporal context *was* on the panel — "마지막 행동 · 52분 전" — but buried several pills down and without any visual link to the pause pill. Visual hierarchy made current-state pills (pause / heartbeat stale) dominant, hiding "this is old" from the first glance.

## Change

Single 3-line insertion into `dashboard/src/components/keeper-detail.ts`: when `keeper.paused`, render an inline `TimeAgo` component directly after the pause pill, labelled `마지막 행동 이후`. Styled with `text-[var(--text-muted)]` so it reads as subordinate context, not as a claim about NOW.

```tsx
${keeper.paused
  ? html`<span class="...">일시정지</span>
    ${keeper.last_autonomous_action_at
      ? html`<span class="text-[var(--text-muted)]">마지막 행동 이후 <${TimeAgo} timestamp=${keeper.last_autonomous_action_at} /></span>`
      : null}
    <button ...>재개</button>`
  : ...}
```

## Why `last_autonomous_action_at` (not a new `paused_at` field)

The keeper type (`lib/keeper/keeper_types.ml{,i}` line 197) has only `paused: bool`, no paused-at timestamp. Adding one would be a schema change spanning OCaml types, serialiser, dashboard types, normalizer — ~5 files — outside the scope of a visual-hierarchy fix.

`last_autonomous_action_at` is a good proxy for contract-violation-triggered pauses because the pause is set on the same turn that failed the contract, so the two timestamps coincide within milliseconds. The label is intentionally `마지막 행동 이후` rather than `일시정지됨 이후` to avoid asserting a stronger claim than the data supports.

## Out of scope (follow-up candidates)

- **Server-side `paused_at` field**: would give a precise "paused since" for all pause origins (manual operator pause, goal completion, etc.), not just violation-triggered. Worth doing but in its own PR.
- **Pill colour decay for old state**: make pills visually fade after N minutes to reinforce "not fresh". Design call, not a mechanical fix.
- **Dedup with existing `마지막 행동 · Xm` at line 337**: both lines now show the same data. If the new inline version proves to be the preferred location, the duplicate can be removed later.

## Verification

- `bun run typecheck` (clean, no TS errors).
- `bun run test` hits a pre-existing `vitest-setup.ts` issue (`Cannot redefine property: AArrowDown` in icon mock) that reproduces on the unmodified main branch as well, so unrelated to this PR.
- Manual render path: paused keeper with `last_autonomous_action_at` set now shows muted "마지막 행동 이후 52m" beside the pill.

## Scope

- 1 file, +3 lines. No type / normalizer / server changes.
