### PR TITLE
chore(keeper-sandbox): add openssh-client to image (#9846)

### DIFF
--- a/Dockerfile.keeper-sandbox
+++ b/Dockerfile.keeper-sandbox
@@ -26,6 +26,7 @@ RUN apt-get update \
       npm \
       opam \
       ocaml-dune \
+      openssh-client \
       python3 \
       ripgrep \
       tree \


### PR DESCRIPTION
## 요약

`masc-keeper-sandbox:local` 이미지에 `openssh-client` 추가. HTTPS-only 경로(현재 op=gh, `git clone https://…`)에는 영향 없고, 향후 SSH git remote 또는 `SSH_AUTH_SOCK` forwarding이 필요한 keeper 워크플로를 위한 선제 조치.

Closes #9846.

## 변경 내용

```diff
       nodejs \
       npm \
       opam \
       ocaml-dune \
+      openssh-client \
       python3 \
       ripgrep \
       tree \
```

`openssh-server`는 제외 — sandbox는 inbound SSH를 받지 않음.

## 검증

이슈 재현 확인:
```bash
$ docker run --rm masc-keeper-sandbox:local bash -lc 'command -v ssh || echo MISSING'
MISSING
```

머지 후 이미지 재빌드 시 `ssh` 바이너리 포함될 예정.

## 회귀 리스크

매우 낮음 — apt 패키지 하나 추가. 이미지 빌드 시간 소폭 증가, 이미지 크기 ~5-10MB 증가 예상.

## 참고

- Issue #9846 — 증상 및 suggested direction
- 관련 audit: F-1/F-2/F-4 (keeper-docker-github-provider)
