### PR TITLE
fix(dashboard): catch up websocket route subscriptions

### DIFF
--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -1,6 +1,87 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { dashboardSlicesForRoute, parseWebSocketSseFrames } from './dashboard-ws'
+import {
+  connectDashboardWS,
+  dashboardSlicesForRoute,
+  disconnectDashboardWS,
+  parseWebSocketSseFrames,
+  subscribeDashboardRoute,
+} from './dashboard-ws'
+import { dashboardWsLastSeq } from './dashboard-ws-state'
+
+interface JsonRpcRequest {
+  id: number
+  method: string
+  params: Record<string, unknown>
+}
+
+const mockSockets: MockWebSocket[] = []
+
+class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+
+  readyState = MockWebSocket.CONNECTING
+  bufferedAmount = 0
+  sent: string[] = []
+  onopen: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  onclose: ((event: CloseEvent) => void) | null = null
+
+  constructor(readonly url: string) {
+    mockSockets.push(this)
+  }
+
+  send(data: string): void {
+    this.sent.push(data)
+  }
+
+  close(): void {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.(new CloseEvent('close'))
+  }
+
+  open(): void {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  receive(payload: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(payload) } as MessageEvent)
+  }
+}
+
+function installWebSocketMocks(): void {
+  mockSockets.length = 0
+  vi.stubGlobal('WebSocket', MockWebSocket)
+  vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+    enabled: true,
+    listening: true,
+    ws_url: 'ws://127.0.0.1:8937/',
+  }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })))
+}
+
+function parseRpc(socket: MockWebSocket, index: number): JsonRpcRequest {
+  return JSON.parse(socket.sent[index] ?? '{}') as JsonRpcRequest
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+afterEach(() => {
+  disconnectDashboardWS()
+  dashboardWsLastSeq.value = 0
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
 
 describe('dashboardSlicesForRoute', () => {
   it('keeps global shell namespace and transport slices on every route', () => {
@@ -53,5 +134,82 @@ describe('parseWebSocketSseFrames', () => {
       { type: 'post_created', post_id: 'p1' },
       { type: 'keeper_composite_changed', name: 'qa-king' },
     ])
+  })
+})
+
+describe('dashboard websocket route subscriptions', () => {
+  it('subscribes the latest route captured while hello is still in flight', async () => {
+    installWebSocketMocks()
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    await subscribeDashboardRoute({ tab: 'workspace', params: { section: 'board' } })
+
+    const socket = mockSockets[0]!
+    socket.open()
+    const hello = parseRpc(socket, 0)
+    expect(hello.method).toBe('dashboard/hello')
+
+    socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
+    await flushPromises()
+
+    const subscribe = parseRpc(socket, 1)
+    expect(subscribe.method).toBe('dashboard/subscribe')
+    expect(subscribe.params.route).toBe('workspace:board::')
+    expect(subscribe.params.slices).toEqual(expect.arrayContaining(['board']))
+
+    socket.receive({
+      jsonrpc: '2.0',
+      id: subscribe.id,
+      result: { snapshot: { seq: 7, slices: {} } },
+    })
+    await flushPromises()
+  })
+
+  it('ignores stale subscribe snapshots that arrive after a newer route subscription', async () => {
+    installWebSocketMocks()
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    const socket = mockSockets[0]!
+    socket.open()
+    const hello = parseRpc(socket, 0)
+    socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
+    await flushPromises()
+
+    const initialSubscribe = parseRpc(socket, 1)
+    socket.receive({
+      jsonrpc: '2.0',
+      id: initialSubscribe.id,
+      result: { snapshot: { seq: 1, slices: {} } },
+    })
+    await flushPromises()
+    dashboardWsLastSeq.value = 0
+
+    const stalePromise = subscribeDashboardRoute({
+      tab: 'workspace',
+      params: { section: 'board' },
+    })
+    const staleSubscribe = parseRpc(socket, 2)
+
+    const latestPromise = subscribeDashboardRoute({
+      tab: 'workspace',
+      params: { section: 'planning' },
+    })
+    const latestSubscribe = parseRpc(socket, 3)
+
+    socket.receive({
+      jsonrpc: '2.0',
+      id: staleSubscribe.id,
+      result: { snapshot: { seq: 11, slices: {} } },
+    })
+    await stalePromise
+    expect(dashboardWsLastSeq.value).toBe(0)
+
+    socket.receive({
+      jsonrpc: '2.0',
+      id: latestSubscribe.id,
+      result: { snapshot: { seq: 22, slices: {} } },
+    })
+    await latestPromise
+    expect(dashboardWsLastSeq.value).toBe(22)
   })
 })

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -67,6 +67,27 @@ function installWebSocketMocks(): void {
   })))
 }
 
+function installControlledDiscovery(): Array<(response: Response) => void> {
+  mockSockets.length = 0
+  const resolvers: Array<(response: Response) => void> = []
+  vi.stubGlobal('WebSocket', MockWebSocket)
+  vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>((resolve) => {
+    resolvers.push(resolve)
+  })))
+  return resolvers
+}
+
+function wsDiscoveryResponse(wsUrl = 'ws://127.0.0.1:8937/'): Response {
+  return new Response(JSON.stringify({
+    enabled: true,
+    listening: true,
+    ws_url: wsUrl,
+  }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
 function parseRpc(socket: MockWebSocket, index: number): JsonRpcRequest {
   return JSON.parse(socket.sent[index] ?? '{}') as JsonRpcRequest
 }
@@ -138,6 +159,40 @@ describe('parseWebSocketSseFrames', () => {
 })
 
 describe('dashboard websocket route subscriptions', () => {
+  it('does not open a socket when discovery resolves after disconnect', async () => {
+    const discoveries = installControlledDiscovery()
+
+    const connect = connectDashboardWS({ tab: 'overview', params: {} })
+    expect(discoveries).toHaveLength(1)
+
+    disconnectDashboardWS()
+    discoveries[0]!(wsDiscoveryResponse())
+    await connect
+    await flushPromises()
+
+    expect(mockSockets).toHaveLength(0)
+  })
+
+  it('ignores stale discovery responses after a newer connect starts', async () => {
+    const discoveries = installControlledDiscovery()
+
+    const staleConnect = connectDashboardWS({ tab: 'overview', params: {} })
+    const latestConnect = connectDashboardWS({ tab: 'workspace', params: { section: 'board' } })
+    expect(discoveries).toHaveLength(2)
+
+    discoveries[1]!(wsDiscoveryResponse('ws://127.0.0.1:8937/latest'))
+    await latestConnect
+    expect(mockSockets).toHaveLength(1)
+    expect(mockSockets[0]!.url).toBe('ws://127.0.0.1:8937/latest')
+
+    discoveries[0]!(wsDiscoveryResponse('ws://127.0.0.1:8937/stale'))
+    await staleConnect
+    await flushPromises()
+
+    expect(mockSockets).toHaveLength(1)
+    expect(mockSockets[0]!.readyState).toBe(MockWebSocket.CONNECTING)
+  })
+
   it('subscribes the latest route captured while hello is still in flight', async () => {
     installWebSocketMocks()
 

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -28,6 +28,7 @@ let reconnectAttempts = 0
 let lastSubscribeKey = ''
 let desiredRouteState: DashboardRouteState | null = null
 let shouldReconnect = true
+let connectGeneration = 0
 const pending = new Map<number, PendingRpc>()
 
 function rememberRouteState(routeState: DashboardRouteState): DashboardRouteState {
@@ -287,11 +288,17 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
 
   shouldReconnect = true
   clearReconnectTimer()
-  const wsUrl = await discoverWsUrl().catch(err => {
-    dashboardWsLastError.value = err instanceof Error ? err.message : String(err)
-    return null
-  })
-  if (!wsUrl) return
+  const generation = ++connectGeneration
+  let wsUrl: string | null
+  try {
+    wsUrl = await discoverWsUrl()
+  } catch (err) {
+    if (generation === connectGeneration && shouldReconnect) {
+      dashboardWsLastError.value = err instanceof Error ? err.message : String(err)
+    }
+    return
+  }
+  if (!wsUrl || !shouldReconnect || generation !== connectGeneration) return
 
   closeSocket()
   const ws = new WebSocket(wsUrl)
@@ -338,6 +345,7 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
 
 export function disconnectDashboardWS(): void {
   shouldReconnect = false
+  connectGeneration += 1
   clearReconnectTimer()
   dashboardWsConnected.value = false
   dashboardWsReady.value = false

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -13,6 +13,7 @@ type PendingRpc = {
   resolve: (value: unknown) => void
   reject: (err: Error) => void
 }
+type DashboardRouteState = Pick<RouteState, 'tab' | 'params'>
 
 interface DashboardWsDiscovery {
   enabled?: boolean
@@ -25,10 +26,19 @@ let rpcId = 0
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null
 let reconnectAttempts = 0
 let lastSubscribeKey = ''
+let desiredRouteState: DashboardRouteState | null = null
 let shouldReconnect = true
 const pending = new Map<number, PendingRpc>()
 
-function routeKey(routeState: Pick<RouteState, 'tab' | 'params'>): string {
+function rememberRouteState(routeState: DashboardRouteState): DashboardRouteState {
+  desiredRouteState = {
+    tab: routeState.tab,
+    params: { ...routeState.params },
+  }
+  return desiredRouteState
+}
+
+function routeKey(routeState: DashboardRouteState): string {
   const params = routeState.params
   return [
     routeState.tab,
@@ -38,7 +48,7 @@ function routeKey(routeState: Pick<RouteState, 'tab' | 'params'>): string {
   ].join(':')
 }
 
-export function dashboardSlicesForRoute(routeState: Pick<RouteState, 'tab' | 'params'>): string[] {
+export function dashboardSlicesForRoute(routeState: DashboardRouteState): string[] {
   const slices = new Set(['shell', 'namespace', 'transport'])
 
   if (routeState.tab === 'workspace' && routeState.params.section === 'planning') {
@@ -248,17 +258,19 @@ function handleMessage(data: unknown): void {
   handleRawPush(record)
 }
 
-export async function subscribeDashboardRoute(routeState: Pick<RouteState, 'tab' | 'params'>): Promise<void> {
+export async function subscribeDashboardRoute(routeState: DashboardRouteState): Promise<void> {
+  const desired = rememberRouteState(routeState)
   if (!dashboardWsReady.value) return
-  const slices = dashboardSlicesForRoute(routeState)
-  const key = `${routeKey(routeState)}|${slices.join(',')}`
+  const slices = dashboardSlicesForRoute(desired)
+  const key = `${routeKey(desired)}|${slices.join(',')}`
   if (key === lastSubscribeKey) return
   lastSubscribeKey = key
   try {
     const result = await sendRpc('dashboard/subscribe', {
-      route: routeKey(routeState),
+      route: routeKey(desired),
       slices,
     })
+    if (lastSubscribeKey !== key) return
     applySubscribeResult(result)
   } catch (err) {
     if (lastSubscribeKey === key) lastSubscribeKey = ''
@@ -266,7 +278,8 @@ export async function subscribeDashboardRoute(routeState: Pick<RouteState, 'tab'
   }
 }
 
-export async function connectDashboardWS(routeState?: Pick<RouteState, 'tab' | 'params'>): Promise<void> {
+export async function connectDashboardWS(routeState?: DashboardRouteState): Promise<void> {
+  if (routeState) rememberRouteState(routeState)
   if (typeof WebSocket === 'undefined') return
   if (socket && (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING)) {
     return
@@ -296,8 +309,8 @@ export async function connectDashboardWS(routeState?: Pick<RouteState, 'tab' | '
       .then(() => {
         dashboardWsReady.value = true
         dashboardWsLastError.value = null
-        if (routeState) {
-          void subscribeDashboardRoute(routeState)
+        if (desiredRouteState) {
+          void subscribeDashboardRoute(desiredRouteState)
         }
       })
       .catch(err => {
@@ -329,5 +342,6 @@ export function disconnectDashboardWS(): void {
   dashboardWsConnected.value = false
   dashboardWsReady.value = false
   lastSubscribeKey = ''
+  desiredRouteState = null
   closeSocket()
 }


### PR DESCRIPTION
## Summary

- remember the latest dashboard route even when WebSocket hello has not completed yet
- subscribe with the latest remembered route once the socket becomes ready
- ignore stale subscribe snapshot responses when a newer route subscription has already been sent
- ignore stale /ws discovery responses after disconnect or a newer connect attempt
- add WebSocket client tests for handshake-time route changes, stale subscribe snapshots, and discovery races

## Root Cause

subscribeDashboardRoute returned immediately while dashboardWsReady was false. If the user navigated during WebSocket discovery or hello, the route update was dropped and hello could subscribe the initial route instead of the current route. A slow response from an older subscribe request could also hydrate a stale snapshot after a newer route had already been selected.

connectDashboardWS also trusted whichever /ws discovery response completed last. A discovery request resolving after disconnect, or after a newer connect attempt, could open or replace a socket from stale lifecycle state.

## Validation

- pnpm typecheck
- pnpm lint
- env PATH=/Users/dancer/.nvm/versions/node/v22.22.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin pnpm exec vitest run src/dashboard-ws.test.ts --no-file-parallelism --maxWorkers=1 --reporter=verbose
- GitHub CI Gate green on PR #9986