### PR TITLE
fix(keeper): replace degenerate heuristic_metrics emit with Prometheus counter (#9919)

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -55,6 +55,20 @@ let usage_has_tokens (usage : Oas.Types.api_usage) =
   || usage.cache_creation_input_tokens > 0
   || usage.cache_read_input_tokens > 0
 
+(* #9919: counter for post_tool_use_failure events.
+
+   Replaces an earlier [Heuristic_metrics.record] emit that produced
+   degenerate 1-bit records (51 identical rows in 48h of production,
+   [threshold=0.0, raw=1.0, triggered=true]).  Per keeper + per tool
+   labels let dashboards and #9880 governance judgments distinguish
+   which keeper-tool pairs are actually failing instead of reading a
+   single undifferentiated marker. *)
+let tool_use_failure_metric = "masc_keeper_tool_use_failure_total"
+
+let record_tool_use_failure ~keeper_name ~tool_name =
+  Prometheus.inc_counter tool_use_failure_metric
+    ~labels:[ ("keeper", keeper_name); ("tool", tool_name) ] ()
+
 (* #9868: use [pricing_for_model_opt] so unknown models surface as
    [None] and get a loud catalog-miss signal instead of silently
    returning $0. [pricing_for_model] (non-opt) collapses unknown into
@@ -721,24 +735,14 @@ let make_hooks
         let meta = !meta_ref in
         (* The richer counterpart
              "tool <name> returned error result (n/max): <detail>"
-           is already emitted at ERROR by keeper_tools_oas before this hook
-           runs. Emitting a second ERROR here with the same error content
-           produces paired duplicate lines per tool failure. Keep a debug
-           trace for hook-chain readers; the metric below still records. *)
+           is already emitted at ERROR by keeper_tools_oas before this
+           hook runs. Emitting a second ERROR here with the same error
+           content produces paired duplicate lines per tool failure —
+           keep a debug trace for hook-chain readers only. *)
         Log.Keeper.debug "keeper:%s tool_use_failure: %s — %s"
           meta.name tool_name error;
-        let error_detail_len =
-          String.length (String.trim error) |> Float.of_int
-        in
-        Heuristic_metrics.record {
-          module_name = "keeper_hooks_oas";
-          site = "post_tool_use_failure";
-          raw_value = error_detail_len;
-          threshold = 1.0;
-          triggered = error_detail_len >= 1.0;
-          provenance = Pipeline_stage ("post_tool_use_failure:" ^ tool_name);
-          timestamp = Unix.gettimeofday ();
-        };
+        (* #9919: this path is a count event, not a heuristic decision. *)
+        record_tool_use_failure ~keeper_name:meta.name ~tool_name;
         Oas.Hooks.Continue
       | _ -> Oas.Hooks.Continue);
   }

--- a/test/dune
+++ b/test/dune
@@ -54,6 +54,7 @@
         test_keeper_hooks_oas_provider
         test_keeper_hooks_oas_pricing
         test_keeper_hooks_oas_telemetry
+          test_keeper_tool_use_failure_counter
         test_keeper_wake_telemetry
         test_keeper_memory
         test_keeper_accountability
@@ -179,6 +180,7 @@
           test_keeper_hooks_oas_provider
           test_keeper_hooks_oas_pricing
           test_keeper_hooks_oas_telemetry
+          test_keeper_tool_use_failure_counter
           test_keeper_wake_telemetry
           test_keeper_memory
           test_keeper_accountability

--- a/test/test_keeper_tool_use_failure_counter.ml
+++ b/test/test_keeper_tool_use_failure_counter.ml
@@ -1,0 +1,68 @@
+(* test/test_keeper_tool_use_failure_counter.ml
+
+   #9919: verify that [post_tool_use_failure] in keeper_hooks_oas
+   emits a proper Prometheus counter with [keeper] and [tool]
+   labels instead of the degenerate [Heuristic_metrics.record]
+   that produced 51 identical 1-bit rows in production. *)
+
+module H = Masc_mcp.Keeper_hooks_oas
+module Prom = Masc_mcp.Prometheus
+
+let counter_for ~keeper ~tool =
+  Prom.metric_value_or_zero
+    H.tool_use_failure_metric
+    ~labels:[ ("keeper", keeper); ("tool", tool) ]
+    ()
+
+let test_metric_name_matches_convention () =
+  (* Prometheus _total suffix + masc_ prefix follow the existing
+     counter naming in keeper_hooks_oas.  A rename would break
+     dashboards and #9880 governance readers. *)
+  Alcotest.(check string)
+    "tool_use_failure counter uses canonical masc_*_total name"
+    "masc_keeper_tool_use_failure_total"
+    H.tool_use_failure_metric
+
+let test_record_increments_with_labels () =
+  let keeper = "test-keeper-9919-a" in
+  let tool = "board_post" in
+  let before = counter_for ~keeper ~tool in
+  H.record_tool_use_failure ~keeper_name:keeper ~tool_name:tool;
+  Alcotest.(check (float 0.0001))
+    "counter +1 for (keeper, tool) pair"
+    (before +. 1.0) (counter_for ~keeper ~tool)
+
+let test_labels_isolate_keeper_tool_pairs () =
+  (* #9919 root complaint: prior emit had no identifying dimension.
+     Verify that two distinct (keeper, tool) pairs accumulate
+     independently — a single emit on one pair must not increment
+     the other. *)
+  let a_keeper = "test-keeper-9919-a" in
+  let b_keeper = "test-keeper-9919-b" in
+  let tool = "keeper_board_comment" in
+  let a_before = counter_for ~keeper:a_keeper ~tool in
+  let b_before = counter_for ~keeper:b_keeper ~tool in
+  H.record_tool_use_failure ~keeper_name:a_keeper ~tool_name:tool;
+  Alcotest.(check (float 0.0001))
+    "A counter +1" (a_before +. 1.0)
+    (counter_for ~keeper:a_keeper ~tool);
+  Alcotest.(check (float 0.0001))
+    "B counter unchanged" b_before
+    (counter_for ~keeper:b_keeper ~tool)
+
+let () =
+  Alcotest.run "keeper_tool_use_failure_counter_9919"
+    [
+      ( "metric_name",
+        [
+          Alcotest.test_case "masc_*_total convention" `Quick
+            test_metric_name_matches_convention;
+        ] );
+      ( "counter",
+        [
+          Alcotest.test_case "increments with labels" `Quick
+            test_record_increments_with_labels;
+          Alcotest.test_case "isolates keeper/tool pairs" `Quick
+            test_labels_isolate_keeper_tool_pairs;
+        ] );
+    ]


### PR DESCRIPTION
## 요약

`keeper_hooks_oas` 의 `post_tool_use_failure` hook 이 `Heuristic_metrics.record` 로 emit — 이 store 는 runtime threshold 가 있는 진짜 heuristic 결정 사이트용 (`post_verifier`, `drift_guard`, `keeper_alerting`, `thompson_sampling`). 본 사이트는 threshold 가 없는 pure count event. 실제 prod 데이터는 48h 동안 51 rows 전부 `raw=1.0 threshold=0.0 triggered=true` — #7718 instrumentation-theatre signature (boot diagnostic 으로 이미 warn 발생).

"가짜 threshold 만들기" 대신 **실제 데이터 모양에 맞는 primitive** 로 이전 — Prometheus counter `masc_keeper_tool_use_failure_total{keeper, tool}`. 이제 #9880 governance judgment / dashboard 가 per-keeper / per-tool 실패율을 읽을 수 있음. 1-bit 마커가 구조화된 dimension 으로 전환.

## 변경 파일

- `lib/keeper/keeper_hooks_oas.ml`
  - `record_tool_use_failure ~keeper_name ~tool_name` 신규 top-level helper (`tool_use_failure_metric` 상수 + Prometheus emit).
  - `post_tool_use_failure` hook 의 `Heuristic_metrics.record { site = "post_tool_use_failure"; threshold = 1.0; ... }` 제거, 대신 helper 호출. 불필요해진 `error_detail_len` float 계산도 제거.
- `test/test_keeper_tool_use_failure_counter.ml` (신규) — 3 테스트:
  - canonical 이름 `masc_keeper_tool_use_failure_total` pin (dashboard rename 방어).
  - `record_tool_use_failure` 가 counter +1 (keeper, tool label).
  - 서로 다른 (keeper, tool) pair 독립 누적 — 한쪽 emit 이 다른 쪽 값을 건드리지 않음. 이슈 본문 "Dimension 없음" 의 회귀 가드.
- `test/dune` — 새 test 등록.

## 로컬 검증

```
$ MASC_BASE_PATH=/tmp/masc-test-9919 dune exec test/test_keeper_tool_use_failure_counter.exe
Testing 'keeper_tool_use_failure_counter_9919'.
  [OK] metric_name 0 masc_*_total convention.
  [OK] counter 0 increments with labels.
  [OK] counter 1 isolates keeper/tool pairs.
Test Successful in 0.001s. 3 tests run.
```

`dune build` clean. Clean rebuild 필요 (OAS 0.170.9 pin 이후).

## 왜 근원 fix 인가

- **Mis-categorization 교정**: `Heuristic_metrics` 는 decision coverage 용, counter 아님. 같은 데이터의 right primitive 선택은 schema 확장/threshold 위조보다 우선.
- **Boot-time 진단은 이미 심어둠**: 이전 tick 에서 `Heuristic_metrics_diagnostics` 가 degenerate 사이트를 warn 하도록 bootstrap 에 연결됨 (`lib/server/server_runtime_bootstrap.ml:272-315`). 이 PR 로 emit 사이트 자체를 제거하면 warn 도 함께 해소.
- **Issue 제안 #1 (schema 확장)** 대안: 스키마를 바꾸지 않고도 올바른 primitive (Prometheus labels) 로 keeper/tool dimension 확보.
- **Issue 제안 #2 (동적 threshold)** 불필요: 이 사이트는 heuristic 이 아님.
- **`feedback_dead-code-removal-full-sweep.md` 원칙**: 다른 `Heuristic_metrics.record` 사이트는 real threshold 를 사용 — 이것만 오분류였음.

## 미검증 / 후속

- Board_core_classify (`raw=1.0 threshold=0.5`) 와 `thompson_sampling priority_trigger` (`raw=signal threshold=0.0 triggered=true`) 도 유사 degenerate 패턴 가능성. 별도 PR 로 audit.
- 이미 `heuristic_metrics.jsonl` 에 축적된 51 rows 는 운영자가 수동 rotate (backup 후 truncate). 본 PR 은 새 쓰기 중단이 목표.
- Grafana query update: `rate(masc_keeper_tool_use_failure_total[5m])` 로 per-keeper 실패율 dashboard panel 추가 — 별도 ops task.

## 관련

- #9919 (root issue).
- #7718 (instrumentation-theatre signature).
- #9517 (silent failure meta).
- #9880 (governance decorative judgments — 본 PR 로 read-side 재료 공급).

🤖 Generated with [Claude Code](https://claude.com/claude-code)