### PR TITLE
fix(dashboard): avoid tailwind var placeholder scan

### DIFF
--- a/dashboard/src/components/fleet-fsm-matrix.test.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.test.ts
@@ -112,7 +112,7 @@ describe('tallyInvariantViolations', () => {
 
 describe('sparkClassFor', () => {
   it('extracts a single bg-* utility from the full chip class', () => {
-    // The bracketed arbitrary-value syntax (`bg-[var(...)]`) cannot
+    // Bracketed Tailwind arbitrary values that wrap CSS vars cannot
     // live inside a JS regex literal because `[...]` starts a
     // character class; use startsWith on the extracted prefix.
     expect(sparkClassFor('Running').startsWith('bg-[var(--ok-10)]')).toBe(true)


### PR DESCRIPTION
## Summary

- remove a literal Tailwind arbitrary-value placeholder from a test comment
- prevent Tailwind from generating invalid `.bg-[var(...)]` CSS during dashboard builds

Fixes #9981

## Verification

- `rg -n -F 'bg-[var(...)]' dashboard/src dashboard -g '!node_modules'` (no matches)
- `pnpm exec vitest run --no-file-parallelism --maxWorkers=1 src/components/fleet-fsm-matrix.test.ts`
- `pnpm build`

The build no longer emits the generated CSS optimizer warning for `.bg-[var(...)]`.
