### PR TITLE
refactor(benchmark): migrate tool_call_quality_benchmark_loader to Result types (#9716)

### DIFF
--- a/lib/tool_call_quality_benchmark.mli
+++ b/lib/tool_call_quality_benchmark.mli
@@ -3,8 +3,8 @@ include module type of Tool_call_quality_benchmark_types
 val default_case_set_path : repo_root:string -> string
 val default_evidence_path : repo_root:string -> string
 
-val load_cases_from_file : string -> benchmark_case list
-val load_runs_from_file : string -> evidence_run list
+val load_cases_from_file : string -> (benchmark_case list, string) result
+val load_runs_from_file : string -> (evidence_run list, string) result
 
 val score_run :
   cases:benchmark_case list -> evidence_run -> case_score option

--- a/lib/tool_call_quality_benchmark_loader.ml
+++ b/lib/tool_call_quality_benchmark_loader.ml
@@ -22,7 +22,16 @@ let normalize_string_list items =
   |> List.filter (fun item -> item <> "")
   |> dedupe_keep_order
 
-let raise_invalidf fmt = Printf.ksprintf invalid_arg fmt
+let errorf fmt = Printf.ksprintf (fun s -> Error s) fmt
+
+let ( let* ) = Result.bind
+
+let rec map_m f = function
+  | [] -> Ok []
+  | x :: xs ->
+      let* y = f x in
+      let* ys = map_m f xs in
+      Ok (y :: ys)
 
 let run_status_of_string raw =
   match String.trim (String.lowercase_ascii raw) with
@@ -33,16 +42,16 @@ let run_status_of_string raw =
 
 let case_category_of_string raw =
   match String.trim (String.lowercase_ascii raw) with
-  | "tool_required" -> Tool_required
-  | "tool_forbidden" -> Tool_forbidden
-  | "recovery_required" -> Recovery_required
-  | "multi_step" -> Multi_step
-  | other -> raise_invalidf "unknown tool-call-quality category: %s" other
+  | "tool_required" -> Ok Tool_required
+  | "tool_forbidden" -> Ok Tool_forbidden
+  | "recovery_required" -> Ok Recovery_required
+  | "multi_step" -> Ok Multi_step
+  | other -> errorf "unknown tool-call-quality category: %s" other
 
 let read_json_file path =
   match Safe_ops.read_json_file_safe path with
-  | Ok json -> json
-  | Error err -> raise_invalidf "failed to read %s: %s" path err
+  | Ok json -> Ok json
+  | Error err -> errorf "failed to read %s: %s" path err
 
 let member_opt key = function
   | `Assoc fields -> List.assoc_opt key fields
@@ -50,24 +59,26 @@ let member_opt key = function
 
 let required_string_field json key =
   match Yojson.Safe.Util.member key json |> Yojson.Safe.Util.to_string_option with
-  | Some value when String.trim value <> "" -> value
-  | _ -> raise_invalidf "missing required string field %s" key
+  | Some value when String.trim value <> "" -> Ok value
+  | _ -> errorf "missing required string field %s" key
 
 let list_field json key =
   match member_opt key json with
-  | Some (`List items) -> items
-  | Some `Null | None -> []
-  | Some _ -> raise_invalidf "field %s must be a list" key
+  | Some (`List items) -> Ok items
+  | Some `Null | None -> Ok []
+  | Some _ -> errorf "field %s must be a list" key
 
 let string_list_field json key =
-  list_field json key
-  |> List.filter_map Yojson.Safe.Util.to_string_option
-  |> normalize_string_list
+  let* items = list_field json key in
+  Ok (items
+      |> List.filter_map Yojson.Safe.Util.to_string_option
+      |> normalize_string_list)
 
 let parse_json_check json =
   let open Yojson.Safe.Util in
-  {
-    path = required_string_field json "path";
+  let* path = required_string_field json "path" in
+  Ok {
+    path;
     equals = (match member_opt "equals" json with Some value -> Some value | None -> None);
     contains = json |> member "contains" |> to_string_option;
     min_int = json |> member "min_int" |> to_int_option;
@@ -76,9 +87,11 @@ let parse_json_check json =
 
 let parse_arg_check json =
   let open Yojson.Safe.Util in
-  {
-    tool_name = required_string_field json "tool_name";
-    path = required_string_field json "path";
+  let* tool_name = required_string_field json "tool_name" in
+  let* path = required_string_field json "path" in
+  Ok {
+    tool_name;
+    path;
     equals = (match member_opt "equals" json with Some value -> Some value | None -> None);
     contains = json |> member "contains" |> to_string_option;
     min_int = json |> member "min_int" |> to_int_option;
@@ -98,35 +111,54 @@ let parse_recovery_policy json =
 
 let benchmark_case_of_yojson json =
   let open Yojson.Safe.Util in
-  let id = required_string_field json "id" in
-  let keeper_profiles = string_list_field json "keeper_profiles" in
-  let success_checks = list_field json "success_checks" |> List.map parse_json_check in
-  if keeper_profiles = [] then
-    raise_invalidf "benchmark case %s must declare keeper_profiles" id;
-  if success_checks = [] then
-    raise_invalidf "benchmark case %s must declare success_checks" id;
+  let* id = required_string_field json "id" in
+  let* keeper_profiles = string_list_field json "keeper_profiles" in
+  let* success_check_items = list_field json "success_checks" in
+  let* success_checks = map_m parse_json_check success_check_items in
+  let* () =
+    if keeper_profiles = [] then
+      errorf "benchmark case %s must declare keeper_profiles" id
+    else Ok ()
+  in
+  let* () =
+    if success_checks = [] then
+      errorf "benchmark case %s must declare success_checks" id
+    else Ok ()
+  in
   let max_tool_calls =
     json |> member "max_tool_calls" |> to_int_option |> Option.value ~default:0
   in
-  if max_tool_calls < 0 then
-    raise_invalidf "benchmark case %s has negative max_tool_calls" id;
-  {
+  let* () =
+    if max_tool_calls < 0 then
+      errorf "benchmark case %s has negative max_tool_calls" id
+    else Ok ()
+  in
+  let* prompt = required_string_field json "prompt" in
+  let* required_tools = string_list_field json "required_tools" in
+  let* forbidden_tools = string_list_field json "forbidden_tools" in
+  let* category =
+    json |> member "category" |> to_string_option
+    |> Option.value ~default:"tool_required"
+    |> case_category_of_string
+  in
+  let* arg_check_items = list_field json "arg_checks" in
+  let* arg_checks = map_m parse_arg_check arg_check_items in
+  let recovery_policy =
+    match member_opt "recovery_policy" json with
+    | Some (`Assoc _ as value) -> Some (parse_recovery_policy value)
+    | _ -> None
+  in
+  Ok {
     id;
-    prompt = required_string_field json "prompt";
-    category =
-      json |> member "category" |> to_string_option
-      |> Option.value ~default:"tool_required"
-      |> case_category_of_string;
+    prompt;
+    category;
     keeper_profiles;
-    required_tools = string_list_field json "required_tools";
-    forbidden_tools = string_list_field json "forbidden_tools";
+    required_tools;
+    forbidden_tools;
     max_tool_calls;
     success_checks;
-    arg_checks = list_field json "arg_checks" |> List.map parse_arg_check;
-    recovery_policy =
-      match member_opt "recovery_policy" json with
-      | Some (`Assoc _ as value) -> Some (parse_recovery_policy value)
-      | _ -> None;
+    arg_checks;
+    recovery_policy;
   }
 
 let tool_call_of_yojson json =
@@ -144,11 +176,16 @@ let tool_call_of_yojson json =
 
 let evidence_run_of_yojson json =
   let open Yojson.Safe.Util in
-  {
-    case_id = required_string_field json "case_id";
-    provider = required_string_field json "provider";
-    model = required_string_field json "model";
-    keeper_profile = required_string_field json "keeper_profile";
+  let* case_id = required_string_field json "case_id" in
+  let* provider = required_string_field json "provider" in
+  let* model = required_string_field json "model" in
+  let* keeper_profile = required_string_field json "keeper_profile" in
+  let* tool_call_items = list_field json "tool_calls" in
+  Ok {
+    case_id;
+    provider;
+    model;
+    keeper_profile;
     run_id = json |> member "run_id" |> to_string_option;
     repeat_index = json |> member "repeat_index" |> to_int_option;
     prompt_fingerprint = json |> member "prompt_fingerprint" |> to_string_option;
@@ -162,25 +199,25 @@ let evidence_run_of_yojson json =
     status =
       json |> member "status" |> to_string_option |> Option.value ~default:"ok"
       |> run_status_of_string;
-    tool_calls = list_field json "tool_calls" |> List.map tool_call_of_yojson;
+    tool_calls = List.map tool_call_of_yojson tool_call_items;
   }
 
 let load_cases_from_file path =
-  let json = read_json_file path in
-  let cases =
+  let* json = read_json_file path in
+  let* cases =
     match json with
-    | `List items -> items
+    | `List items -> Ok items
     | `Assoc _ -> list_field json "cases"
-    | _ -> raise_invalidf "invalid benchmark case set at %s" path
+    | _ -> errorf "invalid benchmark case set at %s" path
   in
-  cases |> List.map benchmark_case_of_yojson
+  map_m benchmark_case_of_yojson cases
 
 let load_runs_from_file path =
-  let json = read_json_file path in
-  let runs =
+  let* json = read_json_file path in
+  let* runs =
     match json with
-    | `List items -> items
+    | `List items -> Ok items
     | `Assoc _ -> list_field json "runs"
-    | _ -> raise_invalidf "invalid benchmark evidence set at %s" path
+    | _ -> errorf "invalid benchmark evidence set at %s" path
   in
-  runs |> List.map evidence_run_of_yojson
+  map_m evidence_run_of_yojson runs

--- a/test/test_tool_call_quality_benchmark.ml
+++ b/test/test_tool_call_quality_benchmark.ml
@@ -10,8 +10,16 @@ let fixture_runs repo_root =
 
 let load_fixture () =
   let repo_root = Sys.getcwd () in
-  let cases = Tool_call_quality_benchmark.load_cases_from_file (fixture_cases repo_root) in
-  let runs = Tool_call_quality_benchmark.load_runs_from_file (fixture_runs repo_root) in
+  let cases =
+    match Tool_call_quality_benchmark.load_cases_from_file (fixture_cases repo_root) with
+    | Ok v -> v
+    | Error msg -> fail ("load_cases_from_file failed: " ^ msg)
+  in
+  let runs =
+    match Tool_call_quality_benchmark.load_runs_from_file (fixture_runs repo_root) with
+    | Ok v -> v
+    | Error msg -> fail ("load_runs_from_file failed: " ^ msg)
+  in
   (cases, runs)
 
 let find_row ~provider ~model ~keeper rows =

--- a/test/tool_call_quality_benchmark_cli.ml
+++ b/test/tool_call_quality_benchmark_cli.ml
@@ -57,8 +57,20 @@ let () =
   in
   let usage = "tool_call_quality_benchmark_cli [--cases PATH] [--evidence PATH]" in
   Arg.parse specs (fun _ -> ()) usage;
-  let cases = Tool_call_quality_benchmark.load_cases_from_file !cases_path in
-  let runs = Tool_call_quality_benchmark.load_runs_from_file !evidence_path in
+  let cases =
+    match Tool_call_quality_benchmark.load_cases_from_file !cases_path with
+    | Ok v -> v
+    | Error msg ->
+        prerr_endline ("load_cases_from_file failed: " ^ msg);
+        exit 1
+  in
+  let runs =
+    match Tool_call_quality_benchmark.load_runs_from_file !evidence_path with
+    | Ok v -> v
+    | Error msg ->
+        prerr_endline ("load_runs_from_file failed: " ^ msg);
+        exit 1
+  in
   let summary =
     Tool_call_quality_benchmark.summarize ~cases ~runs
       ~model_filters:!model_filters ~keeper_filters:!keeper_filters ()


### PR DESCRIPTION
## 요약

`tool_call_quality_benchmark_loader`가 JSON 입력 파일을 파싱하는 **runtime 연산**인데도 `raise_invalidf` (내부 `invalid_arg`)로 실패를 신호함. Alexis King *Parse, Don't Validate* 원칙에 따라 `(_, string) result`로 전환하고 caller가 실패를 타입 레벨에서 처리하도록 강제.

Closes #9716.

## 변경 내용

### 1. `errorf` helper 도입

```diff
- let raise_invalidf fmt = Printf.ksprintf invalid_arg fmt
+ let errorf fmt = Printf.ksprintf (fun s -> Error s) fmt
+ let ( let* ) = Result.bind
```

### 2. Parser 함수 Result 전환

| 함수 | 전 | 후 |
|------|-----|-----|
| `case_category_of_string` | `raw -> category` | `raw -> (category, string) result` |
| `read_json_file` | `path -> json` | `path -> (json, string) result` |
| `required_string_field` | `json, key -> string` | `json, key -> (string, string) result` |
| `list_field` | `json, key -> json list` | `... -> (json list, string) result` |
| `string_list_field` | `json, key -> string list` | `... -> (string list, string) result` |
| `parse_json_check` | `json -> json_check` | `json -> (json_check, string) result` |
| `parse_arg_check` | `json -> arg_check` | `json -> (arg_check, string) result` |
| `benchmark_case_of_yojson` | `json -> benchmark_case` | `json -> (benchmark_case, string) result` |
| `evidence_run_of_yojson` | `json -> evidence_run` | `json -> (evidence_run, string) result` |
| `load_cases_from_file` | `path -> benchmark_case list` | `path -> (benchmark_case list, string) result` |
| `load_runs_from_file` | `path -> evidence_run list` | `path -> (evidence_run list, string) result` |

### 3. `map_m` — first-error short-circuit

```ocaml
let rec map_m f = function
  | [] -> Ok []
  | x :: xs ->
      let* y = f x in
      let* ys = map_m f xs in
      Ok (y :: ys)
```

List 요소 하나가 Error면 즉시 중단. 첫 에러 message 보존.

### 4. 호출부 업데이트

```diff
  (* test/test_tool_call_quality_benchmark.ml *)
- let cases = Tool_call_quality_benchmark.load_cases_from_file (fixture_cases repo_root) in
+ let cases =
+   match Tool_call_quality_benchmark.load_cases_from_file (fixture_cases repo_root) with
+   | Ok v -> v
+   | Error msg -> fail ("load_cases_from_file failed: " ^ msg)
+ in

  (* test/tool_call_quality_benchmark_cli.ml *)
- let cases = Tool_call_quality_benchmark.load_cases_from_file !cases_path in
+ let cases =
+   match Tool_call_quality_benchmark.load_cases_from_file !cases_path with
+   | Ok v -> v
+   | Error msg ->
+       prerr_endline ("load_cases_from_file failed: " ^ msg);
+       exit 1
+ in
```

## Acceptance Criteria

- [x] 모든 parser 함수가 raise 대신 Result 반환
- [x] Caller가 `Error`를 우아하게 처리 (test: `fail`, CLI: `exit 1` + stderr)
- [x] `dune build @check` exit 0
- [x] `dune exec test/test_tool_call_quality_benchmark.exe` 통과 (3/3 benchmark cases)
- [x] Loader에 `invalid_arg`/`failwith` 없음

## 검증

```bash
$ dune exec --root . test/test_tool_call_quality_benchmark.exe
# → Test Successful in 0.007s. 3 tests run.

$ rg 'invalid_arg|failwith|raise_invalidf' lib/tool_call_quality_benchmark_loader.ml
# → no matches
```

## 회귀 리스크

낮음 — 시그니처 변경이므로 caller 컴파일러가 놓친 호출부 강제 탐지. Lib 내부 모듈은 `tool_call_quality_benchmark.ml`이 re-export만 하므로 영향 없음. 기존 fixture 로드가 성공 경로를 유지(테스트 3/3 통과로 확인).

## 참고

- Issue #9716 — 원 요청
- Alexis King — *Parse, Don't Validate* (partial → total function)
