### PR TITLE
[codex] Align masc claim-task progress detection

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -2071,9 +2071,9 @@ let run_turn
                    | Some existing -> Some (existing ^ "\n\n" ^ temporal))
               in
               (* 1c. Claimed-task execution nudge: when the keeper holds a
-                 claimed task but the last turn only called claim tools
-                 (keeper_task_claim / masc_claim_next), inject a prompt
-                 to break the claim-only loop and start real work. *)
+                 claimed task but the last turn only called claim tools,
+                 inject a prompt to break the claim-only loop and start real
+                 work. *)
               let ctx =
                 match (!meta_ref).current_task_id with
                 | Some task_id ->

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -234,7 +234,8 @@ let is_passive_status_tool_name name =
 
 let is_claim_tool_name name =
   match Tool_name.of_string name with
-  | Some (Keeper Task_claim) | Some (Masc Claim_next) -> true
+  | Some (Keeper Task_claim) | Some (Masc Claim_next) | Some (Masc Claim_task) ->
+    true
   | _ -> false
 
 let is_claim_context_tool_name name =

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -393,7 +393,9 @@ let append_decision_record
   let pending_approval_count =
     Keeper_approval_queue.pending_count_for_keeper ~keeper_name:meta.name
   in
-  let claim_executed = List.mem "keeper_task_claim" tools_used in
+  let claim_executed =
+    List.exists Keeper_tool_disclosure.is_claim_tool_name tools_used
+  in
   let social_fields =
     match social_state with
     | None -> []

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
@@ -166,7 +166,7 @@ let inferred_tool_surface tools =
           delivery_surface = Types.Broadcast_surface;
         }
       , Types.Tool_only_broadcast )
-  else if List.mem "keeper_task_claim" tools || List.mem "masc_claim_next" tools then
+  else if List.exists Keeper_tool_disclosure.is_claim_tool_name tools then
     Some
       ( {
           speech_act = Types.Claim_task;

--- a/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.ml
@@ -51,7 +51,7 @@ let active_desire_of_phase = function
 
 let current_intention_of_phase ~(phase : Fsm.phase) ~(tools_used : string list)
     ~(has_text_reply : bool) =
-  if List.mem "keeper_task_claim" tools_used || List.mem "masc_claim_next" tools_used
+  if List.exists Keeper_tool_disclosure.is_claim_tool_name tools_used
   then Some "capture_next_task"
   else if tools_used <> [] then Some "record_progress_evidence"
   else if has_text_reply then Some "publish_progress_update"

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4128,6 +4128,18 @@ let test_actionable_tool_contract_rejects_claim_context_when_already_claimed () 
        ~actionable_signal_context:true
        ~tool_names:[ "keeper_task_claim" ])
 
+let test_claim_tool_classification_covers_masc_claim_task () =
+  check bool "keeper claim is claim tool" true
+    (KTD.is_claim_tool_name "keeper_task_claim");
+  check bool "masc claim next is claim tool" true
+    (KTD.is_claim_tool_name "masc_claim_next");
+  check bool "masc claim task is claim tool" true
+    (KTD.is_claim_tool_name "masc_claim_task");
+  check bool "task creation is not claim tool" false
+    (KTD.is_claim_tool_name "keeper_task_create");
+  check bool "task list is not claim tool" false
+    (KTD.is_claim_tool_name "keeper_tasks_list")
+
 let test_actionable_tool_contract_allows_execution_tools () =
   check (option string) "execution tool satisfies actionable signal" None
     (KTD.actionable_tool_contract_violation_reason
@@ -4528,6 +4540,24 @@ let test_social_model_infers_board_comment_from_tool_use () =
   check (list string) "tool list preserved"
     ["keeper_board_comment"; "masc_status"] routed.tools_used
 
+let test_social_model_infers_masc_claim_task_from_tool_use () =
+  let result =
+    make_run_result ~text:"" ~tools:["masc_claim_task"]
+      ~model:"test-model" ~input_tok:10 ~output_tok:1 ()
+  in
+  let routed, state, transition_reason =
+    KSM.apply_to_result ~meta:minimal_meta
+      ~observation:base_observation ~previous_state:None result
+  in
+  check string "speech act" "claim_task"
+    (KSM.speech_act_to_string state.speech_act);
+  check string "delivery surface" "task_claim"
+    (KSM.delivery_surface_to_string state.delivery_surface);
+  check string "transition reason" "tool_only:claim_task"
+    (KSM.transition_reason_to_string transition_reason);
+  check (list string) "tool list preserved" ["masc_claim_task"]
+    routed.tools_used
+
 let test_social_model_magentic_ledger_silences_tool_only_turn () =
   let meta = { minimal_meta with social_model = "magentic_ledger_v1" } in
   let result =
@@ -4553,6 +4583,25 @@ let test_social_model_magentic_ledger_silences_tool_only_turn () =
     (contains_substring state.belief_summary "ledger:phase=advancing");
   check string "visible response suppressed" "" routed.response_text;
   check (list string) "tool list preserved" ["masc_status"] routed.tools_used
+
+let test_social_model_magentic_ledger_tracks_masc_claim_task () =
+  let meta = { minimal_meta with social_model = "magentic_ledger_v1" } in
+  let result =
+    make_run_result ~text:"" ~tools:["masc_claim_task"]
+      ~model:"test-model" ~input_tok:10 ~output_tok:1 ()
+  in
+  let routed, state, transition_reason =
+    KSM.apply_to_result ~meta ~observation:base_observation
+      ~previous_state:None result
+  in
+  check string "social model" "magentic_ledger_v1" state.social_model;
+  check (option string) "current intention tracks claim"
+    (Some "capture_next_task") state.current_intention;
+  check string "transition reason" "tool_only:claim_task"
+    (KSM.transition_reason_to_string transition_reason);
+  check string "visible response suppressed" "" routed.response_text;
+  check (list string) "tool list preserved" ["masc_claim_task"]
+    routed.tools_used
 
 let test_social_model_magentic_ledger_hides_nonvisible_tool_text () =
   let meta = { minimal_meta with social_model = "magentic_ledger_v1" } in
@@ -5181,6 +5230,8 @@ let () =
             "actionable signal rejects claim context after ownership"
             `Quick
             test_actionable_tool_contract_rejects_claim_context_when_already_claimed;
+          test_case "claim tool classification covers masc claim task" `Quick
+            test_claim_tool_classification_covers_masc_claim_task;
           test_case "actionable signal allows execution tools" `Quick
             test_actionable_tool_contract_allows_execution_tools;
           test_case "tool usage delta uses registry counts" `Quick
@@ -5222,8 +5273,12 @@ let () =
             test_social_model_tool_only_turn_carries_previous_state;
           test_case "social model infers board comment from tool use" `Quick
             test_social_model_infers_board_comment_from_tool_use;
+          test_case "social model infers masc claim task from tool use" `Quick
+            test_social_model_infers_masc_claim_task_from_tool_use;
           test_case "magentic ledger silences tool-only turn" `Quick
             test_social_model_magentic_ledger_silences_tool_only_turn;
+          test_case "magentic ledger tracks masc claim task" `Quick
+            test_social_model_magentic_ledger_tracks_masc_claim_task;
           test_case "magentic ledger hides non-visible tool text" `Quick
             test_social_model_magentic_ledger_hides_nonvisible_tool_text;
           test_case "magentic ledger restores previous state model" `Quick


### PR DESCRIPTION
## Summary
- treat `masc_claim_task` as a first-class claim tool in the shared keeper progress helper
- route social-model claim detection through the shared helper instead of ad hoc string checks
- mark decision receipts `claim_executed` for all recognized claim tools
- add regression coverage for `masc_claim_task` classification and social-model routing

## Root Cause
`masc_claim_task` was included in the claim-context progress taxonomy, but several downstream detectors still hardcoded only `keeper_task_claim` and `masc_claim_next`. That left a real claim path out of claim-only loop nudges, social-model claim routing, and decision receipt metadata.

## Validation
- git diff --check HEAD~1..HEAD
- before rebasing onto latest `origin/main`: `DUNE_BUILD_DIR=_build_codex_check DUNE_JOBS=1 dune build --root . -j 1 test/test_keeper_unified.exe`
- before rebasing onto latest `origin/main`: `MASC_BASE_PATH=$(mktemp -d /tmp/masc-unified-test.XXXXXX) _build_codex_check/default/test/test_keeper_unified.exe` (246 tests)
- after rebasing onto latest `origin/main`: `bash ci/check-oas-pin.sh`

Note: after the rebase, local focused Dune build is blocked by the current opam switch still linking `agent_sdk 0.171.0` while latest main requires `agent_sdk >= 0.172.0`; CI should install the pinned dependency from `scripts/oas-agent-sdk-pin.sh`.