### PR TITLE
fix(fsm): noop compaction must keep context_overflow (#9988)

### DIFF
--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -390,15 +390,30 @@ let update_conditions (c : conditions) (ev : event) : conditions =
     }
   | Compaction_started ->
     { c with compaction_active = true }
-  | Compaction_completed _ ->
-    (* A successful compaction clears the overflow flags.  The retry-
-       exhausted latch is released too: further overflow cycles start
-       fresh. *)
-    { c with
-      compaction_active = false;
-      context_overflow = false;
-      compact_retry_exhausted = false;
-    }
+  | Compaction_completed { before_tokens; after_tokens } ->
+    (* #9988: "completed" alone does not mean the overflow was resolved.
+       In production 98.4% of [Compaction_completed] events arrive with
+       [before_tokens = after_tokens] because the checkpoint reducers
+       produced no savings (no tool_result sections to strip, pure-text
+       turns, etc).  Clearing [context_overflow] unconditionally created
+       an infinite loop with [Context_overflow_detected]: the next turn
+       re-measures the same context, re-fires overflow, re-attempts a
+       noop compaction, and clears the flag again.  #9935 observed
+       45–71 imminent events/day with zero observable reduction action.
+
+       Treat [saved_tokens <= 0] as a noop: keep [context_overflow] set
+       so the next layer (operator alert, stronger compaction profile,
+       handoff) can take over. Only a real reduction clears the flag
+       and releases the retry-exhausted latch. *)
+    let saved_tokens = before_tokens - after_tokens in
+    if saved_tokens > 0 then
+      { c with
+        compaction_active = false;
+        context_overflow = false;
+        compact_retry_exhausted = false;
+      }
+    else
+      { c with compaction_active = false }
   | Compaction_failed _ ->
     (* Leave [context_overflow] set — the overflow has not been resolved.
        The retry-exhausted latch is owned by the caller (keeper_unified_turn

--- a/lib/keeper/keeper_state_machine.mli
+++ b/lib/keeper/keeper_state_machine.mli
@@ -78,13 +78,17 @@ type conditions = {
   (** Provider rejected the most recent prompt for exceeding its max
       context window. Distinct from [context_within_budget] (soft,
       ratio-based warning): [context_overflow] is a hard failure reported
-      by the provider. Cleared by a successful [Compaction_completed] or
-      by an operator clear action. *)
+      by the provider. Cleared by a [Compaction_completed] whose payload
+      reports real token savings ([before_tokens > after_tokens]) or by
+      an operator clear action. A noop compaction ([before = after])
+      leaves this flag set so the overflow can be escalated instead of
+      re-entering an infinite compact→clear→overflow loop (#9988). *)
   compact_retry_exhausted : bool;
   (** Consecutive auto-compact attempts failed to resolve the overflow.
       While set, the next [Context_overflow_detected] derives [Paused]
       instead of [Overflowed] so operator intervention is required.
-      Reset by [Compaction_completed] or [Fiber_started]. *)
+      Reset by a [Compaction_completed] with real savings or by
+      [Fiber_started]; a noop compaction does not reset this latch. *)
 }
 
 val default_conditions : conditions

--- a/test/test_keeper_overflow_recovery.ml
+++ b/test/test_keeper_overflow_recovery.ml
@@ -143,6 +143,83 @@ let test_two_consecutive_overflows () =
   in
   check_phase SM.Compacting tr5.new_phase "cycle 2 auto-compact → Compacting"
 
+(* ── Scenario 4b: noop compaction (#9988) ──────────────────── *)
+
+(* Prior handler dropped the [before_tokens, after_tokens] payload and
+   cleared [context_overflow] on every [Compaction_completed].  In
+   production 98.4% of completion events carried [before = after] (pure-
+   text turns with nothing for reducers to strip), so the FSM re-entered
+   Running, the next turn re-measured, and re-fired
+   [Context_overflow_detected].  Result: 45–71 overflow events/day with
+   zero observable reduction (#9935).  The noop path now has to leave
+   the flag set. *)
+let test_noop_compaction_keeps_overflow () =
+  let tr1 = apply_ok SM.Running running_conds (overflow_event ()) in
+  let tr2 =
+    apply_ok SM.Overflowed tr1.updated_conditions SM.Auto_compact_triggered
+  in
+  let tr3 =
+    apply_ok SM.Compacting tr2.updated_conditions
+      (SM.Compaction_completed
+         { before_tokens = 200_000; after_tokens = 200_000 })
+  in
+  check bool "noop compaction does NOT clear context_overflow"
+    true tr3.updated_conditions.context_overflow;
+  check bool "noop compaction does NOT reset compact_retry_exhausted"
+    tr2.updated_conditions.compact_retry_exhausted
+    tr3.updated_conditions.compact_retry_exhausted;
+  check bool "noop still exits Compacting (compaction_active=false)"
+    false tr3.updated_conditions.compaction_active;
+  check_phase SM.Overflowed tr3.new_phase
+    "post-noop phase remains Overflowed, not Running"
+
+(* [after > before] (reducer added a wrapper, retry grew the payload,
+   etc.) is also degenerate — must not clear. *)
+let test_negative_savings_keeps_overflow () =
+  let tr1 = apply_ok SM.Running running_conds (overflow_event ()) in
+  let tr2 =
+    apply_ok SM.Overflowed tr1.updated_conditions SM.Auto_compact_triggered
+  in
+  let tr3 =
+    apply_ok SM.Compacting tr2.updated_conditions
+      (SM.Compaction_completed
+         { before_tokens = 200_000; after_tokens = 210_000 })
+  in
+  check bool "negative-savings compaction does NOT clear overflow"
+    true tr3.updated_conditions.context_overflow
+
+(* Noop → real savings: first keeps overflow, next cycle with real
+   reduction clears it.  Confirms the new branch is additive, not
+   blocking recovery. *)
+let test_noop_then_real_savings_clears () =
+  let tr1 = apply_ok SM.Running running_conds (overflow_event ()) in
+  let tr2 =
+    apply_ok SM.Overflowed tr1.updated_conditions SM.Auto_compact_triggered
+  in
+  let tr3 =
+    apply_ok SM.Compacting tr2.updated_conditions
+      (SM.Compaction_completed
+         { before_tokens = 180_000; after_tokens = 180_000 })
+  in
+  check bool "after noop, overflow still set"
+    true tr3.updated_conditions.context_overflow;
+  let tr4 =
+    apply_ok tr3.new_phase tr3.updated_conditions (overflow_event ())
+  in
+  let tr5 =
+    apply_ok tr4.new_phase tr4.updated_conditions SM.Auto_compact_triggered
+  in
+  let tr6 =
+    apply_ok SM.Compacting tr5.updated_conditions
+      (SM.Compaction_completed
+         { before_tokens = 180_000; after_tokens = 60_000 })
+  in
+  check_phase SM.Running tr6.new_phase "real savings → Running";
+  check bool "real savings clear context_overflow"
+    false tr6.updated_conditions.context_overflow;
+  check bool "real savings clear compact_retry_exhausted"
+    false tr6.updated_conditions.compact_retry_exhausted
+
 (* ── Scenario 5: heartbeat failure during Overflowed ──────── *)
 
 let test_heartbeat_failure_preserved_through_overflow () =
@@ -185,6 +262,12 @@ let () =
         test_operator_clear_returns_to_running;
       test_case "two consecutive overflows" `Quick
         test_two_consecutive_overflows;
+      test_case "noop compaction keeps overflow (#9988)" `Quick
+        test_noop_compaction_keeps_overflow;
+      test_case "negative-savings keeps overflow (#9988)" `Quick
+        test_negative_savings_keeps_overflow;
+      test_case "noop then real savings clears (#9988)" `Quick
+        test_noop_then_real_savings_clears;
       test_case "heartbeat failure preserved through overflow" `Quick
         test_heartbeat_failure_preserved_through_overflow;
     ]


### PR DESCRIPTION
## 요약

`Keeper_state_machine` 의 `Compaction_completed` handler 가 event payload (`before_tokens`, `after_tokens`) 를 `_` 로 drop 하고 **무조건** `context_overflow := false` 했음. 프로덕션에서 98.4% 의 completion event 가 `before = after` (pure-text turn — reducer 가 strip 할 tool_result 없음, #9943). Flag 가 지워지면 FSM → Running, 다음 turn → 같은 context 다시 측정 → `Context_overflow_detected` 재발화. #9935 의 "imminent 45~71/day, reduction action 0" 이 이 loop 의 outward signature.

이 PR 은 FSM handler 가 payload 를 읽도록 교정:
- `saved_tokens = before - after > 0` → 기존 동작 (overflow clear + retry-exhausted latch 해제).
- `saved_tokens <= 0` → overflow 유지, `compaction_active` 만 해제. 상위 레이어 (operator alert, stronger profile, handoff) 가 인수.

`.mli` contract 도 업데이트 — invariant 가 타입 문서의 일부로 게시됨.

## 변경 파일

- `lib/keeper/keeper_state_machine.ml` — `Compaction_completed` arm 이 payload 를 destructure. Noop branch 는 `context_overflow` 와 `compact_retry_exhausted` 를 보존.
- `lib/keeper/keeper_state_machine.mli` — `context_overflow` / `compact_retry_exhausted` docstring 에 "noop 은 clear 하지 않음" 명시.
- `test/test_keeper_overflow_recovery.ml` — 3 신규 test:
  - `noop_compaction_keeps_overflow`: `before = after` 시 flag 유지, phase 가 Overflowed 로 남음.
  - `negative_savings_keeps_overflow`: `after > before` (reducer wrapper/retry 로 길어짐) 도 degenerate → clear 금지.
  - `noop_then_real_savings_clears`: 첫 noop 후 다음 cycle 에서 real savings 가 도착하면 정상 clear. 새 branch 가 회복을 막지 않음을 확인.

## 로컬 검증

```
$ MASC_BASE_PATH=/tmp/masc-test-9988 dune exec test/test_keeper_overflow_recovery.exe
Testing 'keeper_overflow_recovery'.
  [OK] overflow-lifecycle 0 happy path.
  [OK] overflow-lifecycle 1 compact failure latches Paused.
  [OK] overflow-lifecycle 2 operator clear returns to Running.
  [OK] overflow-lifecycle 3 two consecutive overflows.
  [OK] overflow-lifecycle 4 noop compaction keeps overflow (#9988).
  [OK] overflow-lifecycle 5 negative-savings keeps overflow (#9988).
  [OK] overflow-lifecycle 6 noop then real savings clears (#9988).
  [OK] overflow-lifecycle 7 heartbeat failure preserved through overflow.
Test Successful in 0.002s. 8 tests run.
```

`dune build` clean.

## 왜 근원 fix 인가

- **Parse, don't validate**: Event type 이 이미 `before_tokens`, `after_tokens` 를 carries — 단 handler 가 이를 무시하고 "completed" 를 성공과 등치. Payload 를 실제로 읽으면 schema 변경 없이 semantics 정리.
- **Ladder 제거 불필요**: emit site (`tool_keeper.ml`, `keeper_exec_context.ml`, `keeper_post_turn.ml`) 전부 수정할 필요 없음. 중앙 handler 한 곳에서 필터 → 새 emit 도 자동으로 올바른 동작 상속.
- **상위 레이어 인수 경로 보존**: noop → `compact_retry_exhausted` 그대로, 다음 overflow cycle 에서 retry 카운트 누적 → 결국 `Paused` 로 escalation. 기존 복구 플로우 연속.

## 미검증 / 후속

- `tool_keeper.ml:945-984` / `keeper_exec_context.ml:170-181` 의 emit site 에서 `saved_tokens == 0` 을 warn log 로 surface 하는 것은 별도 PR (observability 추가). 이 PR 은 correctness 만 다룸.
- Runtime 에서 Prometheus counter `masc_keeper_compaction_noop_total{keeper}` 추가 가능 — #9919 pattern 준용.
- 이미 열려 있는 #9935 (imminent-without-action) 은 본 PR 로 loop 이 끊기면 자연히 완화될 것. metric 추세 관찰 필요.

## 관련

- #9988 (root issue).
- #9935 (context_overflow_imminent 45~71/day, action 0 — loop 의 외부 signature).
- #9943 (compaction noop 98.4%).
- #9926 (fleet claim miss — loop 1 iteration 당 LLM 비용 누적으로 miss rate 증가).

🤖 Generated with [Claude Code](https://claude.com/claude-code)