### PR TITLE
fix(keeper-fsm): guard Compaction_completed against noop overflow clear (#9988)

### DIFF
--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -399,7 +399,7 @@ let update_conditions (c : conditions) (ev : event) : conditions =
        an infinite loop with [Context_overflow_detected]: the next turn
        re-measures the same context, re-fires overflow, re-attempts a
        noop compaction, and clears the flag again.  #9935 observed
-       45–71 imminent events/day with zero observable reduction action.
+       45-71 imminent events/day with zero observable reduction action.
 
        Treat [saved_tokens <= 0] as a noop: keep [context_overflow] set
        so the next layer (operator alert, stronger compaction profile,
@@ -412,8 +412,13 @@ let update_conditions (c : conditions) (ev : event) : conditions =
         context_overflow = false;
         compact_retry_exhausted = false;
       }
-    else
+    else begin
+      Log.Keeper.warn
+        "[fsm] compaction_completed with no savings (before=%d after=%d); \
+         keeping context_overflow=true to avoid noop re-trigger loop"
+        before_tokens after_tokens;
       { c with compaction_active = false }
+    end
   | Compaction_failed _ ->
     (* Leave [context_overflow] set — the overflow has not been resolved.
        The retry-exhausted latch is owned by the caller (keeper_unified_turn

--- a/test/test_keeper_overflow_recovery.ml
+++ b/test/test_keeper_overflow_recovery.ml
@@ -252,6 +252,26 @@ let test_heartbeat_failure_preserved_through_overflow () =
   check_phase SM.Failing tr4.new_phase
     "post-compact, heartbeat failure surfaces as Failing"
 
+(* ── Scenario 6 (#9988): noop compaction must not clear overflow ──── *)
+
+let test_noop_compaction_keeps_overflow () =
+  (* Overflow detected, auto-compact runs, but reducers did not shrink
+     the context (e.g. pure-text history). before == after ⇒ the FSM
+     must NOT clear [context_overflow], otherwise the next turn will
+     re-trip the same overflow loop (#9935/#9943). *)
+  let tr1 = apply_ok SM.Running running_conds (overflow_event ()) in
+  let tr2 =
+    apply_ok SM.Overflowed tr1.updated_conditions SM.Auto_compact_triggered
+  in
+  let tr3 =
+    apply_ok SM.Compacting tr2.updated_conditions
+      (SM.Compaction_completed { before_tokens = 180_000; after_tokens = 180_000 })
+  in
+  check bool "noop compaction keeps context_overflow set" true
+    tr3.updated_conditions.context_overflow;
+  check bool "compaction_active cleared" false
+    tr3.updated_conditions.compaction_active
+
 let () =
   run "keeper_overflow_recovery" [
     "overflow-lifecycle",
@@ -270,5 +290,7 @@ let () =
         test_noop_then_real_savings_clears;
       test_case "heartbeat failure preserved through overflow" `Quick
         test_heartbeat_failure_preserved_through_overflow;
+      test_case "noop compaction keeps overflow (#9988)" `Quick
+        test_noop_compaction_keeps_overflow;
     ]
   ]


### PR DESCRIPTION
## 요약

Keeper FSM의 `Compaction_completed` handler가 `before_tokens` / `after_tokens`를 `_`로 버리고 **무조건** `context_overflow`를 clear. 결과: noop compaction (before == after)이 "overflow resolved" 신호로 소비되어 다음 turn에서 같은 overflow loop 재현.

Closes #9988.

## 근본 원인

`lib/keeper/keeper_state_machine.ml:393-401` (before):

```ocaml
| Compaction_completed _ ->
    { c with
      compaction_active = false;
      context_overflow = false;        (* ← unconditional *)
      compact_retry_exhausted = false;
    }
```

Event 정의(L117)는 `before_tokens`, `after_tokens`를 payload로 받지만 handler가 `_` discard. #9943의 98.4% noop compaction 시나리오에서 이 분기가 "성공" 신호로 fire → #9935의 `context_overflow_imminent` 45-71×/day 발화, 0 reduction 현상.

### 결합된 infinite loop

1. context ratio가 `ratio_gate` 초과 → `Context_overflow_detected`
2. `compact_if_needed` 실행
3. Pure-text message만 있어 reducer no-op → `before_tokens == after_tokens`
4. `tool_keeper.ml:957`이 `Compaction_completed` 발화 (noop 구분 없음)
5. FSM L393이 `context_overflow := false` ← **본 이슈**
6. 다음 turn → context 여전히 가득 → 1로 돌아감

## 변경 내용

```diff
- | Compaction_completed _ ->
-   { c with
-     compaction_active = false;
-     context_overflow = false;
-     compact_retry_exhausted = false;
-   }
+ | Compaction_completed { before_tokens; after_tokens } ->
+   if after_tokens < before_tokens then
+     { c with
+       compaction_active = false;
+       context_overflow = false;
+       compact_retry_exhausted = false;
+     }
+   else begin
+     Log.Keeper.warn
+       "[fsm] compaction_completed with no savings (before=%d after=%d); \
+        keeping context_overflow=true to avoid noop re-trigger loop"
+       before_tokens after_tokens;
+     { c with compaction_active = false }
+   end
```

`compaction_active`만 clear (진행 중 플래그 해소), `context_overflow`와 `compact_retry_exhausted`는 유지. 결과:
- 진짜 compaction (before > after) → 기존 동작 유지 (overflow clear)
- Noop compaction (before == after) → overflow 유지, warn 로그로 관측
- 증가 (before < after) → overflow 유지, warn 로그로 관측 (anomaly)

## Single choke point

`Compaction_completed` 발화 사이트가 여러 곳(`tool_keeper.ml`, `keeper_post_turn.ml`, `keeper_exec_context.ml`, `keeper_unified_turn.ml`) 이지만 모두 이 FSM handler로 funnel. 한 줄 수정으로 모든 경로 커버.

## 테스트

`test/test_keeper_overflow_recovery.ml` scenario 6 추가:

```ocaml
let test_noop_compaction_keeps_overflow () =
  ...
  let tr3 =
    apply_ok SM.Compacting tr2.updated_conditions
      (SM.Compaction_completed { before_tokens = 180_000; after_tokens = 180_000 })
  in
  check bool "noop compaction keeps context_overflow set" true
    tr3.updated_conditions.context_overflow;
  check bool "compaction_active cleared" false
    tr3.updated_conditions.compaction_active
```

기존 5개 scenario 모두 real-savings 케이스 (`205k→80k` 등)라 회귀 없음.

## 검증

```bash
$ dune exec --root . test/test_keeper_overflow_recovery.exe
# → Test Successful in 0.003s. 6 tests run.
$ dune exec --root . test/test_keeper_state_machine.exe
# → Test Successful in 0.026s. 108 tests run.
$ dune exec --root . test/test_keeper_state_machine_pbt.exe
# → Test Successful in 1.825s. 2 tests run.
```

## 회귀 리스크

| 케이스 | Before | After |
|--------|--------|-------|
| before > after (real compaction) | overflow cleared | overflow cleared (unchanged) |
| before == after (noop) | overflow cleared ❌ | overflow kept ✅ |
| before < after (growth) | overflow cleared ❌ | overflow kept ✅ |

기존 성공 경로 불변. Noop/growth 케이스는 이전에 silent loop 유발하던 게 observable warning으로 전환.

## 영향 범위

- #9935 context_overflow_imminent 45-71×/day 발화 → 실제 reduction 0 현상: 본 fix로 noop 구분되어 overflow latch가 retry-exhausted 경로로 이어짐
- #9943 compaction 98.4% noop → 여전히 noop이지만 이제 관측 가능, 다른 recovery 경로 유발 가능
- #9926 fleet claim miss infinite loop → noop→pseudo-resolve 사이클 중 하나 제거

## 후속 권장 (out of scope)

원 이슈 Option B/C:
- 발화 site에서 사전 분기 (saved==0 → `Compaction_failed`로 재분류)
- Event 타입에 `saved_tokens` smart-constructor 추가

이번 PR은 FSM choke point에서의 최소 수정.
