### PR TITLE
[codex] Guard keeper usage telemetry trust

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -612,6 +612,8 @@ export interface DashboardRuntimeModelMetric {
     tools_count: number
     usage_reported?: boolean | null
     telemetry_reported?: boolean | null
+    usage_trust?: string | null
+    usage_anomaly_reasons?: string[] | null
     coverage_reason?: string | null
     coverage_stage?: string | null
   }> | null
@@ -746,6 +748,12 @@ function decodeRuntimeModelMetric(raw: unknown): DashboardRuntimeModelMetric | n
             tools_count: asNumber(r.tools_count) ?? 0,
             usage_reported: asBoolean(r.usage_reported),
             telemetry_reported: asBoolean(r.telemetry_reported),
+            usage_trust: asNullableString(r.usage_trust),
+            usage_anomaly_reasons: Array.isArray(r.usage_anomaly_reasons)
+              ? (r.usage_anomaly_reasons as unknown[])
+                  .map(item => asString(item) ?? '')
+                  .filter(item => item.length > 0)
+              : null,
             coverage_reason: asNullableString(r.coverage_reason),
             coverage_stage: asNullableString(r.coverage_stage),
           }))

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -88,6 +88,7 @@ const COVERAGE_REASON_LABELS: Record<string, string> = {
   missing_usage_and_inference: 'usage/inference missing',
   missing_usage: 'usage missing',
   missing_inference: 'inference missing',
+  untrusted_usage: 'usage untrusted',
   text_only_unmetered: 'text-only n/a',
   unknown: 'unknown reason',
 }
@@ -262,6 +263,7 @@ export function recentEntryMissingLabel(
   // signal when the cell is empty due to missing OAS timings vs. missing
   // per-turn usage accounting.
   if (entry.outcome === 'error') return 'error-only'
+  if (entry.usage_trust === 'untrusted') return 'untrusted'
   if (entry.coverage_reason === 'text_only_unmetered') return 'n/a'
   if (entry.telemetry_reported === false && entry.usage_reported === false)
     return 'no-telemetry'
@@ -293,6 +295,12 @@ function recentEntryDetail(
 ): string | null {
   const parts = [
     entry.outcome?.trim(),
+    entry.usage_trust === 'untrusted'
+      ? [
+          'usage untrusted',
+          ...(entry.usage_anomaly_reasons ?? []),
+        ].join(': ')
+      : null,
     coverageStageLabel(entry.coverage_stage),
     coverageReasonLabel(entry.coverage_reason),
     entry.turn_lane?.trim(),

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -47,19 +47,51 @@ let resolved_model_id_for_result ~(meta : keeper_meta)
 
 let turn_cost_for_result ~(meta : keeper_meta)
     (result : Keeper_agent_run.run_result) : float =
-  let pricing =
-    Llm_provider.Pricing.pricing_for_model
-      (resolved_model_id_for_result ~meta result)
+  let resolved_model_id = resolved_model_id_for_result ~meta result in
+  let surface_model_used = Keeper_agent_run.surface_model_used result in
+  let usage_trust =
+    Keeper_unified_metrics.classify_usage_trust
+      ~usage_reported:result.usage_reported
+      ~usage:result.usage
+      ~model_used:surface_model_used
+      ~resolved_model_id
+      ~context_max:0
   in
-  Llm_provider.Pricing.estimate_cost ~pricing
-    ~input_tokens:result.usage.input_tokens
-    ~output_tokens:result.usage.output_tokens ()
+  if Keeper_unified_metrics.usage_trust_is_trusted usage_trust then
+    let pricing =
+      Llm_provider.Pricing.pricing_for_model resolved_model_id
+    in
+    Llm_provider.Pricing.estimate_cost ~pricing
+      ~input_tokens:result.usage.input_tokens
+      ~output_tokens:result.usage.output_tokens ()
+  else 0.0
 
 let update_direct_turn_meta (meta : keeper_meta) ~(latency_ms : int)
     (result : Keeper_agent_run.run_result) : keeper_meta =
   let now_ts = Time_compat.now () in
   let turn_cost = turn_cost_for_result ~meta result in
   let surface_model_used = Keeper_agent_run.surface_model_used result in
+  let resolved_model_id = resolved_model_id_for_result ~meta result in
+  let usage_trust =
+    Keeper_unified_metrics.classify_usage_trust
+      ~usage_reported:result.usage_reported
+      ~usage:result.usage
+      ~model_used:surface_model_used
+      ~resolved_model_id
+      ~context_max:0
+  in
+  let usage_trusted =
+    Keeper_unified_metrics.usage_trust_is_trusted usage_trust
+  in
+  let trusted_input_tokens =
+    if usage_trusted then result.usage.input_tokens else 0
+  in
+  let trusted_output_tokens =
+    if usage_trusted then result.usage.output_tokens else 0
+  in
+  let trusted_total_tokens =
+    if usage_trusted then Keeper_exec_context.total_tokens result.usage else 0
+  in
   {
     meta with
     updated_at = now_iso ();
@@ -70,19 +102,17 @@ let update_direct_turn_meta (meta : keeper_meta) ~(latency_ms : int)
           {
             total_turns = meta.runtime.usage.total_turns + 1;
             total_input_tokens =
-              meta.runtime.usage.total_input_tokens + result.usage.input_tokens;
+              meta.runtime.usage.total_input_tokens + trusted_input_tokens;
             total_output_tokens =
-              meta.runtime.usage.total_output_tokens + result.usage.output_tokens;
+              meta.runtime.usage.total_output_tokens + trusted_output_tokens;
             total_tokens =
-              meta.runtime.usage.total_tokens
-              + Keeper_exec_context.total_tokens result.usage;
+              meta.runtime.usage.total_tokens + trusted_total_tokens;
             total_cost_usd = meta.runtime.usage.total_cost_usd +. turn_cost;
             last_turn_ts = now_ts;
             last_model_used = surface_model_used;
-            last_input_tokens = result.usage.input_tokens;
-            last_output_tokens = result.usage.output_tokens;
-            last_total_tokens =
-              Keeper_exec_context.total_tokens result.usage;
+            last_input_tokens = trusted_input_tokens;
+            last_output_tokens = trusted_output_tokens;
+            last_total_tokens = trusted_total_tokens;
             last_latency_ms = latency_ms;
           };
       };

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -87,6 +87,72 @@ type turn_mode =
   | Skip_text
   | Noop
 
+type usage_trust =
+  | Usage_missing
+  | Usage_trusted
+  | Usage_untrusted of string list
+
+let usage_absurd_token_threshold = 1_000_000
+
+let usage_trust_is_trusted = function
+  | Usage_trusted -> true
+  | Usage_missing | Usage_untrusted _ -> false
+
+let usage_trust_to_string = function
+  | Usage_missing -> "missing"
+  | Usage_trusted -> "trusted"
+  | Usage_untrusted _ -> "untrusted"
+
+let usage_trust_reasons = function
+  | Usage_untrusted reasons -> reasons
+  | Usage_missing | Usage_trusted -> []
+
+let usage_trust_json_fields trust =
+  [
+    ("usage_trust", `String (usage_trust_to_string trust));
+    ( "usage_anomaly",
+      `Bool
+        (match trust with
+         | Usage_untrusted _ -> true
+         | Usage_missing | Usage_trusted -> false) );
+    ( "usage_anomaly_reasons",
+      `List (List.map (fun reason -> `String reason) (usage_trust_reasons trust)) );
+  ]
+
+let add_reason reason reasons =
+  if List.mem reason reasons then reasons else reason :: reasons
+
+let classify_usage_trust ~(usage_reported : bool)
+    ~(usage : Oas.Types.api_usage)
+    ~(model_used : string)
+    ~(resolved_model_id : string)
+    ~(context_max : int) : usage_trust =
+  if not usage_reported then Usage_missing
+  else
+    let reasons = ref [] in
+    let add reason = reasons := add_reason reason !reasons in
+    let model_used = String.trim model_used in
+    let resolved_model_id = String.trim resolved_model_id in
+    let model_missing value = value = "" || String.equal value "unknown" in
+    if model_missing model_used && model_missing resolved_model_id then
+      add "missing_model_id";
+    if usage.input_tokens < 0 then add "negative_input_tokens";
+    if usage.output_tokens < 0 then add "negative_output_tokens";
+    if usage.cache_creation_input_tokens < 0 then
+      add "negative_cache_creation_tokens";
+    if usage.cache_read_input_tokens < 0 then add "negative_cache_read_tokens";
+    if usage.input_tokens = 0 && usage.output_tokens = 0 then
+      add "zero_token_usage_reported";
+    if usage.input_tokens > usage_absurd_token_threshold then
+      add "input_tokens_gt_1m";
+    if usage.output_tokens > usage_absurd_token_threshold then
+      add "output_tokens_gt_1m";
+    if context_max > 0 && usage.input_tokens > context_max * 2 then
+      add "input_tokens_gt_2x_context_max";
+    match List.rev !reasons with
+    | [] -> Usage_trusted
+    | reasons -> Usage_untrusted reasons
+
 let turn_mode_to_string = function
   | Tool_use -> "tool_use"
   | Text_response -> "text_response"
@@ -531,9 +597,20 @@ let append_decision_record
           match result with
           | Some r ->
               let surface_model_used = Keeper_agent_run.surface_model_used r in
+              let resolved_model_id =
+                Keeper_agent_run.surface_resolved_model_id r
+              in
               let telemetry_reported = telemetry_reported_of_result r in
               let coverage_reason = coverage_reason_of_result r in
               let coverage_stage = coverage_stage_of_result r in
+              let usage_trust =
+                classify_usage_trust
+                  ~usage_reported:r.usage_reported
+                  ~usage:r.usage
+                  ~model_used:surface_model_used
+                  ~resolved_model_id
+                  ~context_max:0
+              in
               let thinking_enabled_field =
                 match turn_thinking_enabled with
                 | Some b -> [("thinking_enabled", `Bool b)]
@@ -625,12 +702,13 @@ let append_decision_record
                     ("cache_read_tokens", `Int r.usage.cache_read_input_tokens);
                     ("cost_usd", match r.usage.cost_usd with Some c -> `Float c | None -> `Null);
                     ( "tokens_per_second",
-                      if latency_ms > 0 then
+                      if usage_trust_is_trusted usage_trust && latency_ms > 0 then
                         `Float
                           (float_of_int r.usage.output_tokens
                            /. (float_of_int latency_ms /. 1000.0))
                       else `Null );
                   ]
+                  @ usage_trust_json_fields usage_trust
                 else
                   [
                     ("input_tokens", `Null);
@@ -640,9 +718,11 @@ let append_decision_record
                     ("cost_usd", `Null);
                     ("tokens_per_second", `Null);
                   ]
+                  @ usage_trust_json_fields usage_trust
               in
               `Assoc ([
                 ("model_used", `String surface_model_used);
+                ("resolved_model_id", `String resolved_model_id);
                 ("outcome", `String "success");
                 ("turn_count", `Int r.turn_count);
                 ("stop_reason", `String stop_reason_str);
@@ -717,9 +797,29 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
     ?(update_proactive_rt = true)
     ?social_state
     ?social_transition_reason
+    ?(context_max = 0)
     (result : Keeper_agent_run.run_result) : keeper_meta =
   let now_ts = Time_compat.now () in
   let surface_model_used = Keeper_agent_run.surface_model_used result in
+  let resolved_model_id = Keeper_agent_run.surface_resolved_model_id result in
+  let usage_trust =
+    classify_usage_trust
+      ~usage_reported:result.usage_reported
+      ~usage:result.usage
+      ~model_used:surface_model_used
+      ~resolved_model_id
+      ~context_max
+  in
+  let usage_trusted = usage_trust_is_trusted usage_trust in
+  let trusted_input_tokens =
+    if usage_trusted then result.usage.input_tokens else 0
+  in
+  let trusted_output_tokens =
+    if usage_trusted then result.usage.output_tokens else 0
+  in
+  let trusted_total_tokens =
+    if usage_trusted then Keeper_exec_context.total_tokens result.usage else 0
+  in
   (* Use cascade_observation.selected_model (canonical, no :latest suffix)
      instead of parsing model strings and stripping :latest manually.
      surface_model_used already extracts this from cascade_observation.
@@ -727,10 +827,12 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
      L6 (strip_latest model ID parsing) boundary violations. See #5626. *)
   let used_model_id = surface_model_used in
   let turn_cost =
-    let pricing = Llm_provider.Pricing.pricing_for_model used_model_id in
-    Llm_provider.Pricing.estimate_cost ~pricing
-      ~input_tokens:result.usage.input_tokens
-      ~output_tokens:result.usage.output_tokens ()
+    if usage_trusted then
+      let pricing = Llm_provider.Pricing.pricing_for_model used_model_id in
+      Llm_provider.Pricing.estimate_cost ~pricing
+        ~input_tokens:result.usage.input_tokens
+        ~output_tokens:result.usage.output_tokens ()
+    else 0.0
   in
   let substantive_tool_call_count =
     result.tools_used
@@ -771,16 +873,17 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
     runtime = { rt with
       usage = {
         total_turns = rt.usage.total_turns + 1;
-        total_input_tokens = rt.usage.total_input_tokens + result.usage.input_tokens;
-        total_output_tokens = rt.usage.total_output_tokens + result.usage.output_tokens;
+        total_input_tokens = rt.usage.total_input_tokens + trusted_input_tokens;
+        total_output_tokens =
+          rt.usage.total_output_tokens + trusted_output_tokens;
         total_tokens =
-          rt.usage.total_tokens + Keeper_exec_context.total_tokens result.usage;
+          rt.usage.total_tokens + trusted_total_tokens;
         total_cost_usd = rt.usage.total_cost_usd +. turn_cost;
         last_turn_ts = now_ts;
         last_model_used = surface_model_used;
-        last_input_tokens = result.usage.input_tokens;
-        last_output_tokens = result.usage.output_tokens;
-        last_total_tokens = Keeper_exec_context.total_tokens result.usage;
+        last_input_tokens = trusted_input_tokens;
+        last_output_tokens = trusted_output_tokens;
+        last_total_tokens = trusted_total_tokens;
         last_latency_ms = latency_ms;
       };
       (* Deterministic scheduled autonomous cycle accounting is separated from
@@ -930,6 +1033,14 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
   let turn_mode = turn_mode_of_result result in
   let surface_model_used = Keeper_agent_run.surface_model_used result in
   let resolved_model_id = Keeper_agent_run.surface_resolved_model_id result in
+  let usage_trust =
+    classify_usage_trust
+      ~usage_reported:result.usage_reported
+      ~usage:result.usage
+      ~model_used:surface_model_used
+      ~resolved_model_id
+      ~context_max
+  in
   let scheduled_autonomous_outcome =
     if is_scheduled_autonomous_channel channel then
       Some (scheduled_autonomous_outcome_for_result result)
@@ -939,22 +1050,26 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
   let usage_json =
     if result.usage_reported then
       `Assoc
-        [
+        ([
           ("input_tokens", `Int result.usage.input_tokens);
           ("output_tokens", `Int result.usage.output_tokens);
           ("total_tokens",
            `Int (Keeper_exec_context.total_tokens result.usage));
         ]
+        @ usage_trust_json_fields usage_trust)
     else
       `Assoc
-        [
+        ([
           ("input_tokens", `Null);
           ("output_tokens", `Null);
           ("total_tokens", `Null);
         ]
+        @ usage_trust_json_fields usage_trust)
   in
   let cost_json =
-    if result.usage_reported then `Float turn_cost else `Null
+    if result.usage_reported && usage_trust_is_trusted usage_trust then
+      `Float turn_cost
+    else `Null
   in
   let snapshot =
     `Assoc
@@ -976,6 +1091,12 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
           | None -> `Null );
         ("ctx_composition", Keeper_agent_run.ctx_composition_to_json result.ctx_composition);
         ("usage", usage_json);
+        ("usage_trust", `String (usage_trust_to_string usage_trust));
+        ( "usage_anomaly_reasons",
+          `List
+            (List.map
+               (fun reason -> `String reason)
+               (usage_trust_reasons usage_trust)) );
         ("latency_ms", `Int latency_ms);
         ("cost_usd", cost_json);
         ("context_ratio", `Float context_ratio);

--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -23,6 +23,27 @@ type turn_mode =
   | Skip_text
   | Noop
 
+type usage_trust =
+  | Usage_missing
+  | Usage_trusted
+  | Usage_untrusted of string list
+
+val classify_usage_trust :
+  usage_reported:bool ->
+  usage:Oas.Types.api_usage ->
+  model_used:string ->
+  resolved_model_id:string ->
+  context_max:int ->
+  usage_trust
+
+val usage_trust_is_trusted : usage_trust -> bool
+
+val usage_trust_to_string : usage_trust -> string
+
+val usage_trust_reasons : usage_trust -> string list
+
+val usage_trust_json_fields : usage_trust -> (string * Yojson.Safe.t) list
+
 val update_metrics_from_result :
   Keeper_types.keeper_meta ->
   latency_ms:int ->
@@ -31,6 +52,7 @@ val update_metrics_from_result :
   ?update_proactive_rt:bool ->
   ?social_state:Keeper_social_model.social_state ->
   ?social_transition_reason:string ->
+  ?context_max:int ->
   Keeper_agent_run.run_result ->
   Keeper_types.keeper_meta
 

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1722,13 +1722,28 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           let used_model_id =
             Keeper_agent_run.surface_model_used result
           in
+          let resolved_model_id =
+            Keeper_agent_run.surface_resolved_model_id result
+          in
+          let usage_trust_for_cost =
+            Keeper_unified_metrics.classify_usage_trust
+              ~usage_reported:result.usage_reported
+              ~usage:result.usage
+              ~model_used:used_model_id
+              ~resolved_model_id
+              ~context_max:0
+          in
           let turn_cost =
-            let pricing =
-              Llm_provider.Pricing.pricing_for_model used_model_id
-            in
-            Llm_provider.Pricing.estimate_cost ~pricing
-              ~input_tokens:result.usage.input_tokens
-              ~output_tokens:result.usage.output_tokens ()
+            if Keeper_unified_metrics.usage_trust_is_trusted
+                 usage_trust_for_cost
+            then
+              let pricing =
+                Llm_provider.Pricing.pricing_for_model used_model_id
+              in
+              Llm_provider.Pricing.estimate_cost ~pricing
+                ~input_tokens:result.usage.input_tokens
+                ~output_tokens:result.usage.output_tokens ()
+            else 0.0
           in
           let lifecycle =
             apply_post_turn_lifecycle ~base_dir
@@ -1764,6 +1779,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               ~social_state
               ~social_transition_reason:
                 (Social.transition_reason_to_string social_transition_reason)
+              ~context_max:lifecycle.context_max
               ~update_proactive_rt:true
               result
           in
@@ -1810,8 +1826,23 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           let turn_mode_label =
             Keeper_unified_metrics.turn_mode_to_string turn_mode
           in
+          let model_used = Keeper_agent_run.surface_model_used result in
+          let resolved_model_id =
+            Keeper_agent_run.surface_resolved_model_id result
+          in
+          let usage_trust =
+            Keeper_unified_metrics.classify_usage_trust
+              ~usage_reported:result.usage_reported
+              ~usage:result.usage
+              ~model_used
+              ~resolved_model_id
+              ~context_max:lifecycle.context_max
+          in
+          let usage_trusted =
+            Keeper_unified_metrics.usage_trust_is_trusted usage_trust
+          in
           let wall_tokens_per_second =
-            if result.usage_reported && latency_ms > 0 then
+            if usage_trusted && latency_ms > 0 then
               Some
                 (float_of_int result.usage.output_tokens
                  /. (float_of_int latency_ms /. 1000.0))
@@ -1826,13 +1857,24 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                 ~payload:(`Assoc
                   ([
                     ("keeper_name", `String updated_meta.name);
-                    ("input_tokens", (if result.usage_reported then `Int result.usage.input_tokens else `Null));
-                    ("output_tokens", (if result.usage_reported then `Int result.usage.output_tokens else `Null));
-                    ("cache_creation_tokens", (if result.usage_reported then `Int result.usage.cache_creation_input_tokens else `Null));
-                    ("cache_read_tokens", (if result.usage_reported then `Int result.usage.cache_read_input_tokens else `Null));
-                    ("cost_usd", (if result.usage_reported then `Float turn_cost else `Null));
+                    ("input_tokens", (if usage_trusted then `Int result.usage.input_tokens else `Null));
+                    ("output_tokens", (if usage_trusted then `Int result.usage.output_tokens else `Null));
+                    ("cache_creation_tokens", (if usage_trusted then `Int result.usage.cache_creation_input_tokens else `Null));
+                    ("cache_read_tokens", (if usage_trusted then `Int result.usage.cache_read_input_tokens else `Null));
+                    ("cost_usd", (if usage_trusted then `Float turn_cost else `Null));
                     ("latency_ms", `Int latency_ms);
-                    ("model_used", `String (Keeper_agent_run.surface_model_used result));
+                    ("model_used", `String model_used);
+                    ("resolved_model_id", `String resolved_model_id);
+                    ( "usage_trust",
+                      `String
+                        (Keeper_unified_metrics.usage_trust_to_string
+                           usage_trust) );
+                    ( "usage_anomaly_reasons",
+                      `List
+                        (List.map
+                           (fun reason -> `String reason)
+                           (Keeper_unified_metrics.usage_trust_reasons
+                              usage_trust)) );
                     ("turn_mode", `String turn_mode_label);
                     ("context_ratio", `Float lifecycle.context_ratio);
                     ("tools_used", `List (List.map (fun s -> `String s) result.tools_used));
@@ -1907,7 +1949,6 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                      ~validated_evidence)
                 ()
           | None -> ());
-          let model_used = Keeper_agent_run.surface_model_used result in
           let outcome_str =
             match result.stop_reason with
             | Oas_worker.Completed -> "completed"
@@ -1928,31 +1969,62 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           in
           Prometheus.inc_counter Prometheus.metric_keeper_turns
             ~labels:[("keeper_name", updated_meta.name); ("outcome", outcome_label)] ();
-          Prometheus.inc_counter Prometheus.metric_keeper_input_tokens
-            ~labels:[("keeper_name", updated_meta.name); ("model", model_used)]
-            ~delta:(float_of_int result.usage.input_tokens) ();
-          Prometheus.inc_counter Prometheus.metric_keeper_output_tokens
-            ~labels:[("keeper_name", updated_meta.name); ("model", model_used)]
-            ~delta:(float_of_int result.usage.output_tokens) ();
-          (* #7469 Step 1: emit prompt-cache usage so Anthropic/Bedrock
-             hit rate is observable. Skip when both are zero — non-caching
-             providers (GLM/local-llama) would otherwise register a series
-             per keeper+model combination that never moves off zero.
-             Metric names pulled from [Prometheus] constants so a typo
-             here would fail to compile instead of silently creating a
-             dead series. *)
-          (if result.usage.cache_creation_input_tokens > 0 then
-             Prometheus.inc_counter Prometheus.metric_keeper_cache_creation_tokens
-               ~labels:[("keeper_name", updated_meta.name); ("model", model_used)]
-               ~delta:(float_of_int result.usage.cache_creation_input_tokens) ());
-          (if result.usage.cache_read_input_tokens > 0 then
-             Prometheus.inc_counter Prometheus.metric_keeper_cache_read_tokens
-               ~labels:[("keeper_name", updated_meta.name); ("model", model_used)]
-               ~delta:(float_of_int result.usage.cache_read_input_tokens) ());
+          if usage_trusted then begin
+            Prometheus.inc_counter Prometheus.metric_keeper_input_tokens
+              ~labels:[("keeper_name", updated_meta.name); ("model", model_used)]
+              ~delta:(float_of_int result.usage.input_tokens) ();
+            Prometheus.inc_counter Prometheus.metric_keeper_output_tokens
+              ~labels:[("keeper_name", updated_meta.name); ("model", model_used)]
+              ~delta:(float_of_int result.usage.output_tokens) ();
+            (* #7469 Step 1: emit prompt-cache usage so Anthropic/Bedrock
+               hit rate is observable. Skip when both are zero — non-caching
+               providers (GLM/local-llama) would otherwise register a series
+               per keeper+model combination that never moves off zero.
+               Metric names pulled from [Prometheus] constants so a typo
+               here would fail to compile instead of silently creating a
+               dead series. *)
+            (if result.usage.cache_creation_input_tokens > 0 then
+               Prometheus.inc_counter Prometheus.metric_keeper_cache_creation_tokens
+                 ~labels:[("keeper_name", updated_meta.name); ("model", model_used)]
+                 ~delta:(float_of_int result.usage.cache_creation_input_tokens) ());
+            (if result.usage.cache_read_input_tokens > 0 then
+               Prometheus.inc_counter Prometheus.metric_keeper_cache_read_tokens
+                 ~labels:[("keeper_name", updated_meta.name); ("model", model_used)]
+                 ~delta:(float_of_int result.usage.cache_read_input_tokens) ())
+          end else begin
+            let reasons =
+              match Keeper_unified_metrics.usage_trust_reasons usage_trust with
+              | [] -> [Keeper_unified_metrics.usage_trust_to_string usage_trust]
+              | reasons -> reasons
+            in
+            List.iter
+              (fun reason ->
+                 Prometheus.inc_counter
+                   Prometheus.metric_keeper_usage_anomalies
+                   ~labels:
+                     [
+                       ("keeper_name", updated_meta.name);
+                       ("model", model_used);
+                       ("reason", reason);
+                     ]
+                   ())
+              reasons;
+            Log.Keeper.warn
+              "%s: keeper usage telemetry untrusted model=%s resolved_model=%s reasons=%s input=%d output=%d context_max=%d"
+              updated_meta.name model_used resolved_model_id
+              (String.concat "," reasons)
+              result.usage.input_tokens
+              result.usage.output_tokens
+              lifecycle.context_max
+          end;
+          let logged_total_tokens =
+            if usage_trusted then
+              result.usage.input_tokens + result.usage.output_tokens
+            else 0
+          in
           Log.Keeper.info
             "%s: keeper cycle OK model=%s tokens=%d latency=%dms mode=%s stop=%s"
-            updated_meta.name model_used
-            (result.usage.input_tokens + result.usage.output_tokens)
+            updated_meta.name model_used logged_total_tokens
             latency_ms
             turn_mode_label
             outcome_str;

--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -29,6 +29,8 @@ type recent_entry = {
   re_tools_count : int;
   re_usage_reported : bool option;
   re_telemetry_reported : bool option;
+  re_usage_trust : string option;
+  re_usage_anomaly_reasons : string list;
   re_coverage_reason : string option;
   re_coverage_stage : string option;
 }
@@ -167,6 +169,54 @@ let json_string_field_opt key (fields : (string * Yojson.Safe.t) list) =
       if trimmed = "" then None else Some trimmed
   | _ -> None
 
+let json_string_list_field key (fields : (string * Yojson.Safe.t) list) =
+  match List.assoc_opt key fields with
+  | Some (`List xs) ->
+      List.filter_map
+        (function
+          | `String s ->
+              let trimmed = String.trim s in
+              if trimmed = "" then None else Some trimmed
+          | _ -> None)
+        xs
+  | _ -> []
+
+let usage_absurd_token_threshold = 1_000_000
+
+let infer_usage_trust_from_fields fields ~(usage_reported : bool)
+    ~(model : string) ~(input_tokens : int option)
+    ~(output_tokens : int option) : string option * string list =
+  let emitted_reasons = json_string_list_field "usage_anomaly_reasons" fields in
+  match json_string_field_opt "usage_trust" fields with
+  | Some trust -> Some trust, emitted_reasons
+  | None ->
+      if not usage_reported then Some "missing", []
+      else
+        let reasons = ref [] in
+        let add reason =
+          if not (List.mem reason !reasons) then reasons := reason :: !reasons
+        in
+        let model = String.trim model in
+        if model = "" || String.equal model "unknown" then add "missing_model_id";
+        (match input_tokens with
+         | Some n when n < 0 -> add "negative_input_tokens"
+         | Some n when n > usage_absurd_token_threshold -> add "input_tokens_gt_1m"
+         | _ -> ());
+        (match output_tokens with
+         | Some n when n < 0 -> add "negative_output_tokens"
+         | Some n when n > usage_absurd_token_threshold -> add "output_tokens_gt_1m"
+         | _ -> ());
+        (match input_tokens, output_tokens with
+         | Some 0, Some 0 -> add "zero_token_usage_reported"
+         | _ -> ());
+        match List.rev !reasons with
+        | [] -> Some "trusted", []
+        | reasons -> Some "untrusted", reasons
+
+let usage_trust_untrusted = function
+  | Some "untrusted" -> true
+  | _ -> false
+
 (* ── Parse telemetry from decisions.jsonl entries ────────── *)
 
 type raw_entry = {
@@ -196,6 +246,8 @@ type raw_entry = {
   tools_used : string list;
   usage_reported : bool option;
   telemetry_reported : bool option;
+  usage_trust : string option;
+  usage_anomaly_reasons : string list;
   coverage_reason : string option;
   coverage_stage : string option;
   is_error : bool;
@@ -269,6 +321,9 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option 
                   tools_used = outer_tools_used;
                   usage_reported = json_bool_field_opt "usage_reported" tfields;
                   telemetry_reported = json_bool_field_opt "telemetry_reported" tfields;
+                  usage_trust = json_string_field_opt "usage_trust" tfields;
+                  usage_anomaly_reasons =
+                    json_string_list_field "usage_anomaly_reasons" tfields;
                   coverage_reason = json_string_field_opt "coverage_reason" tfields;
                   coverage_stage = json_string_field_opt "coverage_stage" tfields;
                   is_error = true }
@@ -283,7 +338,9 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option 
                    | _ -> "unknown")
            in
            let provider = provider_opt_of_fields ~model tfields in
-           let tok_per_sec = json_float_field_opt "tokens_per_second" tfields in
+           let tok_per_sec_raw =
+             json_float_field_opt "tokens_per_second" tfields
+           in
            let prompt_tok_per_sec =
              match List.assoc_opt "prompt_per_second" tfields with
              | Some (`Float f) when f > 0.0 -> Some f
@@ -316,15 +373,19 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option 
              | None -> read "peak_memory"
            in
            let latency_ms = json_float_field_opt "request_latency_ms" tfields in
-           let input_tokens = json_int_field_opt "input_tokens" tfields in
-           let output_tokens = json_int_field_opt "output_tokens" tfields in
-           let cache_read_tokens = json_int_field_opt "cache_read_tokens" tfields in
-           let reasoning_tokens = json_int_field_opt "reasoning_tokens" tfields in
+           let input_tokens_raw = json_int_field_opt "input_tokens" tfields in
+           let output_tokens_raw = json_int_field_opt "output_tokens" tfields in
+           let cache_read_tokens_raw =
+             json_int_field_opt "cache_read_tokens" tfields
+           in
+           let reasoning_tokens_raw =
+             json_int_field_opt "reasoning_tokens" tfields
+           in
            let fallback_applied =
              match List.assoc_opt "fallback_applied" tfields with
              | Some (`Bool b) -> b | _ -> false
            in
-           let cost_usd = json_float_field_opt "cost_usd" tfields in
+           let cost_usd_raw = json_float_field_opt "cost_usd" tfields in
            (* Per-turn thinking_enabled — emitted by keeper_unified_turn's
               append_decision_record under telemetry.thinking_enabled. Treat
               explicit null or absent as None so backfill stays clean. *)
@@ -337,19 +398,43 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option 
              match json_bool_field_opt "usage_reported" tfields with
              | Some _ as value -> value
              | None ->
-                 if input_tokens <> None
-                    || output_tokens <> None
-                    || cache_read_tokens <> None
-                    || reasoning_tokens <> None
-                    || cost_usd <> None
+                 if input_tokens_raw <> None
+                    || output_tokens_raw <> None
+                    || cache_read_tokens_raw <> None
+                    || reasoning_tokens_raw <> None
+                    || cost_usd_raw <> None
                  then Some true
                  else None
            in
+           let usage_trust, usage_anomaly_reasons =
+             infer_usage_trust_from_fields tfields
+               ~usage_reported:(Option.value ~default:false usage_reported)
+               ~model
+               ~input_tokens:input_tokens_raw
+               ~output_tokens:output_tokens_raw
+           in
+           let usage_untrusted = usage_trust_untrusted usage_trust in
+           let tok_per_sec =
+             if usage_untrusted then None else tok_per_sec_raw
+           in
+           let input_tokens =
+             if usage_untrusted then None else input_tokens_raw
+           in
+           let output_tokens =
+             if usage_untrusted then None else output_tokens_raw
+           in
+           let cache_read_tokens =
+             if usage_untrusted then None else cache_read_tokens_raw
+           in
+           let reasoning_tokens =
+             if usage_untrusted then None else reasoning_tokens_raw
+           in
+           let cost_usd = if usage_untrusted then None else cost_usd_raw in
            let telemetry_reported =
              match json_bool_field_opt "telemetry_reported" tfields with
              | Some _ as value -> value
              | None ->
-                 if tok_per_sec <> None
+                 if tok_per_sec_raw <> None
                     || prompt_tok_per_sec <> None
                     || hw_decode_tok_per_sec <> None
                     || peak_memory_gb <> None
@@ -377,8 +462,16 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option 
                   tools_used = outer_tools_used;
                   usage_reported;
                   telemetry_reported;
-                  coverage_reason = json_string_field_opt "coverage_reason" tfields;
-                  coverage_stage = json_string_field_opt "coverage_stage" tfields;
+                  usage_trust;
+                  usage_anomaly_reasons;
+                  coverage_reason =
+                    json_string_field_opt "coverage_reason" tfields;
+                  coverage_stage =
+                    if usage_untrusted then
+                      match json_string_field_opt "coverage_stage" tfields with
+                      | Some _ as stage -> stage
+                      | None -> Some "keeper"
+                    else json_string_field_opt "coverage_stage" tfields;
                   is_error = false }
        | _ -> None)
     | _ -> None
@@ -417,39 +510,61 @@ let parse_cost_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option =
       in
       (match ts with
        | Some ts when ts >= since_unix ->
-           (match json_string_field_opt "model" fields with
-            | None -> None
-            | Some raw_model ->
+            let raw_model =
+              json_string_field_opt "model" fields
+              |> Option.value ~default:"unknown"
+            in
                 let provider = provider_opt_of_fields ~model:raw_model fields in
                 let model = canonical_cost_model_id ~provider raw_model in
                 let usage_missing =
                   json_bool_field_opt "usage_missing" fields
                   |> Option.value ~default:false
                 in
-                let input_tokens =
+                let usage_reported = not usage_missing in
+                let input_tokens_raw =
                   if usage_missing then None
                   else json_int_field_opt "input_tokens" fields
                 in
-                let output_tokens =
+                let output_tokens_raw =
                   if usage_missing then None
                   else json_int_field_opt "output_tokens" fields
                 in
-                let cache_read_tokens =
+                let cache_read_tokens_raw =
                   match json_int_field_opt "cache_read_tokens" fields with
                   | Some _ as v -> v
                   | None -> json_int_field_opt "cache_read_input_tokens" fields
                 in
+                let usage_trust, usage_anomaly_reasons =
+                  infer_usage_trust_from_fields fields
+                    ~usage_reported
+                    ~model
+                    ~input_tokens:input_tokens_raw
+                    ~output_tokens:output_tokens_raw
+                in
+                let usage_untrusted = usage_trust_untrusted usage_trust in
                 let latency_ms =
                   json_float_field_opt "request_latency_ms" fields
                 in
-                let tok_per_sec =
+                let tok_per_sec_raw =
                   match json_float_field_opt "tokens_per_second" fields with
                   | Some v when v > 0.0 -> Some v
                   | _ ->
-                      (match output_tokens, latency_ms with
+                      (match output_tokens_raw, latency_ms with
                        | Some out, Some latency when out > 0 && latency > 0.0 ->
                            Some (Float.of_int out /. (latency /. 1000.0))
                        | _ -> None)
+                in
+                let tok_per_sec =
+                  if usage_untrusted then None else tok_per_sec_raw
+                in
+                let input_tokens =
+                  if usage_untrusted then None else input_tokens_raw
+                in
+                let output_tokens =
+                  if usage_untrusted then None else output_tokens_raw
+                in
+                let cache_read_tokens =
+                  if usage_untrusted then None else cache_read_tokens_raw
                 in
                 let prompt_tok_per_sec =
                   match List.assoc_opt "prompt_per_second" fields with
@@ -466,7 +581,7 @@ let parse_cost_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option =
                   | _ -> None
                 in
                 let telemetry_reported =
-                  tok_per_sec <> None
+                  tok_per_sec_raw <> None
                   || prompt_tok_per_sec <> None
                   || hw_decode_tok_per_sec <> None
                   || peak_memory_gb <> None
@@ -488,17 +603,23 @@ let parse_cost_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option =
                   ; input_tokens
                   ; output_tokens
                   ; cache_read_tokens
-                  ; reasoning_tokens = json_int_field_opt "reasoning_tokens" fields
+                  ; reasoning_tokens =
+                      if usage_untrusted then None
+                      else json_int_field_opt "reasoning_tokens" fields
                   ; fallback_applied = false
-                  ; cost_usd = json_float_field_opt "cost_usd" fields
+                  ; cost_usd =
+                      if usage_untrusted then None
+                      else json_float_field_opt "cost_usd" fields
                   ; tool_call_count = 0
                   ; tools_used = []
-                  ; usage_reported = Some (not usage_missing)
+                  ; usage_reported = Some usage_reported
                   ; telemetry_reported = Some telemetry_reported
+                  ; usage_trust
+                  ; usage_anomaly_reasons
                   ; coverage_reason = None
                   ; coverage_stage = Some "costs_jsonl"
                   ; is_error = false
-                  })
+                  }
        | _ -> None)
   | _ -> None
 
@@ -608,11 +729,12 @@ let read_all_entries ~base_path ~since_unix =
   merge_decision_and_cost_entries decisions costs
 
 let usage_signal_present (entry : raw_entry) : bool =
-  entry.input_tokens <> None
+  (not (usage_trust_untrusted entry.usage_trust))
+  && (entry.input_tokens <> None
   || entry.output_tokens <> None
   || entry.cache_read_tokens <> None
   || entry.reasoning_tokens <> None
-  || entry.cost_usd <> None
+  || entry.cost_usd <> None)
 
 let telemetry_signal_present (entry : raw_entry) : bool =
   entry.tok_per_sec <> None
@@ -622,9 +744,11 @@ let telemetry_signal_present (entry : raw_entry) : bool =
   || entry.latency_ms <> None
 
 let usage_reported_effective (entry : raw_entry) : bool =
-  match entry.usage_reported with
-  | Some reported -> reported
-  | None -> usage_signal_present entry
+  if usage_trust_untrusted entry.usage_trust then false
+  else
+    match entry.usage_reported with
+    | Some reported -> reported
+    | None -> usage_signal_present entry
 
 let telemetry_reported_effective (entry : raw_entry) : bool =
   match entry.telemetry_reported with
@@ -633,6 +757,7 @@ let telemetry_reported_effective (entry : raw_entry) : bool =
 
 let coverage_reason_of_entry (entry : raw_entry) : string option =
   if entry.is_error then Some "error_turn"
+  else if usage_trust_untrusted entry.usage_trust then Some "untrusted_usage"
   else
     match entry.coverage_reason with
     | Some _ as reason -> reason
@@ -879,6 +1004,8 @@ let aggregate_by_model (entries : raw_entry list) : model_stats list =
           re_tools_count = e.tool_call_count;
           re_usage_reported = e.usage_reported;
           re_telemetry_reported = e.telemetry_reported;
+          re_usage_trust = e.usage_trust;
+          re_usage_anomaly_reasons = e.usage_anomaly_reasons;
           re_coverage_reason = coverage_reason_of_entry e;
           re_coverage_stage = coverage_stage_of_entry e;
         });
@@ -1084,6 +1211,12 @@ let model_stats_to_json (s : model_stats) : Yojson.Safe.t =
             match r.re_usage_reported with Some value -> `Bool value | None -> `Null);
           ("telemetry_reported",
             match r.re_telemetry_reported with Some value -> `Bool value | None -> `Null);
+          ("usage_trust", opt_string r.re_usage_trust);
+          ( "usage_anomaly_reasons",
+            `List
+              (List.map
+                 (fun reason -> `String reason)
+                 r.re_usage_anomaly_reasons) );
           ("coverage_reason", opt_string r.re_coverage_reason);
           ("coverage_stage", opt_string r.re_coverage_stage);
         ]

--- a/lib/model_inference_metrics.mli
+++ b/lib/model_inference_metrics.mli
@@ -22,6 +22,8 @@ type recent_entry = {
   re_tools_count : int;
   re_usage_reported : bool option;
   re_telemetry_reported : bool option;
+  re_usage_trust : string option;
+  re_usage_anomaly_reasons : string list;
   re_coverage_reason : string option;
   re_coverage_stage : string option;
 }

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -184,6 +184,8 @@ let metric_keeper_cache_creation_tokens =
   "masc_keeper_cache_creation_tokens_total"
 let metric_keeper_cache_read_tokens =
   "masc_keeper_cache_read_tokens_total"
+let metric_keeper_usage_anomalies =
+  "masc_keeper_usage_anomalies_total"
 
 (* Keeper compaction (keeper_compact_policy.ml, tool_keeper.ml). *)
 let metric_keeper_compactions = "masc_keeper_compactions_total"
@@ -500,6 +502,9 @@ let init () =
     Counter;
   add metric_keeper_cache_read_tokens
     "Cumulative prompt-cache read tokens per keeper turn (labels: keeper_name, model)"
+    Counter;
+  add metric_keeper_usage_anomalies
+    "Keeper turns whose reported usage was marked untrusted (labels: keeper_name, model, reason)"
     Counter;
   (* Tool schema budget gauges — set once at boot via
      [set_tool_schema_stats]. Covers #7483 Step 1. *)

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -73,6 +73,7 @@ val metric_keeper_input_tokens : string
 val metric_keeper_output_tokens : string
 val metric_keeper_cache_creation_tokens : string
 val metric_keeper_cache_read_tokens : string
+val metric_keeper_usage_anomalies : string
 val metric_keeper_compactions : string
 val metric_keeper_compaction_ratio_change : string
 val metric_keeper_compaction_saved_tokens : string

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2469,6 +2469,74 @@ let test_append_metrics_snapshot_nulls_unreported_usage () =
       check bool "snapshot cost_usd null when usage unreported" true
         (match json |> member "cost_usd" with `Null -> true | _ -> false))
 
+let test_append_metrics_snapshot_marks_untrusted_usage () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Coord.default_config base_dir in
+      let result =
+        make_run_result
+          ~text:"Usage is absurd."
+          ~tools:[]
+          ~model:"llama:qwen3.5-27b"
+          ~input_tok:1_200_001
+          ~output_tok:20
+          ()
+      in
+      UM.append_metrics_snapshot
+        ~config
+        ~meta:minimal_meta
+        ~observation:base_observation
+        ~result
+        ~latency_ms:321
+        ~turn_cost:0.42
+        ~turn_generation:1
+        ~channel:"turn"
+        ~snapshot_source:"test"
+        ~context_ratio:0.1
+        ~context_tokens:10
+        ~context_max:100_000
+        ~message_count:2
+        ~compaction:
+          {
+            Masc_mcp.Keeper_exec_context.applied = false;
+            attempted = false;
+            failure_reason = None;
+            trigger = None;
+            decision = "no_compaction";
+            before_tokens = 0;
+            after_tokens = 0;
+            saved_tokens = 0;
+          }
+        ~handoff_json:None
+        ();
+      let metrics_store =
+        Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
+      in
+      let line =
+        match Dated_jsonl.read_recent_lines metrics_store 1 with
+        | [ line ] -> line
+        | _ -> fail "expected one metrics line"
+      in
+      let json = Yojson.Safe.from_string line in
+      let open Yojson.Safe.Util in
+      check string "usage trust persisted" "untrusted"
+        (json |> member "usage_trust" |> to_string);
+      check string "nested usage trust persisted" "untrusted"
+        (json |> member "usage" |> member "usage_trust" |> to_string);
+      check bool "cost hidden when usage untrusted" true
+        (match json |> member "cost_usd" with `Null -> true | _ -> false);
+      let reasons =
+        json |> member "usage_anomaly_reasons" |> to_list |> List.map to_string
+      in
+      check bool "absolute token anomaly persisted" true
+        (List.mem "input_tokens_gt_1m" reasons);
+      check bool "context token anomaly persisted" true
+        (List.mem "input_tokens_gt_2x_context_max" reasons))
+
 let test_append_decision_record_persists_tool_calls () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -5127,6 +5195,8 @@ let () =
             test_append_metrics_snapshot_counts_only_mode_violation_refs;
           test_case "snapshot nulls unreported usage" `Quick
             test_append_metrics_snapshot_nulls_unreported_usage;
+          test_case "snapshot marks untrusted usage" `Quick
+            test_append_metrics_snapshot_marks_untrusted_usage;
           test_case "decision record persists tool call details" `Quick
             test_append_decision_record_persists_tool_calls;
           test_case "decision record nulls unreported usage" `Quick

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -71,7 +71,8 @@ let now_unix () = Unix.gettimeofday ()
 
 let success_entry ~model ~ts ?(input_tokens=100) ?(output_tokens=50)
     ?(latency_ms=500) ?prompt_per_second ?peak_memory_gb
-    ?provider ?(cost_usd=0.01) ?(tools_used=[]) () =
+    ?provider ?usage_trust ?(usage_anomaly_reasons=[])
+    ?(cost_usd=0.01) ?(tools_used=[]) () =
   let extra_telemetry_fields =
     (match prompt_per_second with
      | Some v -> [("prompt_per_second", `Float v)]
@@ -84,6 +85,18 @@ let success_entry ~model ~ts ?(input_tokens=100) ?(output_tokens=50)
     (match provider with
      | Some v -> [("provider", `String v)]
      | None -> [])
+    @
+    (match usage_trust with
+     | Some v -> [("usage_trust", `String v)]
+     | None -> [])
+    @
+    (match usage_anomaly_reasons with
+     | [] -> []
+     | reasons ->
+         [
+           ( "usage_anomaly_reasons",
+             `List (List.map (fun reason -> `String reason) reasons) );
+         ])
   in
   `Assoc [
     ("ts_unix", `Float ts);
@@ -195,10 +208,11 @@ let test_single_model_success () =
     write_decisions path [
       success_entry ~model:"claude-sonnet" ~ts:(ts -. 10.0)
         ~input_tokens:200 ~output_tokens:100 ~latency_ms:1000
-        ~cost_usd:0.005 ~tools_used:["shell"; "read"] ();
+        ~provider:"claude" ~cost_usd:0.005
+        ~tools_used:["shell"; "read"] ();
       success_entry ~model:"claude-sonnet" ~ts:(ts -. 5.0)
         ~input_tokens:150 ~output_tokens:80 ~latency_ms:800
-        ~cost_usd:0.003 ~tools_used:["shell"] ();
+        ~provider:"claude" ~cost_usd:0.003 ~tools_used:["shell"] ();
     ];
     let agg = M.compute ~base_path:base ~window_minutes:60 in
     check int "total_entries" 2 agg.total_entries;
@@ -222,6 +236,41 @@ let test_single_model_success () =
       (Option.value ~default:0.0 s.avg_latency_ms > 0.0);
     check bool "tok/s > 0" true
       (Option.value ~default:0.0 s.avg_tok_per_sec > 0.0))
+
+let test_untrusted_usage_excluded_from_aggregates () =
+  let base = test_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+    let path = make_keeper_dir base "meter" in
+    let ts = now_unix () in
+    write_decisions path [
+      success_entry ~model:"llama:qwen3.5-27b" ~ts:(ts -. 10.0)
+        ~input_tokens:100 ~output_tokens:20 ~latency_ms:1000 ();
+      success_entry ~model:"llama:qwen3.5-27b" ~ts:(ts -. 5.0)
+        ~input_tokens:1_721_506 ~output_tokens:900 ~latency_ms:1000
+        ~usage_trust:"untrusted"
+        ~usage_anomaly_reasons:["input_tokens_gt_1m"] ();
+    ];
+    let agg = M.compute ~base_path:base ~window_minutes:60 in
+    check int "total entries retained for diagnosis" 2 agg.total_entries;
+    check int "models" 1 (List.length agg.models);
+    let s = List.hd agg.models in
+    check (option int) "trusted input total only" (Some 100)
+      s.total_input_tokens;
+    check (option int) "trusted output total only" (Some 20)
+      s.total_output_tokens;
+    check int "usage sample count excludes untrusted" 1 s.usage_sample_count;
+    check int "usage missing counts untrusted" 1 s.usage_missing_count;
+    check (option (float 0.001)) "tok/s excludes untrusted outlier"
+      (Some 20.0) s.avg_tok_per_sec;
+    check (option string) "coverage flags untrusted usage"
+      (Some "untrusted_usage") s.primary_coverage_reason;
+    let recent = List.hd s.recent_entries in
+    check (option string) "recent usage trust" (Some "untrusted")
+      recent.re_usage_trust;
+    check (option int) "recent untrusted input hidden" None
+      recent.re_input_tokens;
+    check (list string) "recent anomaly reasons"
+      ["input_tokens_gt_1m"] recent.re_usage_anomaly_reasons)
 
 let test_error_turns_counted () =
   let base = test_dir () in
@@ -873,6 +922,8 @@ let () =
     "basics", [
       test_case "empty dir" `Quick test_empty_dir;
       test_case "single model success" `Quick test_single_model_success;
+      test_case "untrusted usage excluded from aggregates" `Quick
+        test_untrusted_usage_excluded_from_aggregates;
       test_case "error turns counted" `Quick test_error_turns_counted;
       test_case "multi model sorted" `Quick test_multi_model;
       test_case "window filter" `Quick test_window_filter;


### PR DESCRIPTION
## Summary
- classify keeper usage telemetry as trusted, missing, or untrusted with anomaly reasons
- persist usage trust in keeper snapshots, decision telemetry, activity graph events, and dashboard recent rows
- exclude untrusted usage from keeper runtime totals, Prometheus token counters, model token/tok-per-second aggregates, and cost totals
- add a Prometheus anomaly counter for untrusted usage samples

## Validation
- scripts/dune-local.sh build test/test_keeper_unified.exe test/test_model_inference_metrics.exe
- ./_build/default/test/test_model_inference_metrics.exe
- env MASC_BASE_PATH=/tmp/masc-mcp-test-base ./_build/default/test/test_keeper_unified.exe
- pnpm typecheck