### PR TITLE
fix(dashboard): harden websocket recovery

### DIFF
--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -267,4 +267,34 @@ describe('dashboard websocket route subscriptions', () => {
     await latestPromise
     expect(dashboardWsLastSeq.value).toBe(22)
   })
+
+  it('rejects in-flight subscribe RPCs when the socket closes', async () => {
+    installWebSocketMocks()
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    const socket = mockSockets[0]!
+    socket.open()
+    const hello = parseRpc(socket, 0)
+    socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
+    await flushPromises()
+
+    const initialSubscribe = parseRpc(socket, 1)
+    socket.receive({
+      jsonrpc: '2.0',
+      id: initialSubscribe.id,
+      result: { snapshot: { seq: 1, slices: {} } },
+    })
+    await flushPromises()
+
+    const subscribePromise = subscribeDashboardRoute({
+      tab: 'workspace',
+      params: { section: 'planning' },
+    })
+    const subscribe = parseRpc(socket, 2)
+    expect(subscribe.method).toBe('dashboard/subscribe')
+
+    socket.close()
+
+    await expect(subscribePromise).rejects.toThrow('dashboard websocket closed')
+  })
 })

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -100,6 +100,7 @@ async function flushPromises(): Promise<void> {
 afterEach(() => {
   disconnectDashboardWS()
   dashboardWsLastSeq.value = 0
+  vi.useRealTimers()
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
 })
@@ -191,6 +192,31 @@ describe('dashboard websocket route subscriptions', () => {
 
     expect(mockSockets).toHaveLength(1)
     expect(mockSockets[0]!.readyState).toBe(MockWebSocket.CONNECTING)
+  })
+
+  it('retries discovery when the websocket endpoint is enabled but not listening yet', async () => {
+    vi.useFakeTimers()
+    mockSockets.length = 0
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        enabled: true,
+        listening: false,
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(wsDiscoveryResponse())
+    vi.stubGlobal('fetch', fetchMock)
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    expect(mockSockets).toHaveLength(0)
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(mockSockets).toHaveLength(1)
   })
 
   it('subscribes the latest route captured while hello is still in flight', async () => {
@@ -296,5 +322,47 @@ describe('dashboard websocket route subscriptions', () => {
     socket.close()
 
     await expect(subscribePromise).rejects.toThrow('dashboard websocket closed')
+  })
+
+  it('rejects in-flight subscribe RPCs when the server never responds', async () => {
+    vi.useFakeTimers()
+    installWebSocketMocks()
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    const socket = mockSockets[0]!
+    socket.open()
+    const hello = parseRpc(socket, 0)
+    socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
+    await flushPromises()
+
+    const initialSubscribe = parseRpc(socket, 1)
+    socket.receive({
+      jsonrpc: '2.0',
+      id: initialSubscribe.id,
+      result: { snapshot: { seq: 1, slices: {} } },
+    })
+    await flushPromises()
+
+    const subscribePromise = subscribeDashboardRoute({
+      tab: 'workspace',
+      params: { section: 'planning' },
+    })
+    const subscribe = parseRpc(socket, 2)
+    expect(subscribe.method).toBe('dashboard/subscribe')
+
+    const rejection = expect(subscribePromise).rejects.toThrow(
+      'dashboard websocket rpc timed out: dashboard/subscribe',
+    )
+    await vi.advanceTimersByTimeAsync(15_000)
+    await rejection
+
+    socket.receive({
+      jsonrpc: '2.0',
+      id: subscribe.id,
+      result: { snapshot: { seq: 99, slices: {} } },
+    })
+    await flushPromises()
+
+    expect(dashboardWsLastSeq.value).toBe(1)
   })
 })

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -12,6 +12,7 @@ type JsonObject = Record<string, unknown>
 type PendingRpc = {
   resolve: (value: unknown) => void
   reject: (err: Error) => void
+  timeout: ReturnType<typeof setTimeout>
 }
 type DashboardRouteState = Pick<RouteState, 'tab' | 'params'>
 
@@ -20,6 +21,13 @@ interface DashboardWsDiscovery {
   listening?: boolean
   ws_url?: string
 }
+
+interface DashboardWsDiscoveryResult {
+  wsUrl: string | null
+  retry: boolean
+}
+
+const DASHBOARD_WS_RPC_TIMEOUT_MS = 15_000
 
 let socket: WebSocket | null = null
 let rpcId = 0
@@ -87,7 +95,8 @@ function clearReconnectTimer(): void {
 }
 
 function rejectPendingRpcs(err: Error): void {
-  for (const { reject } of pending.values()) {
+  for (const { reject, timeout } of pending.values()) {
+    clearTimeout(timeout)
     reject(err)
   }
   pending.clear()
@@ -116,14 +125,17 @@ function closeSocket(): void {
   rejectPendingRpcs(new Error('dashboard websocket closed'))
 }
 
-async function discoverWsUrl(): Promise<string | null> {
+async function discoverWsUrl(): Promise<DashboardWsDiscoveryResult> {
   const response = await fetch('/ws', { credentials: 'same-origin' })
-  if (!response.ok) return null
+  if (!response.ok) return { wsUrl: null, retry: true }
   const data = await response.json() as DashboardWsDiscovery
-  if (data.enabled !== true || data.listening !== true || typeof data.ws_url !== 'string') {
-    return null
+  if (data.enabled !== true) {
+    return { wsUrl: null, retry: false }
   }
-  return data.ws_url
+  if (data.listening !== true || typeof data.ws_url !== 'string') {
+    return { wsUrl: null, retry: true }
+  }
+  return { wsUrl: data.ws_url, retry: false }
 }
 
 function sendRpc(method: string, params: JsonObject): Promise<unknown> {
@@ -134,11 +146,16 @@ function sendRpc(method: string, params: JsonObject): Promise<unknown> {
   const id = ++rpcId
   const payload = { jsonrpc: '2.0', id, method, params }
   return new Promise((resolve, reject) => {
-    pending.set(id, { resolve, reject })
+    const timeout = setTimeout(() => {
+      if (!pending.delete(id)) return
+      reject(new Error(`dashboard websocket rpc timed out: ${method}`))
+    }, DASHBOARD_WS_RPC_TIMEOUT_MS)
+    pending.set(id, { resolve, reject, timeout })
     try {
       currentSocket.send(JSON.stringify(payload))
     } catch (err) {
       pending.delete(id)
+      clearTimeout(timeout)
       reject(err instanceof Error ? err : new Error(String(err)))
     }
   })
@@ -149,6 +166,7 @@ function handleRpcResponse(raw: JsonObject): boolean {
   const pendingRpc = pending.get(raw.id)
   if (!pendingRpc) return true
   pending.delete(raw.id)
+  clearTimeout(pendingRpc.timeout)
   const error = raw.error as { message?: unknown } | undefined
   if (error) {
     pendingRpc.reject(new Error(typeof error.message === 'string' ? error.message : 'dashboard websocket rpc failed'))
@@ -293,16 +311,25 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
   shouldReconnect = true
   clearReconnectTimer()
   const generation = ++connectGeneration
-  let wsUrl: string | null
+  let discovery: DashboardWsDiscoveryResult
   try {
-    wsUrl = await discoverWsUrl()
+    discovery = await discoverWsUrl()
   } catch (err) {
     if (generation === connectGeneration && shouldReconnect) {
       dashboardWsLastError.value = err instanceof Error ? err.message : String(err)
+      scheduleReconnect()
     }
     return
   }
-  if (!wsUrl || !shouldReconnect || generation !== connectGeneration) return
+  const wsUrl = discovery.wsUrl
+  if (!wsUrl) {
+    if (generation === connectGeneration && shouldReconnect && discovery.retry) {
+      dashboardWsLastError.value = 'dashboard websocket unavailable'
+      scheduleReconnect()
+    }
+    return
+  }
+  if (!shouldReconnect || generation !== connectGeneration) return
 
   closeSocket()
   const ws = new WebSocket(wsUrl)

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -86,6 +86,13 @@ function clearReconnectTimer(): void {
   }
 }
 
+function rejectPendingRpcs(err: Error): void {
+  for (const { reject } of pending.values()) {
+    reject(err)
+  }
+  pending.clear()
+}
+
 function scheduleReconnect(): void {
   if (!shouldReconnect) return
   if (reconnectTimer) return
@@ -106,10 +113,7 @@ function closeSocket(): void {
     socket.close()
     socket = null
   }
-  for (const { reject } of pending.values()) {
-    reject(new Error('dashboard websocket closed'))
-  }
-  pending.clear()
+  rejectPendingRpcs(new Error('dashboard websocket closed'))
 }
 
 async function discoverWsUrl(): Promise<string | null> {
@@ -339,6 +343,7 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
     dashboardWsReady.value = false
     lastSubscribeKey = ''
     socket = null
+    rejectPendingRpcs(new Error('dashboard websocket closed'))
     scheduleReconnect()
   }
 }


### PR DESCRIPTION
## Summary

- reject all in-flight dashboard WebSocket RPCs when the active socket closes
- add a bounded timeout for WebSocket RPCs so stalled hello/subscribe calls cannot hang forever
- retry `/ws` discovery when the endpoint is enabled but temporarily not listening
- keep late subscribe snapshots from applying after timeout or route supersession

## Root Cause

The dashboard WebSocket client already reconnected after socket close, but several lifecycle edges could leave the UI in an ambiguous state: natural close did not reject pending RPCs, open sockets could keep RPC promises pending forever if the server never answered, and transient discovery states returned without scheduling another attempt.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `env PATH=/Users/dancer/.nvm/versions/node/v22.22.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin pnpm exec vitest run src/dashboard-ws.test.ts --no-file-parallelism --maxWorkers=1 --reporter=verbose`