### PR TITLE
[codex] Keep two-turn keeper calls action-capable

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1014,8 +1014,8 @@ let run_turn
       List.length (Keeper_discovered_tools.active_names !discovered_ref ~turn)
     in
     let per_call_turn = turn - start_turn_count in
-    let is_last_turn = per_call_turn >= max_turns - 1 in
-    let is_warning_zone = per_call_turn >= max_turns - 2 in
+    let is_last_turn = per_call_turn >= max_turns in
+    let is_warning_zone = per_call_turn >= max_turns - 1 in
     let tool_gate_requested =
       tool_gate_requested_for_turn ~current_tool_choice ~is_last_turn
     in

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -77,7 +77,7 @@ let turn_affordances_require_tool_gate turn_affordances =
 let should_require_tools_for_initial_turn ~(max_turns : int)
     ~(turn_affordances : string list) =
   let initial_per_call_turn = 1 in
-  let initial_turn_is_last = initial_per_call_turn >= max_turns - 1 in
+  let initial_turn_is_last = initial_per_call_turn >= max_turns in
   max_turns > 1
   && not initial_turn_is_last
   && turn_affordances_require_tool_gate turn_affordances
@@ -247,4 +247,3 @@ let tool_index_entry_of_tool
     | None -> []
   in
   Oas.Tool_index.{ name; description = t.schema.description; group; aliases }
-

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4781,9 +4781,14 @@ let test_keeper_allowed_tools_exclude_heartbeat () =
     (List.mem "masc_heartbeat" allowed)
 
 let test_should_require_tools_for_initial_turn_matches_first_turn_gate () =
-  let affordances = [ "task_claim"; "board_post" ] in
-  check bool "two-turn call reserves final turn without forcing strict lane" false
+  let affordances = [ "task_claim"; "board_post_or_comment" ] in
+  check bool "single-turn call reserves final turn without forcing strict lane" false
+    (KAR.should_require_tools_for_initial_turn ~max_turns:1 ~turn_affordances:affordances);
+  check bool "two-turn call can require initial tools" true
     (KAR.should_require_tools_for_initial_turn ~max_turns:2 ~turn_affordances:affordances);
+  check bool "two-turn board action can require initial tools" true
+    (KAR.should_require_tools_for_initial_turn ~max_turns:2
+       ~turn_affordances:[ "board_post_or_comment" ]);
   check bool "three-turn call can require initial tools" true
     (KAR.should_require_tools_for_initial_turn ~max_turns:3 ~turn_affordances:affordances);
   check bool "no tool-required affordance stays optional" false


### PR DESCRIPTION
## Summary

- Treat the first turn of a two-turn keeper call as action-capable instead of last-turn-only.
- Align the initial required-tool gate with the runtime turn budget calculation.
- Update keeper unified coverage so two-turn actionable affordances require tools, while single-turn calls remain final-response-only.

## Root cause

Scheduled autonomous keeper calls default to a two-turn budget. The keeper runtime and initial tool-surface gate used `per_call_turn >= max_turns - 1` to detect the last turn, so turn 1 of a two-turn call was already treated as the final turn. That disabled required tool gating and injected final-turn guidance before the keeper had spent its action turn.

## Validation

- `git diff --check origin/main..HEAD`
- `bash ci/check-oas-pin.sh`
- Attempted `DUNE_BUILD_DIR=_build_codex_check DUNE_JOBS=1 scripts/dune-local.sh build test/test_keeper_unified.exe`; local focused build is blocked outside this diff by `Discovery_cache.endpoint_info.healthy` / local `agent_sdk` cmi assumptions in current switch state.