### PR TITLE
fix(keeper): keep long turns visibly alive

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -137,7 +137,9 @@ type autonomous_waiter =
     keeper_name : string;
   }
 
-let autonomous_wait_queue_mutex = Eio.Mutex.create ()
+(* Stdlib.Mutex: queue operations are pure/non-yielding and test helpers call
+   them outside Eio_main. *)
+let autonomous_wait_queue_mutex = Stdlib.Mutex.create ()
 
 let autonomous_wait_queue : autonomous_waiter list ref = ref []
 
@@ -146,7 +148,10 @@ let autonomous_wait_queue_next_ticket = ref 0
 let autonomous_queue_poll_sec = 0.05
 
 let with_autonomous_wait_queue f =
-  Eio.Mutex.use_rw ~protect:true autonomous_wait_queue_mutex (fun () -> f ())
+  Mutex.lock autonomous_wait_queue_mutex;
+  Fun.protect
+    ~finally:(fun () -> Mutex.unlock autonomous_wait_queue_mutex)
+    f
 
 let reset_autonomous_turn_queue_for_test () =
   with_autonomous_wait_queue (fun () ->
@@ -1152,6 +1157,75 @@ let collect_keepalive_board_events
     pending_board_events, meta_current)
 ;;
 
+let in_turn_liveness_pulse_interval_sec () =
+  max 5.0 (min 30.0 (float_of_int (keepalive_interval_sec ())))
+;;
+
+let with_in_turn_liveness_pulse_for_test ~sw:_sw ~clock ~interval_sec ~tick f =
+  let interval_sec = max 0.001 interval_sec in
+  Eio.Switch.run (fun pulse_sw ->
+    let pulse_stop = Atomic.make false in
+    Eio.Switch.on_release pulse_sw (fun () -> Atomic.set pulse_stop true);
+    Eio.Fiber.fork ~sw:pulse_sw (fun () ->
+      let rec loop () =
+        Eio.Time.sleep clock interval_sec;
+        if not (Atomic.get pulse_stop) then (
+          (try tick ()
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
+               Log.Keeper.warn "in-turn liveness pulse failed: %s"
+                 (Printexc.to_string exn));
+          loop ())
+      in
+      loop ());
+    f ())
+;;
+
+let emit_in_turn_liveness_pulse ~(ctx : _ context) ~(meta : keeper_meta) =
+  match Keeper_registry.get ~base_path:ctx.config.base_path meta.name with
+  | Some entry when Option.is_some entry.current_turn_observation ->
+      (try
+         ignore (Coord.heartbeat ctx.config ~agent_name:meta.agent_name)
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+           Log.Keeper.debug "in-turn heartbeat failed for %s: %s"
+             meta.name (Printexc.to_string exn));
+      let now_ts = Time_compat.now () in
+      (try
+         Sse.broadcast
+           (`Assoc
+              [ "type", `String "keeper_heartbeat"
+              ; "name", `String meta.name
+              ; "generation", `Int meta.runtime.generation
+              ; "ts_unix", `Float now_ts
+              ; "phase", `String "turn_running"
+              ; "in_turn", `Bool true
+              ])
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+           Log.Keeper.error "in-turn heartbeat SSE broadcast failed: %s"
+             (Printexc.to_string exn))
+  | _ -> ()
+;;
+
+let with_in_turn_liveness_pulse
+      ~(ctx : _ context)
+      ~(meta : keeper_meta)
+      ~(stop : bool Atomic.t)
+      f
+  =
+  with_in_turn_liveness_pulse_for_test
+    ~sw:ctx.sw
+    ~clock:ctx.clock
+    ~interval_sec:(in_turn_liveness_pulse_interval_sec ())
+    ~tick:(fun () ->
+      if not (Atomic.get stop) then emit_in_turn_liveness_pulse ~ctx ~meta)
+    f
+;;
+
 let run_keepalive_unified_turn
       ~(ctx : _ context)
       ~(meta_after_triage : keeper_meta)
@@ -1274,15 +1348,17 @@ let run_keepalive_unified_turn
           with_keeper_turn_slot ~keeper_name:meta_after_triage.name
             ~channel:turn_decision.channel (fun ~semaphore_wait_ms ->
             match
-              Keeper_unified_turn.run_keeper_cycle
-                ~config:ctx.config
-                ~meta:meta_after_observe
-                ~observation:obs
-                ~generation:meta_after_observe.runtime.generation
-                ~channel:turn_decision.channel
-                ~semaphore_wait_ms:semaphore_wait_ms
-                ~shared_context
-                ()
+              with_in_turn_liveness_pulse ~ctx ~meta:meta_after_observe ~stop
+                (fun () ->
+                  Keeper_unified_turn.run_keeper_cycle
+                    ~config:ctx.config
+                    ~meta:meta_after_observe
+                    ~observation:obs
+                    ~generation:meta_after_observe.runtime.generation
+                    ~channel:turn_decision.channel
+                    ~semaphore_wait_ms:semaphore_wait_ms
+                    ~shared_context
+                    ())
             with
             | Error err ->
               let e_str = Oas.Error.to_string err in

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -74,6 +74,15 @@ val with_keeper_turn_slot_for_test :
   (semaphore_wait_ms:int -> 'a) ->
   ('a, [> `Semaphore_wait_timeout of float ]) result
 
+(** Test-only wrapper for the in-turn liveness pulse lifecycle. *)
+val with_in_turn_liveness_pulse_for_test :
+  sw:Eio.Switch.t ->
+  clock:'a Eio.Time.clock ->
+  interval_sec:float ->
+  tick:(unit -> unit) ->
+  (unit -> 'b) ->
+  'b
+
 (** Keepalive loop meta selection. Disk wins when it changed; otherwise
     fall back to the latest registry snapshot instead of the original boot
     meta so continuity/runtime fields do not regress across turns. *)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -240,7 +240,7 @@ let sdk_error_kind = function
   | Oas.Error.A2a _ -> "a2a"
   | Oas.Error.Internal _ -> "internal"
 
-let oas_timeout_guard_sec = 1.0
+let oas_timeout_guard_sec = 30.0
 
 let min_oas_timeout_budget_sec = 30.0
 

--- a/test/test_keeper_semaphore_fairness.ml
+++ b/test/test_keeper_semaphore_fairness.ml
@@ -148,6 +148,33 @@ let test_autonomous_slot_released_when_body_raises () =
   Alcotest.(check (list string)) "autonomous queue drained" []
     (KK.autonomous_waiter_snapshot_for_test ())
 
+let test_in_turn_liveness_pulse_stops_when_body_raises () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let clock = Eio.Stdenv.clock env in
+  let ticks = Atomic.make 0 in
+  let raised =
+    try
+      let _ =
+        KK.with_in_turn_liveness_pulse_for_test
+          ~sw
+          ~clock
+          ~interval_sec:0.01
+          ~tick:(fun () -> ignore (Atomic.fetch_and_add ticks 1))
+          (fun () ->
+            Eio.Time.sleep clock 0.025;
+            raise Exit)
+      in
+      false
+    with Exit -> true
+  in
+  Alcotest.(check bool) "body exception propagated" true raised;
+  Alcotest.(check bool) "pulse ticked while body ran" true (Atomic.get ticks > 0);
+  let ticks_after_raise = Atomic.get ticks in
+  Eio.Time.sleep clock 0.04;
+  Alcotest.(check int) "pulse stopped after body raised" ticks_after_raise
+    (Atomic.get ticks)
+
 let () =
   Alcotest.run "Keeper_semaphore_fairness"
     [
@@ -176,5 +203,10 @@ let () =
             (with_fresh_state test_reactive_slot_released_when_body_raises);
           Alcotest.test_case "autonomous slot released when body raises" `Quick
             (with_fresh_state test_autonomous_slot_released_when_body_raises);
+        ] );
+      ( "in_turn_liveness",
+        [
+          Alcotest.test_case "pulse stops when body raises" `Quick
+            (with_fresh_state test_in_turn_liveness_pulse_stops_when_body_raises);
         ] );
     ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3818,7 +3818,7 @@ let test_bounded_oas_timeout_caps_to_remaining_turn_budget () =
       ~estimated_input_tokens:2_000 ~remaining_turn_budget_s:235.7
   with
   | Some timeout_s ->
-      check (float 0.01) "remaining budget cap applies" 234.7 timeout_s
+      check (float 0.01) "remaining budget cap leaves finalization guard" 205.7 timeout_s
   | None -> fail "expected bounded timeout"
 
 let test_bounded_oas_timeout_uses_channel_turn_budget_override () =


### PR DESCRIPTION
Summary:
- leave a 30s finalization guard inside the keeper turn timeout budget so fallback/meta writes can finish
- emit lightweight in-turn keeper heartbeat SSE pulses while a long OAS turn is still running, without fake OAS snapshots
- switch the pure autonomous wait queue lock to Stdlib.Mutex so test helpers are safe outside Eio_main

Verification:
- scripts/dune-local.sh build test/test_keeper_semaphore_fairness.exe test/test_keeper_unified.exe
- env MASC_BASE_PATH=/tmp/masc-keeper-turn-timeout-test ./_build/default/test/test_keeper_semaphore_fairness.exe (11 tests)
- env MASC_BASE_PATH=/tmp/masc-keeper-turn-timeout-test ./_build/default/test/test_keeper_unified.exe (246 tests)