### PR TITLE
fix(types): tolerate missing last_seen + joined_at in agent deserialisation (#9751)

### DIFF
--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -164,15 +164,41 @@ let agent_of_yojson json =
             in
             Printf.sprintf "%s (last_seen=%s)" original_error last_seen_repr
           in
-          (match
-             match last_seen_raw with
-             | Some value -> normalize_agent_last_seen ~joined_at:joined_at_value value
-             | None -> joined_at_value  (* missing last_seen → bootstrap *)
-           with
+          let now_iso () =
+            `String (iso8601_of_unix_seconds (Unix.gettimeofday ()))
+          in
+          let normalized_last_seen =
+            match last_seen_raw with
+            | Some value ->
+                normalize_agent_last_seen ~joined_at:joined_at_value value
+            | None ->
+                (* Missing last_seen → bootstrap from joined_at when
+                   present, otherwise fall back to the current wall-clock
+                   time (#9751).  [last_seen] is a liveness marker, not
+                   identity-critical; a recent-but-approximate timestamp
+                   is strictly better than failing the whole record
+                   deserialisation for an optional field. *)
+                (match joined_at_value with
+                 | Some _ as v -> v
+                 | None -> Some (now_iso ()))
+          in
+          (match normalized_last_seen with
           | Some normalized_last_seen ->
-              let normalized_fields =
+              let fields_without_last_seen =
                 ("last_seen", normalized_last_seen)
                 :: List.remove_assoc "last_seen" fields
+              in
+              (* If joined_at is also unusable, inject a now() value so
+                 the generated deserialiser's required-field check passes.
+                 The agent record can always be rebuilt from a heartbeat;
+                 losing the whole entry because of a missing timestamp is
+                 strictly worse (#9751). *)
+              let normalized_fields =
+                match joined_at_value with
+                | Some _ -> fields_without_last_seen
+                | None ->
+                    ("joined_at", now_iso ())
+                    :: List.remove_assoc "joined_at" fields_without_last_seen
               in
               (match agent_of_yojson_generated (`Assoc normalized_fields) with
                | Ok _ as ok -> ok

--- a/test/test_room_state_recovery.ml
+++ b/test/test_room_state_recovery.ml
@@ -203,6 +203,33 @@ let test_agent_of_yojson_annotates_invalid_last_seen () =
       check bool "error mentions last_seen value" true
         (contains "last_seen=")
 
+let test_agent_of_yojson_missing_last_seen_falls_back_to_now () =
+  (* #9751: when last_seen is entirely absent AND joined_at is not a usable
+     string, fall back to a current-wall-clock timestamp rather than
+     failing the whole record. last_seen is a liveness marker, not
+     identity-critical. *)
+  let json =
+    `Assoc
+      [
+        ("name", `String "keeper-orphan");
+        ("agent_type", `String "keeper");
+        ("status", `String "active");
+        ("capabilities", `List []);
+        ("current_task", `Null);
+        (* no joined_at, no last_seen *)
+      ]
+  in
+  match Types.agent_of_yojson json with
+  | Ok agent ->
+      check string "agent parsed without last_seen or joined_at"
+        "keeper-orphan" agent.name;
+      check bool "last_seen populated with ISO timestamp" true
+        (String.length agent.last_seen > 0
+         && String.contains agent.last_seen 'T'
+         && String.contains agent.last_seen 'Z')
+  | Error msg ->
+      fail ("missing last_seen+joined_at should fall back, not error: " ^ msg)
+
 let test_heartbeat_repairs_legacy_agent_last_seen () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -259,6 +286,8 @@ let () =
             test_agent_of_yojson_bootstraps_null_last_seen_from_joined_at;
           test_case "agent parser error annotates invalid last_seen (#7947)" `Quick
             test_agent_of_yojson_annotates_invalid_last_seen;
+          test_case "agent parser falls back when both last_seen and joined_at missing (#9751)" `Quick
+            test_agent_of_yojson_missing_last_seen_falls_back_to_now;
           test_case "heartbeat repairs legacy agent last_seen" `Quick
             test_heartbeat_repairs_legacy_agent_last_seen;
         ] );


### PR DESCRIPTION
## 요약

`agent_of_yojson`의 recovery layer가 `last_seen` 누락 시 `joined_at`에서 부트스트랩하지만, **둘 다 누락/비-string**일 때는 record 전체 deserialisation을 실패시켜 `current_task`, `meta`, `capabilities`까지 같이 drop. 로그에 `Types_core.agent.last_seen (last_seen=<missing>)` 증상.

Closes #9751.

## 근본 원인

기존 recovery (types_core.ml:167-180):

```ocaml
(match
   match last_seen_raw with
   | Some value -> normalize_agent_last_seen ~joined_at:joined_at_value value
   | None -> joined_at_value  (* missing last_seen → bootstrap *)
 with
| Some normalized_last_seen ->
    let normalized_fields =
      ("last_seen", normalized_last_seen)
      :: List.remove_assoc "last_seen" fields
    in
    ...
| None -> Error (annotated_error ()))   (* ← both missing → fail *)
```

`joined_at_value`는 `Some (`String _)` 조건에서만 `Some`, 다른 경우 `None`. `joined_at`이 누락이거나 `Int`/`Bool` 등이면 `None` → `last_seen`도 누락이면 `Error`.

추가로, 복구 성공 경로에서도 `joined_at`이 여전히 비-string이면 generated deserialiser가 required-field 검사로 실패.

## 변경 내용

`last_seen`과 `joined_at`이 모두 누락/비-string일 때 현재 ISO 타임스탬프로 주입:

```diff
+ let now_iso () =
+   `String (iso8601_of_unix_seconds (Unix.gettimeofday ()))
+ in
  let normalized_last_seen =
    match last_seen_raw with
    | Some value -> normalize_agent_last_seen ~joined_at:joined_at_value value
-   | None -> joined_at_value
+   | None ->
+       (match joined_at_value with
+        | Some _ as v -> v
+        | None -> Some (now_iso ()))
  in
  (match normalized_last_seen with
  | Some normalized_last_seen ->
+     let fields_without_last_seen = ... in
+     let normalized_fields =
+       match joined_at_value with
+       | Some _ -> fields_without_last_seen
+       | None ->
+           ("joined_at", now_iso ())
+           :: List.remove_assoc "joined_at" fields_without_last_seen
+     in
      ...
```

### 근거

`last_seen`과 `joined_at`은 **liveness marker**, identity-critical 아님. 다음 heartbeat에서 refresh됨. 누락 때문에 record 전체를 drop하면 `current_task`/`meta` 등 복구 불가 데이터까지 손실. 현재-wall-clock 추정치가 strictly better.

## 테스트

`test/test_room_state_recovery.ml` scenario 6 추가:

```ocaml
let test_agent_of_yojson_missing_last_seen_falls_back_to_now () =
  let json =
    `Assoc
      [
        ("name", `String "keeper-orphan");
        ("agent_type", `String "keeper");
        ("status", `String "active");
        ("capabilities", `List []);
        ("current_task", `Null);
        (* no joined_at, no last_seen *)
      ]
  in
  match Types.agent_of_yojson json with
  | Ok agent ->
      check bool "last_seen populated with ISO timestamp" true
        (String.length agent.last_seen > 0
         && String.contains agent.last_seen 'T'
         && String.contains agent.last_seen 'Z')
  | Error msg -> fail ...
```

## 검증

```bash
$ dune exec --root . test/test_room_state_recovery.exe
# → Test Successful in 0.087s. 8 tests run.
```

기존 7개 scenario (numeric last_seen, null bootstrap, invalid annotation, heartbeat repair 등) 모두 유지.

## 회귀 리스크

| 케이스 | Before | After |
|--------|--------|-------|
| last_seen missing, joined_at String | bootstrap from joined_at | bootstrap from joined_at (unchanged) |
| last_seen Null, joined_at String | bootstrap from joined_at (unchanged) | bootstrap from joined_at (unchanged) |
| last_seen String, joined_at String | normal parse | normal parse (unchanged) |
| last_seen Int/Float, joined_at String | normalized to ISO | normalized to ISO (unchanged) |
| last_seen Bool, joined_at Bool | Error (unchanged) | Error (unchanged) |
| **last_seen missing, joined_at missing** | Error | **now() fallback** ✅ |
| **last_seen missing, joined_at Int/Bool** | Error | **now() fallback** ✅ |

앞의 5개 불변. 뒤 2개만 복구 경로 추가.

## 참고

- Issue #9751 — 1회 발생 재현
- 관련: #7947 (Layer 1/2 recovery original work)
