### PR TITLE
[codex] Persist persona-created keepers as TOML

### DIFF
--- a/lib/keeper/keeper_exec_persona.ml
+++ b/lib/keeper/keeper_exec_persona.ml
@@ -106,6 +106,219 @@ let validate_resolved_keeper_create_json (json : Yojson.Safe.t) : string list =
     errors := "mention_targets is required" :: !errors;
   List.rev !errors
 
+let toml_escape_string value =
+  let buf = Buffer.create (String.length value + 8) in
+  String.iter
+    (function
+      | '\\' -> Buffer.add_string buf "\\\\"
+      | '"' -> Buffer.add_string buf "\\\""
+      | '\n' -> Buffer.add_string buf "\\n"
+      | '\r' -> Buffer.add_string buf "\\r"
+      | '\t' -> Buffer.add_string buf "\\t"
+      | c -> Buffer.add_char buf c)
+    value;
+  Buffer.contents buf
+
+let toml_string value = "\"" ^ toml_escape_string value ^ "\""
+
+let toml_string_array values =
+  values |> List.map toml_string |> String.concat ", " |> Printf.sprintf "[%s]"
+
+let toml_float value =
+  if Float.is_finite value then Ok (Printf.sprintf "%.17g" value)
+  else Error "non-finite float cannot be persisted to keeper TOML"
+
+let required_resolved_string key json =
+  match Safe_ops.json_string_opt key json with
+  | Some value when String.trim value <> "" -> Ok value
+  | _ -> Error (Printf.sprintf "resolved_args.%s is required" key)
+
+let optional_resolved_string key json =
+  match Safe_ops.json_string_opt key json with
+  | Some value when String.trim value <> "" -> Some value
+  | _ -> None
+
+let append_string_field acc key value =
+  (Printf.sprintf "%s = %s" key (toml_string value)) :: acc
+
+let append_optional_string_field acc key json =
+  match optional_resolved_string key json with
+  | Some value -> append_string_field acc key value
+  | None -> acc
+
+let append_bool_field acc key value =
+  (Printf.sprintf "%s = %s" key (if value then "true" else "false")) :: acc
+
+let append_optional_bool_field acc key json =
+  match Safe_ops.json_bool_opt key json with
+  | Some value -> append_bool_field acc key value
+  | None -> acc
+
+let append_int_field acc key value =
+  (Printf.sprintf "%s = %d" key value) :: acc
+
+let append_optional_int_field acc key json =
+  match Safe_ops.json_int_opt key json with
+  | Some value -> append_int_field acc key value
+  | None -> acc
+
+let append_string_list_field acc key values =
+  (Printf.sprintf "%s = %s" key (toml_string_array values)) :: acc
+
+let append_present_string_list_field acc key json =
+  match Safe_ops.json_member_opt key json with
+  | Some (`List _) ->
+      append_string_list_field acc key (Safe_ops.json_string_list key json)
+  | Some _ | None -> acc
+
+let append_tool_access_fields acc json =
+  match Safe_ops.json_member_opt "tool_access" json with
+  | Some (`Assoc _ as tool_access) -> (
+      match Safe_ops.json_string_opt "kind" tool_access with
+      | Some "preset" -> (
+          match Safe_ops.json_string_opt "preset" tool_access with
+          | Some preset ->
+              let acc = append_string_field acc "tool_preset" preset in
+              Ok (append_present_string_list_field acc "tool_also_allow" tool_access)
+          | None -> Error "tool_access.preset is required for durable TOML")
+      | Some "custom" ->
+          Error
+            "tool_access.kind=custom cannot be persisted to keeper TOML yet; use a tool_preset/tool_also_allow policy for persona-backed durable keepers"
+      | Some other ->
+          Error (Printf.sprintf "invalid tool_access.kind for durable TOML: %s" other)
+      | None -> Error "tool_access.kind is required for durable TOML")
+  | Some _ -> Error "tool_access must be an object for durable TOML"
+  | None ->
+      let acc =
+        match Safe_ops.json_string_opt "tool_preset" json with
+        | Some preset -> append_string_field acc "tool_preset" preset
+        | None -> acc
+      in
+      Ok (append_present_string_list_field acc "tool_also_allow" json)
+
+let render_keeper_toml_from_resolved_args (json : Yojson.Safe.t) :
+    (string, string) result =
+  match required_resolved_string "name" json with
+  | Error _ as err -> err
+  | Ok name ->
+      if not (validate_name name) then
+        Error "resolved_args.name is not a valid keeper name"
+      else
+        match required_resolved_string "persona_name" json with
+        | Error _ as err -> err
+        | Ok persona_name ->
+            if not (validate_name persona_name) then
+              Error "resolved_args.persona_name is not a valid persona name"
+            else
+              let fields = [] in
+              let fields = append_string_field fields "name" name in
+              let fields = append_string_field fields "persona_name" persona_name in
+              let fields = append_optional_string_field fields "goal" json in
+              let fields = append_optional_string_field fields "short_goal" json in
+              let fields = append_optional_string_field fields "mid_goal" json in
+              let fields = append_optional_string_field fields "long_goal" json in
+              let fields = append_optional_string_field fields "will" json in
+              let fields = append_optional_string_field fields "needs" json in
+              let fields = append_optional_string_field fields "desires" json in
+              let fields = append_optional_string_field fields "instructions" json in
+              let fields =
+                append_optional_bool_field fields "policy_voice_enabled" json
+              in
+              let fields =
+                append_optional_bool_field fields "autoboot_enabled" json
+              in
+              let fields =
+                append_present_string_list_field fields "mention_targets" json
+              in
+              let fields =
+                append_optional_bool_field fields "proactive_enabled" json
+              in
+              let fields =
+                append_optional_int_field fields "proactive_idle_sec" json
+              in
+              let fields =
+                append_optional_int_field fields "proactive_cooldown_sec" json
+              in
+              let fields = append_present_string_list_field fields "shards" json in
+              let fields =
+                append_present_string_list_field fields "allowed_paths" json
+              in
+              let fields =
+                append_optional_string_field fields "sandbox_profile" json
+              in
+              let fields =
+                append_optional_string_field fields "network_mode" json
+              in
+              let fields =
+                append_optional_string_field fields "shared_memory_scope" json
+              in
+              let fields =
+                append_present_string_list_field fields "active_goal_ids" json
+              in
+              (match append_tool_access_fields fields json with
+              | Error _ as err -> err
+              | Ok fields ->
+                  let fields =
+                    append_present_string_list_field fields "tool_denylist" json
+                  in
+                  let timeout_fields =
+                    match Safe_ops.json_float_opt "per_provider_timeout" json with
+                    | None -> Ok fields
+                    | Some value -> (
+                        match toml_float value with
+                        | Error _ as err -> err
+                        | Ok rendered ->
+                            Ok
+                              ((Printf.sprintf "per_provider_timeout = %s"
+                                  rendered)
+                              :: fields))
+                  in
+                  Result.map
+                    (fun fields ->
+                      String.concat "\n"
+                        ([
+                           "# Generated by masc_keeper_create_from_persona.";
+                           "[keeper]";
+                         ]
+                        @ List.rev fields)
+                      ^ "\n")
+                    timeout_fields)
+
+let persist_keeper_toml_from_resolved_args (json : Yojson.Safe.t) :
+    (Yojson.Safe.t, string) result =
+  match required_resolved_string "name" json with
+  | Error _ as err -> err
+  | Ok name ->
+      if not (validate_name name) then
+        Error "resolved_args.name is not a valid keeper name"
+      else
+        let path =
+          Filename.concat (Config_dir_resolver.keepers_dir ()) (name ^ ".toml")
+        in
+        match Config_dir_resolver.keeper_toml_path_opt name with
+        | Some existing_path ->
+            Ok
+              (`Assoc
+                [
+                  ("path", `String existing_path);
+                  ("created", `Bool false);
+                  ("reason", `String "already_exists");
+                ])
+        | None -> (
+            match render_keeper_toml_from_resolved_args json with
+            | Error _ as err -> err
+            | Ok content -> (
+                Fs_compat.mkdir_p (Filename.dirname path);
+                match Fs_compat.save_file_atomic path content with
+                | Error msg -> Error msg
+                | Ok () ->
+                    Ok
+                      (`Assoc
+                        [
+                          ("path", `String path);
+                          ("created", `Bool true);
+                        ])))
+
 let resolved_keeper_args_from_persona args :
     ((persona_summary * Yojson.Safe.t), string) result =
   let persona_name = get_string args "persona_name" "" |> String.trim in

--- a/lib/keeper/keeper_exec_persona.mli
+++ b/lib/keeper/keeper_exec_persona.mli
@@ -11,5 +11,11 @@ val find_jsonl_row_by_action_id :
 
 val validate_resolved_keeper_create_json : Yojson.Safe.t -> string list
 
+val render_keeper_toml_from_resolved_args :
+  Yojson.Safe.t -> (string, string) result
+
+val persist_keeper_toml_from_resolved_args :
+  Yojson.Safe.t -> (Yojson.Safe.t, string) result
+
 val resolved_keeper_args_from_persona :
   Yojson.Safe.t -> (persona_summary * Yojson.Safe.t, string) result

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -356,10 +356,17 @@ let handle_keeper_create_from_persona ctx args : tool_result =
         in
         (true, Yojson.Safe.to_string json)
       else
+        match Keeper_exec_persona.render_keeper_toml_from_resolved_args resolved_args with
+        | Error e -> (false, "❌ " ^ e)
+        | Ok _ ->
         let (ok, body) = with_keeper_startup_gate (fun () -> execute_keeper_up ctx resolved_args) in
         if not ok then
           (false, body)
         else
+          match Keeper_exec_persona.persist_keeper_toml_from_resolved_args resolved_args with
+          | Error e ->
+              (false, "❌ keeper created but durable config write failed: " ^ e)
+          | Ok durable_config ->
           let created_json =
             try Yojson.Safe.from_string body with Yojson.Json_error _ -> `String body
           in
@@ -368,6 +375,7 @@ let handle_keeper_create_from_persona ctx args : tool_result =
               [
                 ("persona", Keeper_exec_persona.persona_summary_to_json persona);
                 ("created", `Bool true);
+                ("durable_config", durable_config);
                 ("result", annotate_keeper_json ~runtime_class:"keeper" created_json);
                 ("resolved_args", resolved_args);
               ]

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -3,6 +3,7 @@ open Alcotest
 module TL = Masc_mcp.Keeper_toml_loader
 module KTP = Masc_mcp.Keeper_types_profile
 module KPA = Masc_mcp.Keeper_persona_authoring
+module KEP = Masc_mcp.Keeper_exec_persona
 
 let contains_substring s needle =
   let s_len = String.length s in
@@ -990,6 +991,79 @@ let test_persona_resolver_preserves_canonical_tool_access_and_allowed_paths () =
          | `String _ -> true
          | _ -> false)
 
+let test_persona_resolver_renders_durable_keeper_toml () =
+  let resolved =
+    `Assoc
+      [
+        ("name", `String "probe-keeper");
+        ("persona_name", `String "probe");
+        ("goal", `String "line1\nline2");
+        ("short_goal", `String "short");
+        ("mid_goal", `String "mid");
+        ("long_goal", `String "long");
+        ("instructions", `String "quote: \"ok\"");
+        ("policy_voice_enabled", `Bool false);
+        ("autoboot_enabled", `Bool false);
+        ("mention_targets", `List [ `String "probe"; `String "@probe" ]);
+        ("proactive_enabled", `Bool true);
+        ("allowed_paths", `List [ `String "/tmp/probe" ]);
+        ("tool_preset", `String "research");
+        ("tool_also_allow", `List [ `String "masc_status" ]);
+        ("tool_denylist", `List [ `String "masc_keeper_reset" ]);
+      ]
+  in
+  match KEP.render_keeper_toml_from_resolved_args resolved with
+  | Error e -> fail ("render failed: " ^ e)
+  | Ok toml -> (
+      match TL.parse_toml toml with
+      | Error e -> fail ("rendered TOML did not parse: " ^ e)
+      | Ok doc -> (
+          match KTP.profile_defaults_of_toml doc with
+          | Error e -> fail ("rendered TOML did not load: " ^ e)
+          | Ok defaults ->
+              check (option string) "name" (Some "probe-keeper")
+                (TL.toml_string_opt doc "keeper.name");
+              check (option string) "persona_name" (Some "probe")
+                defaults.persona_name;
+              check (option string) "goal" (Some "line1\nline2")
+                defaults.goal;
+              check (option string) "instructions"
+                (Some "quote: \"ok\"") defaults.instructions;
+              check (option bool) "autoboot" (Some false)
+                defaults.autoboot_enabled;
+              check (list string) "mention targets"
+                [ "probe"; "@probe" ] defaults.mention_targets;
+              check (option (list string)) "allowed_paths"
+                (Some [ "/tmp/probe" ]) defaults.allowed_paths;
+              check (option string) "tool_preset" (Some "research")
+                defaults.tool_preset;
+              check (option (list string)) "tool_also_allow"
+                (Some [ "masc_status" ]) defaults.tool_also_allow;
+              check (option (list string)) "tool_denylist"
+                (Some [ "masc_keeper_reset" ]) defaults.tool_denylist))
+
+let test_persona_resolver_rejects_custom_tool_access_durable_toml () =
+  let resolved =
+    `Assoc
+      [
+        ("name", `String "probe-keeper");
+        ("persona_name", `String "probe");
+        ("goal", `String "test");
+        ("mention_targets", `List [ `String "probe" ]);
+        ( "tool_access",
+          `Assoc
+            [
+              ("kind", `String "custom");
+              ("tools", `List [ `String "masc_status" ]);
+            ] );
+      ]
+  in
+  match KEP.render_keeper_toml_from_resolved_args resolved with
+  | Ok _ -> fail "expected custom tool_access durable TOML rejection"
+  | Error e ->
+      check bool "mentions custom tool_access" true
+        (contains_substring e "tool_access.kind=custom")
+
 let authoring_minimal_profile =
   `Assoc
     [
@@ -1408,6 +1482,10 @@ let () =
             test_persona_resolver_preserves_autoboot_enabled_arg;
           test_case "persona resolver preserves canonical tool_access and allowed_paths" `Quick
             test_persona_resolver_preserves_canonical_tool_access_and_allowed_paths;
+          test_case "persona resolver renders durable keeper TOML" `Quick
+            test_persona_resolver_renders_durable_keeper_toml;
+          test_case "persona resolver rejects custom tool_access durable TOML" `Quick
+            test_persona_resolver_rejects_custom_tool_access_durable_toml;
           test_case "persona authoring schema explains effects" `Quick
             test_persona_authoring_schema_explains_effects;
           test_case "persona authoring normalizes defaults" `Quick


### PR DESCRIPTION
## Summary
- Persist `masc_keeper_create_from_persona` results as keeper TOML under the resolved config root.
- Return `durable_config` metadata in the create response so operators can see whether the TOML was created or already existed.
- Add focused coverage that generated TOML round-trips through the keeper TOML/profile loader and rejects unsupported custom tool access.

## Root Cause
`masc_keeper_create_from_persona` started a runtime keeper and wrote runtime state, but it did not create the declarative `config/keepers/<name>.toml` overlay promised by the tool contract. Persona-backed keepers therefore were live after creation but not fully durable from the config root.

## Validation
- `env DUNE_LOCAL_JOBS=2 scripts/dune-local.sh build test/test_keeper_toml.exe`
- `./_build/default/test/test_keeper_toml.exe`
- `git diff --check`