### PR TITLE
fix(keeper): cancel-safe emit_turn_end to stop Fun.Finally_raised crash (#9747)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -77,7 +77,22 @@ let run_turn
   : (run_result, Oas.Error.sdk_error) result
   =
   Masc_runtime_events.emit_turn_start ();
-  Fun.protect ~finally:Masc_runtime_events.emit_turn_end
+  (* Cancel-safe cleanup (#9747): stdlib [Fun.protect] wraps finally
+     exceptions in [Fun.Finally_raised], masking the outer
+     [Eio.Cancel.Cancelled] raised by the turn body during fleet-wide
+     cancellation. Swallow Cancelled in the finally (the outer one is
+     already in flight) and log non-cancel exceptions instead of
+     propagating them. Mirrors the pattern used in
+     [keeper_unified_turn.ml] (#9747 iter 1). *)
+  let safe_emit_turn_end () =
+    try Masc_runtime_events.emit_turn_end () with
+    | Eio.Cancel.Cancelled _ -> ()
+    | e ->
+      Log.Keeper.warn
+        "%s: emit_turn_end in finally raised: %s"
+        meta.name (Printexc.to_string e)
+  in
+  Fun.protect ~finally:safe_emit_turn_end
   @@ fun () ->
   let receipt_started_at = Types.now_iso () in
   let meta = sync_current_task_id_from_backlog ~config meta in


### PR DESCRIPTION
## 요약

`keeper_agent_run.ml:80`의 `Fun.protect ~finally:Masc_runtime_events.emit_turn_end` 패턴이 finally 예외를 `Fun.Finally_raised`로 래핑해 원래 `Eio.Cancel.Cancelled`를 덮음. OAS 캔슬 시 4 keeper 동시 crash 증상.

Closes #9747.

## 증상

```
janitor: keeper cycle exception: Fun.Finally_raised: Cancelled: Eio__core__Fiber.Not_first
nick0cave: keeper cycle exception: Fun.Finally_raised: Cancelled: Eio__core__Fiber.Not_first
qa-king: keeper cycle exception: Fun.Finally_raised: Cancelled: Eio__core__Fiber.Not_first
sangsu: keeper cycle exception: Fun.Finally_raised: Cancelled: Eio__core__Fiber.Not_first
```

모두 `keeper_llm_bridge: OAS execution cancelled` 이벤트 ~1s 이내 발생.

## 근본 원인

CLAUDE.md software-development.md에 이미 기재된 OCaml Eio 주의사항:
> `Fun.protect`는 finally 예외가 원래 예외를 덮을 수 있음 (`Fun.Finally_raised`)

기존 코드 (`lib/keeper/keeper_agent_run.ml:80`):

```ocaml
Masc_runtime_events.emit_turn_start ();
Fun.protect ~finally:Masc_runtime_events.emit_turn_end
@@ fun () -> <turn body>
```

Turn body가 `Eio.Cancel.Cancelled`로 터지는 중에 `emit_turn_end`가 뭔가(버퍼 flush, 로그 emit 등)를 하다가 Cancelled를 재발생시키면 OCaml이 `Fun.Finally_raised(Cancelled)`로 래핑 → 원래 Cancelled 사라짐 → 최상위 `try/with Cancelled`가 못 잡음 → 크래시.

## 변경 내용

`keeper_unified_turn.ml:990`에서 이미 쓴 cancel-safe 패턴을 동일하게 적용:

```diff
  Masc_runtime_events.emit_turn_start ();
+ (* Cancel-safe cleanup (#9747): ... *)
+ let safe_emit_turn_end () =
+   try Masc_runtime_events.emit_turn_end () with
+   | Eio.Cancel.Cancelled _ -> ()
+   | e ->
+     Log.Keeper.warn
+       "%s: emit_turn_end in finally raised: %s"
+       meta.name (Printexc.to_string e)
+ in
- Fun.protect ~finally:Masc_runtime_events.emit_turn_end
+ Fun.protect ~finally:safe_emit_turn_end
  @@ fun () -> <turn body>
```

- Outer `Cancelled`가 이미 in-flight이므로 finally에서 삼킴
- Non-cancel 예외는 `Log.Keeper.warn`으로 관측

## 검증

`dune build @check` exit 0. 해당 패턴이 `keeper_unified_turn.ml`에서 이미 동일 방식으로 작동 중 (#9747 iter 1) → 같은 pattern의 idempotent 확장.

## 회귀 리스크

매우 낮음 — finally가 정상 경로면 `Masc_runtime_events.emit_turn_end ()` 그대로 호출. 예외 발생 시에만 분기하므로 성공 경로 동작 동일.

## 범위

본 PR은 `keeper_agent_run.ml`만 처리. `lib/keeper/` 하위 `Fun.protect` 사이트 13곳 중 나머지 (supervisor, keepalive, transition_audit, gh_shared 등)는 별도 audit + 개별 PR로 검토. 본 이슈의 primary crash 경로는 agent_run(턴 본체)이므로 최우선.

## 참고

- Issue #9747 — 4 keeper 동시 crash 증상
- 관련 fix: `keeper_unified_turn.ml:990` (cancel-safe unsubscribe + mark_turn_finished)
- CLAUDE.md software-development.md § OCaml — Fun.protect vs Eio 지침
