### PR TITLE
[codex] Fix cascade provider leak warning false positives

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -779,22 +779,33 @@ let resolve_named_providers ?sw ?net ?clock ?provider_filter
   match lookup_active_profile ?sw ?net ?clock cascade_name with
   | Error _ as e -> e
   | Ok (_snapshot, normalized, profile) ->
-      let providers =
+      let provider_label (c : Llm_provider.Provider_config.t) =
+        Printf.sprintf "%s:%s"
+          (Llm_provider.Provider_config.string_of_provider_kind c.kind)
+          (String.trim c.model_id)
+      in
+      let ordered_entries =
         Cascade_config.order_weighted_entries
           ~rotation_scope:normalized
           profile.weighted_entries
-        |> Cascade_config.parse_weighted_entries
+      in
+      let parsed_declared_providers =
+        Cascade_config.parse_weighted_entries
              ~api_key_env_overrides:profile.api_key_env_overrides
              ~cascade_name:normalized
-        |> Cascade_config.apply_provider_filter
+          ordered_entries
+      in
+      let filtered_declared_providers =
+        Cascade_config.apply_provider_filter
              ~provider_filter
              ~label:normalized
+          parsed_declared_providers
       in
       let providers =
         Provider_tool_support.apply_required_tool_use_filter
           ?runtime_mcp_policy
           ~require_tool_choice_support ~require_tool_support
-          ~label:normalized providers
+          ~label:normalized filtered_declared_providers
       in
       if providers = [] then
         Error
@@ -802,32 +813,23 @@ let resolve_named_providers ?sw ?net ?clock ?provider_filter
              "cascade %s resolved to no callable providers"
              normalized)
       else (
-        (* Observability for cascade-name -> runtime-provider divergence.
-           If the returned provider set ever disagrees with the declared
-           weighted_entries of the profile (e.g. under snapshot staleness
-           or cache leak across cascades), the mismatch shows up here.
+        (* Observability for cascade-name -> runtime-provider divergence.  Compare
+           against the profile after provider:auto expansion, canonical provider
+           parsing, and provider_filter fallback.  The raw declared strings can
+           be aliases such as [codex_cli:auto] or [custom:model@url], while
+           Provider_config carries concrete/canonical labels.
            See memory/handoff-2026-04-24-masc-runtime-mcp-auth-resolved.md *)
         let declared =
-          List.map
-            (fun (e : Cascade_config_loader.weighted_entry) ->
-              String.trim e.model)
-            profile.weighted_entries
+          List.map provider_label filtered_declared_providers
         in
-        let returned =
-          List.map
-            (fun (c : Llm_provider.Provider_config.t) ->
-              Printf.sprintf "%s:%s"
-                (Llm_provider.Provider_config.string_of_provider_kind c.kind)
-                (String.trim c.model_id))
-            providers
-        in
+        let returned = List.map provider_label providers in
         let leaked =
           List.filter (fun m -> not (List.mem m declared)) returned
         in
         (if leaked <> [] then
            Log.warn ~ctx:"CascadeCatalog"
-             "resolve_named_providers(%s): %d providers NOT in declared \
-              profile (declared=[%s] returned=[%s] leaked=[%s])"
+             "resolve_named_providers(%s): %d providers NOT in parsed declared \
+              profile (parsed_declared=[%s] returned=[%s] leaked=[%s])"
              normalized (List.length leaked)
              (String.concat ", " declared)
              (String.concat ", " returned)

--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -45,6 +45,39 @@ let contains_substring haystack needle =
   in
   loop 0
 
+let capture_stderr f =
+  let pipe_read, pipe_write = Unix.pipe () in
+  let saved_stderr = Unix.dup Unix.stderr in
+  Unix.dup2 pipe_write Unix.stderr;
+  Unix.close pipe_write;
+  let result =
+    try
+      f ();
+      Ok ()
+    with exn ->
+      Error (exn, Printexc.get_raw_backtrace ())
+  in
+  flush stderr;
+  Unix.dup2 saved_stderr Unix.stderr;
+  Unix.close saved_stderr;
+  Unix.set_nonblock pipe_read;
+  let buf = Buffer.create 256 in
+  let tmp = Bytes.create 256 in
+  let rec read_all () =
+    match Unix.read pipe_read tmp 0 (Bytes.length tmp) with
+    | 0 -> ()
+    | n ->
+        Buffer.add_subbytes buf tmp 0 n;
+        read_all ()
+    | exception Unix.Unix_error ((Unix.EAGAIN | Unix.EWOULDBLOCK), _, _) -> ()
+  in
+  read_all ();
+  Unix.close pipe_read;
+  let output = Buffer.contents buf in
+  match result with
+  | Ok () -> output
+  | Error (exn, bt) -> Printexc.raise_with_backtrace exn bt
+
 let with_env name value f =
   let saved = Sys.getenv_opt name in
   (match value with
@@ -594,6 +627,37 @@ let test_resolve_named_providers_runtime_mcp_headers_drop_unsupported_providers 
   check bool "keeps claude_code with runtime MCP header support" true
     (List.mem "claude_code" (provider_kinds providers))
 
+let test_resolve_named_providers_canonical_labels_are_not_leaks () =
+  with_temp_dir "cascade-catalog-canonical-labels" @@ fun dir ->
+  let config_dir = Filename.concat dir "config" in
+  init_config_root config_dir;
+  with_config_dir config_dir @@ fun () ->
+  let model = Printf.sprintf "custom:judge@%s/v1" dummy_base_url in
+  ignore
+    (write_cascade_json config_dir
+       (Printf.sprintf
+          {|{
+  "big_three_models": ["%s", "codex_cli:auto", "gemini_cli:auto"],
+  "governance_judge_models": ["%s", "codex_cli:auto", "gemini_cli:auto"]
+}|}
+          model model));
+  Log.set_level Log.Info;
+  let stderr_output =
+    capture_stderr (fun () ->
+        let providers =
+          require_ok
+            (Cascade_catalog_runtime.resolve_named_providers
+               ~cascade_name:"governance_judge" ())
+        in
+        let kinds = provider_kinds providers in
+        check bool "keeps canonical custom provider" true
+          (List.mem "openai_compat" kinds);
+        check bool "expands codex_cli:auto" true (List.mem "codex_cli" kinds);
+        check bool "expands gemini_cli:auto" true (List.mem "gemini_cli" kinds))
+  in
+  check bool "canonicalized provider labels are not false leaks" false
+    (contains_substring stderr_output "NOT in")
+
 let test_config_doctor_live_reports_catalog_validation () =
   with_temp_dir "cascade-doctor-live" @@ fun dir ->
   let base_path = Filename.concat dir "base" in
@@ -715,6 +779,10 @@ let () =
             "resolve_named_providers runtime MCP headers drop unsupported providers"
             `Quick
             test_resolve_named_providers_runtime_mcp_headers_drop_unsupported_providers;
+          test_case
+            "resolve_named_providers canonical labels are not leak warnings"
+            `Quick
+            test_resolve_named_providers_canonical_labels_are_not_leaks;
           test_case
             "config doctor live reports catalog validation"
             `Quick


### PR DESCRIPTION
## Summary

Fixes the noisy `CascadeCatalog resolve_named_providers(...): providers NOT in declared profile` warning when a profile uses aliases such as `codex_cli:auto`, `gemini_cli:auto`, or `custom:model@url`.

The warning used to compare returned canonical provider labels against raw profile strings, so valid auto-expanded or canonicalized providers looked like leaks. The runtime now compares the final returned providers against the parsed, filtered declared providers after provider:auto expansion and canonical parsing.

## Validation

- `git diff --check`
- `./scripts/check-oas-pin.sh --local-only`
- `env DUNE_JOBS=1 DUNE_CACHE=disabled ./scripts/dune-local.sh build test/test_cascade_catalog_runtime.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-cascade-catalog ./_build/default/test/test_cascade_catalog_runtime.exe`

## Notes

The regression test captures stderr and covers both canonical `custom` labels and the live-style `codex_cli:auto` / `gemini_cli:auto` expansion path, asserting that no false `NOT in` warning is emitted.