### PR TITLE
fix(dashboard): add temporal anchor to remaining alert-strip pills

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -276,18 +276,27 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
               <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--warn-14)] text-[var(--warn)]">
                 계속 진행 승인 대기
               </span>
+              ${keeper.last_autonomous_action_at
+                ? html`<span class="text-[var(--text-muted)]">마지막 행동 이후 <${TimeAgo} timestamp=${keeper.last_autonomous_action_at} /></span>`
+                : null}
             `
           : socialFallbackActive
           ? html`
               <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--warn-14)] text-[var(--warn)]">
                 Social fallback
               </span>
+              ${keeper.last_autonomous_action_at
+                ? html`<span class="text-[var(--text-muted)]">마지막 행동 이후 <${TimeAgo} timestamp=${keeper.last_autonomous_action_at} /></span>`
+                : null}
             `
           : runtimeBlockerClass
           ? html`
               <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--bad-soft)] text-[var(--bad)]">
                 ${runtimeBlockerLabel ?? 'Runtime blocker'}
               </span>
+              ${keeper.last_autonomous_action_at
+                ? html`<span class="text-[var(--text-muted)]">마지막 행동 이후 <${TimeAgo} timestamp=${keeper.last_autonomous_action_at} /></span>`
+                : null}
             `
           : null}
         ${runtimeBlocker


### PR DESCRIPTION
## Why

Follow-up to #9982 (which added `마지막 행동 이후 <TimeAgo>` beside the `일시정지` pill). Three sibling pills in the same `KeeperRuntimeAlertStrip` still rendered without temporal context, producing the same class of operator misread: a red pill dominates visual hierarchy, the reader defaults to "now", and residual state from 30+ minutes ago reads as a fresh event.

Pills fixed in this PR:

| Pill | State source | Label |
|------|--------------|-------|
| `계속 진행 승인 대기` | `runtime_blocker_continue_gate === true` | warn |
| `Social fallback` | `social_model_recognized === false` | warn |
| `Runtime blocker` (dynamic) | `runtime_blocker_class` present | bad |

## Change

9-line insertion across the three branches of the cascading pill block in `dashboard/src/components/keeper-detail.ts`. Each branch now renders the `TimeAgo` span pattern established by #9982.

## Why `last_autonomous_action_at`

None of these three states has a dedicated `<state>_at` timestamp on the keeper snapshot. All three are set on the same turn that triggered them (the continue-gate flag, the fallback recognition check, and the runtime blocker class are all written in the reconcile/turn path), so `last_autonomous_action_at` coincides within milliseconds. Label stays `마지막 행동 이후` rather than `차단된 지` / `승인 대기 이후` to avoid asserting a stronger claim than the proxy supports (priority tier 2 per #9984 convention).

## Verification

- `bun run typecheck` clean.
- `bun run test` hits the pre-existing `vitest-setup.ts: Cannot redefine property: AArrowDown` issue that also reproduces on the unmodified main branch (same as #9982 test-plan note), so unrelated.
- Paused + continueGate overlap: when both are true, the anchor shows twice in the strip (once from #9982's paused branch, once from this PR's continueGate branch). Treating this as honest duplication rather than adding conditional suppression — visual cost is low, and a small inline abstraction would bloat the component with no reuse site.

## Scope

- 1 file, +9 lines. No type / normalizer / server changes.

## Closes

Part of #9984 (dashboard pill temporal-anchor audit). Remaining callsites tracked there:
- `agent-roster.ts:753`
- `connector-status.ts:964 / 988 / 1029`
- `keeper-memory-tier-panel.ts:157`

## References

- #9982 — first pill fixed (paused)
- #9984 — audit tracking issue with full inventory
- `memory/feedback_ui-status-pill-needs-temporal-anchor.md`