### PR TITLE
fix(keeper): cancel-safe cleanup_tracking in heartbeat finally (#9747 iter 2)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -2317,6 +2317,24 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
              ~keeper_name:live_meta.name
              ~detail)
       in
+      (* Cancel-safe finally (#9747 iter 2): [cleanup_tracking] touches
+         registry state that can raise transiently during shutdown.
+         Stdlib [Fun.protect] would wrap that as [Fun.Finally_raised],
+         masking the body's Cancelled / Keeper_fiber_crash. Swallow
+         Cancelled (the outer one is in flight) and log non-cancel
+         exceptions instead of propagating them. Mirrors
+         keeper_agent_run.ml and keeper_unified_turn.ml:990. *)
+      let safe_cleanup_tracking () =
+        try
+          Keeper_registry.cleanup_tracking
+            ~base_path:ctx.config.base_path live_meta.name
+        with
+        | Eio.Cancel.Cancelled _ -> ()
+        | e ->
+          Log.Keeper.warn
+            "%s: cleanup_tracking in heartbeat finally raised: %s"
+            live_meta.name (Printexc.to_string e)
+      in
       Fun.protect
         (fun () ->
           try
@@ -2348,8 +2366,7 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
                 (Printexc.to_string exn);
               record_crash (Keeper_registry.Exception (Printexc.to_string exn))
             end)
-        ~finally:(fun () ->
-          Keeper_registry.cleanup_tracking ~base_path:ctx.config.base_path live_meta.name)))
+        ~finally:safe_cleanup_tracking))
   )
 ;;
 


### PR DESCRIPTION
## 요약

PR #10003 (iter 1) 후속 — `keeper_keepalive.ml:2351` heartbeat loop 종료 finally의 `Keeper_registry.cleanup_tracking`이 동일한 `Fun.Finally_raised` 위험을 가짐. 같은 cancel-safe 패턴 적용.

Closes #9747.

## Fun.protect audit 결과

`lib/keeper/` 하위 13개 `Fun.protect` 사이트 전수 검토:

| 사이트 | 위험도 | 조치 |
|--------|--------|------|
| `keeper_agent_run.ml:80` — emit_turn_end | 높음 (Eio event emission) | iter 1 (PR #10003) |
| `keeper_unified_turn.ml:990` — unsubscribe+mark_turn_finished | 높음 (Eio fiber teardown) | 이미 fixed |
| `keeper_supervisor.ml:141` — cleanup_tracking + phase publish | 중 | **이미 try/with 감싸져 있음** (L199 주석 "masc-mcp crash 2026-04-17") |
| **`keeper_keepalive.ml:2351` — cleanup_tracking** | **높음** (registry teardown) | **본 PR** |
| `keeper_keepalive.ml:152, 239` — Stdlib.Mutex.unlock | 낮음 | 안전 (Mutex.unlock은 raise 없음) |
| `keeper_keepalive.ml:426` — release_keeper_turn_slot | 낮음 | 안전 (Eio.Semaphore.release + Stdlib.Mutex 전용) |
| `keeper_transition_audit.ml:312, 410` — close_out_noerr | 낮음 | 안전 (`_noerr` variant) |
| `keeper_gh_shared.ml:618`, `keeper_approval_queue.ml:756`, `keeper_stay_silent_loop_detector.ml:24` | 낮음 | 좁은 scope, 별도 iteration 대상 |

## 변경 내용

```diff
+ (* Cancel-safe finally (#9747 iter 2): ... *)
+ let safe_cleanup_tracking () =
+   try
+     Keeper_registry.cleanup_tracking
+       ~base_path:ctx.config.base_path live_meta.name
+   with
+   | Eio.Cancel.Cancelled _ -> ()
+   | e ->
+     Log.Keeper.warn
+       "%s: cleanup_tracking in heartbeat finally raised: %s"
+       live_meta.name (Printexc.to_string e)
+ in
  Fun.protect
    (fun () -> ...)
-   ~finally:(fun () ->
-     Keeper_registry.cleanup_tracking ~base_path:ctx.config.base_path live_meta.name)
+   ~finally:safe_cleanup_tracking
```

## 검증

`dune build @check` exit 0. 기존 heartbeat_loop 동작 불변 (finally는 정상 경로면 그대로 호출, 예외 시에만 분기).

## 회귀 리스크

매우 낮음 — 성공 경로 동일. `cleanup_tracking`이 예외 raise하는 병적 상황에서만 기존 crash → warn 로그로 전환.

## 참고

- Issue #9747 — 4 keeper 동시 crash
- PR #10003 (iter 1) — `keeper_agent_run.ml:80` emit_turn_end
- `keeper_unified_turn.ml:990` — 원본 cancel-safe 패턴 (이미 머지됨)
- `keeper_supervisor.ml:141` — 별도 해결책 (try/with wrap, 2026-04-17 crash 주석)
