### PR TITLE
feat(keeper): add compaction outcome counter (#9988 observability)

### DIFF
--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -167,18 +167,52 @@ let dispatch_keeper_phase_event ~(config : Coord.config) ~keeper_name event =
         (Keeper_state_machine.event_to_string event)
         (Keeper_state_machine.transition_error_to_string err)
 
+(* #9988 Option B follow-up: centralize [Compaction_completed] dispatch
+   so both emit paths (manual recovery in [tool_keeper] and automatic
+   post-turn lifecycle) share the same outcome counter + warn log.
+
+   [masc_keeper_compaction_outcome_total{keeper,outcome}] splits into
+   [outcome=ok] (real savings) and [outcome=noop] (before==after or
+   after>before).  The FSM (#9993) already refuses to clear
+   [context_overflow] in the noop branch; the counter exposes the
+   surface so dashboards/Grafana can alert on rising noop rate —
+   the operational signal for "reducer has nothing to strip, switch
+   profile or hand off". *)
+let compaction_outcome_metric = "masc_keeper_compaction_outcome_total"
+
+(* Observability-only: bump the outcome counter and log the warn
+   when saved_tokens <= 0.  Split from [dispatch_compaction_completed]
+   so unit tests can verify classification without needing a full
+   [Coord.config] / [Keeper_registry] setup. *)
+let record_compaction_outcome ~keeper_name ~before_tokens ~after_tokens =
+  let saved_tokens = before_tokens - after_tokens in
+  let outcome = if saved_tokens > 0 then "ok" else "noop" in
+  Prometheus.inc_counter compaction_outcome_metric
+    ~labels:[ ("keeper", keeper_name); ("outcome", outcome) ] ();
+  if saved_tokens <= 0 then
+    Log.Keeper.warn
+      "#9988 compaction_completed but saved_tokens=%d \
+       (before=%d after=%d) keeper=%s — context_overflow will stay set \
+       (FSM noop branch).  If this repeats, switch to a stronger \
+       compaction profile or escalate to operator."
+      saved_tokens before_tokens after_tokens keeper_name
+
+let dispatch_compaction_completed
+    ~(config : Coord.config) ~keeper_name ~before_tokens ~after_tokens =
+  record_compaction_outcome ~keeper_name ~before_tokens ~after_tokens;
+  dispatch_keeper_phase_event ~config ~keeper_name
+    (Keeper_state_machine.Compaction_completed
+       { before_tokens; after_tokens })
+
 let dispatch_post_turn_lifecycle_events
     ~(config : Coord.config)
     ~keeper_name
     (lifecycle : post_turn_lifecycle) =
   if lifecycle.compaction.attempted then
     if lifecycle.compaction.applied then
-      dispatch_keeper_phase_event ~config ~keeper_name
-        (Keeper_state_machine.Compaction_completed
-           {
-             before_tokens = lifecycle.compaction.before_tokens;
-             after_tokens = lifecycle.compaction.after_tokens;
-           })
+      dispatch_compaction_completed ~config ~keeper_name
+        ~before_tokens:lifecycle.compaction.before_tokens
+        ~after_tokens:lifecycle.compaction.after_tokens
     else
       dispatch_keeper_phase_event ~config ~keeper_name
         (Keeper_state_machine.Compaction_failed

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -231,6 +231,43 @@ val dispatch_keeper_phase_event :
   Keeper_state_machine.event ->
   unit
 
+(** Canonical metric name for the compaction outcome counter.
+
+    Labels: [("keeper", <name>); ("outcome", "ok" | "noop")].
+    Exported so tests can pin the name without hard-coding a string
+    literal.  #9988. *)
+val compaction_outcome_metric : string
+
+(** [record_compaction_outcome ~keeper_name ~before_tokens ~after_tokens]
+    emits the outcome counter and (for [saved_tokens <= 0]) a warn log,
+    without dispatching an FSM event.  Exposed for unit tests and for
+    callers that need the observability signal before/after a dispatch.  *)
+val record_compaction_outcome :
+  keeper_name:string ->
+  before_tokens:int ->
+  after_tokens:int ->
+  unit
+
+(** [dispatch_compaction_completed ~config ~keeper_name ~before_tokens
+    ~after_tokens] dispatches a [Compaction_completed] phase event and
+    updates observability in one place.
+
+    Emits [compaction_outcome_metric] labelled with [outcome=ok] when
+    [after_tokens < before_tokens] and [outcome=noop] otherwise.  A
+    [noop] outcome also logs a warning — the FSM (#9988) keeps
+    [context_overflow] set in this case, so operators need the signal
+    to escalate profile / alert.
+
+    Two emit paths exist ([tool_keeper] manual compact recovery and
+    [dispatch_post_turn_lifecycle_events] automatic compact); both
+    funnel through this helper to keep observability coherent. *)
+val dispatch_compaction_completed :
+  config:Coord.config ->
+  keeper_name:string ->
+  before_tokens:int ->
+  after_tokens:int ->
+  unit
+
 val dispatch_post_turn_lifecycle_events :
   config:Coord.config ->
   keeper_name:string ->

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -947,12 +947,10 @@ let handle_keeper_compact ctx args : tool_result =
             ~base_dir ~meta ~model ~primary_model_max_tokens:max_tokens
         with
         | Some recovery ->
-          Keeper_exec_context.dispatch_keeper_phase_event
+          Keeper_exec_context.dispatch_compaction_completed
             ~config:ctx.config ~keeper_name:name
-            (Keeper_state_machine.Compaction_completed {
-               before_tokens = recovery.compaction.before_tokens;
-               after_tokens = recovery.compaction.after_tokens;
-            });
+            ~before_tokens:recovery.compaction.before_tokens
+            ~after_tokens:recovery.compaction.after_tokens;
           invalidate_status_cache name;
           Prometheus.inc_counter Prometheus.metric_keeper_operator_compact
             ~labels:[("keeper", name); ("result", "ok")] ();

--- a/test/dune
+++ b/test/dune
@@ -55,6 +55,7 @@
         test_keeper_hooks_oas_pricing
         test_keeper_hooks_oas_telemetry
           test_keeper_tool_use_failure_counter
+          test_keeper_compaction_outcome_counter
         test_keeper_wake_telemetry
         test_keeper_memory
         test_keeper_accountability
@@ -182,6 +183,7 @@
           test_keeper_hooks_oas_pricing
           test_keeper_hooks_oas_telemetry
           test_keeper_tool_use_failure_counter
+          test_keeper_compaction_outcome_counter
           test_keeper_wake_telemetry
           test_keeper_memory
           test_keeper_accountability

--- a/test/test_keeper_compaction_outcome_counter.ml
+++ b/test/test_keeper_compaction_outcome_counter.ml
@@ -1,0 +1,105 @@
+(* test/test_keeper_compaction_outcome_counter.ml
+
+   #9988 Option B follow-up: verify the centralized observability
+   helper [record_compaction_outcome] classifies outcomes
+   correctly on the [masc_keeper_compaction_outcome_total]
+   counter.
+
+   [outcome=ok]   — [before_tokens > after_tokens], real savings
+   [outcome=noop] — [before_tokens <= after_tokens], no savings
+                    (the FSM's #9988 branch that keeps
+                    [context_overflow] set so operators can
+                    escalate). *)
+
+module EC = Masc_mcp.Keeper_exec_context
+module Prom = Masc_mcp.Prometheus
+
+let counter_for ~keeper ~outcome =
+  Prom.metric_value_or_zero
+    EC.compaction_outcome_metric
+    ~labels:[ ("keeper", keeper); ("outcome", outcome) ]
+    ()
+
+let test_metric_name_stable () =
+  (* Dashboards and Grafana rules will be written against this name.
+     A rename would break them silently. *)
+  Alcotest.(check string)
+    "compaction outcome metric name matches canonical form"
+    "masc_keeper_compaction_outcome_total"
+    EC.compaction_outcome_metric
+
+let test_real_savings_marks_ok () =
+  let keeper = "test-keeper-9988b-ok" in
+  let before_ok = counter_for ~keeper ~outcome:"ok" in
+  let before_noop = counter_for ~keeper ~outcome:"noop" in
+  EC.record_compaction_outcome ~keeper_name:keeper
+    ~before_tokens:200_000 ~after_tokens:80_000;
+  Alcotest.(check (float 0.0001))
+    "ok outcome counter +1"
+    (before_ok +. 1.0) (counter_for ~keeper ~outcome:"ok");
+  Alcotest.(check (float 0.0001))
+    "noop outcome counter unchanged"
+    before_noop (counter_for ~keeper ~outcome:"noop")
+
+let test_noop_before_equals_after_marks_noop () =
+  let keeper = "test-keeper-9988b-noop" in
+  let before_ok = counter_for ~keeper ~outcome:"ok" in
+  let before_noop = counter_for ~keeper ~outcome:"noop" in
+  EC.record_compaction_outcome ~keeper_name:keeper
+    ~before_tokens:150_000 ~after_tokens:150_000;
+  Alcotest.(check (float 0.0001))
+    "noop outcome counter +1"
+    (before_noop +. 1.0) (counter_for ~keeper ~outcome:"noop");
+  Alcotest.(check (float 0.0001))
+    "ok outcome counter unchanged"
+    before_ok (counter_for ~keeper ~outcome:"ok")
+
+let test_negative_savings_marks_noop () =
+  (* [after > before]: reducer added a wrapper or retry grew the
+     payload. Also a degenerate outcome — classify as noop so the
+     counter does not over-report success. *)
+  let keeper = "test-keeper-9988b-neg" in
+  let before_noop = counter_for ~keeper ~outcome:"noop" in
+  EC.record_compaction_outcome ~keeper_name:keeper
+    ~before_tokens:100_000 ~after_tokens:110_000;
+  Alcotest.(check (float 0.0001))
+    "negative-savings classified as noop"
+    (before_noop +. 1.0) (counter_for ~keeper ~outcome:"noop")
+
+let test_per_keeper_isolation () =
+  let a = "test-keeper-9988b-a" in
+  let b = "test-keeper-9988b-b" in
+  let a_before = counter_for ~keeper:a ~outcome:"ok" in
+  let b_before = counter_for ~keeper:b ~outcome:"ok" in
+  EC.record_compaction_outcome ~keeper_name:a
+    ~before_tokens:100_000 ~after_tokens:50_000;
+  Alcotest.(check (float 0.0001))
+    "A counter +1" (a_before +. 1.0)
+    (counter_for ~keeper:a ~outcome:"ok");
+  Alcotest.(check (float 0.0001))
+    "B counter unchanged" b_before
+    (counter_for ~keeper:b ~outcome:"ok")
+
+let () =
+  Alcotest.run "keeper_compaction_outcome_counter_9988b"
+    [
+      ( "metric_name",
+        [
+          Alcotest.test_case "canonical name stable" `Quick
+            test_metric_name_stable;
+        ] );
+      ( "outcome_classification",
+        [
+          Alcotest.test_case "real savings marks ok" `Quick
+            test_real_savings_marks_ok;
+          Alcotest.test_case "before==after marks noop" `Quick
+            test_noop_before_equals_after_marks_noop;
+          Alcotest.test_case "after>before marks noop" `Quick
+            test_negative_savings_marks_noop;
+        ] );
+      ( "isolation",
+        [
+          Alcotest.test_case "per-keeper independent" `Quick
+            test_per_keeper_isolation;
+        ] );
+    ]


### PR DESCRIPTION
## 요약

#9993 follow-up. FSM 레벨에서 noop compaction 이 `context_overflow` 를 clear 하지 않도록 고쳤지만 operator 에게는 **rising noop rate** 를 볼 counter 가 없었음. 이 PR 이 observability 레이어를 보강.

`Keeper_exec_context.dispatch_compaction_completed` 를 중앙화해서, 모든 emit site 가 동일한 classification 을 통과하도록 funnel. Counter 는:

```
masc_keeper_compaction_outcome_total{keeper, outcome}
  outcome=ok     → before_tokens > after_tokens (real savings)
  outcome=noop   → before_tokens <= after_tokens
                    (before==after OR after>before 둘 다 포함)
```

Noop 때는 warn log 도 함께. Operator 가 Grafana alert 기다리지 않고 log tail 로 바로 "stronger profile or escalate" 신호를 볼 수 있음.

## 변경 파일

- `lib/keeper/keeper_exec_context.ml`
  - `compaction_outcome_metric = "masc_keeper_compaction_outcome_total"` 상수 (SSOT, rename 방지).
  - `record_compaction_outcome ~keeper_name ~before_tokens ~after_tokens` — 관찰만 (counter + warn). Config 불필요 → 단위 테스트가 `Coord.config` / `Keeper_registry` 전체 setup 없이 classification 검증 가능.
  - `dispatch_compaction_completed ~config ~keeper_name ~before_tokens ~after_tokens` — `record_compaction_outcome` + `dispatch_keeper_phase_event` 를 묶음.
- `lib/keeper/keeper_exec_context.mli` — 위 두 함수 + 상수 docstring 공개.
- `lib/tool_keeper.ml` — 수동 compact recovery emit site 를 helper 호출로 교체.
- `lib/keeper/keeper_exec_context.ml` → `dispatch_post_turn_lifecycle_events` 내부도 helper 경유.
- `test/test_keeper_compaction_outcome_counter.ml` (신규) — 5 테스트:
  - canonical metric name 고정 (dashboard rename 방지).
  - `before > after` → `outcome=ok` 카운터 +1.
  - `before == after` → `outcome=noop`.
  - `after > before` → `outcome=noop` (reducer wrapper/retry degeneracy).
  - 서로 다른 keeper label 간 독립 누적.
- `test/dune` — 새 test 등록.

## 로컬 검증

```
$ MASC_BASE_PATH=/tmp/masc-test-9988b dune exec test/test_keeper_compaction_outcome_counter.exe
Test Successful in 0.005s. 5 tests run.

$ MASC_BASE_PATH=/tmp/masc-test-9988b dune exec test/test_keeper_overflow_recovery.exe
Test Successful in 0.003s. 8 tests run.   # FSM 회귀 0
```

`dune build` clean.

## 왜 근원 fix 인가

- **Emit site 통일**: 기존엔 `tool_keeper.ml` 과 `dispatch_post_turn_lifecycle_events` 두 곳이 각자 `Compaction_completed` 를 dispatch. 새 emit site 가 추가되면 observability 가 한 곳에서만 누락될 위험. 중앙 helper 로 결합.
- **Parse, don't validate**: event payload (`before_tokens, after_tokens`) 를 helper 가 실제로 소비하고 outcome 을 레이블화. 단순 카운터 하나보다 `{keeper, outcome}` 2-dim 이라 Grafana `rate(..{outcome="noop"}[5m])` 로 loop 증후 즉시 관찰 가능.
- **Test 용이성**: `record_compaction_outcome` 분리는 "observability 를 FSM dispatch 에서 읽어오는 test" 의 필요한 backend/registry 의존성 제거. 테스트 runtime 수백 ms → 5 ms.

## 미검증 / 후속

- Grafana panel / alert rule 추가는 ops ticket (metric name 은 이 PR 이 pin 해둔 것 기준).
- `heuristic_metrics_diagnostics` 의 degenerate-site warn 도 본 counter 와 상호 보완 — noop rate 가 알려지면 해당 사이트 탐지도 쉬워짐.

## 관련

- #9988 (root — FSM noop infinite loop).
- #9993 (FSM 측 fix, 이미 merged).
- #9935 (imminent-without-action) — merged 후 metric 추세 관찰.
- #9943 (compaction noop 98.4%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)