### PR TITLE
fix(dashboard): anchor stateNote + connector warn pills with time-since signal

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -753,6 +753,9 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                   <span class="inline-flex items-center rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-0.5 text-3xs font-semibold text-[var(--warn)]">
                     ${stateNote.label}
                   </span>
+                  ${lastActivityAt
+                    ? html`<span class="text-3xs text-[var(--text-muted)]">최근 활동 이후 <${TimeAgo} timestamp=${lastActivityAt} /></span>`
+                    : null}
                   <span class="min-w-0 flex-1 text-xs leading-relaxed text-[var(--text-body)] break-words line-clamp-2" title=${stateNote.text}>
                     ${stateNote.text}
                   </span>

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -967,6 +967,9 @@ function ConnectorLivePanel({
                 <span aria-hidden="true">⚠</span>
                 <span>Directory error</span>
               </span>
+              ${connector?.gate_health_checked_at
+                ? html`<span class="text-3xs text-[var(--text-dim)]">checked ${timeAgo(connector.gate_health_checked_at)}</span>`
+                : null}
               <div class="mt-1">
                 <span class="font-medium">Cause: </span> keeper directory unavailable, manual entry only.
               </div>
@@ -1034,6 +1037,9 @@ function ConnectorLivePanel({
                       <span>Not running</span>
                     </span>
                     <span class="font-medium text-[var(--text-body)]">Sidecar not started</span>
+                    ${connector?.updated_at
+                      ? html`<span class="text-3xs text-[var(--text-dim)]">last seen ${timeAgo(connector.updated_at)}</span>`
+                      : null}
                   </div>
                   <div class="flex items-center gap-2">
                     <${ActionButton}

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -1026,8 +1026,8 @@ function ConnectorLivePanel({
                 class="mt-3 rounded border border-dashed border-[var(--warn-20)] border-l-4 border-l-amber-500 bg-[var(--warn-10)] px-3 py-3 text-xs"
                 data-sidecar-not-started-panel
               >
-                <div class="mb-1 flex items-center justify-between gap-2">
-                  <div class="flex items-center gap-2">
+                <div class="mb-1 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <div class="flex flex-wrap items-center gap-2">
                     <span
                       class="inline-flex items-center gap-1 rounded-sm border border-[var(--warn-20)] bg-[var(--warn-10)] px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-4 text-[var(--warn)]"
                       aria-label="Sidecar process status: not running"
@@ -1041,7 +1041,7 @@ function ConnectorLivePanel({
                       ? html`<span class="text-3xs text-[var(--text-dim)]">last seen ${timeAgo(connector.updated_at)}</span>`
                       : null}
                   </div>
-                  <div class="flex items-center gap-2">
+                  <div class="flex flex-wrap items-center gap-2 sm:justify-end">
                     <${ActionButton}
                       variant="primary"
                       size="sm"


### PR DESCRIPTION
## Why

Cross-file follow-up to #9982 (`일시정지`) and #10007 (3 sibling pills in `keeper-detail.ts`), under the tracking issue #9984.

Same class of bug observed across the dashboard: event-like warn/bad pills dominate visual hierarchy and default the operator's mental model to "now", even when the underlying state is residual or stale.

## Change

Three pills in two files, each gets an inline temporal anchor using a proxy timestamp that's already present on the existing snapshot shape — no server changes.

| File | Pill | Proxy | Label |
|------|------|-------|-------|
| `agent-roster.ts` | `stateNote` (`현재 차단` / `최근 오류` / `상태 메모`) | `lastActivityAt` (already computed, 3-tier fallback) | `최근 활동 이후 <TimeAgo>` |
| `connector-status.ts` | `Directory error` | `connector.gate_health_checked_at` | `checked <timeAgo(...)>` |
| `connector-status.ts` | `Sidecar not started` | `connector.updated_at` | `last seen <timeAgo(...)>` |

## Why not the other two from #9984

- **`connector-status.ts:988` `Not configured`** — intentionally skipped. Memory file's explicit counter-case: "steady-state pills that genuinely mean 'right now, by policy'". No config files means setup was never done — it's not a stale residual of a prior state. Applying a timestamp here would invent meaning.

- **`keeper-memory-tier-panel.ts:157` `compacting`** — intentionally skipped. The composite snapshot's `compaction` object only carries `{ stage }`; there's no `compaction_started_at` or snapshot `captured_at`. Per the memory file priority tier 3 ("If neither exists — add the server-side field rather than shipping a pill that silently defaults to 'now'"), the correct next step is a backend change, not a UI hack. Logged on #9984 for follow-up.

## Label vocabulary

- `agent-roster` uses `최근 활동 이후` (Korean UI, matches footer activity pill's existing label).
- `connector-status` uses `checked` / `last seen` (English UI — that file's copy is all English: `Directory error`, `Not running`, `Sidecar not started`).
- Intent: label must be honest about the proxy. `checked` = "we last probed at this time", not "directory broke at this time". `last seen` = "runtime heartbeat timestamp", not "sidecar died then".

## Verification

- `bun run typecheck` clean (both files).
- `bun run test` hits the same pre-existing `vitest-setup.ts AArrowDown` issue as #9982 / #10007 — reproducible on unmodified main, unrelated to this PR.
- Within-file consistency: `connector-status.ts` uses the local `timeAgo()` string helper (L841 `hb ${timeAgo(...)}` pattern) rather than the `TimeAgo` component, to avoid mixing two time-rendering idioms in the same file.

## Scope

- 2 files, +9 / -0. No type / normalizer / server changes.

## References

- #9982 — first pill fixed (paused)
- #10007 — 3 sibling pills in keeper-detail.ts
- #9984 — audit tracking issue (inventory + convention)
- `memory/feedback_ui-status-pill-needs-temporal-anchor.md`