### PR TITLE
fix(dashboard): reconnect after websocket hello timeout

### DIFF
--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -7,7 +7,12 @@ import {
   parseWebSocketSseFrames,
   subscribeDashboardRoute,
 } from './dashboard-ws'
-import { dashboardWsLastSeq } from './dashboard-ws-state'
+import {
+  dashboardWsConnected,
+  dashboardWsLastError,
+  dashboardWsLastSeq,
+  dashboardWsReady,
+} from './dashboard-ws-state'
 
 interface JsonRpcRequest {
   id: number
@@ -99,7 +104,10 @@ async function flushPromises(): Promise<void> {
 
 afterEach(() => {
   disconnectDashboardWS()
+  dashboardWsConnected.value = false
+  dashboardWsLastError.value = null
   dashboardWsLastSeq.value = 0
+  dashboardWsReady.value = false
   vi.useRealTimers()
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
@@ -244,6 +252,32 @@ describe('dashboard websocket route subscriptions', () => {
       result: { snapshot: { seq: 7, slices: {} } },
     })
     await flushPromises()
+  })
+
+  it('reconnects when the hello handshake never responds', async () => {
+    vi.useFakeTimers()
+    installWebSocketMocks()
+
+    await connectDashboardWS({ tab: 'workspace', params: { section: 'board' } })
+    const firstSocket = mockSockets[0]!
+    firstSocket.open()
+    const hello = parseRpc(firstSocket, 0)
+    expect(hello.method).toBe('dashboard/hello')
+    expect(dashboardWsConnected.value).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(15_000)
+    await flushPromises()
+
+    expect(firstSocket.readyState).toBe(MockWebSocket.CLOSED)
+    expect(dashboardWsConnected.value).toBe(false)
+    expect(dashboardWsReady.value).toBe(false)
+    expect(dashboardWsLastError.value).toBe('dashboard websocket rpc timed out: dashboard/hello')
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    await flushPromises()
+
+    expect(mockSockets).toHaveLength(2)
+    expect(mockSockets[1]!.readyState).toBe(MockWebSocket.CONNECTING)
   })
 
   it('ignores stale subscribe snapshots that arrive after a newer route subscription', async () => {

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -345,6 +345,7 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
       features: ['snapshot', 'delta', 'mode_snapshot'],
     })
       .then(() => {
+        if (socket !== ws) return
         dashboardWsReady.value = true
         dashboardWsLastError.value = null
         if (desiredRouteState) {
@@ -352,8 +353,13 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
         }
       })
       .catch(err => {
+        if (socket !== ws) return
+        dashboardWsConnected.value = false
         dashboardWsReady.value = false
         dashboardWsLastError.value = err instanceof Error ? err.message : String(err)
+        lastSubscribeKey = ''
+        closeSocket()
+        scheduleReconnect()
       })
   }
   ws.onmessage = (event) => {


### PR DESCRIPTION
## Summary

- close the dashboard WebSocket when the `dashboard/hello` RPC fails or times out
- schedule reconnect after a failed hello so an OPEN-but-not-ready socket cannot block recovery
- ignore stale hello resolution/rejection from sockets that are no longer current
- add a regression test for a stalled hello handshake

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec vitest run src/dashboard-ws.test.ts --no-file-parallelism --maxWorkers=1 --reporter=verbose`
