### PR TITLE
fix(keeper-heuristics): sentinel 1.0 for unmeasurable alignment (#10012)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -787,7 +787,14 @@ let write_heartbeat_snapshot
       match latest_user_message, latest_assistant_message with
       | Some user_message, Some assistant_message ->
         jaccard_similarity user_message assistant_message
-      | _ -> 0.0
+      | _ ->
+        (* Unmeasurable (status_tick, heartbeat, empty reply): use the
+           sentinel [1.0] so the plan gate [<= 0.100] and guardrail gate
+           [<= floor] do NOT fire. [0.0] was a permissive default that
+           conflated "no alignment measurable" with "no alignment at
+           all", triggering auto_plan on every status_tick (#10012).
+           CLAUDE.md anti-pattern #2: Unknown → Permissive Default. *)
+        1.0
     in
     let context_ratio_v = match ctx_opt with
       | Some c -> Keeper_exec_context.context_ratio c

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -231,7 +231,13 @@ let goal_alignment_score
     ~(user_message : string option)
     ~(assistant_reply : string option) : float =
   let goals = goal_horizon_candidates meta in
-  if goals = [] then 0.0
+  (* Unmeasurable → sentinel [1.0] so [plan_goal_alignment_threshold <= X]
+     and [guardrail_goal_alignment_threshold <= floor] gates do NOT
+     fire; [goal_drift = 1.0 - alignment] then reads 0.0 (no drift).
+     [0.0] was a permissive default that conflated "no goal data" with
+     "total misalignment", triggering auto_plan on every status_tick
+     (#10012). CLAUDE.md anti-pattern #2: Unknown → Permissive Default. *)
+  if goals = [] then 1.0
   else
     let user_score =
       match user_message with
@@ -244,7 +250,7 @@ let goal_alignment_score
       | Some text -> Some (best_goal_similarity ~text ~goals)
     in
     match user_score, reply_score with
-    | None, None -> 0.0
+    | None, None -> 1.0
     | Some s, None | None, Some s -> s
     | Some u, Some r -> (u +. r) /. 2.0
 

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -276,6 +276,33 @@ let test_evaluate_keeper_auto_rules_plan_requires_both_low () =
   in
   check bool "public evaluator uses same plan contract" false eval.plan
 
+(* #10012: status_tick / heartbeat / empty-reply turns used to trigger
+   plan because the [goal_alignment_score] fallback was 0.0 — conflating
+   "no data to measure alignment" with "total misalignment". The plan
+   gate [goal_alignment <= 0.060] then fired on every such turn.  The
+   fixed sentinel is 1.0 ("perfect alignment" ≡ "no intervention
+   needed when we cannot measure"); the complement [goal_drift = 0.0]
+   also reads clean, so neither the plan gate nor the drift-alert
+   gate false-fires. *)
+let test_goal_alignment_score_missing_messages_returns_sentinel () =
+  let meta = keeper_meta ~name:"ga-keeper" ~mention_targets:["ga-keeper"] () in
+  (* goal_horizon_candidates may return [] for the bare meta — this case
+     is the first arm of the fix (goals = [] → 1.0). *)
+  let empty_goals_score =
+    Keeper_memory_recall.goal_alignment_score
+      ~meta ~user_message:None ~assistant_reply:None
+  in
+  check (float 0.001)
+    "goal_alignment=1.0 when no goals AND no messages (#10012)"
+    1.0 empty_goals_score;
+  let missing_both_score =
+    Keeper_memory_recall.goal_alignment_score
+      ~meta ~user_message:None ~assistant_reply:None
+  in
+  check (float 0.001)
+    "goal_alignment=1.0 when both messages missing (#10012)"
+    1.0 missing_both_score
+
 (* --- history recall tests --- *)
 
 let test_tmpdir () =
@@ -1194,6 +1221,8 @@ let () =
             test_auto_rule_eval_of_measurement_plan_requires_both_low;
           test_case "public evaluator plan requires both low" `Quick
             test_evaluate_keeper_auto_rules_plan_requires_both_low;
+          test_case "goal_alignment_score returns sentinel on missing messages (#10012)" `Quick
+            test_goal_alignment_score_missing_messages_returns_sentinel;
         ] );
       ( "e2e_memory_pipeline",
         [


### PR DESCRIPTION
## 요약

`response_alignment`와 `goal_alignment_score`가 측정 불가 상황(status_tick, heartbeat, empty reply)에서 `0.0`으로 fallback → plan gate `x <= 0.100` 자동 trigger. "측정 불가"와 "총 misalignment"를 혼동한 CLAUDE.md anti-pattern #2 "Unknown → Permissive Default".

Closes #10012.

## 증상

scholar status_tick 2026-04-24 metric:

```json
{
  "work_kind": "status_tick",
  "auto_rules": {
    "goal_alignment": 0.019,
    "response_alignment": 0.0,
    "goal_drift": 0.981,
    "plan": true,
    "reasons": ["plan(goal_alignment=0.019<=0.060,response_alignment=0.000<=0.100)"]
  }
}
```

`status_tick`은 user prompt가 없는 snapshot — plan할 "응답"이 존재하지 않는 turn인데도 plan 발화.

## 근본 원인

### `keeper_keepalive.ml:786-790`

```ocaml
let response_alignment =
  match latest_user_message, latest_assistant_message with
  | Some user_message, Some assistant_message ->
    jaccard_similarity user_message assistant_message
  | _ -> 0.0   (* ← permissive default *)
```

### `keeper_memory_recall.ml:234, 247`

```ocaml
if goals = [] then 0.0   (* 234 *)
...
| None, None -> 0.0      (* 247 *)
```

세 사이트 모두 "측정 불가 → 0.0" 압축. 하류 gate `x <= 0.100`가 0.0을 항상 통과시킴 → 매 status_tick마다 plan=true.

`goal_drift = 1.0 - goal_alignment`이므로 alignment 낮은 fallback이 drift 높은 fallback을 생성 — 같은 bug의 mirror.

## 변경 내용

세 fallback 사이트를 `1.0` (perfect alignment ≡ "no intervention needed when we cannot measure")으로 전환:

```diff
- | _ -> 0.0
+ | _ ->
+   (* Unmeasurable ... sentinel [1.0] so gates don't fire ... *)
+   1.0
```

```diff
- if goals = [] then 0.0
+ if goals = [] then 1.0
```

```diff
- | None, None -> 0.0
+ | None, None -> 1.0
```

합법적인 `0.0` (두 메시지 존재 + jaccard_similarity=0) 경로는 불변. 오직 fallback만 전환.

## 효과

| 상황 | Before | After |
|------|--------|-------|
| 두 메시지 모두 존재, jaccard=0 | 0.0 (legit) | 0.0 (unchanged) |
| 두 메시지 모두 존재, jaccard=0.5 | 0.5 | 0.5 (unchanged) |
| status_tick (messages=None) | 0.0 → plan=true ❌ | 1.0 → plan=false ✅ |
| goals=[] + messages=None | 0.0 → plan=true ❌ | 1.0 → plan=false ✅ |
| goal_drift 표시 | 0.981 (fake drift) ❌ | 0.0 (no drift) ✅ |

## 검증

```bash
$ dune exec --root . test/test_keeper_memory.exe
# → Test Successful in 0.047s. 63 tests run.  (기존 62 + 새로 1)
```

새 테스트 `test_goal_alignment_score_missing_messages_returns_sentinel`가 sentinel 값을 pin.

## 회귀 리스크

매우 낮음 — fallback 경로만 전환. Plan gate와 guardrail gate가 False-positive를 생성하던 경로가 No-op으로 전환되는 효과 → 이미 **의미 없는** plan/alerting trigger 제거. 다른 코드 경로 영향 없음.

## Out of scope — 후속 권장

이슈 Option A (Option type 마이그레이션)는 telemetry에서 "측정 0"과 "측정 불가"를 구분하는 principled fix. `Keeper_measurement.capture` 시그니처 변경이 필요해 별도 PR로 분리. 본 PR은 acute auto_plan mis-fire만 차단.

## 참고

- Issue #10012 — 증상 + 3 fix 제안
- CLAUDE.md software-development.md § AI 코드 생성 안티패턴 #2 "Unknown → Permissive Default"
- 관련: #9919 (heuristic_metrics degenerate — 같은 anti-pattern의 다른 얼굴)
