### PR TITLE
ci: gate agent ready prs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -692,6 +692,22 @@ jobs:
     timeout-minutes: 2
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Enforce agent draft policy on merge gate
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          PR_IS_DRAFT: ${{ github.event.pull_request.draft }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          AGENT_DRAFT_GUARD_TITLE_RE: ${{ vars.AGENT_DRAFT_GUARD_TITLE_RE }}
+          AGENT_DRAFT_GUARD_BRANCH_RE: ${{ vars.AGENT_DRAFT_GUARD_BRANCH_RE }}
+          AGENT_DRAFT_GUARD_BYPASS_LABELS: ${{ vars.AGENT_DRAFT_GUARD_BYPASS_LABELS }}
+        run: scripts/ci/check-agent-draft-policy.sh
+
       - name: Aggregate required check status
         env:
           PR_SYNC_RESULT: ${{ needs.pr-sync-check.result }}

--- a/scripts/ci/check-agent-draft-policy.sh
+++ b/scripts/ci/check-agent-draft-policy.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+title_re="${AGENT_DRAFT_GUARD_TITLE_RE:-^\[codex\]}"
+branch_re="${AGENT_DRAFT_GUARD_BRANCH_RE:-^(codex[/-]|keeper[/-])}"
+bypass_labels_csv="${AGENT_DRAFT_GUARD_BYPASS_LABELS:-human-approved-ready}"
+
+event_name="${GITHUB_EVENT_NAME:-}"
+if [[ "$event_name" != "pull_request" ]]; then
+  echo "agent draft policy: skipped for event ${event_name:-unknown}"
+  exit 0
+fi
+
+pr_is_draft="${PR_IS_DRAFT:-false}"
+pr_title="${PR_TITLE:-}"
+pr_head_ref="${PR_HEAD_REF:-}"
+pr_labels_csv="${PR_LABELS:-}"
+
+lower() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+csv_has_label() {
+  local csv="$1"
+  local wanted
+  wanted="$(lower "$2")"
+  local item
+  IFS=',' read -r -a items <<<"$csv"
+  for item in "${items[@]}"; do
+    item="$(lower "$(printf '%s' "$item" | xargs)")"
+    if [[ "$item" == "$wanted" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+looks_agent_authored=0
+if [[ "$pr_title" =~ $title_re || "$pr_head_ref" =~ $branch_re ]]; then
+  looks_agent_authored=1
+elif csv_has_label "$pr_labels_csv" "agent-pr" || csv_has_label "$pr_labels_csv" "codex"; then
+  looks_agent_authored=1
+fi
+
+if [[ "$looks_agent_authored" -eq 0 ]]; then
+  echo "agent draft policy: skipped for non-agent PR"
+  exit 0
+fi
+
+if [[ "$(lower "$pr_is_draft")" == "true" ]]; then
+  echo "agent draft policy: pass, agent PR remains draft"
+  exit 0
+fi
+
+bypass_present=0
+IFS=',' read -r -a bypass_labels <<<"$bypass_labels_csv"
+for label in "${bypass_labels[@]}"; do
+  label="$(printf '%s' "$label" | xargs)"
+  [[ -n "$label" ]] || continue
+  if [[ "$(lower "$label")" == "allow-auto-merge" ]]; then
+    echo "agent draft policy: ignoring automation-prone bypass label ${label}"
+    continue
+  fi
+  if csv_has_label "$pr_labels_csv" "$label"; then
+    bypass_present=1
+    echo "agent draft policy: pass, bypass label present: ${label}"
+    break
+  fi
+done
+
+if [[ "$bypass_present" -eq 1 ]]; then
+  exit 0
+fi
+
+echo "::error title=Agent draft policy violation::agent-like PR '${pr_head_ref}' is ready without an approved bypass label (${bypass_labels_csv}). Keep it draft or add an approved human bypass label."
+exit 1

--- a/scripts/pr-open.sh
+++ b/scripts/pr-open.sh
@@ -189,4 +189,9 @@ echo "PR: $pr_url"
 
 if [[ $watch_checks -eq 1 ]]; then
   gh pr checks "$pr_number" --repo "$repo" --watch || true
+  echo "PR status:"
+  gh pr view "$pr_number" --repo "$repo" \
+    --json state,isDraft,mergeStateStatus,headRefOid,url \
+    --jq '"state=\(.state) draft=\(.isDraft) mergeState=\(.mergeStateStatus) head=\(.headRefOid)\nurl=\(.url)"' \
+    || true
 fi

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -42,6 +42,28 @@ let file_pattern_position file_rel pattern =
         let re = Str.regexp_string pattern in
         try Some (Str.search_forward re content 0) with Not_found -> None)
 
+let source_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root -> root
+  | None -> Sys.getcwd ()
+
+let quote = Filename.quote
+
+let run_agent_draft_policy env =
+  let env_prefix =
+    env
+    |> List.map (fun (k, v) -> Printf.sprintf "%s=%s" k (quote v))
+    |> String.concat " "
+  in
+  let script =
+    Filename.concat (source_root ()) "scripts/ci/check-agent-draft-policy.sh"
+  in
+  let cmd =
+    Printf.sprintf "cd %s && %s bash %s >/dev/null 2>&1"
+      (quote (source_root ())) env_prefix (quote script)
+  in
+  Sys.command cmd
+
 let test_ci_sync_and_asset_contracts () =
   check bool "pr sync script added" true
     (file_contains_pattern "scripts/check-pr-sync.sh" "workflow payload head");
@@ -51,8 +73,44 @@ let test_ci_sync_and_asset_contracts () =
     (file_contains_pattern ".github/workflows/ci.yml" "Verify PR sync");
   check bool "ci workflow passes pr number to sync check" true
     (file_contains_pattern ".github/workflows/ci.yml" "--pr-number \"$PR_NUMBER\"");
+  check bool "ci gate enforces agent draft policy" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "Enforce agent draft policy on merge gate");
+  check bool "ci gate uses agent draft policy script" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "scripts/ci/check-agent-draft-policy.sh");
   check bool "pr hygiene no longer checks dashboard assets (gitignored)" true
     (not (file_contains_pattern "scripts/check-pr-hygiene.sh" "dashboard source or Vite config changed but assets/dashboard was not updated"))
+
+let test_agent_draft_policy_script () =
+  let base =
+    [
+      ("GITHUB_EVENT_NAME", "pull_request");
+      ("PR_TITLE", "fix: keep long turns visibly alive");
+      ("PR_HEAD_REF", "codex/keeper-process-evidence");
+      ("PR_LABELS", "");
+    ]
+  in
+  check int "non pull_request events are ignored" 0
+    (run_agent_draft_policy [ ("GITHUB_EVENT_NAME", "push") ]);
+  check int "draft agent PR passes" 0
+    (run_agent_draft_policy (("PR_IS_DRAFT", "true") :: base));
+  check bool "ready agent PR without bypass fails" true
+    (run_agent_draft_policy (("PR_IS_DRAFT", "false") :: base) <> 0);
+  check int "ready agent PR with bypass label passes" 0
+    (run_agent_draft_policy
+       (("PR_IS_DRAFT", "false")
+       :: ("PR_LABELS", "enhancement,human-approved-ready")
+       :: List.remove_assoc "PR_LABELS" base));
+  check int "ready non-agent PR passes" 0
+    (run_agent_draft_policy
+       [
+         ("GITHUB_EVENT_NAME", "pull_request");
+         ("PR_IS_DRAFT", "false");
+         ("PR_TITLE", "fix: human authored branch");
+         ("PR_HEAD_REF", "feature/human-branch");
+         ("PR_LABELS", "enhancement");
+       ])
 
 let test_health_and_ci_runner_diagnostics () =
   check bool "health snapshot records baseline source" true
@@ -692,9 +750,13 @@ let test_transport_route_contracts () =
     h2_delete_path_verifies_full_mcp_auth;
   check bool "h2 gateway webrtc routes enforce tool auth" true
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
-       {|authorize_tool_request
-                ~base_path:state.Mcp_server.room_config.base_path
-                ~tool_name:"masc_webrtc_offer"|});
+       {|authorize_tool_request|}
+    && file_contains_pattern "lib/server/server_h2_gateway.ml"
+         {|~base_path:state.Mcp_server.room_config.base_path|}
+    && file_contains_pattern "lib/server/server_h2_gateway.ml"
+         {|~tool_name:"masc_webrtc_offer"|}
+    && file_contains_pattern "lib/server/server_h2_gateway.ml"
+         {|~tool_name:"masc_webrtc_answer"|});
   check bool "h2 gateway respects webrtc disabled state" true
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
        {|Server_webrtc_transport.is_enabled ()|})
@@ -778,9 +840,9 @@ let test_dashboard_timeout_guard_contracts () =
   check bool "h2 dashboard shell route threads state clock" true
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
        "dashboard_shell_http_json ?clock:state.Mcp_server.clock");
-  check bool "h2 transport health route uses transport metrics" true
+  check bool "h2 transport health route uses cached dashboard helper" true
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
-       "Transport_metrics.transport_health_json");
+       "dashboard_transport_health_http_json ~state");
   check bool "server dashboard transport health helper uses cached surface" true
     (file_contains_pattern "lib/server/server_dashboard_http_execution_surfaces.ml"
        {|cached_surface_json _transport_health_cache|});
@@ -849,6 +911,8 @@ let () =
     [
       ("source_guard", [
            test_case "sync and asset contracts" `Quick test_ci_sync_and_asset_contracts;
+           test_case "agent draft policy script" `Quick
+             test_agent_draft_policy_script;
            test_case "contract harness and team session authz contracts" `Quick
              test_contract_harness_and_execution_session_authz_contracts;
            test_case "health and ci diagnostics" `Quick test_health_and_ci_runner_diagnostics;

--- a/test/test_pr_open_script.ml
+++ b/test/test_pr_open_script.ml
@@ -102,18 +102,30 @@ case "${cmd1}:${cmd2}" in
     printf 'https://github.com/example/test/pull/42\n'
     ;;
   pr:view)
-    if [ "${3:-}" = "https://github.com/example/test/pull/42" ]; then
-      printf '42\n'
-    else
-      printf 'https://github.com/example/test/pull/42\n'
-    fi
+    args="$*"
+    case "$args" in
+      *"state,isDraft,mergeStateStatus,headRefOid,url"*)
+        printf 'state=OPEN draft=true mergeState=CLEAN head=abc123\nurl=https://github.com/example/test/pull/42\n'
+        ;;
+      *)
+        if [ "${3:-}" = "https://github.com/example/test/pull/42" ]; then
+          printf '42\n'
+        else
+          printf 'https://github.com/example/test/pull/42\n'
+        fi
+        ;;
+    esac
     ;;
   api:*)
     cat >"$labels_file"
     ;;
   pr:checks)
-    printf 'unexpected pr checks invocation\n' >&2
-    exit 1
+    if [ "${FAKE_GH_ALLOW_CHECKS:-}" = "1" ]; then
+      printf 'checks ok\n'
+    else
+      printf 'unexpected pr checks invocation\n' >&2
+      exit 1
+    fi
     ;;
   *)
     printf 'unexpected gh invocation: %s %s\n' "$cmd1" "$cmd2" >&2
@@ -204,6 +216,46 @@ let test_script_runs_under_system_bash_without_watch () =
       check bool "does not add docs label for code-only change" false
         (contains_substring labels "\"docs\""))
 
+let test_script_prints_final_status_after_watch () =
+  with_temp_dir "pr-open-script-watch-status" (fun dir ->
+      init_repo_with_remote dir;
+      let fake_gh_dir = make_fake_gh dir in
+      let gh_log = Filename.concat dir "gh.log" in
+      let gh_labels = Filename.concat dir "gh-labels.json" in
+      let body_file = Filename.concat dir "body.md" in
+      write_file body_file
+        "## Summary\nTest body\n\n## Product impact\n- Promise affected: `none/internal`\n- User-visible change: none\n\n## Evidence\n- local script test\n\n## Review evidence\n- not applicable for script test\n\n## Linked issue\n- Refs #1234\n";
+      let path =
+        Printf.sprintf "%s:%s" fake_gh_dir
+          (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
+      in
+      let env =
+        [
+          ("PATH", path);
+          ("FAKE_GH_LOG", gh_log);
+          ("FAKE_GH_LABELS", gh_labels);
+          ("FAKE_GH_ALLOW_CHECKS", "1");
+        ]
+      in
+      let cmd =
+        Printf.sprintf "/bin/bash %s --repo %s --title %s --body-file %s"
+          (quote (script_path ()))
+          (quote "example/test")
+          (quote "fix: print final status")
+          (quote body_file)
+      in
+      let code, stdout, stderr = run_shell ~cwd:dir ~env cmd in
+      if code <> 0 then
+        failf "pr-open failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout stderr;
+      check bool "runs watched checks" true
+        (contains_substring (read_file gh_log) "pr checks");
+      check bool "prints final status heading" true
+        (contains_substring stdout "PR status:");
+      check bool "prints final draft state" true
+        (contains_substring stdout "draft=true");
+      check bool "prints final merge state" true
+        (contains_substring stdout "mergeState=CLEAN"))
+
 let test_script_rejects_body_missing_required_sections () =
   with_temp_dir "pr-open-script-missing-sections" (fun dir ->
       init_repo_with_remote dir;
@@ -290,6 +342,8 @@ let () =
             test_source_avoids_mapfile_only_bash4_features;
           test_case "runs under system bash without watch" `Quick
             test_script_runs_under_system_bash_without_watch;
+          test_case "prints final status after watch" `Quick
+            test_script_prints_final_status_after_watch;
           test_case "rejects body missing required sections" `Quick
             test_script_rejects_body_missing_required_sections;
           test_case "rejects staged changes before push" `Quick


### PR DESCRIPTION
## Summary
- connect the draft PR safety guard to the required `CI Gate` path
- make `scripts/pr-open.sh` print final PR state after check watching
- refresh brittle source guards for current H2 WebRTC and transport-health contracts

## Product impact
- Promise affected: `operator workflow safety`
- User-visible change: agent-authored ready PRs without an approved bypass label now fail the required merge gate, and PR opening leaves clearer final state evidence.

## Evidence
- `git diff --check origin/main...HEAD`
- `scripts/dune-local.sh build test/test_ci_hardening_source.exe test/test_pr_open_script.exe` passed before rebase; after rebase, shared dune lock blocked a repeat wrapper build
- `./_build/default/test/test_ci_hardening_source.exe` passed after rebase, 35 tests
- `./_build/default/test/test_pr_open_script.exe` passed after rebase, 5 tests

## Review evidence
- Root cause from prior PR flow: `Draft Auto-Merge Guard` was an automation workflow, but `CI Gate` is the effective required merge gate.
- This change leaves human bypass possible via configured bypass labels while blocking accidental ready/merge states for codex/keeper branches.

## Linked issue
- Follow-up from keeper autonomy/process hardening investigation.
