### PR TITLE
[codex] Lazy-load dashboard markdown renderer

### DIFF
--- a/dashboard/src/components/common/cytoscape-fsm.ts
+++ b/dashboard/src/components/common/cytoscape-fsm.ts
@@ -1,5 +1,5 @@
 // CytoscapeFSM — Reusable interactive state machine visualization.
-// Uses Cytoscape.js (already bundled via mermaid) for pan/zoom/animation.
+// Loads Cytoscape.js on demand for pan/zoom/animation.
 
 import { html } from 'htm/preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
@@ -56,7 +56,7 @@ interface CytoscapeFsmProps {
   class?: string
 }
 
-// Lazy-load Cytoscape (already in bundle via mermaid)
+// Lazy-load Cytoscape for graph-heavy panels.
 type CyCore = cytoscape.Core
 
 let cyPromise: Promise<typeof cytoscape> | null = null

--- a/dashboard/src/components/common/markdown-renderer.ts
+++ b/dashboard/src/components/common/markdown-renderer.ts
@@ -1,0 +1,337 @@
+// Markdown renderer core — uses `marked` for full GFM parsing
+// Handles: tables, code fences, line breaks, inline formatting,
+//          mermaid diagrams (lazy-loaded), <think> blocks (collapsible)
+// CSS classes: .markdown-content (ui.css), .think-block (ui.css),
+//              .mermaid-rendered (ui.css)
+
+import { html } from 'htm/preact'
+import { useRef, useEffect, useMemo } from 'preact/hooks'
+import { Marked } from 'marked'
+import DOMPurify from 'dompurify'
+
+import type MermaidDefault from 'mermaid'
+
+// ── Lazy shiki loader ────────────────────────────────────────
+interface DashboardHighlighter {
+  getLoadedLanguages(): string[]
+  loadLanguage(...langs: unknown[]): Promise<void>
+  codeToHtml(code: string, options: { lang: string; theme: string }): string
+}
+
+type ShikiLanguageModule = { default: unknown | unknown[] }
+type ShikiLanguageLoader = () => Promise<ShikiLanguageModule>
+
+const SHIKI_THEME = 'vitesse-dark'
+const SHIKI_LANG_ALIASES: Record<string, string> = {
+  js: 'javascript',
+  jsx: 'javascript',
+  ts: 'typescript',
+  tsx: 'typescript',
+  py: 'python',
+  sh: 'bash',
+  shell: 'bash',
+  zsh: 'bash',
+  yml: 'yaml',
+  md: 'markdown',
+}
+const SHIKI_LANG_LOADERS: Record<string, ShikiLanguageLoader> = {
+  bash: () => import('shiki/langs/bash.mjs'),
+  css: () => import('shiki/langs/css.mjs'),
+  diff: () => import('shiki/langs/diff.mjs'),
+  go: () => import('shiki/langs/go.mjs'),
+  html: () => import('shiki/langs/html.mjs'),
+  javascript: () => import('shiki/langs/javascript.mjs'),
+  json: () => import('shiki/langs/json.mjs'),
+  markdown: () => import('shiki/langs/markdown.mjs'),
+  ocaml: () => import('shiki/langs/ocaml.mjs'),
+  python: () => import('shiki/langs/python.mjs'),
+  rust: () => import('shiki/langs/rust.mjs'),
+  sql: () => import('shiki/langs/sql.mjs'),
+  typescript: () => import('shiki/langs/typescript.mjs'),
+  yaml: () => import('shiki/langs/yaml.mjs'),
+}
+
+let shikiPromise: Promise<DashboardHighlighter> | null = null
+let loadedShikiLanguages = new Set<string>()
+
+function getShiki(): Promise<DashboardHighlighter> {
+  if (!shikiPromise) {
+    shikiPromise = Promise.all([
+      import('shiki/core'),
+      import('shiki/engine/javascript'),
+      import('shiki/themes/vitesse-dark.mjs'),
+    ]).then(async ([shiki, engine, theme]) => {
+      loadedShikiLanguages = new Set()
+      return shiki.createHighlighterCore({
+        themes: [theme.default],
+        langs: [],
+        engine: engine.createJavaScriptRegexEngine(),
+      })
+    }).catch((err) => {
+      shikiPromise = null  // allow retry on next call
+      loadedShikiLanguages = new Set()
+      throw err
+    })
+  }
+  return shikiPromise
+}
+
+function normalizeShikiLang(lang: string): string {
+  const normalized = lang.trim().toLowerCase()
+  return SHIKI_LANG_ALIASES[normalized] ?? normalized
+}
+
+async function ensureShikiLanguage(highlighter: DashboardHighlighter, lang: string): Promise<string> {
+  const normalized = normalizeShikiLang(lang)
+  if (normalized === 'text') return 'text'
+  const loader = SHIKI_LANG_LOADERS[normalized]
+  if (!loader) return 'text'
+  if (loadedShikiLanguages.has(normalized) || highlighter.getLoadedLanguages().includes(normalized)) {
+    return normalized
+  }
+  const module = await loader()
+  const registrations = Array.isArray(module.default) ? module.default : [module.default]
+  await highlighter.loadLanguage(...registrations)
+  loadedShikiLanguages.add(normalized)
+  return normalized
+}
+
+// ── Lazy mermaid loader ──────────────────────────────────────
+type MermaidApi = typeof MermaidDefault
+
+function importMermaid(): Promise<MermaidApi> {
+  return import('mermaid').then(module => module.default)
+}
+let mermaidPromise: Promise<MermaidApi> | null = null
+let mermaidConfigured = false
+let mermaidRenderCount = 0
+
+function getMermaid(): Promise<MermaidApi> {
+  const promise = mermaidPromise ?? (mermaidPromise = importMermaid())
+  return promise.then(mermaid => {
+    if (mermaidConfigured) return mermaid
+    mermaid.initialize({ startOnLoad: false, theme: 'dark', securityLevel: 'strict', suppressErrorRendering: true })
+    mermaidConfigured = true
+    return mermaid
+  }).catch((err) => {
+    mermaidPromise = null
+    mermaidConfigured = false
+    throw err
+  })
+}
+
+// ── Marked instance (GFM tables + line-break support) ────────
+const md = new Marked({ gfm: true, breaks: true })
+
+// Custom renderer: links open in new tab with noopener
+md.use({
+  renderer: {
+    link({ href, title, text }) {
+      const titleAttr = title ? ` title="${title}"` : ''
+      return `<a href="${href}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`
+    }
+  }
+})
+
+// ── HTML sanitization via DOMPurify ──────────────────────────
+// VDOM→innerHTML migration requires explicit sanitization.
+// DOMPurify handles script/iframe/event handler/SVG attacks.
+const PURIFY_CONFIG = {
+  ALLOWED_TAGS: [
+    'p', 'br', 'strong', 'em', 'del', 'code', 'pre', 'blockquote',
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    'ul', 'ol', 'li', 'hr', 'a', 'img',
+    'table', 'thead', 'tbody', 'tr', 'th', 'td',
+    'details', 'summary', 'div', 'span',
+  ],
+  ALLOWED_ATTR: [
+    'href', 'title', 'target', 'rel', 'src', 'alt', 'class',
+    'align',
+  ],
+}
+
+function sanitize(raw: string): string {
+  return DOMPurify.sanitize(raw, PURIFY_CONFIG)
+}
+
+// Shiki generates <span style="color: ..."> for syntax tokens.
+// Allow `style` only when sanitizing trusted Shiki output.
+const SHIKI_PURIFY_CONFIG = {
+  ALLOWED_TAGS: ['pre', 'code', 'span'],
+  ALLOWED_ATTR: ['class', 'style'],
+}
+
+function sanitizeShikiHtml(raw: string): string {
+  return DOMPurify.sanitize(raw, SHIKI_PURIFY_CONFIG)
+}
+
+function sanitizeMermaidSvg(raw: string): SVGElement | null {
+  const safeSvg = DOMPurify.sanitize(raw, {
+    USE_PROFILES: { svg: true },
+  })
+  if (!safeSvg || !safeSvg.includes('<svg')) {
+    return null
+  }
+  const parsed = new DOMParser().parseFromString(safeSvg, 'image/svg+xml')
+  const svg = parsed.documentElement
+  if (!svg || svg.tagName.toLowerCase() !== 'svg') return null
+  return document.importNode(svg, true) as unknown as SVGElement
+}
+
+// ── Repair truncated markdown ────────────────────────────────
+// Keeper tool outputs occasionally arrive with an unclosed code fence
+// (```) or an odd count of inline backticks (`) — the LLM ran out of
+// max_tokens mid-write and the `board_post` payload is stored as-is.
+// Marked's parser then "swallows" everything after the opening backtick.
+// Repair: close any dangling fence/inline and append a visible marker
+// so the operator can tell the post was cut, not just strangely rendered.
+function repairTruncatedMarkdown(text: string): string {
+  const fenceCount = (text.match(/```/g) ?? []).length
+  if (fenceCount % 2 === 1) {
+    return `${text}\n…[잘림]\n\`\`\``
+  }
+  // Only count inline backticks OUTSIDE fenced blocks, otherwise
+  // a balanced fence would be miscounted as odd.
+  const outsideFences = text.replace(/```[\s\S]*?```/g, '')
+  const inlineCount = (outsideFences.match(/`/g) ?? []).length
+  if (inlineCount % 2 === 1) {
+    return `${text}…[잘림]\``
+  }
+  return text
+}
+
+// ── Parse markdown with <think> block extraction ─────────────
+// Think blocks are extracted first, their content is parsed
+// separately as markdown, then reassembled as <details>.
+function renderMarkdown(text: string): string {
+  const repaired = repairTruncatedMarkdown(text)
+  const parts: string[] = []
+  let lastIdx = 0
+  const thinkRe = /<think>([\s\S]*?)<\/think\s*>/g
+  let m: RegExpExecArray | null
+
+  while ((m = thinkRe.exec(repaired)) !== null) {
+    if (m.index > lastIdx) {
+      parts.push(md.parse(repaired.slice(lastIdx, m.index)) as string)
+    }
+    const innerHtml = md.parse((m[1] as string).trim()) as string
+    parts.push(
+      `<details class="think-block rounded"><summary>생각 중...</summary><div>${innerHtml}</div></details>`
+    )
+    lastIdx = m.index + m[0].length
+  }
+
+  if (lastIdx < repaired.length) {
+    parts.push(md.parse(repaired.slice(lastIdx)) as string)
+  }
+
+  return sanitize(parts.join(''))
+}
+
+// ── Component ────────────────────────────────────────────────
+export function MarkdownContent({ text, class: className }: { text: string; class?: string }) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const htmlStr = useMemo(() => renderMarkdown(text), [text])
+  const classes = ['markdown-content', className].filter(Boolean).join(' ')
+
+  // Post-render: replace mermaid code blocks with rendered SVG
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const mermaidCodes = el.querySelectorAll<HTMLElement>('pre > code.language-mermaid')
+    if (mermaidCodes.length === 0) return
+
+    let cancelled = false
+    void (async () => {
+      const mermaid = await getMermaid()
+      if (cancelled) return
+      for (const codeEl of mermaidCodes) {
+        const pre = codeEl.parentElement
+        if (!pre) continue
+        const code = codeEl.textContent ?? ''
+        try {
+          const id = `mermaid-md-${++mermaidRenderCount}`
+          const { svg } = await mermaid.render(id, code)
+          if (!cancelled && pre.parentElement) {
+            const div = document.createElement('div')
+            div.className = 'mermaid-rendered'
+            const safeSvg = sanitizeMermaidSvg(svg)
+            if (!safeSvg) continue // keep original code block on sanitization failure
+            div.appendChild(safeSvg)
+            pre.replaceWith(div)
+          }
+        } catch {
+          // Keep code block as fallback on render error
+        }
+      }
+    })()
+    return () => { cancelled = true }
+  }, [htmlStr])
+
+  // Post-render: highlight code blocks with shiki
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const codeBlocks = el.querySelectorAll<HTMLElement>('pre > code:not(.language-mermaid)')
+    if (codeBlocks.length === 0) return
+
+    let cancelled = false
+    void (async () => {
+      let highlighter: DashboardHighlighter | null = null
+      
+      for (const codeEl of codeBlocks) {
+        if (cancelled) break
+        if (codeEl.dataset.highlighted) continue
+        
+        const pre = codeEl.parentElement
+        if (!pre) continue
+        const code = codeEl.textContent ?? ''
+        
+        let lang = 'text'
+        for (const cls of codeEl.classList) {
+          if (cls.startsWith('language-')) {
+            lang = cls.replace('language-', '')
+            break
+          }
+        }
+        
+        if (!highlighter) {
+          highlighter = await getShiki()
+          if (cancelled) break
+        }
+
+        try {
+          lang = await ensureShikiLanguage(highlighter, lang)
+        } catch {
+          lang = 'text'
+        }
+        
+        if (cancelled) break
+
+        try {
+          const rawHtml = highlighter.codeToHtml(code, { lang, theme: SHIKI_THEME })
+          const safeHtml = sanitizeShikiHtml(rawHtml)
+
+          const div = document.createElement('div')
+          div.innerHTML = safeHtml
+          const shikiPre = div.firstElementChild as HTMLElement
+
+          if (shikiPre && shikiPre.tagName === 'PRE') {
+            // Apply dashboard specific classes to match existing UI
+            shikiPre.classList.add('shiki-rendered', 'rounded', 'my-3', 'text-sm', 'leading-relaxed')
+
+            pre.replaceWith(shikiPre)
+          }
+          codeEl.dataset.highlighted = 'true'
+        } catch (e) {
+          // Keep original code block on error — do not mark as highlighted
+          console.warn('[shiki] highlight failed', e)
+        }
+      }
+    })()
+    
+    return () => { cancelled = true }
+  }, [htmlStr])
+
+  return html`<div ref=${containerRef} class=${classes} dangerouslySetInnerHTML=${{ __html: htmlStr }}></div>`
+}

--- a/dashboard/src/components/common/markdown.test.ts
+++ b/dashboard/src/components/common/markdown.test.ts
@@ -3,6 +3,7 @@ import { render } from 'preact'
 import { waitFor } from '@testing-library/preact'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { Markdown } from './markdown'
+import { MarkdownContent as MarkdownRenderer } from './markdown-renderer'
 
 describe('Markdown', () => {
   let container: HTMLDivElement
@@ -22,22 +23,24 @@ describe('Markdown', () => {
     expect(container.querySelector('.markdown-content')).toBeNull()
   })
 
-  it('can transition from empty to populated text in the same mount point', () => {
+  it('can transition from empty to populated text in the same mount point', async () => {
     render(html`<${Markdown} text="" />`, container)
     expect(container.querySelector('.markdown-content')).toBeNull()
 
     render(html`<${Markdown} text="later" />`, container)
-    expect(container.querySelector('.markdown-content')?.textContent).toContain('later')
+    await waitFor(() => {
+      expect(container.querySelector('.markdown-content')?.textContent).toContain('later')
+    })
   })
 
   it('renders a paragraph', () => {
-    render(html`<${Markdown} text="hello world" />`, container)
+    render(html`<${MarkdownRenderer} text="hello world" />`, container)
     expect(container.querySelector('p')?.textContent).toBe('hello world')
   })
 
   it('renders GFM table', () => {
     const md = '| a | b |\n|---|---|\n| 1 | 2 |'
-    render(html`<${Markdown} text=${md} />`, container)
+    render(html`<${MarkdownRenderer} text=${md} />`, container)
     const table = container.querySelector('table')
     expect(table).not.toBeNull()
     expect(table?.querySelectorAll('th').length).toBe(2)
@@ -47,7 +50,7 @@ describe('Markdown', () => {
 
   it('renders table with alignment', () => {
     const md = '| left | center | right |\n|:---|:---:|---:|\n| a | b | c |'
-    render(html`<${Markdown} text=${md} />`, container)
+    render(html`<${MarkdownRenderer} text=${md} />`, container)
     const ths = container.querySelectorAll('th')
     expect(ths.length).toBe(3)
     // marked generates align attributes on th/td
@@ -56,14 +59,14 @@ describe('Markdown', () => {
   })
 
   it('converts line breaks with breaks: true', () => {
-    render(html`<${Markdown} text=${'line1\nline2'} />`, container)
+    render(html`<${MarkdownRenderer} text=${'line1\nline2'} />`, container)
     const br = container.querySelector('br')
     expect(br).not.toBeNull()
   })
 
   it('renders code block with language class', () => {
     const md = '```js\nconsole.log("hi")\n```'
-    render(html`<${Markdown} text=${md} />`, container)
+    render(html`<${MarkdownRenderer} text=${md} />`, container)
     const code = container.querySelector('code.language-js')
     expect(code).not.toBeNull()
     expect(code?.textContent).toContain('console.log')
@@ -71,7 +74,7 @@ describe('Markdown', () => {
 
   it('renders think block as collapsible details', () => {
     const md = '<think>some **reasoning**</think>'
-    render(html`<${Markdown} text=${md} />`, container)
+    render(html`<${MarkdownRenderer} text=${md} />`, container)
     const details = container.querySelector('details.think-block')
     expect(details).not.toBeNull()
     expect(details?.querySelector('summary')?.textContent).toBe('생각 중...')
@@ -81,20 +84,20 @@ describe('Markdown', () => {
 
   it('strips script tags (XSS prevention)', () => {
     const md = 'safe text <script>alert("xss")</script> more text'
-    render(html`<${Markdown} text=${md} />`, container)
+    render(html`<${MarkdownRenderer} text=${md} />`, container)
     expect(container.innerHTML).not.toContain('<script')
     expect(container.textContent).toContain('safe text')
   })
 
   it('applies custom class alongside markdown-content', () => {
-    render(html`<${Markdown} text="test" class="custom" />`, container)
+    render(html`<${MarkdownRenderer} text="test" class="custom" />`, container)
     const div = container.querySelector('.markdown-content.custom')
     expect(div).not.toBeNull()
   })
 
   it('renders inline formatting (bold, italic, code)', () => {
     const md = '**bold** and *italic* and `code`'
-    render(html`<${Markdown} text=${md} />`, container)
+    render(html`<${MarkdownRenderer} text=${md} />`, container)
     expect(container.querySelector('strong')?.textContent).toBe('bold')
     expect(container.querySelector('em')?.textContent).toBe('italic')
     expect(container.querySelector('code')?.textContent).toBe('code')
@@ -102,19 +105,19 @@ describe('Markdown', () => {
 
   it('preserves ASCII art inside code blocks', () => {
     const md = '```\n+-----+-----+\n| A   | B   |\n+-----+-----+\n```'
-    render(html`<${Markdown} text=${md} />`, container)
+    render(html`<${MarkdownRenderer} text=${md} />`, container)
     const pre = container.querySelector('pre')
     expect(pre).not.toBeNull()
     expect(pre?.textContent).toContain('+-----+-----+')
   })
 
   it('renders strikethrough (GFM)', () => {
-    render(html`<${Markdown} text="~~deleted~~" />`, container)
+    render(html`<${MarkdownRenderer} text="~~deleted~~" />`, container)
     expect(container.querySelector('del')?.textContent).toBe('deleted')
   })
 
   it('adds target="_blank" and rel="noopener noreferrer" to links', () => {
-    render(html`<${Markdown} text="[example](https://example.com)" />`, container)
+    render(html`<${MarkdownRenderer} text="[example](https://example.com)" />`, container)
     const a = container.querySelector('a')
     expect(a).not.toBeNull()
     expect(a?.getAttribute('target')).toBe('_blank')
@@ -123,13 +126,13 @@ describe('Markdown', () => {
 
   it('sanitizes event handlers via DOMPurify', () => {
     const md = '<img src=x onerror="alert(1)">'
-    render(html`<${Markdown} text=${md} />`, container)
+    render(html`<${MarkdownRenderer} text=${md} />`, container)
     expect(container.innerHTML).not.toContain('onerror')
   })
 
   it('sanitizes javascript: URLs in links', () => {
     const md = '[blocked](javascript:alert(1))'
-    render(html`<${Markdown} text=${md} />`, container)
+    render(html`<${MarkdownRenderer} text=${md} />`, container)
     const anchor = container.querySelector('a')
     if (!anchor) return // DOMPurify removed entire tag — safe
     const href = anchor.getAttribute('href')
@@ -139,7 +142,7 @@ describe('Markdown', () => {
 
   it('sanitizes javascript: URLs in images', () => {
     const md = '![malicious](javascript:alert(1))'
-    render(html`<${Markdown} text=${md} />`, container)
+    render(html`<${MarkdownRenderer} text=${md} />`, container)
     const img = container.querySelector('img')
     if (!img) return // DOMPurify removed entire tag — safe
     const src = img.getAttribute('src') ?? ''
@@ -153,7 +156,7 @@ describe('Markdown', () => {
       '<a href="https://example.com/?onclick=alert(1)">click</a>',
       '```',
     ].join('\n')
-    render(html`<${Markdown} text=${md} />`, container)
+    render(html`<${MarkdownRenderer} text=${md} />`, container)
     const code = container.querySelector('code.language-html') ?? container.querySelector('code')
     expect(code).not.toBeNull()
     const text = code?.textContent ?? ''
@@ -164,7 +167,7 @@ describe('Markdown', () => {
 
   it('handles think block with trailing whitespace in close tag', () => {
     const md = '<think>reasoning</think >'
-    render(html`<${Markdown} text=${md} />`, container)
+    render(html`<${MarkdownRenderer} text=${md} />`, container)
     const details = container.querySelector('details.think-block')
     expect(details).not.toBeNull()
   })
@@ -177,7 +180,7 @@ describe('Markdown', () => {
 
     it('highlights non-mermaid code fences via shiki', async () => {
       const md = '```typescript\nconst x = 1\n```'
-      render(html`<${Markdown} text=${md} />`, container)
+      render(html`<${MarkdownRenderer} text=${md} />`, container)
       await waitForShiki()
       const shikiPre = container.querySelector('pre.shiki-rendered')
       expect(shikiPre).not.toBeNull()
@@ -188,7 +191,7 @@ describe('Markdown', () => {
     it('does not apply shiki to mermaid code fences', async () => {
       // Render both a mermaid and a non-mermaid block to verify selectivity
       const md = '```mermaid\ngraph TD\nA-->B\n```\n\n```js\nconst a = 1\n```'
-      render(html`<${Markdown} text=${md} />`, container)
+      render(html`<${MarkdownRenderer} text=${md} />`, container)
       await waitForShiki()
       // Only the JS block should get shiki highlighting
       const shikiBlocks = container.querySelectorAll('pre.shiki-rendered')
@@ -198,7 +201,7 @@ describe('Markdown', () => {
 
     it('escapes HTML entities in highlighted code (XSS prevention)', async () => {
       const md = '```html\n<script>alert("xss")</script>\n```'
-      render(html`<${Markdown} text=${md} />`, container)
+      render(html`<${MarkdownRenderer} text=${md} />`, container)
       await waitForShiki()
       // The shiki mock escapes < and > so no raw <script> in DOM
       expect(container.innerHTML).not.toContain('<script>')
@@ -210,7 +213,7 @@ describe('Markdown', () => {
       // Reproduces the ani1999 board post symptom: LLM output cut at
       // max_tokens mid-bullet, leaving "- `" as the final line.
       const md = 'first line\n- `keeper_memory_search`\n- `'
-      render(html`<${Markdown} text=${md} />`, container)
+      render(html`<${MarkdownRenderer} text=${md} />`, container)
       // Body is still rendered; the trailing backtick doesn't swallow it.
       expect(container.textContent).toContain('first line')
       expect(container.textContent).toContain('keeper_memory_search')
@@ -220,7 +223,7 @@ describe('Markdown', () => {
 
     it('repairs unclosed triple-backtick code fence', () => {
       const md = 'before\n```ocaml\nlet x = 1'
-      render(html`<${Markdown} text=${md} />`, container)
+      render(html`<${MarkdownRenderer} text=${md} />`, container)
       expect(container.textContent).toContain('before')
       expect(container.textContent).toContain('let x = 1')
       expect(container.textContent).toContain('[잘림]')
@@ -228,7 +231,7 @@ describe('Markdown', () => {
 
     it('leaves balanced markdown untouched', () => {
       const md = 'plain `inline` and ```\ncode\n```'
-      render(html`<${Markdown} text=${md} />`, container)
+      render(html`<${MarkdownRenderer} text=${md} />`, container)
       expect(container.textContent).not.toContain('[잘림]')
     })
   })

--- a/dashboard/src/components/common/markdown.ts
+++ b/dashboard/src/components/common/markdown.ts
@@ -1,342 +1,85 @@
-// Markdown renderer — uses `marked` for full GFM parsing
-// Handles: tables, code fences, line breaks, inline formatting,
-//          mermaid diagrams (lazy-loaded), <think> blocks (collapsible)
-// CSS classes: .markdown-content (ui.css), .think-block (ui.css),
-//              .mermaid-rendered (ui.css)
+// Markdown component shell — loads the full parser/sanitizer renderer only
+// after markdown content is mounted.
 
 import { html } from 'htm/preact'
-import { useRef, useEffect, useMemo } from 'preact/hooks'
-import { Marked } from 'marked'
-import DOMPurify from 'dompurify'
+import { useEffect, useState } from 'preact/hooks'
 
-import type MermaidDefault from 'mermaid'
+import { InlineSpinner } from './inline-spinner'
+import type { MarkdownContent } from './markdown-renderer'
 
-// ── Lazy shiki loader ────────────────────────────────────────
-interface DashboardHighlighter {
-  getLoadedLanguages(): string[]
-  loadLanguage(...langs: unknown[]): Promise<void>
-  codeToHtml(code: string, options: { lang: string; theme: string }): string
+export interface MarkdownProps {
+  text: string
+  class?: string
 }
 
-type ShikiLanguageModule = { default: unknown | unknown[] }
-type ShikiLanguageLoader = () => Promise<ShikiLanguageModule>
+type MarkdownContentComponent = typeof MarkdownContent
 
-const SHIKI_THEME = 'vitesse-dark'
-const SHIKI_LANG_ALIASES: Record<string, string> = {
-  js: 'javascript',
-  jsx: 'javascript',
-  ts: 'typescript',
-  tsx: 'typescript',
-  py: 'python',
-  sh: 'bash',
-  shell: 'bash',
-  zsh: 'bash',
-  yml: 'yaml',
-  md: 'markdown',
-}
-const SHIKI_LANG_LOADERS: Record<string, ShikiLanguageLoader> = {
-  bash: () => import('shiki/langs/bash.mjs'),
-  css: () => import('shiki/langs/css.mjs'),
-  diff: () => import('shiki/langs/diff.mjs'),
-  go: () => import('shiki/langs/go.mjs'),
-  html: () => import('shiki/langs/html.mjs'),
-  javascript: () => import('shiki/langs/javascript.mjs'),
-  json: () => import('shiki/langs/json.mjs'),
-  markdown: () => import('shiki/langs/markdown.mjs'),
-  ocaml: () => import('shiki/langs/ocaml.mjs'),
-  python: () => import('shiki/langs/python.mjs'),
-  rust: () => import('shiki/langs/rust.mjs'),
-  sql: () => import('shiki/langs/sql.mjs'),
-  typescript: () => import('shiki/langs/typescript.mjs'),
-  yaml: () => import('shiki/langs/yaml.mjs'),
-}
+let rendererPromise: Promise<MarkdownContentComponent> | null = null
+let rendererComponent: MarkdownContentComponent | null = null
 
-let shikiPromise: Promise<DashboardHighlighter> | null = null
-let loadedShikiLanguages = new Set<string>()
-
-function getShiki(): Promise<DashboardHighlighter> {
-  if (!shikiPromise) {
-    shikiPromise = Promise.all([
-      import('shiki/core'),
-      import('shiki/engine/javascript'),
-      import('shiki/themes/vitesse-dark.mjs'),
-    ]).then(async ([shiki, engine, theme]) => {
-      loadedShikiLanguages = new Set()
-      return shiki.createHighlighterCore({
-        themes: [theme.default],
-        langs: [],
-        engine: engine.createJavaScriptRegexEngine(),
+function loadMarkdownRenderer(): Promise<MarkdownContentComponent> {
+  if (rendererComponent) return Promise.resolve(rendererComponent)
+  if (!rendererPromise) {
+    rendererPromise = import('./markdown-renderer')
+      .then((module) => {
+        rendererComponent = module.MarkdownContent
+        return module.MarkdownContent
       })
-    }).catch((err) => {
-      shikiPromise = null  // allow retry on next call
-      loadedShikiLanguages = new Set()
-      throw err
-    })
+      .catch((err) => {
+        rendererPromise = null
+        throw err
+      })
   }
-  return shikiPromise
+  return rendererPromise
 }
 
-function normalizeShikiLang(lang: string): string {
-  const normalized = lang.trim().toLowerCase()
-  return SHIKI_LANG_ALIASES[normalized] ?? normalized
+function loadingClasses(className?: string): string {
+  return [
+    'markdown-content',
+    'markdown-content--loading',
+    'inline-flex',
+    'items-center',
+    'text-2xs',
+    'text-[var(--text-dim)]',
+    className,
+  ].filter(Boolean).join(' ')
 }
 
-async function ensureShikiLanguage(highlighter: DashboardHighlighter, lang: string): Promise<string> {
-  const normalized = normalizeShikiLang(lang)
-  if (normalized === 'text') return 'text'
-  const loader = SHIKI_LANG_LOADERS[normalized]
-  if (!loader) return 'text'
-  if (loadedShikiLanguages.has(normalized) || highlighter.getLoadedLanguages().includes(normalized)) {
-    return normalized
-  }
-  const module = await loader()
-  const registrations = Array.isArray(module.default) ? module.default : [module.default]
-  await highlighter.loadLanguage(...registrations)
-  loadedShikiLanguages.add(normalized)
-  return normalized
-}
+export function Markdown({ text, class: className }: MarkdownProps) {
+  const [Renderer, setRenderer] = useState<MarkdownContentComponent | null>(() => rendererComponent)
+  const [failed, setFailed] = useState(false)
 
-// ── Lazy mermaid loader ──────────────────────────────────────
-type MermaidApi = typeof MermaidDefault
-
-function importMermaid(): Promise<MermaidApi> {
-  return import('mermaid').then(module => module.default)
-}
-let mermaidPromise: Promise<MermaidApi> | null = null
-let mermaidConfigured = false
-let mermaidRenderCount = 0
-
-function getMermaid(): Promise<MermaidApi> {
-  const promise = mermaidPromise ?? (mermaidPromise = importMermaid())
-  return promise.then(mermaid => {
-    if (mermaidConfigured) return mermaid
-    mermaid.initialize({ startOnLoad: false, theme: 'dark', securityLevel: 'strict', suppressErrorRendering: true })
-    mermaidConfigured = true
-    return mermaid
-  }).catch((err) => {
-    mermaidPromise = null
-    mermaidConfigured = false
-    throw err
-  })
-}
-
-// ── Marked instance (GFM tables + line-break support) ────────
-const md = new Marked({ gfm: true, breaks: true })
-
-// Custom renderer: links open in new tab with noopener
-md.use({
-  renderer: {
-    link({ href, title, text }) {
-      const titleAttr = title ? ` title="${title}"` : ''
-      return `<a href="${href}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`
+  useEffect(() => {
+    if (!text) return undefined
+    if (rendererComponent) {
+      setRenderer(() => rendererComponent)
+      setFailed(false)
+      return undefined
     }
-  }
-})
 
-// ── HTML sanitization via DOMPurify ──────────────────────────
-// VDOM→innerHTML migration requires explicit sanitization.
-// DOMPurify handles script/iframe/event handler/SVG attacks.
-const PURIFY_CONFIG = {
-  ALLOWED_TAGS: [
-    'p', 'br', 'strong', 'em', 'del', 'code', 'pre', 'blockquote',
-    'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-    'ul', 'ol', 'li', 'hr', 'a', 'img',
-    'table', 'thead', 'tbody', 'tr', 'th', 'td',
-    'details', 'summary', 'div', 'span',
-  ],
-  ALLOWED_ATTR: [
-    'href', 'title', 'target', 'rel', 'src', 'alt', 'class',
-    'align',
-  ],
-}
+    let cancelled = false
+    setFailed(false)
+    void loadMarkdownRenderer()
+      .then((component) => {
+        if (!cancelled) setRenderer(() => component)
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true)
+      })
 
-function sanitize(raw: string): string {
-  return DOMPurify.sanitize(raw, PURIFY_CONFIG)
-}
-
-// Shiki generates <span style="color: ..."> for syntax tokens.
-// Allow `style` only when sanitizing trusted Shiki output.
-const SHIKI_PURIFY_CONFIG = {
-  ALLOWED_TAGS: ['pre', 'code', 'span'],
-  ALLOWED_ATTR: ['class', 'style'],
-}
-
-function sanitizeShikiHtml(raw: string): string {
-  return DOMPurify.sanitize(raw, SHIKI_PURIFY_CONFIG)
-}
-
-function sanitizeMermaidSvg(raw: string): SVGElement | null {
-  const safeSvg = DOMPurify.sanitize(raw, {
-    USE_PROFILES: { svg: true },
-  })
-  if (!safeSvg || !safeSvg.includes('<svg')) {
-    return null
-  }
-  const parsed = new DOMParser().parseFromString(safeSvg, 'image/svg+xml')
-  const svg = parsed.documentElement
-  if (!svg || svg.tagName.toLowerCase() !== 'svg') return null
-  return document.importNode(svg, true) as unknown as SVGElement
-}
-
-// ── Repair truncated markdown ────────────────────────────────
-// Keeper tool outputs occasionally arrive with an unclosed code fence
-// (```) or an odd count of inline backticks (`) — the LLM ran out of
-// max_tokens mid-write and the `board_post` payload is stored as-is.
-// Marked's parser then "swallows" everything after the opening backtick.
-// Repair: close any dangling fence/inline and append a visible marker
-// so the operator can tell the post was cut, not just strangely rendered.
-function repairTruncatedMarkdown(text: string): string {
-  const fenceCount = (text.match(/```/g) ?? []).length
-  if (fenceCount % 2 === 1) {
-    return `${text}\n…[잘림]\n\`\`\``
-  }
-  // Only count inline backticks OUTSIDE fenced blocks, otherwise
-  // a balanced fence would be miscounted as odd.
-  const outsideFences = text.replace(/```[\s\S]*?```/g, '')
-  const inlineCount = (outsideFences.match(/`/g) ?? []).length
-  if (inlineCount % 2 === 1) {
-    return `${text}…[잘림]\``
-  }
-  return text
-}
-
-// ── Parse markdown with <think> block extraction ─────────────
-// Think blocks are extracted first, their content is parsed
-// separately as markdown, then reassembled as <details>.
-function renderMarkdown(text: string): string {
-  const repaired = repairTruncatedMarkdown(text)
-  const parts: string[] = []
-  let lastIdx = 0
-  const thinkRe = /<think>([\s\S]*?)<\/think\s*>/g
-  let m: RegExpExecArray | null
-
-  while ((m = thinkRe.exec(repaired)) !== null) {
-    if (m.index > lastIdx) {
-      parts.push(md.parse(repaired.slice(lastIdx, m.index)) as string)
+    return () => {
+      cancelled = true
     }
-    const innerHtml = md.parse((m[1] as string).trim()) as string
-    parts.push(
-      `<details class="think-block rounded"><summary>생각 중...</summary><div>${innerHtml}</div></details>`
-    )
-    lastIdx = m.index + m[0].length
-  }
+  }, [text])
 
-  if (lastIdx < repaired.length) {
-    parts.push(md.parse(repaired.slice(lastIdx)) as string)
-  }
-
-  return sanitize(parts.join(''))
-}
-
-// ── Component ────────────────────────────────────────────────
-export function Markdown({ text, class: className }: { text: string; class?: string }) {
   if (!text) return null
-  return html`<${MarkdownContent} text=${text} class=${className} />`
-}
+  if (Renderer) return html`<${Renderer} text=${text} class=${className} />`
 
-function MarkdownContent({ text, class: className }: { text: string; class?: string }) {
-  const containerRef = useRef<HTMLDivElement>(null)
-  const htmlStr = useMemo(() => renderMarkdown(text), [text])
-  const classes = ['markdown-content', className].filter(Boolean).join(' ')
-
-  // Post-render: replace mermaid code blocks with rendered SVG
-  useEffect(() => {
-    const el = containerRef.current
-    if (!el) return
-    const mermaidCodes = el.querySelectorAll<HTMLElement>('pre > code.language-mermaid')
-    if (mermaidCodes.length === 0) return
-
-    let cancelled = false
-    void (async () => {
-      const mermaid = await getMermaid()
-      if (cancelled) return
-      for (const codeEl of mermaidCodes) {
-        const pre = codeEl.parentElement
-        if (!pre) continue
-        const code = codeEl.textContent ?? ''
-        try {
-          const id = `mermaid-md-${++mermaidRenderCount}`
-          const { svg } = await mermaid.render(id, code)
-          if (!cancelled && pre.parentElement) {
-            const div = document.createElement('div')
-            div.className = 'mermaid-rendered'
-            const safeSvg = sanitizeMermaidSvg(svg)
-            if (!safeSvg) continue // keep original code block on sanitization failure
-            div.appendChild(safeSvg)
-            pre.replaceWith(div)
-          }
-        } catch {
-          // Keep code block as fallback on render error
-        }
-      }
-    })()
-    return () => { cancelled = true }
-  }, [htmlStr])
-
-  // Post-render: highlight code blocks with shiki
-  useEffect(() => {
-    const el = containerRef.current
-    if (!el) return
-    const codeBlocks = el.querySelectorAll<HTMLElement>('pre > code:not(.language-mermaid)')
-    if (codeBlocks.length === 0) return
-
-    let cancelled = false
-    void (async () => {
-      let highlighter: DashboardHighlighter | null = null
-      
-      for (const codeEl of codeBlocks) {
-        if (cancelled) break
-        if (codeEl.dataset.highlighted) continue
-        
-        const pre = codeEl.parentElement
-        if (!pre) continue
-        const code = codeEl.textContent ?? ''
-        
-        let lang = 'text'
-        for (const cls of codeEl.classList) {
-          if (cls.startsWith('language-')) {
-            lang = cls.replace('language-', '')
-            break
-          }
-        }
-        
-        if (!highlighter) {
-          highlighter = await getShiki()
-          if (cancelled) break
-        }
-
-        try {
-          lang = await ensureShikiLanguage(highlighter, lang)
-        } catch {
-          lang = 'text'
-        }
-        
-        if (cancelled) break
-
-        try {
-          const rawHtml = highlighter.codeToHtml(code, { lang, theme: SHIKI_THEME })
-          const safeHtml = sanitizeShikiHtml(rawHtml)
-
-          const div = document.createElement('div')
-          div.innerHTML = safeHtml
-          const shikiPre = div.firstElementChild as HTMLElement
-
-          if (shikiPre && shikiPre.tagName === 'PRE') {
-            // Apply dashboard specific classes to match existing UI
-            shikiPre.classList.add('shiki-rendered', 'rounded', 'my-3', 'text-sm', 'leading-relaxed')
-
-            pre.replaceWith(shikiPre)
-          }
-          codeEl.dataset.highlighted = 'true'
-        } catch (e) {
-          // Keep original code block on error — do not mark as highlighted
-          console.warn('[shiki] highlight failed', e)
-        }
-      }
-    })()
-    
-    return () => { cancelled = true }
-  }, [htmlStr])
-
-  return html`<div ref=${containerRef} class=${classes} dangerouslySetInnerHTML=${{ __html: htmlStr }}></div>`
+  return html`
+    <div class=${loadingClasses(className)} role=${failed ? 'alert' : 'status'} aria-live="polite">
+      ${failed
+        ? '마크다운을 불러오지 못했습니다'
+        : html`<${InlineSpinner} size="xs" tone="muted" class="mr-1.5" />마크다운 로딩중`}
+    </div>
+  `
 }

--- a/dashboard/src/components/tools/prompt-registry-panel.test.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.test.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
+import { waitFor } from '@testing-library/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 void vi
@@ -181,7 +182,9 @@ describe('PromptRegistryPanel', () => {
     expect(container.textContent).toContain('프롬프트 레지스트리')
     expect(container.textContent).toContain('keeper.world')
     expect(container.textContent).toContain('/tmp/config/prompts/keeper.world.md')
-    expect(container.textContent).toContain('file world')
+    await waitFor(() => {
+      expect(container.textContent).toContain('file world')
+    })
     expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toBe('override world')
 
     const governanceButton = Array.from(container.querySelectorAll('button')).find(button =>


### PR DESCRIPTION
## Summary
- Split the dashboard Markdown component into a lightweight shell and a deferred `markdown-renderer` chunk.
- Keep `marked`, `dompurify`, shiki, and mermaid work out of tab chunks until markdown content is mounted.
- Remove misleading Cytoscape comments that implied it was bundled via mermaid.

## Bundle Delta (`pnpm build`)
Compared against fresh `origin/main` (`88b24b7c9`) with a detached baseline worktree.

| Chunk | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `index-*.js` | 182.37 kB / gzip 56.20 kB | 182.37 kB / gzip 56.21 kB | +0.00 kB / +0.01 gzip |
| `work-*.js` | 115.67 kB / gzip 29.06 kB | 115.67 kB / gzip 29.07 kB | +0.00 kB / +0.01 gzip |
| `markdown-Cvjx9yec.js` (shiki markdown lang) | 59.38 kB / gzip 5.66 kB | 59.38 kB / gzip 5.66 kB | unchanged |
| markdown renderer shell/core | `markdown--sZ9GCga.js` 69.51 kB / gzip 23.27 kB | `markdown-BcT-kD44.js` 2.02 kB / gzip 1.10 kB + deferred `markdown-renderer-CAegZm_G.js` 46.61 kB / gzip 14.74 kB + deferred `purify.es-C_waPgHe.js` 22.75 kB / gzip 8.71 kB | parser/sanitizer deferred until visible |
| `cytoscape.esm-*.js` | 441.77 kB / gzip 140.95 kB | 441.77 kB / gzip 140.95 kB | unchanged |
| `mermaid.core-*.js` | 576.74 kB / gzip 136.08 kB | 576.74 kB / gzip 136.09 kB | +0.00 kB / +0.01 gzip |
| `activity-graph-view-*.js` | 420.33 kB / gzip 119.89 kB | 420.33 kB / gzip 119.89 kB | unchanged |

The main win is deferral rather than total byte removal: markdown-capable tab chunks now receive a tiny shell, and the parser/sanitizer load only when mounted markdown content is visible.

## Validation
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm exec vitest run src/components/common/markdown.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm build`

## Notes
- No route, REST API, or visual layout changes.
- Existing mermaid, shiki, and Cytoscape dynamic imports remain dynamic.