### PR TITLE
feat(keeper): Prometheus counters for usage trust (#9959 defensive layer)

### DIFF
--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -122,6 +122,44 @@ let usage_trust_json_fields trust =
 let add_reason reason reasons =
   if List.mem reason reasons then reasons else reason :: reasons
 
+(* #9959 defensive observability: surface usage-field trust into
+   Prometheus so operators can alert on rising untrusted/missing
+   rates while the upstream OAS fix (jeong-sik/oas#1181 —
+   accumulated values leaking into per-response [api_usage]) lands.
+
+   Two counters:
+   - [masc_keeper_usage_trust_total{keeper, outcome}] — high-level
+     outcome (trusted / missing / untrusted).
+   - [masc_keeper_usage_anomaly_reason_total{keeper, reason}] —
+     per-reason drill-down for untrusted outcomes (e.g.
+     [input_tokens_gt_1m], [input_tokens_gt_2x_context_max],
+     [zero_token_usage_reported]).
+
+   Called once per turn from [update_metrics_from_result]; other
+   classify sites (append_metrics_snapshot, keeper_turn) serialize
+   the trust into the JSONL ledger but do not bump the counter, so
+   the counter rate equals the per-turn rate rather than 2–3×. *)
+let usage_trust_outcome_metric = "masc_keeper_usage_trust_total"
+let usage_anomaly_reason_metric = "masc_keeper_usage_anomaly_reason_total"
+
+let record_usage_trust ~keeper_name ~(trust : usage_trust) =
+  let outcome = usage_trust_to_string trust in
+  Prometheus.inc_counter usage_trust_outcome_metric
+    ~labels:[ ("keeper", keeper_name); ("outcome", outcome) ] ();
+  match trust with
+  | Usage_untrusted reasons ->
+    List.iter
+      (fun reason ->
+        Prometheus.inc_counter usage_anomaly_reason_metric
+          ~labels:[ ("keeper", keeper_name); ("reason", reason) ] ())
+      reasons;
+    Log.Keeper.warn
+      "#9959 usage_anomaly keeper=%s reasons=[%s] — upstream fix \
+       tracked in jeong-sik/oas#1181; cost accounting is suppressed \
+       to 0.0 for this turn by [usage_trust_is_trusted] gate."
+      keeper_name (String.concat "," reasons)
+  | Usage_missing | Usage_trusted -> ()
+
 let classify_usage_trust ~(usage_reported : bool)
     ~(usage : Oas.Types.api_usage)
     ~(model_used : string)
@@ -803,6 +841,10 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
       ~resolved_model_id
       ~context_max
   in
+  (* #9959: surface classification into Prometheus exactly once per
+     turn. Other [classify_usage_trust] call sites serialize the
+     trust into JSONL but do not bump the counter. *)
+  record_usage_trust ~keeper_name:meta.name ~trust:usage_trust;
   let usage_trusted = usage_trust_is_trusted usage_trust in
   let trusted_input_tokens =
     if usage_trusted then result.usage.input_tokens else 0

--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -44,6 +44,33 @@ val usage_trust_reasons : usage_trust -> string list
 
 val usage_trust_json_fields : usage_trust -> (string * Yojson.Safe.t) list
 
+(** Canonical metric names for the per-turn usage-trust counters
+    (#9959).  Exposed so tests can pin the names without hard-coding
+    string literals.
+
+    Labels:
+    - [usage_trust_outcome_metric]: [("keeper", ...); ("outcome",
+      "trusted" | "missing" | "untrusted")]
+    - [usage_anomaly_reason_metric]: [("keeper", ...); ("reason", ...)]
+      where [reason] is one of the strings [classify_usage_trust]
+      attaches to [Usage_untrusted]. *)
+val usage_trust_outcome_metric : string
+val usage_anomaly_reason_metric : string
+
+(** [record_usage_trust ~keeper_name ~trust] increments the outcome
+    counter once and, for [Usage_untrusted] outcomes, also
+    increments [usage_anomaly_reason_metric] per reason and logs a
+    warn line.
+
+    Intended for a single per-turn emit site — currently
+    [update_metrics_from_result]. Other classify sites serialize
+    [trust] into the JSONL ledger without bumping the counter so
+    the counter rate equals the per-turn rate. *)
+val record_usage_trust :
+  keeper_name:string ->
+  trust:usage_trust ->
+  unit
+
 val update_metrics_from_result :
   Keeper_types.keeper_meta ->
   latency_ms:int ->

--- a/test/dune
+++ b/test/dune
@@ -54,8 +54,9 @@
         test_keeper_hooks_oas_provider
         test_keeper_hooks_oas_pricing
         test_keeper_hooks_oas_telemetry
-          test_keeper_tool_use_failure_counter
-          test_keeper_compaction_outcome_counter
+        test_keeper_tool_use_failure_counter
+        test_keeper_compaction_outcome_counter
+        test_keeper_usage_trust_counter
         test_keeper_wake_telemetry
         test_keeper_memory
         test_keeper_accountability
@@ -184,6 +185,7 @@
           test_keeper_hooks_oas_telemetry
           test_keeper_tool_use_failure_counter
           test_keeper_compaction_outcome_counter
+          test_keeper_usage_trust_counter
           test_keeper_wake_telemetry
           test_keeper_memory
           test_keeper_accountability

--- a/test/test_keeper_usage_trust_counter.ml
+++ b/test/test_keeper_usage_trust_counter.ml
@@ -1,0 +1,132 @@
+(* test/test_keeper_usage_trust_counter.ml
+
+   #9959 defensive layer test: verify the new [record_usage_trust]
+   helper increments the right Prometheus counters for each
+   [usage_trust] variant and isolates labels across keepers.
+
+   The upstream root cause (accumulated values leaking into
+   per-response api_usage) is tracked in jeong-sik/oas#1181; the
+   counters here surface the anomaly rate so operators can alert
+   while that fix is in-flight. *)
+
+module UM = Masc_mcp.Keeper_unified_metrics
+module Prom = Masc_mcp.Prometheus
+
+let outcome_for ~keeper ~outcome =
+  Prom.metric_value_or_zero
+    UM.usage_trust_outcome_metric
+    ~labels:[ ("keeper", keeper); ("outcome", outcome) ]
+    ()
+
+let reason_for ~keeper ~reason =
+  Prom.metric_value_or_zero
+    UM.usage_anomaly_reason_metric
+    ~labels:[ ("keeper", keeper); ("reason", reason) ]
+    ()
+
+let test_metric_names_stable () =
+  (* Dashboards / Grafana rules pin these exact strings. *)
+  Alcotest.(check string)
+    "outcome metric canonical"
+    "masc_keeper_usage_trust_total"
+    UM.usage_trust_outcome_metric;
+  Alcotest.(check string)
+    "anomaly reason metric canonical"
+    "masc_keeper_usage_anomaly_reason_total"
+    UM.usage_anomaly_reason_metric
+
+let test_trusted_outcome_only () =
+  let keeper = "test-keeper-9959-ok" in
+  let before = outcome_for ~keeper ~outcome:"trusted" in
+  UM.record_usage_trust ~keeper_name:keeper ~trust:UM.Usage_trusted;
+  Alcotest.(check (float 0.0001))
+    "trusted outcome +1"
+    (before +. 1.0)
+    (outcome_for ~keeper ~outcome:"trusted")
+
+let test_missing_outcome_only () =
+  (* Ollama-style "no usage reported at all" — honest signal, not an
+     anomaly with reasons.  The outcome counter ticks but no
+     per-reason counter moves. *)
+  let keeper = "test-keeper-9959-missing" in
+  let outcome_before = outcome_for ~keeper ~outcome:"missing" in
+  let reason_before =
+    reason_for ~keeper ~reason:"input_tokens_gt_1m"
+  in
+  UM.record_usage_trust ~keeper_name:keeper ~trust:UM.Usage_missing;
+  Alcotest.(check (float 0.0001))
+    "missing outcome +1"
+    (outcome_before +. 1.0)
+    (outcome_for ~keeper ~outcome:"missing");
+  Alcotest.(check (float 0.0001))
+    "no reason counter movement for missing"
+    reason_before
+    (reason_for ~keeper ~reason:"input_tokens_gt_1m")
+
+let test_untrusted_bumps_per_reason () =
+  (* The #9959 path: per-response api_usage carries accumulated
+     values — [input_tokens_gt_1m] fires together with
+     [input_tokens_gt_2x_context_max]. Both reason counters must
+     tick alongside the outcome counter. *)
+  let keeper = "test-keeper-9959-untrusted" in
+  let outcome_before = outcome_for ~keeper ~outcome:"untrusted" in
+  let gt1m_before = reason_for ~keeper ~reason:"input_tokens_gt_1m" in
+  let gt2x_before =
+    reason_for ~keeper ~reason:"input_tokens_gt_2x_context_max"
+  in
+  UM.record_usage_trust
+    ~keeper_name:keeper
+    ~trust:
+      (UM.Usage_untrusted
+         [ "input_tokens_gt_1m"; "input_tokens_gt_2x_context_max" ]);
+  Alcotest.(check (float 0.0001))
+    "untrusted outcome +1"
+    (outcome_before +. 1.0)
+    (outcome_for ~keeper ~outcome:"untrusted");
+  Alcotest.(check (float 0.0001))
+    "input_tokens_gt_1m reason +1"
+    (gt1m_before +. 1.0)
+    (reason_for ~keeper ~reason:"input_tokens_gt_1m");
+  Alcotest.(check (float 0.0001))
+    "input_tokens_gt_2x_context_max reason +1"
+    (gt2x_before +. 1.0)
+    (reason_for ~keeper ~reason:"input_tokens_gt_2x_context_max")
+
+let test_per_keeper_isolation () =
+  let a = "test-keeper-9959-a" in
+  let b = "test-keeper-9959-b" in
+  let a_before = outcome_for ~keeper:a ~outcome:"untrusted" in
+  let b_before = outcome_for ~keeper:b ~outcome:"untrusted" in
+  UM.record_usage_trust ~keeper_name:a
+    ~trust:(UM.Usage_untrusted [ "zero_token_usage_reported" ]);
+  Alcotest.(check (float 0.0001))
+    "A untrusted +1"
+    (a_before +. 1.0)
+    (outcome_for ~keeper:a ~outcome:"untrusted");
+  Alcotest.(check (float 0.0001))
+    "B untrusted unchanged" b_before
+    (outcome_for ~keeper:b ~outcome:"untrusted")
+
+let () =
+  Alcotest.run "keeper_usage_trust_counter_9959"
+    [
+      ( "metric_names",
+        [
+          Alcotest.test_case "canonical names stable" `Quick
+            test_metric_names_stable;
+        ] );
+      ( "trust_outcomes",
+        [
+          Alcotest.test_case "trusted increments outcome only" `Quick
+            test_trusted_outcome_only;
+          Alcotest.test_case "missing increments outcome only" `Quick
+            test_missing_outcome_only;
+          Alcotest.test_case "untrusted bumps per-reason" `Quick
+            test_untrusted_bumps_per_reason;
+        ] );
+      ( "isolation",
+        [
+          Alcotest.test_case "per-keeper independent" `Quick
+            test_per_keeper_isolation;
+        ] );
+    ]


### PR DESCRIPTION
## 요약

#9959 의 upstream root cause 는 OAS 의 type 계약 위반 (`api_usage` 가 per-response 타입인데 누적값이 주입) — jeong-sik/oas#1181 에서 추적 중. MASC 측 ledger 는 이미 [classify_usage_trust] 로 turn 마다 trusted/missing/untrusted 분류하고 anomaly 시 cost 계산을 0 으로 억제하지만, **분류 결과가 per-turn JSONL 에만 남고 Prometheus 에는 노출되지 않음**. Grafana alert 가 불가능.

이 PR 은 분류 결과를 Prometheus 에 surface:

```
masc_keeper_usage_trust_total{keeper, outcome}
  outcome = trusted | missing | untrusted

masc_keeper_usage_anomaly_reason_total{keeper, reason}
  reason = input_tokens_gt_1m | input_tokens_gt_2x_context_max
         | zero_token_usage_reported | ...
```

Untrusted turn 은 warn log 도 함께 — upstream tracker 번호를 메시지에 박아 운영자가 한 링크만 타면 OAS 이슈에 도달.

## 변경 파일

- `lib/keeper/keeper_unified_metrics.ml`
  - `usage_trust_outcome_metric`, `usage_anomaly_reason_metric` 상수 (SSOT).
  - `record_usage_trust ~keeper_name ~trust` helper — outcome 카운터 + `Usage_untrusted` 인 경우 per-reason 카운터 + warn log.
  - `update_metrics_from_result` 에서 classify 결과를 받은 직후 `record_usage_trust` 호출.
- `lib/keeper/keeper_unified_metrics.mli` — 상수와 helper 공개.
- `test/test_keeper_usage_trust_counter.ml` (신규) — 5 테스트:
  - canonical name pin.
  - trusted → outcome counter 만 +1.
  - missing → outcome 만 +1 (reason 카운터 불변).
  - untrusted → outcome +1 **and** 지정된 모든 reason 카운터 +1.
  - 서로 다른 keeper 간 label 독립 누적.
- `test/dune` — 새 test 등록.

## 로컬 검증

```
$ MASC_BASE_PATH=/tmp/masc-test-9959 dune exec test/test_keeper_usage_trust_counter.exe
Test Successful in 0.001s. 5 tests run.

$ MASC_BASE_PATH=/tmp/masc-test-9959 dune exec test/test_keeper_unified.exe -- test metrics_observation
Test Successful in 0.184s. 82 tests run.   # 회귀 0
```

`dune build` clean.

## 왜 근원 fix 인가 (MASC 범위 내)

- **Single emit 규칙**: `classify_usage_trust` 는 3-4 곳에서 호출 (`keeper_unified_turn`, `keeper_turn`, `append_metrics_snapshot`, `update_metrics_from_result`). 각 호출마다 카운터를 증가시키면 rate 가 2-3× 배. 이 PR 은 **한 곳** (`update_metrics_from_result`) 에서만 카운터를 올려 per-turn rate 를 유지.
- **Observability ↔ dispatch 분리**: `record_usage_trust` 를 top-level helper 로 빼서 unit test 가 classify 로직 없이 순수 카운터 동작만 검증 가능.
- **Upstream 추적 연결**: warn message 에 `jeong-sik/oas#1181` 텍스트가 들어가 있어 log tail 만 봐도 root cause tracker 로 바로 이동 — "metric 만 생겼는데 뭐 해야 하지" 를 줄임.

## 미검증 / 후속

- OAS#1181 이 머지되면 이 카운터의 `untrusted` rate 가 0 으로 수렴해야 함 — post-merge 관찰로 upstream fix 효과 확인.
- Grafana alert rule 은 ops ticket (metric 이름은 이 PR 이 pin).
- MASC 영역에서 **새** 이상 패턴이 발견되면 `classify_usage_trust` 의 reason enum 에 추가 → 자동으로 `usage_anomaly_reason_total` 의 새 label 로 노출 (동적 확장 가능).

## 관련

- #9959 (root — usage field systematically broken).
- Upstream jeong-sik/oas#1181 (api_usage type contract violation).
- #9935 / #9943 / #9953 (같은 클러스터 — context accounting 전반이 이 버그의 downstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)