### PR TITLE
fix(keeper-metrics): zero per-turn usage + latency on status_tick (#10018)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -926,14 +926,24 @@ let write_heartbeat_snapshot
         ; "trace_id", `String (Keeper_id.Trace_id.to_string meta_current.runtime.trace_id)
         ; "generation", `Int meta_current.runtime.generation
         ; "model_used", `String meta_current.runtime.usage.last_model_used
-        ; ( "usage"
+        ; (* #10018: status_tick is a snapshot, not an LLM-call event.
+             Emitting [runtime.usage.last_*_tokens] and [last_latency_ms]
+             caused the last turn's per-turn values to be repeat-emitted
+             on every heartbeat — observed analyst heartbeats 5 min
+             apart both reported [input=273325, output=8067,
+             total=281392, latency_ms=191894] while no LLM call ran.
+             Downstream daily token aggregates and p50 latency were
+             inflated by ~heartbeat-count per turn. Same "snapshot vs
+             event" boundary fix as #9950 for compaction fields.
+             [total_cost_usd] is a running total and remains emitted. *)
+          ( "usage"
           , `Assoc
-              [ "input_tokens", `Int meta_current.runtime.usage.last_input_tokens
-              ; "output_tokens", `Int meta_current.runtime.usage.last_output_tokens
-              ; "total_tokens", `Int meta_current.runtime.usage.last_total_tokens
+              [ "input_tokens", `Int 0
+              ; "output_tokens", `Int 0
+              ; "total_tokens", `Int 0
               ]
           )
-        ; "latency_ms", `Int meta_current.runtime.usage.last_latency_ms
+        ; "latency_ms", `Int 0
         ; "cost_usd", `Float meta_current.runtime.usage.total_cost_usd
         ; "context_ratio", `Float context_ratio_v
         ; "context_tokens", `Int token_count_v


### PR DESCRIPTION
## 요약

`status_tick` metric이 `runtime.usage.last_*_tokens`와 `last_latency_ms`를 매 heartbeat마다 repeat-emit → 마지막 turn의 per-turn 값이 heartbeat 수만큼 중복 집계. #9950이 `compaction_before/after_tokens` 필드에 적용한 fix를 `usage`와 `latency_ms`에도 확장.

Closes #10018.

## 증상

analyst keeper 2026-04-24 연속 2개 heartbeat:

```json
{"ts":"14:27:42","channel":"heartbeat","work_kind":"status_tick","usage":{"input_tokens":273325,"output_tokens":8067,"total_tokens":281392},"latency_ms":191894}
{"ts":"14:33:05","channel":"heartbeat","work_kind":"status_tick","usage":{"input_tokens":273325,"output_tokens":8067,"total_tokens":281392},"latency_ms":275368}
```

5분 간격으로 **같은 usage 값** 반복. state JSON의 `total_input_tokens: 273325` 등 last-turn 집계값과 정확히 일치.

## 근본 원인

`lib/keeper/keeper_keepalive.ml:931-936`:

```ocaml
; ( "usage"
  , `Assoc
      [ "input_tokens", `Int meta_current.runtime.usage.last_input_tokens
      ; "output_tokens", `Int meta_current.runtime.usage.last_output_tokens
      ; "total_tokens", `Int meta_current.runtime.usage.last_total_tokens
      ]
  )
; "latency_ms", `Int meta_current.runtime.usage.last_latency_ms
```

`last_*` 필드는 **마지막 turn**의 per-turn 값. `status_tick`은 LLM 호출 없는 snapshot인데도 이 값을 그대로 emit.

### #9950 패턴의 mirror

iter28 #9950이 같은 파일에서 `compaction_before/after_tokens`를 `0`으로 강제한 커밋 주석:

```ocaml
; (* #9943: status_tick is a snapshot, not a compaction
     event. Emitting [before = after = token_count_v]
     caused 956/972 (98.4%) of daily metric entries to
     look like compaction attempts with zero savings —
     a false signal that drowned actual compactions. *)
  "compaction_before_tokens", `Int 0
```

동일 분석이 `usage`와 `latency_ms`에도 적용. 본 PR은 그 fix의 field 확장.

## 변경 내용

```diff
- ( "usage"
-   , `Assoc
-       [ "input_tokens", `Int meta_current.runtime.usage.last_input_tokens
-       ; "output_tokens", `Int meta_current.runtime.usage.last_output_tokens
-       ; "total_tokens", `Int meta_current.runtime.usage.last_total_tokens
-       ]
-   )
- ; "latency_ms", `Int meta_current.runtime.usage.last_latency_ms
+ (* #10018: status_tick is a snapshot, not an LLM-call event ... *)
+ ( "usage"
+   , `Assoc
+       [ "input_tokens", `Int 0
+       ; "output_tokens", `Int 0
+       ; "total_tokens", `Int 0
+       ]
+   )
+ ; "latency_ms", `Int 0
```

### 유지한 필드

- `cost_usd` — `total_cost_usd`는 running total (per-turn 아님). heartbeat마다 emit해도 중복 집계 없음.
- `model_used` — last-turn identifier, 숫자 집계 아님.

## 영향

| 다운스트림 | Before | After |
|----------|--------|-------|
| Daily token aggregate | heartbeat 수만큼 inflation | 정확 (turn-only 합산) |
| Provider cost dashboard | inflation | 정확 |
| p50 latency | heartbeat 포함되어 long-tail 왜곡 | turn-only latency |
| Dashboard snapshot | 동일 (이미 heartbeat 제외) | 동일 |

기존 dashboard는 `channel=heartbeat` 필터로 status_tick을 제외했으므로 UI 영향은 없고, ad-hoc `jq` / logs 분석만 정확해짐.

## 검증

`dune build @check` exit 0. 기존 `test_observability_provider_contracts.ml:240` heartbeat 스냅샷 스키마 테스트는 필수 필드 검증만 하므로 통과 유지.

## 회귀 리스크

매우 낮음 — 필드 값 정정만. 필드 이름/존재 불변. 기존 consumer (dashboard, prometheus) 계약 유지.

## 참고

- Issue #10018 — 증상 및 suggested fix
- PR #9950 — 같은 파일의 compaction field에 대한 동일 fix (선행)
- 관련 #9943 (compaction noop 98.4%), #9933 (p50 latency 왜곡)
