### PR TITLE
fix(dashboard): harden websocket subscribe and ack handling

### DIFF
--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -280,6 +280,72 @@ describe('dashboard websocket route subscriptions', () => {
     expect(mockSockets[1]!.readyState).toBe(MockWebSocket.CONNECTING)
   })
 
+  it('reconnects when the initial route subscription never responds', async () => {
+    vi.useFakeTimers()
+    installWebSocketMocks()
+
+    await connectDashboardWS({ tab: 'workspace', params: { section: 'board' } })
+    const firstSocket = mockSockets[0]!
+    firstSocket.open()
+    const hello = parseRpc(firstSocket, 0)
+    firstSocket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
+    await flushPromises()
+
+    const subscribe = parseRpc(firstSocket, 1)
+    expect(subscribe.method).toBe('dashboard/subscribe')
+    expect(dashboardWsReady.value).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(15_000)
+    await flushPromises()
+
+    expect(firstSocket.readyState).toBe(MockWebSocket.CLOSED)
+    expect(dashboardWsConnected.value).toBe(false)
+    expect(dashboardWsReady.value).toBe(false)
+    expect(dashboardWsLastError.value).toBe(
+      'dashboard websocket rpc timed out: dashboard/subscribe',
+    )
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    await flushPromises()
+
+    expect(mockSockets).toHaveLength(2)
+    expect(mockSockets[1]!.readyState).toBe(MockWebSocket.CONNECTING)
+  })
+
+  it('acknowledges dashboard deltas as notifications without response tracking', async () => {
+    installWebSocketMocks()
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    const socket = mockSockets[0]!
+    socket.open()
+    const hello = parseRpc(socket, 0)
+    socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
+    await flushPromises()
+
+    const subscribe = parseRpc(socket, 1)
+    socket.receive({
+      jsonrpc: '2.0',
+      id: subscribe.id,
+      result: { snapshot: { seq: 1, slices: {} } },
+    })
+    await flushPromises()
+
+    socket.receive({
+      jsonrpc: '2.0',
+      method: 'dashboard/delta',
+      params: { seq: 42 },
+    })
+
+    const ack = JSON.parse(socket.sent[2] ?? '{}') as Record<string, unknown>
+    expect(ack).toMatchObject({
+      jsonrpc: '2.0',
+      method: 'dashboard/ack',
+      params: { seq: 42, bufferedAmount: 0 },
+    })
+    expect(ack).not.toHaveProperty('id')
+    expect(dashboardWsLastSeq.value).toBe(42)
+  })
+
   it('ignores stale subscribe snapshots that arrive after a newer route subscription', async () => {
     installWebSocketMocks()
 

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -161,6 +161,16 @@ function sendRpc(method: string, params: JsonObject): Promise<unknown> {
   })
 }
 
+function sendNotification(method: string, params: JsonObject): void {
+  if (!socket || socket.readyState !== WebSocket.OPEN) return
+  const currentSocket = socket
+  try {
+    currentSocket.send(JSON.stringify({ jsonrpc: '2.0', method, params }))
+  } catch {
+    // Best-effort telemetry; the close/error path owns reconnect decisions.
+  }
+}
+
 function handleRpcResponse(raw: JsonObject): boolean {
   if (typeof raw.id !== 'number') return false
   const pendingRpc = pending.get(raw.id)
@@ -202,10 +212,10 @@ function applyDelta(raw: unknown): void {
   }
   if (typeof delta.seq === 'number') {
     dashboardWsLastSeq.value = delta.seq
-    void sendRpc('dashboard/ack', {
+    sendNotification('dashboard/ack', {
       seq: delta.seq,
       bufferedAmount: socket?.bufferedAmount ?? 0,
-    }).catch(() => {})
+    })
   }
   if (typeof delta.slice !== 'string') return
   hydrateDashboardSlice(
@@ -281,6 +291,16 @@ function handleMessage(data: unknown): void {
   handleRawPush(record)
 }
 
+function reconnectAfterCurrentSocketFailure(ws: WebSocket, err: unknown): void {
+  if (socket !== ws) return
+  dashboardWsConnected.value = false
+  dashboardWsReady.value = false
+  dashboardWsLastError.value = err instanceof Error ? err.message : String(err)
+  lastSubscribeKey = ''
+  closeSocket()
+  scheduleReconnect()
+}
+
 export async function subscribeDashboardRoute(routeState: DashboardRouteState): Promise<void> {
   const desired = rememberRouteState(routeState)
   if (!dashboardWsReady.value) return
@@ -350,17 +370,10 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
         dashboardWsLastError.value = null
         if (desiredRouteState) {
           void subscribeDashboardRoute(desiredRouteState)
+            .catch(err => reconnectAfterCurrentSocketFailure(ws, err))
         }
       })
-      .catch(err => {
-        if (socket !== ws) return
-        dashboardWsConnected.value = false
-        dashboardWsReady.value = false
-        dashboardWsLastError.value = err instanceof Error ? err.message : String(err)
-        lastSubscribeKey = ''
-        closeSocket()
-        scheduleReconnect()
-      })
+      .catch(err => reconnectAfterCurrentSocketFailure(ws, err))
   }
   ws.onmessage = (event) => {
     if (socket !== ws) return

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -457,6 +457,10 @@ let handle_dashboard_ack_eio id ?mcp_session_id params =
   | Some _, None -> make_error ~id (-32602) "Missing params"
   | Some _, Some _ -> make_error ~id (-32602) "Invalid params: expected object"
 
+let handle_dashboard_ack_notification ?mcp_session_id params =
+  ignore (handle_dashboard_ack_eio `Null ?mcp_session_id params);
+  `Null
+
 let contains_casefold = Mcp_server_eio_call_tool.contains_casefold
 
 let tool_call_outcome (json : Yojson.Safe.t) =
@@ -544,7 +548,10 @@ let handle_request
             if not (is_valid_request_id id) then
               make_error ~id:`Null (-32600) "Invalid Request: id must be string, number, or null"
             else if Mcp_transport_protocol.is_notification req then
-              `Null
+              (match req.method_ with
+               | "dashboard/ack" ->
+                   handle_dashboard_ack_notification ?mcp_session_id req.params
+               | _ -> `Null)
             else
                 (try
                    (match req.method_ with


### PR DESCRIPTION
## Summary
- reconnect the dashboard websocket when the initial post-hello route subscription times out or fails
- send dashboard delta acknowledgements as JSON-RPC notifications so ack traffic does not allocate response timers
- accept dashboard/ack notifications server-side without emitting responses

## Validation
- pnpm typecheck
- pnpm lint
- pnpm exec vitest run src/dashboard-ws.test.ts --no-file-parallelism --maxWorkers=1 --reporter=verbose
- scripts/dune-local.sh build lib/masc_mcp.cma