### PR TITLE
[codex] Fix telemetry execution summary labels

### DIFF
--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -68,7 +68,7 @@ async function loadPanel(
     fetchTelemetrySummary,
     fetchDashboardShell: opts?.fetchDashboardShell ?? vi.fn().mockResolvedValue({ counts: { keepers: 2, agents: 0, tasks: 5 }, status: { version: '0.2.0', build: { uptime_seconds: 600 } } }),
     fetchDashboardTools: opts?.fetchDashboardTools ?? vi.fn().mockResolvedValue({ tool_inventory: { count: 10, tools: [], surface_summary: { public_mcp: { count: 5, tools: [] } } }, tool_usage: { total_calls: 100, never_called_count: 0 } }),
-    fetchDashboardNamespaceTruth: opts?.fetchDashboardNamespaceTruth ?? vi.fn().mockResolvedValue({ execution: { summary: { active_sessions: 1, active_operations: 3, continuity_alerts: 0 } } }),
+    fetchDashboardNamespaceTruth: opts?.fetchDashboardNamespaceTruth ?? vi.fn().mockResolvedValue({ execution: { summary: { active_operations: 3, blocked_operations: 1, continuity_alerts: 0 } } }),
   }))
   return import('./telemetry-unified')
 }
@@ -210,7 +210,9 @@ describe('TelemetryUnified', () => {
     expect(container.textContent).toContain('Keeper 현황 (live)')
     expect(container.textContent).toContain('Tool 등록 현황 (live)')
     expect(container.textContent).toContain('Agent 현황 (live)')
-    expect(container.textContent).toContain('1 활성 세션')
+    expect(container.textContent).toContain('3 활성 작업')
+    expect(container.textContent).toContain('1 차단 작업')
+    expect(container.textContent).not.toContain('활성 세션')
     expect(container.textContent).toContain('5 public')
   })
 
@@ -567,7 +569,7 @@ describe('TelemetryUnified', () => {
     const fetchTelemetrySummary = createAbortableResponse(baseSummary)
     const fetchDashboardShell = createAbortableResponse({ counts: { keepers: 2, agents: 0, tasks: 5 }, status: { version: '0.2.0', build: { uptime_seconds: 600 } } })
     const fetchDashboardTools = createAbortableResponse({ tool_inventory: { count: 10, tools: [], surface_summary: { public_mcp: { count: 5, tools: [] } } }, tool_usage: { total_calls: 100, never_called_count: 0 } })
-    const fetchDashboardNamespaceTruth = createAbortableResponse({ execution: { summary: { active_sessions: 1, active_operations: 3, continuity_alerts: 0 } } })
+    const fetchDashboardNamespaceTruth = createAbortableResponse({ execution: { summary: { active_operations: 3, blocked_operations: 1, continuity_alerts: 0 } } })
     const { TelemetryUnified } = await loadPanel(fetchTelemetry, fetchTelemetrySummary, {
       fetchDashboardShell,
       fetchDashboardTools,

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -29,8 +29,8 @@ interface StoreSnapshot {
   keepers: number
   agents: number
   tasks: number
-  activeSessions: number
   activeOperations: number
+  blockedOperations: number
   continuityAlerts: number
   toolsRegistered: number
   toolsPublic: number
@@ -42,7 +42,7 @@ interface StoreSnapshot {
 
 const EMPTY_STORE: StoreSnapshot = {
   keepers: 0, agents: 0, tasks: 0,
-  activeSessions: 0, activeOperations: 0, continuityAlerts: 0,
+  activeOperations: 0, blockedOperations: 0, continuityAlerts: 0,
   toolsRegistered: 0, toolsPublic: 0, toolsTotalCalls: 0, toolsNeverCalled: 0,
   version: null, uptime: null,
 }
@@ -626,8 +626,8 @@ export function TelemetryUnified() {
           keepers: counts?.keepers ?? 0,
           agents: counts?.agents ?? 0,
           tasks: counts?.tasks ?? 0,
-          activeSessions: execSummary?.active_sessions ?? 0,
           activeOperations: execSummary?.active_operations ?? 0,
+          blockedOperations: execSummary?.blocked_operations ?? 0,
           continuityAlerts: execSummary?.continuity_alerts ?? 0,
           toolsRegistered: inv?.count ?? 0,
           toolsPublic: surfacePublic,
@@ -756,7 +756,8 @@ export function TelemetryUnified() {
           title="Keeper 현황 (live)"
           value=${String(store.keepers)}
           detail=${[
-            `${store.activeSessions} 활성 세션`,
+            `${store.activeOperations} 활성 작업`,
+            store.blockedOperations > 0 ? `${store.blockedOperations} 차단 작업` : null,
             `${store.continuityAlerts} continuity 알림`,
             store.version ? `v${store.version}` : null,
             store.uptime != null ? `uptime ${Math.floor(store.uptime / 60)}m` : null,


### PR DESCRIPTION
## Summary

- Align the fleet telemetry Keeper live card with the namespace-truth execution summary contract.
- Use `active_operations` and `blocked_operations` instead of the retired/missing `active_sessions` field.
- Update the telemetry panel test fixture so it no longer locks in the misleading `활성 세션` copy.

## Root Cause

The backend execution summary no longer emits real session counts because the legacy session/team context was removed. The frontend still read `active_sessions` and defaulted it to `0`, so the dashboard could show `0 활성 세션` even while live operations and telemetry were present.

## Validation

- `pnpm install --offline --frozen-lockfile`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec vitest run src/components/telemetry-unified.test.ts --no-file-parallelism --maxWorkers=1 --reporter=verbose`
- `git diff --check`