### PR TITLE
[codex] Guard OAS after-turn usage telemetry

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -493,6 +493,7 @@
    keeper_exec_context
    keeper_tools_oas
    keeper_guards
+   keeper_usage_trust
    keeper_hooks_oas
    keeper_extend_turns
    keeper_llm_bridge

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -69,6 +69,58 @@ let record_tool_use_failure ~keeper_name ~tool_name =
   Prometheus.inc_counter tool_use_failure_metric
     ~labels:[ ("keeper", keeper_name); ("tool", tool_name) ] ()
 
+let zero_usage : Oas.Types.api_usage =
+  {
+    input_tokens = 0;
+    output_tokens = 0;
+    cache_creation_input_tokens = 0;
+    cache_read_input_tokens = 0;
+    cost_usd = None;
+  }
+
+let canonical_model_id_of_telemetry ~model
+    (telemetry : Oas.Types.inference_telemetry option) =
+  match telemetry with
+  | Some { canonical_model_id = Some id; _ } when String.trim id <> "" ->
+      String.trim id
+  | _ -> model
+
+let context_max_of_telemetry
+    (telemetry : Oas.Types.inference_telemetry option) =
+  match telemetry with
+  | Some { effective_context_window = Some n; _ } when n > 0 -> n
+  | _ -> 0
+
+let classify_usage_trust ?usage ~model ~telemetry () =
+  let usage_reported, usage =
+    match usage with
+    | Some usage -> true, usage
+    | None -> false, zero_usage
+  in
+  Keeper_usage_trust.classify ~usage_reported ~usage ~model_used:model
+    ~resolved_model_id:(canonical_model_id_of_telemetry ~model telemetry)
+    ~context_max:(context_max_of_telemetry telemetry)
+
+let record_usage_anomaly_metrics ~keeper_name ~model usage_trust =
+  if not (Keeper_usage_trust.is_trusted usage_trust) then
+    let reasons =
+      match Keeper_usage_trust.reasons usage_trust with
+      | [] -> [Keeper_usage_trust.to_string usage_trust]
+      | reasons -> reasons
+    in
+    List.iter
+      (fun reason ->
+         Prometheus.inc_counter
+           Prometheus.metric_keeper_usage_anomalies
+           ~labels:
+             [
+               ("keeper_name", keeper_name);
+               ("model", model);
+               ("reason", reason);
+             ]
+           ())
+      reasons
+
 (* #9868: use [pricing_for_model_opt] so unknown models surface as
    [None] and get a loud catalog-miss signal instead of silently
    returning $0. [pricing_for_model] (non-opt) collapses unknown into
@@ -218,6 +270,7 @@ let emit_cost_event
     ~(output_tokens : int)
     ~(cost_usd : float)
     ?(usage_missing : bool = false)
+    ?usage_trust
     ?(telemetry : Oas.Types.inference_telemetry option)
     () : unit =
   let path = Filename.concat masc_root "costs.jsonl" in
@@ -228,6 +281,36 @@ let emit_cost_event
   let float_field name = function
     | Some v -> [ (name, `Float v) ]
     | None -> []
+  in
+  let usage_for_trust : Oas.Types.api_usage =
+    {
+      input_tokens;
+      output_tokens;
+      cache_creation_input_tokens = 0;
+      cache_read_input_tokens = 0;
+      cost_usd = Some cost_usd;
+    }
+  in
+  let usage_trust =
+    match usage_trust with
+    | Some usage_trust -> usage_trust
+    | None ->
+        classify_usage_trust
+          ?usage:(if usage_missing then None else Some usage_for_trust)
+          ~model ~telemetry ()
+  in
+  let usage_trusted = Keeper_usage_trust.is_trusted usage_trust in
+  let safe_input_tokens = if usage_trusted then input_tokens else 0 in
+  let safe_output_tokens = if usage_trusted then output_tokens else 0 in
+  let safe_cost_usd = if usage_trusted then cost_usd else 0.0 in
+  let raw_usage_fields =
+    if usage_missing || usage_trusted then []
+    else
+      [
+        ("raw_input_tokens", `Int input_tokens);
+        ("raw_output_tokens", `Int output_tokens);
+        ("raw_cost_usd", `Float cost_usd);
+      ]
   in
   let telemetry_fields = match telemetry with
     | Some t ->
@@ -245,7 +328,9 @@ let emit_cost_event
   in
   let wall_tok_s_fields =
     float_field "tokens_per_second"
-      (wall_tokens_per_second ~usage_missing ~output_tokens ~telemetry)
+      (if usage_trusted then
+         wall_tokens_per_second ~usage_missing ~output_tokens ~telemetry
+       else None)
   in
   let entry = `Assoc ([
     ("agent", `String agent_name);
@@ -253,13 +338,16 @@ let emit_cost_event
     ( "provider",
       `String (provider_of_model_with_telemetry ~model ~telemetry) );
     ("model", `String model);
-    ("input_tokens", `Int input_tokens);
-    ("output_tokens", `Int output_tokens);
-    ("cost_usd", `Float cost_usd);
+    ("input_tokens", `Int safe_input_tokens);
+    ("output_tokens", `Int safe_output_tokens);
+    ("cost_usd", `Float safe_cost_usd);
     ("usage_missing", `Bool usage_missing);
     ("timestamp", `String (Types.now_iso ()));
     ("source", `String "auto_trajectory");
-  ] @ wall_tok_s_fields @ telemetry_fields) in
+  ]
+  @ Keeper_usage_trust.json_fields usage_trust
+  @ raw_usage_fields
+  @ wall_tok_s_fields @ telemetry_fields) in
   let line = Yojson.Safe.to_string entry ^ "\n" in
   (try Fs_compat.append_file path line
    with Eio.Cancel.Cancelled _ as e -> raise e
@@ -467,21 +555,51 @@ let make_hooks
       | Oas.Hooks.AfterTurn { turn; response } ->
         let meta = !meta_ref in
         let model = response.model in
+        let usage_trust =
+          classify_usage_trust ?usage:response.usage ~model
+            ~telemetry:response.telemetry ()
+        in
+        let usage_trusted = Keeper_usage_trust.is_trusted usage_trust in
+        record_usage_anomaly_metrics ~keeper_name:meta.name ~model usage_trust;
+        let raw_input_tok, raw_output_tok =
+          match response.usage with
+          | Some u -> u.input_tokens, u.output_tokens
+          | None -> 0, 0
+        in
         let input_tok, output_tok, turn_cost_usd, usage_missing =
           match response.usage with
-          | Some u ->
+          | Some u when usage_trusted ->
               let provider_kind = provider_kind_of_telemetry response.telemetry in
               ( u.input_tokens,
                 u.output_tokens,
                 cost_usd_for_usage ?provider_kind ~model u,
                 false )
+          | Some _ -> (0, 0, 0.0, false)
           | None -> (0, 0, 0.0, true)
         in
+        let cost_usd_for_event =
+          if usage_trusted then turn_cost_usd
+          else
+            match response.usage with
+            | Some { cost_usd = Some cost; _ } when cost > 0.0 -> cost
+            | Some _ | None -> 0.0
+        in
         let total_tok = input_tok + output_tok in
+        if (not usage_missing) && not usage_trusted then
+          Log.Keeper.warn
+            "keeper:%s after_turn usage telemetry untrusted model=%s resolved_model=%s reasons=%s input=%d output=%d context_max=%d"
+            meta.name model
+            (canonical_model_id_of_telemetry ~model response.telemetry)
+            (String.concat ","
+               (match Keeper_usage_trust.reasons usage_trust with
+                | [] -> [Keeper_usage_trust.to_string usage_trust]
+                | reasons -> reasons))
+            raw_input_tok raw_output_tok
+            (context_max_of_telemetry response.telemetry);
         (* Provider prefix cache token tracking (Anthropic).
            Non-Anthropic providers report 0 for these fields. *)
         (match response.usage with
-         | Some u ->
+         | Some u when usage_trusted ->
            let cc = u.cache_creation_input_tokens in
            let cr = u.cache_read_input_tokens in
            if cc > 0 then
@@ -492,7 +610,7 @@ let make_hooks
              Prometheus.inc_counter
                "masc_provider_prefix_cache_read_tokens_total"
                ~delta:(Float.of_int cr) ()
-         | None -> ());
+         | Some _ | None -> ());
         (* Inference latency histogram for /metrics endpoint.
            Split observations into three buckets so we can tell "metric is
            silent because no telemetry" apart from "metric is silent because
@@ -537,8 +655,10 @@ let make_hooks
           | None -> 0
         in
         let wall_tok_s_opt =
-          wall_tokens_per_second ~usage_missing ~output_tokens:output_tok
-            ~telemetry:response.telemetry
+          if usage_trusted then
+            wall_tokens_per_second ~usage_missing ~output_tokens:output_tok
+              ~telemetry:response.telemetry
+          else None
         in
         record_llm_tok_s_metrics ~model ~telemetry:response.telemetry;
         let wall_tok_s = fmt_tok_s wall_tok_s_opt in
@@ -554,8 +674,9 @@ let make_hooks
          | Some acc ->
            emit_cost_event ~masc_root:acc.masc_root
              ~agent_name:meta.name ~task_id:acc.task_id
-             ~model ~input_tokens:input_tok ~output_tokens:output_tok
-             ~cost_usd:turn_cost_usd ~usage_missing
+             ~model ~input_tokens:raw_input_tok ~output_tokens:raw_output_tok
+             ~cost_usd:cost_usd_for_event ~usage_missing
+             ~usage_trust
              ?telemetry:response.telemetry ()
          | None -> ());
         let text = Oas.Types.text_of_content response.content in

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -87,40 +87,26 @@ type turn_mode =
   | Skip_text
   | Noop
 
-type usage_trust =
+type usage_trust = Keeper_usage_trust.t =
   | Usage_missing
   | Usage_trusted
   | Usage_untrusted of string list
 
-let usage_absurd_token_threshold = 1_000_000
+let classify_usage_trust ~(usage_reported : bool)
+    ~(usage : Oas.Types.api_usage)
+    ~(model_used : string)
+    ~(resolved_model_id : string)
+    ~(context_max : int) : usage_trust =
+  Keeper_usage_trust.classify ~usage_reported ~usage ~model_used
+    ~resolved_model_id ~context_max
 
-let usage_trust_is_trusted = function
-  | Usage_trusted -> true
-  | Usage_missing | Usage_untrusted _ -> false
+let usage_trust_is_trusted = Keeper_usage_trust.is_trusted
 
-let usage_trust_to_string = function
-  | Usage_missing -> "missing"
-  | Usage_trusted -> "trusted"
-  | Usage_untrusted _ -> "untrusted"
+let usage_trust_to_string = Keeper_usage_trust.to_string
 
-let usage_trust_reasons = function
-  | Usage_untrusted reasons -> reasons
-  | Usage_missing | Usage_trusted -> []
+let usage_trust_reasons = Keeper_usage_trust.reasons
 
-let usage_trust_json_fields trust =
-  [
-    ("usage_trust", `String (usage_trust_to_string trust));
-    ( "usage_anomaly",
-      `Bool
-        (match trust with
-         | Usage_untrusted _ -> true
-         | Usage_missing | Usage_trusted -> false) );
-    ( "usage_anomaly_reasons",
-      `List (List.map (fun reason -> `String reason) (usage_trust_reasons trust)) );
-  ]
-
-let add_reason reason reasons =
-  if List.mem reason reasons then reasons else reason :: reasons
+let usage_trust_json_fields = Keeper_usage_trust.json_fields
 
 (* #9959 defensive observability: surface usage-field trust into
    Prometheus so operators can alert on rising untrusted/missing
@@ -159,37 +145,6 @@ let record_usage_trust ~keeper_name ~(trust : usage_trust) =
        to 0.0 for this turn by [usage_trust_is_trusted] gate."
       keeper_name (String.concat "," reasons)
   | Usage_missing | Usage_trusted -> ()
-
-let classify_usage_trust ~(usage_reported : bool)
-    ~(usage : Oas.Types.api_usage)
-    ~(model_used : string)
-    ~(resolved_model_id : string)
-    ~(context_max : int) : usage_trust =
-  if not usage_reported then Usage_missing
-  else
-    let reasons = ref [] in
-    let add reason = reasons := add_reason reason !reasons in
-    let model_used = String.trim model_used in
-    let resolved_model_id = String.trim resolved_model_id in
-    let model_missing value = value = "" || String.equal value "unknown" in
-    if model_missing model_used && model_missing resolved_model_id then
-      add "missing_model_id";
-    if usage.input_tokens < 0 then add "negative_input_tokens";
-    if usage.output_tokens < 0 then add "negative_output_tokens";
-    if usage.cache_creation_input_tokens < 0 then
-      add "negative_cache_creation_tokens";
-    if usage.cache_read_input_tokens < 0 then add "negative_cache_read_tokens";
-    if usage.input_tokens = 0 && usage.output_tokens = 0 then
-      add "zero_token_usage_reported";
-    if usage.input_tokens > usage_absurd_token_threshold then
-      add "input_tokens_gt_1m";
-    if usage.output_tokens > usage_absurd_token_threshold then
-      add "output_tokens_gt_1m";
-    if context_max > 0 && usage.input_tokens > context_max * 2 then
-      add "input_tokens_gt_2x_context_max";
-    match List.rev !reasons with
-    | [] -> Usage_trusted
-    | reasons -> Usage_untrusted reasons
 
 let turn_mode_to_string = function
   | Tool_use -> "tool_use"

--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -23,7 +23,7 @@ type turn_mode =
   | Skip_text
   | Noop
 
-type usage_trust =
+type usage_trust = Keeper_usage_trust.t =
   | Usage_missing
   | Usage_trusted
   | Usage_untrusted of string list

--- a/lib/keeper/keeper_usage_trust.ml
+++ b/lib/keeper/keeper_usage_trust.ml
@@ -1,0 +1,71 @@
+(** Shared trust classification for LLM usage telemetry.
+
+    This module is intentionally independent of the unified keeper metrics
+    pipeline so both unified turns and OAS after-turn hooks can apply the same
+    guard before aggregating tokens, cost, or wall-clock tok/s. *)
+
+type t =
+  | Usage_missing
+  | Usage_trusted
+  | Usage_untrusted of string list
+
+let absurd_token_threshold = 1_000_000
+
+let is_trusted = function
+  | Usage_trusted -> true
+  | Usage_missing | Usage_untrusted _ -> false
+
+let to_string = function
+  | Usage_missing -> "missing"
+  | Usage_trusted -> "trusted"
+  | Usage_untrusted _ -> "untrusted"
+
+let reasons = function
+  | Usage_untrusted reasons -> reasons
+  | Usage_missing | Usage_trusted -> []
+
+let json_fields trust =
+  [
+    ("usage_trust", `String (to_string trust));
+    ( "usage_anomaly",
+      `Bool
+        (match trust with
+         | Usage_untrusted _ -> true
+         | Usage_missing | Usage_trusted -> false) );
+    ( "usage_anomaly_reasons",
+      `List (List.map (fun reason -> `String reason) (reasons trust)) );
+  ]
+
+let add_reason reason reasons =
+  if List.mem reason reasons then reasons else reason :: reasons
+
+let classify ~(usage_reported : bool)
+    ~(usage : Oas.Types.api_usage)
+    ~(model_used : string)
+    ~(resolved_model_id : string)
+    ~(context_max : int) : t =
+  if not usage_reported then Usage_missing
+  else
+    let reasons = ref [] in
+    let add reason = reasons := add_reason reason !reasons in
+    let model_used = String.trim model_used in
+    let resolved_model_id = String.trim resolved_model_id in
+    let model_missing value = value = "" || String.equal value "unknown" in
+    if model_missing model_used && model_missing resolved_model_id then
+      add "missing_model_id";
+    if usage.input_tokens < 0 then add "negative_input_tokens";
+    if usage.output_tokens < 0 then add "negative_output_tokens";
+    if usage.cache_creation_input_tokens < 0 then
+      add "negative_cache_creation_tokens";
+    if usage.cache_read_input_tokens < 0 then add "negative_cache_read_tokens";
+    if usage.input_tokens = 0 && usage.output_tokens = 0 then
+      add "zero_token_usage_reported";
+    if usage.input_tokens > absurd_token_threshold then
+      add "input_tokens_gt_1m";
+    if usage.output_tokens > absurd_token_threshold then
+      add "output_tokens_gt_1m";
+    if context_max > 0 && usage.input_tokens > context_max * 2 then
+      add "input_tokens_gt_2x_context_max";
+    match List.rev !reasons with
+    | [] -> Usage_trusted
+    | reasons -> Usage_untrusted reasons

--- a/lib/keeper/keeper_usage_trust.mli
+++ b/lib/keeper/keeper_usage_trust.mli
@@ -1,0 +1,22 @@
+(** Shared trust classification for LLM usage telemetry. *)
+
+type t =
+  | Usage_missing
+  | Usage_trusted
+  | Usage_untrusted of string list
+
+val classify :
+  usage_reported:bool ->
+  usage:Oas.Types.api_usage ->
+  model_used:string ->
+  resolved_model_id:string ->
+  context_max:int ->
+  t
+
+val is_trusted : t -> bool
+
+val to_string : t -> string
+
+val reasons : t -> string list
+
+val json_fields : t -> (string * Yojson.Safe.t) list

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -133,6 +133,53 @@ let test_emit_cost_event_writes_wall_tok_s_without_provider_timings () =
      | `Null -> true
      | _ -> false)
 
+let test_emit_cost_event_marks_untrusted_usage () =
+  let root = temp_dir () in
+  let telemetry : Agent_sdk.Types.inference_telemetry =
+    {
+      system_fingerprint = None;
+      timings = None;
+      reasoning_tokens = None;
+      request_latency_ms = 250;
+      peak_memory_gb = None;
+      provider_kind = Some Llm_provider.Provider_kind.Ollama;
+      reasoning_effort = None;
+      canonical_model_id = Some "ollama:qwen3.6:27b-coding-nvfp4";
+      effective_context_window = Some 128000;
+      provider_internal_action_count = None;
+    }
+  in
+  Hooks.emit_cost_event ~masc_root:root ~agent_name:"keeper"
+    ~task_id:None ~model:"ollama:qwen3.6:27b-coding-nvfp4"
+    ~input_tokens:2_000_000 ~output_tokens:50 ~cost_usd:0.99
+    ~telemetry ();
+  let json = read_jsonl_line (Filename.concat root "costs.jsonl") in
+  check string "usage trust" "untrusted"
+    (json |> member "usage_trust" |> to_string);
+  check bool "usage anomaly" true
+    (json |> member "usage_anomaly" |> to_bool);
+  let reasons =
+    json |> member "usage_anomaly_reasons" |> to_list |> List.map to_string
+  in
+  check bool "reason includes absurd input" true
+    (List.mem "input_tokens_gt_1m" reasons);
+  check bool "reason includes context overrun" true
+    (List.mem "input_tokens_gt_2x_context_max" reasons);
+  check int "safe input tokens" 0
+    (json |> member "input_tokens" |> to_int);
+  check int "safe output tokens" 0
+    (json |> member "output_tokens" |> to_int);
+  check (float 0.001) "safe cost" 0.0
+    (json |> member "cost_usd" |> to_float);
+  check int "raw input tokens retained" 2_000_000
+    (json |> member "raw_input_tokens" |> to_int);
+  check int "raw output tokens retained" 50
+    (json |> member "raw_output_tokens" |> to_int);
+  check bool "wall tok/s omitted" true
+    (match json |> member "tokens_per_second" with
+     | `Null -> true
+     | _ -> false)
+
 let test_cost_usd_for_usage_falls_back_for_paid_provider () =
   let model = "openai:gpt-4.1" in
   let usage = make_usage ~input_tokens:1000 ~output_tokens:500 () in
@@ -398,6 +445,8 @@ let () =
             test_emit_cost_event_uses_typed_provider_kind_for_bare_model
         ; test_case "emit_cost_event computes wall tok/s without native timings" `Quick
             test_emit_cost_event_writes_wall_tok_s_without_provider_timings
+        ; test_case "emit_cost_event marks untrusted usage" `Quick
+            test_emit_cost_event_marks_untrusted_usage
         ; test_case "cost fallback estimates paid provider usage" `Quick
             test_cost_usd_for_usage_falls_back_for_paid_provider
         ; test_case "cost fallback preserves reported cost" `Quick


### PR DESCRIPTION
## Summary

- Extract the keeper usage trust classifier into `Keeper_usage_trust` so OAS hooks and unified metrics share the same policy.
- Gate OAS after-turn aggregation for untrusted usage: token totals, estimated cost, prefix-cache tokens, and wall tok/sec no longer enter safe aggregates.
- Preserve raw diagnostic fields and anomaly reasons in cost events so bogus provider usage is visible without contaminating telemetry.

## Context

Follow-up after #9995 merged. That PR guarded unified metrics/dashboard aggregation; this patch extends the same trust boundary to the OAS after-turn hook path.

## Validation

- `scripts/check-oas-pin.sh`
- `scripts/dune-local.sh build test/test_keeper_hooks_oas_telemetry.exe test/test_keeper_unified.exe test/test_model_inference_metrics.exe`
- `./_build/default/test/test_keeper_hooks_oas_telemetry.exe`
- `./_build/default/test/test_model_inference_metrics.exe`
- `env MASC_BASE_PATH=/tmp/masc-mcp-test-base ./_build/default/test/test_keeper_unified.exe`
