### PR TITLE
fix(keeper): accept honest refusal when no specific tool applies (#10008 failure mode 1)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1563,9 +1563,23 @@ let run_turn
                 else current_params.tool_choice
               in
               let turn_completion_contract =
-                if computed_surface.tool_gate_requested
-                then Keeper_tool_disclosure.Require_tool_use
-                else Keeper_tool_disclosure.completion_contract_of_tool_choice tool_choice
+                (* #10008: the affordance-driven tool gate still
+                   requests Require_tool_use, but if [preferred_...]
+                   explicitly chose [Auto] (no applicable specific
+                   tool), honor that signal and relax the contract.
+                   Otherwise the gate would reject the model's honest
+                   refusal ("no eligible task to claim") as a
+                   contract violation, producing the 0/14 proactive
+                   success rate observed for the new keeper cohort. *)
+                match computed_surface.tool_gate_requested, tool_choice with
+                | true, Some Oas.Types.Auto ->
+                  Keeper_tool_disclosure.completion_contract_of_tool_choice
+                    tool_choice
+                | true, _ ->
+                  Keeper_tool_disclosure.Require_tool_use
+                | false, _ ->
+                  Keeper_tool_disclosure.completion_contract_of_tool_choice
+                    tool_choice
               in
               completion_contract_ref := turn_completion_contract;
               if turn_completion_contract = Keeper_tool_disclosure.Require_tool_use

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -96,7 +96,23 @@ let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
      && has_task_claim_affordance turn_affordances
      && List.mem "keeper_task_claim" allowed_tool_names
   then Oas.Types.Tool "keeper_task_claim"
-  else Oas.Types.Any
+  else if not has_current_task then
+    (* #10008: no active task and no applicable specific claim tool
+       to force.  Fall back to [Auto] instead of [Any] so the model
+       can respond with an honest refusal ("no eligible task to
+       claim", "no matching affordance to exercise") without
+       triggering the [Require_tool_use] contract violation.  The
+       caller ([Keeper_agent_run]) reads [tool_choice = Auto] as
+       "MASC dropped the specific-tool demand" and relaxes the
+       completion contract to [Allow_text_or_tool].  Otherwise the
+       affordance-driven gate would self-contradict — force a tool
+       call when no applicable tool exists. *)
+    Oas.Types.Auto
+  else
+    (* Active task in progress: keep the strict gate.  The keeper is
+       expected to make progress via some tool call (board update,
+       task_update, task_done, etc.). *)
+    Oas.Types.Any
 
 let owned_active_task_id_for_meta ~(config : Coord.config)
     ~(meta : Keeper_types.keeper_meta) =

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4923,22 +4923,46 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
          (Printf.sprintf
             "expected Any when already owning work, got %s"
             (Agent_sdk.Types.show_tool_choice other)));
+  (* #10008: when no specific tool is applicable for the current
+     affordance, fall back to [Auto] so the model can respond with
+     honest refusal text ("no eligible task to claim") instead of
+     being forced into a [Require_tool_use] contract violation. *)
   (match
      choose
        ~turn_affordances:[ "task_audit" ]
        ~allowed_tool_names:[ "keeper_tasks_list"; "keeper_board_post" ]
        ()
    with
-   | Agent_sdk.Types.Any -> ()
+   | Agent_sdk.Types.Auto -> ()
    | other ->
        fail
-         (Printf.sprintf "expected Any for task audit, got %s"
+         (Printf.sprintf
+            "expected Auto for task audit without applicable tool \
+             (#10008), got %s"
             (Agent_sdk.Types.show_tool_choice other)));
-  match choose ~allowed_tool_names:[ "keeper_board_post" ] () with
+  (match choose ~allowed_tool_names:[ "keeper_board_post" ] () with
+  | Agent_sdk.Types.Auto -> ()
+  | other ->
+      fail
+        (Printf.sprintf
+           "expected Auto when claim is unavailable and keeper is \
+            idle (#10008), got %s"
+           (Agent_sdk.Types.show_tool_choice other)));
+  (* Active task keeper retains the strict gate even without a
+     specific applicable tool — the caller is expected to make
+     progress via board_post, task_update, etc. *)
+  match
+    choose ~has_current_task:true
+      ~turn_affordances:[ "task_audit" ]
+      ~allowed_tool_names:[ "keeper_tasks_list"; "keeper_board_post" ]
+      ()
+  with
   | Agent_sdk.Types.Any -> ()
   | other ->
       fail
-        (Printf.sprintf "expected Any when claim is unavailable, got %s"
+        (Printf.sprintf
+           "expected Any for active-task keeper (must make \
+            progress), got %s"
            (Agent_sdk.Types.show_tool_choice other))
 
 (* ---------- render_inline_skip_reason tests ---------- *)


### PR DESCRIPTION
## 요약

#10008 의 3개 failure mode 중 **mode 1** 을 고침.

신규 cohort (analyst/verifier/scholar/executor/velvet-hammer) 가 14 proactive / 0 성공. analyst/verifier 의 실패 원인은 gate 자기모순:

- Affordance 는 `task_claim` granted
- `preferred_tool_choice_for_required_turn` 이 catch-all fallback `Any` 반환
- Completion contract 가 `Require_tool_use` 로 강제
- 모델은 올바르게 판단 — eligible task 없음, text 로 정직한 refusal
- Contract 가 text-only 응답을 rejection 처리 → `proactive_outcome=error`

"Must call tool" 이 "no applicable tool exists" 를 만나면 false constraint. 이 PR 은 두 경우를 분리:

- Active task 진행 중 → 기존 `Any` (keeper 는 progress 해야 함)
- No active task + claim tool 부재 → `Auto` 로 relax (honest refusal 허용)

Contract 유도 site 도 `tool_choice = Some Auto` 를 존중 — gate 가 requested 라도 [Allow_text_or_tool] 로 완화.

## 변경 파일

- `lib/keeper/keeper_agent_tool_surface.ml` — `preferred_tool_choice_for_required_turn` 의 fallback branch 를 `has_current_task` 로 분기. Active=Any, idle=Auto.
- `lib/keeper/keeper_agent_run.ml` line 1565-1568 — contract 유도가 `tool_choice = Auto` 를 감지하면 gate-requested 여도 `completion_contract_of_tool_choice` 경로 (= Allow_text_or_tool) 로 폴백.
- `test/test_keeper_unified.ml` — 기존 `test_preferred_tool_choice_for_required_turn_claims_first` 를 새 의도에 맞춰 갱신:
  - task_audit affordance + no audit tool + idle → **Auto** (기존 Any)
  - claim affordance + only board_post allowed + idle → **Auto** (기존 Any)
  - active task + task_audit affordance + no audit tool → **Any** (신규 회귀 가드 — active-task keeper 는 여전히 strict gate)

## 로컬 검증

```
$ MASC_BASE_PATH=/tmp/masc-test-10008 dune exec test/test_keeper_unified.exe
Test Successful in 1.851s. 249 tests run.
```

`dune build` clean.

## 왜 근원 fix 인가

- **Parse, don't validate** 에 가까운 구조적 수정: MASC 가 "이 turn 에서 요구할 specific tool 이 없다" 를 결정하면 contract 는 그 결정을 존중. 계층 간 일관성.
- **기존 intent 보존**: active-task keeper 는 기존 동작 유지. 새 행동은 idle keeper + 적용 불가 affordance 조합에서만 발동.
- **OAS 영역 건드리지 않음**: 본 이슈의 대안 fix 로 "OAS completion_contract 에 text-only refusal 수락 경로 추가" 가 제안됐지만, 그건 OAS SDK 책임. MASC 측에서 contract 선택을 올바르게 하면 OAS 는 그대로 신뢰.
- **`feedback_oas-must-not-know-masc.md` 준수**: MASC 가 contract 선택 책임을 진다.

## 미검증 / 후속

- **Failure mode 2** (`per_turn=30s` fantasy, velvet-hammer 423.8s budget) — wall-clock 기반 budget 재설계. 별도 PR.
- **Failure mode 3** (scholar/executor never_started — scheduler bias) — proactive scheduler 의 selection criteria audit. 별도 PR.
- **Config 이원화** (신규 TOML minimal vs 기존 full) — onboarding pipeline 문서화. Infra/docs.
- 실제 fleet 에서 analyst/verifier 의 proactive outcome 이 `text_response_accepted` 로 전환되는지는 머지 후 metric 관찰.

## 관련

- #10008 (root — 0/14 proactive).
- #9851 (qa-king 424s budget timeout — 같은 per_turn heuristic 이슈).
- #9933 (p50 17min turn latency — per_turn=30s 가 34× fantasy 임을 입증하는 실측).

🤖 Generated with [Claude Code](https://claude.com/claude-code)