### PR TITLE
[codex] Type cascade fail-open rotation catalog

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -255,34 +255,49 @@ let required_tool_rotation_candidate name =
     (String.equal normalized Keeper_config.local_only_cascade_name
      || String.equal normalized Keeper_config.local_recovery_cascade_name)
 
+let legacy_degraded_rotation_candidates
+    ~(base_cascade : string)
+    ~(tool_requirement : string) =
+  let normalized_base = normalized_cascade_name base_cascade in
+  let default_cascade =
+    normalized_cascade_name Keeper_config.default_cascade_name
+  in
+  let local_recovery_cascade =
+    normalized_cascade_name Keeper_config.local_recovery_cascade_name
+  in
+  if String.equal tool_requirement "required" then
+    [ normalized_base; default_cascade ]
+  else
+    [ normalized_base; default_cascade; local_recovery_cascade ]
+
+let normalize_rotation_candidates candidates =
+  candidates
+  |> List.filter_map (fun candidate ->
+         let trimmed = String.trim candidate in
+         if String.equal trimmed "" then None else Some (normalized_cascade_name trimmed))
+  |> dedupe_keep_order
+
 let degraded_rotation_candidates
+    ~(rotation_cascades : string list option)
     ~(base_cascade : string)
     ~(effective_cascade : string)
     ~(tool_requirement : string) =
-  let normalized_base = normalized_cascade_name base_cascade in
   let normalized_effective = normalized_cascade_name effective_cascade in
   let candidates =
-    if String.equal tool_requirement "required" then
-      [
-        normalized_base;
-        Keeper_config.default_cascade_name;
-      ]
-    else
-      [
-        normalized_base;
-        Keeper_config.default_cascade_name;
-        Keeper_config.local_recovery_cascade_name;
-      ]
+    match rotation_cascades with
+    | None ->
+        legacy_degraded_rotation_candidates ~base_cascade ~tool_requirement
+    | Some catalog ->
+        normalize_rotation_candidates (base_cascade :: catalog)
   in
   candidates
-  |> List.map normalized_cascade_name
-  |> dedupe_keep_order
   |> List.filter (fun candidate ->
          (not (String.equal candidate normalized_effective))
          && (not (String.equal tool_requirement "required")
              || required_tool_rotation_candidate candidate))
 
 let degraded_rotation_after_recoverable_error
+    ?rotation_cascades
     ~(base_cascade : string)
     ~(effective_cascade : string)
     ~(tool_requirement : string)
@@ -297,6 +312,7 @@ let degraded_rotation_after_recoverable_error
         |> dedupe_keep_order
       in
       degraded_rotation_candidates
+        ~rotation_cascades
         ~base_cascade ~effective_cascade ~tool_requirement
       |> List.find_opt (fun candidate ->
              not (List.exists (String.equal candidate) attempted))

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -72,10 +72,13 @@ val degraded_retry_after_recoverable_error :
   degraded_retry option
 
 (** Returns the next untried cascade in the same-turn recovery group for a
-    whole-cascade failure. This broadens beyond the legacy one-hop
-    local_recovery fallback, while keeping required-tool turns on lanes that
-    can still be filtered for tool-capable providers. *)
+    whole-cascade failure. [rotation_cascades], when provided, is the
+    runtime/catalog-owned candidate order; otherwise the legacy
+    base/default/local_recovery group is used. Required-tool turns keep the
+    tool requirement and leave concrete provider filtering to the cascade
+    resolver. *)
 val degraded_rotation_after_recoverable_error :
+  ?rotation_cascades:string list ->
   base_cascade:string ->
   effective_cascade:string ->
   tool_requirement:string ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -219,13 +219,41 @@ type cascade_execution = {
   max_tokens : int;
 }
 
+let fail_open_rotation_cascades_from_catalog
+    ~(catalog_names : string list)
+    ~(keeper_assignable : string list) =
+  if catalog_names = [] then None
+  else
+    let is_reserved_recovery name =
+      String.equal name Keeper_config.default_cascade_name
+      || String.equal name Keeper_config.local_recovery_cascade_name
+    in
+    let is_keeper_assignable name =
+      List.exists (String.equal name) keeper_assignable
+    in
+    match
+      catalog_names
+      |> List.filter (fun name ->
+             is_reserved_recovery name || is_keeper_assignable name)
+      |> dedupe_keep_order
+    with
+    | [] -> None
+    | candidates -> Some candidates
+
+let active_fail_open_rotation_cascades () =
+  fail_open_rotation_cascades_from_catalog
+    ~catalog_names:(Keeper_cascade_profile.catalog_names ())
+    ~keeper_assignable:(Keeper_cascade_profile.keeper_catalog_names ())
+
 let next_fail_open_cascade_for_turn
+    ?rotation_cascades
     ~(base_cascade : string)
     ~(effective_cascade : string)
     ~(tool_requirement : string)
     ~(attempted_cascades : string list)
     (err : Oas.Error.sdk_error) : EC.degraded_retry option =
   EC.degraded_rotation_after_recoverable_error
+    ?rotation_cascades
     ~base_cascade ~effective_cascade ~tool_requirement
     ~attempted_cascades err
 
@@ -1093,6 +1121,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   ?event_bus:(Keeper_event_bus.get ())
                   ())
           in
+          let fail_open_rotation_cascades =
+            active_fail_open_rotation_cascades ()
+          in
           let rec retry_loop ~run_meta ~(execution : cascade_execution)
               ~run_generation
               ~attempt ~is_retry
@@ -1241,6 +1272,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                 end else
                   match
                     next_fail_open_cascade_for_turn
+                      ?rotation_cascades:fail_open_rotation_cascades
                       ~base_cascade:meta.cascade_name
                       ~effective_cascade:execution.cascade_name
                       ~tool_requirement:initial_tool_requirement

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -117,11 +117,22 @@ val fail_open_local_only_when_unavailable :
   string list ->
   string
 
+(** Pure merge step for runtime-owned fail-open rotation candidates. The
+    active path feeds this from the live cascade catalog: catalog order is
+    preserved while retaining only reserved recovery profiles and
+    keeper-assignable profiles. *)
+val fail_open_rotation_cascades_from_catalog :
+  catalog_names:string list ->
+  keeper_assignable:string list ->
+  string list option
+
 (** Resolve the next cascade to try after an auto-recoverable failure.
-    Uses the current effective cascade plus the turn tool requirement, then
-    suppresses suggestions that would loop back to a cascade already
-    attempted during the current turn. Exposed for targeted tests. *)
+    Uses the current effective cascade, the turn tool requirement, and
+    optionally a runtime/catalog-owned rotation order, then suppresses
+    suggestions that would loop back to a cascade already attempted during
+    the current turn. Exposed for targeted tests. *)
 val next_fail_open_cascade_for_turn :
+  ?rotation_cascades:string list ->
   base_cascade:string ->
   effective_cascade:string ->
   tool_requirement:string ->

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3144,6 +3144,152 @@ let test_next_fail_open_cascade_for_turn_retries_required_tool_contract_violatio
   expect_degraded_retry "required contract degraded retry"
     KC.default_cascade_name "required_tool_contract_violation" degraded_retry
 
+let test_next_fail_open_cascade_for_turn_uses_catalog_rotation_profile () =
+  let degraded_retry =
+    UT.next_fail_open_cascade_for_turn
+      ~rotation_cascades:
+        [
+          KC.default_cascade_name;
+          KC.local_recovery_cascade_name;
+          "ollama_only";
+        ]
+      ~base_cascade:"tool_rerank"
+      ~effective_cascade:"tool_rerank"
+      ~tool_requirement:"optional"
+      ~attempted_cascades:
+        [
+          "tool_rerank";
+          KC.default_cascade_name;
+          KC.local_recovery_cascade_name;
+        ]
+      (wrapped_claude_limit_error ())
+  in
+  expect_degraded_retry "catalog degraded retry"
+    "ollama_only" "hard_quota" degraded_retry
+
+let test_next_fail_open_cascade_for_turn_does_not_inject_default_when_catalog_omits_it () =
+  let degraded_retry =
+    UT.next_fail_open_cascade_for_turn
+      ~rotation_cascades:[ "resilient_breaker" ]
+      ~base_cascade:"tool_rerank"
+      ~effective_cascade:"tool_rerank"
+      ~tool_requirement:"optional"
+      ~attempted_cascades:[ "tool_rerank" ]
+      (wrapped_claude_limit_error ())
+  in
+  expect_degraded_retry "catalog-only degraded retry"
+    "resilient_breaker" "hard_quota" degraded_retry
+
+let test_next_fail_open_cascade_for_required_tool_filters_local_recovery_catalog () =
+  let degraded_retry =
+    UT.next_fail_open_cascade_for_turn
+      ~rotation_cascades:[ KC.local_recovery_cascade_name; "big_three" ]
+      ~base_cascade:KC.default_cascade_name
+      ~effective_cascade:KC.tool_use_strict_cascade_name
+      ~tool_requirement:"required"
+      ~attempted_cascades:[ KC.tool_use_strict_cascade_name ]
+      (required_tool_contract_violation_error ())
+  in
+  expect_degraded_retry "required catalog degraded retry"
+    "big_three" "required_tool_contract_violation" degraded_retry
+
+let test_next_fail_open_cascade_for_required_tool_rejects_local_recovery_only_catalog () =
+  let degraded_retry =
+    UT.next_fail_open_cascade_for_turn
+      ~rotation_cascades:[ KC.local_recovery_cascade_name ]
+      ~base_cascade:KC.tool_use_strict_cascade_name
+      ~effective_cascade:KC.tool_use_strict_cascade_name
+      ~tool_requirement:"required"
+      ~attempted_cascades:[ KC.tool_use_strict_cascade_name ]
+      (required_tool_contract_violation_error ())
+  in
+  check bool "required catalog local_recovery-only group is exhausted" true
+    (Option.is_none degraded_retry)
+
+let test_degraded_rotation_after_recoverable_error_filters_required_catalog_directly () =
+  let degraded_retry =
+    EC.degraded_rotation_after_recoverable_error
+      ~rotation_cascades:[ KC.local_recovery_cascade_name; " big_three " ]
+      ~base_cascade:KC.tool_use_strict_cascade_name
+      ~effective_cascade:KC.tool_use_strict_cascade_name
+      ~tool_requirement:"required"
+      ~attempted_cascades:[ KC.tool_use_strict_cascade_name ]
+      (required_tool_contract_violation_error ())
+  in
+  expect_degraded_retry "required catalog classifier rotation"
+    "big_three" "required_tool_contract_violation" degraded_retry
+
+let test_degraded_rotation_after_recoverable_error_normalizes_catalog_directly () =
+  let degraded_retry =
+    EC.degraded_rotation_after_recoverable_error
+      ~rotation_cascades:[ ""; " tool_rerank "; " catalog_next "; "catalog_next" ]
+      ~base_cascade:" tool_rerank "
+      ~effective_cascade:"tool_rerank"
+      ~tool_requirement:"optional"
+      ~attempted_cascades:[ "tool_rerank" ]
+      (wrapped_claude_limit_error ())
+  in
+  expect_degraded_retry "normalized catalog classifier rotation"
+    "catalog_next" "hard_quota" degraded_retry
+
+let test_fail_open_rotation_cascades_from_catalog_merges_reserved_and_assignable () =
+  let rotation =
+    UT.fail_open_rotation_cascades_from_catalog
+      ~catalog_names:
+        [
+          KC.default_cascade_name;
+          KC.local_recovery_cascade_name;
+          "ollama_only";
+        ]
+      ~keeper_assignable:[ KC.default_cascade_name; "ollama_only" ]
+  in
+  check (option (list string)) "catalog-derived rotation order"
+    (Some
+       [
+         KC.default_cascade_name;
+         KC.local_recovery_cascade_name;
+         "ollama_only";
+       ])
+    rotation
+
+let test_fail_open_rotation_cascades_from_catalog_preserves_catalog_order () =
+  let rotation =
+    UT.fail_open_rotation_cascades_from_catalog
+      ~catalog_names:
+        [
+          "ollama_only";
+          KC.local_recovery_cascade_name;
+          KC.default_cascade_name;
+        ]
+      ~keeper_assignable:[ KC.default_cascade_name; "ollama_only" ]
+  in
+  check (option (list string)) "catalog-derived rotation preserves catalog order"
+    (Some
+       [
+         "ollama_only";
+         KC.local_recovery_cascade_name;
+         KC.default_cascade_name;
+       ])
+    rotation
+
+let test_fail_open_rotation_cascades_from_catalog_empty_when_unresolved () =
+  let rotation =
+    UT.fail_open_rotation_cascades_from_catalog
+      ~catalog_names:[]
+      ~keeper_assignable:[ KC.default_cascade_name ]
+  in
+  check (option (list string)) "unresolved catalog falls back to legacy path"
+    None rotation
+
+let test_fail_open_rotation_cascades_from_catalog_empty_without_assignable_candidates () =
+  let rotation =
+    UT.fail_open_rotation_cascades_from_catalog
+      ~catalog_names:[ "experimental_only" ]
+      ~keeper_assignable:[]
+  in
+  check (option (list string)) "resolved catalog without assignable candidates"
+    None rotation
+
 (* context_overflow_limit is now in OAS as Retry.extract_context_limit.
    These tests verify the OAS SSOT API is accessible from MASC. *)
 let test_context_overflow_limit_parses_common_oas_errors () =
@@ -5630,6 +5776,36 @@ let () =
           test_case "required tool contract violations rotate retry lane"
             `Quick
             test_next_fail_open_cascade_for_turn_retries_required_tool_contract_violation;
+          test_case "catalog rotation can continue beyond reserved recovery"
+            `Quick
+            test_next_fail_open_cascade_for_turn_uses_catalog_rotation_profile;
+          test_case "catalog rotation does not inject missing default"
+            `Quick
+            test_next_fail_open_cascade_for_turn_does_not_inject_default_when_catalog_omits_it;
+          test_case "required-tool catalog rotation filters local recovery"
+            `Quick
+            test_next_fail_open_cascade_for_required_tool_filters_local_recovery_catalog;
+          test_case "required-tool local-recovery-only catalog exhausts"
+            `Quick
+            test_next_fail_open_cascade_for_required_tool_rejects_local_recovery_only_catalog;
+          test_case "classifier filters required-tool catalog rotation"
+            `Quick
+            test_degraded_rotation_after_recoverable_error_filters_required_catalog_directly;
+          test_case "classifier normalizes catalog rotation"
+            `Quick
+            test_degraded_rotation_after_recoverable_error_normalizes_catalog_directly;
+          test_case "catalog rotation order merges reserved and assignable"
+            `Quick
+            test_fail_open_rotation_cascades_from_catalog_merges_reserved_and_assignable;
+          test_case "catalog rotation preserves catalog order"
+            `Quick
+            test_fail_open_rotation_cascades_from_catalog_preserves_catalog_order;
+          test_case "unresolved catalog keeps legacy rotation fallback"
+            `Quick
+            test_fail_open_rotation_cascades_from_catalog_empty_when_unresolved;
+          test_case "resolved catalog without assignable candidates falls back"
+            `Quick
+            test_fail_open_rotation_cascades_from_catalog_empty_without_assignable_candidates;
         ] );
       ( "tool_classification",
         [


### PR DESCRIPTION
## Summary
- Let cascade fail-open rotation accept runtime/catalog-owned candidate order instead of stopping at the hardcoded base/default/local_recovery lane.
- Derive keeper turn rotation candidates from the active cascade catalog, preserving catalog order while retaining only reserved recovery and keeper-assignable profiles.
- Keep required-tool turns from rotating into local_only/local_recovery while leaving concrete provider capability filtering to the cascade resolver.

## Validation
- `scripts/dune-local.sh build test/test_keeper_unified.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-cascade-provider-decision-head ./_build/default/test/test_keeper_unified.exe test phase_gate` (37 tests)
- `git diff --check HEAD~1..HEAD`
- `scripts/review/local-review.sh --base origin/main --head HEAD --format markdown --no-cache` with `glm-direct-no-thinking`: `No findings.`