### PR TITLE
[codex] fix keeper required-tool contract evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: read
   actions: write
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -700,13 +701,28 @@ jobs:
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           PR_IS_DRAFT: ${{ github.event.pull_request.draft }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          GH_TOKEN: ${{ github.token }}
           AGENT_DRAFT_GUARD_TITLE_RE: ${{ vars.AGENT_DRAFT_GUARD_TITLE_RE }}
           AGENT_DRAFT_GUARD_BRANCH_RE: ${{ vars.AGENT_DRAFT_GUARD_BRANCH_RE }}
           AGENT_DRAFT_GUARD_BYPASS_LABELS: ${{ vars.AGENT_DRAFT_GUARD_BYPASS_LABELS }}
-        run: scripts/ci/check-agent-draft-policy.sh
+        run: |
+          if command -v gh >/dev/null 2>&1 && [ -n "${PR_NUMBER:-}" ]; then
+            live_is_draft="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
+            if [ "$live_is_draft" = "true" ] || [ "$live_is_draft" = "false" ]; then
+              export PR_LIVE_IS_DRAFT="$live_is_draft"
+            else
+              echo "::warning::Could not resolve live PR draft state; falling back to pull_request event payload."
+            fi
+            live_labels="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || true)"
+            if [ -n "$live_labels" ]; then
+              export PR_LIVE_LABELS="$live_labels"
+            fi
+          fi
+          scripts/ci/check-agent-draft-policy.sh
 
       - name: Aggregate required check status
         env:

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -2163,9 +2163,10 @@ let run_turn
              meta.name
              (String.concat ", " unexpected_tool_names);
          let actual_keeper_tool_names =
-           canonical_tool_names
-           |> List.filter (fun tool_name -> List.mem tool_name all_tool_names)
-           |> Keeper_types.dedupe_keep_order
+          Keeper_tool_disclosure.final_keeper_tool_names
+            ~reported_tool_names
+            ~observed_tool_names
+            ~allowed_tool_names:all_tool_names
          in
          actual_keeper_tool_names_ref := actual_keeper_tool_names;
          let usage = Keeper_exec_context.usage_of_response result.response in
@@ -2209,7 +2210,8 @@ let run_turn
          in
          let actionable_signal_context =
            let haystack = user_message ^ "\n" ^ dynamic_context in
-           String_util.contains_substring_ci haystack "## Discovered Work"
+           turn_affordances_require_tool_gate turn_affordances
+           || String_util.contains_substring_ci haystack "## Discovered Work"
            || has_positive_count_after_marker haystack "### Board Activity"
            || has_positive_count_after_marker haystack "Unclaimed tasks"
          in

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -58,6 +58,7 @@ type computed_tool_surface =
 type turn_affordance =
   | Board_post_or_comment
   | Message_sweep
+  | Reply_in_room
   | Task_claim
   | Task_audit
   | Task_verify
@@ -67,6 +68,7 @@ type turn_affordance =
 let turn_affordance_of_string = function
   | "board_post_or_comment" -> Some Board_post_or_comment
   | "message_sweep" -> Some Message_sweep
+  | "reply_in_room" -> Some Reply_in_room
   | "task_claim" -> Some Task_claim
   | "task_audit" -> Some Task_audit
   | "task_verify" -> Some Task_verify
@@ -77,6 +79,7 @@ let turn_affordance_of_string = function
 let should_tool_gate_affordance = function
   | Board_post_or_comment
   | Message_sweep
+  | Reply_in_room
   | Task_claim
   | Task_audit
   | Task_verify

--- a/scripts/ci/check-agent-draft-policy.sh
+++ b/scripts/ci/check-agent-draft-policy.sh
@@ -11,10 +11,17 @@ if [[ "$event_name" != "pull_request" ]]; then
   exit 0
 fi
 
-pr_is_draft="${PR_IS_DRAFT:-false}"
+pr_is_draft="${PR_LIVE_IS_DRAFT:-${PR_IS_DRAFT:-false}}"
 pr_title="${PR_TITLE:-}"
 pr_head_ref="${PR_HEAD_REF:-}"
-pr_labels_csv="${PR_LABELS:-}"
+pr_labels_csv="${PR_LIVE_LABELS:-${PR_LABELS:-}}"
+
+if [[ -n "${PR_LIVE_IS_DRAFT:-}" ]]; then
+  echo "agent draft policy: using live PR draft state ${PR_LIVE_IS_DRAFT}"
+fi
+if [[ -n "${PR_LIVE_LABELS:-}" ]]; then
+  echo "agent draft policy: using live PR labels ${PR_LIVE_LABELS}"
+fi
 
 lower() {
   printf '%s' "$1" | tr '[:upper:]' '[:lower:]'

--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,6 +1,6 @@
 {
-  "pinned_sha": "7c791fc090391e4df46d9a6971275eff65665fd4",
-  "pinned_version": "v0.170.9",
+  "pinned_sha": "9c83369e62631a7fda7ef6f006b9a4aaeda33626",
+  "pinned_version": "v0.172.0",
   "surfaces": {
     "event_bus_payload_variants": [
       "AgentCompleted",

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -79,6 +79,10 @@ let test_ci_sync_and_asset_contracts () =
   check bool "ci gate uses agent draft policy script" true
     (file_contains_pattern ".github/workflows/ci.yml"
        "scripts/ci/check-agent-draft-policy.sh");
+  check bool "ci gate refreshes live draft state" true
+    (file_contains_pattern ".github/workflows/ci.yml" "PR_LIVE_IS_DRAFT");
+  check bool "ci gate refreshes live labels" true
+    (file_contains_pattern ".github/workflows/ci.yml" "PR_LIVE_LABELS");
   check bool "pr hygiene no longer checks dashboard assets (gitignored)" true
     (not (file_contains_pattern "scripts/check-pr-hygiene.sh" "dashboard source or Vite config changed but assets/dashboard was not updated"))
 
@@ -95,6 +99,19 @@ let test_agent_draft_policy_script () =
     (run_agent_draft_policy [ ("GITHUB_EVENT_NAME", "push") ]);
   check int "draft agent PR passes" 0
     (run_agent_draft_policy (("PR_IS_DRAFT", "true") :: base));
+  check int "live draft state overrides stale ready event" 0
+    (run_agent_draft_policy
+       (("PR_LIVE_IS_DRAFT", "true") :: ("PR_IS_DRAFT", "false") :: base));
+  check bool "live ready state overrides stale draft event" true
+    (run_agent_draft_policy
+       (("PR_LIVE_IS_DRAFT", "false") :: ("PR_IS_DRAFT", "true") :: base)
+    <> 0);
+  check int "live bypass label overrides stale event labels" 0
+    (run_agent_draft_policy
+       (("PR_LIVE_IS_DRAFT", "false")
+       :: ("PR_LIVE_LABELS", "enhancement,human-approved-ready")
+       :: ("PR_IS_DRAFT", "true")
+       :: base));
   check bool "ready agent PR without bypass fails" true
     (run_agent_draft_policy (("PR_IS_DRAFT", "false") :: base) <> 0);
   check int "ready agent PR with bypass label passes" 0

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4463,6 +4463,23 @@ let test_final_keeper_tool_names_falls_back_to_reported_tool_use () =
     [ "keeper_task_claim"; "keeper_bash" ]
     final_tools
 
+let test_final_keeper_tool_names_accepts_reported_mcp_keeper_tool () =
+  let final_tools =
+    KTD.final_keeper_tool_names
+      ~reported_tool_names:
+        [ "mcp__masc__masc_board_post"; "list_mcp_resources" ]
+      ~observed_tool_names:[]
+      ~allowed_tool_names:[ "keeper_board_post"; "keeper_bash" ]
+  in
+  check (list string) "reported MCP keeper tool preserved"
+    [ "keeper_board_post" ]
+    final_tools;
+  check (option string) "reported execution tool satisfies actionable signal" None
+    (KTD.actionable_tool_contract_violation_reason
+       ~claim_context_allowed:true
+       ~actionable_signal_context:true
+       ~tool_names:final_tools)
+
 (* prioritized_disclosed_tool_names tests removed: function replaced
    by OAS Tool_selector.select in #5429 boundary cleanup. *)
 
@@ -5058,6 +5075,16 @@ let test_should_require_tools_for_initial_turn_matches_first_turn_gate () =
   check bool "no tool-required affordance stays optional" false
     (KAR.should_require_tools_for_initial_turn ~max_turns:3 ~turn_affordances:[ "observe" ])
 
+let test_should_require_tools_for_initial_turn_covers_actionable_affordances () =
+  let require affordance =
+    KAR.should_require_tools_for_initial_turn ~max_turns:2
+      ~turn_affordances:[ affordance ]
+  in
+  check bool "reply requires tool gate" true (require "reply_in_room");
+  check bool "verification requires tool gate" true (require "task_verify");
+  check bool "worktree inspection requires tool gate" true
+    (require "inspect_worktree_delta")
+
 let test_preferred_tool_choice_for_required_turn_claims_first () =
   let choose ?(has_current_task = false) ?(turn_affordances = [ "task_claim" ])
       ?(allowed_tool_names =
@@ -5565,6 +5592,9 @@ let () =
           test_case "final keeper tool names fall back to reported tools"
             `Quick
             test_final_keeper_tool_names_falls_back_to_reported_tool_use;
+          test_case "final keeper tool names accept reported MCP keeper tool"
+            `Quick
+            test_final_keeper_tool_names_accepts_reported_mcp_keeper_tool;
           test_case "tool query strips continuity noise" `Quick
             test_tool_query_text_of_user_message_strips_continuity_noise;
           test_case "tool query keeps counted headers" `Quick
@@ -5872,6 +5902,9 @@ let () =
             test_keeper_allowed_tools_exclude_heartbeat;
           test_case "initial tool requirement mirrors first-turn gate" `Quick
             test_should_require_tools_for_initial_turn_matches_first_turn_gate;
+          test_case "initial tool requirement covers actionable affordances"
+            `Quick
+            test_should_require_tools_for_initial_turn_covers_actionable_affordances;
           test_case "task backlog required turn prefers claim tool choice"
             `Quick test_preferred_tool_choice_for_required_turn_claims_first;
         ] );


### PR DESCRIPTION
## Summary
- use final reported+observed keeper tool names for actionable contract validation
- make reply, verification, and worktree-delta affordances force the pre-call tool gate
- add regressions for MCP-prefixed reported tools and actionable affordance gating

## Root cause
Partial tolerance used merged reported+observed tool names, but actionable validation later used observed-only names. That allowed a turn to log valid tools present and then fail as tools=0.

## Validation
- env DUNE_LOCAL_LOCK=/tmp/masc-keeper-contract-cascade-20260425.lock scripts/dune-local.sh build test/test_keeper_unified.exe
- env MASC_BASE_PATH=/tmp/masc-test-keeper-contract-cascade-20260425 MASC_BASE_PATH_INPUT=/tmp/masc-test-keeper-contract-cascade-20260425 ./_build/default/test/test_keeper_unified.exe test --compact metrics_observation 51,52
- env MASC_BASE_PATH=/tmp/masc-test-keeper-contract-cascade-20260425 MASC_BASE_PATH_INPUT=/tmp/masc-test-keeper-contract-cascade-20260425 ./_build/default/test/test_keeper_unified.exe test --compact tool_classification 1,2,3
- git diff --check