### PR TITLE
fix(dashboard-bonsai): replace Attr.arialabel + broken comment (#10023)

### DIFF
--- a/dashboard_bonsai/src/archive_runs_view.ml
+++ b/dashboard_bonsai/src/archive_runs_view.ml
@@ -264,7 +264,7 @@ let view_loop (l : Archive_runs_types.loop) =
   let keeps = l.total_keeps in
   let discards = l.total_discards in
   Node.div
-    ~attrs:[ Style.loop; Attr.role "listitem"; Attr.arialabel l.goal ]
+    ~attrs:[ Style.loop; Attr.role "listitem"; Attr.create "aria-label" l.goal ]
     [ Pill.view
         ~color:(pill_color l.status)
         ~label:(Archive_runs_types.status_label l.status)
@@ -357,11 +357,11 @@ let render ~(shell : Overview_types.response) (r : Archive_runs_types.response) 
     ; (match r.loops with
        | [] ->
          Node.div
-           ~attrs:[ Style.quiet; Attr.role "status"; Attr.arialabel "No archive runs" ]
+           ~attrs:[ Style.quiet; Attr.role "status"; Attr.create "aria-label" "No archive runs" ]
            [ Node.text "no runs recorded yet." ]
        | loops ->
          Node.div
-           ~attrs:[ Style.loop_list; Attr.role "list"; Attr.arialabel "Archive runs" ]
+           ~attrs:[ Style.loop_list; Attr.role "list"; Attr.create "aria-label" "Archive runs" ]
            (List.map loops ~f:view_loop))
     ]
 ;;

--- a/dashboard_bonsai/src/ctx_chart.ml
+++ b/dashboard_bonsai/src/ctx_chart.ml
@@ -208,7 +208,7 @@ let view ?(keepers : Keepers_types.response = Keepers_types.fixture) () =
         ; svg_a "preserveAspectRatio" "none"
         ; Style.svg
         ; Attr.role "img"
-        ; Attr.arialabel "Context usage chart over 60 minutes"
+        ; Attr.create "aria-label" "Context usage chart over 60 minutes"
         ]
       (hairlines @ guides @ polylines)
   in

--- a/dashboard_bonsai/src/dead_keepers_view.ml
+++ b/dashboard_bonsai/src/dead_keepers_view.ml
@@ -124,11 +124,11 @@ let view_dead_list (dead : Keepers_types.keeper list) =
   match dead with
   | [] ->
     Node.div
-      ~attrs:[ Style.quiet; Attr.role "status"; Attr.arialabel "No dead keepers" ]
+      ~attrs:[ Style.quiet; Attr.role "status"; Attr.create "aria-label" "No dead keepers" ]
       [ Node.text "fleet is whole — no keepers have fallen." ]
   | ks ->
     Node.div
-      ~attrs:[ Attr.role "list"; Attr.arialabel "Dead keepers list" ]
+      ~attrs:[ Attr.role "list"; Attr.create "aria-label" "Dead keepers list" ]
       (List.map ks ~f:Roster.view_slot_of_keeper)
 ;;
 

--- a/dashboard_bonsai/src/flame.ml
+++ b/dashboard_bonsai/src/flame.ml
@@ -105,5 +105,5 @@ let view_mini ~(segments : (kind * int) list) =
                [ Node.text (Printf.sprintf "%d" pct) ]
            ]))
   in
-  Node.div ~attrs:[ Style.flame; Attr.role "img"; Attr.arialabel "Tool category time distribution" ] [ bar; legend ]
+  Node.div ~attrs:[ Style.flame; Attr.role "img"; Attr.create "aria-label" "Tool category time distribution" ] [ bar; legend ]
 ;;

--- a/dashboard_bonsai/src/goals_view.ml
+++ b/dashboard_bonsai/src/goals_view.ml
@@ -375,7 +375,7 @@ let rec view_node ~(depth : int) (n : Goals_types.node) : Node.t =
     else Node.h3 ~attrs:[ Style.goal_title ] [ Node.text (truncate ~max_len:60 n.title) ]
   in
   Node.div
-    ~attrs:(Style.goal :: Attr.role "listitem" :: Attr.arialabel n.title :: indent_attr)
+    ~attrs:(Style.goal :: Attr.role "listitem" :: Attr.create "aria-label" n.title :: indent_attr)
     (List.concat
        [ [ Node.div
              ~attrs:[ Style.goal_head ]
@@ -387,7 +387,7 @@ let rec view_node ~(depth : int) (n : Goals_types.node) : Node.t =
                  ~attrs:[ Style.conv_bar_wrap ]
                  [ Node.text (Printf.sprintf "%d%%" n.convergence_pct)
                  ; Node.div
-                     ~attrs:[ Style.conv_bar; Attr.role "progressbar"; Attr.arialabel "Goal convergence"
+                     ~attrs:[ Style.conv_bar; Attr.role "progressbar"; Attr.create "aria-label" "Goal convergence"
                             ; Attr.create "aria-valuenow" (Int.to_string n.convergence_pct)
                             ; Attr.create "aria-valuemin" "0"
                             ; Attr.create "aria-valuemax" "100" ]
@@ -473,11 +473,11 @@ let render ~(shell : Overview_types.response) (r : Goals_types.response) : Node.
     ; (match r.tree with
        | [] ->
          Node.div
-           ~attrs:[ Style.quiet; Attr.role "status"; Attr.arialabel "No goals" ]
+           ~attrs:[ Style.quiet; Attr.role "status"; Attr.create "aria-label" "No goals" ]
            [ Node.text "goal tree is empty." ]
        | nodes ->
          Node.div
-           ~attrs:[ Style.tree; Attr.role "list"; Attr.arialabel "Goal tree" ]
+           ~attrs:[ Style.tree; Attr.role "list"; Attr.create "aria-label" "Goal tree" ]
            (List.map nodes ~f:(view_node ~depth:0)))
     ]
 ;;

--- a/dashboard_bonsai/src/hello_view.ml
+++ b/dashboard_bonsai/src/hello_view.ml
@@ -1,7 +1,7 @@
 (** Landing view — placeholder at [/dashboard/b] until a real home page lands.
 
     Styling follows the MASC Design System (dark-fantasy theme). Tokens
-    reference CSS variables from [colors_and_type.css] via [var(--*)]. *)
+    reference CSS variables from [colors_and_type.css] via [var] tokens. *)
 
 open! Core
 open! Bonsai_web

--- a/dashboard_bonsai/src/hud.ml
+++ b/dashboard_bonsai/src/hud.ml
@@ -115,14 +115,14 @@ let cell ?(v_class : v_class = `Neutral) ~k ~v () =
     | Some c -> [ Style.v; c ]
   in
   Node.div
-    ~attrs:[ Style.cell; Attr.arialabel (k ^ ": " ^ v) ]
+    ~attrs:[ Style.cell; Attr.create "aria-label" (k ^ ": " ^ v) ]
     [ Node.div ~attrs:[ Style.k ] [ Node.text k ]
     ; Node.div ~attrs:v_attrs [ Node.text v ]
     ]
 ;;
 
 let strip ?(label : string = "Key metrics") cells =
-  Node.div ~attrs:[ Style.hud; Attr.role "status"; Attr.arialabel label ] cells
+  Node.div ~attrs:[ Style.hud; Attr.role "status"; Attr.create "aria-label" label ] cells
 
 (** Extract "HH:MM:SS" from an ISO-8601 UTC timestamp
     (e.g. "2026-04-20T04:02:07Z" → "04:02:07"). Falls back to the full

--- a/dashboard_bonsai/src/keepers_directory.ml
+++ b/dashboard_bonsai/src/keepers_directory.ml
@@ -1120,14 +1120,14 @@ let view
   match rows with
   | [] ->
     Node.div
-      ~attrs:[ Style.quiet; Attr.role "status"; Attr.arialabel "Directory loading" ]
+      ~attrs:[ Style.quiet; Attr.role "status"; Attr.create "aria-label" "Directory loading" ]
       [ Node.text
           "runtime/mission snapshot이 아직 조용합니다. keepers summary만 먼저 올라왔을 가능성이 있습니다."
       ]
   | _ ->
     let selected = selected_row rows selected_name in
     Node.div
-      ~attrs:[ Style.directory; Attr.role "grid"; Attr.arialabel "Keepers directory" ]
+      ~attrs:[ Style.directory; Attr.role "grid"; Attr.create "aria-label" "Keepers directory" ]
       ([ Node.div
            ~attrs:[ Style.head; Attr.role "row" ]
            [ Node.div ~attrs:[ Attr.role "columnheader" ] [ Node.text "Sigil" ]
@@ -1172,7 +1172,7 @@ let view
            [ Style.row
            ; Attr.tabindex 0
            ; Attr.role "row"
-           ; Attr.arialabel row.name
+           ; Attr.create "aria-label" row.name
            ]
            @ row_click_effect row.name
            @ if is_selected then [ Style.row_selected ] else []
@@ -1355,7 +1355,7 @@ let note_section row =
     ; (match notes with
        | [] ->
          Node.div
-           ~attrs:[ Style.quiet; Attr.role "status"; Attr.arialabel "No keeper notes" ]
+           ~attrs:[ Style.quiet; Attr.role "status"; Attr.create "aria-label" "No keeper notes" ]
            [ Node.span ~attrs:[ Attr.create "lang" "ko" ] [ Node.text "trust/note/current_work evidence가 아직 없습니다." ] ]
        | entries ->
          Node.div
@@ -1454,7 +1454,7 @@ let preview_section row =
     Node.div
       [ Shell_view.aside_title "Preview"
       ; Node.div
-          ~attrs:[ Style.quiet; Attr.role "status"; Attr.arialabel "No brief preview" ]
+          ~attrs:[ Style.quiet; Attr.role "status"; Attr.create "aria-label" "No brief preview" ]
           [ Node.span ~attrs:[ Attr.create "lang" "ko" ] [ Node.text "agent brief preview가 아직 없습니다." ] ]
       ]
   else
@@ -1484,7 +1484,7 @@ let aside
       ~attrs:[ Shell_view.Style.aside ]
       [ Shell_view.aside_title ~right:"fleet quiet" "Focus"
       ; Node.div
-          ~attrs:[ Style.quiet; Attr.role "status"; Attr.arialabel "No directory row selected" ]
+          ~attrs:[ Style.quiet; Attr.role "status"; Attr.create "aria-label" "No directory row selected" ]
           [ Node.span ~attrs:[ Attr.create "lang" "ko" ] [ Node.text "선택 가능한 directory row가 아직 없습니다." ] ]
       ]
   | Some row ->

--- a/dashboard_bonsai/src/keepers_view.ml
+++ b/dashboard_bonsai/src/keepers_view.ml
@@ -185,7 +185,7 @@ let render
         ]
       else
         [ Node.div
-            ~attrs:[ Style.quiet; Attr.role "status"; Attr.arialabel "No live keepers" ]
+            ~attrs:[ Style.quiet; Attr.role "status"; Attr.create "aria-label" "No live keepers" ]
             [ Node.span ~attrs:[ Attr.create "lang" "ko" ]
                 [ Node.text
                     "keepers summary endpoint is quiet — directory snapshot만 먼저 올라와 있습니다."

--- a/dashboard_bonsai/src/logs_view.ml
+++ b/dashboard_bonsai/src/logs_view.ml
@@ -1512,7 +1512,7 @@ let view_tombstrip ?(states = keeper_fsm_states) () =
       [ Node.text label ]
   in
   Node.div
-    ~attrs:[ Style.tombstrip; Attr.arialabel "Keeper FSM states" ]
+    ~attrs:[ Style.tombstrip; Attr.create "aria-label" "Keeper FSM states" ]
     (List.map states ~f:tile)
 ;;
 
@@ -1639,7 +1639,7 @@ let render_response
       in
       Node.div
         ~attrs:[ Style.tape_fade ]
-        [ Node.div ~attrs:[ Style.tape; Attr.role "log"; Attr.arialabel "Log entries" ] rendered
+        [ Node.div ~attrs:[ Style.tape; Attr.role "log"; Attr.create "aria-label" "Log entries" ] rendered
         ; Node.div ~attrs:[ Style.tape_end ] []
         ]
   in
@@ -1704,7 +1704,7 @@ let render_response
              [ Node.text label ]
          in
          Node.div
-           ~attrs:[ Style.chip_group; Attr.role "group"; Attr.arialabel "Log level filter" ]
+           ~attrs:[ Style.chip_group; Attr.role "group"; Attr.create "aria-label" "Log level filter" ]
            [ filter_chip ~level:"debug" ~label:"debug+"
            ; filter_chip ~level:"info" ~label:"info+"
            ; filter_chip ~level:"warn" ~label:"warn+"

--- a/dashboard_bonsai/src/meta.ml
+++ b/dashboard_bonsai/src/meta.ml
@@ -72,7 +72,7 @@ let strip ?(label : string option) (cells : Node.t list) : Node.t =
   let base = [ Style.strip ] in
   let attrs =
     match label with
-    | Some l -> Attr.arialabel l :: base
+    | Some l -> Attr.create "aria-label" l :: base
     | None -> base
   in
   Node.div ~attrs cells

--- a/dashboard_bonsai/src/overview_view.ml
+++ b/dashboard_bonsai/src/overview_view.ml
@@ -232,7 +232,7 @@ let view_hero_panel (r : Overview_types.response) =
     ~attrs:[ Style.panel ]
     [ Node.h2 ~attrs:[ Style.panel_title ] [ Node.text "runtime · identity" ]
     ; Node.div
-        ~attrs:[ Style.kv_row; Attr.role "list"; Attr.arialabel "Runtime identity" ]
+        ~attrs:[ Style.kv_row; Attr.role "list"; Attr.create "aria-label" "Runtime identity" ]
         [ Node.div
             ~attrs:[ Style.kv; Attr.role "listitem" ]
             [ Node.div ~attrs:[ Style.k ] [ Node.text "project" ]
@@ -280,7 +280,7 @@ let view_build_panel (r : Overview_types.response) =
     ~attrs:[ Style.panel ]
     [ Node.h2 ~attrs:[ Style.panel_title ] [ Node.text "build · release" ]
     ; Node.div
-        ~attrs:[ Style.kv_row; Attr.role "list"; Attr.arialabel "Build and release" ]
+        ~attrs:[ Style.kv_row; Attr.role "list"; Attr.create "aria-label" "Build and release" ]
         [ Node.div
             ~attrs:[ Style.kv; Attr.role "listitem" ]
             [ Node.div ~attrs:[ Style.k ] [ Node.text "version" ]
@@ -368,7 +368,7 @@ let view_meta_panel (r : Overview_types.response) =
     match m.dominant_belief with
     | Some b ->
       Node.div
-        ~attrs:[ Style.belief; Attr.role "note"; Attr.arialabel ("dominant belief: " ^ b.status) ]
+        ~attrs:[ Style.belief; Attr.role "note"; Attr.create "aria-label" ("dominant belief: " ^ b.status) ]
         [ Node.span
             ~attrs:[ Style.belief_tag ]
             [ Node.text b.status ]
@@ -376,7 +376,7 @@ let view_meta_panel (r : Overview_types.response) =
         ]
     | None ->
       Node.div
-        ~attrs:[ Style.empty; Attr.role "status"; Attr.arialabel "No dominant belief" ]
+        ~attrs:[ Style.empty; Attr.role "status"; Attr.create "aria-label" "No dominant belief" ]
         [ Node.text "no dominant belief recorded." ]
   in
   Node.div
@@ -385,7 +385,7 @@ let view_meta_panel (r : Overview_types.response) =
         ~attrs:[ Style.panel_title ]
         [ Node.text "meta · cognition" ]
     ; Node.div
-        ~attrs:[ Style.kv_row; Attr.role "list"; Attr.arialabel "Meta and cognition" ]
+        ~attrs:[ Style.kv_row; Attr.role "list"; Attr.create "aria-label" "Meta and cognition" ]
         [ Node.div
             ~attrs:[ Style.kv; Attr.role "listitem" ]
             [ Node.div ~attrs:[ Style.k ] [ Node.text "stagnation" ]
@@ -393,7 +393,7 @@ let view_meta_panel (r : Overview_types.response) =
                 ~attrs:[ Style.v ]
                 [ Node.text (Printf.sprintf "%d%%" pct)
                 ; Node.div
-                    ~attrs:[ Style.stag_bar; Attr.role "progressbar"; Attr.arialabel "Stagnation score"
+                    ~attrs:[ Style.stag_bar; Attr.role "progressbar"; Attr.create "aria-label" "Stagnation score"
                            ; Attr.create "aria-valuenow" (Int.to_string pct)
                            ; Attr.create "aria-valuemin" "0"
                            ; Attr.create "aria-valuemax" "100" ]

--- a/dashboard_bonsai/src/placeholder_view.ml
+++ b/dashboard_bonsai/src/placeholder_view.ml
@@ -216,7 +216,7 @@ let blueprint_of_route : Route.t -> blueprint = function
 
 let panel ~title ~text ~code =
   Node.div
-    ~attrs:[ Style.panel; Attr.role "listitem"; Attr.arialabel title ]
+    ~attrs:[ Style.panel; Attr.role "listitem"; Attr.create "aria-label" title ]
     [ Node.h2 ~attrs:[ Style.panel_title ] [ Node.text title ]
     ; Node.p ~attrs:[ Style.panel_text ] [ Node.text text ]
     ; Node.div ~attrs:[ Style.panel_code ] [ Node.text code ]
@@ -243,7 +243,7 @@ let component ~(route : Route.t) (_graph @ local) =
           ]
       ; Sec.view ~title:"operator contract" ~sub:"target · measure · next" ()
       ; Node.div
-          ~attrs:[ Style.grid; Attr.role "list"; Attr.arialabel "Operator contract panels" ]
+          ~attrs:[ Style.grid; Attr.role "list"; Attr.create "aria-label" "Operator contract panels" ]
           [ panel ~title:"measure" ~text:bp.measure ~code:"what must stay visible"
           ; panel ~title:"next" ~text:bp.next_step ~code:bp.endpoint
           ; panel

--- a/dashboard_bonsai/src/roster.ml
+++ b/dashboard_bonsai/src/roster.ml
@@ -204,5 +204,5 @@ let view ?(keepers : Keepers_types.response = Keepers_types.fixture) () =
     | [] -> view_static ()
     | live -> List.map live ~f:view_slot_of_keeper
   in
-  Node.div ~attrs:[ Style.roster; Attr.role "list"; Attr.arialabel "Keeper slots" ] slots
+  Node.div ~attrs:[ Style.roster; Attr.role "list"; Attr.create "aria-label" "Keeper slots" ] slots
 ;;

--- a/dashboard_bonsai/src/shell_view.ml
+++ b/dashboard_bonsai/src/shell_view.ml
@@ -678,7 +678,7 @@ let nav_link ~(active : Route.t) (route : Route.t) =
 let nav ~(active : Route.t) =
   let lnk = nav_link ~active in
   Node.div
-    ~attrs:[ Style.nav; Attr.role "navigation"; Attr.arialabel "Main navigation" ]
+    ~attrs:[ Style.nav; Attr.role "navigation"; Attr.create "aria-label" "Main navigation" ]
     [ section "watch"
     ; lnk Overview
     ; lnk Logs
@@ -755,7 +755,7 @@ let hud_cell ?(tone : tone = `Neutral) ~k ~v () =
     | `Bad -> [ Style.hud_v; Style.hud_bad ]
   in
   Node.div
-    ~attrs:[ Style.hud_cell; Attr.arialabel (k ^ ": " ^ v) ]
+    ~attrs:[ Style.hud_cell; Attr.create "aria-label" (k ^ ": " ^ v) ]
     [ Node.div ~attrs:[ Style.hud_k ] [ Node.text k ]
     ; Node.div ~attrs:v_attrs [ Node.text v ]
     ]
@@ -971,7 +971,7 @@ let watch_feed () =
 
 let default_aside ~(shell : Overview_types.response) ~(active : Route.t) =
   Node.div
-    ~attrs:[ Style.aside; Attr.role "complementary"; Attr.arialabel "Sidebar details" ]
+    ~attrs:[ Style.aside; Attr.role "complementary"; Attr.create "aria-label" "Sidebar details" ]
     [ focus_card ~shell ~active
     ; flame ()
     ; watch_feed ()
@@ -995,14 +995,14 @@ let view ?(shell = Overview_types.fixture) ?hud ?aside ~(active : Route.t) (chil
         ~attrs:
           [ Style.skip_nav
           ; Attr.href "#main-content"
-          ; Attr.arialabel "Skip to main content"
+          ; Attr.create "aria-label" "Skip to main content"
           ]
         [ Node.text "Skip to main content" ]
     ; topbar ~active
     ; nav ~active
     ; Node.div
         ~attrs:[ Style.main; Attr.role "main" ]
-        [ Node.div ~attrs:[ Style.hud; Attr.arialabel "Key metrics" ] hud_nodes
+        [ Node.div ~attrs:[ Style.hud; Attr.create "aria-label" "Key metrics" ] hud_nodes
         ; Node.div ~attrs:[ Style.page; Attr.id "main-content" ] children
         ]
     ; aside_node

--- a/dashboard_bonsai/src/swim.ml
+++ b/dashboard_bonsai/src/swim.ml
@@ -201,7 +201,7 @@ let view_lane ~name ~stat ~(status : lane_status) ~frames =
     | `Live | `Warn -> [ Style.nm ]
   in
   Node.div
-    ~attrs:[ Style.lane; Attr.role "listitem"; Attr.arialabel (name ^ ": " ^ stat) ]
+    ~attrs:[ Style.lane; Attr.role "listitem"; Attr.create "aria-label" (name ^ ": " ^ stat) ]
     [ Node.div
         ~attrs:[ Style.lane_meta ]
         [ Node.span ~attrs:[ Style.dot; dot_cls; Attr.create "aria-hidden" "true" ] []
@@ -292,7 +292,7 @@ let view ?(keepers : Keepers_types.response = Keepers_types.fixture) () =
     | live_keepers -> List.map live_keepers ~f:view_lane_of_keeper
   in
   Node.div
-    ~attrs:[ Style.swim; Attr.role "list"; Attr.arialabel "Keeper activity timeline" ]
+    ~attrs:[ Style.swim; Attr.role "list"; Attr.create "aria-label" "Keeper activity timeline" ]
     ([ Node.div
          ~attrs:[ Style.axis ]
          [ Node.div


### PR DESCRIPTION
## 요약

`dashboard_bonsai`가 `bonsai-dashboard` opam switch 하에서 컴파일 실패한 2개 원인 수정. Unblocks #10009 visual verification.

Closes #10023.

## 근본 원인 1: `Attr.arialabel` 미정의 (40 sites)

로컬 `Virtual_dom.Vdom.Attr` 모듈에 `arialabel` 함수 없음 (표준 API는 `Attr.create "aria-label" value`만 제공). 40개 호출부가 전부 `Unbound value Attr.arialabel`:

- `hud.ml` (2), `swim.ml` (2), `roster.ml` (1), `meta.ml` (1), `flame.ml` (1), `shell_view.ml` (5), `logs_view.ml` (3), `goals_view.ml` (4), `keepers_view.ml` (1), `dead_keepers_view.ml` (2), `placeholder_view.ml` (2), `keepers_directory.ml` (6), `overview_view.ml` (6)

### Fix

`sed` 기반 mechanical 치환:

```diff
- Attr.arialabel "No live keepers"
+ Attr.create "aria-label" "No live keepers"
```

새 helper 모듈 추가 없음 — 표준 API 직접 사용이 의존성 최소. 필요 시 추후 `Attr.aria_label` 헬퍼로 refactor 가능 (본 PR 스코프 밖).

## 근본 원인 2: `hello_view.ml` 주석 조기 종료

```
(** Landing view — ...
    ... reference CSS variables from [colors_and_type.css] via [var(--*)]. *)
```

`var(--*)]. *)`에서 `*)`가 외곽 docstring을 조기 종료 → 뒤따르는 `]. *)` 문법 에러.

### Fix

```diff
- reference CSS variables from [colors_and_type.css] via [var(--*)]. *)
+ reference CSS variables from [colors_and_type.css] via [var] tokens. *)
```

의미 동일, embedded comment terminator 제거.

## 변경 통계

```
 dashboard_bonsai/src/dead_keepers_view.ml |  4 ++--
 dashboard_bonsai/src/flame.ml             |  2 +-
 dashboard_bonsai/src/goals_view.ml        |  8 ++++----
 dashboard_bonsai/src/hello_view.ml        |  2 +-
 dashboard_bonsai/src/hud.ml               |  4 ++--
 dashboard_bonsai/src/keepers_directory.ml | 12 ++++++------
 dashboard_bonsai/src/keepers_view.ml      |  2 +-
 dashboard_bonsai/src/logs_view.ml         |  6 +++---
 dashboard_bonsai/src/meta.ml              |  2 +-
 dashboard_bonsai/src/overview_view.ml     | 12 ++++++------
 dashboard_bonsai/src/placeholder_view.ml  |  4 ++--
 dashboard_bonsai/src/roster.ml            |  2 +-
 dashboard_bonsai/src/shell_view.ml        | 10 +++++-----
 dashboard_bonsai/src/swim.ml              |  4 ++--
 16 files changed, 41 insertions(+), 41 deletions(-)
```

## 검증

```bash
$ rg -n 'Attr\.arialabel' dashboard_bonsai/src/
(no matches)

$ rg -n 'var\(--\*\)' dashboard_bonsai/src/
(no matches)
```

### 로컬 빌드

로컬에 `bonsai-dashboard` opam switch가 없어 `dune build` 직접 검증 불가. Fix는 mechanical + surface-only이므로 CI (또는 해당 switch 보유 reviewer)에서 검증 필요.

이슈에서 언급된 `overview_view.ml:421` syntax error는 cascade (상단 `Attr.arialabel` unbound 때문에 type inference 폭발). arialabel 수정으로 해소 예상.

## 회귀 리스크

매우 낮음 — `Attr.arialabel X` → `Attr.create "aria-label" X` 동등 변환. DOM output 동일. 주석 변경은 docstring 텍스트만.

## 참고

- Issue #10023 — 증상 및 suggested direction
- 관련: #10009 (a11y round 2) visual verification blocker 해소
