### PR TITLE
fix(keeper): mark similarity non-measurable when turn has no message pair

### DIFF
--- a/lib/keeper/keeper_guard.ml
+++ b/lib/keeper/keeper_guard.ml
@@ -26,9 +26,14 @@ let evaluate (s : measurement_snapshot) : event list =
   let events = ref [] in
   let add ev = events := ev :: !events in
 
-  (* 1. Guardrail: 4-way AND gate *)
+  (* 1. Guardrail: 4-way AND gate.
+     Fail-closed when similarity is not measurable (e.g. status_tick without
+     a user/assistant pair) — the goal_alignment / response_alignment floats
+     are 0.0 sentinels in that case, which would otherwise satisfy the two
+     [<=] comparisons trivially. See #10012. *)
   let guardrail_fired =
-    s.similarity.repetition_risk >= t.guardrail_repetition_threshold
+    s.similarity.similarity_measurable
+    && s.similarity.repetition_risk >= t.guardrail_repetition_threshold
     && s.similarity.goal_alignment <= t.guardrail_goal_alignment_threshold
     && s.similarity.response_alignment <= t.guardrail_response_alignment_threshold
     && s.context.context_ratio >= t.guardrail_context_threshold
@@ -105,7 +110,8 @@ let evaluate (s : measurement_snapshot) : event list =
     auto_rules = {
       reflect = s.similarity.repetition_risk >= t.reflect_repetition_threshold;
       plan =
-        s.similarity.goal_alignment <= t.plan_goal_alignment_threshold
+        s.similarity.similarity_measurable
+        && s.similarity.goal_alignment <= t.plan_goal_alignment_threshold
         && s.similarity.response_alignment <= t.plan_response_alignment_threshold;
       compact = (compact_ratio || compact_msg || compact_tok) && cooldown_ok;
       handoff =

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -789,6 +789,13 @@ let write_heartbeat_snapshot
         jaccard_similarity user_message assistant_message
       | _ -> 0.0
     in
+    (* status_tick / heartbeat turns lack a user/assistant pair, so the 0.0
+       fallbacks above are sentinels, not measurements. Mark the snapshot
+       non-measurable and let Keeper_guard fail-closed on similarity gates. *)
+    let similarity_measurable =
+      Option.is_some latest_user_message
+      && Option.is_some latest_assistant_message
+    in
     let context_ratio_v = match ctx_opt with
       | Some c -> Keeper_exec_context.context_ratio c
       | None -> 0.0
@@ -867,6 +874,7 @@ let write_heartbeat_snapshot
         ~repetition_risk
         ~goal_alignment
         ~response_alignment
+        ~similarity_measurable
         ~now_ts
         ~idle_seconds:0
         ~since_last_compaction_sec

--- a/lib/keeper/keeper_measurement.ml
+++ b/lib/keeper/keeper_measurement.ml
@@ -34,6 +34,7 @@ type similarity_measurement = {
   repetition_risk : float;
   goal_alignment : float;
   response_alignment : float;
+  similarity_measurable : bool;
 }
 
 type timing_measurement = {
@@ -96,6 +97,7 @@ let capture
       ~repetition_risk
       ~goal_alignment
       ~response_alignment
+      ?(similarity_measurable = true)
       ~now_ts
       ~idle_seconds
       ~since_last_compaction_sec
@@ -121,6 +123,7 @@ let capture
       { repetition_risk
       ; goal_alignment
       ; response_alignment
+      ; similarity_measurable
       }
   ; timing =
       { now_ts
@@ -152,6 +155,7 @@ let measurement_snapshot_to_json (s : measurement_snapshot) : Yojson.Safe.t =
       "repetition_risk", `Float s.similarity.repetition_risk;
       "goal_alignment", `Float s.similarity.goal_alignment;
       "response_alignment", `Float s.similarity.response_alignment;
+      "similarity_measurable", `Bool s.similarity.similarity_measurable;
     ];
     "timing", `Assoc [
       "now_ts", `Float s.timing.now_ts;

--- a/lib/keeper/keeper_measurement.mli
+++ b/lib/keeper/keeper_measurement.mli
@@ -47,6 +47,12 @@ type similarity_measurement = {
   repetition_risk : float;
   goal_alignment : float;
   response_alignment : float;
+  similarity_measurable : bool;
+  (** [false] when the turn lacked the user/assistant message pair (or goal horizon)
+      needed to compute [goal_alignment] / [response_alignment] honestly. In that
+      case the two similarity floats are sentinel [0.0] — distinguishable from a
+      real measurement of [0.0] only by this flag. Gates that consume similarity
+      must fail-closed when [similarity_measurable = false] (see Keeper_guard). *)
 }
 
 type timing_measurement = {
@@ -98,6 +104,7 @@ val capture :
   repetition_risk:float ->
   goal_alignment:float ->
   response_alignment:float ->
+  ?similarity_measurable:bool ->
   now_ts:float ->
   idle_seconds:int ->
   since_last_compaction_sec:float ->

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -137,6 +137,7 @@ let base_measurement : Meas.measurement_snapshot = {
     repetition_risk = 0.1;
     goal_alignment = 0.8;
     response_alignment = 0.8;
+    similarity_measurable = true;
   };
   timing = {
     now_ts = 1000.0;

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -159,6 +159,7 @@ let test_dispatch_event_with_audit_preserves_snapshot () =
         { repetition_risk = 0.95
         ; goal_alignment = 0.1
         ; response_alignment = 0.1
+        ; similarity_measurable = true
         }
     ; timing =
         { now_ts = 1000.0

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -527,6 +527,7 @@ let healthy_snapshot : Meas.measurement_snapshot = {
     repetition_risk = 0.1;
     goal_alignment = 0.8;
     response_alignment = 0.7;
+    similarity_measurable = true;
   };
   timing = {
     now_ts = 1000.0;
@@ -603,6 +604,7 @@ let test_guard_guardrail_triggers () =
       repetition_risk = 0.95;
       goal_alignment = 0.1;
       response_alignment = 0.1;
+      similarity_measurable = true;
     };
     context = { healthy_snapshot.context with context_ratio = 0.85 };
   } in
@@ -640,6 +642,51 @@ let test_guard_plan_requires_both_alignments_low () =
     ) events
   in
   check bool "plan requires both" false (Option.value ~default:true plan_flag)
+
+(* Regression test for #10012.
+
+   Both [goal_alignment] and [response_alignment] at 0.0 would ordinarily
+   satisfy the plan gate's two [<=] comparisons, but when the snapshot was
+   produced by a turn that had no user/assistant message pair (status_tick,
+   heartbeat), those zeroes are sentinels, not measurements. The guard must
+   fail-closed via [similarity_measurable=false] and emit [plan=false]. *)
+let test_guard_plan_fails_closed_when_similarity_unmeasurable () =
+  let snap = { healthy_snapshot with
+    similarity =
+      { healthy_snapshot.similarity with
+        goal_alignment = 0.0;
+        response_alignment = 0.0;
+        similarity_measurable = false;
+      };
+  } in
+  let events = Guard.evaluate snap in
+  let plan_flag =
+    List.find_map (function
+      | SM.Context_measured { auto_rules; _ } -> Some auto_rules.plan
+      | _ -> None
+    ) events
+  in
+  check bool "plan does not fire on unmeasurable similarity"
+    false (Option.value ~default:true plan_flag)
+
+(* Same invariant for the guardrail gate — even when every float value lines
+   up for a guardrail stop, [similarity_measurable=false] must suppress it. *)
+let test_guard_guardrail_fails_closed_when_similarity_unmeasurable () =
+  let snap = { healthy_snapshot with
+    similarity = {
+      repetition_risk = 0.95;
+      goal_alignment = 0.0;
+      response_alignment = 0.0;
+      similarity_measurable = false;
+    };
+    context = { healthy_snapshot.context with context_ratio = 0.85 };
+  } in
+  let events = Guard.evaluate snap in
+  let has_guardrail = List.exists (function
+    | SM.Guardrail_stop _ -> true | _ -> false
+  ) events in
+  check bool "guardrail does not fire on unmeasurable similarity"
+    false has_guardrail
 
 (* ── Phase roundtrip tests ─────────────────────────────── *)
 
@@ -2104,6 +2151,10 @@ let () =
       test_case "guardrail triggers" `Quick test_guard_guardrail_triggers;
       test_case "hb failure at threshold" `Quick test_guard_hb_failure_threshold;
       test_case "plan requires both low" `Quick test_guard_plan_requires_both_alignments_low;
+      test_case "plan fails-closed when similarity unmeasurable" `Quick
+        test_guard_plan_fails_closed_when_similarity_unmeasurable;
+      test_case "guardrail fails-closed when similarity unmeasurable" `Quick
+        test_guard_guardrail_fails_closed_when_similarity_unmeasurable;
     ];
     "roundtrip", [
       test_case "phase string roundtrip" `Quick test_phase_string_roundtrip;


### PR DESCRIPTION
## Why

Closes #10012.

status_tick and heartbeat turns run the keepalive measurement path but do not carry a user/assistant message pair. The existing fallback in `lib/keeper/keeper_keepalive.ml:786-790` produced `response_alignment = 0.0` for those turns — a sentinel that the downstream plan gate

```
goal_alignment <= 0.060 && response_alignment <= 0.100
```

happily satisfied. Result: every status_tick emitted `reflection.triggered=true, actions=["plan"]` in `~/me/.masc/keepers/<name>/metrics/<YYYY-MM>/<DD>.jsonl`, and the `keeper_guard.evaluate` guardrail gate was equally vulnerable.

This is the classic anti-pattern flagged in `memory/feedback_no-heuristic-category.md` and `CLAUDE.md` ("Unknown → Permissive Default"): collapsing an `option` into a sentinel `0.0` makes "not measurable" and "measured low" indistinguishable to every downstream consumer.

## Change

Additive field `similarity_measurable : bool` on `similarity_measurement`. The keepalive site sets it honestly from `Option.is_some latest_user_message && Option.is_some latest_assistant_message`. Both gates in `keeper_guard.ml` AND the new flag into their existing comparisons — the gate short-circuits to `false` when similarity is not measurable, regardless of what the two 0.0 floats appear to say.

| File | Change |
|------|--------|
| `lib/keeper/keeper_measurement.mli` | +field, +optional param on `capture` (default `true`) |
| `lib/keeper/keeper_measurement.ml`  | thread through capture, emit in `measurement_snapshot_to_json` |
| `lib/keeper/keeper_keepalive.ml`    | compute `similarity_measurable`, pass to capture |
| `lib/keeper/keeper_guard.ml`        | AND into plan gate (L107-110) + guardrail gate (L30-36) |
| `test/test_keeper_memory.ml`        | `similarity_measurable = true` on inline record literal |
| `test/test_keeper_registry.ml`      | same |
| `test/test_keeper_state_machine.ml` | same + 2 new regression tests |

**+81 / -3, 7 files.** The only behavior change is on the `keeper_keepalive.ml` capture site; every other caller of `Keeper_measurement.capture` keeps the default `true` and preserves its current behavior.

## Regression coverage

Both new tests live in `test_keeper_state_machine.ml` and exercise `Keeper_guard.evaluate` directly:

1. `plan fails-closed when similarity unmeasurable` — `goal_alignment=0.0`, `response_alignment=0.0`, `similarity_measurable=false` → emitted `auto_rules.plan` is `false`. Without this fix, both floats would satisfy the `<=` comparisons and the flag would be `true`.

2. `guardrail fails-closed when similarity unmeasurable` — same similarity floats plus a 0.95 repetition and 0.85 context ratio that would otherwise line up for a full guardrail stop. Expect no `Guardrail_stop` event.

Both tests confirm the gates respect the measurability signal in isolation; they do not depend on `keeper_keepalive.ml`. A broader smoke path (the actual status_tick flow) is covered implicitly by the existing `test_keeper_registry.ml` / `test_keeper_memory.ml` scenarios, which now all pass with the new field.

## Verification

- `dune build @runtest --force` — all 3 modified test suites green (`test_keeper_memory`: 63 pass; `test_keeper_state_machine`: 110 pass, +2 regression; `test_keeper_registry`: 62 pass).
- Two pre-existing test failures (`test_disk_hygiene_script` doctor target, `test_tool_worktree_coverage` clone policy) reproduce on unmodified main — unrelated to this PR.

## Why not change `similarity_measurement.*_alignment` to `float option`

That is the cleaner long-term shape, but propagating `option` through `Keeper_measurement.t`, `Keeper_guard.evaluate`, `auto_rule_summary` (state machine), dashboard TS types, and every JSON consumer is a multi-axis refactor that would dwarf the bug being fixed. The boolean is additive, backward-compat, and semantically equivalent to "this slot is None" at the decision boundary. If #10012 follow-up wants to move to `float option`, the boolean becomes `Option.is_some` of the option and the gate edits are unchanged.

## References

- Issue #10012 (full root-cause writeup; `keeper_memory_recall.ml` and `keeper_alerting.ml` have similar patterns — tracked as separate follow-up, not in this PR's scope).
- `memory/feedback_no-heuristic-category.md` — "sound partial > heuristic total".
- `memory/feedback_deterministic-nondeterministic-boundary.md` — Det consumers must not depend on NonDet sentinels.