### PR TITLE
[codex] Scope dashboard refresh fanout to active route

### DIFF
--- a/dashboard/src/components/common/time-ago.test.ts
+++ b/dashboard/src/components/common/time-ago.test.ts
@@ -15,6 +15,8 @@ const flushUi = async () => {
   for (let i = 0; i < 4; i++) await Promise.resolve()
 }
 
+const RELATIVE_SUFFIX_RE = /(?:초|분|시간|일|주|개월|년) 전/
+
 describe('toMs (pure normalization)', () => {
   it('passes unix ms through unchanged', () => {
     expect(toMs(1_700_000_000_000)).toBe(1_700_000_000_000)
@@ -64,9 +66,9 @@ describe('pickDisplayText', () => {
     expect(out).not.toContain('·')
   })
 
-  it('mode=absolute returns only the absolute fragment (no "전")', () => {
+  it('mode=absolute returns only the absolute fragment (no relative suffix)', () => {
     const out = pickDisplayText(recent, 'absolute')
-    expect(out).not.toMatch(/전/)
+    expect(out).not.toMatch(RELATIVE_SUFFIX_RE)
   })
 
   it('mode=both joins relative and absolute with "·"', () => {
@@ -125,7 +127,7 @@ describe('TimeAgo component', () => {
   it('mode="absolute" renders only the absolute fragment', () => {
     render(html`<${TimeAgo} timestamp=${Date.now() - 60_000} mode="absolute" />`, container)
     const el = container.querySelector('time')!
-    expect(el.textContent).not.toMatch(/전/)
+    expect(el.textContent).not.toMatch(RELATIVE_SUFFIX_RE)
   })
 
   it('mode="both" renders both fragments joined by "·"', () => {

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+const sseStoreMocks = vi.hoisted(() => ({
+  hydrateDashboardSlice: vi.fn(),
+  routeServerPushEvent: vi.fn(),
+}))
+
+vi.mock('./sse-store', () => sseStoreMocks)
+
 import {
   connectDashboardWS,
   dashboardSlicesForRoute,
@@ -111,6 +118,8 @@ afterEach(() => {
   vi.useRealTimers()
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
+  sseStoreMocks.hydrateDashboardSlice.mockClear()
+  sseStoreMocks.routeServerPushEvent.mockClear()
 })
 
 describe('dashboardSlicesForRoute', () => {
@@ -398,5 +407,68 @@ describe('dashboard websocket route subscriptions', () => {
     await flushPromises()
 
     expect(dashboardWsLastSeq.value).toBe(1)
+  })
+
+  it('ignores dashboard slice deltas outside the latest route subscription', async () => {
+    installWebSocketMocks()
+
+    await connectDashboardWS({ tab: 'workspace', params: { section: 'board' } })
+    const socket = mockSockets[0]!
+    socket.open()
+    const hello = parseRpc(socket, 0)
+    socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
+    await flushPromises()
+
+    const initialSubscribe = parseRpc(socket, 1)
+    socket.receive({
+      jsonrpc: '2.0',
+      id: initialSubscribe.id,
+      result: { snapshot: { seq: 1, slices: { board: { posts: [] } } } },
+    })
+    await flushPromises()
+    sseStoreMocks.hydrateDashboardSlice.mockClear()
+
+    socket.receive({
+      jsonrpc: '2.0',
+      method: 'dashboard/delta',
+      params: { seq: 2, slice: 'board', payload: { posts: [] } },
+    })
+    expect(sseStoreMocks.hydrateDashboardSlice).toHaveBeenCalledWith(
+      'board',
+      { posts: [] },
+      undefined,
+    )
+    sseStoreMocks.hydrateDashboardSlice.mockClear()
+
+    const switchPromise = subscribeDashboardRoute({
+      tab: 'monitoring',
+      params: { section: 'observatory' },
+    })
+    const routeSubscribe = parseRpc(socket, socket.sent.length - 1)
+    socket.receive({
+      jsonrpc: '2.0',
+      id: routeSubscribe.id,
+      result: { snapshot: { seq: 3, slices: { execution: { agents: [] } } } },
+    })
+    await switchPromise
+    sseStoreMocks.hydrateDashboardSlice.mockClear()
+
+    socket.receive({
+      jsonrpc: '2.0',
+      method: 'dashboard/delta',
+      params: { seq: 4, slice: 'board', payload: { posts: [] } },
+    })
+    expect(sseStoreMocks.hydrateDashboardSlice).not.toHaveBeenCalled()
+
+    socket.receive({
+      jsonrpc: '2.0',
+      method: 'dashboard/delta',
+      params: { seq: 5, slice: 'execution', payload: { agents: [] } },
+    })
+    expect(sseStoreMocks.hydrateDashboardSlice).toHaveBeenCalledWith(
+      'execution',
+      { agents: [] },
+      undefined,
+    )
   })
 })

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -184,7 +184,7 @@ function applySnapshot(raw: unknown): void {
   const slices = snapshot.slices as Record<string, unknown> | undefined
   if (!slices || typeof slices !== 'object') return
   for (const [slice, payload] of Object.entries(slices)) {
-    hydrateDashboardSlice(slice, payload)
+    hydrateRouteDashboardSlice(slice, payload)
   }
 }
 
@@ -208,11 +208,21 @@ function applyDelta(raw: unknown): void {
     }).catch(() => {})
   }
   if (typeof delta.slice !== 'string') return
-  hydrateDashboardSlice(
+  hydrateRouteDashboardSlice(
     delta.slice,
     delta.payload,
     typeof delta.event_type === 'string' ? delta.event_type : undefined,
   )
+}
+
+function activeRouteWantsDashboardSlice(slice: string): boolean {
+  if (!desiredRouteState) return true
+  return dashboardSlicesForRoute(desiredRouteState).includes(slice)
+}
+
+function hydrateRouteDashboardSlice(slice: string, payload: unknown, eventType?: string): void {
+  if (!activeRouteWantsDashboardSlice(slice)) return
+  hydrateDashboardSlice(slice, payload, eventType)
 }
 
 function handleNotification(raw: JsonObject): boolean {

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -268,6 +268,39 @@ describe('setupSSEReaction reconnect hydration', () => {
     expect(refreshBoard).not.toHaveBeenCalled()
   })
 
+  it('does not trigger observatory graph refresh from the workspace board route', async () => {
+    const { sseStore } = await loadSseStore()
+    const refreshActivity = vi.fn()
+    sseStore.registerActivityRefresh(refreshActivity)
+    route.value = { tab: 'workspace', params: { section: 'board' }, postId: null }
+
+    sseStore.routeServerPushEvent({
+      type: 'activity_graph_changed',
+      payload: { kind: 'activity_graph_changed' },
+    } as unknown as Parameters<typeof sseStore.routeServerPushEvent>[0])
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(refreshActivity).not.toHaveBeenCalled()
+  })
+
+  it('cancels pending stale refresh dispatches after a route switch', async () => {
+    const { sseStore } = await loadSseStore()
+    route.value = { tab: 'workspace', params: { section: 'board' }, postId: null }
+
+    sseStore.routeServerPushEvent({
+      type: 'comment_added',
+      post_id: 'post-1',
+      comment_id: 'comment-1',
+    })
+    route.value = { tab: 'monitoring', params: { section: 'observatory' }, postId: null }
+    sseStore.cancelPendingSSERefreshes()
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(refreshBoard).not.toHaveBeenCalled()
+  })
+
   it('hydrates websocket dashboard snapshots for board, goals, and composite slices', async () => {
     const { sseStore } = await loadSseStore()
 

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -170,14 +170,21 @@ describe('refreshPlanForRoute fleet-health view-aware branching', () => {
     expect(refreshPlanForRoute({
       tab: 'monitoring',
       params: { section: 'fleet-health' },
-    })).toEqual(['namespaceTruth', 'missionSnapshot'])
+    })).toEqual(['namespaceTruth'])
   })
 
   it('view=event-log hydrates general monitoring data', () => {
     expect(refreshPlanForRoute({
       tab: 'monitoring',
       params: { section: 'fleet-health', view: 'event-log' },
-    })).toEqual(['namespaceTruth', 'missionSnapshot'])
+    })).toEqual(['namespaceTruth'])
+  })
+
+  it('view=governance avoids mission and operator-heavy route refreshes', () => {
+    expect(refreshPlanForRoute({
+      tab: 'monitoring',
+      params: { section: 'fleet-health', view: 'governance' },
+    })).toEqual(['namespaceTruth'])
   })
 
   it('view=tool-quality routes to the existing refreshToolQuality API', () => {

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -79,8 +79,9 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
         const view = routeState.params.view
         if (view === 'tool-quality') return ['toolQuality']
         if (view === 'comparison') return ['execution', 'toolQuality']
-        // default + event-log + governance: general monitoring refresh
-        return ['namespaceTruth', 'missionSnapshot']
+        // default + event-log + governance: keep the route visit light.
+        // Mounted fleet-health panels own telemetry/tool/governance polling.
+        return ['namespaceTruth']
       }
       return ['namespaceTruth', 'missionSnapshot']
     case 'command':


### PR DESCRIPTION
## Summary

Step 2 of the dashboard performance plan: reduce hidden-route refresh fanout and prevent stale route hydration.

- keep `monitoring/fleet-health` route entry light by refreshing `namespaceTruth` only unless an explicit heavy view needs more data
- gate WebSocket dashboard snapshot/delta hydration to the latest subscribed route slices so stale board/operator-heavy slices do not hydrate after route switches
- add regression coverage for fleet-health refresh plans, workspace-board vs observatory activity refresh, pending stale dispatch cancellation, and stale WS slice hydration
- tighten the Korean `TimeAgo` absolute-mode test so `오전` does not false-match the relative `전` suffix during midnight-local test runs

## Validation

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm exec vitest run src/components/common/time-ago.test.ts src/tab-refresh.test.ts src/sse-store.test.ts src/dashboard-ws.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm test`
- `pnpm build`

## Notes

Local Vitest still emits the existing `--localstorage-file` warnings, and the WebSocket tests can emit sandboxed localhost `EPERM` warnings. The suites pass.