### PR TITLE
feat(oas-worker): per-kind counter for masc_oas_error emissions (#9933)

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -300,7 +300,36 @@ let masc_internal_error_to_json = function
         ("original_error", `String original_error);
       ]
 
+(* #9933: classify emitted [masc_oas_error] payloads by kind so
+   dashboards and Grafana alerts can watch the fleet-wide rate per
+   error class (cascade_exhausted vs oas_timeout_budget vs
+   ambiguous_post_commit, etc.) rather than reading the free-form
+   BDI blocker string.  125 [oas_timeout_budget] events accumulated
+   across 9 keepers in 24h without an aggregate signal — this
+   counter is the per-kind surface.
+
+   Emit point is this constructor so all 14 call sites of
+   [sdk_error_of_masc_internal_error] are covered automatically,
+   without changing their signatures or threading [keeper_name]
+   through callers that do not have it readily.  A follow-up PR
+   can add a [keeper] label once every construction site has the
+   name in scope. *)
+let masc_oas_error_total_metric = "masc_oas_error_total"
+
+let kind_of_masc_internal_error = function
+  | Cascade_exhausted _ -> "cascade_exhausted"
+  | Resumable_cli_session _ -> "resumable_cli_session"
+  | No_tool_capable_provider _ -> "no_tool_capable_provider"
+  | Accept_rejected _ -> "accept_rejected"
+  | Admission_queue_timeout _ -> "admission_queue_timeout"
+  | Admission_queue_rejected _ -> "admission_queue_rejected"
+  | Turn_timeout _ -> "turn_timeout"
+  | Oas_timeout_budget _ -> "oas_timeout_budget"
+  | Ambiguous_post_commit _ -> "ambiguous_post_commit"
+
 let sdk_error_of_masc_internal_error err =
+  Prometheus.inc_counter masc_oas_error_total_metric
+    ~labels:[ ("kind", kind_of_masc_internal_error err) ] ();
   Oas.Error.Internal
     (masc_internal_error_prefix ^ Yojson.Safe.to_string (masc_internal_error_to_json err))
 

--- a/test/dune
+++ b/test/dune
@@ -60,6 +60,7 @@
         test_heuristic_theatre_audit
         test_hebbian_edge_update_counter
         test_keeper_proactive_skip_counter
+        test_oas_error_kind_counter
         test_keeper_wake_telemetry
         test_keeper_memory
         test_keeper_accountability
@@ -192,6 +193,7 @@
           test_heuristic_theatre_audit
           test_hebbian_edge_update_counter
           test_keeper_proactive_skip_counter
+          test_oas_error_kind_counter
           test_keeper_wake_telemetry
           test_keeper_memory
           test_keeper_accountability

--- a/test/test_oas_error_kind_counter.ml
+++ b/test/test_oas_error_kind_counter.ml
@@ -1,0 +1,148 @@
+(* test/test_oas_error_kind_counter.ml
+
+   #9933: verify that [Oas_worker_named.sdk_error_of_masc_internal_error]
+   emits [masc_oas_error_total{kind}] once per constructed error so
+   Grafana can alert on per-kind rates without parsing the
+   free-form BDI blocker string.  Exercises all 5 variants of
+   [masc_internal_error] (the single production source of
+   [masc_oas_error] payloads). *)
+
+module OWN = Masc_mcp.Oas_worker_named
+module Prom = Masc_mcp.Prometheus
+
+let counter_for kind =
+  Prom.metric_value_or_zero
+    OWN.masc_oas_error_total_metric
+    ~labels:[ ("kind", kind) ]
+    ()
+
+let test_metric_name_stable () =
+  Alcotest.(check string)
+    "canonical oas error total metric name"
+    "masc_oas_error_total"
+    OWN.masc_oas_error_total_metric
+
+let test_oas_timeout_budget_kind () =
+  let kind = "oas_timeout_budget" in
+  let before = counter_for kind in
+  let _ =
+    OWN.sdk_error_of_masc_internal_error
+      (OWN.Oas_timeout_budget
+         {
+           budget_sec = 423.8;
+           keeper_turn_timeout_sec = 1200.0;
+           estimated_input_tokens = 2519;
+           source = "adaptive_estimated_input_tokens";
+         })
+  in
+  Alcotest.(check (float 0.0001))
+    "oas_timeout_budget counter +1"
+    (before +. 1.0)
+    (counter_for kind)
+
+let test_turn_timeout_kind () =
+  let kind = "turn_timeout" in
+  let before = counter_for kind in
+  let _ =
+    OWN.sdk_error_of_masc_internal_error
+      (OWN.Turn_timeout { elapsed_sec = 1201.0 })
+  in
+  Alcotest.(check (float 0.0001))
+    "turn_timeout counter +1"
+    (before +. 1.0)
+    (counter_for kind)
+
+let test_cascade_exhausted_kind () =
+  let kind = "cascade_exhausted" in
+  let before = counter_for kind in
+  let _ =
+    OWN.sdk_error_of_masc_internal_error
+      (OWN.Cascade_exhausted
+         {
+           cascade_name = "big_three";
+           reason =
+             Masc_mcp.Keeper_types.Other_detail "all providers tried";
+         })
+  in
+  Alcotest.(check (float 0.0001))
+    "cascade_exhausted counter +1"
+    (before +. 1.0)
+    (counter_for kind)
+
+let test_resumable_cli_session_kind () =
+  let kind = "resumable_cli_session" in
+  let before = counter_for kind in
+  let _ =
+    OWN.sdk_error_of_masc_internal_error
+      (OWN.Resumable_cli_session
+         {
+           cascade_name = "big_three";
+           detail = "session resumable";
+           exit_code = Some 130;
+         })
+  in
+  Alcotest.(check (float 0.0001))
+    "resumable_cli_session counter +1"
+    (before +. 1.0)
+    (counter_for kind)
+
+let test_ambiguous_post_commit_kind () =
+  let kind = "ambiguous_post_commit" in
+  let before = counter_for kind in
+  let _ =
+    OWN.sdk_error_of_masc_internal_error
+      (OWN.Ambiguous_post_commit
+         {
+           is_timeout = true;
+           tools = [ "keeper_board_post" ];
+           original_error = "provider timeout";
+         })
+  in
+  Alcotest.(check (float 0.0001))
+    "ambiguous_post_commit counter +1"
+    (before +. 1.0)
+    (counter_for kind)
+
+let test_kind_isolation () =
+  (* Bumping one kind must not move the counter for a different
+     kind — the label separation is what lets Grafana split
+     [rate(...{kind=~"oas_timeout_budget"}[5m])] cleanly. *)
+  let a = "turn_timeout" in
+  let b = "oas_timeout_budget" in
+  let b_before = counter_for b in
+  let _ =
+    OWN.sdk_error_of_masc_internal_error
+      (OWN.Turn_timeout { elapsed_sec = 42.0 })
+  in
+  Alcotest.(check (float 0.0001))
+    "different kind counter unchanged"
+    b_before (counter_for b);
+  ignore a
+
+let () =
+  Alcotest.run "oas_error_kind_counter_9933"
+    [
+      ( "metric_name",
+        [
+          Alcotest.test_case "canonical name stable" `Quick
+            test_metric_name_stable;
+        ] );
+      ( "per_kind_increment",
+        [
+          Alcotest.test_case "oas_timeout_budget" `Quick
+            test_oas_timeout_budget_kind;
+          Alcotest.test_case "turn_timeout" `Quick
+            test_turn_timeout_kind;
+          Alcotest.test_case "cascade_exhausted" `Quick
+            test_cascade_exhausted_kind;
+          Alcotest.test_case "resumable_cli_session" `Quick
+            test_resumable_cli_session_kind;
+          Alcotest.test_case "ambiguous_post_commit" `Quick
+            test_ambiguous_post_commit_kind;
+        ] );
+      ( "isolation",
+        [
+          Alcotest.test_case "kind labels separate" `Quick
+            test_kind_isolation;
+        ] );
+    ]

--- a/test/test_oas_error_kind_counter.ml
+++ b/test/test_oas_error_kind_counter.ml
@@ -3,7 +3,7 @@
    #9933: verify that [Oas_worker_named.sdk_error_of_masc_internal_error]
    emits [masc_oas_error_total{kind}] once per constructed error so
    Grafana can alert on per-kind rates without parsing the
-   free-form BDI blocker string.  Exercises all 5 variants of
+   free-form BDI blocker string.  Exercises all 9 variants of
    [masc_internal_error] (the single production source of
    [masc_oas_error] payloads). *)
 
@@ -86,6 +86,69 @@ let test_resumable_cli_session_kind () =
     (before +. 1.0)
     (counter_for kind)
 
+let test_no_tool_capable_provider_kind () =
+  let kind = "no_tool_capable_provider" in
+  let before = counter_for kind in
+  let _ =
+    OWN.sdk_error_of_masc_internal_error
+      (OWN.No_tool_capable_provider
+         {
+           cascade_name = "tool_required";
+           configured_labels = [ "openai"; "anthropic" ];
+         })
+  in
+  Alcotest.(check (float 0.0001))
+    "no_tool_capable_provider counter +1"
+    (before +. 1.0)
+    (counter_for kind)
+
+let test_accept_rejected_kind () =
+  let kind = "accept_rejected" in
+  let before = counter_for kind in
+  let _ =
+    OWN.sdk_error_of_masc_internal_error
+      (OWN.Accept_rejected
+         {
+           scope = "keeper_turn";
+           model = Some "codex";
+           reason = "accept=false";
+         })
+  in
+  Alcotest.(check (float 0.0001))
+    "accept_rejected counter +1"
+    (before +. 1.0)
+    (counter_for kind)
+
+let test_admission_queue_timeout_kind () =
+  let kind = "admission_queue_timeout" in
+  let before = counter_for kind in
+  let _ =
+    OWN.sdk_error_of_masc_internal_error
+      (OWN.Admission_queue_timeout
+         {
+           keeper_name = "keeper-alpha";
+           cascade_name = "big_three";
+           wait_sec = 30.0;
+         })
+  in
+  Alcotest.(check (float 0.0001))
+    "admission_queue_timeout counter +1"
+    (before +. 1.0)
+    (counter_for kind)
+
+let test_admission_queue_rejected_kind () =
+  let kind = "admission_queue_rejected" in
+  let before = counter_for kind in
+  let _ =
+    OWN.sdk_error_of_masc_internal_error
+      (OWN.Admission_queue_rejected
+         { keeper_name = "keeper-alpha"; reason = "queue closed" })
+  in
+  Alcotest.(check (float 0.0001))
+    "admission_queue_rejected counter +1"
+    (before +. 1.0)
+    (counter_for kind)
+
 let test_ambiguous_post_commit_kind () =
   let kind = "ambiguous_post_commit" in
   let before = counter_for kind in
@@ -137,6 +200,14 @@ let () =
             test_cascade_exhausted_kind;
           Alcotest.test_case "resumable_cli_session" `Quick
             test_resumable_cli_session_kind;
+          Alcotest.test_case "no_tool_capable_provider" `Quick
+            test_no_tool_capable_provider_kind;
+          Alcotest.test_case "accept_rejected" `Quick
+            test_accept_rejected_kind;
+          Alcotest.test_case "admission_queue_timeout" `Quick
+            test_admission_queue_timeout_kind;
+          Alcotest.test_case "admission_queue_rejected" `Quick
+            test_admission_queue_rejected_kind;
           Alcotest.test_case "ambiguous_post_commit" `Quick
             test_ambiguous_post_commit_kind;
         ] );


### PR DESCRIPTION
## 요약

125 `oas_timeout_budget` blocker 가 9 keeper 에 24h 누적됐지만 Prometheus 에 aggregate signal 없음 — operator 는 BDI blocker 문자열 grep 으로만 kind 를 식별. 게다가 blocker text 가 `budget_...` 로 잘려 structured data 접근도 불안정.

이 PR 은 `[masc_oas_error]` payload 를 packaging 하는 단일 constructor (`sdk_error_of_masc_internal_error`) 에서 counter 를 증가:

```
masc_oas_error_total{kind}
  kind = cascade_exhausted | resumable_cli_session
       | no_tool_capable_provider | accept_rejected
       | admission_queue_timeout | admission_queue_rejected
       | turn_timeout | oas_timeout_budget
       | ambiguous_post_commit
```

Construction 에 hook 하므로 14 caller site 가 자동 커버 — caller signature 변경 0. `keeper` label 은 모든 construction path 가 keeper_name 을 가지게 된 후속 PR 에서 추가.

## 변경 파일

- `lib/oas_worker_named.ml`
  - `masc_oas_error_total_metric` 상수 + `kind_of_masc_internal_error` extractor (9 variants exhaustive).
  - `sdk_error_of_masc_internal_error` 가 counter 증가 후 기존 SDK error 반환.
- `test/test_oas_error_kind_counter.ml` (신규) — 7 테스트:
  - Canonical metric name pin (Grafana rename 방어).
  - 각 variant 별 counter +1 (`oas_timeout_budget`, `turn_timeout`, `cascade_exhausted`, `resumable_cli_session`, `ambiguous_post_commit`) — 5 cases.
  - Kind label isolation (`turn_timeout` 증가가 `oas_timeout_budget` 을 건드리지 않음).
- `test/dune` — 새 test 등록.

`No_tool_capable_provider`, `Accept_rejected`, `Admission_queue_timeout`, `Admission_queue_rejected` 의 emit path 테스트는 구성 복잡도가 높아 이 PR 에서는 pattern-match 망라만 (exhaustive compile-time 체크) — extractor 의 9-variant 경로가 compiler 에 의해 보장됨.

## 로컬 검증

```
$ MASC_BASE_PATH=/tmp/masc-test-9933 dune exec test/test_oas_error_kind_counter.exe
Test Successful in 0.001s. 7 tests run.

$ dune exec test/test_oas_worker.exe
Test Successful in 0.699s. 109 tests run.   # 회귀 0
```

`dune build --cache=disabled` clean.

## 왜 근원 fix 인가

- **Single construction point hook**: 14 emit site 에 개별 inject 대신 constructor 한 곳에서 처리. 새 emit site 추가 시 자동으로 observability 상속.
- **Exhaustive pattern match**: OCaml compiler 가 9 variant 전부 커버되는지 체크. 새 variant 가 추가되면 build error → reviewer 가 kind name 을 정해야 merge 가능. `feedback_no-invented-abstractions.md` 의 "SDK drift 는 compile-time 에 surface" 정신.
- **Parse 하지 않고 structured 유지**: 기존 구조는 JSON payload 를 문자열 grep 으로 소비 (truncation 때문에 불안정). 이 PR 은 source of truth 인 constructor 에서 kind 를 뽑아 label 로 고정.
- **#9933 의 iter 32 재측정 결과 반영**: p50 16분, p90 20분 (= 1200s turn timeout) — OAS budget 이 실제로 turn timeout 근처에서 발화. 이 counter 가 seen rate 를 fleet-wide 로 surface 해서 improvement 가 noop 인지 effective 인지 측정 가능.

## 미검증 / 후속

- Grafana panel / alert rule 은 ops ticket (metric 이름은 이 PR 이 pin).
- `keeper` label 추가 — 현재 14 construction site 중 일부만 keeper_name 이 in-scope. 나머지 site 에 threading 후 label 추가.
- Blocker text truncation (~200 chars) 자체는 이 PR 범위 밖. `masc_oas_error_prefix_len` 관련 이슈로 별도 triage.

## 관련

- #9933 (root).
- #9932 (kimi_cli permanent) — `oas_timeout_budget` label 하에 가시화될 것.
- #9637 (1200s turn timeout) — p90 이 도달하는 upper bound.
- #9926 (fleet claim-gap) — downstream.
- #9517 (silent failure meta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)