### PR TITLE
[codex] Add coordination product FSM evidence

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -434,6 +434,19 @@ function bootstrapInitializingPayload(path: string): unknown | null {
           done: 0,
           cancelled: 0,
         },
+        coordination_fsm: {
+          schema_version: 1,
+          mode: 'advisory',
+          summary: {
+            products: 0,
+            violations: 0,
+            evidence: 0,
+            severity_counts: { info: 0, warn: 0, error: 0 },
+          },
+          products: [],
+          evidence: [],
+          violations: [],
+        },
       }
     case '/api/v1/dashboard/mission':
       return {

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -10,6 +10,7 @@ import {
   goalTreeLoading as treeLoading,
   hydrateGoalTreeSnapshot,
 } from '../../goal-tree-state'
+import { coordinationFsmSnapshot } from '../../store'
 import { EmptyState, ErrorState, LoadingState } from '../common/feedback-state'
 import { ActionButton } from '../common/button'
 import { FilterChips } from '../common/filter-chips'
@@ -18,6 +19,7 @@ import { TimeAgo } from '../common/time-ago'
 import { TaskCreateForm } from '../task-manage/task-create-form'
 import type {
   DashboardGoalDetailResponse,
+  DashboardCoordinationFsmViolation,
   GoalDetailKeeper,
   GoalDetailTimelineEvent,
   GoalTreeNode,
@@ -403,6 +405,11 @@ function GoalBadges({ badges }: { badges: string[] }) {
   `
 }
 
+function coordinationViolationsForGoal(goalId: string): DashboardCoordinationFsmViolation[] {
+  const violations = coordinationFsmSnapshot.value?.violations ?? []
+  return violations.filter(violation => violation.refs?.goal_id === goalId)
+}
+
 function TreeTask({ task }: { task: GoalTreeTask }) {
   return html`
     <div class="flex flex-wrap items-center gap-2 rounded bg-white/3 px-2 py-1.5 text-xs">
@@ -424,6 +431,8 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
   const hasContent = node.children.length > 0 || node.tasks.length > 0
   const isSelected = selectedGoalId.value === node.id
   const verificationSummary = node.verification_summary ?? EMPTY_GOAL_VERIFICATION_SUMMARY
+  const coordinationViolations = coordinationViolationsForGoal(node.id)
+  const coordinationHasError = coordinationViolations.some(v => v.severity === 'error')
   const indent = depth * 20
   const headerBase = isSelected
     ? 'group flex items-start gap-3 rounded border border-accent/35 bg-[rgba(11,18,32,0.94)] p-3 transition-colors w-full text-left shadow-[0_0_0_1px_rgba(110,231,255,0.08)]'
@@ -488,6 +497,14 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
             ${node.pending_approval_count > 0 ? html`
               <span class="rounded border border-warn/30 bg-warn/10 px-2 py-0.5 text-3xs font-medium text-warn">
                 approval ${node.pending_approval_count}
+              </span>
+            ` : null}
+            ${coordinationViolations.length > 0 ? html`
+              <span
+                class="rounded border px-2 py-0.5 text-3xs font-medium ${coordinationHasError ? 'border-bad/30 bg-bad/10 text-bad' : 'border-warn/30 bg-warn/10 text-warn'}"
+                title="Goal x Task x Board x Reward"
+              >
+                FSM ${coordinationViolations.length}
               </span>
             ` : null}
             ${node.blocking_source !== 'none' ? html`

--- a/dashboard/src/components/planning-panel.test.ts
+++ b/dashboard/src/components/planning-panel.test.ts
@@ -13,6 +13,12 @@ vi.mock('../router', () => ({
   get route() { return routeSignal },
 }))
 
+const coordinationSignal = signal<unknown>(null)
+
+vi.mock('../store', () => ({
+  get coordinationFsmSnapshot() { return coordinationSignal },
+}))
+
 vi.mock('./goals', () => ({
   Planning: () => html`<div data-testid="planning">Planning</div>`,
 }))
@@ -29,7 +35,10 @@ function setRoute(view?: string) {
 }
 
 describe('PlanningPanel', () => {
-  beforeEach(() => setRoute())
+  beforeEach(() => {
+    setRoute()
+    coordinationSignal.value = null
+  })
   afterEach(() => cleanup())
 
   it('renders GoalTree by default', () => {
@@ -55,5 +64,59 @@ describe('PlanningPanel', () => {
     setRoute('nonexistent')
     render(html`<${PlanningPanel} />`)
     expect(screen.getByTestId('goal-tree')).toBeTruthy()
+  })
+
+  it('renders coordination health violations', () => {
+    coordinationSignal.value = {
+      mode: 'advisory',
+      summary: {
+        products: 1,
+        violations: 1,
+        evidence: 2,
+        severity_counts: { info: 0, warn: 0, error: 1 },
+      },
+      evidence: [
+        {
+          source: 'telemetry',
+          kind: 'task_completed',
+          label: 'task completed',
+          detail: 'success=true; duration_ms=42',
+          refs: { goal_id: 'goal-1', task_ids: ['task-1'] },
+        },
+        {
+          source: 'board',
+          kind: 'post',
+          label: 'Board post',
+          detail: 'author=keeper',
+          refs: { goal_id: 'goal-1' },
+        },
+      ],
+      violations: [
+        {
+          severity: 'error',
+          code: 'reward_without_evidence',
+          message: 'Reward missing evidence',
+          refs: { goal_id: 'goal-1', task_ids: ['task-1'] },
+          evidence: [
+            {
+              source: 'telemetry',
+              kind: 'task_completed',
+              label: 'task completed',
+              detail: 'success=true; duration_ms=42',
+            },
+          ],
+        },
+      ],
+    }
+
+    render(html`<${PlanningPanel} />`)
+
+    expect(screen.getByText('Coordination Health')).toBeTruthy()
+    expect(screen.getByText('reward_without_evidence')).toBeTruthy()
+    expect(screen.getByText(/Reward missing evidence/)).toBeTruthy()
+    expect(screen.getByText(/goal: goal-1/)).toBeTruthy()
+    expect(screen.getAllByText('telemetry/task_completed').length).toBeGreaterThan(0)
+    expect(screen.getByText('board/post')).toBeTruthy()
+    expect(screen.getAllByText('task completed').length).toBeGreaterThan(0)
   })
 })

--- a/dashboard/src/components/planning-panel.ts
+++ b/dashboard/src/components/planning-panel.ts
@@ -6,9 +6,16 @@
 import { html } from 'htm/preact'
 import { computed } from '@preact/signals'
 import { route } from '../router'
+import { coordinationFsmSnapshot } from '../store'
 import { FilterChips } from './common/filter-chips'
 import { Planning } from './goals'
 import { GoalTree } from './goals/goal-tree'
+import type {
+  DashboardCoordinationFsmEvidence,
+  DashboardCoordinationFsmRefs,
+  DashboardCoordinationFsmSnapshot,
+  DashboardCoordinationFsmViolation,
+} from '../types'
 
 type PlanningView = 'default' | 'goal-tree'
 
@@ -36,6 +43,148 @@ function updateViewParam(view: PlanningView): void {
   window.dispatchEvent(new HashChangeEvent('hashchange'))
 }
 
+function coordinationCount(
+  snapshot: DashboardCoordinationFsmSnapshot | null,
+  key: 'products' | 'violations' | 'evidence' | 'warn' | 'error',
+): number {
+  if (!snapshot?.summary) return 0
+  if (key === 'products') return snapshot.summary.products ?? 0
+  if (key === 'violations') return snapshot.summary.violations ?? 0
+  if (key === 'evidence') return snapshot.summary.evidence ?? snapshot.evidence?.length ?? 0
+  return snapshot.summary.severity_counts?.[key] ?? 0
+}
+
+function severityToneClass(severity: string | undefined): string {
+  switch (severity) {
+    case 'error':
+      return 'border-bad/35 bg-bad/10 text-bad'
+    case 'warn':
+      return 'border-warn/35 bg-warn/10 text-warn'
+    default:
+      return 'border-accent/25 bg-[var(--accent-10)] text-accent'
+  }
+}
+
+function refsLabel(refs: DashboardCoordinationFsmRefs | undefined): string {
+  if (!refs) return 'refs: -'
+  const parts: string[] = []
+  if (refs.goal_id) parts.push(`goal: ${refs.goal_id}`)
+  if (refs.task_ids && refs.task_ids.length > 0) parts.push(`tasks: ${refs.task_ids.join(', ')}`)
+  if (refs.post_ids && refs.post_ids.length > 0) parts.push(`posts: ${refs.post_ids.join(', ')}`)
+  if (refs.agent_name) parts.push(`agent: ${refs.agent_name}`)
+  return parts.length > 0 ? parts.join(' · ') : 'refs: -'
+}
+
+function evidenceLabel(evidence: DashboardCoordinationFsmEvidence): string {
+  const source = evidence.source ?? 'evidence'
+  const kind = evidence.kind ? `/${evidence.kind}` : ''
+  return `${source}${kind}`
+}
+
+function CoordinationEvidenceRow({ evidence }: { evidence: DashboardCoordinationFsmEvidence }) {
+  return html`
+    <li class="min-w-0 rounded border border-card-border/40 bg-white/[0.03] px-2 py-1">
+      <div class="flex min-w-0 flex-wrap items-center gap-2">
+        <span class="rounded border border-card-border/50 bg-black/15 px-1.5 py-0.5 text-3xs font-semibold uppercase text-text-muted">
+          ${evidenceLabel(evidence)}
+        </span>
+        <span class="min-w-0 truncate text-2xs font-medium text-text-strong">
+          ${evidence.label ?? evidence.id ?? 'evidence'}
+        </span>
+      </div>
+      ${evidence.detail ? html`
+        <div class="mt-0.5 truncate text-3xs text-text-dim" title=${evidence.detail}>${evidence.detail}</div>
+      ` : null}
+    </li>
+  `
+}
+
+function CoordinationViolationRow({ violation }: { violation: DashboardCoordinationFsmViolation }) {
+  const evidence = (violation.evidence ?? []).slice(0, 3)
+  return html`
+    <li class="rounded border border-card-border/60 bg-black/10 p-2">
+      <div class="flex flex-wrap items-center gap-2 text-xs">
+        <span class="rounded border px-2 py-0.5 text-3xs font-semibold uppercase ${severityToneClass(violation.severity)}">
+          ${violation.severity ?? 'info'}
+        </span>
+        <span class="font-mono text-2xs text-text-strong">${violation.code ?? violation.axis ?? 'coordination'}</span>
+        ${violation.axis ? html`<span class="text-3xs text-text-dim">${violation.axis}</span>` : null}
+      </div>
+      <div class="mt-1 text-xs leading-relaxed text-text-body">${violation.message ?? 'Coordination invariant needs attention.'}</div>
+      <div class="mt-1 truncate text-3xs text-text-dim" title=${refsLabel(violation.refs)}>${refsLabel(violation.refs)}</div>
+      ${evidence.length > 0 ? html`
+        <ul class="mt-2 grid gap-1">
+          ${evidence.map((item, index) => html`
+            <${CoordinationEvidenceRow} key=${`${item.source ?? 'evidence'}-${item.kind ?? 'kind'}-${item.id ?? index}`} evidence=${item} />
+          `)}
+        </ul>
+      ` : null}
+    </li>
+  `
+}
+
+function CoordinationHealthPanel() {
+  const snapshot = coordinationFsmSnapshot.value
+  if (!snapshot) return null
+  const violations = snapshot.violations ?? []
+  const topViolations = violations.slice(0, 5)
+  const topEvidence = (snapshot.evidence ?? []).slice(0, 5)
+  const errorCount = coordinationCount(snapshot, 'error')
+  const warnCount = coordinationCount(snapshot, 'warn')
+  const evidenceCount = coordinationCount(snapshot, 'evidence')
+  return html`
+    <section class="rounded border border-card-border/70 bg-[rgba(8,13,22,0.74)] p-3">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <div class="text-sm font-semibold text-text-strong">Coordination Health</div>
+          <div class="text-2xs text-text-dim">Goal x Task x Board x Reward · ${snapshot.mode ?? 'advisory'}</div>
+        </div>
+        <div class="flex flex-wrap items-center gap-2 text-3xs font-medium">
+          <span class="rounded border border-card-border/60 bg-white/4 px-2 py-1 text-text-body">
+            products ${coordinationCount(snapshot, 'products')}
+          </span>
+          <span class="rounded border border-card-border/60 bg-white/4 px-2 py-1 text-text-body">
+            violations ${coordinationCount(snapshot, 'violations')}
+          </span>
+          <span class="rounded border border-card-border/60 bg-white/4 px-2 py-1 text-text-body">
+            evidence ${evidenceCount}
+          </span>
+          ${errorCount > 0 ? html`
+            <span class="rounded border border-bad/35 bg-bad/10 px-2 py-1 text-bad">error ${errorCount}</span>
+          ` : null}
+          ${warnCount > 0 ? html`
+            <span class="rounded border border-warn/35 bg-warn/10 px-2 py-1 text-warn">warn ${warnCount}</span>
+          ` : null}
+        </div>
+      </div>
+      ${snapshot.projection_error ? html`
+        <div class="mt-2 rounded border border-warn/30 bg-warn/10 px-2 py-1 text-xs text-warn">
+          projection: ${snapshot.projection_error}
+        </div>
+      ` : null}
+      ${violations.length === 0 ? html`
+        <div class="mt-2 text-xs text-text-muted">Aligned</div>
+      ` : html`
+        <ul class="mt-2 grid gap-2">
+          ${topViolations.map((violation, index) => html`
+            <${CoordinationViolationRow} key=${`${violation.code ?? violation.axis ?? 'coordination'}-${index}`} violation=${violation} />
+          `)}
+        </ul>
+      `}
+      ${topEvidence.length > 0 ? html`
+        <div class="mt-3">
+          <div class="mb-1 text-3xs font-semibold uppercase text-text-muted">Evidence</div>
+          <ul class="grid gap-1 md:grid-cols-2">
+            ${topEvidence.map((item, index) => html`
+              <${CoordinationEvidenceRow} key=${`${item.source ?? 'evidence'}-${item.kind ?? 'kind'}-${item.id ?? index}`} evidence=${item} />
+            `)}
+          </ul>
+        </div>
+      ` : null}
+    </section>
+  `
+}
+
 export function PlanningPanel() {
   const view = activeView.value
 
@@ -48,6 +197,7 @@ export function PlanningPanel() {
         size="sm"
         tone="accent"
       />
+      <${CoordinationHealthPanel} />
       ${view === 'goal-tree'
         ? html`<${GoalTree} />`
         : html`<${Planning} />`}

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -23,6 +23,11 @@ import type {
   DashboardShellAuthSummary,
   DashboardShellMetaCognitionSummary,
   DashboardShellResponse,
+  DashboardCoordinationFsmEvidence,
+  DashboardCoordinationFsmProduct,
+  DashboardCoordinationFsmRefs,
+  DashboardCoordinationFsmSnapshot,
+  DashboardCoordinationFsmViolation,
 } from './types'
 import { fetchDashboardShell } from './api/dashboard-hot'
 import { journal } from './sse'
@@ -113,6 +118,7 @@ export function removeBoardPost(postId: string | undefined): void {
 
 export const goals = signal<Goal[]>([])
 export const goalsLoading = signal(false)
+export const coordinationFsmSnapshot = signal<DashboardCoordinationFsmSnapshot | null>(null)
 
 // --- OAS monitoring state ---
 
@@ -396,7 +402,138 @@ export async function refreshDashboard(opts?: RefreshOptions): Promise<void> {
   return inflightDashboardRefresh
 }
 
+function normalizeStringList(raw: unknown): string[] {
+  if (Array.isArray(raw)) {
+    return raw.filter((value): value is string =>
+      typeof value === 'string' && value.trim() !== '',
+    )
+  }
+  if (typeof raw === 'string' && raw.trim() !== '') return [raw]
+  return []
+}
+
+function normalizeCoordinationFsmRefs(raw: unknown): DashboardCoordinationFsmRefs {
+  const refsRecord = isRecord(raw) ? raw : {}
+  return {
+    goal_id: asString(refsRecord.goal_id) ?? null,
+    task_ids: normalizeStringList(refsRecord.task_ids),
+    post_ids: normalizeStringList(refsRecord.post_ids),
+    agent_name: asString(refsRecord.agent_name) ?? null,
+  }
+}
+
+function normalizeCoordinationFsmEvidence(raw: unknown): DashboardCoordinationFsmEvidence | null {
+  if (!isRecord(raw)) return null
+  return {
+    source: asString(raw.source) ?? undefined,
+    kind: asString(raw.kind) ?? undefined,
+    id: asString(raw.id) ?? null,
+    label: asString(raw.label) ?? undefined,
+    detail: asString(raw.detail) ?? undefined,
+    timestamp: asNumber(raw.timestamp) ?? null,
+    refs: normalizeCoordinationFsmRefs(raw.refs),
+  }
+}
+
+function normalizeCoordinationFsmEvidenceList(raw: unknown): DashboardCoordinationFsmEvidence[] {
+  return Array.isArray(raw)
+    ? raw
+      .map(normalizeCoordinationFsmEvidence)
+      .filter((row): row is DashboardCoordinationFsmEvidence => row !== null)
+    : []
+}
+
+function refsOverlap(
+  left: DashboardCoordinationFsmRefs | undefined,
+  right: DashboardCoordinationFsmRefs | undefined,
+): boolean {
+  if (!left || !right) return false
+  if (left.goal_id && left.goal_id === right.goal_id) return true
+  if (left.agent_name && left.agent_name === right.agent_name) return true
+  if ((left.task_ids ?? []).some(taskId => (right.task_ids ?? []).includes(taskId))) return true
+  return (left.post_ids ?? []).some(postId => (right.post_ids ?? []).includes(postId))
+}
+
+function normalizeCoordinationFsmSnapshot(raw: unknown): DashboardCoordinationFsmSnapshot | null {
+  if (!isRecord(raw)) return null
+  const summaryRecord = isRecord(raw.summary) ? raw.summary : {}
+  const severityRecord = isRecord(summaryRecord.severity_counts)
+    ? summaryRecord.severity_counts
+    : {}
+  const products: DashboardCoordinationFsmProduct[] = Array.isArray(raw.products)
+    ? raw.products
+      .map((row): DashboardCoordinationFsmProduct | null => {
+        if (!isRecord(row)) return null
+        return {
+          refs: normalizeCoordinationFsmRefs(row.refs),
+          goal: asString(row.goal) ?? null,
+          task: asString(row.task) ?? undefined,
+          board: asString(row.board) ?? undefined,
+          reward: asString(row.reward) ?? undefined,
+          evidence: normalizeCoordinationFsmEvidenceList(row.evidence),
+          violations: Array.isArray(row.violations)
+            ? row.violations
+              .map((violation): DashboardCoordinationFsmViolation | null => {
+                if (!isRecord(violation)) return null
+                return {
+                  axis: asString(violation.axis) ?? undefined,
+                  code: asString(violation.code) ?? undefined,
+                  severity: asString(violation.severity) ?? undefined,
+                  message: asString(violation.message) ?? undefined,
+                  refs: normalizeCoordinationFsmRefs(violation.refs),
+                  evidence: normalizeCoordinationFsmEvidenceList(violation.evidence),
+                }
+              })
+              .filter((violation): violation is DashboardCoordinationFsmViolation => violation !== null)
+            : [],
+        }
+      })
+      .filter((row): row is DashboardCoordinationFsmProduct => row !== null)
+    : []
+  const fallbackEvidence = products.flatMap(product => product.evidence ?? [])
+  const snapshotEvidence = normalizeCoordinationFsmEvidenceList(raw.evidence)
+  const evidence = snapshotEvidence.length > 0 ? snapshotEvidence : fallbackEvidence
+  const violations = Array.isArray(raw.violations)
+    ? raw.violations
+      .map((row): DashboardCoordinationFsmViolation | null => {
+        if (!isRecord(row)) return null
+        const refs = normalizeCoordinationFsmRefs(row.refs)
+        const rowEvidence = normalizeCoordinationFsmEvidenceList(row.evidence)
+        return {
+          axis: asString(row.axis) ?? undefined,
+          code: asString(row.code) ?? undefined,
+          severity: asString(row.severity) ?? undefined,
+          message: asString(row.message) ?? undefined,
+          refs,
+          evidence: rowEvidence.length > 0
+            ? rowEvidence
+            : fallbackEvidence.filter(item => refsOverlap(refs, item.refs)).slice(0, 5),
+        }
+      })
+      .filter((row): row is DashboardCoordinationFsmViolation => row !== null)
+    : []
+  return {
+    schema_version: asNumber(raw.schema_version) ?? undefined,
+    mode: asString(raw.mode) ?? undefined,
+    summary: {
+      products: asNumber(summaryRecord.products) ?? undefined,
+      violations: asNumber(summaryRecord.violations) ?? undefined,
+      evidence: asNumber(summaryRecord.evidence) ?? evidence.length,
+      severity_counts: {
+        info: asNumber(severityRecord.info) ?? 0,
+        warn: asNumber(severityRecord.warn) ?? 0,
+        error: asNumber(severityRecord.error) ?? 0,
+      },
+    },
+    products,
+    evidence,
+    violations,
+    projection_error: asString(raw.projection_error) ?? null,
+  }
+}
+
 function applyPlanningEnvelope(data: DashboardPlanningResponse): void {
+  coordinationFsmSnapshot.value = normalizeCoordinationFsmSnapshot(data.coordination_fsm)
   goals.value = (Array.isArray(data.goals) ? data.goals : [])
     .map((row): Goal | null => {
       if (!isRecord(row)) return null

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -452,6 +452,64 @@ export interface DashboardPlanningResponse {
     done?: number
     cancelled?: number
   }
+  coordination_fsm?: DashboardCoordinationFsmSnapshot | null
+}
+
+export interface DashboardCoordinationFsmRefs {
+  goal_id?: string | null
+  task_ids?: string[]
+  post_ids?: string[]
+  agent_name?: string | null
+}
+
+export interface DashboardCoordinationFsmEvidence {
+  source?: string
+  kind?: string
+  id?: string | null
+  label?: string
+  detail?: string
+  timestamp?: number | null
+  refs?: DashboardCoordinationFsmRefs
+}
+
+export interface DashboardCoordinationFsmViolation {
+  axis?: string
+  code?: string
+  severity?: 'info' | 'warn' | 'error' | string
+  message?: string
+  refs?: DashboardCoordinationFsmRefs
+  evidence?: DashboardCoordinationFsmEvidence[]
+}
+
+export interface DashboardCoordinationFsmProduct {
+  refs?: DashboardCoordinationFsmRefs
+  goal?: string | null
+  task?: string
+  board?: string
+  reward?: string
+  evidence?: DashboardCoordinationFsmEvidence[]
+  violations?: DashboardCoordinationFsmViolation[]
+}
+
+export interface DashboardCoordinationFsmSummary {
+  products?: number
+  violations?: number
+  evidence?: number
+  severity_counts?: {
+    info?: number
+    warn?: number
+    error?: number
+  }
+}
+
+export interface DashboardCoordinationFsmSnapshot {
+  schema_version?: number
+  mode?: string
+  summary?: DashboardCoordinationFsmSummary
+  products?: DashboardCoordinationFsmProduct[]
+  evidence?: DashboardCoordinationFsmEvidence[]
+  violations?: DashboardCoordinationFsmViolation[]
+  projection_error?: string | null
 }
 
 // --- Goal Tree (hierarchical goal decomposition) ---

--- a/lib/agent_economy.ml
+++ b/lib/agent_economy.ml
@@ -224,6 +224,27 @@ let get_balance ~base_path ~agent_name =
     | Some b -> b
     | None -> initial_balance ())
 
+let list_transactions ~base_path =
+  let path = ledger_path base_path in
+  if not (Sys.file_exists path) then []
+  else
+    match Safe_ops.read_file_safe path with
+    | Error e ->
+      Log.Misc.warn "economy ledger read failed for %s: %s" path e;
+      []
+    | Ok content ->
+      content
+      |> String.split_on_char '\n'
+      |> List.filter_map (fun line ->
+        let trimmed = String.trim line in
+        if trimmed = "" then None
+        else
+          try transaction_of_json (Yojson.Safe.from_string trimmed)
+          with Yojson.Json_error msg ->
+            Log.Misc.warn
+              "agent_economy: skipping malformed ledger entry: %s" msg;
+            None)
+
 (** {1 Reputation Integration} *)
 
 let reward_multiplier ~overall_score =

--- a/lib/agent_economy.mli
+++ b/lib/agent_economy.mli
@@ -88,6 +88,9 @@ val spend :
 val get_balance : base_path:string -> agent_name:string -> float
 (** Current balance for an agent. Returns initial_balance if no history. *)
 
+val list_transactions : base_path:string -> transaction list
+(** Read ledger transactions in append order. Malformed entries are skipped. *)
+
 val economic_pressure : base_path:string -> agent_name:string -> pressure_mode
 (** Determine behavioral pressure mode from current balance. *)
 

--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -102,6 +102,7 @@ let select_public_local_worker_schemas () =
   let wanted = local_worker_public_tool_names in
   dedupe_schemas
     (Tool_board.tools
+    @ Tool_schemas_coord_core.schemas
     @ Tool_schemas_coord_extra.schemas
     @ local_worker_code_schemas
     @ local_worker_worktree_schemas

--- a/lib/coordination_product.ml
+++ b/lib/coordination_product.ml
@@ -1,0 +1,462 @@
+(** Advisory orthogonal product for Goal x Task x Board x Reward. *)
+
+type task_phase =
+  | No_task
+  | Todo
+  | Claimed
+  | In_progress
+  | Awaiting_verification
+  | Done
+  | Cancelled
+  | Mixed
+
+let task_phase_to_string = function
+  | No_task -> "no_task"
+  | Todo -> "todo"
+  | Claimed -> "claimed"
+  | In_progress -> "in_progress"
+  | Awaiting_verification -> "awaiting_verification"
+  | Done -> "done"
+  | Cancelled -> "cancelled"
+  | Mixed -> "mixed"
+;;
+
+let task_phase_of_status = function
+  | Types.Todo -> Todo
+  | Types.Claimed _ -> Claimed
+  | Types.InProgress _ -> In_progress
+  | Types.AwaitingVerification _ -> Awaiting_verification
+  | Types.Done _ -> Done
+  | Types.Cancelled _ -> Cancelled
+;;
+
+type board_phase =
+  | Quiet
+  | Signal_pending
+  | Signal_acknowledged
+  | Signal_expired
+  | Degraded
+
+let board_phase_to_string = function
+  | Quiet -> "quiet"
+  | Signal_pending -> "signal_pending"
+  | Signal_acknowledged -> "signal_acknowledged"
+  | Signal_expired -> "signal_expired"
+  | Degraded -> "degraded"
+;;
+
+type reward_phase =
+  | Disabled
+  | Neutral
+  | Credit_pending
+  | Rewarded
+  | Spent
+  | Penalized
+
+let reward_phase_to_string = function
+  | Disabled -> "disabled"
+  | Neutral -> "neutral"
+  | Credit_pending -> "credit_pending"
+  | Rewarded -> "rewarded"
+  | Spent -> "spent"
+  | Penalized -> "penalized"
+;;
+
+type axis =
+  | Goal
+  | Task
+  | Board
+  | Reward
+  | Product
+
+let axis_to_string = function
+  | Goal -> "goal"
+  | Task -> "task"
+  | Board -> "board"
+  | Reward -> "reward"
+  | Product -> "product"
+;;
+
+type severity =
+  | Info
+  | Warn
+  | Error
+
+let severity_to_string = function
+  | Info -> "info"
+  | Warn -> "warn"
+  | Error -> "error"
+;;
+
+type ids =
+  { goal_id : string option
+  ; task_ids : string list
+  ; post_ids : string list
+  ; agent_name : string option
+  }
+
+let empty_ids = { goal_id = None; task_ids = []; post_ids = []; agent_name = None }
+
+type task_counts =
+  { total : int
+  ; open_count : int
+  ; done_count : int
+  ; cancelled_count : int
+  ; awaiting_verification_count : int
+  }
+
+let empty_task_counts =
+  { total = 0
+  ; open_count = 0
+  ; done_count = 0
+  ; cancelled_count = 0
+  ; awaiting_verification_count = 0
+  }
+;;
+
+let task_counts_of_statuses statuses =
+  let count pred = statuses |> List.filter pred |> List.length in
+  { total = List.length statuses
+  ; open_count = count (fun status -> not (Types.task_status_is_terminal status))
+  ; done_count = count Types.task_status_is_done
+  ; cancelled_count =
+      count (function
+        | Types.Cancelled _ -> true
+        | _ -> false)
+  ; awaiting_verification_count =
+      count (function
+        | Types.AwaitingVerification _ -> true
+        | _ -> false)
+  }
+;;
+
+let task_phase_of_counts statuses =
+  match statuses with
+  | [] -> No_task
+  | [ status ] -> task_phase_of_status status
+  | first :: rest ->
+    let first_phase = task_phase_of_status first in
+    if List.for_all (fun status -> task_phase_of_status status = first_phase) rest
+    then first_phase
+    else Mixed
+;;
+
+type facts =
+  { economy_enabled : bool
+  ; has_reward_earning : bool
+  ; has_spend : bool
+  ; has_penalty : bool
+  ; board_signal_count : int
+  ; board_persist_error_count : int
+  ; active_goal_verification : bool
+  }
+
+let default_facts =
+  { economy_enabled = false
+  ; has_reward_earning = false
+  ; has_spend = false
+  ; has_penalty = false
+  ; board_signal_count = 0
+  ; board_persist_error_count = 0
+  ; active_goal_verification = false
+  }
+;;
+
+type evidence =
+  { source : string
+  ; kind : string
+  ; id : string option
+  ; label : string
+  ; detail : string
+  ; timestamp : float option
+  ; refs : ids
+  }
+
+type product =
+  { ids : ids
+  ; goal : Goal_phase.t option
+  ; task : task_phase
+  ; board : board_phase
+  ; reward : reward_phase
+  ; task_counts : task_counts
+  ; facts : facts
+  ; evidence : evidence list
+  }
+
+type violation =
+  { axis : axis
+  ; code : string
+  ; severity : severity
+  ; message : string
+  ; ids : ids
+  }
+
+let reward_phase_of_facts
+      ~economy_enabled
+      ~task_counts
+      ~board
+      ~has_reward_earning
+      ~has_spend
+      ~has_penalty
+  =
+  if not economy_enabled
+  then Disabled
+  else if has_penalty
+  then Penalized
+  else if has_reward_earning && has_spend
+  then Spent
+  else if has_reward_earning
+  then Rewarded
+  else if task_counts.done_count > 0 || board = Signal_acknowledged
+  then Credit_pending
+  else Neutral
+;;
+
+let add_violation violations ~axis ~code ~severity ~message ~ids =
+  { axis; code; severity; message; ids } :: violations
+;;
+
+let goal_is_terminal = function
+  | Some Goal_phase.Completed | Some Goal_phase.Dropped -> true
+  | Some
+      ( Goal_phase.Executing
+      | Goal_phase.Awaiting_verification
+      | Goal_phase.Awaiting_approval
+      | Goal_phase.Blocked
+      | Goal_phase.Paused )
+  | None -> false
+;;
+
+let reward_has_evidence (product : product) =
+  product.task_counts.done_count > 0
+  || product.board = Signal_acknowledged
+  || product.facts.has_reward_earning
+;;
+
+let check_invariants (product : product) =
+  let violations = ref [] in
+  let add ~axis ~code ~severity ~message =
+    violations
+    := add_violation !violations ~axis ~code ~severity ~message ~ids:product.ids
+  in
+  (match product.goal with
+   | Some (Goal_phase.Completed | Goal_phase.Dropped)
+     when product.task_counts.open_count > 0 ->
+     add
+       ~axis:Product
+       ~code:"goal_terminal_open_tasks"
+       ~severity:Error
+       ~message:"Goal is terminal while one or more linked tasks are still open."
+   | Some Goal_phase.Completed
+     when product.task_counts.total = 0 || product.task_counts.done_count = 0 ->
+     add
+       ~axis:Goal
+       ~code:"goal_completed_without_done_task"
+       ~severity:Warn
+       ~message:
+         "Goal is completed without linked done-task evidence; this may be an operator \
+          override."
+   | Some Goal_phase.Awaiting_verification
+     when product.task_counts.done_count = 0 && not product.facts.active_goal_verification
+     ->
+     add
+       ~axis:Goal
+       ~code:"goal_verification_without_evidence"
+       ~severity:Warn
+       ~message:
+         "Goal is awaiting verification without done-task evidence or an active \
+          verification request."
+   | Some
+       ( Goal_phase.Executing
+       | Goal_phase.Awaiting_verification
+       | Goal_phase.Awaiting_approval
+       | Goal_phase.Blocked
+       | Goal_phase.Paused
+       | Goal_phase.Completed
+       | Goal_phase.Dropped )
+   | None -> ());
+  (match product.reward with
+   | (Rewarded | Spent) when not (reward_has_evidence product) ->
+     add
+       ~axis:Reward
+       ~code:"reward_without_evidence"
+       ~severity:Error
+       ~message:
+         "Reward state is earned/spent without task completion or acknowledged board \
+          evidence."
+   | Credit_pending
+     when product.goal = Some Goal_phase.Dropped || product.task = Cancelled ->
+     add
+       ~axis:Reward
+       ~code:"pending_credit_for_dropped_work"
+       ~severity:Warn
+       ~message:
+         "Credit is pending for dropped or cancelled work; ledger should stay neutral \
+          unless an override exists."
+   | Disabled | Neutral | Credit_pending | Rewarded | Spent | Penalized -> ());
+  (match product.board with
+   | Degraded ->
+     add
+       ~axis:Board
+       ~code:"board_degraded"
+       ~severity:Error
+       ~message:
+         "Board persistence has recorded errors; coordination signals may be incomplete."
+   | Signal_pending when goal_is_terminal product.goal ->
+     add
+       ~axis:Board
+       ~code:"board_signal_pending_after_terminal_goal"
+       ~severity:Warn
+       ~message:"Board signal remains pending after the goal reached a terminal phase."
+   | Signal_pending
+     when product.task_counts.total > 0 && product.task_counts.open_count = 0 ->
+     add
+       ~axis:Board
+       ~code:"board_signal_pending_after_terminal_tasks"
+       ~severity:Warn
+       ~message:
+         "Board signal remains pending after all linked tasks reached terminal states."
+   | Quiet | Signal_pending | Signal_acknowledged | Signal_expired -> ());
+  List.rev !violations
+;;
+
+let option_string_to_yojson = function
+  | Some value -> `String value
+  | None -> `Null
+;;
+
+let string_list_to_yojson values = `List (List.map (fun value -> `String value) values)
+
+let ids_to_yojson ids =
+  `Assoc
+    [ "goal_id", option_string_to_yojson ids.goal_id
+    ; "task_ids", string_list_to_yojson ids.task_ids
+    ; "post_ids", string_list_to_yojson ids.post_ids
+    ; "agent_name", option_string_to_yojson ids.agent_name
+    ]
+;;
+
+let task_counts_to_yojson counts =
+  `Assoc
+    [ "total", `Int counts.total
+    ; "open", `Int counts.open_count
+    ; "done", `Int counts.done_count
+    ; "cancelled", `Int counts.cancelled_count
+    ; "awaiting_verification", `Int counts.awaiting_verification_count
+    ]
+;;
+
+let facts_to_yojson facts =
+  `Assoc
+    [ "economy_enabled", `Bool facts.economy_enabled
+    ; "has_reward_earning", `Bool facts.has_reward_earning
+    ; "has_spend", `Bool facts.has_spend
+    ; "has_penalty", `Bool facts.has_penalty
+    ; "board_signal_count", `Int facts.board_signal_count
+    ; "board_persist_error_count", `Int facts.board_persist_error_count
+    ; "active_goal_verification", `Bool facts.active_goal_verification
+    ]
+;;
+
+let option_float_to_yojson = function
+  | Some value -> `Float value
+  | None -> `Null
+;;
+
+let evidence_to_yojson evidence =
+  `Assoc
+    [ "source", `String evidence.source
+    ; "kind", `String evidence.kind
+    ; "id", option_string_to_yojson evidence.id
+    ; "label", `String evidence.label
+    ; "detail", `String evidence.detail
+    ; "timestamp", option_float_to_yojson evidence.timestamp
+    ; "refs", ids_to_yojson evidence.refs
+    ]
+;;
+
+let violation_to_yojson ?(evidence = []) violation =
+  `Assoc
+    [ "axis", `String (axis_to_string violation.axis)
+    ; "code", `String violation.code
+    ; "severity", `String (severity_to_string violation.severity)
+    ; "message", `String violation.message
+    ; "refs", ids_to_yojson violation.ids
+    ; "evidence", `List (List.map evidence_to_yojson evidence)
+    ]
+;;
+
+let product_to_yojson product =
+  let violations = check_invariants product in
+  `Assoc
+    [ "refs", ids_to_yojson product.ids
+    ; ( "goal"
+      , match product.goal with
+        | Some phase -> Goal_phase.to_yojson phase
+        | None -> `Null )
+    ; "task", `String (task_phase_to_string product.task)
+    ; "board", `String (board_phase_to_string product.board)
+    ; "reward", `String (reward_phase_to_string product.reward)
+    ; "task_counts", task_counts_to_yojson product.task_counts
+    ; "facts", facts_to_yojson product.facts
+    ; "evidence", `List (List.map evidence_to_yojson product.evidence)
+    ; ( "violations"
+      , `List
+          (List.map
+             (fun violation -> violation_to_yojson ~evidence:product.evidence violation)
+             violations) )
+    ]
+;;
+
+type snapshot =
+  { products : product list
+  ; violations : violation list
+  }
+
+let snapshot products =
+  let violations = List.concat_map check_invariants products in
+  { products; violations }
+;;
+
+let severity_counts violations =
+  let count severity =
+    violations
+    |> List.filter (fun violation -> violation.severity = severity)
+    |> List.length
+  in
+  `Assoc
+    [ "info", `Int (count Info); "warn", `Int (count Warn); "error", `Int (count Error) ]
+;;
+
+let evidence_for_violation products violation =
+  products
+  |> List.find_map (fun (product : product) ->
+    if product.ids = violation.ids then Some product.evidence else None)
+  |> Option.value ~default:[]
+;;
+
+let snapshot_to_yojson snapshot =
+  let evidence =
+    snapshot.products |> List.concat_map (fun product -> product.evidence)
+  in
+  `Assoc
+    [ "schema_version", `Int 1
+    ; "mode", `String "advisory"
+    ; ( "summary"
+      , `Assoc
+          [ "products", `Int (List.length snapshot.products)
+          ; "violations", `Int (List.length snapshot.violations)
+          ; "evidence", `Int (List.length evidence)
+          ; "severity_counts", severity_counts snapshot.violations
+          ] )
+    ; "products", `List (List.map product_to_yojson snapshot.products)
+    ; "evidence", `List (List.map evidence_to_yojson evidence)
+    ; ( "violations"
+      , `List
+          (List.map
+             (fun violation ->
+               let evidence = evidence_for_violation snapshot.products violation in
+               violation_to_yojson ~evidence violation)
+             snapshot.violations) )
+    ]
+;;

--- a/lib/coordination_product.mli
+++ b/lib/coordination_product.mli
@@ -1,0 +1,140 @@
+(** Advisory orthogonal product for Goal x Task x Board x Reward.
+
+    This module is intentionally pure. Runtime code projects existing stores
+    into these axes and consumes the returned advisory violations; it does not
+    enforce transitions or mutate balances/tasks/goals. *)
+
+type task_phase =
+  | No_task
+  | Todo
+  | Claimed
+  | In_progress
+  | Awaiting_verification
+  | Done
+  | Cancelled
+  | Mixed
+
+val task_phase_of_status : Types.task_status -> task_phase
+val task_phase_to_string : task_phase -> string
+
+type board_phase =
+  | Quiet
+  | Signal_pending
+  | Signal_acknowledged
+  | Signal_expired
+  | Degraded
+
+val board_phase_to_string : board_phase -> string
+
+type reward_phase =
+  | Disabled
+  | Neutral
+  | Credit_pending
+  | Rewarded
+  | Spent
+  | Penalized
+
+val reward_phase_to_string : reward_phase -> string
+
+type axis =
+  | Goal
+  | Task
+  | Board
+  | Reward
+  | Product
+
+val axis_to_string : axis -> string
+
+type severity =
+  | Info
+  | Warn
+  | Error
+
+val severity_to_string : severity -> string
+
+type ids =
+  { goal_id : string option
+  ; task_ids : string list
+  ; post_ids : string list
+  ; agent_name : string option
+  }
+
+val empty_ids : ids
+
+type task_counts =
+  { total : int
+  ; open_count : int
+  ; done_count : int
+  ; cancelled_count : int
+  ; awaiting_verification_count : int
+  }
+
+val empty_task_counts : task_counts
+val task_counts_of_statuses : Types.task_status list -> task_counts
+val task_phase_of_counts : Types.task_status list -> task_phase
+val task_counts_to_yojson : task_counts -> Yojson.Safe.t
+
+type facts =
+  { economy_enabled : bool
+  ; has_reward_earning : bool
+  ; has_spend : bool
+  ; has_penalty : bool
+  ; board_signal_count : int
+  ; board_persist_error_count : int
+  ; active_goal_verification : bool
+  }
+
+val default_facts : facts
+
+type evidence =
+  { source : string
+  ; kind : string
+  ; id : string option
+  ; label : string
+  ; detail : string
+  ; timestamp : float option
+  ; refs : ids
+  }
+
+type product =
+  { ids : ids
+  ; goal : Goal_phase.t option
+  ; task : task_phase
+  ; board : board_phase
+  ; reward : reward_phase
+  ; task_counts : task_counts
+  ; facts : facts
+  ; evidence : evidence list
+  }
+
+type violation =
+  { axis : axis
+  ; code : string
+  ; severity : severity
+  ; message : string
+  ; ids : ids
+  }
+
+val reward_phase_of_facts
+  :  economy_enabled:bool
+  -> task_counts:task_counts
+  -> board:board_phase
+  -> has_reward_earning:bool
+  -> has_spend:bool
+  -> has_penalty:bool
+  -> reward_phase
+
+val check_invariants : product -> violation list
+val ids_to_yojson : ids -> Yojson.Safe.t
+val facts_to_yojson : facts -> Yojson.Safe.t
+val evidence_to_yojson : evidence -> Yojson.Safe.t
+val violation_to_yojson : ?evidence:evidence list -> violation -> Yojson.Safe.t
+val product_to_yojson : product -> Yojson.Safe.t
+
+type snapshot =
+  { products : product list
+  ; violations : violation list
+  }
+
+val snapshot : product list -> snapshot
+val snapshot_to_yojson : snapshot -> Yojson.Safe.t

--- a/lib/coordination_product_snapshot.ml
+++ b/lib/coordination_product_snapshot.ml
@@ -1,0 +1,544 @@
+(** Read model for Goal x Task x Board x Reward coordination snapshots. *)
+
+type severity_counts =
+  { info : int
+  ; warn : int
+  ; error : int
+  }
+
+let unique_strings items =
+  List.fold_left
+    (fun acc item ->
+      let item = String.trim item in
+      if item = "" || List.exists (String.equal item) acc then acc else item :: acc)
+    []
+    items
+  |> List.rev
+;;
+
+let assoc_string_opt key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`String value) when String.trim value <> "" -> Some value
+     | _ -> None)
+  | _ -> None
+;;
+
+let assoc_string_list key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`List values) ->
+       List.filter_map
+         (function
+           | `String value when String.trim value <> "" -> Some value
+           | _ -> None)
+         values
+     | Some (`String value) when String.trim value <> "" -> [ value ]
+     | _ -> [])
+  | _ -> []
+;;
+
+let meta_string key (post : Board.post) =
+  match post.meta_json with
+  | Some meta -> assoc_string_opt key meta
+  | None -> None
+;;
+
+let meta_string_list key (post : Board.post) =
+  match post.meta_json with
+  | Some meta -> assoc_string_list key meta
+  | None -> []
+;;
+
+let post_id_string (post : Board.post) = Board.Post_id.to_string post.id
+
+let take n values =
+  let rec loop remaining acc = function
+    | _ when remaining <= 0 -> List.rev acc
+    | [] -> List.rev acc
+    | value :: rest -> loop (remaining - 1) (value :: acc) rest
+  in
+  loop n [] values
+;;
+
+let truncate ?(limit = 160) value =
+  let value = String.trim value in
+  if String.length value <= limit then value else String.sub value 0 limit ^ "..."
+;;
+
+let single_unique = function
+  | [ value ] -> Some value
+  | [] | _ :: _ :: _ -> None
+;;
+
+let task_actor_name (task : Types.task) =
+  match task.task_status with
+  | Types.Todo -> task.created_by
+  | Types.Claimed { assignee; _ }
+  | Types.InProgress { assignee; _ }
+  | Types.AwaitingVerification { assignee; _ }
+  | Types.Done { assignee; _ } ->
+    Some assignee
+  | Types.Cancelled { cancelled_by; _ } -> Some cancelled_by
+;;
+
+let earning_kind = function
+  | Agent_economy.Earn_task_done
+  | Agent_economy.Earn_board_post
+  | Agent_economy.Earn_upvote
+  | Agent_economy.Earn_mention_response ->
+    true
+  | Agent_economy.Spend_model_call
+  | Agent_economy.Spend_deliberation
+  | Agent_economy.Adjustment ->
+    false
+;;
+
+let spend_kind = function
+  | Agent_economy.Spend_model_call | Agent_economy.Spend_deliberation -> true
+  | Agent_economy.Earn_task_done
+  | Agent_economy.Earn_board_post
+  | Agent_economy.Earn_upvote
+  | Agent_economy.Earn_mention_response
+  | Agent_economy.Adjustment ->
+    false
+;;
+
+let transaction_kind_to_string = function
+  | Agent_economy.Earn_task_done -> "earn_task_done"
+  | Agent_economy.Earn_board_post -> "earn_board_post"
+  | Agent_economy.Earn_upvote -> "earn_upvote"
+  | Agent_economy.Earn_mention_response -> "earn_mention_response"
+  | Agent_economy.Spend_model_call -> "spend_model_call"
+  | Agent_economy.Spend_deliberation -> "spend_deliberation"
+  | Agent_economy.Adjustment -> "adjustment"
+;;
+
+let json_links_any (ids : Coordination_product.ids) json =
+  let matches_one key values =
+    match assoc_string_opt key json with
+    | Some value -> List.mem value values
+    | None -> false
+  in
+  let matches_many key values =
+    assoc_string_list key json |> List.exists (fun value -> List.mem value values)
+  in
+  (match ids.goal_id with
+   | Some goal_id -> matches_one "goal_id" [ goal_id ]
+   | None -> false)
+  || matches_one "task_id" ids.task_ids
+  || matches_many "task_ids" ids.task_ids
+  || matches_one "post_id" ids.post_ids
+  || matches_many "post_ids" ids.post_ids
+;;
+
+let transaction_links_any ids (txn : Agent_economy.transaction) =
+  json_links_any ids txn.metadata
+;;
+
+let economy_transactions_for ids transactions =
+  transactions
+  |> List.filter (fun (txn : Agent_economy.transaction) ->
+    transaction_links_any ids txn
+    ||
+    match ids.agent_name with
+    | Some agent_name -> String.equal txn.agent_name agent_name && spend_kind txn.kind
+    | None -> false)
+  |> List.sort (fun left right ->
+    Float.compare
+      (right : Agent_economy.transaction).timestamp
+      (left : Agent_economy.transaction).timestamp)
+;;
+
+let reward_facts ~(ids : Coordination_product.ids) transactions =
+  let relevant_transactions = economy_transactions_for ids transactions in
+  let has_reward_earning =
+    List.exists
+      (fun (txn : Agent_economy.transaction) -> earning_kind txn.kind)
+      relevant_transactions
+  in
+  let has_penalty =
+    List.exists
+      (fun (txn : Agent_economy.transaction) ->
+        txn.kind = Agent_economy.Adjustment && txn.amount < 0.0)
+      relevant_transactions
+  in
+  let has_spend =
+    match ids.agent_name with
+    | None -> false
+    | Some agent_name ->
+      List.exists
+        (fun (txn : Agent_economy.transaction) ->
+          String.equal txn.agent_name agent_name && spend_kind txn.kind)
+        transactions
+  in
+  has_reward_earning, has_spend, has_penalty
+;;
+
+let task_evidence (ids : Coordination_product.ids) (task : Types.task)
+  : Coordination_product.evidence
+  =
+  { source = "task_store"
+  ; kind = "task_status"
+  ; id = Some task.id
+  ; label = truncate ~limit:80 task.title
+  ; detail =
+      Printf.sprintf
+        "status=%s; priority=%d; created_by=%s"
+        (Types.task_status_to_string task.task_status)
+        task.priority
+        (Option.value task.created_by ~default:"-")
+  ; timestamp = Types.parse_iso8601_opt task.created_at
+  ; refs = { ids with task_ids = unique_strings (task.id :: ids.task_ids) }
+  }
+;;
+
+let goal_evidence (ids : Coordination_product.ids) (goal : Goal_store.goal)
+  : Coordination_product.evidence
+  =
+  { source = "goal_store"
+  ; kind = "goal_phase"
+  ; id = Some goal.id
+  ; label = truncate ~limit:80 goal.title
+  ; detail =
+      Printf.sprintf
+        "phase=%s; priority=%d; active_verification=%s"
+        (Goal_phase.to_string goal.phase)
+        goal.priority
+        (Option.value goal.active_verification_request_id ~default:"-")
+  ; timestamp = Types.parse_iso8601_opt goal.updated_at
+  ; refs = { ids with goal_id = Some goal.id }
+  }
+;;
+
+let board_evidence (ids : Coordination_product.ids) (post : Board.post)
+  : Coordination_product.evidence
+  =
+  let body = if String.trim post.content <> "" then post.content else post.body in
+  { source = "board"
+  ; kind = "post"
+  ; id = Some (post_id_string post)
+  ; label = truncate ~limit:80 post.title
+  ; detail =
+      Printf.sprintf
+        "author=%s; replies=%d; %s"
+        (Board.Agent_id.to_string post.author)
+        post.reply_count
+        (truncate ~limit:120 body)
+  ; timestamp = Some post.updated_at
+  ; refs = { ids with post_ids = unique_strings (post_id_string post :: ids.post_ids) }
+  }
+;;
+
+let economy_evidence (ids : Coordination_product.ids) (txn : Agent_economy.transaction)
+  : Coordination_product.evidence
+  =
+  { source = "economy"
+  ; kind = transaction_kind_to_string txn.kind
+  ; id = Some txn.id
+  ; label =
+      Printf.sprintf "%s %.2f" (transaction_kind_to_string txn.kind) txn.amount
+  ; detail =
+      Printf.sprintf
+        "agent=%s; balance_after=%.2f; reason=%s"
+        txn.agent_name
+        txn.balance_after
+        (truncate ~limit:120 txn.reason)
+  ; timestamp = Some txn.timestamp
+  ; refs = ids
+  }
+;;
+
+let telemetry_evidence_for_event
+      (ids : Coordination_product.ids)
+      (record : Telemetry_eio.event_record)
+  : Coordination_product.evidence option
+  =
+  match record.event with
+  | Telemetry_eio.Task_started { task_id; agent_id } when List.mem task_id ids.task_ids
+    ->
+    Some
+      { source = "telemetry"
+      ; kind = "task_started"
+      ; id = Some task_id
+      ; label = "task started"
+      ; detail = Printf.sprintf "agent=%s" agent_id
+      ; timestamp = Some record.timestamp
+      ; refs = { ids with task_ids = unique_strings (task_id :: ids.task_ids) }
+      }
+  | Telemetry_eio.Task_completed { task_id; duration_ms; success }
+    when List.mem task_id ids.task_ids ->
+    Some
+      { source = "telemetry"
+      ; kind = "task_completed"
+      ; id = Some task_id
+      ; label = "task completed"
+      ; detail = Printf.sprintf "success=%b; duration_ms=%d" success duration_ms
+      ; timestamp = Some record.timestamp
+      ; refs = { ids with task_ids = unique_strings (task_id :: ids.task_ids) }
+      }
+  | Telemetry_eio.Tool_called
+      { tool_name; success; duration_ms; agent_id = Some agent_id; source }
+    when Option.equal String.equal ids.agent_name (Some agent_id) ->
+    Some
+      { source = "telemetry"
+      ; kind = "tool_called"
+      ; id = Some tool_name
+      ; label = tool_name
+      ; detail =
+          Printf.sprintf
+            "agent=%s; success=%b; duration_ms=%d; source=%s"
+            agent_id
+            success
+            duration_ms
+            (Option.value source ~default:"-")
+      ; timestamp = Some record.timestamp
+      ; refs = ids
+      }
+  | Telemetry_eio.Agent_joined _ | Telemetry_eio.Agent_left _
+  | Telemetry_eio.Task_started _ | Telemetry_eio.Task_completed _
+  | Telemetry_eio.Handoff_triggered _ | Telemetry_eio.Error_occurred _
+  | Telemetry_eio.Tool_called _ | Telemetry_eio.Tool_assigned _ ->
+    None
+;;
+
+let evidence_for ~ids ~tasks ~linked_posts ~transactions ~telemetry_events =
+  let task_rows = tasks |> List.map (task_evidence ids) |> take 5 in
+  let board_rows =
+    linked_posts
+    |> List.sort (fun (left : Board.post) (right : Board.post) ->
+      Float.compare right.updated_at left.updated_at)
+    |> List.map (board_evidence ids)
+    |> take 5
+  in
+  let economy_rows =
+    economy_transactions_for ids transactions |> List.map (economy_evidence ids) |> take 5
+  in
+  let telemetry_rows =
+    telemetry_events
+    |> List.sort (fun left right ->
+      Float.compare
+        (right : Telemetry_eio.event_record).timestamp
+        (left : Telemetry_eio.event_record).timestamp)
+    |> List.filter_map (telemetry_evidence_for_event ids)
+    |> take 5
+  in
+  task_rows @ board_rows @ economy_rows @ telemetry_rows
+;;
+
+let post_links_ids (ids : Coordination_product.ids) (post : Board.post) =
+  let post_goal =
+    match ids.goal_id with
+    | Some goal_id -> meta_string "goal_id" post = Some goal_id
+    | None -> false
+  in
+  let post_task =
+    match meta_string "task_id" post with
+    | Some task_id -> List.mem task_id ids.task_ids
+    | None -> false
+  in
+  let post_tasks =
+    meta_string_list "task_ids" post
+    |> List.exists (fun task_id -> List.mem task_id ids.task_ids)
+  in
+  post_goal || post_task || post_tasks
+;;
+
+let goal_terminal = function
+  | Goal_phase.Completed | Goal_phase.Dropped -> true
+  | Goal_phase.Executing
+  | Goal_phase.Awaiting_verification
+  | Goal_phase.Awaiting_approval
+  | Goal_phase.Blocked
+  | Goal_phase.Paused ->
+    false
+;;
+
+let board_phase_for
+      ~persist_errors
+      ~goal_phase
+      ~(task_counts : Coordination_product.task_counts)
+      ~linked_posts
+  =
+  if persist_errors > 0
+  then Coordination_product.Degraded
+  else (
+    match linked_posts with
+    | [] -> Coordination_product.Quiet
+    | _
+      when (match goal_phase with
+            | Some phase -> goal_terminal phase
+            | None -> false) -> Coordination_product.Signal_acknowledged
+    | _ when task_counts.total > 0 && task_counts.open_count = 0 ->
+      Coordination_product.Signal_acknowledged
+    | _ -> Coordination_product.Signal_pending)
+;;
+
+let product_for
+      ~goal_phase
+      ~goal_id
+      ~tasks
+      ~posts
+      ~transactions
+      ~telemetry_events
+      ~persist_errors
+  =
+  let task_statuses = List.map (fun (task : Types.task) -> task.task_status) tasks in
+  let task_counts = Coordination_product.task_counts_of_statuses task_statuses in
+  let task = Coordination_product.task_phase_of_counts task_statuses in
+  let task_ids = List.map (fun (task : Types.task) -> task.id) tasks in
+  let agent_name =
+    tasks |> List.filter_map task_actor_name |> unique_strings |> single_unique
+  in
+  let ids : Coordination_product.ids =
+    { goal_id; task_ids; post_ids = []; agent_name }
+  in
+  let linked_posts = List.filter (post_links_ids ids) posts in
+  let ids = { ids with post_ids = List.map post_id_string linked_posts } in
+  let board = board_phase_for ~persist_errors ~goal_phase ~task_counts ~linked_posts in
+  let has_reward_earning, has_spend, has_penalty =
+    reward_facts ~ids transactions
+  in
+  let economy_enabled = Agent_economy.enabled () in
+  let reward =
+    Coordination_product.reward_phase_of_facts
+      ~economy_enabled
+      ~task_counts
+      ~board
+      ~has_reward_earning
+      ~has_spend
+      ~has_penalty
+  in
+  let facts : Coordination_product.facts =
+    { economy_enabled
+    ; has_reward_earning
+    ; has_spend
+    ; has_penalty
+    ; board_signal_count = List.length linked_posts
+    ; board_persist_error_count = persist_errors
+    ; active_goal_verification = false
+    }
+  in
+  let evidence =
+    evidence_for ~ids ~tasks ~linked_posts ~transactions ~telemetry_events
+  in
+  let product : Coordination_product.product =
+    { ids; goal = goal_phase; task; board; reward; task_counts; facts; evidence }
+  in
+  product
+;;
+
+let product_for_goal ~all_tasks ~posts ~transactions ~telemetry_events ~persist_errors
+    (goal : Goal_store.goal)
+  =
+  let tasks =
+    all_tasks |> List.filter (Convergence.task_matches_goal ~goal_id:goal.id)
+  in
+  let product =
+    product_for
+      ~goal_phase:(Some goal.phase)
+      ~goal_id:(Some goal.id)
+      ~tasks
+      ~posts
+      ~transactions
+      ~telemetry_events
+      ~persist_errors
+  in
+  { product with
+    facts =
+      { product.facts with
+        active_goal_verification = Option.is_some goal.active_verification_request_id
+      }
+  ; evidence = goal_evidence product.ids goal :: product.evidence
+  }
+;;
+
+let read_recent_telemetry config =
+  try
+    let since = Time_compat.now () -. (7.0 *. Masc_time_constants.day) in
+    Telemetry_eio.read_events_since config ~since
+  with
+  | exn ->
+    Log.Coord.warn
+      "coordination product telemetry evidence failed: %s"
+      (Printexc.to_string exn);
+    []
+;;
+
+let build (config : Coord.config) =
+  let goals = Goal_store.list_goals config () in
+  let all_tasks = Coord_query.get_tasks_safe config in
+  let posts = Board_dispatch.list_posts ~limit:Board.Limits.max_posts () in
+  let transactions = Agent_economy.list_transactions ~base_path:config.base_path in
+  let telemetry_events = read_recent_telemetry config in
+  let persist_errors = Board.persist_error_count () in
+  let goal_products =
+    List.map
+      (product_for_goal
+         ~all_tasks
+         ~posts
+         ~transactions
+         ~telemetry_events
+         ~persist_errors)
+      goals
+  in
+  let linked_task_ids =
+    goal_products
+    |> List.concat_map (fun (product : Coordination_product.product) ->
+      product.ids.task_ids)
+    |> unique_strings
+  in
+  let unlinked_task_products =
+    all_tasks
+    |> List.filter (fun (task : Types.task) -> not (List.mem task.id linked_task_ids))
+    |> List.map (fun task ->
+      product_for
+        ~goal_phase:None
+        ~goal_id:None
+        ~tasks:[ task ]
+        ~posts
+        ~transactions
+        ~telemetry_events
+        ~persist_errors)
+  in
+  Coordination_product.snapshot (goal_products @ unlinked_task_products)
+;;
+
+let severity_counts (snapshot : Coordination_product.snapshot) =
+  let count severity =
+    snapshot.violations
+    |> List.filter (fun (violation : Coordination_product.violation) ->
+      violation.severity = severity)
+    |> List.length
+  in
+  { info = count Coordination_product.Info
+  ; warn = count Coordination_product.Warn
+  ; error = count Coordination_product.Error
+  }
+;;
+
+let to_yojson = Coordination_product.snapshot_to_yojson
+let build_yojson config = build config |> to_yojson
+
+let safe_build_yojson config =
+  try build_yojson config with
+  | exn ->
+    let message = Printexc.to_string exn in
+    Log.Coord.warn "coordination product snapshot failed: %s" message;
+    `Assoc
+      [ "schema_version", `Int 1
+      ; "mode", `String "advisory"
+      ; ( "summary"
+        , `Assoc
+            [ "products", `Int 0
+            ; "violations", `Int 0
+            ; "evidence", `Int 0
+            ; ( "severity_counts"
+              , `Assoc [ "info", `Int 0; "warn", `Int 0; "error", `Int 0 ] )
+            ] )
+      ; "products", `List []
+      ; "evidence", `List []
+      ; "violations", `List []
+      ; "projection_error", `String message
+      ]
+;;

--- a/lib/coordination_product_snapshot.mli
+++ b/lib/coordination_product_snapshot.mli
@@ -1,0 +1,28 @@
+(** Read model for Goal x Task x Board x Reward coordination snapshots.
+
+    The projection is advisory and read-only. It gathers facts from existing
+    stores and feeds the pure {!Coordination_product} invariant checker. *)
+
+type severity_counts =
+  { info : int
+  ; warn : int
+  ; error : int
+  }
+
+val build : Coord.config -> Coordination_product.snapshot
+(** Build a live coordination product snapshot from existing runtime stores. *)
+
+val severity_counts : Coordination_product.snapshot -> severity_counts
+(** Count snapshot violations by severity. *)
+
+val to_yojson : Coordination_product.snapshot -> Yojson.Safe.t
+(** Serialize a snapshot using the stable dashboard/MCP JSON shape. *)
+
+val build_yojson : Coord.config -> Yojson.Safe.t
+(** Build and serialize a snapshot. *)
+
+val safe_build_yojson : Coord.config -> Yojson.Safe.t
+(** Build and serialize a snapshot without raising.
+
+    On projection failure the result keeps the normal snapshot shape with empty
+    products/violations and a [projection_error] field. *)

--- a/lib/dune
+++ b/lib/dune
@@ -338,6 +338,8 @@
    typed_tool_masc
    tool_broadcast_typed
    state_product
+   coordination_product
+   coordination_product_snapshot
    tool_token
    tool_dispatch
    tool_name

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -408,6 +408,8 @@ let dashboard_planning_http_json ~(config : Coord.config) : Yojson.Safe.t =
             ("done", `Int done_count);
             ("cancelled", `Int cancelled_count);
           ] );
+      ( "coordination_fsm",
+        Coordination_product_snapshot.safe_build_yojson config );
     ]
 
 let dashboard_goals_tree_http_json ~(config : Coord.config) : Yojson.Safe.t =

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -462,6 +462,7 @@ let inferred_effect_domain_of_typed_tool_name = function
   | TN.Masc TM.Code_symbols
   | TN.Masc TM.Collaboration_graph
   | TN.Masc TM.Config
+  | TN.Masc TM.Coordination_fsm_snapshot
   | TN.Masc TM.Dashboard
   | TN.Masc TM.Get_metrics
   | TN.Masc TM.Goal_list
@@ -670,6 +671,7 @@ let tool_group_of_typed_tool_name = function
       | TM.Collaboration_graph
       | TM.Complete_task
       | TM.Config
+      | TM.Coordination_fsm_snapshot
       | TM.Coord_status
       | TM.Dashboard
       | TM.Deliver

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -123,7 +123,7 @@ let public_mcp_surface_tools =
     "masc_claim_next"; "masc_transition";
     (* Planning *)
     "masc_goal_list"; "masc_goal_upsert"; "masc_goal_review";
-    "masc_goal_transition"; "masc_goal_verify";
+    "masc_goal_transition"; "masc_goal_verify"; "masc_coordination_fsm_snapshot";
     "masc_plan_init"; "masc_plan_get"; "masc_plan_set_task"; "masc_plan_update";
     (* Heartbeat *)
     "masc_heartbeat";
@@ -140,7 +140,7 @@ let public_mcp_surface_tools =
     "masc_board_post"; "masc_board_list"; "masc_board_get";
     "masc_board_comment"; "masc_board_vote";
     (* Agent discovery *)
-    "masc_agents"; "masc_dashboard"; "masc_agent_card"; "masc_collaboration_graph";
+    "masc_agents"; "masc_dashboard"; "masc_agent_card";
     (* Utility *)
     "masc_tool_help"; "masc_web_search"; "masc_check";
     (* HITL approval queue *)
@@ -160,7 +160,7 @@ let spawned_agent_surface_tools =
     "masc_who"; "masc_agent_update"; "masc_add_task"; "masc_heartbeat";
     "masc_messages";
     "masc_goal_list"; "masc_goal_upsert"; "masc_goal_review";
-    "masc_goal_transition"; "masc_goal_verify";
+    "masc_goal_transition"; "masc_goal_verify"; "masc_coordination_fsm_snapshot";
     "masc_worktree_create"; "masc_worktree_remove"; "masc_worktree_list";
     "masc_board_list"; "masc_board_post"; "masc_board_comment";
     "masc_board_vote"; "masc_board_get";
@@ -180,7 +180,7 @@ let local_worker_surface_tools =
     "masc_status"; "masc_tasks"; "masc_claim_next"; "masc_transition";
     "masc_add_task"; "masc_heartbeat";
     "masc_goal_list"; "masc_goal_upsert"; "masc_goal_review";
-    "masc_goal_transition"; "masc_goal_verify";
+    "masc_goal_transition"; "masc_goal_verify"; "masc_coordination_fsm_snapshot";
     "masc_board_post"; "masc_board_list"; "masc_board_get";
     "masc_board_comment"; "masc_board_vote"; "masc_board_search";
     "masc_code_search"; "masc_code_symbols"; "masc_code_read";
@@ -194,7 +194,7 @@ let session_min_surface_tools =
     "masc_status"; "masc_tasks"; "masc_claim_next";
     "masc_plan_set_task"; "masc_transition"; "masc_add_task";
     "masc_goal_list"; "masc_goal_upsert"; "masc_goal_review";
-    "masc_goal_transition"; "masc_goal_verify";
+    "masc_goal_transition"; "masc_goal_verify"; "masc_coordination_fsm_snapshot";
     "masc_broadcast"; "masc_heartbeat";
   ]
 
@@ -281,6 +281,7 @@ let coordination_role_tools : string list =
     "masc_who";
     "masc_heartbeat";
     "masc_messages";
+    "masc_coordination_fsm_snapshot";
     "masc_board_list";
     "masc_board_post";
     "masc_board_comment";

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -275,6 +275,24 @@ let planning_context_state (ctx : context) (binding : current_binding)
           in
           { planning_missing_task = None; deliverable_conflict_task })
 
+let coordination_fsm_attention_items ctx =
+  try
+    let snapshot = Coordination_product_snapshot.build ctx.config in
+    let counts = Coordination_product_snapshot.severity_counts snapshot in
+    if counts.error = 0 && counts.warn = 0 then
+      []
+    else
+      [
+        Printf.sprintf
+          "Coordination FSM advisory has %d error(s), %d warning(s). Call masc_coordination_fsm_snapshot before changing goal/task/board/reward state."
+          counts.error counts.warn;
+      ]
+  with
+  | exn ->
+      Log.Coord.warn "coordination FSM status advisory failed: %s"
+        (Printexc.to_string exn);
+      []
+
 let status_summary_string (ctx : context) =
   Coord.ensure_initialized ctx.config;
   let state = Coord.read_state ctx.config in
@@ -468,6 +486,7 @@ let status_summary_string (ctx : context) =
         ]
     else
       items
+    |> fun items -> items @ coordination_fsm_attention_items ctx
     |> fun items ->
     if zombie_count > 0 then
       items
@@ -577,6 +596,13 @@ let handle_workflow_guide ctx _args =
   in
   (true, Yojson.Safe.to_string result)
 
+(* ── Coordination product FSM snapshot ─────────────────────────── *)
+
+let handle_coordination_fsm_snapshot ctx _args =
+  ( true,
+    Yojson.Safe.to_string
+      (Coordination_product_snapshot.safe_build_yojson ctx.config) )
+
 (* ── State check (assertion-based verification) ────────────────── *)
 
 (** Issue #8636: SSOT for [masc_check] assertion vocabulary. Schema
@@ -603,6 +629,8 @@ let dispatch ctx ~name ~args : tool_result option =
   | "masc_goal_review" -> Some (Coord_goals.handle_goal_review ctx args)
   | "masc_goal_transition" -> Some (Coord_goals.handle_goal_transition ctx args)
   | "masc_goal_verify" -> Some (Coord_goals.handle_goal_verify ctx args)
+  | "masc_coordination_fsm_snapshot" ->
+      Some (handle_coordination_fsm_snapshot ctx args)
   | "masc_reset" -> Some (handle_reset ctx args)
   | "masc_workflow_guide" -> Some (handle_workflow_guide ctx args)
   | "masc_check" ->
@@ -625,13 +653,15 @@ let schemas = Tool_schemas_coord.schemas
 (* Tool_spec registration                                           *)
 (* ================================================================ *)
 
-let _tool_spec_read_only = [ "masc_status"; "masc_goal_list" ]
+let _tool_spec_read_only =
+  [ "masc_status"; "masc_goal_list"; "masc_coordination_fsm_snapshot" ]
 let _tool_spec_system_internal = [ "masc_reset" ]
 
 let _tool_spec_requires_join = [ "masc_heartbeat" ]
 
 let tool_required_permission = function
   | "masc_status" | "masc_workflow_guide" | "masc_check"
+  | "masc_coordination_fsm_snapshot"
   | "masc_goal_list" ->
       Some Types.CanReadState
   | "masc_goal_upsert" | "masc_goal_review"

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -184,6 +184,7 @@ module Masc = struct
     | Claim_next
     | Claim_task
     | Cleanup_zombies
+    | Coordination_fsm_snapshot
     | Code_delete
     | Code_edit
     | Code_git
@@ -283,6 +284,7 @@ module Masc = struct
     | Claim_next -> "masc_claim_next"
     | Claim_task -> "masc_claim_task"
     | Cleanup_zombies -> "masc_cleanup_zombies"
+    | Coordination_fsm_snapshot -> "masc_coordination_fsm_snapshot"
     | Autoresearch_cycle -> "masc_autoresearch_cycle"
     | Autoresearch_inject -> "masc_autoresearch_inject"
     | Autoresearch_start -> "masc_autoresearch_start"
@@ -387,6 +389,7 @@ module Masc = struct
     | "masc_claim_next" -> Some Claim_next
     | "masc_claim_task" -> Some Claim_task
     | "masc_cleanup_zombies" -> Some Cleanup_zombies
+    | "masc_coordination_fsm_snapshot" -> Some Coordination_fsm_snapshot
     | "masc_autoresearch_cycle" -> Some Autoresearch_cycle
     | "masc_autoresearch_inject" -> Some Autoresearch_inject
     | "masc_autoresearch_start" -> Some Autoresearch_start

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -90,6 +90,7 @@ module Masc : sig
     | Claim_next
     | Claim_task
     | Cleanup_zombies
+    | Coordination_fsm_snapshot
     | Code_delete
     | Code_edit
     | Code_git

--- a/lib/tool_permission_map.ml
+++ b/lib/tool_permission_map.ml
@@ -34,6 +34,7 @@ let legacy_permission_entries : (string * permission) list =
     ("masc_agent_fitness", CanReadState);
     ("masc_dashboard", CanReadState);
     ("masc_check", CanReadState);
+    ("masc_coordination_fsm_snapshot", CanReadState);
     ("masc_approval_pending", CanReadState);
     ("masc_approval_get", CanAdmin);
     ("masc_collaboration_graph", CanReadState);

--- a/lib/tool_schemas/tool_schemas_coord_core.ml
+++ b/lib/tool_schemas/tool_schemas_coord_core.ml
@@ -57,6 +57,15 @@ Pair with masc_check to assert specific prerequisites before acting.";
     ];
   };
   {
+    name = "masc_coordination_fsm_snapshot";
+    description = "Read-only advisory snapshot of Goal x Task x Board x Reward orthogonal coordination states. \
+Use to detect inconsistent cross-axis state such as terminal goals with open tasks, pending board signals after terminal work, or rewards without evidence.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc []);
+    ];
+  };
+  {
     name = "masc_check";
     description = "Assert preconditions on your agent state (joined, task claimed, worktree active, etc). \
 Call when you want to confirm prerequisites before starting work; returns pass/fail with fix hints. \

--- a/lib/tool_schemas/tool_schemas_coord_core.mli
+++ b/lib/tool_schemas/tool_schemas_coord_core.mli
@@ -14,5 +14,5 @@
 val assertion_kind_enum_strings : string list
 
 (** Tool schemas: [masc_status], [masc_reset], [masc_workflow_guide],
-    [masc_check], [masc_heartbeat]. *)
+    [masc_coordination_fsm_snapshot], [masc_check], [masc_heartbeat]. *)
 val schemas : Types.tool_schema list

--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -163,6 +163,12 @@ run_tlc "$REPO_ROOT/specs/boundary" "KeeperContinueGate.tla"
 run_tlc_buggy "$REPO_ROOT/specs/boundary" "KeeperContinueGate.tla"
 run_tlc "$REPO_ROOT/specs/boundary" "ToolCallContract.tla"
 run_tlc_buggy "$REPO_ROOT/specs/boundary" "ToolCallContract.tla"
+run_tlc "$REPO_ROOT/specs/state-product" "StateProduct.tla"
+run_tlc_buggy "$REPO_ROOT/specs/state-product" "StateProduct.tla"
+run_tlc "$REPO_ROOT/specs/state-product" "CoordinationProduct.tla"
+run_tlc_buggy "$REPO_ROOT/specs/state-product" "CoordinationProduct.tla"
+run_tlc "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
+run_tlc_buggy "$REPO_ROOT/specs/task-lifecycle" "TaskLifecycle.tla"
 
 # Optional: run TraceSpec if --trace flag provided
 if [ "${1:-}" = "--trace" ]; then

--- a/specs/state-product/CoordinationProduct-buggy.cfg
+++ b/specs/state-product/CoordinationProduct-buggy.cfg
@@ -1,0 +1,7 @@
+\* Buggy spec: at least one cross-axis invariant MUST be violated.
+SPECIFICATION SpecBuggy
+
+INVARIANT SafetyInvariant
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/state-product/CoordinationProduct.cfg
+++ b/specs/state-product/CoordinationProduct.cfg
@@ -1,0 +1,7 @@
+\* Clean spec: all cross-axis advisory invariants must hold.
+SPECIFICATION SpecClean
+
+INVARIANT SafetyInvariant
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/state-product/CoordinationProduct.tla
+++ b/specs/state-product/CoordinationProduct.tla
@@ -1,0 +1,218 @@
+--------------------------- MODULE CoordinationProduct ---------------------------
+\* Advisory Goal x Task x Board x Reward orthogonal product.
+\*
+\* Mirrors: lib/coordination_product.ml
+\*
+\* This model checks cross-axis safety only. Each axis can evolve
+\* independently, but terminal goal/reward states require evidence from
+\* another axis. The OCaml implementation reports violations in advisory mode
+\* instead of blocking writes.
+\*
+\* Two-config pattern:
+\*   CoordinationProduct.cfg       -- clean spec, invariants must hold
+\*   CoordinationProduct-buggy.cfg -- buggy spec, invariants MUST be violated
+
+VARIABLES goal, task, board, reward, earned
+
+vars == <<goal, task, board, reward, earned>>
+
+GoalPhases ==
+    {"None", "Executing", "AwaitingVerification", "AwaitingApproval",
+     "Blocked", "Paused", "Completed", "Dropped"}
+
+TaskPhases ==
+    {"NoTask", "Todo", "Claimed", "InProgress", "AwaitingVerification",
+     "Done", "Cancelled", "Mixed"}
+
+BoardPhases ==
+    {"Quiet", "SignalPending", "SignalAcknowledged", "SignalExpired",
+     "Degraded"}
+
+RewardPhases ==
+    {"Disabled", "Neutral", "CreditPending", "Rewarded", "Spent",
+     "Penalized"}
+
+OpenTasks == {"Todo", "Claimed", "InProgress", "AwaitingVerification", "Mixed"}
+TerminalGoals == {"Completed", "Dropped"}
+EvidenceTasks == {"Done"}
+EarnedRewards == {"Rewarded", "Spent"}
+
+TypeOK ==
+    /\ goal \in GoalPhases
+    /\ task \in TaskPhases
+    /\ board \in BoardPhases
+    /\ reward \in RewardPhases
+    /\ earned \in BOOLEAN
+
+Init ==
+    /\ goal = "Executing"
+    /\ task = "NoTask"
+    /\ board = "Quiet"
+    /\ reward = "Disabled"
+    /\ earned = FALSE
+
+\* ── Clean axis transitions ─────────────────────────────────────
+
+TaskCreate ==
+    /\ task = "NoTask"
+    /\ goal \notin TerminalGoals
+    /\ task' = "Todo"
+    /\ UNCHANGED <<goal, board, reward, earned>>
+
+TaskClaim ==
+    /\ task = "Todo"
+    /\ goal \notin TerminalGoals
+    /\ task' = "Claimed"
+    /\ UNCHANGED <<goal, board, reward, earned>>
+
+TaskStart ==
+    /\ task = "Claimed"
+    /\ goal \notin TerminalGoals
+    /\ task' = "InProgress"
+    /\ UNCHANGED <<goal, board, reward, earned>>
+
+TaskSubmit ==
+    /\ task = "InProgress"
+    /\ goal \notin TerminalGoals
+    /\ task' = "AwaitingVerification"
+    /\ goal' = "AwaitingVerification"
+    /\ UNCHANGED <<board, reward, earned>>
+
+TaskApprove ==
+    /\ task = "AwaitingVerification"
+    /\ task' = "Done"
+    /\ UNCHANGED <<goal, board, reward, earned>>
+
+TaskCancel ==
+    /\ task \in OpenTasks
+    /\ goal \notin TerminalGoals
+    /\ task' = "Cancelled"
+    /\ UNCHANGED <<goal, board, reward, earned>>
+
+BoardSignal ==
+    /\ board = "Quiet"
+    /\ goal \notin TerminalGoals
+    /\ task \in OpenTasks
+    /\ board' = "SignalPending"
+    /\ UNCHANGED <<goal, task, reward, earned>>
+
+BoardAcknowledge ==
+    /\ board = "SignalPending"
+    /\ task \notin OpenTasks
+    /\ board' = "SignalAcknowledged"
+    /\ UNCHANGED <<goal, task, reward, earned>>
+
+BoardExpire ==
+    /\ board = "SignalPending"
+    /\ board' = "SignalExpired"
+    /\ UNCHANGED <<goal, task, reward, earned>>
+
+GoalComplete ==
+    /\ goal \in {"Executing", "AwaitingVerification", "AwaitingApproval"}
+    /\ task = "Done"
+    /\ board # "SignalPending"
+    /\ goal' = "Completed"
+    /\ UNCHANGED <<task, board, reward, earned>>
+
+GoalDrop ==
+    /\ goal \notin TerminalGoals
+    /\ task \notin OpenTasks
+    /\ board # "SignalPending"
+    /\ reward # "CreditPending"
+    /\ goal' = "Dropped"
+    /\ UNCHANGED <<task, board, reward, earned>>
+
+RewardEnable ==
+    /\ reward = "Disabled"
+    /\ reward' = "Neutral"
+    /\ UNCHANGED <<goal, task, board, earned>>
+
+RewardPending ==
+    /\ reward = "Neutral"
+    /\ task = "Done"
+    /\ reward' = "CreditPending"
+    /\ UNCHANGED <<goal, task, board, earned>>
+
+RewardEarn ==
+    /\ reward \in {"Neutral", "CreditPending"}
+    /\ (task = "Done" \/ board = "SignalAcknowledged")
+    /\ reward' = "Rewarded"
+    /\ earned' = TRUE
+    /\ UNCHANGED <<goal, task, board>>
+
+RewardSpend ==
+    /\ reward = "Rewarded"
+    /\ earned = TRUE
+    /\ reward' = "Spent"
+    /\ UNCHANGED <<goal, task, board, earned>>
+
+Terminal ==
+    /\ goal \in TerminalGoals
+    /\ UNCHANGED vars
+
+NextClean ==
+    \/ TaskCreate
+    \/ TaskClaim
+    \/ TaskStart
+    \/ TaskSubmit
+    \/ TaskApprove
+    \/ TaskCancel
+    \/ BoardSignal
+    \/ BoardAcknowledge
+    \/ BoardExpire
+    \/ GoalComplete
+    \/ GoalDrop
+    \/ RewardEnable
+    \/ RewardPending
+    \/ RewardEarn
+    \/ RewardSpend
+    \/ Terminal
+
+\* ── Bug transitions that must violate safety ───────────────────
+
+BugCompleteWithOpenTask ==
+    /\ task = "InProgress"
+    /\ goal' = "Completed"
+    /\ UNCHANGED <<task, board, reward, earned>>
+
+BugRewardWithoutEvidence ==
+    /\ task \notin EvidenceTasks
+    /\ board # "SignalAcknowledged"
+    /\ earned = FALSE
+    /\ reward' = "Rewarded"
+    /\ UNCHANGED <<goal, task, board, earned>>
+
+BugBoardPendingTerminal ==
+    /\ task = "Done"
+    /\ board' = "SignalPending"
+    /\ goal' = "Completed"
+    /\ UNCHANGED <<task, reward, earned>>
+
+NextBuggy ==
+    \/ NextClean
+    \/ BugCompleteWithOpenTask
+    \/ BugRewardWithoutEvidence
+    \/ BugBoardPendingTerminal
+
+SpecClean == Init /\ [][NextClean]_vars
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+\* ── Cross-axis safety ──────────────────────────────────────────
+
+TerminalGoalNoOpenTask ==
+    goal \in TerminalGoals => task \notin OpenTasks
+
+RewardNeedsEvidence ==
+    reward \in EarnedRewards =>
+        task \in EvidenceTasks \/ board = "SignalAcknowledged" \/ earned
+
+TerminalGoalNoPendingBoard ==
+    goal \in TerminalGoals => board # "SignalPending"
+
+SafetyInvariant ==
+    /\ TypeOK
+    /\ TerminalGoalNoOpenTask
+    /\ RewardNeedsEvidence
+    /\ TerminalGoalNoPendingBoard
+
+================================================================================

--- a/test/dune
+++ b/test/dune
@@ -460,6 +460,7 @@
         test_tool_spec
         test_typed_tool_masc
         test_state_product
+        test_coordination_product
         test_tool_result
         test_tool_hooks
         test_governance_pipeline
@@ -630,6 +631,7 @@
         test_tool_spec
         test_typed_tool_masc
         test_state_product
+        test_coordination_product
         test_tool_result
         test_tool_hooks
         test_governance_pipeline

--- a/test/test_agent_economy.ml
+++ b/test/test_agent_economy.ml
@@ -230,6 +230,27 @@ let test_ledger_file_created () =
       Alcotest.(check bool) "ledger file exists" true (Sys.file_exists path)));
   rm_rf dir
 
+let test_list_transactions () =
+  let dir = fresh_tmpdir () in
+  reset_cache ();
+  with_economy_enabled (fun () ->
+    with_env "MASC_ECONOMY_REPUTATION_MULTIPLIER" "false" (fun () ->
+      ignore (Agent_economy.earn
+        ~base_path:dir ~agent_name:"reader"
+        ~kind:Earn_task_done ~reason:"task done"
+        ~metadata:(`Assoc [ ("goal_id", `String "goal-1") ])
+        ());
+      ignore (Agent_economy.spend
+        ~base_path:dir ~agent_name:"reader"
+        ~amount:0.25 ~kind:Spend_model_call ~reason:"model call" ());
+      let txns = Agent_economy.list_transactions ~base_path:dir in
+      Alcotest.(check int) "transaction count" 2 (List.length txns);
+      let first = List.hd txns in
+      let open Yojson.Safe.Util in
+      Alcotest.(check string) "metadata goal id" "goal-1"
+        (first.metadata |> member "goal_id" |> to_string)));
+  rm_rf dir
+
 (** {1 Reputation Multiplier Tests} *)
 
 let test_reward_multiplier_range () =
@@ -332,6 +353,7 @@ let () =
     ("persistence", [
       Alcotest.test_case "ledger persistence" `Quick test_ledger_persistence;
       Alcotest.test_case "ledger file created" `Quick test_ledger_file_created;
+      Alcotest.test_case "list transactions" `Quick test_list_transactions;
     ]);
     ("reputation", [
       Alcotest.test_case "multiplier range" `Quick test_reward_multiplier_range;

--- a/test/test_coordination_product.ml
+++ b/test/test_coordination_product.ml
@@ -1,0 +1,228 @@
+(** Tests for Coordination_product — Goal x Task x Board x Reward. *)
+
+open Masc_mcp
+module CP = Coordination_product
+
+let done_status =
+  Types.Done
+    { assignee = "worker"; completed_at = "2026-04-24T00:00:00Z"; notes = Some "ok" }
+;;
+
+let claimed_status =
+  Types.Claimed { assignee = "worker"; claimed_at = "2026-04-24T00:00:00Z" }
+;;
+
+let cancelled_status =
+  Types.Cancelled
+    { cancelled_by = "operator"
+    ; cancelled_at = "2026-04-24T00:00:00Z"
+    ; reason = Some "superseded"
+    }
+;;
+
+let ids ?goal_id ?(task_ids = []) ?(post_ids = []) ?agent_name () : CP.ids =
+  { goal_id; task_ids; post_ids; agent_name }
+;;
+
+let product
+      ?goal
+      ?(task = CP.No_task)
+      ?(board = CP.Quiet)
+      ?(reward = CP.Disabled)
+      ?(task_counts = CP.empty_task_counts)
+      ?(facts = CP.default_facts)
+      ?(evidence = [])
+      ?(ids = ids ())
+      ()
+  : CP.product
+  =
+  { ids; goal; task; board; reward; task_counts; facts; evidence }
+;;
+
+let violation_codes violations = violations |> List.map (fun (v : CP.violation) -> v.code)
+
+let check_has_code code violations =
+  Alcotest.(check bool) code true (List.mem code (violation_codes violations))
+;;
+
+let test_task_axis_projection () =
+  Alcotest.(check string)
+    "todo"
+    "todo"
+    (CP.task_phase_to_string (CP.task_phase_of_status Types.Todo));
+  Alcotest.(check string)
+    "done"
+    "done"
+    (CP.task_phase_to_string (CP.task_phase_of_status done_status));
+  Alcotest.(check string)
+    "empty aggregate"
+    "no_task"
+    (CP.task_phase_to_string (CP.task_phase_of_counts []));
+  Alcotest.(check string)
+    "mixed aggregate"
+    "mixed"
+    (CP.task_phase_to_string (CP.task_phase_of_counts [ done_status; cancelled_status ]))
+;;
+
+let test_goal_terminal_open_tasks_violation () =
+  let task_counts = CP.task_counts_of_statuses [ claimed_status ] in
+  let p =
+    product
+      ~goal:Goal_phase.Completed
+      ~task:CP.Claimed
+      ~task_counts
+      ~ids:(ids ~goal_id:"goal-1" ~task_ids:[ "task-1" ] ())
+      ()
+  in
+  let violations = CP.check_invariants p in
+  check_has_code "goal_terminal_open_tasks" violations
+;;
+
+let test_goal_completed_without_done_task_is_advisory () =
+  let p =
+    product ~goal:Goal_phase.Completed ~task:CP.No_task ~ids:(ids ~goal_id:"goal-1" ()) ()
+  in
+  let violations = CP.check_invariants p in
+  check_has_code "goal_completed_without_done_task" violations;
+  match violations with
+  | [ { CP.severity = CP.Warn; _ } ] -> ()
+  | _ -> Alcotest.fail "expected one warning"
+;;
+
+let test_reward_machine_phases () =
+  let task_counts = CP.task_counts_of_statuses [ done_status ] in
+  let pending =
+    CP.reward_phase_of_facts
+      ~economy_enabled:true
+      ~task_counts
+      ~board:CP.Quiet
+      ~has_reward_earning:false
+      ~has_spend:false
+      ~has_penalty:false
+  in
+  Alcotest.(check string) "pending" "credit_pending" (CP.reward_phase_to_string pending);
+  let rewarded =
+    CP.reward_phase_of_facts
+      ~economy_enabled:true
+      ~task_counts
+      ~board:CP.Quiet
+      ~has_reward_earning:true
+      ~has_spend:false
+      ~has_penalty:false
+  in
+  Alcotest.(check string) "rewarded" "rewarded" (CP.reward_phase_to_string rewarded);
+  let spent =
+    CP.reward_phase_of_facts
+      ~economy_enabled:true
+      ~task_counts
+      ~board:CP.Quiet
+      ~has_reward_earning:true
+      ~has_spend:true
+      ~has_penalty:false
+  in
+  Alcotest.(check string) "spent" "spent" (CP.reward_phase_to_string spent);
+  let penalized =
+    CP.reward_phase_of_facts
+      ~economy_enabled:true
+      ~task_counts
+      ~board:CP.Quiet
+      ~has_reward_earning:true
+      ~has_spend:true
+      ~has_penalty:true
+  in
+  Alcotest.(check string) "penalized" "penalized" (CP.reward_phase_to_string penalized);
+  let disabled =
+    CP.reward_phase_of_facts
+      ~economy_enabled:false
+      ~task_counts
+      ~board:CP.Quiet
+      ~has_reward_earning:true
+      ~has_spend:true
+      ~has_penalty:true
+  in
+  Alcotest.(check string) "disabled wins" "disabled" (CP.reward_phase_to_string disabled)
+;;
+
+let test_reward_without_evidence_violation () =
+  let p =
+    product ~reward:CP.Rewarded ~ids:(ids ~goal_id:"goal-1" ~task_ids:[ "task-1" ] ()) ()
+  in
+  CP.check_invariants p |> check_has_code "reward_without_evidence"
+;;
+
+let test_board_degraded_violation () =
+  let facts = { CP.default_facts with board_persist_error_count = 1 } in
+  let p =
+    product
+      ~board:CP.Degraded
+      ~facts
+      ~ids:(ids ~goal_id:"goal-1" ~post_ids:[ "post-1" ] ())
+      ()
+  in
+  CP.check_invariants p |> check_has_code "board_degraded"
+;;
+
+let test_snapshot_json () =
+  let task_counts = CP.task_counts_of_statuses [ done_status ] in
+  let refs = ids ~goal_id:"goal-1" ~task_ids:[ "task-1" ] () in
+  let evidence : CP.evidence =
+    { source = "telemetry"
+    ; kind = "task_completed"
+    ; id = Some "task-1"
+    ; label = "task completed"
+    ; detail = "success=true; duration_ms=42"
+    ; timestamp = Some 1.0
+    ; refs
+    }
+  in
+  let p =
+    product
+      ~goal:Goal_phase.Completed
+      ~task:CP.Done
+      ~task_counts
+      ~ids:refs
+      ~evidence:[ evidence ]
+      ()
+  in
+  let json = CP.snapshot_to_yojson (CP.snapshot [ p ]) in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string) "mode" "advisory" (json |> member "mode" |> to_string);
+  Alcotest.(check int)
+    "products"
+    1
+    (json |> member "summary" |> member "products" |> to_int);
+  Alcotest.(check int)
+    "evidence"
+    1
+    (json |> member "summary" |> member "evidence" |> to_int);
+  Alcotest.(check string)
+    "evidence source"
+    "telemetry"
+    (json |> member "products" |> index 0 |> member "evidence" |> index 0 |> member "source"
+     |> to_string)
+;;
+
+let () =
+  Alcotest.run
+    "Coordination_product"
+    [ "task_axis", [ Alcotest.test_case "projection" `Quick test_task_axis_projection ]
+    ; ( "invariants"
+      , [ Alcotest.test_case
+            "terminal goal with open task"
+            `Quick
+            test_goal_terminal_open_tasks_violation
+        ; Alcotest.test_case
+            "completed without evidence warns"
+            `Quick
+            test_goal_completed_without_done_task_is_advisory
+        ; Alcotest.test_case
+            "reward without evidence"
+            `Quick
+            test_reward_without_evidence_violation
+        ; Alcotest.test_case "board degraded" `Quick test_board_degraded_violation
+        ] )
+    ; ( "reward"
+      , [ Alcotest.test_case "reward machine phases" `Quick test_reward_machine_phases ] )
+    ; "json", [ Alcotest.test_case "snapshot json" `Quick test_snapshot_json ]
+    ]
+;;

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -249,6 +249,30 @@ let test_dashboard_shell_http_json_prefers_last_good_while_prewarming () =
       check int "last-good counts reused" 7
         (json |> member "counts" |> member "agents" |> to_int))
 
+let test_dashboard_planning_http_json_includes_coordination_fsm () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  ignore (Lib.Coord.init config ~agent_name:(Some "dashboard"));
+  let json = Lib.Server_dashboard_http.dashboard_planning_http_json ~config in
+  let open Yojson.Safe.Util in
+  let coordination = json |> member "coordination_fsm" in
+  check string "mode" "advisory" (coordination |> member "mode" |> to_string);
+  check bool "summary present" true
+    (match coordination |> member "summary" with
+     | `Assoc _ -> true
+     | _ -> false);
+  check bool "summary evidence present" true
+    (match coordination |> member "summary" |> member "evidence" with
+     | `Int _ -> true
+     | _ -> false);
+  check bool "violations present" true
+    (match coordination |> member "violations" with
+     | `List _ -> true
+     | _ -> false);
+  check bool "evidence present" true
+    (match coordination |> member "evidence" with
+     | `List _ -> true
+     | _ -> false)
+
 let test_dashboard_shell_auth_json_canonicalizes_token_owner () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
   let cfg =
@@ -363,6 +387,8 @@ let () =
             test_dashboard_shell_http_json_uses_bootstrap_payload_while_prewarming;
           test_case "shell reuses last good payload while prewarming" `Quick
             test_dashboard_shell_http_json_prefers_last_good_while_prewarming;
+          test_case "planning payload includes coordination FSM" `Quick
+            test_dashboard_planning_http_json_includes_coordination_fsm;
           test_case "shell auth canonicalizes token owner" `Quick
             test_dashboard_shell_auth_json_canonicalizes_token_owner;
           test_case "shell auth reports missing token" `Quick

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -89,6 +89,22 @@ let () = test "dispatch_status" (fun () ->
   | None -> failwith "dispatch returned None"
 )
 
+(* Test dispatch coordination FSM snapshot *)
+let () = test "dispatch_coordination_fsm_snapshot" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ = Coord.init ctx.config ~agent_name:(Some "test-agent") in
+  let args = `Assoc [] in
+  match Tool_coord.dispatch ctx ~name:"masc_coordination_fsm_snapshot" ~args with
+  | Some (success, result) ->
+      assert success;
+      let json = Yojson.Safe.from_string result in
+      let open Yojson.Safe.Util in
+      assert (json |> member "mode" |> to_string = "advisory");
+      assert (json |> member "summary" |> member "products" |> to_int >= 0);
+      assert (json |> member "summary" |> member "evidence" |> to_int >= 0)
+  | None -> failwith "dispatch returned None"
+)
+
 (* Test status summary and active task cap *)
 let () = test "dispatch_status_summary_and_cap" (fun () ->
   let ctx = make_test_ctx () in

--- a/test/test_tool_name.ml
+++ b/test/test_tool_name.ml
@@ -22,7 +22,8 @@ let all_masc : Tool_name.Masc.t list =
   ; Board_delete; Board_get; Board_hearths; Board_list; Board_post
   ; Board_profile; Board_search
   ; Board_stats; Board_vote; Broadcast; Cancel_task; Check; Claim_next
-  ; Claim_task; Cleanup_zombies; Code_delete; Code_edit; Code_git; Code_read
+  ; Claim_task; Cleanup_zombies; Coordination_fsm_snapshot; Code_delete
+  ; Code_edit; Code_git; Code_read
   ; Code_search; Code_shell; Code_symbols; Code_write; Complete_task
   ; Dashboard; Deliver; Dispatch_plan
   ; Heartbeat; Join; Leave; List_tasks; Messages; Note_add


### PR DESCRIPTION
## Summary

Adds a read-only, advisory Goal x Task x Board x Reward coordination product FSM and exposes it through MCP and the dashboard.

- Adds a pure `Coordination_product` invariant checker plus `Coordination_product_snapshot` read model.
- Projects evidence from goal store, task store, board posts, economy ledger, and telemetry into the snapshot JSON.
- Registers `masc_coordination_fsm_snapshot` and surfaces advisory warnings through `masc_status`.
- Adds a Planning dashboard `Coordination Health` panel and per-goal FSM badges.
- Adds TLC coverage for the coordination product with a buggy model that must violate the invariant.

## Validation

- `pnpm --prefix dashboard exec tsc --noEmit --pretty false`
- `pnpm --prefix dashboard exec vitest run --no-file-parallelism --maxWorkers=1 src/components/planning-panel.test.ts src/components/goals/goal-tree.test.ts`
- `env MASC_DUNE_THROTTLE=0 DUNE_BUILD_DIR=.../_build-fsm-check DUNE_JOBS=1 scripts/dune-local.sh build ./test/test_coordination_product.exe ./test/test_tool_coord_coverage.exe ./test/test_dashboard_http_core.exe ./test/test_agent_economy.exe ./test/test_tool_surface_ssot.exe ./test/test_tool_exposure.exe ./test/test_tool_registration_consistency.exe ./test/test_tool_name.exe`
- `_build-fsm-check/default/test/test_coordination_product.exe`
- `_build-fsm-check/default/test/test_agent_economy.exe`
- `_build-fsm-check/default/test/test_tool_coord_coverage.exe`
- `_build-fsm-check/default/test/test_dashboard_http_core.exe`
- `_build-fsm-check/default/test/test_tool_surface_ssot.exe`
- `_build-fsm-check/default/test/test_tool_exposure.exe`
- `_build-fsm-check/default/test/test_tool_registration_consistency.exe`
- `_build-fsm-check/default/test/test_tool_name.exe`
- `java -XX:+UseParallelGC -Xmx2g -cp ~/.local/lib/tla/tla2tools-1.8.0.jar tlc2.TLC -config specs/state-product/CoordinationProduct.cfg -workers auto -deadlock specs/state-product/CoordinationProduct.tla`
- `java -XX:+UseParallelGC -Xmx2g -cp ~/.local/lib/tla/tla2tools-1.8.0.jar tlc2.TLC -config specs/state-product/CoordinationProduct-buggy.cfg -workers auto -deadlock specs/state-product/CoordinationProduct.tla` exited 12 as expected on `SafetyInvariant`.
- `git diff --check`

Dashboard smoke: Vite served `http://localhost:5174/dashboard/` with HTTP 200.