### PR TITLE
feat(hebbian): per-outcome counter for edge updates (#9876 observability)

### DIFF
--- a/lib/hebbian_eio.ml
+++ b/lib/hebbian_eio.ml
@@ -260,6 +260,15 @@ let update_synapse graph (synapse : synapse) : synapse_graph =
   ) graph.synapses) in
   { graph with synapses = updated }
 
+(* #9876: Prometheus counter for Hebbian edge updates.  The graph
+   sits dormant across 7h+ of fleet traffic (synapses written once
+   at boot, [last_updated] never advances) and operators had no
+   fleet-wide signal distinguishing "hook never fires" from "write
+   fails silently" from "weaken called but no synapse existed".
+   One counter with an [outcome] label surfaces each path so the
+   dormant-graph diagnosis has ground truth. *)
+let edge_update_outcome_metric = "masc_hebbian_edge_update_total"
+
 (** Strengthen connection - synchronous *)
 let strengthen config ?params ~from_agent ~to_agent () : unit =
   let params = Option.value params ~default:(default_params ()) in
@@ -280,15 +289,24 @@ let strengthen config ?params ~from_agent ~to_agent () : unit =
     } in
     let new_graph = update_synapse graph updated in
     save_graph config new_graph
-  )
+  );
+  Prometheus.inc_counter edge_update_outcome_metric
+    ~labels:[ ("outcome", "strengthened") ] ()
 
 (** Weaken connection - synchronous *)
 let weaken config ?params ~from_agent ~to_agent () : unit =
   let params = Option.value params ~default:(default_params ()) in
+  let outcome = ref "weaken_no_synapse" in
   with_graph_lock config (fun () ->
     let graph = load_graph config in
     match find_synapse graph ~from_agent ~to_agent with
-    | None -> ()  (* No synapse to weaken *)
+    | None ->
+      (* #9876: keep outcome="weaken_no_synapse" so Grafana can see
+         "fleet tried to weaken A→B but no edge existed" — silent
+         drop used to hide one failure mode where failure-side
+         learning never persisted because the matching strengthen
+         event never ran first. *)
+      ()
     | Some synapse ->
       let new_weight = max 0.0 (synapse.weight -. params.weaken_rate) in
       let now = Time_compat.now () in
@@ -300,8 +318,11 @@ let weaken config ?params ~from_agent ~to_agent () : unit =
         weight_history = append_history ~ts:now ~w:new_weight synapse.weight_history;
       } in
       let new_graph = update_synapse graph updated in
-      save_graph config new_graph
-  )
+      save_graph config new_graph;
+      outcome := "weakened"
+  );
+  Prometheus.inc_counter edge_update_outcome_metric
+    ~labels:[ ("outcome", !outcome) ] ()
 
 (** Get preferred collaboration partner - synchronous *)
 let get_preferred_partner config ~agent_id : string option =

--- a/test/dune
+++ b/test/dune
@@ -58,6 +58,7 @@
         test_keeper_compaction_outcome_counter
         test_keeper_usage_trust_counter
         test_heuristic_theatre_audit
+        test_hebbian_edge_update_counter
         test_keeper_wake_telemetry
         test_keeper_memory
         test_keeper_accountability
@@ -188,6 +189,7 @@
           test_keeper_compaction_outcome_counter
           test_keeper_usage_trust_counter
           test_heuristic_theatre_audit
+          test_hebbian_edge_update_counter
           test_keeper_wake_telemetry
           test_keeper_memory
           test_keeper_accountability

--- a/test/test_hebbian_edge_update_counter.ml
+++ b/test/test_hebbian_edge_update_counter.ml
@@ -1,0 +1,121 @@
+(* test/test_hebbian_edge_update_counter.ml
+
+   #9876 observability follow-up: verify that
+   [Hebbian_eio.strengthen] and [weaken] surface edge-update
+   outcomes via the new Prometheus counter
+
+     masc_hebbian_edge_update_total{outcome}
+
+   where [outcome] is one of [strengthened], [weakened], or
+   [weaken_no_synapse].
+
+   Motivation: the synapse graph stayed frozen for 7+ hours with
+   432 turn outcomes recorded (issue body).  No counter
+   distinguished "hook never fired" from "fired but silently
+   did nothing" (the [weaken] [None] branch).  This test pins
+   each outcome's label so Grafana can split
+   [rate(...{outcome="strengthened"})] vs
+   [rate(...{outcome="weaken_no_synapse"})] cleanly. *)
+
+open Masc_mcp
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let with_temp_masc_dir f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-hebbian-counter-9876-%d-%d"
+         (Unix.getpid ())
+         (int_of_float (Unix.gettimeofday () *. 1000000.)))
+  in
+  Unix.mkdir base 0o755;
+  let config = Coord.default_config base in
+  let _ = Coord.init config ~agent_name:None in
+  Hebbian_eio.reset_lock_stats ();
+  try
+    let result = f config in
+    let _ = Coord.reset config in
+    rm_rf base;
+    result
+  with e ->
+    let _ = Coord.reset config in
+    rm_rf base;
+    raise e
+
+let counter_for ~outcome =
+  Prometheus.metric_value_or_zero Hebbian_eio.edge_update_outcome_metric
+    ~labels:[ ("outcome", outcome) ]
+    ()
+
+let test_metric_name_stable () =
+  Alcotest.(check string)
+    "hebbian edge update counter canonical name"
+    "masc_hebbian_edge_update_total"
+    Hebbian_eio.edge_update_outcome_metric
+
+let test_strengthen_bumps_strengthened () =
+  with_temp_masc_dir (fun cfg ->
+    let before = counter_for ~outcome:"strengthened" in
+    Hebbian_eio.strengthen cfg
+      ~from_agent:"test-9876-a" ~to_agent:"test-9876-b" ();
+    Alcotest.(check (float 0.0001))
+      "strengthen counter +1"
+      (before +. 1.0) (counter_for ~outcome:"strengthened"))
+
+let test_weaken_existing_edge_bumps_weakened () =
+  with_temp_masc_dir (fun cfg ->
+    (* Prime the graph by strengthening first so the edge exists. *)
+    Hebbian_eio.strengthen cfg
+      ~from_agent:"test-9876-c" ~to_agent:"test-9876-d" ();
+    let before = counter_for ~outcome:"weakened" in
+    Hebbian_eio.weaken cfg
+      ~from_agent:"test-9876-c" ~to_agent:"test-9876-d" ();
+    Alcotest.(check (float 0.0001))
+      "weaken counter +1 when edge exists"
+      (before +. 1.0) (counter_for ~outcome:"weakened"))
+
+let test_weaken_missing_edge_bumps_no_synapse () =
+  with_temp_masc_dir (fun cfg ->
+    (* Weaken a never-strengthened pair — ticks [weaken_no_synapse]
+       label, not [weakened].  Surfaces the silent-drop failure
+       mode from #9876. *)
+    let before_no_synapse = counter_for ~outcome:"weaken_no_synapse" in
+    let before_weakened = counter_for ~outcome:"weakened" in
+    Hebbian_eio.weaken cfg
+      ~from_agent:"test-9876-missing-x"
+      ~to_agent:"test-9876-missing-y" ();
+    Alcotest.(check (float 0.0001))
+      "weaken_no_synapse counter +1"
+      (before_no_synapse +. 1.0)
+      (counter_for ~outcome:"weaken_no_synapse");
+    Alcotest.(check (float 0.0001))
+      "weakened counter unchanged"
+      before_weakened (counter_for ~outcome:"weakened"))
+
+let () =
+  Alcotest.run "hebbian_edge_update_counter_9876"
+    [
+      ( "metric_name",
+        [
+          Alcotest.test_case "canonical name stable" `Quick
+            test_metric_name_stable;
+        ] );
+      ( "outcomes",
+        [
+          Alcotest.test_case "strengthen bumps strengthened" `Quick
+            test_strengthen_bumps_strengthened;
+          Alcotest.test_case "weaken existing edge bumps weakened" `Quick
+            test_weaken_existing_edge_bumps_weakened;
+          Alcotest.test_case "weaken missing edge bumps weaken_no_synapse"
+            `Quick test_weaken_missing_edge_bumps_no_synapse;
+        ] );
+    ]


### PR DESCRIPTION
## 요약

#9876 의 dormant synapse graph 근원 조사를 위한 observability 레이어. Tick #8 PR #9914 에서 consolidation fiber 를 붙였지만, **쓰기 경로** (strengthen/weaken hook) 가 실제로 불리는지, 불렸는데 silent drop 됐는지, 얼마나 자주인지 구분할 수 있는 신호가 없었음.

3 경로 구분:

- `strengthen` 성공 — edge weight 증가.
- `weaken` 성공 — 기존 edge 의 weight 감소.
- `weaken` 이 edge 없는 pair 에 호출 — 현재 silent `()`, failure-side learning 이 persist 못 하는 한 failure mode.

이 PR 이 추가:

```
masc_hebbian_edge_update_total{outcome}
  outcome = strengthened | weakened | weaken_no_synapse
```

Grafana 질의 예:
- Hook 이 전혀 안 불림? `rate(masc_hebbian_edge_update_total[5m]) == 0`
- Weaken 이 missing edge 에서만 발화? `rate({outcome="weaken_no_synapse"}) > 0 AND rate({outcome="weakened"}) == 0`
- Strengthen 이 weaken 보다 압도 → 음성 학습 부재? `rate({strengthened}) / rate({weakened})`

## 변경 파일

- `lib/hebbian_eio.ml`
  - `edge_update_outcome_metric` 상수 (SSOT).
  - `strengthen` 이 lock block 밖에서 `outcome=strengthened` 카운터 증가.
  - `weaken` 이 local `outcome` ref 로 inside-lock 결과 기록 후 block 밖에서 카운터 증가 (`weakened` | `weaken_no_synapse`).
- `test/test_hebbian_edge_update_counter.ml` (신규) — 4 테스트:
  - canonical name pin.
  - `strengthen` → `strengthened` counter +1.
  - `weaken` on existing edge → `weakened` +1.
  - `weaken` on missing pair → `weaken_no_synapse` +1 AND `weakened` 불변 (#9876 silent-drop 회귀 가드).
- `test/dune` — 새 test 등록.

## 로컬 검증

```
$ MASC_BASE_PATH=/tmp/masc-test-9876 dune exec test/test_hebbian_edge_update_counter.exe
Test Successful in 0.050s. 4 tests run.

$ dune exec test/test_hebbian_eio.exe
Test Successful in 0.770s. 15 tests run.    # 회귀 0
```

`dune build --cache=disabled` clean.

## 왜 근원 fix 인가

- **"가짜 휴리스틱" 금지 정신 유지**: learning behavior 는 건드리지 않음. 진단 전에 hook invocation 실측 먼저.
- **Silent `()` drop 드러냄**: `weaken` 의 `None ->` 분기는 failure_count persistence 가 왜 0 인지 설명할 강한 후보. 카운터가 "weaken_no_synapse" rate 를 보여주면 "failure-side learning 이 strengthen-precondition 에 gating 됨" 이 데이터로 확정됨.
- **Post-merge 결정 기반**: `strengthen/weaken` 모두 매시간 0 이면 → upstream hook (coord.ml:215-223) 이 task_done/cancelled 에 반응 안 함 → 그쪽 조사. 만약 strengthen 만 나오면 → failure-side 자체가 돌지 않음 → weaken dispatch 게이트 조사. 중간 단계를 건너뛰지 않음.

## 미검증 / 후속

- Fleet 에서 얼마가 `weaken_no_synapse` rate 인지는 머지 후 Prometheus 로 관찰.
- 만약 `weaken_no_synapse` 가 압도적이면 → `weaken` 의 `None` 분기를 "create-with-failure=1" 으로 변경하는 behavior change 가 별도 PR. 현재 PR 은 signal 만.
- #9876 의 Related 에 기록된 #7763 (failures never persisted) 이 같은 structural family — 이 counter 결과에 따라 두 이슈가 하나의 root-cause merge 될 수도 있음.

## 관련

- #9876 (root — dormant graph).
- PR #9914 (tick #8, consolidation fiber wiring).
- #7763 (failures never persist — same family).
- #9517 (silent failure meta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)