### PR TITLE
fix(governance): recover JSON object after prose prefix (#9851)

### DIFF
--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -483,6 +483,21 @@ let compute_judgments
            to {raw: string} only after all recovery transforms fail. *)
         let raw_text = Oas_response.text_of_response response in
         let parsed = Llm_provider.Lenient_json.parse raw_text in
+        let parsed =
+          (* #9851: when the model prefixes prose before the JSON object
+             ("Here is the judgment: {...}"), Lenient_json's fence/comma
+             recovery does not strip the prose and falls through to the
+             {raw: <text>} sentinel. Try one more recovery: locate the
+             first balanced {...} block in the raw text and re-parse. *)
+          match parsed with
+          | `Assoc [("raw", `String raw)] -> (
+              match Judge_json_recovery.extract_balanced_object raw with
+              | Some block -> (
+                  try Llm_provider.Lenient_json.parse block
+                  with _ -> parsed)
+              | None -> parsed)
+          | _ -> parsed
+        in
         match parsed with
         | `Assoc [("raw", `String raw)] ->
             (* #9774: surface a preview of the raw text so the next

--- a/lib/dashboard/judge_json_recovery.ml
+++ b/lib/dashboard/judge_json_recovery.ml
@@ -1,0 +1,42 @@
+(* Recover a JSON object from LLM output that prefixes or suffixes prose.
+
+   Locate the first balanced {...} block in the raw string and return it
+   as a candidate for re-parsing. String-literal aware: a [{] inside a
+   pair of [" "] does not open a nested object, and escaped quotes inside
+   a string literal are honoured, so valid prose containing stray braces
+   inside a string literal does not unbalance the scan.
+
+   Returns None when no opening brace appears at all, or when the scan
+   reaches EOF with unbalanced depth. *)
+
+let extract_balanced_object (s : string) : string option =
+  let len = String.length s in
+  let start_idx = String.index_opt s '{' in
+  match start_idx with
+  | None -> None
+  | Some start ->
+      let depth = ref 0 in
+      let in_string = ref false in
+      let escape = ref false in
+      let end_idx = ref None in
+      let i = ref start in
+      while !end_idx = None && !i < len do
+        let c = s.[!i] in
+        if !in_string then begin
+          if !escape then escape := false
+          else if c = '\\' then escape := true
+          else if c = '"' then in_string := false
+        end else begin
+          match c with
+          | '"' -> in_string := true
+          | '{' -> incr depth
+          | '}' ->
+              decr depth;
+              if !depth = 0 then end_idx := Some !i
+          | _ -> ()
+        end;
+        incr i
+      done;
+      match !end_idx with
+      | Some finish -> Some (String.sub s start (finish - start + 1))
+      | None -> None

--- a/lib/dashboard/judge_json_recovery.mli
+++ b/lib/dashboard/judge_json_recovery.mli
@@ -1,0 +1,5 @@
+(* Recover a JSON object from LLM output that prefixes or suffixes prose.
+   Returns the first balanced {...} substring, or None if no well-formed
+   object opens-and-closes in the input. String-literal aware. *)
+
+val extract_balanced_object : string -> string option

--- a/lib/dune
+++ b/lib/dune
@@ -71,6 +71,7 @@
    dashboard_governance_metrics
    dashboard_operator_judge
    judge_diagnostics
+   judge_json_recovery
    dashboard_safe_autonomy
    dashboard_surface_readiness
    dashboard_execution

--- a/test/dune
+++ b/test/dune
@@ -370,6 +370,7 @@
         test_keeper_meta_listing
         test_keeper_meta_cas_retry
         test_judge_diagnostics
+        test_judge_json_recovery
         test_keeper_identity_parse
         test_worker_runtime
         test_capability_registry
@@ -540,6 +541,7 @@
         test_keeper_meta_listing
         test_keeper_meta_cas_retry
         test_judge_diagnostics
+        test_judge_json_recovery
         test_keeper_identity_parse
         test_worker_runtime
         test_capability_registry

--- a/test/test_judge_json_recovery.ml
+++ b/test/test_judge_json_recovery.ml
@@ -1,0 +1,63 @@
+(* #9851: governance judge parse recovery — tests for the secondary
+   brace-balanced block extraction used when [Lenient_json.parse] falls
+   through to the {raw: <text>} sentinel because the LLM prefixed prose
+   before the JSON. *)
+
+open Alcotest
+open Masc_mcp
+
+let test_no_brace_returns_none () =
+  let out = Judge_json_recovery.extract_balanced_object "no json here" in
+  check (option string) "plain prose has no json block" None out
+
+let test_balanced_object_after_prose () =
+  let raw = "Here is the judgment: {\"items\": []}\nThanks!" in
+  match Judge_json_recovery.extract_balanced_object raw with
+  | Some block -> check string "extracts object after prose" "{\"items\": []}" block
+  | None -> fail "expected Some with the balanced object"
+
+let test_nested_object () =
+  let raw = "prefix {\"a\": {\"b\": 1}, \"c\": 2} suffix" in
+  match Judge_json_recovery.extract_balanced_object raw with
+  | Some block ->
+      check string "depth-2 object closes correctly"
+        "{\"a\": {\"b\": 1}, \"c\": 2}" block
+  | None -> fail "expected Some"
+
+let test_braces_inside_string_ignored () =
+  (* A stray { inside a string literal must NOT open a new scope, so the
+     outer object should close at the matching }. *)
+  let raw = "before {\"text\": \"hello {world}\"} after" in
+  match Judge_json_recovery.extract_balanced_object raw with
+  | Some block ->
+      check string "brace inside string is content, not scope"
+        "{\"text\": \"hello {world}\"}" block
+  | None -> fail "expected Some"
+
+let test_escaped_quote_inside_string () =
+  let raw = "prefix {\"msg\": \"quote \\\"inside\\\" value\"}" in
+  match Judge_json_recovery.extract_balanced_object raw with
+  | Some block ->
+      check string "escaped quotes do not close the string"
+        "{\"msg\": \"quote \\\"inside\\\" value\"}" block
+  | None -> fail "expected Some"
+
+let test_unbalanced_returns_none () =
+  let raw = "prefix {\"items\": [" in
+  let out = Judge_json_recovery.extract_balanced_object raw in
+  check (option string) "truncated object returns None" None out
+
+let () =
+  run "judge_json_recovery" [
+    "extract_balanced_object", [
+      test_case "no brace → None" `Quick test_no_brace_returns_none;
+      test_case "balanced object after prose" `Quick
+        test_balanced_object_after_prose;
+      test_case "nested object" `Quick test_nested_object;
+      test_case "braces inside string are ignored" `Quick
+        test_braces_inside_string_ignored;
+      test_case "escaped quote inside string" `Quick
+        test_escaped_quote_inside_string;
+      test_case "unbalanced → None" `Quick test_unbalanced_returns_none;
+    ]
+  ]


### PR DESCRIPTION
## 요약

Governance judge가 LLM의 "Here is the judgment: {...}" 패턴(프로즈 접두사) 응답을 파싱 실패해 dashboard refresh가 통째로 에러. `Lenient_json.parse`가 `{raw: <text>}` fallback에 빠진 후 error로 이어지는 경로에 **balanced `{...}` 추출 재시도**를 추가.

Partially closes #9851 (governance parse symptom — qa-king OAS timeout-budget은 별도 후속).

## 근본 원인

`lib/dashboard/dashboard_governance_judge.ml:487-493`:

```ocaml
match parsed with
| `Assoc [("raw", `String raw)] ->
    let msg = Judge_diagnostics.format_lenient_fallback ~judge_label:"Governance" raw in
    Log.Governance.warn "%s" msg;
    Error msg    (* ← 프로즈 접두사면 여기서 끝 *)
```

`Lenient_json`은 fence/trailing comma/double-stringified JSON을 처리하지만 prose prefix는 처리 안 함:
- 입력: `Here is the judgment: {"items": [...]}`
- Lenient_json: `{raw: "Here is ..."}` sentinel 반환
- 현재 코드: Error 반환 → judgment pane 비어있음

## 변경 내용

### 1. `lib/dashboard/judge_json_recovery.ml` (신규)

```ocaml
let extract_balanced_object (s : string) : string option = ...
```

첫 `{`부터 매칭되는 `}`까지 추출. **String-literal aware** — `""` 안의 `{` `}`는 content로 무시, `\"` escape 처리.

### 2. Governance judge 에 recovery 경로 추가

```diff
  let parsed = Llm_provider.Lenient_json.parse raw_text in
+ let parsed =
+   match parsed with
+   | `Assoc [("raw", `String raw)] -> (
+       match Judge_json_recovery.extract_balanced_object raw with
+       | Some block -> (
+           try Llm_provider.Lenient_json.parse block
+           with _ -> parsed)
+       | None -> parsed)
+   | _ -> parsed
+ in
  match parsed with
  | `Assoc [("raw", `String raw)] -> Error msg
  | _ -> ...
```

Recovery 실패 시 기존 Error 경로 불변. 성공 시 정상 파싱 path.

### 3. 테스트 `test/test_judge_json_recovery.ml`

6 scenario:
- 중괄호 없음 → None
- 프로즈 접두사 뒤 object 추출
- 중첩 object (depth 2)
- 문자열 내 `{`/`}`는 scope 아님
- escaped quote `\"` 내부 정상 처리
- 잘린 object → None

## 검증

```bash
$ dune build @check --root .
(exit 0)

$ dune exec --root . test/test_judge_json_recovery.exe
# → Test Successful in 0.001s. 6 tests run.
```

## 회귀 리스크

매우 낮음 — 추가 경로만. 기존 `{raw: _}` 패턴이 extract 실패 시 그대로 error로 흐름. 정상 JSON 입력은 Lenient_json 성공 branch 변경 없음.

## 후속

`#9851`의 다른 증상(qa-king OAS timeout-budget)은 OAS 레이어 조사 필요 — 별도 scope.

## 참고

- Issue #9851 — governance judge + qa-king timeout
- `lib/dashboard/judge_diagnostics.ml` — `Lenient_json` fallback preview formatter
- `Lenient_json.parse` — OAS 제공 fence/comma/nested-json 복구
