### PR TITLE
refactor(keeper): split meta tool access contract

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -426,6 +426,7 @@
    keeper_deliberation
    keeper_id
    keeper_types_profile
+   keeper_meta_tool_access
    keeper_meta_contract
    keeper_meta_json_scrub
    keeper_meta_json_parse
@@ -631,6 +632,7 @@
  dashboard_mission_agents
  dashboard_mission_assembly
  keeper_types_profile
+ keeper_meta_tool_access
  keeper_meta_contract
  keeper_meta_json_scrub
  keeper_meta_json_parse

--- a/lib/keeper/keeper_exec_masc.ml
+++ b/lib/keeper/keeper_exec_masc.ml
@@ -47,7 +47,8 @@ let keeper_masc_path_blocked
     then keeper_effective_allowed_paths ~meta
     else keeper_effective_write_allowed_paths ~meta
   in
-  if effective_paths = [] then None
+  if effective_paths = []
+  then None
   else (
     let candidates =
       List.filter_map
@@ -58,11 +59,13 @@ let keeper_masc_path_blocked
         [ "path"; "file_path"; "target_path" ]
     in
     let resolve raw =
-      if is_read_only then
-        resolve_keeper_read_path ~config ~meta ~raw_path:raw
+      if is_read_only
+      then resolve_keeper_read_path ~config ~meta ~raw_path:raw
       else
         Keeper_alerting_path.resolve_keeper_target_path
-          ~config ~allowed_paths:effective_paths ~raw_path:raw
+          ~config
+          ~allowed_paths:effective_paths
+          ~raw_path:raw
     in
     List.find_map
       (fun raw ->
@@ -70,6 +73,62 @@ let keeper_masc_path_blocked
          | Error e -> Some e
          | Ok _ -> None)
       candidates)
+;;
+
+let handle_keeper_masc_code_read
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      ~(args : Yojson.Safe.t)
+  =
+  let path = Safe_ops.json_string ~default:"" "path" args in
+  let offset = Safe_ops.json_int ~default:0 "offset" args in
+  let limit = Safe_ops.json_int ~default:100 "limit" args in
+  if path = ""
+  then error_json "❌ Path required: 'path' parameter"
+  else (
+    match resolve_keeper_read_path ~config ~meta ~raw_path:path with
+    | Error e -> error_json e
+    | Ok target ->
+      if not (Sys.file_exists target)
+      then error_json (Printf.sprintf "❌ File not found: %s" path)
+      else if Tool_code.is_binary_file target
+      then error_json "❌ Binary file detected"
+      else (
+        let file_size = (Unix.stat target).Unix.st_size in
+        if file_size > Tool_code.max_file_size
+        then
+          error_json
+            (Printf.sprintf
+               "❌ File too large: %d bytes (max: %d)"
+               file_size
+               Tool_code.max_file_size)
+        else (
+          try
+            let content = In_channel.with_open_text target In_channel.input_all in
+            let lines = String.split_on_char '\n' content in
+            let total_lines = List.length lines in
+            let safe_offset = max 0 (min offset total_lines) in
+            let safe_limit = min limit (total_lines - safe_offset) in
+            let selected_lines = ref [] in
+            for i = safe_offset to safe_offset + safe_limit - 1 do
+              match List.nth_opt lines i with
+              | Some line -> selected_lines := line :: !selected_lines
+              | None -> ()
+            done;
+            let result_lines = List.rev !selected_lines in
+            Yojson.Safe.to_string
+              (`Assoc
+                  [ "path", `String path
+                  ; "offset", `Int safe_offset
+                  ; "limit", `Int safe_limit
+                  ; "total_lines", `Int total_lines
+                  ; "lines", `List (List.map (fun line -> `String line) result_lines)
+                  ])
+          with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
+            error_json
+              (Printf.sprintf "❌ Failed to read file: %s" (Printexc.to_string exn)))))
 ;;
 
 let handle_keeper_masc_tool
@@ -90,39 +149,47 @@ let handle_keeper_masc_tool
              ; "reason", `String reason
              ])
      | Ok token ->
-       (match Tool_dispatch.dispatch ~token ~args with
-        | Some (true, msg) -> msg
-        | Some (false, msg) -> error_json msg
-        | None ->
-          if Tool_dispatch.is_mcp_context_required name
-          then
-            error_json
-              (Printf.sprintf
-                 "tool '%s' requires MCP session (use keeper_* equivalent)"
-                 name)
-          else (
-            match Tool_dispatch.lookup_tag name with
-            | Some tag ->
-              let keeper_agent = keeper_agent_sender ~meta in
-              (match
-                 !Keeper_exec_shared.tag_dispatch_fn ~config ~agent_name:keeper_agent ~tag ~name ~args
-               with
-               | Some (true, msg) -> msg
-               | Some (false, msg) -> error_json msg
-               | None ->
-                 Yojson.Safe.to_string
-                   (`Assoc
-                       [ "error", `String "tool_not_supported_in_keeper"
-                       ; "tool", `String name
-                       ; ( "hint"
-                         , `String
-                             "tag dispatch returned None; tool may be unsupported, \
-                              blocked, or misconfigured" )
-                       ]))
-            | None ->
-              Yojson.Safe.to_string
-                (`Assoc
-                    [ "error", `String "unregistered_masc_tool"; "tool", `String name ]))))
+       if name = "masc_code_read"
+       then handle_keeper_masc_code_read ~config ~meta ~args
+       else (
+         match Tool_dispatch.dispatch ~token ~args with
+         | Some (true, msg) -> msg
+         | Some (false, msg) -> error_json msg
+         | None ->
+           if Tool_dispatch.is_mcp_context_required name
+           then
+             error_json
+               (Printf.sprintf
+                  "tool '%s' requires MCP session (use keeper_* equivalent)"
+                  name)
+           else (
+             match Tool_dispatch.lookup_tag name with
+             | Some tag ->
+               let keeper_agent = keeper_agent_sender ~meta in
+               (match
+                  !Keeper_exec_shared.tag_dispatch_fn
+                    ~config
+                    ~agent_name:keeper_agent
+                    ~tag
+                    ~name
+                    ~args
+                with
+                | Some (true, msg) -> msg
+                | Some (false, msg) -> error_json msg
+                | None ->
+                  Yojson.Safe.to_string
+                    (`Assoc
+                        [ "error", `String "tool_not_supported_in_keeper"
+                        ; "tool", `String name
+                        ; ( "hint"
+                          , `String
+                              "tag dispatch returned None; tool may be unsupported, \
+                               blocked, or misconfigured" )
+                        ]))
+             | None ->
+               Yojson.Safe.to_string
+                 (`Assoc
+                     [ "error", `String "unregistered_masc_tool"; "tool", `String name ]))))
 ;;
 
 (* ── Tool execution dispatch ──────────────────────────────────── *)

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -5,6 +5,7 @@
     parsing and store I/O. *)
 
 open Keeper_types_profile
+include Keeper_meta_tool_access
 
 (* -- Policy types (remain in keeper_meta top-level) -- *)
 
@@ -36,36 +37,6 @@ type proactive_cycle_outcome =
 
 type scheduled_autonomous_cycle_outcome = proactive_cycle_outcome
 
-type tool_preset =
-  | Minimal
-  | Social
-  | Messaging
-  | Dispatch
-  | Coding
-  | Research
-  | Delivery
-  | Full
-
-type tool_access =
-  | Preset of
-      { preset : tool_preset
-      ; also_allow : string list
-      }
-  | Custom of string list
-
-let tool_names_include_board name_list =
-  List.exists
-    (fun name ->
-       String.starts_with ~prefix:"keeper_board_" name
-       || String.starts_with ~prefix:"masc_board_" name)
-    name_list
-
-let tool_access_default_room_signal_prompt_enabled ~default = function
-  | Preset { preset = Minimal; also_allow } ->
-      default || tool_names_include_board also_allow
-  | Preset _ -> true
-  | Custom tool_names -> tool_names_include_board tool_names
-
 (* -- Runtime types (moved into agent_runtime_state) -- *)
 
 type compaction_runtime =
@@ -88,7 +59,7 @@ type proactive_runtime =
   ; last_work_discovery_ts : float
   ; work_discovery_count : int
   ; consecutive_noop_count : int
-      (** Consecutive autonomous cycles where only observation tools
+    (** Consecutive autonomous cycles where only observation tools
           (board_list, stay_silent, context_status) were used with no
           substantive action.  Resets to 0 on any productive cycle.
           Used by [effective_scheduled_autonomous_cooldown] for exponential
@@ -129,6 +100,7 @@ let blocker_class_to_string = function
   | Turn_timeout -> "turn_timeout"
   | Completion_contract_violation -> "completion_contract_violation"
   | No_tool_capable_provider -> "no_tool_capable_provider"
+;;
 
 let blocker_class_of_serialized_string = function
   | "cascade_exhausted" -> Some (Cascade_exhausted (Other_detail "cascade_exhausted"))
@@ -142,45 +114,44 @@ let blocker_class_of_serialized_string = function
   | "completion_contract_violation" -> Some Completion_contract_violation
   | "no_tool_capable_provider" -> Some No_tool_capable_provider
   | _ -> None
+;;
 
 let cascade_exhaustion_summary = function
   | Connection_refused ->
-      "Cascade exhausted after provider failures; local runtime connection refused."
-  | No_providers_available ->
-      "Cascade exhausted; no providers were available."
-  | All_providers_failed ->
-      "Cascade exhausted after all configured providers failed."
-  | Candidates_filtered_after_cycles ->
-      "Cascade exhausted after provider failures."
-  | Other_detail _ ->
-      "Cascade exhausted after provider failures."
+    "Cascade exhausted after provider failures; local runtime connection refused."
+  | No_providers_available -> "Cascade exhausted; no providers were available."
+  | All_providers_failed -> "Cascade exhausted after all configured providers failed."
+  | Candidates_filtered_after_cycles -> "Cascade exhausted after provider failures."
+  | Other_detail _ -> "Cascade exhausted after provider failures."
+;;
 
 let blocker_class_continue_gate = function
   | Ambiguous_post_commit_timeout | Ambiguous_post_commit_failure -> true
   | _ -> false
+;;
 
 let cascade_exhaustion_reason_to_json = function
   | Connection_refused -> `String "connection_refused"
   | No_providers_available -> `String "no_providers_available"
   | All_providers_failed -> `String "all_providers_failed"
   | Candidates_filtered_after_cycles -> `String "candidates_filtered_after_cycles"
-  | Other_detail msg ->
-      `Assoc [("tag", `String "other_detail"); ("message", `String msg)]
+  | Other_detail msg -> `Assoc [ "tag", `String "other_detail"; "message", `String msg ]
+;;
 
 let cascade_exhaustion_reason_of_json = function
   | `String "connection_refused" -> Some Connection_refused
   | `String "no_providers_available" -> Some No_providers_available
   | `String "all_providers_failed" -> Some All_providers_failed
-  | `String "candidates_filtered_after_cycles" ->
-      Some Candidates_filtered_after_cycles
+  | `String "candidates_filtered_after_cycles" -> Some Candidates_filtered_after_cycles
   | `Assoc fields ->
-      (match List.assoc_opt "tag" fields with
-       | Some (`String "other_detail") ->
-           (match List.assoc_opt "message" fields with
-            | Some (`String msg) -> Some (Other_detail msg)
-            | _ -> None)
-       | _ -> None)
+    (match List.assoc_opt "tag" fields with
+     | Some (`String "other_detail") ->
+       (match List.assoc_opt "message" fields with
+        | Some (`String msg) -> Some (Other_detail msg)
+        | _ -> None)
+     | _ -> None)
   | _ -> None
+;;
 
 type usage_metrics =
   { total_turns : int
@@ -291,71 +262,6 @@ type keeper_meta =
   ; meta_version : int
   }
 
-let normalize_tool_names names =
-  names
-  |> List.map String.trim
-  |> List.filter (fun name -> name <> "")
-  |> dedupe_keep_order
-;;
-
-let legacy_keeper_internal_tool_names =
-  Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal
-;;
-
-let legacy_session_min_tool_names =
-  (* Legacy keepers historically received canonical masc_* coordination tools,
-     not the SDK alias-heavy Session_min surface. Keep this compatibility list
-     explicit so missing tool_access migration remains stable after tier removal. *)
-  List.map Tool_name.Masc.to_string
-    Tool_name.Masc.[
-      Status;
-      Tasks;
-      Claim_next;
-      Plan_set_task;
-      Transition;
-      Add_task;
-      Broadcast;
-    ]
-
-let migrate_legacy_restricted_tools names =
-  Custom (normalize_tool_names (legacy_keeper_internal_tool_names @ names))
-;;
-
-let tool_preset_to_string = function
-  | Minimal -> "minimal"
-  | Social -> "social"
-  | Messaging -> "messaging"
-  | Dispatch -> "dispatch"
-  | Coding -> "coding"
-  | Research -> "research"
-  | Delivery -> "delivery"
-  | Full -> "full"
-;;
-
-(** Issue #8430: schema enums for [tool_preset] in [keeper_schema.ml]
-    used to be hand-rolled and dropped [Social] and [Delivery] — a live
-    correctness bug since callers reading the schema could not discover
-    those values exist. Same Variant SSOT class as #8354 / #8392. All
-    constructors are nullary so the simple [List.map] trick works.
-    Adding an 8th constructor will fail compilation in
-    [tool_preset_to_string] and in the witness test. *)
-let all_tool_presets =
-  [ Minimal; Social; Messaging; Dispatch; Coding; Research; Delivery; Full ]
-let valid_tool_preset_strings = List.map tool_preset_to_string all_tool_presets
-
-let tool_preset_of_string raw =
-  match String.trim (String.lowercase_ascii raw) with
-  | "minimal" -> Some Minimal
-  | "social" -> Some Social
-  | "messaging" -> Some Messaging
-  | "dispatch" -> Some Dispatch
-  | "coding" -> Some Coding
-  | "research" -> Some Research
-  | "delivery" -> Some Delivery
-  | "full" -> Some Full
-  | _ -> None
-;;
-
 let proactive_cycle_outcome_to_string = function
   | Proactive_never_started -> "never_started"
   | Proactive_unknown -> "unknown"
@@ -396,10 +302,10 @@ let () =
      | Proactive_mixed_response
      | Proactive_error -> ());
     let s = proactive_cycle_outcome_to_string v in
-    if proactive_cycle_outcome_of_string s <> v then
+    if proactive_cycle_outcome_of_string s <> v
+    then
       invalid_arg
-        (Printf.sprintf
-           "keeper_types: proactive round-trip broken for label %S" s)
+        (Printf.sprintf "keeper_types: proactive round-trip broken for label %S" s)
   in
   List.iter
     assert_roundtrip
@@ -413,207 +319,8 @@ let () =
     ]
 ;;
 
-let scheduled_autonomous_cycle_outcome_to_string =
-  proactive_cycle_outcome_to_string
-;;
-
-let scheduled_autonomous_cycle_outcome_of_string =
-  proactive_cycle_outcome_of_string
-;;
-
-let normalize_tool_access = function
-  | Preset { preset; also_allow } ->
-    Preset { preset; also_allow = normalize_tool_names also_allow }
-  | Custom names -> Custom (normalize_tool_names names)
-;;
-
-let tool_access_preset = function
-  | Preset { preset; _ } -> Some preset
-  | Custom _ -> None
-;;
-
-let tool_access_custom_allowlist = function
-  | Preset _ -> None
-  | Custom names -> Some names
-;;
-
-let tool_access_also_allowlist = function
-  | Preset { also_allow; _ } -> also_allow
-  | Custom _ -> []
-;;
-
-let tool_access_to_json access =
-  match normalize_tool_access access with
-  | Preset { preset; also_allow } ->
-    `Assoc
-      [ "kind", `String "preset"
-      ; "preset", `String (tool_preset_to_string preset)
-      ; "also_allow", `List (List.map (fun s -> `String s) also_allow)
-      ]
-  | Custom names ->
-    `Assoc
-      [ "kind", `String "custom"; "tools", `List (List.map (fun s -> `String s) names) ]
-;;
-
-let json_member_present key (json : Yojson.Safe.t) =
-  match json with
-  | `Assoc fields -> List.mem_assoc key fields
-  | _ -> false
-;;
-
-let string_list_field_result ?label ~field_name (json : Yojson.Safe.t) =
-  let label = Option.value ~default:field_name label in
-  match Yojson.Safe.Util.member field_name json with
-  | `List items ->
-    let rec collect acc index = function
-      | [] -> Ok (List.rev acc)
-      | `String value :: rest -> collect (value :: acc) (index + 1) rest
-      | _ :: _ -> Error (Printf.sprintf "keeper %s[%d] must be a string" label index)
-    in
-    collect [] 0 items
-  | `Null -> Error (Printf.sprintf "keeper %s must be an array of strings" label)
-  | _ -> Error (Printf.sprintf "keeper %s must be an array of strings" label)
-;;
-
-let string_list_field_opt_result ?label ~field_name (json : Yojson.Safe.t) =
-  match Yojson.Safe.Util.member field_name json with
-  | `Null -> Ok []
-  | _ -> string_list_field_result ?label ~field_name json
-;;
-
-let parse_tool_preset_projection (json : Yojson.Safe.t) =
-  let preset_member = Yojson.Safe.Util.member "tool_preset" json in
-  match preset_member with
-  | `String raw ->
-    (match tool_preset_of_string raw with
-     | Some preset -> Ok preset
-     | None -> Error (Printf.sprintf "invalid keeper tool_preset: %s" raw))
-  | `Null -> Error "keeper tool_preset required"
-  | _ -> Error "keeper tool_preset must be a string"
-;;
-
-let default_tool_access_of_meta_json () =
-  migrate_legacy_restricted_tools legacy_session_min_tool_names
-;;
-
-let legacy_tool_access_projection_of_meta_json (json : Yojson.Safe.t) =
-  let custom_present = json_member_present "tool_custom_allowlist" json in
-  let preset_present = json_member_present "tool_preset" json in
-  let also_allow_present = json_member_present "tool_also_allow" json in
-  let legacy_allowlist_present = json_member_present "tool_allowlist" json in
-  if custom_present
-  then (
-    match string_list_field_result ~field_name:"tool_custom_allowlist" json with
-    | Ok tools -> Ok (normalize_tool_access (Custom tools))
-    | Error msg -> Error msg)
-  else if preset_present || also_allow_present
-  then (
-    match parse_tool_preset_projection json with
-    | Error msg -> Error msg
-    | Ok preset ->
-      (match string_list_field_opt_result ~field_name:"tool_also_allow" json with
-       | Ok also_allow -> Ok (normalize_tool_access (Preset { preset; also_allow }))
-       | Error msg -> Error msg))
-  else if legacy_allowlist_present
-  then (
-    match string_list_field_result ~field_name:"tool_allowlist" json with
-    | Ok names -> Ok (migrate_legacy_restricted_tools names)
-    | Error msg -> Error msg)
-  else Ok (default_tool_access_of_meta_json ())
-;;
-
-let legacy_tool_access_of_meta_json (json : Yojson.Safe.t) =
-  match Yojson.Safe.Util.member "tool_access" json with
-  | `Null -> legacy_tool_access_projection_of_meta_json json
-  | `Assoc _ as access_json ->
-    let kind =
-      Yojson.Safe.Util.member "kind" access_json |> Yojson.Safe.Util.to_string_option
-    in
-    (match kind with
-     | Some "unrestricted" ->
-       Ok (Preset { preset = Full; also_allow = [] } |> normalize_tool_access)
-     | Some "restricted" ->
-       (match
-          string_list_field_opt_result
-            ~field_name:"tools"
-            ~label:"tool_access.tools"
-            access_json
-        with
-        | Ok tools -> Ok (migrate_legacy_restricted_tools tools)
-        | Error msg -> Error msg)
-     | Some "preset" ->
-       let preset_raw =
-         Yojson.Safe.Util.member "preset" access_json |> Yojson.Safe.Util.to_string_option
-       in
-       (match preset_raw with
-        | None -> Error "keeper tool_access.preset required"
-        | Some raw ->
-          (match tool_preset_of_string raw with
-           | None -> Error (Printf.sprintf "invalid keeper tool_access.preset: %s" raw)
-           | Some preset ->
-             (match
-                string_list_field_opt_result
-                  ~field_name:"also_allow"
-                  ~label:"tool_access.also_allow"
-                  access_json
-              with
-              | Ok also_allow ->
-                Ok (normalize_tool_access (Preset { preset; also_allow }))
-              | Error msg -> Error msg)))
-     | Some "custom" ->
-       (match
-          string_list_field_result
-            ~field_name:"tools"
-            ~label:"tool_access.tools"
-            access_json
-        with
-        | Ok tools -> Ok (normalize_tool_access (Custom tools))
-        | Error msg -> Error msg)
-     | Some other -> Error (Printf.sprintf "invalid keeper tool_access.kind: %s" other)
-     | None -> Error "keeper tool_access.kind required")
-  | _ -> Error "keeper tool_access must be an object"
-;;
-
-let tool_access_of_meta_json (json : Yojson.Safe.t) =
-  match Yojson.Safe.Util.member "tool_access" json with
-  | `Null -> Ok (default_tool_access_of_meta_json ())
-  | `Assoc _ as access_json ->
-    let kind =
-      Yojson.Safe.Util.member "kind" access_json |> Yojson.Safe.Util.to_string_option
-    in
-    (match kind with
-     | Some "preset" ->
-       let preset_raw =
-         Yojson.Safe.Util.member "preset" access_json |> Yojson.Safe.Util.to_string_option
-       in
-       (match preset_raw with
-        | None -> Error "keeper tool_access.preset required"
-        | Some raw ->
-          (match tool_preset_of_string raw with
-           | None -> Error (Printf.sprintf "invalid keeper tool_access.preset: %s" raw)
-           | Some preset ->
-             (match
-                string_list_field_opt_result
-                  ~field_name:"also_allow"
-                  ~label:"tool_access.also_allow"
-                  access_json
-              with
-              | Ok also_allow ->
-                Ok (normalize_tool_access (Preset { preset; also_allow }))
-              | Error msg -> Error msg)))
-     | Some "custom" ->
-       (match
-          string_list_field_result
-            ~field_name:"tools"
-            ~label:"tool_access.tools"
-            access_json
-        with
-        | Ok tools -> Ok (normalize_tool_access (Custom tools))
-        | Error msg -> Error msg)
-     | Some other -> Error (Printf.sprintf "invalid keeper tool_access.kind: %s" other)
-     | None -> Error "keeper tool_access.kind required")
-  | _ -> Error "keeper tool_access must be an object"
-;;
+let scheduled_autonomous_cycle_outcome_to_string = proactive_cycle_outcome_to_string
+let scheduled_autonomous_cycle_outcome_of_string = proactive_cycle_outcome_of_string
 
 (* -- Updater helpers for nested record updates -- *)
 
@@ -628,13 +335,23 @@ let map_usage (f : usage_metrics -> usage_metrics) (m : keeper_meta) : keeper_me
 ;;
 
 let zero_usage : usage_metrics =
-  { total_turns = 0; total_input_tokens = 0; total_output_tokens = 0
-  ; total_tokens = 0; total_cost_usd = 0.0; last_turn_ts = 0.0
-  ; last_model_used = ""; last_input_tokens = 0; last_output_tokens = 0
-  ; last_total_tokens = 0; last_latency_ms = 0 }
+  { total_turns = 0
+  ; total_input_tokens = 0
+  ; total_output_tokens = 0
+  ; total_tokens = 0
+  ; total_cost_usd = 0.0
+  ; last_turn_ts = 0.0
+  ; last_model_used = ""
+  ; last_input_tokens = 0
+  ; last_output_tokens = 0
+  ; last_total_tokens = 0
+  ; last_latency_ms = 0
+  }
+;;
 
 let reset_runtime_state (m : keeper_meta) : keeper_meta =
   map_usage (fun _ -> zero_usage) m
+;;
 
 let map_compaction_rt (f : compaction_runtime -> compaction_runtime) (m : keeper_meta)
   : keeper_meta
@@ -648,9 +365,6 @@ let map_proactive_rt (f : proactive_runtime -> proactive_runtime) (m : keeper_me
   { m with runtime = { m.runtime with proactive_rt = f m.runtime.proactive_rt } }
 ;;
 
-let map_scheduled_autonomous_rt =
-  map_proactive_rt
-;;
-
+let map_scheduled_autonomous_rt = map_proactive_rt
 let now_iso () = Types.now_iso ()
 let keeper_legacy_model_arg_names = [ "models"; "allowed_models"; "active_model" ]

--- a/lib/keeper/keeper_meta_tool_access.ml
+++ b/lib/keeper/keeper_meta_tool_access.ml
@@ -1,0 +1,299 @@
+(** Keeper meta tool-access contract and JSON helpers.
+
+    Included by [Keeper_meta_contract] so [Keeper_types.*] keeps the same
+    public API while tool preset/access policy is isolated from the broader
+    keeper meta runtime contract. *)
+
+open Keeper_types_profile
+
+type tool_preset =
+  | Minimal
+  | Social
+  | Messaging
+  | Dispatch
+  | Coding
+  | Research
+  | Delivery
+  | Full
+
+type tool_access =
+  | Preset of
+      { preset : tool_preset
+      ; also_allow : string list
+      }
+  | Custom of string list
+
+let tool_names_include_board name_list =
+  List.exists
+    (fun name ->
+       String.starts_with ~prefix:"keeper_board_" name
+       || String.starts_with ~prefix:"masc_board_" name)
+    name_list
+;;
+
+let tool_access_default_room_signal_prompt_enabled ~default = function
+  | Preset { preset = Minimal; also_allow } ->
+    default || tool_names_include_board also_allow
+  | Preset _ -> true
+  | Custom tool_names -> tool_names_include_board tool_names
+;;
+
+let normalize_tool_names names =
+  names
+  |> List.map String.trim
+  |> List.filter (fun name -> name <> "")
+  |> dedupe_keep_order
+;;
+
+let legacy_keeper_internal_tool_names =
+  (* Keep legacy masc coordination defaults explicit in
+     [legacy_session_min_tool_names]; new [masc_*] internal tools should not
+     silently expand missing [tool_access] migrations. *)
+  Tool_catalog.tools_for_surface Tool_catalog.Keeper_internal
+  |> List.filter (fun name -> not (String.starts_with ~prefix:"masc_" name))
+;;
+
+let legacy_session_min_tool_names =
+  (* Legacy keepers historically received canonical masc_* coordination tools,
+     not the SDK alias-heavy Session_min surface. Keep this compatibility list
+     explicit so missing tool_access migration remains stable after tier removal. *)
+  List.map
+    Tool_name.Masc.to_string
+    Tool_name.Masc.
+      [ Status; Tasks; Claim_next; Plan_set_task; Transition; Add_task; Broadcast ]
+;;
+
+let migrate_legacy_restricted_tools names =
+  Custom (normalize_tool_names (legacy_keeper_internal_tool_names @ names))
+;;
+
+let tool_preset_to_string = function
+  | Minimal -> "minimal"
+  | Social -> "social"
+  | Messaging -> "messaging"
+  | Dispatch -> "dispatch"
+  | Coding -> "coding"
+  | Research -> "research"
+  | Delivery -> "delivery"
+  | Full -> "full"
+;;
+
+(** Issue #8430: schema enums for [tool_preset] in [keeper_schema.ml]
+    used to be hand-rolled and dropped [Social] and [Delivery] — a live
+    correctness bug since callers reading the schema could not discover
+    those values exist. Same Variant SSOT class as #8354 / #8392. All
+    constructors are nullary so the simple [List.map] trick works.
+    Adding an 8th constructor will fail compilation in
+    [tool_preset_to_string] and in the witness test. *)
+let all_tool_presets =
+  [ Minimal; Social; Messaging; Dispatch; Coding; Research; Delivery; Full ]
+;;
+
+let valid_tool_preset_strings = List.map tool_preset_to_string all_tool_presets
+
+let tool_preset_of_string raw =
+  match String.trim (String.lowercase_ascii raw) with
+  | "minimal" -> Some Minimal
+  | "social" -> Some Social
+  | "messaging" -> Some Messaging
+  | "dispatch" -> Some Dispatch
+  | "coding" -> Some Coding
+  | "research" -> Some Research
+  | "delivery" -> Some Delivery
+  | "full" -> Some Full
+  | _ -> None
+;;
+
+let normalize_tool_access = function
+  | Preset { preset; also_allow } ->
+    Preset { preset; also_allow = normalize_tool_names also_allow }
+  | Custom names -> Custom (normalize_tool_names names)
+;;
+
+let tool_access_preset = function
+  | Preset { preset; _ } -> Some preset
+  | Custom _ -> None
+;;
+
+let tool_access_custom_allowlist = function
+  | Preset _ -> None
+  | Custom names -> Some names
+;;
+
+let tool_access_also_allowlist = function
+  | Preset { also_allow; _ } -> also_allow
+  | Custom _ -> []
+;;
+
+let tool_access_to_json access =
+  match normalize_tool_access access with
+  | Preset { preset; also_allow } ->
+    `Assoc
+      [ "kind", `String "preset"
+      ; "preset", `String (tool_preset_to_string preset)
+      ; "also_allow", `List (List.map (fun s -> `String s) also_allow)
+      ]
+  | Custom names ->
+    `Assoc
+      [ "kind", `String "custom"; "tools", `List (List.map (fun s -> `String s) names) ]
+;;
+
+let json_member_present key (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc fields -> List.mem_assoc key fields
+  | _ -> false
+;;
+
+let string_list_field_result ?label ~field_name (json : Yojson.Safe.t) =
+  let label = Option.value ~default:field_name label in
+  match Yojson.Safe.Util.member field_name json with
+  | `List items ->
+    let rec collect acc index = function
+      | [] -> Ok (List.rev acc)
+      | `String value :: rest -> collect (value :: acc) (index + 1) rest
+      | _ :: _ -> Error (Printf.sprintf "keeper %s[%d] must be a string" label index)
+    in
+    collect [] 0 items
+  | `Null -> Error (Printf.sprintf "keeper %s must be an array of strings" label)
+  | _ -> Error (Printf.sprintf "keeper %s must be an array of strings" label)
+;;
+
+let string_list_field_opt_result ?label ~field_name (json : Yojson.Safe.t) =
+  match Yojson.Safe.Util.member field_name json with
+  | `Null -> Ok []
+  | _ -> string_list_field_result ?label ~field_name json
+;;
+
+let parse_tool_preset_projection (json : Yojson.Safe.t) =
+  let preset_member = Yojson.Safe.Util.member "tool_preset" json in
+  match preset_member with
+  | `String raw ->
+    (match tool_preset_of_string raw with
+     | Some preset -> Ok preset
+     | None -> Error (Printf.sprintf "invalid keeper tool_preset: %s" raw))
+  | `Null -> Error "keeper tool_preset required"
+  | _ -> Error "keeper tool_preset must be a string"
+;;
+
+let default_tool_access_of_meta_json () =
+  migrate_legacy_restricted_tools legacy_session_min_tool_names
+;;
+
+let legacy_tool_access_projection_of_meta_json (json : Yojson.Safe.t) =
+  let custom_present = json_member_present "tool_custom_allowlist" json in
+  let preset_present = json_member_present "tool_preset" json in
+  let also_allow_present = json_member_present "tool_also_allow" json in
+  let legacy_allowlist_present = json_member_present "tool_allowlist" json in
+  if custom_present
+  then (
+    match string_list_field_result ~field_name:"tool_custom_allowlist" json with
+    | Ok tools -> Ok (normalize_tool_access (Custom tools))
+    | Error msg -> Error msg)
+  else if preset_present || also_allow_present
+  then (
+    match parse_tool_preset_projection json with
+    | Error msg -> Error msg
+    | Ok preset ->
+      (match string_list_field_opt_result ~field_name:"tool_also_allow" json with
+       | Ok also_allow -> Ok (normalize_tool_access (Preset { preset; also_allow }))
+       | Error msg -> Error msg))
+  else if legacy_allowlist_present
+  then (
+    match string_list_field_result ~field_name:"tool_allowlist" json with
+    | Ok names -> Ok (migrate_legacy_restricted_tools names)
+    | Error msg -> Error msg)
+  else Ok (default_tool_access_of_meta_json ())
+;;
+
+let legacy_tool_access_of_meta_json (json : Yojson.Safe.t) =
+  match Yojson.Safe.Util.member "tool_access" json with
+  | `Null -> legacy_tool_access_projection_of_meta_json json
+  | `Assoc _ as access_json ->
+    let kind =
+      Yojson.Safe.Util.member "kind" access_json |> Yojson.Safe.Util.to_string_option
+    in
+    (match kind with
+     | Some "unrestricted" ->
+       Ok (Preset { preset = Full; also_allow = [] } |> normalize_tool_access)
+     | Some "restricted" ->
+       (match
+          string_list_field_opt_result
+            ~field_name:"tools"
+            ~label:"tool_access.tools"
+            access_json
+        with
+        | Ok tools -> Ok (migrate_legacy_restricted_tools tools)
+        | Error msg -> Error msg)
+     | Some "preset" ->
+       let preset_raw =
+         Yojson.Safe.Util.member "preset" access_json |> Yojson.Safe.Util.to_string_option
+       in
+       (match preset_raw with
+        | None -> Error "keeper tool_access.preset required"
+        | Some raw ->
+          (match tool_preset_of_string raw with
+           | None -> Error (Printf.sprintf "invalid keeper tool_access.preset: %s" raw)
+           | Some preset ->
+             (match
+                string_list_field_opt_result
+                  ~field_name:"also_allow"
+                  ~label:"tool_access.also_allow"
+                  access_json
+              with
+              | Ok also_allow ->
+                Ok (normalize_tool_access (Preset { preset; also_allow }))
+              | Error msg -> Error msg)))
+     | Some "custom" ->
+       (match
+          string_list_field_result
+            ~field_name:"tools"
+            ~label:"tool_access.tools"
+            access_json
+        with
+        | Ok tools -> Ok (normalize_tool_access (Custom tools))
+        | Error msg -> Error msg)
+     | Some other -> Error (Printf.sprintf "invalid keeper tool_access.kind: %s" other)
+     | None -> Error "keeper tool_access.kind required")
+  | _ -> Error "keeper tool_access must be an object"
+;;
+
+let tool_access_of_meta_json (json : Yojson.Safe.t) =
+  match Yojson.Safe.Util.member "tool_access" json with
+  | `Null -> Ok (default_tool_access_of_meta_json ())
+  | `Assoc _ as access_json ->
+    let kind =
+      Yojson.Safe.Util.member "kind" access_json |> Yojson.Safe.Util.to_string_option
+    in
+    (match kind with
+     | Some "preset" ->
+       let preset_raw =
+         Yojson.Safe.Util.member "preset" access_json |> Yojson.Safe.Util.to_string_option
+       in
+       (match preset_raw with
+        | None -> Error "keeper tool_access.preset required"
+        | Some raw ->
+          (match tool_preset_of_string raw with
+           | None -> Error (Printf.sprintf "invalid keeper tool_access.preset: %s" raw)
+           | Some preset ->
+             (match
+                string_list_field_opt_result
+                  ~field_name:"also_allow"
+                  ~label:"tool_access.also_allow"
+                  access_json
+              with
+              | Ok also_allow ->
+                Ok (normalize_tool_access (Preset { preset; also_allow }))
+              | Error msg -> Error msg)))
+     | Some "custom" ->
+       (match
+          string_list_field_result
+            ~field_name:"tools"
+            ~label:"tool_access.tools"
+            access_json
+        with
+        | Ok tools -> Ok (normalize_tool_access (Custom tools))
+        | Error msg -> Error msg)
+     | Some other -> Error (Printf.sprintf "invalid keeper tool_access.kind: %s" other)
+     | None -> Error "keeper tool_access.kind required")
+  | _ -> Error "keeper tool_access must be an object"
+;;


### PR DESCRIPTION
## Summary
- split keeper meta tool preset/access parsing into Keeper_meta_tool_access while keeping Keeper_meta_contract as the public facade
- keep legacy missing-tool_access migration stable by making masc coordination defaults explicit
- handle keeper bridge masc_code_read through the meta-aware read resolver so Docker sandbox-relative paths keep working

## Validation
- git diff --check origin/main...HEAD
- ocamlformat --check lib/keeper/keeper_exec_masc.ml lib/keeper/keeper_meta_contract.ml lib/keeper/keeper_meta_tool_access.ml
- scripts/check-boundary-guard.sh
- ./scripts/check-oas-pin.sh --local-only
- env MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 ./scripts/dune-local.sh build ./test/test_types.exe ./test/test_keeper_masc_bridge.exe ./test/test_keeper_tool_exposure.exe ./test/test_keeper_runtime_config_ssot.exe ./test/test_keeper_toml.exe ./test/test_tool_access_policy.exe
- env MASC_BASE_PATH=/tmp/masc-test-meta-tool-access-types ./_build/default/test/test_types.exe
- env MASC_BASE_PATH=/tmp/masc-test-meta-tool-access-bridge ./_build/default/test/test_keeper_masc_bridge.exe
- env MASC_BASE_PATH=/tmp/masc-test-meta-tool-access-exposure ./_build/default/test/test_keeper_tool_exposure.exe
- env MASC_BASE_PATH=/tmp/masc-test-meta-tool-access-ssot ./_build/default/test/test_keeper_runtime_config_ssot.exe
- env MASC_BASE_PATH=/tmp/masc-test-meta-tool-access-toml ./_build/default/test/test_keeper_toml.exe
- env MASC_BASE_PATH=/tmp/masc-test-meta-tool-access-policy ./_build/default/test/test_tool_access_policy.exe