### PR TITLE
observability(keeper): warn when CLI providers run without claude_mcp_config

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1872,6 +1872,30 @@ let run_turn
           Keeper_runtime_resolved.oas_timeout_for_estimated_input_tokens
             ~estimated_input_tokens
     in
+    (* Observability for issue #10049: CLI-backed providers
+       (claude_code, kimi_cli) need claude_mcp_config to reach the masc-mcp
+       HTTP MCP endpoint; otherwise the MCP tool catalog is invisible to
+       the subprocess and the model will correctly report that no shell
+       tools are bound. Codex CLI has a separate sync path
+       (MASC_SYNC_CODEX_MCP_CONFIG) so it is not affected. *)
+    (if keeper_oas_context.claude_mcp_config = None then
+       let uses_cli_missing_sync =
+         List.exists
+           (fun label ->
+              let lbl = String.lowercase_ascii label in
+              let starts p =
+                String.length lbl >= String.length p
+                && String.equal (String.sub lbl 0 (String.length p)) p
+              in
+              starts "claude_code" || starts "kimi_cli")
+           meta.models
+       in
+       if uses_cli_missing_sync then
+         Log.Keeper.warn
+           "keeper %s (cascade=%s): cli-backed providers selected but \
+            claude_mcp_config is None; MCP tool catalog will not be \
+            visible to the subprocess (see issue #10049 for fix plan)"
+           meta.name cascade_name);
     let cli_transport_overrides =
       Some
         ({


### PR DESCRIPTION
## Summary

Surfaces a silent configuration gap identified in #10049: keepers whose cascade resolves to `claude_code` or `kimi_cli` have no way to reach the masc-mcp HTTP MCP endpoint unless `claude_mcp_config` is set. Without it the MCP tool catalog (keeper_shell, keeper_fs_*, etc.) is invisible to the model and the keeper correctly refuses any tool-requiring task.

This PR adds **one warning log** at the point where \`cli_transport_overrides\` is built in \`lib/keeper/keeper_agent_run.ml\`:

- triggers when \`keeper_oas_context.claude_mcp_config = None\`
- AND the keeper's \`meta.models\` includes a label prefixed with \`claude_code\` or \`kimi_cli\`

No behaviour change. This is purely an observability breadcrumb so operators notice the misconfiguration in logs instead of discovering it via keeper refusals.

## Product impact

- Promise level: ops visibility (Supporting).
- Zero runtime cost in the common path (claude_mcp_config set): the outer \`if\` short-circuits.
- When the warning fires, it emits once per reactive turn for affected keepers; that is the correct cadence while the root-cause fix is pending.

## Why not fix the root cause in this PR

The root-cause fix (proposed option C in #10049 — auto-construct the MCP config JSON from base_path + agent bearer token) is security-sensitive: it reads the keeper's bearer token from disk and injects it into the subprocess environment. That deserves its own review and tests. This PR lands the observability hook first so the fix PR has a regression canary to point at.

## Evidence

Local on \`.worktrees/feat-cli-mcp-observability\` (commit \`8a4153b42\`, base \`main@8f70eec6e\`):

- \`dune build @check --root .\` → pass
- \`test/test_keeper_prompt_metrics.exe\` → 9/9 pass (no regression on the system-prompt harness)
- \`git diff --stat\` → \`1 file changed, 24 insertions(+), 0 deletions(-)\`

Empirical setup that motivated this (full data in \`memory/procedural-memory/2026-04-25-keeper-prompt-dedup-evidence-record.md\`):

| Keeper | Cascade | Providers | claude_mcp_config | Behaviour |
|---|---|---|---|---|
| sangsu | tool_use_strict | claude_code + kimi_cli | \`None\` | Refused: \"keeper_shell not in tool registry\" |
| masc-improver | tool_use_strict | claude_code + kimi_cli | \`None\` | Identical refusal |
| issue_king | big_three | codex_cli | (covered by Codex sync) | **Attempted \`git clone\`**, blocked by sandbox permission |

With this PR merged, the first two would emit a warning per turn pointing at #10049.

## Review evidence

Best Programmer self-review:
- Goal: make an existing silent gap observable. One log line, no state change.
- Non-goals: fix the root cause, add new tests around model-label parsing (the lowercase-prefix check is standard and used elsewhere in the file).
- Local checks: build + targeted test green.
- Unverified: how noisy the warning will be in production-scale log volume. Cadence is per reactive turn of an affected keeper, bounded by the keeper-scheduler budget.

## Linked issue

- Closes (partially): #10049 — observability track
- Full root-cause fix: tracked in same issue under option C; separate PR to follow.

Promise: ops visibility