### PR TITLE
feat(keeper-metrics): surface metric-emit drops as Prometheus counter (#10047)

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -492,6 +492,18 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                with
                | Eio.Cancel.Cancelled _ as e -> raise e
                | exn ->
+                   (* #10047: surface the drop as a Prometheus counter so
+                      dashboards can alert when state advances without a
+                      matching metric record. The log alone was too easy
+                      to miss and operators trusted metric jsonl as
+                      ground truth. *)
+                   Prometheus.inc_counter
+                     Prometheus.metric_keeper_metric_emit_dropped
+                     ~labels:[
+                       ("keeper", updated_meta.name);
+                       ("channel", "turn");
+                       ("site", "keeper_turn_msg");
+                     ] ();
                    Log.Keeper.error
                      "write metrics snapshot failed after keeper_msg turn: %s"
                      (Printexc.to_string exn));

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1851,6 +1851,24 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           with
            | Eio.Cancel.Cancelled _ as e -> raise e
            | exn ->
+               (* #10047: surface drop as a Prometheus counter so
+                  dashboards can alert when state advances without a
+                  matching metric record (keeper was running but jsonl
+                  shows no turn). *)
+               let channel =
+                 if observation.pending_mentions <> []
+                    || observation.pending_board_events <> []
+                    || observation.pending_scope_messages <> []
+                 then "turn"
+                 else "scheduled_autonomous"
+               in
+               Prometheus.inc_counter
+                 Prometheus.metric_keeper_metric_emit_dropped
+                 ~labels:[
+                   ("keeper", updated_meta.Keeper_types.name);
+                   ("channel", channel);
+                   ("site", "keeper_unified_turn");
+                 ] ();
                Log.Keeper.error
                  "write metrics snapshot failed after keeper cycle: %s"
                  (Printexc.to_string exn));

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -187,6 +187,14 @@ let metric_keeper_cache_read_tokens =
 let metric_keeper_usage_anomalies =
   "masc_keeper_usage_anomalies_total"
 
+(* #10047: [append_metrics_snapshot] failures in [keeper_turn.ml] and
+   [keeper_unified_turn.ml] used to be log-only, masking state/metric
+   divergence. Surface as a counter so dashboards can alert on silent
+   metric drops and operators stop trusting metric jsonl as ground
+   truth when keepers are running. *)
+let metric_keeper_metric_emit_dropped =
+  "masc_keeper_metric_emit_dropped_total"
+
 (* Keeper compaction (keeper_compact_policy.ml, tool_keeper.ml). *)
 let metric_keeper_compactions = "masc_keeper_compactions_total"
 let metric_keeper_compaction_ratio_change =

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -74,6 +74,7 @@ val metric_keeper_output_tokens : string
 val metric_keeper_cache_creation_tokens : string
 val metric_keeper_cache_read_tokens : string
 val metric_keeper_usage_anomalies : string
+val metric_keeper_metric_emit_dropped : string
 val metric_keeper_compactions : string
 val metric_keeper_compaction_ratio_change : string
 val metric_keeper_compaction_saved_tokens : string


### PR DESCRIPTION
## 요약

`append_metrics_snapshot` 실패가 log-only로 swallow되어 state JSON은 전진하지만 metric jsonl엔 turn 기록 누락. 운영자가 "silent keeper"로 오진. **Option D (minimum): Prometheus drop counter 추가**로 관측 가능성 복구.

Closes #10047 (observability-level fix).

## 증상

- 2026-04-25 01:33 KST qa-king/nick0cave: state `last_turn_ts`는 rebuild 후 수 차례 업데이트되었지만 metric jsonl post-rebuild turn records 0건.
- Dashboard, fleet latency histogram, cost aggregation이 turn을 못 봄 → false-low 숫자.

## 근본 원인

두 swallow 사이트:

`lib/keeper/keeper_turn.ml:494-497`:
```ocaml
with
| Eio.Cancel.Cancelled _ as e -> raise e
| exn ->
    Log.Keeper.error "write metrics snapshot failed after keeper_msg turn: %s" ...
```

`lib/keeper/keeper_unified_turn.ml:1853-1856`: 동일 패턴.

`write_meta` 성공 + `append_metrics_snapshot` 예외 → state/metric divergence (atomicity 위반).

## 변경 내용

### 1. 새 Prometheus counter

`lib/prometheus.ml` + `.mli`:

```ocaml
let metric_keeper_metric_emit_dropped =
  "masc_keeper_metric_emit_dropped_total"
```

### 2. 두 swallow 사이트에서 counter 증가

`keeper_turn.ml` (keeper_msg turn):
```ocaml
Prometheus.inc_counter Prometheus.metric_keeper_metric_emit_dropped
  ~labels:[
    ("keeper", updated_meta.name);
    ("channel", "turn");
    ("site", "keeper_turn_msg");
  ] ();
Log.Keeper.error "..." ...
```

`keeper_unified_turn.ml` (scheduled_autonomous / turn):
```ocaml
let channel = if observation has_pending then "turn" else "scheduled_autonomous" in
Prometheus.inc_counter Prometheus.metric_keeper_metric_emit_dropped
  ~labels:[("keeper", ...); ("channel", channel); ("site", "keeper_unified_turn")] ();
Log.Keeper.error "..." ...
```

기존 log 경로 유지.

## 검증

```bash
$ dune build @check --root .
(exit 0)
```

## 회귀 리스크

매우 낮음 — counter 증가는 부수 작용. 기존 error log 경로 불변. 성공 경로는 counter 증가 안 함.

## Out of scope

이슈가 제시한 4개 옵션 중:
- **Option A (fail-fast)**: `write_meta` 롤백 또는 keeper degraded state — 아토미시티 요구, 더 큰 refactor
- **Option B (queued retry)**: in-memory queue + 다음 tick retry — 재시도 semantics 설계 필요
- **Option C (atomic transaction)**: state + metric 단일 write — 파일 포맷 변경

본 PR은 **Option D**만 처리. A/B/C는 별도 이슈로 분리 권장.

## 대시보드 활용

```
sum by (keeper) (rate(masc_keeper_metric_emit_dropped_total[5m])) > 0
```

Alert rule로 "state가 돌아가는데 metric이 안 찍히는 keeper" 즉시 감지 가능.

## 참고

- Issue #10047 — 증상 및 4가지 fix options
- 관련 #10018 (heartbeat stale-copy), #10008 (cohort failure)
