### PR TITLE
[codex] Repair MASC/OAS telemetry flow

### DIFF
--- a/docs/qa/MASC-OAS-TELEMETRY-FLOW-AUDIT-2026-04-25.json
+++ b/docs/qa/MASC-OAS-TELEMETRY-FLOW-AUDIT-2026-04-25.json
@@ -1,0 +1,105 @@
+{
+  "audit_id": "masc-oas-telemetry-flow-audit-2026-04-25",
+  "checked_at": "2026-04-25T00:00:00+09:00",
+  "scope": "MASC keeper telemetry flow from OAS tool execution into dashboard surfaces",
+  "boundary": {
+    "oas": "generic agent/run/tool/proof truth",
+    "masc": "keeper/task/goal/sandbox/approval/runtime-radius semantics",
+    "oas_patch_made": false
+  },
+  "before_snapshot": {
+    "observed_at": "2026-04-24T16:16:28Z",
+    "sources": [
+      { "source": "oas_event", "state": "fresh" },
+      { "source": "agent_event", "state": "fresh" },
+      { "source": "keeper_metric", "state": "fresh" },
+      { "source": "tool_call_io", "state": "fresh" },
+      { "source": "tool_metric", "state": "stale", "latest_age_approx_s": 2040 },
+      { "source": "tool_usage", "state": "stale", "latest_age_approx_s": 15120 }
+    ]
+  },
+  "implemented": {
+    "runtime_contract": true,
+    "action_radius": true,
+    "trajectory_post_tool_rows": true,
+    "trajectory_gate_decode": true,
+    "coverage_gap_store": true,
+    "unified_source_health": true
+  },
+  "surfaces": [
+    {
+      "surface": "/api/v1/keepers/:name/tool-calls",
+      "producer": "keeper_hooks_oas.post_tool_use",
+      "durable_store": ".masc/tool_calls/YYYY-MM/DD.jsonl",
+      "status": "contract_and_action_radius_added"
+    },
+    {
+      "surface": "/api/v1/keepers/:name/tool-stats",
+      "producer": "keeper_hooks_oas.post_tool_use",
+      "durable_store": ".masc/trajectories/<keeper>/<trace>.jsonl",
+      "status": "trajectory_tool_call_rows_added"
+    },
+    {
+      "surface": "/api/v1/dashboard/execution-trust",
+      "producer": "keeper_agent_run.execution_receipt",
+      "durable_store": ".masc/keepers/<keeper>/execution-receipts",
+      "status": "contract_and_action_radius_added"
+    },
+    {
+      "surface": "/api/v1/dashboard/telemetry/summary",
+      "producer": "Telemetry_unified.summary_json",
+      "durable_store": "unified read side",
+      "status": "source_health_and_coverage_gaps_added"
+    }
+  ],
+  "oas_audit": {
+    "patched": false,
+    "findings": [
+      "EventBus envelope already has correlation_id, run_id, and caused_by.",
+      "ToolCalled and ToolCompleted propagate correlation_id/run_id and completion caused_by.",
+      "Event forwarding preserves correlation_id, run_id, and caused_by.",
+      "Raw_trace remains generic with worker_run_id/session_id.",
+      "Runtime evidence carries raw_trace_run_id through participant outcomes."
+    ]
+  },
+  "verification": {
+    "masc_build": {
+      "command": "scripts/dune-local.sh build test/test_trajectory.exe test/test_keeper_tool_call_log.exe test/test_dashboard_keeper_routes.exe test/test_dashboard_execution.exe test/test_telemetry_unified.exe test/test_telemetry_eio_coverage.exe",
+      "status": "passed"
+    },
+    "test_binaries": [
+      { "command": "_build/default/test/test_trajectory.exe", "status": "passed" },
+      { "command": "_build/default/test/test_keeper_tool_call_log.exe", "status": "passed" },
+      { "command": "env MASC_BASE_PATH=/tmp/masc-test-dashboard-keeper-routes _build/default/test/test_dashboard_keeper_routes.exe", "status": "passed" },
+      { "command": "env MASC_BASE_PATH=/tmp/masc-test-dashboard-execution _build/default/test/test_dashboard_execution.exe", "status": "passed" },
+      { "command": "_build/default/test/test_telemetry_unified.exe", "status": "passed" },
+      { "command": "_build/default/test/test_telemetry_eio_coverage.exe", "status": "passed" }
+    ],
+    "dashboard_tests": {
+      "command": "pnpm --dir dashboard exec vitest run --no-file-parallelism --maxWorkers=1 src/components/keeper-tool-telemetry.test.ts src/components/telemetry-unified.test.ts src/api/dashboard.test.ts",
+      "status": "passed",
+      "files": 3,
+      "tests": 49
+    },
+    "dashboard_typecheck": {
+      "command": "pnpm --dir dashboard typecheck",
+      "status": "passed"
+    },
+    "dashboard_full_suite_note": "A package-script invocation with an extra argument separator ran the full dashboard suite and failed in unrelated locale-sensitive TimeAgo tests where Korean absolute-time text contained the excluded character.",
+    "live_keeper_turn_acceptance": "not_run"
+  },
+  "external_evidence": [
+    {
+      "claim": "OpenTelemetry GenAI semantic conventions are Development",
+      "source": "https://opentelemetry.io/docs/specs/semconv/gen-ai/",
+      "checked_at": "2026-04-25 KST",
+      "confidence": "High"
+    },
+    {
+      "claim": "MCP specification redirects to 2025-11-25",
+      "source": "https://modelcontextprotocol.io/specification",
+      "checked_at": "2026-04-25 KST",
+      "confidence": "High"
+    }
+  ]
+}

--- a/docs/qa/MASC-OAS-TELEMETRY-FLOW-AUDIT-2026-04-25.md
+++ b/docs/qa/MASC-OAS-TELEMETRY-FLOW-AUDIT-2026-04-25.md
@@ -1,0 +1,106 @@
+# MASC/OAS Telemetry Flow Audit
+
+Date: 2026-04-25 KST
+
+## Scope
+
+This audit covers the MASC-owned keeper telemetry repair between OAS tool execution and dashboard surfaces. OAS remains the generic agent/run/tool/proof substrate; MASC owns keeper/task/goal/sandbox/approval/runtime-radius semantics.
+
+## Before Snapshot
+
+The handoff snapshot from 2026-04-24T16:16:28Z showed the pipeline was partially flowing:
+
+| Source | State |
+| --- | --- |
+| `oas_event` | fresh |
+| `agent_event` | fresh |
+| `keeper_metric` | fresh |
+| `tool_call_io` | fresh |
+| `tool_metric` | stale by about 34 min |
+| `tool_usage` | stale by about 4.2 h |
+
+Primary mismatch: keeper/OAS tool calls reached `.masc/tool_calls`, but the trajectory-backed `/tool-stats` lane could miss the same executions, so `/tool-calls` and `/tool-stats` disagreed.
+
+## Implementation Result
+
+| Surface / Store | Producer | Durable Store | Result |
+| --- | --- | --- | --- |
+| `/api/v1/keepers/:name/tool-calls` | `keeper_hooks_oas.post_tool_use` | `.masc/tool_calls/YYYY-MM/DD.jsonl` | Full I/O rows now include `runtime_contract` and `action_radius`. |
+| `/api/v1/keepers/:name/tool-stats` | `keeper_hooks_oas.post_tool_use` | `.masc/trajectories/<keeper>/<trace>.jsonl` | Post-tool-use now records trajectory `Tool_call` rows when `trajectory_acc` exists. |
+| `/api/v1/dashboard/execution-trust` | `keeper_agent_run.execution_receipt` | `.masc/keepers/<keeper>/execution-receipts` | Execution receipts now include `runtime_contract` and `action_radius`. |
+| `/api/v1/dashboard/telemetry/summary` | `Telemetry_unified.summary_json` | all unified telemetry stores | Each source now reports `health`, `freshness_slo_s`, `producer`, `durable_store`, `dashboard_surface`, and `stale_reason`. |
+| `.masc/telemetry-coverage-gaps` | trajectory/receipt failure reporters | `.masc/telemetry-coverage-gaps/YYYY-MM/DD.jsonl` | Trajectory append and receipt append failures are durable coverage gaps. |
+
+## Runtime Contract
+
+Keeper tool-call logs, trajectory tool-call rows, execution receipts, and unified projections now use the same canonical nested fields where the producing lane has enough context:
+
+- `runtime_contract`: keeper/agent identity, trace/session/generation/turn, task/goal ids, sandbox/network/shared-memory/approval context, tool surface counts and required/missing tools, provider/model/cascade profile.
+- `action_radius`: tool/action key, target kind/path, sandbox target, observed path-like inputs, success, duration, and error.
+
+Existing top-level fields remain in place for backwards-compatible dashboard readers.
+
+## Gate Decoding
+
+Trajectory readers now parse the persisted `gate` object. Legacy rows without a readable gate remain readable as `Pass`, and `/tool-stats` reports `gate_decode.parsed_gate_count` and `gate_decode.legacy_default_count` so operators can see how much of the window is using legacy defaults.
+
+## OAS Boundary Audit
+
+No OAS patch was made. The audit found generic correlation already present at the OAS boundary:
+
+| Area | Evidence | Finding |
+| --- | --- | --- |
+| EventBus envelope | `lib/event_bus.mli` | `correlation_id`, `run_id`, and `caused_by` are generic envelope fields. |
+| Tool events | `lib/agent/agent_tools.ml` | `ToolCalled` and `ToolCompleted` propagate `correlation_id`, `run_id`, and completion `caused_by`. |
+| Event forwarding | `lib/event_forward.ml` | forwarded payloads preserve `correlation_id`, `run_id`, and `caused_by`. |
+| Raw trace | `lib/raw_trace.ml` | raw trace remains generic with `worker_run_id` and `session_id`; no MASC-specific fields were added. |
+| Runtime evidence | `lib/runtime_server_worker.ml`, `lib/runtime_server.ml` | participant success/failure events carry `raw_trace_run_id` through runtime evidence. |
+
+`Runtime_server_types.emit_event` publishes session-level runtime events with `correlation_id=session_id`; that path does not currently expose a per-participant `run_id`, so no MASC runtime fields were added there.
+
+## Known Provider Gaps
+
+Provider usage gaps remain data-source limitations, not MASC coverage failures. For example, providers/CLIs that do not report token usage should continue to be classified as `provider_unavailable` rather than a broken MASC telemetry lane.
+
+## Verification
+
+Focused MASC build:
+
+```sh
+scripts/dune-local.sh build test/test_trajectory.exe test/test_keeper_tool_call_log.exe test/test_dashboard_keeper_routes.exe test/test_dashboard_execution.exe test/test_telemetry_unified.exe test/test_telemetry_eio_coverage.exe
+```
+
+Result: passed.
+
+Focused binaries:
+
+```sh
+_build/default/test/test_trajectory.exe
+_build/default/test/test_keeper_tool_call_log.exe
+env MASC_BASE_PATH=/tmp/masc-test-dashboard-keeper-routes _build/default/test/test_dashboard_keeper_routes.exe
+env MASC_BASE_PATH=/tmp/masc-test-dashboard-execution _build/default/test/test_dashboard_execution.exe
+_build/default/test/test_telemetry_unified.exe
+_build/default/test/test_telemetry_eio_coverage.exe
+```
+
+Result: all passed. The two dashboard binaries require an explicit `/tmp` `MASC_BASE_PATH` because their startup guard rejects the home workspace as a test base path.
+
+Dashboard checks:
+
+```sh
+pnpm --dir dashboard exec vitest run --no-file-parallelism --maxWorkers=1 src/components/keeper-tool-telemetry.test.ts src/components/telemetry-unified.test.ts src/api/dashboard.test.ts
+pnpm --dir dashboard typecheck
+```
+
+Result: targeted telemetry/API tests passed (3 files, 49 tests) and typecheck passed. An earlier package-script invocation with an extra argument separator ran the full dashboard suite and hit an unrelated locale-sensitive `TimeAgo` assertion where the Korean absolute-time marker `오전` matched the test's `/전/` exclusion.
+
+Runtime acceptance with a fresh live keeper turn was not executed in this worktree. The code path is covered by focused tests and the next live acceptance check should confirm:
+
+- `/api/v1/dashboard/telemetry/summary` shows fresh `keeper_metric`, `tool_call_io`, and `oas_event`.
+- `/tool-stats` and `/tool-calls` agree on recent keeper tool executions.
+- A sample execution receipt and trajectory row both include `runtime_contract` and `action_radius`.
+
+## External Currentness Evidence
+
+- [근거] OpenTelemetry Generative AI semantic conventions are still marked `Development`; do not rename emitted fields to the latest experimental `gen_ai.*` names without a dedicated compatibility decision. Source: https://opentelemetry.io/docs/specs/semconv/gen-ai/ checked 2026-04-25 KST, confidence High.
+- [근거] The MCP specification URL currently redirects to `2025-11-25`; `/mcp`, sessions, roots, headers, and security behavior should be checked against that current spec before protocol naming changes. Source: https://modelcontextprotocol.io/specification checked 2026-04-25 KST, confidence High.

--- a/lib/dune
+++ b/lib/dune
@@ -286,6 +286,7 @@
    subsystem_health
    subscriptions
    telemetry_eio
+   telemetry_coverage_gap
    telemetry_unified
    tempo
    timeout_policy

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1688,6 +1688,7 @@ let run_turn
               in
               Keeper_tool_call_log.set_turn_context
                 ~keeper_name:meta.name
+                ~agent_name:meta.agent_name
                 ~lane
                 ?tool_choice:(Option.map
                   (fun choice ->
@@ -1698,19 +1699,27 @@ let run_turn
                 ?thinking_budget:current_params.thinking_budget
                 ~prompt_fingerprint:prompt_metrics.fingerprint
                 ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-	                ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-	                ~turn
-	                ~keeper_turn_id:turn
-	                ?task_id:(Option.map Keeper_id.Task_id.to_string (!meta_ref).current_task_id)
-	                ~goal_ids:meta.active_goal_ids
+                ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+                ~generation
+                ~turn
+                ~keeper_turn_id:turn
+                ?task_id:(Option.map Keeper_id.Task_id.to_string (!meta_ref).current_task_id)
+                ~goal_ids:meta.active_goal_ids
                 ~sandbox_profile:
                   (Keeper_types.sandbox_profile_to_string meta.sandbox_profile)
+                ~sandbox_root:(Keeper_sandbox.host_root_abs_of_meta ~config meta)
+                ~allowed_paths:(Keeper_alerting_path.effective_allowed_paths ~meta)
                 ~network_mode:
                   (Keeper_types.network_mode_to_string meta.network_mode)
                 ~shared_memory_scope:
                   (Keeper_types.shared_memory_scope_to_string
                      meta.shared_memory_scope)
                 ?approval_mode:approval_mode_effective
+                ~tool_surface_class:computed_surface.tool_surface_class
+                ~visible_tool_count:(List.length all_allowed)
+                ~required_tools:computed_surface.required_tool_names
+                ~missing_required_tools:computed_surface.missing_required_tool_names
+                ~cascade_profile:cascade_name
                 ();
               (* Tool disclosure telemetry: emitted after all allow-list rewrites
            (last-turn intersect, max_tools cap) so that
@@ -2767,6 +2776,29 @@ let run_turn
        Log.Keeper.warn
          "keeper:%s execution_receipt append failed: %s"
          meta.name
-         (Printexc.to_string exn));
+         (Printexc.to_string exn);
+       (try
+          let masc_root = Coord.masc_root_dir config in
+          Telemetry_coverage_gap.record
+            ~masc_root
+            ~source:"execution_receipt"
+            ~producer:"keeper_agent_run.execution_receipt"
+            ~durable_store:
+              (Filename.concat
+                 (Filename.concat (Filename.concat masc_root "keepers") meta.name)
+                 "execution-receipts")
+            ~dashboard_surface:"/api/v1/dashboard/execution-trust"
+            ~stale_reason:"execution_receipt_append_failed"
+            ~keeper_name:meta.name
+            ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+            ~error:(Printexc.to_string exn)
+            ()
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | gap_exn ->
+          Log.Keeper.warn
+            "keeper:%s execution_receipt coverage gap append failed: %s"
+            meta.name
+            (Printexc.to_string gap_exn)));
     turn_result
 ;;

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -95,6 +95,15 @@ let cascade_rotation_attempt_to_json attempt =
       ("recorded_at", `String attempt.recorded_at);
     ]
 
+let receipt_duration_ms receipt =
+  match
+    Types.parse_iso8601_opt receipt.started_at,
+    Types.parse_iso8601_opt receipt.ended_at
+  with
+  | Some started_at, Some ended_at ->
+    max 0.0 ((ended_at -. started_at) *. 1000.0)
+  | _ -> 0.0
+
 let string_contains_ci haystack needle =
   let haystack = String.lowercase_ascii haystack in
   let needle = String.lowercase_ascii needle in
@@ -185,6 +194,44 @@ let to_json (receipt : t) =
             | None -> `Null );
         ]
   in
+  let runtime_contract =
+    Keeper_runtime_contract.runtime_contract_json_from_fields
+      ~keeper_name:receipt.keeper_name
+      ~agent_name:receipt.agent_name
+      ~trace_id:receipt.trace_id
+      ~session_id:receipt.trace_id
+      ~generation:receipt.generation
+      ?keeper_turn_id:receipt.turn_count
+      ?task_id:receipt.current_task_id
+      ~goal_ids:receipt.goal_ids
+      ~sandbox_profile:receipt.sandbox_kind
+      ?sandbox_root:receipt.sandbox_root
+      ~network_mode:receipt.network_mode
+      ?approval_mode:receipt.approval_profile
+      ~tool_surface_class:receipt.tool_surface.tool_surface_class
+      ~visible_tool_count:receipt.tool_surface.visible_tool_count
+      ~required_tools:receipt.tool_surface.required_tools
+      ~missing_required_tools:receipt.tool_surface.missing_required_tools
+      ?model:receipt.model_used
+      ~cascade_profile:receipt.cascade_name
+      ()
+  in
+  let action_radius =
+    Keeper_runtime_contract.action_radius_json
+      ~tool_name:"keeper_turn"
+      ~input:
+        (`Assoc
+           [
+             ("action", `String "run_turn");
+             ("target_kind", `String "keeper");
+             ("target_path", string_opt_json receipt.sandbox_root);
+           ])
+      ~success:(String.equal receipt.outcome "ok")
+      ~duration_ms:(receipt_duration_ms receipt)
+      ?error:receipt.error_message
+      ~sandbox_target:receipt.sandbox_kind
+      ()
+  in
   `Assoc
     [
       ("schema", `String "keeper.execution_receipt.v1");
@@ -206,6 +253,8 @@ let to_json (receipt : t) =
       ("terminal_reason_code", `String receipt.terminal_reason_code);
       ("operator_disposition", `String operator_disposition);
       ("operator_disposition_reason", `String operator_disposition_reason);
+      ("runtime_contract", runtime_contract);
+      ("action_radius", action_radius);
       ("response_text_present", `Bool receipt.response_text_present);
       ( "model_used",
         match receipt.model_used with

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -672,6 +672,70 @@ let make_hooks
              ?shared_memory_scope ?approval_mode
              ~result_bytes ?truncated_to ()
          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+        (match trajectory_acc with
+         | None -> ()
+         | Some acc ->
+           let keeper_name = (!meta_ref).name in
+           let trace_id = acc.Trajectory.trace_id in
+           let safe_input =
+             Observability_redact.redact_json_value input
+           in
+           let safe_output =
+             Observability_redact.redact_preview
+               ~max_len:4000
+               output_text
+           in
+           let runtime_contract =
+             Keeper_tool_call_log.runtime_contract_json_for_call
+               ~keeper_name
+               ~model
+               ()
+           in
+           let action_radius =
+             Keeper_tool_call_log.action_radius_json_for_call
+               ~keeper_name
+               ~tool_name
+               ~input:safe_input
+               ~success:(outcome = "ok")
+               ~duration_ms
+               ?error:(if outcome = "ok" then None else Some safe_output)
+               ()
+           in
+           let now = Time_compat.now () in
+           let entry : Trajectory.tool_call_entry =
+             {
+               ts = now;
+               ts_iso = Types.iso8601_of_unix_seconds now;
+               turn = acc.Trajectory.turn;
+               round = Trajectory.calls_in_current_turn acc + 1;
+               tool_name;
+               args_json = Yojson.Safe.to_string safe_input;
+               gate_decision = Trajectory.Pass;
+               result = Some safe_output;
+               duration_ms = int_of_float (Float.round duration_ms);
+               error = (if outcome = "ok" then None else Some safe_output);
+               cost_usd = Trajectory.tool_cost_estimate tool_name;
+             }
+           in
+           Trajectory.record_entry
+             ~runtime_contract
+             ~action_radius
+             ~on_persist_error:(fun exn ->
+               Telemetry_coverage_gap.record
+                 ~masc_root:acc.Trajectory.masc_root
+                 ~source:"trajectory_tool_call"
+                 ~producer:"keeper_hooks_oas.post_tool_use"
+                 ~durable_store:
+                   (Trajectory.trajectory_path acc.Trajectory.masc_root
+                      acc.Trajectory.keeper_name trace_id)
+                 ~dashboard_surface:"/api/v1/keepers/:name/tool-stats"
+                 ~stale_reason:"trajectory_append_failed"
+                 ~keeper_name
+                 ~trace_id
+                 ~error:(Printexc.to_string exn)
+                 ())
+             acc
+             entry);
         (try
            on_tool_executed
              ~tool_name

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -81,6 +81,152 @@ let approval_policy_effective_json ?config (meta : keeper_meta) =
   in
   Keeper_approval_queue.policy_summary_json ~base_path ~keeper_name:meta.name
 
+let string_opt_json = function
+  | Some value when String.trim value <> "" -> `String value
+  | _ -> `Null
+
+let int_opt_json = function
+  | Some value -> `Int value
+  | None -> `Null
+
+let string_list_json values =
+  `List (List.map (fun value -> `String value) values)
+
+let nonempty_list = function
+  | Some values -> values
+  | None -> []
+
+let provider_of_model = function
+  | None -> None
+  | Some model -> (
+      let model = String.trim model in
+      if model = "" then None
+      else
+        match String.index_opt model ':' with
+        | Some idx when idx > 0 -> Some (String.sub model 0 idx)
+        | _ -> None)
+
+let runtime_contract_json_from_fields ~keeper_name ?agent_name ?trace_id
+    ?session_id ?generation ?keeper_turn_id ?task_id ?goal_ids
+    ?sandbox_profile ?sandbox_root ?allowed_paths ?network_mode
+    ?shared_memory_scope ?approval_mode ?tool_surface_class
+    ?visible_tool_count ?required_tools ?missing_required_tools ?provider ?model
+    ?cascade_profile () : Yojson.Safe.t =
+  let provider =
+    match provider with
+    | Some _ -> provider
+    | None -> provider_of_model model
+  in
+  `Assoc
+    [
+      ("keeper_name", `String keeper_name);
+      ("agent_name", string_opt_json agent_name);
+      ("trace_id", string_opt_json trace_id);
+      ("session_id", string_opt_json session_id);
+      ("generation", int_opt_json generation);
+      ("keeper_turn_id", int_opt_json keeper_turn_id);
+      ("task_id", string_opt_json task_id);
+      ("goal_ids", string_list_json (nonempty_list goal_ids));
+      ("sandbox_profile", string_opt_json sandbox_profile);
+      ("sandbox_root", string_opt_json sandbox_root);
+      ("allowed_paths", string_list_json (nonempty_list allowed_paths));
+      ("network_mode", string_opt_json network_mode);
+      ("shared_memory_scope", string_opt_json shared_memory_scope);
+      ("approval_mode", string_opt_json approval_mode);
+      ("tool_surface_class", string_opt_json tool_surface_class);
+      ("visible_tool_count", int_opt_json visible_tool_count);
+      ("required_tools", string_list_json (nonempty_list required_tools));
+      ( "missing_required_tools",
+        string_list_json (nonempty_list missing_required_tools) );
+      ("provider", string_opt_json provider);
+      ("model", string_opt_json model);
+      ("cascade_profile", string_opt_json cascade_profile);
+    ]
+
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop i =
+    if needle_len = 0 then true
+    else if i + needle_len > haystack_len then false
+    else if String.sub haystack i needle_len = needle then true
+    else loop (i + 1)
+  in
+  loop 0
+
+let json_string_field name = function
+  | `Assoc fields -> (
+      match List.assoc_opt name fields with
+      | Some (`String value) when String.trim value <> "" -> Some value
+      | _ -> None)
+  | _ -> None
+
+let first_string_field names json =
+  List.find_map (fun name -> json_string_field name json) names
+
+let path_like_key key =
+  let key = String.lowercase_ascii key in
+  key = "cwd" || key = "dir" || key = "directory" || key = "file"
+  || contains_substring key "path"
+
+let collect_observed_paths json =
+  let rec loop acc = function
+    | `Assoc fields ->
+        List.fold_left
+          (fun acc (key, value) ->
+            match value with
+            | `String path when path_like_key key && String.trim path <> "" ->
+                path :: acc
+            | other -> loop acc other)
+          acc fields
+    | `List values -> List.fold_left loop acc values
+    | _ -> acc
+  in
+  loop [] json
+  |> List.sort_uniq String.compare
+
+let target_kind_of_input input target_path =
+  match json_string_field "target_kind" input with
+  | Some value -> value
+  | None -> (
+      match json_string_field "kind" input with
+      | Some value -> value
+      | None -> (
+          match target_path with
+          | Some _ -> "path"
+          | None -> "tool"))
+
+let action_radius_json ~tool_name ~input ~success ~duration_ms ?error
+    ?sandbox_target () : Yojson.Safe.t =
+  let action_key =
+    first_string_field [ "action"; "action_key"; "op"; "cmd"; "command" ] input
+    |> Option.value ~default:tool_name
+  in
+  let target_path =
+    first_string_field
+      [
+        "target_path";
+        "path";
+        "file_path";
+        "repo_path";
+        "worktree_path";
+        "cwd";
+      ]
+      input
+  in
+  `Assoc
+    [
+      ("tool_name", `String tool_name);
+      ("action_key", `String action_key);
+      ("target_kind", `String (target_kind_of_input input target_path));
+      ("target_path", string_opt_json target_path);
+      ("sandbox_target", string_opt_json sandbox_target);
+      ("observed_paths", string_list_json (collect_observed_paths input));
+      ("success", `Bool success);
+      ("duration_ms", `Float duration_ms);
+      ("error", string_opt_json error);
+    ]
+
 let runtime_contract_json ?config (meta : keeper_meta) : Yojson.Safe.t =
   let sandbox_target = backend_of_meta meta in
   let goal_progress = goal_progress_json ?config meta in

--- a/lib/keeper/keeper_runtime_contract.mli
+++ b/lib/keeper/keeper_runtime_contract.mli
@@ -5,3 +5,38 @@ val task_is_linked_to_keeper_goals :
   string list -> Types.task -> bool
 val runtime_contract_json :
   ?config:Coord.config -> Keeper_types.keeper_meta -> Yojson.Safe.t
+
+val runtime_contract_json_from_fields :
+  keeper_name:string ->
+  ?agent_name:string ->
+  ?trace_id:string ->
+  ?session_id:string ->
+  ?generation:int ->
+  ?keeper_turn_id:int ->
+  ?task_id:string ->
+  ?goal_ids:string list ->
+  ?sandbox_profile:string ->
+  ?sandbox_root:string ->
+  ?allowed_paths:string list ->
+  ?network_mode:string ->
+  ?shared_memory_scope:string ->
+  ?approval_mode:string ->
+  ?tool_surface_class:string ->
+  ?visible_tool_count:int ->
+  ?required_tools:string list ->
+  ?missing_required_tools:string list ->
+  ?provider:string ->
+  ?model:string ->
+  ?cascade_profile:string ->
+  unit ->
+  Yojson.Safe.t
+
+val action_radius_json :
+  tool_name:string ->
+  input:Yojson.Safe.t ->
+  success:bool ->
+  duration_ms:float ->
+  ?error:string ->
+  ?sandbox_target:string ->
+  unit ->
+  Yojson.Safe.t

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -23,6 +23,7 @@ let max_output_len = 4000
 let pending_truncation : (string, int * int option) Hashtbl.t = Hashtbl.create 8
 
 type turn_context = {
+  agent_name: string option;
   lane: string option;
   tool_choice: string option;
   thinking_enabled: bool option;
@@ -30,17 +31,26 @@ type turn_context = {
   prompt_fingerprint: string option;
   trace_id: string option;
   session_id: string option;
+  generation: int option;
   turn: int option;
   keeper_turn_id: int option;
   task_id: string option;
   goal_ids: string list option;
   sandbox_profile: string option;
+  sandbox_root: string option;
+  allowed_paths: string list option;
   network_mode: string option;
   shared_memory_scope: string option;
   approval_mode: string option;
+  tool_surface_class: string option;
+  visible_tool_count: int option;
+  required_tools: string list option;
+  missing_required_tools: string list option;
+  cascade_profile: string option;
 }
 
 let empty_turn_context = {
+  agent_name = None;
   lane = None;
   tool_choice = None;
   thinking_enabled = None;
@@ -48,14 +58,22 @@ let empty_turn_context = {
   prompt_fingerprint = None;
   trace_id = None;
   session_id = None;
+  generation = None;
   turn = None;
   keeper_turn_id = None;
   task_id = None;
   goal_ids = None;
   sandbox_profile = None;
+  sandbox_root = None;
+  allowed_paths = None;
   network_mode = None;
   shared_memory_scope = None;
   approval_mode = None;
+  tool_surface_class = None;
+  visible_tool_count = None;
+  required_tools = None;
+  missing_required_tools = None;
+  cascade_profile = None;
 }
 
 let pending_turn_context : (string, turn_context) Hashtbl.t = Hashtbl.create 8
@@ -68,12 +86,15 @@ let consume_truncation_info ~keeper_name () =
   | Some info -> Hashtbl.remove pending_truncation keeper_name; info
   | None -> (0, None)
 
-let set_turn_context ~keeper_name ?lane ?tool_choice ?thinking_enabled
-    ?thinking_budget ?prompt_fingerprint ?trace_id ?session_id ?turn
-    ?keeper_turn_id ?task_id ?goal_ids ?sandbox_profile
-    ?network_mode ?shared_memory_scope ?approval_mode () =
+let set_turn_context ~keeper_name ?agent_name ?lane ?tool_choice
+    ?thinking_enabled ?thinking_budget ?prompt_fingerprint ?trace_id
+    ?session_id ?generation ?turn ?keeper_turn_id ?task_id ?goal_ids
+    ?sandbox_profile ?sandbox_root ?allowed_paths ?network_mode
+    ?shared_memory_scope ?approval_mode ?tool_surface_class ?visible_tool_count
+    ?required_tools ?missing_required_tools ?cascade_profile () =
   Hashtbl.replace pending_turn_context keeper_name
     {
+      agent_name;
       lane;
       tool_choice;
       thinking_enabled;
@@ -81,22 +102,31 @@ let set_turn_context ~keeper_name ?lane ?tool_choice ?thinking_enabled
       prompt_fingerprint;
       trace_id;
       session_id;
+      generation;
       turn;
       keeper_turn_id;
       task_id;
       goal_ids;
       sandbox_profile;
+      sandbox_root;
+      allowed_paths;
       network_mode;
       shared_memory_scope;
       approval_mode;
+      tool_surface_class;
+      visible_tool_count;
+      required_tools;
+      missing_required_tools;
+      cascade_profile;
     }
 
-let get_turn_context ~keeper_name () =
-  let ctx =
+let get_turn_context_record ~keeper_name () =
     match Hashtbl.find_opt pending_turn_context keeper_name with
     | Some ctx -> ctx
     | None -> empty_turn_context
-  in
+
+let get_turn_context ~keeper_name () =
+  let ctx = get_turn_context_record ~keeper_name () in
   ( ctx.lane
   , ctx.tool_choice
   , ctx.thinking_enabled
@@ -112,6 +142,48 @@ let get_turn_context ~keeper_name () =
   , ctx.network_mode
   , ctx.shared_memory_scope
   , ctx.approval_mode )
+
+let optional_model model =
+  match model with
+  | Some value when String.trim value <> "" -> Some value
+  | _ -> None
+
+let runtime_contract_json_for_call ~keeper_name ?model () =
+  let ctx = get_turn_context_record ~keeper_name () in
+  Keeper_runtime_contract.runtime_contract_json_from_fields
+    ~keeper_name
+    ?agent_name:ctx.agent_name
+    ?trace_id:ctx.trace_id
+    ?session_id:ctx.session_id
+    ?generation:ctx.generation
+    ?keeper_turn_id:ctx.keeper_turn_id
+    ?task_id:ctx.task_id
+    ?goal_ids:ctx.goal_ids
+    ?sandbox_profile:ctx.sandbox_profile
+    ?sandbox_root:ctx.sandbox_root
+    ?allowed_paths:ctx.allowed_paths
+    ?network_mode:ctx.network_mode
+    ?shared_memory_scope:ctx.shared_memory_scope
+    ?approval_mode:ctx.approval_mode
+    ?tool_surface_class:ctx.tool_surface_class
+    ?visible_tool_count:ctx.visible_tool_count
+    ?required_tools:ctx.required_tools
+    ?missing_required_tools:ctx.missing_required_tools
+    ?model:(optional_model model)
+    ?cascade_profile:ctx.cascade_profile
+    ()
+
+let action_radius_json_for_call ~keeper_name ~tool_name ~input ~success
+    ~duration_ms ?error () =
+  let ctx = get_turn_context_record ~keeper_name () in
+  Keeper_runtime_contract.action_radius_json
+    ~tool_name
+    ~input
+    ~success
+    ~duration_ms
+    ?error
+    ?sandbox_target:ctx.sandbox_profile
+    ()
 
 let store_ref : Dated_jsonl.t option ref = ref None
 
@@ -179,16 +251,18 @@ let input_to_json (input : Yojson.Safe.t) : Yojson.Safe.t =
 
 let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
     ~(output_text : string) ~(success : bool) ~(duration_ms : float)
-    ?(model : string = "") ?lane ?tool_choice ?thinking_enabled
-    ?thinking_budget ?prompt_fingerprint ?trace_id ?session_id ?turn
-    ?keeper_turn_id ?task_id ?goal_ids ?sandbox_profile
-    ?network_mode ?shared_memory_scope ?approval_mode ?result_bytes
-    ?truncated_to () =
+    ?(model : string = "") ?agent_name ?lane ?tool_choice ?thinking_enabled
+    ?thinking_budget ?prompt_fingerprint ?trace_id ?session_id ?generation
+    ?turn ?keeper_turn_id ?task_id ?goal_ids ?sandbox_profile ?sandbox_root
+    ?allowed_paths ?network_mode ?shared_memory_scope ?approval_mode
+    ?tool_surface_class ?visible_tool_count ?required_tools
+    ?missing_required_tools ?cascade_profile ?result_bytes ?truncated_to () =
   if Observability_redact.is_denied_tool ~tool_name then ()
   else
     match !store_ref with
     | None -> ()
     | Some store ->
+      let ctx = get_turn_context_record ~keeper_name () in
       let ( ctx_lane
           , ctx_tool_choice
           , ctx_thinking_enabled
@@ -258,6 +332,43 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
         match approval_mode with
         | Some _ -> approval_mode
         | None -> ctx_approval_mode
+      in
+      let agent_name =
+        match agent_name with Some _ -> agent_name | None -> ctx.agent_name
+      in
+      let generation =
+        match generation with Some _ -> generation | None -> ctx.generation
+      in
+      let sandbox_root =
+        match sandbox_root with Some _ -> sandbox_root | None -> ctx.sandbox_root
+      in
+      let allowed_paths =
+        match allowed_paths with Some _ -> allowed_paths | None -> ctx.allowed_paths
+      in
+      let tool_surface_class =
+        match tool_surface_class with
+        | Some _ -> tool_surface_class
+        | None -> ctx.tool_surface_class
+      in
+      let visible_tool_count =
+        match visible_tool_count with
+        | Some _ -> visible_tool_count
+        | None -> ctx.visible_tool_count
+      in
+      let required_tools =
+        match required_tools with
+        | Some _ -> required_tools
+        | None -> ctx.required_tools
+      in
+      let missing_required_tools =
+        match missing_required_tools with
+        | Some _ -> missing_required_tools
+        | None -> ctx.missing_required_tools
+      in
+      let cascade_profile =
+        match cascade_profile with
+        | Some _ -> cascade_profile
+        | None -> ctx.cascade_profile
       in
       let model_field =
         if model = "" then [] else [("model", `String model)]
@@ -334,6 +445,42 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
       let safe_input = input_to_json (Observability_redact.redact_json_value input) in
       let safe_output = Observability_redact.redact_preview ~max_len:max_output_len output_text in
       let output_json = blob_aware_output_json safe_output in
+      let model_opt = optional_model (Some model) in
+      let runtime_contract =
+        Keeper_runtime_contract.runtime_contract_json_from_fields
+          ~keeper_name
+          ?agent_name
+          ?trace_id
+          ?session_id
+          ?generation
+          ?keeper_turn_id
+          ?task_id
+          ?goal_ids
+          ?sandbox_profile
+          ?sandbox_root
+          ?allowed_paths
+          ?network_mode
+          ?shared_memory_scope
+          ?approval_mode
+          ?tool_surface_class
+          ?visible_tool_count
+          ?required_tools
+          ?missing_required_tools
+          ?model:model_opt
+          ?cascade_profile
+          ()
+      in
+      let error = if success then None else Some safe_output in
+      let action_radius =
+        Keeper_runtime_contract.action_radius_json
+          ~tool_name
+          ~input:safe_input
+          ~success
+          ~duration_ms
+          ?error
+          ?sandbox_target:sandbox_profile
+          ()
+      in
       let json =
         `Assoc
           ([ ("ts", `Float (Time_compat.now ()))
@@ -343,6 +490,8 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
            ; ("output", output_json)
            ; ("success", `Bool success)
            ; ("duration_ms", `Float duration_ms)
+           ; ("runtime_contract", runtime_contract)
+           ; ("action_radius", action_radius)
            ]
            @ model_field @ lane_field @ tool_choice_field
            @ thinking_enabled_field @ thinking_budget_field

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -28,6 +28,7 @@ val consume_truncation_info :
 
 val set_turn_context :
   keeper_name:string ->
+  ?agent_name:string ->
   ?lane:string ->
   ?tool_choice:string ->
   ?thinking_enabled:bool ->
@@ -35,14 +36,22 @@ val set_turn_context :
   ?prompt_fingerprint:string ->
   ?trace_id:string ->
   ?session_id:string ->
+  ?generation:int ->
   ?turn:int ->
   ?keeper_turn_id:int ->
   ?task_id:string ->
   ?goal_ids:string list ->
   ?sandbox_profile:string ->
+  ?sandbox_root:string ->
+  ?allowed_paths:string list ->
   ?network_mode:string ->
   ?shared_memory_scope:string ->
   ?approval_mode:string ->
+  ?tool_surface_class:string ->
+  ?visible_tool_count:int ->
+  ?required_tools:string list ->
+  ?missing_required_tools:string list ->
+  ?cascade_profile:string ->
   unit ->
   unit
 (** [set_turn_context ...] stores the current effective turn policy for
@@ -61,6 +70,26 @@ val get_turn_context :
     the keeper, or [None] values when no turn context has
     been recorded. *)
 
+val runtime_contract_json_for_call :
+  keeper_name:string ->
+  ?model:string ->
+  unit ->
+  Yojson.Safe.t
+(** [runtime_contract_json_for_call ~keeper_name ?model ()] returns the
+    canonical keeper runtime contract from the current turn context. *)
+
+val action_radius_json_for_call :
+  keeper_name:string ->
+  tool_name:string ->
+  input:Yojson.Safe.t ->
+  success:bool ->
+  duration_ms:float ->
+  ?error:string ->
+  unit ->
+  Yojson.Safe.t
+(** [action_radius_json_for_call ...] derives the canonical action radius
+    from a keeper tool call and its current sandbox context. *)
+
 val init : ?cluster_name:string -> base_path:string -> unit -> unit
 (** [init ?cluster_name ~base_path ()] creates the cluster-aware Dated_jsonl
     store. Call once at startup. *)
@@ -73,6 +102,7 @@ val log_call :
   success:bool ->
   duration_ms:float ->
   ?model:string ->
+  ?agent_name:string ->
   ?lane:string ->
   ?tool_choice:string ->
   ?thinking_enabled:bool ->
@@ -80,14 +110,22 @@ val log_call :
   ?prompt_fingerprint:string ->
   ?trace_id:string ->
   ?session_id:string ->
+  ?generation:int ->
   ?turn:int ->
   ?keeper_turn_id:int ->
   ?task_id:string ->
   ?goal_ids:string list ->
   ?sandbox_profile:string ->
+  ?sandbox_root:string ->
+  ?allowed_paths:string list ->
   ?network_mode:string ->
   ?shared_memory_scope:string ->
   ?approval_mode:string ->
+  ?tool_surface_class:string ->
+  ?visible_tool_count:int ->
+  ?required_tools:string list ->
+  ?missing_required_tools:string list ->
+  ?cascade_profile:string ->
   ?result_bytes:int ->
   ?truncated_to:int ->
   unit ->

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1054,15 +1054,80 @@ let handle_keeper_get_subroutes state req request reqd =
         |> max 1 |> min 168  (* 1h .. 7d *)
       in
       let since = Time_compat.now () -. (float_of_int window_hours *. 3600.0) in
-      let entries =
-        Trajectory.read_entries_since ~masc_root ~keeper_name:name ~since
+      let read_result =
+        Trajectory.read_entries_since_result ~masc_root ~keeper_name:name ~since
       in
+      let entries = read_result.Trajectory.entries in
       let tools = Trajectory.aggregate_tool_stats entries in
       let timeline = Trajectory.hourly_timeline entries in
+      let latest_ts =
+        List.fold_left
+          (fun acc (entry : Trajectory.tool_call_entry) ->
+            match acc with
+            | Some ts when ts >= entry.ts -> acc
+            | _ -> Some entry.ts)
+          None entries
+      in
+      let latest_age_s =
+        match latest_ts with
+        | Some ts -> Some (max 0.0 (Time_compat.now () -. ts))
+        | None -> None
+      in
+      let freshness_slo_s = 300.0 in
+      let dashboard_surface = "/api/v1/keepers/:name/tool-stats" in
+      let coverage_gaps =
+        Telemetry_coverage_gap.read_recent ~masc_root ~n:32
+        |> List.filter (fun gap ->
+             String.equal
+               (Safe_ops.json_string ~default:"" "dashboard_surface" gap)
+               dashboard_surface
+             &&
+             match Safe_ops.json_string_opt "keeper_name" gap with
+             | Some keeper_name -> String.equal keeper_name name
+             | None -> true)
+      in
+      let latest_gap = List.rev coverage_gaps |> List.find_opt (fun _ -> true) in
+      let health, stale_reason =
+        match latest_gap with
+        | Some gap ->
+            ( "coverage_gap",
+              Safe_ops.json_string ~default:"coverage_gap" "stale_reason" gap )
+        | None -> (
+            match latest_age_s with
+            | None -> ("empty", "no_entries")
+            | Some age when age > freshness_slo_s ->
+                ("stale", "freshness_slo_exceeded")
+            | Some _ -> ("ok", ""))
+      in
       let json = `Assoc [
         ("keeper", `String name);
         ("window_hours", `Int window_hours);
         ("total_entries", `Int (List.length entries));
+        ("source", `String "trajectory_tool_call");
+        ("producer", `String "keeper_hooks_oas.post_tool_use");
+        ("durable_store", `String (Trajectory.trajectories_dir masc_root name));
+        ("dashboard_surface", `String dashboard_surface);
+        ("freshness_slo_s", `Float freshness_slo_s);
+        ( "latest_ts_unix",
+          match latest_ts with Some ts -> `Float ts | None -> `Null );
+        ( "latest_ts_iso",
+          match latest_ts with
+          | Some ts -> `String (Types.iso8601_of_unix_seconds ts)
+          | None -> `Null );
+        ( "latest_age_s",
+          match latest_age_s with Some age -> `Float age | None -> `Null );
+        ("health", `String health);
+        ( "stale_reason",
+          if stale_reason = "" then `Null else `String stale_reason );
+        ( "gate_decode",
+          `Assoc
+            [
+              ( "parsed_gate_count",
+                `Int read_result.Trajectory.gate_decode.parsed_gate_count );
+              ( "legacy_default_count",
+                `Int read_result.Trajectory.gate_decode.legacy_default_count );
+            ] );
+        ("coverage_gaps", `List coverage_gaps);
         ("tools", `List (List.map Trajectory.tool_stat_to_json tools));
         ("timeline", `List (List.map Trajectory.hourly_bucket_to_json timeline));
       ] in
@@ -1085,9 +1150,51 @@ let handle_keeper_get_subroutes state req request reqd =
       let entries =
         Keeper_tool_call_log.read_recent ~keeper_name:name ~n:limit ()
       in
+      let config = state.Mcp_server.room_config in
+      let masc_root = Coord.masc_root_dir config in
+      let latest_ts =
+        List.fold_left
+          (fun acc json ->
+            match Safe_ops.json_float_opt "ts" json with
+            | Some ts -> (
+                match acc with
+                | Some existing when existing >= ts -> acc
+                | _ -> Some ts)
+            | None -> acc)
+          None entries
+      in
+      let freshness_slo_s = 300.0 in
+      let latest_age_s =
+        match latest_ts with
+        | Some ts -> Some (max 0.0 (Time_compat.now () -. ts))
+        | None -> None
+      in
+      let health, stale_reason =
+        match latest_age_s with
+        | None -> ("empty", "no_entries")
+        | Some age when age > freshness_slo_s ->
+            ("stale", "freshness_slo_exceeded")
+        | Some _ -> ("ok", "")
+      in
       let json = `Assoc [
         ("keeper", `String name);
         ("count", `Int (List.length entries));
+        ("source", `String "tool_call_io");
+        ("producer", `String "keeper_hooks_oas.post_tool_use");
+        ("durable_store", `String (Filename.concat masc_root "tool_calls"));
+        ("dashboard_surface", `String "/api/v1/keepers/:name/tool-calls");
+        ("freshness_slo_s", `Float freshness_slo_s);
+        ( "latest_ts_unix",
+          match latest_ts with Some ts -> `Float ts | None -> `Null );
+        ( "latest_ts_iso",
+          match latest_ts with
+          | Some ts -> `String (Types.iso8601_of_unix_seconds ts)
+          | None -> `Null );
+        ( "latest_age_s",
+          match latest_age_s with Some age -> `Float age | None -> `Null );
+        ("health", `String health);
+        ( "stale_reason",
+          if stale_reason = "" then `Null else `String stale_reason );
         ("entries", `List entries);
       ] in
       Http.Response.json ~compress:true ~request:req

--- a/lib/telemetry_coverage_gap.ml
+++ b/lib/telemetry_coverage_gap.ml
@@ -1,0 +1,41 @@
+(** Durable telemetry coverage gaps.
+
+    This store records write-path failures that leave one telemetry lane behind
+    another.  Unified telemetry can then surface the gap even when the primary
+    lane itself has no fresh rows to read. *)
+
+let store_dir masc_root =
+  Filename.concat masc_root "telemetry-coverage-gaps"
+
+let string_opt_json = function
+  | Some value when String.trim value <> "" -> `String value
+  | _ -> `Null
+
+let record ~masc_root ~source ~producer ~durable_store ~dashboard_surface
+    ~stale_reason ?keeper_name ?trace_id ?error () =
+  let store = Dated_jsonl.create ~base_dir:(store_dir masc_root) () in
+  let now = Time_compat.now () in
+  let json =
+    `Assoc
+      [
+        ("schema", `String "masc.telemetry_coverage_gap.v1");
+        ("ts", `Float now);
+        ("ts_iso", `String (Types.iso8601_of_unix_seconds now));
+        ("source", `String source);
+        ("producer", `String producer);
+        ("durable_store", `String durable_store);
+        ("dashboard_surface", `String dashboard_surface);
+        ("stale_reason", `String stale_reason);
+        ("keeper_name", string_opt_json keeper_name);
+        ("trace_id", string_opt_json trace_id);
+        ("error", string_opt_json error);
+      ]
+  in
+  Dated_jsonl.append store json
+
+let read_recent ~masc_root ~n =
+  if n <= 0 then []
+  else
+    let dir = store_dir masc_root in
+    if not (Sys.file_exists dir) then []
+    else Dated_jsonl.read_recent (Dated_jsonl.create ~base_dir:dir ()) n

--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -70,6 +70,37 @@ let fixed_store_dir ~masc_root ~base_path = function
   | Tool_metric  -> Some (Filename.concat base_path "data/tool-metrics")
   | Keeper_metric -> None  (* handled separately *)
 
+let source_freshness_slo_s = function
+  | Keeper_metric -> 300.0
+  | Tool_call_io -> 300.0
+  | Oas_event -> 300.0
+  | Agent_event -> 900.0
+  | Tool_usage -> 900.0
+  | Tool_metric -> 900.0
+
+let source_producer = function
+  | Keeper_metric -> "keeper_unified_metrics"
+  | Agent_event -> "telemetry_eio"
+  | Tool_call_io -> "keeper_hooks_oas"
+  | Tool_usage -> "tool_usage_log"
+  | Oas_event -> "oas_event_bus"
+  | Tool_metric -> "tool_metrics_persist"
+
+let source_dashboard_surface = function
+  | Keeper_metric -> "/api/v1/dashboard/telemetry/summary"
+  | Agent_event -> "/api/v1/dashboard/telemetry"
+  | Tool_call_io -> "/api/v1/keepers/:name/tool-calls"
+  | Tool_usage -> "/api/v1/dashboard/tools"
+  | Oas_event -> "/api/v1/dashboard/telemetry"
+  | Tool_metric -> "/api/v1/dashboard/tool-quality"
+
+let source_durable_store ~masc_root ~base_path = function
+  | Keeper_metric -> Filename.concat masc_root "keepers/*/metrics"
+  | source -> (
+      match fixed_store_dir ~masc_root ~base_path source with
+      | Some dir -> dir
+      | None -> "")
+
 (** Discover all keeper metric directories under [masc_root/keepers/]. *)
 let discover_keeper_metric_dirs masc_root : (string * string) list =
   let keepers_dir = Filename.concat masc_root "keepers" in
@@ -187,6 +218,44 @@ let freshness_fields ~now latest_ts =
     ]
   | None ->
     [ ("latest_ts_unix", `Null); ("latest_ts_iso", `Null); ("latest_age_s", `Null) ]
+
+let source_health_fields ~now ~exists ~entry_count ~latest_ts ~freshness_slo_s
+    ?coverage_gap () =
+  match coverage_gap with
+  | Some gap ->
+    [
+      ("health", `String "coverage_gap");
+      ( "stale_reason",
+        `String
+          (Safe_ops.json_string ~default:"coverage_gap" "stale_reason" gap) );
+    ]
+  | None ->
+    let health, stale_reason =
+      if not exists then ("missing", "store_missing")
+      else if entry_count = 0 then ("empty", "no_entries")
+      else
+        match latest_ts with
+        | None -> ("empty", "no_entries")
+        | Some ts ->
+          let latest_age_s = max 0.0 (now -. ts) in
+          if latest_age_s > freshness_slo_s then
+            ("stale", "freshness_slo_exceeded")
+          else ("ok", "")
+    in
+    [
+      ("health", `String health);
+      ( "stale_reason",
+        if stale_reason = "" then `Null else `String stale_reason );
+    ]
+
+let latest_coverage_gap_for_source gaps source =
+  let source_name = source_to_string source in
+  gaps
+  |> List.rev
+  |> List.find_opt (fun gap ->
+       String.equal
+         (Safe_ops.json_string ~default:"" "source" gap)
+         source_name)
 
 (* ── Semantic duplicate suppression ───────────────── *)
 
@@ -491,6 +560,7 @@ let count_fixed_source_entries ~masc_root ~base_path source : int =
 
 let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
   let now = Unix.gettimeofday () in
+  let coverage_gaps = Telemetry_coverage_gap.read_recent ~masc_root ~n:50 in
   let keeper_dirs = discover_keeper_metric_dirs masc_root in
   let keeper_total =
     List.fold_left (fun acc (name, dir) ->
@@ -513,8 +583,20 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
       None keeper_dirs
   in
   let source_json_and_count source =
+    let freshness_slo_s = source_freshness_slo_s source in
+    let metadata_fields =
+      [
+        ("freshness_slo_s", `Float freshness_slo_s);
+        ("producer", `String (source_producer source));
+        ( "durable_store",
+          `String (source_durable_store ~masc_root ~base_path source) );
+        ("dashboard_surface", `String (source_dashboard_surface source));
+      ]
+    in
+    let coverage_gap = latest_coverage_gap_for_source coverage_gaps source in
     match source with
     | Keeper_metric ->
+      let exists = keeper_dirs <> [] in
       ( `Assoc
           ([
              ("source", `String (source_to_string source));
@@ -527,7 +609,10 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
              ("keeper_count", `Int (List.length keeper_dirs));
              ("entry_count", `Int keeper_total);
            ]
-          @ freshness_fields ~now keeper_latest_ts),
+          @ metadata_fields
+          @ freshness_fields ~now keeper_latest_ts
+          @ source_health_fields ~now ~exists ~entry_count:keeper_total
+              ~latest_ts:keeper_latest_ts ~freshness_slo_s ?coverage_gap ()),
         keeper_total )
     | _ ->
       let dir = match fixed_store_dir ~masc_root ~base_path source with
@@ -544,7 +629,10 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
              ("exists", `Bool exists);
              ("entry_count", `Int count);
            ]
-          @ freshness_fields ~now latest_ts),
+          @ metadata_fields
+          @ freshness_fields ~now latest_ts
+          @ source_health_fields ~now ~exists ~entry_count:count ~latest_ts
+              ~freshness_slo_s ?coverage_gap ()),
         count )
   in
   let source_summaries = List.map source_json_and_count all_sources in
@@ -554,5 +642,6 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
   `Assoc [
     ("generated_at", `String (Types.now_iso ()));
     ("sources", `List (List.map fst source_summaries));
+    ("coverage_gaps", `List coverage_gaps);
     ("total_entries", `Int total_entries);
   ]

--- a/lib/trajectory.ml
+++ b/lib/trajectory.ml
@@ -33,6 +33,16 @@ type tool_call_entry = {
   cost_usd : float;                 (** Estimated cost of this call *)
 }
 
+type gate_decode_summary = {
+  parsed_gate_count : int;
+  legacy_default_count : int;
+}
+
+type entries_read_result = {
+  entries : tool_call_entry list;
+  gate_decode : gate_decode_summary;
+}
+
 type trajectory_outcome =
   | Completed
   | Failed of string
@@ -120,28 +130,46 @@ let outcome_to_string = function
 (** Default truncation limit for result text in JSONL persistence. *)
 let default_result_truncation = 500
 
-let entry_to_json ?(result_max_len = default_result_truncation) (e : tool_call_entry) : Yojson.Safe.t =
-  `Assoc [
-    ("ts", `Float e.ts);
-    ("ts_iso", `String e.ts_iso);
-    ("turn", `Int e.turn);
-    ("round", `Int e.round);
-    ("tool_name", `String e.tool_name);
-    ("args", (try Yojson.Safe.from_string e.args_json with Yojson.Json_error _ -> `String e.args_json));
-    ("gate", gate_decision_to_json e.gate_decision);
-    ("result",
-      (match e.result with
-       | None -> `Null
-       | Some r ->
-           if result_max_len > 0 then
-             `String (String_util.utf8_safe
-                        ~max_bytes:(result_max_len + 3) ~suffix:"..." r
-                      |> String_util.to_string)
-           else `String r));
-    ("duration_ms", `Int e.duration_ms);
-    ("error", Json_util.string_opt_to_json e.error);
-    ("cost_usd", `Float e.cost_usd);
-  ]
+let entry_to_json ?(result_max_len = default_result_truncation)
+    ?runtime_contract ?action_radius (e : tool_call_entry) : Yojson.Safe.t =
+  let runtime_contract_field =
+    match runtime_contract with
+    | Some value -> [ ("runtime_contract", value) ]
+    | None -> []
+  in
+  let action_radius_field =
+    match action_radius with
+    | Some value -> [ ("action_radius", value) ]
+    | None -> []
+  in
+  `Assoc
+    ([
+       ("ts", `Float e.ts);
+       ("ts_iso", `String e.ts_iso);
+       ("turn", `Int e.turn);
+       ("round", `Int e.round);
+       ("tool_name", `String e.tool_name);
+       ( "args",
+         (try Yojson.Safe.from_string e.args_json with
+          | Yojson.Json_error _ -> `String e.args_json) );
+       ("gate", gate_decision_to_json e.gate_decision);
+       ( "result",
+         (match e.result with
+          | None -> `Null
+          | Some r ->
+              if result_max_len > 0 then
+                `String
+                  (String_util.utf8_safe
+                     ~max_bytes:(result_max_len + 3)
+                     ~suffix:"..."
+                     r
+                   |> String_util.to_string)
+              else `String r) );
+       ("duration_ms", `Int e.duration_ms);
+       ("error", Json_util.string_opt_to_json e.error);
+       ("cost_usd", `Float e.cost_usd);
+     ]
+    @ runtime_contract_field @ action_radius_field)
 
 let default_thinking_truncation = 2000
 
@@ -198,12 +226,13 @@ let trajectory_path (masc_root : string) (keeper_name : string) (trace_id : stri
 let ensure_dir path =
   Fs_compat.mkdir_p path
 
-let append_entry ~(masc_root : string) ~(keeper_name : string) ~(trace_id : string)
-    (entry : tool_call_entry) : unit =
+let append_entry ?runtime_contract ?action_radius ~(masc_root : string)
+    ~(keeper_name : string) ~(trace_id : string) (entry : tool_call_entry) :
+    unit =
   let dir = trajectories_dir masc_root keeper_name in
   ensure_dir dir;
   let path = trajectory_path masc_root keeper_name trace_id in
-  let json = entry_to_json entry in
+  let json = entry_to_json ?runtime_contract ?action_radius entry in
   let line = Yojson.Safe.to_string json ^ "\n" in
   Fs_compat.append_file path line
 
@@ -283,14 +312,31 @@ let clear_task_id (acc : accumulator) : unit =
 let increment_turn (acc : accumulator) : unit =
   acc.turn <- acc.turn + 1
 
-let record_entry (acc : accumulator) (entry : tool_call_entry) : unit =
+let record_entry ?runtime_contract ?action_radius ?on_persist_error
+    (acc : accumulator) (entry : tool_call_entry) : unit =
   acc.entries <- entry :: acc.entries;
   acc.total_cost <- acc.total_cost +. entry.cost_usd;
   acc.total_calls <- acc.total_calls + 1;
   (* Persist immediately for crash recovery *)
-  (try append_entry ~masc_root:acc.masc_root ~keeper_name:acc.keeper_name
-       ~trace_id:acc.trace_id entry
-   with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Keeper.error "Failed to persist entry for %s: %s" acc.trace_id (Printexc.to_string exn))
+  (try
+     append_entry ?runtime_contract ?action_radius ~masc_root:acc.masc_root
+       ~keeper_name:acc.keeper_name ~trace_id:acc.trace_id entry
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+       Log.Keeper.error "Failed to persist entry for %s: %s" acc.trace_id
+         (Printexc.to_string exn);
+       (match on_persist_error with
+        | None -> ()
+        | Some report ->
+            try report exn
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | report_exn ->
+                Log.Keeper.warn
+                  "Failed to report trajectory persist gap for %s: %s"
+                  acc.trace_id
+                  (Printexc.to_string report_exn)))
 
 let finalize (acc : accumulator) (outcome : trajectory_outcome) : trajectory =
   let traj = {
@@ -451,15 +497,72 @@ let hourly_bucket_to_json (b : hourly_bucket) : Yojson.Safe.t =
     ("error_count", `Int b.error_count);
   ]
 
+let gate_decision_of_json = function
+  | `Assoc fields -> (
+      match List.assoc_opt "status" fields with
+      | Some (`String status) -> (
+          match String.lowercase_ascii status with
+          | "pass" | "passed" -> (Pass, true)
+          | "reject" | "rejected" | "gated" ->
+              let reason =
+                match List.assoc_opt "reason" fields with
+                | Some (`String value) when String.trim value <> "" -> value
+                | _ -> "persisted gate rejection"
+              in
+              (Reject reason, true)
+          | _ -> (Pass, false))
+      | _ -> (Pass, false))
+  | _ -> (Pass, false)
+
+let tool_call_entry_of_json (json : Yojson.Safe.t) :
+    (tool_call_entry * bool) option =
+  try
+    let open Yojson.Safe.Util in
+    match member "type" json with
+    | `String "trajectory_summary" -> None
+    | `String "thinking" -> None
+    | _ ->
+        let gate_decision, parsed_gate =
+          gate_decision_of_json (member "gate" json)
+        in
+        Some
+          ( {
+              ts = json |> member "ts" |> to_float;
+              ts_iso = json |> member "ts_iso" |> to_string;
+              turn = json |> member "turn" |> to_int;
+              round = json |> member "round" |> to_int;
+              tool_name = json |> member "tool_name" |> to_string;
+              args_json = json |> member "args" |> Yojson.Safe.to_string;
+              gate_decision;
+              result =
+                (match json |> member "result" with
+                 | `Null -> None
+                 | `String s -> Some s
+                 | _ -> None);
+              duration_ms = json |> member "duration_ms" |> to_int;
+              error =
+                (match json |> member "error" with
+                 | `Null -> None
+                 | `String s -> Some s
+                 | _ -> None);
+              cost_usd = json |> member "cost_usd" |> to_float;
+            },
+            parsed_gate )
+  with
+  | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
+
 (** Read all .jsonl trace files for a keeper. Filter entries with ts >= since.
     Scans the keeper's trajectory directory for all trace files. *)
-let read_entries_since ~(masc_root : string) ~(keeper_name : string) ~(since : float)
-    : tool_call_entry list =
+let read_entries_since_result ~(masc_root : string) ~(keeper_name : string)
+    ~(since : float) : entries_read_result =
   let dir = trajectories_dir masc_root keeper_name in
-  if not (Sys.file_exists dir) then []
+  if not (Sys.file_exists dir) then
+    { entries = []; gate_decode = { parsed_gate_count = 0; legacy_default_count = 0 } }
   else
     let files = Sys.readdir dir in
     let all_entries = ref [] in
+    let parsed_gate_count = ref 0 in
+    let legacy_default_count = ref 0 in
     Array.iter (fun fname ->
       if Filename.check_suffix fname ".jsonl" then begin
         let path = Filename.concat dir fname in
@@ -470,39 +573,31 @@ let read_entries_since ~(masc_root : string) ~(keeper_name : string) ~(since : f
              if String.trim line <> "" then
                try
                  let json = Yojson.Safe.from_string line in
-                 let open Yojson.Safe.Util in
-                 (match member "type" json with
-                  | `String "trajectory_summary" -> ()
-                  | _ ->
-                    let ts = json |> member "ts" |> to_float in
-                    if ts >= since then
-                      let entry = {
-                        ts;
-                        ts_iso = json |> member "ts_iso" |> to_string;
-                        turn = json |> member "turn" |> to_int;
-                        round = json |> member "round" |> to_int;
-                        tool_name = json |> member "tool_name" |> to_string;
-                        args_json = json |> member "args" |> Yojson.Safe.to_string;
-                        gate_decision = Pass;
-                        result =
-                          (match json |> member "result" with
-                           | `Null -> None
-                           | `String s -> Some s
-                           | _ -> None);
-                        duration_ms = json |> member "duration_ms" |> to_int;
-                        error =
-                          (match json |> member "error" with
-                           | `Null -> None
-                           | `String s -> Some s
-                           | _ -> None);
-                        cost_usd = json |> member "cost_usd" |> to_float;
-                      } in
-                      all_entries := entry :: !all_entries)
+                 (match tool_call_entry_of_json json with
+                  | Some (entry, parsed_gate) when entry.ts >= since ->
+                      if parsed_gate then incr parsed_gate_count
+                      else incr legacy_default_count;
+                      all_entries := entry :: !all_entries
+                  | _ -> ())
                with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> ())
          with Sys_error _ -> ())
       end
     ) files;
-    List.sort (fun (a : tool_call_entry) (b : tool_call_entry) -> compare a.ts b.ts) !all_entries
+    {
+      entries =
+        List.sort
+          (fun (a : tool_call_entry) (b : tool_call_entry) -> compare a.ts b.ts)
+          !all_entries;
+      gate_decode =
+        {
+          parsed_gate_count = !parsed_gate_count;
+          legacy_default_count = !legacy_default_count;
+        };
+    }
+
+let read_entries_since ~(masc_root : string) ~(keeper_name : string)
+    ~(since : float) : tool_call_entry list =
+  (read_entries_since_result ~masc_root ~keeper_name ~since).entries
 
 (* ================================================================ *)
 (* Read trajectory from JSONL (for replay/eval)                     *)
@@ -519,32 +614,9 @@ let read_entries ~(masc_root : string) ~(keeper_name : string) ~(trace_id : stri
     |> List.filter_map (fun line ->
         try
           let json = Yojson.Safe.from_string line in
-          (* Skip summary lines *)
-          match Yojson.Safe.Util.member "type" json with
-          | `String "trajectory_summary" -> None
-          | _ ->
-              let open Yojson.Safe.Util in
-              Some {
-                ts = json |> member "ts" |> to_float;
-                ts_iso = json |> member "ts_iso" |> to_string;
-                turn = json |> member "turn" |> to_int;
-                round = json |> member "round" |> to_int;
-                tool_name = json |> member "tool_name" |> to_string;
-                args_json = json |> member "args" |> Yojson.Safe.to_string;
-                gate_decision = Pass;  (* Simplified for replay *)
-                result =
-                  (match json |> member "result" with
-                   | `Null -> None
-                   | `String s -> Some s
-                   | _ -> None);
-                duration_ms = json |> member "duration_ms" |> to_int;
-                error =
-                  (match json |> member "error" with
-                   | `Null -> None
-                   | `String s -> Some s
-                   | _ -> None);
-                cost_usd = json |> member "cost_usd" |> to_float;
-              }
+          match tool_call_entry_of_json json with
+          | Some (entry, _parsed_gate) -> Some entry
+          | None -> None
         with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None)
 
 (** Read all trajectory lines including thinking entries. *)
@@ -572,25 +644,7 @@ let read_all_lines ~(masc_root : string) ~(keeper_name : string) ~(trace_id : st
                 redacted = (match json |> member "redacted" with `Bool b -> b | _ -> false);
               })
           | _ ->
-              Some (Tool_call {
-                ts = json |> member "ts" |> to_float;
-                ts_iso = json |> member "ts_iso" |> to_string;
-                turn = json |> member "turn" |> to_int;
-                round = json |> member "round" |> to_int;
-                tool_name = json |> member "tool_name" |> to_string;
-                args_json = json |> member "args" |> Yojson.Safe.to_string;
-                gate_decision = Pass;
-                result =
-                  (match json |> member "result" with
-                   | `Null -> None
-                   | `String s -> Some s
-                   | _ -> None);
-                duration_ms = json |> member "duration_ms" |> to_int;
-                error =
-                  (match json |> member "error" with
-                   | `Null -> None
-                   | `String s -> Some s
-                   | _ -> None);
-                cost_usd = json |> member "cost_usd" |> to_float;
-              })
+              (match tool_call_entry_of_json json with
+               | Some (entry, _parsed_gate) -> Some (Tool_call entry)
+               | None -> None)
         with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None)

--- a/lib/trajectory.mli
+++ b/lib/trajectory.mli
@@ -23,6 +23,16 @@ type tool_call_entry = {
   cost_usd : float;
 }
 
+type gate_decode_summary = {
+  parsed_gate_count : int;
+  legacy_default_count : int;
+}
+
+type entries_read_result = {
+  entries : tool_call_entry list;
+  gate_decode : gate_decode_summary;
+}
+
 type trajectory_outcome =
   | Completed
   | Failed of string
@@ -76,7 +86,12 @@ val outcome_to_json : trajectory_outcome -> Yojson.Safe.t
 val outcome_to_string : trajectory_outcome -> string
 val default_result_truncation : int
 val default_thinking_truncation : int
-val entry_to_json : ?result_max_len:int -> tool_call_entry -> Yojson.Safe.t
+val entry_to_json :
+  ?result_max_len:int ->
+  ?runtime_contract:Yojson.Safe.t ->
+  ?action_radius:Yojson.Safe.t ->
+  tool_call_entry ->
+  Yojson.Safe.t
 val thinking_entry_to_json : ?content_max_len:int -> thinking_entry -> Yojson.Safe.t
 val trajectory_line_to_json : ?result_max_len:int -> ?content_max_len:int -> trajectory_line -> Yojson.Safe.t
 val trajectory_to_json : trajectory -> Yojson.Safe.t
@@ -87,6 +102,8 @@ val trajectories_dir : string -> string -> string
 val trajectory_path : string -> string -> string -> string
 
 val append_entry :
+  ?runtime_contract:Yojson.Safe.t ->
+  ?action_radius:Yojson.Safe.t ->
   masc_root:string -> keeper_name:string -> trace_id:string ->
   tool_call_entry -> unit
 
@@ -131,7 +148,13 @@ val create_accumulator :
 val set_task_id : accumulator -> string -> unit
 val clear_task_id : accumulator -> unit
 val increment_turn : accumulator -> unit
-val record_entry : accumulator -> tool_call_entry -> unit
+val record_entry :
+  ?runtime_contract:Yojson.Safe.t ->
+  ?action_radius:Yojson.Safe.t ->
+  ?on_persist_error:(exn -> unit) ->
+  accumulator ->
+  tool_call_entry ->
+  unit
 val finalize : accumulator -> trajectory_outcome -> trajectory
 
 val detect_entropy :
@@ -180,3 +203,9 @@ val read_entries_since :
   tool_call_entry list
 (** Read entries from all trace files for a keeper with ts >= [since].
     Results sorted chronologically. *)
+
+val read_entries_since_result :
+  masc_root:string -> keeper_name:string -> since:float ->
+  entries_read_result
+(** Like {!read_entries_since}, plus whether the persisted gate object was
+    parsed or defaulted for legacy rows that had no readable gate payload. *)

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -126,6 +126,7 @@ let test_turn_context_fields_stored () =
   with_tmp_log (fun () ->
     Keeper_tool_call_log.set_turn_context
       ~keeper_name:"k"
+      ~agent_name:"keeper-k-agent"
       ~lane:"tool_required"
       ~tool_choice:"required"
       ~thinking_enabled:false
@@ -133,18 +134,27 @@ let test_turn_context_fields_stored () =
       ~prompt_fingerprint:"prompt-fp-k"
       ~trace_id:"trace-k"
       ~session_id:"trace-k"
+      ~generation:3
       ~turn:7
       ~keeper_turn_id:7
       ~task_id:"task-runtime-trust"
       ~goal_ids:["goal-short"; "goal-long"]
       ~sandbox_profile:"docker"
+      ~sandbox_root:"/tmp/k-sandbox"
+      ~allowed_paths:["/tmp/k-sandbox"; "/tmp/shared"]
       ~network_mode:"inherit"
       ~shared_memory_scope:"team"
       ~approval_mode:"manual"
+      ~tool_surface_class:"execution"
+      ~visible_tool_count:2
+      ~required_tools:["keeper_bash"]
+      ~missing_required_tools:["keeper_fs_edit"]
+      ~cascade_profile:"tool_use_strict"
       ();
     Keeper_tool_call_log.log_call
       ~keeper_name:"k" ~tool_name:"masc_status"
-      ~input:(`Assoc []) ~output_text:"ok"
+      ~input:(`Assoc [("path", `String "/tmp/k-sandbox/status.json")])
+      ~output_text:"ok"
       ~success:true ~duration_ms:2.0 ();
     let entries = Keeper_tool_call_log.read_recent () in
     Alcotest.(check int) "one entry" 1 (List.length entries);
@@ -191,7 +201,40 @@ let test_turn_context_fields_stored () =
       (Safe_ops.json_string_opt "shared_memory_scope" entry);
     Alcotest.(check (option string)) "approval_mode field"
       (Some "manual")
-      (Safe_ops.json_string_opt "approval_mode" entry))
+      (Safe_ops.json_string_opt "approval_mode" entry);
+    let runtime_contract =
+      Yojson.Safe.Util.member "runtime_contract" entry
+    in
+    Alcotest.(check (option string)) "runtime_contract keeper"
+      (Some "k")
+      (Safe_ops.json_string_opt "keeper_name" runtime_contract);
+    Alcotest.(check (option string)) "runtime_contract agent"
+      (Some "keeper-k-agent")
+      (Safe_ops.json_string_opt "agent_name" runtime_contract);
+    Alcotest.(check int) "runtime_contract generation" 3
+      (Safe_ops.json_int ~default:0 "generation" runtime_contract);
+    Alcotest.(check (list string)) "runtime_contract allowed_paths"
+      ["/tmp/k-sandbox"; "/tmp/shared"]
+      Yojson.Safe.Util.(
+        runtime_contract |> member "allowed_paths" |> to_list |> List.map to_string);
+    Alcotest.(check (list string)) "runtime_contract required_tools"
+      ["keeper_bash"]
+      Yojson.Safe.Util.(
+        runtime_contract |> member "required_tools" |> to_list |> List.map to_string);
+    Alcotest.(check (list string)) "runtime_contract missing_required_tools"
+      ["keeper_fs_edit"]
+      Yojson.Safe.Util.(
+        runtime_contract |> member "missing_required_tools" |> to_list
+        |> List.map to_string);
+    let action_radius = Yojson.Safe.Util.member "action_radius" entry in
+    Alcotest.(check (option string)) "action_radius tool"
+      (Some "masc_status")
+      (Safe_ops.json_string_opt "tool_name" action_radius);
+    Alcotest.(check (option string)) "action_radius target path"
+      (Some "/tmp/k-sandbox/status.json")
+      (Safe_ops.json_string_opt "target_path" action_radius);
+    Alcotest.(check bool) "action_radius success" true
+      (Safe_ops.json_bool ~default:false "success" action_radius))
 
 let test_turn_context_fields_absent_without_context () =
   with_tmp_log (fun () ->

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -513,12 +513,70 @@ let test_summary_includes_freshness_metadata () =
       | Some (`Int age) -> float_of_int age
       | _ -> Alcotest.fail "expected latest_age_s"
     in
+    let health =
+      match List.assoc_opt "health" fields with
+      | Some (`String value) -> value
+      | _ -> Alcotest.fail "expected health"
+    in
+    let producer =
+      match List.assoc_opt "producer" fields with
+      | Some (`String value) -> value
+      | _ -> Alcotest.fail "expected producer"
+    in
+    let freshness_slo_s =
+      match List.assoc_opt "freshness_slo_s" fields with
+      | Some (`Float value) -> value
+      | Some (`Int value) -> float_of_int value
+      | _ -> Alcotest.fail "expected freshness_slo_s"
+    in
     Alcotest.(check bool) "latest ts close to event" true
       (abs_float (latest_ts -. recent_ts) < 5.0);
     Alcotest.(check bool) "latest iso present" true (String.length latest_iso > 0);
     Alcotest.(check bool) "latest age bounded" true
-      (latest_age >= 0.0 && latest_age < 180.0)
+      (latest_age >= 0.0 && latest_age < 180.0);
+    Alcotest.(check string) "health ok" "ok" health;
+    Alcotest.(check string) "producer" "telemetry_eio" producer;
+    Alcotest.(check (float 0.1)) "freshness SLO" 900.0 freshness_slo_s
   | None -> Alcotest.fail "expected agent_event source summary"
+
+let test_summary_surfaces_coverage_gaps () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_summary_gap" in
+  let root = masc_root dir in
+  Telemetry_coverage_gap.record
+    ~masc_root:root
+    ~source:"agent_event"
+    ~producer:"telemetry_eio"
+    ~durable_store:(Filename.concat root "telemetry")
+    ~dashboard_surface:"/api/v1/dashboard/telemetry"
+    ~stale_reason:"append_failed"
+    ~error:"disk full"
+    ();
+  let json = Telemetry_unified.summary_json ~base_path:dir ~masc_root:root () in
+  match json with
+  | `Assoc fields ->
+    let gaps =
+      match List.assoc_opt "coverage_gaps" fields with
+      | Some (`List values) -> values
+      | _ -> Alcotest.fail "expected coverage_gaps"
+    in
+    Alcotest.(check int) "one coverage gap" 1 (List.length gaps);
+    let source_summary =
+      match List.assoc_opt "sources" fields with
+      | Some (`List sources) ->
+        List.find
+          (fun source_json ->
+            String.equal "agent_event"
+              (json_string_field "source" source_json))
+          sources
+      | _ -> Alcotest.fail "expected sources"
+    in
+    Alcotest.(check string) "agent_event health" "coverage_gap"
+      (json_string_field "health" source_summary);
+    Alcotest.(check string) "agent_event stale reason" "append_failed"
+      (json_string_field "stale_reason" source_summary)
+  | _ -> Alcotest.fail "expected Assoc"
 
 let test_summary_counts_all_entries_beyond_recent_cap () =
   Eio_main.run @@ fun env ->
@@ -616,6 +674,8 @@ let () =
           Alcotest.test_case "with data" `Quick test_summary_with_data;
           Alcotest.test_case "includes freshness metadata" `Quick
             test_summary_includes_freshness_metadata;
+          Alcotest.test_case "surfaces coverage gaps" `Quick
+            test_summary_surfaces_coverage_gaps;
           Alcotest.test_case "counts all rows beyond recent cap" `Quick
             test_summary_counts_all_entries_beyond_recent_cap;
         ] );

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -397,6 +397,49 @@ let test_hourly_bucket_json () =
   Alcotest.(check int) "calls" 5 (json |> member "call_count" |> to_int);
   Alcotest.(check int) "errors" 1 (json |> member "error_count" |> to_int)
 
+let test_entry_to_json_includes_contract_and_radius () =
+  let entry : Trajectory.tool_call_entry = {
+    ts = 1000.0;
+    ts_iso = "2026-04-06T10:00:00Z";
+    turn = 1;
+    round = 1;
+    tool_name = "keeper_bash";
+    args_json = {|{"command":"pwd"}|};
+    gate_decision = Trajectory.Pass;
+    result = Some "/tmp/work";
+    duration_ms = 25;
+    error = None;
+    cost_usd = 0.0001;
+  } in
+  let runtime_contract =
+    Keeper_runtime_contract.runtime_contract_json_from_fields
+      ~keeper_name:"alpha"
+      ~agent_name:"alpha-agent"
+      ~trace_id:"trace-alpha"
+      ~generation:2
+      ~sandbox_profile:"docker"
+      ()
+  in
+  let action_radius =
+    Keeper_runtime_contract.action_radius_json
+      ~tool_name:"keeper_bash"
+      ~input:(`Assoc [("cwd", `String "/tmp/work")])
+      ~success:true
+      ~duration_ms:25.0
+      ()
+  in
+  let json =
+    Trajectory.entry_to_json ~runtime_contract ~action_radius entry
+  in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string) "runtime keeper" "alpha"
+    (json |> member "runtime_contract" |> member "keeper_name" |> to_string);
+  Alcotest.(check string) "action tool" "keeper_bash"
+    (json |> member "action_radius" |> member "tool_name" |> to_string);
+  Alcotest.(check string) "observed path" "/tmp/work"
+    (json |> member "action_radius" |> member "observed_paths" |> to_list
+     |> List.hd |> to_string)
+
 (* ================================================================ *)
 (* Test: read_entries_since (file-based)                             *)
 (* ================================================================ *)
@@ -424,6 +467,37 @@ let test_read_entries_since () =
     (* Read since ts=0 should get all 3 *)
     let all = Trajectory.read_entries_since ~masc_root ~keeper_name:keeper ~since:0.0 in
     Alcotest.(check int) "all entries" 3 (List.length all))
+
+let test_read_entries_since_result_parses_gate_summary () =
+  with_tmpdir (fun dir ->
+    let masc_root = dir in
+    let keeper = "test-keeper" in
+    let traj_dir = Filename.concat masc_root (Printf.sprintf "trajectories/%s" keeper) in
+    ignore (Sys.command (Printf.sprintf "mkdir -p %s" (Filename.quote traj_dir)));
+    let path = Filename.concat traj_dir "trace-101.jsonl" in
+    let rows =
+      [
+        {|{"ts":1000.0,"ts_iso":"2026-04-06T10:00:00Z","turn":1,"round":1,"tool_name":"keeper_bash","args":{},"gate":{"status":"pass"},"result":"ok","duration_ms":100,"error":null,"cost_usd":0.001}|};
+        {|{"ts":2000.0,"ts_iso":"2026-04-06T10:01:00Z","turn":1,"round":2,"tool_name":"keeper_bash","args":{},"gate":{"status":"reject","reason":"blocked"},"result":null,"duration_ms":0,"error":"blocked","cost_usd":0.0}|};
+        {|{"ts":3000.0,"ts_iso":"2026-04-06T10:02:00Z","turn":1,"round":3,"tool_name":"keeper_bash","args":{},"result":"legacy","duration_ms":10,"error":null,"cost_usd":0.001}|};
+      ]
+    in
+    let oc = open_out path in
+    List.iter (Printf.fprintf oc "%s\n") rows;
+    close_out oc;
+    let result =
+      Trajectory.read_entries_since_result ~masc_root ~keeper_name:keeper
+        ~since:0.0
+    in
+    Alcotest.(check int) "three entries" 3 (List.length result.Trajectory.entries);
+    Alcotest.(check int) "parsed gate count" 2
+      result.Trajectory.gate_decode.parsed_gate_count;
+    Alcotest.(check int) "legacy default count" 1
+      result.Trajectory.gate_decode.legacy_default_count;
+    match List.nth result.Trajectory.entries 1 with
+    | { Trajectory.gate_decision = Trajectory.Reject reason; _ } ->
+      Alcotest.(check string) "reject reason parsed" "blocked" reason
+    | _ -> Alcotest.fail "expected persisted reject gate")
 
 let test_read_entries_since_no_dir () =
   with_tmpdir (fun dir ->
@@ -483,9 +557,13 @@ let () =
     ("json_serialization", [
       Alcotest.test_case "tool_stat to json" `Quick test_tool_stat_json_roundtrip;
       Alcotest.test_case "hourly_bucket to json" `Quick test_hourly_bucket_json;
+      Alcotest.test_case "entry carries runtime/action telemetry" `Quick
+        test_entry_to_json_includes_contract_and_radius;
     ]);
     ("read_entries_since", [
       Alcotest.test_case "filter by timestamp" `Quick test_read_entries_since;
+      Alcotest.test_case "parses persisted gate summary" `Quick
+        test_read_entries_since_result_parses_gate_summary;
       Alcotest.test_case "nonexistent directory" `Quick test_read_entries_since_no_dir;
     ]);
   ]


### PR DESCRIPTION
## Summary

- Write keeper/OAS post-tool executions to both `.masc/tool_calls` and trajectory `Tool_call` rows when a trajectory accumulator exists.
- Add canonical `runtime_contract` and `action_radius` payloads to keeper tool-call logs, trajectory rows, execution receipts, and unified telemetry projections.
- Surface telemetry freshness/health metadata plus durable coverage gaps so dashboard lanes can explain stale or missing sources.
- Add the MASC/OAS telemetry flow audit report and JSON sidecar for the before/after evidence trail.

## Root Cause

Keeper/OAS tool calls could reach the durable `.masc/tool_calls` lane and execution receipts while the trajectory-backed `/tool-stats` lane missed the same execution. That made dashboard surfaces disagree even though parts of the live pipeline were still flowing.

## OAS Boundary

OAS was audited read-only and left unchanged. The generic correlation fields (`correlation_id`, `run_id`, `caused_by`, `raw_trace_run_id`) were already preserved at the audited EventBus, forwarding, raw-trace, and runtime evidence boundaries. MASC-specific keeper/task/goal/sandbox/approval/runtime-radius semantics stay in MASC.

## Validation

- `scripts/dune-local.sh build test/test_trajectory.exe test/test_keeper_tool_call_log.exe test/test_dashboard_keeper_routes.exe test/test_dashboard_execution.exe test/test_telemetry_unified.exe test/test_telemetry_eio_coverage.exe`
- `_build/default/test/test_trajectory.exe`
- `_build/default/test/test_keeper_tool_call_log.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-dashboard-keeper-routes _build/default/test/test_dashboard_keeper_routes.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-dashboard-execution _build/default/test/test_dashboard_execution.exe`
- `_build/default/test/test_telemetry_unified.exe`
- `_build/default/test/test_telemetry_eio_coverage.exe`
- `pnpm --dir dashboard exec vitest run --no-file-parallelism --maxWorkers=1 src/components/keeper-tool-telemetry.test.ts src/components/telemetry-unified.test.ts src/api/dashboard.test.ts`
- `pnpm --dir dashboard typecheck`
- `git diff --check HEAD~1..HEAD`

## Not Run

- Live keeper-turn acceptance against this rebased commit. The local server on `127.0.0.1:8935` was a root-workspace build, not this worktree build.