### PR TITLE
feat(keeper-cli): auto-construct Claude Code / Kimi CLI MCP config behind flag (#10049)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -500,6 +500,7 @@
    keeper_tools_oas
    keeper_guards
    keeper_hooks_oas
+   keeper_cli_mcp_config
    keeper_extend_turns
    keeper_llm_bridge
    keeper_tool_alias

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1897,10 +1897,25 @@ let run_turn
             visible to the subprocess (see issue #10049 for fix plan)"
            meta.name cascade_name);
     let cli_transport_overrides =
+      let claude_mcp_config =
+        match keeper_oas_context.claude_mcp_config with
+        | Some _ as cfg -> cfg
+        | None ->
+            (* #10049 Option C: auto-construct from the keeper bearer
+               token + server host/port when env is unset. Gated
+               behind MASC_AUTO_CONSTRUCT_CLAUDE_MCP (default false) so
+               the existing explicit-env path stays unchanged until
+               operators opt in. Returns [None] when the flag is off
+               or the token file is missing — the Log.Keeper.warn
+               above (iter 10052) still fires for visibility. *)
+            Keeper_cli_mcp_config.try_construct_for_keeper
+              ~base_path:config.base_path
+              ~agent_name:meta.agent_name
+      in
       Some
         ({
           cwd = Some keeper_sandbox_root;
-          claude_mcp_config = keeper_oas_context.claude_mcp_config;
+          claude_mcp_config;
           claude_allowed_tools = None;
           claude_permission_mode = None;
           claude_max_turns = Some max_turns;

--- a/lib/keeper/keeper_cli_mcp_config.ml
+++ b/lib/keeper/keeper_cli_mcp_config.ml
@@ -1,0 +1,58 @@
+(* #10049: auto-construct Claude Code / Kimi CLI MCP config JSON for
+   keepers whose cascade includes those CLI providers but whose env
+   (OAS_CLAUDE_MCP_CONFIG) is unset.
+
+   Without this fallback, Claude Code / Kimi CLI launches with no
+   [mcpServers] entry and the keeper cannot reach the masc-mcp HTTP
+   endpoint; tool calls surface as "keeper_shell not in session's tool
+   registry". See #10049 for the full root-cause analysis and the
+   codex_cli sibling path in [server_runtime_bootstrap.sync_codex_mcp_config].
+
+   Gated behind [MASC_AUTO_CONSTRUCT_CLAUDE_MCP] (default false) so the
+   existing explicit-env path stays unchanged until operators opt in. *)
+
+let feature_flag_env = "MASC_AUTO_CONSTRUCT_CLAUDE_MCP"
+
+let feature_enabled () =
+  Env_config_core.get_bool ~default:false feature_flag_env
+
+let build_json ~url ~bearer_token =
+  let json =
+    `Assoc
+      [
+        ( "mcpServers",
+          `Assoc
+            [
+              ( "masc",
+                `Assoc
+                  [
+                    "url", `String url;
+                    "type", `String "http";
+                    ( "headers",
+                      `Assoc
+                        [ "Authorization", `String ("Bearer " ^ bearer_token) ] );
+                  ] );
+            ] );
+      ]
+  in
+  Yojson.Safe.to_string json
+
+let try_construct_for_keeper ~base_path ~agent_name =
+  if not (feature_enabled ()) then None
+  else
+    let token_file =
+      Filename.concat (Auth.auth_dir base_path) (agent_name ^ ".token")
+    in
+    if not (Sys.file_exists token_file) then None
+    else
+      try
+        let raw_token = String.trim (Fs_compat.load_file token_file) in
+        if String.equal raw_token "" then None
+        else
+          let host = Env_config_core.masc_host () in
+          let port = Env_config_core.masc_http_port_int () in
+          let url = Printf.sprintf "http://%s:%d/mcp" host port in
+          Some (build_json ~url ~bearer_token:raw_token)
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | _ -> None

--- a/lib/keeper/keeper_cli_mcp_config.mli
+++ b/lib/keeper/keeper_cli_mcp_config.mli
@@ -1,0 +1,15 @@
+(* #10049: auto-construct Claude Code / Kimi CLI MCP config JSON when
+   OAS_CLAUDE_MCP_CONFIG env is unset. Gated behind
+   MASC_AUTO_CONSTRUCT_CLAUDE_MCP (default false). *)
+
+val feature_flag_env : string
+
+val feature_enabled : unit -> bool
+
+val build_json : url:string -> bearer_token:string -> string
+
+val try_construct_for_keeper :
+  base_path:string -> agent_name:string -> string option
+(** Returns [Some json] if the feature flag is on AND the token file
+    exists, non-empty, and host/port are resolvable. [None] otherwise;
+    the caller falls through to the existing behaviour unchanged. *)

--- a/test/dune
+++ b/test/dune
@@ -371,6 +371,7 @@
         test_keeper_meta_cas_retry
         test_judge_diagnostics
         test_judge_json_recovery
+        test_keeper_cli_mcp_config
         test_keeper_identity_parse
         test_worker_runtime
         test_capability_registry
@@ -543,6 +544,7 @@
         test_keeper_meta_cas_retry
         test_judge_diagnostics
         test_judge_json_recovery
+        test_keeper_cli_mcp_config
         test_keeper_identity_parse
         test_worker_runtime
         test_capability_registry

--- a/test/test_keeper_cli_mcp_config.ml
+++ b/test/test_keeper_cli_mcp_config.ml
@@ -1,0 +1,42 @@
+(* #10049: tests for Claude Code / Kimi CLI MCP config auto-construction. *)
+
+open Alcotest
+
+module K = Masc_mcp.Keeper_cli_mcp_config
+
+let test_build_json_shape () =
+  let out = K.build_json ~url:"http://127.0.0.1:8935/mcp" ~bearer_token:"tok" in
+  let json = Yojson.Safe.from_string out in
+  let open Yojson.Safe.Util in
+  let masc =
+    json |> member "mcpServers" |> member "masc"
+  in
+  check string "url field"
+    "http://127.0.0.1:8935/mcp"
+    (masc |> member "url" |> to_string);
+  check string "type field" "http" (masc |> member "type" |> to_string);
+  check string "authorization header" "Bearer tok"
+    (masc |> member "headers" |> member "Authorization" |> to_string)
+
+let test_feature_flag_env_name () =
+  check string "env key is stable"
+    "MASC_AUTO_CONSTRUCT_CLAUDE_MCP" K.feature_flag_env
+
+let test_try_construct_disabled_by_default () =
+  (* No env set, no token file: should return None regardless. *)
+  Unix.putenv K.feature_flag_env "";
+  let base = Filename.get_temp_dir_name () in
+  let out = K.try_construct_for_keeper ~base_path:base ~agent_name:"nobody" in
+  check (option string) "disabled flag returns None" None out
+
+let () =
+  run "keeper_cli_mcp_config" [
+    "build_json", [
+      test_case "shape includes url/type/Authorization" `Quick
+        test_build_json_shape;
+    ];
+    "flag", [
+      test_case "env key stable" `Quick test_feature_flag_env_name;
+      test_case "disabled → None" `Quick test_try_construct_disabled_by_default;
+    ]
+  ]


### PR DESCRIPTION
## 요약

#10049 Option C 구현. PR #10052(Option B warn)에 이어 **auto-construct MCP config**를 feature flag `MASC_AUTO_CONSTRUCT_CLAUDE_MCP` 뒤에 추가.

Closes #10049.

## 근본 원인 (이슈 인용)

`OAS_CLAUDE_MCP_CONFIG` 미설정 시 Claude Code / Kimi CLI subprocess가 `mcpServers` 엔트리 없이 launch → keeper가 masc-mcp HTTP 엔드포인트에 접근 불가 → tool call이 `keeper_shell not in session's tool registry`로 실패. Codex CLI는 `MASC_SYNC_CODEX_MCP_CONFIG`로 이미 처리되는데 Claude/Kimi만 gap.

## 변경 내용

### 1. 새 모듈 `Keeper_cli_mcp_config`

- `feature_flag_env = "MASC_AUTO_CONSTRUCT_CLAUDE_MCP"` (default false)
- `feature_enabled` — 플래그 확인
- `build_json ~url ~bearer_token` — JSON 생성 (pure, test하기 쉬움)
- `try_construct_for_keeper ~base_path ~agent_name` — 통합 엔트리

### 2. `keeper_agent_run.ml` cli_transport_overrides 변경

```diff
  let cli_transport_overrides =
+   let claude_mcp_config =
+     match keeper_oas_context.claude_mcp_config with
+     | Some _ as cfg -> cfg
+     | None ->
+         Keeper_cli_mcp_config.try_construct_for_keeper
+           ~base_path:config.base_path
+           ~agent_name:meta.agent_name
+   in
    Some
      ({
        cwd = Some keeper_sandbox_root;
-       claude_mcp_config = keeper_oas_context.claude_mcp_config;
+       claude_mcp_config;
        ...
```

Plug-in 방식 — 기존 warn (`#10052`)은 유지.

### 3. 동작 매트릭스

| 환경 | OAS_CLAUDE_MCP_CONFIG | MASC_AUTO_CONSTRUCT_CLAUDE_MCP | 결과 |
|------|----------------------|-------------------------------|------|
| default | unset | unset/false | `None` (기존 동작, warn 로그) |
| 기존 explicit | set | (무관) | env 값 사용 (기존 동작 불변) |
| **new opt-in** | **unset** | **true** | **자동 생성 JSON 주입** |
| new opt-in but broken | unset | true | 토큰 파일 없음/공백 → `None` + warn |

## 생성되는 JSON

```json
{
  "mcpServers": {
    "masc": {
      "url": "http://<masc_host>:<masc_http_port>/mcp",
      "type": "http",
      "headers": { "Authorization": "Bearer <keeper-token>" }
    }
  }
}
```

- 토큰 경로: `<base_path>/.masc/auth/<agent_name>.token` (Codex sync와 동일 파일)
- 호스트: `Env_config_core.masc_host ()`
- 포트: `Env_config_core.masc_http_port_int ()`

## 테스트

`test/test_keeper_cli_mcp_config.ml` 3개 scenario:
- `build_json` 출력 shape (url, type, Authorization header 검증)
- `feature_flag_env` 이름 안정성
- 플래그 비활성 시 `None` 반환

```bash
$ dune exec --root . test/test_keeper_cli_mcp_config.exe
# → Test Successful in 0.001s. 3 tests run.
```

## 회귀 리스크

매우 낮음 — feature flag 기본 OFF. 기존 배포 operator는 영향 없음. Opt-in 한 operator만 새 동작.

예외 안전: 토큰 파일 read/JSON 직렬화 실패 시 `None`으로 falls through (try/with `_ -> None`, `Eio.Cancel.Cancelled`는 re-raise).

## Security 고려

- Bearer token이 명시적으로 url/header 쌍에 노출됨. Claude Code subprocess가 이 config를 stdin으로 받아 로컬 MCP HTTP로 전달.
- `Auth.save_private_text_file` (6xx permissions)로 저장된 같은 토큰을 read. 유출 경로 동일.
- 이미 Codex sync가 `~/.codex/config.toml`에 같은 방식으로 bearer를 쓰므로 위험 모델 동일.

## 후속

Kimi CLI는 이 config를 어떻게 소비하는지 runtime 검증 필요 (현재 코드는 Claude Code 스펙 사용). Kimi-specific config가 다르면 추가 PR 필요.

## 참고

- Issue #10049 — Option A/B/C/D 제안
- PR #10052 — Option B (warn) 완료
- 이 PR — Option C (auto-construct)
- 관련: Codex sync `server_runtime_bootstrap.sync_codex_mcp_config`
