### PR TITLE
[codex] Remove coordination FSM hardcoded evidence strings

### DIFF
--- a/lib/coordination_product.ml
+++ b/lib/coordination_product.ml
@@ -95,6 +95,15 @@ type ids =
   ; agent_name : string option
   }
 
+module Ref_key = struct
+  let goal_id = "goal_id"
+  let task_id = "task_id"
+  let task_ids = "task_ids"
+  let post_id = "post_id"
+  let post_ids = "post_ids"
+  let agent_name = "agent_name"
+end
+
 let empty_ids = { goal_id = None; task_ids = []; post_ids = []; agent_name = None }
 
 type task_counts =
@@ -162,9 +171,55 @@ let default_facts =
   }
 ;;
 
+type evidence_source =
+  | Source_goal_store
+  | Source_task_store
+  | Source_board
+  | Source_economy
+  | Source_telemetry
+
+let evidence_source_to_string = function
+  | Source_goal_store -> "goal_store"
+  | Source_task_store -> "task_store"
+  | Source_board -> "board"
+  | Source_economy -> "economy"
+  | Source_telemetry -> "telemetry"
+;;
+
+type evidence_kind =
+  | Evidence_goal_phase
+  | Evidence_task_status
+  | Evidence_board_post
+  | Evidence_economy_earn_task_done
+  | Evidence_economy_earn_board_post
+  | Evidence_economy_earn_upvote
+  | Evidence_economy_earn_mention_response
+  | Evidence_economy_spend_model_call
+  | Evidence_economy_spend_deliberation
+  | Evidence_economy_adjustment
+  | Evidence_telemetry_task_started
+  | Evidence_telemetry_task_completed
+  | Evidence_telemetry_tool_called
+
+let evidence_kind_to_string = function
+  | Evidence_goal_phase -> "goal_phase"
+  | Evidence_task_status -> "task_status"
+  | Evidence_board_post -> "post"
+  | Evidence_economy_earn_task_done -> "earn_task_done"
+  | Evidence_economy_earn_board_post -> "earn_board_post"
+  | Evidence_economy_earn_upvote -> "earn_upvote"
+  | Evidence_economy_earn_mention_response -> "earn_mention_response"
+  | Evidence_economy_spend_model_call -> "spend_model_call"
+  | Evidence_economy_spend_deliberation -> "spend_deliberation"
+  | Evidence_economy_adjustment -> "adjustment"
+  | Evidence_telemetry_task_started -> "task_started"
+  | Evidence_telemetry_task_completed -> "task_completed"
+  | Evidence_telemetry_tool_called -> "tool_called"
+;;
+
 type evidence =
-  { source : string
-  ; kind : string
+  { source : evidence_source
+  ; kind : evidence_kind
   ; id : string option
   ; label : string
   ; detail : string
@@ -329,10 +384,10 @@ let string_list_to_yojson values = `List (List.map (fun value -> `String value) 
 
 let ids_to_yojson ids =
   `Assoc
-    [ "goal_id", option_string_to_yojson ids.goal_id
-    ; "task_ids", string_list_to_yojson ids.task_ids
-    ; "post_ids", string_list_to_yojson ids.post_ids
-    ; "agent_name", option_string_to_yojson ids.agent_name
+    [ Ref_key.goal_id, option_string_to_yojson ids.goal_id
+    ; Ref_key.task_ids, string_list_to_yojson ids.task_ids
+    ; Ref_key.post_ids, string_list_to_yojson ids.post_ids
+    ; Ref_key.agent_name, option_string_to_yojson ids.agent_name
     ]
 ;;
 
@@ -365,8 +420,8 @@ let option_float_to_yojson = function
 
 let evidence_to_yojson evidence =
   `Assoc
-    [ "source", `String evidence.source
-    ; "kind", `String evidence.kind
+    [ "source", `String (evidence_source_to_string evidence.source)
+    ; "kind", `String (evidence_kind_to_string evidence.kind)
     ; "id", option_string_to_yojson evidence.id
     ; "label", `String evidence.label
     ; "detail", `String evidence.detail
@@ -413,6 +468,14 @@ type snapshot =
   ; violations : violation list
   }
 
+let schema_version_current = 1
+
+type snapshot_mode = Advisory
+
+let snapshot_mode_to_string = function
+  | Advisory -> "advisory"
+;;
+
 let snapshot products =
   let violations = List.concat_map check_invariants products in
   { products; violations }
@@ -435,13 +498,13 @@ let evidence_for_violation products violation =
   |> Option.value ~default:[]
 ;;
 
-let snapshot_to_yojson snapshot =
+let snapshot_to_yojson ?projection_error snapshot =
   let evidence =
     snapshot.products |> List.concat_map (fun product -> product.evidence)
   in
-  `Assoc
-    [ "schema_version", `Int 1
-    ; "mode", `String "advisory"
+  let fields =
+    [ "schema_version", `Int schema_version_current
+    ; "mode", `String (snapshot_mode_to_string Advisory)
     ; ( "summary"
       , `Assoc
           [ "products", `Int (List.length snapshot.products)
@@ -459,4 +522,8 @@ let snapshot_to_yojson snapshot =
                violation_to_yojson ~evidence violation)
              snapshot.violations) )
     ]
+  in
+  match projection_error with
+  | Some message -> `Assoc (fields @ [ "projection_error", `String message ])
+  | None -> `Assoc fields
 ;;

--- a/lib/coordination_product.mli
+++ b/lib/coordination_product.mli
@@ -59,6 +59,15 @@ type ids =
   ; agent_name : string option
   }
 
+module Ref_key : sig
+  val goal_id : string
+  val task_id : string
+  val task_ids : string
+  val post_id : string
+  val post_ids : string
+  val agent_name : string
+end
+
 val empty_ids : ids
 
 type task_counts =
@@ -86,9 +95,35 @@ type facts =
 
 val default_facts : facts
 
+type evidence_source =
+  | Source_goal_store
+  | Source_task_store
+  | Source_board
+  | Source_economy
+  | Source_telemetry
+
+val evidence_source_to_string : evidence_source -> string
+
+type evidence_kind =
+  | Evidence_goal_phase
+  | Evidence_task_status
+  | Evidence_board_post
+  | Evidence_economy_earn_task_done
+  | Evidence_economy_earn_board_post
+  | Evidence_economy_earn_upvote
+  | Evidence_economy_earn_mention_response
+  | Evidence_economy_spend_model_call
+  | Evidence_economy_spend_deliberation
+  | Evidence_economy_adjustment
+  | Evidence_telemetry_task_started
+  | Evidence_telemetry_task_completed
+  | Evidence_telemetry_tool_called
+
+val evidence_kind_to_string : evidence_kind -> string
+
 type evidence =
-  { source : string
-  ; kind : string
+  { source : evidence_source
+  ; kind : evidence_kind
   ; id : string option
   ; label : string
   ; detail : string
@@ -136,5 +171,10 @@ type snapshot =
   ; violations : violation list
   }
 
+val schema_version_current : int
+
+type snapshot_mode = Advisory
+
+val snapshot_mode_to_string : snapshot_mode -> string
 val snapshot : product list -> snapshot
-val snapshot_to_yojson : snapshot -> Yojson.Safe.t
+val snapshot_to_yojson : ?projection_error:string -> snapshot -> Yojson.Safe.t

--- a/lib/coordination_product_snapshot.ml
+++ b/lib/coordination_product_snapshot.ml
@@ -104,14 +104,19 @@ let spend_kind = function
     false
 ;;
 
-let transaction_kind_to_string = function
-  | Agent_economy.Earn_task_done -> "earn_task_done"
-  | Agent_economy.Earn_board_post -> "earn_board_post"
-  | Agent_economy.Earn_upvote -> "earn_upvote"
-  | Agent_economy.Earn_mention_response -> "earn_mention_response"
-  | Agent_economy.Spend_model_call -> "spend_model_call"
-  | Agent_economy.Spend_deliberation -> "spend_deliberation"
-  | Agent_economy.Adjustment -> "adjustment"
+let transaction_kind_to_evidence_kind = function
+  | Agent_economy.Earn_task_done ->
+    Coordination_product.Evidence_economy_earn_task_done
+  | Agent_economy.Earn_board_post ->
+    Coordination_product.Evidence_economy_earn_board_post
+  | Agent_economy.Earn_upvote -> Coordination_product.Evidence_economy_earn_upvote
+  | Agent_economy.Earn_mention_response ->
+    Coordination_product.Evidence_economy_earn_mention_response
+  | Agent_economy.Spend_model_call ->
+    Coordination_product.Evidence_economy_spend_model_call
+  | Agent_economy.Spend_deliberation ->
+    Coordination_product.Evidence_economy_spend_deliberation
+  | Agent_economy.Adjustment -> Coordination_product.Evidence_economy_adjustment
 ;;
 
 let json_links_any (ids : Coordination_product.ids) json =
@@ -124,12 +129,12 @@ let json_links_any (ids : Coordination_product.ids) json =
     assoc_string_list key json |> List.exists (fun value -> List.mem value values)
   in
   (match ids.goal_id with
-   | Some goal_id -> matches_one "goal_id" [ goal_id ]
+   | Some goal_id -> matches_one Coordination_product.Ref_key.goal_id [ goal_id ]
    | None -> false)
-  || matches_one "task_id" ids.task_ids
-  || matches_many "task_ids" ids.task_ids
-  || matches_one "post_id" ids.post_ids
-  || matches_many "post_ids" ids.post_ids
+  || matches_one Coordination_product.Ref_key.task_id ids.task_ids
+  || matches_many Coordination_product.Ref_key.task_ids ids.task_ids
+  || matches_one Coordination_product.Ref_key.post_id ids.post_ids
+  || matches_many Coordination_product.Ref_key.post_ids ids.post_ids
 ;;
 
 let transaction_links_any ids (txn : Agent_economy.transaction) =
@@ -178,8 +183,8 @@ let reward_facts ~(ids : Coordination_product.ids) transactions =
 let task_evidence (ids : Coordination_product.ids) (task : Types.task)
   : Coordination_product.evidence
   =
-  { source = "task_store"
-  ; kind = "task_status"
+  { source = Coordination_product.Source_task_store
+  ; kind = Coordination_product.Evidence_task_status
   ; id = Some task.id
   ; label = truncate ~limit:80 task.title
   ; detail =
@@ -196,8 +201,8 @@ let task_evidence (ids : Coordination_product.ids) (task : Types.task)
 let goal_evidence (ids : Coordination_product.ids) (goal : Goal_store.goal)
   : Coordination_product.evidence
   =
-  { source = "goal_store"
-  ; kind = "goal_phase"
+  { source = Coordination_product.Source_goal_store
+  ; kind = Coordination_product.Evidence_goal_phase
   ; id = Some goal.id
   ; label = truncate ~limit:80 goal.title
   ; detail =
@@ -215,8 +220,8 @@ let board_evidence (ids : Coordination_product.ids) (post : Board.post)
   : Coordination_product.evidence
   =
   let body = if String.trim post.content <> "" then post.content else post.body in
-  { source = "board"
-  ; kind = "post"
+  { source = Coordination_product.Source_board
+  ; kind = Coordination_product.Evidence_board_post
   ; id = Some (post_id_string post)
   ; label = truncate ~limit:80 post.title
   ; detail =
@@ -233,11 +238,12 @@ let board_evidence (ids : Coordination_product.ids) (post : Board.post)
 let economy_evidence (ids : Coordination_product.ids) (txn : Agent_economy.transaction)
   : Coordination_product.evidence
   =
-  { source = "economy"
-  ; kind = transaction_kind_to_string txn.kind
+  let kind = transaction_kind_to_evidence_kind txn.kind in
+  { source = Coordination_product.Source_economy
+  ; kind
   ; id = Some txn.id
   ; label =
-      Printf.sprintf "%s %.2f" (transaction_kind_to_string txn.kind) txn.amount
+      Printf.sprintf "%s %.2f" (Coordination_product.evidence_kind_to_string kind) txn.amount
   ; detail =
       Printf.sprintf
         "agent=%s; balance_after=%.2f; reason=%s"
@@ -258,8 +264,8 @@ let telemetry_evidence_for_event
   | Telemetry_eio.Task_started { task_id; agent_id } when List.mem task_id ids.task_ids
     ->
     Some
-      { source = "telemetry"
-      ; kind = "task_started"
+      { source = Coordination_product.Source_telemetry
+      ; kind = Coordination_product.Evidence_telemetry_task_started
       ; id = Some task_id
       ; label = "task started"
       ; detail = Printf.sprintf "agent=%s" agent_id
@@ -269,8 +275,8 @@ let telemetry_evidence_for_event
   | Telemetry_eio.Task_completed { task_id; duration_ms; success }
     when List.mem task_id ids.task_ids ->
     Some
-      { source = "telemetry"
-      ; kind = "task_completed"
+      { source = Coordination_product.Source_telemetry
+      ; kind = Coordination_product.Evidence_telemetry_task_completed
       ; id = Some task_id
       ; label = "task completed"
       ; detail = Printf.sprintf "success=%b; duration_ms=%d" success duration_ms
@@ -281,8 +287,8 @@ let telemetry_evidence_for_event
       { tool_name; success; duration_ms; agent_id = Some agent_id; source }
     when Option.equal String.equal ids.agent_name (Some agent_id) ->
     Some
-      { source = "telemetry"
-      ; kind = "tool_called"
+      { source = Coordination_product.Source_telemetry
+      ; kind = Coordination_product.Evidence_telemetry_tool_called
       ; id = Some tool_name
       ; label = tool_name
       ; detail =
@@ -329,16 +335,16 @@ let evidence_for ~ids ~tasks ~linked_posts ~transactions ~telemetry_events =
 let post_links_ids (ids : Coordination_product.ids) (post : Board.post) =
   let post_goal =
     match ids.goal_id with
-    | Some goal_id -> meta_string "goal_id" post = Some goal_id
+    | Some goal_id -> meta_string Coordination_product.Ref_key.goal_id post = Some goal_id
     | None -> false
   in
   let post_task =
-    match meta_string "task_id" post with
+    match meta_string Coordination_product.Ref_key.task_id post with
     | Some task_id -> List.mem task_id ids.task_ids
     | None -> false
   in
   let post_tasks =
-    meta_string_list "task_ids" post
+    meta_string_list Coordination_product.Ref_key.task_ids post
     |> List.exists (fun task_id -> List.mem task_id ids.task_ids)
   in
   post_goal || post_task || post_tasks
@@ -432,7 +438,7 @@ let product_for_goal ~all_tasks ~posts ~transactions ~telemetry_events ~persist_
     (goal : Goal_store.goal)
   =
   let tasks =
-    all_tasks |> List.filter (Convergence.task_matches_goal ~goal_id:goal.id)
+    all_tasks |> List.filter (Convergence.task_has_goal_id ~goal_id:goal.id)
   in
   let product =
     product_for
@@ -517,7 +523,7 @@ let severity_counts (snapshot : Coordination_product.snapshot) =
   }
 ;;
 
-let to_yojson = Coordination_product.snapshot_to_yojson
+let to_yojson snapshot = Coordination_product.snapshot_to_yojson snapshot
 let build_yojson config = build config |> to_yojson
 
 let safe_build_yojson config =
@@ -525,20 +531,7 @@ let safe_build_yojson config =
   | exn ->
     let message = Printexc.to_string exn in
     Log.Coord.warn "coordination product snapshot failed: %s" message;
-    `Assoc
-      [ "schema_version", `Int 1
-      ; "mode", `String "advisory"
-      ; ( "summary"
-        , `Assoc
-            [ "products", `Int 0
-            ; "violations", `Int 0
-            ; "evidence", `Int 0
-            ; ( "severity_counts"
-              , `Assoc [ "info", `Int 0; "warn", `Int 0; "error", `Int 0 ] )
-            ] )
-      ; "products", `List []
-      ; "evidence", `List []
-      ; "violations", `List []
-      ; "projection_error", `String message
-      ]
+    Coordination_product.snapshot_to_yojson
+      ~projection_error:message
+      (Coordination_product.snapshot [])
 ;;

--- a/lib/goal/convergence.ml
+++ b/lib/goal/convergence.ml
@@ -51,11 +51,16 @@ let title_has_goal_marker ~goal_id title =
     done;
     !found
 
+let task_has_goal_id ~goal_id (task : Types.task) =
+  match task.goal_id with
+  | Some linked_goal_id -> String.equal linked_goal_id goal_id
+  | None -> false
+
 (** A task belongs to a goal when its structured goal_id matches or its title
     carries the legacy [goal:<id>] marker. *)
 let task_matches_goal ~goal_id (task : Types.task) =
   match task.goal_id with
-  | Some linked_goal_id -> String.equal linked_goal_id goal_id
+  | Some _ -> task_has_goal_id ~goal_id task
   | None -> title_has_goal_marker ~goal_id task.title
 
 let is_terminal (task : Types.task) =

--- a/lib/goal/convergence.mli
+++ b/lib/goal/convergence.mli
@@ -19,6 +19,12 @@ val goal_title_marker : string -> string
     legacy [[goal:<id>]] title marker. *)
 val task_matches_goal : goal_id:string -> Types.task -> bool
 
+(** True only when the task's structured [goal_id] field matches.
+
+    New read models should prefer this over {!task_matches_goal}; the latter is
+    retained for legacy convergence compatibility with old title-marker tasks. *)
+val task_has_goal_id : goal_id:string -> Types.task -> bool
+
 (** Check whether a goal's tasks have converged.
 
     Returns [Some signal] when convergence or stagnation is detected,

--- a/test/test_coordination_product.ml
+++ b/test/test_coordination_product.ml
@@ -24,6 +24,25 @@ let ids ?goal_id ?(task_ids = []) ?(post_ids = []) ?agent_name () : CP.ids =
   { goal_id; task_ids; post_ids; agent_name }
 ;;
 
+let task ?goal_id ~id ~title () : Types.task =
+  { id
+  ; title
+  ; description = ""
+  ; task_status = Types.Todo
+  ; priority = 3
+  ; files = []
+  ; created_at = "2026-04-24T00:00:00Z"
+  ; created_by = None
+  ; worktree = None
+  ; goal_id
+  ; stage = None
+  ; contract = None
+  ; handoff_context = None
+  ; cycle_count = 0
+  ; do_not_reclaim_reason = None
+  }
+;;
+
 let product
       ?goal
       ?(task = CP.No_task)
@@ -62,6 +81,38 @@ let test_task_axis_projection () =
     "mixed aggregate"
     "mixed"
     (CP.task_phase_to_string (CP.task_phase_of_counts [ done_status; cancelled_status ]))
+;;
+
+let test_goal_linkage_prefers_structured_goal_id () =
+  let explicit =
+    task ~id:"task-1" ~title:"Implement product FSM" ~goal_id:"goal-1" ()
+  in
+  let legacy =
+    task ~id:"task-2" ~title:"[goal:goal-1] legacy marker" ()
+  in
+  let explicit_other_with_legacy_marker =
+    task
+      ~id:"task-3"
+      ~title:"[goal:goal-1] stale legacy marker"
+      ~goal_id:"goal-2"
+      ()
+  in
+  Alcotest.(check bool)
+    "explicit goal_id matches"
+    true
+    (Convergence.task_has_goal_id ~goal_id:"goal-1" explicit);
+  Alcotest.(check bool)
+    "legacy marker does not satisfy structured matcher"
+    false
+    (Convergence.task_has_goal_id ~goal_id:"goal-1" legacy);
+  Alcotest.(check bool)
+    "legacy matcher remains backward compatible"
+    true
+    (Convergence.task_matches_goal ~goal_id:"goal-1" legacy);
+  Alcotest.(check bool)
+    "structured goal_id wins over stale title marker"
+    false
+    (Convergence.task_matches_goal ~goal_id:"goal-1" explicit_other_with_legacy_marker)
 ;;
 
 let test_goal_terminal_open_tasks_violation () =
@@ -166,8 +217,8 @@ let test_snapshot_json () =
   let task_counts = CP.task_counts_of_statuses [ done_status ] in
   let refs = ids ~goal_id:"goal-1" ~task_ids:[ "task-1" ] () in
   let evidence : CP.evidence =
-    { source = "telemetry"
-    ; kind = "task_completed"
+    { source = CP.Source_telemetry
+    ; kind = CP.Evidence_telemetry_task_completed
     ; id = Some "task-1"
     ; label = "task completed"
     ; detail = "success=true; duration_ms=42"
@@ -206,6 +257,12 @@ let () =
   Alcotest.run
     "Coordination_product"
     [ "task_axis", [ Alcotest.test_case "projection" `Quick test_task_axis_projection ]
+    ; ( "goal_linkage"
+      , [ Alcotest.test_case
+            "structured goal_id matcher"
+            `Quick
+            test_goal_linkage_prefers_structured_goal_id
+        ] )
     ; ( "invariants"
       , [ Alcotest.test_case
             "terminal goal with open task"


### PR DESCRIPTION
## Summary
- Replace coordination FSM evidence source/kind free-form strings with typed OCaml variants and compile-checked serializers.
- Centralize coordination ref JSON keys and snapshot schema/mode serialization.
- Make the coordination product snapshot link goal tasks through structured task.goal_id instead of the legacy title-marker fallback; keep the legacy convergence matcher backward-compatible.

## Validation
- git diff --check HEAD~1..HEAD
- env MASC_DUNE_THROTTLE=0 DUNE_BUILD_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/remove-coordination-hardcoding/_build-hardcoding-check DUNE_JOBS=1 scripts/dune-local.sh build ./test/test_coordination_product.exe ./test/test_dashboard_http_core.exe ./test/test_tool_coord_coverage.exe
- env MASC_BASE_PATH=/tmp/masc-hardcoding-rebase-coordination-test MASC_BASE_PATH_INPUT=/tmp/masc-hardcoding-rebase-coordination-test _build-hardcoding-check/default/test/test_coordination_product.exe
- env MASC_BASE_PATH=/tmp/masc-hardcoding-rebase-dashboard-test MASC_BASE_PATH_INPUT=/tmp/masc-hardcoding-rebase-dashboard-test _build-hardcoding-check/default/test/test_dashboard_http_core.exe
- env MASC_BASE_PATH=/tmp/masc-hardcoding-rebase-toolcoord-test MASC_BASE_PATH_INPUT=/tmp/masc-hardcoding-rebase-toolcoord-test _build-hardcoding-check/default/test/test_tool_coord_coverage.exe