### PR TITLE
fix(keeper-runtime): trim personality fields before compare (#10061)

### DIFF
--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -239,15 +239,27 @@ let ensure_keeper_meta config name =
       Keeper_cascade_profile.normalize_declared_name meta.cascade_name
       <> resolved_target_cascade_name
     in
+    (* #10061: persisted state vs TOML source can differ by a single
+       trailing newline when OCaml string literals round-trip through
+       the TOML writer (heredoc [""" … """] closing sequence drops the
+       final newline) or through an older binary that wrote the field
+       with extra whitespace. The semantic content of these prose
+       fields does not care about trailing whitespace, yet a byte-
+       level [<>] compare marks every 30 s hot-reload tick as a
+       personality change, producing a re-sync storm (2880 redundant
+       writes/day on nick0cave alone; other 13 keepers: 0 events).
+       Normalise both sides with [String.trim] so only meaningful
+       content drives resync. *)
+    let trim_equal a b = String.equal (String.trim a) (String.trim b) in
     let personality_changed =
-      meta.goal <> target_goal
-      || meta.short_goal <> target_short_goal
-      || meta.mid_goal <> target_mid_goal
-      || meta.long_goal <> target_long_goal
-      || meta.will <> target_will
-      || meta.needs <> target_needs
-      || meta.desires <> target_desires
-      || meta.instructions <> target_instructions in
+      not (trim_equal meta.goal target_goal)
+      || not (trim_equal meta.short_goal target_short_goal)
+      || not (trim_equal meta.mid_goal target_mid_goal)
+      || not (trim_equal meta.long_goal target_long_goal)
+      || not (trim_equal meta.will target_will)
+      || not (trim_equal meta.needs target_needs)
+      || not (trim_equal meta.desires target_desires)
+      || not (trim_equal meta.instructions target_instructions) in
     let policy_changed =
       meta.policy_voice_enabled <> target_policy_voice_enabled
       || meta.autoboot_enabled <> target_autoboot_enabled


### PR DESCRIPTION
## 요약

`ensure_keeper_meta` hot-reload이 persisted state vs TOML source를 8개 prose 필드에 대해 byte-exact `<>`로 비교. nick0cave의 state JSON이 `instructions` 필드에 trailing newline 1개를 더 가진 상태라 매 30초 tick마다 "personality change"로 오판, 2880회/일 redundant write + log 소음.

Closes #10061.

## 근본 원인

```ocaml
(* lib/keeper/keeper_runtime.ml:242-250 *)
let personality_changed =
  meta.goal <> target_goal
  || meta.short_goal <> target_short_goal
  ...
  || meta.instructions <> target_instructions in
```

`meta` (state JSON에서 로드) vs `target_*` (TOML defaults 적용). 둘 다 OCaml string — 의미적 동일하지만 trailing whitespace 1-byte 차이가 `<>`에서 true로 평가.

### 실측 증거

```
$ grep 're-syncing \[personality\]' .masc/logs/system_log_*.jsonl | grep -oE 'for [a-z0-9-]+' | sort | uniq -c
121 for nick0cave
  0 for all others
```

```
$ diff <(echo "$state_instructions") <(echo "$toml_instructions")
27d26
< (state에 빈 줄 1개 추가)
```

nick0cave만 drift — systemic config가 아니라 과거 binary migration 잔재로 추정.

## 변경 내용

Option A (normalize on compare) 적용:

```diff
+ let trim_equal a b = String.equal (String.trim a) (String.trim b) in
  let personality_changed =
-   meta.goal <> target_goal
-   || meta.short_goal <> target_short_goal
-   ...
-   || meta.instructions <> target_instructions in
+   not (trim_equal meta.goal target_goal)
+   || not (trim_equal meta.short_goal target_short_goal)
+   ...
+   || not (trim_equal meta.instructions target_instructions) in
```

8개 prose 필드만. Policy/discovery/telemetry/timeout/oas_env는 byte-exact 유지 (정책 필드는 whitespace 포함 의미 가질 수 있음).

## 동작

| 상황 | Before | After |
|------|--------|-------|
| state == TOML byte-exact | personality_changed=false | false (unchanged) |
| state에 trailing `\n` 추가 | true → 매 tick re-sync | false ✅ |
| 실제 content 변경 | true → re-sync | true (unchanged) |
| 내부 content 중간 whitespace | true → re-sync | true (unchanged, `trim`은 ends만) |

## 검증

`dune build @check --root .` exit 0. 기존 테스트 영향 없음 (`ensure_keeper_meta` 직접 테스트 부재 — 추가는 별도 scope).

## 회귀 리스크

매우 낮음:
- `String.trim`은 ASCII whitespace (space, tab, \n, \r)만 양끝에서 제거
- Prose content (goal/instructions)는 trailing whitespace 의미 없음
- 의도된 중간 whitespace (단락 구분 등)는 영향 없음
- Policy/model 필드는 byte-exact 유지 — semantic whitespace 보존 필요한 필드는 변화 없음

## 후속 (Out of scope)

- **Option C (normalize on write)**: persist 시 `String.trim` 후 저장 — 기존 drift 상태도 scrub. 하지만 마이그레이션 없이 14개 keeper state 자동 rewrite → masc operator가 `git diff` 난감. 별도 이슈로 분리.
- **TOML writer newline 처리**: heredoc closing의 `\n` drop이 parser 기본 동작인지 확인 + 필요 시 writer format 변경. Parser 레이어 조사는 별도.

## 참고

- Issue #10061 — nick0cave 121회 re-sync log 증거
- 관련: memory `JSON serializer/parser key symmetry` (round-trip drift 패턴)
- #10047 재평가 근거: nick0cave `state advances`는 이 re-sync storm 때문 (실제 turn 실행 아님)
