### PR TITLE
fix(keeper-metrics): zero model_used on status_tick heartbeat (#10018 follow-up)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -940,7 +940,19 @@ let write_heartbeat_snapshot
         ; "agent_name", `String meta_current.agent_name
         ; "trace_id", `String (Keeper_id.Trace_id.to_string meta_current.runtime.trace_id)
         ; "generation", `Int meta_current.runtime.generation
-        ; "model_used", `String meta_current.runtime.usage.last_model_used
+        ; (* #10018 follow-up: [model_used] is also snapshot-stale.
+             last_model_used is the *previous turn's* provider label;
+             emitting it on every heartbeat made
+             per-provider latency histograms and dashboards show
+             ghost provider names long after the binary that wrote
+             them was rebuilt (observed qa-king / nick0cave stuck on
+             "deterministic_required_tool_fallback" across
+             post-#9967 rebuild).  Emit empty string here so
+             downstream per-provider aggregation ignores heartbeat
+             records.  `last_model_used_label` on the keeper state
+             JSON still reflects the last real turn for dashboard
+             snapshot panels. *)
+          "model_used", `String ""
         ; (* #10018: status_tick is a snapshot, not an LLM-call event.
              Emitting [runtime.usage.last_*_tokens] and [last_latency_ms]
              caused the last turn's per-turn values to be repeat-emitted


### PR DESCRIPTION
## Summary

Follow-up to #10022. status_tick heartbeat still emits stale `model_used` from `runtime.usage.last_model_used`. Replace with empty string.

## Observed

post-#10022 fleet metrics show qa-king / nick0cave heartbeats with `model_used="deterministic_required_tool_fallback"` — a provider name that #9967 removed from the source (string absent from current running binary via `strings`). The value persists in state JSON from a pre-rebuild binary session and the heartbeat snapshot re-emits it every ~10s, so per-provider latency histograms and cost aggregation see a ghost provider that does not exist in any live code path.

## Change

`lib/keeper/keeper_keepalive.ml:943` — `model_used` on status_tick is now `""`. Real turn records (channel=turn / scheduled_autonomous) continue to carry `surface_model_used`. Keeper state JSON `last_model_used` is unchanged so dashboard snapshot panels still show last-known provider.

Same "snapshot vs event" boundary principle as #9950 (compaction fields) and #10022 (usage/latency).

## Test plan

- [x] `dune build lib/keeper/` green
- [ ] Observe heartbeat jsonl after restart: `model_used` should be empty, turn-channel records unchanged
- [ ] Per-provider latency histogram no longer shows `deterministic_required_tool_fallback`

## Related

- #10018 (status_tick stale-copy umbrella)
- #10022 (zero usage/latency — this is the model_used mirror)
- #10008 (ghost drtf surfaced by this stale-copy)
- #9967 (deleted the provider; state still holds the name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)