### PR TITLE
fix(keeper): bind internal runtime MCP tools

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -157,19 +157,22 @@ let handle_request
     ?(profile = Full)
     ?mcp_session_id
     ?auth_token
+    ?(internal_keeper_runtime = false)
     state
     request_str =
   Mcp_server_eio_protocol.handle_request
-    ~handle_call_tool_eio:(fun ~sw ~clock ~profile ?mcp_session_id ?auth_token state id params ->
+    ~handle_call_tool_eio:(fun ~sw ~clock ~profile ?mcp_session_id ?auth_token
+        ~internal_keeper_runtime state id params ->
        Mcp_server_eio_call_tool.handle_call_tool_eio
          ~execute_tool_eio
          ~maybe_emit_resource_notifications:Mcp_server_eio_protocol.maybe_emit_resource_notifications
          ~broadcast_tools_list_changed:Mcp_server_eio_protocol.broadcast_tools_list_changed
-         ~sw ~clock ~profile ?mcp_session_id ?auth_token state id params)
+         ~sw ~clock ~profile ?mcp_session_id ?auth_token
+         ~internal_keeper_runtime state id params)
     ~handle_read_resource_eio:Mcp_server_eio_resource.handle_read_resource_eio
     ~clock ~sw
     ~profile:(profile : tool_profile :> Mcp_server_eio_types.tool_profile)
-    ?mcp_session_id ?auth_token state request_str
+    ?mcp_session_id ?auth_token ~internal_keeper_runtime state request_str
 
 (** Re-export transport mode from protocol for backward compatibility *)
 type transport_mode = Mcp_server_eio_protocol.transport_mode = Framed | LineDelimited

--- a/lib/mcp_server_eio.mli
+++ b/lib/mcp_server_eio.mli
@@ -107,6 +107,7 @@ val handle_request :
   ?profile:tool_profile ->
   ?mcp_session_id:string ->
   ?auth_token:string ->
+  ?internal_keeper_runtime:bool ->
   server_state ->
   string ->
   Yojson.Safe.t
@@ -119,6 +120,7 @@ val execute_tool_eio :
   ?profile:tool_profile ->
   ?mcp_session_id:string ->
   ?auth_token:string ->
+  ?internal_keeper_runtime:bool ->
   server_state ->
   name:string ->
   arguments:Yojson.Safe.t ->

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -318,7 +318,7 @@ let resolve_managed_agent_call ?mcp_session_id params =
 (** Handle tools/call JSON-RPC method *)
 let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     ~broadcast_tools_list_changed ~sw ~clock ?(profile = Full) ?mcp_session_id
-    ?auth_token state id params =
+    ?auth_token ?(internal_keeper_runtime = false) state id params =
   let module U = Yojson.Safe.Util in
   let make_response = Mcp_transport_protocol.make_response in
   let (name, arguments) =
@@ -345,6 +345,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
         match tool_timeout_sec_opt ~tool_name:name ~_arguments:arguments with
         | None ->
             execute_tool_eio ~sw ~clock ?profile:(Some profile) ?mcp_session_id ?auth_token
+              ?internal_keeper_runtime:(Some internal_keeper_runtime)
               state ~name ~arguments
         | Some timeout_sec ->
             (try
@@ -358,6 +359,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
                      ?profile:(Some profile)
                      ?mcp_session_id
                      ?auth_token
+                     ?internal_keeper_runtime:(Some internal_keeper_runtime)
                      state
                      ~name
                      ~arguments)

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -41,7 +41,8 @@ let direct_call_block_message name =
       name
 
 let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
-    ?mcp_session_id ?auth_token state ~name ~arguments =
+    ?mcp_session_id ?auth_token ?(internal_keeper_runtime = false) state ~name
+    ~arguments =
   (* clock parameter used for Session_eio.wait_for_message *)
   (* mcp_session_id: HTTP MCP session ID for agent_name persistence across tool calls *)
   let module U = Yojson.Safe.Util in
@@ -157,6 +158,17 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
     | Some _ as token -> token
     | None -> arg_get_string_opt "token"
   in
+  let verified_internal_keeper_runtime =
+    internal_keeper_runtime
+    &&
+    match token with
+    | Some raw -> Auth.verify_internal_keeper_token config.base_path ~token:raw
+    | None -> false
+  in
+  let internal_keeper_runtime_tool =
+    verified_internal_keeper_runtime
+    && Tool_catalog.is_on_surface Tool_catalog.Keeper_internal name
+  in
 
   let resolve_owner_keeper_identity owner_name =
     let candidates =
@@ -193,7 +205,10 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
   in
 
   let mode_gate_error =
-    if not (Tool_catalog.allow_direct_call name) then
+    if
+      (not internal_keeper_runtime_tool)
+      && not (Tool_catalog.allow_direct_call name)
+    then
       Some (direct_call_block_message name)
     else
       None
@@ -684,10 +699,105 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
         Printf.sprintf "Unknown tool: %s — did you mean: %s? (%s)"
           name (String.concat ", " xs) reason
   in
+  let internal_keeper_meta_of_agent () =
+    match Keeper_registry.find_by_agent_name agent_name with
+    | Some (entry : Keeper_registry.registry_entry)
+      when String.equal entry.base_path config.base_path ->
+        Ok entry.meta
+    | Some _ | None ->
+        let candidates =
+          [
+            Keeper_types.canonical_keeper_name_from_agent_name agent_name;
+            Keeper_types.canonical_keeper_name agent_name;
+          ]
+          |> List.filter_map (function
+               | Some value when String.trim value <> "" ->
+                   Some (String.trim value)
+               | _ -> None)
+          |> List.sort_uniq String.compare
+        in
+        let rec loop = function
+          | [] ->
+              Error
+                (Printf.sprintf
+                   "Internal keeper runtime request is not bound to a known \
+                    keeper agent: %s"
+                   agent_name)
+          | candidate :: rest -> (
+              match Keeper_types.read_meta_resolved config candidate with
+              | Ok (Some (_resolved_name, meta)) -> Ok meta
+              | Ok None -> loop rest
+              | Error msg -> Error msg)
+        in
+        loop candidates
+  in
+  let dispatch_internal_keeper_runtime_tool () =
+    match Tool_dispatch.run_pre_hooks ~name ~args:arguments with
+    | (Some blocked, _) -> Some (Tool_result.to_legacy blocked)
+    | (None, coerced_args) -> (
+        match internal_keeper_meta_of_agent () with
+        | Error msg -> Some (false, msg)
+        | Ok meta ->
+            let ctx_work =
+              Keeper_exec_context.create ~system_prompt:""
+                ~max_tokens:(Keeper_config.keeper_unified_max_tokens ())
+            in
+            let turn_sandbox_runtime =
+              match meta.Keeper_types.sandbox_profile with
+              | Keeper_types.Docker ->
+                  Some
+                    (Keeper_turn_sandbox_runtime.create ~config ~meta
+                       ~network_mode:meta.network_mode ())
+              | Keeper_types.Local -> None
+            in
+            let turn_sandbox_runtime_git =
+              match meta.Keeper_types.sandbox_profile with
+              | Keeper_types.Docker ->
+                  if Env_config_keeper.KeeperSandbox.hard_mode () then
+                    None
+                  else
+                    Some
+                      (Keeper_turn_sandbox_runtime.create ~config ~meta
+                         ~network_mode:Keeper_types.Network_inherit ())
+              | Keeper_types.Local -> None
+            in
+            let cleanup () =
+              (match turn_sandbox_runtime with
+               | Some runtime -> Keeper_turn_sandbox_runtime.cleanup runtime
+               | None -> ());
+              match turn_sandbox_runtime_git with
+              | Some runtime -> Keeper_turn_sandbox_runtime.cleanup runtime
+              | None -> ()
+            in
+            let exec_cache = Some (Masc_exec.Exec_cache.create ()) in
+            let result =
+              Fun.protect
+                ~finally:cleanup
+                (fun () ->
+                  Keeper_exec_tools.execute_keeper_tool_call_with_outcome
+                    ~config ~meta ~ctx_work ?turn_sandbox_runtime
+                    ?turn_sandbox_runtime_git ~exec_cache ~name
+                    ~input:coerced_args ())
+            in
+            let success =
+              match result.Keeper_exec_tools.outcome with
+              | `Success -> true
+              | `Failure -> false
+            in
+            Some (success, result.raw_output))
+  in
   (* Primary dispatch: mint token at I/O boundary, then O(1) tag lookup.
      Tool_token validates the name exists in the tag registry (Parse, Don't
      Validate). If mint fails, the tool is truly unknown. *)
-  match Tool_dispatch.mint_token ~name with
+  match
+    if internal_keeper_runtime_tool then
+      dispatch_internal_keeper_runtime_tool ()
+    else
+      None
+  with
+  | Some result ->
+      with_system_internal_audit ~agent_name result
+  | None -> match Tool_dispatch.mint_token ~name with
   | Error reason ->
       with_system_internal_audit ~agent_name
         (false, format_unknown_tool_error ~reason)

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -193,8 +193,8 @@ let public_tool_help_schemas () =
   Config.visible_tool_schemas ()
 
 let handle_list_tools_eio ?(profile = Full) ?names ?(include_hidden = false)
-    ?(include_deprecated = false) ?(include_usage = false) ?cursor
-    ?agent_id
+    ?(include_deprecated = false) ?(include_usage = false)
+    ?(include_keeper_internal = false) ?cursor ?agent_id
     state id =
   let usage_summary =
     if include_usage then
@@ -204,6 +204,7 @@ let handle_list_tools_eio ?(profile = Full) ?names ?(include_hidden = false)
   in
   let tools =
     TP.tool_schemas_for_profile ~include_hidden ~include_deprecated
+      ~include_keeper_internal
       state profile
     |> (match names with
        | None -> Fun.id
@@ -518,6 +519,7 @@ let handle_request
     ?(profile = Full)
     ?mcp_session_id
     ?auth_token
+    ?(internal_keeper_runtime = false)
     state
     request_str =
   try
@@ -600,6 +602,7 @@ let handle_request
                            in
                            handle_list_tools_eio ~profile:list_profile ?names
                              ~include_hidden ~include_deprecated ~include_usage
+                             ~include_keeper_internal:internal_keeper_runtime
                              ?cursor ?agent_id:auth_token state id)
                    | "tools/call" ->
                        (match req.params with
@@ -616,7 +619,11 @@ let handle_request
                               | Operator_remote | Managed_agent -> profile
                               | Full -> Full
                             in
-                            if not (TP.tool_allowed_in_profile state call_profile name) then
+                            if not
+                                 (TP.tool_allowed_in_profile
+                                    ~internal_keeper_runtime
+                                    state call_profile name)
+                            then
                                make_error ~id (-32601)
                                  (unavailable_tool_message name)
                              else (
@@ -630,7 +637,9 @@ let handle_request
                                     name (jsonrpc_id_label id)
                                     (match mcp_session_id with Some s -> s | None -> "none"));
                                let result =
-                                 handle_call_tool_eio ~sw ~clock ~profile ?mcp_session_id ?auth_token state id params
+                                 handle_call_tool_eio ~sw ~clock ~profile
+                                   ?mcp_session_id ?auth_token
+                                   ~internal_keeper_runtime state id params
                                in
                                let outcome = tool_call_outcome result in
                                Log.Mcp.emit Log.Info

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -60,29 +60,42 @@ Use masc_heartbeat periodically; use @agent mentions in masc_broadcast. \
 Prefer worktrees for parallel work. \
 Use masc_tool_help to inspect tool contracts and prefer the smallest useful surface."
 
-let tool_schemas_for_profile ?(include_hidden = false) ?(include_deprecated = false)
-    _state profile =
+let tool_schemas_for_profile ?(include_hidden = false)
+    ?(include_deprecated = false) ?(include_keeper_internal = false) _state
+    profile =
   let schemas =
     match profile with
     | Full ->
         let show_all = include_hidden || Tool_catalog.full_surface_override () in
+        let keeper_internal_schemas =
+          if not include_keeper_internal then []
+          else
+            Tool_shard.keeper_model_tools
+            |> List.filter (fun (schema : Types.tool_schema) ->
+                   Tool_catalog.is_on_surface Tool_catalog.Keeper_internal
+                     schema.name
+                   && Tool_catalog.is_visible ~include_hidden:true
+                        ~include_deprecated schema.name)
+        in
         let all =
           Config.visible_tool_schemas
-            ~include_hidden:show_all ~include_deprecated ()
+            ~include_hidden:(show_all || include_keeper_internal)
+            ~include_deprecated ()
+          @ keeper_internal_schemas
+          |> dedupe_tool_schemas_by_name
         in
-        let without_internal =
+        let full_profile_tools =
           List.filter
             (fun (schema : Types.tool_schema) ->
-              not (Tool_catalog.is_on_surface Tool_catalog.Keeper_internal schema.name)
-              && not (Tool_catalog.is_on_surface Tool_catalog.System_internal schema.name))
+              let is_keeper_internal =
+                Tool_catalog.is_on_surface Tool_catalog.Keeper_internal schema.name
+              in
+              (not (Tool_catalog.is_on_surface Tool_catalog.System_internal schema.name))
+              && (if is_keeper_internal then include_keeper_internal
+                  else show_all || Tool_catalog.is_public_mcp schema.name))
             all
         in
-        if show_all then without_internal
-        else
-          List.filter
-            (fun (schema : Types.tool_schema) ->
-              Tool_catalog.is_public_mcp schema.name)
-            without_internal
+        full_profile_tools
     | Managed_agent ->
         let passthrough =
           Config.visible_tool_schemas ~include_hidden:true ~include_deprecated:false ()
@@ -96,11 +109,12 @@ let tool_schemas_for_profile ?(include_hidden = false) ?(include_deprecated = fa
   in
   schemas
 
-let tool_allowed_in_profile state profile tool_name =
+let tool_allowed_in_profile ?(internal_keeper_runtime = false) state profile
+    tool_name =
   match profile with
   | Full ->
       if Tool_catalog.is_on_surface Tool_catalog.Keeper_internal tool_name then
-        false
+        internal_keeper_runtime
       else
         let allowed_schema_names =
           Config.visible_tool_schemas ~include_hidden:true ~include_deprecated:true ()

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -156,6 +156,9 @@ let public_mcp_tool_names_of_oas_tools =
 let public_mcp_tool_requires_bound_actor =
   Oas_worker_exec_transport.public_mcp_tool_requires_bound_actor
 
+let runtime_mcp_tool_requires_bound_actor =
+  Oas_worker_exec_transport.runtime_mcp_tool_requires_bound_actor
+
 let runtime_mcp_policy_with_masc_agent_name =
   Oas_worker_exec_transport.runtime_mcp_policy_with_masc_agent_name
 
@@ -173,6 +176,9 @@ let tool_names_are_public_mcp =
 
 let public_mcp_runtime_policy_of_tool_names =
   Oas_worker_exec_transport.public_mcp_runtime_policy_of_tool_names
+
+let runtime_mcp_policy_of_tool_names =
+  Oas_worker_exec_transport.runtime_mcp_policy_of_tool_names
 
 let provider_label =
   Oas_worker_exec_transport.provider_label

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -255,8 +255,23 @@ let public_mcp_tools_of_oas_tools (tools : Oas.Tool.t list) =
 let tool_names_are_public_mcp (tool_names : string list) =
   tool_names <> [] && List.for_all Tool_catalog.is_public_mcp tool_names
 
-let public_mcp_tool_requires_bound_actor tool_name =
+let runtime_mcp_tool_requires_bound_actor tool_name =
   Tool_catalog.requires_actor_binding tool_name
+
+let public_mcp_tool_requires_bound_actor tool_name =
+  Tool_catalog.is_public_mcp tool_name
+  && runtime_mcp_tool_requires_bound_actor tool_name
+
+let tool_names_are_runtime_mcp ?(allow_keeper_internal = false)
+    (tool_names : string list) =
+  tool_names <> []
+  && List.for_all
+    (fun tool_name ->
+      Tool_catalog.is_public_mcp tool_name
+      ||
+      (allow_keeper_internal
+       && Tool_catalog.is_on_surface Tool_catalog.Keeper_internal tool_name))
+    tool_names
 
 let trim_nonempty_string raw =
   let trimmed = String.trim raw in
@@ -268,18 +283,32 @@ let trim_nonempty value =
 let first_nonempty_env names =
   List.find_map (fun name -> Sys.getenv_opt name |> trim_nonempty) names
 
-let public_mcp_runtime_policy_of_tool_names ?agent_name (tool_names : string list) :
+let runtime_mcp_policy_of_tool_names ?agent_name
+    ?(allow_keeper_internal = false) (tool_names : string list) :
     Llm_provider.Llm_transport.runtime_mcp_policy option =
   let tool_names = dedupe_preserve_order tool_names in
-  if not (tool_names_are_public_mcp tool_names) then
+  let has_keeper_internal =
+    List.exists
+      (Tool_catalog.is_on_surface Tool_catalog.Keeper_internal)
+      tool_names
+  in
+  if
+    not (tool_names_are_runtime_mcp ~allow_keeper_internal tool_names)
+  then
     None
   else
     let agent_name = Option.bind agent_name trim_nonempty_string in
     let keeper_name = Option.bind agent_name keeper_name_of_agent_name in
+    let internal_keeper_token =
+      first_nonempty_env [ "MASC_INTERNAL_MCP_TOKEN" ]
+    in
+    if has_keeper_internal
+       && (Option.is_none keeper_name || Option.is_none internal_keeper_token)
+    then
+      None
+    else
     let masc_headers =
-      match
-        (keeper_name, first_nonempty_env [ "MASC_INTERNAL_MCP_TOKEN" ])
-      with
+      match (keeper_name, internal_keeper_token) with
       | Some keeper_name, Some token ->
           let agent_header =
             match agent_name with
@@ -311,6 +340,10 @@ let public_mcp_runtime_policy_of_tool_names ?agent_name (tool_names : string lis
         strict = true;
         disable_builtin_tools = true;
       }
+
+let public_mcp_runtime_policy_of_tool_names ?agent_name (tool_names : string list) :
+    Llm_provider.Llm_transport.runtime_mcp_policy option =
+  runtime_mcp_policy_of_tool_names ?agent_name tool_names
 
 let provider_label (provider_cfg : Llm_provider.Provider_config.t) =
   Printf.sprintf "%s:%s"
@@ -386,11 +419,23 @@ let resolve_tool_lane_for_oas_tools
   let requested_agent_name =
     Option.bind agent_name trim_nonempty_string
   in
+  let keeper_internal_tool_names =
+    match requested_agent_name with
+    | Some agent_name when Option.is_some (keeper_name_of_agent_name agent_name) ->
+        tools
+        |> List.filter (fun (tool : Oas.Tool.t) ->
+               Tool_catalog.is_on_surface Tool_catalog.Keeper_internal
+                 tool.schema.name)
+        |> List.map (fun (tool : Oas.Tool.t) -> tool.schema.name)
+        |> dedupe_preserve_order
+    | _ -> []
+  in
   let codex_keeper_bound_actor_tools =
     match provider_cfg.kind, requested_agent_name with
     | Llm_provider.Provider_config.Codex_cli, Some agent_name
       when Option.is_some (keeper_name_of_agent_name agent_name) ->
-        List.filter public_mcp_tool_requires_bound_actor public_tool_names
+        List.filter runtime_mcp_tool_requires_bound_actor
+          (public_tool_names @ keeper_internal_tool_names)
     | _ -> []
   in
   if codex_keeper_bound_actor_tools <> [] then
@@ -405,9 +450,23 @@ let resolve_tool_lane_for_oas_tools
         (fun tool_name -> not (public_mcp_tool_requires_bound_actor tool_name))
         public_tool_names
   in
+  let keeper_internal_tool_names =
+    if codex_keeper_bound_actor_tools = [] then
+      keeper_internal_tool_names
+    else
+      List.filter
+        (fun tool_name ->
+          not (runtime_mcp_tool_requires_bound_actor tool_name))
+        keeper_internal_tool_names
+  in
+  let runtime_tool_names =
+    dedupe_preserve_order (public_tool_names @ keeper_internal_tool_names)
+  in
   let runtime_mcp_policy =
-    public_mcp_runtime_policy_of_tool_names
-      ?agent_name:requested_agent_name public_tool_names
+    runtime_mcp_policy_of_tool_names
+      ?agent_name:requested_agent_name
+      ~allow_keeper_internal:(keeper_internal_tool_names <> [])
+      runtime_tool_names
     |> runtime_mcp_policy_for_provider ~provider_cfg
          ~agent_name:(Option.value ~default:"" requested_agent_name)
   in

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -67,15 +67,27 @@ let keeper_agent_name_opt (keeper_name : string) =
 
 let runtime_mcp_policy_for_tools ~(keeper_name : string) (tools : Oas.Tool.t list)
     =
-  let public_tool_names =
+  let agent_name = keeper_agent_name_opt keeper_name in
+  let runtime_tool_names =
     tools
-    |> Oas_worker_exec.public_mcp_tools_of_oas_tools
-    |> Oas_worker_exec.public_mcp_tool_names_of_oas_tools
+    |> List.filter (fun (tool : Oas.Tool.t) ->
+           Tool_catalog.is_public_mcp tool.schema.name
+           ||
+           (Option.is_some agent_name
+            && Tool_catalog.is_on_surface Tool_catalog.Keeper_internal
+                 tool.schema.name))
+    |> List.map (fun (tool : Oas.Tool.t) -> tool.schema.name)
+  in
+  let has_keeper_internal =
+    List.exists
+      (Tool_catalog.is_on_surface Tool_catalog.Keeper_internal)
+      runtime_tool_names
   in
   match
-    Oas_worker_exec.public_mcp_runtime_policy_of_tool_names
-      ?agent_name:(keeper_agent_name_opt keeper_name) public_tool_names,
-    keeper_agent_name_opt keeper_name
+    Oas_worker_exec.runtime_mcp_policy_of_tool_names
+      ?agent_name
+      ~allow_keeper_internal:has_keeper_internal runtime_tool_names,
+    agent_name
   with
   | Some policy, Some agent_name ->
       Some
@@ -102,13 +114,14 @@ let codex_cli_cannot_carry_keeper_bound_runtime_mcp
   | Llm_provider.Provider_config.Codex_cli, Some agent_name, Some policy
     when Option.is_some (Keeper_identity.keeper_name_from_agent_name agent_name)
     ->
-      List.exists Oas_worker_exec.public_mcp_tool_requires_bound_actor
+      List.exists Oas_worker_exec.runtime_mcp_tool_requires_bound_actor
         policy.allowed_tool_names
   | _ -> false
 
 let filter_candidate_providers_for_tool_support
     ~(keeper_name : string)
     ?runtime_mcp_policy
+    ?(tools = [])
     ~require_tool_choice_support
     ~require_tool_support
     ~label
@@ -123,9 +136,26 @@ let filter_candidate_providers_for_tool_support
              runtime_mcp_policy_for_provider
                ~keeper_name ~provider_cfg runtime_mcp_policy
            in
+           let tool_lane_supported =
+             match tools with
+             | [] -> true
+             | _ -> (
+                 match
+                   Oas_worker_exec.resolve_tool_lane_for_oas_tools
+                     ?agent_name:(keeper_agent_name_opt keeper_name)
+                     ~tool_requirement:
+                       (if require_tool_choice_support || require_tool_support
+                        then `Required
+                        else `Optional)
+                     ~provider_cfg ~tools ()
+                 with
+                 | Ok _ -> true
+                 | Error _ -> false)
+           in
            (not
               (codex_cli_cannot_carry_keeper_bound_runtime_mcp
                  ~keeper_name ~provider_cfg normalized_runtime_mcp_policy))
+           && tool_lane_supported
            && Provider_tool_support.supports_required_tool_use
              ?runtime_mcp_policy:normalized_runtime_mcp_policy
              ~require_tool_choice_support
@@ -957,6 +987,7 @@ let run_named
     filter_candidate_providers_for_tool_support
       ~keeper_name
       ?runtime_mcp_policy
+      ~tools
       ~require_tool_choice_support
       ~require_tool_support
       ~label:cascade_name

--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -10,10 +10,19 @@ let normalize_cli_provider_caps
     ~(provider_cfg : Llm_provider.Provider_config.t)
     (caps : Llm_provider.Capabilities.capabilities) =
   match provider_cfg.kind with
+  | Llm_provider.Provider_config.Claude_code ->
+      {
+        caps with
+        supports_tools = false;
+        supports_tool_choice = false;
+        supports_runtime_mcp_tools = true;
+        supports_runtime_tool_events = true;
+      }
   | Llm_provider.Provider_config.Kimi_cli ->
       {
         caps with
         supports_tools = false;
+        supports_tool_choice = false;
         supports_runtime_mcp_tools = true;
         supports_runtime_tool_events = true;
       }

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -266,6 +266,12 @@ let dashboard_actor_for_request ~base_path request =
       | Ok None | Error _ -> request_actor_hint request)
   | None -> request_actor_hint request
 
+let is_verified_internal_keeper_request ~base_path request =
+  match auth_token_from_request request with
+  | Some token when Auth.verify_internal_keeper_token base_path ~token ->
+      Option.is_some (internal_keeper_agent_from_request request)
+  | _ -> false
+
 let sanitized_dashboard_actor_for_request ~base_path request =
   match dashboard_actor_for_request ~base_path request with
   | Some raw ->

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -13,6 +13,7 @@ type runtime = Server_mcp_transport_http_types.runtime = {
     ?profile:tool_profile ->
     ?mcp_session_id:string ->
     ?auth_token:string ->
+    ?internal_keeper_runtime:bool ->
     string ->
     Yojson.Safe.t;
   clear_resource_subscriptions_for_session : string -> unit;
@@ -365,9 +366,14 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
                                 body_with_canonical_http_actor ~base_path
                                   ~auth_token request body_str
                               in
+                              let internal_keeper_runtime =
+                                Server_auth.is_verified_internal_keeper_request
+                                  ~base_path request
+                              in
                               let response_json =
                                 runtime.handle_request ?auth_token ~profile
-                                  ~mcp_session_id:session_id body_with_agent
+                                  ~mcp_session_id:session_id
+                                  ~internal_keeper_runtime body_with_agent
                               in
                               let protocol_version =
                                 get_protocol_version_for_session ~session_id request
@@ -750,9 +756,13 @@ let handle_post_messages ~deps request reqd =
                     body_with_canonical_http_actor ~base_path ~auth_token
                       request body_str
                   in
+                  let internal_keeper_runtime =
+                    Server_auth.is_verified_internal_keeper_request
+                      ~base_path request
+                  in
                   let response_json =
                     runtime.handle_request ~mcp_session_id:session_id
-                      ?auth_token body_with_agent
+                      ?auth_token ~internal_keeper_runtime body_with_agent
                   in
                   (match response_json with
                   | `Null -> ()

--- a/lib/server/server_mcp_transport_http.mli
+++ b/lib/server/server_mcp_transport_http.mli
@@ -11,6 +11,7 @@ type runtime = Server_mcp_transport_http_types.runtime = {
     ?profile:tool_profile ->
     ?mcp_session_id:string ->
     ?auth_token:string ->
+    ?internal_keeper_runtime:bool ->
     string ->
     Yojson.Safe.t;
   clear_resource_subscriptions_for_session : string -> unit;

--- a/lib/server/server_mcp_transport_http_types.ml
+++ b/lib/server/server_mcp_transport_http_types.ml
@@ -11,6 +11,7 @@ type runtime = {
     ?profile:tool_profile ->
     ?mcp_session_id:string ->
     ?auth_token:string ->
+    ?internal_keeper_runtime:bool ->
     string ->
     Yojson.Safe.t;
   clear_resource_subscriptions_for_session : string -> unit;

--- a/lib/server/server_mcp_transport_http_types.mli
+++ b/lib/server/server_mcp_transport_http_types.mli
@@ -11,6 +11,7 @@ type runtime = {
     ?profile:tool_profile ->
     ?mcp_session_id:string ->
     ?auth_token:string ->
+    ?internal_keeper_runtime:bool ->
     string ->
     Yojson.Safe.t;
   clear_resource_subscriptions_for_session : string -> unit;

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -208,12 +208,13 @@ let mcp_transport_http_deps () : Server_mcp_transport_http.deps =
                     handle_request =
                       (fun ?(profile = Server_mcp_transport_http.Full)
                            ?mcp_session_id
-                           ?auth_token body_str ->
+                           ?auth_token ?internal_keeper_runtime body_str ->
                         let profile =
                           mcp_eio_profile_of_transport_profile profile
                         in
                         Mcp_server_eio.handle_request ~clock ~sw ~profile
-                          ?mcp_session_id ?auth_token state body_str);
+                          ?mcp_session_id ?auth_token ?internal_keeper_runtime
+                          state body_str);
                     clear_resource_subscriptions_for_session =
                       Mcp_server_eio.clear_resource_subscriptions_for_session;
                   }

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -318,12 +318,19 @@ let keeper_internal_metadata name =
     | Some _ -> Adapter
     | None -> Real
   in
-  hidden_active
+  let meta =
+    hidden_active
     ?canonical_name:replacement
     ?replacement
     ~allow_direct_call_when_hidden:false
     ~implementation_status
     "Keeper-internal tool. Use the keeper runtime or the public MASC equivalent when available."
+  in
+  {
+    meta with
+    required_permission = Some Types.CanBroadcast;
+    requires_actor_binding = Some true;
+  }
 
 let public_mcp_set : (string, unit) Hashtbl.t =
   let tbl = Hashtbl.create 64 in

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -59,19 +59,25 @@ let write_text_file path content =
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc content)
 
-let make_keeper_meta ?agent_name name =
+let make_keeper_meta ?agent_name ?tool_access name =
   let agent_name =
     Option.value agent_name
       ~default:(Keeper_types.keeper_agent_name name)
   in
+  let tool_access_fields =
+    match tool_access with
+    | Some access -> [ ("tool_access", access) ]
+    | None -> []
+  in
   let json =
     `Assoc
-      [
-        ("name", `String name);
-        ("agent_name", `String agent_name);
-        ("trace_id", `String ("trace-test-" ^ name));
-        ("goal", `String "test goal");
-      ]
+      ([
+         ("name", `String name);
+         ("agent_name", `String agent_name);
+         ("trace_id", `String ("trace-test-" ^ name));
+         ("goal", `String "test goal");
+       ]
+       @ tool_access_fields)
   in
   match Keeper_types.meta_of_json json with
   | Ok meta -> meta
@@ -2173,6 +2179,105 @@ let test_handle_request_tools_call_blocks_keeper_internal_tool () =
      with Not_found -> false);
   cleanup_dir base_path
 
+let tool_names_from_list_response response =
+  match response with
+  | `Assoc fields -> (
+      match List.assoc_opt "result" fields with
+      | Some (`Assoc result_fields) -> (
+          match List.assoc_opt "tools" result_fields with
+          | Some (`List tools) ->
+              tools
+              |> List.filter_map (function
+                   | `Assoc fields -> List.assoc_opt "name" fields
+                   | _ -> None)
+              |> List.filter_map (function `String s -> Some s | _ -> None)
+          | _ -> Alcotest.fail "tools not a list")
+      | _ -> Alcotest.fail "result not an object")
+  | _ -> Alcotest.fail "response not an object"
+
+let test_handle_request_tools_list_internal_keeper_runtime_includes_keeper_internal_tools
+    () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let token = Masc_mcp.Auth.ensure_internal_keeper_token base_path in
+      let request = Yojson.Safe.to_string (`Assoc [
+        ("jsonrpc", `String "2.0");
+        ("id", `Int 119);
+        ("method", `String "tools/list");
+        ("params", `Assoc []);
+      ]) in
+      let response =
+        Mcp_eio.handle_request ~clock ~sw ~auth_token:token
+          ~internal_keeper_runtime:true state request
+      in
+      let names = tool_names_from_list_response response in
+      Alcotest.(check bool) "keeper_bash listed" true
+        (List.mem "keeper_bash" names);
+      Alcotest.(check bool) "system internal still hidden" false
+        (List.mem "masc_mcp_session" names))
+
+let test_handle_request_tools_call_internal_keeper_runtime_allows_keeper_internal_tool
+    () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.clear ();
+      cleanup_dir base_path)
+    (fun () ->
+      Keeper_registry.clear ();
+      let keeper_name = "sangsu" in
+      let keeper_agent_name = Keeper_types.keeper_agent_name keeper_name in
+      let tool_access =
+        `Assoc
+          [
+            ("kind", `String "custom");
+            ("tools", `List [ `String "keeper_bash"; `String "keeper_time_now" ]);
+          ]
+      in
+      ignore
+        (Keeper_registry.register ~base_path keeper_name
+           (make_keeper_meta ~agent_name:keeper_agent_name ~tool_access
+              keeper_name));
+      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let token = Masc_mcp.Auth.ensure_internal_keeper_token base_path in
+      let request = Yojson.Safe.to_string (`Assoc [
+        ("jsonrpc", `String "2.0");
+        ("id", `Int 120);
+        ("method", `String "tools/call");
+        ("params", `Assoc [
+          ("name", `String "keeper_bash");
+          ( "arguments",
+            `Assoc
+              [
+                ("_agent_name", `String keeper_agent_name);
+                ("cmd", `String "pwd");
+              ] );
+        ]);
+      ]) in
+      let response =
+        Mcp_eio.handle_request ~clock ~sw ~auth_token:token
+          ~internal_keeper_runtime:true state request
+      in
+      let result = result_fields_exn response in
+      Alcotest.(check bool) "keeper_bash is not an MCP error" false
+        (match List.assoc_opt "isError" result with
+         | Some (`Bool value) -> value
+         | _ -> Alcotest.fail "missing isError");
+      let structured = structured_content_exn response in
+      Alcotest.(check bool) "keeper_bash ok" true
+        Yojson.Safe.Util.(structured |> member "ok" |> to_bool))
+
 let test_handle_request_batch_rejected () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2991,6 +3096,10 @@ let eio_tests = [
     test_handle_request_tools_call_records_keeper_usage_for_public_mcp;
   "handle tools/call blocks keeper internal tool", `Quick,
     test_handle_request_tools_call_blocks_keeper_internal_tool;
+  "handle tools/list internal keeper runtime includes keeper tools", `Quick,
+    test_handle_request_tools_list_internal_keeper_runtime_includes_keeper_internal_tools;
+  "handle tools/call internal keeper runtime allows keeper tool", `Quick,
+    test_handle_request_tools_call_internal_keeper_runtime_allows_keeper_internal_tool;
   "handle invalid json", `Quick, test_handle_request_invalid_json;
   "handle method not found", `Quick, test_handle_request_method_not_found;
   (* TRPG tool tests removed — modules archived *)

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1463,6 +1463,11 @@ let make_codex_cli_provider_cfg ?(model_id = "codex") () =
     ~kind:Llm_provider.Provider_config.Codex_cli
     ~model_id ~base_url:"" ()
 
+let make_claude_code_provider_cfg ?(model_id = "auto") () =
+  Llm_provider.Provider_config.make
+    ~kind:Llm_provider.Provider_config.Claude_code
+    ~model_id ~base_url:"" ()
+
 let make_openai_compat_provider_cfg ?(model_id = "gpt-4.1") () =
   Llm_provider.Provider_config.make
     ~kind:Llm_provider.Provider_config.OpenAI_compat
@@ -1690,6 +1695,60 @@ let test_resolve_tool_lane_for_kimi_cli_public_tools_with_agent_name_keeps_runti
         "expected kimi_cli public MCP tools with agent_name to use runtime MCP lane"
   | Error err -> Alcotest.fail (Oas.Error.to_string err)
 
+let test_resolve_tool_lane_for_claude_code_keeper_internal_tools_uses_runtime_mcp_policy () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  let tools = [ make_named_noop_tool "keeper_bash" ] in
+  match
+    Oas_worker_exec.resolve_tool_lane_for_oas_tools
+      ~agent_name:"keeper-sangsu-agent"
+      ~provider_cfg:(make_claude_code_provider_cfg ())
+      ~tools ()
+  with
+  | Ok (effective_tools, Some policy) ->
+      let masc_headers =
+        List.find_map
+          (function
+            | Llm_provider.Llm_transport.Http_server server
+              when String.equal server.name "masc" -> Some server.headers
+            | _ -> None)
+          policy.servers
+      in
+      Alcotest.(check int) "runtime lane strips inline tools" 0
+        (List.length effective_tools);
+      Alcotest.(check (list string)) "keeper internal tool allowed"
+        [ "keeper_bash" ] policy.allowed_tool_names;
+      Alcotest.(check (option string)) "keeper header preserved"
+        (Some "sangsu")
+        (Option.bind masc_headers (List.assoc_opt "x-masc-keeper-name"));
+      Alcotest.(check (option string)) "internal token preserved"
+        (Some "internal-keeper-token")
+        (Option.bind masc_headers (List.assoc_opt "x-masc-internal-token"))
+  | Ok (_, None) ->
+      Alcotest.fail
+        "expected claude_code keeper-internal tools to use runtime MCP lane"
+  | Error err -> Alcotest.fail (Oas.Error.to_string err)
+
+let test_resolve_tool_lane_for_kimi_cli_keeper_internal_tools_uses_runtime_mcp_policy () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  let tools = [ make_named_noop_tool "keeper_bash" ] in
+  match
+    Oas_worker_exec.resolve_tool_lane_for_oas_tools
+      ~agent_name:"keeper-sangsu-agent"
+      ~provider_cfg:(make_kimi_cli_provider_cfg ())
+      ~tools ()
+  with
+  | Ok (effective_tools, Some policy) ->
+      Alcotest.(check int) "runtime lane strips inline tools" 0
+        (List.length effective_tools);
+      Alcotest.(check (list string)) "keeper internal tool allowed"
+        [ "keeper_bash" ] policy.allowed_tool_names
+  | Ok (_, None) ->
+      Alcotest.fail
+        "expected kimi_cli keeper-internal tools to use runtime MCP lane"
+  | Error err -> Alcotest.fail (Oas.Error.to_string err)
+
 let test_resolve_tool_lane_for_kimi_cli_mixed_tools_keeps_public_runtime_subset () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
   let tools =
@@ -1741,6 +1800,22 @@ let test_resolve_tool_lane_for_codex_cli_internal_tools_rejects () =
   | Ok _ ->
       Alcotest.fail
         "expected codex_cli to reject keeper-internal tools without inline tool support"
+  | Error (Oas.Error.Config (Oas.Error.InvalidConfig { field; _ })) ->
+      Alcotest.(check string) "field" "tool_support" field
+  | Error err -> Alcotest.fail (Oas.Error.to_string err)
+
+let test_resolve_tool_lane_for_codex_cli_keeper_internal_tools_with_agent_rejects () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  match
+    Oas_worker_exec.resolve_tool_lane_for_oas_tools
+      ~agent_name:"keeper-sangsu-agent"
+      ~provider_cfg:(make_codex_cli_provider_cfg ())
+      ~tools:[ make_named_noop_tool "keeper_bash" ] ()
+  with
+  | Ok _ ->
+      Alcotest.fail
+        "expected codex_cli to reject keeper-internal tools requiring request-scoped headers"
   | Error (Oas.Error.Config (Oas.Error.InvalidConfig { field; _ })) ->
       Alcotest.(check string) "field" "tool_support" field
   | Error err -> Alcotest.fail (Oas.Error.to_string err)
@@ -1818,6 +1893,33 @@ let test_filter_candidate_providers_for_tool_support_drops_codex_cli_keeper_boun
   | _ ->
       Alcotest.failf "expected only kimi_cli provider to remain, got %d"
         (List.length filtered)
+
+let test_filter_candidate_providers_for_tool_support_keeps_header_capable_cli_for_keeper_internal_tools
+    () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
+  with_env "MASC_INTERNAL_MCP_TOKEN" "internal-keeper-token" @@ fun () ->
+  let tools = [ make_named_noop_tool "keeper_bash" ] in
+  let runtime_mcp_policy =
+    Masc_mcp.Oas_worker_named.runtime_mcp_policy_for_tools
+      ~keeper_name:"sangsu" tools
+  in
+  let filtered =
+    Masc_mcp.Oas_worker_named.filter_candidate_providers_for_tool_support
+      ~keeper_name:"sangsu"
+      ?runtime_mcp_policy
+      ~tools
+      ~require_tool_choice_support:true
+      ~require_tool_support:true
+      ~label:"tool_use_strict"
+      [
+        make_claude_code_provider_cfg ();
+        make_codex_cli_provider_cfg ();
+        make_kimi_cli_provider_cfg ();
+      ]
+  in
+  Alcotest.(check (list string)) "header-capable CLI providers remain"
+    [ "claude_code:auto"; "kimi_cli:kimi-for-coding" ]
+    (List.map Provider_tool_support.provider_debug_label filtered)
 
 let test_kimi_mcp_config_json_of_policy_filters_to_allowed_servers () =
   let policy =
@@ -3506,8 +3608,20 @@ let () =
         test_resolve_tool_lane_for_kimi_cli_mixed_tools_keeps_public_runtime_subset;
       Alcotest.test_case "public MCP tools on openai_compat stay inline" `Quick
         test_resolve_tool_lane_for_openai_public_tools_keeps_inline_tools;
+      Alcotest.test_case
+        "keeper-internal tools on claude_code use runtime MCP lane"
+        `Quick
+        test_resolve_tool_lane_for_claude_code_keeper_internal_tools_uses_runtime_mcp_policy;
+      Alcotest.test_case
+        "keeper-internal tools on kimi_cli use runtime MCP lane when keeper-bound"
+        `Quick
+        test_resolve_tool_lane_for_kimi_cli_keeper_internal_tools_uses_runtime_mcp_policy;
       Alcotest.test_case "keeper-internal tools on codex_cli are rejected" `Quick
         test_resolve_tool_lane_for_codex_cli_internal_tools_rejects;
+      Alcotest.test_case
+        "keeper-internal tools on codex_cli with keeper actor are rejected"
+        `Quick
+        test_resolve_tool_lane_for_codex_cli_keeper_internal_tools_with_agent_rejects;
       Alcotest.test_case "keeper-internal tools on kimi_cli are rejected" `Quick
         test_resolve_tool_lane_for_kimi_cli_internal_tools_rejects;
       Alcotest.test_case "optional keeper-internal tools on codex_cli drop to text" `Quick
@@ -3518,6 +3632,10 @@ let () =
         "provider-normalized filter drops codex keeper-bound actor tools"
         `Quick
         test_filter_candidate_providers_for_tool_support_drops_codex_cli_keeper_bound_actor_tools;
+      Alcotest.test_case
+        "provider-normalized filter keeps header-capable keeper-internal lanes"
+        `Quick
+        test_filter_candidate_providers_for_tool_support_keeps_header_capable_cli_for_keeper_internal_tools;
       Alcotest.test_case "kimi runtime MCP config keeps only allowed servers" `Quick
         test_kimi_mcp_config_json_of_policy_filters_to_allowed_servers;
       Alcotest.test_case "runtime MCP policy injects keeper agent header for masc server" `Quick


### PR DESCRIPTION
## Summary

- expose keeper-internal tool schemas only to verified internal keeper runtime requests
- dispatch verified `keeper_bash` calls through the keeper execution tool path instead of the generic MCP external tool path
- make keeper-bound provider selection preserve header-capable CLI providers such as Claude Code and Kimi while rejecting Codex CLI for request-scoped runtime MCP headers

## Root Cause

`sangsu` could select `keeper_bash`, but the internal runtime request was still being validated and dispatched like an external MCP tool call. That made the server reject the call as an unknown/not-allowed tool even when the keeper tool set contained `keeper_bash`. Provider filtering also treated CLI providers too generically, so rotation could pick a provider that could not carry the internal runtime MCP auth headers.

## Validation

- `env DUNE_BUILD_DIR=_build_verify DUNE_JOBS=2 dune build --root . test/test_mcp_server_eio.exe test/test_oas_worker.exe bin/main_eio.exe`
- `env MASC_BASE_PATH=/tmp/masc-mcp-test-mcp-eio _build_verify/default/test/test_mcp_server_eio.exe` -> 71 tests passed
- `env MASC_BASE_PATH=/tmp/masc-mcp-test-oas-worker _build_verify/default/test/test_oas_worker.exe` -> 113 tests passed
- live server restarted on `127.0.0.1:8935` from commit `a82c17dbec`, `/health` reported `ok`
- live `sangsu` smoke on current HEAD: requested `keeper_bash { cmd = "pwd" }`, result `ok: true`, model `claude_code:auto`, sandbox `via: docker`, observed cwd `/home/keeper/playground/analyst`
- `/Users/dancer/me/.masc/keepers/tool_usage/sangsu.json` now records `keeper_bash` as `count=4`, `successes=3`, `failures=1`

Note: the repo wrapper was blocked by an unrelated long-held `/tmp/me-dune-local.lock`, so validation used an isolated `DUNE_BUILD_DIR=_build_verify` rather than waiting on other agents' builds.