### PR TITLE
[codex] Add keeper persona audit tool

### DIFF
--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -267,6 +267,35 @@ let keeper_schemas : tool_schema list = [
   };
 
   {
+    name = "masc_keeper_persona_audit";
+    description = "Audit persona-backed keeper materialization across the active config root, durable keeper TOML, live runtime metadata, registry presence, autoboot, and keepalive state.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional keeper handle to audit. When omitted, all known keepers in the current base path/config root are audited.");
+        ]);
+        ("names", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+          ("description", `String "Optional keeper handles to audit. Combined with name when both are provided.");
+        ]);
+        ("limit", `Assoc [
+          ("type", `String "integer");
+          ("default", `Int 100);
+          ("description", `String "Maximum number of keepers to audit when name/names are omitted. Clamped to 500.");
+        ]);
+        ("include_ok", `Assoc [
+          ("type", `String "boolean");
+          ("default", `Bool true);
+          ("description", `String "If false, return only keepers with audit issues while keeping summary counts over all audited keepers.");
+        ]);
+      ]);
+    ];
+  };
+
+  {
     name = "masc_keeper_up";
     description = "Create or update a durable keeper. Keepers auto-start on server boot and are reconciled back into live presence.";
     input_schema = `Assoc [

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -196,6 +196,7 @@ let explicit_metadata : (string * metadata) list =
     ("masc_tool_help", readonly_tool);
     ("masc_keeper_list", readonly_tool);
     ("masc_keeper_status", readonly_tool);
+    ("masc_keeper_persona_audit", readonly_tool);
     ("masc_plan_get", readonly_tool);
     ("masc_worktree_list", readonly_tool);
     ( "masc_join",

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -129,6 +129,7 @@ let public_mcp_surface_tools =
     "masc_heartbeat";
     (* Keeper interaction *)
     "masc_keeper_msg"; "masc_keeper_msg_result"; "masc_keeper_list"; "masc_keeper_status";
+    "masc_keeper_persona_audit";
     "masc_keeper_sandbox_status"; "masc_keeper_sandbox_start"; "masc_keeper_sandbox_stop";
     "masc_keeper_up"; "masc_keeper_repair"; "masc_keeper_reset";
     "masc_keeper_down";

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -708,6 +708,329 @@ let handle_keeper_list ctx args : tool_result =
   in
   (true, body)
 
+let json_bool_opt = function
+  | Some value -> `Bool value
+  | None -> `Null
+
+let json_float_opt = function
+  | Some value -> `Float value
+  | None -> `Null
+
+let existing_path_json ?(candidates = []) path_opt =
+  let exists =
+    match path_opt with
+    | Some path -> Fs_compat.file_exists path
+    | None -> false
+  in
+  `Assoc
+    [
+      ("path", Json_util.string_opt_to_json path_opt);
+      ("exists", `Bool exists);
+      ( "candidates",
+        `List (List.map (fun path -> `String path) candidates) );
+    ]
+
+let dedupe_sorted_strings values =
+  values
+  |> List.map String.trim
+  |> List.filter (fun value -> not (String.equal value ""))
+  |> List.sort_uniq String.compare
+
+let keeper_persona_audit_requested_names ctx args =
+  let explicit_names =
+    let names = get_string_list args "names" in
+    (match get_string_opt args "name" with
+     | Some name -> name :: names
+     | None -> names)
+    |> dedupe_sorted_strings
+  in
+  if explicit_names <> [] then explicit_names
+  else
+    let registry_names =
+      Keeper_registry.all ~base_path:ctx.config.base_path ()
+      |> List.map (fun (entry : Keeper_registry.registry_entry) -> entry.name)
+    in
+    registry_names @ configured_keeper_names ctx.config @ keeper_names ctx.config
+    |> dedupe_sorted_strings
+
+let keeper_persona_audit_status ctx (meta : keeper_meta) =
+  let keepalive_running =
+    Keeper_status_bridge.runtime_keepalive_running ctx.config meta
+  in
+  let agent_status =
+    Keeper_exec_status.parse_agent_status ctx.config ~agent_name:meta.agent_name
+  in
+  let now_ts = Time_compat.now () in
+  let diagnostic =
+    Keeper_exec_status.keeper_diagnostic_json
+      ~meta ~agent_status ~keepalive_running ~history_items:[] ~now_ts
+    |> Keeper_exec_status.augment_keeper_diagnostic_json
+         ~meta ~keepalive_running
+         ~keepalive_started_at:
+           (Keeper_status_bridge.runtime_keepalive_started_at ctx.config meta)
+         ~now_ts
+  in
+  Keeper_exec_status.keeper_surface_status ~agent_status ~diagnostic
+
+let keeper_persona_profile_candidates persona_name =
+  let resolution = Config_dir_resolver.resolve () in
+  (resolution.personas.path :: Config_dir_resolver.personas_dirs ())
+  |> dedupe_sorted_strings
+  |> List.map (fun root ->
+         Filename.concat (Filename.concat root persona_name) "profile.json")
+
+let keeper_persona_audit_item ctx requested_name =
+  let meta_result = read_meta_resolved ctx.config requested_name in
+  let resolved_name, runtime_meta, runtime_meta_error =
+    match meta_result with
+    | Ok (Some (name, meta)) -> (name, Some meta, None)
+    | Ok None -> (requested_name, None, None)
+    | Error msg -> (requested_name, None, Some msg)
+  in
+  let keeper_toml_candidate =
+    Filename.concat (Config_dir_resolver.keepers_dir ()) (resolved_name ^ ".toml")
+  in
+  let keeper_toml_path =
+    match keeper_toml_path_opt resolved_name with
+    | Some path -> Some path
+    | None -> Some keeper_toml_candidate
+  in
+  let keeper_toml_exists = Fs_compat.file_exists keeper_toml_candidate in
+  let defaults_result = load_keeper_profile_defaults_result resolved_name in
+  let default_source = keeper_default_source_snapshot resolved_name in
+  let defaults =
+    match defaults_result with
+    | Ok defaults -> defaults
+    | Error _ -> default_source.defaults
+  in
+  let toml_error =
+    match defaults_result with
+    | Ok _ -> None
+    | Error msg -> Some msg
+  in
+  let explicit_persona_name =
+    match defaults.persona_name with
+    | Some name when String.trim name <> "" -> Some (String.trim name)
+    | _ -> None
+  in
+  let default_source_kind = default_source.source_kind in
+  let inferred_persona_name =
+    resolved_persona_name ~keeper_name:resolved_name defaults |> String.trim
+  in
+  let inferred_persona_profile_path =
+    match inferred_persona_name with
+    | "" -> None
+    | name -> persona_profile_path_opt name
+  in
+  let persona_name =
+    match explicit_persona_name with
+    | Some name -> Some name
+    | None -> (
+        match default_source_kind, inferred_persona_profile_path with
+        | Some "persona", _ when inferred_persona_name <> "" ->
+            Some inferred_persona_name
+        | _, Some _ when inferred_persona_name <> "" -> Some inferred_persona_name
+        | _ -> None)
+  in
+  let persona_candidates =
+    match persona_name with
+    | Some name -> keeper_persona_profile_candidates name
+    | None -> []
+  in
+  let persona_profile_path =
+    match persona_name with
+    | Some name -> (
+        match persona_profile_path_opt name with
+        | Some path -> Some path
+        | None -> (
+            match persona_candidates with
+            | candidate :: _ -> Some candidate
+            | [] -> None))
+    | None -> None
+  in
+  let persona_profile_exists =
+    match persona_profile_path with
+    | Some path -> Fs_compat.file_exists path
+    | None -> false
+  in
+  let persona_expected =
+    Option.is_some explicit_persona_name
+    || persona_profile_exists
+    ||
+    match default_source_kind with
+    | Some "persona" -> true
+    | _ -> false
+  in
+  let live_meta_path = keeper_meta_path ctx.config resolved_name in
+  let live_meta_exists = Fs_compat.file_exists live_meta_path in
+  let registry_entry =
+    Keeper_registry.get ~base_path:ctx.config.base_path resolved_name
+  in
+  let keepalive_running =
+    runtime_meta
+    |> Option.map (Keeper_status_bridge.runtime_keepalive_running ctx.config)
+  in
+  let keepalive_started_at =
+    match runtime_meta with
+    | Some meta -> Keeper_status_bridge.runtime_keepalive_started_at ctx.config meta
+    | None -> None
+  in
+  let runtime_status =
+    runtime_meta |> Option.map (keeper_persona_audit_status ctx)
+  in
+  let autoboot_enabled =
+    match runtime_meta with
+    | Some meta -> Some meta.autoboot_enabled
+    | None -> defaults.autoboot_enabled
+  in
+  let paused = runtime_meta |> Option.map (fun meta -> meta.paused) in
+  let issues =
+    let add cond issue acc = if cond then issue :: acc else acc in
+    []
+    |> add (not keeper_toml_exists) "missing_keeper_toml"
+    |> add (Option.is_some toml_error) "toml_parse_error"
+    |> add (persona_expected && not persona_profile_exists)
+         "missing_persona_profile"
+    |> add (not live_meta_exists) "missing_runtime_meta"
+    |> add (Option.is_some runtime_meta_error) "runtime_meta_error"
+    |> add (Option.is_some runtime_meta && Option.is_none registry_entry)
+         "registry_missing"
+    |> add (match autoboot_enabled with Some false -> true | _ -> false)
+         "autoboot_disabled"
+    |> add (match paused with Some true -> true | _ -> false) "keeper_paused"
+    |> add
+         (match runtime_meta, autoboot_enabled, paused, keepalive_running with
+          | Some _, (Some true | None), (Some false | None), Some false -> true
+          | _ -> false)
+         "keepalive_not_running"
+    |> List.rev
+  in
+  let phase =
+    registry_entry
+    |> Option.map (fun (entry : Keeper_registry.registry_entry) ->
+           Keeper_state_machine.phase_to_string entry.phase)
+  in
+  `Assoc
+    [
+      ("name", `String resolved_name);
+      ( "requested_name",
+        if String.equal requested_name resolved_name then `Null
+        else `String requested_name );
+      ( "keeper_toml",
+        existing_path_json ~candidates:[ keeper_toml_candidate ] keeper_toml_path );
+      ("default_source_kind", Json_util.string_opt_to_json default_source_kind);
+      ( "default_manifest_path",
+        Json_util.string_opt_to_json defaults.manifest_path );
+      ("toml_error", Json_util.string_opt_to_json toml_error);
+      ("persona_name", Json_util.string_opt_to_json persona_name);
+      ( "explicit_persona_name",
+        Json_util.string_opt_to_json explicit_persona_name );
+      ( "persona_profile",
+        existing_path_json ~candidates:persona_candidates persona_profile_path );
+      ( "runtime_meta",
+        `Assoc
+          [
+            ("path", `String live_meta_path);
+            ("exists", `Bool live_meta_exists);
+            ("error", Json_util.string_opt_to_json runtime_meta_error);
+          ] );
+      ("registry_present", `Bool (Option.is_some registry_entry));
+      ("phase", Json_util.string_opt_to_json phase);
+      ("runtime_status", Json_util.string_opt_to_json runtime_status);
+      ("autoboot_enabled", json_bool_opt autoboot_enabled);
+      ("paused", json_bool_opt paused);
+      ("keepalive_running", json_bool_opt keepalive_running);
+      ("keepalive_started_at", json_float_opt keepalive_started_at);
+      ("issues", `List (List.map (fun issue -> `String issue) issues));
+      ("ok", `Bool (issues = []));
+    ]
+
+let keeper_persona_audit_summary items =
+  let issue_list item =
+    match Yojson.Safe.Util.member "issues" item with
+    | `List issues ->
+        List.filter_map (function `String issue -> Some issue | _ -> None) issues
+    | _ -> []
+  in
+  let has_issue issue item = List.mem issue (issue_list item) in
+  let count pred =
+    List.fold_left (fun acc item -> if pred item then acc + 1 else acc) 0 items
+  in
+  let count_issue issue = count (has_issue issue) in
+  let ok_count =
+    count (fun item ->
+        match Yojson.Safe.Util.member "ok" item with
+        | `Bool true -> true
+        | _ -> false)
+  in
+  `Assoc
+    [
+      ("total", `Int (List.length items));
+      ("ok", `Int ok_count);
+      ("with_issues", `Int (List.length items - ok_count));
+      ("missing_keeper_toml", `Int (count_issue "missing_keeper_toml"));
+      ("toml_parse_error", `Int (count_issue "toml_parse_error"));
+      ( "missing_persona_profile",
+        `Int (count_issue "missing_persona_profile") );
+      ("missing_runtime_meta", `Int (count_issue "missing_runtime_meta"));
+      ("runtime_meta_error", `Int (count_issue "runtime_meta_error"));
+      ("registry_missing", `Int (count_issue "registry_missing"));
+      ("autoboot_disabled", `Int (count_issue "autoboot_disabled"));
+      ("keeper_paused", `Int (count_issue "keeper_paused"));
+      ("keepalive_not_running", `Int (count_issue "keepalive_not_running"));
+    ]
+
+let handle_keeper_persona_audit ctx args : tool_result =
+  let names = keeper_persona_audit_requested_names ctx args in
+  let invalid_names = List.filter (fun name -> not (validate_name name)) names in
+  if invalid_names <> [] then
+    error_result_typed ~code:Validation_error
+      (Printf.sprintf "invalid keeper name(s): %s"
+         (String.concat ", " invalid_names))
+  else
+    let limit = get_int args "limit" 100 |> max 0 |> min 500 in
+    let include_ok = get_bool args "include_ok" true in
+    let audited_items =
+      names
+      |> take limit
+      |> List.map (keeper_persona_audit_item ctx)
+    in
+    let returned_items =
+      if include_ok then audited_items
+      else
+        List.filter
+          (fun item ->
+            match Yojson.Safe.Util.member "ok" item with
+            | `Bool true -> false
+            | _ -> true)
+          audited_items
+    in
+    let resolution = Config_dir_resolver.resolve () in
+    let roots =
+      `Assoc
+        [
+          ("base_path", `String ctx.config.base_path);
+          ("masc_root", `String (Coord.masc_root_dir ctx.config));
+          ("config_resolution", Config_dir_resolver.to_json resolution);
+          ( "personas_dirs",
+            `List
+              (List.map
+                 (fun path -> `String path)
+                 (Config_dir_resolver.personas_dirs ())) );
+        ]
+    in
+    ( true,
+      Yojson.Safe.pretty_to_string
+        (`Assoc
+           [
+             ("status", `String "ok");
+             ("tool", `String "masc_keeper_persona_audit");
+             ("roots", roots);
+             ("summary", keeper_persona_audit_summary audited_items);
+             ("returned_count", `Int (List.length returned_items));
+             ("items", `List returned_items);
+           ]) )
+
 let parse_network_mode_or_error raw =
   match network_mode_of_string raw with
   | Some mode -> Ok mode
@@ -1190,6 +1513,7 @@ let dispatch ctx ~name ~args : tool_result option =
   | "masc_keeper_repair" -> Some (handle_keeper_repair ctx args)
   | "masc_keeper_down" -> Some (handle_keeper_down ctx args)
   | "masc_keeper_list" -> Some (handle_keeper_list ctx args)
+  | "masc_keeper_persona_audit" -> Some (handle_keeper_persona_audit ctx args)
   | "masc_keeper_sandbox_status" -> Some (handle_keeper_sandbox_status ctx args)
   | "masc_keeper_sandbox_start" -> Some (handle_keeper_sandbox_start ctx args)
   | "masc_keeper_sandbox_stop" -> Some (handle_keeper_sandbox_stop ctx args)
@@ -1215,11 +1539,13 @@ let dispatch_stream ~on_text_delta ctx ~name ~args : tool_result option =
 
 let _tool_spec_read_only =
   [ "masc_persona_list"; "masc_persona_schema"; "masc_keeper_list";
-    "masc_keeper_status"; "masc_keeper_sandbox_status" ]
+    "masc_keeper_status"; "masc_keeper_persona_audit";
+    "masc_keeper_sandbox_status" ]
 
 let tool_required_permission = function
   | "masc_persona_list" | "masc_persona_schema" | "masc_keeper_list"
-  | "masc_keeper_status" | "masc_keeper_sandbox_status" ->
+  | "masc_keeper_status" | "masc_keeper_persona_audit"
+  | "masc_keeper_sandbox_status" ->
       Some Types.CanReadState
   | "masc_persona_generate" | "masc_persona_save"
   | "masc_keeper_create_from_persona" | "masc_keeper_up"

--- a/lib/tool_permission_map.ml
+++ b/lib/tool_permission_map.ml
@@ -23,6 +23,7 @@ let legacy_permission_entries : (string * permission) list =
     ("masc_persona_schema", CanReadState);
     ("masc_keeper_status", CanReadState);
     ("masc_keeper_list", CanReadState);
+    ("masc_keeper_persona_audit", CanReadState);
     ("masc_runtime_verify", CanReadState);
     ("masc_runtime_ollama_probe", CanReadState);
     ("masc_operation_status", CanReadState);

--- a/lib/tool_prefilter.ml
+++ b/lib/tool_prefilter.ml
@@ -207,6 +207,8 @@ let synonyms : (string * string list) list =
      [ "stop keeper"; "shutdown keeper"; "kill keeper"; "keeper terminate" ]);
     ("masc_keeper_list",
      [ "list keepers"; "show keepers"; "keeper status all"; "active keepers" ]);
+    ("masc_keeper_persona_audit",
+     [ "keeper persona audit"; "persona keeper check"; "keeper toml persona"; "autoboot keepalive audit" ]);
     ("masc_keeper_msg",
      [ "send keeper message"; "talk to keeper"; "message keeper"; "keeper chat" ]);
     ("masc_keeper_status",

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -73,6 +73,50 @@ let write_keeper_toml_exn ?autoboot_enabled config ~name =
         proactive_enabled = false\n"
        autoboot_line)
 
+let write_keeper_persona_toml_exn ?autoboot_enabled config ~name ~persona_name =
+  let keepers_dir =
+    Filename.concat (Coord.masc_root_dir config) "config/keepers"
+  in
+  let autoboot_line =
+    match autoboot_enabled with
+    | Some value -> Printf.sprintf "autoboot_enabled = %b\n" value
+    | None -> ""
+  in
+  Fs_compat.mkdir_p keepers_dir;
+  Fs_compat.save_file
+    (Filename.concat keepers_dir (name ^ ".toml"))
+    (Printf.sprintf
+       "[keeper]\n\
+        persona_name = %S\n\
+        goal = \"test persona keeper\"\n\
+        %s\
+        proactive_enabled = false\n"
+       persona_name autoboot_line)
+
+let write_persona_profile_exn config ~name =
+  let persona_dir =
+    Filename.concat
+      (Filename.concat (Coord.masc_root_dir config) "config/personas")
+      name
+  in
+  Fs_compat.mkdir_p persona_dir;
+  write_json
+    (Filename.concat persona_dir "profile.json")
+    (`Assoc
+       [
+         ("name", `String name);
+         ("role", `String "test persona");
+         ( "keeper",
+           `Assoc
+             [
+               ("goal", `String "test persona keeper");
+               ("tool_preset", `String "research");
+             ] );
+       ])
+
+let write_corrupt_keeper_meta_exn config ~name =
+  write_file (Keeper_types.keeper_meta_path config name) "{not-json"
+
 let write_keeper_meta_exn ?(autoboot_enabled = true)
     ?(social_model = "bdi_speech_v1")
     ?(last_social_transition_reason = "") config ~name ~trace_id =
@@ -113,6 +157,15 @@ let keeper_json_by_name json name =
   Yojson.Safe.Util.(json |> member "keepers" |> to_list)
   |> List.find_opt (fun keeper ->
          Yojson.Safe.Util.(keeper |> member "name" |> to_string = name))
+
+let audit_item_by_name json name =
+  Yojson.Safe.Util.(json |> member "items" |> to_list)
+  |> List.find_opt (fun item ->
+         Yojson.Safe.Util.(item |> member "name" |> to_string = name))
+
+let string_list_of_json json =
+  Yojson.Safe.Util.to_list json
+  |> List.filter_map (function `String value -> Some value | _ -> None)
 
 let keeper_ctx env sw config agent_name : _ Tool_keeper.context =
   {
@@ -375,6 +428,194 @@ let test_keeper_list_exposes_last_social_transition_reason () =
               keeper |> member "last_social_transition_reason" |> to_string)
       | None -> fail "expected sangsu row in keeper list")
 
+let test_keeper_persona_audit_reports_durable_live_persona_keeper () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  with_clean_base_path_env @@ fun () ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Config_dir_resolver.reset ();
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      write_persona_profile_exn config ~name:"analyst";
+      write_keeper_persona_toml_exn config ~name:"analyst"
+        ~persona_name:"analyst";
+      write_keeper_meta_exn config ~name:"analyst" ~trace_id:"trace-analyst";
+      let config_root = Filename.concat (Coord.masc_root_dir config) "config" in
+      Unix.putenv "MASC_CONFIG_DIR" config_root;
+      Config_dir_resolver.reset ();
+      (match Keeper_types.read_meta config "analyst" with
+       | Ok (Some meta) ->
+           ignore
+             (Keeper_registry.register ~base_path:config.base_path "analyst"
+                meta)
+       | Ok None -> fail "expected analyst meta"
+       | Error e -> fail ("read_meta failed: " ^ e));
+      let ctx = keeper_ctx env sw config "operator" in
+      let ok, body =
+        match
+          Tool_keeper.dispatch ctx ~name:"masc_keeper_persona_audit"
+            ~args:(`Assoc [ ("name", `String "analyst") ])
+        with
+        | Some result -> result
+        | None -> fail "expected masc_keeper_persona_audit dispatch"
+      in
+      check bool "tool audit ok" true ok;
+      let json = parse_json_exn body in
+      check int "summary total" 1
+        Yojson.Safe.Util.(json |> member "summary" |> member "total" |> to_int);
+      check int "summary ok" 1
+        Yojson.Safe.Util.(json |> member "summary" |> member "ok" |> to_int);
+      match audit_item_by_name json "analyst" with
+      | None -> fail "expected analyst audit item"
+      | Some item ->
+          check bool "item ok" true
+            Yojson.Safe.Util.(item |> member "ok" |> to_bool);
+          check string "default source" "toml"
+            Yojson.Safe.Util.(item |> member "default_source_kind" |> to_string);
+          check string "persona name" "analyst"
+            Yojson.Safe.Util.(item |> member "persona_name" |> to_string);
+          check bool "keeper toml exists" true
+            Yojson.Safe.Util.(
+              item |> member "keeper_toml" |> member "exists" |> to_bool);
+          check bool "persona profile exists" true
+            Yojson.Safe.Util.(
+              item |> member "persona_profile" |> member "exists" |> to_bool);
+          check bool "runtime meta exists" true
+            Yojson.Safe.Util.(
+              item |> member "runtime_meta" |> member "exists" |> to_bool);
+          check bool "registry present" true
+            Yojson.Safe.Util.(item |> member "registry_present" |> to_bool);
+          check bool "keepalive running" true
+            Yojson.Safe.Util.(item |> member "keepalive_running" |> to_bool);
+          check int "no issues" 0
+            Yojson.Safe.Util.(item |> member "issues" |> to_list |> List.length))
+
+let test_keeper_persona_audit_flags_missing_persona_runtime () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  with_clean_base_path_env @@ fun () ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Config_dir_resolver.reset ();
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      write_keeper_persona_toml_exn config ~name:"ghost"
+        ~persona_name:"missing-persona";
+      let config_root = Filename.concat (Coord.masc_root_dir config) "config" in
+      Unix.putenv "MASC_CONFIG_DIR" config_root;
+      Config_dir_resolver.reset ();
+      let ctx = keeper_ctx env sw config "operator" in
+      let ok, body =
+        match
+          Tool_keeper.dispatch ctx ~name:"masc_keeper_persona_audit"
+            ~args:(`Assoc [ ("name", `String "ghost") ])
+        with
+        | Some result -> result
+        | None -> fail "expected masc_keeper_persona_audit dispatch"
+      in
+      check bool "tool audit ok" true ok;
+      let json = parse_json_exn body in
+      check int "missing persona count" 1
+        Yojson.Safe.Util.(
+          json |> member "summary" |> member "missing_persona_profile"
+          |> to_int);
+      check int "missing runtime count" 1
+        Yojson.Safe.Util.(
+          json |> member "summary" |> member "missing_runtime_meta" |> to_int);
+      match audit_item_by_name json "ghost" with
+      | None -> fail "expected ghost audit item"
+      | Some item ->
+          let issues =
+            Yojson.Safe.Util.(item |> member "issues") |> string_list_of_json
+          in
+          check bool "flags missing persona" true
+            (List.mem "missing_persona_profile" issues);
+          check bool "flags missing runtime" true
+            (List.mem "missing_runtime_meta" issues);
+          check bool "keeper toml exists" true
+            Yojson.Safe.Util.(
+              item |> member "keeper_toml" |> member "exists" |> to_bool);
+          check bool "persona profile missing" false
+            Yojson.Safe.Util.(
+              item |> member "persona_profile" |> member "exists" |> to_bool);
+          check string "persona profile candidate path surfaced"
+            (Filename.concat
+               (Filename.concat
+                  (Filename.concat config_root "personas")
+                  "missing-persona")
+               "profile.json")
+            Yojson.Safe.Util.(
+              item |> member "persona_profile" |> member "path" |> to_string))
+
+let test_keeper_persona_audit_flags_runtime_meta_parse_error () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  with_clean_base_path_env @@ fun () ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Config_dir_resolver.reset ();
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      write_persona_profile_exn config ~name:"broken";
+      write_keeper_persona_toml_exn config ~name:"broken" ~persona_name:"broken";
+      write_corrupt_keeper_meta_exn config ~name:"broken";
+      let config_root = Filename.concat (Coord.masc_root_dir config) "config" in
+      Unix.putenv "MASC_CONFIG_DIR" config_root;
+      Config_dir_resolver.reset ();
+      let ctx = keeper_ctx env sw config "operator" in
+      let ok, body =
+        match
+          Tool_keeper.dispatch ctx ~name:"masc_keeper_persona_audit"
+            ~args:(`Assoc [ ("name", `String "broken") ])
+        with
+        | Some result -> result
+        | None -> fail "expected masc_keeper_persona_audit dispatch"
+      in
+      check bool "tool audit ok" true ok;
+      let json = parse_json_exn body in
+      check int "runtime meta parse error count" 1
+        Yojson.Safe.Util.(
+          json |> member "summary" |> member "runtime_meta_error" |> to_int);
+      check int "runtime meta file is not missing" 0
+        Yojson.Safe.Util.(
+          json |> member "summary" |> member "missing_runtime_meta" |> to_int);
+      match audit_item_by_name json "broken" with
+      | None -> fail "expected broken audit item"
+      | Some item ->
+          let issues =
+            Yojson.Safe.Util.(item |> member "issues") |> string_list_of_json
+          in
+          check bool "flags runtime meta error" true
+            (List.mem "runtime_meta_error" issues);
+          check bool "item not ok" false
+            Yojson.Safe.Util.(item |> member "ok" |> to_bool);
+          check bool "runtime meta file exists" true
+            Yojson.Safe.Util.(
+              item |> member "runtime_meta" |> member "exists" |> to_bool);
+          check bool "runtime meta error surfaced" true
+            (Yojson.Safe.Util.(
+               item |> member "runtime_meta" |> member "error" |> to_string)
+             <> ""))
+
 let test_keeper_list_preserves_known_social_model () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -432,5 +673,11 @@ let () =
             test_keeper_list_preserves_known_social_model;
           test_case "tool keeper list exposes last social transition reason"
             `Quick test_keeper_list_exposes_last_social_transition_reason;
+          test_case "keeper persona audit reports durable live keeper" `Quick
+            test_keeper_persona_audit_reports_durable_live_persona_keeper;
+          test_case "keeper persona audit flags missing persona runtime" `Quick
+            test_keeper_persona_audit_flags_missing_persona_runtime;
+          test_case "keeper persona audit flags runtime meta parse error" `Quick
+            test_keeper_persona_audit_flags_runtime_meta_parse_error;
         ] );
     ]


### PR DESCRIPTION
## Summary
- add `masc_keeper_persona_audit` as a read-only public MCP tool
- audit active config-root keeper TOML, persona profile, runtime meta, registry presence, autoboot, pause, and keepalive state
- register the tool across schema, catalog metadata, public surface, permission map, and prefilter synonyms

## Validation
- `scripts/dune-local.sh build test/test_keeper_meta_listing.exe test/test_tool_prefilter.exe test/test_tool_access_policy.exe test/test_tool_surface_ssot.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-keeper-meta-listing-codex MASC_BASE_PATH_INPUT=/tmp/masc-test-keeper-meta-listing-codex MASC_STORAGE_TYPE=filesystem GRAPHQL_API_KEY= ZAI_API_KEY= MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED=false MASC_KEEPER_DOCKER_PLAYGROUND=false ./_build/default/test/test_keeper_meta_listing.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-tool-prefilter-codex MASC_BASE_PATH_INPUT=/tmp/masc-test-tool-prefilter-codex MASC_STORAGE_TYPE=filesystem GRAPHQL_API_KEY= ZAI_API_KEY= ./_build/default/test/test_tool_prefilter.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-tool-access-codex MASC_BASE_PATH_INPUT=/tmp/masc-test-tool-access-codex MASC_STORAGE_TYPE=filesystem GRAPHQL_API_KEY= ZAI_API_KEY= ./_build/default/test/test_tool_access_policy.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-tool-surface-codex MASC_BASE_PATH_INPUT=/tmp/masc-test-tool-surface-codex MASC_STORAGE_TYPE=filesystem GRAPHQL_API_KEY= ZAI_API_KEY= ./_build/default/test/test_tool_surface_ssot.exe`