### PR TITLE
fix(keeper-config): warn-and-accept non-public keeper args from external clients (#9752)

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -166,24 +166,31 @@ let present_json_keys (keys : string list) (json : Yojson.Safe.t) : string list 
   | _ -> []
 
 let reject_removed_keeper_input_keys ~tool_name (args : Yojson.Safe.t) =
+  (* #9752: non-public args (currently only [social_model]) should not
+     fail the whole call. External clients like codex-mcp-client have
+     sent [social_model] in real traffic — hard-rejecting DoS's the
+     call for a field that is never consumed downstream from the args
+     blob anyway ([social_model] runtime value comes from the keeper
+     meta, not the MCP args). Warn and continue; the policy from #7447
+     (social_model off the public OAS/MCP surface) is preserved because
+     no caller path reads [args.social_model] to drive behaviour. *)
   let non_public = present_json_keys non_public_keeper_input_key_names args in
-  match non_public with
-  | _ :: _ as fields ->
+  (match non_public with
+   | _ :: _ as fields ->
+       Log.Keeper.warn
+         "%s: ignoring non-public keeper args %s (see #7447, #9752 — \
+          accepted for external-client compatibility, no runtime effect)"
+         tool_name (String.concat ", " fields)
+   | [] -> ());
+  let present = present_json_keys removed_keeper_input_key_names args in
+  match present with
+  | [] -> Ok ()
+  | fields ->
       Error
         (Printf.sprintf
-           "non-public keeper args for %s: %s. These keeper runtime internals are not part of the public MCP/OAS surface."
+           "removed keeper args for %s: %s. Keepers are always-on by definition."
            tool_name
            (String.concat ", " fields))
-  | [] ->
-      let present = present_json_keys removed_keeper_input_key_names args in
-      match present with
-      | [] -> Ok ()
-      | fields ->
-          Error
-            (Printf.sprintf
-               "removed keeper args for %s: %s. Keepers are always-on by definition."
-               tool_name
-               (String.concat ", " fields))
 
 let reject_removed_keeper_msg_input_keys ~tool_name (args : Yojson.Safe.t) =
   let present = present_json_keys removed_keeper_msg_input_key_names args in


### PR DESCRIPTION
## 요약

`masc_keeper_up` 호출이 `codex-mcp-client`가 보낸 `social_model` arg로 전체 실패하던 hard-reject을 warn-and-continue로 변경. 정책 위반 없음 — `social_model`은 args에서 downstream이 안 읽음.

Closes #9752.

## 근본 원인

`lib/keeper/keeper_config.ml:168-186` `reject_removed_keeper_input_keys`:

```ocaml
let non_public = present_json_keys non_public_keeper_input_key_names args in
match non_public with
| _ :: _ as fields ->
    Error ("non-public keeper args for ...")   (* ← hard reject *)
| [] -> ...
```

`non_public_keeper_input_key_names = ["social_model"]` (from #7447, social_model을 public OAS surface에서 배제하는 정책).

외부 MCP 클라이언트(`codex-mcp-client`)는 `social_model`을 args에 포함시키는데, 서버가 전체 호출을 거부 → DoS.

## 정책 vs 견고함 tension

- **#7447 policy**: social_model은 keeper runtime internal, public MCP/OAS surface에 없음.
- **현실**: 외부 클라이언트가 이 필드를 보낸 후 실패.

middle ground: **accept + ignore**. social_model이 args에 있어도 downstream 어느 경로도 읽지 않음 (검증: `rg social_model lib/keeper/keeper_turn.ml lib/keeper/keeper_turn_up_args.ml lib/keeper/keeper_exec_persona.ml` → 실질적 runtime consumer 없음; runtime value는 항상 keeper meta record에서 옴).

## 변경 내용

```diff
- match non_public with
- | _ :: _ as fields ->
-     Error (Printf.sprintf "non-public keeper args for %s: %s. ...")
- | [] -> ...
+ (match non_public with
+  | _ :: _ as fields ->
+      Log.Keeper.warn
+        "%s: ignoring non-public keeper args %s (see #7447, #9752 — \
+         accepted for external-client compatibility, no runtime effect)"
+        tool_name (String.concat ", " fields)
+  | [] -> ());
+ ... existing removed_keeper_input_key_names check ...
```

- **Non-public args** (social_model) → warn + continue (Ok)
- **Removed args** (persona_profile_path 등 완전 제거 surface) → 여전히 hard Error

## 동작

| 상황 | Before | After |
|------|--------|-------|
| args = `{social_model: "foo"}` | **Error** (전체 호출 실패) | warn log + Ok (호출 진행) |
| args = `{persona_profile_path: "bar"}` | Error | Error (unchanged, 완전 제거 surface) |
| args = `{goal: "legit"}` (public) | Ok | Ok (unchanged) |

## 검증

```bash
$ dune build @check --root .
(exit 0)
```

## 회귀 리스크

매우 낮음:
- 정책 불변: social_model은 여전히 args에서 consumed 안 됨 (downstream 코드 수정 없음)
- Observable: warn 로그로 외부 client의 잘못된 usage 추적 가능
- 하위 호환: `removed_keeper_input_key_names` 하드 reject 유지

## 후속

- `codex-mcp-client` 쪽에서 `social_model` 제거 (외부 repo) — 별도 트래킹
- 로그 누적되면 alerting rule로 외부 client 행동 감지

## 참고

- Issue #9752 — 증상 + suggested direction
- #7447 (original policy: keep social_model off public OAS surface)
- memory: `feedback_masc-no-model-in-persona-or-metadata`
