### PR TITLE
chore(cascade): add gpt-5.5 to codex cli rotation

### DIFF
--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -354,6 +354,7 @@ let direct_adapters =
                     "gpt-5.3-codex";
                     "gpt-5.4-mini";
                     "gpt-5.4";
+                    "gpt-5.5";
                   ];
                 prefer_default_model_env = false;
               };

--- a/test/test_cascade_model_resolve.ml
+++ b/test/test_cascade_model_resolve.ml
@@ -102,13 +102,14 @@ let test_gemini_cli_auto_models_env_override () =
 
 let test_codex_and_claude_cli_auto_models_env_override () =
   with_clean_env (fun () ->
-    check (list string) "codex default keeps ChatGPT-supported models only"
+    check (list string) "codex default keeps Codex-supported models only"
       [
         "gpt-5.2";
         "gpt-5.3-codex-spark";
         "gpt-5.3-codex";
         "gpt-5.4-mini";
         "gpt-5.4";
+        "gpt-5.5";
       ]
       (R.codex_cli_auto_models ());
     check (list string) "claude default delegates to CLI"
@@ -157,6 +158,7 @@ let test_expand_auto_models_includes_cli_auto_specs () =
         "codex_cli:gpt-5.3-codex";
         "codex_cli:gpt-5.4-mini";
         "codex_cli:gpt-5.4";
+        "codex_cli:gpt-5.5";
         "claude_code:auto";
         "kimi_cli:kimi-for-coding";
       ]


### PR DESCRIPTION
## Summary
- add gpt-5.5 to the default codex_cli:auto model rotation
- update cascade model resolver expectations for the expanded Codex CLI list

## Evidence
- OpenAI latest-model docs currently say GPT-5.5 is available in ChatGPT and Codex, with API availability coming soon: https://developers.openai.com/api/docs/guides/latest-model
- OpenAI pricing docs do not list GPT-5.5 API pricing yet, so this intentionally does not update OAS/API pricing: https://developers.openai.com/api/docs/pricing

## Validation
- env DUNE_LOCAL_LOCK=/tmp/masc-model-catalog-20260425.lock scripts/dune-local.sh build test/test_cascade_model_resolve.exe
- ./_build/default/test/test_cascade_model_resolve.exe
- git diff --check