### PR TITLE
[codex] fix dashboard keeper card/detail signals

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -1,7 +1,7 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   AgentRoster,
   runtimeBadgeClass,
@@ -480,6 +480,7 @@ describe('AgentRoster live-only cards', () => {
   afterEach(() => {
     render(null, container)
     container.remove()
+    vi.useRealTimers()
     agents.value = []
     keepers.value = []
     executionLoaded.value = false
@@ -555,6 +556,46 @@ describe('AgentRoster live-only cards', () => {
     expect(container.textContent).not.toContain('stale keeper brief work')
     expect(container.textContent).not.toContain('stale_tool')
     expect(container.textContent).not.toContain('old blocker that should stay out of the roster')
+  })
+
+  it('uses heartbeat and full keeper model for cards when action/model fallbacks disagree', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-24T18:00:00Z'))
+    agents.value = [
+      makeAgent({
+        name: 'keeper-sangsu-agent',
+        status: 'active',
+        last_seen: '2026-04-24T17:55:00Z',
+        model: 'claude',
+      }),
+    ]
+    keepers.value = [
+      {
+        name: 'sangsu',
+        agent_name: 'keeper-sangsu-agent',
+        status: 'active',
+        active_model: 'claude_code:auto',
+        model: 'claude',
+        last_heartbeat: '2026-04-24T17:54:00Z',
+        last_autonomous_action_at: '2026-04-24T12:00:00Z',
+        last_activity_ago_s: 21_600,
+        recent_output_preview: '지금 필요한 코드 변경을 바로 만들고 결과를 확인한다.',
+        recent_tool_names: ['keeper_tasks_list'],
+      } as Keeper,
+    ]
+
+    await act(async () => {
+      render(html`<${AgentRoster} keeperFilter="keeper-only" />`, container)
+    })
+    await flushUi()
+
+    const text = container.textContent ?? ''
+    expect(text).toContain('sangsu')
+    expect(text).toContain('하트비트')
+    expect(text).toContain('6분 전')
+    expect(text).toContain('claude_code:auto')
+    expect(text).not.toContain('마지막 행동 이후')
+    expect(text).not.toContain('최근 모델claude')
   })
 })
 

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -44,6 +44,10 @@ import {
   runtimeCountSourceLabel,
   shouldShowExecutionFallbackState,
 } from '../runtime-counts'
+import {
+  keeperActivityDisplay,
+  keeperDisplayModel,
+} from '../lib/keeper-runtime-display'
 
 type StatusFilter = 'all' | RuntimeBand
 
@@ -84,23 +88,11 @@ export function rosterModelMeta(
     active_model_label?: string | null
     active_model?: string | null
     model?: string | null
+    primary_model?: string | null
+    metrics_series?: Array<{ model_used?: string | null } | null> | null
   } | null | undefined,
 ): { label: string; value: string } | null {
-  const lastModelLabel = source?.last_model_used_label?.trim()
-  if (lastModelLabel) return { label: '최근 모델', value: lastModelLabel }
-
-  const lastModel = source?.last_model_used?.trim()
-  if (lastModel) return { label: '최근 모델', value: lastModel }
-
-  const activeModelLabel = source?.active_model_label?.trim()
-  if (activeModelLabel) return { label: '현재 모델', value: activeModelLabel }
-
-  const activeModel = source?.active_model?.trim()
-  if (activeModel) return { label: '현재 모델', value: activeModel }
-
-  const fallbackModel = source?.model?.trim()
-  if (fallbackModel) return { label: '모델', value: fallbackModel }
-  return null
+  return keeperDisplayModel(source)
 }
 
 export function rosterContextMeta(
@@ -656,12 +648,12 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             ?? keeperRuntime?.recent_input_preview
             ?? goalSummary
             ?? null
-          const lastActivityAge = keeperRuntime?.last_activity_ago_s ?? null
-          const lastActivityAt =
-            keeperRuntime?.last_autonomous_action_at
-            ?? keeperRuntime?.last_heartbeat
-            ?? agent.last_seen
-            ?? null
+          const activityDisplay = keeperRuntime
+            ? keeperActivityDisplay(keeperRuntime, agent.last_seen)
+            : null
+          const lastActivityAge = activityDisplay?.ageSeconds ?? null
+          const lastActivityAt = activityDisplay?.timestamp ?? agent.last_seen ?? null
+          const lastActivityLabel = activityDisplay?.label ?? '최근 활동'
           const contextMeta =
             rosterContextMeta(keeperRuntime ?? null)
           const workPreview =
@@ -692,7 +684,9 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             )
             ?? agent.name
           const modelMeta = rosterModelMeta(keeperRuntime ?? agent)
-          const compactModel = compactModelLabel(modelMeta?.value)
+          const modelDisplay = isKeeper
+            ? modelMeta?.value ?? null
+            : compactModelLabel(modelMeta?.value)
           const fsmPhaseKey =
             keeperMonitoring?.phase.key && keeperMonitoring.phase.key !== 'unknown'
               ? keeperMonitoring.phase.key
@@ -754,7 +748,9 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                     ${stateNote.label}
                   </span>
                   ${lastActivityAt
-                    ? html`<span class="text-3xs text-[var(--text-muted)]">마지막 행동 이후 <${TimeAgo} timestamp=${lastActivityAt} /></span>`
+                    ? html`<span class="text-3xs text-[var(--text-muted)]">최근 신호 · ${lastActivityLabel} <${TimeAgo} timestamp=${lastActivityAt} /></span>`
+                    : lastActivityAge != null
+                      ? html`<span class="text-3xs text-[var(--text-muted)]">최근 신호 · ${lastActivityLabel} ${formatDuration(lastActivityAge)} 전</span>`
                     : null}
                   <span class="min-w-0 flex-1 text-xs leading-relaxed text-[var(--text-body)] break-words line-clamp-2" title=${stateNote.text}>
                     ${stateNote.text}
@@ -779,7 +775,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
               <div class="flex flex-wrap items-center gap-2 text-2xs text-[var(--text-muted)]">
                 <span class="inline-flex items-center rounded-sm border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-1">
-                  최근 활동
+                  ${lastActivityLabel}
                   <span class="ml-1 text-[var(--text-body)]">
                     ${lastActivityAt
                       ? html`<${TimeAgo} timestamp=${lastActivityAt} />`
@@ -800,10 +796,10 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                     </span>
                   </span>
                 ` : null}
-                ${modelMeta && compactModel ? html`
+                ${modelMeta && modelDisplay ? html`
                   <span class="inline-flex items-center gap-1.5 rounded-sm border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-1">
                     <span>${modelMeta.label}</span>
-                    <span class="font-mono text-3xs text-[var(--text-body)]" translate="no" title=${modelMeta.value}>${compactModel}</span>
+                    <span class="max-w-[18rem] overflow-hidden text-ellipsis whitespace-nowrap font-mono text-3xs text-[var(--text-body)]" translate="no" title=${modelMeta.value}>${modelDisplay}</span>
                   </span>
                 ` : null}
               </div>

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -8,17 +8,20 @@ import type { Keeper } from '../types'
 import { refreshDashboard } from '../store'
 import { peekLoadedKeeperConfig } from './keeper-config-panel'
 import { KeeperPhaseAndStage } from './keeper-phase-indicator'
+import { formatDuration } from '../lib/format-time'
+import {
+  keeperDisplayModel,
+  type KeeperActivityDisplay,
+} from '../lib/keeper-runtime-display'
 
 function KeeperModelChip({ keeper }: { keeper: Keeper }) {
-  const series = keeper.metrics_series ?? []
-  const lastUsed = series.length > 0 ? series[series.length - 1]?.model_used : null
-  const display = lastUsed || keeper.active_model || keeper.model
+  const display = keeperDisplayModel(keeper)
   if (!display) return null
   return html`
     <span
       class="inline-flex items-center py-0.5 px-2 rounded text-3xs font-mono bg-[var(--accent-12)] text-[var(--accent)] border border-[var(--accent-20)]"
-      title=${lastUsed && keeper.model ? `마지막 호출: ${lastUsed}\n설정: ${keeper.model}` : ''}
-    >${display}</span>
+      title=${`${display.label}: ${display.value}`}
+    >${display.value}</span>
   `
 }
 
@@ -258,16 +261,28 @@ function KeeperDetailQuickFact({
   `
 }
 
+function KeeperActivityValue({ activity }: { activity: KeeperActivityDisplay }) {
+  if (activity.timestamp) {
+    return html`${activity.label} <${TimeAgo} timestamp=${activity.timestamp} />`
+  }
+  if (activity.ageSeconds != null) {
+    return html`${activity.label} ${formatDuration(activity.ageSeconds)} 전`
+  }
+  return html`정보 없음`
+}
+
 export function KeeperDetailOverviewSidebar({
   effectiveStatus,
   contextRatioPct,
+  effectiveModelLabel,
   effectiveModel,
-  lastActivity,
+  activity,
 }: {
   effectiveStatus: string
   contextRatioPct: string
+  effectiveModelLabel: string
   effectiveModel: string
-  lastActivity: string | null
+  activity: KeeperActivityDisplay
 }) {
   return html`
     <aside class="order-2 xl:order-1 xl:sticky xl:top-[104px] xl:self-start">
@@ -282,9 +297,9 @@ export function KeeperDetailOverviewSidebar({
         <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
           <${KeeperDetailQuickFact} label="상태">${effectiveStatus}</${KeeperDetailQuickFact}>
           <${KeeperDetailQuickFact} label="컨텍스트">${contextRatioPct}</${KeeperDetailQuickFact}>
-          <${KeeperDetailQuickFact} label="현재 모델">${effectiveModel}</${KeeperDetailQuickFact}>
+          <${KeeperDetailQuickFact} label=${effectiveModelLabel}>${effectiveModel}</${KeeperDetailQuickFact}>
           <${KeeperDetailQuickFact} label="최근 활동">
-            ${lastActivity ? html`<${TimeAgo} timestamp=${lastActivity} />` : '정보 없음'}
+            <${KeeperActivityValue} activity=${activity} />
           </${KeeperDetailQuickFact}>
         </div>
 

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -4,7 +4,12 @@
 
 import { html } from 'htm/preact'
 import { isOfflineStatus } from '../lib/status-utils'
-import { keeperDisplayStatus, keeperRuntimeBlockerHint } from '../lib/keeper-runtime-display'
+import {
+  keeperActivityDisplay,
+  keeperDisplayModel,
+  keeperDisplayStatus,
+  keeperRuntimeBlockerHint,
+} from '../lib/keeper-runtime-display'
 import { signal } from '@preact/signals'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { requestConfirm } from './common/confirm-dialog'
@@ -757,12 +762,10 @@ export function KeeperDetailPage() {
     typeof keeper.context_ratio === 'number' && Number.isFinite(keeper.context_ratio)
       ? `${Math.round(keeper.context_ratio * 100)}%`
       : '정보 없음'
-  const lastModel =
-    keeper.metrics_series && keeper.metrics_series.length > 0
-      ? keeper.metrics_series[keeper.metrics_series.length - 1]?.model_used
-      : null
-  const effectiveModel = lastModel || keeper.active_model || keeper.model || '정보 없음'
-  const lastActivity = keeper.last_autonomous_action_at ?? keeper.last_heartbeat ?? keeper.created_at ?? null
+  const effectiveModelMeta = keeperDisplayModel(keeper)
+  const effectiveModelLabel = effectiveModelMeta?.label ?? '모델'
+  const effectiveModel = effectiveModelMeta?.value ?? '정보 없음'
+  const activityDisplay = keeperActivityDisplay(keeper, keeper.agent?.last_seen)
 
   const submitClearContext = () => {
     void (async () => {
@@ -857,8 +860,9 @@ export function KeeperDetailPage() {
         <${KeeperDetailOverviewSidebar}
           effectiveStatus=${effectiveStatus}
           contextRatioPct=${contextRatioPct}
+          effectiveModelLabel=${effectiveModelLabel}
           effectiveModel=${effectiveModel}
-          lastActivity=${lastActivity}
+          activity=${activityDisplay}
         />
 
         <div class="order-1 xl:order-2 flex flex-col gap-5">

--- a/dashboard/src/lib/keeper-runtime-display.test.ts
+++ b/dashboard/src/lib/keeper-runtime-display.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Keeper } from '../types'
-import { keeperDisplayStatus } from './keeper-runtime-display'
+import {
+  keeperActivityDisplay,
+  keeperDisplayModel,
+  keeperDisplayStatus,
+} from './keeper-runtime-display'
 
 /** Minimal Keeper stub with only the fields relevant to status classification. */
 function makeKeeper(overrides: Partial<Keeper> = {}): Keeper {
@@ -88,6 +92,98 @@ describe('keeperDisplayStatus', () => {
         agent: { exists: true },
       })
       expect(keeperDisplayStatus(keeper)).toBe('stopped')
+    })
+  })
+})
+
+describe('keeperDisplayModel', () => {
+  it('keeps CLI/provider runtime labels intact for active auto profiles', () => {
+    expect(
+      keeperDisplayModel({
+        active_model_label: 'claude_code:auto',
+        active_model: 'claude',
+        model: 'claude',
+      }),
+    ).toEqual({ label: '현재 모델', value: 'claude_code:auto' })
+  })
+
+  it('keeps active runtime labels ahead of metrics-series fallback', () => {
+    expect(
+      keeperDisplayModel({
+        active_model: 'claude_code:auto',
+        metrics_series: [
+          { model_used: 'openai:gpt-5.4' },
+          { model_used: 'anthropic:claude-sonnet-4-6' },
+        ],
+      }),
+    ).toEqual({ label: '현재 모델', value: 'claude_code:auto' })
+  })
+
+  it('uses the latest metrics model when structured runtime model is absent', () => {
+    expect(
+      keeperDisplayModel({
+        metrics_series: [
+          { model_used: 'openai:gpt-5.4' },
+          { model_used: 'anthropic:claude-sonnet-4-6' },
+        ],
+      }),
+    ).toEqual({ label: '최근 모델', value: 'anthropic:claude-sonnet-4-6' })
+  })
+})
+
+describe('keeperActivityDisplay', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-24T18:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('uses heartbeat as the latest live signal when autonomous action is older', () => {
+    expect(
+      keeperActivityDisplay({
+        last_autonomous_action_at: '2026-04-24T12:00:00Z',
+        last_heartbeat: '2026-04-24T17:54:00Z',
+      }),
+    ).toEqual({
+      source: 'heartbeat',
+      label: '하트비트',
+      timestamp: '2026-04-24T17:54:00Z',
+      ageSeconds: 360,
+    })
+  })
+
+  it('does not let agent last_seen override keeper runtime signals', () => {
+    expect(
+      keeperActivityDisplay(
+        { last_heartbeat: '2026-04-24T17:54:00Z' },
+        '2026-04-24T17:59:00Z',
+      ).source,
+    ).toBe('heartbeat')
+  })
+
+  it('uses autonomous action when it is newer than heartbeat', () => {
+    expect(
+      keeperActivityDisplay({
+        last_autonomous_action_at: '2026-04-24T17:59:00Z',
+        last_heartbeat: '2026-04-24T17:54:00Z',
+      }).source,
+    ).toBe('autonomous_action')
+  })
+
+  it('falls back to numeric activity age when no timestamp exists', () => {
+    expect(
+      keeperActivityDisplay({
+        last_activity_ago_s: 75,
+        last_turn_ago_s: 180,
+      }),
+    ).toEqual({
+      source: 'last_activity',
+      label: '최근 활동',
+      timestamp: null,
+      ageSeconds: 75,
     })
   })
 })

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -4,6 +4,149 @@ import { relativeTime } from './format-time'
 /** Max seconds since last heartbeat to consider the keeper process alive. */
 const HEARTBEAT_ALIVE_THRESHOLD_S = 120
 
+export type KeeperActivitySource =
+  | 'autonomous_action'
+  | 'heartbeat'
+  | 'last_activity'
+  | 'last_turn'
+  | 'agent_seen'
+  | 'created'
+  | 'none'
+
+export interface KeeperActivityDisplay {
+  source: KeeperActivitySource
+  label: string
+  timestamp: string | null
+  ageSeconds: number | null
+}
+
+export interface KeeperModelDisplay {
+  label: string
+  value: string
+}
+
+type KeeperModelDisplaySource = {
+  last_model_used_label?: string | null
+  last_model_used?: string | null
+  active_model_label?: string | null
+  active_model?: string | null
+  model?: string | null
+  primary_model?: string | null
+  metrics_series?: Array<{ model_used?: string | null } | null> | null
+}
+
+type KeeperActivityDisplaySource = {
+  last_autonomous_action_at?: string | null
+  last_heartbeat?: string | null
+  last_activity_ago_s?: number | null
+  last_turn_ago_s?: number | null
+  created_at?: string | null
+}
+
+type ActivityCandidate = {
+  source: KeeperActivitySource
+  label: string
+  timestamp: string | null
+  ageSeconds: number
+}
+
+function trimmed(value: string | null | undefined): string | null {
+  const text = value?.trim()
+  return text ? text : null
+}
+
+function latestMetricModel(source: KeeperModelDisplaySource | null | undefined): string | null {
+  const series = source?.metrics_series ?? []
+  for (let index = series.length - 1; index >= 0; index -= 1) {
+    const model = trimmed(series[index]?.model_used)
+    if (model) return model
+  }
+  return null
+}
+
+export function keeperDisplayModel(
+  source: KeeperModelDisplaySource | null | undefined,
+): KeeperModelDisplay | null {
+  const lastModelLabel = trimmed(source?.last_model_used_label)
+  if (lastModelLabel) return { label: '최근 모델', value: lastModelLabel }
+
+  const lastModel = trimmed(source?.last_model_used)
+  if (lastModel) return { label: '최근 모델', value: lastModel }
+
+  const activeModelLabel = trimmed(source?.active_model_label)
+  if (activeModelLabel) return { label: '현재 모델', value: activeModelLabel }
+
+  const activeModel = trimmed(source?.active_model)
+  if (activeModel) return { label: '현재 모델', value: activeModel }
+
+  const metricModel = latestMetricModel(source)
+  if (metricModel) return { label: '최근 모델', value: metricModel }
+
+  const fallbackModel = trimmed(source?.model) ?? trimmed(source?.primary_model)
+  if (fallbackModel) return { label: '모델', value: fallbackModel }
+  return null
+}
+
+function timestampCandidate(
+  source: KeeperActivitySource,
+  label: string,
+  timestamp: string | null | undefined,
+): ActivityCandidate | null {
+  const value = trimmed(timestamp)
+  if (!value) return null
+  const ms = Date.parse(value)
+  if (Number.isNaN(ms)) return null
+  return {
+    source,
+    label,
+    timestamp: value,
+    ageSeconds: Math.max(0, Math.round((Date.now() - ms) / 1000)),
+  }
+}
+
+function ageCandidate(
+  source: KeeperActivitySource,
+  label: string,
+  ageSeconds: number | null | undefined,
+): ActivityCandidate | null {
+  if (typeof ageSeconds !== 'number' || !Number.isFinite(ageSeconds) || ageSeconds < 0) return null
+  return {
+    source,
+    label,
+    timestamp: null,
+    ageSeconds: Math.round(ageSeconds),
+  }
+}
+
+export function keeperActivityDisplay(
+  keeper: KeeperActivityDisplaySource | null | undefined,
+  fallbackAgentLastSeen?: string | null,
+): KeeperActivityDisplay {
+  const candidates = [
+    timestampCandidate('autonomous_action', '마지막 행동', keeper?.last_autonomous_action_at),
+    timestampCandidate('heartbeat', '하트비트', keeper?.last_heartbeat),
+    ageCandidate('last_activity', '최근 활동', keeper?.last_activity_ago_s),
+    ageCandidate('last_turn', '마지막 턴', keeper?.last_turn_ago_s),
+  ].filter((candidate): candidate is ActivityCandidate => candidate != null)
+
+  candidates.sort((left, right) => left.ageSeconds - right.ageSeconds)
+  const freshest = candidates[0]
+  if (freshest) return freshest
+
+  const agentSeen = timestampCandidate('agent_seen', '에이전트 신호', fallbackAgentLastSeen)
+  if (agentSeen) return agentSeen
+
+  const created = timestampCandidate('created', '생성', keeper?.created_at)
+  if (created) return created
+
+  return {
+    source: 'none',
+    label: '최근 활동',
+    timestamp: null,
+    ageSeconds: null,
+  }
+}
+
 export function keeperDisplayStatus(keeper: Keeper | null | undefined, fallbackStatus?: string | null): string {
   if (keeper?.paused) return 'paused'
   const status = keeper?.status ?? fallbackStatus


### PR DESCRIPTION
Root cause: the monitoring agent card and keeper detail page derived display values independently. The card could prefer an old autonomous-action timestamp over a fresh heartbeat and could compact claude_code:auto into the ambiguous label claude. Detail used a different model/activity fallback chain, so the two surfaces did not share one display contract.

Changes:
- Added shared keeper display helpers for model and activity signal selection.
- Wired both the roster card and keeper detail sidebar/header through those helpers.
- Kept keeper cards on keeper runtime signals first, so agent last_seen cannot mask keeper heartbeat/action state.
- Preserved full keeper runtime labels such as claude_code:auto on keeper cards.
- Added regression coverage for the sangsu-style mismatch: stale action, fresher heartbeat, and compacted model label.

Validation:
- pnpm -C dashboard test src/lib/keeper-runtime-display.test.ts src/components/agent-roster.test.ts
- pnpm -C dashboard typecheck
- pnpm -C dashboard lint