### PR TITLE
test(disk-hygiene): scan Makefile + mk/*.mk fragments after Makefile split

### DIFF
--- a/test/test_disk_hygiene_script.ml
+++ b/test/test_disk_hygiene_script.ml
@@ -281,8 +281,27 @@ let test_tla_check_respects_keep_tlc_artifacts () =
         (Sys.file_exists
            (Filename.concat repo_dir "specs/keeper-state-machine/TraceData.tla")))
 
+(* Makefile surface was split into [Makefile] + [mk/*.mk] fragments; the
+   target definitions now live in [mk/quality.mk]. Concatenate the top-level
+   Makefile with every fragment the Makefile includes so a future refactor
+   that moves targets between fragments still satisfies this test. *)
+let read_makefile_surface () =
+  let root = source_root () in
+  let top = read_file (Filename.concat root "Makefile") in
+  let mk_dir = Filename.concat root "mk" in
+  let fragments =
+    if Sys.file_exists mk_dir && Sys.is_directory mk_dir then
+      Sys.readdir mk_dir
+      |> Array.to_list
+      |> List.filter (fun name -> Filename.check_suffix name ".mk")
+      |> List.map (fun name -> read_file (Filename.concat mk_dir name))
+    else
+      []
+  in
+  String.concat "\n" (top :: fragments)
+
 let test_makefile_exposes_disk_hygiene_targets () =
-  let makefile = read_file (Filename.concat (source_root ()) "Makefile") in
+  let makefile = read_makefile_surface () in
   check bool "doctor target exists" true
     (contains_substring makefile "doctor-disk-hygiene:");
   check bool "safe fix target exists" true


### PR DESCRIPTION
## Why

`test_disk_hygiene_script` case 3 (`makefile exposes disk hygiene targets`) fails on main with:

```
ASSERT doctor target exists
FAIL doctor target exists
```

Reproduces on a clean main checkout via `dune exec test/test_disk_hygiene_script.exe`. The make targets themselves are fine — `make doctor-disk-hygiene` works — but the test's string search is looking at the wrong file.

## Root cause

The Makefile was refactored into include-based fragments:

```make
# Makefile (14 lines total on main)
include $(MAKEFILE_DIR)mk/build.mk
include $(MAKEFILE_DIR)mk/test.mk
include $(MAKEFILE_DIR)mk/quality.mk
include $(MAKEFILE_DIR)mk/release.mk
```

`doctor-disk-hygiene:`, `fix-disk-hygiene:`, `fix-disk-hygiene-hard:`, and the `bash scripts/cleanup-tlc-artifacts.sh` recipe all moved into `mk/quality.mk`. The test's

```ocaml
let makefile = read_file (Filename.concat (source_root ()) "Makefile") in
check bool "doctor target exists" true (contains_substring makefile "doctor-disk-hygiene:");
```

only ever sees the 14-line stub, so all four assertions fail.

## Change

Replace the single-file read with a helper that concatenates the top-level Makefile plus every `mk/*.mk` fragment — the same surface `make` itself sees after include resolution. Assertions are unchanged, so any future refactor that moves targets between `mk/*.mk` files still passes without further edits.

One file, +20/-1.

## Why not scope tighter to `mk/quality.mk`

Hard-coding `mk/quality.mk` in the test re-creates the same coupling that broke the test the first time. Globbing the fragment directory once survives future moves.

## Verification

```
dune exec test/test_disk_hygiene_script.exe
→ Test Successful in 4.799s. 4 tests run.
```

Before the patch, all four assertions in `test_makefile_exposes_disk_hygiene_targets` failed on unmodified main.

## References

- Memory pattern: `feedback_structural-bug-class-rg-sweep.md` — when a refactor moves definitions, every test that scans the moved definitions by string path needs to follow.