### PR TITLE
[codex] Split coordination snapshot capture and projection

### DIFF
--- a/lib/coordination_product_snapshot.ml
+++ b/lib/coordination_product_snapshot.ml
@@ -6,6 +6,16 @@ type severity_counts =
   ; error : int
   }
 
+type observed_state =
+  { goals : Goal_store.goal list
+  ; tasks : Types.task list
+  ; posts : Board.post list
+  ; transactions : Agent_economy.transaction list
+  ; telemetry_events : Telemetry_eio.event_record list
+  ; persist_errors : int
+  ; economy_enabled : bool
+  }
+
 let unique_strings items =
   List.fold_left
     (fun acc item ->
@@ -51,6 +61,84 @@ let meta_string_list key (post : Board.post) =
 ;;
 
 let post_id_string (post : Board.post) = Board.Post_id.to_string post.id
+
+let compare_desc_float_then_string ~float_value ~string_value left right =
+  let by_time = Float.compare (float_value right) (float_value left) in
+  if by_time <> 0 then by_time else String.compare (string_value left) (string_value right)
+;;
+
+let compare_goal_id (left : Goal_store.goal) (right : Goal_store.goal) =
+  String.compare left.id right.id
+;;
+
+let compare_task_id (left : Types.task) (right : Types.task) =
+  String.compare left.id right.id
+;;
+
+let compare_post_activity left right =
+  compare_desc_float_then_string
+    ~float_value:(fun (post : Board.post) -> post.updated_at)
+    ~string_value:post_id_string
+    left
+    right
+;;
+
+let compare_transaction_activity left right =
+  compare_desc_float_then_string
+    ~float_value:(fun (txn : Agent_economy.transaction) -> txn.timestamp)
+    ~string_value:(fun txn -> txn.id)
+    left
+    right
+;;
+
+let telemetry_event_sort_key = function
+  | Telemetry_eio.Agent_joined { agent_id; capabilities } ->
+    Printf.sprintf "agent_joined:%s:%s" agent_id (String.concat "," capabilities)
+  | Telemetry_eio.Agent_left { agent_id; reason } ->
+    Printf.sprintf "agent_left:%s:%s" agent_id reason
+  | Telemetry_eio.Task_started { task_id; agent_id } ->
+    Printf.sprintf "task_started:%s:%s" task_id agent_id
+  | Telemetry_eio.Task_completed { task_id; duration_ms; success } ->
+    Printf.sprintf "task_completed:%s:%d:%b" task_id duration_ms success
+  | Telemetry_eio.Handoff_triggered { from_agent; to_agent; reason } ->
+    Printf.sprintf "handoff:%s:%s:%s" from_agent to_agent reason
+  | Telemetry_eio.Error_occurred { code; message; context } ->
+    Printf.sprintf "error:%s:%s:%s" code message context
+  | Telemetry_eio.Tool_called { tool_name; success; duration_ms; agent_id; source } ->
+    Printf.sprintf
+      "tool_called:%s:%b:%d:%s:%s"
+      tool_name
+      success
+      duration_ms
+      (Option.value agent_id ~default:"")
+      (Option.value source ~default:"")
+  | Telemetry_eio.Tool_assigned { agent_id; profile; preset; tool_count; assignment_id } ->
+    Printf.sprintf
+      "tool_assigned:%s:%s:%s:%d:%s"
+      agent_id
+      profile
+      (Option.value preset ~default:"")
+      tool_count
+      assignment_id
+;;
+
+let compare_telemetry_activity left right =
+  compare_desc_float_then_string
+    ~float_value:(fun (record : Telemetry_eio.event_record) -> record.timestamp)
+    ~string_value:(fun record -> telemetry_event_sort_key record.event)
+    left
+    right
+;;
+
+let canonicalize_observed_state state =
+  { state with
+    goals = List.sort compare_goal_id state.goals
+  ; tasks = List.sort compare_task_id state.tasks
+  ; posts = List.sort compare_post_activity state.posts
+  ; transactions = List.sort compare_transaction_activity state.transactions
+  ; telemetry_events = List.sort compare_telemetry_activity state.telemetry_events
+  }
+;;
 
 let take n values =
   let rec loop remaining acc = function
@@ -149,10 +237,7 @@ let economy_transactions_for ids transactions =
     match ids.agent_name with
     | Some agent_name -> String.equal txn.agent_name agent_name && spend_kind txn.kind
     | None -> false)
-  |> List.sort (fun left right ->
-    Float.compare
-      (right : Agent_economy.transaction).timestamp
-      (left : Agent_economy.transaction).timestamp)
+  |> List.sort compare_transaction_activity
 ;;
 
 let reward_facts ~(ids : Coordination_product.ids) transactions =
@@ -312,8 +397,7 @@ let evidence_for ~ids ~tasks ~linked_posts ~transactions ~telemetry_events =
   let task_rows = tasks |> List.map (task_evidence ids) |> take 5 in
   let board_rows =
     linked_posts
-    |> List.sort (fun (left : Board.post) (right : Board.post) ->
-      Float.compare right.updated_at left.updated_at)
+    |> List.sort compare_post_activity
     |> List.map (board_evidence ids)
     |> take 5
   in
@@ -322,10 +406,7 @@ let evidence_for ~ids ~tasks ~linked_posts ~transactions ~telemetry_events =
   in
   let telemetry_rows =
     telemetry_events
-    |> List.sort (fun left right ->
-      Float.compare
-        (right : Telemetry_eio.event_record).timestamp
-        (left : Telemetry_eio.event_record).timestamp)
+    |> List.sort compare_telemetry_activity
     |> List.filter_map (telemetry_evidence_for_event ids)
     |> take 5
   in
@@ -388,6 +469,7 @@ let product_for
       ~transactions
       ~telemetry_events
       ~persist_errors
+      ~economy_enabled
   =
   let task_statuses = List.map (fun (task : Types.task) -> task.task_status) tasks in
   let task_counts = Coordination_product.task_counts_of_statuses task_statuses in
@@ -405,7 +487,6 @@ let product_for
   let has_reward_earning, has_spend, has_penalty =
     reward_facts ~ids transactions
   in
-  let economy_enabled = Agent_economy.enabled () in
   let reward =
     Coordination_product.reward_phase_of_facts
       ~economy_enabled
@@ -434,7 +515,13 @@ let product_for
   product
 ;;
 
-let product_for_goal ~all_tasks ~posts ~transactions ~telemetry_events ~persist_errors
+let product_for_goal
+      ~all_tasks
+      ~posts
+      ~transactions
+      ~telemetry_events
+      ~persist_errors
+      ~economy_enabled
     (goal : Goal_store.goal)
   =
   let tasks =
@@ -449,6 +536,7 @@ let product_for_goal ~all_tasks ~posts ~transactions ~telemetry_events ~persist_
       ~transactions
       ~telemetry_events
       ~persist_errors
+      ~economy_enabled
   in
   { product with
     facts =
@@ -471,22 +559,30 @@ let read_recent_telemetry config =
     []
 ;;
 
-let build (config : Coord.config) =
-  let goals = Goal_store.list_goals config () in
-  let all_tasks = Coord_query.get_tasks_safe config in
-  let posts = Board_dispatch.list_posts ~limit:Board.Limits.max_posts () in
-  let transactions = Agent_economy.list_transactions ~base_path:config.base_path in
-  let telemetry_events = read_recent_telemetry config in
-  let persist_errors = Board.persist_error_count () in
+let capture (config : Coord.config) =
+  { goals = Goal_store.list_goals config ()
+  ; tasks = Coord_query.get_tasks_safe config
+  ; posts = Board_dispatch.list_posts ~limit:Board.Limits.max_posts ()
+  ; transactions = Agent_economy.list_transactions ~base_path:config.base_path
+  ; telemetry_events = read_recent_telemetry config
+  ; persist_errors = Board.persist_error_count ()
+  ; economy_enabled = Agent_economy.enabled ()
+  }
+;;
+
+let project state =
+  let state = canonicalize_observed_state state in
+  let all_tasks = state.tasks in
   let goal_products =
     List.map
       (product_for_goal
          ~all_tasks
-         ~posts
-         ~transactions
-         ~telemetry_events
-         ~persist_errors)
-      goals
+         ~posts:state.posts
+         ~transactions:state.transactions
+         ~telemetry_events:state.telemetry_events
+         ~persist_errors:state.persist_errors
+         ~economy_enabled:state.economy_enabled)
+      state.goals
   in
   let linked_task_ids =
     goal_products
@@ -502,13 +598,16 @@ let build (config : Coord.config) =
         ~goal_phase:None
         ~goal_id:None
         ~tasks:[ task ]
-        ~posts
-        ~transactions
-        ~telemetry_events
-        ~persist_errors)
+        ~posts:state.posts
+        ~transactions:state.transactions
+        ~telemetry_events:state.telemetry_events
+        ~persist_errors:state.persist_errors
+        ~economy_enabled:state.economy_enabled)
   in
   Coordination_product.snapshot (goal_products @ unlinked_task_products)
 ;;
+
+let build config = config |> capture |> project
 
 let severity_counts (snapshot : Coordination_product.snapshot) =
   let count severity =

--- a/lib/coordination_product_snapshot.mli
+++ b/lib/coordination_product_snapshot.mli
@@ -9,8 +9,31 @@ type severity_counts =
   ; error : int
   }
 
+type observed_state =
+  { goals : Goal_store.goal list
+  ; tasks : Types.task list
+  ; posts : Board.post list
+  ; transactions : Agent_economy.transaction list
+  ; telemetry_events : Telemetry_eio.event_record list
+  ; persist_errors : int
+  ; economy_enabled : bool
+  }
+(** Captured non-deterministic inputs for the coordination projection.
+
+    Store reads, clock reads, feature flags, and global counters belong before
+    this boundary. Consumers can pass a fixed value to {!project} for
+    repeatable tests and diagnostics. *)
+
+val capture : Coord.config -> observed_state
+(** Capture live runtime inputs from the existing stores. *)
+
+val project : observed_state -> Coordination_product.snapshot
+(** Deterministically project captured inputs into the pure product FSM view. *)
+
 val build : Coord.config -> Coordination_product.snapshot
-(** Build a live coordination product snapshot from existing runtime stores. *)
+(** Build a live coordination product snapshot from existing runtime stores.
+
+    Equivalent to [capture config |> project]. *)
 
 val severity_counts : Coordination_product.snapshot -> severity_counts
 (** Count snapshot violations by severity. *)

--- a/test/test_coordination_product.ml
+++ b/test/test_coordination_product.ml
@@ -2,6 +2,7 @@
 
 open Masc_mcp
 module CP = Coordination_product
+module CPS = Coordination_product_snapshot
 
 let done_status =
   Types.Done
@@ -24,11 +25,11 @@ let ids ?goal_id ?(task_ids = []) ?(post_ids = []) ?agent_name () : CP.ids =
   { goal_id; task_ids; post_ids; agent_name }
 ;;
 
-let task ?goal_id ~id ~title () : Types.task =
+let task ?goal_id ?(task_status = Types.Todo) ~id ~title () : Types.task =
   { id
   ; title
   ; description = ""
-  ; task_status = Types.Todo
+  ; task_status
   ; priority = 3
   ; files = []
   ; created_at = "2026-04-24T00:00:00Z"
@@ -40,6 +41,78 @@ let task ?goal_id ~id ~title () : Types.task =
   ; handoff_context = None
   ; cycle_count = 0
   ; do_not_reclaim_reason = None
+  }
+;;
+
+let goal ?(phase = Goal_phase.Executing) ~id ~title () : Goal_store.goal =
+  { id
+  ; horizon = Goal_store.Short
+  ; title
+  ; metric = None
+  ; target_value = None
+  ; due_date = None
+  ; priority = 3
+  ; status = Goal_store.Active
+  ; phase
+  ; verifier_policy = None
+  ; require_completion_approval = false
+  ; active_verification_request_id = None
+  ; parent_goal_id = None
+  ; last_review_note = None
+  ; last_review_at = None
+  ; created_at = "2026-04-24T00:00:00Z"
+  ; updated_at = "2026-04-24T00:00:01Z"
+  }
+;;
+
+let post_id value =
+  match Board.Post_id.of_string value with
+  | Ok id -> id
+  | Error err -> Alcotest.failf "invalid post id: %s" (Board.show_board_error err)
+;;
+
+let agent_id value =
+  match Board.Agent_id.of_string value with
+  | Ok id -> id
+  | Error err -> Alcotest.failf "invalid agent id: %s" (Board.show_board_error err)
+;;
+
+let post ?(updated_at = 2.0) ~id ~title ~meta_json () : Board.post =
+  { id = post_id id
+  ; author = agent_id "worker"
+  ; title
+  ; body = "body"
+  ; content = "content"
+  ; post_kind = Board.Automation_post
+  ; meta_json = Some meta_json
+  ; visibility = Board.Internal
+  ; created_at = 1.0
+  ; updated_at
+  ; expires_at = 0.0
+  ; votes_up = 0
+  ; votes_down = 0
+  ; reply_count = 0
+  ; hearth = None
+  ; thread_id = None
+  }
+;;
+
+let transaction ?(timestamp = 3.0) ~id ~task_id () : Agent_economy.transaction =
+  { id
+  ; agent_name = "worker"
+  ; kind = Agent_economy.Earn_task_done
+  ; amount = 1.0
+  ; balance_after = 11.0
+  ; reason = "done"
+  ; counterparty = "system"
+  ; metadata = `Assoc [ CP.Ref_key.task_id, `String task_id ]
+  ; timestamp
+  }
+;;
+
+let telemetry ?(timestamp = 4.0) ~task_id () : Telemetry_eio.event_record =
+  { timestamp
+  ; event = Telemetry_eio.Task_completed { task_id; duration_ms = 42; success = true }
   }
 ;;
 
@@ -253,6 +326,57 @@ let test_snapshot_json () =
      |> to_string)
 ;;
 
+let test_projection_is_deterministic_from_captured_state () =
+  let goal_a = goal ~id:"goal-a" ~title:"A" () in
+  let goal_b = goal ~id:"goal-b" ~title:"B" () in
+  let task_a =
+    task ~goal_id:"goal-a" ~id:"task-a" ~title:"A task" ~task_status:done_status ()
+  in
+  let task_b = task ~goal_id:"goal-b" ~id:"task-b" ~title:"B task" () in
+  let orphan = task ~id:"task-orphan" ~title:"Orphan task" () in
+  let post_a =
+    post
+      ~id:"post-a"
+      ~title:"A signal"
+      ~meta_json:(`Assoc [ CP.Ref_key.task_id, `String "task-a" ])
+      ()
+  in
+  let txn_a = transaction ~id:"txn-a" ~task_id:"task-a" () in
+  let telemetry_a = telemetry ~task_id:"task-a" () in
+  let left : CPS.observed_state =
+    { goals = [ goal_b; goal_a ]
+    ; tasks = [ orphan; task_b; task_a ]
+    ; posts = [ post_a ]
+    ; transactions = [ txn_a ]
+    ; telemetry_events = [ telemetry_a ]
+    ; persist_errors = 0
+    ; economy_enabled = true
+    }
+  in
+  let right =
+    { left with
+      goals = List.rev left.goals
+    ; tasks = List.rev left.tasks
+    ; posts = List.rev left.posts
+    ; transactions = List.rev left.transactions
+    ; telemetry_events = List.rev left.telemetry_events
+    }
+  in
+  let left_json = left |> CPS.project |> CP.snapshot_to_yojson |> Yojson.Safe.to_string in
+  let right_json = right |> CPS.project |> CP.snapshot_to_yojson |> Yojson.Safe.to_string in
+  Alcotest.(check string) "projection ignores capture order" left_json right_json;
+  let disabled =
+    { left with economy_enabled = false }
+    |> CPS.project
+    |> CP.snapshot_to_yojson
+  in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string)
+    "captured economy flag controls reward deterministically"
+    "disabled"
+    (disabled |> member "products" |> index 0 |> member "reward" |> to_string)
+;;
+
 let () =
   Alcotest.run
     "Coordination_product"
@@ -280,6 +404,12 @@ let () =
         ] )
     ; ( "reward"
       , [ Alcotest.test_case "reward machine phases" `Quick test_reward_machine_phases ] )
-    ; "json", [ Alcotest.test_case "snapshot json" `Quick test_snapshot_json ]
+    ; ( "json"
+      , [ Alcotest.test_case "snapshot json" `Quick test_snapshot_json
+        ; Alcotest.test_case
+            "captured-state projection is deterministic"
+            `Quick
+            test_projection_is_deterministic_from_captured_state
+        ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- Split coordination product snapshot construction into non-deterministic `capture` and deterministic `project`.
- Move economy feature flag reads into the capture boundary.
- Canonicalize captured goals/tasks/posts/ledger/telemetry before projection so output does not depend on store read order.
- Add regression coverage for deterministic projection from fixed captured inputs.

## Verification
- `env MASC_DUNE_THROTTLE=0 DUNE_BUILD_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/separate-det-nondet/_build-det-boundary-check DUNE_JOBS=1 scripts/dune-local.sh build ./test/test_coordination_product.exe ./test/test_dashboard_http_core.exe ./test/test_tool_coord_coverage.exe`
- `env MASC_BASE_PATH=/tmp/masc-det-boundary-rebase-coordination-test MASC_BASE_PATH_INPUT=/tmp/masc-det-boundary-rebase-coordination-test _build-det-boundary-check/default/test/test_coordination_product.exe`
- `env MASC_BASE_PATH=/tmp/masc-det-boundary-rebase-dashboard-test MASC_BASE_PATH_INPUT=/tmp/masc-det-boundary-rebase-dashboard-test _build-det-boundary-check/default/test/test_dashboard_http_core.exe`
- `env MASC_BASE_PATH=/tmp/masc-det-boundary-rebase-toolcoord-test MASC_BASE_PATH_INPUT=/tmp/masc-det-boundary-rebase-toolcoord-test _build-det-boundary-check/default/test/test_tool_coord_coverage.exe`
