### PR TITLE
fix(keeper-budget): bump per_turn default 30s → 60s (#10008 fm2)

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -390,18 +390,28 @@ module KeeperKeepalive = struct
         get_float ~default:1.5 "MASC_KEEPER_OAS_TIMEOUT_PER_1K"
       in
       let per_turn =
-        get_float ~default:30.0 "MASC_KEEPER_OAS_TIMEOUT_PER_TURN"
+        (* #10008 fm2: bumped from 30.0 to 60.0. Recent-hour p50 turn
+           latency across the fleet is ~17min (#9933); 30s was the
+           "fantasy" value flagged in the issue body.  60s is still
+           well below observed p50 but doubles the budget allowance
+           without pushing the formula past [turn_timeout_sec] (1200 s
+           cap).  Operators who need more can raise
+           [MASC_KEEPER_OAS_TIMEOUT_PER_TURN] via env; the hard cap at
+           [Float.min turn_timeout_sec ...] below protects the fleet
+           from runaway budgets. *)
+        get_float ~default:60.0 "MASC_KEEPER_OAS_TIMEOUT_PER_TURN"
       in
       let input_time =
         Float.of_int (max 0 estimated_input_tokens) /. 1000.0 *. per_1k
       in
-      (* Cap at 40 effective turns even if the configured per-call turn
-         budget is higher. This is a deliberate safety cap: with
-         per_turn=30s, 40 turns alone consume 1200s — the entire
-         turn_timeout_sec budget. Users pushing beyond 40 turns should
-         instead raise turn_timeout_sec or split the work. *)
+      (* Cap at 20 effective turns even if the configured per-call turn
+         budget is higher.  With per_turn=60s, 20 turns consume 1200s —
+         the entire turn_timeout_sec budget.  Users pushing beyond 20
+         turns should instead raise turn_timeout_sec or split the
+         work.  Cap halved from 40 → 20 when per_turn default doubled
+         (30 → 60) so the boundary condition is preserved. *)
       let effective_turns =
-        Float.of_int (min max_turns 40)
+        Float.of_int (min max_turns 20)
       in
       let turn_time = effective_turns *. per_turn in
       Float.max 30.0


### PR DESCRIPTION
## 요약

#10008 FM2 대응. OAS budget timeout formula의 `per_turn=30s` 가정이 실측 p50 17min과 34배 괴리. 보수적으로 60s로 doubling + effective_turns cap 40→20 (boundary 유지).

Partially closes #10008 (FM2 only). FM1 (#10031), FM3 (#10060) 이미 처리됨.

## 증상 (이슈 인용)

velvet-hammer keeper:
```
unified:error:OAS budget timeout after 423.8s
  (adaptive_estimated_input_tokens, estimated input 2519 tokens,
   keeper hard cap 1200.0s)
```

Formula: `base(120) + 2519/1000 * 1.5 + 10 * 30 = 423.78s` ← 계산은 정상.

**문제**: `per_turn=30s`가 fantasy. #9933 recent-hour 측정 p50 = **1,047,932ms (17분 28초/turn)**. Formula가 **34배 under-estimate**.

## 변경 내용

```diff
- let per_turn =
-   get_float ~default:30.0 "MASC_KEEPER_OAS_TIMEOUT_PER_TURN"
- in
+ let per_turn =
+   (* #10008 fm2: bumped from 30.0 to 60.0 ... *)
+   get_float ~default:60.0 "MASC_KEEPER_OAS_TIMEOUT_PER_TURN"
+ in

- (* Cap at 40 effective turns even if the configured per-call turn
-    budget is higher. This is a deliberate safety cap: with
-    per_turn=30s, 40 turns alone consume 1200s ... *)
- let effective_turns = Float.of_int (min max_turns 40) in
+ (* Cap at 20 effective turns ... With per_turn=60s, 20 turns
+    consume 1200s — the entire turn_timeout_sec budget.
+    Cap halved from 40 → 20 when per_turn default doubled
+    (30→60) so the boundary condition is preserved. *)
+ let effective_turns = Float.of_int (min max_turns 20) in
```

## 수치 영향

| max_turns | input_tokens | per_turn=30 (before) | per_turn=60 (after) | 1200s cap |
|-----------|-------------:|---------------------:|--------------------:|----------:|
| 10 | 2519 | 423.8s | **723.8s** (+300s) | clamped to 723.8s |
| 10 | 10000 | 435.0s | **735.0s** (+300s) | clamped to 735.0s |
| 20 | 2519 | 723.8s | **1200.0s** (cap) | 1200s |
| 40 | 2519 | 1200.0s (cap, was 1323 unc) | **1200.0s** (cap, was 2523 unc) | 1200s |

Boundary 유지: max_turns ≥ 20에서 formula가 cap에 도달. 이전에도 40턴에서 cap에 도달했고, 지금도 20턴에서 cap에 도달. Fleet 안전성 불변.

## 왜 60s (not 17min)?

- 17min (observed p50) 설정 시 formula = base+input_time + turns*1020s → 10턴이면 10000+ 초로 폭발 → `turn_timeout_sec` hard cap(1200s)이 계속 발동 → 실질적으로 **모든 keeper가 cap에 걸림**
- cap은 cascade rotation + fleet-wide fair-share 위해 필요. 1200s 이상 못 주는 인프라 제약.
- **현실**: 17min turn이 돌 수 있는 workload는 별도 `turn_timeout_sec` bump 필요 — 이 formula만으론 해결 불가
- 60s는 중간 지점 — 기존 fantasy 제거하되 fleet throughput 유지

## 진짜 fix (out of scope)

이슈 body 제안:
> per_turn 기본값을 실측 p50 반영으로 올리거나, **turn_budget을 turn 수가 아닌 wall-clock budget 기반으로 교체**

Wall-clock budget 기반 전환은 OAS interface 변경 필요 — 큰 refactor, 별도 PR.

## 검증

```bash
$ dune build @check --root .
(exit 0)
```

기존 테스트 영향 없음 (이 formula 직접 테스트 없음).

## 회귀 리스크

| 시나리오 | 영향 |
|---------|------|
| 저-turn (1-5) + 저-input | +30~150s 추가 (여유) |
| 중-turn (10) | +300s → 723s (cap 하) |
| 고-turn (20+) | cap 1200s (이전과 동일) |
| env override 사용자 | 영향 없음 (custom 값 유지) |

간단한 heuristic 조정. Operator가 env로 override 가능.

## 참고

- Issue #10008 — FM1/2/3 analysis
- PR #10031 — FM1 fix (already merged)
- PR #10060 — FM3 observability (already merged)
- #9933 — p50 17min 실측 근거
