### PR TITLE
fix(keeper): drop per_turn multiplier, use wall-clock cap as OAS budget (#10008 fm2)

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -326,17 +326,11 @@ module KeeperKeepalive = struct
       Guards against indefinite LLM response waits within a turn.
 
       When [MASC_KEEPER_OAS_TIMEOUT_SEC] is set, that value is used directly.
-      Otherwise, {!oas_timeout_for_estimated_input_tokens} computes an
-      adaptive timeout:
-        base + estimated_input_tokens/1K × per_1k + min(max_turns, 40) × per_turn
-      References {!oas_max_turns_per_call} (default 30) directly to avoid
-      default drift.  Previous formula used 4× headroom on a default of 5,
-      producing min(5, 40)=5 effective turns.  Using the actual per-call
-      turn budget keeps scheduled-autonomous and reactive channels aligned
-      with the timeout heuristic.
-
-      At 262K context, 30 turns/call:
-        120 + 393 + min(30,40)×30 = 120+393+900 = 1413
+      Otherwise, {!oas_timeout_for_estimated_input_tokens} returns the
+      keeper wall-clock cap directly.  The previous adaptive formula used
+      token count and per-turn multipliers, but those estimates were far
+      below observed fleet turn latency and could timeout before a real
+      multi-turn call completed.
 
       Env: [MASC_KEEPER_OAS_TIMEOUT_SEC]. Default: adaptive.
       Range: [30, turn_timeout_sec]. *)
@@ -382,40 +376,38 @@ module KeeperKeepalive = struct
 
   let oas_timeout_for_estimated_input_tokens_with_turn_budget
       ~(estimated_input_tokens : int) ~(max_turns : int) : float =
+    let _ = max_turns in
     match oas_timeout_sec_override with
     | Some v -> v
     | None ->
-      let base = 120.0 in
-      let per_1k =
-        get_float ~default:1.5 "MASC_KEEPER_OAS_TIMEOUT_PER_1K"
-      in
-      let per_turn =
-        (* #10008 fm2: bumped from 30.0 to 60.0. Recent-hour p50 turn
-           latency across the fleet is ~17min (#9933); 30s was the
-           "fantasy" value flagged in the issue body.  60s is still
-           well below observed p50 but doubles the budget allowance
-           without pushing the formula past [turn_timeout_sec] (1200 s
-           cap).  Operators who need more can raise
-           [MASC_KEEPER_OAS_TIMEOUT_PER_TURN] via env; the hard cap at
-           [Float.min turn_timeout_sec ...] below protects the fleet
-           from runaway budgets. *)
-        get_float ~default:60.0 "MASC_KEEPER_OAS_TIMEOUT_PER_TURN"
-      in
-      let input_time =
-        Float.of_int (max 0 estimated_input_tokens) /. 1000.0 *. per_1k
-      in
-      (* Cap at 20 effective turns even if the configured per-call turn
-         budget is higher.  With per_turn=60s, 20 turns consume 1200s —
-         the entire turn_timeout_sec budget.  Users pushing beyond 20
-         turns should instead raise turn_timeout_sec or split the
-         work.  Cap halved from 40 → 20 when per_turn default doubled
-         (30 → 60) so the boundary condition is preserved. *)
-      let effective_turns =
-        Float.of_int (min max_turns 20)
-      in
-      let turn_time = effective_turns *. per_turn in
-      Float.max 30.0
-        (Float.min turn_timeout_sec (base +. input_time +. turn_time))
+      (* #10008 fm2: the prior formula scaled the budget linearly with
+         [max_turns * per_turn (=30s)].  #9933 recent-hour measurement
+         shows fleet p50 turn latency ~16 min (960s) — the 30s-per-turn
+         assumption was 32x below reality.  velvet-hammer at max_turns=10
+         computed only 423.8s of OAS budget against a 1200s wall-clock
+         cap; multi-turn research calls regularly hit
+         [oas_timeout_budget] before a single real turn finished.
+
+         Root-cause fix: drop the [per_turn * turns] term entirely.
+         [turn_timeout_sec] is already the authoritative wall-clock
+         cap the formula was trying to approach.  Keep the tiny
+         [base + input_time] estimate as a lower bound so tests and
+         callers that set explicit overrides still see a sensible
+         value, then floor at the wall-clock cap.  [max_turns] stops
+         being an input to this computation — the count controls the
+         OAS agent's retry budget elsewhere, not MASC's wall-clock
+         expectation. *)
+      let _ = estimated_input_tokens in
+      (* Use wall-clock cap directly.  Short calls exit early via
+         tool-response detection; they do not need a smaller budget
+         reserved up front.  [estimated_input_tokens] and the old
+         [base + input_time] estimate are no longer load-bearing
+         inputs — they scaled at 1.5s/1k tokens, which was
+         negligible compared to the real p50 turn latency the
+         multiplier was trying to reserve for.  Kept in the
+         signature because callers still pass the value; ignored
+         for budget computation. *)
+      turn_timeout_sec
 
   let oas_timeout_for_estimated_input_tokens
       ~(estimated_input_tokens : int) : float =

--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -231,22 +231,22 @@ let admission_wait_timeout_sec () =
 
 let oas_timeout_for_estimated_input_tokens_with_turn_budget
     ~(estimated_input_tokens : int) ~(max_turns : int) : float =
+  let _ = estimated_input_tokens in
+  let _ = max_turns in
   let runtime = current () in
   match runtime.oas_timeout_override_sec.value with
   | Some value -> value
   | None ->
-      let base = 120.0 in
-      let input_time =
-        Float.of_int (max 0 estimated_input_tokens) /. 1000.0
-        *. runtime.oas_timeout_per_1k.value
-      in
-      let effective_turns =
-        Float.of_int (min max_turns 40)
-      in
-      let turn_time = effective_turns *. runtime.oas_timeout_per_turn.value in
-      Float.max 30.0
-        (Float.min runtime.turn_timeout_sec.value
-           (base +. input_time +. turn_time))
+      (* #10008 fm2: kept in lockstep with
+         [Env_config.KeeperKeepalive.oas_timeout_for_estimated_input_tokens_with_turn_budget].
+         The old formula scaled linearly with [max_turns * per_turn(=30s)]
+         but production p50 turn latency was ~16 min (#9933), making
+         the multiplier 32x below reality.  Drop the turn-count and
+         input-token scaling; return [turn_timeout_sec] directly as
+         the wall-clock cap.  Short calls exit early via tool-response
+         detection, they do not need a smaller budget reserved up
+         front. *)
+      runtime.turn_timeout_sec.value
 
 let oas_timeout_for_estimated_input_tokens ~(estimated_input_tokens : int) :
     float =

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4012,11 +4012,24 @@ let test_bounded_oas_timeout_uses_adaptive_when_budget_is_large () =
       ~estimated_input_tokens ~remaining_turn_budget_s:1200.0
   with
   | Some timeout_s ->
-      check (float 0.01) "adaptive timeout kept under full budget"
-        expected timeout_s
+      (* The bounded variant subtracts a ~30s finalization guard
+         from [remaining_turn_budget_s] and caps at the adaptive
+         raw.  With #10008 fm2 the adaptive raw equals
+         [turn_timeout_sec] (1200), so the finalization guard path
+         dominates: returned value is [remaining - 30]. *)
+      check bool "bounded timeout at or below adaptive raw"
+        true (timeout_s <= expected);
+      check bool "bounded leaves positive finalization guard"
+        true (timeout_s < 1200.0 && timeout_s > 1100.0)
   | None -> fail "expected bounded timeout"
 
-let test_bounded_oas_timeout_scales_with_estimated_input_tokens () =
+(* #10008 fm2: the budget formula no longer scales with token count,
+   so [bounded_oas_timeout_for_turn_budget] returns the same value
+   for small and large prompts when the remaining_turn_budget is
+   unchanged.  Replaces the prior "smaller prompt gets smaller
+   budget" invariant, which was load-bearing on the (removed)
+   [per_1k * tokens] term. *)
+let test_bounded_oas_timeout_is_token_independent () =
   match
     ( UT.bounded_oas_timeout_for_turn_budget
         ~estimated_input_tokens:2_000 ~remaining_turn_budget_s:1200.0,
@@ -4024,8 +4037,8 @@ let test_bounded_oas_timeout_scales_with_estimated_input_tokens () =
         ~estimated_input_tokens:262_144 ~remaining_turn_budget_s:1200.0 )
   with
   | Some low_prompt_timeout, Some high_prompt_timeout ->
-      check bool "smaller prompt gets smaller budget" true
-        (low_prompt_timeout < high_prompt_timeout)
+      check (float 0.01) "token count no longer affects budget"
+        low_prompt_timeout high_prompt_timeout
   | _ -> fail "expected bounded timeouts for both prompt sizes"
 
 let test_bounded_oas_timeout_caps_to_remaining_turn_budget () =
@@ -4042,7 +4055,7 @@ let test_bounded_oas_timeout_uses_channel_turn_budget_override () =
     Env_config.KeeperKeepalive.oas_max_turns_per_call_scheduled_autonomous
   in
   let estimated_input_tokens = 2_000 in
-  let expected =
+  let raw =
     Env_config.KeeperKeepalive
     .oas_timeout_for_estimated_input_tokens_with_turn_budget
       ~estimated_input_tokens ~max_turns
@@ -4052,8 +4065,15 @@ let test_bounded_oas_timeout_uses_channel_turn_budget_override () =
       ~max_turns ~estimated_input_tokens ~remaining_turn_budget_s:1200.0
   with
   | Some timeout_s ->
-      check (float 0.01) "scheduled autonomous turn budget lowers adaptive timeout"
-        expected timeout_s
+      (* #10008 fm2: raw formula no longer depends on max_turns;
+         bounded variant still subtracts the ~30s finalization
+         guard from [remaining_turn_budget_s] and caps at the
+         raw.  Verify the cap was applied ([<=] raw) and the
+         guard reserved a positive amount. *)
+      check bool "bounded timeout at or below raw formula output"
+        true (timeout_s <= raw);
+      check bool "finalization guard reserves positive delta"
+        true (timeout_s <= 1200.0 && timeout_s > 1100.0)
   | None -> fail "expected bounded timeout"
 
 let test_bounded_oas_timeout_refuses_too_little_budget () =
@@ -5762,8 +5782,8 @@ let () =
             test_cascade_exhausted_error_includes_resumable_cli_session_error;
           test_case "bounded OAS timeout keeps adaptive timeout under full budget" `Quick
             test_bounded_oas_timeout_uses_adaptive_when_budget_is_large;
-          test_case "bounded OAS timeout scales with estimated input tokens" `Quick
-            test_bounded_oas_timeout_scales_with_estimated_input_tokens;
+          test_case "bounded OAS timeout is token-independent (#10008 fm2)" `Quick
+            test_bounded_oas_timeout_is_token_independent;
           test_case "bounded OAS timeout caps to remaining turn budget" `Quick
             test_bounded_oas_timeout_caps_to_remaining_turn_budget;
           test_case "bounded OAS timeout respects channel turn budget override" `Quick

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -71,60 +71,81 @@ let test_keepalive_jitter_range () =
 
 let adaptive = Cfg.KeeperKeepalive.oas_timeout_for_estimated_input_tokens
 
-let test_oas_timeout_32k () =
+(* #10008 fm2: the budget formula no longer scales with
+   [max_turns * per_turn(=30s)].  Production p50 turn latency is
+   ~16 min (#9933) — the 30s/turn assumption was 32x off, and
+   velvet-hammer at max_turns=10 computed only 423.8s against a
+   1200s wall-clock cap, starving multi-turn research calls.
+   Budget now equals [turn_timeout_sec] directly.  These tests
+   pin that invariant: input-token size and max_turns no longer
+   affect the computed budget, only the env override and the
+   wall-clock cap do. *)
+
+let turn_cap = Cfg.KeeperKeepalive.turn_timeout_sec
+
+let test_oas_timeout_32k_uses_wall_clock () =
   let v = adaptive ~estimated_input_tokens:32_000 in
-  (* 120 + 32*1.5 + min(15,40)*30 = 120+48+450 = 618 *)
-  check (float 1.0) "32K → 618s" 618.0 v
+  check (float 1.0)
+    "32K input → wall-clock cap (turn_timeout_sec)" turn_cap v
 
-let test_oas_timeout_128k () =
+let test_oas_timeout_128k_uses_wall_clock () =
   let v = adaptive ~estimated_input_tokens:128_000 in
-  (* 120 + 128*1.5 + 450 = 762 *)
-  check (float 1.0) "128K → 762s" 762.0 v
+  check (float 1.0)
+    "128K input → wall-clock cap (turn_timeout_sec)" turn_cap v
 
-let test_oas_timeout_262k () =
+let test_oas_timeout_262k_uses_wall_clock () =
   let v = adaptive ~estimated_input_tokens:262_144 in
-  (* 120 + 262.144*1.5 + min(15,40)*30 = 120+393.216+450 = 963.216 *)
-  check bool "262K → [960, 970]" true (v >= 960.0 && v <= 970.0)
+  check (float 1.0)
+    "262K input → wall-clock cap (turn_timeout_sec)" turn_cap v
 
-let test_oas_timeout_262k_scheduled_autonomous () =
+let test_oas_timeout_scheduled_autonomous_uses_wall_clock () =
+  (* #10008 fm2 regression guard: max_turns must not pull the
+     budget below the wall-clock cap anymore. velvet-hammer's
+     423.8s symptom is gone; this call returns [turn_timeout_sec]
+     regardless of max_turns. *)
   let v =
     Cfg.KeeperKeepalive.oas_timeout_for_estimated_input_tokens_with_turn_budget
       ~estimated_input_tokens:262_144
       ~max_turns:Cfg.KeeperKeepalive.oas_max_turns_per_call_scheduled_autonomous
   in
-  (* #6810: default lowered 5→2 to keep semaphore hold under wait timeout.
-     120 + 262.144*1.5 + min(2,40)*30 = 120+393.216+60 = 573.216 *)
-  check bool "262K scheduled autonomous → [570, 580]" true
-    (v >= 570.0 && v <= 580.0)
+  check (float 1.0)
+    "scheduled_autonomous → wall-clock cap (turn_timeout_sec)"
+    turn_cap v
 
-let test_oas_timeout_zero () =
+let test_oas_timeout_zero_uses_wall_clock () =
   let v = adaptive ~estimated_input_tokens:0 in
-  (* 120 + 0 + min(15,40)*30 = 570 *)
-  check (float 1.0) "0 context → base+turn budget 570s" 570.0 v
+  check (float 1.0)
+    "0 context → wall-clock cap (turn_timeout_sec)" turn_cap v
 
-let test_oas_timeout_monotonic () =
+(* #10008 fm2: the formula no longer varies with token count,
+   so the old "monotonic increase with input size" invariant is
+   replaced by a "constant equal to wall-clock cap" invariant. *)
+let test_oas_timeout_is_token_independent () =
   let v1 = adaptive ~estimated_input_tokens:32_000 in
   let v2 = adaptive ~estimated_input_tokens:128_000 in
   let v3 = adaptive ~estimated_input_tokens:262_144 in
-  check bool "32K < 128K" true (v1 < v2);
-  check bool "128K < 262K" true (v2 < v3)
+  check (float 0.1) "32K == 128K (both at wall-clock cap)" v1 v2;
+  check (float 0.1) "128K == 262K (both at wall-clock cap)" v2 v3;
+  check (float 0.1) "all equal to turn_timeout_sec" turn_cap v1
 
 let test_oas_timeout_cap () =
   let v = adaptive ~estimated_input_tokens:1_000_000 in
-  check (float 0.1) "1M estimated input tokens → capped at turn timeout 1200" 1200.0 v
+  check (float 0.1)
+    "1M estimated input tokens → capped at turn timeout 1200"
+    turn_cap v
 
 let test_turn_timeout_default () =
   check (float 0.1) "default turn timeout 1200s" 1200.0
     Cfg.KeeperKeepalive.turn_timeout_sec
 
 let test_max_turns_default () =
-  check int "default max_turns_per_call 15" 15
+  check int "default max_turns_per_call 30" 30
     Cfg.KeeperKeepalive.oas_max_turns_per_call
 
 let test_scheduled_autonomous_max_turns_default () =
-  (* #6810: lowered 5→2 so autonomous semaphore hold
-     (turns × latency) stays under 60s wait timeout. *)
-  check int "default scheduled autonomous max_turns_per_call 2" 2
+  (* Raised to 10 after Docker oas_env propagation restored; see
+     [env_config_keeper.ml] docstring. *)
+  check int "default scheduled autonomous max_turns_per_call 10" 10
     Cfg.KeeperKeepalive.oas_max_turns_per_call_scheduled_autonomous
 
 let test_max_turns_range () =
@@ -349,17 +370,22 @@ let () =
       test_case "jitter range" `Quick test_keepalive_jitter_range;
     ];
     "oas_timeout_adaptive", [
-      test_case "adaptive 32K context" `Quick test_oas_timeout_32k;
-      test_case "adaptive 128K context" `Quick test_oas_timeout_128k;
-      test_case "adaptive 262K context" `Quick test_oas_timeout_262k;
-      test_case "adaptive 262K scheduled autonomous context" `Quick
-        test_oas_timeout_262k_scheduled_autonomous;
-      test_case "adaptive 0 context" `Quick test_oas_timeout_zero;
-      test_case "adaptive monotonic" `Quick test_oas_timeout_monotonic;
+      test_case "32K context uses wall-clock cap (#10008 fm2)" `Quick
+        test_oas_timeout_32k_uses_wall_clock;
+      test_case "128K context uses wall-clock cap (#10008 fm2)" `Quick
+        test_oas_timeout_128k_uses_wall_clock;
+      test_case "262K context uses wall-clock cap (#10008 fm2)" `Quick
+        test_oas_timeout_262k_uses_wall_clock;
+      test_case "scheduled autonomous uses wall-clock cap (#10008 fm2)" `Quick
+        test_oas_timeout_scheduled_autonomous_uses_wall_clock;
+      test_case "0 context uses wall-clock cap (#10008 fm2)" `Quick
+        test_oas_timeout_zero_uses_wall_clock;
+      test_case "budget is token-count independent (#10008 fm2)" `Quick
+        test_oas_timeout_is_token_independent;
       test_case "turn timeout default is 1200" `Quick test_turn_timeout_default;
       test_case "adaptive capped at turn timeout" `Quick test_oas_timeout_cap;
-      test_case "max_turns default is 15" `Quick test_max_turns_default;
-      test_case "scheduled autonomous max_turns default is 2" `Quick
+      test_case "max_turns default is 30" `Quick test_max_turns_default;
+      test_case "scheduled autonomous max_turns default is 10" `Quick
         test_scheduled_autonomous_max_turns_default;
       test_case "max_turns range" `Quick test_max_turns_range;
       test_case "scheduled autonomous max_turns range" `Quick


### PR DESCRIPTION
## 요약

#10008 failure mode 2: velvet-hammer 가 `max_turns=10` 에서 OAS budget **423.8s** 만 받고 (wall-clock cap 1200s 의 35%) 매 call 이 `oas_timeout_budget` 로 종료.

Formula:
```
budget = base(120) + tokens/1k * per_1k(1.5) + min(max_turns,40) * per_turn(30)
       = 120 + 3.0 + 10*30 = 423.0s
```

`per_turn = 30s` 가정이 #9933 측정 p50 (960s, 16분) 대비 **32배 fantasy**. Formula 는 turn 수에 비례해 budget 을 키우려 했지만 기본값이 reality 의 3% 라 항상 wall-clock cap 미만에서 starve.

## 근원 fix

`per_turn * max_turns` 항 자체를 제거. `input_time` 항도 제거 (1.5s/1k 로 영향 미미했음). `turn_timeout_sec` (기본 1200s) 을 wall-clock cap 으로 **직접** 반환.

이유:
- Wall-clock cap 은 이미 formula 의 ceiling 이었음 — 기존 `Float.min turn_timeout_sec (...)` 가 그걸 확인.
- "Small max_turns 에 작은 budget" 정당성은 per_turn=30s 가정에 의존했고 그게 fantasy 로 판명.
- 실제 짧은 call 은 tool-response detection 으로 조기 종료 — budget 크게 잡아도 semaphore 를 오래 점유하지 않음.

## 변경 파일

- `lib/config/env_config_keeper.ml` — `oas_timeout_for_estimated_input_tokens_with_turn_budget` 이 `turn_timeout_sec` 반환.
- `lib/keeper/keeper_runtime_resolved.ml` — 동일한 lockstep formula 도 같은 방식 (runtime-resolved 경로에서 사용).
- `test/test_work_as_heartbeat.ml`
  - 5개 adaptive timeout 테스트를 "uses_wall_clock" 으로 재작성.
  - `test_oas_timeout_monotonic` → `test_oas_timeout_is_token_independent` (token 크기 증가가 budget 증가를 의미하지 않음).
  - Drive-by: stale `test_max_turns_default` 15→30, `test_scheduled_autonomous_max_turns_default` 2→10 (main 에서 이미 깨져 있던 stale 기대값).
- `test/test_keeper_unified.ml`
  - `test_bounded_oas_timeout_uses_adaptive_when_budget_is_large` — bounded variant 가 raw 이하 + finalization guard 양수를 확인.
  - `test_bounded_oas_timeout_scales_with_estimated_input_tokens` → `test_bounded_oas_timeout_is_token_independent`.
  - `test_bounded_oas_timeout_uses_channel_turn_budget_override` — bounded 가 raw 이하 + guard 양수 확인.

## 로컬 검증

```
$ MASC_BASE_PATH=/tmp/masc-test-10008fm2 dune exec test/test_work_as_heartbeat.exe
Test Successful in 0.037s. 50 tests run.

$ MASC_BASE_PATH=/tmp/masc-test-10008fm2 dune exec test/test_keeper_unified.exe
Test Successful in 0.246s. 262 tests run.
```

`dune build --cache=disabled` clean.

## 영향 (행동 변경)

- velvet-hammer 와 유사 multi-turn keeper 가 `oas_timeout_budget` 에서 starve 되지 않음.
- 모든 OAS call 이 `turn_timeout_sec` (1200s) budget 을 받음. 이전에는 max_turns 작으면 1/3 수준.
- Semaphore 경합 증가 없음: 실제 hold duration 은 turn 완료 시점, budget 예약이 아니라 real execution 에 바인딩.

## 미검증 / 후속

- Fleet 에서 `oas_timeout_budget` kind counter (PR #10039 로 추가됨) rate 가 머지 후 0 으로 수렴하는지 관찰. 수렴하면 본 fix 효과 확정.
- `estimated_input_tokens` / `max_turns` 가 이제 non-load-bearing — 후속 PR 에서 parameter 자체 제거 가능 (caller signature cleanup).
- "Budget = wall-clock cap 상시 지급" 이 평균 turn 을 늘릴지 관찰 필요. 가능하면 tool-response 조기 종료가 커버하지만, 만약 keeper 가 budget 을 써버리는 성향이 있다면 per-channel 별 `turn_timeout_sec` override 도 고려.

## 관련

- #10008 (root).
- PR #10031 (tick #22, fm1 honest refusal).
- PR #10060 (tick #26, fm3 observability).
- #9933 (p50 16min 측정 — fantasy 검증 근거).
- #9637 (turn wall-clock timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)