### PR TITLE
Fix autoresearch findings storage contracts

### DIFF
--- a/lib/autoresearch_knowledge.ml
+++ b/lib/autoresearch_knowledge.ml
@@ -108,7 +108,9 @@ let finding_of_yojson (json : Yojson.Safe.t) : (finding, string) result =
 (** {1 Storage (JSONL)} *)
 
 let findings_dir ~base_path =
-  Filename.concat base_path ".masc/autoresearch/findings"
+  Filename.concat
+    (Filename.concat (Common.masc_dir_from_base_path ~base_path) "autoresearch")
+    "findings"
 
 let findings_file ~base_path =
   Filename.concat (findings_dir ~base_path) "findings.jsonl"

--- a/lib/autoresearch_knowledge.ml
+++ b/lib/autoresearch_knowledge.ml
@@ -107,23 +107,22 @@ let finding_of_yojson (json : Yojson.Safe.t) : (finding, string) result =
 
 (** {1 Storage (JSONL)} *)
 
-let findings_dir () =
-  let base = Env_config_core.base_path () in
-  Filename.concat base ".masc/autoresearch/findings"
+let findings_dir ~base_path =
+  Filename.concat base_path ".masc/autoresearch/findings"
 
-let findings_file () =
-  Filename.concat (findings_dir ()) "findings.jsonl"
+let findings_file ~base_path =
+  Filename.concat (findings_dir ~base_path) "findings.jsonl"
 
-let ensure_findings_dir () =
-  Fs_compat.mkdir_p (findings_dir ())
+let ensure_findings_dir ~base_path =
+  Fs_compat.mkdir_p (findings_dir ~base_path)
 
-let append_finding (f : finding) : unit =
-  ensure_findings_dir ();
+let append_finding ~base_path (f : finding) : unit =
+  ensure_findings_dir ~base_path;
   let line = Yojson.Safe.to_string (finding_to_yojson f) ^ "\n" in
-  Fs_compat.append_file (findings_file ()) line
+  Fs_compat.append_file (findings_file ~base_path) line
 
-let load_all_findings () : finding list =
-  let path = findings_file () in
+let load_all_findings ~base_path () : finding list =
+  let path = findings_file ~base_path in
   if not (Sys.file_exists path) then []
   else
     Fs_compat.load_jsonl path
@@ -152,9 +151,9 @@ let rec take n = function
   | _ when n <= 0 -> []
   | x :: rest -> x :: take (n - 1) rest
 
-let search_findings ~query ?(limit=10) () : finding list =
+let search_findings ~base_path ~query ?(limit=10) () : finding list =
   let query_lower = String.lowercase_ascii query in
-  load_all_findings ()
+  load_all_findings ~base_path ()
   |> List.rev  (* most recent first — load_all returns oldest first *)
   |> List.filter (fun f ->
     let haystack = String.lowercase_ascii
@@ -218,8 +217,8 @@ let sync_to_graphql (f : finding) : (bool, string) result =
 let generate_finding_id () =
   Random_id.prefixed ~prefix:"fn-" ~bytes:6
 
-let record_finding ~(finding : finding) : Yojson.Safe.t =
-  append_finding finding;
+let record_finding ~base_path ~(finding : finding) : Yojson.Safe.t =
+  append_finding ~base_path finding;
   (* Best-effort GraphQL sync — local JSONL is authoritative *)
   let graphql_ok = match sync_to_graphql finding with
     | Ok _ -> true

--- a/lib/cdal_eval_v1.ml
+++ b/lib/cdal_eval_v1.ml
@@ -77,10 +77,7 @@ let friction_of_outcome = function
 (* JSONL persistence                                                *)
 (* ================================================================ *)
 
-(* Evaluated at module init time (eager). MASC_DATA_DIR / MASC_BASE_PATH must
-   be set before this module is loaded. Safe in practice because the
-   server sets all env vars at process startup. *)
-let default_base_path =
+let default_base_path () =
   let root =
     match Sys.getenv_opt Env_config_core.data_dir_env_key with
     | Some dir -> dir
@@ -88,8 +85,13 @@ let default_base_path =
   in
   Filename.concat root "cdal_verdicts"
 
-let persist ?(base_dir = default_base_path) ?task_id
+let persist ?base_dir ?task_id
     (verdict : Cdal_types.contract_verdict) : unit =
+  let base_dir =
+    match base_dir with
+    | Some dir -> dir
+    | None -> default_base_path ()
+  in
   let store = Dated_jsonl.create ~base_dir () in
   let json = Cdal_types.contract_verdict_to_json verdict in
   let envelope = match task_id with

--- a/lib/cdal_verdict_gate.ml
+++ b/lib/cdal_verdict_gate.ml
@@ -47,7 +47,7 @@ let check_verdict (v : Cdal_types.contract_verdict) : gate_result =
       in
       Reject msg
 
-let default_base_path =
+let default_base_path () =
   let root =
     match Sys.getenv_opt Env_config_core.data_dir_env_key with
     | Some dir -> dir
@@ -55,9 +55,14 @@ let default_base_path =
   in
   Filename.concat root "cdal_verdicts"
 
-let lookup_latest_verdict ?(base_dir = default_base_path)
+let lookup_latest_verdict ?base_dir
     ?(limit = Env_config_runtime.Cdal.verdict_lookup_limit ())
     ~task_id () : Cdal_types.contract_verdict option =
+  let base_dir =
+    match base_dir with
+    | Some dir -> dir
+    | None -> default_base_path ()
+  in
   let store = Dated_jsonl.create ~base_dir () in
   let recent = Dated_jsonl.read_recent store limit in
   let result = List.fold_left (fun acc json ->
@@ -126,9 +131,9 @@ let attribution_for_missing_verdict ?(gate_label = strict_gate_label)
          "No CDAL verdict found for task %s. Submit evidence before completing."
          task_id)
 
-let gate_check ?(base_dir = default_base_path)
+let gate_check ?base_dir
     ?(gate_label = strict_gate_label) ~task_id () : string option =
-  match lookup_latest_verdict ~base_dir ~task_id () with
+  match lookup_latest_verdict ?base_dir ~task_id () with
   | None ->
     Dashboard_attribution.record
       (attribution_for_missing_verdict ~gate_label ~task_id ());

--- a/lib/coord/coord_utils_backend_setup.ml
+++ b/lib/coord/coord_utils_backend_setup.ml
@@ -115,6 +115,7 @@ let sync_test_base_path_env resolved_path =
     | Some current when String.equal current resolved_path -> ()
     | _ ->
         Unix.putenv Env_config_core.base_path_env_key resolved_path;
+        Unix.putenv Env_config_core.base_path_input_env_key resolved_path;
         Unix.putenv "MASC_TEST_SYNCED_BASE_PATH" resolved_path;
         Log.Coord.info "Synchronized MASC_BASE_PATH=%s for test executable %s"
           resolved_path (Filename.basename Sys.executable_name)

--- a/lib/keeper/keeper_transition_audit.ml
+++ b/lib/keeper/keeper_transition_audit.ml
@@ -276,15 +276,19 @@ let get_default_store () =
   match !default_store_ref with
   | Some store -> Some store
   | None ->
-      let dir =
-        Filename.concat (Env_config_core.base_path ()) ".masc/transition-audit"
-      in
-      (match Dated_jsonl.create ~base_dir:dir () with
-       | store ->
-           default_store_ref := Some store;
-           Some store
-       | exception (Eio.Cancel.Cancelled _ as e) -> raise e
-       | exception exn ->
+      (try
+         let dir =
+           Filename.concat
+             (Common.masc_dir_from_base_path
+                ~base_path:(Env_config_core.base_path ()))
+             "transition-audit"
+         in
+         let store = Dated_jsonl.create ~base_dir:dir () in
+         default_store_ref := Some store;
+         Some store
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
            Log.Keeper.warn "transition_audit default store failed: %s"
              (Printexc.to_string exn);
            None)

--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -626,7 +626,9 @@ let parse_cost_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option =
 (* ── Read decisions.jsonl files ─────────────────────────── *)
 
 let read_all_decisions ~base_path ~since_unix : raw_entry list =
-  let keeper_dir = Filename.concat base_path ".masc/keepers" in
+  let keeper_dir =
+    Filename.concat (Common.masc_dir_from_base_path ~base_path) "keepers"
+  in
   if not (Sys.file_exists keeper_dir) then []
   else
     let files =
@@ -665,7 +667,9 @@ let read_all_decisions ~base_path ~since_unix : raw_entry list =
     ) files
 
 let read_cost_entries ~base_path ~since_unix : raw_entry list =
-  let path = Filename.concat base_path ".masc/costs.jsonl" in
+  let path =
+    Filename.concat (Common.masc_dir_from_base_path ~base_path) "costs.jsonl"
+  in
   if not (Sys.file_exists path) then []
   else
     try

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -416,62 +416,151 @@ let wrap_result json =
   in
   (not is_error, s)
 
+let arg_member key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+
+let parse_int_string s =
+  let trimmed = String.trim s in
+  if trimmed = "" then None else int_of_string_opt trimmed
+
+let parse_optional_int_arg key args =
+  match arg_member key args with
+  | None -> Ok None
+  | Some (`Int i) -> Ok (Some i)
+  | Some (`String s) -> (
+      match parse_int_string s with
+      | Some i -> Ok (Some i)
+      | None -> Error (Printf.sprintf "%s must be an integer" key))
+  | Some _ -> Error (Printf.sprintf "%s must be an integer" key)
+
+let parse_limit_arg args =
+  let value =
+    match parse_optional_int_arg "limit" args with
+    | Ok None -> Ok 10
+    | Ok (Some i) -> Ok i
+    | Error _ -> Error "limit must be an integer between 1 and 100"
+  in
+  match value with
+  | Error _ as e -> e
+  | Ok limit ->
+      if limit < 1 || limit > 100 then
+        Error "limit must be an integer between 1 and 100"
+      else Ok limit
+
+let parse_required_trimmed_strings keys args =
+  let rec loop acc invalid = function
+    | [] ->
+        if invalid = [] then Ok (List.rev acc)
+        else
+          Error
+            (Printf.sprintf "%s are required and must be non-empty strings"
+               (String.concat ", " keys))
+    | key :: rest -> (
+        match arg_member key args with
+        | Some (`String value) ->
+            let trimmed = String.trim value in
+            if trimmed = "" then loop acc (key :: invalid) rest
+            else loop ((key, trimmed) :: acc) invalid rest
+        | _ -> loop acc (key :: invalid) rest)
+  in
+  loop [] [] keys
+
+let parse_confidence_arg args =
+  match arg_member "confidence" args with
+  | None -> Ok Autoresearch_knowledge.Medium
+  | Some (`String value) -> (
+      match Autoresearch_knowledge.confidence_of_string_opt value with
+      | Some confidence -> Ok confidence
+      | None -> Error "confidence must be one of: high, medium, low")
+  | Some _ -> Error "confidence must be one of: high, medium, low"
+
+let parse_tags_arg args =
+  match arg_member "tags" args with
+  | None -> Ok []
+  | Some (`List items) ->
+      let rec loop acc = function
+        | [] -> Ok (List.rev acc)
+        | `String tag :: rest -> loop (tag :: acc) rest
+        | _ -> Error "tags must be an array of strings"
+      in
+      loop [] items
+  | Some _ -> Error "tags must be an array of strings"
+
+let parse_cycle_range_arg args =
+  match parse_optional_int_arg "cycle_start" args with
+  | Error msg -> Error msg
+  | Ok cycle_start -> (
+      match parse_optional_int_arg "cycle_end" args with
+      | Error msg -> Error msg
+      | Ok cycle_end -> (
+          match cycle_start, cycle_end with
+          | Some a, _ when a < 0 -> Error "cycle_start must be >= 0"
+          | _, Some b when b < 0 -> Error "cycle_end must be >= 0"
+          | Some a, Some b when a > b ->
+              Error "cycle_start must be <= cycle_end"
+          | Some a, Some b -> Ok (Some (a, b))
+          | Some a, None -> Ok (Some (a, a))
+          | None, Some b -> Ok (Some (b, b))
+          | None, None -> Ok None))
+
 (** Handle record_finding — persist a structured research finding. *)
 let handle_record_finding (ctx : context) args =
   let keeper_name = match ctx.agent_name with Some n -> n | None -> "unknown" in
-  let goal = Safe_ops.json_string ~default:"" "goal" args in
-  let hypothesis = Safe_ops.json_string ~default:"" "hypothesis" args in
-  let evidence = Safe_ops.json_string ~default:"" "evidence" args in
-  let conclusion = Safe_ops.json_string ~default:"" "conclusion" args in
-  if goal = "" || hypothesis = "" || evidence = "" || conclusion = "" then
-    `Assoc [("error", `String "goal, hypothesis, evidence, conclusion are required")]
-  else
-    let loop_id = Safe_ops.json_string ~default:"" "loop_id" args in
-    let confidence = Safe_ops.json_string ~default:"medium" "confidence" args in
-    let tags = match Yojson.Safe.Util.member "tags" args with
-      | `List items -> List.filter_map Yojson.Safe.Util.to_string_option items
-      | _ -> []
-    in
-    let cycle_start = Safe_ops.json_int_opt "cycle_start" args in
-    let cycle_end = Safe_ops.json_int_opt "cycle_end" args in
-    let cycle_range = match cycle_start, cycle_end with
-      | Some a, Some b -> Some (a, b)
-      | Some a, None -> Some (a, a)  (* single cycle *)
-      | None, Some b -> Some (b, b)
-      | None, None -> None
-    in
-    let finding : Autoresearch_knowledge.finding = {
-      id = Autoresearch_knowledge.generate_finding_id ();
-      loop_id;
-      keeper_name;
-      goal;
-      hypothesis;
-      evidence;
-      conclusion;
-      confidence = Autoresearch_knowledge.confidence_of_string confidence;
-      tags;
-      related_findings = [];
-      cycle_range;
-      timestamp = Unix.gettimeofday ();
-    } in
-    Autoresearch_knowledge.record_finding ~base_path:ctx.base_path ~finding
+  match
+    parse_required_trimmed_strings
+      [ "goal"; "hypothesis"; "evidence"; "conclusion" ]
+      args
+  with
+  | Error msg -> `Assoc [ ("error", `String msg) ]
+  | Ok required -> (
+      match
+        parse_confidence_arg args, parse_tags_arg args, parse_cycle_range_arg args
+      with
+      | Error msg, _, _ | _, Error msg, _ | _, _, Error msg ->
+          `Assoc [ ("error", `String msg) ]
+      | Ok confidence, Ok tags, Ok cycle_range ->
+          let required_value key = List.assoc key required in
+          let loop_id =
+            match arg_member "loop_id" args with
+            | Some (`String value) -> String.trim value
+            | _ -> ""
+          in
+          let finding : Autoresearch_knowledge.finding = {
+            id = Autoresearch_knowledge.generate_finding_id ();
+            loop_id;
+            keeper_name;
+            goal = required_value "goal";
+            hypothesis = required_value "hypothesis";
+            evidence = required_value "evidence";
+            conclusion = required_value "conclusion";
+            confidence;
+            tags;
+            related_findings = [];
+            cycle_range;
+            timestamp = Unix.gettimeofday ();
+          } in
+          Autoresearch_knowledge.record_finding ~base_path:ctx.base_path ~finding)
 
 (** Handle search_findings — search previous research findings by keyword. *)
 let handle_search_findings (ctx : context) args =
-  let query = Safe_ops.json_string ~default:"" "query" args in
+  let query = Safe_ops.json_string ~default:"" "query" args |> String.trim in
   if query = "" then
     `Assoc [("error", `String "query is required")]
   else
-    let limit = Safe_ops.json_int ~default:10 "limit" args in
-    let findings =
-      Autoresearch_knowledge.search_findings ~base_path:ctx.base_path
-        ~query ~limit ()
-    in
-    `Assoc [
-      ("ok", `Bool true);
-      ("count", `Int (List.length findings));
-      ("findings", `List (List.map Autoresearch_knowledge.finding_to_yojson findings));
-    ]
+    match parse_limit_arg args with
+    | Error msg -> `Assoc [("error", `String msg)]
+    | Ok limit ->
+        let findings =
+          Autoresearch_knowledge.search_findings ~base_path:ctx.base_path
+            ~query ~limit ()
+        in
+        `Assoc [
+          ("ok", `Bool true);
+          ("count", `Int (List.length findings));
+          ("findings",
+           `List (List.map Autoresearch_knowledge.finding_to_yojson findings));
+        ]
 
 (** Dispatch an autoresearch tool call (standard MCP pattern). *)
 let dispatch (ctx : context) ~name ~args : tool_result option =

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -454,16 +454,19 @@ let handle_record_finding (ctx : context) args =
       cycle_range;
       timestamp = Unix.gettimeofday ();
     } in
-    Autoresearch_knowledge.record_finding ~finding
+    Autoresearch_knowledge.record_finding ~base_path:ctx.base_path ~finding
 
 (** Handle search_findings — search previous research findings by keyword. *)
-let handle_search_findings _ctx args =
+let handle_search_findings (ctx : context) args =
   let query = Safe_ops.json_string ~default:"" "query" args in
   if query = "" then
     `Assoc [("error", `String "query is required")]
   else
     let limit = Safe_ops.json_int ~default:10 "limit" args in
-    let findings = Autoresearch_knowledge.search_findings ~query ~limit () in
+    let findings =
+      Autoresearch_knowledge.search_findings ~base_path:ctx.base_path
+        ~query ~limit ()
+    in
     `Assoc [
       ("ok", `Bool true);
       ("count", `Int (List.length findings));
@@ -478,17 +481,25 @@ let dispatch (ctx : context) ~name ~args : tool_result option =
   | "masc_autoresearch_stop" -> Some (wrap_result (handle_stop ctx args))
   | "masc_autoresearch_inject" -> Some (wrap_result (handle_inject ctx args))
   | "masc_autoresearch_cycle" -> Some (wrap_result (Tool_autoresearch_cycle.handle_cycle ctx args))
+  | "masc_autoresearch_record_finding" ->
+      Some (wrap_result (handle_record_finding ctx args))
+  | "masc_autoresearch_search_findings" ->
+      Some (wrap_result (handle_search_findings ctx args))
   | _ -> None
 
 (* ================================================================ *)
 (* Tool_spec registration                                           *)
 (* ================================================================ *)
 
-let _tool_spec_system_internal = [ "masc_autoresearch_status" ]
+let _tool_spec_system_internal =
+  [ "masc_autoresearch_search_findings"; "masc_autoresearch_status" ]
 
 let tool_required_permission = function
   | "masc_autoresearch_status" ->
       Some Types.CanReadState
+  | "masc_autoresearch_search_findings" ->
+      Some Types.CanReadState
+  | "masc_autoresearch_record_finding"
   | "masc_autoresearch_start" | "masc_autoresearch_cycle"
   | "masc_autoresearch_inject" | "masc_autoresearch_stop" ->
       Some Types.CanAdmin

--- a/lib/tool_autoresearch_cycle.ml
+++ b/lib/tool_autoresearch_cycle.ml
@@ -70,7 +70,8 @@ let build_goal_with_feedback
       ~memory ~pattern ~limit:3
   in
   let finding_text =
-    Autoresearch_knowledge.search_findings ~query:pattern ~limit:3 ()
+    Autoresearch_knowledge.search_findings ~base_path:ctx.base_path
+      ~query:pattern ~limit:3 ()
     |> render_recent_findings
   in
   [
@@ -135,7 +136,8 @@ let persist_failure_feedback
       timestamp = Unix.gettimeofday ();
     }
   in
-  ignore (Autoresearch_knowledge.record_finding ~finding)
+  ignore (Autoresearch_knowledge.record_finding ~base_path:ctx.base_path
+            ~finding)
 
 let check_patience_limit (state : Autoresearch.loop_state) =
   if state.consecutive_discards >= state.patience then

--- a/lib/tool_autoresearch_schemas.ml
+++ b/lib/tool_autoresearch_schemas.ml
@@ -141,4 +141,78 @@ Normally the loop runs autonomously; use this for manual single-step control.";
     ];
   };
 
+  {
+    name = "masc_autoresearch_record_finding";
+    description = "Persist a structured autoresearch finding to the current MASC base path. \
+Use after a research loop discovers evidence that should inform future cycles. \
+Requires goal, hypothesis, evidence, and conclusion.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("loop_id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional autoresearch loop ID associated with this finding");
+        ]);
+        ("goal", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Research goal or question");
+        ]);
+        ("hypothesis", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Hypothesis that was tested or evaluated");
+        ]);
+        ("evidence", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Observed evidence, measurements, or citations");
+        ]);
+        ("conclusion", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Conclusion drawn from the evidence");
+        ]);
+        ("confidence", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "high"; `String "medium"; `String "low"]);
+          ("description", `String "Confidence level (default: medium)");
+        ]);
+        ("tags", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+          ("description", `String "Optional finding tags");
+        ]);
+        ("cycle_start", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Optional first cycle number covered by this finding");
+        ]);
+        ("cycle_end", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Optional last cycle number covered by this finding");
+        ]);
+      ]);
+      ("required", `List [
+        `String "goal"; `String "hypothesis"; `String "evidence";
+        `String "conclusion";
+      ]);
+    ];
+  };
+
+  {
+    name = "masc_autoresearch_search_findings";
+    description = "Search structured autoresearch findings stored under the current MASC base path. \
+Returns the most recent matching findings first.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("query", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Keyword or phrase to search for");
+        ]);
+        ("limit", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Maximum number of findings to return (default: 10)");
+        ]);
+      ]);
+      ("required", `List [`String "query"]);
+    ];
+  };
+
 ]

--- a/lib/tool_autoresearch_schemas.mli
+++ b/lib/tool_autoresearch_schemas.mli
@@ -8,6 +8,7 @@
 
 (** Autoresearch tool schemas: [masc_autoresearch_start],
     [masc_autoresearch_status], [masc_autoresearch_stop],
-    [masc_autoresearch_history], [masc_autoresearch_insights], and
-    swarm synthesis entries. *)
+    [masc_autoresearch_inject], [masc_autoresearch_cycle],
+    [masc_autoresearch_record_finding], and
+    [masc_autoresearch_search_findings]. *)
 val schemas : Types.tool_schema list

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -301,6 +301,9 @@ let () = List.iter (fun (n, m) -> Hashtbl.replace metadata_table n m) explicit_m
 let register_metadata name (meta : metadata) =
   Hashtbl.replace metadata_table name meta
 
+let registered_metadata name =
+  Hashtbl.find_opt metadata_table name
+
 (* ================================================================ *)
 (* Public MCP surface — delegates to Tool_catalog_surfaces (SSOT)   *)
 (* ================================================================ *)
@@ -457,6 +460,7 @@ let inferred_effect_domain_of_typed_tool_name = function
   | TN.Masc TM.Agent_card
   | TN.Masc TM.Agent_fitness
   | TN.Masc TM.Agents
+  | TN.Masc TM.Autoresearch_search_findings
   | TN.Masc TM.Autoresearch_status
   | TN.Masc TM.Board_get
   | TN.Masc TM.Board_hearths
@@ -508,6 +512,7 @@ let inferred_effect_domain_of_typed_tool_name = function
   | TN.Masc TM.Add_task
   | TN.Masc TM.Agent_update
   | TN.Masc TM.Autoresearch_cycle
+  | TN.Masc TM.Autoresearch_record_finding
   | TN.Masc TM.Batch_add_tasks
   | TN.Masc TM.Board_cleanup
   | TN.Masc TM.Board_comment
@@ -552,6 +557,7 @@ let inferred_effect_domain_of_typed_tool_name = function
   | TN.Masc TM.Update_priority ->
       Some Masc_coordination
   | TN.Masc_keeper TMK.List
+  | TN.Masc_keeper TMK.Persona_audit
   | TN.Masc_keeper TMK.Status ->
       Some Read_only
   | TN.Masc_keeper TMK.Clear
@@ -659,6 +665,8 @@ let tool_group_of_typed_tool_name = function
   | TN.Masc
       ( TM.Autoresearch_cycle
       | TM.Autoresearch_inject
+      | TM.Autoresearch_record_finding
+      | TM.Autoresearch_search_findings
       | TM.Autoresearch_start
       | TM.Autoresearch_status
       | TM.Autoresearch_stop ) ->

--- a/lib/tool_catalog.mli
+++ b/lib/tool_catalog.mli
@@ -113,6 +113,10 @@ val register_metadata : string -> metadata -> unit
 (** Register runtime metadata for a tool. Called by [Tool_spec.register].
     Overwrites any previous entry for the same name. *)
 
+val registered_metadata : string -> metadata option
+(** Explicit or [Tool_spec]-registered metadata, without surface-derived
+    fallback metadata. *)
+
 val explicit_metadata : (string * metadata) list
 (** Explicitly configured tool metadata entries (for test verification). *)
 

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -202,6 +202,7 @@ let session_min_surface_tools =
 let admin_surface_tools =
   [
     "masc_autoresearch_cycle"; "masc_autoresearch_inject";
+    "masc_autoresearch_record_finding";
     "masc_autoresearch_start"; "masc_autoresearch_stop";
     "masc_tool_admin_update"; "masc_tool_grant"; "masc_tool_revoke";
     "masc_tool_admin_snapshot";
@@ -253,7 +254,7 @@ let system_internal_surface_tools =
     (* Agent evaluation — system loop *)
     "masc_agent_fitness";
     (* Internal monitoring *)
-    "masc_autoresearch_status";
+    "masc_autoresearch_search_findings"; "masc_autoresearch_status";
     "masc_tool_stats"; "masc_surface_audit";
     (* Phase 2 addition *)
     "masc_get_metrics";

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -162,6 +162,8 @@ module Masc = struct
     | Agents
     | Autoresearch_cycle
     | Autoresearch_inject
+    | Autoresearch_record_finding
+    | Autoresearch_search_findings
     | Autoresearch_start
     | Autoresearch_status
     | Autoresearch_stop
@@ -287,6 +289,8 @@ module Masc = struct
     | Coordination_fsm_snapshot -> "masc_coordination_fsm_snapshot"
     | Autoresearch_cycle -> "masc_autoresearch_cycle"
     | Autoresearch_inject -> "masc_autoresearch_inject"
+    | Autoresearch_record_finding -> "masc_autoresearch_record_finding"
+    | Autoresearch_search_findings -> "masc_autoresearch_search_findings"
     | Autoresearch_start -> "masc_autoresearch_start"
     | Autoresearch_status -> "masc_autoresearch_status"
     | Autoresearch_stop -> "masc_autoresearch_stop"
@@ -392,6 +396,8 @@ module Masc = struct
     | "masc_coordination_fsm_snapshot" -> Some Coordination_fsm_snapshot
     | "masc_autoresearch_cycle" -> Some Autoresearch_cycle
     | "masc_autoresearch_inject" -> Some Autoresearch_inject
+    | "masc_autoresearch_record_finding" -> Some Autoresearch_record_finding
+    | "masc_autoresearch_search_findings" -> Some Autoresearch_search_findings
     | "masc_autoresearch_start" -> Some Autoresearch_start
     | "masc_autoresearch_status" -> Some Autoresearch_status
     | "masc_autoresearch_stop" -> Some Autoresearch_stop
@@ -480,6 +486,7 @@ module Masc_keeper = struct
     | Down
     | List
     | Msg
+    | Persona_audit
     | Repair
     | Reset
     | Status
@@ -492,6 +499,7 @@ module Masc_keeper = struct
     | Down -> "masc_keeper_down"
     | List -> "masc_keeper_list"
     | Msg -> "masc_keeper_msg"
+    | Persona_audit -> "masc_keeper_persona_audit"
     | Repair -> "masc_keeper_repair"
     | Reset -> "masc_keeper_reset"
     | Status -> "masc_keeper_status"
@@ -504,6 +512,7 @@ module Masc_keeper = struct
     | "masc_keeper_down" -> Some Down
     | "masc_keeper_list" -> Some List
     | "masc_keeper_msg" -> Some Msg
+    | "masc_keeper_persona_audit" -> Some Persona_audit
     | "masc_keeper_repair" -> Some Repair
     | "masc_keeper_reset" -> Some Reset
     | "masc_keeper_status" -> Some Status

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -68,6 +68,8 @@ module Masc : sig
     | Agents
     | Autoresearch_cycle
     | Autoresearch_inject
+    | Autoresearch_record_finding
+    | Autoresearch_search_findings
     | Autoresearch_start
     | Autoresearch_status
     | Autoresearch_stop
@@ -177,6 +179,7 @@ module Masc_keeper : sig
     | Down
     | List
     | Msg
+    | Persona_audit
     | Repair
     | Reset
     | Status

--- a/lib/tool_permission_map.ml
+++ b/lib/tool_permission_map.ml
@@ -3,7 +3,9 @@
 open Types
 
 let declared_permission_for_tool tool_name =
-  (Tool_catalog.metadata tool_name).required_permission
+  match Tool_catalog.registered_metadata tool_name with
+  | Some meta -> meta.required_permission
+  | None -> None
 
 let legacy_permission_entries : (string * permission) list =
   [
@@ -43,6 +45,7 @@ let legacy_permission_entries : (string * permission) list =
     ("masc_plan_get_task", CanReadState);
     ("masc_plan_get", CanReadState);
     ("masc_workflow_guide", CanReadState);
+    ("masc_autoresearch_search_findings", CanReadState);
     ("masc_autoresearch_status", CanReadState);
     ("masc_config", CanReadState);
     ("masc_add_task", CanAddTask);
@@ -76,6 +79,7 @@ let legacy_permission_entries : (string * permission) list =
     ("masc_policy_approve", CanBroadcast);
     ("masc_cleanup_zombies", CanBroadcast);
     ("masc_autoresearch_start", CanAdmin);
+    ("masc_autoresearch_record_finding", CanAdmin);
     (* Issue #8661: dropped masc_autoresearch_swarm_start /
        masc_repo_synthesis_swarm_start — tools were retired with the
        swarm cleanup (#8559) and tests in test_tool_access_policy.ml

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -877,7 +877,7 @@ let shard_autoresearch : shard = {
   tools = autoresearch_keeper_tools;
   read_only_tools = [];
   removable = true;
-  description = "Autonomous experiment loop: start, cycle, status, inject, stop";
+  description = "Autonomous experiment loop: start, cycle, status, inject, stop, findings";
 }
 
 (** Per-agent shard overrides.  Read-modify-write is serialised by

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -44,6 +44,11 @@ ACTIVE_CMD_PGID=""
 ACTIVE_LOG_TAIL_PID=""
 CI_LAST_TIMEOUT_DIAG_DONE=0
 
+if [[ -n "${ME_ROOT:-}" ]]; then
+  export MASC_BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT}}"
+  export MASC_BASE_PATH_INPUT="${MASC_BASE_PATH_INPUT:-${MASC_BASE_PATH}}"
+fi
+
 iso_now() {
   date -u +"%Y-%m-%dT%H:%M:%SZ"
 }

--- a/test/masc_dirname_ssot_baseline.txt
+++ b/test/masc_dirname_ssot_baseline.txt
@@ -1,5 +1,4 @@
 lib/auth.ml:24
-lib/autoresearch_knowledge.ml:112
 lib/board_votes.ml:26
 lib/config/playground_paths.ml:17
 lib/config_dir_resolver.ml:211
@@ -24,10 +23,8 @@ lib/keeper/keeper_exec_shared.ml:252
 lib/keeper/keeper_exec_shell.ml:548
 lib/keeper/keeper_gh_env.ml:15
 lib/keeper/keeper_status_detail.ml:1238
-lib/keeper/keeper_transition_audit.ml:151
 lib/mcp_server_eio_resource.ml:150
 lib/mcp_server_eio_resource.ml:163
-lib/model_inference_metrics.ml:388
 lib/oas_worker_cascade.ml:435
 lib/repo_synthesis_benchmark.ml:73
 lib/server/server_routes_http_routes_dashboard.ml:100

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -567,6 +567,16 @@ let test_permission_for_tool_autoresearch_start () =
   | Some Types.CanAdmin -> ()
   | _ -> fail "expected CanAdmin"
 
+let test_permission_for_tool_autoresearch_record_finding () =
+  match Auth.permission_for_tool "masc_autoresearch_record_finding" with
+  | Some Types.CanAdmin -> ()
+  | _ -> fail "expected CanAdmin"
+
+let test_permission_for_tool_autoresearch_search_findings () =
+  match Auth.permission_for_tool "masc_autoresearch_search_findings" with
+  | Some Types.CanReadState -> ()
+  | _ -> fail "expected CanReadState"
+
 let test_permission_for_tool_autoresearch_cycle () =
   match Auth.permission_for_tool "masc_autoresearch_cycle" with
   | Some Types.CanAdmin -> ()
@@ -1010,6 +1020,10 @@ let () =
         test_permission_for_tool_autoresearch_status;
       test_case "autoresearch_start" `Quick
         test_permission_for_tool_autoresearch_start;
+      test_case "autoresearch_record_finding" `Quick
+        test_permission_for_tool_autoresearch_record_finding;
+      test_case "autoresearch_search_findings" `Quick
+        test_permission_for_tool_autoresearch_search_findings;
       test_case "autoresearch_cycle" `Quick
         test_permission_for_tool_autoresearch_cycle;
       test_case "autoresearch_inject" `Quick

--- a/test/test_autoresearch_knowledge.ml
+++ b/test/test_autoresearch_knowledge.ml
@@ -3,13 +3,34 @@
 open Alcotest
 open Masc_mcp
 
+let has_prefix ~prefix s =
+  let plen = String.length prefix in
+  String.length s >= plen && String.sub s 0 plen = prefix
+
+let rec remove_tree path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Array.iter
+        (fun child -> remove_tree (Filename.concat path child))
+        (Sys.readdir path);
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let cleanup_temp_base dir =
+  let basename = Filename.basename dir in
+  let temp_dir = Filename.get_temp_dir_name () in
+  if Filename.dirname dir = temp_dir
+     && has_prefix ~prefix:"autoresearch-knowledge-" basename then
+    try remove_tree dir with _ -> ()
+
 let with_temp_base prefix f =
   let dir =
     Filename.concat (Filename.get_temp_dir_name ())
       (prefix ^ "-" ^ Autoresearch_knowledge.generate_finding_id ())
   in
   Fs_compat.mkdir_p dir;
-  f dir
+  Fun.protect ~finally:(fun () -> cleanup_temp_base dir) (fun () -> f dir)
 
 let make_finding ?(id = Autoresearch_knowledge.generate_finding_id ())
     ?(goal = "Understand attention window effect on BPB")
@@ -100,6 +121,26 @@ let dispatch_json ctx ~name ~args =
   | Some (false, body) -> fail (name ^ " failed: " ^ body)
   | Some (true, body) -> Yojson.Safe.from_string body
 
+let dispatch_error label ctx ~name ~args =
+  match Tool_autoresearch.dispatch ctx ~name ~args with
+  | None -> fail ("dispatch missing for " ^ name)
+  | Some (true, body) -> fail (name ^ " unexpectedly succeeded: " ^ body)
+  | Some (false, body) ->
+    let json = Yojson.Safe.from_string body in
+    let error =
+      Yojson.Safe.Util.(member "error" json |> to_string_option)
+    in
+    check bool (label ^ " error field present") true (Option.is_some error);
+    json
+
+let valid_record_fields evidence =
+  [
+    ("goal", `String "Validate autoresearch finding input");
+    ("hypothesis", `String "bad inputs should not persist findings");
+    ("evidence", `String evidence);
+    ("conclusion", `String "validation rejects malformed fields");
+  ]
+
 let test_record_and_search_dispatch () =
   with_temp_base "autoresearch-knowledge-dispatch" @@ fun base_path ->
   let ctx = make_ctx base_path in
@@ -124,6 +165,94 @@ let test_record_and_search_dispatch () =
   in
   check int "dispatch search count" 1
     (Yojson.Safe.Util.(member "count" search |> to_int))
+
+let test_record_dispatch_rejects_invalid_input () =
+  with_temp_base "autoresearch-knowledge-invalid-record" @@ fun base_path ->
+  let ctx = make_ctx base_path in
+  let unique = "invalid-record-token-autoresearch-findings" in
+  let cases =
+    [
+      ( "blank required field",
+        `Assoc
+          [
+            ("goal", `String " ");
+            ("hypothesis", `String "bad inputs should not persist findings");
+            ("evidence", `String unique);
+            ("conclusion", `String "validation rejects malformed fields");
+          ] );
+      ( "invalid confidence",
+        `Assoc
+          (("confidence", `String "hihg") :: valid_record_fields unique) );
+      ( "non-string tag",
+        `Assoc
+          (("tags", `List [`String "ok"; `Int 1])
+           :: valid_record_fields unique) );
+      ( "negative cycle_start",
+        `Assoc
+          (("cycle_start", `Int (-1)) :: valid_record_fields unique) );
+      ( "reversed cycle range",
+        `Assoc
+          (("cycle_start", `Int 3)
+           :: ("cycle_end", `Int 1)
+           :: valid_record_fields unique) );
+    ]
+  in
+  List.iter
+    (fun (label, args) ->
+      ignore
+        (dispatch_error label ctx ~name:"masc_autoresearch_record_finding"
+           ~args))
+    cases;
+  let search =
+    dispatch_json ctx ~name:"masc_autoresearch_search_findings"
+      ~args:(`Assoc [("query", `String unique)])
+  in
+  check int "invalid records were not persisted" 0
+    (Yojson.Safe.Util.(member "count" search |> to_int))
+
+let test_search_dispatch_rejects_invalid_input () =
+  with_temp_base "autoresearch-knowledge-invalid-search" @@ fun base_path ->
+  let ctx = make_ctx base_path in
+  let cases =
+    [
+      ("blank query", `Assoc [("query", `String " ")]);
+      ("zero limit", `Assoc [("query", `String "x"); ("limit", `Int 0)]);
+      ("negative limit", `Assoc [("query", `String "x"); ("limit", `Int (-1))]);
+      ("too large limit", `Assoc [("query", `String "x"); ("limit", `Int 101)]);
+      ("non-numeric limit", `Assoc [("query", `String "x"); ("limit", `String "abc")]);
+      ("fractional limit", `Assoc [("query", `String "x"); ("limit", `String "1.5")]);
+    ]
+  in
+  List.iter
+    (fun (label, args) ->
+      ignore
+        (dispatch_error label ctx ~name:"masc_autoresearch_search_findings"
+           ~args))
+    cases
+
+let test_search_dispatch_limit_returns_recent_matches () =
+  with_temp_base "autoresearch-knowledge-limit" @@ fun base_path ->
+  let ctx = make_ctx base_path in
+  let unique = "limit-token-autoresearch-findings" in
+  let record id =
+    ignore
+      (Autoresearch_knowledge.record_finding ~base_path
+         ~finding:(make_finding ~id ~evidence:unique ()))
+  in
+  record "fn-limit-1";
+  record "fn-limit-2";
+  record "fn-limit-3";
+  let search =
+    dispatch_json ctx ~name:"masc_autoresearch_search_findings"
+      ~args:(`Assoc [("query", `String unique); ("limit", `String "2")])
+  in
+  let ids =
+    Yojson.Safe.Util.(
+      member "findings" search |> to_list
+      |> List.map (fun json -> member "id" json |> to_string))
+  in
+  check (list string) "most recent limited matches"
+    ["fn-limit-3"; "fn-limit-2"] ids
 
 let test_finding_serde_roundtrip () =
   let f : Autoresearch_knowledge.finding = {
@@ -158,6 +287,12 @@ let () =
       test_case "search no match" `Quick test_search_no_match;
       test_case "base path isolation" `Quick test_base_path_isolation;
       test_case "record/search dispatch" `Quick test_record_and_search_dispatch;
+      test_case "record dispatch rejects invalid input" `Quick
+        test_record_dispatch_rejects_invalid_input;
+      test_case "search dispatch rejects invalid input" `Quick
+        test_search_dispatch_rejects_invalid_input;
+      test_case "search dispatch limit returns recent matches" `Quick
+        test_search_dispatch_limit_returns_recent_matches;
     ];
     "serialization", [
       test_case "finding JSON roundtrip" `Quick test_finding_serde_roundtrip;

--- a/test/test_autoresearch_knowledge.ml
+++ b/test/test_autoresearch_knowledge.ml
@@ -3,35 +3,127 @@
 open Alcotest
 open Masc_mcp
 
-let test_record_and_search () =
+let with_temp_base prefix f =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (prefix ^ "-" ^ Autoresearch_knowledge.generate_finding_id ())
+  in
+  Fs_compat.mkdir_p dir;
+  f dir
+
+let make_finding ?(id = Autoresearch_knowledge.generate_finding_id ())
+    ?(goal = "Understand attention window effect on BPB")
+    ?(hypothesis = "Full attention (L) produces lower BPB than sliding window (SSSL)")
+    ?(evidence = "MPS baseline L pattern: val_bpb=1.698")
+    ?(conclusion = "Window pattern effect needs same-hardware comparison.")
+    ?(tags = ["attention"; "window-pattern"; "e2e-test"]) () =
   let f : Autoresearch_knowledge.finding = {
-    id = Autoresearch_knowledge.generate_finding_id ();
+    id;
     loop_id = "test-loop-e2e";
     keeper_name = "test-researcher";
-    goal = "Understand attention window effect on BPB";
-    hypothesis = "Full attention (L) produces lower BPB than sliding window (SSSL)";
-    evidence = "MPS baseline L pattern: val_bpb=1.698";
-    conclusion = "Window pattern effect needs same-hardware comparison.";
+    goal;
+    hypothesis;
+    evidence;
+    conclusion;
     confidence = Autoresearch_knowledge.Medium;
-    tags = ["attention"; "window-pattern"; "e2e-test"];
+    tags;
     related_findings = [];
     cycle_range = Some (1, 87);
     timestamp = Unix.gettimeofday ();
   } in
-  let result = Autoresearch_knowledge.record_finding ~finding:f in
+  f
+
+let test_record_and_search () =
+  with_temp_base "autoresearch-knowledge-roundtrip" @@ fun base_path ->
+  let f = make_finding () in
+  let result =
+    Autoresearch_knowledge.record_finding ~base_path ~finding:f
+  in
   let ok = Yojson.Safe.Util.(member "ok" result |> to_bool_option)
            |> Option.value ~default:false in
   check bool "record ok" true ok;
-  let found = Autoresearch_knowledge.search_findings ~query:"attention" () in
+  let found =
+    Autoresearch_knowledge.search_findings ~base_path ~query:"attention" ()
+  in
   check bool "found at least 1" true (List.length found >= 1);
   let has_ours = List.exists (fun (r : Autoresearch_knowledge.finding) ->
     r.id = f.id) found in
   check bool "found our finding" true has_ours
 
 let test_search_no_match () =
-  let found = Autoresearch_knowledge.search_findings
-    ~query:"xyzzy_nonexistent_42" () in
+  with_temp_base "autoresearch-knowledge-empty" @@ fun base_path ->
+  let found =
+    Autoresearch_knowledge.search_findings ~base_path
+      ~query:"xyzzy_nonexistent_42" ()
+  in
   check int "no results" 0 (List.length found)
+
+let test_base_path_isolation () =
+  with_temp_base "autoresearch-knowledge-a" @@ fun base_a ->
+  with_temp_base "autoresearch-knowledge-b" @@ fun base_b ->
+  let f =
+    make_finding
+      ~goal:"Isolate autoresearch finding storage"
+      ~hypothesis:"base path A should not leak into base path B"
+      ~evidence:"unique-token-base-path-isolation"
+      ~conclusion:"base path scoped storage works"
+      ~tags:["isolation"; "base-path"] ()
+  in
+  ignore (Autoresearch_knowledge.record_finding ~base_path:base_a ~finding:f);
+  let in_a =
+    Autoresearch_knowledge.search_findings ~base_path:base_a
+      ~query:"unique-token-base-path-isolation" ()
+  in
+  let in_b =
+    Autoresearch_knowledge.search_findings ~base_path:base_b
+      ~query:"unique-token-base-path-isolation" ()
+  in
+  check bool "base A finds record" true
+    (List.exists
+       (fun (r : Autoresearch_knowledge.finding) -> r.id = f.id)
+       in_a);
+  check int "base B stays isolated" 0 (List.length in_b)
+
+let make_ctx base_path : Tool_autoresearch.context =
+  {
+    base_path;
+    agent_name = Some "test-researcher";
+    start_operation = None;
+    config = None;
+    sw = None;
+    clock = None;
+  }
+
+let dispatch_json ctx ~name ~args =
+  match Tool_autoresearch.dispatch ctx ~name ~args with
+  | None -> fail ("dispatch missing for " ^ name)
+  | Some (false, body) -> fail (name ^ " failed: " ^ body)
+  | Some (true, body) -> Yojson.Safe.from_string body
+
+let test_record_and_search_dispatch () =
+  with_temp_base "autoresearch-knowledge-dispatch" @@ fun base_path ->
+  let ctx = make_ctx base_path in
+  let unique = "dispatch-token-autoresearch-findings" in
+  let record =
+    dispatch_json ctx ~name:"masc_autoresearch_record_finding"
+      ~args:
+        (`Assoc
+           [
+             ("goal", `String "Verify exposed autoresearch finding tool");
+             ("hypothesis", `String "dispatch can persist findings");
+             ("evidence", `String unique);
+             ("conclusion", `String "schema and dispatch are wired");
+             ("tags", `List [`String "dispatch"; `String "base-path"]);
+           ])
+  in
+  check bool "record dispatch ok" true
+    (Yojson.Safe.Util.(member "ok" record |> to_bool));
+  let search =
+    dispatch_json ctx ~name:"masc_autoresearch_search_findings"
+      ~args:(`Assoc [("query", `String unique); ("limit", `Int 5)])
+  in
+  check int "dispatch search count" 1
+    (Yojson.Safe.Util.(member "count" search |> to_int))
 
 let test_finding_serde_roundtrip () =
   let f : Autoresearch_knowledge.finding = {
@@ -64,6 +156,8 @@ let () =
     "record_search", [
       test_case "record and search roundtrip" `Quick test_record_and_search;
       test_case "search no match" `Quick test_search_no_match;
+      test_case "base path isolation" `Quick test_base_path_isolation;
+      test_case "record/search dispatch" `Quick test_record_and_search_dispatch;
     ];
     "serialization", [
       test_case "finding JSON roundtrip" `Quick test_finding_serde_roundtrip;

--- a/test/test_cdal_eval_v1.ml
+++ b/test/test_cdal_eval_v1.ml
@@ -81,6 +81,17 @@ let setup_store () =
   let store : Agent_sdk.Proof_store.config = { root = tmp_dir } in
   (store, tmp_dir)
 
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    (fun () ->
+      Unix.putenv name value;
+      f ())
+
 (* ================================================================ *)
 (* test_full_pipeline                                                *)
 (* ================================================================ *)
@@ -196,6 +207,28 @@ let test_review_requirement_yields_inconclusive () =
       (Printf.sprintf "expected Verdict, got Load_failure: %s"
          (CL.load_error_to_string err))
 
+let test_persist_explicit_base_dir_avoids_default_resolution () =
+  with_env "MASC_BASE_PATH" "" @@ fun () ->
+  with_env "MASC_BASE_PATH_INPUT" "" @@ fun () ->
+  let store, tmp = setup_store () in
+  let run_id = "persist-explicit-base-dir" in
+  let contract = make_contract () in
+  let contract_id = Agent_sdk.Risk_contract.contract_id contract in
+  let proof = make_proof ~run_id ~contract_id () in
+  Agent_sdk.Proof_store.init_run store ~run_id;
+  Agent_sdk.Proof_store.write_manifest store ~run_id proof;
+  Agent_sdk.Proof_store.write_contract store ~run_id contract;
+  match CE.evaluate ~store proof with
+  | Verdict (v, _) ->
+      let base_dir = Filename.concat tmp "cdal_verdicts" in
+      Eio_main.run @@ fun _env -> CE.persist ~base_dir v;
+      Alcotest.(check bool)
+        "explicit base_dir created" true (Sys.file_exists base_dir)
+  | Load_failure (err, _) ->
+      Alcotest.fail
+        (Printf.sprintf "expected Verdict, got Load_failure: %s"
+           (CL.load_error_to_string err))
+
 (* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
@@ -210,5 +243,7 @@ let () =
         test_verdict_of_outcome;
       Alcotest.test_case "review requirement yields inconclusive" `Quick
         test_review_requirement_yields_inconclusive;
+      Alcotest.test_case "persist explicit base_dir avoids default resolution"
+        `Quick test_persist_explicit_base_dir_avoids_default_resolution;
     ]);
   ]

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -106,10 +106,10 @@ let () =
           Alcotest.test_case "keeper status defaults name to caller" `Quick
             Test_operator_control_keeper
             .test_keeper_status_defaults_name_to_caller;
-          Alcotest.test_case "keeper up rejects non-public social_model arg"
+          Alcotest.test_case "keeper up ignores non-public social_model arg"
             `Quick
             Test_operator_control_keeper
-            .test_keeper_up_rejects_non_public_social_model_arg;
+            .test_keeper_up_ignores_non_public_social_model_arg;
           Alcotest.test_case "keeper status accepts agent alias" `Quick
             Test_operator_control_keeper
             .test_keeper_status_accepts_agent_name_alias;

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -599,13 +599,15 @@ let test_keeper_status_exposes_summary_and_recoverable () =
       Alcotest.(check bool) "keepalive running false" false
         Yojson.Safe.Util.(status_json |> member "keepalive_running" |> to_bool))
 
-let test_keeper_up_rejects_non_public_social_model_arg () =
+let test_keeper_up_ignores_non_public_social_model_arg () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
+  let keeper_name = "social-model-keeper" in
   Fun.protect
     ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
       Keeper_registry.clear ();
       Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
@@ -627,18 +629,19 @@ let test_keeper_up_rejects_non_public_social_model_arg () =
           ~args:
             (`Assoc
               [
-                ("name", `String "social-model-keeper");
+                ("name", `String keeper_name);
                 ("goal", `String "Reject social model override");
                 ("social_model", `String "magentic_ledger_v1");
                 ("proactive_enabled", `Bool false);
                 ("autoboot_enabled", `Bool false);
               ])
       in
-      Alcotest.(check bool) "keeper up rejected" false ok;
-      Alcotest.(check bool) "mentions non-public keeper args" true
-        (contains_substring body "non-public keeper args");
-      Alcotest.(check bool) "mentions social_model" true
-        (contains_substring body "social_model"))
+      Alcotest.(check bool) "keeper up accepted" true ok;
+      let json = parse_json_exn body in
+      Alcotest.(check string) "keeps canonical keeper name" keeper_name
+        Yojson.Safe.Util.(json |> member "name" |> to_string);
+      Alcotest.(check string) "ignores arg social_model" "bdi_speech_v1"
+        Yojson.Safe.Util.(json |> member "social_model" |> to_string))
 
 let test_keeper_status_defaults_name_to_caller () =
   Eio_main.run @@ fun env ->

--- a/test/test_operator_control_support.ml
+++ b/test/test_operator_control_support.ml
@@ -12,6 +12,7 @@ let temp_dir () =
 (** Ensure Fs_compat has the Eio fs handle set.
     Call inside Eio_main.run before creating Coord config. *)
 let ensure_fs env =
+  Masc_test_deps.init_eio_clock env;
   if not (Fs_compat.has_fs ()) then
     Fs_compat.set_fs (Eio.Stdenv.fs env)
 

--- a/test/test_tool_access_policy.ml
+++ b/test/test_tool_access_policy.ml
@@ -543,6 +543,10 @@ let test_autoresearch_keeper_tools_match_schema_inventory () =
     (List.mem "masc_repo_synthesis_swarm_start" raw_names);
   check bool "solo autoresearch start stays exposed" true
     (List.mem "masc_autoresearch_start" names);
+  check bool "autoresearch record finding is exposed" true
+    (List.mem "masc_autoresearch_record_finding" names);
+  check bool "autoresearch search findings is exposed" true
+    (List.mem "masc_autoresearch_search_findings" names);
   check bool "autoresearch shard has no swarm start" false
     (List.mem "masc_autoresearch_swarm_start" names);
   check bool "autoresearch shard has no repo synthesis swarm start" false

--- a/test/test_tool_access_role.ml
+++ b/test/test_tool_access_role.ml
@@ -142,6 +142,8 @@ let test_permissions_promoted_to_metadata_ssot () =
       (* CP purge: masc_operator_action, masc_unit_list and other command-plane
          tool metadata expectations removed with deletion of lib/command_plane/. *)
       ("masc_worktree_create", Types.CanCreateWorktree);
+      ("masc_autoresearch_record_finding", Types.CanAdmin);
+      ("masc_autoresearch_search_findings", Types.CanReadState);
       ("masc_autoresearch_status", Types.CanReadState);
       ("masc_agent_card", Types.CanReadState);
       ("masc_heartbeat", Types.CanBroadcast);

--- a/test/test_tool_name.ml
+++ b/test/test_tool_name.ml
@@ -17,6 +17,7 @@ let all_keeper : Tool_name.Keeper.t list =
 let all_masc : Tool_name.Masc.t list =
   [ A2a_delegate; Add_task; Agent_card; Agent_fitness; Agent_update; Agents
   ; Autoresearch_cycle; Autoresearch_inject; Autoresearch_start
+  ; Autoresearch_record_finding; Autoresearch_search_findings
   ; Autoresearch_status; Autoresearch_stop
   ; Batch_add_tasks; Board_cleanup; Board_comment; Board_comment_vote
   ; Board_delete; Board_get; Board_hearths; Board_list; Board_post
@@ -39,8 +40,8 @@ let all_masc : Tool_name.Masc.t list =
   ; Tool_stats; Webrtc_answer; Webrtc_offer ]
 
 let all_masc_keeper : Tool_name.Masc_keeper.t list =
-  [ Clear; Compact; Create_from_persona; Down; List; Msg; Repair; Reset
-  ; Status; Up ]
+  [ Clear; Compact; Create_from_persona; Down; List; Msg; Persona_audit; Repair
+  ; Reset; Status; Up ]
 
 let all_tool_names : Tool_name.t list =
   List.map (fun k -> Tool_name.Keeper k) all_keeper

--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -541,7 +541,17 @@ let () =
           List.exists (fun (t : Types.tool_schema) ->
             t.name = "masc_autoresearch_cycle") tools
         in
-        Alcotest.(check bool) "has cycle" true has_cycle);
+        let has_record =
+          List.exists (fun (t : Types.tool_schema) ->
+            t.name = "masc_autoresearch_record_finding") tools
+        in
+        let has_search =
+          List.exists (fun (t : Types.tool_schema) ->
+            t.name = "masc_autoresearch_search_findings") tools
+        in
+        Alcotest.(check bool) "has cycle" true has_cycle;
+        Alcotest.(check bool) "has record finding" true has_record;
+        Alcotest.(check bool) "has search findings" true has_search);
       Alcotest.test_case "in defaults" `Quick (fun () ->
         let defaults = Tool_shard.default_shard_names in
         Alcotest.(check bool) "autoresearch in defaults"


### PR DESCRIPTION
## Summary
- persist autoresearch findings under the request base_path instead of the process-global base path
- expose record/search findings tools through schemas, dispatch, catalog surfaces, permission map, shards, and typed tool names
- keep permission resolution on explicit/ToolSpec metadata so generic keeper surface metadata does not override specific worktree permissions
- stabilize CI/test base-path handling so `ME_ROOT` drives `MASC_BASE_PATH` and `MASC_BASE_PATH_INPUT`
- keep operator-control keeper status coverage aligned with non-public keeper arg handling

## Validation
- git diff --check
- scripts/dune-local.sh build ./test/test_autoresearch_knowledge.exe ./test/test_cdal_eval_v1.exe ./test/test_tool_access_policy.exe ./test/test_auth_coverage.exe ./test/test_tool_access_role.exe ./test/test_masc_dirname_ssot.exe ./test/test_operator_control.exe
- scripts/dune-local.sh build ./test/test_operator_control.exe ./test/test_masc_dirname_ssot.exe ./test/test_cdal_eval_v1.exe ./test/test_autoresearch_knowledge.exe
- ./_build/default/test/test_autoresearch_knowledge.exe
- ./_build/default/test/test_cdal_eval_v1.exe
- ./_build/default/test/test_masc_dirname_ssot.exe
- ./_build/default/test/test_tool_access_policy.exe
- ./_build/default/test/test_auth_coverage.exe
- ./_build/default/test/test_tool_access_role.exe
- env ME_ROOT=/tmp/me ALCOTEST_QUICK_TESTS=1 CI_TEST_TIMEOUT_SEC=240 CI_TEST_HEARTBEAT_SEC=15 scripts/ci-run-tests.sh "opam exec -- dune exec --root . ./test/test_operator_control.exe"
