### PR TITLE
[codex] Improve persona generator archetype controls

### DIFF
--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -14,6 +14,19 @@ type save_result =
   ; warnings : string list
   }
 
+type archetype_axes =
+  { alignment : string option
+  ; operating_style : string option
+  ; risk_posture : string option
+  }
+
+type archetype_choice_effect =
+  { value : string
+  ; effect_text : string
+  ; generated_fields : string list
+  ; default_tool_preset : string option
+  }
+
 let string_list_to_json values = `List (List.map (fun value -> `String value) values)
 
 let option_field name value =
@@ -104,6 +117,121 @@ let tool_preset_choices_json =
 
 let social_model_choices_json =
   string_list_to_json [ "bdi_speech_v1"; "magentic_ledger_v1" ]
+;;
+
+let alignment_choices = [ "helpful"; "skeptical"; "protective"; "chaotic"; "ruthless" ]
+
+let operating_style_choices =
+  [ "research"; "coding"; "dispatch"; "social"; "delivery" ]
+;;
+
+let risk_posture_choices = [ "cautious"; "balanced"; "high-autonomy" ]
+
+let choice_effect ?default_tool_preset ~value ~effect_text ~generated_fields () =
+  { value; effect_text; generated_fields; default_tool_preset }
+;;
+
+let choice_effect_fields choice =
+  [ "value", `String choice.value
+  ; "effect", `String choice.effect_text
+  ; "generated_fields", string_list_to_json choice.generated_fields
+  ]
+  @ option_field
+      "default_tool_preset"
+      (Option.map (fun value -> `String value) choice.default_tool_preset)
+;;
+
+let choice_effect_to_json choice = `Assoc (choice_effect_fields choice)
+
+let alignment_choice_effects =
+  [ choice_effect
+      ~value:"helpful"
+      ~effect_text:"Biases the draft toward cooperative task support and clear next actions."
+      ~generated_fields:[ "role"; "trait"; "keeper.goal"; "keeper.instructions" ]
+      ()
+  ; choice_effect
+      ~value:"skeptical"
+      ~effect_text:"Biases the draft toward critique, evidence checks, and assumption testing."
+      ~generated_fields:[ "role"; "trait"; "keeper.goal"; "keeper.instructions" ]
+      ()
+  ; choice_effect
+      ~value:"protective"
+      ~effect_text:"Biases the draft toward guardrails, risk spotting, and escalation language."
+      ~generated_fields:[ "role"; "trait"; "keeper.goal"; "keeper.instructions" ]
+      ()
+  ; choice_effect
+      ~value:"chaotic"
+      ~effect_text:
+        "Biases the draft toward divergent options while keeping keeper goals executable."
+      ~generated_fields:[ "role"; "trait"; "keeper.goal"; "keeper.instructions" ]
+      ()
+  ; choice_effect
+      ~value:"ruthless"
+      ~effect_text:"Biases the draft toward prioritization, pruning, and direct tradeoff calls."
+      ~generated_fields:[ "role"; "trait"; "keeper.goal"; "keeper.instructions" ]
+      ()
+  ]
+;;
+
+let operating_style_choice_effects =
+  [ choice_effect
+      ~value:"research"
+      ~effect_text:"Favors evidence gathering, synthesis, and source-grounded analysis."
+      ~generated_fields:[ "keeper.tool_preset"; "keeper.goal"; "keeper.instructions" ]
+      ~default_tool_preset:"research"
+      ()
+  ; choice_effect
+      ~value:"coding"
+      ~effect_text:"Favors repo-local implementation, test repair, and code review loops."
+      ~generated_fields:[ "keeper.tool_preset"; "keeper.goal"; "keeper.instructions" ]
+      ~default_tool_preset:"coding"
+      ()
+  ; choice_effect
+      ~value:"dispatch"
+      ~effect_text:"Favors triage, routing, task assignment, and operational follow-through."
+      ~generated_fields:[ "keeper.tool_preset"; "keeper.goal"; "keeper.instructions" ]
+      ~default_tool_preset:"dispatch"
+      ()
+  ; choice_effect
+      ~value:"social"
+      ~effect_text:"Favors conversation tracking, replies, coordination, and social context."
+      ~generated_fields:[ "keeper.tool_preset"; "keeper.goal"; "keeper.instructions" ]
+      ~default_tool_preset:"social"
+      ()
+  ; choice_effect
+      ~value:"delivery"
+      ~effect_text:"Favors milestone tracking, completion pressure, and release readiness."
+      ~generated_fields:[ "keeper.tool_preset"; "keeper.goal"; "keeper.instructions" ]
+      ~default_tool_preset:"delivery"
+      ()
+  ]
+;;
+
+let risk_posture_choice_effects =
+  [ choice_effect
+      ~value:"cautious"
+      ~effect_text:"Biases the draft toward dry runs, explicit approvals, and low autonomy."
+      ~generated_fields:[ "keeper.instructions"; "keeper.proactive_enabled" ]
+      ()
+  ; choice_effect
+      ~value:"balanced"
+      ~effect_text:"Biases the draft toward normal autonomous help with explicit escalation."
+      ~generated_fields:[ "keeper.instructions"; "keeper.proactive_enabled" ]
+      ()
+  ; choice_effect
+      ~value:"high-autonomy"
+      ~effect_text:
+        "Biases the draft toward proactive follow-through while concrete fields still \
+         require validation."
+      ~generated_fields:[ "keeper.instructions"; "keeper.proactive_enabled" ]
+      ()
+  ]
+;;
+
+let choice_effects_to_json effects = `List (List.map choice_effect_to_json effects)
+
+let choice_effect_for value effects =
+  List.find_opt (fun choice -> String.equal choice.value value) effects
 ;;
 
 let field_catalog_json () =
@@ -294,9 +422,8 @@ let archetype_axes_json () =
   `List
     [ `Assoc
         [ "name", `String "alignment"
-        ; ( "choices"
-          , string_list_to_json
-              [ "helpful"; "skeptical"; "protective"; "chaotic"; "ruthless" ] )
+        ; "choices", string_list_to_json alignment_choices
+        ; "choice_effects", choice_effects_to_json alignment_choice_effects
         ; ( "effect"
           , `String
               "Generation prompt input only. The saved effect appears through role, \
@@ -304,9 +431,8 @@ let archetype_axes_json () =
         ]
     ; `Assoc
         [ "name", `String "operating_style"
-        ; ( "choices"
-          , string_list_to_json [ "research"; "coding"; "dispatch"; "social"; "delivery" ]
-          )
+        ; "choices", string_list_to_json operating_style_choices
+        ; "choice_effects", choice_effects_to_json operating_style_choice_effects
         ; ( "effect"
           , `String
               "Maps naturally to keeper.tool_preset and instructions when drafting a \
@@ -314,7 +440,8 @@ let archetype_axes_json () =
         ]
     ; `Assoc
         [ "name", `String "risk_posture"
-        ; "choices", string_list_to_json [ "cautious"; "balanced"; "high-autonomy" ]
+        ; "choices", string_list_to_json risk_posture_choices
+        ; "choice_effects", choice_effects_to_json risk_posture_choice_effects
         ; ( "effect"
           , `String
               "Generation prompt input only. Save still validates concrete keeper fields."
@@ -387,6 +514,9 @@ let schema_json ?(include_examples = false) () =
            ; ( "draft_args"
              , `Assoc
                  [ "concept", `String "<natural-language persona concept>"
+                 ; "alignment", `String "<optional archetype axis>"
+                 ; "operating_style", `String "<optional archetype axis>"
+                 ; "risk_posture", `String "<optional archetype axis>"
                  ; "tool_preset", `String "<optional preset>"
                  ] )
            ; ( "save_args"
@@ -768,10 +898,116 @@ let handle_from_concept concept =
   else "persona-" ^ String.sub (Digest.to_hex (Digest.string concept)) 0 8
 ;;
 
+let normalize_choice_arg ~field ~choices raw =
+  let normalized = String.trim raw |> String.lowercase_ascii in
+  if List.mem normalized choices
+  then Ok normalized
+  else
+    Error
+      (Printf.sprintf
+         "invalid %s '%s' (allowed: %s)"
+         field
+         raw
+         (String.concat ", " choices))
+;;
+
+let optional_choice_arg ~field ~choices args =
+  match get_string_opt args field |> trim_nonempty_opt with
+  | None -> Ok None
+  | Some raw ->
+    Result.map
+      (fun normalized -> Some normalized)
+      (normalize_choice_arg ~field ~choices raw)
+;;
+
+let selected_archetype_axes_from_args args =
+  Result.bind
+    (optional_choice_arg ~field:"alignment" ~choices:alignment_choices args)
+    (fun alignment ->
+       Result.bind
+         (optional_choice_arg
+            ~field:"operating_style"
+            ~choices:operating_style_choices
+            args)
+         (fun operating_style ->
+            Result.map
+              (fun risk_posture -> { alignment; operating_style; risk_posture })
+              (optional_choice_arg
+                 ~field:"risk_posture"
+                 ~choices:risk_posture_choices
+                 args)))
+;;
+
+let archetype_axes_to_json axes =
+  `Assoc
+    ([]
+     @ option_field "alignment" (Option.map (fun value -> `String value) axes.alignment)
+     @ option_field
+         "operating_style"
+         (Option.map (fun value -> `String value) axes.operating_style)
+     @ option_field
+         "risk_posture"
+         (Option.map (fun value -> `String value) axes.risk_posture))
+;;
+
+let selected_axis_effect_to_json ~axis value effects =
+  match choice_effect_for value effects with
+  | Some choice -> Some (`Assoc (("axis", `String axis) :: choice_effect_fields choice))
+  | None -> None
+;;
+
+let selected_archetype_effects_to_json axes =
+  let selected =
+    [ Option.bind
+        axes.alignment
+        (fun value ->
+           selected_axis_effect_to_json
+             ~axis:"alignment"
+             value
+             alignment_choice_effects)
+    ; Option.bind
+        axes.operating_style
+        (fun value ->
+           selected_axis_effect_to_json
+             ~axis:"operating_style"
+             value
+             operating_style_choice_effects)
+    ; Option.bind
+        axes.risk_posture
+        (fun value ->
+           selected_axis_effect_to_json
+             ~axis:"risk_posture"
+             value
+             risk_posture_choice_effects)
+    ]
+    |> List.filter_map (fun x -> x)
+  in
+  `List selected
+;;
+
+let archetype_axes_prompt axes =
+  let value = Option.value ~default:"(unspecified)" in
+  Printf.sprintf
+    "- alignment: %s\n- operating_style: %s\n- risk_posture: %s"
+    (value axes.alignment)
+    (value axes.operating_style)
+    (value axes.risk_posture)
+;;
+
+let generation_tool_preset args axes =
+  match get_string_opt args "tool_preset" |> trim_nonempty_opt with
+  | Some raw -> normalize_tool_preset raw
+  | None ->
+    (match axes.operating_style with
+     | Some style -> normalize_tool_preset style
+     | None -> Ok "research")
+;;
+
 let generation_prompt
       ~concept
       ~handle
       ~display_name_opt
+      ~archetype_axes
       ~tool_preset
       ~proactive_enabled
       ~language
@@ -810,16 +1046,26 @@ The JSON shape must be:
 Concept:
 %s
 
+Selected archetype axes:
+%s
+
+Selected archetype effects:
+%s
+
 Preferred display name: %s
 Output language: %s
 
 Supported field catalog:
 %s
 
+Supported archetype axes:
+%s
+
 Constraints:
 - keeper.goal is required and must be concrete enough to create a keeper.
 - Do not include unsupported keeper fields.
 - Keep the result useful for a real long-running keeper, not a marketing character sheet.
+- Apply the selected archetype axes concretely through role, trait, keeper.goal, and keeper.instructions.
 - Give field_explanations for every non-empty keeper.* field you set.
 |}
     handle
@@ -827,9 +1073,12 @@ Constraints:
     tool_preset
     proactive_enabled
     concept
+    (archetype_axes_prompt archetype_axes)
+    (Yojson.Safe.pretty_to_string (selected_archetype_effects_to_json archetype_axes))
     (Option.value ~default:"(choose one)" display_name_opt)
     language
     (Yojson.Safe.pretty_to_string (field_catalog_json ()))
+    (Yojson.Safe.pretty_to_string (archetype_axes_json ()))
 ;;
 
 let parsed_profile_payload json =
@@ -874,83 +1123,89 @@ let handle_persona_generate ctx args =
       ( false
       , error_response_typed ~code:Validation_error "handle must match [A-Za-z0-9._-]+" )
     else (
-      let tool_preset =
-        match get_string_opt args "tool_preset" with
-        | Some raw ->
-          (match Keeper_types_profile.normalize_tool_preset_raw raw with
-           | Some value -> value
-           | None -> "research")
-        | None -> "research"
-      in
-      let cascade_name = get_string args "cascade_name" "operator_judge" |> String.trim in
-      let cascade_name = if cascade_name = "" then "operator_judge" else cascade_name in
-      let temperature = get_float_opt args "temperature" |> Option.value ~default:0.7 in
-      let max_tokens = get_int_opt args "max_tokens" |> Option.value ~default:2500 in
-      let proactive_enabled = get_bool args "proactive_enabled" false in
-      let language = get_string args "language" "ko" |> String.trim in
-      let display_name_opt = get_string_opt args "display_name" in
-      let prompt =
-        generation_prompt
-          ~concept
-          ~handle:fallback_handle
-          ~display_name_opt
-          ~tool_preset
-          ~proactive_enabled
-          ~language
-      in
-      match
-        Masc_oas_bridge.run_safe ~timeout_s:120.0 (fun () ->
-          Oas_worker.run_named
-            ~cascade_name
-            ~goal:prompt
-            ~max_turns:1
-            ~temperature
-            ~max_tokens
-            ~approval:Approval_callbacks.auto_approve
-            ~sw:ctx.Keeper_types.sw
-            ?net:ctx.Keeper_types.net
-            ())
-      with
-      | Error err ->
-        ( false
-        , error_response_typed
-            ~code:Internal_error
-            (Printf.sprintf "persona generation failed: %s" (Oas.Error.to_string err)) )
-      | Ok result ->
-        let raw_text = Oas_response.text_of_response result.Oas_worker.response in
-        (try
-           let parsed = Llm_provider.Lenient_json.parse raw_text in
-           let handle = parsed_handle_payload fallback_handle parsed in
-           let profile = parsed_profile_payload parsed in
-           match normalize_profile ~handle profile with
-           | Error msg ->
+      match selected_archetype_axes_from_args args with
+      | Error msg -> false, error_response_typed ~code:Validation_error msg
+      | Ok archetype_axes ->
+        (match generation_tool_preset args archetype_axes with
+         | Error msg -> false, error_response_typed ~code:Validation_error msg
+         | Ok tool_preset ->
+           let cascade_name =
+             get_string args "cascade_name" "operator_judge" |> String.trim
+           in
+           let cascade_name = if cascade_name = "" then "operator_judge" else cascade_name in
+           let temperature = get_float_opt args "temperature" |> Option.value ~default:0.7 in
+           let max_tokens = get_int_opt args "max_tokens" |> Option.value ~default:2500 in
+           let proactive_enabled = get_bool args "proactive_enabled" false in
+           let language = get_string args "language" "ko" |> String.trim in
+           let display_name_opt = get_string_opt args "display_name" in
+           let prompt =
+             generation_prompt
+               ~concept
+               ~handle:fallback_handle
+               ~display_name_opt
+               ~archetype_axes
+               ~tool_preset
+               ~proactive_enabled
+               ~language
+           in
+           match
+             Masc_oas_bridge.run_safe ~timeout_s:120.0 (fun () ->
+               Oas_worker.run_named
+                 ~cascade_name
+                 ~goal:prompt
+                 ~max_turns:1
+                 ~temperature
+                 ~max_tokens
+                 ~approval:Approval_callbacks.auto_approve
+                 ~sw:ctx.Keeper_types.sw
+                 ?net:ctx.Keeper_types.net
+                 ())
+           with
+           | Error err ->
              ( false
              , error_response_typed
-                 ~code:Validation_error
-                 (Printf.sprintf "generated profile is invalid: %s" msg) )
-           | Ok normalized ->
-             let json =
-               `Assoc
-                 [ "handle", `String handle
-                 ; "profile", normalized
-                 ; "field_explanations", field_explanations_payload parsed
-                 ; "raw_model", `String raw_text
-                 ; ( "save_args"
-                   , `Assoc
-                       [ "handle", `String handle
-                       ; "profile", normalized
-                       ; "overwrite", `Bool false
-                       ; "dry_run", `Bool false
-                       ] )
-                 ; ( "keeper_create_preview_args"
-                   , `Assoc [ "persona_name", `String handle; "dry_run", `Bool true ] )
-                 ]
-             in
-             true, Yojson.Safe.to_string json
-         with
-         | Yojson.Json_error msg ->
-           ( false
-           , error_response_typed
-               ~code:Validation_error
-               (Printf.sprintf "generation did not return parseable JSON: %s" msg) )))
+                 ~code:Internal_error
+                 (Printf.sprintf
+                    "persona generation failed: %s"
+                    (Oas.Error.to_string err)) )
+           | Ok result ->
+             let raw_text = Oas_response.text_of_response result.Oas_worker.response in
+             (try
+                let parsed = Llm_provider.Lenient_json.parse raw_text in
+                let handle = parsed_handle_payload fallback_handle parsed in
+                let profile = parsed_profile_payload parsed in
+                match normalize_profile ~handle profile with
+                | Error msg ->
+                  ( false
+                  , error_response_typed
+                      ~code:Validation_error
+                      (Printf.sprintf "generated profile is invalid: %s" msg) )
+                | Ok normalized ->
+                  let json =
+                    `Assoc
+                      [ "handle", `String handle
+                      ; "selected_archetype_axes", archetype_axes_to_json archetype_axes
+                      ; ( "selected_archetype_effects"
+                        , selected_archetype_effects_to_json archetype_axes )
+                      ; "profile", normalized
+                      ; "field_explanations", field_explanations_payload parsed
+                      ; "raw_model", `String raw_text
+                      ; ( "save_args"
+                        , `Assoc
+                            [ "handle", `String handle
+                            ; "profile", normalized
+                            ; "overwrite", `Bool false
+                            ; "dry_run", `Bool false
+                            ] )
+                      ; ( "keeper_create_preview_args"
+                        , `Assoc [ "persona_name", `String handle; "dry_run", `Bool true ] )
+                      ]
+                  in
+                  true, Yojson.Safe.to_string json
+              with
+              | Yojson.Json_error msg ->
+                ( false
+                , error_response_typed
+                    ~code:Validation_error
+                    (Printf.sprintf "generation did not return parseable JSON: %s" msg) ))))
 ;;

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -109,7 +109,7 @@ let keeper_schemas : tool_schema list = [
   };
   {
     name = "masc_persona_generate";
-    description = "Draft a persona profile.json from a natural-language concept. This does not write files; use masc_persona_save to persist it.";
+    description = "Draft a persona profile.json from a natural-language concept. This does not write files; use masc_persona_schema for field and archetype choice effects, then masc_persona_save to persist it.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -130,11 +130,34 @@ let keeper_schemas : tool_schema list = [
           ("default", `String "ko");
           ("description", `String "Preferred language for generated text.");
         ]);
+        ("alignment", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [
+            `String "helpful"; `String "skeptical"; `String "protective";
+            `String "chaotic"; `String "ruthless";
+          ]);
+          ("description", `String "Optional archetype axis. Influences generated role, trait, goals, and instructions. Call masc_persona_schema for per-choice effects.");
+        ]);
+        ("operating_style", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [
+            `String "research"; `String "coding"; `String "dispatch";
+            `String "social"; `String "delivery";
+          ]);
+          ("description", `String "Optional archetype axis. If tool_preset is omitted, this also selects the default keeper.tool_preset. Call masc_persona_schema for per-choice effects.");
+        ]);
+        ("risk_posture", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [
+            `String "cautious"; `String "balanced"; `String "high-autonomy";
+          ]);
+          ("description", `String "Optional archetype axis. Influences generated autonomy and safety language while save still validates concrete fields. Call masc_persona_schema for per-choice effects.");
+        ]);
         ("tool_preset", `Assoc [
           ("type", `String "string");
           ("default", `String "research");
           ("enum", `List (List.map (fun s -> `String s) tool_preset_enum_strings));
-          ("description", `String "Default keeper.tool_preset for the draft.");
+          ("description", `String "Default keeper.tool_preset for the draft. When omitted, operating_style is used if present, otherwise research.");
         ]);
         ("proactive_enabled", `Assoc [
           ("type", `String "boolean");

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -884,7 +884,7 @@ let test_persona_resolver_defaults_to_research_tool_preset () =
       check string "persona default tool_preset" "research"
         (Yojson.Safe.Util.to_string tool_preset)
 
-let test_persona_resolver_rejects_non_public_social_model_arg () =
+let test_persona_resolver_ignores_non_public_social_model_arg () =
   with_personas_dir @@ fun personas_dir ->
   let persona_dir = Filename.concat personas_dir "probe" in
   mkdir_p persona_dir;
@@ -906,12 +906,12 @@ let test_persona_resolver_rejects_non_public_social_model_arg () =
           ("social_model", `String "magentic_ledger_v1");
         ])
   with
-  | Ok _ -> fail "expected non-public social_model rejection"
-  | Error e ->
-      check bool "mentions non-public keeper args" true
-        (Str.string_match (Str.regexp_string "non-public keeper args") e 0
-         || contains_substring e "non-public keeper args");
-      check bool "mentions social_model" true (contains_substring e "social_model")
+  | Error e -> fail ("resolver failed: " ^ e)
+  | Ok (_, resolved) ->
+      check bool "social_model omitted from resolved args" false
+        (match Yojson.Safe.Util.member "social_model" resolved with
+         | `String _ -> true
+         | _ -> false)
 
 let test_persona_resolver_preserves_autoboot_enabled_arg () =
   with_personas_dir @@ fun personas_dir ->
@@ -1086,6 +1086,12 @@ let test_persona_authoring_schema_explains_effects () =
     (contains_substring rendered "tool_preset");
   check bool "documents archetype axes" true
     (contains_substring rendered "archetype_axes");
+  check bool "documents alignment axis" true
+    (contains_substring rendered "alignment");
+  check bool "documents choice effects" true
+    (contains_substring rendered "choice_effects");
+  check bool "documents generated fields" true
+    (contains_substring rendered "generated_fields");
   check string "draft tool" "masc_persona_generate"
     (Yojson.Safe.Util.member "authoring_flow" json
      |> Yojson.Safe.Util.member "draft_tool"
@@ -1094,6 +1100,53 @@ let test_persona_authoring_schema_explains_effects () =
     (Yojson.Safe.Util.member "authoring_flow" json
      |> Yojson.Safe.Util.member "save_tool"
      |> Yojson.Safe.Util.to_string)
+
+let test_persona_authoring_axes_validate_and_default_preset () =
+  let args =
+    `Assoc
+      [
+        ("alignment", `String "Chaotic");
+        ("operating_style", `String "coding");
+        ("risk_posture", `String "high-autonomy");
+      ]
+  in
+  match KPA.selected_archetype_axes_from_args args with
+  | Error e -> fail e
+  | Ok axes ->
+      check string "alignment normalized" "chaotic"
+        (Yojson.Safe.Util.member "alignment" (KPA.archetype_axes_to_json axes)
+         |> Yojson.Safe.Util.to_string);
+      check string "operating style default preset" "coding"
+        (match KPA.generation_tool_preset (`Assoc []) axes with
+         | Ok value -> value
+         | Error e -> fail e);
+      check string "explicit preset overrides style" "research"
+        (match
+           KPA.generation_tool_preset
+             (`Assoc [ ("tool_preset", `String "research") ])
+             axes
+         with
+         | Ok value -> value
+         | Error e -> fail e);
+      let selected_effects = KPA.selected_archetype_effects_to_json axes in
+      let rendered_effects = Yojson.Safe.to_string selected_effects in
+      check bool "selected effects include axes" true
+        (contains_substring rendered_effects "operating_style");
+      check bool "selected effects expose default preset" true
+        (contains_substring rendered_effects "default_tool_preset");
+      check bool "selected effects expose generated fields" true
+        (contains_substring rendered_effects "keeper.instructions")
+
+let test_persona_authoring_axes_reject_unknown_choices () =
+  match
+    KPA.selected_archetype_axes_from_args
+      (`Assoc [ ("alignment", `String "evil") ])
+  with
+  | Ok _ -> fail "expected invalid alignment rejection"
+  | Error e ->
+      check bool "mentions invalid alignment" true
+        (contains_substring e "invalid alignment");
+      check bool "mentions allowed values" true (contains_substring e "helpful")
 
 let test_persona_authoring_normalizes_keeper_defaults () =
   match KPA.normalize_profile ~handle:"probe" authoring_minimal_profile with
@@ -1476,8 +1529,8 @@ let () =
           test_case "skips bad files" `Quick test_discover_skips_bad_files;
           test_case "persona profile canonicalizes soul_profile" `Quick
             test_persona_resolver_defaults_to_research_tool_preset;
-          test_case "persona resolver rejects non-public social_model arg" `Quick
-            test_persona_resolver_rejects_non_public_social_model_arg;
+          test_case "persona resolver ignores non-public social_model arg" `Quick
+            test_persona_resolver_ignores_non_public_social_model_arg;
           test_case "persona resolver preserves autoboot_enabled arg" `Quick
             test_persona_resolver_preserves_autoboot_enabled_arg;
           test_case "persona resolver preserves canonical tool_access and allowed_paths" `Quick
@@ -1488,6 +1541,10 @@ let () =
             test_persona_resolver_rejects_custom_tool_access_durable_toml;
           test_case "persona authoring schema explains effects" `Quick
             test_persona_authoring_schema_explains_effects;
+          test_case "persona authoring axes validate and default preset" `Quick
+            test_persona_authoring_axes_validate_and_default_preset;
+          test_case "persona authoring axes reject unknown choices" `Quick
+            test_persona_authoring_axes_reject_unknown_choices;
           test_case "persona authoring normalizes defaults" `Quick
             test_persona_authoring_normalizes_keeper_defaults;
           test_case "persona authoring rejects unknown keeper fields" `Quick

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -517,7 +517,13 @@ let test_masc_persona_authoring_schemas () =
           Alcotest.(check bool) "generate has concept" true
             (List.mem_assoc "concept" props);
           Alcotest.(check bool) "generate has tool_preset" true
-            (List.mem_assoc "tool_preset" props)
+            (List.mem_assoc "tool_preset" props);
+          Alcotest.(check bool) "generate has alignment axis" true
+            (List.mem_assoc "alignment" props);
+          Alcotest.(check bool) "generate has operating_style axis" true
+            (List.mem_assoc "operating_style" props);
+          Alcotest.(check bool) "generate has risk_posture axis" true
+            (List.mem_assoc "risk_posture" props)
       | None -> Alcotest.fail "masc_persona_generate missing properties"));
   match find_tool "masc_persona_save" with
   | None -> Alcotest.fail "masc_persona_save not found"


### PR DESCRIPTION
## Summary
- Add explicit `alignment`, `operating_style`, and `risk_posture` inputs to `masc_persona_generate`.
- Validate archetype choices before invoking the OAS generation path and return `selected_archetype_axes` in generated results.
- Let `operating_style` choose the default `keeper.tool_preset` when `tool_preset` is omitted, while explicit `tool_preset` still wins.
- Update persona authoring tests and align the non-public `social_model` resolver test with the current warn-and-ignore behavior on `main`.

## Validation
- `scripts/dune-local.sh build test/test_keeper_toml.exe test/test_tools_coverage.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-persona-axis-toml-final3 MASC_BASE_PATH_INPUT=/tmp/masc-test-persona-axis-toml-final3 MASC_STORAGE_TYPE=filesystem GRAPHQL_API_KEY= ZAI_API_KEY= MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE=true ./_build/default/test/test_keeper_toml.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-persona-axis-tools-final3 MASC_BASE_PATH_INPUT=/tmp/masc-test-persona-axis-tools-final3 MASC_STORAGE_TYPE=filesystem GRAPHQL_API_KEY= ZAI_API_KEY= ./_build/default/test/test_tools_coverage.exe`
- `git diff --check`