### PR TITLE
fix(keeper): retry bootstrap meta writes on CAS conflict (#9749)

### DIFF
--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -18,6 +18,14 @@ let preset_of_defaults defaults =
     ~call_site:"keeper_turn_up_create"
     ~defaults_tool_preset:defaults.tool_preset
 
+(* #9749: bootstrap can race a heartbeat/supervisor meta write after
+   crash recovery. Retry on CAS conflict while keeping heartbeat-owned
+   cursors from disk. *)
+let write_initial_meta config meta =
+  write_meta_with_merge
+    ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+    config meta
+
 let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
   Log.Keeper.info "create_keeper: starting for name=%s" p.name;
   let task_id = Printf.sprintf "keeper_create_%s" p.name in
@@ -508,7 +516,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         (false, Printf.sprintf "initial checkpoint save failed: %s" e)
       | Ok _ ->
       Progress.Tracker.step tracker ~message:"Writing keeper metadata" ();
-      match write_meta ctx.config meta with
+      match write_initial_meta ctx.config meta with
       | Error e ->
         Log.Keeper.error "create_keeper failed: write_meta error for name=%s: %s" p.name e;
         Progress.stop_tracking task_id;

--- a/test/dune
+++ b/test/dune
@@ -342,6 +342,11 @@
     (run %{test}))))
  (libraries masc_test_deps))
 
+(test
+ (name test_keeper_turn_up_create_meta_retry)
+ (modules test_keeper_turn_up_create_meta_retry)
+ (libraries masc_test_deps))
+
 ; test_worker_run_evidence_summary removed (team session cleanup)
 
 ; test_team_session_worker_run_meta_repair removed (team session cleanup)

--- a/test/test_keeper_turn_up_create_meta_retry.ml
+++ b/test/test_keeper_turn_up_create_meta_retry.ml
@@ -1,0 +1,111 @@
+(* #9749: keeper bootstrap metadata writes must survive a concurrent
+   heartbeat/supervisor version bump. *)
+
+open Alcotest
+open Masc_mcp
+
+let () = Server_startup_state.mark_state_ready ~backend_mode:"test"
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_keeper_bootstrap_meta_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let rec cleanup_dir path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then (
+      Array.iter
+        (fun name -> cleanup_dir (Filename.concat path name))
+        (Sys.readdir path);
+      Unix.rmdir path)
+    else Unix.unlink path
+
+let ensure_fs env =
+  if not (Fs_compat.has_fs ()) then
+    Fs_compat.set_fs (Eio.Stdenv.fs env)
+
+let make_meta ~name =
+  match
+    Keeper_types.meta_of_json
+      (`Assoc
+        [
+          ("name", `String name);
+          ("agent_name", `String ("keeper-" ^ name ^ "-agent"));
+          ("trace_id", `String ("trace-" ^ name));
+          ("goal", `String "bootstrap seed");
+          ("autoboot_enabled", `Bool false);
+        ])
+  with
+  | Ok meta -> meta
+  | Error err -> fail ("meta_of_json failed: " ^ err)
+
+let read_meta_exn config name =
+  match Keeper_types.read_meta config name with
+  | Ok (Some meta) -> meta
+  | Ok None -> fail ("missing meta for " ^ name)
+  | Error err -> fail ("read_meta failed: " ^ err)
+
+let write_meta_exn config meta =
+  match Keeper_types.write_meta config meta with
+  | Ok () -> ()
+  | Error err -> fail ("write_meta failed: " ^ err)
+
+let test_bootstrap_write_retries_and_preserves_heartbeat_fields () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let seed = make_meta ~name:"bootstrap-race" in
+      write_meta_exn config seed;
+      let bootstrap_view = read_meta_exn config "bootstrap-race" in
+
+      let heartbeat_write =
+        {
+          bootstrap_view with
+          joined_room_ids = [ "live-room" ];
+          last_seen_seq_by_room = [ ("live-room", 42) ];
+        }
+      in
+      write_meta_exn config heartbeat_write;
+
+      let bootstrap_payload =
+        {
+          bootstrap_view with
+          goal = "bootstrap payload wins";
+          joined_room_ids = [];
+          last_seen_seq_by_room = [];
+        }
+      in
+      (match
+         Keeper_turn_up_create.write_initial_meta config bootstrap_payload
+       with
+       | Ok () -> ()
+       | Error err -> fail ("write_initial_meta failed: " ^ err));
+
+      let final = read_meta_exn config "bootstrap-race" in
+      check string "bootstrap-owned field wins"
+        "bootstrap payload wins" final.goal;
+      check (list string) "heartbeat rooms preserved"
+        [ "live-room" ] final.joined_room_ids;
+      check (list (pair string int)) "heartbeat cursors preserved"
+        [ ("live-room", 42) ] final.last_seen_seq_by_room;
+      check bool "version advanced past heartbeat write" true
+        (final.meta_version > heartbeat_write.meta_version))
+
+let () =
+  run "keeper_turn_up_create bootstrap meta CAS retry"
+    [
+      ( "write_initial_meta",
+        [
+          test_case
+            "retries stale bootstrap write and keeps heartbeat fields"
+            `Quick
+            test_bootstrap_write_retries_and_preserves_heartbeat_fields;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- route keeper bootstrap metadata writes through CAS retry with field-level merge
- preserve heartbeat-owned room/cursor fields when bootstrap loses a version race
- add focused regression coverage for the crash-recovery bootstrap race

## Root Cause
A recovered keeper bootstrap could write an initial meta snapshot with a stale version while heartbeat/supervisor state had already advanced the on-disk metadata. The old path treated that CAS conflict as fatal and could lose bootstrap progress even though the fields can be merged safely.

## Verification
- env DUNE_BUILD_DIR=_build_9749_verify DUNE_JOBS=2 dune build --root . test/test_keeper_turn_up_create_meta_retry.exe test/test_keeper_meta_cas_retry.exe test/test_keeper_meta_merge.exe
- env MASC_BASE_PATH=/tmp/masc-test-9749-bootstrap MASC_TEST_ALLOW_HOME_BASE_PATH=1 _build_9749_verify/default/test/test_keeper_turn_up_create_meta_retry.exe
- env MASC_BASE_PATH=/tmp/masc-test-9749-cas MASC_TEST_ALLOW_HOME_BASE_PATH=1 _build_9749_verify/default/test/test_keeper_meta_cas_retry.exe
- env MASC_BASE_PATH=/tmp/masc-test-9749-merge MASC_TEST_ALLOW_HOME_BASE_PATH=1 _build_9749_verify/default/test/test_keeper_meta_merge.exe

Closes #9749