### PR TITLE
fix(keeper): smart heartbeat Skip_busy no longer starves claim-holding keepers

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1551,6 +1551,22 @@ let dispatch_recurring_keepalive
     0
 ;;
 
+(** Whether a smart-heartbeat decision should allow the keepalive
+    cycle to continue evaluating turns.
+
+    Pure for testability. The full [run_smart_heartbeat_gate] layers
+    side-effects (sleep, cycle-timestamp update) on top of this
+    decision. Regression guard for the "claim-holding keeper
+    starvation" bug: [Skip_busy] must NOT gate cycle execution,
+    otherwise any keeper with [current_task_id=Some _] is blocked
+    from ever running a turn (discovered 2026-04-25 — 8/14 keepers
+    frozen with claimed tasks). *)
+let smart_heartbeat_cycle_continues (d : Heartbeat_smart.decision) : bool =
+  match d with
+  | Heartbeat_smart.Skip_busy | Heartbeat_smart.Emit -> true
+  | Heartbeat_smart.Skip_idle _ -> false
+;;
+
 let run_smart_heartbeat_gate
       ~(clock : _ Eio.Time.clock)
       ~(stop : bool Atomic.t)
@@ -1573,28 +1589,25 @@ let run_smart_heartbeat_gate
         ~last_heartbeat:!last_heartbeat_cycle_ts)
     else Heartbeat_smart.Emit
   in
-  match smart_hb_decision with
-  | Heartbeat_smart.Skip_busy ->
-    Log.Keeper.debug
-      "smart heartbeat: skip (busy, task=%s)"
-      (match meta_current.current_task_id with Some t -> Keeper_id.Task_id.to_string t | None -> "?");
-    let base =
-      Heartbeat_smart.effective_interval
-        ~config:smart_hb_config
-        ~last_activity:!last_successful_heartbeat_ts
-    in
-    let jitter = base *. 0.2 *. Random.float 1.0 in
-    interruptible_sleep ~clock ~stop ~wakeup (base +. jitter);
-    false
-  | Heartbeat_smart.Skip_idle next_time ->
-    let wait = Float.max 1.0 (next_time -. Time_compat.now ()) in
-    Log.Keeper.debug "smart heartbeat: skip (idle, next in %.1fs)" wait;
-    let jitter = wait *. 0.1 *. Random.float 1.0 in
-    interruptible_sleep ~clock ~stop ~wakeup (wait +. jitter);
-    false
-  | Heartbeat_smart.Emit ->
-    last_heartbeat_cycle_ts := Time_compat.now ();
-    true
+  (* Run side-effects (idle sleep, cycle-timestamp update) per the
+     decision, then use [smart_heartbeat_cycle_continues] (pure, see
+     .mli) as the authoritative gate answer. This split exists so the
+     regression guard lives in a pure function that unit tests can
+     exercise without an Eio runtime. *)
+  (match smart_hb_decision with
+   | Heartbeat_smart.Skip_busy ->
+     Log.Keeper.debug
+       "smart heartbeat: busy (task=%s) — cycle continues, broadcast may be debounced"
+       (match meta_current.current_task_id with Some t -> Keeper_id.Task_id.to_string t | None -> "?");
+     last_heartbeat_cycle_ts := Time_compat.now ()
+   | Heartbeat_smart.Skip_idle next_time ->
+     let wait = Float.max 1.0 (next_time -. Time_compat.now ()) in
+     Log.Keeper.debug "smart heartbeat: skip (idle, next in %.1fs)" wait;
+     let jitter = wait *. 0.1 *. Random.float 1.0 in
+     interruptible_sleep ~clock ~stop ~wakeup (wait +. jitter)
+   | Heartbeat_smart.Emit ->
+     last_heartbeat_cycle_ts := Time_compat.now ());
+  smart_heartbeat_cycle_continues smart_hb_decision
 ;;
 
 let maybe_write_heartbeat_snapshot

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -70,6 +70,17 @@ val drop_autonomous_waiter_for_test : int -> unit
     at time [now].  0.0 = no yield needed.  Exposed for unit testing. *)
 val fairness_delay_sec_at : now:float -> keeper_name:string -> float
 
+(** Pure: whether a [Heartbeat_smart] decision should allow the
+    keepalive cycle (presence/snapshot/board/turn/recurring) to run.
+
+    Contract: [Skip_busy] -> [true] (cycle continues; broadcast may be
+    debounced elsewhere). [Skip_idle] -> [false] (keeper idle, back
+    off). [Emit] -> [true]. Regression guard for the claim-holding
+    keeper starvation bug where [Skip_busy] was mis-used as a
+    cycle-skip signal, blocking any keeper with a claimed task from
+    ever running a turn. *)
+val smart_heartbeat_cycle_continues : Heartbeat_smart.decision -> bool
+
 (** Test-only: stamp a completion time directly (bypasses [Time_compat.now]).
     Use to set up deterministic fairness-cooldown scenarios. *)
 val record_autonomous_completion_at_for_test : keeper_name:string -> ts:float -> unit

--- a/test/test_smart_heartbeat_keepalive.ml
+++ b/test/test_smart_heartbeat_keepalive.ml
@@ -121,6 +121,29 @@ let test_decision_to_string_skip_idle () =
   check bool "starts with skip:idle" true
     (String.length s > 9 && String.sub s 0 9 = "skip:idle")
 
+(* ── Cycle-gate regression guard ───────────────────────────────────
+   Claim-holding keeper starvation (2026-04-25): 8 of 14 keepers
+   were frozen because Skip_busy (emitted whenever current_task_id
+   was Some _) was mis-used as a cycle-skip signal. The only way to
+   reach the turn evaluator is through [run_smart_heartbeat_gate]
+   returning true. These tests codify the correct mapping: Skip_busy
+   debounces the broadcast but must NEVER skip the cycle itself. *)
+
+module KK = Masc_mcp.Keeper_keepalive
+
+let test_cycle_continues_on_skip_busy () =
+  check bool "Skip_busy cycle continues" true
+    (KK.smart_heartbeat_cycle_continues HS.Skip_busy)
+
+let test_cycle_continues_on_emit () =
+  check bool "Emit cycle continues" true
+    (KK.smart_heartbeat_cycle_continues HS.Emit)
+
+let test_cycle_pauses_on_skip_idle () =
+  let next = Unix.gettimeofday () +. 60.0 in
+  check bool "Skip_idle pauses cycle" false
+    (KK.smart_heartbeat_cycle_continues (HS.Skip_idle next))
+
 (* ── Test runner ─── *)
 
 let () =
@@ -146,5 +169,11 @@ let () =
       test_case "emit" `Quick test_decision_to_string_emit;
       test_case "skip_busy" `Quick test_decision_to_string_skip_busy;
       test_case "skip_idle" `Quick test_decision_to_string_skip_idle;
+    ];
+    "cycle_gate_regression", [
+      test_case "Skip_busy -> cycle continues (#claim-starvation regression)"
+        `Quick test_cycle_continues_on_skip_busy;
+      test_case "Emit -> cycle continues" `Quick test_cycle_continues_on_emit;
+      test_case "Skip_idle -> cycle pauses" `Quick test_cycle_pauses_on_skip_idle;
     ];
   ]


### PR DESCRIPTION
## Summary

- `Heartbeat_smart.Skip_busy` (emitted whenever `current_task_id = Some _`) was treated by `run_smart_heartbeat_gate` as a whole-cycle skip, preventing the turn evaluator from ever running for any keeper with a claimed task.
- Observed live today: 8 of 14 autobooted keepers frozen for 15+ minutes. Perfect split — all 8 had non-null `current_task_id`, all 6 progressing keepers had null.
- Fix decouples: `Skip_busy` now keeps the cycle running (broadcast debounce via inline timestamp update remains intact), only `Skip_idle` pauses the cycle.

## Root cause

`Heartbeat_smart` was designed to debounce redundant **heartbeat broadcasts** when task operations already prove liveness — the module doc even says so. But `run_smart_heartbeat_gate` returned `false` on `Skip_busy`, and the caller uses that return value to gate `presence + snapshot + board + turn + recurring` — the entire keepalive cycle.

Once a keeper claimed a task (`current_task_id = Some _`), `keeper_agent_status` (keeper_keepalive.ml:1066) returned `Types.Busy` on every heartbeat iteration → `Skip_busy` → cycle halted → no turn → no progress → task stays claimed → repeat forever. No \"not scheduled\" log either (that lives inside the cycle we never entered).

## Evidence (2026-04-25 03:20 KST, dev server PID 78425)

| Keeper | current_task_id | Scheduled turn? |
|---|---|---|
| analyst, qa-king, ramarama, taskmaster, velvet-hammer, verifier | null | yes (6/6) |
| sangsu, masc-improver, issue_king, scholar, executor, janitor, nick0cave, ollama-local | task-0xx | **no (0/8)** |

Server log shows 3 `board signal wakeup: keeper=sangsu` entries in 11 min but zero `keepalive turn scheduled for sangsu` — the wakeups deliver but the gate kills the cycle before evaluation.

## Fix

Pure helper codifies the intent:

```ocaml
let smart_heartbeat_cycle_continues (d : Heartbeat_smart.decision) : bool =
  match d with
  | Heartbeat_smart.Skip_busy | Heartbeat_smart.Emit -> true
  | Heartbeat_smart.Skip_idle _ -> false
```

`run_smart_heartbeat_gate` keeps side-effects (idle sleep, cycle-timestamp update) per decision, then delegates to the helper for the gate answer. Exposed via `.mli` for unit test coverage (no Eio runtime required).

## Test plan

- [x] `dune build @check --root .` — pass
- [x] `dune exec test/test_smart_heartbeat_keepalive.exe --root .` — **17/17 pass** (14 existing + 3 new regression guards for `Skip_busy -> continues`, `Emit -> continues`, `Skip_idle -> pauses`)
- [ ] Post-merge live verification: server restart should show all 14 keepers eventually getting `keepalive turn scheduled` logs regardless of `current_task_id` state
- [ ] Smoke: the 8 frozen keepers on current dev server should each record a new `decisions.jsonl` entry within 2 heartbeat cycles after deploy

## Blast radius

- Changed: `run_smart_heartbeat_gate` return value for `Skip_busy` (was `false`, now `true`).
- **What gets less debouncing**: presence sync, snapshot, board collection, turn evaluation, recurring dispatch can now run while a task is claimed. Each of these has its own cooldown/idle logic (`turn_decision` evaluates idle gates, snapshot has `snapshot_interval_sec`, etc.) — they were the intended throttles.
- **What stays debounced**: heartbeat broadcast itself — `last_heartbeat_cycle_ts` is still updated inline, preserving the token-saving intent.

## Rollback

`git revert 3c722735a0` — single commit, 3 files. Pure side-effect decoupling, no schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)