### PR TITLE
fix(board-votes): quarantine fixture votes by default (#9886)

### DIFF
--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -431,9 +431,19 @@ let is_fixture_voter_target target =
   || has_prefix ~prefix:"test-voter-" voter
 
 let quarantine_enabled () =
+  (* #9886: production ledger observed 112/112 (100%) fixture-pattern
+     votes orphaning downstream ranking/scoring. Fixture voters
+     ([hot-voter-*], [synthetic-voter-*], [test-voter-*]) never appear
+     in legitimate production traffic, so default the quarantine ON.
+     Operators who intentionally want fixture votes loaded (e.g. a
+     benchmark replay against a live ledger) can set the env to [0],
+     [false], or [off].  #9921 still tracks the root-cause write path;
+     this change keeps downstream stats honest in the meantime. *)
   match Sys.getenv_opt "MASC_BOARD_VOTE_QUARANTINE" with
-  | Some v -> v = "1" || String.lowercase_ascii v = "true"
-  | None -> false
+  | Some v ->
+      let norm = String.lowercase_ascii (String.trim v) in
+      not (norm = "0" || norm = "false" || norm = "off" || norm = "")
+  | None -> true
 
 let load_persisted_votes store =
   let path = vote_log_path () in

--- a/test/dune
+++ b/test/dune
@@ -387,6 +387,7 @@
         test_judge_diagnostics
         test_judge_json_recovery
         test_keeper_cli_mcp_config
+        test_board_vote_quarantine
         test_keeper_identity_parse
         test_worker_runtime
         test_capability_registry
@@ -560,6 +561,7 @@
         test_judge_diagnostics
         test_judge_json_recovery
         test_keeper_cli_mcp_config
+        test_board_vote_quarantine
         test_keeper_identity_parse
         test_worker_runtime
         test_capability_registry

--- a/test/test_board_vote_quarantine.ml
+++ b/test/test_board_vote_quarantine.ml
@@ -1,0 +1,52 @@
+(* #9886: verify fixture-vote quarantine default behaviour. *)
+
+open Alcotest
+
+module BV = Masc_mcp.Board_votes
+
+let with_env key value f =
+  let prev = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match prev with
+      | Some v -> Unix.putenv key v
+      | None -> Unix.putenv key "")
+    f
+
+(* [Unix.unsetenv] is not available portably, so the default-unset case
+   is exercised by the matching [quarantine_enabled] branch below via
+   the "empty string treated as disabled" rule. The code path for the
+   [None] arm of [Sys.getenv_opt] is trivially [true] and not tested
+   directly here — [test_quarantine_explicit_*] pins the non-default
+   paths. *)
+let test_quarantine_empty_treated_as_disabled () =
+  with_env "MASC_BOARD_VOTE_QUARANTINE" "" (fun () ->
+    check bool "empty string disables (explicit operator opt-out)"
+      false (BV.quarantine_enabled ()))
+
+let test_quarantine_explicit_true () =
+  with_env "MASC_BOARD_VOTE_QUARANTINE" "true" (fun () ->
+    check bool "'true' enables" true (BV.quarantine_enabled ()));
+  with_env "MASC_BOARD_VOTE_QUARANTINE" "1" (fun () ->
+    check bool "'1' enables" true (BV.quarantine_enabled ()));
+  with_env "MASC_BOARD_VOTE_QUARANTINE" "TRUE" (fun () ->
+    check bool "'TRUE' enables (case)" true (BV.quarantine_enabled ()))
+
+let test_quarantine_explicit_false () =
+  with_env "MASC_BOARD_VOTE_QUARANTINE" "0" (fun () ->
+    check bool "'0' disables" false (BV.quarantine_enabled ()));
+  with_env "MASC_BOARD_VOTE_QUARANTINE" "false" (fun () ->
+    check bool "'false' disables" false (BV.quarantine_enabled ()));
+  with_env "MASC_BOARD_VOTE_QUARANTINE" "off" (fun () ->
+    check bool "'off' disables" false (BV.quarantine_enabled ()))
+
+let () =
+  run "board_vote_quarantine" [
+    "explicit", [
+      test_case "empty string treated as disabled" `Quick
+        test_quarantine_empty_treated_as_disabled;
+      test_case "truthy values enable" `Quick test_quarantine_explicit_true;
+      test_case "falsy values disable" `Quick test_quarantine_explicit_false;
+    ];
+  ]


### PR DESCRIPTION
## 요약

Fixture-vote quarantine flag default를 `false` → `true`로 전환. 기존 quarantine 메커니즘(`is_fixture_voter_target` + `quarantine_enabled`)을 default ON으로 활성화해 downstream 집계 왜곡을 즉시 차단.

Closes #9886 Part 2 (orphan ledger).

## 근본 원인

```ocaml
(* lib/board_votes.ml:433-436, before *)
let quarantine_enabled () =
  match Sys.getenv_opt "MASC_BOARD_VOTE_QUARANTINE" with
  | Some v -> v = "1" || String.lowercase_ascii v = "true"
  | None -> false   (* ← default off *)
```

Production 실측:
- `board_votes.jsonl` 112/112 (100%) `hot-voter-*` 패턴
- `board_posts.jsonl` 어디에도 해당 post ID 존재 안 함 (orphan)
- `is_fixture_voter_target` 검출 로직 ✓ 작동
- `quarantine_enabled` 기본 OFF → fixture vote 그대로 load → downstream 집계 왜곡

## 변경 내용

```diff
 let quarantine_enabled () =
+  (* #9886: production ledger observed 112/112 (100%) fixture-pattern
+     votes orphaning downstream ranking/scoring. Fixture voters
+     ([hot-voter-*], [synthetic-voter-*], [test-voter-*]) never appear
+     in legitimate production traffic, so default the quarantine ON.
+     Operators who intentionally want fixture votes loaded (e.g. a
+     benchmark replay against a live ledger) can set the env to [0],
+     [false], or [off]. #9921 still tracks the root-cause write path. *)
   match Sys.getenv_opt "MASC_BOARD_VOTE_QUARANTINE" with
-  | Some v -> v = "1" || String.lowercase_ascii v = "true"
-  | None -> false
+  | Some v ->
+      let norm = String.lowercase_ascii (String.trim v) in
+      not (norm = "0" || norm = "false" || norm = "off" || norm = "")
+  | None -> true
```

## 동작

| 상황 | Before | After |
|------|--------|-------|
| env unset | quarantine OFF — fixture vote 로드 | **quarantine ON — fixture vote 제외** |
| env `"1"` / `"true"` / `"TRUE"` | ON | ON (unchanged) |
| env `"0"` / `"false"` / `"off"` / `""` | OFF | OFF (explicit opt-out) |

## 테스트

`test/test_board_vote_quarantine.ml` 3 scenario:
- 빈 문자열 → disabled (operator opt-out 경로)
- truthy values (`"true"`, `"1"`, `"TRUE"`) → enable
- falsy values (`"0"`, `"false"`, `"off"`) → disable

```bash
$ dune exec --root . test/test_board_vote_quarantine.exe
# → Test Successful in 0.001s. 3 tests run.
```

`Unix.unsetenv`가 이 toolchain에 없어 env-unset 케이스는 portable test 불가. 프로덕션에선 `Sys.getenv_opt key` → `None` 경로가 실행되며 그 브랜치는 trivially `true` 반환.

## 회귀 리스크

낮음 — 이미 구현된 quarantine 경로를 default로 활성화. Warn log, Prometheus counter 그대로. 벤치마크 replay 등 fixture 의존 operator는 env로 명시적 opt-out 가능.

## 후속

- **#9921**: `test_board_dispatch` writes to prod `.masc` — root-cause 여전히 open. 본 PR은 symptom mitigation.
- **#9886 Part 1 (engagement collapse)**: agent-behaviour scope, 별도 track (sangsu BDI #9773, qa-king #9637).

## 참고

- Issue #9886 — 데이터 증거 + scrub 제안
- `lib/board_votes.ml:416-431` — `is_fixture_voter_target` detection
- `lib/board_votes.ml:438-484` — `load_persisted_votes` fixture 분기 (quarantine counter + warn log 이미 존재)
