### PR TITLE
feat(coord): Prometheus counter for task FSM drift (#9795)

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -183,6 +183,24 @@ let observe_task_transition_event config ~agent_name ~task_id
 let () = Atomic.set Coord_hooks.force_release_task_fn (fun config ~agent_name ~task_id () ->
     force_release_task_r config ~agent_name ~task_id ())
 
+(* #9795: wire the FSM drift hook to a Prometheus counter emit.
+   [Coord_task.transition] calls the hook whenever
+   [Coord_task_lifecycle.decide] returns a [drift]; this side
+   puts the signal on
+   [masc_task_fsm_drift_total{variant, force}] so Grafana /
+   ratchet-readiness dashboards can see it.  The emit lives at
+   [masc_mcp] layer because [masc_coord] sits below [Prometheus]
+   in the library dep graph. *)
+let fsm_drift_metric = "masc_task_fsm_drift_total"
+
+let record_fsm_drift ~variant ~force =
+  Prometheus.inc_counter fsm_drift_metric
+    ~labels:[ ("variant", variant);
+              ("force", if force then "true" else "false") ]
+    ()
+
+let () = Atomic.set Coord_hooks.fsm_drift_observer_fn record_fsm_drift
+
 (* Activity graph emit — wraps Activity_graph for room sub-modules *)
 let () = Atomic.set Coord_hooks.activity_emit_fn (fun config ~actor ?subject ~kind ~payload ~tags () ->
     (try

--- a/lib/coord.mli
+++ b/lib/coord.mli
@@ -23,3 +23,17 @@ include module type of Coord_agent
 (** Initialize MASC room with optional auto-join.
     Wraps [Coord_init.init] and calls [join] when [agent_name] is provided. *)
 val init : config -> agent_name:string option -> string
+
+(** {1 FSM drift observability (#9795)} *)
+
+val fsm_drift_metric : string
+(** Canonical Prometheus metric name for task FSM drift events.
+    Labels: [("variant", <drift_variant>); ("force", "true" | "false")].
+    Exposed so tests and Grafana rules can pin the name. *)
+
+val record_fsm_drift : variant:string -> force:bool -> unit
+(** Increment {!fsm_drift_metric} with the supplied labels.
+    Wired to {!Coord_hooks.fsm_drift_observer_fn} at module load
+    so [Coord_task.transition] signals every detected drift
+    through this path without [masc_coord] needing a direct
+    [Prometheus] dependency. *)

--- a/lib/coord/coord_hooks.ml
+++ b/lib/coord/coord_hooks.ml
@@ -141,6 +141,16 @@ let subscribe_messages_fn
   : (subscriber:string -> unit) Atomic.t
   = Atomic.make (fun ~subscriber:_ -> ())
 
+(** #9795: FSM drift observability.  [Coord_task.transition]
+    signals TLA+ KeeperTaskInterlock violations (currently the
+    [Claimed_to_done_skip] branch) through this hook; [lib/coord.ml]
+    wires it to a Prometheus counter emit at startup.  Keeping the
+    hook here avoids a [masc_coord → masc_mcp.Prometheus]
+    dependency cycle. *)
+let fsm_drift_observer_fn
+  : (variant:string -> force:bool -> unit) Atomic.t
+  = Atomic.make (fun ~variant:_ ~force:_ -> ())
+
 (** Tool assignment telemetry — wraps Tool_assignment_telemetry.emit_assigned.
     Wired at startup to record which tools were provisioned to which agent. *)
 let tool_assigned_fn

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -7,6 +7,17 @@ include Coord_broadcast
 
 (* activity_room_id removed — namespace retired (#unify-namespace). *)
 
+(* #9795: FSM drift observability. [masc_coord] sits below the
+   [masc_mcp] library in the dep graph, so it cannot call
+   [Prometheus.inc_counter] directly. The variant→label mapping
+   stays here (pattern-matches the sealed drift enum), and the
+   emit runs through a [Coord_hooks] callback wired by
+   [lib/coord.ml] at startup.  Exhaustive pattern-match forces
+   any new drift variant to be named alongside existing
+   dashboards. *)
+let drift_variant_label = function
+  | Coord_task_lifecycle.Claimed_to_done_skip -> "claimed_to_done_skip"
+
 let task_actor_kind agent_name =
   let normalized = String.lowercase_ascii (String.trim agent_name) in
   if normalized = "" || normalized = "system"
@@ -1197,7 +1208,18 @@ let transition_task_r
            (* FSM drift: TLA+ KeeperTaskInterlock.DoneTask requires in_progress.
               Log WARN so dashboards can surface keepers that skip Start. The
               jump is still permitted for client compatibility; strictness
-              ratchet follows once keeper_task_start is exposed. *)
+              ratchet follows once keeper_task_start is exposed.
+
+              #9795: also tick the [fsm_drift_observer_fn] hook so
+              ratchet readiness ("is the skip pattern rare enough
+              to promote to a hard error?") has a measurable
+              baseline instead of relying on log-scraping. Hook is
+              wired by [lib/coord.ml] at startup to emit a
+              Prometheus counter. *)
+           (Atomic.get Coord_hooks.fsm_drift_observer_fn)
+             ~variant:(drift_variant_label
+                         Coord_task_lifecycle.Claimed_to_done_skip)
+             ~force;
            Log.RoomTask.warn
              "fsm_drift claimed_to_done_skip task=%s agent=%s force=%b"
              task_id

--- a/lib/coord/coord_task.mli
+++ b/lib/coord/coord_task.mli
@@ -7,6 +7,18 @@
 include module type of Coord_utils
 include module type of Coord_state
 
+(** {1 Task FSM drift observability (#9795)} *)
+
+val drift_variant_label : Coord_task_lifecycle.drift -> string
+(** Canonical label string for each [Coord_task_lifecycle.drift]
+    variant.  Exhaustive — adding a new drift case forces reviewers
+    to update both the match and dashboards that consume the
+    [variant] label.  The emit runs through
+    {!Coord_hooks.fsm_drift_observer_fn}, wired to
+    {!Coord.record_fsm_drift} by [lib/coord.ml].  [masc_coord]
+    cannot call Prometheus directly — it sits below that module
+    in the library dep graph. *)
+
 (** {1 Task activity helpers} *)
 
 val update_local_agent_state :

--- a/test/dune
+++ b/test/dune
@@ -61,6 +61,7 @@
         test_hebbian_edge_update_counter
         test_keeper_proactive_skip_counter
         test_oas_error_kind_counter
+        test_fsm_drift_counter
         test_keeper_wake_telemetry
         test_keeper_memory
         test_keeper_accountability
@@ -194,6 +195,7 @@
           test_hebbian_edge_update_counter
           test_keeper_proactive_skip_counter
           test_oas_error_kind_counter
+          test_fsm_drift_counter
           test_keeper_wake_telemetry
           test_keeper_memory
           test_keeper_accountability

--- a/test/test_fsm_drift_counter.ml
+++ b/test/test_fsm_drift_counter.ml
@@ -1,0 +1,101 @@
+(* test/test_fsm_drift_counter.ml
+
+   #9795: pin the canonical Prometheus metric name + label
+   shape for task FSM drift observability.  The single current
+   [Coord_task_lifecycle.drift] variant ([Claimed_to_done_skip])
+   was warn-only until this counter was added; now ratchet
+   readiness (promoting the skip to a hard error) can be
+   measured instead of scraped from logs.
+
+   Layering: [masc_coord] (home of [Coord_task]) sits below
+   [masc_mcp.Prometheus] in the library dep graph, so the emit
+   runs through [Coord_hooks.fsm_drift_observer_fn] which
+   [lib/coord.ml] wires to [Masc_mcp.Coord.record_fsm_drift].  This test
+   exercises the wired pair — [record_fsm_drift] directly for
+   counter mechanics, and [Coord_task.drift_variant_label]
+   for the enum→label mapping that keeps Grafana rules
+   aligned with the sealed [drift] variant. *)
+
+let counter_for ~variant ~force =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    Masc_mcp.Coord.fsm_drift_metric
+    ~labels:[
+      ("variant", variant);
+      ("force", if force then "true" else "false");
+    ]
+    ()
+
+let test_metric_name_stable () =
+  Alcotest.(check string)
+    "fsm drift canonical metric name"
+    "masc_task_fsm_drift_total"
+    Masc_mcp.Coord.fsm_drift_metric
+
+(* Exhaustive enum → label mapping.  Adding a new
+   [Coord_task_lifecycle.drift] variant forces the reviewer to
+   update [drift_variant_label] (compile error on the pattern
+   match) and this test (assertion failure) at the same time,
+   which keeps the Grafana label vocabulary in sync with the
+   sealed enum. *)
+let test_variant_label_claimed_to_done_skip () =
+  Alcotest.(check string)
+    "claimed_to_done_skip → canonical label"
+    "claimed_to_done_skip"
+    (Coord_task.drift_variant_label Coord_task_lifecycle.Claimed_to_done_skip)
+
+let test_record_increments_variant_and_force () =
+  let variant =
+    Coord_task.drift_variant_label Coord_task_lifecycle.Claimed_to_done_skip
+  in
+  let before_false = counter_for ~variant ~force:false in
+  let before_true = counter_for ~variant ~force:true in
+  Masc_mcp.Coord.record_fsm_drift ~variant ~force:false;
+  Alcotest.(check (float 0.0001))
+    "force=false +1"
+    (before_false +. 1.0)
+    (counter_for ~variant ~force:false);
+  Alcotest.(check (float 0.0001))
+    "force=true unchanged"
+    before_true
+    (counter_for ~variant ~force:true);
+  Masc_mcp.Coord.record_fsm_drift ~variant ~force:true;
+  Alcotest.(check (float 0.0001))
+    "force=true +1"
+    (before_true +. 1.0)
+    (counter_for ~variant ~force:true)
+
+let test_label_isolation () =
+  (* Unknown variant label must not bleed into the known
+     variant's count — validates the label-key split. *)
+  let known =
+    Coord_task.drift_variant_label Coord_task_lifecycle.Claimed_to_done_skip
+  in
+  let unknown = "unused_test_variant_9795" in
+  let before_known = counter_for ~variant:known ~force:false in
+  Masc_mcp.Coord.record_fsm_drift ~variant:unknown ~force:false;
+  Alcotest.(check (float 0.0001))
+    "known variant counter unchanged"
+    before_known
+    (counter_for ~variant:known ~force:false)
+
+let () =
+  Alcotest.run "fsm_drift_counter_9795"
+    [
+      ( "metric_name",
+        [
+          Alcotest.test_case "canonical name stable" `Quick
+            test_metric_name_stable;
+        ] );
+      ( "variant_label",
+        [
+          Alcotest.test_case "claimed_to_done_skip" `Quick
+            test_variant_label_claimed_to_done_skip;
+        ] );
+      ( "counter",
+        [
+          Alcotest.test_case "increments with variant + force" `Quick
+            test_record_increments_variant_and_force;
+          Alcotest.test_case "label isolation" `Quick
+            test_label_isolation;
+        ] );
+    ]


### PR DESCRIPTION
## 요약

#9795 에서 `claimed_to_done_skip` transition이 warn-only 로만 surface. Ratchet readiness ("skip 을 hard error 로 promote 가능한가?") 는 log scraping 으로만 측정 가능 — fragile + silent regression 위험.

Fleet-wide Prometheus counter 추가:

```
masc_task_fsm_drift_total{variant, force}
  variant = claimed_to_done_skip
  force   = "true" | "false"
```

## Layering 주의

`masc_coord` (= `Coord_task.transition` 거주) 이 `masc_mcp.Prometheus` 보다 **아래** 레벨. 직접 호출 불가 → 기존 `Coord_hooks` 패턴 (e.g. `hebbian_on_task_done_fn`) 준용:

1. `Coord_hooks.fsm_drift_observer_fn` — no-op default callback (masc_coord layer).
2. `lib/coord.ml` (masc_mcp layer) 가 `Coord.record_fsm_drift` 를 hook 에 wire.
3. `Coord_task.transition` 의 warn log 바로 옆에서 hook 호출 — emit 과 log 가 lockstep.

## 변경 파일

- `lib/coord/coord_hooks.ml` — `fsm_drift_observer_fn` Atomic ref.
- `lib/coord/coord_task.ml`
  - `drift_variant_label` — exhaustive enum→label mapping (compile-time guard).
  - Warn site 에서 hook 호출.
- `lib/coord/coord_task.mli` — `drift_variant_label` 공개, docstring 으로 layering 설명.
- `lib/coord.ml` — `fsm_drift_metric` 상수 + `record_fsm_drift` helper + startup wiring.
- `lib/coord.mli` — 상수 + helper 공개.
- `test/test_fsm_drift_counter.ml` (신규) — 4 테스트:
  - Canonical metric name pin.
  - `claimed_to_done_skip` → canonical label string mapping.
  - Counter +1 per (variant, force) pair.
  - Label isolation (unknown variant 가 known variant 의 count 침범 없음).
- `test/dune` — test 등록.

## 로컬 검증

```
$ MASC_BASE_PATH=/tmp/masc-test-9795 dune exec test/test_fsm_drift_counter.exe
Test Successful in 0.000s. 4 tests run.
```

`dune build --cache=disabled` clean.

## 왜 근원 fix 인가

- **TLA+ KeeperTaskInterlock violation 의 측정 가능한 surface**: 로그 scrape 에 의존하지 않고 rate(counter) 로 fleet 전체 비율 집계.
- **Exhaustive pattern match = enum-label drift 불가능**: 새 drift variant 추가 시 compiler 가 `drift_variant_label` 갱신 강제. Grafana 라벨 vocabulary 와 enum 이 사일런트하게 갈라질 수 없음.
- **Layer boundary 존중**: Prometheus 직접 호출 대신 hook pattern — 기존 `hebbian_on_task_done_fn` 과 동일 방식. 새 abstraction 아님.
- **Behavior 미변경**: Skip 은 여전히 허용 + warn — 머지 후 counter 가 낮은 rate 로 관찰되면 향후 ratchet PR 에서 hard-error 전환 근거로 활용.

## 미검증 / 후속

- Grafana alert rule: `rate(masc_task_fsm_drift_total{variant="claimed_to_done_skip"}[5m]) > threshold`. Ops ticket.
- 향후 [keeper_task_start](https://github.com/jeong-sik/masc-mcp/blob/main/lib/coord/coord_task_lifecycle.mli) 가 client surface 에 노출 되면, 본 counter 기준으로 ratchet (promote to hard error) 여부 결정.
- 다른 `drift` variant 가 추가되면 `drift_variant_label` compile error 로 reviewer 가 인지.

## 관련

- #9795 (root).
- #9517 (silent failure meta — warn-only signal 은 이 meta 에서 지목한 scrape 의존성).
- `Coord_hooks.hebbian_on_task_done_fn` — 같은 layering 해법 precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)