### PR TITLE
[codex] fix dashboard keeper display ssot

### DIFF
--- a/dashboard/src/components/agent-monitor/runtime-strip.ts
+++ b/dashboard/src/components/agent-monitor/runtime-strip.ts
@@ -1,11 +1,12 @@
 // AgentRuntimeStrip — compact horizontal strip showing keeper live metrics.
-// Renders pipeline stage badge, context ratio bar, generation, active model, last turn age.
+// Renders pipeline stage badge, context ratio bar, generation, display model, and latest activity signal.
 // Only renders if the agent has a linked keeper.
 
 import { html } from 'htm/preact'
 import { PipelineStageBadge } from '../keeper-pipeline-stage'
 import { findKeeper } from '../../lib/keeper-utils'
 import { formatDuration } from '../mission-utils'
+import { keeperActivityDisplay, keeperDisplayModel } from '../../lib/keeper-runtime-display'
 
 function ctxBarClass(ratio: number | null | undefined): string {
   if (ratio == null) return ''
@@ -26,8 +27,8 @@ export function AgentRuntimeStrip({ name }: { name: string }) {
   const ctxRatio = keeper.context_ratio
   const ctxPct = ctxRatio != null ? Math.round(ctxRatio * 100) : null
   const generation = keeper.generation
-  const model = keeper.active_model ?? keeper.model ?? null
-  const lastTurnAge = keeper.last_turn_ago_s
+  const model = keeperDisplayModel(keeper)
+  const activity = keeperActivityDisplay(keeper, keeper.agent?.last_seen)
 
   return html`
     <div class="agent-runtime-strip">
@@ -57,15 +58,15 @@ export function AgentRuntimeStrip({ name }: { name: string }) {
 
       ${model ? html`
         <div class="flex items-center gap-1.5 text-sm">
-          <span class="text-3xs text-[var(--text-muted)] uppercase tracking-wider">MODEL</span>
-          <span class="text-sm text-[var(--text-body)] font-mono truncate max-w-50">${model}</span>
+          <span class="text-3xs text-[var(--text-muted)] uppercase tracking-wider">${model.label}</span>
+          <span class="text-sm text-[var(--text-body)] font-mono truncate max-w-50">${model.value}</span>
         </div>
       ` : null}
 
-      ${lastTurnAge != null ? html`
+      ${activity.ageSeconds != null ? html`
         <div class="flex items-center gap-1.5 text-sm">
-          <span class="text-3xs text-[var(--text-muted)] uppercase tracking-wider">TURN</span>
-          <span class="text-sm text-[var(--text-body)] tabular-nums">${formatDuration(lastTurnAge)} ago</span>
+          <span class="text-3xs text-[var(--text-muted)] uppercase tracking-wider">ACTIVITY</span>
+          <span class="text-sm text-[var(--text-body)] tabular-nums">${activity.label} ${formatDuration(activity.ageSeconds)} 전</span>
         </div>
       ` : null}
     </div>

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -39,6 +39,7 @@ import { missionSnapshot } from '../mission-store'
 import { navigate } from '../router'
 import { formatDuration } from './mission-utils'
 import { trimText } from '../lib/truncate'
+import { keeperActivityDisplay, keeperDisplayModel } from '../lib/keeper-runtime-display'
 import type {
   Agent,
   DashboardExecutionContinuityBrief,
@@ -211,12 +212,16 @@ function CharacterPlate({ name }: { name: string }) {
   const headerStatus = keeper?.status ?? agent?.status ?? brief?.status ?? 'unknown'
   const agentEmoji = agent?.emoji ?? keeper?.emoji
   const currentWork = brief?.current_work ?? agent?.current_task ?? null
-  const lastSeenAt = agent?.last_seen ?? brief?.last_activity_at ?? null
-  const lastActivity = keeper?.last_turn_ago_s ?? brief?.last_activity_age_sec ?? null
+  const keeperActivity = keeper
+    ? keeperActivityDisplay(keeper, agent?.last_seen ?? brief?.last_activity_at ?? null)
+    : null
+  const lastSeenAt = keeperActivity?.timestamp ?? agent?.last_seen ?? brief?.last_activity_at ?? null
+  const lastActivity = keeperActivity?.ageSeconds ?? brief?.last_activity_age_sec ?? null
+  const activityLabel = keeperActivity?.label ?? '마지막 확인'
   const ctxRatio = keeper?.context_ratio
   const ctxPct = ctxRatio != null ? Math.round(ctxRatio * 100) : null
   const generation = keeper?.generation
-  const model = agent?.model ?? keeper?.model ?? null
+  const model = keeper ? keeperDisplayModel(keeper)?.value ?? agent?.model ?? null : agent?.model ?? null
   const keeperIdent = keeperIdentityHint(keeper?.name, keeper?.agent_name)
   const signalTruth = brief?.signal_truth
   const continuitySummary =
@@ -285,8 +290,10 @@ function CharacterPlate({ name }: { name: string }) {
 
         ${lastSeenAt || lastActivity != null ? html`
           <div class="flex gap-3 flex-wrap text-sm text-[var(--text-muted)]">
-            ${lastSeenAt ? html`<span>마지막 확인: <${TimeAgo} timestamp=${lastSeenAt} /></span>` : null}
-            ${lastActivity != null ? html`<span>${formatDuration(lastActivity)} 전 활동</span>` : null}
+            ${lastSeenAt ? html`<span>${activityLabel}: <${TimeAgo} timestamp=${lastSeenAt} /></span>` : null}
+            ${lastActivity != null && (!keeperActivity || !lastSeenAt)
+              ? html`<span>${activityLabel} ${formatDuration(lastActivity)} 전</span>`
+              : null}
           </div>
         ` : null}
 

--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -19,6 +19,8 @@ function makeRow(overrides: Partial<FleetRow> = {}): FleetRow {
     turn_count: 0,
     last_latency_ms: 0,
     last_activity_ago_s: null,
+    activity_label: '최근 활동',
+    activity_source: 'none',
     model: '',
     tool_calls: 0,
     tool_success_pct: null,
@@ -511,7 +513,8 @@ describe('FleetTelemetryPanel', () => {
     expect(rows[0]?.recent_tools).toEqual(['masc_status', 'keeper_stay_silent'])
   })
 
-  it('prefers active_model over placeholder metric model strings', async () => {
+  it('uses display model and freshest keeper activity helpers for fleet rows', async () => {
+    vi.setSystemTime(new Date('2026-04-24T18:00:00Z'))
     const { buildFleetRows } = await loadPanel({
       fetchDashboardExecution: vi.fn().mockResolvedValue(executionResponse),
       fetchToolQuality: vi.fn().mockResolvedValue(toolQualityResponse),
@@ -525,7 +528,9 @@ describe('FleetTelemetryPanel', () => {
         keepalive_running: true,
         context_ratio: 0.3,
         total_turns: 5,
-        last_activity_ago_s: 60,
+        last_model_used: 'unknown',
+        last_autonomous_action_at: '2026-04-24T12:00:00Z',
+        last_heartbeat: '2026-04-24T17:54:00Z',
         active_model: 'gpt-5.4',
         metrics_series: [
           { ...metricSeriesPoint, model_used: 'unknown' },
@@ -540,6 +545,11 @@ describe('FleetTelemetryPanel', () => {
 
     expect(rows).toHaveLength(1)
     expect(rows[0]?.model).toBe('gpt-5.4')
+    expect(rows[0]).toMatchObject({
+      activity_label: '하트비트',
+      activity_source: 'heartbeat',
+      last_activity_ago_s: 360,
+    })
   })
 
   it('sorts attention keepers ahead of healthy and offline rows', async () => {

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -33,7 +33,7 @@ import {
   emptyState,
   errorMessage,
   fleetBand,
-  formatActivity,
+  formatActivitySignal,
   formatLatency,
   formatPercent,
   pressureClass,
@@ -309,13 +309,13 @@ function PressureWatchlist({ rows }: { rows: FleetRow[] }) {
             <div class="font-mono text-[var(--text)]">${row.name}</div>
             <div class="text-[var(--text-dim)]">
               ${row.last_activity_ago_s != null && row.last_activity_ago_s >= STALE_ACTIVITY_SEC
-                ? `stale ${formatActivity(row.last_activity_ago_s)}`
+                ? `stale ${formatActivitySignal(row)}`
                 : `ctx ${formatPercent(row.context_ratio * 100, 1)}`}
             </div>
           </div>
           <div class="text-right">
             <div class="font-mono ${pressureClass(row.context_ratio)}">${formatPercent(row.context_ratio * 100, 1)}</div>
-            <div class="text-[var(--text-dim)]">${formatActivity(row.last_activity_ago_s)}</div>
+            <div class="text-[var(--text-dim)]">${formatActivitySignal(row)}</div>
           </div>
         </div>
       `)}
@@ -436,7 +436,7 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
                   : null}
               </td>
               <td class="py-1.5 text-right font-mono ${statusClass(row)}">${row.status}</td>
-              <td class="py-1.5 text-right text-[var(--text-dim)]">${formatActivity(row.last_activity_ago_s)}</td>
+              <td class="py-1.5 text-right text-[var(--text-dim)]">${formatActivitySignal(row)}</td>
               <td class="py-1.5 text-right text-3xs ${auditFreshnessClass(row.tool_audit_at)}" title=${row.tool_audit_at ?? ''}>
                 ${row.tool_audit_at ? formatTimeAgo(row.tool_audit_at) : '-'}
               </td>

--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -19,6 +19,7 @@ import {
   formatPercent,
   formatLatency,
   formatActivity,
+  formatActivitySignal,
   numericAge,
   toneForToolSuccess,
   toneForPressure,
@@ -43,6 +44,8 @@ function makeRow(overrides: Partial<FleetRow> = {}): FleetRow {
     turn_count: 10,
     last_latency_ms: 500,
     last_activity_ago_s: 60,
+    activity_label: '최근 활동',
+    activity_source: 'last_activity',
     model: 'test-model',
     tool_calls: 5,
     tool_success_pct: 95,
@@ -313,6 +316,16 @@ describe('formatActivity', () => {
   it('returns dash for null/negative', () => {
     expect(formatActivity(null)).toBe('-')
     expect(formatActivity(-1)).toBe('-')
+  })
+})
+
+describe('formatActivitySignal', () => {
+  it('prefixes the age with the selected keeper activity label', () => {
+    expect(formatActivitySignal(makeRow({ activity_label: '하트비트', last_activity_ago_s: 360 }))).toBe('하트비트 6m 0s')
+  })
+
+  it('returns dash when the activity age is unknown', () => {
+    expect(formatActivitySignal(makeRow({ last_activity_ago_s: null }))).toBe('-')
   })
 })
 

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -3,6 +3,11 @@ import type { DashboardNamespaceTruthResponse } from '../types'
 import { telemetrySourceLabel } from '../config/telemetry-sources'
 import type { Keeper } from '../types'
 import { formatElapsedCompact } from '../lib/format-time'
+import {
+  keeperActivityDisplay,
+  keeperDisplayModel,
+  type KeeperActivitySource,
+} from '../lib/keeper-runtime-display'
 
 export const PRESSURE_HOT_RATIO = 0.75
 export const PRESSURE_WARN_RATIO = 0.5
@@ -21,6 +26,8 @@ export interface FleetRow {
   turn_count: number
   last_latency_ms: number
   last_activity_ago_s: number | null
+  activity_label: string
+  activity_source: KeeperActivitySource
   model: string
   tool_calls: number
   tool_success_pct: number | null
@@ -120,29 +127,15 @@ export function uniqueStrings(values: Array<string | null | undefined>): string[
   return items
 }
 
-function keeperLatestMetricModel(keeper: Keeper): string | null {
-  const series = keeper.metrics_series ?? []
-  for (let index = series.length - 1; index >= 0; index -= 1) {
-    const model = normalizeModelText(series[index]?.model_used)
-    if (model) return model
-  }
-  return null
-}
-
 function keeperMetricsWindowModel(keeper: Keeper): string | null {
   const primary = keeper.metrics_window?.primary_model
   return typeof primary === 'string' ? normalizeModelText(primary) : null
 }
 
 function keeperModel(keeper: Keeper): string {
-  return firstNonEmptyString(
-    keeper.last_model_used,
-    keeperLatestMetricModel(keeper),
-    keeperMetricsWindowModel(keeper),
-    keeper.active_model,
-    keeper.model,
-    keeper.primary_model,
-  ) ?? 'unknown'
+  return normalizeModelText(keeperDisplayModel(keeper)?.value)
+    ?? keeperMetricsWindowModel(keeper)
+    ?? 'unknown'
 }
 
 function keeperLastLatencyMs(keeper: Keeper): number {
@@ -333,6 +326,7 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
           const toolQualityForKeeper = toolStats.get(keeper.name)
           const recentTools = keeperRecentTools(keeper)
           const toolCalls = keeperToolCallCount(keeper, toolQualityForKeeper?.calls)
+          const activity = keeperActivityDisplay(keeper, keeper.agent?.last_seen)
           return {
             name: keeper.name,
             status: keeper.status ?? (keeper.keepalive_running ? 'active' : 'offline'),
@@ -343,7 +337,9 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
             context_ratio: keeper.context_ratio ?? 0,
             turn_count: keeper.total_turns ?? keeper.turn_count ?? 0,
             last_latency_ms: keeperLastLatencyMs(keeper),
-            last_activity_ago_s: keeper.last_activity_ago_s ?? null,
+            last_activity_ago_s: activity.ageSeconds,
+            activity_label: activity.label,
+            activity_source: activity.source,
             model: keeperModel(keeper),
             tool_calls: toolCalls,
             tool_success_pct: toolQualityForKeeper?.success_pct ?? null,
@@ -382,6 +378,8 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
           turn_count: 0,
           last_latency_ms: 0,
           last_activity_ago_s: null,
+          activity_label: '최근 활동',
+          activity_source: 'none',
           model: 'unknown',
           tool_calls: keeper.calls,
           tool_success_pct: keeper.success_pct,
@@ -460,6 +458,14 @@ export function formatLatency(ms: number): string {
 export function formatActivity(seconds: number | null): string {
   if (seconds == null || !Number.isFinite(seconds) || seconds < 0) return '-'
   return formatElapsedCompact(seconds)
+}
+
+export function formatActivitySignal(
+  row: Pick<FleetRow, 'activity_label' | 'last_activity_ago_s'>,
+): string {
+  const activity = formatActivity(row.last_activity_ago_s)
+  if (activity === '-') return '-'
+  return `${row.activity_label} ${activity}`
 }
 
 export function numericAge(value: number | null | undefined): number | null {

--- a/dashboard/src/components/fleet-trend-store.test.ts
+++ b/dashboard/src/components/fleet-trend-store.test.ts
@@ -11,6 +11,8 @@ function makeRow(name: string, overrides: Partial<FleetRow> = {}): FleetRow {
     turn_count: 0,
     last_latency_ms: 100,
     last_activity_ago_s: 10,
+    activity_label: '최근 활동',
+    activity_source: 'last_activity',
     model: 'test-model',
     tool_calls: 5,
     tool_success_pct: 95,

--- a/dashboard/src/components/journey-panel.ts
+++ b/dashboard/src/components/journey-panel.ts
@@ -27,6 +27,7 @@ import { RouteLink } from './common/route-link'
 import { StatusBadge } from './common/status-badge'
 import { StatusChip, keeperStateTone } from './common/status-chip'
 import { TimeAgo } from './common/time-ago'
+import { keeperActivityDisplay, keeperDisplayModel } from '../lib/keeper-runtime-display'
 
 type JourneyMissionSession = {
   session_id: string
@@ -139,8 +140,9 @@ function pipelineTone(stage?: string | null): string {
 
 function shouldShowStandaloneKeeper(keeper: Keeper): boolean {
   const status = (keeper.status ?? '').trim().toLowerCase()
+  const activity = keeperActivityDisplay(keeper, keeper.agent?.last_seen)
   if (keeper.keepalive_running === true) return true
-  if (keeper.last_turn_ago_s != null) return true
+  if (activity.source !== 'none') return true
   if (keeper.pipeline_stage && keeper.pipeline_stage !== 'offline') return true
   return !['offline', 'inactive', 'stopped', 'dead'].includes(status)
 }
@@ -344,8 +346,8 @@ export function buildJourneyRecords(input: JourneyBuildInput): JourneyRecord[] {
     .filter(shouldShowStandaloneKeeper)
     .slice()
     .sort((left, right) => {
-      const leftAge = left.last_activity_ago_s ?? left.last_turn_ago_s ?? Number.POSITIVE_INFINITY
-      const rightAge = right.last_activity_ago_s ?? right.last_turn_ago_s ?? Number.POSITIVE_INFINITY
+      const leftAge = keeperActivityDisplay(left, left.agent?.last_seen).ageSeconds ?? Number.POSITIVE_INFINITY
+      const rightAge = keeperActivityDisplay(right, right.agent?.last_seen).ageSeconds ?? Number.POSITIVE_INFINITY
       return leftAge - rightAge
     })
 
@@ -421,6 +423,7 @@ export function filterJourneyRecords(
       record.keeper?.name,
       record.keeper?.agent_name,
       record.keeper?.cascade_name,
+      record.keeper ? keeperDisplayModel(record.keeper)?.value : null,
       record.keeper?.active_model,
       record.keeper?.model,
       record.continuity?.model,
@@ -489,6 +492,8 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
   const contextSummary = keeper?.context_tokens != null && keeper?.context_max != null
     ? `${formatTokens(keeper.context_tokens)} / ${formatTokens(keeper.context_max)}`
     : null
+  const keeperActivity = keeper ? keeperActivityDisplay(keeper, keeper.agent?.last_seen) : null
+  const keeperModel = keeper ? keeperDisplayModel(keeper) : null
   const showExtended = useSignal(false)
 
   return html`
@@ -616,7 +621,7 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
                   <div class="flex flex-wrap gap-3 text-xs text-[var(--text-muted)]">
                     <span>ctx ${formatPct(keeper.context_ratio)}</span>
                     ${contextSummary ? html`<span>${contextSummary}</span>` : null}
-                    ${keeper.last_activity_ago_s != null ? html`<span>활동 ${formatAgeSeconds(keeper.last_activity_ago_s)}</span>` : null}
+                    ${keeperActivity?.ageSeconds != null ? html`<span>${keeperActivity.label} ${formatAgeSeconds(keeperActivity.ageSeconds)}</span>` : null}
                   </div>
                   ${trimText(record.continuity?.continuity_summary ?? record.continuity?.note, 100)
                     ? html`<div class="text-xs leading-relaxed text-[var(--text-muted)]">${trimText(record.continuity?.continuity_summary ?? record.continuity?.note, 100)}</div>`
@@ -706,10 +711,10 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
                     ? html`
                         <div class="flex flex-wrap items-center gap-2">
                           ${keeper.cascade_name ? html`<${StatusChip} tone="info">${keeper.cascade_name}<//>` : null}
-                          ${keeper.active_model ? html`<${StatusChip} tone="neutral" uppercase=${false}>${keeper.active_model}<//>` : null}
+                          ${keeperModel ? html`<${StatusChip} tone="neutral" uppercase=${false}>${keeperModel.value}<//>` : null}
                         </div>
                         <div class="text-xs text-[var(--text-muted)]">
-                          ${keeper.last_model_used || keeper.model ? html`last ${keeper.last_model_used ?? keeper.model}` : 'model 기록 없음'}
+                          ${keeperModel ? html`${keeperModel.label} ${keeperModel.value}` : 'model 기록 없음'}
                         </div>
                         ${keeper.next_model_hint
                           ? html`<div class="text-xs text-[var(--text-muted)]">next ${keeper.next_model_hint}</div>`

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -35,6 +35,7 @@ import {
   KeeperDiagnosticSummary,
   KeeperRuntimeActions,
 } from './keeper-shared'
+import { formatDuration } from './mission-utils'
 import { showToast } from './common/toast'
 import { purgeAgent } from '../api/actions'
 import {
@@ -215,7 +216,14 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
   const hbAgeMs = hbTs != null && !Number.isNaN(hbTs) ? Date.now() - hbTs : null
   const hbStale = hbAgeMs != null && hbAgeMs > 300_000 // 5 minutes
   const needsAttention = keeperNeedsDiagnosticAttention(keeper)
-  if (!needsAttention && !keeper.last_autonomous_action_at) return null
+  const activity = keeperActivityDisplay(keeper, keeper.agent?.last_seen)
+  const hasActivitySignal = activity.timestamp != null || activity.ageSeconds != null
+  const renderActivitySignal = () => activity.timestamp
+    ? html`${activity.label} <${TimeAgo} timestamp=${activity.timestamp} />`
+    : activity.ageSeconds != null
+      ? html`${activity.label} ${formatDuration(activity.ageSeconds)} 전`
+      : null
+  if (!needsAttention && !hasActivitySignal) return null
 
   const directiveLoading = signal(false)
   const handleDirective = async (action: 'pause' | 'resume') => {
@@ -266,9 +274,7 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
       <div class="rounded border ${toneClass} px-4 py-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-[var(--text-body)]">
         ${keeper.paused
           ? html`<span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--warn-14)] text-[var(--warn)]">일시정지</span>
-            ${keeper.last_autonomous_action_at
-              ? html`<span class="text-[var(--text-muted)]">마지막 행동 이후 <${TimeAgo} timestamp=${keeper.last_autonomous_action_at} /></span>`
-              : null}
+            ${hasActivitySignal ? html`<span class="text-[var(--text-muted)]">${renderActivitySignal()}</span>` : null}
             <button
               class="inline-flex items-center rounded px-2 py-0.5 text-2xs font-medium bg-[var(--white-6)] hover:bg-[var(--white-8)] text-[var(--text-strong)] transition-colors disabled:opacity-50"
               disabled=${directiveLoading.value}
@@ -293,27 +299,21 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
               <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--warn-14)] text-[var(--warn)]">
                 계속 진행 승인 대기
               </span>
-              ${keeper.last_autonomous_action_at
-                ? html`<span class="text-[var(--text-muted)]">마지막 행동 이후 <${TimeAgo} timestamp=${keeper.last_autonomous_action_at} /></span>`
-                : null}
+              ${hasActivitySignal ? html`<span class="text-[var(--text-muted)]">${renderActivitySignal()}</span>` : null}
             `
           : socialFallbackActive
           ? html`
               <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--warn-14)] text-[var(--warn)]">
                 Social fallback
               </span>
-              ${keeper.last_autonomous_action_at
-                ? html`<span class="text-[var(--text-muted)]">마지막 행동 이후 <${TimeAgo} timestamp=${keeper.last_autonomous_action_at} /></span>`
-                : null}
+              ${hasActivitySignal ? html`<span class="text-[var(--text-muted)]">${renderActivitySignal()}</span>` : null}
             `
           : runtimeBlockerClass
           ? html`
               <span class="inline-flex items-center rounded-sm px-2 py-0.5 text-2xs font-semibold bg-[var(--bad-soft)] text-[var(--bad)]">
                 ${runtimeBlockerLabel ?? 'Runtime blocker'}
               </span>
-              ${keeper.last_autonomous_action_at
-                ? html`<span class="text-[var(--text-muted)]">마지막 행동 이후 <${TimeAgo} timestamp=${keeper.last_autonomous_action_at} /></span>`
-                : null}
+              ${hasActivitySignal ? html`<span class="text-[var(--text-muted)]">${renderActivitySignal()}</span>` : null}
             `
           : null}
         ${runtimeBlocker
@@ -384,8 +384,8 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
         ${typeof goalConvergence === 'number'
           ? html`<span><strong class="text-[var(--text-strong)]">Goal Progress</strong> · ${Math.round(goalConvergence * 100)}%</span>`
           : null}
-        ${keeper.last_autonomous_action_at
-          ? html`<span><strong class="text-[var(--text-strong)]">마지막 행동</strong> · <${TimeAgo} timestamp=${keeper.last_autonomous_action_at} /></span>`
+        ${hasActivitySignal
+          ? html`<span><strong class="text-[var(--text-strong)]">최근 신호</strong> · ${renderActivitySignal()}</span>`
           : null}
       </div>
     </div>

--- a/dashboard/src/lib/keeper-runtime-display.test.ts
+++ b/dashboard/src/lib/keeper-runtime-display.test.ts
@@ -119,6 +119,16 @@ describe('keeperDisplayModel', () => {
     ).toEqual({ label: '현재 모델', value: 'claude_code:auto' })
   })
 
+  it('skips placeholder model sentinels before falling back to active runtime labels', () => {
+    expect(
+      keeperDisplayModel({
+        last_model_used: 'unknown',
+        active_model: 'claude_code:auto',
+        model: 'claude',
+      }),
+    ).toEqual({ label: '현재 모델', value: 'claude_code:auto' })
+  })
+
   it('uses the latest metrics model when structured runtime model is absent', () => {
     expect(
       keeperDisplayModel({

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -50,15 +50,23 @@ type ActivityCandidate = {
   ageSeconds: number
 }
 
+const MODEL_PLACEHOLDERS = new Set(['unknown', 'none', '-', 'n/a'])
+
 function trimmed(value: string | null | undefined): string | null {
   const text = value?.trim()
   return text ? text : null
 }
 
+function modelText(value: string | null | undefined): string | null {
+  const text = trimmed(value)
+  if (!text || MODEL_PLACEHOLDERS.has(text.toLowerCase())) return null
+  return text
+}
+
 function latestMetricModel(source: KeeperModelDisplaySource | null | undefined): string | null {
   const series = source?.metrics_series ?? []
   for (let index = series.length - 1; index >= 0; index -= 1) {
-    const model = trimmed(series[index]?.model_used)
+    const model = modelText(series[index]?.model_used)
     if (model) return model
   }
   return null
@@ -67,22 +75,22 @@ function latestMetricModel(source: KeeperModelDisplaySource | null | undefined):
 export function keeperDisplayModel(
   source: KeeperModelDisplaySource | null | undefined,
 ): KeeperModelDisplay | null {
-  const lastModelLabel = trimmed(source?.last_model_used_label)
+  const lastModelLabel = modelText(source?.last_model_used_label)
   if (lastModelLabel) return { label: '최근 모델', value: lastModelLabel }
 
-  const lastModel = trimmed(source?.last_model_used)
+  const lastModel = modelText(source?.last_model_used)
   if (lastModel) return { label: '최근 모델', value: lastModel }
 
-  const activeModelLabel = trimmed(source?.active_model_label)
+  const activeModelLabel = modelText(source?.active_model_label)
   if (activeModelLabel) return { label: '현재 모델', value: activeModelLabel }
 
-  const activeModel = trimmed(source?.active_model)
+  const activeModel = modelText(source?.active_model)
   if (activeModel) return { label: '현재 모델', value: activeModel }
 
   const metricModel = latestMetricModel(source)
   if (metricModel) return { label: '최근 모델', value: metricModel }
 
-  const fallbackModel = trimmed(source?.model) ?? trimmed(source?.primary_model)
+  const fallbackModel = modelText(source?.model) ?? modelText(source?.primary_model)
   if (fallbackModel) return { label: '모델', value: fallbackModel }
   return null
 }


### PR DESCRIPTION
## Summary
- Route keeper model display through the shared runtime display helper across fleet, detail, profile, runtime strip, and journey views.
- Route keeper activity display through the shared helper so heartbeat, recent activity, autonomous action, and agent-seen signals are labeled consistently.
- Ignore placeholder model sentinels like `unknown`, `none`, `-`, and `n/a` before falling back to real runtime model values.

## Why This Matters
The agent directory is an operator trust surface. Before this change, different dashboard panels could tell different stories for the same keeper because they read different raw fields directly. That made a live keeper look stale, inactive, or attached to the wrong model even when fresher runtime evidence existed.

This is intentionally a display SSOT fix, not a cosmetic rename. The dashboard now centralizes keeper-facing activity and model labels through `keeper-runtime-display`, so the fleet cards, keeper detail, profile, runtime strip, and journey views converge on the same precedence rules.

## Root Cause
Several dashboard surfaces still read raw keeper fields directly, so the agent directory could show stale or misleading values such as `claude` instead of `claude_code:auto`, or `last turn` instead of the fresher heartbeat signal.

## Implementation Notes
- `keeperDisplayModel` now filters placeholder sentinel values before exposing a model label.
- `buildFleetRows` now emits explicit `activity_label` and `activity_source` values from the shared helper.
- Operator-facing dashboard components now consume the shared display fields instead of recomputing last-activity/model text locally.
- Raw/debug detail remains raw where that is useful for inspection.

## Validation
- `pnpm -C dashboard typecheck`
- `pnpm -C dashboard exec vitest run src/lib/keeper-runtime-display.test.ts src/components/fleet-telemetry-utils.test.ts src/components/fleet-telemetry-panel.test.ts src/components/fleet-trend-store.test.ts src/components/journey-panel.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm -C dashboard lint`
- `git diff --check`
- GitHub checks: Dashboard, CI Gate, Meta Guards, PR Sync Check, Draft Auto-Merge Guard all passed on PR #10084.

## Review Focus
- Confirm the shared display precedence matches operator expectations: heartbeat/seen/runtime signals should win over stale autonomous-turn text when they are fresher.
- Confirm only operator-facing summaries changed, while raw diagnostic sections still expose raw fields for debugging.
