### PR TITLE
fix(fs-compat): write-boundary HOME guard for test executables (#9921)

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -44,6 +44,67 @@ let with_io ~path f =
   with Eio.Io _ as e ->
     raise (Sys_error (Printf.sprintf "%s: %s" path (Printexc.to_string e)))
 
+(* #9921: defense-in-depth write-boundary guard.
+
+   [Env_config_core.base_path_prod_guard] stops HOME fallback during path
+   resolution.  This stops writes when the resolved path nevertheless
+   points under HOME — any code that caches a stale [base_path ()] result
+   or builds a HOME-relative path directly hits this gate before the
+   write lands on the production ledger.
+
+   The prod ledger observed 106 test-pattern rows
+   ([hot-voter-*], [flipper], [same-voter], [judge]) written pre-#9920.
+   This guard prevents regression if any new code path slips past the
+   resolution guard.
+
+   Active only for test executables (basename starts with [test_]).
+   Escape hatch [MASC_TEST_ALLOW_HOME_BASE_PATH=1] matches
+   [base_path_prod_guard] for the rare test that legitimately writes
+   under HOME.  Reads remain unguarded — this is about preventing
+   silent corruption, not restricting observability. *)
+exception Test_isolation_breach of string
+
+let test_exec_home_guard ~op path =
+  let basename =
+    Sys.executable_name |> Filename.basename |> String.lowercase_ascii
+  in
+  let is_test_exec =
+    String.length basename >= 5 && String.sub basename 0 5 = "test_"
+  in
+  if not is_test_exec then ()
+  else
+    let allow =
+      match Sys.getenv_opt "MASC_TEST_ALLOW_HOME_BASE_PATH" with
+      | Some v ->
+          let v = String.lowercase_ascii (String.trim v) in
+          v = "1" || v = "true" || v = "yes"
+      | None -> false
+    in
+    if allow then ()
+    else
+      match Sys.getenv_opt "HOME" with
+      | None | Some "" -> ()
+      | Some home ->
+          let home_norm =
+            let trimmed = String.trim home in
+            let len = String.length trimmed in
+            if len > 1 && trimmed.[len - 1] = '/' then
+              String.sub trimmed 0 (len - 1)
+            else
+              trimmed
+          in
+          let home_len = String.length home_norm in
+          if home_len > 0
+             && String.length path >= home_len
+             && String.sub path 0 home_len = home_norm then
+            raise (Test_isolation_breach
+              (Printf.sprintf
+                 "#9921 %s blocked under HOME=%S (path=%S) in test executable %S. \
+                  MASC_BASE_PATH override did not apply — fix the test setup or \
+                  set MASC_TEST_ALLOW_HOME_BASE_PATH=1."
+                 op home_norm path
+                 (Filename.basename Sys.executable_name)))
+
 let with_fs_or_fallback ~path ~fallback f =
   match Atomic.get global_fs with
   | Some fs -> (
@@ -93,6 +154,7 @@ let load_file (path : string) : string =
     Eio-native when available, fallback to Unix.
     @raises Sys_error on all I/O failures. Eio.Io is normalized internally. *)
 let save_file (path : string) (content : string) : unit =
+  test_exec_home_guard ~op:"save_file" path;
   with_fs_or_fallback ~path ~fallback:(fun () -> save_file_unix path content) (fun fs ->
       let eio_path = Eio.Path.(fs / path) in
       Eio.Path.save ~create:(`Or_truncate 0o644) eio_path content)
@@ -133,6 +195,7 @@ let save_file_atomic (path : string) (content : string) : (unit, string) result 
     Eio-native when available, fallback to Unix.
     @raises Sys_error on all I/O failures. Eio.Io is normalized internally. *)
 let append_file (path : string) (content : string) : unit =
+  test_exec_home_guard ~op:"append_file" path;
   with_fs_or_fallback ~path ~fallback:(fun () -> append_file_unix path content) (fun fs ->
       let eio_path = Eio.Path.(fs / path) in
       Eio.Path.save ~append:true ~create:(`If_missing 0o644) eio_path content)
@@ -177,6 +240,7 @@ let realpath (path : string) : string =
 (** Create directory recursively if not exists.
     @raises Sys_error on all I/O failures. Eio.Io is normalized internally. *)
 let mkdir_p (path : string) : unit =
+  test_exec_home_guard ~op:"mkdir_p" path;
   with_fs_or_fallback ~path ~fallback:(fun () -> mkdir_p_unix path) (fun fs ->
       let eio_path = Eio.Path.(fs / path) in
       Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 eio_path)

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -3,6 +3,13 @@
     @since 2026-02 - Keeper Emergent Identity v2.0
 *)
 
+exception Test_isolation_breach of string
+(** #9921: raised by mutating [Fs_compat] entry points
+    ([append_file], [save_file], [mkdir_p]) when the target path falls
+    under [HOME] and the process is a test executable. Defense in depth
+    behind [Env_config_core.base_path_prod_guard]. Bypass with
+    [MASC_TEST_ALLOW_HOME_BASE_PATH=1]. *)
+
 val set_fs : Eio.Fs.dir_ty Eio.Path.t -> unit
 (** Set global Eio filesystem. Call at server startup. *)
 

--- a/test/dune
+++ b/test/dune
@@ -333,6 +333,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_fs_compat_home_guard)
+ (modules test_fs_compat_home_guard)
+ (libraries masc_test_deps))
+
+(test
  (name test_governance_cases_snapshot)
  (modules test_governance_cases_snapshot)
  (libraries masc_test_deps))

--- a/test/test_fs_compat_home_guard.ml
+++ b/test/test_fs_compat_home_guard.ml
@@ -1,0 +1,96 @@
+(* #9921: write-boundary guard complementing the #9903 path-resolution
+   guard.  If any code path bypasses [Env_config_core.base_path()] and
+   asks [Fs_compat] to write under HOME, the guard raises
+   [Fs_compat.Test_isolation_breach] so the test crashes loud instead
+   of silently corrupting the production ledger.  The real production
+   ledger was observed to hold 106 test-pattern voter rows
+   ([hot-voter-*], [flipper], [same-voter], [judge]) written before the
+   #9920 partial fix landed. *)
+
+module FC = Fs_compat
+
+let home () =
+  match Sys.getenv_opt "HOME" with
+  | Some h when h <> "" -> h
+  | _ -> Alcotest.fail "HOME unset — cannot exercise guard"
+
+let disable_escape_hatch () =
+  Unix.putenv "MASC_TEST_ALLOW_HOME_BASE_PATH" ""
+
+let test_append_under_home_raises () =
+  disable_escape_hatch ();
+  let path = Filename.concat (home ()) ".masc/_9921_guard_probe.jsonl" in
+  try
+    FC.append_file path "{\"probe\":1}\n";
+    Alcotest.failf "expected Test_isolation_breach, but write succeeded to %S" path
+  with FC.Test_isolation_breach msg ->
+    Alcotest.(check bool)
+      "message references #9921"
+      true
+      (let m = String.lowercase_ascii msg in
+       let needle = "#9921" in
+       let nlen = String.length needle in
+       let rec scan i =
+         if i + nlen > String.length m then false
+         else if String.sub m i nlen = needle then true
+         else scan (i + 1)
+       in scan 0)
+
+let test_save_under_home_raises () =
+  disable_escape_hatch ();
+  let path = Filename.concat (home ()) ".masc/_9921_guard_probe_save.txt" in
+  try
+    FC.save_file path "probe";
+    Alcotest.fail "expected Test_isolation_breach on save_file"
+  with FC.Test_isolation_breach _ -> ()
+
+let test_mkdir_under_home_raises () =
+  disable_escape_hatch ();
+  let path = Filename.concat (home ()) ".masc/_9921_guard_probe_dir" in
+  try
+    FC.mkdir_p path;
+    Alcotest.fail "expected Test_isolation_breach on mkdir_p"
+  with FC.Test_isolation_breach _ -> ()
+
+let test_tmp_write_allowed () =
+  disable_escape_hatch ();
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-9921-guard-allow-%d" (Unix.getpid ()))
+  in
+  FC.mkdir_p dir;
+  let path = Filename.concat dir "probe.txt" in
+  FC.append_file path "ok\n";
+  Alcotest.(check bool) "tmp write succeeded" true (Sys.file_exists path);
+  (* clean up *)
+  (try Sys.remove path with Sys_error _ -> ());
+  (try Unix.rmdir dir with Unix.Unix_error _ -> ())
+
+let test_escape_hatch_allows_home () =
+  Unix.putenv "MASC_TEST_ALLOW_HOME_BASE_PATH" "1";
+  let path = Filename.concat (home ()) ".masc/_9921_guard_probe_bypass.jsonl" in
+  (try
+    FC.append_file path "{\"bypass\":1}\n";
+    Alcotest.(check bool) "bypass write succeeded" true (Sys.file_exists path)
+  with FC.Test_isolation_breach msg ->
+    Alcotest.failf
+      "escape hatch should allow HOME write, got Test_isolation_breach: %s" msg);
+  (* clean up so we do not leave probe junk in the real ledger dir *)
+  (try Sys.remove path with Sys_error _ -> ());
+  Unix.putenv "MASC_TEST_ALLOW_HOME_BASE_PATH" ""
+
+let () =
+  Alcotest.run "fs_compat_home_guard" [
+    "guard", [
+      Alcotest.test_case "append under HOME raises" `Quick
+        test_append_under_home_raises;
+      Alcotest.test_case "save under HOME raises" `Quick
+        test_save_under_home_raises;
+      Alcotest.test_case "mkdir under HOME raises" `Quick
+        test_mkdir_under_home_raises;
+      Alcotest.test_case "tmp write allowed" `Quick
+        test_tmp_write_allowed;
+      Alcotest.test_case "escape hatch allows HOME" `Quick
+        test_escape_hatch_allows_home;
+    ];
+  ]


### PR DESCRIPTION
## 요약

`Fs_compat`의 write entry point(`append_file`/`save_file`/`mkdir_p`)에 **write-boundary HOME guard**를 추가. `Env_config_core.base_path_prod_guard`(PR #9920)가 path resolution 단계에서 HOME fallback을 막지만, 그걸 우회하는 코드 경로가 있을 경우를 위한 2차 안전망.

Closes #9921.

## 실측으로 뒤집힌 원인 분석

이슈 작성자는 `dune exec test/test_board_dispatch.exe` 실행 시 `~/me/.masc/board_votes.jsonl`의 mtime이 advance하고 count가 121행(106개가 test voter pattern)이라는 증거로 "테스트가 prod ledger에 쓰고 있다"고 진단했습니다.

**실측 결과**: mtime advance는 테스트와 무관. 주행 중인 MCP 서버가 범인이었습니다.

```bash
$ ps aux | grep main_eio
dancer  50199  ... main_eio.exe --host=127.0.0.1 --port=8935 --base-path=/Users/dancer/me

$ wc -l ~/me/.masc/board_votes.jsonl
121

$ jq -r '.voter' ~/me/.masc/board_votes.jsonl | awk -F'-' '{print $1"-"$2}' | sort | uniq -c
      2 analyst-
      1 anonymous-
      1 flipper-           ← test_board_dispatch.test_vote_flip
    101 hot-voter-         ← test_recent_sort_bypasses_hot_cutoff (101 iter)
      2 judge-             ← test_vote_post + test_vote_persisted_by_flusher_actor
      1 keeper-janitor
      2 masc-improver
     10 ramarama-
      1 same-voter         ← test_vote_dedup
```

- **121행 중 106개가 test voter**: `test_board_dispatch.ml`의 literal voter 이름과 1:1 매칭. pre-#9920 유출 잔재.
- **mtime 진동**: `lib/board_votes.ml:61` — `rewrite_vote_log`가 flush마다 모든 row의 `ts` field를 `Time_compat.now ()`로 덮어쓰기. 서버가 주기적으로 flush하면서 mtime만 갱신됨.

Guard 활성화 상태로 `test_board_dispatch` 27/27 pass. 현재 테스트 코드는 HOME에 쓰지 않습니다.

## 변경 내용

### `lib/fs_compat/fs_compat.ml`

```ocaml
exception Test_isolation_breach of string

let test_exec_home_guard ~op path =
  let basename =
    Sys.executable_name |> Filename.basename |> String.lowercase_ascii
  in
  let is_test_exec =
    String.length basename >= 5 && String.sub basename 0 5 = "test_"
  in
  if not is_test_exec then ()
  else
    let allow = (* MASC_TEST_ALLOW_HOME_BASE_PATH 체크 *) ... in
    if allow then ()
    else
      match Sys.getenv_opt "HOME" with
      | None | Some "" -> ()
      | Some home ->
          let home_norm = (* trailing slash strip *) ... in
          if home_norm 이 path의 prefix 면
            raise (Test_isolation_breach
              "#9921 {op} blocked under HOME=...")
```

Hook 포인트:
- `append_file`
- `save_file` (→ `save_file_atomic` 전이적 보호)
- `mkdir_p`

Read path(`load_file`, `file_exists`, `file_size`, `file_mtime`)는 guard 미적용 — observability 유지.

### 환경변수

| 변수 | 동작 |
|------|------|
| 기본 | 테스트 실행파일(`test_*`)이 HOME 하위 경로 쓰기 시도 → `Test_isolation_breach` raise |
| `MASC_TEST_ALLOW_HOME_BASE_PATH=1` / `true` / `yes` | 우회 — 기존 `#9920` resolution guard와 동일한 escape hatch |

## 테스트

`test/test_fs_compat_home_guard.ml` 5 scenario:

| 시나리오 | 기대 |
|---------|------|
| `append_file ~/me/.masc/...` | `Test_isolation_breach` |
| `save_file ~/me/.masc/...` | `Test_isolation_breach` |
| `mkdir_p ~/me/.masc/...` | `Test_isolation_breach` |
| `append_file /tmp/...` | 통과 |
| ALLOW=1 bypass → `append_file ~/me/...` | 통과 |

```bash
$ dune exec test/test_fs_compat_home_guard.exe
[OK]  guard  0  append under HOME raises.
[OK]  guard  1  save under HOME raises.
[OK]  guard  2  mkdir under HOME raises.
[OK]  guard  3  tmp write allowed.
[OK]  guard  4  escape hatch allows HOME.
Test Successful in 0.001s. 5 tests run.

$ dune exec test/test_board_dispatch.exe
Test Successful in 0.185s. 27 tests run.

$ dune exec test/test_base_path_prod_guard.exe
Test Successful in 0.001s. 3 tests run.
```

## 회귀 리스크

낮음. Guard는:
- Test 실행파일에서만 활성 (`Sys.executable_name` basename `test_*`)
- HOME-prefix path에 대해서만 fire
- Read path 건드리지 않음 (observability 유지)
- Escape hatch 존재

`save_file_atomic`는 내부에서 `save_file`을 호출하므로 자동 보호.

## 후속

- **Rewrite ts clobbering**: `lib/board_votes.ml:61`의 `rewrite_vote_log`가 `ts` field를 매 flush마다 `Time_compat.now()`로 덮어씀 → original vote timestamp 파괴. 데이터 무결성 이슈로 별건 track 예정.
- **Prod ledger cleanup**: 121행 중 106개 test-pattern 행은 #10079 (fixture quarantine default ON) 머지되면 read 시점에 자동 격리. 물리적 purge는 operator 수동 작업.

## 참고

- PR #9920 — Part 1 partial safeguard (path resolution guard)
- PR #10079 — fixture vote quarantine default ON (read-time defense)
- Issue #9921 — 이 PR의 대상
- Issue #9886 — 같은 근본 테마 (board dead surface)
