### PR TITLE
fix(board-votes): preserve original vote timestamp across rewrites (#10086)

### DIFF
--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -184,7 +184,11 @@ type flusher_msg =
 type store = {
   posts: (string, post) Hashtbl.t;
   comments: (string, comment) Hashtbl.t;
-  vote_log: (string, vote_direction) Hashtbl.t;
+  (* #10086: vote_log entry carries the original vote timestamp so
+     [rewrite_vote_log] can persist it without overwriting with
+     [Time_compat.now ()] on every flush.  Legacy rows that lack [ts]
+     load with a fallback timestamp — see [load_persisted_votes]. *)
+  vote_log: (string, vote_direction * float) Hashtbl.t;
   post_count: int ref;
   mutable last_sweep: float;
   mutex: Eio.Mutex.t;

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -25,7 +25,11 @@ let vote_log_path () =
   let base = board_base_path () in
   Filename.concat base ".masc/board_votes.jsonl"
 
-let append_vote_log ~target ~voter ~direction =
+(* #10086: [~ts] is the vote's original timestamp.  [append_vote_log]
+   writes it verbatim; [rewrite_vote_log] preserves the value stored
+   in [store.vote_log] instead of clobbering with [Time_compat.now ()]
+   on every flush. *)
+let append_vote_log ~target ~voter ~direction ~ts =
   try
     ensure_masc_dir ();
     let path = vote_log_path () in
@@ -33,7 +37,7 @@ let append_vote_log ~target ~voter ~direction =
       ("target", `String target);
       ("voter", `String voter);
       ("direction", `String (vote_direction_to_string direction));
-      ("ts", `Float (Time_compat.now ()));
+      ("ts", `Float ts);
     ] in
     Fs_compat.append_file path (Yojson.Safe.to_string json ^ "\n");
     rotate_if_needed path
@@ -45,7 +49,7 @@ let rewrite_vote_log store =
     let path = vote_log_path () in
     let buf = Buffer.create 4096 in
     Hashtbl.iter
-      (fun target direction ->
+      (fun target (direction, ts) ->
         let voter =
           match String.rindex_opt target ':' with
           | Some idx when idx + 1 < String.length target ->
@@ -58,7 +62,7 @@ let rewrite_vote_log store =
               ("target", `String target);
               ("voter", `String voter);
               ("direction", `String (vote_direction_to_string direction));
-              ("ts", `Float (Time_compat.now ()));
+              ("ts", `Float ts);
             ]
         in
         Buffer.add_string buf (Yojson.Safe.to_string json ^ "\n"))
@@ -93,10 +97,10 @@ let vote store ~voter ~post_id ~direction : (int, board_error) result =
               let vote_key = "post:" ^ Post_id.to_string pid ^ ":" ^ voter in
               let now = Time_compat.now () in
               match Hashtbl.find_opt store.vote_log vote_key with
-              | Some prev when prev = direction ->
+              | Some (prev, _prev_ts) when prev = direction ->
                   Error (Already_voted (Printf.sprintf "%s already voted %s on %s"
                     voter (vote_direction_to_string direction) post_id))
-              | Some _opposite ->
+              | Some (_opposite, _prev_ts) ->
                   let flipped = match direction with
                     | Up -> { post with votes_up = post.votes_up + 1;
                                         votes_down = max 0 (post.votes_down - 1);
@@ -106,10 +110,10 @@ let vote store ~voter ~post_id ~direction : (int, board_error) result =
                                           updated_at = now }
                   in
                   Hashtbl.replace store.posts (Post_id.to_string pid) flipped;
-                  Hashtbl.replace store.vote_log vote_key direction;
+                  Hashtbl.replace store.vote_log vote_key (direction, now);
                   store.dirty_posts <- true;  (* Deferred flush *)
                   invalidate_post_caches store;
-                  append_vote_log ~target:vote_key ~voter ~direction;
+                  append_vote_log ~target:vote_key ~voter ~direction ~ts:now;
                   (* Record vote for Thompson Sampling feedback *)
                   let author_name = Agent_id.to_string post.author in
                   let vote_dir = match direction with Up -> `Up | Down -> `Down in
@@ -123,10 +127,10 @@ let vote store ~voter ~post_id ~direction : (int, board_error) result =
                     | Down -> { post with votes_down = post.votes_down + 1; updated_at = now }
                   in
                   Hashtbl.replace store.posts (Post_id.to_string pid) updated;
-                  Hashtbl.replace store.vote_log vote_key direction;
+                  Hashtbl.replace store.vote_log vote_key (direction, now);
                   store.dirty_posts <- true;  (* Deferred flush *)
                   invalidate_post_caches store;
-                  append_vote_log ~target:vote_key ~voter ~direction;
+                  append_vote_log ~target:vote_key ~voter ~direction ~ts:now;
                   (* Record vote for Thompson Sampling feedback *)
                   let author_name = Agent_id.to_string post.author in
                   let vote_dir = match direction with Up -> `Up | Down -> `Down in
@@ -167,11 +171,12 @@ let vote_comment store ~voter ~comment_id ~direction : (int, board_error) result
         | None -> Error (Comment_not_found comment_id)
         | Some cmt ->
             let vote_key = "comment:" ^ Comment_id.to_string cid ^ ":" ^ voter in
+            let now = Time_compat.now () in
             match Hashtbl.find_opt store.vote_log vote_key with
-            | Some prev when prev = direction ->
+            | Some (prev, _prev_ts) when prev = direction ->
                 Error (Already_voted (Printf.sprintf "%s already voted %s on comment %s"
                   voter (vote_direction_to_string direction) comment_id))
-            | Some _opposite ->
+            | Some (_opposite, _prev_ts) ->
                 let flipped = match direction with
                   | Up -> { cmt with votes_up = cmt.votes_up + 1;
                                      votes_down = max 0 (cmt.votes_down - 1) }
@@ -179,10 +184,10 @@ let vote_comment store ~voter ~comment_id ~direction : (int, board_error) result
                                        votes_up = max 0 (cmt.votes_up - 1) }
                 in
                 Hashtbl.replace store.comments (Comment_id.to_string cid) flipped;
-                Hashtbl.replace store.vote_log vote_key direction;
+                Hashtbl.replace store.vote_log vote_key (direction, now);
                 store.dirty_comments <- true;  (* Deferred flush *)
                 invalidate_comment_caches store;
-                append_vote_log ~target:vote_key ~voter ~direction;
+                append_vote_log ~target:vote_key ~voter ~direction ~ts:now;
                 (* Record vote for Thompson Sampling feedback *)
                 let author_name = Agent_id.to_string cmt.author in
                 let vote_dir = match direction with Up -> `Up | Down -> `Down in
@@ -194,10 +199,10 @@ let vote_comment store ~voter ~comment_id ~direction : (int, board_error) result
                   | Down -> { cmt with votes_down = cmt.votes_down + 1 }
                 in
                 Hashtbl.replace store.comments (Comment_id.to_string cid) updated;
-                Hashtbl.replace store.vote_log vote_key direction;
+                Hashtbl.replace store.vote_log vote_key (direction, now);
                 store.dirty_comments <- true;  (* Deferred flush *)
                 invalidate_comment_caches store;
-                append_vote_log ~target:vote_key ~voter ~direction;
+                append_vote_log ~target:vote_key ~voter ~direction ~ts:now;
                 (* Record vote for Thompson Sampling feedback *)
                 let author_name = Agent_id.to_string cmt.author in
                 let vote_dir = match direction with Up -> `Up | Down -> `Down in
@@ -444,20 +449,29 @@ let load_persisted_votes store =
       let fixture_detected = ref 0 in
       let quarantine = quarantine_enabled () in
       let lines = Fs_compat.load_jsonl path in
+      let load_fallback_ts = Time_compat.now () in
       List.iter (fun json ->
         match Safe_ops.json_string_opt "target" json,
               Safe_ops.json_string_opt "direction" json with
         | Some target, Some dir_str ->
           let direction = if dir_str = "down" then Down else Up in
+          (* #10086: preserve original vote ts when present.  Legacy
+             rows missing [ts] get a load-time fallback — lossy but
+             stable across further flushes (the entry keeps whatever
+             it was assigned at first load). *)
+          let ts =
+            Safe_ops.json_float_opt "ts" json
+            |> Option.value ~default:load_fallback_ts
+          in
           if is_fixture_voter_target target then begin
             incr fixture_detected;
             if quarantine then incr quarantined
             else begin
-              Hashtbl.replace store.vote_log target direction;
+              Hashtbl.replace store.vote_log target (direction, ts);
               incr loaded
             end
           end else begin
-            Hashtbl.replace store.vote_log target direction;
+            Hashtbl.replace store.vote_log target (direction, ts);
             incr loaded
           end
         | _ -> ()

--- a/test/dune
+++ b/test/dune
@@ -324,6 +324,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_board_vote_ts_preservation)
+ (modules test_board_vote_ts_preservation)
+ (libraries masc_test_deps))
+
+(test
  (name test_governance_cases_snapshot)
  (modules test_governance_cases_snapshot)
  (libraries masc_test_deps))

--- a/test/test_board_vote_ts_preservation.ml
+++ b/test/test_board_vote_ts_preservation.ml
@@ -1,0 +1,124 @@
+(* #10086: [rewrite_vote_log] must preserve the original vote
+   timestamp, not overwrite with [Time_compat.now ()] on every
+   flush.  The prior bug caused every [ts] in [board_votes.jsonl]
+   to advance on each flush cycle, destroying the information that
+   downstream analytics (vote velocity, recency scoring) depend on. *)
+
+open Masc_mcp
+
+let () = Mirage_crypto_rng_unix.use_default ()
+
+let setup_base_path () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-10086-vote-ts-%d-%06x"
+         (Unix.getpid ()) (Random.bits ()))
+  in
+  Unix.putenv "MASC_BASE_PATH" dir;
+  dir
+
+let read_ts_map path =
+  let lines = Fs_compat.load_jsonl path in
+  List.filter_map (fun json ->
+    match
+      Safe_ops.json_string_opt "target" json,
+      Safe_ops.json_float_opt "ts" json
+    with
+    | Some target, Some ts -> Some (target, ts)
+    | _ -> None) lines
+
+(** Cast a vote, rewrite, cast a different vote, rewrite again.
+    The first vote's [ts] must remain unchanged across the second
+    rewrite cycle. *)
+let test_ts_stable_across_rewrites () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  ignore (setup_base_path ());
+  Board.reset_global_for_test ();
+  Board_dispatch.reset_for_test ();
+  Board_dispatch.init_jsonl ();
+  let post_id =
+    match
+      Board_dispatch.create_post ~author:"ts-author"
+        ~content:"ts preservation test" ~post_kind:Board.Human_post ()
+    with
+    | Ok p -> Board.Post_id.to_string p.id
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  (match Board_dispatch.vote
+           ~voter:"ts-voter-1" ~post_id ~direction:Board.Up with
+   | Ok _ -> ()
+   | Error e -> Alcotest.fail (Board.show_board_error e));
+  Board_dispatch.flush ();
+  let path = Board.vote_log_path () in
+  let ts1_map = read_ts_map path in
+  let target_key = "post:" ^ post_id ^ ":ts-voter-1" in
+  let ts1 =
+    match List.assoc_opt target_key ts1_map with
+    | Some ts -> ts
+    | None -> Alcotest.failf "expected target %S in ledger" target_key
+  in
+  (* Add a second vote from a different voter and rewrite again. *)
+  Unix.sleep 1;  (* ensure wall-clock advances so a bug would be detectable *)
+  (match Board_dispatch.vote
+           ~voter:"ts-voter-2" ~post_id ~direction:Board.Up with
+   | Ok _ -> ()
+   | Error e -> Alcotest.fail (Board.show_board_error e));
+  Board_dispatch.flush ();
+  let ts2_map = read_ts_map path in
+  let ts1_after =
+    match List.assoc_opt target_key ts2_map with
+    | Some ts -> ts
+    | None -> Alcotest.failf "target %S disappeared after rewrite" target_key
+  in
+  Alcotest.(check (float 1e-9))
+    "first vote ts unchanged across rewrite"
+    ts1 ts1_after
+
+(** Legacy rows lacking [ts] get a stable load-time fallback — not a
+    fresh-per-rewrite [now ()].  Verifies the fallback is captured
+    once at load, then preserved like any other [ts]. *)
+let test_ts_fallback_stable_for_legacy_rows () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = setup_base_path () in
+  Fs_compat.mkdir_p (Filename.concat dir ".masc");
+  let path = Filename.concat dir ".masc/board_votes.jsonl" in
+  (* Legacy row: no [ts] field. *)
+  Fs_compat.append_file path
+    "{\"target\":\"post:p-legacy:legacy-voter\",\
+      \"voter\":\"legacy-voter\",\"direction\":\"up\"}\n";
+  Board.reset_global_for_test ();
+  Board_dispatch.reset_for_test ();
+  Board_dispatch.init_jsonl ();
+  Board_dispatch.flush ();
+  let map1 = read_ts_map path in
+  let ts_legacy =
+    match List.assoc_opt "post:p-legacy:legacy-voter" map1 with
+    | Some ts -> ts
+    | None -> Alcotest.fail "legacy row dropped at load"
+  in
+  Alcotest.(check bool) "legacy got a fallback ts" true (ts_legacy > 0.);
+  (* Second flush must not re-stamp the legacy row. *)
+  Unix.sleep 1;
+  Board_dispatch.flush ();
+  let map2 = read_ts_map path in
+  let ts_after =
+    match List.assoc_opt "post:p-legacy:legacy-voter" map2 with
+    | Some ts -> ts
+    | None -> Alcotest.fail "legacy row dropped after rewrite"
+  in
+  Alcotest.(check (float 1e-9))
+    "legacy fallback ts stable across rewrite"
+    ts_legacy ts_after
+
+let () =
+  Random.self_init ();
+  Alcotest.run "board_vote_ts_preservation" [
+    "rewrite", [
+      Alcotest.test_case "ts stable across rewrites" `Slow
+        test_ts_stable_across_rewrites;
+      Alcotest.test_case "legacy fallback ts stable" `Slow
+        test_ts_fallback_stable_for_legacy_rows;
+    ];
+  ]


### PR DESCRIPTION
## 요약

`rewrite_vote_log`이 flush마다 모든 row의 `ts` 필드를 `Time_compat.now ()`로 덮어쓰던 데이터 무결성 버그를 수정. `store.vote_log` value를 `vote_direction` → `(vote_direction * float)`으로 확장해 original 타임스탬프를 보존.

Closes #10086.

## 근본 원인

```ocaml
(* lib/board_votes.ml:42-69 (before) *)
let rewrite_vote_log store =
  ...
  Hashtbl.iter
    (fun target direction ->              (* ← ts 정보 없음 *)
      let json =
        `Assoc
          [
            ...
            ("ts", `Float (Time_compat.now ()));  (* ← 매 flush마다 갱신 *)
          ] in
      ...)
    store.vote_log;
```

`store.vote_log: (string, vote_direction) Hashtbl.t` — value가 방향뿐이라 rewrite 시 원본 ts 정보가 없음. 매 flush마다 `now ()` 찍고 덮어쓰기.

영향:
- `board_votes.jsonl`의 `ts`가 "마지막 flush 시각"을 기록. "투표 시각"이 아님.
- vote velocity, recency scoring, age 기반 hot ranking 전부 가짜 타임스탬프로 동작.
- **#9921의 잘못된 진단 원인**: 작성자가 "테스트가 prod ledger에 쓴다"고 본 mtime advance 증상은 실제로 주행 중인 MCP 서버의 flush cycle이 같은 row들을 새 ts로 rewrite하는 현상이었음.

## 변경 내용

### 타입 확장

```diff
  (* lib/board_types/board_types.ml *)
- vote_log: (string, vote_direction) Hashtbl.t;
+ (* #10086: entry carries original timestamp so rewrite preserves it. *)
+ vote_log: (string, vote_direction * float) Hashtbl.t;
```

### append_vote_log — 명시적 ts 인자

```diff
- let append_vote_log ~target ~voter ~direction =
+ let append_vote_log ~target ~voter ~direction ~ts =
    ...
-   ("ts", `Float (Time_compat.now ()));
+   ("ts", `Float ts);
```

### rewrite_vote_log — 저장된 ts 사용

```diff
- Hashtbl.iter (fun target direction ->
+ Hashtbl.iter (fun target (direction, ts) ->
    ...
-   ("ts", `Float (Time_compat.now ()));
+   ("ts", `Float ts);
```

### vote / vote_comment — 호출 시 now() 캡처하여 tuple 저장

```diff
- Hashtbl.replace store.vote_log vote_key direction;
+ Hashtbl.replace store.vote_log vote_key (direction, now);
- append_vote_log ~target:vote_key ~voter ~direction;
+ append_vote_log ~target:vote_key ~voter ~direction ~ts:now;
```

### load_persisted_votes — legacy row fallback

```ocaml
let load_fallback_ts = Time_compat.now () in   (* load 시점 단일 값 *)
...
let ts =
  Safe_ops.json_float_opt "ts" json
  |> Option.value ~default:load_fallback_ts
in
Hashtbl.replace store.vote_log target (direction, ts);
```

`ts` 없는 legacy row는 load 시점의 단일 `now()`값으로 fallback. Lossy하지만 이후 flush에서 stable — 한 번 찍힌 fallback이 그대로 persist.

## 동작

| 상황 | Before | After |
|------|--------|-------|
| 투표 후 1차 flush의 `ts` | `vote 시각` ✓ | `vote 시각` ✓ |
| 투표 후 10초 뒤 2차 flush (다른 유저 투표 triggered) | **`2차 flush 시각`** (파괴) | `원래 vote 시각` 유지 |
| `ts` 없는 legacy row load | 어떤 ts도 기록 안 됨 | load 시 단일 `now()` fallback, 이후 stable |

## 테스트

`test/test_board_vote_ts_preservation.ml` 2 scenario:

1. **ts stable across rewrites**: vote → flush → wait 1s → second vote → flush. 첫 vote의 `ts`가 rewrite 후에도 동일해야 함.
2. **legacy fallback stable**: `ts` 없는 row를 직접 append → init → flush → wait 1s → flush. 두 flush 사이에 legacy row의 fallback ts가 변하지 않아야 함.

```bash
$ dune exec test/test_board_vote_ts_preservation.exe
[OK]  rewrite  0  ts stable across rewrites.
[OK]  rewrite  1  legacy fallback ts stable.
Test Successful in 2.050s. 2 tests run.
```

Regression:
```bash
$ dune exec test/test_board_dispatch.exe
Test Successful in 0.794s. 27 tests run.
$ dune exec test/test_board_fixture_detector.exe
Test Successful in 0.006s. 7 tests run.
```

## 회귀 리스크

낮음. 변경은 데이터 타입 확장(backward-compatible load 포함) + 10개 내부 call site. External consumer 없음(lib/test 전체 grep 확인). Legacy row는 fallback으로 load 가능, 이후 stable하게 유지됨.

## 후속

- **Downstream analytics reset**: 기존 ledger의 모든 `ts`는 누적 flush로 오염되어 있음. History-dependent 분석(vote velocity 등)은 이번 PR 머지 후 첫 24h 데이터만 신뢰. Historical data 복구는 불가.
- **#9921**: 같은 조사 세션에서 발견된 write-boundary HOME guard (PR #10085)와 함께 본 PR이 board-path-leak 이슈군의 종결부.

## 참고

- Issue #10086 — 이 PR
- PR #10085 — `Fs_compat` write-boundary HOME guard (#9921)
- PR #10079 — fixture voter quarantine default ON (#9886)
- `lib/board_types/board_types.ml:184-199` — store record
- `lib/board_votes.ml:28-69` — append/rewrite
- `lib/board_votes.ml:443-470` — load_persisted_votes
