### PR TITLE
refactor(keeper-config): hoist 1M context ceiling to SSOT constant (#9953)

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -23,6 +23,13 @@ let tool_use_strict_cascade_name = "tool_use_strict"
     to 65,536, which can exceed the discovered provider ceiling. *)
 let min_keeper_context_tokens = 64_000
 
+(** Maximum context window (tokens) accepted for [max_context_override] on
+    keeper turn-up args (#9953).  Matches the largest published context
+    window among supported providers (Claude Opus 4.7 / Sonnet 4.6 = 1M).
+    Bumps to a 2M-class model must update this constant alongside the
+    provider registry entry. *)
+let max_keeper_context_tokens = 1_000_000
+
 (* ── Alert preview truncation lengths ─────────────────────── *)
 (* Invariant: excerpt_min < message_max < reply_max.
    Violating this makes the min/max logic in keeper_alerting.ml degenerate. *)

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -26,6 +26,12 @@ val tool_use_strict_cascade_name : string
 (** Minimum context window (tokens) for any keeper turn. *)
 val min_keeper_context_tokens : int
 
+(** Maximum context window (tokens) accepted for [max_context_override].
+    Matches the largest published context window among supported
+    providers (Claude Opus 4.7 / Sonnet 4.6 = 1M).  #9953 SSOT — do not
+    re-hardcode [1_000_000] elsewhere. *)
+val max_keeper_context_tokens : int
+
 (** {2 Alert Preview Truncation Lengths}
 
     Invariant: [excerpt_min < message_max < reply_max]. *)

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -240,17 +240,20 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let mention_targets_in = get_string_list args "mention_targets" in
     let max_context_override_opt =
       let min_keeper_context = Keeper_config.min_keeper_context_tokens in
+      let max_keeper_context = Keeper_config.max_keeper_context_tokens in
       match Safe_ops.json_int_opt "max_context_override" args with
       | None -> None
-      | Some v when v >= min_keeper_context && v <= 1_000_000 -> Some v
+      | Some v when v >= min_keeper_context && v <= max_keeper_context ->
+          Some v
       | Some v when v > 0 && v < min_keeper_context ->
           Log.Misc.warn
             "max_context_override=%d below minimum %d, clamped to %d"
             v min_keeper_context min_keeper_context;
           Some min_keeper_context
       | Some v ->
-          Log.Misc.warn "max_context_override=%d out of range (%d..1000000), ignored"
-            v min_keeper_context;
+          Log.Misc.warn
+            "max_context_override=%d out of range (%d..%d), ignored"
+            v min_keeper_context max_keeper_context;
           None
     in
     let proactive_enabled_opt = get_bool_opt args "proactive_enabled" in

--- a/test/dune
+++ b/test/dune
@@ -324,6 +324,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_keeper_context_bounds_ssot)
+ (modules test_keeper_context_bounds_ssot)
+ (libraries masc_test_deps))
+
+(test
  (name test_governance_cases_snapshot)
  (modules test_governance_cases_snapshot)
  (libraries masc_test_deps))

--- a/test/test_keeper_context_bounds_ssot.ml
+++ b/test/test_keeper_context_bounds_ssot.ml
@@ -1,0 +1,32 @@
+(* #9953: pin the SSOT context-window bounds so a regression that
+   re-introduces a local [1_000_000] literal (or changes the ceiling
+   inconsistently with the provider registry) is caught at test time.
+
+   [min_keeper_context_tokens] / [max_keeper_context_tokens] are the
+   only constants allowed to name these values.  [keeper_turn_up_args]
+   must thread both through [Keeper_config]; new code that builds
+   context caps must do the same. *)
+
+module KC = Masc_mcp.Keeper_config
+
+let test_min_matches_64k () =
+  Alcotest.(check int) "min keeper context tokens" 64_000
+    KC.min_keeper_context_tokens
+
+let test_max_matches_1m () =
+  Alcotest.(check int) "max keeper context tokens" 1_000_000
+    KC.max_keeper_context_tokens
+
+let test_min_below_max () =
+  Alcotest.(check bool)
+    "min < max (otherwise the override band collapses)"
+    true (KC.min_keeper_context_tokens < KC.max_keeper_context_tokens)
+
+let () =
+  Alcotest.run "keeper_context_bounds_ssot" [
+    "bounds", [
+      Alcotest.test_case "min is 64k" `Quick test_min_matches_64k;
+      Alcotest.test_case "max is 1M" `Quick test_max_matches_1m;
+      Alcotest.test_case "min < max" `Quick test_min_below_max;
+    ];
+  ]


### PR DESCRIPTION
## 요약

`keeper_turn_up_args.ml`에 2회 하드코드된 `1_000_000` context ceiling을 `Keeper_config.max_keeper_context_tokens` SSOT 상수로 승격. 향후 모델 업그레이드(Opus 4.8 2M context 등) 시 한 줄 수정으로 전파되도록 전환.

Closes **일부** #9953 (literal consolidation 항목).

## 스코프 정직성

이슈 #9953은 **세 가지 별개 문제**를 하나로 묶어 기술:

| 현상 | 성격 | 본 PR 스코프 |
|------|------|-------------|
| metric에서 `claude_code:auto`의 `context_max`가 64k/262k/1M 3-way drift | **label resolution + provider routing** | ❌ 별건 |
| `keeper_turn_up_args.ml:245,252`의 bare `1_000_000` literal 2회 | **SSOT 위생** | ✅ 본 PR |
| `oas_worker_exec_transport.ml:394`의 `262144` (Kimi CLI max_context_size) | **Kimi 고유 ceiling** | ❌ provider-specific, 통합 대상 아님 |
| `keeper_config.ml:739-740` `max_v:262144` | **max_output_tokens(output)** — context window 아님 | ❌ 다른 축 |

즉 `keeper_turn_up_args.ml`의 2개 literal만 SSOT로 뺌. 나머지는 각자 고유 의미를 갖는 값이라 무조건 통합하는 건 잘못된 refactor. Metric drift의 근본 원인(`claude_code:auto` label이 turn마다 다른 provider로 resolve)은 provider registry + metric 기록부 리팩터링 필요 — 별건.

## 변경 내용

### `lib/keeper/keeper_config.ml` + `.mli`

```diff
  let min_keeper_context_tokens = 64_000

+ (** Maximum context window (tokens) accepted for [max_context_override] on
+     keeper turn-up args (#9953).  Matches the largest published context
+     window among supported providers (Claude Opus 4.7 / Sonnet 4.6 = 1M).
+     Bumps to a 2M-class model must update this constant alongside the
+     provider registry entry. *)
+ let max_keeper_context_tokens = 1_000_000
```

### `lib/keeper/keeper_turn_up_args.ml`

```diff
  let max_context_override_opt =
    let min_keeper_context = Keeper_config.min_keeper_context_tokens in
+   let max_keeper_context = Keeper_config.max_keeper_context_tokens in
    match Safe_ops.json_int_opt "max_context_override" args with
    | None -> None
-   | Some v when v >= min_keeper_context && v <= 1_000_000 -> Some v
+   | Some v when v >= min_keeper_context && v <= max_keeper_context ->
+       Some v
    | Some v when v > 0 && v < min_keeper_context -> ...
    | Some v ->
-       Log.Misc.warn "max_context_override=%d out of range (%d..1000000), ignored"
-         v min_keeper_context;
+       Log.Misc.warn
+         "max_context_override=%d out of range (%d..%d), ignored"
+         v min_keeper_context max_keeper_context;
```

## 테스트

`test/test_keeper_context_bounds_ssot.ml` 3 scenario:

```bash
$ dune exec test/test_keeper_context_bounds_ssot.exe
[OK]  bounds  0  min is 64k.
[OK]  bounds  1  max is 1M.
[OK]  bounds  2  min < max.
Test Successful in 0.001s. 3 tests run.
```

Ratchet 역할:
- `1_000_000`을 다른 keeper 코드에 다시 하드코드하려는 회귀를 catch할 수 없지만,
- 상수 자체가 silently 바뀌거나 `min >= max`가 되면 (override band 붕괴) fail.

## 회귀 리스크

매우 낮음. Pure identity refactor — 값 그대로, 이름만 부여. Build clean, `test_keeper_cli_mcp_config` + 3/3 신규 테스트 pass.

## 후속 (별도 PR 필요)

1. **`claude_code:auto` label resolution 추적**: metric `AfterTurn`에 `resolved_model_id` 필드 추가. 어떤 provider로 routing됐는지 turn 단위 기록. (이슈 #9953 proposal 4)
2. **context_max source 태깅**: metric에 `context_max_source` 필드 — registry / cascade_override / turn_override / default 중 어디서 나왔는지. (proposal 3)
3. **Kimi CLI max_context_size 262144 → provider entry 참조**: `oas_worker_exec_transport.ml:394` literal을 `Provider_registry.find`로 전환. (proposal 1 부분)

각자 metric recording 경로/provider registry 경로 개편이 필요해 별건 트래킹.

## 참고

- Issue #9953 — 이 PR이 literal consolidation 부분만 처리
- `lib/keeper/keeper_config.ml:24-32` — SSOT 상수
- `lib/keeper/keeper_turn_up_args.ml:241-256` — 소비자
- `memory/feedback_context-floor-64k.md` — 64k min 근거
