### PR TITLE
fix(heuristic-metrics): scrub legacy degenerate rows at init (#9919)

### DIFF
--- a/lib/heuristic_metrics.ml
+++ b/lib/heuristic_metrics.ml
@@ -125,6 +125,82 @@ let do_flush () =
           Queue.clear buffer
     end
 
+(* #9919: the pre-fix emit at [keeper_hooks_oas.post_tool_use_failure]
+   produced an exact tuple [(site="post_tool_use_failure", raw=1.0,
+   threshold=0.0, triggered=true)] that carried no diagnostic signal
+   (51 identical rows observed in 48h of production).  The live
+   emitter is now a Prometheus counter; this scrub clears the legacy
+   residue so boot-time diagnostics and external readers (dashboards,
+   governance judgments) stop getting a false-positive degenerate
+   site warning for data that is no longer produced. *)
+let is_known_degenerate (json : Yojson.Safe.t) : bool =
+  match json with
+  | `Assoc fields ->
+      let get k =
+        match List.assoc_opt k fields with Some v -> Some v | None -> None
+      in
+      (match get "site", get "raw_value", get "threshold", get "triggered" with
+       | Some (`String "post_tool_use_failure"),
+         Some (`Float 1.0 | `Int 1),
+         Some (`Float 0.0 | `Int 0),
+         Some (`Bool true) -> true
+       | _ -> false)
+  | _ -> false
+
+let scrub_legacy_degenerate_rows path =
+  if not (Sys.file_exists path) then 0
+  else
+    match Safe_ops.read_file_safe path with
+    | Error msg ->
+        Log.warn ~ctx:"heuristic_metrics"
+          "#9919 scrub skipped — read failed: %s" msg;
+        0
+    | Ok content ->
+        let lines =
+          String.split_on_char '\n' content
+          |> List.filter (fun l -> String.length (String.trim l) > 0)
+        in
+        let kept, dropped =
+          List.partition
+            (fun line ->
+              match Yojson.Safe.from_string line with
+              | json -> not (is_known_degenerate json)
+              | exception Yojson.Json_error _ ->
+                  (* Keep malformed lines — let the existing
+                     diagnostics path log them. *)
+                  true)
+            lines
+        in
+        let ndrop = List.length dropped in
+        if ndrop = 0 then 0
+        else begin
+          (* Rewrite the file with the kept rows only.  Use atomic
+             rename to avoid tearing the file if the process is
+             interrupted during init. *)
+          let tmp = path ^ ".9919-scrub.tmp" in
+          (try
+             let oc =
+               open_out_gen [Open_wronly; Open_creat; Open_trunc] 0o644 tmp
+             in
+             Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+               List.iter (fun line ->
+                 output_string oc line;
+                 output_char oc '\n') kept);
+             Sys.rename tmp path;
+             Log.Server.info
+               "#9919 scrubbed %d legacy degenerate rows from %s \
+                (pattern: post_tool_use_failure raw=1.0 threshold=0.0 \
+                triggered=true) — emitter has migrated to Prometheus \
+                counter [masc_keeper_tool_use_failure_total]"
+               ndrop path;
+             ndrop
+           with Sys_error msg ->
+             Log.warn ~ctx:"heuristic_metrics"
+               "#9919 scrub skipped — write failed: %s" msg;
+             (try Sys.remove tmp with Sys_error _ -> ());
+             0)
+        end
+
 let init ~base_path =
   Stdlib.Mutex.protect mu (fun () ->
     match !store_path_ref with
@@ -132,6 +208,7 @@ let init ~base_path =
     | None ->
       let masc_dir = Coord_utils.masc_dir_from_base_path ~base_path in
       let path = Filename.concat masc_dir "heuristic_metrics.jsonl" in
+      let _ = scrub_legacy_degenerate_rows path in
       store_path_ref := Some path)
 
 let record (e : event) =

--- a/lib/heuristic_metrics.mli
+++ b/lib/heuristic_metrics.mli
@@ -50,7 +50,17 @@ val record : event -> unit
 
 val init : base_path:string -> unit
 (** Initialize the JSONL store under [base_path/.masc/heuristic_metrics.jsonl].
-    Idempotent; second call is a no-op. *)
+    Idempotent; second call is a no-op.  Also runs a one-time
+    {!scrub_legacy_degenerate_rows} against the existing file to clear
+    the #9919 legacy degenerate signature. *)
+
+val scrub_legacy_degenerate_rows : string -> int
+(** Filter out rows matching the #9919 legacy degenerate signature
+    (site=post_tool_use_failure, raw_value=1.0, threshold=0.0,
+    triggered=true) from the JSONL file at [path] in-place.  Returns
+    the number of rows dropped.  Returns [0] without writing the file
+    when no rows match, preserving mtime.  Exposed for test coverage
+    and for operators who want to run a manual scrub. *)
 
 val flush : unit -> unit
 (** Force flush pending writes (useful in tests). *)

--- a/test/dune
+++ b/test/dune
@@ -343,6 +343,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_heuristic_metrics_scrub)
+ (modules test_heuristic_metrics_scrub)
+ (libraries masc_test_deps))
+
+(test
  (name test_governance_cases_snapshot)
  (modules test_governance_cases_snapshot)
  (libraries masc_test_deps))

--- a/test/test_heuristic_metrics_scrub.ml
+++ b/test/test_heuristic_metrics_scrub.ml
@@ -1,0 +1,132 @@
+(* #9919: verify init-time scrub drops legacy degenerate rows
+   matching the exact signature diagnosed in the issue
+   (site=post_tool_use_failure, raw=1.0, threshold=0.0, triggered=true)
+   and preserves every other row — including near-misses that differ
+   in any single field. *)
+
+module HM = Masc_mcp.Heuristic_metrics
+
+let make_row ~site ~raw ~threshold ~triggered =
+  Printf.sprintf
+    "{\"site\":%S,\"module\":\"m\",\"raw_value\":%.6f,\"threshold\":%.6f,\
+     \"triggered\":%b,\"timestamp\":1.0,\
+     \"provenance\":{\"type\":\"pipeline_stage\",\"detail\":\"d\"}}"
+    site raw threshold triggered
+
+let mk_temp_file contents =
+  let path =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "9919-scrub-%d-%06x.jsonl"
+         (Unix.getpid ()) (Random.bits ()))
+  in
+  let oc = open_out path in
+  output_string oc contents;
+  close_out oc;
+  path
+
+let read_lines path =
+  let ic = open_in path in
+  let rec loop acc =
+    match input_line ic with
+    | line -> loop (line :: acc)
+    | exception End_of_file ->
+        close_in ic;
+        List.rev acc
+  in
+  loop []
+
+let degenerate =
+  make_row ~site:"post_tool_use_failure"
+    ~raw:1.0 ~threshold:0.0 ~triggered:true
+
+let test_drops_exact_degenerate_signature () =
+  let contents = degenerate ^ "\n" ^ degenerate ^ "\n" in
+  let path = mk_temp_file contents in
+  Fun.protect ~finally:(fun () ->
+    try Sys.remove path with Sys_error _ -> ())
+    (fun () ->
+      let dropped = HM.scrub_legacy_degenerate_rows path in
+      Alcotest.(check int) "both rows dropped" 2 dropped;
+      Alcotest.(check int) "file empty after scrub" 0
+        (List.length (read_lines path)))
+
+let test_preserves_same_site_different_value () =
+  (* Same site but raw ≠ 1.0 — real data, not the degenerate tuple. *)
+  let live_row =
+    make_row ~site:"post_tool_use_failure"
+      ~raw:0.5 ~threshold:0.0 ~triggered:true
+  in
+  let contents = degenerate ^ "\n" ^ live_row ^ "\n" in
+  let path = mk_temp_file contents in
+  Fun.protect ~finally:(fun () ->
+    try Sys.remove path with Sys_error _ -> ())
+    (fun () ->
+      let dropped = HM.scrub_legacy_degenerate_rows path in
+      Alcotest.(check int) "only the degenerate row dropped" 1 dropped;
+      let remaining = read_lines path in
+      Alcotest.(check int) "one row kept" 1 (List.length remaining);
+      Alcotest.(check bool)
+        "kept row is the live data"
+        true
+        (List.hd remaining = live_row))
+
+let test_preserves_unrelated_sites () =
+  let rows =
+    String.concat "\n" [
+      make_row ~site:"drift_guard" ~raw:0.9 ~threshold:0.7 ~triggered:false;
+      make_row ~site:"keeper_alert_signal"
+        ~raw:0.3 ~threshold:0.5 ~triggered:false;
+      make_row ~site:"verify" ~raw:1.0 ~threshold:0.5 ~triggered:false;
+    ] ^ "\n"
+  in
+  let path = mk_temp_file rows in
+  Fun.protect ~finally:(fun () ->
+    try Sys.remove path with Sys_error _ -> ())
+    (fun () ->
+      let dropped = HM.scrub_legacy_degenerate_rows path in
+      Alcotest.(check int) "nothing dropped" 0 dropped;
+      Alcotest.(check int) "all three rows kept" 3
+        (List.length (read_lines path)))
+
+let test_no_rewrite_when_nothing_to_drop () =
+  (* When the file contains zero degenerate rows, the scrub must leave
+     the file untouched (no needless rewrite that would bump mtime
+     and race with the running server's flusher). *)
+  let live = make_row ~site:"verify" ~raw:1.0 ~threshold:0.5 ~triggered:false in
+  let path = mk_temp_file (live ^ "\n") in
+  Fun.protect ~finally:(fun () ->
+    try Sys.remove path with Sys_error _ -> ())
+    (fun () ->
+      let before = (Unix.stat path).st_mtime in
+      Unix.sleep 1;
+      let _ = HM.scrub_legacy_degenerate_rows path in
+      let after = (Unix.stat path).st_mtime in
+      Alcotest.(check (float 1e-9))
+        "mtime unchanged when no drops"
+        before after)
+
+let test_missing_file_returns_zero () =
+  let path =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "9919-scrub-missing-%06x" (Random.bits ()))
+  in
+  (* file does not exist *)
+  Alcotest.(check int) "zero dropped" 0
+    (HM.scrub_legacy_degenerate_rows path)
+
+let () =
+  Random.self_init ();
+  Alcotest.run "heuristic_metrics_scrub" [
+    "scrub", [
+      Alcotest.test_case "drops exact degenerate signature" `Quick
+        test_drops_exact_degenerate_signature;
+      Alcotest.test_case "preserves same site different value" `Quick
+        test_preserves_same_site_different_value;
+      Alcotest.test_case "preserves unrelated sites" `Quick
+        test_preserves_unrelated_sites;
+      Alcotest.test_case "no rewrite when nothing to drop" `Slow
+        test_no_rewrite_when_nothing_to_drop;
+      Alcotest.test_case "missing file returns zero" `Quick
+        test_missing_file_returns_zero;
+    ];
+  ]


### PR DESCRIPTION
## 요약

#9919의 잔존 legacy degenerate 행을 `Heuristic_metrics.init` 시점에 one-time scrub. 기존에 이미 landed된 fix(#9987 emit 교체, #9936 diagnostic, #10044 2-site Prometheus 이관, #10017 sentinel)에 이어 **운영 중인 `heuristic_metrics.jsonl`의 51개 pre-fix 레지듀를 제거**하는 마무리.

Closes #9919 (residual cleanup).

## 왜 필요한가

이슈가 open인 상태에서 live ledger 점검:

```bash
$ jq -r '.site' ~/me/.masc/heuristic_metrics.jsonl | sort | uniq -c
  51 post_tool_use_failure
```

- 2026-04-24 06:18 이후 파일 mtime 변화 없음 — emitter는 Prometheus counter로 이관 완료.
- 51행은 pre-fix 시기(4/22~24)의 degenerate 레지듀.
- `Heuristic_metrics_diagnostics`가 부팅마다 `degenerate_sites: [post_tool_use_failure]` 경고를 뿜음 — **false positive**로 이제는 생산되지 않는 데이터를 가리킴.

이 PR은 레지듀를 삭제해 boot diagnostic이 clean slate를 보고하도록 함.

## 변경 내용

### `lib/heuristic_metrics.ml`

```ocaml
let is_known_degenerate (json : Yojson.Safe.t) : bool =
  match json with
  | `Assoc fields ->
      let get k = List.assoc_opt k fields in
      (match get "site", get "raw_value", get "threshold", get "triggered" with
       | Some (`String "post_tool_use_failure"),
         Some (`Float 1.0 | `Int 1),
         Some (`Float 0.0 | `Int 0),
         Some (`Bool true) -> true
       | _ -> false)
  | _ -> false

let scrub_legacy_degenerate_rows path =
  ...
  (* 1) read lines
     2) partition into kept / dropped
     3) if dropped = 0 → return 0 WITHOUT rewriting (mtime preserved)
     4) else atomic rename: path.9919-scrub.tmp → path
     5) log count + pointer to replacement counter
  *)
```

`init`에서 1회 호출:

```diff
  let init ~base_path =
    Stdlib.Mutex.protect mu (fun () ->
      match !store_path_ref with
      | Some _ -> ()
      | None ->
        let masc_dir = Coord_utils.masc_dir_from_base_path ~base_path in
        let path = Filename.concat masc_dir "heuristic_metrics.jsonl" in
+       let _ = scrub_legacy_degenerate_rows path in
        store_path_ref := Some path)
```

## 안전장치

| 가드 | 목적 |
|------|------|
| **4-field exact match** | site "startswith" 아닌 정확한 (`post_tool_use_failure`, 1.0, 0.0, true) 4-튜플. 다른 값(예: `raw=0.5`)은 온전히 보존 |
| **Zero-drop → no rewrite** | 매칭 없으면 파일 그대로. mtime 유지 → running server's flusher와 race 없음 |
| **Atomic rename** | `path.9919-scrub.tmp` 경유. init 중단되어도 torn file 없음 |
| **Malformed 보존** | JSON parse 실패 행은 keep. 기존 diagnostic path가 malformed 처리 |
| **Logged** | 삭제 행 수 + 대체 counter 이름(`masc_keeper_tool_use_failure_total`) 로깅 |

## 테스트

`test/test_heuristic_metrics_scrub.ml` 5 scenario:

```bash
$ dune exec test/test_heuristic_metrics_scrub.exe
[OK]  scrub  0  drops exact degenerate signature.
[OK]  scrub  1  preserves same site different value.
[OK]  scrub  2  preserves unrelated sites.
[OK]  scrub  3  no rewrite when nothing to drop.
[OK]  scrub  4  missing file returns zero.
Test Successful in 1.010s. 5 tests run.
```

Regression check (기존 diagnostic + boot wireup):
```bash
$ dune exec test/test_heuristic_metrics_diagnostics.exe → OK
$ dune exec test/test_heuristic_metrics_boot_wireup.exe → Test Successful. 2 tests run.
```

## 후속

일단 이 PR 머지 후 서버 재시작 시점에 51행 정리됨. Boot log에:

```
#9919 scrubbed 51 legacy degenerate rows from /Users/dancer/me/.masc/heuristic_metrics.jsonl
(pattern: post_tool_use_failure raw=1.0 threshold=0.0 triggered=true) —
emitter has migrated to Prometheus counter [masc_keeper_tool_use_failure_total]
```

이후 diagnostic은 cleaner state를 report.

## 회귀 리스크

낮음:
- 4-field exact match — near-miss 전부 preserve.
- Zero-drop 경로는 파일 건드리지 않음.
- Atomic rename으로 interrupt-safe.
- 운영 중 server가 계속 `append_file`로 쓰지만, init 시점은 한 번뿐 (mutex 보호).

## 참고

- Issue #9919 — 이 PR로 residual cleanup.
- PR #9987 — degenerate emit → Prometheus counter.
- PR #9936 — boot-time diagnostics.
- PR #10044 — 2 remaining theatre sites migrated.
- PR #10017 — sentinel 1.0 for unmeasurable alignment.
- `lib/heuristic_metrics.ml:128-230` — init + scrub.
- `test/test_heuristic_metrics_scrub.ml` — coverage.
