### PR TITLE
perf(ws): share Bytes allocation across raw SSE forwards in a broadcast

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -257,6 +257,8 @@ let metric_grpc_events_delivered = "masc_grpc_events_delivered_total"
 let metric_ws_sessions = "masc_ws_sessions_total"
 let metric_ws_parse_cache_hits = "masc_ws_parse_cache_hits_total"
 let metric_ws_parse_cache_misses = "masc_ws_parse_cache_misses_total"
+let metric_ws_bytes_cache_hits = "masc_ws_bytes_cache_hits_total"
+let metric_ws_bytes_cache_misses = "masc_ws_bytes_cache_misses_total"
 
 (* Admission queue metrics — used in admission_queue_metrics.ml. *)
 let metric_inference_queue_depth = "masc_inference_queue_depth"
@@ -571,6 +573,12 @@ let init () =
     Counter;
   add metric_ws_parse_cache_misses
     "WS dashboard delta parse cache misses (fresh JSON parse required)"
+    Counter;
+  add metric_ws_bytes_cache_hits
+    "WS raw-SSE-forward Bytes cache hits (same event reused across sessions)"
+    Counter;
+  add metric_ws_bytes_cache_misses
+    "WS raw-SSE-forward Bytes cache misses (fresh allocation required)"
     Counter
 
 let start_time = Time_compat.now ()

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -161,6 +161,8 @@ val metric_grpc_events_delivered : string
 val metric_ws_sessions : string
 val metric_ws_parse_cache_hits : string
 val metric_ws_parse_cache_misses : string
+val metric_ws_bytes_cache_hits : string
+val metric_ws_bytes_cache_misses : string
 
 (** {1 Admission queue metrics} *)
 

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -105,8 +105,12 @@ let bytes_cache : (string * Bytes.t) Atomic.t =
 
 let bytes_of_shared_text text =
   let cached_str, cached_bytes = Atomic.get bytes_cache in
-  if cached_str == text then cached_bytes
+  if cached_str == text then begin
+    Transport_metrics.inc_ws_bytes_cache_hit ();
+    cached_bytes
+  end
   else begin
+    Transport_metrics.inc_ws_bytes_cache_miss ();
     let bytes = Bytes.of_string text in
     Atomic.set bytes_cache (text, bytes);
     bytes

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -59,16 +59,22 @@ let new_session ~id ~wsd =
     inbound_partial_text = None;
   }
 
-(** Send a text frame to a WebSocket client. *)
-let send_text session text =
+(** Send a pre-allocated frame to a WebSocket client.
+
+    The caller owns the [bytes] buffer; this function only reads it.  In
+    server mode httpun-ws does not mask (see httpun-ws 0.2.0
+    [Serialize.serialize_bytes]: [apply_mask_bytes] is only called when
+    [mode = `Client]), and [Faraday.write_bytes] copies into its internal
+    buffer synchronously, so the same [bytes] value can safely be passed
+    to multiple sessions in one broadcast without re-allocation. *)
+let send_frame_bytes session bytes ~len =
   if session.closed || Httpun_ws.Wsd.is_closed session.wsd then begin
     session.closed <- true;
     false
   end else begin
     try
-      let bytes = Bytes.of_string text in
       Httpun_ws.Wsd.send_bytes session.wsd
-        ~kind:`Text bytes ~off:0 ~len:(Bytes.length bytes);
+        ~kind:`Text bytes ~off:0 ~len;
       true
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
@@ -79,8 +85,47 @@ let send_text session text =
       false
   end
 
+(** Send a text frame to a WebSocket client.
+    Allocates [Bytes.t] per call — fine for single-destination sends.
+    Multicast paths should go through [send_text_shared] instead so the
+    bytes allocation is paid once per broadcast, not once per session. *)
+let send_text session text =
+  let bytes = Bytes.of_string text in
+  send_frame_bytes session bytes ~len:(Bytes.length bytes)
+
+(** Module-local cache of the last [Bytes.of_string sse_event] result.
+
+    [Sse.notify_external_subscribers] delivers the same [event: string]
+    reference to every subscribed WS session in sequence.  Before this
+    cache, every session ran [Bytes.of_string] independently in the
+    raw-SSE-forward path, producing O(sessions) identical allocations.
+    Keyed by physical equality so a fresh broadcast invalidates it. *)
+let bytes_cache : (string * Bytes.t) Atomic.t =
+  Atomic.make ("", Bytes.empty)
+
+let bytes_of_shared_text text =
+  let cached_str, cached_bytes = Atomic.get bytes_cache in
+  if cached_str == text then cached_bytes
+  else begin
+    let bytes = Bytes.of_string text in
+    Atomic.set bytes_cache (text, bytes);
+    bytes
+  end
+
+(** Send a text frame that will also be sent to other sessions in this
+    broadcast.  Allocates [Bytes.of_string text] once per unique string
+    reference; subsequent sessions in the same fanout reuse the bytes. *)
+let send_text_shared session text =
+  let bytes = bytes_of_shared_text text in
+  send_frame_bytes session bytes ~len:(Bytes.length bytes)
+
 let send_text_checked ~context session text =
   let sent = send_text session text in
+  if not sent then log_ws_delivery_dropped ~context session.id;
+  sent
+
+let send_text_shared_checked ~context session text =
+  let sent = send_text_shared session text in
   if not sent then log_ws_delivery_dropped ~context session.id;
   sent
 
@@ -355,11 +400,16 @@ let send_dashboard_or_raw_sse session sse_event =
   if session.dashboard_authenticated then
     match dashboard_delta_for_sse session sse_event with
     | Some delta ->
+        (* Delta carries a per-session [seq], so the encoded text is unique
+           per session and cannot be shared. *)
         send_json_checked ~context:"dashboard-delta" session delta
     | None ->
-        send_text_checked ~context:"sse-forward" session sse_event
+        (* Same event string is forwarded verbatim to every session that
+           does not match a subscribed dashboard slice; the shared cache
+           collapses N identical [Bytes.of_string] allocations into 1. *)
+        send_text_shared_checked ~context:"sse-forward" session sse_event
   else
-    send_text_checked ~context:"sse-forward" session sse_event
+    send_text_shared_checked ~context:"sse-forward" session sse_event
 
 let read_payload_string payload ~len ~on_complete =
   let buffer = Bytes.create len in

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -66,6 +66,12 @@ let inc_ws_parse_cache_hit () =
 let inc_ws_parse_cache_miss () =
   Prometheus.inc_counter Prometheus.metric_ws_parse_cache_misses ()
 
+let inc_ws_bytes_cache_hit () =
+  Prometheus.inc_counter Prometheus.metric_ws_bytes_cache_hits ()
+
+let inc_ws_bytes_cache_miss () =
+  Prometheus.inc_counter Prometheus.metric_ws_bytes_cache_misses ()
+
 (** {1 Environment-derived Transport Config} *)
 
 let grpc_runtime_listening : bool Atomic.t = Atomic.make false

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -156,6 +156,45 @@ let test_parse_cache_counters () =
   Alcotest.(check (float 0.001)) "fresh allocation forces miss"
     1.0 (misses2 -. misses1)
 
+(* ====== Bytes cache for broadcast fanout ====== *)
+
+(* Sse.notify_external_subscribers delivers the same event string reference
+   to every WS session.  The bytes cache collapses N identical
+   [Bytes.of_string] allocations into one per unique string reference. *)
+
+let test_bytes_of_shared_text_reuses_same_ref () =
+  let text = String.make 32 'x' in
+  let b1 = Ws.bytes_of_shared_text text in
+  let b2 = Ws.bytes_of_shared_text text in
+  (* Physical equality: the same reference returns the exact same
+     [Bytes.t] (not just equal content), proving no re-allocation. *)
+  Alcotest.(check bool) "same string ref returns same Bytes"
+    true (b1 == b2)
+
+let test_bytes_of_shared_text_content_matches () =
+  let text = "{\"type\":\"execution_snapshot\",\"payload\":{\"n\":1}}" in
+  let bytes = Ws.bytes_of_shared_text text in
+  Alcotest.(check int) "length matches" (String.length text)
+    (Bytes.length bytes);
+  Alcotest.(check string) "content round-trips" text
+    (Bytes.to_string bytes)
+
+let test_bytes_of_shared_text_invalidates_on_new_ref () =
+  (* Force two distinct string allocations so physical equality differs
+     even though content is the same.  The cache must re-allocate rather
+     than return the prior bytes. *)
+  let a = String.concat "" ["hello"; "-world"] in
+  let b = String.concat "" ["hello"; "-world"] in
+  assert (not (a == b));
+  let ba = Ws.bytes_of_shared_text a in
+  let bb = Ws.bytes_of_shared_text b in
+  Alcotest.(check bool) "distinct refs get distinct bytes"
+    true (not (ba == bb));
+  Alcotest.(check string) "content still correct for A"
+    a (Bytes.to_string ba);
+  Alcotest.(check string) "content still correct for B"
+    b (Bytes.to_string bb)
+
 (* ====== External Subscriber Broadcast (WS delivery path) ====== *)
 
 let test_ws_external_subscriber_receives_broadcast () =
@@ -263,6 +302,14 @@ let () =
         test_parse_sse_dashboard_event_invalidated_on_new_ref;
       Alcotest.test_case "hit/miss counters track reuse" `Quick
         test_parse_cache_counters;
+    ]);
+    ("bytes_cache", [
+      Alcotest.test_case "same string ref returns same Bytes" `Quick
+        test_bytes_of_shared_text_reuses_same_ref;
+      Alcotest.test_case "content round-trips through cache" `Quick
+        test_bytes_of_shared_text_content_matches;
+      Alcotest.test_case "distinct refs force re-allocation" `Quick
+        test_bytes_of_shared_text_invalidates_on_new_ref;
     ]);
     ("external_subscriber", [
       Alcotest.test_case "single subscriber receives broadcast" `Quick

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -195,6 +195,34 @@ let test_bytes_of_shared_text_invalidates_on_new_ref () =
   Alcotest.(check string) "content still correct for B"
     b (Bytes.to_string bb)
 
+(* Observability: the Prometheus counters must account exactly for the
+   traffic the cache absorbs — hits for reuse, misses for fresh
+   allocations.  Delta-check against shared module-level state so other
+   tests running before us do not poison the expected values. *)
+let read_counter name = Masc_mcp.Prometheus.metric_value_or_zero name ()
+
+let test_bytes_cache_counters () =
+  let hits_name = Masc_mcp.Prometheus.metric_ws_bytes_cache_hits in
+  let misses_name = Masc_mcp.Prometheus.metric_ws_bytes_cache_misses in
+  let hits0 = read_counter hits_name in
+  let misses0 = read_counter misses_name in
+  let text = String.make 16 'z' in
+  let _ = Ws.bytes_of_shared_text text in   (* miss: first time *)
+  let _ = Ws.bytes_of_shared_text text in   (* hit *)
+  let _ = Ws.bytes_of_shared_text text in   (* hit *)
+  Alcotest.(check (float 0.001)) "two hits observed"
+    2.0 (read_counter hits_name -. hits0);
+  Alcotest.(check (float 0.001)) "one miss observed"
+    1.0 (read_counter misses_name -. misses0);
+  (* A fresh allocation with the same content must register as another
+     miss — confirms the key is physical, not structural, at the counter
+     level too. *)
+  let text' = String.concat "" [String.make 8 'z'; String.make 8 'z'] in
+  assert (not (text == text'));
+  let _ = Ws.bytes_of_shared_text text' in
+  Alcotest.(check (float 0.001)) "fresh allocation forces another miss"
+    2.0 (read_counter misses_name -. misses0)
+
 (* ====== External Subscriber Broadcast (WS delivery path) ====== *)
 
 let test_ws_external_subscriber_receives_broadcast () =
@@ -310,6 +338,8 @@ let () =
         test_bytes_of_shared_text_content_matches;
       Alcotest.test_case "distinct refs force re-allocation" `Quick
         test_bytes_of_shared_text_invalidates_on_new_ref;
+      Alcotest.test_case "hit/miss counters track reuse" `Quick
+        test_bytes_cache_counters;
     ]);
     ("external_subscriber", [
       Alcotest.test_case "single subscriber receives broadcast" `Quick


### PR DESCRIPTION
## Why

`Sse.notify_external_subscribers` delivers the same `event: string` reference to every subscribed WS session. For the **raw-SSE-forward path** (events that do not match any subscribed dashboard slice), each session previously ran `Bytes.of_string sse_event` independently, producing N identical allocations per broadcast.

For `N` connected WS sessions and `E` bytes per event, each broadcast burns `N × E` bytes of short-lived allocation that the GC then has to sweep. A steady-state multi-tab operator (N=5, E=2KB, 10 events/s) wastes ~100 KB/s of allocation churn that carries zero information beyond the first copy.

This is a sibling to the parse cache in #10089: same delivery pattern, different layer.

## What

In `lib/server/server_mcp_transport_ws.ml`:

- Factor out `send_frame_bytes session bytes ~len` as the raw primitive over `Httpun_ws.Wsd.send_bytes`.
- Add `bytes_cache : (string * Bytes.t) Atomic.t` plus `bytes_of_shared_text` keyed by physical equality on the string reference.
- Add `send_text_shared` and `send_text_shared_checked` that go through the cache.
- `send_dashboard_or_raw_sse` routes the two raw-forward call sites (authenticated-but-slice-miss and unauthenticated) through the shared helper.
- `send_text` / `send_text_checked` stay on the allocating path — single-destination sends do not benefit from sharing.

Dashboard **delta** sends still go through `send_json_checked` → `send_text` unchanged, because each session's delta carries a unique `seq` and therefore a unique encoded string.

## Why sharing bytes across sessions is safe

Read from `httpun-ws` 0.2.0 to avoid guessing ownership semantics:

- `Serialize.serialize_bytes` only calls `Websocket.Frame.apply_mask_bytes` when `mask` is `Some _`, which only happens when `mode = `Client`. Our upgrade handler is a server, so `mode = `Server` and the payload is never mutated.
- `Faraday.write_bytes faraday payload ~off ~len` copies synchronously into the serializer's internal buffer. The argument `Bytes.t` needs to be valid only for the duration of the synchronous `Wsd.send_bytes` call; no reference is retained after return.

Both conditions hold on the server send path, so the same `Bytes.t` can be handed to multiple sessions sequentially without observable side effects.

## Tests

`test/test_ws_transport.ml` gains a `bytes_cache` group:

- Same string reference returns the exact same `Bytes.t` (cache hit by physical identity, not structural equality).
- Content round-trips through the cache — `Bytes.to_string` recovers the original.
- Two distinct allocations of identical content force separate `Bytes.t` values — proves the key is physical identity so fresh broadcasts always refresh.

Verified suites:

```
test_ws_transport          14/14  (11 prior + 3 new)
test_transport_integration  8/8   (ws_sse forwarding path covered)
```

## Scope guard

- No wire-format change. The frame on the network is identical — only the server-side allocation pattern differs.
- No change to client code.
- No dependency added.

## Interaction with #10089 / #10096

Independent and stackable:

- #10089 collapses **parse** work per broadcast (input direction).
- #10096 records client **drain rate** per broadcast (output observability).
- This PR collapses **allocation** per broadcast (output direction, GC pressure).

None of the three PRs touch the same function in a conflicting way; they are orthogonal perf layers around the same fanout path.

## Follow-ups (separate PRs)

- Add `masc_ws_bytes_cache_hits_total` / `..._misses_total` counters consistent with the parse-cache observability layer once #10089 lands and sets a naming convention.
- Consider pushing the bytes cache into `Sse.notify_external_subscribers` so gRPC subscribers also reuse bytes (requires a callback signature change — separate blast radius).

🤖 Generated with [Claude Code](https://claude.com/claude-code)