### PR TITLE
feat(keeper): counter for require_tool_use violations on active task (#10091)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -2336,7 +2336,21 @@ let run_turn
              , actionable_tool_contract_violation_reason
            with
            | Ok (), Some reason ->
-               receipt_tool_contract_result_ref := tool_contract_status ();
+               let contract_status = tool_contract_status () in
+               receipt_tool_contract_result_ref := contract_status;
+               (* #10091: emit the labelled counter so dashboards
+                  can distinguish the [has_current_task=true]
+                  strict-gate path (#10031 kept this intentionally
+                  strict) from the [has_current_task=false] path
+                  (already relaxed to [Auto]).  The strict gate
+                  behaviour is unchanged — this is pure
+                  observability that lets the operator pinpoint
+                  which (keeper, contract_status) pairs are
+                  config-mismatched. *)
+               Keeper_tool_disclosure.record_require_tool_use_violation
+                 ~keeper_name:meta.name
+                 ~has_current_task:(keeper_has_owned_active_task ())
+                 ~contract_status;
                Log.Keeper.error
                  "keeper:%s required tool contract violated \
                   (turn=%d, tools=%d). Rejecting no-op/passive actionable turn. \
@@ -2349,9 +2363,15 @@ let run_turn
                receipt_tool_contract_result_ref := tool_contract_status ();
                Ok (`Provider_text text)
            | Error reason, _ ->
-               receipt_tool_contract_result_ref :=
+               let contract_status =
                  if actual_keeper_tool_names = [] then "missing_required_tool_use"
-                 else tool_contract_status ();
+                 else tool_contract_status ()
+               in
+               receipt_tool_contract_result_ref := contract_status;
+               Keeper_tool_disclosure.record_require_tool_use_violation
+                 ~keeper_name:meta.name
+                 ~has_current_task:(keeper_has_owned_active_task ())
+                 ~contract_status;
                let contract_str =
                  match effective_completion_contract with
                  | Keeper_tool_disclosure.Allow_text_or_tool -> "Allow_text_or_tool"

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -268,6 +268,27 @@ let is_execution_progress_tool_name name =
   | Execution | Completion -> true
   | Passive_status | Claim_context -> false
 
+(* #10091: record a [require_tool_use] contract violation with
+   the labels the operator needs to fix the underlying cause
+   (tool_preset mismatch vs. active-task refusal vs. cohort
+   misconfiguration).  Split out of [keeper_agent_run.ml] so the
+   counter emission is directly testable without standing up a
+   full OAS/Eio harness.  [contract_status] is the same string
+   already assigned to [receipt_tool_contract_result_ref] at the
+   call site, so receipt JSON and fleet metric share one
+   vocabulary. *)
+let record_require_tool_use_violation
+      ~(keeper_name : string)
+      ~(has_current_task : bool)
+      ~(contract_status : string) : unit =
+  Prometheus.inc_counter
+    Prometheus.metric_keeper_require_tool_use_violations
+    ~labels:[
+      ("keeper", keeper_name);
+      ("has_current_task", if has_current_task then "true" else "false");
+      ("contract_status", contract_status);
+    ] ()
+
 let actionable_tool_contract_violation_reason
       ~(claim_context_allowed : bool)
       ~(actionable_signal_context : bool)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -219,6 +219,18 @@ let metric_keeper_paused_state_persist_errors =
   "masc_keeper_paused_state_persist_errors_total"
 let metric_keeper_unexpected_tool_partial_tolerance =
   "masc_keeper_unexpected_tool_partial_tolerance_total"
+(* #10091: [require_tool_use] contract violations labelled by
+   [has_current_task] (true = #10091's active-task path that
+   [#10031] intentionally left strict, false = the no-task path
+   that [#10031] relaxed to [Auto]) and by fine-grained
+   [contract_status] ([passive_only], [needs_execution_progress],
+   [claim_only_after_owned_task], [tool_surface_mismatch],
+   [missing_required_tool_use]).  The fleet histogram of
+   (keeper, contract_status) pairs tells the operator which
+   keeper tool_presets need reshaping for the current task mix
+   without masking the strict gate. *)
+let metric_keeper_require_tool_use_violations =
+  "masc_keeper_require_tool_use_violations_total"
 let metric_keeper_tool_alias_canonicalizations =
   "masc_keeper_tool_alias_canonicalizations_total"
 let metric_keeper_profile_config_conflicts =

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -87,6 +87,10 @@ val metric_keeper_write_meta_failures : string
 val metric_keeper_lifecycle_dispatch_rejections : string
 val metric_keeper_paused_state_persist_errors : string
 val metric_keeper_unexpected_tool_partial_tolerance : string
+val metric_keeper_require_tool_use_violations : string
+(** #10091: labelled [keeper, has_current_task, contract_status]
+    so fleet histograms can distinguish the active-task strict
+    path from the no-task path covered by #10031. *)
 val metric_keeper_tool_alias_canonicalizations : string
 val metric_keeper_profile_config_conflicts : string
 val metric_keeper_oas_timeout_classifications : string

--- a/test/dune
+++ b/test/dune
@@ -342,6 +342,19 @@
     (run %{test}))))
  (libraries masc_test_deps))
 
+; #10091: dedicated stanza so MASC_BASE_PATH is set BEFORE the
+; test executable loads — the top-level Masc_mcp init includes
+; [Cdal_verdict_gate.default_base_path] which triggers the #9903
+; prod-guard when base_path resolves to the operator's HOME.
+(test
+ (name test_require_tool_use_violation_counter_10091)
+ (modules test_require_tool_use_violation_counter_10091)
+ (action
+  (setenv MASC_BASE_PATH /tmp/test-require-tool-use-violation-counter-10091
+   (setenv MASC_BASE_PATH_INPUT /tmp/test-require-tool-use-violation-counter-10091
+    (run %{test}))))
+ (libraries masc_test_deps))
+
 (test
  (name test_keeper_turn_up_create_meta_retry)
  (modules test_keeper_turn_up_create_meta_retry)

--- a/test/test_require_tool_use_violation_counter_10091.ml
+++ b/test/test_require_tool_use_violation_counter_10091.ml
@@ -1,0 +1,165 @@
+(* test/test_require_tool_use_violation_counter_10091.ml
+
+   #10091: pin the label vocabulary for
+   [masc_keeper_require_tool_use_violations_total].  The counter
+   is the operator's only signal for the active-task strict-gate
+   path that #10031 intentionally left strict (the no-task path
+   was already relaxed to [Auto]); its label set must be
+   structurally stable so dashboards keyed on
+   (keeper, has_current_task, contract_status) do not silently
+   drop series when new cohorts or contract statuses appear.
+
+   The test covers:
+
+   1. [has_current_task=true]: the #10091 target — active-task
+      refusal, strict gate fires, counter increments with
+      [has_current_task="true"] and the supplied contract_status.
+   2. [has_current_task=false]: the #10031 relaxation path —
+      still emitted (with [has_current_task="false"]) so dashboards
+      can compare relative volume of the two paths and justify or
+      roll back the relaxation.
+   3. Multiple contract_status values remain isolated per label
+      bucket (increment on one status must not leak into another).
+   4. Multiple keeper labels remain isolated.  Regression guard
+      for the "single undifferentiated counter" anti-pattern
+      (same one documented for [heuristic_metrics.jsonl] degenerate
+      rows in [feedback_no-heuristic-category.md]).
+*)
+
+(* Set [MASC_BASE_PATH] before any module that calls
+   [Env_config_core.base_path ()] at init time — #9903's
+   prod-guard raises from under [/Users/dancer] otherwise,
+   dune test env sets the var to [""] but that's still
+   empty-string which the guard rejects. *)
+let () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-rtuv-10091-%06x" (Random.bits ()))
+  in
+  Unix.putenv "MASC_BASE_PATH" dir
+
+module D = Masc_mcp.Keeper_tool_disclosure
+module Prom = Masc_mcp.Prometheus
+
+let metric = Prom.metric_keeper_require_tool_use_violations
+
+let counter_for ~keeper ~has_current_task ~contract_status =
+  Prom.metric_value_or_zero metric
+    ~labels:[
+      ("keeper", keeper);
+      ("has_current_task", if has_current_task then "true" else "false");
+      ("contract_status", contract_status);
+    ] ()
+
+(* Active-task refusal (the #10091 target): counter increments
+   exactly on the [has_current_task="true"] bucket. *)
+let test_active_task_violation_counts_on_true_bucket () =
+  let keeper = "test-verifier-10091" in
+  let status = "needs_execution_progress" in
+  let before = counter_for ~keeper ~has_current_task:true ~contract_status:status in
+  D.record_require_tool_use_violation
+    ~keeper_name:keeper
+    ~has_current_task:true
+    ~contract_status:status;
+  Alcotest.(check (float 0.0001))
+    "has_current_task=true bucket +1"
+    (before +. 1.0)
+    (counter_for ~keeper ~has_current_task:true ~contract_status:status);
+  Alcotest.(check (float 0.0001))
+    "has_current_task=false bucket unchanged"
+    0.0
+    (counter_for ~keeper ~has_current_task:false ~contract_status:status)
+
+(* No-task refusal path still emits — dashboards compare volume
+   of the two paths to justify or roll back #10031's relaxation.
+   If this bucket silently drops to zero we lose the ability to
+   argue about the relaxation's effect. *)
+let test_no_task_violation_counts_on_false_bucket () =
+  let keeper = "test-ramarama-10091" in
+  let status = "passive_only" in
+  let before = counter_for ~keeper ~has_current_task:false ~contract_status:status in
+  D.record_require_tool_use_violation
+    ~keeper_name:keeper
+    ~has_current_task:false
+    ~contract_status:status;
+  Alcotest.(check (float 0.0001))
+    "has_current_task=false bucket +1"
+    (before +. 1.0)
+    (counter_for ~keeper ~has_current_task:false ~contract_status:status);
+  Alcotest.(check (float 0.0001))
+    "has_current_task=true bucket unchanged"
+    0.0
+    (counter_for ~keeper ~has_current_task:true ~contract_status:status)
+
+(* The fine-grained contract_status labels must stay isolated.
+   Regression guard: a call with [needs_execution_progress] must
+   not leak into the [passive_only] series, otherwise the operator
+   sees a single undifferentiated counter that cannot drive
+   preset-reshape decisions. *)
+let test_contract_status_labels_are_isolated () =
+  let keeper = "test-velvet-10091" in
+  let before_needs =
+    counter_for ~keeper ~has_current_task:true
+      ~contract_status:"needs_execution_progress"
+  in
+  let before_passive =
+    counter_for ~keeper ~has_current_task:true ~contract_status:"passive_only"
+  in
+  D.record_require_tool_use_violation
+    ~keeper_name:keeper
+    ~has_current_task:true
+    ~contract_status:"needs_execution_progress";
+  Alcotest.(check (float 0.0001))
+    "needs_execution_progress +1"
+    (before_needs +. 1.0)
+    (counter_for ~keeper ~has_current_task:true
+       ~contract_status:"needs_execution_progress");
+  Alcotest.(check (float 0.0001))
+    "passive_only unchanged (no label leak)"
+    before_passive
+    (counter_for ~keeper ~has_current_task:true
+       ~contract_status:"passive_only")
+
+(* Keeper name is the primary cohort discriminator: the operator
+   uses it to target the right tool_preset.  Regression guard for
+   cross-keeper label leakage. *)
+let test_keeper_labels_are_isolated () =
+  let status = "claim_only_after_owned_task" in
+  let before_a =
+    counter_for ~keeper:"test-analyst-10091" ~has_current_task:true
+      ~contract_status:status
+  in
+  let before_b =
+    counter_for ~keeper:"test-scholar-10091" ~has_current_task:true
+      ~contract_status:status
+  in
+  D.record_require_tool_use_violation
+    ~keeper_name:"test-analyst-10091"
+    ~has_current_task:true
+    ~contract_status:status;
+  Alcotest.(check (float 0.0001))
+    "analyst +1"
+    (before_a +. 1.0)
+    (counter_for ~keeper:"test-analyst-10091" ~has_current_task:true
+       ~contract_status:status);
+  Alcotest.(check (float 0.0001))
+    "scholar unchanged"
+    before_b
+    (counter_for ~keeper:"test-scholar-10091" ~has_current_task:true
+       ~contract_status:status)
+
+let () =
+  Alcotest.run "require_tool_use_violation_counter_10091"
+    [
+      ( "label_vocabulary",
+        [
+          Alcotest.test_case "active-task bucket" `Quick
+            test_active_task_violation_counts_on_true_bucket;
+          Alcotest.test_case "no-task bucket" `Quick
+            test_no_task_violation_counts_on_false_bucket;
+          Alcotest.test_case "contract_status isolation" `Quick
+            test_contract_status_labels_are_isolated;
+          Alcotest.test_case "keeper isolation" `Quick
+            test_keeper_labels_are_isolated;
+        ] );
+    ]


### PR DESCRIPTION
## Problem (#10091)

#10031 (tick #22 of the current /loop) relaxed the
`require_tool_use` gate to `Auto` when `has_current_task=false`
but intentionally kept the strict `Any` gate for the active-task
path. #10091 reports 13 violations/session (9 from new cohorts:
verifier, velvet-hammer, analyst) landing on that strict path —
and the operator has **no observable signal** that distinguishes
them from the already-relaxed path or from one another.

| keeper | count |
|--------|------:|
| verifier | 5 |
| velvet-hammer | 4 |
| ramarama | 2 |
| analyst | 2 |

## Root Cause

`keeper_agent_run.ml:2338-2367` emits the violation with zero
label structure. Yet the exact strings needed for triage are
already computed locally:

- `keeper_has_owned_active_task ()` → distinguishes the #10091
  target path from the #10031-relaxed path
- `tool_contract_status ()` → fine-grained reason
  (`tool_surface_mismatch` / `passive_only` /
  `claim_only_after_owned_task` / `needs_execution_progress` /
  `missing_required_tool_use`)

These get written to `receipt_tool_contract_result_ref` but never
reach Prometheus. Fleet dashboards see an undifferentiated
"13 errors" number.

## Fix

Emit `masc_keeper_require_tool_use_violations_total{keeper,
has_current_task, contract_status}` at both violation branches.
Helper `record_require_tool_use_violation` extracted to
`Keeper_tool_disclosure` so it is unit-testable without an Eio
harness.

`contract_status` reuses the same string assigned to
`receipt_tool_contract_result_ref` — fleet metric and receipt
JSON share one vocabulary.

The strict gate is **unchanged**. This is pure observability.
#10091's Option C (semantic refusal handling) and Option A
(pre-flight preset compatibility check) both require more design
work — this PR establishes the evidence base for those decisions.

## Tests

`test/test_require_tool_use_violation_counter_10091.ml`:

- **active-task (has_current_task=true) bucket**: increments on
  the #10091 target path; no-task bucket stays at 0.
- **no-task (has_current_task=false) bucket**: still emits, so
  dashboards can compare relative volume and justify/roll back
  #10031.
- **contract_status isolation**: a call with
  `needs_execution_progress` must not leak into `passive_only`.
  Regression guard for the "single undifferentiated counter"
  anti-pattern.
- **keeper isolation**: per-cohort signal is preserved for
  preset-reshape targeting.

## Notes

- Test uses a dedicated `(test ...)` stanza with `setenv
  MASC_BASE_PATH ...` because `Masc_mcp` module init pulls
  `Cdal_verdict_gate.default_base_path` which triggers the #9903
  prod-guard when base_path resolves to HOME. Pre-existing smell
  (module init should not call functions that can fail). Out of
  scope for this PR but worth its own issue.
- Label vocabulary intentionally stable: adding a new
  `contract_status` variant is a conscious dashboard update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)