### PR TITLE
fix(oas-worker): dedup codex_cli MCP omission WARN + per-tool counter (#10097)

### DIFF
--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -13,28 +13,83 @@ type cli_transport_overrides = {
   gemini_yolo : bool option;
 }
 
-(* #10097: codex_cli omits the same set of keeper-bound runtime MCP
-   tools on every request because the structural limitation
-   (request-scoped auth headers) cannot be carried through codex's
-   transport.  The previous Log.warn fired 143×/session with one
-   distinct tool list — pure noise that masked other warnings.  Track
-   the most recent tool list per [agent_name] and only emit when it
-   changes (initial fire, or tool surface drift).  Stdlib.Mutex
-   guards concurrent access from heartbeat/turn fibers across
-   domains. *)
+(* #10097: codex_cli omits keeper-bound runtime MCP tools that require
+   request-scoped auth headers.  That omission is a structural provider
+   limitation, not a per-call incident:
+
+     - [WARN] emits only when an agent first sees an omitted-tool
+       fingerprint, or when that agent's omitted tool set changes.
+     - [Prometheus] per-tool counters increment on every omission so
+       dashboards retain the frequency signal.
+
+   Fingerprint = sorted, comma-joined tool list.  Stdlib.Mutex guards
+   concurrent access from heartbeat/turn fibers across domains. *)
 let codex_omission_state_mu = Stdlib.Mutex.create ()
 let codex_omission_state : (string, string) Hashtbl.t = Hashtbl.create 16
 
-let codex_omission_should_log ~agent_name ~tool_list_key =
+let codex_cli_omission_fingerprint (tools : string list) : string =
+  tools
+  |> List.sort String.compare
+  |> String.concat ","
+
+let codex_omission_agent_key = function
+  | Some agent_name ->
+      let agent_name = String.trim agent_name in
+      if String.equal agent_name "" then "<no_agent>" else agent_name
+  | None -> "<no_agent>"
+
+let codex_omission_should_log ~agent_name ~tool_fingerprint =
   Stdlib.Mutex.lock codex_omission_state_mu;
   Fun.protect
     ~finally:(fun () -> Stdlib.Mutex.unlock codex_omission_state_mu)
     (fun () ->
        match Hashtbl.find_opt codex_omission_state agent_name with
-       | Some prev when String.equal prev tool_list_key -> false
+       | Some prev when String.equal prev tool_fingerprint -> false
        | _ ->
-         Hashtbl.replace codex_omission_state agent_name tool_list_key;
+         Hashtbl.replace codex_omission_state agent_name tool_fingerprint;
          true)
+
+let codex_cli_omission_fingerprint_seen fingerprint =
+  not
+    (codex_omission_should_log ~agent_name:"<no_agent>"
+       ~tool_fingerprint:fingerprint)
+
+(* For tests: reset the dedup state so each test starts clean. *)
+let reset_codex_cli_omission_dedup_for_tests () =
+  Stdlib.Mutex.lock codex_omission_state_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock codex_omission_state_mu)
+    (fun () -> Hashtbl.clear codex_omission_state)
+
+let record_codex_cli_omission_for_agent
+    ~(agent_name : string option)
+    ~(tools : string list)
+  : unit =
+  match tools with
+  | [] -> ()
+  | _ ->
+    List.iter (fun tool ->
+      Prometheus.inc_counter
+        Prometheus.metric_codex_cli_mcp_tool_omission
+        ~labels:[ ("tool", tool) ] ())
+      tools;
+    let tool_fingerprint = codex_cli_omission_fingerprint tools in
+    let agent_name_key = codex_omission_agent_key agent_name in
+    if
+      codex_omission_should_log ~agent_name:agent_name_key
+        ~tool_fingerprint
+    then
+      Log.warn ~ctx:"oas_worker_exec"
+        "codex_cli omitting keeper-bound runtime MCP tool(s) that \
+         require request-scoped auth headers: %s \
+         (structural provider limitation for %s; subsequent omissions \
+         of this same set are counted in \
+         masc_codex_cli_mcp_tool_omission_total and not re-logged)"
+        (String.concat ", " (List.sort String.compare tools))
+        agent_name_key
+
+let record_codex_cli_omission ~(tools : string list) : unit =
+  record_codex_cli_omission_for_agent ~agent_name:None ~tools
 
 (** Resolve a model label string to an OAS Provider.config.
     Uses MASC [Cascade_config.parse_model_string] (with Provider_registry as SSOT).
@@ -461,17 +516,10 @@ let resolve_tool_lane_for_oas_tools
           (public_tool_names @ keeper_internal_tool_names)
     | _ -> []
   in
-  (if codex_keeper_bound_actor_tools <> [] then
-    let tool_list_key = String.concat "," codex_keeper_bound_actor_tools in
-    let agent_name_key =
-      Option.value ~default:"<no_agent>" requested_agent_name
-    in
-    if codex_omission_should_log ~agent_name:agent_name_key ~tool_list_key
-    then
-      Log.warn ~ctx:"oas_worker_exec"
-        "codex_cli omitting keeper-bound runtime MCP tool(s) that require request-scoped auth headers: %s (subsequent identical omissions for %s suppressed)"
-        tool_list_key
-        agent_name_key);
+  (* #10097: WARN once per distinct fingerprint + always-emit
+     per-tool counter.  See [record_codex_cli_omission] docs. *)
+  record_codex_cli_omission_for_agent ~agent_name:requested_agent_name
+    ~tools:codex_keeper_bound_actor_tools;
   let public_tool_names =
     if codex_keeper_bound_actor_tools = [] then
       public_tool_names

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -228,6 +228,17 @@ let metric_keeper_oas_timeout_classifications =
 let metric_persistence_read_drops =
   "masc_persistence_read_drops_total"
 
+(* #10097: codex_cli provider cannot carry keeper-bound runtime MCP
+   tools that need request-scoped auth headers.  Every time
+   oas_worker_exec_transport strips such a tool, this counter
+   increments with the tool name so dashboards can track WHICH
+   tools are being omitted and at WHAT rate.  Paired with a
+   once-per-session WARN log ([fingerprint]-deduplicated) so the
+   operator sees the structural fact exactly once while the
+   counter carries the frequency signal. *)
+let metric_codex_cli_mcp_tool_omission =
+  "masc_codex_cli_mcp_tool_omission_total"
+
 (* OAS SSE relay (oas_sse_bridge.ml). *)
 let metric_oas_sse_relay_retries =
   "masc_oas_sse_relay_retries_total"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -91,6 +91,11 @@ val metric_keeper_tool_alias_canonicalizations : string
 val metric_keeper_profile_config_conflicts : string
 val metric_keeper_oas_timeout_classifications : string
 val metric_persistence_read_drops : string
+val metric_codex_cli_mcp_tool_omission : string
+(** #10097: per-tool counter for codex_cli keeper-bound runtime
+    MCP omissions.  Paired with a once-per-fingerprint WARN log
+    so logs carry structural facts and Prometheus carries
+    frequency. *)
 val metric_oas_sse_relay_retries : string
 val metric_oas_sse_relay_drops : string
 val metric_oas_sse_relay_queue_depth : string

--- a/test/dune
+++ b/test/dune
@@ -347,6 +347,18 @@
  (modules test_keeper_turn_up_create_meta_retry)
  (libraries masc_test_deps))
 
+; #10097: dedicated stanza so MASC_BASE_PATH is set BEFORE the
+; test executable loads — same reason as test_require_tool_use_
+; violation_counter_10091 above.  See that stanza's comment.
+(test
+ (name test_codex_cli_omission_dedup_10097)
+ (modules test_codex_cli_omission_dedup_10097)
+ (action
+  (setenv MASC_BASE_PATH /tmp/test-codex-cli-omission-dedup-10097
+   (setenv MASC_BASE_PATH_INPUT /tmp/test-codex-cli-omission-dedup-10097
+    (run %{test}))))
+ (libraries masc_test_deps))
+
 ; test_worker_run_evidence_summary removed (team session cleanup)
 
 ; test_team_session_worker_run_meta_repair removed (team session cleanup)

--- a/test/test_codex_cli_omission_dedup_10097.ml
+++ b/test/test_codex_cli_omission_dedup_10097.ml
@@ -1,0 +1,168 @@
+(* test/test_codex_cli_omission_dedup_10097.ml
+
+   #10097: 143 identical WARN lines per session for codex_cli
+   keeper-bound runtime MCP omissions masked unrelated warnings
+   in [grep WARN] output.  [record_codex_cli_omission] splits
+   the signal:
+
+     - WARN logged once per distinct fingerprint (sorted,
+       comma-joined tool list) — operator sees the structural
+       fact the first time a given set is stripped;
+     - Prometheus counter [masc_codex_cli_mcp_tool_omission_total
+       {tool}] increments on EVERY call so dashboards retain the
+       frequency signal.
+
+   The test pins:
+
+     1. Counter increments on every call (even repeat calls with
+        the same fingerprint) — the frequency signal is not
+        deduplicated.
+     2. Fingerprint is order-insensitive (sorted) — the same set
+        in different orders counts as one fingerprint.
+     3. A genuinely new fingerprint (different tool set) is NOT
+        silenced — changed omission sets are new information and
+        must be re-logged.
+     4. Per-tool label isolation — a call with [keeper_shell]
+        does not leak into the [keeper_fs_edit] bucket.
+     5. Empty tool list is a no-op — fires neither the counter
+        nor the WARN.
+*)
+
+(* Set MASC_BASE_PATH before Masc_mcp module init (Cdal_verdict_
+   gate calls base_path at init time — #9903 prod-guard). *)
+let () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-codex-omission-10097-%06x" (Random.bits ()))
+  in
+  Unix.putenv "MASC_BASE_PATH" dir
+
+module T = Masc_mcp.Oas_worker_exec_transport
+module Prom = Masc_mcp.Prometheus
+
+let metric = Prom.metric_codex_cli_mcp_tool_omission
+
+let counter_for ~tool =
+  Prom.metric_value_or_zero metric ~labels:[ ("tool", tool) ] ()
+
+(* Counter must increment on every invocation, even when the
+   fingerprint has been seen before (the WARN dedup is about log
+   noise; the Prometheus rate signal stays honest). *)
+let test_counter_increments_on_every_call () =
+  T.reset_codex_cli_omission_dedup_for_tests ();
+  let tool = "keeper_library_search_t1_10097" in
+  let before = counter_for ~tool in
+  T.record_codex_cli_omission ~tools:[ tool ];
+  T.record_codex_cli_omission ~tools:[ tool ];
+  T.record_codex_cli_omission ~tools:[ tool ];
+  Alcotest.(check (float 0.0001))
+    "counter +3 across three calls with same fingerprint"
+    (before +. 3.0)
+    (counter_for ~tool)
+
+(* Fingerprint is the sorted list, so [a; b] and [b; a] are one
+   set — reordering must not bypass dedup. *)
+let test_fingerprint_is_order_insensitive () =
+  let a = "keeper_shell_t2_10097" in
+  let b = "keeper_fs_edit_t2_10097" in
+  Alcotest.(check string)
+    "sorted [b;a] and sorted [a;b] yield same fingerprint"
+    (T.codex_cli_omission_fingerprint [ a; b ])
+    (T.codex_cli_omission_fingerprint [ b; a ])
+
+(* Different tool sets must NOT be silenced by each other.
+   Regression guard for over-eager dedup (a single global flag
+   would lose genuinely new information when the omission set
+   evolves). *)
+let test_new_fingerprint_reprints_warn () =
+  T.reset_codex_cli_omission_dedup_for_tests ();
+  let fp1 =
+    T.codex_cli_omission_fingerprint [ "keeper_shell_t3_10097" ]
+  in
+  let fp2 =
+    T.codex_cli_omission_fingerprint
+      [ "keeper_shell_t3_10097"; "keeper_fs_edit_t3_10097" ]
+  in
+  Alcotest.(check bool)
+    "fp1 is fresh on first encounter"
+    false
+    (T.codex_cli_omission_fingerprint_seen fp1);
+  Alcotest.(check bool)
+    "fp1 is seen on second encounter"
+    true
+    (T.codex_cli_omission_fingerprint_seen fp1);
+  Alcotest.(check bool)
+    "fp2 is fresh even though fp1 is seen — new set is new information"
+    false
+    (T.codex_cli_omission_fingerprint_seen fp2);
+  Alcotest.(check bool)
+    "fp2 is seen on second encounter"
+    true
+    (T.codex_cli_omission_fingerprint_seen fp2)
+
+(* Per-tool labels must stay isolated — a call with tool X must
+   not leak into tool Y's bucket.  Same anti-pattern guard as
+   the other counter tests in this tick series. *)
+let test_per_tool_label_isolation () =
+  T.reset_codex_cli_omission_dedup_for_tests ();
+  let x = "keeper_shell_t4_10097" in
+  let y = "keeper_fs_edit_t4_10097" in
+  let before_y = counter_for ~tool:y in
+  T.record_codex_cli_omission ~tools:[ x ];
+  Alcotest.(check (float 0.0001))
+    "tool Y bucket unchanged when X is omitted"
+    before_y
+    (counter_for ~tool:y);
+  Alcotest.(check bool)
+    "tool X bucket grew"
+    true
+    (counter_for ~tool:x >= 1.0)
+
+(* Empty list must be a pure no-op: no counter, no WARN.  The
+   call site checks [if codex_keeper_bound_actor_tools <> []]
+   before [record_codex_cli_omission] was introduced, and the
+   helper defends the contract so future callers cannot
+   accidentally trigger the dedup slot on empty input. *)
+let test_empty_tools_is_noop () =
+  T.reset_codex_cli_omission_dedup_for_tests ();
+  let probe = "keeper_probe_empty_t5_10097" in
+  let before = counter_for ~tool:probe in
+  T.record_codex_cli_omission ~tools:[];
+  Alcotest.(check (float 0.0001))
+    "probe bucket unchanged"
+    before
+    (counter_for ~tool:probe);
+  let empty_fp = T.codex_cli_omission_fingerprint [] in
+  (* An empty fingerprint, if it were ever recorded, would burn
+     one dedup slot — assert it was NOT seen. *)
+  Alcotest.(check bool)
+    "empty fingerprint never recorded"
+    false
+    (T.codex_cli_omission_fingerprint_seen empty_fp);
+  (* Clean up the slot we just opened so other tests are not
+     affected by the side-effect check above. *)
+  T.reset_codex_cli_omission_dedup_for_tests ()
+
+let () =
+  Alcotest.run "codex_cli_omission_dedup_10097"
+    [
+      ( "counter",
+        [
+          Alcotest.test_case "increments on every call" `Quick
+            test_counter_increments_on_every_call;
+          Alcotest.test_case "per-tool label isolation" `Quick
+            test_per_tool_label_isolation;
+        ] );
+      ( "fingerprint",
+        [
+          Alcotest.test_case "order-insensitive" `Quick
+            test_fingerprint_is_order_insensitive;
+          Alcotest.test_case "new set reprints" `Quick
+            test_new_fingerprint_reprints_warn;
+        ] );
+      ( "empty",
+        [
+          Alcotest.test_case "empty tools is no-op" `Quick
+            test_empty_tools_is_noop;
+        ] );
+    ]


### PR DESCRIPTION
## Problem (#10097)

`lib/oas_worker_exec_transport.ml:443` emits a WARN on every
codex_cli request whose keeper-bound runtime MCP tool set
includes any tool that needs request-scoped auth headers.

```
143 × "codex_cli omitting keeper-bound runtime MCP tool(s) that require request-scoped auth headers: ..."
```

**1 distinct content × 143 occurrences** — identical 16-tool
list every time. The noise masks unrelated warnings
(`resolve_named_providers leak`, `fixture_contamination`,
`heuristic_metrics degenerate`) in `grep WARN` output.

## Root Cause

The WARN is a **structural fact** about what codex_cli can
carry, not an incident. It was emitted at call-site rate instead
of at "new information" rate. Both signals (structural fact +
frequency) were collapsed into the same channel.

## Fix

Split the two signals:

| Signal | Channel | Rate |
|--------|---------|------|
| Structural fact | `Log.warn` | Once per distinct omitted-tool fingerprint per session |
| Frequency | `masc_codex_cli_mcp_tool_omission_total{tool}` | Every call |

Fingerprint = sorted, comma-joined tool list. If the set
**changes** (a new tool starts being stripped), that is
genuinely new information and the WARN re-fires. Not a single
global "warned-once" flag.

The WARN message now tells the operator where to find the
frequency:
> "subsequent omissions of this same set are counted in
> masc_codex_cli_mcp_tool_omission_total and not re-logged"

`record_codex_cli_omission` lives at the top of
`oas_worker_exec_transport.ml` (alongside other helpers) and is
exported so the invariants are unit-testable without the full
OAS transport harness. `Stdlib.Mutex` guards the dedup Hashtbl
(Eio fibers on separate domains).

## Tests

`test/test_codex_cli_omission_dedup_10097.ml` pins:

- **counter on every call** — 3 calls with same fingerprint
  → counter +3, dedup applies only to logs;
- **per-tool label isolation** — X's counter stays cold when
  Y fires (regression guard for single undifferentiated
  counter anti-pattern);
- **order-insensitive fingerprint** — `[a;b]` and `[b;a]`
  collapse to the same fingerprint;
- **new set re-prints** — a genuinely different omission set
  is NOT silenced; this is the critical invariant that keeps
  the dedup from losing new information;
- **empty list no-op** — pure no-op, no counter, no fingerprint
  slot burned.

Dedicated `(test ...)` stanza with `setenv MASC_BASE_PATH ...`
for the same reason as #10091 (`Masc_mcp` module init triggers
#9903 prod-guard on HOME).

## Notes

- `Option A/B/C` from the issue: this PR implements a hybrid
  (A: one-shot per fingerprint × C: counter). Option B
  (DEBUG-level downgrade) loses the first-occurrence signal
  and the per-tool attribution.
- Dedup is in-memory / session-scoped. A server restart
  re-logs the first occurrence, which is correct: the
  structural fact belongs in the startup-era warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)