### PR TITLE
feat(dashboard): WS-only cutover flag eliminates parallel /sse delivery

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -17,6 +17,7 @@ import { requestNamespaceTruthNow, disposeNamespaceTruthScheduler } from './name
 import { cancelPendingSSERefreshes, registerMissionRefresh, setupSSEReaction, startPeriodicRefresh, stopPeriodicRefresh } from './sse-store'
 import { refreshShell } from './store'
 import { connectDashboardWS, disconnectDashboardWS, subscribeDashboardRoute } from './dashboard-ws'
+import { dashboardWsOnlyEnabled } from './dashboard-ws-cutover'
 import { ensureDevToken } from './api/dev-token'
 import {
   BuildIdentityBadge,
@@ -84,6 +85,11 @@ function refreshCurrentRoute(options?: { recordVisit?: boolean }): void {
 export function App() {
   useEffect(() => {
     let cancelled = false
+    // Resolved once per mount; runtime changes require a reload.  The
+    // server-side fanout guarantees every event that hits /sse also hits
+    // the WS external-subscriber path, so turning SSE off is safe when
+    // operators have validated the WS channel in their environment.
+    const wsOnly = dashboardWsOnlyEnabled()
 
     // Initialize hash router and compatible deep links
     initRouter()
@@ -109,7 +115,13 @@ export function App() {
           .finally(() => {
             if (cancelled) return
             void connectDashboardWS(route.value)
-            connectSSE()
+            // In cutover mode the WS channel is trusted to carry every
+            // broadcast (it is already registered as an Sse external
+            // subscriber on the server).  Opening the /sse EventSource in
+            // parallel only duplicates delivery; skip it.
+            if (!wsOnly) {
+              connectSSE()
+            }
             resumeQueuedOasRuntimeIngress()
           })
       })
@@ -136,7 +148,9 @@ export function App() {
     return () => {
       cancelled = true
       disconnectDashboardWS()
-      disconnectSSE()
+      if (!wsOnly) {
+        disconnectSSE()
+      }
       unsubSSE()
       stopPeriodicRefresh()
       stopErrorCleanup()

--- a/dashboard/src/dashboard-ws-cutover.test.ts
+++ b/dashboard/src/dashboard-ws-cutover.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { dashboardWsOnlyEnabled } from './dashboard-ws-cutover'
+
+type MutableWindow = Window & {
+  __MASC_DASHBOARD_WS_ONLY__?: unknown
+}
+
+describe('dashboardWsOnlyEnabled', () => {
+  let originalWindow: MutableWindow
+
+  beforeEach(() => {
+    originalWindow = window as MutableWindow
+    delete originalWindow.__MASC_DASHBOARD_WS_ONLY__
+    vi.unstubAllEnvs()
+  })
+
+  afterEach(() => {
+    delete originalWindow.__MASC_DASHBOARD_WS_ONLY__
+    vi.unstubAllEnvs()
+  })
+
+  it('defaults to false when neither runtime nor build flag is set', () => {
+    expect(dashboardWsOnlyEnabled()).toBe(false)
+  })
+
+  it('returns true when runtime window flag is explicitly true', () => {
+    originalWindow.__MASC_DASHBOARD_WS_ONLY__ = true
+    expect(dashboardWsOnlyEnabled()).toBe(true)
+  })
+
+  it('returns false when runtime window flag is explicitly false, even if build flag says true', () => {
+    originalWindow.__MASC_DASHBOARD_WS_ONLY__ = false
+    vi.stubEnv('VITE_DASHBOARD_WS_ONLY', 'true')
+    expect(dashboardWsOnlyEnabled()).toBe(false)
+  })
+
+  it('falls through to build flag when runtime flag is not a boolean', () => {
+    originalWindow.__MASC_DASHBOARD_WS_ONLY__ = 'maybe'
+    vi.stubEnv('VITE_DASHBOARD_WS_ONLY', 'true')
+    expect(dashboardWsOnlyEnabled()).toBe(true)
+  })
+
+  it('accepts "true" or "1" as affirmative build flag values', () => {
+    vi.stubEnv('VITE_DASHBOARD_WS_ONLY', 'true')
+    expect(dashboardWsOnlyEnabled()).toBe(true)
+    vi.stubEnv('VITE_DASHBOARD_WS_ONLY', '1')
+    expect(dashboardWsOnlyEnabled()).toBe(true)
+  })
+
+  it('treats other build flag values as false', () => {
+    vi.stubEnv('VITE_DASHBOARD_WS_ONLY', 'yes')
+    expect(dashboardWsOnlyEnabled()).toBe(false)
+    vi.stubEnv('VITE_DASHBOARD_WS_ONLY', '')
+    expect(dashboardWsOnlyEnabled()).toBe(false)
+  })
+})

--- a/dashboard/src/dashboard-ws-cutover.ts
+++ b/dashboard/src/dashboard-ws-cutover.ts
@@ -1,0 +1,31 @@
+// Dashboard WS cutover flag.
+//
+// The dashboard historically opened both an /sse EventSource and a /ws
+// WebSocket in parallel.  The server fans every broadcast to both
+// channels, so every event reaches the client twice — once through the
+// direct SSE stream and once through the WS session's
+// [Sse.subscribe_external] callback.  The client in turn processes each
+// event twice: deltas land in the store via [applyDelta], raw pushes
+// via the [routeServerPushEvent] call inside [handleRawPush].
+//
+// This flag lets operators turn the parallel mode off and run WS-only,
+// eliminating the duplication once the WS transport is trusted in a
+// given environment.  Default is false so existing deployments keep the
+// safety net until explicitly opted in.
+//
+// Precedence (first match wins):
+//   1. window.__MASC_DASHBOARD_WS_ONLY__ === true   (runtime injection)
+//   2. import.meta.env.VITE_DASHBOARD_WS_ONLY === 'true'  (build time)
+//   3. false
+
+interface CutoverWindow extends Window {
+  __MASC_DASHBOARD_WS_ONLY__?: unknown
+}
+
+export function dashboardWsOnlyEnabled(globalRef: Window = window): boolean {
+  const runtime = (globalRef as CutoverWindow).__MASC_DASHBOARD_WS_ONLY__
+  if (runtime === true) return true
+  if (runtime === false) return false
+  const env = import.meta.env?.VITE_DASHBOARD_WS_ONLY
+  return env === 'true' || env === '1'
+}


### PR DESCRIPTION
## Why

The dashboard currently runs **two delivery channels in parallel**: a direct `/sse` EventSource opened by `connectSSE()` in `app.ts:112-113`, plus the `/ws` WebSocket opened by `connectDashboardWS()` one line above.

On the server, `broadcast_impl` (`lib/sse.ml:640-655`) fans every event to both:

1. Direct SSE clients via the `clients_snapshot` path.
2. External subscribers via `notify_external_subscribers event`, which every WS session registers on.

So every broadcast reaches the dashboard twice, and the client processes each event twice: deltas land in the store via `applyDelta`, raw pushes via the `routeServerPushEvent` call inside `handleRawPush`. The WS migration is **in parallel mode** and never actually cut over.

## What

Add a cutover flag that turns the parallel `/sse` open off once operators trust the WS channel.

Resolution order (first match wins):

1. `window.__MASC_DASHBOARD_WS_ONLY__ === true` — runtime injection for staged rollout.
2. `import.meta.env.VITE_DASHBOARD_WS_ONLY === 'true' | '1'` — build-time opt-in for per-deployment control.
3. `false` — default, existing behaviour preserved.

The flag is resolved once per app mount in `app.ts`; toggling at runtime requires a reload.

## Why WS-only is safe

The WS session is already registered as an `Sse` external subscriber (`lib/server/server_ws_standalone.ml:43-54`). Its callback (`send_dashboard_or_raw_sse`) routes every event either:

- into a `dashboard/delta` if the event's `type` maps to a subscribed slice, or
- into a raw SSE text frame if not.

Both paths feed the same client-side store hydration that `/sse` would have driven. Every event the direct SSE connection would have delivered is already delivered through the WS channel.

## Scope

- `dashboard-ws-cutover.ts` (new, 31 lines): flag resolver with the precedence above.
- `dashboard-ws-cutover.test.ts` (new, 56 lines): 6 cases covering default, runtime override (both `true` and explicit `false`), runtime fall-through, affirmative build values (`'true'` / `'1'`), and non-affirmative build values.
- `app.ts` (2 call-site edits): skip `connectSSE()` and `disconnectSSE()` when `wsOnly` is true. `connectDashboardWS` is always called.

Nothing on the server side changes; this is a pure client rollout lever.

## Tests

```
vitest src/dashboard-ws-cutover.test.ts           6/6 pass
vitest src/dashboard-ws.test.ts src/sse.test.ts   19/19 pass
tsc --noEmit                                      clean
```

## What this does NOT do

- Does not remove the `/sse` endpoint or client code. Rollback stays available.
- Does not change server wire format.
- Does not alter the default — existing deployments behave exactly as before unless the flag is set.

## Follow-ups (separate PRs)

- Expose the current mode via `/readyz` or a dashboard diagnostic so operators can verify which transport is active end-to-end.
- Delete the `/sse` client code path once cutover is enabled everywhere for a sustained period and no rollback is needed.
- Remove the `setupSSEReaction` call in the `wsOnly` branch (it becomes a no-op because its signal never fires, but explicit removal clarifies intent).

## Interaction with other open WS PRs

| PR | Layer | Direction |
|----|-------|-----------|
| #10089 | Parse cache | server→client input |
| #10096 | bufferedAmount observability | client→server drain |
| #10098 | Bytes allocation sharing | server→client GC pressure |
| **this** | Transport cutover | eliminates duplicate delivery |

Independent and stackable; this PR operates on the client-side mount entry, not the fanout internals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)