### PR TITLE
fix(keeper-metrics): normalize empty response.model to unknown_provider (#10083)

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -554,7 +554,22 @@ let make_hooks
       match event with
       | Oas.Hooks.AfterTurn { turn; response } ->
         let meta = !meta_ref in
-        let model = response.model in
+        (* #10083: OAS provider transports can return [response.model = ""]
+           on silent failure paths (kimi_cli empty-usage fallback, cascade
+           contract retry exhaustion).  Leaving it empty propagates to
+           every downstream metric label ([masc_after_turn_hook_total],
+           [masc_pricing_catalog_miss_total], [masc_llm_inference_duration_seconds])
+           as the literal key `""`, contaminating per-provider latency
+           histograms and making pricing catalog miss unobservable (which
+           provider is missing?).  Normalise to a stable sentinel
+           `unknown_provider` so the miss becomes grepable and
+           dashboards distinguish empty-model turns from legitimate ones.
+           CLAUDE.md anti-pattern #2: Unknown -> Permissive Default. *)
+        let model =
+          match String.trim response.model with
+          | "" -> "unknown_provider"
+          | s -> s
+        in
         let usage_trust =
           classify_usage_trust ?usage:response.usage ~model
             ~telemetry:response.telemetry ()


### PR DESCRIPTION
## Summary

Single-line defensive fix at `lib/keeper/keeper_hooks_oas.ml:557`. Replaces empty `response.model` with sentinel `"unknown_provider"` so downstream metric labels show provenance rather than literal `""`.

## Observed

`/metrics` current session (10+ events):

```
masc_after_turn_hook_total{model=""} 10
masc_pricing_catalog_miss_total{model=""} 10
masc_llm_inference_duration_seconds_count{model=""} 10
```

Empty string label pollutes per-provider latency histograms and makes pricing catalog miss unobservable ("which provider is missing?").

## Change

```diff
+ let model =
+   match String.trim response.model with
+   | "" -> "unknown_provider"
+   | s -> s
+ in
```

After fix, the same counters will carry `model="unknown_provider"` making the miss rate grepable and dashboards can distinguish.

## Scope

- This is the **MASC boundary normalisation**, not the root cause.
- Root cause is in OAS provider transports (kimi_cli empty-usage fallback, cascade contract retry exhaustion). Tracked separately on #10083.
- cost_usd stays 0.0 (no pricing for unknown_provider) — same conservative fallback. Only the label changes.

## Related

- #10083 (empty model on AfterTurn) — partial mitigation
- #10064 (heartbeat model_used "") — different scope (snapshot vs event); empty sentinel is safe there because no downstream aggregation per-provider on heartbeat
- #10087 (provider resolve leak) — related observability umbrella

## Test plan

- [x] `dune build lib/keeper/` green
- [ ] After rebuild + restart, `/metrics` should show `model="unknown_provider"` labels instead of `model=""` for the silent-failure path turns
- [ ] Per-provider dashboards no longer double-count silent failures under the empty-string label

🤖 Generated with [Claude Code](https://claude.com/claude-code)