### PR TITLE
feat(transport-health): surface WS delivery counters inline in payload

### DIFF
--- a/dashboard/src/api/schemas/transport-health.ts
+++ b/dashboard/src/api/schemas/transport-health.ts
@@ -105,6 +105,22 @@ const GrpcSchema = object({
   events_delivered: fallback(number(), 0),
 })
 
+// Diagnostic counters for the WS delivery path.  Each field falls back
+// to 0 so this remains forward-compatible with servers that have not
+// yet landed the corresponding Prometheus metric (e.g. a dashboard
+// pointed at an older build should not surface schema errors, it
+// should show zeroes and let the operator know the metric is absent).
+const WebsocketDeliverySchema = object({
+  parse_cache_hits: fallback(number(), 0),
+  parse_cache_misses: fallback(number(), 0),
+  bytes_cache_hits: fallback(number(), 0),
+  bytes_cache_misses: fallback(number(), 0),
+  client_acks: fallback(number(), 0),
+  throttled_deliveries: fallback(number(), 0),
+  client_buffered_bytes_sum: fallback(number(), 0),
+  client_buffered_bytes_count: fallback(number(), 0),
+})
+
 const WebsocketSchema = object({
   enabled: fallback(boolean(), false),
   configured: fallback(boolean(), false),
@@ -113,6 +129,16 @@ const WebsocketSchema = object({
   port: fallback(number(), 0),
   sessions: fallback(number(), 0),
   relay_source: fallback(string(), 'unknown'),
+  delivery: fallback(WebsocketDeliverySchema, {
+    parse_cache_hits: 0,
+    parse_cache_misses: 0,
+    bytes_cache_hits: 0,
+    bytes_cache_misses: 0,
+    client_acks: 0,
+    throttled_deliveries: 0,
+    client_buffered_bytes_sum: 0,
+    client_buffered_bytes_count: 0,
+  }),
 })
 
 const WebrtcSchema = object({

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -330,6 +330,33 @@ let transport_health_json ~config =
       ("port", `Int (ws_port ()));
       ("sessions", `Int ws_sessions);
       ("relay_source", `String "sse_external_subscriber");
+      (* Diagnostic counters for the WS delivery path.  Read by literal
+         metric name so this surface does not take a compile-time
+         dependency on any particular WS perf/observability PR.  If the
+         metric has not been registered yet [metric_value_or_zero]
+         returns 0.0, which reads naturally as "nothing has happened" —
+         the same thing the caller would see immediately after server
+         startup before the first event. *)
+      ("delivery", `Assoc [
+        ("parse_cache_hits",
+         `Int (int_of_float (v "masc_ws_parse_cache_hits_total" ())));
+        ("parse_cache_misses",
+         `Int (int_of_float (v "masc_ws_parse_cache_misses_total" ())));
+        ("bytes_cache_hits",
+         `Int (int_of_float (v "masc_ws_bytes_cache_hits_total" ())));
+        ("bytes_cache_misses",
+         `Int (int_of_float (v "masc_ws_bytes_cache_misses_total" ())));
+        ("client_acks",
+         `Int (int_of_float (v "masc_ws_client_acks_total" ())));
+        ("throttled_deliveries",
+         `Int (int_of_float (v "masc_ws_throttled_deliveries_total" ())));
+        (* Histogram sum + auto _count give operators enough to compute
+           average buffered bytes per ack without scraping /metrics. *)
+        ("client_buffered_bytes_sum",
+         `Float (v "masc_ws_client_buffered_bytes" ()));
+        ("client_buffered_bytes_count",
+         `Int (int_of_float (v "masc_ws_client_buffered_bytes_count" ())));
+      ]);
     ]);
     ("webrtc", `Assoc [
       ("enabled", `Bool webrtc_configured);

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -176,6 +176,29 @@ let hot_session_json (session : hot_queue_session) =
       ("idle_seconds", `Float session.idle_seconds);
     ]
 
+type ws_delivery_metric_names = {
+  parse_cache_hits : string;
+  parse_cache_misses : string;
+  bytes_cache_hits : string;
+  bytes_cache_misses : string;
+  client_acks : string;
+  throttled_deliveries : string;
+  client_buffered_bytes : string;
+  client_buffered_bytes_count : string;
+}
+
+let ws_delivery_metric_names =
+  {
+    parse_cache_hits = "masc_ws_parse_cache_hits_total";
+    parse_cache_misses = "masc_ws_parse_cache_misses_total";
+    bytes_cache_hits = "masc_ws_bytes_cache_hits_total";
+    bytes_cache_misses = "masc_ws_bytes_cache_misses_total";
+    client_acks = "masc_ws_client_acks_total";
+    throttled_deliveries = "masc_ws_throttled_deliveries_total";
+    client_buffered_bytes = "masc_ws_client_buffered_bytes";
+    client_buffered_bytes_count = "masc_ws_client_buffered_bytes_count";
+  }
+
 let transport_health_json ~config =
   let v name ?(labels=[]) () =
     Prometheus.metric_value_or_zero name ~labels ()
@@ -242,6 +265,7 @@ let transport_health_json ~config =
       (Prometheus.metric_total
          Prometheus.metric_keeper_lifecycle_dispatch_rejections)
   in
+  let ws_delivery_metrics = ws_delivery_metric_names in
   let ws_sessions = int_of_float (v Prometheus.metric_ws_sessions ()) in
   let grpc_configured = grpc_enabled () in
   let grpc_live = grpc_listening () in
@@ -330,32 +354,30 @@ let transport_health_json ~config =
       ("port", `Int (ws_port ()));
       ("sessions", `Int ws_sessions);
       ("relay_source", `String "sse_external_subscriber");
-      (* Diagnostic counters for the WS delivery path.  Read by literal
-         metric name so this surface does not take a compile-time
-         dependency on any particular WS perf/observability PR.  If the
-         metric has not been registered yet [metric_value_or_zero]
-         returns 0.0, which reads naturally as "nothing has happened" —
-         the same thing the caller would see immediately after server
-         startup before the first event. *)
+      (* Diagnostic counters for the WS delivery path.  The metric names
+         are catalogued here so this surface does not take a compile-time
+         dependency on any particular WS perf/observability PR.  If a
+         producing PR has not registered a metric yet, [metric_value_or_zero]
+         returns 0.0, which reads naturally as "nothing has happened". *)
       ("delivery", `Assoc [
         ("parse_cache_hits",
-         `Int (int_of_float (v "masc_ws_parse_cache_hits_total" ())));
+         `Int (int_of_float (v ws_delivery_metrics.parse_cache_hits ())));
         ("parse_cache_misses",
-         `Int (int_of_float (v "masc_ws_parse_cache_misses_total" ())));
+         `Int (int_of_float (v ws_delivery_metrics.parse_cache_misses ())));
         ("bytes_cache_hits",
-         `Int (int_of_float (v "masc_ws_bytes_cache_hits_total" ())));
+         `Int (int_of_float (v ws_delivery_metrics.bytes_cache_hits ())));
         ("bytes_cache_misses",
-         `Int (int_of_float (v "masc_ws_bytes_cache_misses_total" ())));
+         `Int (int_of_float (v ws_delivery_metrics.bytes_cache_misses ())));
         ("client_acks",
-         `Int (int_of_float (v "masc_ws_client_acks_total" ())));
+         `Int (int_of_float (v ws_delivery_metrics.client_acks ())));
         ("throttled_deliveries",
-         `Int (int_of_float (v "masc_ws_throttled_deliveries_total" ())));
+         `Int (int_of_float (v ws_delivery_metrics.throttled_deliveries ())));
         (* Histogram sum + auto _count give operators enough to compute
            average buffered bytes per ack without scraping /metrics. *)
         ("client_buffered_bytes_sum",
-         `Float (v "masc_ws_client_buffered_bytes" ()));
+         `Float (v ws_delivery_metrics.client_buffered_bytes ()));
         ("client_buffered_bytes_count",
-         `Int (int_of_float (v "masc_ws_client_buffered_bytes_count" ())));
+         `Int (int_of_float (v ws_delivery_metrics.client_buffered_bytes_count ())));
       ]);
     ]);
     ("webrtc", `Assoc [

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -282,8 +282,8 @@ let test_transport_health_json () =
      |> U.to_int);
   (* The [delivery] sub-object surfaces WS cache/ack/throttle counters
      inline so the dashboard can render operational state without
-     scraping /metrics directly.  Fields are read by literal name with
-     [metric_value_or_zero], so presence (not value) is the contract
+     scraping /metrics directly.  Producing metrics may not be registered
+     yet in this standalone PR, so presence (not value) is the contract
      this test enforces. *)
   let delivery_json = ws_json |> U.member "delivery" in
   check bool "websocket delivery sub-object present" true

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -280,6 +280,28 @@ let test_transport_health_json () =
     (agent_health_json
      |> U.member "lifecycle_dispatch_rejections_total"
      |> U.to_int);
+  (* The [delivery] sub-object surfaces WS cache/ack/throttle counters
+     inline so the dashboard can render operational state without
+     scraping /metrics directly.  Fields are read by literal name with
+     [metric_value_or_zero], so presence (not value) is the contract
+     this test enforces. *)
+  let delivery_json = ws_json |> U.member "delivery" in
+  check bool "websocket delivery sub-object present" true
+    (match delivery_json with `Assoc _ -> true | _ -> false);
+  List.iter (fun (field, label) ->
+    check bool (Printf.sprintf "%s field present (int)" label) true
+      (match delivery_json |> U.member field with `Int _ -> true | _ -> false))
+    [ "parse_cache_hits", "parse_cache_hits"
+    ; "parse_cache_misses", "parse_cache_misses"
+    ; "bytes_cache_hits", "bytes_cache_hits"
+    ; "bytes_cache_misses", "bytes_cache_misses"
+    ; "client_acks", "client_acks"
+    ; "throttled_deliveries", "throttled_deliveries"
+    ; "client_buffered_bytes_count", "client_buffered_bytes_count"
+    ];
+  check bool "client_buffered_bytes_sum field present (float)" true
+    (match delivery_json |> U.member "client_buffered_bytes_sum" with
+     | `Float _ | `Int _ -> true | _ -> false);
   ignore (Masc_mcp.Sse.close_all_clients ());
   cleanup_dir base_dir
 


### PR DESCRIPTION
## Why

The broadcast-cached `transport_health_snapshot` event is already what the dashboard consumes to render the transport health strip. It was silent about the WS delivery path: parse/bytes cache effectiveness, client acks, buffered bytes, and backpressure throttling were only visible by scraping `/metrics`.

## What

Add a `delivery` sub-object under `websocket` in `transport_health_json`:

```json
{
  "websocket": {
    "delivery": {
      "parse_cache_hits": 0,
      "parse_cache_misses": 0,
      "bytes_cache_hits": 0,
      "bytes_cache_misses": 0,
      "client_acks": 0,
      "throttled_deliveries": 0,
      "client_buffered_bytes_sum": 0.0,
      "client_buffered_bytes_count": 0
    }
  }
}
```

The producer metrics may live in independent WS PRs, so this PR does not reference producer modules or constants. Instead it keeps the metric names in a small local `ws_delivery_metric_names` catalog and reads them through `metric_value_or_zero`. If a producer PR has not registered a metric yet, the value is `0`, which is the correct cold-start / not-yet-observed state.

## Client Schema

`dashboard/src/api/schemas/transport-health.ts` adds `WebsocketDeliverySchema` with zero defaults, so old servers parse cleanly and new clients see coherent zeroes until data exists.

## Tests

Server:

```text
./scripts/dune-local.sh build test/test_transport_metrics.exe
./_build/default/test/test_transport_metrics.exe
```

Result: `test_transport_metrics` 20/20 pass.

Dashboard tests from the original change remain the intended client-side coverage:

```text
src/api/transport-health.test.ts
src/components/transport-health.test.ts
```

## Interaction With Open WS PRs

| PR | Metric this exposes |
|----|---------------------|
| #10089 | `parse_cache_hits` / `parse_cache_misses` |
| #10096 | `client_acks`, `client_buffered_bytes_sum`, `client_buffered_bytes_count` |
| #10098 | `bytes_cache_hits` / `bytes_cache_misses` |
| #10104 | `throttled_deliveries` |

Works standalone: values stay zero until the producing PRs land or the server observes events.

## Scope Guard

- Additive JSON block only.
- No compile-time dependency on producer PRs.
- No dashboard rendering change in this PR; #10107 renders the fields.
