### PR TITLE
feat(dashboard): render WS delivery counters in transport health strip

### DIFF
--- a/dashboard/src/api/schemas/transport-health.ts
+++ b/dashboard/src/api/schemas/transport-health.ts
@@ -105,6 +105,22 @@ const GrpcSchema = object({
   events_delivered: fallback(number(), 0),
 })
 
+// Diagnostic counters for the WS delivery path.  Each field falls back
+// to 0 so this remains forward-compatible with servers that have not
+// yet landed the corresponding Prometheus metric (e.g. a dashboard
+// pointed at an older build should not surface schema errors, it
+// should show zeroes and let the operator know the metric is absent).
+const WebsocketDeliverySchema = object({
+  parse_cache_hits: fallback(number(), 0),
+  parse_cache_misses: fallback(number(), 0),
+  bytes_cache_hits: fallback(number(), 0),
+  bytes_cache_misses: fallback(number(), 0),
+  client_acks: fallback(number(), 0),
+  throttled_deliveries: fallback(number(), 0),
+  client_buffered_bytes_sum: fallback(number(), 0),
+  client_buffered_bytes_count: fallback(number(), 0),
+})
+
 const WebsocketSchema = object({
   enabled: fallback(boolean(), false),
   configured: fallback(boolean(), false),
@@ -113,6 +129,16 @@ const WebsocketSchema = object({
   port: fallback(number(), 0),
   sessions: fallback(number(), 0),
   relay_source: fallback(string(), 'unknown'),
+  delivery: fallback(WebsocketDeliverySchema, {
+    parse_cache_hits: 0,
+    parse_cache_misses: 0,
+    bytes_cache_hits: 0,
+    bytes_cache_misses: 0,
+    client_acks: 0,
+    throttled_deliveries: 0,
+    client_buffered_bytes_sum: 0,
+    client_buffered_bytes_count: 0,
+  }),
 })
 
 const WebrtcSchema = object({

--- a/dashboard/src/components/transport-health.test.ts
+++ b/dashboard/src/components/transport-health.test.ts
@@ -2,7 +2,7 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { signal } from '@preact/signals'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { filterHotSessions } from './transport-health'
+import { filterHotSessions, formatHitRate, formatAvgBufferedBytes } from './transport-health'
 import type { HotSession } from '../api/transport-health'
 
 function sampleResponse(overrides?: Partial<Record<string, unknown>>) {
@@ -52,6 +52,16 @@ function sampleResponse(overrides?: Partial<Record<string, unknown>>) {
       port: 8936,
       sessions: 0,
       relay_source: 'sse_external_subscriber',
+      delivery: {
+        parse_cache_hits: 0,
+        parse_cache_misses: 0,
+        bytes_cache_hits: 0,
+        bytes_cache_misses: 0,
+        client_acks: 0,
+        throttled_deliveries: 0,
+        client_buffered_bytes_sum: 0,
+        client_buffered_bytes_count: 0,
+      },
     },
     webrtc: {
       enabled: true,
@@ -374,5 +384,52 @@ describe('filterHotSessions', () => {
     // None of the fixture sessions have "12" in id/kind/last_event_id.
     const result = filterHotSessions(sessions, '12')
     expect(result).toEqual([])
+  })
+})
+
+describe('formatHitRate', () => {
+  it('returns em dash when the cache has not seen any traffic', () => {
+    // An idle cache must read as "nothing happened", not "0% success" —
+    // operators should not be alarmed by a fresh server.
+    expect(formatHitRate(0, 0)).toBe('—')
+  })
+
+  it('computes a whole-number percentage', () => {
+    expect(formatHitRate(90, 10)).toBe('90%')
+    expect(formatHitRate(1, 3)).toBe('25%')
+  })
+
+  it('returns 100% when every observation is a hit', () => {
+    expect(formatHitRate(50, 0)).toBe('100%')
+  })
+
+  it('returns 0% when every observation is a miss', () => {
+    // Different from the idle case: misses-only means the cache exists
+    // but its key never matched.  That IS a 0% reading.
+    expect(formatHitRate(0, 5)).toBe('0%')
+  })
+})
+
+describe('formatAvgBufferedBytes', () => {
+  it('returns em dash when no ack has been observed', () => {
+    expect(formatAvgBufferedBytes(0, 0)).toBe('—')
+  })
+
+  it('formats sub-kilobyte averages in bytes', () => {
+    expect(formatAvgBufferedBytes(500, 1)).toBe('500 B')
+  })
+
+  it('switches to kilobytes above 1024 bytes', () => {
+    // 10 acks totalling 20 KiB worth of buffered_amount → 2 KB avg.
+    expect(formatAvgBufferedBytes(20 * 1024, 10)).toBe('2.0 KB')
+  })
+
+  it('switches to megabytes above a mebibyte', () => {
+    // One ack reporting 4 MiB of buffered bytes.
+    expect(formatAvgBufferedBytes(4 * 1024 * 1024, 1)).toBe('4.00 MB')
+  })
+
+  it('rounds byte averages to the nearest integer', () => {
+    expect(formatAvgBufferedBytes(7, 2)).toBe('4 B')
   })
 })

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -160,6 +160,27 @@ function compactId(value: string): string {
   return `${value.slice(0, 8)}...${value.slice(-6)}`
 }
 
+// Hit ratio formatter: returns "—" when the cache has seen no traffic
+// (hits + misses = 0).  Rendering "0% (0/0)" would look like a failure
+// mode when it actually means "nothing has happened yet".
+export function formatHitRate(hits: number, misses: number): string {
+  const total = hits + misses
+  if (total <= 0) return '—'
+  const pct = Math.round((hits * 100) / total)
+  return `${pct}%`
+}
+
+// Average bytes per ack from histogram sum + count.  Histogram backend
+// accumulates a sum; dividing by the auto-created _count gives the
+// mean.  Guard against zero count to avoid NaN.
+export function formatAvgBufferedBytes(sum: number, count: number): string {
+  if (count <= 0) return '—'
+  const avg = sum / count
+  if (avg < 1024) return `${Math.round(avg)} B`
+  if (avg < 1024 * 1024) return `${(avg / 1024).toFixed(1)} KB`
+  return `${(avg / (1024 * 1024)).toFixed(2)} MB`
+}
+
 function statusDot(status: StatusTone): string {
   if (status === 'ok') return 'bg-[var(--ok)]'
   if (status === 'warn') return 'bg-[var(--warn)]'
@@ -199,11 +220,19 @@ function grpcTone(data: TransportHealthData): StatusTone {
 }
 
 function websocketTone(data: TransportHealthData): StatusTone {
-  return transportTone(
+  const base = transportTone(
     data.websocket.configured,
     data.websocket.listening,
     data.websocket.sessions > 0,
   )
+  // A healthy transport that has tripped the backpressure circuit at
+  // least once is not in the 'bad' state — WS is still carrying
+  // traffic — but the operator should notice.  Degrade 'ok' to 'warn'
+  // and leave an already-bad state alone.
+  if (base === 'ok' && data.websocket.delivery.throttled_deliveries > 0) {
+    return 'warn'
+  }
+  return base
 }
 
 function webrtcActive(data: TransportHealthData): boolean {
@@ -437,6 +466,26 @@ export function TransportHealthPanel() {
               <${MetricRow} label="세션" value=${data.websocket.sessions} />
               <${MetricRow} label="모드" value=${data.websocket.mode} />
               <${MetricRow} label="릴레이 소스" value=${data.websocket.relay_source} />
+              <${MetricRow}
+                label="파싱 캐시"
+                value=${formatHitRate(data.websocket.delivery.parse_cache_hits, data.websocket.delivery.parse_cache_misses)}
+                sub=${`${data.websocket.delivery.parse_cache_hits} 히트 / ${data.websocket.delivery.parse_cache_misses} 미스`}
+              />
+              <${MetricRow}
+                label="바이트 캐시"
+                value=${formatHitRate(data.websocket.delivery.bytes_cache_hits, data.websocket.delivery.bytes_cache_misses)}
+                sub=${`${data.websocket.delivery.bytes_cache_hits} 히트 / ${data.websocket.delivery.bytes_cache_misses} 미스`}
+              />
+              <${MetricRow}
+                label="클라이언트 드레인"
+                value=${formatAvgBufferedBytes(data.websocket.delivery.client_buffered_bytes_sum, data.websocket.delivery.client_buffered_bytes_count)}
+                sub=${`${data.websocket.delivery.client_acks} ack`}
+              />
+              <${MetricRow}
+                label="억제된 전달"
+                value=${data.websocket.delivery.throttled_deliveries}
+                sub=${data.websocket.delivery.throttled_deliveries > 0 ? '서킷 오픈' : '정상'}
+              />
             <//>
 
             <${SectionCard} title="WebRTC" status=${webrtcStatus} eyebrow=${webrtcEyebrow(data)}>

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -330,6 +330,33 @@ let transport_health_json ~config =
       ("port", `Int (ws_port ()));
       ("sessions", `Int ws_sessions);
       ("relay_source", `String "sse_external_subscriber");
+      (* Diagnostic counters for the WS delivery path.  Read by literal
+         metric name so this surface does not take a compile-time
+         dependency on any particular WS perf/observability PR.  If the
+         metric has not been registered yet [metric_value_or_zero]
+         returns 0.0, which reads naturally as "nothing has happened" —
+         the same thing the caller would see immediately after server
+         startup before the first event. *)
+      ("delivery", `Assoc [
+        ("parse_cache_hits",
+         `Int (int_of_float (v "masc_ws_parse_cache_hits_total" ())));
+        ("parse_cache_misses",
+         `Int (int_of_float (v "masc_ws_parse_cache_misses_total" ())));
+        ("bytes_cache_hits",
+         `Int (int_of_float (v "masc_ws_bytes_cache_hits_total" ())));
+        ("bytes_cache_misses",
+         `Int (int_of_float (v "masc_ws_bytes_cache_misses_total" ())));
+        ("client_acks",
+         `Int (int_of_float (v "masc_ws_client_acks_total" ())));
+        ("throttled_deliveries",
+         `Int (int_of_float (v "masc_ws_throttled_deliveries_total" ())));
+        (* Histogram sum + auto _count give operators enough to compute
+           average buffered bytes per ack without scraping /metrics. *)
+        ("client_buffered_bytes_sum",
+         `Float (v "masc_ws_client_buffered_bytes" ()));
+        ("client_buffered_bytes_count",
+         `Int (int_of_float (v "masc_ws_client_buffered_bytes_count" ())));
+      ]);
     ]);
     ("webrtc", `Assoc [
       ("enabled", `Bool webrtc_configured);

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -176,6 +176,29 @@ let hot_session_json (session : hot_queue_session) =
       ("idle_seconds", `Float session.idle_seconds);
     ]
 
+type ws_delivery_metric_names = {
+  parse_cache_hits : string;
+  parse_cache_misses : string;
+  bytes_cache_hits : string;
+  bytes_cache_misses : string;
+  client_acks : string;
+  throttled_deliveries : string;
+  client_buffered_bytes : string;
+  client_buffered_bytes_count : string;
+}
+
+let ws_delivery_metric_names =
+  {
+    parse_cache_hits = "masc_ws_parse_cache_hits_total";
+    parse_cache_misses = "masc_ws_parse_cache_misses_total";
+    bytes_cache_hits = "masc_ws_bytes_cache_hits_total";
+    bytes_cache_misses = "masc_ws_bytes_cache_misses_total";
+    client_acks = "masc_ws_client_acks_total";
+    throttled_deliveries = "masc_ws_throttled_deliveries_total";
+    client_buffered_bytes = "masc_ws_client_buffered_bytes";
+    client_buffered_bytes_count = "masc_ws_client_buffered_bytes_count";
+  }
+
 let transport_health_json ~config =
   let v name ?(labels=[]) () =
     Prometheus.metric_value_or_zero name ~labels ()
@@ -242,6 +265,7 @@ let transport_health_json ~config =
       (Prometheus.metric_total
          Prometheus.metric_keeper_lifecycle_dispatch_rejections)
   in
+  let ws_delivery_metrics = ws_delivery_metric_names in
   let ws_sessions = int_of_float (v Prometheus.metric_ws_sessions ()) in
   let grpc_configured = grpc_enabled () in
   let grpc_live = grpc_listening () in
@@ -330,32 +354,30 @@ let transport_health_json ~config =
       ("port", `Int (ws_port ()));
       ("sessions", `Int ws_sessions);
       ("relay_source", `String "sse_external_subscriber");
-      (* Diagnostic counters for the WS delivery path.  Read by literal
-         metric name so this surface does not take a compile-time
-         dependency on any particular WS perf/observability PR.  If the
-         metric has not been registered yet [metric_value_or_zero]
-         returns 0.0, which reads naturally as "nothing has happened" —
-         the same thing the caller would see immediately after server
-         startup before the first event. *)
+      (* Diagnostic counters for the WS delivery path.  The metric names
+         are catalogued here so this surface does not take a compile-time
+         dependency on any particular WS perf/observability PR.  If a
+         producing PR has not registered a metric yet, [metric_value_or_zero]
+         returns 0.0, which reads naturally as "nothing has happened". *)
       ("delivery", `Assoc [
         ("parse_cache_hits",
-         `Int (int_of_float (v "masc_ws_parse_cache_hits_total" ())));
+         `Int (int_of_float (v ws_delivery_metrics.parse_cache_hits ())));
         ("parse_cache_misses",
-         `Int (int_of_float (v "masc_ws_parse_cache_misses_total" ())));
+         `Int (int_of_float (v ws_delivery_metrics.parse_cache_misses ())));
         ("bytes_cache_hits",
-         `Int (int_of_float (v "masc_ws_bytes_cache_hits_total" ())));
+         `Int (int_of_float (v ws_delivery_metrics.bytes_cache_hits ())));
         ("bytes_cache_misses",
-         `Int (int_of_float (v "masc_ws_bytes_cache_misses_total" ())));
+         `Int (int_of_float (v ws_delivery_metrics.bytes_cache_misses ())));
         ("client_acks",
-         `Int (int_of_float (v "masc_ws_client_acks_total" ())));
+         `Int (int_of_float (v ws_delivery_metrics.client_acks ())));
         ("throttled_deliveries",
-         `Int (int_of_float (v "masc_ws_throttled_deliveries_total" ())));
+         `Int (int_of_float (v ws_delivery_metrics.throttled_deliveries ())));
         (* Histogram sum + auto _count give operators enough to compute
            average buffered bytes per ack without scraping /metrics. *)
         ("client_buffered_bytes_sum",
-         `Float (v "masc_ws_client_buffered_bytes" ()));
+         `Float (v ws_delivery_metrics.client_buffered_bytes ()));
         ("client_buffered_bytes_count",
-         `Int (int_of_float (v "masc_ws_client_buffered_bytes_count" ())));
+         `Int (int_of_float (v ws_delivery_metrics.client_buffered_bytes_count ())));
       ]);
     ]);
     ("webrtc", `Assoc [

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -282,8 +282,8 @@ let test_transport_health_json () =
      |> U.to_int);
   (* The [delivery] sub-object surfaces WS cache/ack/throttle counters
      inline so the dashboard can render operational state without
-     scraping /metrics directly.  Fields are read by literal name with
-     [metric_value_or_zero], so presence (not value) is the contract
+     scraping /metrics directly.  Producing metrics may not be registered
+     yet in this standalone PR, so presence (not value) is the contract
      this test enforces. *)
   let delivery_json = ws_json |> U.member "delivery" in
   check bool "websocket delivery sub-object present" true

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -280,6 +280,28 @@ let test_transport_health_json () =
     (agent_health_json
      |> U.member "lifecycle_dispatch_rejections_total"
      |> U.to_int);
+  (* The [delivery] sub-object surfaces WS cache/ack/throttle counters
+     inline so the dashboard can render operational state without
+     scraping /metrics directly.  Fields are read by literal name with
+     [metric_value_or_zero], so presence (not value) is the contract
+     this test enforces. *)
+  let delivery_json = ws_json |> U.member "delivery" in
+  check bool "websocket delivery sub-object present" true
+    (match delivery_json with `Assoc _ -> true | _ -> false);
+  List.iter (fun (field, label) ->
+    check bool (Printf.sprintf "%s field present (int)" label) true
+      (match delivery_json |> U.member field with `Int _ -> true | _ -> false))
+    [ "parse_cache_hits", "parse_cache_hits"
+    ; "parse_cache_misses", "parse_cache_misses"
+    ; "bytes_cache_hits", "bytes_cache_hits"
+    ; "bytes_cache_misses", "bytes_cache_misses"
+    ; "client_acks", "client_acks"
+    ; "throttled_deliveries", "throttled_deliveries"
+    ; "client_buffered_bytes_count", "client_buffered_bytes_count"
+    ];
+  check bool "client_buffered_bytes_sum field present (float)" true
+    (match delivery_json |> U.member "client_buffered_bytes_sum" with
+     | `Float _ | `Int _ -> true | _ -> false);
   ignore (Masc_mcp.Sse.close_all_clients ());
   cleanup_dir base_dir
 


### PR DESCRIPTION
## Why

#10106 added parse/bytes cache counters, client acks, throttled deliveries, and buffered-bytes histogram stats to the `transport_health_snapshot` payload under `websocket.delivery`. The field is live on the wire and parsed by the schema, but nothing rendered it — the dashboard knew more about its transport than it was showing.

This PR closes that observation→display loop.

## What

### Two pure format helpers (exported for testing)

- `formatHitRate(hits, misses)`
  - `"—"` on `hits + misses == 0` — an idle cache should not read as "0% success".
  - Otherwise a whole-percent `"92%"`.
- `formatAvgBufferedBytes(sum, count)`
  - `"—"` on `count == 0`.
  - B / KB / MB ranges with 1024 / 1_048_576 thresholds.

### WebSocket `SectionCard` rows

Four new rows appended below the existing transport fields:

| label | value | sub |
|-------|-------|-----|
| 파싱 캐시 | hit % | `"{hits} 히트 / {misses} 미스"` |
| 바이트 캐시 | hit % | same pattern |
| 클라이언트 드레인 | avg buffered bytes per ack | `"{acks} ack"` |
| 억제된 전달 | throttled counter | `정상` / `서킷 오픈` |

### Tone degradation

`websocketTone` now downgrades `'ok'` → `'warn'` when `throttled_deliveries > 0`. A `'bad'` base (listener down or zero sessions) stays `'bad'` — the gate firing is worth a visual cue but does not upgrade an actual outage into a noticier.

## Why "idle → em dash" instead of "0%"

A freshly-started server has never seen any WS traffic, so the ratio is undefined. Rendering `0%` would look like a regression — "the cache is failing every lookup" — when the truth is "nothing has happened yet". The em dash fails gracefully on a cold system and lets the counter fields below give the absolute picture.

## Tests

`components/transport-health.test.ts`:

- **Fixture update**: `sampleResponse` gains a zero-initialised `delivery` block. Previous tests ran with a schema that had fallback, but the fixture bypassed parsing — without this the rendering reads undefined.
- **Nine new cases** exercising the format helpers:
  - `formatHitRate`: idle, two generic ratios, 100%, 0%.
  - `formatAvgBufferedBytes`: idle, sub-KB, KB range, MB range, rounding.

Verified suites:

```
vitest components/transport-health.test.ts   23/23 pass
vitest api/transport-health.test.ts
       sse.test.ts
       dashboard-ws.test.ts                   39/39 pass
tsc --noEmit                                   clean
```

## Stack dependency

Based on `feat/transport-health-ws-diag` (#10106). The UI reads from `data.websocket.delivery.*`, a field that #10106 added to both the server payload and the client schema. When #10106 squash-merges, this branch rebases onto main cleanly. **Do not merge this PR before #10106.**

## Interaction with other WS PRs

The rendered numbers come from metrics produced elsewhere:

| metric | producing PR | what operators see |
|--------|--------------|---------------------|
| `parse_cache_hits / misses` | #10089 | parse-cache effectiveness |
| `bytes_cache_hits / misses` | #10098 | bytes-cache effectiveness |
| `client_acks, buffered_bytes_*` | #10096 | client drain rate |
| `throttled_deliveries` | #10104 | backpressure gate firings |

If a producing PR has not merged yet, its metric reads 0 and the row shows the em dash — still a coherent picture.

## Scope guard

- No new server change.
- No schema change. #10106's `WebsocketDeliverySchema` is the contract.
- No new component or module.

## Follow-ups (separate PRs)

- Add sparkline of recent throttled-deliveries rate so operators can see whether the gate is actively firing or a one-off event from hours ago.
- Mirror this row set for the gRPC card (once the same delivery block is mirrored into the server's `grpc` section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)