### PR TITLE
fix(oas-bridge): per-caller timeout SSOT replacing 7 hardcoded literals (#10094)

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -488,7 +488,7 @@ let review
         (false, sprintf "Invalid verdict format: %s" msg)
     in
     (match
-       Masc_oas_bridge.run_safe ~timeout_s:180.0 (fun () ->
+       Masc_oas_bridge.run_with_caller ~caller:"anti_rationalization" (fun () ->
          Oas_worker.run_named_with_masc_tools
            ~cascade_name:evaluator_cascade
            ~goal:prompt

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -175,7 +175,7 @@ let call_model_direct_sync ~agent_type ~prompt =
   let cascade_name = cascade_name_for_agent_type agent_type in
   try
     match
-      Masc_oas_bridge.run_safe ~timeout_s:60.0 (fun () ->
+      Masc_oas_bridge.run_with_caller ~caller:"auto_responder" (fun () ->
         Oas_worker.run_named ~cascade_name
           ~goal:prompt ~max_turns:1
           ~accept:model_response_is_valid ~max_tokens:500

--- a/lib/autoresearch_codegen.ml
+++ b/lib/autoresearch_codegen.ml
@@ -138,7 +138,7 @@ let generate_code_change ~goal ~baseline ~lower_is_better ~history ~insights
   let prompt = build_code_change_prompt ~goal ~baseline ~lower_is_better ~history ~insights
     ~file_content ~target_file in
   match
-    Masc_oas_bridge.run_safe ~timeout_s:120.0 (fun () ->
+    Masc_oas_bridge.run_with_caller ~caller:"autoresearch_codegen" (fun () ->
       Oas_worker.run_named ~cascade_name:"autoresearch"
         ~goal:prompt ~max_turns:1
         ~temperature:(Cascade_inference.resolve_temperature

--- a/lib/config/dune
+++ b/lib/config/dune
@@ -9,6 +9,7 @@
    env_config_core
    env_config_governance
    env_config_keeper
+   env_config_oas_bridge
    env_config_runtime
    env_config_snapshot
    feature_flag_registry

--- a/lib/config/env_config_oas_bridge.ml
+++ b/lib/config/env_config_oas_bridge.ml
@@ -1,0 +1,109 @@
+(** Env_config_oas_bridge — per-caller OAS bridge timeout SSOT (#10094).
+
+    Replaces seven hardcoded [Masc_oas_bridge.run_safe ~timeout_s:N.N]
+    literals scattered across the lib tree.  Each caller is named so:
+
+      1. its default is preserved when the original literal was a
+         deliberately-tuned value (autoresearch_codegen=120s,
+         tool_deep_review=180s, anti_rationalization=180s);
+      2. the two "fantasy" 60s budgets ([auto_responder],
+         [dashboard_provider_runs]) get raised to [default_timeout_sec]
+         (300s) — the original 60s did not match observed p50 latency
+         (50–700s) and produced 27 timeouts/session;
+      3. the operator can override any single caller's budget via
+         [MASC_OAS_BRIDGE_TIMEOUT_<CALLER>_SEC];
+      4. the operator can shift every default in lockstep via
+         [MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC] without per-caller
+         tuning, useful when an OAS deployment is uniformly slow.
+
+    The lookup order is per-caller env > per-caller hardcoded default
+    > [MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC] > 300.0.  An unknown
+    caller (string typo or future caller without a default) falls
+    through to the global default rather than failing closed — the
+    operator will see [metric_oas_bridge_timeout{caller=...}] in
+    Prometheus regardless. *)
+
+(** Hardcoded default seconds for each known caller.  When the
+    original literal was 60s on a path with observed p50 above 60s,
+    we raise to [global_default_sec] (300s) — silent fix for the
+    fantasy budgets called out in #10094.  When the original literal
+    was 120/180s on a path that intentionally needed more compute,
+    we preserve the value so the fix does not regress
+    autoresearch / deep_review / anti_rationalization. *)
+let global_default_sec = 300.0
+
+let known_caller_defaults : (string * float) list = [
+  (* #10094: was hardcoded 60s, raised to global_default.  p50 of
+     the underlying LLM call is in the 50–700s range; 60s timed out
+     27 times per session. *)
+  "auto_responder", global_default_sec;
+  "dashboard_provider_runs", global_default_sec;
+
+  (* Preserved at original literal — these were tuned for the
+     specific compute pattern of the caller. *)
+  "autoresearch_codegen", 120.0;
+  "keeper_persona_authoring", 120.0;
+  "server_openai_compat", 120.0;
+  "tool_deep_review", 180.0;
+  "anti_rationalization", 180.0;
+]
+
+let upper_case s =
+  s
+  |> String.map (fun c ->
+       if c >= 'a' && c <= 'z' then
+         Char.chr (Char.code c - 32)
+       else if c = '-' then '_'
+       else c)
+
+let per_caller_env_var ~caller =
+  Printf.sprintf "MASC_OAS_BRIDGE_TIMEOUT_%s_SEC" (upper_case caller)
+
+let global_env_var = "MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC"
+
+(** Empty-string env vars (the [Unix.putenv NAME ""] pattern used
+    by tests to clear an override) must NOT be treated as "set".
+    [Sys.getenv_opt] returns [Some ""] in that case. *)
+let trimmed_value_opt name =
+  match Env_config_core.raw_value_opt name with
+  | Some v ->
+    let t = String.trim v in
+    if t = "" then None else Some t
+  | None -> None
+
+(** [timeout_sec ~caller ()] resolves the OAS bridge timeout for
+    [caller].  Lookup order:
+
+      1. Per-caller env [MASC_OAS_BRIDGE_TIMEOUT_<CALLER>_SEC]
+         — wins unconditionally.  Lets the operator tune one
+         caller without touching others.
+      2. Per-caller hardcoded default ([known_caller_defaults]).
+         Preserves intentional 120/180s budgets for compute-heavy
+         callers; raises the fantasy 60s budgets to
+         [global_default_sec] (300s).
+      3. Global env [MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC] — only
+         consulted for UNKNOWN callers (typo, future caller
+         without a default entry).  Treating it as an override
+         would let one slow provider silently shift every
+         caller's budget; that is a footgun.
+      4. [global_default_sec] (300s) hardcoded final fallback. *)
+let timeout_sec ~caller () =
+  let per_caller_env = per_caller_env_var ~caller in
+  match trimmed_value_opt per_caller_env with
+  | Some v ->
+    Safe_ops.float_of_string_with_default
+      ~default:global_default_sec v
+  | None ->
+    match List.assoc_opt caller known_caller_defaults with
+    | Some d -> d
+    | None ->
+      (* Unknown caller: fall to global env, then global default. *)
+      match trimmed_value_opt global_env_var with
+      | Some v ->
+        Safe_ops.float_of_string_with_default
+          ~default:global_default_sec v
+      | None -> global_default_sec
+
+(** Exported for tests that pin the per-caller default table. *)
+let known_callers () : string list =
+  List.map fst known_caller_defaults

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -420,7 +420,7 @@ let execute_single_agent_run ~sw ~net ~run_id ~provider ~model ~prompt =
                provider)
         else (
           match
-            Masc_oas_bridge.run_safe ~timeout_s:60.0 (fun () ->
+            Masc_oas_bridge.run_with_caller ~caller:"dashboard_provider_runs" (fun () ->
               Oas_worker.run_model_by_label ~model_label:label ~goal:prompt
                 ~system_prompt:(run_system_prompt provider)
                 ~max_turns:4

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -1149,17 +1149,19 @@ let handle_persona_generate ctx args =
                ~language
            in
            match
-             Masc_oas_bridge.run_safe ~timeout_s:120.0 (fun () ->
-               Oas_worker.run_named
-                 ~cascade_name
-                 ~goal:prompt
-                 ~max_turns:1
-                 ~temperature
-                 ~max_tokens
-                 ~approval:Approval_callbacks.auto_approve
-                 ~sw:ctx.Keeper_types.sw
-                 ?net:ctx.Keeper_types.net
-                 ())
+             Masc_oas_bridge.run_with_caller
+               ~caller:"keeper_persona_authoring"
+               (fun () ->
+                 Oas_worker.run_named
+                   ~cascade_name
+                   ~goal:prompt
+                   ~max_turns:1
+                   ~temperature
+                   ~max_tokens
+                   ~approval:Approval_callbacks.auto_approve
+                   ~sw:ctx.Keeper_types.sw
+                   ?net:ctx.Keeper_types.net
+                   ())
            with
            | Error err ->
              ( false

--- a/lib/masc_oas_bridge.ml
+++ b/lib/masc_oas_bridge.ml
@@ -5,8 +5,16 @@
 (** Safe execution of a generic OAS operation.
     Applies timeout handling when an Eio clock is available, and converts
     [Eio.Time.Timeout] into an error result.
-    [Eio.Cancel.Cancelled] is always re-raised to preserve structured concurrency. *)
-let run_safe ~timeout_s fn =
+    [Eio.Cancel.Cancelled] is always re-raised to preserve structured concurrency.
+
+    [caller] (#10094) is a free-form identifier ("auto_responder",
+    "tool_deep_review", ...) that flows into the timeout label so
+    operators can distinguish fantasy budgets from intentional ones
+    when both fire timeouts in the same session.  Defaults to
+    "unknown" so legacy callers still compile; new code should
+    pass [~caller] explicitly or use {!run_with_caller}, which
+    also pulls the configured budget from [Env_config_oas_bridge]. *)
+let run_safe ?(caller = "unknown") ~timeout_s fn =
   let do_timeout fn =
     match Masc_eio_env.get_opt () with
     | Some { clock = Some clock; _ } -> Eio.Time.with_timeout_exn clock timeout_s fn
@@ -16,13 +24,42 @@ let run_safe ~timeout_s fn =
     do_timeout fn
   with
   | Eio.Time.Timeout ->
-    Log.Misc.warn "masc_oas_bridge: OAS execution timed out after %.1fs" timeout_s;
+    (* #10094: per-caller timeout counter so the operator can see
+       WHICH caller is timing out at WHICH configured budget — log
+       lines alone collapsed all 27 [auto_responder] 60s-timeouts
+       and the 1 [tool_deep_review] 180s-timeout into the same
+       "after N.Ns" string. *)
+    Prometheus.inc_counter
+      Prometheus.metric_oas_bridge_timeout
+      ~labels:[
+        ("caller", caller);
+        ("timeout_s", Printf.sprintf "%.1f" timeout_s);
+      ] ();
+    Log.Misc.warn
+      "masc_oas_bridge: OAS execution timed out after %.1fs (caller=%s)"
+      timeout_s caller;
     Error (Oas.Error.Api (Timeout { message = Printf.sprintf "Execution timed out after %.1fs" timeout_s }))
   | Eio.Cancel.Cancelled _ as exn ->
     let bt = Printexc.get_raw_backtrace () in
-    Log.Misc.warn "masc_oas_bridge: OAS execution cancelled";
+    Log.Misc.warn "masc_oas_bridge: OAS execution cancelled (caller=%s)" caller;
     Printexc.raise_with_backtrace exn bt
   | exn ->
     let bt = Printexc.get_backtrace () in
-    Log.Misc.error "masc_oas_bridge: OAS execution error: %s\n%s" (Printexc.to_string exn) bt;
+    Log.Misc.error "masc_oas_bridge: OAS execution error (caller=%s): %s\n%s"
+      caller (Printexc.to_string exn) bt;
     Error (Oas.Error.Internal (Printexc.to_string exn))
+
+(** [run_with_caller ~caller fn] — single entry point that resolves
+    the per-caller timeout from [Env_config_oas_bridge] and labels
+    the resulting Prometheus counter.  Replaces the seven hardcoded
+    [run_safe ~timeout_s:N.N] literals scattered across the lib
+    tree.  The original tuned values for autoresearch / deep_review
+    / anti_rationalization are preserved as per-caller defaults;
+    the two fantasy 60s budgets ([auto_responder],
+    [dashboard_provider_runs]) are raised to the global default
+    (300s) since the original 60s did not match observed p50
+    latency.  See [Env_config_oas_bridge] for the full table and
+    env-var override layout. *)
+let run_with_caller ~caller fn =
+  let timeout_s = Env_config_oas_bridge.timeout_sec ~caller () in
+  run_safe ~caller ~timeout_s fn

--- a/lib/masc_oas_bridge.mli
+++ b/lib/masc_oas_bridge.mli
@@ -4,8 +4,23 @@
     Enforces strict structural timeouts, cancellation safety, and type isolation. *)
 
 (** Safe execution of a generic OAS operation with a mandatory timeout.
-    Catches [Eio.Time.Timeout] and [Eio.Cancel.Cancelled] to perform functional rollback. *)
+    Catches [Eio.Time.Timeout] and [Eio.Cancel.Cancelled] to perform functional rollback.
+    [caller] (#10094) labels the Prometheus timeout counter so the
+    operator can attribute timeouts to specific call sites; defaults
+    to ["unknown"] for backwards compatibility with legacy callers. *)
 val run_safe :
+  ?caller:string ->
   timeout_s:float ->
+  (unit -> ('a, Oas.Error.sdk_error) result) ->
+  ('a, Oas.Error.sdk_error) result
+
+(** Single entry point that resolves the per-caller timeout from
+    [Env_config_oas_bridge] and labels the resulting Prometheus
+    counter.  Preferred over [run_safe] for new callers — the
+    timeout is no longer a hardcoded literal but an
+    env-overridable per-caller budget.  See [Env_config_oas_bridge]
+    for the per-caller default table and env-var layout. *)
+val run_with_caller :
+  caller:string ->
   (unit -> ('a, Oas.Error.sdk_error) result) ->
   ('a, Oas.Error.sdk_error) result

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -281,6 +281,19 @@ let metric_persistence_read_drops =
 let metric_codex_cli_mcp_tool_omission =
   "masc_codex_cli_mcp_tool_omission_total"
 
+(* #10094: per-caller counter for [Masc_oas_bridge.run_safe]
+   timeouts.  The [caller] string supplied at the run_safe entry
+   point lets the operator see WHICH caller is timing out at
+   WHICH configured budget without grepping warn-level log
+   lines.  Paired with per-caller env-overridable defaults in
+   [Env_config_oas_bridge] so 60s "fantasy" budgets in
+   [auto_responder] / [dashboard_provider_runs] no longer
+   silently masquerade as the same class of event as
+   intentional 120s/180s budgets in autoresearch / deep_review. *)
+let metric_oas_bridge_timeout =
+  "masc_oas_bridge_timeout_total"
+
+
 (* OAS SSE relay (oas_sse_bridge.ml). *)
 let metric_oas_sse_relay_retries =
   "masc_oas_sse_relay_retries_total"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -112,6 +112,10 @@ val metric_codex_cli_mcp_tool_omission : string
     MCP omissions.  Paired with a once-per-fingerprint WARN log
     so logs carry structural facts and Prometheus carries
     frequency. *)
+val metric_oas_bridge_timeout : string
+(** #10094: labelled [caller, timeout_s] so operators can
+    distinguish fantasy 60s budgets from intentional 120/180s
+    budgets when both fire timeouts in the same session. *)
 val metric_oas_sse_relay_retries : string
 val metric_oas_sse_relay_drops : string
 val metric_oas_sse_relay_queue_depth : string

--- a/lib/server/server_openai_compat.ml
+++ b/lib/server/server_openai_compat.ml
@@ -102,7 +102,7 @@ let route_keeper ~config ~sw ~clock ~keeper_name ~message : (string, string) res
 let route_cascade ~message ~system_prompt ~max_tokens ~temperature
   : (string, string) result =
   match
-    Masc_oas_bridge.run_safe ~timeout_s:120.0 (fun () ->
+    Masc_oas_bridge.run_with_caller ~caller:"server_openai_compat" (fun () ->
       Oas_worker.run_named
         ~cascade_name:"default_models"
         ~goal:message

--- a/lib/tool_deep_review.ml
+++ b/lib/tool_deep_review.ml
@@ -104,7 +104,7 @@ let handle_deep_review (config : Coord.config) args : bool * string =
         ]))
     | Ok prompt ->
         match
-          Masc_oas_bridge.run_safe ~timeout_s:180.0 (fun () ->
+          Masc_oas_bridge.run_with_caller ~caller:"tool_deep_review" (fun () ->
             Oas_worker.run_named
               ~cascade_name:"adversarial_reviewer"
               ~goal:prompt

--- a/test/dune
+++ b/test/dune
@@ -430,6 +430,18 @@
     (run %{test}))))
  (libraries masc_test_deps))
 
+; #10094: dedicated stanza so MASC_BASE_PATH is set BEFORE the
+; test executable loads.  Same rationale as #10091/#10097/#10101.
+(test
+ (name test_oas_bridge_timeout_ssot_10094)
+ (modules test_oas_bridge_timeout_ssot_10094)
+ (action
+  (setenv MASC_BASE_PATH /tmp/test-oas-bridge-timeout-ssot-10094
+   (setenv MASC_BASE_PATH_INPUT /tmp/test-oas-bridge-timeout-ssot-10094
+    (run %{test}))))
+ (libraries masc_test_deps))
+
+
 ; test_worker_run_evidence_summary removed (team session cleanup)
 
 ; test_team_session_worker_run_meta_repair removed (team session cleanup)

--- a/test/test_oas_bridge_timeout_ssot_10094.ml
+++ b/test/test_oas_bridge_timeout_ssot_10094.ml
@@ -1,0 +1,179 @@
+(* test/test_oas_bridge_timeout_ssot_10094.ml
+
+   #10094: seven hardcoded [Masc_oas_bridge.run_safe ~timeout_s:N.N]
+   literals lived in five different lib modules with three distinct
+   values (60, 120, 180).  The 60s budgets in [auto_responder] and
+   [dashboard_provider_runs] did not match observed p50 latency
+   (50–700s) and produced 27 timeouts/session.
+
+   [Env_config_oas_bridge] is the new SSOT.  This test pins:
+
+     1. The known caller table preserves the deliberate 120s/180s
+        budgets that were originally chosen for compute-heavy
+        callers — a future refactor that drops them by accident
+        regresses autoresearch / deep_review / anti_rationalization
+        rather than just the fantasy 60s sites this PR fixed.
+     2. The two fantasy 60s budgets are raised to the global
+        default (300s) — the explicit symptom from the issue.
+     3. Per-caller env-var override takes precedence over the
+        hardcoded default (operator can tune any single caller).
+     4. The global env-var override
+        ([MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC]) shifts UNKNOWN
+        callers (typo / future caller without a default) without
+        affecting known callers — the global is a fallback, not
+        an override.
+     5. Per-caller env var beats global env var.
+*)
+
+(* MASC_BASE_PATH must be set BEFORE Masc_mcp module init —
+   #9903 prod-guard fires under HOME otherwise.  Same dune
+   [setenv] pattern as #10091 / #10097 / #10101. *)
+let () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-oas-bridge-timeout-10094-%06x"
+         (Random.bits ()))
+  in
+  Unix.putenv "MASC_BASE_PATH" dir
+
+module Cfg = Env_config_oas_bridge
+
+let clear_envs () =
+  Unix.putenv Cfg.global_env_var "";
+  List.iter
+    (fun caller ->
+       Unix.putenv (Cfg.per_caller_env_var ~caller) "")
+    (Cfg.known_callers ());
+  (* Clear an unknown-caller override too so the global-fallback
+     test starts clean. *)
+  Unix.putenv (Cfg.per_caller_env_var ~caller:"unknown_caller_test_10094") ""
+
+(* The intentional 120s / 180s budgets must remain after this
+   PR.  If a future refactor accidentally drops them (e.g. by
+   collapsing every caller onto the global default), this test
+   regresses the heavy-compute paths and reports the exact
+   caller name. *)
+let test_intentional_budgets_preserved () =
+  clear_envs ();
+  let cases =
+    [
+      "autoresearch_codegen", 120.0;
+      "keeper_persona_authoring", 120.0;
+      "server_openai_compat", 120.0;
+      "tool_deep_review", 180.0;
+      "anti_rationalization", 180.0;
+    ]
+  in
+  List.iter
+    (fun (caller, expected) ->
+      let got = Cfg.timeout_sec ~caller () in
+      Alcotest.(check (float 0.0001))
+        (Printf.sprintf "preserved budget for %s" caller)
+        expected got)
+    cases
+
+(* The two fantasy 60s budgets must be raised to the global
+   default (300s).  This is the direct symptom from #10094. *)
+let test_fantasy_60s_budgets_raised () =
+  clear_envs ();
+  Alcotest.(check (float 0.0001))
+    "auto_responder raised to global default"
+    Cfg.global_default_sec
+    (Cfg.timeout_sec ~caller:"auto_responder" ());
+  Alcotest.(check (float 0.0001))
+    "dashboard_provider_runs raised to global default"
+    Cfg.global_default_sec
+    (Cfg.timeout_sec ~caller:"dashboard_provider_runs" ())
+
+(* Per-caller env override beats the hardcoded default. *)
+let test_per_caller_env_override () =
+  clear_envs ();
+  Unix.putenv
+    (Cfg.per_caller_env_var ~caller:"auto_responder")
+    "45.5";
+  Alcotest.(check (float 0.0001))
+    "auto_responder env overrides default"
+    45.5
+    (Cfg.timeout_sec ~caller:"auto_responder" ());
+  (* Other callers must NOT be affected by this single override. *)
+  Alcotest.(check (float 0.0001))
+    "tool_deep_review unaffected"
+    180.0
+    (Cfg.timeout_sec ~caller:"tool_deep_review" ());
+  clear_envs ()
+
+(* Global env var (MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC) is a
+   FALLBACK — it shifts the default for unknown callers but
+   does NOT override per-caller hardcoded defaults.  Otherwise
+   bumping the global env var to absorb one slow provider would
+   silently change every other caller's budget. *)
+let test_global_env_does_not_override_known_callers () =
+  clear_envs ();
+  Unix.putenv Cfg.global_env_var "999.0";
+  Alcotest.(check (float 0.0001))
+    "tool_deep_review keeps 180.0 (global env is a fallback, not an override)"
+    180.0
+    (Cfg.timeout_sec ~caller:"tool_deep_review" ());
+  Alcotest.(check (float 0.0001))
+    "unknown caller picks up global env"
+    999.0
+    (Cfg.timeout_sec ~caller:"unknown_caller_test_10094" ());
+  clear_envs ()
+
+(* Per-caller env var beats global env var.  Operator should
+   always be able to fix one caller at a time without affecting
+   others. *)
+let test_per_caller_env_beats_global_env () =
+  clear_envs ();
+  Unix.putenv Cfg.global_env_var "999.0";
+  Unix.putenv
+    (Cfg.per_caller_env_var ~caller:"tool_deep_review")
+    "42.0";
+  Alcotest.(check (float 0.0001))
+    "per-caller env wins over global env"
+    42.0
+    (Cfg.timeout_sec ~caller:"tool_deep_review" ());
+  clear_envs ()
+
+(* Per-caller env-var name follows the documented convention.
+   Pin it so dashboards / runbooks that reference the literal
+   name keep matching what the code reads. *)
+let test_env_var_name_convention () =
+  Alcotest.(check string)
+    "auto_responder env var"
+    "MASC_OAS_BRIDGE_TIMEOUT_AUTO_RESPONDER_SEC"
+    (Cfg.per_caller_env_var ~caller:"auto_responder");
+  Alcotest.(check string)
+    "tool_deep_review env var"
+    "MASC_OAS_BRIDGE_TIMEOUT_TOOL_DEEP_REVIEW_SEC"
+    (Cfg.per_caller_env_var ~caller:"tool_deep_review");
+  Alcotest.(check string)
+    "global env var"
+    "MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC"
+    Cfg.global_env_var
+
+let () =
+  Alcotest.run "oas_bridge_timeout_ssot_10094"
+    [
+      ( "defaults",
+        [
+          Alcotest.test_case "intentional 120/180s budgets preserved"
+            `Quick test_intentional_budgets_preserved;
+          Alcotest.test_case "fantasy 60s budgets raised to global default"
+            `Quick test_fantasy_60s_budgets_raised;
+        ] );
+      ( "env_overrides",
+        [
+          Alcotest.test_case "per-caller env wins over hardcoded default"
+            `Quick test_per_caller_env_override;
+          Alcotest.test_case "global env does not override known callers"
+            `Quick test_global_env_does_not_override_known_callers;
+          Alcotest.test_case "per-caller env wins over global env"
+            `Quick test_per_caller_env_beats_global_env;
+        ] );
+      ( "naming_contract",
+        [
+          Alcotest.test_case "env var name convention" `Quick
+            test_env_var_name_convention;
+        ] );
+    ]


### PR DESCRIPTION
## Problem (#10094)

`Masc_oas_bridge.run_safe ~timeout_s:N.N` was called from seven different lib modules with three distinct hardcoded values:

| caller | hardcoded | observed |
|--------|-----------|----------|
| `auto_responder` | **60s** | **27 timeouts/session** |
| `dashboard_provider_runs` | **60s** | timeouts |
| `autoresearch_codegen` | 120s | tuned, fine |
| `keeper_persona_authoring` | 120s | tuned, fine |
| `server_openai_compat` | 120s | tuned, fine |
| `tool_deep_review` | 180s | 1 timeout/session |
| `anti_rationalization` | 180s | tuned, fine |

The 60s budgets are fantasy — observed LLM p50 latency runs 50–700s. The 120/180s budgets are deliberately tuned for compute-heavy callers and a uniform "raise everything to 300s" fix would silently regress them.

## Root Cause

No SSOT. Each caller carried its own float literal. The operator had no place to override one budget without forking the source tree, and could not see in metrics WHICH caller was timing out at WHICH budget — `Log.Misc.warn "after N.Ns"` collapses every site into the same string.

## Fix

| | Before | After |
|---|--------|-------|
| **Defaults table** | scattered literals | `Env_config_oas_bridge.known_caller_defaults` (preserves 120/180s, raises fantasy 60s to 300s) |
| **Per-caller override** | impossible without source change | `MASC_OAS_BRIDGE_TIMEOUT_<CALLER>_SEC` |
| **Global fallback** | none | `MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC` for unknown callers only |
| **Observability** | `warn` log line | `masc_oas_bridge_timeout_total{caller, timeout_s}` |
| **Entry point** | `run_safe ~timeout_s:N.N` | `run_with_caller ~caller fn` |

Lookup precedence (documented in `timeout_sec` docstring):

1. Per-caller env (`MASC_OAS_BRIDGE_TIMEOUT_<CALLER>_SEC`) — wins unconditionally.
2. Per-caller hardcoded default — preserves intentional budgets.
3. Global env (`MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC`) — **only for unknown callers** (typo / future caller without an entry).
4. `global_default_sec` (300s) — final fallback.

Treating the global env as an override of known defaults would let one slow provider silently shift every caller's budget. That footgun is explicitly tested.

All seven call sites migrated to `run_with_caller ~caller:"..."`. Legacy `run_safe` keeps a backwards-compatible `?caller` default of `"unknown"`.

## Tests

`test/test_oas_bridge_timeout_ssot_10094.ml` pins:

- **intentional budgets preserved** — autoresearch (120), persona_authoring (120), openai_compat (120), deep_review (180), anti_rationalization (180). Regression guard for the heavy-compute paths.
- **fantasy 60s raised to 300s** — auto_responder, dashboard_provider_runs (the direct symptom).
- **per-caller env wins over hardcoded default** — single-caller tuning works.
- **global env is FALLBACK only** — known callers ignore it. This test caught a real bug in v1 of the impl that treated global as an override.
- **per-caller env wins over global env**.
- **env var name convention** pinned (dashboards / runbooks).

## Notes

- Mirror of #10074 (the keeper-path mode 2 budget fix) for non-keeper code paths.
- Dedicated `(test ...)` stanza with `setenv MASC_BASE_PATH` for the same reason as #10091/#10097/#10101 — `Masc_mcp` module init triggers #9903 prod-guard on HOME.
- `Env_config_oas_bridge.global_env_var` and `per_caller_env_var` are exposed for the test contract; downstream callers should use `timeout_sec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
