### PR TITLE
fix(oas-worker): suppress repeated codex_cli omission warning (#10097)

### DIFF
--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -13,6 +13,29 @@ type cli_transport_overrides = {
   gemini_yolo : bool option;
 }
 
+(* #10097: codex_cli omits the same set of keeper-bound runtime MCP
+   tools on every request because the structural limitation
+   (request-scoped auth headers) cannot be carried through codex's
+   transport.  The previous Log.warn fired 143×/session with one
+   distinct tool list — pure noise that masked other warnings.  Track
+   the most recent tool list per [agent_name] and only emit when it
+   changes (initial fire, or tool surface drift).  Stdlib.Mutex
+   guards concurrent access from heartbeat/turn fibers across
+   domains. *)
+let codex_omission_state_mu = Stdlib.Mutex.create ()
+let codex_omission_state : (string, string) Hashtbl.t = Hashtbl.create 16
+
+let codex_omission_should_log ~agent_name ~tool_list_key =
+  Stdlib.Mutex.lock codex_omission_state_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock codex_omission_state_mu)
+    (fun () ->
+       match Hashtbl.find_opt codex_omission_state agent_name with
+       | Some prev when String.equal prev tool_list_key -> false
+       | _ ->
+         Hashtbl.replace codex_omission_state agent_name tool_list_key;
+         true)
+
 (** Resolve a model label string to an OAS Provider.config.
     Uses MASC [Cascade_config.parse_model_string] (with Provider_registry as SSOT).
     Explicit model-label execution must never silently substitute a
@@ -438,10 +461,17 @@ let resolve_tool_lane_for_oas_tools
           (public_tool_names @ keeper_internal_tool_names)
     | _ -> []
   in
-  if codex_keeper_bound_actor_tools <> [] then
-    Log.warn ~ctx:"oas_worker_exec"
-      "codex_cli omitting keeper-bound runtime MCP tool(s) that require request-scoped auth headers: %s"
-      (String.concat ", " codex_keeper_bound_actor_tools);
+  (if codex_keeper_bound_actor_tools <> [] then
+    let tool_list_key = String.concat "," codex_keeper_bound_actor_tools in
+    let agent_name_key =
+      Option.value ~default:"<no_agent>" requested_agent_name
+    in
+    if codex_omission_should_log ~agent_name:agent_name_key ~tool_list_key
+    then
+      Log.warn ~ctx:"oas_worker_exec"
+        "codex_cli omitting keeper-bound runtime MCP tool(s) that require request-scoped auth headers: %s (subsequent identical omissions for %s suppressed)"
+        tool_list_key
+        agent_name_key);
   let public_tool_names =
     if codex_keeper_bound_actor_tools = [] then
       public_tool_names


### PR DESCRIPTION
## Summary

Track per-agent codex_cli omitted-tool-list in a mutex-guarded Hashtbl. Emit `Log.warn` only when the list changes (initial fire or tool-surface drift). Closes #10097.

## Observed

`grep 'codex_cli omitting' system_log.jsonl | wc -l → 143` per session, with **1 distinct tool-list variation**:

```
keeper_stay_silent, keeper_time_now, keeper_context_status, keeper_memory_search,
keeper_tools_list, keeper_board_get, keeper_board_post, keeper_board_list,
keeper_board_comment, keeper_board_vote, keeper_board_stats, keeper_board_search,
keeper_fs_read, keeper_fs_edit, keeper_shell, keeper_library_search
```

100% redundant — same 16 tools, same agent, repeated every codex_cli request.

## Change

```ocaml
let codex_omission_state : (agent_name, tool_list_key) Hashtbl.t = Hashtbl.create 16

let codex_omission_should_log ~agent_name ~tool_list_key =
  match Hashtbl.find_opt codex_omission_state agent_name with
  | Some prev when String.equal prev tool_list_key -> false
  | _ ->
    Hashtbl.replace codex_omission_state agent_name tool_list_key;
    true
```

`Stdlib.Mutex` guards concurrent access from heartbeat/turn fibers. Surface drift (new tool joins bound-actor predicate) re-fires the warning.

## Trade-off

- **A (this PR)**: per-agent tool-list dedup, one warn per (agent × distinct tool set).
- **B (rejected)**: `Log.debug` downgrade — operator must enable verbose logging to see structural limitation. Higher friction.
- **C (rejected)**: Prometheus counter only — log entirely silent. Loses one-shot operator awareness during incident.

A balances visibility (one warn per distinct configuration) with noise reduction (subsequent identical omissions suppressed).

## Test plan

- [x] `dune build lib/` green
- [ ] Post-rebuild: first codex_cli request per agent logs once with "subsequent identical omissions … suppressed" hint; subsequent identical requests are silent
- [ ] If a new keeper-bound tool is added, the warning re-fires (drift detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)