### PR TITLE
test(cascade): pin 3-CLI :auto declaration is not a leak warning (#10087)

### DIFF
--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -658,6 +658,76 @@ let test_resolve_named_providers_canonical_labels_are_not_leaks () =
   check bool "canonicalized provider labels are not false leaks" false
     (contains_substring stderr_output "NOT in")
 
+(* #10087 regression: the live big_three cascade declares
+   [claude_code:auto, codex_cli:auto, gemini_cli:auto] — three
+   CLI providers all using [:auto].  The user-reported symptom is
+   "11 providers NOT in declared profile" warnings; #10004
+   already replaced the comparison baseline with the post-expansion
+   list, but the existing test only covers the case where the
+   first declared entry is a [custom:...@url] alias.  This test
+   pins the case where ALL three entries are bare CLI [:auto]
+   shorthands so that any future change to the expansion or
+   filter pipeline that breaks symmetry is caught immediately. *)
+let test_resolve_named_providers_three_cli_auto_not_leaks_10087 () =
+  with_temp_dir "cascade-catalog-three-cli-auto-10087" @@ fun dir ->
+  let config_dir = Filename.concat dir "config" in
+  init_config_root config_dir;
+  with_config_dir config_dir @@ fun () ->
+  ignore
+    (write_cascade_json config_dir
+       {|{
+  "big_three_models": ["claude_code:auto", "codex_cli:auto", "gemini_cli:auto"],
+  "governance_judge_models": ["kimi_cli:kimi-for-coding", "codex_cli:auto", "gemini_cli:auto"]
+}|});
+  Log.set_level Log.Info;
+  let big_three_stderr =
+    capture_stderr (fun () ->
+        let providers =
+          require_ok
+            (Cascade_catalog_runtime.resolve_named_providers
+               ~cascade_name:"big_three" ())
+        in
+        let kinds = provider_kinds providers in
+        check bool "big_three: claude_code present" true
+          (List.mem "claude_code" kinds);
+        check bool "big_three: codex_cli present" true
+          (List.mem "codex_cli" kinds);
+        check bool "big_three: gemini_cli present" true
+          (List.mem "gemini_cli" kinds))
+  in
+  check bool
+    "#10087 big_three: NO 'NOT in' leak warning fires for 3 CLI :auto"
+    false
+    (contains_substring big_three_stderr "NOT in");
+  (* The governance_judge case from the issue uses kimi_cli +
+     codex_cli + gemini_cli.  Don't require kimi to resolve in
+     this test (it needs an API key the test env does not
+     provide); just assert that the expanded codex/gemini path
+     does NOT emit a leak warning regardless of kimi's
+     resolution outcome. *)
+  let gov_stderr =
+    capture_stderr (fun () ->
+        match
+          Cascade_catalog_runtime.resolve_named_providers
+            ~cascade_name:"governance_judge" ()
+        with
+        | Ok providers ->
+          let kinds = provider_kinds providers in
+          check bool "governance_judge: codex_cli expanded" true
+            (List.mem "codex_cli" kinds);
+          check bool "governance_judge: gemini_cli expanded" true
+            (List.mem "gemini_cli" kinds)
+        | Error _ ->
+          (* If the cascade fails to resolve at all, the leak
+             warning code path is unreachable, so the invariant
+             is vacuously satisfied. *)
+          ())
+  in
+  check bool
+    "#10087 governance_judge: NO 'NOT in' leak warning fires"
+    false
+    (contains_substring gov_stderr "NOT in")
+
 let test_config_doctor_live_reports_catalog_validation () =
   with_temp_dir "cascade-doctor-live" @@ fun dir ->
   let base_path = Filename.concat dir "base" in
@@ -783,6 +853,10 @@ let () =
             "resolve_named_providers canonical labels are not leak warnings"
             `Quick
             test_resolve_named_providers_canonical_labels_are_not_leaks;
+          test_case
+            "resolve_named_providers 3 CLI :auto are not leak warnings (#10087)"
+            `Quick
+            test_resolve_named_providers_three_cli_auto_not_leaks_10087;
           test_case
             "config doctor live reports catalog validation"
             `Quick


### PR DESCRIPTION
## Summary (#10087)

The reported "11 providers NOT in declared profile" warnings are **stale**. Inspecting `system_log_2026-04-25.jsonl`:

```
$ rg "resolve_named_providers.*NOT in" system_log_2026-04-25.jsonl | wc -l
12
$ rg "resolve_named_providers.*NOT in" system_log_2026-04-25.jsonl | rg -o '"ts":"[^"]+"' | tail -1
"ts":"2026-04-24T15:20:53Z"
```

All 12 occurrences land between `15:00:25Z` and `15:20:53Z` UTC. PR #10004 (`b2038bc07a`) merged at `2026-04-25 00:04:47 KST = 2026-04-24 15:04:47 UTC`. The running server kept the old code in memory for ~16 minutes after merge; nothing has fired since (current log timestamp `22:18:48 UTC`, no further `NOT in` lines).

So the issue is **already fixed** by #10004 — the warnings the reporter saw were pre-deployment residue.

## Why add a test then?

The existing #10004 regression test (`test_resolve_named_providers_canonical_labels_are_not_leaks`) only covers the case where the **first** declared entry is a `custom:judge@<url>` alias. The two cascades #10087 explicitly names (`big_three` and `governance_judge`) put a pure CLI `:auto` shorthand in the first slot:

```json
big_three_models = ["claude_code:auto", "codex_cli:auto", "gemini_cli:auto"]
governance_judge_models = ["kimi_cli:kimi-for-coding", "codex_cli:auto", "gemini_cli:auto"]
```

If a future change to `expand_weighted_auto_entries`, `apply_provider_filter`, or `apply_required_tool_use_filter` breaks the invariant for these CLI-heavy cascades, the existing test won't catch it. This PR adds a named regression guard that does.

## Test contents

`test_resolve_named_providers_three_cli_auto_not_leaks_10087`:

- **big_three** (3 pure CLI `:auto`) — resolves cleanly, asserts `claude_code` / `codex_cli` / `gemini_cli` all present in the result, asserts NO `NOT in` warning hits stderr.
- **governance_judge** (kimi + 2 CLI `:auto`) — `kimi_cli` requires an API key the test env doesn't provide, so the test does not assert kimi resolves; it only asserts that the leak warning never fires regardless of kimi's outcome (the invariant must hold either way).

Failure messages name the cascade explicitly so a regression reads as `"#10087 big_three: NO 'NOT in' leak warning fires for 3 CLI :auto"` rather than a generic provider-count mismatch.

## Notes

- No production code changes.
- Closes #10087 as already-fixed by #10004 with this regression guard added.
- All 13 cascade-catalog-runtime tests pass on the current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
