### PR TITLE
obs(grpc): expose events_dropped counter for subscriber capacity pressure

### DIFF
--- a/dashboard/src/api/schemas/transport-health.ts
+++ b/dashboard/src/api/schemas/transport-health.ts
@@ -103,6 +103,7 @@ const GrpcSchema = object({
   subscribers: fallback(number(), 0),
   heartbeat_avg_seconds: fallback(number(), 0),
   events_delivered: fallback(number(), 0),
+  events_dropped: fallback(number(), 0),
 })
 
 // Diagnostic counters for the WS delivery path.  Each field falls back

--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -495,10 +495,14 @@ let handle_subscribe
     if Atomic.get stream_closed || Grpc_eio.Stream.is_closed stream then begin
       (* Stream already gone — auto-cleanup *)
       cleanup_subscriber ()
-    end else if Grpc_eio.Stream.length stream >= max_buffer then
-      (* Stream buffer near-full — drop event to avoid blocking broadcast *)
+    end else if Grpc_eio.Stream.length stream >= max_buffer then begin
+      (* Stream buffer near-full — drop event to avoid blocking broadcast.
+         Bump [masc_grpc_events_dropped_total] so the capacity pressure
+         is visible to operators and the drop is not just a log line. *)
+      Transport_metrics.inc_grpc_events_dropped ();
       Log.Misc.warn "gRPC subscriber %s: buffer full (%d), dropping event"
         sub_id (Grpc_eio.Stream.length stream)
+    end
     else begin
       let seq = Int64.of_int (Atomic.fetch_and_add seq_counter 1) in
       let event = T.Event.{

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -277,6 +277,7 @@ let metric_grpc_active_streams = "masc_grpc_active_streams_total"
 let metric_grpc_heartbeat_latency = "masc_grpc_heartbeat_latency_seconds"
 let metric_grpc_subscribers = "masc_grpc_subscribers_total"
 let metric_grpc_events_delivered = "masc_grpc_events_delivered_total"
+let metric_grpc_events_dropped = "masc_grpc_events_dropped_total"
 let metric_ws_sessions = "masc_ws_sessions_total"
 let metric_ws_parse_cache_hits = "masc_ws_parse_cache_hits_total"
 let metric_ws_parse_cache_misses = "masc_ws_parse_cache_misses_total"
@@ -592,6 +593,10 @@ let init () =
     ~help:"gRPC heartbeat round-trip latency" ();
   add metric_grpc_subscribers "Active gRPC Subscribe stream subscribers" Gauge;
   add metric_grpc_events_delivered "Total events delivered via gRPC streams" Counter;
+  add metric_grpc_events_dropped
+    "Events dropped by gRPC subscribers when the stream buffer is full \
+     (capacity pressure — operator must investigate slow consumers)"
+    Counter;
   add metric_ws_sessions "Active standalone WebSocket sessions" Gauge;
   add metric_ws_parse_cache_hits
     "WS dashboard delta parse cache hits (same event string reused across sessions)"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -167,6 +167,7 @@ val metric_grpc_active_streams : string
 val metric_grpc_heartbeat_latency : string
 val metric_grpc_subscribers : string
 val metric_grpc_events_delivered : string
+val metric_grpc_events_dropped : string
 val metric_ws_sessions : string
 val metric_ws_parse_cache_hits : string
 val metric_ws_parse_cache_misses : string

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -55,6 +55,9 @@ let inc_grpc_events_delivered ?(delta=1) () =
   Prometheus.inc_counter Prometheus.metric_grpc_events_delivered
     ~delta:(float_of_int delta) ()
 
+let inc_grpc_events_dropped () =
+  Prometheus.inc_counter Prometheus.metric_grpc_events_dropped ()
+
 (** {1 WebSocket Metrics} *)
 
 let set_ws_sessions count =
@@ -276,6 +279,7 @@ let transport_health_json ~config =
     else 0.0
   in
   let grpc_events = v Prometheus.metric_grpc_events_delivered () in
+  let grpc_events_dropped = v Prometheus.metric_grpc_events_dropped () in
   let stale_agents = v Prometheus.metric_agent_stale_total () in
   let lifecycle_dispatch_rejections =
     int_of_float
@@ -360,6 +364,7 @@ let transport_health_json ~config =
       ("subscribers", `Int grpc_subscribers_i);
       ("heartbeat_avg_seconds", `Float grpc_heartbeat_avg);
       ("events_delivered", `Int (int_of_float grpc_events));
+      ("events_dropped", `Int (int_of_float grpc_events_dropped));
     ]);
     ("websocket", `Assoc [
       ("enabled", `Bool ws_configured);

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -126,6 +126,17 @@ let test_grpc_events_delivered () =
     "masc_grpc_events_delivered_total" () in
   check (float 0.01) "grpc events delta" 5.0 (after -. before)
 
+let test_grpc_events_dropped () =
+  let before = Prometheus.metric_value_or_zero
+    "masc_grpc_events_dropped_total" () in
+  TM.inc_grpc_events_dropped ();
+  TM.inc_grpc_events_dropped ();
+  TM.inc_grpc_events_dropped ();
+  let after = Prometheus.metric_value_or_zero
+    "masc_grpc_events_dropped_total" () in
+  check (float 0.01) "three drop observations advance counter by 3"
+    3.0 (after -. before)
+
 let test_grpc_runtime_listening_cache () =
   TM.set_grpc_runtime_listening true;
   check bool "grpc listening uses runtime cache" true (TM.grpc_listening ());
@@ -248,6 +259,9 @@ let test_transport_health_json () =
     (grpc_json |> U.member "active_streams" |> U.to_int);
   check int "grpc subscribers" 2
     (grpc_json |> U.member "subscribers" |> U.to_int);
+  check bool "grpc events_dropped field present" true
+    (match grpc_json |> U.member "events_dropped" with
+     | `Int _ -> true | _ -> false);
   check bool "grpc listening field exists" true
     (match grpc_json |> U.member "listening" with `Bool _ -> true | _ -> false);
   check bool "grpc reachable field exists" true
@@ -376,6 +390,7 @@ let () =
       test_case "observe_grpc_heartbeat_latency" `Quick test_grpc_heartbeat_latency;
       test_case "set_grpc_subscribers" `Quick test_grpc_subscribers;
       test_case "inc_grpc_events_delivered" `Quick test_grpc_events_delivered;
+      test_case "inc_grpc_events_dropped" `Quick test_grpc_events_dropped;
       test_case "runtime listening cache" `Quick test_grpc_runtime_listening_cache;
     ]);
     ("websocket", [


### PR DESCRIPTION
## Why

The gRPC subscriber callback (`lib/grpc/masc_grpc_service.ml:484`) already drops events when the stream's buffer is near-capacity:

```
end else if Grpc_eio.Stream.length stream >= max_buffer then
  (* Stream buffer near-full — drop event to avoid blocking broadcast *)
  Log.Misc.warn "gRPC subscriber %s: buffer full (%d), dropping event"
    sub_id (Grpc_eio.Stream.length stream)
```

The drop is silent in metrics. An operator watching the dashboard or alerting on `/metrics` has no signal that the system is dropping events under capacity pressure — they would have to grep server logs. For a pressure signal that should inform paging decisions, this is a poor failure mode.

The WS side shipped `masc_ws_throttled_deliveries_total` in #10104 for the parallel reason on its path. This PR adds the same hygiene to gRPC.

## What

- `lib/prometheus.ml(.mli)`: new `metric_grpc_events_dropped = "masc_grpc_events_dropped_total"`, registered as `Counter` with a help string that names capacity pressure as the cause.
- `lib/transport_metrics.ml`: `inc_grpc_events_dropped ()` helper, matching the shape of the existing `inc_grpc_events_delivered`. The `grpc` section of `transport_health_json` gains an `events_dropped` field alongside `events_delivered`.
- `lib/grpc/masc_grpc_service.ml`: the `Stream.length >= max_buffer` branch now calls `Transport_metrics.inc_grpc_events_dropped` before the existing log line. No behaviour change beyond the counter bump.
- `dashboard/src/api/schemas/transport-health.ts`: `GrpcSchema` gains `events_dropped` with `fallback(number(), 0)` so older servers still parse cleanly.

## Tests

`test/test_transport_metrics.ml`:

- New case: three `inc_grpc_events_dropped` calls advance the counter by exactly 3 (delta-read against pre-state to be robust to shared module-level metric state).
- Extended `transport_health_json structure` test: asserts `grpc.events_dropped` is present as an `` `Int ``.

```
test_transport_metrics         21/21  (20 prior + 1 new)
test_transport_integration      8/8   (grpc_subscribe_sse path)
vitest transport-health schema 34/34  (client fallback default kicks
                                       in cleanly when field absent)
```

## Scope guard

- No behaviour change. A gRPC subscriber under capacity pressure drops events today and continues to drop events in the same places with the same buffer threshold; the only difference is that the drop is visible in `/metrics` and the `grpc` section of `transport_health`.
- No wire format change beyond an additive integer field. `fallback(number(), 0)` on the client means older dashboards against a new server still render; newer dashboards against an older server see 0.
- No new module dependency.

## Interaction with the WS migration series

This is the symmetric observability that #10106 set up for WS. The transport-health payload now exposes drop-style signals for both external-subscriber paths:

- WS → `websocket.delivery.throttled_deliveries` (from #10104 + #10106)
- gRPC → `grpc.events_dropped` (this PR)

Both are monotonic counters. Both read 0 in a healthy system. Both are dashboard-ready through the existing transport-health strip.

## Follow-ups (separate PRs)

- Dashboard UI: render a small badge in the gRPC card when `events_dropped` has advanced since last refresh, mirroring the WebSocket card's throttled indicator (#10107). Easy follow-up once this lands.
- Consider making the `max_buffer` value itself env-tunable (currently hard-coded at 48) for the same reason #10104 made the WS threshold tunable: operators can widen it in environments where the underlying pressure is structural.

🤖 Generated with [Claude Code](https://claude.com/claude-code)