### PR TITLE
perf(grpc): make subscriber drop threshold tunable via env var

### DIFF
--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -224,6 +224,11 @@ let transport_entries =
     entry ~default:"8936" "MASC_GRPC_PORT" "gRPC server port";
     entry ~default:"true" "MASC_GRPC_ENABLED" "Enable gRPC transport";
     entry ~default:"(derived)" "MASC_GRPC_TARGET" "gRPC client target address";
+    entry ~default:"48" "MASC_GRPC_STREAM_MAX_BUFFER"
+      "Per-subscriber outbound buffer drop threshold.  When the stream has \
+       this many unsent events queued, new events are dropped and \
+       masc_grpc_events_dropped_total advances.  Stream capacity is 64, \
+       default leaves headroom.";
     entry ~default:"8937" "MASC_WS_PORT" "WebSocket server port";
     entry ~default:"true" "MASC_WS_ENABLED" "Enable WebSocket transport";
     entry ~default:"true" "MASC_WEBRTC_ENABLED" "Enable WebRTC transport";

--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -14,6 +14,17 @@ let service_name = "masc.coordination.v1.MascCoordination"
 (** Current timestamp in milliseconds. *)
 let now_ms () = Int64.of_float (Unix.gettimeofday () *. 1000.0)
 
+(** Per-subscriber outbound buffer drop threshold.
+
+    Reads [MASC_GRPC_STREAM_MAX_BUFFER] on each call so tests and
+    operators can drive it without wiring in-process state.  The
+    default 48 leaves headroom under the 64-slot stream capacity; a
+    value at or above stream capacity effectively disables the gate
+    and lets Grpc_eio.Stream itself decide (usually the wrong
+    choice, but available for debugging). *)
+let stream_max_buffer () =
+  Env_config_core.get_int ~default:48 "MASC_GRPC_STREAM_MAX_BUFFER"
+
 let decode_request_or_raise ~rpc decode bytes =
   match decode bytes with
   | Ok req -> req
@@ -473,7 +484,10 @@ let handle_subscribe
      capacity before adding. If the stream is full or closed, the event
      is dropped and the subscriber auto-unregisters. *)
   let seq_counter = Atomic.make (Int64.to_int req.since_seq + 1) in
-  let max_buffer = 48 in (* stream capacity is 64; leave headroom *)
+  (* Read once per subscribe so existing streams are not disturbed
+     mid-flight by a config change; newly-subscribing clients pick up
+     the new value. *)
+  let max_buffer = stream_max_buffer () in
   Sse.subscribe_external ~id:sub_id
     ~is_alive:(fun () ->
       not (Atomic.get stream_closed) && not (Grpc_eio.Stream.is_closed stream))

--- a/lib/grpc/masc_grpc_service.mli
+++ b/lib/grpc/masc_grpc_service.mli
@@ -6,6 +6,14 @@
 (** Full gRPC service name: "masc.coordination.v1.MascCoordination". *)
 val service_name : string
 
+(** Per-subscriber outbound buffer drop threshold.  Reads
+    [MASC_GRPC_STREAM_MAX_BUFFER] on each call; defaults to 48.  When
+    [Grpc_eio.Stream.length] reaches this value the subscriber
+    callback drops new events and [masc_grpc_events_dropped_total]
+    advances.  Exposed so tests and operators can verify the effective
+    value without instrumenting the full subscribe handler. *)
+val stream_max_buffer : unit -> int
+
 (** Create the gRPC service with all handlers wired to the given room config.
 
     @param room_config The MASC room configuration.

--- a/test/test_grpc_coordination.ml
+++ b/test/test_grpc_coordination.ml
@@ -236,6 +236,34 @@ let test_grpc_default_port () =
   Alcotest.(check int) "default port" 8936
     Masc_mcp.Masc_grpc_server.default_port
 
+let test_grpc_stream_max_buffer_default () =
+  (* Without the env override, the drop threshold defaults to 48 —
+     the value below the 64-slot Grpc_eio.Stream capacity.  Clear any
+     inherited value from the test harness so the default applies. *)
+  let was_set = Sys.getenv_opt "MASC_GRPC_STREAM_MAX_BUFFER" in
+  Unix.putenv "MASC_GRPC_STREAM_MAX_BUFFER" "";
+  Fun.protect
+    ~finally:(fun () ->
+      match was_set with
+      | Some v -> Unix.putenv "MASC_GRPC_STREAM_MAX_BUFFER" v
+      | None -> Unix.putenv "MASC_GRPC_STREAM_MAX_BUFFER" "")
+    (fun () ->
+      Alcotest.(check int) "default is 48"
+        48 (Masc_mcp.Masc_grpc_service.stream_max_buffer ()))
+
+let test_grpc_stream_max_buffer_env_override () =
+  (* Operators retune the drop threshold without a code change. *)
+  let was_set = Sys.getenv_opt "MASC_GRPC_STREAM_MAX_BUFFER" in
+  Unix.putenv "MASC_GRPC_STREAM_MAX_BUFFER" "12";
+  Fun.protect
+    ~finally:(fun () ->
+      match was_set with
+      | Some v -> Unix.putenv "MASC_GRPC_STREAM_MAX_BUFFER" v
+      | None -> Unix.putenv "MASC_GRPC_STREAM_MAX_BUFFER" "")
+    (fun () ->
+      Alcotest.(check int) "env override applied"
+        12 (Masc_mcp.Masc_grpc_service.stream_max_buffer ()))
+
 let test_grpc_default_on_enablement () =
   (* With no MASC_GRPC_ENABLED env var, gRPC stays enabled. *)
   let was_set = Sys.getenv_opt "MASC_GRPC_ENABLED" in
@@ -483,6 +511,10 @@ let () =
         [
           Alcotest.test_case "default_port" `Quick test_grpc_default_port;
           Alcotest.test_case "default_on_enablement" `Quick test_grpc_default_on_enablement;
+          Alcotest.test_case "stream_max_buffer default" `Quick
+            test_grpc_stream_max_buffer_default;
+          Alcotest.test_case "stream_max_buffer env override" `Quick
+            test_grpc_stream_max_buffer_env_override;
           Alcotest.test_case "registers_health_service" `Quick
             test_grpc_server_registers_health_service;
         ] );


### PR DESCRIPTION
## Why

The gRPC subscriber callback in `lib/grpc/masc_grpc_service.ml` has carried a hard-coded `let max_buffer = 48` for some time. That value leaves headroom under the 64-slot `Grpc_eio.Stream` capacity and is a reasonable default, but there is no way to retune it without a code change.

Environments with structurally bursty upstreams or slow consumers need more headroom. Latency-sensitive paths want to drop earlier. An env var is the standard knob.

This is a direct follow-up to #10112, which made drops visible via `masc_grpc_events_dropped_total`. Observability without a knob is incomplete — operators can see the pressure but cannot relieve it.

## What

`lib/grpc/masc_grpc_service.ml(.mli)`:

- New `stream_max_buffer () : unit -> int` — reads `MASC_GRPC_STREAM_MAX_BUFFER` on each call via `Env_config_core.get_int`, defaults to `48`.
- Exposed in the `.mli` so tests and operators can verify the effective value without instrumenting the full subscribe handler.
- The `SubscribeEvents` handler now calls this **once per subscribe**, not once per event. Existing streams are not disturbed mid-flight by a config change; newly-subscribing clients pick up the new value. This is intentional — re-reading per event would let a config change tear through in-flight streams, which is harder to reason about than "clients see the value that was live when they connected".

`lib/config/env_config_snapshot.ml`:

- Declares `MASC_GRPC_STREAM_MAX_BUFFER` in the `transport` category with default `"48"` and help text explaining the drop semantics. Shows up in `sb env snapshot`.

## Tests

`test/test_grpc_coordination.ml`, `server_config` group:

- `stream_max_buffer default` — clears any inherited env, asserts `48`.
- `stream_max_buffer env override` — sets the var to `"12"`, asserts `12`.

Both use `Fun.protect` to restore the pre-test env state so ordering is independent.

```
test_grpc_coordination  26/26 pass  (24 prior + 2 new)
```

## Scope guard

- **No behaviour change at default.** Existing deployments that have never touched `MASC_GRPC_STREAM_MAX_BUFFER` continue to see a threshold of `48`.
- No wire format change.
- No new module dependency (`Env_config_core` is already a transport dependency).

## Interaction with other WS/gRPC PRs

| PR | What it adds |
|----|--------------|
| #10112 | `masc_grpc_events_dropped_total` counter + payload field |
| #10114 | UI rendering of the counter |
| **this** | Env-tunable threshold so the counter can be managed, not just observed |

The WS path has a parallel structure: #10104 ships `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` (env-tunable drop threshold) alongside its counter. This PR closes the symmetry on the gRPC side.

## Follow-ups

- Consider exposing the current `max_buffer` value in the `grpc` section of `transport_health` so operators can confirm the running configuration without reading env directly.
- Same mechanism could be applied to the gRPC stream capacity itself (currently also hard-coded at 64), but that touches `Grpc_eio.Stream` semantics and is a larger change best done separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)