### PR TITLE
fix(cdal-gate): accurate dormancy diagnostics + ledger health surface (#10115)

### DIFF
--- a/lib/cdal_verdict_gate.ml
+++ b/lib/cdal_verdict_gate.ml
@@ -77,15 +77,127 @@ let lookup_latest_verdict ?base_dir
        | _ -> acc)
     | _ -> acc
   ) None recent in
-  (* If we scanned the full limit and still no match, the verdict may exist
-     in older entries outside the scan window. Log a WARN so debugging is
-     possible instead of silent skipping. Issue #7546. *)
-  (if result = None && List.length recent >= limit then
-    Log.Task.warn
-      "[cdal-gate] lookup_latest_verdict: scanned limit=%d without finding task_id=%s; \
-       older verdicts beyond window are silently skipped (MASC_CDAL_VERDICT_LOOKUP_LIMIT)"
-      limit task_id);
+  (* #10115: distinguish three "verdict not found" cases so the
+     operator gets an accurate diagnosis.  The previous WARN
+     unconditionally said "older verdicts beyond window are
+     silently skipped" — true when the scan saturated [limit],
+     misleading when the ledger is empty or the writer pipeline
+     is dormant (12-day gap observed in production).  If the
+     operator follows the WARN's hint and bumps
+     [MASC_CDAL_VERDICT_LOOKUP_LIMIT], they spend cycles
+     investigating the wrong layer. *)
+  (match result, recent with
+   | Some _, _ -> ()
+   | None, [] ->
+     Log.Task.warn
+       "[cdal-gate] task_id=%s: cdal_verdicts ledger is EMPTY at %s. \
+        Writer pipeline likely dormant — check that OAS Agent.run \
+        emits result.proof and Cdal_eval_v1.persist is reached. (#10115)"
+       task_id base_dir
+   | None, _ when List.length recent >= limit ->
+     Log.Task.warn
+       "[cdal-gate] task_id=%s: scanned newest %d entries without \
+        match; older verdicts beyond window are silently skipped \
+        (raise MASC_CDAL_VERDICT_LOOKUP_LIMIT to widen the window)"
+       task_id limit
+   | None, _ ->
+     Log.Task.warn
+       "[cdal-gate] task_id=%s: no verdict in current ledger window \
+        (%d entries scanned, below limit=%d).  Either the task has \
+        never been verified, or the writer pipeline is dormant — \
+        bumping MASC_CDAL_VERDICT_LOOKUP_LIMIT will not help. (#10115)"
+       task_id (List.length recent) limit);
   result
+
+(* #10115: ledger health introspection.  Walks [base_dir/YYYY-MM/]
+   to find the newest [DD.jsonl] file's mtime; lets a boot-time
+   health check catch a dormant writer pipeline before any
+   strict-contract task tries to gate on a verdict that will
+   never arrive. *)
+type ledger_health = {
+  base_dir : string;
+  total_files : int;
+  latest_mtime : float option;
+  age_seconds : float option;
+}
+
+let ledger_health_report ?base_dir () : ledger_health =
+  let base_dir =
+    match base_dir with
+    | Some dir -> dir
+    | None -> default_base_path ()
+  in
+  let collect_jsonl_mtimes () =
+    if not (Sys.file_exists base_dir) then []
+    else
+      let month_dirs =
+        try
+          Sys.readdir base_dir
+          |> Array.to_list
+          |> List.filter (fun name ->
+               let full = Filename.concat base_dir name in
+               try Sys.is_directory full with Sys_error _ -> false)
+        with Sys_error _ -> []
+      in
+      List.concat_map
+        (fun month ->
+          let dir = Filename.concat base_dir month in
+          try
+            Sys.readdir dir
+            |> Array.to_list
+            |> List.filter_map (fun name ->
+                 if Filename.check_suffix name ".jsonl" then
+                   let full = Filename.concat dir name in
+                   try Some (Unix.stat full).st_mtime
+                   with Unix.Unix_error _ -> None
+                 else None)
+          with Sys_error _ -> [])
+        month_dirs
+  in
+  let mtimes = collect_jsonl_mtimes () in
+  let latest_mtime =
+    match mtimes with
+    | [] -> None
+    | _ -> Some (List.fold_left max neg_infinity mtimes)
+  in
+  let age_seconds =
+    Option.map (fun m -> Time_compat.now () -. m) latest_mtime
+  in
+  {
+    base_dir;
+    total_files = List.length mtimes;
+    latest_mtime;
+    age_seconds;
+  }
+
+(* Threshold for boot-time staleness WARN.  7 days picks up the
+   12-day production dormancy from #10115 with margin while not
+   firing on transient quiet periods. *)
+let stale_age_seconds_default = 7. *. 86400.
+
+let log_ledger_health_warn_if_stale ?base_dir
+    ?(stale_age_seconds = stale_age_seconds_default) () : ledger_health =
+  let report = ledger_health_report ?base_dir () in
+  (match report.latest_mtime, report.age_seconds with
+   | None, _ ->
+     Log.Task.warn
+       "[cdal-gate] ledger health: %s has NO verdict files. \
+        Writer pipeline likely never started or never reached \
+        Cdal_eval_v1.persist. (#10115)"
+       report.base_dir
+   | Some _, Some age when age > stale_age_seconds ->
+     let days = age /. 86400. in
+     Log.Task.warn
+       "[cdal-gate] ledger health: latest verdict file is %.1f \
+        days old (threshold %.1f days; %d files scanned in %s).  \
+        Writer pipeline likely dormant — strict-contract tasks \
+        will fail until restored. (#10115)"
+       days
+       (stale_age_seconds /. 86400.)
+       report.total_files
+       report.base_dir
+   | Some _, _ -> ());
+  report
 
 (* --- Attribution envelope conversion ---
    Layer 1 of the attribution rollout. Lets emitters surface a typed

--- a/lib/cdal_verdict_gate.mli
+++ b/lib/cdal_verdict_gate.mli
@@ -70,3 +70,45 @@ val to_attribution : ?gate_label:string -> Cdal_types.contract_verdict -> Attrib
     is required so the optional argument can be erased. *)
 val attribution_for_missing_verdict :
   ?gate_label:string -> task_id:string -> unit -> Attribution.t
+
+(** {1 Ledger health (#10115)}
+
+    The verdict gate reads from a JSONL ledger maintained by
+    [Cdal_eval_v1.persist].  When the writer pipeline goes
+    dormant (observed: 12-day gap before #10115) the reader gate
+    keeps firing "no verdict found" advisories that have no
+    grounded fix — operator-visible WARNs misdirect the
+    investigation toward [MASC_CDAL_VERDICT_LOOKUP_LIMIT].
+    {!ledger_health_report} surfaces the underlying file-system
+    state so a boot-time check (or a [sb] introspection tool)
+    can detect dormancy at the source. *)
+
+type ledger_health = {
+  base_dir : string;          (** Directory the report was taken from. *)
+  total_files : int;          (** Count of [DD.jsonl] files found. *)
+  latest_mtime : float option;
+    (** Newest [DD.jsonl] mtime in Unix seconds, or [None] when no
+        files exist. *)
+  age_seconds : float option;
+    (** [now - latest_mtime] when [latest_mtime] is set; [None]
+        otherwise. *)
+}
+
+val ledger_health_report : ?base_dir:string -> unit -> ledger_health
+(** Snapshot the on-disk state of the verdict ledger.  No I/O on
+    the verdict contents themselves; only readdir + stat.  Pure
+    introspection — does not log. *)
+
+val stale_age_seconds_default : float
+(** Default staleness threshold (7 days) used by
+    {!log_ledger_health_warn_if_stale}. *)
+
+val log_ledger_health_warn_if_stale :
+  ?base_dir:string ->
+  ?stale_age_seconds:float ->
+  unit -> ledger_health
+(** Combines {!ledger_health_report} with a structured WARN line
+    when the ledger is empty or older than [stale_age_seconds].
+    Returns the same report so the caller can also publish it on
+    a metrics surface.  Intended for boot-time wiring or a
+    dedicated [sb cdal health] command. *)

--- a/test/dune
+++ b/test/dune
@@ -446,6 +446,16 @@
     (run %{test}))))
  (libraries masc_test_deps))
 
+; #10115: dedicated stanza so MASC_BASE_PATH is set BEFORE the
+; test executable loads. Same rationale as #10091/#10097/#10101.
+(test
+ (name test_cdal_ledger_health_10115)
+ (modules test_cdal_ledger_health_10115)
+ (action
+  (setenv MASC_BASE_PATH /tmp/test-cdal-ledger-health-10115
+   (setenv MASC_BASE_PATH_INPUT /tmp/test-cdal-ledger-health-10115
+    (run %{test}))))
+ (libraries masc_test_deps))
 
 ; test_worker_run_evidence_summary removed (team session cleanup)
 

--- a/test/test_cdal_ledger_health_10115.ml
+++ b/test/test_cdal_ledger_health_10115.ml
@@ -1,0 +1,169 @@
+(* test/test_cdal_ledger_health_10115.ml
+
+   #10115: the cdal_verdict writer pipeline went 12 days dormant in
+   production while the reader gate kept firing "no verdict found"
+   advisories whose WARN message misdirected the operator toward
+   [MASC_CDAL_VERDICT_LOOKUP_LIMIT].  The lookup limit was never
+   the cause — the writer never ran.  This test pins the new
+   diagnosis surface:
+
+     1. [ledger_health_report] returns [latest_mtime=None] and
+        [total_files=0] for an empty / nonexistent base_dir.
+     2. After writing one file, [latest_mtime] reflects that
+        file's mtime and [age_seconds] is non-negative.
+     3. [log_ledger_health_warn_if_stale] returns the same shape
+        as [ledger_health_report] (caller can keep it for metrics).
+     4. The empty-ledger path yields a report a caller can detect
+        without parsing log lines. *)
+
+let () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-cdal-ledger-10115-%06x"
+         (Random.bits ()))
+  in
+  Unix.putenv "MASC_BASE_PATH" dir
+
+module G = Masc_mcp.Cdal_verdict_gate
+
+let with_temp_base_dir f =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "cdal-ledger-test-%06x" (Random.bits ()))
+  in
+  Unix.mkdir dir 0o755;
+  let cleanup () =
+    let rec rm_rf path =
+      if Sys.is_directory path then begin
+        Array.iter
+          (fun name -> rm_rf (Filename.concat path name))
+          (Sys.readdir path);
+        Unix.rmdir path
+      end else Sys.remove path
+    in
+    try rm_rf dir with _ -> ()
+  in
+  Fun.protect ~finally:cleanup (fun () -> f dir)
+
+let touch_jsonl ~base_dir ~month ~day =
+  let month_dir = Filename.concat base_dir month in
+  (try Unix.mkdir month_dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let path = Filename.concat month_dir (day ^ ".jsonl") in
+  let oc = open_out path in
+  output_string oc "{}\n";
+  close_out oc;
+  path
+
+(* Empty / nonexistent base_dir: report total_files=0 + no mtime. *)
+let test_empty_base_dir_no_files () =
+  let dir = "/tmp/cdal-test-nonexistent-" ^ string_of_int (Random.bits ()) in
+  (* Don't mkdir — we want the nonexistent-dir branch. *)
+  let report = G.ledger_health_report ~base_dir:dir () in
+  Alcotest.(check int)
+    "no files reported for nonexistent dir"
+    0 report.total_files;
+  Alcotest.(check bool)
+    "latest_mtime is None"
+    true (report.latest_mtime = None);
+  Alcotest.(check bool)
+    "age_seconds is None"
+    true (report.age_seconds = None);
+  Alcotest.(check string)
+    "base_dir round-trips"
+    dir report.base_dir
+
+(* Empty existing dir: no jsonl files = same shape as nonexistent. *)
+let test_existing_dir_with_no_jsonl () =
+  with_temp_base_dir @@ fun dir ->
+  let report = G.ledger_health_report ~base_dir:dir () in
+  Alcotest.(check int) "total_files=0" 0 report.total_files;
+  Alcotest.(check bool) "no latest_mtime" true (report.latest_mtime = None)
+
+(* One jsonl file present: report sees it.  age_seconds is small. *)
+let test_one_jsonl_file_visible () =
+  with_temp_base_dir @@ fun dir ->
+  let _path = touch_jsonl ~base_dir:dir ~month:"2026-04" ~day:"08" in
+  let report = G.ledger_health_report ~base_dir:dir () in
+  Alcotest.(check int) "total_files=1" 1 report.total_files;
+  (match report.latest_mtime with
+   | None -> Alcotest.fail "latest_mtime should be Some after touching a file"
+   | Some _ -> ());
+  match report.age_seconds with
+  | None -> Alcotest.fail "age_seconds should be Some after touching a file"
+  | Some age ->
+    (* The file was just touched; age should be small.  Allow up
+       to 60s to absorb test-runner clock skew. *)
+    Alcotest.(check bool)
+      "age_seconds non-negative and bounded"
+      true (age >= 0.0 && age < 60.0)
+
+(* Multiple files across months: latest_mtime is the newest.
+   This pins that we walk all month directories, not just one. *)
+let test_multiple_months_pick_newest () =
+  with_temp_base_dir @@ fun dir ->
+  let _ = touch_jsonl ~base_dir:dir ~month:"2026-03" ~day:"01" in
+  let _ = touch_jsonl ~base_dir:dir ~month:"2026-04" ~day:"01" in
+  let _ = touch_jsonl ~base_dir:dir ~month:"2026-04" ~day:"08" in
+  let report = G.ledger_health_report ~base_dir:dir () in
+  Alcotest.(check int) "total_files=3" 3 report.total_files;
+  match report.latest_mtime with
+  | None -> Alcotest.fail "expected a latest_mtime"
+  | Some t ->
+    let age =
+      match report.age_seconds with
+      | Some a -> a
+      | None -> Alcotest.fail "age_seconds should accompany latest_mtime"
+    in
+    Alcotest.(check bool)
+      "age_seconds matches now - latest_mtime"
+      true
+      (Float.abs ((Time_compat.now () -. t) -. age) < 1.0)
+
+(* log_ledger_health_warn_if_stale returns the same shape as
+   ledger_health_report.  Pin the wrapper contract independently
+   of the WARN side effect (which we don't capture here). *)
+let test_warn_wrapper_returns_report () =
+  with_temp_base_dir @@ fun dir ->
+  let _ = touch_jsonl ~base_dir:dir ~month:"2026-04" ~day:"08" in
+  let report = G.log_ledger_health_warn_if_stale ~base_dir:dir () in
+  Alcotest.(check int)
+    "wrapper returns same total_files as bare report"
+    1 report.total_files;
+  Alcotest.(check string)
+    "base_dir round-trips through wrapper"
+    dir report.base_dir
+
+(* Default staleness threshold is exposed as a constant so
+   operators (and dashboards) can reference the same value the
+   gate uses internally. *)
+let test_default_threshold_is_seven_days () =
+  Alcotest.(check (float 0.001))
+    "stale_age_seconds_default = 7 days in seconds"
+    (7. *. 86400.)
+    G.stale_age_seconds_default
+
+let () =
+  Alcotest.run "cdal_ledger_health_10115"
+    [
+      ( "empty_ledger",
+        [
+          Alcotest.test_case "nonexistent base_dir" `Quick
+            test_empty_base_dir_no_files;
+          Alcotest.test_case "existing dir, no jsonl" `Quick
+            test_existing_dir_with_no_jsonl;
+        ] );
+      ( "populated_ledger",
+        [
+          Alcotest.test_case "single jsonl file visible" `Quick
+            test_one_jsonl_file_visible;
+          Alcotest.test_case "multiple months, latest picked" `Quick
+            test_multiple_months_pick_newest;
+        ] );
+      ( "wrapper_contract",
+        [
+          Alcotest.test_case "warn wrapper returns report" `Quick
+            test_warn_wrapper_returns_report;
+          Alcotest.test_case "default threshold is 7 days" `Quick
+            test_default_threshold_is_seven_days;
+        ] );
+    ]


### PR DESCRIPTION
## Problem (#10115)

The CDAL verdict ledger went **12 days dormant** in production:

```
$ ls -la ~/me/data/cdal_verdicts/2026-04/
-rw-------  ... Apr 13 11:47 KST  08.jsonl    ← last write
$ grep -c 'log_keeper_proof' ~/me/.masc/logs/system_log_2026-04-{22,23,24,25}.jsonl
0 0 0 0    ← writer never fired in 4 days
```

The reader gate (`Cdal_verdict_gate.lookup_latest_verdict`) kept firing, returning "no verdict found" advisories. Worse, its WARN actively misled the operator:

```
> [cdal-gate] lookup_latest_verdict: scanned limit=500 without finding task_id=task-047;
>  older verdicts beyond window are silently skipped (MASC_CDAL_VERDICT_LOOKUP_LIMIT)
```

Bumping `MASC_CDAL_VERDICT_LOOKUP_LIMIT` cannot fix dormancy. Following that hint sends the operator into the wrong layer.

## Root Cause

The actual root cause is OAS-side: `OAS Agent.run` does not emit `result.proof`, so `Cdal_eval_v1.persist` is never reached. That writer-pipeline fix is **out of scope** for this PR (Option A in the issue).

What's in scope is the masc-mcp-side surfaces. The reader gate's diagnostic was wrong, and there was no boot-time signal that the ledger was stale. So even though the dormancy was 12 days old, no operator saw a loud warning about it.

## Fix (Option B + C from the issue)

### B — `lookup_latest_verdict` WARN distinguishes three cases

| Case | New WARN |
|------|----------|
| Ledger empty at `base_dir` | "Writer pipeline likely dormant — check that OAS Agent.run emits result.proof and Cdal_eval_v1.persist is reached" |
| Scan saturated `limit` | "older verdicts beyond window are silently skipped (raise MASC_CDAL_VERDICT_LOOKUP_LIMIT to widen the window)" (original) |
| Ledger has entries but `< limit` and no match | "no verdict in current ledger window … bumping MASC_CDAL_VERDICT_LOOKUP_LIMIT will not help" |

The dormancy case now points at the right layer.

### C — `Cdal_verdict_gate.ledger_health_report`

```ocaml
type ledger_health = {
  base_dir : string;
  total_files : int;
  latest_mtime : float option;
  age_seconds : float option;
}

val ledger_health_report : ?base_dir:string -> unit -> ledger_health

val log_ledger_health_warn_if_stale :
  ?base_dir:string -> ?stale_age_seconds:float -> unit -> ledger_health
```

Walks `base_dir/YYYY-MM/*.jsonl`, returns the newest file's mtime + age. The wrapper logs a WARN when the ledger is empty or older than 7 days (default; picks up the observed 12-day gap with margin). Pure introspection — `readdir` + `stat`, no verdict-content I/O.

Exposed as a public surface so a future boot-time check or a `sb cdal health` command can detect dormancy at process startup, before any strict-contract task tries to gate.

## Tests

`test/test_cdal_ledger_health_10115.ml`:

- **nonexistent base_dir** — `total_files=0`, `latest_mtime=None`, `age_seconds=None` (exercises the `Sys.file_exists=false` guard);
- **existing empty dir, no jsonl** — same shape (regression guard for "directory listing fooled by non-jsonl content");
- **single fresh file** — `total_files=1`, `latest_mtime=Some _`, `age_seconds` non-negative and bounded < 60s;
- **multiple months** — walker visits all month dirs and picks the newest mtime (regression guard for "scanned only current month");
- **wrapper returns report** — `log_ledger_health_warn_if_stale` returns the same shape as `ledger_health_report` so callers can keep it for metrics;
- **`stale_age_seconds_default = 7 days`** — dashboard / runbook contract.

All 22 existing `test_cdal_verdict_gate` tests still pass.

## Notes

- Closes #10115 partially (B + C). Option A (proof emission writer recovery) needs an OAS investigation and is tracked as a follow-up.
- Dedicated `(test ...)` stanza with `setenv MASC_BASE_PATH` for the same reason as #10091 / #10097 / #10101.
- `lookup_latest_verdict` is internal-only; the WARN refinement is a behavior change of an internal function, but the public surface (`gate_check`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
