### PR TITLE
chore(ws): drop no-op List.map and typed String.compare in dashboard_snapshot

### DIFF
--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -211,8 +211,7 @@ let dashboard_snapshot session =
         | Some json -> (slice, json) :: acc
         | None -> acc)
       session.dashboard_slices []
-    |> List.sort (fun (a, _) (b, _) -> compare a b)
-    |> List.map (fun (slice, json) -> (slice, json))
+    |> List.sort (fun (a, _) (b, _) -> String.compare a b)
   in
   `Assoc
     [


### PR DESCRIPTION
## Why

`server_mcp_transport_ws.dashboard_snapshot` ended its pipeline with `|> List.map (fun (slice, json) -> (slice, json))` — the identity function. It builds a fresh list with the same contents and order as its input. Pure waste: a per-subscribe allocation that produces no information.

While there, the sort comparator used `compare a b` on two strings. Polymorphic compare works but pays a runtime dispatch on every comparison; for an always-string operand `String.compare` is the typed equivalent.

Both inside one function. One file changed. Net: −1 line.

## What

```diff
       session.dashboard_slices []
-    |> List.sort (fun (a, _) (b, _) -> compare a b)
-    |> List.map (fun (slice, json) -> (slice, json))
+    |> List.sort (fun (a, _) (b, _) -> String.compare a b)
   in
```

No behaviour change. The list shape, ordering, and contents are identical.

## Why this is a separate PR

Could have been bundled into one of the larger WS migration PRs, but those are scoped to specific concerns (parse cache, bytes cache, observability, etc.). Mixing trivial chore into them would have made each PR slightly less reviewable. A standalone chore is honest about its modest value and reviewable in 30 seconds.

## Tests

```
test_ws_transport          11/11 pass
test_transport_integration  8/8   (ws_sse forwarding path)
```

No new test cases — the existing `dashboard route scoped slices are valid` already exercises the surrounding code path.

## Scope guard

- One function, three lines net change.
- No `.mli` change.
- No wire format change.
- No test fixture change.
- Independent of every other open WS PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)