### PR TITLE
feat(keeper-metrics): bucketed counter for context_max drift observability (#9953)

### DIFF
--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -100,6 +100,42 @@ let classify_usage_trust ~(usage_reported : bool)
   Keeper_usage_trust.classify ~usage_reported ~usage ~model_used
     ~resolved_model_id ~context_max
 
+(* #9953: bucket the raw [context_max] integer into a tightly
+   bounded vocabulary so the Prometheus label cardinality stays
+   small AND the dashboards see the same drift the issue
+   reported (42% / 17% / 41% three-way split for one model).
+
+   Boundaries match observed deployments:
+   - [zero]  : context_max = 0 (uninitialised / pre-resolve)
+   - [64k]   : (0, 64_000]
+   - [128k]  : (64_000, 128_000]
+   - [200k]  : (128_000, 200_000]   — anthropic claude-sonnet-4
+   - [256k]  : (200_000, 262_144]   — kimi / claude haiku 4.5
+   - [1m]    : (262_144, 1_048_576] — claude opus 4.7 / 1M
+   - [other] : everything else (sanity check / future caps) *)
+let context_max_bucket (n : int) : string =
+  if n <= 0 then "zero"
+  else if n <= 64_000 then "64k"
+  else if n <= 128_000 then "128k"
+  else if n <= 200_000 then "200k"
+  else if n <= 262_144 then "256k"
+  else if n <= 1_048_576 then "1m"
+  else "other"
+
+let record_context_max_observation
+    ~(keeper : string)
+    ~(model_used : string)
+    ~(resolved_model_id : string)
+    ~(context_max : int) : unit =
+  Prometheus.inc_counter
+    Prometheus.metric_keeper_context_max_observed
+    ~labels:[
+      ("keeper", keeper);
+      ("model_used", model_used);
+      ("resolved_model_id", resolved_model_id);
+      ("context_max_bucket", context_max_bucket context_max);
+    ] ()
+
 let usage_trust_is_trusted = Keeper_usage_trust.is_trusted
 
 let usage_trust_to_string = Keeper_usage_trust.to_string
@@ -1042,6 +1078,16 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
       ~resolved_model_id
       ~context_max
   in
+  (* #9953: record the (keeper, model_used, resolved_model_id,
+     context_max_bucket) tuple so dashboards can directly count
+     drift.  A model whose label takes >1 bucket on a single
+     deployment indicates the resolution path produced
+     different ceilings on different turns. *)
+  record_context_max_observation
+    ~keeper:meta.name
+    ~model_used:surface_model_used
+    ~resolved_model_id
+    ~context_max;
   let scheduled_autonomous_outcome =
     if is_scheduled_autonomous_channel channel then
       Some (scheduled_autonomous_outcome_for_result result)

--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -71,6 +71,25 @@ val record_usage_trust :
   trust:usage_trust ->
   unit
 
+val context_max_bucket : int -> string
+(** #9953: bucket a raw [context_max] integer into a bounded
+    label vocabulary [zero | 64k | 128k | 200k | 256k | 1m |
+    other].  Pure helper exposed so dashboards / runbooks can
+    reference the same string mapping the metric uses. *)
+
+val record_context_max_observation :
+  keeper:string ->
+  model_used:string ->
+  resolved_model_id:string ->
+  context_max:int ->
+  unit
+(** #9953: emit the
+    [masc_keeper_context_max_observed_total
+       {keeper, model_used, resolved_model_id, context_max_bucket}]
+    counter for one turn.  Intended to be called once per
+    snapshot-write so the counter rate equals the per-turn
+    rate. *)
+
 val update_metrics_from_result :
   Keeper_types.keeper_meta ->
   latency_ms:int ->

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -195,6 +195,21 @@ let metric_keeper_usage_anomalies =
 let metric_keeper_metric_emit_dropped =
   "masc_keeper_metric_emit_dropped_total"
 
+(* #9953: counter of observed [context_max] values labelled by
+   [keeper, model_used, resolved_model_id, context_max_bucket].
+   The bucket label collapses raw token counts into a small set
+   of strings ("64k" | "128k" | "200k" | "256k" | "1m" | "other"
+   | "zero") so the cardinality stays bounded.
+
+   Operators use this counter to detect drift: the same
+   ([model_used], [resolved_model_id]) pair should land in ONE
+   bucket; observing two buckets means the resolution path
+   produced different ceilings on different turns.  The 42% /
+   17% / 41% split for [claude_code:auto] reported in #9953 is
+   directly visible here as three counter rows. *)
+let metric_keeper_context_max_observed =
+  "masc_keeper_context_max_observed_total"
+
 (* Keeper compaction (keeper_compact_policy.ml, tool_keeper.ml). *)
 let metric_keeper_compactions = "masc_keeper_compactions_total"
 let metric_keeper_compaction_ratio_change =
@@ -396,6 +411,15 @@ let init () =
   add metric_sse_capacity_evictions "Total SSE clients evicted due to max client capacity" Counter;
   add metric_sse_write_failures "Total SSE write failures by reason" Counter;
   add metric_sse_rejects "Total SSE connections rejected by storm guard" Counter;
+  (* #9953: context_max distribution per keeper / model / resolved
+     model.  Operators query [count by (model_used, resolved_model_id)
+     (masc_keeper_context_max_observed_total)] to detect drift —
+     a count > 1 indicates the same model resolved to different
+     ceilings on different turns. *)
+  add metric_keeper_context_max_observed
+    "Total observed keeper context_max values, bucketed (labels: keeper, \
+     model_used, resolved_model_id, context_max_bucket=64k|128k|200k|256k|1m|other|zero)"
+    Counter;
   (* Keeper compaction metrics — emitted by keeper_compact_policy.ml *)
   add metric_keeper_compactions
     "Total keeper compactions performed" Counter;

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -75,6 +75,11 @@ val metric_keeper_cache_creation_tokens : string
 val metric_keeper_cache_read_tokens : string
 val metric_keeper_usage_anomalies : string
 val metric_keeper_metric_emit_dropped : string
+val metric_keeper_context_max_observed : string
+(** #9953: bucketed counter for observed [context_max] values.
+    Labels: [keeper, model_used, resolved_model_id,
+    context_max_bucket].  Bucket vocabulary:
+    [64k | 128k | 200k | 256k | 1m | other | zero]. *)
 val metric_keeper_compactions : string
 val metric_keeper_compaction_ratio_change : string
 val metric_keeper_compaction_saved_tokens : string

--- a/test/dune
+++ b/test/dune
@@ -381,6 +381,17 @@
     (run %{test}))))
  (libraries masc_test_deps))
 
+; #9953: dedicated stanza so MASC_BASE_PATH is set BEFORE the
+; test executable loads. Same rationale as #10091/#10097/#10101.
+(test
+ (name test_context_max_observed_9953)
+ (modules test_context_max_observed_9953)
+ (action
+  (setenv MASC_BASE_PATH /tmp/test-context-max-observed-9953
+   (setenv MASC_BASE_PATH_INPUT /tmp/test-context-max-observed-9953
+    (run %{test}))))
+ (libraries masc_test_deps))
+
 ; test_worker_run_evidence_summary removed (team session cleanup)
 
 ; test_team_session_worker_run_meta_repair removed (team session cleanup)

--- a/test/test_context_max_observed_9953.ml
+++ b/test/test_context_max_observed_9953.ml
@@ -1,0 +1,206 @@
+(* test/test_context_max_observed_9953.ml
+
+   #9953: same model label was recording 3 different
+   [context_max] values across turns (claude_code:auto getting
+   42% / 17% / 41% split between 64k / 262k / 1M).  The data was
+   in the JSONL ledger but invisible to Prometheus dashboards.
+
+   This test pins:
+     1. The [context_max_bucket] string vocabulary — dashboards
+        and runbooks key off these literals, so a future change
+        is an explicit decision.
+     2. Boundary behaviour for each bucket transition (off-by-
+        one regression guard).
+     3. The counter increments on the bucket inferred from the
+        observed value, with the labels operators expect.
+     4. Per-(keeper, model_used, resolved_model_id) bucket
+        isolation — a turn that lands in [200k] must not leak
+        into the [256k] bucket for the same keeper.
+
+   The point of the metric is that
+   [count by (model_used, resolved_model_id)
+            (masc_keeper_context_max_observed_total)] returning
+   > 1 directly indicates drift.  Test #4 pins this counting
+   contract by exercising two distinct buckets for one
+   (model_used, resolved_model_id) and asserting both labels
+   carry the expected count. *)
+
+let () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-context-max-observed-9953-%06x"
+         (Random.bits ()))
+  in
+  Unix.putenv "MASC_BASE_PATH" dir
+
+module UM = Masc_mcp.Keeper_unified_metrics
+module Prom = Masc_mcp.Prometheus
+
+let metric = Prom.metric_keeper_context_max_observed
+
+let counter_for ~keeper ~model_used ~resolved_model_id ~bucket =
+  Prom.metric_value_or_zero metric
+    ~labels:[
+      ("keeper", keeper);
+      ("model_used", model_used);
+      ("resolved_model_id", resolved_model_id);
+      ("context_max_bucket", bucket);
+    ] ()
+
+(* Pin the vocabulary: an exhaustive table of representative
+   inputs and the bucket each must land in.  Adding a new
+   bucket / changing a boundary is now an explicit change. *)
+let test_bucket_vocabulary () =
+  let cases =
+    [
+      0,         "zero";
+      -1,        "zero";       (* clamp negative to zero bucket *)
+      1,         "64k";
+      32_000,    "64k";
+      64_000,    "64k";
+      64_001,    "128k";
+      128_000,   "128k";
+      128_001,   "200k";
+      200_000,   "200k";
+      200_001,   "256k";
+      262_144,   "256k";
+      262_145,   "1m";
+      1_000_000, "1m";
+      1_048_576, "1m";
+      1_048_577, "other";
+      5_000_000, "other";
+    ]
+  in
+  List.iter
+    (fun (input, expected) ->
+      Alcotest.(check string)
+        (Printf.sprintf "context_max_bucket %d" input)
+        expected (UM.context_max_bucket input))
+    cases
+
+(* Boundary regression: each transition is +1 / -1 from the
+   threshold.  Splitting these out makes a failure name the
+   exact off-by-one. *)
+let test_bucket_boundary_64k () =
+  Alcotest.(check string) "64_000 → 64k" "64k"
+    (UM.context_max_bucket 64_000);
+  Alcotest.(check string) "64_001 → 128k" "128k"
+    (UM.context_max_bucket 64_001)
+
+let test_bucket_boundary_256k () =
+  Alcotest.(check string) "262_144 → 256k" "256k"
+    (UM.context_max_bucket 262_144);
+  Alcotest.(check string) "262_145 → 1m" "1m"
+    (UM.context_max_bucket 262_145)
+
+let test_bucket_boundary_1m () =
+  Alcotest.(check string) "1_048_576 → 1m" "1m"
+    (UM.context_max_bucket 1_048_576);
+  Alcotest.(check string) "1_048_577 → other" "other"
+    (UM.context_max_bucket 1_048_577)
+
+(* The counter increments on the inferred bucket and labels are
+   isolated across (keeper, model_used, resolved_model_id). *)
+let test_record_increments_correct_bucket () =
+  let keeper = "test-keeper-9953" in
+  let model = "claude_code:auto-9953" in
+  let resolved = "anthropic-claude-opus-4-7" in
+  let before_1m =
+    counter_for ~keeper ~model_used:model ~resolved_model_id:resolved
+      ~bucket:"1m"
+  in
+  let before_256k =
+    counter_for ~keeper ~model_used:model ~resolved_model_id:resolved
+      ~bucket:"256k"
+  in
+  UM.record_context_max_observation
+    ~keeper ~model_used:model ~resolved_model_id:resolved
+    ~context_max:1_000_000;
+  Alcotest.(check (float 0.0001))
+    "1m bucket +1"
+    (before_1m +. 1.0)
+    (counter_for ~keeper ~model_used:model ~resolved_model_id:resolved
+       ~bucket:"1m");
+  Alcotest.(check (float 0.0001))
+    "256k bucket unchanged"
+    before_256k
+    (counter_for ~keeper ~model_used:model ~resolved_model_id:resolved
+       ~bucket:"256k")
+
+(* The whole point of the metric: same (model_used,
+   resolved_model_id) pair landing in two buckets directly
+   visible in counter rows.  A future fix that pins context_max
+   to one bucket per pair will see this test still pass — it
+   pins the OBSERVABILITY contract, not the underlying bug. *)
+let test_drift_visible_as_two_bucket_rows () =
+  let keeper = "test-keeper-drift-9953" in
+  let model = "claude_code:auto-drift-9953" in
+  let resolved = "auto-drift-resolved-9953" in
+  let before_64k =
+    counter_for ~keeper ~model_used:model ~resolved_model_id:resolved
+      ~bucket:"64k"
+  in
+  let before_1m =
+    counter_for ~keeper ~model_used:model ~resolved_model_id:resolved
+      ~bucket:"1m"
+  in
+  (* Simulate the #9953 split: 1 turn lands at 64k, another at 1m. *)
+  UM.record_context_max_observation
+    ~keeper ~model_used:model ~resolved_model_id:resolved
+    ~context_max:64_000;
+  UM.record_context_max_observation
+    ~keeper ~model_used:model ~resolved_model_id:resolved
+    ~context_max:1_000_000;
+  Alcotest.(check (float 0.0001))
+    "64k bucket recorded one drift turn"
+    (before_64k +. 1.0)
+    (counter_for ~keeper ~model_used:model ~resolved_model_id:resolved
+       ~bucket:"64k");
+  Alcotest.(check (float 0.0001))
+    "1m bucket recorded the other drift turn"
+    (before_1m +. 1.0)
+    (counter_for ~keeper ~model_used:model ~resolved_model_id:resolved
+       ~bucket:"1m")
+
+(* keeper isolation — a turn for keeper A must not affect
+   keeper B's counters even with identical model labels. *)
+let test_keeper_label_isolation () =
+  let model = "model-iso-9953" in
+  let resolved = "resolved-iso-9953" in
+  let before_b =
+    counter_for ~keeper:"keeper-B-9953" ~model_used:model
+      ~resolved_model_id:resolved ~bucket:"1m"
+  in
+  UM.record_context_max_observation
+    ~keeper:"keeper-A-9953" ~model_used:model ~resolved_model_id:resolved
+    ~context_max:1_000_000;
+  Alcotest.(check (float 0.0001))
+    "keeper B unaffected"
+    before_b
+    (counter_for ~keeper:"keeper-B-9953" ~model_used:model
+       ~resolved_model_id:resolved ~bucket:"1m")
+
+let () =
+  Alcotest.run "context_max_observed_9953"
+    [
+      ( "vocabulary",
+        [
+          Alcotest.test_case "bucket vocabulary table" `Quick
+            test_bucket_vocabulary;
+          Alcotest.test_case "boundary 64k / 128k" `Quick
+            test_bucket_boundary_64k;
+          Alcotest.test_case "boundary 256k / 1m" `Quick
+            test_bucket_boundary_256k;
+          Alcotest.test_case "boundary 1m / other" `Quick
+            test_bucket_boundary_1m;
+        ] );
+      ( "counter_emission",
+        [
+          Alcotest.test_case "increments correct bucket" `Quick
+            test_record_increments_correct_bucket;
+          Alcotest.test_case "drift visible as two bucket rows"
+            `Quick test_drift_visible_as_two_bucket_rows;
+          Alcotest.test_case "keeper label isolation" `Quick
+            test_keeper_label_isolation;
+        ] );
+    ]


### PR DESCRIPTION
## Problem (#9953)

Same model label `claude_code:auto` recording **three different** `context_max` values across turns within one session:

| model_used | context_max | count | % |
|---|---:|---:|---:|
| `claude_code:auto` | **64000** | 271 | **42%** |
| `claude_code:auto` | **1000000** | 267 | **41%** |
| `claude_code:auto` | **262144** | 111 | **17%** |

The data is in the JSONL ledger but invisible to Prometheus dashboards. Operators cannot answer "is this model getting consistent ceilings?" without grepping files. Downstream consequences observed in #9943 (compaction noop on 64k clipped turns) and #9935 (`context_ratio > 1.0` from miscapped budgets).

## Root Cause

The threaded `context_max` resolution chain — `Provider_registry.find` → `Cascade_runtime.max_context_of_label` → per-call overrides → OAS `effective_context_window` telemetry — produces different ceilings under three conditions:

1. **`*_cli:auto` resolution drift** — `claude_code:auto` resolves to opus (1M), sonnet (200k), or haiku (256k) on different turns.
2. **Hardcoded ceilings drift** — `keeper_turn_up_args.ml:245` accepts overrides up to 1M while `oas_worker_exec_transport.ml:394` emits 262144 to CLI configs.
3. **Hot-reload caching** — config changes mid-session leave some turns on stale caps.

Fixing the threaded resolution itself is invasive and out of scope. **This PR establishes the observability surface** so the drift becomes a directly queryable metric.

## Fix

| Piece | Detail |
|-------|--------|
| New counter | `masc_keeper_context_max_observed_total{keeper, model_used, resolved_model_id, context_max_bucket}` |
| Bucketing | `Keeper_unified_metrics.context_max_bucket : int -> string` collapses raw token counts into `zero \| 64k \| 128k \| 200k \| 256k \| 1m \| other` |
| Wiring | `record_context_max_observation` called once per `record_keeper_response` snapshot — per-turn rate matches the JSONL row rate |

The query

```promql
count by (model_used, resolved_model_id) (masc_keeper_context_max_observed_total)
```

returns `> 1` directly when the same model resolves to multiple ceilings — the 42%/41%/17% split from the issue becomes three counter rows.

Bucket boundaries are keyed on real deployments (Anthropic sonnet 200k, kimi/haiku 256k, opus 1M). Cardinality stays small (7 buckets × actual deployed models).

No production behaviour change — pure observability.

## Tests

`test/test_context_max_observed_9953.ml`:

- **bucket vocabulary table** — 16 representative inputs pinning every transition.
- **boundary tests** — `64_000 → 64k`, `64_001 → 128k`; `262_144 → 256k`, `262_145 → 1m`; `1_048_576 → 1m`, `1_048_577 → other`. Off-by-one regressions caught by name.
- **counter increments correct bucket** — verifies labels `(keeper, model_used, resolved_model_id, context_max_bucket)`.
- **drift visible as two bucket rows** — same `(keeper, model_used, resolved_model_id)` pair landing in `64k` AND `1m` buckets via two separate calls. Pins the observability contract.
- **keeper label isolation** — keeper A's emit doesn't bleed into keeper B's counter.

5 sibling `test_keeper_usage_trust_counter` tests still pass.

## Notes

- Closes the observability side of #9953. The threaded-resolution SSOT fix (Provider_registry vs cascade override vs turn override) remains a follow-up; this PR makes its impact measurable.
- Dedicated `(test ...)` stanza with `setenv MASC_BASE_PATH` for the same reason as #10091/#10097/#10101/#10094/#10115.
- Pattern repeats from earlier ticks: surface the drift first (counter with structured labels), fix the underlying resolution second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
