### PR TITLE
feat(keeper): livelock observer counters for stuck-turn re-attempts (#10121)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -525,6 +525,7 @@
    keeper_behavioral_regime_observer
    keeper_unified_prompt
    keeper_unified_metrics
+   keeper_turn_livelock
    keeper_stay_silent_loop_detector
    keeper_error_classify
    keeper_unified_turn

--- a/lib/keeper/keeper_turn_livelock.ml
+++ b/lib/keeper/keeper_turn_livelock.ml
@@ -1,0 +1,117 @@
+(** Keeper_turn_livelock — observability surface for stuck-turn livelocks.
+
+    #10121 reports 10 (keeper, turn) pairs retrying 4-12× over 4+ hours
+    because the FSM has no max-attempts guard or stuck-turn detector.
+    The root cause trigger is a [write_meta] CAS race (#9733) that
+    silently drops the in-memory turn-counter increment, but the
+    defense-in-depth gap is observability: nothing surfaces "this
+    keeper has tried turn 91 twelve times" until an operator greps
+    log lines.
+
+    This module is the OBSERVABILITY half — it does NOT gate dispatch
+    yet (that's a follow-up).  Per-keeper in-memory state tracks the
+    most recent turn id seen and the attempt count for that id.  When
+    the same id starts again we emit a re-attempt counter.  When the
+    id moves strictly backwards we emit a regression counter (rare;
+    indicative of the write_meta race).  When the id advances normally
+    we reset the per-keeper bookkeeping.
+
+    State is process-local: a server restart resets the counters,
+    which is intentional — the issue's fleet-wide signal comes from
+    in-process retry storms, not cross-restart divergence. *)
+
+type attempt_state = {
+  turn_id : int;
+  attempts : int;
+  first_started_at : float;
+}
+
+let mu = Stdlib.Mutex.create ()
+let state : (string, attempt_state) Hashtbl.t = Hashtbl.create 16
+
+(** Reset for tests so each test starts clean.  Public so the test
+    harness can call it without poking at internals. *)
+let reset_for_tests () =
+  Stdlib.Mutex.lock mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock mu)
+    (fun () -> Hashtbl.clear state)
+
+(** [start_outcome] records what happened on a [record_turn_start]
+    call.  Returned so callers (tests, future gating logic) don't
+    have to re-derive the classification from external data. *)
+type start_outcome =
+  | Fresh
+    (** First time we have ever seen this keeper, or the turn id
+        advanced from the previous one. *)
+  | Reattempt of { previous_attempts : int; first_started_at : float }
+    (** The same turn id is being started again.  [previous_attempts]
+        is the count BEFORE this start (so the new attempt count is
+        [previous_attempts + 1]).  [first_started_at] lets a future
+        gate compute "stuck for X minutes". *)
+  | Regression of { previous_turn_id : int }
+    (** The turn id strictly decreased — usually a write_meta race
+        losing an in-memory increment (#9733). *)
+
+let now_unix () = Time_compat.now ()
+
+let record_turn_start ~(keeper : string) ~(turn_id : int) : start_outcome =
+  let outcome =
+    Stdlib.Mutex.lock mu;
+    Fun.protect
+      ~finally:(fun () -> Stdlib.Mutex.unlock mu)
+      (fun () ->
+        match Hashtbl.find_opt state keeper with
+        | None ->
+          Hashtbl.replace state keeper
+            { turn_id; attempts = 1; first_started_at = now_unix () };
+          Fresh
+        | Some prev when prev.turn_id < turn_id ->
+          Hashtbl.replace state keeper
+            { turn_id; attempts = 1; first_started_at = now_unix () };
+          Fresh
+        | Some prev when prev.turn_id = turn_id ->
+          let attempts = prev.attempts + 1 in
+          Hashtbl.replace state keeper { prev with attempts };
+          Reattempt
+            { previous_attempts = prev.attempts;
+              first_started_at = prev.first_started_at }
+        | Some prev (* prev.turn_id > turn_id *) ->
+          (* Strictly backwards.  Reset bookkeeping so the next start
+             at this lower id counts as Fresh, not Reattempt. *)
+          Hashtbl.replace state keeper
+            { turn_id; attempts = 1; first_started_at = now_unix () };
+          Regression { previous_turn_id = prev.turn_id })
+  in
+  (* Counter emissions outside the lock — Prometheus calls allocate
+     and can recurse; minimise critical-section scope. *)
+  Prometheus.inc_counter
+    Prometheus.metric_keeper_turn_starts
+    ~labels:[ ("keeper", keeper) ] ();
+  (match outcome with
+   | Fresh -> ()
+   | Reattempt _ ->
+     Prometheus.inc_counter
+       Prometheus.metric_keeper_turn_reattempts
+       ~labels:[ ("keeper", keeper) ] ()
+   | Regression _ ->
+     Prometheus.inc_counter
+       Prometheus.metric_keeper_turn_regressions
+       ~labels:[ ("keeper", keeper) ] ());
+  outcome
+
+(** Read current attempt state for [keeper] without modifying it.
+    Useful for diagnostics and future gating logic that wants to
+    decide BEFORE incrementing. *)
+let current_state ~(keeper : string) : attempt_state option =
+  Stdlib.Mutex.lock mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock mu)
+    (fun () -> Hashtbl.find_opt state keeper)
+
+(** [seconds_since_first_attempt ~keeper] returns the age of the
+    current turn's FIRST attempt for [keeper], or [None] if no state
+    exists.  Pure read. *)
+let seconds_since_first_attempt ~(keeper : string) : float option =
+  current_state ~keeper
+  |> Option.map (fun s -> now_unix () -. s.first_started_at)

--- a/lib/keeper/keeper_turn_livelock.mli
+++ b/lib/keeper/keeper_turn_livelock.mli
@@ -1,0 +1,41 @@
+(** Keeper turn livelock observer (#10121).
+
+    Observability surface for stuck-turn livelocks: per-keeper
+    in-memory state tracks the most recent turn id seen and the
+    attempt count for that id.  Re-starts of the same id and
+    backwards regressions emit dedicated Prometheus counters so
+    operators can alert without grepping log lines.
+
+    This module does NOT gate dispatch — that's a follow-up.
+    State is process-local; a server restart resets the
+    bookkeeping. *)
+
+type attempt_state = {
+  turn_id : int;
+  attempts : int;
+  first_started_at : float;  (** Unix seconds. *)
+}
+
+type start_outcome =
+  | Fresh
+  | Reattempt of { previous_attempts : int; first_started_at : float }
+  | Regression of { previous_turn_id : int }
+
+(** [record_turn_start ~keeper ~turn_id] increments the
+    [masc_keeper_turn_starts_total] counter and, when the start
+    classifies as [Reattempt] or [Regression], the matching
+    counter as well.  Returns the classification for the caller.
+    Thread-safe across keeper fibers / domains. *)
+val record_turn_start : keeper:string -> turn_id:int -> start_outcome
+
+(** Read-only view of the current attempt state for a keeper.
+    Returns [None] when no state has been recorded yet. *)
+val current_state : keeper:string -> attempt_state option
+
+(** Convenience wrapper — Unix seconds since the FIRST attempt of
+    the current turn id.  [None] when no state exists. *)
+val seconds_since_first_attempt : keeper:string -> float option
+
+(** Reset the in-memory state.  Intended for unit tests; the live
+    server resets state implicitly on process restart. *)
+val reset_for_tests : unit -> unit

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -986,6 +986,17 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         ~base_path:config.base_path meta.name;
       Keeper_registry.mark_turn_measurement
         ~base_path:config.base_path meta.name;
+      (* #10121: livelock observer — emit reattempt counter when
+         the same turn id starts again before the counter
+         advanced.  The classification result is intentionally
+         dropped here (no behaviour change yet); a follow-up PR
+         can act on [Reattempt { previous_attempts = N; _ }] to
+         gate dispatch above a threshold. *)
+      let _ : Keeper_turn_livelock.start_outcome =
+        Keeper_turn_livelock.record_turn_start
+          ~keeper:meta.name
+          ~turn_id:meta.runtime.usage.total_turns
+      in
       (match Keeper_registry.get ~base_path:config.base_path meta.name with
        | Some { current_turn_observation = Some { measurement = Some _; _ }; _ } ->
            Keeper_registry.set_turn_decision_stage

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -210,6 +210,21 @@ let metric_keeper_metric_emit_dropped =
 let metric_keeper_context_max_observed =
   "masc_keeper_context_max_observed_total"
 
+(* #10121: keeper turn livelock observer.  Each turn-start
+   bumps [metric_keeper_turn_starts]; a re-start of the SAME
+   turn id (turn counter did not advance) bumps the dedicated
+   [metric_keeper_turn_reattempts].  Operators alert on
+   [rate(masc_keeper_turn_reattempts_total[5m]) > 0] and pick
+   up stuck-turn pairs without grepping log lines.  See also
+   [metric_keeper_turn_regressions] when the FSM moves to a
+   strictly LOWER turn id (very unusual; indicative of
+   write_meta race losing an in-memory counter increment,
+   #9733). *)
+let metric_keeper_turn_starts = "masc_keeper_turn_starts_total"
+let metric_keeper_turn_reattempts = "masc_keeper_turn_reattempts_total"
+let metric_keeper_turn_regressions = "masc_keeper_turn_regressions_total"
+
+
 (* Keeper compaction (keeper_compact_policy.ml, tool_keeper.ml). *)
 let metric_keeper_compactions = "masc_keeper_compactions_total"
 let metric_keeper_compaction_ratio_change =
@@ -419,6 +434,22 @@ let init () =
   add metric_keeper_context_max_observed
     "Total observed keeper context_max values, bucketed (labels: keeper, \
      model_used, resolved_model_id, context_max_bucket=64k|128k|200k|256k|1m|other|zero)"
+    Counter;
+  (* #10121: keeper turn livelock observer counters.  Operator
+     alert: rate(masc_keeper_turn_reattempts_total[5m]) > 0
+     surfaces stuck (keeper, turn) pairs without grepping logs. *)
+  add metric_keeper_turn_starts
+    "Total keeper turn starts (every dispatch increments, regardless of \
+     whether the turn id is new or repeated)"
+    Counter;
+  add metric_keeper_turn_reattempts
+    "Total keeper turn re-attempts: same turn id started again before \
+     the counter advanced (livelock signal — #10121)"
+    Counter;
+  add metric_keeper_turn_regressions
+    "Total keeper turn regressions: turn id moved to a strictly LOWER \
+     value than previously observed (write_meta race losing an in-memory \
+     counter increment — #9733 / #10121)"
     Counter;
   (* Keeper compaction metrics — emitted by keeper_compact_policy.ml *)
   add metric_keeper_compactions

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -80,6 +80,13 @@ val metric_keeper_context_max_observed : string
     Labels: [keeper, model_used, resolved_model_id,
     context_max_bucket].  Bucket vocabulary:
     [64k | 128k | 200k | 256k | 1m | other | zero]. *)
+val metric_keeper_turn_starts : string
+val metric_keeper_turn_reattempts : string
+val metric_keeper_turn_regressions : string
+(** #10121: keeper turn livelock observer counters.  Labels:
+    [keeper].  Re-attempt = same turn id started again before
+    the counter advanced; regression = turn id moved strictly
+    backwards (write_meta race symptom — #9733). *)
 val metric_keeper_compactions : string
 val metric_keeper_compaction_ratio_change : string
 val metric_keeper_compaction_saved_tokens : string

--- a/test/dune
+++ b/test/dune
@@ -392,6 +392,18 @@
     (run %{test}))))
  (libraries masc_test_deps))
 
+; #10121: dedicated stanza so MASC_BASE_PATH is set BEFORE the
+; test executable loads. Same rationale as #10091/#10097/#10101.
+(test
+ (name test_keeper_turn_livelock_10121)
+ (modules test_keeper_turn_livelock_10121)
+ (action
+  (setenv MASC_BASE_PATH /tmp/test-keeper-turn-livelock-10121
+   (setenv MASC_BASE_PATH_INPUT /tmp/test-keeper-turn-livelock-10121
+    (run %{test}))))
+ (libraries masc_test_deps))
+
+
 ; test_worker_run_evidence_summary removed (team session cleanup)
 
 ; test_team_session_worker_run_meta_repair removed (team session cleanup)

--- a/test/test_keeper_turn_livelock_10121.ml
+++ b/test/test_keeper_turn_livelock_10121.ml
@@ -1,0 +1,197 @@
+(* test/test_keeper_turn_livelock_10121.ml
+
+   #10121 reports 10 (keeper, turn) pairs retrying 4-12× over
+   4+ hours with no FSM guard.  This test pins the
+   observability surface that surfaces those retries directly
+   to Prometheus instead of leaving them buried in log lines:
+
+     1. The first start of any (keeper, turn_id) is [Fresh] —
+        no reattempt counter increment.
+     2. The same id starting again classifies as [Reattempt]
+        and increments [masc_keeper_turn_reattempts_total].
+        [previous_attempts] grows by 1 per reattempt.
+     3. Advancing the turn id resets bookkeeping — a normal
+        forward progression must NOT count as reattempt.
+     4. A turn id moving strictly backwards classifies as
+        [Regression] (write_meta race symptom #9733) and
+        increments the regression counter.
+     5. Per-keeper isolation: keeper A's reattempts do not
+        leak into keeper B's counters even with identical
+        turn ids.
+     6. [seconds_since_first_attempt] returns the time since
+        the FIRST start of the current turn id (so a future
+        gate can compute "stuck for X minutes" without
+        re-deriving the timeline).
+*)
+
+let () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-keeper-turn-livelock-10121-%06x"
+         (Random.bits ()))
+  in
+  Unix.putenv "MASC_BASE_PATH" dir
+
+module L = Masc_mcp.Keeper_turn_livelock
+module Prom = Masc_mcp.Prometheus
+
+let starts_for ~keeper =
+  Prom.metric_value_or_zero Prom.metric_keeper_turn_starts
+    ~labels:[ ("keeper", keeper) ] ()
+
+let reattempts_for ~keeper =
+  Prom.metric_value_or_zero Prom.metric_keeper_turn_reattempts
+    ~labels:[ ("keeper", keeper) ] ()
+
+let regressions_for ~keeper =
+  Prom.metric_value_or_zero Prom.metric_keeper_turn_regressions
+    ~labels:[ ("keeper", keeper) ] ()
+
+(* Fresh start: no prior state → [Fresh] outcome, starts counter
+   +1, reattempt counter unchanged. *)
+let test_fresh_first_start () =
+  L.reset_for_tests ();
+  let keeper = "test-keeper-fresh-10121" in
+  let before_starts = starts_for ~keeper in
+  let before_reattempts = reattempts_for ~keeper in
+  let outcome = L.record_turn_start ~keeper ~turn_id:1 in
+  Alcotest.(check bool) "outcome is Fresh" true (outcome = L.Fresh);
+  Alcotest.(check (float 0.0001))
+    "starts +1"
+    (before_starts +. 1.0) (starts_for ~keeper);
+  Alcotest.(check (float 0.0001))
+    "reattempts unchanged"
+    before_reattempts (reattempts_for ~keeper)
+
+(* Same turn id starts twice → second is Reattempt, counter
+   labelled correctly. *)
+let test_same_turn_classifies_as_reattempt () =
+  L.reset_for_tests ();
+  let keeper = "test-keeper-reattempt-10121" in
+  let before_reattempts = reattempts_for ~keeper in
+  let _ : L.start_outcome = L.record_turn_start ~keeper ~turn_id:91 in
+  let outcome = L.record_turn_start ~keeper ~turn_id:91 in
+  (match outcome with
+   | L.Reattempt { previous_attempts; _ } ->
+     Alcotest.(check int) "previous_attempts is 1" 1 previous_attempts
+   | _ -> Alcotest.fail "expected Reattempt outcome");
+  Alcotest.(check (float 0.0001))
+    "reattempts +1"
+    (before_reattempts +. 1.0) (reattempts_for ~keeper)
+
+(* Multiple reattempts grow the previous_attempts count.  The
+   #10121 worst case is 12× — pin that the count grows
+   monotonically over many retries. *)
+let test_reattempt_count_grows_monotonically () =
+  L.reset_for_tests ();
+  let keeper = "test-keeper-12x-10121" in
+  let _ : L.start_outcome = L.record_turn_start ~keeper ~turn_id:91 in
+  let counts = List.init 11 (fun _ ->
+    match L.record_turn_start ~keeper ~turn_id:91 with
+    | L.Reattempt { previous_attempts; _ } -> previous_attempts
+    | _ -> -1
+  ) in
+  Alcotest.(check (list int))
+    "previous_attempts: 1, 2, 3, ..., 11"
+    [1; 2; 3; 4; 5; 6; 7; 8; 9; 10; 11]
+    counts
+
+(* Forward progression: turn id advances → outcome is Fresh,
+   no reattempt counter increment. *)
+let test_forward_advance_resets () =
+  L.reset_for_tests ();
+  let keeper = "test-keeper-advance-10121" in
+  let _ : L.start_outcome = L.record_turn_start ~keeper ~turn_id:5 in
+  let _ : L.start_outcome = L.record_turn_start ~keeper ~turn_id:5 in
+  let before_reattempts = reattempts_for ~keeper in
+  let outcome = L.record_turn_start ~keeper ~turn_id:6 in
+  Alcotest.(check bool) "advance is Fresh" true (outcome = L.Fresh);
+  Alcotest.(check (float 0.0001))
+    "advance does not increment reattempts"
+    before_reattempts (reattempts_for ~keeper);
+  (* And the next start at the new id classifies as Reattempt
+     against the NEW id, not the old one. *)
+  let outcome2 = L.record_turn_start ~keeper ~turn_id:6 in
+  match outcome2 with
+  | L.Reattempt { previous_attempts; _ } ->
+    Alcotest.(check int)
+      "reattempt of new id starts at previous_attempts=1"
+      1 previous_attempts
+  | _ -> Alcotest.fail "expected Reattempt of new id"
+
+(* Backwards regression: write_meta race symptom from #9733. *)
+let test_backward_turn_classifies_as_regression () =
+  L.reset_for_tests ();
+  let keeper = "test-keeper-regression-10121" in
+  let _ : L.start_outcome = L.record_turn_start ~keeper ~turn_id:91 in
+  let before_regressions = regressions_for ~keeper in
+  let outcome = L.record_turn_start ~keeper ~turn_id:90 in
+  (match outcome with
+   | L.Regression { previous_turn_id } ->
+     Alcotest.(check int) "previous_turn_id is 91" 91 previous_turn_id
+   | _ -> Alcotest.fail "expected Regression outcome");
+  Alcotest.(check (float 0.0001))
+    "regressions +1"
+    (before_regressions +. 1.0) (regressions_for ~keeper)
+
+(* Per-keeper isolation. *)
+let test_keeper_isolation () =
+  L.reset_for_tests ();
+  let a = "test-keeper-iso-A-10121" in
+  let b = "test-keeper-iso-B-10121" in
+  let before_b = reattempts_for ~keeper:b in
+  let _ : L.start_outcome = L.record_turn_start ~keeper:a ~turn_id:1 in
+  let _ : L.start_outcome = L.record_turn_start ~keeper:a ~turn_id:1 in
+  Alcotest.(check (float 0.0001))
+    "keeper B unaffected by keeper A reattempts"
+    before_b (reattempts_for ~keeper:b)
+
+(* seconds_since_first_attempt accuracy.  After two reattempts
+   with a small sleep between them, the wrapper should report
+   roughly the elapsed time since the FIRST attempt. *)
+let test_seconds_since_first_attempt () =
+  L.reset_for_tests ();
+  let keeper = "test-keeper-stuck-time-10121" in
+  let _ : L.start_outcome = L.record_turn_start ~keeper ~turn_id:1 in
+  Unix.sleepf 0.05;
+  let _ : L.start_outcome = L.record_turn_start ~keeper ~turn_id:1 in
+  match L.seconds_since_first_attempt ~keeper with
+  | None -> Alcotest.fail "expected Some elapsed seconds"
+  | Some t ->
+    Alcotest.(check bool)
+      "elapsed >= 50ms (sleep) and < 60s (test budget)"
+      true (t >= 0.04 && t < 60.0)
+
+let () =
+  Alcotest.run "keeper_turn_livelock_10121"
+    [
+      ( "fresh",
+        [
+          Alcotest.test_case "first start is Fresh" `Quick
+            test_fresh_first_start;
+        ] );
+      ( "reattempt",
+        [
+          Alcotest.test_case "same id is Reattempt" `Quick
+            test_same_turn_classifies_as_reattempt;
+          Alcotest.test_case "reattempt count grows" `Quick
+            test_reattempt_count_grows_monotonically;
+          Alcotest.test_case "forward advance resets" `Quick
+            test_forward_advance_resets;
+        ] );
+      ( "regression",
+        [
+          Alcotest.test_case "backward id is Regression" `Quick
+            test_backward_turn_classifies_as_regression;
+        ] );
+      ( "isolation",
+        [
+          Alcotest.test_case "per-keeper labels" `Quick
+            test_keeper_isolation;
+        ] );
+      ( "timing",
+        [
+          Alcotest.test_case "seconds_since_first_attempt" `Quick
+            test_seconds_since_first_attempt;
+        ] );
+    ]


### PR DESCRIPTION
## Problem (#10121)

10 distinct (keeper, turn) pairs retried 4-12× over 4+ hours with no FSM guard. Worst case: `qa-king turn=91` ran 6 "completed" cycles + 3 "FAILED" cycles in 4 hours without the turn counter advancing — ~30 minutes of LLM time stuck on one turn.

Root cause TRIGGER is a `write_meta` CAS race (#9733) that silently drops the in-memory turn-counter increment. The defense-in-depth gap is observability: nothing surfaces "this keeper has tried turn 91 twelve times" until an operator greps log lines.

## Fix (Observability Half of Option A)

Per-keeper in-memory state tracks `(turn_id, attempts, first_started_at)`. Each `record_turn_start` classifies as `Fresh` / `Reattempt` / `Regression` and emits the matching Prometheus counter.

Three counters, all labelled by `keeper`:

| Counter | Fires on |
|---------|----------|
| `masc_keeper_turn_starts_total` | every dispatch |
| `masc_keeper_turn_reattempts_total` | same turn id started again before the counter advanced (livelock signal) |
| `masc_keeper_turn_regressions_total` | turn id moved strictly backwards (write_meta race symptom #9733) |

**Operator alert**: `rate(masc_keeper_turn_reattempts_total[5m]) > 0` directly surfaces stuck pairs without log grep.

`record_turn_start` returns the classification so a future gate can act on `Reattempt { previous_attempts = N; _ }` above a threshold. `seconds_since_first_attempt` gives the data needed for "stuck for X minutes". This PR delivers the OBSERVABILITY surface; gating dispatch is a follow-up.

## Wiring

One call site: `keeper_unified_turn.ml:986`, right after `mark_turn_started`, with `~turn_id:meta.runtime.usage.total_turns`. The classification result is intentionally ignored at the call site — **zero behaviour change** in this PR.

State is process-local. A server restart resets the counters. Intentional — the issue's fleet-wide signal comes from in-process retry storms, not cross-restart divergence.

## Tests

`test/test_keeper_turn_livelock_10121.ml`:

- **Fresh start** — first call returns `Fresh`, no reattempt counter increment.
- **Reattempt classification** — second call with same id returns `Reattempt { previous_attempts = 1 }`.
- **12× reattempt** — monotonic growth `[1, 2, 3, ..., 11]` matches the issue's worst case.
- **Forward advance resets** — turn id N → N+1 is `Fresh`, then the first start at N+1 increments. Regression guard for "advance is a Reattempt because counter > 0".
- **Backwards regression** — turn id 91 → 90 returns `Regression { previous_turn_id = 91 }`, increments regression counter.
- **Per-keeper isolation** — keeper A's reattempts do not bleed into keeper B's counter.
- **`seconds_since_first_attempt`** — returns wall time since the FIRST attempt of the current turn id (basis for future stuck-turn gate).

## Notes

- Closes the observability side of #10121. Gating PR is the follow-up — it will read `Reattempt { previous_attempts; _ }` / `seconds_since_first_attempt` and refuse dispatch above a configurable threshold (max-attempts + stuck-time). This PR establishes the contract those gates act on.
- Not addressed here: #9733 (write_meta CAS race, the root cause TRIGGER). Two-fix plan per the issue's Option A + C; this is half of A.
- Pattern reinforces tick series: **observability surface FIRST (no behaviour change), gating SECOND**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
