### PR TITLE
feat(keeper): bucket per-keeper turn latency to surface 20-min turns (#9943)

### DIFF
--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -136,6 +136,57 @@ let record_context_max_observation
       ("context_max_bucket", context_max_bucket context_max);
     ] ()
 
+(* #9943: per-keeper turn-latency bucket counter.  Buckets are
+   chosen so each name a reachable operator state:
+
+   - [under_60s]:    routine turn; no signal.
+   - [60-300s]:      acceptable for cloud-LLM heavy turns.
+   - [300-600s]:     unusually slow; investigate if persistent.
+   - [600-1200s]:    long turn — approaches but does not exceed
+                     the 1200s [oas_timeout_budget] cap (#9933).
+                     Operator-actionable warning.
+   - [over_1200s]:   turn longer than the OAS budget cap.
+                     Almost always indicates the budget fired
+                     and the keeper retried.  Direct evidence
+                     of #9943's 1,204,542 ms taskmaster sample.
+
+   Boundaries are inclusive on the upper edge so 60.0 → 60-300,
+   600.0 → 600-1200, 1200.0 → over_1200s.  This matches the
+   typical "alert on turn > 600s" threshold operators use. *)
+let turn_latency_bucket (latency_ms : int) : string =
+  let s = float_of_int latency_ms /. 1000.0 in
+  if s < 60.0 then "under_60s"
+  else if s < 300.0 then "60-300s"
+  else if s < 600.0 then "300-600s"
+  else if s < 1200.0 then "600-1200s"
+  else "over_1200s"
+
+(* Default WARN threshold (10 minutes).  Picks up the 600-1200s
+   and over_1200s buckets without firing on routine cloud-LLM
+   turns. Env-overridable. *)
+let long_turn_warn_threshold_ms_default = 600_000
+
+let long_turn_warn_threshold_ms () : int =
+  Env_config_core.get_int
+    ~default:long_turn_warn_threshold_ms_default
+    "MASC_KEEPER_LONG_TURN_WARN_MS"
+
+let record_turn_latency_bucket
+    ~(keeper : string)
+    ~(latency_ms : int) : unit =
+  let bucket = turn_latency_bucket latency_ms in
+  Prometheus.inc_counter
+    Prometheus.metric_keeper_turn_latency_bucket
+    ~labels:[ ("keeper", keeper); ("bucket", bucket) ]
+    ();
+  let threshold = long_turn_warn_threshold_ms () in
+  if latency_ms >= threshold then
+    Log.Keeper.warn
+      "[long-turn] keeper=%s latency_ms=%d (>= %d ms threshold) bucket=%s \
+       — investigate cascade exhaustion / oas_timeout_budget (#9933, #9943)"
+      keeper latency_ms threshold bucket
+
+
 let usage_trust_is_trusted = Keeper_usage_trust.is_trusted
 
 let usage_trust_to_string = Keeper_usage_trust.to_string
@@ -1118,6 +1169,11 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
       `Float turn_cost
     else `Null
   in
+  (* #9943: per-keeper turn-latency bucket counter + WARN if the
+     turn crossed the long-turn threshold (default 600s, env-
+     overridable).  Emitted once per snapshot write so the
+     counter rate matches the JSONL row rate. *)
+  record_turn_latency_bucket ~keeper:meta.name ~latency_ms;
   let snapshot =
     `Assoc
       [

--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -90,6 +90,30 @@ val record_context_max_observation :
     snapshot-write so the counter rate equals the per-turn
     rate. *)
 
+(** {1 #9943: long-turn observer}
+
+    [turn_latency_bucket ms] returns the bucket label for a turn that
+    took [ms] milliseconds.  The vocabulary is bounded
+    ([under_60s | 60-300s | 300-600s | 600-1200s | over_1200s]) so
+    Prometheus cardinality stays at [keeper × 5].
+
+    [record_turn_latency_bucket] increments
+    {!Prometheus.metric_keeper_turn_latency_bucket} on the matching
+    bucket and emits a [Log.Keeper.warn] line when [latency_ms]
+    crosses {!long_turn_warn_threshold_ms}.  Threshold reads
+    [MASC_KEEPER_LONG_TURN_WARN_MS] (ms, default
+    [long_turn_warn_threshold_ms_default = 600_000] = 10 min) on each
+    call so operators can dial it without restart. *)
+val turn_latency_bucket : int -> string
+
+val long_turn_warn_threshold_ms_default : int
+
+val long_turn_warn_threshold_ms : unit -> int
+
+val record_turn_latency_bucket :
+  keeper:string -> latency_ms:int -> unit
+
+
 val update_metrics_from_result :
   Keeper_types.keeper_meta ->
   latency_ms:int ->

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -224,6 +224,22 @@ let metric_keeper_turn_starts = "masc_keeper_turn_starts_total"
 let metric_keeper_turn_reattempts = "masc_keeper_turn_reattempts_total"
 let metric_keeper_turn_regressions = "masc_keeper_turn_regressions_total"
 
+(* #9943: per-keeper turn-latency bucket counter.  Each completed
+   turn lands in exactly one [latency_bucket] label so a Prometheus
+   query like
+     rate(masc_keeper_turn_latency_bucket_total{bucket="600-1200s"}[5m])
+   directly surfaces slow-turn keepers without needing the JSONL
+   ledger.  20-minute turns from oas_timeout_budget exhaustion
+   (#9933, observed 1,204,542 ms = 20 min on taskmaster
+   2026-04-24) appear in the [over_1200s] bucket and operators can
+   alert on its rate.  Existing [masc_llm_inference_duration_seconds]
+   histogram is labelled by [model] only (per-LLM-call latency); this
+   counter labels by [keeper] (per-turn latency) and uses bucket
+   strings instead of histogram observations so dashboards can group
+   counts directly. *)
+let metric_keeper_turn_latency_bucket =
+  "masc_keeper_turn_latency_bucket_total"
+
 
 (* Keeper compaction (keeper_compact_policy.ml, tool_keeper.ml). *)
 let metric_keeper_compactions = "masc_keeper_compactions_total"
@@ -473,6 +489,13 @@ let init () =
     "Total keeper turn regressions: turn id moved to a strictly LOWER \
      value than previously observed (write_meta race losing an in-memory \
      counter increment — #9733 / #10121)"
+    Counter;
+  (* #9943: per-keeper turn latency bucket distribution.  Each
+     completed turn increments exactly one bucket.  Bucket vocabulary
+     [under_60s | 60-300s | 300-600s | 600-1200s | over_1200s]. *)
+  add metric_keeper_turn_latency_bucket
+    "Total keeper turn completions, bucketed by latency (labels: keeper, \
+     bucket=under_60s|60-300s|300-600s|600-1200s|over_1200s)"
     Counter;
   (* Keeper compaction metrics — emitted by keeper_compact_policy.ml *)
   add metric_keeper_compactions

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -87,6 +87,10 @@ val metric_keeper_turn_regressions : string
     [keeper].  Re-attempt = same turn id started again before
     the counter advanced; regression = turn id moved strictly
     backwards (write_meta race symptom — #9733). *)
+val metric_keeper_turn_latency_bucket : string
+(** #9943: per-keeper turn latency distribution.  Labels:
+    [keeper, bucket].  Bucket vocabulary:
+    [under_60s | 60-300s | 300-600s | 600-1200s | over_1200s]. *)
 val metric_keeper_compactions : string
 val metric_keeper_compaction_ratio_change : string
 val metric_keeper_compaction_saved_tokens : string

--- a/test/dune
+++ b/test/dune
@@ -1346,6 +1346,15 @@
  (modules test_fs_atomic_orphan_sweep_10130)
  (libraries fs_compat alcotest unix))
 
+(test
+ (name test_keeper_long_turn_9943)
+ (modules test_keeper_long_turn_9943)
+ (action
+  (setenv MASC_BASE_PATH /tmp/test-keeper-long-turn-9943
+   (run %{test})))
+ (libraries masc_mcp alcotest unix))
+
+
 
 ; ============================================================
 ; Executables (benchmarks, distributed tests, tools)

--- a/test/test_keeper_long_turn_9943.ml
+++ b/test/test_keeper_long_turn_9943.ml
@@ -1,0 +1,171 @@
+(* test/test_keeper_long_turn_9943.ml
+
+   #9943 reports a 20-minute turn where the post-turn
+   compaction step appears to no-op and the turn keeps
+   running.  Several adjacent issues report the same
+   "long-running turn that nobody noticed" symptom from
+   different angles (#9982 trust pause, #10121 livelock).
+
+   This test pins the observability surface that surfaces
+   such turns directly to Prometheus instead of leaving
+   the duration trapped in a single info log line:
+
+     1. The bucket vocabulary is bounded to five labels
+        ([under_60s | 60-300s | 300-600s | 600-1200s |
+        over_1200s]) so [keeper × bucket] cardinality is
+        bounded at runtime.
+     2. Bucket boundaries are inclusive on the lower end
+        (60_000 ms classifies as [60-300s], 600_000 ms as
+        [600-1200s], 1_200_000 ms as [over_1200s]).
+     3. [record_turn_latency_bucket] increments the matching
+        bucket counter and is keeper-isolated.
+     4. The WARN threshold reads
+        [MASC_KEEPER_LONG_TURN_WARN_MS] on each call (default
+        600_000 = 10 min) so operators can dial it without
+        a restart.
+*)
+
+let () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-keeper-long-turn-9943-%06x"
+         (Random.bits ()))
+  in
+  Unix.putenv "MASC_BASE_PATH" dir
+
+module M = Masc_mcp.Keeper_unified_metrics
+module Prom = Masc_mcp.Prometheus
+
+let bucket_count ~keeper ~bucket =
+  Prom.metric_value_or_zero
+    Prom.metric_keeper_turn_latency_bucket
+    ~labels:[ ("keeper", keeper); ("bucket", bucket) ]
+    ()
+
+(* Bucket vocabulary is exactly five labels.  Shrinking or
+   exploding this set is a breaking dashboard change. *)
+let test_bucket_vocabulary () =
+  let cases =
+    [ 0, "under_60s"
+    ; 30_000, "under_60s"
+    ; 59_999, "under_60s"
+    ; 60_000, "60-300s"
+    ; 299_999, "60-300s"
+    ; 300_000, "300-600s"
+    ; 599_999, "300-600s"
+    ; 600_000, "600-1200s"
+    ; 1_199_999, "600-1200s"
+    ; 1_200_000, "over_1200s"
+    ; 7_200_000, "over_1200s"
+    ]
+  in
+  List.iter
+    (fun (ms, expected) ->
+      Alcotest.(check string)
+        (Printf.sprintf "%d ms -> %s" ms expected)
+        expected
+        (M.turn_latency_bucket ms))
+    cases
+
+(* The boundary 60_000 must classify as [60-300s], not
+   [under_60s].  This is the smallest "this turn looked
+   suspicious" boundary and getting it wrong by a single
+   millisecond turns into a dashboard step-change. *)
+let test_bucket_boundaries () =
+  Alcotest.(check string) "59_999 -> under_60s"
+    "under_60s" (M.turn_latency_bucket 59_999);
+  Alcotest.(check string) "60_000 -> 60-300s"
+    "60-300s" (M.turn_latency_bucket 60_000);
+  Alcotest.(check string) "599_999 -> 300-600s"
+    "300-600s" (M.turn_latency_bucket 599_999);
+  Alcotest.(check string) "600_000 -> 600-1200s"
+    "600-1200s" (M.turn_latency_bucket 600_000);
+  Alcotest.(check string) "1_199_999 -> 600-1200s"
+    "600-1200s" (M.turn_latency_bucket 1_199_999);
+  Alcotest.(check string) "1_200_000 -> over_1200s"
+    "over_1200s" (M.turn_latency_bucket 1_200_000)
+
+(* Recording a single observation increments exactly one
+   bucket on the labelled keeper. *)
+let test_record_increments_matching_bucket () =
+  let keeper = "test-keeper-long-turn-9943-record" in
+  let before = bucket_count ~keeper ~bucket:"60-300s" in
+  M.record_turn_latency_bucket ~keeper ~latency_ms:120_000;
+  Alcotest.(check (float 0.0001))
+    "60-300s bucket +1"
+    (before +. 1.0)
+    (bucket_count ~keeper ~bucket:"60-300s");
+  Alcotest.(check (float 0.0001))
+    "under_60s bucket unchanged"
+    0.0
+    (bucket_count ~keeper ~bucket:"under_60s");
+  Alcotest.(check (float 0.0001))
+    "over_1200s bucket unchanged"
+    0.0
+    (bucket_count ~keeper ~bucket:"over_1200s")
+
+(* Per-keeper isolation: keeper A's long turns do not
+   leak into keeper B's bucket counter. *)
+let test_keeper_isolation () =
+  let a = "test-keeper-long-turn-iso-A-9943" in
+  let b = "test-keeper-long-turn-iso-B-9943" in
+  let before_b = bucket_count ~keeper:b ~bucket:"over_1200s" in
+  M.record_turn_latency_bucket ~keeper:a ~latency_ms:1_500_000;
+  M.record_turn_latency_bucket ~keeper:a ~latency_ms:1_800_000;
+  Alcotest.(check (float 0.0001))
+    "keeper B over_1200s unchanged by keeper A"
+    before_b
+    (bucket_count ~keeper:b ~bucket:"over_1200s")
+
+(* WARN threshold default is 10 minutes.  Crossing it
+   trips the warn log, but the bucket is still counted —
+   logs are not the gate. *)
+let test_warn_threshold_default_is_ten_minutes () =
+  Alcotest.(check int) "default 600_000 ms"
+    600_000 M.long_turn_warn_threshold_ms_default;
+  let env = M.long_turn_warn_threshold_ms () in
+  Alcotest.(check bool)
+    "threshold reads positive ms"
+    true (env > 0)
+
+(* Threshold is read on every call, not cached at module
+   init.  Operators flip the env var via the running
+   process's [Unix.putenv] equivalent. *)
+let test_warn_threshold_reads_env () =
+  let saved =
+    try Some (Unix.getenv "MASC_KEEPER_LONG_TURN_WARN_MS")
+    with Not_found -> None
+  in
+  Unix.putenv "MASC_KEEPER_LONG_TURN_WARN_MS" "300000";
+  let observed = M.long_turn_warn_threshold_ms () in
+  Alcotest.(check int) "threshold honours env override"
+    300_000 observed;
+  (match saved with
+   | Some v -> Unix.putenv "MASC_KEEPER_LONG_TURN_WARN_MS" v
+   | None -> Unix.putenv "MASC_KEEPER_LONG_TURN_WARN_MS" "")
+
+let () =
+  Alcotest.run "keeper_long_turn_9943"
+    [
+      ( "bucket-vocabulary",
+        [
+          Alcotest.test_case "five labels, exhaustive" `Quick
+            test_bucket_vocabulary;
+          Alcotest.test_case "boundaries land correctly" `Quick
+            test_bucket_boundaries;
+        ] );
+      ( "record",
+        [
+          Alcotest.test_case "matching bucket increments" `Quick
+            test_record_increments_matching_bucket;
+          Alcotest.test_case "per-keeper isolation" `Quick
+            test_keeper_isolation;
+        ] );
+      ( "warn-threshold",
+        [
+          Alcotest.test_case "default is 10 minutes" `Quick
+            test_warn_threshold_default_is_ten_minutes;
+          Alcotest.test_case "reads env per call" `Quick
+            test_warn_threshold_reads_env;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

#9943 reports a 20-minute keeper turn (1,204,542 ms on taskmaster
2026-04-24) whose post-turn compaction step appears to no-op while
the turn keeps running.  The duration was visible only in a single
info log line.  This PR raises the long-turn signal to Prometheus.

This is **option #4** from the issue's resolution list — observability
+ operator-actionable WARN — and is the bucket-counter foundation a
later fix (#9933 oas_timeout_budget cap tightening / #10121 livelock
gate) can hang an alert on.

## Why a counter, not just a histogram

`masc_llm_inference_duration_seconds` is already a histogram labelled
by `model`.  That measures per-LLM-call latency.  The #9943 symptom
is per-turn (post-tool-loop) latency on a specific **keeper**.
A bucketed counter labelled by `keeper × bucket` gives:

- direct \`rate(...{bucket="over_1200s"}[5m])\` alerting,
- bounded cardinality (5 bucket strings × keeper count),
- one row in the export for every JSONL ledger row, so dashboards and
  on-disk records stay aligned.

## Bucket vocabulary

\`\`\`
under_60s    | 60-300s   | 300-600s  | 600-1200s | over_1200s
routine      | acceptable| slow      | long      | over OAS budget cap
\`\`\`

Boundaries are inclusive on the lower edge: 60_000 ms → \`60-300s\`,
600_000 ms → \`600-1200s\`, 1_200_000 ms → \`over_1200s\`.  That last
bucket is the #9943 sample.

## WARN threshold

\`record_turn_latency_bucket\` emits a \`Log.Keeper.warn\` line when
\`latency_ms >= long_turn_warn_threshold_ms\` (default 600_000 ms = 10 min).
The threshold reads \`MASC_KEEPER_LONG_TURN_WARN_MS\` on each call so
operators can dial it without restarting the process — module-init
capture would have made the env var dead.

## Files

- \`lib/prometheus.ml/mli\`: \`metric_keeper_turn_latency_bucket\` +
  registration with bounded label vocabulary.
- \`lib/keeper/keeper_unified_metrics.ml/mli\`:
  \`turn_latency_bucket\`, \`long_turn_warn_threshold_ms\`,
  \`record_turn_latency_bucket\`; wired into
  \`append_metrics_snapshot\` (single emit site, JSONL-row-rate).
- \`test/test_keeper_long_turn_9943.ml\`: 6 tests pinning bucket
  vocabulary, boundary points, per-keeper isolation, threshold default,
  env-override behaviour.

## Test plan

- [x] \`dune build --root . lib/\` clean (mli/ml aligned)
- [x] \`dune exec test/test_keeper_long_turn_9943.exe\` — 6/6 pass
- [ ] Roll forward locally on a long keeper run; confirm
      \`/metrics\` exposes \`masc_keeper_turn_latency_bucket_total\` with
      keeper labels and that taskmaster appears in \`over_1200s\` after
      a budget-exhaustion turn.

## Refs

Refs #9933 (oas_timeout_budget cap tightening, the next layer of
defence on top of this counter), #9982 (trust pause residual UI bug
that left "long turn" invisible), #10121 (same-turn livelock counter
which this complements).

## Do-not-merge

\`do-not-merge\` label set so the auto-merge pipeline does not flip
this Draft to Ready.  Operator validation on a real long-running
keeper required before this can land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)