### PR TITLE
obs(keeper): supervisor sweep liveness counter + age gauge (#10125)

### DIFF
--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -567,6 +567,13 @@ let start_supervisor_sweep ctx =
            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
              Log.Keeper.error "TOML reconcile sweep failed: %s"
                (Printexc.to_string exn));
+          (* #10125: advance the supervisor liveness gauge after a
+             completed beat.  Stale gauge (now - last > 2 × interval)
+             tells operators the sweep stopped. *)
+          Prometheus.set_gauge
+            Prometheus.metric_keeper_supervisor_last_sweep_unixtime
+            ~labels:[ ("base_path", base_path) ]
+            (Unix.gettimeofday ());
           Ok ()
       end)
     in
@@ -583,8 +590,39 @@ let start_supervisor_sweep ctx =
     with_sweeps_rw (fun () ->
       Hashtbl.replace supervisor_sweeps base_path p);
     Pulse.run ~sw:ctx.sw p;
+    (* #10125: counter increments once per actual Pulse start.
+       After a server restart, if this stays at 0 the supervisor
+       never came up — operators alert on absence of advancement. *)
+    Prometheus.inc_counter
+      Prometheus.metric_keeper_supervisor_sweep_starts
+      ~labels:[ ("base_path", base_path) ]
+      ();
+    (* Initialize the liveness gauge to "now" so dashboards do not
+       start at unixtime=0 (which would look infinitely stale).  The
+       on_beat will overwrite this on every subsequent sweep. *)
+    Prometheus.set_gauge
+      Prometheus.metric_keeper_supervisor_last_sweep_unixtime
+      ~labels:[ ("base_path", base_path) ]
+      (Unix.gettimeofday ());
     Log.Keeper.info "keeper supervisor sweep started (interval %.0fs)" sweep_sec
   end
+
+(** #10125: supervisor sweep age helper.  Returns the wall-clock
+    seconds since the last successful sweep beat, or [None] if the
+    gauge was never set (i.e., the sweep never started in this
+    process).  Dashboards use this to render a [stale] badge when
+    the sweep stalls; tests use it to verify the gauge advances. *)
+let supervisor_sweep_age_seconds ~(base_path : string) : float option =
+  match
+    Prometheus.get_metric_value
+      Prometheus.metric_keeper_supervisor_last_sweep_unixtime
+      ~labels:[ ("base_path", base_path) ]
+      ()
+  with
+  | None -> None
+  | Some last ->
+    let now = Unix.gettimeofday () in
+    Some (now -. last)
 
 let existing_keepalive_bootstrap_done : (string, unit) Hashtbl.t =
   Hashtbl.create 4

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -240,6 +240,31 @@ let metric_keeper_turn_regressions = "masc_keeper_turn_regressions_total"
 let metric_keeper_turn_latency_bucket =
   "masc_keeper_turn_latency_bucket_total"
 
+(* #10125: keeper supervisor sweep observability.
+
+   The supervisor sweep is a Pulse loop that recovers crashed
+   keepers.  When the loop fails to start (or stops), the fleet
+   silently dies — keepers exit on cascade exhaustion and nobody
+   restarts them.  Observed 2026-04-24: 14 keepers dead, supervisor
+   "started" log line missing for 4h+ across a server restart.
+
+   Two metrics surface the sweep liveness directly so dashboards
+   can alert on absence instead of relying on a log grep:
+
+   - [metric_keeper_supervisor_sweep_starts_total] — increments
+     once each time [start_supervisor_sweep] actually creates a
+     Pulse (i.e., once per process unless explicitly stopped).
+     If the counter does not advance after a server restart, the
+     supervisor never came up.
+   - [metric_keeper_supervisor_last_sweep_unixtime] — gauge updated
+     on every successful sweep beat.  Operator alert:
+     [time() - masc_keeper_supervisor_last_sweep_unixtime > 90]
+     means the sweep is stalled (default sweep interval is 30s). *)
+let metric_keeper_supervisor_sweep_starts =
+  "masc_keeper_supervisor_sweep_starts_total"
+let metric_keeper_supervisor_last_sweep_unixtime =
+  "masc_keeper_supervisor_last_sweep_unixtime"
+
 
 (* Keeper compaction (keeper_compact_policy.ml, tool_keeper.ml). *)
 let metric_keeper_compactions = "masc_keeper_compactions_total"
@@ -510,6 +535,17 @@ let init () =
     "Total keeper turn completions, bucketed by latency (labels: keeper, \
      bucket=under_60s|60-300s|300-600s|600-1200s|over_1200s)"
     Counter;
+  (* #10125: supervisor sweep liveness.  Counter increments on
+     each [start_supervisor_sweep] that actually creates a Pulse;
+     gauge advances on every successful sweep beat. *)
+  add metric_keeper_supervisor_sweep_starts
+    "Total times keeper supervisor sweep Pulse was started (labels: base_path)"
+    Counter;
+  add metric_keeper_supervisor_last_sweep_unixtime
+    "Wall-clock unixtime of the most recent successful supervisor \
+     sweep beat (labels: base_path).  Stale (> 2 × interval) means \
+     the sweep stalled."
+    Gauge;
   (* Keeper compaction metrics — emitted by keeper_compact_policy.ml *)
   add metric_keeper_compactions
     "Total keeper compactions performed" Counter;

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -91,6 +91,13 @@ val metric_keeper_turn_latency_bucket : string
 (** #9943: per-keeper turn latency distribution.  Labels:
     [keeper, bucket].  Bucket vocabulary:
     [under_60s | 60-300s | 300-600s | 600-1200s | over_1200s]. *)
+
+(** #10125: supervisor sweep liveness counters.  See {!Prometheus.ml}
+    for the rationale.  Counter increments on each Pulse start;
+    gauge advances on every successful beat. *)
+val metric_keeper_supervisor_sweep_starts : string
+val metric_keeper_supervisor_last_sweep_unixtime : string
+
 val metric_keeper_compactions : string
 val metric_keeper_compaction_ratio_change : string
 val metric_keeper_compaction_saved_tokens : string

--- a/test/dune
+++ b/test/dune
@@ -1376,6 +1376,13 @@
    (run %{test})))
  (libraries masc_mcp alcotest unix))
 
+(test
+ (name test_keeper_supervisor_observability_10125)
+ (modules test_keeper_supervisor_observability_10125)
+ (action
+  (setenv MASC_BASE_PATH /tmp/test-keeper-supervisor-obs-10125
+   (run %{test})))
+ (libraries masc_mcp alcotest unix))
 
 
 ; ============================================================

--- a/test/test_keeper_supervisor_observability_10125.ml
+++ b/test/test_keeper_supervisor_observability_10125.ml
@@ -1,0 +1,197 @@
+(* test/test_keeper_supervisor_observability_10125.ml
+
+   #10125 reports a 4h+ silent fleet death after server
+   restart: 14 keepers exit on cascade exhaustion and the
+   supervisor sweep never restarts (the
+   "keeper supervisor sweep started" log line is missing
+   for the entire post-restart session).
+
+   The deeper fix is to remove the conditional gate on
+   [maybe_start_supervisor_sweep] so the sweep starts
+   unconditionally during server boot.  This test covers
+   the observability half: a counter that advances each
+   time the Pulse actually starts, and a gauge that
+   advances on every sweep beat.  Operators alert on:
+
+     - counter_starts == 0 after a server restart
+       (sweep never came up); and
+     - now - last_sweep_unixtime > 2 × interval
+       (sweep stalled).
+
+   Pulse-driven integration is too heavy for a unit test
+   (needs Eio switch, clock, full ctx) so the tests below
+   exercise the metric surface and helper directly.  The
+   wiring inside [start_supervisor_sweep] is verified by
+   reading the diff: counter increments before the log
+   line, gauge sets before AND after each beat.
+*)
+
+let () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-keeper-supervisor-obs-10125-%06x"
+         (Random.bits ()))
+  in
+  Unix.putenv "MASC_BASE_PATH" dir
+
+module R = Masc_mcp.Keeper_runtime
+module Prom = Masc_mcp.Prometheus
+
+let starts_for ~base_path =
+  Prom.metric_value_or_zero
+    Prom.metric_keeper_supervisor_sweep_starts
+    ~labels:[ ("base_path", base_path) ]
+    ()
+
+let last_sweep_for ~base_path =
+  Prom.get_metric_value
+    Prom.metric_keeper_supervisor_last_sweep_unixtime
+    ~labels:[ ("base_path", base_path) ]
+    ()
+
+(* Both metrics are declared at init, so [metric_total]
+   returns a finite total even before any keeper runs.
+   This pins that the registration block actually runs —
+   if either name is missing the whole #10125 dashboard
+   becomes invisible on a fresh install. *)
+let test_metrics_registered () =
+  let _ = Prom.metric_total Prom.metric_keeper_supervisor_sweep_starts in
+  let _ = Prom.metric_total Prom.metric_keeper_supervisor_last_sweep_unixtime in
+  Alcotest.(check pass) "both supervisor metrics are registered" () ()
+
+(* Helper returns [None] before the sweep gauge is set in
+   this process.  Dashboards must distinguish "never set"
+   (sweep never started) from "set in the past" (sweep
+   started then stalled) — a numeric default of 0 would
+   blur that boundary. *)
+let test_age_helper_returns_none_before_first_sweep () =
+  let base_path = "/tmp/test-supervisor-obs-never-started-10125" in
+  Alcotest.(check (option (float 0.001)))
+    "no gauge label set yet"
+    None
+    (last_sweep_for ~base_path);
+  Alcotest.(check (option (float 0.001)))
+    "age helper agrees: None"
+    None
+    (R.supervisor_sweep_age_seconds ~base_path)
+
+(* Setting the gauge to "now" makes the helper return a
+   small positive age (read-after-write).  This exercises
+   the same code path [on_beat] uses to mark sweep
+   liveness. *)
+let test_age_helper_advances_after_gauge_set () =
+  let base_path = "/tmp/test-supervisor-obs-advances-10125" in
+  Prom.set_gauge
+    Prom.metric_keeper_supervisor_last_sweep_unixtime
+    ~labels:[ ("base_path", base_path) ]
+    (Unix.gettimeofday ());
+  match R.supervisor_sweep_age_seconds ~base_path with
+  | None -> Alcotest.fail "expected Some age after gauge set"
+  | Some age ->
+    Alcotest.(check bool)
+      "age is small (< 5s) and non-negative"
+      true (age >= 0.0 && age < 5.0)
+
+(* Setting the gauge to a deliberately old timestamp
+   reproduces the #10125 "stalled sweep" condition.  The
+   helper returns a large positive age that dashboards
+   convert into the [stale] badge. *)
+let test_age_helper_reports_stale_when_gauge_old () =
+  let base_path = "/tmp/test-supervisor-obs-stale-10125" in
+  let stale_ts = Unix.gettimeofday () -. 3600.0 in
+  Prom.set_gauge
+    Prom.metric_keeper_supervisor_last_sweep_unixtime
+    ~labels:[ ("base_path", base_path) ]
+    stale_ts;
+  match R.supervisor_sweep_age_seconds ~base_path with
+  | None -> Alcotest.fail "expected Some age"
+  | Some age ->
+    Alcotest.(check bool)
+      "stale gauge: age >= 1 hour"
+      true (age >= 3599.0)
+
+(* Counter increments are per-base_path so a bench harness
+   that exercises multiple base paths in one process can
+   tell which one had its supervisor restart. *)
+let test_counter_per_base_path_isolation () =
+  let a = "/tmp/test-supervisor-obs-iso-A-10125" in
+  let b = "/tmp/test-supervisor-obs-iso-B-10125" in
+  let before_b = starts_for ~base_path:b in
+  Prom.inc_counter
+    Prom.metric_keeper_supervisor_sweep_starts
+    ~labels:[ ("base_path", a) ]
+    ();
+  Prom.inc_counter
+    Prom.metric_keeper_supervisor_sweep_starts
+    ~labels:[ ("base_path", a) ]
+    ();
+  Alcotest.(check (float 0.0001))
+    "base_path B unaffected by base_path A increments"
+    before_b
+    (starts_for ~base_path:b);
+  Alcotest.(check (float 0.0001))
+    "base_path A counter advanced by 2"
+    2.0
+    (starts_for ~base_path:a)
+
+(* The textual export uses [base_path] as the label key
+   for both metrics, so PromQL queries can join them on
+   that label. *)
+let test_prometheus_text_export_includes_metrics () =
+  let base_path = "/tmp/test-supervisor-obs-export-10125" in
+  Prom.inc_counter
+    Prom.metric_keeper_supervisor_sweep_starts
+    ~labels:[ ("base_path", base_path) ]
+    ();
+  Prom.set_gauge
+    Prom.metric_keeper_supervisor_last_sweep_unixtime
+    ~labels:[ ("base_path", base_path) ]
+    (Unix.gettimeofday ());
+  let text = Prom.to_prometheus_text () in
+  let contains s sub =
+    let n = String.length s and m = String.length sub in
+    let rec loop i =
+      if i + m > n then false
+      else if String.sub s i m = sub then true
+      else loop (i + 1)
+    in
+    loop 0
+  in
+  Alcotest.(check bool)
+    "counter name appears in export"
+    true (contains text Prom.metric_keeper_supervisor_sweep_starts);
+  Alcotest.(check bool)
+    "gauge name appears in export"
+    true (contains text Prom.metric_keeper_supervisor_last_sweep_unixtime);
+  Alcotest.(check bool)
+    "base_path label appears for export"
+    true (contains text "base_path=")
+
+let () =
+  Alcotest.run "keeper_supervisor_observability_10125"
+    [
+      ( "metrics-registered",
+        [
+          Alcotest.test_case "both metrics registered at init" `Quick
+            test_metrics_registered;
+        ] );
+      ( "age-helper",
+        [
+          Alcotest.test_case "None before first sweep" `Quick
+            test_age_helper_returns_none_before_first_sweep;
+          Alcotest.test_case "advances after gauge set" `Quick
+            test_age_helper_advances_after_gauge_set;
+          Alcotest.test_case "stale gauge reports large age" `Quick
+            test_age_helper_reports_stale_when_gauge_old;
+        ] );
+      ( "counter-isolation",
+        [
+          Alcotest.test_case "per-base_path label isolation" `Quick
+            test_counter_per_base_path_isolation;
+        ] );
+      ( "export",
+        [
+          Alcotest.test_case "metrics appear in /metrics text" `Quick
+            test_prometheus_text_export_includes_metrics;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

#10125 reports a 4h+ silent fleet death on 2026-04-24: 14 keepers
exit on cascade exhaustion, the supervisor sweep `started` log line
is missing for the entire post-restart session, and nobody restarts
them.  Dashboard kept showing `keepers=14` (reading stale meta on
disk) while real activity was 0.

This PR is the **observability half** (issue Option C) of the fix.
The deeper fix — issue Option A, dropping the conditional gate on
`maybe_start_supervisor_sweep` so the server boot path starts the
sweep unconditionally — needs a careful review of the boot path
and lands separately as a follow-up that will use this counter as
its alert source.

## Surface

| metric | type | what it tells operators |
|---|---|---|
| `masc_keeper_supervisor_sweep_starts_total{base_path}` | counter | Each successful `start_supervisor_sweep` Pulse creation. **No advance after a restart = #10125 reproduced.** |
| `masc_keeper_supervisor_last_sweep_unixtime{base_path}` | gauge | Wall-clock unixtime of the last successful sweep beat. **`time() - gauge > 90s` = sweep stalled.** Initialized to "now" at Pulse start so dashboards do not show unixtime=0. |
| `Keeper_runtime.supervisor_sweep_age_seconds ~base_path` | `float option` | Read helper. `None` = sweep never started in this process; `Some n` = `n` seconds since the last beat. |

Both metrics are labelled by `base_path` so a process serving
multiple workspaces can tell which one died.

## Why two signals

Counter alone cannot tell "started then stalled" from "still
running fine"; gauge alone cannot tell "never started" from
"started but stalled and reset" (the gauge is gauge — it can be
re-set).  The pair lets operators write:

```promql
# Sweep never came up after restart
absent(masc_keeper_supervisor_sweep_starts_total)
or
rate(masc_keeper_supervisor_sweep_starts_total[1h]) == 0
  and time() - process_start_time_seconds > 60

# Sweep started but stalled
time() - masc_keeper_supervisor_last_sweep_unixtime > 90
```

## Files

- `lib/prometheus.ml/mli` — register both metrics with `base_path` label.
- `lib/keeper/keeper_runtime.ml`:
  - `start_supervisor_sweep` — `inc_counter` + initialize gauge once
    at Pulse start; `on_beat` updates gauge after `sweep_and_recover` +
    TOML reconcile complete (so a partially-failed beat does not
    register as fully successful).
  - new helper `supervisor_sweep_age_seconds : base_path:string -> float option`.
- `test/test_keeper_supervisor_observability_10125.ml` — 6 tests.

## Test plan

- [x] `dune build --root . lib/` clean
- [x] `dune exec test/test_keeper_supervisor_observability_10125.exe` — 6/6 pass
- [ ] Roll forward locally, restart server, confirm:
  - `/metrics` exposes both names with `base_path=...` label
  - counter advances exactly once at Pulse start, not per beat
  - gauge advances every ~30s

## Refs

- #9933 (oas_timeout_budget — the cascade-exhaustion trigger upstream)
- #10121 (same-turn livelock — different layer of the "fleet stuck" cluster)
- #9982 (trust pause UI residual — same "fleet death goes unnoticed" theme)

## Do-not-merge

`do-not-merge` label set so the auto-merge pipeline does not flip
this Draft.  The companion PR (Option A: unconditional supervisor
start at boot) should be reviewed alongside before either lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)