### PR TITLE
fix(keeper-autoboot): start supervisor sweep at end of autoboot pass (#10125)

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -453,7 +453,27 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
           end
         in
         retry_loop 1
-      end
+      end;
+      (* #10125: start the supervisor sweep here, after autoboot
+         completes.  Without this call the sweep would only fire
+         on the first [masc_keeper_msg] tool dispatch (the single
+         caller of [start_existing_keepalives] in [tool_keeper.ml]
+         — see #10125 timeline 2026-04-24, where 14 keepers ran
+         under autoboot but the sweep never came up because no
+         operator [masc_keeper_msg] arrived after the restart;
+         four hours later the entire fleet was dead with no
+         supervisor to recover them).
+
+         [start_supervisor_sweep] is idempotent — its internal
+         [supervisor_sweep_running] guard makes a second call a
+         noop, so this stays correct if [masc_keeper_msg] later
+         races into [start_existing_keepalives] anyway. *)
+      (try Keeper_runtime.start_supervisor_sweep keeper_boot_ctx
+       with Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
+            Log.Keeper.error
+              "autoboot: supervisor sweep failed to start: %s"
+              (Printexc.to_string exn))
     end);
   (* Phase 5: unified startup subsystem summary *)
   Log.info ~ctx:"startup" "subsystems: keeper loops started"

--- a/test/dune
+++ b/test/dune
@@ -1295,6 +1295,14 @@
  (modules test_keeper_usage_trust_anthropic_cache_9959)
  (libraries masc_mcp alcotest))
 
+(test
+ (name test_keeper_autoboot_supervisor_start_10125)
+ (modules test_keeper_autoboot_supervisor_start_10125)
+ (action
+  (setenv MASC_BASE_PATH /tmp/test-keeper-autoboot-sup-10125
+   (run %{test})))
+ (libraries masc_mcp alcotest unix))
+
 ; ============================================================
 ; Executables (benchmarks, distributed tests, tools)
 ; ============================================================

--- a/test/test_keeper_autoboot_supervisor_start_10125.ml
+++ b/test/test_keeper_autoboot_supervisor_start_10125.ml
@@ -1,0 +1,71 @@
+(* test/test_keeper_autoboot_supervisor_start_10125.ml
+
+   #10125 root-cause fix: [keeper_autoboot] now starts the
+   supervisor sweep at the end of its boot pass, instead of
+   leaving it dormant until the first [masc_keeper_msg] tool
+   call.
+
+   A full integration test would require a real Eio switch
+   plus a process manager plus a clock and a server context,
+   which is heavier than a unit test should be.  These tests
+   cover the contract the fix relies on: the supervisor-sweep
+   running predicate behaves correctly for "never started"
+   and the stop helper is a noop on that state — both
+   properties together let the autoboot fiber call
+   [start_supervisor_sweep] unconditionally with no risk of
+   double-starting on the (later) first-tool-call path.
+*)
+
+let () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-keeper-autoboot-sup-10125-%06x"
+         (Random.bits ()))
+  in
+  Unix.putenv "MASC_BASE_PATH" dir
+
+module R = Masc_mcp.Keeper_runtime
+
+(* Fresh base_path: the running predicate must say [false]
+   so [start_supervisor_sweep] can take the "actually start
+   a Pulse" branch and emit the
+   [keeper supervisor sweep started] log line / counter +1.
+   If a future refactor flipped the default to true (e.g. by
+   using a sentinel Pulse handle), the autoboot fix below
+   would silently noop and #10125 would re-emerge. *)
+let test_running_predicate_false_on_fresh_base_path () =
+  let bp = "/tmp/test-keeper-autoboot-sup-10125-fresh" in
+  Alcotest.(check bool)
+    "supervisor_sweep_running on never-touched base_path is false"
+    false
+    (R.supervisor_sweep_running bp)
+
+(* [stop_supervisor_sweep] must be a noop on a base_path
+   that never started a sweep.  The autoboot fix calls
+   [start_supervisor_sweep] inside an exception handler;
+   any sweep-related cleanup elsewhere must not throw on
+   the "no entry" case or autoboot crashes propagate as
+   server bootstrap failures. *)
+let test_stop_is_noop_on_fresh_base_path () =
+  let bp = "/tmp/test-keeper-autoboot-sup-10125-noop-stop" in
+  (* Should not raise *)
+  R.stop_supervisor_sweep bp;
+  Alcotest.(check bool)
+    "after stop on never-started: still not running"
+    false
+    (R.supervisor_sweep_running bp)
+
+let () =
+  Alcotest.run "keeper_autoboot_supervisor_start_10125"
+    [
+      ( "running-predicate",
+        [
+          Alcotest.test_case "false on fresh base_path" `Quick
+            test_running_predicate_false_on_fresh_base_path;
+        ] );
+      ( "stop-helper",
+        [
+          Alcotest.test_case "noop on fresh base_path" `Quick
+            test_stop_is_noop_on_fresh_base_path;
+        ] );
+    ]


### PR DESCRIPTION
## Root cause

The keeper supervisor sweep was started by exactly **one** path —
`start_existing_keepalives` in `tool_keeper.ml`, fired only on the
first `masc_keeper_msg` tool dispatch (because
`should_bootstrap_existing_keepalives` whitelists exactly that one
tool name).

The `keeper_autoboot` fiber in `server_bootstrap_loops.ml` happily
boots every keeper at server startup via `Keeper_keepalive.start_keepalive`
but never starts the sweep, so a server restart with autoboot
enabled leaves a fleet running under no supervisor.

## Observed (#10125 timeline 2026-04-24)

| time | event |
|------|-------|
| 18:04:37Z | new server boot |
| 18:05:52Z | autoboot fiber starts keepers (`analyst keepalive turn scheduled`) |
| **18:04:37Z onward** | **no `keeper supervisor sweep started` log line — sweep dormant** |
| 19:45–19:48Z | 14 keepers all hit `oas_timeout_budget`, cycle FAILED |
| 20:26–20:47Z | `Coord_gc` cleans up 14 zombies |
| 20:47Z–01:05Z (next day) | **0 keeper rejoin, 0 turn started, fleet dead 4h 18m** |

No operator sent `masc_keeper_msg` for the entire post-restart
session, so `start_existing_keepalives` never fired, so the sweep
that would have re-spawned the dead keepers never came up.

## Fix

At the end of the `keeper_autoboot` fiber (after initial boot pass
and any retry rounds), call `Keeper_runtime.start_supervisor_sweep`
directly with the autoboot context:

```ocaml
retry_loop 1
end;
(* #10125: start the supervisor sweep here, after autoboot
   completes.  ... *)
(try Keeper_runtime.start_supervisor_sweep keeper_boot_ctx
 with Eio.Cancel.Cancelled _ as e -> raise e
    | exn ->
      Log.Keeper.error
        "autoboot: supervisor sweep failed to start: %s"
        (Printexc.to_string exn))
```

`start_supervisor_sweep` is idempotent — its
`supervisor_sweep_running` guard makes a second call a noop.  So
the existing `masc_keeper_msg` -> `start_existing_keepalives` ->
`maybe_start_supervisor_sweep` path stays correct and serves as
defense-in-depth.

## Why this layer (not boot-step or self-monitor)

- **Server bootstrap step** (issue Option A) — would need
  `start_supervisor_sweep` in the synchronous boot path.  But the
  context (sw, clock, proc_mgr) the sweep needs is the same one
  the autoboot fiber already builds — putting it in the boot path
  would mean either duplicating that ctx-build or reordering
  fiber forks.  Doing it inside the autoboot fiber, right after
  it has finished its work, gets the right ctx for free and
  keeps the change to a single file.
- **Self-monitor fiber** (issue Option B) — defense-in-depth, not
  root fix.  The next layer; can land in a follow-up if needed.
- **Whitelist all keeper tools** for `should_bootstrap_existing_keepalives` —
  doesn't help the case where no operator tool call ever fires
  after a restart, which is exactly the #10125 timeline.

## Test plan

- [x] `dune build --root . lib/` clean
- [x] `dune exec test/test_keeper_autoboot_supervisor_start_10125.exe` — 2/2 pass (sanity tests pinning `supervisor_sweep_running` / `stop_supervisor_sweep` contracts that the fix relies on)
- [ ] **Deployment validation** (after #10126 lands): restart server,
      confirm `masc_keeper_supervisor_sweep_starts_total{base_path=...}`
      counter advances by exactly 1 at boot (currently stays at 0
      until the first `masc_keeper_msg` — that gap is the fix).
- [ ] Restart again on a workspace with zero bootable keepers;
      confirm sweep still starts (it should, the autoboot fiber
      runs the call regardless of `bootable_keeper_names` returning
      empty — see `Pulse.create + Pulse.run` flow, harmless on an
      empty registry).

## Refs

- #9933 — `oas_timeout_budget` exhaustion (the trigger that exposed this)
- #10121 — same-turn livelock (different layer of the "fleet stuck" cluster)
- #10126 — supervisor observability (uses this fix's outcome as alert source — `sweep_starts_total` advancing exactly once at boot becomes the empirical proof of the fix)

## Do-not-merge

`do-not-merge` label set so the auto-merge pipeline does not flip
this Draft.  Wants a manual operator validation on a real server
restart before landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)