### PR TITLE
fix(keeper-usage-trust): flag Anthropic cache silent disable (#9959)

### DIFF
--- a/lib/keeper/keeper_usage_trust.ml
+++ b/lib/keeper/keeper_usage_trust.ml
@@ -11,6 +11,37 @@ type t =
 
 let absurd_token_threshold = 1_000_000
 
+(* #9959: Anthropic prompt caching minimum cacheable input size.
+
+   Anthropic's prompt caching (the [cache_control] field on
+   message content blocks) only kicks in when the cached prefix
+   contains at least 1024 input tokens for sonnet/opus and 2048
+   for haiku.  Below that threshold,
+   [cache_creation_input_tokens] and [cache_read_input_tokens]
+   legitimately stay at zero.  The conservative minimum (1024)
+   avoids false positives on tiny keepalive prompts while still
+   catching the #9959 case where 1078/1078 turn rows (every
+   claude_code:auto turn over a full day) reported
+   cache_creation = cache_read = 0 despite typical keeper system
+   prompts running 5K-30K tokens. *)
+let anthropic_cache_min_input_tokens = 1024
+
+let model_uses_anthropic_caching ~(model_used : string)
+    ~(resolved_model_id : string) : bool =
+  let s = String.lowercase_ascii (model_used ^ "|" ^ resolved_model_id) in
+  let contains substr =
+    let n = String.length s and m = String.length substr in
+    if m = 0 || m > n then false
+    else
+      let rec loop i =
+        if i + m > n then false
+        else if String.sub s i m = substr then true
+        else loop (i + 1)
+      in
+      loop 0
+  in
+  contains "claude" || contains "anthropic"
+
 let is_trusted = function
   | Usage_trusted -> true
   | Usage_missing | Usage_untrusted _ -> false
@@ -66,6 +97,22 @@ let classify ~(usage_reported : bool)
       add "output_tokens_gt_1m";
     if context_max > 0 && usage.input_tokens > context_max * 2 then
       add "input_tokens_gt_2x_context_max";
+    (* #9959 facet 1: Anthropic prompt caching silently disabled.
+       claude_code:auto and similar Anthropic-routed models report
+       [cache_creation_input_tokens = cache_read_input_tokens = 0]
+       across every turn even though keeper system prompts run far
+       above the minimum cacheable size.  This costs roughly 90%
+       of the input-token bill the cache would otherwise eliminate.
+       We classify it as an anomaly per turn whose input passes the
+       cache-eligibility threshold; dashboards convert that into a
+       per-keeper rate and alert when the rate is sustained
+       (one-shot anomalies on tiny prompts are correctly noise). *)
+    if
+      model_uses_anthropic_caching ~model_used ~resolved_model_id
+      && usage.input_tokens >= anthropic_cache_min_input_tokens
+      && usage.cache_creation_input_tokens = 0
+      && usage.cache_read_input_tokens = 0
+    then add "anthropic_caching_likely_disabled";
     match List.rev !reasons with
     | [] -> Usage_trusted
     | reasons -> Usage_untrusted reasons

--- a/lib/keeper/keeper_usage_trust.mli
+++ b/lib/keeper/keeper_usage_trust.mli
@@ -5,6 +5,21 @@ type t =
   | Usage_trusted
   | Usage_untrusted of string list
 
+(** #9959: Anthropic prompt caching minimum cacheable input.  At
+    1024 input tokens, sonnet/opus prompts become eligible for
+    [cache_control] caching; below this threshold, a 0 cache
+    counter is normal.  Exposed for tests and downstream callers
+    that want to use the same threshold. *)
+val anthropic_cache_min_input_tokens : int
+
+(** Returns [true] when the model identifier indicates an
+    Anthropic-routed model (claude_code, anthropic-direct, etc.)
+    that would normally exercise prompt caching.  The check is
+    case-insensitive and looks for ["claude"] or ["anthropic"]
+    anywhere in [model_used] or [resolved_model_id]. *)
+val model_uses_anthropic_caching :
+  model_used:string -> resolved_model_id:string -> bool
+
 val classify :
   usage_reported:bool ->
   usage:Oas.Types.api_usage ->

--- a/test/dune
+++ b/test/dune
@@ -1279,6 +1279,11 @@
  (modules test_keeper_meta_heartbeat_retain_9733)
  (libraries masc_mcp fs_compat alcotest eio eio_main unix))
 
+(test
+ (name test_keeper_usage_trust_anthropic_cache_9959)
+ (modules test_keeper_usage_trust_anthropic_cache_9959)
+ (libraries masc_mcp alcotest))
+
 ; ============================================================
 ; Executables (benchmarks, distributed tests, tools)
 ; ============================================================

--- a/test/test_keeper_usage_trust_anthropic_cache_9959.ml
+++ b/test/test_keeper_usage_trust_anthropic_cache_9959.ml
@@ -1,0 +1,193 @@
+(* test/test_keeper_usage_trust_anthropic_cache_9959.ml
+
+   #9959 facet 1: Anthropic prompt caching silently disabled.
+   1078/1078 turn rows on 2026-04-24 (every claude_code:auto
+   turn over a full day) reported
+   [cache_creation_input_tokens = cache_read_input_tokens = 0]
+   despite typical keeper system prompts running 5K-30K tokens.
+
+   The classify function previously did not flag this — caches
+   at zero are normal on tiny prompts (below the
+   [anthropic_cache_min_input_tokens = 1024] threshold for
+   sonnet/opus).  This test set pins the new
+   [anthropic_caching_likely_disabled] reason added to
+   [Keeper_usage_trust.classify]:
+
+     - Fires when the model is Anthropic-routed AND
+       [input_tokens >= 1024] AND
+       [cache_creation + cache_read = 0].
+     - Does NOT fire on tiny prompts (below threshold) — those
+       are correctly normal even on Anthropic.
+     - Does NOT fire on non-Anthropic providers (ollama, gemini,
+       codex_cli) — they have no Anthropic-style cache surface
+       to begin with, so cache_creation = cache_read = 0 is the
+       only valid state.
+     - Does NOT fire when caching IS working (cache_read > 0
+       OR cache_creation > 0).
+*)
+
+module T = Masc_mcp.Keeper_usage_trust
+module Oas = Masc_mcp.Oas
+
+let mk_usage
+    ?(cache_creation = 0) ?(cache_read = 0) ?(cost_usd = None)
+    ~input ~output () : Oas.Types.api_usage =
+  {
+    input_tokens = input;
+    output_tokens = output;
+    cache_creation_input_tokens = cache_creation;
+    cache_read_input_tokens = cache_read;
+    cost_usd;
+  }
+
+let classify_with ~model ~usage =
+  T.classify ~usage_reported:true ~usage
+    ~model_used:model ~resolved_model_id:model
+    ~context_max:200_000
+
+let reasons_of trust =
+  match trust with
+  | T.Usage_untrusted reasons -> reasons
+  | T.Usage_trusted | T.Usage_missing -> []
+
+let has_reason trust r = List.mem r (reasons_of trust)
+
+(* Threshold sanity: the constant is [1024] (Anthropic
+   sonnet/opus minimum). Pinning this avoids accidental drift
+   to e.g. 2048 or 4096 which would silently start ignoring
+   real cache failures on smaller-but-cacheable prompts. *)
+let test_threshold_is_1024 () =
+  Alcotest.(check int) "anthropic cache threshold = 1024"
+    1024 T.anthropic_cache_min_input_tokens
+
+(* Helper: model_uses_anthropic_caching is case-insensitive,
+   substring-based, and matches both [model_used] and
+   [resolved_model_id]. *)
+let test_model_detector_recognizes_anthropic () =
+  let yes m =
+    Alcotest.(check bool) (Printf.sprintf "%s -> Anthropic" m) true
+      (T.model_uses_anthropic_caching ~model_used:m ~resolved_model_id:m)
+  in
+  let no m =
+    Alcotest.(check bool) (Printf.sprintf "%s -> not Anthropic" m) false
+      (T.model_uses_anthropic_caching ~model_used:m ~resolved_model_id:m)
+  in
+  yes "claude-sonnet-4-6";
+  yes "claude_code:auto";
+  yes "Claude-3-Opus";
+  yes "anthropic/claude-haiku";
+  no "qwen3-coder";
+  no "gpt-5.3";
+  no "gemini-2.5-pro";
+  no "ollama-local";
+  no "kimi-for-coding"
+
+(* Anthropic + cacheable prompt (>= 1024 tokens) + zero caches
+   = #9959 facet 1.  Classify must flag. *)
+let test_anthropic_with_zero_cache_above_threshold_flags () =
+  let usage = mk_usage ~input:5000 ~output:500 () in
+  let t = classify_with ~model:"claude-sonnet-4-6" ~usage in
+  Alcotest.(check bool)
+    "anthropic_caching_likely_disabled flagged"
+    true (has_reason t "anthropic_caching_likely_disabled");
+  Alcotest.(check bool)
+    "trust is untrusted because of cache anomaly"
+    false (T.is_trusted t)
+
+(* Boundary case: input_tokens exactly 1024 should fire.
+   Anthropic's threshold is "at least 1024" so 1024 is the
+   first cacheable size. *)
+let test_threshold_boundary_1024_inclusive () =
+  let usage = mk_usage ~input:1024 ~output:50 () in
+  let t = classify_with ~model:"claude_code:auto" ~usage in
+  Alcotest.(check bool)
+    "1024 tokens: cache anomaly fires"
+    true (has_reason t "anthropic_caching_likely_disabled")
+
+(* Below threshold: tiny keepalive prompts legitimately have
+   zero caches and must NOT be flagged. *)
+let test_below_threshold_does_not_flag () =
+  let usage = mk_usage ~input:1023 ~output:50 () in
+  let t = classify_with ~model:"claude_code:auto" ~usage in
+  Alcotest.(check bool)
+    "1023 tokens: cache anomaly does NOT fire"
+    false (has_reason t "anthropic_caching_likely_disabled")
+
+(* Non-Anthropic providers must not be flagged regardless of
+   cache fields — they don't expose Anthropic-style caching. *)
+let test_non_anthropic_does_not_flag () =
+  let usage = mk_usage ~input:50_000 ~output:1_000 () in
+  List.iter (fun model ->
+    let t = classify_with ~model ~usage in
+    Alcotest.(check bool)
+      (Printf.sprintf "%s: no anthropic anomaly" model)
+      false (has_reason t "anthropic_caching_likely_disabled"))
+    [ "qwen3-coder"; "gpt-5.3-codex"; "gemini-2.5-pro";
+      "ollama-local"; "kimi-for-coding"; "ramarama" ]
+
+(* Caching working as intended: cache_read > 0 — no anomaly. *)
+let test_cache_read_positive_does_not_flag () =
+  let usage = mk_usage ~input:5000 ~output:500
+    ~cache_creation:0 ~cache_read:4500 () in
+  let t = classify_with ~model:"claude-sonnet-4-6" ~usage in
+  Alcotest.(check bool)
+    "cache_read > 0 means caching is working"
+    false (has_reason t "anthropic_caching_likely_disabled")
+
+(* First-turn caching: cache_creation > 0, cache_read = 0 is
+   the cold-cache case.  No anomaly. *)
+let test_cache_creation_positive_does_not_flag () =
+  let usage = mk_usage ~input:5000 ~output:500
+    ~cache_creation:4500 ~cache_read:0 () in
+  let t = classify_with ~model:"claude-sonnet-4-6" ~usage in
+  Alcotest.(check bool)
+    "cache_creation > 0 (cold cache) is not an anomaly"
+    false (has_reason t "anthropic_caching_likely_disabled")
+
+(* Existing reasons still fire for unrelated anomalies; the new
+   reason composes additively with negative_*, gt_1m, etc. *)
+let test_multiple_anomalies_compose () =
+  let usage = mk_usage ~input:1_500_000 ~output:500 () in
+  let t = classify_with ~model:"claude_code:auto" ~usage in
+  Alcotest.(check bool) "input_tokens_gt_1m present"
+    true (has_reason t "input_tokens_gt_1m");
+  Alcotest.(check bool) "anthropic_caching_likely_disabled present"
+    true (has_reason t "anthropic_caching_likely_disabled");
+  Alcotest.(check bool) "trust untrusted" false (T.is_trusted t)
+
+let () =
+  Alcotest.run "keeper_usage_trust_anthropic_cache_9959"
+    [
+      ( "threshold-constant",
+        [
+          Alcotest.test_case "1024 tokens" `Quick test_threshold_is_1024;
+        ] );
+      ( "model-detector",
+        [
+          Alcotest.test_case "claude/anthropic substrings" `Quick
+            test_model_detector_recognizes_anthropic;
+        ] );
+      ( "fires-when-it-should",
+        [
+          Alcotest.test_case "anthropic + 0 cache above threshold" `Quick
+            test_anthropic_with_zero_cache_above_threshold_flags;
+          Alcotest.test_case "boundary 1024 inclusive" `Quick
+            test_threshold_boundary_1024_inclusive;
+        ] );
+      ( "false-positive-prevention",
+        [
+          Alcotest.test_case "below threshold: silent" `Quick
+            test_below_threshold_does_not_flag;
+          Alcotest.test_case "non-anthropic: silent" `Quick
+            test_non_anthropic_does_not_flag;
+          Alcotest.test_case "cache_read > 0: silent" `Quick
+            test_cache_read_positive_does_not_flag;
+          Alcotest.test_case "cache_creation > 0: silent" `Quick
+            test_cache_creation_positive_does_not_flag;
+        ] );
+      ( "composition",
+        [
+          Alcotest.test_case "stacks with input_tokens_gt_1m" `Quick
+            test_multiple_anomalies_compose;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

#9959 facet 1: 1078/1078 turn rows on 2026-04-24 (every
\`claude_code:auto\` turn over a full day) reported
\`cache_creation_input_tokens = cache_read_input_tokens = 0\`
despite typical keeper system prompts running 5K-30K tokens.
Anthropic prompt caching pays for ~90% of the input-token bill
on cacheable prefixes, so a silent cache disable is a major cost
event the dashboard had no way to surface.

## Why the existing classifier missed it

\`Keeper_usage_trust.classify\` already catches:
- negative fields (\`negative_input_tokens\`, …),
- both-zero turns (\`zero_token_usage_reported\`),
- absurd values (\`input_tokens_gt_1m\`, \`gt_2x_context_max\`),
- missing model id.

But \`cache_creation = cache_read = 0\` is **legitimate** on
prompts below Anthropic's minimum cacheable prefix size (1024
tokens for sonnet/opus, 2048 for haiku — see [Anthropic prompt
caching docs](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching)).
The classifier treated it as the normal case, which is exactly
what let #9959 stay invisible across 1078 turns.

## Fix

New anomaly reason \`anthropic_caching_likely_disabled\`. Fires
only when ALL of:

| condition | rationale |
|---|---|
| model identifier matches \`claude\` or \`anthropic\` (case-insensitive substring on either \`model_used\` or \`resolved_model_id\`) | the only providers with \`cache_control\` semantics |
| \`input_tokens >= 1024\` | Anthropic minimum cacheable prefix; below this, 0 caches are normal |
| \`cache_creation_input_tokens = 0\` AND \`cache_read_input_tokens = 0\` | both zero means caching never engaged |

The threshold is exposed as \`anthropic_cache_min_input_tokens\`
in the .mli for tests and downstream callers — pins drift to
e.g. 2048 or 4096 from accidentally hiding real failures.

## Composition

The new reason **adds** to existing ones.  A turn with 1.5M
input + 0 caches gets BOTH \`input_tokens_gt_1m\` AND
\`anthropic_caching_likely_disabled\`, so the existing
\`masc_keeper_usage_anomaly_reason_total{keeper, reason}\`
counter directly separates "cost overrun caught by token limit"
from "cost overrun because cache disabled" without any new
metric.

## Test plan

- [x] \`dune build --root . lib/\` clean (mli/ml aligned)
- [x] \`dune exec test/test_keeper_usage_trust_anthropic_cache_9959.exe\` — 9/9 pass
  - threshold constant pinned to 1024
  - case-insensitive substring match on both \`claude\` / \`anthropic\` for \`model_used\` and \`resolved_model_id\`
  - fires above threshold + zero caches + Anthropic
  - boundary 1024 inclusive
  - **false-positive guards**: below threshold (1023 tokens) silent; non-Anthropic providers silent; \`cache_read > 0\` silent; cold-cache (\`cache_creation > 0\`) silent
  - composes with \`input_tokens_gt_1m\`
- [ ] Deploy: confirm \`masc_keeper_usage_anomaly_reason_total{reason="anthropic_caching_likely_disabled"}\` advances on the affected fleet (taskmaster, nick0cave, qa-king, janitor were the heaviest hitters per #9959 evidence table)

## What this does NOT fix

#9959 has three facets:
1. ✅ Anthropic cache silent disable — this PR
2. ❌ Ollama provider reporting input/output = 0 in 50+ turns — separate metric pipeline (provider adapter), follow-up tick
3. ❌ \`input_tokens\` 1M-3.69M values exceeding 1M context ceiling (accumulator bug or unit error) — separate root cause, follow-up tick

The existing classifier already catches facet 3 via
\`input_tokens_gt_1m\` / \`gt_2x_context_max\` so the dashboard
already has a signal there.  Facet 2 (ollama 0 tokens after a
17-min turn) is the closest to invisible and likely the next
target.

## Refs

- #9943 (compaction noop — same metric-credibility cluster)
- #9953 (context_max 3-way drift)
- #9935 (context_overflow_imminent fires 45×/day no action — same cluster of metric pipeline trust gaps)

## Do-not-merge

\`do-not-merge\` label set so the auto-merge pipeline does not
flip this Draft.  Wants a manual confirmation that the new
reason fires on the affected fleet before landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)