### PR TITLE
obs(auth): counter for bearer-token cross-agent mismatch (#9786)

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -486,9 +486,24 @@ let create_token config ~agent_name ~role : (string * agent_credential, masc_err
   | Ok cred -> Ok (raw_token, cred)
   | Error e -> Error e
 
+(* #9786: record bearer-token mismatch for observability.  Shared
+   helper so both reject sites feed the same counter with the same
+   label shape.  Non-mismatch rejects (no owner found at all) are
+   NOT counted here — they have a different root cause. *)
+let record_bearer_token_mismatch ~expected_agent ~actual_agent =
+  Prometheus.inc_counter
+    Prometheus.metric_auth_bearer_token_mismatch
+    ~labels:[
+      ("expected_agent", expected_agent);
+      ("actual_agent", actual_agent);
+    ]
+    ()
+
 let missing_credential_error config ~agent_name ~token : masc_error =
   match find_credential_by_token config ~token with
   | Ok owner when owner.agent_name <> agent_name ->
+      record_bearer_token_mismatch
+        ~expected_agent:agent_name ~actual_agent:owner.agent_name;
       Unauthorized
         (Printf.sprintf
            "No credential found for %s (bearer token belongs to %s)"
@@ -512,6 +527,12 @@ let verify_token_owner_alias config ~agent_name ~token =
   | Ok owner when String.equal owner.agent_name (credential_agent_name agent_name) ->
       Ok owner
   | Ok owner ->
+      (* #9786: same mismatch counter as [missing_credential_error] —
+         this path fires when no credential file exists for the
+         requested agent but the presented token resolves to some
+         other agent.  Equivalent operator signal. *)
+      record_bearer_token_mismatch
+        ~expected_agent:agent_name ~actual_agent:owner.agent_name;
       Error
         (Unauthorized
            (Printf.sprintf

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -462,6 +462,18 @@ let metric_runtime_ollama_probe_generate_skips =
 let metric_fs_atomic_orphans_cleaned =
   "masc_fs_atomic_orphans_cleaned_total"
 
+(* #9786: bearer token mismatch — agent [A] presents a token that
+   resolves to credential owner [B].  The Auth layer rejects with
+   [Unauthorized "No credential found for A (bearer token belongs to B)"],
+   but the failure was invisible to Prometheus: dashboards could
+   only see cascading downstream rejections (masc_claim_next
+   failures, keeper degraded proactive state) without the upstream
+   cause.  Labels [expected_agent, actual_agent] keep cardinality
+   bounded at the small cross-product of fleet identities. *)
+let metric_auth_bearer_token_mismatch =
+  "masc_auth_bearer_token_mismatch_total"
+
+
 (** {1 Built-in Metrics} *)
 
 let init () =
@@ -747,6 +759,14 @@ let init () =
      (labels: size_class=empty|with_data).  [with_data] rate > 0 \
      indicates silent atomic-save failures (SIGKILL / ENFILE) that \
      dropped payloads; moved to [<base_path>/.recovered/]."
+    Counter;
+  (* #9786: auth layer rejects a request whose bearer token resolves
+     to a credential owner different from the requested agent. *)
+  add metric_auth_bearer_token_mismatch
+    "Total Auth rejects where bearer token owner does not match the \
+     requested agent_name (labels: expected_agent, actual_agent). Rate \
+     advancing after a server restart indicates shared credential state \
+     (connection pool / process fork) across agent identities."
     Counter;
   (* Transport metrics — registered here so transport_metrics.ml can use
      module constants instead of string literals. *)

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -198,6 +198,13 @@ val metric_runtime_ollama_probe_generate_skips : string
     Labels: [size_class = empty | with_data]. *)
 val metric_fs_atomic_orphans_cleaned : string
 
+(** #9786: Auth rejects where bearer token owner does not match the
+    requested agent_name.  Labels: [expected_agent, actual_agent].
+    Dashboards alert on rate advancing after a server restart as a
+    signal of shared credential state (connection pool / fork). *)
+val metric_auth_bearer_token_mismatch : string
+
+
 (** {1 Transport metrics} *)
 
 val metric_sse_sessions : string

--- a/test/dune
+++ b/test/dune
@@ -1401,6 +1401,11 @@
    (run %{test})))
  (libraries masc_mcp alcotest unix))
 
+(test
+ (name test_auth_bearer_mismatch_9786)
+ (modules test_auth_bearer_mismatch_9786)
+ (libraries masc_mcp masc_types alcotest unix))
+
 
 ; ============================================================
 ; Executables (benchmarks, distributed tests, tools)

--- a/test/test_auth_bearer_mismatch_9786.ml
+++ b/test/test_auth_bearer_mismatch_9786.ml
@@ -1,0 +1,169 @@
+(* test/test_auth_bearer_mismatch_9786.ml
+
+   #9786: agent A presents a token that resolves to credential
+   owner B.  The Auth layer rejects with an [Unauthorized] error
+   but the failure was invisible to Prometheus — dashboards could
+   only see downstream cascades (masc_claim_next failures, keeper
+   degraded proactive state) with no upstream cause.
+
+   This test pins the new
+   [masc_auth_bearer_token_mismatch_total{expected_agent,
+   actual_agent}] counter:
+
+     1. verify_token on an agent whose credential file doesn't
+        exist, using a token that DOES resolve to some other
+        agent, counts a mismatch with labels (expected, actual).
+     2. verify_token on an agent with a VALID matching token
+        does NOT count a mismatch.
+     3. verify_token on an agent with a credential file but
+        wrong token (the [cred.token <> token_hash] path) does
+        NOT hit this counter — that's a simple wrong-token case,
+        not the #9786 cross-agent reuse pattern.
+     4. Mismatches across different (expected, actual) pairs land
+        on separate counter rows so dashboards can attribute
+        blame to the right agent pair.
+*)
+
+open Masc_mcp
+module Prom = Prometheus
+
+let mismatch_total ~expected ~actual =
+  Prom.metric_value_or_zero
+    Prom.metric_auth_bearer_token_mismatch
+    ~labels:[
+      ("expected_agent", expected);
+      ("actual_agent", actual);
+    ]
+    ()
+
+let with_temp_base_path f =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-auth-bearer-9786-%06x"
+         (Random.bits ()))
+  in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error _ -> ());
+  Fun.protect
+    ~finally:(fun () ->
+      (* best-effort recursive cleanup; tolerate missing files *)
+      try
+        let rec rm p =
+          match (Unix.lstat p).st_kind with
+          | S_DIR ->
+            Array.iter (fun e -> rm (Filename.concat p e)) (Sys.readdir p);
+            Unix.rmdir p
+          | _ -> Unix.unlink p
+        in
+        rm dir
+      with _ -> ())
+    (fun () -> f dir)
+
+let save_cred base_path ~agent_name ~raw_token =
+  match
+    Auth.save_raw_token_credential base_path
+      ~agent_name ~role:Types.Worker ~raw_token
+  with
+  | Ok _ -> ()
+  | Error e ->
+    Alcotest.failf "failed to seed credential %s: %s" agent_name
+      (Types.masc_error_to_string e)
+
+(* A's credential never saved; B's credential saved with token-B.
+   Verifying A with token-B triggers the cross-agent mismatch
+   path ([verify_token_owner_alias]).  Counter must advance by
+   exactly 1 with labels (A, B). *)
+let test_cross_agent_mismatch_advances_counter () =
+  with_temp_base_path @@ fun dir ->
+  save_cred dir ~agent_name:"agent-b-9786" ~raw_token:"token-b-raw";
+  let before = mismatch_total ~expected:"agent-a-9786" ~actual:"agent-b-9786" in
+  let result =
+    Auth.verify_token dir ~agent_name:"agent-a-9786" ~token:"token-b-raw"
+  in
+  (match result with
+   | Error (Types.Unauthorized _) -> ()
+   | Error e ->
+     Alcotest.failf "expected Unauthorized, got: %s"
+       (Types.masc_error_to_string e)
+   | Ok _ -> Alcotest.fail "expected Unauthorized, got Ok");
+  Alcotest.(check (float 0.0001))
+    "mismatch counter (A, B) advanced by 1"
+    (before +. 1.0)
+    (mismatch_total ~expected:"agent-a-9786" ~actual:"agent-b-9786")
+
+(* Valid token for the matching agent: the happy path must not
+   count any mismatch. *)
+let test_valid_token_no_mismatch () =
+  with_temp_base_path @@ fun dir ->
+  save_cred dir ~agent_name:"agent-valid-9786" ~raw_token:"token-valid";
+  let before_self =
+    mismatch_total ~expected:"agent-valid-9786" ~actual:"agent-valid-9786"
+  in
+  let result =
+    Auth.verify_token dir ~agent_name:"agent-valid-9786"
+      ~token:"token-valid"
+  in
+  Alcotest.(check bool) "verify Ok"
+    true (Result.is_ok result);
+  Alcotest.(check (float 0.0001))
+    "no mismatch counter movement for matching pair"
+    before_self
+    (mismatch_total ~expected:"agent-valid-9786" ~actual:"agent-valid-9786")
+
+(* Agent C has a credential file; wrong token presented that does
+   NOT resolve to any other agent.  The reject is a plain wrong-
+   token case and should NOT increment #9786's
+   cross-agent counter — that counter is scoped to the "token
+   belongs to someone else" failure only. *)
+let test_wrong_token_no_other_owner_does_not_count () =
+  with_temp_base_path @@ fun dir ->
+  save_cred dir ~agent_name:"agent-c-9786" ~raw_token:"token-c";
+  let before_totals =
+    (* Take a snapshot across a reasonable label cross-product;
+       if none of these advance we can assert the counter stayed
+       still for the test keeper pair. *)
+    mismatch_total ~expected:"agent-c-9786" ~actual:"agent-c-9786"
+  in
+  let result =
+    Auth.verify_token dir ~agent_name:"agent-c-9786"
+      ~token:"completely-unseen-token-abc"
+  in
+  Alcotest.(check bool) "verify Error" true (Result.is_error result);
+  Alcotest.(check (float 0.0001))
+    "no self-mismatch counter movement on wrong-token case"
+    before_totals
+    (mismatch_total ~expected:"agent-c-9786" ~actual:"agent-c-9786")
+
+(* Different (expected, actual) pairs land on different counter
+   rows — dashboards can attribute blame to the correct agent
+   pair.  Pin that (A, B) and (A, C) are separate label
+   combinations, not collapsed into one. *)
+let test_distinct_pairs_recorded_separately () =
+  with_temp_base_path @@ fun dir ->
+  save_cred dir ~agent_name:"bee-9786" ~raw_token:"token-bee";
+  save_cred dir ~agent_name:"cee-9786" ~raw_token:"token-cee";
+  let before_ab = mismatch_total ~expected:"aaa-9786" ~actual:"bee-9786" in
+  let before_ac = mismatch_total ~expected:"aaa-9786" ~actual:"cee-9786" in
+  let _ = Auth.verify_token dir ~agent_name:"aaa-9786" ~token:"token-bee" in
+  let _ = Auth.verify_token dir ~agent_name:"aaa-9786" ~token:"token-cee" in
+  Alcotest.(check (float 0.0001)) "(aaa, bee) +1"
+    (before_ab +. 1.0)
+    (mismatch_total ~expected:"aaa-9786" ~actual:"bee-9786");
+  Alcotest.(check (float 0.0001)) "(aaa, cee) +1"
+    (before_ac +. 1.0)
+    (mismatch_total ~expected:"aaa-9786" ~actual:"cee-9786")
+
+let () =
+  Alcotest.run "auth_bearer_mismatch_9786"
+    [
+      ( "mismatch-counter",
+        [
+          Alcotest.test_case "cross-agent mismatch advances" `Quick
+            test_cross_agent_mismatch_advances_counter;
+          Alcotest.test_case "valid token: no counter movement" `Quick
+            test_valid_token_no_mismatch;
+          Alcotest.test_case "wrong token but no other owner: no counter" `Quick
+            test_wrong_token_no_other_owner_does_not_count;
+          Alcotest.test_case "distinct (expected, actual) pairs" `Quick
+            test_distinct_pairs_recorded_separately;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

#9786 reports agents rejected with errors like
\`No credential found for nick0cave-sage-heron (bearer token belongs to codex-mcp-client)\`
across multiple agents in the same post-restart session.  The
comment thread establishes the credential files exist and
redirect correctly — the runtime resolves the wrong bearer
token (shared connection-pool state, process-fork inheritance,
or similar cross-identity leakage).

The Auth layer correctly rejects with \`Unauthorized\`, but the
failure was invisible to Prometheus.  Dashboards could only see
downstream symptoms (\`masc_claim_next\` failures, keeper
degraded proactive state, #10008's 0/14 cohort proactive
success) with no upstream cause.

## Observability surface

| metric | label | semantics |
|---|---|---|
| \`masc_auth_bearer_token_mismatch_total\` | \`expected_agent\`, \`actual_agent\` | Advanced **only** when Auth rejects because the presented token resolves to a different agent than requested.  Plain wrong-token (cred file exists, hash doesn't match) is NOT counted — different root cause. |

Cardinality: \`expected × actual\` is bounded by fleet size
(~15 keepers + handful of client agents).  Evidence from #9786
shows 3 distinct pairs; label explosion is not a realistic
risk.

## Why two call sites

Two separate Auth helpers build the "bearer token belongs to"
message:

- \`missing_credential_error\` (\`auth.ml:489\`) — when no
  credential record exists AND the token matches some other
  agent's.
- \`verify_token_owner_alias\` (\`auth.ml:510\`) — the
  alias-resolution path that handles generated nicknames and
  keeper-<name>-agent transport aliases.

Both feed the shared helper \`record_bearer_token_mismatch\` so
the label shape stays consistent and downstream PromQL doesn't
need two queries.

## Test plan

- [x] \`dune build --root . lib/\` clean
- [x] \`dune exec test/test_auth_bearer_mismatch_9786.exe\` — 4/4 pass
  - cross-agent mismatch advances counter with correct labels
  - valid-token happy path does not move the counter
  - plain wrong-token (no other owner found) does NOT move counter — scoped intentionally
  - distinct \`(expected, actual)\` pairs land on separate rows
- [ ] Deploy: restart the server on a workspace with the shared-pool pattern; confirm \`masc_auth_bearer_token_mismatch_total\` advances and identifies the colliding pair.

## Not in this PR

The **root fix** — \`Auth.ensure_keeper_credential\` contract
plus per-fiber \`MASC_MCP_TOKEN\` so connection-pool state can't
leak across identities — is a larger structural change that
stays open as follow-up.  With this counter in place,
operators watch the root fix drive the counter back to zero
instead of relying on log grep.

## Refs

- #10008 (cohort 0/14 proactive success — downstream)
- #10012 (fake-alignment heuristic — same cluster, separate drift)

## Do-not-merge

\`do-not-merge\` label set so the auto-merge pipeline does not
flip this Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)