### PR TITLE
fix(fs-atomic): boot-time sweep of save_file_atomic orphans (#10130)

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -191,6 +191,87 @@ let save_file_atomic (path : string) (content : string) : (unit, string) result 
     (try Sys.remove tmp with Sys_error _ -> ());
     Error (Printf.sprintf "save_file_atomic %s: %s" path (Printexc.to_string exn))
 
+(* #10130: orphaned [.atomic_*.tmp] files from [save_file_atomic]
+   that accumulated because the owning process was SIGKILL'd or
+   [Filename.temp_file] raised ENFILE/EMFILE (so the with-handler
+   never ran).  The 2026-04-24 audit found 33 orphans in
+   [~/me/.masc/] with 6 non-zero files carrying real keeper-meta
+   JSON — evidence of 6 silent atomic-save failures that
+   dropped data.
+
+   [cleanup_atomic_orphans] is a boot-time sweep.  Zero-byte
+   orphans are deleted (they lost the rename race but never
+   held data).  Non-zero orphans are MOVED to
+   [<base_path>/<recovered_subdir>/] instead of deleted so
+   operators can forensically inspect them — a data-loss event
+   deserves preservation, not silent cleanup.
+
+   Returns [(deleted, preserved)]:
+   - [deleted]: number of zero-byte orphans removed.
+   - [preserved]: number of non-zero orphans moved to the
+     recovered directory. *)
+let is_atomic_orphan_name name =
+  let prefix = ".atomic_" and suffix = ".tmp" in
+  let n = String.length name in
+  let p = String.length prefix in
+  let s = String.length suffix in
+  n >= p + s
+  && String.sub name 0 p = prefix
+  && String.sub name (n - s) s = suffix
+
+let cleanup_atomic_orphans
+    ~(base_path : string)
+    ?(recovered_subdir = ".recovered")
+    () : int * int =
+  let recovered_dir = Filename.concat base_path recovered_subdir in
+  let deleted = ref 0 in
+  let preserved = ref 0 in
+  let ensure_recovered_dir () =
+    if not (Sys.file_exists recovered_dir) then
+      try Unix.mkdir recovered_dir 0o755
+      with Unix.Unix_error _ -> ()
+  in
+  let handle_file dir name =
+    let path = Filename.concat dir name in
+    match Unix.stat path with
+    | exception Unix.Unix_error _ -> ()
+    | stat when stat.Unix.st_size = 0 ->
+        (try Sys.remove path; incr deleted
+         with Sys_error _ -> ())
+    | _stat ->
+        ensure_recovered_dir ();
+        let target =
+          Filename.concat recovered_dir
+            (Printf.sprintf "%s.%.0f" name (Unix.gettimeofday () *. 1000.0))
+        in
+        (try Sys.rename path target; incr preserved
+         with Sys_error _ | Unix.Unix_error _ -> ())
+  in
+  let scan_dir dir =
+    match Sys.readdir dir with
+    | exception Sys_error _ -> ()
+    | entries ->
+        Array.iter
+          (fun name ->
+            if is_atomic_orphan_name name then handle_file dir name)
+          entries
+  in
+  scan_dir base_path;
+  (match Sys.readdir base_path with
+   | exception Sys_error _ -> ()
+   | entries ->
+       Array.iter
+         (fun name ->
+           if name = recovered_subdir then ()
+           else
+             let sub = Filename.concat base_path name in
+             match Unix.stat sub with
+             | exception Unix.Unix_error _ -> ()
+             | stat when stat.Unix.st_kind = Unix.S_DIR -> scan_dir sub
+             | _ -> ())
+         entries);
+  (!deleted, !preserved)
+
 (** Append string to file.
     Eio-native when available, fallback to Unix.
     @raises Sys_error on all I/O failures. Eio.Io is normalized internally. *)

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -32,6 +32,34 @@ val save_file_atomic : string -> string -> (unit, string) result
 (** Write content to path via temp file + rename.
     Returns [Error msg] on I/O failure instead of raising. *)
 
+val is_atomic_orphan_name : string -> bool
+(** [true] iff [name] matches the [.atomic_*.tmp] pattern produced
+    by [Filename.temp_file ~temp_dir:dir ".atomic_" ".tmp"] inside
+    {!save_file_atomic}.  Exposed for tests and for a potential
+    periodic sweep. *)
+
+val cleanup_atomic_orphans :
+  base_path:string ->
+  ?recovered_subdir:string ->
+  unit ->
+  int * int
+(** #10130: boot-time sweep for [.atomic_*.tmp] orphans left
+    behind when [save_file_atomic]'s with-handler never ran (the
+    owning process was SIGKILL'd, or [Filename.temp_file] itself
+    raised ENFILE/EMFILE before the cleanup was registered).
+
+    Scans [base_path] and its immediate subdirectories (skipping
+    [recovered_subdir] and anything that isn't a directory).
+    - Zero-byte orphans are deleted.
+    - Non-zero orphans are moved to
+      [<base_path>/<recovered_subdir>/<original-name>.<ts-ms>]
+      so operators can forensically inspect data-loss events
+      instead of having them silently cleaned up.
+
+    Returns [(deleted, preserved)]:
+    - [deleted]: zero-byte orphans removed.
+    - [preserved]: non-zero orphans moved to [recovered_subdir]. *)
+
 val append_file : string -> string -> unit
 (** Append string to file. *)
 

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -382,6 +382,14 @@ let metric_oas_bus_publish = "masc_oas_bus_publish_total"
 let metric_runtime_ollama_probe_generate_skips =
   "masc_runtime_ollama_probe_generate_skips_total"
 
+(* #10130: boot-time sweep of [save_file_atomic] orphan temp
+   files.  Labels: [size_class = empty | with_data].  The
+   [with_data] rate is the interesting operator signal — each
+   non-zero orphan represents a silent atomic-save failure
+   (SIGKILL / ENFILE mid-write) that dropped the payload. *)
+let metric_fs_atomic_orphans_cleaned =
+  "masc_fs_atomic_orphans_cleaned_total"
+
 (** {1 Built-in Metrics} *)
 
 let init () =
@@ -628,6 +636,13 @@ let init () =
   add metric_runtime_ollama_probe_generate_skips
     "Total Ollama runtime probes that intentionally skipped /api/generate. \
      Labeled by reason=status_only|model_unloaded|ps_error|no_effective_model|policy_skip."
+    Counter;
+  (* #10130: boot-time sweep of save_file_atomic orphans. *)
+  add metric_fs_atomic_orphans_cleaned
+    "Total save_file_atomic orphan temp files cleaned at boot \
+     (labels: size_class=empty|with_data).  [with_data] rate > 0 \
+     indicates silent atomic-save failures (SIGKILL / ENFILE) that \
+     dropped payloads; moved to [<base_path>/.recovered/]."
     Counter;
   (* Transport metrics — registered here so transport_metrics.ml can use
      module constants instead of string literals. *)

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -166,6 +166,10 @@ val metric_oas_bus_publish_block_seconds : string
 val metric_oas_bus_publish : string
 val metric_runtime_ollama_probe_generate_skips : string
 
+(** #10130: boot-time sweep of save_file_atomic orphan temp files.
+    Labels: [size_class = empty | with_data]. *)
+val metric_fs_atomic_orphans_cleaned : string
+
 (** {1 Transport metrics} *)
 
 val metric_sse_sessions : string

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1231,6 +1231,39 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       Runtime_params.restore ~base_path;
       Log.Server.info "Runtime_params restored from %s" base_path;
       Keeper_crash_persistence.start_drain_fiber ~sw ~clock;
+      (* #10130: sweep [save_file_atomic] orphan temp files left by
+         SIGKILL'd or ENFILE-crashed prior processes.  Zero-byte
+         orphans are deleted; non-zero orphans (evidence of silent
+         atomic-save data loss) are preserved in
+         [<base_path>/.recovered/] for forensic inspection.  Always
+         runs at boot so each restart publishes fresh cleanup
+         counters. *)
+      (try
+        let deleted, preserved =
+          Fs_compat.cleanup_atomic_orphans ~base_path ()
+        in
+        if deleted > 0 then
+          Prometheus.inc_counter
+            Prometheus.metric_fs_atomic_orphans_cleaned
+            ~labels:[ ("size_class", "empty") ]
+            ~delta:(float_of_int deleted)
+            ();
+        if preserved > 0 then
+          Prometheus.inc_counter
+            Prometheus.metric_fs_atomic_orphans_cleaned
+            ~labels:[ ("size_class", "with_data") ]
+            ~delta:(float_of_int preserved)
+            ();
+        if deleted + preserved > 0 then
+          Log.Server.warn
+            "boot: cleaned %d save_file_atomic orphans (%d empty, \
+             %d preserved with data in .recovered/ — see #10130)"
+            (deleted + preserved) deleted preserved
+       with Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
+            Log.Server.error
+              "boot: atomic orphan sweep failed: %s"
+              (Printexc.to_string exn));
       let t2 = Eio.Time.now clock in
       Log.Server.info "Bootstrap completed in %.1fs" (t2 -. t1);
       Server_bootstrap_loops.install_tooling ~governance_level state;

--- a/test/dune
+++ b/test/dune
@@ -1330,6 +1330,12 @@
    (run %{test})))
  (libraries masc_mcp alcotest unix))
 
+(test
+ (name test_fs_atomic_orphan_sweep_10130)
+ (modules test_fs_atomic_orphan_sweep_10130)
+ (libraries fs_compat alcotest unix))
+
+
 ; ============================================================
 ; Executables (benchmarks, distributed tests, tools)
 ; ============================================================

--- a/test/test_fs_atomic_orphan_sweep_10130.ml
+++ b/test/test_fs_atomic_orphan_sweep_10130.ml
@@ -1,0 +1,215 @@
+(* test/test_fs_atomic_orphan_sweep_10130.ml
+
+   #10130: [.atomic_*.tmp] orphans from [save_file_atomic]
+   accumulate after SIGKILL or ENFILE because the OCaml
+   with-handler never ran.  The 2026-04-24 audit found 33
+   orphans with 6 non-zero files holding real keeper-meta
+   JSON — evidence of 6 silent data-loss events.
+
+   [Fs_compat.cleanup_atomic_orphans] is a boot-time sweep:
+   - zero-byte orphans are deleted;
+   - non-zero orphans are MOVED (not deleted) to
+     [<base_path>/.recovered/] so operators can forensically
+     inspect data-loss events.
+
+   These tests pin that contract so a future refactor can't
+   silently delete the forensic evidence.
+*)
+
+let make_temp_base () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-fs-atomic-10130-%06x"
+         (Random.bits ()))
+  in
+  Unix.mkdir dir 0o755;
+  dir
+
+let rm_rf path =
+  let rec go p =
+    match Unix.lstat p with
+    | exception Unix.Unix_error _ -> ()
+    | { st_kind = S_DIR; _ } ->
+        (Array.iter (fun e -> go (Filename.concat p e)) (Sys.readdir p));
+        (try Unix.rmdir p with Unix.Unix_error _ -> ())
+    | _ -> (try Unix.unlink p with Unix.Unix_error _ -> ())
+  in
+  go path
+
+let with_temp_base f =
+  let dir = make_temp_base () in
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let write_file ~path ~content =
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc
+
+let touch path = write_file ~path ~content:""
+
+(* Name matcher is strict: both prefix and suffix required. *)
+let test_name_matcher () =
+  let yes s =
+    Alcotest.(check bool) ("match " ^ s) true
+      (Fs_compat.is_atomic_orphan_name s)
+  in
+  let no s =
+    Alcotest.(check bool) ("no match " ^ s) false
+      (Fs_compat.is_atomic_orphan_name s)
+  in
+  yes ".atomic_abc.tmp";
+  yes ".atomic_946c84.tmp";
+  yes ".atomic_.tmp";
+  no "atomic_abc.tmp";
+  no ".atomic_abc";
+  no "normal.json";
+  no "sangsu.json";
+  no ".atomic_prefix_only";
+  no "prefix_.atomic_abc.tmp" (* prefix not at start *)
+
+(* Zero-byte orphans at base_path: deleted, counter reports
+   [(1, 0)]. *)
+let test_zero_byte_orphan_at_base_deleted () =
+  with_temp_base @@ fun base_path ->
+  let orphan = Filename.concat base_path ".atomic_empty01.tmp" in
+  touch orphan;
+  let deleted, preserved =
+    Fs_compat.cleanup_atomic_orphans ~base_path ()
+  in
+  Alcotest.(check int) "1 deleted" 1 deleted;
+  Alcotest.(check int) "0 preserved" 0 preserved;
+  Alcotest.(check bool) "orphan file removed" false
+    (Sys.file_exists orphan)
+
+(* Non-zero orphan at base_path: moved to .recovered/, NOT
+   deleted.  The original path is gone but the payload survives
+   in the recovered directory for forensic inspection. *)
+let test_nonzero_orphan_preserved_in_recovered () =
+  with_temp_base @@ fun base_path ->
+  let orphan = Filename.concat base_path ".atomic_data42.tmp" in
+  let payload = "{\"name\":\"sangsu\",\"goal\":\"…\"}" in
+  write_file ~path:orphan ~content:payload;
+  let deleted, preserved =
+    Fs_compat.cleanup_atomic_orphans ~base_path ()
+  in
+  Alcotest.(check int) "0 deleted" 0 deleted;
+  Alcotest.(check int) "1 preserved" 1 preserved;
+  Alcotest.(check bool) "original removed" false
+    (Sys.file_exists orphan);
+  let recovered_dir = Filename.concat base_path ".recovered" in
+  Alcotest.(check bool) ".recovered/ created" true
+    (Sys.file_exists recovered_dir);
+  let entries = Sys.readdir recovered_dir in
+  Alcotest.(check int) "1 file in .recovered/" 1 (Array.length entries);
+  let recovered_path = Filename.concat recovered_dir entries.(0) in
+  let ic = open_in recovered_path in
+  let n = in_channel_length ic in
+  let content = really_input_string ic n in
+  close_in ic;
+  Alcotest.(check string) "payload survived"
+    payload content
+
+(* Orphans in subdirs are found too.  #10130 evidence was mostly
+   under base_path/keepers/. *)
+let test_orphans_in_subdirs_found () =
+  with_temp_base @@ fun base_path ->
+  let subdir = Filename.concat base_path "keepers" in
+  Unix.mkdir subdir 0o755;
+  touch (Filename.concat subdir ".atomic_zeroKeeper.tmp");
+  write_file ~path:(Filename.concat subdir ".atomic_dataKeeper.tmp")
+    ~content:"sangsu data";
+  let deleted, preserved =
+    Fs_compat.cleanup_atomic_orphans ~base_path ()
+  in
+  Alcotest.(check int) "1 deleted from subdir" 1 deleted;
+  Alcotest.(check int) "1 preserved from subdir" 1 preserved
+
+(* Non-orphan files must NOT be touched.  Matches the
+   [is_atomic_orphan_name] predicate strictly. *)
+let test_non_orphan_files_untouched () =
+  with_temp_base @@ fun base_path ->
+  let normal = Filename.concat base_path "sangsu.json" in
+  write_file ~path:normal ~content:"{\"real\":\"data\"}";
+  let atomic_no_suffix = Filename.concat base_path ".atomic_abc" in
+  write_file ~path:atomic_no_suffix ~content:"not an orphan";
+  let _ = Fs_compat.cleanup_atomic_orphans ~base_path () in
+  Alcotest.(check bool) "sangsu.json survived" true
+    (Sys.file_exists normal);
+  Alcotest.(check bool) ".atomic_abc (no .tmp) survived" true
+    (Sys.file_exists atomic_no_suffix)
+
+(* Idempotent: second call on an already-clean dir is a noop. *)
+let test_idempotent () =
+  with_temp_base @@ fun base_path ->
+  touch (Filename.concat base_path ".atomic_once.tmp");
+  let _ = Fs_compat.cleanup_atomic_orphans ~base_path () in
+  let deleted, preserved =
+    Fs_compat.cleanup_atomic_orphans ~base_path ()
+  in
+  Alcotest.(check int) "second call: 0 deleted" 0 deleted;
+  Alcotest.(check int) "second call: 0 preserved" 0 preserved
+
+(* Mixed case (matches the 2026-04-24 production evidence:
+   33 orphans total, 6 with data). *)
+let test_mixed_batch () =
+  with_temp_base @@ fun base_path ->
+  (* 10 empty + 3 with data *)
+  for i = 0 to 9 do
+    touch (Filename.concat base_path
+             (Printf.sprintf ".atomic_empty%02d.tmp" i))
+  done;
+  for i = 0 to 2 do
+    write_file
+      ~path:(Filename.concat base_path
+               (Printf.sprintf ".atomic_data%02d.tmp" i))
+      ~content:(Printf.sprintf "payload %d" i)
+  done;
+  let deleted, preserved =
+    Fs_compat.cleanup_atomic_orphans ~base_path ()
+  in
+  Alcotest.(check int) "10 deleted" 10 deleted;
+  Alcotest.(check int) "3 preserved" 3 preserved
+
+(* .recovered/ dir itself must be skipped on recursion so we
+   don't loop on any orphan someone moved there by hand. *)
+let test_recovered_dir_skipped_on_rescan () =
+  with_temp_base @@ fun base_path ->
+  let recovered = Filename.concat base_path ".recovered" in
+  Unix.mkdir recovered 0o755;
+  (* Drop an orphan-shaped name into .recovered/ directly.  A
+     rescan must not touch it. *)
+  write_file ~path:(Filename.concat recovered ".atomic_seed.tmp")
+    ~content:"already forensic";
+  let deleted, preserved =
+    Fs_compat.cleanup_atomic_orphans ~base_path ()
+  in
+  Alcotest.(check int) "0 deleted" 0 deleted;
+  Alcotest.(check int) "0 preserved (recovered/ not re-scanned)"
+    0 preserved;
+  Alcotest.(check bool) ".recovered/ seed file untouched" true
+    (Sys.file_exists (Filename.concat recovered ".atomic_seed.tmp"))
+
+let () =
+  Alcotest.run "fs_atomic_orphan_sweep_10130"
+    [
+      ( "name-matcher",
+        [ Alcotest.test_case "strict prefix+suffix match" `Quick
+            test_name_matcher ] );
+      ( "sweep-behavior",
+        [
+          Alcotest.test_case "zero-byte at base: deleted" `Quick
+            test_zero_byte_orphan_at_base_deleted;
+          Alcotest.test_case "non-zero: preserved in .recovered/" `Quick
+            test_nonzero_orphan_preserved_in_recovered;
+          Alcotest.test_case "orphans in subdirs found" `Quick
+            test_orphans_in_subdirs_found;
+          Alcotest.test_case "non-orphan files untouched" `Quick
+            test_non_orphan_files_untouched;
+          Alcotest.test_case "idempotent: second call is noop" `Quick
+            test_idempotent;
+          Alcotest.test_case "mixed batch (prod-shaped)" `Quick
+            test_mixed_batch;
+          Alcotest.test_case ".recovered/ skipped on rescan" `Quick
+            test_recovered_dir_skipped_on_rescan;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

2026-04-24 audit found 33 \`.atomic_*.tmp\` orphans in \`~/me/.masc/\`,
**6 of them non-zero** (4.8-14.5 KB) carrying real keeper-meta
JSON — direct evidence of 6 silent atomic-save data-loss events.

Root cause: \`save_file_atomic\`'s \`try ... with\` cleanup never
ran because either:
1. the owning process was SIGKILL'd (OCaml exception handlers
   don't cover SIGKILL), or
2. \`Filename.temp_file\` raised ENFILE/EMFILE before the
   handler was registered in the first place.

The server had no boot-time sweep, so orphans (including the 6
non-zero data-loss artifacts) accumulated unnoticed.

## Fix (issue Options A + D combined)

Add \`Fs_compat.cleanup_atomic_orphans\` and wire it into server
bootstrap right after \`Keeper_crash_persistence.start_drain_fiber\`.

| orphan size | action | rationale |
|---|---|---|
| 0 bytes | \`Sys.remove\` | lost the rename race, never held data |
| > 0 bytes | **move** to \`<base_path>/.recovered/<name>.<ts-ms>\` | preserve forensic evidence of data-loss event, NOT silent cleanup |

The sweep scans \`base_path\` plus its immediate subdirectories
(matches production evidence layout: mostly \`base_path/keepers/\`).
\`.recovered/\` itself is skipped on recursion so previously
preserved files don't loop.

## Observability

New counter
\`masc_fs_atomic_orphans_cleaned_total{size_class=empty|with_data}\`.

Operators alert on \`with_data\` advancing after a restart:

\`\`\`promql
rate(masc_fs_atomic_orphans_cleaned_total{size_class="with_data"}[1h]) > 0
\`\`\`

Each advancement represents a silent data-loss event that
would previously have been invisible.  A boot-time \`Log.Server.warn\`
also summarises the batch.

## Design notes

- \`cleanup_atomic_orphans : ~base_path:string -> ?recovered_subdir:string -> unit -> int * int\`
  is a **pure filesystem function** returning \`(deleted, preserved)\`.
  Counter emission and log WARN live in \`server_runtime_bootstrap\`
  so \`fs_compat\` stays Prometheus-free (it's a lower-layer library
  outside the observability module's dependency graph).
- \`is_atomic_orphan_name\` exported so tests + any future periodic
  sweep can share the same glob without reimplementing.
- **SIGKILL-safe by design**: sweep runs at EVERY boot regardless of
  why the prior process died.  Not "try harder on the exception
  path" (Option B, blunted) — the sweep catches orphans the exception
  handler couldn't possibly catch.

## Test plan

- [x] \`dune build --root . lib/\` clean (mli/ml aligned for both fs_compat and prometheus)
- [x] \`dune exec test/test_fs_atomic_orphan_sweep_10130.exe\` — 8/8 pass:
  - strict name matcher (prefix + suffix both required);
  - zero-byte orphan deleted;
  - non-zero orphan preserved in \`.recovered/\` with payload intact;
  - orphans in subdirectories found;
  - non-orphan files (sangsu.json, \`.atomic_abc\` without \`.tmp\`) untouched;
  - idempotent second call;
  - mixed 10+3 batch (production-shaped) correctly counted;
  - \`.recovered/\` skipped on rescan so previously-preserved files do not loop.
- [ ] Deploy: restart server on a workspace with known orphans; confirm \`Log.Server.warn\` at boot + \`masc_fs_atomic_orphans_cleaned_total\` advances with correct label values; confirm \`.recovered/\` directory created with non-zero payloads preserved.

## Follow-ups (NOT in this PR)

- Periodic sweep (issue Option C) for orphans created during a
  long-running session (this PR catches them at next restart only).
- \`Fun.protect\` on \`Filename.temp_file\` call (issue Option B) —
  blunted because SIGKILL is the harder failure mode and this sweep
  already catches that.

## Refs

- #9733 (write_meta CAS race + ENFILE trigger — upstream of the orphan pattern)
- #9780 (renameat ENOENT, closed — different atomic-save failure mode)

## Do-not-merge

\`do-not-merge\` label set so the auto-merge pipeline does not flip
this Draft.  Wants a manual operator validation on a real workspace
with existing orphans before landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)