### PR TITLE
fix: increase default governance judge timeout to 180s

### DIFF
--- a/lib/config/env_config_governance.ml
+++ b/lib/config/env_config_governance.ml
@@ -34,7 +34,7 @@ module Inference = struct
     in
     let chosen =
       if dedicated > 0 then dedicated
-      else max 60 timeout_seconds_int
+      else max 180 timeout_seconds_int
     in
     max 5 chosen
 


### PR DESCRIPTION
When primary models fail quickly (e.g., quota limits), the fallback cascade might select a slower model. The previous 60s hard timeout was often insufficient for these slower models, causing a timeout loop. This increases the default timeout to 180s to give fallback models sufficient time.