### PR TITLE
fix(board): unify keeper actor identity

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   derivePostTitle,
+  fetchBoard,
   sanitizeBoardTitle,
   asNullableIsoTimestamp,
   normalizePendingConfirmation,
@@ -10,6 +11,10 @@ import {
   normalizeGovernanceTimelineEvent,
   normalizeGovernanceJudgeSummary,
 } from './board'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 // ================================================================
 // board title helpers (existing)
@@ -414,5 +419,52 @@ describe('normalizeGovernanceJudgeSummary', () => {
   it('returns undefined for non-boolean judge_online', () => {
     const result = normalizeGovernanceJudgeSummary({ judge_online: 'yes' })
     expect(result!.judge_online).toBeUndefined()
+  })
+})
+
+// ================================================================
+// fetchBoard
+// ================================================================
+
+describe('fetchBoard', () => {
+  it('preserves board actor identity provenance from the server', async () => {
+    const rawResponse = {
+      posts: [
+        {
+          id: 'post-1',
+          author: 'analyst',
+          title: 'Status',
+          body: 'Working',
+          created_at: 1_713_000_000,
+          updated_at: 1_713_000_000,
+          author_identity: {
+            kind: 'keeper',
+            id: 'analyst',
+            key: 'keeper:analyst',
+            display_name: 'analyst',
+            raw: 'keeper-analyst-agent',
+            source: 'keeper_alias_contract',
+            runtime_agent_name: 'keeper-analyst-agent',
+          },
+        },
+      ],
+    }
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchBoard()
+
+    expect(result.posts[0]?.author_identity).toMatchObject({
+      kind: 'keeper',
+      id: 'analyst',
+      raw: 'keeper-analyst-agent',
+      source: 'keeper_alias_contract',
+      runtime_agent_name: 'keeper-analyst-agent',
+    })
   })
 })

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -1,7 +1,7 @@
 import { get, post, withRetries, defaultBoardVoter } from './core'
 import { isRecord, asNullableString, asString, asNumber, asInt, asStringList } from '../components/common/normalize'
 import type {
-  BoardPost, BoardComment, BoardSortMode,
+  BoardActorIdentity, BoardPost, BoardComment, BoardSortMode,
   GovernanceContextRef,
   GovernanceDecisionItem, GovernanceExecutedRoute,
   GovernanceGuardrailState, GovernanceJudgeSummary, GovernanceJudgment,
@@ -300,6 +300,29 @@ function normalizeBoardMeta(raw: unknown): BoardPost['meta'] {
   return Object.keys(next).length > 0 ? next : null
 }
 
+function normalizeBoardActorIdentity(
+  raw: unknown,
+  fallbackRaw: string,
+): BoardActorIdentity | null {
+  if (!isRecord(raw)) return null
+  const kindRaw = asString(raw.kind, '').trim().toLowerCase()
+  const kind = kindRaw === 'keeper' ? 'keeper' : kindRaw === 'agent' ? 'agent' : null
+  const id = asString(raw.id, '').trim()
+  if (!kind || !id) return null
+  const key = asString(raw.key, '').trim() || `${kind}:${id.toLowerCase()}`
+  const displayName = asString(raw.display_name, '').trim() || id
+  const original = asString(raw.raw, '').trim() || fallbackRaw
+  const runtimeAgentName = asString(raw.runtime_agent_name, '').trim()
+  return {
+    kind,
+    id,
+    key,
+    display_name: displayName,
+    raw: original,
+    runtime_agent_name: runtimeAgentName || undefined,
+  }
+}
+
 function normalizeBoardPost(raw: unknown): BoardPost | null {
   if (!isRecord(raw)) return null
   const id = asString(raw.id, '').trim()
@@ -337,6 +360,7 @@ function normalizeBoardPost(raw: unknown): BoardPost | null {
   return {
     id,
     author,
+    author_identity: normalizeBoardActorIdentity(raw.author_identity, author),
     post_kind:
       (() => {
         const rawKind = asString(raw.post_kind, '').trim().toLowerCase()
@@ -379,6 +403,7 @@ function normalizeBoardComment(raw: unknown): BoardComment | null {
     post_id: postId,
     parent_id: parentId,
     author,
+    author_identity: normalizeBoardActorIdentity(raw.author_identity, author),
     content: asString(raw.content, ''),
     created_at: toIsoTimestamp(raw.created_at) ?? '',
   }

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -312,6 +312,7 @@ function normalizeBoardActorIdentity(
   const key = asString(raw.key, '').trim() || `${kind}:${id.toLowerCase()}`
   const displayName = asString(raw.display_name, '').trim() || id
   const original = asString(raw.raw, '').trim() || fallbackRaw
+  const source = asString(raw.source, '').trim()
   const runtimeAgentName = asString(raw.runtime_agent_name, '').trim()
   return {
     kind,
@@ -319,6 +320,7 @@ function normalizeBoardActorIdentity(
     key,
     display_name: displayName,
     raw: original,
+    source: source || undefined,
     runtime_agent_name: runtimeAgentName || undefined,
   }
 }

--- a/dashboard/src/components/activity-graph-view.ts
+++ b/dashboard/src/components/activity-graph-view.ts
@@ -14,6 +14,7 @@ const hoveredNodeId = signal<string | null>(null)
 function nodeColor(kind: string, status: string): string {
   if (status === 'offline' || status === 'retired') return 'var(--slate-500)'
   switch (kind) {
+    case 'keeper': return 'var(--ok)'
     case 'agent': return 'var(--cyan)'
     case 'task': return 'var(--warn)'
     case 'decision': return 'var(--purple)'
@@ -46,6 +47,7 @@ function edgeColor(kind: string, active: boolean): string {
 
 function kindLabel(kind: string): string {
   switch (kind) {
+    case 'keeper': return '키퍼'
     case 'agent': return '에이전트'
     case 'task': return '작업'
     case 'decision': return '결정'
@@ -176,8 +178,8 @@ export function GraphView({ data }: GraphViewProps) {
       if (params.nodes.length > 0) {
         const found = params.nodes[0]
         selectedNodeId.value = found
-        if (found && found.startsWith('agent:')) {
-          highlightedAgentId.value = found.slice(6)
+        if (found && (found.startsWith('agent:') || found.startsWith('keeper:'))) {
+          highlightedAgentId.value = found.slice(found.indexOf(':') + 1)
         } else {
           highlightedAgentId.value = null
         }
@@ -245,6 +247,7 @@ export function GraphView({ data }: GraphViewProps) {
     </div>
     <div class="flex flex-wrap gap-x-4 gap-y-1 mt-1 px-1">
       ${[
+        { label: '키퍼', color: 'var(--ok)' },
         { label: '에이전트', color: 'var(--cyan)' },
         { label: '작업', color: 'var(--warn)' },
         { label: '결정', color: 'var(--purple)' },

--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -286,12 +286,12 @@ function nodeScore(node: ActivityGraphNode): number {
 
 function NodeLeaderboard({ nodes }: { nodes: ActivityGraphNode[] }) {
   const agentNodes = nodes
-    .filter(n => n.kind === 'agent')
+    .filter(n => n.kind === 'agent' || n.kind === 'keeper')
     .sort((a, b) => nodeScore(b) - nodeScore(a))
     .slice(0, 15)
 
   if (agentNodes.length === 0) {
-    return html`<${EmptyState} message="활동 집계에 포함된 에이전트가 없습니다." compact />`
+    return html`<${EmptyState} message="활동 집계에 포함된 키퍼/에이전트가 없습니다." compact />`
   }
 
   const maxScore = nodeScore(agentNodes[0]!) || 1

--- a/dashboard/src/components/common/keeper-identity.test.ts
+++ b/dashboard/src/components/common/keeper-identity.test.ts
@@ -39,6 +39,10 @@ describe('keeper identity helpers', () => {
     expect(canonicalKeeperName('keeper-sangsu-agent')).toBe('sangsu')
   })
 
+  it('canonicalizes board runtime aliases to keeper names', () => {
+    expect(canonicalKeeperNameFromAgentName('keeper-analyst-agent')).toBe('analyst')
+  })
+
   it('prefers keeper_id for principal keys', () => {
     expect(keeperPrincipalKey('uuid-1', 'ramarama', 'ramarama-fierce-panda')).toBe('keeper_id:uuid-1')
   })

--- a/dashboard/src/components/memory-post-detail.ts
+++ b/dashboard/src/components/memory-post-detail.ts
@@ -10,7 +10,12 @@ import { RichComposer } from './common/rich-composer'
 import { RichContent } from './common/rich-content'
 import { stripStateBlocks } from '../keeper-message'
 import { navigate } from '../router'
-import { navigateToAuthor } from '../lib/board-utils'
+import {
+  boardActorAvatarKey,
+  boardActorDisplayName,
+  boardActorTitle,
+  navigateToAuthor,
+} from '../lib/board-utils'
 import {
   detailComments,
   detailLoading,
@@ -129,13 +134,16 @@ function CommentItem({
   const isReplying = replyingTo.value === comment.id
   const indent = depth > 0 ? `ml-${Math.min(depth * 4, 12)}` : ''
   const replies = childrenMap.get(comment.id) ?? []
+  const authorLabel = boardActorDisplayName(comment.author, comment.author_identity)
+  const authorAvatarKey = boardActorAvatarKey(comment.author, comment.author_identity)
+  const authorTitle = boardActorTitle(comment.author, comment.author_identity)
 
   return html`
     <div class="${indent}">
       <div class="board-comment rounded p-3 bg-[var(--white-3)] border border-[var(--border-slate-12)] ${depth > 0 ? 'border-l-2 border-l-[var(--accent-20)]' : ''}">
         <div class="flex items-center gap-2 mb-1.5">
-          <span class="text-xs">${authorAvatar(comment.author)}</span>
-          <button type="button" class="text-xs font-medium text-[var(--text-body)] hover:text-[var(--accent)] transition-colors cursor-pointer bg-transparent border-none p-0" onClick=${() => navigateToAuthor(comment.author)}>${comment.author}</button>
+          <span class="text-xs">${authorAvatar(authorAvatarKey)}</span>
+          <button type="button" class="text-xs font-medium text-[var(--text-body)] hover:text-[var(--accent)] transition-colors cursor-pointer bg-transparent border-none p-0" title=${authorTitle} onClick=${() => navigateToAuthor(comment.author, undefined, comment.author_identity)}>${authorLabel}</button>
           <span class="text-2xs text-[var(--text-muted)] opacity-60"><${TimeAgo} timestamp=${comment.created_at} /></span>
           <button type="button"
             class="text-2xs text-[var(--text-muted)] hover:text-[var(--accent)] cursor-pointer bg-transparent border-0 ml-auto"
@@ -285,6 +293,9 @@ export function PostDetail({ post }: { post: BoardPost }) {
       showToast('투표에 실패했습니다', 'error')
     }
   }
+  const authorLabel = boardActorDisplayName(post.author, post.author_identity)
+  const authorAvatarKey = boardActorAvatarKey(post.author, post.author_identity)
+  const authorTitle = boardActorTitle(post.author, post.author_identity)
 
   return html`
     <div>
@@ -305,8 +316,8 @@ export function PostDetail({ post }: { post: BoardPost }) {
 
           <!-- Author and meta -->
           <div class="flex gap-2.5 items-center flex-wrap pt-3 border-t border-[var(--border-slate-12)]">
-            <span class="text-sm">${authorAvatar(post.author)}</span>
-            <button type="button" class="text-xs text-[var(--text-body)] hover:text-[var(--accent)] transition-colors cursor-pointer bg-transparent border-none p-0" onClick=${() => navigateToAuthor(post.author)}>${post.author}</button>
+            <span class="text-sm">${authorAvatar(authorAvatarKey)}</span>
+            <button type="button" class="text-xs text-[var(--text-body)] hover:text-[var(--accent)] transition-colors cursor-pointer bg-transparent border-none p-0" title=${authorTitle} onClick=${() => navigateToAuthor(post.author, undefined, post.author_identity)}>${authorLabel}</button>
             <span class="text-2xs text-[var(--text-muted)]"><${TimeAgo} timestamp=${post.created_at} /></span>
             <span class="text-2xs text-[var(--text-muted)]">${post.votes ?? 0} votes</span>
           </div>

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -12,7 +12,13 @@ import { RichContent } from './common/rich-content'
 import { stripStateBlocks } from '../keeper-message'
 import { navigate, navigateToPost, route } from '../router'
 import { PostDetail } from './memory-post-detail'
-import { stripInlineMarkdown, navigateToAuthor } from '../lib/board-utils'
+import {
+  boardActorAvatarKey,
+  boardActorDisplayName,
+  boardActorTitle,
+  navigateToAuthor,
+  stripInlineMarkdown,
+} from '../lib/board-utils'
 import { hasRichMarkdownSignals } from './common/rich-content-utils'
 import {
   boardPosts,
@@ -351,6 +357,9 @@ function PostCard({ post }: { post: BoardPost }) {
   const isDeleting = deletingPostId.value === post.id
   const previewBody = stripStateBlocks(post.body)
   const richPreview = hasRichMarkdownSignals(previewBody)
+  const authorLabel = boardActorDisplayName(post.author, post.author_identity)
+  const authorAvatarKey = boardActorAvatarKey(post.author, post.author_identity)
+  const authorTitle = boardActorTitle(post.author, post.author_identity)
 
   const handleVote = async (dir: 'up' | 'down', event: Event) => {
     event.stopPropagation()
@@ -427,11 +436,12 @@ function PostCard({ post }: { post: BoardPost }) {
         <!-- Footer: author + meta + badges -->
         <div class="flex items-center gap-2 flex-wrap">
           <!-- Author line -->
-          <span class="text-xs text-[var(--text-muted)]">${authorAvatar(post.author)}</span>
+          <span class="text-xs text-[var(--text-muted)]">${authorAvatar(authorAvatarKey)}</span>
           <a
             class="text-xs text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors cursor-pointer"
-            onClick=${(e: Event) => navigateToAuthor(post.author, e)}
-          >${post.author}</a>
+            title=${authorTitle}
+            onClick=${(e: Event) => navigateToAuthor(post.author, e, post.author_identity)}
+          >${authorLabel}</a>
           <span class="text-2xs text-[var(--text-muted)] opacity-60"><${TimeAgo} timestamp=${post.created_at} /></span>
           ${isUpdated(post) ? html`<span class="text-3xs text-[var(--text-muted)] opacity-50">(수정됨)</span>` : null}
 

--- a/dashboard/src/lib/board-utils.ts
+++ b/dashboard/src/lib/board-utils.ts
@@ -3,6 +3,7 @@
 import { navigate } from '../router'
 import { findKeeper } from './keeper-utils'
 import { openKeeperDetail } from '../components/keeper-detail'
+import type { BoardActorIdentity } from '../types'
 
 /** Strip inline markdown formatting from title text (bold, italic, code). */
 export function stripInlineMarkdown(text: string): string {
@@ -14,13 +15,55 @@ export function stripInlineMarkdown(text: string): string {
     .replace(/`(.+?)`/g, '$1')
 }
 
+export function boardActorDisplayName(
+  authorName: string,
+  identity?: BoardActorIdentity | null,
+): string {
+  const displayName = identity?.display_name?.trim()
+  return displayName || authorName
+}
+
+export function boardActorRuntimeName(
+  authorName: string,
+  identity?: BoardActorIdentity | null,
+): string | null {
+  const runtime = identity?.runtime_agent_name?.trim()
+  if (runtime) return runtime
+  const raw = identity?.raw?.trim()
+  if (raw && raw !== authorName) return raw
+  return null
+}
+
+export function boardActorAvatarKey(
+  authorName: string,
+  identity?: BoardActorIdentity | null,
+): string {
+  return identity?.key?.trim() || boardActorDisplayName(authorName, identity)
+}
+
+export function boardActorTitle(
+  authorName: string,
+  identity?: BoardActorIdentity | null,
+): string | undefined {
+  const runtime = boardActorRuntimeName(authorName, identity)
+  const display = boardActorDisplayName(authorName, identity)
+  return runtime && runtime !== display ? `런타임 ${runtime}` : undefined
+}
+
 /** Navigate to keeper detail if author is a keeper, otherwise agent profile. */
-export function navigateToAuthor(authorName: string, event?: Event) {
+export function navigateToAuthor(
+  authorName: string,
+  event?: Event,
+  identity?: BoardActorIdentity | null,
+) {
   event?.stopPropagation()
-  const keeper = findKeeper(authorName)
+  const keeper =
+    identity?.kind === 'keeper'
+      ? findKeeper(identity.id) ?? findKeeper(identity.raw) ?? findKeeper(authorName)
+      : findKeeper(authorName)
   if (keeper) {
     openKeeperDetail(keeper)
   } else {
-    navigate('monitoring', { section: 'agents', agent: authorName })
+    navigate('monitoring', { section: 'agents', agent: identity?.raw ?? authorName })
   }
 }

--- a/dashboard/src/lib/keeper-utils.ts
+++ b/dashboard/src/lib/keeper-utils.ts
@@ -2,11 +2,21 @@
 
 import { keepers } from '../store'
 import type { Keeper } from '../types'
+import {
+  canonicalKeeperNameFromAgentName,
+  keeperIdentityKeys,
+} from '../components/common/keeper-identity'
 
 /** Find a keeper by name or agent_name. Returns null when not found or name is empty. */
 export function findKeeper(name?: string | null): Keeper | null {
   if (!name) return null
-  return keepers.value.find(k => k.name === name || k.agent_name === name) ?? null
+  const needle = name.trim().toLowerCase()
+  if (!needle) return null
+  const alias = canonicalKeeperNameFromAgentName(name)?.toLowerCase() ?? null
+  return keepers.value.find(k => {
+    const keys = keeperIdentityKeys(k.keeper_id, k.name, k.agent_name)
+    return keys.includes(needle) || (alias !== null && keys.includes(alias))
+  }) ?? null
 }
 
 /**

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -349,6 +349,7 @@ function handleBoardPostCreated(event: SSEEvent): boolean {
   const post: BoardPost = {
     id: postId,
     author: event.author ?? '',
+    author_identity: event.author_identity ?? null,
     title: event.title ?? '',
     body: content,
     content,

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -99,6 +99,11 @@ function actorLabel(name: string | undefined): string {
   return normalized || 'system'
 }
 
+function projectedActorLabel(raw: string | undefined, displayName: string | undefined): string {
+  const projected = displayName?.trim()
+  return actorLabel(projected || raw)
+}
+
 function asString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() !== '' ? value : undefined
 }
@@ -350,38 +355,44 @@ function handleEvent(event: SSEEvent): void {
       break
     case 'board_post':
     case 'masc/board_post':
-      addTypedJournalEntry(
-        agent,
-        formatBoardJournalText('Post', event.content ?? event.message),
-        'board',
-        'board_post',
-        {
-          author: event.author ?? agent,
-          severity: event.severity,
-          source: event.source,
-          narrativeText: formatBoardNarrative('게시글', event.author ?? agent, event.content ?? event.message),
-          preview: normalizePreview(event.content ?? event.message),
-          postId: event.post_id,
-        },
-      )
-      break
+      {
+        const author = projectedActorLabel(event.author ?? agent, event.author_identity?.display_name)
+        addTypedJournalEntry(
+          author,
+          formatBoardJournalText('Post', event.content ?? event.message),
+          'board',
+          'board_post',
+          {
+            author,
+            severity: event.severity,
+            source: event.source,
+            narrativeText: formatBoardNarrative('게시글', author, event.content ?? event.message),
+            preview: normalizePreview(event.content ?? event.message),
+            postId: event.post_id,
+          },
+        )
+        break
+      }
     case 'board_comment':
     case 'masc/board_comment':
-      addTypedJournalEntry(
-        agent,
-        formatBoardJournalText('Comment', event.content ?? event.message),
-        'board',
-        'board_comment',
-        {
-          author: event.author ?? agent,
-          severity: event.severity,
-          source: event.source,
-          narrativeText: formatBoardNarrative('댓글', event.author ?? agent, event.content ?? event.message),
-          preview: normalizePreview(event.content ?? event.message),
-          postId: event.post_id,
-        },
-      )
-      break
+      {
+        const author = projectedActorLabel(event.author ?? agent, event.author_identity?.display_name)
+        addTypedJournalEntry(
+          author,
+          formatBoardJournalText('Comment', event.content ?? event.message),
+          'board',
+          'board_comment',
+          {
+            author,
+            severity: event.severity,
+            source: event.source,
+            narrativeText: formatBoardNarrative('댓글', author, event.content ?? event.message),
+            preview: normalizePreview(event.content ?? event.message),
+            postId: event.post_id,
+          },
+        )
+        break
+      }
     case 'board_delete':
     case 'masc/board_delete':
       removeBoardPost(event.post_id)
@@ -402,66 +413,78 @@ function handleEvent(event: SSEEvent): void {
     // Path A board events — emitted by server_bootstrap_loops.ml via
     // JSON-RPC notifications/board envelope (unwrapped to params.type).
     case 'post_created':
-      addTypedJournalEntry(
-        event.author ?? agent,
-        formatBoardJournalText('Post', event.content ?? event.title),
-        'board',
-        'board_post',
-        {
-          author: event.author ?? agent,
-          severity: event.severity,
-          source: event.source,
-          narrativeText: formatBoardNarrative('게시글', event.author ?? agent, event.content ?? event.title),
-          preview: normalizePreview(event.content ?? event.title),
-          postId: event.post_id,
-        },
-      )
-      break
+      {
+        const author = projectedActorLabel(event.author ?? agent, event.author_identity?.display_name)
+        addTypedJournalEntry(
+          author,
+          formatBoardJournalText('Post', event.content ?? event.title),
+          'board',
+          'board_post',
+          {
+            author,
+            severity: event.severity,
+            source: event.source,
+            narrativeText: formatBoardNarrative('게시글', author, event.content ?? event.title),
+            preview: normalizePreview(event.content ?? event.title),
+            postId: event.post_id,
+          },
+        )
+        break
+      }
     case 'comment_added':
-      addTypedJournalEntry(
-        event.author ?? agent,
-        formatBoardJournalText('Comment', event.content),
-        'board',
-        'board_comment',
-        {
-          author: event.author ?? agent,
-          severity: event.severity,
-          source: event.source,
-          narrativeText: formatBoardNarrative('댓글', event.author ?? agent, event.content),
-          preview: normalizePreview(event.content),
-          postId: event.post_id,
-        },
-      )
-      break
+      {
+        const author = projectedActorLabel(event.author ?? agent, event.author_identity?.display_name)
+        addTypedJournalEntry(
+          author,
+          formatBoardJournalText('Comment', event.content),
+          'board',
+          'board_comment',
+          {
+            author,
+            severity: event.severity,
+            source: event.source,
+            narrativeText: formatBoardNarrative('댓글', author, event.content),
+            preview: normalizePreview(event.content),
+            postId: event.post_id,
+          },
+        )
+        break
+      }
     case 'post_voted':
-      addTypedJournalEntry(
-        event.voter ?? agent,
-        `Vote ${event.direction ?? '?'} on post ${event.post_id ?? ''}`,
-        'board',
-        'board_vote',
-        {
-          author: event.voter ?? agent,
-          severity: event.severity,
-          source: event.source,
-          narrativeText: `${actorLabel(event.voter ?? agent)}가 게시글에 ${event.direction === 'up' ? '추천' : '비추천'} 투표했습니다`,
-          postId: event.post_id,
-        },
-      )
-      break
+      {
+        const voter = projectedActorLabel(event.voter ?? agent, event.voter_identity?.display_name)
+        addTypedJournalEntry(
+          voter,
+          `Vote ${event.direction ?? '?'} on post ${event.post_id ?? ''}`,
+          'board',
+          'board_vote',
+          {
+            author: voter,
+            severity: event.severity,
+            source: event.source,
+            narrativeText: `${actorLabel(voter)}가 게시글에 ${event.direction === 'up' ? '추천' : '비추천'} 투표했습니다`,
+            postId: event.post_id,
+          },
+        )
+        break
+      }
     case 'comment_voted':
-      addTypedJournalEntry(
-        event.voter ?? agent,
-        `Vote ${event.direction ?? '?'} on comment ${event.comment_id ?? ''}`,
-        'board',
-        'board_vote',
-        {
-          author: event.voter ?? agent,
-          severity: event.severity,
-          source: event.source,
-          narrativeText: `${actorLabel(event.voter ?? agent)}가 댓글에 ${event.direction === 'up' ? '추천' : '비추천'} 투표했습니다`,
-        },
-      )
-      break
+      {
+        const voter = projectedActorLabel(event.voter ?? agent, event.voter_identity?.display_name)
+        addTypedJournalEntry(
+          voter,
+          `Vote ${event.direction ?? '?'} on comment ${event.comment_id ?? ''}`,
+          'board',
+          'board_vote',
+          {
+            author: voter,
+            severity: event.severity,
+            source: event.source,
+            narrativeText: `${actorLabel(voter)}가 댓글에 ${event.direction === 'up' ? '추천' : '비추천'} 투표했습니다`,
+          },
+        )
+        break
+      }
     case 'keeper_turn_complete':
       addTypedJournalEntry(
         event.name ?? agent,

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -37,6 +37,11 @@ import {
   normalizeKeepers,
 } from './keeper-store-normalize'
 import { buildAgentMotion, normalizeAgentKey, type AgentMotionSnapshot } from './components/common/agent-motion'
+import {
+  canonicalKeeperNameFromAgentName,
+  keeperIdentityKeys,
+  keeperPrincipalKey,
+} from './components/common/keeper-identity'
 import { groupByKey } from './components/common/collection'
 import { setArrayByKeyIfChanged } from './signal-utils'
 import { FetchScheduler } from './lib/fetch-scheduler'
@@ -308,6 +313,41 @@ export const tasksByStatus = computed(() => {
   }
 })
 
+function keeperPrincipalLookup(keeperList: Keeper[]): Map<string, string> {
+  const lookup = new Map<string, string>()
+  for (const keeper of keeperList) {
+    const principal =
+      keeperPrincipalKey(keeper.keeper_id, keeper.name, keeper.agent_name)
+      ?? normalizeAgentKey(keeper.name)
+    for (const key of keeperIdentityKeys(keeper.keeper_id, keeper.name, keeper.agent_name)) {
+      lookup.set(normalizeAgentKey(key), principal)
+    }
+  }
+  return lookup
+}
+
+function actorPrincipalKey(
+  value: string | null | undefined,
+  lookup: ReadonlyMap<string, string>,
+): string {
+  const raw = normalizeAgentKey(value)
+  if (!raw) return raw
+  const known = lookup.get(raw)
+  if (known) return known
+  const alias = canonicalKeeperNameFromAgentName(value)
+  return alias ? `keeper:${alias.toLowerCase()}` : raw
+}
+
+function boardPostPrincipalKey(
+  post: BoardPost,
+  lookup: ReadonlyMap<string, string>,
+): string {
+  const rawResolved = actorPrincipalKey(post.author, lookup)
+  if (rawResolved !== normalizeAgentKey(post.author)) return rawResolved
+  const projected = post.author_identity?.key
+  return projected ? normalizeAgentKey(projected) : rawResolved
+}
+
 export const agentMotionMap: ReadonlySignal<Map<string, AgentMotionSnapshot>> = computed(() => {
   const map = new Map<string, AgentMotionSnapshot>()
   const taskList = tasks.value
@@ -315,17 +355,22 @@ export const agentMotionMap: ReadonlySignal<Map<string, AgentMotionSnapshot>> = 
   const journalList = journal.value
   const boardPostList = boardPosts.value
   const keeperList = keepers.value
+  const keeperLookup = keeperPrincipalLookup(keeperList)
 
   // Pre-index: one pass per array — O(N) total instead of O(N * agents)
-  const tasksByAgent = groupByKey(taskList, t => normalizeAgentKey(t.assignee))
-  const messagesByAgent = groupByKey(messageList, m => normalizeAgentKey(m.from ?? ''))
-  const journalByAgent = groupByKey(journalList, e => normalizeAgentKey(e.agent))
-  const journalByAuthor = groupByKey(journalList, e => normalizeAgentKey(e.author))
-  const boardByAgent = groupByKey(boardPostList, p => normalizeAgentKey(p.author))
-  const keepersByAgent = groupByKey(keeperList, k => normalizeAgentKey(k.name))
+  const tasksByAgent = groupByKey(taskList, t => actorPrincipalKey(t.assignee, keeperLookup))
+  const messagesByAgent = groupByKey(messageList, m => actorPrincipalKey(m.from ?? '', keeperLookup))
+  const journalByAgent = groupByKey(journalList, e => actorPrincipalKey(e.agent, keeperLookup))
+  const journalByAuthor = groupByKey(journalList, e => actorPrincipalKey(e.author, keeperLookup))
+  const boardByAgent = groupByKey(boardPostList, p => boardPostPrincipalKey(p, keeperLookup))
+  const keepersByAgent = groupByKey(
+    keeperList,
+    k => keeperPrincipalKey(k.keeper_id, k.name, k.agent_name) ?? normalizeAgentKey(k.name),
+  )
 
   for (const agent of agents.value) {
-    const key = normalizeAgentKey(agent.name)
+    const rawKey = normalizeAgentKey(agent.name)
+    const key = actorPrincipalKey(agent.name, keeperLookup)
     // Merge journal entries matched by agent OR author (deduplicate)
     const agentJournal = journalByAgent.get(key) ?? []
     const authorJournal = journalByAuthor.get(key) ?? []
@@ -335,20 +380,19 @@ export const agentMotionMap: ReadonlySignal<Map<string, AgentMotionSnapshot>> = 
         ? agentJournal
         : agentJournal.concat(authorJournal)
 
-    map.set(
-      key,
-      buildAgentMotion(
-        tasksByAgent.get(key) ?? [],
-        messagesByAgent.get(key) ?? [],
-        mergedJournal,
-        {
-          currentTask: agent.current_task,
-          lastSeen: agent.last_seen,
-          boardPosts: boardByAgent.get(key) ?? [],
-          keepers: keepersByAgent.get(key) ?? [],
-        },
-      ),
+    const snapshot = buildAgentMotion(
+      tasksByAgent.get(key) ?? [],
+      messagesByAgent.get(key) ?? [],
+      mergedJournal,
+      {
+        currentTask: agent.current_task,
+        lastSeen: agent.last_seen,
+        boardPosts: boardByAgent.get(key) ?? [],
+        keepers: keepersByAgent.get(key) ?? [],
+      },
     )
+    map.set(rawKey, snapshot)
+    map.set(key, snapshot)
   }
   return map
 })
@@ -728,8 +772,21 @@ function sameStringArray(a: string[] | undefined, b: string[] | undefined): bool
   return left.length === right.length && left.every((value, index) => value === right[index])
 }
 
+function sameBoardAuthorIdentity(previous: BoardPost, next: BoardPost): boolean {
+  const left = previous.author_identity
+  const right = next.author_identity
+  return (left?.kind ?? null) === (right?.kind ?? null)
+    && (left?.id ?? null) === (right?.id ?? null)
+    && (left?.key ?? null) === (right?.key ?? null)
+    && (left?.display_name ?? null) === (right?.display_name ?? null)
+    && (left?.raw ?? null) === (right?.raw ?? null)
+    && (left?.runtime_agent_name ?? null) === (right?.runtime_agent_name ?? null)
+}
+
 function canReuseBoardPost(previous: BoardPost, next: BoardPost): boolean {
   return previous.updated_at === next.updated_at
+    && previous.author === next.author
+    && sameBoardAuthorIdentity(previous, next)
     && previous.votes === next.votes
     && previous.vote_balance === next.vote_balance
     && previous.comment_count === next.comment_count

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -108,9 +108,19 @@ type BoardPostMeta = Record<string, unknown> & {
   judgment?: unknown
 }
 
+export interface BoardActorIdentity {
+  kind: 'keeper' | 'agent'
+  id: string
+  key: string
+  display_name: string
+  raw: string
+  runtime_agent_name?: string
+}
+
 export interface BoardPost {
   id: string
   author: string
+  author_identity?: BoardActorIdentity | null
   post_kind?: 'direct' | 'automation' | 'system'
   classification_reason?: string | null
   title: string
@@ -135,6 +145,7 @@ export interface BoardComment {
   post_id: string
   parent_id?: string | null
   author: string
+  author_identity?: BoardActorIdentity | null
   content: string
   created_at: string
 }

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -114,6 +114,7 @@ export interface BoardActorIdentity {
   key: string
   display_name: string
   raw: string
+  source?: 'keeper_registry_agent_name' | 'keeper_registry_name' | 'keeper_alias_contract' | 'raw_agent' | string
   runtime_agent_name?: string
 }
 

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -1,3 +1,5 @@
+import type { BoardActorIdentity } from './core'
+
 // --- SSE Events ---
 
 export type SSEEventType =
@@ -130,7 +132,9 @@ export interface SSEEvent {
   comment_id?: string
   title?: string
   author?: string
+  author_identity?: BoardActorIdentity | null
   voter?: string
+  voter_identity?: BoardActorIdentity | null
   direction?: 'up' | 'down' | string
   hearth?: string
   agent_name?: string

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -145,6 +145,7 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
           let base = [("type", `String "post_created");
                       ("post_id", `String post_id);
                       ("author", `String author);
+                      ("author_identity", Server_utils.board_actor_identity_json author);
                       ("title", `String title);
                       ("content", `String preview)] in
           `Assoc (match hearth with
@@ -154,18 +155,21 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
           `Assoc [("type", `String "comment_added");
                   ("post_id", `String post_id);
                   ("comment_id", `String comment_id);
-                  ("author", `String author)]
+                  ("author", `String author);
+                  ("author_identity", Server_utils.board_actor_identity_json author)]
       | Board_dispatch.Post_voted { post_id; voter; direction } ->
           let dir = Board_votes.vote_direction_to_string direction in
           `Assoc [("type", `String "post_voted");
                   ("post_id", `String post_id);
                   ("voter", `String voter);
+                  ("voter_identity", Server_utils.board_actor_identity_json voter);
                   ("direction", `String dir)]
       | Board_dispatch.Comment_voted { comment_id; voter; direction } ->
           let dir = Board_votes.vote_direction_to_string direction in
           `Assoc [("type", `String "comment_voted");
                   ("comment_id", `String comment_id);
                   ("voter", `String voter);
+                  ("voter_identity", Server_utils.board_actor_identity_json voter);
                   ("direction", `String dir)]
     in
     Sse.broadcast (`Assoc [
@@ -177,33 +181,39 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
     let activity_kind, activity_actor, activity_subject, activity_payload = match event with
       | Board_dispatch.Post_created { post_id; author; title; content; hearth } ->
           let base = [("post_id", `String post_id); ("title", `String title);
-                      ("content", `String content); ("author", `String author)] in
+                      ("content", `String content); ("author", `String author);
+                      ("author_identity", Server_utils.board_actor_identity_json author)] in
           let payload_fields = match hearth with
             | Some h -> ("hearth", `String h) :: base
             | None -> base
           in
           (Event_kind.Board.to_string Event_kind.Board.Posted,
-           Activity_graph.entity ~kind:"agent" author,
+           Server_utils.board_actor_entity author,
            Some (Activity_graph.entity ~kind:"post" post_id),
            `Assoc payload_fields)
       | Board_dispatch.Comment_added { post_id; comment_id; author } ->
           (Event_kind.Board.to_string Event_kind.Board.Commented,
-           Activity_graph.entity ~kind:"agent" author,
+           Server_utils.board_actor_entity author,
            Some (Activity_graph.entity ~kind:"post" post_id),
            `Assoc [("post_id", `String post_id); ("comment_id", `String comment_id);
-                   ("author", `String author)])
+                   ("author", `String author);
+                   ("author_identity", Server_utils.board_actor_identity_json author)])
       | Board_dispatch.Post_voted { post_id; voter; direction } ->
           let dir = Board_votes.vote_direction_to_string direction in
           (Event_kind.Board.to_string Event_kind.Board.Voted,
-           Activity_graph.entity ~kind:"agent" voter,
+           Server_utils.board_actor_entity voter,
            Some (Activity_graph.entity ~kind:"post" post_id),
-           `Assoc [("post_id", `String post_id); ("direction", `String dir)])
+           `Assoc [("post_id", `String post_id); ("voter", `String voter);
+                   ("voter_identity", Server_utils.board_actor_identity_json voter);
+                   ("direction", `String dir)])
       | Board_dispatch.Comment_voted { comment_id; voter; direction } ->
           let dir = Board_votes.vote_direction_to_string direction in
           (Event_kind.Board.to_string Event_kind.Board.Voted,
-           Activity_graph.entity ~kind:"agent" voter,
+           Server_utils.board_actor_entity voter,
            Some (Activity_graph.entity ~kind:"comment" comment_id),
-           `Assoc [("comment_id", `String comment_id); ("direction", `String dir)])
+           `Assoc [("comment_id", `String comment_id); ("voter", `String voter);
+                   ("voter_identity", Server_utils.board_actor_identity_json voter);
+                   ("direction", `String dir)])
     in
     ignore (Activity_graph.emit state.room_config
       ~actor:activity_actor ?subject:activity_subject

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -25,6 +25,7 @@ let dashboard_board_json ?hearth ?author_filter
     Yojson.Safe.t =
   let limit = clamp ~min_v:1 ~max_v:500 limit in
   let offset = clamp ~min_v:0 ~max_v:5000 offset in
+  let author_filter = Option.map board_actor_author_for_write author_filter in
   let cache_key =
     Printf.sprintf "board:memory:%s;%s;%s;%b;%b;%d;%d"
       (Option.value ~default:"-" hearth)
@@ -85,7 +86,8 @@ let dashboard_memory_http_json request : Yojson.Safe.t =
   let author_filter =
     query_param request "author"
     |> Option.map String.trim
-    |> Fun.flip Option.bind (fun s -> if s = "" then None else Some s)
+    |> Fun.flip Option.bind (fun s ->
+         if s = "" then None else Some (board_actor_author_for_write s))
   in
   let sort_by = board_sort_order_of_request request in
   let exclude_system = bool_query_param request "exclude_system" ~default:false in

--- a/lib/server/server_h2_gateway_routes_extra.ml
+++ b/lib/server/server_h2_gateway_routes_extra.ml
@@ -29,7 +29,8 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path
       let author_filter =
         query_param httpun_request "author"
         |> Option.map String.trim
-        |> Fun.flip Option.bind (fun s -> if s = "" then None else Some s)
+        |> Fun.flip Option.bind (fun s ->
+             if s = "" then None else Some (board_actor_author_for_write s))
       in
       let limit = int_query_param httpun_request "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
       let offset = int_query_param httpun_request "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -53,6 +53,29 @@ let json_ensure_meta_source source = function
   | _non_object ->
       Error "json_ensure_meta_source: expected JSON object"
 
+let json_ensure_meta_string_field name value = function
+  | `Assoc fields ->
+      let value = String.trim value in
+      if value = "" then Ok (`Assoc fields)
+      else
+        let meta_json =
+          match List.assoc_opt "meta" fields with
+          | Some (`Assoc meta_fields as existing_meta) -> (
+              match List.assoc_opt name meta_fields with
+              | Some (`String current) when String.trim current <> "" -> existing_meta
+              | _ ->
+                  `Assoc
+                    ((name, `String value)
+                    :: List.filter (fun (k, _) -> k <> name) meta_fields))
+          | _ -> `Assoc [ (name, `String value) ]
+        in
+        let fields =
+          ("meta", meta_json) :: List.filter (fun (k, _) -> k <> "meta") fields
+        in
+        Ok (`Assoc fields)
+  | _non_object ->
+      Error "json_ensure_meta_string_field: expected JSON object"
+
 let governance_surface_for_param_key param_key =
   Governance_registry.surfaces
   |> List.find_opt (fun (surface : Governance_registry.surface) ->
@@ -155,7 +178,8 @@ let add_routes ~sw ~clock router =
          let author_filter =
            query_param req "author"
            |> Option.map String.trim
-           |> Fun.flip Option.bind (fun s -> if s = "" then None else Some s)
+           |> Fun.flip Option.bind (fun s ->
+                if s = "" then None else Some (board_actor_author_for_write s))
          in
          let limit = int_query_param req "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
          let offset = int_query_param req "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
@@ -241,7 +265,8 @@ let add_routes ~sw ~clock router =
                try Ok (Yojson.Safe.from_string body_str)
                with Yojson.Json_error msg -> Error ("Invalid JSON: " ^ msg)
              in
-             let* args = json_upsert_string_field "voter" agent_name args in
+             let voter = board_actor_author_for_write agent_name in
+             let* args = json_upsert_string_field "voter" voter args in
              let (ok, msg) = Tool_board.handle_tool "masc_board_vote" args in
              let status = if ok then `OK else `Bad_request in
              respond_json_with_cors ~status request reqd
@@ -277,7 +302,12 @@ let add_routes ~sw ~clock router =
                try Ok (Yojson.Safe.from_string body_str)
                with Yojson.Json_error msg -> Error ("Invalid JSON: " ^ msg)
              in
-             let* args = json_upsert_string_field "author" agent_name args in
+             let author = board_actor_author_for_write agent_name in
+             let* args = json_upsert_string_field "author" author args in
+             let* args =
+               if String.equal author (String.trim agent_name) then Ok args
+               else json_ensure_meta_string_field "author_raw_agent_name" agent_name args
+             in
              let* args = json_ensure_meta_source "dashboard_board_post" args in
              let (ok, msg) = Tool_board.handle_tool "masc_board_post" args in
              let status = if ok then `Created else `Bad_request in
@@ -314,7 +344,8 @@ let add_routes ~sw ~clock router =
                try Ok (Yojson.Safe.from_string body_str)
                with Yojson.Json_error msg -> Error ("Invalid JSON: " ^ msg)
              in
-             let* args = json_upsert_string_field "author" agent_name args in
+             let author = board_actor_author_for_write agent_name in
+             let* args = json_upsert_string_field "author" author args in
              let (ok, msg) = Tool_board.handle_tool "masc_board_comment" args in
              let status = if ok then `Created else `Bad_request in
              respond_json_with_cors ~status request reqd

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -196,7 +196,7 @@ let board_post_detail_json ~response_format ~post_id =
         | Error _ -> []
       in
       let post_json = board_post_dashboard_json ~author_karma post in
-      let comments_json = `List (List.map Board.comment_to_yojson comments) in
+      let comments_json = `List (List.map board_comment_dashboard_json comments) in
       let json =
         if String.equal (String.lowercase_ascii (String.trim response_format)) "flat" then
           match post_json with

--- a/lib/server/server_utils.ml
+++ b/lib/server/server_utils.ml
@@ -51,6 +51,62 @@ let filter_board_posts ~exclude_system ~exclude_automation posts =
   |> List.filter
        (Board.post_matches_filters ~exclude_system ~exclude_automation)
 
+let board_actor_key ~kind id =
+  kind ^ ":" ^ String.lowercase_ascii (String.trim id)
+
+let board_actor_keeper_identity raw =
+  let raw = String.trim raw in
+  if raw = "" then None
+  else
+    match Keeper_registry.find_by_agent_name raw with
+    | Some entry -> Some (entry.name, Some entry.meta.agent_name)
+    | None -> (
+        match Keeper_registry.find_by_name raw with
+        | Some entry -> Some (entry.name, Some entry.meta.agent_name)
+        | None -> (
+            match Keeper_identity.canonical_keeper_name_from_agent_name raw with
+            | Some name -> Some (name, Some raw)
+            | None -> None))
+
+let board_actor_identity_json raw : Yojson.Safe.t =
+  let raw = String.trim raw in
+  match board_actor_keeper_identity raw with
+  | Some (keeper_name, runtime_agent_name) ->
+      let runtime_fields =
+        match runtime_agent_name with
+        | Some runtime when String.trim runtime <> "" && not (String.equal runtime keeper_name) ->
+            [ ("runtime_agent_name", `String runtime) ]
+        | _ -> []
+      in
+      `Assoc
+        ([
+           ("kind", `String "keeper");
+           ("id", `String keeper_name);
+           ("key", `String (board_actor_key ~kind:"keeper" keeper_name));
+           ("display_name", `String keeper_name);
+           ("raw", `String raw);
+         ]
+        @ runtime_fields)
+  | None ->
+      `Assoc
+        [
+          ("kind", `String "agent");
+          ("id", `String raw);
+          ("key", `String (board_actor_key ~kind:"agent" raw));
+          ("display_name", `String raw);
+          ("raw", `String raw);
+        ]
+
+let board_actor_entity raw =
+  match board_actor_keeper_identity raw with
+  | Some (keeper_name, _) -> Activity_graph.entity ~kind:"keeper" keeper_name
+  | None -> Activity_graph.entity ~kind:"agent" (String.trim raw)
+
+let board_actor_author_for_write raw =
+  match board_actor_keeper_identity raw with
+  | Some (keeper_name, _) -> keeper_name
+  | None -> String.trim raw
+
 let max_filtered_board_window = 5200
 
 let board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset =
@@ -58,7 +114,15 @@ let board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset =
   if exclude_system || exclude_automation then max base max_filtered_board_window
   else base
 
+let board_comment_dashboard_json (c : Board.comment) : Yojson.Safe.t =
+  let author = Board.Agent_id.to_string c.author in
+  match Board.comment_to_yojson c with
+  | `Assoc fields ->
+      `Assoc (fields @ [ ("author_identity", board_actor_identity_json author) ])
+  | other -> other
+
 let board_post_dashboard_json ~author_karma (p : Board.post) : Yojson.Safe.t =
+  let author = Board.Agent_id.to_string p.author in
   let base_fields =
     match Board_dispatch.post_to_yojson_with_karma p ~author_karma with
     | `Assoc fields -> fields
@@ -84,6 +148,7 @@ let board_post_dashboard_json ~author_karma (p : Board.post) : Yojson.Safe.t =
           ("created_at_iso", `String (iso8601_of_unix p.created_at));
           ("updated_at_iso", `String (iso8601_of_unix p.updated_at));
           ("hearth_count", `Int (match p.hearth with Some _ -> 1 | None -> 0));
+          ("author_identity", board_actor_identity_json author);
         ] )
 
 let dashboard_compact_mode request =

--- a/lib/server/server_utils.ml
+++ b/lib/server/server_utils.ml
@@ -59,19 +59,21 @@ let board_actor_keeper_identity raw =
   if raw = "" then None
   else
     match Keeper_registry.find_by_agent_name raw with
-    | Some entry -> Some (entry.name, Some entry.meta.agent_name)
+    | Some entry ->
+        Some (entry.name, Some entry.meta.agent_name, "keeper_registry_agent_name")
     | None -> (
         match Keeper_registry.find_by_name raw with
-        | Some entry -> Some (entry.name, Some entry.meta.agent_name)
+        | Some entry ->
+            Some (entry.name, Some entry.meta.agent_name, "keeper_registry_name")
         | None -> (
             match Keeper_identity.canonical_keeper_name_from_agent_name raw with
-            | Some name -> Some (name, Some raw)
+            | Some name -> Some (name, Some raw, "keeper_alias_contract")
             | None -> None))
 
 let board_actor_identity_json raw : Yojson.Safe.t =
   let raw = String.trim raw in
   match board_actor_keeper_identity raw with
-  | Some (keeper_name, runtime_agent_name) ->
+  | Some (keeper_name, runtime_agent_name, source) ->
       let runtime_fields =
         match runtime_agent_name with
         | Some runtime when String.trim runtime <> "" && not (String.equal runtime keeper_name) ->
@@ -85,6 +87,7 @@ let board_actor_identity_json raw : Yojson.Safe.t =
            ("key", `String (board_actor_key ~kind:"keeper" keeper_name));
            ("display_name", `String keeper_name);
            ("raw", `String raw);
+           ("source", `String source);
          ]
         @ runtime_fields)
   | None ->
@@ -95,16 +98,17 @@ let board_actor_identity_json raw : Yojson.Safe.t =
           ("key", `String (board_actor_key ~kind:"agent" raw));
           ("display_name", `String raw);
           ("raw", `String raw);
+          ("source", `String "raw_agent");
         ]
 
 let board_actor_entity raw =
   match board_actor_keeper_identity raw with
-  | Some (keeper_name, _) -> Activity_graph.entity ~kind:"keeper" keeper_name
+  | Some (keeper_name, _, _) -> Activity_graph.entity ~kind:"keeper" keeper_name
   | None -> Activity_graph.entity ~kind:"agent" (String.trim raw)
 
 let board_actor_author_for_write raw =
   match board_actor_keeper_identity raw with
-  | Some (keeper_name, _) -> keeper_name
+  | Some (keeper_name, _, _) -> keeper_name
   | None -> String.trim raw
 
 let max_filtered_board_window = 5200

--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -5,9 +5,17 @@
 
 let emit_activity config ~kind ~actor ?subject ?(tags = []) ~payload () =
   try
+    let payload =
+      match payload with
+      | `Assoc fields ->
+          `Assoc
+            (("actor_identity", Server_utils.board_actor_identity_json actor)
+            :: List.filter (fun (k, _) -> k <> "actor_identity") fields)
+      | other -> other
+    in
     ignore
       (Activity_graph.emit config
-         ~actor:(Activity_graph.entity ~kind:"agent" actor)
+         ~actor:(Server_utils.board_actor_entity actor)
          ?subject ~kind ~payload ~tags ())
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -31,29 +39,64 @@ let extract_board_post_id (message : string) =
       | Invalid_argument _
       | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
 
+let json_upsert_assoc_field name value fields =
+  (name, value) :: List.filter (fun (k, _) -> k <> name) fields
+
+let json_upsert_meta_string_field name value fields =
+  let value = String.trim value in
+  if value = "" then fields
+  else
+    let meta_json =
+      match List.assoc_opt "meta" fields with
+      | Some (`Assoc meta_fields) ->
+          `Assoc (json_upsert_assoc_field name (`String value) meta_fields)
+      | _ -> `Assoc [ (name, `String value) ]
+    in
+    json_upsert_assoc_field "meta" meta_json fields
+
+let canonicalize_board_actor_field field arguments =
+  match arguments with
+  | `Assoc fields -> (
+      match List.assoc_opt field fields with
+      | Some (`String raw) ->
+          let raw = String.trim raw in
+          if raw = "" then arguments
+          else
+            let canonical = Server_utils.board_actor_author_for_write raw in
+            if String.equal canonical raw then arguments
+            else
+              `Assoc
+                (json_upsert_assoc_field field (`String canonical) fields)
+      | _ -> arguments)
+  | _ -> arguments
+
 (** Fill [author] from the caller's agent identity when the arg is absent or
     blank. Keepers, the HTTP surface, and autonomous callers routinely omit
     [author] — we used to reject those calls at pre-hook validation, which
-    forced every caller to know about the legacy schema field. Canonical
-    identity lives in [agent_name]; mirror it into the arg object so the
-    downstream [Tool_board.handle_post_create] author check passes. *)
+    forced every caller to know about the legacy schema field. The board store
+    keeps canonical keeper names as principals while preserving raw runtime
+    agent names in metadata. *)
 let ensure_board_post_author ~agent_name arguments =
   match arguments with
-  | `Assoc fields ->
-    let existing =
-      match List.assoc_opt "author" fields with
-      | Some (`String s) -> String.trim s
-      | _ -> ""
-    in
-    if existing <> "" && existing <> "anonymous" then arguments
-    else
-      let injected = String.trim agent_name in
-      if injected = "" then arguments
+  | `Assoc fields -> (
+      let existing =
+        match List.assoc_opt "author" fields with
+        | Some (`String s) -> String.trim s
+        | _ -> ""
+      in
+      let raw_author =
+        if existing <> "" && existing <> "anonymous" then existing
+        else String.trim agent_name
+      in
+      if raw_author = "" then arguments
       else
-        let stripped =
-          List.filter (fun (k, _) -> k <> "author") fields
+        let canonical = Server_utils.board_actor_author_for_write raw_author in
+        let fields = json_upsert_assoc_field "author" (`String canonical) fields in
+        let fields =
+          if String.equal canonical raw_author then fields
+          else json_upsert_meta_string_field "author_raw_agent_name" raw_author fields
         in
-        `Assoc (("author", `String injected) :: stripped)
+        `Assoc fields)
   | _ -> arguments
 
 let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~sw ~clock ~name =
@@ -61,6 +104,9 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
   let arguments =
     match name with
     | "masc_board_post" -> ensure_board_post_author ~agent_name arguments
+    | "masc_board_comment" -> canonicalize_board_actor_field "author" arguments
+    | "masc_board_vote" | "masc_board_comment_vote" ->
+        canonicalize_board_actor_field "voter" arguments
     | _ -> arguments
   in
   let arg_get_string key default =
@@ -110,6 +156,7 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
         let notification = `Assoc [
           ("type", `String "masc/board_post");
           ("author", `String author);
+          ("author_identity", Server_utils.board_actor_identity_json author);
           ("content", `String (String.sub content 0 (min 200 (String.length content))));
           ("post_id", `String (Option.value post_id ~default:"unknown"));
           ("timestamp", `String (Types.now_iso ()));
@@ -177,6 +224,7 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
         let notification = `Assoc [
           ("type", `String "board_comment");
           ("author", `String author);
+          ("author_identity", Server_utils.board_actor_identity_json author);
           ("post_id", `String post_id);
           ("content", `String (String.sub content 0 (min 200 (String.length content))));
           ("timestamp", `String (Types.now_iso ()));

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -163,6 +163,8 @@ let test_board_actor_identity_canonicalizes_keeper_alias () =
   Alcotest.(check string) "key" "keeper:analyst" (json_member_string json "key");
   Alcotest.(check string) "raw" "keeper-analyst-agent"
     (json_member_string json "raw");
+  Alcotest.(check string) "source" "keeper_alias_contract"
+    (json_member_string json "source");
   Alcotest.(check string) "runtime agent" "keeper-analyst-agent"
     (json_member_string json "runtime_agent_name")
 
@@ -173,7 +175,9 @@ let test_board_actor_identity_keeps_non_keeper_agent () =
   let json = Server_utils.board_actor_identity_json "codex" in
   Alcotest.(check string) "kind" "agent" (json_member_string json "kind");
   Alcotest.(check string) "id" "codex" (json_member_string json "id");
-  Alcotest.(check string) "key" "agent:codex" (json_member_string json "key")
+  Alcotest.(check string) "key" "agent:codex" (json_member_string json "key");
+  Alcotest.(check string) "source" "raw_agent"
+    (json_member_string json "source")
 
 (** {2 Group 2: JSON helper functions} *)
 

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -148,6 +148,33 @@ let test_format_timestamp_relative () =
   let s3 = Tool_board.format_timestamp_relative minutes_ago in
   Alcotest.(check bool) "2min ago has 'm'" true (String.contains s3 'm')
 
+let json_member_string json key =
+  match Yojson.Safe.Util.member key json with
+  | `String value -> value
+  | _ -> Alcotest.failf "expected string field %s" key
+
+let test_board_actor_identity_canonicalizes_keeper_alias () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let json = Server_utils.board_actor_identity_json "keeper-analyst-agent" in
+  Alcotest.(check string) "kind" "keeper" (json_member_string json "kind");
+  Alcotest.(check string) "id" "analyst" (json_member_string json "id");
+  Alcotest.(check string) "key" "keeper:analyst" (json_member_string json "key");
+  Alcotest.(check string) "raw" "keeper-analyst-agent"
+    (json_member_string json "raw");
+  Alcotest.(check string) "runtime agent" "keeper-analyst-agent"
+    (json_member_string json "runtime_agent_name")
+
+let test_board_actor_identity_keeps_non_keeper_agent () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let json = Server_utils.board_actor_identity_json "codex" in
+  Alcotest.(check string) "kind" "agent" (json_member_string json "kind");
+  Alcotest.(check string) "id" "codex" (json_member_string json "id");
+  Alcotest.(check string) "key" "agent:codex" (json_member_string json "key")
+
 (** {2 Group 2: JSON helper functions} *)
 
 let test_get_string () =
@@ -724,6 +751,10 @@ let () =
           Alcotest.test_case "board_error_to_string" `Quick test_board_error_to_string;
           Alcotest.test_case "is_agent" `Quick test_is_agent;
           Alcotest.test_case "format_timestamp_relative" `Quick test_format_timestamp_relative;
+          Alcotest.test_case "board actor identity canonicalizes keeper alias"
+            `Quick test_board_actor_identity_canonicalizes_keeper_alias;
+          Alcotest.test_case "board actor identity keeps non-keeper agent"
+            `Quick test_board_actor_identity_keeps_non_keeper_agent;
         ] );
       ( "json_helpers",
         [


### PR DESCRIPTION
## Summary
- canonicalize keeper board authors/voters so `keeper-*-agent` aliases collapse to the keeper principal
- expose `author_identity` / `voter_identity` in board API, SSE, and activity graph payloads
- update dashboard display, navigation, and motion grouping to use projected board actor identity

## Tests
- `scripts/dune-local.sh build test/test_tool_board_coverage.exe`
- `./_build/default/test/test_tool_board_coverage.exe`
- `pnpm typecheck`
- `pnpm lint`
- `./node_modules/.bin/vitest run src/components/common/keeper-identity.test.ts --no-file-parallelism --maxWorkers=1 --reporter=verbose`
- `./node_modules/.bin/vitest run src/schemas/sse.test.ts src/journal-entry.test.ts --no-file-parallelism --maxWorkers=1 --reporter=verbose`