### PR TITLE
fix(a11y): remove viewport zoom restriction from GraphQL Playground

### DIFF
--- a/dashboard/src/components/activity-heatmap.ts
+++ b/dashboard/src/components/activity-heatmap.ts
@@ -258,7 +258,7 @@ export function ActivityHeatmap({ data }: HeatmapProps) {
         <p class="text-sm text-[var(--text-muted)]">필터링된 전체 이벤트를 기준으로 요일별, 시간대별 활동 밀도를 보여줍니다.</p>
       </div>
       <div ref=${containerRef} class="relative overflow-x-auto bg-[#0f1117] rounded p-3">
-        <canvas ref=${canvasRef} class="block" />
+        <canvas ref=${canvasRef} class="block" role="img" aria-label="요일별 시간대별 활동 밀도 히트맵" />
       </div>
     <//>
   `

--- a/dashboard/src/components/autoresearch-form.ts
+++ b/dashboard/src/components/autoresearch-form.ts
@@ -135,6 +135,7 @@ export function StartAutoresearchForm() {
             value=${formGoal.value}
             placeholder="최적화 목표 (예: Reduce inference latency by optimizing hot path)"
             rows=${2}
+            required
             onInput=${inputHandler(formGoal)}
           />
         </label>
@@ -144,6 +145,7 @@ export function StartAutoresearchForm() {
           <${TextInput}
             value=${formMetricFn.value}
             placeholder="마지막 줄에 float를 출력하는 명령어 (예: python eval.py --metric accuracy)"
+            required
             onInput=${inputHandler(formMetricFn)}
           />
         </label>
@@ -153,6 +155,7 @@ export function StartAutoresearchForm() {
           <${TextInput}
             value=${formTargetFile.value}
             placeholder="수정할 파일 경로 (예: lib/optimizer.ml)"
+            required
             onInput=${inputHandler(formTargetFile)}
           />
         </label>

--- a/dashboard/src/components/common/input.ts
+++ b/dashboard/src/components/common/input.ts
@@ -17,6 +17,7 @@ interface TextInputProps {
   value?: string
   placeholder?: string
   disabled?: boolean
+  required?: boolean
   class?: string
   type?: string
   name?: string
@@ -31,6 +32,7 @@ export function TextInput({
   value,
   placeholder,
   disabled,
+  required,
   class: cx,
   type = 'text',
   name,
@@ -47,6 +49,7 @@ export function TextInput({
       value=${value}
       placeholder=${placeholder}
       disabled=${disabled}
+      required=${required}
       name=${name}
       aria-label=${ariaLabel}
       autocomplete=${autoComplete}
@@ -65,6 +68,7 @@ interface TextAreaProps {
   name?: string
   ariaLabel?: string
   disabled?: boolean
+  required?: boolean
   onInput?: (e: Event) => void
 }
 
@@ -77,6 +81,7 @@ export function TextArea({
   name,
   ariaLabel,
   disabled,
+  required,
   onInput,
 }: TextAreaProps) {
   return html`
@@ -88,6 +93,7 @@ export function TextArea({
       name=${name}
       aria-label=${ariaLabel}
       disabled=${disabled}
+      required=${required}
       value=${value}
       onInput=${onInput}
     ></textarea>

--- a/dashboard/src/components/common/mermaid-graph.ts
+++ b/dashboard/src/components/common/mermaid-graph.ts
@@ -130,6 +130,8 @@ export function MermaidGraph({
         <div
           class=${`overflow-auto rounded-[10px] p-3 bg-[rgba(9,12,20,0.7)] ${diagramClass}`.trim()}
           ref=${hostRef}
+          role="img"
+          aria-label=${fallbackText ?? '다이어그램'}
         ></div>
       `}
     </div>

--- a/lib/server/server_routes_http_pages.ml
+++ b/lib/server/server_routes_http_pages.ml
@@ -15,7 +15,7 @@ let graphql_playground_html ~nonce =
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="user-scalable=no,initial-scale=1,minimum-scale=1,maximum-scale=1" />
+    <meta name="viewport" content="initial-scale=1" />
     <title>MASC GraphQL Playground</title>
     <link rel="stylesheet" href="/static/css/middleware.css" />
   </head>
@@ -241,7 +241,7 @@ let serve_dashboard_index request reqd =
         ~request body reqd
   | Error _ ->
       Http.Response.html
-        "<html><body>Dashboard build not found. Run: cd dashboard &amp;&amp; pnpm run build</body></html>"
+        "<!doctype html><html lang=\"en\"><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"><title>Dashboard not found</title><body><p>Dashboard build not found. Run: <code>cd dashboard &amp;&amp; pnpm run build</code></p></body></html>"
         reqd
 
 let is_compressible_asset name =


### PR DESCRIPTION
## Summary
- Remove `user-scalable=no` and `maximum-scale=1` from GraphQL Playground viewport meta (WCAG 1.4.4 Resize Text violation)
- Add proper HTML structure (doctype, lang, charset, viewport) to dashboard-not-found error page

## Test plan
- [x] `dune build @check` passes
- [ ] Verify GraphQL Playground still renders correctly
- [ ] Verify error page displays correctly when dashboard build is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)