### PR TITLE
fix(keeper-turn): migrate keeper_msg write_meta to merged-CAS retry (#9733)

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -467,10 +467,29 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               let updated_meta =
                 update_direct_turn_meta lifecycle.updated_meta ~latency_ms result
               in
-              (match write_meta ctx.config updated_meta with
+              (* #9733: keeper_msg turn-completion is the same race shape
+                 as the unified-turn failure path — heartbeat updates
+                 [last_seen]/[joined_room_ids] in parallel and bumps
+                 [meta_version], so a bare [write_meta] loses the CAS
+                 race and silently drops the turn payload (usage tokens,
+                 trace_history, generation).  Use the same merged-CAS
+                 retry as [keeper_unified_turn.ml:1683] so the cycle
+                 payload wins at the cycle-owned fields and heartbeat-
+                 owned fields are taken from disk. *)
+              (match
+                 write_meta_with_merge
+                   ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+                   ctx.config updated_meta
+               with
                | Ok () -> ()
                | Error msg ->
-                   Log.Keeper.error "write_meta failed after keeper_msg turn: %s" msg);
+                   if is_version_conflict_error msg then
+                     Log.Keeper.warn
+                       "write_meta lost CAS race after retries (keeper_msg turn): %s"
+                       msg
+                   else
+                     Log.Keeper.error
+                       "write_meta failed after keeper_msg turn: %s" msg);
               (try
                  Keeper_unified_metrics.append_metrics_snapshot
                    ~config:ctx.config

--- a/test/dune
+++ b/test/dune
@@ -1236,6 +1236,11 @@
  (modules test_keeper_fs)
  (libraries masc_mcp alcotest yojson unix eio eio_main))
 
+(test
+ (name test_keeper_meta_heartbeat_retain_9733)
+ (modules test_keeper_meta_heartbeat_retain_9733)
+ (libraries masc_mcp fs_compat alcotest eio eio_main unix))
+
 ; ============================================================
 ; Executables (benchmarks, distributed tests, tools)
 ; ============================================================

--- a/test/test_keeper_meta_heartbeat_retain_9733.ml
+++ b/test/test_keeper_meta_heartbeat_retain_9733.ml
@@ -1,0 +1,158 @@
+(** #9733 keeper_msg turn migration: pin the contract that
+    [Keeper_types.write_meta_with_merge ~merge:heartbeat_fields_from_disk]
+    actually retains the disk-owned heartbeat fields after a CAS
+    retry, while letting the caller's payload win at the cycle-owned
+    fields.
+
+    The 2026-04-25 audit identified [keeper_turn.ml:470] (the
+    keeper_msg turn-completion path) as the last bare [write_meta]
+    call in turn-completion code.  The fix migrates it to
+    [write_meta_with_merge] using the same [heartbeat_fields_from_disk]
+    merge that [keeper_unified_turn.ml:1683] already uses.  This test
+    pins both halves of that merge so a future refactor of
+    [Keeper_meta_merge.heartbeat_fields_from_disk] cannot silently
+    regress either side.
+
+    The existing [test_keeper_meta_cas_retry.ml] verifies retry
+    succeeds; this test additionally verifies field ownership. *)
+
+open Alcotest
+open Masc_mcp
+
+let () = Server_startup_state.mark_state_ready ~backend_mode:"test"
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_keeper_meta_hb_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let ensure_fs env =
+  if not (Fs_compat.has_fs ()) then
+    Fs_compat.set_fs (Eio.Stdenv.fs env)
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else
+        Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let make_meta ~name =
+  match
+    Keeper_types.meta_of_json
+      (`Assoc
+        [
+          ("name", `String name);
+          ("agent_name", `String ("keeper-" ^ name ^ "-agent"));
+          ("trace_id", `String ("trace-" ^ name));
+          ("goal", `String "test keeper");
+          ("autoboot_enabled", `Bool false);
+        ])
+  with
+  | Ok m -> m
+  | Error e -> fail ("meta_of_json failed: " ^ e)
+
+(* The race we model:
+
+   - cycle fiber reads meta at version N (joined_room_ids=[r1])
+   - heartbeat fiber bumps disk to version N+1 with
+     joined_room_ids=[r1; r2]
+   - cycle fiber writes its payload (goal="cycle done") with the
+     stale joined_room_ids=[r1]
+
+   After [write_meta_with_merge ~merge:heartbeat_fields_from_disk]:
+
+   - on-disk goal must be "cycle done"  (caller wins)
+   - on-disk joined_room_ids must be [r1; r2]  (disk wins)
+   - on-disk meta_version must be > N+1       (we wrote past it) *)
+let test_caller_wins_cycle_disk_wins_heartbeat () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) (fun () ->
+    let config = Coord.default_config base_dir in
+    ignore (Coord.init config ~agent_name:(Some "operator"));
+    let name = "race9733" in
+    let m0 =
+      let m = make_meta ~name in
+      { m with joined_room_ids = ["r1"] }
+    in
+    (match Keeper_types.write_meta ~force:true config m0 with
+     | Ok () -> ()
+     | Error e -> fail ("seed write failed: " ^ e));
+    let caller_view = match Keeper_types.read_meta config name with
+      | Ok (Some m) -> m
+      | _ -> fail "seed read failed"
+    in
+    (* Heartbeat fiber: bumps version, adds room. *)
+    let heartbeat_payload =
+      { caller_view with joined_room_ids = ["r1"; "r2"] }
+    in
+    (match Keeper_types.write_meta config heartbeat_payload with
+     | Ok () -> ()
+     | Error e -> fail ("heartbeat write failed: " ^ e));
+    (* Cycle fiber: had stale joined_room_ids; writes its own
+       cycle payload. *)
+    let cycle_payload =
+      { caller_view with goal = "cycle done" }
+    in
+    (match
+       Keeper_types.write_meta_with_merge
+         ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+         config cycle_payload
+     with
+     | Ok () -> ()
+     | Error e -> fail ("merged retry failed: " ^ e));
+    let final = match Keeper_types.read_meta config name with
+      | Ok (Some m) -> m
+      | _ -> fail "final read failed"
+    in
+    check string "caller wins: goal" "cycle done" final.goal;
+    check (list string)
+      "disk wins: joined_room_ids preserved heartbeat update"
+      ["r1"; "r2"] final.joined_room_ids;
+    check bool "version moved past heartbeat write" true
+      (final.meta_version > heartbeat_payload.meta_version))
+
+(* Sanity: when no concurrent writer interferes, the merge function
+   is never called and behaviour matches plain
+   [write_meta_with_retry]. *)
+let test_no_race_writes_first_attempt () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) (fun () ->
+    let config = Coord.default_config base_dir in
+    ignore (Coord.init config ~agent_name:(Some "operator"));
+    let m0 = make_meta ~name:"smooth9733" in
+    (match
+       Keeper_types.write_meta_with_merge
+         ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+         config m0
+     with
+     | Ok () -> ()
+     | Error e -> fail ("first write failed: " ^ e));
+    let on_disk = match Keeper_types.read_meta config "smooth9733" with
+      | Ok (Some m) -> m
+      | _ -> fail "read failed"
+    in
+    check string "goal landed" "test keeper" on_disk.goal)
+
+let () =
+  run "Keeper meta heartbeat-retain merge (#9733)"
+    [
+      ( "merge-contract",
+        [
+          test_case "caller wins cycle, disk wins heartbeat" `Quick
+            test_caller_wins_cycle_disk_wins_heartbeat;
+          test_case "no race: first attempt succeeds" `Quick
+            test_no_race_writes_first_attempt;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

#9733 reports keeper cycle-completion writes lose data with
\`meta version conflict for X: expected N, disk has M+1\`
errors, silently dropping turn payload (usage tokens,
trace_history, generation).  Logs across 2026-04-{23..25} show
39 such errors across multiple keepers (janitor, sangsu, etc.).

Root cause: \`keeper_turn.ml:470\` (the keeper_msg turn-completion
path) used a bare \`write_meta\` while a heartbeat fiber bumped
\`meta_version\` in parallel.  CAS check fails, the cycle's
payload never lands.

The unified-turn path (\`keeper_unified_turn.ml:1683\`) and the
create_keeper path (\`keeper_turn_up_create.ml:25\`) had already
migrated to \`write_meta_with_merge\` using
\`Keeper_meta_merge.heartbeat_fields_from_disk\` (#9769).  This
PR moves the last in-tree turn-completion caller of bare
\`write_meta\` to the same pattern.

## Field-ownership contract

| field class | owner | examples |
|---|---|---|
| **cycle-owned** (caller wins) | turn-completion fiber | \`goal\`, \`usage\`, \`trace_history\`, \`generation\` |
| **heartbeat-owned** (disk wins) | heartbeat fiber | \`meta_version\`, \`joined_room_ids\`, \`last_seen_seq_by_room\` |

Cycle data is non-recoverable; heartbeat data is ephemeral and
resyncs on the next heartbeat tick.  The merge picks the right
side for each.

## What changed

- \`lib/keeper/keeper_turn.ml:470\` — bare \`write_meta\` →
  \`write_meta_with_merge ~merge:heartbeat_fields_from_disk\`,
  with a separate \`Log.Keeper.warn\` branch when CAS retries
  exhaust (so operators distinguish "version conflict drained
  the retries" from "write actually failed").

## Test plan

- [x] \`dune build --root . lib/\` clean
- [x] \`dune exec test/test_keeper_meta_heartbeat_retain_9733.exe\` — 2/2 pass:
  - **caller wins cycle, disk wins heartbeat**: race scenario where caller's stale \`joined_room_ids=[r1]\` is retained from disk as \`[r1; r2]\` (heartbeat update preserved) while caller's \`goal="cycle done"\` lands on disk;
  - **no race: first attempt succeeds**: smooth path is unchanged.
- [x] Existing \`test_keeper_meta_cas_retry\` continues to pass (this PR doesn't touch \`write_meta_with_retry\` or \`write_meta_with_merge\` themselves).
- [ ] Deploy: confirm the 39-error/4-day rate of "meta version conflict ... after keeper_msg turn" drops to near-zero.

## Sites surveyed but intentionally NOT migrated

| site | reason |
|---|---|
| \`tool_keeper.ml\` (3 sites), dashboard HTTP routes (3 sites), TOML reload (2 sites) | use \`~force:true\` — explicit user-action overrides where conflict is acceptable |
| \`keeper_supervisor.ml\` (3 sites), \`keeper_unified_turn.ml\` overflow-pause/sync, \`keeper_turn_up_update.ml\` | own ownership semantics; per-site review needed; out of this PR's scope |

## Refs

- #9764, #9769 (CLOSED): introduced \`write_meta_with_retry\` /
  \`write_meta_with_merge\` for the unified-turn path
- #10130 (PR #10131, open): boot-time atomic-orphan sweep — FD-leak /
  ENFILE failure mode that compounded this race in production
- #10061 (CLOSED): nick0cave re-sync storm — likely production trigger

## Do-not-merge

\`do-not-merge\` label set so the auto-merge pipeline does not
flip this Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)