### PR TITLE
fix(keeper-hooks): normalize empty response.model with sentinel + counter (#10083)

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -85,6 +85,46 @@ let canonical_model_id_of_telemetry ~model
       String.trim id
   | _ -> model
 
+(* #10083: sentinel label for metrics when [response.model] arrives
+   empty AND telemetry provides no canonical_model_id.  Keep the
+   merged #10103 vocabulary so existing dashboards keep one explicit
+   bucket for unattributed provider turns. [pricing_catalog_miss_total]
+   still fires; the sentinel only makes the miss debuggable. *)
+let empty_model_sentinel = "unknown_provider"
+
+let record_empty_model_fallback ~keeper_name ~source =
+  Prometheus.inc_counter
+    Prometheus.metric_after_turn_empty_model
+    ~labels:[ ("keeper_name", keeper_name); ("source", source) ] ()
+
+(* Normalize [response.model] for metric labels.  Three layers:
+     1. [response.model] if non-empty (normal path).
+     2. [canonical_model_id] from telemetry if non-empty (transport
+        omitted the top-level field but telemetry recovered it).
+     3. [empty_model_sentinel] - fail-loud so the metric bucket is
+        still searchable and [pricing_catalog_miss] carries a
+        diagnostic label.
+   Every fallback increments the AfterTurn empty-model counter with
+   [keeper_name] and [source] labels so we can see how often each
+   layer fires. *)
+let observed_model_label_of_response ?(keeper_name = "unknown_keeper")
+    (response : Oas.Types.api_response) =
+  let raw = response.model in
+  if String.trim raw <> "" then raw
+  else
+    let from_telemetry =
+      canonical_model_id_of_telemetry ~model:"" response.telemetry
+    in
+    if String.trim from_telemetry <> "" then begin
+      record_empty_model_fallback ~keeper_name
+        ~source:"telemetry_resolved";
+      from_telemetry
+    end else begin
+      record_empty_model_fallback ~keeper_name
+        ~source:"unknown_sentinel";
+      empty_model_sentinel
+    end
+
 let context_max_of_telemetry
     (telemetry : Oas.Types.inference_telemetry option) =
   match telemetry with
@@ -554,21 +594,14 @@ let make_hooks
       match event with
       | Oas.Hooks.AfterTurn { turn; response } ->
         let meta = !meta_ref in
-        (* #10083: OAS provider transports can return [response.model = ""]
-           on silent failure paths (kimi_cli empty-usage fallback, cascade
-           contract retry exhaustion).  Leaving it empty propagates to
-           every downstream metric label ([masc_after_turn_hook_total],
-           [masc_pricing_catalog_miss_total], [masc_llm_inference_duration_seconds])
-           as the literal key `""`, contaminating per-provider latency
-           histograms and making pricing catalog miss unobservable (which
-           provider is missing?).  Normalise to a stable sentinel
-           `unknown_provider` so the miss becomes grepable and
-           dashboards distinguish empty-model turns from legitimate ones.
-           CLAUDE.md anti-pattern #2: Unknown -> Permissive Default. *)
+        (* #10083: normalize empty [response.model] so metric labels
+           stay searchable and [pricing_catalog_miss] carries a
+           diagnostic label instead of the silent empty string.
+           Internal pricing/usage paths still see the resolved
+           [model] - pricing_for_model_opt on "unknown_provider" correctly
+           misses the catalog, matching the prior behaviour. *)
         let model =
-          match String.trim response.model with
-          | "" -> "unknown_provider"
-          | s -> s
+          observed_model_label_of_response ~keeper_name:meta.name response
         in
         let usage_trust =
           classify_usage_trust ?usage:response.usage ~model

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -289,6 +289,8 @@ let metric_after_turn_telemetry_missing =
   "masc_after_turn_telemetry_missing_total"
 let metric_after_turn_telemetry_zero_latency =
   "masc_after_turn_telemetry_zero_latency_total"
+let metric_after_turn_empty_model =
+  "masc_after_turn_empty_model_total"
 let metric_tasks = "masc_tasks_total"
 let metric_errors = "masc_errors_total"
 let metric_error_events = "masc_error_events_total"
@@ -355,6 +357,10 @@ let init () =
     "AfterTurn responses where response.telemetry was None." Counter;
   add metric_after_turn_telemetry_zero_latency
     "AfterTurn responses where telemetry was present but request_latency_ms was 0." Counter;
+  add metric_after_turn_empty_model
+    "AfterTurn responses whose top-level response.model was empty and had \
+     to be resolved from telemetry or an explicit sentinel (labels: \
+     keeper_name, source=telemetry_resolved|unknown_sentinel)." Counter;
   add metric_tasks "Total tasks processed" Counter;
   add metric_errors "Total errors" Counter;
   add metric_error_events

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -117,6 +117,7 @@ val metric_llm_decode_tok_per_sec : string
 val metric_after_turn_hook : string
 val metric_after_turn_telemetry_missing : string
 val metric_after_turn_telemetry_zero_latency : string
+val metric_after_turn_empty_model : string
 val metric_tasks : string
 val metric_errors : string
 val metric_error_events : string

--- a/test/dune
+++ b/test/dune
@@ -324,6 +324,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_empty_model_fallback)
+ (modules test_empty_model_fallback)
+ (libraries masc_test_deps))
+
+(test
  (name test_governance_cases_snapshot)
  (modules test_governance_cases_snapshot)
  (libraries masc_test_deps))

--- a/test/test_empty_model_fallback.ml
+++ b/test/test_empty_model_fallback.ml
@@ -1,0 +1,124 @@
+(* #10083: [observed_model_label_of_response] normalizes empty
+   [response.model] through a 3-tier fallback
+   (response.model -> canonical_model_id -> "unknown_provider") so metric
+   labels stay searchable and [pricing_catalog_miss] carries a
+   diagnostic label instead of the silent empty string. *)
+
+module KH = Masc_mcp.Keeper_hooks_oas
+module Prometheus = Masc_mcp.Prometheus
+
+(* Construct a minimal [Agent_sdk.Types.api_response].  We cannot
+   introspect the full record definition here, so we build the
+   fields we need through the public-facing [api_response] type
+   defined in [agent_sdk]. *)
+
+let empty_usage : Agent_sdk.Types.api_usage =
+  { input_tokens = 0;
+    output_tokens = 0;
+    cache_creation_input_tokens = 0;
+    cache_read_input_tokens = 0;
+    cost_usd = None }
+
+let empty_telemetry : Agent_sdk.Types.inference_telemetry =
+  { system_fingerprint = None;
+    timings = None;
+    reasoning_tokens = None;
+    request_latency_ms = 0;
+    peak_memory_gb = None;
+    provider_kind = None;
+    reasoning_effort = None;
+    canonical_model_id = None;
+    effective_context_window = None;
+    provider_internal_action_count = None }
+
+let make_response ?(model = "") ?telemetry ?usage () : Agent_sdk.Types.api_response =
+  {
+    id = "";
+    model;
+    content = [];
+    stop_reason = Agent_sdk.Types.EndTurn;
+    usage;
+    telemetry;
+  }
+
+let test_non_empty_model_passes_through () =
+  let before =
+    Prometheus.metric_total Prometheus.metric_after_turn_empty_model
+  in
+  let r = make_response ~model:"claude_code:auto" () in
+  Alcotest.(check string)
+    "model returned verbatim"
+    "claude_code:auto"
+    (KH.observed_model_label_of_response ~keeper_name:"test-nonempty" r);
+  Alcotest.(check (float 0.01))
+    "non-empty path does not increment fallback metric"
+    before
+    (Prometheus.metric_total Prometheus.metric_after_turn_empty_model)
+
+let test_empty_model_falls_back_to_telemetry () =
+  let labels =
+    [ ("keeper_name", "test-telemetry");
+      ("source", "telemetry_resolved") ]
+  in
+  let before =
+    Prometheus.metric_value_or_zero
+      Prometheus.metric_after_turn_empty_model ~labels ()
+  in
+  let telemetry =
+    { empty_telemetry with
+      canonical_model_id = Some "gpt-5.4-codex-spark" }
+  in
+  let r = make_response ~model:"" ~telemetry () in
+  Alcotest.(check string)
+    "telemetry canonical id used when response.model empty"
+    "gpt-5.4-codex-spark"
+    (KH.observed_model_label_of_response ~keeper_name:"test-telemetry" r);
+  Alcotest.(check (float 0.01))
+    "telemetry fallback increments source metric"
+    (before +. 1.0)
+    (Prometheus.metric_value_or_zero
+       Prometheus.metric_after_turn_empty_model ~labels ())
+
+let test_empty_and_no_telemetry_returns_sentinel () =
+  let labels =
+    [ ("keeper_name", "test-sentinel");
+      ("source", "unknown_sentinel") ]
+  in
+  let before =
+    Prometheus.metric_value_or_zero
+      Prometheus.metric_after_turn_empty_model ~labels ()
+  in
+  let r = make_response ~model:"" () in
+  Alcotest.(check string)
+    "sentinel used when both channels empty"
+    "unknown_provider"
+    (KH.observed_model_label_of_response ~keeper_name:"test-sentinel" r);
+  Alcotest.(check (float 0.01))
+    "sentinel fallback increments source metric"
+    (before +. 1.0)
+    (Prometheus.metric_value_or_zero
+       Prometheus.metric_after_turn_empty_model ~labels ())
+
+let test_empty_and_empty_telemetry_canonical_returns_sentinel () =
+  let telemetry =
+    { empty_telemetry with canonical_model_id = Some "   " }
+  in
+  let r = make_response ~model:"" ~telemetry () in
+  Alcotest.(check string)
+    "whitespace-only canonical id still falls through to sentinel"
+    "unknown_provider"
+    (KH.observed_model_label_of_response ~keeper_name:"test-whitespace" r)
+
+let () =
+  Alcotest.run "empty_model_fallback" [
+    "observed_model_label", [
+      Alcotest.test_case "non-empty passes through" `Quick
+        test_non_empty_model_passes_through;
+      Alcotest.test_case "empty -> telemetry canonical id" `Quick
+        test_empty_model_falls_back_to_telemetry;
+      Alcotest.test_case "empty + no telemetry -> sentinel" `Quick
+        test_empty_and_no_telemetry_returns_sentinel;
+      Alcotest.test_case "empty + whitespace canonical -> sentinel" `Quick
+        test_empty_and_empty_telemetry_canonical_returns_sentinel;
+    ];
+  ]


### PR DESCRIPTION
## Summary

Fixes the remaining #10083 telemetry gap on top of the already-merged
single-sentinel defense from #10103.

When an OAS transport returns `response.model = ""`, the AfterTurn hook now
uses a stable three-step label resolution path:

1. non-empty `response.model`
2. non-empty `response.telemetry.canonical_model_id`
3. explicit sentinel `unknown_provider`

Every fallback path increments
`masc_after_turn_empty_model_total{keeper_name,source}` with
`source=telemetry_resolved` or `source=unknown_sentinel`. This keeps the
current `unknown_provider` label vocabulary intact while making the recovery
source visible per keeper.

## Why

The original issue showed empty model labels in:

- `masc_after_turn_hook_total{model=""}`
- `masc_llm_inference_duration_seconds{model=""}`
- `masc_pricing_catalog_miss_total{model=""}`

That made latency and pricing misses unattributable. The merged #10103 stopped
the empty label leak; this PR adds the missing source/keeper counter and recovers
real model ids when telemetry has `canonical_model_id`.

## Validation

```bash
scripts/opam-pin-external-deps.sh --install
env DUNE_BUILD_DIR=_build_10083_pin_verify DUNE_JOBS=2 MASC_DUNE_THROTTLE=0 \
  scripts/dune-local.sh build \
  test/test_empty_model_fallback.exe \
  test/test_prometheus_coverage.exe \
  test/test_keeper_hooks_oas_provider.exe \
  test/test_keeper_hooks_oas_pricing.exe \
  test/test_keeper_hooks_oas_telemetry.exe \
  test/test_keeper_usage_trust_counter.exe

./_build_10083_pin_verify/default/test/test_empty_model_fallback.exe
./_build_10083_pin_verify/default/test/test_prometheus_coverage.exe
./_build_10083_pin_verify/default/test/test_keeper_hooks_oas_provider.exe
./_build_10083_pin_verify/default/test/test_keeper_hooks_oas_pricing.exe
./_build_10083_pin_verify/default/test/test_keeper_hooks_oas_telemetry.exe
./_build_10083_pin_verify/default/test/test_keeper_usage_trust_counter.exe
```

All six binaries passed locally.

## Notes

- This is still a MASC-side defensive layer. OAS transports should ultimately
  return non-empty model ids.
- The branch was rebased onto current `origin/main` after #10089 merged.

Closes #10083.
