### PR TITLE
fix(hebbian): run first consolidation immediately on fork (#9876)

### DIFF
--- a/lib/hebbian_eio.ml
+++ b/lib/hebbian_eio.ml
@@ -410,6 +410,38 @@ let get_graph_data config : (synapse list * string list) =
     passive cancellation — we do NOT run a final consolidation on
     shutdown because pruning on an unclean exit is riskier than
     skipping one cycle. *)
+let run_consolidation_once config ~decay_after_days =
+  let t0 = Time_compat.now () in
+  (try
+     let pruned = consolidate config ~decay_after_days () in
+     let elapsed = Time_compat.now () -. t0 in
+     Prometheus.inc_counter
+       "masc_hebbian_consolidate_total"
+       ~labels:[("outcome", "ok")] ();
+     if pruned > 0 then
+       Prometheus.inc_counter
+         "masc_hebbian_consolidate_pruned_total"
+         ~delta:(Float.of_int pruned) ();
+     Prometheus.observe_histogram
+       "masc_hebbian_consolidate_duration_seconds" elapsed;
+     if pruned > 0 then
+       Log.Coord.info
+         "hebbian: consolidated graph, pruned=%d duration=%.3fs"
+         pruned elapsed
+     else
+       Log.Coord.debug
+         "hebbian: consolidated graph, pruned=0 duration=%.3fs"
+         elapsed
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+     Prometheus.inc_counter
+       "masc_hebbian_consolidate_total"
+       ~labels:[("outcome", "error")] ();
+     Log.Coord.error
+       "hebbian: consolidation iteration failed: %s"
+       (Printexc.to_string exn))
+
 let start_consolidation_fiber ~sw ~clock config =
   let interval_s = Level2_config.Hebbian.consolidation_interval_s () in
   let decay_after_days =
@@ -419,38 +451,22 @@ let start_consolidation_fiber ~sw ~clock config =
     "hebbian: consolidation fiber starting (interval=%.0fs decay_after=%dd)"
     interval_s decay_after_days;
   Eio.Fiber.fork ~sw (fun () ->
+    (* #9876 followup: run one consolidation pass immediately so
+       [last_consolidation] never reads epoch zero on a live server.
+       Operators have hit the [last_consolidation = 0.0] signature
+       repeatedly as a "fiber never started" silent-failure
+       indicator; advancing the field on first iteration makes the
+       three observable states distinguishable:
+         - [0.0]: fiber actually never started (binary mismatch).
+         - [start_time + small delta]: fiber ran once, healthy.
+         - [stale + > interval_s old]: fiber wedged, real failure.
+       Pruning on a fresh graph is a no-op (every synapse's
+       [last_updated >= boot_time > cutoff]), so this changes no
+       data — only the [last_consolidation] timestamp. *)
+    run_consolidation_once config ~decay_after_days;
     let rec loop () =
       Eio.Time.sleep clock interval_s;
-      let t0 = Time_compat.now () in
-      (try
-         let pruned = consolidate config ~decay_after_days () in
-         let elapsed = Time_compat.now () -. t0 in
-         Prometheus.inc_counter
-           "masc_hebbian_consolidate_total"
-           ~labels:[("outcome", "ok")] ();
-         if pruned > 0 then
-           Prometheus.inc_counter
-             "masc_hebbian_consolidate_pruned_total"
-             ~delta:(Float.of_int pruned) ();
-         Prometheus.observe_histogram
-           "masc_hebbian_consolidate_duration_seconds" elapsed;
-         if pruned > 0 then
-           Log.Coord.info
-             "hebbian: consolidated graph, pruned=%d duration=%.3fs"
-             pruned elapsed
-         else
-           Log.Coord.debug
-             "hebbian: consolidated graph, pruned=0 duration=%.3fs"
-             elapsed
-       with
-       | Eio.Cancel.Cancelled _ as e -> raise e
-       | exn ->
-         Prometheus.inc_counter
-           "masc_hebbian_consolidate_total"
-           ~labels:[("outcome", "error")] ();
-         Log.Coord.error
-           "hebbian: consolidation iteration failed: %s"
-           (Printexc.to_string exn));
+      run_consolidation_once config ~decay_after_days;
       loop ()
     in
     loop ())

--- a/test/dune
+++ b/test/dune
@@ -338,6 +338,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_hebbian_first_consolidation)
+ (modules test_hebbian_first_consolidation)
+ (libraries masc_test_deps))
+
+(test
  (name test_governance_cases_snapshot)
  (modules test_governance_cases_snapshot)
  (libraries masc_test_deps))

--- a/test/test_hebbian_first_consolidation.ml
+++ b/test/test_hebbian_first_consolidation.ml
@@ -1,0 +1,87 @@
+(* #9876 follow-up: [start_consolidation_fiber] runs one
+   consolidation pass immediately on fork so [last_consolidation]
+   never reads epoch zero on a live server.  This test exercises
+   the extracted [run_consolidation_once] helper directly so it
+   does not need a clock or switch — the same code path runs
+   inside the fiber. *)
+
+open Masc_mcp
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let with_temp_masc_dir f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-9876-first-consol-%d-%d"
+         (Unix.getpid ())
+         (int_of_float (Unix.gettimeofday () *. 1000000.)))
+  in
+  Unix.mkdir base 0o755;
+  let config = Coord.default_config base in
+  let _ = Coord.init config ~agent_name:None in
+  Hebbian_eio.reset_lock_stats ();
+  Fun.protect ~finally:(fun () ->
+    let _ = Coord.reset config in
+    rm_rf base)
+    (fun () -> f config)
+
+let load_consolidation_ts config =
+  let g = Hebbian_eio.load_graph config in
+  g.last_consolidation
+
+let test_immediate_run_advances_last_consolidation () =
+  with_temp_masc_dir (fun config ->
+    (* Seed one synapse so the graph file exists with default
+       last_consolidation = 0.0 *)
+    Hebbian_eio.strengthen config
+      ~from_agent:"sangsu" ~to_agent:"issue-king" ();
+    Alcotest.(check (float 1e-9))
+      "boot graph has last_consolidation = 0"
+      0.0 (load_consolidation_ts config);
+    let before = Time_compat.now () in
+    Hebbian_eio.run_consolidation_once config ~decay_after_days:14;
+    let after_ts = load_consolidation_ts config in
+    Alcotest.(check bool)
+      "last_consolidation advanced past boot 0.0"
+      true (after_ts > 0.0);
+    Alcotest.(check bool)
+      "last_consolidation is recent (>= just before call)"
+      true (after_ts >= before -. 0.001))
+
+let test_idempotent_under_no_decay_horizon () =
+  (* With decay_after_days=14 and synapses created seconds ago,
+     no row meets the cutoff, so pruned=0 and the row data is
+     unchanged.  Only [last_consolidation] advances. *)
+  with_temp_masc_dir (fun config ->
+    Hebbian_eio.strengthen config
+      ~from_agent:"a" ~to_agent:"b" ();
+    let (before_synapses, _) = Hebbian_eio.get_graph_data config in
+    let s_before = List.hd before_synapses in
+    Hebbian_eio.run_consolidation_once config ~decay_after_days:14;
+    let (after_synapses, _) = Hebbian_eio.get_graph_data config in
+    Alcotest.(check int) "synapse count unchanged"
+      1 (List.length after_synapses);
+    let s_after = List.hd after_synapses in
+    Alcotest.(check int) "success_count preserved"
+      s_before.Hebbian_eio.success_count s_after.Hebbian_eio.success_count;
+    Alcotest.(check (float 1e-9)) "weight preserved"
+      s_before.Hebbian_eio.weight s_after.Hebbian_eio.weight)
+
+let () =
+  Alcotest.run "hebbian_first_consolidation" [
+    "first_pass", [
+      Alcotest.test_case "immediate run advances last_consolidation" `Quick
+        test_immediate_run_advances_last_consolidation;
+      Alcotest.test_case "no-decay run is idempotent on rows" `Quick
+        test_idempotent_under_no_decay_horizon;
+    ];
+  ]


### PR DESCRIPTION
## 요약

Hebbian consolidation fiber가 첫 cycle을 1시간 sleep한 후에 실행하던 동작을 변경 — fork 직후 즉시 1회 consolidation 실행. `last_consolidation = 0.0` (silent-failure 시그니처)을 부팅 후 수 초 안에 해소.

Closes #9876 (residual cleanup following #9914 / #10048).

## 근본 원인

`#9914`에서 `start_consolidation_fiber`을 추가했지만 sleep-then-consolidate 순서로 짜여 있음:

```ocaml
(* before *)
Eio.Fiber.fork ~sw (fun () ->
  let rec loop () =
    Eio.Time.sleep clock interval_s;   (* ← default 3600s *)
    consolidate config ...;
    loop ()
  in
  loop ())
```

운영 의미: 서버 부팅 후 첫 1시간 동안 `last_consolidation`은 그대로 epoch zero(0.0). 이 0.0은 운영자에게 학습된 **silent-failure 시그니처** — fiber가 시작 안 됐거나 첫 시도에서 silent crash 한 경우와 모양이 똑같음.

이슈 작성자도 같은 0.0을 보고 "the consolidation pass has never run, not just 'not recently.'"라고 진단했고 — 첫 시간이라면 정상이지만, 1시간 이상 운영 후에도 0.0이면 진짜 silent failure인지, 아직 첫 cycle 전인지 metric만으로 구분 불가.

## 변경 내용

```diff
+ let run_consolidation_once config ~decay_after_days =
+   let t0 = Time_compat.now () in
+   (try ... pruned = consolidate ...
+    with ... )
+
  let start_consolidation_fiber ~sw ~clock config =
    ...
    Eio.Fiber.fork ~sw (fun () ->
+     run_consolidation_once config ~decay_after_days;
      let rec loop () =
        Eio.Time.sleep clock interval_s;
+       run_consolidation_once config ~decay_after_days;
-       (try ... consolidate ...
-        with ... )
        loop ()
      in
      loop ())
```

루프 본문을 `run_consolidation_once`로 추출해 즉시 first-pass와 periodic 양쪽이 같은 metric/log 경로 공유.

## 동작

부팅 후 수 초 안에 metric 가능한 3가지 상태가 명확히 distinguishable:

| 관찰 | 의미 |
|------|------|
| `last_consolidation = 0.0` | fiber가 실제로 시작 못 함 (binary mismatch / dep miss / bootstrap fail) |
| `last_consolidation = boot_time + 작은 delta` | fiber 정상 동작, 이후 cycle마다 갱신 |
| `last_consolidation = stale (> interval_s 이상 old)` | fiber wedged (save_graph block, decay loop 무한 등) — 진짜 failure |

이전에는 셋 다 같은 0.0으로 보였음.

## 안전성

- **No data change**: 14일 decay horizon으로 부팅 직후 모든 synapse는 `last_updated > cutoff`이라 prune 대상 아님. `decayed = synapses` 그대로, `pruned = 0`.
- **No race**: `consolidate`은 `with_graph_lock` 안에서 read-modify-write. 부팅 직후 strengthen/weaken과의 race는 lock으로 방어.
- **No startup latency 영향**: fiber fork는 async. 즉시 실행되는 consolidation은 fiber 내부에서 진행, bootstrap 메인 thread block 안 함.

## 테스트

`test/test_hebbian_first_consolidation.ml` 2 scenario:

```bash
$ dune exec test/test_hebbian_first_consolidation.exe
[OK]  first_pass  0  immediate run advances last_consolidation past 0.0.
[OK]  first_pass  1  no-decay run is idempotent on rows.
Test Successful in 0.026s. 2 tests run.
```

기존 hebbian 테스트 regression check:
```bash
$ dune exec test/test_hebbian_eio.exe                     # 15/15
$ dune exec test/test_hebbian_edge_update_counter.exe     # 4/4
```

## 회귀 리스크

매우 낮음. Pure refactor + 1-line addition (`run_consolidation_once` immediate call). 기존 sleep+consolidate 동작은 loop 내부에서 그대로 유지. fiber 자체의 cancel/exception 경로 변경 없음.

## 후속 — 별건

이슈 본문은 더 큰 문제도 지적:
- **Synapse strengthen/weaken이 task Done/Cancel transition에서만 fire**: 432 turn outcomes 중 task 전이로 이어지는 비율이 작아서 graph가 거의 정지 상태로 보임. 이는 hebbian wiring을 turn-level로 확장하는 separate architectural 변경 필요.
- **`failure_count = 0` 모든 edge**: weaken이 task Cancel에서만 fire하지만 keeper turn 실패는 task Cancel으로 이어지지 않음. negative learning signal 부재 — 별건 #7763 family.

본 PR은 `last_consolidation` 시그니처 한정 fix.

## 참고

- Issue #9876 — 이 PR
- PR #9914 — consolidation fiber 첫 wiring
- PR #10048 — per-outcome edge counter
- `lib/hebbian_eio.ml:389-462` — fiber + extracted helper
- `test/test_hebbian_first_consolidation.ml` — coverage
