### PR TITLE
fix(keeper-usage-trust): flag Anthropic cache silence as trust anomaly (#9959)

### DIFF
--- a/lib/keeper/keeper_usage_trust.ml
+++ b/lib/keeper/keeper_usage_trust.ml
@@ -11,6 +11,35 @@ type t =
 
 let absurd_token_threshold = 1_000_000
 
+(* #9959: Anthropic prompt caching is enabled by default and reports
+   cache hits/creates via [cache_creation_input_tokens] and
+   [cache_read_input_tokens].  The production scan (1078 entries
+   across 9 keepers / 24h) found these fields at exactly zero on
+   100% of [claude_code:*] turns despite [input_tokens] regularly
+   exceeding 100k — the threshold beyond which caching pays off and
+   should be visible.  Treating this as a usage-trust anomaly gives
+   operators one Prometheus counter to alert on instead of having
+   to scan JSONL by hand.
+
+   Floor of 10k input tokens: below this, cache may legitimately
+   not engage (Anthropic caching has a minimum prompt size), so
+   silence is not yet diagnostic.  Above 10k, every observed
+   Anthropic turn should report at least some cache traffic over
+   the lifetime of the keeper. *)
+let anthropic_cache_floor_tokens = 10_000
+
+let model_looks_anthropic ~model_used ~resolved_model_id =
+  let probe s =
+    let s = String.lowercase_ascii s in
+    let has_prefix p =
+      String.length s >= String.length p
+      && String.sub s 0 (String.length p) = p
+    in
+    has_prefix "claude" || has_prefix "anthropic"
+    || has_prefix "claude_code:" || has_prefix "anthropic:"
+  in
+  probe model_used || probe resolved_model_id
+
 let is_trusted = function
   | Usage_trusted -> true
   | Usage_missing | Usage_untrusted _ -> false
@@ -66,6 +95,12 @@ let classify ~(usage_reported : bool)
       add "output_tokens_gt_1m";
     if context_max > 0 && usage.input_tokens > context_max * 2 then
       add "input_tokens_gt_2x_context_max";
+    (* #9959: Anthropic cache silence detector. *)
+    if usage.input_tokens > anthropic_cache_floor_tokens
+       && usage.cache_creation_input_tokens = 0
+       && usage.cache_read_input_tokens = 0
+       && model_looks_anthropic ~model_used ~resolved_model_id then
+      add "anthropic_cache_silence";
     match List.rev !reasons with
     | [] -> Usage_trusted
     | reasons -> Usage_untrusted reasons

--- a/test/dune
+++ b/test/dune
@@ -324,6 +324,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_usage_trust_anthropic_cache_silence)
+ (modules test_usage_trust_anthropic_cache_silence)
+ (libraries masc_test_deps))
+
+(test
  (name test_governance_cases_snapshot)
  (modules test_governance_cases_snapshot)
  (libraries masc_test_deps))

--- a/test/test_usage_trust_anthropic_cache_silence.ml
+++ b/test/test_usage_trust_anthropic_cache_silence.ml
@@ -1,0 +1,111 @@
+(* #9959: [Keeper_usage_trust.classify] flags cache silence on
+   Anthropic-resolved turns where input_tokens crosses the cache
+   floor (10k) but both [cache_creation_input_tokens] and
+   [cache_read_input_tokens] are zero — the production scan saw
+   this on 100% of [claude_code:*] turns despite Anthropic's
+   default-on prompt caching. *)
+
+module KUT = Masc_mcp.Keeper_usage_trust
+
+let usage ~input ~output ~cc ~cr : Agent_sdk.Types.api_usage =
+  { input_tokens = input;
+    output_tokens = output;
+    cache_creation_input_tokens = cc;
+    cache_read_input_tokens = cr;
+    cost_usd = None }
+
+let classify_with_cache ?(model = "claude_code:auto")
+    ?(resolved_model_id = "claude-sonnet-4-6")
+    ?(context_max = 200_000) ~input ~cc ~cr () =
+  KUT.classify
+    ~usage_reported:true
+    ~usage:(usage ~input ~output:1024 ~cc ~cr)
+    ~model_used:model
+    ~resolved_model_id
+    ~context_max
+
+let has_reason expected trust =
+  List.mem expected (KUT.reasons trust)
+
+let test_cache_silence_on_anthropic_above_floor () =
+  let trust =
+    classify_with_cache ~input:50_000 ~cc:0 ~cr:0 ()
+  in
+  Alcotest.(check bool)
+    "anthropic_cache_silence reason added"
+    true (has_reason "anthropic_cache_silence" trust)
+
+let test_cache_silence_below_floor_ignored () =
+  (* 5k input is below the 10k cache floor — silence is not yet
+     diagnostic because Anthropic caching may not engage. *)
+  let trust =
+    classify_with_cache ~input:5_000 ~cc:0 ~cr:0 ()
+  in
+  Alcotest.(check bool)
+    "no anthropic_cache_silence below floor"
+    false (has_reason "anthropic_cache_silence" trust)
+
+let test_cache_silence_with_cache_read_ignored () =
+  (* Cache read > 0 means Anthropic IS caching — no silence. *)
+  let trust =
+    classify_with_cache ~input:50_000 ~cc:0 ~cr:12_000 ()
+  in
+  Alcotest.(check bool)
+    "no silence when cache_read > 0"
+    false (has_reason "anthropic_cache_silence" trust)
+
+let test_cache_silence_non_anthropic_ignored () =
+  (* Ollama/codex/kimi turns have their own usage shape — cache
+     silence is not diagnostic for them. *)
+  let trust =
+    classify_with_cache
+      ~model:"ollama:qwen3.6"
+      ~resolved_model_id:"qwen3.6:27b-coding-nvfp4"
+      ~input:50_000 ~cc:0 ~cr:0 ()
+  in
+  Alcotest.(check bool)
+    "no silence on non-anthropic"
+    false (has_reason "anthropic_cache_silence" trust)
+
+let test_cache_silence_on_bare_claude_id () =
+  (* "claude-sonnet-4-6" is recognised even without "claude_code:"
+     prefix because [resolved_model_id] is the canonical id. *)
+  let trust =
+    classify_with_cache
+      ~model:"unknown"
+      ~resolved_model_id:"claude-opus-4-7"
+      ~input:50_000 ~cc:0 ~cr:0 ()
+  in
+  Alcotest.(check bool)
+    "silence detected on bare anthropic canonical id"
+    true (has_reason "anthropic_cache_silence" trust)
+
+let test_existing_reasons_preserved () =
+  (* Cache silence does not mask other anomalies — input_tokens_gt_1m
+     and zero_token_usage_reported still surface alongside it where
+     applicable. *)
+  let trust =
+    classify_with_cache ~input:1_500_000 ~cc:0 ~cr:0 ()
+  in
+  Alcotest.(check bool) "input_tokens_gt_1m preserved"
+    true (has_reason "input_tokens_gt_1m" trust);
+  Alcotest.(check bool) "anthropic_cache_silence also added"
+    true (has_reason "anthropic_cache_silence" trust)
+
+let () =
+  Alcotest.run "usage_trust_anthropic_cache_silence" [
+    "cache_silence", [
+      Alcotest.test_case "above floor on anthropic → flag" `Quick
+        test_cache_silence_on_anthropic_above_floor;
+      Alcotest.test_case "below floor → no flag" `Quick
+        test_cache_silence_below_floor_ignored;
+      Alcotest.test_case "cache_read > 0 → no flag" `Quick
+        test_cache_silence_with_cache_read_ignored;
+      Alcotest.test_case "non-anthropic → no flag" `Quick
+        test_cache_silence_non_anthropic_ignored;
+      Alcotest.test_case "bare canonical anthropic id → flag" `Quick
+        test_cache_silence_on_bare_claude_id;
+      Alcotest.test_case "co-exists with other reasons" `Quick
+        test_existing_reasons_preserved;
+    ];
+  ]


### PR DESCRIPTION
## 요약

`Keeper_usage_trust.classify`에 `anthropic_cache_silence` reason 추가. Anthropic prompt caching이 default-on임에도 production turn에서 cache_creation/read = 0인 100% silent 케이스를 자동 flag.

Closes part of #9959 (cache_silence detection — symptom #1 of 3).

## 근본 원인

이슈 보고: 24h × 9 keeper × 1078 entries 전수 scan 결과:
```
cache_creation_tokens p50/p90/p99/max: 0/0/0/0
cache_read_tokens     p50/p90/p99/max: 0/0/0/0
total cache_creation: 0, total cache_read: 0
```

`claude_code:auto`는 Anthropic prompt caching을 default 활성화. `input_tokens`이 100k 넘는 turn이 빈번한데 cache가 100% silent — caching 자체가 깨졌거나 transport가 cache 필드를 누락 중.

운영자는 이를 JSONL hand-scan으로만 발견 가능. 현재 `Keeper_usage_trust`에는 `negative_*`, `zero_token_usage_reported`, `input_tokens_gt_1m`, `input_tokens_gt_2x_context_max` 등 reason이 있지만 cache silence는 누락.

## 변경 내용

```ocaml
let anthropic_cache_floor_tokens = 10_000

let model_looks_anthropic ~model_used ~resolved_model_id =
  let probe s =
    let s = String.lowercase_ascii s in
    let has_prefix p = ... in
    has_prefix "claude" || has_prefix "anthropic"
    || has_prefix "claude_code:" || has_prefix "anthropic:"
  in
  probe model_used || probe resolved_model_id

(* Inside classify: *)
if usage.input_tokens > anthropic_cache_floor_tokens
   && usage.cache_creation_input_tokens = 0
   && usage.cache_read_input_tokens = 0
   && model_looks_anthropic ~model_used ~resolved_model_id then
  add "anthropic_cache_silence";
```

### Threshold 근거: 10k floor

Anthropic prompt caching은 minimum prompt size가 있어 짧은 prompt에서는 legitimately 미작동. 10k 미만에서 silence는 진단 정보가 아님 → false positive 회피. 10k 이상에서는 keeper 평생 trace상 cache traffic이 0이면 broken.

### Detection 범위

| Model 표기 | 매칭 |
|-----------|------|
| `claude_code:auto` | ✓ |
| `claude-sonnet-4-6` | ✓ (canonical id) |
| `claude-opus-4-7` | ✓ |
| `anthropic:claude-sonnet` | ✓ |
| `ollama:qwen3.6` | ✗ |
| `qwen3.6:27b-coding-nvfp4` | ✗ |

`model_used`와 `resolved_model_id` 둘 다 검사 — provider transport가 어느 한 쪽만 채워도 잡힘.

## 운영 영향

기존 `masc_keeper_usage_anomaly_reason_total{reason}` Prometheus counter가 자동으로 새 label `reason="anthropic_cache_silence"`를 emit. Operators가:

```promql
rate(masc_keeper_usage_anomaly_reason_total{reason="anthropic_cache_silence"}[5m]) > 0
```

으로 fleet-wide cache breakage 알람. JSONL의 `usage_anomaly_reasons` 배열에도 동일 string 포함 → grep 가능.

## 스코프 정직성

이슈 #9959는 3가지 **별개 증상**을 묶음:

| 증상 | 본 PR 처리 |
|------|-----------|
| (1) Anthropic cache_*=0 100% | ✅ classify reason 추가 |
| (2) Ollama input=0/output=0 50+ turns | ❌ 기존 `zero_token_usage_reported`로 이미 감지됨 |
| (3) input_tokens 1M-3.69M | ❌ 기존 `input_tokens_gt_1m`로 이미 감지됨 |

본 PR은 (1)에 한정. (2)(3)는 root cause(provider adapter / OAS transport)가 cross-repo이며 별건. 본 PR이 추가하는 detection은 reasons 리스트로 coexist — 한 turn에 여러 reason 동시 부착 가능 (test로 검증).

## 테스트

`test/test_usage_trust_anthropic_cache_silence.ml` 6 scenario:

```bash
$ dune exec test/test_usage_trust_anthropic_cache_silence.exe
[OK]  cache_silence  0  above floor on anthropic → flag.
[OK]  cache_silence  1  below floor → no flag.
[OK]  cache_silence  2  cache_read > 0 → no flag.
[OK]  cache_silence  3  non-anthropic → no flag.
[OK]  cache_silence  4  bare canonical anthropic id → flag.
[OK]  cache_silence  5  co-exists with other reasons.
Test Successful in 0.015s. 6 tests run.
```

기존 `test_keeper_usage_trust_counter` 5/5 통과 — regression 없음.

## 회귀 리스크

낮음. Pure classification additive change — 기존 reason은 그대로, `cache_silence`만 추가로 부착 가능. cost/usage 누적 로직(line 821-836의 `usage_trusted` gating)은 reason 1개 추가로도 이미 false 처리되어 cost = 0.0로 떨어짐 (정상 — untrusted 데이터는 누적 안 함).

## 후속

- **OAS transport-level investigation**: Anthropic 응답에서 cache 필드가 누락되는지, MASC가 파싱 누락하는지 — cross-repo 추적.
- **Ollama usage 0/0 (#9959 symptom #2)**: provider adapter에서 `prompt_eval_count` / `eval_count` 매핑 검증 필요.
- **input_tokens 3.69M (#9959 symptom #3)**: cumulative vs per-turn 단위 의심. provider 응답 schema cross-check.

## 참고

- Issue #9959 — 이 PR (symptom #1)
- `lib/keeper/keeper_usage_trust.ml:12-71` — classifier
- `test/test_usage_trust_anthropic_cache_silence.ml` — coverage
- 관련: #9926, #9935, #9943, #9953, #9520
