### PR TITLE
feat(keeper): affordance-tool intersection at Require_tool_use gate

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -2258,10 +2258,32 @@ let run_turn
          in
          let actionable_signal_context =
            let haystack = user_message ^ "\n" ^ dynamic_context in
-           turn_affordances_require_tool_gate turn_affordances
-           || String_util.contains_substring_ci haystack "## Discovered Work"
-           || has_positive_count_after_marker haystack "### Board Activity"
-           || has_positive_count_after_marker haystack "Unclaimed tasks"
+           let has_any_tool tools =
+             List.exists (fun t -> List.mem t all_tool_names) tools
+           in
+           (* P1 affordance-tool intersection: an actionable signal only
+              counts when the keeper actually has a tool that can act on
+              it.  Without this filter, presets like [social] see
+              "Unclaimed tasks=N" or board activity but lack the
+              corresponding action tools, so [Require_tool_use] becomes
+              unwinnable and the turn fails as [Failure_run_error]. *)
+           Keeper_agent_tool_surface
+             .turn_affordances_require_tool_gate_with_allowed
+             ~allowed_tool_names:all_tool_names turn_affordances
+           || (String_util.contains_substring_ci haystack "## Discovered Work"
+               && has_any_tool
+                    [ "keeper_task_claim"; "masc_claim_next";
+                      "masc_claim_task";
+                      "keeper_board_post"; "masc_add_task";
+                      "keeper_tasks_audit" ])
+           || (has_positive_count_after_marker haystack "### Board Activity"
+               && has_any_tool
+                    [ "keeper_board_post"; "keeper_board_comment";
+                      "masc_broadcast"; "masc_keeper_msg" ])
+           || (has_positive_count_after_marker haystack "Unclaimed tasks"
+               && has_any_tool
+                    [ "keeper_task_claim"; "masc_claim_next";
+                      "masc_claim_task" ])
          in
          let actionable_tool_contract_violation_reason =
            Keeper_tool_disclosure.actionable_tool_contract_violation_reason

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -100,6 +100,16 @@ val preferred_tool_choice_for_required_turn :
   -> allowed_tool_names:string list
   -> Oas.Types.tool_choice
 
+(** Filtered variant of [turn_affordances_require_tool_gate] (in
+    {!Keeper_agent_tool_surface}): only counts an affordance when at
+    least one tool capable of satisfying it appears in
+    [allowed_tool_names].  Used at the [Require_tool_use] contract gate
+    so keepers without the relevant action tools (e.g. a [social]
+    preset facing unclaimed tasks) aren't forced into unwinnable
+    contract violations. *)
+val turn_affordances_require_tool_gate_with_allowed :
+  allowed_tool_names:string list -> string list -> bool
+
 (** Canonical model label for MASC status/metrics surfaces.
     Prefers the final cascade attempt label when available, then the
     selected/primary configured cascade label, and finally falls back to the

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -93,6 +93,56 @@ let turn_affordances_require_tool_gate turn_affordances =
       | None -> false)
     (List.map turn_affordance_of_string turn_affordances)
 
+(* Affordance -> minimum viable tools that can satisfy that affordance.
+   The list is intentionally narrow ("at least one of these is enough").
+   Keepers without any matching tool cannot satisfy a [Require_tool_use]
+   contract for that affordance and must be allowed to respond with
+   text instead. *)
+let tools_for_gated_affordance = function
+  | Board_post_or_comment ->
+    [ "keeper_board_post"; "keeper_board_comment"; "masc_broadcast" ]
+  | Message_sweep ->
+    [ "keeper_messages_read"; "masc_messages"; "keeper_keeper_msg" ]
+  | Reply_in_room ->
+    [ "keeper_board_post"; "keeper_board_comment";
+      "masc_keeper_msg"; "masc_broadcast" ]
+  | Task_claim ->
+    [ "keeper_task_claim"; "masc_claim_next"; "masc_claim_task" ]
+  | Task_audit ->
+    [ "keeper_tasks_audit"; "keeper_tasks_list"; "masc_tasks" ]
+  | Task_verify ->
+    [ "keeper_tasks_list"; "keeper_tasks_audit";
+      "keeper_task_done"; "keeper_task_submit_for_verification";
+      "masc_transition" ]
+  | Work_discovery ->
+    [ "keeper_task_claim"; "masc_claim_next";
+      "keeper_board_post"; "masc_add_task";
+      "keeper_tasks_audit" ]
+  | Inspect_worktree_delta ->
+    [ "keeper_shell"; "keeper_bash"; "masc_code_git";
+      "keeper_fs_read" ]
+
+(* Filtered variant of [turn_affordances_require_tool_gate]:  a gated
+   affordance only counts when the keeper actually has a tool that can
+   satisfy it.  Without this filter, presets such as [social] (which
+   excludes claim/execution tools) get [Require_tool_use] forced on
+   them whenever the board lists unclaimed tasks, leading to repeated
+   [Failure_run_error] turns the keeper cannot resolve. *)
+let turn_affordances_require_tool_gate_with_allowed
+    ~(allowed_tool_names : string list) turn_affordances : bool =
+  let has_matching_tool affordance =
+    List.exists
+      (fun tool -> List.mem tool allowed_tool_names)
+      (tools_for_gated_affordance affordance)
+  in
+  List.exists
+    (function
+      | Some affordance ->
+        should_tool_gate_affordance affordance
+        && has_matching_tool affordance
+      | None -> false)
+    (List.map turn_affordance_of_string turn_affordances)
+
 let should_require_tools_for_initial_turn ~(max_turns : int)
     ~(turn_affordances : string list) =
   let initial_per_call_turn = 1 in

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -5105,6 +5105,66 @@ let test_should_require_tools_for_initial_turn_covers_actionable_affordances () 
   check bool "worktree inspection requires tool gate" true
     (require "inspect_worktree_delta")
 
+let test_turn_affordances_require_tool_gate_with_allowed_filters_by_tool () =
+  (* P1: an affordance must have a matching tool in the keeper's
+     visible surface to count as a "tool-gated" affordance.  This
+     prevents Require_tool_use from firing on keepers that cannot
+     satisfy the demanded action class. *)
+  let gate ~tools affordances =
+    KAR.turn_affordances_require_tool_gate_with_allowed
+      ~allowed_tool_names:tools affordances
+  in
+  check bool
+    "task_claim affordance with claim tool present -> gate fires" true
+    (gate ~tools:[ "keeper_task_claim" ] [ "task_claim" ]);
+  check bool
+    "task_claim affordance without any claim tool -> gate suppressed" false
+    (gate ~tools:[ "keeper_board_post"; "keeper_context_status" ]
+       [ "task_claim" ]);
+  check bool
+    "board_post_or_comment with comment tool -> gate fires" true
+    (gate ~tools:[ "keeper_board_comment" ] [ "board_post_or_comment" ]);
+  check bool
+    "board_post_or_comment without any post tool -> gate suppressed" false
+    (gate ~tools:[ "keeper_task_claim"; "keeper_tasks_list" ]
+       [ "board_post_or_comment" ]);
+  check bool
+    "any matching affordance is enough" true
+    (gate
+       ~tools:[ "masc_claim_next" ]
+       [ "task_claim"; "task_audit"; "board_post_or_comment" ]);
+  check bool
+    "all gated affordances missing tools -> gate suppressed" false
+    (gate
+       ~tools:[ "keeper_context_status"; "keeper_time_now" ]
+       [ "task_claim"; "task_verify"; "board_post_or_comment" ]);
+  check bool "empty affordances -> gate stays off" false
+    (gate ~tools:[ "keeper_task_claim" ] []);
+  check bool
+    "unknown affordance string is ignored" false
+    (gate ~tools:[ "keeper_task_claim" ] [ "totally_unknown_affordance" ])
+
+let test_tools_for_gated_affordance_covers_each_variant () =
+  (* Compile-time exhaustiveness already ensures every variant is
+     handled; this asserts the runtime mapping is non-empty so a
+     well-meaning future edit cannot silently break the gate by
+     returning [] for an affordance. *)
+  let module Surface = Masc_mcp.Keeper_agent_tool_surface in
+  let nonempty label affordance =
+    let tools = Surface.tools_for_gated_affordance affordance in
+    check bool
+      (Printf.sprintf "tools_for_gated_affordance non-empty for %s" label)
+      true (tools <> [])
+  in
+  nonempty "Board_post_or_comment" Surface.Board_post_or_comment;
+  nonempty "Message_sweep" Surface.Message_sweep;
+  nonempty "Reply_in_room" Surface.Reply_in_room;
+  nonempty "Task_claim" Surface.Task_claim;
+  nonempty "Task_audit" Surface.Task_audit;
+  nonempty "Task_verify" Surface.Task_verify;
+  nonempty "Work_discovery" Surface.Work_discovery;
+  nonempty "Inspect_worktree_delta" Surface.Inspect_worktree_delta
+
 let test_preferred_tool_choice_for_required_turn_claims_first () =
   let choose ?(has_current_task = false) ?(turn_affordances = [ "task_claim" ])
       ?(allowed_tool_names =
@@ -5927,6 +5987,11 @@ let () =
             test_should_require_tools_for_initial_turn_covers_actionable_affordances;
           test_case "task backlog required turn prefers claim tool choice"
             `Quick test_preferred_tool_choice_for_required_turn_claims_first;
+          test_case "affordance gate filters by allowed_tool_names"
+            `Quick
+            test_turn_affordances_require_tool_gate_with_allowed_filters_by_tool;
+          test_case "tools_for_gated_affordance non-empty for every variant"
+            `Quick test_tools_for_gated_affordance_covers_each_variant;
         ] );
       ( "verification_surface",
         [


### PR DESCRIPTION
## Summary

When the keeper's BDI gate detects an actionable signal (mention, board
activity, unclaimed task, work discovery, etc.) it forces a
`Require_tool_use` completion contract. Today the gate fires regardless
of whether the keeper actually has a tool that can satisfy the demanded
action class. Keepers with narrow presets (e.g. `social` for ramarama)
see *Unclaimed tasks = N* every cycle but lack `keeper_task_claim`, so
every proactive turn ends as `Failure_run_error` and the keeper sits
silently in `Defer`.

This PR makes the gate an **affordance-tool intersection**: an
affordance/string-marker only counts as actionable when the keeper has
at least one tool that can satisfy it.

## Why

Cross-keeper investigation on 2026-04-25 (8 keepers, 24h of receipts)
found the failure pattern clearly:

- `janitor` receipts trace the cascade-fallback chain firing five times
  per day: `ollama_only` (timeout) → `tool_use_strict`
  (`resumable_cli_session`) → `big_three`
  (`completion_contract_violation:require_tool_use`).
- Even the `ollama_only`/`qwen3.6:27b-coding-nvfp4` model failed
  `require_tool_use` (2026-04-24T09:56:44Z, 19:35:24Z), so the symptom is
  *not* codex_cli-specific.
- 5/14 keepers ended their last cycle with
  `last_social_transition_reason = failure:run_error`. Successful
  keepers — `masc-improver`, `sangsu` (cascade `tool_use_strict`,
  preset `delivery`) — kept working through the same window.

Existing knobs were complementary but did not close the hole:

- `#10008` already adds `Auto` fallback when `not has_current_task`
  and there is no specific applicable claim tool, but only at the
  `tool_choice` level.
- `#10091` / `#10099` add observability counters for
  `require_tool_use` violations on active tasks.

The remaining hole is on the **`actionable_signal_context`** side: the
contract gate fires whenever the world observation/dynamic context
mentions the signal, even when the keeper's preset has no tool to act
on it. That makes `Require_tool_use` unwinnable for those keepers and
funnels them into `Failure_run_error`.

## Changes

- `Keeper_agent_tool_surface.tools_for_gated_affordance` maps each
  `turn_affordance` variant to a minimum viable tool list ("at least
  one is enough"). Pattern-match is exhaustive so a future
  `turn_affordance` variant cannot silently bypass the filter.
- `turn_affordances_require_tool_gate_with_allowed` is a new filtered
  variant; the unfiltered `turn_affordances_require_tool_gate` is
  preserved unchanged for callers that don't yet have
  `allowed_tool_names` in scope.
- `Keeper_agent_run.actionable_signal_context` now uses the filtered
  variant and applies analogous tool-availability checks for the
  `## Discovered Work`, `### Board Activity`, and `Unclaimed tasks`
  string markers.
- `.mli` exposes `turn_affordances_require_tool_gate_with_allowed`
  via the `Keeper_agent_run` facade so callers and tests can reach it.

## Boundary

- Deterministic gate logic only. No change to LLM prompts,
  scheduler, cascade selection, or budget calculation.
- Filter is one-sided: it can only *suppress* a gate firing. A
  keeper that already has the tool and the signal will see exactly
  the same contract enforcement as today.
- Tool name strings are intentionally narrow per affordance. Wider
  coverage can be added incrementally as new gated affordances or
  satisfy-tools are introduced.

## Test plan

- [x] New `tool_classification 4`: gate fires when matching tool
      present, stays off when absent; multi-affordance / unknown
      affordance / empty list cases.
- [x] New `tool_classification 5`: every `turn_affordance` variant
      has a non-empty tool list (regression guard).
- [x] Existing `tool_classification` group still green (6/6).
- [ ] Production sanity: monitor `metric_keeper_oas_timeout_classifications`
      and `Failure_run_error` counts for ramarama/janitor/qa-king after
      rollout.

## Related

- #10008 (Auto fallback for missing claim tool)
- #10091 / #10099 (require_tool_use violation observability)
- #9933 (125 OAS-bridge budget blockers across 9 keepers)
- #9773 (sangsu BDI self-defeating loop — same family)
- Procedural memory record:
  `memory/procedural-memory/2026-04-25-keeper-stop-proactive-early-docker-pr-root-causes-evidence-record.md`

## Do not merge yet

Marked `do-not-merge` and Draft per the
`feedback_masc-mcp-do-not-merge-label-on-create` and
`feedback_do-not-merge-label-insufficient` rules: this is a new gate
and needs offline validation against a few keeper turns plus operator
review before flipping to Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)