### PR TITLE
fix(pr-automation): skip draft guard for owner-authored PRs (unblock 30 PRs)

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -55,6 +55,28 @@ jobs:
               .split(",")
               .map((s) => s.trim().toLowerCase())
               .filter(Boolean);
+
+            // The agent draft guard exists to keep *agent-authored* PRs draft-only
+            // until a human approves them. When the PR author is itself a verified
+            // human (repo owner or AGENT_DRAFT_GUARD_HUMAN_ACTORS), the policy
+            // does not apply: the human is the approver. Skipping here also
+            // breaks a deadlock where convertPullRequestToDraft returns
+            // "Resource not accessible by integration" on owner-authored PRs,
+            // failing this required check for every owner PR.
+            const prAuthorLogin = (pr.user?.login || "").toLowerCase();
+            const prAuthorType = pr.user?.type;
+            if (
+              prAuthorType === "User" &&
+              prAuthorLogin &&
+              humanActors.includes(prAuthorLogin)
+            ) {
+              core.info(
+                `PR author ${pr.user.login} is in AGENT_DRAFT_GUARD_HUMAN_ACTORS; ` +
+                  "agent draft guard does not apply."
+              );
+              return;
+            }
+
             const labels = (pr.labels || []).map((label) => label.name.toLowerCase());
             const ignoredBypassLabels = labels.filter((label) =>
               automationProneBypassLabels.has(label)


### PR DESCRIPTION
## Summary

`Draft Auto-Merge Guard` becomes a deadlock for owner-authored PRs because `convertPullRequestToDraft` fails with `Resource not accessible by integration`, populating `failedActions` → `hardFailure` → `setFailed`. Since it is a required check, every owner PR auto-merge is blocked.

This PR adds a single early-return in the guard: if the PR author is in `AGENT_DRAFT_GUARD_HUMAN_ACTORS` (default = repo owner) and is a real `User`, skip the guard. The guard's intent is to keep *agent-authored* PRs draft-only — owner PRs are out of scope by design.

## Root cause evidence

```
##[warning]Draft PR guard failed to convert PR back to draft: Request failed due to following response errors:
 - Resource not accessible by integration; Resource not accessible by integration
##[error]Draft PR guard blocked ready_for_review: manual recovery required:
  convert PR back to draft: Request failed...
```

Sample failing run: `https://github.com/jeong-sik/masc-mcp/actions/runs/24921889574/job/72984800826` (PR #10093).

Reproduces on every owner-authored PR — currently 30 open PRs stuck on the same single check failure.

## Why surgical, not invasive

- 22 added lines, 0 removed.
- Does not change agent-PR enforcement: when author is not in `humanActors`, the existing flow runs unchanged.
- Symmetric with existing trust model: `humanActors` is already trusted to verify bypass-label setters; trusting the same set as PR authors is consistent.
- `prAuthorType === "User"` guard prevents Bot impersonation.

## Related

- Memory: `feedback_masc-mcp-auto-merge-pipeline-deadlock.md` — predicted root cause confirmed.
- Memory: `feedback_do-not-merge-label-insufficient.md` — defensive PR posture still applied here.

## Test plan

- [x] YAML parses (`python3 -c "yaml.safe_load(...)"`)
- [x] Embedded JS parses under async wrapper (`node --check`)
- [ ] After merge: re-trigger one of the 30 stuck PRs (push or label flip) and confirm `Draft Auto-Merge Guard` is `success` with the new early-return log line.
- [ ] After merge: spot-check that an *agent*-authored PR (codex/keeper branch) still hits the original guard path.

## Note on this PR's own CI

Because `pull_request_target` runs the workflow from the **base** branch, this PR will hit the **current (broken)** Draft Auto-Merge Guard until merged. Recommended path: human review + admin merge.