### PR TITLE
fix(memory): persist failed keeper turn episodes (#7763)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -2759,6 +2759,55 @@ let run_turn
              | Error e -> Error (Oas.Error.Internal e)
              | Ok response_text -> finalize_response_text response_text))
     in
+    (match turn_result with
+     | Ok _ -> ()
+     | Error err ->
+       (try
+          let turn =
+            match !receipt_turn_count_ref with
+            | Some turns -> turns
+            | None -> start_turn_count + 1
+          in
+          Memory_oas_bridge.store_failed_turn_episode
+            ~memory
+            ~keeper_name:meta.name
+            ~turn
+            ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+            ~error_kind:(sdk_error_kind err)
+            ~error_message:(Oas.Error.to_string err)
+            ();
+          let ep, pr =
+            Memory_oas_bridge.flush_incremental ~memory ~agent_name:meta.name
+          in
+          if ep > 0 || pr > 0 then begin
+            Log.Keeper.debug
+              "keeper:%s post-run failure flush episodes=%d procedures=%d"
+              meta.name ep pr;
+            (try
+               (Atomic.get Coord_hooks.activity_emit_fn) config
+                 ~actor:Coord_hooks.{ kind = "keeper"; id = meta.name }
+                 ~kind:"episode.flush"
+                 ~payload:
+                   (`Assoc
+                     [
+                       ("keeper", `String meta.name);
+                       ("episodes", `Int ep);
+                       ("procedures", `Int pr);
+                       ("turn", `Int turn);
+                       ("outcome", `String "failure");
+                     ])
+                 ~tags:[ "memory"; "episode"; "flush"; "failure" ]
+                 ()
+             with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | _ -> ())
+          end
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+          Log.Keeper.error "keeper:%s failed_turn_episode_create failed: %s"
+            meta.name (Printexc.to_string exn)))
+    ;
     let receipt_ended_at = Types.now_iso () in
     let error_kind, error_message =
       match turn_result with

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -466,6 +466,64 @@ let store_episode_from_snapshot
   in
   Oas.Memory.store_episode memory episode
 
+let store_failed_turn_episode
+    ~(memory : Oas.Memory.t)
+    ~(keeper_name : string)
+    ~(turn : int)
+    ~(trace_id : string)
+    ~(error_kind : string)
+    ~(error_message : string)
+    () : unit =
+  let error_preview =
+    String_util.utf8_safe ~max_bytes:403 ~suffix:"..." error_message
+    |> String_util.to_string
+  in
+  let error_context =
+    String_util.utf8_safe ~max_bytes:4099 ~suffix:"..." error_message
+    |> String_util.to_string
+  in
+  let summary =
+    Printf.sprintf "keeper turn %d failed (%s): %s" turn error_kind
+      error_preview
+  in
+  let ts = Time_compat.now () in
+  let episode_id =
+    Printf.sprintf "keeper-%s-t%d-failure-%d" keeper_name turn
+      (int_of_float (ts *. 1000.0) mod 1_000_000)
+  in
+  let episode : Oas.Memory.episode =
+    {
+      id = episode_id;
+      timestamp = ts;
+      participants = [ keeper_name ];
+      action = summary;
+      outcome = Oas.Memory.Failure error_context;
+      salience = 0.8;
+      metadata =
+        [
+          ("event_type", `String "keeper_turn");
+          ("institution_summary", `String summary);
+          ("institution_outcome", `String "failure");
+          ( "learnings",
+            `List
+              [
+                `String
+                  "persist failed keeper turns so future runs can learn from \
+                   failure patterns";
+              ] );
+          ( "context",
+            `Assoc
+              [
+                ("trace_id", `String trace_id);
+                ("turn", `String (string_of_int turn));
+                ("error_kind", `String error_kind);
+                ("error_message", `String error_context);
+              ] );
+        ];
+    }
+  in
+  Oas.Memory.store_episode memory episode
+
 let persisted_episode_ids () =
   (load_all_episodes_cached ()).ids
 
@@ -698,4 +756,3 @@ let flush_incremental ~(memory : Oas.Memory.t) ~(agent_name : string)
   let ep = flush_episodes ~memory ~agent_name in
   let pr = flush_procedures ~memory ~agent_name in
   (ep, pr)
-

--- a/test/test_memory_oas_5tier.ml
+++ b/test/test_memory_oas_5tier.ml
@@ -476,6 +476,53 @@ let test_flush_episodes_appends_only_new_records () =
   Alcotest.(check bool) "new record appended" true (List.mem "new-episode-id" ids);
   cleanup_tmp_dir dir
 
+let test_failed_turn_episode_flushes_failure_outcome () =
+  let dir = setup_tmp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tmp_dir dir)
+    (fun () ->
+      let memory =
+        Memory_oas_bridge.create_memory ~agent_name:"test-failed-turn" ()
+      in
+      Memory_oas_bridge.store_failed_turn_episode
+        ~memory
+        ~keeper_name:"test-failed-turn"
+        ~turn:7
+        ~trace_id:"trace-failed-turn"
+        ~error_kind:"provider_timeout"
+        ~error_message:"provider timed out before producing a tool-using turn"
+        ();
+      let flushed =
+        Memory_oas_bridge.flush_episodes
+          ~memory
+          ~agent_name:"test-failed-turn"
+      in
+      Alcotest.(check int) "failure episode flushed" 1 flushed;
+      let persisted = Institution_eio.load_recent_episodes_jsonl ~limit:10 in
+      let episode =
+        List.find_opt
+          (fun (episode : Institution_eio.episode) ->
+            String.equal episode.event_type "keeper_turn"
+            && List.mem "test-failed-turn" episode.participants)
+          persisted
+      in
+      match episode with
+      | None -> Alcotest.fail "expected failed keeper_turn episode"
+      | Some episode ->
+        Alcotest.(check bool) "outcome is failure" true
+          (match episode.outcome with
+           | `Failure -> true
+           | `Success | `Partial -> false);
+        Alcotest.(check string) "trace_id preserved" "trace-failed-turn"
+          (List.assoc "trace_id" episode.context);
+        Alcotest.(check string) "turn preserved" "7"
+          (List.assoc "turn" episode.context);
+        Alcotest.(check string) "error kind preserved" "provider_timeout"
+          (List.assoc "error_kind" episode.context);
+        Alcotest.(check string) "error message preserved"
+          "provider timed out before producing a tool-using turn"
+          (List.assoc "error_message" episode.context))
+
 (* ================================================================ *)
 (* Test Suite                                                        *)
 (* ================================================================ *)
@@ -519,5 +566,7 @@ let () =
         test_jsonl_backend_uses_explicit_base_dir;
       Alcotest.test_case "flush_episodes appends only new" `Quick
         test_flush_episodes_appends_only_new_records;
+      Alcotest.test_case "failed keeper turn flushes failure outcome" `Quick
+        test_failed_turn_episode_flushes_failure_outcome;
     ]);
   ]


### PR DESCRIPTION
## Summary
- add a failed keeper-turn episode writer that records institution_outcome=failure with trace/turn/error context
- flush failed-turn episodes from the keeper run error path before execution receipts are finalized
- add a focused memory/OAS bridge test for failed keeper turn JSONL persistence

Closes #7763

## Verification
- git diff --check origin/main..HEAD
- attempted: env DUNE_BUILD_DIR=_build_verify_7763 DUNE_JOBS=2 scripts/dune-local.sh build test/test_memory_oas_5tier.exe
  - blocked by the shared /tmp/me-dune-local.lock held by another worktree build for feature/require-tool-use-affordance-filter