### PR TITLE
fix(keeper-unified-turn): migrate overflow-pause/resume write_meta to merged-CAS retry (#9733)

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -506,8 +506,24 @@ let pause_keeper_for_overflow
       updated_at = now_iso ();
     }
   in
-  (match write_meta config paused_meta with
+  (* #9733: [paused = true] is cycle-owned (the overflow-recovery
+     fiber decided the keeper must pause); heartbeat-owned fields
+     (joined_room_ids, last_seen_seq_by_room) must come from disk so
+     a parallel heartbeat write doesn't fight us for [meta_version].
+     Bare [write_meta] here drops the pause silently in the lost-CAS
+     case — the keeper then reports unpaused while the caller
+     believes it succeeded.  Same pattern as the unified-turn
+     failure path. *)
+  (match
+     write_meta_with_merge
+       ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+       config paused_meta
+   with
    | Ok () -> ()
+   | Error err when is_version_conflict_error err ->
+       Log.Keeper.warn
+         "%s: overflow pause write_meta lost CAS race after retries: %s"
+         meta.name err
    | Error err ->
        Log.Keeper.error
          "%s: overflow pause write_meta failed: %s"
@@ -546,7 +562,18 @@ let sync_keeper_paused_state
       updated_at = now_iso ();
     }
   in
-  match write_meta config synced_meta with
+  (* #9733: pause/resume sync is operator-driven; the [paused]
+     field is cycle-owned at this site, so use the same merged-CAS
+     write as overflow pause + unified-turn failure paths.  Without
+     this, an operator pause/resume that races a heartbeat tick
+     can land partially (paused field correct on disk, but write
+     reports failure) which leaves the registry update unsync'd
+     with disk. *)
+  match
+    write_meta_with_merge
+      ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+      config synced_meta
+  with
   | Error err ->
       report_keeper_cycle_side_effect_issue
         ~config

--- a/test/dune
+++ b/test/dune
@@ -1291,6 +1291,11 @@
  (libraries masc_mcp fs_compat alcotest eio eio_main unix))
 
 (test
+ (name test_keeper_paused_cas_retain_9733)
+ (modules test_keeper_paused_cas_retain_9733)
+ (libraries masc_mcp fs_compat alcotest eio eio_main unix))
+
+(test
  (name test_keeper_usage_trust_anthropic_cache_9959)
  (modules test_keeper_usage_trust_anthropic_cache_9959)
  (libraries masc_mcp alcotest))

--- a/test/test_keeper_paused_cas_retain_9733.ml
+++ b/test/test_keeper_paused_cas_retain_9733.ml
@@ -1,0 +1,178 @@
+(** #9733 follow-up to PR #10135: pin that the [paused] field
+    survives a heartbeat-vs-overflow-pause race when the
+    [Keeper_unified_turn] overflow-pause / pause-sync paths use
+    [write_meta_with_merge ~merge:heartbeat_fields_from_disk].
+
+    Without the migration, a bare [write_meta] in
+    [pause_keeper_for_overflow] / [sync_keeper_paused_state] can
+    silently lose the pause when a heartbeat fiber bumps
+    [meta_version] between the overflow fiber's read and write.
+    The dashboard then shows the keeper as unpaused while the
+    caller's [Keeper_registry.update_meta] thinks the persist
+    succeeded — a state corruption with no operator-visible
+    signal.
+
+    These tests exercise the merge contract directly so a future
+    refactor of [heartbeat_fields_from_disk] cannot silently
+    reintroduce the regression. *)
+
+open Alcotest
+open Masc_mcp
+
+let () = Server_startup_state.mark_state_ready ~backend_mode:"test"
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_keeper_paused_cas_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let ensure_fs env =
+  if not (Fs_compat.has_fs ()) then
+    Fs_compat.set_fs (Eio.Stdenv.fs env)
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else
+        Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let make_meta ~name =
+  match
+    Keeper_types.meta_of_json
+      (`Assoc
+        [
+          ("name", `String name);
+          ("agent_name", `String ("keeper-" ^ name ^ "-agent"));
+          ("trace_id", `String ("trace-" ^ name));
+          ("goal", `String "test keeper");
+          ("autoboot_enabled", `Bool false);
+        ])
+  with
+  | Ok m -> m
+  | Error e -> fail ("meta_of_json failed: " ^ e)
+
+(* Race: overflow fiber observed unpaused at version N, decides
+   to pause; heartbeat fiber bumps to version N+1 with new
+   joined_room_ids; overflow fiber attempts write with stale
+   version.  Merged CAS retry must:
+   - persist [paused = true]      (caller wins on cycle field)
+   - retain [joined_room_ids]      (disk wins on heartbeat field)
+   - increment meta_version past the heartbeat write *)
+let test_pause_caller_wins_heartbeat_disk_wins () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) (fun () ->
+    let config = Coord.default_config base_dir in
+    ignore (Coord.init config ~agent_name:(Some "operator"));
+    let m0 =
+      let m = make_meta ~name:"pause-race-9733" in
+      { m with paused = false; joined_room_ids = ["r1"] }
+    in
+    (match Keeper_types.write_meta ~force:true config m0 with
+     | Ok () -> ()
+     | Error e -> fail ("seed failed: " ^ e));
+    let overflow_view =
+      match Keeper_types.read_meta config "pause-race-9733" with
+      | Ok (Some m) -> m
+      | _ -> fail "seed read failed"
+    in
+    (* Heartbeat fiber bumps version, joins another room. *)
+    let heartbeat_payload =
+      { overflow_view with joined_room_ids = ["r1"; "r2"] }
+    in
+    (match Keeper_types.write_meta config heartbeat_payload with
+     | Ok () -> ()
+     | Error e -> fail ("heartbeat write failed: " ^ e));
+    (* Overflow fiber writes pause with a stale version (the one
+       it read at [overflow_view]).  This is what
+       [pause_keeper_for_overflow] does: it modifies [paused] on
+       its captured snapshot then writes.  The merged-CAS retry
+       inside [write_meta_with_merge] must lift [paused = true]
+       onto the disk's latest version + retain
+       [joined_room_ids = [r1; r2]]. *)
+    let pause_payload = { overflow_view with paused = true } in
+    (match
+       Keeper_types.write_meta_with_merge
+         ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+         config pause_payload
+     with
+     | Ok () -> ()
+     | Error e -> fail ("pause merged write failed: " ^ e));
+    let final = match Keeper_types.read_meta config "pause-race-9733" with
+      | Ok (Some m) -> m
+      | _ -> fail "final read failed"
+    in
+    check bool "paused = true (caller wins on cycle field)"
+      true final.paused;
+    check (list string)
+      "joined_room_ids = [r1; r2] (disk wins on heartbeat field)"
+      ["r1"; "r2"] final.joined_room_ids;
+    check bool "meta_version moved past heartbeat write"
+      true (final.meta_version > heartbeat_payload.meta_version))
+
+(* Resume side of the same migration.  [sync_keeper_paused_state
+   ~paused:false] must also retain heartbeat fields and persist
+   the resume even under race. *)
+let test_resume_caller_wins_heartbeat_disk_wins () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) (fun () ->
+    let config = Coord.default_config base_dir in
+    ignore (Coord.init config ~agent_name:(Some "operator"));
+    let m0 =
+      let m = make_meta ~name:"resume-race-9733" in
+      { m with paused = true; joined_room_ids = ["r1"] }
+    in
+    (match Keeper_types.write_meta ~force:true config m0 with
+     | Ok () -> ()
+     | Error e -> fail ("seed failed: " ^ e));
+    let resume_view =
+      match Keeper_types.read_meta config "resume-race-9733" with
+      | Ok (Some m) -> m
+      | _ -> fail "seed read failed"
+    in
+    let heartbeat_payload =
+      { resume_view with joined_room_ids = ["r1"; "r3"] }
+    in
+    (match Keeper_types.write_meta config heartbeat_payload with
+     | Ok () -> ()
+     | Error e -> fail ("heartbeat failed: " ^ e));
+    let resume_payload = { resume_view with paused = false } in
+    (match
+       Keeper_types.write_meta_with_merge
+         ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+         config resume_payload
+     with
+     | Ok () -> ()
+     | Error e -> fail ("resume merged write failed: " ^ e));
+    let final = match Keeper_types.read_meta config "resume-race-9733" with
+      | Ok (Some m) -> m
+      | _ -> fail "final read failed"
+    in
+    check bool "paused = false (caller wins on cycle field)"
+      false final.paused;
+    check (list string)
+      "joined_room_ids = [r1; r3] (disk wins on heartbeat field)"
+      ["r1"; "r3"] final.joined_room_ids)
+
+let () =
+  run "Keeper paused-field CAS retain (#9733)"
+    [
+      ( "pause-resume-merge",
+        [
+          test_case "pause: caller wins, heartbeat retained" `Quick
+            test_pause_caller_wins_heartbeat_disk_wins;
+          test_case "resume: caller wins, heartbeat retained" `Quick
+            test_resume_caller_wins_heartbeat_disk_wins;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

#9733 follow-up to PR #10135 (which migrated keeper_msg
turn-completion).  Two more bare \`write_meta\` sites in
\`keeper_unified_turn.ml\` have the same heartbeat-vs-cycle race
shape:

| site | risk if CAS lost |
|---|---|
| \`pause_keeper_for_overflow:509\` | dashboard reports unpaused while overflow recovery thinks pause succeeded |
| \`sync_keeper_paused_state:549\` | operator pause/resume \`Result\` reports Error while disk is actually correct |

Both migrate to the same pattern already used by the unified-turn
failure paths and the create_keeper path:

\`\`\`ocaml
write_meta_with_merge
  ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
  config payload
\`\`\`

## Field-ownership contract

| field class | owner | examples |
|---|---|---|
| **cycle-owned** (caller wins) | overflow / pause-sync fiber | \`paused\`, \`updated_at\` |
| **heartbeat-owned** (disk wins) | heartbeat fiber | \`meta_version\`, \`joined_room_ids\`, \`last_seen_seq_by_room\` |

## Existing migrations (reference patterns)

| caller | line |
|---|---|
| turn-failure path (#9769) | \`keeper_unified_turn.ml:1683\` |
| second turn-failure path | \`keeper_unified_turn.ml:2088\` |
| create_keeper | \`keeper_turn_up_create.ml:25\` |
| keeper_msg turn (#10135) | \`keeper_turn.ml:467\` |
| **overflow_pause (this PR)** | **\`keeper_unified_turn.ml:509\`** |
| **pause/resume sync (this PR)** | **\`keeper_unified_turn.ml:549\`** |

## Test plan

- [x] \`dune build --root . lib/\` clean
- [x] \`dune exec test/test_keeper_paused_cas_retain_9733.exe\` — 2/2 pass:
  - **pause: caller wins, heartbeat retained** — \`paused\` flips to true even when \`meta_version\` advanced; \`joined_room_ids\` from the racing heartbeat write is retained on disk
  - **resume: caller wins, heartbeat retained** — same merge contract for the resume direction
- [x] Existing \`test_keeper_meta_cas_retry\` and \`test_keeper_meta_heartbeat_retain_9733\` continue to pass.
- [ ] Deploy: confirm pause/resume race no longer drops state silently when heartbeat is hot.

## Sites surveyed but NOT migrated

| site | reason |
|---|---|
| \`tool_keeper.ml\` (3 sites), dashboard HTTP routes, TOML reload | use \`~force:true\` — explicit operator overrides |
| \`keeper_supervisor.ml\` (3 sites) | own ownership semantics; per-site review needed |
| \`keeper_turn_up_update.ml:292\`, \`keeper_turn_lifecycle.ml:42\` | scope discipline — separate PR |

## Refs

- PR #10135 (MERGED): keeper_msg site migration
- #9764, #9769: introduced \`write_meta_with_merge\`
- #10130 / PR #10131: boot-time atomic-orphan sweep — FD-leak compound

## Do-not-merge

\`do-not-merge\` label set so the auto-merge pipeline does not
flip this Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)