### PR TITLE
Dehardcode persona authoring contract

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -401,6 +401,7 @@
    exec_core
    eval_calibration
    ;; Keeper contract
+   keeper_persona_authoring_contract
    keeper_schema
    keeper_social_model_types
    keeper_social_model_protocol
@@ -638,6 +639,7 @@
  briefing_sections
  dashboard_mission_agents
  dashboard_mission_assembly
+ keeper_persona_authoring_contract
  keeper_types_profile
  keeper_meta_tool_access
  keeper_meta_contract

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -15,6 +15,10 @@ let local_recovery_cascade_name = "local_recovery"
     Maps to local_only_* entries in cascade.json. *)
 let local_only_cascade_name = "local_only"
 
+let phase_routing_cascade_names =
+  [ local_only_cascade_name; local_recovery_cascade_name ]
+;;
+
 (** Cascade name for turns that must use a tool-capable provider lane. *)
 let tool_use_strict_cascade_name = "tool_use_strict"
 

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -20,6 +20,10 @@ val local_recovery_cascade_name : string
     @since Core Triad *)
 val local_only_cascade_name : string
 
+(** Cascade names that are selected by keeper phase-routing rather than by
+    keeper-assignable profile choice. *)
+val phase_routing_cascade_names : string list
+
 (** Cascade name for turns that must use a tool-capable provider lane. *)
 val tool_use_strict_cascade_name : string
 

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -5,6 +5,7 @@
     keeps writes constrained to the resolved personas root. *)
 
 open Tool_args
+module Archetypes = Keeper_persona_authoring_contract
 
 type save_result =
   { handle : string
@@ -20,20 +21,8 @@ type archetype_axes =
   ; risk_posture : string option
   }
 
-type archetype_choice_effect =
-  { value : string
-  ; effect_text : string
-  ; generated_fields : string list
-  ; default_tool_preset : string option
-  }
-
-let string_list_to_json values = `List (List.map (fun value -> `String value) values)
-
-let option_field name value =
-  match value with
-  | Some json -> [ name, json ]
-  | None -> []
-;;
+let string_list_to_json = Archetypes.string_list_to_json
+let option_field = Archetypes.option_field
 
 let assoc_without key fields =
   List.filter (fun (candidate, _) -> not (String.equal candidate key)) fields
@@ -119,120 +108,15 @@ let social_model_choices_json =
   string_list_to_json [ "bdi_speech_v1"; "magentic_ledger_v1" ]
 ;;
 
-let alignment_choices = [ "helpful"; "skeptical"; "protective"; "chaotic"; "ruthless" ]
-
-let operating_style_choices =
-  [ "research"; "coding"; "dispatch"; "social"; "delivery" ]
-;;
-
-let risk_posture_choices = [ "cautious"; "balanced"; "high-autonomy" ]
-
-let choice_effect ?default_tool_preset ~value ~effect_text ~generated_fields () =
-  { value; effect_text; generated_fields; default_tool_preset }
-;;
-
-let choice_effect_fields choice =
-  [ "value", `String choice.value
-  ; "effect", `String choice.effect_text
-  ; "generated_fields", string_list_to_json choice.generated_fields
-  ]
-  @ option_field
-      "default_tool_preset"
-      (Option.map (fun value -> `String value) choice.default_tool_preset)
-;;
-
-let choice_effect_to_json choice = `Assoc (choice_effect_fields choice)
-
-let alignment_choice_effects =
-  [ choice_effect
-      ~value:"helpful"
-      ~effect_text:"Biases the draft toward cooperative task support and clear next actions."
-      ~generated_fields:[ "role"; "trait"; "keeper.goal"; "keeper.instructions" ]
-      ()
-  ; choice_effect
-      ~value:"skeptical"
-      ~effect_text:"Biases the draft toward critique, evidence checks, and assumption testing."
-      ~generated_fields:[ "role"; "trait"; "keeper.goal"; "keeper.instructions" ]
-      ()
-  ; choice_effect
-      ~value:"protective"
-      ~effect_text:"Biases the draft toward guardrails, risk spotting, and escalation language."
-      ~generated_fields:[ "role"; "trait"; "keeper.goal"; "keeper.instructions" ]
-      ()
-  ; choice_effect
-      ~value:"chaotic"
-      ~effect_text:
-        "Biases the draft toward divergent options while keeping keeper goals executable."
-      ~generated_fields:[ "role"; "trait"; "keeper.goal"; "keeper.instructions" ]
-      ()
-  ; choice_effect
-      ~value:"ruthless"
-      ~effect_text:"Biases the draft toward prioritization, pruning, and direct tradeoff calls."
-      ~generated_fields:[ "role"; "trait"; "keeper.goal"; "keeper.instructions" ]
-      ()
-  ]
-;;
-
-let operating_style_choice_effects =
-  [ choice_effect
-      ~value:"research"
-      ~effect_text:"Favors evidence gathering, synthesis, and source-grounded analysis."
-      ~generated_fields:[ "keeper.tool_preset"; "keeper.goal"; "keeper.instructions" ]
-      ~default_tool_preset:"research"
-      ()
-  ; choice_effect
-      ~value:"coding"
-      ~effect_text:"Favors repo-local implementation, test repair, and code review loops."
-      ~generated_fields:[ "keeper.tool_preset"; "keeper.goal"; "keeper.instructions" ]
-      ~default_tool_preset:"coding"
-      ()
-  ; choice_effect
-      ~value:"dispatch"
-      ~effect_text:"Favors triage, routing, task assignment, and operational follow-through."
-      ~generated_fields:[ "keeper.tool_preset"; "keeper.goal"; "keeper.instructions" ]
-      ~default_tool_preset:"dispatch"
-      ()
-  ; choice_effect
-      ~value:"social"
-      ~effect_text:"Favors conversation tracking, replies, coordination, and social context."
-      ~generated_fields:[ "keeper.tool_preset"; "keeper.goal"; "keeper.instructions" ]
-      ~default_tool_preset:"social"
-      ()
-  ; choice_effect
-      ~value:"delivery"
-      ~effect_text:"Favors milestone tracking, completion pressure, and release readiness."
-      ~generated_fields:[ "keeper.tool_preset"; "keeper.goal"; "keeper.instructions" ]
-      ~default_tool_preset:"delivery"
-      ()
-  ]
-;;
-
-let risk_posture_choice_effects =
-  [ choice_effect
-      ~value:"cautious"
-      ~effect_text:"Biases the draft toward dry runs, explicit approvals, and low autonomy."
-      ~generated_fields:[ "keeper.instructions"; "keeper.proactive_enabled" ]
-      ()
-  ; choice_effect
-      ~value:"balanced"
-      ~effect_text:"Biases the draft toward normal autonomous help with explicit escalation."
-      ~generated_fields:[ "keeper.instructions"; "keeper.proactive_enabled" ]
-      ()
-  ; choice_effect
-      ~value:"high-autonomy"
-      ~effect_text:
-        "Biases the draft toward proactive follow-through while concrete fields still \
-         require validation."
-      ~generated_fields:[ "keeper.instructions"; "keeper.proactive_enabled" ]
-      ()
-  ]
-;;
-
-let choice_effects_to_json effects = `List (List.map choice_effect_to_json effects)
-
-let choice_effect_for value effects =
-  List.find_opt (fun choice -> String.equal choice.value value) effects
-;;
+let alignment_choices = Archetypes.alignment_choices
+let operating_style_choices = Archetypes.operating_style_choices
+let risk_posture_choices = Archetypes.risk_posture_choices
+let alignment_choice_effects = Archetypes.alignment_choice_effects
+let operating_style_choice_effects = Archetypes.operating_style_choice_effects
+let risk_posture_choice_effects = Archetypes.risk_posture_choice_effects
+let choice_effect_fields = Archetypes.choice_effect_fields
+let choice_effect_for = Archetypes.choice_effect_for
+let archetype_axes_json = Archetypes.archetype_axes_json
 
 let field_catalog_json () =
   `List
@@ -312,7 +196,7 @@ let field_catalog_json () =
     ; field_catalog_entry
         ~path:"keeper.tool_preset"
         ~typ:"enum"
-        ~default:(`String "research")
+        ~default:(`String Archetypes.default_tool_preset)
         ~choices:tool_preset_choices_json
         ~field_effect:"Preset used to derive the keeper tool policy during creation."
         ()
@@ -418,38 +302,6 @@ let field_catalog_json () =
     ]
 ;;
 
-let archetype_axes_json () =
-  `List
-    [ `Assoc
-        [ "name", `String "alignment"
-        ; "choices", string_list_to_json alignment_choices
-        ; "choice_effects", choice_effects_to_json alignment_choice_effects
-        ; ( "effect"
-          , `String
-              "Generation prompt input only. The saved effect appears through role, \
-               trait, goal, and instructions." )
-        ]
-    ; `Assoc
-        [ "name", `String "operating_style"
-        ; "choices", string_list_to_json operating_style_choices
-        ; "choice_effects", choice_effects_to_json operating_style_choice_effects
-        ; ( "effect"
-          , `String
-              "Maps naturally to keeper.tool_preset and instructions when drafting a \
-               persona." )
-        ]
-    ; `Assoc
-        [ "name", `String "risk_posture"
-        ; "choices", string_list_to_json risk_posture_choices
-        ; "choice_effects", choice_effects_to_json risk_posture_choice_effects
-        ; ( "effect"
-          , `String
-              "Generation prompt input only. Save still validates concrete keeper fields."
-          )
-        ]
-    ]
-;;
-
 let personas_root_candidate () =
   let resolution = Config_dir_resolver.resolve () in
   resolution.personas.path
@@ -478,7 +330,7 @@ let schema_json ?(include_examples = false) () =
                           , `String
                               "Find weak assumptions and turn them into actionable tasks."
                           )
-                        ; "tool_preset", `String "research"
+                        ; "tool_preset", `String Archetypes.default_tool_preset
                         ; "mention_targets", string_list_to_json [ "sharp-researcher" ]
                         ] )
                   ] )
@@ -578,7 +430,9 @@ let normalize_cascade_name raw =
     | _ -> []
   in
   let known =
-    Keeper_cascade_profile.known_cascades @ [ "local_only"; "local_recovery" ] @ catalog
+    Keeper_cascade_profile.known_cascades
+    @ Keeper_config.phase_routing_cascade_names
+    @ catalog
   in
   if List.mem (String.lowercase_ascii normalized) known
   then Ok normalized
@@ -640,7 +494,7 @@ let normalize_keeper_json ~handle keeper_json =
       Result.bind result (fun goal ->
         let tool_preset_result =
           match json_trimmed_string_opt "tool_preset" keeper_json with
-          | None -> Ok "research"
+          | None -> Ok Archetypes.default_tool_preset
           | Some raw -> normalize_tool_preset raw
         in
         Result.bind tool_preset_result (fun tool_preset ->
@@ -1000,7 +854,7 @@ let generation_tool_preset args axes =
   | None ->
     (match axes.operating_style with
      | Some style -> normalize_tool_preset style
-     | None -> Ok "research")
+     | None -> Ok Archetypes.default_tool_preset)
 ;;
 
 let generation_prompt
@@ -1130,13 +984,29 @@ let handle_persona_generate ctx args =
          | Error msg -> false, error_response_typed ~code:Validation_error msg
          | Ok tool_preset ->
            let cascade_name =
-             get_string args "cascade_name" "operator_judge" |> String.trim
+             get_string args "cascade_name" Archetypes.default_generation_cascade_name
+             |> String.trim
            in
-           let cascade_name = if cascade_name = "" then "operator_judge" else cascade_name in
-           let temperature = get_float_opt args "temperature" |> Option.value ~default:0.7 in
-           let max_tokens = get_int_opt args "max_tokens" |> Option.value ~default:2500 in
-           let proactive_enabled = get_bool args "proactive_enabled" false in
-           let language = get_string args "language" "ko" |> String.trim in
+           let cascade_name =
+             if cascade_name = ""
+             then Archetypes.default_generation_cascade_name
+             else cascade_name
+           in
+           let temperature =
+             get_float_opt args "temperature"
+             |> Option.value ~default:Archetypes.default_temperature
+           in
+           let max_tokens =
+             get_int_opt args "max_tokens"
+             |> Option.value ~default:Archetypes.default_max_tokens
+           in
+           let proactive_enabled =
+             get_bool args "proactive_enabled" Archetypes.default_proactive_enabled
+           in
+           let language =
+             get_string args "language" Archetypes.default_generation_language
+             |> String.trim
+           in
            let display_name_opt = get_string_opt args "display_name" in
            let prompt =
              generation_prompt

--- a/lib/keeper/keeper_persona_authoring_contract.ml
+++ b/lib/keeper/keeper_persona_authoring_contract.ml
@@ -1,0 +1,211 @@
+(** Shared persona authoring contract.
+
+    The persona generator schema, persona schema explanation, and generation
+    logic must agree on archetype choices, choice effects, and draft defaults.
+    Keep those values here so adding or renaming a choice is one edit instead
+    of a schema/runtime mirror. *)
+
+type archetype_choice_effect =
+  { value : string
+  ; effect_text : string
+  ; generated_fields : string list
+  ; default_tool_preset : string option
+  }
+
+type archetype_axis =
+  { name : string
+  ; choices : string list
+  ; choice_effects : archetype_choice_effect list
+  ; effect_text : string
+  ; schema_description : string
+  }
+
+let default_generation_language = "ko"
+let default_generation_cascade_name = "operator_judge"
+let default_tool_preset = "research"
+let default_temperature = 0.7
+let default_max_tokens = 2500
+let default_proactive_enabled = false
+let string_list_to_json values = `List (List.map (fun value -> `String value) values)
+
+let option_field name value =
+  match value with
+  | Some json -> [ name, json ]
+  | None -> []
+;;
+
+let choice_effect ?default_tool_preset ~value ~effect_text ~generated_fields () =
+  { value; effect_text; generated_fields; default_tool_preset }
+;;
+
+let choice_effect_fields choice =
+  [ "value", `String choice.value
+  ; "effect", `String choice.effect_text
+  ; "generated_fields", string_list_to_json choice.generated_fields
+  ]
+  @ option_field
+      "default_tool_preset"
+      (Option.map (fun value -> `String value) choice.default_tool_preset)
+;;
+
+let choice_effect_to_json choice = `Assoc (choice_effect_fields choice)
+let choice_effects_to_json effects = `List (List.map choice_effect_to_json effects)
+
+let choice_values effects =
+  List.map (fun (choice : archetype_choice_effect) -> choice.value) effects
+;;
+
+let choice_effect_for value effects =
+  List.find_opt (fun choice -> String.equal choice.value value) effects
+;;
+
+let alignment_choice_effects =
+  [ choice_effect
+      ~value:"helpful"
+      ~effect_text:
+        "Biases the draft toward cooperative task support and clear next actions."
+      ~generated_fields:[ "role"; "trait"; "keeper.goal"; "keeper.instructions" ]
+      ()
+  ; choice_effect
+      ~value:"skeptical"
+      ~effect_text:
+        "Biases the draft toward critique, evidence checks, and assumption testing."
+      ~generated_fields:[ "role"; "trait"; "keeper.goal"; "keeper.instructions" ]
+      ()
+  ; choice_effect
+      ~value:"protective"
+      ~effect_text:
+        "Biases the draft toward guardrails, risk spotting, and escalation language."
+      ~generated_fields:[ "role"; "trait"; "keeper.goal"; "keeper.instructions" ]
+      ()
+  ; choice_effect
+      ~value:"chaotic"
+      ~effect_text:
+        "Biases the draft toward divergent options while keeping keeper goals executable."
+      ~generated_fields:[ "role"; "trait"; "keeper.goal"; "keeper.instructions" ]
+      ()
+  ; choice_effect
+      ~value:"ruthless"
+      ~effect_text:
+        "Biases the draft toward prioritization, pruning, and direct tradeoff calls."
+      ~generated_fields:[ "role"; "trait"; "keeper.goal"; "keeper.instructions" ]
+      ()
+  ]
+;;
+
+let operating_style_choice_effects =
+  [ choice_effect
+      ~value:"research"
+      ~effect_text:"Favors evidence gathering, synthesis, and source-grounded analysis."
+      ~generated_fields:[ "keeper.tool_preset"; "keeper.goal"; "keeper.instructions" ]
+      ~default_tool_preset:"research"
+      ()
+  ; choice_effect
+      ~value:"coding"
+      ~effect_text:"Favors repo-local implementation, test repair, and code review loops."
+      ~generated_fields:[ "keeper.tool_preset"; "keeper.goal"; "keeper.instructions" ]
+      ~default_tool_preset:"coding"
+      ()
+  ; choice_effect
+      ~value:"dispatch"
+      ~effect_text:
+        "Favors triage, routing, task assignment, and operational follow-through."
+      ~generated_fields:[ "keeper.tool_preset"; "keeper.goal"; "keeper.instructions" ]
+      ~default_tool_preset:"dispatch"
+      ()
+  ; choice_effect
+      ~value:"social"
+      ~effect_text:
+        "Favors conversation tracking, replies, coordination, and social context."
+      ~generated_fields:[ "keeper.tool_preset"; "keeper.goal"; "keeper.instructions" ]
+      ~default_tool_preset:"social"
+      ()
+  ; choice_effect
+      ~value:"delivery"
+      ~effect_text:
+        "Favors milestone tracking, completion pressure, and release readiness."
+      ~generated_fields:[ "keeper.tool_preset"; "keeper.goal"; "keeper.instructions" ]
+      ~default_tool_preset:"delivery"
+      ()
+  ]
+;;
+
+let risk_posture_choice_effects =
+  [ choice_effect
+      ~value:"cautious"
+      ~effect_text:
+        "Biases the draft toward dry runs, explicit approvals, and low autonomy."
+      ~generated_fields:[ "keeper.instructions"; "keeper.proactive_enabled" ]
+      ()
+  ; choice_effect
+      ~value:"balanced"
+      ~effect_text:
+        "Biases the draft toward normal autonomous help with explicit escalation."
+      ~generated_fields:[ "keeper.instructions"; "keeper.proactive_enabled" ]
+      ()
+  ; choice_effect
+      ~value:"high-autonomy"
+      ~effect_text:
+        "Biases the draft toward proactive follow-through while concrete fields still \
+         require validation."
+      ~generated_fields:[ "keeper.instructions"; "keeper.proactive_enabled" ]
+      ()
+  ]
+;;
+
+let alignment_choices = choice_values alignment_choice_effects
+let operating_style_choices = choice_values operating_style_choice_effects
+let risk_posture_choices = choice_values risk_posture_choice_effects
+
+let alignment_axis =
+  { name = "alignment"
+  ; choices = alignment_choices
+  ; choice_effects = alignment_choice_effects
+  ; effect_text =
+      "Generation prompt input only. The saved effect appears through role, trait, goal, \
+       and instructions."
+  ; schema_description =
+      "Optional archetype axis. Influences generated role, trait, goals, and \
+       instructions. Call masc_persona_schema for per-choice effects."
+  }
+;;
+
+let operating_style_axis =
+  { name = "operating_style"
+  ; choices = operating_style_choices
+  ; choice_effects = operating_style_choice_effects
+  ; effect_text =
+      "Maps naturally to keeper.tool_preset and instructions when drafting a persona."
+  ; schema_description =
+      "Optional archetype axis. If tool_preset is omitted, this also selects the default \
+       keeper.tool_preset. Call masc_persona_schema for per-choice effects."
+  }
+;;
+
+let risk_posture_axis =
+  { name = "risk_posture"
+  ; choices = risk_posture_choices
+  ; choice_effects = risk_posture_choice_effects
+  ; effect_text =
+      "Generation prompt input only. Save still validates concrete keeper fields."
+  ; schema_description =
+      "Optional archetype axis. Influences generated autonomy and safety language while \
+       save still validates concrete fields. Call masc_persona_schema for per-choice \
+       effects."
+  }
+;;
+
+let axes = [ alignment_axis; operating_style_axis; risk_posture_axis ]
+
+let axis_to_json axis =
+  `Assoc
+    [ "name", `String axis.name
+    ; "choices", string_list_to_json axis.choices
+    ; "choice_effects", choice_effects_to_json axis.choice_effects
+    ; "effect", `String axis.effect_text
+    ]
+;;
+
+let archetype_axes_json () = `List (List.map axis_to_json axes)
+let axis_by_name name = List.find_opt (fun axis -> String.equal axis.name name) axes
+let choices_for_axis name = Option.map (fun axis -> axis.choices) (axis_by_name name)

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -1,6 +1,7 @@
 (** Keeper tool schemas — MCP tool definitions for keeper agents. *)
 
 open Types
+module Persona_contract = Keeper_persona_authoring_contract
 
 (** Issue #8430: canonical [tool_preset] strings. Mirrors
     [Keeper_types.valid_tool_preset_strings]. Direct dependency would
@@ -41,6 +42,13 @@ let string_array_schema =
     ("type", `String "array");
     ("items", `Assoc [ ("type", `String "string") ]);
   ]
+
+let persona_axis_schema (axis : Persona_contract.archetype_axis) =
+  `Assoc
+    [ "type", `String "string"
+    ; "enum", Persona_contract.string_list_to_json axis.choices
+    ; "description", `String axis.schema_description
+    ]
 
 let tool_access_schema description =
   let preset_shape =
@@ -127,55 +135,40 @@ let keeper_schemas : tool_schema list = [
         ]);
         ("language", `Assoc [
           ("type", `String "string");
-          ("default", `String "ko");
+          ("default", `String Persona_contract.default_generation_language);
           ("description", `String "Preferred language for generated text.");
         ]);
-        ("alignment", `Assoc [
-          ("type", `String "string");
-          ("enum", `List [
-            `String "helpful"; `String "skeptical"; `String "protective";
-            `String "chaotic"; `String "ruthless";
-          ]);
-          ("description", `String "Optional archetype axis. Influences generated role, trait, goals, and instructions. Call masc_persona_schema for per-choice effects.");
-        ]);
-        ("operating_style", `Assoc [
-          ("type", `String "string");
-          ("enum", `List [
-            `String "research"; `String "coding"; `String "dispatch";
-            `String "social"; `String "delivery";
-          ]);
-          ("description", `String "Optional archetype axis. If tool_preset is omitted, this also selects the default keeper.tool_preset. Call masc_persona_schema for per-choice effects.");
-        ]);
-        ("risk_posture", `Assoc [
-          ("type", `String "string");
-          ("enum", `List [
-            `String "cautious"; `String "balanced"; `String "high-autonomy";
-          ]);
-          ("description", `String "Optional archetype axis. Influences generated autonomy and safety language while save still validates concrete fields. Call masc_persona_schema for per-choice effects.");
-        ]);
+        ("alignment", persona_axis_schema Persona_contract.alignment_axis);
+        ("operating_style", persona_axis_schema Persona_contract.operating_style_axis);
+        ("risk_posture", persona_axis_schema Persona_contract.risk_posture_axis);
         ("tool_preset", `Assoc [
           ("type", `String "string");
-          ("default", `String "research");
+          ("default", `String Persona_contract.default_tool_preset);
           ("enum", `List (List.map (fun s -> `String s) tool_preset_enum_strings));
-          ("description", `String "Default keeper.tool_preset for the draft. When omitted, operating_style is used if present, otherwise research.");
+          ( "description"
+          , `String
+              (Printf.sprintf
+                 "Default keeper.tool_preset for the draft. When omitted, \
+                  operating_style is used if present, otherwise %s."
+                 Persona_contract.default_tool_preset) );
         ]);
         ("proactive_enabled", `Assoc [
           ("type", `String "boolean");
-          ("default", `Bool false);
+          ("default", `Bool Persona_contract.default_proactive_enabled);
           ("description", `String "Default keeper.proactive_enabled for the draft.");
         ]);
         ("cascade_name", `Assoc [
           ("type", `String "string");
-          ("default", `String "operator_judge");
+          ("default", `String Persona_contract.default_generation_cascade_name);
           ("description", `String "Named cascade used to draft the persona.");
         ]);
         ("temperature", `Assoc [
           ("type", `String "number");
-          ("default", `Float 0.7);
+          ("default", `Float Persona_contract.default_temperature);
         ]);
         ("max_tokens", `Assoc [
           ("type", `String "integer");
-          ("default", `Int 2500);
+          ("default", `Int Persona_contract.default_max_tokens);
         ]);
       ]);
       ("required", `List [`String "concept"]);

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -646,7 +646,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
               |> String.lowercase_ascii
             in
             let compile_known = Keeper_cascade_profile.known_cascades in
-            let phase_routing = [ "local_only"; "local_recovery" ] in
+            let phase_routing = phase_routing_cascade_names in
             let catalog =
               try Keeper_cascade_profile.catalog_names ()
               with _ -> []

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -523,7 +523,46 @@ let test_masc_persona_authoring_schemas () =
           Alcotest.(check bool) "generate has operating_style axis" true
             (List.mem_assoc "operating_style" props);
           Alcotest.(check bool) "generate has risk_posture axis" true
-            (List.mem_assoc "risk_posture" props)
+            (List.mem_assoc "risk_posture" props);
+          let enum_strings name =
+            match List.assoc_opt name props with
+            | Some (`Assoc fields) ->
+                (match List.assoc_opt "enum" fields with
+                 | Some (`List values) -> List.map Yojson.Safe.Util.to_string values
+                 | _ -> [])
+            | _ -> []
+          in
+          let default_string name =
+            match List.assoc_opt name props with
+            | Some (`Assoc fields) ->
+                (match List.assoc_opt "default" fields with
+                 | Some (`String value) -> value
+                 | _ -> "")
+            | _ -> ""
+          in
+          let default_bool name =
+            match List.assoc_opt name props with
+            | Some (`Assoc fields) ->
+                (match List.assoc_opt "default" fields with
+                 | Some (`Bool value) -> value
+                 | _ -> false)
+            | _ -> false
+          in
+          let module Contract = Masc_mcp.Keeper_persona_authoring_contract in
+          Alcotest.(check (list string)) "alignment enum follows contract"
+            Contract.alignment_choices (enum_strings "alignment");
+          Alcotest.(check (list string)) "operating_style enum follows contract"
+            Contract.operating_style_choices (enum_strings "operating_style");
+          Alcotest.(check (list string)) "risk_posture enum follows contract"
+            Contract.risk_posture_choices (enum_strings "risk_posture");
+          Alcotest.(check string) "language default follows contract"
+            Contract.default_generation_language (default_string "language");
+          Alcotest.(check string) "tool_preset default follows contract"
+            Contract.default_tool_preset (default_string "tool_preset");
+          Alcotest.(check string) "cascade default follows contract"
+            Contract.default_generation_cascade_name (default_string "cascade_name");
+          Alcotest.(check bool) "proactive default follows contract"
+            Contract.default_proactive_enabled (default_bool "proactive_enabled")
       | None -> Alcotest.fail "masc_persona_generate missing properties"));
   match find_tool "masc_persona_save" with
   | None -> Alcotest.fail "masc_persona_save not found"


### PR DESCRIPTION
Summary:
- Move persona archetype choices, choice effects, and draft defaults into Keeper_persona_authoring_contract.
- Make masc_persona_generate schema and persona generation logic read from the same contract.
- Centralize phase-routing cascade names in Keeper_config and add schema drift coverage.

Verification:
- scripts/dune-local.sh build test/test_keeper_toml.exe test/test_tools_coverage.exe (passed before final rebase; final rerun was blocked by shared Dune lock and canceled)
- ./_build/default/test/test_keeper_toml.exe (passed before final rebase)
- ./_build/default/test/test_tools_coverage.exe (passed before final rebase)
- scripts/audit-hardcoding-truth.sh --fail-on-confirmed (passed on final head 94afaeb6e8)
- git diff --check origin/main..HEAD