### PR TITLE
fix(keeper): loud alert when supervisor exhausts max_restarts

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -588,11 +588,38 @@ let sweep_and_recover (ctx : _ context) =
     ignore (Keeper_registry.dispatch_event ~base_path entry.name
       Keeper_state_machine.Restart_budget_exhausted);
     Keeper_registry.mark_dead ~base_path entry.name ~at:now;
+    let detail =
+      Printf.sprintf "restart budget exhausted (%d), last: %s"
+        max_restarts msg
+    in
     publish_phase_lifecycle ~phase:Keeper_state_machine.Dead entry.name
-      (Printf.sprintf "restart budget exhausted (%d), last: %s"
-         max_restarts msg) ();
-    Log.Keeper.error "%s: restart budget exhausted (%d). Dead."
-      entry.name max_restarts
+      detail ();
+    (* Loud alert: structured Dead event + Prometheus counter so a fleet-wide
+       silent crash (8 keepers, 2026-04-25) is impossible to miss in dashboard
+       or PromQL. The free-form [event="dead"] on masc.keeper.lifecycle does
+       not carry restart_count or the structured failure reason. *)
+    let last_fr_str =
+      Option.map Keeper_registry.failure_reason_to_string
+        entry.last_failure_reason
+    in
+    (match Keeper_keepalive.get_bus () with
+     | Some bus ->
+         Oas_events.publish_keeper_dead bus
+           ~keeper_name:entry.name
+           ~reason:msg
+           ~restart_count:entry.restart_count
+           ~last_failure_reason:last_fr_str
+           ()
+     | None -> ());
+    Prometheus.inc_counter Prometheus.metric_keeper_dead_total
+      ~labels:[
+        ("keeper", entry.name);
+        ("reason", Option.value last_fr_str ~default:"unknown");
+      ] ();
+    Log.Keeper.error
+      "keeper DEAD (max_restarts exhausted): name=%s reason=%s \
+       restart_count=%d — operator action required"
+      entry.name msg entry.restart_count
   ) !to_mark_dead;
   List.iter (cleanup_dead_tombstone ctx) !to_cleanup_dead;
   let active_count =
@@ -626,7 +653,17 @@ let sweep_and_recover (ctx : _ context) =
           old_entry.name
           (Printf.sprintf "attempt %d" attempt) ();
         Log.Keeper.info "%s: restarted (attempt %d, backoff %.0fs)"
-          old_entry.name attempt (backoff_delay (attempt - 1))
+          old_entry.name attempt (backoff_delay (attempt - 1));
+        (* Soft pre-warning when this is the FINAL allowed restart: next
+           crash will trip the budget and mark Dead. Operator-actionable
+           but not yet a fault — investigate root cause now. *)
+        if attempt >= max_restarts then begin
+          Log.Keeper.warn
+            "keeper near-exhaustion: name=%s restart=%d/%d — investigate"
+            old_entry.name attempt max_restarts;
+          Prometheus.inc_counter Prometheus.metric_keeper_near_exhaustion_total
+            ~labels:[("keeper", old_entry.name)] ()
+        end
     | _ ->
         Log.Keeper.error "%s: cannot read meta for restart, removing"
           old_entry.name;

--- a/lib/oas_events.ml
+++ b/lib/oas_events.ml
@@ -186,6 +186,31 @@ let publish_keeper_lifecycle (_bus : Oas.Event_bus.t)
   masc_publish
     (Oas.Event_bus.mk_event (Custom ("masc.keeper.lifecycle", payload)))
 
+(** Publish a structured keeper-Dead event.
+
+    Emitted when [Keeper_supervisor.sweep_and_recover] gives up on a keeper
+    after [restart_count >= max_restarts]. Operators should treat this as
+    actionable: the supervisor will NOT retry the keeper. Independent from
+    the [event="dead"] entry on [masc.keeper.lifecycle] (which is unstructured
+    free-form [detail]) so subscribers can filter on a stable topic and pull
+    the structured fields directly. Topic: [masc.keeper.dead]. *)
+let publish_keeper_dead (_bus : Oas.Event_bus.t)
+    ~keeper_name ~reason ~restart_count ~last_failure_reason () =
+  let last_failure_json =
+    match last_failure_reason with
+    | Some s -> `String s
+    | None -> `Null
+  in
+  let payload = `Assoc [
+    ("keeper_name", `String keeper_name);
+    ("reason", `String reason);
+    ("restart_count", `Int restart_count);
+    ("last_failure_reason", last_failure_json);
+    ("timestamp", `Float (Time_compat.now ()));
+  ] in
+  masc_publish
+    (Oas.Event_bus.mk_event (Custom ("masc.keeper.dead", payload)))
+
 (** {1 Phase 4: Social Events}
 
     These two publishers were scaffolded in #1060 (OAS v0.23

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -361,6 +361,8 @@ let metric_board_truncated_posts = "masc_board_truncated_posts_total"
 let metric_cascade_strategy_decisions = "masc_cascade_strategy_decisions_total"
 let metric_cascade_capacity_events = "masc_cascade_capacity_events_total"
 let metric_keeper_invariant_violations = "masc_keeper_invariant_violations_total"
+let metric_keeper_dead_total = "masc_keeper_dead_total"
+let metric_keeper_near_exhaustion_total = "masc_keeper_near_exhaustion_total"
 let metric_oas_bus_subscriber_stream_depth = "masc_oas_bus_subscriber_stream_depth"
 let metric_oas_bus_publish_block_seconds = "masc_oas_bus_publish_block_seconds_total"
 let metric_oas_bus_publish = "masc_oas_bus_publish_total"
@@ -487,6 +489,15 @@ let init () =
     "Total keeper turns that tolerated unexpected tool names because at least \
      one valid keeper tool call was present. Labeled by keeper_name and \
      logged=true|false so WARN suppression remains observable."
+    Counter;
+  add metric_keeper_dead_total
+    "Total keeper transitions to Dead phase after the supervisor exhausts \
+     max_restarts. Labeled by keeper and reason. Any rate >0 is operator-\
+     actionable: the supervisor will not retry the keeper."
+    Counter;
+  add metric_keeper_near_exhaustion_total
+    "Total keeper restart attempts at restart_count = max_restarts - 1, \
+     i.e. one failure away from Dead. Soft pre-warning; labeled by keeper."
     Counter;
   add metric_keeper_tool_alias_canonicalizations
     "Total observed LLM-facing tool names canonicalized to keeper internal \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -154,6 +154,15 @@ val metric_anti_rationalization_fallback : string
 val metric_cascade_strategy_decisions : string
 val metric_cascade_capacity_events : string
 val metric_keeper_invariant_violations : string
+val metric_keeper_dead_total : string
+(** Total keeper transitions to [Dead] phase after restart-budget exhaustion.
+    Labeled by [keeper] and [reason]. Operators should alert on any rate >0:
+    by construction Dead means the supervisor gave up and no further
+    restart will be attempted. *)
+val metric_keeper_near_exhaustion_total : string
+(** Total times a keeper restart attempt landed at
+    [restart_count = max_restarts - 1], i.e. one attempt away from Dead.
+    Soft pre-warning; labeled by [keeper]. *)
 val metric_oas_bus_subscriber_stream_depth : string
 val metric_oas_bus_publish_block_seconds : string
 val metric_oas_bus_publish : string

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -302,6 +302,72 @@ let test_sweep_restores_reconcile_gate_for_paused_keeper () =
       check bool "keeper registered after approval" true
         (Reg.is_registered ~base_path:config.base_path meta.name))
 
+(* ── Dead-state loud alert (PR-C) ──────────────────────── *)
+
+(* Reproduces the 2026-04-25 incident pattern: 8 keepers crashed silently
+   after the supervisor exhausted max_restarts. The ERROR log + Prometheus
+   counter + structured OAS event emitted from sweep_and_recover give
+   operators the signal that was missing. *)
+let test_max_restarts_exhaustion_emits_dead_alert () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Reg.clear ();
+      Masc_mcp.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
+      let name = "dead-alert-keeper" in
+      let meta = make_meta name in
+      (match KT.write_meta config meta with
+       | Ok () -> ()
+       | Error err -> fail err);
+      let reg = Reg.register ~base_path:config.base_path name meta in
+      (* Drive the entry to Crashed with restart_count already at the
+         default budget (5) so sweep takes the Dead branch on the first
+         pass, not the restart branch. *)
+      Eio.Promise.resolve reg.done_r (`Crashed "synthetic exhaustion");
+      Reg.set_failure_reason ~base_path:config.base_path name
+        (Some (Reg.Heartbeat_consecutive_failures 9));
+      let max_restarts =
+        Masc_mcp.Runtime_params.get
+          Masc_mcp.Governance_registry.keeper_supervisor_max_restarts
+      in
+      Reg.restore_supervisor_state ~base_path:config.base_path name
+        ~restart_count:max_restarts ~last_restart_ts:0.0 ~crash_log:[];
+      let baseline =
+        Masc_mcp.Prometheus.metric_total
+          Masc_mcp.Prometheus.metric_keeper_dead_total
+      in
+      let ctx : _ KT.context =
+        {
+          config;
+          agent_name = "supervisor";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = Some (Eio.Stdenv.net env);
+        }
+      in
+      Sup.sweep_and_recover ctx;
+      let after =
+        Masc_mcp.Prometheus.metric_total
+          Masc_mcp.Prometheus.metric_keeper_dead_total
+      in
+      check (float 0.001) "metric_keeper_dead_total incremented by 1"
+        (baseline +. 1.0) after;
+      (* Phase advanced to Dead. *)
+      let phase =
+        Reg.get_phase ~base_path:config.base_path name
+        |> Option.value ~default:Masc_mcp.Keeper_state_machine.Running
+      in
+      check bool "keeper phase advanced to Dead"
+        true (phase = Masc_mcp.Keeper_state_machine.Dead))
+
 (* ── Test runner ────────────────────────────────────────── *)
 
 let () =
@@ -341,5 +407,9 @@ let () =
     "reconcile_gate_recovery", [
       test_case "sweep restores reconcile gate for paused keeper" `Quick
         test_sweep_restores_reconcile_gate_for_paused_keeper;
+    ];
+    "dead_state_alert", [
+      test_case "max_restarts exhaustion emits Dead alert" `Quick
+        test_max_restarts_exhaustion_emits_dead_alert;
     ];
   ]


### PR DESCRIPTION
## Root cause

User reported "갑자기 다 잠에 빠져들었음" — 8 keepers crashed silently.
`Keeper_supervisor.sweep_and_recover` runs with `max_restarts=5` and,
once restart_count crosses the budget, marks the keeper `Dead` and
publishes a `event="dead"` row on `masc.keeper.lifecycle` with a
free-form `detail` string. There was no Prometheus counter and no
structured event; the lifecycle row was easy to miss. Operators only
noticed when the fleet went idle.

## Change

Three additions to the Dead transition (lib/keeper/keeper_supervisor.ml,
`to_mark_dead` branch in `sweep_and_recover`):

1. **ERROR log** with a stable, greppable format:
   `keeper DEAD (max_restarts exhausted): name=X reason=Y restart_count=N — operator action required`
2. **Prometheus counter** `masc_keeper_dead_total`
   labels: `keeper`, `reason` (from `last_failure_reason` or `unknown`)
3. **OAS event** `masc.keeper.dead` (new topic, same `Event_bus`)
   payload: `{keeper_name, reason, restart_count, last_failure_reason, timestamp}`
   Distinct from the unstructured `event="dead"` on
   `masc.keeper.lifecycle` so subscribers can filter on a stable topic
   and pull the structured fields directly.

Plus a soft pre-warning at the final allowed restart (in the restart
branch, when `attempt >= max_restarts`):

- WARN log: `keeper near-exhaustion: name=X restart=N/M — investigate`
- Counter `masc_keeper_near_exhaustion_total` (labels: `keeper`).

## Files

- `lib/prometheus.{ml,mli}` — two new counter constants registered with HELP.
- `lib/oas_events.ml` — `publish_keeper_dead` helper (uses existing `masc_publish` backbone, no new bus).
- `lib/keeper/keeper_supervisor.ml` — Dead branch + final-restart branch.
- `test/test_keeper_supervisor.ml` — alcotest case `dead_state_alert.max_restarts exhaustion emits Dead alert`.

## Test plan

- [x] `dune build @check --root .` — passes
- [x] `dune build bin/main_eio.exe --root .` — full link passes
- [x] `dune exec test/test_keeper_supervisor.exe --root .` — 19/19 OK including new case
- [ ] CI green
- [ ] PromQL spot check: `sum by (keeper) (masc_keeper_dead_total)` returns expected series after deploy

## Out of scope

- No version bump.
- No cascade.toml or governance code change.
- Scope kept under 200 lines (157 ins / 5 del).

## Why structured event vs reusing detail string

The existing `event="dead"` on `masc.keeper.lifecycle` carries only
free-form `detail`. Parsing `restart_count` out of "restart budget
exhausted (N), last: M" at every subscriber is fragile and was the
exact failure mode here — nobody parsed it. A dedicated topic with
typed fields is cheap and matches the existing
`publish_keeper_snapshot` / `publish_keeper_lifecycle` pattern in the
same module.