### PR TITLE
fix(governance): auto-approve keeper-routine masc_transition + keeper_board_post for autonomous flow

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -512,6 +512,7 @@
    keeper_turn_telemetry
    keeper_wake_telemetry
    keeper_approval_queue
+   keeper_routine_allowlist
    keeper_runtime_contract
    keeper_runtime_trust_snapshot
    keeper_agent_prompt_metrics

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -323,8 +323,21 @@ let to_oas_approval_callback
         Option.bind meta (fun (m : Keeper_types.keeper_meta) -> m.always_approve)
         |> Option.value ~default:false
       in
+      (* Routine allowlist: code-defined narrow auto-approval for keeper
+         task lifecycle. Covers masc_transition routine actions
+         (claim, start, heartbeat, done, release), keeper_board_post at
+         Low or Medium risk, and keeper_task_claim or _done or
+         _submit_for_verification. Gated by [forbidden] so destructive
+         actions (force_ prefixed, shell, git, Critical risk) still
+         require operator approval. See keeper_routine_allowlist.mli. *)
+      let routine_label =
+        if forbidden then None
+        else
+          Keeper_routine_allowlist.rule_label ~tool_name ~input
+            ~risk_level
+      in
       let rule_match =
-        if forbidden then
+        if forbidden || Option.is_some routine_label then
           None
         else
           Keeper_approval_queue.find_matching_rule
@@ -340,6 +353,20 @@ let to_oas_approval_callback
           ~goal_ids:(Option.value ~default:[] goal_ids) ?runtime_contract
           ?selected_model ~disposition:"Pass"
           ~disposition_reason:"always_approve_enabled" ~auto_approved:true ();
+        Oas.Hooks.Approve
+      ) else if Option.is_some routine_label then (
+        let label = Option.get routine_label in
+        Keeper_approval_queue.audit_approval_event
+          ?base_path
+          ~event_type:"auto_approved_keeper_routine"
+          ~id:(Printf.sprintf "auto_routine_%s_%s" keeper_name tool_name)
+          ~keeper_name ~tool_name ~risk_level ?turn_id ?task_id ?goal_id
+          ~goal_ids:(Option.value ~default:[] goal_ids) ?runtime_contract
+          ?selected_model ~disposition:"Pass"
+          ~disposition_reason:label ~auto_approved:true ();
+        Log.Governance.debug
+          "[%s] keeper-routine auto-approve tool=%s risk=%s label=%s"
+          keeper_name tool_name (risk_level_to_string risk) label;
         Oas.Hooks.Approve
       ) else
         match rule_match with

--- a/lib/keeper/keeper_routine_allowlist.ml
+++ b/lib/keeper/keeper_routine_allowlist.ml
@@ -1,0 +1,134 @@
+(** Keeper_routine_allowlist — code-defined auto-approval rules for keeper
+    autonomous task lifecycle. See keeper_routine_allowlist.mli for rationale. *)
+
+module RL = Keeper_approval_queue
+
+(* ── Action extraction ───────────────────────────────────── *)
+
+(** Extract the [action] field from a tool input JSON, lowercased and
+    trimmed. Returns [None] when the field is missing or non-string. *)
+let action_of_input (input : Yojson.Safe.t) : string option =
+  match input with
+  | `Assoc fields ->
+      (match List.assoc_opt "action" fields with
+       | Some (`String s) ->
+           let trimmed = String.trim s in
+           if trimmed = "" then None
+           else Some (String.lowercase_ascii trimmed)
+       | _ -> None)
+  | _ -> None
+
+(* ── Static rule table ────────────────────────────────────── *)
+
+(** Tool-specific allowlist rule. Each rule encodes:
+    - which tool name it applies to;
+    - the maximum risk level at which it auto-approves;
+    - an optional set of action strings (matched against the [action]
+      field in the input). [None] means "any input is allowed up to
+      [max_risk]" (no action discrimination needed);
+    - a short human-readable label for audit logs. *)
+type rule = {
+  tool : string;
+  max_risk : RL.risk_level;
+  allowed_actions : string list option;
+  label : string;
+}
+
+(** Allowlist rules. KEEP THIS LIST NARROW.
+
+    Adding entries here changes governance policy. Do not allowlist:
+    - destructive force_* actions (these are classified Critical via
+      "force" pattern and stopped by [auto_approval_forbidden] anyway,
+      but listing them here would be a defense-in-depth hole);
+    - shell or git tools (also blocked by [destructive_tool_or_op]);
+    - high/critical-risk tools.
+    *)
+let rules : rule list =
+  [
+    (* masc_transition: keeper task lifecycle. Only the routine actions
+       are allowlisted. cancel and force_* are intentionally excluded. *)
+    {
+      tool = "masc_transition";
+      max_risk = RL.Medium;
+      allowed_actions =
+        Some [ "claim"; "start"; "heartbeat"; "done"; "release" ];
+      label = "keeper_routine.masc_transition";
+    };
+
+    (* keeper_board_post: routine status posts. Up to Medium risk
+       auto-approves. High/Critical still require operator approval. *)
+    {
+      tool = "keeper_board_post";
+      max_risk = RL.Medium;
+      allowed_actions = None;
+      label = "keeper_routine.keeper_board_post";
+    };
+
+    (* Keeper-side task lifecycle helpers (counterpart to masc_transition
+       on the keeper tool surface). These are the standard autonomous
+       flow used by long-running keepers. *)
+    {
+      tool = "keeper_task_claim";
+      max_risk = RL.Medium;
+      allowed_actions = None;
+      label = "keeper_routine.keeper_task_claim";
+    };
+    {
+      tool = "keeper_task_done";
+      max_risk = RL.Medium;
+      allowed_actions = None;
+      label = "keeper_routine.keeper_task_done";
+    };
+    {
+      tool = "keeper_task_submit_for_verification";
+      max_risk = RL.Medium;
+      allowed_actions = None;
+      label = "keeper_routine.keeper_task_submit_for_verification";
+    };
+  ]
+
+(* ── Matching ─────────────────────────────────────────────── *)
+
+let action_matches (rule : rule) (input : Yojson.Safe.t) : bool =
+  match rule.allowed_actions with
+  | None -> true
+  | Some allowed ->
+      (match action_of_input input with
+       | None -> false
+       | Some action -> List.mem action allowed)
+
+let find_rule ~tool_name ~input ~risk_level : rule option =
+  List.find_opt
+    (fun rule ->
+      String.equal rule.tool tool_name
+      && RL.risk_level_to_int risk_level
+         <= RL.risk_level_to_int rule.max_risk
+      && action_matches rule input)
+    rules
+
+let matches ~tool_name ~input ~risk_level =
+  Option.is_some (find_rule ~tool_name ~input ~risk_level)
+
+let rule_label ~tool_name ~input ~risk_level =
+  Option.map
+    (fun (rule : rule) -> rule.label)
+    (find_rule ~tool_name ~input ~risk_level)
+
+(* ── Observability ────────────────────────────────────────── *)
+
+let rule_to_yojson (rule : rule) : Yojson.Safe.t =
+  let actions_json =
+    match rule.allowed_actions with
+    | None -> `String "*"
+    | Some xs -> `List (List.map (fun a -> `String a) xs)
+  in
+  `Assoc
+    [
+      ("tool", `String rule.tool);
+      ("max_risk", `String (RL.risk_level_to_string rule.max_risk));
+      ("allowed_actions", actions_json);
+      ("label", `String rule.label);
+    ]
+
+let rules_summary () : Yojson.Safe.t =
+  `List (List.map rule_to_yojson rules)

--- a/lib/keeper/keeper_routine_allowlist.mli
+++ b/lib/keeper/keeper_routine_allowlist.mli
@@ -1,0 +1,60 @@
+(** Keeper_routine_allowlist — code-defined auto-approval rules for keeper
+    autonomous task lifecycle.
+
+    Background: in production/enterprise/paranoid governance, certain
+    common keeper actions (e.g. masc_transition action=claim, action=done)
+    can land on or above the confirmation threshold and stall keepers in
+    [awaiting_approval] indefinitely. Operators are not always present to
+    approve every routine claim/heartbeat/done.
+
+    This module defines a narrow, code-only allowlist of (tool, action)
+    pairs that are safe for autonomous keeper flow. The rules are checked
+    by [Governance_pipeline.to_oas_approval_callback] AFTER the existing
+    [auto_approval_forbidden] gate, so:
+
+    - destructive_tool_or_op shell or git tools still gate
+    - Critical risk still gates
+    - runtime_auto_approval_blocked (cascade_exhausted etc.) still gates
+    - force_* actions still gate (classified as Critical via "force"
+      pattern in {!Governance_pipeline_risk.classify_name})
+
+    The allowlist is intentionally narrow:
+    - [masc_transition]: only claim, start, heartbeat, done, release.
+      cancel and force_* are NOT allowlisted.
+    - [keeper_board_post]: any post at risk Low or Medium.
+    - [keeper_task_claim], [keeper_task_done],
+      [keeper_task_submit_for_verification]: standard autonomous flow.
+
+    These rules are not persisted; they are part of the policy code surface
+    and require code review to change. Operator-managed rules continue to
+    flow through {!Keeper_approval_queue.find_matching_rule}.
+
+    @since 2.270.0 *)
+
+(** Returns [true] when the given tool call matches a routine
+    allowlist rule. Caller is assumed to be a keeper agent (this is
+    only ever invoked from the keeper OAS approval callback path).
+
+    [risk_level] is the risk classification computed by
+    {!Governance_pipeline.assess_risk}. [keeper_board_post] is
+    rejected at [High]/[Critical].
+
+    Returns [false] for any tool/action pair not on the allowlist;
+    this preserves the human-loop for non-routine flows. *)
+val matches :
+  tool_name:string ->
+  input:Yojson.Safe.t ->
+  risk_level:Keeper_approval_queue.risk_level ->
+  bool
+
+(** A short label describing which rule matched. Returns [None] when
+    no rule matches. Useful for audit logs and dashboard observability. *)
+val rule_label :
+  tool_name:string ->
+  input:Yojson.Safe.t ->
+  risk_level:Keeper_approval_queue.risk_level ->
+  string option
+
+(** Returns the static rule list as JSON for dashboard inspection.
+    Shape: [[ { tool, allowed_actions, max_risk, note } ... ]]. *)
+val rules_summary : unit -> Yojson.Safe.t

--- a/test/dune
+++ b/test/dune
@@ -590,6 +590,7 @@
         test_tool_result
         test_tool_hooks
         test_governance_pipeline
+        test_keeper_routine_allowlist
         test_keeper_agent_isolation
         test_sse_external_sub
         test_ws_transport
@@ -765,6 +766,7 @@
         test_tool_result
         test_tool_hooks
         test_governance_pipeline
+        test_keeper_routine_allowlist
         test_keeper_agent_isolation
         test_sse_external_sub
         test_ws_transport

--- a/test/test_keeper_routine_allowlist.ml
+++ b/test/test_keeper_routine_allowlist.ml
@@ -1,0 +1,281 @@
+(** Tests for Keeper_routine_allowlist — narrow auto-approval for keeper
+    task lifecycle. *)
+
+module RA = Masc_mcp.Keeper_routine_allowlist
+module RL = Masc_mcp.Keeper_approval_queue
+
+let transition_input action =
+  `Assoc [ ("action", `String action); ("task_id", `String "task-1") ]
+
+(* ── matches: masc_transition routine actions ──────────────── *)
+
+let test_transition_claim_matches () =
+  let input = transition_input "claim" in
+  Alcotest.(check bool) "claim matches"
+    true
+    (RA.matches ~tool_name:"masc_transition" ~input ~risk_level:RL.Medium)
+
+let test_transition_start_matches () =
+  let input = transition_input "start" in
+  Alcotest.(check bool) "start matches"
+    true
+    (RA.matches ~tool_name:"masc_transition" ~input ~risk_level:RL.Medium)
+
+let test_transition_heartbeat_matches () =
+  let input = transition_input "heartbeat" in
+  Alcotest.(check bool) "heartbeat matches"
+    true
+    (RA.matches ~tool_name:"masc_transition" ~input ~risk_level:RL.Low)
+
+let test_transition_done_matches () =
+  let input = transition_input "done" in
+  Alcotest.(check bool) "done matches"
+    true
+    (RA.matches ~tool_name:"masc_transition" ~input ~risk_level:RL.Low)
+
+let test_transition_release_matches () =
+  let input = transition_input "release" in
+  Alcotest.(check bool) "release matches"
+    true
+    (RA.matches ~tool_name:"masc_transition" ~input ~risk_level:RL.Low)
+
+(* ── matches: NOT allowlisted (still gated) ─────────────────── *)
+
+let test_transition_cancel_not_matched () =
+  let input = transition_input "cancel" in
+  Alcotest.(check bool) "cancel does not match (gated)"
+    false
+    (RA.matches ~tool_name:"masc_transition" ~input ~risk_level:RL.Medium)
+
+let test_transition_force_release_not_matched () =
+  let input = transition_input "force_release" in
+  Alcotest.(check bool) "force_release does not match"
+    false
+    (RA.matches ~tool_name:"masc_transition" ~input
+       ~risk_level:RL.Critical)
+
+let test_transition_force_done_not_matched () =
+  let input = transition_input "force_done" in
+  Alcotest.(check bool) "force_done does not match"
+    false
+    (RA.matches ~tool_name:"masc_transition" ~input
+       ~risk_level:RL.Critical)
+
+let test_transition_unknown_action_not_matched () =
+  let input = transition_input "wibble" in
+  Alcotest.(check bool) "unknown action does not match"
+    false
+    (RA.matches ~tool_name:"masc_transition" ~input ~risk_level:RL.Medium)
+
+let test_transition_missing_action_not_matched () =
+  let input = `Assoc [ ("task_id", `String "t-1") ] in
+  Alcotest.(check bool) "missing action does not match"
+    false
+    (RA.matches ~tool_name:"masc_transition" ~input ~risk_level:RL.Low)
+
+let test_case_insensitive_action () =
+  let input = `Assoc [ ("action", `String "CLAIM") ] in
+  Alcotest.(check bool) "uppercase CLAIM matches (lowercased)"
+    true
+    (RA.matches ~tool_name:"masc_transition" ~input ~risk_level:RL.Medium)
+
+(* ── matches: keeper_board_post risk ceiling ────────────────── *)
+
+let test_board_post_low_matches () =
+  Alcotest.(check bool) "board_post Low matches"
+    true
+    (RA.matches ~tool_name:"keeper_board_post"
+       ~input:(`Assoc [ ("body", `String "status update") ])
+       ~risk_level:RL.Low)
+
+let test_board_post_medium_matches () =
+  Alcotest.(check bool) "board_post Medium matches"
+    true
+    (RA.matches ~tool_name:"keeper_board_post"
+       ~input:(`Assoc [ ("body", `String "status update") ])
+       ~risk_level:RL.Medium)
+
+let test_board_post_high_does_not_match () =
+  Alcotest.(check bool) "board_post High exceeds max_risk"
+    false
+    (RA.matches ~tool_name:"keeper_board_post"
+       ~input:(`Assoc [ ("body", `String "alert") ])
+       ~risk_level:RL.High)
+
+let test_board_post_critical_does_not_match () =
+  Alcotest.(check bool) "board_post Critical exceeds max_risk"
+    false
+    (RA.matches ~tool_name:"keeper_board_post"
+       ~input:(`Assoc [])
+       ~risk_level:RL.Critical)
+
+(* ── matches: keeper task tool surface ──────────────────────── *)
+
+let test_keeper_task_claim_matches () =
+  Alcotest.(check bool) "keeper_task_claim matches"
+    true
+    (RA.matches ~tool_name:"keeper_task_claim"
+       ~input:(`Assoc [ ("task_id", `String "t-1") ])
+       ~risk_level:RL.Medium)
+
+let test_keeper_task_done_matches () =
+  Alcotest.(check bool) "keeper_task_done matches"
+    true
+    (RA.matches ~tool_name:"keeper_task_done"
+       ~input:(`Assoc [])
+       ~risk_level:RL.Medium)
+
+let test_keeper_task_submit_for_verification_matches () =
+  Alcotest.(check bool) "keeper_task_submit_for_verification matches"
+    true
+    (RA.matches ~tool_name:"keeper_task_submit_for_verification"
+       ~input:(`Assoc [])
+       ~risk_level:RL.Low)
+
+(* ── matches: unrelated tools never match ──────────────────── *)
+
+let test_keeper_shell_does_not_match () =
+  Alcotest.(check bool) "keeper_shell never auto-approved by routine list"
+    false
+    (RA.matches ~tool_name:"keeper_shell"
+       ~input:(`Assoc [ ("action", `String "ls") ])
+       ~risk_level:RL.Low)
+
+let test_keeper_fs_edit_does_not_match () =
+  Alcotest.(check bool) "keeper_fs_edit never auto-approved"
+    false
+    (RA.matches ~tool_name:"keeper_fs_edit"
+       ~input:(`Assoc [])
+       ~risk_level:RL.Medium)
+
+let test_unknown_tool_does_not_match () =
+  Alcotest.(check bool) "unknown tool does not match"
+    false
+    (RA.matches ~tool_name:"random_tool_xyz"
+       ~input:(`Assoc [])
+       ~risk_level:RL.Low)
+
+(* ── rule_label observability ──────────────────────────────── *)
+
+let test_rule_label_for_claim () =
+  let label =
+    RA.rule_label ~tool_name:"masc_transition"
+      ~input:(transition_input "claim")
+      ~risk_level:RL.Medium
+  in
+  Alcotest.(check (option string)) "claim has routine label"
+    (Some "keeper_routine.masc_transition") label
+
+let test_rule_label_for_cancel_is_none () =
+  let label =
+    RA.rule_label ~tool_name:"masc_transition"
+      ~input:(transition_input "cancel")
+      ~risk_level:RL.Medium
+  in
+  Alcotest.(check (option string)) "cancel has no label" None label
+
+(* ── rules_summary: stable JSON shape for dashboard ─────────── *)
+
+let test_rules_summary_is_list () =
+  let summary = RA.rules_summary () in
+  match summary with
+  | `List entries ->
+      Alcotest.(check bool) "summary has at least the 5 expected rules"
+        true
+        (List.length entries >= 5)
+  | _ -> Alcotest.fail "rules_summary should return `List"
+
+let test_rules_summary_includes_masc_transition () =
+  let summary = RA.rules_summary () in
+  match summary with
+  | `List entries ->
+      let has_masc_transition =
+        List.exists
+          (function
+            | `Assoc fields ->
+                (match List.assoc_opt "tool" fields with
+                 | Some (`String "masc_transition") -> true
+                 | _ -> false)
+            | _ -> false)
+          entries
+      in
+      Alcotest.(check bool) "summary includes masc_transition"
+        true has_masc_transition
+  | _ -> Alcotest.fail "rules_summary should return `List"
+
+(* ── Runner ───────────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "Keeper_routine_allowlist"
+    [
+      ( "transition_routine_actions",
+        [
+          Alcotest.test_case "claim auto-approves" `Quick
+            test_transition_claim_matches;
+          Alcotest.test_case "start auto-approves" `Quick
+            test_transition_start_matches;
+          Alcotest.test_case "heartbeat auto-approves" `Quick
+            test_transition_heartbeat_matches;
+          Alcotest.test_case "done auto-approves" `Quick
+            test_transition_done_matches;
+          Alcotest.test_case "release auto-approves" `Quick
+            test_transition_release_matches;
+          Alcotest.test_case "case-insensitive action" `Quick
+            test_case_insensitive_action;
+        ] );
+      ( "transition_gated_actions",
+        [
+          Alcotest.test_case "cancel still gated" `Quick
+            test_transition_cancel_not_matched;
+          Alcotest.test_case "force_release still gated" `Quick
+            test_transition_force_release_not_matched;
+          Alcotest.test_case "force_done still gated" `Quick
+            test_transition_force_done_not_matched;
+          Alcotest.test_case "unknown action gated" `Quick
+            test_transition_unknown_action_not_matched;
+          Alcotest.test_case "missing action gated" `Quick
+            test_transition_missing_action_not_matched;
+        ] );
+      ( "board_post_risk_ceiling",
+        [
+          Alcotest.test_case "Low passes" `Quick
+            test_board_post_low_matches;
+          Alcotest.test_case "Medium passes" `Quick
+            test_board_post_medium_matches;
+          Alcotest.test_case "High blocked" `Quick
+            test_board_post_high_does_not_match;
+          Alcotest.test_case "Critical blocked" `Quick
+            test_board_post_critical_does_not_match;
+        ] );
+      ( "keeper_task_lifecycle",
+        [
+          Alcotest.test_case "keeper_task_claim" `Quick
+            test_keeper_task_claim_matches;
+          Alcotest.test_case "keeper_task_done" `Quick
+            test_keeper_task_done_matches;
+          Alcotest.test_case "keeper_task_submit_for_verification" `Quick
+            test_keeper_task_submit_for_verification_matches;
+        ] );
+      ( "non_routine_tools_never_match",
+        [
+          Alcotest.test_case "keeper_shell" `Quick
+            test_keeper_shell_does_not_match;
+          Alcotest.test_case "keeper_fs_edit" `Quick
+            test_keeper_fs_edit_does_not_match;
+          Alcotest.test_case "unknown tool" `Quick
+            test_unknown_tool_does_not_match;
+        ] );
+      ( "rule_label",
+        [
+          Alcotest.test_case "claim has label" `Quick
+            test_rule_label_for_claim;
+          Alcotest.test_case "cancel has no label" `Quick
+            test_rule_label_for_cancel_is_none;
+        ] );
+      ( "rules_summary",
+        [
+          Alcotest.test_case "is a list" `Quick test_rules_summary_is_list;
+          Alcotest.test_case "includes masc_transition" `Quick
+            test_rules_summary_includes_masc_transition;
+        ] );
+    ]


### PR DESCRIPTION
## Problem

In production governance mode, common keeper task-lifecycle tools land at or above the keeper confirm threshold and return `awaiting_approval`. Unattended autonomous keepers cannot complete the standard claim → start → heartbeat → done → release flow without an operator clicking approve, which stalls the swarm whenever no operator is present.

Symptom (production logs, `[STATE]` blocks for keeper sangsu show repeated):
- `tool=masc_transition action=claim risk=medium -> awaiting_approval` (paranoid threshold = Medium)
- `tool=keeper_board_post risk=high -> awaiting_approval` (enterprise threshold = High)
- Keeper turn budget bleeds in Pause until cascade_exhausted.

## Approach (PR-A from plan, Option 1: narrow allowlist)

Add a code-defined narrow allowlist module `Keeper_routine_allowlist` (`lib/keeper/keeper_routine_allowlist.{ml,mli}`) checked inside `Governance_pipeline.to_oas_approval_callback` after the existing `auto_approval_forbidden` gate.

The check sits between `meta.always_approve` (operator override) and `Keeper_approval_queue.find_matching_rule` (operator-managed persistent rules), so the precedence is:

1. `auto_approval_forbidden` (Critical risk, destructive tool/op, runtime-blocked) → still gates
2. `meta.always_approve` (operator override) → Approve
3. **Routine allowlist (new)** → Approve + audit `auto_approved_keeper_routine`
4. `Keeper_approval_queue.find_matching_rule` (operator-defined fingerprint rules) → Approve
5. Otherwise → `submit_and_await` (HITL)

## Action allowlist (auto-approve)

| Tool | Allowed | Max risk |
|------|---------|----------|
| `masc_transition` | `claim`, `start`, `heartbeat`, `done`, `release` | Medium |
| `keeper_board_post` | (any input) | Medium |
| `keeper_task_claim` | (any input) | Medium |
| `keeper_task_done` | (any input) | Medium |
| `keeper_task_submit_for_verification` | (any input) | Medium |

## Still gated (intentional human-loop)

- `masc_transition` action=`cancel` — Medium risk but excluded; cancel is not a routine autonomous action.
- `masc_transition` action=`force_release` / `force_done` — classified Critical via "force" pattern in `Governance_pipeline_risk.classify_name`, blocked by `auto_approval_forbidden`.
- `keeper_board_post` at High/Critical risk (allowlist `max_risk = Medium`).
- Any tool tagged `destructive_tool_or_op` (shell, git, git_push, git_reset, etc.).
- Runtime-blocked keepers (`cascade_exhausted`, `completion_contract_violation`, manual block).
- Non-keeper callers — this callback is only installed for keeper agents (see `lib/keeper/keeper_agent_run.ml:2039`), so dashboard/operator/MCP tool calls go through the legacy `make_pre_hook` path which is **unchanged**.

## Constraints honored

- `MASC_GOVERNANCE_LEVEL` default unchanged. Production stays production.
- No bypass of `keeper_task_force_release`, `keeper_task_force_done`, `masc_transition action=force_*`, or any `destructive_tool_or_op`.
- No supervisor or cascade code touched.
- Diff: production code 31 LOC + 194 LOC new module = ~225 LOC. Tests 281 LOC.

## Test plan

- [x] `dune build @check --root .` — passes
- [x] `dune exec test/test_keeper_routine_allowlist.exe --root .` — 25/25 pass
  - claim/start/heartbeat/done/release auto-approve
  - cancel, force_release, force_done, unknown action, missing action all gated
  - keeper_board_post Low/Medium pass, High/Critical blocked
  - keeper_task_claim/done/submit_for_verification pass
  - keeper_shell, keeper_fs_edit, unknown tools never match
  - rule_label observability + rules_summary JSON shape
- [x] `dune exec test/test_governance_pipeline.exe --root .` — 87/87 pass (existing)

## Audit shape

Successful routine bypass writes to `<base_path>/.masc/audit-approvals/YYYY-MM/DD.jsonl`:

```
{"event":"auto_approved_keeper_routine","keeper":"sangsu","tool":"masc_transition",
 "risk":"medium","disposition":"Pass","disposition_reason":"keeper_routine.masc_transition",
 "auto_approved":true,...}
```

Distinguishable from `auto_approved_always` (meta.always_approve) and `auto_approved_rule_match` (operator-defined rules).

## Notes

- This is the highest-risk PR in the plan (touches governance policy). Reviewers: please scrutinize the action allowlist and the precedence ordering against the destructive checks.
- `do-not-merge` label is set; PR stays Draft until reviewed.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>