### PR TITLE
fix(keeper): skip turn when ollama cascade is saturated to avoid budget timeouts

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -207,6 +207,91 @@ let fail_open_local_only_when_unavailable
          if List.exists probe ollama_base_urls then effective_cascade
          else fallback_cascade)
 
+(** PR-B: ollama saturation pre-skip support.
+
+    When every label in the resolved cascade points at the same
+    ollama [base_url] (single-provider profile), we can pre-check the
+    [Cascade_ollama_probe] cache before paying an [Agent.run] dispatch.
+    If the probe reports [process_available <= 0] the request would
+    queue on a busy slot and very likely blow the keeper turn budget,
+    causing a cascading FAILED cycle.  Skipping the turn here keeps
+    the keeper alive without burning the budget. *)
+
+(** [resolve_ollama_only_base_url ?resolve_label labels] returns
+    [Some url] when [labels] is non-empty AND every label parses to
+    an ollama provider config sharing the same [base_url].  Returns
+    [None] when the cascade has zero candidates, when any candidate
+    is non-ollama, when ollama candidates point at different hosts,
+    or when any label fails to parse.
+
+    Pure: [resolve_label] is the only injected dependency for tests. *)
+let resolve_ollama_only_base_url
+    ?resolve_label
+    (labels : string list) : string option =
+  let resolve_label =
+    match resolve_label with
+    | Some f -> f
+    | None -> fun label -> Cascade_config.parse_model_string label
+  in
+  match labels with
+  | [] -> None
+  | first :: rest ->
+      let is_ollama_cfg (cfg : Llm_provider.Provider_config.t) =
+        match cfg.kind with
+        | Llm_provider.Provider_config.Ollama -> true
+        | _ -> false
+      in
+      (match resolve_label first with
+       | Some cfg when is_ollama_cfg cfg ->
+           let base_url = cfg.base_url in
+           let same_ollama_host label =
+             match resolve_label label with
+             | Some other when is_ollama_cfg other ->
+                 String.equal other.base_url base_url
+             | _ -> false
+           in
+           if List.for_all same_ollama_host rest then Some base_url
+           else None
+       | _ -> None)
+
+(** [is_ollama_saturated ?capacity_lookup base_url] returns [true]
+    only when the cache has a fresh entry whose
+    [process_available <= 0] AND there is at least one queued or
+    active request.  [None] (no cache entry / probe never ran) and
+    failed probes are deliberately treated as "not saturated" so a
+    flaky probe never starves the keeper.  Mirrors the conservative
+    fail-open policy in [Cascade_ollama_probe.try_probe]. *)
+let is_ollama_saturated
+    ?capacity_lookup
+    (base_url : string) : bool =
+  let capacity_lookup =
+    match capacity_lookup with
+    | Some f -> f
+    | None -> fun url -> Cascade_ollama_probe.cached_capacity url
+  in
+  match capacity_lookup base_url with
+  | None -> false
+  | Some (info : Cascade_throttle.capacity_info) ->
+      info.process_available <= 0
+      && (info.process_active > 0 || info.process_queue_length > 0)
+
+(** Backoff sleep applied after a saturation skip so the keeper does
+    not hot-spin against a busy ollama instance. Short by design:
+    the heartbeat loop already has its own pacing (see
+    [keeper_keepalive.ml]); this only covers the case where multiple
+    keepers race the probe cache. *)
+let saturation_skip_backoff_sec = 5.0
+
+let saturation_skip_jitter_factor = 0.4
+
+let saturation_skip_sleep_duration () =
+  let jitter =
+    saturation_skip_backoff_sec
+    *. saturation_skip_jitter_factor
+    *. Random.float 1.0
+  in
+  saturation_skip_backoff_sec +. jitter
+
 (* Extracted to Keeper_error_classify — see keeper_error_classify.ml *)
 
 module EC = Keeper_error_classify
@@ -769,6 +854,61 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
              | _ -> effective_cascade_name)
         | None -> effective_cascade_name
       in
+      (* PR-B: ollama saturation pre-skip.  If the resolved cascade
+         is ollama-only and the [/api/ps] cache reports zero
+         available slots, skip this cycle BEFORE [Agent.run] dispatch
+         so the queued request cannot exceed the keeper turn budget
+         and trip a FAILED cycle.  Probe failures fall through to the
+         normal dispatch path (fail-open) so a flaky probe never
+         starves the keeper. *)
+      let saturation_skip_meta =
+        let meta_for_check =
+          { meta with cascade_name = effective_cascade_name }
+        in
+        let labels =
+          Keeper_coordination.effective_model_labels_for_turn meta_for_check
+        in
+        match resolve_ollama_only_base_url labels with
+        | None -> None
+        | Some base_url ->
+            if not (is_ollama_saturated base_url) then None
+            else
+              let info = Cascade_ollama_probe.cached_capacity base_url in
+              let queue_len =
+                match info with
+                | Some i -> i.process_queue_length
+                | None -> 0
+              in
+              let available =
+                match info with
+                | Some i -> i.process_available
+                | None -> 0
+              in
+              Log.Keeper.info
+                "%s: ollama saturated for keeper=%s cascade=%s queue=%d \
+                 available=%d \xe2\x80\x94 skipping turn"
+                meta.name meta.name effective_cascade_name queue_len
+                available;
+              Prometheus.inc_counter
+                Prometheus.metric_keeper_ollama_saturation_skip
+                ~labels:[ ("keeper", meta.name);
+                          ("cascade", effective_cascade_name) ]
+                ();
+              (match Eio_context.get_clock_opt () with
+               | Some clock ->
+                   (try Eio.Time.sleep clock (saturation_skip_sleep_duration ())
+                    with
+                    | Eio.Cancel.Cancelled _ as e -> raise e
+                    | exn ->
+                        Log.Keeper.debug
+                          "%s: saturation skip sleep failed: %s"
+                          meta.name (Printexc.to_string exn))
+               | None -> ());
+              Some meta
+      in
+      (match saturation_skip_meta with
+       | Some meta_after_skip -> Ok meta_after_skip
+       | None ->
       let build_cascade_execution ~(cascade_name : string) :
           (cascade_execution, Oas.Error.sdk_error) result =
         let meta_for_cascade = { meta with cascade_name } in
@@ -2159,6 +2299,6 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
            | Oas_worker.Completed ->
              Keeper_registry.reset_turn_failures ~base_path:config.base_path
                updated_meta.name);
-          Ok updated_meta
+          Ok updated_meta)
 
 let run_unified_turn = run_keeper_cycle

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -117,6 +117,23 @@ val fail_open_local_only_when_unavailable :
   string list ->
   string
 
+(** PR-B: when every label in the resolved cascade points at the
+    same ollama [base_url] return [Some url], else [None].  Purely
+    structural: does not probe the network. *)
+val resolve_ollama_only_base_url :
+  ?resolve_label:(string -> Llm_provider.Provider_config.t option) ->
+  string list ->
+  string option
+
+(** PR-B: read the [Cascade_ollama_probe] cache and report whether
+    the endpoint is saturated (no available slots while at least one
+    request is active or queued).  No cache / failed probe returns
+    [false] (fail-open) so a flaky probe never starves the keeper. *)
+val is_ollama_saturated :
+  ?capacity_lookup:(string -> Cascade_throttle.capacity_info option) ->
+  string ->
+  bool
+
 (** Pure merge step for runtime-owned fail-open rotation candidates. The
     active path feeds this from the live cascade catalog: catalog order is
     preserved while retaining only reserved recovery profiles and

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -308,6 +308,10 @@ let metric_keeper_profile_config_conflicts =
   "masc_keeper_profile_config_conflicts_total"
 let metric_keeper_oas_timeout_classifications =
   "masc_keeper_oas_timeout_classifications_total"
+(* PR-B: keeper turn skipped due to ollama saturation pre-check.
+   Labelled by [keeper] and [cascade]. *)
+let metric_keeper_ollama_saturation_skip =
+  "masc_keeper_ollama_saturation_skip_total"
 let metric_persistence_read_drops =
   "masc_persistence_read_drops_total"
 
@@ -649,6 +653,11 @@ let init () =
   add metric_keeper_oas_timeout_classifications
     "Total keeper OAS timeout classifications. Labeled by \
      classification=transient_network|structural_budget|other_timeout."
+    Counter;
+  add metric_keeper_ollama_saturation_skip
+    "Total keeper turns skipped because the resolved cascade is \
+     ollama-only and the /api/ps probe reported zero available slots. \
+     Labeled by keeper and cascade."
     Counter;
   add metric_persistence_read_drops
     "Total persisted read-model entries dropped during filesystem scans, \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -117,6 +117,12 @@ val metric_keeper_require_tool_use_violations : string
 val metric_keeper_tool_alias_canonicalizations : string
 val metric_keeper_profile_config_conflicts : string
 val metric_keeper_oas_timeout_classifications : string
+val metric_keeper_ollama_saturation_skip : string
+(** PR-B: counter incremented when [run_keeper_cycle] skips a turn
+    because the keeper's resolved cascade is ollama-only and the
+    [/api/ps] probe reports zero process_available slots.  Labelled
+    by [keeper] and [cascade] so dashboards can attribute starvation
+    to specific cascade profiles. *)
 val metric_persistence_read_drops : string
 val metric_codex_cli_mcp_tool_omission : string
 (** #10097: per-tool counter for codex_cli keeper-bound runtime

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2925,6 +2925,91 @@ let test_fail_open_local_only_preserves_healthy_local_only () =
   in
   check string "healthy ollama keeps local_only" "local_only" cascade
 
+(* PR-B: ollama saturation pre-skip helpers. *)
+
+let make_capacity_info ?(total = 1) ?(active = 0) ?(available = 1)
+    ?(queue = 0) () : Masc_mcp.Cascade_throttle.capacity_info =
+  {
+    total;
+    process_active = active;
+    process_available = available;
+    process_queue_length = queue;
+    source = Llm_provider.Provider_throttle.Discovered;
+  }
+
+let test_resolve_ollama_only_base_url_empty_returns_none () =
+  match UT.resolve_ollama_only_base_url [] with
+  | None -> ()
+  | Some _ -> fail "empty labels should not resolve to ollama-only"
+
+let test_resolve_ollama_only_base_url_single_ollama () =
+  let label = "ollama:qwen3.6:35b-a3b-mlx-bf16" in
+  let cfg = provider_config_of_label label in
+  match UT.resolve_ollama_only_base_url [ label ] with
+  | Some url -> check string "single ollama base url" cfg.base_url url
+  | None -> fail "single ollama label should resolve"
+
+let test_resolve_ollama_only_base_url_mixed_provider () =
+  match
+    UT.resolve_ollama_only_base_url
+      [ "ollama:qwen3.6:35b-a3b-mlx-bf16"; "claude:sonnet-4-5" ]
+  with
+  | None -> ()
+  | Some _ -> fail "mixed provider must not be classified as ollama-only"
+
+let test_resolve_ollama_only_base_url_different_hosts () =
+  let resolve_label = function
+    | "ollama:a" ->
+        Some
+          (Llm_provider.Provider_config.make
+             ~kind:Llm_provider.Provider_config.Ollama
+             ~model_id:"a"
+             ~base_url:"http://127.0.0.1:11434"
+             ())
+    | "ollama:b" ->
+        Some
+          (Llm_provider.Provider_config.make
+             ~kind:Llm_provider.Provider_config.Ollama
+             ~model_id:"b"
+             ~base_url:"http://10.0.0.5:11434"
+             ())
+    | _ -> None
+  in
+  match
+    UT.resolve_ollama_only_base_url ~resolve_label
+      [ "ollama:a"; "ollama:b" ]
+  with
+  | None -> ()
+  | Some _ -> fail "different ollama hosts must not collapse"
+
+let test_is_ollama_saturated_returns_false_when_cache_missing () =
+  let url = "http://127.0.0.1:11434" in
+  check bool "missing cache treated as healthy" false
+    (UT.is_ollama_saturated ~capacity_lookup:(fun _ -> None) url)
+
+let test_is_ollama_saturated_returns_false_when_idle () =
+  let url = "http://127.0.0.1:11434" in
+  let info = make_capacity_info ~active:0 ~available:1 ~queue:0 () in
+  check bool "idle endpoint not saturated" false
+    (UT.is_ollama_saturated
+       ~capacity_lookup:(fun _ -> Some info) url)
+
+let test_is_ollama_saturated_returns_true_when_full_with_queue () =
+  let url = "http://127.0.0.1:11434" in
+  let info = make_capacity_info ~active:1 ~available:0 ~queue:3 () in
+  check bool "full endpoint with queue is saturated" true
+    (UT.is_ollama_saturated
+       ~capacity_lookup:(fun _ -> Some info) url)
+
+let test_is_ollama_saturated_ignores_zero_available_when_idle () =
+  (* Defensive: discovery may report 0 available before any traffic.
+     Without active or queued requests the keeper should still dispatch. *)
+  let url = "http://127.0.0.1:11434" in
+  let info = make_capacity_info ~active:0 ~available:0 ~queue:0 () in
+  check bool "idle endpoint with no slots is fail-open" false
+    (UT.is_ollama_saturated
+       ~capacity_lookup:(fun _ -> Some info) url)
+
 let wrapped_claude_limit_error () =
   Agent_sdk.Error.Api
     (NetworkError
@@ -5905,6 +5990,22 @@ let () =
             test_fail_open_local_only_preserves_explicit_local_only_base;
           test_case "healthy local_only stays selected" `Quick
             test_fail_open_local_only_preserves_healthy_local_only;
+          test_case "PR-B: empty labels are not ollama-only" `Quick
+            test_resolve_ollama_only_base_url_empty_returns_none;
+          test_case "PR-B: single ollama label is ollama-only" `Quick
+            test_resolve_ollama_only_base_url_single_ollama;
+          test_case "PR-B: mixed providers are not ollama-only" `Quick
+            test_resolve_ollama_only_base_url_mixed_provider;
+          test_case "PR-B: different ollama hosts are not ollama-only" `Quick
+            test_resolve_ollama_only_base_url_different_hosts;
+          test_case "PR-B: missing cache is fail-open" `Quick
+            test_is_ollama_saturated_returns_false_when_cache_missing;
+          test_case "PR-B: idle endpoint not saturated" `Quick
+            test_is_ollama_saturated_returns_false_when_idle;
+          test_case "PR-B: full endpoint with queue is saturated" `Quick
+            test_is_ollama_saturated_returns_true_when_full_with_queue;
+          test_case "PR-B: zero available without traffic is fail-open" `Quick
+            test_is_ollama_saturated_ignores_zero_available_when_idle;
           test_case "hard quota degraded retry uses local_recovery" `Quick
             test_degraded_retry_after_recoverable_error_uses_local_recovery_for_hard_quota;
           test_case "resumable session degraded retry uses local_recovery"


### PR DESCRIPTION
## Summary
- 4 keepers (qa-king/taskmaster/nick0cave/ollama-local) contend for one Ollama slot. Queued requests blow `MASC_KEEPER_TURN_TIMEOUT_SEC` (1200s), turn FAILED counters tick, fiber crashes follow.
- Adds an Ollama saturation pre-skip inside `run_keeper_cycle`: only fires when every resolved cascade label points at the same Ollama `base_url`, and only when the cached `/api/ps` probe reports queue/active > 0 with `process_available <= 0`.
- On a saturated hit: log INFO, bump `masc_keeper_ollama_saturation_skip_total{keeper, cascade}`, sleep ~5s + jitter via `Eio.Time.sleep`, return `Ok meta`. No `Agent.run` dispatch, no `turn_failures` increment.
- Probe failures (no cache / parse error / network blip) fall through to normal dispatch (fail-open). Mixed-provider cascades and rotations are unaffected.

## Why this layer

`Cascade_ollama_probe` already exists and is consumed by autoresearch / judge loops; the keeper turn loop just hadn't picked it up. The skip lives **after** `keeper_world_observation` decided the turn should run and **before** `Agent.run`, so the world-observation contract is preserved.

## Test plan
- [x] `dune build @check --root .`
- [x] `dune build bin/main_eio.exe --root .`
- [x] `dune exec test/test_keeper_unified.exe --root .` — 270 tests pass, 8 new
- [ ] Production smoke once smart-heartbeat (#10078) is in: confirm Ollama-only keepers log `ollama saturated ... skipping turn` instead of `keeper cycle FAILED ... budget` under multi-keeper load.

## Risk notes
- `is_ollama_saturated` is fail-open by design: missing cache returns `false`, idle endpoint with no traffic returns `false` even if `process_available=0` (defensive against discovery race).
- `resolve_ollama_only_base_url` requires every label parse to ollama at the **same** host; rotation cascades that include Ollama as one of N providers continue to dispatch.
- 5s+jitter inline sleep avoids hot-loop without needing the keeper-loop's stop/wakeup atomics, which `run_keeper_cycle` does not own.
- Does not compete with #10078 smart heartbeat gate; this skip is inside `run_keeper_cycle`, after the heartbeat decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)