### PR TITLE
fix(dashboard): dedupe websocket delivery schema

### DIFF
--- a/dashboard/src/api/schemas/transport-health.ts
+++ b/dashboard/src/api/schemas/transport-health.ts
@@ -122,22 +122,6 @@ const WebsocketDeliverySchema = object({
   client_buffered_bytes_count: fallback(number(), 0),
 })
 
-// Diagnostic counters for the WS delivery path.  Each field falls back
-// to 0 so this remains forward-compatible with servers that have not
-// yet landed the corresponding Prometheus metric (e.g. a dashboard
-// pointed at an older build should not surface schema errors, it
-// should show zeroes and let the operator know the metric is absent).
-const WebsocketDeliverySchema = object({
-  parse_cache_hits: fallback(number(), 0),
-  parse_cache_misses: fallback(number(), 0),
-  bytes_cache_hits: fallback(number(), 0),
-  bytes_cache_misses: fallback(number(), 0),
-  client_acks: fallback(number(), 0),
-  throttled_deliveries: fallback(number(), 0),
-  client_buffered_bytes_sum: fallback(number(), 0),
-  client_buffered_bytes_count: fallback(number(), 0),
-})
-
 const WebsocketSchema = object({
   enabled: fallback(boolean(), false),
   configured: fallback(boolean(), false),


### PR DESCRIPTION
## Summary
- remove the duplicate WebsocketDeliverySchema declaration introduced by the WS delivery metric merge stack
- restore dashboard TypeScript compilation on current main without changing the transport health contract

## Validation
- pnpm exec tsc --noEmit --pretty
- pnpm exec vitest run src/components/transport-health.test.ts src/components/fleet-health-panel.test.ts src/components/operations-panel.test.ts --no-file-parallelism --maxWorkers=1
- git diff --check