### PR TITLE
feat(coord): add per-agent FSM drift counter (#9795)

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -199,7 +199,23 @@ let record_fsm_drift ~variant ~force =
               ("force", if force then "true" else "false") ]
     ()
 
-let () = Atomic.set Coord_hooks.fsm_drift_observer_fn record_fsm_drift
+(* #9795 follow-up: per-agent breakout so operators can identify
+   which keepers most often skip [in_progress] before [done].
+   Cardinality is bounded by fleet size (~10 keepers in masc-mcp),
+   keeping the additional series count safe for Prometheus.  Emit
+   the variant-only counter alongside so existing dashboards keep
+   working — the new metric is purely additive. *)
+let fsm_drift_per_agent_metric = "masc_task_fsm_drift_per_agent_total"
+
+let record_fsm_drift_with_agent ~variant ~force ~agent_name =
+  record_fsm_drift ~variant ~force;
+  Prometheus.inc_counter fsm_drift_per_agent_metric
+    ~labels:[ ("variant", variant);
+              ("agent_name", agent_name);
+              ("force", if force then "true" else "false") ]
+    ()
+
+let () = Atomic.set Coord_hooks.fsm_drift_observer_fn record_fsm_drift_with_agent
 
 (* Activity graph emit — wraps Activity_graph for room sub-modules *)
 let () = Atomic.set Coord_hooks.activity_emit_fn (fun config ~actor ?subject ~kind ~payload ~tags () ->

--- a/lib/coord.mli
+++ b/lib/coord.mli
@@ -33,7 +33,23 @@ val fsm_drift_metric : string
 
 val record_fsm_drift : variant:string -> force:bool -> unit
 (** Increment {!fsm_drift_metric} with the supplied labels.
-    Wired to {!Coord_hooks.fsm_drift_observer_fn} at module load
-    so [Coord_task.transition] signals every detected drift
-    through this path without [masc_coord] needing a direct
-    [Prometheus] dependency. *)
+    Kept for tests and direct callers that don't carry agent
+    attribution.  Production drift events flow through
+    {!record_fsm_drift_with_agent} via
+    {!Coord_hooks.fsm_drift_observer_fn}. *)
+
+val fsm_drift_per_agent_metric : string
+(** Per-agent variant of {!fsm_drift_metric}. Labels:
+    [("variant", _); ("agent_name", _); ("force", "true" | "false")].
+    Cardinality is bounded by fleet size (~10 keepers in masc-mcp),
+    so the per-agent breakout is safe for Prometheus. *)
+
+val record_fsm_drift_with_agent :
+  variant:string -> force:bool -> agent_name:string -> unit
+(** Emit BOTH the variant-only {!fsm_drift_metric} and the
+    per-agent {!fsm_drift_per_agent_metric}.  Wired to
+    {!Coord_hooks.fsm_drift_observer_fn} at module load so every
+    drift detected by [Coord_task.transition] surfaces with agent
+    attribution.  This lets ratchet readiness ("which keepers are
+    skipping Start?") be answered from Prometheus without
+    log-scraping the WARN line. *)

--- a/lib/coord/coord_hooks.ml
+++ b/lib/coord/coord_hooks.ml
@@ -148,8 +148,8 @@ let subscribe_messages_fn
     hook here avoids a [masc_coord → masc_mcp.Prometheus]
     dependency cycle. *)
 let fsm_drift_observer_fn
-  : (variant:string -> force:bool -> unit) Atomic.t
-  = Atomic.make (fun ~variant:_ ~force:_ -> ())
+  : (variant:string -> force:bool -> agent_name:string -> unit) Atomic.t
+  = Atomic.make (fun ~variant:_ ~force:_ ~agent_name:_ -> ())
 
 (** Tool assignment telemetry — wraps Tool_assignment_telemetry.emit_assigned.
     Wired at startup to record which tools were provisioned to which agent. *)

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -1219,7 +1219,8 @@ let transition_task_r
            (Atomic.get Coord_hooks.fsm_drift_observer_fn)
              ~variant:(drift_variant_label
                          Coord_task_lifecycle.Claimed_to_done_skip)
-             ~force;
+             ~force
+             ~agent_name;
            Log.RoomTask.warn
              "fsm_drift claimed_to_done_skip task=%s agent=%s force=%b"
              task_id

--- a/test/dune
+++ b/test/dune
@@ -328,6 +328,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_fsm_drift_per_agent_counter)
+ (modules test_fsm_drift_per_agent_counter)
+ (libraries masc_test_deps))
+
+(test
  (name test_keeper_context_bounds_ssot)
  (modules test_keeper_context_bounds_ssot)
  (libraries masc_test_deps))

--- a/test/test_fsm_drift_per_agent_counter.ml
+++ b/test/test_fsm_drift_per_agent_counter.ml
@@ -1,0 +1,106 @@
+(* #9795 follow-up: per-agent FSM drift counter.
+
+   Pins the canonical metric name + label shape for the
+   per-agent breakout, and verifies that
+   [record_fsm_drift_with_agent] emits to BOTH the existing
+   variant-only counter and the new per-agent counter without
+   double-counting either side. *)
+
+let counter_for_per_agent ~variant ~agent_name ~force =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    Masc_mcp.Coord.fsm_drift_per_agent_metric
+    ~labels:[
+      ("variant", variant);
+      ("agent_name", agent_name);
+      ("force", if force then "true" else "false");
+    ]
+    ()
+
+let counter_for_variant ~variant ~force =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    Masc_mcp.Coord.fsm_drift_metric
+    ~labels:[
+      ("variant", variant);
+      ("force", if force then "true" else "false");
+    ]
+    ()
+
+let test_metric_name_stable () =
+  Alcotest.(check string)
+    "per-agent canonical name"
+    "masc_task_fsm_drift_per_agent_total"
+    Masc_mcp.Coord.fsm_drift_per_agent_metric
+
+let test_emits_both_counters () =
+  let variant =
+    Coord_task.drift_variant_label
+      Coord_task_lifecycle.Claimed_to_done_skip
+  in
+  let agent = "kaboo-test-agent" in
+  let before_variant = counter_for_variant ~variant ~force:false in
+  let before_per_agent =
+    counter_for_per_agent ~variant ~agent_name:agent ~force:false
+  in
+  Masc_mcp.Coord.record_fsm_drift_with_agent
+    ~variant ~force:false ~agent_name:agent;
+  Alcotest.(check (float 0.0001))
+    "variant counter +1"
+    (before_variant +. 1.0)
+    (counter_for_variant ~variant ~force:false);
+  Alcotest.(check (float 0.0001))
+    "per-agent counter +1"
+    (before_per_agent +. 1.0)
+    (counter_for_per_agent ~variant ~agent_name:agent ~force:false)
+
+let test_per_agent_isolation () =
+  (* Different agents must land in different series. *)
+  let variant =
+    Coord_task.drift_variant_label
+      Coord_task_lifecycle.Claimed_to_done_skip
+  in
+  let agent_a = "alpha-test-agent" in
+  let agent_b = "beta-test-agent" in
+  let before_a =
+    counter_for_per_agent ~variant ~agent_name:agent_a ~force:false
+  in
+  Masc_mcp.Coord.record_fsm_drift_with_agent
+    ~variant ~force:false ~agent_name:agent_b;
+  Alcotest.(check (float 0.0001))
+    "agent_a counter unchanged when agent_b drifts"
+    before_a
+    (counter_for_per_agent ~variant ~agent_name:agent_a ~force:false)
+
+let test_force_label_isolation () =
+  (* force=true and force=false land in different series within
+     the same agent. *)
+  let variant =
+    Coord_task.drift_variant_label
+      Coord_task_lifecycle.Claimed_to_done_skip
+  in
+  let agent = "force-isolation-agent" in
+  let before_true =
+    counter_for_per_agent ~variant ~agent_name:agent ~force:true
+  in
+  Masc_mcp.Coord.record_fsm_drift_with_agent
+    ~variant ~force:false ~agent_name:agent;
+  Alcotest.(check (float 0.0001))
+    "force=true counter unchanged when force=false event lands"
+    before_true
+    (counter_for_per_agent ~variant ~agent_name:agent ~force:true)
+
+let () =
+  Alcotest.run "fsm_drift_per_agent_counter_9795" [
+    "metric_name", [
+      Alcotest.test_case "canonical name stable" `Quick test_metric_name_stable;
+    ];
+    "emit", [
+      Alcotest.test_case "emits to both counters" `Quick
+        test_emits_both_counters;
+    ];
+    "isolation", [
+      Alcotest.test_case "per-agent label isolation" `Quick
+        test_per_agent_isolation;
+      Alcotest.test_case "force label isolation" `Quick
+        test_force_label_isolation;
+    ];
+  ]


### PR DESCRIPTION
## 요약

기존 `masc_task_fsm_drift_total{variant, force}` 카운터는 fleet-wide 발화 빈도만 보여주고, "어느 keeper가 가장 자주 `in_progress` skip하는가?" — ratchet readiness 핵심 질문 — 에 답할 수 없음. 평행으로 `masc_task_fsm_drift_per_agent_total{variant, agent_name, force}`를 추가해 per-agent 분해 가능.

Closes part of #9795 (per-agent attribution for ratchet readiness).

## 근본 의도

이슈 #9795는 `claimed_to_done_skip` drift를 보고하지만 transition은 client compatibility를 위해 permitted 상태 (line 1208-1218 comment: "strictness ratchet follows once keeper_task_start is exposed"). 이 ratchet이 가능하려면:

1. **Per-keeper 발화 빈도 측정** — 어느 keeper가 skip pattern 주범인가?
2. **시간 추세** — skip rate가 줄어드는가? prompt 개선 효과 있나?
3. **임계 결정** — rate < N 이면 hard-error로 promote 가능?

(1)이 본 PR. WARN log는 agent 정보 있지만 log scraping은 운영 metric 채널 아님. Prometheus counter가 표준.

## 변경 내용

### Hook signature 확장

```diff
  let fsm_drift_observer_fn
-   : (variant:string -> force:bool -> unit) Atomic.t
-   = Atomic.make (fun ~variant:_ ~force:_ -> ())
+   : (variant:string -> force:bool -> agent_name:string -> unit) Atomic.t
+   = Atomic.make (fun ~variant:_ ~force:_ ~agent_name:_ -> ())
```

### Call site에서 agent_name 전달 (`coord_task.ml:1219-1222`)

이미 scope에 있는 `agent_name`을 hook으로 forwarding. WARN log line 1224-1227에서 같은 변수 이미 사용 중.

### `coord.ml`에 새 counter + emit 함수

```ocaml
let fsm_drift_per_agent_metric = "masc_task_fsm_drift_per_agent_total"

let record_fsm_drift_with_agent ~variant ~force ~agent_name =
  record_fsm_drift ~variant ~force;        (* existing variant-only *)
  Prometheus.inc_counter fsm_drift_per_agent_metric
    ~labels:[ ("variant", variant);
              ("agent_name", agent_name);
              ("force", if force then "true" else "false") ]
    ()

let () = Atomic.set Coord_hooks.fsm_drift_observer_fn record_fsm_drift_with_agent
```

기존 `record_fsm_drift`는 그대로 유지 — 직접 호출하는 callers/tests를 위해.

### `.mli` 노출

새 함수 + 새 metric 이름을 mli에 추가. 기존 `record_fsm_drift` doc은 "kept for tests and direct callers"로 명시.

## 카디널리티

| 차원 | 크기 |
|------|------|
| variant | 1 (현재 `claimed_to_done_skip`만; 새 variant 추가 시 +1씩) |
| force | 2 (true / false) |
| agent_name | ~10 (masc-mcp fleet 크기) |
| **총 series** | ~20 (variant × force × agent) |

20 series는 Prometheus 측면에서 무시 가능. cardinality 안전.

## 운영 영향

기존 dashboard:
```promql
rate(masc_task_fsm_drift_total{variant="claimed_to_done_skip"}[5m])
```
→ 변경 없음. 본 PR은 additive emit만 추가.

새로 가능한 alert:
```promql
# 특정 keeper의 drift rate가 임계 초과
rate(masc_task_fsm_drift_per_agent_total{
  variant="claimed_to_done_skip",
  agent_name="sangsu-happy-raven"
}[1h]) > 0.1

# 전체 keeper drift rate ranking
sort_desc(
  rate(masc_task_fsm_drift_per_agent_total[1h]) by (agent_name)
)
```

## 테스트

`test/test_fsm_drift_per_agent_counter.ml` 4 scenario:

```bash
$ dune exec test/test_fsm_drift_per_agent_counter.exe
[OK]  metric_name  0  canonical name stable.
[OK]  emit         0  emits to both counters.
[OK]  isolation    0  per-agent label isolation.
[OK]  isolation    1  force label isolation.
Test Successful in 0.001s. 4 tests run.
```

기존 test:
```bash
$ dune exec test/test_fsm_drift_counter.exe        # 4/4 (변경 없음)
```

## 회귀 리스크

낮음. Pure additive change:
- Existing `masc_task_fsm_drift_total{variant, force}` emit 그대로 (test로 pin됨).
- `record_fsm_drift` API 그대로 (signature 변경 없음).
- Hook signature 확장은 internal — 유일한 caller(`coord_task.ml`)만 영향.

## 후속

- **Strictness ratchet decision**: 본 counter로 1주 운영하며 per-keeper rate 관찰. < threshold 키퍼는 prompt 개선, 모든 키퍼 < threshold 도달 시 hard-error로 promote.
- **다른 drift variant 추가 시**: `decide` 함수에 variant 추가 → `drift_variant_label` exhaustive match → 본 counter 자동 emit (label 만 다름).

## 참고

- Issue #9795
- `lib/coord.ml:194-218` — emit 함수
- `lib/coord/coord_task_lifecycle.ml:68-71` — drift detection
- `lib/coord/coord_task.ml:1207-1228` — hook firing
- `test/test_fsm_drift_per_agent_counter.ml` — coverage
- 기존 PR로 wired된 part: `record_fsm_drift` (variant-only)
