### PR TITLE
fix(oas-bridge): type timeout caller contract

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -488,7 +488,8 @@ let review
         (false, sprintf "Invalid verdict format: %s" msg)
     in
     (match
-       Masc_oas_bridge.run_with_caller ~caller:"anti_rationalization" (fun () ->
+       Masc_oas_bridge.run_with_caller
+         ~caller:Env_config_oas_bridge.Anti_rationalization (fun () ->
          Oas_worker.run_named_with_masc_tools
            ~cascade_name:evaluator_cascade
            ~goal:prompt

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -175,7 +175,8 @@ let call_model_direct_sync ~agent_type ~prompt =
   let cascade_name = cascade_name_for_agent_type agent_type in
   try
     match
-      Masc_oas_bridge.run_with_caller ~caller:"auto_responder" (fun () ->
+      Masc_oas_bridge.run_with_caller
+        ~caller:Env_config_oas_bridge.Auto_responder (fun () ->
         Oas_worker.run_named ~cascade_name
           ~goal:prompt ~max_turns:1
           ~accept:model_response_is_valid ~max_tokens:500

--- a/lib/autoresearch_codegen.ml
+++ b/lib/autoresearch_codegen.ml
@@ -138,7 +138,8 @@ let generate_code_change ~goal ~baseline ~lower_is_better ~history ~insights
   let prompt = build_code_change_prompt ~goal ~baseline ~lower_is_better ~history ~insights
     ~file_content ~target_file in
   match
-    Masc_oas_bridge.run_with_caller ~caller:"autoresearch_codegen" (fun () ->
+    Masc_oas_bridge.run_with_caller
+      ~caller:Env_config_oas_bridge.Autoresearch_codegen (fun () ->
       Oas_worker.run_named ~cascade_name:"autoresearch"
         ~goal:prompt ~max_turns:1
         ~temperature:(Cascade_inference.resolve_temperature

--- a/lib/config/env_config_oas_bridge.ml
+++ b/lib/config/env_config_oas_bridge.ml
@@ -12,16 +12,25 @@
          (50–700s) and produced 27 timeouts/session;
       3. the operator can override any single caller's budget via
          [MASC_OAS_BRIDGE_TIMEOUT_<CALLER>_SEC];
-      4. the operator can shift every default in lockstep via
-         [MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC] without per-caller
-         tuning, useful when an OAS deployment is uniformly slow.
+      4. the operator can set a fallback for unknown / future callers
+         via [MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC].
 
     The lookup order is per-caller env > per-caller hardcoded default
     > [MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC] > 300.0.  An unknown
-    caller (string typo or future caller without a default) falls
-    through to the global default rather than failing closed — the
-    operator will see [metric_oas_bridge_timeout{caller=...}] in
-    Prometheus regardless. *)
+    caller (future caller without a typed default) falls through to
+    the global default rather than failing closed — the operator will
+    see [metric_oas_bridge_timeout{caller=...}] in Prometheus
+    regardless. *)
+
+type caller =
+  | Auto_responder
+  | Dashboard_provider_runs
+  | Autoresearch_codegen
+  | Keeper_persona_authoring
+  | Server_openai_compat
+  | Tool_deep_review
+  | Anti_rationalization
+  | Unknown of string
 
 (** Hardcoded default seconds for each known caller.  When the
     original literal was 60s on a path with observed p50 above 60s,
@@ -32,21 +41,40 @@
     autoresearch / deep_review / anti_rationalization. *)
 let global_default_sec = 300.0
 
-let known_caller_defaults : (string * float) list = [
+let caller_key = function
+  | Auto_responder -> "auto_responder"
+  | Dashboard_provider_runs -> "dashboard_provider_runs"
+  | Autoresearch_codegen -> "autoresearch_codegen"
+  | Keeper_persona_authoring -> "keeper_persona_authoring"
+  | Server_openai_compat -> "server_openai_compat"
+  | Tool_deep_review -> "tool_deep_review"
+  | Anti_rationalization -> "anti_rationalization"
+  | Unknown caller -> caller
+
+(** Exported for tests that pin the per-caller default table. *)
+let known_callers () =
+  [
+    Auto_responder;
+    Dashboard_provider_runs;
+    Autoresearch_codegen;
+    Keeper_persona_authoring;
+    Server_openai_compat;
+    Tool_deep_review;
+    Anti_rationalization;
+  ]
+
+let known_default_sec = function
   (* #10094: was hardcoded 60s, raised to global_default.  p50 of
      the underlying LLM call is in the 50–700s range; 60s timed out
      27 times per session. *)
-  "auto_responder", global_default_sec;
-  "dashboard_provider_runs", global_default_sec;
-
+  | Auto_responder | Dashboard_provider_runs -> Some global_default_sec
   (* Preserved at original literal — these were tuned for the
      specific compute pattern of the caller. *)
-  "autoresearch_codegen", 120.0;
-  "keeper_persona_authoring", 120.0;
-  "server_openai_compat", 120.0;
-  "tool_deep_review", 180.0;
-  "anti_rationalization", 180.0;
-]
+  | Autoresearch_codegen
+  | Keeper_persona_authoring
+  | Server_openai_compat -> Some 120.0
+  | Tool_deep_review | Anti_rationalization -> Some 180.0
+  | Unknown _ -> None
 
 let upper_case s =
   s
@@ -57,7 +85,7 @@ let upper_case s =
        else c)
 
 let per_caller_env_var ~caller =
-  Printf.sprintf "MASC_OAS_BRIDGE_TIMEOUT_%s_SEC" (upper_case caller)
+  Printf.sprintf "MASC_OAS_BRIDGE_TIMEOUT_%s_SEC" (upper_case (caller_key caller))
 
 let global_env_var = "MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC"
 
@@ -77,7 +105,7 @@ let trimmed_value_opt name =
       1. Per-caller env [MASC_OAS_BRIDGE_TIMEOUT_<CALLER>_SEC]
          — wins unconditionally.  Lets the operator tune one
          caller without touching others.
-      2. Per-caller hardcoded default ([known_caller_defaults]).
+      2. Per-caller checked-in default ([known_default_sec]).
          Preserves intentional 120/180s budgets for compute-heavy
          callers; raises the fantasy 60s budgets to
          [global_default_sec] (300s).
@@ -94,7 +122,7 @@ let timeout_sec ~caller () =
     Safe_ops.float_of_string_with_default
       ~default:global_default_sec v
   | None ->
-    match List.assoc_opt caller known_caller_defaults with
+    match known_default_sec caller with
     | Some d -> d
     | None ->
       (* Unknown caller: fall to global env, then global default. *)
@@ -103,7 +131,3 @@ let timeout_sec ~caller () =
         Safe_ops.float_of_string_with_default
           ~default:global_default_sec v
       | None -> global_default_sec
-
-(** Exported for tests that pin the per-caller default table. *)
-let known_callers () : string list =
-  List.map fst known_caller_defaults

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -420,7 +420,8 @@ let execute_single_agent_run ~sw ~net ~run_id ~provider ~model ~prompt =
                provider)
         else (
           match
-            Masc_oas_bridge.run_with_caller ~caller:"dashboard_provider_runs" (fun () ->
+            Masc_oas_bridge.run_with_caller
+              ~caller:Env_config_oas_bridge.Dashboard_provider_runs (fun () ->
               Oas_worker.run_model_by_label ~model_label:label ~goal:prompt
                 ~system_prompt:(run_system_prompt provider)
                 ~max_turns:4

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -1020,7 +1020,7 @@ let handle_persona_generate ctx args =
            in
            match
              Masc_oas_bridge.run_with_caller
-               ~caller:"keeper_persona_authoring"
+               ~caller:Env_config_oas_bridge.Keeper_persona_authoring
                (fun () ->
                  Oas_worker.run_named
                    ~cascade_name

--- a/lib/masc_oas_bridge.ml
+++ b/lib/masc_oas_bridge.ml
@@ -13,7 +13,8 @@
     when both fire timeouts in the same session.  Defaults to
     "unknown" so legacy callers still compile; new code should
     pass [~caller] explicitly or use {!run_with_caller}, which
-    also pulls the configured budget from [Env_config_oas_bridge]. *)
+    accepts a typed caller and pulls the configured budget from
+    [Env_config_oas_bridge]. *)
 let run_safe ?(caller = "unknown") ~timeout_s fn =
   let do_timeout fn =
     match Masc_eio_env.get_opt () with
@@ -62,4 +63,4 @@ let run_safe ?(caller = "unknown") ~timeout_s fn =
     env-var override layout. *)
 let run_with_caller ~caller fn =
   let timeout_s = Env_config_oas_bridge.timeout_sec ~caller () in
-  run_safe ~caller ~timeout_s fn
+  run_safe ~caller:(Env_config_oas_bridge.caller_key caller) ~timeout_s fn

--- a/lib/masc_oas_bridge.mli
+++ b/lib/masc_oas_bridge.mli
@@ -21,6 +21,6 @@ val run_safe :
     env-overridable per-caller budget.  See [Env_config_oas_bridge]
     for the per-caller default table and env-var layout. *)
 val run_with_caller :
-  caller:string ->
+  caller:Env_config_oas_bridge.caller ->
   (unit -> ('a, Oas.Error.sdk_error) result) ->
   ('a, Oas.Error.sdk_error) result

--- a/lib/server/server_openai_compat.ml
+++ b/lib/server/server_openai_compat.ml
@@ -102,7 +102,8 @@ let route_keeper ~config ~sw ~clock ~keeper_name ~message : (string, string) res
 let route_cascade ~message ~system_prompt ~max_tokens ~temperature
   : (string, string) result =
   match
-    Masc_oas_bridge.run_with_caller ~caller:"server_openai_compat" (fun () ->
+    Masc_oas_bridge.run_with_caller
+      ~caller:Env_config_oas_bridge.Server_openai_compat (fun () ->
       Oas_worker.run_named
         ~cascade_name:"default_models"
         ~goal:message

--- a/lib/tool_deep_review.ml
+++ b/lib/tool_deep_review.ml
@@ -104,7 +104,8 @@ let handle_deep_review (config : Coord.config) args : bool * string =
         ]))
     | Ok prompt ->
         match
-          Masc_oas_bridge.run_with_caller ~caller:"tool_deep_review" (fun () ->
+          Masc_oas_bridge.run_with_caller
+            ~caller:Env_config_oas_bridge.Tool_deep_review (fun () ->
             Oas_worker.run_named
               ~cascade_name:"adversarial_reviewer"
               ~goal:prompt

--- a/test/test_oas_bridge_timeout_ssot_10094.ml
+++ b/test/test_oas_bridge_timeout_ssot_10094.ml
@@ -46,7 +46,9 @@ let clear_envs () =
     (Cfg.known_callers ());
   (* Clear an unknown-caller override too so the global-fallback
      test starts clean. *)
-  Unix.putenv (Cfg.per_caller_env_var ~caller:"unknown_caller_test_10094") ""
+  Unix.putenv
+    (Cfg.per_caller_env_var ~caller:(Cfg.Unknown "unknown_caller_test_10094"))
+    ""
 
 (* The intentional 120s / 180s budgets must remain after this
    PR.  If a future refactor accidentally drops them (e.g. by
@@ -57,18 +59,18 @@ let test_intentional_budgets_preserved () =
   clear_envs ();
   let cases =
     [
-      "autoresearch_codegen", 120.0;
-      "keeper_persona_authoring", 120.0;
-      "server_openai_compat", 120.0;
-      "tool_deep_review", 180.0;
-      "anti_rationalization", 180.0;
+      Cfg.Autoresearch_codegen, 120.0;
+      Cfg.Keeper_persona_authoring, 120.0;
+      Cfg.Server_openai_compat, 120.0;
+      Cfg.Tool_deep_review, 180.0;
+      Cfg.Anti_rationalization, 180.0;
     ]
   in
   List.iter
     (fun (caller, expected) ->
       let got = Cfg.timeout_sec ~caller () in
       Alcotest.(check (float 0.0001))
-        (Printf.sprintf "preserved budget for %s" caller)
+        (Printf.sprintf "preserved budget for %s" (Cfg.caller_key caller))
         expected got)
     cases
 
@@ -79,27 +81,27 @@ let test_fantasy_60s_budgets_raised () =
   Alcotest.(check (float 0.0001))
     "auto_responder raised to global default"
     Cfg.global_default_sec
-    (Cfg.timeout_sec ~caller:"auto_responder" ());
+    (Cfg.timeout_sec ~caller:Cfg.Auto_responder ());
   Alcotest.(check (float 0.0001))
     "dashboard_provider_runs raised to global default"
     Cfg.global_default_sec
-    (Cfg.timeout_sec ~caller:"dashboard_provider_runs" ())
+    (Cfg.timeout_sec ~caller:Cfg.Dashboard_provider_runs ())
 
 (* Per-caller env override beats the hardcoded default. *)
 let test_per_caller_env_override () =
   clear_envs ();
   Unix.putenv
-    (Cfg.per_caller_env_var ~caller:"auto_responder")
+    (Cfg.per_caller_env_var ~caller:Cfg.Auto_responder)
     "45.5";
   Alcotest.(check (float 0.0001))
     "auto_responder env overrides default"
     45.5
-    (Cfg.timeout_sec ~caller:"auto_responder" ());
+    (Cfg.timeout_sec ~caller:Cfg.Auto_responder ());
   (* Other callers must NOT be affected by this single override. *)
   Alcotest.(check (float 0.0001))
     "tool_deep_review unaffected"
     180.0
-    (Cfg.timeout_sec ~caller:"tool_deep_review" ());
+    (Cfg.timeout_sec ~caller:Cfg.Tool_deep_review ());
   clear_envs ()
 
 (* Global env var (MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC) is a
@@ -113,11 +115,11 @@ let test_global_env_does_not_override_known_callers () =
   Alcotest.(check (float 0.0001))
     "tool_deep_review keeps 180.0 (global env is a fallback, not an override)"
     180.0
-    (Cfg.timeout_sec ~caller:"tool_deep_review" ());
+    (Cfg.timeout_sec ~caller:Cfg.Tool_deep_review ());
   Alcotest.(check (float 0.0001))
     "unknown caller picks up global env"
     999.0
-    (Cfg.timeout_sec ~caller:"unknown_caller_test_10094" ());
+    (Cfg.timeout_sec ~caller:(Cfg.Unknown "unknown_caller_test_10094") ());
   clear_envs ()
 
 (* Per-caller env var beats global env var.  Operator should
@@ -127,12 +129,12 @@ let test_per_caller_env_beats_global_env () =
   clear_envs ();
   Unix.putenv Cfg.global_env_var "999.0";
   Unix.putenv
-    (Cfg.per_caller_env_var ~caller:"tool_deep_review")
+    (Cfg.per_caller_env_var ~caller:Cfg.Tool_deep_review)
     "42.0";
   Alcotest.(check (float 0.0001))
     "per-caller env wins over global env"
     42.0
-    (Cfg.timeout_sec ~caller:"tool_deep_review" ());
+    (Cfg.timeout_sec ~caller:Cfg.Tool_deep_review ());
   clear_envs ()
 
 (* Per-caller env-var name follows the documented convention.
@@ -142,11 +144,11 @@ let test_env_var_name_convention () =
   Alcotest.(check string)
     "auto_responder env var"
     "MASC_OAS_BRIDGE_TIMEOUT_AUTO_RESPONDER_SEC"
-    (Cfg.per_caller_env_var ~caller:"auto_responder");
+    (Cfg.per_caller_env_var ~caller:Cfg.Auto_responder);
   Alcotest.(check string)
     "tool_deep_review env var"
     "MASC_OAS_BRIDGE_TIMEOUT_TOOL_DEEP_REVIEW_SEC"
-    (Cfg.per_caller_env_var ~caller:"tool_deep_review");
+    (Cfg.per_caller_env_var ~caller:Cfg.Tool_deep_review);
   Alcotest.(check string)
     "global env var"
     "MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC"


### PR DESCRIPTION
## Summary
- replace free-form OAS bridge timeout caller strings with a typed Env_config_oas_bridge.caller contract
- keep legacy run_safe string labels only for backwards compatibility while making run_with_caller compile-time checked
- update timeout SSOT tests to pin typed callers, env-var naming, and unknown-caller fallback behavior

## Why this matters
This closes a truthfulness gap in #10108: the timeout values were centralized, but known callers were still routed by free-form strings. A typo could silently fall into the unknown fallback path and make the SSOT look real while bypassing the intended per-caller default. Known call sites now use constructors, so the compiler catches drift.

## Verification
- scripts/dune-local.sh build test/test_oas_bridge_timeout_ssot_10094.exe
- ./_build/default/test/test_oas_bridge_timeout_ssot_10094.exe
- git diff --check