### PR TITLE
fix(telemetry): record runtime MCP keeper trajectories

### DIFF
--- a/docs/qa/MASC-OAS-TELEMETRY-FLOW-AUDIT-2026-04-25.json
+++ b/docs/qa/MASC-OAS-TELEMETRY-FLOW-AUDIT-2026-04-25.json
@@ -29,15 +29,15 @@
   "surfaces": [
     {
       "surface": "/api/v1/keepers/:name/tool-calls",
-      "producer": "keeper_hooks_oas.post_tool_use",
+      "producer": "keeper_hooks_oas.post_tool_use|mcp_server_eio_call_tool.runtime_mcp",
       "durable_store": ".masc/tool_calls/YYYY-MM/DD.jsonl",
       "status": "contract_and_action_radius_added"
     },
     {
       "surface": "/api/v1/keepers/:name/tool-stats",
-      "producer": "keeper_hooks_oas.post_tool_use",
+      "producer": "keeper_hooks_oas.post_tool_use|mcp_server_eio_call_tool.runtime_mcp",
       "durable_store": ".masc/trajectories/<keeper>/<trace>.jsonl",
-      "status": "trajectory_tool_call_rows_added"
+      "status": "trajectory_tool_call_rows_added_in_post_tool_and_runtime_mcp_paths"
     },
     {
       "surface": "/api/v1/dashboard/execution-trust",
@@ -86,7 +86,11 @@
       "status": "passed"
     },
     "dashboard_full_suite_note": "A package-script invocation with an extra argument separator ran the full dashboard suite and failed in unrelated locale-sensitive TimeAgo tests where Korean absolute-time text contained the excluded character.",
-    "live_keeper_turn_acceptance": "not_run"
+    "live_keeper_turn_acceptance": "not_run",
+    "live_runtime_mcp_delta": {
+      "observed": "sangsu /tool-calls had runtime_mcp rows while /tool-stats was empty for the same keeper",
+      "status": "fixed_by_runtime_mcp_trajectory_append"
+    }
   },
   "external_evidence": [
     {

--- a/docs/qa/MASC-OAS-TELEMETRY-FLOW-AUDIT-2026-04-25.md
+++ b/docs/qa/MASC-OAS-TELEMETRY-FLOW-AUDIT-2026-04-25.md
@@ -25,8 +25,8 @@ Primary mismatch: keeper/OAS tool calls reached `.masc/tool_calls`, but the traj
 
 | Surface / Store | Producer | Durable Store | Result |
 | --- | --- | --- | --- |
-| `/api/v1/keepers/:name/tool-calls` | `keeper_hooks_oas.post_tool_use` | `.masc/tool_calls/YYYY-MM/DD.jsonl` | Full I/O rows now include `runtime_contract` and `action_radius`. |
-| `/api/v1/keepers/:name/tool-stats` | `keeper_hooks_oas.post_tool_use` | `.masc/trajectories/<keeper>/<trace>.jsonl` | Post-tool-use now records trajectory `Tool_call` rows when `trajectory_acc` exists. |
+| `/api/v1/keepers/:name/tool-calls` | `keeper_hooks_oas.post_tool_use`, `mcp_server_eio_call_tool.runtime_mcp` | `.masc/tool_calls/YYYY-MM/DD.jsonl` | Full I/O rows now include `runtime_contract` and `action_radius`. |
+| `/api/v1/keepers/:name/tool-stats` | `keeper_hooks_oas.post_tool_use`, `mcp_server_eio_call_tool.runtime_mcp` | `.masc/trajectories/<keeper>/<trace>.jsonl` | Post-tool-use and runtime-MCP keeper tool traces now record trajectory `Tool_call` rows. |
 | `/api/v1/dashboard/execution-trust` | `keeper_agent_run.execution_receipt` | `.masc/keepers/<keeper>/execution-receipts` | Execution receipts now include `runtime_contract` and `action_radius`. |
 | `/api/v1/dashboard/telemetry/summary` | `Telemetry_unified.summary_json` | all unified telemetry stores | Each source now reports `health`, `freshness_slo_s`, `producer`, `durable_store`, `dashboard_surface`, and `stale_reason`. |
 | `.masc/telemetry-coverage-gaps` | trajectory/receipt failure reporters | `.masc/telemetry-coverage-gaps/YYYY-MM/DD.jsonl` | Trajectory append and receipt append failures are durable coverage gaps. |
@@ -99,6 +99,8 @@ Runtime acceptance with a fresh live keeper turn was not executed in this worktr
 - `/api/v1/dashboard/telemetry/summary` shows fresh `keeper_metric`, `tool_call_io`, and `oas_event`.
 - `/tool-stats` and `/tool-calls` agree on recent keeper tool executions.
 - A sample execution receipt and trajectory row both include `runtime_contract` and `action_radius`.
+
+Additional runtime-MCP delta found during 2026-04-25 re-verification: the live server had `sangsu` `/tool-calls` rows with `lane=runtime_mcp`, `runtime_contract`, and `action_radius`, while `/tool-stats` was empty for the same keeper because that direct runtime-MCP trace path bypassed `keeper_hooks_oas`. This report now includes the follow-up fix: `mcp_server_eio_call_tool.runtime_mcp` appends the matching trajectory row and reports append failures to `.masc/telemetry-coverage-gaps`.
 
 ## External Currentness Evidence
 

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -178,6 +178,110 @@ let runtime_mcp_keeper_tool_call_sse_payload
   in
   `Assoc (base_fields @ error_fields)
 
+let record_runtime_mcp_keeper_trajectory
+    (ctx : keeper_runtime_mcp_log_context)
+    ~(base_path : string)
+    ~(tool_name : string)
+    ~(arguments : Yojson.Safe.t)
+    ~(message : string)
+    ~(success : bool)
+    ~(duration_ms : int) : unit =
+  let trace_id = Option.value ~default:"runtime-mcp" ctx.trace_id in
+  let masc_root =
+    Coord_utils.masc_root_dir_from
+      ~base_path
+      ~cluster_name:(Env_config_core.cluster_name ())
+  in
+  let safe_input = Observability_redact.redact_json_value arguments in
+  let safe_output =
+    Observability_redact.redact_preview ~max_len:4000 message
+  in
+  let existing_entries =
+    Trajectory.read_entries
+      ~masc_root
+      ~keeper_name:ctx.keeper_name
+      ~trace_id
+  in
+  let turn = Option.value ~default:0 ctx.turn in
+  let round =
+    existing_entries
+    |> List.fold_left
+         (fun acc (entry : Trajectory.tool_call_entry) ->
+           if entry.turn = turn then acc + 1 else acc)
+         1
+  in
+  let runtime_contract =
+    Keeper_runtime_contract.runtime_contract_json_from_fields
+      ~keeper_name:ctx.keeper_name
+      ?trace_id:ctx.trace_id
+      ?session_id:ctx.session_id
+      ?keeper_turn_id:ctx.keeper_turn_id
+      ?task_id:ctx.task_id
+      ?goal_ids:ctx.goal_ids
+      ?sandbox_profile:ctx.sandbox_profile
+      ?network_mode:ctx.network_mode
+      ?shared_memory_scope:ctx.shared_memory_scope
+      ?model:(Some ctx.model)
+      ()
+  in
+  let error = if success then None else Some safe_output in
+  let action_radius =
+    Keeper_runtime_contract.action_radius_json
+      ~tool_name
+      ~input:safe_input
+      ~success
+      ~duration_ms:(float_of_int duration_ms)
+      ?error
+      ?sandbox_target:ctx.sandbox_profile
+      ()
+  in
+  let now = Time_compat.now () in
+  let entry : Trajectory.tool_call_entry =
+    {
+      ts = now;
+      ts_iso = Types.iso8601_of_unix_seconds now;
+      turn;
+      round;
+      tool_name;
+      args_json = Yojson.Safe.to_string safe_input;
+      gate_decision = Trajectory.Pass;
+      result = Some safe_output;
+      duration_ms;
+      error;
+      cost_usd = Trajectory.tool_cost_estimate tool_name;
+    }
+  in
+  try
+    Trajectory.append_entry
+      ~runtime_contract
+      ~action_radius
+      ~masc_root
+      ~keeper_name:ctx.keeper_name
+      ~trace_id
+      entry
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      (try
+         Telemetry_coverage_gap.record
+           ~masc_root
+           ~source:"trajectory_tool_call"
+           ~producer:"mcp_server_eio_call_tool.runtime_mcp"
+           ~durable_store:
+             (Trajectory.trajectory_path masc_root ctx.keeper_name trace_id)
+           ~dashboard_surface:"/api/v1/keepers/:name/tool-stats"
+           ~stale_reason:"runtime_mcp_trajectory_append_failed"
+           ~keeper_name:ctx.keeper_name
+           ~trace_id
+           ~error:(Printexc.to_string exn)
+           ()
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | gap_exn ->
+           log_mcp_exn
+             ~label:"runtime MCP trajectory coverage gap append failed"
+             gap_exn)
+
 let record_runtime_mcp_keeper_tool_trace
     ?mcp_session_id
     (entry : Keeper_registry.registry_entry)
@@ -212,6 +316,14 @@ let record_runtime_mcp_keeper_tool_trace
     ?shared_memory_scope:ctx.shared_memory_scope
     ~result_bytes:(String.length message)
     ();
+  record_runtime_mcp_keeper_trajectory
+    ctx
+    ~base_path:entry.base_path
+    ~tool_name
+    ~arguments
+    ~message
+    ~success
+    ~duration_ms;
   Sse.broadcast
     (runtime_mcp_keeper_tool_call_sse_payload
        ~keeper_name:ctx.keeper_name

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1104,7 +1104,9 @@ let handle_keeper_get_subroutes state req request reqd =
         ("window_hours", `Int window_hours);
         ("total_entries", `Int (List.length entries));
         ("source", `String "trajectory_tool_call");
-        ("producer", `String "keeper_hooks_oas.post_tool_use");
+        ( "producer",
+          `String
+            "keeper_hooks_oas.post_tool_use|mcp_server_eio_call_tool.runtime_mcp" );
         ("durable_store", `String (Trajectory.trajectories_dir masc_root name));
         ("dashboard_surface", `String dashboard_surface);
         ("freshness_slo_s", `Float freshness_slo_s);
@@ -1180,7 +1182,9 @@ let handle_keeper_get_subroutes state req request reqd =
         ("keeper", `String name);
         ("count", `Int (List.length entries));
         ("source", `String "tool_call_io");
-        ("producer", `String "keeper_hooks_oas.post_tool_use");
+        ( "producer",
+          `String
+            "keeper_hooks_oas.post_tool_use|mcp_server_eio_call_tool.runtime_mcp" );
         ("durable_store", `String (Filename.concat masc_root "tool_calls"));
         ("dashboard_surface", `String "/api/v1/keepers/:name/tool-calls");
         ("freshness_slo_s", `Float freshness_slo_s);

--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -81,7 +81,7 @@ let source_freshness_slo_s = function
 let source_producer = function
   | Keeper_metric -> "keeper_unified_metrics"
   | Agent_event -> "telemetry_eio"
-  | Tool_call_io -> "keeper_hooks_oas"
+  | Tool_call_io -> "keeper_hooks_oas|mcp_server_eio_call_tool"
   | Tool_usage -> "tool_usage_log"
   | Oas_event -> "oas_event_bus"
   | Tool_metric -> "tool_metrics_persist"

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -231,6 +231,45 @@ let test_record_runtime_mcp_keeper_tool_trace_logs_and_broadcasts () =
         (row |> U.member "task_id" |> U.to_string);
       check int "goal id count" 1
         (row |> U.member "goal_ids" |> U.to_list |> List.length);
+      let masc_root =
+        Filename.concat base_path Common.masc_dirname
+      in
+      let trace_id = "trace-test-" ^ keeper_name in
+      let trajectory_entries =
+        Masc_mcp.Trajectory.read_entries
+          ~masc_root
+          ~keeper_name
+          ~trace_id
+      in
+      check int "trajectory row count" 1 (List.length trajectory_entries);
+      let trajectory_entry = List.hd trajectory_entries in
+      check string "trajectory tool" "keeper_bash"
+        trajectory_entry.Masc_mcp.Trajectory.tool_name;
+      check int "trajectory turn" 1
+        trajectory_entry.Masc_mcp.Trajectory.turn;
+      check int "trajectory round" 1
+        trajectory_entry.Masc_mcp.Trajectory.round;
+      let trajectory_json =
+        let path =
+          Masc_mcp.Trajectory.trajectory_path masc_root keeper_name trace_id
+        in
+        let ic = open_in path in
+        let content =
+          Fun.protect
+            ~finally:(fun () -> close_in_noerr ic)
+            (fun () -> really_input_string ic (in_channel_length ic))
+        in
+        content
+        |> String.split_on_char '\n'
+        |> List.find (fun line -> String.trim line <> "")
+        |> Yojson.Safe.from_string
+      in
+      check string "trajectory runtime keeper" keeper_name
+        (trajectory_json |> U.member "runtime_contract" |> U.member "keeper_name"
+         |> U.to_string);
+      check string "trajectory action tool" "keeper_bash"
+        (trajectory_json |> U.member "action_radius" |> U.member "tool_name"
+         |> U.to_string);
       let sse_payload =
         match !received_sse with
         | Some payload -> extract_json_from_text payload


### PR DESCRIPTION
## Summary
- records runtime-MCP keeper tool executions into trajectory JSONL alongside the existing full I/O tool-call log
- preserves runtime_contract and action_radius on the trajectory row, and records trajectory append failures as telemetry coverage gaps
- updates dashboard/unified telemetry producer metadata and the telemetry flow audit report for the runtime-MCP lane

## Why it matters
Runtime-MCP keeper tool calls could appear in /tool-calls while /tool-stats stayed empty because that direct path bypassed keeper_hooks_oas. This makes the dashboard disagree about whether a keeper actually used tools. The patch joins that lane into the trajectory-backed stats surface without adding MASC-specific fields to OAS.

## Verification
- scripts/check-oas-pin.sh --local-only
- env MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh build test/test_trajectory.exe test/test_keeper_tool_call_log.exe test/test_dashboard_keeper_routes.exe test/test_dashboard_execution.exe test/test_telemetry_unified.exe test/test_telemetry_eio_coverage.exe test/test_mcp_server_eio_call_tool.exe
- _build/default/test/test_trajectory.exe
- _build/default/test/test_keeper_tool_call_log.exe
- _build/default/test/test_mcp_server_eio_call_tool.exe
- _build/default/test/test_telemetry_unified.exe
- env MASC_BASE_PATH=/tmp/masc-test-dashboard-keeper-routes _build/default/test/test_dashboard_keeper_routes.exe
- env MASC_BASE_PATH=/tmp/masc-test-dashboard-execution _build/default/test/test_dashboard_execution.exe
- _build/default/test/test_telemetry_eio_coverage.exe
- pnpm --dir dashboard exec vitest run --no-file-parallelism --maxWorkers=1 src/components/keeper-tool-telemetry.test.ts src/components/telemetry-unified.test.ts src/api/dashboard.test.ts
- pnpm --dir dashboard typecheck
- jq empty docs/qa/MASC-OAS-TELEMETRY-FLOW-AUDIT-2026-04-25.json
- git diff --check

## Runtime acceptance
Not restarted against the live server. A read-only probe found the pre-patch mismatch: live runtime_mcp /tool-calls rows existed for sangsu while /tool-stats was empty. The patched worktree path now writes the matching trajectory row, but live-turn acceptance still needs a server restart or deployed PR build.