### PR TITLE
perf(ws): slice index bookkeeping (Phase 1 of #10119)

### DIFF
--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -47,6 +47,74 @@ let sessions_mutex = Eio.Mutex.create ()
 
 let with_sessions_rw f = Eio_guard.with_mutex sessions_mutex f
 
+(** Side index mapping each dashboard slice to the set of session IDs
+    currently subscribed to it.  Phase 1 of the slice-indexed fanout RFC
+    (#10119): the index is maintained at subscribe / unsubscribe / cleanup
+    time but the broadcast fanout still iterates every session.  Phase 2
+    consults this index to skip raw-SSE-forwards to sessions whose route
+    does not subscribe to the event's slice.
+
+    Inner [Hashtbl.t] is keyed by [session_id] with [unit] values — a set.
+    Mutated only under [sessions_mutex], so the consistency invariant
+    matches [sessions]: a session present in [slice_index.(s)] is present
+    in [sessions] until [cleanup_session] runs. *)
+let slice_index : (string, (string, unit) Hashtbl.t) Hashtbl.t =
+  Hashtbl.create 8
+
+let slice_index_add_locked ~session_id ~slice =
+  let set =
+    match Hashtbl.find_opt slice_index slice with
+    | Some s -> s
+    | None ->
+        let s = Hashtbl.create 4 in
+        Hashtbl.add slice_index slice s;
+        s
+  in
+  Hashtbl.replace set session_id ()
+
+let slice_index_remove_locked ~session_id ~slice =
+  match Hashtbl.find_opt slice_index slice with
+  | None -> ()
+  | Some set ->
+      Hashtbl.remove set session_id;
+      if Hashtbl.length set = 0 then Hashtbl.remove slice_index slice
+
+let slice_index_remove_session_locked session_id =
+  Hashtbl.iter
+    (fun _slice set -> Hashtbl.remove set session_id)
+    slice_index;
+  Hashtbl.filter_map_inplace
+    (fun _slice set -> if Hashtbl.length set = 0 then None else Some set)
+    slice_index
+
+(** Test/debug helper: return the session IDs currently indexed under
+    [slice], in unspecified order.  Acquires [sessions_mutex]. *)
+let slice_index_subscribers slice =
+  with_sessions_rw (fun () ->
+      match Hashtbl.find_opt slice_index slice with
+      | None -> []
+      | Some set -> Hashtbl.fold (fun sid () acc -> sid :: acc) set [])
+
+(** Test/debug helper: total (slice × session) entries across all slices.
+    Equals the sum of subscribed-slice counts over every session. *)
+let slice_index_size () =
+  with_sessions_rw (fun () ->
+      Hashtbl.fold
+        (fun _slice set acc -> acc + Hashtbl.length set)
+        slice_index 0)
+
+(** Test-only: drive the slice index without needing a fully constructed
+    WS session.  Production code paths reach the same helpers via
+    [dashboard_subscribe] / [dashboard_unsubscribe] / [cleanup_session]. *)
+let __test_slice_index_add ~session_id ~slice =
+  with_sessions_rw (fun () -> slice_index_add_locked ~session_id ~slice)
+
+let __test_slice_index_remove ~session_id ~slice =
+  with_sessions_rw (fun () -> slice_index_remove_locked ~session_id ~slice)
+
+let __test_slice_index_remove_session session_id =
+  with_sessions_rw (fun () -> slice_index_remove_session_locked session_id)
+
 (** Generate a unique session ID. *)
 let next_id =
   let counter = Atomic.make 0 in
@@ -300,10 +368,14 @@ let dashboard_subscribe ~session_id ?route ~slices () =
         | bad :: _ ->
             Error (Printf.sprintf "unsupported dashboard slice: %s" bad)
         | [] ->
-            Hashtbl.clear session.dashboard_slices;
-            List.iter
-              (fun slice -> Hashtbl.replace session.dashboard_slices slice ())
-              slices;
+            with_sessions_rw (fun () ->
+                slice_index_remove_session_locked session_id;
+                Hashtbl.clear session.dashboard_slices;
+                List.iter
+                  (fun slice ->
+                    Hashtbl.replace session.dashboard_slices slice ();
+                    slice_index_add_locked ~session_id ~slice)
+                  slices);
             session.dashboard_route <- route;
             Ok
               (`Assoc
@@ -320,11 +392,17 @@ let dashboard_unsubscribe ~session_id ?slices () =
       if not session.dashboard_authenticated then
         Error "dashboard/unsubscribe requires dashboard/hello first"
       else begin
-        (match slices with
-         | None -> Hashtbl.clear session.dashboard_slices
-         | Some slices ->
-             List.iter (fun slice -> Hashtbl.remove session.dashboard_slices slice)
-               slices);
+        with_sessions_rw (fun () ->
+            match slices with
+            | None ->
+                Hashtbl.clear session.dashboard_slices;
+                slice_index_remove_session_locked session_id
+            | Some slices ->
+                List.iter
+                  (fun slice ->
+                    Hashtbl.remove session.dashboard_slices slice;
+                    slice_index_remove_locked ~session_id ~slice)
+                  slices);
         Ok (`Assoc [ ("session", dashboard_session_result session) ])
       end
 
@@ -533,6 +611,7 @@ let cleanup_session session_id =
              with Eio.Cancel.Cancelled _ as e -> raise e
                 | exn -> Log.Server.warn "WS close failed for %s: %s" session_id (Printexc.to_string exn));
             Hashtbl.remove sessions session_id;
+            slice_index_remove_session_locked session_id;
             true)
   in
   Transport_metrics.set_ws_sessions

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -396,6 +396,97 @@ let test_ws_external_subscriber_count () =
     let final = Sse.external_subscriber_count () in
     Alcotest.(check int) "back to before" before final)
 
+(* ====== Slice index (Phase 1: bookkeeping only) ====== *)
+
+(* The slice index maps each dashboard slice to the set of session IDs
+   currently subscribed to it.  Phase 1 maintains the index at subscribe
+   / unsubscribe / cleanup time but does NOT yet rewire the broadcast
+   fanout (RFC #10119).  These tests pin add/remove/sweep semantics so
+   Phase 2 can rely on them. *)
+
+let test_slice_index_starts_empty_for_unknown_slice () =
+  Eio_main.run (fun _env ->
+    let subs = Ws.slice_index_subscribers "execution" in
+    (* The index is process-global state shared across tests, so we cannot
+       assert it is empty.  We can assert this specific session id is
+       not in it, which is the property the index exists to answer. *)
+    Alcotest.(check bool) "fresh session id not present"
+      true (not (List.mem "ws-slice-test-fresh" subs)))
+
+let test_slice_index_add_records_session () =
+  Eio_main.run (fun _env ->
+    let sid = "ws-slice-add-1" in
+    Ws.__test_slice_index_remove_session sid; (* defensive cleanup *)
+    Ws.__test_slice_index_add ~session_id:sid ~slice:"execution";
+    let subs = Ws.slice_index_subscribers "execution" in
+    Alcotest.(check bool) "session present after add"
+      true (List.mem sid subs);
+    Ws.__test_slice_index_remove_session sid)
+
+let test_slice_index_remove_specific_slice () =
+  Eio_main.run (fun _env ->
+    let sid = "ws-slice-remove-1" in
+    Ws.__test_slice_index_remove_session sid;
+    Ws.__test_slice_index_add ~session_id:sid ~slice:"execution";
+    Ws.__test_slice_index_add ~session_id:sid ~slice:"keepers";
+    Ws.__test_slice_index_remove ~session_id:sid ~slice:"execution";
+    let exec = Ws.slice_index_subscribers "execution" in
+    let keepers = Ws.slice_index_subscribers "keepers" in
+    Alcotest.(check bool) "removed from execution"
+      true (not (List.mem sid exec));
+    Alcotest.(check bool) "still in keepers"
+      true (List.mem sid keepers);
+    Ws.__test_slice_index_remove_session sid)
+
+let test_slice_index_remove_session_clears_all_slices () =
+  Eio_main.run (fun _env ->
+    let sid = "ws-slice-cleanup-1" in
+    Ws.__test_slice_index_remove_session sid;
+    List.iter
+      (fun slice -> Ws.__test_slice_index_add ~session_id:sid ~slice)
+      ["execution"; "keepers"; "transport"; "shell"];
+    Ws.__test_slice_index_remove_session sid;
+    List.iter
+      (fun slice ->
+        let subs = Ws.slice_index_subscribers slice in
+        Alcotest.(check bool)
+          (Printf.sprintf "session removed from %s" slice)
+          true (not (List.mem sid subs)))
+      ["execution"; "keepers"; "transport"; "shell"])
+
+let test_slice_index_size_reflects_pairs () =
+  Eio_main.run (fun _env ->
+    let sid_a = "ws-slice-size-a" in
+    let sid_b = "ws-slice-size-b" in
+    Ws.__test_slice_index_remove_session sid_a;
+    Ws.__test_slice_index_remove_session sid_b;
+    let baseline = Ws.slice_index_size () in
+    Ws.__test_slice_index_add ~session_id:sid_a ~slice:"execution";
+    Ws.__test_slice_index_add ~session_id:sid_a ~slice:"keepers";
+    Ws.__test_slice_index_add ~session_id:sid_b ~slice:"execution";
+    let after = Ws.slice_index_size () in
+    (* 2 entries for sid_a + 1 for sid_b = +3 over baseline *)
+    Alcotest.(check int) "size grew by exactly the new pair count"
+      3 (after - baseline);
+    Ws.__test_slice_index_remove_session sid_a;
+    Ws.__test_slice_index_remove_session sid_b;
+    let final = Ws.slice_index_size () in
+    Alcotest.(check int) "size returns to baseline after sweep"
+      baseline final)
+
+let test_slice_index_add_is_idempotent () =
+  Eio_main.run (fun _env ->
+    let sid = "ws-slice-idem" in
+    Ws.__test_slice_index_remove_session sid;
+    Ws.__test_slice_index_add ~session_id:sid ~slice:"execution";
+    Ws.__test_slice_index_add ~session_id:sid ~slice:"execution";
+    Ws.__test_slice_index_add ~session_id:sid ~slice:"execution";
+    let subs = Ws.slice_index_subscribers "execution" in
+    let occurrences = List.length (List.filter ((=) sid) subs) in
+    Alcotest.(check int) "session appears at most once after duplicate adds"
+      1 occurrences;
+    Ws.__test_slice_index_remove_session sid)
+
 let () =
   Alcotest.run "WebSocket Transport" [
     ("session_registry", [
@@ -462,5 +553,19 @@ let () =
         test_ws_dead_subscriber_auto_removed;
       Alcotest.test_case "subscriber count tracking" `Quick
         test_ws_external_subscriber_count;
+    ]);
+    ("slice_index", [
+      Alcotest.test_case "unknown slice yields no subscribers" `Quick
+        test_slice_index_starts_empty_for_unknown_slice;
+      Alcotest.test_case "add records session under slice" `Quick
+        test_slice_index_add_records_session;
+      Alcotest.test_case "remove targets only the named slice" `Quick
+        test_slice_index_remove_specific_slice;
+      Alcotest.test_case "remove_session sweeps every slice" `Quick
+        test_slice_index_remove_session_clears_all_slices;
+      Alcotest.test_case "size tracks (slice × session) pair count" `Quick
+        test_slice_index_size_reflects_pairs;
+      Alcotest.test_case "duplicate add is idempotent" `Quick
+        test_slice_index_add_is_idempotent;
     ]);
   ]


### PR DESCRIPTION
## Summary

Implements **Phase 1** of the WS slice-indexed fanout RFC ([#10119](https://github.com/jeong-sik/masc-mcp/pull/10119)): a side index mapping each dashboard slice to the set of session IDs currently subscribed to it.  Phase 1 is bookkeeping only — the broadcast fanout path is unchanged, so behaviour is identical to today.  Phase 2 (separate PR) will consume the index to skip raw-SSE-forwards to sessions whose route does not subscribe to the event's slice.

## What changes

- `slice_index : (string, (string, unit) Hashtbl.t) Hashtbl.t` in `lib/server/server_mcp_transport_ws.ml` (module-level, mutated under `sessions_mutex`).
- Hooks into:
  - `dashboard_subscribe` — clears prior entries, adds new slices.
  - `dashboard_unsubscribe` — removes specified slices (or all).
  - `cleanup_session` — sweeps every slice the session was in.
- Empty inner sets are pruned so `slice_index_size` is honest.
- Public helpers: `slice_index_subscribers`, `slice_index_size`.
- Test-only entry points (`__test_slice_index_*`) drive the index directly — the dashboard subscribe path requires a fully-constructed `Wsd.t` which only integration tests build.

## What does not change

- Sse fanout: still iterates every external subscriber.
- Wire format: no message changes.
- Public API for non-test code: `dashboard_subscribe` / `dashboard_unsubscribe` / `cleanup_session` keep their signatures.

## Test plan

- 6 new test cases under `slice_index` group:
  - unknown slice yields no subscribers
  - add records session under slice
  - remove targets only the named slice
  - remove_session sweeps every slice
  - size tracks (slice × session) pair count (delta-based, shared global state friendly)
  - duplicate add is idempotent
- Full `test_ws_transport.exe` passes (33 / 33).
- Full `dune build` clean.

## Phase 2 follow-up

Will rewire the WS callback registered with `Sse.subscribe_external` to consult `slice_index` for slice-scoped events (mapping known event types to slices, falling back to raw forward when the event has no slice mapping).  RFC §4.2 lays out the proposed structure; the index added here is exactly its input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)