### PR TITLE
fix(oas): detect API fingerprint metadata drift

### DIFF
--- a/scripts/check-oas-pin.sh
+++ b/scripts/check-oas-pin.sh
@@ -310,9 +310,10 @@ if [[ -x "${SCRIPT_DIR}/oas-drift-check.sh" ]]; then
     drift_exit=$?
     if [[ "${drift_exit}" -eq 2 ]]; then
       # Count delta entries across all sections for a one-line summary.
+      metadata_n="$(printf '%s\n' "${drift_output}" | grep -c '^      ~ ' || true)"
       added_n="$(printf '%s\n' "${drift_output}" | grep -c '^      + ' || true)"
       removed_n="$(printf '%s\n' "${drift_output}" | grep -c '^      - ' || true)"
-      echo "OAS API surface: ⚠ drift (added ${added_n}, removed ${removed_n}) — run 'make doctor-oas-drift' for detail"
+      echo "OAS API surface: ⚠ drift (metadata ${metadata_n}, added ${added_n}, removed ${removed_n}) — run 'make doctor-oas-drift' for detail"
     else
       echo "OAS API surface: (could not compute — ${drift_exit}; run 'bash scripts/oas-drift-check.sh' for detail)"
     fi

--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,6 +1,6 @@
 {
-  "pinned_sha": "9c83369e62631a7fda7ef6f006b9a4aaeda33626",
-  "pinned_version": "v0.172.0",
+  "pinned_sha": "e56ab56a667ea4145d7bbd8ea5a2d1c194f2cde6",
+  "pinned_version": "v0.173.0",
   "surfaces": {
     "event_bus_payload_variants": [
       "AgentCompleted",

--- a/scripts/oas-drift-check.sh
+++ b/scripts/oas-drift-check.sh
@@ -223,6 +223,30 @@ report_diff() {
   return 1
 }
 
+report_metadata_diff() {
+  local prev="$1" curr="$2"
+  local changed=0
+  local prev_sha curr_sha prev_ver curr_ver
+  prev_sha="$(jq -r '.pinned_sha // ""' <<<"${prev}")"
+  curr_sha="$(jq -r '.pinned_sha // ""' <<<"${curr}")"
+  prev_ver="$(jq -r '.pinned_version // ""' <<<"${prev}")"
+  curr_ver="$(jq -r '.pinned_version // ""' <<<"${curr}")"
+
+  if [[ "${prev_sha}" != "${curr_sha}" || "${prev_ver}" != "${curr_ver}" ]]; then
+    echo
+    echo "  [fingerprint_metadata]"
+  fi
+  if [[ "${prev_sha}" != "${curr_sha}" ]]; then
+    echo "      ~ pinned_sha: ${prev_sha:-<missing>} -> ${curr_sha:-<missing>}"
+    changed=1
+  fi
+  if [[ "${prev_ver}" != "${curr_ver}" ]]; then
+    echo "      ~ pinned_version: ${prev_ver:-<missing>} -> ${curr_ver:-<missing>}"
+    changed=1
+  fi
+  return "${changed}"
+}
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -251,6 +275,9 @@ case "${MODE}" in
     prev="$(cat "${FINGERPRINT_FILE}")"
 
     drift=0
+    if ! report_metadata_diff "${prev}" "${current}"; then
+      drift=1
+    fi
     for section in event_bus_payload_variants http_error_variants metrics_fields; do
       prev_arr="$(jq ".surfaces.${section}" <<<"${prev}")"
       curr_arr="$(jq ".surfaces.${section}" <<<"${current}")"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -387,10 +387,16 @@ let test_http_write_auth_contracts () =
        {|with_tool_auth ~tool_name:"masc_board_vote"|});
   check bool "board vote route overwrites voter from auth identity" true
     (file_contains_pattern "lib/server/server_routes_http_routes_activity.ml"
-       {|json_upsert_string_field "voter" agent_name|});
+       {|let voter = board_actor_author_for_write agent_name|});
+  check bool "board vote route writes normalized voter" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_activity.ml"
+       {|json_upsert_string_field "voter" voter|});
   check bool "board comment route overwrites author from auth identity" true
     (file_contains_pattern "lib/server/server_routes_http_routes_activity.ml"
-       {|json_upsert_string_field "author" agent_name|});
+       {|let author = board_actor_author_for_write agent_name|});
+  check bool "board comment route writes normalized author" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_activity.ml"
+       {|json_upsert_string_field "author" author|});
   check bool "tool-host-failures route requires tool auth" true
     (file_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
        {|with_tool_auth ~tool_name:"masc_broadcast"|});


### PR DESCRIPTION
## Summary
- make `scripts/oas-drift-check.sh` compare `pinned_sha` and `pinned_version`, not only surface arrays
- refresh `scripts/oas-api-surface.json` to current OAS pin `e56ab56a667ea4145d7bbd8ea5a2d1c194f2cde6` / `v0.173.0`
- update source-hardening guards for normalized board author/voter writes after the latest route refactor

## Why
#10149 moved the OAS pin to `v0.173.0`, but the fingerprint metadata could remain stale because drift-check treated matching arrays as success. That made `check-oas-pin` report a false green for the API fingerprint lane.

## Validation
- `bash -n scripts/oas-drift-check.sh`
- `bash -n scripts/check-oas-pin.sh`
- `scripts/check-oas-pin.sh --local-only`
- `scripts/oas-drift-check.sh`
- `scripts/check-oas-pin.sh`
- `env DUNE_BUILD_DIR=_build_oas_surface_current DUNE_JOBS=2 DUNE_CACHE=disabled MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_ci_hardening_source.exe`
- `_build_oas_surface_current/default/test/test_ci_hardening_source.exe`

Follow-up to #10149 / #10139.