### PR TITLE
fix(keeper): gate backlog turns on claimable tasks

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1286,7 +1286,11 @@ let run_keepalive_unified_turn
   else (
     try
       let obs =
+        let allowed_tool_names =
+          Keeper_tool_policy.keeper_allowed_tool_names meta_after_triage
+        in
         Keeper_world_observation.observe
+          ~allowed_tool_names:(Some allowed_tool_names)
           ~pending_board_events:(Some pending_board_events)
           ~config:ctx.config
           ~meta:meta_after_triage

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -132,6 +132,7 @@ let direct_turn_observation (meta : keeper_meta) :
     context_ratio = 0.0;
     economic_pressure = Agent_economy.Normal;
     unclaimed_task_count = 0;
+    claimable_task_count = 0;
     failed_task_count = 0;
     pending_verification_count = 0;
     backlog_updated_since_last_scheduled_autonomous = false;

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -393,6 +393,7 @@ let observed_triggers_of_observation
   if observation.pending_board_events <> [] then add "board_activity";
   if observation.pending_scope_messages <> [] then add "scope_message";
   if observation.unclaimed_task_count > 0 then add "new_unclaimed_task";
+  if observation.claimable_task_count > 0 then add "claimable_task";
   if observation.failed_task_count > 0 then add "failed_task";
   let _ = meta in
   if observation.pending_verification_count > 0 then
@@ -410,7 +411,7 @@ let observed_affordances_of_observation
   if observation.pending_mentions <> [] then add "reply_in_room";
   if observation.pending_board_events <> [] then add "board_post_or_comment";
   if observation.pending_scope_messages <> [] then add "message_sweep";
-  if observation.unclaimed_task_count > 0 then add "task_claim";
+  if observation.claimable_task_count > 0 then add "task_claim";
   if observation.failed_task_count > 0 then add "task_audit";
   let _ = meta in
   if observation.pending_verification_count > 0 then
@@ -607,6 +608,12 @@ let append_decision_record
               ("idle_seconds", `Int observation.idle_seconds);
               ("context_ratio", `Float observation.context_ratio);
               ("unclaimed_task_count", `Int observation.unclaimed_task_count);
+              ("claimable_task_count", `Int observation.claimable_task_count);
+              ( "claim_blocked_task_count",
+                `Int
+                  (max 0
+                     (observation.unclaimed_task_count
+                      - observation.claimable_task_count)) );
               ("failed_task_count", `Int observation.failed_task_count);
               ("pending_verification_count", `Int observation.pending_verification_count);
               ("active_agent_count", `Int observation.active_agent_count);
@@ -615,7 +622,9 @@ let append_decision_record
         ("tool_call_count", `Int tool_call_count);
         ("tools_used", `List (List.map (fun s -> `String s) tools_used));
         ("tool_calls", `List (List.map tool_call_detail_to_json tool_calls));
-        ("claim_was_available", `Bool (observation.unclaimed_task_count > 0));
+        ("claim_absolute_available", `Bool (observation.unclaimed_task_count > 0));
+        ("claim_matched_available", `Bool (observation.claimable_task_count > 0));
+        ("claim_was_available", `Bool (observation.claimable_task_count > 0));
         ("claim_executed", `Bool claim_executed);
         ( "action_source",
           match deliberation_execution with

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -106,11 +106,11 @@ let autonomous_trigger_lines
            | _ -> None);
           (match decision.task_reactive_cooldown with
            | Some cooldown
-             when observation.unclaimed_task_count > 0
+             when observation.claimable_task_count > 0
                   || observation.failed_task_count > 0 ->
                Some
                  (Printf.sprintf
-                    "- Backlog acceleration cooldown: %ds for unclaimed/failed tasks"
+                    "- Backlog acceleration cooldown: %ds for claimable/failed tasks"
                     cooldown)
            | _ -> None);
         ]
@@ -169,7 +169,7 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
     |> List.mem "keeper_task_claim"
   in
   let show_claim_guidance =
-    observation.unclaimed_task_count > 0
+    observation.claimable_task_count > 0
     && claim_tool_available
     && not meta.paused
     && Option.is_none meta.current_task_id
@@ -244,6 +244,7 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
   (* 2. Namespace state — usually lower churn than inbox/board detail *)
   if
     observation.unclaimed_task_count > 0
+    || observation.claimable_task_count > 0
     || observation.failed_task_count > 0
     || observation.active_agent_count > 0
   then (
@@ -252,6 +253,15 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
       Buffer.add_string ubuf
         (Printf.sprintf "- Unclaimed tasks: %d\n"
            observation.unclaimed_task_count);
+    if observation.claimable_task_count > 0 then
+      Buffer.add_string ubuf
+        (Printf.sprintf "- Claimable tasks for this keeper: %d\n"
+           observation.claimable_task_count);
+    if observation.unclaimed_task_count > 0
+       && observation.claimable_task_count = 0
+    then
+      Buffer.add_string ubuf
+        "- Claimable tasks for this keeper: 0\n";
     if observation.failed_task_count > 0 then
       Buffer.add_string ubuf
         (Printf.sprintf "- Failed tasks: %d\n" observation.failed_task_count);

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -37,6 +37,7 @@ type world_observation = {
   context_ratio : float;
   economic_pressure : Agent_economy.pressure_mode;
   unclaimed_task_count : int;
+  claimable_task_count : int;
   failed_task_count : int;
   pending_verification_count : int;
   backlog_updated_since_last_scheduled_autonomous : bool;
@@ -242,15 +243,33 @@ let backlog_updated_since_last_scheduled_autonomous
     | None -> false
 
 (** Read room backlog counts. *)
-let read_backlog_counts ~(config : Coord.config) ~(meta : keeper_meta) :
-    int * int * int * bool =
+let read_backlog_counts ~allowed_tool_names ~(config : Coord.config)
+    ~(meta : keeper_meta) :
+    int * int * int * int * bool =
   try
     let backlog = Coord.read_backlog config in
-    let unclaimed =
+    let unclaimed_tasks =
+      List.filter
+        (fun (t : Types.task) -> t.task_status = Types.Todo)
+        backlog.tasks
+    in
+    let unclaimed = List.length unclaimed_tasks in
+    let required_tools_allowed required_tools =
+      match allowed_tool_names with
+      | Some names ->
+          Coord_task_schedule.required_tools_allowed ~agent_tool_names:names
+            required_tools
+      | None ->
+          Coord_task_schedule.required_tools_allowed required_tools
+    in
+    let claimable =
       List.length
         (List.filter
-           (fun (t : Types.task) -> t.task_status = Types.Todo)
-           backlog.tasks)
+           (fun task ->
+             Coord_task_schedule.task_is_claim_pool_candidate task
+             && required_tools_allowed
+                  (Coord_task_schedule.task_required_tools task))
+           unclaimed_tasks)
     in
     let failed =
       List.length
@@ -276,6 +295,7 @@ let read_backlog_counts ~(config : Coord.config) ~(meta : keeper_meta) :
       backlog_updated_since_last_scheduled_autonomous ~meta ~backlog
     in
     ( unclaimed,
+      claimable,
       failed,
       pending_verification,
       backlog_updated_since_last_scheduled_autonomous )
@@ -283,7 +303,7 @@ let read_backlog_counts ~(config : Coord.config) ~(meta : keeper_meta) :
   | Eio.Cancel.Cancelled _ as e -> raise e
   | ex ->
       Log.Keeper.warn "read_backlog_counts failed: %s" (Printexc.to_string ex);
-      (0, 0, 0, false)
+      (0, 0, 0, 0, false)
 
 (** Count active agents in room. *)
 let count_active_agents ~(config : Coord.config) : int =
@@ -701,7 +721,8 @@ let collect_board_events ~(base_path : string) ~(continuity_summary : string)
       (Printexc.to_string exn);
     ([], 0, 0)
 
-let observe ~(pending_board_events : pending_board_event list option)
+let observe ~allowed_tool_names
+    ~(pending_board_events : pending_board_event list option)
     ~(config : Coord.config)
     ~(meta : keeper_meta) :
     world_observation =
@@ -709,10 +730,11 @@ let observe ~(pending_board_events : pending_board_event list option)
     collect_message_scope ~config ~meta
   in
   let ( unclaimed_task_count,
+        claimable_task_count,
         failed_task_count,
         pending_verification_count,
         backlog_updated_since_last_scheduled_autonomous ) =
-    read_backlog_counts ~config ~meta
+    read_backlog_counts ~allowed_tool_names ~config ~meta
   in
   let active_agent_count = count_active_agents ~config in
   let idle_seconds = compute_idle_seconds ~meta in
@@ -765,6 +787,7 @@ let observe ~(pending_board_events : pending_board_event list option)
     context_ratio;
     economic_pressure;
     unclaimed_task_count;
+    claimable_task_count;
     failed_task_count;
     pending_verification_count;
     backlog_updated_since_last_scheduled_autonomous;
@@ -779,7 +802,7 @@ let actionable_signal_present (observation : world_observation) =
   || observation.pending_board_events <> []
   || observation.pending_scope_messages <> []
   || Option.is_some observation.worktree_change_summary
-  || observation.unclaimed_task_count > 0
+  || observation.claimable_task_count > 0
   || observation.failed_task_count > 0
   || observation.pending_verification_count > 0
   || observation.work_discovery_due
@@ -954,7 +977,7 @@ let keeper_cycle_decision
             (effective_cooldown / max 1 task_cooldown_divisor)
         in
         let has_actionable_tasks =
-          observation.unclaimed_task_count > 0 || observation.failed_task_count > 0
+          observation.claimable_task_count > 0 || observation.failed_task_count > 0
         in
         let idle_gate_elapsed = observation.idle_seconds >= idle_gate_sec in
         let cooldown_elapsed =
@@ -1022,7 +1045,7 @@ let keeper_cycle_decision
                 (if cooldown_elapsed then Some Cooldown_elapsed else None);
                 (if has_actionable_tasks
                  then Some (Task_backlog
-                              { unclaimed = observation.unclaimed_task_count;
+                              { unclaimed = observation.claimable_task_count;
                                 failed = observation.failed_task_count }) else None);
                 (if backlog_fresh || backlog_elapsed
                  then Some Task_reactive_cooldown_elapsed else None);

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -66,6 +66,10 @@ type world_observation = {
   unclaimed_task_count : int;
   (** Number of unclaimed tasks in the room backlog. *)
 
+  claimable_task_count : int;
+  (** Number of unclaimed tasks this keeper can claim with its current tool
+      surface. This is a matched subset of [unclaimed_task_count]. *)
+
   failed_task_count : int;
   (** Number of failed/cancelled tasks in the room backlog. *)
 
@@ -207,6 +211,7 @@ val read_continuity_summary :
     @param config Coord configuration for I/O operations
     @param meta Current keeper metadata *)
 val observe :
+  allowed_tool_names:string list option ->
   pending_board_events:pending_board_event list option ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
@@ -85,6 +85,10 @@ let belief_summary_of_observation
            Some
              (Printf.sprintf "unclaimed_tasks=%d" observation.unclaimed_task_count)
          else None);
+        (if observation.claimable_task_count > 0 then
+           Some
+             (Printf.sprintf "claimable_tasks=%d" observation.claimable_task_count)
+         else None);
         (if observation.failed_task_count > 0 then
            Some (Printf.sprintf "failed_tasks=%d" observation.failed_task_count)
          else None);
@@ -428,7 +432,7 @@ let derive_failure_state ~(meta : keeper_meta)
     | value -> Some (short_preview value)
   in
   let state =
-    if is_auto_recoverable && observation.unclaimed_task_count > 0 then
+    if is_auto_recoverable && observation.claimable_task_count > 0 then
       make_state ~meta ~observation ?previous_state
         ~active_desire:"recover_tool_route"
         ~current_intention:"retry_claim_after_recovery"

--- a/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.ml
@@ -21,7 +21,7 @@ let reactive_signal_count
   + List.length observation.pending_scope_messages
 
 let backlog_count (observation : Keeper_world_observation.world_observation) =
-  observation.unclaimed_task_count + observation.failed_task_count
+  observation.claimable_task_count + observation.failed_task_count
 
 let belief_summary_of_snapshot ~(snapshot : Fsm.snapshot)
     ~(event : Fsm.event)
@@ -33,6 +33,8 @@ let belief_summary_of_snapshot ~(snapshot : Fsm.snapshot)
       "event=" ^ Fsm.event_to_string event;
       "reactive=" ^ string_of_int (reactive_signal_count observation);
       "backlog=" ^ string_of_int (backlog_count observation);
+      "unclaimed=" ^ string_of_int observation.unclaimed_task_count;
+      "claimable=" ^ string_of_int observation.claimable_task_count;
       "goals=" ^ string_of_int (List.length observation.active_goals);
       "tools=" ^ string_of_int tool_count;
       "idle=" ^ string_of_int observation.idle_seconds ^ "s";

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -132,6 +132,7 @@ let base_observation : WO.world_observation =
     context_ratio = 0.0;
     economic_pressure = AE.Normal;
     unclaimed_task_count = 0;
+    claimable_task_count = 0;
     failed_task_count = 0;
     pending_verification_count = 0;
     backlog_updated_since_last_scheduled_autonomous = false;
@@ -163,6 +164,7 @@ let test_observation_defaults () =
   check int "idle_seconds default" 0 obs.idle_seconds;
   check (float 0.001) "context_ratio default" 0.0 obs.context_ratio;
   check int "unclaimed default" 0 obs.unclaimed_task_count;
+  check int "claimable default" 0 obs.claimable_task_count;
   check int "failed default" 0 obs.failed_task_count;
   check int "active_agents default" 0 obs.active_agent_count;
   check bool "no mentions" true (obs.pending_mentions = []);
@@ -217,6 +219,22 @@ let minimal_policy_meta =
 let room_signal_meta =
   { minimal_meta with room_signal_prompt_enabled = true }
 
+let contract_requiring_tools required_tools : Types.task_contract =
+  {
+    strict = false;
+    completion_contract = [];
+    required_tools;
+    required_evidence = [];
+    inspect_gate_evidence = [];
+    verify_gate_evidence = [];
+    links =
+      {
+        operation_id = None;
+        session_id = None;
+        autoresearch_loop_id = None;
+      };
+  }
+
 let test_observe_uses_precollected_board_events () =
   let base_dir = temp_dir () in
   Fun.protect
@@ -243,13 +261,35 @@ let test_observe_uses_precollected_board_events () =
           ~meta:minimal_meta
       in
       let obs =
-        WO.observe ~pending_board_events:(Some events)
+        WO.observe ~allowed_tool_names:None
+          ~pending_board_events:(Some events)
           ~config ~meta:minimal_meta
       in
       check int "precollected board events preserved" (List.length events)
         (List.length obs.pending_board_events);
       check bool "board event schedules turn" true
         (WO.should_run_keeper_cycle ~meta:minimal_meta obs))
+
+let test_observe_splits_absolute_and_claimable_backlog () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+      ignore
+        (Masc_mcp.Coord.add_task config ~title:"Open task" ~priority:1
+           ~description:"");
+      ignore
+        (Masc_mcp.Coord.add_task config ~title:"Bash task" ~priority:1
+           ~description:""
+           ~contract:(contract_requiring_tools [ "keeper_bash" ]));
+      let obs =
+        WO.observe ~allowed_tool_names:(Some [ "keeper_task_claim" ])
+          ~pending_board_events:(Some []) ~config ~meta:minimal_meta
+      in
+      check int "absolute todo backlog" 2 obs.unclaimed_task_count;
+      check int "matched claimable backlog" 1 obs.claimable_task_count)
 
 let test_collect_board_events_keeps_non_mentions_as_followup_signal () =
   let base_dir = temp_dir () in
@@ -438,7 +478,8 @@ let test_observe_ignores_scope_messages_without_room_signal_opt_in () =
       ignore (Masc_mcp.Coord.broadcast config ~from_agent:"alice" ~content:"general room update");
       let meta = { minimal_meta with joined_room_ids = [ "default" ] } in
       let obs =
-        WO.observe ~pending_board_events:(Some [])
+        WO.observe ~allowed_tool_names:None
+          ~pending_board_events:(Some [])
           ~config ~meta
       in
       check int "mentions stay empty" 0 (List.length obs.pending_mentions);
@@ -458,7 +499,8 @@ let test_observe_collects_scope_messages_for_room_signal_keepers () =
       ignore (Masc_mcp.Coord.broadcast config ~from_agent:"alice" ~content:"general room update");
       let meta = { room_signal_meta with joined_room_ids = [ "default" ] } in
       let obs =
-        WO.observe ~pending_board_events:(Some [])
+        WO.observe ~allowed_tool_names:None
+          ~pending_board_events:(Some [])
           ~config ~meta
       in
       check int "mentions stay empty" 0 (List.length obs.pending_mentions);
@@ -781,6 +823,45 @@ let test_scheduled_turn_decision_uses_backlog_acceleration () =
          List.mem WO.Task_reactive_cooldown_elapsed (first :: rest)
      | WO.Skip _ -> false)
 
+let test_scheduled_turn_ignores_unclaimable_backlog () =
+  let meta =
+    {
+      minimal_meta with
+      proactive =
+        { enabled = true; idle_sec = 600; cooldown_sec = 900 };
+      runtime =
+        {
+          minimal_meta.runtime with
+          proactive_rt =
+            { minimal_meta.runtime.proactive_rt with
+              last_ts = Time_compat.now () -. 320.0;
+            };
+        };
+    }
+  in
+  let obs =
+    {
+      base_observation with
+      idle_seconds = 120;
+      unclaimed_task_count = 3;
+      claimable_task_count = 0;
+      backlog_updated_since_last_scheduled_autonomous = true;
+    }
+  in
+  let decision =
+    WO.keeper_cycle_decision
+      ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
+      ~meta obs
+  in
+  check bool "absolute-only backlog does not wake keeper" false
+    decision.should_run;
+  check bool "no task backlog reason for unclaimable backlog" true
+    (match decision.verdict with
+     | WO.Skip { reasons = (first, rest)} ->
+         List.exists (function WO.No_signal -> true | _ -> false)
+           (first :: rest)
+     | WO.Run _ -> false)
+
 let test_verdict_reasons_to_strings_uses_structured_run_tags () =
   let verdict =
     WO.Run
@@ -934,6 +1015,7 @@ let test_task_backlog_cooldown_applies_noop_backoff_once () =
         base_observation with
         idle_seconds = 1000;
         unclaimed_task_count = 1;
+        claimable_task_count = 1;
       }
     in
     let decision =
@@ -967,6 +1049,7 @@ let test_scheduled_turn_decision_runs_immediately_on_fresh_backlog_update () =
     {
       base_observation with
       unclaimed_task_count = 1;
+      claimable_task_count = 1;
       backlog_updated_since_last_scheduled_autonomous = true;
     }
   in
@@ -1196,6 +1279,7 @@ let test_prompt_continuity_drops_stale_tool_surface_claims () =
          Next plan: call keeper_task_claim after checking live policy\n\
          Constraints: tool surface: masc_* only; no keeper_* tools visible";
       unclaimed_task_count = 3;
+      claimable_task_count = 3;
     }
   in
   let _sys, user =
@@ -1323,6 +1407,7 @@ let test_prompt_orders_stable_sections_before_reactive_sections () =
       context_ratio = 0.42;
       idle_seconds = 45;
       unclaimed_task_count = 2;
+      claimable_task_count = 2;
       active_agent_count = 3;
     }
   in
@@ -1345,6 +1430,7 @@ let test_prompt_room_state_section () =
   let obs =
     { base_observation with
       unclaimed_task_count = 3;
+      claimable_task_count = 3;
       failed_task_count = 1;
       active_agent_count = 5;
     }
@@ -1363,6 +1449,7 @@ let test_prompt_includes_claim_first_guidance () =
   let obs =
     { base_observation with
       unclaimed_task_count = 3;
+      claimable_task_count = 3;
       active_agent_count = 5;
     }
   in
@@ -1380,6 +1467,24 @@ let test_prompt_includes_claim_first_guidance () =
   check bool "user prompt explains gh requires claim first" true
     (contains_substring user "If you need keeper_shell op=gh, claim first")
 
+let test_prompt_omits_claim_first_guidance_when_no_claimable_tasks () =
+  let obs =
+    { base_observation with
+      unclaimed_task_count = 3;
+      claimable_task_count = 0;
+      active_agent_count = 5;
+    }
+  in
+  let sys, user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
+  in
+  check bool "system prompt omits auto-claim for unclaimable backlog" false
+    (contains_substring sys "Call keeper_task_claim with {}");
+  check bool "user prompt omits immediate task move for unclaimable backlog" false
+    (contains_substring user "### Immediate Task Move");
+  check bool "namespace exposes zero matched availability" true
+    (contains_substring user "Claimable tasks for this keeper: 0")
+
 let test_prompt_omits_claim_first_guidance_when_task_claimed () =
   let current_task_id =
     match Masc_mcp.Keeper_id.Task_id.of_string "task-123" with
@@ -1390,6 +1495,7 @@ let test_prompt_omits_claim_first_guidance_when_task_claimed () =
   let obs =
     { base_observation with
       unclaimed_task_count = 3;
+      claimable_task_count = 3;
       active_agent_count = 5;
     }
   in
@@ -1403,6 +1509,7 @@ let test_prompt_omits_claim_first_guidance_when_claim_tool_unavailable () =
   let obs =
     { base_observation with
       unclaimed_task_count = 3;
+      claimable_task_count = 3;
       active_agent_count = 5;
     }
   in
@@ -1419,6 +1526,7 @@ let test_prompt_omits_claim_first_guidance_when_paused () =
   let obs =
     { base_observation with
       unclaimed_task_count = 3;
+      claimable_task_count = 3;
       active_agent_count = 5;
     }
   in
@@ -5095,7 +5203,13 @@ let test_social_model_previous_state_of_meta_falls_back_for_unknown_model () =
         (KSM.delivery_surface_to_string state.delivery_surface)
 
 let test_social_model_bdi_failure_state_rewrites_claim_retry_loop () =
-  let observation = { base_observation with unclaimed_task_count = 12 } in
+  let observation =
+    {
+      base_observation with
+      unclaimed_task_count = 12;
+      claimable_task_count = 12;
+    }
+  in
   let previous_state =
     Some
       KSM.
@@ -5548,6 +5662,8 @@ let () =
           test_case "with mentions" `Quick test_observation_with_mentions;
           test_case "uses precollected board events" `Quick
             test_observe_uses_precollected_board_events;
+          test_case "splits absolute and claimable backlog" `Quick
+            test_observe_splits_absolute_and_claimable_backlog;
           test_case "default keepers ignore unmatched non-mention board events" `Quick
             test_collect_board_events_keeps_non_mentions_as_followup_signal;
           test_case "room-signal keepers keep unmatched non-mention board events" `Quick
@@ -5596,6 +5712,8 @@ let () =
             test_idle_decay_triggers_turn;
           test_case "scheduled decision uses backlog acceleration" `Quick
             test_scheduled_turn_decision_uses_backlog_acceleration;
+          test_case "scheduled decision ignores unclaimable backlog" `Quick
+            test_scheduled_turn_ignores_unclaimable_backlog;
           test_case "verdict reasons use structured run tags" `Quick
             test_verdict_reasons_to_strings_uses_structured_run_tags;
           test_case "verdict reasons use structured skip tags" `Quick
@@ -5652,6 +5770,8 @@ let () =
           test_case "room state section" `Quick test_prompt_room_state_section;
           test_case "claim first guidance" `Quick
             test_prompt_includes_claim_first_guidance;
+          test_case "claim first guidance omitted when no task is claimable" `Quick
+            test_prompt_omits_claim_first_guidance_when_no_claimable_tasks;
           test_case "claim first guidance omitted when task claimed" `Quick
             test_prompt_omits_claim_first_guidance_when_task_claimed;
           test_case "claim first guidance omitted when tool unavailable" `Quick
@@ -6193,6 +6313,48 @@ let () =
               in
               check bool "work_discovery present" true
                 (List.mem "work_discovery" affordances));
+          test_case "affordance: task claim requires matched backlog" `Quick
+            (fun () ->
+              let obs =
+                {
+                  base_observation with
+                  unclaimed_task_count = 3;
+                  claimable_task_count = 0;
+                }
+              in
+              let affordances =
+                UM.observed_affordances_of_observation obs
+              in
+              check bool "task_claim absent for unclaimable backlog" false
+                (List.mem "task_claim" affordances));
+          test_case "affordance: task claim present for claimable backlog" `Quick
+            (fun () ->
+              let obs =
+                {
+                  base_observation with
+                  unclaimed_task_count = 3;
+                  claimable_task_count = 1;
+                }
+              in
+              let affordances =
+                UM.observed_affordances_of_observation obs
+              in
+              check bool "task_claim present for matched backlog" true
+                (List.mem "task_claim" affordances));
+          test_case "trigger: absolute and matched backlog split" `Quick
+            (fun () ->
+              let obs =
+                {
+                  base_observation with
+                  unclaimed_task_count = 3;
+                  claimable_task_count = 1;
+                }
+              in
+              let triggers = UM.observed_triggers_of_observation obs in
+              check bool "absolute backlog trigger remains visible" true
+                (List.mem "new_unclaimed_task" triggers);
+              check bool "matched backlog trigger is explicit" true
+                (List.mem "claimable_task" triggers));
           test_case "trigger: keeper sees pending_verification"
             `Quick (fun () ->
               let meta =


### PR DESCRIPTION
## Summary
- split absolute unclaimed backlog from keeper-matched claimable backlog in world observation
- gate autonomous backlog wakeups, claim affordance, prompt claim-first guidance, and social recovery on claimable tasks
- add decision metrics for absolute vs matched availability and blocked claim count

## Why it matters
#9926 showed fleet-wide LLM burn because any todo task made every keeper think claim work was actionable. This moves the deterministic required_tools/tool-surface check before the LLM turn, while preserving absolute backlog visibility for diagnostics.

Fixes #9926.

## Verification
- git diff --check origin/main..HEAD
- env DUNE_BUILD_DIR=_build_verify_9926 DUNE_JOBS=2 scripts/dune-local.sh build test/test_keeper_unified.exe
- env DUNE_BUILD_DIR=_build_verify_9926 _build_verify_9926/default/test/test_keeper_unified.exe (278 tests)