### PR TITLE
perf(ws): slice-aware fanout gate (Phase 2 of #10119)

### DIFF
--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -234,6 +234,11 @@ let transport_entries =
     entry ~default:"1048576" "MASC_WS_CLIENT_BUFFER_LIMIT_BYTES"
       "Skip WS dashboard deltas for authenticated sessions whose last reported \
        WebSocket.bufferedAmount exceeds this many bytes. 0 disables the gate.";
+    entry ~default:"false" "MASC_WS_SLICE_INDEX_ENABLED"
+      "When true, slice-scoped events skip the raw-SSE-forward to authenticated \
+       WS sessions whose route does not subscribe to the event's slice. \
+       Catch-all events (no slice mapping) still reach every session. \
+       masc_ws_slice_fanout_skipped_total advances per skip. RFC #10119 Phase 2.";
     entry ~default:"true" "MASC_WEBRTC_ENABLED" "Enable WebRTC transport";
     entry ~default:"auto" "MASC_USE_H2" "HTTP mode (auto|h2_only|h1_only)";
     entry ~default:"240" "MASC_STARTUP_WATCHDOG_SEC"

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -374,6 +374,7 @@ let metric_ws_bytes_cache_misses = "masc_ws_bytes_cache_misses_total"
 let metric_ws_client_buffered_bytes = "masc_ws_client_buffered_bytes"
 let metric_ws_client_acks = "masc_ws_client_acks_total"
 let metric_ws_throttled_deliveries = "masc_ws_throttled_deliveries_total"
+let metric_ws_slice_fanout_skipped = "masc_ws_slice_fanout_skipped_total"
 
 (* Admission queue metrics — used in admission_queue_metrics.ml. *)
 let metric_inference_queue_depth = "masc_inference_queue_depth"
@@ -821,6 +822,11 @@ let init () =
   add metric_ws_throttled_deliveries
     "WS dashboard deliveries skipped because the client's last reported \
      bufferedAmount exceeded MASC_WS_CLIENT_BUFFER_LIMIT_BYTES"
+    Counter;
+  add metric_ws_slice_fanout_skipped
+    "WS sessions skipped during slice-scoped fanout because their route \
+     does not subscribe to the event's slice (gated by \
+     MASC_WS_SLICE_INDEX_ENABLED, RFC #10119 Phase 2)"
     Counter
 
 let start_time = Time_compat.now ()

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -233,6 +233,7 @@ val metric_ws_bytes_cache_misses : string
 val metric_ws_client_buffered_bytes : string
 val metric_ws_client_acks : string
 val metric_ws_throttled_deliveries : string
+val metric_ws_slice_fanout_skipped : string
 
 (** {1 Admission queue metrics} *)
 

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -522,6 +522,17 @@ let session_is_backpressured session =
     let limit = client_buffer_limit_bytes () in
     limit > 0 && session.dashboard_last_buffered_amount >= limit
 
+(** RFC #10119 Phase 2 gate.  When enabled, slice-scoped events skip the
+    raw-SSE-forward to authenticated sessions whose route does not
+    subscribe to the event's slice.  Default [false] — Phase 1
+    (#10155) only adds bookkeeping; Phase 2 flips behaviour, so the
+    rollout is staged via this flag.  The env var is read on every
+    fanout call so operators can flip without a restart; the read is
+    cheap (atomic hash lookup in [Env_config_core]). *)
+let slice_index_enabled () =
+  Env_config_core.get_bool ~default:false
+    "MASC_WS_SLICE_INDEX_ENABLED"
+
 let send_dashboard_or_raw_sse session sse_event =
   if session_is_backpressured session then begin
     (* Drop the delivery rather than queue it.  Next ack after the client
@@ -540,10 +551,38 @@ let send_dashboard_or_raw_sse session sse_event =
            per session and cannot be shared. *)
         send_json_checked ~context:"dashboard-delta" session delta
     | None ->
-        (* Same event string is forwarded verbatim to every session that
-           does not match a subscribed dashboard slice; the shared cache
-           collapses N identical [Bytes.of_string] allocations into 1. *)
-        send_text_shared_checked ~context:"sse-forward" session sse_event
+        (* Two sub-cases lead here:
+           1. The event has a parsed slice but this session's route is
+              not subscribed.  Today we raw-forward anyway so the client
+              can hydrate its store via [handleRawPush].  With the
+              slice-index gate enabled (RFC #10119 Phase 2) we skip
+              instead, since the client cannot do anything useful with
+              a slice it did not request and the wire write is pure
+              waste at the dashboard fleet's scale.
+           2. The event has no slice mapping (parse miss or unknown
+              event_type).  This is the catch-all path and must still
+              raw-forward so events outside the slice vocabulary still
+              reach authenticated sessions.
+
+           [parse_sse_dashboard_event] is the cached source of truth
+           for which case applies.  A [Some _] result with a [Some
+           slice] field means case 1 (slice known, session did not
+           subscribe — [dashboard_delta_for_sse] would have returned
+           [Some] otherwise).  Anything else is case 2. *)
+        let is_slice_mismatch =
+          match parse_sse_dashboard_event sse_event with
+          | Some { slice = Some _; _ } -> true
+          | _ -> false
+        in
+        if is_slice_mismatch && slice_index_enabled () then begin
+          Transport_metrics.inc_ws_slice_fanout_skipped ();
+          true
+        end
+        else
+          (* Same event string is forwarded verbatim to every session that
+             does not match a subscribed dashboard slice; the shared cache
+             collapses N identical [Bytes.of_string] allocations into 1. *)
+          send_text_shared_checked ~context:"sse-forward" session sse_event
   else
     send_text_shared_checked ~context:"sse-forward" session sse_event
 

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -83,6 +83,9 @@ let observe_ws_client_buffered_bytes n =
 let inc_ws_throttled_delivery () =
   Prometheus.inc_counter Prometheus.metric_ws_throttled_deliveries ()
 
+let inc_ws_slice_fanout_skipped () =
+  Prometheus.inc_counter Prometheus.metric_ws_slice_fanout_skipped ()
+
 (** {1 Environment-derived Transport Config} *)
 
 let grpc_runtime_listening : bool Atomic.t = Atomic.make false

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -487,6 +487,49 @@ let test_slice_index_add_is_idempotent () =
       1 occurrences;
     Ws.__test_slice_index_remove_session sid)
 
+(* ====== Slice fanout gate (Phase 2) ====== *)
+
+(* Phase 2 turns on the slice-aware fanout: when the env flag is set,
+   slice-scoped events skip raw-SSE-forwards to authenticated sessions
+   whose route does not subscribe.  The counter
+   [masc_ws_slice_fanout_skipped_total] advances per skip.  Catch-all
+   events (no slice mapping) still raw-forward to every session. *)
+
+let read_skip_counter () =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    Masc_mcp.Prometheus.metric_ws_slice_fanout_skipped ()
+
+let with_env_var key value f =
+  let prev = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match prev with
+      | Some v -> Unix.putenv key v
+      | None -> Unix.putenv key "")
+    f
+
+let test_slice_fanout_skip_counter_metric_registered () =
+  (* The counter is registered at startup; reading it must succeed
+     without raising even before any skip occurs. *)
+  let v = read_skip_counter () in
+  Alcotest.(check bool) "counter readable (>= 0)" true (v >= 0.0)
+
+let test_slice_fanout_flag_default_is_off () =
+  Eio_main.run (fun _env ->
+    with_env_var "MASC_WS_SLICE_INDEX_ENABLED" "" (fun () ->
+        Alcotest.(check bool) "default off"
+          false (Ws.slice_index_enabled ())))
+
+let test_slice_fanout_flag_reads_env () =
+  Eio_main.run (fun _env ->
+    with_env_var "MASC_WS_SLICE_INDEX_ENABLED" "true" (fun () ->
+        Alcotest.(check bool) "env=true → enabled"
+          true (Ws.slice_index_enabled ()));
+    with_env_var "MASC_WS_SLICE_INDEX_ENABLED" "false" (fun () ->
+        Alcotest.(check bool) "env=false → disabled"
+          false (Ws.slice_index_enabled ())))
+
 let () =
   Alcotest.run "WebSocket Transport" [
     ("session_registry", [
@@ -567,5 +610,13 @@ let () =
         test_slice_index_size_reflects_pairs;
       Alcotest.test_case "duplicate add is idempotent" `Quick
         test_slice_index_add_is_idempotent;
+    ]);
+    ("slice_fanout_gate", [
+      Alcotest.test_case "skip counter registered" `Quick
+        test_slice_fanout_skip_counter_metric_registered;
+      Alcotest.test_case "flag default is off" `Quick
+        test_slice_fanout_flag_default_is_off;
+      Alcotest.test_case "flag reads env var" `Quick
+        test_slice_fanout_flag_reads_env;
     ]);
   ]


### PR DESCRIPTION
Stacked on #10155 (Phase 1). Implements Phase 2 of WS slice-indexed fanout RFC #10119. New env MASC_WS_SLICE_INDEX_ENABLED (default false) gates slice-aware fanout; new counter masc_ws_slice_fanout_skipped_total. send_dashboard_or_raw_sse splits None-branch via parse cache. 36/36 tests pass. Default-off rollout per RFC §10. When parent squash-merges, will rebase to main.