### PR TITLE
fix(keeper-runtime): drop stats.enabled gate from supervisor sweep startup (#10125)

### DIFF
--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -630,11 +630,37 @@ let existing_keepalive_bootstrap_done : (string, unit) Hashtbl.t =
 let has_boot_entries config =
   bootable_keeper_names config <> []
 
+(* #10125: extracted predicate so it can be unit-tested without
+   spinning up an Eio + Pulse runtime.  See [maybe_start_supervisor_sweep]
+   for the WHY. *)
+let should_start_supervisor_sweep
+    ~(config : Coord.config)
+    ~(stats : keeper_bootstrap_stats) : bool =
+  let _ = stats.enabled in
+  stats.started > 0
+  || Keeper_registry.count_running ~base_path:config.base_path () > 0
+  || has_boot_entries config
+
 let maybe_start_supervisor_sweep ctx (stats : keeper_bootstrap_stats) =
-  if stats.enabled
-     && (stats.started > 0
-         || Keeper_registry.count_running ~base_path:ctx.config.base_path () > 0
-         || has_boot_entries ctx.config)
+  (* #10125: drop the [stats.enabled] precondition.  The previous
+     gate required bootstrap to have processed at least one keeper
+     successfully ([enabled = true] only when [bootable_keeper_names]
+     was non-empty AND at least one entry got past
+     [load_or_materialize_boot_meta]).  In the 2026-04-24 production
+     incident every bootstrap entry hit a transient
+     [load_or_materialize_boot_meta] error after a server restart,
+     so [stats.enabled] stayed [false] even though 14 keeper meta
+     files were on disk — supervisor never started, fleet stayed
+     dead for 4h+.
+
+     Decouple supervisor startup from bootstrap success: if there
+     are bootable keepers on disk OR any are already running OR
+     any started this boot, run the sweep.  The supervisor can
+     recover keepers that bootstrap failed to load, which is
+     exactly what the sweep is for.  Without this change, a
+     transient load failure during bootstrap silently disables
+     auto-recovery for the rest of the server lifetime. *)
+  if should_start_supervisor_sweep ~config:ctx.config ~stats
   then start_supervisor_sweep ctx
 
 let start_existing_keepalives ctx =

--- a/test/dune
+++ b/test/dune
@@ -333,6 +333,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_supervisor_start_predicate)
+ (modules test_supervisor_start_predicate)
+ (libraries masc_test_deps))
+
+(test
  (name test_keeper_context_bounds_ssot)
  (modules test_keeper_context_bounds_ssot)
  (libraries masc_test_deps))

--- a/test/test_supervisor_start_predicate.ml
+++ b/test/test_supervisor_start_predicate.ml
@@ -1,0 +1,109 @@
+(* #10125: pin [should_start_supervisor_sweep] decision logic.
+   Pre-fix the gate required [stats.enabled = true]; a transient
+   bootstrap failure (every keeper meta hit a load error) made the
+   supervisor never start, so the sweep that would otherwise
+   recover those keepers never ran — fleet stayed dead 4h+.
+
+   Post-fix: [stats.enabled] is no longer load-bearing.  Bootable
+   keepers on disk OR running count > 0 OR started > 0 each
+   independently force the supervisor up.  This is what protects
+   us from a degenerate bootstrap.
+
+   Note on test isolation: [Keeper_runtime.has_boot_entries] reads
+   keeper TOML profiles via [Config_dir_resolver.keepers_dir ()],
+   which is a GLOBAL path (operator's [$HOME/.masc/config/keepers/])
+   independent of the [Coord.config.base_path].  So in every test
+   environment with the operator profile present,
+   [bootable_keeper_names] returns non-empty.  The tests below
+   exploit that — they verify the post-fix path
+   ([enabled = false] still triggers sweep) without trying to
+   construct an empty profile environment. *)
+
+open Alcotest
+
+module Coord = Masc_mcp.Coord
+module KR = Masc_mcp.Keeper_runtime
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then (
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else
+      Sys.remove path
+
+let with_temp_masc_dir f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-10125-%d-%d" (Unix.getpid ())
+         (int_of_float (Unix.gettimeofday () *. 1_000_000.)))
+  in
+  Unix.mkdir base 0o755;
+  let config = Coord.default_config base in
+  ignore (Coord.init config ~agent_name:None);
+  Fun.protect
+    ~finally:(fun () ->
+      ignore (Coord.reset config);
+      rm_rf base)
+    (fun () -> f config)
+
+(* The regression case the fix is for: bootstrap reported [enabled
+   = false] AND [started = 0]. Pre-fix this killed the supervisor
+   for the entire process lifetime (the [stats.enabled] AND-gate).
+   Post-fix [has_boot_entries] alone is sufficient and keepers can
+   be recovered by the sweep loop. *)
+let test_disabled_bootstrap_with_disk_keepers_starts_sweep () =
+  with_temp_masc_dir (fun config ->
+    let stats =
+      KR.{ enabled = false; scanned = 0; started = 0;
+           stale = 0; recovering = 0 }
+    in
+    check bool
+      "disabled bootstrap + disk keepers (operator profile) → true"
+      true
+      (KR.should_start_supervisor_sweep ~config ~stats))
+
+(* Even without [enabled], a positive [started] count is enough.
+   This covers the second post-fix invariant: the boot path
+   produced at least one running keeper, so the sweep must
+   monitor it regardless of how the bootstrap-stats record
+   interpreted aggregate enabled-ness. *)
+let test_started_gt_zero_starts_sweep_without_enabled () =
+  with_temp_masc_dir (fun config ->
+    let stats =
+      KR.{ enabled = false; scanned = 1; started = 1;
+           stale = 0; recovering = 0 }
+    in
+    check bool
+      "stats.started > 0 even when enabled = false → true"
+      true
+      (KR.should_start_supervisor_sweep ~config ~stats))
+
+(* Sanity check: predicate runs without raising on a fully
+   defaulted [stats] record.  Pre-fix this would short-circuit on
+   [enabled = false]; post-fix it falls through to
+   [has_boot_entries], so we MUST not regress to raising or
+   silently returning [false] on a real config. *)
+let test_predicate_total_on_defaulted_stats () =
+  with_temp_masc_dir (fun config ->
+    let stats =
+      KR.{ enabled = false; scanned = 0; started = 0;
+           stale = 0; recovering = 0 }
+    in
+    let _ : bool = KR.should_start_supervisor_sweep ~config ~stats in
+    ())
+
+let () =
+  run "supervisor_start_predicate_10125" [
+    "predicate", [
+      test_case "disabled bootstrap + disk keeper → true (regression fix)" `Quick
+        test_disabled_bootstrap_with_disk_keepers_starts_sweep;
+      test_case "stats.started > 0 even when enabled = false → true" `Quick
+        test_started_gt_zero_starts_sweep_without_enabled;
+      test_case "predicate is total on defaulted stats (no raise)" `Quick
+        test_predicate_total_on_defaulted_stats;
+    ];
+  ]


### PR DESCRIPTION
## 요약

`maybe_start_supervisor_sweep`의 `stats.enabled` 전제조건 제거. 부팅 시 모든 keeper meta load가 transient 실패해 `enabled=false`여도, on-disk keeper profile이 존재하면 supervisor sweep을 무조건 시작.

Closes #10125.

## 근본 원인

2026-04-24 18:04 UTC 서버 재시작 후:
- 14 keeper meta files on disk (정상)
- `bootstrap_existing_keepers` 모든 entry에서 `load_or_materialize_boot_meta` 실패
- → `stats.enabled = false` (한 entry도 성공 못 함)
- → `maybe_start_supervisor_sweep` 의 AND-gate 차단
- → `keeper supervisor sweep started` 로그 0회
- → 14 keeper 모두 cascade exhaustion으로 죽고 zombie cleanup 후 누구도 rejoin 안 함
- → fleet **4시간+ silent**

```ocaml
(* before *)
let maybe_start_supervisor_sweep ctx (stats : keeper_bootstrap_stats) =
  if stats.enabled                          (* ← 차단 지점 *)
     && (stats.started > 0
         || Keeper_registry.count_running ... > 0
         || has_boot_entries ctx.config)
  then start_supervisor_sweep ctx
```

`stats.enabled`은 bootstrap 자체가 한 keeper라도 처리에 성공한 경우만 true. 그러나 supervisor sweep의 책임은 "bootstrap 실패한 keeper도 회복"이므로 `enabled` 전제가 의미 없음 — 오히려 회복 가능성을 차단.

## 변경 내용

```diff
+ let should_start_supervisor_sweep
+     ~(config : Coord.config)
+     ~(stats : keeper_bootstrap_stats) : bool =
+   let _ = stats.enabled in
+   stats.started > 0
+   || Keeper_registry.count_running ~base_path:config.base_path () > 0
+   || has_boot_entries config

  let maybe_start_supervisor_sweep ctx (stats : keeper_bootstrap_stats) =
-   if stats.enabled
-      && (stats.started > 0
-          || Keeper_registry.count_running ~base_path:ctx.config.base_path () > 0
-          || has_boot_entries ctx.config)
+   if should_start_supervisor_sweep ~config:ctx.config ~stats
    then start_supervisor_sweep ctx
```

Predicate를 별도 함수로 추출 → unit test 가능 (Eio + Pulse runtime 안 띄움).

## 동작

| 상황 | Before | After |
|------|--------|-------|
| 14 keepers on disk, bootstrap 모두 fail (`enabled=false`) | **차단** (실제 incident) | **start** ✓ |
| 14 keepers on disk, bootstrap 일부 성공 (`enabled=true, started=14`) | start | start (변경 없음) |
| 0 keepers on disk, 0 running | skip | skip (변경 없음) |
| 0 keepers on disk, but 5 running (외부 process가 등록함) | start | start (변경 없음) |

Supervisor가 빈 fleet에 대해 spurious start해도 sweep 자체는 빠르고 무해 (sweep_and_recover에 처리할 keeper 0개). False positive 비용 = 1 무해한 sweep cycle.

## 테스트

`test/test_supervisor_start_predicate.ml` 3 scenario:

```bash
$ dune exec test/test_supervisor_start_predicate.exe
[OK]  predicate  0  disabled bootstrap + disk keeper → true (regression fix).
[OK]  predicate  1  stats.started > 0 even when enabled = false → true.
[OK]  predicate  2  predicate is total on defaulted stats (no raise).
Test Successful in 0.018s. 3 tests run.
```

테스트 isolation 한계:
- `has_boot_entries` 가 `Config_dir_resolver.keepers_dir()` GLOBAL 경로 (`$HOME/.masc/config/keepers/`) 읽음. 즉 test의 `Coord.config.base_path` 와 무관한 위치.
- 결과: tmp dir 만으로 "true negative" (no boot entries) 케이스 unit-test 불가능. mock 도입은 별건.

## 회귀 리스크

매우 낮음. Single conditional change. 새 path는 원래 conditional의 super set:
- `enabled=true`인 경우: 동작 동일.
- `enabled=false, started>0`인 경우: 새 path가 sweep start. (이전엔 차단, 이제 start) — 정상 동작.
- `enabled=false, has_boot_entries`인 경우: 새 path가 sweep start. (incident 케이스 fix)

기존 keeper-runtime 테스트는 `should_start_supervisor_sweep`을 내부 함수로 사용하지 않음 → regression 없음.

## 후속 (별건)

- **`load_or_materialize_boot_meta` transient failure root cause**: 14/14 entry가 동시에 실패한 원인 별건 — disk corruption / config drift / file lock contention 등. 본 PR은 supervisor 회복 path만 fix.
- **Dashboard supervisor liveness gauge 활용**: `metric_keeper_supervisor_last_sweep_unixtime` 이미 존재. Dashboard에 stale badge (>2× interval) 추가하면 incident 30초 안에 detect.
- **재시작 후 health check end-to-end test**: chaos engineering 차원의 integration test. bootstrap + supervisor + recovery flow를 simulator로 verify.

## 참고

- Issue #10125
- `lib/keeper/keeper_runtime.ml:633-660` — predicate + caller
- `test/test_supervisor_start_predicate.ml` — coverage
- 관련: #10121 (keeper FSM stuck-turn livelock), #9933 (oas_timeout_budget cascade exhaustion trigger)
