### PR TITLE
fix(usage): require provider-kind evidence for anthropic cache trust

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -142,7 +142,9 @@ let classify_usage_trust ?usage ~model ~telemetry () =
     | Some usage -> true, usage
     | None -> false, zero_usage
   in
-  Keeper_usage_trust.classify ~usage_reported ~usage ~model_used:model
+  let provider_kind = provider_kind_of_telemetry telemetry in
+  Keeper_usage_trust.classify_with_provider_kind ~provider_kind ~usage_reported ~usage
+    ~model_used:model
     ~resolved_model_id:(canonical_model_id_of_telemetry ~model telemetry)
     ~context_max:(context_max_of_telemetry telemetry)
 

--- a/lib/keeper/keeper_usage_trust.ml
+++ b/lib/keeper/keeper_usage_trust.ml
@@ -26,21 +26,33 @@ let absurd_token_threshold = 1_000_000
    prompts running 5K-30K tokens. *)
 let anthropic_cache_min_input_tokens = 1024
 
+let provider_kind_uses_anthropic_caching
+    (kind : Llm_provider.Provider_config.provider_kind) : bool =
+  match kind with
+  | Anthropic | Claude_code -> true
+  | OpenAI_compat | Ollama | Gemini | Gemini_cli | Kimi | Kimi_cli | Glm
+  | Codex_cli ->
+      false
+
+let model_label_provider_kind label =
+  Provider_kind_resolver.kind_of_spec label
+
+let model_uses_anthropic_caching_with_provider_kind ~provider_kind ~(model_used : string)
+    ~(resolved_model_id : string) : bool =
+  match provider_kind with
+  | Some kind -> provider_kind_uses_anthropic_caching kind
+  | None ->
+      List.exists
+        (fun label ->
+           match model_label_provider_kind label with
+           | Some kind -> provider_kind_uses_anthropic_caching kind
+           | None -> false)
+        [ model_used; resolved_model_id ]
+
 let model_uses_anthropic_caching ~(model_used : string)
     ~(resolved_model_id : string) : bool =
-  let s = String.lowercase_ascii (model_used ^ "|" ^ resolved_model_id) in
-  let contains substr =
-    let n = String.length s and m = String.length substr in
-    if m = 0 || m > n then false
-    else
-      let rec loop i =
-        if i + m > n then false
-        else if String.sub s i m = substr then true
-        else loop (i + 1)
-      in
-      loop 0
-  in
-  contains "claude" || contains "anthropic"
+  model_uses_anthropic_caching_with_provider_kind ~provider_kind:None
+    ~model_used ~resolved_model_id
 
 let is_trusted = function
   | Usage_trusted -> true
@@ -70,7 +82,7 @@ let json_fields trust =
 let add_reason reason reasons =
   if List.mem reason reasons then reasons else reason :: reasons
 
-let classify ~(usage_reported : bool)
+let classify_with_provider_kind ~provider_kind ~(usage_reported : bool)
     ~(usage : Oas.Types.api_usage)
     ~(model_used : string)
     ~(resolved_model_id : string)
@@ -108,7 +120,8 @@ let classify ~(usage_reported : bool)
        per-keeper rate and alert when the rate is sustained
        (one-shot anomalies on tiny prompts are correctly noise). *)
     if
-      model_uses_anthropic_caching ~model_used ~resolved_model_id
+      model_uses_anthropic_caching_with_provider_kind ~provider_kind ~model_used
+        ~resolved_model_id
       && usage.input_tokens >= anthropic_cache_min_input_tokens
       && usage.cache_creation_input_tokens = 0
       && usage.cache_read_input_tokens = 0
@@ -116,3 +129,11 @@ let classify ~(usage_reported : bool)
     match List.rev !reasons with
     | [] -> Usage_trusted
     | reasons -> Usage_untrusted reasons
+
+let classify ~(usage_reported : bool)
+    ~(usage : Oas.Types.api_usage)
+    ~(model_used : string)
+    ~(resolved_model_id : string)
+    ~(context_max : int) : t =
+  classify_with_provider_kind ~provider_kind:None ~usage_reported ~usage
+    ~model_used ~resolved_model_id ~context_max

--- a/lib/keeper/keeper_usage_trust.mli
+++ b/lib/keeper/keeper_usage_trust.mli
@@ -12,15 +12,32 @@ type t =
     that want to use the same threshold. *)
 val anthropic_cache_min_input_tokens : int
 
-(** Returns [true] when the model identifier indicates an
-    Anthropic-routed model (claude_code, anthropic-direct, etc.)
-    that would normally exercise prompt caching.  The check is
-    case-insensitive and looks for ["claude"] or ["anthropic"]
-    anywhere in [model_used] or [resolved_model_id]. *)
+(** Returns [true] when typed provider evidence indicates an
+    Anthropic-routed model (Anthropic API, Claude Code, etc.) that
+    would normally exercise prompt caching.
+
+    The [provider_kind] from OAS telemetry is authoritative when supplied.
+    Without it, only explicit [provider:model] labels are resolved via
+    the provider registry. Bare model ids intentionally stay unknown so
+    substring matches such as [openrouter:anthropic/...] cannot produce
+    false cache-anomaly trust signals. *)
 val model_uses_anthropic_caching :
   model_used:string -> resolved_model_id:string -> bool
 
+val model_uses_anthropic_caching_with_provider_kind :
+  provider_kind:Llm_provider.Provider_config.provider_kind option ->
+  model_used:string -> resolved_model_id:string -> bool
+
 val classify :
+  usage_reported:bool ->
+  usage:Oas.Types.api_usage ->
+  model_used:string ->
+  resolved_model_id:string ->
+  context_max:int ->
+  t
+
+val classify_with_provider_kind :
+  provider_kind:Llm_provider.Provider_config.provider_kind option ->
   usage_reported:bool ->
   usage:Oas.Types.api_usage ->
   model_used:string ->

--- a/test/test_keeper_usage_trust_anthropic_cache_9959.ml
+++ b/test/test_keeper_usage_trust_anthropic_cache_9959.ml
@@ -40,8 +40,25 @@ let mk_usage
     cost_usd;
   }
 
-let classify_with ~model ~usage =
+let provider_kind_of_spec spec =
+  match Masc_mcp.Provider_kind_resolver.kind_of_spec spec with
+  | Some kind -> kind
+  | None -> Alcotest.failf "expected provider kind for %S" spec
+
+let anthropic_kind =
+  provider_kind_of_spec "claude:claude-sonnet-4-6"
+
+let openai_compat_kind =
+  provider_kind_of_spec "openrouter:anthropic/claude-3.5"
+
+let classify_without_kind ~model ~usage =
   T.classify ~usage_reported:true ~usage
+    ~model_used:model ~resolved_model_id:model
+    ~context_max:200_000
+
+let classify_with_kind ~provider_kind ~model ~usage =
+  T.classify_with_provider_kind ~provider_kind:(Some provider_kind)
+    ~usage_reported:true ~usage
     ~model_used:model ~resolved_model_id:model
     ~context_max:200_000
 
@@ -60,22 +77,34 @@ let test_threshold_is_1024 () =
   Alcotest.(check int) "anthropic cache threshold = 1024"
     1024 T.anthropic_cache_min_input_tokens
 
-(* Helper: model_uses_anthropic_caching is case-insensitive,
-   substring-based, and matches both [model_used] and
-   [resolved_model_id]. *)
+(* Helper: model_uses_anthropic_caching is provider-kind based. Typed
+   telemetry is authoritative; without it only explicit provider:model labels
+   resolve through the provider registry. Bare model substrings do not count. *)
 let test_model_detector_recognizes_anthropic () =
   let yes m =
     Alcotest.(check bool) (Printf.sprintf "%s -> Anthropic" m) true
       (T.model_uses_anthropic_caching ~model_used:m ~resolved_model_id:m)
   in
+  let yes_kind kind m =
+    Alcotest.(check bool) (Printf.sprintf "%s -> Anthropic" m) true
+      (T.model_uses_anthropic_caching_with_provider_kind
+         ~provider_kind:(Some kind) ~model_used:m ~resolved_model_id:m)
+  in
   let no m =
     Alcotest.(check bool) (Printf.sprintf "%s -> not Anthropic" m) false
       (T.model_uses_anthropic_caching ~model_used:m ~resolved_model_id:m)
   in
-  yes "claude-sonnet-4-6";
-  yes "claude_code:auto";
-  yes "Claude-3-Opus";
-  yes "anthropic/claude-haiku";
+  let no_kind kind m =
+    Alcotest.(check bool) (Printf.sprintf "%s -> not Anthropic" m) false
+      (T.model_uses_anthropic_caching_with_provider_kind
+         ~provider_kind:(Some kind) ~model_used:m ~resolved_model_id:m)
+  in
+  yes "claude:claude-sonnet-4-6";
+  yes_kind anthropic_kind "Claude-3-Opus";
+  no "Claude-3-Opus";
+  no "anthropic/claude-haiku";
+  no "openrouter:anthropic/claude-3.5";
+  no_kind openai_compat_kind "anthropic/claude-haiku";
   no "qwen3-coder";
   no "gpt-5.3";
   no "gemini-2.5-pro";
@@ -86,7 +115,11 @@ let test_model_detector_recognizes_anthropic () =
    = #9959 facet 1.  Classify must flag. *)
 let test_anthropic_with_zero_cache_above_threshold_flags () =
   let usage = mk_usage ~input:5000 ~output:500 () in
-  let t = classify_with ~model:"claude-sonnet-4-6" ~usage in
+  let t =
+    classify_with_kind
+      ~provider_kind:anthropic_kind
+      ~model:"claude-sonnet-4-6" ~usage
+  in
   Alcotest.(check bool)
     "anthropic_caching_likely_disabled flagged"
     true (has_reason t "anthropic_caching_likely_disabled");
@@ -99,7 +132,11 @@ let test_anthropic_with_zero_cache_above_threshold_flags () =
    first cacheable size. *)
 let test_threshold_boundary_1024_inclusive () =
   let usage = mk_usage ~input:1024 ~output:50 () in
-  let t = classify_with ~model:"claude_code:auto" ~usage in
+  let t =
+    classify_with_kind
+      ~provider_kind:anthropic_kind
+      ~model:"claude_code:auto" ~usage
+  in
   Alcotest.(check bool)
     "1024 tokens: cache anomaly fires"
     true (has_reason t "anthropic_caching_likely_disabled")
@@ -108,7 +145,11 @@ let test_threshold_boundary_1024_inclusive () =
    zero caches and must NOT be flagged. *)
 let test_below_threshold_does_not_flag () =
   let usage = mk_usage ~input:1023 ~output:50 () in
-  let t = classify_with ~model:"claude_code:auto" ~usage in
+  let t =
+    classify_with_kind
+      ~provider_kind:anthropic_kind
+      ~model:"claude_code:auto" ~usage
+  in
   Alcotest.(check bool)
     "1023 tokens: cache anomaly does NOT fire"
     false (has_reason t "anthropic_caching_likely_disabled")
@@ -118,18 +159,23 @@ let test_below_threshold_does_not_flag () =
 let test_non_anthropic_does_not_flag () =
   let usage = mk_usage ~input:50_000 ~output:1_000 () in
   List.iter (fun model ->
-    let t = classify_with ~model ~usage in
+    let t = classify_without_kind ~model ~usage in
     Alcotest.(check bool)
       (Printf.sprintf "%s: no anthropic anomaly" model)
       false (has_reason t "anthropic_caching_likely_disabled"))
     [ "qwen3-coder"; "gpt-5.3-codex"; "gemini-2.5-pro";
-      "ollama-local"; "kimi-for-coding"; "ramarama" ]
+      "ollama-local"; "kimi-for-coding"; "ramarama";
+      "openrouter:anthropic/claude-3.5" ]
 
 (* Caching working as intended: cache_read > 0 — no anomaly. *)
 let test_cache_read_positive_does_not_flag () =
   let usage = mk_usage ~input:5000 ~output:500
     ~cache_creation:0 ~cache_read:4500 () in
-  let t = classify_with ~model:"claude-sonnet-4-6" ~usage in
+  let t =
+    classify_with_kind
+      ~provider_kind:anthropic_kind
+      ~model:"claude-sonnet-4-6" ~usage
+  in
   Alcotest.(check bool)
     "cache_read > 0 means caching is working"
     false (has_reason t "anthropic_caching_likely_disabled")
@@ -139,7 +185,11 @@ let test_cache_read_positive_does_not_flag () =
 let test_cache_creation_positive_does_not_flag () =
   let usage = mk_usage ~input:5000 ~output:500
     ~cache_creation:4500 ~cache_read:0 () in
-  let t = classify_with ~model:"claude-sonnet-4-6" ~usage in
+  let t =
+    classify_with_kind
+      ~provider_kind:anthropic_kind
+      ~model:"claude-sonnet-4-6" ~usage
+  in
   Alcotest.(check bool)
     "cache_creation > 0 (cold cache) is not an anomaly"
     false (has_reason t "anthropic_caching_likely_disabled")
@@ -148,7 +198,11 @@ let test_cache_creation_positive_does_not_flag () =
    reason composes additively with negative_*, gt_1m, etc. *)
 let test_multiple_anomalies_compose () =
   let usage = mk_usage ~input:1_500_000 ~output:500 () in
-  let t = classify_with ~model:"claude_code:auto" ~usage in
+  let t =
+    classify_with_kind
+      ~provider_kind:anthropic_kind
+      ~model:"claude_code:auto" ~usage
+  in
   Alcotest.(check bool) "input_tokens_gt_1m present"
     true (has_reason t "input_tokens_gt_1m");
   Alcotest.(check bool) "anthropic_caching_likely_disabled present"
@@ -164,7 +218,7 @@ let () =
         ] );
       ( "model-detector",
         [
-          Alcotest.test_case "claude/anthropic substrings" `Quick
+          Alcotest.test_case "provider-kind contract" `Quick
             test_model_detector_recognizes_anthropic;
         ] );
       ( "fires-when-it-should",


### PR DESCRIPTION
## Summary
- replace Anthropic cache anomaly detection substring matching with provider-kind / provider-registry evidence
- thread OAS telemetry provider_kind into keeper usage-trust classification
- add false-positive guards for bare Claude-ish model ids and openrouter:anthropic/... labels

## Why
The previous detector treated any model label containing claude or anthropic as Anthropic-routed. That can make usage trust look authoritative when the provider is actually OpenAI-compatible or unknown. This patch keeps bare model ids unknown unless OAS telemetry or the provider registry supplies typed provider evidence.

## Validation
- git diff --check
- scripts/dune-local.sh build test/test_keeper_usage_trust_anthropic_cache_9959.exe
- ./_build/default/test/test_keeper_usage_trust_anthropic_cache_9959.exe
- scripts/dune-local.sh build test/test_keeper_hooks_oas_telemetry.exe
- ./_build/default/test/test_keeper_hooks_oas_telemetry.exe