### PR TITLE
Dehardcode autoresearch feedback lineage

### DIFF
--- a/lib/autoresearch_lineage.ml
+++ b/lib/autoresearch_lineage.ml
@@ -1,0 +1,40 @@
+(** Autoresearch_lineage — shared actor and tag contract for autoresearch
+    feedback artifacts.
+
+    Autoresearch failure lessons and finding records need to describe the same
+    lineage consistently: which internal actor produced the record, which loop
+    actor participated, and which baseline tags make the record discoverable. *)
+
+type actor =
+  | Lesson_reviewer
+  | Cycle_runner
+
+let actor_name = function
+  | Lesson_reviewer -> "autoresearch-reviewer"
+  | Cycle_runner -> "autoresearch_cycle"
+
+let lesson_reviewer_actor_name = actor_name Lesson_reviewer
+
+let cycle_runner_actor_name = actor_name Cycle_runner
+
+let cycle_failure_participants =
+  [
+    lesson_reviewer_actor_name;
+    cycle_runner_actor_name;
+  ]
+
+let domain_tag = "autoresearch"
+
+let normalize_tag tag =
+  match String.trim tag with
+  | "" -> None
+  | trimmed -> Some trimmed
+
+let finding_tags ~target_file ~extra =
+  [ Some domain_tag; normalize_tag target_file ]
+  @ List.map normalize_tag extra
+  |> List.filter_map (fun tag -> tag)
+  |> List.fold_left
+       (fun acc tag -> if List.mem tag acc then acc else tag :: acc)
+       []
+  |> List.rev

--- a/lib/dune
+++ b/lib/dune
@@ -607,6 +607,7 @@
    autoresearch
    autoresearch_codegen
    autoresearch_knowledge
+   autoresearch_lineage
    tool_autoresearch_context
    tool_autoresearch_schemas
    tool_autoresearch_registry
@@ -740,6 +741,7 @@
   ;; godsplit-phase2: additional sub-modules
   autoresearch_codegen
   autoresearch_knowledge
+  autoresearch_lineage
   tool_autoresearch_context
   tool_autoresearch_schemas
   tool_autoresearch_registry

--- a/lib/tool_autoresearch_cycle.ml
+++ b/lib/tool_autoresearch_cycle.ml
@@ -4,8 +4,6 @@ open Tool_args
 open Tool_autoresearch_registry
 open Tool_autoresearch_broadcast
 
-let autoresearch_lesson_agent_name = "autoresearch-reviewer"
-
 let clip text max_len =
   String_util.utf8_safe ~max_bytes:(max_len + 3) ~suffix:"..." text |> String_util.to_string
 
@@ -32,7 +30,7 @@ let make_loop_memory (ctx : Tool_autoresearch_context.t)
   | None ->
     let mem =
       Memory_oas_bridge.create_memory
-        ~agent_name:autoresearch_lesson_agent_name
+        ~agent_name:Autoresearch_lineage.lesson_reviewer_actor_name
         ~base_dir:(Common.masc_dir_from_base_path ~base_path:ctx.base_path)
         ~session_id:("autoresearch-" ^ state.loop_id)
         ()
@@ -44,7 +42,7 @@ let flush_loop_memory memory =
   ignore
     (Memory_oas_bridge.flush_incremental
        ~memory
-       ~agent_name:autoresearch_lesson_agent_name)
+       ~agent_name:Autoresearch_lineage.lesson_reviewer_actor_name)
 
 let render_recent_findings findings =
   match findings with
@@ -115,7 +113,7 @@ let persist_failure_feedback
          (fun _ -> Autoresearch_metric.default_metric_name)
          metric_error)
     ?metric_error
-    ~participants:[ autoresearch_lesson_agent_name; "autoresearch_cycle" ]
+    ~participants:Autoresearch_lineage.cycle_failure_participants
     ~metadata
     ();
   flush_loop_memory memory;
@@ -123,14 +121,16 @@ let persist_failure_feedback
     {
       id = Autoresearch_knowledge.generate_finding_id ();
       loop_id = state.loop_id;
-      keeper_name = autoresearch_lesson_agent_name;
+      keeper_name = Autoresearch_lineage.lesson_reviewer_actor_name;
       goal = state.goal;
       hypothesis;
       evidence = if evidence = "" then summary else evidence;
       conclusion =
         Option.value ~default:(clip summary 240) conclusion;
       confidence = Autoresearch_knowledge.Medium;
-      tags = "autoresearch" :: state.target_file :: tags;
+      tags =
+        Autoresearch_lineage.finding_tags ~target_file:state.target_file
+          ~extra:tags;
       related_findings = [];
       cycle_range = Some (state.current_cycle, state.current_cycle);
       timestamp = Unix.gettimeofday ();

--- a/test/test_autoresearch_knowledge.ml
+++ b/test/test_autoresearch_knowledge.ml
@@ -254,6 +254,18 @@ let test_search_dispatch_limit_returns_recent_matches () =
   check (list string) "most recent limited matches"
     ["fn-limit-3"; "fn-limit-2"] ids
 
+let test_lineage_contract_normalizes_finding_tags () =
+  check (list string) "cycle participants"
+    [
+      Autoresearch_lineage.lesson_reviewer_actor_name;
+      Autoresearch_lineage.cycle_runner_actor_name;
+    ]
+    Autoresearch_lineage.cycle_failure_participants;
+  check (list string) "lineage tags"
+    [ Autoresearch_lineage.domain_tag; "main.txt"; "diff-guard" ]
+    (Autoresearch_lineage.finding_tags ~target_file:" main.txt "
+       ~extra:[ "diff-guard"; ""; "autoresearch"; "main.txt"; "diff-guard" ])
+
 let test_finding_serde_roundtrip () =
   let f : Autoresearch_knowledge.finding = {
     id = "fn-test-serde";
@@ -293,6 +305,10 @@ let () =
         test_search_dispatch_rejects_invalid_input;
       test_case "search dispatch limit returns recent matches" `Quick
         test_search_dispatch_limit_returns_recent_matches;
+    ];
+    "lineage", [
+      test_case "lineage contract normalizes finding tags" `Quick
+        test_lineage_contract_normalizes_finding_tags;
     ];
     "serialization", [
       test_case "finding JSON roundtrip" `Quick test_finding_serde_roundtrip;

--- a/test/test_autoresearch_oas_primitives.ml
+++ b/test/test_autoresearch_oas_primitives.ml
@@ -177,6 +177,30 @@ let test_cycle_reinjects_diff_guard_lesson () =
     (Fs_compat.load_file (Filename.concat repo "main.txt"));
   check string "external drift preserved" "drifted\n"
     (Fs_compat.load_file (Filename.concat repo "notes.txt"));
+  let feedback_findings =
+    Lib.Autoresearch_knowledge.search_findings ~base_path:root
+      ~query:"Diff guard rejected patch" ~limit:5 ()
+  in
+  let feedback_finding =
+    match
+      List.find_opt
+        (fun (finding : Lib.Autoresearch_knowledge.finding) ->
+           finding.loop_id = state.loop_id)
+        feedback_findings
+    with
+    | Some finding -> finding
+    | None -> fail "diff guard finding was not persisted"
+  in
+  check string "finding keeper uses lineage actor"
+    Lib.Autoresearch_lineage.lesson_reviewer_actor_name
+    feedback_finding.keeper_name;
+  check (list string) "finding tags use lineage contract"
+    [
+      Lib.Autoresearch_lineage.domain_tag;
+      state.target_file;
+      "diff-guard";
+    ]
+    feedback_finding.tags;
   write_file (Filename.concat repo "notes.txt") "notes\n";
   let captured_goal = ref None in
   Lib.Tool_autoresearch_registry.set_generator state.loop_id


### PR DESCRIPTION
## Summary
- add Autoresearch_lineage as the shared actor/tag contract for autoresearch feedback artifacts
- route cycle memory agent names, failure lesson participants, and persisted finding tags through that contract
- cover both direct tag normalization and the cycle path that persists diff-guard findings

## Why it matters
Autoresearch feedback currently writes memory lessons and finding records from separate string literals. That makes the lesson actor, cycle participant, and search tags easy to drift independently, which weakens the feedback loop after failures. This keeps the persisted lineage contract in one place while preserving the external strings.

## Verification
- scripts/dune-local.sh build test/test_autoresearch_knowledge.exe test/test_autoresearch_oas_primitives.exe
- ./_build/default/test/test_autoresearch_knowledge.exe
- ./_build/default/test/test_autoresearch_oas_primitives.exe
- scripts/audit-hardcoding-truth.sh --fail-on-confirmed
- git diff --check