### PR TITLE
fix(keeper): keep reserved cascade lanes loadable

### DIFF
--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -72,12 +72,32 @@ let catalog_entries ?config_path () =
       | Ok entries -> Some entries
       | Error _ -> None)
 
+let catalog_entries_result ?config_path () =
+  let path_opt =
+    match config_path with
+    | Some path -> Some path
+    | None -> Config_dir_resolver.cascade_path_opt ()
+  in
+  match path_opt with
+  | None -> Error "cascade catalog path is not resolved"
+  | Some path ->
+      Cascade_config_loader.load_catalog ~config_path:path
+
 let catalog_names ?config_path () =
   match catalog_entries ?config_path () with
   | Some entries ->
       List.map (fun (entry : Cascade_config_loader.catalog_entry) -> entry.name)
         entries
   | None -> []
+
+let catalog_names_result ?config_path () =
+  match catalog_entries_result ?config_path () with
+  | Error _ as err -> err
+  | Ok entries ->
+      Ok
+        (List.map
+           (fun (entry : Cascade_config_loader.catalog_entry) -> entry.name)
+           entries)
 
 let is_system_only_cascade raw =
   let name = String.trim raw in

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -54,6 +54,11 @@ val catalog_names : ?config_path:string -> unit -> string list
 (** Live profile catalog discovered from the active [cascade.json].
     When the file cannot be read, returns [[]]. *)
 
+val catalog_names_result : ?config_path:string -> unit -> (string list, string) result
+(** Like {!catalog_names}, but preserves the loader error so validation
+    boundaries can fail loud instead of collapsing catalog drift into an empty
+    dynamic profile set. *)
+
 val keeper_catalog_names : ?config_path:string -> unit -> string list
 (** Assignable live profile names from {!catalog_names}, filtered by
     [keeper_assignable] metadata. *)

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -35,6 +35,12 @@ let sandbox_profile_to_string = function
   | Local -> "local"
   | Docker -> "docker"
 
+let reserved_cascade_names =
+  List.sort_uniq String.compare
+    (Keeper_cascade_profile.known_cascades
+     @ phase_routing_cascade_names
+     @ [ tool_use_strict_cascade_name ])
+
 (** Parse a sandbox profile string. Canonical values are ["local"] and
     ["docker"]. Legacy names ["legacy_local"], ["docker_hardened"], and
     ["docker_with_git"] are still accepted for backward compatibility
@@ -645,21 +651,29 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
               Keeper_cascade_profile.normalize_declared_name raw
               |> String.lowercase_ascii
             in
-            let compile_known = Keeper_cascade_profile.known_cascades in
-            let phase_routing = phase_routing_cascade_names in
-            let catalog =
-              try Keeper_cascade_profile.catalog_names ()
-              with _ -> []
-            in
-            let all_valid = compile_known @ phase_routing @ catalog in
-            if List.mem normalized all_valid then Ok ()
+            if List.mem normalized reserved_cascade_names then Ok ()
             else
-              Error
-                (Printf.sprintf
-                   "invalid cascade_name '%s' (known: %s)"
-                   raw
-                   (String.concat ", "
-                      (compile_known @ phase_routing))))
+              match Keeper_cascade_profile.catalog_names_result () with
+              | Ok catalog ->
+                  let all_valid =
+                    List.sort_uniq String.compare
+                      (reserved_cascade_names @ catalog)
+                  in
+                  if List.mem normalized all_valid then Ok ()
+                  else
+                    Error
+                      (Printf.sprintf
+                         "invalid cascade_name '%s' (known: %s)"
+                         raw
+                         (String.concat ", " all_valid))
+              | Error catalog_error ->
+                  Error
+                    (Printf.sprintf
+                       "invalid cascade_name '%s' (reserved: %s; live catalog \
+                        unavailable: %s)"
+                       raw
+                       (String.concat ", " reserved_cascade_names)
+                       catalog_error))
   in
   Result.map
     (fun () ->

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -71,24 +71,54 @@ let with_temp_toml content f =
     ~finally:(fun () -> try Sys.remove path with _ -> ())
     (fun () -> f path)
 
+let write_file path contents =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc contents)
+
+let contains ~needle haystack =
+  let len = String.length haystack in
+  let nlen = String.length needle in
+  let found = ref false in
+  if nlen <= len then
+    for i = 0 to len - nlen do
+      if String.sub haystack i nlen = needle then found := true
+    done;
+  !found
+
+let with_config_dir contents f =
+  let dir = Filename.temp_file "keeper_config_dir_" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  let toml_path = Filename.concat dir "cascade.toml" in
+  let json_path = Filename.concat dir "cascade.json" in
+  write_file toml_path contents;
+  let prior = Sys.getenv_opt "MASC_CONFIG_DIR" in
+  Unix.putenv "MASC_CONFIG_DIR" dir;
+  Masc_mcp.Config_dir_resolver.reset ();
+  Fun.protect
+    ~finally:(fun () ->
+      (match prior with
+       | Some value -> Unix.putenv "MASC_CONFIG_DIR" value
+       | None -> Unix.putenv "MASC_CONFIG_DIR" "");
+      Masc_mcp.Config_dir_resolver.reset ();
+      (try Sys.remove json_path with _ -> ());
+      (try Sys.remove toml_path with _ -> ());
+      try Unix.rmdir dir with _ -> ())
+    (fun () -> f dir)
+
 let test_cascade_name_rejects_unknown () =
   let result =
     with_temp_toml
-      "[keeper]\nname = \"testkeeper\"\ncascade_name = \"nick0cave\"\n"
+      "[keeper]\nname = \"testkeeper\"\ncascade_name = \"definitely_missing_profile\"\n"
       KTP.load_keeper_toml
   in
   match result with
-  | Ok _ -> fail "nick0cave cascade_name should be rejected"
+  | Ok _ -> fail "definitely_missing_profile cascade_name should be rejected"
   | Error e ->
       check bool "error mentions cascade_name" true
-        (let len = String.length e in
-         let needle = "invalid cascade_name" in
-         let nlen = String.length needle in
-         let found = ref false in
-         for i = 0 to len - nlen do
-           if String.sub e i nlen = needle then found := true
-         done;
-         !found)
+        (contains ~needle:"invalid cascade_name" e)
 
 let test_cascade_name_accepts_known () =
   let check_ok label cascade_name =
@@ -106,7 +136,61 @@ let test_cascade_name_accepts_known () =
   in
   check_ok "big_three variant" "big_three";
   check_ok "local_only phase-routing" "local_only";
-  check_ok "local_recovery phase-routing" "local_recovery"
+  check_ok "local_recovery phase-routing" "local_recovery";
+  check_ok "tool_use_strict reserved tool lane" "tool_use_strict"
+
+let test_cascade_name_accepts_tool_lane_without_catalog () =
+  let missing_dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      "missing-masc-config-for-tool-use-strict"
+  in
+  let prior = Sys.getenv_opt "MASC_CONFIG_DIR" in
+  Unix.putenv "MASC_CONFIG_DIR" missing_dir;
+  Masc_mcp.Config_dir_resolver.reset ();
+  Fun.protect
+    ~finally:(fun () ->
+      (match prior with
+       | Some value -> Unix.putenv "MASC_CONFIG_DIR" value
+       | None -> Unix.putenv "MASC_CONFIG_DIR" "");
+      Masc_mcp.Config_dir_resolver.reset ())
+    (fun () ->
+      let result =
+        with_temp_toml
+          "[keeper]\nname = \"testkeeper\"\ncascade_name = \"tool_use_strict\"\n"
+          KTP.load_keeper_toml
+      in
+      match result with
+      | Ok _ -> ()
+      | Error e ->
+          fail
+            (Printf.sprintf
+               "tool_use_strict is a reserved tool lane and should not require \
+                a readable live catalog: %s"
+               e))
+
+let test_cascade_name_error_lists_live_catalog () =
+  with_config_dir
+    {|
+[custom_live]
+models = ["ollama:auto"]
+
+[tool_use_strict]
+models = ["ollama:auto"]
+keeper_assignable = false
+|}
+    (fun _dir ->
+      let result =
+        with_temp_toml
+          "[keeper]\nname = \"testkeeper\"\ncascade_name = \"missing_profile\"\n"
+          KTP.load_keeper_toml
+      in
+      match result with
+      | Ok _ -> fail "missing_profile cascade_name should be rejected"
+      | Error e ->
+          check bool "error lists live catalog profile" true
+            (contains ~needle:"custom_live" e);
+          check bool "error lists reserved tool lane" true
+            (contains ~needle:"tool_use_strict" e))
 
 let test_cascade_name_accepts_catalog_entry () =
   (* "tool_use_strict" is a known catalog entry in cascade.json,
@@ -226,6 +310,10 @@ let () =
             test_cascade_name_rejects_unknown;
           test_case "accepts known cascade names" `Quick
             test_cascade_name_accepts_known;
+          test_case "accepts reserved tool lane without live catalog" `Quick
+            test_cascade_name_accepts_tool_lane_without_catalog;
+          test_case "invalid cascade message lists live catalog" `Quick
+            test_cascade_name_error_lists_live_catalog;
           test_case "accepts catalog entry (legacy alias)" `Quick
             test_cascade_name_accepts_catalog_entry;
           test_case "accepts dispatch tool_preset" `Quick


### PR DESCRIPTION
## Summary
- keep reserved keeper cascade lanes, including tool_use_strict, valid even when the live cascade catalog is temporarily unavailable
- add a result-returning catalog-name API so TOML validation can surface catalog load errors instead of silently treating the catalog as empty
- make invalid cascade_name diagnostics list the actual reserved + live catalog names

Fixes #10158.

## Verification
- env DUNE_BUILD_DIR=_build_verify_10158 DUNE_JOBS=2 scripts/dune-local.sh build test/test_keeper_toml_config_validation.exe
- env DUNE_BUILD_DIR=_build_verify_10158 _build_verify_10158/default/test/test_keeper_toml_config_validation.exe
- env DUNE_BUILD_DIR=_build_verify_10158 DUNE_JOBS=2 scripts/dune-local.sh build test/test_keeper_cascade_profile.exe
- env DUNE_BUILD_DIR=_build_verify_10158 _build_verify_10158/default/test/test_keeper_cascade_profile.exe
- git diff --check HEAD^..HEAD