### PR TITLE
feat(observability): per-(tool, agent) join_required guard counter (#9770)

### DIFF
--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -592,16 +592,33 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
   Log.Misc.debug "tool=%s agent_name=%s join_required=%b room_initialized=%b is_joined=%b"
     name agent_name join_required room_initialized is_joined;
 
-  if join_required && not room_initialized then
+  if join_required && not room_initialized then begin
+    (* #9770: surface guard fires as a fleet-wide metric so
+       operators can see which (tool, agent) pairs repeatedly skip
+       masc_join without log-scraping. *)
+    Prometheus.inc_counter
+      Prometheus.metric_tool_join_required_guard
+      ~labels:[ ("tool", name);
+                ("agent_name", agent_name);
+                ("reason", "room_uninitialized") ]
+      ();
     with_system_internal_audit ~agent_name
       (false, Printf.sprintf
          "⚠️ MASC room not initialized.\n\n💡 Fastest: masc_start(path=\"<project>\") — one-step init+join, then call %s.\n💡 Alternative: masc_init → masc_join → masc_status → %s\n📚 See: @~/me/instructions/masc-workflow.md\n[DEBUG] agent_name=%s room_initialized=%b"
          name name agent_name room_initialized)
-  else if join_required && not is_joined then
+  end
+  else if join_required && not is_joined then begin
+    Prometheus.inc_counter
+      Prometheus.metric_tool_join_required_guard
+      ~labels:[ ("tool", name);
+                ("agent_name", agent_name);
+                ("reason", "agent_not_joined") ]
+      ();
     with_system_internal_audit ~agent_name
       (false, Printf.sprintf
          "❌ Join required before using %s.\n\n💡 Fastest: masc_start(path=\"<project>\") — one-step join with room scope.\n💡 Alternative: masc_join → masc_status → %s\n📚 See: @~/me/instructions/masc-workflow.md\n[DEBUG] agent_name=%s is_joined=%b"
          name name agent_name is_joined)
+  end
   else (
 
   (* === Fix 1: Tag-based lazy context dispatch ===

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -265,6 +265,21 @@ let metric_keeper_supervisor_sweep_starts =
 let metric_keeper_supervisor_last_sweep_unixtime =
   "masc_keeper_supervisor_last_sweep_unixtime"
 
+(* #9770: counter for the [join_required] guard firing in
+   [Mcp_server_eio_execute].  Production observed agents calling
+   [masc_claim_next] (and similar) without [masc_join] first; the
+   guard returns a polite error message but no fleet-wide signal
+   exists for "how often does this happen, and which agent / tool
+   pair is most affected".  Labels:
+     [tool]: tool name that hit the guard (bounded by tool surface
+       size, ~50).
+     [agent_name]: agent that called the tool (bounded by fleet
+       size, ~10).
+     [reason]: ["room_uninitialized" | "agent_not_joined"].
+   Cardinality: ~50 × ~10 × 2 = ~1000 series, safe for Prometheus. *)
+let metric_tool_join_required_guard =
+  "masc_tool_join_required_guard_total"
+
 
 (* Keeper compaction (keeper_compact_policy.ml, tool_keeper.ml). *)
 let metric_keeper_compactions = "masc_keeper_compactions_total"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -98,6 +98,12 @@ val metric_keeper_turn_latency_bucket : string
 val metric_keeper_supervisor_sweep_starts : string
 val metric_keeper_supervisor_last_sweep_unixtime : string
 
+val metric_tool_join_required_guard : string
+(** #9770: count fires of the [join_required] guard in
+    [Mcp_server_eio_execute].  Labels:
+    [tool, agent_name, reason] with reason
+    [room_uninitialized | agent_not_joined]. *)
+
 val metric_keeper_compactions : string
 val metric_keeper_compaction_ratio_change : string
 val metric_keeper_compaction_saved_tokens : string

--- a/test/dune
+++ b/test/dune
@@ -328,6 +328,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_join_required_guard_counter)
+ (modules test_join_required_guard_counter)
+ (libraries masc_test_deps))
+
+(test
  (name test_fsm_drift_per_agent_counter)
  (modules test_fsm_drift_per_agent_counter)
  (libraries masc_test_deps))

--- a/test/test_join_required_guard_counter.ml
+++ b/test/test_join_required_guard_counter.ml
@@ -1,0 +1,115 @@
+(* #9770: pin canonical metric name + label vocabulary for the
+   join_required guard counter.  The execute path emits this
+   counter whenever an agent calls a join-required tool without
+   first calling [masc_join] (or [masc_start]).
+
+   Test exercises the counter directly — the guard's surrounding
+   plumbing (audit emit + system-prompt assembly) is not needed
+   to pin the metric contract.  Wiring tests for the guard itself
+   live elsewhere; this test only protects the metric vocabulary
+   so Grafana / alerting rules cannot drift. *)
+
+let counter_for ~tool ~agent_name ~reason =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    Masc_mcp.Prometheus.metric_tool_join_required_guard
+    ~labels:[
+      ("tool", tool);
+      ("agent_name", agent_name);
+      ("reason", reason);
+    ]
+    ()
+
+let test_metric_name_stable () =
+  Alcotest.(check string)
+    "join-required guard canonical metric name"
+    "masc_tool_join_required_guard_total"
+    Masc_mcp.Prometheus.metric_tool_join_required_guard
+
+let test_increments_room_uninitialized () =
+  let tool = "masc_claim_next" in
+  let agent_name = "san-test-9770" in
+  let reason = "room_uninitialized" in
+  let before = counter_for ~tool ~agent_name ~reason in
+  Masc_mcp.Prometheus.inc_counter
+    Masc_mcp.Prometheus.metric_tool_join_required_guard
+    ~labels:[ ("tool", tool);
+              ("agent_name", agent_name);
+              ("reason", reason) ]
+    ();
+  Alcotest.(check (float 0.0001))
+    "room_uninitialized +1"
+    (before +. 1.0)
+    (counter_for ~tool ~agent_name ~reason)
+
+let test_increments_agent_not_joined () =
+  let tool = "masc_claim_next" in
+  let agent_name = "nic-test-9770" in
+  let reason = "agent_not_joined" in
+  let before = counter_for ~tool ~agent_name ~reason in
+  Masc_mcp.Prometheus.inc_counter
+    Masc_mcp.Prometheus.metric_tool_join_required_guard
+    ~labels:[ ("tool", tool);
+              ("agent_name", agent_name);
+              ("reason", reason) ]
+    ();
+  Alcotest.(check (float 0.0001))
+    "agent_not_joined +1"
+    (before +. 1.0)
+    (counter_for ~tool ~agent_name ~reason)
+
+let test_label_isolation_across_reasons () =
+  (* Same (tool, agent) but different reason must land in
+     different series, otherwise we cannot distinguish the two
+     failure modes in operator dashboards. *)
+  let tool = "masc_status" in
+  let agent_name = "isolation-test-9770" in
+  let before_room =
+    counter_for ~tool ~agent_name ~reason:"room_uninitialized"
+  in
+  Masc_mcp.Prometheus.inc_counter
+    Masc_mcp.Prometheus.metric_tool_join_required_guard
+    ~labels:[ ("tool", tool);
+              ("agent_name", agent_name);
+              ("reason", "agent_not_joined") ]
+    ();
+  Alcotest.(check (float 0.0001))
+    "room_uninitialized counter unchanged when agent_not_joined fires"
+    before_room
+    (counter_for ~tool ~agent_name ~reason:"room_uninitialized")
+
+let test_label_isolation_across_agents () =
+  let tool = "masc_claim_next" in
+  let reason = "agent_not_joined" in
+  let agent_a = "alpha-9770" in
+  let agent_b = "beta-9770" in
+  let before_a = counter_for ~tool ~agent_name:agent_a ~reason in
+  Masc_mcp.Prometheus.inc_counter
+    Masc_mcp.Prometheus.metric_tool_join_required_guard
+    ~labels:[ ("tool", tool);
+              ("agent_name", agent_b);
+              ("reason", reason) ]
+    ();
+  Alcotest.(check (float 0.0001))
+    "alpha counter unaffected by beta increment"
+    before_a
+    (counter_for ~tool ~agent_name:agent_a ~reason)
+
+let () =
+  Alcotest.run "join_required_guard_counter_9770" [
+    "metric_name", [
+      Alcotest.test_case "canonical name stable" `Quick
+        test_metric_name_stable;
+    ];
+    "counter", [
+      Alcotest.test_case "room_uninitialized increments" `Quick
+        test_increments_room_uninitialized;
+      Alcotest.test_case "agent_not_joined increments" `Quick
+        test_increments_agent_not_joined;
+    ];
+    "isolation", [
+      Alcotest.test_case "reasons isolated" `Quick
+        test_label_isolation_across_reasons;
+      Alcotest.test_case "agents isolated" `Quick
+        test_label_isolation_across_agents;
+    ];
+  ]


### PR DESCRIPTION
## 요약

`Mcp_server_eio_execute`의 `join_required` guard 발화 시 fleet-wide 추적 가능한 Prometheus counter 추가. 어느 (tool, agent) pair가 가장 자주 `masc_join` 없이 호출하는지 metric으로 식별 가능.

Closes part of #9770 (observability for the workflow violation).

## 근본 원인

기존 동작:
- 에이전트가 `masc_claim_next`/`masc_status` 등 join-required tool을 `masc_join` 없이 호출 → `❌ Join required before using ...` 에러 메시지 반환.
- 에러 메시지는 actionable하지만 fleet-wide 통계 없음.
- 운영자가 "어느 agent가 자주 skip하는가?" 알려면 log scraping 필요.

이슈 보고: 2026-04-23에 `san`(seq=50836), `nic`(seq=51676) 두 agent가 동일 패턴 발화. 이 행동이 일회성인지 누적되는지 metric 채널이 없어 평가 불가.

## 변경 내용

### `lib/prometheus.{ml,mli}`

```ocaml
let metric_tool_join_required_guard =
  "masc_tool_join_required_guard_total"
```

Labels: `(tool, agent_name, reason)` where:
- `tool`: tool name (~50 cardinality)
- `agent_name`: keeper id (~10 cardinality)
- `reason`: `"room_uninitialized" | "agent_not_joined"`

Total ~1000 series — Prometheus-safe.

### `lib/mcp_server_eio_execute.ml`

```diff
  if join_required && not room_initialized then
+   Prometheus.inc_counter
+     Prometheus.metric_tool_join_required_guard
+     ~labels:[ ("tool", name);
+               ("agent_name", agent_name);
+               ("reason", "room_uninitialized") ] ();
    with_system_internal_audit ~agent_name (false, ...)
  else if join_required && not is_joined then
+   Prometheus.inc_counter
+     Prometheus.metric_tool_join_required_guard
+     ~labels:[ ("tool", name);
+               ("agent_name", agent_name);
+               ("reason", "agent_not_joined") ] ();
    with_system_internal_audit ~agent_name (false, ...)
```

에러 메시지는 변경 없음. 에이전트가 받는 응답 그대로 — 운영자만 metric 추가로 받음.

## 운영 활용

```promql
# 어느 agent가 가장 자주 join skip하는가
sort_desc(
  sum by (agent_name) (
    rate(masc_tool_join_required_guard_total[1h])
  )
)

# 어느 tool이 가장 자주 guard에 막히는가
sort_desc(
  sum by (tool) (
    rate(masc_tool_join_required_guard_total[1h])
  )
)

# Reason 분포 (room_uninitialized vs agent_not_joined)
sum by (reason) (rate(masc_tool_join_required_guard_total[1h]))
```

이 데이터로 다음 결정 가능:
- Specific agent에 SDK 업데이트 필요한지
- 특정 tool은 자동 join이 더 합리적인지 (auto-recover semantic)
- `room_uninitialized`이 vs `agent_not_joined` 비율로 init 누락 vs join 누락 분리 진단

## 테스트

`test/test_join_required_guard_counter.ml` 5 scenario:

```bash
$ dune exec test/test_join_required_guard_counter.exe
[OK]  metric_name  0  canonical name stable.
[OK]  counter      0  room_uninitialized increments.
[OK]  counter      1  agent_not_joined increments.
[OK]  isolation    0  reasons isolated.
[OK]  isolation    1  agents isolated.
Test Successful in 0.002s. 5 tests run.
```

## 회귀 리스크

매우 낮음. Pure additive — counter emit만 추가, error message 동일, control flow 동일. 기존 guard/audit 동작 변경 없음.

## 후속 (별건)

- **Auto-join 결정**: 특정 tool (`masc_claim_next` 등)에서 guard fire가 누적되면 server-side auto-join을 도입할지. 본 PR은 데이터 수집 단계.
- **SDK 측 fix**: 어떤 client SDK가 `masc_join` 단계를 skip하는지 — counter로 패턴 식별 후 SDK 업데이트.
- **`masc_start` migration**: 단순 join 대신 one-step `masc_start` 권장 — 에이전트 prompt 가이드 갱신.

## 참고

- Issue #9770
- `lib/mcp_server_eio_execute.ml:595-621` — guard fire sites
- `lib/prometheus.ml:262-278` — metric definition
- `test/test_join_required_guard_counter.ml` — coverage
