### PR TITLE
fix(keeper): gate stuck turn livelocks

### DIFF
--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -727,6 +727,10 @@ let keeper_keepalive_entries =
       "Interruptible sleep chunk size (seconds, clamped 0.1-10)";
     entry ~default:"(none)" "MASC_KEEPER_SMART_HEARTBEAT"
       "Adaptive heartbeat scheduling in keepalive loop (feature flag)";
+    entry ~default:"3" "MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS"
+      "Max dispatch attempts for the same keeper turn id before livelock guard blocks";
+    entry ~default:"1800.0" "MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC"
+      "Max seconds a keeper turn id may stay active before livelock guard blocks";
     entry ~default:"1200.0" "MASC_KEEPER_TURN_TIMEOUT_SEC"
       "Wall-clock timeout for a single unified turn (clamped 60-3600 seconds)";
     entry ~default:"(none)" "MASC_KEEPER_WORK_AS_HEARTBEAT"

--- a/lib/keeper/keeper_turn_livelock.ml
+++ b/lib/keeper/keeper_turn_livelock.ml
@@ -8,13 +8,13 @@
     keeper has tried turn 91 twelve times" until an operator greps
     log lines.
 
-    This module is the OBSERVABILITY half — it does NOT gate dispatch
-    yet (that's a follow-up).  Per-keeper in-memory state tracks the
-    most recent turn id seen and the attempt count for that id.  When
-    the same id starts again we emit a re-attempt counter.  When the
-    id moves strictly backwards we emit a regression counter (rare;
-    indicative of the write_meta race).  When the id advances normally
-    we reset the per-keeper bookkeeping.
+    Per-keeper in-memory state tracks the most recent turn id seen and
+    the attempt count for that id.  When the same id starts again we emit
+    a re-attempt counter.  When the id moves strictly backwards we emit a
+    regression counter (rare; indicative of the write_meta race).  When
+    the id advances normally we reset the per-keeper bookkeeping.  The
+    guarded entrypoint enforces a per-turn retry/age budget before the
+    dispatcher marks the turn live.
 
     State is process-local: a server restart resets the counters,
     which is intentional — the issue's fleet-wide signal comes from
@@ -53,38 +53,26 @@ type start_outcome =
     (** The turn id strictly decreased — usually a write_meta race
         losing an in-memory increment (#9733). *)
 
+type gate_reason =
+  | Attempts_exhausted of {
+      attempts : int;
+      max_attempts : int;
+      first_started_at : float;
+    }
+  | Stuck_age_exceeded of {
+      attempts : int;
+      age_sec : float;
+      threshold_sec : float;
+      first_started_at : float;
+    }
+
+type guarded_start_outcome =
+  | Started of start_outcome
+  | Blocked of gate_reason
+
 let now_unix () = Time_compat.now ()
 
-let record_turn_start ~(keeper : string) ~(turn_id : int) : start_outcome =
-  let outcome =
-    Stdlib.Mutex.lock mu;
-    Fun.protect
-      ~finally:(fun () -> Stdlib.Mutex.unlock mu)
-      (fun () ->
-        match Hashtbl.find_opt state keeper with
-        | None ->
-          Hashtbl.replace state keeper
-            { turn_id; attempts = 1; first_started_at = now_unix () };
-          Fresh
-        | Some prev when prev.turn_id < turn_id ->
-          Hashtbl.replace state keeper
-            { turn_id; attempts = 1; first_started_at = now_unix () };
-          Fresh
-        | Some prev when prev.turn_id = turn_id ->
-          let attempts = prev.attempts + 1 in
-          Hashtbl.replace state keeper { prev with attempts };
-          Reattempt
-            { previous_attempts = prev.attempts;
-              first_started_at = prev.first_started_at }
-        | Some prev (* prev.turn_id > turn_id *) ->
-          (* Strictly backwards.  Reset bookkeeping so the next start
-             at this lower id counts as Fresh, not Reattempt. *)
-          Hashtbl.replace state keeper
-            { turn_id; attempts = 1; first_started_at = now_unix () };
-          Regression { previous_turn_id = prev.turn_id })
-  in
-  (* Counter emissions outside the lock — Prometheus calls allocate
-     and can recurse; minimise critical-section scope. *)
+let record_started_metrics ~keeper outcome =
   Prometheus.inc_counter
     Prometheus.metric_keeper_turn_starts
     ~labels:[ ("keeper", keeper) ] ();
@@ -98,6 +86,96 @@ let record_turn_start ~(keeper : string) ~(turn_id : int) : start_outcome =
      Prometheus.inc_counter
        Prometheus.metric_keeper_turn_regressions
        ~labels:[ ("keeper", keeper) ] ());
+  outcome
+
+let gate_reason_kind = function
+  | Attempts_exhausted _ -> "attempts_exhausted"
+  | Stuck_age_exceeded _ -> "stuck_age_exceeded"
+
+let gate_reason_to_string = function
+  | Attempts_exhausted { attempts; max_attempts; _ } ->
+      Printf.sprintf "attempts_exhausted attempts=%d max_attempts=%d"
+        attempts max_attempts
+  | Stuck_age_exceeded { attempts; age_sec; threshold_sec; _ } ->
+      Printf.sprintf
+        "stuck_age_exceeded attempts=%d age_sec=%.1f threshold_sec=%.1f"
+        attempts age_sec threshold_sec
+
+let classify_and_update_start ~now ~(keeper : string) ~(turn_id : int)
+    : start_outcome =
+  match Hashtbl.find_opt state keeper with
+  | None ->
+    Hashtbl.replace state keeper
+      { turn_id; attempts = 1; first_started_at = now };
+    Fresh
+  | Some prev when prev.turn_id < turn_id ->
+    Hashtbl.replace state keeper
+      { turn_id; attempts = 1; first_started_at = now };
+    Fresh
+  | Some prev when prev.turn_id = turn_id ->
+    let attempts = prev.attempts + 1 in
+    Hashtbl.replace state keeper { prev with attempts };
+    Reattempt
+      { previous_attempts = prev.attempts;
+        first_started_at = prev.first_started_at }
+  | Some prev (* prev.turn_id > turn_id *) ->
+    (* Strictly backwards.  Reset bookkeeping so the next start
+       at this lower id counts as Fresh, not Reattempt. *)
+    Hashtbl.replace state keeper
+      { turn_id; attempts = 1; first_started_at = now };
+    Regression { previous_turn_id = prev.turn_id }
+
+let record_turn_start ~(keeper : string) ~(turn_id : int) : start_outcome =
+  let outcome =
+    Stdlib.Mutex.lock mu;
+    Fun.protect
+      ~finally:(fun () -> Stdlib.Mutex.unlock mu)
+      (fun () ->
+        classify_and_update_start ~now:(now_unix ()) ~keeper ~turn_id)
+  in
+  (* Counter emissions outside the lock — Prometheus calls allocate
+     and can recurse; minimise critical-section scope. *)
+  record_started_metrics ~keeper outcome
+
+let guard_and_record_turn_start ?(now = now_unix) ~(keeper : string)
+    ~(turn_id : int) ~(max_attempts : int) ~(stuck_after_sec : float) () :
+    guarded_start_outcome =
+  let max_attempts = Int.max 1 max_attempts in
+  let stuck_after_sec = Float.max 0.0 stuck_after_sec in
+  let now_value = now () in
+  let outcome =
+    Stdlib.Mutex.lock mu;
+    Fun.protect
+      ~finally:(fun () -> Stdlib.Mutex.unlock mu)
+      (fun () ->
+        match Hashtbl.find_opt state keeper with
+        | Some prev when prev.turn_id = turn_id ->
+          let age_sec = now_value -. prev.first_started_at in
+          if prev.attempts >= max_attempts then
+            Blocked
+              (Attempts_exhausted
+                 { attempts = prev.attempts;
+                   max_attempts;
+                   first_started_at = prev.first_started_at })
+          else if age_sec >= stuck_after_sec then
+            Blocked
+              (Stuck_age_exceeded
+                 { attempts = prev.attempts;
+                   age_sec;
+                   threshold_sec = stuck_after_sec;
+                   first_started_at = prev.first_started_at })
+          else
+            Started
+              (classify_and_update_start ~now:now_value ~keeper ~turn_id)
+        | _ ->
+          Started (classify_and_update_start ~now:now_value ~keeper ~turn_id))
+  in
+  (match outcome with
+   | Started started -> ignore (record_started_metrics ~keeper started)
+   | Blocked reason ->
+     Prometheus.inc_counter
+       Prometheus.metric_keeper_turn_livelock_blocks
+       ~labels:[ ("keeper", keeper); ("reason", gate_reason_kind reason) ] ());
   outcome
 
 (** Read current attempt state for [keeper] without modifying it.

--- a/lib/keeper/keeper_turn_livelock.mli
+++ b/lib/keeper/keeper_turn_livelock.mli
@@ -6,7 +6,8 @@
     backwards regressions emit dedicated Prometheus counters so
     operators can alert without grepping log lines.
 
-    This module does NOT gate dispatch — that's a follow-up.
+    [guard_and_record_turn_start] can also gate dispatch once a
+    turn exhausts its retry budget or stays stuck too long.
     State is process-local; a server restart resets the
     bookkeeping. *)
 
@@ -21,12 +22,45 @@ type start_outcome =
   | Reattempt of { previous_attempts : int; first_started_at : float }
   | Regression of { previous_turn_id : int }
 
+type gate_reason =
+  | Attempts_exhausted of {
+      attempts : int;
+      max_attempts : int;
+      first_started_at : float;
+    }
+  | Stuck_age_exceeded of {
+      attempts : int;
+      age_sec : float;
+      threshold_sec : float;
+      first_started_at : float;
+    }
+
+type guarded_start_outcome =
+  | Started of start_outcome
+  | Blocked of gate_reason
+
 (** [record_turn_start ~keeper ~turn_id] increments the
     [masc_keeper_turn_starts_total] counter and, when the start
     classifies as [Reattempt] or [Regression], the matching
     counter as well.  Returns the classification for the caller.
     Thread-safe across keeper fibers / domains. *)
 val record_turn_start : keeper:string -> turn_id:int -> start_outcome
+
+val guard_and_record_turn_start :
+  ?now:(unit -> float) ->
+  keeper:string ->
+  turn_id:int ->
+  max_attempts:int ->
+  stuck_after_sec:float ->
+  unit ->
+  guarded_start_outcome
+(** Atomically enforce a per-turn retry/age budget before recording a start.
+    With [max_attempts = 3], attempts 1, 2, and 3 are started; the fourth
+    start for the same [(keeper, turn_id)] is [Blocked].  Blocked starts do
+    not increment [metric_keeper_turn_starts], because no dispatch occurs. *)
+
+val gate_reason_kind : gate_reason -> string
+val gate_reason_to_string : gate_reason -> string
 
 (** Read-only view of the current attempt state for a keeper.
     Returns [None] when no state has been recorded yet. *)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -292,6 +292,16 @@ let saturation_skip_sleep_duration () =
   in
   saturation_skip_backoff_sec +. jitter
 
+let turn_livelock_max_attempts () =
+  Int.max 1
+    (Env_config_core.get_int ~default:3
+       "MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS")
+
+let turn_livelock_stuck_after_sec () =
+  Float.max 1.0
+    (Env_config_core.get_float ~default:1800.0
+       "MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC")
+
 (* Extracted to Keeper_error_classify — see keeper_error_classify.ml *)
 
 module EC = Keeper_error_classify
@@ -913,6 +923,22 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       (match saturation_skip_meta with
        | Some meta_after_skip -> Ok meta_after_skip
        | None ->
+      let turn_id = meta.runtime.usage.total_turns in
+      (match
+         Keeper_turn_livelock.guard_and_record_turn_start
+           ~keeper:meta.name
+           ~turn_id
+           ~max_attempts:(turn_livelock_max_attempts ())
+           ~stuck_after_sec:(turn_livelock_stuck_after_sec ())
+           ()
+       with
+       | Keeper_turn_livelock.Blocked reason ->
+           Log.Keeper.error
+             "%s: keeper turn livelock guard blocked dispatch turn=%d: %s"
+             meta.name turn_id
+             (Keeper_turn_livelock.gate_reason_to_string reason);
+           Ok meta
+       | Keeper_turn_livelock.Started _ ->
       let build_cascade_execution ~(cascade_name : string) :
           (cascade_execution, Oas.Error.sdk_error) result =
         let meta_for_cascade = { meta with cascade_name } in
@@ -1157,17 +1183,6 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         ~base_path:config.base_path meta.name;
       Keeper_registry.mark_turn_measurement
         ~base_path:config.base_path meta.name;
-      (* #10121: livelock observer — emit reattempt counter when
-         the same turn id starts again before the counter
-         advanced.  The classification result is intentionally
-         dropped here (no behaviour change yet); a follow-up PR
-         can act on [Reattempt { previous_attempts = N; _ }] to
-         gate dispatch above a threshold. *)
-      let _ : Keeper_turn_livelock.start_outcome =
-        Keeper_turn_livelock.record_turn_start
-          ~keeper:meta.name
-          ~turn_id:meta.runtime.usage.total_turns
-      in
       (match Keeper_registry.get ~base_path:config.base_path meta.name with
        | Some { current_turn_observation = Some { measurement = Some _; _ }; _ } ->
            Keeper_registry.set_turn_decision_stage
@@ -2303,6 +2318,6 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
            | Oas_worker.Completed ->
              Keeper_registry.reset_turn_failures ~base_path:config.base_path
                updated_meta.name);
-          Ok updated_meta)
+          Ok updated_meta))
 
 let run_unified_turn = run_keeper_cycle

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -223,6 +223,8 @@ let metric_keeper_context_max_observed =
 let metric_keeper_turn_starts = "masc_keeper_turn_starts_total"
 let metric_keeper_turn_reattempts = "masc_keeper_turn_reattempts_total"
 let metric_keeper_turn_regressions = "masc_keeper_turn_regressions_total"
+let metric_keeper_turn_livelock_blocks =
+  "masc_keeper_turn_livelock_blocks_total"
 
 (* #9943: per-keeper turn-latency bucket counter.  Each completed
    turn lands in exactly one [latency_bucket] label so a Prometheus
@@ -547,6 +549,10 @@ let init () =
     "Total keeper turn regressions: turn id moved to a strictly LOWER \
      value than previously observed (write_meta race losing an in-memory \
      counter increment — #9733 / #10121)"
+    Counter;
+  add metric_keeper_turn_livelock_blocks
+    "Total keeper turn dispatches blocked by the stuck-turn livelock guard \
+     (labels: keeper, reason=attempts_exhausted|stuck_age_exceeded)"
     Counter;
   (* #9943: per-keeper turn latency bucket distribution.  Each
      completed turn increments exactly one bucket.  Bucket vocabulary

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -83,10 +83,12 @@ val metric_keeper_context_max_observed : string
 val metric_keeper_turn_starts : string
 val metric_keeper_turn_reattempts : string
 val metric_keeper_turn_regressions : string
+val metric_keeper_turn_livelock_blocks : string
 (** #10121: keeper turn livelock observer counters.  Labels:
     [keeper].  Re-attempt = same turn id started again before
     the counter advanced; regression = turn id moved strictly
-    backwards (write_meta race symptom — #9733). *)
+    backwards (write_meta race symptom — #9733); livelock blocks
+    are labeled by [keeper, reason]. *)
 val metric_keeper_turn_latency_bucket : string
 (** #9943: per-keeper turn latency distribution.  Labels:
     [keeper, bucket].  Bucket vocabulary:

--- a/test/test_keeper_turn_livelock_10121.ml
+++ b/test/test_keeper_turn_livelock_10121.ml
@@ -22,6 +22,8 @@
         the FIRST start of the current turn id (so a future
         gate can compute "stuck for X minutes" without
         re-deriving the timeline).
+     7. The guard blocks attempt 4 when [max_attempts=3],
+        gates on stuck age, and resets on forward turn advance.
 *)
 
 let () =
@@ -46,6 +48,10 @@ let reattempts_for ~keeper =
 let regressions_for ~keeper =
   Prom.metric_value_or_zero Prom.metric_keeper_turn_regressions
     ~labels:[ ("keeper", keeper) ] ()
+
+let blocks_for ~keeper ~reason =
+  Prom.metric_value_or_zero Prom.metric_keeper_turn_livelock_blocks
+    ~labels:[ ("keeper", keeper); ("reason", reason) ] ()
 
 (* Fresh start: no prior state → [Fresh] outcome, starts counter
    +1, reattempt counter unchanged. *)
@@ -162,6 +168,94 @@ let test_seconds_since_first_attempt () =
       "elapsed >= 50ms (sleep) and < 60s (test budget)"
       true (t >= 0.04 && t < 60.0)
 
+let test_guard_blocks_after_max_attempts () =
+  L.reset_for_tests ();
+  let keeper = "test-keeper-guard-max-10121" in
+  let now = ref 1000.0 in
+  let call () =
+    L.guard_and_record_turn_start
+      ~now:(fun () -> !now)
+      ~keeper
+      ~turn_id:91
+      ~max_attempts:3
+      ~stuck_after_sec:3600.0
+      ()
+  in
+  let before_starts = starts_for ~keeper in
+  let before_blocks =
+    blocks_for ~keeper ~reason:"attempts_exhausted"
+  in
+  (match call () with
+   | L.Started L.Fresh -> ()
+   | _ -> Alcotest.fail "attempt 1 should start fresh");
+  (match call () with
+   | L.Started (L.Reattempt { previous_attempts = 1; _ }) -> ()
+   | _ -> Alcotest.fail "attempt 2 should start");
+  (match call () with
+   | L.Started (L.Reattempt { previous_attempts = 2; _ }) -> ()
+   | _ -> Alcotest.fail "attempt 3 should start");
+  (match call () with
+   | L.Blocked (L.Attempts_exhausted { attempts; max_attempts; _ }) ->
+     Alcotest.(check int) "attempts held at 3" 3 attempts;
+     Alcotest.(check int) "max attempts" 3 max_attempts
+   | _ -> Alcotest.fail "attempt 4 should be blocked");
+  Alcotest.(check (float 0.0001))
+    "only the three dispatches increment starts"
+    (before_starts +. 3.0) (starts_for ~keeper);
+  Alcotest.(check (float 0.0001))
+    "block counter +1"
+    (before_blocks +. 1.0)
+    (blocks_for ~keeper ~reason:"attempts_exhausted")
+
+let test_guard_blocks_on_stuck_age () =
+  L.reset_for_tests ();
+  let keeper = "test-keeper-guard-age-10121" in
+  let now = ref 10.0 in
+  let call () =
+    L.guard_and_record_turn_start
+      ~now:(fun () -> !now)
+      ~keeper
+      ~turn_id:24
+      ~max_attempts:10
+      ~stuck_after_sec:30.0
+      ()
+  in
+  (match call () with
+   | L.Started L.Fresh -> ()
+   | _ -> Alcotest.fail "first attempt should start");
+  now := 41.0;
+  (match call () with
+   | L.Blocked
+       (L.Stuck_age_exceeded { attempts; age_sec; threshold_sec; _ }) ->
+     Alcotest.(check int) "only one prior attempt" 1 attempts;
+     Alcotest.(check bool) "age crosses threshold" true (age_sec >= 30.0);
+     Alcotest.(check (float 0.0001)) "threshold" 30.0 threshold_sec
+   | _ -> Alcotest.fail "stuck age should block");
+  Alcotest.(check (float 0.0001))
+    "age block counter +1"
+    1.0 (blocks_for ~keeper ~reason:"stuck_age_exceeded")
+
+let test_guard_forward_advance_resets () =
+  L.reset_for_tests ();
+  let keeper = "test-keeper-guard-advance-10121" in
+  let call turn_id =
+    L.guard_and_record_turn_start
+      ~now:(fun () -> 100.0)
+      ~keeper
+      ~turn_id
+      ~max_attempts:2
+      ~stuck_after_sec:3600.0
+      ()
+  in
+  ignore (call 7 : L.guarded_start_outcome);
+  ignore (call 7 : L.guarded_start_outcome);
+  (match call 7 with
+   | L.Blocked (L.Attempts_exhausted _) -> ()
+   | _ -> Alcotest.fail "third attempt for turn 7 should block");
+  (match call 8 with
+   | L.Started L.Fresh -> ()
+   | _ -> Alcotest.fail "turn 8 should reset guard state")
+
 let () =
   Alcotest.run "keeper_turn_livelock_10121"
     [
@@ -193,5 +287,14 @@ let () =
         [
           Alcotest.test_case "seconds_since_first_attempt" `Quick
             test_seconds_since_first_attempt;
+        ] );
+      ( "guard",
+        [
+          Alcotest.test_case "max attempts gates attempt 4" `Quick
+            test_guard_blocks_after_max_attempts;
+          Alcotest.test_case "stuck age gates dispatch" `Quick
+            test_guard_blocks_on_stuck_age;
+          Alcotest.test_case "forward advance resets guard" `Quick
+            test_guard_forward_advance_resets;
         ] );
     ]


### PR DESCRIPTION
## Summary
- turn the #10121 livelock observer into an actual dispatch gate before registry mark_turn_started
- block repeated keeper turn ids after a bounded retry budget or stuck-age threshold, with env knobs and Prometheus block metrics
- keep existing start/reattempt/regression telemetry and add regression tests for max-attempt, stuck-age, and forward-reset behavior

Fixes #10121.

## Verification
- env DUNE_BUILD_DIR=_build_verify_10121 DUNE_JOBS=2 scripts/dune-local.sh build test/test_keeper_turn_livelock_10121.exe
- env DUNE_BUILD_DIR=_build_verify_10121 _build_verify_10121/default/test/test_keeper_turn_livelock_10121.exe
- git diff --check HEAD^..HEAD