### PR TITLE
fix(keeper-toml): operator-visible cascade_name validator + load_catalog WARN (#10158)

### DIFF
--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -59,6 +59,18 @@ let canonical (raw : string) : t =
   | Some t -> t
   | None -> default
 
+(* #10158: cascade.toml load failures used to silently return [None].
+   That made every downstream caller (catalog_names,
+   keeper_catalog_names, system_catalog_names) return [], which
+   made [keeper_types_profile] reject every TOML keeper config
+   whose cascade_name lived only in cascade.toml
+   ([tool_use_strict] etc.) — six configs were silently dropped
+   on 2026-04-25.  Surface the failure once per process so the
+   root cause is visible without spamming dashboard render
+   loops; reset on success so a fixed config flips the alarm
+   off. *)
+let cascade_load_warn_emitted : bool Atomic.t = Atomic.make false
+
 let catalog_entries ?config_path () =
   let path_opt =
     match config_path with
@@ -69,8 +81,17 @@ let catalog_entries ?config_path () =
   | None -> None
   | Some path -> (
       match Cascade_config_loader.load_catalog ~config_path:path with
-      | Ok entries -> Some entries
-      | Error _ -> None)
+      | Ok entries ->
+          Atomic.set cascade_load_warn_emitted false;
+          Some entries
+      | Error e ->
+          if not (Atomic.exchange cascade_load_warn_emitted true) then
+            Log.Keeper.warn
+              "cascade catalog load failed for %s: %s — keeper TOML \
+               configs whose cascade_name is defined only in \
+               cascade.toml will be silently rejected (see #10158)"
+              path e;
+          None)
 
 let catalog_names ?config_path () =
   match catalog_entries ?config_path () with

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -654,12 +654,21 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
             let all_valid = compile_known @ phase_routing @ catalog in
             if List.mem normalized all_valid then Ok ()
             else
+              (* #10158: include cascade.toml [catalog] entries in the
+                 operator-visible "known:" list.  Previously this
+                 printed only [compile_known @ phase_routing] (4
+                 names on prod), so an operator trying to add a
+                 valid name from cascade.toml ([tool_use_strict],
+                 [local_only], etc.) saw a misleading rejection
+                 that did not even mention the name they wanted to
+                 use.  Sort + dedupe so the message is stable
+                 across runs even when [catalog] reorders. *)
+              let dedup_sorted xs = List.sort_uniq String.compare xs in
               Error
                 (Printf.sprintf
                    "invalid cascade_name '%s' (known: %s)"
                    raw
-                   (String.concat ", "
-                      (compile_known @ phase_routing))))
+                   (String.concat ", " (dedup_sorted all_valid))))
   in
   Result.map
     (fun () ->

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -141,6 +141,92 @@ let test_cascade_name_accepts_catalog_entry () =
       if catalog = [] then ()
       else fail (Printf.sprintf "%s should be accepted: %s" test_name e)
 
+(* #10158: when a cascade_name is rejected, the operator-visible
+   error message must include cascade.toml [catalog] entries —
+   otherwise an operator who tried [tool_use_strict] (a real
+   catalog entry) would see the rejection list missing that name
+   and conclude the system does not support it.  Pre-fix the
+   message printed only [compile_known @ phase_routing] (4 names
+   on prod). *)
+let test_invalid_cascade_name_message_includes_catalog () =
+  let catalog =
+    try Masc_mcp.Keeper_cascade_profile.catalog_names ()
+    with _ -> []
+  in
+  let unique_catalog_name =
+    List.find_opt
+      (fun n ->
+        not (List.mem n Masc_mcp.Keeper_cascade_profile.known_cascades)
+        && not (List.mem n [ "local_only"; "local_recovery" ]))
+      catalog
+  in
+  match unique_catalog_name with
+  | None ->
+      (* Catalog unavailable in test environment — the fix is still
+         correct (it just degrades to the old behaviour); skip. *)
+      ()
+  | Some name ->
+      let result =
+        with_temp_toml
+          "[keeper]\nname = \"foo\"\n\
+           cascade_name = \"definitely_not_real_xyz_10158\"\n"
+          KTP.load_keeper_toml
+      in
+      (match result with
+       | Ok _ -> fail "should reject"
+       | Error e ->
+           let contains needle s =
+             let n = String.length s and m = String.length needle in
+             if m > n then false
+             else
+               let rec loop i =
+                 if i + m > n then false
+                 else if String.sub s i m = needle then true
+                 else loop (i + 1)
+               in
+               loop 0
+           in
+           check bool
+             (Printf.sprintf "message mentions catalog entry %s" name)
+             true (contains name e))
+
+(* The "(known: ...)" list must be sorted + deduplicated so
+   operators see a stable, readable enumeration even when
+   compile_known and the catalog overlap or reorder. *)
+let test_invalid_cascade_name_message_sorted_and_unique () =
+  let result =
+    with_temp_toml
+      "[keeper]\nname = \"foo\"\n\
+       cascade_name = \"definitely_not_real_xyz_10158_dup\"\n"
+      KTP.load_keeper_toml
+  in
+  match result with
+  | Ok _ -> fail "should reject"
+  | Error e ->
+      let prefix = "(known: " in
+      let plen = String.length prefix in
+      let n = String.length e in
+      let rec find i =
+        if i + plen > n then None
+        else if String.sub e i plen = prefix then Some (i + plen)
+        else find (i + 1)
+      in
+      (match find 0 with
+       | None -> fail (Printf.sprintf "no (known: ...) in: %s" e)
+       | Some start ->
+           (* End at the matching ')' *)
+           let close = String.index_from e start ')' in
+           let body = String.sub e start (close - start) in
+           let names =
+             String.split_on_char ',' body |> List.map String.trim
+           in
+           let sorted = List.sort String.compare names in
+           check (list string) "names are sorted alphabetically"
+             sorted names;
+           let unique = List.sort_uniq String.compare names in
+           check int "no duplicates"
+             (List.length names) (List.length unique))
+
 let test_tool_preset_accepts_dispatch () =
   let result =
     with_temp_toml
@@ -228,6 +314,10 @@ let () =
             test_cascade_name_accepts_known;
           test_case "accepts catalog entry (legacy alias)" `Quick
             test_cascade_name_accepts_catalog_entry;
+          test_case "rejection message includes catalog entries (#10158)" `Quick
+            test_invalid_cascade_name_message_includes_catalog;
+          test_case "rejection message is sorted + deduped (#10158)" `Quick
+            test_invalid_cascade_name_message_sorted_and_unique;
           test_case "accepts dispatch tool_preset" `Quick
             test_tool_preset_accepts_dispatch;
         ] );


### PR DESCRIPTION
## Summary

#10158 reports 6 keeper TOML configs silently rejected at boot:

\`\`\`
toml_loader: skipping nick0cave.toml: invalid cascade_name 'ollama_only'
  (known: big_three, tool_rerank, local_only, local_recovery)
\`\`\`

Two distinct sub-bugs underneath:

### 1. Display drift (Option B)

The message printed only \`compile_known @ phase_routing\` (4 names).  But the validator's actual \`all_valid\` set also includes \`Keeper_cascade_profile.catalog_names ()\` from cascade.toml.  Operators trying \`tool_use_strict\` saw a rejection that didn't even mention the name — they had no way to tell "this name is invalid" from "the system does not support it."

**Fix**: print every valid name, sorted + deduped.

### 2. Silent catalog load failure (Option C — code half)

\`Keeper_cascade_profile.catalog_entries\` swallowed \`Cascade_config_loader.load_catalog\`'s \`Error _\` and returned \`None\`.  Every downstream caller then operated on \`catalog_names () = []\`, which made the validator reject every cascade.toml-defined name.  The only signal was the cascading "invalid" rejections — operators couldn't distinguish "load failed" from "name unknown."

**Fix**: once-per-process \`Log.Keeper.warn\` at the first \`Error e\`, reset on a later successful load so a fixed config flips the alarm off.

\`\`\`ocaml
let cascade_load_warn_emitted : bool Atomic.t = Atomic.make false
...
| Error e ->
    if not (Atomic.exchange cascade_load_warn_emitted true) then
      Log.Keeper.warn "cascade catalog load failed for %s: %s — ..." path e;
    None
\`\`\`

## Not in this PR (per issue resolution table)

| option | scope | why deferred |
|---|---|---|
| **A** (cascade.toml + keeper TOMLs config drift) | repo config edit | separate from code change; needs operator decision (define \`ollama_only\` vs migrate keepers to \`local_only\`) |
| **D** (silent skip → fail-loud / startup blocker) | larger policy change | escalating WARN → ERROR or startup-block needs review and rollout plan |

## Test plan

- [x] \`dune build --root . lib/\` clean
- [x] **new** \`test_invalid_cascade_name_message_includes_catalog\` — pins catalog entries appear in the rejection message when catalog loads
- [x] **new** \`test_invalid_cascade_name_message_sorted_and_unique\` — pins sort + dedup (stable, readable output regardless of catalog ordering)
- [x] Existing \`test_cascade_name_accepts_catalog_entry\` continues to pass
- [ ] Local environment caveat: \`test_cascade_name_rejects_unknown\` fails on my machine because \`~/me/.masc/config/cascade.json\` happens to register \`nick0cave\` as a catalog entry (so the test fixture name is accidentally valid).  Pre-existing test fragility independent of this PR — confirm CI passes (CI's HOME is clean).

## Refs

- #9572, #9768, #6747 (CLOSED) — same-shape regressions
- iter62 #9733 follow-up: same keepers, different layer

## Do-not-merge

\`do-not-merge\` label set so the auto-merge pipeline does not flip this Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)