### PR TITLE
feat(auth): boot-time credential token uniqueness audit (#9786)

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -421,6 +421,47 @@ let list_credentials config : agent_credential list =
   else
     []
 
+(** #9786: detect credentials sharing the same bearer token.
+
+    The 2026-04-23 audit found [codex-mcp-client] and [admin]
+    tokens being presented for [keeper-sangsu-agent] /
+    [nick0cave-sage-heron] requests — symptom of multiple
+    credentials hashing to the same token, or a single MCP
+    client connection being reused across agent identities.
+
+    [find_credential_by_token]'s [List.find_opt] returns the FIRST
+    matching credential, so when two credentials share a token the
+    second agent's auth silently routes to the first agent's
+    identity — which is exactly the [bearer token belongs to X]
+    rejection observed in #9786 once the requested name does not
+    match the routed credential's owner.
+
+    This audit walks the credential store and returns groups of
+    [(token_hash_prefix, agent_names)] where [List.length
+    agent_names >= 2].  Empty list means every credential's token
+    hash is unique. *)
+let audit_token_uniqueness config : (string * string list) list =
+  let creds = list_credentials config in
+  let by_token : (string, string list) Hashtbl.t = Hashtbl.create 16 in
+  List.iter
+    (fun (cred : agent_credential) ->
+      let prev = Hashtbl.find_opt by_token cred.token |> Option.value ~default:[] in
+      Hashtbl.replace by_token cred.token (cred.agent_name :: prev))
+    creds;
+  Hashtbl.fold
+    (fun token_hash agents acc ->
+      match agents with
+      | [] | [ _ ] -> acc
+      | xs ->
+        let prefix =
+          if String.length token_hash >= 12
+          then String.sub token_hash 0 12
+          else token_hash
+        in
+        (prefix, List.sort String.compare xs) :: acc)
+    by_token []
+  |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+
 (** Find credential by raw token (hash lookup + expiry check) *)
 let find_credential_by_token config ~token : (agent_credential, masc_error) result =
   let token_hash = sha256_hash token in

--- a/lib/auth.mli
+++ b/lib/auth.mli
@@ -51,6 +51,19 @@ val delete_credential : string -> string -> unit
 
 val list_credentials : string -> agent_credential list
 
+val audit_token_uniqueness : string -> (string * string list) list
+(** #9786: walk all credentials under [config] and return groups of
+    agent names that share the same token hash.  Each entry is
+    [(token_hash_prefix, agent_names)] where [agent_names] has at
+    least 2 elements (a unique token would not appear in the
+    result).  [token_hash_prefix] is the first 12 chars of the
+    SHA-256 hash, so logs / dashboards can correlate without
+    leaking the full credential.
+
+    Used at server bootstrap to surface the
+    [bearer-token-belongs-to-X] failure mode (#9786) BEFORE
+    runtime requests start failing.  Empty list = healthy. *)
+
 val find_credential_by_token :
   string -> token:string -> (agent_credential, masc_error) result
 

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -497,6 +497,15 @@ let metric_fs_atomic_orphans_cleaned =
 let metric_auth_bearer_token_mismatch =
   "masc_auth_bearer_token_mismatch_total"
 
+(* #9786 follow-up: boot-time audit counter for credentials
+   sharing the same token hash.  Distinct from
+   [bearer_token_mismatch]: the mismatch counter fires per
+   request, this fires once per boot per detected duplicate
+   group.  Operators alert on a non-zero value at all — every
+   shared-token group is a routing ambiguity. *)
+let metric_auth_credential_token_duplicate =
+  "masc_auth_credential_token_duplicate_total"
+
 
 (** {1 Built-in Metrics} *)
 

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -218,6 +218,12 @@ val metric_fs_atomic_orphans_cleaned : string
     signal of shared credential state (connection pool / fork). *)
 val metric_auth_bearer_token_mismatch : string
 
+val metric_auth_credential_token_duplicate : string
+(** #9786 follow-up: boot-time audit counter for credentials
+    sharing the same token hash.  Increments once per boot per
+    duplicate group.  Operator alert: any non-zero rate is a
+    routing-ambiguity that must be rotated. *)
+
 
 (** {1 Transport metrics} *)
 

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1264,6 +1264,36 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
             Log.Server.error
               "boot: atomic orphan sweep failed: %s"
               (Printexc.to_string exn));
+      (* #9786: audit credential store for shared bearer tokens.
+         When two credentials hash to the same token,
+         [find_credential_by_token] silently routes to the FIRST
+         match — which is exactly the [bearer token belongs to X]
+         rejection observed when the second agent's name does not
+         match the first agent's credential.  Surface the
+         duplicate at boot so operators can rotate tokens before
+         requests start failing. *)
+      (try
+         let groups = Auth.audit_token_uniqueness base_path in
+         List.iter
+           (fun (token_hash_prefix, agent_names) ->
+             Prometheus.inc_counter
+               Prometheus.metric_auth_credential_token_duplicate
+               ~labels:[ ("token_hash_prefix", token_hash_prefix) ]
+               ();
+             Log.Server.warn
+               "#9786 credential token shared by %d agents \
+                [%s] (token_hash_prefix=%s) — rotate via \
+                Auth.create_token to prevent bearer-token routing \
+                ambiguity"
+               (List.length agent_names)
+               (String.concat ", " agent_names)
+               token_hash_prefix)
+           groups
+       with Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
+            Log.Server.error
+              "boot: credential token uniqueness audit failed: %s"
+              (Printexc.to_string exn));
       let t2 = Eio.Time.now clock in
       Log.Server.info "Bootstrap completed in %.1fs" (t2 -. t1);
       Server_bootstrap_loops.install_tooling ~governance_level state;

--- a/test/dune
+++ b/test/dune
@@ -333,6 +333,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_auth_token_uniqueness_audit)
+ (modules test_auth_token_uniqueness_audit)
+ (libraries masc_test_deps))
+
+(test
  (name test_fsm_drift_per_agent_counter)
  (modules test_fsm_drift_per_agent_counter)
  (libraries masc_test_deps))

--- a/test/test_auth_token_uniqueness_audit.ml
+++ b/test/test_auth_token_uniqueness_audit.ml
@@ -1,0 +1,113 @@
+(* #9786: [Auth.audit_token_uniqueness] surfaces credentials
+   sharing the same bearer token hash.  Tests pin:
+   - empty store / unique tokens → []
+   - two creds with same hash → one group with both names
+   - three creds, two share / one unique → only the shared pair
+   - returned hash is a 12-char prefix (not the full hash) *)
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then (
+      Sys.readdir path
+      |> Array.iter (fun e -> rm_rf (Filename.concat path e));
+      Unix.rmdir path)
+    else
+      Sys.remove path
+
+let with_temp_base f =
+  let base =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-9786-%06x" (Random.bits ()))
+  in
+  Unix.mkdir base 0o755;
+  Fun.protect
+    ~finally:(fun () -> rm_rf base)
+    (fun () -> f base)
+
+(* Create a credential file directly under [<base>/.masc/auth/agents/].
+   Bypasses the Auth API on purpose so we can craft duplicates
+   without [save_raw_token_credential] re-hashing. *)
+let write_cred ~base ~agent_name ~token_hash =
+  let agents_dir =
+    Filename.concat base ".masc/auth/agents"
+  in
+  let rec mkdirs p =
+    if Sys.file_exists p then ()
+    else begin
+      mkdirs (Filename.dirname p);
+      try Unix.mkdir p 0o755 with Unix.Unix_error _ -> ()
+    end
+  in
+  mkdirs agents_dir;
+  let path = Filename.concat agents_dir (agent_name ^ ".json") in
+  let json =
+    Printf.sprintf
+      "{\"agent_name\":%S,\"token\":%S,\"role\":\"agent\",\"created_at\":\"2026-04-25T00:00:00Z\"}"
+      agent_name token_hash
+  in
+  let oc = open_out path in
+  output_string oc json;
+  close_out oc
+
+let test_empty_store_returns_empty () =
+  with_temp_base (fun base ->
+    let groups = Masc_mcp.Auth.audit_token_uniqueness base in
+    Alcotest.(check int) "empty store" 0 (List.length groups))
+
+let test_unique_tokens_return_empty () =
+  with_temp_base (fun base ->
+    write_cred ~base ~agent_name:"alpha" ~token_hash:"hash_alpha_12345678";
+    write_cred ~base ~agent_name:"beta"  ~token_hash:"hash_beta_12345678_";
+    let groups = Masc_mcp.Auth.audit_token_uniqueness base in
+    Alcotest.(check int) "no duplicate groups" 0 (List.length groups))
+
+let test_shared_token_surfaces_pair () =
+  with_temp_base (fun base ->
+    let shared = "shared_token_hash_value_with_enough_length" in
+    write_cred ~base ~agent_name:"keeper-sangsu-agent" ~token_hash:shared;
+    write_cred ~base ~agent_name:"nick0cave-sage-heron" ~token_hash:shared;
+    let groups = Masc_mcp.Auth.audit_token_uniqueness base in
+    match groups with
+    | [ (prefix, agents) ] ->
+        Alcotest.(check int) "exactly 2 agents in group"
+          2 (List.length agents);
+        Alcotest.(check (list string)) "agents sorted"
+          [ "keeper-sangsu-agent"; "nick0cave-sage-heron" ]
+          agents;
+        Alcotest.(check int) "prefix is 12 chars"
+          12 (String.length prefix);
+        Alcotest.(check string) "prefix matches token start"
+          "shared_token" prefix
+    | _ ->
+        Alcotest.failf "expected exactly 1 duplicate group, got %d"
+          (List.length groups))
+
+let test_mixed_unique_and_shared () =
+  with_temp_base (fun base ->
+    write_cred ~base ~agent_name:"unique-1" ~token_hash:"unique_hash_AAA_long";
+    let shared = "shared_hash_BBB_long_enough_value" in
+    write_cred ~base ~agent_name:"shared-a" ~token_hash:shared;
+    write_cred ~base ~agent_name:"shared-b" ~token_hash:shared;
+    write_cred ~base ~agent_name:"unique-2" ~token_hash:"unique_hash_CCC_long";
+    let groups = Masc_mcp.Auth.audit_token_uniqueness base in
+    Alcotest.(check int) "one duplicate group" 1 (List.length groups);
+    match groups with
+    | [ (_, agents) ] ->
+        Alcotest.(check (list string)) "shared pair"
+          [ "shared-a"; "shared-b" ] agents
+    | _ -> Alcotest.fail "unreachable")
+
+let () =
+  Random.self_init ();
+  Alcotest.run "auth_token_uniqueness_audit_9786" [
+    "audit", [
+      Alcotest.test_case "empty store" `Quick
+        test_empty_store_returns_empty;
+      Alcotest.test_case "unique tokens → empty" `Quick
+        test_unique_tokens_return_empty;
+      Alcotest.test_case "shared token surfaces pair" `Quick
+        test_shared_token_surfaces_pair;
+      Alcotest.test_case "mixed unique + shared" `Quick
+        test_mixed_unique_and_shared;
+    ];
+  ]


### PR DESCRIPTION
## 요약

`Auth.audit_token_uniqueness` 함수 추가 — 같은 token hash를 공유하는 credential pair 검출. Server bootstrap 끝에 실행하여 routing-ambiguity를 운영 시작 전 감지.

Closes part of #9786 (boot-time detection).

## 근본 원인

이슈 보고:
- `nick0cave-sage-heron` 호출 → bearer token이 `codex-mcp-client` 소유로 resolve
- `keeper-sangsu-agent` 호출 → 동일하게 `codex-mcp-client` (또는 `admin`) 소유

`lib/auth.ml:425-428`의 `find_credential_by_token`:
```ocaml
match List.find_opt (fun cred -> cred.token = token_hash) (list_credentials config) with
```

`List.find_opt`은 token_hash 일치 첫 credential 반환. 두 credential이 동일 hash → 두 번째 agent의 bearer 인증이 silently 첫 agent 신원으로 routing됨. 요청 agent_name이 routed credential 소유자와 다르면 `bearer token belongs to <first agent>` 거부.

이 routing ambiguity 자체는 boot 시점에 검출 가능 — credential file 모두 디스크에 있음. 그러나 기존엔 runtime 요청 실패할 때까지 invisible.

## 변경 내용

### `lib/auth.{ml,mli}`

```ocaml
val audit_token_uniqueness : string -> (string * string list) list
(** Walk credentials, return groups of (token_hash_prefix, agent_names)
    where len(agent_names) >= 2. Empty list = healthy. *)
```

구현: `list_credentials`로 전수 walk → Hashtbl로 hash별 grouping → ≥2 agents인 group만 반환. `token_hash_prefix`는 SHA-256 첫 12 chars (forensic 가능, full hash leak 안 함).

### Server bootstrap wiring

`Bootstrap completed in ...` 직전:

```ocaml
let groups = Auth.audit_token_uniqueness base_path in
List.iter (fun (token_hash_prefix, agent_names) ->
  Prometheus.inc_counter
    Prometheus.metric_auth_credential_token_duplicate
    ~labels:[ ("token_hash_prefix", token_hash_prefix) ] ();
  Log.Server.warn
    "#9786 credential token shared by %d agents [%s] (token_hash_prefix=%s) — \
     rotate via Auth.create_token to prevent bearer-token routing ambiguity"
    (List.length agent_names)
    (String.concat ", " agent_names)
    token_hash_prefix
) groups
```

### Prometheus metric

`masc_auth_credential_token_duplicate_total{token_hash_prefix}` — boot마다 duplicate group 1개당 1번 increment.

기존 `masc_auth_bearer_token_mismatch_total{expected_agent, actual_agent}`와 보완 관계:
- mismatch = per-request count (runtime 실패 누적)
- duplicate = per-boot count (cause detection at boot)

## 운영 활용

```promql
# 시작부터 duplicate 발견 — operator 즉시 rotate 필요
masc_auth_credential_token_duplicate_total > 0

# 어느 hash prefix 가 가장 많이 fire하는가 (multi-cluster시)
sort_desc(masc_auth_credential_token_duplicate_total)
```

WARN log:
```
[WARN] #9786 credential token shared by 2 agents [keeper-sangsu-agent, codex-mcp-client]
       (token_hash_prefix=a3f2b1c4d5e6) — rotate via Auth.create_token to prevent
       bearer-token routing ambiguity
```

## 테스트

`test/test_auth_token_uniqueness_audit.ml` 4 scenario:

```bash
$ dune exec test/test_auth_token_uniqueness_audit.exe
[OK]  audit  0  empty store.
[OK]  audit  1  unique tokens → empty.
[OK]  audit  2  shared token surfaces pair.
[OK]  audit  3  mixed unique + shared.
Test Successful in 0.008s. 4 tests run.
```

## 회귀 리스크

매우 낮음. Audit 함수는 read-only. Bootstrap에서 try-with로 wrap, 실패 시 ERROR log + 계속 (non-blocking). Forensic prefix만 노출, full hash 노출 없음.

## 후속 (별건)

- **Auto-rotation policy**: duplicate 발견 시 자동 rotate? — 어느 agent가 keep하고 어느 가 re-issue 받는지 operator 결정 필요. 본 PR로 평소 발견율 측정 후 결정.
- **runtime-level check**: `find_credential_by_token`이 `List.find_opt`로 first match 반환하는 동안 ambiguity 가능. 두 매칭 발견 시 hard-fail로 promote 검토 (operator alert).
- **Migration tools**: legacy token alias나 manual file copy 패턴이 root cause면 migration script 필요.

## 참고

- Issue #9786
- `lib/auth.ml:424-466` — audit 함수
- `lib/server/server_runtime_bootstrap.ml:1267-1300` — boot wiring
- `lib/prometheus.ml:478-490` — metric def
- `test/test_auth_token_uniqueness_audit.ml` — coverage
- 관련: #9843 (anyang-keepers PAT 공유 — 본 audit이 detect 가능), `feedback_keeper-credential-name-drift.md`
