### PR TITLE
perf(ws,grpc): bandwidth-burst hardening (default-on slice gate + bytes counters)

### DIFF
--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -234,11 +234,12 @@ let transport_entries =
     entry ~default:"1048576" "MASC_WS_CLIENT_BUFFER_LIMIT_BYTES"
       "Skip WS dashboard deltas for authenticated sessions whose last reported \
        WebSocket.bufferedAmount exceeds this many bytes. 0 disables the gate.";
-    entry ~default:"false" "MASC_WS_SLICE_INDEX_ENABLED"
-      "When true, slice-scoped events skip the raw-SSE-forward to authenticated \
-       WS sessions whose route does not subscribe to the event's slice. \
-       Catch-all events (no slice mapping) still reach every session. \
-       masc_ws_slice_fanout_skipped_total advances per skip. RFC #10119 Phase 2.";
+    entry ~default:"true" "MASC_WS_SLICE_INDEX_ENABLED"
+      "When true (default), slice-scoped events skip the raw-SSE-forward to \
+       authenticated WS sessions whose route does not subscribe to the event's \
+       slice. Catch-all events (no slice mapping) still reach every session. \
+       masc_ws_slice_fanout_skipped_total advances per skip. RFC #10119 \
+       Phase 2. Set to false for emergency rollback only.";
     entry ~default:"true" "MASC_WEBRTC_ENABLED" "Enable WebRTC transport";
     entry ~default:"auto" "MASC_USE_H2" "HTTP mode (auto|h2_only|h1_only)";
     entry ~default:"240" "MASC_STARTUP_WATCHDOG_SEC"

--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -375,7 +375,10 @@ let handle_heartbeat
             pending_task_count = pending_count;
             directives;
           } in
-          Grpc_eio.Stream.add response_stream (T.HeartbeatAck.to_bytes ack);
+          let ack_bytes = T.HeartbeatAck.to_bytes ack in
+          Transport_metrics.inc_grpc_bytes_sent
+            ~bytes:(String.length ack_bytes);
+          Grpc_eio.Stream.add response_stream ack_bytes;
           (* Record heartbeat latency *)
           let latency = Unix.gettimeofday () -. t0 in
           Transport_metrics.observe_grpc_heartbeat_latency latency
@@ -442,7 +445,9 @@ let handle_subscribe
       (Yojson.Safe.to_string
         (`List (List.map (fun s -> `String s) req.event_types)));
   } in
-  Grpc_eio.Stream.add stream (T.Event.to_bytes init_event);
+  let init_bytes = T.Event.to_bytes init_event in
+  Transport_metrics.inc_grpc_bytes_sent ~bytes:(String.length init_bytes);
+  Grpc_eio.Stream.add stream init_bytes;
   incr events_count;
   (* Read recent messages and push as events *)
   let backlog_file =
@@ -465,7 +470,10 @@ let handle_subscribe
             timestamp_ms = now_ms ();
             payload_json = line;
           } in
-          Grpc_eio.Stream.add stream (T.Event.to_bytes event);
+          let event_bytes = T.Event.to_bytes event in
+          Transport_metrics.inc_grpc_bytes_sent
+            ~bytes:(String.length event_bytes);
+          Grpc_eio.Stream.add stream event_bytes;
           incr events_count
         end;
         seq := Int64.add !seq 1L
@@ -512,7 +520,11 @@ let handle_subscribe
         timestamp_ms = now_ms ();
         payload_json = sse_event;
       } in
-      try Grpc_eio.Stream.add stream (T.Event.to_bytes event)
+      try
+        let event_bytes = T.Event.to_bytes event in
+        Transport_metrics.inc_grpc_bytes_sent
+          ~bytes:(String.length event_bytes);
+        Grpc_eio.Stream.add stream event_bytes
       with
       | Eio.Cancel.Cancelled _ as e ->
         cleanup_subscriber ();

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -375,6 +375,8 @@ let metric_ws_client_buffered_bytes = "masc_ws_client_buffered_bytes"
 let metric_ws_client_acks = "masc_ws_client_acks_total"
 let metric_ws_throttled_deliveries = "masc_ws_throttled_deliveries_total"
 let metric_ws_slice_fanout_skipped = "masc_ws_slice_fanout_skipped_total"
+let metric_ws_bytes_sent = "masc_ws_bytes_sent_total"
+let metric_grpc_bytes_sent = "masc_grpc_bytes_sent_total"
 
 (* Admission queue metrics — used in admission_queue_metrics.ml. *)
 let metric_inference_queue_depth = "masc_inference_queue_depth"
@@ -827,6 +829,16 @@ let init () =
     "WS sessions skipped during slice-scoped fanout because their route \
      does not subscribe to the event's slice (gated by \
      MASC_WS_SLICE_INDEX_ENABLED, RFC #10119 Phase 2)"
+    Counter;
+  add metric_ws_bytes_sent
+    "Bytes written to WebSocket clients (frame payload only, includes \
+     dashboard deltas and raw SSE forwards). Capacity-planning input \
+     for bandwidth-burst response."
+    Counter;
+  add metric_grpc_bytes_sent
+    "Bytes serialised into gRPC Subscribe stream events delivered to \
+     subscribers. Same purpose as masc_ws_bytes_sent_total but for the \
+     gRPC transport."
     Counter
 
 let start_time = Time_compat.now ()

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -234,6 +234,8 @@ val metric_ws_client_buffered_bytes : string
 val metric_ws_client_acks : string
 val metric_ws_throttled_deliveries : string
 val metric_ws_slice_fanout_skipped : string
+val metric_ws_bytes_sent : string
+val metric_grpc_bytes_sent : string
 
 (** {1 Admission queue metrics} *)
 

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -156,6 +156,7 @@ let send_frame_bytes session bytes ~len =
     try
       Httpun_ws.Wsd.send_bytes session.wsd
         ~kind:`Text bytes ~off:0 ~len;
+      Transport_metrics.inc_ws_bytes_sent ~bytes:len;
       true
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
@@ -522,15 +523,16 @@ let session_is_backpressured session =
     let limit = client_buffer_limit_bytes () in
     limit > 0 && session.dashboard_last_buffered_amount >= limit
 
-(** RFC #10119 Phase 2 gate.  When enabled, slice-scoped events skip the
-    raw-SSE-forward to authenticated sessions whose route does not
-    subscribe to the event's slice.  Default [false] — Phase 1
-    (#10155) only adds bookkeeping; Phase 2 flips behaviour, so the
-    rollout is staged via this flag.  The env var is read on every
-    fanout call so operators can flip without a restart; the read is
-    cheap (atomic hash lookup in [Env_config_core]). *)
+(** RFC #10119 Phase 2 gate.  When enabled (default since the bandwidth
+    burst hardening pass), slice-scoped events skip the raw-SSE-forward
+    to authenticated sessions whose route does not subscribe to the
+    event's slice.  Catch-all events (no slice mapping) still reach
+    every session.  Set [MASC_WS_SLICE_INDEX_ENABLED=false] only as an
+    emergency rollback.  The env var is read on every fanout call so
+    operators can flip without a restart; the read is cheap (atomic
+    hash lookup in [Env_config_core]). *)
 let slice_index_enabled () =
-  Env_config_core.get_bool ~default:false
+  Env_config_core.get_bool ~default:true
     "MASC_WS_SLICE_INDEX_ENABLED"
 
 let send_dashboard_or_raw_sse session sse_event =

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -86,6 +86,16 @@ let inc_ws_throttled_delivery () =
 let inc_ws_slice_fanout_skipped () =
   Prometheus.inc_counter Prometheus.metric_ws_slice_fanout_skipped ()
 
+let inc_ws_bytes_sent ~bytes =
+  if bytes > 0 then
+    Prometheus.inc_counter Prometheus.metric_ws_bytes_sent
+      ~delta:(float_of_int bytes) ()
+
+let inc_grpc_bytes_sent ~bytes =
+  if bytes > 0 then
+    Prometheus.inc_counter Prometheus.metric_grpc_bytes_sent
+      ~delta:(float_of_int bytes) ()
+
 (** {1 Environment-derived Transport Config} *)
 
 let grpc_runtime_listening : bool Atomic.t = Atomic.make false

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -515,11 +515,13 @@ let test_slice_fanout_skip_counter_metric_registered () =
   let v = read_skip_counter () in
   Alcotest.(check bool) "counter readable (>= 0)" true (v >= 0.0)
 
-let test_slice_fanout_flag_default_is_off () =
+let test_slice_fanout_flag_default_is_on () =
   Eio_main.run (fun _env ->
     with_env_var "MASC_WS_SLICE_INDEX_ENABLED" "" (fun () ->
-        Alcotest.(check bool) "default off"
-          false (Ws.slice_index_enabled ())))
+        (* Bandwidth-burst hardening flipped the default from false to
+           true.  Operators set false only as an emergency rollback. *)
+        Alcotest.(check bool) "default on"
+          true (Ws.slice_index_enabled ())))
 
 let test_slice_fanout_flag_reads_env () =
   Eio_main.run (fun _env ->
@@ -614,8 +616,8 @@ let () =
     ("slice_fanout_gate", [
       Alcotest.test_case "skip counter registered" `Quick
         test_slice_fanout_skip_counter_metric_registered;
-      Alcotest.test_case "flag default is off" `Quick
-        test_slice_fanout_flag_default_is_off;
+      Alcotest.test_case "flag default is on" `Quick
+        test_slice_fanout_flag_default_is_on;
       Alcotest.test_case "flag reads env var" `Quick
         test_slice_fanout_flag_reads_env;
     ]);


### PR DESCRIPTION
Three changes for dashboard-fleet bandwidth burst preparation: (1) MASC_WS_SLICE_INDEX_ENABLED default false→true (RFC #10119 Phase 2 emergency-rollback only via false), (2) masc_ws_bytes_sent_total at send_frame_bytes, (3) masc_grpc_bytes_sent_total at all 4 Stream.add sites. 36/36 tests pass.