### PR TITLE
fix(keeper): type board write tool contract

### DIFF
--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -247,17 +247,28 @@ let dispatch_post_turn_lifecycle_events
 
 let generate_trace_id = Keeper_identity.generate_trace_id
 
-let keeper_board_write_tool_names =
-  [ "keeper_board_post"; "keeper_board_comment"; "keeper_board_vote" ]
+let keeper_board_write_tool_names = Tool_name.Keeper.board_write_tool_names
+
+let keeper_tool_name_matches tool name =
+  match Tool_name.Keeper.of_string name with
+  | Some parsed -> parsed = tool
+  | None -> false
 
 let keeper_write_done tool_names =
-  List.exists (fun name -> List.mem name keeper_board_write_tool_names) tool_names
+  List.exists
+    (fun name ->
+       match Tool_name.Keeper.of_string name with
+       | Some tool -> Tool_name.Keeper.is_board_write tool
+       | None -> false)
+    tool_names
 
 let keeper_action_kind_of_tool_names tool_names =
-  if List.mem "keeper_board_post" tool_names then "post"
-  else if List.mem "keeper_board_comment" tool_names then "comment"
-  else if List.mem "keeper_board_vote" tool_names then "vote"
-  else "none"
+  Tool_name.Keeper.board_write_tools
+  |> List.find_map (fun tool ->
+    if List.exists (keeper_tool_name_matches tool) tool_names then
+      Tool_name.Keeper.board_write_action_kind tool
+    else None)
+  |> Option.value ~default:"none"
 
 let effective_model_labels_for_turn (m : keeper_meta) : string list =
   (* provider filtering now handled by OAS cascade via ~provider_filter *)

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -55,6 +55,11 @@ let usage_has_tokens (usage : Oas.Types.api_usage) =
   || usage.cache_creation_input_tokens > 0
   || usage.cache_read_input_tokens > 0
 
+let is_keeper_board_write_tool_name tool_name =
+  match Tool_name.Keeper.of_string tool_name with
+  | Some tool -> Tool_name.Keeper.is_board_write tool
+  | None -> false
+
 (* #9919: counter for post_tool_use_failure events.
 
    Replaces an earlier [Heuristic_metrics.record] emit that produced
@@ -535,9 +540,6 @@ let make_hooks
     ()
   : Oas.Hooks.hooks =
   let sse_turn_complete = "keeper_turn_complete" in
-  let board_write_tools =
-    [ "keeper_board_post"; "keeper_board_comment"; "keeper_board_vote" ]
-  in
   let tool_start_time = ref 0.0 in
   (* Per-turn tool call counter for SSE enrichment.
      Incremented in post_tool_use, reset in after_turn. *)
@@ -916,7 +918,7 @@ let make_hooks
             | exn ->
               Log.Keeper.error "keeper:%s on_tool_executed callback failed for %s: %s"
                 (!meta_ref).name tool_name (Printexc.to_string exn));
-        if List.mem tool_name board_write_tools then
+        if is_keeper_board_write_tool_name tool_name then
           Log.Keeper.debug "keeper:%s social_event tool=%s"
             (!meta_ref).name tool_name;
         Oas.Hooks.Continue

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -149,6 +149,20 @@ module Keeper = struct
     | "keeper_write" -> Some Write
     | _ -> None
 
+  let board_write_tools = [ Board_post; Board_comment; Board_vote ]
+
+  let board_write_tool_names = List.map to_string board_write_tools
+
+  let is_board_write = function
+    | Board_post | Board_comment | Board_vote -> true
+    | _ -> false
+
+  let board_write_action_kind = function
+    | Board_post -> Some "post"
+    | Board_comment -> Some "comment"
+    | Board_vote -> Some "vote"
+    | _ -> None
+
   let pp fmt t = Format.pp_print_string fmt (to_string t)
 end
 

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -55,6 +55,10 @@ module Keeper : sig
 
   val to_string : t -> string
   val of_string : string -> t option
+  val board_write_tools : t list
+  val board_write_tool_names : string list
+  val is_board_write : t -> bool
+  val board_write_action_kind : t -> string option
   val pp : Format.formatter -> t -> unit
 end
 

--- a/test/test_tool_name.ml
+++ b/test/test_tool_name.ml
@@ -3,13 +3,14 @@
 open Masc_mcp
 
 let all_keeper : Tool_name.Keeper.t list =
-  [ Bash; Board_cleanup; Board_comment; Board_comment_vote; Board_delete
+  [ Bash; Bash_kill; Bash_output; Board_cleanup; Board_comment; Board_comment_vote; Board_delete
   ; Board_get; Board_list; Board_post; Board_search; Board_stats; Board_vote
   ; Broadcast; Code_read; Context_status; Discovery; Fs_edit; Fs_read
   ; Handoff; Library_read; Library_search; Memory_search
   ; Pr_review_comment; Pr_review_read; Pr_review_reply
   ; Preflight_check; Shell; Stay_silent
-  ; Task_claim; Task_create; Task_done; Task_force_done; Task_force_release
+  ; Task_claim; Task_create; Task_done; Task_submit_for_verification
+  ; Task_force_done; Task_force_release
   ; Tasks_audit; Tasks_list; Time_now; Tool_search; Tools_list
   ; Voice_agent; Voice_listen; Voice_session_end; Voice_session_start
   ; Voice_sessions; Voice_speak; Write ]
@@ -135,6 +136,49 @@ let test_unknown_returns_none () =
       None (Tool_name.of_string s)
   ) unknowns
 
+let test_keeper_board_write_helpers () =
+  let open Tool_name.Keeper in
+  Alcotest.(check (list string)) "canonical board write names"
+    [ "keeper_board_post"; "keeper_board_comment"; "keeper_board_vote" ]
+    board_write_tool_names;
+  List.iter
+    (fun tool ->
+       Alcotest.(check bool)
+         (Printf.sprintf "%s is board write" (to_string tool))
+         true
+         (is_board_write tool))
+    board_write_tools;
+  List.iter
+    (fun tool ->
+       Alcotest.(check bool)
+         (Printf.sprintf "%s is not board write" (to_string tool))
+         false
+         (is_board_write tool))
+    [ Board_list; Board_get; Board_comment_vote; Task_done; Write ];
+  Alcotest.(check (option string)) "post action kind"
+    (Some "post") (board_write_action_kind Board_post);
+  Alcotest.(check (option string)) "comment action kind"
+    (Some "comment") (board_write_action_kind Board_comment);
+  Alcotest.(check (option string)) "vote action kind"
+    (Some "vote") (board_write_action_kind Board_vote);
+  Alcotest.(check (option string)) "non-board action kind"
+    None (board_write_action_kind Board_list)
+
+let test_keeper_board_write_facade_uses_typed_contract () =
+  Alcotest.(check (list string)) "exec context names mirror Tool_name"
+    Tool_name.Keeper.board_write_tool_names
+    Keeper_exec_context.keeper_board_write_tool_names;
+  Alcotest.(check bool) "comment is board write" true
+    (Keeper_exec_context.keeper_write_done [ "keeper_board_comment" ]);
+  Alcotest.(check bool) "comment vote is not board write" false
+    (Keeper_exec_context.keeper_write_done [ "keeper_board_comment_vote" ]);
+  Alcotest.(check string) "post has stable priority" "post"
+    (Keeper_exec_context.keeper_action_kind_of_tool_names
+       [ "keeper_board_vote"; "keeper_board_post" ]);
+  Alcotest.(check string) "non-board action kind is none" "none"
+    (Keeper_exec_context.keeper_action_kind_of_tool_names
+       [ "keeper_board_comment_vote"; "unknown" ])
+
 (* ── Group predicates ──────────────────────────────────────── *)
 
 let test_is_keeper () =
@@ -191,6 +235,10 @@ let () =
       Alcotest.test_case "masc_keeper prefix" `Quick test_masc_keeper_prefix;
       Alcotest.test_case "all unique" `Quick test_all_names_unique;
       Alcotest.test_case "unknown -> None" `Quick test_unknown_returns_none;
+      Alcotest.test_case "keeper board write helpers" `Quick
+        test_keeper_board_write_helpers;
+      Alcotest.test_case "keeper board write facade" `Quick
+        test_keeper_board_write_facade_uses_typed_contract;
       Alcotest.test_case "is_keeper" `Quick test_is_keeper;
     ];
     "coverage", [


### PR DESCRIPTION
## Summary
- move keeper board-write tool membership into Tool_name.Keeper typed helpers
- replace duplicated raw string lists in Keeper_exec_context and Keeper_hooks_oas
- extend Tool_name coverage so Bash_kill, Bash_output, and Task_submit_for_verification roundtrip, and pin board-write facade behavior against prefix/substring drift

## Why it matters
This removes another fake-looking string-matching seam from keeper runtime accounting. Board write detection now parses external tool strings once at the Tool_name boundary and uses typed variants internally, so nearby names like keeper_board_comment_vote do not accidentally count as social board writes.

## Validation
- git diff --check
- scripts/dune-local.sh build test/test_tool_name.exe
- ./_build/default/test/test_tool_name.exe
- scripts/dune-local.sh build test/test_keeper_hooks_oas_telemetry.exe
- ./_build/default/test/test_keeper_hooks_oas_telemetry.exe