### PR TITLE
fix(dashboard): surface keeper execution receipts in composite

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -28,6 +28,7 @@ export type {
   KeeperCompositeInvariants,
   KeeperCompositeMeasurement,
   KeeperLastOutcome,
+  KeeperCompositeExecution,
   KeeperCompositePhase,
   KeeperCompositeTurnPhase,
   KeeperCompositeDecisionStage,

--- a/dashboard/src/api/schemas/keeper-composite.test.ts
+++ b/dashboard/src/api/schemas/keeper-composite.test.ts
@@ -77,6 +77,50 @@ describe('parseKeeperCompositeSnapshot', () => {
     expect(result.last_outcome!.selected_model).toBe('claude-sonnet')
   })
 
+  it('parses optional execution receipt summary', () => {
+    const result = parseKeeperCompositeSnapshot({
+      ...VALID_SNAPSHOT,
+      execution: {
+        latest_receipt_present: true,
+        recorded_at: '2026-04-25T05:07:00Z',
+        outcome: 'error',
+        terminal_reason_code: 'config_error',
+        operator_disposition: 'pause_human',
+        operator_disposition_reason: 'tool_required_unsatisfied',
+        model_used: 'claude_code:auto',
+        stop_reason: 'max_turns',
+        tool_contract_result: 'violated',
+        duration_ms: 87736,
+        error: {
+          kind: 'config',
+          message_preview: 'unknown field fallback_cascade',
+          message_truncated: false,
+        },
+        cascade: {
+          name: 'big_three',
+          selected_model: 'claude_code:auto',
+          attempt_count: 2,
+          fallback_applied: true,
+          outcome: 'exhausted',
+          degraded_retry_applied: false,
+          degraded_retry_cascade: null,
+          fallback_reason: 'turn_timeout',
+        },
+        tool_surface: {
+          tool_requirement: 'required',
+          tool_gate_enabled: true,
+          missing_required_tools: ['keeper_task_claim'],
+          required_tools: ['keeper_task_claim'],
+        },
+      },
+    })
+
+    expect(result.execution?.latest_receipt_present).toBe(true)
+    expect(result.execution?.terminal_reason_code).toBe('config_error')
+    expect(result.execution?.cascade?.fallback_reason).toBe('turn_timeout')
+    expect(result.execution?.error?.message_preview).toContain('fallback_cascade')
+  })
+
   it('parses snapshot with measurement auto_rules', () => {
     const result = parseKeeperCompositeSnapshot({
       ...VALID_SNAPSHOT,

--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -28,6 +28,7 @@ import {
   optional,
   picklist,
   string,
+  unknown,
   type BaseIssue,
   type InferOutput,
 } from 'valibot'
@@ -119,6 +120,46 @@ const KeeperLastOutcomeSchema = object({
   selected_model: nullable(string()),
 })
 
+const KeeperCompositeExecutionSchema = object({
+  latest_receipt_present: boolean(),
+  recorded_at: nullable(string()),
+  outcome: nullable(string()),
+  terminal_reason_code: nullable(string()),
+  operator_disposition: nullable(string()),
+  operator_disposition_reason: nullable(string()),
+  model_used: nullable(string()),
+  stop_reason: nullable(string()),
+  tool_contract_result: nullable(string()),
+  duration_ms: nullable(number()),
+  error: nullable(
+    object({
+      kind: nullable(string()),
+      message_preview: nullable(string()),
+      message_truncated: boolean(),
+    }),
+  ),
+  cascade: nullable(
+    object({
+      name: nullable(string()),
+      selected_model: nullable(string()),
+      attempt_count: nullable(number()),
+      fallback_applied: nullable(boolean()),
+      outcome: nullable(string()),
+      degraded_retry_applied: nullable(boolean()),
+      degraded_retry_cascade: nullable(string()),
+      fallback_reason: nullable(string()),
+    }),
+  ),
+  tool_surface: nullable(
+    object({
+      tool_requirement: nullable(string()),
+      tool_gate_enabled: nullable(boolean()),
+      missing_required_tools: array(string()),
+      required_tools: array(string()),
+    }),
+  ),
+})
+
 export const KeeperCompositeSnapshotSchema = object({
   correlation_id: string(),
   run_id: string(),
@@ -143,12 +184,16 @@ export const KeeperCompositeSnapshotSchema = object({
   invariants: KeeperCompositeInvariantsSchema,
   is_live: boolean(),
   last_outcome: nullable(KeeperLastOutcomeSchema),
+  execution: optional(KeeperCompositeExecutionSchema),
+  /** @deprecated kept only for old backend experiments; new payloads use `execution`. */
+  latest_receipt: optional(unknown()),
 })
 
 export type KeeperCompositeSnapshot = InferOutput<typeof KeeperCompositeSnapshotSchema>
 export type KeeperCompositeInvariants = InferOutput<typeof KeeperCompositeInvariantsSchema>
 export type KeeperCompositeMeasurement = InferOutput<typeof KeeperCompositeMeasurementSchema>
 export type KeeperLastOutcome = InferOutput<typeof KeeperLastOutcomeSchema>
+export type KeeperCompositeExecution = InferOutput<typeof KeeperCompositeExecutionSchema>
 export type KeeperCompositePhase = InferOutput<typeof KeeperCompositePhaseSchema>
 export type KeeperCompositeTurnPhase = InferOutput<typeof KeeperCompositeTurnPhaseSchema>
 export type KeeperCompositeDecisionStage = InferOutput<typeof KeeperCompositeDecisionStageSchema>

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -4,6 +4,7 @@ import { InlineSpinner } from './common/inline-spinner'
 
 import {
   fetchKeeperComposite,
+  type KeeperCompositeExecution,
   type KeeperCompositeSnapshot,
 } from '../api/keeper'
 import { fetchGateKeepers } from '../api/gate'
@@ -109,6 +110,66 @@ export function filterKeeperNames(
 
 export function isCompositeFetchNotFound(err: unknown): boolean {
   return err instanceof Error && /composite fetch failed: 404$/.test(err.message)
+}
+
+function shortText(value: string | null | undefined, max = 80): string {
+  const text = (value ?? '').trim()
+  if (!text) return ''
+  return text.length > max ? `${text.slice(0, max)}...` : text
+}
+
+function formatMs(ms: number | null | undefined): string {
+  if (ms == null || !Number.isFinite(ms) || ms < 0) return ''
+  if (ms >= 1000) return `${Math.round(ms / 1000)}s`
+  return `${Math.round(ms)}ms`
+}
+
+function executionReceiptTone(execution: KeeperCompositeExecution | undefined): 'ok' | 'warn' | 'bad' | 'muted' {
+  if (!execution?.latest_receipt_present) return 'muted'
+  const outcome = execution.outcome?.toLowerCase()
+  const terminal = execution.terminal_reason_code?.toLowerCase() ?? ''
+  if (outcome === 'ok' || terminal === 'completed') return 'ok'
+  if (terminal.includes('config') || terminal.includes('exhausted') || outcome === 'error') return 'bad'
+  return 'warn'
+}
+
+function executionReceiptLabel(execution: KeeperCompositeExecution | undefined): string | null {
+  if (!execution) return null
+  if (!execution.latest_receipt_present) return 'receipt 없음'
+  const terminal = shortText(execution.terminal_reason_code, 32)
+  const model = shortText(execution.cascade?.selected_model ?? execution.model_used, 36)
+  const elapsed = formatMs(execution.duration_ms)
+  return [
+    execution.outcome ?? 'unknown',
+    terminal,
+    model,
+    elapsed,
+  ].filter(Boolean).join(' · ')
+}
+
+function executionReceiptTitle(execution: KeeperCompositeExecution | undefined): string {
+  if (!execution?.latest_receipt_present) return '아직 execution receipt가 없습니다.'
+  return [
+    execution.recorded_at ? `recorded_at: ${execution.recorded_at}` : '',
+    execution.operator_disposition ? `operator: ${execution.operator_disposition}` : '',
+    execution.operator_disposition_reason ? `reason: ${execution.operator_disposition_reason}` : '',
+    execution.cascade?.fallback_reason ? `fallback: ${execution.cascade.fallback_reason}` : '',
+    execution.error?.kind ? `error: ${execution.error.kind}` : '',
+    execution.error?.message_preview ? execution.error.message_preview : '',
+  ].filter(Boolean).join('\n')
+}
+
+function executionReceiptClass(execution: KeeperCompositeExecution | undefined): string {
+  switch (executionReceiptTone(execution)) {
+    case 'ok':
+      return 'border-[var(--ok-20)] text-[var(--ok)] bg-[var(--ok-10)]'
+    case 'bad':
+      return 'border-[rgba(248,113,113,0.36)] text-[var(--bad-light)] bg-[rgba(248,113,113,0.08)]'
+    case 'warn':
+      return 'border-[var(--warn-20)] text-[var(--warn)] bg-[var(--warn-10)]'
+    case 'muted':
+      return 'border-[var(--white-8)] text-[var(--text-dim)] bg-[var(--white-3)]'
+  }
 }
 
 // ── State Reducer ──────────────────────────────────────
@@ -651,6 +712,7 @@ function StatusBar({
       ? html`<span class="px-2 py-0.5 rounded-sm border text-3xs font-mono text-[var(--ok)] border-[var(--ok-20)] bg-[var(--ok-10)] animate-pulse">● 실행 중</span>`
       : html`<span class="px-2 py-0.5 rounded-sm border text-3xs font-mono ${idleIsLong ? 'text-[var(--text-muted)] border-[var(--warn-20)]' : 'text-[var(--text-dim)] border-white/10'}">○ 대기 ${idleDuration}${snapshot.last_outcome ? html` <span class="text-4xs opacity-70">· 턴 #${snapshot.last_outcome.turn_id}</span>` : ''}</span>`
     : null
+  const receiptLabel = snapshot ? executionReceiptLabel(snapshot.execution) : null
 
   const staleSec = lastFetchAt > 0 ? Math.max(0, now - lastFetchAt) : 0
 
@@ -694,6 +756,14 @@ function StatusBar({
             ${density === 'compact' ? '▣ 조밀' : '▢ 여유'}
           </button>
           ${liveBadge}
+          ${snapshot && receiptLabel ? html`
+            <span
+              class=${`inline-block max-w-[28rem] truncate align-middle px-2 py-0.5 rounded-sm border text-3xs font-mono ${executionReceiptClass(snapshot.execution)}`}
+              title=${executionReceiptTitle(snapshot.execution)}
+            >
+              receipt ${receiptLabel}
+            </span>
+          ` : null}
           ${loading ? html`<${InlineSpinner} size="xs" />` : null}
           ${paused ? html`
             <span

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -424,15 +424,159 @@ let dashboard_goals_snapshot_json ~(config : Coord.config) : Yojson.Safe.t =
       ("tree", dashboard_goals_tree_http_json ~config);
     ]
 
-let dashboard_fleet_composite_json ~(base_path : string) () : Yojson.Safe.t =
-  let snapshots = Keeper_composite_observer.all_snapshots ~base_path () in
+let compact_preview ~max_chars text =
+  let text = String.trim text in
+  if String.length text <= max_chars then (text, false)
+  else (String.sub text 0 max_chars ^ "...", true)
+
+let json_member key = function
+  | `Assoc fields -> (match List.assoc_opt key fields with Some v -> v | None -> `Null)
+  | _ -> `Null
+
+let json_string key json = Json_util.get_string json key
+let json_int key json = Json_util.get_int json key
+let json_float key json = Json_util.get_float json key
+let json_bool key json = Json_util.get_bool json key
+
+let compact_receipt_error_json receipt =
+  match json_member "error" receipt with
+  | `Assoc _ as error ->
+      let kind = json_string "kind" error in
+      let message = json_string "message" error in
+      let message_preview, message_truncated =
+        match message with
+        | Some value -> compact_preview ~max_chars:900 value
+        | None -> ("", false)
+      in
+      `Assoc
+        [
+          ("kind", Json_util.string_opt_to_json kind);
+          ( "message_preview",
+            match message with
+            | Some _ -> `String message_preview
+            | None -> `Null );
+          ("message_truncated", `Bool message_truncated);
+        ]
+  | _ -> `Null
+
+let compact_receipt_cascade_json receipt =
+  match json_member "cascade" receipt with
+  | `Assoc _ as cascade ->
+      `Assoc
+        [
+          ("name", Json_util.string_opt_to_json (json_string "name" cascade));
+          ( "selected_model",
+            Json_util.string_opt_to_json (json_string "selected_model" cascade) );
+          ( "attempt_count",
+            Json_util.int_opt_to_json (json_int "attempt_count" cascade) );
+          ( "fallback_applied",
+            Json_util.bool_opt_to_json (json_bool "fallback_applied" cascade) );
+          ("outcome", Json_util.string_opt_to_json (json_string "outcome" cascade));
+          ( "degraded_retry_applied",
+            Json_util.bool_opt_to_json (json_bool "degraded_retry_applied" cascade) );
+          ( "degraded_retry_cascade",
+            Json_util.string_opt_to_json
+              (json_string "degraded_retry_cascade" cascade) );
+          ( "fallback_reason",
+            Json_util.string_opt_to_json (json_string "fallback_reason" cascade) );
+        ]
+  | _ -> `Null
+
+let compact_receipt_tool_surface_json receipt =
+  match json_member "tool_surface" receipt with
+  | `Assoc _ as surface ->
+      `Assoc
+        [
+          ( "tool_requirement",
+            Json_util.string_opt_to_json (json_string "tool_requirement" surface)
+          );
+          ( "tool_gate_enabled",
+            Json_util.bool_opt_to_json (json_bool "tool_gate_enabled" surface)
+          );
+          ( "missing_required_tools",
+            Json_util.json_string_list
+              (Json_util.get_string_list surface "missing_required_tools") );
+          ( "required_tools",
+            Json_util.json_string_list
+              (Json_util.get_string_list surface "required_tools") );
+        ]
+  | _ -> `Null
+
+let composite_execution_receipt_json ~(config : Coord.config) ~keeper_name =
+  match Keeper_execution_receipt.latest_json config keeper_name with
+  | None ->
+      `Assoc
+        [
+          ("latest_receipt_present", `Bool false);
+          ("recorded_at", `Null);
+          ("outcome", `Null);
+          ("terminal_reason_code", `Null);
+          ("operator_disposition", `Null);
+          ("operator_disposition_reason", `Null);
+          ("model_used", `Null);
+          ("stop_reason", `Null);
+          ("tool_contract_result", `Null);
+          ("duration_ms", `Null);
+          ("error", `Null);
+          ("cascade", `Null);
+          ("tool_surface", `Null);
+        ]
+  | Some receipt ->
+      let action_radius = json_member "action_radius" receipt in
+      `Assoc
+        [
+          ("latest_receipt_present", `Bool true);
+          ( "recorded_at",
+            Json_util.string_opt_to_json (json_string "recorded_at" receipt) );
+          ("outcome", Json_util.string_opt_to_json (json_string "outcome" receipt));
+          ( "terminal_reason_code",
+            Json_util.string_opt_to_json
+              (json_string "terminal_reason_code" receipt) );
+          ( "operator_disposition",
+            Json_util.string_opt_to_json
+              (json_string "operator_disposition" receipt) );
+          ( "operator_disposition_reason",
+            Json_util.string_opt_to_json
+              (json_string "operator_disposition_reason" receipt) );
+          ( "model_used",
+            Json_util.string_opt_to_json (json_string "model_used" receipt) );
+          ( "stop_reason",
+            Json_util.string_opt_to_json (json_string "stop_reason" receipt) );
+          ( "tool_contract_result",
+            Json_util.string_opt_to_json
+              (json_string "tool_contract_result" receipt) );
+          ( "duration_ms",
+            Json_util.float_opt_to_json (json_float "duration_ms" action_radius) );
+          ("error", compact_receipt_error_json receipt);
+          ("cascade", compact_receipt_cascade_json receipt);
+          ("tool_surface", compact_receipt_tool_surface_json receipt);
+        ]
+
+let enrich_composite_snapshot_json ~(config : Coord.config) ~keeper_name json =
+  match json with
+  | `Assoc fields ->
+      `Assoc
+        (fields
+         @ [
+             ( "execution",
+               composite_execution_receipt_json ~config ~keeper_name );
+           ])
+  | other -> other
+
+let dashboard_keeper_composite_json ~(config : Coord.config)
+    (entry : Keeper_registry.registry_entry) : Yojson.Safe.t =
+  Keeper_composite_observer.observe entry
+  |> Keeper_composite_observer.snapshot_to_json
+  |> enrich_composite_snapshot_json ~config ~keeper_name:entry.name
+
+let dashboard_fleet_composite_json ~(config : Coord.config) () : Yojson.Safe.t =
+  let entries = Keeper_registry.all ~base_path:config.base_path () in
+  let snapshots = List.map (dashboard_keeper_composite_json ~config) entries in
   `Assoc
     [
       ("generated_at", `Float (Unix.gettimeofday ()));
       ("count", `Int (List.length snapshots));
-      ( "snapshots",
-        `List (List.map Keeper_composite_observer.snapshot_to_json snapshots)
-      );
+      ("snapshots", `List snapshots);
     ]
 
 let dashboard_goal_detail_http_json ~(config : Coord.config) ~goal_id :

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1556,9 +1556,9 @@ let handle_keeper_get_subroutes state req request reqd =
 
        Consumed by [dashboard/src/components/fleet-fsm-matrix.ts]
        (LT-16b, upcoming). *)
-    let base_path = state.Mcp_server.room_config.base_path in
     let json =
-      Server_dashboard_http.dashboard_fleet_composite_json ~base_path ()
+      Server_dashboard_http.dashboard_fleet_composite_json
+        ~config:state.Mcp_server.room_config ()
     in
     Http.Response.json ~compress:true ~request:req
       (Yojson.Safe.to_string json) reqd
@@ -1577,10 +1577,10 @@ let handle_keeper_get_subroutes state req request reqd =
          Http.Response.json ~status:`Not_found
            (Printf.sprintf {|{"error":"keeper %S not registered"}|} name) reqd
        | Some entry ->
-         let snapshot =
-           Keeper_composite_observer.observe entry
+         let json =
+           Server_dashboard_http.dashboard_keeper_composite_json
+             ~config:state.Mcp_server.room_config entry
          in
-         let json = Keeper_composite_observer.snapshot_to_json snapshot in
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd)
   else if req_path = prefix ^ "regime" then

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1402,7 +1402,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
         | "composite" ->
             Some
               (Server_dashboard_http.dashboard_fleet_composite_json
-                 ~base_path:state.Mcp_server.room_config.base_path ())
+                 ~config:state.Mcp_server.room_config ())
         | "board" ->
             Some
               (Server_dashboard_http.dashboard_board_json

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -1208,6 +1208,50 @@ let test_execution_trust_route_surfaces_trust_summary_fields () =
      | _ -> false)
 ;;
 
+let test_composite_routes_surface_latest_execution_receipt () =
+  with_seeded_server
+  @@ fun ~port ~config ~admin_token ~keeper_name ->
+  let boot_path = Printf.sprintf "/api/v1/keepers/%s/boot" keeper_name in
+  let boot_result =
+    run_curl_post ~body:"{}" ~token:admin_token ~port ~path:boot_path ()
+  in
+  require_status "boot route registers keeper before composite read" 200 boot_result;
+  append_execution_receipt config ~keeper_name;
+  let per_keeper_path =
+    Printf.sprintf "/api/v1/keepers/%s/composite" keeper_name
+  in
+  let per_keeper = run_curl_get ~port ~path:per_keeper_path () in
+  require_status "per-keeper composite GET returns 200" 200 per_keeper;
+  let open Yojson.Safe.Util in
+  let per_keeper_json = Yojson.Safe.from_string per_keeper.body in
+  let execution = per_keeper_json |> member "execution" in
+  check bool "composite exposes latest receipt presence" true
+    (execution |> member "latest_receipt_present" |> to_bool);
+  check string "composite exposes terminal reason" "completed"
+    (execution |> member "terminal_reason_code" |> to_string);
+  check bool "composite exposes receipt duration" true
+    (match execution |> member "duration_ms" with
+     | `Float _ | `Int _ -> true
+     | _ -> false);
+  check string "composite exposes cascade fallback reason" "turn_timeout"
+    (execution |> member "cascade" |> member "fallback_reason" |> to_string);
+  check int "composite exposes provider attempt count" 2
+    (execution |> member "cascade" |> member "attempt_count" |> to_int);
+  let fleet = run_curl_get ~port ~path:"/api/v1/keepers/composite" () in
+  require_status "fleet composite GET returns 200" 200 fleet;
+  let fleet_json = Yojson.Safe.from_string fleet.body in
+  let fleet_snapshot =
+    match fleet_json |> member "snapshots" |> to_list with
+    | snapshot :: _ -> snapshot
+    | [] -> fail "expected at least one fleet composite snapshot"
+  in
+  let fleet_execution = fleet_snapshot |> member "execution" in
+  check bool "fleet composite exposes latest receipt presence" true
+    (fleet_execution |> member "latest_receipt_present" |> to_bool);
+  check string "fleet composite exposes selected model" "custom:mock"
+    (fleet_execution |> member "cascade" |> member "selected_model" |> to_string)
+;;
+
 let test_merge_keeper_trace_lines_includes_internal_history () =
   let base_path = Filename.temp_file "dashboard-keeper-trajectory-" "" in
   (try Sys.remove base_path with
@@ -1388,6 +1432,10 @@ let () =
             "execution trust route surfaces trust summary fields"
             `Slow
             test_execution_trust_route_surfaces_trust_summary_fields
+        ; test_case
+            "composite routes surface latest execution receipt"
+            `Slow
+            test_composite_routes_surface_latest_execution_receipt
         ; test_case
             "dashboard dev token rotates legacy dashboard-dev owner"
             `Quick


### PR DESCRIPTION
## Summary
- enrich keeper composite API responses with compact latest execution receipt summaries
- show receipt outcome/terminal reason/duration/fallback/error preview in the FSM Hub
- keep fleet polling bounded by truncating long receipt error messages

## Why it matters
Operators were seeing keepers as Running/idle/done while the actual blocker lived only in execution receipts, for example config materialization failures, max-turn/cascade exhaustion, timeout fallback, or tool contract failures. This makes the composite dashboard answer why a keeper is stuck or slow without tailing logs.

## Verification
- scripts/dune-local.sh build test/test_dashboard_keeper_routes.exe bin/main_eio.exe
- ./_build/default/test/test_dashboard_keeper_routes.exe
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- pnpm --dir dashboard exec vitest run src/api/schemas/keeper-composite.test.ts src/components/fsm-hub.test.ts --no-file-parallelism --maxWorkers=1
- live 8935: /api/v1/keepers/composite status=200 time_total=0.010452, execution field present for all 14 snapshots
- live 8935: /api/v1/dashboard/shell status=200 time_total=0.012330