### PR TITLE
fix(kimi-cli): source context window from OAS SSOT

### DIFF
--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -377,6 +377,12 @@ val filter_healthy :
 
 (** {1 Context Window Resolution} *)
 
+(** Resolve the Kimi context window from the OAS capability SSOT.
+
+    This is shared by cascade profile generation and Kimi CLI transport config
+    so those paths do not drift through local "256k" constants. *)
+val resolve_kimi_max_context : string -> int
+
 (** Effective max context tokens for a provider entry.
 
     Returns [caps.max_context_tokens] when known (per-model), otherwise

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -141,6 +141,9 @@ let kimi_mcp_config_json_of_policy =
 let kimi_cli_model_for_provider =
   Oas_worker_exec_transport.kimi_cli_model_for_provider
 
+let kimi_cli_config_json_for_provider =
+  Oas_worker_exec_transport.kimi_cli_config_json_for_provider
+
 let provider_supports_inline_tools =
   Oas_worker_exec_transport.provider_supports_inline_tools
 

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -446,6 +446,7 @@ let kimi_cli_config_json_for_provider
   match kimi_cli_model_for_provider provider_cfg, kimi_cli_auth_value provider_cfg with
   | Some model_name, Some _ ->
       let provider_name = "masc-kimi" in
+      let max_context_size = Cascade_config.resolve_kimi_max_context model_name in
       let config_json =
         `Assoc
           [
@@ -469,7 +470,7 @@ let kimi_cli_config_json_for_provider
                       [
                         ("provider", `String provider_name);
                         ("model", `String model_name);
-                        ("max_context_size", `Int 262144);
+                        ("max_context_size", `Int max_context_size);
                       ] );
                 ] );
           ]

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -2196,6 +2196,28 @@ let test_kimi_cli_model_for_provider_keeps_explicit_model () =
     (Some "kimi-k2.5")
     (Oas_worker_exec.kimi_cli_model_for_provider provider_cfg)
 
+let test_kimi_cli_config_uses_oas_context_ssot () =
+  let model_id = "kimi-for-coding" in
+  let provider_cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.Kimi_cli
+      ~model_id
+      ~base_url:""
+      ~api_key:"test-key" ()
+  in
+  match Oas_worker_exec.kimi_cli_config_json_for_provider provider_cfg with
+  | None -> Alcotest.fail "expected kimi_cli config json"
+  | Some raw ->
+      let json = _parse_json raw in
+      let actual =
+        Yojson.Safe.Util.(
+          json |> member "models" |> member model_id
+          |> member "max_context_size" |> to_int)
+      in
+      let expected = Cascade_config.resolve_kimi_max_context model_id in
+      Alcotest.(check int) "max_context_size from OAS capabilities SSOT"
+        expected actual
+
 let test_kimi_cli_should_log_stderr_line_filters_resume_noise () =
   let should_log =
     Oas_worker_exec.Kimi_cli_transport_local.should_log_stderr_line
@@ -3654,6 +3676,8 @@ let () =
         test_kimi_cli_model_for_provider_keeps_transport_default_on_auto;
       Alcotest.test_case "kimi explicit model is preserved" `Quick
         test_kimi_cli_model_for_provider_keeps_explicit_model;
+      Alcotest.test_case "kimi config max context uses OAS SSOT" `Quick
+        test_kimi_cli_config_uses_oas_context_ssot;
       Alcotest.test_case "kimi stderr resume noise is filtered" `Quick
         test_kimi_cli_should_log_stderr_line_filters_resume_noise;
       Alcotest.test_case "kimi exit 75 detail is redacted" `Quick


### PR DESCRIPTION
## Summary

Fixes a remaining #9953 context-window drift path in Kimi CLI transport config.

- exposes the existing `Cascade_config.resolve_kimi_max_context` SSOT resolver through the interface
- uses that resolver when emitting Kimi CLI `max_context_size`
- adds an `Oas_worker_exec` regression test that parses the generated Kimi CLI config JSON and checks the value against the OAS capability SSOT

This follows the earlier #9970 cascade fix: cascade Kimi config was already SSOT-backed, but the OAS worker transport still had a local `262144` literal.

## Verification

- `git diff --check`
- `env DUNE_BUILD_DIR=_build_verify_9953_kimi_cli DUNE_JOBS=2 scripts/dune-local.sh build test/test_oas_worker.exe`
- `env DUNE_BUILD_DIR=_build_verify_9953_kimi_cli MASC_BASE_PATH=/tmp/masc-test-9953-kimi-cli _build_verify_9953_kimi_cli/default/test/test_oas_worker.exe` -> 114 tests

After rebasing onto latest `origin/main`, `git diff --check HEAD~1..HEAD` is clean. A duplicate post-rebase local build was stopped because other worktrees were holding the shared Dune lock; PR CI should be the head verification surface.
