### PR TITLE
feat(observability): per-keeper semaphore wait timeout counter (#9771)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -357,6 +357,14 @@ let rec wait_for_autonomous_queue_head ~(keeper_name : string) ~(ticket : int)
       Log.Keeper.info
         "semaphore_wait: autonomous fairness queue wait exceeded %.0fs (keeper=%s ahead=%d), skipping turn"
         semaphore_wait_timeout_sec keeper_name ahead;
+      (* #9771: surface the timeout as a fleet-wide metric so
+         operators can detect chronic slot starvation without
+         scraping the WARN log. *)
+      Prometheus.inc_counter
+        Prometheus.metric_keeper_semaphore_wait_timeout
+        ~labels:[ ("keeper", keeper_name);
+                  ("channel", "autonomous_queue_head") ]
+        ();
       Error (`Semaphore_wait_timeout semaphore_wait_timeout_sec)
     else (
       (match Eio_context.get_clock_opt () with
@@ -419,6 +427,14 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
            skipping turn"
           label semaphore_wait_timeout_sec
           channel_label;
+        (* #9771: per-keeper × per-acquire-channel counter so
+           operators can attribute slot starvation to autonomous
+           vs turn semaphore pressure. *)
+        Prometheus.inc_counter
+          Prometheus.metric_keeper_semaphore_wait_timeout
+          ~labels:[ ("keeper", keeper_name);
+                    ("channel", label) ]
+          ();
         Error (`Semaphore_wait_timeout semaphore_wait_timeout_sec))
     | None ->
       (* No Eio clock available: we are running outside an Eio main loop

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -292,6 +292,24 @@ let metric_keeper_supervisor_last_sweep_unixtime =
 let metric_tool_join_required_guard =
   "masc_tool_join_required_guard_total"
 
+(* #9771: keeper turn-slot semaphore wait timeout counter.
+
+   Production observed multiple keepers ([sangsu], [janitor],
+   [ramarama], [qa-king], [taskmaster]) repeatedly skipping turns
+   with [semaphore wait > 60s, peers holding slot] — peers holding
+   the slot for a long-running OAS call (276s-963s observed) ran
+   past the 60s wait budget, every waiting keeper timed out, and
+   the WARN log was the only signal.
+
+   Three observable channels at which the timeout fires:
+     - [autonomous_queue_head]: fairness-FIFO head wait exceeded
+     - [autonomous]: autonomous-track semaphore acquire timed out
+     - [turn]: shared turn semaphore acquire timed out
+
+   Labels: [keeper, channel].  Cardinality = ~10 keepers × 3
+   channels = ~30 series, well within Prometheus best practice. *)
+let metric_keeper_semaphore_wait_timeout =
+  "masc_keeper_semaphore_wait_timeout_total"
 
 (* Keeper compaction (keeper_compact_policy.ml, tool_keeper.ml). *)
 let metric_keeper_compactions = "masc_keeper_compactions_total"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -112,6 +112,11 @@ val metric_tool_join_required_guard : string
     [tool, agent_name, reason] with reason
     [room_uninitialized | agent_not_joined]. *)
 
+val metric_keeper_semaphore_wait_timeout : string
+(** #9771: counter for keeper turn-slot semaphore wait timeouts.
+    Labels: [keeper, channel] with channel in
+    [autonomous_queue_head | autonomous | turn]. *)
+
 val metric_keeper_compactions : string
 val metric_keeper_compaction_ratio_change : string
 val metric_keeper_compaction_saved_tokens : string

--- a/test/dune
+++ b/test/dune
@@ -343,6 +343,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_keeper_semaphore_wait_counter)
+ (modules test_keeper_semaphore_wait_counter)
+ (libraries masc_test_deps))
+
+(test
  (name test_fsm_drift_per_agent_counter)
  (modules test_fsm_drift_per_agent_counter)
  (libraries masc_test_deps))

--- a/test/test_keeper_semaphore_wait_counter.ml
+++ b/test/test_keeper_semaphore_wait_counter.ml
@@ -1,0 +1,87 @@
+(* #9771: pin canonical metric name + label vocabulary for the
+   semaphore wait timeout counter.  The keepalive path emits this
+   counter at three sites:
+     - [autonomous_queue_head]: fairness FIFO head wait exceeded
+     - [autonomous]: autonomous-track semaphore acquire timeout
+     - [turn]: shared turn semaphore acquire timeout
+
+   Test exercises the counter directly so the metric vocabulary
+   is pinned independently of the surrounding Eio + semaphore
+   plumbing. *)
+
+let counter_for ~keeper ~channel =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    Masc_mcp.Prometheus.metric_keeper_semaphore_wait_timeout
+    ~labels:[
+      ("keeper", keeper);
+      ("channel", channel);
+    ]
+    ()
+
+let test_metric_name_stable () =
+  Alcotest.(check string)
+    "semaphore wait timeout canonical metric name"
+    "masc_keeper_semaphore_wait_timeout_total"
+    Masc_mcp.Prometheus.metric_keeper_semaphore_wait_timeout
+
+let test_increments_per_channel () =
+  let keeper = "sangsu-test-9771" in
+  let channels =
+    [ "autonomous_queue_head"; "autonomous"; "turn" ]
+  in
+  List.iter
+    (fun channel ->
+      let before = counter_for ~keeper ~channel in
+      Masc_mcp.Prometheus.inc_counter
+        Masc_mcp.Prometheus.metric_keeper_semaphore_wait_timeout
+        ~labels:[ ("keeper", keeper); ("channel", channel) ]
+        ();
+      Alcotest.(check (float 0.0001))
+        (Printf.sprintf "%s +1" channel)
+        (before +. 1.0)
+        (counter_for ~keeper ~channel))
+    channels
+
+let test_keeper_isolation () =
+  (* Different keepers must land in different series. *)
+  let channel = "autonomous" in
+  let keeper_a = "alpha-9771" in
+  let keeper_b = "beta-9771" in
+  let before_a = counter_for ~keeper:keeper_a ~channel in
+  Masc_mcp.Prometheus.inc_counter
+    Masc_mcp.Prometheus.metric_keeper_semaphore_wait_timeout
+    ~labels:[ ("keeper", keeper_b); ("channel", channel) ]
+    ();
+  Alcotest.(check (float 0.0001))
+    "alpha unaffected by beta"
+    before_a
+    (counter_for ~keeper:keeper_a ~channel)
+
+let test_channel_isolation () =
+  (* Different channels for the same keeper must not bleed. *)
+  let keeper = "channel-iso-9771" in
+  let before_turn = counter_for ~keeper ~channel:"turn" in
+  Masc_mcp.Prometheus.inc_counter
+    Masc_mcp.Prometheus.metric_keeper_semaphore_wait_timeout
+    ~labels:[ ("keeper", keeper); ("channel", "autonomous_queue_head") ]
+    ();
+  Alcotest.(check (float 0.0001))
+    "turn channel unchanged when queue_head fires"
+    before_turn
+    (counter_for ~keeper ~channel:"turn")
+
+let () =
+  Alcotest.run "keeper_semaphore_wait_counter_9771" [
+    "metric_name", [
+      Alcotest.test_case "canonical name stable" `Quick
+        test_metric_name_stable;
+    ];
+    "counter", [
+      Alcotest.test_case "all 3 channels increment" `Quick
+        test_increments_per_channel;
+    ];
+    "isolation", [
+      Alcotest.test_case "keepers isolated" `Quick test_keeper_isolation;
+      Alcotest.test_case "channels isolated" `Quick test_channel_isolation;
+    ];
+  ]


### PR DESCRIPTION
## 요약

`masc_keeper_semaphore_wait_timeout_total{keeper, channel}` Prometheus counter 추가. 60s wait budget이 OAS turn 길이(276-963s)를 못 따라가 발생하는 fleet-wide slot starvation을 metric으로 추적 가능.

Closes part of #9771 (observability for slot starvation).

## 근본 원인

이슈 보고: 5+ keepers (sangsu, janitor, ramarama, qa-king, taskmaster)가 반복적으로 `semaphore wait > 60s` 발화. 60s wait timeout은 60s. 그러나 OAS turn은 276-963s 관찰됨. 한 keeper가 long turn 잡고 있으면 모든 대기 keeper 60s 대기 후 timeout, skip turn → cascading backlog.

기존 신호:
- INFO log at acquire site (line 357, 417)
- WARN log at caller (line 1473)
- Prometheus metric: 없음

운영 측면:
- "어느 keeper가 가장 자주 starve되나?" — log scraping 외 답할 수 없음
- "autonomous vs turn 채널 어디 contention 심한가?" — 답할 수 없음
- "wait budget 늘리면 rate 줄어드나?" — pre/post 측정 불가

## 변경 내용

### `lib/prometheus.{ml,mli}`

```ocaml
let metric_keeper_semaphore_wait_timeout =
  "masc_keeper_semaphore_wait_timeout_total"
```

Labels: `(keeper, channel)` where channel ∈ `{autonomous_queue_head, autonomous, turn}`.

### `lib/keeper/keeper_keepalive.ml` 3 emit sites

```diff
  (* Site 1: autonomous queue head fairness wait *)
  Log.Keeper.info "semaphore_wait: autonomous fairness queue ..."
+ Prometheus.inc_counter
+   Prometheus.metric_keeper_semaphore_wait_timeout
+   ~labels:[ ("keeper", keeper_name); ("channel", "autonomous_queue_head") ] ();
  Error (`Semaphore_wait_timeout ...)

  (* Site 2: acquire_bounded ~label:"autonomous" *)
  Log.Keeper.info "semaphore_wait: %s semaphore wait exceeded ..." label ...
+ Prometheus.inc_counter
+   Prometheus.metric_keeper_semaphore_wait_timeout
+   ~labels:[ ("keeper", keeper_name); ("channel", label) ] ();
  Error (`Semaphore_wait_timeout ...)
```

`label` 변수는 acquire_bounded 호출자가 `"autonomous"` 또는 `"turn"` 전달 → channel label로 직접 사용.

## 카디널리티

| 차원 | 크기 |
|------|------|
| keeper | ~10 (fleet 크기) |
| channel | 3 (`autonomous_queue_head`, `autonomous`, `turn`) |
| **총 series** | ~30 |

30 series는 안전.

## 운영 활용

```promql
# 가장 starve되는 keeper ranking
sort_desc(
  sum by (keeper) (
    rate(masc_keeper_semaphore_wait_timeout_total[5m])
  )
)

# 채널별 contention 분포 (autonomous vs turn vs queue head)
sum by (channel) (rate(masc_keeper_semaphore_wait_timeout_total[5m]))

# Wait budget 변경 전후 비교
masc_keeper_semaphore_wait_timeout_total
```

## 테스트

`test/test_keeper_semaphore_wait_counter.ml` 4 scenario:

```bash
$ dune exec test/test_keeper_semaphore_wait_counter.exe
[OK]  metric_name  0  canonical name stable.
[OK]  counter      0  all 3 channels increment.
[OK]  isolation    0  keepers isolated.
[OK]  isolation    1  channels isolated.
Test Successful in 0.001s. 4 tests run.
```

## 회귀 리스크

매우 낮음. Pure additive — emit 3개 추가, control flow 동일, INFO log/Error return 그대로.

## 후속 (별건)

- **Wait budget tuning**: 본 counter rate 측정 후 60s → 120s/180s 변경 검토. OAS turn ceiling과 align.
- **Capacity increase**: Autonomous slot 수 (현재 N) 늘리면 contention 감소. 그러나 LLM 동시 호출 비용/quota 영향. metric으로 ROI 평가.
- **Per-keeper turn duration histogram**: 본 counter는 wait timeout만 측정. 어느 keeper가 long turn 만드는지 별도 metric 필요. #9943의 turn latency bucket과 cross-reference.

## 참고

- Issue #9771
- `lib/keeper/keeper_keepalive.ml:357-371` (queue head emit), `:417-435` (acquire_bounded emit)
- `lib/prometheus.ml:268-285` (metric def)
- `test/test_keeper_semaphore_wait_counter.ml` (coverage)
- 관련: #9933 (oas_timeout_budget), #9943 (turn latency), #9769 (timeout-leaked semaphore inconsistency)
