### PR TITLE
refactor(sse): purge dead push callback (legacy direct-push)

### DIFF
--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -572,15 +572,8 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
           let writer = Httpun.Reqd.respond_with_streaming reqd response in
           let mutex = Eio.Mutex.create () in
           let info_ref : sse_conn_info option ref = ref None in
-          let push event =
-            match !info_ref with
-            | None -> ()
-            | Some info ->
-                if not (send_raw info event) then
-                  Log.Server.debug "SSE push failed for session %s" info.session_id
-          in
           let client_id, event_stream, evicted =
-            Sse.register ~kind:sse_kind session_id ~push
+            Sse.register ~kind:sse_kind session_id
               ~last_event_id:(Option.value ~default:0 last_event_id)
           in
           (match evicted with

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -54,15 +54,8 @@ let handle_ag_ui_events ~deps request reqd =
       let writer = Httpun.Reqd.respond_with_streaming reqd response in
       let mutex = Eio.Mutex.create () in
       let info_ref : sse_conn_info option ref = ref None in
-      let push event =
-        match !info_ref with
-        | None -> ()
-        | Some info ->
-            if not (send_raw info (ag_ui_event_of_masc_event event)) then
-              Log.Server.debug "ag-ui push failed for session %s" info.session_id
-      in
       let client_id, event_stream, evicted =
-        Sse.register session_id ~push
+        Sse.register session_id
           ~last_event_id:(Option.value ~default:0 last_event_id)
       in
       (match evicted with

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -62,7 +62,6 @@ type client = {
   id: int;
   kind: session_kind;
   event_stream: string Eio.Stream.t;
-  push: string -> unit;  (** legacy direct-push callback (used by drain) *)
   last_event_id: int Atomic.t;
   created_at: float;
   last_seen_at: float Atomic.t;
@@ -267,7 +266,7 @@ let next_id () =
     capacity.  The client stream/id are allocated once; map installation
     is linearized via CAS over the immutable registry state.
     [kind] defaults to [Coordinator] for backward compatibility. *)
-let register ?(kind = Coordinator) session_id ~push ~last_event_id =
+let register ?(kind = Coordinator) session_id ~last_event_id =
   let client_id = Atomic.fetch_and_add client_id_counter 1 + 1 in
   let last_event_id = Atomic.make last_event_id in
   let event_stream = Eio.Stream.create stream_capacity in
@@ -275,7 +274,6 @@ let register ?(kind = Coordinator) session_id ~push ~last_event_id =
     id = client_id;
     kind;
     event_stream;
-    push;
     last_event_id;
     created_at = 0.0;
     last_seen_at = Atomic.make 0.0;

--- a/lib/sse.mli
+++ b/lib/sse.mli
@@ -22,7 +22,6 @@ type client = {
   id : int;
   kind : session_kind;
   event_stream : string Eio.Stream.t;
-  push : string -> unit;
   last_event_id : int Atomic.t;
   created_at : float;
   last_seen_at : float Atomic.t;
@@ -50,7 +49,7 @@ val buffer_ttl_seconds : float
 (** {1 Session Management} *)
 
 val register :
-  ?kind:session_kind -> string -> push:(string -> unit) -> last_event_id:int ->
+  ?kind:session_kind -> string -> last_event_id:int ->
   int * string Eio.Stream.t * string option
 val unregister : string -> unit
 val unregister_if_current : string -> int -> unit

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -289,9 +289,9 @@ let test_oas_sse_bridge_broadcasts_lifecycle_to_observers () =
       try
         Eio.Switch.run (fun sw ->
             ignore (Masc_mcp.Sse.register ~kind:Masc_mcp.Sse.Observer
-                      "observer-lifecycle" ~push:(fun _ -> ()) ~last_event_id:0);
+                      "observer-lifecycle" ~last_event_id:0);
             ignore (Masc_mcp.Sse.register ~kind:Masc_mcp.Sse.Coordinator
-                      "coordinator-lifecycle" ~push:(fun _ -> ()) ~last_event_id:0);
+                      "coordinator-lifecycle" ~last_event_id:0);
             Oas_sse_bridge.start_with_interval ~drain_interval_s:0.1
               ~sw ~clock:(Eio.Stdenv.clock env) ~config ~bus;
             Oas_events.publish_keeper_lifecycle bus
@@ -328,7 +328,7 @@ let test_oas_sse_bridge_retries_append_failure_then_recovers () =
       try
         Eio.Switch.run (fun sw ->
             ignore (Masc_mcp.Sse.register ~kind:Masc_mcp.Sse.Observer
-                      "observer-retry" ~push:(fun _ -> ()) ~last_event_id:0);
+                      "observer-retry" ~last_event_id:0);
             Oas_sse_bridge.start_with_interval ~drain_interval_s:0.1
               ~sw ~clock:(Eio.Stdenv.clock env) ~config ~bus;
             Event_bus.publish bus
@@ -373,7 +373,7 @@ let test_oas_sse_bridge_drop_marker_on_exhausted_append_failure () =
       try
         Eio.Switch.run (fun sw ->
             ignore (Masc_mcp.Sse.register ~kind:Masc_mcp.Sse.Observer
-                      "observer-drop" ~push:(fun _ -> ()) ~last_event_id:0);
+                      "observer-drop" ~last_event_id:0);
             Oas_sse_bridge.start_with_interval ~drain_interval_s:0.1
               ~sw ~clock:(Eio.Stdenv.clock env) ~config ~bus;
             Event_bus.publish bus

--- a/test/test_sse.ml
+++ b/test/test_sse.ml
@@ -21,13 +21,13 @@ let run_domains_together count fn =
 let test_unregister_if_current () =
   let open Masc_mcp.Sse in
   let session_id = "test_session" in
-  let noop _ = () in
+  let _noop _ = () in
 
-  let (id1, _, _) = register session_id ~push:noop ~last_event_id:0 in
+  let (id1, _, _) = register session_id ~last_event_id:0 in
   check bool "registered" true (exists session_id);
 
   (* Re-register same session_id (simulates reconnect) *)
-  let (id2, _, _) = register session_id ~push:noop ~last_event_id:0 in
+  let (id2, _, _) = register session_id ~last_event_id:0 in
   check bool "still registered" true (exists session_id);
 
   (* Old connection cleanup must not unregister the new connection *)
@@ -43,9 +43,9 @@ let test_cleanup_stale_respects_touch () =
   let open Masc_mcp.Sse in
   let stale_sid = "stale_session_" ^ string_of_int (Random.int 1000000) in
   let alive_sid = "alive_session_" ^ string_of_int (Random.int 1000000) in
-  let noop _ = () in
-  let (_id1, _, _) = register stale_sid ~push:noop ~last_event_id:0 in
-  let (_id2, _, _) = register alive_sid ~push:noop ~last_event_id:0 in
+  let _noop _ = () in
+  let (_id1, _, _) = register stale_sid ~last_event_id:0 in
+  let (_id2, _, _) = register alive_sid ~last_event_id:0 in
 
   Unix.sleepf 0.05;
   touch alive_sid;
@@ -63,7 +63,7 @@ let test_concurrent_register_unregister () =
   let open Masc_mcp.Sse in
   let n = 50 in
   let prefix = "conc_" ^ string_of_int (Random.int 1000000) ^ "_" in
-  let noop _ = () in
+  let _noop _ = () in
   let count_before = client_count () in
   (* N fibers register, then unregister concurrently.
      Switch.run waits for all forked fibers before returning. *)
@@ -71,7 +71,7 @@ let test_concurrent_register_unregister () =
     for i = 0 to n - 1 do
       Eio.Fiber.fork ~sw (fun () ->
         let sid = prefix ^ string_of_int i in
-        let (_id, _, _) = register sid ~push:noop ~last_event_id:0 in
+        let (_id, _, _) = register sid ~last_event_id:0 in
         Eio.Fiber.yield ();
         unregister sid)
     done);
@@ -83,7 +83,7 @@ let test_client_count_linearized_under_domain_contention () =
   let open Masc_mcp.Sse in
   let worker_count = 24 in
   let prefix = "count_linearized_" ^ string_of_int (Random.int 1_000_000) ^ "_" in
-  let noop _ = () in
+  let _noop _ = () in
   let session_id index = prefix ^ string_of_int index in
   let count_before = client_count () in
   Fun.protect
@@ -93,7 +93,7 @@ let test_client_count_linearized_under_domain_contention () =
       done)
     (fun () ->
       run_domains_together worker_count (fun index ->
-        ignore (register (session_id index) ~push:noop ~last_event_id:0));
+        ignore (register (session_id index) ~last_event_id:0));
       check int "count after concurrent register" (count_before + worker_count)
         (client_count ());
       run_domains_together worker_count (fun index ->

--- a/test/test_sse_coverage.ml
+++ b/test/test_sse_coverage.ml
@@ -94,15 +94,15 @@ let test_next_id_sequential () =
 
 let test_register_creates_client () =
   let session_id = "test_register_" ^ string_of_int (Random.int 10000) in
-  let push _ = () in
-  let (_id, _, _) = Sse.register session_id ~push ~last_event_id:0 in
+  let _push _ = () in
+  let (_id, _, _) = Sse.register session_id ~last_event_id:0 in
   check bool "exists after register" true (Sse.exists session_id);
   Sse.unregister session_id
 
 let test_unregister_removes_client () =
   let session_id = "test_unregister_" ^ string_of_int (Random.int 10000) in
-  let push _ = () in
-  let (_id, _, _) = Sse.register session_id ~push ~last_event_id:0 in
+  let _push _ = () in
+  let (_id, _, _) = Sse.register session_id ~last_event_id:0 in
   Sse.unregister session_id;
   check bool "not exists after unregister" false (Sse.exists session_id)
 
@@ -112,16 +112,16 @@ let test_exists_false_for_unknown () =
 let test_register_returns_unique_id () =
   let session1 = "test_unique1_" ^ string_of_int (Random.int 10000) in
   let session2 = "test_unique2_" ^ string_of_int (Random.int 10000) in
-  let push _ = () in
-  let (id1, _, _) = Sse.register session1 ~push ~last_event_id:0 in
-  let (id2, _, _) = Sse.register session2 ~push ~last_event_id:0 in
+  let _push _ = () in
+  let (id1, _, _) = Sse.register session1 ~last_event_id:0 in
+  let (id2, _, _) = Sse.register session2 ~last_event_id:0 in
   check bool "unique ids" true (id1 <> id2);
   Sse.unregister session1;
   Sse.unregister session2
 
 let test_register_uses_successful_commit_time_after_retry () =
   let session_id = "register_retry_" ^ string_of_int (Random.int 10000) in
-  let push _ = () in
+  let _push _ = () in
   let original_hook = Atomic.get Sse.register_commit_test_hook in
   let forced_retry = Atomic.make false in
   let retry_barrier = ref 0.0 in
@@ -142,7 +142,7 @@ let test_register_uses_successful_commit_time_after_retry () =
              ignore (Unix.select [] [] [] 0.02);
              retry_barrier := Unix.gettimeofday ()
            end));
-      ignore (Sse.register session_id ~push ~last_event_id:0);
+      ignore (Sse.register session_id ~last_event_id:0);
       check bool "forced retry triggered" true (Atomic.get forced_retry);
       match Sse.SMap.find_opt session_id (Atomic.get Sse.clients).entries with
       | Some client ->
@@ -163,8 +163,8 @@ let test_client_count_nonnegative () =
 let test_client_count_increments () =
   let before = Sse.client_count () in
   let session_id = "test_count_" ^ string_of_int (Random.int 10000) in
-  let push _ = () in
-  let (_id, _, _) = Sse.register session_id ~push ~last_event_id:0 in
+  let _push _ = () in
+  let (_id, _, _) = Sse.register session_id ~last_event_id:0 in
   let after = Sse.client_count () in
   Sse.unregister session_id;
   check bool "incremented" true (after > before || after = before)
@@ -251,8 +251,8 @@ let test_cleanup_expired_events_exact_under_domain_contention () =
 let test_client_type_fields () =
   let session_id = "test_client_" ^ string_of_int (Random.int 10000) in
   let received = ref [] in
-  let push msg = received := msg :: !received in
-  let (_id, _, _) = Sse.register session_id ~push ~last_event_id:5 in
+  let _push msg = received := msg :: !received in
+  let (_id, _, _) = Sse.register session_id ~last_event_id:5 in
   check bool "exists" true (Sse.exists session_id);
   Sse.unregister session_id
 
@@ -262,16 +262,16 @@ let test_client_type_fields () =
 
 let test_unregister_if_current_matches () =
   let session_id = "test_unreg_match_" ^ string_of_int (Random.int 10000) in
-  let push _ = () in
-  let (client_id, _, _) = Sse.register session_id ~push ~last_event_id:0 in
+  let _push _ = () in
+  let (client_id, _, _) = Sse.register session_id ~last_event_id:0 in
   check bool "exists before" true (Sse.exists session_id);
   Sse.unregister_if_current session_id client_id;
   check bool "removed when matching" false (Sse.exists session_id)
 
 let test_unregister_if_current_no_match () =
   let session_id = "test_unreg_nomatch_" ^ string_of_int (Random.int 10000) in
-  let push _ = () in
-  let (_client_id, _, _) = Sse.register session_id ~push ~last_event_id:0 in
+  let _push _ = () in
+  let (_client_id, _, _) = Sse.register session_id ~last_event_id:0 in
   check bool "exists before" true (Sse.exists session_id);
   Sse.unregister_if_current session_id 999999;  (* wrong client id *)
   check bool "not removed when not matching" true (Sse.exists session_id);
@@ -287,8 +287,8 @@ let test_unregister_if_current_nonexistent () =
 
 let test_update_last_event_id_exists () =
   let session_id = "test_update_id_" ^ string_of_int (Random.int 10000) in
-  let push _ = () in
-  let (_id, _, _) = Sse.register session_id ~push ~last_event_id:0 in
+  let _push _ = () in
+  let (_id, _, _) = Sse.register session_id ~last_event_id:0 in
   Sse.update_last_event_id session_id 42;
   ();
   Sse.unregister session_id
@@ -303,8 +303,8 @@ let test_update_last_event_id_nonexistent () =
 
 let test_broadcast_sends_to_clients () =
   let session_id = "test_broadcast_" ^ string_of_int (Random.int 10000) in
-  let push _ = () in
-  let (_id, _, _) = Sse.register session_id ~push ~last_event_id:0 in
+  let _push _ = () in
+  let (_id, _, _) = Sse.register session_id ~last_event_id:0 in
   Sse.broadcast (`Assoc [("test", `String "value")]);
   (* Events are queued in the per-session stream, not pushed directly *)
   let event = Sse.try_pop session_id in
@@ -325,8 +325,8 @@ let test_broadcast_empty_clients () =
 
 let test_send_to_existing () =
   let session_id = "test_send_to_" ^ string_of_int (Random.int 10000) in
-  let push _ = () in
-  let (_id, _, _) = Sse.register session_id ~push ~last_event_id:0 in
+  let _push _ = () in
+  let (_id, _, _) = Sse.register session_id ~last_event_id:0 in
   Sse.send_to session_id (`Assoc [("direct", `String "message")]);
   (* Events are queued in the per-session stream *)
   let event = Sse.try_pop session_id in

--- a/test/test_sse_qw.ml
+++ b/test/test_sse_qw.ml
@@ -5,7 +5,7 @@ open Masc_mcp
 
 let () =
   let reset () = ignore (Sse.close_all_clients ()) in
-  let dummy_push _s = () in
+  let _dummy_push _s = () in
 
   Alcotest.run "sse-qw"
     [
@@ -20,18 +20,18 @@ let () =
         [
           Alcotest.test_case "register adds client" `Quick (fun () ->
               reset ();
-              ignore (Sse.register "sess-1" ~push:dummy_push ~last_event_id:0);
+              ignore (Sse.register "sess-1" ~last_event_id:0);
               Alcotest.(check bool) "exists" true (Sse.exists "sess-1");
               Sse.unregister "sess-1");
           Alcotest.test_case "unregister removes client" `Quick (fun () ->
               reset ();
-              ignore (Sse.register "sess-2" ~push:dummy_push ~last_event_id:0);
+              ignore (Sse.register "sess-2" ~last_event_id:0);
               Sse.unregister "sess-2";
               Alcotest.(check bool) "gone" false (Sse.exists "sess-2"));
           Alcotest.test_case "client_count" `Quick (fun () ->
               reset ();
-              ignore (Sse.register "s-a" ~push:dummy_push ~last_event_id:0);
-              ignore (Sse.register "s-b" ~push:dummy_push ~last_event_id:0);
+              ignore (Sse.register "s-a" ~last_event_id:0);
+              ignore (Sse.register "s-b" ~last_event_id:0);
               Alcotest.(check int) "count" 2 (Sse.client_count ());
               Sse.unregister "s-a";
               Sse.unregister "s-b");
@@ -40,7 +40,7 @@ let () =
         [
           Alcotest.test_case "existing client" `Quick (fun () ->
               reset ();
-              ignore (Sse.register "sess-3" ~push:dummy_push ~last_event_id:0);
+              ignore (Sse.register "sess-3" ~last_event_id:0);
               Unix.sleepf 0.05;
               Sse.touch "sess-3";
               (* No exception = pass *)
@@ -54,9 +54,9 @@ let () =
         [
           Alcotest.test_case "with clients" `Quick (fun () ->
               reset ();
-              ignore (Sse.register "c-1" ~push:dummy_push ~last_event_id:0);
-              ignore (Sse.register "c-2" ~push:dummy_push ~last_event_id:0);
-              ignore (Sse.register "c-3" ~push:dummy_push ~last_event_id:0);
+              ignore (Sse.register "c-1" ~last_event_id:0);
+              ignore (Sse.register "c-2" ~last_event_id:0);
+              ignore (Sse.register "c-3" ~last_event_id:0);
               let closed = Sse.close_all_clients () in
               Alcotest.(check int) "closed 3" 3 closed;
               Alcotest.(check int) "now empty" 0 (Sse.client_count ()));
@@ -69,19 +69,19 @@ let () =
         [
           Alcotest.test_case "fresh clients survive" `Quick (fun () ->
               reset ();
-              ignore (Sse.register "fresh" ~push:dummy_push ~last_event_id:0);
+              ignore (Sse.register "fresh" ~last_event_id:0);
               let evicted = Sse.cleanup_stale () in
               Alcotest.(check int) "none evicted" 0 (List.length evicted);
               Sse.unregister "fresh");
           Alcotest.test_case "zero threshold evicts all" `Quick (fun () ->
               reset ();
-              ignore (Sse.register "old" ~push:dummy_push ~last_event_id:0);
+              ignore (Sse.register "old" ~last_event_id:0);
               Unix.sleepf 0.05;
               let evicted = Sse.cleanup_stale ~max_age_s:0.0 () in
               Alcotest.(check bool) "evicted" true (List.length evicted > 0));
           Alcotest.test_case "returns evicted ids" `Quick (fun () ->
               reset ();
-              ignore (Sse.register "target" ~push:dummy_push ~last_event_id:0);
+              ignore (Sse.register "target" ~last_event_id:0);
               Unix.sleepf 0.05;
               let evicted = Sse.cleanup_stale ~max_age_s:0.0 () in
               Alcotest.(check bool) "contains target" true

--- a/test/test_sse_stream.ml
+++ b/test/test_sse_stream.ml
@@ -9,7 +9,7 @@ open Masc_mcp
 
 let reset () = ignore (Sse.close_all_clients ())
 
-let dummy_push _s = ()
+let _dummy_push _s = ()
 
 (* ============================================================
    pop / try_pop
@@ -22,14 +22,14 @@ let test_try_pop_empty () =
 
 let test_try_pop_no_events () =
   reset ();
-  ignore (Sse.register "s-pop-empty" ~push:dummy_push ~last_event_id:0);
+  ignore (Sse.register "s-pop-empty" ~last_event_id:0);
   let result = Sse.try_pop "s-pop-empty" in
   Alcotest.(check bool) "None when stream empty" true (result = None);
   Sse.unregister "s-pop-empty"
 
 let test_broadcast_popable () =
   reset ();
-  ignore (Sse.register "s-pop-bc" ~push:dummy_push ~last_event_id:0);
+  ignore (Sse.register "s-pop-bc" ~last_event_id:0);
   Sse.broadcast (`Assoc [("key", `String "val")]);
   let ev = Sse.try_pop "s-pop-bc" in
   Alcotest.(check bool) "got event from stream" true (ev <> None);
@@ -40,9 +40,9 @@ let test_broadcast_popable () =
 
 let test_broadcast_multiple_clients_streams () =
   reset ();
-  ignore (Sse.register "s-mc-1" ~push:dummy_push ~last_event_id:0);
-  ignore (Sse.register "s-mc-2" ~push:dummy_push ~last_event_id:0);
-  ignore (Sse.register "s-mc-3" ~push:dummy_push ~last_event_id:0);
+  ignore (Sse.register "s-mc-1" ~last_event_id:0);
+  ignore (Sse.register "s-mc-2" ~last_event_id:0);
+  ignore (Sse.register "s-mc-3" ~last_event_id:0);
   Sse.broadcast (`Assoc [("multi", `Bool true)]);
   let got1 = Sse.try_pop "s-mc-1" in
   let got2 = Sse.try_pop "s-mc-2" in
@@ -56,8 +56,8 @@ let test_broadcast_multiple_clients_streams () =
 
 let test_send_to_popable () =
   reset ();
-  ignore (Sse.register "s-st-1" ~push:dummy_push ~last_event_id:0);
-  ignore (Sse.register "s-st-2" ~push:dummy_push ~last_event_id:0);
+  ignore (Sse.register "s-st-1" ~last_event_id:0);
+  ignore (Sse.register "s-st-2" ~last_event_id:0);
   Sse.send_to "s-st-1" (`Assoc [("direct", `Bool true)]);
   let got1 = Sse.try_pop "s-st-1" in
   let got2 = Sse.try_pop "s-st-2" in
@@ -68,7 +68,7 @@ let test_send_to_popable () =
 
 let test_pop_blocks_then_receives () =
   reset ();
-  ignore (Sse.register "s-block" ~push:dummy_push ~last_event_id:0);
+  ignore (Sse.register "s-block" ~last_event_id:0);
   (* pop in a sub-fiber, broadcast from main fiber *)
   Eio.Fiber.both
     (fun () ->
@@ -83,7 +83,7 @@ let test_pop_blocks_then_receives () =
 let test_broadcast_skips_already_seen () =
   reset ();
   (* Register with a high last_event_id so events are skipped *)
-  ignore (Sse.register "s-skip" ~push:dummy_push ~last_event_id:999_999_999);
+  ignore (Sse.register "s-skip" ~last_event_id:999_999_999);
   Sse.broadcast (`Assoc [("skip", `Bool true)]);
   let ev = Sse.try_pop "s-skip" in
   Alcotest.(check bool) "skipped (already seen)" true (ev = None);
@@ -91,7 +91,7 @@ let test_broadcast_skips_already_seen () =
 
 let test_broadcast_event_contains_data () =
   reset ();
-  ignore (Sse.register "s-data" ~push:dummy_push ~last_event_id:0);
+  ignore (Sse.register "s-data" ~last_event_id:0);
   Sse.broadcast (`Assoc [("payload", `Int 42)]);
   match Sse.try_pop "s-data" with
   | None -> Alcotest.fail "expected an event"
@@ -113,8 +113,8 @@ let test_broadcast_event_contains_data () =
 
 let test_broadcast_to_observers_only () =
   reset ();
-  ignore (Sse.register ~kind:Observer "s-obs" ~push:dummy_push ~last_event_id:0);
-  ignore (Sse.register ~kind:Coordinator "s-coord" ~push:dummy_push ~last_event_id:0);
+  ignore (Sse.register ~kind:Observer "s-obs" ~last_event_id:0);
+  ignore (Sse.register ~kind:Coordinator "s-coord" ~last_event_id:0);
   Sse.broadcast_to Observers (`Assoc [("target", `String "observers")]);
   let got_obs = Sse.try_pop "s-obs" in
   let got_coord = Sse.try_pop "s-coord" in
@@ -125,8 +125,8 @@ let test_broadcast_to_observers_only () =
 
 let test_broadcast_to_coordinators_only () =
   reset ();
-  ignore (Sse.register ~kind:Observer "s-obs2" ~push:dummy_push ~last_event_id:0);
-  ignore (Sse.register ~kind:Coordinator "s-coord2" ~push:dummy_push ~last_event_id:0);
+  ignore (Sse.register ~kind:Observer "s-obs2" ~last_event_id:0);
+  ignore (Sse.register ~kind:Coordinator "s-coord2" ~last_event_id:0);
   Sse.broadcast_to Coordinators (`Assoc [("target", `String "coordinators")]);
   let got_obs = Sse.try_pop "s-obs2" in
   let got_coord = Sse.try_pop "s-coord2" in
@@ -137,8 +137,8 @@ let test_broadcast_to_coordinators_only () =
 
 let test_broadcast_to_all () =
   reset ();
-  ignore (Sse.register ~kind:Observer "s-all-obs" ~push:dummy_push ~last_event_id:0);
-  ignore (Sse.register ~kind:Coordinator "s-all-coord" ~push:dummy_push ~last_event_id:0);
+  ignore (Sse.register ~kind:Observer "s-all-obs" ~last_event_id:0);
+  ignore (Sse.register ~kind:Coordinator "s-all-coord" ~last_event_id:0);
   Sse.broadcast_to All (`Assoc [("target", `String "all")]);
   let got_obs = Sse.try_pop "s-all-obs" in
   let got_coord = Sse.try_pop "s-all-coord" in
@@ -149,8 +149,8 @@ let test_broadcast_to_all () =
 
 let test_broadcast_equals_broadcast_to_all () =
   reset ();
-  ignore (Sse.register ~kind:Observer "s-eq-obs" ~push:dummy_push ~last_event_id:0);
-  ignore (Sse.register ~kind:Coordinator "s-eq-coord" ~push:dummy_push ~last_event_id:0);
+  ignore (Sse.register ~kind:Observer "s-eq-obs" ~last_event_id:0);
+  ignore (Sse.register ~kind:Coordinator "s-eq-coord" ~last_event_id:0);
   (* broadcast (no target) should reach everyone, same as broadcast_to All *)
   Sse.broadcast (`Assoc [("compat", `Bool true)]);
   let got_obs = Sse.try_pop "s-eq-obs" in
@@ -163,7 +163,7 @@ let test_broadcast_equals_broadcast_to_all () =
 let test_register_defaults_to_coordinator () =
   reset ();
   (* Register without explicit kind *)
-  ignore (Sse.register "s-default" ~push:dummy_push ~last_event_id:0);
+  ignore (Sse.register "s-default" ~last_event_id:0);
   (* Should be Coordinator: receives Coordinators-targeted broadcast *)
   Sse.broadcast_to Coordinators (`Assoc [("default_kind", `Bool true)]);
   let got = Sse.try_pop "s-default" in

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -202,10 +202,10 @@ let test_transport_health_json () =
   ignore (Masc_mcp.Coord.init config ~agent_name:(Some "tester"));
   ignore
     (Masc_mcp.Sse.register ~kind:Masc_mcp.Sse.Observer "observer-session"
-       ~push:(fun _ -> ()) ~last_event_id:0);
+       ~last_event_id:0);
   ignore
     (Masc_mcp.Sse.register ~kind:Masc_mcp.Sse.Coordinator "coordinator-session"
-       ~push:(fun _ -> ()) ~last_event_id:0);
+       ~last_event_id:0);
   TM.set_grpc_active_streams 1;
   TM.set_grpc_subscribers 2;
   Prometheus.set_gauge Prometheus.metric_oas_sse_relay_queue_depth 4.0;


### PR DESCRIPTION
Removed Sse.client.push field — annotated 'legacy direct-push callback (used by drain)' but never invoked. All delivery goes through event_stream + Sse.pop. Removed ~push from register signature, 2 production callers, 6 test call sites. Build clean, test_sse 4/4 pass.