### PR TITLE
obs(keeper): counter for compaction trigger that produced no savings (#9943)

### DIFF
--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -1300,7 +1300,24 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
          | None -> `Null);
       ]
   in
-  Dated_jsonl.append metrics_store snapshot
+  Dated_jsonl.append metrics_store snapshot;
+  (* #9943: a compaction trigger that produced no token reduction
+     is invisible in [masc_keeper_compactions_total] (which counts
+     trigger fires).  Emit a dedicated counter here so dashboards
+     can alert on the noop rate — production audit (2026-04-24)
+     showed 956/972 = 98.4% of compaction snapshots were silent
+     noops.  Emit only when a trigger fired and before/after match
+     at a non-zero token count; the [trigger] label uses the
+     human-readable reason already present in the snapshot. *)
+  (match compaction.trigger with
+   | Some trigger
+     when compaction.before_tokens > 0
+       && compaction.before_tokens = compaction.after_tokens ->
+       Prometheus.inc_counter
+         Prometheus.metric_keeper_compaction_noop
+         ~labels:[ ("keeper", meta.name); ("trigger", trigger) ]
+         ()
+   | _ -> ())
 
 let broadcast_lifecycle_events ~(name : string)
     ~(turn_generation : int)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -292,6 +292,24 @@ let metric_keeper_compaction_saved_tokens =
 let metric_keeper_operator_compact = "masc_keeper_operator_compact_total"
 let metric_keeper_operator_clear = "masc_keeper_operator_clear_total"
 
+(* #9943: per-keeper counter of "compaction triggered but
+   resulted in no token reduction".  2026-04-24 audit found
+   956/972 (98.4%) of recorded compaction snapshots had
+   [compaction_before_tokens = compaction_after_tokens > 0],
+   meaning a trigger fired but the strategy returned the same
+   token budget — a silent failure mode that
+   [masc_keeper_compactions_total] hides because that counter
+   is incremented on the trigger rather than the savings.  This
+   counter labels by [keeper, trigger] so dashboards separate
+   "context_overflow_imminent triggered noop" from "manual
+   trigger noop" etc. and operators can attribute blame.  Pair
+   with [masc_keeper_compaction_saved_tokens_total] (already
+   shipping) — that one tracks the bytes saved by the 1.6%
+   that DID save anything; this one tracks the 98.4% that
+   ran for nothing. *)
+let metric_keeper_compaction_noop =
+  "masc_keeper_compaction_noop_total"
+
 (* Keeper keepalive (keeper_keepalive.ml). *)
 let metric_keeper_heartbeat_successes =
   "masc_keeper_heartbeat_successes_total"
@@ -596,6 +614,13 @@ let init () =
     "Context ratio change after compaction (pre - post)" Gauge;
   add metric_keeper_compaction_saved_tokens
     "Total tokens removed by keeper context compaction" Counter;
+  (* #9943: noop compactions — trigger fired but strategy did
+     not reduce token budget. *)
+  add metric_keeper_compaction_noop
+    "Total compaction snapshots where before_tokens == \
+     after_tokens > 0 (compaction triggered but produced no \
+     savings; labels: keeper, trigger)"
+    Counter;
   (* Operator-initiated overflow recovery — emitted by tool_keeper.ml *)
   add metric_keeper_operator_compact
     "Total operator-invoked masc_keeper_compact calls (labels: result=ok|no_checkpoint|precondition|not_found)" Counter;

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -109,6 +109,16 @@ val metric_tool_join_required_guard : string
 val metric_keeper_compactions : string
 val metric_keeper_compaction_ratio_change : string
 val metric_keeper_compaction_saved_tokens : string
+
+(** #9943: per-keeper noop compaction counter.  Increments when
+    a snapshot records [compaction_before_tokens =
+    compaction_after_tokens > 0] — the trigger fired but the
+    strategy returned the same token budget.  Pre-fix, 956/972
+    (98.4%) of compaction snapshots in production were silent
+    noops because [masc_keeper_compactions_total] counts
+    triggers rather than savings.  Labels: [keeper, trigger]. *)
+val metric_keeper_compaction_noop : string
+
 val metric_keeper_operator_compact : string
 val metric_keeper_operator_clear : string
 val metric_keeper_heartbeat_successes : string

--- a/test/dune
+++ b/test/dune
@@ -1383,6 +1383,11 @@
  (libraries masc_mcp fs_compat alcotest eio eio_main unix))
 
 (test
+ (name test_keeper_compaction_noop_counter_9943)
+ (modules test_keeper_compaction_noop_counter_9943)
+ (libraries masc_mcp alcotest unix))
+
+(test
  (name test_keeper_usage_trust_anthropic_cache_9959)
  (modules test_keeper_usage_trust_anthropic_cache_9959)
  (libraries masc_mcp alcotest))

--- a/test/test_keeper_compaction_noop_counter_9943.ml
+++ b/test/test_keeper_compaction_noop_counter_9943.ml
@@ -1,0 +1,151 @@
+(** #9943 facet 1: compaction-triggered-but-no-savings counter.
+
+    Production audit (2026-04-24) found 956/972 = 98.4% of compaction
+    snapshots had [compaction_before_tokens =
+    compaction_after_tokens > 0] — the trigger fired but the strategy
+    did not reduce the token budget.  [masc_keeper_compactions_total]
+    counts trigger fires, not savings, so the noop rate was invisible
+    on dashboards.
+
+    [Keeper_unified_metrics.append_metrics_snapshot] now emits
+    [masc_keeper_compaction_noop_total{keeper, trigger}] in addition
+    to writing the JSONL row.  Full integration testing requires a
+    keeper context + run_result + observation, which is heavier than
+    a unit test should be — these tests pin the metric surface and
+    label shape so a future refactor cannot silently flip the
+    cardinality or rename the labels. *)
+
+let () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-keeper-compaction-noop-9943-%06x"
+         (Random.bits ()))
+  in
+  Unix.putenv "MASC_BASE_PATH" dir
+
+module Prom = Masc_mcp.Prometheus
+
+let noop_for ~keeper ~trigger =
+  Prom.metric_value_or_zero
+    Prom.metric_keeper_compaction_noop
+    ~labels:[ ("keeper", keeper); ("trigger", trigger) ]
+    ()
+
+(* Metric is registered at module init.  If a future refactor
+   accidentally drops the [add metric_keeper_compaction_noop ...]
+   call, the dashboard would silently flatten this signal — pin
+   the registration. *)
+let test_metric_registered () =
+  let _ = Prom.metric_total Prom.metric_keeper_compaction_noop in
+  Alcotest.(check pass) "metric registered at init" () ()
+
+(* Direct increment using the same call shape
+   [append_metrics_snapshot] uses.  Verifies the counter advances
+   with the labels in the documented order. *)
+let test_counter_advances_for_noop_pattern () =
+  let keeper = "test-keeper-compaction-noop-9943" in
+  let trigger = "context_overflow_imminent" in
+  let before = noop_for ~keeper ~trigger in
+  Prom.inc_counter
+    Prom.metric_keeper_compaction_noop
+    ~labels:[ ("keeper", keeper); ("trigger", trigger) ]
+    ();
+  Alcotest.(check (float 0.0001))
+    "noop counter +1 with correct labels"
+    (before +. 1.0)
+    (noop_for ~keeper ~trigger)
+
+(* Different triggers land on different counter rows so dashboards
+   can attribute noops to the source trigger.  Pre-fix the only
+   signal was [compactions_total] aggregated across all triggers. *)
+let test_distinct_triggers_separate_rows () =
+  let keeper = "test-keeper-compaction-noop-9943-trigger" in
+  let before_overflow = noop_for ~keeper ~trigger:"context_overflow_imminent" in
+  let before_proactive = noop_for ~keeper ~trigger:"proactive_warmup" in
+  Prom.inc_counter
+    Prom.metric_keeper_compaction_noop
+    ~labels:[ ("keeper", keeper);
+              ("trigger", "context_overflow_imminent") ]
+    ();
+  Prom.inc_counter
+    Prom.metric_keeper_compaction_noop
+    ~labels:[ ("keeper", keeper); ("trigger", "proactive_warmup") ]
+    ();
+  Alcotest.(check (float 0.0001)) "overflow row +1"
+    (before_overflow +. 1.0)
+    (noop_for ~keeper ~trigger:"context_overflow_imminent");
+  Alcotest.(check (float 0.0001)) "proactive row +1"
+    (before_proactive +. 1.0)
+    (noop_for ~keeper ~trigger:"proactive_warmup")
+
+(* Per-keeper isolation — keeper A's noops do not leak into
+   keeper B's row.  Necessary because a fleet has 9-15 keepers
+   each with their own noop rate; aggregating obscures which
+   keeper is suffering. *)
+let test_per_keeper_isolation () =
+  let a = "test-keeper-compaction-noop-9943-iso-A" in
+  let b = "test-keeper-compaction-noop-9943-iso-B" in
+  let trigger = "context_overflow_imminent" in
+  let before_b = noop_for ~keeper:b ~trigger in
+  Prom.inc_counter
+    Prom.metric_keeper_compaction_noop
+    ~labels:[ ("keeper", a); ("trigger", trigger) ]
+    ();
+  Prom.inc_counter
+    Prom.metric_keeper_compaction_noop
+    ~labels:[ ("keeper", a); ("trigger", trigger) ]
+    ();
+  Alcotest.(check (float 0.0001))
+    "keeper B unaffected by keeper A increments"
+    before_b
+    (noop_for ~keeper:b ~trigger)
+
+(* Prometheus text export must include the metric name and the
+   keeper / trigger label keys — PromQL queries depend on this. *)
+let test_prometheus_text_export () =
+  let keeper = "test-keeper-compaction-noop-9943-export" in
+  let trigger = "context_overflow_imminent" in
+  Prom.inc_counter
+    Prom.metric_keeper_compaction_noop
+    ~labels:[ ("keeper", keeper); ("trigger", trigger) ]
+    ();
+  let text = Prom.to_prometheus_text () in
+  let contains s sub =
+    let n = String.length s and m = String.length sub in
+    let rec loop i =
+      if i + m > n then false
+      else if String.sub s i m = sub then true
+      else loop (i + 1)
+    in
+    loop 0
+  in
+  Alcotest.(check bool) "metric name in export"
+    true (contains text Prom.metric_keeper_compaction_noop);
+  Alcotest.(check bool) "keeper label key in export"
+    true (contains text "keeper=");
+  Alcotest.(check bool) "trigger label key in export"
+    true (contains text "trigger=")
+
+let () =
+  Alcotest.run "keeper_compaction_noop_counter_9943"
+    [
+      ( "registration",
+        [
+          Alcotest.test_case "metric registered at init" `Quick
+            test_metric_registered;
+        ] );
+      ( "label-shape",
+        [
+          Alcotest.test_case "counter advances with (keeper, trigger)"
+            `Quick test_counter_advances_for_noop_pattern;
+          Alcotest.test_case "distinct triggers → distinct rows"
+            `Quick test_distinct_triggers_separate_rows;
+          Alcotest.test_case "per-keeper isolation" `Quick
+            test_per_keeper_isolation;
+        ] );
+      ( "export",
+        [
+          Alcotest.test_case "metric + labels appear in /metrics"
+            `Quick test_prometheus_text_export;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

#9943 reports that on 2026-04-24, **956/972 (98.4%)** of recorded
keeper compaction snapshots had \`compaction_before_tokens =
compaction_after_tokens > 0\` — the trigger fired but the strategy
did not reduce the token budget.

\`masc_keeper_compactions_total\` counts trigger fires rather than
savings, so the noop rate was invisible on dashboards.  This is
also (per #9935) why \`context_overflow_imminent\` fires 45×/day
with no observable reduction action: the existing metric layer
reports "compaction triggered" without revealing it accomplished
nothing.

## Surface

| metric | label | semantics |
|---|---|---|
| \`masc_keeper_compaction_noop_total\` | \`keeper\`, \`trigger\` | Increments when \`compaction.trigger = Some _\` AND \`before_tokens > 0\` AND \`before_tokens = after_tokens\`. |

Pairs with the already-shipping \`masc_keeper_compaction_saved_tokens_total\`:
- saved_tokens counts the 1.6% that DID save anything.
- noop counts the 98.4% that ran for nothing.

## Cardinality

\`keeper × trigger\` — both bounded.  Trigger strings come from the existing snapshot field \`compaction_trigger\` (small enumeration: context_overflow, proactive_warmup, …).  Fleet has ~9-15 keepers; total rows stay in low hundreds.

## Why a separate counter, not a histogram

A noop is a discrete event ("trigger fired and accomplished nothing"), not a distribution.  A histogram of saved_tokens would mix legitimate small savings with noops in the bottom bucket.  A counter labelled by the triggering reason gives operators direct PromQL like:

\`\`\`promql
rate(masc_keeper_compaction_noop_total{trigger="context_overflow_imminent"}[5m])
\`\`\`

— exactly the alert needed to detect "overflow trigger fires but doesn't reduce."

## Test plan

- [x] \`dune build --root . lib/\` clean (mli/ml aligned)
- [x] \`dune exec test/test_keeper_compaction_noop_counter_9943.exe\` — 5/5 pass:
  - metric registered at init
  - counter advances with documented label order \`(keeper, trigger)\`
  - distinct triggers land on distinct counter rows
  - per-keeper isolation
  - metric name and label keys appear in \`/metrics\` text export
- [ ] Deploy: confirm the noop counter advances at the production rate (~98.4% of trigger fires) on the affected fleet, identifying the dominant trigger producing the noops.

## Not in this PR

#9943 is multi-faceted; this counter only addresses **facet 1** (compaction silently produces no savings).  Other facets:

| facet | status |
|---|---|
| 1 — compaction noop | **this PR** |
| 2 — claude_code context_max=64000 (clipping) | covered by #9953 / PR #10122 (MERGED, context_max bucket counter) |
| 3 — 20-min latency turns | covered by #10124 (MERGED, turn latency bucket counter) |

## Refs

- #9935 (context_overflow_imminent fires 45×/day no action — same metric trust gap)
- #10124 (MERGED): turn latency bucket — observability-first sibling
- #9953 (context_max 3-way drift) — same cluster

## Do-not-merge

\`do-not-merge\` label set so the auto-merge pipeline does not flip this Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)