### PR TITLE
feat(metrics): split keeper latency buckets by model

### DIFF
--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -186,6 +186,40 @@ let record_turn_latency_bucket
        — investigate cascade exhaustion / oas_timeout_budget (#9933, #9943)"
       keeper latency_ms threshold bucket
 
+let label_or_unknown raw =
+  let trimmed = String.trim raw in
+  if trimmed = "" then "unknown" else trimmed
+
+let provider_kind_of_model_used raw =
+  let model_used = label_or_unknown raw in
+  match String.index_opt model_used ':' with
+  | Some idx when idx > 0 -> String.sub model_used 0 idx
+  | _ -> "unknown"
+
+let record_turn_latency_by_model_bucket
+    ~(keeper : string)
+    ~(channel : string)
+    ~(model_used : string)
+    ~(resolved_model_id : string)
+    ~(cascade_profile : string)
+    ~(latency_ms : int) : unit =
+  let bucket = turn_latency_bucket latency_ms in
+  let model_used = label_or_unknown model_used in
+  let resolved_model_id = label_or_unknown resolved_model_id in
+  let cascade_profile = label_or_unknown cascade_profile in
+  Prometheus.inc_counter
+    Prometheus.metric_keeper_turn_latency_by_model_bucket
+    ~labels:
+      [ ("keeper", label_or_unknown keeper)
+      ; ("channel", label_or_unknown channel)
+      ; ("provider_kind", provider_kind_of_model_used model_used)
+      ; ("model_used", model_used)
+      ; ("resolved_model_id", resolved_model_id)
+      ; ("cascade_profile", cascade_profile)
+      ; ("bucket", bucket)
+      ]
+    ()
+
 
 let usage_trust_is_trusted = Keeper_usage_trust.is_trusted
 
@@ -1183,6 +1217,21 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
      overridable).  Emitted once per snapshot write so the
      counter rate matches the JSONL row rate. *)
   record_turn_latency_bucket ~keeper:meta.name ~latency_ms;
+  let cascade_profile =
+    match result.cascade_observation with
+    | Some observation -> observation.Oas_worker.cascade_name
+    | None -> meta.cascade_name
+  in
+  (* #9933: same latency bucket, split by provider/model/cascade.
+     This keeps the existing keeper-only counter stable while making
+     timeout-budget burn attributable to a concrete model surface. *)
+  record_turn_latency_by_model_bucket
+    ~keeper:meta.name
+    ~channel
+    ~model_used:surface_model_used
+    ~resolved_model_id
+    ~cascade_profile
+    ~latency_ms;
   let snapshot =
     `Assoc
       [

--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -113,6 +113,20 @@ val long_turn_warn_threshold_ms : unit -> int
 val record_turn_latency_bucket :
   keeper:string -> latency_ms:int -> unit
 
+val provider_kind_of_model_used : string -> string
+(** Derive the bounded provider label from a keeper [model_used]
+    surface such as [claude_code:auto] or [kimi_cli:kimi-for-coding].
+    Empty or unprefixed values collapse to [unknown]. *)
+
+val record_turn_latency_by_model_bucket :
+  keeper:string ->
+  channel:string ->
+  model_used:string ->
+  resolved_model_id:string ->
+  cascade_profile:string ->
+  latency_ms:int ->
+  unit
+
 
 val update_metrics_from_result :
   Keeper_types.keeper_meta ->

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -242,6 +242,16 @@ let metric_keeper_turn_livelock_blocks =
 let metric_keeper_turn_latency_bucket =
   "masc_keeper_turn_latency_bucket_total"
 
+(* #9933 follow-up: per-turn latency buckets split by the effective
+   provider/model/cascade surface.  [metric_keeper_turn_latency_bucket]
+   tells operators which keeper is slow; this counter answers the next
+   operational question: which provider/cascade/profile is burning the
+   timeout budget.  Labels are bounded by fleet size, configured model
+   labels, configured cascades, channel vocabulary, and the five bucket
+   names from [Keeper_unified_metrics.turn_latency_bucket]. *)
+let metric_keeper_turn_latency_by_model_bucket =
+  "masc_keeper_turn_latency_by_model_bucket_total"
+
 (* #10125: keeper supervisor sweep observability.
 
    The supervisor sweep is a Pulse loop that recovers crashed
@@ -576,6 +586,12 @@ let init () =
      [under_60s | 60-300s | 300-600s | 600-1200s | over_1200s]. *)
   add metric_keeper_turn_latency_bucket
     "Total keeper turn completions, bucketed by latency (labels: keeper, \
+     bucket=under_60s|60-300s|300-600s|600-1200s|over_1200s)"
+    Counter;
+  add metric_keeper_turn_latency_by_model_bucket
+    "Total keeper turn completions, bucketed by latency and effective \
+     model surface (labels: keeper, channel, provider_kind, model_used, \
+     resolved_model_id, cascade_profile, \
      bucket=under_60s|60-300s|300-600s|600-1200s|over_1200s)"
     Counter;
   (* #10125: supervisor sweep liveness.  Counter increments on

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -94,6 +94,12 @@ val metric_keeper_turn_latency_bucket : string
     [keeper, bucket].  Bucket vocabulary:
     [under_60s | 60-300s | 300-600s | 600-1200s | over_1200s]. *)
 
+val metric_keeper_turn_latency_by_model_bucket : string
+(** #9933: per-keeper turn latency distribution split by effective
+    model/cascade surface.  Labels:
+    [keeper, channel, provider_kind, model_used, resolved_model_id,
+    cascade_profile, bucket]. *)
+
 (** #10125: supervisor sweep liveness counters.  See {!Prometheus.ml}
     for the rationale.  Counter increments on each Pulse start;
     gauge advances on every successful beat. *)

--- a/test/test_keeper_long_turn_9943.ml
+++ b/test/test_keeper_long_turn_9943.ml
@@ -42,6 +42,21 @@ let bucket_count ~keeper ~bucket =
     ~labels:[ ("keeper", keeper); ("bucket", bucket) ]
     ()
 
+let model_bucket_count ~keeper ~channel ~provider_kind ~model_used
+    ~resolved_model_id ~cascade_profile ~bucket =
+  Prom.metric_value_or_zero
+    Prom.metric_keeper_turn_latency_by_model_bucket
+    ~labels:
+      [ ("keeper", keeper)
+      ; ("channel", channel)
+      ; ("provider_kind", provider_kind)
+      ; ("model_used", model_used)
+      ; ("resolved_model_id", resolved_model_id)
+      ; ("cascade_profile", cascade_profile)
+      ; ("bucket", bucket)
+      ]
+    ()
+
 (* Bucket vocabulary is exactly five labels.  Shrinking or
    exploding this set is a breaking dashboard change. *)
 let test_bucket_vocabulary () =
@@ -144,6 +159,58 @@ let test_warn_threshold_reads_env () =
    | Some v -> Unix.putenv "MASC_KEEPER_LONG_TURN_WARN_MS" v
    | None -> Unix.putenv "MASC_KEEPER_LONG_TURN_WARN_MS" "")
 
+let test_provider_kind_of_model_used () =
+  Alcotest.(check string) "claude_code label"
+    "claude_code" (M.provider_kind_of_model_used "claude_code:auto");
+  Alcotest.(check string) "kimi_cli label"
+    "kimi_cli" (M.provider_kind_of_model_used " kimi_cli:kimi-for-coding ");
+  Alcotest.(check string) "unprefixed"
+    "unknown" (M.provider_kind_of_model_used "gpt-5.4");
+  Alcotest.(check string) "empty"
+    "unknown" (M.provider_kind_of_model_used "")
+
+let test_record_by_model_bucket () =
+  let keeper = "test-keeper-provider-latency-9933" in
+  let before =
+    model_bucket_count
+      ~keeper
+      ~channel:"scheduled_autonomous"
+      ~provider_kind:"claude_code"
+      ~model_used:"claude_code:auto"
+      ~resolved_model_id:"claude-sonnet-4.7"
+      ~cascade_profile:"big_three"
+      ~bucket:"over_1200s"
+  in
+  M.record_turn_latency_by_model_bucket
+    ~keeper
+    ~channel:"scheduled_autonomous"
+    ~model_used:"claude_code:auto"
+    ~resolved_model_id:"claude-sonnet-4.7"
+    ~cascade_profile:"big_three"
+    ~latency_ms:1_200_000;
+  Alcotest.(check (float 0.0001))
+    "by-model over_1200s bucket +1"
+    (before +. 1.0)
+    (model_bucket_count
+       ~keeper
+       ~channel:"scheduled_autonomous"
+       ~provider_kind:"claude_code"
+       ~model_used:"claude_code:auto"
+       ~resolved_model_id:"claude-sonnet-4.7"
+       ~cascade_profile:"big_three"
+       ~bucket:"over_1200s");
+  Alcotest.(check (float 0.0001))
+    "different cascade unchanged"
+    0.0
+    (model_bucket_count
+       ~keeper
+       ~channel:"scheduled_autonomous"
+       ~provider_kind:"claude_code"
+       ~model_used:"claude_code:auto"
+       ~resolved_model_id:"claude-sonnet-4.7"
+       ~cascade_profile:"tool_use_strict"
+       ~bucket:"over_1200s")
+
 let () =
   Alcotest.run "keeper_long_turn_9943"
     [
@@ -167,5 +234,12 @@ let () =
             test_warn_threshold_default_is_ten_minutes;
           Alcotest.test_case "reads env per call" `Quick
             test_warn_threshold_reads_env;
+        ] );
+      ( "provider-model",
+        [
+          Alcotest.test_case "provider kind from model surface" `Quick
+            test_provider_kind_of_model_used;
+          Alcotest.test_case "records by model/cascade bucket" `Quick
+            test_record_by_model_bucket;
         ] );
     ]


### PR DESCRIPTION
## Summary
- add `masc_keeper_turn_latency_by_model_bucket_total` with `keeper`, `channel`, `provider_kind`, `model_used`, `resolved_model_id`, `cascade_profile`, and latency `bucket` labels
- emit the new counter beside the existing keeper-only latency bucket when keeper metrics snapshots are appended
- cover provider-kind derivation and per-model/cascade bucket increments in `test_keeper_long_turn_9943`

## Why
#9933 needs to identify which provider/model/cascade surface is burning the OAS timeout budget. The existing keeper latency bucket shows that a keeper is slow, but not whether the slow path is Claude Code, Kimi CLI, or a specific cascade profile. This keeps the existing metric stable and adds a bounded attribution counter for the next operational question.

## Verification
- `git diff --check`
- `scripts/check-boundary-guard.sh`
- `env DUNE_BUILD_DIR=_build_9933_provider_latency DUNE_JOBS=2 DUNE_CACHE=disabled MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_keeper_long_turn_9943.exe test/test_prometheus_coverage.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-9933-provider-latency-keeper _build_9933_provider_latency/default/test/test_keeper_long_turn_9943.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-9933-provider-latency-prom _build_9933_provider_latency/default/test/test_prometheus_coverage.exe`

Refs #9933