### PR TITLE
fix(keeper): route registered tools without name prefixes

### DIFF
--- a/lib/keeper/keeper_exec_masc.ml
+++ b/lib/keeper/keeper_exec_masc.ml
@@ -192,4 +192,20 @@ let handle_keeper_masc_tool
                      [ "error", `String "unregistered_masc_tool"; "tool", `String name ]))))
 ;;
 
+let handle_registered_keeper_tool
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      ~(name : string)
+      ~(args : Yojson.Safe.t)
+  =
+  match Tool_dispatch.lookup_tag name with
+  | Some Tool_dispatch.Mod_autoresearch ->
+    Some (handle_keeper_autoresearch_tool ~config ~meta ~name ~args)
+  | Some _ ->
+    Some (handle_keeper_masc_tool ~config ~meta ~name ~args)
+  | None when Tool_dispatch.is_registered name ->
+    Some (handle_keeper_masc_tool ~config ~meta ~name ~args)
+  | None -> None
+;;
+
 (* ── Tool execution dispatch ──────────────────────────────────── *)

--- a/lib/keeper/keeper_exec_masc.mli
+++ b/lib/keeper/keeper_exec_masc.mli
@@ -13,3 +13,10 @@ val handle_keeper_masc_tool :
   name:string ->
   args:Yojson.Safe.t ->
   string
+
+val handle_registered_keeper_tool :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  name:string ->
+  args:Yojson.Safe.t ->
+  string option

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -296,67 +296,67 @@ let execute_keeper_tool_call_with_outcome
     | "keeper_task_submit_for_verification" ->
       make_executed_tool_result
         (Keeper_exec_task.handle_keeper_task_tool ~config ~meta ~name ~args)
-    | n when String.starts_with ~prefix:"masc_autoresearch_" n ->
-      make_executed_tool_result
-        (Keeper_exec_masc.handle_keeper_autoresearch_tool ~config ~meta ~name ~args)
-    | n when String.starts_with ~prefix:"masc_" n ->
-      make_executed_tool_result
-        (Keeper_exec_masc.handle_keeper_masc_tool ~config ~meta ~name ~args)
     | other ->
-      let suggestion =
-        let candidates = keeper_allowed_tool_names meta in
-        let scored =
-          candidates
-          |> List.filter_map (fun c ->
-            if String.length c > 2 && String.length other > 2 then
-              let other_lower = String.lowercase_ascii other in
-              let c_lower = String.lowercase_ascii c in
-              let contains haystack needle =
-                let nlen = String.length needle in
-                let hlen = String.length haystack in
-                if nlen = 0 then true
-                else if nlen > hlen then false
-                else
-                  let found = ref false in
-                  for i = 0 to hlen - nlen do
-                    if not !found
-                       && String.sub haystack i nlen = needle
-                    then found := true
-                  done;
-                  !found
-              in
-              if contains c_lower other_lower
-                 || contains other_lower c_lower
-              then Some c
-              else None
-            else None)
-          |> List.filteri (fun i _ -> i < 3)
-        in
-        scored
-      in
-      let masc_schemas = !Keeper_tool_registry.masc_schemas_ref in
-      let enrich_suggestion name =
-        let schema_opt =
-          List.find_opt (fun (s : Types.tool_schema) -> s.name = name) masc_schemas
-        in
-        match schema_opt with
-        | Some s ->
-          `Assoc [
-            ("name", `String name);
-            ("description", `String s.description);
-            ("input_schema", s.input_schema);
-          ]
-        | None -> `String name
-      in
-      let fields =
-        [ ("error", `String "unknown_tool"); ("tool", `String other) ]
-        @ (match suggestion with
-           | [] -> [("hint", `String "Use keeper_tool_search to find available tools.")]
-           | names ->
-             [ ("did_you_mean", `List (List.map enrich_suggestion names));
-               ("hint", `String "Call one of these tools with the correct parameters.") ])
-      in
-      make_executed_tool_result (Yojson.Safe.to_string (`Assoc fields))))
+      (match
+         Keeper_exec_masc.handle_registered_keeper_tool
+           ~config ~meta ~name:other ~args
+       with
+       | Some raw_output -> make_executed_tool_result raw_output
+       | None ->
+         let suggestion =
+           let candidates = keeper_allowed_tool_names meta in
+           let scored =
+             candidates
+             |> List.filter_map (fun c ->
+               if String.length c > 2 && String.length other > 2 then
+                 let other_lower = String.lowercase_ascii other in
+                 let c_lower = String.lowercase_ascii c in
+                 let contains haystack needle =
+                   let nlen = String.length needle in
+                   let hlen = String.length haystack in
+                   if nlen = 0 then true
+                   else if nlen > hlen then false
+                   else
+                     let found = ref false in
+                     for i = 0 to hlen - nlen do
+                       if not !found
+                          && String.sub haystack i nlen = needle
+                       then found := true
+                     done;
+                     !found
+                 in
+                 if contains c_lower other_lower
+                    || contains other_lower c_lower
+                 then Some c
+                 else None
+               else None)
+             |> List.filteri (fun i _ -> i < 3)
+           in
+           scored
+         in
+         let masc_schemas = !Keeper_tool_registry.masc_schemas_ref in
+         let enrich_suggestion name =
+           let schema_opt =
+             List.find_opt (fun (s : Types.tool_schema) -> s.name = name) masc_schemas
+           in
+           match schema_opt with
+           | Some s ->
+             `Assoc [
+               ("name", `String name);
+               ("description", `String s.description);
+               ("input_schema", s.input_schema);
+             ]
+           | None -> `String name
+         in
+         let fields =
+           [ ("error", `String "unknown_tool"); ("tool", `String other) ]
+           @ (match suggestion with
+              | [] -> [("hint", `String "Use keeper_tool_search to find available tools.")]
+              | names ->
+                [ ("did_you_mean", `List (List.map enrich_suggestion names));
+                  ("hint", `String "Call one of these tools with the correct parameters.") ])
+         in
+         make_executed_tool_result (Yojson.Safe.to_string (`Assoc fields)))))
 
 let execute_keeper_tool_call
       ~(config : Coord.config)

--- a/lib/keeper/keeper_tag_dispatch.ml
+++ b/lib/keeper/keeper_tag_dispatch.ml
@@ -143,8 +143,9 @@ let dispatch
           "tool '%s' belongs to the removed operator surface; keeper runtime stays on OAS Agent.run" name)
 
   | Mod_autoresearch ->
-      (* Keeper already handles masc_autoresearch_* before reaching this path.
-         If we get here, provide a minimal context without team session starter. *)
+      (* Registered keeper dispatch handles autoresearch explicitly when
+         possible. This fallback still provides a minimal context for tools
+         that reach the generic tag dispatcher. *)
       let ctx : Tool_autoresearch.context =
         {
           base_path = config.base_path;

--- a/test/test_keeper_exec_tools.ml
+++ b/test/test_keeper_exec_tools.ml
@@ -157,6 +157,45 @@ let test_execute_with_outcome_bad_query_is_failure () =
       check string "bad query payload shape" "structured_error"
         (payload_kind result.payload_shape))
 
+let registered_dispatch_probe_tool = "test_keeper_registered_dispatch_probe"
+
+let register_registered_dispatch_probe () =
+  Masc_mcp.Tool_dispatch.register_name_tag
+    ~tool_name:registered_dispatch_probe_tool
+    ~tag:Masc_mcp.Tool_dispatch.Mod_misc;
+  Masc_mcp.Tool_dispatch.register
+    ~tool_name:registered_dispatch_probe_tool
+    ~handler:(fun ~name ~args:_ ->
+      Some
+        ( true
+        , Yojson.Safe.to_string
+            (`Assoc
+              [ ("ok", `Bool true)
+              ; ("tool", `String name)
+              ; ("route", `String "registered")
+              ]) ))
+
+let test_registered_tool_dispatch_without_masc_prefix () =
+  register_registered_dispatch_probe ();
+  check bool "probe has no masc_ prefix" false
+    (String.starts_with ~prefix:"masc_" registered_dispatch_probe_tool);
+  with_exec_fixture "keeper_exec_registered_dispatch"
+    (fun ~config ~meta ~ctx_work:_ ->
+      match
+        Masc_mcp.Keeper_exec_masc.handle_registered_keeper_tool
+          ~config
+          ~meta
+          ~name:registered_dispatch_probe_tool
+          ~args:(`Assoc [])
+      with
+      | None -> fail "expected registered keeper tool dispatch"
+      | Some raw ->
+        let json = Yojson.Safe.from_string raw in
+        check string "registered tool name" registered_dispatch_probe_tool
+          Yojson.Safe.Util.(member "tool" json |> to_string);
+        check string "registered route" "registered"
+          Yojson.Safe.Util.(member "route" json |> to_string))
+
 (* ── Exec cache integration tests ──────────────────────────── *)
 
 let test_exec_cache_miss_then_hit () =
@@ -275,6 +314,8 @@ let () =
         test_execute_with_outcome_missing_file_is_failure;
       test_case "bad query is failure" `Quick
         test_execute_with_outcome_bad_query_is_failure;
+      test_case "registered dispatch does not require masc_ prefix" `Quick
+        test_registered_tool_dispatch_without_masc_prefix;
     ]);
     ("exec_cache", [
       test_case "miss then hit" `Quick test_exec_cache_miss_then_hit;


### PR DESCRIPTION
## Summary
- Replace keeper `masc_` / `masc_autoresearch_` prefix dispatch with `Tool_dispatch` tag/handler registration routing.
- Keep autoresearch on its keeper-specific context path when the registered tag is `Mod_autoresearch`.
- Add a regression test for a registered non-`masc_` tool name reaching keeper dispatch.

## Verification
- `scripts/dune-local.sh build test/test_keeper_exec_tools.exe`
- `./_build/default/test/test_keeper_exec_tools.exe test execute_keeper_tool_call_with_outcome`

## Notes
- Full `test_keeper_exec_tools.exe` was not used as the readiness gate because the pre-existing `exec_cache/miss then hit` case fails locally on Docker socket permission (`/Users/dancer/.docker/run/docker.sock`). The changed dispatch group passes independently.
