### PR TITLE
fix(social-model): type keeper board tool routing

### DIFF
--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
@@ -147,23 +147,33 @@ let inferred_text_reply_state ~(meta : keeper_meta)
   ( make_state ~meta ~observation ?previous_state (),
     { speech_act = Types.Inform; delivery_surface = Types.Visible_reply } )
 
+let keeper_tool_name tool = Tool_name.Keeper.to_string tool
+
+let keeper_tool_name_matches tool name =
+  match Tool_name.Keeper.of_string name with
+  | Some parsed -> parsed = tool
+  | None -> false
+
+let tools_include_keeper tool tools =
+  List.exists (keeper_tool_name_matches tool) tools
+
 let inferred_tool_surface tools =
-  if tools = [ Tool_name.Keeper.to_string Tool_name.Keeper.Stay_silent ] then
+  if tools = [ keeper_tool_name Tool_name.Keeper.Stay_silent ] then
     Some
       ( { speech_act = Types.Stay_silent; delivery_surface = Types.Silent }
       , Types.Tool_only_stay_silent )
-  else if List.mem "keeper_board_comment" tools then
+  else if tools_include_keeper Tool_name.Keeper.Board_comment tools then
     Some
       ( {
           speech_act = Types.Comment_board;
           delivery_surface = Types.Board_comment;
         }
       , Types.Tool_only_comment_board )
-  else if List.mem "keeper_board_post" tools then
+  else if tools_include_keeper Tool_name.Keeper.Board_post tools then
     Some
       ( { speech_act = Types.Post_board; delivery_surface = Types.Board_post }
       , Types.Tool_only_post_board )
-  else if List.mem "keeper_broadcast" tools then
+  else if tools_include_keeper Tool_name.Keeper.Broadcast tools then
     Some
       ( {
           speech_act = Types.Broadcast;
@@ -294,7 +304,7 @@ let deliver_request_help_post ~(meta : keeper_meta)
         Some
           (`Assoc
             [
-              ("source", `String "keeper_board_post");
+              ("source", `String (keeper_tool_name Tool_name.Keeper.Board_post));
               ("social_model", `String state.social_model);
               ( "speech_act",
                 `String (Types.speech_act_to_string state.speech_act) );
@@ -367,7 +377,8 @@ let apply_output_to_result ~(meta : keeper_meta)
       (match deliver_request_help_post ~meta ~state with
       | Request_help_posted ->
           let tools_used =
-            dedupe_keep_order ("keeper_board_post" :: result.tools_used)
+            dedupe_keep_order
+              (keeper_tool_name Tool_name.Keeper.Board_post :: result.tools_used)
           in
           ( { result with
               response_text = "";

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -5068,6 +5068,28 @@ let test_social_model_infers_board_comment_from_tool_use () =
   check (list string) "tool list preserved"
     ["keeper_board_comment"; "masc_status"] routed.tools_used
 
+let test_social_model_does_not_infer_comment_vote_as_board_comment () =
+  let result =
+    make_run_result ~text:""
+      ~tools:["keeper_board_comment_vote"; "masc_status"]
+      ~model:"test-model" ~input_tok:10 ~output_tok:1 ()
+  in
+  let routed, state, transition_reason =
+    KSM.apply_to_result ~meta:minimal_meta
+      ~observation:base_observation ~previous_state:None result
+  in
+  check string "speech act" "inform"
+    (KSM.speech_act_to_string state.speech_act);
+  check string "delivery surface" "visible_reply"
+    (KSM.delivery_surface_to_string state.delivery_surface);
+  check string "transition reason" "tool_only:visible_reply"
+    (KSM.transition_reason_to_string transition_reason);
+  check bool "tool-only turn synthesizes visible response" true
+    (contains_substring routed.response_text
+       "Tools used: keeper_board_comment_vote, masc_status.");
+  check (list string) "tool list preserved"
+    ["keeper_board_comment_vote"; "masc_status"] routed.tools_used
+
 let test_social_model_infers_masc_claim_task_from_tool_use () =
   let result =
     make_run_result ~text:"" ~tools:["masc_claim_task"]
@@ -5953,6 +5975,9 @@ let () =
             test_social_model_tool_only_turn_carries_previous_state;
           test_case "social model infers board comment from tool use" `Quick
             test_social_model_infers_board_comment_from_tool_use;
+          test_case
+            "social model does not infer comment vote as board comment" `Quick
+            test_social_model_does_not_infer_comment_vote_as_board_comment;
           test_case "social model infers masc claim task from tool use" `Quick
             test_social_model_infers_masc_claim_task_from_tool_use;
           test_case "magentic ledger silences tool-only turn" `Quick


### PR DESCRIPTION
## Summary
- route BDI social-model tool-only board surfaces through Tool_name.Keeper typed parsing
- remove raw keeper_board_comment/post/broadcast membership checks from the social model
- add regression coverage so keeper_board_comment_vote stays a visible reply, not a board comment

## Why it matters
This removes another stringly internal routing point from keeper social-state synthesis. Tool strings still enter at the external run-result boundary, but internal board/comment/broadcast routing now uses the typed Tool_name contract added in #10173.

## Validation
- git diff --check origin/main..HEAD
- scripts/dune-local.sh build test/test_keeper_unified.exe
- ./_build/default/test/test_keeper_unified.exe (282 tests, run ID RLM05NMT)