### PR TITLE
feat(observability): timeout overshoot counter in Timeout_policy (#9662)

### DIFF
--- a/lib/timeout_policy.ml
+++ b/lib/timeout_policy.ml
@@ -31,6 +31,30 @@ end
 
 let default_overshoot_slack_s = 5.0
 
+(* #9662: counter for cooperative-cancel overshoot events.
+
+   The 2026-04-23 production trace observed [keeper_llm_bridge]
+   timing out at 596.6s against a 573s budget — a 23.6s overshoot.
+   Eio's cooperative cancellation only fires at the next yield, so
+   a fiber blocked inside an uncancellable region (native HTTP
+   read, syscall, non-yielding loop) keeps running past the
+   [with_timeout_exn] deadline.  The WARN log already surfaces
+   the excess; this counter lets operators alert on the rate
+   without log scraping and attribute overshoots to a specific
+   [(layer, origin)] pair.
+
+   Labels:
+     [layer]  : Layer.to_string output (oas_bridge / tool /
+                keeper_turn / keeper_cycle / shutdown)
+     [origin] : free-form site name passed by caller (e.g.,
+                "keeper_llm_bridge", a tool name).  Caller
+                discipline keeps cardinality bounded — origin
+                strings are intended to be small, named sites,
+                not user-supplied identifiers.
+
+   Cardinality: ~5 layers × ~20 origins = ~100 series. *)
+let metric_overshoot_total = "masc_timeout_policy_overshoot_total"
+
 let overshoot_warn ?(slack_s = default_overshoot_slack_s) ~deadline ~actual_wall_s () =
   let excess = actual_wall_s -. deadline.Deadline.wall_cap_s in
   if excess > slack_s then begin
@@ -42,6 +66,10 @@ let overshoot_warn ?(slack_s = default_overshoot_slack_s) ~deadline ~actual_wall
       actual_wall_s
       excess
       slack_s;
+    Prometheus.inc_counter metric_overshoot_total
+      ~labels:[ ("layer", Layer.to_string deadline.Deadline.layer);
+                ("origin", deadline.Deadline.origin) ]
+      ();
     true
   end
   else

--- a/lib/timeout_policy.mli
+++ b/lib/timeout_policy.mli
@@ -54,6 +54,11 @@ val default_overshoot_slack_s : float
 (** Default grace window applied when distinguishing expected cleanup tail
     from a cooperative-cancel miss. Callers may override per site. *)
 
+val metric_overshoot_total : string
+(** #9662: canonical Prometheus metric name for overshoot events.
+    Labels: [layer, origin].  Internal series name is
+    [masc_timeout_policy_overshoot_total]. *)
+
 val overshoot_warn
   :  ?slack_s:float
   -> deadline:Deadline.t
@@ -61,5 +66,7 @@ val overshoot_warn
   -> unit
   -> bool
 (** Emit a warn-level log when [actual_wall_s] exceeds
-    [deadline.wall_cap_s] by more than [slack_s]. Returns [true] when a
-    warn was emitted so callers can increment a metric. *)
+    [deadline.wall_cap_s] by more than [slack_s].  Also increments
+    {!metric_overshoot_total} with [layer] and [origin] labels.
+    Returns [true] when an overshoot was detected (caller no
+    longer needs to emit a parallel counter). *)

--- a/test/dune
+++ b/test/dune
@@ -328,6 +328,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_timeout_policy_overshoot_counter)
+ (modules test_timeout_policy_overshoot_counter)
+ (libraries masc_test_deps))
+
+(test
  (name test_join_required_guard_counter)
  (modules test_join_required_guard_counter)
  (libraries masc_test_deps))

--- a/test/test_timeout_policy_overshoot_counter.ml
+++ b/test/test_timeout_policy_overshoot_counter.ml
@@ -1,0 +1,118 @@
+(* #9662: pin canonical metric name + label vocabulary for the
+   timeout-policy overshoot counter.  [Timeout_policy.overshoot_warn]
+   emits this counter whenever the actual wall time exceeds the
+   declared deadline by more than the slack window.
+
+   Tests verify:
+   - canonical metric name stable;
+   - within-slack does NOT increment;
+   - past-slack DOES increment;
+   - per-(layer, origin) label isolation. *)
+
+module TP = Masc_mcp.Timeout_policy
+
+let counter_for ~layer ~origin =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    TP.metric_overshoot_total
+    ~labels:[ ("layer", layer); ("origin", origin) ]
+    ()
+
+let make_deadline ~layer ~origin ~wall_cap_s =
+  TP.Deadline.make ~layer ~origin ~wall_cap_s ~now:0.0
+
+let test_metric_name_stable () =
+  Alcotest.(check string)
+    "overshoot canonical metric name"
+    "masc_timeout_policy_overshoot_total"
+    TP.metric_overshoot_total
+
+let test_within_slack_no_increment () =
+  let deadline =
+    make_deadline ~layer:TP.Layer.Oas_bridge
+      ~origin:"slack-test-9662" ~wall_cap_s:573.0
+  in
+  let before = counter_for ~layer:"oas_bridge" ~origin:"slack-test-9662" in
+  (* 575s vs 573s budget, 2s excess — within default 5s slack. *)
+  let warned = TP.overshoot_warn ~deadline ~actual_wall_s:575.0 () in
+  Alcotest.(check bool) "no warn within slack" false warned;
+  Alcotest.(check (float 0.0001))
+    "counter unchanged within slack"
+    before
+    (counter_for ~layer:"oas_bridge" ~origin:"slack-test-9662")
+
+let test_past_slack_increments () =
+  let deadline =
+    make_deadline ~layer:TP.Layer.Oas_bridge
+      ~origin:"keeper_llm_bridge_9662_test" ~wall_cap_s:573.0
+  in
+  let before =
+    counter_for ~layer:"oas_bridge"
+      ~origin:"keeper_llm_bridge_9662_test"
+  in
+  (* The exact #9662 reported case: 596.6s vs 573s = 23.6s excess
+     well past the 5s default slack. *)
+  let warned = TP.overshoot_warn ~deadline ~actual_wall_s:596.6 () in
+  Alcotest.(check bool) "warned past slack" true warned;
+  Alcotest.(check (float 0.0001))
+    "counter +1"
+    (before +. 1.0)
+    (counter_for ~layer:"oas_bridge"
+       ~origin:"keeper_llm_bridge_9662_test")
+
+let test_layer_isolation () =
+  (* Same origin but different layer must land in different
+     series — operators distinguish OAS bridge overshoot from
+     tool-layer overshoot. *)
+  let origin = "layer-iso-9662" in
+  let oas =
+    make_deadline ~layer:TP.Layer.Oas_bridge ~origin ~wall_cap_s:60.0
+  in
+  let tool =
+    make_deadline ~layer:TP.Layer.Tool ~origin ~wall_cap_s:60.0
+  in
+  let before_tool = counter_for ~layer:"tool" ~origin in
+  let _ = TP.overshoot_warn ~deadline:oas ~actual_wall_s:90.0 () in
+  Alcotest.(check (float 0.0001))
+    "tool counter unchanged when oas overshoots"
+    before_tool
+    (counter_for ~layer:"tool" ~origin);
+  let _ = TP.overshoot_warn ~deadline:tool ~actual_wall_s:90.0 () in
+  Alcotest.(check (float 0.0001))
+    "tool counter +1 after tool overshoot"
+    (before_tool +. 1.0)
+    (counter_for ~layer:"tool" ~origin)
+
+let test_origin_isolation () =
+  let layer = TP.Layer.Keeper_turn in
+  let alpha =
+    make_deadline ~layer ~origin:"alpha-9662" ~wall_cap_s:60.0
+  in
+  let _beta =
+    make_deadline ~layer ~origin:"beta-9662" ~wall_cap_s:60.0
+  in
+  let before_beta = counter_for ~layer:"keeper_turn" ~origin:"beta-9662" in
+  let _ = TP.overshoot_warn ~deadline:alpha ~actual_wall_s:90.0 () in
+  Alcotest.(check (float 0.0001))
+    "beta counter unchanged after alpha overshoot"
+    before_beta
+    (counter_for ~layer:"keeper_turn" ~origin:"beta-9662")
+
+let () =
+  Alcotest.run "timeout_policy_overshoot_counter_9662" [
+    "metric_name", [
+      Alcotest.test_case "canonical name stable" `Quick
+        test_metric_name_stable;
+    ];
+    "increment", [
+      Alcotest.test_case "within slack → no increment" `Quick
+        test_within_slack_no_increment;
+      Alcotest.test_case "past slack → +1 (exact #9662 case)" `Quick
+        test_past_slack_increments;
+    ];
+    "isolation", [
+      Alcotest.test_case "layer labels isolated" `Quick
+        test_layer_isolation;
+      Alcotest.test_case "origin labels isolated" `Quick
+        test_origin_isolation;
+    ];
+  ]


### PR DESCRIPTION
## 요약

`Timeout_policy.overshoot_warn`이 fire될 때 `masc_timeout_policy_overshoot_total{layer, origin}` Prometheus counter도 같이 증가. WARN log만으론 fleet-wide rate 측정 불가했던 cooperative-cancel overshoot을 metric channel로 surfacing.

Closes part of #9662 (observability for cooperative-cancel overshoot).

## 근본 원인

이슈 보고 (2026-04-23 18:43:21):
```
keeper_llm_bridge: OAS execution timed out after 596.6s (budget=573s)
```

23.6s overshoot. Eio의 cooperative cancellation은 next yield에서만 fire — fiber가 uncancellable region (native HTTP read, syscall, non-yielding loop) 안에 있으면 `with_timeout_exn` 발화해도 fiber가 계속 진행. budget=573s가 hard cap이 아닌 advisory cap으로 동작.

기존 detection:
- `Timeout_policy.overshoot_warn`이 excess > slack 시 WARN log emit
- `keeper_llm_bridge.ml:48`이 helper 호출하여 detection 가능

Missing:
- Prometheus counter — operator가 rate 추적/alert 불가능

## 변경 내용

### `lib/timeout_policy.{ml,mli}`

```ocaml
let metric_overshoot_total = "masc_timeout_policy_overshoot_total"

let overshoot_warn ?(slack_s = default_overshoot_slack_s) ~deadline ~actual_wall_s () =
  let excess = actual_wall_s -. deadline.Deadline.wall_cap_s in
  if excess > slack_s then begin
    Log.Keeper.warn ...;
    Prometheus.inc_counter metric_overshoot_total
      ~labels:[ ("layer", Layer.to_string deadline.layer);
                ("origin", deadline.origin) ]
      ();
    true
  end
  else false
```

`overshoot_warn`이 SSOT — 모든 caller (현재 keeper_llm_bridge:48만 사용 중) 자동으로 metric에 기여. Caller side 변경 없음.

### Labels

- `layer`: `Layer.to_string` 출력 — `oas_bridge | tool | keeper_turn | keeper_cycle | shutdown` (5)
- `origin`: caller-controlled site name (e.g., `keeper_llm_bridge`) — bounded set (~20 named sites)

Cardinality: 5 × 20 = ~100 series. 안전.

## 운영 활용

```promql
# Layer × origin 별 overshoot rate ranking
sort_desc(
  sum by (layer, origin) (
    rate(masc_timeout_policy_overshoot_total[5m])
  )
)

# Overshoot이 가장 심한 layer 식별
sum by (layer) (rate(masc_timeout_policy_overshoot_total[5m]))

# Budget tuning 전후 비교
masc_timeout_policy_overshoot_total
```

## 테스트

`test/test_timeout_policy_overshoot_counter.ml` 5 scenario:

```bash
$ dune exec test/test_timeout_policy_overshoot_counter.exe
[OK]  metric_name  0  canonical name stable.
[OK]  increment    0  within slack → no increment.
[OK]  increment    1  past slack → +1 (exact #9662 case).
[OK]  isolation    0  layer labels isolated.
[OK]  isolation    1  origin labels isolated.
Test Successful in 0.003s. 5 tests run.
```

특히 첫 시나리오(`within slack → no increment`): 575s actual vs 573s budget = 2s excess는 default 5s slack 안 → counter 증가 안 함. False positive 방지.

두 번째 (`past slack → +1`): 정확한 #9662 reported case (596.6s vs 573s = 23.6s excess) — counter +1.

## 회귀 리스크

매우 낮음. Pure additive — 기존 `overshoot_warn` semantic (boolean return + WARN log) 동일, Prometheus counter만 추가. Caller code 변경 없음.

## 후속 (별건)

- **Root cause fix**: Eio cooperative-cancel limitation은 OCaml runtime 레벨 — uncancellable native call에 explicit yield point 추가 필요. #9639의 deeper investigation 트랙. 본 PR로 measurement 확보 후 prioritize.
- **Slack tuning**: Default 5s slack은 보수적. 실제 cleanup tail이 < 1s면 slack 줄여서 detection sensitivity 높일 수 있음. counter rate 관찰 후 결정.
- **Per-origin SLO**: 각 origin별 overshoot rate target을 SLO로 명시. 이상 시 alert.

## 참고

- Issue #9662
- `lib/timeout_policy.ml:32-66` — counter wiring
- `lib/keeper/keeper_llm_bridge.ml:46-49` — 기존 단일 caller
- `test/test_timeout_policy_overshoot_counter.ml` — coverage
- 관련: #9639 (timeout layering meta), #9629 (governance OAS 60s), #9637 (keeper turn 1200s)
