### PR TITLE
fix(timeouts): raise keeper turn + governance judge defaults (#9637)

### DIFF
--- a/lib/config/env_config_governance.ml
+++ b/lib/config/env_config_governance.ml
@@ -34,7 +34,7 @@ module Inference = struct
     in
     let chosen =
       if dedicated > 0 then dedicated
-      else max 180 timeout_seconds_int
+      else max 300 timeout_seconds_int
     in
     max 5 chosen
 

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -292,12 +292,15 @@ module KeeperKeepalive = struct
   (** Wall-clock timeout in seconds for a single unified turn (including all
       retries and cascade fallbacks). Prevents indefinite blocking when an
       upstream LLM hangs at the TCP level.
-      Env: [MASC_KEEPER_TURN_TIMEOUT_SEC]. Default: 1200. Range: [60, 3600].
-      Raised from 600 to 1200: keepers using GLM-5.1 + local 27B need more
-      wall-clock time for multi-turn research cycles. *)
+      Env: [MASC_KEEPER_TURN_TIMEOUT_SEC]. Default: 3600. Range: [60, 7200].
+      Raised from 1200 to 3600 (issue #9637): production fleet observed
+      "turn wall-clock timeout after 1200s" with sangsu/qa-king keepers
+      stalling on multi-turn research cycles using GLM-5.1 + local 27B
+      cascade. The new floor matches the budgeted ceiling and gives
+      operators headroom; range upper bumped to 7200 for the same reason. *)
   let turn_timeout_sec =
-    Float.max 60.0 (Float.min 3600.0
-      (get_float ~default:1200.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
+    Float.max 60.0 (Float.min 7200.0
+      (get_float ~default:3600.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
 
   (** Maximum time a proactive keeper will wait in the MASC admission queue
       before abandoning the current OAS attempt.

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -131,11 +131,11 @@ let test_oas_timeout_is_token_independent () =
 let test_oas_timeout_cap () =
   let v = adaptive ~estimated_input_tokens:1_000_000 in
   check (float 0.1)
-    "1M estimated input tokens → capped at turn timeout 1200"
+    "1M estimated input tokens → capped at turn_timeout_sec"
     turn_cap v
 
 let test_turn_timeout_default () =
-  check (float 0.1) "default turn timeout 1200s" 1200.0
+  check (float 0.1) "default turn timeout 3600s" 3600.0
     Cfg.KeeperKeepalive.turn_timeout_sec
 
 let test_max_turns_default () =
@@ -382,7 +382,7 @@ let () =
         test_oas_timeout_zero_uses_wall_clock;
       test_case "budget is token-count independent (#10008 fm2)" `Quick
         test_oas_timeout_is_token_independent;
-      test_case "turn timeout default is 1200" `Quick test_turn_timeout_default;
+      test_case "turn timeout default is 3600" `Quick test_turn_timeout_default;
       test_case "adaptive capped at turn timeout" `Quick test_oas_timeout_cap;
       test_case "max_turns default is 30" `Quick test_max_turns_default;
       test_case "scheduled autonomous max_turns default is 10" `Quick


### PR DESCRIPTION
## Summary

Production fleet hit `turn_timeout` at 1200s in #9637 (sangsu and qa-king at 2026-04-23 18:58:15-17). Raise the wall-clock ceiling so multi-turn research cycles do not starve under GLM-5.1 + local 27B cascade load.

## Changes

| File | Before | After | Rationale |
|------|--------|-------|-----------|
| `env_config_keeper.ml` `turn_timeout_sec` default | 1200 | 3600 | #9637 incident: 1200s insufficient |
| `env_config_keeper.ml` `turn_timeout_sec` range upper | 3600 | 7200 | operator headroom for high-latency profiles |
| `env_config_governance.ml` `dashboard_governance_judge_timeout_seconds` default | 180 | 300 | #10132 chain: 60→180 (merged), 180→300 here, motivated by #9629 governance fail loop |
| `test/test_work_as_heartbeat.ml` | pin 1200 | pin 3600 | follow default change |

## Evidence

From #9637 issue body:

```
[ERROR] [Keeper] sangsu: keeper cycle FAILED ... latency=1391820ms
        error=[masc_oas_error] {"kind":"turn_timeout","elapsed_sec":1200.0}
[ERROR] [Keeper] qa-king: keeper cycle FAILED ... latency=1264961ms
        error=[masc_oas_error] {"kind":"turn_timeout","elapsed_sec":1200.0}
```

Latency observed (1391s, 1264s) > old default (1200) → 새 default 3600 가 ~2.6× headroom 확보.

## Why not surgical (per-keeper override)?

`MASC_KEEPER_TURN_TIMEOUT_SEC` env var already exists. Operator can already override per-instance. The default itself was the production bottleneck — every keeper that did not set the env var hit the cap.

## Stuck-turn safety

Higher ceiling could in theory delay stuck-turn detection. This is mitigated:
- `#10169` (gate stuck turn livelocks) — separate FSM path, runs independently
- `#10147` (supervisor max_restarts loud alert) — independent path
- `#10166` per-(tool, agent) `join_required` guard counter — independent telemetry

These observe stuck/livelock conditions without depending on `turn_timeout_sec` being the trip wire.

## Test plan

- [x] `dune build` (sandbox) — green.
- [x] `dune test test/test_work_as_heartbeat.ml` — green after pin update (50/50).
- [ ] Full `dune runtest` (CI).
- [ ] Production canary: `sangsu` and `qa-king` keepers complete a research cycle without `turn_timeout` for 24h.

## Defensive PR posture

- Created with `--label do-not-merge`.
- `gh pr ready --undo` + `gh pr merge --disable-auto` applied immediately after creation per `feedback_do-not-merge-label-insufficient.md`.

Closes #9637
Related: #9629, #9933, #10132