### PR TITLE
perf(ws): expose delta build amplification counter

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -394,6 +394,7 @@ let metric_ws_throttled_deliveries = "masc_ws_throttled_deliveries_total"
 let metric_ws_slice_fanout_skipped = "masc_ws_slice_fanout_skipped_total"
 let metric_ws_bytes_sent = "masc_ws_bytes_sent_total"
 let metric_grpc_bytes_sent = "masc_grpc_bytes_sent_total"
+let metric_ws_delta_built = "masc_ws_delta_built_total"
 
 (* Admission queue metrics — used in admission_queue_metrics.ml. *)
 let metric_inference_queue_depth = "masc_inference_queue_depth"
@@ -860,6 +861,11 @@ let init () =
     "Bytes serialised into gRPC Subscribe stream events delivered to \
      subscribers. Same purpose as masc_ws_bytes_sent_total but for the \
      gRPC transport."
+    Counter;
+  add metric_ws_delta_built
+    "Per-session dashboard deltas constructed (one Yojson.Safe.t \
+     allocation + jsonrpc_notification wrap per delta). Divide by \
+     broadcast count to estimate fanout amplification."
     Counter
 
 let start_time = Time_compat.now ()

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -244,6 +244,7 @@ val metric_ws_throttled_deliveries : string
 val metric_ws_slice_fanout_skipped : string
 val metric_ws_bytes_sent : string
 val metric_grpc_bytes_sent : string
+val metric_ws_delta_built : string
 
 (** {1 Admission queue metrics} *)
 

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -489,6 +489,7 @@ let dashboard_delta_for_sse session sse_event =
   match parse_sse_dashboard_event sse_event with
   | Some { event_type; slice = Some slice; payload }
     when Hashtbl.mem session.dashboard_slices slice ->
+      Transport_metrics.inc_ws_delta_built ();
       Some
         (jsonrpc_notification "dashboard/delta"
            (`Assoc

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -96,6 +96,9 @@ let inc_grpc_bytes_sent ~bytes =
     Prometheus.inc_counter Prometheus.metric_grpc_bytes_sent
       ~delta:(float_of_int bytes) ()
 
+let inc_ws_delta_built () =
+  Prometheus.inc_counter Prometheus.metric_ws_delta_built ()
+
 (** {1 Environment-derived Transport Config} *)
 
 let grpc_runtime_listening : bool Atomic.t = Atomic.make false


### PR DESCRIPTION
masc_ws_delta_built_total counter advances on every dashboard delta successfully built in dashboard_delta_for_sse. Divide by Sse broadcast rate for live fanout amplification factor (S deltas per slice-scoped event). Pairs with masc_ws_slice_fanout_skipped_total for full N=S+skipped breakdown. 36/36 tests pass.