### PR TITLE
fix(auth): allow unmapped keeper_* runtime tools in strict mode (#10183)

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -679,13 +679,36 @@ let is_protocol_canonical_tool_name tool_name =
   || String.starts_with ~prefix:"experiment." tool_name
   || String.starts_with ~prefix:"client." tool_name
 
+(* #10183: keeper-bound runtime tools ([keeper_shell], [keeper_bash],
+   [keeper_task_claim], …) are not [masc_*] but ARE first-class
+   internal tools dispatched by every keeper.  When
+   [permission_for_tool] does not have an entry for them, the
+   strict-mode gate below treats them as foreign and rejects with
+   [Forbidden "unknown non-masc tool"].  Production audit
+   (2026-04-25) caught the analyst keeper hitting this path 116
+   times — keeper_shell x22, keeper_bash x10, keeper_task_claim
+   x10, etc. — across 12+ tools.  The 13 other keepers were
+   unaffected because their token resolves through a credential
+   path whose tools [permission_for_tool] already maps; analyst's
+   token took the codex_cli path and fell through to the
+   unmapped branch.
+
+   Until that token-routing regression
+   (#9786 / #10183 Option D) is addressed, broaden the prefix
+   gate so [keeper_*] tools survive the auth boundary regardless
+   of which credential path resolved them. *)
+let is_keeper_runtime_tool_name tool_name =
+  String.starts_with ~prefix:"keeper_" tool_name
+
 (** Check permission for a tool call *)
 let authorize_tool config ~agent_name ~token ~tool_name : (unit, masc_error) result =
   match permission_for_tool tool_name with
   | None ->
       if not (is_tool_auth_strict_enabled ()) then
         Ok ()  (* Legacy fail-open *)
-      else if is_masc_tool_name tool_name || is_protocol_canonical_tool_name tool_name then
+      else if is_masc_tool_name tool_name
+              || is_protocol_canonical_tool_name tool_name
+              || is_keeper_runtime_tool_name tool_name then
         (* Conservative default in strict mode for unmapped internal tools. *)
         check_permission config ~agent_name ~token ~permission:CanBroadcast
       else
@@ -739,7 +762,8 @@ let authorize_tool_for_role ~agent_name ~role ~tool_name :
     | Some _ -> Ok ()  (* Mapped tool — policy already checked *)
     | None ->
         if is_masc_tool_name tool_name
-           || is_protocol_canonical_tool_name tool_name then
+           || is_protocol_canonical_tool_name tool_name
+           || is_keeper_runtime_tool_name tool_name then
           (* Unmapped internal tool: require at least Worker *)
           if has_permission role CanBroadcast then Ok ()
           else Error (Forbidden { agent = agent_name; action = tool_name })

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -740,6 +740,73 @@ let test_authorize_unknown_canonical_tool_strict_worker_allowed () =
   | Ok () -> ()
   | Error e -> fail (Types.masc_error_to_string e)
 
+(* #10183: keeper-bound runtime tools (keeper_-prefixed) must
+   not be rejected at the strict-mode auth boundary even when
+   permission_for_tool has no entry for them.  The analyst
+   keeper regression hit this path 116 times across keeper_shell,
+   keeper_bash, keeper_task_claim, etc. *)
+let test_authorize_unknown_keeper_runtime_tool_strict_worker_allowed () =
+  let dir = setup_test_room () in
+  let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
+  let create_result =
+    Auth.create_token dir ~agent_name:"worker_agent" ~role:Types.Worker
+  in
+  let try_tool tool_name =
+    match create_result with
+    | Ok (raw_token, _) ->
+        with_env "MASC_TOOL_AUTH_STRICT" "1" (fun () ->
+            Auth.authorize_tool dir ~agent_name:"worker_agent"
+              ~token:(Some raw_token) ~tool_name)
+    | Error e -> Error e
+  in
+  let outcomes =
+    List.map
+      (fun tn -> (tn, try_tool tn))
+      [
+        "keeper_shell";
+        "keeper_bash";
+        "keeper_task_claim";
+        "keeper_tasks_list";
+        "keeper_board_search";
+      ]
+  in
+  cleanup_test_room dir;
+  List.iter
+    (fun (tn, r) ->
+      match r with
+      | Ok () -> ()
+      | Error e ->
+          fail
+            (Printf.sprintf "%s should be allowed in strict mode but got: %s"
+               tn (Types.masc_error_to_string e)))
+    outcomes
+
+(* Negative regression: a tool name that ONLY embeds "keeper_" as
+   a substring (not a prefix) must still be treated as foreign so
+   the gate cannot be bypassed by clever naming. *)
+let test_authorize_keeper_substring_not_prefix_still_denied () =
+  let dir = setup_test_room () in
+  let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
+  let create_result =
+    Auth.create_token dir ~agent_name:"worker_agent" ~role:Types.Worker
+  in
+  let result =
+    match create_result with
+    | Ok (raw_token, _) ->
+        with_env "MASC_TOOL_AUTH_STRICT" "1" (fun () ->
+            Auth.authorize_tool dir ~agent_name:"worker_agent"
+              ~token:(Some raw_token) ~tool_name:"evil_keeper_shell")
+    | Error e -> Error e
+  in
+  cleanup_test_room dir;
+  match result with
+  | Ok () ->
+      fail "tool name with keeper_ as substring (not prefix) should be denied"
+  | Error (Types.Forbidden _) -> ()
+  | Error e ->
+      fail
+        (Printf.sprintf "wrong error: %s" (Types.masc_error_to_string e))
+
 let test_declared_tool_permission_from_tool_spec () =
   let name = "__test_declared_permission_tool" in
   let spec =
@@ -843,6 +910,10 @@ let () =
         `Quick test_authorize_unknown_non_masc_tool_strict_denied;
       test_case "strict unknown canonical tool allows worker"
         `Quick test_authorize_unknown_canonical_tool_strict_worker_allowed;
+      test_case "strict keeper_* runtime tool allows worker (#10183)"
+        `Quick test_authorize_unknown_keeper_runtime_tool_strict_worker_allowed;
+      test_case "keeper_ substring (not prefix) still denied (#10183)"
+        `Quick test_authorize_keeper_substring_not_prefix_still_denied;
       test_case "declared tool permission from Tool_spec"
         `Quick test_declared_tool_permission_from_tool_spec;
     ];


### PR DESCRIPTION
## Summary

#10183 reports the analyst keeper hitting the strict-mode auth boundary 116 times in a single session and being rejected with \`unknown non-masc tool\` on every dispatch.  Affected tools (12+ distinct):

| count | tool |
|---:|---|
| 22 | keeper_shell |
| 18 | keeper_ta… (truncated in WARN) |
| 13 | keeper_bo… |
| 10 | keeper_task_claim |
| 10 | keeper_bash |
|  8 | keeper_tasks_list |
|  7 | keeper_board_search |
|  5 | keeper_fs_read |
|  5 | keeper_board_list |

The 13 other keepers ran the same tools without trouble.

## Root cause

The strict-mode gate in \`authorize_tool\` and \`authorize_tool_for_role\` accepts:
- \`masc_*\` prefix (\`is_masc_tool_name\`)
- \`decision.|experiment.|client.\` canonical (\`is_protocol_canonical_tool_name\`)

…but treats \`keeper_*\` as foreign.  When \`permission_for_tool\` has no entry for the dispatched name, the gate falls through to \`Forbidden { action = "use unknown non-masc tool: " ^ tool_name }\`.

The 13 other keepers were unaffected because their token resolves through a credential path whose tools \`permission_for_tool\` already maps; analyst's token took the \`codex_cli\` path and landed on the unmapped branch — likely the cross-agent credential reuse pattern in #9786.

## Fix (Option B from issue)

Introduce \`is_keeper_runtime_tool_name\` alongside the existing two prefix predicates and add it to both strict-mode gates with the same "require at least Worker" semantics:

\`\`\`ocaml
let is_keeper_runtime_tool_name tool_name =
  String.starts_with ~prefix:"keeper_" tool_name

(* in both gates: *)
if is_masc_tool_name tool_name
   || is_protocol_canonical_tool_name tool_name
   || is_keeper_runtime_tool_name tool_name then
  (* require at least Worker / CanBroadcast *)
\`\`\`

No new permission level introduced — same semantics as the masc and canonical branches.

## Why not Option A (broaden \`is_masc_tool_name\`)

Option A (\`is_masc_tool_name\` accepts \`keeper_\` too) would make the function name a lie ("masc tool" includes keeper tools).  A separate predicate keeps the semantics clean and makes future audits explicit about which prefix family is being unblocked.

## Why not Option C (full \`permission_for_tool\` map of every keeper_*)

Option C is the most robust long-term fix but expensive (every new keeper_* tool needs a permission entry, easy to forget).  This PR is the defensive fix; Option C can land later as enumeration work.

## Why not Option D (analyst token routing fix)

Option D needs deeper investigation of #9786 (cross-agent credential reuse) to understand exactly why analyst's token resolves to codex_cli credential.  That's a separate, larger PR.  This PR keeps the fleet running without changing the permission model.

## Test plan

- [x] \`dune build --root . lib/\` clean
- [x] \`dune exec test/test_auth.exe\` — 40 tests pass (38 prior + 2 new):
  - **\`strict keeper_* runtime tool allows worker\`**: all five prod-log tool families (\`keeper_shell\`, \`keeper_bash\`, \`keeper_task_claim\`, \`keeper_tasks_list\`, \`keeper_board_search\`) succeed in strict mode for a Worker.
  - **\`keeper_ substring (not prefix) still denied\`**: \`evil_keeper_shell\` (keeper_ as substring) remains \`Forbidden\` — gate cannot be bypassed by clever naming.

- [ ] Deploy: confirm analyst's 116-events/session rejection rate drops to zero on the affected fleet without changing other keepers' behaviour.

## Refs

- #9786 (OPEN): cross-agent credential reuse — likely upstream of the analyst-specific token routing that made this codepath reachable
- #10101 (CLOSED): tool_help registry drift — same class (registry didn't enumerate keeper_* tools either)
- #4513 (CLOSED): prompt_override strict-mode gate — similar defensive fix shape

## Do-not-merge

\`do-not-merge\` label set so the auto-merge pipeline does not flip this Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)