### PR TITLE
fix(auth): allow keeper runtime tools in strict mode

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -708,7 +708,7 @@ let permission_for_tool tool_name =
 
 (** Strict tool auth mode:
     - 0/false: legacy fail-open for unknown tools
-    - 1/true: unknown masc_* tools require at least worker-level permission *)
+    - 1/true: unknown internal tools require at least worker-level permission *)
 let is_tool_auth_strict_enabled () =
   Env_config_core.tool_auth_strict ()
 
@@ -720,26 +720,22 @@ let is_protocol_canonical_tool_name tool_name =
   || String.starts_with ~prefix:"experiment." tool_name
   || String.starts_with ~prefix:"client." tool_name
 
-(* #10183: keeper-bound runtime tools ([keeper_shell], [keeper_bash],
-   [keeper_task_claim], …) are not [masc_*] but ARE first-class
-   internal tools dispatched by every keeper.  When
-   [permission_for_tool] does not have an entry for them, the
-   strict-mode gate below treats them as foreign and rejects with
-   [Forbidden "unknown non-masc tool"].  Production audit
-   (2026-04-25) caught the analyst keeper hitting this path 116
-   times — keeper_shell x22, keeper_bash x10, keeper_task_claim
-   x10, etc. — across 12+ tools.  The 13 other keepers were
-   unaffected because their token resolves through a credential
-   path whose tools [permission_for_tool] already maps; analyst's
-   token took the codex_cli path and fell through to the
-   unmapped branch.
+(* Keeper runtime tools are internal only when the catalog owns
+   them; a [keeper_*] prefix alone is not enough to cross auth. *)
+let is_unmapped_internal_tool_name tool_name =
+  is_masc_tool_name tool_name
+  || is_protocol_canonical_tool_name tool_name
+  || Tool_catalog.is_on_surface Tool_catalog.Keeper_internal tool_name
 
-   Until that token-routing regression
-   (#9786 / #10183 Option D) is addressed, broaden the prefix
-   gate so [keeper_*] tools survive the auth boundary regardless
-   of which credential path resolved them. *)
-let is_keeper_runtime_tool_name tool_name =
-  String.starts_with ~prefix:"keeper_" tool_name
+let unknown_tool_class tool_name =
+  if String.trim tool_name = "" then "empty" else "external"
+
+let record_strict_unknown_tool_denial ~agent_name ~tool_name =
+  Prometheus.inc_counter
+    Prometheus.metric_auth_strict_unknown_tool_denials
+    ~labels:
+      [ ("agent_name", agent_name); ("tool_class", unknown_tool_class tool_name) ]
+    ()
 
 (** Check permission for a tool call *)
 let authorize_tool config ~agent_name ~token ~tool_name : (unit, masc_error) result =
@@ -747,13 +743,17 @@ let authorize_tool config ~agent_name ~token ~tool_name : (unit, masc_error) res
   | None ->
       if not (is_tool_auth_strict_enabled ()) then
         Ok ()  (* Legacy fail-open *)
-      else if is_masc_tool_name tool_name
-              || is_protocol_canonical_tool_name tool_name
-              || is_keeper_runtime_tool_name tool_name then
+      else if is_unmapped_internal_tool_name tool_name then
         (* Conservative default in strict mode for unmapped internal tools. *)
         check_permission config ~agent_name ~token ~permission:CanBroadcast
       else
-        Error (Forbidden { agent = agent_name; action = "use unknown non-masc tool" })
+        let () = record_strict_unknown_tool_denial ~agent_name ~tool_name in
+        Error
+          (Forbidden
+             {
+               agent = agent_name;
+               action = "use unknown non-masc tool: " ^ tool_name;
+             })
   | Some perm -> check_permission config ~agent_name ~token ~permission:perm
 
 (* ============================================ *)
@@ -802,13 +802,12 @@ let authorize_tool_for_role ~agent_name ~role ~tool_name :
     match permission_for_tool tool_name with
     | Some _ -> Ok ()  (* Mapped tool — policy already checked *)
     | None ->
-        if is_masc_tool_name tool_name
-           || is_protocol_canonical_tool_name tool_name
-           || is_keeper_runtime_tool_name tool_name then
+        if is_unmapped_internal_tool_name tool_name then
           (* Unmapped internal tool: require at least Worker *)
           if has_permission role CanBroadcast then Ok ()
           else Error (Forbidden { agent = agent_name; action = tool_name })
         else
+          let () = record_strict_unknown_tool_denial ~agent_name ~tool_name in
           Error
             (Forbidden
                {
@@ -822,8 +821,8 @@ let authorize_tool_for_role ~agent_name ~role ~tool_name :
 
     Strict mode (MASC_TOOL_AUTH_STRICT, default=true):
     Tools not mapped by permission_for_tool are subject to additional
-    checks — unmapped masc_* tools require at least Worker, and
-    unmapped non-masc tools are forbidden. *)
+    checks — unmapped internal tools require at least Worker, and
+    unmapped external tools are forbidden. *)
 let authorize_tool_v2 config ~agent_name ~token ~tool_name : (unit, masc_error) result =
   match resolve_role config ~agent_name ~token with
   | Error e -> Error e

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -544,6 +544,13 @@ let metric_fs_atomic_orphans_cleaned =
 let metric_auth_bearer_token_mismatch =
   "masc_auth_bearer_token_mismatch_total"
 
+(* #10183: strict Auth rejects unknown external tools.  Before this,
+   repeated "unknown non-masc tool" denials were only visible by
+   grepping logs.  Keep labels bounded: [agent_name] is fleet-sized
+   and [tool_class] is a small vocabulary, not the raw tool name. *)
+let metric_auth_strict_unknown_tool_denials =
+  "masc_auth_strict_unknown_tool_denials_total"
+
 (* #9786 follow-up: boot-time audit counter for credentials
    sharing the same token hash.  Distinct from
    [bearer_token_mismatch]: the mismatch counter fires per
@@ -869,6 +876,12 @@ let init () =
      requested agent_name (labels: expected_agent, actual_agent). Rate \
      advancing after a server restart indicates shared credential state \
      (connection pool / process fork) across agent identities."
+    Counter;
+  add metric_auth_strict_unknown_tool_denials
+    "Total strict Auth rejects for unknown external tools \
+     (labels: agent_name, tool_class=empty|external). This catches \
+     fleet-wide tool dispatch regressions without using raw tool names \
+     as metric labels."
     Counter;
   (* Transport metrics — registered here so transport_metrics.ml can use
      module constants instead of string literals. *)

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -239,6 +239,11 @@ val metric_fs_atomic_orphans_cleaned : string
     signal of shared credential state (connection pool / fork). *)
 val metric_auth_bearer_token_mismatch : string
 
+val metric_auth_strict_unknown_tool_denials : string
+(** #10183: strict Auth rejects for unknown external tools.  Labels:
+    [agent_name, tool_class] where [tool_class] is bounded to
+    [empty | external]. *)
+
 val metric_auth_credential_token_duplicate : string
 (** #9786 follow-up: boot-time audit counter for credentials
     sharing the same token hash.  Increments once per boot per

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -83,6 +83,22 @@ let capture_stderr f =
   Unix.close pipe_read;
   Buffer.contents buf
 
+let strict_unknown_tool_denial_count ~agent_name ~tool_class =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    Masc_mcp.Prometheus.metric_auth_strict_unknown_tool_denials
+    ~labels:[ ("agent_name", agent_name); ("tool_class", tool_class) ]
+    ()
+
+let keeper_strict_auth_regression_tools =
+  [
+    "keeper_shell";
+    "keeper_bash";
+    "keeper_task_claim";
+    "keeper_fs_read";
+    "keeper_board_search";
+    "keeper_tools_list";
+  ]
+
 (* ============================================ *)
 (* Token generation tests                       *)
 (* ============================================ *)
@@ -709,6 +725,10 @@ let test_authorize_unknown_non_masc_tool_strict_denied () =
   let dir = setup_test_room () in
   let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
   let create_result = Auth.create_token dir ~agent_name:"worker_agent" ~role:Types.Worker in
+  let before =
+    strict_unknown_tool_denial_count
+      ~agent_name:"worker_agent" ~tool_class:"external"
+  in
   let result =
     match create_result with
     | Ok (raw_token, _) ->
@@ -720,7 +740,11 @@ let test_authorize_unknown_non_masc_tool_strict_denied () =
   cleanup_test_room dir;
   match result with
   | Ok () -> fail "unknown non-masc tool should be denied in strict mode"
-  | Error (Types.Forbidden _) -> ()
+  | Error (Types.Forbidden _) ->
+      check (float 0.0001) "denial counter increments"
+        (before +. 1.0)
+        (strict_unknown_tool_denial_count
+           ~agent_name:"worker_agent" ~tool_class:"external")
   | Error e -> fail (Printf.sprintf "wrong error: %s" (Types.masc_error_to_string e))
 
 let test_authorize_unknown_canonical_tool_strict_worker_allowed () =
@@ -740,72 +764,57 @@ let test_authorize_unknown_canonical_tool_strict_worker_allowed () =
   | Ok () -> ()
   | Error e -> fail (Types.masc_error_to_string e)
 
-(* #10183: keeper-bound runtime tools (keeper_-prefixed) must
-   not be rejected at the strict-mode auth boundary even when
-   permission_for_tool has no entry for them.  The analyst
-   keeper regression hit this path 116 times across keeper_shell,
-   keeper_bash, keeper_task_claim, etc. *)
-let test_authorize_unknown_keeper_runtime_tool_strict_worker_allowed () =
+let test_authorize_known_keeper_tool_strict_worker_allowed () =
   let dir = setup_test_room () in
   let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
   let create_result =
-    Auth.create_token dir ~agent_name:"worker_agent" ~role:Types.Worker
-  in
-  let try_tool tool_name =
-    match create_result with
-    | Ok (raw_token, _) ->
-        with_env "MASC_TOOL_AUTH_STRICT" "1" (fun () ->
-            Auth.authorize_tool dir ~agent_name:"worker_agent"
-              ~token:(Some raw_token) ~tool_name)
-    | Error e -> Error e
-  in
-  let outcomes =
-    List.map
-      (fun tn -> (tn, try_tool tn))
-      [
-        "keeper_shell";
-        "keeper_bash";
-        "keeper_task_claim";
-        "keeper_tasks_list";
-        "keeper_board_search";
-      ]
-  in
-  cleanup_test_room dir;
-  List.iter
-    (fun (tn, r) ->
-      match r with
-      | Ok () -> ()
-      | Error e ->
-          fail
-            (Printf.sprintf "%s should be allowed in strict mode but got: %s"
-               tn (Types.masc_error_to_string e)))
-    outcomes
-
-(* Negative regression: a tool name that ONLY embeds "keeper_" as
-   a substring (not a prefix) must still be treated as foreign so
-   the gate cannot be bypassed by clever naming. *)
-let test_authorize_keeper_substring_not_prefix_still_denied () =
-  let dir = setup_test_room () in
-  let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
-  let create_result =
-    Auth.create_token dir ~agent_name:"worker_agent" ~role:Types.Worker
+    Auth.create_token dir ~agent_name:"keeper-analyst-agent" ~role:Types.Worker
   in
   let result =
     match create_result with
     | Ok (raw_token, _) ->
         with_env "MASC_TOOL_AUTH_STRICT" "1" (fun () ->
-            Auth.authorize_tool dir ~agent_name:"worker_agent"
-              ~token:(Some raw_token) ~tool_name:"evil_keeper_shell")
+            List.fold_left
+              (fun acc tool_name ->
+                 match acc with
+                 | Error _ as e -> e
+                 | Ok () ->
+                     Auth.authorize_tool dir ~agent_name:"keeper-analyst-agent"
+                       ~token:(Some raw_token) ~tool_name)
+              (Ok ()) keeper_strict_auth_regression_tools)
     | Error e -> Error e
   in
   cleanup_test_room dir;
   match result with
-  | Ok () ->
-      fail "tool name with keeper_ as substring (not prefix) should be denied"
+  | Ok () -> ()
+  | Error e -> fail (Types.masc_error_to_string e)
+
+let test_authorize_tool_v2_known_keeper_tool_strict_worker_allowed () =
+  let result =
+    with_env "MASC_TOOL_AUTH_STRICT" "1" (fun () ->
+        List.fold_left
+          (fun acc tool_name ->
+             match acc with
+             | Error _ as e -> e
+             | Ok () ->
+                 Auth.authorize_tool_for_role ~agent_name:"keeper-analyst-agent"
+                   ~role:Types.Worker ~tool_name)
+          (Ok ()) keeper_strict_auth_regression_tools)
+  in
+  match result with
+  | Ok () -> ()
+  | Error e -> fail (Types.masc_error_to_string e)
+
+let test_authorize_tool_v2_unknown_keeper_prefix_strict_denied () =
+  let result =
+    with_env "MASC_TOOL_AUTH_STRICT" "1" (fun () ->
+        Auth.authorize_tool_for_role ~agent_name:"keeper-analyst-agent"
+          ~role:Types.Worker ~tool_name:"keeper_totally_fake")
+  in
+  match result with
+  | Ok () -> fail "unknown keeper_* prefix should not bypass strict auth"
   | Error (Types.Forbidden _) -> ()
-  | Error e ->
-      fail
-        (Printf.sprintf "wrong error: %s" (Types.masc_error_to_string e))
+  | Error e -> fail (Printf.sprintf "wrong error: %s" (Types.masc_error_to_string e))
 
 let test_declared_tool_permission_from_tool_spec () =
   let name = "__test_declared_permission_tool" in
@@ -910,10 +919,12 @@ let () =
         `Quick test_authorize_unknown_non_masc_tool_strict_denied;
       test_case "strict unknown canonical tool allows worker"
         `Quick test_authorize_unknown_canonical_tool_strict_worker_allowed;
-      test_case "strict keeper_* runtime tool allows worker (#10183)"
-        `Quick test_authorize_unknown_keeper_runtime_tool_strict_worker_allowed;
-      test_case "keeper_ substring (not prefix) still denied (#10183)"
-        `Quick test_authorize_keeper_substring_not_prefix_still_denied;
+      test_case "strict known keeper tool allows worker"
+        `Quick test_authorize_known_keeper_tool_strict_worker_allowed;
+      test_case "strict v2 known keeper tool allows worker"
+        `Quick test_authorize_tool_v2_known_keeper_tool_strict_worker_allowed;
+      test_case "strict v2 fake keeper prefix denied"
+        `Quick test_authorize_tool_v2_unknown_keeper_prefix_strict_denied;
       test_case "declared tool permission from Tool_spec"
         `Quick test_declared_tool_permission_from_tool_spec;
     ];


### PR DESCRIPTION
## Summary

Follow-up to #10183 after #10187 landed the broad keeper_* strict-auth recovery.

This PR tightens that recovery path so strict auth treats only cataloged Keeper_internal tools as unmapped internal tools, instead of allowing every keeper_* prefix. It also makes future unknown external strict-auth denials observable through a bounded Prometheus counter.

## Changes

- Replace the keeper_* prefix fallback with Tool_catalog.Keeper_internal membership for unmapped internal tools.
- Keep masc_* and protocol-canonical tool names as internal strict-mode fallbacks.
- Add `masc_auth_strict_unknown_tool_denials_total{agent_name,tool_class}` for denied unknown external tools.
- Cover both token auth and role-auth strict gates.
- Add a negative regression for fake keeper-prefixed names such as `keeper_totally_fake`.

## Verification

- `git diff --check origin/main...HEAD`
- `scripts/check-boundary-guard.sh`
- `env DUNE_BUILD_DIR=_build_10183_keeper_auth_rebase DUNE_JOBS=2 DUNE_CACHE=disabled MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_auth.exe test/test_tool_access_role.exe test/test_prometheus_coverage.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-10183-auth-rebase _build_10183_keeper_auth_rebase/default/test/test_auth.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-10183-role-rebase _build_10183_keeper_auth_rebase/default/test/test_tool_access_role.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-10183-prom-rebase _build_10183_keeper_auth_rebase/default/test/test_prometheus_coverage.exe`

Fixes #10183.
