### PR TITLE
fix(keeper): recover from CLI max-turn exhaustion

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -103,8 +103,13 @@ let is_auto_recoverable_cascade_exhausted_error (err : Oas.Error.sdk_error) : bo
       true
   | Some
       (Oas_worker_named.Cascade_exhausted
+         { reason = Keeper_types.Max_turns_exceeded; _ }) ->
+      true
+  | Some
+      (Oas_worker_named.Cascade_exhausted
          { reason = Keeper_types.Other_detail detail; _ }) ->
       Oas_worker_named.message_looks_like_cli_wrapped_hard_quota detail
+      || Oas_worker_named.message_looks_like_cli_wrapped_max_turns detail
   | Some (Oas_worker_named.Cascade_exhausted _) ->
       false
   | Some (Oas_worker_named.No_tool_capable_provider _)
@@ -135,6 +140,7 @@ let is_resumable_cli_session_error (err : Oas.Error.sdk_error) : bool =
 let is_auto_recoverable_cascade_fail_open_error
     (err : Oas.Error.sdk_error) : bool =
   Oas_worker_named.sdk_error_is_hard_quota err
+  || Oas_worker_named.sdk_error_is_max_turns_exceeded err
   || is_resumable_cli_session_error err
   || is_auto_recoverable_cascade_exhausted_error err
 
@@ -181,6 +187,8 @@ let degraded_retry_after_recoverable_error
   then None
   else if Oas_worker_named.sdk_error_is_hard_quota err then
     local_recovery_retry "hard_quota"
+  else if Oas_worker_named.sdk_error_is_max_turns_exceeded err then
+    local_recovery_retry "max_turns"
   else
     match Oas_worker_named.classify_masc_internal_error err with
     | Some (Oas_worker_named.Resumable_cli_session _) ->
@@ -195,6 +203,10 @@ let degraded_retry_after_recoverable_error
         (Oas_worker_named.Cascade_exhausted
            { reason = Keeper_types.Candidates_filtered_after_cycles; _ }) ->
         local_recovery_retry "cascade_candidates_filtered"
+    | Some
+        (Oas_worker_named.Cascade_exhausted
+           { reason = Keeper_types.Max_turns_exceeded; _ }) ->
+        local_recovery_retry "max_turns"
     | Some
         (Oas_worker_named.Cascade_exhausted
            { reason = Keeper_types.Other_detail detail; _ })
@@ -213,6 +225,8 @@ let recoverable_cascade_failure_reason (err : Oas.Error.sdk_error) =
     Some "required_tool_contract_violation"
   else if Oas_worker_named.sdk_error_is_hard_quota err then
     Some "hard_quota"
+  else if Oas_worker_named.sdk_error_is_max_turns_exceeded err then
+    Some "max_turns"
   else
     match Oas_worker_named.classify_masc_internal_error err with
     | Some (Oas_worker_named.Resumable_cli_session _) ->
@@ -227,6 +241,10 @@ let recoverable_cascade_failure_reason (err : Oas.Error.sdk_error) =
         (Oas_worker_named.Cascade_exhausted
            { reason = Keeper_types.Candidates_filtered_after_cycles; _ }) ->
         Some "cascade_candidates_filtered"
+    | Some
+        (Oas_worker_named.Cascade_exhausted
+           { reason = Keeper_types.Max_turns_exceeded; _ }) ->
+        Some "max_turns"
     | Some
         (Oas_worker_named.Cascade_exhausted
            { reason = Keeper_types.Other_detail detail; _ })
@@ -333,6 +351,7 @@ let degraded_rotation_after_recoverable_error
 let is_auto_recoverable_turn_error (err : Oas.Error.sdk_error) : bool =
   is_transient_network_error err
   || is_server_rejected_parse_error err
+  || Oas_worker_named.sdk_error_is_max_turns_exceeded err
   || is_resumable_cli_session_error err
   || is_auto_recoverable_cascade_exhausted_error err
 

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -75,6 +75,7 @@ type cascade_exhaustion_reason =
   | No_providers_available
   | All_providers_failed
   | Candidates_filtered_after_cycles
+  | Max_turns_exceeded
   | Other_detail of string
 
 type blocker_class =
@@ -122,6 +123,8 @@ let cascade_exhaustion_summary = function
   | No_providers_available -> "Cascade exhausted; no providers were available."
   | All_providers_failed -> "Cascade exhausted after all configured providers failed."
   | Candidates_filtered_after_cycles -> "Cascade exhausted after provider failures."
+  | Max_turns_exceeded ->
+    "Cascade exhausted after a provider hit its per-call turn budget."
   | Other_detail _ -> "Cascade exhausted after provider failures."
 ;;
 
@@ -135,6 +138,7 @@ let cascade_exhaustion_reason_to_json = function
   | No_providers_available -> `String "no_providers_available"
   | All_providers_failed -> `String "all_providers_failed"
   | Candidates_filtered_after_cycles -> `String "candidates_filtered_after_cycles"
+  | Max_turns_exceeded -> `String "max_turns_exceeded"
   | Other_detail msg -> `Assoc [ "tag", `String "other_detail"; "message", `String msg ]
 ;;
 
@@ -143,6 +147,7 @@ let cascade_exhaustion_reason_of_json = function
   | `String "no_providers_available" -> Some No_providers_available
   | `String "all_providers_failed" -> Some All_providers_failed
   | `String "candidates_filtered_after_cycles" -> Some Candidates_filtered_after_cycles
+  | `String "max_turns_exceeded" -> Some Max_turns_exceeded
   | `Assoc fields ->
     (match List.assoc_opt "tag" fields with
      | Some (`String "other_detail") ->

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -164,6 +164,13 @@ let blocker_class_of_string (reason : string) : blocker_class option =
         String_util.contains_substring_ci trimmed "no providers available"
       then
         No_providers_available
+      else if
+        String_util.contains_substring_ci trimmed "error_max_turns"
+        || String_util.contains_substring_ci trimmed
+             "reached maximum number of turns"
+        || String_util.contains_substring_ci trimmed "max turns exceeded"
+      then
+        Max_turns_exceeded
       else if String_util.contains_substring_ci trimmed "all providers failed"
       then
         All_providers_failed

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -105,6 +105,7 @@ type cascade_exhaustion_reason =
   | No_providers_available
   | All_providers_failed
   | Candidates_filtered_after_cycles
+  | Max_turns_exceeded
   | Other_detail of string
 
 type blocker_class =

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -844,6 +844,21 @@ let message_looks_like_cli_wrapped_hard_quota (message : string) : bool =
    && contains "\"api_error_status\":429"
    && contains "you've hit your limit")
 
+let cli_wrapped_max_turns_indicators = [
+  "\"subtype\":\"error_max_turns\"";
+  "error_max_turns";
+  "\"terminal_reason\":\"max_turns\"";
+  "terminal_reason\":\"max_turns";
+  "reached maximum number of turns";
+  "max turns exceeded";
+]
+
+let message_looks_like_cli_wrapped_max_turns (message : string) : bool =
+  let contains needle =
+    String_util.contains_substring_ci message needle
+  in
+  List.exists contains cli_wrapped_max_turns_indicators
+
 let exit_code_of_message (message : string) : int option =
   let prefix = "exited with code " in
   match String.index_opt message ' ' with
@@ -914,6 +929,46 @@ let sdk_error_is_hard_quota (err : Oas.Error.sdk_error) : bool =
      | Llm_provider.Retry.Timeout _ ->
        false)
   | _ -> false
+
+let sdk_error_is_max_turns_exceeded (err : Oas.Error.sdk_error) : bool =
+  match classify_masc_internal_error err with
+  | Some
+      (Cascade_exhausted
+         { reason = Keeper_types.Max_turns_exceeded; _ }) ->
+      true
+  | Some
+      (Cascade_exhausted
+         { reason = Keeper_types.Other_detail detail; _ }) ->
+      message_looks_like_cli_wrapped_max_turns detail
+  | Some (Cascade_exhausted _)
+  | Some (Resumable_cli_session _)
+  | Some (No_tool_capable_provider _)
+  | Some (Accept_rejected _)
+  | Some (Admission_queue_timeout _)
+  | Some (Admission_queue_rejected _)
+  | Some (Turn_timeout _)
+  | Some (Oas_timeout_budget _)
+  | Some (Ambiguous_post_commit _) ->
+      false
+  | None -> (
+      match err with
+      | Oas.Error.Agent (Oas.Error.MaxTurnsExceeded _) -> true
+      | Oas.Error.Api
+          (Llm_provider.Retry.NetworkError { message; _ }
+          | Llm_provider.Retry.Overloaded { message }
+          | Llm_provider.Retry.ServerError { message; _ }
+          | Llm_provider.Retry.InvalidRequest { message }
+          | Llm_provider.Retry.Timeout { message }) ->
+          message_looks_like_cli_wrapped_max_turns message
+      | Oas.Error.Api
+          (Llm_provider.Retry.RateLimited _
+          | Llm_provider.Retry.AuthError _
+          | Llm_provider.Retry.NotFound _
+          | Llm_provider.Retry.ContextOverflow _) ->
+          false
+      | Oas.Error.Internal message ->
+          message_looks_like_cli_wrapped_max_turns message
+      | _ -> false)
 
 (** Run a single Agent.run() call with MASC-driven cascade model fallback.
 
@@ -1199,14 +1254,22 @@ let run_named
             if kind = Llm_provider.Http_client.Connection_refused
                || String_util.contains_substring_ci message "connection refused" then
               Keeper_types.Connection_refused
+            else if message_looks_like_cli_wrapped_max_turns message then
+              Keeper_types.Max_turns_exceeded
             else
               Keeper_types.Other_detail message
         | Some (Llm_provider.Http_client.HttpError { code; body }) ->
-            Keeper_types.Other_detail
-              (Printf.sprintf "HTTP %d: %s" code
-                (String_util.utf8_safe ~max_bytes:203 ~suffix:"..." body |> String_util.to_string))
+            if message_looks_like_cli_wrapped_max_turns body then
+              Keeper_types.Max_turns_exceeded
+            else
+              Keeper_types.Other_detail
+                (Printf.sprintf "HTTP %d: %s" code
+                  (String_util.utf8_safe ~max_bytes:203 ~suffix:"..." body |> String_util.to_string))
         | Some (Llm_provider.Http_client.AcceptRejected { reason = r }) ->
-            Keeper_types.Other_detail r
+            if message_looks_like_cli_wrapped_max_turns r then
+              Keeper_types.Max_turns_exceeded
+            else
+              Keeper_types.Other_detail r
         | Some (Llm_provider.Http_client.CliTransportRequired { kind }) ->
             Keeper_types.Other_detail
               (Printf.sprintf "%s provider requires a CLI transport" kind)

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3127,6 +3127,25 @@ let wrapped_claude_limit_error () =
          kind = Llm_provider.Http_client.Unknown;
        })
 
+let wrapped_claude_max_turns_message =
+  "claude exited with code 1: {\"type\":\"result\",\"subtype\":\"error_max_turns\",\"is_error\":true,\"stop_reason\":\"tool_use\",\"terminal_reason\":\"max_turns\",\"errors\":[\"Reached maximum number of turns (10)\"]}"
+
+let wrapped_claude_max_turns_error () =
+  Agent_sdk.Error.Api
+    (NetworkError
+       {
+         message = wrapped_claude_max_turns_message;
+         kind = Llm_provider.Http_client.Unknown;
+       })
+
+let wrapped_cascade_max_turns_error () =
+  Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
+    (Masc_mcp.Oas_worker_named.Cascade_exhausted
+       {
+         cascade_name = Masc_mcp.Keeper_config.default_cascade_name;
+         reason = Keeper_types.Other_detail wrapped_claude_max_turns_message;
+       })
+
 let required_tool_contract_violation_error () =
   Agent_sdk.Error.Agent
     (CompletionContractViolation
@@ -3212,6 +3231,16 @@ let test_degraded_retry_after_recoverable_error_includes_oas_timeout_budget () =
   in
   expect_degraded_retry "oas timeout budget degraded retry"
     KC.local_recovery_cascade_name "oas_timeout_budget" degraded_retry
+
+let test_degraded_retry_after_recoverable_error_includes_max_turns () =
+  let degraded_retry =
+    EC.degraded_retry_after_recoverable_error
+      ~effective_cascade:"underdog"
+      ~tool_requirement:"optional"
+      (wrapped_cascade_max_turns_error ())
+  in
+  expect_degraded_retry "max turns degraded retry"
+    KC.local_recovery_cascade_name "max_turns" degraded_retry
 
 let test_degraded_retry_after_recoverable_error_blocks_required_tools () =
   let degraded_retry =
@@ -4121,6 +4150,10 @@ let test_auto_recoverable_turn_error_includes_wrapped_hard_quota () =
   check bool "wrapped hard quota is auto-recoverable" true
     (EC.is_auto_recoverable_turn_error err)
 
+let test_auto_recoverable_turn_error_includes_wrapped_max_turns () =
+  check bool "wrapped CLI max-turns is auto-recoverable" true
+    (EC.is_auto_recoverable_turn_error (wrapped_claude_max_turns_error ()))
+
 let test_required_tool_contract_violation_detected () =
   let err =
     Agent_sdk.Error.Agent
@@ -4196,6 +4229,10 @@ let test_auto_recoverable_turn_error_includes_wrapped_cascade_exhausted_hard_quo
   in
   check bool "wrapped cascade hard quota is auto-recoverable" true
     (EC.is_auto_recoverable_turn_error err)
+
+let test_auto_recoverable_turn_error_includes_wrapped_cascade_max_turns () =
+  check bool "wrapped cascade max-turns is auto-recoverable" true
+    (EC.is_auto_recoverable_turn_error (wrapped_cascade_max_turns_error ()))
 
 let test_auto_recoverable_turn_error_includes_filtered_candidates_cascade_exhaustion () =
   let err =
@@ -6093,6 +6130,8 @@ let () =
             test_auto_recoverable_turn_error_includes_server_parse_rejection;
           test_case "auto-recoverable includes wrapped hard quota" `Quick
             test_auto_recoverable_turn_error_includes_wrapped_hard_quota;
+          test_case "auto-recoverable includes wrapped CLI max turns" `Quick
+            test_auto_recoverable_turn_error_includes_wrapped_max_turns;
           test_case "required tool contract violation detected from structured error" `Quick
             test_required_tool_contract_violation_detected;
           test_case "legacy internal contract violation is ignored" `Quick
@@ -6107,6 +6146,8 @@ let () =
             test_auto_recoverable_turn_error_excludes_persistent_errors;
           test_case "auto-recoverable includes wrapped cascade hard quota" `Quick
             test_auto_recoverable_turn_error_includes_wrapped_cascade_exhausted_hard_quota;
+          test_case "auto-recoverable includes wrapped cascade max turns" `Quick
+            test_auto_recoverable_turn_error_includes_wrapped_cascade_max_turns;
           test_case "auto-recoverable includes filtered candidates cascade exhaustion" `Quick
             test_auto_recoverable_turn_error_includes_filtered_candidates_cascade_exhaustion;
           test_case "auto-recoverable includes resumable CLI session error" `Quick
@@ -6206,6 +6247,8 @@ let () =
             test_degraded_retry_after_recoverable_error_includes_turn_timeout;
           test_case "OAS timeout budget is degraded-retry eligible" `Quick
             test_degraded_retry_after_recoverable_error_includes_oas_timeout_budget;
+          test_case "max turns is degraded-retry eligible" `Quick
+            test_degraded_retry_after_recoverable_error_includes_max_turns;
           test_case "required tool turns block degraded retry" `Quick
             test_degraded_retry_after_recoverable_error_blocks_required_tools;
           test_case "local_only stays terminal for degraded retry" `Quick

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -695,6 +695,21 @@ let test_sdk_error_is_hard_quota_detects_claude_org_monthly_limit_wrapper () =
   Alcotest.(check bool) "Claude org monthly usage limit counts as hard quota" true
     (Oas_worker_named.sdk_error_is_hard_quota err)
 
+let test_sdk_error_is_max_turns_detects_claude_cli_wrapper () =
+  let err =
+    Oas.Error.Api
+      (Llm_provider.Retry.NetworkError
+         {
+           message =
+             "claude exited with code 1: {\"type\":\"result\",\"subtype\":\"error_max_turns\",\"is_error\":true,\"terminal_reason\":\"max_turns\",\"errors\":[\"Reached maximum number of turns (10)\"]}";
+           kind = Llm_provider.Http_client.Unknown;
+         })
+  in
+  Alcotest.(check bool) "Claude CLI max turns counts as max-turns" true
+    (Oas_worker_named.sdk_error_is_max_turns_exceeded err);
+  Alcotest.(check bool) "Claude CLI max turns is not hard quota" false
+    (Oas_worker_named.sdk_error_is_hard_quota err)
+
 let test_sdk_error_is_hard_quota_keeps_transient_network_errors_false () =
   let err =
     Oas.Error.Api
@@ -3550,6 +3565,8 @@ let () =
         test_sdk_error_is_hard_quota_detects_claude_cli_limit_wrapper;
       Alcotest.test_case "sdk_error_is_hard_quota detects Claude org monthly limit wrapper" `Quick
         test_sdk_error_is_hard_quota_detects_claude_org_monthly_limit_wrapper;
+      Alcotest.test_case "sdk_error_is_max_turns detects Claude CLI wrapper" `Quick
+        test_sdk_error_is_max_turns_detects_claude_cli_wrapper;
       Alcotest.test_case "sdk_error_is_hard_quota keeps transient network errors false" `Quick
         test_sdk_error_is_hard_quota_keeps_transient_network_errors_false;
       Alcotest.test_case "sdk_error_is_hard_quota preserves RateLimited detection" `Quick


### PR DESCRIPTION
## Summary

- classify wrapped Claude CLI `error_max_turns` / "Reached maximum number of turns" failures as typed `max_turns_exceeded`
- allow keeper recovery logic to treat max-turn exhaustion as auto-recoverable and retry via `local_recovery`
- keep max-turn exhaustion distinct from hard quota, with focused regression coverage for both paths

## Why it matters

The live keeper error was surfaced as `cascade_exhausted` with `Other_detail` because Claude CLI exited after hitting its per-call turn budget while still in `tool_use`. That made the keeper wait/crash path look terminal even though the correct operator behavior is fail-open recovery to the next degraded profile.

## Verification

- `env MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_keeper_unified.exe test/test_oas_worker.exe test/test_dashboard_keeper_routes.exe bin/main_eio.exe`
- `./_build/default/test/test_keeper_unified.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-oas-worker-base ./_build/default/test/test_oas_worker.exe`
- `./_build/default/test/test_dashboard_keeper_routes.exe`
