### PR TITLE
fix(keeper): use provider policy for MCP header routing

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1881,22 +1881,15 @@ let run_turn
           Keeper_runtime_resolved.oas_timeout_for_estimated_input_tokens
             ~estimated_input_tokens
     in
-    (* Observability for issue #10049: CLI-backed providers
-       (claude_code, kimi_cli) need claude_mcp_config to reach the masc-mcp
+    (* Observability for issue #10049: providers that declare runtime MCP
+       HTTP header support need claude_mcp_config to reach the masc-mcp
        HTTP MCP endpoint; otherwise the MCP tool catalog is invisible to
        the subprocess and the model will correctly report that no shell
-       tools are bound. Codex CLI has a separate sync path
-       (MASC_SYNC_CODEX_MCP_CONFIG) so it is not affected. *)
+       tools are bound. *)
     (if keeper_oas_context.claude_mcp_config = None then
        let uses_cli_missing_sync =
          List.exists
-           (fun label ->
-              let lbl = String.lowercase_ascii label in
-              let starts p =
-                String.length lbl >= String.length p
-                && String.equal (String.sub lbl 0 (String.length p)) p
-              in
-              starts "claude_code" || starts "kimi_cli")
+           Provider_adapter.supports_runtime_mcp_http_headers_for_model_label
            meta.models
        in
        if uses_cli_missing_sync then

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -1296,6 +1296,24 @@ let provider_of_model_label ?provider_kind (model : string) : string =
   | None, Some kind -> provider_label_of_provider_kind kind
   | None, None -> "unknown"
 
+let adapter_of_registry_label label =
+  match resolve_adapter_by_cascade_prefix label with
+  | Some adapter -> Some adapter
+  | None -> resolve_direct_adapter label
+
+let supports_runtime_mcp_http_headers_for_model_label ?provider_kind model =
+  let provider_label =
+    match provider_prefix_of_label_result model with
+    | Ok prefix -> prefix
+    | Error _ -> (
+        match provider_kind with
+        | Some kind -> provider_label_of_provider_kind kind
+        | None -> model)
+  in
+  match adapter_of_registry_label provider_label with
+  | Some adapter -> adapter.tool_policy.supports_runtime_mcp_http_headers
+  | None -> false
+
 (** Whether a provider emits no usage tokens in its standard response.
 
     Used by metrics coverage gating: a text-only turn against one of

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -303,6 +303,13 @@ val provider_prefix_of_label_result : string -> (string, string) result
 val provider_of_model_label :
   ?provider_kind:Llm_provider.Provider_config.provider_kind -> string -> string
 
+(** Whether the model label resolves to a provider that supports runtime MCP
+    HTTP headers. Bare labels are accepted only when they exactly match an
+    adapter/cascade registry entry or when [provider_kind] supplies the typed
+    provider boundary. *)
+val supports_runtime_mcp_http_headers_for_model_label :
+  ?provider_kind:Llm_provider.Provider_config.provider_kind -> string -> bool
+
 (** True when the provider emits no usage tokens in its standard response.
     Used by metrics coverage gating so text-only turns against CLI-class
     providers that strip usage do not count as coverage gaps. *)

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -311,7 +311,20 @@ let test_runtime_mcp_header_support_uses_declared_policy () =
   check bool "kimi cli supports runtime MCP headers" true
     (Adapter.supports_runtime_mcp_http_headers_for_config kimi_cli_cfg);
   check bool "codex cli does not support runtime MCP headers" false
-    (Adapter.supports_runtime_mcp_http_headers_for_config codex_cli_cfg)
+    (Adapter.supports_runtime_mcp_http_headers_for_config codex_cli_cfg);
+  check bool "claude code model label supports runtime MCP headers" true
+    (Adapter.supports_runtime_mcp_http_headers_for_model_label
+       "claude_code:auto");
+  check bool "kimi cli model label supports runtime MCP headers" true
+    (Adapter.supports_runtime_mcp_http_headers_for_model_label
+       "kimi_cli:kimi-for-coding");
+  check bool "bare exact cascade prefix uses registry" true
+    (Adapter.supports_runtime_mcp_http_headers_for_model_label "kimi_cli");
+  check bool "codex cli model label keeps declared false" false
+    (Adapter.supports_runtime_mcp_http_headers_for_model_label
+       "codex_cli:gpt-5.4");
+  check bool "bare model id does not guess by substring" false
+    (Adapter.supports_runtime_mcp_http_headers_for_model_label "gpt-5.4")
 
 let test_provider_label_of_config_preserves_cli_vs_api_identity () =
   let kimi_api_cfg =


### PR DESCRIPTION
## Summary
- Replace keeper-side provider prefix checks for MCP header routing with a Provider_adapter policy lookup.
- Add a model-label helper that resolves exact adapter/cascade registry entries instead of guessing from substrings.
- Extend provider adapter tests for claude_code/kimi_cli/codex_cli model labels and bare-model non-guessing.

## Verification
- `scripts/dune-local.sh build test/test_provider_adapter.exe`
- `./_build/default/test/test_provider_adapter.exe`

## Notes
- This is the next de-hardcoding pass after #10181: #10181 removed keeper tool-name prefix dispatch; this PR removes provider-name prefix inference from keeper run setup.
