### PR TITLE
fix(keeper): type board tool access detection

### DIFF
--- a/lib/keeper/keeper_meta_tool_access.ml
+++ b/lib/keeper/keeper_meta_tool_access.ml
@@ -26,8 +26,9 @@ type tool_access =
 let tool_names_include_board name_list =
   List.exists
     (fun name ->
-       String.starts_with ~prefix:"keeper_board_" name
-       || String.starts_with ~prefix:"masc_board_" name)
+       match Tool_name.of_string name with
+       | Some tool -> Tool_name.is_board tool
+       | None -> false)
     name_list
 ;;
 

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -153,6 +153,19 @@ module Keeper = struct
 
   let board_write_tool_names = List.map to_string board_write_tools
 
+  let is_board = function
+    | Board_cleanup
+    | Board_comment
+    | Board_comment_vote
+    | Board_delete
+    | Board_get
+    | Board_list
+    | Board_post
+    | Board_search
+    | Board_stats
+    | Board_vote -> true
+    | _ -> false
+
   let is_board_write = function
     | Board_post | Board_comment | Board_vote -> true
     | _ -> false
@@ -489,6 +502,21 @@ module Masc = struct
     | "masc_webrtc_offer" -> Some Webrtc_offer
     | _ -> None
 
+  let is_board = function
+    | Board_cleanup
+    | Board_comment
+    | Board_comment_vote
+    | Board_delete
+    | Board_get
+    | Board_hearths
+    | Board_list
+    | Board_post
+    | Board_profile
+    | Board_search
+    | Board_stats
+    | Board_vote -> true
+    | _ -> false
+
   let pp fmt t = Format.pp_print_string fmt (to_string t)
 end
 
@@ -562,3 +590,8 @@ let pp fmt t = Format.pp_print_string fmt (to_string t)
 let is_keeper = function Keeper _ -> true | _ -> false
 let is_masc = function Masc _ -> true | _ -> false
 let is_masc_keeper = function Masc_keeper _ -> true | _ -> false
+
+let is_board = function
+  | Keeper k -> Keeper.is_board k
+  | Masc m -> Masc.is_board m
+  | Masc_keeper _ -> false

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -57,6 +57,7 @@ module Keeper : sig
   val of_string : string -> t option
   val board_write_tools : t list
   val board_write_tool_names : string list
+  val is_board : t -> bool
   val is_board_write : t -> bool
   val board_write_action_kind : t -> string option
   val pp : Format.formatter -> t -> unit
@@ -172,6 +173,7 @@ module Masc : sig
 
   val to_string : t -> string
   val of_string : string -> t option
+  val is_board : t -> bool
   val pp : Format.formatter -> t -> unit
 end
 
@@ -206,3 +208,4 @@ val pp : Format.formatter -> t -> unit
 val is_keeper : t -> bool
 val is_masc : t -> bool
 val is_masc_keeper : t -> bool
+val is_board : t -> bool

--- a/test/test_tool_name.ml
+++ b/test/test_tool_name.ml
@@ -138,6 +138,21 @@ let test_unknown_returns_none () =
 
 let test_keeper_board_write_helpers () =
   let open Tool_name.Keeper in
+  List.iter
+    (fun tool ->
+       Alcotest.(check bool)
+         (Printf.sprintf "%s is board" (to_string tool))
+         true
+         (is_board tool))
+    [ Board_cleanup; Board_comment; Board_comment_vote; Board_delete; Board_get
+    ; Board_list; Board_post; Board_search; Board_stats; Board_vote ];
+  List.iter
+    (fun tool ->
+       Alcotest.(check bool)
+         (Printf.sprintf "%s is not board" (to_string tool))
+         false
+         (is_board tool))
+    [ Broadcast; Task_done; Write ];
   Alcotest.(check (list string)) "canonical board write names"
     [ "keeper_board_post"; "keeper_board_comment"; "keeper_board_vote" ]
     board_write_tool_names;
@@ -178,6 +193,21 @@ let test_keeper_board_write_facade_uses_typed_contract () =
   Alcotest.(check string) "non-board action kind is none" "none"
     (Keeper_exec_context.keeper_action_kind_of_tool_names
        [ "keeper_board_comment_vote"; "unknown" ])
+
+let test_board_predicate_facade_uses_typed_contract () =
+  let check_tool label expected name =
+    Alcotest.(check bool) label expected
+      (match Tool_name.of_string name with
+       | Some tool -> Tool_name.is_board tool
+       | None -> false)
+  in
+  check_tool "keeper board post is board" true "keeper_board_post";
+  check_tool "keeper comment vote is board" true "keeper_board_comment_vote";
+  check_tool "masc board post is board" true "masc_board_post";
+  check_tool "masc board profile is board" true "masc_board_profile";
+  check_tool "keeper fake board prefix fails closed" false "keeper_board_fake";
+  check_tool "masc fake board prefix fails closed" false "masc_board_fake";
+  check_tool "broadcast is not board" false "keeper_broadcast"
 
 (* ── Group predicates ──────────────────────────────────────── *)
 
@@ -239,6 +269,8 @@ let () =
         test_keeper_board_write_helpers;
       Alcotest.test_case "keeper board write facade" `Quick
         test_keeper_board_write_facade_uses_typed_contract;
+      Alcotest.test_case "board predicate facade" `Quick
+        test_board_predicate_facade_uses_typed_contract;
       Alcotest.test_case "is_keeper" `Quick test_is_keeper;
     ];
     "coverage", [

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -389,12 +389,18 @@ let () =
           (Preset { preset = Minimal; also_allow = [] });
         check_access "minimal board opt-in listens" true
           (Preset { preset = Minimal; also_allow = [ "keeper_board_post" ] });
+        check_access "minimal fake keeper board prefix stays quiet" false
+          (Preset { preset = Minimal; also_allow = [ "keeper_board_fake" ] });
         check_access "delivery listens to board by default" true
           (Preset { preset = Delivery; also_allow = [] });
         check_access "messaging listens to board by default" true
           (Preset { preset = Messaging; also_allow = [] });
         check_access "custom without board stays quiet" false
           (Custom [ "keeper_time_now" ]);
+        check_access "custom masc board allowlist listens" true
+          (Custom [ "masc_board_post" ]);
+        check_access "custom fake masc board prefix stays quiet" false
+          (Custom [ "masc_board_fake" ]);
         check_access "custom board allowlist listens" true
           (Custom [ "keeper_board_post" ]));
       Alcotest.test_case "Social, Dispatch, and Delivery present" `Quick (fun () ->


### PR DESCRIPTION
## Summary
- add typed Tool_name board predicates for keeper and masc tool variants
- route keeper room-signal board access detection through Tool_name.of_string instead of keeper_board_/masc_board_ prefix checks
- add regressions so fake board-prefixed names fail closed while canonical board tools still opt in

## Why it matters
This removes another prefix heuristic from keeper tool-access policy. Tool names still enter as strings at the metadata boundary, but board detection now depends on the typed Tool_name catalog instead of accepting any board-looking string.

## Validation
- git diff --check origin/main..HEAD
- scripts/dune-local.sh build test/test_tool_name.exe test/test_types.exe
- ./_build/default/test/test_tool_name.exe (15 tests, run ID H529KE1W)
- ./_build/default/test/test_types.exe (117 tests, run ID E15P8NYJ)