### PR TITLE
fix(ws): peel SSE wrapper before parsing dashboard delta payload

### DIFF
--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -463,6 +463,33 @@ type parsed_sse_event = {
 let parse_cache : (string * parsed_sse_event option) Atomic.t =
   Atomic.make ("", None)
 
+(** Extract the JSON body from an SSE-formatted event string.
+
+    Sse.format_event always emits exactly four lines:
+    [{|id: <N>\nevent: <type>\ndata: <body>\n\n|}].  The body line
+    starts with [data: ] (6-char prefix) and is the JSON payload that
+    parse_sse_dashboard_event needs.  External subscribers receive the
+    full SSE-formatted string (gRPC stuffs it into payload_json verbatim
+    and lets the gRPC client re-parse), so the WS callback must peel
+    the SSE wrapper before feeding [Yojson.Safe.from_string].
+
+    The earlier implementation skipped this step, so every production
+    parse failed and dashboard_delta_for_sse always fell through to
+    raw-SSE-forward — defeating the parse cache, slice-aware fanout
+    (Phase 2 of #10119), and delta-built counter.  Pure-JSON inputs
+    (the unit-test path) still work via the [_ -> Some sse_event]
+    fallback. *)
+let extract_sse_data_line sse_event =
+  match String.split_on_char '\n' sse_event with
+  | _id :: _event :: data_line :: _
+    when String.length data_line >= 6
+         && String.sub data_line 0 6 = "data: " ->
+      Some (String.sub data_line 6 (String.length data_line - 6))
+  | _ ->
+      (* Not the 4-line format we emit — pass through as-is so unit
+         tests that hand us pure JSON keep working. *)
+      Some sse_event
+
 let parse_sse_dashboard_event sse_event =
   let cached_str, cached_val = Atomic.get parse_cache in
   if cached_str == sse_event then begin
@@ -472,21 +499,24 @@ let parse_sse_dashboard_event sse_event =
   else begin
     Transport_metrics.inc_ws_parse_cache_miss ();
     let result =
-      match Yojson.Safe.from_string sse_event with
-      | exception _ -> None
-      | `Assoc fields as event_json -> (
-          match List.assoc_opt "type" fields with
-          | Some (`String event_type) ->
-              let payload =
-                match List.assoc_opt "payload" fields with
-                | Some payload -> payload
-                | None -> event_json
-              in
-              let slice = dashboard_slice_for_sse_type event_type in
-              let broadcast_ts = Time_compat.now () in
-              Some { event_type; slice; payload; broadcast_ts }
-          | _ -> None)
-      | _ -> None
+      match extract_sse_data_line sse_event with
+      | None -> None
+      | Some json_body ->
+        match Yojson.Safe.from_string json_body with
+        | exception _ -> None
+        | `Assoc fields as event_json -> (
+            match List.assoc_opt "type" fields with
+            | Some (`String event_type) ->
+                let payload =
+                  match List.assoc_opt "payload" fields with
+                  | Some payload -> payload
+                  | None -> event_json
+                in
+                let slice = dashboard_slice_for_sse_type event_type in
+                let broadcast_ts = Time_compat.now () in
+                Some { event_type; slice; payload; broadcast_ts }
+            | _ -> None)
+        | _ -> None
     in
     Atomic.set parse_cache (sse_event, result);
     result

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -121,6 +121,30 @@ let test_parse_sse_dashboard_event_invalidated_on_new_ref () =
   Alcotest.(check (option string)) "second parse distinct"
     (Some "transport_health_snapshot") (et r2)
 
+(* The production wire format is SSE — Sse.format_event emits
+   "id: N\nevent: message\ndata: <json>\n\n".  parse_sse_dashboard_event
+   must extract the data line before parsing or every production parse
+   fails (pre-fix behaviour, mistakenly hidden by unit tests that fed
+   pure JSON). *)
+let test_parse_sse_dashboard_event_handles_sse_format () =
+  let body =
+    Yojson.Safe.to_string
+      (`Assoc [
+        ("type", `String "execution_snapshot");
+        ("payload", `Assoc [("keepers", `Int 7)]);
+      ])
+  in
+  let sse_formatted =
+    Printf.sprintf "id: 42\nevent: message\ndata: %s\n\n" body
+  in
+  match Ws.parse_sse_dashboard_event sse_formatted with
+  | Some parsed ->
+      Alcotest.(check string) "event_type extracted from SSE wrapper"
+        "execution_snapshot" parsed.event_type;
+      Alcotest.(check (option string)) "slice resolved past the wrapper"
+        (Some "execution") parsed.slice
+  | None -> Alcotest.fail "expected parse to succeed on SSE-formatted input"
+
 (* Counter observability: reuse of the same event string reference
    must register as a hit, distinct strings must register as misses.
    Read counter deltas because the global state is shared across tests. *)
@@ -558,6 +582,8 @@ let () =
         test_parse_sse_dashboard_event_stable_on_repeat;
       Alcotest.test_case "cache invalidates on new ref" `Quick
         test_parse_sse_dashboard_event_invalidated_on_new_ref;
+      Alcotest.test_case "handles production SSE wire format" `Quick
+        test_parse_sse_dashboard_event_handles_sse_format;
       Alcotest.test_case "hit/miss counters track reuse" `Quick
         test_parse_cache_counters;
     ]);


### PR DESCRIPTION
Production bug: parse_sse_dashboard_event fed full SSE-formatted string into Yojson.Safe.from_string which always raised. Every production parse returned None — dashboard_delta_for_sse fell through to raw-SSE-forward, parse cache served dead None, slice-aware fanout (RFC #10119 Phase 2) never activated. Unit tests passed because they fed pure JSON. Fix: extract_sse_data_line strips the 4-line SSE wrapper. New test pins wire format. 37/37 tests pass.