### PR TITLE
fix(keeper): use real tools for message sweep affordance

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -101,8 +101,7 @@ let turn_affordances_require_tool_gate turn_affordances =
 let tools_for_gated_affordance = function
   | Board_post_or_comment ->
     [ "keeper_board_post"; "keeper_board_comment"; "masc_broadcast" ]
-  | Message_sweep ->
-    [ "keeper_messages_read"; "masc_messages"; "keeper_keeper_msg" ]
+  | Message_sweep -> [ "masc_messages"; "masc_keeper_msg" ]
   | Reply_in_room ->
     [ "keeper_board_post"; "keeper_board_comment";
       "masc_keeper_msg"; "masc_broadcast" ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -5449,13 +5449,22 @@ let test_tools_for_gated_affordance_covers_each_variant () =
   (* Compile-time exhaustiveness already ensures every variant is
      handled; this asserts the runtime mapping is non-empty so a
      well-meaning future edit cannot silently break the gate by
-     returning [] for an affordance. *)
+     returning [] for an affordance.  It also checks each mapped name
+     against tool-name/surface SSOTs so typoed affordance tools do not
+     silently turn into dead gate entries. *)
   let module Surface = Masc_mcp.Keeper_agent_tool_surface in
+  let known_tool_name name =
+    Masc_mcp.Tool_name.of_string name <> None
+    || Masc_mcp.Tool_catalog_surfaces.surfaces_for_tool name <> []
+  in
   let nonempty label affordance =
     let tools = Surface.tools_for_gated_affordance affordance in
     check bool
       (Printf.sprintf "tools_for_gated_affordance non-empty for %s" label)
-      true (tools <> [])
+      true (tools <> []);
+    check (list string)
+      (Printf.sprintf "tools_for_gated_affordance known tools for %s" label)
+      [] (List.filter (fun name -> not (known_tool_name name)) tools)
   in
   nonempty "Board_post_or_comment" Surface.Board_post_or_comment;
   nonempty "Message_sweep" Surface.Message_sweep;


### PR DESCRIPTION
## Summary
- Replace nonexistent message-sweep affordance tool names with real tool surface names.
- Add an SSOT guard so every affordance tool maps to Tool_name or Tool_catalog_surfaces.

## Verification
- `scripts/dune-local.sh build test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_unified.exe test tool_classification`

## Notes
- This catches typoed/dead hardcoded tool names such as `keeper_keeper_msg` before they can silently weaken keeper tool-gate behavior.
