### PR TITLE
fix(keeper): type board execution dispatch

### DIFF
--- a/lib/keeper/keeper_exec_board.ml
+++ b/lib/keeper/keeper_exec_board.ml
@@ -46,6 +46,12 @@ let ensure_keeper_board_post_args ~author ~source = function
   | other -> other
 ;;
 
+let dispatchable_keeper_board_tool_name name =
+  match Tool_name.Keeper.of_string name with
+  | Some tool when Tool_name.Keeper.is_board tool -> Some tool
+  | Some _ | None -> None
+;;
+
 let handle_keeper_board_tool
       ~(meta : keeper_meta)
       ~(name : string)
@@ -54,36 +60,57 @@ let handle_keeper_board_tool
   let dispatch tool_name tool_args =
     tool_result_or_error (Tool_board.handle_tool tool_name tool_args)
   in
-  match name with
-  | "keeper_board_post" ->
+  let dispatch_board tool tool_args =
+    dispatch (Tool_name.Masc.to_string tool) tool_args
+  in
+  match dispatchable_keeper_board_tool_name name with
+  | Some Tool_name.Keeper.Board_post ->
     let author = meta.name in
+    let keeper_source = Tool_name.Keeper.to_string Tool_name.Keeper.Board_post in
     Log.Keeper.debug
-      "keeper_board_post called by %s, raw args: %s"
+      "%s called by %s, raw args: %s"
+      keeper_source
       author
       (Yojson.Safe.to_string args);
     let board_args =
       ensure_keeper_board_post_args
         ~author
-        ~source:"keeper_board_post"
+        ~source:keeper_source
         (assoc_override_string "author" author args)
     in
     Log.Keeper.debug "board_args: %s" (Yojson.Safe.to_string board_args);
-    let result = Tool_board.handle_tool "masc_board_post" board_args in
+    let result =
+      Tool_board.handle_tool (Tool_name.Masc.to_string Tool_name.Masc.Board_post) board_args
+    in
     let ok, msg = result in
     Log.Keeper.info
       "handle_tool result: ok=%b msg=%s"
       ok
       (String_util.utf8_safe ~max_bytes:203 ~suffix:"..." msg |> String_util.to_string);
     tool_result_or_error result
-  | "keeper_board_list" -> dispatch "masc_board_list" args
-  | "keeper_board_get" -> dispatch "masc_board_get" args
-  | "keeper_board_comment" ->
-    dispatch "masc_board_comment" (assoc_override_string "author" meta.name args)
-  | "keeper_board_vote" ->
-    dispatch "masc_board_vote" (assoc_override_string "voter" meta.name args)
-  | "keeper_board_stats" -> dispatch "masc_board_stats" args
-  | "keeper_board_search" -> dispatch "masc_board_search" args
-  | "keeper_board_delete" -> dispatch "masc_board_delete" args
-  | "keeper_board_cleanup" -> dispatch "masc_board_cleanup" args
-  | other -> error_json ~fields:[ "tool", `String other ] "unknown_board_tool"
+  | Some Tool_name.Keeper.Board_list ->
+    dispatch_board Tool_name.Masc.Board_list args
+  | Some Tool_name.Keeper.Board_get ->
+    dispatch_board Tool_name.Masc.Board_get args
+  | Some Tool_name.Keeper.Board_comment ->
+    dispatch_board
+      Tool_name.Masc.Board_comment
+      (assoc_override_string "author" meta.name args)
+  | Some Tool_name.Keeper.Board_vote ->
+    dispatch_board Tool_name.Masc.Board_vote (assoc_override_string "voter" meta.name args)
+  | Some Tool_name.Keeper.Board_comment_vote ->
+    dispatch_board
+      Tool_name.Masc.Board_comment_vote
+      (assoc_override_string "voter" meta.name args)
+  | Some Tool_name.Keeper.Board_stats ->
+    dispatch_board Tool_name.Masc.Board_stats args
+  | Some Tool_name.Keeper.Board_search ->
+    dispatch_board Tool_name.Masc.Board_search args
+  | Some Tool_name.Keeper.Board_delete ->
+    dispatch_board Tool_name.Masc.Board_delete args
+  | Some Tool_name.Keeper.Board_cleanup ->
+    dispatch_board Tool_name.Masc.Board_cleanup args
+  | Some _
+  | None ->
+    error_json ~fields:[ "tool", `String name ] "unknown_board_tool"
 ;;

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -104,7 +104,11 @@ let success_tool_result raw_output =
 let failure_tool_result raw_output =
   make_executed_tool_result ~outcome:`Failure raw_output
 
-
+let is_keeper_board_tool_name name =
+  match Tool_name.Keeper.of_string name with
+  | Some tool -> Tool_name.Keeper.is_board tool
+  | None -> false
+;;
 
 (* ── Tool execution dispatch ──────────────────────────────────── *)
 
@@ -187,6 +191,9 @@ let execute_keeper_tool_call_with_outcome
          ]))
   else (
     match name with
+    | _ when is_keeper_board_tool_name name ->
+      make_executed_tool_result
+        (Keeper_exec_board.handle_keeper_board_tool ~meta ~name ~args)
     | "keeper_tool_search" ->
       let query =
         Safe_ops.json_string ~default:"" "query" args |> String.trim
@@ -234,17 +241,6 @@ let execute_keeper_tool_call_with_outcome
       in
       if ok then success_tool_result msg
       else failure_tool_result (error_json msg)
-    | "keeper_board_post"
-    | "keeper_board_list"
-    | "keeper_board_get"
-    | "keeper_board_comment"
-    | "keeper_board_vote"
-    | "keeper_board_stats"
-    | "keeper_board_search"
-    | "keeper_board_delete"
-    | "keeper_board_cleanup" ->
-      make_executed_tool_result
-        (Keeper_exec_board.handle_keeper_board_tool ~meta ~name ~args)
     | "keeper_fs_read" ->
       make_executed_tool_result
         (Keeper_exec_fs.handle_keeper_fs_read ~turn_sandbox_runtime ~config ~meta ~args)

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -330,6 +330,30 @@ let test_keeper_board_post_preserves_meta_reason () =
   Alcotest.(check string) "author forced from keeper meta" "judge-keeper"
     Yojson.Safe.Util.(json |> member "author" |> to_string)
 
+let test_keeper_board_dispatch_uses_typed_tool_names () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let keeper_meta = make_keeper_meta ~name:"typed-keeper" () in
+  let fake =
+    Keeper_exec_board.handle_keeper_board_tool
+      ~meta:keeper_meta
+      ~name:"keeper_board_fake"
+      ~args:(make_args [])
+  in
+  Alcotest.(check bool) "fake board name rejected" true
+    (contains_substring fake "unknown_board_tool");
+  let comment_vote =
+    Keeper_exec_board.handle_keeper_board_tool
+      ~meta:keeper_meta
+      ~name:"keeper_board_comment_vote"
+      ~args:(make_args [ ("comment_id", `String "") ])
+  in
+  Alcotest.(check bool) "typed comment vote reaches board handler" true
+    (contains_substring comment_vote "comment_id required");
+  Alcotest.(check bool) "typed comment vote is not unknown" false
+    (contains_substring comment_vote "unknown_board_tool")
+
 let test_post_create_accepts_automation_rejects_system () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -776,6 +800,8 @@ let () =
             test_post_create_judgment_roundtrip;
           Alcotest.test_case "keeper board post preserves meta reason" `Quick
             test_keeper_board_post_preserves_meta_reason;
+          Alcotest.test_case "keeper board dispatch uses typed names" `Quick
+            test_keeper_board_dispatch_uses_typed_tool_names;
           Alcotest.test_case "accept automation reject system" `Quick
             test_post_create_accepts_automation_rejects_system;
           Alcotest.test_case "create empty content" `Quick test_post_create_empty_content;


### PR DESCRIPTION
## Summary
- parse keeper board execution tool names through Tool_name.Keeper before dispatching
- replace raw keeper_board_* dispatcher cases with Tool_name.Keeper.is_board routing
- route keeper_board_comment_vote through the typed board wrapper and reject fake board-prefixed names

## Why it matters
This removes another stringly execution boundary. Keeper board wrappers now depend on the typed Tool_name catalog, so board-looking names such as keeper_board_fake fail closed instead of being treated as dispatch candidates.

## Validation
- git diff --check origin/main..HEAD
- scripts/dune-local.sh build test/test_tool_board_coverage.exe test/test_keeper_unified.exe
- ./_build/default/test/test_tool_board_coverage.exe (59 tests, run ID KLMVH0SU)
- ./_build/default/test/test_keeper_unified.exe (285 tests, run ID UVS5Y5IG)