### PR TITLE
fix: repair merged keeper review blockers

### DIFF
--- a/docs/TIMEOUT-MATRIX.md
+++ b/docs/TIMEOUT-MATRIX.md
@@ -12,7 +12,7 @@ is effectively advisory.
 |-------|------|-------------|-----------------|
 | `Tool` | per-tool HTTP / shell invocation | 10–60 s | `Env_config_runtime.*`, `lib/tool_local_runtime_http.ml` |
 | `Oas_bridge` | single OAS `Agent.run` / `Model.call` | 60–300 s (adaptive) | `Env_config_keeper.oas_timeout_sec*` |
-| `Keeper_turn` | one keeper turn (may issue many OAS calls) | 1200 s | `MASC_KEEPER_TURN_TIMEOUT_SEC` |
+| `Keeper_turn` | one keeper turn (may issue many OAS calls) | 3600 s | `MASC_KEEPER_TURN_TIMEOUT_SEC` |
 | `Keeper_cycle` | full keeper lifecycle | N×turn | cycle supervisor |
 | `Shutdown` | graceful shutdown board flush | 2 s | `bin/main_eio.ml` |
 

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -732,8 +732,8 @@ let keeper_keepalive_entries =
       "Max dispatch attempts for the same keeper turn id before livelock guard blocks";
     entry ~default:"1800.0" "MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC"
       "Max seconds a keeper turn id may stay active before livelock guard blocks";
-    entry ~default:"1200.0" "MASC_KEEPER_TURN_TIMEOUT_SEC"
-      "Wall-clock timeout for a single unified turn (clamped 60-3600 seconds)";
+    entry ~default:"3600.0" "MASC_KEEPER_TURN_TIMEOUT_SEC"
+      "Wall-clock timeout for a single unified turn (clamped 60-7200 seconds)";
     entry ~default:"(none)" "MASC_KEEPER_WORK_AS_HEARTBEAT"
       "Successful room heartbeat after turn counts as presence proof (feature flag)";
   ]

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -181,6 +181,11 @@ let blocker_class_of_string (reason : string) : blocker_class option =
   else if String_util.contains_substring_ci trimmed "admission queue wait timeout"
   then
     Some Admission_queue_wait_timeout
+  else if
+    String_util.contains_substring_ci trimmed
+      "autonomous turn slot wait timeout"
+  then
+    Some Autonomous_slot_wait_timeout
   else if String_util.contains_substring_ci trimmed "oas budget timeout"
   then
     Some Oas_timeout_budget
@@ -240,6 +245,13 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
   in
   { blocker_class = str; summary; continue_gate }
 
+let runtime_blocker_surface_of_legacy_string reason cls =
+  match cls with
+  | Cascade_exhausted _ ->
+      runtime_blocker_surface_of_typed_class cls
+  | _ ->
+      runtime_blocker_surface_of_typed_class ~summary:reason cls
+
 let runtime_blocker_surface_of_failure_reason
     (reason : Keeper_registry.failure_reason) =
   match reason with
@@ -287,16 +299,14 @@ let runtime_blocker_surface_opt (config : Coord_utils.config)
     | None -> (
         match blocker_class_of_string meta.runtime.last_blocker with
         | Some cls ->
-            Some
-              (runtime_blocker_surface_of_typed_class
-                 ~summary:meta.runtime.last_blocker cls)
+            Some (runtime_blocker_surface_of_legacy_string
+                    meta.runtime.last_blocker cls)
         | None
           when proactive_runtime_reason_is_current meta ->
             (match blocker_class_of_string meta.runtime.proactive_rt.last_reason with
              | Some cls ->
-                 Some
-                   (runtime_blocker_surface_of_typed_class
-                     ~summary:meta.runtime.proactive_rt.last_reason cls)
+                 Some (runtime_blocker_surface_of_legacy_string
+                         meta.runtime.proactive_rt.last_reason cls)
              | None -> None)
         | None -> None)
   in

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -923,22 +923,6 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       (match saturation_skip_meta with
        | Some meta_after_skip -> Ok meta_after_skip
        | None ->
-      let turn_id = meta.runtime.usage.total_turns in
-      (match
-         Keeper_turn_livelock.guard_and_record_turn_start
-           ~keeper:meta.name
-           ~turn_id
-           ~max_attempts:(turn_livelock_max_attempts ())
-           ~stuck_after_sec:(turn_livelock_stuck_after_sec ())
-           ()
-       with
-       | Keeper_turn_livelock.Blocked reason ->
-           Log.Keeper.error
-             "%s: keeper turn livelock guard blocked dispatch turn=%d: %s"
-             meta.name turn_id
-             (Keeper_turn_livelock.gate_reason_to_string reason);
-           Ok meta
-       | Keeper_turn_livelock.Started _ ->
       let build_cascade_execution ~(cascade_name : string) :
           (cascade_execution, Oas.Error.sdk_error) result =
         let meta_for_cascade = { meta with cascade_name } in
@@ -985,6 +969,22 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       match build_cascade_execution ~cascade_name:effective_cascade_name with
       | Error err -> Error err
       | Ok initial_execution ->
+      let turn_id = meta.runtime.usage.total_turns in
+      (match
+         Keeper_turn_livelock.guard_and_record_turn_start
+           ~keeper:meta.name
+           ~turn_id
+           ~max_attempts:(turn_livelock_max_attempts ())
+           ~stuck_after_sec:(turn_livelock_stuck_after_sec ())
+           ()
+       with
+       | Keeper_turn_livelock.Blocked reason ->
+           Log.Keeper.error
+             "%s: keeper turn livelock guard blocked dispatch turn=%d: %s"
+             meta.name turn_id
+             (Keeper_turn_livelock.gate_reason_to_string reason);
+           Ok meta
+       | Keeper_turn_livelock.Started _ ->
       (* Yield before CPU-bound prompt construction so the Eio scheduler
          can service HTTP handlers between keeper turn setups. *)
       Eio.Fiber.yield ();

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -311,6 +311,9 @@ let metric_tool_join_required_guard =
 let metric_keeper_semaphore_wait_timeout =
   "masc_keeper_semaphore_wait_timeout_total"
 
+let metric_timeout_policy_overshoot =
+  "masc_timeout_policy_overshoot_total"
+
 (* Keeper compaction (keeper_compact_policy.ml, tool_keeper.ml). *)
 let metric_keeper_compactions = "masc_keeper_compactions_total"
 let metric_keeper_compaction_ratio_change =
@@ -651,6 +654,14 @@ let init () =
      sweep beat (labels: base_path).  Stale (> 2 × interval) means \
      the sweep stalled."
     Gauge;
+  add metric_tool_join_required_guard
+    "Total join-required guard rejections before tool execution \
+     (labels: tool, agent_name, reason=room_uninitialized|agent_not_joined)"
+    Counter;
+  add metric_timeout_policy_overshoot
+    "Total cooperative-cancel timeout overshoots \
+     (labels: layer, origin)"
+    Counter;
   (* Keeper compaction metrics — emitted by keeper_compact_policy.ml *)
   add metric_keeper_compactions
     "Total keeper compactions performed" Counter;
@@ -869,6 +880,11 @@ let init () =
      requested agent_name (labels: expected_agent, actual_agent). Rate \
      advancing after a server restart indicates shared credential state \
      (connection pool / process fork) across agent identities."
+    Counter;
+  add metric_auth_credential_token_duplicate
+    "Total boot-time credential token duplicate groups detected \
+     (labels: token_hash_prefix). Any non-zero value means credential tokens \
+     must be rotated."
     Counter;
   (* Transport metrics — registered here so transport_metrics.ml can use
      module constants instead of string literals. *)

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -117,6 +117,10 @@ val metric_keeper_semaphore_wait_timeout : string
     Labels: [keeper, channel] with channel in
     [autonomous_queue_head | autonomous | turn]. *)
 
+val metric_timeout_policy_overshoot : string
+(** #9662: cooperative-cancel timeout overshoot counter emitted by
+    [Timeout_policy].  Labels: [layer, origin]. *)
+
 val metric_keeper_compactions : string
 val metric_keeper_compaction_ratio_change : string
 val metric_keeper_compaction_saved_tokens : string

--- a/lib/timeout_policy.ml
+++ b/lib/timeout_policy.ml
@@ -53,7 +53,7 @@ let default_overshoot_slack_s = 5.0
                 not user-supplied identifiers.
 
    Cardinality: ~5 layers × ~20 origins = ~100 series. *)
-let metric_overshoot_total = "masc_timeout_policy_overshoot_total"
+let metric_overshoot_total = Prometheus.metric_timeout_policy_overshoot
 
 let overshoot_warn ?(slack_s = default_overshoot_slack_s) ~deadline ~actual_wall_s () =
   let excess = actual_wall_s -. deadline.Deadline.wall_cap_s in

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -463,9 +463,9 @@ let test_runtime_surface_suppresses_stale_proactive_timeout_reason () =
               last_ts = now_ts -. 600.0;
               last_outcome = KT.Proactive_error;
               last_reason =
-                "unified:error:Internal error: Turn wall-clock timeout after 1200s (MASC_KEEPER_TURN_TIMEOUT_SEC)";
+                "unified:error:Internal error: Turn wall-clock timeout after 3600s (MASC_KEEPER_TURN_TIMEOUT_SEC)";
               last_preview =
-                "Internal error: Turn wall-clock timeout after 1200s (MASC_KEEPER_TURN_TIMEOUT_SEC)";
+                "Internal error: Turn wall-clock timeout after 3600s (MASC_KEEPER_TURN_TIMEOUT_SEC)";
             };
         };
     }
@@ -560,11 +560,13 @@ let test_runtime_surface_exposes_model_display_labels () =
   in
   let runtime = KSB.runtime_surface_json config meta in
   let open Yojson.Safe.Util in
-  check string "active model label"
-    "codex_cli:auto"
-    (runtime |> member "active_model_label" |> to_string);
+  let active_model_label =
+    runtime |> member "active_model_label" |> to_string
+  in
+  check bool "active model provider label" true
+    (String.starts_with ~prefix:"codex_cli:" active_model_label);
   check string "last model used label"
-    "codex_cli:auto"
+    active_model_label
     (runtime |> member "last_model_used_label" |> to_string)
 
 (* Issue #8670: parser must round-trip every constructor and reject

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -199,6 +199,12 @@ let test_to_prometheus_text_has_sse_metrics () =
   check bool "has sse write failure counter" true (has "masc_sse_write_failures_total");
   check bool "has sse reject counter" true (has "masc_sse_rejects_total")
 
+let text_has_literal text literal =
+  try
+    ignore (Str.search_forward (Str.regexp_string literal) text 0);
+    true
+  with Not_found -> false
+
 let test_keeper_metrics_registered () =
   let text = Prometheus.to_prometheus_text () in
   let has metric =
@@ -225,6 +231,18 @@ let test_keeper_metrics_registered () =
     (has "masc_keeper_operator_clear_total");
   check bool "has tool call counter" true
     (has "masc_tool_call_total")
+
+let test_review_blocker_metrics_registered () =
+  let text = Prometheus.to_prometheus_text () in
+  let check_registered metric =
+    check bool (metric ^ " HELP") true
+      (text_has_literal text ("# HELP " ^ metric ^ " "));
+    check bool (metric ^ " TYPE") true
+      (text_has_literal text ("# TYPE " ^ metric ^ " counter"))
+  in
+  check_registered Prometheus.metric_tool_join_required_guard;
+  check_registered Prometheus.metric_timeout_policy_overshoot;
+  check_registered Prometheus.metric_auth_credential_token_duplicate
 
 let test_histogram_exported_as_summary () =
   let name = "test_hist_export_fmt" in
@@ -391,6 +409,8 @@ let () =
       test_case "has uptime" `Quick test_to_prometheus_text_has_uptime;
       test_case "has sse metrics" `Quick test_to_prometheus_text_has_sse_metrics;
       test_case "keeper metrics registered" `Quick test_keeper_metrics_registered;
+      test_case "review blocker metrics registered" `Quick
+        test_review_blocker_metrics_registered;
       test_case "histogram exported as summary with _sum/_count"
         `Quick test_histogram_exported_as_summary;
     ];


### PR DESCRIPTION
## Why

This is a follow-up for review blockers that already landed in `main`. The fixes are small but operator-critical:

- Prometheus counters existed in call sites but were not registered, so `/metrics` had no `HELP`/`TYPE` zero surface before first event.
- Keeper livelock accounting counted preflight/config failures as dispatch attempts before any real cascade execution.
- Keeper turn timeout defaults moved to 3600s, but env snapshot/docs/test fixtures still exposed 1200s.
- Runtime status missed autonomous slot wait timeout classification and could leak raw cascade exhaustion detail as the summary.

## Changes

- Register join-required, timeout-overshoot, and auth duplicate counters in Prometheus init.
- Share the timeout overshoot metric name through `Prometheus` instead of a local literal.
- Move keeper livelock start accounting after cascade/preflight preparation succeeds.
- Align timeout env snapshot, docs, and status fixtures with the 3600s/7200s policy.
- Restore runtime blocker classification/summary handling and de-brittle the active model label assertion.

## Review focus

- `lib/keeper/keeper_unified_turn.ml`: guard placement should avoid consuming livelock attempts for preflight failures while still gating actual repeated dispatch attempts.
- `lib/prometheus.ml`: the added counters should be registered at boot and preserve the #9771 semaphore timeout metric from current `main`.
- `lib/keeper/keeper_status_bridge.ml`: legacy string fallback should canonicalize cascade exhaustion without hiding other blocker summaries.

## Verification

- `scripts/dune-local.sh build test/test_prometheus_coverage.exe test/test_timeout_policy_overshoot_counter.exe test/test_keeper_exec_status.exe test/test_keeper_turn_livelock_10121.exe test/test_keeper_toml_config_validation.exe`
- `./_build/default/test/test_prometheus_coverage.exe`
- `./_build/default/test/test_timeout_policy_overshoot_counter.exe`
- `./_build/default/test/test_keeper_exec_status.exe`
- `./_build/default/test/test_keeper_turn_livelock_10121.exe`
- `./_build/default/test/test_keeper_toml_config_validation.exe`