### PR TITLE
fix(ci-gate): skip agent draft policy when PR is already merged (#10192)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -725,6 +725,14 @@ jobs:
             if [ -n "$live_labels" ]; then
               export PR_LIVE_LABELS="$live_labels"
             fi
+            # #10192: CI Gate runs that fire after auto-merge can
+            # see the bypass label cleaned up by post-merge
+            # automation; pass live state to the policy script so
+            # it skips the check when the PR is no longer open.
+            live_state="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state --jq '.state' 2>/dev/null || true)"
+            if [ -n "$live_state" ]; then
+              export PR_LIVE_STATE="$live_state"
+            fi
           fi
           scripts/ci/check-agent-draft-policy.sh
 

--- a/scripts/ci/check-agent-draft-policy.sh
+++ b/scripts/ci/check-agent-draft-policy.sh
@@ -15,6 +15,7 @@ pr_is_draft="${PR_LIVE_IS_DRAFT:-${PR_IS_DRAFT:-false}}"
 pr_title="${PR_TITLE:-}"
 pr_head_ref="${PR_HEAD_REF:-}"
 pr_labels_csv="${PR_LIVE_LABELS:-${PR_LABELS:-}}"
+pr_live_state="${PR_LIVE_STATE:-}"
 
 if [[ -n "${PR_LIVE_IS_DRAFT:-}" ]]; then
   echo "agent draft policy: using live PR draft state ${PR_LIVE_IS_DRAFT}"
@@ -26,6 +27,22 @@ fi
 lower() {
   printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
 }
+
+# #10192: CI Gate runs that fire after auto-merge (observed
+# 12 min post-merge) sometimes query live PR labels AFTER
+# post-merge automation has cleaned the bypass label.  The
+# gate then evaluates an already-merged PR as ready-without-
+# bypass and fails — a red check on a PR that has already
+# shipped (PR #10181, run 24924336433).  Skip when the live
+# state says the PR is no longer open: the policy is moot
+# for closed/merged PRs and the merge-time CI Gate already
+# gated the merge itself.
+case "$(lower "${pr_live_state}")" in
+  merged|closed)
+    echo "agent draft policy: skipped, PR live state is ${pr_live_state} (post-merge gate race, see #10192)"
+    exit 0
+    ;;
+esac
 
 csv_has_label() {
   local csv="$1"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -83,6 +83,10 @@ let test_ci_sync_and_asset_contracts () =
     (file_contains_pattern ".github/workflows/ci.yml" "PR_LIVE_IS_DRAFT");
   check bool "ci gate refreshes live labels" true
     (file_contains_pattern ".github/workflows/ci.yml" "PR_LIVE_LABELS");
+  (* #10192: ci gate must also pass live PR state to the
+     policy script so already-merged PRs do not flip red. *)
+  check bool "ci gate refreshes live PR state" true
+    (file_contains_pattern ".github/workflows/ci.yml" "PR_LIVE_STATE");
   check bool "pr hygiene no longer checks dashboard assets (gitignored)" true
     (not (file_contains_pattern "scripts/check-pr-hygiene.sh" "dashboard source or Vite config changed but assets/dashboard was not updated"))
 
@@ -127,7 +131,24 @@ let test_agent_draft_policy_script () =
          ("PR_TITLE", "fix: human authored branch");
          ("PR_HEAD_REF", "feature/human-branch");
          ("PR_LABELS", "enhancement");
-       ])
+       ]);
+  (* #10192: post-merge gate race.  When the live PR state is
+     MERGED or CLOSED, the policy is moot (the merge already
+     happened) and a missing bypass label must NOT resurrect a
+     red check on a shipped PR. *)
+  check int "ready agent PR with live state MERGED is skipped" 0
+    (run_agent_draft_policy
+       (("PR_IS_DRAFT", "false") :: ("PR_LIVE_STATE", "MERGED") :: base));
+  check int "ready agent PR with live state CLOSED is skipped" 0
+    (run_agent_draft_policy
+       (("PR_IS_DRAFT", "false") :: ("PR_LIVE_STATE", "CLOSED") :: base));
+  check int "live state lower-case merged is also skipped" 0
+    (run_agent_draft_policy
+       (("PR_IS_DRAFT", "false") :: ("PR_LIVE_STATE", "merged") :: base));
+  check bool "live state OPEN does NOT bypass policy" true
+    (run_agent_draft_policy
+       (("PR_IS_DRAFT", "false") :: ("PR_LIVE_STATE", "OPEN") :: base)
+     <> 0)
 
 let test_health_and_ci_runner_diagnostics () =
   check bool "health snapshot records baseline source" true


### PR DESCRIPTION
## Summary

#10192 reports the CI Gate flipping a merged PR to red ~12 minutes after merge.  PR #10181 merged at 06:17:55Z; the same CI run reported "agent-like PR ready without \`human-approved-ready\`" at 06:29:29Z.  All substantive checks (Build, Health, Lint, TLA+, Meta Guards, PR Sync) had passed at merge time.

## Root cause

The agent-draft policy step reads \`PR_LIVE_LABELS\` from \`gh pr view\` at the step's start time, not from the merge-time snapshot.  When auto-merge fires earlier than this gate, the gate sees the post-merge cleanup state (bypass label removed by automation) and concludes "ready without bypass" — for a PR that has already shipped.

## Fix (issue Option 2: skip-when-merged)

\`scripts/ci/check-agent-draft-policy.sh\` now skips when \`PR_LIVE_STATE\` reports \`MERGED\` or \`CLOSED\`.  \`ci.yml\` exports the state via the same \`gh pr view --json state\` call already used for \`isDraft\` and \`labels\`.  Case-insensitive match.

\`\`\`bash
case "$(lower "${pr_live_state}")" in
  merged|closed)
    echo "agent draft policy: skipped, PR live state is ${pr_live_state} (post-merge gate race, see #10192)"
    exit 0
    ;;
esac
\`\`\`

## Why option 2

| option | analysis |
|---|---|
| 1 — snapshot labels at merge-gate time | requires ordering changes or a separate snapshot store; doesn't survive a workflow re-run from a stale point |
| 2 — **skip-when-merged (this PR)** | surgical to the gate itself; treats the "PR has shipped" race as a no-op; OPEN behaviour unchanged |
| 3 — delay label cleanup | couples cleanup automation to gate completion; more fragile across multiple workflows |

The script remains the authoritative gate at merge time — when the PR is OPEN, all existing logic runs unchanged.

## Test plan

- [x] \`dune build --root . lib/\` clean
- [x] \`dune exec test/test_ci_hardening_source.exe\` — 35/35 pass:
  - new MERGED state → exit 0 (skipped)
  - new CLOSED state → exit 0 (skipped)
  - new lower-case \`merged\` → exit 0 (case insensitivity)
  - new OPEN state → still fails (policy still enforced)
  - new source-guard check pins \`PR_LIVE_STATE\` export in ci.yml so a future workflow refactor can't silently drop it
- [ ] Deploy: rerun CI Gate on a recently-merged PR; confirm the gate skips with the expected notice instead of flipping red.

## Refs

- PR #10181 (the merged PR that flipped red)
- CI run 24924336433, failing job 72992513952

## Do-not-merge

\`do-not-merge\` label set so the auto-merge pipeline does not flip this Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)