### PR TITLE
feat(observability): distributed lock acquire-failed counter (#9645)

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -242,7 +242,7 @@ let () =
    alert on chronic lock contention (production observed
    tasks:.backlog starvation under 16-keeper fleet load). *)
 let distributed_lock_acquire_failed_metric =
-  "masc_distributed_lock_acquire_failed_total"
+  Prometheus.metric_distributed_lock_acquire_failed
 
 let record_distributed_lock_acquire_failed ~key ~attempts =
   Prometheus.inc_counter distributed_lock_acquire_failed_metric

--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -234,6 +234,25 @@ let record_process_timeout ~program ~timeout_sec =
 let () =
   Atomic.set Process_eio.process_timeout_observer_fn record_process_timeout
 
+(* #9645: distributed lock acquire exhaustion observability.
+
+   [Coord_utils_ops.with_distributed_lock]/[..._r] now signal
+   exhaustion via [Coord_hooks.distributed_lock_acquire_failed_fn].
+   Wire that hook to a Prometheus counter so operators can rate-
+   alert on chronic lock contention (production observed
+   tasks:.backlog starvation under 16-keeper fleet load). *)
+let distributed_lock_acquire_failed_metric =
+  "masc_distributed_lock_acquire_failed_total"
+
+let record_distributed_lock_acquire_failed ~key ~attempts =
+  Prometheus.inc_counter distributed_lock_acquire_failed_metric
+    ~labels:[ ("key", key); ("attempts", string_of_int attempts) ]
+    ()
+
+let () =
+  Atomic.set Coord_hooks.distributed_lock_acquire_failed_fn
+    record_distributed_lock_acquire_failed
+
 (* Activity graph emit — wraps Activity_graph for room sub-modules *)
 let () = Atomic.set Coord_hooks.activity_emit_fn (fun config ~actor ?subject ~kind ~payload ~tags () ->
     (try

--- a/lib/coord.mli
+++ b/lib/coord.mli
@@ -70,3 +70,19 @@ val record_process_timeout : program:string -> timeout_sec:float -> unit
     [run_argv_with_stdin_and_status_split] / [run_argv_with_status_split]
     surfaces in Prometheus without taking a direct dependency on
     [masc_mcp.Prometheus] from the lower [masc_process] layer. *)
+
+(** {1 Distributed lock observability (#9645)} *)
+
+val distributed_lock_acquire_failed_metric : string
+(** Canonical Prometheus metric for distributed lock acquire
+    exhaustion ([masc_distributed_lock_acquire_failed_total]).
+    Labels: [key, attempts].  Exposed so tests and Grafana
+    rules can pin the name. *)
+
+val record_distributed_lock_acquire_failed :
+  key:string -> attempts:int -> unit
+(** Increment {!distributed_lock_acquire_failed_metric} with
+    [(key, attempts)] labels.  Wired to
+    {!Coord_hooks.distributed_lock_acquire_failed_fn} so
+    [Coord_utils_ops] can fire the metric without taking a
+    direct [Prometheus] dependency. *)

--- a/lib/coord/coord_hooks.ml
+++ b/lib/coord/coord_hooks.ml
@@ -151,6 +151,25 @@ let fsm_drift_observer_fn
   : (variant:string -> force:bool -> agent_name:string -> unit) Atomic.t
   = Atomic.make (fun ~variant:_ ~force:_ ~agent_name:_ -> ())
 
+(** #9645: distributed lock acquire failure observability.
+
+    [Coord_utils_ops.with_distributed_lock] / [..._r] raise
+    [Invalid_argument] (or return [Error]) after exhausting the
+    retry budget when keeper fleet contention prevents acquiring
+    a lock (production observed [tasks:.backlog] starvation under
+    16-keeper load).  The error path is the only signal — there
+    is no fleet-wide rate metric for "how often does this fail,
+    on which key?".
+
+    This hook decouples the emit from [masc_mcp.Prometheus] (which
+    sits above [masc_coord] in the dep graph).  [lib/coord.ml]
+    wires it to a Prometheus counter at startup; [masc_coord]
+    callers fire it from the failure branches without taking a
+    direct Prometheus dependency. *)
+let distributed_lock_acquire_failed_fn
+  : (key:string -> attempts:int -> unit) Atomic.t
+  = Atomic.make (fun ~key:_ ~attempts:_ -> ())
+
 (** Tool assignment telemetry — wraps Tool_assignment_telemetry.emit_assigned.
     Wired at startup to record which tools were provisioned to which agent. *)
 let tool_assigned_fn

--- a/lib/coord/coord_utils_ops.ml
+++ b/lib/coord/coord_utils_ops.ml
@@ -429,11 +429,16 @@ let with_distributed_lock ?clock config _path key f =
             in
             Log.Coord.warn "lock release failed for %s: %s" key msg)
       f
-  else
+  else begin
+    (* #9645: surface lock acquire exhaustion as a fleet-wide
+       metric.  Hook is wired by [lib/coord.ml] at startup. *)
+    (Atomic.get Coord_hooks.distributed_lock_acquire_failed_fn)
+      ~key ~attempts:50;
     invalid_arg
       (Printf.sprintf
          "Failed to acquire distributed lock for key: %s (50 attempts exhausted)"
          key)
+  end
 
 let with_distributed_lock_r ?clock config path key f : ('a, masc_error) result =
   let owner = config.backend_config.node_id in
@@ -461,11 +466,15 @@ let with_distributed_lock_r ?clock config path key f : ('a, masc_error) result =
             in
             Log.Coord.warn "lock release failed for %s: %s" key msg)
       (fun () -> Ok (f ()))
-  else
+  else begin
+    (* #9645: see [with_distributed_lock] above. *)
+    (Atomic.get Coord_hooks.distributed_lock_acquire_failed_fn)
+      ~key ~attempts:50;
     Error
       (IoError
          (Printf.sprintf "Failed to acquire distributed lock for %s"
             path))
+  end
 
 let with_file_lock_impl ?clock config path f =
   match key_of_path config path with

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -538,6 +538,8 @@ let metric_oas_bus_publish = "masc_oas_bus_publish_total"
 let metric_runtime_ollama_probe_generate_skips =
   "masc_runtime_ollama_probe_generate_skips_total"
 let metric_process_timeout = "masc_process_timeout_total"
+let metric_distributed_lock_acquire_failed =
+  "masc_distributed_lock_acquire_failed_total"
 
 (* #10130: boot-time sweep of [save_file_atomic] orphan temp
    files.  Labels: [size_class = empty | with_data].  The
@@ -887,6 +889,10 @@ let init () =
   add metric_process_timeout
     "Total subprocess executions that exceeded their configured timeout. \
      Labeled by program and timeout_sec."
+    Counter;
+  add metric_distributed_lock_acquire_failed
+    "Total distributed lock acquire exhaustions. Labeled by key and attempts. \
+     A non-zero rate indicates lock contention exhausted the retry budget."
     Counter;
   (* #10130: boot-time sweep of save_file_atomic orphans. *)
   add metric_fs_atomic_orphans_cleaned

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -235,6 +235,9 @@ val metric_runtime_ollama_probe_generate_skips : string
 val metric_process_timeout : string
 (** #9632: subprocess executions that exceeded their configured
     timeout. Labels: [program, timeout_sec]. *)
+val metric_distributed_lock_acquire_failed : string
+(** #9645: distributed lock acquire retry-budget exhaustions.
+    Labels: [key, attempts]. *)
 
 (** #10130: boot-time sweep of save_file_atomic orphan temp files.
     Labels: [size_class = empty | with_data]. *)

--- a/test/dune
+++ b/test/dune
@@ -330,6 +330,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_distributed_lock_acquire_failed_counter)
+ (modules test_distributed_lock_acquire_failed_counter)
+ (libraries masc_test_deps))
+
+(test
  (name test_timeout_policy_overshoot_counter)
  (modules test_timeout_policy_overshoot_counter)
  (libraries masc_test_deps))

--- a/test/test_distributed_lock_acquire_failed_counter.ml
+++ b/test/test_distributed_lock_acquire_failed_counter.ml
@@ -16,7 +16,7 @@ let counter_for ~key ~attempts =
 let test_metric_name_stable () =
   Alcotest.(check string)
     "distributed lock acquire failed canonical name"
-    "masc_distributed_lock_acquire_failed_total"
+    Masc_mcp.Prometheus.metric_distributed_lock_acquire_failed
     Masc_mcp.Coord.distributed_lock_acquire_failed_metric
 
 let test_record_increments () =

--- a/test/test_distributed_lock_acquire_failed_counter.ml
+++ b/test/test_distributed_lock_acquire_failed_counter.ml
@@ -1,0 +1,75 @@
+(* #9645: pin canonical metric name + label vocabulary for the
+   distributed lock acquire-failed counter.
+
+   [Coord_utils_ops] fires this counter when the retry budget is
+   exhausted (50 attempts) and the caller's lock acquire either
+   raises [Invalid_argument] or returns [IoError].  Production
+   observed [tasks:.backlog] starvation under 16-keeper load —
+   the counter lets operators rate-alert without log scraping. *)
+
+let counter_for ~key ~attempts =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    Masc_mcp.Coord.distributed_lock_acquire_failed_metric
+    ~labels:[ ("key", key); ("attempts", string_of_int attempts) ]
+    ()
+
+let test_metric_name_stable () =
+  Alcotest.(check string)
+    "distributed lock acquire failed canonical name"
+    "masc_distributed_lock_acquire_failed_total"
+    Masc_mcp.Coord.distributed_lock_acquire_failed_metric
+
+let test_record_increments () =
+  let key = "tasks:.backlog-9645-test" in
+  let attempts = 50 in
+  let before = counter_for ~key ~attempts in
+  Masc_mcp.Coord.record_distributed_lock_acquire_failed
+    ~key ~attempts;
+  Alcotest.(check (float 0.0001))
+    "+1 after record"
+    (before +. 1.0)
+    (counter_for ~key ~attempts)
+
+let test_key_isolation () =
+  (* Different keys land in different series — operators
+     attribute starvation to a specific lock. *)
+  let attempts = 50 in
+  let key_a = "tasks:.backlog-iso-9645" in
+  let key_b = "keepers:state-iso-9645" in
+  let before_a = counter_for ~key:key_a ~attempts in
+  Masc_mcp.Coord.record_distributed_lock_acquire_failed
+    ~key:key_b ~attempts;
+  Alcotest.(check (float 0.0001))
+    "key_a counter unaffected by key_b record"
+    before_a
+    (counter_for ~key:key_a ~attempts)
+
+let test_attempts_label_carried () =
+  (* Different attempts values (e.g., the two callers'
+     identical 50 vs a future caller with a different cap)
+     stay in distinct series. *)
+  let key = "tasks:.backlog-attempts-iso-9645" in
+  let before_50 = counter_for ~key ~attempts:50 in
+  Masc_mcp.Coord.record_distributed_lock_acquire_failed
+    ~key ~attempts:20;
+  Alcotest.(check (float 0.0001))
+    "50-attempt counter unaffected by 20-attempt record"
+    before_50
+    (counter_for ~key ~attempts:50)
+
+let () =
+  Alcotest.run "distributed_lock_acquire_failed_counter_9645" [
+    "metric_name", [
+      Alcotest.test_case "canonical name stable" `Quick
+        test_metric_name_stable;
+    ];
+    "record", [
+      Alcotest.test_case "increments on call" `Quick
+        test_record_increments;
+    ];
+    "isolation", [
+      Alcotest.test_case "keys isolated" `Quick test_key_isolation;
+      Alcotest.test_case "attempts isolated" `Quick
+        test_attempts_label_carried;
+    ];
+  ]

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -244,6 +244,16 @@ let test_review_blocker_metrics_registered () =
   check_registered Prometheus.metric_timeout_policy_overshoot;
   check_registered Prometheus.metric_auth_credential_token_duplicate
 
+let test_distributed_lock_metric_registered () =
+  let text = Prometheus.to_prometheus_text () in
+  check bool "has distributed lock HELP" true
+    (text_has_literal text
+       ("# HELP " ^ Prometheus.metric_distributed_lock_acquire_failed ^ " "));
+  check bool "has distributed lock TYPE" true
+    (text_has_literal text
+       ("# TYPE " ^ Prometheus.metric_distributed_lock_acquire_failed
+        ^ " counter"))
+
 let test_histogram_exported_as_summary () =
   let name = "test_hist_export_fmt" in
   Prometheus.register_histogram ~name ~help:"export format test" ();
@@ -411,6 +421,8 @@ let () =
       test_case "keeper metrics registered" `Quick test_keeper_metrics_registered;
       test_case "review blocker metrics registered" `Quick
         test_review_blocker_metrics_registered;
+      test_case "distributed lock metric registered" `Quick
+        test_distributed_lock_metric_registered;
       test_case "histogram exported as summary with _sum/_count"
         `Quick test_histogram_exported_as_summary;
     ];


### PR DESCRIPTION
## 요약

`Coord_utils_ops.with_distributed_lock`/`..._r` 의 retry 소진 시점에 Prometheus counter 발화. `tasks:.backlog` 등 distributed lock contention을 fleet-wide rate로 추적 가능.

Closes part of #9645 (observability for lock contention).

## 근본 원인

이슈 보고 (2026-04-23 19:26):
```
[WARN] [Orchestrator] [stale-claims] error:
Invalid_argument("Failed to acquire distributed lock for key: tasks:.backlog (20 attempts exhausted)")
```

기존 신호:
- `invalid_arg` 예외 (line 433-436) 또는 `IoError` (line 465-468)
- WARN log (caller side)
- Prometheus counter: 없음

운영 측면:
- "어느 lock key가 가장 자주 contention되는가?" — log scraping 외 답할 수 없음
- "fleet 크기 변경 후 contention rate 어떻게 달라지나?" — 측정 불가
- "20 attempt → 50 attempt bump이 효과 있었나?" — pre/post 비교 불가

## Architecture Layering

`masc_coord` 가 `masc_mcp.Prometheus` 보다 **아래** 레이어. 직접 dep 추가하면 dependency cycle. 

기존 `#9795 FSM drift` 패턴 재사용:
- Hook 정의: `lib/coord/coord_hooks.ml` `distributed_lock_acquire_failed_fn`
- Prometheus emit: `lib/coord.ml` `record_distributed_lock_acquire_failed`
- Hook wire: `Atomic.set Coord_hooks.distributed_lock_acquire_failed_fn record_...` at module load
- Caller fire: `Coord_utils_ops`에서 hook 호출만 (직접 Prometheus 의존 없음)

## 변경 내용

### `lib/coord/coord_hooks.ml`

```ocaml
let distributed_lock_acquire_failed_fn
  : (key:string -> attempts:int -> unit) Atomic.t
  = Atomic.make (fun ~key:_ ~attempts:_ -> ())
```

### `lib/coord/coord_utils_ops.ml` 두 exhaustion 사이트

```diff
  if acquire 50 0.05 then ...
- else
+ else begin
+   (Atomic.get Coord_hooks.distributed_lock_acquire_failed_fn)
+     ~key ~attempts:50;
    invalid_arg (Printf.sprintf "Failed to acquire ...")
+ end
```

`with_distributed_lock_r`도 동일 패턴.

### `lib/coord.{ml,mli}`

```ocaml
let distributed_lock_acquire_failed_metric =
  "masc_distributed_lock_acquire_failed_total"

let record_distributed_lock_acquire_failed ~key ~attempts =
  Prometheus.inc_counter distributed_lock_acquire_failed_metric
    ~labels:[ ("key", key); ("attempts", string_of_int attempts) ]
    ()

let () = Atomic.set Coord_hooks.distributed_lock_acquire_failed_fn
                    record_distributed_lock_acquire_failed
```

## 카디널리티

| 차원 | 크기 |
|------|------|
| key | ~10 (tasks:.backlog, keepers:state, etc. — bounded by named locks) |
| attempts | 1-2 (현재 항상 50) |
| **총** | ~10-20 series |

안전.

## 운영 활용

```promql
# Lock 별 exhaustion rate ranking
sort_desc(
  sum by (key) (
    rate(masc_distributed_lock_acquire_failed_total[5m])
  )
)

# tasks:.backlog 만 알람
rate(masc_distributed_lock_acquire_failed_total{key="tasks:.backlog"}[5m]) > 0
```

## 테스트

`test/test_distributed_lock_acquire_failed_counter.ml` 4 scenario:

```bash
$ dune exec test/test_distributed_lock_acquire_failed_counter.exe
[OK]  metric_name  0  canonical name stable.
[OK]  record       0  increments on call.
[OK]  isolation    0  keys isolated.
[OK]  isolation    1  attempts isolated.
Test Successful in 0.000s. 4 tests run.
```

## 회귀 리스크

매우 낮음. Pure additive — exhaustion 시점에 hook 호출만 추가, 기존 raise/return 동작 동일. Hook 미wire 시 default no-op이라 module load 순서 문제 없음.

## 후속 (별건)

- **Retry budget tuning**: counter rate 측정 후 50 → 100 같은 bump 검토 (또는 hard-fail 결정).
- **Lock sharding**: `tasks:.backlog`이 hot key면 task ID hash 별 sharding.
- **Local mutex fallback**: single-process MASC에서는 distributed lock보다 in-memory mutex가 빠르고 contention 적음. memory backend 사용 keeper에 한해 fallback.

## 참고

- Issue #9645
- `lib/coord/coord_utils_ops.ml:432-441, 466-474` — exhaustion 사이트
- `lib/coord/coord_hooks.ml:154-172` — hook
- `lib/coord.ml:220-240` — wire + Prometheus emit
- `test/test_distributed_lock_acquire_failed_counter.ml` — coverage
- 기존 패턴 참조: #9795 FSM drift hook
