### PR TITLE
fix(ci): skip agent draft gate for merged PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,6 +715,10 @@ jobs:
           AGENT_DRAFT_GUARD_BYPASS_LABELS: ${{ vars.AGENT_DRAFT_GUARD_BYPASS_LABELS }}
         run: |
           if command -v gh >/dev/null 2>&1 && [ -n "${PR_NUMBER:-}" ]; then
+            live_state="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state --jq '.state' 2>/dev/null || true)"
+            if [ -n "$live_state" ]; then
+              export PR_LIVE_STATE="$live_state"
+            fi
             live_is_draft="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
             if [ "$live_is_draft" = "true" ] || [ "$live_is_draft" = "false" ]; then
               export PR_LIVE_IS_DRAFT="$live_is_draft"

--- a/scripts/ci/check-agent-draft-policy.sh
+++ b/scripts/ci/check-agent-draft-policy.sh
@@ -15,17 +15,27 @@ pr_is_draft="${PR_LIVE_IS_DRAFT:-${PR_IS_DRAFT:-false}}"
 pr_title="${PR_TITLE:-}"
 pr_head_ref="${PR_HEAD_REF:-}"
 pr_labels_csv="${PR_LIVE_LABELS:-${PR_LABELS:-}}"
+pr_live_state="${PR_LIVE_STATE:-}"
 
+lower() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+if [[ -n "$pr_live_state" ]]; then
+  echo "agent draft policy: using live PR state ${pr_live_state}"
+  case "$(lower "$pr_live_state")" in
+    merged|closed)
+      echo "agent draft policy: skipped for ${pr_live_state} PR"
+      exit 0
+      ;;
+  esac
+fi
 if [[ -n "${PR_LIVE_IS_DRAFT:-}" ]]; then
   echo "agent draft policy: using live PR draft state ${PR_LIVE_IS_DRAFT}"
 fi
 if [[ -n "${PR_LIVE_LABELS:-}" ]]; then
   echo "agent draft policy: using live PR labels ${PR_LIVE_LABELS}"
 fi
-
-lower() {
-  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
-}
 
 csv_has_label() {
   local csv="$1"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -83,6 +83,8 @@ let test_ci_sync_and_asset_contracts () =
     (file_contains_pattern ".github/workflows/ci.yml" "PR_LIVE_IS_DRAFT");
   check bool "ci gate refreshes live labels" true
     (file_contains_pattern ".github/workflows/ci.yml" "PR_LIVE_LABELS");
+  check bool "ci gate refreshes live PR state" true
+    (file_contains_pattern ".github/workflows/ci.yml" "PR_LIVE_STATE");
   check bool "pr hygiene no longer checks dashboard assets (gitignored)" true
     (not (file_contains_pattern "scripts/check-pr-hygiene.sh" "dashboard source or Vite config changed but assets/dashboard was not updated"))
 
@@ -112,6 +114,9 @@ let test_agent_draft_policy_script () =
        :: ("PR_LIVE_LABELS", "enhancement,human-approved-ready")
        :: ("PR_IS_DRAFT", "true")
        :: base));
+  check int "merged PR no longer fails late label cleanup" 0
+    (run_agent_draft_policy
+       (("PR_LIVE_STATE", "MERGED") :: ("PR_IS_DRAFT", "false") :: base));
   check bool "ready agent PR without bypass fails" true
     (run_agent_draft_policy (("PR_IS_DRAFT", "false") :: base) <> 0);
   check int "ready agent PR with bypass label passes" 0


### PR DESCRIPTION
## Summary
- read live PR state in the CI Gate before enforcing the agent draft policy
- skip the agent draft policy for PRs that are already `MERGED` or `CLOSED`
- keep ready agent PRs without `human-approved-ready` failing while they are still open

## Why
Fixes #10192. The prior gate refreshed live draft state and labels, but not live PR state. If merge automation removed `human-approved-ready` after an auto-merge while CI Gate was still running, the late job could evaluate the already-merged PR as ready without approval and fail after the fact.

## Verification
- `git diff --check`
- `bash -n scripts/ci/check-agent-draft-policy.sh`
- `env GITHUB_EVENT_NAME=pull_request PR_TITLE="fix: keep long turns visibly alive" PR_HEAD_REF=codex/keeper-process-evidence PR_LABELS=enhancement PR_IS_DRAFT=false PR_LIVE_STATE=MERGED scripts/ci/check-agent-draft-policy.sh`
- `env GITHUB_EVENT_NAME=pull_request PR_TITLE="fix: keep long turns visibly alive" PR_HEAD_REF=codex/keeper-process-evidence PR_LABELS=enhancement PR_IS_DRAFT=false scripts/ci/check-agent-draft-policy.sh` (expected failure)
- `env DUNE_BUILD_DIR=_build_verify_10192_ci_gate DUNE_JOBS=2 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_ci_hardening_source.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-10192-ci-gate _build_verify_10192_ci_gate/default/test/test_ci_hardening_source.exe`
