### PR TITLE
fix(keeper): type tools-list grouping

### DIFF
--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -382,14 +382,57 @@ let tag_dispatch_fn
 
 let keeper_tools_list_json ~(meta : keeper_meta) =
   let names = Keeper_tool_policy.keeper_allowed_tool_names meta in
+  let categorize_keeper_tool = function
+    | Tool_name.Keeper.Board_cleanup
+    | Tool_name.Keeper.Board_comment
+    | Tool_name.Keeper.Board_comment_vote
+    | Tool_name.Keeper.Board_delete
+    | Tool_name.Keeper.Board_get
+    | Tool_name.Keeper.Board_list
+    | Tool_name.Keeper.Board_post
+    | Tool_name.Keeper.Board_search
+    | Tool_name.Keeper.Board_stats
+    | Tool_name.Keeper.Board_vote ->
+      "board"
+    | Tool_name.Keeper.Voice_agent
+    | Tool_name.Keeper.Voice_listen
+    | Tool_name.Keeper.Voice_session_end
+    | Tool_name.Keeper.Voice_session_start
+    | Tool_name.Keeper.Voice_sessions
+    | Tool_name.Keeper.Voice_speak ->
+      "voice"
+    | Tool_name.Keeper.Task_claim
+    | Tool_name.Keeper.Task_create
+    | Tool_name.Keeper.Task_done
+    | Tool_name.Keeper.Task_force_done
+    | Tool_name.Keeper.Task_force_release
+    | Tool_name.Keeper.Task_submit_for_verification
+    | Tool_name.Keeper.Tasks_audit
+    | Tool_name.Keeper.Tasks_list ->
+      "coordination"
+    | Tool_name.Keeper.Bash
+    | Tool_name.Keeper.Bash_kill
+    | Tool_name.Keeper.Bash_output
+    | Tool_name.Keeper.Shell ->
+      "shell"
+    | Tool_name.Keeper.Fs_edit
+    | Tool_name.Keeper.Fs_read
+    | Tool_name.Keeper.Write ->
+      "fs"
+    | Tool_name.Keeper.Library_read
+    | Tool_name.Keeper.Library_search
+    | Tool_name.Keeper.Memory_search ->
+      "memory"
+    | _ -> "core"
+  in
   let categorize n =
-    if String.starts_with ~prefix:"keeper_board" n then "board"
-    else if String.starts_with ~prefix:"keeper_voice" n then "voice"
-    else if String.starts_with ~prefix:"keeper_task" n then "coordination"
-    else if String.starts_with ~prefix:"keeper_shell" n || n = "keeper_bash" then "shell"
-    else if String.starts_with ~prefix:"keeper_fs" n then "fs"
-    else if String.starts_with ~prefix:"keeper_memory" n then "memory"
-    else "core"
+    match Tool_name.of_string n with
+    | Some (Tool_name.Keeper tool) -> categorize_keeper_tool tool
+    | Some typed ->
+      (match Tool_catalog.tool_group (Tool_name.to_string typed) with
+       | Some group -> Tool_catalog.tool_group_to_string group
+       | None -> "core")
+    | None -> "core"
   in
   let map =
     List.fold_left (fun acc n ->

--- a/test/test_keeper_exec_tools.ml
+++ b/test/test_keeper_exec_tools.ml
@@ -1,6 +1,7 @@
 open Alcotest
 
 module KET = Masc_mcp.Keeper_exec_tools
+module KES = Masc_mcp.Keeper_exec_shared
 
 let temp_dir prefix =
   let dir = Filename.temp_file prefix "" in
@@ -67,6 +68,20 @@ let check_kind ~msg expected payload =
   check string msg expected
     (payload_kind (KET.classify_tool_result_payload payload))
 
+let json_list_contains name = function
+  | `List values ->
+      List.exists
+        (function
+          | `String value -> String.equal value name
+          | _ -> false)
+        values
+  | _ -> false
+
+let json_contains_tool name = function
+  | `Assoc fields ->
+      List.exists (fun (_, value) -> json_list_contains name value) fields
+  | _ -> false
+
 let test_plain_text_is_success_shape () =
   check_kind
     ~msg:"plain text stays plain_text"
@@ -126,6 +141,40 @@ let test_execute_with_outcome_policy_gate_is_non_failure () =
       let json = Yojson.Safe.from_string result.raw_output in
       check string "policy gate error" "tool_not_allowed"
         Yojson.Safe.Util.(member "error" json |> to_string))
+
+let test_keeper_tools_list_json_uses_typed_groups () =
+  let meta =
+    make_meta
+      ~tool_access:
+        (Masc_mcp.Keeper_types.Custom
+           [ "keeper_board_post";
+             "keeper_board_fake";
+             "keeper_voice_speak";
+             "keeper_task_claim";
+             "keeper_shell";
+             "keeper_fs_read";
+             "keeper_memory_search";
+           ])
+      ()
+  in
+  let json = Yojson.Safe.from_string (KES.keeper_tools_list_json ~meta) in
+  let member group name =
+    json_list_contains name Yojson.Safe.Util.(member group json)
+  in
+  check bool "board canonical tool grouped" true
+    (member "board" "keeper_board_post");
+  check bool "fake board-looking tool excluded" false
+    (json_contains_tool "keeper_board_fake" json);
+  check bool "voice tool grouped" true
+    (member "voice" "keeper_voice_speak");
+  check bool "task tool grouped as coordination" true
+    (member "coordination" "keeper_task_claim");
+  check bool "shell tool grouped" true
+    (member "shell" "keeper_shell");
+  check bool "fs tool grouped" true
+    (member "fs" "keeper_fs_read");
+  check bool "memory tool grouped" true
+    (member "memory" "keeper_memory_search")
 
 let test_execute_with_outcome_missing_file_is_failure () =
   with_exec_fixture "keeper_exec_tools_missing_file"
@@ -316,6 +365,10 @@ let () =
         test_execute_with_outcome_bad_query_is_failure;
       test_case "registered dispatch does not require masc_ prefix" `Quick
         test_registered_tool_dispatch_without_masc_prefix;
+    ]);
+    ("keeper_tools_list_json", [
+      test_case "uses typed groups" `Quick
+        test_keeper_tools_list_json_uses_typed_groups;
     ]);
     ("exec_cache", [
       test_case "miss then hit" `Quick test_exec_cache_miss_then_hit;


### PR DESCRIPTION
## Summary
- replace keeper_tools_list_json prefix heuristics with typed Tool_name grouping
- keep the existing operator-facing group names while classifying through the typed catalog
- add a regression that keeper_board_fake is not grouped while canonical tools still land in the expected groups

## Why it matters
This removes a UI-facing string-prefix heuristic from the keeper tool-list surface. The grouping now follows typed tool identifiers instead of accepting board-looking or voice-looking names by spelling alone.

## Validation
- git diff --check origin/main..HEAD
- scripts/dune-local.sh build test/test_keeper_exec_tools.exe
- ./_build/default/test/test_keeper_exec_tools.exe test keeper_tools_list_json (1 test, run ID FD519ZOM)

## Note
- Full ./_build/default/test/test_keeper_exec_tools.exe was attempted and the new keeper_tools_list_json test passed, but the pre-existing exec_cache/miss-then-hit case failed locally because Docker socket access was denied at unix:///Users/dancer/.docker/run/docker.sock.