### PR TITLE
refactor(transport): catalog openapi operation tags

### DIFF
--- a/lib/transport.ml
+++ b/lib/transport.ml
@@ -319,47 +319,54 @@ module Rest = struct
               prompt_hints = [];
             })
 
+  let operation_tag_groups =
+    [
+      ( "transport",
+        [
+          "masc_transport_status";
+          "masc_websocket_discovery";
+          "masc_webrtc_offer";
+          "masc_webrtc_answer";
+        ] );
+      ( "tasks",
+        [
+          "masc_status";
+          "masc_tasks";
+          "masc_add_task";
+          "masc_batch_add_tasks";
+          "masc_transition";
+          "masc_claim_next";
+        ] );
+      ( "planning",
+        [
+          "masc_plan_init";
+          "masc_plan_get";
+          "masc_plan_update";
+          "masc_note_add";
+          "masc_deliver";
+        ] );
+      ( "messaging",
+        [
+          "masc_broadcast";
+          "masc_messages";
+          "masc_a2a_delegate";
+          "masc_a2a_subscribe";
+        ] );
+      ( "decision",
+        [
+          "decision_create";
+          "decision_finalize";
+          "decision_status";
+          "masc_execution_orders";
+        ] );
+    ]
+
   let tags_for_operation name =
-    if
-      String.equal name "masc_transport_status"
-      || String.equal name "masc_websocket_discovery"
-      || String.equal name "masc_webrtc_offer"
-      || String.equal name "masc_webrtc_answer"
-    then
-      [ "transport" ]
-    else if
-      String.equal name "masc_status"
-      || String.equal name "masc_tasks"
-      || String.equal name "masc_add_task"
-      || String.equal name "masc_batch_add_tasks"
-      || String.equal name "masc_transition"
-      || String.equal name "masc_claim_next"
-    then
-      [ "tasks" ]
-    else if
-      String.equal name "masc_plan_init"
-      || String.equal name "masc_plan_get"
-      || String.equal name "masc_plan_update"
-      || String.equal name "masc_note_add"
-      || String.equal name "masc_deliver"
-    then
-      [ "planning" ]
-    else if
-      String.equal name "masc_broadcast"
-      || String.equal name "masc_messages"
-      || String.equal name "masc_a2a_delegate"
-      || String.equal name "masc_a2a_subscribe"
-    then
-      [ "messaging" ]
-    else if
-      String.equal name "decision_create"
-      || String.equal name "decision_finalize"
-      || String.equal name "decision_status"
-      || String.equal name "masc_execution_orders"
-    then
-      [ "decision" ]
-    else
-      [ "masc" ]
+    operation_tag_groups
+    |> List.find_map (fun (tag, operations) ->
+           if List.exists (String.equal name) operations then Some [ tag ]
+           else None)
+    |> Option.value ~default:[ "masc" ]
 
   let parameters_from_schema (schema : Yojson.Safe.t) =
     let required = Sdk_tool_contract.required_names schema in

--- a/test/test_transport_coverage.ml
+++ b/test/test_transport_coverage.ml
@@ -680,13 +680,25 @@ let test_rest_generate_openapi_document () =
   check bool "mcp security present" true
     (mcp_post |> member "security" <> `Null);
   let operations = mcp_post |> member "x-mcp-operations" |> to_list in
-  let status_entry =
+  let operation_entry operation_id =
     operations
     |> List.find (fun row ->
-           row |> member "operationId" |> to_string = "masc_status")
+           row |> member "operationId" |> to_string = operation_id)
   in
+  let check_operation_tags operation_id expected =
+    let tags =
+      operation_entry operation_id |> member "tags" |> to_list
+      |> List.map to_string
+    in
+    check (list string) (operation_id ^ " tags") expected tags
+  in
+  let status_entry = operation_entry "masc_status" in
   check bool "status summary non-empty" true
     (String.length (status_entry |> member "summary" |> to_string) > 0);
+  check_operation_tags "masc_status" [ "tasks" ];
+  check_operation_tags "masc_plan_init" [ "planning" ];
+  check_operation_tags "masc_broadcast" [ "messaging" ];
+  check_operation_tags "masc_join" [ "masc" ];
   let sdk_aliases =
     status_entry |> member "x-agent-sdk" |> member "aliases" |> to_list
   in
@@ -694,19 +706,11 @@ let test_rest_generate_openapi_document () =
     (List.exists
        (fun row -> row |> member "name" |> to_string = "masc_room_status")
        sdk_aliases);
-  let add_task_entry =
-    operations
-    |> List.find (fun row ->
-           row |> member "operationId" |> to_string = "masc_add_task")
-  in
+  let add_task_entry = operation_entry "masc_add_task" in
   check int "add_task has no fake rest binding"
     0
     (add_task_entry |> member "x-rest-bindings" |> to_list |> List.length);
-  let broadcast_entry =
-    operations
-    |> List.find (fun row ->
-           row |> member "operationId" |> to_string = "masc_broadcast")
-  in
+  let broadcast_entry = operation_entry "masc_broadcast" in
   check bool "broadcast rest binding is real" true
     (List.exists
        (fun row ->
@@ -715,6 +719,8 @@ let test_rest_generate_openapi_document () =
   let broadcast_post =
     doc |> member "paths" |> member "/api/v1/broadcast" |> member "post"
   in
+  check (list string) "broadcast REST operation tags" [ "messaging" ]
+    (broadcast_post |> member "tags" |> to_list |> List.map to_string);
   check string "broadcast auth mode" "bearer_required"
     (broadcast_post |> member "x-auth-mode" |> to_string);
   check bool "broadcast security present" true


### PR DESCRIPTION
## Summary
- replace the OpenAPI operation tag if/else string chain with an explicit tag-group catalog
- keep default  tagging behavior for uncategorized operations
- add OpenAPI document coverage for task, planning, messaging, default, and REST path tags

## Why this matters
The websocket/transport follow-up reduced route mapping drift, but tag assignment still lived in a hand-maintained OR-chain. This makes the classification table easier to audit and less likely to drift when transport-facing operations are added or moved.

## Validation
- git diff --check
- scripts/dune-local.sh build test/test_transport_coverage.exe
- ./_build/default/test/test_transport_coverage.exe