### PR TITLE
[#9632] feat(process): masc_process_timeout_total Prometheus counter

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -217,6 +217,23 @@ let record_fsm_drift_with_agent ~variant ~force ~agent_name =
 
 let () = Atomic.set Coord_hooks.fsm_drift_observer_fn record_fsm_drift_with_agent
 
+(* #9632: Process_eio timeout observability.
+   Fleet-wide rate of subprocess timeouts, broken down by program
+   (argv[0] basename) and configured budget.  Lets operators answer
+   "which command is timing out, and is 15s/60s the right budget?"
+   without log-scraping the WARN line.  Cardinality is bounded by
+   the small set of commands MASC actually invokes (~10-20 series). *)
+let process_timeout_metric = "masc_process_timeout_total"
+
+let record_process_timeout ~program ~timeout_sec =
+  Prometheus.inc_counter process_timeout_metric
+    ~labels:[ ("program", program);
+              ("timeout_sec", Printf.sprintf "%.0f" timeout_sec) ]
+    ()
+
+let () =
+  Atomic.set Process_eio.process_timeout_observer_fn record_process_timeout
+
 (* Activity graph emit — wraps Activity_graph for room sub-modules *)
 let () = Atomic.set Coord_hooks.activity_emit_fn (fun config ~actor ?subject ~kind ~payload ~tags () ->
     (try

--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -223,7 +223,7 @@ let () = Atomic.set Coord_hooks.fsm_drift_observer_fn record_fsm_drift_with_agen
    "which command is timing out, and is 15s/60s the right budget?"
    without log-scraping the WARN line.  Cardinality is bounded by
    the small set of commands MASC actually invokes (~10-20 series). *)
-let process_timeout_metric = "masc_process_timeout_total"
+let process_timeout_metric = Prometheus.metric_process_timeout
 
 let record_process_timeout ~program ~timeout_sec =
   Prometheus.inc_counter process_timeout_metric

--- a/lib/coord.mli
+++ b/lib/coord.mli
@@ -53,3 +53,20 @@ val record_fsm_drift_with_agent :
     attribution.  This lets ratchet readiness ("which keepers are
     skipping Start?") be answered from Prometheus without
     log-scraping the WARN line. *)
+
+(** {1 Process timeout observability (#9632)} *)
+
+val process_timeout_metric : string
+(** Canonical Prometheus metric for [Process_eio] timeouts
+    ([masc_process_timeout_total]).  Labels: [program] (argv0
+    basename, e.g. ["git"], ["gh"]), [timeout_sec] (configured budget,
+    e.g. ["15"], ["60"]).  Exposed so tests and Grafana rules can pin
+    the name. *)
+
+val record_process_timeout : program:string -> timeout_sec:float -> unit
+(** Increment {!process_timeout_metric}.  Wired to
+    {!Process_eio.process_timeout_observer_fn} at module load so every
+    [Eio.Time.Timeout] in [run_argv] / [run_argv_with_stdin] /
+    [run_argv_with_stdin_and_status_split] / [run_argv_with_status_split]
+    surfaces in Prometheus without taking a direct dependency on
+    [masc_mcp.Prometheus] from the lower [masc_process] layer. *)

--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -23,6 +23,22 @@ type runtime = {
     after [init] has published the runtime on the main domain. *)
 let runtime_state : runtime option Atomic.t = Atomic.make None
 
+(** Observability hook: invoked when an Eio process call hits its
+    [timeout_sec] budget.  Default no-op so the lower [masc_process]
+    layer carries no [Prometheus] dependency.  Wired from [lib/coord.ml]
+    at module load to emit [masc_process_timeout_total].
+
+    Cardinality: callers should pass [program = Filename.basename argv0]
+    (~10-20 distinct programs fleet-wide); [timeout_sec] is the per-call
+    budget (a few discrete values: 15.0, 60.0, ...). *)
+let process_timeout_observer_fn :
+    (program:string -> timeout_sec:float -> unit) Atomic.t =
+  Atomic.make (fun ~program:_ ~timeout_sec:_ -> ())
+
+let argv_program = function
+  | [] -> "<empty>"
+  | prog :: _ -> Filename.basename prog
+
 let init ~cwd_default ~proc_mgr ~clock =
   Atomic.set runtime_state (Some { proc_mgr; clock; cwd_default })
 
@@ -472,6 +488,8 @@ let run_argv ?(timeout_sec = 60.0) ?env (argv : string list) : string =
         | Eio.Time.Timeout ->
             Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
               timeout_sec label;
+            (Atomic.get process_timeout_observer_fn)
+              ~program:(argv_program argv) ~timeout_sec;
             process_error_output ~label
               ~reason:(Printf.sprintf "timeout after %.0fs" timeout_sec) ()
         | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -507,6 +525,8 @@ let run_argv_with_stdin ?(timeout_sec = 60.0) ?env ~(stdin_content : string) (ar
         | Eio.Time.Timeout ->
             Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
               timeout_sec label;
+            (Atomic.get process_timeout_observer_fn)
+              ~program:(argv_program argv) ~timeout_sec;
             process_error_output ~label
               ~reason:(Printf.sprintf "timeout after %.0fs" timeout_sec) ()
         | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -558,6 +578,8 @@ let run_argv_with_stdin_and_status_split
         | Eio.Time.Timeout ->
             Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
               timeout_sec label;
+            (Atomic.get process_timeout_observer_fn)
+              ~program:(argv_program argv) ~timeout_sec;
             let timeout_status = Unix.WEXITED 124 in
             let stdout = Buffer.contents stdout_buf in
             let stderr = Buffer.contents stderr_buf in
@@ -626,6 +648,8 @@ let run_argv_with_status_split ?(timeout_sec = 60.0) ?env ?cwd
         | Eio.Time.Timeout ->
             Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
               timeout_sec label;
+            (Atomic.get process_timeout_observer_fn)
+              ~program:(argv_program argv) ~timeout_sec;
             let timeout_status = Unix.WEXITED 124 in
             let stdout = Buffer.contents stdout_buf in
             let stderr = Buffer.contents stderr_buf in

--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -39,6 +39,14 @@ let argv_program = function
   | [] -> "<empty>"
   | prog :: _ -> Filename.basename prog
 
+let observe_process_timeout argv ~timeout_sec =
+  try
+    (Atomic.get process_timeout_observer_fn)
+      ~program:(argv_program argv) ~timeout_sec
+  with exn ->
+    Log.Misc.warn "[Process_eio] timeout observer failed: %s"
+      (Printexc.to_string exn)
+
 let init ~cwd_default ~proc_mgr ~clock =
   Atomic.set runtime_state (Some { proc_mgr; clock; cwd_default })
 
@@ -350,6 +358,8 @@ let with_unix_capture ?env ?cwd ?stdin_content ?(capture_stderr = false)
                   ()
               else stderr
             in
+            if !timed_out then
+              observe_process_timeout argv ~timeout_sec;
             cleanup ();
             on_success status stdout stderr)
      with
@@ -488,8 +498,7 @@ let run_argv ?(timeout_sec = 60.0) ?env (argv : string list) : string =
         | Eio.Time.Timeout ->
             Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
               timeout_sec label;
-            (Atomic.get process_timeout_observer_fn)
-              ~program:(argv_program argv) ~timeout_sec;
+            observe_process_timeout argv ~timeout_sec;
             process_error_output ~label
               ~reason:(Printf.sprintf "timeout after %.0fs" timeout_sec) ()
         | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -525,8 +534,7 @@ let run_argv_with_stdin ?(timeout_sec = 60.0) ?env ~(stdin_content : string) (ar
         | Eio.Time.Timeout ->
             Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
               timeout_sec label;
-            (Atomic.get process_timeout_observer_fn)
-              ~program:(argv_program argv) ~timeout_sec;
+            observe_process_timeout argv ~timeout_sec;
             process_error_output ~label
               ~reason:(Printf.sprintf "timeout after %.0fs" timeout_sec) ()
         | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -578,8 +586,7 @@ let run_argv_with_stdin_and_status_split
         | Eio.Time.Timeout ->
             Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
               timeout_sec label;
-            (Atomic.get process_timeout_observer_fn)
-              ~program:(argv_program argv) ~timeout_sec;
+            observe_process_timeout argv ~timeout_sec;
             let timeout_status = Unix.WEXITED 124 in
             let stdout = Buffer.contents stdout_buf in
             let stderr = Buffer.contents stderr_buf in
@@ -648,8 +655,7 @@ let run_argv_with_status_split ?(timeout_sec = 60.0) ?env ?cwd
         | Eio.Time.Timeout ->
             Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
               timeout_sec label;
-            (Atomic.get process_timeout_observer_fn)
-              ~program:(argv_program argv) ~timeout_sec;
+            observe_process_timeout argv ~timeout_sec;
             let timeout_status = Unix.WEXITED 124 in
             let stdout = Buffer.contents stdout_buf in
             let stderr = Buffer.contents stderr_buf in

--- a/lib/process/process_eio.mli
+++ b/lib/process/process_eio.mli
@@ -23,6 +23,21 @@ val get_cwd_default : unit -> (Eio.Fs.dir_ty Eio.Path.t, string) result
     fallback path (e.g. bind-related subprocess transport errors on macOS). *)
 val should_retry_unix_fallback : exn -> bool
 
+(** {1 Observability hook (#9632)} *)
+
+val process_timeout_observer_fn :
+  (program:string -> timeout_sec:float -> unit) Atomic.t
+(** Hook fired from every [run_argv*] timeout branch.  Default no-op so
+    [masc_process] carries no [Prometheus] dependency.  [lib/coord.ml]
+    wires it at module load to emit [masc_process_timeout_total].
+    [program] is [Filename.basename argv0] (~10-20 distinct programs
+    fleet-wide). *)
+
+val argv_program : string list -> string
+(** [argv_program argv] returns [Filename.basename argv0] (or
+    ["<empty>"] for an empty argv).  Exposed for tests and parity with
+    the hook payload. *)
+
 (** {1 Eio-native process execution (global refs)} *)
 
 (** Run command with explicit argv (no shell). Safe from injection.

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -524,6 +524,7 @@ let metric_oas_bus_publish_block_seconds = "masc_oas_bus_publish_block_seconds_t
 let metric_oas_bus_publish = "masc_oas_bus_publish_total"
 let metric_runtime_ollama_probe_generate_skips =
   "masc_runtime_ollama_probe_generate_skips_total"
+let metric_process_timeout = "masc_process_timeout_total"
 
 (* #10130: boot-time sweep of [save_file_atomic] orphan temp
    files.  Labels: [size_class = empty | with_data].  The
@@ -854,6 +855,10 @@ let init () =
   add metric_runtime_ollama_probe_generate_skips
     "Total Ollama runtime probes that intentionally skipped /api/generate. \
      Labeled by reason=status_only|model_unloaded|ps_error|no_effective_model|policy_skip."
+    Counter;
+  add metric_process_timeout
+    "Total subprocess executions that exceeded their configured timeout. \
+     Labeled by program and timeout_sec."
     Counter;
   (* #10130: boot-time sweep of save_file_atomic orphans. *)
   add metric_fs_atomic_orphans_cleaned

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -228,6 +228,9 @@ val metric_oas_bus_subscriber_stream_depth : string
 val metric_oas_bus_publish_block_seconds : string
 val metric_oas_bus_publish : string
 val metric_runtime_ollama_probe_generate_skips : string
+val metric_process_timeout : string
+(** #9632: subprocess executions that exceeded their configured
+    timeout. Labels: [program, timeout_sec]. *)
 
 (** #10130: boot-time sweep of save_file_atomic orphan temp files.
     Labels: [size_class = empty | with_data]. *)

--- a/test/dune
+++ b/test/dune
@@ -63,6 +63,7 @@
         test_keeper_proactive_skip_counter
         test_oas_error_kind_counter
         test_fsm_drift_counter
+        test_process_timeout_counter
         test_keeper_wake_telemetry
         test_keeper_memory
         test_keeper_accountability
@@ -198,6 +199,7 @@
           test_keeper_proactive_skip_counter
           test_oas_error_kind_counter
           test_fsm_drift_counter
+          test_process_timeout_counter
           test_keeper_wake_telemetry
           test_keeper_memory
           test_keeper_accountability

--- a/test/test_process_eio_coverage.ml
+++ b/test/test_process_eio_coverage.ml
@@ -74,6 +74,31 @@ let test_run_argv_with_status_fallback_enforces_timeout () =
   let code = match status with Unix.WEXITED c -> c | _ -> -1 in
   check int "fallback timeout exit code" 124 code
 
+let with_timeout_observer f =
+  let previous = Atomic.get Process_eio.process_timeout_observer_fn in
+  let seen = ref [] in
+  Atomic.set Process_eio.process_timeout_observer_fn
+    (fun ~program ~timeout_sec ->
+       seen := (program, timeout_sec) :: !seen);
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set Process_eio.process_timeout_observer_fn previous)
+    (fun () -> f seen)
+
+let test_run_argv_with_status_fallback_observes_timeout () =
+  Process_eio.reset_for_testing ();
+  with_timeout_observer (fun seen ->
+      let status, _output =
+        Process_eio.run_argv_with_status ~timeout_sec:0.02 [ "/bin/sleep"; "5" ]
+      in
+      let code = match status with Unix.WEXITED c -> c | _ -> -1 in
+      check int "fallback timeout exit code" 124 code;
+      check
+        (list (pair string (float 0.0001)))
+        "fallback timeout observer payload"
+        [ ("sleep", 0.02) ]
+        (List.rev !seen))
+
 let test_init_exposes_complete_runtime () =
   Eio_main.run @@ fun env ->
   let proc_mgr = Eio.Stdenv.process_mgr env in
@@ -223,6 +248,8 @@ let () =
             test_run_argv_with_status_fallback_surfaces_spawn_error;
           test_case "argv-with-status-fallback-enforces-timeout" `Quick
             test_run_argv_with_status_fallback_enforces_timeout;
+          test_case "argv-with-status-fallback-observes-timeout" `Quick
+            test_run_argv_with_status_fallback_observes_timeout;
           test_case "init-exposes-complete-runtime" `Quick
             test_init_exposes_complete_runtime;
         ] );

--- a/test/test_process_timeout_counter.ml
+++ b/test/test_process_timeout_counter.ml
@@ -1,0 +1,118 @@
+(* test/test_process_timeout_counter.ml
+
+   #9632: pin the canonical Prometheus metric name + label
+   shape for [Process_eio] timeout observability.
+
+   Background: [run_argv] / [run_argv_with_stdin] /
+   [run_argv_with_stdin_and_status_split] /
+   [run_argv_with_status_split] all WARN-log on
+   [Eio.Time.Timeout] but never produced a metric, so
+   operators could not answer "which command is timing out
+   and is 15s/60s the right budget?" without log scraping.
+
+   Layering: [masc_process] sits below [masc_mcp.Prometheus]
+   in the library dep graph, so the emit runs through
+   [Process_eio.process_timeout_observer_fn] which [lib/coord.ml]
+   wires to [Masc_mcp.Coord.record_process_timeout].  This test
+   exercises the wired pair — [record_process_timeout]
+   directly for counter mechanics, and [Process_eio.argv_program]
+   for the cardinality-bounding helper. *)
+
+let counter_for ~program ~timeout_sec =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    Masc_mcp.Coord.process_timeout_metric
+    ~labels:[
+      ("program", program);
+      ("timeout_sec", Printf.sprintf "%.0f" timeout_sec);
+    ]
+    ()
+
+let test_metric_name_stable () =
+  Alcotest.(check string)
+    "process timeout canonical metric name"
+    "masc_process_timeout_total"
+    Masc_mcp.Coord.process_timeout_metric
+
+let test_argv_program_basename () =
+  Alcotest.(check string)
+    "absolute path → basename"
+    "git"
+    (Process_eio.argv_program
+       [ "/usr/bin/git"; "status"; "--porcelain" ]);
+  Alcotest.(check string)
+    "bare command → unchanged"
+    "gh"
+    (Process_eio.argv_program [ "gh"; "auth"; "status" ])
+
+let test_argv_program_empty () =
+  Alcotest.(check string)
+    "empty argv → sentinel"
+    "<empty>"
+    (Process_eio.argv_program [])
+
+let test_record_increments () =
+  let program = "test_program_9632" in
+  let timeout_sec = 15.0 in
+  let before = counter_for ~program ~timeout_sec in
+  Masc_mcp.Coord.record_process_timeout ~program ~timeout_sec;
+  Alcotest.(check (float 0.0001))
+    "+1 on call"
+    (before +. 1.0)
+    (counter_for ~program ~timeout_sec);
+  Masc_mcp.Coord.record_process_timeout ~program ~timeout_sec;
+  Alcotest.(check (float 0.0001))
+    "+1 again"
+    (before +. 2.0)
+    (counter_for ~program ~timeout_sec)
+
+let test_program_isolation () =
+  (* Two programs with the same timeout must not bleed. *)
+  let timeout_sec = 60.0 in
+  let prog_a = "isolation_a_9632" in
+  let prog_b = "isolation_b_9632" in
+  let before_a = counter_for ~program:prog_a ~timeout_sec in
+  Masc_mcp.Coord.record_process_timeout ~program:prog_b ~timeout_sec;
+  Alcotest.(check (float 0.0001))
+    "program A unchanged"
+    before_a
+    (counter_for ~program:prog_a ~timeout_sec)
+
+let test_timeout_sec_isolation () =
+  (* Same program with two budgets must split into separate series. *)
+  let program = "budget_split_9632" in
+  let before_15 = counter_for ~program ~timeout_sec:15.0 in
+  let before_60 = counter_for ~program ~timeout_sec:60.0 in
+  Masc_mcp.Coord.record_process_timeout ~program ~timeout_sec:15.0;
+  Alcotest.(check (float 0.0001))
+    "15s budget +1"
+    (before_15 +. 1.0)
+    (counter_for ~program ~timeout_sec:15.0);
+  Alcotest.(check (float 0.0001))
+    "60s budget unchanged"
+    before_60
+    (counter_for ~program ~timeout_sec:60.0)
+
+let () =
+  Alcotest.run "process_timeout_counter_9632"
+    [
+      ( "metric_name",
+        [
+          Alcotest.test_case "canonical name stable" `Quick
+            test_metric_name_stable;
+        ] );
+      ( "argv_program",
+        [
+          Alcotest.test_case "basename" `Quick test_argv_program_basename;
+          Alcotest.test_case "empty sentinel" `Quick test_argv_program_empty;
+        ] );
+      ( "record",
+        [
+          Alcotest.test_case "increments on call" `Quick test_record_increments;
+        ] );
+      ( "isolation",
+        [
+          Alcotest.test_case "programs isolated" `Quick test_program_isolation;
+          Alcotest.test_case "timeout_sec isolated" `Quick
+            test_timeout_sec_isolation;
+        ] );
+    ]

--- a/test/test_process_timeout_counter.ml
+++ b/test/test_process_timeout_counter.ml
@@ -30,8 +30,25 @@ let counter_for ~program ~timeout_sec =
 let test_metric_name_stable () =
   Alcotest.(check string)
     "process timeout canonical metric name"
-    "masc_process_timeout_total"
+    Masc_mcp.Prometheus.metric_process_timeout
     Masc_mcp.Coord.process_timeout_metric
+
+let test_metric_registered_at_init () =
+  let text = Masc_mcp.Prometheus.to_prometheus_text () in
+  let has literal =
+    try
+      ignore (Str.search_forward (Str.regexp_string literal) text 0);
+      true
+    with Not_found -> false
+  in
+  Alcotest.(check bool)
+    "process timeout HELP registered"
+    true
+    (has "# HELP masc_process_timeout_total");
+  Alcotest.(check bool)
+    "process timeout TYPE registered"
+    true
+    (has "# TYPE masc_process_timeout_total counter")
 
 let test_argv_program_basename () =
   Alcotest.(check string)
@@ -99,6 +116,8 @@ let () =
         [
           Alcotest.test_case "canonical name stable" `Quick
             test_metric_name_stable;
+          Alcotest.test_case "registered in Prometheus init" `Quick
+            test_metric_registered_at_init;
         ] );
       ( "argv_program",
         [


### PR DESCRIPTION
## 요약

`Process_eio`의 4개 `run_argv*` API에서 `Eio.Time.Timeout` 발생 시 Prometheus counter 발화. `git status --porcelain` 같은 fleet-wide 서브프로세스 timeout을 rate로 추적 가능.

Closes part of #9632 (observability — home repo git status 지연의 근본 원인은 별도 후속).

## 근본 원인

이슈 보고 (2026-04-23 18:55):
```
[WARN] [Misc] [Process_eio] Timeout after 15s: 'git' '-C' '/Users/dancer/me' '--no-optional-locks' 'status' '--porcelain'
```

기존 신호:
- WARN log (`lib/process/process_eio.ml:473, 508, 559, 627`)
- Prometheus counter: 없음

운영 측면 답할 수 없는 질문:
- "어떤 program이 가장 자주 timeout되는가?" — log scraping 외 답할 수 없음
- "15s 예산이 적당한가, 60s가 적당한가?" — pre/post 비교 불가
- "특정 keeper만 timeout이 몰리는가?" — 측정 불가 (program 단위 첫 단계)

## Architecture Layering

`masc_process` 가 `masc_mcp.Prometheus` 보다 **아래** 레이어 (lib/dune, lib/coord/dune 모두 `masc_process`를 의존). 직접 dep 추가하면 dependency cycle.

기존 `Coord_hooks` 패턴을 process 레이어에도 동일 적용:
- Hook 정의: `lib/process/process_eio.ml` `process_timeout_observer_fn`
- Prometheus emit: `lib/coord.ml` `record_process_timeout`
- Hook wire: `Atomic.set Process_eio.process_timeout_observer_fn record_...` at module load
- Caller fire: `Process_eio` timeout 분기에서 hook 호출만 (직접 Prometheus 의존 없음)

## 변경 내용

### `lib/process/process_eio.ml`

```ocaml
let process_timeout_observer_fn :
    (program:string -> timeout_sec:float -> unit) Atomic.t =
  Atomic.make (fun ~program:_ ~timeout_sec:_ -> ())

let argv_program = function
  | [] -> "<empty>"
  | prog :: _ -> Filename.basename prog
```

### 4개 timeout 분기 (lines 473, 508, 559, 627)

```diff
   | Eio.Time.Timeout ->
       Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
         timeout_sec label;
+      (Atomic.get process_timeout_observer_fn)
+        ~program:(argv_program argv) ~timeout_sec;
       process_error_output ~label ...
```

### `lib/coord.{ml,mli}`

```ocaml
let process_timeout_metric = "masc_process_timeout_total"

let record_process_timeout ~program ~timeout_sec =
  Prometheus.inc_counter process_timeout_metric
    ~labels:[ ("program", program);
              ("timeout_sec", Printf.sprintf "%.0f" timeout_sec) ]
    ()

let () =
  Atomic.set Process_eio.process_timeout_observer_fn record_process_timeout
```

## 카디널리티

| 차원 | 크기 |
|------|------|
| program | ~10-20 (git, gh, curl, tmux, dune, bash, ...) |
| timeout_sec | 2-3 (15.0, 60.0, occasionally other budgets) |
| **총** | ~20-60 series |

안전 (FSM drift counter와 같은 수준).

## 운영 활용

```promql
# Program 별 timeout rate 랭킹
sort_desc(
  sum by (program) (
    rate(masc_process_timeout_total[5m])
  )
)

# git status 만 알람 (issue의 증상)
rate(masc_process_timeout_total{program="git"}[5m]) > 0

# Budget 별 분포 — 15s가 너무 빠듯한가?
sum by (timeout_sec) (rate(masc_process_timeout_total[1h]))
```

## 테스트

`test/test_process_timeout_counter.ml` 6 scenario:

```bash
$ dune exec test/test_process_timeout_counter.exe
[OK]  metric_name  0  canonical name stable.
[OK]  argv_program 0  basename.
[OK]  argv_program 1  empty sentinel.
[OK]  record       0  increments on call.
[OK]  isolation    0  programs isolated.
[OK]  isolation    1  timeout_sec isolated.
Test Successful in 0.001s. 6 tests run.
```

## 회귀 리스크

매우 낮음. Pure additive — timeout 분기에 hook 호출만 추가, 기존 WARN/process_error_output 동작 그대로. Hook 미wire 시 default no-op이라 module load 순서 문제 없음. `argv_program` helper는 새 export로 caller 영향 없음.

## 후속 (별건)

- **Home repo git latency 근본 원인**: `git -C ~/me status --porcelain` 자체가 왜 15s 넘는가? Working tree 크기/index lock/background gc 의심. 이 PR이 fleet-wide rate 측정 가능하게 만든 후 별도 조사.
- **Budget tuning**: rate 측정 후 `git` 계열만 30s/60s로 분리 검토.
- **`reason_of_exn_for_output` 결합**: timeout 외 exit reason도 같은 모양으로 분류 가능 (cancelled, exec_error 등). 별도 PR로 확장.

## 참고

- Issue #9632
- `lib/process/process_eio.ml:473, 508, 559, 627` — timeout 분기 4곳
- `lib/process/process_eio.ml:34-43` — hook + helper
- `lib/coord.ml:220-238` — wire + Prometheus emit
- `test/test_process_timeout_counter.ml` — coverage
- 기존 패턴 참조: #9795 FSM drift hook, #9645 distributed lock acquire counter (in-flight)
