### PR TITLE
[#10192] fix(ci): skip agent draft policy gate on already-merged PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,15 +715,27 @@ jobs:
           AGENT_DRAFT_GUARD_BYPASS_LABELS: ${{ vars.AGENT_DRAFT_GUARD_BYPASS_LABELS }}
         run: |
           if command -v gh >/dev/null 2>&1 && [ -n "${PR_NUMBER:-}" ]; then
-            live_is_draft="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
-            if [ "$live_is_draft" = "true" ] || [ "$live_is_draft" = "false" ]; then
-              export PR_LIVE_IS_DRAFT="$live_is_draft"
+            # #10192: collect state, draft, labels in one query so the
+            # post-merge skip and the live-label refresh see the same
+            # snapshot.
+            live_pr_json="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state,isDraft,labels 2>/dev/null || true)"
+            if [ -n "$live_pr_json" ]; then
+              live_state="$(printf '%s' "$live_pr_json" | jq -r '.state // empty')"
+              if [ -n "$live_state" ]; then
+                export PR_LIVE_STATE="$live_state"
+              fi
+              live_is_draft="$(printf '%s' "$live_pr_json" | jq -r '.isDraft // empty')"
+              if [ "$live_is_draft" = "true" ] || [ "$live_is_draft" = "false" ]; then
+                export PR_LIVE_IS_DRAFT="$live_is_draft"
+              else
+                echo "::warning::Could not resolve live PR draft state; falling back to pull_request event payload."
+              fi
+              live_labels="$(printf '%s' "$live_pr_json" | jq -r '[.labels[].name] | join(",")')"
+              if [ -n "$live_labels" ]; then
+                export PR_LIVE_LABELS="$live_labels"
+              fi
             else
-              echo "::warning::Could not resolve live PR draft state; falling back to pull_request event payload."
-            fi
-            live_labels="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || true)"
-            if [ -n "$live_labels" ]; then
-              export PR_LIVE_LABELS="$live_labels"
+              echo "::warning::Could not fetch live PR snapshot; falling back to pull_request event payload."
             fi
           fi
           scripts/ci/check-agent-draft-policy.sh

--- a/scripts/ci/check-agent-draft-policy.sh
+++ b/scripts/ci/check-agent-draft-policy.sh
@@ -11,6 +11,18 @@ if [[ "$event_name" != "pull_request" ]]; then
   exit 0
 fi
 
+# #10192: CI Gate is a `needs:` aggregator that runs after every other
+# job, so on auto-merge it can fire after the PR is already merged and
+# label-cleanup has stripped `human-approved-ready`.  At that point the
+# live label snapshot no longer reflects the approval state that
+# permitted the merge — a post-merge red mark with no recovery action.
+# Treat MERGED/CLOSED as a hard skip; the gate has nothing to enforce.
+pr_state="$(printf '%s' "${PR_LIVE_STATE:-${PR_STATE:-OPEN}}" | tr '[:lower:]' '[:upper:]')"
+if [[ "$pr_state" == "MERGED" || "$pr_state" == "CLOSED" ]]; then
+  echo "agent draft policy: skipped — PR already ${pr_state} (post-merge live-label artifact, #10192)"
+  exit 0
+fi
+
 pr_is_draft="${PR_LIVE_IS_DRAFT:-${PR_IS_DRAFT:-false}}"
 pr_title="${PR_TITLE:-}"
 pr_head_ref="${PR_HEAD_REF:-}"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -83,6 +83,17 @@ let test_ci_sync_and_asset_contracts () =
     (file_contains_pattern ".github/workflows/ci.yml" "PR_LIVE_IS_DRAFT");
   check bool "ci gate refreshes live labels" true
     (file_contains_pattern ".github/workflows/ci.yml" "PR_LIVE_LABELS");
+  (* #10192: keep ci.yml's `gh pr view` query and the policy script's
+     skip branch in sync.  Either side drifting silently re-introduces
+     the post-merge red mark. *)
+  check bool "ci gate exports live PR state" true
+    (file_contains_pattern ".github/workflows/ci.yml" "PR_LIVE_STATE");
+  check bool "agent draft policy script reads live PR state" true
+    (file_contains_pattern "scripts/ci/check-agent-draft-policy.sh"
+       "PR_LIVE_STATE");
+  check bool "agent draft policy script skips MERGED PRs" true
+    (file_contains_pattern "scripts/ci/check-agent-draft-policy.sh"
+       "MERGED");
   check bool "pr hygiene no longer checks dashboard assets (gitignored)" true
     (not (file_contains_pattern "scripts/check-pr-hygiene.sh" "dashboard source or Vite config changed but assets/dashboard was not updated"))
 
@@ -127,7 +138,26 @@ let test_agent_draft_policy_script () =
          ("PR_TITLE", "fix: human authored branch");
          ("PR_HEAD_REF", "feature/human-branch");
          ("PR_LABELS", "enhancement");
-       ])
+       ]);
+  (* #10192: post-merge skip.  An agent PR that would otherwise FAIL
+     (ready + no bypass) must pass when the live PR state is MERGED,
+     because label cleanup turns the live snapshot into a post-merge
+     artifact rather than the approval state at merge time.  Without
+     this skip, CI Gate posts a permanent red mark with no recovery
+     action against an already-merged PR. *)
+  check int "MERGED state skips check (no bypass label)" 0
+    (run_agent_draft_policy
+       (("PR_LIVE_STATE", "MERGED") :: ("PR_IS_DRAFT", "false") :: base));
+  check int "CLOSED state skips check" 0
+    (run_agent_draft_policy
+       (("PR_LIVE_STATE", "CLOSED") :: ("PR_IS_DRAFT", "false") :: base));
+  check int "lower-case merged also skips" 0
+    (run_agent_draft_policy
+       (("PR_LIVE_STATE", "merged") :: ("PR_IS_DRAFT", "false") :: base));
+  check bool "OPEN state still enforces (regression guard)" true
+    (run_agent_draft_policy
+       (("PR_LIVE_STATE", "OPEN") :: ("PR_IS_DRAFT", "false") :: base)
+    <> 0)
 
 let test_health_and_ci_runner_diagnostics () =
   check bool "health snapshot records baseline source" true


### PR DESCRIPTION
## 요약

`CI Gate`의 agent draft policy step이 auto-merge 직후 발화하면, label 자동정리(`human-approved-ready` 제거)가 끝난 **post-merge** label snapshot을 보고 fail. 머지된 PR에 영구 빨간 표시, 복구 불가능. PR_LIVE_STATE를 읽어 MERGED/CLOSED는 skip.

Closes #10192.

## 근본 원인

이슈 보고 (PR #10181, run 24924336433):
- 06:17:55Z PR 머지 (auto-merge)
- 06:17:55Z 직후 label 자동정리로 `human-approved-ready` 제거
- 06:29:29Z `CI Gate` job 실행 → live label 읽으면 `enhancement` only → fail

`CI Gate`는 `needs:` aggregator라 모든 다른 job 후에 돌고, label cleanup은 머지 시점에 즉시 발화. 두 시점이 어긋나면서 gate가 머지 당시 approval state가 아닌 정리 후 state를 본다.

## Architecture

기존 step (`scripts/ci/check-agent-draft-policy.sh` 호출 전):
1. `gh pr view --json isDraft` → `PR_LIVE_IS_DRAFT`
2. `gh pr view --json labels` → `PR_LIVE_LABELS`

문제: 두 query가 별개 호출이라 race가능 + state(`MERGED`)는 안 봄.

이번 PR:
1. **단일 `gh pr view --json state,isDraft,labels`** + `jq` 파싱 — 한 snapshot
2. 새 `PR_LIVE_STATE` export
3. 스크립트 진입 직후: `MERGED`/`CLOSED`면 skip

## 변경 내용

### `.github/workflows/ci.yml` (line 716-728)

```diff
-          live_is_draft="$(gh pr view "$PR_NUMBER" ... --json isDraft ...)"
-          ...
-          live_labels="$(gh pr view "$PR_NUMBER" ... --json labels ...)"
+          live_pr_json="$(gh pr view "$PR_NUMBER" ... --json state,isDraft,labels ...)"
+          live_state="$(printf '%s' "$live_pr_json" | jq -r '.state // empty')"
+          export PR_LIVE_STATE="$live_state"
+          live_is_draft="$(printf '%s' "$live_pr_json" | jq -r '.isDraft // empty')"
+          ...
+          live_labels="$(printf '%s' "$live_pr_json" | jq -r '[.labels[].name] | join(",")')"
```

### `scripts/ci/check-agent-draft-policy.sh`

```diff
 event_name="${GITHUB_EVENT_NAME:-}"
 if [[ "$event_name" != "pull_request" ]]; then
   echo "agent draft policy: skipped for event ${event_name:-unknown}"
   exit 0
 fi
+
+pr_state="$(printf '%s' "${PR_LIVE_STATE:-${PR_STATE:-OPEN}}" | tr '[:lower:]' '[:upper:]')"
+if [[ "$pr_state" == "MERGED" || "$pr_state" == "CLOSED" ]]; then
+  echo "agent draft policy: skipped — PR already ${pr_state} (post-merge live-label artifact, #10192)"
+  exit 0
+fi
```

`OPEN` (default fallback)이면 기존 enforcement 로직 그대로 유지.

## 테스트

`test_ci_hardening_source.ml`에 7개 새 assertion 추가 (4 runtime + 3 source contract):

```bash
$ dune exec test/test_ci_hardening_source.exe
[OK]  source_guard  0  sync and asset contracts.   ← +3 contract assertions
[OK]  source_guard  1  agent draft policy script.  ← +4 runtime assertions
... (33 more)
Test Successful in 0.371s. 35 tests run.
```

새 케이스:
- `MERGED state skips check (no bypass label)` — 핵심 fix
- `CLOSED state skips check`
- `lower-case merged also skips` — case insensitivity
- `OPEN state still enforces (regression guard)` — Open PR에는 기존 enforcement 그대로
- `ci gate exports live PR state` (source contract)
- `agent draft policy script reads live PR state` (source contract)
- `agent draft policy script skips MERGED PRs` (source contract)

마지막 3개는 ci.yml의 `PR_LIVE_STATE` export와 script의 `MERGED` 분기가 silent drift하지 않도록 SSOT lock.

## 회귀 리스크

낮음.

| 시나리오 | 기존 동작 | 새 동작 |
|---------|---------|--------|
| OPEN PR + ready + no bypass | FAIL | FAIL (그대로) |
| OPEN PR + draft | PASS | PASS (그대로) |
| OPEN PR + bypass label | PASS | PASS (그대로) |
| **MERGED PR + ready + no bypass** | **FAIL (false alarm)** | **PASS (skip)** |
| CLOSED PR + ready + no bypass | FAIL | PASS (skip) |

`gh pr view` 실패 시 (네트워크 장애 등) `PR_LIVE_STATE`는 unset → fallback `PR_STATE` 도 unset → default `OPEN`. 즉 fallback은 항상 enforcement 활성, fail-closed.

## 참고

- Issue #10192 (PR #10181 사례)
- `.github/workflows/ci.yml:716-735` — gate step
- `scripts/ci/check-agent-draft-policy.sh:8-23` — skip 분기
- `test/test_ci_hardening_source.ml:115-145` — runtime + contract tests
- 기존 패턴: #9707 (draft auto-merge guard), #9719 (manual recovery), #9727 (bypass actor verification)
