### PR TITLE
obs(grpc): backlog replay scanned/replayed counters

### DIFF
--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -459,8 +459,11 @@ let handle_subscribe
     let content = Fs_compat.load_file backlog_file in
     let lines = String.split_on_char '\n' content in
     let seq = ref 1L in
+    let scanned = ref 0 in
+    let replayed = ref 0 in
     List.iter (fun line ->
       if String.length line > 0 then begin
+        incr scanned;
         let msg_seq = !seq in
         if Int64.compare msg_seq req.since_seq > 0 then begin
           let event = T.Event.{
@@ -474,11 +477,20 @@ let handle_subscribe
           Transport_metrics.inc_grpc_bytes_sent
             ~bytes:(String.length event_bytes);
           Grpc_eio.Stream.add stream event_bytes;
-          incr events_count
+          incr events_count;
+          incr replayed
         end;
         seq := Int64.add !seq 1L
       end
-    ) lines
+    ) lines;
+    (* Attribution: scanned vs replayed splits wasted scan cost from
+       useful catch-up delivery on this Subscribe RPC. *)
+    if !scanned > 0 then
+      Transport_metrics.inc_grpc_backlog_replay_lines_scanned
+        ~delta:!scanned ();
+    if !replayed > 0 then
+      Transport_metrics.inc_grpc_backlog_replay_events_replayed
+        ~delta:!replayed ()
   end;
   (* Record delivered events from backlog replay *)
   Transport_metrics.inc_grpc_events_delivered ~delta:!events_count ();

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -441,6 +441,16 @@ let metric_ws_slice_fanout_skipped = "masc_ws_slice_fanout_skipped_total"
 let metric_ws_bytes_sent = "masc_ws_bytes_sent_total"
 let metric_grpc_bytes_sent = "masc_grpc_bytes_sent_total"
 let metric_ws_delta_built = "masc_ws_delta_built_total"
+(* Backlog-replay attribution: every gRPC Subscribe RPC reads
+   [.masc/backlog.jsonl] from disk before the live broadcast hook
+   takes over.  These two counters separate replay cost from live
+   delivery so a Subscribe burst can be billed against backlog IO,
+   not [grpc_bytes_sent] / [grpc_events_delivered] which lump init
+   + replay + live into one bucket. *)
+let metric_grpc_backlog_replay_lines_scanned =
+  "masc_grpc_backlog_replay_lines_scanned_total"
+let metric_grpc_backlog_replay_events_replayed =
+  "masc_grpc_backlog_replay_events_replayed_total"
 
 (* Admission queue metrics — used in admission_queue_metrics.ml. *)
 let metric_inference_queue_depth = "masc_inference_queue_depth"
@@ -947,6 +957,18 @@ let init () =
     "Per-session dashboard deltas constructed (one Yojson.Safe.t \
      allocation + jsonrpc_notification wrap per delta). Divide by \
      broadcast count to estimate fanout amplification."
+    Counter;
+  add metric_grpc_backlog_replay_lines_scanned
+    "Lines walked while replaying .masc/backlog.jsonl on a gRPC \
+     Subscribe RPC (every line, including those filtered by \
+     since_seq). Use with backlog file size to estimate disk read \
+     cost amplification under a Subscribe burst."
+    Counter;
+  add metric_grpc_backlog_replay_events_replayed
+    "Backlog events actually delivered (post-since_seq filter) on \
+     gRPC Subscribe. Subset of grpc_events_delivered; the difference \
+     between scanned-lines and replayed-events isolates wasted \
+     scan cost."
     Counter
 
 let start_time = Time_compat.now ()

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -278,6 +278,15 @@ val metric_ws_bytes_sent : string
 val metric_grpc_bytes_sent : string
 val metric_ws_delta_built : string
 
+val metric_grpc_backlog_replay_lines_scanned : string
+(** Lines walked while replaying [.masc/backlog.jsonl] on a gRPC
+    Subscribe RPC, including those filtered out by [since_seq]. *)
+
+val metric_grpc_backlog_replay_events_replayed : string
+(** Backlog events actually delivered (post-[since_seq] filter)
+    on a gRPC Subscribe RPC. The gap between scanned-lines and
+    replayed-events isolates wasted scan cost. *)
+
 (** {1 Admission queue metrics} *)
 
 val metric_inference_queue_depth : string

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -99,6 +99,18 @@ let inc_grpc_bytes_sent ~bytes =
 let inc_ws_delta_built () =
   Prometheus.inc_counter Prometheus.metric_ws_delta_built ()
 
+let inc_grpc_backlog_replay_lines_scanned ?(delta=1) () =
+  if delta > 0 then
+    Prometheus.inc_counter
+      Prometheus.metric_grpc_backlog_replay_lines_scanned
+      ~delta:(float_of_int delta) ()
+
+let inc_grpc_backlog_replay_events_replayed ?(delta=1) () =
+  if delta > 0 then
+    Prometheus.inc_counter
+      Prometheus.metric_grpc_backlog_replay_events_replayed
+      ~delta:(float_of_int delta) ()
+
 (** {1 Environment-derived Transport Config} *)
 
 let grpc_runtime_listening : bool Atomic.t = Atomic.make false


### PR DESCRIPTION
## 문제
gRPC Subscribe RPC마다 `.masc/backlog.jsonl`을 읽어서 모든 라인을 `since_seq`로 필터링. 기존 카운터(`grpc_bytes_sent`, `grpc_events_delivered`)는 init + replay + live 모두를 한 버킷에 합산하므로 backlog 비대 + Subscribe burst 시 IO 비용 attribution 불가.

## 변경
2개 카운터 추가:
- `masc_grpc_backlog_replay_lines_scanned_total`: replay loop에서 walk한 non-empty 라인 (since_seq 미만 포함)
- `masc_grpc_backlog_replay_events_replayed_total`: filter 통과해 enqueue된 라인

scanned − replayed 차이가 wasted scan cost. `scanned / active_subscribers` 로 burst 시 per-RPC amplification 측정.

## Behavior
무변동. 카운터는 `Sys.file_exists` 가드 안에서만 fire. 기존 `grpc_bytes_sent`, `grpc_events_delivered` 의미 보존.

## Validation
- `test_grpc_coordination` 26/26
- `test_transport_integration` 9/9 (`grpc_subscribe_sse` 3 + `auto_cleanup` 등)