### PR TITLE
fix(keeper): gate timeout rotation by turn budget

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -444,6 +444,58 @@ let bounded_oas_timeout_for_turn_budget ~(estimated_input_tokens : int)
     ~max_turns:(Keeper_runtime_resolved.reactive_max_turns_per_call ())
     ~remaining_turn_budget_s
 
+let oas_retry_budget_available_for_turn ~(estimated_input_tokens : int)
+    ~(max_turns : int) ~(remaining_turn_budget_s : float) : bool =
+  Option.is_some
+    (resolve_bounded_oas_timeout_budget_with_turn_budget
+       ~estimated_input_tokens ~max_turns ~remaining_turn_budget_s)
+
+let reclassify_oas_timeout_for_attempt
+    ~(timeout_budget : oas_timeout_budget_resolution option)
+    (err : Oas.Error.sdk_error) : Oas.Error.sdk_error =
+  match err, timeout_budget with
+  | Oas.Error.Api (Timeout { message }), Some timeout_budget
+    when EC.is_structural_oas_timeout_message message ->
+      Oas_worker_named.sdk_error_of_masc_internal_error
+        (Oas_worker_named.Oas_timeout_budget
+           {
+             budget_sec = timeout_budget.effective_timeout_sec;
+             keeper_turn_timeout_sec =
+               timeout_budget.keeper_turn_timeout_sec;
+             estimated_input_tokens = timeout_budget.estimated_input_tokens;
+             source = timeout_budget.source;
+           })
+  | _ -> err
+
+type degraded_retry_budget_decision =
+  | No_degraded_retry
+  | Degraded_retry_budget_exhausted of EC.degraded_retry
+  | Degraded_retry_allowed of EC.degraded_retry
+
+let next_fail_open_cascade_for_turn_with_budget
+    ?rotation_cascades
+    ~(base_cascade : string)
+    ~(effective_cascade : string)
+    ~(tool_requirement : string)
+    ~(attempted_cascades : string list)
+    ~(estimated_input_tokens : int)
+    ~(max_turns : int)
+    ~(remaining_turn_budget_s : float)
+    (err : Oas.Error.sdk_error) : degraded_retry_budget_decision =
+  match
+    next_fail_open_cascade_for_turn
+      ?rotation_cascades
+      ~base_cascade ~effective_cascade ~tool_requirement
+      ~attempted_cascades err
+  with
+  | None -> No_degraded_retry
+  | Some retry ->
+      if
+        oas_retry_budget_available_for_turn
+          ~estimated_input_tokens ~max_turns ~remaining_turn_budget_s
+      then Degraded_retry_allowed retry
+      else Degraded_retry_budget_exhausted retry
+
 type overflow_retry_plan = {
   retry_max_context : int;
   retry_generation : int;
@@ -1332,10 +1384,11 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   ~base_path:config.base_path meta.name
                   Keeper_registry.Cascade_exhausted
               else
-                Keeper_registry.set_turn_phase
-                  ~base_path:config.base_path meta.name
-                  Keeper_registry.Turn_finalizing
+                  Keeper_registry.set_turn_phase
+                    ~base_path:config.base_path meta.name
+                    Keeper_registry.Turn_finalizing
             in
+            let attempt_timeout_budget = ref None in
             let max_turns =
               match channel with
               | Keeper_world_observation.Reactive ->
@@ -1364,6 +1417,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                                 (remaining_turn_budget_s ());
                           }))
               | Some timeout_budget ->
+                  attempt_timeout_budget := Some timeout_budget;
                   last_timeout_budget := Some timeout_budget;
                   Keeper_registry.set_turn_cascade_state
                     ~base_path:config.base_path meta.name
@@ -1387,20 +1441,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                 Ok result
             | Error err ->
                 let err =
-                  match err, !last_timeout_budget with
-                  | Oas.Error.Api (Timeout { message }), Some timeout_budget
-                    when EC.is_structural_oas_timeout_message message ->
-                      Oas_worker_named.sdk_error_of_masc_internal_error
-                        (Oas_worker_named.Oas_timeout_budget
-                           {
-                             budget_sec = timeout_budget.effective_timeout_sec;
-                             keeper_turn_timeout_sec =
-                               timeout_budget.keeper_turn_timeout_sec;
-                             estimated_input_tokens =
-                               timeout_budget.estimated_input_tokens;
-                             source = timeout_budget.source;
-                           })
-                  | _ -> err
+                  reclassify_oas_timeout_for_attempt
+                    ~timeout_budget:!attempt_timeout_budget err
                 in
                 let _ = drain_turn_event_bus () in
                 let committed_tools = committed_mutating_tools_snapshot () in
@@ -1468,15 +1510,19 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   Error reclassified
                 end else
                   match
-                    next_fail_open_cascade_for_turn
+                    next_fail_open_cascade_for_turn_with_budget
                       ?rotation_cascades:fail_open_rotation_cascades
                       ~base_cascade:meta.cascade_name
                       ~effective_cascade:execution.cascade_name
                       ~tool_requirement:initial_tool_requirement
                       ~attempted_cascades
+                      ~estimated_input_tokens:
+                        prompt_timeout_estimate_tokens
+                      ~max_turns
+                      ~remaining_turn_budget_s:(remaining_turn_budget_s ())
                       err
                   with
-                  | Some degraded_retry -> (
+                  | Degraded_retry_allowed degraded_retry -> (
                       match
                         build_cascade_execution
                           ~cascade_name:degraded_retry.next_cascade
@@ -1524,7 +1570,17 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                             ~overflow_retry_used
                             ~attempted_cascades:
                               (next_execution.cascade_name :: attempted_cascades))
-                  | None when EC.is_transient_network_error err
+                  | Degraded_retry_budget_exhausted degraded_retry ->
+                      Log.Keeper.warn
+                        "%s: recoverable cascade failure in %s suggested degraded retry to %s (reason=%s), but remaining turn budget %.1fs is below the OAS retry guard/minimum; ending this cycle: %s"
+                        meta.name execution.cascade_name
+                        degraded_retry.next_cascade
+                        degraded_retry.fallback_reason
+                        (remaining_turn_budget_s ())
+                        (short_preview (Oas.Error.to_string err));
+                      mark_terminal_error err;
+                      Error err
+                  | No_degraded_retry when EC.is_transient_network_error err
                               && attempt <= EC.max_transient_retries ->
                       let delay = EC.transient_backoff_sec attempt in
                       Log.Keeper.warn
@@ -1543,7 +1599,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                         ~attempt:(attempt + 1)
                         ~is_retry:true ~overflow_retry_used
                         ~attempted_cascades
-                  | None when EC.is_context_overflow err ->
+                  | No_degraded_retry when EC.is_context_overflow err ->
                   let current_turn_event_bus = drain_turn_event_bus () in
                   dispatch_keeper_phase_event
                     ~config
@@ -1618,12 +1674,12 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                     mark_paused_after_overflow
                       ~run_meta
                       ~reason:"overflow_persisted_after_auto_compact_retry";
-                    Keeper_registry.set_turn_phase
-                      ~base_path:config.base_path meta.name
-                      Keeper_registry.Turn_finalizing;
+                      Keeper_registry.set_turn_phase
+                        ~base_path:config.base_path meta.name
+                        Keeper_registry.Turn_finalizing;
                     Error err
                   end
-                | None ->
+                | No_degraded_retry ->
                     mark_terminal_error err;
                     Error err
           in

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -35,6 +35,58 @@ val bounded_oas_timeout_for_turn_budget_with_turn_budget :
   remaining_turn_budget_s:float ->
   float option
 
+(** Full timeout-budget resolution used by the unified turn loop.
+    Exposed for regression tests that need to distinguish "an OAS
+    call had a bounded budget" from "the turn had no retry budget
+    left before dispatch". *)
+type oas_timeout_budget_resolution = {
+  effective_timeout_sec : float;
+  adaptive_timeout_sec : float;
+  keeper_turn_timeout_sec : float;
+  remaining_turn_budget_sec : float;
+  estimated_input_tokens : int;
+  max_turns : int;
+  source : string;
+}
+
+val resolve_bounded_oas_timeout_budget_with_turn_budget :
+  estimated_input_tokens:int ->
+  max_turns:int ->
+  remaining_turn_budget_s:float ->
+  oas_timeout_budget_resolution option
+
+val oas_retry_budget_available_for_turn :
+  estimated_input_tokens:int ->
+  max_turns:int ->
+  remaining_turn_budget_s:float ->
+  bool
+
+(** Reclassify a structural OAS timeout only when the current attempt
+    actually dispatched with an OAS timeout budget. This prevents a
+    pre-retry turn-budget exhaustion from borrowing a stale previous
+    attempt budget and incorrectly rotating cascades. *)
+val reclassify_oas_timeout_for_attempt :
+  timeout_budget:oas_timeout_budget_resolution option ->
+  Oas.Error.sdk_error ->
+  Oas.Error.sdk_error
+
+type degraded_retry_budget_decision =
+  | No_degraded_retry
+  | Degraded_retry_budget_exhausted of Keeper_error_classify.degraded_retry
+  | Degraded_retry_allowed of Keeper_error_classify.degraded_retry
+
+val next_fail_open_cascade_for_turn_with_budget :
+  ?rotation_cascades:string list ->
+  base_cascade:string ->
+  effective_cascade:string ->
+  tool_requirement:string ->
+  attempted_cascades:string list ->
+  estimated_input_tokens:int ->
+  max_turns:int ->
+  remaining_turn_budget_s:float ->
+  Oas.Error.sdk_error ->
+  degraded_retry_budget_decision
+
 (** Turn-local overflow hint published by the OAS event bus before a
     proactive compaction attempt. Exposed for regression tests. *)
 type turn_event_bus_overflow = {

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4354,6 +4354,99 @@ let test_bounded_oas_timeout_refuses_too_little_budget () =
     (UT.bounded_oas_timeout_for_turn_budget
        ~estimated_input_tokens:2_000 ~remaining_turn_budget_s:20.0)
 
+let test_oas_timeout_reclassifies_only_current_attempt_budget () =
+  let err =
+    Agent_sdk.Error.Api
+      (Timeout { message = "Timeout after 273.0s (budget=273s)" })
+  in
+  match
+    UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+      ~estimated_input_tokens:2_000 ~max_turns:4
+      ~remaining_turn_budget_s:1200.0
+  with
+  | None -> fail "expected timeout budget"
+  | Some timeout_budget ->
+      let classified =
+        UT.reclassify_oas_timeout_for_attempt
+          ~timeout_budget:(Some timeout_budget)
+          err
+      in
+      (match
+         Masc_mcp.Oas_worker_named.classify_masc_internal_error classified
+       with
+       | Some (Masc_mcp.Oas_worker_named.Oas_timeout_budget budget) ->
+           check int "estimated tokens preserved" 2_000
+             budget.estimated_input_tokens;
+           check string "source preserved" timeout_budget.source budget.source
+       | _ -> fail "expected OAS timeout budget classification")
+
+let test_pre_retry_budget_exhaustion_not_reclassified_with_stale_budget () =
+  let err =
+    Agent_sdk.Error.Api
+      (Timeout
+         {
+           message =
+             "Turn wall-clock budget exhausted before retry (remaining=2.0s)";
+         })
+  in
+  let classified =
+    UT.reclassify_oas_timeout_for_attempt ~timeout_budget:None err
+  in
+  check bool "pre-dispatch exhaustion remains raw timeout" true
+    (Option.is_none
+       (Masc_mcp.Oas_worker_named.classify_masc_internal_error classified))
+
+let oas_timeout_budget_error () =
+  Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
+    (Masc_mcp.Oas_worker_named.Oas_timeout_budget
+       {
+         budget_sec = 273.0;
+         keeper_turn_timeout_sec = 1200.0;
+         estimated_input_tokens = 2_000;
+         source = "adaptive_estimated_input_tokens";
+       })
+
+let test_degraded_retry_budget_gate_allows_remaining_budget () =
+  match
+    UT.next_fail_open_cascade_for_turn_with_budget
+      ~base_cascade:"underdog"
+      ~effective_cascade:"underdog"
+      ~tool_requirement:"optional"
+      ~attempted_cascades:[ "underdog" ]
+      ~estimated_input_tokens:2_000
+      ~max_turns:4
+      ~remaining_turn_budget_s:1200.0
+      (oas_timeout_budget_error ())
+  with
+  | UT.Degraded_retry_allowed retry ->
+      check string "retry cascade" KC.local_recovery_cascade_name
+        retry.next_cascade;
+      check string "fallback reason" "oas_timeout_budget"
+        retry.fallback_reason
+  | UT.Degraded_retry_budget_exhausted _ ->
+      fail "expected retry budget to remain"
+  | UT.No_degraded_retry -> fail "expected degraded retry"
+
+let test_degraded_retry_budget_gate_blocks_exhausted_budget () =
+  match
+    UT.next_fail_open_cascade_for_turn_with_budget
+      ~base_cascade:"underdog"
+      ~effective_cascade:"underdog"
+      ~tool_requirement:"optional"
+      ~attempted_cascades:[ "underdog" ]
+      ~estimated_input_tokens:2_000
+      ~max_turns:4
+      ~remaining_turn_budget_s:20.0
+      (oas_timeout_budget_error ())
+  with
+  | UT.Degraded_retry_budget_exhausted retry ->
+      check string "retry cascade candidate" KC.local_recovery_cascade_name
+        retry.next_cascade;
+      check string "fallback reason" "oas_timeout_budget"
+        retry.fallback_reason
+  | UT.Degraded_retry_allowed _ -> fail "expected exhausted retry budget"
+  | UT.No_degraded_retry -> fail "expected recoverable retry candidate"
+
 let test_pure_local_labels_detection () =
   check bool "ollama-only cascade is pure local" true
     (OMR.labels_are_pure_local [ "ollama:qwen3.5:35b-a3b-nvfp4" ]);
@@ -6164,6 +6257,14 @@ let () =
             test_bounded_oas_timeout_uses_channel_turn_budget_override;
           test_case "bounded OAS timeout refuses too little remaining budget" `Quick
             test_bounded_oas_timeout_refuses_too_little_budget;
+          test_case "OAS timeout classification uses current attempt budget" `Quick
+            test_oas_timeout_reclassifies_only_current_attempt_budget;
+          test_case "pre-retry budget exhaustion does not reuse stale budget" `Quick
+            test_pre_retry_budget_exhaustion_not_reclassified_with_stale_budget;
+          test_case "degraded retry is allowed when turn budget remains" `Quick
+            test_degraded_retry_budget_gate_allows_remaining_budget;
+          test_case "degraded retry is blocked when turn budget is exhausted" `Quick
+            test_degraded_retry_budget_gate_blocks_exhausted_budget;
           test_case "pure local label detection" `Quick
             test_pure_local_labels_detection;
           test_case "pure local context clamp" `Quick


### PR DESCRIPTION
## Summary

Fixes the keeper-side retry loop that could keep reporting/rotating `oas_timeout_budget` after the turn budget was already exhausted.

- Reclassify structural OAS timeouts with the current attempt's OAS budget only, not the last successful budget resolution.
- Gate degraded cascade/model rotation on the current remaining turn budget before scheduling another same-turn attempt.
- Add regression coverage for stale budget reuse and exhausted-budget rotation blocking.

## Why it matters

The #9933 failure mode was not just "provider slow": once an OAS call consumed the ~1170s bounded budget, the retry path could borrow `last_timeout_budget` and schedule degraded rotation even though no safe OAS retry budget remained. That makes keepers look alive while they burn the whole cycle and records misleading repeated `oas_timeout_budget` blockers.

This keeps the deterministic boundary honest: if the current attempt had an OAS budget, classify that budget; if the next retry has no turn budget left, end the cycle and let the next keeper heartbeat resume instead of pretending provider/model rotation can still happen in the same turn.

## Verification

- `git diff --check`
- `scripts/check-boundary-guard.sh`
- `env DUNE_BUILD_DIR=_build_verify_9933_oas_budget DUNE_JOBS=2 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_unified.exe test/test_oas_error_kind_counter.exe test/test_keeper_long_turn_9943.exe test/test_prometheus_coverage.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-9933-unified _build_verify_9933_oas_budget/default/test/test_keeper_unified.exe`
  - 289 tests passed
- `env MASC_BASE_PATH=/tmp/masc-test-9933-oas-kind _build_verify_9933_oas_budget/default/test/test_oas_error_kind_counter.exe`
  - 11 tests passed
- `env MASC_BASE_PATH=/tmp/masc-test-9933-long-turn _build_verify_9933_oas_budget/default/test/test_keeper_long_turn_9943.exe`
  - 8 tests passed
- `env MASC_BASE_PATH=/tmp/masc-test-9933-prom _build_verify_9933_oas_budget/default/test/test_prometheus_coverage.exe`
  - 49 tests passed

Note: after a conflict-free rebase onto current `origin/main`, I started the same focused Dune build in `_build_verify_9933_oas_budget_rebased`; it waited behind another repo-local Dune lock and then ran without output for over 10 minutes, so I terminated that duplicate local recheck. PR CI should be treated as the fresh post-push verification surface.

Closes #9933 after merge.
