### PR TITLE
refactor(fs-compat): SSOT atomic-tmp constants + reuse mkdir_p_unix + single readdir (#10205)

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -174,9 +174,19 @@ let fsync_path path =
            is still durable to the extent the underlying FS offers. *)
         ())
 
+(* #10205: SSOT for the [.atomic_*.tmp] naming used by
+   [save_file_atomic] (writer) and [is_atomic_orphan_name]
+   (reader, via the boot-time sweep in [cleanup_atomic_orphans]).
+   Without these constants the writer at line ~180 and the
+   reader at line ~217 carried duplicate string literals that
+   had to agree by hand.  See instructions/software-development.md
+   anti-pattern #1 (hardcoded scatter). *)
+let atomic_tmp_prefix = ".atomic_"
+let atomic_tmp_suffix = ".tmp"
+
 let save_file_atomic (path : string) (content : string) : (unit, string) result =
   let dir = Filename.dirname path in
-  let tmp = Filename.temp_file ~temp_dir:dir ".atomic_" ".tmp" in
+  let tmp = Filename.temp_file ~temp_dir:dir atomic_tmp_prefix atomic_tmp_suffix in
   try
     save_file tmp content;
     fsync_path tmp;
@@ -211,13 +221,12 @@ let save_file_atomic (path : string) (content : string) : (unit, string) result 
    - [preserved]: number of non-zero orphans moved to the
      recovered directory. *)
 let is_atomic_orphan_name name =
-  let prefix = ".atomic_" and suffix = ".tmp" in
   let n = String.length name in
-  let p = String.length prefix in
-  let s = String.length suffix in
+  let p = String.length atomic_tmp_prefix in
+  let s = String.length atomic_tmp_suffix in
   n >= p + s
-  && String.sub name 0 p = prefix
-  && String.sub name (n - s) s = suffix
+  && String.sub name 0 p = atomic_tmp_prefix
+  && String.sub name (n - s) s = atomic_tmp_suffix
 
 let cleanup_atomic_orphans
     ~(base_path : string)
@@ -226,10 +235,15 @@ let cleanup_atomic_orphans
   let recovered_dir = Filename.concat base_path recovered_subdir in
   let deleted = ref 0 in
   let preserved = ref 0 in
+  (* #10205 finding 3: reuse the existing recursive-idempotent
+     [mkdir_p_unix] in the same module instead of an inline
+     [Sys.file_exists + Unix.mkdir] reinvention.  Behaviour is
+     identical for the leaf case here (recovered_dir lives
+     directly under base_path) but stays correct if a future
+     caller passes a deeper [recovered_subdir]. *)
   let ensure_recovered_dir () =
-    if not (Sys.file_exists recovered_dir) then
-      try Unix.mkdir recovered_dir 0o755
-      with Unix.Unix_error _ -> ()
+    try mkdir_p_unix recovered_dir
+    with Unix.Unix_error _ -> ()
   in
   let handle_file dir name =
     let path = Filename.concat dir name in
@@ -247,30 +261,38 @@ let cleanup_atomic_orphans
         (try Sys.rename path target; incr preserved
          with Sys_error _ | Unix.Unix_error _ -> ())
   in
-  let scan_dir dir =
-    match Sys.readdir dir with
-    | exception Sys_error _ -> ()
-    | entries ->
-        Array.iter
-          (fun name ->
-            if is_atomic_orphan_name name then handle_file dir name)
-          entries
+  let scan_orphans_in dir entries =
+    Array.iter
+      (fun name ->
+        if is_atomic_orphan_name name then handle_file dir name)
+      entries
   in
-  scan_dir base_path;
-  (match Sys.readdir base_path with
-   | exception Sys_error _ -> ()
-   | entries ->
-       Array.iter
-         (fun name ->
-           if name = recovered_subdir then ()
-           else
-             let sub = Filename.concat base_path name in
-             match Unix.stat sub with
-             | exception Unix.Unix_error _ -> ()
-             | stat when stat.Unix.st_kind = Unix.S_DIR -> scan_dir sub
-             | _ -> ())
-         entries);
-  (!deleted, !preserved)
+  let read_subdir name =
+    match Sys.readdir name with
+    | exception Sys_error _ -> [||]
+    | entries -> entries
+  in
+  (* #10205 finding 4: read [base_path] once and feed both the
+     orphan-scan pass and the subdirectory-recursion pass.
+     Pre-fix, [scan_dir base_path] called [Sys.readdir base_path]
+     and the recursion loop called it again — two enumerations
+     of the same directory on every boot. *)
+  match Sys.readdir base_path with
+  | exception Sys_error _ -> (!deleted, !preserved)
+  | base_entries ->
+      scan_orphans_in base_path base_entries;
+      Array.iter
+        (fun name ->
+          if name = recovered_subdir then ()
+          else
+            let sub = Filename.concat base_path name in
+            match Unix.stat sub with
+            | exception Unix.Unix_error _ -> ()
+            | stat when stat.Unix.st_kind = Unix.S_DIR ->
+                scan_orphans_in sub (read_subdir sub)
+            | _ -> ())
+        base_entries;
+      (!deleted, !preserved)
 
 (** Append string to file.
     Eio-native when available, fallback to Unix.


### PR DESCRIPTION
## Summary

Three of the five findings from #10205's post-hoc \`/simplify\` review of PRs #10127/#10131/#10135/#10187, all in \`lib/fs_compat/fs_compat.ml\`.

| finding | scope | status |
|---|---|---|
| 1 — auth predicate sprawl | \`lib/auth.ml\` | **NOT in this PR** — PR #10188 (MERGED) landed a stricter superset using \`Tool_catalog.is_on_surface Tool_catalog.Keeper_internal\` + \`is_unmapped_internal_tool_name\` + per-call denial counter |
| 2 — \`.atomic_*.tmp\` literal scatter | \`fs_compat.ml\` | **this PR** |
| 3 — \`ensure_recovered_dir\` reinvents \`mkdir_p\` | \`fs_compat.ml\` | **this PR** |
| 4 — double \`readdir\` of \`base_path\` | \`fs_compat.ml\` | **this PR** |
| 5 — move sweep to background fiber | architectural | **deferred** — boot critical-path behaviour change, deserves explicit ordering review in its own PR |

## Finding 2: literal scatter

Writer (line ~180) and reader (line ~217) carried duplicate \`.atomic_\` + \`.tmp\` string literals.  Accidental rename on either side would silently break the orphan sweep.

\`\`\`ocaml
let atomic_tmp_prefix = ".atomic_"
let atomic_tmp_suffix = ".tmp"
\`\`\`

Both [save_file_atomic] (writer) and [is_atomic_orphan_name] (reader) now reference these constants.

## Finding 3: \`mkdir_p_unix\` reuse

The orphan sweep's \`ensure_recovered_dir\` had its own \`if not file_exists then Unix.mkdir\` helper.  \`mkdir_p_unix\` already exists in the same module (recursive, idempotent, EEXIST-tolerant) — use it.

Behaviour identical for the leaf case (\`recovered_dir\` directly under \`base_path\`) but stays correct if a future caller passes a deeper \`recovered_subdir\`.

## Finding 4: single readdir

Pre-fix, [cleanup_atomic_orphans] called \`Sys.readdir base_path\` twice on every boot — once via \`scan_dir base_path\` and once in the recursion loop.  Read once into \`base_entries\`, run both passes over the cached array.  Subdirectories still call \`readdir\` once each (one read per directory, not one per pass).

## Test plan

- [x] \`dune build --root . lib/\` clean
- [x] \`dune exec test/test_fs_atomic_orphan_sweep_10130.exe\` — 8/8 pass.  Refactoring preserves behaviour: name matcher, zero-byte deletion, non-zero preservation, subdir scan, non-orphan untouched, idempotent, mixed batch, \`.recovered/\` skip-on-rescan.

## Why finding 5 is deferred

Moving the sweep to a background fiber is a real change to boot ordering — \`Bootstrap completed in Xs\` would log earlier but operators won't see the sweep counter on first \`/metrics\` scrape until the fiber finishes.  Worth its own PR with rollback runbook and ordering review.

## Why finding 1 is skipped

PR #10188 \`fix(auth): allow keeper runtime tools in strict mode\` already landed a strictly better fix:

- Catalog-driven (\`Tool_catalog.is_on_surface Tool_catalog.Keeper_internal\`) — keeper_* prefix alone no longer crosses the gate, only catalog-owned ones do
- Unified predicate \`is_unmapped_internal_tool_name\`
- New \`masc_auth_strict_unknown_tool_denials_total\` counter for explicit denials

The data-driven prefix list suggested in #10205 would be a regression compared to that.

## Refs

- #10131 (orphan sweep landing PR)
- #10205 (post-merge review)
- #10188 (independent auth fix that supersedes #10205 finding 1)

## Do-not-merge

\`do-not-merge\` label set so the auto-merge pipeline does not flip this Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)