### PR TITLE
fix(mcp-config): default MASC_AUTO_CONSTRUCT_CLAUDE_MCP to true

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1905,10 +1905,10 @@ let run_turn
         | None ->
             (* #10049 Option C: auto-construct from the keeper bearer
                token + server host/port when env is unset. Gated
-               behind MASC_AUTO_CONSTRUCT_CLAUDE_MCP (default true) so
-               the existing explicit-env path stays unchanged until
-               operators opt in. Returns [None] when the flag is off
-               or the token file is missing — the Log.Keeper.warn
+               behind MASC_AUTO_CONSTRUCT_CLAUDE_MCP (default true). The
+               existing explicit-env path still wins, and operators can opt
+               out by setting the flag false. Returns [None] when the flag
+               is off or the token file is missing — the Log.Keeper.warn
                above (iter 10052) still fires for visibility. *)
             Keeper_cli_mcp_config.try_construct_for_keeper
               ~base_path:config.base_path

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1905,7 +1905,7 @@ let run_turn
         | None ->
             (* #10049 Option C: auto-construct from the keeper bearer
                token + server host/port when env is unset. Gated
-               behind MASC_AUTO_CONSTRUCT_CLAUDE_MCP (default false) so
+               behind MASC_AUTO_CONSTRUCT_CLAUDE_MCP (default true) so
                the existing explicit-env path stays unchanged until
                operators opt in. Returns [None] when the flag is off
                or the token file is missing — the Log.Keeper.warn

--- a/lib/keeper/keeper_cli_mcp_config.ml
+++ b/lib/keeper/keeper_cli_mcp_config.ml
@@ -8,13 +8,19 @@
    registry". See #10049 for the full root-cause analysis and the
    codex_cli sibling path in [server_runtime_bootstrap.sync_codex_mcp_config].
 
-   Gated behind [MASC_AUTO_CONSTRUCT_CLAUDE_MCP] (default false) so the
-   existing explicit-env path stays unchanged until operators opt in. *)
+   Gated behind [MASC_AUTO_CONSTRUCT_CLAUDE_MCP] (default true since
+   #10059 validation; the legacy explicit-env path still wins when
+   [OAS_CLAUDE_MCP_CONFIG] is set, and operators can opt out with
+   [MASC_AUTO_CONSTRUCT_CLAUDE_MCP=false]). *)
 
 let feature_flag_env = "MASC_AUTO_CONSTRUCT_CLAUDE_MCP"
 
+(* Default true: PR #10059 validated the auto-construct path under flag-gated
+   rollout; running without it leaves CLI keeper subprocesses with empty
+   mcpServers, which breaks every keeper_* tool call. Operators can still
+   opt out with [MASC_AUTO_CONSTRUCT_CLAUDE_MCP=false]. *)
 let feature_enabled () =
-  Env_config_core.get_bool ~default:false feature_flag_env
+  Env_config_core.get_bool ~default:true feature_flag_env
 
 let build_json ~url ~bearer_token =
   let json =

--- a/lib/keeper/keeper_cli_mcp_config.mli
+++ b/lib/keeper/keeper_cli_mcp_config.mli
@@ -1,6 +1,7 @@
 (* #10049: auto-construct Claude Code / Kimi CLI MCP config JSON when
    OAS_CLAUDE_MCP_CONFIG env is unset. Gated behind
-   MASC_AUTO_CONSTRUCT_CLAUDE_MCP (default false). *)
+   MASC_AUTO_CONSTRUCT_CLAUDE_MCP (default true since #10059 validation;
+   set to "false" to opt out). *)
 
 val feature_flag_env : string
 

--- a/test/test_keeper_cli_mcp_config.ml
+++ b/test/test_keeper_cli_mcp_config.ml
@@ -23,11 +23,21 @@ let test_feature_flag_env_name () =
     "MASC_AUTO_CONSTRUCT_CLAUDE_MCP" K.feature_flag_env
 
 let test_try_construct_disabled_by_default () =
-  (* No env set, no token file: should return None regardless. *)
+  (* Flag default flipped to true (#10059 validation): explicit "false"
+     disables auto-construct and returns None even when token file would
+     have been resolvable. *)
+  Unix.putenv K.feature_flag_env "false";
+  let base = Filename.get_temp_dir_name () in
+  let out = K.try_construct_for_keeper ~base_path:base ~agent_name:"nobody" in
+  check (option string) "explicit-false flag returns None" None out
+
+let test_try_construct_default_true_no_token () =
+  (* Flag default true: still returns None when no token file exists for
+     the keeper, so auto-construct fails closed without a credential. *)
   Unix.putenv K.feature_flag_env "";
   let base = Filename.get_temp_dir_name () in
   let out = K.try_construct_for_keeper ~base_path:base ~agent_name:"nobody" in
-  check (option string) "disabled flag returns None" None out
+  check (option string) "missing token returns None" None out
 
 let () =
   run "keeper_cli_mcp_config" [
@@ -37,6 +47,8 @@ let () =
     ];
     "flag", [
       test_case "env key stable" `Quick test_feature_flag_env_name;
-      test_case "disabled → None" `Quick test_try_construct_disabled_by_default;
+      test_case "explicit false → None" `Quick test_try_construct_disabled_by_default;
+      test_case "default true + no token → None" `Quick
+        test_try_construct_default_true_no_token;
     ]
   ]


### PR DESCRIPTION
## Context (Leak 5 — Swiss Cheese Pipeline)

`/tmp/leak5-evidence.md` 검증 결과: `MASC_AUTO_CONSTRUCT_CLAUDE_MCP` default=false 시 keeper subprocess가 빈 mcpServers로 launch → keeper_* tool 전부 invisible → autonomous flow 차단. 운영에서는 항상 명시적 true 설정 필요.

PR #10059이 auto-construct path를 flag-gated rollout으로 검증 완료. default를 true로 flip해 base 동작이 안전한 형태가 되도록 만든다. opt-out path(env=false)는 보존.

## Why

- 베이스라인 8h keeper 침묵 사고 직후 추적된 5 leak 중 가장 단순한 1-line.
- masc-improver 로그가 보여주는 SUCCESS path(via=docker keeper_bash)는 OAS_CLAUDE_MCP_CONFIG 또는 auto-construct 둘 중 하나가 정상 작동했을 때 가능. 운영 절차 의존을 코드 default로 끌어내림.

## Changes

- \`lib/keeper/keeper_cli_mcp_config.ml\`: \`feature_enabled\` default \`false\` → \`true\`. 주석 일치화.
- \`lib/keeper/keeper_cli_mcp_config.mli\`: 주석 default 표기.
- \`lib/keeper/keeper_agent_run.ml:1908\`: 주석 default 표기.
- \`test/test_keeper_cli_mcp_config.ml\`: \"explicit-false → None\" + \"default-true + no-token → None\" 두 케이스로 분리.

## Test

\`\`\`
$ dune build @check --root .
$ dune test test/test_keeper_cli_mcp_config.exe --root .
[OK]   build_json   shape includes url/type/Authorization
[OK]   flag         env key stable
[OK]   flag         explicit false → None
[OK]   flag         default true + no token → None
\`\`\`

## Risks & Out-of-scope

- Breaking change 없음. \`OAS_CLAUDE_MCP_CONFIG\` 명시 set 시 그 값 우선.
- Opt-out 보존 (\`MASC_AUTO_CONSTRUCT_CLAUDE_MCP=false\`).
- Identity drift(Leak 2)는 PR-F에서 다룸. governance allowlist(Leak 1+3)는 PR-E에서 다룸.

Refs #10049, #10059.

🤖 Generated with [Claude Code](https://claude.com/claude-code)