### PR TITLE
[#10205] refactor(fs_compat): SSOT atomic-tmp + mkdir_p reuse + single readdir

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -174,9 +174,20 @@ let fsync_path path =
            is still durable to the extent the underlying FS offers. *)
         ())
 
+(* #10205 finding 2: keep the atomic-tmp filename shape in one place
+   so the writer ([save_file_atomic]) and the orphan-sweep matcher
+   ([is_atomic_orphan_name]) cannot drift independently.  A
+   prefix/suffix change on one side without the other would cause
+   the sweep to either miss live orphans or scoop unrelated tmp
+   files. *)
+let atomic_tmp_prefix = ".atomic_"
+let atomic_tmp_suffix = ".tmp"
+
 let save_file_atomic (path : string) (content : string) : (unit, string) result =
   let dir = Filename.dirname path in
-  let tmp = Filename.temp_file ~temp_dir:dir ".atomic_" ".tmp" in
+  let tmp =
+    Filename.temp_file ~temp_dir:dir atomic_tmp_prefix atomic_tmp_suffix
+  in
   try
     save_file tmp content;
     fsync_path tmp;
@@ -211,13 +222,12 @@ let save_file_atomic (path : string) (content : string) : (unit, string) result 
    - [preserved]: number of non-zero orphans moved to the
      recovered directory. *)
 let is_atomic_orphan_name name =
-  let prefix = ".atomic_" and suffix = ".tmp" in
   let n = String.length name in
-  let p = String.length prefix in
-  let s = String.length suffix in
+  let p = String.length atomic_tmp_prefix in
+  let s = String.length atomic_tmp_suffix in
   n >= p + s
-  && String.sub name 0 p = prefix
-  && String.sub name (n - s) s = suffix
+  && String.sub name 0 p = atomic_tmp_prefix
+  && String.sub name (n - s) s = atomic_tmp_suffix
 
 let cleanup_atomic_orphans
     ~(base_path : string)
@@ -226,10 +236,14 @@ let cleanup_atomic_orphans
   let recovered_dir = Filename.concat base_path recovered_subdir in
   let deleted = ref 0 in
   let preserved = ref 0 in
+  (* #10205 finding 3: previous body reinvented [mkdir_p] inline with
+     [Sys.file_exists]+[Unix.mkdir]+[Unix.Unix_error _] swallowing.  The
+     same module already exposes [mkdir_p_unix], which is recursive,
+     idempotent (handles [EEXIST] precisely instead of swallowing every
+     [Unix_error]), and correct when [base_path] itself does not exist
+     yet (boot-time race). *)
   let ensure_recovered_dir () =
-    if not (Sys.file_exists recovered_dir) then
-      try Unix.mkdir recovered_dir 0o755
-      with Unix.Unix_error _ -> ()
+    try mkdir_p_unix recovered_dir with Unix.Unix_error _ -> ()
   in
   let handle_file dir name =
     let path = Filename.concat dir name in
@@ -247,29 +261,34 @@ let cleanup_atomic_orphans
         (try Sys.rename path target; incr preserved
          with Sys_error _ | Unix.Unix_error _ -> ())
   in
-  let scan_dir dir =
-    match Sys.readdir dir with
-    | exception Sys_error _ -> ()
-    | entries ->
-        Array.iter
-          (fun name ->
-            if is_atomic_orphan_name name then handle_file dir name)
-          entries
+  let scan_dir dir entries =
+    Array.iter
+      (fun name ->
+        if is_atomic_orphan_name name then handle_file dir name)
+      entries
   in
-  scan_dir base_path;
-  (match Sys.readdir base_path with
-   | exception Sys_error _ -> ()
-   | entries ->
-       Array.iter
-         (fun name ->
-           if name = recovered_subdir then ()
-           else
-             let sub = Filename.concat base_path name in
-             match Unix.stat sub with
-             | exception Unix.Unix_error _ -> ()
-             | stat when stat.Unix.st_kind = Unix.S_DIR -> scan_dir sub
-             | _ -> ())
-         entries);
+  let read_dir_entries dir =
+    match Sys.readdir dir with
+    | exception Sys_error _ -> [||]
+    | entries -> entries
+  in
+  (* #10205 finding 4: previous body called [Sys.readdir base_path]
+     twice — once via [scan_dir] for orphan-find, once for the
+     subdirectory recursion pass.  Read once, run both passes against
+     the cached entry array. *)
+  let entries = read_dir_entries base_path in
+  scan_dir base_path entries;
+  Array.iter
+    (fun name ->
+      if name = recovered_subdir then ()
+      else
+        let sub = Filename.concat base_path name in
+        match Unix.stat sub with
+        | exception Unix.Unix_error _ -> ()
+        | stat when stat.Unix.st_kind = Unix.S_DIR ->
+            scan_dir sub (read_dir_entries sub)
+        | _ -> ())
+    entries;
   (!deleted, !preserved)
 
 (** Append string to file.


### PR DESCRIPTION
## 요약

#10205 `/simplify` findings #2, #3, #4 — 모두 `lib/fs_compat/fs_compat.ml` 내 surgical refactor. behaviour 변경 없음.

Closes part of #10205 (#1 auth predicate sprawl, #5 boot-path sweep deferral은 별도 PR).

## 변경 내용

### Finding #2 — `.atomic_*.tmp` literal scatter → SSOT 상수

writer (`save_file_atomic`)와 sweep matcher (`is_atomic_orphan_name`)가 같은 prefix/suffix를 따로 들고 있었음. 한쪽 변경이 silent하게 sweep을 깨뜨릴 수 있는 drift class.

```diff
+let atomic_tmp_prefix = ".atomic_"
+let atomic_tmp_suffix = ".tmp"
+
 let save_file_atomic ...
-  let tmp = Filename.temp_file ~temp_dir:dir ".atomic_" ".tmp" in
+  let tmp = Filename.temp_file ~temp_dir:dir atomic_tmp_prefix atomic_tmp_suffix in

 let is_atomic_orphan_name name =
-  let prefix = ".atomic_" and suffix = ".tmp" in
-  ... String.sub ... = prefix && ... = suffix
+  ... String.sub ... = atomic_tmp_prefix && ... = atomic_tmp_suffix
```

### Finding #3 — `ensure_recovered_dir` reinvented `mkdir_p`

`Sys.file_exists` + `Unix.mkdir 0o755` + `Unix_error _` 광범위 swallow → 같은 모듈의 `mkdir_p_unix` (recursive, idempotent, EEXIST-precise) 재사용.

```diff
 let ensure_recovered_dir () =
-  if not (Sys.file_exists recovered_dir) then
-    try Unix.mkdir recovered_dir 0o755
-    with Unix.Unix_error _ -> ()
+  try mkdir_p_unix recovered_dir with Unix.Unix_error _ -> ()
```

부수 효과: `base_path` 자체가 없는 boot 시점 race에서도 안전 (mkdir_p가 부모 ensure).

### Finding #4 — `Sys.readdir base_path` 두 번 → 한 번

기존: `scan_dir base_path`(readdir #1) → `Sys.readdir base_path`(readdir #2 for subdir 재귀). 같은 디렉토리 두 번 enumerate.

```diff
+let read_dir_entries dir =
+  match Sys.readdir dir with
+  | exception Sys_error _ -> [||]
+  | entries -> entries
+
+let entries = read_dir_entries base_path in
-scan_dir base_path;
+scan_dir base_path entries;
-(match Sys.readdir base_path with
- | exception Sys_error _ -> ()
- | entries -> Array.iter ... entries)
+Array.iter ... entries
```

`scan_dir`는 이제 entry array를 인자로 받음 — readdir 책임이 호출자로 lift.

## 회귀 리스크

- **Finding #2**: pure constant extraction, 동일 string. 컴파일 오류 외에 동작 차이 없음.
- **Finding #3**: `mkdir_p_unix`는 `Unix.mkdir`보다 더 robust (recursive, EEXIST 정확 처리). 기존 swallow 분기는 동일하게 유지. 동작 차이 없음.
- **Finding #4**: 같은 entries array를 두 pass에 사용. 첫 pass와 둘째 pass 사이에 디렉토리가 바뀔 가능성? 부정 — boot-time sweep은 단일 fiber 내, 같은 array 재사용은 idempotent.

## 테스트

```bash
$ dune exec test/test_fs_atomic_orphan_sweep_10130.exe
[OK]  name-matcher          0   strict prefix+suffix match.
[OK]  sweep-behavior        0   zero-byte at base: deleted.
[OK]  sweep-behavior        1   non-zero: preserved in .recovered/.
[OK]  sweep-behavior        2   orphans in subdirs found.
[OK]  sweep-behavior        3   non-orphan files untouched.
[OK]  sweep-behavior        4   idempotent: second call is noop.
[OK]  sweep-behavior        5   mixed batch (prod-shaped).
[OK]  sweep-behavior        6   .recovered/ skipped on rescan.
Test Successful in 0.024s. 8 tests run.

$ dune exec test/test_fs_compat.exe
[OK]  mkdir_p             0   creates nested dirs.
[OK]  mkdir_p             1   no shell injection.
[OK]  save_file_atomic    0   leaves no .atomic_ tmp on success.
[OK]  save_file_atomic    1   overwrites existing target.
Test Successful in 0.084s. 4 tests run.
```

12/12 pass — 기존 contract 그대로.

## 후속 (별건 PR)

- **Finding #1** — `auth.ml:773-787` 3 sibling prefix predicates → `internal_tool_prefixes` list. .ml + .mli + caller migration.
- **Finding #5** — orphan sweep on boot critical path → background fiber.

## 참고

- Issue #10205 (post-merge /simplify findings)
- `lib/fs_compat/fs_compat.ml:177-220` — atomic-tmp constants + matcher
- `lib/fs_compat/fs_compat.ml:222-280` — single-readdir cleanup loop
- `test/test_fs_atomic_orphan_sweep_10130.ml` — 8/8 unchanged
- `test/test_fs_compat.ml` — 4/4 unchanged
