### PR TITLE
perf(sse): iterate broadcast_impl client snapshot in place

### DIFF
--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -613,12 +613,14 @@ let broadcast_impl target json =
   let current_event_id = next_id () in
   let event = format_event ~id:current_event_id ~event_type:"message" data in
   buffer_event current_event_id event;
-  (* Snapshot under read-lock *)
-  let clients_snapshot =
-    SMap.fold (fun k v acc -> (k, v) :: acc) (Atomic.get clients).entries []
-  in
+  (* The [SMap.t] returned by [Atomic.get] is immutable
+     (Lockfree_atomic.update_with_commit replaces it wholesale on
+     subscribe/unsubscribe), so we iterate it directly with [SMap.iter].
+     Skipping the [(k, v) :: acc] fold trims one tuple + cons cell per
+     client per broadcast on this hot fan-out path. *)
+  let clients_entries = (Atomic.get clients).entries in
   let failed = ref [] in
-  List.iter (fun (session_id, client) ->
+  SMap.iter (fun session_id client ->
     if client_matches_target target client
        && current_event_id > Atomic.get client.last_event_id then begin
       (* Pre-check stream capacity to avoid blocking broadcast.
@@ -644,7 +646,7 @@ let broadcast_impl target json =
                session_id (Printexc.to_string e);
              failed := session_id :: !failed)
     end
-  ) clients_snapshot;
+  ) clients_entries;
   (* Remove failed connections *)
   List.iter (fun sid -> unregister sid) !failed;
   (* Record broadcast duration for transport observability *)


### PR DESCRIPTION
#10203의 자매 PR. 같은 패턴을 broadcast_impl(주 fan-out 경로)에 적용.

## 변경
`broadcast_impl`에서 `SMap.fold + (k,v)::acc + List.iter` → `SMap.iter` 직접. `Atomic.get`이 immutable SMap을 돌려주므로 list 변환 불필요. Tuple + cons cell per-client 절감.

## 효과
broadcast_impl은 모든 연결된 SSE/WS 클라이언트를 fanout (dashboard observer 다수 attach 시 수백 가능). #10203(external subs ~30-50)보다 핫. 같은 broadcast가 양쪽 모두 호출하므로 burst 시 양쪽 절감 누적.

## Behavior
- iteration order = SMap key(session_id) 정렬. 기존 fold reverse 순서에 의존하던 consumer 없음.
- `failed` ref 변형은 `SMap.iter` 안에서 안전 (yield 없음).
- TLA+ `SSEBroadcastBlock` 불변 (single-domain, no yield) 유지.
- `Eio.Cancel.Cancelled` re-raise 그대로.
- failed list post-iter `List.iter unregister` 그대로.

## Validation
- `test_sse` 4/4
- `test_transport_integration` 9/9 (grpc_subscribe_sse 3, ws_sse 2, auto_cleanup 2 — 모두 broadcast_impl 경로 exercise)