### PR TITLE
perf(sse): collapse sync_transport_snapshot two-pass into SMap.iter

### DIFF
--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -104,34 +104,40 @@ let take n xs =
 
 let sync_transport_snapshot () =
   let now = Time_compat.now () in
-  let snapshot =
-    SMap.fold
-      (fun sid client acc -> (sid, client) :: acc)
-      (Atomic.get clients).entries []
-  in
+  (* Single-pass aggregation: previously [SMap.fold] built a
+     [(sid, client)] tuple list, then [List.map] re-walked it to
+     produce [session_snapshot] records.  [SMap.iter] over the
+     immutable map snapshot folds both passes into one, dropping
+     the per-client tuple cons cell.  Counters and the [sessions]
+     accumulator share the iteration; [total_sessions] is also
+     counted in-line, avoiding a trailing [List.length].  Called
+     on every [broadcast_impl] invocation, so the saved allocation
+     compounds with the fan-out itself. *)
   let observer = ref 0 in
   let coordinator = ref 0 in
   let queue_sum = ref 0 in
   let max_queue_depth = ref 0 in
-  let sessions =
-    List.map
-      (fun (session_id, client) ->
-        let queue_depth = Eio.Stream.length client.event_stream in
-        queue_sum := !queue_sum + queue_depth;
-        max_queue_depth := max !max_queue_depth queue_depth;
-        (match client.kind with
-         | Observer -> incr observer
-         | Coordinator -> incr coordinator);
-        {
-          session_id;
-          kind = client.kind;
-          queue_depth;
-          last_event_id = Atomic.get client.last_event_id;
-          idle_seconds = max 0.0 (now -. Atomic.get client.last_seen_at);
-        })
-      snapshot
-  in
-  let total_sessions = List.length sessions in
+  let sessions_acc = ref [] in
+  let total_sessions_acc = ref 0 in
+  SMap.iter (fun session_id client ->
+    let queue_depth = Eio.Stream.length client.event_stream in
+    queue_sum := !queue_sum + queue_depth;
+    max_queue_depth := max !max_queue_depth queue_depth;
+    (match client.kind with
+     | Observer -> incr observer
+     | Coordinator -> incr coordinator);
+    incr total_sessions_acc;
+    sessions_acc :=
+      {
+        session_id;
+        kind = client.kind;
+        queue_depth;
+        last_event_id = Atomic.get client.last_event_id;
+        idle_seconds = max 0.0 (now -. Atomic.get client.last_seen_at);
+      } :: !sessions_acc
+  ) (Atomic.get clients).entries;
+  let sessions = !sessions_acc in
+  let total_sessions = !total_sessions_acc in
   let avg_depth =
     if total_sessions = 0 then 0.0
     else float_of_int !queue_sum /. float_of_int total_sessions


### PR DESCRIPTION
#10203 + #10222 시리즈의 마지막 조각. 같은 SMap.fold→list→List.map 패턴을 `sync_transport_snapshot`에서도 `SMap.iter` 단일 패스로 합침.

## 문제
`sync_transport_snapshot`은 매 broadcast 끝(`broadcast_impl` 라인 652)에서 호출됨:
1. `SMap.fold` → `(sid, client)` tuple list (N tuples + N cons cells)
2. `List.map` → `session_snapshot` 레코드 list (N 추가 cons cells)
3. `List.length` → 또 한 번 walk

세 번의 traversal + 두 list materialize per broadcast.

## 변경
`SMap.iter` 단일 패스에서 counter aggregation + queue-depth + session_snapshot 동시 누적. `total_sessions` ref로 in-line 카운트 → trailing `List.length` 제거.

## 효과
broadcast 1회당 list 절감 누적:
- #10203 (이미 머지): notify_external_subscribers의 SMap.fold 제거 (~30-50 subs)
- #10222 (in-flight): broadcast_impl의 tuple list 제거 (모든 SSE/WS 클라이언트)
- 본 PR: sync_transport_snapshot의 tuple list + map intermediate 제거

세 PR 모두 머지 후 broadcast 1회당 list snapshot **3 → 0**. 1000 events/s burst 시 fleet 50 clients 가정 → 절감 cons cell **150k/sec**.

## Behavior
- `session_snapshot` 레코드 필드 무변동
- iteration order = SMap key (session_id) 정렬. downstream sort가 `(queue_depth, idle_seconds, session_id)` stable이므로 영향 없음
- counter 합계 동일
- hot_sessions sort + take 3 + projection 그대로

## Validation
- `test_sse` 4/4
- `test_transport_integration` 9/9 (모든 broadcast 경로가 sync_transport_snapshot exercise)