### PR TITLE
[#10205] refactor(auth): SSOT internal_tool_prefixes list

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -712,19 +712,31 @@ let permission_for_tool tool_name =
 let is_tool_auth_strict_enabled () =
   Env_config_core.tool_auth_strict ()
 
-let is_masc_tool_name tool_name =
-  String.starts_with ~prefix:"masc_" tool_name
+(* #10205 finding 1: SSOT for the internal-tool prefix vocabulary.
+   Adding a new internal namespace (e.g. [foo.]) was previously a
+   two-predicate edit ([is_masc_tool_name] +
+   [is_protocol_canonical_tool_name]) glued by a [||] chain at the
+   call site.  Keep the prefixes in one list so the next addition
+   is a single edit; predicate identity does not matter to callers,
+   which only consume {!is_unmapped_internal_tool_name}.
 
-let is_protocol_canonical_tool_name tool_name =
-  String.starts_with ~prefix:"decision." tool_name
-  || String.starts_with ~prefix:"experiment." tool_name
-  || String.starts_with ~prefix:"client." tool_name
+   Keeper runtime tools are NOT a prefix: a [keeper_*] prefix
+   alone is not enough to cross auth — the catalog must own the
+   tool.  That check stays separate. *)
+let internal_tool_prefixes = [
+  "masc_";
+  "decision.";
+  "experiment.";
+  "client.";
+]
 
-(* Keeper runtime tools are internal only when the catalog owns
-   them; a [keeper_*] prefix alone is not enough to cross auth. *)
+let has_internal_tool_prefix tool_name =
+  List.exists
+    (fun pref -> String.starts_with ~prefix:pref tool_name)
+    internal_tool_prefixes
+
 let is_unmapped_internal_tool_name tool_name =
-  is_masc_tool_name tool_name
-  || is_protocol_canonical_tool_name tool_name
+  has_internal_tool_prefix tool_name
   || Tool_catalog.is_on_surface Tool_catalog.Keeper_internal tool_name
 
 let unknown_tool_class tool_name =

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -748,6 +748,16 @@ let test_authorize_unknown_non_masc_tool_strict_denied () =
   | Error e -> fail (Printf.sprintf "wrong error: %s" (Types.masc_error_to_string e))
 
 let test_authorize_unknown_canonical_tool_strict_worker_allowed () =
+  (* #10205 finding 1: lock the [internal_tool_prefixes] vocabulary
+     (masc_, decision., experiment., client.) so a future refactor
+     that drops one silently is caught here.  Each prefix's
+     unmapped tool must pass strict-mode check for a Worker. *)
+  let prefixes_with_unlisted_tool = [
+    "masc_unlisted_tool";
+    "decision.unlisted_tool";
+    "experiment.unlisted_tool";
+    "client.unlisted_tool";
+  ] in
   let dir = setup_test_room () in
   let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
   let create_result = Auth.create_token dir ~agent_name:"worker_agent" ~role:Types.Worker in
@@ -755,8 +765,15 @@ let test_authorize_unknown_canonical_tool_strict_worker_allowed () =
     match create_result with
     | Ok (raw_token, _) ->
         with_env "MASC_TOOL_AUTH_STRICT" "1" (fun () ->
-            Auth.authorize_tool dir ~agent_name:"worker_agent" ~token:(Some raw_token)
-              ~tool_name:"decision.unlisted_tool")
+            List.fold_left
+              (fun acc tool_name ->
+                 match acc with
+                 | Error _ as e -> e
+                 | Ok () ->
+                     Auth.authorize_tool dir ~agent_name:"worker_agent"
+                       ~token:(Some raw_token) ~tool_name)
+              (Ok ())
+              prefixes_with_unlisted_tool)
     | Error e -> Error e
   in
   cleanup_test_room dir;


### PR DESCRIPTION
## 요약

#10205 `/simplify` finding #1 — `lib/auth.ml`의 internal-tool prefix vocabulary을 두 predicate (`is_masc_tool_name`, `is_protocol_canonical_tool_name`)에서 단일 SSOT list (`internal_tool_prefixes`)로 통합. 새 namespace 추가는 1줄 list edit으로 단축.

Closes #10205 finding 1 (#2-4는 #10220 이미 PR).

## 변경 내용

### 기존 (drift class)

```ocaml
let is_masc_tool_name tool_name =
  String.starts_with ~prefix:"masc_" tool_name

let is_protocol_canonical_tool_name tool_name =
  String.starts_with ~prefix:"decision." tool_name
  || String.starts_with ~prefix:"experiment." tool_name
  || String.starts_with ~prefix:"client." tool_name

let is_unmapped_internal_tool_name tool_name =
  is_masc_tool_name tool_name
  || is_protocol_canonical_tool_name tool_name
  || Tool_catalog.is_on_surface Tool_catalog.Keeper_internal tool_name
```

### 변경 후

```ocaml
let internal_tool_prefixes = [
  "masc_";
  "decision.";
  "experiment.";
  "client.";
]

let has_internal_tool_prefix tool_name =
  List.exists
    (fun pref -> String.starts_with ~prefix:pref tool_name)
    internal_tool_prefixes

let is_unmapped_internal_tool_name tool_name =
  has_internal_tool_prefix tool_name
  || Tool_catalog.is_on_surface Tool_catalog.Keeper_internal tool_name
```

`is_masc_tool_name`/`is_protocol_canonical_tool_name`은 호출자가 `auth.ml` 내부에만 있어 안전하게 제거. `Tool_catalog.is_on_surface Keeper_internal` 체크는 prefix가 아닌 catalog membership 검사라 prefix list와 분리 유지.

## 회귀 가드 강화

기존 `test_authorize_unknown_canonical_tool_strict_worker_allowed`는 `decision.unlisted_tool` 1개만 검사. 이제 4개 prefix 모두를 fold:

```diff
+  let prefixes_with_unlisted_tool = [
+    "masc_unlisted_tool";
+    "decision.unlisted_tool";
+    "experiment.unlisted_tool";
+    "client.unlisted_tool";
+  ] in
   ...
+  List.fold_left
+    (fun acc tool_name -> ...
+       Auth.authorize_tool ... ~tool_name)
+    (Ok ())
+    prefixes_with_unlisted_tool
```

미래에 `internal_tool_prefixes`에서 prefix를 빼면 해당 prefix의 `*_unlisted_tool` 호출이 strict-mode에서 거부 → 테스트 실패. SSOT lock.

## 테스트

```bash
$ dune exec test/test_auth.exe       → 41/41 pass
$ dune exec test/test_auth_coverage.exe → 100/100 pass
```

## 회귀 리스크

낮음. 동작 차이 없음:
- `is_unmapped_internal_tool_name`의 진리값이 모든 입력에 대해 동일 (4 prefix + 1 catalog 검사 동일).
- 두 predicate 제거는 caller가 auth.ml 내부에만 있었으므로 외부 영향 없음.
- mli 변경 없음.

## 후속 (남은 #10205 findings)

- **Finding #5** — orphan sweep on boot critical path → background fiber. (별도 PR)
- 이 PR로 #10205의 코드 leveled refactoring 4개 중 4개 완료 (#2-#4 #10220, #1 본 PR).

## 참고

- Issue #10205 (post-merge /simplify findings)
- `lib/auth.ml:715-740` — SSOT prefix list + helpers
- `test/test_auth.ml:750-781` — 4-prefix vocabulary lock
