### PR TITLE
perf(sse): build format_event with Buffer instead of three sprintfs

### DIFF
--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -244,12 +244,30 @@ let format_event ?id ?event_type data =
         (* Atomic fetch_and_add: returns old value, we want new value so +1 *)
         Atomic.fetch_and_add event_counter 1 + 1
   in
-  let id_line = Printf.sprintf "id: %d\n" effective_id in
-  let event_line = match event_type with
-    | Some e -> Printf.sprintf "event: %s\n" e
-    | None -> ""
-  in
-  Printf.sprintf "%s%sdata: %s\n\n" id_line event_line data
+  (* Hot path: every broadcast goes through here once.  The previous
+     three [Printf.sprintf] calls each ran the format interpreter and
+     allocated an intermediate string ([id_line], [event_line], the
+     concat), so a single broadcast paid for three string allocations
+     plus the [%d]/[%s] dispatch overhead before the result string was
+     produced.  A single [Buffer] accumulator with primitive
+     [string_of_int] sidesteps the format interpreter entirely and
+     emits exactly the bytes the SSE wire format requires (id-line +
+     optional event-line + data-line + blank).  The output string is
+     byte-for-byte identical to what [Printf.sprintf] produced. *)
+  let buf = Buffer.create 64 in
+  Buffer.add_string buf "id: ";
+  Buffer.add_string buf (string_of_int effective_id);
+  Buffer.add_char buf '\n';
+  (match event_type with
+   | Some e ->
+       Buffer.add_string buf "event: ";
+       Buffer.add_string buf e;
+       Buffer.add_char buf '\n'
+   | None -> ());
+  Buffer.add_string buf "data: ";
+  Buffer.add_string buf data;
+  Buffer.add_string buf "\n\n";
+  Buffer.contents buf
 
 (** Get current event ID *)
 let current_id () = Atomic.get event_counter


### PR DESCRIPTION
## 문제
`format_event`은 매 broadcast당 1회 호출되는 hot path. 기존 구현은 3 `Printf.sprintf` 체인:
1. `Printf.sprintf "id: %d\n" effective_id`
2. `Printf.sprintf "event: %s\n" e` (event_type=Some 시)
3. `Printf.sprintf "%s%sdata: %s\n\n" id_line event_line data`

각 sprintf는 format 인터프리터(`%d`/`%s` dispatch) + intermediate string allocation. 결과 string 1개 만들기 위해 3 alloc + 3 format trip.

## 변경
단일 `Buffer` accumulator + 원시 `string_of_int` + `Buffer.add_string` 으로 통합. format 인터프리터 우회. Final allocation은 `Buffer.contents` 1회.

Wire bytes identical to Printf 결과 (id-line + optional event-line + data-line + blank).

## 효과
1000 events/s burst 가정 시 3000 sprintf → 1000 Buffer.contents. format machinery overhead 제거. Modest 단독 효과지만 #10203/#10222/#10225 series와 함께 broadcast 1회당 비용 누적 절감:
- list snapshot: 3 → 0 (#10203/#10222/#10225)
- string sprintf: 3 → 0 (이 PR)
- Buffer alloc: 0 → 1

## Behavior
- byte-for-byte identical wire output
- ~id omit branch (atomic id alloc) 그대로
- event_type=None 분기 그대로 (no event-line)
- 예외 클래스 추가/제거 없음

## Validation
- `test_sse` 4/4 (event format이 모든 4개 테스트에서 사용)
- `test_transport_integration` 9/9 (broadcast 경로 end-to-end)