### PR TITLE
obs(governance): empty response.model fallback + counter (#9880 facet 4)

### DIFF
--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -50,6 +50,23 @@ let () =
        [source=telemetry_resolved | unknown_sentinel]."
     ()
 
+type governance_model_source =
+  | Response_model
+  | Telemetry_resolved
+  | Unknown_sentinel
+
+let governance_model_source_to_string = function
+  | Response_model -> "response_model"
+  | Telemetry_resolved -> "telemetry_resolved"
+  | Unknown_sentinel -> "unknown_sentinel"
+
+let resolve_governance_model_used ~raw_model ~canonical_model_id =
+  if String.trim raw_model <> "" then raw_model, Response_model
+  else
+    match canonical_model_id with
+    | Some id when String.trim id <> "" -> String.trim id, Telemetry_resolved
+    | _ -> "unknown_provider", Unknown_sentinel
+
 let governance_dir base_path =
   Filename.concat
     (Coord_utils.masc_dir_from_base_path ~base_path)
@@ -548,31 +565,27 @@ let compute_judgments
                keeper-side string [unknown_provider] so dashboards
                can union-aggregate empty-model events across both
                callers. *)
-            let resolved_model =
-              let raw = response.model in
-              if String.trim raw <> "" then raw
-              else begin
-                let canonical =
-                  match response.telemetry with
-                  | Some { canonical_model_id = Some id; _ }
-                    when String.trim id <> "" ->
-                      String.trim id
-                  | _ -> ""
-                in
-                let resolved, source =
-                  if canonical <> "" then canonical, "telemetry_resolved"
-                  else "unknown_provider", "unknown_sentinel"
-                in
+            let canonical_model_id =
+              match response.telemetry with
+              | Some { canonical_model_id = Some id; _ } -> Some id
+              | _ -> None
+            in
+            let resolved_model, model_source =
+              resolve_governance_model_used ~raw_model:response.model ~canonical_model_id
+            in
+            begin
+              match model_source with
+              | Response_model -> ()
+              | Telemetry_resolved | Unknown_sentinel ->
+                let source = governance_model_source_to_string model_source in
                 Prometheus.inc_counter
                   governance_response_model_empty_metric
                   ~labels:[ ("source", source) ]
                   ();
                 Log.Governance.warn
                   "compute_judgments: response.model empty → fallback=%s resolved=%s (#9880)"
-                  source resolved;
-                resolved
-              end
-            in
+                  source resolved_model;
+            end;
             let judgments =
               items
               |> List.filter_map

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -32,6 +32,24 @@ type state = {
   mutable judgments : (string, Yojson.Safe.t) Hashtbl.t;
 }
 
+(* #9880 facet 4: per-cycle counter for empty [response.model] in
+   governance compute_judgments.  Mirrors the keeper-side
+   [masc_after_turn_response_model_empty_total] introduced by
+   #10083; separate metric name keeps governance vs keeper
+   attribution clean while sharing the [unknown_provider]
+   sentinel string so PromQL can union-aggregate across both. *)
+let governance_response_model_empty_metric =
+  "masc_governance_response_model_empty_total"
+
+let () =
+  Prometheus.register_counter
+    ~name:governance_response_model_empty_metric
+    ~help:
+      "Count of governance compute_judgments cycles where \
+       [response.model] was empty.  Labels: \
+       [source=telemetry_resolved | unknown_sentinel]."
+    ()
+
 let governance_dir base_path =
   Filename.concat
     (Coord_utils.masc_dir_from_base_path ~base_path)
@@ -514,13 +532,54 @@ let compute_judgments
               | `List rows -> rows
               | _ -> []
             in
+            (* #9880 facet 4: 17% of yesterday's judgment records had
+               [model_used = ""] because OAS transports occasionally
+               return [response.model = ""] (Kimi/Codex CLI silent
+               failure path; CompletionContractViolation
+               retry-exhausted synthetic responses).  An empty
+               [model_used] field destroys attribution downstream
+               (cost rollups, per-model latency p50/p99, daily
+               judgments-by-model breakdown).
+
+               Same shape as keeper-side fix #10083: layered
+               fallback (raw → telemetry canonical_model_id → named
+               sentinel) plus a counter so the operator can see
+               WHICH transport leaked.  Sentinel matches the
+               keeper-side string [unknown_provider] so dashboards
+               can union-aggregate empty-model events across both
+               callers. *)
+            let resolved_model =
+              let raw = response.model in
+              if String.trim raw <> "" then raw
+              else begin
+                let canonical =
+                  match response.telemetry with
+                  | Some { canonical_model_id = Some id; _ }
+                    when String.trim id <> "" ->
+                      String.trim id
+                  | _ -> ""
+                in
+                let resolved, source =
+                  if canonical <> "" then canonical, "telemetry_resolved"
+                  else "unknown_provider", "unknown_sentinel"
+                in
+                Prometheus.inc_counter
+                  governance_response_model_empty_metric
+                  ~labels:[ ("source", source) ]
+                  ();
+                Log.Governance.warn
+                  "compute_judgments: response.model empty → fallback=%s resolved=%s (#9880)"
+                  source resolved;
+                resolved
+              end
+            in
             let judgments =
               items
               |> List.filter_map
                    (parse_item_judgment ~generated_at ~expires_at
-                      ~model_used:response.model)
+                      ~model_used:resolved_model)
             in
-            Ok (response.model, generated_at, expires_at, judgments)
+            Ok (resolved_model, generated_at, expires_at, judgments)
       with
       | Yojson.Json_error msg ->
           Error (Printf.sprintf "Governance judge returned invalid JSON: %s" msg)

--- a/test/dune
+++ b/test/dune
@@ -1410,6 +1410,11 @@
  (libraries masc_mcp alcotest))
 
 (test
+ (name test_governance_response_model_empty_9880)
+ (modules test_governance_response_model_empty_9880)
+ (libraries masc_mcp alcotest unix))
+
+(test
  (name test_keeper_autoboot_supervisor_start_10125)
  (modules test_keeper_autoboot_supervisor_start_10125)
  (action

--- a/test/test_governance_response_model_empty_9880.ml
+++ b/test/test_governance_response_model_empty_9880.ml
@@ -1,0 +1,126 @@
+(** #9880 facet 4: governance compute_judgments emits a
+    counter when [response.model] is empty so the operator can
+    see WHICH transports leak.  Pre-fix, 17% of yesterday's
+    judgment records had [model_used = ""] with zero
+    visibility.
+
+    Full integration testing of [compute_judgments] requires a
+    masc_tools fixture + dispatch wiring; these tests pin the
+    metric surface and label shape so a future refactor cannot
+    silently rename or drop the counter. *)
+
+let () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-governance-empty-model-9880-%06x"
+         (Random.bits ()))
+  in
+  Unix.putenv "MASC_BASE_PATH" dir
+
+module Prom = Masc_mcp.Prometheus
+
+let metric_name = "masc_governance_response_model_empty_total"
+
+let count_for ~source =
+  Prom.metric_value_or_zero metric_name
+    ~labels:[ ("source", source) ]
+    ()
+
+(* Metric is registered at module load via the
+   [let () = Prometheus.register_counter ...] block in
+   [dashboard_governance_judge.ml]. *)
+let test_metric_registered () =
+  let _ = Prom.metric_total metric_name in
+  Alcotest.(check pass) "metric registered" () ()
+
+(* Direct increment using the documented label shape.  Mirrors
+   the call in [compute_judgments] when [response.model] is
+   empty and telemetry's [canonical_model_id] resolves it. *)
+let test_telemetry_resolved_branch () =
+  let before = count_for ~source:"telemetry_resolved" in
+  Prom.inc_counter metric_name
+    ~labels:[ ("source", "telemetry_resolved") ]
+    ();
+  Alcotest.(check (float 0.0001))
+    "telemetry_resolved row +1"
+    (before +. 1.0)
+    (count_for ~source:"telemetry_resolved")
+
+(* When neither [response.model] nor telemetry resolves the
+   model, the writer falls back to the [unknown_provider]
+   sentinel and counts under [unknown_sentinel].  Distinct row
+   from telemetry_resolved so dashboards can separate
+   "transport leaked but recovered" from "transport leaked and
+   no recovery available". *)
+let test_unknown_sentinel_branch () =
+  let before = count_for ~source:"unknown_sentinel" in
+  Prom.inc_counter metric_name
+    ~labels:[ ("source", "unknown_sentinel" ) ]
+    ();
+  Alcotest.(check (float 0.0001))
+    "unknown_sentinel row +1"
+    (before +. 1.0)
+    (count_for ~source:"unknown_sentinel")
+
+(* Distinct sources land on distinct counter rows.  Necessary
+   because operators want to attribute leaks to either
+   "telemetry recovered" (transport-only issue) vs
+   "no recovery" (deeper provider failure). *)
+let test_distinct_sources_separate_rows () =
+  let before_t = count_for ~source:"telemetry_resolved" in
+  let before_u = count_for ~source:"unknown_sentinel" in
+  Prom.inc_counter metric_name
+    ~labels:[ ("source", "telemetry_resolved") ]
+    ();
+  Prom.inc_counter metric_name
+    ~labels:[ ("source", "unknown_sentinel") ]
+    ();
+  Alcotest.(check (float 0.0001)) "telemetry_resolved +1"
+    (before_t +. 1.0) (count_for ~source:"telemetry_resolved");
+  Alcotest.(check (float 0.0001)) "unknown_sentinel +1"
+    (before_u +. 1.0) (count_for ~source:"unknown_sentinel")
+
+(* Prometheus text export must include the metric name and
+   the [source] label key — PromQL queries depend on this. *)
+let test_export () =
+  Prom.inc_counter metric_name
+    ~labels:[ ("source", "telemetry_resolved") ]
+    ();
+  let text = Prom.to_prometheus_text () in
+  let contains s sub =
+    let n = String.length s and m = String.length sub in
+    let rec loop i =
+      if i + m > n then false
+      else if String.sub s i m = sub then true
+      else loop (i + 1)
+    in
+    loop 0
+  in
+  Alcotest.(check bool) "metric name in export"
+    true (contains text metric_name);
+  Alcotest.(check bool) "source label key in export"
+    true (contains text "source=")
+
+let () =
+  Alcotest.run "governance_response_model_empty_9880"
+    [
+      ( "registration",
+        [
+          Alcotest.test_case "metric registered at module load" `Quick
+            test_metric_registered;
+        ] );
+      ( "label-shape",
+        [
+          Alcotest.test_case "telemetry_resolved branch" `Quick
+            test_telemetry_resolved_branch;
+          Alcotest.test_case "unknown_sentinel branch" `Quick
+            test_unknown_sentinel_branch;
+          Alcotest.test_case "distinct sources distinct rows" `Quick
+            test_distinct_sources_separate_rows;
+        ] );
+      ( "export",
+        [
+          Alcotest.test_case "metric + label key in /metrics" `Quick
+            test_export;
+        ] );
+    ]

--- a/test/test_governance_response_model_empty_9880.ml
+++ b/test/test_governance_response_model_empty_9880.ml
@@ -4,10 +4,9 @@
     judgment records had [model_used = ""] with zero
     visibility.
 
-    Full integration testing of [compute_judgments] requires a
-    masc_tools fixture + dispatch wiring; these tests pin the
-    metric surface and label shape so a future refactor cannot
-    silently rename or drop the counter. *)
+    The fallback resolver is tested directly so this cannot
+    degrade into a metric-only smoke test that never proves
+    [model_used] is actually filled. *)
 
 let () =
   let dir =
@@ -18,6 +17,7 @@ let () =
   Unix.putenv "MASC_BASE_PATH" dir
 
 module Prom = Masc_mcp.Prometheus
+module Judge = Masc_mcp.Dashboard_governance_judge
 
 let metric_name = "masc_governance_response_model_empty_total"
 
@@ -80,6 +80,45 @@ let test_distinct_sources_separate_rows () =
   Alcotest.(check (float 0.0001)) "unknown_sentinel +1"
     (before_u +. 1.0) (count_for ~source:"unknown_sentinel")
 
+let check_resolution ~msg ~raw_model ~canonical_model_id ~expected_model
+    ~expected_source =
+  let model, source =
+    Judge.resolve_governance_model_used ~raw_model ~canonical_model_id
+  in
+  Alcotest.(check string) (msg ^ " model") expected_model model;
+  Alcotest.(check string)
+    (msg ^ " source")
+    expected_source
+    (Judge.governance_model_source_to_string source)
+
+let test_non_empty_raw_model_wins () =
+  check_resolution ~msg:"raw model"
+    ~raw_model:"claude-code:auto"
+    ~canonical_model_id:(Some "anthropic:claude-opus-4-7")
+    ~expected_model:"claude-code:auto"
+    ~expected_source:"response_model"
+
+let test_empty_raw_falls_back_to_telemetry () =
+  check_resolution ~msg:"telemetry fallback"
+    ~raw_model:""
+    ~canonical_model_id:(Some " anthropic:claude-opus-4-7 ")
+    ~expected_model:"anthropic:claude-opus-4-7"
+    ~expected_source:"telemetry_resolved"
+
+let test_empty_everywhere_uses_unknown_sentinel () =
+  check_resolution ~msg:"unknown sentinel"
+    ~raw_model:""
+    ~canonical_model_id:None
+    ~expected_model:"unknown_provider"
+    ~expected_source:"unknown_sentinel"
+
+let test_empty_canonical_id_uses_unknown_sentinel () =
+  check_resolution ~msg:"empty canonical"
+    ~raw_model:""
+    ~canonical_model_id:(Some "")
+    ~expected_model:"unknown_provider"
+    ~expected_source:"unknown_sentinel"
+
 (* Prometheus text export must include the metric name and
    the [source] label key — PromQL queries depend on this. *)
 let test_export () =
@@ -117,6 +156,17 @@ let () =
             test_unknown_sentinel_branch;
           Alcotest.test_case "distinct sources distinct rows" `Quick
             test_distinct_sources_separate_rows;
+        ] );
+      ( "fallback-tiers",
+        [
+          Alcotest.test_case "raw model wins" `Quick
+            test_non_empty_raw_model_wins;
+          Alcotest.test_case "empty raw -> telemetry canonical" `Quick
+            test_empty_raw_falls_back_to_telemetry;
+          Alcotest.test_case "empty everywhere -> sentinel" `Quick
+            test_empty_everywhere_uses_unknown_sentinel;
+          Alcotest.test_case "empty canonical_model_id -> sentinel" `Quick
+            test_empty_canonical_id_uses_unknown_sentinel;
         ] );
       ( "export",
         [


### PR DESCRIPTION
## Summary

#9880 reports governance judgment ledger as decorative across five simultaneous failure signals.  This PR addresses **facet 4** only.

| facet | scope | status |
|---|---|---|
| 1 — \`recommended_action\` 100% null | JSON parser / schema drift | not in this PR |
| 2 — confidence ≥0.95 95.7% degenerate | LLM prompt / schema removal | not in this PR |
| 3 — status always \`active\` | needs downstream consumer pattern | not in this PR |
| **4 — 17% empty \`model_used\`** | **this PR** | observability + sentinel fallback |
| 5 — 93% volume drop | OAS bridge 60s timeout (#9629); covered by #10094 SSOT | already addressed |

## Facet 4 root

OAS transports occasionally return \`response.model = ""\` — the Kimi/Codex CLI silent failure path and \`CompletionContractViolation\` retry-exhausted synthetic responses both have this shape.  Governance writer wrote the empty string straight into the JSONL.  17% of yesterday's records lost attribution.

## Fix (mirrors keeper-side #10083)

\`\`\`ocaml
let resolved_model =
  let raw = response.model in
  if String.trim raw <> "" then raw
  else begin
    let canonical = (* try telemetry.canonical_model_id *) in
    let resolved, source =
      if canonical <> "" then canonical, "telemetry_resolved"
      else "unknown_provider", "unknown_sentinel"
    in
    Prometheus.inc_counter
      governance_response_model_empty_metric
      ~labels:[ ("source", source) ] ();
    Log.Governance.warn
      "compute_judgments: response.model empty → fallback=%s resolved=%s (#9880)"
      source resolved;
    resolved
  end
in
\`\`\`

- Layered fallback: \`raw → telemetry.canonical_model_id → unknown_provider sentinel\`
- Sentinel \`unknown_provider\` matches keeper-side string so PromQL can union-aggregate across both callers
- Per-cycle counter \`masc_governance_response_model_empty_total{source}\` with \`telemetry_resolved\` vs \`unknown_sentinel\`

## Why a separate metric from keeper-side

Keeper-side counter \`masc_after_turn_response_model_empty_total\` is labelled by \`{keeper, source}\`.  Governance has no \`keeper\` semantics — it's a single judge daemon, not a fleet of identities.  Separate metric keeps the label shapes honest while sharing the sentinel string for cross-caller aggregation.

## Test plan

- [x] \`dune build --root . lib/\` clean
- [x] \`dune exec test/test_governance_response_model_empty_9880.exe\` — 5/5 pass:
  - metric registered at module load
  - \`telemetry_resolved\` branch increments
  - \`unknown_sentinel\` branch increments
  - distinct sources land on distinct rows
  - metric name + \`source=\` label key appear in \`/metrics\` text export

- [ ] Deploy: confirm the counter advances at the production 17% rate, and that the dominant \`source\` label tells operators whether the fix path is the OAS telemetry envelope or the bare sentinel.

## Refs

- #10083 / PR #10090 (keeper-side, same pattern, separate caller)
- #9520 (silent-failure cluster — empty model_used with no alert is exactly this theme)
- #9629, #9734 (OAS bridge 60s timeout — facet 5 root cause, already addressed by #10094)

## Do-not-merge

\`do-not-merge\` label set so the auto-merge pipeline does not flip this Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)