### PR TITLE
[codex] Fix MASC bearer login auth path

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -30,6 +30,7 @@ module Dashboard_mission_briefing = Masc_mcp.Dashboard_mission_briefing
 module Build_identity = Masc_mcp.Build_identity
 module Config_doctor = Masc_mcp.Config_doctor
 module Auth_doctor = Masc_mcp.Auth_doctor
+module Auth_login = Masc_mcp.Auth_login
 module Graphql_api = Masc_mcp.Graphql_api
 module Types = Types
 module Tempo = Masc_mcp.Tempo
@@ -301,6 +302,30 @@ let base_path =
 let doctor_json =
   let doc = "Emit machine-readable JSON instead of text output" in
   Arg.(value & flag & info ["json"] ~doc)
+
+let parse_login_role value =
+  match Types.agent_role_of_string (String.lowercase_ascii value) with
+  | Ok role -> Ok role
+  | Error msg -> Error (`Msg msg)
+
+let login_role =
+  let doc = "Role for the minted bearer token: admin or worker" in
+  let role_printer fmt role =
+    Format.pp_print_string fmt (Types.agent_role_to_string role)
+  in
+  let role_conv = Arg.conv (parse_login_role, role_printer) in
+  Arg.(value & opt role_conv Types.Admin & info ["role"] ~docv:"ROLE" ~doc)
+
+let login_agent =
+  let doc = "Agent identity bound to the minted bearer token" in
+  Arg.(
+    value
+    & opt string "codex-local-admin"
+    & info ["agent"] ~docv:"AGENT" ~doc)
+
+let login_shell =
+  let doc = "Emit shell export commands only" in
+  Arg.(value & flag & info ["shell"] ~doc)
 
 (** Graceful shutdown exception *)
 (* Shutdown exception removed: graceful shutdown returns normally from
@@ -883,6 +908,36 @@ let doctor_cmd =
     info
     [ doctor_config_cmd; doctor_auth_cmd; doctor_sidecar_cmd; doctor_all_cmd ]
 
+let login_cmd_exit base_path host port agent role as_json as_shell =
+  match
+    Auth_login.mint ~base_path ~host ~port ~agent_name:agent ~role ()
+  with
+  | Error err ->
+      Printf.eprintf "login failed: %s\n" (Types.masc_error_to_string err);
+      1
+  | Ok report ->
+      let output =
+        if as_shell then
+          Auth_login.render_shell report
+        else if as_json then
+          Auth_login.to_yojson report |> Yojson.Safe.pretty_to_string
+        else
+          Auth_login.render_text report
+      in
+      print_endline output;
+      0
+
+let login_cmd =
+  let doc =
+    "Mint a local bearer token, persist its raw token file, and print \
+     dashboard/Codex MCP auth exports"
+  in
+  let info = Cmd.info "login" ~doc in
+  Cmd.v info
+    Term.(
+      const login_cmd_exit $ base_path $ host $ port $ login_agent
+      $ login_role $ doctor_json $ login_shell)
+
 let init_force =
   let doc = "Overwrite existing config files instead of skipping them" in
   Arg.(value & flag & info ["force"] ~doc)
@@ -932,6 +987,6 @@ let cmd =
   let doc = "MASC MCP Server and operator diagnostics" in
   let info = Cmd.info "masc-mcp" ~version:Masc_mcp.Version.version ~doc in
   Cmd.group ~default:Term.(const run_cmd_exit $ host $ port $ base_path)
-    info [ doctor_cmd; init_cmd ]
+    info [ doctor_cmd; init_cmd; login_cmd ]
 
 let () = exit (Cmd.eval' cmd)

--- a/docs/DOCTOR-ARCHITECTURE.md
+++ b/docs/DOCTOR-ARCHITECTURE.md
@@ -130,7 +130,7 @@ class AutoFix:
 | 계층 | Doctor | 구현 상태 |
 |------|--------|-----------|
 | OCaml 서버 | `masc-mcp doctor config` — 베이스 경로 / 활성 config root | 운영 중 (`docs/CONFIG-DOCTOR.md`) |
-| OCaml 서버 | `masc-mcp doctor auth` — auth mode / admin bearer readiness / role mismatch | 운영 중 (`docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md`) |
+| OCaml 서버 | `masc-mcp doctor auth` — auth mode / admin bearer readiness / role mismatch / Codex MCP bearer env | 운영 중 (`docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md`) |
 | Discord sidecar | `masc-mcp doctor sidecar discord` ↔ `python -m src doctor` | 운영 중 |
 | Slack sidecar | `masc-mcp doctor sidecar slack` ↔ `python -m src doctor` | 운영 중 |
 | Telegram sidecar | `masc-mcp doctor sidecar telegram` ↔ `python -m src doctor` | 운영 중 |
@@ -145,7 +145,7 @@ class AutoFix:
 ```
 masc-mcp doctor                     # default → config (backward-compat)
 masc-mcp doctor config              # base path / config root 진단
-masc-mcp doctor auth                # auth/bearer/role mismatch 진단
+masc-mcp doctor auth                # auth/bearer/role mismatch + Codex MCP bearer env 진단
 masc-mcp doctor sidecar <name>      # python -m src doctor 를 해당 sidecar 디렉터리에서 실행
 masc-mcp doctor sidecar <name> --json
 masc-mcp doctor all                 # config + 5 sidecar 연쇄 실행 + aggregate 요약

--- a/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
+++ b/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
@@ -78,15 +78,49 @@ Useful interpretations:
   - room auth may be enabled, but no usable admin bearer source was found
 - `dashboard_dev_token: available=yes`
   - the easiest local bootstrap path is `GET /api/v1/dashboard/dev-token`
+- `codex_mcp.token_status=unset` or `invalid_or_expired`
+  - Codex MCP is missing a live bearer token; this is not fixed by `codex mcp login`
 
 If you want structured output for automation:
 
 ```bash
 ./_build/default/bin/main_eio.exe doctor auth --base-path "$BASE_PATH" --json \
-  | jq '{status,warnings,next_actions}'
+  | jq '{status,codex_mcp,warnings,next_actions}'
 ```
 
-## 4. Supported Local Start
+## 4. Codex MCP Bearer Login
+
+`masc-mcp` uses bearer-token MCP auth. It does not expose an OAuth
+authorization endpoint, so `codex mcp login masc` is expected to fail with
+`No authorization support detected`.
+
+For the Codex MCP server, mint a worker bearer and export it as
+`MASC_MCP_TOKEN`:
+
+```bash
+BASE_PATH="${MASC_BASE_PATH:-$HOME}"
+./_build/default/bin/main_eio.exe login \
+  --base-path "$BASE_PATH" \
+  --agent codex-mcp-client \
+  --role worker \
+  --shell
+```
+
+Then use the printed `export MASC_MCP_TOKEN=...` in the shell that starts
+Codex. Confirm the Codex-side registration points at the bearer env var:
+
+```bash
+codex mcp get masc
+```
+
+Expected shape:
+
+```text
+URL: http://127.0.0.1:8935/mcp
+Bearer Token Env Var: MASC_MCP_TOKEN
+```
+
+## 5. Supported Local Start
 
 When running from a worktree but using a shared local coordination root, start the server with an explicit base path:
 
@@ -101,9 +135,22 @@ MASC_BASE_PATH="$BASE_PATH" \
 
 Then run `./_build/default/bin/main_eio.exe doctor --base-path "$BASE_PATH"` and re-check `/health` to confirm the effective base path is the path you intended.
 
-## 5. Bootstrap an Admin Bearer
+## 6. Bootstrap an Admin Bearer
 
-If you already have an admin bearer, skip to step 6.
+If you already have an admin bearer, skip to step 7.
+
+The shortest local CLI path is:
+
+```bash
+BASE_PATH="${MASC_BASE_PATH:-$HOME}"
+./_build/default/bin/main_eio.exe login \
+  --base-path "$BASE_PATH" \
+  --agent codex-local-admin \
+  --role admin
+```
+
+The command prints the raw bearer once, writes the matching private raw-token
+file under the live auth root, and includes a dashboard URL.
 
 If `doctor auth` says `dashboard_dev_token: available=yes`, the easiest local path is the dev-token bootstrap:
 
@@ -174,7 +221,7 @@ Notes:
 - keep the raw bearer outside the repo
 - this is for trusted local operator use, not a remote/public bootstrap path
 
-## 6. Open the Dashboard as Admin
+## 7. Open the Dashboard as Admin
 
 Pass the token once via query string. The dashboard moves it into `sessionStorage` and removes it from the URL.
 
@@ -199,7 +246,7 @@ Expected:
 - `effective_agent="codex-tool-matrix"`
 - `effective_role="admin"`
 
-## 7. Verify Admin-Only Routes
+## 8. Verify Admin-Only Routes
 
 Use a low-risk keeper first.
 
@@ -249,7 +296,7 @@ curl -sS http://127.0.0.1:8935/api/v1/dashboard/execution \
   | jq '.keepers[] | select(.name=="<keeper>") | {name,status,paused,trace_id,active_model}'
 ```
 
-## 8. Rollback
+## 9. Rollback
 
 If you need to go back to anonymous loopback behavior:
 
@@ -267,7 +314,7 @@ rm -f "$BASE_PATH/.masc/auth/agents/codex-tool-matrix.json"
 
 If you used only `dashboard-dev` dev-token bootstrap, there may be no auth files to roll back.
 
-## 9. Known Failure Modes
+## 10. Known Failure Modes
 
 - `effective_base_path` points somewhere else:
   you edited the wrong `.masc/auth` tree

--- a/lib/auth_doctor.ml
+++ b/lib/auth_doctor.ml
@@ -14,6 +14,19 @@ type watched_agent = {
   raw_token_file_present : bool;
 }
 
+type codex_mcp = {
+  server_name : string;
+  auth_model : string;
+  token_env_var : string;
+  token_env_configured : bool;
+  token_status : string;
+  token_agent : string option;
+  token_role : string option;
+  token_can_read_state : bool option;
+  login_supported : bool;
+  login_note : string;
+}
+
 type t = {
   status : status;
   base_path : string;
@@ -37,6 +50,7 @@ type t = {
   credential_count : int;
   role_counts : (string * int) list;
   watched_agents : watched_agent list;
+  codex_mcp : codex_mcp;
   warnings : string list;
   next_actions : string list;
 }
@@ -51,6 +65,11 @@ let status_to_string = function
   | Ok -> "ok"
   | Warn -> "warn"
   | Error -> "error"
+
+let codex_mcp_token_env_var = "MASC_MCP_TOKEN"
+
+let codex_mcp_login_note =
+  "`codex mcp login` is OAuth-only; masc-mcp uses bearer token auth."
 
 let canonicalize_path path =
   try Unix.realpath path with
@@ -194,6 +213,53 @@ let admin_bearer_sources ~base_path ~auth_dir ~dashboard_dev_token_available
   env_sources @ dashboard_sources @ token_file_sources
   |> dedupe_keep_order
 
+let codex_mcp_report ~base_path =
+  match
+    Sys.getenv_opt codex_mcp_token_env_var |> Env_config_core.trim_opt
+  with
+  | None ->
+      {
+        server_name = "masc";
+        auth_model = "bearer_token_env";
+        token_env_var = codex_mcp_token_env_var;
+        token_env_configured = false;
+        token_status = "unset";
+        token_agent = None;
+        token_role = None;
+        token_can_read_state = None;
+        login_supported = false;
+        login_note = codex_mcp_login_note;
+      }
+  | Some raw_token -> (
+      match Auth.find_credential_by_token base_path ~token:raw_token with
+      | Ok cred ->
+          {
+            server_name = "masc";
+            auth_model = "bearer_token_env";
+            token_env_var = codex_mcp_token_env_var;
+            token_env_configured = true;
+            token_status = "live";
+            token_agent = Some cred.agent_name;
+            token_role = Some (agent_role_to_string cred.role);
+            token_can_read_state =
+              Some (has_permission cred.role CanReadState);
+            login_supported = false;
+            login_note = codex_mcp_login_note;
+          }
+      | Error _ ->
+          {
+            server_name = "masc";
+            auth_model = "bearer_token_env";
+            token_env_var = codex_mcp_token_env_var;
+            token_env_configured = true;
+            token_status = "invalid_or_expired";
+            token_agent = None;
+            token_role = None;
+            token_can_read_state = None;
+            login_supported = false;
+            login_note = codex_mcp_login_note;
+          })
+
 let analyze ~base_path_input ~default_base_path () =
   let normalized_base_path =
     Env_config_core.normalize_masc_base_path_input base_path_input
@@ -228,6 +294,7 @@ let analyze ~base_path_input ~default_base_path () =
     admin_bearer_sources ~base_path ~auth_dir
       ~dashboard_dev_token_available ~admin_token_env_state credentials
   in
+  let codex_mcp = codex_mcp_report ~base_path in
   let token_bound_admin_http_ready =
     auth_cfg.enabled && auth_cfg.require_token && admin_bearer_sources <> []
   in
@@ -295,6 +362,18 @@ let analyze ~base_path_input ~default_base_path () =
            "Dashboard dev-token bootstrap is unavailable because the bind host is non-loopback or HTTP strict auth is enabled."
        else
          None);
+      (if auth_cfg.enabled && auth_cfg.require_token then
+         match codex_mcp.token_status with
+         | "unset" ->
+             Some
+               "Codex MCP bearer env var MASC_MCP_TOKEN is unset; Codex should use bearer_token_env_var, not `codex mcp login`."
+         | "invalid_or_expired" ->
+             Some
+               "Codex MCP bearer env var MASC_MCP_TOKEN is set, but it does not resolve to a live credential in this base path."
+         | "live" -> None
+         | _ -> None
+       else
+         None);
     ]
     |> List.filter_map Fun.id
     |> dedupe_keep_order
@@ -335,6 +414,12 @@ let analyze ~base_path_input ~default_base_path () =
            "Follow docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md to bootstrap an admin bearer under the live auth root."
        else
          None);
+      (if auth_cfg.enabled && auth_cfg.require_token
+          && not (String.equal codex_mcp.token_status "live") then
+         Some
+           "For Codex MCP, run `masc-mcp login --agent codex-mcp-client --role worker --shell` and export MASC_MCP_TOKEN; do not run `codex mcp login masc`."
+       else
+         None);
       Some "Rerun `masc-mcp doctor auth` after editing auth files or rotating tokens.";
     ]
     |> List.filter_map Fun.id
@@ -372,6 +457,7 @@ let analyze ~base_path_input ~default_base_path () =
     credential_count = List.length credentials;
     role_counts = role_counts_of_credentials credentials;
     watched_agents;
+    codex_mcp;
     warnings;
     next_actions;
   }
@@ -388,6 +474,24 @@ let watched_agent_to_yojson agent =
         | None -> `Null );
       (option_field "expires_at" agent.expires_at);
       ("raw_token_file_present", `Bool agent.raw_token_file_present);
+    ]
+
+let codex_mcp_to_yojson codex_mcp =
+  `Assoc
+    [
+      ("server_name", `String codex_mcp.server_name);
+      ("auth_model", `String codex_mcp.auth_model);
+      ("token_env_var", `String codex_mcp.token_env_var);
+      ("token_env_configured", `Bool codex_mcp.token_env_configured);
+      ("token_status", `String codex_mcp.token_status);
+      (option_field "token_agent" codex_mcp.token_agent);
+      (option_field "token_role" codex_mcp.token_role);
+      ( "token_can_read_state",
+        match codex_mcp.token_can_read_state with
+        | Some value -> `Bool value
+        | None -> `Null );
+      ("login_supported", `Bool codex_mcp.login_supported);
+      ("login_note", `String codex_mcp.login_note);
     ]
 
 let to_yojson (report : t) =
@@ -429,6 +533,7 @@ let to_yojson (report : t) =
              report.role_counts) );
       ( "watched_agents",
         `List (List.map watched_agent_to_yojson report.watched_agents) );
+      ("codex_mcp", codex_mcp_to_yojson report.codex_mcp);
       ("warnings", `List (List.map (fun value -> `String value) report.warnings));
       ("next_actions", `List (List.map (fun value -> `String value) report.next_actions));
     ]
@@ -505,6 +610,36 @@ let render_text (report : t) =
            (yes_no agent.raw_token_file_present)
            (option_value agent.expires_at)))
     report.watched_agents;
+  add_line "";
+  add_line "codex_mcp:";
+  add_line
+    (Printf.sprintf "- server_name: %s" report.codex_mcp.server_name);
+  add_line
+    (Printf.sprintf "- auth_model: %s" report.codex_mcp.auth_model);
+  add_line
+    (Printf.sprintf "- token_env_var: %s"
+       report.codex_mcp.token_env_var);
+  add_line
+    (Printf.sprintf "- token_env_configured: %s"
+       (yes_no report.codex_mcp.token_env_configured));
+  add_line
+    (Printf.sprintf "- token_status: %s"
+       report.codex_mcp.token_status);
+  add_line
+    (Printf.sprintf "- token_agent: %s"
+       (option_value report.codex_mcp.token_agent));
+  add_line
+    (Printf.sprintf "- token_role: %s"
+       (option_value report.codex_mcp.token_role));
+  add_line
+    (Printf.sprintf "- token_can_read_state: %s"
+       (match report.codex_mcp.token_can_read_state with
+        | Some value -> yes_no value
+        | None -> "(n/a)"));
+  add_line
+    (Printf.sprintf "- login_supported: %s"
+       (yes_no report.codex_mcp.login_supported));
+  add_line (Printf.sprintf "- login_note: %s" report.codex_mcp.login_note);
   if report.warnings <> [] then begin
     add_line "";
     add_line "warnings:";

--- a/lib/auth_login.ml
+++ b/lib/auth_login.ml
@@ -1,0 +1,177 @@
+open Types
+
+type auth_change =
+  | Auth_already_required
+  | Auth_enabled
+  | Require_token_enabled
+
+type t = {
+  base_path : string;
+  auth_config_path : string;
+  auth_change : auth_change;
+  agent_name : string;
+  role : agent_role;
+  bearer_token : string;
+  raw_token_file : string;
+  dashboard_url : string;
+  mcp_url : string;
+  codex_server_name : string;
+  codex_token_env_var : string;
+  codex_login_supported : bool;
+}
+
+let codex_server_name = "masc"
+
+let codex_token_env_var = "MASC_MCP_TOKEN"
+
+let rng_initialized = Atomic.make false
+
+let ensure_rng_initialized () =
+  if not (Atomic.get rng_initialized) then begin
+    Mirage_crypto_rng_unix.use_default ();
+    Atomic.set rng_initialized true
+  end
+
+let auth_change_to_string = function
+  | Auth_already_required -> "already_required"
+  | Auth_enabled -> "auth_enabled"
+  | Require_token_enabled -> "require_token_enabled"
+
+let normalize_base_path path =
+  Env_config_core.normalize_masc_base_path_input path
+
+let url_encode value =
+  let buf = Buffer.create (String.length value) in
+  String.iter
+    (function
+      | ('A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '-' | '_' | '.' | '~') as c
+        ->
+          Buffer.add_char buf c
+      | c -> Buffer.add_string buf (Printf.sprintf "%%%02X" (Char.code c)))
+    value;
+  Buffer.contents buf
+
+let single_quote_shell value =
+  "'" ^ String.concat "'\\''" (String.split_on_char '\'' value) ^ "'"
+
+let token_file_path ~base_path ~agent_name =
+  Filename.concat (Auth.auth_dir base_path) (agent_name ^ ".token")
+
+let persist_raw_token ~base_path ~agent_name raw_token =
+  let path = token_file_path ~base_path ~agent_name in
+  Fs_compat.mkdir_p (Filename.dirname path);
+  Auth.save_private_text_file path raw_token;
+  path
+
+let ensure_required_bearer_auth ~base_path ~agent_name =
+  let cfg = Auth.load_auth_config base_path in
+  if cfg.enabled && cfg.require_token then
+    Ok Auth_already_required
+  else if not cfg.enabled then
+    let _room_secret, _bootstrap_token =
+      Auth.enable_auth base_path ~require_token:true ~agent_name
+    in
+    Ok Auth_enabled
+  else (
+    Auth.save_auth_config base_path { cfg with require_token = true };
+    Ok Require_token_enabled)
+
+let mint ~base_path ~host ~port ~agent_name ~role () =
+  ensure_rng_initialized ();
+  let base_path = normalize_base_path base_path in
+  match ensure_required_bearer_auth ~base_path ~agent_name with
+  | Error err -> Error err
+  | Ok auth_change -> (
+      match Auth.create_token base_path ~agent_name ~role with
+      | Error err -> Error err
+      | Ok (bearer_token, cred) ->
+          let raw_token_file =
+            persist_raw_token ~base_path ~agent_name bearer_token
+          in
+          let agent_param = url_encode agent_name in
+          let token_param = url_encode bearer_token in
+          let dashboard_url =
+            Printf.sprintf "http://%s:%d/dashboard?agent=%s&token=%s"
+              host port agent_param token_param
+          in
+          let mcp_url = Printf.sprintf "http://%s:%d/mcp" host port in
+          Ok
+            {
+              base_path;
+              auth_config_path = Auth.auth_config_file base_path;
+              auth_change;
+              agent_name = cred.agent_name;
+              role = cred.role;
+              bearer_token;
+              raw_token_file;
+              dashboard_url;
+              mcp_url;
+              codex_server_name;
+              codex_token_env_var;
+              codex_login_supported = false;
+            })
+
+let to_yojson report =
+  `Assoc
+    [
+      ("status", `String "ok");
+      ("base_path", `String report.base_path);
+      ("auth_config_path", `String report.auth_config_path);
+      ("auth_change", `String (auth_change_to_string report.auth_change));
+      ("agent_name", `String report.agent_name);
+      ("role", `String (agent_role_to_string report.role));
+      ("bearer_token", `String report.bearer_token);
+      ("raw_token_file", `String report.raw_token_file);
+      ("dashboard_url", `String report.dashboard_url);
+      ("mcp_url", `String report.mcp_url);
+      ( "codex_mcp",
+        `Assoc
+          [
+            ("server_name", `String report.codex_server_name);
+            ("auth_model", `String "bearer_token_env");
+            ("token_env_var", `String report.codex_token_env_var);
+            ("login_supported", `Bool report.codex_login_supported);
+            ( "login_note",
+              `String
+                "`codex mcp login` is OAuth-only; masc-mcp uses bearer token auth." );
+          ] );
+    ]
+
+let render_shell report =
+  String.concat "\n"
+    [
+      Printf.sprintf "export MASC_OPERATOR_AGENT=%s"
+        (single_quote_shell report.agent_name);
+      Printf.sprintf "export MASC_OPERATOR_TOKEN=%s"
+        (single_quote_shell report.bearer_token);
+      Printf.sprintf "export %s=%s" report.codex_token_env_var
+        (single_quote_shell report.bearer_token);
+      Printf.sprintf "export MASC_DASHBOARD_URL=%s"
+        (single_quote_shell report.dashboard_url);
+    ]
+
+let render_text report =
+  String.concat "\n"
+    [
+      "MASC Login";
+      "status: ok";
+      Printf.sprintf "base_path: %s" report.base_path;
+      Printf.sprintf "auth_config_path: %s" report.auth_config_path;
+      Printf.sprintf "auth_change: %s"
+        (auth_change_to_string report.auth_change);
+      Printf.sprintf "agent_name: %s" report.agent_name;
+      Printf.sprintf "role: %s" (agent_role_to_string report.role);
+      Printf.sprintf "raw_token_file: %s" report.raw_token_file;
+      Printf.sprintf "dashboard_url: %s" report.dashboard_url;
+      Printf.sprintf "mcp_url: %s" report.mcp_url;
+      "";
+      "exports:";
+      render_shell report;
+      "";
+      "codex_mcp:";
+      Printf.sprintf "- server_name: %s" report.codex_server_name;
+      Printf.sprintf "- token_env_var: %s" report.codex_token_env_var;
+      "- auth_model: bearer_token_env";
+      "- login_supported: no";
+      "- note: `codex mcp login` is OAuth-only; use the exported bearer token instead.";
+    ]

--- a/lib/dune
+++ b/lib/dune
@@ -23,6 +23,7 @@
    auto_responder
    auth
    auth_doctor
+   auth_login
    board
    board_core
    board_core_classify

--- a/test/dune
+++ b/test/dune
@@ -31,7 +31,7 @@
 ; Group 1: Pure synchronous tests
 ; ============================================================
 (tests
- (names test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_audit_log test_governance_anomaly test_http_negotiation
+ (names test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
         test_attempt_state
         test_sse test_cancellation test_graphql_api
         test_graphql_endpoint
@@ -166,7 +166,7 @@
         test_memory_hooks
         test_mid_turn_resume
         test_lockfree_atomic)
- (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_audit_log test_governance_anomaly test_http_negotiation
+ (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
           test_attempt_state
           test_sse test_cancellation test_graphql_api
           test_graphql_endpoint

--- a/test/test_auth_doctor.ml
+++ b/test/test_auth_doctor.ml
@@ -75,6 +75,7 @@ let test_warns_for_codex_worker_admin_route_mismatch () =
   with_env "MASC_HOST" "127.0.0.1" @@ fun () ->
   with_env "MASC_HTTP_AUTH_STRICT" "" @@ fun () ->
   with_env "MASC_ADMIN_TOKEN" "" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "" @@ fun () ->
   let report =
     Auth_doctor.analyze ~base_path_input:base_path
       ~default_base_path:base_path ()
@@ -115,6 +116,7 @@ let test_errors_when_no_admin_bearer_source_exists () =
   with_env "MASC_HOST" "0.0.0.0" @@ fun () ->
   with_env "MASC_HTTP_AUTH_STRICT" "1" @@ fun () ->
   with_env "MASC_ADMIN_TOKEN" "" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "" @@ fun () ->
   let report =
     Auth_doctor.analyze ~base_path_input:base_path
       ~default_base_path:base_path ()
@@ -153,6 +155,7 @@ let test_ignores_stale_admin_raw_token_file () =
   with_env "MASC_HOST" "0.0.0.0" @@ fun () ->
   with_env "MASC_HTTP_AUTH_STRICT" "1" @@ fun () ->
   with_env "MASC_ADMIN_TOKEN" "" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "" @@ fun () ->
   let report =
     Auth_doctor.analyze ~base_path_input:base_path
       ~default_base_path:base_path ()
@@ -169,6 +172,54 @@ let test_ignores_stale_admin_raw_token_file () =
        ~needle:"No usable admin bearer source was detected"
        report.warnings)
 
+let test_reports_codex_mcp_bearer_env () =
+  with_temp_dir "auth-doctor-codex-mcp" @@ fun base_path ->
+  let auth_cfg =
+    Types.
+      {
+        enabled = true;
+        room_secret_hash = None;
+        require_token = true;
+        token_expiry_hours = 24;
+      }
+  in
+  Auth.save_auth_config base_path auth_cfg;
+  save_credential_or_fail base_path ~agent_name:"admin" ~role:Types.Admin
+    ~raw_token:"admin-token";
+  Auth.save_private_text_file (raw_token_file base_path "admin")
+    "admin-token";
+  save_credential_or_fail base_path ~agent_name:"codex-mcp-client"
+    ~role:Types.Worker ~raw_token:"codex-mcp-token";
+  with_env "MASC_HOST" "127.0.0.1" @@ fun () ->
+  with_env "MASC_HTTP_AUTH_STRICT" "" @@ fun () ->
+  with_env "MASC_ADMIN_TOKEN" "" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "codex-mcp-token" @@ fun () ->
+  let report =
+    Auth_doctor.analyze ~base_path_input:base_path
+      ~default_base_path:base_path ()
+  in
+  check string "codex server name" "masc"
+    report.codex_mcp.server_name;
+  check string "codex auth model" "bearer_token_env"
+    report.codex_mcp.auth_model;
+  check string "codex token status" "live"
+    report.codex_mcp.token_status;
+  check (option string) "codex token agent"
+    (Some "codex-mcp-client")
+    report.codex_mcp.token_agent;
+  check (option string) "codex token role" (Some "worker")
+    report.codex_mcp.token_role;
+  check (option bool) "codex can read state" (Some true)
+    report.codex_mcp.token_can_read_state;
+  check bool "codex login unsupported" false
+    report.codex_mcp.login_supported;
+  check bool "doctor text names bearer env" true
+    (contains_substring ~needle:"token_env_var: MASC_MCP_TOKEN"
+       (Auth_doctor.render_text report));
+  check bool "no codex login warning when env is live" false
+    (list_contains_substring ~needle:"codex mcp login"
+       report.warnings)
+
 let () =
   run "auth_doctor"
     [
@@ -180,5 +231,7 @@ let () =
             test_errors_when_no_admin_bearer_source_exists;
           test_case "ignores stale admin raw token file" `Quick
             test_ignores_stale_admin_raw_token_file;
+          test_case "reports Codex MCP bearer env" `Quick
+            test_reports_codex_mcp_bearer_env;
         ] );
     ]

--- a/test/test_auth_login.ml
+++ b/test/test_auth_login.ml
@@ -1,0 +1,87 @@
+open Alcotest
+open Masc_mcp
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end
+    else
+      Sys.remove path
+
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let contains_substring ~needle s =
+  let nl = String.length needle in
+  let sl = String.length s in
+  if nl = 0 || nl > sl then
+    false
+  else
+    let limit = sl - nl in
+    let rec loop i =
+      if i > limit then false
+      else if String.sub s i nl = needle then true
+      else loop (i + 1)
+    in
+    loop 0
+
+let test_login_enables_bearer_auth_and_prints_codex_exports () =
+  with_temp_dir "auth-login" @@ fun base_path ->
+  match
+    Auth_login.mint ~base_path ~host:"127.0.0.1" ~port:8935
+      ~agent_name:"codex-mcp-client" ~role:Types.Worker ()
+  with
+  | Error err ->
+      failf "login mint failed: %s" (Types.masc_error_to_string err)
+  | Ok report ->
+      let cfg = Auth.load_auth_config base_path in
+      check bool "auth enabled" true cfg.enabled;
+      check bool "require token" true cfg.require_token;
+      check string "agent" "codex-mcp-client" report.agent_name;
+      check string "role" "worker"
+        (Types.agent_role_to_string report.role);
+      check string "codex env" "MASC_MCP_TOKEN"
+        report.codex_token_env_var;
+      check bool "codex login unsupported" false
+        report.codex_login_supported;
+      check bool "raw token file exists" true
+        (Sys.file_exists report.raw_token_file);
+      (match
+         Auth.find_credential_by_token base_path
+           ~token:report.bearer_token
+       with
+       | Ok cred ->
+           check string "token owner" "codex-mcp-client"
+             cred.agent_name
+       | Error err ->
+           failf "minted token did not verify: %s"
+             (Types.masc_error_to_string err));
+      let shell = Auth_login.render_shell report in
+      check bool "shell exports mcp token" true
+        (contains_substring ~needle:"export MASC_MCP_TOKEN="
+           shell);
+      let text = Auth_login.render_text report in
+      check bool "text explains codex login" true
+        (contains_substring
+           ~needle:"`codex mcp login` is OAuth-only"
+           text);
+      let json = Auth_login.to_yojson report in
+      check string "json status" "ok"
+        (Yojson.Safe.Util.member "status" json
+        |> Yojson.Safe.Util.to_string)
+
+let () =
+  run "auth_login"
+    [
+      ( "login",
+        [
+          test_case "enables bearer auth and prints Codex exports" `Quick
+            test_login_enables_bearer_auth_and_prints_codex_exports;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

- add `masc-mcp login` to mint local bearer tokens, persist the matching raw token file, and print dashboard/Codex MCP exports
- extend `doctor auth` with a `codex_mcp` section that verifies `MASC_MCP_TOKEN` against the live auth store and makes clear that `codex mcp login` is not supported for MASC bearer auth
- update the local auth runbook and doctor architecture docs with the Codex MCP bearer-token path

## Why

Codex was nudging operators toward an OAuth-style `codex mcp login ...` flow, but `masc-mcp` is a bearer-token MCP server. The practical fix is to expose a first-class local bearer minting path and make the doctor report the real auth model and env var status.

## Validation

- `scripts/dune-local.sh build test/test_auth_doctor.exe test/test_auth_login.exe bin/main_eio.exe`
- `./_build/default/test/test_auth_doctor.exe`
- `./_build/default/test/test_auth_login.exe`
- `./_build/default/bin/main_eio.exe login --help`
- `git diff --check HEAD~1..HEAD`