### PR TITLE
fix: preserve verification tasks during claim_next

### DIFF
--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -337,14 +337,14 @@ let claim_next_r
 
       (* BUG-004: Detect and auto-release previous claim to prevent orphaned tasks.
          If this agent already holds a Claimed or InProgress task, release it
-         back to Todo before proceeding. This prevents "claimed but orphaned"
-         tasks that permanently block the backlog. *)
+         back to Todo before proceeding. AwaitingVerification is deliberately
+         excluded: releasing it would drop the verification FSM edge and reopen
+         work before a verifier approve/reject decision. *)
       let previous_claim = List.find_opt (fun (t : Types.task) ->
         match t.task_status with
-        | Claimed { assignee; _ } | InProgress { assignee; _ }
-        | AwaitingVerification { assignee; _ } ->
+        | Claimed { assignee; _ } | InProgress { assignee; _ } ->
             String.equal assignee agent_name
-        | Todo | Done _ | Cancelled _ -> false
+        | Todo | AwaitingVerification _ | Done _ | Cancelled _ -> false
       ) backlog.tasks in
       let observe_auto_release () =
         match previous_claim with

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -631,21 +631,6 @@ type codex_mcp_config_sync_status =
   | Codex_mcp_config_server_missing
   | Codex_mcp_config_header_missing
 
-let escape_toml_basic_string value =
-  let buf = Buffer.create (String.length value) in
-  String.iter
-    (function
-      | '\\' -> Buffer.add_string buf "\\\\"
-      | '"' -> Buffer.add_string buf "\\\""
-      | '\b' -> Buffer.add_string buf "\\b"
-      | '\012' -> Buffer.add_string buf "\\f"
-      | '\n' -> Buffer.add_string buf "\\n"
-      | '\r' -> Buffer.add_string buf "\\r"
-      | '\t' -> Buffer.add_string buf "\\t"
-      | c -> Buffer.add_char buf c)
-    value;
-  Buffer.contents buf
-
 let split_lines_with_trailing_newline content =
   let has_trailing_newline =
     String.length content > 0 && content.[String.length content - 1] = '\n'
@@ -687,18 +672,57 @@ let is_http_headers_binding trimmed =
     | ' ' | '\t' | '=' -> true
     | _ -> false
 
-let sync_codex_mcp_auth_header_content ~raw_token content =
+let is_bearer_token_env_var_binding trimmed =
+  let key = "bearer_token_env_var" in
+  let key_len = String.length key in
+  if String.length trimmed < key_len then
+    false
+  else if not (String.equal (String.sub trimmed 0 key_len) key) then
+    false
+  else
+    match String.get trimmed key_len with
+    | exception Invalid_argument _ -> true
+    | ' ' | '\t' | '=' -> true
+    | _ -> false
+
+let codex_mcp_headers_line indent =
+  Printf.sprintf
+    "%shttp_headers = { \"Accept\" = \"application/json, text/event-stream\", \"X-MASC-Agent\" = \"codex-mcp-client\" }"
+    indent
+
+let codex_mcp_bearer_env_line indent =
+  Printf.sprintf "%sbearer_token_env_var = \"MASC_MCP_TOKEN\"" indent
+
+let sync_codex_mcp_auth_header_content ~raw_token:_ content =
   let lines, has_trailing_newline =
     split_lines_with_trailing_newline content
   in
-  let replacement_line line =
-    Printf.sprintf "%shttp_headers = { Authorization = \"Bearer %s\" }"
-      (leading_indent line)
-      (escape_toml_basic_string raw_token)
+  let add_missing_section_bindings ~seen_header ~seen_bearer_env ~changed acc =
+    let acc, seen_header, changed =
+      if seen_header then
+        (acc, seen_header, changed)
+      else
+        (codex_mcp_headers_line "" :: acc, true, true)
+    in
+    let acc, seen_bearer_env, changed =
+      if seen_bearer_env then
+        (acc, seen_bearer_env, changed)
+      else
+        (codex_mcp_bearer_env_line "" :: acc, true, true)
+    in
+    (acc, seen_header, seen_bearer_env, changed)
   in
-  let rec loop ~in_masc_section ~seen_masc_section ~seen_header ~changed acc =
+  let rec loop ~in_masc_section ~seen_masc_section ~seen_header
+      ~seen_bearer_env ~changed acc =
     function
     | [] ->
+        let acc, seen_header, _seen_bearer_env, changed =
+          if in_masc_section then
+            add_missing_section_bindings ~seen_header ~seen_bearer_env ~changed
+              acc
+          else
+            (acc, seen_header, seen_bearer_env, changed)
+        in
         let status =
           if not seen_masc_section then
             Codex_mcp_config_server_missing
@@ -724,27 +748,44 @@ let sync_codex_mcp_auth_header_content ~raw_token content =
           && is_toml_section_header trimmed
           && not entering_masc_section
         in
+        let acc, seen_header, seen_bearer_env, changed =
+          if leaving_masc_section then
+            add_missing_section_bindings ~seen_header ~seen_bearer_env ~changed
+              acc
+          else
+            (acc, seen_header, seen_bearer_env, changed)
+        in
         let in_masc_section =
           if entering_masc_section then true
           else if leaving_masc_section then false
           else in_masc_section
         in
         let seen_masc_section = seen_masc_section || entering_masc_section in
-        let should_replace =
-          in_masc_section && is_http_headers_binding trimmed
+        let seen_header, seen_bearer_env =
+          if entering_masc_section then (false, false)
+          else (seen_header, seen_bearer_env)
         in
-        let line, seen_header, changed =
-          if should_replace then
-            let next = replacement_line line in
-            (next, true, changed || not (String.equal next line))
+        let line, seen_header, seen_bearer_env, changed =
+          if in_masc_section && is_http_headers_binding trimmed then
+            let next = codex_mcp_headers_line (leading_indent line) in
+            ( next,
+              true,
+              seen_bearer_env,
+              changed || not (String.equal next line) )
+          else if in_masc_section && is_bearer_token_env_var_binding trimmed then
+            let next = codex_mcp_bearer_env_line (leading_indent line) in
+            ( next,
+              seen_header,
+              true,
+              changed || not (String.equal next line) )
           else
-            (line, seen_header, changed)
+            (line, seen_header, seen_bearer_env, changed)
         in
-        loop ~in_masc_section ~seen_masc_section ~seen_header ~changed
-          (line :: acc) rest
+        loop ~in_masc_section ~seen_masc_section ~seen_header
+          ~seen_bearer_env ~changed (line :: acc) rest
   in
   loop ~in_masc_section:false ~seen_masc_section:false ~seen_header:false
-    ~changed:false [] lines
+    ~seen_bearer_env:false ~changed:false [] lines
 
 let codex_config_path_opt () =
   match Sys.getenv_opt codex_config_path_env_key |> Env_config_core.trim_opt with
@@ -789,11 +830,11 @@ let sync_codex_mcp_config ~base_path ~agent_name =
                | Codex_mcp_config_updated ->
                    Auth.save_private_text_file config_path updated;
                    Log.Server.warn
-                     "startup synced Codex MCP bearer header for %s in %s"
+                     "startup synced Codex MCP bearer-token env config for %s in %s"
                      agent_name config_path
                | Codex_mcp_config_unchanged ->
                    Log.Server.info
-                     "startup Codex MCP bearer header already current for %s"
+                     "startup Codex MCP bearer-token env config already current for %s"
                      agent_name
                | Codex_mcp_config_server_missing ->
                    Log.Server.info

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1627,7 +1627,7 @@ let test_main_eio_self_heals_codex_mcp_token_file () =
               Alcotest.failf "repaired raw token should verify: %s"
                 (Types.masc_error_to_string err)))
 
-let test_codex_mcp_config_sync_updates_only_masc_header () =
+let test_codex_mcp_config_sync_updates_only_masc_section () =
   let raw_token = "fresh-\"codex\"\\\\token" in
   let content =
     {|[mcp_servers.other]
@@ -1637,6 +1637,7 @@ http_headers = { Authorization = "Bearer keep-other" }
 url = "http://127.0.0.1:8935/mcp"
 http_headers_extra = "keep-extra"
 http_headers = { Authorization = "Bearer stale" }
+bearer_token_env_var = "OLD_TOKEN"
 
 [mcp_servers.masc.tools.status]
 http_headers = { Authorization = "Bearer nested-should-stay" }
@@ -1649,7 +1650,8 @@ http_headers = { Authorization = "Bearer keep-other" }
 [mcp_servers.masc]
 url = "http://127.0.0.1:8935/mcp"
 http_headers_extra = "keep-extra"
-http_headers = { Authorization = "Bearer fresh-\"codex\"\\\\token" }
+http_headers = { "Accept" = "application/json, text/event-stream", "X-MASC-Agent" = "codex-mcp-client" }
+bearer_token_env_var = "MASC_MCP_TOKEN"
 
 [mcp_servers.masc.tools.status]
 http_headers = { Authorization = "Bearer nested-should-stay" }
@@ -1659,23 +1661,30 @@ http_headers = { Authorization = "Bearer nested-should-stay" }
     Server_runtime_bootstrap.sync_codex_mcp_auth_header_content ~raw_token
       content
   in
-  Alcotest.(check string) "masc header updated" expected updated;
+  Alcotest.(check string) "masc section updated" expected updated;
   Alcotest.(check bool) "reported updated" true
     (status = Server_runtime_bootstrap.Codex_mcp_config_updated)
 
-let test_codex_mcp_config_sync_missing_header_is_noop () =
+let test_codex_mcp_config_sync_missing_header_is_inserted () =
   let content =
     {|[mcp_servers.masc]
 url = "http://127.0.0.1:8935/mcp"
+|}
+  in
+  let expected =
+    {|[mcp_servers.masc]
+url = "http://127.0.0.1:8935/mcp"
+http_headers = { "Accept" = "application/json, text/event-stream", "X-MASC-Agent" = "codex-mcp-client" }
+bearer_token_env_var = "MASC_MCP_TOKEN"
 |}
   in
   let updated, status =
     Server_runtime_bootstrap.sync_codex_mcp_auth_header_content
       ~raw_token:"fresh-token" content
   in
-  Alcotest.(check string) "content unchanged" content updated;
-  Alcotest.(check bool) "reported missing header" true
-    (status = Server_runtime_bootstrap.Codex_mcp_config_header_missing)
+  Alcotest.(check string) "missing config inserted" expected updated;
+  Alcotest.(check bool) "reported updated" true
+    (status = Server_runtime_bootstrap.Codex_mcp_config_updated)
 
 let test_sync_bootable_keeper_credentials_mints_keeper_alias_token () =
   with_temp_dir "startup-keeper-credential-sync" (fun dir ->
@@ -2222,11 +2231,11 @@ let () =
             "main_eio self-heals codex mcp token file"
             `Slow test_main_eio_self_heals_codex_mcp_token_file;
           Alcotest.test_case
-            "codex mcp config sync updates only masc header"
-            `Quick test_codex_mcp_config_sync_updates_only_masc_header;
+            "codex mcp config sync updates only masc section"
+            `Quick test_codex_mcp_config_sync_updates_only_masc_section;
           Alcotest.test_case
-            "codex mcp config sync missing header is noop"
-            `Quick test_codex_mcp_config_sync_missing_header_is_noop;
+            "codex mcp config sync inserts missing bearer env config"
+            `Quick test_codex_mcp_config_sync_missing_header_is_inserted;
           Alcotest.test_case
             "startup sync mints bootable keeper credentials"
             `Quick test_sync_bootable_keeper_credentials_mints_keeper_alias_token;

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -116,6 +116,18 @@ let expect_claim_next_no_eligible result =
       Alcotest.failf "expected claim_next to report no_eligible, got error: %s"
         message
 
+let expect_claim_next_no_unclaimed result =
+  match result with
+  | Coord.Claim_next_no_unclaimed -> ()
+  | Coord.Claim_next_no_eligible _ ->
+      Alcotest.fail "expected claim_next to report no_unclaimed, got no_eligible"
+  | Coord.Claim_next_claimed { task_id; _ } ->
+      Alcotest.failf "expected claim_next to report no_unclaimed, got %s"
+        task_id
+  | Coord.Claim_next_error message ->
+      Alcotest.failf "expected claim_next to report no_unclaimed, got error: %s"
+        message
+
 (* ================================================================ *)
 (* FSM transitions (enabled)                                         *)
 (* ================================================================ *)
@@ -271,9 +283,11 @@ let test_claim_next_skips_pending_verification_tasks () =
       (create_pending_request config ~task_id:task_1 ~worker:"worker"
          ~request_id:"vrf-pending-claim-next");
     Coord.claim_next_r config ~agent_name:"worker" ()
-    |> expect_claim_next_claimed ~task_id:task_2 ~released_task_id:(Some task_1);
+    |> expect_claim_next_claimed ~task_id:task_2 ~released_task_id:None;
+    Alcotest.(check string) "pending task remains awaiting_verification"
+      "awaiting_verification" (status_string config task_1);
     Coord.claim_next_r config ~agent_name:"other" ()
-    |> expect_claim_next_no_eligible)
+    |> expect_claim_next_no_unclaimed)
 
 let test_claim_next_skips_rejected_verification_tasks () =
   with_temp_config ~fsm_enabled:true (fun config ->


### PR DESCRIPTION
Summary
- keep AwaitingVerification tasks out of claim_next auto-release so verifier approve/reject remains the only way out of the verification FSM edge
- align startup Codex MCP config repair with the env-var SSOT: Accept + X-MASC-Agent headers and bearer_token_env_var = MASC_MCP_TOKEN, without rewriting literal Authorization headers
- update regression coverage for pending verification claim_next behavior and Codex config sync repair

Root cause
- claim_next treated AwaitingVerification as a previous owned task and auto-released it to Todo before claiming new work, which could reopen a verification-gated task while an active verification request still existed.
- startup self-heal could flip ~/.codex/config.toml from the mcp-sync env-var shape back to a literal Authorization header, causing Codex-side auth drift and misleading login warnings.

Verification
- MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh build test/test_verification_fsm.exe test/test_server_runtime_bootstrap.exe
- ./_build/default/test/test_verification_fsm.exe
- ./_build/default/test/test_server_runtime_bootstrap.exe test bootstrap 44,45 --color=never
- codex mcp get masc
- codex mcp list
