### PR TITLE
[#10205] perf(boot): fork atomic-orphan sweep into background fiber

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1278,33 +1278,45 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
          atomic-save data loss) are preserved in
          [<base_path>/.recovered/] for forensic inspection.  Always
          runs at boot so each restart publishes fresh cleanup
-         counters. *)
-      (try
-        let deleted, preserved =
-          Fs_compat.cleanup_atomic_orphans ~base_path ()
-        in
-        if deleted > 0 then
-          Prometheus.inc_counter
-            Prometheus.metric_fs_atomic_orphans_cleaned
-            ~labels:[ ("size_class", "empty") ]
-            ~delta:(float_of_int deleted)
-            ();
-        if preserved > 0 then
-          Prometheus.inc_counter
-            Prometheus.metric_fs_atomic_orphans_cleaned
-            ~labels:[ ("size_class", "with_data") ]
-            ~delta:(float_of_int preserved)
-            ();
-        if deleted + preserved > 0 then
-          Log.Server.warn
-            "boot: cleaned %d save_file_atomic orphans (%d empty, \
-             %d preserved with data in .recovered/ — see #10130)"
-            (deleted + preserved) deleted preserved
-       with Eio.Cancel.Cancelled _ as e -> raise e
-          | exn ->
-            Log.Server.error
-              "boot: atomic orphan sweep failed: %s"
-              (Printexc.to_string exn));
+         counters.
+
+         #10205 finding 5: the sweep walks every keeper subdirectory
+         under [base_path] ([Sys.readdir] per directory + [Unix.stat]
+         per orphan candidate).  It does NOT need to gate
+         [install_tooling] or the [Bootstrap completed] log line —
+         the sweep results are advisory diagnostics, not a
+         precondition for serving.  Fork it into a background fiber
+         so the boot hot path completes immediately; the counter
+         and WARN publish asynchronously, which is the right shape
+         for operator dashboards (delta-from-zero, not synchronous
+         readback). *)
+      Eio.Fiber.fork ~sw (fun () ->
+        try
+          let deleted, preserved =
+            Fs_compat.cleanup_atomic_orphans ~base_path ()
+          in
+          if deleted > 0 then
+            Prometheus.inc_counter
+              Prometheus.metric_fs_atomic_orphans_cleaned
+              ~labels:[ ("size_class", "empty") ]
+              ~delta:(float_of_int deleted)
+              ();
+          if preserved > 0 then
+            Prometheus.inc_counter
+              Prometheus.metric_fs_atomic_orphans_cleaned
+              ~labels:[ ("size_class", "with_data") ]
+              ~delta:(float_of_int preserved)
+              ();
+          if deleted + preserved > 0 then
+            Log.Server.warn
+              "boot: cleaned %d save_file_atomic orphans (%d empty, \
+               %d preserved with data in .recovered/ — see #10130)"
+              (deleted + preserved) deleted preserved
+        with Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
+             Log.Server.error
+               "boot: atomic orphan sweep failed: %s"
+               (Printexc.to_string exn));
       (* #9786: audit credential store for shared bearer tokens.
          When two credentials hash to the same token,
          [find_credential_by_token] silently routes to the FIRST


### PR DESCRIPTION
## 요약

#10205 finding #5 — `cleanup_atomic_orphans` 부트 sweep을 background fiber로 분리. 부트 hot path가 sweep walltime만큼 지연되지 않도록.

Closes #10205 finding 5 (#1-4 모두 #10220, #10226에서 PR 또는 머지 진행).

## 근본 원인

`server_runtime_bootstrap.ml:1234-1266`의 sweep은:
- `base_path`의 모든 keeper subdirectory를 walk
- 각 dir에서 `Sys.readdir` + 각 orphan 후보에 `Unix.stat`
- 부트 경로 _안에서_ synchronous 실행 → `Bootstrap completed` log + `install_tooling` 모두 차단

하지만 sweep 결과는:
- `metric_fs_atomic_orphans_cleaned` counter publish (delta-from-zero, 동기 readback 불필요)
- WARN log (정보성)

→ **serving precondition이 아닌 advisory diagnostic**. fork 가능.

## 변경 내용

```diff
-      (try
-        let deleted, preserved =
-          Fs_compat.cleanup_atomic_orphans ~base_path ()
-        in
-        ... counter + WARN ...
-       with Eio.Cancel.Cancelled _ as e -> raise e
-          | exn -> Log.Server.error ...);
+      Eio.Fiber.fork ~sw (fun () ->
+        try
+          let deleted, preserved =
+            Fs_compat.cleanup_atomic_orphans ~base_path ()
+          in
+          ... counter + WARN ...
+        with Eio.Cancel.Cancelled _ as e -> raise e
+           | exn -> Log.Server.error ...);
```

`sw`는 같은 함수 위쪽 (`line 1233`)에서 `Keeper_crash_persistence.start_drain_fiber ~sw ~clock`이 사용 중이므로 in-scope. 동일 switch에서 fork되므로 server shutdown 시 자연 cancel.

## 측정

같은 worktree에서 boot integration 테스트 walltime:

| | walltime | tests |
|---|---|---|
| `main` | 15.191s | 51 |
| 본 PR | 5.774s | 51 |
| 단축 | **−9.4s (62%)** | — |

(이 walltime은 51 testcase 누적 합. 단일 부트당 sweep latency는 분배되어 측정되지만, 차이는 sweep이 critical path에 있었다는 강한 evidence.)

## 회귀 리스크

낮음.

| 시나리오 | 기존 | 본 PR |
|---|---|---|
| Sweep 발화 | 부트 path 동기 | switch에 fork된 fiber, 비동기 |
| Counter publish | 부트 path 내 | fiber 내 (asynchronous) |
| WARN log | 부트 path 내 | fiber 내 |
| 예외 처리 | `try ... with` | `try ... with` (fiber 내) |
| Eio.Cancel | re-raise | re-raise (동일) |
| 다른 boot 작업 | sweep 후 | sweep과 병행 가능 |

부수 효과 가능:
- Sweep과 `install_tooling`이 동시 실행 — 둘은 disjoint 디렉토리 (`base_path/.recovered/` vs tooling state)이므로 race 없음.
- Server shutdown이 sweep 도중 발화 → `Eio.Cancel.Cancelled` re-raise → switch가 자연 정리.

## 의도적으로 유지

`Auth.audit_token_uniqueness` (`#9786`, lines 1267-1296) 호출은 그대로 동기 유지:
- Auth 결과는 dispatcher가 즉시 사용 가능해야 함 (선택적이지만 boot 직후 첫 요청에서 평가).
- finding #5 scope에서 명시적 제외.

## 테스트

```bash
$ dune exec test/test_fs_atomic_orphan_sweep_10130.exe
Test Successful in 0.008s. 8 tests run.

$ dune exec test/test_server_runtime_bootstrap.exe
Test Successful in 5.774s. 51 tests run.
```

## 참고

- Issue #10205 (post-merge /simplify findings)
- `lib/server/server_runtime_bootstrap.ml:1234-1283` — fork된 sweep
- `test/test_server_runtime_bootstrap.ml` — 51/51 unchanged
- 기존 background fiber 패턴: `Keeper_crash_persistence.start_drain_fiber` (같은 file `:1233`)
