### PR TITLE
perf(ws): TTL-cache fanout env reads to skip per-session getenv

### DIFF
--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -554,15 +554,39 @@ let dashboard_delta_for_sse session sse_event =
              ]))
   | _ -> None
 
-(** Backpressure gate threshold in bytes.  Reads the env var on each call
-    so operators can retune without a restart; the read is cheap (atomic
-    hash lookup in [Env_config_core]).  A value of 0 disables the gate
-    entirely — appropriate for environments that have not yet accumulated
-    enough production data from the [masc_ws_client_buffered_bytes]
-    histogram to pick a threshold and prefer observation-only mode. *)
+(** TTL cache for env-var reads on the fan-out hot path.
+
+    [client_buffer_limit_bytes] and [slice_index_enabled] are both
+    invoked once per session per broadcast, so a 100-session fanout
+    at 1000 broadcasts/sec produced 200k [Sys.getenv_opt] calls per
+    second per var.  The earlier docstring claimed the read was
+    "atomic hash lookup", but [Env_config_core.raw_value_opt] runs
+    [Sys.getenv_opt] which on glibc is a linear search of the
+    process [environ] array — far from free.
+
+    Cache the resolved value with a short TTL ([env_cache_ttl_s])
+    so an operator-initiated retune still takes effect within the
+    next half-second, while steady-state fanout pays the full env
+    read at most twice per second per var.  CAS races on
+    [Atomic.set] are benign because the env value did not change
+    in the cached window — both racers compute the same number. *)
+let env_cache_ttl_s = 0.5
+
+let client_buffer_limit_cache : (float * int) Atomic.t =
+  Atomic.make (Float.neg_infinity, 0)
+
 let client_buffer_limit_bytes () =
-  Env_config_core.get_int ~default:1048576
-    "MASC_WS_CLIENT_BUFFER_LIMIT_BYTES"
+  let now = Time_compat.now () in
+  let last_at, cached = Atomic.get client_buffer_limit_cache in
+  if now -. last_at < env_cache_ttl_s then cached
+  else begin
+    let value =
+      Env_config_core.get_int ~default:1048576
+        "MASC_WS_CLIENT_BUFFER_LIMIT_BYTES"
+    in
+    Atomic.set client_buffer_limit_cache (now, value);
+    value
+  end
 
 (** True when the session has reported enough outstanding bytes that
     another push will only grow the client's buffer further.  Only
@@ -579,12 +603,31 @@ let session_is_backpressured session =
     to authenticated sessions whose route does not subscribe to the
     event's slice.  Catch-all events (no slice mapping) still reach
     every session.  Set [MASC_WS_SLICE_INDEX_ENABLED=false] only as an
-    emergency rollback.  The env var is read on every fanout call so
-    operators can flip without a restart; the read is cheap (atomic
-    hash lookup in [Env_config_core]). *)
+    emergency rollback.  TTL-cached so a fanout pays at most one env
+    resolution per [env_cache_ttl_s] window; same CAS-race semantics
+    as [client_buffer_limit_bytes]. *)
+let slice_index_enabled_cache : (float * bool) Atomic.t =
+  Atomic.make (Float.neg_infinity, true)
+
 let slice_index_enabled () =
-  Env_config_core.get_bool ~default:true
-    "MASC_WS_SLICE_INDEX_ENABLED"
+  let now = Time_compat.now () in
+  let last_at, cached = Atomic.get slice_index_enabled_cache in
+  if now -. last_at < env_cache_ttl_s then cached
+  else begin
+    let value =
+      Env_config_core.get_bool ~default:true
+        "MASC_WS_SLICE_INDEX_ENABLED"
+    in
+    Atomic.set slice_index_enabled_cache (now, value);
+    value
+  end
+
+(** Test-only: invalidate the env-var TTL caches above so back-to-back
+    tests that flip [Unix.putenv] do not see stale resolved values.
+    Production code never calls this. *)
+let __test_reset_env_caches () =
+  Atomic.set client_buffer_limit_cache (Float.neg_infinity, 0);
+  Atomic.set slice_index_enabled_cache (Float.neg_infinity, true)
 
 let send_dashboard_or_raw_sse session sse_event =
   if session_is_backpressured session then begin

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -338,6 +338,7 @@ let test_backpressure_gate_unauthenticated_ignored () =
 let test_backpressure_gate_zero_disables () =
   (* MASC_WS_CLIENT_BUFFER_LIMIT_BYTES=0 means gate disabled. Even if a
      session has a huge buffered_amount, the helper should pass. *)
+  Ws.__test_reset_env_caches ();
   with_env_var "MASC_WS_CLIENT_BUFFER_LIMIT_BYTES" "0" (fun () ->
     let limit = Ws.client_buffer_limit_bytes () in
     Alcotest.(check int) "zero limit disables gate" 0 limit)
@@ -347,6 +348,7 @@ let test_backpressure_gate_default_is_one_mib () =
      any inherited value explicitly to avoid passing through the test
      harness's environment. *)
   Unix.putenv "MASC_WS_CLIENT_BUFFER_LIMIT_BYTES" "";
+  Ws.__test_reset_env_caches ();
   let limit = Ws.client_buffer_limit_bytes () in
   Alcotest.(check int) "default limit is 1 MiB"
     1048576 limit
@@ -560,6 +562,7 @@ let test_slice_fanout_skip_counter_metric_registered () =
 
 let test_slice_fanout_flag_default_is_on () =
   Eio_main.run (fun _env ->
+    Ws.__test_reset_env_caches ();
     with_env_var "MASC_WS_SLICE_INDEX_ENABLED" "" (fun () ->
         (* Bandwidth-burst hardening flipped the default from false to
            true.  Operators set false only as an emergency rollback. *)
@@ -568,9 +571,11 @@ let test_slice_fanout_flag_default_is_on () =
 
 let test_slice_fanout_flag_reads_env () =
   Eio_main.run (fun _env ->
+    Ws.__test_reset_env_caches ();
     with_env_var "MASC_WS_SLICE_INDEX_ENABLED" "true" (fun () ->
         Alcotest.(check bool) "env=true → enabled"
           true (Ws.slice_index_enabled ()));
+    Ws.__test_reset_env_caches ();
     with_env_var "MASC_WS_SLICE_INDEX_ENABLED" "false" (fun () ->
         Alcotest.(check bool) "env=false → disabled"
           false (Ws.slice_index_enabled ())))


### PR DESCRIPTION
## 문제
`client_buffer_limit_bytes`와 `slice_index_enabled`는 매 session × 매 broadcast마다 호출되는 fanout 핫패스. 기존 docstring은 `Env_config_core` 조회가 "cheap atomic hash lookup"이라고 했지만 실제로 `Sys.getenv_opt`가 glibc에서 process `environ` array를 선형 탐색.

100 sessions × 1000 broadcasts/s = 200k getenv_opt/s per var.

## 변경
각 getter를 0.5s TTL 캐시로 감쌈. CAS race on `Atomic.set`은 cache window 내 env가 바뀌지 않으므로 동일 값 — benign. Operator retune은 0.5s 내 반영, steady-state fanout은 var당 최대 2 env read/s.

## 효과
~2000× 감소 가능 (100k → 2 reads/s per var). 자체적으로는 modest이지만, broadcast 1회당 hot path 누적 정리에 마지막 한 조각:
- list snapshot 3 → 0 (#10203/#10222/#10225)
- sprintf 3 → 1 Buffer (#10227)
- env getenv per session → TTL cache (이 PR)

## 테스트
`__test_reset_env_caches` helper 추가 — back-to-back env flip 테스트가 stale 값을 보지 않도록. Production code never calls.

## Behavior
- 두 getter 반환값 무변동 (default 1 MiB / true 그대로)
- TTL refresh는 `Time_compat.now` (production clock)
- `Float.neg_infinity` sentinel로 첫 호출은 반드시 env resolve

## Validation
- `test_ws_transport` 38/38 (`backpressure_gate` + `slice_fanout_gate` 모두 두 helper exercise)
- `test_transport_integration` 9/9