### PR TITLE
fix(dated-jsonl): remove tail trim List.tl regression

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -148,7 +148,11 @@ let load_tail_lines path ~max_lines =
           |> String.split_on_char '\n'
         in
         let raw_lines =
-          if !pos > 0 && raw_lines <> [] then List.tl raw_lines else raw_lines
+          if !pos > 0 then
+            match raw_lines with
+            | _partial :: rest -> rest
+            | [] -> []
+          else raw_lines
         in
         let all_lines =
           raw_lines

--- a/test/test_dated_jsonl.ml
+++ b/test/test_dated_jsonl.ml
@@ -104,7 +104,7 @@ let test_load_tail_lines_keeps_first_data_after_blank_prefix () =
     ^ "\n"
   in
   Fs_compat.append_file path content;
-  let lines = Dated_jsonl.load_tail_lines path ~max_lines:10 in
+  let lines = Dated_jsonl.load_tail_lines path ~max_lines:5 in
   check (list string) "keeps first data row after blank partial prefix" expected lines
 
 (* ── read_recent_lines returns raw strings ─────────────── *)


### PR DESCRIPTION
## Summary
- replace the #10223 tail-prefix trim List.tl with explicit pattern matching
- keep the blank-prefix regression test focused on the intended 5-line tail window

## Verification
- git diff --check origin/main...HEAD
- scripts/dune-local.sh build test/test_dated_jsonl.exe
- ./_build/default/test/test_dated_jsonl.exe
- bash scripts/health_snapshot.sh --json-out /tmp/health-10223.json --baseline-ref origin/main --fail-on-lib-regression