### PR TITLE
fix(dashboard): count keeper masc tools from schema SSOT

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -1430,9 +1430,8 @@ let keeper_config_json (config : Coord.config) (name : string)
       in
       let tools_access =
         let allowed = Keeper_exec_tools.keeper_allowed_tool_names m in
-        let masc_tools =
-          allowed
-          |> List.filter (fun n -> String.starts_with ~prefix:"masc_" n)
+        let masc_tool_count =
+          List.length (Keeper_exec_tools.keeper_masc_tool_names m)
         in
         let tool_preset = Keeper_types.tool_access_preset m.tool_access in
         let tool_also_allow = Keeper_types.tool_access_also_allowlist m.tool_access in
@@ -1459,9 +1458,9 @@ let keeper_config_json (config : Coord.config) (name : string)
                  (Option.value ~default:[] custom_allowlist)));
           ("resolved_allowlist", `List (List.map (fun s -> `String s) allowed));
           ("tool_denylist", `List (List.map (fun s -> `String s) m.tool_denylist));
-          ("active_masc_tool_count", `Int (List.length masc_tools));
+          ("active_masc_tool_count", `Int masc_tool_count);
           ("active_keeper_tool_count",
-            `Int (List.length allowed - List.length masc_tools));
+            `Int (List.length allowed - masc_tool_count));
           ("total_active", `Int (List.length allowed));
         ]
       in

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -100,10 +100,7 @@ let merge_keeper_trace_lines ~(config : Coord.config) ~(trace_id : string)
 
 let keeper_tools_response_json (meta : Keeper_types.keeper_meta) =
   let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
-  let masc_count =
-    List.length
-      (List.filter (fun name -> String.starts_with ~prefix:"masc_" name) allowed)
-  in
+  let masc_count = List.length (Keeper_exec_tools.keeper_masc_tool_names meta) in
   let tool_preset = Keeper_types.tool_access_preset meta.tool_access in
   let tool_also_allow = Keeper_types.tool_access_also_allowlist meta.tool_access in
   let tool_custom_allowlist =

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -242,6 +242,37 @@ let test_custom_keeps_registered_inline_board_tool () =
   Alcotest.(check bool) "drops unsupported inline tool" false
     (List.mem "masc_who" names)
 
+let with_masc_schema_ref schemas f =
+  let previous = !(KET.masc_schemas_ref) in
+  Fun.protect
+    ~finally:(fun () -> KET.masc_schemas_ref := previous)
+    (fun () ->
+      KET.masc_schemas_ref := schemas;
+      f ())
+
+let test_dashboard_tool_count_uses_schema_ssot () =
+  let bridge_name = "mcp__masc__masc_status" in
+  let schema : Types.tool_schema =
+    { name = bridge_name; description = ""; input_schema = `Assoc [] }
+  in
+  with_masc_schema_ref [ schema ] (fun () ->
+      let meta =
+        make_meta
+          ~tool_access:
+            (Masc_mcp.Keeper_types.Custom [ bridge_name ])
+          ()
+      in
+      let allowed = KET.keeper_allowed_tool_names meta in
+      Alcotest.(check bool) "schema bridge is allowed" true
+        (List.mem bridge_name allowed);
+      let json =
+        Masc_mcp.Server_dashboard_http_keeper_api.keeper_tools_response_json meta
+      in
+      let count =
+        Yojson.Safe.Util.(json |> member "active_masc_tool_count" |> to_int)
+      in
+      Alcotest.(check int) "dashboard counts schema-derived masc tools" 1 count)
+
 let test_tool_access_missing_migrates_legacy_standard_policy () =
   let names =
     allowed_names_of_json
@@ -700,6 +731,8 @@ let () =
             test_preset_with_also_allow_opens_extra_tool;
           Alcotest.test_case "custom filters board tools with keeper wrappers" `Quick
             test_custom_keeps_registered_inline_board_tool;
+          Alcotest.test_case "dashboard count uses schema SSOT" `Quick
+            test_dashboard_tool_count_uses_schema_ssot;
         ] );
       ( "custom_policy",
         [


### PR DESCRIPTION
Summary
- Replace dashboard active_masc_tool_count prefix filtering with Keeper_exec_tools.keeper_masc_tool_names.
- Apply the same schema/policy-derived count to the legacy keeper config JSON path.
- Add a regression guard proving dashboard counts follow the injected schema SSOT, not a hardcoded name prefix.

Verification
- git diff --check origin/main..HEAD
- rg -n "List\\.tl" lib --glob "*.ml" --glob "*.mli" (no matches)
- env DUNE_BUILD_DIR=_build_verify_dashboard_tool_count DUNE_JOBS=2 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_masc_bridge.exe
- ./_build_verify_dashboard_tool_count/default/test/test_keeper_masc_bridge.exe
- env DUNE_BUILD_DIR=_build_verify_health_10235 DUNE_JOBS=2 DUNE_CACHE=disabled bash scripts/health_snapshot.sh --json-out /tmp/masc-health-10235.json --baseline-file .ci/health-baseline.json --fail-on-lib-regression

Health note
- Latest main already carries the Dated_jsonl List.tl repair; this branch rebases on that fix.
- Local Health reports Ratchet: pass (no lib regressions) and Unsafe patterns (lib) list_tl=0.
- The ML line-cap audit still prints the existing manual_ml_over_500 baseline mismatch, but this run was gated with --fail-on-lib-regression and exited 0.