### PR TITLE
fix(keeper-supervisor): migrate resume + dead-tombstone write_meta to merged-CAS retry (#9733)

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -301,8 +301,24 @@ let resume_keeper_after_reconcile_gate (ctx : _ context) (meta : keeper_meta) =
         };
     }
   in
-  (match write_meta ctx.config resumed_meta with
+  (* #9733: same race shape as keeper_msg/overflow-pause/sync paths
+     already migrated by #10135 / #10145.  The supervisor reconcile
+     fiber clears [paused] and [runtime.last_blocker] (cycle-owned
+     fields); a heartbeat fiber bumping [joined_room_ids] /
+     [last_seen_seq_by_room] in parallel can still steal the CAS
+     write and silently leave the keeper paused while
+     [Keeper_registry.update_meta] applies the resume in-memory —
+     a registry/disk split that hides the failure. *)
+  (match
+     write_meta_with_merge
+       ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+       ctx.config resumed_meta
+   with
    | Ok () -> ()
+   | Error err when is_version_conflict_error err ->
+       Log.Keeper.warn
+         "%s: reconcile gate resume write_meta lost CAS race after retries: %s"
+         resumed_meta.name err
    | Error err ->
        Log.Keeper.error
          "%s: reconcile gate resume write_meta failed: %s"
@@ -436,8 +452,24 @@ let cleanup_dead_tombstone (ctx : _ context)
       let persisted_paused =
         if meta.paused then true
         else
-          match write_meta ctx.config { meta with paused = true } with
+          (* #9733: dead tombstone cleanup writes [paused = true] —
+             cycle-owned field — while heartbeat fibers can still
+             update the same record's heartbeat-owned fields.  Use
+             the same merged-CAS retry as the resume + overflow-pause
+             paths so a parallel heartbeat write doesn't make this
+             write fail and leave the keeper unpaused on disk while
+             the supervisor proceeds to unregister it. *)
+          match
+            write_meta_with_merge
+              ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+              ctx.config { meta with paused = true }
+          with
           | Ok () -> true
+          | Error err when is_version_conflict_error err ->
+              Log.Keeper.warn
+                "%s: dead tombstone cleanup paused write lost CAS race after retries: %s"
+                entry.name err;
+              false
           | Error err ->
               Log.Keeper.warn
                 "%s: dead tombstone cleanup paused write failed: %s"


### PR DESCRIPTION
## Summary

#9733 follow-up to PRs #10135 (keeper_msg) and #10145 (overflow-pause + sync_paused_state).  Two more bare \`write_meta\` sites in \`keeper_supervisor.ml\`:

| site | risk if CAS lost |
|---|---|
| \`resume_keeper_after_reconcile_gate:304\` | supervisor decides to resume; bare write fails silently → disk says still paused while registry says resumed → registry/disk split |
| \`cleanup_dead_tombstone:439\` | supervisor writes \`paused = true\` before unregistering a dead keeper; lost CAS leaves the keeper "alive but unpaused" on disk |

Both migrate to the now-standard pattern:

\`\`\`ocaml
write_meta_with_merge
  ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
\`\`\`

## Field-ownership contract (same as 5 prior sites)

| field class | owner | examples |
|---|---|---|
| **cycle-owned** (caller wins) | supervisor reconcile / cleanup fiber | \`paused\`, \`runtime.last_blocker\`, \`updated_at\` |
| **heartbeat-owned** (disk wins) | heartbeat fiber | \`meta_version\`, \`joined_room_ids\`, \`last_seen_seq_by_room\` |

## Existing migrations (reference patterns)

| caller | line |
|---|---|
| turn-failure path (#9769) | \`keeper_unified_turn.ml:1683\` |
| second turn-failure path | \`keeper_unified_turn.ml:2088\` |
| create_keeper | \`keeper_turn_up_create.ml:25\` |
| keeper_msg turn (#10135) | \`keeper_turn.ml:467\` |
| overflow_pause (#10145) | \`keeper_unified_turn.ml:509\` |
| pause/resume sync (#10145) | \`keeper_unified_turn.ml:549\` |
| **resume reconcile gate (this PR)** | **\`keeper_supervisor.ml:304\`** |
| **dead tombstone cleanup (this PR)** | **\`keeper_supervisor.ml:439\`** |

## Tests

Existing \`test_keeper_paused_cas_retain_9733\` (PR #10145 MERGED) and \`test_keeper_meta_heartbeat_retain_9733\` (PR #10135 MERGED) pin the merge contract.  This PR adds two new callers to the same contract; the contract IS the test.  Duplicating the merge-contract scenario per caller would be noise without coverage gain.

- [x] \`dune build --root . lib/\` clean

## Sites still surveyed but NOT migrated

| site | reason |
|---|---|
| \`keeper_supervisor.ml:263\` (presence sync) | writes \`joined_room_ids\` — that's HEARTBEAT-owned, so \`heartbeat_fields_from_disk\` is the WRONG merge here. Needs a separate "supervisor-owns-presence" merge function. |
| \`keeper_turn_up_update.ml:292\` | per-site review pending |
| \`keeper_turn_lifecycle.ml:42\` (keeper_down) | per-site review pending |

## Refs

- #9733 (root)
- PR #10135 (keeper_msg, MERGED)
- PR #10145 (overflow-pause + sync, MERGED)
- #9769 (introduced \`write_meta_with_merge\`)

## Do-not-merge

\`do-not-merge\` label set so the auto-merge pipeline does not flip this Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)