### PR TITLE
[#9571] refactor(paths): SSOT masc_dirname via Common helper (batch 1 of N)

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -21,7 +21,8 @@ let sha256_hash input =
 (* Auth directory management                    *)
 (* ============================================ *)
 
-let auth_dir config = Filename.concat config ".masc/auth"
+let auth_dir config =
+  Filename.concat (Common.masc_dir_from_base_path ~base_path:config) "auth"
 let agents_dir config = Filename.concat (auth_dir config) "agents"
 let room_secret_file config = Filename.concat (auth_dir config) "room_secret.hash"
 let auth_config_file config = Filename.concat (auth_dir config) "config.json"

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -23,7 +23,9 @@ let vote_direction_of_string_opt raw =
 
 let vote_log_path () =
   let base = board_base_path () in
-  Filename.concat base ".masc/board_votes.jsonl"
+  Filename.concat
+    (Common.masc_dir_from_base_path ~base_path:base)
+    "board_votes.jsonl"
 
 (* #10086: [ts] is the cast timestamp supplied by the caller.  Both
    the append (line-append on cast) and the rewrite (atomic flush

--- a/lib/discovery_history.ml
+++ b/lib/discovery_history.ml
@@ -14,7 +14,11 @@ let get_or_create_store ~base_path : Dated_jsonl.t =
   match !store_ref with
   | Some (cached_path, s) when String.equal cached_path base_path -> s
   | _ ->
-    let dir = Filename.concat base_path ".masc/discovery" in
+    let dir =
+      Filename.concat
+        (Common.masc_dir_from_base_path ~base_path)
+        "discovery"
+    in
     let s = Dated_jsonl.create ~base_dir:dir () in
     store_ref := Some (base_path, s);
     s

--- a/lib/handover_eio.ml
+++ b/lib/handover_eio.ml
@@ -136,8 +136,9 @@ let handover_of_json (json : Yojson.Safe.t) : handover_record option =
 
 (** Storage paths *)
 let handover_dir_path (config : Coord_utils.config) =
-  let path = Filename.concat config.base_path ".masc/handovers" in
-  path
+  Filename.concat
+    (Common.masc_dir_from_base_path ~base_path:config.base_path)
+    "handovers"
 
 let handover_file_path config handover_id =
   Filename.concat (handover_dir_path config) (handover_id ^ ".json")

--- a/lib/hebbian_eio.ml
+++ b/lib/hebbian_eio.ml
@@ -76,7 +76,10 @@ let default_params () = {
 
 (** Get synapses file path *)
 let synapses_file (config : config) =
-  Filename.concat config.Coord_utils.base_path ".masc/synapses/graph.json"
+  Filename.concat
+    (Common.masc_dir_from_base_path
+       ~base_path:config.Coord_utils.base_path)
+    "synapses/graph.json"
 
 (** Get lock file path *)
 let synapses_lock_file (config : config) =

--- a/lib/institution_eio.ml
+++ b/lib/institution_eio.ml
@@ -626,7 +626,9 @@ let load_and_format_for_welcome ~fs:_ (config : config) : string =
     Storage: .masc/institution_episodes.jsonl *)
 
 let episodes_jsonl_path () =
-  Filename.concat (Env_config.base_path ()) ".masc/institution_episodes.jsonl"
+  Filename.concat
+    (Common.masc_dir_from_base_path ~base_path:(Env_config.base_path ()))
+    "institution_episodes.jsonl"
 
 (** Record an episode to JSONL without Eio context.
     This is the primary entry point for Keeper autonomy integration. *)

--- a/lib/repo_synthesis_benchmark.ml
+++ b/lib/repo_synthesis_benchmark.ml
@@ -70,7 +70,9 @@ type run_record = {
 }
 
 let bench_root ~base_path =
-  Filename.concat base_path ".masc/repo-synthesis-benchmarks"
+  Filename.concat
+    (Common.masc_dir_from_base_path ~base_path)
+    "repo-synthesis-benchmarks"
 
 let contains_substring = String_util.contains_substring
 

--- a/lib/tool_blob_store/tool_blob_store.ml
+++ b/lib/tool_blob_store/tool_blob_store.ml
@@ -18,7 +18,12 @@ let make_preview bytes =
   Buffer.contents buf
 
 let create ~base_path =
-  { root = Filename.concat base_path ".masc/tool_blobs" }
+  {
+    root =
+      Filename.concat
+        (Common.masc_dir_from_base_path ~base_path)
+        "tool_blobs";
+  }
 
 let root_dir t = t.root
 

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -950,6 +950,38 @@ let test_runtime_precondition_contracts () =
      remaining routes do not need server state guard. *)
   ()
 
+(* #9571: MASC dirname SSOT — every runtime path that lives under
+   [base_path/.masc/...] must go through [Common.masc_dir_from_base_path]
+   instead of inlining the literal [".masc/<sub>"].  These contracts
+   cover the first migration batch (issue triage 2026-04-25); a future
+   PR can extend them as remaining call sites are migrated.
+
+   Each entry asserts: the migrated file uses the helper AND no
+   longer contains the inlined literal.  Either side regressing breaks
+   the SSOT and this test catches it before merge. *)
+let test_masc_dirname_ssot_contracts () =
+  let migrated_files = [
+    "lib/auth.ml";
+    "lib/board_votes.ml";
+    "lib/discovery_history.ml";
+    "lib/handover_eio.ml";
+    "lib/hebbian_eio.ml";
+    "lib/institution_eio.ml";
+    "lib/repo_synthesis_benchmark.ml";
+    "lib/tool_blob_store/tool_blob_store.ml";
+  ] in
+  List.iter
+    (fun file ->
+       check bool
+         (Printf.sprintf "%s uses Common.masc_dir_from_base_path" file)
+         true
+         (file_contains_pattern file "Common.masc_dir_from_base_path");
+       check bool
+         (Printf.sprintf "%s no longer inlines \".masc/\"" file)
+         true
+         (file_not_contains_pattern file "\".masc/"))
+    migrated_files
+
 let () =
   run "ci_hardening_source"
     [
@@ -1009,5 +1041,7 @@ let () =
              test_runtime_precondition_contracts;
            test_case "router contract alignment" `Quick
              test_router_contract_alignment;
+           test_case "masc_dirname SSOT contracts (#9571 batch 1)" `Quick
+             test_masc_dirname_ssot_contracts;
          ]);
     ]


### PR DESCRIPTION
## 요약

#9571 SSOT drift — `lib/core/common.ml`의 `Common.masc_dirname` (".masc") + `Common.masc_dir_from_base_path` helper가 `#8355` 이후 노출되어 있지만 ~20개 사이트가 여전히 `Filename.concat <base> ".masc/<sub>"` 또는 `Printf.sprintf "%s/.masc/..."`로 inline. 디렉토리 rename이나 typo가 SSOT와 silent 분기.

8개 high-traffic 사이트 마이그레이션 + source-guard regression test. **Batch 1 of N** — 다음 PR에서 나머지 사이트 확장 가능.

Closes part of #9571.

## 마이그레이션 (8 files)

| 파일 | 함수 | 역할 |
|------|------|------|
| `lib/auth.ml:24` | `auth_dir` | room secret/agents/config root |
| `lib/board_votes.ml:24-27` | `vote_log_path` | board votes JSONL |
| `lib/discovery_history.ml:17` | per-base-path store | discovery JSONL store |
| `lib/handover_eio.ml:138-140` | `handover_dir_path` | handover JSON dir |
| `lib/hebbian_eio.ml:78-79` | `synapses_file` | hebbian synapses graph |
| `lib/institution_eio.ml:628-629` | `episodes_jsonl_path` | episode JSONL |
| `lib/repo_synthesis_benchmark.ml:72-73` | `bench_root` | benchmark root |
| `lib/tool_blob_store/tool_blob_store.ml:20-21` | `create` | blob store root |

각 site 변경 패턴:

```diff
-Filename.concat config ".masc/auth"
+Filename.concat
+  (Common.masc_dir_from_base_path ~base_path:config) "auth"
```

행동 동일. `Common.masc_dirname` rename이 일어나면 모든 8 사이트가 한 번에 따라가도록 lock.

## 회귀 가드

`test/test_ci_hardening_source.ml`에 새 source guard:

```ocaml
let migrated_files = [
  "lib/auth.ml"; ...8 files...
] in
List.iter (fun file ->
  check bool (... "uses Common.masc_dir_from_base_path") true
    (file_contains_pattern file "Common.masc_dir_from_base_path");
  check bool (... "no longer inlines \".masc/\"") true
    (file_not_contains_pattern file "\".masc/"))
  migrated_files
```

각 파일에 대해 (a) helper 사용 + (b) literal 부재 둘 다 검사. 누군가 한 site를 재-inline해도 즉시 fail.

## 테스트

```bash
$ dune exec test/test_ci_hardening_source.exe       → 36/36 pass (35→36)
$ dune exec test/test_auth.exe                      → 41/41 pass
$ dune exec test/test_handover_eio_coverage.exe     → 29/29 pass
$ dune exec test/test_hebbian_eio.exe               → 15/15 pass
```

행동 변화 없음.

## 회귀 리스크

매우 낮음.
- 모든 사이트에서 `Common.masc_dir_from_base_path ~base_path:X = Filename.concat X ".masc"`. 즉 `Filename.concat (helper_X) "Y" = Filename.concat (Filename.concat X ".masc") "Y" = Filename.concat X ".masc/Y"`. 동일 path 결과.
- `Common.masc_dir_from_base_path`는 `lib/core/common.ml`에 정의, 모든 마이그레이션 파일이 의존하는 `masc_core` 라이브러리에 포함.
- mli 변경 없음.

## 후속 (남은 사이트)

이번 PR에서 다루지 않은 ~12 사이트 (다음 PR 후보):

- `lib/config_dir_resolver.ml:211, 228` (`home + ".masc/config"`)
- `lib/exec_core.ml:513` (`Printf.sprintf ".masc/exec-artifacts/..."`)
- `lib/tool_team_memory.ml:108` (`Printf.sprintf ".masc/shared/rooms/..."`)
- `lib/oas_worker_cascade.ml:435` (`".masc/cascade_audit"`)
- `lib/mcp_server_eio_resource.ml:150, 163` (`".masc/institution.json"`)
- `lib/server/server_routes_http_routes_dashboard.ml:100, 103` (`".masc/auth/dashboard.token"`)
- `lib/procedural_memory.ml:35` (`Printf.sprintf "%s/.masc/procedures/%s"`)
- `bin/masc_compaction_audit.ml`, `bin/masc_cost.ml`, `bin/masc_tui_loader.ml` (bin/ subset)

`Printf.sprintf` 케이스는 helper가 아닌 새로운 패턴 helper (`masc_subdir_from_base_path`)이 더 깔끔할 수 있음 — batch 2에서 검토.

## 참고

- Issue #9571 (SSOT drift)
- `lib/core/common.ml:37-40` — SSOT definition + helper
- `test/test_ci_hardening_source.ml:953-981` — regression guard
