### PR TITLE
perf(sse): drop O(N) SMap.cardinal in unregister + unregister_if_current

### DIFF
--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -356,10 +356,17 @@ let unregister session_id =
     Lockfree_atomic.update_with_commit clients (fun state ->
       if SMap.mem session_id state.entries then
         let next_entries = SMap.remove session_id state.entries in
+        (* [state.count] is the authoritative cardinality maintained
+           by every other [update_with_commit] in this module, so
+           re-walking [next_entries] with [SMap.cardinal] (O(N) for
+           [Stdlib.Map]) is wasted work.  Slow-client storms that
+           fire [unregister] for each dropped session in
+           [broadcast_impl]'s failed list paid this O(N) cost per
+           call: N dropped × O(N) sweep = O(N²). *)
         {
           next_state = {
             entries = next_entries;
-            count = SMap.cardinal next_entries;
+            count = state.count - 1;
           };
           result = true;
         }
@@ -381,10 +388,12 @@ let unregister_if_current session_id client_id =
       match SMap.find_opt session_id state.entries with
       | Some client when client.id = client_id ->
           let next_entries = SMap.remove session_id state.entries in
+          (* Same rationale as [unregister]: state.count is
+             authoritative, [SMap.cardinal] is O(N) and unnecessary. *)
           {
             next_state = {
               entries = next_entries;
-              count = SMap.cardinal next_entries;
+              count = state.count - 1;
             };
             result = true;
           }

--- a/test/test_sse_coverage.ml
+++ b/test/test_sse_coverage.ml
@@ -169,6 +169,49 @@ let test_client_count_increments () =
   Sse.unregister session_id;
   check bool "incremented" true (after > before || after = before)
 
+let test_client_count_exact_unregister_decrement () =
+  let before = Sse.client_count () in
+  let session1 = "test_count_exact_1_" ^ string_of_int (Random.bits ()) in
+  let session2 = "test_count_exact_2_" ^ string_of_int (Random.bits ()) in
+  Fun.protect
+    ~finally:(fun () ->
+      Sse.unregister session1;
+      Sse.unregister session2)
+    (fun () ->
+      let (_id1, _, _) = Sse.register session1 ~last_event_id:0 in
+      let (_id2, _, _) = Sse.register session2 ~last_event_id:0 in
+      check int "two registrations increment count by two"
+        (before + 2) (Sse.client_count ());
+      Sse.unregister session1;
+      check int "first unregister decrements count by one"
+        (before + 1) (Sse.client_count ());
+      Sse.unregister session2;
+      check int "second unregister restores original count"
+        before (Sse.client_count ()))
+
+let test_unregister_if_current_replacement_count () =
+  let before = Sse.client_count () in
+  let session_id =
+    "test_unreg_replacement_" ^ string_of_int (Random.bits ())
+  in
+  Fun.protect
+    ~finally:(fun () -> Sse.unregister session_id)
+    (fun () ->
+      let (old_client_id, _, _) = Sse.register session_id ~last_event_id:0 in
+      let (new_client_id, _, _) = Sse.register session_id ~last_event_id:0 in
+      check int "replacement keeps one live session"
+        (before + 1) (Sse.client_count ());
+      Sse.unregister_if_current session_id old_client_id;
+      check bool "old cleanup cannot remove replacement"
+        true (Sse.exists session_id);
+      check int "stale cleanup leaves count unchanged"
+        (before + 1) (Sse.client_count ());
+      Sse.unregister_if_current session_id new_client_id;
+      check bool "current cleanup removes replacement"
+        false (Sse.exists session_id);
+      check int "current cleanup restores original count"
+        before (Sse.client_count ()))
+
 (* ============================================================
    buffer_event / get_events_after Tests
    ============================================================ *)
@@ -371,6 +414,8 @@ let () =
       test_case "matches" `Quick test_unregister_if_current_matches;
       test_case "no match" `Quick test_unregister_if_current_no_match;
       test_case "nonexistent" `Quick test_unregister_if_current_nonexistent;
+      test_case "replacement count invariant" `Quick
+        test_unregister_if_current_replacement_count;
     ];
     "update_last_event_id", [
       test_case "exists" `Quick test_update_last_event_id_exists;
@@ -379,6 +424,8 @@ let () =
     "client_count", [
       test_case "nonnegative" `Quick test_client_count_nonnegative;
       test_case "increments" `Quick test_client_count_increments;
+      test_case "unregister decrements exactly" `Quick
+        test_client_count_exact_unregister_decrement;
     ];
     "event_buffer", [
       test_case "buffer and retrieve" `Quick test_buffer_event_and_retrieve;


### PR DESCRIPTION
## 문제
`unregister`/`unregister_if_current`이 commit 시 `count = SMap.cardinal next_entries`로 카드ality 재계산. `Stdlib.Map.cardinal`은 트리 walk = O(N) (size 미캐시).

state record가 `count`를 invariant로 유지하므로 1개 제거 시 `state.count - 1`로 충분 — cardinal walk 불필요.

## 효과
broadcast slow-client storms에서 누적: `broadcast_impl`이 `failed` list (event_stream full or Eio.Stream.add 예외 세션)에 unregister를 N번 호출 → N × O(N) = **O(N²)**. #10222 (broadcast_impl SMap.iter)로 fan-out이 단일 패스가 된 후 unregister O(N²)이 그 path의 다음 가시 비용.

## Behavior
- count 값 동일 (state.count는 cardinal이 계산할 동일 invariant)
- CAS retry: state 재읽기 시 entries와 count가 lockstep
- "client not present" 분기 무변동
- post-commit `sync_transport_snapshot` trigger 그대로

## Validation
- `test_sse` 4/4 — concurrency: `client_count linearized under register/unregister` 테스트가 contention 하에서 count 일관성 검증
- `test_sse_coverage` 32/32 (register/unregister/broadcast 경로 커버)