### PR TITLE
[#9587] fix(coord): make git fetch timeout configurable, raise default to 120s

### DIFF
--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -454,9 +454,8 @@ let tool_auth_strict () =
 (** [git fetch origin] before worktree creation is network-bound and
     can stall behind a slow Docker bridge or a large remote.  The
     previous hardcoded 30s budget at [coord_worktree.run_argv_exit]
-    rejected legitimately slow fetches inside the keeper sandbox
-    (#9587) — observed at [/Users/dancer/me/.masc/playground/docker/
-    masc-improver/repos/masc-mcp]).  Default 120s gives enough
+    rejected legitimately slow fetches inside a Docker keeper
+    playground clone (#9587).  Default 120s gives enough
     headroom for a cold fetch on a non-trivial repo while still
     bounding hung connections.  Operators can override via
     [MASC_GIT_FETCH_TIMEOUT_SEC] when running on faster networks

--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -449,6 +449,26 @@ let admin_token_opt () =
 let tool_auth_strict () =
   get_bool ~default:true tool_auth_strict_env_key
 
+(** {1 Git operations} *)
+
+(** [git fetch origin] before worktree creation is network-bound and
+    can stall behind a slow Docker bridge or a large remote.  The
+    previous hardcoded 30s budget at [coord_worktree.run_argv_exit]
+    rejected legitimately slow fetches inside the keeper sandbox
+    (#9587) — observed at [/Users/dancer/me/.masc/playground/docker/
+    masc-improver/repos/masc-mcp]).  Default 120s gives enough
+    headroom for a cold fetch on a non-trivial repo while still
+    bounding hung connections.  Operators can override via
+    [MASC_GIT_FETCH_TIMEOUT_SEC] when running on faster networks
+    (e.g. 60s in CI) or slower ones (e.g. 300s on a constrained
+    laptop tether).  Floor 10s prevents a footgun setting like
+    [0] from disabling the cap entirely. *)
+let git_fetch_timeout_sec_env_key = "MASC_GIT_FETCH_TIMEOUT_SEC"
+
+let git_fetch_timeout_sec () =
+  Float.max 10.0
+    (get_float ~default:120.0 git_fetch_timeout_sec_env_key)
+
 (** {1 Logging / Telemetry} *)
 
 (** SSOT for logging / observability env-var names (issue 8352). *)

--- a/lib/coord/coord_git.ml
+++ b/lib/coord/coord_git.ml
@@ -27,14 +27,17 @@ let run_argv_line (argv : string list) : string option =
   | [] -> None
   | h :: _ -> Some h
 
-(** Run argv and return exit code. *)
-let run_argv_exit (argv : string list) : int =
+(** Run argv and return exit code.
+    [timeout_sec] defaults to 30s for local-only operations.  Network-
+    bound commands (git fetch / push) should pass an explicit longer
+    budget — see {!Env_config_core.git_fetch_timeout_sec}. *)
+let run_argv_exit ?(timeout_sec = 30.0) (argv : string list) : int =
   match
     Masc_exec.Exec_gate.run_argv_with_status
       ~actor:"coord/git"
       ~raw_source:(exec_gate_raw_source argv)
       ~summary:"coord_git argv"
-      ~timeout_sec:30.0
+      ~timeout_sec
       argv
   with
   | Unix.WEXITED n, _ -> n
@@ -179,8 +182,15 @@ let create ~base_path ~agent_name ~task_id ~base_branch : string masc_result =
             (Printf.sprintf "✅ Worktree already exists:\n  Path: %s\n  Branch: %s\n\nNext: cd %s"
                worktree_path branch_name worktree_path)
         else (
-          (* Fetch origin first; never create from a silently stale remote ref. *)
-          let fetch_exit = run_argv_exit ["git"; "-C"; root; "fetch"; "origin"] in
+          (* Fetch origin first; never create from a silently stale remote ref.
+             Use the longer git_fetch_timeout_sec budget — the default
+             30s rejected legitimately slow Docker-bridge fetches and
+             cold fetches on large remotes (#9587). *)
+          let fetch_exit =
+            run_argv_exit
+              ~timeout_sec:(Env_config_core.git_fetch_timeout_sec ())
+              ["git"; "-C"; root; "fetch"; "origin"]
+          in
           if fetch_exit <> 0 then
             Error (IoError "Failed to fetch origin before worktree creation.")
           else match resolve_base_branch root base_branch with

--- a/lib/coord/coord_worktree.ml
+++ b/lib/coord/coord_worktree.ml
@@ -23,18 +23,22 @@ let run_argv_lines argv =
   |> String.split_on_char '\n'
   |> List.filter (fun s -> s <> "")
 
-(** Run argv and get process status + combined output. *)
-let run_argv_with_status argv =
+(** Run argv and get process status + combined output.
+    [timeout_sec] defaults to the short 30s window appropriate for
+    local-only git operations (status, branch, rev-parse).  Network-
+    bound operations like [git fetch origin] should pass an explicit
+    longer budget — see {!Env_config.git_fetch_timeout_sec}. *)
+let run_argv_with_status ?(timeout_sec = 30.0) argv =
   Masc_exec.Exec_gate.run_argv_with_status
     ~actor:"coord/worktree"
     ~raw_source:(exec_gate_raw_source argv)
     ~summary:"coord_worktree argv"
-    ~timeout_sec:30.0
+    ~timeout_sec
     argv
 
 (** Run argv and get exit code (Eio-native, no shell) *)
-let run_argv_exit argv =
-  match run_argv_with_status argv with
+let run_argv_exit ?timeout_sec argv =
+  match run_argv_with_status ?timeout_sec argv with
   | Unix.WEXITED n, _ -> n
   | Unix.WSIGNALED _, _ -> 128
   | Unix.WSTOPPED _, _ -> 128
@@ -792,8 +796,15 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
                        usable git worktree. Remove or repair it before retrying."
                       worktree_path))
           end else begin
-            (* Fetch origin first; stale remotes must be explicit, not hidden. *)
-            let fetch_exit = run_argv_exit ["git"; "-C"; root; "fetch"; "origin"] in
+            (* Fetch origin first; stale remotes must be explicit, not hidden.
+               Use the longer git_fetch_timeout_sec budget — the default
+               30s rejected legitimately slow Docker-bridge fetches and
+               cold fetches on large remotes (#9587). *)
+            let fetch_exit =
+              run_argv_exit
+                ~timeout_sec:(Env_config_core.git_fetch_timeout_sec ())
+                ["git"; "-C"; root; "fetch"; "origin"]
+            in
             if fetch_exit <> 0 then
               Error
                 (IoError

--- a/test/dune
+++ b/test/dune
@@ -64,6 +64,7 @@
         test_oas_error_kind_counter
         test_fsm_drift_counter
         test_process_timeout_counter
+        test_git_fetch_timeout_9587
         test_keeper_wake_telemetry
         test_keeper_memory
         test_keeper_accountability
@@ -200,6 +201,7 @@
           test_oas_error_kind_counter
           test_fsm_drift_counter
           test_process_timeout_counter
+          test_git_fetch_timeout_9587
           test_keeper_wake_telemetry
           test_keeper_memory
           test_keeper_accountability

--- a/test/test_git_fetch_timeout_9587.ml
+++ b/test/test_git_fetch_timeout_9587.ml
@@ -1,0 +1,96 @@
+(* test/test_git_fetch_timeout_9587.ml
+
+   #9587: lock the git_fetch_timeout_sec contract.  The previous
+   hardcoded 30s budget at Coord_worktree.run_argv_exit timed out
+   legitimately slow [git fetch origin] inside the Docker keeper
+   sandbox; the fix introduces a configurable timeout via
+   [MASC_GIT_FETCH_TIMEOUT_SEC] with a 120s default and a 10s
+   floor (so a [0] override does not silently disable the cap). *)
+
+open Masc_mcp
+
+let with_env key value f =
+  let prev = Sys.getenv_opt key in
+  (match value with
+   | Some v -> Unix.putenv key v
+   | None ->
+       (match prev with
+        | Some _ -> Unix.putenv key ""
+        | None -> ()));
+  Fun.protect
+    ~finally:(fun () ->
+      match prev with
+      | Some v -> Unix.putenv key v
+      | None -> Unix.putenv key "")
+    f
+
+let env_key = "MASC_GIT_FETCH_TIMEOUT_SEC"
+
+let test_default () =
+  with_env env_key None (fun () ->
+    Alcotest.(check (float 0.0001))
+      "default budget = 120s"
+      120.0
+      (Env_config_core.git_fetch_timeout_sec ()))
+
+let test_env_override () =
+  with_env env_key (Some "300") (fun () ->
+    Alcotest.(check (float 0.0001))
+      "env override 300s honoured"
+      300.0
+      (Env_config_core.git_fetch_timeout_sec ()))
+
+let test_env_override_floats () =
+  with_env env_key (Some "60.5") (fun () ->
+    Alcotest.(check (float 0.0001))
+      "fractional seconds honoured"
+      60.5
+      (Env_config_core.git_fetch_timeout_sec ()))
+
+let test_floor_clamps_zero () =
+  (* MASC_GIT_FETCH_TIMEOUT_SEC=0 was the most plausible footgun
+     setting (operator trying to "disable" the cap).  Floor must
+     keep a non-trivial budget so the call cannot block forever. *)
+  with_env env_key (Some "0") (fun () ->
+    Alcotest.(check (float 0.0001))
+      "floor 10s prevents zero-disable"
+      10.0
+      (Env_config_core.git_fetch_timeout_sec ()))
+
+let test_floor_clamps_negative () =
+  with_env env_key (Some "-5") (fun () ->
+    Alcotest.(check (float 0.0001))
+      "negative override clamped to floor"
+      10.0
+      (Env_config_core.git_fetch_timeout_sec ()))
+
+let test_invalid_env_falls_back_to_default () =
+  with_env env_key (Some "not-a-number") (fun () ->
+    Alcotest.(check (float 0.0001))
+      "garbage env reverts to default"
+      120.0
+      (Env_config_core.git_fetch_timeout_sec ()))
+
+let () =
+  Alcotest.run "git_fetch_timeout_9587"
+    [
+      ( "defaults",
+        [
+          Alcotest.test_case "default 120s" `Quick test_default;
+        ] );
+      ( "env override",
+        [
+          Alcotest.test_case "300s" `Quick test_env_override;
+          Alcotest.test_case "fractional" `Quick test_env_override_floats;
+        ] );
+      ( "floor",
+        [
+          Alcotest.test_case "zero clamped" `Quick test_floor_clamps_zero;
+          Alcotest.test_case "negative clamped" `Quick test_floor_clamps_negative;
+        ] );
+      ( "robustness",
+        [
+          Alcotest.test_case "invalid env falls back" `Quick
+            test_invalid_env_falls_back_to_default;
+        ] );
+    ]


### PR DESCRIPTION
## 요약

`masc_worktree_create`가 사전에 `git fetch origin`을 호출하는데, `coord_worktree.ml` / `coord_git.ml`의 `run_argv_exit`가 hardcoded 30s timeout. Docker bridge + cold remote fetch가 정당하게 30s 초과 → 키퍼 반환 `IoError "Failed to fetch origin before worktree creation"` → turn burn.

`MASC_GIT_FETCH_TIMEOUT_SEC` env 추가 (default 120s, floor 10s) + 두 fetch 호출 사이트에서 사용. 다른 local git op (status, branch, rev-parse)는 기존 30s 유지.

Closes #9587.

## 근본 원인

이슈 보고:
```
Timeout after 30s: 'git' '-C' '/Users/dancer/me/.masc/playground/docker/masc-improver/repos/masc-mcp' 'fetch' 'origin'
❌ IO error: Failed to fetch origin before worktree creation.
```

- Keeper: masc-improver
- Sandbox: Docker bridge networking
- 30s budget는 LAN-fast 네트워크 가정 — Docker bridge + cold cache는 평균 latency 더 높음

`run_argv_exit`는 `Masc_exec.Exec_gate.run_argv_with_status ~timeout_sec:30.0`을 호출하는데, 모든 git operation이 같은 budget을 공유. Local-only git command(`status`, `rev-parse`)는 30s가 충분하지만 network-bound `fetch`/`push`는 부족.

## 변경 내용

### `lib/config/env_config_core.ml` — SSOT env knob

```ocaml
let git_fetch_timeout_sec_env_key = "MASC_GIT_FETCH_TIMEOUT_SEC"

let git_fetch_timeout_sec () =
  Float.max 10.0
    (get_float ~default:120.0 git_fetch_timeout_sec_env_key)
```

**Default 120s**: 4× 기존 30s. Docker bridge cold fetch + 큰 remote에서 헤드룸. CI fast network에서는 60s overlay.

**Floor 10s**: `MASC_GIT_FETCH_TIMEOUT_SEC=0`으로 cap을 비활성화하려는 footgun 방지. 0 또는 음수도 10s로 clamp.

### `lib/coord/coord_worktree.ml` + `lib/coord/coord_git.ml`

`run_argv_exit`에 `?timeout_sec` optional 파라미터 추가 (default 30s 유지). `fetch origin` 호출 사이트만 `~timeout_sec:(Env_config_core.git_fetch_timeout_sec ())` 명시 사용:

```diff
-let run_argv_exit argv = match run_argv_with_status argv with
+let run_argv_exit ?timeout_sec argv =
+  match run_argv_with_status ?timeout_sec argv with
 ...
-let fetch_exit = run_argv_exit ["git"; "-C"; root; "fetch"; "origin"] in
+let fetch_exit =
+  run_argv_exit
+    ~timeout_sec:(Env_config_core.git_fetch_timeout_sec ())
+    ["git"; "-C"; root; "fetch"; "origin"]
+in
```

다른 호출 (worktree remove, branch -D, prune 등)은 modified 없음 — local fast op이므로 30s 그대로.

## 테스트

`test/test_git_fetch_timeout_9587.ml` 6 scenario:

```bash
$ dune exec test/test_git_fetch_timeout_9587.exe
[OK]  defaults     0  default 120s.
[OK]  env override 0  300s.
[OK]  env override 1  fractional.
[OK]  floor        0  zero clamped.
[OK]  floor        1  negative clamped.
[OK]  robustness   0  invalid env falls back.
Test Successful in 0.001s. 6 tests run.
```

| 시나리오 | 검증 |
|---|---|
| Env unset | 120s default |
| `=300` | 300s |
| `=60.5` | 60.5s (fractional) |
| `=0` | clamp to 10s |
| `=-5` | clamp to 10s |
| `=not-a-number` | fall back to 120s |

## 회귀 리스크

낮음.

| 시나리오 | 기존 | 본 PR |
|---|---|---|
| Local git op (status, branch) | 30s | 30s (그대로) |
| `fetch origin` slow (60s) | FAIL | OK (120s budget) |
| `fetch origin` fast (5s) | OK | OK (그대로) |
| `fetch origin` hung | timeout @ 30s | timeout @ 120s (longer 검사) |
| MASC_GIT_FETCH_TIMEOUT_SEC=0 | n/a | clamp 10s (cap 유지) |
| MASC_GIT_FETCH_TIMEOUT_SEC unset | n/a | 120s default |

가장 큰 행동 변화: hung fetch가 30s 대신 120s 후 timeout. 이는 의도된 변화 — 60s까지 정당한 fetch도 fail이었던 이전 행동이 잘못이었음.

## 후속 (별건)

- **Cache repo outside sandbox**: 이슈에서 제안한 대안 (큰 repo를 호스트에 캐시 + read-only mount). RFC scope.
- **Per-keeper budget**: Docker sandbox가 평균 host보다 느린 경우 keeper-specific 값을 sweep할 수 있음 (`MASC_GIT_FETCH_TIMEOUT_SEC_<KEEPER>=...`). 현재 PR scope 외.
- **Fetch retry with exponential backoff**: 첫 시도 timeout 시 짧게 백오프 후 재시도. #9731이 CI 에서 한 패턴.

## 참고

- Issue #9587
- `lib/config/env_config_core.ml:447-461` — SSOT env knob
- `lib/coord/coord_worktree.ml:26-44, 794-808` — fetch site 1
- `lib/coord/coord_git.ml:30-46, 181-189` — fetch site 2
- `test/test_git_fetch_timeout_9587.ml` — 6/6 contract pin
