### PR TITLE
fix(worktree-live-context): per-repo single-flight gate for git status capture (#9632)

### DIFF
--- a/lib/worktree_live_context.ml
+++ b/lib/worktree_live_context.ml
@@ -119,6 +119,36 @@ let clear_status_cache_for_tests () =
     ~finally:(fun () -> Stdlib.Mutex.unlock status_cache_mu)
     (fun () -> Hashtbl.clear status_cache)
 
+(* Single-flight gates: per-repo Stdlib.Mutex serialising concurrent cache
+   misses so only one [git status] runs per repo at a time.  Without this
+   gate N keepers + dashboard fibers hitting an expired cache simultaneously
+   each fork+exec git, multiplying the I/O contention that was already
+   making git status take 10s+ on a 13-line working tree (#9632).  After
+   the winner refreshes the cache, followers re-check and reuse it.
+   Pattern: Go [singleflight.Group], Caffeine loading cache. *)
+let single_flight_registry : (string, Stdlib.Mutex.t) Hashtbl.t =
+  Hashtbl.create 4
+
+let single_flight_registry_mu = Stdlib.Mutex.create ()
+
+let single_flight_gate repo_root =
+  Stdlib.Mutex.lock single_flight_registry_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock single_flight_registry_mu)
+    (fun () ->
+      match Hashtbl.find_opt single_flight_registry repo_root with
+      | Some mu -> mu
+      | None ->
+          let mu = Stdlib.Mutex.create () in
+          Hashtbl.replace single_flight_registry repo_root mu;
+          mu)
+
+let clear_single_flight_for_tests () =
+  Stdlib.Mutex.lock single_flight_registry_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock single_flight_registry_mu)
+    (fun () -> Hashtbl.clear single_flight_registry)
+
 let current_status_lines_uncached ~repo_root =
   run_git_capture_lines ~workdir:repo_root
     [ "--no-optional-locks"; "status"; "--porcelain"; "--untracked-files=no" ]
@@ -127,14 +157,26 @@ let current_status_lines_uncached ~repo_root =
   |> List.filter (fun line -> line <> "")
 
 let current_status_lines ~repo_root =
-  let now = Time_compat.now () in
   let ttl = status_cache_ttl_sec () in
-  match status_cache_lookup repo_root ~now ~ttl with
+  match status_cache_lookup repo_root ~now:(Time_compat.now ()) ~ttl with
   | Some lines -> lines
   | None ->
-      let lines = current_status_lines_uncached ~repo_root in
-      status_cache_store repo_root lines ~now:(Time_compat.now ()) ~ttl;
-      lines
+      let gate = single_flight_gate repo_root in
+      Stdlib.Mutex.lock gate;
+      Fun.protect
+        ~finally:(fun () -> Stdlib.Mutex.unlock gate)
+        (fun () ->
+          (* Double-check: the caller that won the race may have refreshed
+             the cache while we were blocked on [gate]. *)
+          match
+            status_cache_lookup repo_root ~now:(Time_compat.now ()) ~ttl
+          with
+          | Some lines -> lines
+          | None ->
+              let lines = current_status_lines_uncached ~repo_root in
+              status_cache_store repo_root lines
+                ~now:(Time_compat.now ()) ~ttl;
+              lines)
 
 let state_dir ~repo_root =
   Filename.concat

--- a/lib/worktree_live_context.mli
+++ b/lib/worktree_live_context.mli
@@ -45,6 +45,10 @@ val git_status_timeout_sec : unit -> float
     deterministic "no previous hash" state. *)
 val clear_status_cache_for_tests : unit -> unit
 
+(** Reset the per-repo single-flight registry so tests observe an
+    uncontended gate. Pairs with {!clear_status_cache_for_tests}. *)
+val clear_single_flight_for_tests : unit -> unit
+
 (** [current_status_lines ~repo_root] returns the cached
     [git status --porcelain] lines for [repo_root], refreshing from
     disk on cache miss. *)

--- a/test/dune
+++ b/test/dune
@@ -125,6 +125,7 @@
         test_keeper_docker_read
         test_keeper_github_read_only
         test_worktree_live_context
+        test_worktree_status_single_flight_9632
         test_tool_input_validation
         test_autoresearch_codegen
         test_autoresearch_oas_primitives
@@ -261,6 +262,7 @@
           test_keeper_docker_read
           test_keeper_github_read_only
           test_worktree_live_context
+          test_worktree_status_single_flight_9632
           test_tool_input_validation
           test_autoresearch_codegen
           test_autoresearch_oas_primitives

--- a/test/test_worktree_status_single_flight_9632.ml
+++ b/test/test_worktree_status_single_flight_9632.ml
@@ -2,8 +2,8 @@
     a TTL cache but no single-flight gate, so N keepers + dashboard
     fibers hitting an expired cache simultaneously each fork+exec
     [git status --porcelain].  The resulting I/O contention pushed
-    individual git invocations past the 15s timeout budget on
-    [/Users/dancer/me] with 64 worktrees and a Second Brain working tree.
+    individual git invocations past the 15s timeout budget on a large
+    local workspace with many worktrees.
 
     These tests pin the per-repo single-flight contract:
 
@@ -23,9 +23,21 @@ module Wlc = Masc_mcp.Worktree_live_context
 (* Helpers ---------------------------------------------------------- *)
 
 let run_concurrent ~workers (f : int -> unit) =
+  let ready = Atomic.make 0 in
+  let go = Atomic.make false in
   let domains =
-    List.init workers (fun idx -> Domain.spawn (fun () -> f idx))
+    List.init workers (fun idx ->
+      Domain.spawn (fun () ->
+        ignore (Atomic.fetch_and_add ready 1);
+        while not (Atomic.get go) do
+          Domain.cpu_relax ()
+        done;
+        f idx))
   in
+  while Atomic.get ready < workers do
+    Domain.cpu_relax ()
+  done;
+  Atomic.set go true;
   List.iter Domain.join domains
 
 let with_hook ~hook k =
@@ -75,14 +87,32 @@ let test_concurrent_misses_same_repo_collapse_to_one_git_call () =
 
 let test_distinct_repos_do_not_serialise () =
   reset ();
-  (* Each repo's hook records its own call count.  A correct per-repo
-     gate lets the two captures execute concurrently; a single global
-     gate would force them sequentially.  We don't time the test (timing
-     is flaky on CI), we just assert each repo had exactly one capture. *)
+  (* Each repo's hook records its own call count and overlap. A correct
+     per-repo gate lets repo A and repo B execute concurrently; a single
+     global gate would keep [max_active] at 1. *)
   let calls_a = Atomic.make 0 in
   let calls_b = Atomic.make 0 in
+  let active = Atomic.make 0 in
+  let max_active = Atomic.make 0 in
+  let enter_capture () =
+    let now_active = Atomic.fetch_and_add active 1 + 1 in
+    let rec update_max () =
+      let current = Atomic.get max_active in
+      if now_active > current then
+        if not (Atomic.compare_and_set max_active current now_active) then
+          update_max ()
+    in
+    update_max ()
+  in
+  let leave_capture () =
+    ignore (Atomic.fetch_and_add active (-1))
+  in
   let hook ~workdir args =
     let _ = args in
+    enter_capture ();
+    Fun.protect
+      ~finally:leave_capture
+      (fun () ->
     if String.equal workdir "/tmp/repo-A" then begin
       Atomic.incr calls_a;
       Unix.sleepf 0.02;
@@ -91,7 +121,7 @@ let test_distinct_repos_do_not_serialise () =
       Atomic.incr calls_b;
       Unix.sleepf 0.02;
       Some [ " M b.ml" ]
-    end
+    end)
   in
   with_hook ~hook (fun () ->
     let workers = 8 in
@@ -100,7 +130,8 @@ let test_distinct_repos_do_not_serialise () =
       let _ = Wlc.current_status_lines ~repo_root:repo in
       ());
     check int "repo A captured once" 1 (Atomic.get calls_a);
-    check int "repo B captured once" 1 (Atomic.get calls_b))
+    check int "repo B captured once" 1 (Atomic.get calls_b);
+    check int "distinct repos captured concurrently" 2 (Atomic.get max_active))
 
 (* 3. Cache TTL still respected after single-flight returns --------- *)
 

--- a/test/test_worktree_status_single_flight_9632.ml
+++ b/test/test_worktree_status_single_flight_9632.ml
@@ -1,0 +1,139 @@
+(** #9632 root cause: [Worktree_live_context.current_status_lines] held
+    a TTL cache but no single-flight gate, so N keepers + dashboard
+    fibers hitting an expired cache simultaneously each fork+exec
+    [git status --porcelain].  The resulting I/O contention pushed
+    individual git invocations past the 15s timeout budget on
+    [/Users/dancer/me] with 64 worktrees and a Second Brain working tree.
+
+    These tests pin the per-repo single-flight contract:
+
+    1. [N] concurrent cache-miss callers collapse into a single git
+       invocation (the winner; followers double-check the cache).
+    2. Distinct [repo_root] values do NOT serialise — each repo has its
+       own gate, so a slow capture for repo A never blocks repo B.
+
+    The test deliberately stalls the captured git invocation to widen
+    the race window; without the single-flight gate the pre-#9632 code
+    invokes the hook once per domain. *)
+
+open Alcotest
+
+module Wlc = Masc_mcp.Worktree_live_context
+
+(* Helpers ---------------------------------------------------------- *)
+
+let run_concurrent ~workers (f : int -> unit) =
+  let domains =
+    List.init workers (fun idx -> Domain.spawn (fun () -> f idx))
+  in
+  List.iter Domain.join domains
+
+let with_hook ~hook k =
+  Wlc.set_git_capture_hook_for_tests hook;
+  Fun.protect
+    ~finally:(fun () ->
+      Wlc.clear_git_capture_hook_for_tests ();
+      Wlc.clear_status_cache_for_tests ();
+      Wlc.clear_single_flight_for_tests ())
+    k
+
+(* Reset between tests so cache/single-flight state from one case
+   does not silently mask the next. *)
+let reset () =
+  Wlc.clear_status_cache_for_tests ();
+  Wlc.clear_single_flight_for_tests ()
+
+(* 1. Concurrent miss for the same repo -> single git call ---------- *)
+
+let test_concurrent_misses_same_repo_collapse_to_one_git_call () =
+  reset ();
+  let calls = Atomic.make 0 in
+  let hook ~workdir:_ _args =
+    Atomic.incr calls;
+    (* Stall briefly so concurrent callers DEFINITELY race the gate.
+       Without a single-flight gate, every caller fires git in this
+       window and this counter climbs to [workers]. *)
+    Unix.sleepf 0.05;
+    Some [ " M sample.ml" ]
+  in
+  with_hook ~hook (fun () ->
+    let workers = 12 in
+    let observed = Array.make workers [] in
+    run_concurrent ~workers (fun i ->
+      observed.(i) <-
+        Wlc.current_status_lines ~repo_root:"/tmp/repo-A");
+    check int "single-flight collapses N concurrent misses to 1 git call"
+      1 (Atomic.get calls);
+    Array.iteri
+      (fun i lines ->
+        check (list string)
+          (Printf.sprintf "worker %d sees the captured status" i)
+          [ "M sample.ml" ] lines)
+      observed)
+
+(* 2. Distinct repos run in parallel — no cross-repo serialisation -- *)
+
+let test_distinct_repos_do_not_serialise () =
+  reset ();
+  (* Each repo's hook records its own call count.  A correct per-repo
+     gate lets the two captures execute concurrently; a single global
+     gate would force them sequentially.  We don't time the test (timing
+     is flaky on CI), we just assert each repo had exactly one capture. *)
+  let calls_a = Atomic.make 0 in
+  let calls_b = Atomic.make 0 in
+  let hook ~workdir args =
+    let _ = args in
+    if String.equal workdir "/tmp/repo-A" then begin
+      Atomic.incr calls_a;
+      Unix.sleepf 0.02;
+      Some [ " M a.ml" ]
+    end else begin
+      Atomic.incr calls_b;
+      Unix.sleepf 0.02;
+      Some [ " M b.ml" ]
+    end
+  in
+  with_hook ~hook (fun () ->
+    let workers = 8 in
+    run_concurrent ~workers (fun i ->
+      let repo = if i mod 2 = 0 then "/tmp/repo-A" else "/tmp/repo-B" in
+      let _ = Wlc.current_status_lines ~repo_root:repo in
+      ());
+    check int "repo A captured once" 1 (Atomic.get calls_a);
+    check int "repo B captured once" 1 (Atomic.get calls_b))
+
+(* 3. Cache TTL still respected after single-flight returns --------- *)
+
+let test_followers_reuse_cache_not_re_capture () =
+  reset ();
+  let calls = Atomic.make 0 in
+  let hook ~workdir:_ _args =
+    Atomic.incr calls;
+    Some [ " M sample.ml" ]
+  in
+  with_hook ~hook (fun () ->
+    (* Prime the cache. *)
+    let _ = Wlc.current_status_lines ~repo_root:"/tmp/repo-C" in
+    check int "primed once" 1 (Atomic.get calls);
+    (* Subsequent direct calls within TTL must not invoke the hook,
+       even though they pass through the single-flight gate. *)
+    for _ = 1 to 10 do
+      let _ = Wlc.current_status_lines ~repo_root:"/tmp/repo-C" in
+      ()
+    done;
+    check int "TTL cache reuse after single-flight returns"
+      1 (Atomic.get calls))
+
+let () =
+  run "Worktree_status_single_flight_9632"
+    [
+      ( "single-flight",
+        [
+          test_case "concurrent misses same repo collapse to one" `Quick
+            test_concurrent_misses_same_repo_collapse_to_one_git_call;
+          test_case "distinct repos do not serialise" `Quick
+            test_distinct_repos_do_not_serialise;
+          test_case "followers reuse cache" `Quick
+            test_followers_reuse_cache_not_re_capture;
+        ] );
+    ]


### PR DESCRIPTION
## Goal

Stop the thundering-herd that turns `git status --porcelain` into a 15s timeout across the keeper fleet (#9632).

## Root cause

`Worktree_live_context.current_status_lines` had a 5s TTL cache but **no single-flight gate**. When the cache expired, 16 keepers + dashboard `mission_profile` + governance compute_judgments all hit it concurrently and each fork+exec'd git in parallel. On a Second Brain root with 64 worktrees and concurrent indexers (gitstatusd, IDE), the I/O contention pushed individual invocations past the 15s budget — even though the working tree only had 13 lines of changes.

```
$ time git -C /Users/dancer/me status --porcelain | wc -l
13
git status --porcelain  0.19s user 2.03s system 21% cpu  10.147 total
```

10s baseline + N concurrent forks = repeated `Process_eio Timeout after 15s` warnings, stale operator snapshots, and `Coord.get_agents_raw` cancellations.

## Change

- `lib/worktree_live_context.ml`: per-repo `Stdlib.Mutex` registry. On cache miss the caller acquires the per-repo gate, double-checks the cache (in case another caller refreshed it while waiting), runs the git capture, stores the result, and releases. Followers reuse the freshly-stored cache line and never spawn git.
- `lib/worktree_live_context.mli`: expose `clear_single_flight_for_tests` next to existing `clear_status_cache_for_tests`.
- `test/test_worktree_status_single_flight_9632.ml`: pin the contract.

## Why a per-repo gate (not global)

A global mutex would serialise unrelated repos — bad for hosts with multiple monorepos. Distinct `repo_root` values get their own `Stdlib.Mutex.t`; concurrent captures across repos remain parallel.

## Pattern

Standard cache-stampede protection:

| System | Mechanism |
|--------|-----------|
| Go `singleflight.Group` | per-key in-flight call collapse |
| Caffeine `loadingCache.get(K, mappingFunction)` | per-key compute lock + double-check |
| Linux page cache `stable_page_writes` | per-page write lock |

The masc implementation is the simplest variant (Mutex + double-check) because the value is small, immutable, and short-lived.

## Tests (local, all green)

`test_worktree_status_single_flight_9632`:
- `concurrent misses same repo collapse to one` — 12 `Domain.spawn` callers on the same `repo_root` stall a 50ms hook; assert hook called **exactly 1 time** (was 12 before).
- `distinct repos do not serialise` — 8 callers split across `/tmp/repo-A` and `/tmp/repo-B`; assert each repo captured exactly once.
- `followers reuse cache` — after priming, 10 follow-up calls within TTL invoke the hook 0 additional times.

`test_worktree_live_context` (existing): 7/7 pass unchanged — single-flight is transparent to single-caller paths.

## Risk / scope

- No public API change beyond the new test hook.
- Cache TTL semantics (`MASC_WORKTREE_STATUS_CACHE_TTL_S`) unchanged.
- Timeout budget (`MASC_WORKTREE_GIT_STATUS_TIMEOUT_SEC`) unchanged.
- Behavior under contention only changes from "all callers race git" to "one caller runs, others wait briefly then read cache".

## Verification (post-merge, on prod root)

After merge, watch `Process_eio Timeout after 15s: 'git'` warnings on the Second Brain runtime. Pre-fix the issue logs three timeouts within 12 minutes (#9632 19:08, 19:17, 19:18). Post-fix, the rate should drop to at most one per cache expiry interval (5s default, so worst case once every cycle when actual git is genuinely slow — not amplified by N callers).

## Out of scope (follow-ups, separate issues)

- Replacing `git status --porcelain` with libgit2 / direct `.git/index` read (lower variance but bigger surface).
- Reducing the dashboard refresh cadence so fewer cycles need this snapshot.
- `gitstatusd` collision avoidance (env-level concern).

Refs #9632. Related observations: #9628 (timeout budget), #9734 (operator snapshot refresh), #9766 (dashboard slow render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)