### PR TITLE
perf(sse): drop two List.rev passes in get_events_after

### DIFF
--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -200,10 +200,18 @@ let buffer_event event_id event_str =
 (** Get events after given ID for replay (MCP spec MUST) *)
 let get_events_after last_id =
   let lst = Atomic.get event_buffer in
+  (* [event_buffer] is newest-first (each [buffer_event] [cons]es onto
+     the head).  Folding it left-to-right and prepending every match to
+     [acc] visits newest first and pushes oldest last, so [acc] ends as
+     oldest-first directly — no surrounding [List.rev] needed.
+
+     The previous shape was [List.rev lst |> fold prepend |> List.rev],
+     which walked the buffer three times to produce the same result.
+     Each SSE replay (client reconnect with [Last-Event-Id]) saves
+     2 × O(buffer) over the old form; max_buffer_size=100. *)
   List.fold_left (fun acc (id, ev, _ts) ->
     if id > last_id then ev :: acc else acc
-  ) [] (List.rev lst)
-  |> List.rev
+  ) [] lst
 
 (** Remove events older than [buffer_ttl_seconds] from the front of the buffer.
     Returns count of evicted events. *)

--- a/test/test_sse_coverage.ml
+++ b/test/test_sse_coverage.ml
@@ -213,11 +213,30 @@ let test_buffer_event_timestamps_successful_commit_after_retry () =
           fail "buffer should contain the fresh event")
 
 let test_get_events_after_filters () =
-  let base_id = Sse.current_id () in
-  Sse.buffer_event (base_id + 2000) "event A";
-  Sse.buffer_event (base_id + 2001) "event B";
-  let events = Sse.get_events_after (base_id + 2000) in
-  check bool "filtered" true (List.length events >= 1)
+  let original_buffer = Atomic.get Sse.event_buffer in
+  Fun.protect
+    ~finally:(fun () -> Atomic.set Sse.event_buffer original_buffer)
+    (fun () ->
+      Atomic.set Sse.event_buffer [];
+      Sse.buffer_event 802_000 "event A";
+      Sse.buffer_event 802_001 "event B";
+      check (list string) "filtered exact replay" [ "event B" ]
+        (Sse.get_events_after 802_000))
+
+let test_get_events_after_preserves_oldest_first_order () =
+  let original_buffer = Atomic.get Sse.event_buffer in
+  Fun.protect
+    ~finally:(fun () -> Atomic.set Sse.event_buffer original_buffer)
+    (fun () ->
+      Atomic.set Sse.event_buffer [];
+      Sse.buffer_event 803_000 "event A";
+      Sse.buffer_event 803_001 "event B";
+      Sse.buffer_event 803_002 "event C";
+      check (list string) "all replayed oldest-first"
+        [ "event A"; "event B"; "event C" ]
+        (Sse.get_events_after 802_999);
+      check (list string) "tail replayed oldest-first" [ "event B"; "event C" ]
+        (Sse.get_events_after 803_000))
 
 let test_get_events_after_empty () =
   let future_id = Sse.current_id () + 100000 in
@@ -385,6 +404,8 @@ let () =
       test_case "buffer retry timestamps on successful commit" `Quick
         test_buffer_event_timestamps_successful_commit_after_retry;
       test_case "filters" `Quick test_get_events_after_filters;
+      test_case "preserves oldest-first order" `Quick
+        test_get_events_after_preserves_oldest_first_order;
       test_case "empty for future" `Quick test_get_events_after_empty;
       test_case "cleanup exact under domain contention" `Quick
         test_cleanup_expired_events_exact_under_domain_contention;


### PR DESCRIPTION
## 문제
SSE 클라이언트 reconnect (Last-Event-Id) 시 `get_events_after`이 buffer를 **세 번** 순회:
1. `List.rev lst` (newest-first → oldest-first)
2. `List.fold_left ev :: acc` (oldest-first → newest-first matches)
3. `|> List.rev` (newest-first → oldest-first 결과)

buffer는 항상 newest-first (`buffer_event` cons), 그래서 단일 `fold_left` + prepend가 동일 결과를 1 traversal에 산출:
- 가장 새로운 element 먼저 방문 → acc에 prepend → 가장 오래된 element가 마지막에 들어가 → acc는 oldest-first 직접

## 효과
buffer 최대 100, 매 replay 200 ops 절감. 매 reconnect (모바일/탭 focus 전환)마다 호출되는 sustained cost.

## Behavior
- output oldest-first (MCP spec MUST replay order) 유지
- `id > last_id` filter 동일
- future last_id에 대한 empty 결과 동일

## Validation
- `test_sse` 4/4
- `test_sse_coverage` 32/32 (`get_events_after_filters`, `get_events_after_empty`, domain contention 하 buffer_event 포함)