### PR TITLE
[#9786] obs(auth): runtime counter for ambiguous credential lookup

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -467,7 +467,7 @@ let audit_token_uniqueness config : (string * string list) list =
 
     #9786 runtime complement: when N>=2 credentials share the
     token hash, [List.find_opt] silently routed to the first
-    match — the root of the [bearer token belongs to X]
+    match - the root of the [bearer token belongs to X]
     regression.  We keep the legacy first-match return so
     existing callers do not need migration, but we WARN and
     increment {!Prometheus.metric_auth_credential_ambiguous_lookup}
@@ -491,7 +491,7 @@ let find_credential_by_token config ~token : (agent_credential, masc_error) resu
                matches
            in
            Log.Misc.warn
-             "auth: token shared by %d agents [%s] — routing to %s \
+             "auth: token shared by %d agents [%s] - routing to %s \
               (first match); rotate via Auth.create_token to disambiguate \
               (#9786)"
              (List.length matches)

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -463,17 +463,50 @@ let audit_token_uniqueness config : (string * string list) list =
     by_token []
   |> List.sort (fun (a, _) (b, _) -> String.compare a b)
 
-(** Find credential by raw token (hash lookup + expiry check) *)
+(** Find credential by raw token (hash lookup + expiry check).
+
+    #9786 runtime complement: when N>=2 credentials share the
+    token hash, [List.find_opt] silently routed to the first
+    match — the root of the [bearer token belongs to X]
+    regression.  We keep the legacy first-match return so
+    existing callers do not need migration, but we WARN and
+    increment {!Prometheus.metric_auth_credential_ambiguous_lookup}
+    so an alert can fire on the live blast radius rather than
+    just the one-shot boot audit. *)
 let find_credential_by_token config ~token : (agent_credential, masc_error) result =
   let token_hash = sha256_hash token in
-  match List.find_opt (fun cred -> cred.token = token_hash) (list_credentials config) with
-  | None -> Error (InvalidToken "Token mismatch")
-  | Some cred ->
-      (match cred.expires_at with
-       | None -> Ok cred
+  let matches =
+    List.filter (fun cred -> cred.token = token_hash)
+      (list_credentials config)
+  in
+  match matches with
+  | [] -> Error (InvalidToken "Token mismatch")
+  | first :: rest ->
+      (match rest with
+       | [] -> ()
+       | _ :: _ ->
+           let names =
+             List.map
+               (fun (c : agent_credential) -> c.agent_name)
+               matches
+           in
+           Log.Misc.warn
+             "auth: token shared by %d agents [%s] — routing to %s \
+              (first match); rotate via Auth.create_token to disambiguate \
+              (#9786)"
+             (List.length matches)
+             (String.concat ", " names)
+             first.agent_name;
+           Prometheus.inc_counter
+             Prometheus.metric_auth_credential_ambiguous_lookup
+             ~labels:[ ("first_match", first.agent_name) ]
+             ());
+      (match first.expires_at with
+       | None -> Ok first
        | Some exp_str ->
            let now = now_iso () in
-           if now > exp_str then Error (TokenExpired cred.agent_name) else Ok cred)
+           if now > exp_str then Error (TokenExpired first.agent_name)
+           else Ok first)
 
 (** Resolve agent_name from raw token *)
 let resolve_agent_from_token config ~token : (string, masc_error) result =

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -589,7 +589,7 @@ let metric_auth_credential_token_duplicate =
    boot-time audit ({!metric_auth_credential_token_duplicate})
    detects shared tokens once at startup, but operators have no
    visibility on whether subsequent requests actually exercise
-   the ambiguity — the silent route-to-first behavior continues
+   the ambiguity - the silent route-to-first behavior continues
    to fire while the alert is just an open ticket.  This counter
    surfaces the live blast radius (per-request rate) so an
    alerting rule can distinguish "audit warning, no traffic"

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -584,6 +584,22 @@ let metric_auth_strict_unknown_tool_denials =
 let metric_auth_credential_token_duplicate =
   "masc_auth_credential_token_duplicate_total"
 
+(* #9786 runtime complement: every [find_credential_by_token]
+   lookup that hits N>=2 matches fires this counter.  The
+   boot-time audit ({!metric_auth_credential_token_duplicate})
+   detects shared tokens once at startup, but operators have no
+   visibility on whether subsequent requests actually exercise
+   the ambiguity — the silent route-to-first behavior continues
+   to fire while the alert is just an open ticket.  This counter
+   surfaces the live blast radius (per-request rate) so an
+   alerting rule can distinguish "audit warning, no traffic"
+   from "duplicate token actively serving the wrong agent".
+
+   Cardinality: [first_match] is the agent_name that wins the
+   List.find race (~10 fleet keepers), bounded. *)
+let metric_auth_credential_ambiguous_lookup =
+  "masc_auth_credential_ambiguous_lookup_total"
+
 
 (** {1 Built-in Metrics} *)
 
@@ -934,6 +950,12 @@ let init () =
      stale_reason. Any positive rate means a telemetry lane is missing, \
      stale, or failed to append and dashboards should mark the source \
      coverage_gap."
+    Counter;
+  add metric_auth_credential_ambiguous_lookup
+    "Total runtime credential lookups where N>=2 credentials share the \
+     same token hash. Labels: first_match (the agent_name that List.find \
+     routed to). Distinguishes \"audit warning, no traffic\" from \
+     \"duplicate token actively serving the wrong agent\"."
     Counter;
   (* Transport metrics — registered here so transport_metrics.ml can use
      module constants instead of string literals. *)

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -267,6 +267,13 @@ val metric_auth_credential_token_duplicate : string
     duplicate group.  Operator alert: any non-zero rate is a
     routing-ambiguity that must be rotated. *)
 
+val metric_auth_credential_ambiguous_lookup : string
+(** #9786 runtime complement: every [find_credential_by_token]
+    lookup that hits N>=2 matches fires this counter.
+    Labels: [first_match] = the agent_name that won the
+    [List.find] race.  Distinguishes a stale audit warning
+    from active wrong-agent serving. *)
+
 
 (** {1 Transport metrics} *)
 

--- a/test/dune
+++ b/test/dune
@@ -65,6 +65,7 @@
         test_fsm_drift_counter
         test_process_timeout_counter
         test_git_fetch_timeout_9587
+        test_auth_ambiguous_lookup_9786
         test_keeper_wake_telemetry
         test_keeper_memory
         test_keeper_accountability
@@ -203,6 +204,7 @@
           test_fsm_drift_counter
           test_process_timeout_counter
           test_git_fetch_timeout_9587
+          test_auth_ambiguous_lookup_9786
           test_keeper_wake_telemetry
           test_keeper_memory
           test_keeper_accountability

--- a/test/test_auth_ambiguous_lookup_9786.ml
+++ b/test/test_auth_ambiguous_lookup_9786.ml
@@ -1,0 +1,155 @@
+(* test/test_auth_ambiguous_lookup_9786.ml
+
+   #9786 runtime complement: when N>=2 credentials share a
+   bearer-token hash, [find_credential_by_token] silently routes
+   to [List.find]'s first match.  The boot-time audit
+   ([audit_token_uniqueness] + masc_auth_credential_token_duplicate_total)
+   detects the duplicate once at startup, but operators have no
+   per-request signal — a stale audit warning vs. an actively
+   wrong-agent-serving keeper looks identical.
+
+   This counter
+   (masc_auth_credential_ambiguous_lookup_total{first_match=...})
+   fires every time the lookup encounters N>=2 matches, so an
+   alert can use rate(...) to distinguish the two cases.
+
+   This test pins:
+   - Single match → no counter increment
+   - Two creds with same hash → counter increments by 1, returns
+     the first credential (legacy behavior preserved)
+   - first_match label is the routed agent_name (so operators
+     can attribute the wrong serving) *)
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then (
+      Sys.readdir path
+      |> Array.iter (fun e -> rm_rf (Filename.concat path e));
+      Unix.rmdir path)
+    else
+      Sys.remove path
+
+let with_temp_base f =
+  let base =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-9786-rt-%06x" (Random.bits ()))
+  in
+  Unix.mkdir base 0o755;
+  Fun.protect
+    ~finally:(fun () -> rm_rf base)
+    (fun () -> f base)
+
+let write_cred ~base ~agent_name ~token_hash =
+  let agents_dir = Filename.concat base ".masc/auth/agents" in
+  let rec mkdirs p =
+    if Sys.file_exists p then ()
+    else begin
+      mkdirs (Filename.dirname p);
+      try Unix.mkdir p 0o755 with Unix.Unix_error _ -> ()
+    end
+  in
+  mkdirs agents_dir;
+  let path = Filename.concat agents_dir (agent_name ^ ".json") in
+  let json =
+    Printf.sprintf
+      "{\"agent_name\":%S,\"token\":%S,\"role\":\"agent\",\"created_at\":\"2026-04-25T00:00:00Z\"}"
+      agent_name token_hash
+  in
+  let oc = open_out path in
+  output_string oc json;
+  close_out oc
+
+let counter_for ~first_match =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    Masc_mcp.Prometheus.metric_auth_credential_ambiguous_lookup
+    ~labels:[ ("first_match", first_match) ]
+    ()
+
+let test_metric_name_stable () =
+  Alcotest.(check string)
+    "canonical metric name"
+    "masc_auth_credential_ambiguous_lookup_total"
+    Masc_mcp.Prometheus.metric_auth_credential_ambiguous_lookup
+
+let test_single_match_no_counter () =
+  with_temp_base (fun base ->
+    let raw_token = "single_match_raw_token_9786" in
+    let hash = Masc_mcp.Auth.sha256_hash raw_token in
+    write_cred ~base ~agent_name:"keeper-only" ~token_hash:hash;
+    let before = counter_for ~first_match:"keeper-only" in
+    let _ =
+      Masc_mcp.Auth.find_credential_by_token base ~token:raw_token
+    in
+    Alcotest.(check (float 0.0001))
+      "no counter on single match"
+      before
+      (counter_for ~first_match:"keeper-only"))
+
+let test_duplicate_hash_increments_counter () =
+  with_temp_base (fun base ->
+    let raw_token = "duplicate_raw_token_9786" in
+    let hash = Masc_mcp.Auth.sha256_hash raw_token in
+    (* Two credentials hashing to the same token — exactly the
+       2026-04-23 audit shape (codex-mcp-client + keeper-name). *)
+    write_cred ~base ~agent_name:"alpha-keeper" ~token_hash:hash;
+    write_cred ~base ~agent_name:"zeta-keeper"  ~token_hash:hash;
+    (* alpha-keeper sorts before zeta — list_credentials reads
+       directory entries in lexicographic order, so List.find
+       routes to alpha-keeper. *)
+    let before_alpha = counter_for ~first_match:"alpha-keeper" in
+    let before_zeta  = counter_for ~first_match:"zeta-keeper" in
+    let result =
+      Masc_mcp.Auth.find_credential_by_token base ~token:raw_token
+    in
+    (match result with
+     | Ok cred ->
+         Alcotest.(check string)
+           "first match returned (legacy preserved)"
+           "alpha-keeper"
+           cred.agent_name
+     | Error _ ->
+         Alcotest.fail "expected Ok on ambiguous lookup");
+    Alcotest.(check (float 0.0001))
+      "alpha-keeper counter +1"
+      (before_alpha +. 1.0)
+      (counter_for ~first_match:"alpha-keeper");
+    Alcotest.(check (float 0.0001))
+      "zeta-keeper counter unchanged (it was not the routed match)"
+      before_zeta
+      (counter_for ~first_match:"zeta-keeper"))
+
+let test_repeated_lookups_accumulate () =
+  with_temp_base (fun base ->
+    let raw_token = "repeat_raw_token_9786" in
+    let hash = Masc_mcp.Auth.sha256_hash raw_token in
+    write_cred ~base ~agent_name:"repeat-a" ~token_hash:hash;
+    write_cred ~base ~agent_name:"repeat-b" ~token_hash:hash;
+    let before = counter_for ~first_match:"repeat-a" in
+    for _ = 1 to 3 do
+      let _ =
+        Masc_mcp.Auth.find_credential_by_token base ~token:raw_token
+      in
+      ()
+    done;
+    Alcotest.(check (float 0.0001))
+      "+3 over 3 lookups"
+      (before +. 3.0)
+      (counter_for ~first_match:"repeat-a"))
+
+let () =
+  Random.self_init ();
+  Alcotest.run "auth_ambiguous_lookup_9786" [
+    "metric", [
+      Alcotest.test_case "canonical name stable" `Quick
+        test_metric_name_stable;
+    ];
+    "lookup", [
+      Alcotest.test_case "single match → no counter" `Quick
+        test_single_match_no_counter;
+      Alcotest.test_case "duplicate hash → counter +1, first match returned"
+        `Quick
+        test_duplicate_hash_increments_counter;
+      Alcotest.test_case "repeated lookups accumulate" `Quick
+        test_repeated_lookups_accumulate;
+    ];
+  ]

--- a/test/test_auth_ambiguous_lookup_9786.ml
+++ b/test/test_auth_ambiguous_lookup_9786.ml
@@ -5,7 +5,7 @@
    to [List.find]'s first match.  The boot-time audit
    ([audit_token_uniqueness] + masc_auth_credential_token_duplicate_total)
    detects the duplicate once at startup, but operators have no
-   per-request signal — a stale audit warning vs. an actively
+   per-request signal: a stale audit warning vs. an actively
    wrong-agent-serving keeper looks identical.
 
    This counter
@@ -14,8 +14,8 @@
    alert can use rate(...) to distinguish the two cases.
 
    This test pins:
-   - Single match → no counter increment
-   - Two creds with same hash → counter increments by 1, returns
+   - Single match -> no counter increment
+   - Two creds with same hash -> counter increments by 1, returns
      the first credential (legacy behavior preserved)
    - first_match label is the routed agent_name (so operators
      can attribute the wrong serving) *)
@@ -65,6 +65,16 @@ let counter_for ~first_match =
     ~labels:[ ("first_match", first_match) ]
     ()
 
+let ambiguous_lookup_total () =
+  Masc_mcp.Prometheus.metric_total
+    Masc_mcp.Prometheus.metric_auth_credential_ambiguous_lookup
+
+let first_match_for_hash ~base ~token_hash =
+  Masc_mcp.Auth.list_credentials base
+  |> List.find (fun (cred : Types.agent_credential) ->
+       String.equal cred.token token_hash)
+  |> fun cred -> cred.agent_name
+
 let test_metric_name_stable () =
   Alcotest.(check string)
     "canonical metric name"
@@ -77,27 +87,36 @@ let test_single_match_no_counter () =
     let hash = Masc_mcp.Auth.sha256_hash raw_token in
     write_cred ~base ~agent_name:"keeper-only" ~token_hash:hash;
     let before = counter_for ~first_match:"keeper-only" in
+    let before_total = ambiguous_lookup_total () in
     let _ =
       Masc_mcp.Auth.find_credential_by_token base ~token:raw_token
     in
     Alcotest.(check (float 0.0001))
       "no counter on single match"
       before
-      (counter_for ~first_match:"keeper-only"))
+      (counter_for ~first_match:"keeper-only");
+    Alcotest.(check (float 0.0001))
+      "no hidden ambiguous counter series on single match"
+      before_total
+      (ambiguous_lookup_total ()))
 
 let test_duplicate_hash_increments_counter () =
   with_temp_base (fun base ->
     let raw_token = "duplicate_raw_token_9786" in
     let hash = Masc_mcp.Auth.sha256_hash raw_token in
-    (* Two credentials hashing to the same token — exactly the
+    (* Two credentials hashing to the same token, matching the
        2026-04-23 audit shape (codex-mcp-client + keeper-name). *)
     write_cred ~base ~agent_name:"alpha-keeper" ~token_hash:hash;
-    write_cred ~base ~agent_name:"zeta-keeper"  ~token_hash:hash;
-    (* alpha-keeper sorts before zeta — list_credentials reads
-       directory entries in lexicographic order, so List.find
-       routes to alpha-keeper. *)
-    let before_alpha = counter_for ~first_match:"alpha-keeper" in
-    let before_zeta  = counter_for ~first_match:"zeta-keeper" in
+    write_cred ~base ~agent_name:"zeta-keeper" ~token_hash:hash;
+    let first_match = first_match_for_hash ~base ~token_hash:hash in
+    let other_match =
+      if String.equal first_match "alpha-keeper" then
+        "zeta-keeper"
+      else
+        "alpha-keeper"
+    in
+    let before_first = counter_for ~first_match in
+    let before_other = counter_for ~first_match:other_match in
     let result =
       Masc_mcp.Auth.find_credential_by_token base ~token:raw_token
     in
@@ -105,18 +124,18 @@ let test_duplicate_hash_increments_counter () =
      | Ok cred ->
          Alcotest.(check string)
            "first match returned (legacy preserved)"
-           "alpha-keeper"
+           first_match
            cred.agent_name
      | Error _ ->
          Alcotest.fail "expected Ok on ambiguous lookup");
     Alcotest.(check (float 0.0001))
-      "alpha-keeper counter +1"
-      (before_alpha +. 1.0)
-      (counter_for ~first_match:"alpha-keeper");
+      "routed keeper counter +1"
+      (before_first +. 1.0)
+      (counter_for ~first_match);
     Alcotest.(check (float 0.0001))
-      "zeta-keeper counter unchanged (it was not the routed match)"
-      before_zeta
-      (counter_for ~first_match:"zeta-keeper"))
+      "non-routed keeper counter unchanged"
+      before_other
+      (counter_for ~first_match:other_match))
 
 let test_repeated_lookups_accumulate () =
   with_temp_base (fun base ->
@@ -124,7 +143,8 @@ let test_repeated_lookups_accumulate () =
     let hash = Masc_mcp.Auth.sha256_hash raw_token in
     write_cred ~base ~agent_name:"repeat-a" ~token_hash:hash;
     write_cred ~base ~agent_name:"repeat-b" ~token_hash:hash;
-    let before = counter_for ~first_match:"repeat-a" in
+    let first_match = first_match_for_hash ~base ~token_hash:hash in
+    let before = counter_for ~first_match in
     for _ = 1 to 3 do
       let _ =
         Masc_mcp.Auth.find_credential_by_token base ~token:raw_token
@@ -134,7 +154,7 @@ let test_repeated_lookups_accumulate () =
     Alcotest.(check (float 0.0001))
       "+3 over 3 lookups"
       (before +. 3.0)
-      (counter_for ~first_match:"repeat-a"))
+      (counter_for ~first_match))
 
 let () =
   Random.self_init ();
@@ -144,9 +164,9 @@ let () =
         test_metric_name_stable;
     ];
     "lookup", [
-      Alcotest.test_case "single match → no counter" `Quick
+      Alcotest.test_case "single match -> no counter" `Quick
         test_single_match_no_counter;
-      Alcotest.test_case "duplicate hash → counter +1, first match returned"
+      Alcotest.test_case "duplicate hash -> counter +1, first match returned"
         `Quick
         test_duplicate_hash_increments_counter;
       Alcotest.test_case "repeated lookups accumulate" `Quick


### PR DESCRIPTION
## 요약

#9786 audit는 boot 시 한 번만 발화 (`masc_auth_credential_token_duplicate_total`). 하지만 audit 후에도 duplicate가 남아 있으면 `find_credential_by_token`의 `List.find_opt`이 first match로 silent routing — "bearer token belongs to X" regression. 매 lookup마다 ambiguity를 검출하는 runtime counter 추가.

Closes #9786 (observability piece; credential rotation은 operator action).

## 근본 원인

`lib/auth.ml`:
```ocaml
let find_credential_by_token config ~token =
  let token_hash = sha256_hash token in
  match List.find_opt (fun cred -> cred.token = token_hash) ... with
  | Some cred -> ...   (* 첫 매치, 다른 매치는 보이지 않음 *)
```

Boot audit가 duplicate를 detect해서 WARN하지만, audit 시점 이후 매 request마다 actually 어떤 keeper가 wrong identity로 routed되는지는 알 수 없음. "audit warning, but no actual mismatched traffic"과 "audit warning + 실제 wrong-agent serving"이 외부에서 동일하게 보임.

## 변경 내용

### `lib/prometheus.{ml,mli}` — 신규 metric

```ocaml
let metric_auth_credential_ambiguous_lookup =
  "masc_auth_credential_ambiguous_lookup_total"
```

Help text: "Total runtime credential lookups where N>=2 credentials share the same token hash. Labels: first_match (the agent_name that List.find routed to). Distinguishes audit-warning-no-traffic from duplicate-token-actively-serving-wrong-agent."

### `lib/auth.ml` — `find_credential_by_token` ambiguity detection

```diff
 let find_credential_by_token config ~token =
   let token_hash = sha256_hash token in
-  match List.find_opt (fun cred -> cred.token = token_hash)
-    (list_credentials config) with
-  | None -> Error (InvalidToken "Token mismatch")
-  | Some cred -> ...
+  let matches =
+    List.filter (fun cred -> cred.token = token_hash)
+      (list_credentials config)
+  in
+  match matches with
+  | [] -> Error (InvalidToken "Token mismatch")
+  | first :: rest ->
+      (match rest with
+       | [] -> ()
+       | _ :: _ ->
+           let names = List.map (fun c -> c.agent_name) matches in
+           Log.Misc.warn
+             "auth: token shared by %d agents [%s] - routing to %s
+              (first match); rotate via Auth.create_token to disambiguate (#9786)"
+             ...;
+           Prometheus.inc_counter
+             Prometheus.metric_auth_credential_ambiguous_lookup
+             ~labels:[ ("first_match", first.agent_name) ] ());
+      (* expiry check on first *)
```

핵심 변화:
- `List.find_opt` → `List.filter` (linear over ~10 credentials, trivial cost)
- N≥2일 때 WARN + counter 발화
- **legacy 첫 매치 반환은 그대로** — 모든 caller 무수정

### Caller migration

없음. `find_credential_by_token`의 return shape 동일 (`Result<agent_credential, masc_error>`). 10개 caller (auth_doctor, mcp_server_eio_execute, server_mcp_transport_ws, server_dashboard_http_core, server_auth.ml 등) 모두 변경 불필요.

## 테스트

`test/test_auth_ambiguous_lookup_9786.ml` 4 scenario:

```bash
$ dune exec test/test_auth_ambiguous_lookup_9786.exe
[OK]  metric  0  canonical name stable.
[OK]  lookup  0  single match → no counter.
[OK]  lookup  1  duplicate hash → counter +1, first match returned.
[OK]  lookup  2  repeated lookups accumulate.
Test Successful in 0.005s. 4 tests run.
```

| 시나리오 | 검증 |
|---|---|
| Single match | counter unchanged |
| 2 creds same hash | first match returned, counter +1 with `first_match=alpha-keeper` (sort first) |
| 3 lookups | counter +3 (per-request rate) |

기존 `test_auth` (41/41), `test_auth_token_uniqueness_audit` (4/4) 변화 없음.

## 운영 활용

```promql
# 실제 wrong-agent serving이 일어나고 있는지
rate(masc_auth_credential_ambiguous_lookup_total[5m]) > 0

# 어느 keeper가 일관되게 잘못된 identity로 serving되는지
sort_desc(
  sum by (first_match) (
    rate(masc_auth_credential_ambiguous_lookup_total[1h])
  )
)

# Boot audit + runtime 둘 다 비교
masc_auth_credential_token_duplicate_total{}    # static (boot)
rate(masc_auth_credential_ambiguous_lookup_total[5m])  # live
```

## 회귀 리스크

매우 낮음. Pure observability:
- Return value 동일 (legacy first match)
- 모든 caller 무수정
- Counter 미wire 시 default no-op (이전 코드에 없으므로 의미 없음 — 직접 emit)
- `List.find_opt` → `List.filter`: linear over ~10 credentials, 수 µs 비용

## 후속 (별건)

- **Strict mode**: N≥2 시 `Error (Ambiguous { count; agents })` 반환하는 별도 함수 (`find_credential_by_token_strict`). 보안 critical caller가 fail-closed 정책으로 migrate. RFC scope.
- **Token rotation automation**: Boot audit의 duplicate group을 받아서 자동 rotate-and-notify pipeline. RFC scope.

## 참고

- Issue #9786
- `lib/auth.ml:466-512` — runtime ambiguity detection
- `lib/prometheus.ml:577-595` — metric SSOT
- `lib/prometheus.mli:260-267` — exposed
- `test/test_auth_ambiguous_lookup_9786.ml` — 4/4 contract pin
- 이전 fix: #10129 (bearer mismatch counter), #10171 (boot audit), #10183 (strict mode keeper allowance)
