### PR TITLE
Alert on telemetry coverage gaps

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -392,6 +392,14 @@ let metric_persistence_read_drops =
 let metric_codex_cli_mcp_tool_omission =
   "masc_codex_cli_mcp_tool_omission_total"
 
+(* #9520: durable coverage-gap records must also have an alertable
+   Prometheus surface.  The labels deliberately avoid raw paths and
+   error strings; [source], [producer], [dashboard_surface], and
+   [stale_reason] are bounded vocabularies owned by telemetry
+   producers. *)
+let metric_telemetry_coverage_gap =
+  "masc_telemetry_coverage_gap_total"
+
 (* #10094: per-caller counter for [Masc_oas_bridge.run_safe]
    timeouts.  The [caller] string supplied at the run_safe entry
    point lets the operator see WHICH caller is timing out at
@@ -913,6 +921,13 @@ let init () =
     "Total boot-time credential token duplicate groups detected \
      (labels: token_hash_prefix). Any non-zero value means credential tokens \
      must be rotated."
+    Counter;
+  add metric_telemetry_coverage_gap
+    "Total telemetry coverage gaps recorded before append to the durable \
+     coverage-gap store. Labels: source, producer, dashboard_surface, \
+     stale_reason. Any positive rate means a telemetry lane is missing, \
+     stale, or failed to append and dashboards should mark the source \
+     coverage_gap."
     Counter;
   (* Transport metrics — registered here so transport_metrics.ml can use
      module constants instead of string literals. *)

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -162,6 +162,13 @@ val metric_codex_cli_mcp_tool_omission : string
     MCP omissions.  Paired with a once-per-fingerprint WARN log
     so logs carry structural facts and Prometheus carries
     frequency. *)
+
+val metric_telemetry_coverage_gap : string
+(** #9520: total telemetry coverage gaps recorded. Labels:
+    [source, producer, dashboard_surface, stale_reason]. This is the
+    alertable pair to the durable
+    [.masc/telemetry-coverage-gaps/YYYY-MM/DD.jsonl] store. *)
+
 val metric_oas_bridge_timeout : string
 (** #10094: labelled [caller, timeout_s] so operators can
     distinguish fantasy 60s budgets from intentional 120/180s

--- a/lib/telemetry_coverage_gap.ml
+++ b/lib/telemetry_coverage_gap.ml
@@ -13,6 +13,13 @@ let string_opt_json = function
 
 let record ~masc_root ~source ~producer ~durable_store ~dashboard_surface
     ~stale_reason ?keeper_name ?trace_id ?error () =
+  Prometheus.inc_counter Prometheus.metric_telemetry_coverage_gap
+    ~labels:[
+      ("source", source);
+      ("producer", producer);
+      ("dashboard_surface", dashboard_surface);
+      ("stale_reason", stale_reason);
+    ] ();
   let store = Dated_jsonl.create ~base_dir:(store_dir masc_root) () in
   let now = Time_compat.now () in
   let json =

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -242,7 +242,8 @@ let test_review_blocker_metrics_registered () =
   in
   check_registered Prometheus.metric_tool_join_required_guard;
   check_registered Prometheus.metric_timeout_policy_overshoot;
-  check_registered Prometheus.metric_auth_credential_token_duplicate
+  check_registered Prometheus.metric_auth_credential_token_duplicate;
+  check_registered Prometheus.metric_telemetry_coverage_gap
 
 let test_histogram_exported_as_summary () =
   let name = "test_hist_export_fmt" in

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -698,6 +698,18 @@ let test_summary_surfaces_coverage_gaps () =
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir "telem_summary_gap" in
   let root = masc_root dir in
+  let labels =
+    [
+      ("source", "agent_event");
+      ("producer", "telemetry_eio");
+      ("dashboard_surface", "/api/v1/dashboard/telemetry");
+      ("stale_reason", "append_failed");
+    ]
+  in
+  let before =
+    Prometheus.metric_value_or_zero Prometheus.metric_telemetry_coverage_gap
+      ~labels ()
+  in
   Telemetry_coverage_gap.record
     ~masc_root:root
     ~source:"agent_event"
@@ -707,6 +719,10 @@ let test_summary_surfaces_coverage_gaps () =
     ~stale_reason:"append_failed"
     ~error:"disk full"
     ();
+  Alcotest.(check (float 0.001))
+    "coverage gap Prometheus counter increments" (before +. 1.0)
+    (Prometheus.metric_value_or_zero Prometheus.metric_telemetry_coverage_gap
+       ~labels ());
   let json = Telemetry_unified.summary_json ~base_path:dir ~masc_root:root () in
   match json with
   | `Assoc fields ->


### PR DESCRIPTION
## Summary
- add bounded Prometheus counter `masc_telemetry_coverage_gap_total{source,producer,dashboard_surface,stale_reason}`
- increment the counter from `Telemetry_coverage_gap.record` before durable JSONL append
- cover registration and unified telemetry coverage-gap counter behavior

## Why
#9520 still had durable coverage-gap JSONL rows but no alertable missing-metric signal. This makes append failures and missing lanes visible both in the dashboard summary and Prometheus.

## Verification
- `git diff --check origin/main...HEAD`
- `bash scripts/ml_line_cap_audit.sh --baseline-ref origin/main --fail-on-regression`
- `bash scripts/ci/check-telemetry-coverage.sh` (PASS; existing WARN-only heuristic fires on changed files)
- `env DUNE_BUILD_DIR=_build_9520_telemetry_gap_counter DUNE_JOBS=2 DUNE_CACHE=disabled MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_telemetry_unified.exe test/test_prometheus_coverage.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-9520-telemetry-rebased2 _build_9520_telemetry_gap_counter/default/test/test_telemetry_unified.exe`
- `_build_9520_telemetry_gap_counter/default/test/test_prometheus_coverage.exe`

Refs #9520