### PR TITLE
[#9571] refactor(paths): SSOT masc_dirname (batch 2 of N)

### DIFF
--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -208,7 +208,7 @@ let path_from_home_masc (inputs : inputs) =
   match trim_opt inputs.env_home with
   | None -> None
   | Some home ->
-      let candidate = Filename.concat home ".masc/config" in
+      let candidate = Filename.concat (Common.masc_dir_from_base_path ~base_path:home) "config" in
       if config_signature_exists candidate then Some candidate else None
 
 let path_from_local_masc (inputs : inputs) =
@@ -225,7 +225,7 @@ let path_from_local_masc (inputs : inputs) =
 
 let default_missing_root (inputs : inputs) =
   match trim_opt inputs.env_home with
-  | Some home -> Filename.concat home ".masc/config"
+  | Some home -> Filename.concat (Common.masc_dir_from_base_path ~base_path:home) "config"
   | None -> Filename.concat inputs.cwd "config" |> absolute_path_from ~cwd:inputs.cwd
 
 let config_root_resolution (inputs : inputs) =

--- a/lib/mcp_server_eio_resource.ml
+++ b/lib/mcp_server_eio_resource.ml
@@ -147,7 +147,9 @@ let handle_read_resource_eio state id params =
           | "schema.json" ->
               ("application/json", Some (Yojson.Safe.pretty_to_string Mcp_server.schema_json))
           | "institution" ->
-              let file = Filename.concat config.base_path ".masc/institution.json" in
+              let file = Filename.concat
+                (Common.masc_dir_from_base_path ~base_path:config.base_path)
+                "institution.json" in
               if Sys.file_exists file then
                 try
                   let json = Coord.read_json config file in
@@ -160,7 +162,9 @@ let handle_read_resource_eio state id params =
               else
                 ("text/markdown", Some "No institution memory found. Create one with masc_init.")
           | "institution.json" ->
-              let file = Filename.concat config.base_path ".masc/institution.json" in
+              let file = Filename.concat
+                (Common.masc_dir_from_base_path ~base_path:config.base_path)
+                "institution.json" in
               if Sys.file_exists file then
                 let content = Fs_compat.load_file file in
                 ("application/json", Some content)

--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -432,7 +432,11 @@ let get_cascade_audit_store () =
   | Some store -> Some store
   | None ->
       let base_path = Env_config_core.base_path () in
-      let dir = Filename.concat base_path ".masc/cascade_audit" in
+      let dir =
+        Filename.concat
+          (Common.masc_dir_from_base_path ~base_path)
+          "cascade_audit"
+      in
       (match Dated_jsonl.create ~base_dir:dir () with
       | store ->
           cascade_audit_store_ref := Some store;

--- a/lib/procedural_memory.ml
+++ b/lib/procedural_memory.ml
@@ -32,7 +32,11 @@ type procedure = {
 (* ================================================================ *)
 
 let procedures_dir ~agent_name =
-  sprintf "%s/.masc/procedures/%s" (Env_config.base_path ()) agent_name
+  Filename.concat
+    (Filename.concat
+       (Common.masc_dir_from_base_path ~base_path:(Env_config.base_path ()))
+       "procedures")
+    agent_name
 
 let procedures_path ~agent_name =
   sprintf "%s/procedures.jsonl" (procedures_dir ~agent_name)

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -961,6 +961,7 @@ let test_runtime_precondition_contracts () =
    the SSOT and this test catches it before merge. *)
 let test_masc_dirname_ssot_contracts () =
   let migrated_files = [
+    (* batch 1 (#10237) *)
     "lib/auth.ml";
     "lib/board_votes.ml";
     "lib/discovery_history.ml";
@@ -969,6 +970,11 @@ let test_masc_dirname_ssot_contracts () =
     "lib/institution_eio.ml";
     "lib/repo_synthesis_benchmark.ml";
     "lib/tool_blob_store/tool_blob_store.ml";
+    (* batch 2 (this PR) *)
+    "lib/config_dir_resolver.ml";
+    "lib/mcp_server_eio_resource.ml";
+    "lib/oas_worker_cascade.ml";
+    "lib/procedural_memory.ml";
   ] in
   List.iter
     (fun file ->


### PR DESCRIPTION
## 요약

#9571 batch 2 — `Filename.concat <base> ".masc/<sub>"` 패턴 4개 추가 마이그레이션 + Printf.sprintf format-string 변형 1건. Source guard 12 files로 확장.

Closes part of #9571 (batch 2 of N). batch 1: #10237 (merged).

## 마이그레이션 (4 files)

| 파일 | 변경 |
|------|------|
| `lib/config_dir_resolver.ml:211, 228` | `Filename.concat home ".masc/config"` → helper. HOME을 base_path로 사용. |
| `lib/mcp_server_eio_resource.ml:150, 163` | `Filename.concat config.base_path ".masc/institution.json"` × 2 → helper |
| `lib/oas_worker_cascade.ml:435` | `Filename.concat base_path ".masc/cascade_audit"` → helper |
| `lib/procedural_memory.ml:35` | `sprintf "%s/.masc/procedures/%s" base agent` → 두 번의 `Filename.concat` |

마지막 케이스는 sprintf format-string 변형이지만 의미상 동일 — `Filename.concat (helper base) "procedures" |> Filename.concat _ agent`로 단순화 (path 동일).

## Source guard 확장

```diff
 let migrated_files = [
+  (* batch 1 (#10237) *)
   "lib/auth.ml";
   ... 8 files ...
+  (* batch 2 (this PR) *)
+  "lib/config_dir_resolver.ml";
+  "lib/mcp_server_eio_resource.ml";
+  "lib/oas_worker_cascade.ml";
+  "lib/procedural_memory.ml";
 ]
```

이제 12개 파일이 (a) `Common.masc_dir_from_base_path` 사용 + (b) `".masc/"` literal 부재 둘 다 검사받음.

## 테스트

```bash
$ dune exec test/test_ci_hardening_source.exe          → 36/36 pass
$ dune exec test/test_config_dir_resolver.exe          → 18/18 pass
```

## 회귀 리스크

매우 낮음.
- `Filename.concat (helper X) "Y/Z" = Filename.concat X (".masc/" ^ "Y/Z")` (path algebra 동일).
- mli 변경 없음.

## 후속 (남은 사이트)

이번 PR scope 외 (별도 PR):

- `lib/tool_team_memory.ml:108` — `Printf.sprintf ".masc/shared/rooms/%s/memory" room`. **Relative path** (no base prefix). 새 helper `masc_subdir_relative` 또는 `Filename.concat masc_dirname "..."` 필요.
- `lib/exec_core.ml:513` — `Printf.sprintf ".masc/exec-artifacts/%s/%04d-%02d-%02d"`. 같은 relative-path case.
- `bin/masc_compaction_audit.ml`, `bin/masc_cost.ml`, `bin/masc_tui_loader.ml` (bin/ subset)

상대 경로 케이스는 `Common.masc_dirname` 자체를 노출하거나 새 helper가 필요. Batch 3에서 다룰 예정.

## 참고

- Issue #9571
- Batch 1: #10237 (merged)
- `lib/core/common.ml:37-40` — SSOT
- `test/test_ci_hardening_source.ml:962-987` — 12 files locked
