### PR TITLE
perf(mention): precompile static parse regexes at module load

### DIFF
--- a/lib/coord/mention.ml
+++ b/lib/coord/mention.ml
@@ -34,6 +34,40 @@ let is_nickname mention =
   let parts = String.split_on_char '-' mention in
   List.length parts >= 3
 
+(* The three mention patterns are static.  [Re.compile] runs the
+   DFA construction once at module load instead of per [parse] call;
+   on a high-broadcast room every message previously paid three
+   compilations + three DFA builds before [Re.exec_opt] could
+   even start. *)
+let broadcast_re =
+  Re.(compile
+        (seq [
+          str "@@";
+          group (rep1 (alt [rg 'a' 'z'; rg 'A' 'Z'; rg '0' '9'; char '_']));
+        ]))
+
+let stateful_re =
+  Re.(compile
+        (seq [
+          char '@';
+          group (seq [
+            rep1 (alt [rg 'a' 'z'; rg 'A' 'Z'; rg '0' '9'; char '_']);
+            char '-';
+            rep1 (alt [rg 'a' 'z'; rg 'A' 'Z'; rg '0' '9']);
+            char '-';
+            rep1 (alt [rg 'a' 'z'; rg 'A' 'Z'; rg '0' '9']);
+          ]);
+        ]))
+
+let mention_re =
+  Re.(compile
+        (seq [
+          char '@';
+          group (rep1 (alt [
+            rg 'a' 'z'; rg 'A' 'Z'; rg '0' '9'; char '_'; char '-';
+          ]));
+        ]))
+
 (** Parse @mention from message content
 
     Priority order:
@@ -42,27 +76,12 @@ let is_nickname mention =
     3. @agent → Stateless
 *)
 let parse content =
-  (* Pattern 1: @@agent (broadcast) *)
-  let broadcast_re = Re.(compile (seq [str "@@"; group (rep1 (alt [rg 'a' 'z'; rg 'A' 'Z'; rg '0' '9'; char '_']))])) in
   match Re.exec_opt broadcast_re content with
   | Some g -> Broadcast (Re.Group.get g 1)
   | None ->
-    (* Pattern 2: @agent-xxx-yyy (stateful - 3+ parts, alphanumeric allowed) *)
-    let stateful_re = Re.(compile (seq [
-      char '@';
-      group (seq [
-        rep1 (alt [rg 'a' 'z'; rg 'A' 'Z'; rg '0' '9'; char '_']);
-        char '-';
-        rep1 (alt [rg 'a' 'z'; rg 'A' 'Z'; rg '0' '9']);
-        char '-';
-        rep1 (alt [rg 'a' 'z'; rg 'A' 'Z'; rg '0' '9'])
-      ])
-    ])) in
     match Re.exec_opt stateful_re content with
     | Some g -> Stateful (Re.Group.get g 1)
     | None ->
-      (* Pattern 3: @agent (stateless) or @agent-something (stateful) *)
-      let mention_re = Re.(compile (seq [char '@'; group (rep1 (alt [rg 'a' 'z'; rg 'A' 'Z'; rg '0' '9'; char '_'; char '-']))])) in
       match Re.exec_opt mention_re content with
       | Some g ->
         let matched = Re.Group.get g 1 in


### PR DESCRIPTION
## 문제
`Mention.parse`이 매 호출마다 **3개 `Re` regex를 `compile`**:
- `broadcast_re` (@@agent)
- `stateful_re` (@agent-adj-animal 3-part)
- `mention_re` (@agent 또는 @agent-something)

세 패턴 모두 static (caller 값 interpolation 없음). `Re.compile`은 DFA 빌드를 수행하므로, high-broadcast room에서 매 메시지가 **3 DFA construction**을 매칭 시작 전에 부담.

## 변경
세 패턴을 module-level `let` binding으로 hoist. compile 비용이 module init에 1회만 발생. `parse`는 `Re.exec_opt` 3번만 실행.

## Behavior
- 세 패턴 byte-for-byte 동일
- priority order (broadcast → stateful → mention) 유지
- hyphen heuristic (stateful vs stateless) 무변동
- `Re.exec_opt` 반환 의미 동일

## Validation
- `test_mention` 14/14 (parse + extract + resolution + utility — Korean 문자, multiple-mention 등 edge case 포함)

## 다음 후보
- `is_mentioned`은 target-parameterized regex, target별 캐시 가능 (별도 PR)
- `coord_gc.mentions_open_task` 매 task_id 별 `Re.compile` 호출 (별도 PR)