### PR TITLE
fix(distributed-lock): full-jitter backoff to break retry herd (#9645)

### DIFF
--- a/lib/coord/coord_utils_ops.ml
+++ b/lib/coord/coord_utils_ops.ml
@@ -403,6 +403,33 @@ let sleep_lock_retry ?clock delay =
   | Some clock -> Eio.Time.sleep clock delay
   | None -> Time_compat.sleep delay
 
+(* Per-domain RNG for backoff jitter.  [Random.State.t] is NOT
+   cross-domain safe, so each domain keeps its own seed.  Cf. the
+   [nickname_rng] precedent in [lib/coord/nickname.ml]; here we use
+   [Domain.DLS] instead of an Eio mutex because the lock-acquire path
+   may run from non-Eio contexts (Time_compat.sleep branch). *)
+let backoff_rng_key : Random.State.t Domain.DLS.key =
+  Domain.DLS.new_key Random.State.make_self_init
+
+(* "Full jitter" backoff (Marc Brooker, AWS Architecture Blog,
+   "Exponential Backoff And Jitter", 2015): sleep ∈ [0, delay]
+   while [delay] still doubles up to the cap on every miss.
+
+   Pre-fix, all 17 fleet actors (16 keepers + orchestrator GC) hit
+   the [tasks:.backlog] file lock with the SAME deterministic backoff
+   sequence (0.05, 0.1, 0.2, 0.4, 0.5, 0.5, …).  When they collided
+   they re-collided exactly one tick later, so 50 retries decayed
+   into 50 contention spikes instead of 50 independent attempts —
+   #9645 reports the orchestrator giving up after the budget was
+   exhausted.  Full jitter desynchronises the herd: two actors that
+   collide at attempt N pick different sleeps in [0, current_delay],
+   so attempt N+1 is staggered. *)
+let backoff_with_jitter delay =
+  if delay <= 0.0 then delay
+  else
+    let st = Domain.DLS.get backoff_rng_key in
+    Random.State.float st delay
+
 let with_distributed_lock ?clock config _path key f =
   let owner = config.backend_config.node_id in
   let ttl_seconds = config.lock_expiry_minutes * 60 in
@@ -412,7 +439,7 @@ let with_distributed_lock ?clock config _path key f =
       match backend_acquire_lock config ~key ~ttl_seconds ~owner with
       | Ok true -> true
       | _ ->
-          sleep_lock_retry ?clock delay;
+          sleep_lock_retry ?clock (backoff_with_jitter delay);
           acquire (attempts - 1) (Float.min 0.5 (delay *. 2.0))
   in
   if acquire 50 0.05 then
@@ -449,7 +476,7 @@ let with_distributed_lock_r ?clock config path key f : ('a, masc_error) result =
       match backend_acquire_lock config ~key ~ttl_seconds ~owner with
       | Ok true -> true
       | _ ->
-          sleep_lock_retry ?clock delay;
+          sleep_lock_retry ?clock (backoff_with_jitter delay);
           acquire (attempts - 1) (Float.min 0.5 (delay *. 2.0))
   in
   if acquire 50 0.05 then

--- a/test/dune
+++ b/test/dune
@@ -335,6 +335,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_distributed_lock_backoff_jitter_9645)
+ (modules test_distributed_lock_backoff_jitter_9645)
+ (libraries masc_test_deps))
+
+(test
  (name test_timeout_policy_overshoot_counter)
  (modules test_timeout_policy_overshoot_counter)
  (libraries masc_test_deps))

--- a/test/test_distributed_lock_backoff_jitter_9645.ml
+++ b/test/test_distributed_lock_backoff_jitter_9645.ml
@@ -1,0 +1,119 @@
+(** #9645 root cause (companion to PR #10056 retry-count bump and
+    PR #10201 acquire-failed counter): the lock backoff sequence was
+    DETERMINISTIC.  Every retry slept exactly [delay], with [delay]
+    doubling up to a cap.  When 17 actors (16 keepers + orchestrator
+    GC) collided on [tasks:.backlog] they all retried at the same
+    instants, so 50 attempts decayed into 50 contention spikes
+    instead of 50 independent attempts.
+
+    Marc Brooker, "Exponential Backoff And Jitter", AWS Architecture
+    Blog (2015): full jitter (sleep ∈ [0, delay], delay still doubles)
+    is the standard fix for retry storms.  Production systems
+    (envoy, AWS SDK, kubernetes client-go) all ship this.
+
+    These tests pin the contract that [backoff_with_jitter] enforces
+    the [0, delay] interval and produces variance.  Behaviour in the
+    main acquire loop is left to the existing #9645 metric — once
+    contention drops we expect the [acquire-failed] counter to fall. *)
+
+module C = Coord_utils_ops
+
+(* 1. Range invariants ------------------------------------------- *)
+
+let test_jitter_within_zero_and_delay () =
+  let delay = 0.5 in
+  for _ = 1 to 1_000 do
+    let v = C.backoff_with_jitter delay in
+    Alcotest.(check bool)
+      (Printf.sprintf "0.0 <= %f" v) true (v >= 0.0);
+    Alcotest.(check bool)
+      (Printf.sprintf "%f < %f" v delay) true (v < delay)
+  done
+
+let test_zero_delay_returns_zero () =
+  Alcotest.(check (float 0.0))
+    "delay=0 stays 0" 0.0 (C.backoff_with_jitter 0.0)
+
+let test_negative_delay_returned_unchanged () =
+  (* Defensive: caller never passes negative, but if it did the
+     function must not call into [Random.State.float] which would
+     raise [Invalid_argument]. *)
+  Alcotest.(check (float 0.0))
+    "negative delay echoed" (-1.0)
+    (C.backoff_with_jitter (-1.0))
+
+(* 2. Variance: jitter actually desynchronises -------------------- *)
+
+let test_produces_variance_at_fixed_delay () =
+  (* Without jitter every call would return [delay] — zero variance.
+     With full jitter the mean of 1000 samples on [0, 0.5] should be
+     close to 0.25.  We allow generous slack so the test is not
+     flaky on any RNG seed. *)
+  let n = 1_000 in
+  let delay = 0.5 in
+  let sum = ref 0.0 in
+  let unique = Hashtbl.create n in
+  for _ = 1 to n do
+    let v = C.backoff_with_jitter delay in
+    sum := !sum +. v;
+    Hashtbl.replace unique v ()
+  done;
+  let mean = !sum /. float_of_int n in
+  Alcotest.(check bool)
+    (Printf.sprintf "mean %f near 0.25 (jitter active)" mean)
+    true
+    (mean > 0.15 && mean < 0.35);
+  (* Sanity check: at least 100 distinct floats out of 1000 samples
+     proves the distribution is not collapsed to a single value
+     (which would happen if jitter were a no-op). *)
+  Alcotest.(check bool)
+    (Printf.sprintf "uniques %d > 100" (Hashtbl.length unique))
+    true
+    (Hashtbl.length unique > 100)
+
+(* 3. Different domains use different RNG state ------------------- *)
+
+let test_per_domain_rng_independent () =
+  (* Each Domain.spawn gets its own [Random.State] via DLS.  Two
+     domains drawing 50 samples each must produce two distinct
+     sequences (extremely high probability under independent
+     [make_self_init] seeds; flake budget << 1e-50). *)
+  let collect () =
+    let buf = Buffer.create 256 in
+    for _ = 1 to 50 do
+      Buffer.add_string buf (Printf.sprintf "%.6f," (C.backoff_with_jitter 1.0))
+    done;
+    Buffer.contents buf
+  in
+  let d1 = Domain.spawn collect in
+  let d2 = Domain.spawn collect in
+  let s1 = Domain.join d1 in
+  let s2 = Domain.join d2 in
+  Alcotest.(check bool)
+    "two domains produce different sequences"
+    true
+    (s1 <> s2)
+
+let () =
+  Alcotest.run "distributed_lock_backoff_jitter_9645"
+    [
+      ( "range",
+        [
+          Alcotest.test_case "0 <= jitter < delay" `Quick
+            test_jitter_within_zero_and_delay;
+          Alcotest.test_case "zero delay echoes zero" `Quick
+            test_zero_delay_returns_zero;
+          Alcotest.test_case "negative delay echoed" `Quick
+            test_negative_delay_returned_unchanged;
+        ] );
+      ( "variance",
+        [
+          Alcotest.test_case "mean near delay/2 + many uniques" `Quick
+            test_produces_variance_at_fixed_delay;
+        ] );
+      ( "per-domain",
+        [
+          Alcotest.test_case "domains have independent state" `Quick
+            test_per_domain_rng_independent;
+        ] );
+    ]


### PR DESCRIPTION
## Goal

Stop the retry herd that drives the [tasks:.backlog] distributed lock to retry-budget exhaustion (#9645).

## Root cause

PR #10056 raised the retry budget (20→50) and the max delay (0.05→0.5). It did not change the **shape** of the backoff sequence: every loser of a contended acquire slept exactly \`delay\`, with \`delay\` doubling up to the cap. Sequence:

\`\`\`
0.05, 0.10, 0.20, 0.40, 0.50, 0.50, 0.50, 0.50, ...
\`\`\`

With 17 fleet actors (16 keepers + orchestrator GC) all spinning on the same \`tasks:.backlog\` lock, a collision at attempt N became another collision at attempt N+1 — every loser woke at the same instant. **50 retries decayed into 50 contention spikes instead of 50 independent attempts**, exactly the symptom in #9645 ("20/50 attempts exhausted").

This is a textbook retry-storm pattern. Without jitter, raising the retry count just raises the failure latency, not the success rate.

## Fix

Apply **full jitter** (Marc Brooker, AWS Architecture Blog, [\"Exponential Backoff And Jitter\"](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/), 2015):

| Strategy | Sleep | Effect on herd |
|---|---|---|
| Pre-fix (deterministic) | \`delay\` | All losers wake at the same instant — herd persists |
| Equal jitter | \`delay/2 + uniform[0, delay/2]\` | Half-staggered — partial fix |
| **Full jitter (this PR)** | \`uniform[0, delay]\` | Fully staggered — herd breaks |

Marc Brooker's data shows full jitter wins for throughput at high contention. Same shape used by AWS SDK, envoy, kubernetes client-go.

\`delay\` itself still doubles up to the 0.5s cap on every miss — only the actual sleep is randomised within \`[0, delay]\`.

## OCaml 5 specifics

- \`Random.State.t\` is NOT cross-domain safe.
- The codebase has precedent (\`lib/coord/nickname.ml\`) of guarding a single \`Random.State\` with \`Eio.Mutex\`. That pattern requires Eio context — which the lock-acquire path lacks (the \`Time_compat.sleep\` branch runs outside Eio).
- This PR uses \`Domain.DLS.new_key Random.State.make_self_init\` so each domain has its own RNG state. No mutex, no Eio dependency, zero contention on the RNG itself.

## Tests (\`test_distributed_lock_backoff_jitter_9645\`, 5 cases, all green)

- **range**: 1000 samples each show \`0.0 <= jitter < delay\`; \`delay=0\` echoes; negative delay echoes (defensive — caller never passes negative, but the function must not crash on it).
- **variance**: 1000 samples on \`delay=0.5\` produce mean ≈ 0.25 with ≥100 unique floats — proves jitter is active, not a pass-through.
- **per-domain**: two \`Domain.spawn\` workers each draw 50 samples; sequences differ (DLS isolation works).

Existing \`test_distributed_lock_acquire_failed_counter\` (4/4): unchanged, still green.

## Behaviour preserved

- Retry budget (50), max delay (0.5s), initial delay (0.05s) — all unchanged.
- Acquire-failed counter from PR #10201 — unchanged. Now becomes the leading indicator for whether jitter is sufficient or whether the next layer (lock-free \`claim_next\`, finer-grained sharding) is needed.
- Lock release path — unchanged.

## Verification (post-merge, on prod fleet)

- \`masc_distributed_lock_acquire_failed_total{key=\"tasks:.backlog\"}\` rate from PR #10201 should drop materially.
- \`[stale-claims] error: Failed to acquire distributed lock\` log warns on the orchestrator should disappear in normal operation.
- Lock acquire latency (if instrumented) should show smoother distribution instead of bimodal "fast win" vs "50 retries to exhaustion".

## Out of scope (separate issues / PRs)

- **Lock-free \`claim_next\`** via optimistic concurrency control on backlog \`version\`. Lower contention but bigger surface — RFC-worthy.
- **Sharding** the backlog into per-task files. Eliminates the global lock but is a wire-format change.
- **\`acquire_with_timeout\` API** that returns \`Error\` instead of \`invalid_arg\` on exhaustion — caller-side ergonomics, no contention impact.

Refs #9645. Pairs with #10056 (retry count bump) and #10201 (acquire-failed counter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)