### PR TITLE
perf(mention): cache target-keyed regex in is_mentioned

### DIFF
--- a/lib/coord/mention.ml
+++ b/lib/coord/mention.ml
@@ -104,19 +104,55 @@ let resolve_targets mode ~available_agents =
       available_agents
       |> List.filter (fun name -> agent_type_of_mention name = agent_type)
 
+(* Target-keyed cache for [is_mentioned]'s compiled regex.
+
+   The pattern interpolates [target] (an agent name) so it cannot
+   be compiled at module load like the static parse patterns above.
+   But the set of distinct targets is bounded by the agent fleet
+   (~20 in production), so a Hashtbl keyed by trimmed target is
+   enough — no LRU needed, the cache stabilises after warm-up.
+
+   Without this cache, [any_mentioned ~targets content] for N
+   targets re-ran [Re.compile] N times per call.  Per-keeper
+   message-policy evaluation (keeper_memory_policy /
+   keeper_exec_context / keeper_prompt) re-paid that on every
+   message, so with 14 keepers × per-message direct-mention checks
+   the compile cost was a sustained tax.
+
+   [Stdlib.Mutex] (not [Eio.Mutex]) because callers may run from
+   non-Eio contexts and the hold time is bounded by a
+   [Hashtbl.find_opt] + occasional one-shot compile per new target. *)
+let is_mentioned_cache : (string, Re.re) Hashtbl.t = Hashtbl.create 32
+
+let is_mentioned_cache_mu = Stdlib.Mutex.create ()
+
+let compile_target_pattern target =
+  Re.(compile (seq [
+    (* Start of string or non-mention character *)
+    group (alt [bos; compl [rg 'A' 'Z'; rg 'a' 'z'; rg '0' '9'; char '@'; char '_'; char '-']]);
+    no_case (seq [char '@'; str target]);
+    (* End of string or non-mention character *)
+    group (alt [eos; compl [rg 'A' 'Z'; rg 'a' 'z'; rg '0' '9'; char '_'; char '-']])
+  ]))
+
+let target_re target =
+  Stdlib.Mutex.lock is_mentioned_cache_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock is_mentioned_cache_mu)
+    (fun () ->
+      match Hashtbl.find_opt is_mentioned_cache target with
+      | Some re -> re
+      | None ->
+          let re = compile_target_pattern target in
+          Hashtbl.add is_mentioned_cache target re;
+          re)
+
 let is_mentioned target content =
   let target = String.trim target in
   if target = "" then
     false
   else
-    let re = Re.(compile (seq [
-      (* Start of string or non-mention character *)
-      group (alt [bos; compl [rg 'A' 'Z'; rg 'a' 'z'; rg '0' '9'; char '@'; char '_'; char '-']]);
-      no_case (seq [char '@'; str target]);
-      (* End of string or non-mention character *)
-      group (alt [eos; compl [rg 'A' 'Z'; rg 'a' 'z'; rg '0' '9'; char '_'; char '-']])
-    ])) in
-    Re.execp re content
+    Re.execp (target_re target) content
 
 let any_mentioned ~targets content =
   targets


### PR DESCRIPTION
## 문제
`is_mentioned`은 trimmed `target`을 interpolation하여 regex compile 하므로 module-level hoist 불가 (#10250와 다름). 그러나 distinct target set은 fleet bounded (~20 keepers), Hashtbl 캐시면 충분 — LRU 불필요, warm-up 후 안정.

Hot callers 모두 `any_mentioned ~targets content`를 통해 is_mentioned을 N targets × M messages 호출:
- `keeper_memory_policy.ml`: per-message direct_mention check
- `keeper_exec_context.ml`: per-message content match
- `keeper_prompt.ml`: prompt-time targets check

Pre-fix: N×M `Re.compile` 호출. After warm-up: target별 1 compile, 나머지 모두 `Re.execp` cache hit.

## 변경
- Hashtbl 키: trimmed target string → `Re.re`
- `Stdlib.Mutex` (not `Eio.Mutex`) — non-Eio context에서도 호출 가능
- Hold time bounded: `Hashtbl.find_opt` + occasional one-shot compile
- `Fun.protect`로 cancel/exception unlock 보장

#10250 (static parse-pattern hoist)과 짝 — 둘이 합쳐 Mention 모듈에서 모든 per-call Re.compile 비용 제거.

## Behavior
- regex 패턴 byte-for-byte 동일
- 빈/공백 target은 여전히 false
- `Re.execp` 결과 무변동

## Validation
- `test_mention` 14/14
- `test_mention_coverage` 44/44 (is_mentioned + any_mentioned across spawnable / nickname / empty / agent-type edge cases)