### PR TITLE
fix: resolve OAS timeouts and truncated JSON parsing errors

### DIFF
--- a/lib/cascade/cascade_client_capacity.ml
+++ b/lib/cascade/cascade_client_capacity.ml
@@ -6,13 +6,17 @@ type entry = {
 }
 
 let registry : (string, entry) Hashtbl.t = Hashtbl.create 4
-let registry_mu = Eio.Mutex.create ()
+let registry_mu = Stdlib.Mutex.create ()
+
+let with_lock mu f =
+  Stdlib.Mutex.lock mu;
+  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock mu) f
 
 let clamp_max n = if n < 1 then 1 else n
 
 let register ~url ~max_concurrent =
   let max_concurrent = clamp_max max_concurrent in
-  Eio.Mutex.use_rw ~protect:true registry_mu (fun () ->
+  with_lock registry_mu (fun () ->
       match Hashtbl.find_opt registry url with
       | None ->
         let e = { max_concurrent; active = Atomic.make 0 } in
@@ -24,11 +28,11 @@ let register ~url ~max_concurrent =
             { max_concurrent; active = existing.active })
 
 let registered_urls () =
-  Eio.Mutex.use_rw ~protect:true registry_mu (fun () ->
+  with_lock registry_mu (fun () ->
       Hashtbl.fold (fun url _ acc -> url :: acc) registry [])
 
 let snapshot () =
-  Eio.Mutex.use_rw ~protect:true registry_mu (fun () ->
+  with_lock registry_mu (fun () ->
       Hashtbl.fold
         (fun url e acc ->
            let active = Atomic.get e.active in
@@ -44,10 +48,10 @@ let snapshot () =
         registry [])
 
 let unregister_all () =
-  Eio.Mutex.use_rw ~protect:true registry_mu (fun () -> Hashtbl.clear registry)
+  with_lock registry_mu (fun () -> Hashtbl.clear registry)
 
 let lookup url =
-  Eio.Mutex.use_rw ~protect:true registry_mu (fun () -> Hashtbl.find_opt registry url)
+  with_lock registry_mu (fun () -> Hashtbl.find_opt registry url)
 
 let is_registered url = lookup url <> None
 

--- a/lib/cascade/cascade_client_capacity_history.ml
+++ b/lib/cascade/cascade_client_capacity_history.ml
@@ -54,7 +54,11 @@ let cap_ref = ref 0
 let buf : event option array ref = ref [||]
 let head = ref 0
 let count = ref 0
-let mu = Eio.Mutex.create ()
+let mu = Stdlib.Mutex.create ()
+
+let with_lock f =
+  Stdlib.Mutex.lock mu;
+  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock mu) f
 
 (* Lazy init: resolve capacity + allocate buffer on first use.  We
    do this outside [record] so [clear] / [capacity] can be called
@@ -85,7 +89,7 @@ let bump_prometheus_counter (ev : event) =
     ] ()
 
 let record ev =
-  Eio.Mutex.use_rw ~protect:true mu (fun () ->
+  with_lock (fun () ->
       ensure_initialised_locked ();
       let cap = !cap_ref in
       (!buf).(!head) <- Some ev;
@@ -94,17 +98,17 @@ let record ev =
   bump_prometheus_counter ev
 
 let clear () =
-  Eio.Mutex.use_rw ~protect:true mu (fun () ->
+  with_lock (fun () ->
       ensure_initialised_locked ();
       let cap = !cap_ref in
       for i = 0 to cap - 1 do (!buf).(i) <- None done;
       head := 0;
       count := 0)
 
-let size () = Eio.Mutex.use_rw ~protect:true mu (fun () -> !count)
+let size () = with_lock (fun () -> !count)
 
 let capacity () =
-  Eio.Mutex.use_rw ~protect:true mu (fun () ->
+  with_lock (fun () ->
       ensure_initialised_locked ();
       !cap_ref)
 
@@ -138,7 +142,7 @@ let collect_newest_first_locked () =
 
 let snapshot ?(limit = 100) ?kind ?since_ts () =
   let events =
-    Eio.Mutex.use_rw ~protect:true mu (fun () ->
+    with_lock (fun () ->
         ensure_initialised_locked ();
         collect_newest_first_locked ())
   in

--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -160,6 +160,7 @@ let load_tail_lines path ~max_lines =
           raw_lines
           |> List.filter (fun l -> String.trim l <> "")
         in
+        let all_lines = if !pos > 0 && all_lines <> [] then List.tl all_lines else all_lines in
         let total = List.length all_lines in
         if total <= max_lines then all_lines
         else

--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -160,7 +160,13 @@ let load_tail_lines path ~max_lines =
           raw_lines
           |> List.filter (fun l -> String.trim l <> "")
         in
-        let all_lines = if !pos > 0 && all_lines <> [] then List.tl all_lines else all_lines in
+        let all_lines =
+          if !pos > 0 then
+            match all_lines with
+            | _resume_overlap :: rest -> rest
+            | [] -> []
+          else all_lines
+        in
         let total = List.length all_lines in
         if total <= max_lines then all_lines
         else


### PR DESCRIPTION
## Description
Addresses Category 2 issues from the backlog:

1. **Governance `compute_judgments` Timeout:** Increased `dashboard_governance_judge_timeout_seconds` default from 60s to 300s to prevent constant 60s timeouts when scoring the board.
2. **Keeper Turn Timeout:** Bumped `MASC_KEEPER_TURN_TIMEOUT_SEC` default from 1200.0s (20m) to 3600.0s (1h) to accommodate heavy multi-turn research cycles via big cascades.
3. **Invalid JSON / Parsing Errors:**
   - Fixed `Dated_jsonl.load_tail_lines` to correctly drop the first line when reading from the middle of the file to prevent parsing truncated JSON strings (fixes `Invalid JSON: Line 1 ... Unexpected end of input`).
   - Fixed unhandled `Stdlib.Effect.Unhandled(Eio__core__Cancel.Get_context)` exceptions in capacity tests by migrating `Cascade_client_capacity` and `Cascade_client_capacity_history` from `Eio.Mutex` to `Stdlib.Mutex`, as these simple thread-safe data structures do not need cooperative yielding, mirroring the fix in #9873.