### PR TITLE
perf(coord-gc): hoist task-id alternation regex outside message loop

### DIFF
--- a/lib/coord/coord_gc.ml
+++ b/lib/coord/coord_gc.ml
@@ -250,12 +250,19 @@ let gc config ?(days=7) () =
     ) backlog.tasks
   in
 
-  (* Helper to check if content mentions an open task *)
-  let mentions_open_task content =
-    List.exists (fun task_id ->
-      let re = Re.(compile (str task_id)) in
-      Re.execp re content
-    ) open_task_ids
+  (* Substring check against any open task ID.
+
+     Old version compiled a fresh [Re.t] per (task_id × message), so a
+     GC pass over M old messages with N open tasks paid M × N compiles
+     before [execp] could even run.  The task ID set is fixed for the
+     entire pass, so collapse it into a single alternation DFA compiled
+     once outside the message loop. *)
+  let mentions_open_task =
+    match open_task_ids with
+    | [] -> fun _ -> false
+    | ids ->
+        let re = Re.(compile (alt (List.map str ids))) in
+        fun content -> Re.execp re content
   in
 
   if Sys.file_exists messages_path then begin


### PR DESCRIPTION
## Summary

`mentions_open_task` in the GC message-cleanup pass compiled a fresh `Re.t` per `(task_id × message)` pair before `execp` could even run.

```
M old messages × N open task IDs = M × N regex compiles per GC pass
```

The set of open task IDs is fixed for the whole pass, so collapse it into a single alternation DFA compiled once outside the message loop:

```ocaml
let mentions_open_task =
  match open_task_ids with
  | [] -> fun _ -> false
  | ids ->
      let re = Re.(compile (alt (List.map str ids))) in
      fun content -> Re.execp re content
in
```

Cost goes from `M × N × compile + M × N × execp` to `1 × compile + M × execp`. With 1000 old messages × 10 open tasks, ~10,000 compiles collapse to one.

Pairs with #10250/#10252 (per-call `Re.compile` removal in `Mention`) — same anti-pattern, different module.

## Test plan
- [x] `dune build @check` clean
- Behavior preserved: alternation matches iff any branch matches, identical semantics to `List.exists ... execp`. Empty list short-circuits to `false`.
- No direct unit test for `Coord_gc.gc` exists in repo; structural equivalence suffices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)