### PR TITLE
fix(persona): derive social model choices from variant SSOT

### DIFF
--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -105,7 +105,7 @@ let tool_preset_choices_json =
 ;;
 
 let social_model_choices_json =
-  string_list_to_json [ "bdi_speech_v1"; "magentic_ledger_v1" ]
+  string_list_to_json Keeper_types_profile.valid_social_model_strings
 ;;
 
 let alignment_choices = Archetypes.alignment_choices
@@ -418,8 +418,9 @@ let normalize_social_model raw =
   | None ->
     Error
       (Printf.sprintf
-         "invalid keeper.social_model '%s' (allowed: bdi_speech_v1, magentic_ledger_v1)"
-         raw)
+         "invalid keeper.social_model '%s' (allowed: %s)"
+         raw
+         (String.concat ", " Keeper_types_profile.valid_social_model_strings))
 ;;
 
 let normalize_cascade_name raw =

--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -65,6 +65,8 @@ let delivery_surface_to_string =
 
 let model_id_to_string = Keeper_social_model_types.model_id_to_string
 let model_id_of_string = Keeper_social_model_types.model_id_of_string
+let all_model_ids = Keeper_social_model_types.all_model_ids
+let valid_model_id_strings = Keeper_social_model_types.valid_model_id_strings
 let is_known_social_model = Keeper_social_model_types.is_known_social_model
 let fallback_social_model = Keeper_social_model_types.fallback_social_model
 let normalize_social_model = Keeper_social_model_types.normalize_social_model

--- a/lib/keeper/keeper_social_model.mli
+++ b/lib/keeper/keeper_social_model.mli
@@ -68,6 +68,8 @@ val delivery_surface_view_source_of_meta :
   Keeper_types.keeper_meta -> string option
 val model_id_to_string : model_id -> string
 val model_id_of_string : string -> model_id option
+val all_model_ids : model_id list
+val valid_model_id_strings : string list
 val is_known_social_model : string -> bool
 val fallback_social_model : string -> string option
 val normalize_social_model : string -> string

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -204,6 +204,9 @@ let normalize_social_model_opt = function
           Some (Keeper_social_model_types.model_id_to_string model_id)
       | None -> None)
 
+let valid_social_model_strings =
+  Keeper_social_model_types.valid_model_id_strings
+
 let lower_string_list_opt = function
   | [] -> None
   | xs -> Some (List.map String.lowercase_ascii xs)
@@ -597,8 +600,9 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
             | None ->
                 Error
                   (Printf.sprintf
-                     "invalid social_model '%s' (allowed: bdi_speech_v1, magentic_ledger_v1)"
-                     raw))
+                     "invalid social_model '%s' (allowed: %s)"
+                     raw
+                     (String.concat ", " valid_social_model_strings)))
         | None -> Ok ())
   in
   let result =

--- a/lib/keeper/social_model/keeper_social_model_types.ml
+++ b/lib/keeper/social_model/keeper_social_model_types.ml
@@ -100,6 +100,10 @@ let model_id_to_string = function
   | Bdi_speech_v1 -> "bdi_speech_v1"
   | Magentic_ledger_v1 -> "magentic_ledger_v1"
 
+let all_model_ids = [ Bdi_speech_v1; Magentic_ledger_v1 ]
+
+let valid_model_id_strings = List.map model_id_to_string all_model_ids
+
 let model_id_of_string value =
   match String.lowercase_ascii (String.trim value) with
   | "bdi_speech_v1" -> Some Bdi_speech_v1

--- a/lib/keeper/social_model/keeper_social_model_types.mli
+++ b/lib/keeper/social_model/keeper_social_model_types.mli
@@ -55,6 +55,8 @@ val default_delivery_surface_of_speech_act : speech_act -> delivery_surface
 val delivery_surface_of_string : string -> delivery_surface option
 val model_id_to_string : model_id -> string
 val model_id_of_string : string -> model_id option
+val all_model_ids : model_id list
+val valid_model_id_strings : string list
 val default_model_id : model_id
 val is_known_social_model : string -> bool
 val fallback_social_model : string -> string option

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1101,6 +1101,21 @@ let test_persona_authoring_schema_explains_effects () =
      |> Yojson.Safe.Util.member "save_tool"
      |> Yojson.Safe.Util.to_string)
 
+let test_persona_authoring_social_model_choices_follow_variant_ssot () =
+  let json = KPA.schema_json () in
+  let choices =
+    Yojson.Safe.Util.member "choice_sets" json
+    |> Yojson.Safe.Util.member "social_model"
+    |> Yojson.Safe.Util.to_list
+    |> List.map Yojson.Safe.Util.to_string
+  in
+  check (list string) "persona schema social_model choices"
+    Masc_mcp.Keeper_social_model.valid_model_id_strings
+    choices;
+  check (list string) "profile parser social_model choices"
+    Masc_mcp.Keeper_social_model.valid_model_id_strings
+    KTP.valid_social_model_strings
+
 let test_persona_authoring_axes_validate_and_default_preset () =
   let args =
     `Assoc
@@ -1541,6 +1556,8 @@ let () =
             test_persona_resolver_rejects_custom_tool_access_durable_toml;
           test_case "persona authoring schema explains effects" `Quick
             test_persona_authoring_schema_explains_effects;
+          test_case "persona authoring social_model choices follow variant SSOT" `Quick
+            test_persona_authoring_social_model_choices_follow_variant_ssot;
           test_case "persona authoring axes validate and default preset" `Quick
             test_persona_authoring_axes_validate_and_default_preset;
           test_case "persona authoring axes reject unknown choices" `Quick


### PR DESCRIPTION
Summary
- Add social-model choice helpers to the typed Keeper_social_model_types model-id variant.
- Derive persona schema choices and profile validation errors from that SSOT instead of a duplicated string list.
- Add a regression guard so persona schema/profile choices stay aligned with the variant.

Why this matters
- Persona creation exposed social_model choices from a handwritten string list while validation parsed through the typed variant. That mirror could drift silently when another social model is added.
- The schema/tooling now inherits the choices from the same typed source used by parsing.

Verification
- git diff --check origin/main..HEAD
- rg -n "bdi_speech_v1, magentic_ledger_v1|\[ \"bdi_speech_v1\"; \"magentic_ledger_v1\" \]" lib test --glob "*.ml" --glob "*.mli" (no matches)
- env DUNE_BUILD_DIR=_build_verify_social_model_ssot DUNE_JOBS=2 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_toml.exe
- ./_build_verify_social_model_ssot/default/test/test_keeper_toml.exe (82 tests)
- gh run watch 24928350791 --exit-status --interval 20 (CI green: PR Sync, Meta Guards, Health, Lint, TLA+, Build and Test, CI Gate)
