### PR TITLE
fix(telemetry): persist pre-tool gate attempts

### DIFF
--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -98,6 +98,29 @@ let extract_command_from_input (input : Yojson.Safe.t) : string =
 (* Telemetry                                                       *)
 (* -------------------------------------------------------------- *)
 
+type gate_decision_event = {
+  stage : string;
+  decision : string;
+  reason_code : string;
+  reason_text : string;
+  tool_name : string;
+  input : Yojson.Safe.t;
+  turn : int;
+  accumulated_cost_usd : float;
+  stage_latency_ms : float;
+}
+
+let ignore_gate_decision (_ : gate_decision_event) = ()
+
+let notify_gate_decision on_gate_decision (event : gate_decision_event) =
+  try on_gate_decision event
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Log.Keeper.warn
+        "keeper_guards: gate observer failed stage=%s tool=%s err=%s"
+        event.stage event.tool_name (Printexc.to_string exn)
+
 (** Emit a [masc:keeper_gate] Event_bus Custom event.
 
     Payload schema:
@@ -144,6 +167,17 @@ let emit_gate_event
       Log.Keeper.warn
         "keeper_guards: event emit failed stage=%s tool=%s err=%s"
         stage tool_name (Printexc.to_string exn))
+
+let report_gate_decision on_gate_decision
+    ~stage ~decision ~reason_code ~reason_text
+    ~tool_name ~keeper_name ~input ~turn
+    ~accumulated_cost_usd ~stage_latency_ms =
+  emit_gate_event ~stage ~decision ~reason_code ~tool_name
+    ~agent_name:keeper_name ~turn ~accumulated_cost_usd
+    ~stage_latency_ms ~reason_text;
+  notify_gate_decision on_gate_decision
+    { stage; decision; reason_code; reason_text; tool_name; input; turn;
+      accumulated_cost_usd; stage_latency_ms }
 
 (* -------------------------------------------------------------- *)
 (* Composition helpers                                             *)
@@ -197,6 +231,7 @@ let timing_guard ~(tool_start_time : float ref)
     the caller's callback returns [Some reason_text]. *)
 let custom_guard
     ~(meta_ref : Keeper_types.keeper_meta ref)
+    ~on_gate_decision
     ~(guard : tool_name:string -> input:Yojson.Safe.t -> string option)
   : Oas.Hooks.hooks =
   hooks_of_pre_tool_use (fun event ->
@@ -213,13 +248,11 @@ let custom_guard
            keeper_name tool_name;
          broadcast_tool_skipped
            ~keeper_name ~tool_name ~reason_code:"pre_tool_use_guard";
-         emit_gate_event
+         report_gate_decision on_gate_decision
            ~stage:"pre_tool_use_guard" ~decision:"override"
-           ~reason_code:"pre_tool_use_guard"
-           ~tool_name ~agent_name:keeper_name ~turn
-           ~accumulated_cost_usd
-           ~stage_latency_ms:latency_ms
-           ~reason_text:reason;
+           ~reason_code:"pre_tool_use_guard" ~reason_text:reason
+           ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
+           ~stage_latency_ms:latency_ms;
          Oas.Hooks.Override
            (render_inline_skip_reason
               ~tool_name ~reason_code:"pre_tool_use_guard"
@@ -234,13 +267,14 @@ let custom_guard
     board posts one by one). *)
 let streak_guard
     ~(meta_ref : Keeper_types.keeper_meta ref)
+    ~on_gate_decision
     ~(state : streak_state)
     ~(threshold : int)
   : Oas.Hooks.hooks =
   hooks_of_pre_tool_use (fun event ->
     match event with
     | Oas.Hooks.PreToolUse
-        { tool_name; accumulated_cost_usd; turn; _ } ->
+        { tool_name; input; accumulated_cost_usd; turn; _ } ->
       let t0 = Time_compat.now () in
       let keeper_name = (!meta_ref).Keeper_types.name in
       let prev_name, prev_count = state.entry in
@@ -260,13 +294,11 @@ let streak_guard
           keeper_name tool_name new_count;
         broadcast_tool_skipped
           ~keeper_name ~tool_name ~reason_code:"streak_gate";
-        emit_gate_event
+        report_gate_decision on_gate_decision
           ~stage:"streak_gate" ~decision:"override"
-          ~reason_code:"streak_gate"
-          ~tool_name ~agent_name:keeper_name ~turn
-          ~accumulated_cost_usd
-          ~stage_latency_ms:latency_ms
-          ~reason_text;
+          ~reason_code:"streak_gate" ~reason_text
+          ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
+          ~stage_latency_ms:latency_ms;
         Oas.Hooks.Override
           (render_inline_skip_reason
              ~tool_name ~reason_code:"streak_gate" ~reason_text)
@@ -278,12 +310,13 @@ let streak_guard
     should only be invoked by operators or controlled workflows. *)
 let deny_guard
     ~(meta_ref : Keeper_types.keeper_meta ref)
+    ~on_gate_decision
     ~(denied : string list)
   : Oas.Hooks.hooks =
   hooks_of_pre_tool_use (fun event ->
     match event with
     | Oas.Hooks.PreToolUse
-        { tool_name; accumulated_cost_usd; turn; _ } ->
+        { tool_name; input; accumulated_cost_usd; turn; _ } ->
       let t0 = Time_compat.now () in
       let keeper_name = (!meta_ref).Keeper_types.name in
       if List.mem tool_name denied then begin
@@ -293,13 +326,11 @@ let deny_guard
           keeper_name tool_name;
         broadcast_tool_skipped
           ~keeper_name ~tool_name ~reason_code:"keeper_deny";
-        emit_gate_event
+        report_gate_decision on_gate_decision
           ~stage:"keeper_deny" ~decision:"override"
-          ~reason_code:"keeper_deny"
-          ~tool_name ~agent_name:keeper_name ~turn
-          ~accumulated_cost_usd
-          ~stage_latency_ms:latency_ms
-          ~reason_text;
+          ~reason_code:"keeper_deny" ~reason_text
+          ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
+          ~stage_latency_ms:latency_ms;
         Oas.Hooks.Override
           (render_inline_skip_reason
              ~tool_name ~reason_code:"keeper_deny" ~reason_text)
@@ -311,12 +342,13 @@ let deny_guard
     [limit]. No-op when [max_cost_usd] is [None]. *)
 let cost_guard
     ~(meta_ref : Keeper_types.keeper_meta ref)
+    ~on_gate_decision
     ~(max_cost_usd : float option)
   : Oas.Hooks.hooks =
   hooks_of_pre_tool_use (fun event ->
     match event with
     | Oas.Hooks.PreToolUse
-        { tool_name; accumulated_cost_usd; turn; _ } ->
+        { tool_name; input; accumulated_cost_usd; turn; _ } ->
       let t0 = Time_compat.now () in
       let keeper_name = (!meta_ref).Keeper_types.name in
       (match max_cost_usd with
@@ -332,13 +364,11 @@ let cost_guard
            keeper_name accumulated_cost_usd limit tool_name;
          broadcast_tool_skipped
            ~keeper_name ~tool_name ~reason_code:"cost_gate";
-         emit_gate_event
+         report_gate_decision on_gate_decision
            ~stage:"cost_gate" ~decision:"override"
-           ~reason_code:"cost_gate"
-           ~tool_name ~agent_name:keeper_name ~turn
-           ~accumulated_cost_usd
-           ~stage_latency_ms:latency_ms
-           ~reason_text;
+           ~reason_code:"cost_gate" ~reason_text
+           ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
+           ~stage_latency_ms:latency_ms;
          Oas.Hooks.Override
            (render_inline_skip_reason
               ~tool_name ~reason_code:"cost_gate" ~reason_text)
@@ -350,6 +380,7 @@ let cost_guard
     [Tool_dispatch.is_destructive]. *)
 let destructive_guard
     ~(meta_ref : Keeper_types.keeper_meta ref)
+    ~on_gate_decision
     ~(enabled : bool)
   : Oas.Hooks.hooks =
   hooks_of_pre_tool_use (fun event ->
@@ -375,13 +406,11 @@ let destructive_guard
              keeper_name tool_name pattern desc;
            broadcast_tool_skipped
              ~keeper_name ~tool_name ~reason_code:"destructive_guard";
-           emit_gate_event
+           report_gate_decision on_gate_decision
              ~stage:"destructive_guard" ~decision:"override"
-             ~reason_code:"destructive_guard"
-             ~tool_name ~agent_name:keeper_name ~turn
-             ~accumulated_cost_usd
-             ~stage_latency_ms:latency_ms
-             ~reason_text;
+             ~reason_code:"destructive_guard" ~reason_text
+             ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
+             ~stage_latency_ms:latency_ms;
            Oas.Hooks.Override
              (render_inline_skip_reason
                 ~tool_name ~reason_code:"destructive_guard"
@@ -394,6 +423,7 @@ let destructive_guard
     agent Builder to resolve the decision. *)
 let governance_approval_guard
     ~(meta_ref : Keeper_types.keeper_meta ref)
+    ~on_gate_decision
   : Oas.Hooks.hooks =
   hooks_of_pre_tool_use (fun event ->
     match event with
@@ -412,13 +442,12 @@ let governance_approval_guard
       in
       if needs_approval then begin
         let latency_ms = (Time_compat.now () -. t0) *. 1000.0 in
-        emit_gate_event
+        report_gate_decision on_gate_decision
           ~stage:"governance_approval" ~decision:"approval_required"
           ~reason_code:"governance_approval"
-          ~tool_name ~agent_name:keeper_name ~turn
-          ~accumulated_cost_usd
-          ~stage_latency_ms:latency_ms
-          ~reason_text:"risk threshold reached; operator approval required";
+          ~reason_text:"risk threshold reached; operator approval required"
+          ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
+          ~stage_latency_ms:latency_ms;
         Oas.Hooks.ApprovalRequired
       end
       else Oas.Hooks.Continue
@@ -443,15 +472,16 @@ let build_chain
     ~(denied : string list)
     ~(max_cost_usd : float option)
     ~(destructive_check : bool)
+    ~on_gate_decision
     ~(pre_tool_use_guard :
         tool_name:string -> input:Yojson.Safe.t -> string option)
   : Oas.Hooks.hooks =
   compose_all [
     timing_guard ~tool_start_time;
-    custom_guard ~meta_ref ~guard:pre_tool_use_guard;
-    streak_guard ~meta_ref ~state:streak_state ~threshold:streak_threshold;
-    deny_guard ~meta_ref ~denied;
-    cost_guard ~meta_ref ~max_cost_usd;
-    destructive_guard ~meta_ref ~enabled:destructive_check;
-    governance_approval_guard ~meta_ref;
+    custom_guard ~meta_ref ~on_gate_decision ~guard:pre_tool_use_guard;
+    streak_guard ~meta_ref ~on_gate_decision ~state:streak_state ~threshold:streak_threshold;
+    deny_guard ~meta_ref ~on_gate_decision ~denied;
+    cost_guard ~meta_ref ~on_gate_decision ~max_cost_usd;
+    destructive_guard ~meta_ref ~on_gate_decision ~enabled:destructive_check;
+    governance_approval_guard ~meta_ref ~on_gate_decision;
   ]

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -60,6 +60,120 @@ let is_keeper_board_write_tool_name tool_name =
   | Some tool -> Tool_name.Keeper.is_board_write tool
   | None -> false
 
+let current_keeper_model meta =
+  let m = meta.Keeper_types.runtime.usage.last_model_used in
+  if m = "" then meta.Keeper_types.cascade_name else m
+
+let render_pre_tool_gate_output (event : Keeper_guards.gate_decision_event) =
+  if String.equal event.decision "approval_required" then
+    Printf.sprintf
+      "[tool_approval_required] tool=%s source=keeper_hook code=%s reason=%s"
+      (Keeper_guards.escape_field event.tool_name)
+      (Keeper_guards.escape_field event.reason_code)
+      (Keeper_guards.escape_field event.reason_text)
+  else
+    Keeper_guards.render_inline_skip_reason
+      ~tool_name:event.tool_name
+      ~reason_code:event.reason_code
+      ~reason_text:event.reason_text
+
+let pre_tool_gate_error (event : Keeper_guards.gate_decision_event) =
+  Printf.sprintf "%s:%s: %s"
+    event.decision event.reason_code event.reason_text
+
+let record_pre_tool_gate_attempt
+    ~(meta_ref : Keeper_types.keeper_meta ref)
+    ~(tool_call_count_ref : int ref)
+    ?(trajectory_acc : Trajectory.accumulator option)
+    (event : Keeper_guards.gate_decision_event) =
+  incr tool_call_count_ref;
+  let meta = !meta_ref in
+  let keeper_name = meta.name in
+  let model = current_keeper_model meta in
+  let safe_input = Observability_redact.redact_json_value event.input in
+  let output_text = render_pre_tool_gate_output event in
+  let error = pre_tool_gate_error event in
+  let duration_ms = Float.max 0.0 event.stage_latency_ms in
+  (try
+     Keeper_tool_call_log.log_call
+       ~keeper_name
+       ~tool_name:event.tool_name
+       ~input:safe_input
+       ~output_text
+       ~success:false
+       ~duration_ms
+       ~model
+       ~result_bytes:(String.length output_text)
+       ()
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+       Log.Keeper.warn
+         "keeper:%s pre_tool_use gate tool_call log failed tool=%s err=%s"
+         keeper_name event.tool_name (Printexc.to_string exn));
+  match trajectory_acc with
+  | None -> ()
+  | Some acc ->
+      let trace_id = acc.Trajectory.trace_id in
+      let runtime_contract =
+        Keeper_tool_call_log.runtime_contract_json_for_call
+          ~keeper_name
+          ~model
+          ()
+      in
+      let action_radius =
+        Keeper_tool_call_log.action_radius_json_for_call
+          ~keeper_name
+          ~tool_name:event.tool_name
+          ~input:safe_input
+          ~success:false
+          ~duration_ms
+          ~error
+          ()
+      in
+      let now = Time_compat.now () in
+      let turn = if event.turn > 0 then event.turn else acc.Trajectory.turn in
+      let round =
+        acc.Trajectory.entries
+        |> List.filter (fun (e : Trajectory.tool_call_entry) -> e.turn = turn)
+        |> List.length
+        |> ( + ) 1
+      in
+      let entry : Trajectory.tool_call_entry =
+        {
+          ts = now;
+          ts_iso = Types.iso8601_of_unix_seconds now;
+          turn;
+          round;
+          tool_name = event.tool_name;
+          args_json = Yojson.Safe.to_string safe_input;
+          gate_decision = Trajectory.Reject error;
+          result = Some output_text;
+          duration_ms = int_of_float (Float.round duration_ms);
+          error = Some error;
+          cost_usd = 0.0;
+        }
+      in
+      Trajectory.record_entry
+        ~runtime_contract
+        ~action_radius
+        ~on_persist_error:(fun exn ->
+          Telemetry_coverage_gap.record
+            ~masc_root:acc.Trajectory.masc_root
+            ~source:"trajectory_tool_call"
+            ~producer:"keeper_hooks_oas.pre_tool_use"
+            ~durable_store:
+              (Trajectory.trajectory_path acc.Trajectory.masc_root
+                 acc.Trajectory.keeper_name trace_id)
+            ~dashboard_surface:"/api/v1/keepers/:name/tool-stats"
+            ~stale_reason:"trajectory_append_failed"
+            ~keeper_name
+            ~trace_id
+            ~error:(Printexc.to_string exn)
+            ())
+        acc
+        entry
+
 (* #9919: counter for post_tool_use_failure events.
 
    Replaces an earlier [Heuristic_metrics.record] emit that produced
@@ -549,9 +663,18 @@ let make_hooks
      [make_hooks] closure — one state per keeper. *)
   let streak_state = Keeper_guards.make_streak_state () in
   let streak_threshold = 5 in
+  let record_gate_decision event =
+    record_pre_tool_gate_attempt
+      ~meta_ref
+      ~tool_call_count_ref
+      ?trajectory_acc
+      event
+  in
   (* Build the pre_tool_use guard chain via Hooks.compose. Each guard
      lives in Keeper_guards and emits its own masc:keeper_gate event
-     on override/approval decisions. *)
+     on override/approval decisions. The observer persists the same
+     attempted action into tool-call and trajectory lanes so blocked
+     pre-tool attempts are not invisible to tool-stats. *)
   let guard_chain =
     Keeper_guards.build_chain
       ~meta_ref
@@ -561,6 +684,7 @@ let make_hooks
       ~denied:keeper_denied_tools
       ~max_cost_usd
       ~destructive_check
+      ~on_gate_decision:record_gate_decision
       ~pre_tool_use_guard
   in
   let non_gate_hooks =

--- a/test/test_keeper_guards.ml
+++ b/test/test_keeper_guards.ml
@@ -70,6 +70,8 @@ let override_text (d : Agent_sdk.Hooks.hook_decision) : string =
   | Override s -> s
   | _ -> failwith ("expected Override, got " ^ decision_kind d)
 
+let no_gate_observer = KG.ignore_gate_decision
+
 (* ----------------------------------------------------------------- *)
 (* Utility tests                                                      *)
 (* ----------------------------------------------------------------- *)
@@ -89,6 +91,16 @@ let contains_substring (haystack : string) (needle : string) : bool =
     let _ = Str.search_forward (Str.regexp_string needle) haystack 0 in
     true
   with Not_found -> false
+
+let with_env name value f =
+  let old = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match old with
+      | Some old_value -> Unix.putenv name old_value
+      | None -> Unix.putenv name "")
+    f
 
 let test_render_inline_skip_reason () =
   let s = KG.render_inline_skip_reason
@@ -110,7 +122,8 @@ let test_render_inline_skip_reason () =
 let test_deny_guard_blocks () =
   let meta_ref = make_meta_ref "test_keeper" in
   let hook =
-    KG.deny_guard ~meta_ref ~denied:["dangerous_tool"]
+    KG.deny_guard ~meta_ref ~on_gate_decision:no_gate_observer
+      ~denied:["dangerous_tool"]
   in
   let d = invoke hook (pre_tool_use_event ~tool_name:"dangerous_tool" ()) in
   check string "denied tool -> Override" "Override" (decision_kind d);
@@ -118,10 +131,39 @@ let test_deny_guard_blocks () =
   check bool "override mentions deny list" true
     (contains_substring text "code=keeper_deny")
 
+let test_deny_guard_notifies_gate_observer () =
+  let meta_ref = make_meta_ref "test_keeper" in
+  let observed = ref [] in
+  let on_gate_decision event = observed := event :: !observed in
+  let hook =
+    KG.deny_guard ~meta_ref ~on_gate_decision ~denied:["dangerous_tool"]
+  in
+  let d =
+    invoke hook
+      (pre_tool_use_event ~tool_name:"dangerous_tool"
+         ~input:(`Assoc [ ("path", `String "/tmp/secret") ])
+         ~turn:4 ())
+  in
+  check string "denied tool -> Override" "Override" (decision_kind d);
+  match !observed with
+  | [ event ] ->
+    check string "stage" "keeper_deny" event.KG.stage;
+    check string "decision" "override" event.KG.decision;
+    check string "reason_code" "keeper_deny" event.KG.reason_code;
+    check string "tool_name" "dangerous_tool" event.KG.tool_name;
+    check int "turn" 4 event.KG.turn;
+    check bool "input preserved" true
+      (match event.KG.input with
+       | `Assoc [ ("path", `String "/tmp/secret") ] -> true
+       | _ -> false)
+  | events ->
+    failf "expected one observer event, got %d" (List.length events)
+
 let test_deny_guard_continues () =
   let meta_ref = make_meta_ref "test_keeper" in
   let hook =
-    KG.deny_guard ~meta_ref ~denied:["other_tool"]
+    KG.deny_guard ~meta_ref ~on_gate_decision:no_gate_observer
+      ~denied:["other_tool"]
   in
   let d = invoke hook (pre_tool_use_event ~tool_name:"allowed_tool" ()) in
   check string "allowed tool -> Continue" "Continue" (decision_kind d)
@@ -129,7 +171,8 @@ let test_deny_guard_continues () =
 let test_cost_guard_blocks () =
   let meta_ref = make_meta_ref "test_keeper" in
   let hook =
-    KG.cost_guard ~meta_ref ~max_cost_usd:(Some 0.10)
+    KG.cost_guard ~meta_ref ~on_gate_decision:no_gate_observer
+      ~max_cost_usd:(Some 0.10)
   in
   let d = invoke hook
     (pre_tool_use_event ~tool_name:"expensive" ~accumulated_cost_usd:0.15 ())
@@ -139,7 +182,8 @@ let test_cost_guard_blocks () =
 let test_cost_guard_under_limit () =
   let meta_ref = make_meta_ref "test_keeper" in
   let hook =
-    KG.cost_guard ~meta_ref ~max_cost_usd:(Some 0.10)
+    KG.cost_guard ~meta_ref ~on_gate_decision:no_gate_observer
+      ~max_cost_usd:(Some 0.10)
   in
   let d = invoke hook
     (pre_tool_use_event ~tool_name:"cheap" ~accumulated_cost_usd:0.05 ())
@@ -148,7 +192,10 @@ let test_cost_guard_under_limit () =
 
 let test_cost_guard_disabled () =
   let meta_ref = make_meta_ref "test_keeper" in
-  let hook = KG.cost_guard ~meta_ref ~max_cost_usd:None in
+  let hook =
+    KG.cost_guard ~meta_ref ~on_gate_decision:no_gate_observer
+      ~max_cost_usd:None
+  in
   let d = invoke hook
     (pre_tool_use_event ~tool_name:"any" ~accumulated_cost_usd:999.0 ())
   in
@@ -158,7 +205,8 @@ let test_streak_guard_under_threshold () =
   let meta_ref = make_meta_ref "test_keeper" in
   let state = KG.make_streak_state () in
   let hook =
-    KG.streak_guard ~meta_ref ~state ~threshold:5
+    KG.streak_guard ~meta_ref ~on_gate_decision:no_gate_observer
+      ~state ~threshold:5
   in
   (* 4 consecutive calls — should all Continue *)
   for _ = 1 to 4 do
@@ -170,7 +218,8 @@ let test_streak_guard_at_threshold () =
   let meta_ref = make_meta_ref "test_keeper" in
   let state = KG.make_streak_state () in
   let hook =
-    KG.streak_guard ~meta_ref ~state ~threshold:5
+    KG.streak_guard ~meta_ref ~on_gate_decision:no_gate_observer
+      ~state ~threshold:5
   in
   (* 4 calls Continue, 5th blocks *)
   for _ = 1 to 4 do
@@ -187,7 +236,8 @@ let test_streak_guard_resets_on_different_tool () =
   let meta_ref = make_meta_ref "test_keeper" in
   let state = KG.make_streak_state () in
   let hook =
-    KG.streak_guard ~meta_ref ~state ~threshold:3
+    KG.streak_guard ~meta_ref ~on_gate_decision:no_gate_observer
+      ~state ~threshold:3
   in
   (* 2 calls of tool_a, then tool_b resets counter *)
   let _ = invoke hook (pre_tool_use_event ~tool_name:"tool_a" ()) in
@@ -203,7 +253,8 @@ let test_streak_state_manual_reset () =
   let meta_ref = make_meta_ref "test_keeper" in
   let state = KG.make_streak_state () in
   let hook =
-    KG.streak_guard ~meta_ref ~state ~threshold:3
+    KG.streak_guard ~meta_ref ~on_gate_decision:no_gate_observer
+      ~state ~threshold:3
   in
   let _ = invoke hook (pre_tool_use_event ~tool_name:"t" ()) in
   let _ = invoke hook (pre_tool_use_event ~tool_name:"t" ()) in
@@ -217,16 +268,43 @@ let test_custom_guard_blocks () =
   let guard ~tool_name ~input:_ =
     if tool_name = "bad" then Some "user blocked" else None
   in
-  let hook = KG.custom_guard ~meta_ref ~guard in
+  let hook =
+    KG.custom_guard ~meta_ref ~on_gate_decision:no_gate_observer ~guard
+  in
   let d = invoke hook (pre_tool_use_event ~tool_name:"bad" ()) in
   check string "custom blocked -> Override" "Override" (decision_kind d)
 
 let test_custom_guard_passthrough () =
   let meta_ref = make_meta_ref "test_keeper" in
   let guard ~tool_name:_ ~input:_ = None in
-  let hook = KG.custom_guard ~meta_ref ~guard in
+  let hook =
+    KG.custom_guard ~meta_ref ~on_gate_decision:no_gate_observer ~guard
+  in
   let d = invoke hook (pre_tool_use_event ~tool_name:"ok" ()) in
   check string "custom None -> Continue" "Continue" (decision_kind d)
+
+let test_governance_approval_notifies_gate_observer () =
+  with_env "MASC_GOVERNANCE_LEVEL" "production" (fun () ->
+    let meta_ref = make_meta_ref "test_keeper" in
+    let observed = ref [] in
+    let on_gate_decision event = observed := event :: !observed in
+    let hook = KG.governance_approval_guard ~meta_ref ~on_gate_decision in
+    let d =
+      invoke hook
+        (pre_tool_use_event ~tool_name:"keeper_fs_edit"
+           ~input:(`Assoc [ ("path", `String "/tmp/file"); ("content", `String "x") ])
+           ())
+    in
+    check string "high-risk tool -> ApprovalRequired"
+      "ApprovalRequired" (decision_kind d);
+    match !observed with
+    | [ event ] ->
+      check string "stage" "governance_approval" event.KG.stage;
+      check string "decision" "approval_required" event.KG.decision;
+      check string "reason_code" "governance_approval" event.KG.reason_code;
+      check string "tool_name" "keeper_fs_edit" event.KG.tool_name
+    | events ->
+      failf "expected one observer event, got %d" (List.length events))
 
 let test_timing_guard_sets_time_and_continues () =
   let tool_start_time = ref 0.0 in
@@ -248,8 +326,9 @@ let test_compose_all_empty () =
 let test_compose_all_continue_all () =
   let meta_ref = make_meta_ref "test_keeper" in
   let hooks = KG.compose_all [
-    KG.deny_guard ~meta_ref ~denied:[];
-    KG.cost_guard ~meta_ref ~max_cost_usd:None;
+    KG.deny_guard ~meta_ref ~on_gate_decision:no_gate_observer ~denied:[];
+    KG.cost_guard ~meta_ref ~on_gate_decision:no_gate_observer
+      ~max_cost_usd:None;
   ] in
   let d = invoke hooks (pre_tool_use_event ~tool_name:"anything" ()) in
   check string "all Continue -> Continue" "Continue" (decision_kind d)
@@ -258,8 +337,10 @@ let test_compose_all_short_circuits_at_first_override () =
   let meta_ref = make_meta_ref "test_keeper" in
   (* deny_guard blocks first -> cost_guard should not fire *)
   let hooks = KG.compose_all [
-    KG.deny_guard ~meta_ref ~denied:["blocked_tool"];
-    KG.cost_guard ~meta_ref ~max_cost_usd:(Some 0.10);
+    KG.deny_guard ~meta_ref ~on_gate_decision:no_gate_observer
+      ~denied:["blocked_tool"];
+    KG.cost_guard ~meta_ref ~on_gate_decision:no_gate_observer
+      ~max_cost_usd:(Some 0.10);
   ] in
   let d = invoke hooks
     (pre_tool_use_event ~tool_name:"blocked_tool"
@@ -276,8 +357,10 @@ let test_compose_all_preserves_order () =
   let streak_state = KG.make_streak_state () in
   (* streak_guard fires first; after 3 calls it blocks before reaching cost_guard *)
   let hooks = KG.compose_all [
-    KG.streak_guard ~meta_ref ~state:streak_state ~threshold:3;
-    KG.cost_guard ~meta_ref ~max_cost_usd:(Some 0.10);
+    KG.streak_guard ~meta_ref ~on_gate_decision:no_gate_observer
+      ~state:streak_state ~threshold:3;
+    KG.cost_guard ~meta_ref ~on_gate_decision:no_gate_observer
+      ~max_cost_usd:(Some 0.10);
   ] in
   let _ = invoke hooks (pre_tool_use_event ~tool_name:"x"
                           ~accumulated_cost_usd:0.05 ()) in
@@ -316,6 +399,8 @@ let () = run "Keeper_guards" [
   ];
   "deny_guard", [
     test_case "blocks denied tool" `Quick test_deny_guard_blocks;
+    test_case "notifies observer on block" `Quick
+      test_deny_guard_notifies_gate_observer;
     test_case "continues for allowed tool" `Quick test_deny_guard_continues;
   ];
   "cost_guard", [
@@ -332,6 +417,10 @@ let () = run "Keeper_guards" [
   "custom_guard", [
     test_case "user blocks" `Quick test_custom_guard_blocks;
     test_case "user passes through" `Quick test_custom_guard_passthrough;
+  ];
+  "governance_approval_guard", [
+    test_case "notifies observer on approval required" `Quick
+      test_governance_approval_notifies_gate_observer;
   ];
   "timing_guard", [
     test_case "sets time and continues" `Quick test_timing_guard_sets_time_and_continues;

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2937,6 +2937,120 @@ let test_run_keeper_cycle_records_trajectory_source_contract () =
     (source_file_contains "lib/keeper/keeper_unified_turn.ml"
        "Printf.sprintf \"turn_livelock:%s\"")
 
+let test_pre_tool_gate_records_durable_attempt_telemetry () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      KTCL.reset_for_testing ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let keeper_name = "pre-tool-gate-keeper" in
+      let meta_ref = ref (make_meta keeper_name) in
+      let config = Masc_mcp.Coord.default_config base_dir in
+      let masc_root = Masc_mcp.Coord.masc_root_dir config in
+      let trace_id = "trace-pre-tool-gate" in
+      let acc =
+        Masc_mcp.Trajectory.create_accumulator
+          ~masc_root ~keeper_name ~trace_id ~generation:9
+      in
+      KTCL.reset_for_testing ();
+      KTCL.init ~base_path:base_dir ();
+      KTCL.set_turn_context
+        ~keeper_name
+        ~agent_name:"pre-tool-gate-agent"
+        ~trace_id
+        ~session_id:"session-pre-tool-gate"
+        ~generation:9
+        ~turn:3
+        ~keeper_turn_id:3
+        ~task_id:"task-pre-tool"
+        ~goal_ids:["goal-pre-tool"]
+        ~approval_mode:"manual"
+        ~tool_surface_class:"execution"
+        ~visible_tool_count:1
+        ~required_tools:["keeper_bash"]
+        ();
+      let hooks =
+        HK.make_hooks
+          ~meta_ref
+          ~generation:9
+          ~pre_tool_use_guard:(fun ~tool_name:_ ~input:_ ->
+            Some "operator approval required before dispatch")
+          ~trajectory_acc:acc
+          ()
+      in
+      let schedule : Agent_sdk.Hooks.tool_schedule =
+        {
+          planned_index = 0;
+          batch_index = 0;
+          batch_size = 1;
+          concurrency_class = "default";
+          batch_kind = "sequential";
+        }
+      in
+      let decision =
+        Agent_sdk.Hooks.invoke hooks.pre_tool_use
+          (Agent_sdk.Hooks.PreToolUse
+             {
+               tool_use_id = "toolu_pre_gate";
+               tool_name = "keeper_bash";
+               input = `Assoc [ ("cmd", `String "git status --short") ];
+               accumulated_cost_usd = 0.0;
+               turn = 3;
+               schedule;
+             })
+      in
+      check string "custom gate blocked"
+        "Override"
+        (Agent_sdk.Hooks.decision_kind_to_string
+           (Agent_sdk.Hooks.classify_decision decision));
+      let entries =
+        Masc_mcp.Trajectory.read_entries ~masc_root ~keeper_name ~trace_id
+      in
+      check int "trajectory entry count" 1 (List.length entries);
+      (match entries with
+       | [ entry ] ->
+         check string "trajectory tool" "keeper_bash" entry.tool_name;
+         check int "trajectory turn" 3 entry.turn;
+         (match entry.gate_decision with
+          | Masc_mcp.Trajectory.Reject reason ->
+            check bool "reject reason names pre-tool guard" true
+              (contains_substring reason "pre_tool_use_guard")
+          | Masc_mcp.Trajectory.Pass ->
+            fail "expected rejected gate decision");
+         check bool "trajectory error present" true
+           (Option.is_some entry.error)
+       | _ -> fail "expected one trajectory entry");
+      let raw_trajectory =
+        read_jsonl_line
+          (Masc_mcp.Trajectory.trajectory_path masc_root keeper_name trace_id)
+      in
+      let runtime_contract =
+        Yojson.Safe.Util.member "runtime_contract" raw_trajectory
+      in
+      check string "runtime contract keeper" keeper_name
+        Yojson.Safe.Util.(runtime_contract |> member "keeper_name" |> to_string);
+      check string "runtime contract trace" trace_id
+        Yojson.Safe.Util.(runtime_contract |> member "trace_id" |> to_string);
+      let action_radius =
+        Yojson.Safe.Util.member "action_radius" raw_trajectory
+      in
+      check string "action radius tool" "keeper_bash"
+        Yojson.Safe.Util.(action_radius |> member "tool_name" |> to_string);
+      check bool "action radius failed" false
+        Yojson.Safe.Util.(action_radius |> member "success" |> to_bool);
+      let tool_call_entries = KTCL.read_recent ~keeper_name ~n:1 () in
+      check int "tool-call log entry count" 1 (List.length tool_call_entries);
+      let tool_call = List.hd tool_call_entries in
+      check string "tool-call log tool" "keeper_bash"
+        (Safe_ops.json_string ~default:"" "tool" tool_call);
+      check bool "tool-call log failed" false
+        (Safe_ops.json_bool ~default:true "success" tool_call);
+      check string "tool-call trace" trace_id
+        (Safe_ops.json_string ~default:"" "trace_id" tool_call))
+
 let test_run_keeper_cycle_surfaces_side_effect_failures_source_contract () =
   check bool "keeper cycle records side-effect issues in registry" true
     (source_file_contains "lib/keeper/keeper_unified_turn.ml"
@@ -6357,6 +6471,8 @@ let () =
             test_run_keeper_cycle_skips_non_executable_phase;
           test_case "run_keeper_cycle records trajectory contract" `Quick
             test_run_keeper_cycle_records_trajectory_source_contract;
+          test_case "pre-tool gates record durable attempt telemetry" `Quick
+            test_pre_tool_gate_records_durable_attempt_telemetry;
           test_case "run_keeper_cycle surfaces side-effect failures contract"
             `Quick
             test_run_keeper_cycle_surfaces_side_effect_failures_source_contract;


### PR DESCRIPTION
## Summary
- Persist keeper pre-tool gate decisions into both durable tool-call JSONL and trajectory rows before execution happens.
- Wire guard decisions through a MASC-side observer, keeping keeper/task/sandbox semantics out of OAS.
- Preserve `runtime_contract` and `action_radius` on blocked attempts so `/tool-stats` and `/tool-calls` can agree on approval-required or rejected tool attempts.
- Add regressions for observer delivery, approval-required gates, and persisted runtime/action metadata.

Fixes #10246.

## Verification
- `env DUNE_BUILD_DIR=_build_10246_approval_gate_trajectory DUNE_JOBS=2 DUNE_CACHE=disabled MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_keeper_guards.exe test/test_keeper_unified.exe`
- `_build_10246_approval_gate_trajectory/default/test/test_keeper_guards.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-10246-pretool _build_10246_approval_gate_trajectory/default/test/test_keeper_unified.exe`
- `git diff --check origin/main..HEAD`
- `bash scripts/ml_line_cap_audit.sh --baseline-ref origin/main --fail-on-regression`
- `bash scripts/ci/check-telemetry-coverage.sh`