### PR TITLE
[#9571] refactor(paths): SSOT masc_dirname (batch 5 of N)

### DIFF
--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -1234,8 +1234,9 @@ let handle_keeper_status ctx args : tool_result =
              ("history", `String history_path);
              ("history_internal", `String internal_history_path);
              ("evidence_dir", `String
-               (Filename.concat ctx.config.base_path
-                 (Printf.sprintf ".masc/evidence/%s/%s"
+               (Filename.concat
+                 (Common.masc_dir_from_base_path ~base_path:ctx.config.base_path)
+                 (Printf.sprintf "evidence/%s/%s"
                    (Coord_utils.safe_filename m.name)
                    (Coord_utils.safe_filename (Keeper_id.Trace_id.to_string m.runtime.trace_id)))));
            ]);

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -132,7 +132,9 @@ let today_yyyymmdd () =
     (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
 
 let legacy_status_rel id =
-  Printf.sprintf ".masc/connectors/%s/status.json" id
+  Filename.concat
+    Common.masc_dirname
+    (Printf.sprintf "connectors/%s/status.json" id)
 
 type sidecar_status_config = {
   env_names : string list;
@@ -284,8 +286,9 @@ let log_file_candidates ?sidecar_root ?project_root ~base_path id =
   let roots = sidecar_root_candidates ?sidecar_root ?project_root ~base_path () in
   roots
   |> List.map (fun root ->
-         Filename.concat root
-           (Printf.sprintf ".masc/logs/%s-sidecar-%s.log" id (today_yyyymmdd ())))
+         Filename.concat
+           (Common.masc_dir_from_base_path ~base_path:root)
+           (Printf.sprintf "logs/%s-sidecar-%s.log" id (today_yyyymmdd ())))
   |> dedupe_keep_order
 
 let today_log_file ?sidecar_root ?project_root ~base_path id =
@@ -293,8 +296,9 @@ let today_log_file ?sidecar_root ?project_root ~base_path id =
   |> first_existing_or_first
   |> Option.value
        ~default:
-         (Filename.concat base_path
-            (Printf.sprintf ".masc/logs/%s-sidecar-%s.log" id (today_yyyymmdd ())))
+         (Filename.concat
+            (Common.masc_dir_from_base_path ~base_path)
+            (Printf.sprintf "logs/%s-sidecar-%s.log" id (today_yyyymmdd ())))
 
 let runtime_sidecar_dir_result ?base_path id =
   let runtime_base_path = runtime_base_path ?base_path () in

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -979,9 +979,12 @@ let test_masc_dirname_ssot_contracts () =
     "lib/tool_team_memory.ml";
     "lib/exec_core.ml";
     "lib/keeper/keeper_accountability.ml";
-    (* batch 4 (this PR — dashboard token paths and approval queue audit store) *)
+    (* batch 4 (#10262) *)
     "lib/server/server_routes_http_routes_dashboard.ml";
     "lib/keeper/keeper_approval_queue.ml";
+    (* batch 5 (this PR — sidecar relative paths and keeper_status_detail evidence dir) *)
+    "lib/server/server_routes_http_routes_sidecar.ml";
+    "lib/keeper/keeper_status_detail.ml";
   ] in
   let file_uses_masc_dir_helper file =
     file_contains_pattern file "Common.masc_dir_from_base_path"


### PR DESCRIPTION
## 요약

`#9571` SSOT 마이그레이션의 batch 5입니다. `.masc/<sub>` 리터럴을 `Common.masc_dirname` (relative-only) 또는 `Common.masc_dir_from_base_path` (base-rooted) 헬퍼로 교체합니다.

## 변경 파일

| 파일 | 함수 | 형태 |
|------|------|------|
| `lib/server/server_routes_http_routes_sidecar.ml` | `legacy_status_rel` | **relative**: `Common.masc_dirname` |
| 동일 | `log_file_candidates` | **base-rooted**: per-root `masc_dir_from_base_path` |
| 동일 | `today_log_file` default | **base-rooted**: `masc_dir_from_base_path` |
| `lib/keeper/keeper_status_detail.ml` | evidence_dir builder | **base-rooted** |

## 두 가지 패턴

이번 배치는 처음으로 **relative-only path** 패턴을 다룹니다.

```ocaml
(* 1. base-rooted (기존 4 batches와 동일) *)
Filename.concat
  (Common.masc_dir_from_base_path ~base_path)
  "logs/foo.log"
(* = base_path/.masc/logs/foo.log *)

(* 2. relative-only (이번 batch부터) *)
Filename.concat
  Common.masc_dirname
  "connectors/X/status.json"
(* = .masc/connectors/X/status.json — caller가 이후 base_path와 concat *)
```

`legacy_status_rel`은 호출자가 결과에 `base_path` 또는 다른 root를 붙이는 helper이므로 *relative*만 반환해야 함. 이 경우 `Common.masc_dirname` 상수가 적합.

## 경로 대수 불변성 (regression risk = 0)

```
Common.masc_dirname = ".masc"
Common.masc_dir_from_base_path ~base_path = Filename.concat base_path ".masc"
```

따라서 마이그레이션 전후 디스크 경로 동일.

## 검증

```text
DUNE_CACHE=disabled dune build --root . --cache=disabled @check
→ EXIT=0

dune exec test/test_ci_hardening_source.exe
→ 36/36 OK (source guard, batch 5 entries 추가)

dune exec test/test_sidecar_lifecycle_routes.exe
→ 45/45 OK (sidecar 직접 단위 테스트)
```

## 후속 (남은 사이트)

- `lib/gate/channel_gate_*_state.ml` 모듈 레벨 상수 (별도 idiom)
- `bin/*` CLI 도구

## Defensive guards

- Draft + `do-not-merge` label
- `gh pr merge --disable-auto`

## 관련

- Issue: `#9571`
- 배치: 1=`#10237` (merged), 2=`#10249` (open), 3=`#10257` (open), 4=`#10262` (open), **5=this**
