### PR TITLE
perf(mcp-call-tool): replace regex-based contains_casefold with byte scan

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -28,10 +28,35 @@ let int_of_env_default name ~default ~min_v ~max_v =
       in
       max min_v (min max_v parsed)
 
+(* Substring containment, ASCII case-insensitive.
+
+   Old version compiled a fresh [Re.t] from the needle on every call —
+   ~20 hot call-sites, all string literals, mostly tool-error
+   classification on the per-call path.  The needles are short
+   (< 30 chars) and haystacks are bounded error messages, so a naive
+   byte-wise scan with inline [Char.lowercase_ascii] is strictly
+   cheaper than DFA construction and avoids the two
+   [String.lowercase_ascii] allocations the old form needed. *)
 let contains_casefold haystack needle =
-  let haystack = String.lowercase_ascii haystack in
-  let needle = String.lowercase_ascii needle in
-  Re.execp (Re.str needle |> Re.compile) haystack
+  let nlen = String.length needle in
+  let hlen = String.length haystack in
+  if nlen = 0 then true
+  else if nlen > hlen then false
+  else
+    let rec match_at i j =
+      if j = nlen then true
+      else if Char.lowercase_ascii (String.unsafe_get haystack (i + j))
+            <> Char.lowercase_ascii (String.unsafe_get needle j)
+      then false
+      else match_at i (j + 1)
+    in
+    let last = hlen - nlen in
+    let rec loop i =
+      if i > last then false
+      else if match_at i 0 then true
+      else loop (i + 1)
+    in
+    loop 0
 
 let parse_status_from_message ~success ~message =
   if not success then

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -88,6 +88,19 @@ let test_success_quality_has_no_issues () =
   check bool "passed" true (quality |> U.member "passed" |> U.to_bool);
   check int "issue count" 0 (quality |> U.member "issues" |> U.to_list |> List.length)
 
+let test_contains_casefold_keeps_semantics () =
+  let contains = Masc_mcp.Mcp_server_eio_call_tool.contains_casefold in
+  check bool "empty needle" true (contains "anything" "");
+  check bool "exact match" true (contains "auth required" "auth required");
+  check bool "ascii casefold" true
+    (contains "Auth REQUIRED by server" "auth required");
+  check bool "middle substring" true
+    (contains "prefix temporary network suffix" "TEMPORARY NETWORK");
+  check bool "numeric literal" true
+    (contains "HTTP 503 Service Unavailable" "503");
+  check bool "needle longer than haystack" false (contains "short" "shorter");
+  check bool "absent substring" false (contains "Invalid JSON" "timeout")
+
 let test_transition_has_no_fixed_timeout () =
   check bool "masc_transition has no fixed timeout"
     true
@@ -344,6 +357,8 @@ let () =
           test_case "timeout is error" `Quick test_timeout_quality_is_error;
           test_case "generic failure is error" `Quick test_generic_failure_quality_is_error;
           test_case "success has no issues" `Quick test_success_quality_has_no_issues;
+          test_case "contains casefold keeps semantics" `Quick
+            test_contains_casefold_keeps_semantics;
           test_case "transition has no fixed timeout" `Quick test_transition_has_no_fixed_timeout;
           test_case "persona generate timeout exceeds OAS budget" `Quick
             test_persona_generate_timeout_exceeds_oas_budget;


### PR DESCRIPTION
## Summary

`Mcp_server_eio_call_tool.contains_casefold` compiled a fresh `Re.t` from the needle on every call:

```ocaml
let contains_casefold haystack needle =
  let haystack = String.lowercase_ascii haystack in
  let needle = String.lowercase_ascii needle in
  Re.execp (Re.str needle |> Re.compile) haystack
```

~20 hot call-sites pass string literals on tool-dispatch paths (`parse_status_from_message`, `is_retryable_error`, auth-required detection). Each call paid:
- 2 `String.lowercase_ascii` allocations
- `Re.compile` of an `str` pattern (DFA construction)
- `Re.execp` over the lowered haystack

Replaced with a byte-wise scan using inline `Char.lowercase_ascii`:

```ocaml
let contains_casefold haystack needle =
  let nlen = String.length needle in
  let hlen = String.length haystack in
  if nlen = 0 then true
  else if nlen > hlen then false
  else
    let rec match_at i j = ... in
    let last = hlen - nlen in
    let rec loop i = ... in
    loop 0
```

No allocation in the loop. Aligns with the peer definition in `Server_routes_http_keeper_stream` which already uses a byte-wise scan.

Same anti-pattern series:
- #10250 / #10252: `Mention` per-call `Re.compile` (merged)
- #10260: `Coord_gc.mentions_open_task` M×N compile (in-flight)
- This PR: `contains_casefold` per-call `Re.compile`

## Test plan
- [x] `dune build @check` clean
- Behavior preserved: empty-needle → `true`, `nlen > hlen` → `false`, ASCII case fold via `Char.lowercase_ascii` (identical semantics to `String.lowercase_ascii` byte-by-byte).
- No direct unit test exists; semantics-equivalent rewrite of a 4-line helper, structurally verifiable from the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)