### PR TITLE
fix(dashboard): prefer streamed fleet snapshots

### DIFF
--- a/dashboard/eslint.config.mjs
+++ b/dashboard/eslint.config.mjs
@@ -10,6 +10,7 @@ const TARGET_FILES = [
   'src/components/common/feedback-state.ts',
   'src/components/common/markdown.ts',
   'src/components/connector-status.ts',
+  'src/components/fleet-fsm-matrix.ts',
   'src/components/harness-health-state.ts',
   'src/components/harness-health.ts',
   'src/components/keeper-tool-call-inspector.ts',
@@ -25,6 +26,7 @@ const TARGET_FILES = [
 const TEST_FILES = [
   'src/components/common/markdown.test.ts',
   'src/components/connector-status.test.ts',
+  'src/components/fleet-fsm-matrix.test.ts',
   'src/components/keeper-tool-call-inspector.test.ts',
   'src/components/transport-health.test.ts',
   'src/lib/async-state.test.ts',

--- a/dashboard/src/components/fleet-fsm-matrix.test.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.test.ts
@@ -1,4 +1,14 @@
-import { describe, it, expect } from 'vitest'
+import { html } from 'htm/preact'
+import { act, cleanup, render, screen } from '@testing-library/preact'
+import { afterEach, describe, it, expect, vi } from 'vitest'
+
+const { fetchKeepersCompositeMock } = vi.hoisted(() => ({
+  fetchKeepersCompositeMock: vi.fn(),
+}))
+
+vi.mock('../api/keeper', () => ({
+  fetchKeepersComposite: fetchKeepersCompositeMock,
+}))
 
 import {
   chipClassFor,
@@ -12,8 +22,14 @@ import {
   tallyInvariantViolations,
   tallyRuntimeAttention,
   type KeeperFleetHistory,
+  FleetFsmMatrix,
 } from './fleet-fsm-matrix'
-import type { KeeperCompositeExecution, KeeperCompositeSnapshot } from '../api/keeper'
+import { fleetCompositeSnapshot } from '../composite-signals'
+import type {
+  FleetCompositeSnapshot,
+  KeeperCompositeExecution,
+  KeeperCompositeSnapshot,
+} from '../api/keeper'
 
 function snapshot(
   overrides: Partial<KeeperCompositeSnapshot> & {
@@ -67,6 +83,23 @@ function execution(
     ...overrides,
   }
 }
+
+function fleetSnapshot(
+  snapshots: KeeperCompositeSnapshot[] = [snapshot()],
+): FleetCompositeSnapshot {
+  return {
+    generated_at: 1_713_000_000,
+    count: snapshots.length,
+    snapshots,
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+  fetchKeepersCompositeMock.mockReset()
+  fleetCompositeSnapshot.value = null
+})
 
 describe('chipClassFor', () => {
   it('maps known states to the right semantic tone', () => {
@@ -379,5 +412,39 @@ describe('filterKeeperSnapshots', () => {
     const out = filterKeeperSnapshots(rows, 'gen12')
     expect(out).not.toBe(rows)
     expect(out.length).toBe(2)
+  })
+})
+
+describe('FleetFsmMatrix streaming fallback', () => {
+  it('uses an existing streamed snapshot without starting fallback polling', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-25T00:00:00Z'))
+    fetchKeepersCompositeMock.mockResolvedValue(
+      fleetSnapshot([snapshot({ name: 'fallback' })]),
+    )
+    fleetCompositeSnapshot.value = fleetSnapshot([snapshot({ name: 'streamed' })])
+
+    render(html`<${FleetFsmMatrix} pollIntervalMs=${1000} />`)
+    await act(async () => {})
+
+    expect(screen.getByText('streamed')).toBeTruthy()
+    expect(fetchKeepersCompositeMock).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000)
+    })
+
+    expect(fetchKeepersCompositeMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to fetching immediately when no streamed snapshot exists', async () => {
+    fetchKeepersCompositeMock.mockResolvedValue(
+      fleetSnapshot([snapshot({ name: 'fallback' })]),
+    )
+
+    render(html`<${FleetFsmMatrix} pollIntervalMs=${1000} />`)
+
+    expect(await screen.findByText('fallback')).toBeTruthy()
+    expect(fetchKeepersCompositeMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -18,7 +18,7 @@
  */
 
 import { html } from 'htm/preact'
-import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 
 import { fetchKeepersComposite } from '../api/keeper'
 import type {
@@ -411,43 +411,58 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState<boolean>(true)
   const [query, setQuery] = useState<string>('')
+  const lastStreamedAtRef = useRef<number | null>(null)
   // Observation ring. Ref rather than state because pushObservation
   // returns a fresh record per tick and we pair it with a setData call
   // which triggers the re-render — avoids a redundant state subscription.
   const historyRef = useRef<KeeperFleetHistory>({})
 
+  const applySnapshot = useCallback((snap: FleetCompositeSnapshot) => {
+    historyRef.current = pushObservation(
+      historyRef.current,
+      snap.snapshots,
+      FLEET_HISTORY_LEN,
+    )
+    setData(snap)
+    setError(null)
+    setLoading(false)
+  }, [])
+
   useEffect(() => {
     if (!allowStreamedData) return
     const applyStreamedSnapshot = (snap: FleetCompositeSnapshot | null) => {
       if (!snap) return
-      historyRef.current = pushObservation(
-        historyRef.current,
-        snap.snapshots,
-        FLEET_HISTORY_LEN,
-      )
-      setData(snap)
-      setError(null)
-      setLoading(false)
+      lastStreamedAtRef.current = Date.now()
+      applySnapshot(snap)
     }
     applyStreamedSnapshot(fleetCompositeSnapshot.value)
     return fleetCompositeSnapshot.subscribe(applyStreamedSnapshot)
-  }, [allowStreamedData])
+  }, [allowStreamedData, applySnapshot])
 
   useEffect(() => {
     let cancelled = false
     let timer: ReturnType<typeof setTimeout> | null = null
+    const streamStaleAfterMs = Math.max(intervalMs * 2, 1)
+    // In live mode the pushed fleet snapshot is primary; polling is only a
+    // seed/watchdog path so this matrix does not double-hit the backend every
+    // interval while the stream is healthy.
+    const shouldFetchFallback = (): boolean => {
+      if (!allowStreamedData) return true
+      const lastStreamedAt = lastStreamedAtRef.current
+      if (lastStreamedAt == null) return true
+      return Date.now() - lastStreamedAt >= streamStaleAfterMs
+    }
     const tick = async () => {
+      if (!shouldFetchFallback()) {
+        if (!cancelled) {
+          timer = setTimeout(tick, intervalMs)
+        }
+        return
+      }
       try {
         const snap = await fetcher()
         if (!cancelled) {
-          historyRef.current = pushObservation(
-            historyRef.current,
-            snap.snapshots,
-            FLEET_HISTORY_LEN,
-          )
-          setData(snap)
-          setError(null)
-          setLoading(false)
+          applySnapshot(snap)
         }
       } catch (e) {
         if (!cancelled) {
@@ -460,12 +475,16 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
         }
       }
     }
-    tick()
+    if (allowStreamedData && fleetCompositeSnapshot.value) {
+      timer = setTimeout(tick, intervalMs)
+    } else {
+      void tick()
+    }
     return () => {
       cancelled = true
       if (timer) clearTimeout(timer)
     }
-  }, [fetcher, intervalMs])
+  }, [allowStreamedData, applySnapshot, fetcher, intervalMs])
 
   const tallies = useMemo(
     () => (data ? tallyInvariantViolations(data.snapshots) : null),
@@ -609,11 +628,12 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
             ${visibleSnapshots.map(snap => {
               const anyViolated = INVARIANT_KEYS.some(k => !snap.invariants[k])
               const attention = runtimeAttentionForSnapshot(snap, data.generated_at)
-              const rowTone = anyViolated || attention.level === 'blocked'
-                ? 'border-l-2 border-[var(--bad-20)]'
-                : attention.level === 'stale' || attention.level === 'idle'
-                  ? 'border-l-2 border-[var(--warn-20)]'
-                  : ''
+              let rowTone = ''
+              if (anyViolated || attention.level === 'blocked') {
+                rowTone = 'border-l-2 border-[var(--bad-20)]'
+              } else if (attention.level === 'stale' || attention.level === 'idle') {
+                rowTone = 'border-l-2 border-[var(--warn-20)]'
+              }
               const name = inferKeeperNameFrom(snap)
               return html`
                 <tr


### PR DESCRIPTION
## Summary
- make FleetFsmMatrix treat pushed fleet snapshots as the primary live source
- keep HTTP polling only as the initial seed/watchdog fallback when the stream is absent or stale
- add focused regression tests and include the matrix files in dashboard ESLint coverage

## Why it matters
The dashboard already receives fleet composite snapshots from the live stream. Polling the same backend endpoint every interval while streamed data is fresh creates avoidable frontend/server work and makes transport changes look more valuable than they are. This keeps the existing fallback behavior without double-hitting the backend during healthy streaming.

## Validation
- pnpm exec vitest run src/components/fleet-fsm-matrix.test.ts --pool=threads --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- pnpm exec eslint src/components/fleet-fsm-matrix.ts src/components/fleet-fsm-matrix.test.ts
- curl http://127.0.0.1:8935/health
- curl http://127.0.0.1:8935/api/v1/dashboard/transport-health