### PR TITLE
fix(keeper): render tool guidance from active policy

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -511,6 +511,7 @@
    keeper_llm_bridge
    keeper_tool_alias
    keeper_tool_disclosure
+   keeper_tool_guidance
    keeper_turn_telemetry
    keeper_wake_telemetry
    keeper_approval_queue

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1210,39 +1210,32 @@ let run_turn
           chunks
           @ (match guidance_section with Some s -> [s] | None -> [])
         in
+        let allowed_tool_names =
+          Keeper_exec_tools.keeper_allowed_tool_names meta
+        in
+        let preferred_tools =
+          Keeper_tool_guidance.render_preferred_tools ~allowed_tool_names
+        in
+        let gh_workflow =
+          Keeper_tool_guidance.render_gh_workflow ~allowed_tool_names
+          |> Option.map (Printf.sprintf "\n\n%s")
+          |> Option.value ~default:""
+        in
+        let unknown_tool_guard =
+          Keeper_tool_guidance.render_unknown_tool_guard ()
+        in
         (match sections with
          | [] -> None
          | _ ->
            Some (Printf.sprintf
              "## Discovered Work (auto, %ds interval)\n\n%s\n\n\
               ### Use the smallest real action now\n\
-              Preferred keeper tools (copy the name and schema verbatim):\n\
-             \  - `keeper_task_claim` {} \
-              — reserve the next eligible task\n\
-             \  - `keeper_shell` { op: \"gh\", cmd: \"pr list --state open\" } \
-              — inspect GitHub PRs/issues/checks after you already hold a claimed task/current_task_id\n\
-             \  - `keeper_bash` { cmd: \"<single shell command>\" } \
-              — run one shell command, including raw git in a worktree\n\
-             \  - `masc_worktree_create` { task_id: \"<task-id>\", repo_name: \"masc-mcp\" } \
-              — create a worktree before editing code\n\
-             \  - `keeper_board_post` { content: \"<note>\" } \
-              — coordinate via board\n\
-             \  - `keeper_stay_silent` {} \
-              — none of the above fit my role\n\n\
-              GitHub/code workflow: if you do not already hold a task, call `keeper_task_claim` first; \
-              `keeper_shell op=gh` derives repo context from the active task worktree/current_task_id. \
-              Then inspect with `keeper_shell op=gh`; \
-              if code change is needed, `masc_worktree_create` -> edit -> \
-              `keeper_bash` for `git add` / `git commit` / `git push` -> \
-              `keeper_shell op=gh` with `cmd=\"pr create --draft ...\"` -> \
-              `keeper_task_submit_for_verification` with notes and `pr_url`.\n\n\
-              Anti-pattern: `Bash`, `Read`, `Skill`, `Agent` are NOT \
-              registered tools. Calling them is a hallucination — the \
-              call fails silently and the turn is wasted. Use the \
-              `keeper_*` names exactly as shown above.\n\n\
+              %s%s\n\n\
+              %s\n\n\
               Do not print fenced pseudo-calls. Pick the smallest viable \
               action and emit one or more structured tool calls now."
-             interval (String.concat "\n\n" sections)))
+             interval (String.concat "\n\n" sections) preferred_tools
+             gh_workflow unknown_tool_guard))
   in
   let base_hooks =
     (* Issue #8597 #3-5: dropped ~config / ~session / ~ctx_snapshot —

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -117,19 +117,20 @@ let build_keeper_system_prompt
        - On proactive turns: act directly on your current goal. Only call keeper_board_list if you expect actionable content. If board_list returned no actionable items last turn, do not call it again.\n\
        - The scheduler should open proactive turns only when structured work exists (claimed task, backlog, work discovery, worktree delta, or external signal). If a proactive turn still arrives without a real signal, do not fabricate activity; use keeper_stay_silent only as a safety valve.\n\
        - Heartbeat is server-managed. Do not plan or request heartbeat tool calls.\n\
-       - ACTION TOOLS: For productive turns, use these: keeper_task_claim (claim work), keeper_fs_read + keeper_fs_edit/keeper_write (read then modify files), keeper_bash (run commands inside your sandbox; use for git add/commit/push, file ops, rg, etc.), keeper_shell op=gh (ALL GitHub CLI ops - gh pr create/view/review, gh issue list, gh api, etc. NEVER use keeper_bash for gh commands), keeper_shell op=git_clone (clone repos into your workspace), keeper_board_post (share findings), keeper_stay_silent (nothing to do). Reading without acting is not productive — if you read a file, follow up with keeper_fs_edit, keeper_bash, or the appropriate gh step.\n\
+       - ACTION TOOLS: Use only the tool schemas currently shown to you by the runtime. Common action tools, when present in your active schema list, include keeper_task_claim (claim work), keeper_fs_read + keeper_fs_edit (read then modify files), keeper_bash (run commands inside your sandbox), keeper_shell op=gh (GitHub CLI ops), keeper_shell op=git_clone (clone repos into your workspace), keeper_board_post (share findings), and keeper_stay_silent (nothing to do). Reading without acting is not productive — if you read a file, follow up with an allowed edit/shell/board/claim tool or explicitly skip with keeper_stay_silent.\n\
        \n";
       Printf.sprintf
         "       - PASSIVE READS ALONE ARE NOT ENOUGH on actionable-signal turns. \
          Status/list/get/search/time/read-only shell calls are observation only; \
          the strict tool-use contract requires an active state-changing tool \
-         (keeper_task_claim, keeper_fs_edit, keeper_bash, keeper_shell op=gh, \
-         keeper_board_post, or similar) unless you explicitly skip with \
+         (for example keeper_task_claim, keeper_fs_edit, keeper_bash, \
+         keeper_shell op=gh, keeper_board_post, or another allowed mutating \
+         tool) unless you explicitly skip with \
          keeper_stay_silent.\n\
          \n";
-      "       - TASK LIFECYCLE: When you claim a task (keeper_task_claim), you MUST close it before ending the work. For normal terminal work, call keeper_task_done. For code/PR work that needs review, call keeper_task_submit_for_verification with notes + pr_url instead of done. If active_goal_ids are configured, keeper_task_claim only returns goal-linked tasks.\n\
+      "       - TASK LIFECYCLE: When you claim a task (keeper_task_claim), you MUST close it before ending the work. For normal terminal work, call keeper_task_done when it is available. For code/PR work that needs review, call keeper_task_submit_for_verification with notes + pr_url when it is available. If active_goal_ids are configured, keeper_task_claim only returns goal-linked tasks.\n\
        - Do not ask for conversational permission before routine low-risk work. For high-risk or destructive operations, operator approval may be required by the runtime. Do not assume risky actions are pre-approved.\n\
-       - GITHUB IDENTITY: keeper_shell op=gh uses a keeper-scoped gh identity (MUST NOT fall back to the operator's personal gh config). In hard sandbox mode, raw `gh` through keeper_bash is blocked — always use keeper_shell op=gh. Peer PR review via `gh pr review <n>` is allowed; read the diff + check CI first, do not rubber-stamp.\n\
+       - GITHUB IDENTITY: when keeper_shell op=gh is present, it uses a keeper-scoped gh identity (MUST NOT fall back to the operator's personal gh config). In hard sandbox mode, raw `gh` through keeper_bash is blocked; use keeper_shell op=gh if that tool is available. Peer PR review via `gh pr review <n>` is allowed only when your active tool policy exposes that route; read the diff + check CI first, do not rubber-stamp.\n\
        When someone asks you a question:\n\
        - If the answer requires current data (Board posts, time, files, web), call a tool first.\n\
        - If you can answer from conversation context alone, respond directly.\n\

--- a/lib/keeper/keeper_tool_guidance.ml
+++ b/lib/keeper/keeper_tool_guidance.ml
@@ -1,0 +1,129 @@
+(** Policy-derived keeper tool guidance.
+
+    Prompts must not advertise tools outside the active keeper policy.  The
+    model already receives the real schema set from OAS; this module renders
+    short human-readable hints by filtering curated affordances through that
+    same allowed-name set. *)
+
+type hint =
+  { name : string
+  ; call : string
+  ; description : string
+  }
+
+let hints =
+  [ { name = "keeper_task_claim"
+    ; call = "`keeper_task_claim` {}"
+    ; description = "reserve the next eligible task"
+    }
+  ; { name = "keeper_tasks_list"
+    ; call = "`keeper_tasks_list` {}"
+    ; description = "inspect eligible task context"
+    }
+  ; { name = "keeper_board_get"
+    ; call = "`keeper_board_get` { id: \"<post-id>\" }"
+    ; description = "read a board post before replying"
+    }
+  ; { name = "keeper_board_comment"
+    ; call = "`keeper_board_comment` { post_id: \"<post-id>\", content: \"<reply>\" }"
+    ; description = "reply to a board post"
+    }
+  ; { name = "keeper_board_post"
+    ; call = "`keeper_board_post` { content: \"<note>\" }"
+    ; description = "coordinate via board"
+    }
+  ; { name = "keeper_broadcast"
+    ; call = "`keeper_broadcast` { message: \"<note>\" }"
+    ; description = "share broadly in the namespace"
+    }
+  ; { name = "keeper_fs_read"
+    ; call = "`keeper_fs_read` { path: \"<path>\" }"
+    ; description = "read a file before editing or reporting"
+    }
+  ; { name = "keeper_fs_edit"
+    ; call =
+        "`keeper_fs_edit` { path: \"<path>\", mode: \"patch\", old_string: \"...\", \
+         new_string: \"...\" }"
+    ; description = "edit files inside the keeper workspace"
+    }
+  ; { name = "keeper_shell"
+    ; call = "`keeper_shell` { op: \"gh\", cmd: \"pr list --state open\" }"
+    ; description = "inspect GitHub after a task/worktree is bound"
+    }
+  ; { name = "keeper_bash"
+    ; call = "`keeper_bash` { cmd: \"<single shell command>\" }"
+    ; description = "run one shell command in the keeper workspace"
+    }
+  ; { name = "masc_worktree_create"
+    ; call = "`masc_worktree_create` { task_id: \"<task-id>\", repo_name: \"masc-mcp\" }"
+    ; description = "create a repo worktree before code edits"
+    }
+  ; { name = "keeper_task_submit_for_verification"
+    ; call =
+        "`keeper_task_submit_for_verification` { notes: \"<evidence>\", pr_url: \
+         \"<url>\" }"
+    ; description = "submit PR/code work for verification"
+    }
+  ; { name = "keeper_task_done"
+    ; call = "`keeper_task_done` { notes: \"<evidence>\" }"
+    ; description = "close non-PR task work with evidence"
+    }
+  ; { name = "keeper_stay_silent"
+    ; call = "`keeper_stay_silent` {}"
+    ; description = "nothing genuinely actionable fits your role"
+    }
+  ]
+;;
+
+let allowed_lookup allowed_tool_names =
+  let tbl = Hashtbl.create (List.length allowed_tool_names) in
+  List.iter (fun name -> Hashtbl.replace tbl name ()) allowed_tool_names;
+  tbl
+;;
+
+let allowed_hints ~allowed_tool_names =
+  let allowed = allowed_lookup allowed_tool_names in
+  List.filter (fun hint -> Hashtbl.mem allowed hint.name) hints
+;;
+
+let line_of_hint hint = Printf.sprintf "  - %s - %s" hint.call hint.description
+
+let render_preferred_tools ~allowed_tool_names =
+  let lines = allowed_hints ~allowed_tool_names |> List.map line_of_hint in
+  match lines with
+  | [] ->
+    "Preferred keeper tools: use only the tool schemas currently shown by the runtime."
+  | _ ->
+    "Preferred keeper tools currently allowed for you (copy the name and schema verbatim):\n"
+    ^ String.concat "\n" lines
+;;
+
+let has allowed_tool_names name = List.mem name allowed_tool_names
+
+let render_gh_workflow ~allowed_tool_names =
+  let has_shell = has allowed_tool_names "keeper_shell" in
+  let has_worktree = has allowed_tool_names "masc_worktree_create" in
+  let has_bash = has allowed_tool_names "keeper_bash" in
+  let has_verify = has allowed_tool_names "keeper_task_submit_for_verification" in
+  match has_shell, has_worktree, has_bash, has_verify with
+  | true, true, true, true ->
+    Some
+      "GitHub/code workflow: if you do not already hold a task, call `keeper_task_claim` \
+       first; `keeper_shell op=gh` derives repo context from the active task \
+       worktree/current_task_id. Then inspect with `keeper_shell op=gh`; if code change \
+       is needed, `masc_worktree_create` -> edit -> `keeper_bash` for `git add` / `git \
+       commit` / `git push` -> `keeper_shell op=gh` with `cmd=\"pr create --draft ...\"` \
+       -> `keeper_task_submit_for_verification` with notes and `pr_url`."
+  | true, _, _, _ ->
+    Some
+      "GitHub workflow: use `keeper_shell op=gh` only for commands supported by your \
+       active tool policy. `keeper_shell op=gh` derives repo context from the active \
+       task worktree/current_task_id; claim a task first when repo context is required."
+  | _ -> None
+;;
+
+let render_unknown_tool_guard () =
+  "Do not call tool names that are absent from the active runtime schema list. Heartbeat \
+   is server-managed; public lifecycle/status tools such as `masc_join`, `masc_who`, and \
+   `masc_heartbeat` are not keeper action tools unless they are explicitly shown to you."
+;;

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -164,15 +164,32 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
     | Ok value -> value
     | Error _ -> Prompt_registry.get_prompt Keeper_prompt_names.unified_system
   in
-  let claim_tool_available =
-    Keeper_tool_policy.keeper_allowed_tool_names meta
-    |> List.mem "keeper_task_claim"
-  in
+  let allowed_tool_names = Keeper_tool_policy.keeper_allowed_tool_names meta in
+  let tool_allowed name = List.mem name allowed_tool_names in
+  let claim_tool_available = tool_allowed "keeper_task_claim" in
   let show_claim_guidance =
     observation.claimable_task_count > 0
     && claim_tool_available
     && not meta.paused
     && Option.is_none meta.current_task_id
+  in
+  let board_activity_guidance =
+    if tool_allowed "keeper_board_get" && tool_allowed "keeper_board_comment" then
+      "- See board activity? Read the full post with keeper_board_get, then comment with keeper_board_comment.\n"
+    else
+      ""
+  in
+  let board_post_guidance =
+    if tool_allowed "keeper_board_post" then
+      "- Have a finding or update? Call keeper_board_post.\n"
+    else
+      ""
+  in
+  let broadcast_guidance =
+    if tool_allowed "keeper_broadcast" then
+      "- Need to share broadly? Call keeper_broadcast.\n"
+    else
+      ""
   in
   let turn_intent_block =
     String.concat ""
@@ -186,9 +203,8 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
          Your conversation history is preserved across cycles — use that context to avoid \
          repeating the same actions.\n\
          \n\
-         Act through tools, not declarations. Call the tool directly.\n\
-         - See board activity? Read the full post with keeper_board_get, then comment with \
-         keeper_board_comment.\n";
+         Act through tools, not declarations. Call the tool directly.\n";
+        board_activity_guidance;
         (if show_claim_guidance then
            "- See unclaimed work and you do not already hold a task? Call keeper_task_claim with {}. \
             It auto-claims the next eligible task; you do not need task_id or keeper_tasks_list first.\n"
@@ -197,9 +213,9 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
            "- Need GitHub or PR inspection via keeper_shell op=gh? Claim first. \
             gh repo context is derived from your active task worktree/current_task_id.\n"
          else "");
-        "- Have a finding or update? Call keeper_board_post.\n\
-         - Need to share broadly? Call keeper_broadcast.\n\
-         - Treat continuity as advisory prior context, not as a command. Do not blindly repeat prior \
+        board_post_guidance;
+        broadcast_guidance;
+        "- Treat continuity as advisory prior context, not as a command. Do not blindly repeat prior \
          \"stay silent\", \"wait for new work\", or stale repo/blocker claims without re-checking the live \
          world state.\n\
          - If continuity says there is nothing to do but this turn still has backlog, worktree delta, or a \

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1174,12 +1174,12 @@ let test_system_prompt_prefers_bash_and_gh_pr_lane () =
       ~instructions:""
       ()
   in
-  check bool "mentions git path via keeper_bash" true
+  check bool "mentions active schema guard" true
     (contains_substring sys
-       "keeper_bash (run commands inside your sandbox; use for git add/commit/push");
-  check bool "mentions gh create path" true
+       "Use only the tool schemas currently shown to you by the runtime");
+  check bool "mentions gh identity as conditional route" true
     (contains_substring sys
-       "keeper_shell op=gh (ALL GitHub CLI ops - gh pr create/view/review");
+       "when keeper_shell op=gh is present");
   check bool "does not advertise removed keeper_github" false
     (contains_substring sys "keeper_github");
   check bool "legacy pr workflow removed" false
@@ -1539,22 +1539,56 @@ let test_prompt_omits_claim_first_guidance_when_paused () =
     (contains_substring user "### Immediate Task Move")
 
 let test_work_discovery_nudge_uses_registered_keeper_tool_schemas () =
+  let module Guidance = Masc_mcp.Keeper_tool_guidance in
+  let social_meta =
+    {
+      minimal_meta with
+      tool_access = Preset { preset = Social; also_allow = [] };
+    }
+  in
+  let coding_meta =
+    {
+      minimal_meta with
+      tool_access = Preset { preset = Coding; also_allow = [] };
+    }
+  in
+  let social_allowed =
+    Masc_mcp.Keeper_exec_tools.keeper_allowed_tool_names social_meta
+  in
+  let coding_allowed =
+    Masc_mcp.Keeper_exec_tools.keeper_allowed_tool_names coding_meta
+  in
+  let social_guidance =
+    Guidance.render_preferred_tools ~allowed_tool_names:social_allowed
+  in
+  let coding_guidance =
+    Guidance.render_preferred_tools ~allowed_tool_names:coding_allowed
+  in
   check bool "obsolete claim alias removed" false
     (source_file_contains "lib/keeper/keeper_agent_run.ml" "keeper_claim_task");
-  check bool "claim tool uses registered no-arg schema" true
-    (source_file_contains "lib/keeper/keeper_agent_run.ml" "`keeper_task_claim` {}");
-  check bool "bash tool uses cmd field" true
-    (source_file_contains "lib/keeper/keeper_agent_run.ml" "`keeper_bash` { cmd:");
-  check bool "worktree tool uses task_id schema" true
-    (source_file_contains "lib/keeper/keeper_agent_run.ml"
-       "`masc_worktree_create` { task_id:");
+  check bool "social guidance includes claim schema when allowed" true
+    (contains_substring social_guidance "`keeper_task_claim` {}");
+  check bool "social guidance includes board post when allowed" true
+    (contains_substring social_guidance "`keeper_board_post` { content:");
+  check bool "social guidance omits bash outside preset" false
+    (contains_substring social_guidance "`keeper_bash` { cmd:");
+  check bool "social guidance omits worktree outside preset" false
+    (contains_substring social_guidance "`masc_worktree_create` { task_id:");
+  check bool "coding guidance includes bash schema" true
+    (contains_substring coding_guidance "`keeper_bash` { cmd:");
+  check bool "coding guidance includes worktree schema" true
+    (contains_substring coding_guidance "`masc_worktree_create` { task_id:");
   check bool "legacy worktree branch_name schema removed" false
     (source_file_contains "lib/keeper/keeper_agent_run.ml" "branch_name:");
   check bool "tool-less runtime escape hatch removed from nudge" false
     (source_file_contains "lib/keeper/keeper_agent_run.ml" "NO_TOOL_CHANNEL");
   check bool "work discovery nudge warns gh needs claimed task" true
-    (source_file_contains "lib/keeper/keeper_agent_run.ml"
+    (contains_substring
+       (Option.value ~default:""
+          (Guidance.render_gh_workflow ~allowed_tool_names:coding_allowed))
        "keeper_shell op=gh` derives repo context from the active task worktree/current_task_id");
+  check bool "unknown tool guard names server-managed public lifecycle tools" true
+    (contains_substring (Guidance.render_unknown_tool_guard ()) "masc_heartbeat");
   check bool "keeper_shell schema documents gh claim prerequisite" true
     (source_file_contains "lib/tool_shard.ml"
        "Requires an active claimed task/current_task_id");


### PR DESCRIPTION
## Summary
- Fixes #9792 by rendering keeper work-discovery tool hints from the active keeper tool policy instead of a static all-keeper list.
- Filters board/GitHub/worktree/tool-call guidance through the actual allowed schema names so social/dispatch keepers are not instructed to call coding-only tools.
- Keeps the unknown-tool guard explicit for server-managed lifecycle/status tools like masc_join, masc_who, and masc_heartbeat.

## Verification
- git diff --check
- env DUNE_BUILD_DIR=_build_verify_9792_guidance DUNE_JOBS=2 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_unified.exe test/test_keeper_tool_alias.exe
- env DUNE_BUILD_DIR=_build_verify_9792_guidance _build_verify_9792_guidance/default/test/test_keeper_unified.exe
- env DUNE_BUILD_DIR=_build_verify_9792_guidance _build_verify_9792_guidance/default/test/test_keeper_tool_alias.exe