### PR TITLE
fix(goals): route lifecycle changes through Goal FSM

### DIFF
--- a/lib/coord_goals.ml
+++ b/lib/coord_goals.ml
@@ -100,6 +100,12 @@ let parse_optional_goal_phase args field =
            ~expected:"string"
            ~received:(Yojson.Safe.to_string json))
 
+let goal_upsert_lifecycle_error field =
+  error_result_typed ~code:Validation_error
+    (Printf.sprintf
+       "masc_goal_upsert does not accept lifecycle field %s; use masc_goal_transition / masc_goal_verify for goal lifecycle moves"
+       field)
+
 let parse_optional_review_outcome args field =
   match Yojson.Safe.Util.member field args with
   | `Null -> Ok None
@@ -393,11 +399,9 @@ let handle_goal_upsert (ctx : context) args =
       let due_date = get_string_opt args "due_date" in
       let parent_goal_id = get_string_opt args "parent_goal_id" in
       begin
-        match phase with
-        | Some Goal_phase.Awaiting_verification
-        | Some Goal_phase.Awaiting_approval ->
-            error_result_typed ~code:Validation_error
-              "Use masc_goal_transition for verification and approval phases"
+        match phase, status with
+        | Some _, _ -> goal_upsert_lifecycle_error "phase"
+        | _, Some _ -> goal_upsert_lifecycle_error "status"
         | _ -> (
             match
               Goal_store.upsert_goal ctx.config ?id ?horizon ?title ?metric

--- a/lib/tool_schemas/tool_schemas_coord_extra.ml
+++ b/lib/tool_schemas/tool_schemas_coord_extra.ml
@@ -102,7 +102,7 @@ The response includes each goal's explicit lifecycle phase and verification poli
 For new goals, provide at least title; omitted horizon defaults to short. \
 After creation, link tasks into the tree with task.goal_id=<goal_id>; legacy [goal:<id>] title markers remain supported for compatibility. \
 Use this tool for goal metadata, parent linkage, and verifier-policy configuration. \
-Use masc_goal_transition / masc_goal_verify for lifecycle moves and votes.";
+Lifecycle status/phase fields are intentionally omitted here; use masc_goal_transition / masc_goal_verify for lifecycle moves.";
       input_schema =
         `Assoc
           [
@@ -117,8 +117,6 @@ Use masc_goal_transition / masc_goal_verify for lifecycle moves and votes.";
                   ("target_value", `Assoc [ ("type", `String "string") ]);
                   ("due_date", `Assoc [ ("type", `String "string") ]);
                   ("priority", `Assoc [ ("type", `String "integer") ]);
-                  ("status", enum_schema goal_status_enum);
-                  ("phase", enum_schema goal_phase_enum);
                   ("parent_goal_id", `Assoc [ ("type", `String "string") ]);
                   ("verifier_policy", goal_verifier_policy_schema);
                   ("require_completion_approval", `Assoc [ ("type", `String "boolean") ]);

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -139,18 +139,14 @@ let test_goal_upsert_and_list () =
 let test_goal_list_filters_by_phase () =
   with_room @@ fun config ->
   let create ~title ~phase =
-    let created =
-      Tool_coord.dispatch (coord_ctx config) ~name:"masc_goal_upsert"
-        ~args:
-          (`Assoc
-            [
-              ("title", `String title);
-              ("phase", `String phase);
-            ])
+    let phase =
+      match Goal_phase.parse phase with
+      | Some phase -> phase
+      | None -> fail ("invalid phase fixture: " ^ phase)
     in
-    match created with
-    | Some result -> ignore (parse_json_result result)
-    | None -> fail "masc_goal_upsert not handled"
+    match Goal_store.upsert_goal config ~title ~phase () with
+    | Ok _ -> ()
+    | Error msg -> fail msg
   in
   create ~title:"Executing goal" ~phase:"executing";
   create ~title:"Blocked goal" ~phase:"blocked";
@@ -170,6 +166,47 @@ let test_goal_list_filters_by_phase () =
       check string "phase filter honored" "blocked"
         (get_string_field goal_json "phase")
   | _ -> fail "expected one filtered goal"
+
+let test_goal_upsert_rejects_lifecycle_fields () =
+  with_room @@ fun config ->
+  let rejected_phase =
+    Tool_coord.dispatch (coord_ctx config) ~name:"masc_goal_upsert"
+      ~args:
+        (`Assoc
+          [
+            ("title", `String "Bypass block");
+            ("phase", `String "blocked");
+          ])
+  in
+  let phase_error = expect_error rejected_phase in
+  check string "phase blocked" "validation_error"
+    (get_string_field phase_error "error_code");
+  check bool "phase error points at transition" true
+    (contains_substring (Yojson.Safe.to_string phase_error) "masc_goal_transition");
+  let goal, _kind =
+    match Goal_store.upsert_goal config ~title:"Existing goal" () with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  let rejected_status =
+    Tool_coord.dispatch (coord_ctx config) ~name:"masc_goal_upsert"
+      ~args:
+        (`Assoc
+          [
+            ("id", `String goal.id);
+            ("status", `String "dropped");
+          ])
+  in
+  let status_error = expect_error rejected_status in
+  check string "terminal status blocked" "validation_error"
+    (get_string_field status_error "error_code");
+  let saved_goal =
+    match Goal_store.get_goal config ~goal_id:goal.id with
+    | Some goal -> goal
+    | None -> fail "goal missing after rejected upsert"
+  in
+  check string "phase unchanged after rejected status" "executing"
+    (Goal_phase.to_string saved_goal.phase)
 
 let test_goal_review_updates_status () =
   with_room @@ fun config ->
@@ -532,6 +569,8 @@ let () =
         [
           test_case "upsert and list" `Quick test_goal_upsert_and_list;
           test_case "list filters by phase" `Quick test_goal_list_filters_by_phase;
+          test_case "upsert rejects lifecycle fields" `Quick
+            test_goal_upsert_rejects_lifecycle_fields;
           test_case "review updates status" `Quick test_goal_review_updates_status;
           test_case "transition verify complete" `Quick
             test_goal_transition_verification_to_completion;

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -228,7 +228,10 @@ let test_masc_goal_upsert_schema () =
           Alcotest.(check bool) "has id" true (List.mem_assoc "id" props);
           Alcotest.(check bool) "has title" true (List.mem_assoc "title" props);
           Alcotest.(check bool) "has horizon" true (List.mem_assoc "horizon" props);
-          Alcotest.(check bool) "has phase" true (List.mem_assoc "phase" props);
+          Alcotest.(check bool) "omits status lifecycle field" false
+            (List.mem_assoc "status" props);
+          Alcotest.(check bool) "omits phase lifecycle field" false
+            (List.mem_assoc "phase" props);
           Alcotest.(check bool) "has verifier_policy" true
             (List.mem_assoc "verifier_policy" props);
           Alcotest.(check bool) "has require_completion_approval" true


### PR DESCRIPTION
## Summary
- Reject status/phase lifecycle fields on masc_goal_upsert so goal state cannot bypass the FSM path.
- Remove lifecycle status/phase from the upsert tool schema and keep list filtering as the read-side phase surface.
- Seed phase filter tests through Goal_store fixtures and add a regression for rejected lifecycle upserts.

Fixes #10247.

## Verification
- env MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=2 DUNE_CACHE=disabled DUNE_BUILD_DIR=/tmp/masc-10247-build scripts/dune-local.sh build --cache=disabled test/test_goal_tools.exe test/test_tools_coverage.exe
- /tmp/masc-10247-build/default/test/test_goal_tools.exe
- /tmp/masc-10247-build/default/test/test_tools_coverage.exe
- git diff --check HEAD~1..HEAD