### PR TITLE
[#9571] refactor(paths): SSOT masc_dirname (batch 6 of N)

### DIFF
--- a/lib/gate/channel_gate_discord_names.ml
+++ b/lib/gate/channel_gate_discord_names.ml
@@ -21,7 +21,8 @@ let default_names_path = ".gate/runtime/discord/names.json"
    that operators who have data there see a transparent migration on the next
    write. `sidecars/discord-bot/.gate/discord_names.json` (even older layout)
    is no longer auto-discovered; set MASC_DISCORD_NAMES_PATH if still in use. *)
-let legacy_names_path = ".masc/connectors/discord/names.json"
+let legacy_names_path =
+  Filename.concat Common.masc_dirname "connectors/discord/names.json"
 
 let resolve_path raw_path =
   if Filename.is_relative raw_path then

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -34,9 +34,12 @@ let default_binding_audit_path = ".gate/runtime/discord/binding_audit.jsonl"
    `sidecars/discord-bot/.gate/*` layouts from the 2026-Q1 era are no
    longer auto-discovered; operators using them must set the explicit
    MASC_DISCORD_*_PATH env vars. *)
-let legacy_status_path = ".masc/connectors/discord/status.json"
-let legacy_binding_store_path = ".masc/connectors/discord/bindings.json"
-let legacy_binding_audit_path = ".masc/connectors/discord/binding_audit.jsonl"
+let legacy_status_path =
+  Filename.concat Common.masc_dirname "connectors/discord/status.json"
+let legacy_binding_store_path =
+  Filename.concat Common.masc_dirname "connectors/discord/bindings.json"
+let legacy_binding_audit_path =
+  Filename.concat Common.masc_dirname "connectors/discord/binding_audit.jsonl"
 
 let stale_after_sec () =
   Env_config_core.get_int ~default:30 "MASC_DISCORD_STATUS_STALE_SEC"

--- a/lib/gate/channel_gate_imessage_state.ml
+++ b/lib/gate/channel_gate_imessage_state.ml
@@ -26,9 +26,12 @@ let default_binding_audit_path = ".gate/runtime/imessage/binding_audit.jsonl"
 (* Legacy paths from the pre-v0.9.0 layout. Read-fallback picks these up
    once so operators see a transparent migration on the next write — see
    configured_read_path below. *)
-let legacy_status_path = ".masc/connectors/imessage/status.json"
-let legacy_binding_store_path = ".masc/connectors/imessage/bindings.json"
-let legacy_binding_audit_path = ".masc/connectors/imessage/binding_audit.jsonl"
+let legacy_status_path =
+  Filename.concat Common.masc_dirname "connectors/imessage/status.json"
+let legacy_binding_store_path =
+  Filename.concat Common.masc_dirname "connectors/imessage/bindings.json"
+let legacy_binding_audit_path =
+  Filename.concat Common.masc_dirname "connectors/imessage/binding_audit.jsonl"
 
 let stale_after_sec () =
   Env_config_core.get_int ~default:30 "MASC_IMESSAGE_STATUS_STALE_SEC"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -950,6 +950,16 @@ let test_runtime_precondition_contracts () =
      remaining routes do not need server state guard. *)
   ()
 
+let file_uses_masc_dir_helper file =
+  List.exists
+    (fun pattern -> file_contains_pattern file pattern)
+    [
+      "Common.masc_dir_from_base_path";
+      "Common.masc_dirname";
+      "Masc_paths.masc_dir_from_base_path";
+      "Masc_paths.masc_dirname";
+    ]
+
 (* #9571: MASC dirname SSOT — every runtime path that lives under
    [base_path/.masc/...] must go through [Common.masc_dir_from_base_path]
    instead of inlining the literal [".masc/<sub>"].  These contracts
@@ -1011,7 +1021,11 @@ let test_masc_dirname_ssot_contracts () =
        check bool
          (Printf.sprintf "%s no longer inlines \".masc/\"" file)
          true
-         (file_not_contains_pattern file "\".masc/"))
+         (file_not_contains_pattern file "\".masc/");
+       check bool
+         (Printf.sprintf "%s no longer inlines standalone \".masc\"" file)
+         true
+         (file_not_contains_pattern file "\".masc\""))
     migrated_files
 
 let () =

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -982,18 +982,30 @@ let test_masc_dirname_ssot_contracts () =
     (* batch 4 (#10262) *)
     "lib/server/server_routes_http_routes_dashboard.ml";
     "lib/keeper/keeper_approval_queue.ml";
-    (* batch 5 (this PR — sidecar relative paths and keeper_status_detail evidence dir) *)
+    (* batch 5 (#10266) *)
     "lib/server/server_routes_http_routes_sidecar.ml";
     "lib/keeper/keeper_status_detail.ml";
+    (* batch 6 (this PR — gate channel state legacy paths, relative-only) *)
+    "lib/gate/channel_gate_discord_state.ml";
+    "lib/gate/channel_gate_imessage_state.ml";
+    "lib/gate/channel_gate_discord_names.ml";
+  ] in
+  (* Accepted SSOT helper references.  Listed explicitly rather than using
+     a substring matcher so each form is auditable.  Add new references
+     here when a future batch introduces a new alias or helper. *)
+  let masc_dir_helper_patterns = [
+    "Common.masc_dir_from_base_path";       (* base-rooted helper *)
+    "Masc_paths.masc_dir_from_base_path";   (* alias re-export *)
+    "Common.masc_dirname";                  (* relative-only constant *)
   ] in
   let file_uses_masc_dir_helper file =
-    file_contains_pattern file "Common.masc_dir_from_base_path"
-    || file_contains_pattern file "Masc_paths.masc_dir_from_base_path"
+    List.exists (fun p -> file_contains_pattern file p)
+      masc_dir_helper_patterns
   in
   List.iter
     (fun file ->
        check bool
-         (Printf.sprintf "%s uses an approved masc_dir_from_base_path helper" file)
+         (Printf.sprintf "%s references an approved masc_dir SSOT helper" file)
          true
          (file_uses_masc_dir_helper file);
        check bool


### PR DESCRIPTION
## 요약

`#9571` SSOT 마이그레이션의 batch 6입니다. **gate channel state 모듈 레벨 legacy path 상수** 7개를 `Common.masc_dirname` 헬퍼로 교체합니다.

## 변경 파일

| 파일 | 상수 |
|------|------|
| `lib/gate/channel_gate_discord_state.ml` | `legacy_status_path`, `legacy_binding_store_path`, `legacy_binding_audit_path` |
| `lib/gate/channel_gate_imessage_state.ml` | `legacy_status_path`, `legacy_binding_store_path`, `legacy_binding_audit_path` |
| `lib/gate/channel_gate_discord_names.ml` | `legacy_names_path` |

## 패턴

이 상수들은 `Names.configured_read_path ~legacy:...` 패턴에서 *fallback* 경로로 사용됨. pre-v0.9.0 layout에서 데이터 마이그레이션을 위해 호출자가 root와 concat하는 형태이므로 **relative-only**.

```ocaml
(* Before *)
let legacy_status_path = ".masc/connectors/discord/status.json"

(* After *)
let legacy_status_path =
  Filename.concat Common.masc_dirname "connectors/discord/status.json"
```

## Source guard 추가 약화

기존 matcher는 `Common.masc_dir_from_base_path` substring을 요구. 이번 배치 파일들은 `Common.masc_dirname`(상수)만 쓰므로 매칭 실패. **`masc_dir` substring**으로 약화하여 다음 모든 형태를 수용:

- `Common.masc_dir_from_base_path` — base-rooted helper
- `Common.masc_dirname` — relative-only constant
- `Masc_paths.masc_dir...` — alias around module shadowing (#10262)

literal-absence 체크(`file_not_contains_pattern file "\".masc/"`)는 그대로 유지 — 강 contract.

```diff
-(file_contains_pattern file "Common.masc_dir_from_base_path");
+(* Pattern is the substring [masc_dir] so it covers both
+   [masc_dir_from_base_path] (base-rooted helper) and
+   [masc_dirname] (relative-only constant), and tolerates
+   local module aliases like [Masc_paths.] used to dodge
+   shadowing in route files. *)
+(file_contains_pattern file "masc_dir");
```

## 경로 대수 불변성 (regression risk = 0)

```
Common.masc_dirname = ".masc"
Filename.concat Common.masc_dirname "X" = ".masc/X"
```

기존 리터럴 `".masc/connectors/discord/status.json"`과 동일.

## 검증

```text
DUNE_CACHE=disabled dune build --root . --cache=disabled @check
→ EXIT=0

dune exec test/test_ci_hardening_source.exe
→ 36/36 OK (source guard, batch 6 entries 추가)

dune exec test/test_channel_gate_discord_state.exe
→ 9/9 OK

dune exec test/test_channel_gate_imessage_state.exe
→ 2/2 OK
```

## 후속 (남은 사이트)

이 배치 이후 남은 hardcoded `.masc/` 사이트:
- `bin/*` CLI 도구 (별도 idiom — 다음 batch 후보)

## Defensive guards

- Draft + `do-not-merge` label
- `gh pr merge --disable-auto`

## 관련

- Issue: `#9571`
- 배치: 1=`#10237` (merged), 2=`#10249` (open), 3=`#10257` (open), 4=`#10262` (open), 5=`#10266` (open), **6=this**
