### PR TITLE
diag(keeper): name diverging personality fields in re-sync log (#10269)

### DIFF
--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -10,6 +10,54 @@ open Keeper_types
     hot-reload tick unless the compare normalizes whitespace. *)
 let personality_text_equal a b = String.equal (String.trim a) (String.trim b)
 
+(** #10269: when [personality_text_equal] reports a mismatch, the
+    operator needs to know WHICH personality field differs and HOW
+    badly.  Pre-fix the re-sync log was opaque
+    ([re-syncing [personality] for <name>]) so a fleet of repeated
+    re-syncs (371 events / 3000 logs on [nick0cave] alone, 12% of all
+    log volume) carried no information about whether the drift was a
+    1-byte trailing newline or a structural divergence between the
+    TOML source and the persisted JSON.
+
+    [personality_diff_summary] returns one entry per differing field
+    formatted as [<field>(cur=<len>,tgt=<len>,diff@<pos>)] where [pos]
+    is the byte index of the first character that disagrees AFTER the
+    same trimming used by {!personality_text_equal}.  [pos = -1] means
+    the trimmed strings agree byte-for-byte (impossible by
+    construction here since the entry is only emitted when
+    [personality_text_equal] is false; kept as a defensive sentinel).
+
+    The summary is cheap: only invoked on the cycle that actually
+    performs a re-sync, never on the stable steady-state path. *)
+let first_byte_diff a b =
+  let len_a = String.length a and len_b = String.length b in
+  let limit = min len_a len_b in
+  let rec loop i =
+    if i >= limit then
+      if len_a = len_b then -1 else limit
+    else if Char.equal a.[i] b.[i] then loop (i + 1)
+    else i
+  in
+  loop 0
+
+let personality_field_diff_entry name current target =
+  if personality_text_equal current target then None
+  else
+    let cur_t = String.trim current and tgt_t = String.trim target in
+    let pos = first_byte_diff cur_t tgt_t in
+    Some
+      (Printf.sprintf "%s(cur=%d,tgt=%d,diff@%d)"
+         name
+         (String.length cur_t)
+         (String.length tgt_t)
+         pos)
+
+let personality_diff_summary fields =
+  List.filter_map
+    (fun (name, current, target) ->
+      personality_field_diff_entry name current target)
+    fields
+
 type boot_meta_resolution = {
   meta : keeper_meta;
   materialized : bool;
@@ -257,19 +305,23 @@ let ensure_keeper_meta config name =
        writes/day on nick0cave alone; other 13 keepers: 0 events).
        Normalise both sides with [String.trim] so only meaningful
        content drives resync. *)
-    let personality_field_differs current target =
-      not (personality_text_equal current target)
+    (* #10269: name the diverging fields so the re-sync log carries
+       the diagnostic upstream (length and first-diff offset) instead
+       of the opaque [personality] category. *)
+    let personality_diff_entries =
+      personality_diff_summary
+        [
+          ("goal", meta.goal, target_goal);
+          ("short_goal", meta.short_goal, target_short_goal);
+          ("mid_goal", meta.mid_goal, target_mid_goal);
+          ("long_goal", meta.long_goal, target_long_goal);
+          ("will", meta.will, target_will);
+          ("needs", meta.needs, target_needs);
+          ("desires", meta.desires, target_desires);
+          ("instructions", meta.instructions, target_instructions);
+        ]
     in
-    let personality_changed =
-      personality_field_differs meta.goal target_goal
-      || personality_field_differs meta.short_goal target_short_goal
-      || personality_field_differs meta.mid_goal target_mid_goal
-      || personality_field_differs meta.long_goal target_long_goal
-      || personality_field_differs meta.will target_will
-      || personality_field_differs meta.needs target_needs
-      || personality_field_differs meta.desires target_desires
-      || personality_field_differs meta.instructions target_instructions
-    in
+    let personality_changed = personality_diff_entries <> [] in
     let policy_changed =
       meta.policy_voice_enabled <> target_policy_voice_enabled
       || meta.autoboot_enabled <> target_autoboot_enabled
@@ -308,7 +360,11 @@ let ensure_keeper_meta config name =
         (if models_changed then Some "models" else None);
         (if social_model_changed then Some "social_model" else None);
         (if cascade_changed then Some "cascade" else None);
-        (if personality_changed then Some "personality" else None);
+        (if personality_changed then
+           Some
+             (Printf.sprintf "personality:%s"
+                (String.concat "+" personality_diff_entries))
+         else None);
         (if policy_changed then Some "policy" else None);
         (if discovery_changed then Some "discovery" else None);
         (if telemetry_changed then Some "telemetry" else None);

--- a/test/dune
+++ b/test/dune
@@ -412,6 +412,15 @@
     (run %{test}))))
  (libraries masc_test_deps))
 
+(test
+ (name test_personality_diff_summary_10269)
+ (modules test_personality_diff_summary_10269)
+ (action
+  (setenv MASC_BASE_PATH /tmp/test-personality-diff-summary-10269
+   (setenv MASC_BASE_PATH_INPUT /tmp/test-personality-diff-summary-10269
+    (run %{test}))))
+ (libraries masc_test_deps))
+
 ; #10091: dedicated stanza so MASC_BASE_PATH is set BEFORE the
 ; test executable loads — the top-level Masc_mcp init includes
 ; [Cdal_verdict_gate.default_base_path] which triggers the #9903

--- a/test/test_personality_diff_summary_10269.ml
+++ b/test/test_personality_diff_summary_10269.ml
@@ -1,0 +1,162 @@
+(** #10269 — pin the personality re-sync diagnostic surface.
+
+    Pre-#10269 the re-sync log line was opaque:
+    [re-syncing [personality] for nick0cave].  371 such events
+    accumulated on a single keeper in 3000 logs (12% of all log
+    volume) without surfacing WHICH personality field diverged or by
+    HOW MUCH.  Operators couldn't tell whether the drift was a
+    1-byte trailing-newline mismatch (already covered by
+    [personality_text_equal] from #10061) or a structural divergence
+    between TOML source and persisted JSON.
+
+    These tests pin the contract of {!Keeper_runtime.personality_diff_summary}:
+
+    1. Empty input list -> empty summary.
+    2. Equal-after-trim fields produce no entries (matches the
+       semantics of {!personality_text_equal}).
+    3. Differing fields produce entries naming the field, both
+       trimmed lengths, and the byte index of the first divergence.
+    4. The first-diff offset is computed AFTER trimming so trailing
+       whitespace drift never reports a position artefact.
+    5. When two fields differ, the summary preserves their input
+       order (so the log line is stable across runs). *)
+
+open Alcotest
+module KR = Masc_mcp.Keeper_runtime
+
+(* --- empty / no-diff cases -------------------------------------- *)
+
+let test_empty_list_yields_empty_summary () =
+  check (list string) "empty input -> empty summary"
+    [] (KR.personality_diff_summary [])
+
+let test_equal_fields_emit_no_entries () =
+  let same = "You are nick0cave.\nSubstantive or skip." in
+  check (list string)
+    "byte-equal fields produce no entries"
+    []
+    (KR.personality_diff_summary [ ("goal", same, same) ])
+
+let test_trim_equivalent_fields_emit_no_entries () =
+  (* Same shape as the #10061 trailing-newline drift. *)
+  let cur = "You are nick0cave.\nSubstantive or skip.\n\n" in
+  let tgt = "You are nick0cave.\nSubstantive or skip.\n" in
+  check (list string)
+    "trim-equivalent fields produce no entries"
+    []
+    (KR.personality_diff_summary [ ("goal", cur, tgt) ])
+
+(* --- diff cases ------------------------------------------------- *)
+
+let test_single_field_diff_names_field_and_lengths () =
+  let cur = "short" in        (* trimmed length 5 *)
+  let tgt = "different" in    (* trimmed length 9 *)
+  match
+    KR.personality_diff_summary [ ("instructions", cur, tgt) ]
+  with
+  | [ entry ] ->
+      check string "names instructions, lengths 5 vs 9, diff @ 0"
+        "instructions(cur=5,tgt=9,diff@0)" entry
+  | other ->
+      failf "expected exactly 1 entry, got %d: [%s]"
+        (List.length other) (String.concat ";" other)
+
+let test_first_diff_offset_after_common_prefix () =
+  let cur = "You are nick0cave." in        (* 18 chars *)
+  let tgt = "You are sangsu." in           (* 15 chars; differs at byte 8 *)
+  match
+    KR.personality_diff_summary [ ("goal", cur, tgt) ]
+  with
+  | [ entry ] ->
+      check string "diff @ 8 (after 'You are ')"
+        "goal(cur=18,tgt=15,diff@8)" entry
+  | other ->
+      failf "expected exactly 1 entry, got %d: [%s]"
+        (List.length other) (String.concat ";" other)
+
+let test_one_string_is_prefix_of_other_reports_shorter_length () =
+  (* Common prefix exhausted, then [target] has more bytes.
+     [diff] offset becomes [min len_a len_b] = the shorter length. *)
+  let cur = "You are nick0cave." in           (* 18 chars *)
+  let tgt = "You are nick0cave. Be sharp." in (* 28 chars *)
+  match
+    KR.personality_diff_summary [ ("goal", cur, tgt) ]
+  with
+  | [ entry ] ->
+      check string "prefix case: diff @ 18"
+        "goal(cur=18,tgt=28,diff@18)" entry
+  | other ->
+      failf "expected exactly 1 entry, got %d: [%s]"
+        (List.length other) (String.concat ";" other)
+
+(* --- order-preservation across multiple fields ------------------- *)
+
+let test_multiple_diff_fields_preserve_input_order () =
+  let same = "X" in
+  let entries =
+    KR.personality_diff_summary
+      [
+        ("goal", same, same);                 (* equal: skipped *)
+        ("short_goal", "abc", "abd");         (* differs at 2 *)
+        ("mid_goal", same, same);             (* equal: skipped *)
+        ("instructions", "longer", "longish");(* differs at 4 *)
+      ]
+  in
+  check (list string)
+    "stable order, equal fields filtered"
+    [
+      "short_goal(cur=3,tgt=3,diff@2)";
+      "instructions(cur=6,tgt=7,diff@4)";
+    ]
+    entries
+
+(* --- offset is computed AFTER trim ------------------------------ *)
+
+let test_first_diff_offset_uses_trimmed_strings () =
+  (* Without trim, the leading newlines on [cur] would shift the
+     diff offset to a misleading position.  After trim, both sides
+     start at byte 0 with character ['Y']. *)
+  let cur = "\n\n  You are nick0cave." in  (* trims to "You are nick0cave." len 18 *)
+  let tgt = "You are sangsu." in           (* len 15; diff @ 8 *)
+  match
+    KR.personality_diff_summary [ ("goal", cur, tgt) ]
+  with
+  | [ entry ] ->
+      check string "trim runs before offset computation"
+        "goal(cur=18,tgt=15,diff@8)" entry
+  | other ->
+      failf "expected exactly 1 entry, got %d: [%s]"
+        (List.length other) (String.concat ";" other)
+
+let () =
+  run "personality_diff_summary_10269"
+    [
+      ( "no-diff",
+        [
+          test_case "empty input -> empty summary" `Quick
+            test_empty_list_yields_empty_summary;
+          test_case "byte-equal fields skipped" `Quick
+            test_equal_fields_emit_no_entries;
+          test_case "trim-equivalent fields skipped" `Quick
+            test_trim_equivalent_fields_emit_no_entries;
+        ] );
+      ( "diff",
+        [
+          test_case "single field names lengths + diff @ 0" `Quick
+            test_single_field_diff_names_field_and_lengths;
+          test_case "diff @ offset after common prefix" `Quick
+            test_first_diff_offset_after_common_prefix;
+          test_case "prefix case reports shorter length" `Quick
+            test_one_string_is_prefix_of_other_reports_shorter_length;
+        ] );
+      ( "ordering",
+        [
+          test_case "multiple diffs preserve input order" `Quick
+            test_multiple_diff_fields_preserve_input_order;
+        ] );
+      ( "trim-before-offset",
+        [
+          test_case "offset computed against trimmed strings" `Quick
+            test_first_diff_offset_uses_trimmed_strings;
+        ] );
+    ]


### PR DESCRIPTION
## Goal

Convert the opaque \`re-syncing [personality] for nick0cave\` re-sync log into a per-field diagnostic that names which personality field drifts and by how much, so the next /loop tick can pick the right structural fix (#10269).

## Why diagnostic first

#10269 lists four candidate fixes:

| option | what it does | risk |
|--------|--------------|------|
| **A** | Add per-field diagnostic to the re-sync log | none — log content only |
| B | Strengthen \`personality_text_equal\` (line endings, NFC) | over-normalize real content changes |
| C | Cache TOML defaults across cycles | masks an underlying mtime / cache drift |
| D | Rate-limit duplicate re-sync WARNs | hides the storm; doesn't explain it |

The issuer recommends A first, and explicitly: \"권장: A 즉시 (root cause 진단용), 이후 결과 보고 B/C 결정.\" Without runtime evidence about WHICH field drifts (8 candidates: \`goal / short_goal / mid_goal / long_goal / will / needs / desires / instructions\`) and HOW (length delta, first-divergence offset), B/C/D risk picking the wrong layer.

Once this PR lands and the next reconcile cycle logs run, the operator sees one of:

- \`personality:instructions(cur=1008,tgt=2243,diff@234)\` → structural divergence in body content; needs the TOML→JSON round-trip investigated.
- \`personality:instructions(cur=1008,tgt=1009,diff@1008)\` → 1-byte trailing drift that escaped the existing \`String.trim\` fix; B applies.
- Multiple fields drifting equally → defaults reload churn; C applies.

## Change

**\`lib/keeper/keeper_runtime.ml\`** — pure helpers:

- \`first_byte_diff a b\` — returns the byte index of the first disagreement, or \`-1\` when the trimmed strings agree byte-for-byte (defensive sentinel, never emitted in practice).
- \`personality_field_diff_entry name current target\` — returns \`Some \"field(cur=N,tgt=M,diff@K)\"\` when \`personality_text_equal\` reports a mismatch, \`None\` otherwise. Lengths and offset are computed on the **trimmed** strings, matching the comparison semantics.
- \`personality_diff_summary fields\` — \`List.filter_map\` over a list of \`(name, current, target)\` triples.

**\`ensure_keeper_meta\`** — replaces the bool-only \`personality_changed\` cascade with:

\`\`\`ocaml
let personality_diff_entries =
  personality_diff_summary
    [ (\"goal\", meta.goal, target_goal);
      (\"short_goal\", meta.short_goal, target_short_goal);
      ... 8 fields ... ]
in
let personality_changed = personality_diff_entries <> [] in
\`\`\`

The log emission then formats the category as \`personality:<entries joined with +>\`.

## What does NOT change

- \`personality_text_equal\` semantics (still trim-only equality from #10061).
- \`personality_changed\` truth value (a derivative of \`<> []\`).
- The write_meta path or any side effects of detecting a change.
- Steady-state log volume — the diff summary is computed only on cycles that already trigger a re-sync.

This is observability-only. Worst case if the helper has a bug: the log line shows nonsense, but the keeper still re-syncs correctly.

## Tests (\`test_personality_diff_summary_10269\`, 8 cases, all green)

| group | case | pin |
|-------|------|-----|
| no-diff | empty input | empty summary |
| no-diff | byte-equal fields | summary skips them |
| no-diff | trim-equivalent fields | summary skips them (matches #10061 semantics) |
| diff | single field | names lengths + \`diff@0\` |
| diff | common prefix | offset after the prefix |
| diff | one string is prefix of other | offset = shorter length |
| ordering | mixed equal/diff list | stable input order preserved |
| trim-before-offset | leading whitespace on one side | offset measured against trimmed strings |

Existing sibling tests (no regression):
- \`test_personality_text_equal\`: 5/5 green.
- \`test_keeper_runtime_config_ssot\`: 23/23 green.

## Out of scope (next /loop tick once evidence lands)

- B: stronger normalize (Windows line endings, per-line trailing whitespace) — needs the diagnostic above to confirm shape.
- C: defaults caching (mtime-keyed memoize on TOML read) — needs evidence of cycle-vs-cycle drift in defaults themselves, separable from the field-level divergence this PR exposes.
- D: rate-limit duplicate re-sync WARNs — irrelevant once A pinpoints the cause and B/C eliminates the source.

Refs #10269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)