### PR TITLE
fix(fsm): preserve composite operator truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,7 @@ jobs:
           bash scripts/ci/check-enum-string-safety.sh
           bash scripts/ci/check-masc-oas-boundary.sh
           bash scripts/ci/check-tla-variant-sync.sh
+          bash scripts/ci/check-tla-harness-coverage.sh
           bash scripts/ci/check-telemetry-coverage.sh
           bash scripts/ci/check-determinism-contract.sh
           bash scripts/audit-hardcoding-truth.sh --fail-on-confirmed

--- a/dashboard/src/api/schemas/keeper-composite.test.ts
+++ b/dashboard/src/api/schemas/keeper-composite.test.ts
@@ -41,24 +41,24 @@ describe('parseKeeperCompositeSnapshot', () => {
     }
   })
 
-  it('falls back unknown phase to Stable', () => {
+  it('preserves unknown phase values for operator visibility', () => {
     const result = parseKeeperCompositeSnapshot({ ...VALID_SNAPSHOT, phase: 'UnknownPhase' })
-    expect(result.phase).toBe('Stable')
+    expect(result.phase).toBe('UnknownPhase')
   })
 
-  it('falls back unknown turn_phase to idle', () => {
+  it('preserves unknown turn_phase values for operator visibility', () => {
     const result = parseKeeperCompositeSnapshot({ ...VALID_SNAPSHOT, turn_phase: 'unknown' })
-    expect(result.turn_phase).toBe('idle')
+    expect(result.turn_phase).toBe('unknown')
   })
 
-  it('falls back unknown decision stage to undecided', () => {
+  it('preserves unknown decision stage values for operator visibility', () => {
     const result = parseKeeperCompositeSnapshot({ ...VALID_SNAPSHOT, decision: { stage: 'mystery' } })
-    expect(result.decision.stage).toBe('undecided')
+    expect(result.decision.stage).toBe('mystery')
   })
 
-  it('falls back unknown cascade state to idle', () => {
+  it('preserves unknown cascade state values for operator visibility', () => {
     const result = parseKeeperCompositeSnapshot({ ...VALID_SNAPSHOT, cascade: { state: 'wat' } })
-    expect(result.cascade.state).toBe('idle')
+    expect(result.cascade.state).toBe('wat')
   })
 
   it('parses snapshot with last_outcome present', () => {
@@ -181,12 +181,12 @@ describe('parseKeeperCompositeSnapshot', () => {
     expect(result.circuit_breaker!.state).toBe('warning')
   })
 
-  it('falls back unknown circuit_breaker.state to clean', () => {
+  it('preserves unknown circuit_breaker.state for operator visibility', () => {
     const result = parseKeeperCompositeSnapshot({
       ...VALID_SNAPSHOT,
       circuit_breaker: { state: 'completely-new-future-variant' },
     })
-    expect(result.circuit_breaker!.state).toBe('clean')
+    expect(result.circuit_breaker!.state).toBe('completely-new-future-variant')
   })
 
   it('tolerates missing circuit_breaker during Phase 2 → 3 rollout', () => {

--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -21,12 +21,10 @@
 import {
   array,
   boolean,
-  fallback,
   nullable,
   number,
   object,
   optional,
-  picklist,
   string,
   unknown,
   type BaseIssue,
@@ -35,60 +33,26 @@ import {
 
 import { SchemaDriftError, parseOrThrow } from './drift-error'
 
-// The FSM enums below use `fallback` (not hard-rejection) because
-// Keeper state machines evolve asymmetrically: the OCaml backend
-// (`keeper_composite_observer.ml`) can ship a new state variant in a
-// release ahead of the dashboard. Hard-failing the parse would brick
-// the entire operator view for the window between backend-deploy and
-// frontend-deploy. The fallback state is intentionally the safest
-// visible default — "Stable" / "idle" / "undecided" — so an unknown
-// value renders as "nothing happening" rather than a misleading live
-// state. When backend adds a new enum member, this file must be
-// updated in the next dashboard release; the fallback buys time, not
-// permanent tolerance. See docs/API_CONTRACT.md §Drift policy.
+// FSM state fields stay open strings. The backend can ship new variants
+// ahead of the dashboard, and coercing an unknown state to Stable/idle/clean
+// hides the exact operator signal we need during a drift event. Consumers
+// already render unknown strings opaquely through `displayState`.
+const KeeperCompositePhaseSchema = string()
 
-const KeeperCompositePhaseSchema = fallback(
-  picklist([
-    'Running',
-    'Failing',
-    'Overflowed',
-    'Compacting',
-    'HandingOff',
-    'Draining',
-    'Stable',
-  ]),
-  'Stable',
-)
+const KeeperCompositeTurnPhaseSchema = string()
 
-const KeeperCompositeTurnPhaseSchema = fallback(
-  picklist(['idle', 'prompting', 'executing', 'compacting', 'finalizing']),
-  'idle',
-)
+const KeeperCompositeDecisionStageSchema = string()
 
-const KeeperCompositeDecisionStageSchema = fallback(
-  picklist(['undecided', 'guard_ok', 'gate_rejected', 'tool_policy_selected']),
-  'undecided',
-)
+const KeeperCompositeCascadeStateSchema = string()
 
-const KeeperCompositeCascadeStateSchema = fallback(
-  picklist(['idle', 'selecting', 'trying', 'done', 'exhausted']),
-  'idle',
-)
-
-const KeeperCompositeCompactionStageSchema = fallback(
-  picklist(['accumulating', 'compacting', 'done']),
-  'accumulating',
-)
+const KeeperCompositeCompactionStageSchema = string()
 
 // LT-16-KCB Phase 3: 6th axis. KCB is counter-based, not a classical
 // Closed/Open/Half_open FSM — only three states are observable between
 // tool calls because `record_failure` resets `consecutive_count` to 0
 // inside the trip transition. See
 // `lib/keeper/keeper_failure_circuit_breaker.mli`.
-const KeeperCompositeCircuitBreakerStateSchema = fallback(
-  picklist(['clean', 'warning', 'cooling']),
-  'clean',
-)
+const KeeperCompositeCircuitBreakerStateSchema = string()
 
 const KeeperCompositeAutoRulesSchema = object({
   reflect: boolean(),

--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -10,10 +10,9 @@ export type CompositeObservation = {
   decision: KeeperCompositeSnapshot['decision']['stage']
   cascade: KeeperCompositeSnapshot['cascade']['state']
   compaction: KeeperCompositeSnapshot['compaction']['stage']
-  // 6th axis (LT-16-KCB Phase 3). `'clean'` when the backend omits
-  // `circuit_breaker` — Phase 2 backends that have not yet picked up
-  // the schema still render a sensible cell rather than a blank.
-  breaker: 'clean' | 'warning' | 'cooling'
+  // 6th axis (LT-16-KCB Phase 3). Unknown backend-ahead values are kept
+  // as raw strings; only a missing rollout-era key falls back to `clean`.
+  breaker: string
 }
 
 export type LaneKey = keyof Omit<CompositeObservation, 'ts'>

--- a/dashboard/src/components/fsm-hub.integration.test.ts
+++ b/dashboard/src/components/fsm-hub.integration.test.ts
@@ -154,13 +154,12 @@ describe('FSM Hub integration — API response shape', () => {
       )
     })
 
-    it('coerces unknown phase values to Stable fallback (forward compat)', () => {
+    it('preserves unknown phase values for operator visibility', () => {
       const future = { ...REAL_COMPOSITE_PAYLOAD, phase: 'SomeNewPhase' }
       const parsed = parseKeeperCompositeSnapshot(future)
-      // unknown enum value → fallback, not a hard error. Prevents
-      // backend-added states from bricking the dashboard before the
-      // frontend can ship a matching union member.
-      expect(parsed.phase).toBe('Stable')
+      // Unknown FSM values are explicit drift signals. The dashboard
+      // should render the raw value instead of hiding it as Stable.
+      expect(parsed.phase).toBe('SomeNewPhase')
     })
 
     it('carries all 5 sub-FSM fields the FsmHub renders', () => {

--- a/docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md
+++ b/docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md
@@ -50,10 +50,11 @@ This document is the operator-facing SSOT for:
 
 - `Keeper_registry.dispatch_event_with_audit` emits `keeper_composite_changed` after the registry entry is updated.
 - This happens in both the phase-change branch and the no-phase-change success branch.
+- Turn sub-FSM mutation helpers also emit `keeper_composite_changed` after they update observer-visible turn/composite fields.
 
-### Important non-trigger cases
+### Direct turn helper trigger cases
 
-The following direct registry mutation helpers update fields that the composite observer reads, but they do not emit `keeper_composite_changed` by themselves:
+The following direct registry mutation helpers update fields that the composite observer reads, and now emit `keeper_composite_changed` when they actually change a live turn observation:
 
 - `mark_turn_started`
 - `mark_turn_measurement`
@@ -64,27 +65,22 @@ The following direct registry mutation helpers update fields that the composite 
 - `mark_turn_finished`
 
 Current code cross-check: `keeper_unified_turn.ml` still calls these helpers directly in the live turn path
-(`1711-1731`, `1781-1836`, `1934-2074` in the 2026-04-18 tree), so this is not dead API
-surface. The helpers are active, but they remain silent with respect to
-`keeper_composite_changed`.
+(`mark_turn_started`, `mark_turn_measurement`, `set_turn_*`, `mark_turn_finished`), so this is not dead API surface. The helpers are active and are part of the composite freshness contract.
 
 | Helper | Current direct caller(s) | Composite fields touched | Emits `keeper_composite_changed`? |
 | --- | --- | --- | --- |
-| `mark_turn_started` | `keeper_unified_turn.ml:1716` | installs `current_turn_observation`, initializes `turn_phase=prompting`, resets compaction stage | No |
-| `mark_turn_measurement` | `keeper_unified_turn.ml:1718` | binds pending measurement into the current turn snapshot | No |
-| `set_turn_decision_stage` | `keeper_unified_turn.ml:1722` | updates `decision_stage` to `guard_ok` when measurement is present | No |
-| `set_turn_cascade_state` | `keeper_unified_turn.ml:1782`, `1818`, `1834` | updates `cascade_state`, and via `turn_phase_of_cascade_state` also changes `turn_phase` | No |
-| `set_turn_phase` | `keeper_unified_turn.ml:1786`, `1934`, `1979`, `1987`, `2033`, `2067`, `2072` | forces `turn_phase` during terminal/compaction/error paths | No |
-| `set_turn_selected_model` | `keeper_unified_turn.ml:1831` | stores `selected_model` after a successful cascade attempt | No |
-| `mark_turn_finished` | `keeper_unified_turn.ml:1730` (finally block) | clears `current_turn_observation`, ending the live turn snapshot | No |
+| `mark_turn_started` | live turn entry | installs `current_turn_observation`, initializes `turn_phase=prompting`, resets compaction stage | Yes |
+| `mark_turn_measurement` | live turn measurement bind | binds pending measurement into the current turn snapshot | Yes, when a pending measurement exists |
+| `set_turn_decision_stage` | live turn decision path | updates `decision_stage` to `guard_ok` when measurement is present | Yes, when a live turn exists |
+| `set_turn_cascade_state` | cascade attempt path | updates `cascade_state`, and via `turn_phase_of_cascade_state` also changes `turn_phase` | Yes, when a live turn exists |
+| `set_turn_phase` | terminal/compaction/error paths | forces `turn_phase` during terminal/compaction/error paths | Yes, when a live turn exists |
+| `set_turn_selected_model` | successful cascade attempt path | stores `selected_model` after a successful cascade attempt | Yes, when a live turn exists |
+| `mark_turn_finished` | turn finally block | clears `current_turn_observation`, ending the live turn snapshot and freezing `last_completed_turn` | Yes, when a live turn exists |
 
 By contrast, the nearby `dispatch_keeper_phase_event` calls in the overflow-retry path
 (`keeper_unified_turn.ml:1939-1946`) eventually go through
 `Keeper_registry.dispatch_event_with_audit`, so those phase-machine events *do* emit
-`keeper_composite_changed`. The gap is therefore real: direct turn-mutation helpers update
-observer-visible composite fields without producing the composite tick.
-
-That means `keeper_composite_changed` is not a complete “all composite mutations” stream. It is specifically tied to successful `dispatch_event*` applications.
+`keeper_composite_changed`. Direct turn-mutation helpers and state-machine dispatch now both produce the same signal-only tick, while consumers still re-fetch `/api/v1/keepers/:name/composite` for the authoritative payload.
 
 ## Keeper Heartbeat Snapshot Timing
 

--- a/docs/audits/fsm-cross-layer-audit-2026-04-25.md
+++ b/docs/audits/fsm-cross-layer-audit-2026-04-25.md
@@ -1,0 +1,121 @@
+---
+status: reference
+last_verified: 2026-04-25
+code_refs:
+  - lib/keeper/keeper_registry.ml
+  - dashboard/src/api/schemas/keeper-composite.ts
+  - scripts/ci/check-tla-harness-coverage.sh
+---
+
+# FSM Cross-Layer Audit (2026-04-25)
+
+## Scope
+
+Cross-layer review of the currently active FSM surfaces:
+
+| Axis | Runtime source | Operator/read-model surface | Spec/test surface |
+| --- | --- | --- | --- |
+| Keeper lifecycle | `Keeper_state_machine.phase` | transition audit, runtime trust, `keeper_phase_changed` | `KeeperStateMachine.tla`, `test_keeper_state_machine*` |
+| Composite FSM | `Keeper_composite_observer` + registry turn fields | `/api/v1/keepers/:name/composite`, FSM Hub, fleet matrix | `KeeperCompositeLifecycle.tla`, dashboard schema/tests |
+| Cascade | `Cascade_fsm.decide`, cascade runtime/strategy | cascade dashboard, execution receipt | `KeeperCascadeLifecycle.tla`, cascade tests |
+| Task/verification | `Verification.request_status`, `verification_protocol` | board posts, SSE verification events | `TaskLifecycle.tla`, `test_verification_fsm` |
+| Goal/product state | `Goal_store`, `Goal_phase`, state-product modules | dashboard goal tree, goal tools | `StateProduct.tla`, `CoordinationProduct.tla` |
+| Social ledger | `keeper_social_model_magentic_ledger_fsm` | social-model belief summary | `KeeperSocialModelMagenticLedger.tla`, ledger tests |
+| Server/product state | server startup/state-product modules | runtime/bootstrap surfaces | `ServerState.tla`, `StateProduct.tla` |
+
+Validation was direct source inspection plus targeted checks. Full TLC was not run in this pass.
+
+## Findings and Fixes
+
+### 1. Dashboard composite schema hid backend-ahead FSM states
+
+**Severity**: High
+**Status**: fixed in this PR
+
+`dashboard/src/api/schemas/keeper-composite.ts` used `fallback(picklist(...), Stable/idle/clean)` for FSM state fields. That meant a new backend state was parsed successfully but rendered as a harmless default. This was inconsistent with `keeper-transitions.ts`, which intentionally keeps phase names open strings so operator diagnostics preserve drift.
+
+Fix:
+- Changed composite FSM state schemas to `string()`.
+- Updated tests to assert unknown phase/turn/decision/cascade/breaker values are preserved.
+- Left only the rollout-era missing `circuit_breaker` key fallback in component code (`missing key -> clean`), because absent data from an older backend is different from an explicit unknown value.
+
+### 2. Direct turn sub-FSM mutations changed the composite read model without a composite tick
+
+**Severity**: High
+**Status**: fixed in this PR
+
+`Keeper_registry.dispatch_event_with_audit` emitted `keeper_composite_changed`, but direct live-turn helpers also mutate fields consumed by `Keeper_composite_observer`: `current_turn_observation`, turn phase, decision stage, cascade state, selected model, and `last_completed_turn`.
+
+Fix:
+- Added one shared `broadcast_composite_changed` helper in `keeper_registry.ml`.
+- Emitted the signal after direct turn-helper mutations when a live turn actually changes.
+- Reused the helper in `dispatch_event_with_audit` to avoid duplicate literal envelopes.
+- Added an OCaml test proving `mark_turn_started`, `set_turn_cascade_state`, and `mark_turn_finished` each produce `keeper_composite_changed`.
+- Updated `docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md` so the operator SSOT now matches code.
+
+### 3. TLA+ harness coverage could silently drift
+
+**Severity**: Medium
+**Status**: guarded in this PR; existing debt documented
+
+`scripts/tla-check.sh` is explicit for most directories and dynamic only for `specs/bug-models/`. Several cfg-backed specs exist outside that harness. The prior drift class was "spec present but unguarded"; the general case still needed a cheap gate.
+
+Fix:
+- Added `scripts/ci/check-tla-harness-coverage.sh`.
+- CI now runs the gate after `check-tla-variant-sync.sh`.
+- Existing unchecked cfg-backed specs are explicitly allowlisted as known debt; future cfg-backed `.tla` files must be wired into `scripts/tla-check.sh` or consciously added to the allowlist with an audit note.
+
+Known unchecked cfg-backed specs as of this audit:
+
+```text
+specs/boundary/CascadeKeeperRecovery.tla
+specs/boundary/CascadeStrategy.tla
+specs/boundary/CascadeStrategyStateful.tla
+specs/boundary/KeeperRecoveryOrchestration.tla
+specs/boundary/KeeperTurnScheduler.tla
+specs/checkpoint-trim/CheckpointTrim.tla
+specs/closure/ContractClosure.tla
+specs/keeper-state-machine/KeeperConditionsGovernPhase.tla
+specs/keeper-state-machine/KeeperCounterCausality.tla
+specs/keeper-state-machine/KeeperDwellMonotone.tla
+specs/keeper-state-machine/KeeperMemoryLifecycle.tla
+specs/keeper-state-machine/KeeperOutcomesConservation.tla
+specs/keeper-state-machine/KeeperReconcileLiveness.tla
+specs/keeper-state-machine/KeeperSocialModelMagenticLedger.tla
+specs/keeper-state-machine/KeeperWorkPipeline.tla
+specs/server-state/ServerState.tla
+specs/social-state-cap/SocialStateCap.tla
+```
+
+### 4. CFG-level variants still need a stricter follow-up
+
+**Severity**: Medium
+**Status**: follow-up
+
+The new coverage gate is spec-level, not cfg-variant-level. It catches a new `.tla` with cfg files that is not harnessed, but it does not yet prove every non-standard cfg variant is executed. Examples worth sweeping next:
+
+- `KeeperCompositeLifecycle-buggy-cascade.cfg`
+- `KeeperCompositeLifecycle-buggy-compaction.cfg`
+- `KeeperStateMachine-overflow-buggy.cfg`
+- `KeeperDecisionPipeline-cap2.cfg`
+- `KeeperContextLifecycle-ci.cfg`
+- `KeeperWorktreeContainment-*-buggy.cfg`
+
+Recommended follow-up: teach `scripts/tla-check.sh` a generic cfg-discovery mode for selected directories, or add a cfg-level coverage manifest that distinguishes clean, buggy, liveness, and reduced-CI configs.
+
+## Verification Commands
+
+Focused checks for this PR:
+
+```bash
+bash scripts/ci/check-tla-harness-coverage.sh
+scripts/dune-local.sh build test/test_keeper_composite_observer.exe
+cd dashboard && pnpm vitest run src/api/schemas/keeper-composite.test.ts src/components/fsm-hub-types.test.ts --no-file-parallelism --maxWorkers=1
+cd dashboard && pnpm typecheck
+```
+
+Full formal verification remains CI/nightly scope:
+
+```bash
+scripts/tla-check.sh
+```

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -377,6 +377,18 @@ let turn_phase_of_cascade_state = function
   | Cascade_trying -> Turn_executing
   | Cascade_done | Cascade_exhausted -> Turn_finalizing
 
+let broadcast_composite_changed ~name ~ts_unix =
+  try
+    Sse.broadcast
+      (`Assoc [
+         "type", `String "keeper_composite_changed";
+         "name", `String name;
+         "ts_unix", `Float ts_unix;
+       ])
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _exn -> ()
+
 let completed_turn_outcome_of_observation
     (obs : turn_observation) : Keeper_transition_audit.completed_turn_outcome =
   match obs.decision_stage, obs.cascade_state with
@@ -393,11 +405,13 @@ let update_current_turn e f =
   { e with current_turn_observation }
 
 let mark_turn_started ~base_path name =
+  let changed = ref false in
+  let now = Time_compat.now () in
   update_entry ~base_path name (fun e ->
     let turn_id = e.meta.runtime.usage.total_turns + 1 in
     let obs = {
       turn_id;
-      started_at = Time_compat.now ();
+      started_at = now;
       turn_phase = Turn_prompting;
       decision_stage = Decision_undecided;
       cascade_state = Cascade_idle;
@@ -405,15 +419,20 @@ let mark_turn_started ~base_path name =
       measurement_bind_count = 0;
       selected_model = None;
     } in
+    changed := true;
     { e with
       current_turn_observation = Some obs;
       compaction_stage = Compaction_accumulating;
-    })
+    });
+  if !changed then broadcast_composite_changed ~name ~ts_unix:now
 
 let mark_turn_measurement ~base_path name =
+  let changed = ref false in
+  let now = Time_compat.now () in
   update_entry ~base_path name (fun e ->
     match e.current_turn_observation, e.pending_turn_measurement with
     | Some obs, Some measurement ->
+      changed := true;
       {
         e with
         current_turn_observation =
@@ -424,39 +443,63 @@ let mark_turn_measurement ~base_path name =
           };
         pending_turn_measurement = None;
       }
-    | _ -> e)
+    | _ -> e);
+  if !changed then broadcast_composite_changed ~name ~ts_unix:now
 
 let set_turn_decision_stage ~base_path name decision_stage =
-  update_entry ~base_path name (fun e ->
-    update_current_turn e (fun obs -> { obs with decision_stage }))
-
-let set_turn_cascade_state ~base_path name cascade_state =
+  let changed = ref false in
+  let now = Time_compat.now () in
   update_entry ~base_path name (fun e ->
     update_current_turn e (fun obs ->
+      changed := true;
+      { obs with decision_stage }));
+  if !changed then broadcast_composite_changed ~name ~ts_unix:now
+
+let set_turn_cascade_state ~base_path name cascade_state =
+  let changed = ref false in
+  let now = Time_compat.now () in
+  update_entry ~base_path name (fun e ->
+    update_current_turn e (fun obs ->
+      changed := true;
       {
         obs with
         cascade_state;
         turn_phase = turn_phase_of_cascade_state cascade_state;
-      }))
+      }));
+  if !changed then broadcast_composite_changed ~name ~ts_unix:now
 
 let set_turn_phase ~base_path name turn_phase =
-  update_entry ~base_path name (fun e ->
-    update_current_turn e (fun obs -> { obs with turn_phase }))
-
-let set_turn_selected_model ~base_path name selected_model =
-  update_entry ~base_path name (fun e ->
-    update_current_turn e (fun obs -> { obs with selected_model }))
-
-let prepare_turn_retry_after_compaction ~base_path name =
+  let changed = ref false in
+  let now = Time_compat.now () in
   update_entry ~base_path name (fun e ->
     update_current_turn e (fun obs ->
+      changed := true;
+      { obs with turn_phase }));
+  if !changed then broadcast_composite_changed ~name ~ts_unix:now
+
+let set_turn_selected_model ~base_path name selected_model =
+  let changed = ref false in
+  let now = Time_compat.now () in
+  update_entry ~base_path name (fun e ->
+    update_current_turn e (fun obs ->
+      changed := true;
+      { obs with selected_model }));
+  if !changed then broadcast_composite_changed ~name ~ts_unix:now
+
+let prepare_turn_retry_after_compaction ~base_path name =
+  let changed = ref false in
+  let now = Time_compat.now () in
+  update_entry ~base_path name (fun e ->
+    update_current_turn e (fun obs ->
+      changed := true;
       {
         obs with
         turn_phase = Turn_prompting;
         decision_stage = Decision_guard_ok;
         cascade_state = Cascade_idle;
         selected_model = None;
-      }))
+      }));
+  if !changed then broadcast_composite_changed ~name ~ts_unix:now
 
 let mark_turn_gate_rejected_by_name name =
   let target =
@@ -470,21 +513,28 @@ let mark_turn_gate_rejected_by_name name =
   match target with
   | None -> ()
   | Some entry ->
+      let changed = ref false in
+      let now = Time_compat.now () in
       update_entry ~base_path:entry.base_path name (fun e ->
         update_current_turn e (fun obs ->
+          changed := true;
           {
             obs with
             decision_stage = Decision_gate_rejected;
             turn_phase = Turn_finalizing;
-          }))
+          }));
+      if !changed then broadcast_composite_changed ~name ~ts_unix:now
 
 let mark_turn_finished ~base_path name =
   let completed_turn_to_record = ref None in
+  let changed = ref false in
+  let now = Time_compat.now () in
   update_entry ~base_path name (fun e ->
     let last_completed_turn =
       match e.current_turn_observation with
       | Some obs ->
-          let ended_at = Time_compat.now () in
+          let ended_at = now in
+          changed := true;
           completed_turn_to_record :=
             Some
               {
@@ -509,7 +559,8 @@ let mark_turn_finished ~base_path name =
       last_completed_turn });
   Option.iter
     (Keeper_transition_audit.record_completed_turn ~keeper_name:name)
-    !completed_turn_to_record
+    !completed_turn_to_record;
+  if !changed then broadcast_composite_changed ~name ~ts_unix:now
 
 let increment_turn_failures ~base_path name =
   update_entry ~base_path name (fun e ->
@@ -1006,7 +1057,7 @@ let rec dispatch_event_with_audit
        List.iter
          (fun followup_event ->
             ignore (dispatch_event_with_audit ~base_path name followup_event))
-         (List.filter_map
+       (List.filter_map
             (followup_event_of_entry_action ~phase:tr.new_phase)
             tr.entry_actions);
        (* Composite-lifecycle SSE envelope — RFC-0003 §6.
@@ -1014,16 +1065,7 @@ let rec dispatch_event_with_audit
           subscribers re-fetch [/api/v1/keepers/:name/composite] for the
           full snapshot so the spec's "single writer, pull observers"
           invariant is preserved. *)
-       (try
-          Sse.broadcast
-            (`Assoc [
-               "type", `String "keeper_composite_changed";
-               "name", `String name;
-               "ts_unix", `Float now;
-             ])
-        with
-        | Eio.Cancel.Cancelled _ as e -> raise e
-        | _exn -> ());
+       broadcast_composite_changed ~name ~ts_unix:now;
        Ok tr
      | Ok tr ->
        (* No phase change — still update conditions *)
@@ -1043,16 +1085,7 @@ let rec dispatch_event_with_audit
          pending_turn_measurement;
          compaction_stage;
        };
-       (try
-          Sse.broadcast
-            (`Assoc [
-               "type", `String "keeper_composite_changed";
-               "name", `String name;
-               "ts_unix", `Float now;
-             ])
-        with
-        | Eio.Cancel.Cancelled _ as e -> raise e
-        | _exn -> ());
+       broadcast_composite_changed ~name ~ts_unix:now;
        Ok tr
      | Error e ->
        Log.Keeper.warn "registry: dispatch_event rejected name=%s error=%s"

--- a/scripts/ci/check-tla-harness-coverage.sh
+++ b/scripts/ci/check-tla-harness-coverage.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Ensure cfg-backed TLA+ specs are either checked by scripts/tla-check.sh or
+# explicitly recorded as known unchecked debt.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+known_unchecked_specs() {
+  cat <<'EOF'
+specs/boundary/CascadeKeeperRecovery.tla
+specs/boundary/CascadeStrategy.tla
+specs/boundary/CascadeStrategyStateful.tla
+specs/boundary/KeeperRecoveryOrchestration.tla
+specs/boundary/KeeperTurnScheduler.tla
+specs/checkpoint-trim/CheckpointTrim.tla
+specs/closure/ContractClosure.tla
+specs/keeper-state-machine/KeeperConditionsGovernPhase.tla
+specs/keeper-state-machine/KeeperCounterCausality.tla
+specs/keeper-state-machine/KeeperDwellMonotone.tla
+specs/keeper-state-machine/KeeperMemoryLifecycle.tla
+specs/keeper-state-machine/KeeperOutcomesConservation.tla
+specs/keeper-state-machine/KeeperReconcileLiveness.tla
+specs/keeper-state-machine/KeeperSocialModelMagenticLedger.tla
+specs/keeper-state-machine/KeeperWorkPipeline.tla
+specs/server-state/ServerState.tla
+specs/social-state-cap/SocialStateCap.tla
+EOF
+}
+
+has_cfg() {
+  local spec="$1"
+  local dir="${spec%/*}"
+  local file="${spec##*/}"
+  local stem="${file%.tla}"
+
+  [[ -f "$dir/$stem.cfg" ]] && return 0
+  [[ -f "$dir/$stem-buggy.cfg" ]] && return 0
+  compgen -G "$dir/$stem-*.cfg" >/dev/null
+}
+
+is_known_unchecked() {
+  local spec="$1"
+  known_unchecked_specs | grep -Fxq "$spec"
+}
+
+is_checked() {
+  local spec="$1"
+  local dir="${spec%/*}"
+  local file="${spec##*/}"
+
+  # scripts/tla-check.sh dynamically runs every non-symlink spec in bug-models
+  # that has a matching clean or -buggy cfg.
+  if [[ "$dir" == "specs/bug-models" ]]; then
+    return 0
+  fi
+
+  grep -Fq "\"$file\"" scripts/tla-check.sh
+}
+
+missing=()
+known=()
+
+while IFS= read -r spec; do
+  [[ -n "$spec" ]] || continue
+  has_cfg "$spec" || continue
+
+  if is_checked "$spec"; then
+    continue
+  fi
+  if is_known_unchecked "$spec"; then
+    known+=("$spec")
+    continue
+  fi
+  missing+=("$spec")
+done < <(find specs -name '*.tla' -type f | sort)
+
+if ((${#missing[@]} > 0)); then
+  echo "FAIL: cfg-backed TLA+ specs not covered by scripts/tla-check.sh:" >&2
+  printf '  %s\n' "${missing[@]}" >&2
+  echo >&2
+  echo "Either wire the spec into scripts/tla-check.sh or add it to the known_unchecked_specs list with an audit note." >&2
+  exit 1
+fi
+
+echo "=== TLA harness coverage: PASS ==="
+if ((${#known[@]} > 0)); then
+  echo "Known unchecked cfg-backed specs (${#known[@]}):"
+  printf '  %s\n' "${known[@]}"
+fi

--- a/scripts/ci/check-tla-harness-coverage.sh
+++ b/scripts/ci/check-tla-harness-coverage.sh
@@ -48,6 +48,8 @@ is_checked() {
   local spec="$1"
   local dir="${spec%/*}"
   local file="${spec##*/}"
+  local tla_dir_arg
+  local line
 
   # scripts/tla-check.sh dynamically runs every non-symlink spec in bug-models
   # that has a matching clean or -buggy cfg.
@@ -55,7 +57,16 @@ is_checked() {
     return 0
   fi
 
-  grep -Fq "\"$file\"" scripts/tla-check.sh
+  # Match both directory and file on the same harness invocation. A basename-only
+  # grep can false-pass if another directory later adds a spec with the same
+  # file name.
+  tla_dir_arg="\$REPO_ROOT/$dir"
+  while IFS= read -r line; do
+    if [[ "$line" == *"\"$tla_dir_arg\""* && "$line" == *"\"$file\""* ]]; then
+      return 0
+    fi
+  done < scripts/tla-check.sh
+  return 1
 }
 
 missing=()

--- a/test/test_keeper_composite_observer.ml
+++ b/test/test_keeper_composite_observer.ml
@@ -53,6 +53,24 @@ let with_registry f =
     ~finally:(fun () -> Reg.clear ())
     f
 
+let contains needle haystack =
+  try
+    ignore (Str.search_forward (Str.regexp_string needle) haystack 0);
+    true
+  with Not_found -> false
+
+let with_sse_capture id f =
+  let events = ref [] in
+  Masc_mcp.Sse.subscribe_external ~id
+    ~callback:(fun event -> events := event :: !events)
+    ();
+  Fun.protect
+    ~finally:(fun () -> Masc_mcp.Sse.unsubscribe_external id)
+    (fun () -> f events)
+
+let saw_composite_changed events =
+  List.exists (contains "\"type\":\"keeper_composite_changed\"") !events
+
 (* --- bump: no-op when all satisfied ------------------------------- *)
 
 let test_bump_noop_when_all_satisfied () =
@@ -159,6 +177,26 @@ let test_snapshot_omits_collapsed_from_for_active_phase () =
       (Some "Running")
       (Json.member "phase" snapshot |> Json.to_string_option))
 
+let test_direct_turn_mutations_emit_composite_changed () =
+  with_registry (fun () ->
+    let base_path = "/tmp/keeper-composite-turn-ticks" in
+    let keeper_name = "turn-tick" in
+    ignore (Reg.register ~base_path keeper_name (make_meta keeper_name));
+    with_sse_capture "test-direct-turn-composite-tick" (fun events ->
+      Reg.mark_turn_started ~base_path keeper_name;
+      check bool "turn start emits composite tick" true
+        (saw_composite_changed events);
+      events := [];
+
+      Reg.set_turn_cascade_state ~base_path keeper_name Reg.Cascade_trying;
+      check bool "turn cascade update emits composite tick" true
+        (saw_composite_changed events);
+      events := [];
+
+      Reg.mark_turn_finished ~base_path keeper_name;
+      check bool "turn finish emits composite tick" true
+        (saw_composite_changed events)))
+
 let () =
   run "keeper_composite_observer" [
     "bump_invariant_violations",
@@ -173,4 +211,6 @@ let () =
     [ test_case "stable phase exposes collapsed_from" `Quick test_snapshot_reports_collapsed_from_for_stable_phase
     ; test_case "active phase leaves collapsed_from null" `Quick test_snapshot_omits_collapsed_from_for_active_phase
     ];
+    "composite change signals",
+    [ test_case "direct turn mutations emit composite tick" `Quick test_direct_turn_mutations_emit_composite_changed ];
   ]


### PR DESCRIPTION
## Summary

This PR fixes two operator-truth gaps found during the FSM cross-layer audit and adds a cheap CI guard for formal-spec harness drift.

- Keep dashboard composite FSM state fields as open strings so backend-ahead states are shown as-is instead of being coerced to `Stable`, `idle`, or `clean`.
- Emit `keeper_composite_changed` from direct live-turn registry mutations, not only phase transitions, so FSM Hub/fleet consumers know when turn phase, decision, cascade, selected model, or completed-turn fields changed.
- Add `scripts/ci/check-tla-harness-coverage.sh` and wire it into CI so cfg-backed TLA specs cannot silently exist outside `scripts/tla-check.sh` without being recorded as known unchecked debt.
- Record the audit in `docs/audits/fsm-cross-layer-audit-2026-04-25.md` and update the system event/snapshot inventory.

## Operator Impact

Unknown FSM values now remain visible instead of being normalized into safe-looking defaults. A future backend state can show up raw in the dashboard, which is noisy but truthful. Direct turn-substate updates now notify pull observers, reducing stale FSM Hub and fleet matrix cells after keeper turn mutations.

## Verification

- `pnpm vitest run src/api/schemas/keeper-composite.test.ts src/components/fsm-hub-types.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm typecheck`
- `bash scripts/ci/check-tla-harness-coverage.sh`
- `git diff --check HEAD`
- `MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh exec test/test_keeper_composite_observer.exe`
