### PR TITLE
fix(task): make verification submit persistence atomic

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -1034,6 +1034,7 @@ let transition_task_r
       ~task_id
       ~action
       ?agent_tool_names
+      ?prepare_verification_request
       ?expected_version
       ?(notes = "")
       ?(reason = "")
@@ -1203,6 +1204,56 @@ let transition_task_r
         in
         let new_status = decision.Coord_task_lifecycle.new_status in
         let set_current = decision.set_current in
+        let* () =
+          match action, new_status, prepare_verification_request with
+          | ( Types.Submit_for_verification,
+              Types.AwaitingVerification { assignee; verification_id; _ },
+              Some prepare ) ->
+            let evidence_refs =
+              match task.contract with
+              | Some c -> c.verify_gate_evidence
+              | None -> []
+            in
+            (match prepare ~task ~assignee ~verification_id ~evidence_refs with
+             | Ok () -> Ok ()
+             | Error e ->
+               Error
+                 (Types.IoError
+                    (Printf.sprintf
+                       "verification request creation failed before status transition \
+                        (task=%s vrf=%s): %s"
+                       task_id
+                       verification_id
+                       e)))
+          | Types.Submit_for_verification, _, Some _ ->
+            Error
+              (Types.TaskInvalidState
+                 (Printf.sprintf
+                    "submit_for_verification did not produce AwaitingVerification \
+                     for task %s"
+                    task_id))
+          | ( Types.Claim
+            | Types.Start
+            | Types.Done_action
+            | Types.Cancel
+            | Types.Release
+            | Types.Approve_verification
+            | Types.Reject_verification ),
+            _,
+            Some _ ->
+            Ok ()
+          | ( Types.Claim
+            | Types.Start
+            | Types.Done_action
+            | Types.Cancel
+            | Types.Release
+            | Types.Approve_verification
+            | Types.Reject_verification
+            | Types.Submit_for_verification ),
+            _,
+            None ->
+            Ok ()
+        in
         (match decision.drift with
          | Some Coord_task_lifecycle.Claimed_to_done_skip ->
            (* FSM drift: TLA+ KeeperTaskInterlock.DoneTask requires in_progress.

--- a/lib/coord/coord_task.mli
+++ b/lib/coord/coord_task.mli
@@ -116,6 +116,12 @@ val clear_soft_do_not_reclaim_reason : Types.task -> Types.task
 val transition_task_r :
   config -> agent_name:string -> task_id:string -> action:Types_core.task_action ->
   ?agent_tool_names:string list ->
+  ?prepare_verification_request:
+    (task:Types.task ->
+     assignee:string ->
+     verification_id:string ->
+     evidence_refs:string list ->
+     (unit, string) result) ->
   ?expected_version:int -> ?notes:string -> ?reason:string ->
   ?handoff_context:Types.task_handoff_context ->
   ?force:bool -> unit -> string Types.masc_result

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -837,6 +837,26 @@ and handle_transition ?agent_tool_names ctx args =
         && String.sub msg 0 (String.length prefix) = prefix
     | _ -> false
   in
+  let prepare_verification_request =
+    match action with
+    | Types.Submit_for_verification ->
+      Some
+        (fun ~task ~assignee ~verification_id ~evidence_refs ->
+           Verification_protocol.create_submit_request
+             ~config:ctx.config
+             ~task
+             ~assignee
+             ~verification_id
+             ~evidence_refs)
+    | Types.Claim
+    | Types.Start
+    | Types.Done_action
+    | Types.Cancel
+    | Types.Release
+    | Types.Approve_verification
+    | Types.Reject_verification ->
+      None
+  in
   let rec try_transition attempt =
     let ev = if attempt = 0 then expected_version else None in
     let agent_tool_names =
@@ -846,7 +866,7 @@ and handle_transition ?agent_tool_names ctx args =
     in
     let r = Coord.transition_task_r ctx.config ~agent_name:ctx.agent_name
               ~task_id ~action ?expected_version:ev ~notes ~reason
-              ?handoff_context ?agent_tool_names () in
+              ?handoff_context ?agent_tool_names ?prepare_verification_request () in
     if is_version_mismatch r && attempt < max_cas_retries then begin
       Log.Task.info "CAS version mismatch on %s (attempt %d/%d), retrying in %.0fms"
         task_id (attempt + 1) max_cas_retries (cas_retry_delay_s *. 1000.0);
@@ -898,7 +918,7 @@ and handle_transition ?agent_tool_names ctx args =
                | None -> [] in
              (match task.task_status with
               | Types.AwaitingVerification { verification_id; assignee; _ } ->
-                Verification_protocol.on_submit_for_verification
+                Verification_protocol.notify_submit_for_verification
                   ~config:ctx.config ~task ~assignee ~verification_id ~evidence_refs
               | Types.Todo | Types.Claimed _ | Types.InProgress _
               | Types.Done _ | Types.Cancelled _ -> ())

--- a/lib/verification.ml
+++ b/lib/verification.ml
@@ -278,12 +278,22 @@ let request_path base_path req_id =
   Coord_verification_store.request_path base_path req_id
 
 let save_request base_path req =
-  let dir = verifications_dir base_path in
-  ensure_dir dir;
-  let json = request_to_yojson req in
-  let path = request_path base_path req.id in
-  Fs_compat.save_file path (Yojson.Safe.pretty_to_string json);
-  Ok req.id
+  try
+    let dir = verifications_dir base_path in
+    ensure_dir dir;
+    let json = request_to_yojson req in
+    let path = request_path base_path req.id in
+    match Fs_compat.save_file_atomic path (Yojson.Safe.pretty_to_string json) with
+    | Ok () -> Ok req.id
+    | Error e -> Error e
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Error
+        (Printf.sprintf
+           "save_request %s: %s"
+           req.id
+           (Printexc.to_string exn))
 
 let load_request base_path req_id =
   let path = request_path base_path req_id in

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -18,28 +18,38 @@
    - [evidence_refs]: the artefact list the verifier expects to see →
      [task.contract.verify_gate_evidence], passed in by the caller at
      [tool_task.ml] so this function does not reach into task.contract
-     twice for different fields. *)
-let on_submit_for_verification ~(config : Coord.config)
-    ~(task : Types.task) ~assignee ~verification_id ~evidence_refs =
-  let base_path = config.Coord.base_path in
-  let first_line text =
-    match String.index_opt text '\n' with
-    | Some i -> String.sub text 0 i
-    | None -> text
+   twice for different fields. *)
+type submit_request_spec =
+  { criteria : Verification.criterion list
+  ; output : Yojson.Safe.t
+  ; request_kind : string
+  ; request_summary : string
+  ; next_action : string
+  ; board_type : string
+  ; board_title : string
+  ; board_content : string
+  }
+
+let first_line text =
+  match String.index_opt text '\n' with
+  | Some i -> String.sub text 0 i
+  | None -> text
+
+let deliverable_claims_completion ~task_id deliverable =
+  let normalized =
+    deliverable
+    |> String.trim
+    |> String.lowercase_ascii
+    |> first_line
   in
-  let deliverable_claims_completion ~task_id deliverable =
-    let normalized =
-      deliverable
-      |> String.trim
-      |> String.lowercase_ascii
-      |> first_line
-    in
-    normalized <> ""
-    && (String.starts_with
-          ~prefix:(String.lowercase_ascii task_id ^ " completed")
-          normalized
-        || String.starts_with ~prefix:"completed" normalized)
-  in
+  normalized <> ""
+  && (String.starts_with
+        ~prefix:(String.lowercase_ascii task_id ^ " completed")
+        normalized
+      || String.starts_with ~prefix:"completed" normalized)
+
+let submit_request_spec ~(config : Coord.config) ~(task : Types.task)
+    ~assignee ~evidence_refs =
   let request_kind, request_summary, next_action, board_type, board_title, board_content =
     match Planning_eio.load config ~task_id:task.id with
     | Ok plan_ctx
@@ -61,6 +71,30 @@ let on_submit_for_verification ~(config : Coord.config)
           Printf.sprintf "Verification requested for task %s (%s) by %s"
             task.id task.title assignee )
   in
+  let criteria = List.map (fun s -> Verification.Custom s)
+    (match task.contract with
+     | Some c -> c.completion_contract
+     | None -> []) in
+  let output =
+    `Assoc [
+      ("evidence_refs", `List (List.map (fun s -> `String s) evidence_refs));
+      ("task_title", `String task.title);
+      ("request_kind", `String request_kind);
+      ("request_summary", `String request_summary);
+      ("next_action", `String next_action);
+    ]
+  in
+  { criteria
+  ; output
+  ; request_kind
+  ; request_summary
+  ; next_action
+  ; board_type
+  ; board_title
+  ; board_content
+  }
+
+let warn_contract_gap (task : Types.task) =
   (* Observability for #8272: tasks submitted without a contract land in
      storage with empty completion_contract + empty evidence, which the
      dashboard renders as "—". Surface this as a warn so operators can
@@ -75,46 +109,44 @@ let on_submit_for_verification ~(config : Coord.config)
    | Some c when c.completion_contract = [] && c.verify_gate_evidence = [] ->
      Log.Task.warn
        "[verification-submit] task=%s has a contract but both \
-        completion_contract and verify_gate_evidence are empty"
+       completion_contract and verify_gate_evidence are empty"
        task.id
-   | Some _ -> ());
-  let criteria = List.map (fun s -> Verification.Custom s)
-    (match task.contract with
-     | Some c -> c.completion_contract
-     | None -> []) in
-  let () =
-    match
-      Verification.create_request ~base_path ~task_id:task.id ~request_id:verification_id
-        ~output:(`Assoc [
-          ("evidence_refs", `List (List.map (fun s -> `String s) evidence_refs));
-          ("task_title", `String task.title);
-          ("request_kind", `String request_kind);
-          ("request_summary", `String request_summary);
-          ("next_action", `String next_action);
-        ])
-        ~criteria ~worker:assignee ()
-    with
-    | Ok _ -> ()
-    | Error e ->
-      Log.Task.error
-        "verification create_request failed (task=%s vrf=%s): %s"
-        task.id verification_id e
-  in
+   | Some _ -> ())
+
+let create_submit_request ~(config : Coord.config)
+    ~(task : Types.task) ~assignee ~verification_id ~evidence_refs =
+  let base_path = config.Coord.base_path in
+  warn_contract_gap task;
+  let spec = submit_request_spec ~config ~task ~assignee ~evidence_refs in
+  match
+    Verification.create_request ~base_path ~task_id:task.id ~request_id:verification_id
+      ~output:spec.output ~criteria:spec.criteria ~worker:assignee ()
+  with
+  | Ok _ -> Ok ()
+  | Error e ->
+    Log.Task.error
+      "verification create_request failed (task=%s vrf=%s): %s"
+      task.id verification_id e;
+    Error e
+
+let notify_submit_for_verification ~(config : Coord.config)
+    ~(task : Types.task) ~assignee ~verification_id ~evidence_refs =
+  let spec = submit_request_spec ~config ~task ~assignee ~evidence_refs in
   let meta_json = `Assoc [
-    ("type", `String board_type);
+    ("type", `String spec.board_type);
     ("task_id", `String task.id);
     ("verification_id", `String verification_id);
     ("worker", `String assignee);
     ("evidence_refs", `List (List.map (fun s -> `String s) evidence_refs));
-    ("criteria", `List (List.map Verification.criterion_to_yojson criteria));
-    ("request_kind", `String request_kind);
-    ("next_action", `String next_action);
+    ("criteria", `List (List.map Verification.criterion_to_yojson spec.criteria));
+    ("request_kind", `String spec.request_kind);
+    ("next_action", `String spec.next_action);
   ] in
   let () =
     match Board_dispatch.create_post
       ~author:"system"
-      ~content:board_content
-      ~title:board_title
+      ~content:spec.board_content
+      ~title:spec.board_title
       ~post_kind:Board.System_post
       ~meta_json
       ~visibility:Board.Internal
@@ -136,6 +168,14 @@ let on_submit_for_verification ~(config : Coord.config)
     ("timestamp", `Float (Time_compat.now ()));
   ]);
   ()
+
+let on_submit_for_verification ~(config : Coord.config)
+    ~(task : Types.task) ~assignee ~verification_id ~evidence_refs =
+  match create_submit_request ~config ~task ~assignee ~verification_id ~evidence_refs with
+  | Error e -> Error e
+  | Ok () ->
+    notify_submit_for_verification ~config ~task ~assignee ~verification_id ~evidence_refs;
+    Ok ()
 
 let on_approve_verification ~(config : Coord.config)
     ~task_id ~verifier ~verification_id ~notes =

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -80,6 +80,14 @@ let create_pending_request config ~task_id ~worker ~request_id =
   | Ok req -> req
   | Error e -> Alcotest.fail ("create_request failed: " ^ e)
 
+let submit_protocol_or_fail config task ~assignee ~verification_id ~evidence_refs =
+  match
+    Verification_protocol.on_submit_for_verification ~config ~task
+      ~assignee ~verification_id ~evidence_refs
+  with
+  | Ok () -> ()
+  | Error e -> Alcotest.fail ("on_submit_for_verification failed: " ^ e)
+
 let get_task config task_id =
   let backlog = Coord.read_backlog config in
   List.find_opt (fun (t : Types.task) -> t.id = task_id) backlog.tasks
@@ -156,6 +164,38 @@ let test_submit_for_verification_from_claimed_moves_to_awaiting () =
       Alcotest.(check string) "status" "awaiting_verification"
         (status_string config task_id))
 
+let test_submit_prepare_failure_keeps_task_in_progress () =
+  with_temp_config ~fsm_enabled:true (fun config ->
+    let task_id = add_strict_task config in
+    claim_and_start config "worker" task_id;
+    let prepare_called = ref false in
+    let result =
+      Coord.transition_task_r config ~agent_name:"worker"
+        ~task_id ~action:Types.Submit_for_verification
+        ~prepare_verification_request:
+          (fun ~task:_ ~assignee:_ ~verification_id:_ ~evidence_refs:_ ->
+             prepare_called := true;
+             Error "simulated verification store failure")
+        ()
+    in
+    match result with
+    | Ok _ -> Alcotest.fail "submit should fail when verification request creation fails"
+    | Error e ->
+      Alcotest.(check bool) "prepare called" true !prepare_called;
+      Alcotest.(check string) "status remains in_progress" "in_progress"
+        (status_string config task_id);
+      let msg = Types.show_masc_error e in
+      Alcotest.(check bool) "error mentions verification request" true
+        (Astring.String.is_infix
+           ~affix:"verification request creation failed"
+           msg);
+      let reqs =
+        Verification.list_requests config.Coord.base_path
+        |> List.filter (fun (r : Verification.verification_request) ->
+          r.task_id = task_id)
+      in
+      Alcotest.(check int) "no orphan request" 0 (List.length reqs))
+
 (* Regression for the criteria ← completion_contract vs
    evidence_refs ← verify_gate_evidence split. Prior to the fix both
    sides pulled from verify_gate_evidence, so criteria ended up
@@ -176,7 +216,7 @@ let test_submit_populates_criteria_from_completion_contract () =
       | Some c -> c.verify_gate_evidence
       | None -> []
     in
-    Verification_protocol.on_submit_for_verification ~config ~task
+    submit_protocol_or_fail config task
       ~assignee:"verifier-agent" ~verification_id:"vrf-wiring"
       ~evidence_refs;
     let reqs = Verification.list_requests config.Coord.base_path in
@@ -216,7 +256,7 @@ let test_submit_marks_conflict_triage_when_deliverable_claims_completion () =
       | Some c -> c.verify_gate_evidence
       | None -> []
     in
-    Verification_protocol.on_submit_for_verification ~config ~task
+    submit_protocol_or_fail config task
       ~assignee:"verifier-agent" ~verification_id:"vrf-conflict"
       ~evidence_refs;
     let reqs = Verification.list_requests config.Coord.base_path in
@@ -445,6 +485,8 @@ let () =
         test_submit_for_verification_moves_to_awaiting;
       Alcotest.test_case "submit from claimed moves to awaiting_verification"
         `Quick test_submit_for_verification_from_claimed_moves_to_awaiting;
+      Alcotest.test_case "submit prepare failure keeps task in_progress"
+        `Quick test_submit_prepare_failure_keeps_task_in_progress;
       Alcotest.test_case "submit splits criteria/evidence by contract field"
         `Quick test_submit_populates_criteria_from_completion_contract;
       Alcotest.test_case "submit marks conflict triage from completed deliverable"


### PR DESCRIPTION
## Why

`Submit_for_verification` could commit `AwaitingVerification` first and only then try to persist the verification request from `tool_task`. If request persistence failed, the task stayed awaiting verification with no durable request record. #10230 correctly preserves awaiting-verification tasks during `claim_next`, so this missing-record case becomes a stuck task instead of being accidentally reopened.

## What changed

- make verification request saves atomic and return `Error` on I/O failure
- add a pre-commit verification request callback to `Coord.transition_task_r`
- wire `tool_task` so request persistence succeeds before the status changes to `AwaitingVerification`
- split submit protocol storage from board/SSE notification
- add a regression proving request-prepare failure leaves the task `in_progress` with no orphan request

## Verification

- `MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh build test/test_verification_fsm.exe`
- `./_build/default/test/test_verification_fsm.exe` (15 tests)

## Review focus

Please focus on the new `prepare_verification_request` boundary in `Coord.transition_task_r` and the storage/notification split in `Verification_protocol`. Approval/rejection durability remains a separate follow-up seam: this PR closes the submit-side hole that can strand tasks in `AwaitingVerification` without a request record.