### PR TITLE
feat(cascade): fingerprint counter for trust observability (Phase 0a)

### DIFF
--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -145,6 +145,11 @@ type provider_state = {
   mutable events: event list;  (* newest first *)
   mutable consecutive_failures: int;
   mutable cooldown_until: float;  (* 0.0 = not in cooldown *)
+  fingerprint_counts: (string, int) Hashtbl.t;
+  (* Per-fingerprint cumulative counter (lifetime, no rolling decay).
+     Phase 0 observability anchor for "which error keeps recurring".
+     Updated under [t.mu]. *)
+  mutable last_failure_at: float;  (* 0.0 = none *)
 }
 
 type t = {
@@ -193,9 +198,42 @@ let get_or_create_state t key =
       events = [];
       consecutive_failures = 0;
       cooldown_until = 0.0;
+      fingerprint_counts = Hashtbl.create 4;
+      last_failure_at = 0.0;
     } in
     Hashtbl.replace t.providers key s;
     s
+
+(* Build a stable fingerprint from caller-provided classification.
+   Format: "kind|hash8(reason)" — kind defaults to "unclassified",
+   hash suffix is omitted when reason is absent or empty.  Hash is
+   MD5-truncated to 8 hex chars: collision-tolerant for an
+   observability-only counter. *)
+let make_fingerprint ?error_kind ?error_reason () =
+  let kind =
+    match error_kind with
+    | Some k when String.trim k <> "" -> String.trim k
+    | _ -> "unclassified"
+  in
+  match error_reason with
+  | None -> kind
+  | Some r ->
+    let r = String.trim r in
+    if r = "" then kind
+    else
+      let h = Digest.to_hex (Digest.string r) in
+      let h_short =
+        if String.length h >= 8 then String.sub h 0 8 else h
+      in
+      kind ^ "|" ^ h_short
+
+let bump_fingerprint state fp =
+  let prev =
+    match Hashtbl.find_opt state.fingerprint_counts fp with
+    | Some n -> n
+    | None -> 0
+  in
+  Hashtbl.replace state.fingerprint_counts fp (prev + 1)
 
 (* ── Recording ────────────────────────────────── *)
 
@@ -203,11 +241,16 @@ let prune_old_events now events =
   let cutoff = now -. window_sec in
   List.filter (fun e -> e.time >= cutoff) events
 
-let record t ~provider_key ~outcome ~now =
+let record t ~provider_key ~outcome ?error_kind ?error_reason ~now () =
   with_lock t (fun () ->
     let state = get_or_create_state t provider_key in
     let event = { time = now; outcome } in
     state.events <- event :: prune_old_events now state.events;
+    let bump_failure_fp () =
+      let fp = make_fingerprint ?error_kind ?error_reason () in
+      bump_fingerprint state fp;
+      state.last_failure_at <- now
+    in
     match outcome with
     | Success ->
       state.consecutive_failures <- 0;
@@ -221,6 +264,7 @@ let record t ~provider_key ~outcome ~now =
          responds.  The outcome tag is preserved in [events] so
          [provider_info] can count Rejected separately for dashboards. *)
       state.consecutive_failures <- state.consecutive_failures + 1;
+      bump_failure_fp ();
       if state.consecutive_failures >= cooldown_threshold then
         state.cooldown_until <- now +. cooldown_sec
     | Hard_quota ->
@@ -231,21 +275,25 @@ let record t ~provider_key ~outcome ~now =
          an already-longer cooldown (e.g. if two hard-quota events fire
          concurrently and the second arrives first in wall time). *)
       state.consecutive_failures <- state.consecutive_failures + 1;
+      bump_failure_fp ();
       let new_until = now +. hard_quota_cooldown_sec in
       if new_until > state.cooldown_until then
         state.cooldown_until <- new_until)
 
 let record_success t ~provider_key =
-  record t ~provider_key ~outcome:Success ~now:(Unix.gettimeofday ())
+  record t ~provider_key ~outcome:Success ~now:(Unix.gettimeofday ()) ()
 
-let record_failure t ~provider_key =
-  record t ~provider_key ~outcome:Failure ~now:(Unix.gettimeofday ())
+let record_failure t ~provider_key ?error_kind ?error_reason () =
+  record t ~provider_key ~outcome:Failure ?error_kind ?error_reason
+    ~now:(Unix.gettimeofday ()) ()
 
-let record_rejected t ~provider_key =
-  record t ~provider_key ~outcome:Rejected ~now:(Unix.gettimeofday ())
+let record_rejected t ~provider_key ?error_kind ?error_reason () =
+  record t ~provider_key ~outcome:Rejected ?error_kind ?error_reason
+    ~now:(Unix.gettimeofday ()) ()
 
-let record_hard_quota t ~provider_key =
-  record t ~provider_key ~outcome:Hard_quota ~now:(Unix.gettimeofday ())
+let record_hard_quota t ~provider_key ?error_kind ?error_reason () =
+  record t ~provider_key ~outcome:Hard_quota ?error_kind ?error_reason
+    ~now:(Unix.gettimeofday ()) ()
 
 (* ── Queries ──────────────────────────────────── *)
 
@@ -322,7 +370,17 @@ type provider_info = {
   cooldown_expires_at : float option;
   events_in_window : int;
   rejected_in_window : int;
+  top_fingerprints : (string * int) list;
+  last_failure_at : float option;
 }
+
+let take_first_n n lst =
+  let rec loop k acc = function
+    | [] -> List.rev acc
+    | _ when k <= 0 -> List.rev acc
+    | x :: rest -> loop (k - 1) (x :: acc) rest
+  in
+  loop n [] lst
 
 let build_info_locked ~now ~key state =
   let recent = prune_old_events now state.events in
@@ -336,6 +394,15 @@ let build_info_locked ~now ~key state =
     else float_of_int successes /. float_of_int total
   in
   let in_cd = state.cooldown_until > now in
+  let top_fingerprints =
+    Hashtbl.fold (fun fp count acc -> (fp, count) :: acc)
+      state.fingerprint_counts []
+    |> List.sort (fun (_, a) (_, b) -> compare b a)
+    |> take_first_n 3
+  in
+  let last_failure_at =
+    if state.last_failure_at > 0.0 then Some state.last_failure_at else None
+  in
   {
     provider_key = key;
     success_rate = rate;
@@ -344,6 +411,8 @@ let build_info_locked ~now ~key state =
     cooldown_expires_at = (if in_cd then Some state.cooldown_until else None);
     events_in_window = total;
     rejected_in_window = rejected;
+    top_fingerprints;
+    last_failure_at;
   }
 
 let provider_info t ~provider_key =

--- a/lib/cascade/cascade_health_tracker.mli
+++ b/lib/cascade/cascade_health_tracker.mli
@@ -45,8 +45,23 @@ val create : unit -> t
 val record_success : t -> provider_key:string -> unit
 
 (** Record a failed provider call. Increments consecutive failure
-    counter; triggers cooldown when threshold is reached. *)
-val record_failure : t -> provider_key:string -> unit
+    counter; triggers cooldown when threshold is reached.
+
+    Optional [error_kind] (e.g. "auth", "timeout", "schema") and
+    [error_reason] (raw error string) are folded into a stable
+    fingerprint [error_kind|hash8(reason)] and accumulated in
+    [provider_info.top_fingerprints] for observability. Both default
+    to [None] (unclassified) which is still recorded under the synthetic
+    fingerprint ["unclassified"].
+
+    @since 0.174.0 *)
+val record_failure :
+  t ->
+  provider_key:string ->
+  ?error_kind:string ->
+  ?error_reason:string ->
+  unit ->
+  unit
 
 (** Record a provider call where the response arrived but was rejected
     by the cascade's [accept] predicate (e.g. empty body, schema gate).
@@ -62,8 +77,16 @@ val record_failure : t -> provider_key:string -> unit
     could rank 100% healthy while every call fell through to the next
     cascade tier.
 
+    See {!record_failure} for [error_kind] / [error_reason] semantics.
+
     @since 0.160.0 *)
-val record_rejected : t -> provider_key:string -> unit
+val record_rejected :
+  t ->
+  provider_key:string ->
+  ?error_kind:string ->
+  ?error_reason:string ->
+  unit ->
+  unit
 
 (** Record a provider call that failed with a hard-quota error (balance
     depleted, monthly quota reached, resource exhausted — classified
@@ -79,8 +102,16 @@ val record_rejected : t -> provider_key:string -> unit
     Counts toward [consecutive_failures] for dashboard continuity and
     toward [events_in_window] in {!provider_info}.
 
+    See {!record_failure} for [error_kind] / [error_reason] semantics.
+
     @since 0.161.0 *)
-val record_hard_quota : t -> provider_key:string -> unit
+val record_hard_quota :
+  t ->
+  provider_key:string ->
+  ?error_kind:string ->
+  ?error_reason:string ->
+  unit ->
+  unit
 
 (** Drop tracker entries whose rolling window is empty AND whose cooldown
     has expired.  Intended as opportunistic maintenance — idle providers
@@ -120,6 +151,16 @@ type provider_info = {
   cooldown_expires_at : float option; (** Unix timestamp, Some iff [in_cooldown] *)
   events_in_window : int;             (** Events retained in rolling window *)
   rejected_in_window : int;           (** Subset of [events_in_window] whose outcome was [Rejected]. @since 0.160.0 *)
+  top_fingerprints : (string * int) list;
+  (** Top-N error fingerprints with cumulative counts (descending), capped
+      at 3.  Fingerprint format: ["error_kind|hash8(error_reason)"] —
+      built by {!record_failure} / {!record_rejected} / {!record_hard_quota}
+      from caller-provided classifications.  Empty list when no failures
+      have been recorded.  @since 0.174.0 *)
+  last_failure_at : float option;
+  (** Unix timestamp of the most recent non-success event, or [None] if
+      none.  Phase 0 observability anchor for "did this provider fail
+      recently".  @since 0.174.0 *)
 }
 
 (** Structured info for a single provider. Returns [None] if untracked.

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -407,6 +407,8 @@ let zero_provider_info (key : string) : Health.provider_info =
   ; cooldown_expires_at = None
   ; events_in_window = 0
   ; rejected_in_window = 0
+  ; top_fingerprints = []
+  ; last_failure_at = None
   }
 
 (** [provider_entry_to_json ~declared info] serialises a provider_info
@@ -453,6 +455,14 @@ let provider_entry_to_json ~(declared : bool)
       ; ("request_count", `Int stats.ps_entry_count)
       ]
   in
+  let top_fingerprints_json =
+    `List
+      (List.map
+         (fun (fp, count) ->
+           `Assoc
+             [ ("fingerprint", `String fp); ("count", `Int count) ])
+         info.top_fingerprints)
+  in
   `Assoc ([
     ("provider_key", `String info.provider_key);
     ("success_rate", `Float info.success_rate);
@@ -468,6 +478,12 @@ let provider_entry_to_json ~(declared : bool)
        so dashboards can distinguish "provider down" from "provider
        returns unusable output". *)
     ("rejected_in_window", `Int info.rejected_in_window);
+    (* top_fingerprints / last_failure_at are Phase 0 trust observability
+       anchors (cumulative, not window-bounded).  Surfaced so dashboards
+       can show "which error keeps recurring" alongside the existing
+       success-rate snapshot. *)
+    ("top_fingerprints", top_fingerprints_json);
+    ("last_failure_at", opt_float info.last_failure_at);
     ("declared", `Bool declared);
     ("status", `String (provider_status info));
   ] @ perf_fields)

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -1350,7 +1350,9 @@ let run_named
            [record_rejected] behaves like a failure for cooldown /
            weight but keeps the [Rejected] tag so the dashboard can
            distinguish it from hard errors. *)
-        Cascade_health_tracker.(record_rejected global ~provider_key:provider_cfg.model_id);
+        Cascade_health_tracker.(
+          record_rejected global ~provider_key:provider_cfg.model_id
+            ~error_kind:"accept_rejected" ());
         (* FSM: Accept_rejected → decide *)
         let reason = Printf.sprintf "response rejected by accept (model=%s)" result.response.model in
         let outcome = Cascade_fsm.Accept_rejected
@@ -1418,10 +1420,15 @@ let run_named
            ([hard_quota_cooldown_sec], default 1h) so weighted_random
            re-selection doesn't waste cascade turns on a provider that
            is terminally unavailable. *)
+        let err_str = Oas.Error.to_string sdk_err in
         if sdk_error_is_hard_quota sdk_err then
-          Cascade_health_tracker.(record_hard_quota global ~provider_key:provider_cfg.model_id)
+          Cascade_health_tracker.(
+            record_hard_quota global ~provider_key:provider_cfg.model_id
+              ~error_kind:"hard_quota" ~error_reason:err_str ())
         else
-          Cascade_health_tracker.(record_failure global ~provider_key:provider_cfg.model_id);
+          Cascade_health_tracker.(
+            record_failure global ~provider_key:provider_cfg.model_id
+              ~error_kind:"failure" ~error_reason:err_str ());
         (* FSM: Call_err → decide *)
         (match sdk_error_to_cascade_outcome sdk_err with
          | Some outcome ->

--- a/test/test_cascade_health_tracker.ml
+++ b/test/test_cascade_health_tracker.ml
@@ -15,34 +15,34 @@ let test_record_success_keeps_rate_1 () =
 
 let test_single_failure_no_cooldown () =
   let t = H.create () in
-  H.record_failure t ~provider_key:"p";
+  H.record_failure t ~provider_key:"p" ();
   check bool "single failure does not trip cooldown"
     false (H.is_in_cooldown t ~provider_key:"p")
 
 let test_cooldown_after_threshold () =
   (* cooldown_threshold default = 3 *)
   let t = H.create () in
-  H.record_failure t ~provider_key:"p";
-  H.record_failure t ~provider_key:"p";
-  H.record_failure t ~provider_key:"p";
+  H.record_failure t ~provider_key:"p" ();
+  H.record_failure t ~provider_key:"p" ();
+  H.record_failure t ~provider_key:"p" ();
   check bool "cooldown trips after 3 consecutive failures"
     true (H.is_in_cooldown t ~provider_key:"p")
 
 let test_success_resets_streak () =
   let t = H.create () in
-  H.record_failure t ~provider_key:"p";
-  H.record_failure t ~provider_key:"p";
+  H.record_failure t ~provider_key:"p" ();
+  H.record_failure t ~provider_key:"p" ();
   H.record_success t ~provider_key:"p";
-  H.record_failure t ~provider_key:"p";
-  H.record_failure t ~provider_key:"p";
+  H.record_failure t ~provider_key:"p" ();
+  H.record_failure t ~provider_key:"p" ();
   check bool "success resets consecutive_failures"
     false (H.is_in_cooldown t ~provider_key:"p")
 
 let test_effective_weight_cooldown_zero () =
   let t = H.create () in
-  H.record_failure t ~provider_key:"p";
-  H.record_failure t ~provider_key:"p";
-  H.record_failure t ~provider_key:"p";
+  H.record_failure t ~provider_key:"p" ();
+  H.record_failure t ~provider_key:"p" ();
+  H.record_failure t ~provider_key:"p" ();
   check int "effective_weight = 0 during cooldown"
     0 (H.effective_weight t ~provider_key:"p" ~config_weight:100)
 
@@ -54,7 +54,7 @@ let test_effective_weight_unknown_full () =
 let test_provider_info_reflects_events () =
   let t = H.create () in
   H.record_success t ~provider_key:"p";
-  H.record_failure t ~provider_key:"p";
+  H.record_failure t ~provider_key:"p" ();
   match H.provider_info t ~provider_key:"p" with
   | None -> fail "provider_info returned None after record calls"
   | Some info ->
@@ -69,9 +69,9 @@ let test_rejected_counts_as_failure_for_cooldown () =
      same consecutive-failure streak as hard errors so a provider whose
      outputs are unusable eventually stops being retried. *)
   let t = H.create () in
-  H.record_rejected t ~provider_key:"p";
-  H.record_rejected t ~provider_key:"p";
-  H.record_rejected t ~provider_key:"p";
+  H.record_rejected t ~provider_key:"p" ();
+  H.record_rejected t ~provider_key:"p" ();
+  H.record_rejected t ~provider_key:"p" ();
   check bool "3 consecutive rejections trip cooldown"
     true (H.is_in_cooldown t ~provider_key:"p")
 
@@ -80,17 +80,17 @@ let test_rejected_counts_against_success_rate () =
      100% as it did before 0.160.0 when [Accept_rejected] called
      [record_success]. *)
   let t = H.create () in
-  H.record_rejected t ~provider_key:"p";
-  H.record_rejected t ~provider_key:"p";
+  H.record_rejected t ~provider_key:"p" ();
+  H.record_rejected t ~provider_key:"p" ();
   check (float 0.001) "success_rate = 0.0 after only rejections"
     0.0 (H.success_rate t ~provider_key:"p")
 
 let test_rejected_separately_counted_in_provider_info () =
   let t = H.create () in
   H.record_success t ~provider_key:"p";
-  H.record_rejected t ~provider_key:"p";
-  H.record_rejected t ~provider_key:"p";
-  H.record_failure t ~provider_key:"p";
+  H.record_rejected t ~provider_key:"p" ();
+  H.record_rejected t ~provider_key:"p" ();
+  H.record_failure t ~provider_key:"p" ();
   match H.provider_info t ~provider_key:"p" with
   | None -> fail "provider_info returned None"
   | Some info ->
@@ -100,11 +100,11 @@ let test_rejected_separately_counted_in_provider_info () =
 
 let test_success_after_rejected_clears_streak () =
   let t = H.create () in
-  H.record_rejected t ~provider_key:"p";
-  H.record_rejected t ~provider_key:"p";
+  H.record_rejected t ~provider_key:"p" ();
+  H.record_rejected t ~provider_key:"p" ();
   H.record_success t ~provider_key:"p";
-  H.record_rejected t ~provider_key:"p";
-  H.record_rejected t ~provider_key:"p";
+  H.record_rejected t ~provider_key:"p" ();
+  H.record_rejected t ~provider_key:"p" ();
   check bool "success resets rejected streak"
     false (H.is_in_cooldown t ~provider_key:"p")
 
@@ -137,7 +137,7 @@ let test_evict_idle_drops_no_event_providers () =
 let test_evict_idle_returns_zero_when_all_active () =
   let t = H.create () in
   H.record_success t ~provider_key:"a";
-  H.record_failure t ~provider_key:"b";
+  H.record_failure t ~provider_key:"b" ();
   check int "no eviction when all providers have recent events"
     0 (H.evict_idle t)
 
@@ -148,13 +148,13 @@ let test_hard_quota_triggers_immediate_cooldown () =
      events, a single hard_quota event must trip cooldown on its own —
      balance depletion will not recover within 60s. *)
   let t = H.create () in
-  H.record_hard_quota t ~provider_key:"p";
+  H.record_hard_quota t ~provider_key:"p" ();
   check bool "single hard_quota event trips cooldown immediately"
     true (H.is_in_cooldown t ~provider_key:"p")
 
 let test_hard_quota_cooldown_is_long () =
   let t = H.create () in
-  H.record_hard_quota t ~provider_key:"p";
+  H.record_hard_quota t ~provider_key:"p" ();
   match H.provider_info t ~provider_key:"p" with
   | None -> fail "provider_info returned None after record_hard_quota"
   | Some info ->
@@ -172,7 +172,7 @@ let test_hard_quota_cooldown_is_long () =
 
 let test_hard_quota_effective_weight_zero () =
   let t = H.create () in
-  H.record_hard_quota t ~provider_key:"p";
+  H.record_hard_quota t ~provider_key:"p" ();
   check int "effective_weight = 0 during hard_quota cooldown"
     0 (H.effective_weight t ~provider_key:"p" ~config_weight:100)
 
@@ -181,7 +181,7 @@ let test_hard_quota_success_clears_cooldown () =
      provider starts responding again, one successful call should
      let us re-select the provider on the next tick. *)
   let t = H.create () in
-  H.record_hard_quota t ~provider_key:"p";
+  H.record_hard_quota t ~provider_key:"p" ();
   H.record_success t ~provider_key:"p";
   check bool "success after hard_quota clears cooldown"
     false (H.is_in_cooldown t ~provider_key:"p")
@@ -193,13 +193,13 @@ let test_hard_quota_preserves_longer_existing_cooldown () =
      test focuses on the idempotent case: two hard_quota events should
      leave the cooldown no shorter than a single event. *)
   let t = H.create () in
-  H.record_hard_quota t ~provider_key:"p";
+  H.record_hard_quota t ~provider_key:"p" ();
   let expires_after_first =
     match H.provider_info t ~provider_key:"p" with
     | Some { cooldown_expires_at = Some x; _ } -> x
     | _ -> fail "no cooldown after first hard_quota"
   in
-  H.record_hard_quota t ~provider_key:"p";
+  H.record_hard_quota t ~provider_key:"p" ();
   let expires_after_second =
     match H.provider_info t ~provider_key:"p" with
     | Some { cooldown_expires_at = Some x; _ } -> x
@@ -207,6 +207,97 @@ let test_hard_quota_preserves_longer_existing_cooldown () =
   in
   check bool "second hard_quota does not shorten cooldown"
     true (expires_after_second >= expires_after_first)
+
+(* ── Fingerprint counter (Phase 0 trust observability) ──────────── *)
+
+let info_or_fail t ~provider_key =
+  match H.provider_info t ~provider_key with
+  | Some info -> info
+  | None -> failwith "expected provider_info to be present"
+
+let test_fingerprint_same_classification_accumulates () =
+  let t = H.create () in
+  H.record_failure t ~provider_key:"p"
+    ~error_kind:"timeout" ~error_reason:"deadline exceeded" ();
+  H.record_failure t ~provider_key:"p"
+    ~error_kind:"timeout" ~error_reason:"deadline exceeded" ();
+  H.record_failure t ~provider_key:"p"
+    ~error_kind:"timeout" ~error_reason:"deadline exceeded" ();
+  let info = info_or_fail t ~provider_key:"p" in
+  check int "exactly one fingerprint bucket"
+    1 (List.length info.top_fingerprints);
+  match info.top_fingerprints with
+  | [ (_, count) ] ->
+    check int "fingerprint count = 3" 3 count
+  | _ -> failwith "unreachable"
+
+let test_fingerprint_distinct_reasons_split () =
+  let t = H.create () in
+  H.record_failure t ~provider_key:"p"
+    ~error_kind:"failure" ~error_reason:"reason A" ();
+  H.record_failure t ~provider_key:"p"
+    ~error_kind:"failure" ~error_reason:"reason B" ();
+  let info = info_or_fail t ~provider_key:"p" in
+  check int "two distinct fingerprints"
+    2 (List.length info.top_fingerprints)
+
+let test_fingerprint_top_3_cap () =
+  let t = H.create () in
+  for i = 1 to 5 do
+    let r = Printf.sprintf "reason %d" i in
+    H.record_failure t ~provider_key:"p"
+      ~error_kind:"failure" ~error_reason:r ()
+  done;
+  let info = info_or_fail t ~provider_key:"p" in
+  check int "top_fingerprints capped at 3"
+    3 (List.length info.top_fingerprints)
+
+let test_fingerprint_unclassified_when_kind_missing () =
+  let t = H.create () in
+  H.record_failure t ~provider_key:"p" ();
+  let info = info_or_fail t ~provider_key:"p" in
+  match info.top_fingerprints with
+  | [ (fp, _) ] ->
+    check string "fingerprint defaults to unclassified"
+      "unclassified" fp
+  | _ -> failwith "expected 1 fingerprint"
+
+let test_last_failure_at_set_on_failure () =
+  let t = H.create () in
+  H.record_failure t ~provider_key:"p" ~error_kind:"failure" ();
+  let info_after = info_or_fail t ~provider_key:"p" in
+  check bool "last_failure_at populated after failure"
+    true (info_after.last_failure_at <> None)
+
+let test_last_failure_at_none_for_pure_success () =
+  let t = H.create () in
+  H.record_success t ~provider_key:"p";
+  H.record_success t ~provider_key:"p";
+  let info = info_or_fail t ~provider_key:"p" in
+  check bool "last_failure_at stays None after success-only events"
+    true (info.last_failure_at = None)
+
+let test_fingerprint_top_sorted_descending () =
+  let t = H.create () in
+  (* low: 1, medium: 2, high: 3 *)
+  H.record_failure t ~provider_key:"p"
+    ~error_kind:"failure" ~error_reason:"low" ();
+  H.record_failure t ~provider_key:"p"
+    ~error_kind:"failure" ~error_reason:"medium" ();
+  H.record_failure t ~provider_key:"p"
+    ~error_kind:"failure" ~error_reason:"medium" ();
+  H.record_failure t ~provider_key:"p"
+    ~error_kind:"failure" ~error_reason:"high" ();
+  H.record_failure t ~provider_key:"p"
+    ~error_kind:"failure" ~error_reason:"high" ();
+  H.record_failure t ~provider_key:"p"
+    ~error_kind:"failure" ~error_reason:"high" ();
+  let info = info_or_fail t ~provider_key:"p" in
+  match info.top_fingerprints with
+  | (_, c1) :: (_, c2) :: (_, c3) :: _ ->
+    check bool "descending" true (c1 >= c2 && c2 >= c3);
+    check int "highest count" 3 c1
+  | _ -> failwith "expected at least 3 fingerprints"
 
 let () =
   run "cascade_health_tracker" [
@@ -253,5 +344,21 @@ let () =
         test_hard_quota_success_clears_cooldown;
       test_case "second hard_quota does not shorten cooldown" `Quick
         test_hard_quota_preserves_longer_existing_cooldown;
+    ];
+    "fingerprint", [
+      test_case "same classification accumulates" `Quick
+        test_fingerprint_same_classification_accumulates;
+      test_case "distinct reasons → distinct fingerprints" `Quick
+        test_fingerprint_distinct_reasons_split;
+      test_case "top_fingerprints capped at 3" `Quick
+        test_fingerprint_top_3_cap;
+      test_case "missing kind defaults to unclassified" `Quick
+        test_fingerprint_unclassified_when_kind_missing;
+      test_case "last_failure_at populated on failure" `Quick
+        test_last_failure_at_set_on_failure;
+      test_case "last_failure_at stays None on success-only" `Quick
+        test_last_failure_at_none_for_pure_success;
+      test_case "top_fingerprints sorted descending" `Quick
+        test_fingerprint_top_sorted_descending;
     ];
   ]

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -75,9 +75,9 @@ let test_failover_preserves_order () =
 
 let test_failover_filters_cooldown () =
   let h = H.create () in
-  H.record_failure h ~provider_key:"a";
-  H.record_failure h ~provider_key:"a";
-  H.record_failure h ~provider_key:"a";
+  H.record_failure h ~provider_key:"a" ();
+  H.record_failure h ~provider_key:"a" ();
+  H.record_failure h ~provider_key:"a" ();
   let cands = [mk_cand "a"; mk_cand "b"; mk_cand "c"] in
   let ctx = mk_ctx ~health:h () in
   let ordered = S.order_candidates S.failover ~adapter ~ctx ~cycle:0 cands in
@@ -141,9 +141,9 @@ let test_weighted_random_all_cooldown_yields_empty () =
      and let the caller surface a filtered-empty cascade state. *)
   let h = H.create () in
   let cool_down k =
-    H.record_failure h ~provider_key:k;
-    H.record_failure h ~provider_key:k;
-    H.record_failure h ~provider_key:k
+    H.record_failure h ~provider_key:k ();
+    H.record_failure h ~provider_key:k ();
+    H.record_failure h ~provider_key:k ()
   in
   cool_down "a"; cool_down "b";
   let cands = [mk_cand ~w:50 "a"; mk_cand ~w:30 "b"] in
@@ -157,9 +157,9 @@ let test_weighted_random_all_cooldown_yields_empty () =
 
 let test_cb_cycling_excludes_cooldown_and_busy () =
   let h = H.create () in
-  H.record_failure h ~provider_key:"a";
-  H.record_failure h ~provider_key:"a";
-  H.record_failure h ~provider_key:"a";
+  H.record_failure h ~provider_key:"a" ();
+  H.record_failure h ~provider_key:"a" ();
+  H.record_failure h ~provider_key:"a" ();
   let cands = [mk_cand "a"; mk_cand "b"; mk_cand "c"] in
   let table = [
     (List.nth cands 1).url, mk_capacity_info ~total:1 ~active:1;

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -485,7 +485,8 @@ let test_provider_status_transitions () =
   let info_cooldown : Masc_mcp.Cascade_health_tracker.provider_info =
     { provider_key = "x"; success_rate = 0.0; consecutive_failures = 3
     ; in_cooldown = true; cooldown_expires_at = Some 1.0
-    ; events_in_window = 5; rejected_in_window = 5 }
+    ; events_in_window = 5; rejected_in_window = 5
+    ; top_fingerprints = []; last_failure_at = None }
   in
   let info_active : Masc_mcp.Cascade_health_tracker.provider_info =
     { info_cooldown with in_cooldown = false; consecutive_failures = 0


### PR DESCRIPTION
## Why

`cascade_health_tracker` currently exposes `consecutive_failures` and a 5-minute rolling `success_rate`. Neither answers "**which** error keeps recurring on this provider". Memory `feedback_keeper-5gate-fallback-pressure` shows fleet error rate at 20-55% with persistent skew per keeper — failures are not random, but the existing counters cannot tell which fingerprints dominate.

This PR adds the missing observability so the upcoming **cascade self-tuning** work (Phase 1, in-memory `trust_score`) can calibrate reward / decay defaults from real fleet data instead of magic numbers (anti-pattern flagged in memory `no-fake-research-justification`).

No policy change in this PR — purely additive.

## Changes

### `lib/cascade/cascade_health_tracker.{ml,mli}`
- `record_failure / record_rejected / record_hard_quota` 시그니처에 `?error_kind ?error_reason ()` 추가. kind 기본 `unclassified`, reason은 `Digest.to_hex` 8 hex chars로 hash.
- `provider_state` 에 per-fingerprint Hashtbl + `last_failure_at` 추가 (`with_lock` 안에서 갱신, race 없음).
- `provider_info` 에 `top_fingerprints : (string * int) list` (desc, top 3) + `last_failure_at : float option` 신규 필드.

### `lib/oas_worker_named.ml`
3 호출 사이트 분류:
- Accept_rejected → `error_kind:"accept_rejected"` (no reason — 기존 reason은 model_id 포함이라 fingerprint cardinality 폭발).
- Hard_quota → `"hard_quota" + Oas.Error.to_string sdk_err`.
- Failure → `"failure" + Oas.Error.to_string sdk_err`.

### `lib/dashboard_cascade.ml`
`provider_entry_to_json` 에 `top_fingerprints` (list of `{fingerprint, count}`) + `last_failure_at` (nullable float) 추가. 기존 필드 무변경.

## Test plan

- `test/test_cascade_health_tracker.ml`: **7 신규 alcotest** 추가 (동일 분류 누적, 상이 reason 분리, top-3 cap, kind missing→unclassified, last_failure_at, descending sort). 결과: **25/25 pass**.
- `test/test_cascade_strategy.ml`: 기존 record_failure 호출 사이트들 새 unit terminator 시그니처로 업데이트. **18 pre-existing client_capacity failures**(Eio.Mutex effect-handler 이슈, baseline 회귀 아님 — `b56c3c0fa9` 에 대해 stash + rerun으로 확인).
- `test/test_dashboard_cascade.ml`: `provider_info` literal 에 두 신규 필드 추가.
- `dune build @check` exit=0 (모든 컴파일 + interface 검증 통과).

## Surface impact

- Public `provider_info` record에 필드 2개 추가 — 직접 record literal로 build하는 모든 코드(`dashboard_cascade.ml`, `test_dashboard_cascade.ml`)는 본 PR에서 함께 갱신.
- `record_failure` 시그니처 변경 — 호출자 ~30곳(`oas_worker_named.ml` 3, `test/*` 25+)을 본 PR에서 함께 갱신. `dune build @check` 통과로 누락 없음 확인.

## Phase 0b (deferred)

`Dated_jsonl` snapshot of fingerprints to `~/.masc/cascade_trust/YYYY-MM/DD.jsonl` needs a tick fiber + base_path resolution; split to a follow-up PR to keep this change scoped to one concept (`tool_metrics_persist.ml` 패턴 재사용 예정).

## 안전 가드

- Draft + `do-not-merge` label.
- 본 PR 생성 직후 `gh pr ready --undo` + `gh pr merge --disable-auto` 이중 안전망 (메모리 `do-not-merge-label-insufficient`).
- 회귀 검증 완료 후에만 ready 전환 — 1주 dashboard 관찰로 fingerprint 분포 측정 후 Phase 1 reward/decay 기본값 calibration.

## Plan reference

`~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-s-binary-crown.md`