### PR TITLE
[codex] Expose Codex MCP auth pipeline

### DIFF
--- a/docs/DOCTOR-ARCHITECTURE.md
+++ b/docs/DOCTOR-ARCHITECTURE.md
@@ -130,7 +130,7 @@ class AutoFix:
 | 계층 | Doctor | 구현 상태 |
 |------|--------|-----------|
 | OCaml 서버 | `masc-mcp doctor config` — 베이스 경로 / 활성 config root | 운영 중 (`docs/CONFIG-DOCTOR.md`) |
-| OCaml 서버 | `masc-mcp doctor auth` — auth mode / admin bearer readiness / role mismatch / Codex MCP bearer env | 운영 중 (`docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md`) |
+| OCaml 서버 | `masc-mcp doctor auth` — auth mode / admin bearer readiness / role mismatch / Codex MCP bearer env + config pipeline | 운영 중 (`docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md`) |
 | Discord sidecar | `masc-mcp doctor sidecar discord` ↔ `python -m src doctor` | 운영 중 |
 | Slack sidecar | `masc-mcp doctor sidecar slack` ↔ `python -m src doctor` | 운영 중 |
 | Telegram sidecar | `masc-mcp doctor sidecar telegram` ↔ `python -m src doctor` | 운영 중 |
@@ -145,7 +145,7 @@ class AutoFix:
 ```
 masc-mcp doctor                     # default → config (backward-compat)
 masc-mcp doctor config              # base path / config root 진단
-masc-mcp doctor auth                # auth/bearer/role mismatch + Codex MCP bearer env 진단
+masc-mcp doctor auth                # auth/bearer/role mismatch + Codex MCP bearer env/config pipeline 진단
 masc-mcp doctor sidecar <name>      # python -m src doctor 를 해당 sidecar 디렉터리에서 실행
 masc-mcp doctor sidecar <name> --json
 masc-mcp doctor all                 # config + 5 sidecar 연쇄 실행 + aggregate 요약

--- a/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
+++ b/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
@@ -80,12 +80,15 @@ Useful interpretations:
   - the easiest local bootstrap path is `GET /api/v1/dashboard/dev-token`
 - `codex_mcp.token_status=unset` or `invalid_or_expired`
   - Codex MCP is missing a live bearer token; this is not fixed by `codex mcp login`
+- `codex_mcp.config.stages[]`
+  - Codex config pipeline checks for `[mcp_servers.masc]`, `bearer_token_env_var`,
+    missing hardcoded `Authorization`, and the Streamable HTTP `Accept` header
 
 If you want structured output for automation:
 
 ```bash
 ./_build/default/bin/main_eio.exe doctor auth --base-path "$BASE_PATH" --json \
-  | jq '{status,codex_mcp,warnings,next_actions}'
+  | jq '{status,codex_mcp:{token_status:.codex_mcp.token_status,config:.codex_mcp.config},warnings,next_actions}'
 ```
 
 ## 4. Codex MCP Bearer Login
@@ -119,6 +122,17 @@ Expected shape:
 URL: http://127.0.0.1:8935/mcp
 Bearer Token Env Var: MASC_MCP_TOKEN
 ```
+
+If Codex still reports that `masc` is not logged in, check the pipeline
+projection before retrying OAuth login:
+
+```bash
+./_build/default/bin/main_eio.exe doctor auth --base-path "$BASE_PATH" --json \
+  | jq '.codex_mcp.config.stages'
+```
+
+Every required config stage should be `pass`; `codex_oauth_login` is expected
+to be `skip` because MASC uses bearer-token auth.
 
 ## 5. Supported Local Start
 

--- a/lib/auth_doctor.ml
+++ b/lib/auth_doctor.ml
@@ -25,6 +25,7 @@ type codex_mcp = {
   token_can_read_state : bool option;
   login_supported : bool;
   login_note : string;
+  config : Codex_mcp_config_doctor.t;
 }
 
 type t = {
@@ -214,6 +215,7 @@ let admin_bearer_sources ~base_path ~auth_dir ~dashboard_dev_token_available
   |> dedupe_keep_order
 
 let codex_mcp_report ~base_path =
+  let config = Codex_mcp_config_doctor.analyze_default () in
   match
     Sys.getenv_opt codex_mcp_token_env_var |> Env_config_core.trim_opt
   with
@@ -229,6 +231,7 @@ let codex_mcp_report ~base_path =
         token_can_read_state = None;
         login_supported = false;
         login_note = codex_mcp_login_note;
+        config;
       }
   | Some raw_token -> (
       match Auth.find_credential_by_token base_path ~token:raw_token with
@@ -245,6 +248,7 @@ let codex_mcp_report ~base_path =
               Some (has_permission cred.role CanReadState);
             login_supported = false;
             login_note = codex_mcp_login_note;
+            config;
           }
       | Error _ ->
           {
@@ -258,6 +262,7 @@ let codex_mcp_report ~base_path =
             token_can_read_state = None;
             login_supported = false;
             login_note = codex_mcp_login_note;
+            config;
           })
 
 let analyze ~base_path_input ~default_base_path () =
@@ -376,6 +381,7 @@ let analyze ~base_path_input ~default_base_path () =
          None);
     ]
     |> List.filter_map Fun.id
+    |> (fun values -> values @ Codex_mcp_config_doctor.warnings codex_mcp.config)
     |> dedupe_keep_order
   in
   let next_actions =
@@ -420,9 +426,11 @@ let analyze ~base_path_input ~default_base_path () =
            "For Codex MCP, run `masc-mcp login --agent codex-mcp-client --role worker --shell` and export MASC_MCP_TOKEN; do not run `codex mcp login masc`."
        else
          None);
+      Some "For Codex MCP pipeline drift, inspect the codex_mcp.config.stages section from `masc-mcp doctor auth --json`.";
       Some "Rerun `masc-mcp doctor auth` after editing auth files or rotating tokens.";
     ]
     |> List.filter_map Fun.id
+    |> (fun values -> values @ Codex_mcp_config_doctor.next_actions codex_mcp.config)
     |> dedupe_keep_order
   in
   let status =
@@ -492,6 +500,7 @@ let codex_mcp_to_yojson codex_mcp =
         | None -> `Null );
       ("login_supported", `Bool codex_mcp.login_supported);
       ("login_note", `String codex_mcp.login_note);
+      ("config", Codex_mcp_config_doctor.to_yojson codex_mcp.config);
     ]
 
 let to_yojson (report : t) =
@@ -640,6 +649,26 @@ let render_text (report : t) =
     (Printf.sprintf "- login_supported: %s"
        (yes_no report.codex_mcp.login_supported));
   add_line (Printf.sprintf "- login_note: %s" report.codex_mcp.login_note);
+  add_line "- config:";
+  add_line
+    (Printf.sprintf "  path: %s"
+       (option_value report.codex_mcp.config.config_path));
+  add_line
+    (Printf.sprintf "  file_present: %s"
+       (yes_no report.codex_mcp.config.file_present));
+  add_line
+    (Printf.sprintf "  server_names: %s"
+       (match report.codex_mcp.config.server_names with
+        | [] -> "(none)"
+        | names -> String.concat ", " names));
+  add_line "  stages:";
+  List.iter
+    (fun (stage : Codex_mcp_config_doctor.stage) ->
+      add_line
+        (Printf.sprintf "  - %s: %s - %s" stage.name
+           (Codex_mcp_config_doctor.stage_status_to_string stage.status)
+           stage.detail))
+    report.codex_mcp.config.stages;
   if report.warnings <> [] then begin
     add_line "";
     add_line "warnings:";

--- a/lib/codex_mcp_config_doctor.ml
+++ b/lib/codex_mcp_config_doctor.ml
@@ -1,0 +1,433 @@
+type stage_status =
+  | Stage_pass
+  | Stage_warn
+  | Stage_fail
+  | Stage_skip
+
+type stage = {
+  name : string;
+  status : stage_status;
+  detail : string;
+}
+
+type t = {
+  config_path : string option;
+  file_present : bool;
+  parse_error : string option;
+  server_names : string list;
+  server_present : bool;
+  url : string option;
+  bearer_token_env_var : string option;
+  bearer_token_env_matches : bool option;
+  authorization_header_present : bool option;
+  accept_header : string option;
+  accept_header_ok : bool option;
+  x_masc_agent : string option;
+  x_masc_agent_ok : bool option;
+  stages : stage list;
+}
+
+let expected_server_name = "masc"
+let expected_token_env_var = "MASC_MCP_TOKEN"
+let expected_x_masc_agent = "codex-mcp-client"
+let codex_config_path_env_key = "MASC_CODEX_CONFIG_PATH"
+
+let stage name status detail = { name; status; detail }
+
+let oauth_login_stage () =
+  stage "codex_oauth_login" Stage_skip
+    "`codex mcp login` is not part of the MASC bearer-token path"
+
+let stage_status_to_string = function
+  | Stage_pass -> "pass"
+  | Stage_warn -> "warn"
+  | Stage_fail -> "fail"
+  | Stage_skip -> "skip"
+
+let empty ?config_path ?parse_error ?(file_present = false) stages =
+  {
+    config_path;
+    file_present;
+    parse_error;
+    server_names = [];
+    server_present = false;
+    url = None;
+    bearer_token_env_var = None;
+    bearer_token_env_matches = None;
+    authorization_header_present = None;
+    accept_header = None;
+    accept_header_ok = None;
+    x_masc_agent = None;
+    x_masc_agent_ok = None;
+    stages;
+  }
+
+let table_fields_opt = function
+  | Otoml.TomlTable fields
+  | Otoml.TomlInlineTable fields ->
+      Some fields
+  | _ -> None
+
+let assoc_opt key fields = List.assoc_opt key fields
+
+let assoc_ci_opt key fields =
+  let expected = String.lowercase_ascii key in
+  List.find_map
+    (fun (field_key, value) ->
+      if String.equal (String.lowercase_ascii field_key) expected then
+        Some value
+      else
+        None)
+    fields
+
+let string_opt key fields =
+  match assoc_opt key fields with
+  | Some (Otoml.TomlString value) -> Some value
+  | _ -> None
+
+let string_ci_opt key fields =
+  match assoc_ci_opt key fields with
+  | Some (Otoml.TomlString value) -> Some value
+  | _ -> None
+
+let sorted_keys fields =
+  fields |> List.map fst |> List.sort_uniq String.compare
+
+let accept_header_ok raw =
+  let media_types =
+    raw |> String.split_on_char ','
+    |> List.map (fun value -> value |> String.trim |> String.lowercase_ascii)
+  in
+  List.mem "application/json" media_types
+  && List.mem "text/event-stream" media_types
+
+let server_names_detail names =
+  match names with
+  | [] -> "(none)"
+  | _ -> String.concat ", " names
+
+let config_path_opt () =
+  match Sys.getenv_opt codex_config_path_env_key |> Env_config_core.trim_opt with
+  | Some path -> Some path
+  | None ->
+      Option.map
+        (fun home -> Filename.concat home ".codex/config.toml")
+        (Env_config_core.home_dir_opt ())
+
+let analyze_content ~config_path content =
+  match Otoml.Parser.from_string_result content with
+  | Error parse_error ->
+      empty ~config_path ~file_present:true ~parse_error
+        [
+          stage "codex_config_file" Stage_pass
+            (Printf.sprintf "read %s" config_path);
+          stage "codex_config_parse" Stage_fail parse_error;
+          stage "codex_server_config" Stage_skip
+            "skipped because Codex config did not parse as TOML";
+          stage "codex_auth_model" Stage_skip
+            "skipped because Codex config did not parse as TOML";
+          stage "codex_http_headers" Stage_skip
+            "skipped because Codex config did not parse as TOML";
+          stage "codex_agent_header" Stage_skip
+            "skipped because Codex config did not parse as TOML";
+          oauth_login_stage ();
+        ]
+  | Ok toml ->
+      let root_fields = table_fields_opt toml |> Option.value ~default:[] in
+      let mcp_servers_fields =
+        match assoc_opt "mcp_servers" root_fields with
+        | Some value -> table_fields_opt value |> Option.value ~default:[]
+        | None -> []
+      in
+      let server_names = sorted_keys mcp_servers_fields in
+      let masc_fields =
+        match assoc_opt expected_server_name mcp_servers_fields with
+        | Some value -> table_fields_opt value
+        | None -> None
+      in
+      let server_present = Option.is_some masc_fields in
+      let url = Option.bind masc_fields (fun fields -> string_opt "url" fields) in
+      let bearer_token_env_var =
+        Option.bind masc_fields (fun fields ->
+            string_opt "bearer_token_env_var" fields)
+      in
+      let bearer_token_env_matches =
+        Option.map
+          (String.equal expected_token_env_var)
+          bearer_token_env_var
+      in
+      let headers_fields =
+        Option.bind masc_fields (fun fields ->
+            match assoc_opt "http_headers" fields with
+            | Some value -> table_fields_opt value
+            | None -> None)
+      in
+      let authorization_header_present =
+        if not server_present then
+          None
+        else
+          Some
+            (match headers_fields with
+             | Some fields ->
+                 Option.is_some (assoc_ci_opt "Authorization" fields)
+             | None -> false)
+      in
+      let accept_header =
+        Option.bind headers_fields (fun fields -> string_ci_opt "Accept" fields)
+      in
+      let accept_header_ok = Option.map accept_header_ok accept_header in
+      let x_masc_agent =
+        Option.bind headers_fields (fun fields ->
+            string_ci_opt "X-MASC-Agent" fields)
+      in
+      let x_masc_agent_ok =
+        Option.map (String.equal expected_x_masc_agent) x_masc_agent
+      in
+      let config_stage =
+        stage "codex_config_file" Stage_pass
+          (Printf.sprintf "read %s" config_path)
+      in
+      let parse_stage =
+        stage "codex_config_parse" Stage_pass "TOML parsed"
+      in
+      let server_stage =
+        if server_present then
+          stage "codex_server_config" Stage_pass
+            "[mcp_servers.masc] is present"
+        else
+          stage "codex_server_config" Stage_fail
+            (Printf.sprintf
+               "[mcp_servers.masc] is missing; configured server names: %s"
+               (server_names_detail server_names))
+      in
+      let auth_stage =
+        match server_present, bearer_token_env_var, authorization_header_present with
+        | false, _, _ ->
+            stage "codex_auth_model" Stage_skip
+              "skipped because [mcp_servers.masc] is missing"
+        | true, Some env_var, Some false
+          when String.equal env_var expected_token_env_var ->
+            stage "codex_auth_model" Stage_pass
+              "uses bearer_token_env_var=MASC_MCP_TOKEN and no hardcoded Authorization header"
+        | true, Some env_var, Some true
+          when String.equal env_var expected_token_env_var ->
+            stage "codex_auth_model" Stage_fail
+              "bearer_token_env_var is correct, but http_headers still contains Authorization"
+        | true, Some env_var, _ ->
+            stage "codex_auth_model" Stage_fail
+              (Printf.sprintf
+                 "expected bearer_token_env_var=%s, found %s"
+                 expected_token_env_var env_var)
+        | true, None, Some true ->
+            stage "codex_auth_model" Stage_fail
+              "missing bearer_token_env_var and http_headers contains Authorization"
+        | true, None, _ ->
+            stage "codex_auth_model" Stage_fail
+              "missing bearer_token_env_var=MASC_MCP_TOKEN"
+      in
+      let headers_stage =
+        match server_present, accept_header_ok with
+        | false, _ ->
+            stage "codex_http_headers" Stage_skip
+              "skipped because [mcp_servers.masc] is missing"
+        | true, Some true ->
+            stage "codex_http_headers" Stage_pass
+              "Accept covers application/json and text/event-stream"
+        | true, Some false ->
+            stage "codex_http_headers" Stage_fail
+              "Accept must include application/json and text/event-stream"
+        | true, None ->
+            stage "codex_http_headers" Stage_fail
+              "missing http_headers.Accept for Streamable HTTP MCP"
+      in
+      let agent_stage =
+        match server_present, x_masc_agent_ok with
+        | false, _ ->
+            stage "codex_agent_header" Stage_skip
+              "skipped because [mcp_servers.masc] is missing"
+        | true, Some true ->
+            stage "codex_agent_header" Stage_pass
+              "X-MASC-Agent identifies codex-mcp-client"
+        | true, Some false ->
+            stage "codex_agent_header" Stage_warn
+              "X-MASC-Agent is present but not codex-mcp-client"
+        | true, None ->
+            stage "codex_agent_header" Stage_warn
+              "missing X-MASC-Agent=codex-mcp-client header"
+      in
+      {
+        config_path = Some config_path;
+        file_present = true;
+        parse_error = None;
+        server_names;
+        server_present;
+        url;
+        bearer_token_env_var;
+        bearer_token_env_matches;
+        authorization_header_present;
+        accept_header;
+        accept_header_ok;
+        x_masc_agent;
+        x_masc_agent_ok;
+        stages =
+          [
+            config_stage;
+            parse_stage;
+            server_stage;
+            auth_stage;
+            headers_stage;
+            agent_stage;
+            oauth_login_stage ();
+          ];
+      }
+
+let analyze_path config_path =
+  if not (Sys.file_exists config_path) then
+    empty ~config_path
+      [
+        stage "codex_config_file" Stage_fail
+          (Printf.sprintf "Codex config file does not exist: %s" config_path);
+        stage "codex_config_parse" Stage_skip
+          "skipped because Codex config file is missing";
+        stage "codex_server_config" Stage_skip
+          "skipped because Codex config file is missing";
+        stage "codex_auth_model" Stage_skip
+          "skipped because Codex config file is missing";
+        stage "codex_http_headers" Stage_skip
+          "skipped because Codex config file is missing";
+        stage "codex_agent_header" Stage_skip
+          "skipped because Codex config file is missing";
+        oauth_login_stage ();
+      ]
+  else
+    try analyze_content ~config_path (Fs_compat.load_file config_path)
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+        empty ~config_path ~file_present:true
+          ~parse_error:(Printexc.to_string exn)
+          [
+            stage "codex_config_file" Stage_fail
+              (Printf.sprintf "failed to read %s: %s" config_path
+                 (Printexc.to_string exn));
+            stage "codex_config_parse" Stage_skip
+              "skipped because Codex config file could not be read";
+            stage "codex_server_config" Stage_skip
+              "skipped because Codex config file could not be read";
+            stage "codex_auth_model" Stage_skip
+              "skipped because Codex config file could not be read";
+            stage "codex_http_headers" Stage_skip
+              "skipped because Codex config file could not be read";
+            stage "codex_agent_header" Stage_skip
+              "skipped because Codex config file could not be read";
+            oauth_login_stage ();
+          ]
+
+let analyze_default () =
+  match config_path_opt () with
+  | None ->
+      empty
+        [
+          stage "codex_config_file" Stage_fail
+            "HOME and MASC_CODEX_CONFIG_PATH are unset";
+          stage "codex_config_parse" Stage_skip
+            "skipped because Codex config path is unknown";
+          stage "codex_server_config" Stage_skip
+            "skipped because Codex config path is unknown";
+          stage "codex_auth_model" Stage_skip
+            "skipped because Codex config path is unknown";
+          stage "codex_http_headers" Stage_skip
+            "skipped because Codex config path is unknown";
+          stage "codex_agent_header" Stage_skip
+            "skipped because Codex config path is unknown";
+          oauth_login_stage ();
+        ]
+  | Some path -> analyze_path path
+
+let stage_to_yojson stage =
+  `Assoc
+    [
+      ("name", `String stage.name);
+      ("status", `String (stage_status_to_string stage.status));
+      ("detail", `String stage.detail);
+    ]
+
+let option_field name = function
+  | Some value -> (name, `String value)
+  | None -> (name, `Null)
+
+let option_bool_field name = function
+  | Some value -> (name, `Bool value)
+  | None -> (name, `Null)
+
+let to_yojson report =
+  `Assoc
+    [
+      option_field "config_path" report.config_path;
+      ("file_present", `Bool report.file_present);
+      option_field "parse_error" report.parse_error;
+      ( "server_names",
+        `List (List.map (fun value -> `String value) report.server_names) );
+      ("server_present", `Bool report.server_present);
+      option_field "url" report.url;
+      option_field "bearer_token_env_var" report.bearer_token_env_var;
+      option_bool_field "bearer_token_env_matches"
+        report.bearer_token_env_matches;
+      option_bool_field "authorization_header_present"
+        report.authorization_header_present;
+      option_field "accept_header" report.accept_header;
+      option_bool_field "accept_header_ok" report.accept_header_ok;
+      option_field "x_masc_agent" report.x_masc_agent;
+      option_bool_field "x_masc_agent_ok" report.x_masc_agent_ok;
+      ("stages", `List (List.map stage_to_yojson report.stages));
+    ]
+
+let warnings report =
+  report.stages
+  |> List.filter_map (fun stage ->
+         match stage.status with
+         | Stage_fail | Stage_warn ->
+             Some
+               (Printf.sprintf "Codex MCP pipeline %s: %s" stage.name
+                  stage.detail)
+         | Stage_pass | Stage_skip -> None)
+
+let next_actions report =
+  let has_stage name =
+    List.exists
+      (fun stage ->
+        String.equal stage.name name
+        &&
+        match stage.status with
+        | Stage_fail | Stage_warn -> true
+        | Stage_pass | Stage_skip -> false)
+      report.stages
+  in
+  [
+    (if has_stage "codex_config_file" then
+       Some
+         "Set MASC_CODEX_CONFIG_PATH or HOME so doctor auth can inspect the Codex MCP config file."
+     else
+       None);
+    (if has_stage "codex_server_config" then
+       Some
+         "Create a [mcp_servers.masc] entry in Codex config; MASC does not use `codex mcp login` OAuth."
+     else
+       None);
+    (if has_stage "codex_auth_model" then
+       Some
+         "Set [mcp_servers.masc].bearer_token_env_var=\"MASC_MCP_TOKEN\" and remove hardcoded Authorization from http_headers."
+     else
+       None);
+    (if has_stage "codex_http_headers" then
+       Some
+         "Set [mcp_servers.masc].http_headers.Accept to include application/json and text/event-stream."
+     else
+       None);
+    (if has_stage "codex_agent_header" then
+       Some
+         "Set [mcp_servers.masc].http_headers.X-MASC-Agent=\"codex-mcp-client\" for config/runtime attribution."
+     else
+       None);
+  ]
+  |> List.filter_map Fun.id

--- a/lib/dune
+++ b/lib/dune
@@ -24,6 +24,7 @@
    auth
    auth_doctor
    auth_login
+   codex_mcp_config_doctor
    board
    board_core
    board_core_classify

--- a/test/test_auth_doctor.ml
+++ b/test/test_auth_doctor.ml
@@ -26,6 +26,24 @@ let with_temp_dir prefix f =
   Unix.mkdir dir 0o755;
   Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
 
+let write_file path content =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
+let valid_codex_config =
+  {|[mcp_servers.masc]
+url = "http://127.0.0.1:8935/mcp"
+http_headers = { "Accept" = "application/json, text/event-stream", "X-MASC-Agent" = "codex-mcp-client" }
+bearer_token_env_var = "MASC_MCP_TOKEN"
+|}
+
+let with_valid_codex_config dir f =
+  let path = Filename.concat dir "codex-config.toml" in
+  write_file path valid_codex_config;
+  with_env "MASC_CODEX_CONFIG_PATH" path f
+
 let contains_substring ~needle s =
   let nl = String.length needle in
   let sl = String.length s in
@@ -41,6 +59,26 @@ let contains_substring ~needle s =
 
 let list_contains_substring ~needle values =
   List.exists (contains_substring ~needle) values
+
+let expected_codex_config_stage_names =
+  [
+    "codex_config_file";
+    "codex_config_parse";
+    "codex_server_config";
+    "codex_auth_model";
+    "codex_http_headers";
+    "codex_agent_header";
+    "codex_oauth_login";
+  ]
+
+let check_codex_config_stage_names (config : Codex_mcp_config_doctor.t) =
+  let names =
+    List.map
+      (fun (stage : Codex_mcp_config_doctor.stage) -> stage.name)
+      config.stages
+  in
+  check (list string) "stable codex config stage names"
+    expected_codex_config_stage_names names
 
 let save_credential_or_fail base_path ~agent_name ~role ~raw_token =
   match
@@ -76,6 +114,7 @@ let test_warns_for_codex_worker_admin_route_mismatch () =
   with_env "MASC_HTTP_AUTH_STRICT" "" @@ fun () ->
   with_env "MASC_ADMIN_TOKEN" "" @@ fun () ->
   with_env "MASC_MCP_TOKEN" "" @@ fun () ->
+  with_valid_codex_config base_path @@ fun () ->
   let report =
     Auth_doctor.analyze ~base_path_input:base_path
       ~default_base_path:base_path ()
@@ -117,6 +156,7 @@ let test_errors_when_no_admin_bearer_source_exists () =
   with_env "MASC_HTTP_AUTH_STRICT" "1" @@ fun () ->
   with_env "MASC_ADMIN_TOKEN" "" @@ fun () ->
   with_env "MASC_MCP_TOKEN" "" @@ fun () ->
+  with_valid_codex_config base_path @@ fun () ->
   let report =
     Auth_doctor.analyze ~base_path_input:base_path
       ~default_base_path:base_path ()
@@ -156,6 +196,7 @@ let test_ignores_stale_admin_raw_token_file () =
   with_env "MASC_HTTP_AUTH_STRICT" "1" @@ fun () ->
   with_env "MASC_ADMIN_TOKEN" "" @@ fun () ->
   with_env "MASC_MCP_TOKEN" "" @@ fun () ->
+  with_valid_codex_config base_path @@ fun () ->
   let report =
     Auth_doctor.analyze ~base_path_input:base_path
       ~default_base_path:base_path ()
@@ -194,6 +235,7 @@ let test_reports_codex_mcp_bearer_env () =
   with_env "MASC_HTTP_AUTH_STRICT" "" @@ fun () ->
   with_env "MASC_ADMIN_TOKEN" "" @@ fun () ->
   with_env "MASC_MCP_TOKEN" "codex-mcp-token" @@ fun () ->
+  with_valid_codex_config base_path @@ fun () ->
   let report =
     Auth_doctor.analyze ~base_path_input:base_path
       ~default_base_path:base_path ()
@@ -220,6 +262,143 @@ let test_reports_codex_mcp_bearer_env () =
     (list_contains_substring ~needle:"codex mcp login"
        report.warnings)
 
+let test_reports_codex_config_pipeline_stages () =
+  with_temp_dir "auth-doctor-codex-config-ok" @@ fun base_path ->
+  let auth_cfg =
+    Types.
+      {
+        enabled = true;
+        room_secret_hash = None;
+        require_token = true;
+        token_expiry_hours = 24;
+      }
+  in
+  Auth.save_auth_config base_path auth_cfg;
+  save_credential_or_fail base_path ~agent_name:"codex-mcp-client"
+    ~role:Types.Worker ~raw_token:"codex-mcp-token";
+  save_credential_or_fail base_path ~agent_name:"admin" ~role:Types.Admin
+    ~raw_token:"admin-token";
+  Auth.save_private_text_file (raw_token_file base_path "admin")
+    "admin-token";
+  with_env "MASC_HOST" "127.0.0.1" @@ fun () ->
+  with_env "MASC_HTTP_AUTH_STRICT" "" @@ fun () ->
+  with_env "MASC_ADMIN_TOKEN" "" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "codex-mcp-token" @@ fun () ->
+  with_valid_codex_config base_path @@ fun () ->
+  let report =
+    Auth_doctor.analyze ~base_path_input:base_path
+      ~default_base_path:base_path ()
+  in
+  let config = report.codex_mcp.config in
+  check bool "codex config file present" true config.file_present;
+  check bool "masc server present" true config.server_present;
+  check (option string) "bearer env var"
+    (Some "MASC_MCP_TOKEN")
+    config.bearer_token_env_var;
+  check (option bool) "bearer env var matches" (Some true)
+    config.bearer_token_env_matches;
+  check (option bool) "no hardcoded authorization header" (Some false)
+    config.authorization_header_present;
+  check (option bool) "accept header ok" (Some true)
+    config.accept_header_ok;
+  check (option bool) "agent header ok" (Some true)
+    config.x_masc_agent_ok;
+  check bool "no codex config pipeline warning" false
+    (list_contains_substring ~needle:"Codex MCP pipeline"
+       report.warnings);
+  check bool "json exposes config stages" true
+    (contains_substring ~needle:"\"stages\""
+       (Auth_doctor.to_yojson report |> Yojson.Safe.to_string));
+  check_codex_config_stage_names config
+
+let test_reports_stable_codex_config_stages_when_file_missing () =
+  with_temp_dir "auth-doctor-codex-config-missing" @@ fun base_path ->
+  let missing_path = Filename.concat base_path "missing-codex.toml" in
+  with_env "MASC_HOST" "127.0.0.1" @@ fun () ->
+  with_env "MASC_HTTP_AUTH_STRICT" "" @@ fun () ->
+  with_env "MASC_ADMIN_TOKEN" "" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "" @@ fun () ->
+  with_env "MASC_CODEX_CONFIG_PATH" missing_path @@ fun () ->
+  let report =
+    Auth_doctor.analyze ~base_path_input:base_path
+      ~default_base_path:base_path ()
+  in
+  let config = report.codex_mcp.config in
+  check bool "codex config file missing" false config.file_present;
+  check_codex_config_stage_names config;
+  check bool "oauth login remains classified as skip" true
+    (List.exists
+       (fun (stage : Codex_mcp_config_doctor.stage) ->
+         String.equal stage.name "codex_oauth_login"
+         && match stage.status with
+            | Codex_mcp_config_doctor.Stage_skip -> true
+            | Codex_mcp_config_doctor.Stage_pass
+            | Codex_mcp_config_doctor.Stage_warn
+            | Codex_mcp_config_doctor.Stage_fail ->
+                false)
+       config.stages);
+  check bool "suggests config path repair" true
+    (list_contains_substring ~needle:"MASC_CODEX_CONFIG_PATH"
+       report.next_actions)
+
+let test_warns_when_codex_config_uses_wrong_server_name () =
+  with_temp_dir "auth-doctor-codex-config-wrong-name" @@ fun base_path ->
+  let config_path = Filename.concat base_path "codex-config.toml" in
+  write_file config_path
+    {|[mcp_servers.mago]
+url = "http://127.0.0.1:8935/mcp"
+http_headers = { "Accept" = "application/json, text/event-stream" }
+bearer_token_env_var = "MASC_MCP_TOKEN"
+|};
+  with_env "MASC_HOST" "127.0.0.1" @@ fun () ->
+  with_env "MASC_HTTP_AUTH_STRICT" "" @@ fun () ->
+  with_env "MASC_ADMIN_TOKEN" "" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "" @@ fun () ->
+  with_env "MASC_CODEX_CONFIG_PATH" config_path @@ fun () ->
+  let report =
+    Auth_doctor.analyze ~base_path_input:base_path
+      ~default_base_path:base_path ()
+  in
+  check bool "masc server missing" false
+    report.codex_mcp.config.server_present;
+  check bool "captures wrong server name" true
+    (List.mem "mago" report.codex_mcp.config.server_names);
+  check bool "warns with wrong server name detail" true
+    (list_contains_substring
+       ~needle:"configured server names: mago"
+       report.warnings);
+  check bool "suggests canonical server section" true
+    (list_contains_substring
+       ~needle:"Create a [mcp_servers.masc] entry"
+       report.next_actions)
+
+let test_warns_when_codex_config_uses_hardcoded_authorization () =
+  with_temp_dir "auth-doctor-codex-config-hardcoded-auth" @@ fun base_path ->
+  let config_path = Filename.concat base_path "codex-config.toml" in
+  write_file config_path
+    {|[mcp_servers.masc]
+url = "http://127.0.0.1:8935/mcp"
+http_headers = { "Accept" = "application/json, text/event-stream", "Authorization" = "Bearer stale-token" }
+bearer_token_env_var = "MASC_MCP_TOKEN"
+|};
+  with_env "MASC_HOST" "127.0.0.1" @@ fun () ->
+  with_env "MASC_HTTP_AUTH_STRICT" "" @@ fun () ->
+  with_env "MASC_ADMIN_TOKEN" "" @@ fun () ->
+  with_env "MASC_MCP_TOKEN" "" @@ fun () ->
+  with_env "MASC_CODEX_CONFIG_PATH" config_path @@ fun () ->
+  let report =
+    Auth_doctor.analyze ~base_path_input:base_path
+      ~default_base_path:base_path ()
+  in
+  check (option bool) "authorization header detected" (Some true)
+    report.codex_mcp.config.authorization_header_present;
+  check bool "warns about hardcoded authorization" true
+    (list_contains_substring
+       ~needle:"http_headers still contains Authorization"
+       report.warnings);
+  check bool "does not leak token literal" false
+    (list_contains_substring ~needle:"stale-token" report.warnings)
+
 let () =
   run "auth_doctor"
     [
@@ -233,5 +412,14 @@ let () =
             test_ignores_stale_admin_raw_token_file;
           test_case "reports Codex MCP bearer env" `Quick
             test_reports_codex_mcp_bearer_env;
+          test_case "reports Codex MCP config pipeline stages" `Quick
+            test_reports_codex_config_pipeline_stages;
+          test_case "reports stable Codex MCP config stages when file missing"
+            `Quick
+            test_reports_stable_codex_config_stages_when_file_missing;
+          test_case "warns when Codex MCP config uses wrong server name" `Quick
+            test_warns_when_codex_config_uses_wrong_server_name;
+          test_case "warns when Codex MCP config uses hardcoded auth" `Quick
+            test_warns_when_codex_config_uses_hardcoded_authorization;
         ] );
     ]


### PR DESCRIPTION
## Summary\n- add a typed Codex MCP config doctor that parses Codex TOML with Otoml and exposes stable pipeline stages\n- wire the config projection into doctor auth JSON/text output, warnings, and next actions\n- document the bearer-token path so operators check codex_mcp.config.stages before retrying codex mcp login\n\n## Why it matters\nCodex can emit a generic not-logged-in warning for MCP servers, but MASC does not use codex mcp login OAuth. The operator needs to see the actual pipeline: config file, [mcp_servers.masc], bearer_token_env_var, literal Authorization header absence, Streamable HTTP Accept header, X-MASC-Agent attribution, and the explicit OAuth-login skip. This makes wrong server names like mago, stale hardcoded Authorization, and missing headers visible without string-matching the warning.\n\n## Verification\n- DUNE_CACHE=disabled dune build --root . --cache=disabled -j1 test/test_auth_doctor.exe\n- _build/default/test/test_auth_doctor.exe: 8 tests passed\n- _build/default/bin/main_eio.exe doctor auth --base-path /Users/dancer/me --json: live Codex config stages pass/pass/pass/pass/pass/pass/skip\n- live POST http://127.0.0.1:8935/mcp initialize with MASC_MCP_TOKEN returned HTTP 200, server_name=masc-mcp, capabilities prompts/resources/tools\n\n## Follow-up\n- Recorded out-of-scope config generation/token exposure hardening as #10289