### PR TITLE
fix(persona): derive save field allowlist from catalog

### DIFF
--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -55,49 +55,28 @@ let json_string_list_normalized key json =
   Safe_ops.json_string_list key json |> Keeper_types_profile.normalize_name_list
 ;;
 
-let allowed_keeper_fields =
-  [ "goal"
-  ; "short_goal"
-  ; "mid_goal"
-  ; "long_goal"
-  ; "will"
-  ; "needs"
-  ; "desires"
-  ; "instructions"
-  ; "policy_voice_enabled"
-  ; "mention_targets"
-  ; "proactive_enabled"
-  ; "proactive_idle_sec"
-  ; "proactive_cooldown_sec"
-  ; "room_signal_prompt_enabled"
-  ; "shards"
-  ; "tool_preset"
-  ; "tool_also_allow"
-  ; "tool_denylist"
-  ; "work_discovery_enabled"
-  ; "work_discovery_sources"
-  ; "work_discovery_interval_sec"
-  ; "work_discovery_guidance"
-  ; "telemetry_feedback_enabled"
-  ; "telemetry_feedback_window_hours"
-  ; "per_provider_timeout"
-  ; "always_approve"
-  ; "max_turns_per_call"
-  ; "max_turns_per_call_scheduled_autonomous"
-  ; "social_model"
-  ; "cascade_name"
-  ]
-;;
+type field_catalog_entry =
+  { path : string
+  ; typ : string
+  ; required : bool
+  ; default : Yojson.Safe.t option
+  ; choices : Yojson.Safe.t option
+  ; field_effect : string
+  }
 
 let field_catalog_entry ?default ?choices ?(required = false) ~path ~typ ~field_effect () =
+  { path; typ; required; default; choices; field_effect }
+;;
+
+let field_catalog_entry_to_json entry =
   `Assoc
-    ([ "path", `String path
-     ; "type", `String typ
-     ; "required", `Bool required
-     ; "effect", `String field_effect
+    ([ "path", `String entry.path
+     ; "type", `String entry.typ
+     ; "required", `Bool entry.required
+     ; "effect", `String entry.field_effect
      ]
-     @ option_field "default" default
-     @ option_field "choices" choices)
+     @ option_field "default" entry.default
+     @ option_field "choices" entry.choices)
 ;;
 
 let tool_preset_choices_json =
@@ -118,9 +97,8 @@ let choice_effect_fields = Archetypes.choice_effect_fields
 let choice_effect_for = Archetypes.choice_effect_for
 let archetype_axes_json = Archetypes.archetype_axes_json
 
-let field_catalog_json () =
-  `List
-    [ field_catalog_entry
+let field_catalog_entries =
+  [ field_catalog_entry
         ~path:"name"
         ~typ:"string"
         ~default:(`String "<handle>")
@@ -181,16 +159,21 @@ let field_catalog_json () =
         ~field_effect:
           "Self-model needs statement. Overrides the keeper environment default."
         ()
-    ; field_catalog_entry
-        ~path:"keeper.desires"
-        ~typ:"string"
-        ~field_effect:
-          "Self-model desires statement. Overrides the keeper environment default."
-        ()
-    ; field_catalog_entry
-        ~path:"keeper.mention_targets"
-        ~typ:"string[]"
-        ~default:(`String "[<handle>]")
+  ; field_catalog_entry
+      ~path:"keeper.desires"
+      ~typ:"string"
+      ~field_effect:
+        "Self-model desires statement. Overrides the keeper environment default."
+      ()
+  ; field_catalog_entry
+      ~path:"keeper.policy_voice_enabled"
+      ~typ:"boolean"
+      ~field_effect:"Whether persona-created keepers should surface voice tools."
+      ()
+  ; field_catalog_entry
+      ~path:"keeper.mention_targets"
+      ~typ:"string[]"
+      ~default:(`String "[<handle>]")
         ~field_effect:"Names that wake or target this persona-backed keeper."
         ()
     ; field_catalog_entry
@@ -299,7 +282,29 @@ let field_catalog_json () =
         ~field_effect:
           "Optional named cascade override. Must resolve to a known cascade at runtime."
         ()
-    ]
+  ]
+;;
+
+let field_catalog_json () =
+  `List (List.map field_catalog_entry_to_json field_catalog_entries)
+;;
+
+let keeper_field_prefix = "keeper."
+
+let keeper_field_name_of_catalog_path path =
+  if String.starts_with ~prefix:keeper_field_prefix path
+  then
+    Some
+      (String.sub
+         path
+         (String.length keeper_field_prefix)
+         (String.length path - String.length keeper_field_prefix))
+  else None
+;;
+
+let allowed_keeper_fields =
+  field_catalog_entries
+  |> List.filter_map (fun entry -> keeper_field_name_of_catalog_path entry.path)
 ;;
 
 let personas_root_candidate () =

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1116,6 +1116,29 @@ let test_persona_authoring_social_model_choices_follow_variant_ssot () =
     Masc_mcp.Keeper_social_model.valid_model_id_strings
     KTP.valid_social_model_strings
 
+let test_persona_authoring_allowed_keeper_fields_follow_catalog () =
+  let json = KPA.schema_json () in
+  let keeper_prefix = "keeper." in
+  let keeper_fields =
+    Yojson.Safe.Util.member "field_catalog" json
+    |> Yojson.Safe.Util.to_list
+    |> List.filter_map (fun entry ->
+           let path =
+             Yojson.Safe.Util.member "path" entry |> Yojson.Safe.Util.to_string
+           in
+           if String.starts_with ~prefix:keeper_prefix path
+           then
+             Some
+               (String.sub
+                  path
+                  (String.length keeper_prefix)
+                  (String.length path - String.length keeper_prefix))
+           else None)
+    |> List.sort String.compare
+  in
+  check (list string) "allowed keeper fields follow schema catalog" keeper_fields
+    (List.sort String.compare KPA.allowed_keeper_fields)
+
 let test_persona_authoring_axes_validate_and_default_preset () =
   let args =
     `Assoc
@@ -1558,6 +1581,8 @@ let () =
             test_persona_authoring_schema_explains_effects;
           test_case "persona authoring social_model choices follow variant SSOT" `Quick
             test_persona_authoring_social_model_choices_follow_variant_ssot;
+          test_case "persona authoring allowed keeper fields follow catalog" `Quick
+            test_persona_authoring_allowed_keeper_fields_follow_catalog;
           test_case "persona authoring axes validate and default preset" `Quick
             test_persona_authoring_axes_validate_and_default_preset;
           test_case "persona authoring axes reject unknown choices" `Quick


### PR DESCRIPTION
Summary
- Turn persona field catalog entries into typed records.
- Derive schema JSON and keeper save allowlist from the same catalog entries.
- Add the missing policy_voice_enabled catalog entry so existing save behavior stays documented.
- Add a regression guard so supported keeper fields cannot drift between masc_persona_schema and save validation.

Why this matters
- Before, allowed_keeper_fields was a handwritten mirror of field_catalog_json.
- A future catalog edit could make the schema lie about what masc_persona_save accepts, or silently reject a documented field.

Verification
- git diff --check origin/main..HEAD
- env DUNE_BUILD_DIR=_build_verify_persona_catalog_ssot DUNE_JOBS=2 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_toml.exe
- ./_build_verify_persona_catalog_ssot/default/test/test_keeper_toml.exe (83 tests)