### PR TITLE
fix(keeper): reset fiber latches on launch

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -2292,8 +2292,7 @@ let publish_keeper_started ~(live_meta : keeper_meta) : unit =
 ;;
 
 let dispatch_fiber_started ~base_path keeper_name =
-  match Keeper_registry.dispatch_event ~base_path keeper_name
-          Keeper_state_machine.Fiber_started with
+  match Keeper_registry.prepare_fiber_launch ~base_path keeper_name with
   | Ok _ -> ()
   | Error err ->
       Log.Keeper.warn

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1062,6 +1062,15 @@ let rec dispatch_event_with_audit
 let dispatch_event ~base_path name event =
   dispatch_event_with_audit ~base_path name event
 
+let prepare_fiber_launch ~base_path name =
+  (match get ~base_path name with
+   | Some entry ->
+       Atomic.set entry.fiber_stop false;
+       Atomic.set entry.fiber_wakeup false;
+       Atomic.set entry.waiting_for_inference false
+   | None -> ());
+  dispatch_event ~base_path name Keeper_state_machine.Fiber_started
+
 let get_phase ~base_path name =
   match get ~base_path name with
   | Some entry -> Some entry.phase

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -180,6 +180,13 @@ val register_offline : base_path:string -> string -> keeper_meta -> registry_ent
     replacement fiber launches. *)
 val register_restarting : base_path:string -> string -> keeper_meta -> registry_entry
 
+(** Prepare a registry entry for a newly launched keepalive fiber.
+    Clears stale per-fiber atomic latches before applying [Fiber_started] so
+    the runtime stop flag matches the state machine's restart semantics. *)
+val prepare_fiber_launch :
+  base_path:string -> string ->
+  (Keeper_state_machine.transition_result, Keeper_state_machine.transition_error) result
+
 (** Unregister a keeper (removes from registry). *)
 val unregister : base_path:string -> string -> unit
 

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -120,8 +120,7 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
   let base_path = ctx.config.base_path in
   let keepers_dir =
     Filename.concat (Coord.masc_root_dir ctx.config) "keepers" in
-  (match Keeper_registry.dispatch_event ~base_path meta.name
-           Keeper_state_machine.Fiber_started with
+  (match Keeper_registry.prepare_fiber_launch ~base_path meta.name with
    | Ok _ -> ()
    | Error err ->
        Log.Keeper.warn

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -120,6 +120,29 @@ let test_register_restarting_and_start () =
       check bool "running after Fiber_started" true
         (R.is_running ~base_path:bp "k1-restart")
 
+let test_prepare_fiber_launch_resets_stale_runtime_latches () =
+  R.clear ();
+  let name = "k1-stale-stop" in
+  let entry = R.register_restarting ~base_path:bp name (make_meta name) in
+  Atomic.set entry.fiber_stop true;
+  Atomic.set entry.fiber_wakeup true;
+  Atomic.set entry.waiting_for_inference true;
+  (match R.prepare_fiber_launch ~base_path:bp name with
+   | Ok _ -> ()
+   | Error err -> fail (KSM.transition_error_to_string err));
+  match R.get ~base_path:bp name with
+  | None -> fail "expected k1-stale-stop"
+  | Some updated ->
+      check bool "fiber_stop reset before launch" false
+        (Atomic.get updated.fiber_stop);
+      check bool "fiber_wakeup reset before launch" false
+        (Atomic.get updated.fiber_wakeup);
+      check bool "waiting_for_inference reset before launch" false
+        (Atomic.get updated.waiting_for_inference);
+      check string "running after prepare launch" "running"
+        (KSM.phase_to_string updated.phase);
+      check bool "fsm stop_requested reset" false updated.conditions.stop_requested
+
 let test_dispatch_event_with_audit_preserves_snapshot () =
   R.clear ();
   let keeper_name = "k-audit-guardrail" in
@@ -1074,6 +1097,8 @@ let () =
           eio_test "register and get" test_register_and_get;
           eio_test "register offline and start" test_register_offline_and_start;
           eio_test "register restarting and start" test_register_restarting_and_start;
+          eio_test "prepare fiber launch resets stale latches"
+            test_prepare_fiber_launch_resets_stale_runtime_latches;
           eio_test "dispatch event with audit preserves snapshot"
             test_dispatch_event_with_audit_preserves_snapshot;
           eio_test "mark_turn_finished records completed turn outcome once"


### PR DESCRIPTION
## Summary

- add `Keeper_registry.prepare_fiber_launch` as the single launch boundary for keepalive fibers
- reset stale per-fiber runtime latches (`fiber_stop`, `fiber_wakeup`, `waiting_for_inference`) before applying `Fiber_started`
- route both direct keepalive startup and supervisor relaunch through that helper
- add a registry regression test for stale stop/wakeup/inference latches

## Root Cause

The keeper FSM already treats `Fiber_started` as a new fiber lifetime and clears `stop_requested`. The runtime-side atomic latches were reset only when a fresh registry entry happened to be allocated. Any reused entry with a stale `fiber_stop=true` could let a launch report `fiber_started` while the heartbeat loop exits before evaluating a cycle.

## Validation

- `env DUNE_BUILD_DIR=_build_10254_keeper_fiber_stop DUNE_JOBS=2 DUNE_CACHE=disabled MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_keeper_registry.exe test/test_keeper_supervisor.exe test/test_keeper_unified.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-10254-registry-final _build_10254_keeper_fiber_stop/default/test/test_keeper_registry.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-10254-supervisor-final _build_10254_keeper_fiber_stop/default/test/test_keeper_supervisor.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-10254-unified-final _build_10254_keeper_fiber_stop/default/test/test_keeper_unified.exe`
- `git diff --check origin/main..HEAD`
- `bash scripts/ml_line_cap_audit.sh --baseline-ref origin/main --fail-on-regression`
- `bash scripts/ci/check-telemetry-coverage.sh`

Fixes #10254
