### PR TITLE
fix(ws): tighten dashboard event fanout and text frames

### DIFF
--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -167,12 +167,18 @@ let send_frame_bytes session bytes ~len =
       false
   end
 
+(** WebSocket text frames must contain valid UTF-8.  Raw SSE broadcasts can
+    include tool/provider output bytes that are valid for local persistence but
+    invalid as browser WebSocket text, so repair at the final wire boundary. *)
+let websocket_text_payload text =
+  Inference_utils.sanitize_text_utf8 text
+
 (** Send a text frame to a WebSocket client.
     Allocates [Bytes.t] per call — fine for single-destination sends.
     Multicast paths should go through [send_text_shared] instead so the
     bytes allocation is paid once per broadcast, not once per session. *)
 let send_text session text =
-  let bytes = Bytes.of_string text in
+  let bytes = Bytes.of_string (websocket_text_payload text) in
   send_frame_bytes session bytes ~len:(Bytes.length bytes)
 
 (** Module-local cache of the last [Bytes.of_string sse_event] result.
@@ -193,7 +199,7 @@ let bytes_of_shared_text text =
   end
   else begin
     Transport_metrics.inc_ws_bytes_cache_miss ();
-    let bytes = Bytes.of_string text in
+    let bytes = Bytes.of_string (websocket_text_payload text) in
     Atomic.set bytes_cache (text, bytes);
     bytes
   end

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -251,6 +251,8 @@ let dashboard_slice_for_sse_type = function
       Some "operator"
   | "transport_health_snapshot" ->
       Some "transport"
+  | "keeper_composite_changed" ->
+      Some "composite"
   | _ -> None
 
 let dashboard_session_result session =

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -71,6 +71,23 @@ let test_parse_sse_dashboard_event_known_type () =
         (Some "execution") parsed.slice
   | None -> Alcotest.fail "expected parsed event"
 
+let test_parse_sse_dashboard_event_composite_change_maps_to_composite () =
+  let event_str =
+    Yojson.Safe.to_string
+      (`Assoc [
+        ("type", `String "keeper_composite_changed");
+        ("name", `String "qa-king");
+        ("ts_unix", `Float 1_774_000_000.0);
+      ])
+  in
+  match Ws.parse_sse_dashboard_event event_str with
+  | Some parsed ->
+      Alcotest.(check string) "event_type preserved"
+        "keeper_composite_changed" parsed.event_type;
+      Alcotest.(check (option string)) "composite change maps to composite"
+        (Some "composite") parsed.slice
+  | None -> Alcotest.fail "expected parsed composite event"
+
 let test_parse_sse_dashboard_event_unknown_type () =
   let event_str =
     Yojson.Safe.to_string
@@ -598,6 +615,8 @@ let () =
     ("parse_cache", [
       Alcotest.test_case "known type maps to slice" `Quick
         test_parse_sse_dashboard_event_known_type;
+      Alcotest.test_case "composite change maps to composite slice" `Quick
+        test_parse_sse_dashboard_event_composite_change_maps_to_composite;
       Alcotest.test_case "unknown type yields None slice" `Quick
         test_parse_sse_dashboard_event_unknown_type;
       Alcotest.test_case "malformed input returns None" `Quick

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -239,6 +239,27 @@ let test_bytes_of_shared_text_content_matches () =
   Alcotest.(check string) "content round-trips" text
     (Bytes.to_string bytes)
 
+let contains_substring haystack needle =
+  let hlen = String.length haystack in
+  let nlen = String.length needle in
+  let rec loop i =
+    i + nlen <= hlen
+    && (String.sub haystack i nlen = needle || loop (i + 1))
+  in
+  nlen = 0 || loop 0
+
+let test_bytes_of_shared_text_repairs_invalid_utf8_for_text_frames () =
+  let text =
+    "id: 42\nevent: message\ndata: {\"type\":\"transport_health_snapshot\",\
+     \"payload\":\"bad\xC3\"}\n\n"
+  in
+  let bytes = Ws.bytes_of_shared_text text in
+  let wire = Bytes.to_string bytes in
+  Alcotest.(check bool) "wire payload is valid UTF-8"
+    true (String.is_valid_utf_8 wire);
+  Alcotest.(check bool) "invalid byte is replaced"
+    true (contains_substring wire "\xEF\xBF\xBD")
+
 let test_bytes_of_shared_text_invalidates_on_new_ref () =
   (* Force two distinct string allocations so physical equality differs
      even though content is the same.  The cache must re-allocate rather
@@ -637,6 +658,8 @@ let () =
         test_bytes_of_shared_text_reuses_same_ref;
       Alcotest.test_case "content round-trips through cache" `Quick
         test_bytes_of_shared_text_content_matches;
+      Alcotest.test_case "invalid UTF-8 is repaired before text frames" `Quick
+        test_bytes_of_shared_text_repairs_invalid_utf8_for_text_frames;
       Alcotest.test_case "distinct refs force re-allocation" `Quick
         test_bytes_of_shared_text_invalidates_on_new_ref;
       Alcotest.test_case "hit/miss counters track reuse" `Quick


### PR DESCRIPTION
## Summary
- Map keeper_composite_changed SSE events to the dashboard composite slice.
- Repair WebSocket text-frame payloads at the final wire boundary when upstream SSE/tool output contains invalid UTF-8 bytes.
- Add websocket transport regressions for composite slice routing and invalid UTF-8 repair.

## Why it matters
The immediate scaling issue is not only whether to move traffic to WebSocket or gRPC. A missing slice meant keeper_composite_changed bypassed the default-on WebSocket dashboard slice gate and was raw-forwarded to every authenticated dashboard session. Invalid UTF-8 in raw SSE payloads could also make browser WebSocket text frames unreliable. These fixes reduce wasted fanout and make the existing WS path a more trustworthy baseline before pushing gRPC deeper into high-frequency/internal streams.

## Notes
The composite payload remains name/ts and the frontend still routes it through the existing composite tick refresh path. The UTF-8 repair is intentionally placed at send_text/bytes_of_shared_text so local persistence semantics stay unchanged while browser text-frame requirements are enforced at the transport boundary.

## Validation
- scripts/dune-local.sh build test/test_ws_transport.exe
- ./_build/default/test/test_ws_transport.exe
- git diff --check