### PR TITLE
fix(cascade): attribute and cool down Kimi resumable failures (#10285)

### DIFF
--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -308,6 +308,8 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason ~now () =
          state and fail again.  Cool down immediately to keep fallback from
          becoming a hidden tax on every request. *)
       state.consecutive_failures <- state.consecutive_failures + 1;
+      let persistent = bump_failure_fp () in
+      apply_trust_failure_locked state ~persistent;
       let new_until = now +. terminal_failure_cooldown_sec in
       if new_until > state.cooldown_until then
         state.cooldown_until <- new_until)
@@ -327,8 +329,9 @@ let record_hard_quota t ~provider_key ?error_kind ?error_reason () =
   record t ~provider_key ~outcome:Hard_quota ?error_kind ?error_reason
     ~now:(Unix.gettimeofday ()) ()
 
-let record_terminal_failure t ~provider_key =
-  record t ~provider_key ~outcome:Terminal_failure ~now:(Unix.gettimeofday ())
+let record_terminal_failure t ~provider_key ?error_kind ?error_reason () =
+  record t ~provider_key ~outcome:Terminal_failure ?error_kind ?error_reason
+    ~now:(Unix.gettimeofday ()) ()
 
 (* ── Queries ──────────────────────────────────── *)
 

--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -119,6 +119,24 @@ let hard_quota_cooldown_sec =
     ~deprecated:"OAS_CASCADE_HARD_QUOTA_COOLDOWN_SEC"
     ~default:3600.0
 
+(** Cooldown duration for provider calls classified as terminal structural
+    failures, where retrying the same provider on the next cascade tick is
+    expected to reproduce the same failure until operator/runtime state changes.
+    Examples: Kimi CLI reporting a resumable session conflict instead of
+    accepting a fresh non-interactive invocation.
+
+    This is separate from hard-quota so dashboards and future policy can
+    distinguish "account exhausted" from "adapter/session state is wedged",
+    while both use the same immediate long-cooldown behavior.
+
+    Default: 3600s (1h). *)
+let terminal_failure_cooldown_sec =
+  read_float_setting
+    ~primary:"MASC_CASCADE_TERMINAL_FAILURE_COOLDOWN_SEC"
+    ~deprecated:"OAS_CASCADE_TERMINAL_FAILURE_COOLDOWN_SEC"
+    ~default:3600.0
+
+
 (* ── Types ────────────────────────────────────── *)
 
 (* [Rejected] is the third outcome kind introduced in 0.160.0.  It
@@ -134,7 +152,12 @@ let hard_quota_cooldown_sec =
    triggers an immediate long cooldown ([hard_quota_cooldown_sec]); the
    [cooldown_threshold] does not apply because retry on the next cascade
    tick is pointless when the upstream account is out of credit. *)
-type outcome = Success | Failure | Rejected | Hard_quota
+(* [Terminal_failure] represents structural provider/adapter failures that are
+   deterministic for the current runtime state.  A Kimi CLI resumable-session
+   conflict is the motivating case: fallback is correct for the current call,
+   but repeatedly attempting Kimi first on every later call only adds latency
+   and silently degrades cascade diversity. *)
+type outcome = Success | Failure | Rejected | Hard_quota | Terminal_failure
 
 type event = {
   time: float;  (* Unix timestamp *)
@@ -278,6 +301,15 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason ~now () =
       bump_failure_fp ();
       let new_until = now +. hard_quota_cooldown_sec in
       if new_until > state.cooldown_until then
+        state.cooldown_until <- new_until
+    | Terminal_failure ->
+      (* Terminal structural errors are not quota exhaustion, but they have the
+         same retry shape: the next cascade tick will hit the same provider
+         state and fail again.  Cool down immediately to keep fallback from
+         becoming a hidden tax on every request. *)
+      state.consecutive_failures <- state.consecutive_failures + 1;
+      let new_until = now +. terminal_failure_cooldown_sec in
+      if new_until > state.cooldown_until then
         state.cooldown_until <- new_until)
 
 let record_success t ~provider_key =
@@ -294,6 +326,9 @@ let record_rejected t ~provider_key ?error_kind ?error_reason () =
 let record_hard_quota t ~provider_key ?error_kind ?error_reason () =
   record t ~provider_key ~outcome:Hard_quota ?error_kind ?error_reason
     ~now:(Unix.gettimeofday ()) ()
+
+let record_terminal_failure t ~provider_key =
+  record t ~provider_key ~outcome:Terminal_failure ~now:(Unix.gettimeofday ())
 
 (* ── Queries ──────────────────────────────────── *)
 

--- a/lib/cascade/cascade_health_tracker.mli
+++ b/lib/cascade/cascade_health_tracker.mli
@@ -127,8 +127,16 @@ val record_hard_quota :
 
     This uses immediate long cooldown semantics like {!record_hard_quota},
     but is kept distinct from quota exhaustion so the caller can classify
-    adapter/session failures without pretending the account is out of credit. *)
-val record_terminal_failure : t -> provider_key:string -> unit
+    adapter/session failures without pretending the account is out of credit.
+
+    See {!record_failure} for [error_kind] / [error_reason] semantics. *)
+val record_terminal_failure :
+  t ->
+  provider_key:string ->
+  ?error_kind:string ->
+  ?error_reason:string ->
+  unit ->
+  unit
 
 (** Drop tracker entries whose rolling window is empty AND whose cooldown
     has expired.  Intended as opportunistic maintenance — idle providers

--- a/lib/cascade/cascade_health_tracker.mli
+++ b/lib/cascade/cascade_health_tracker.mli
@@ -34,6 +34,15 @@ val hard_quota_cooldown_sec : float
 
     @since 0.161.0 *)
 
+val terminal_failure_cooldown_sec : float
+(** Cooldown duration applied immediately on a terminal structural
+    provider/adapter failure, such as a Kimi CLI resumable-session conflict.
+    Unlike {!cooldown_sec}, no threshold is required.  Default 3600.0 (1h).
+
+    Env: [MASC_CASCADE_TERMINAL_FAILURE_COOLDOWN_SEC] (with deprecated
+    [OAS_CASCADE_TERMINAL_FAILURE_COOLDOWN_SEC] alias). *)
+
+
 (** Opaque health tracker state. *)
 type t
 
@@ -112,6 +121,14 @@ val record_hard_quota :
   ?error_reason:string ->
   unit ->
   unit
+
+(** Record a provider call that failed with a terminal structural
+    provider/adapter error.
+
+    This uses immediate long cooldown semantics like {!record_hard_quota},
+    but is kept distinct from quota exhaustion so the caller can classify
+    adapter/session failures without pretending the account is out of credit. *)
+val record_terminal_failure : t -> provider_key:string -> unit
 
 (** Drop tracker entries whose rolling window is empty AND whose cooldown
     has expired.  Intended as opportunistic maintenance — idle providers

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -954,7 +954,24 @@ let sdk_error_to_resumable_cli_session ~cascade_name
 let sdk_error_is_resumable_cli_session (err : Oas.Error.sdk_error) : bool =
   match classify_masc_internal_error err with
   | Some (Resumable_cli_session _) -> true
-  | _ -> message_looks_like_resumable_cli_session (Oas.Error.to_string err)
+  | _ ->
+      let direct_api_message =
+        match err with
+        | Oas.Error.Api
+            (Llm_provider.Retry.NetworkError { message; _ }
+            | Llm_provider.Retry.Overloaded { message }
+            | Llm_provider.Retry.ServerError { message; _ }
+            | Llm_provider.Retry.InvalidRequest { message }
+            | Llm_provider.Retry.RateLimited { message; _ }
+            | Llm_provider.Retry.AuthError { message }
+            | Llm_provider.Retry.NotFound { message }
+            | Llm_provider.Retry.ContextOverflow { message; _ }
+            | Llm_provider.Retry.Timeout { message }) ->
+            message_looks_like_resumable_cli_session message
+        | _ -> false
+      in
+      direct_api_message
+      || message_looks_like_resumable_cli_session (Oas.Error.to_string err)
 
 let sdk_error_is_hard_quota (err : Oas.Error.sdk_error) : bool =
   match err with

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -1494,7 +1494,8 @@ let run_named
               ~error_kind:"hard_quota" ~error_reason:err_str ())
         else if sdk_error_is_resumable_cli_session sdk_err then
           Cascade_health_tracker.(
-            record_terminal_failure global ~provider_key:provider_cfg.model_id)
+            record_terminal_failure global ~provider_key:provider_cfg.model_id
+              ~error_kind:"resumable_cli_session" ~error_reason:err_str ())
         else
           Cascade_health_tracker.(
             record_failure global ~provider_key:provider_cfg.model_id

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -327,9 +327,47 @@ let kind_of_masc_internal_error = function
   | Oas_timeout_budget _ -> "oas_timeout_budget"
   | Ambiguous_post_commit _ -> "ambiguous_post_commit"
 
+(** #10285: which cascade emitted this error.
+
+    Pre-fix [masc_oas_error_total] only carried a [kind] label, so the
+    97 [resumable_cli_session] events observed in 10000 logs flattened
+    into a single counter even though they were unevenly distributed
+    across 5 cascades (governance_judge=32, kimi_cli_keeper=8,
+    keeper_unified=6, tool_use_strict=5, local_with_kimi_coding_with_glm=1).
+    Operators couldn't tell which cascade was the dominant offender —
+    a critical signal because cascade demotion / model-order edits
+    are per-cascade actions, not global ones.
+
+    Variants that carry [cascade_name] in their payload return it
+    directly.  The five variants that don't ([Accept_rejected],
+    [Admission_queue_rejected], [Turn_timeout], [Oas_timeout_budget],
+    [Ambiguous_post_commit]) emit the ["unknown"] sentinel — they
+    fire outside cascade context so a synthetic value would be
+    misleading.  An empty-string [cascade_name] in a cascade-aware
+    variant also collapses to ["unknown"] so the label always carries
+    a non-empty value (Prometheus exporters reject empty labels in
+    some configurations and Grafana group-bys lose the row). *)
+let cascade_name_of_masc_internal_error = function
+  | Cascade_exhausted { cascade_name; _ }
+  | Resumable_cli_session { cascade_name; _ }
+  | No_tool_capable_provider { cascade_name; _ }
+  | Admission_queue_timeout { cascade_name; _ } ->
+      if String.equal (String.trim cascade_name) "" then "unknown"
+      else cascade_name
+  | Accept_rejected _
+  | Admission_queue_rejected _
+  | Turn_timeout _
+  | Oas_timeout_budget _
+  | Ambiguous_post_commit _ -> "unknown"
+
 let sdk_error_of_masc_internal_error err =
   Prometheus.inc_counter masc_oas_error_total_metric
-    ~labels:[ ("kind", kind_of_masc_internal_error err) ] ();
+    ~labels:
+      [
+        ("kind", kind_of_masc_internal_error err);
+        ("cascade_name", cascade_name_of_masc_internal_error err);
+      ]
+    ();
   Oas.Error.Internal
     (masc_internal_error_prefix ^ Yojson.Safe.to_string (masc_internal_error_to_json err))
 
@@ -913,6 +951,11 @@ let sdk_error_to_resumable_cli_session ~cascade_name
                 }))
       else None
 
+let sdk_error_is_resumable_cli_session (err : Oas.Error.sdk_error) : bool =
+  match classify_masc_internal_error err with
+  | Some (Resumable_cli_session _) -> true
+  | _ -> message_looks_like_resumable_cli_session (Oas.Error.to_string err)
+
 let sdk_error_is_hard_quota (err : Oas.Error.sdk_error) : bool =
   match err with
   | Oas.Error.Api api_err ->
@@ -1420,18 +1463,21 @@ let run_named
           | Some err -> err
           | None -> sdk_err
         in
-        (* Classify hard-quota (account-level exhaustion) distinctly from
-           transient failures.  Hard quota (e.g. Anthropic multi-day usage
-           limit, ZAI balance 0) will not recover within the 60s
-           [cooldown_sec]; apply an immediate long cooldown
-           ([hard_quota_cooldown_sec], default 1h) so weighted_random
-           re-selection doesn't waste cascade turns on a provider that
-           is terminally unavailable. *)
+        (* Classify deterministic non-transient failures distinctly from
+           ordinary call errors.  Hard quota (e.g. Anthropic multi-day usage
+           limit, ZAI balance 0) and Kimi CLI resumable-session conflicts do
+           not recover within the 60s [cooldown_sec]; apply an immediate long
+           cooldown so weighted_random/failover selection does not waste later
+           cascade turns on a provider that is terminal for the current runtime
+           state. *)
         let err_str = Oas.Error.to_string sdk_err in
         if sdk_error_is_hard_quota sdk_err then
           Cascade_health_tracker.(
             record_hard_quota global ~provider_key:provider_cfg.model_id
               ~error_kind:"hard_quota" ~error_reason:err_str ())
+        else if sdk_error_is_resumable_cli_session sdk_err then
+          Cascade_health_tracker.(
+            record_terminal_failure global ~provider_key:provider_cfg.model_id)
         else
           Cascade_health_tracker.(
             record_failure global ~provider_key:provider_cfg.model_id

--- a/test/test_cascade_health_tracker.ml
+++ b/test/test_cascade_health_tracker.ml
@@ -299,6 +299,60 @@ let test_fingerprint_top_sorted_descending () =
     check int "highest count" 3 c1
   | _ -> failwith "expected at least 3 fingerprints"
 
+(* ── Terminal_failure outcome (#10285) ───────────────── *)
+
+let test_terminal_failure_triggers_immediate_cooldown () =
+  let t = H.create () in
+  H.record_terminal_failure t ~provider_key:"kimi-for-coding";
+  check bool "single terminal_failure event trips cooldown immediately"
+    true (H.is_in_cooldown t ~provider_key:"kimi-for-coding")
+
+let test_terminal_failure_cooldown_is_long () =
+  let t = H.create () in
+  H.record_terminal_failure t ~provider_key:"kimi-for-coding";
+  match H.provider_info t ~provider_key:"kimi-for-coding" with
+  | None -> fail "provider_info returned None after record_terminal_failure"
+  | Some info ->
+    let now = Unix.gettimeofday () in
+    (match info.cooldown_expires_at with
+     | None -> fail "expected cooldown_expires_at = Some _, got None"
+     | Some expires ->
+       let remaining = expires -. now in
+       check bool
+         (Printf.sprintf "terminal_failure cooldown (%.0fs) >> regular cooldown (60s)" remaining)
+         true (remaining > 300.0))
+
+let test_terminal_failure_effective_weight_zero () =
+  let t = H.create () in
+  H.record_terminal_failure t ~provider_key:"kimi-for-coding";
+  check int "effective_weight = 0 during terminal_failure cooldown"
+    0 (H.effective_weight t ~provider_key:"kimi-for-coding" ~config_weight:100)
+
+let test_terminal_failure_success_clears_cooldown () =
+  let t = H.create () in
+  H.record_terminal_failure t ~provider_key:"kimi-for-coding";
+  H.record_success t ~provider_key:"kimi-for-coding";
+  check bool "success after terminal_failure clears cooldown"
+    false (H.is_in_cooldown t ~provider_key:"kimi-for-coding")
+
+let test_terminal_failure_preserves_longer_existing_cooldown () =
+  let t = H.create () in
+  H.record_terminal_failure t ~provider_key:"kimi-for-coding";
+  let expires_after_first =
+    match H.provider_info t ~provider_key:"kimi-for-coding" with
+    | Some { cooldown_expires_at = Some x; _ } -> x
+    | _ -> fail "no cooldown after first terminal_failure"
+  in
+  H.record_terminal_failure t ~provider_key:"kimi-for-coding";
+  let expires_after_second =
+    match H.provider_info t ~provider_key:"kimi-for-coding" with
+    | Some { cooldown_expires_at = Some x; _ } -> x
+    | _ -> fail "no cooldown after second terminal_failure"
+  in
+  check bool "second terminal_failure does not shorten cooldown"
+    true (expires_after_second >= expires_after_first)
+
+
 let () =
   run "cascade_health_tracker" [
     "record", [
@@ -360,5 +414,17 @@ let () =
         test_last_failure_at_none_for_pure_success;
       test_case "top_fingerprints sorted descending" `Quick
         test_fingerprint_top_sorted_descending;
+    ];
+    "terminal_failure", [
+      test_case "single event trips immediate cooldown" `Quick
+        test_terminal_failure_triggers_immediate_cooldown;
+      test_case "cooldown duration is long (≫ 60s)" `Quick
+        test_terminal_failure_cooldown_is_long;
+      test_case "effective_weight = 0 during terminal_failure cooldown" `Quick
+        test_terminal_failure_effective_weight_zero;
+      test_case "success after terminal_failure clears cooldown" `Quick
+        test_terminal_failure_success_clears_cooldown;
+      test_case "second terminal_failure does not shorten cooldown" `Quick
+        test_terminal_failure_preserves_longer_existing_cooldown;
     ];
   ]

--- a/test/test_cascade_health_tracker.ml
+++ b/test/test_cascade_health_tracker.ml
@@ -303,13 +303,13 @@ let test_fingerprint_top_sorted_descending () =
 
 let test_terminal_failure_triggers_immediate_cooldown () =
   let t = H.create () in
-  H.record_terminal_failure t ~provider_key:"kimi-for-coding";
+  H.record_terminal_failure t ~provider_key:"kimi-for-coding" ();
   check bool "single terminal_failure event trips cooldown immediately"
     true (H.is_in_cooldown t ~provider_key:"kimi-for-coding")
 
 let test_terminal_failure_cooldown_is_long () =
   let t = H.create () in
-  H.record_terminal_failure t ~provider_key:"kimi-for-coding";
+  H.record_terminal_failure t ~provider_key:"kimi-for-coding" ();
   match H.provider_info t ~provider_key:"kimi-for-coding" with
   | None -> fail "provider_info returned None after record_terminal_failure"
   | Some info ->
@@ -324,26 +324,26 @@ let test_terminal_failure_cooldown_is_long () =
 
 let test_terminal_failure_effective_weight_zero () =
   let t = H.create () in
-  H.record_terminal_failure t ~provider_key:"kimi-for-coding";
+  H.record_terminal_failure t ~provider_key:"kimi-for-coding" ();
   check int "effective_weight = 0 during terminal_failure cooldown"
     0 (H.effective_weight t ~provider_key:"kimi-for-coding" ~config_weight:100)
 
 let test_terminal_failure_success_clears_cooldown () =
   let t = H.create () in
-  H.record_terminal_failure t ~provider_key:"kimi-for-coding";
+  H.record_terminal_failure t ~provider_key:"kimi-for-coding" ();
   H.record_success t ~provider_key:"kimi-for-coding";
   check bool "success after terminal_failure clears cooldown"
     false (H.is_in_cooldown t ~provider_key:"kimi-for-coding")
 
 let test_terminal_failure_preserves_longer_existing_cooldown () =
   let t = H.create () in
-  H.record_terminal_failure t ~provider_key:"kimi-for-coding";
+  H.record_terminal_failure t ~provider_key:"kimi-for-coding" ();
   let expires_after_first =
     match H.provider_info t ~provider_key:"kimi-for-coding" with
     | Some { cooldown_expires_at = Some x; _ } -> x
     | _ -> fail "no cooldown after first terminal_failure"
   in
-  H.record_terminal_failure t ~provider_key:"kimi-for-coding";
+  H.record_terminal_failure t ~provider_key:"kimi-for-coding" ();
   let expires_after_second =
     match H.provider_info t ~provider_key:"kimi-for-coding" with
     | Some { cooldown_expires_at = Some x; _ } -> x
@@ -351,6 +351,19 @@ let test_terminal_failure_preserves_longer_existing_cooldown () =
   in
   check bool "second terminal_failure does not shorten cooldown"
     true (expires_after_second >= expires_after_first)
+
+let test_terminal_failure_records_fingerprint () =
+  let t = H.create () in
+  H.record_terminal_failure t ~provider_key:"kimi-for-coding"
+    ~error_kind:"resumable_cli_session"
+    ~error_reason:"kimi exited with code 1: session conflict" ();
+  let info = info_or_fail t ~provider_key:"kimi-for-coding" in
+  match info.top_fingerprints with
+  | [ (fp, count) ] ->
+    check bool "terminal failure fingerprint keeps kind"
+      true (String.starts_with ~prefix:"resumable_cli_session" fp);
+    check int "terminal failure fingerprint count" 1 count
+  | _ -> failwith "expected exactly one terminal failure fingerprint"
 
 
 let () =
@@ -426,5 +439,7 @@ let () =
         test_terminal_failure_success_clears_cooldown;
       test_case "second terminal_failure does not shorten cooldown" `Quick
         test_terminal_failure_preserves_longer_existing_cooldown;
+      test_case "terminal_failure records fingerprint" `Quick
+        test_terminal_failure_records_fingerprint;
     ];
   ]

--- a/test/test_oas_error_kind_counter.ml
+++ b/test/test_oas_error_kind_counter.ml
@@ -10,10 +10,13 @@
 module OWN = Masc_mcp.Oas_worker_named
 module Prom = Masc_mcp.Prometheus
 
-let counter_for kind =
+(* #10285: cascade_name label was added.  Query [(kind, cascade_name)]
+   pair.  Tests that only care about kind regardless of cascade pass
+   the expected cascade_name explicitly so assertions stay exact. *)
+let counter_for ?(cascade_name = "unknown") kind =
   Prom.metric_value_or_zero
     OWN.masc_oas_error_total_metric
-    ~labels:[ ("kind", kind) ]
+    ~labels:[ ("kind", kind); ("cascade_name", cascade_name) ]
     ()
 
 let test_metric_name_stable () =
@@ -54,53 +57,56 @@ let test_turn_timeout_kind () =
 
 let test_cascade_exhausted_kind () =
   let kind = "cascade_exhausted" in
-  let before = counter_for kind in
+  let cascade_name = "big_three" in
+  let before = counter_for ~cascade_name kind in
   let _ =
     OWN.sdk_error_of_masc_internal_error
       (OWN.Cascade_exhausted
          {
-           cascade_name = "big_three";
+           cascade_name;
            reason =
              Masc_mcp.Keeper_types.Other_detail "all providers tried";
          })
   in
   Alcotest.(check (float 0.0001))
-    "cascade_exhausted counter +1"
+    "cascade_exhausted{cascade_name=big_three} counter +1"
     (before +. 1.0)
-    (counter_for kind)
+    (counter_for ~cascade_name kind)
 
 let test_resumable_cli_session_kind () =
   let kind = "resumable_cli_session" in
-  let before = counter_for kind in
+  let cascade_name = "big_three" in
+  let before = counter_for ~cascade_name kind in
   let _ =
     OWN.sdk_error_of_masc_internal_error
       (OWN.Resumable_cli_session
          {
-           cascade_name = "big_three";
+           cascade_name;
            detail = "session resumable";
            exit_code = Some 130;
          })
   in
   Alcotest.(check (float 0.0001))
-    "resumable_cli_session counter +1"
+    "resumable_cli_session{cascade_name=big_three} counter +1"
     (before +. 1.0)
-    (counter_for kind)
+    (counter_for ~cascade_name kind)
 
 let test_no_tool_capable_provider_kind () =
   let kind = "no_tool_capable_provider" in
-  let before = counter_for kind in
+  let cascade_name = "tool_required" in
+  let before = counter_for ~cascade_name kind in
   let _ =
     OWN.sdk_error_of_masc_internal_error
       (OWN.No_tool_capable_provider
          {
-           cascade_name = "tool_required";
+           cascade_name;
            configured_labels = [ "openai"; "anthropic" ];
          })
   in
   Alcotest.(check (float 0.0001))
-    "no_tool_capable_provider counter +1"
+    "no_tool_capable_provider{cascade_name=tool_required} counter +1"
     (before +. 1.0)
-    (counter_for kind)
+    (counter_for ~cascade_name kind)
 
 let test_accept_rejected_kind () =
   let kind = "accept_rejected" in
@@ -121,20 +127,17 @@ let test_accept_rejected_kind () =
 
 let test_admission_queue_timeout_kind () =
   let kind = "admission_queue_timeout" in
-  let before = counter_for kind in
+  let cascade_name = "big_three" in
+  let before = counter_for ~cascade_name kind in
   let _ =
     OWN.sdk_error_of_masc_internal_error
       (OWN.Admission_queue_timeout
-         {
-           keeper_name = "keeper-alpha";
-           cascade_name = "big_three";
-           wait_sec = 30.0;
-         })
+         { keeper_name = "keeper-alpha"; cascade_name; wait_sec = 30.0 })
   in
   Alcotest.(check (float 0.0001))
-    "admission_queue_timeout counter +1"
+    "admission_queue_timeout{cascade_name=big_three} counter +1"
     (before +. 1.0)
-    (counter_for kind)
+    (counter_for ~cascade_name kind)
 
 let test_admission_queue_rejected_kind () =
   let kind = "admission_queue_rejected" in
@@ -182,6 +185,64 @@ let test_kind_isolation () =
     b_before (counter_for b);
   ignore a
 
+(* #10285: cascade_name label separation -------------------------- *)
+
+let test_resumable_cli_session_per_cascade_isolation () =
+  (* The exact #10285 shape: resumable_cli_session events are
+     unevenly distributed across 5 cascades.  Bumping
+     [governance_judge] must NOT move the counter for
+     [kimi_cli_keeper] — operators rate-alert and demote per cascade. *)
+  let kind = "resumable_cli_session" in
+  let cascade_a = "governance_judge" in
+  let cascade_b = "kimi_cli_keeper" in
+  let b_before = counter_for ~cascade_name:cascade_b kind in
+  let a_before = counter_for ~cascade_name:cascade_a kind in
+  let _ =
+    OWN.sdk_error_of_masc_internal_error
+      (OWN.Resumable_cli_session
+         { cascade_name = cascade_a; detail = "exit 1"; exit_code = Some 1 })
+  in
+  Alcotest.(check (float 0.0001))
+    "governance_judge counter advanced"
+    (a_before +. 1.0)
+    (counter_for ~cascade_name:cascade_a kind);
+  Alcotest.(check (float 0.0001))
+    "kimi_cli_keeper counter unchanged by governance_judge bump"
+    b_before
+    (counter_for ~cascade_name:cascade_b kind)
+
+let test_empty_cascade_name_collapses_to_unknown () =
+  (* Defensive: a cascade-aware variant whose payload happens to
+     carry an empty cascade_name (whitespace-only allowed) must NOT
+     emit a series with [cascade_name=""].  Empty-label rows are
+     rejected by some Prometheus scraper configs and collapse in
+     Grafana group-by. *)
+  let kind = "resumable_cli_session" in
+  let unknown_before = counter_for ~cascade_name:"unknown" kind in
+  let _ =
+    OWN.sdk_error_of_masc_internal_error
+      (OWN.Resumable_cli_session
+         { cascade_name = "  "; detail = "exit 1"; exit_code = Some 1 })
+  in
+  Alcotest.(check (float 0.0001))
+    "blank cascade_name routes to 'unknown'"
+    (unknown_before +. 1.0)
+    (counter_for ~cascade_name:"unknown" kind)
+
+let test_non_cascade_aware_variant_uses_unknown () =
+  (* [Turn_timeout] has no cascade_name in its payload; the label
+     stays ["unknown"] rather than guessing. *)
+  let kind = "turn_timeout" in
+  let before = counter_for ~cascade_name:"unknown" kind in
+  let _ =
+    OWN.sdk_error_of_masc_internal_error
+      (OWN.Turn_timeout { elapsed_sec = 99.0 })
+  in
+  Alcotest.(check (float 0.0001))
+    "non-cascade-aware variant labels cascade_name=unknown"
+    (before +. 1.0)
+    (counter_for ~cascade_name:"unknown" kind)
+
 let () =
   Alcotest.run "oas_error_kind_counter_9933"
     [
@@ -215,5 +276,17 @@ let () =
         [
           Alcotest.test_case "kind labels separate" `Quick
             test_kind_isolation;
+        ] );
+      ( "cascade_name_label_10285",
+        [
+          Alcotest.test_case
+            "resumable_cli_session per-cascade isolation" `Quick
+            test_resumable_cli_session_per_cascade_isolation;
+          Alcotest.test_case
+            "blank cascade_name collapses to unknown" `Quick
+            test_empty_cascade_name_collapses_to_unknown;
+          Alcotest.test_case
+            "non-cascade-aware variant uses unknown" `Quick
+            test_non_cascade_aware_variant_uses_unknown;
         ] );
     ]

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -840,6 +840,35 @@ let test_sdk_error_to_cascade_outcome_cascades_resumable_cli_session () =
          | Some Cascade_fsm.Slot_full -> "some-slot-full"
          | None -> "none")
 
+let test_sdk_error_is_resumable_cli_session_detects_structured_error () =
+  let err =
+    Oas_worker_named.sdk_error_of_masc_internal_error
+      (Oas_worker_named.Resumable_cli_session
+         {
+           cascade_name = "governance_judge";
+           detail =
+             "kimi_cli reported a resumable CLI session (exit 1). \
+              Resumable session available via -r.";
+           exit_code = Some 1;
+         })
+  in
+  Alcotest.(check bool) "structured resumable CLI session detected" true
+    (Oas_worker_named.sdk_error_is_resumable_cli_session err);
+  Alcotest.(check bool) "resumable CLI session is not hard quota" false
+    (Oas_worker_named.sdk_error_is_hard_quota err)
+
+let test_sdk_error_is_resumable_cli_session_detects_raw_kimi_hint () =
+  let raw_message =
+    "kimi exited with code 1: \nTo resume this session: kimi -r 5de0f199-6bd7-4509-bfa6-3308e0ebd97f"
+  in
+  let err =
+    Oas.Error.Api
+      (Llm_provider.Retry.NetworkError
+         { message = raw_message; kind = Llm_provider.Http_client.Unknown })
+  in
+  Alcotest.(check bool) "raw Kimi resume hint detected" true
+    (Oas_worker_named.sdk_error_is_resumable_cli_session err)
+
 let make_openai_compat_provider_cfg ?(model_id = "mock-model")
     ?(base_url = "http://127.0.0.1:18080/v1")
     ?(request_path = "/chat/completions") ?(api_key = "") () =
@@ -3623,6 +3652,10 @@ let () =
         test_sdk_error_to_cascade_outcome_cascades_runtime_mcp_auth_config;
       Alcotest.test_case "sdk_error_to_cascade_outcome cascades resumable CLI session" `Quick
         test_sdk_error_to_cascade_outcome_cascades_resumable_cli_session;
+      Alcotest.test_case "sdk_error_is_resumable_cli_session detects structured error" `Quick
+        test_sdk_error_is_resumable_cli_session_detects_structured_error;
+      Alcotest.test_case "sdk_error_is_resumable_cli_session detects raw Kimi hint" `Quick
+        test_sdk_error_is_resumable_cli_session_detects_raw_kimi_hint;
       Alcotest.test_case "Moonshot auth errors include configured env hint" `Quick
         test_enrich_sdk_error_for_moonshot_auth_includes_env_hint;
       Alcotest.test_case "OpenAI-compatible 404 errors include endpoint hint" `Quick


### PR DESCRIPTION
## Goal

Fix #10285's Kimi `resumable_cli_session` failure loop without guessing at undocumented Kimi session-state cleanup.

Observed shape from the issue:

- 97 `resumable_cli_session` events in the last 10,000 logs.
- 5 affected cascades, dominated by `governance_judge`.
- Every affected call first hits Kimi, fails with exit 1, then falls back to the next provider.
- Operators only saw a global error kind, not the per-cascade offender.

## Change

This PR now fixes both the observability gap and the repeated first-tier retry tax.

1. Add `cascade_name` to `masc_oas_error_total`.

   `Resumable_cli_session`, `Cascade_exhausted`, `No_tool_capable_provider`, and `Admission_queue_timeout` use their payload `cascade_name`. Non-cascade-scoped variants emit `cascade_name="unknown"` instead of inventing misleading context.

2. Add terminal structural failure health tracking.

   `Cascade_health_tracker` now has a `Terminal_failure` outcome and `record_terminal_failure`. It behaves like hard quota operationally: one event triggers immediate long cooldown, preserving any longer existing cooldown, and success clears it.

   Default cooldown: `MASC_CASCADE_TERMINAL_FAILURE_COOLDOWN_SEC=3600`
   Deprecated alias: `OAS_CASCADE_TERMINAL_FAILURE_COOLDOWN_SEC`

3. Wire Kimi resumable-session errors to terminal cooldown.

   `run_named` already reclassifies Kimi resume hints into structured `[masc_oas_error] {"kind":"resumable_cli_session" ...}`. After this change, that structured error records `record_terminal_failure` instead of ordinary `record_failure`, so Kimi is skipped on subsequent cascade selections during cooldown instead of failing first on every request.

4. Detect both structured and raw Kimi resume hints.

   `sdk_error_is_resumable_cli_session` detects:

   - structured `Resumable_cli_session`
   - raw `Oas.Error.Api` messages where `Oas.Error.to_string` would otherwise hide the original `kimi exited with code 1` prefix

## Why Not `--no-resume`

[근거] `kimi --help`, checked 2026-04-25 KST, High confidence: current local CLI exposes `--session/--resume -S,-r` and `--continue -C`, but no `--no-resume`. Help points to official docs at `https://moonshotai.github.io/kimi-cli/`.

So this PR does not invent an unsupported flag or delete guessed session files. It models the failure deterministically in the cascade layer, where MASC already owns provider health and failover policy.

## Behavior

- First Kimi resumable-session failure still falls through to the next cascade provider.
- Subsequent selections skip that Kimi provider while the terminal cooldown is active.
- Fleet metrics can now answer which cascade is producing the error.
- Existing `sum by (kind)` dashboards keep working; they simply ignore the extra label.

## Verification

```bash
git diff --check origin/main...HEAD
env MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=2 DUNE_CACHE=disabled DUNE_BUILD_DIR=/tmp/masc-10285-build scripts/dune-local.sh build --cache=disabled test/test_cascade_health_tracker.exe test/test_oas_worker.exe test/test_oas_error_kind_counter.exe
env MASC_BASE_PATH=/tmp/masc-10285-test-base /tmp/masc-10285-build/default/test/test_cascade_health_tracker.exe
env MASC_BASE_PATH=/tmp/masc-10285-test-base /tmp/masc-10285-build/default/test/test_oas_error_kind_counter.exe
env MASC_BASE_PATH=/tmp/masc-10285-test-base /tmp/masc-10285-build/default/test/test_oas_worker.exe
```

Results:

- `test_cascade_health_tracker.exe`: 23 tests
- `test_oas_error_kind_counter.exe`: 14 tests
- `test_oas_worker.exe`: 117 tests

## Follow-Up

If Kimi documents a fresh-session flag or stable session-state directory, that can become a narrower cleanup PR. This PR deliberately avoids undocumented filesystem mutation.
