### PR TITLE
perf(bounded,auto-recall): drop per-call Re.compile from substring helpers

### DIFF
--- a/lib/auto_recall.ml
+++ b/lib/auto_recall.ml
@@ -402,6 +402,32 @@ let extract_query_hints query =
   |> List.filter (fun w -> String.length w > 2)
   |> List.filter (fun w -> not (List.mem (String.lowercase_ascii w) common_words))
 
+(* Byte-wise substring search (haystack already lowered, needle lowered
+   inline).  Replaces a per-hint [Re.compile] that ran inside a
+   [List.exists]: with K hints and N items in [fetch_context_smart],
+   the old form built K × N regex DFAs even though each pattern was a
+   plain literal. *)
+let contains_lowered_substring ~haystack_lower needle =
+  let nlen = String.length needle in
+  let hlen = String.length haystack_lower in
+  if nlen = 0 then true
+  else if nlen > hlen then false
+  else
+    let rec match_at i j =
+      if j = nlen then true
+      else
+        let h = String.unsafe_get haystack_lower (i + j) in
+        let n = Char.lowercase_ascii (String.unsafe_get needle j) in
+        if h <> n then false else match_at i (j + 1)
+    in
+    let last = hlen - nlen in
+    let rec loop i =
+      if i > last then false
+      else if match_at i 0 then true
+      else loop (i + 1)
+    in
+    loop 0
+
 (** Check if content matches query (simple keyword matching) *)
 let content_matches_query content query =
   if query = "" then true
@@ -409,8 +435,8 @@ let content_matches_query content query =
     let hints = extract_query_hints query in
     let content_lower = String.lowercase_ascii content in
     List.exists (fun hint ->
-      String.length hint >= 3 &&
-      Re.execp (Re.str (String.lowercase_ascii hint) |> Re.compile) content_lower
+      String.length hint >= 3
+      && contains_lowered_substring ~haystack_lower:content_lower hint
     ) hints
 
 (** Fetch context with query-based relevance boosting *)

--- a/lib/bounded.ml
+++ b/lib/bounded.ml
@@ -91,13 +91,12 @@ let calc_backoff_delay retry_config attempt =
   let jitter = (Random.State.float bounded_rng jitter_range) -. (jitter_range /. 2.0) in
   int_of_float (capped +. jitter)
 
-(** Check if error is retryable (transient failures) *)
-let is_retryable_error msg =
-  let msg_lower = String.lowercase_ascii msg in
-  List.exists (fun pattern ->
-    let pattern_lower = String.lowercase_ascii pattern in
-    Re.execp (Re.str pattern_lower |> Re.compile) msg_lower
-  ) [
+(* Static alternation of retryable-failure markers, hoisted to module
+   load.  Old form rebuilt 14 [Re.t] DFAs and 14 lowercase strings on
+   every error classification; the patterns are literals and
+   case-insensitive matching is delegated to [no_case]. *)
+let retryable_error_re =
+  let patterns = [
     "timeout";
     "timed out";
     "connection refused";
@@ -112,7 +111,12 @@ let is_retryable_error msg =
     "504";
     "overloaded";
     "temporarily unavailable";
-  ]
+  ] in
+  Re.(compile (no_case (alt (List.map str patterns))))
+
+(** Check if error is retryable (transient failures) *)
+let is_retryable_error msg =
+  Re.execp retryable_error_re msg
 
 (** Create new bounded state *)
 let create_state constraints =


### PR DESCRIPTION
## Summary

Two more substring-only helpers paid `Re.compile` on every invocation.

### `Bounded.is_retryable_error`

```ocaml
(* before *)
let is_retryable_error msg =
  let msg_lower = String.lowercase_ascii msg in
  List.exists (fun pattern ->
    let pattern_lower = String.lowercase_ascii pattern in
    Re.execp (Re.str pattern_lower |> Re.compile) msg_lower
  ) [ "timeout"; "timed out"; ...14 patterns... ]
```

14 DFA builds + 14 lowercase allocations per error classification. Patterns are static literals — hoisted to a module-level alternation regex wrapped in `no_case`:

```ocaml
let retryable_error_re =
  Re.(compile (no_case (alt (List.map str [
    "timeout"; "timed out"; ...
  ]))))

let is_retryable_error msg = Re.execp retryable_error_re msg
```

### `Auto_recall.content_matches_query`

```ocaml
(* before — per-hint compile inside List.exists *)
List.exists (fun hint ->
  String.length hint >= 3 &&
  Re.execp (Re.str (String.lowercase_ascii hint) |> Re.compile) content_lower
) hints
```

Used by `fetch_context_smart` per-item per-recall. Pure substring containment with no regex semantics required. Replaced with a byte-wise scan helper that takes an already-lowered haystack and lowers needle bytes inline (zero allocation in the loop).

Same anti-pattern series:
- #10250 / #10252: `Mention` per-call `Re.compile` (merged)
- #10260: `Coord_gc.mentions_open_task` M×N compile (merged)
- #10267: `Mcp_server_eio_call_tool.contains_casefold` byte scan (in-flight)
- #10286: dashboard helper hoist + byte scan (in-flight)
- This PR: `bounded` alternation + `auto_recall` byte scan

## Test plan
- [x] `dune build @check` clean
- Behavior preserved:
  - `is_retryable_error`: alternation matches iff any pattern matches; `no_case` is the canonical case-fold for `Re`.
  - `content_matches_query`: byte-wise compare with `Char.lowercase_ascii` is identical to `String.lowercase_ascii` on ASCII bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)