### PR TITLE
fix(telemetry): close runtime-contract and goal-event gaps

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2134,6 +2134,7 @@ export type TelemetrySource =
   | 'tool_usage'
   | 'oas_event'
   | 'execution_receipt'
+  | 'goal_event'
   | 'tool_metric'
 
 export type TelemetryEntry = Record<string, unknown> & {
@@ -2185,6 +2186,7 @@ function decodeTelemetrySource(value: unknown): TelemetrySource | null {
     case 'tool_usage':
     case 'oas_event':
     case 'execution_receipt':
+    case 'goal_event':
     case 'tool_metric':
       return value
     default:

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -296,6 +296,11 @@ function entryPreview(e: TelemetryEntry): string {
       const reason = normalizeText(e.terminal_reason_code)
       return reason ? `${keeper} receipt ${outcome} (${reason})` : `${keeper} receipt ${outcome}`
     }
+    case 'goal_event': {
+      const goal = normalizeText(e.goal_id) ?? 'unknown-goal'
+      const eventType = normalizeText(e.event_type) ?? 'goal_event'
+      return `${goal} ${eventType}`
+    }
     case 'tool_metric': {
       const tool = normalizeText(e.tool_name) ?? ''
       const dur = typeof e.duration_ms === 'number' ? e.duration_ms : null

--- a/dashboard/src/config/telemetry-sources.test.ts
+++ b/dashboard/src/config/telemetry-sources.test.ts
@@ -26,6 +26,10 @@ describe('telemetrySourceLabel', () => {
     expect(telemetrySourceLabel('oas_event')).toBe('OAS 이벤트')
   })
 
+  it('returns Korean label for goal_event', () => {
+    expect(telemetrySourceLabel('goal_event')).toBe('Goal FSM 이벤트')
+  })
+
   it('returns Korean label for tool_metric', () => {
     expect(telemetrySourceLabel('tool_metric')).toBe('Tool 성능')
   })

--- a/dashboard/src/config/telemetry-sources.ts
+++ b/dashboard/src/config/telemetry-sources.ts
@@ -10,6 +10,7 @@ type TelemetrySourceKey =
   | 'tool_usage'
   | 'oas_event'
   | 'execution_receipt'
+  | 'goal_event'
   | 'tool_metric'
 
 interface TelemetrySourceMeta {
@@ -27,6 +28,7 @@ export const TELEMETRY_SOURCE_META: Record<TelemetrySourceKey, TelemetrySourceMe
   tool_usage: { label: 'Keeper 내부 호출', sublabel: 'keeper_internal caller 기록', color: 'text-purple-400', icon: 'U' },
   oas_event: { label: 'OAS 이벤트', sublabel: 'native/custom event bus durable relay', color: 'text-rose-400', icon: 'O' },
   execution_receipt: { label: 'Execution Receipt', sublabel: 'keeper turn terminal receipts', color: 'text-orange-400', icon: 'E' },
+  goal_event: { label: 'Goal FSM 이벤트', sublabel: 'goal lifecycle and verification events', color: 'text-sky-400', icon: 'G' },
   tool_metric: { label: 'Tool 성능', sublabel: 'duration/success 측정', color: 'text-cyan-400', icon: 'M' },
 }
 

--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -497,23 +497,39 @@ let matches_keeper name (json : Yojson.Safe.t) : bool =
     || check_runtime_contract ()
   | _ -> false
 
-let matches_string_field field expected (json : Yojson.Safe.t) : bool =
-  match json with
-  | `Assoc fields -> (
-      match List.assoc_opt field fields with
-      | Some (`String value) -> String.equal value expected
-      | _ -> false)
+let matches_field fields field expected =
+  match List.assoc_opt field fields with
+  | Some (`String value) -> String.equal value expected
   | _ -> false
 
 let matches_scope ?session_id ?operation_id ?worker_run_id (json : Yojson.Safe.t) :
     bool =
-  let matches field = function
+  let matches ~top_fields ~runtime_contract_fields = function
     | None -> true
-    | Some expected -> matches_string_field field expected json
+    | Some expected -> (
+        match json with
+        | `Assoc fields ->
+          List.exists
+            (fun field -> matches_field fields field expected)
+            top_fields
+          ||
+          (match List.assoc_opt "runtime_contract" fields with
+           | Some (`Assoc runtime_fields) ->
+             List.exists
+               (fun field -> matches_field runtime_fields field expected)
+               runtime_contract_fields
+           | _ -> false)
+        | _ -> false)
   in
-  matches "session_id" session_id
-  && matches "operation_id" operation_id
-  && matches "worker_run_id" worker_run_id
+  matches ~top_fields:[ "session_id" ]
+    ~runtime_contract_fields:[ "session_id" ]
+    session_id
+  && matches ~top_fields:[ "operation_id" ]
+       ~runtime_contract_fields:[ "operation_id" ]
+       operation_id
+  && matches ~top_fields:[ "worker_run_id" ]
+       ~runtime_contract_fields:[ "worker_run_id"; "trace_id" ]
+       worker_run_id
 
 (* ── Read from a single fixed-path source ───────────── *)
 

--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -26,6 +26,7 @@ type source =
   | Tool_usage     (** System_internal surface tool invocations *)
   | Oas_event      (** Durable OAS native/custom event bus relays *)
   | Execution_receipt  (** Keeper execution receipt rows *)
+  | Goal_event     (** Goal FSM lifecycle and verification events *)
   | Tool_metric    (** Tool duration and success metrics *)
 
 let source_to_string = function
@@ -36,6 +37,7 @@ let source_to_string = function
   | Tool_usage -> "tool_usage"
   | Oas_event -> "oas_event"
   | Execution_receipt -> "execution_receipt"
+  | Goal_event -> "goal_event"
   | Tool_metric -> "tool_metric"
 
 let source_of_string = function
@@ -46,6 +48,7 @@ let source_of_string = function
   | "tool_usage" -> Some Tool_usage
   | "oas_event" -> Some Oas_event
   | "execution_receipt" -> Some Execution_receipt
+  | "goal_event" -> Some Goal_event
   | "tool_metric" -> Some Tool_metric
   | _ -> None
 
@@ -57,6 +60,7 @@ let all_sources =
   ; Tool_usage
   ; Oas_event
   ; Execution_receipt
+  ; Goal_event
   ; Tool_metric
   ]
 
@@ -79,7 +83,8 @@ let fixed_store_dir ~masc_root ~base_path = function
   | Tool_usage   -> Some (Filename.concat masc_root "tool_usage")
   | Oas_event    -> Some (Filename.concat masc_root "oas-events")
   | Tool_metric  -> Some (Filename.concat base_path "data/tool-metrics")
-  | Keeper_metric | Trajectory_tool_call | Execution_receipt -> None
+  | Keeper_metric | Trajectory_tool_call | Execution_receipt | Goal_event ->
+      None
     (* handled separately *)
 
 let source_freshness_slo_s = function
@@ -90,6 +95,7 @@ let source_freshness_slo_s = function
   | Oas_event -> 300.0
   | Agent_event -> 900.0
   | Tool_usage -> 900.0
+  | Goal_event -> 604800.0
   | Tool_metric -> 900.0
 
 let source_producer = function
@@ -100,6 +106,7 @@ let source_producer = function
   | Tool_usage -> "tool_usage_log"
   | Oas_event -> "oas_event_bus"
   | Execution_receipt -> "keeper_agent_run.execution_receipt"
+  | Goal_event -> "goal_fsm"
   | Tool_metric -> "tool_metrics_persist"
 
 let source_dashboard_surface = function
@@ -110,12 +117,14 @@ let source_dashboard_surface = function
   | Tool_usage -> "/api/v1/dashboard/tools"
   | Oas_event -> "/api/v1/dashboard/telemetry"
   | Execution_receipt -> "/api/v1/dashboard/execution-trust"
+  | Goal_event -> "/api/v1/dashboard/goals"
   | Tool_metric -> "/api/v1/tool-metrics"
 
 let source_durable_store ~masc_root ~base_path = function
   | Keeper_metric -> Filename.concat masc_root "keepers/*/metrics"
   | Trajectory_tool_call -> Filename.concat masc_root "trajectories/*/*.jsonl"
   | Execution_receipt -> Filename.concat masc_root "keepers/*/execution-receipts"
+  | Goal_event -> Filename.concat masc_root "goal_events.jsonl"
   | source -> (
       match fixed_store_dir ~masc_root ~base_path source with
       | Some dir -> dir
@@ -205,7 +214,8 @@ let extract_ts (json : Yojson.Safe.t) : float =
     (match first_some try_numeric_field [ "ts_unix"; "ts"; "timestamp" ] with
      | Some ts -> ts
      | None ->
-       first_some try_iso_field [ "ts_iso"; "recorded_at"; "ended_at"; "started_at" ]
+       first_some try_iso_field
+         [ "ts_iso"; "ts"; "recorded_at"; "ended_at"; "started_at" ]
        |> Option.value ~default:0.0)
   | _ -> 0.0
 
@@ -681,6 +691,22 @@ let read_trajectory_tool_calls ~masc_root ?keeper_name ?since_ts ?until_ts ~n ()
   let entries = if n <= 0 then entries else take_first n entries in
   List.map (tag_entry Trajectory_tool_call) entries
 
+let goal_events_path ~masc_root =
+  Filename.concat masc_root "goal_events.jsonl"
+
+let read_goal_events ~masc_root ?since_ts ?until_ts ~n () : Yojson.Safe.t list =
+  let path = goal_events_path ~masc_root in
+  if not (Sys.file_exists path) then []
+  else
+    let entries =
+      Safe_ops.protect ~default:[] (fun () ->
+        Fs_compat.load_jsonl path
+        |> List.filter (within_requested_window ?since_ts ?until_ts))
+    in
+    let entries = sort_newest_first entries in
+    let entries = if n <= 0 then entries else take_first n entries in
+    List.map (tag_entry Goal_event) entries
+
 (* ── Unified read ───────────────────────────────────── *)
 
 let read_unified_result ~base_path ~masc_root ?(sources = all_sources)
@@ -712,6 +738,8 @@ let read_unified_result ~base_path ~masc_root ?(sources = all_sources)
       | Execution_receipt ->
         read_execution_receipts ~masc_root ?keeper_name ?since_ts ?until_ts
           ~n:per_source ()
+      | Goal_event ->
+        read_goal_events ~masc_root ?since_ts ?until_ts ~n:per_source ()
       | _ ->
         match fixed_store_dir ~masc_root ~base_path source with
         | Some dir ->
@@ -810,6 +838,15 @@ let trajectory_tool_call_summary_stats ~masc_root =
            | Some ts -> max_ts_opt latest_acc ts
            | None -> latest_acc ))
        (0, None)
+
+let goal_event_summary_stats ~masc_root =
+  let path = goal_events_path ~masc_root in
+  if not (Sys.file_exists path) then (0, None)
+  else
+    let entries =
+      Safe_ops.protect ~default:[] (fun () -> Fs_compat.load_jsonl path)
+    in
+    (List.length entries, latest_ts_of_entries entries)
 
 let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
   let now = Unix.gettimeofday () in
@@ -915,6 +952,25 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
              ("entry_count", `Int count);
            ]
           @ keeper_dir_fields dirs
+          @ metadata_fields
+          @ freshness_fields ~now latest_ts
+          @ source_health_fields ~now ~exists ~entry_count:count ~latest_ts
+              ~freshness_slo_s ?coverage_gap ()),
+        count )
+    | Goal_event ->
+      let path = goal_events_path ~masc_root in
+      let exists = Sys.file_exists path in
+      let count, latest_ts =
+        if exists then goal_event_summary_stats ~masc_root
+        else (0, None)
+      in
+      ( `Assoc
+          ([
+             ("source", `String (source_to_string source));
+             ("path", `String path);
+             ("exists", `Bool exists);
+             ("entry_count", `Int count);
+           ]
           @ metadata_fields
           @ freshness_fields ~now latest_ts
           @ source_health_fields ~now ~exists ~entry_count:count ~latest_ts

--- a/lib/telemetry_unified.mli
+++ b/lib/telemetry_unified.mli
@@ -11,6 +11,7 @@
     - [<masc_root>/oas-events/]             — Durable OAS native/custom bus events
     - [<masc_root>/keepers/<name>/execution-receipts/]
                                               — Keeper execution receipts
+    - [<masc_root>/goal_events.jsonl]       — Goal FSM lifecycle events
     - [<base_path>/data/tool-metrics/]      — Tool duration/success metrics
 
     Each returned entry is tagged with a ["source"] field for discrimination.
@@ -27,6 +28,7 @@ type source =
   | Tool_usage     (** System_internal surface tool invocations *)
   | Oas_event      (** Durable OAS native/custom event bus relays *)
   | Execution_receipt  (** Keeper execution receipt rows *)
+  | Goal_event     (** Goal FSM lifecycle and verification events *)
   | Tool_metric    (** Tool duration and success metrics *)
 
 val source_to_string : source -> string

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -742,6 +742,62 @@ let test_read_unified_reads_trajectory_and_execution_receipts () =
   Alcotest.(check string) "oldest source" "execution_receipt"
     (List.nth entries 1 |> json_string_field "source")
 
+let test_scope_filter_matches_runtime_contract_fields () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_runtime_contract_scope" in
+  let root = masc_root dir in
+  let trajectory_dir = Filename.concat root "trajectories/alice" in
+  Fs_compat.mkdir_p trajectory_dir;
+  Fs_compat.append_file
+    (Filename.concat trajectory_dir "trace-1.jsonl")
+    (Yojson.Safe.to_string
+       (`Assoc
+          [
+            ("ts", `Float 3000.0);
+            ("ts_iso", `String "1970-01-01T00:50:00Z");
+            ("turn", `Int 1);
+            ("round", `Int 1);
+            ("tool_name", `String "keeper_bash");
+            ("args", `Assoc []);
+            ("gate", `Assoc [ ("status", `String "pass") ]);
+            ("result", `String "ok");
+            ("duration_ms", `Int 7);
+            ("error", `Null);
+            ("cost_usd", `Float 0.0);
+            ( "runtime_contract",
+              `Assoc
+                [
+                  ("keeper_name", `String "alice");
+                  ("session_id", `String "sess-nested");
+                  ("operation_id", `String "op-nested");
+                  ("trace_id", `String "run-nested");
+                ] );
+            ( "action_radius",
+              `Assoc [ ("tool_name", `String "keeper_bash") ] );
+          ])
+     ^ "\n");
+  let result =
+    Telemetry_unified.read_unified_result
+      ~base_path:dir
+      ~masc_root:root
+      ~sources:[ Telemetry_unified.Trajectory_tool_call ]
+      ~session_id:"sess-nested"
+      ~operation_id:"op-nested"
+      ~worker_run_id:"run-nested"
+      ~n:10
+      ()
+  in
+  Alcotest.(check int) "runtime contract scoped row visible" 1
+    result.total_matching_entries;
+  match result.entries with
+  | [ entry ] ->
+    Alcotest.(check string) "source" "trajectory_tool_call"
+      (json_string_field "source" entry);
+    Alcotest.(check string) "tool" "keeper_bash"
+      (json_string_field "tool_name" entry)
+  | _ -> Alcotest.fail "expected one scoped trajectory row"
+
 let test_summary_surfaces_coverage_gaps () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -890,6 +946,8 @@ let () =
             test_time_window_n_zero_disables_truncation;
           Alcotest.test_case "trajectory and receipts" `Quick
             test_read_unified_reads_trajectory_and_execution_receipts;
+          Alcotest.test_case "runtime contract scope filter" `Quick
+            test_scope_filter_matches_runtime_contract_fields;
         ] );
       ( "summary",
         [

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -798,6 +798,58 @@ let test_scope_filter_matches_runtime_contract_fields () =
       (json_string_field "tool_name" entry)
   | _ -> Alcotest.fail "expected one scoped trajectory row"
 
+let test_goal_event_source_and_summary () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_goal_event" in
+  let root = masc_root dir in
+  Fs_compat.mkdir_p root;
+  let newer_ts = Unix.gettimeofday () in
+  let older_ts = newer_ts -. 1.0 in
+  let path = Filename.concat root "goal_events.jsonl" in
+  Fs_compat.append_file path
+    (Yojson.Safe.to_string
+       (`Assoc
+          [
+            ("ts", `String (Types.iso8601_of_unix_seconds older_ts));
+            ("goal_id", `String "goal-1");
+            ("event_type", `String "transition_requested");
+            ("payload", `Assoc [ ("phase", `String "active") ]);
+          ])
+     ^ "\n");
+  Fs_compat.append_file path
+    (Yojson.Safe.to_string
+       (`Assoc
+          [
+            ("ts", `String (Types.iso8601_of_unix_seconds newer_ts));
+            ("goal_id", `String "goal-1");
+            ("event_type", `String "transition_completed");
+            ("payload", `Assoc [ ("phase", `String "done") ]);
+          ])
+     ^ "\n");
+  let entries =
+    Telemetry_unified.read_unified
+      ~base_path:dir
+      ~masc_root:root
+      ~sources:[ Telemetry_unified.Goal_event ]
+      ~n:10
+      ()
+  in
+  Alcotest.(check int) "two goal events" 2 (List.length entries);
+  Alcotest.(check string) "newest source" "goal_event"
+    (List.hd entries |> json_string_field "source");
+  Alcotest.(check string) "newest event" "transition_completed"
+    (List.hd entries |> json_string_field "event_type");
+  let summary = Telemetry_unified.summary_json ~base_path:dir ~masc_root:root () in
+  let goal_summary = source_summary "goal_event" summary in
+  Alcotest.(check int) "goal event count" 2
+    (json_int_field "entry_count" goal_summary);
+  Alcotest.(check string) "goal event health" "ok"
+    (json_string_field "health" goal_summary);
+  Alcotest.(check string) "goal dashboard surface"
+    "/api/v1/dashboard/goals"
+    (json_string_field "dashboard_surface" goal_summary)
+
 let test_summary_surfaces_coverage_gaps () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -948,6 +1000,8 @@ let () =
             test_read_unified_reads_trajectory_and_execution_receipts;
           Alcotest.test_case "runtime contract scope filter" `Quick
             test_scope_filter_matches_runtime_contract_fields;
+          Alcotest.test_case "goal events" `Quick
+            test_goal_event_source_and_summary;
         ] );
       ( "summary",
         [


### PR DESCRIPTION
## What changed

- Make unified telemetry scope filtering inspect both top-level scope fields and nested `runtime_contract` fields.
- Preserve compatibility with existing top-level `session_id`, `operation_id`, and `worker_run_id` rows.
- Treat `runtime_contract.trace_id` as the trajectory-backed run identifier for `worker_run_id` filters.
- Add `goal_event` as a unified telemetry source backed by `.masc/goal_events.jsonl`.
- Teach the dashboard API decoder, source metadata, and telemetry preview renderer about `goal_event`.

## Why

The telemetry write path now records keeper/OAS tool-call truth in runtime contracts, but the unified telemetry query path only checked top-level scope fields. That meant a row could be durable and visible in source freshness while returning zero entries when the dashboard filtered by its session/run scope.

Goal FSM transitions were also durable in `goal_events.jsonl` and visible on goal detail pages, but they were absent from the unified telemetry surface. That left a blind spot when tracing FSM behavior alongside tool calls, receipts, and OAS events.

This keeps existing store shapes stable and fixes the read-side fan-in that was leaking truth from the operator view.

## Validation

- env MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=2 DUNE_CACHE=disabled DUNE_BUILD_DIR=/tmp/masc-telemetry-scope-build scripts/dune-local.sh build --cache=disabled test/test_telemetry_unified.exe
- /tmp/masc-telemetry-scope-build/default/test/test_telemetry_unified.exe
- pnpm --dir dashboard exec vitest run --no-file-parallelism --maxWorkers=1 src/components/telemetry-unified.test.ts src/config/telemetry-sources.test.ts
- pnpm --dir dashboard typecheck
- git diff --check HEAD~2..HEAD

Note: `pnpm --dir dashboard install --frozen-lockfile --offline` was used in this worktree because `dashboard/node_modules` was absent; it reused the local pnpm store and downloaded nothing.
