### PR TITLE
perf(error-recovery,coord-git): drop per-call Re.compile for substring lookups

### DIFF
--- a/lib/coord/coord_git.ml
+++ b/lib/coord/coord_git.ml
@@ -9,6 +9,28 @@ open Types
 let exec_gate_raw_source argv =
   String.concat " " (List.map Filename.quote argv)
 
+(* Substring check for the [.worktrees] sentinel without paying a
+   per-call [Re.compile] inside the JSON-shaping path. *)
+let path_is_masc_worktree path =
+  let needle = ".worktrees" in
+  let nlen = String.length needle in
+  let hlen = String.length path in
+  if nlen > hlen then false
+  else
+    let rec match_at i j =
+      if j = nlen then true
+      else if String.unsafe_get path (i + j) <> String.unsafe_get needle j
+      then false
+      else match_at i (j + 1)
+    in
+    let last = hlen - nlen in
+    let rec loop i =
+      if i > last then false
+      else if match_at i 0 then true
+      else loop (i + 1)
+    in
+    loop 0
+
 (* ============================================ *)
 (* argv-based process helpers                   *)
 (* ============================================ *)
@@ -291,8 +313,7 @@ let list ~base_path =
               [
                 ("path", `String !path);
                 ("branch", `String !branch);
-                (* Check if path contains .worktrees - stdlib compatible *)
-                ("is_masc", `Bool (Re.execp (Re.compile (Re.str ".worktrees")) !path));
+                ("is_masc", `Bool (path_is_masc_worktree !path));
               ])
         else None
       in

--- a/lib/masc_error_recovery.ml
+++ b/lib/masc_error_recovery.ml
@@ -4,8 +4,31 @@
     self-recover without human intervention.
     self-correct without human intervention. *)
 
+(* Byte-wise substring containment.
+
+   [recovery_hint] chains ~15 [contains] calls per error message; the
+   old form built a fresh [Re.t] per call (10-30 [Re.compile] per
+   tool failure once short-circuiting is accounted for).  The needles
+   are short literals and [s] is already lowercased by the caller, so
+   a naive byte scan is strictly cheaper than DFA construction. *)
 let contains s sub =
-  Re.execp (Re.str sub |> Re.compile) s
+  let nlen = String.length sub in
+  let hlen = String.length s in
+  if nlen = 0 then true
+  else if nlen > hlen then false
+  else
+    let rec match_at i j =
+      if j = nlen then true
+      else if String.unsafe_get s (i + j) <> String.unsafe_get sub j then false
+      else match_at i (j + 1)
+    in
+    let last = hlen - nlen in
+    let rec loop i =
+      if i > last then false
+      else if match_at i 0 then true
+      else loop (i + 1)
+    in
+    loop 0
 
 (** Given an error message, return a suggested recovery action or None. *)
 let recovery_hint (message : string) : string option =


### PR DESCRIPTION
## Summary

Two more substring-only paths paid `Re.compile` per invocation.

### `Masc_error_recovery.contains`

```ocaml
(* before *)
let contains s sub =
  Re.execp (Re.str sub |> Re.compile) s
```

`recovery_hint` chains ~15 `contains` calls per error message, so every tool failure paid 10-30 `Re.compile` calls (depending on how early the `&&`/`||` chain matched). Replaced with a byte-wise scan; the caller already lowercases the haystack, so no normalization changes are needed.

### `Coord_git` worktree JSON shaping

```ocaml
(* before — inline DFA construction inside the JSON-shaping block *)
("is_masc", `Bool (Re.execp (Re.compile (Re.str ".worktrees")) !path));
```

The `.worktrees` sentinel was rebuilt as a `Re.t` for every entry in the worktree list output. Replaced with a module-level `path_is_masc_worktree` helper using the same byte-wise pattern.

Same anti-pattern series:
- #10250 / #10252: `Mention` per-call `Re.compile` (merged)
- #10260: `Coord_gc.mentions_open_task` M×N compile (merged)
- #10267: `Mcp_server_eio_call_tool.contains_casefold` byte scan (merged)
- #10286: dashboard helper hoist + byte scan (merged)
- #10301: `Bounded` alternation + `Auto_recall` byte scan (in-flight)
- This PR: `Masc_error_recovery` + `Coord_git` byte scan

## Test plan
- [x] `dune build @check` clean
- Behavior preserved: byte-wise compare with `String.unsafe_get` is identical to `Re.execp (Re.str needle)` for literal substring containment. Empty needle keeps the `true` short-circuit (matches old `Re.str ""` behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)