### PR TITLE
fix(dashboard): key fleet rows by keeper identity

### DIFF
--- a/dashboard/src/api/schemas/keeper-composite.test.ts
+++ b/dashboard/src/api/schemas/keeper-composite.test.ts
@@ -34,6 +34,14 @@ describe('parseKeeperCompositeSnapshot', () => {
     expect(result.last_outcome).toBeNull()
   })
 
+  it('parses explicit keeper identity when emitted by the backend', () => {
+    const result = parseKeeperCompositeSnapshot({
+      ...VALID_SNAPSHOT,
+      keeper: 'analyst',
+    })
+    expect(result.keeper).toBe('analyst')
+  })
+
   it('parses all valid phase values', () => {
     for (const phase of ['Running', 'Failing', 'Overflowed', 'Compacting', 'HandingOff', 'Draining', 'Stable']) {
       const result = parseKeeperCompositeSnapshot({ ...VALID_SNAPSHOT, phase })

--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -125,6 +125,9 @@ const KeeperCompositeExecutionSchema = object({
 })
 
 export const KeeperCompositeSnapshotSchema = object({
+  // Explicit registry identity from new backends. Optional so pinned older
+  // backends keep rendering; UI falls back to canonical correlation_id parsing.
+  keeper: optional(string()),
   correlation_id: string(),
   run_id: string(),
   ts: number(),

--- a/dashboard/src/components/fleet-fsm-matrix.test.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.test.ts
@@ -41,6 +41,7 @@ function snapshot(
   const name = overrides.name ?? 'alpha'
   const allHold = overrides.allHold ?? true
   const base: KeeperCompositeSnapshot = {
+    keeper: name,
     correlation_id: `keeper:${name}:42`,
     run_id: `r-0-${name}`,
     ts: 1_713_000_000,
@@ -122,13 +123,23 @@ describe('chipClassFor', () => {
 })
 
 describe('inferKeeperNameFrom', () => {
-  it('extracts the keeper name from a canonical correlation_id', () => {
+  it('uses the explicit keeper identity when present', () => {
+    const snap = snapshot({
+      keeper: 'analyst',
+      correlation_id: 'agent:analyst-session:42',
+    })
+    expect(inferKeeperNameFrom(snap)).toBe('analyst')
+  })
+
+  it('extracts the keeper name from a canonical correlation_id for old payloads', () => {
     const snap = snapshot({ name: 'gen12-payroll' })
+    delete snap.keeper
     expect(inferKeeperNameFrom(snap)).toBe('gen12-payroll')
   })
 
   it('falls back to the correlation_id verbatim on non-canonical ids', () => {
     const snap = snapshot({ correlation_id: 'not-a-keeper-id' })
+    delete snap.keeper
     expect(inferKeeperNameFrom(snap)).toBe('not-a-keeper-id')
   })
 })

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -343,8 +343,9 @@ export function pushObservation(
 /**
  * Pure filter for fleet keeper snapshots.
  *
- * Case-insensitive substring match on the keeper name (as derived
- * from the canonical correlation_id) and on the current value of
+ * Case-insensitive substring match on the keeper name (prefer the
+ * explicit backend identity, falling back to canonical correlation_id)
+ * and on the current value of
  * each of the six FSM axes so an operator can isolate a single
  * keeper by name, or every keeper currently in a specific state
  * (e.g. `trying`, `Overflowed`, `warning`).
@@ -701,12 +702,15 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
 }
 
 /**
- * Best-effort keeper name extraction from the snapshot correlation id.
- * Format: `keeper:<name>:<transition_seq>` (see keeper_composite_observer
- * .ml:stable_correlation_id). Falls back to correlation_id verbatim so
- * the UI never renders an empty cell.
+ * Keeper row identity for fleet views. New backends emit the registry
+ * keeper name explicitly as `keeper`; older payloads fall back to the
+ * canonical correlation_id format `keeper:<name>:<transition_seq>`.
+ * Non-canonical ids still render verbatim rather than collapsing to an
+ * empty row key.
  */
 export function inferKeeperNameFrom(snap: KeeperCompositeSnapshot): string {
+  const explicit = snap.keeper?.trim()
+  if (explicit) return explicit
   const m = /^keeper:([^:]+):/.exec(snap.correlation_id)
   return m?.[1] ?? snap.correlation_id
 }

--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -103,6 +103,7 @@ type last_outcome = {
 }
 
 type snapshot = {
+  keeper_name : string;
   correlation_id : string;
   run_id : string;
   ts : float;
@@ -432,6 +433,7 @@ let observe
       ~keeper_name:entry.name
   in
   {
+    keeper_name = entry.name;
     correlation_id;
     run_id;
     ts;
@@ -491,6 +493,7 @@ let measurement_to_json (m : Keeper_state_machine.auto_rule_summary) : Yojson.Sa
 
 let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
   `Assoc [
+    "keeper", `String s.keeper_name;
     "correlation_id", `String s.correlation_id;
     "run_id", `String s.run_id;
     "ts", `Float s.ts;

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -131,6 +131,10 @@ type last_outcome = {
 }
 
 type snapshot = {
+  keeper_name : string;
+      (** Canonical keeper identity from the registry entry. This is separate
+          from [correlation_id], which may come from an external event envelope
+          and is not a stable row key for fleet dashboards. *)
   correlation_id : string;
   run_id : string;
   ts : float;

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -556,11 +556,15 @@ let enrich_composite_snapshot_json ~(config : Coord.config) ~keeper_name json =
   match json with
   | `Assoc fields ->
       let fields =
-        List.filter (fun (name, _) -> not (String.equal name "execution")) fields
+        List.filter
+          (fun (name, _) ->
+            not (String.equal name "keeper" || String.equal name "execution"))
+          fields
       in
       `Assoc
         (fields
          @ [
+             ("keeper", `String keeper_name);
              ( "execution",
                composite_execution_receipt_json ~config ~keeper_name );
            ])

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -1231,6 +1231,8 @@ let test_composite_routes_surface_latest_execution_receipt () =
   require_status "per-keeper composite GET returns 200" 200 per_keeper;
   let open Yojson.Safe.Util in
   let per_keeper_json = Yojson.Safe.from_string per_keeper.body in
+  check string "per-keeper composite exposes keeper identity" keeper_name
+    (per_keeper_json |> member "keeper" |> to_string);
   let execution = per_keeper_json |> member "execution" in
   check bool "composite exposes latest receipt presence" true
     (execution |> member "latest_receipt_present" |> to_bool);
@@ -1252,6 +1254,8 @@ let test_composite_routes_surface_latest_execution_receipt () =
     | snapshot :: _ -> snapshot
     | [] -> fail "expected at least one fleet composite snapshot"
   in
+  check string "fleet composite exposes keeper identity" keeper_name
+    (fleet_snapshot |> member "keeper" |> to_string);
   let fleet_execution = fleet_snapshot |> member "execution" in
   check bool "fleet composite exposes latest receipt presence" true
     (fleet_execution |> member "latest_receipt_present" |> to_bool);

--- a/test/test_keeper_composite_observer.ml
+++ b/test/test_keeper_composite_observer.ml
@@ -177,6 +177,16 @@ let test_snapshot_omits_collapsed_from_for_active_phase () =
       (Some "Running")
       (Json.member "phase" snapshot |> Json.to_string_option))
 
+let test_snapshot_reports_keeper_identity () =
+  with_registry (fun () ->
+    let base_path = "/tmp/keeper-composite-identity" in
+    let keeper_name = "analyst" in
+    let entry = Reg.register ~base_path keeper_name (make_meta keeper_name) in
+    let snapshot = Obs.observe entry |> Obs.snapshot_to_json in
+    check (option string) "snapshot exposes registry keeper identity"
+      (Some keeper_name)
+      (Json.member "keeper" snapshot |> Json.to_string_option))
+
 let test_direct_turn_mutations_emit_composite_changed () =
   with_registry (fun () ->
     let base_path = "/tmp/keeper-composite-turn-ticks" in
@@ -210,6 +220,7 @@ let () =
     "snapshot projection",
     [ test_case "stable phase exposes collapsed_from" `Quick test_snapshot_reports_collapsed_from_for_stable_phase
     ; test_case "active phase leaves collapsed_from null" `Quick test_snapshot_omits_collapsed_from_for_active_phase
+    ; test_case "snapshot exposes keeper identity" `Quick test_snapshot_reports_keeper_identity
     ];
     "composite change signals",
     [ test_case "direct turn mutations emit composite tick" `Quick test_direct_turn_mutations_emit_composite_changed ];


### PR DESCRIPTION
## Summary
- emit explicit registry keeper identity in composite snapshots as `keeper`
- make fleet dashboard row naming prefer the typed `keeper` field before falling back to canonical correlation_id parsing
- cover backend observer JSON, composite route payloads, schema parsing, and fleet row inference

## Why
The fleet matrix was deriving keeper rows from `correlation_id` string shape. When a snapshot used an external event/run correlation id, the same keeper could appear under an agent/session-like row instead of the canonical keeper row.

## Verification
- `pnpm exec vitest run src/api/schemas/keeper-composite.test.ts src/components/fleet-fsm-matrix.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc --noEmit --pretty false`
- `scripts/dune-local.sh build bin/main_eio.exe test/test_dashboard_keeper_routes.exe test/test_keeper_composite_observer.exe`
- `_build/default/test/test_keeper_composite_observer.exe test`
- `ALCOTEST_QUICK_TESTS=false _build/default/test/test_dashboard_keeper_routes.exe test dashboard_keeper_routes 9 --show-errors`
