### PR TITLE
fix(board): bind post author to runtime agent (#10297)

### DIFF
--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -70,12 +70,19 @@ let canonicalize_board_actor_field field arguments =
       | _ -> arguments)
   | _ -> arguments
 
+let canonical_board_author raw =
+  Server_utils.board_actor_author_for_write (String.trim raw)
+
 (** Fill [author] from the caller's agent identity when the arg is absent or
     blank. Keepers, the HTTP surface, and autonomous callers routinely omit
     [author] — we used to reject those calls at pre-hook validation, which
     forced every caller to know about the legacy schema field. The board store
     keeps canonical keeper names as principals while preserving raw runtime
-    agent names in metadata. *)
+    agent names in metadata.
+
+    If a caller supplies a different [author], the trusted runtime
+    [agent_name] wins. The caller's claim is retained in [meta] for forensics,
+    but the stored principal must match the dispatch context. *)
 let ensure_board_post_author ~agent_name arguments =
   match arguments with
   | `Assoc fields -> (
@@ -84,14 +91,38 @@ let ensure_board_post_author ~agent_name arguments =
         | Some (`String s) -> String.trim s
         | _ -> ""
       in
+      let trusted_raw = String.trim agent_name in
+      let trusted_author =
+        if trusted_raw = "" then "" else canonical_board_author trusted_raw
+      in
       let raw_author =
-        if existing <> "" && existing <> "anonymous" then existing
-        else String.trim agent_name
+        if existing = "" || existing = "anonymous" then trusted_raw
+        else if
+          trusted_author <> ""
+          && not
+               (String.equal (canonical_board_author existing) trusted_author)
+        then trusted_raw
+        else existing
       in
       if raw_author = "" then arguments
       else
         let canonical = Server_utils.board_actor_author_for_write raw_author in
         let fields = json_upsert_assoc_field "author" (`String canonical) fields in
+        let fields =
+          if
+            existing <> "" && existing <> "anonymous" && trusted_author <> ""
+            && not
+                 (String.equal
+                    (canonical_board_author existing)
+                    trusted_author)
+          then
+            fields
+            |> json_upsert_meta_string_field
+                 "caller_supplied_author" existing
+            |> json_upsert_meta_string_field
+                 "author_rewrite_reason" "caller_author_mismatch"
+          else fields
+        in
         let fields =
           if String.equal canonical raw_author then fields
           else json_upsert_meta_string_field "author_raw_agent_name" raw_author fields

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -179,6 +179,51 @@ let test_board_actor_identity_keeps_non_keeper_agent () =
   Alcotest.(check string) "source" "raw_agent"
     (json_member_string json "source")
 
+let test_inline_board_post_author_rewrites_caller_claim () =
+  let args =
+    make_args
+      [
+        ("content", `String "ctx-owned post");
+        ("author", `String "analyst");
+        ("meta", `Assoc [ ("trace", `String "probe-10297") ]);
+      ]
+  in
+  let normalized =
+    Tool_inline_dispatch_extra.ensure_board_post_author
+      ~agent_name:"keeper-velvet-hammer-agent" args
+  in
+  Alcotest.(check string) "author from ctx" "velvet-hammer"
+    Yojson.Safe.Util.(normalized |> member "author" |> to_string);
+  Alcotest.(check string) "caller claim preserved" "analyst"
+    Yojson.Safe.Util.(
+      normalized |> member "meta" |> member "caller_supplied_author" |> to_string);
+  Alcotest.(check string) "rewrite reason preserved" "caller_author_mismatch"
+    Yojson.Safe.Util.(
+      normalized |> member "meta" |> member "author_rewrite_reason" |> to_string);
+  Alcotest.(check string) "raw ctx agent preserved" "keeper-velvet-hammer-agent"
+    Yojson.Safe.Util.(
+      normalized |> member "meta" |> member "author_raw_agent_name" |> to_string);
+  Alcotest.(check string) "existing meta preserved" "probe-10297"
+    Yojson.Safe.Util.(normalized |> member "meta" |> member "trace" |> to_string)
+
+let test_inline_board_post_author_accepts_matching_alias () =
+  let args =
+    make_args
+      [
+        ("content", `String "ctx-owned post");
+        ("author", `String "keeper-analyst-agent");
+      ]
+  in
+  let normalized =
+    Tool_inline_dispatch_extra.ensure_board_post_author
+      ~agent_name:"keeper-analyst-agent" args
+  in
+  Alcotest.(check string) "author canonical" "analyst"
+    Yojson.Safe.Util.(normalized |> member "author" |> to_string);
+  Alcotest.(check bool) "no mismatch claim" true
+    Yojson.Safe.Util.(
+      normalized |> member "meta" |> member "caller_supplied_author" = `Null)
+
 (** {2 Group 2: JSON helper functions} *)
 
 let test_get_string () =
@@ -783,6 +828,10 @@ let () =
             `Quick test_board_actor_identity_canonicalizes_keeper_alias;
           Alcotest.test_case "board actor identity keeps non-keeper agent"
             `Quick test_board_actor_identity_keeps_non_keeper_agent;
+          Alcotest.test_case "inline board post author rewrites caller claim"
+            `Quick test_inline_board_post_author_rewrites_caller_claim;
+          Alcotest.test_case "inline board post author accepts matching alias"
+            `Quick test_inline_board_post_author_accepts_matching_alias;
         ] );
       ( "json_helpers",
         [


### PR DESCRIPTION
## Summary

Fixes #10297.

`masc_board_post` inline dispatch now treats the runtime `agent_name` as the trusted identity source. If tool args include a non-empty `author` that canonicalizes to a different principal than the dispatch context, MASC rewrites `author` to the context principal and preserves the caller claim in `meta.caller_supplied_author` with `meta.author_rewrite_reason = "caller_author_mismatch"`.

## Why

The previous path only used `agent_name` when `author` was blank. A keeper could pass `author = "analyst"` and create a board post under that principal even while the runtime contract identified a different keeper. That broke audit attribution and made board-derived diagnostics trust caller-supplied identity.

The new behavior keeps successful autonomous posting, but makes the stored author match the authenticated runtime context. Matching aliases such as `keeper-analyst-agent` still canonicalize normally.

## Validation

- `env DUNE_BUILD_DIR=_build_10297_board_author_ctx DUNE_JOBS=2 DUNE_CACHE=disabled MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_tool_board_coverage.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-10297-board-author-final _build_10297_board_author_ctx/default/test/test_tool_board_coverage.exe`
- `git diff --check origin/main..HEAD`
- `bash scripts/ml_line_cap_audit.sh --baseline-ref origin/main --fail-on-regression`
- `bash scripts/ci/check-telemetry-coverage.sh`
