### PR TITLE
fix(task): make verification verdict persistence atomic

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -1035,6 +1035,7 @@ let transition_task_r
       ~action
       ?agent_tool_names
       ?prepare_verification_request
+      ?prepare_verification_verdict
       ?expected_version
       ?(notes = "")
       ?(reason = "")
@@ -1205,8 +1206,9 @@ let transition_task_r
         let new_status = decision.Coord_task_lifecycle.new_status in
         let set_current = decision.set_current in
         let* () =
-          match action, new_status, prepare_verification_request with
+          match action, task.task_status, new_status, prepare_verification_request with
           | ( Types.Submit_for_verification,
+              _,
               Types.AwaitingVerification { assignee; verification_id; _ },
               Some prepare ) ->
             let evidence_refs =
@@ -1225,7 +1227,7 @@ let transition_task_r
                        task_id
                        verification_id
                        e)))
-          | Types.Submit_for_verification, _, Some _ ->
+          | Types.Submit_for_verification, _, _, Some _ ->
             Error
               (Types.TaskInvalidState
                  (Printf.sprintf
@@ -1240,6 +1242,7 @@ let transition_task_r
             | Types.Approve_verification
             | Types.Reject_verification ),
             _,
+            _,
             Some _ ->
             Ok ()
           | ( Types.Claim
@@ -1250,6 +1253,78 @@ let transition_task_r
             | Types.Approve_verification
             | Types.Reject_verification
             | Types.Submit_for_verification ),
+            _,
+            _,
+            None ->
+            Ok ()
+        in
+        let* () =
+          match action, task.task_status, prepare_verification_verdict with
+          | ( Types.Approve_verification,
+              Types.AwaitingVerification { verification_id; _ },
+              Some prepare ) ->
+            (match
+               prepare
+                 ~task
+                 ~verifier:agent_name
+                 ~verification_id
+                 ~decision:(`Approve notes)
+             with
+             | Ok () -> Ok ()
+             | Error e ->
+               Error
+                 (Types.IoError
+                    (Printf.sprintf
+                       "verification verdict persistence failed before status transition \
+                        (task=%s vrf=%s): %s"
+                       task_id
+                       verification_id
+                       e)))
+          | ( Types.Reject_verification,
+              Types.AwaitingVerification { verification_id; _ },
+              Some prepare ) ->
+            let reject_reason = if notes <> "" then notes else reason in
+            (match
+               prepare
+                 ~task
+                 ~verifier:agent_name
+                 ~verification_id
+                 ~decision:(`Reject reject_reason)
+             with
+             | Ok () -> Ok ()
+             | Error e ->
+               Error
+                 (Types.IoError
+                    (Printf.sprintf
+                       "verification verdict persistence failed before status transition \
+                        (task=%s vrf=%s): %s"
+                       task_id
+                       verification_id
+                       e)))
+          | (Types.Approve_verification | Types.Reject_verification), _, Some _ ->
+            Error
+              (Types.TaskInvalidState
+                 (Printf.sprintf
+                    "verification verdict action did not start from AwaitingVerification \
+                     for task %s"
+                    task_id))
+          | ( Types.Claim
+            | Types.Start
+            | Types.Done_action
+            | Types.Cancel
+            | Types.Release
+            | Types.Submit_for_verification ),
+            _,
+            Some _ ->
+            Ok ()
+          | ( Types.Claim
+            | Types.Start
+            | Types.Done_action
+            | Types.Cancel
+            | Types.Release
+            | Types.Submit_for_verification
+            | Types.Approve_verification
+            | Types.Reject_verification ),
             _,
             None ->
             Ok ()

--- a/lib/coord/coord_task.mli
+++ b/lib/coord/coord_task.mli
@@ -122,6 +122,12 @@ val transition_task_r :
      verification_id:string ->
      evidence_refs:string list ->
      (unit, string) result) ->
+  ?prepare_verification_verdict:
+    (task:Types.task ->
+     verifier:string ->
+     verification_id:string ->
+     decision:[ `Approve of string | `Reject of string ] ->
+     (unit, string) result) ->
   ?expected_version:int -> ?notes:string -> ?reason:string ->
   ?handoff_context:Types.task_handoff_context ->
   ?force:bool -> unit -> string Types.masc_result

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -311,10 +311,10 @@ let dashboard_governance_approval_rule_delete_http_json ~base_path
               ])
       | Error message -> Error message)
 
-(* Dashboard-initiated verification verdict. Mirrors the 2-step path that
-   tool_task uses for Approve_verification / Reject_verification: first
-   transition the task FSM (AwaitingVerification -> Done or InProgress),
-   then wire the protocol side effects (Verification store + Board + SSE).
+(* Dashboard-initiated verification verdict. Mirrors the tool_task path for
+   Approve_verification / Reject_verification: persist the Verification store
+   verdict before the task FSM transition, then publish Board + SSE
+   notifications only after the transition succeeds.
 
    [verifier] is a namespaced agent_id of the form "operator:<actor>".
    The colon form is permitted by Validation.Agent_id and keeps operator
@@ -355,9 +355,26 @@ let dashboard_verification_resolve_http_json
         Error (Printf.sprintf
           "decision must be 'approve' or 'reject' (got %s)" other)
   in
+  let prepare_verification_verdict ~task:_ ~verifier ~verification_id:state_vid
+      ~decision =
+    if state_vid <> verification_id then
+      Error
+        (Printf.sprintf
+           "verification_id mismatch for task %s: request=%s state=%s"
+           task_id verification_id state_vid)
+    else
+      match decision with
+      | `Approve notes ->
+          Verification_protocol.record_approve_verification
+            ~config ~task_id ~verifier ~verification_id:state_vid ~notes
+      | `Reject reason ->
+          Verification_protocol.record_reject_verification
+            ~config ~task_id ~verifier ~verification_id:state_vid ~reason
+  in
   let fsm_result =
     Coord.transition_task_r config
       ~agent_name:verifier ~task_id ~action
+      ~prepare_verification_verdict
       ~notes:reason ~reason ()
   in
   match fsm_result with
@@ -365,11 +382,11 @@ let dashboard_verification_resolve_http_json
   | Ok _ ->
       (match action with
        | Types.Approve_verification ->
-           Verification_protocol.on_approve_verification
-             ~config ~task_id ~verifier ~verification_id ~notes:reason
+           Verification_protocol.notify_approve_verification
+             ~task_id ~verifier ~verification_id ~notes:reason
        | Types.Reject_verification ->
-           Verification_protocol.on_reject_verification
-             ~config ~task_id ~verifier ~verification_id ~reason
+           Verification_protocol.notify_reject_verification
+             ~task_id ~verifier ~verification_id ~reason
        | Types.Claim | Types.Start | Types.Done_action | Types.Cancel
        | Types.Release | Types.Submit_for_verification -> ());
       Ok (`Assoc [

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -857,6 +857,35 @@ and handle_transition ?agent_tool_names ctx args =
     | Types.Reject_verification ->
       None
   in
+  let prepare_verification_verdict =
+    match action with
+    | Types.Approve_verification
+    | Types.Reject_verification ->
+      Some
+        (fun ~(task : Types.task) ~verifier ~verification_id ~decision ->
+           match decision with
+           | `Approve notes ->
+             Verification_protocol.record_approve_verification
+               ~config:ctx.config
+               ~task_id:task.id
+               ~verifier
+               ~verification_id
+               ~notes
+           | `Reject reason ->
+             Verification_protocol.record_reject_verification
+               ~config:ctx.config
+               ~task_id:task.id
+               ~verifier
+               ~verification_id
+               ~reason)
+    | Types.Claim
+    | Types.Start
+    | Types.Done_action
+    | Types.Cancel
+    | Types.Release
+    | Types.Submit_for_verification ->
+      None
+  in
   let rec try_transition attempt =
     let ev = if attempt = 0 then expected_version else None in
     let agent_tool_names =
@@ -866,7 +895,8 @@ and handle_transition ?agent_tool_names ctx args =
     in
     let r = Coord.transition_task_r ctx.config ~agent_name:ctx.agent_name
               ~task_id ~action ?expected_version:ev ~notes ~reason
-              ?handoff_context ?agent_tool_names ?prepare_verification_request () in
+              ?handoff_context ?agent_tool_names ?prepare_verification_request
+              ?prepare_verification_verdict () in
     if is_version_mismatch r && attempt < max_cas_retries then begin
       Log.Task.info "CAS version mismatch on %s (attempt %d/%d), retrying in %.0fms"
         task_id (attempt + 1) max_cas_retries (cas_retry_delay_s *. 1000.0);
@@ -925,9 +955,8 @@ and handle_transition ?agent_tool_names ctx args =
            | None -> ())
         | Types.Approve_verification ->
           let verification_id = Option.value ~default:"" verification_id_before in
-          Verification_protocol.on_approve_verification
-            ~config:ctx.config ~task_id ~verifier:ctx.agent_name
-            ~verification_id ~notes;
+          Verification_protocol.notify_approve_verification
+            ~task_id ~verifier:ctx.agent_name ~verification_id ~notes;
           (* Record a CDAL verdict attribution on the approval leg so the
              dashboard gets a complete audit line.  With the verification
              FSM enabled, tasks reach Done via approve_verification rather
@@ -943,9 +972,8 @@ and handle_transition ?agent_tool_names ctx args =
         | Types.Reject_verification ->
           let reason = if notes <> "" then notes else reason in
           let verification_id = Option.value ~default:"" verification_id_before in
-          Verification_protocol.on_reject_verification
-            ~config:ctx.config ~task_id ~verifier:ctx.agent_name
-            ~verification_id ~reason;
+          Verification_protocol.notify_reject_verification
+            ~task_id ~verifier:ctx.agent_name ~verification_id ~reason;
           if Env_config_runtime.Cdal.gate_enabled () then
             ignore (Cdal_verdict_gate.gate_check ~task_id ())
         | Types.Claim | Types.Start | Types.Done_action | Types.Cancel | Types.Release -> ())

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -177,22 +177,32 @@ let on_submit_for_verification ~(config : Coord.config)
     notify_submit_for_verification ~config ~task ~assignee ~verification_id ~evidence_refs;
     Ok ()
 
-let on_approve_verification ~(config : Coord.config)
+let record_approve_verification ~(config : Coord.config)
     ~task_id ~verifier ~verification_id ~notes =
   let base_path = config.Coord.base_path in
   (* Update Verification.ml state machine: Pending -> Completed Pass.
      Issue #7544. *)
-  (if verification_id <> "" then
-    match Verification.submit_verdict ~base_path
-            ~req_id:verification_id ~verifier
-            ~verdict:Verification.Pass with
+  if verification_id = "" then
+    Error "verification_id is required for approval verdict persistence"
+  else
+    match
+      Verification.submit_verdict
+        ~base_path
+        ~req_id:verification_id
+        ~verifier
+        ~verdict:Verification.Pass
+    with
     | Ok updated ->
       Verification.attribution_of_request updated
-      |> Option.iter Dashboard_attribution.record
+      |> Option.iter Dashboard_attribution.record;
+      Ok ()
     | Error e ->
       Log.Task.error
         "verification submit_verdict failed (task=%s vrf=%s verifier=%s): %s"
-        task_id verification_id verifier e);
+        task_id verification_id verifier e;
+      Error e
+
+let notify_approve_verification ~task_id ~verifier ~verification_id ~notes =
   let meta_json = `Assoc [
     ("type", `String "verification_verdict");
     ("task_id", `String task_id);
@@ -227,22 +237,42 @@ let on_approve_verification ~(config : Coord.config)
     ("timestamp", `Float (Time_compat.now ()));
   ])
 
-let on_reject_verification ~(config : Coord.config)
+let on_approve_verification ~(config : Coord.config)
+    ~task_id ~verifier ~verification_id ~notes =
+  match
+    record_approve_verification ~config ~task_id ~verifier ~verification_id ~notes
+  with
+  | Error e -> Error e
+  | Ok () ->
+    notify_approve_verification ~task_id ~verifier ~verification_id ~notes;
+    Ok ()
+
+let record_reject_verification ~(config : Coord.config)
     ~task_id ~verifier ~verification_id ~reason =
   let base_path = config.Coord.base_path in
   (* Update Verification.ml state machine: Pending -> Completed (Fail reason).
      Issue #7544. *)
-  (if verification_id <> "" then
-    match Verification.submit_verdict ~base_path
-            ~req_id:verification_id ~verifier
-            ~verdict:(Verification.Fail reason) with
+  if verification_id = "" then
+    Error "verification_id is required for rejection verdict persistence"
+  else
+    match
+      Verification.submit_verdict
+        ~base_path
+        ~req_id:verification_id
+        ~verifier
+        ~verdict:(Verification.Fail reason)
+    with
     | Ok updated ->
       Verification.attribution_of_request updated
-      |> Option.iter Dashboard_attribution.record
+      |> Option.iter Dashboard_attribution.record;
+      Ok ()
     | Error e ->
       Log.Task.error
         "verification submit_verdict failed (task=%s vrf=%s verifier=%s): %s"
-        task_id verification_id verifier e);
+        task_id verification_id verifier e;
+      Error e
+
+let notify_reject_verification ~task_id ~verifier ~verification_id ~reason =
   let meta_json = `Assoc [
     ("type", `String "verification_verdict");
     ("task_id", `String task_id);
@@ -274,6 +304,16 @@ let on_reject_verification ~(config : Coord.config)
     ("reason", `String reason);
     ("timestamp", `Float (Time_compat.now ()));
   ])
+
+let on_reject_verification ~(config : Coord.config)
+    ~task_id ~verifier ~verification_id ~reason =
+  match
+    record_reject_verification ~config ~task_id ~verifier ~verification_id ~reason
+  with
+  | Error e -> Error e
+  | Ok () ->
+    notify_reject_verification ~task_id ~verifier ~verification_id ~reason;
+    Ok ()
 
 let check_timeouts ~(config : Coord.config) =
   if not (Env_config_runtime.Verification.fsm_enabled ()) then ()

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -97,6 +97,14 @@ let status_string config task_id =
   | None -> "not_found"
   | Some t -> Types.string_of_task_status t.task_status
 
+let verification_id_of_task config task_id =
+  match get_task config task_id with
+  | None -> Alcotest.fail "task not found"
+  | Some (t : Types.task) ->
+    (match t.task_status with
+     | Types.AwaitingVerification { verification_id; _ } -> verification_id
+     | _ -> Alcotest.fail "task is not awaiting verification")
+
 let expect_claim_next_claimed result ~task_id ~released_task_id =
   match result with
   | Coord.Claim_next_claimed
@@ -310,6 +318,111 @@ let test_reject_by_other_agent_moves_to_in_progress () =
       Alcotest.(check string) "status" "in_progress"
         (status_string config task_id))
 
+let test_approve_prepare_failure_keeps_task_awaiting () =
+  with_temp_config ~fsm_enabled:true (fun config ->
+    let task_id = add_strict_task config in
+    claim_and_start config "worker" task_id;
+    (match
+       Coord.transition_task_r
+         config
+         ~agent_name:"worker"
+         ~task_id
+         ~action:Types.Submit_for_verification
+         ()
+     with
+     | Ok _ -> ()
+     | Error e -> Alcotest.fail ("submit failed: " ^ Types.show_masc_error e));
+    let verification_id = verification_id_of_task config task_id in
+    let req =
+      create_pending_request
+        config
+        ~task_id
+        ~worker:"worker"
+        ~request_id:verification_id
+    in
+    let prepare_called = ref false in
+    let result =
+      Coord.transition_task_r
+        config
+        ~agent_name:"verifier"
+        ~task_id
+        ~action:Types.Approve_verification
+        ~prepare_verification_verdict:
+          (fun ~task:_ ~verifier:_ ~verification_id:_ ~decision:_ ->
+             prepare_called := true;
+             Error "simulated verdict store failure")
+        ()
+    in
+    match result with
+    | Ok _ -> Alcotest.fail "approve should fail when verdict persistence fails"
+    | Error e ->
+      Alcotest.(check bool) "prepare called" true !prepare_called;
+      Alcotest.(check string) "status remains awaiting_verification"
+        "awaiting_verification" (status_string config task_id);
+      let msg = Types.show_masc_error e in
+      Alcotest.(check bool) "error mentions verdict persistence" true
+        (Astring.String.is_infix
+           ~affix:"verification verdict persistence failed"
+           msg);
+      (match Verification.load_request config.Coord.base_path req.id with
+       | Error err -> Alcotest.fail ("load_request failed: " ^ err)
+       | Ok updated ->
+         Alcotest.(check bool) "request remains pending" true
+           (match updated.status with Pending -> true | _ -> false)))
+
+let test_reject_prepare_failure_keeps_task_awaiting () =
+  with_temp_config ~fsm_enabled:true (fun config ->
+    let task_id = add_strict_task config in
+    claim_and_start config "worker" task_id;
+    (match
+       Coord.transition_task_r
+         config
+         ~agent_name:"worker"
+         ~task_id
+         ~action:Types.Submit_for_verification
+         ()
+     with
+     | Ok _ -> ()
+     | Error e -> Alcotest.fail ("submit failed: " ^ Types.show_masc_error e));
+    let verification_id = verification_id_of_task config task_id in
+    let req =
+      create_pending_request
+        config
+        ~task_id
+        ~worker:"worker"
+        ~request_id:verification_id
+    in
+    let prepare_called = ref false in
+    let result =
+      Coord.transition_task_r
+        config
+        ~agent_name:"verifier"
+        ~task_id
+        ~action:Types.Reject_verification
+        ~reason:"missing evidence"
+        ~prepare_verification_verdict:
+          (fun ~task:_ ~verifier:_ ~verification_id:_ ~decision:_ ->
+             prepare_called := true;
+             Error "simulated verdict store failure")
+        ()
+    in
+    match result with
+    | Ok _ -> Alcotest.fail "reject should fail when verdict persistence fails"
+    | Error e ->
+      Alcotest.(check bool) "prepare called" true !prepare_called;
+      Alcotest.(check string) "status remains awaiting_verification"
+        "awaiting_verification" (status_string config task_id);
+      let msg = Types.show_masc_error e in
+      Alcotest.(check bool) "error mentions verdict persistence" true
+        (Astring.String.is_infix
+           ~affix:"verification verdict persistence failed"
+           msg);
+      (match Verification.load_request config.Coord.base_path req.id with
+       | Error err -> Alcotest.fail ("load_request failed: " ^ err)
+       | Ok updated ->
+         Alcotest.(check bool) "request remains pending" true
+           (match updated.status with Pending -> true | _ -> false)))
+
 let test_claim_next_skips_pending_verification_tasks () =
   with_temp_config ~fsm_enabled:true (fun config ->
     let task_1 = add_strict_task config in
@@ -495,6 +608,10 @@ let () =
         test_approve_by_other_agent_moves_to_done;
       Alcotest.test_case "cross-agent reject moves to in_progress" `Quick
         test_reject_by_other_agent_moves_to_in_progress;
+      Alcotest.test_case "approve prepare failure keeps task awaiting" `Quick
+        test_approve_prepare_failure_keeps_task_awaiting;
+      Alcotest.test_case "reject prepare failure keeps task awaiting" `Quick
+        test_reject_prepare_failure_keeps_task_awaiting;
       Alcotest.test_case "claim_next skips pending verification tasks" `Quick
         test_claim_next_skips_pending_verification_tasks;
       Alcotest.test_case "claim_next skips rejected verification tasks" `Quick


### PR DESCRIPTION
## Summary
- persist approve/reject verification verdicts before committing the task FSM transition
- keep tool and dashboard verdict paths on the same record -> transition -> notify order
- block dashboard verification_id mismatches before moving AwaitingVerification tasks
- add regression coverage for approve/reject persistence failures leaving tasks awaiting verification

## Verification
- MASC_DUNE_THROTTLE=0 DUNE_JOBS=1 scripts/dune-local.sh build test/test_verification_fsm.exe
- ./_build/default/test/test_verification_fsm.exe (17 tests)