### PR TITLE
Fix keeper resume budget hygiene

### DIFF
--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -49,8 +49,8 @@ type pre_compact_event = {
     that OAS will append from [~goal], matching the wire-level message
     list the LLM will receive.
 
-    [has_compact_happened] is reserved for future wake-time pre-reduction
-    (Option C PR4). Currently always false — compaction runs post-turn. *)
+    [has_compact_happened] marks whether MASC applied a pre-dispatch context
+    compaction before handing the resumed checkpoint to OAS. *)
 type wake_payload_event = {
   timestamp : float;
   keeper_name : string;

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -11,6 +11,77 @@ include Keeper_agent_error
 
 (* Post-turn telemetry logging — extracted to Keeper_turn_telemetry (#5732) *)
 
+type pre_dispatch_checkpoint_hygiene_result =
+  { context : Keeper_types.working_context
+  ; resume_checkpoint : Oas.Checkpoint.t option
+  ; compacted : bool
+  ; applied : bool
+  ; meaningful_reduction : bool
+  ; before_tokens : int
+  ; after_tokens : int
+  ; trigger : string option
+  ; decision : string
+  ; save_error : string option
+  }
+
+let prepare_resume_checkpoint_for_dispatch
+      ~(meta : Keeper_types.keeper_meta)
+      ~(now_ts : float)
+      ~(loaded_checkpoint_present : bool)
+      ~(save_checkpoint :
+           Keeper_types.working_context -> (Oas.Checkpoint.t, string) result)
+      (ctx_work : Keeper_types.working_context)
+  : pre_dispatch_checkpoint_hygiene_result
+  =
+  let before_tokens = Keeper_exec_context.token_count ctx_work in
+  let pre_dispatch_meta =
+    {
+      meta with
+      compaction =
+        {
+          meta.compaction with
+          cooldown_sec = 0;
+        };
+    }
+  in
+  let compacted_ctx, trigger, decision =
+    Keeper_compact_policy.compact_if_needed
+      ~meta:pre_dispatch_meta
+      ~now_ts
+      ctx_work
+  in
+  let after_tokens = Keeper_exec_context.token_count compacted_ctx in
+  let applied = Option.is_some trigger in
+  let meaningful_reduction = after_tokens < before_tokens in
+  let checkpoint_opt, save_error =
+    if not loaded_checkpoint_present then
+      (None, None)
+    else if not applied then
+      (Some (Keeper_exec_context.checkpoint_of_context compacted_ctx), None)
+    else
+      match save_checkpoint compacted_ctx with
+      | Ok checkpoint -> (Some checkpoint, None)
+      | Error detail ->
+          (Some (Keeper_exec_context.checkpoint_of_context compacted_ctx), Some detail)
+  in
+  let context =
+    match checkpoint_opt with
+    | Some checkpoint -> { compacted_ctx with checkpoint }
+    | None -> compacted_ctx
+  in
+  {
+    context;
+    resume_checkpoint = checkpoint_opt;
+    compacted = applied;
+    applied;
+    meaningful_reduction;
+    before_tokens;
+    after_tokens;
+    trigger;
+    decision;
+    save_error;
+  }
+
 (** Run a single keeper turn via OAS Agent.run().
 
     Loads checkpoint, creates working context with the base keeper system
@@ -145,27 +216,7 @@ let run_turn
       ~primary_model_max_tokens:max_context
       ~base_dir
   in
-  (* 2b. Load raw OAS checkpoint for Agent.resume path.
-     Preserves turn_count, usage_stats, and lifecycle state across turns.
-     Falls back to fresh build when unavailable (first turn, rollover). *)
-  let raw_oas_checkpoint =
-    match
-      Keeper_checkpoint_store.load_oas
-        ~session_dir:session.session_dir
-        ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-    with
-    | Ok cp -> Some cp
-    | Error _ ->
-        Eio.traceln "[KeeperAgentRun] load_oas checkpoint failed";
-        None
-  in
-  (* Starting turn count for per-call budget calculation in hooks.
-     With Agent.resume, turn count is cumulative from checkpoint. *)
-  let start_turn_count =
-    match raw_oas_checkpoint with
-    | Some cp -> cp.turn_count
-    | None -> 0
-  in
+  let loaded_checkpoint_present = Option.is_some ctx_opt in
   (* 3. Build base system prompt from meta *)
   let profile_defaults = Keeper_types_profile.load_keeper_profile_defaults meta.name in
   let keeper_oas_context =
@@ -230,6 +281,53 @@ let run_turn
   in
   let ctx_work =
     Keeper_exec_context.set_system_prompt base_ctx ~system_prompt:base_system_prompt
+  in
+  (* Pre-dispatch checkpoint hygiene.
+
+     [load_context_from_checkpoint] already sanitizes and trims into
+     [ctx_work], but the previous Agent.resume path reloaded and passed the
+     raw checkpoint to OAS.  That bypassed MASC-side compaction and let local
+     keepers repeatedly dispatch over-budget histories until the 20 minute
+     turn timeout fired.  Use the sanitized working context as the single
+     resume source, and persist any pre-dispatch compaction before calling
+     OAS so a timed-out turn does not reload the same bloated checkpoint. *)
+  let checkpoint_hygiene =
+    prepare_resume_checkpoint_for_dispatch
+      ~meta
+      ~now_ts:(Time_compat.now ())
+      ~loaded_checkpoint_present
+      ~save_checkpoint:(fun compacted_ctx ->
+        Keeper_exec_context.save_oas_checkpoint
+          ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
+          ~session
+          ~agent_name:meta.agent_name
+          ~model:(Keeper_exec_context.checkpoint_model_of_meta meta)
+          ~ctx:compacted_ctx
+          ~generation)
+      ctx_work
+  in
+  let ctx_work = checkpoint_hygiene.context in
+  let resume_oas_checkpoint = checkpoint_hygiene.resume_checkpoint in
+  let pre_dispatch_compacted = checkpoint_hygiene.compacted in
+  (match checkpoint_hygiene.save_error with
+   | Some detail ->
+       Log.Keeper.error
+         "%s: pre-dispatch checkpoint compaction save failed: %s"
+         meta.name detail
+   | None -> ());
+  (if checkpoint_hygiene.applied then
+     Log.Keeper.info
+       "%s: pre-dispatch compaction %s trigger=%s tokens=%d->%d max_context=%d"
+       meta.name
+       (if checkpoint_hygiene.meaningful_reduction then "applied" else "attempted")
+       (Option.value ~default:checkpoint_hygiene.decision checkpoint_hygiene.trigger)
+       checkpoint_hygiene.before_tokens checkpoint_hygiene.after_tokens max_context);
+  (* Starting turn count for per-call budget calculation in hooks.
+     With Agent.resume, turn count is cumulative from checkpoint. *)
+  let start_turn_count =
+    match resume_oas_checkpoint with
+    | Some cp -> cp.turn_count
+    | None -> 0
   in
   (* 5. Build final turn system prompt via caller callback.
      Hard constraints stay in system_prompt; soft context is injected
@@ -1834,7 +1932,7 @@ let run_turn
               ~message_count:sizes.message_count
               ~role_counts:sizes.role_counts
               ~tool_count:sizes.tool_count
-              ~has_compact_happened:false
+              ~has_compact_happened:pre_dispatch_compacted
           in
           ()
         with
@@ -1911,7 +2009,7 @@ let run_turn
            ~enable_thinking:(Keeper_config.keeper_enable_thinking ())
            (* exit_condition removed with mutation_boundary — OAS runs to
               natural completion (max_turns or model end_turn). *)
-           ?oas_checkpoint:raw_oas_checkpoint
+           ?oas_checkpoint:resume_oas_checkpoint
            ?event_bus
            ?per_provider_timeout_s:meta.per_provider_timeout_s
            ())

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -91,6 +91,34 @@ type run_result =
   ; tool_surface : tool_surface_metrics
   }
 
+(** Result of pre-dispatch resume checkpoint hygiene.
+
+    [resume_checkpoint] is the only checkpoint passed to OAS resume.  It is
+    derived from the sanitized MASC working context, optionally after
+    pre-dispatch compaction, so run_turn does not reload a separate raw
+    checkpoint immediately before dispatch. *)
+type pre_dispatch_checkpoint_hygiene_result =
+  { context : Keeper_types.working_context
+  ; resume_checkpoint : Oas.Checkpoint.t option
+  ; compacted : bool
+  ; applied : bool
+  ; meaningful_reduction : bool
+  ; before_tokens : int
+  ; after_tokens : int
+  ; trigger : string option
+  ; decision : string
+  ; save_error : string option
+  }
+
+val prepare_resume_checkpoint_for_dispatch :
+     meta:Keeper_types.keeper_meta
+  -> now_ts:float
+  -> loaded_checkpoint_present:bool
+  -> save_checkpoint:
+       (Keeper_types.working_context -> (Oas.Checkpoint.t, string) result)
+  -> Keeper_types.working_context
+  -> pre_dispatch_checkpoint_hygiene_result
+
 val should_require_tools_for_initial_turn :
   max_turns:int -> turn_affordances:string list -> bool
 

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -992,7 +992,7 @@ let resolved_max_context_for_turn
        meta.name requested resolution.turn_budget resolution.primary_budget
        resolution.effective_budget
    | None -> ());
-  resolution.turn_budget
+  resolution.effective_budget
 
 
 (* Extracted to Keeper_unified_metrics — see keeper_unified_metrics.ml *)
@@ -1793,8 +1793,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                       Log.Keeper.warn
                         "%s: transient network error cascade=%s max_context=%d context_budget=%d primary_budget=%d requested_override=%s retry=%d/%d backoff=%.0fs: %s"
                         meta.name execution.cascade_name
-                        execution.max_context_resolution.effective_budget
                         execution.max_context
+                        execution.max_context_resolution.effective_budget
                         execution.max_context_resolution.primary_budget
                         (match execution.max_context_resolution.requested_override with
                          | Some requested -> string_of_int requested
@@ -2032,8 +2032,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           Log.Keeper.error
             "%s: keeper cycle FAILED cascade=%s max_context=%d context_budget=%d primary_budget=%d requested_override=%s latency=%dms%s error=%s"
             meta.name final_execution.cascade_name
-            final_execution.max_context_resolution.effective_budget
             final_execution.max_context
+            final_execution.max_context_resolution.effective_budget
             final_execution.max_context_resolution.primary_budget
             (match final_execution.max_context_resolution.requested_override with
              | Some requested -> string_of_int requested

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -2,6 +2,7 @@ open Alcotest
 
 module KEC = Masc_mcp.Keeper_exec_context
 module KCC = Masc_mcp.Keeper_context_core
+module KAR = Masc_mcp.Keeper_agent_run
 module KMP = Masc_mcp.Keeper_memory_policy
 module KT = Masc_mcp.Keeper_types
 module KR = Masc_mcp.Keeper_registry
@@ -1799,6 +1800,127 @@ let test_compact_if_needed_records_saved_tokens_metric () =
     (KCC.token_count compacted_ctx < KCC.token_count ctx);
   check bool "saved tokens metric increased" true (after_metric > before_metric)
 
+let test_pre_dispatch_resume_checkpoint_uses_loaded_working_context () =
+  let meta = make_gate_only_meta () in
+  let ctx =
+    KEC.create ~system_prompt:"sp" ~max_tokens:4096
+    |> fun c -> KEC.append c (Agent_sdk.Types.user_msg "sanitized user")
+    |> KEC.sync_oas_context
+  in
+  let checkpoint =
+    {
+      (KEC.checkpoint_of_context ctx) with
+      turn_count = 7;
+      messages = KEC.messages_of_context ctx;
+    }
+  in
+  let ctx = { ctx with checkpoint } in
+  let save_called = ref false in
+  let result =
+    KAR.prepare_resume_checkpoint_for_dispatch
+      ~meta
+      ~now_ts:1000.0
+      ~loaded_checkpoint_present:true
+      ~save_checkpoint:(fun _ ->
+        save_called := true;
+        Error "unexpected save without compaction")
+      ctx
+  in
+  check bool "no compaction save for below-threshold context" false !save_called;
+  check bool "below threshold does not apply compaction" false result.applied;
+  check bool "resume checkpoint is present for loaded context" true
+    (Option.is_some result.resume_checkpoint);
+  let resume_checkpoint =
+    match result.resume_checkpoint with
+    | Some checkpoint -> checkpoint
+    | None -> Alcotest.fail "expected resume checkpoint"
+  in
+  check int "resume turn count comes from sanitized working context" 7
+    resume_checkpoint.turn_count;
+  check int "resume messages come from sanitized working context"
+    (List.length (KEC.messages_of_context ctx))
+    (List.length resume_checkpoint.messages);
+  let fresh_result =
+    KAR.prepare_resume_checkpoint_for_dispatch
+      ~meta
+      ~now_ts:1000.0
+      ~loaded_checkpoint_present:false
+      ~save_checkpoint:(fun _ -> Error "fresh context should not save")
+      ctx
+  in
+  check bool "fresh context does not force Agent.resume" false
+    (Option.is_some fresh_result.resume_checkpoint)
+
+let test_pre_dispatch_resume_checkpoint_saves_compacted_context () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let now_ts = 30_000.0 in
+  let base_meta =
+    make_gate_only_meta
+      ~last_continuity_update_ts:now_ts
+      ~cooldown_sec:3600
+      ()
+  in
+  let meta =
+    {
+      base_meta with
+      compaction =
+        {
+          base_meta.compaction with
+          ratio_gate = 0.1;
+        };
+    }
+  in
+  let long_text = String.make emergency_test_text_length 'x' in
+  let ctx =
+    KEC.create ~system_prompt:"sp" ~max_tokens:1000
+    |> fun c -> KEC.append c (Agent_sdk.Types.user_msg long_text)
+    |> fun c -> KEC.append c (Agent_sdk.Types.assistant_msg long_text)
+    |> KEC.sync_oas_context
+  in
+  let checkpoint =
+    {
+      (KEC.checkpoint_of_context ctx) with
+      turn_count = 11;
+      messages = KEC.messages_of_context ctx;
+    }
+  in
+  let ctx = { ctx with checkpoint } in
+  let save_called = ref false in
+  let saved_message_count = ref 0 in
+  let result =
+    KAR.prepare_resume_checkpoint_for_dispatch
+      ~meta
+      ~now_ts
+      ~loaded_checkpoint_present:true
+      ~save_checkpoint:(fun compacted_ctx ->
+        save_called := true;
+        saved_message_count := List.length (KEC.messages_of_context compacted_ctx);
+        Ok
+          {
+            (KEC.checkpoint_of_context compacted_ctx) with
+            turn_count = 42;
+          })
+      ctx
+  in
+  check bool "pre-dispatch compaction applied despite fresh cooldown" true
+    result.applied;
+  check bool "compaction reduced token pressure" true
+    result.meaningful_reduction;
+  check bool "compacted checkpoint is saved before resume" true !save_called;
+  let resume_checkpoint =
+    match result.resume_checkpoint with
+    | Some checkpoint -> checkpoint
+    | None -> Alcotest.fail "expected compacted resume checkpoint"
+  in
+  check int "resume checkpoint is the saved compacted checkpoint" 42
+    resume_checkpoint.turn_count;
+  check int "context carries the same saved checkpoint" 42
+    result.context.checkpoint.turn_count;
+  check int "saved checkpoint received compacted messages"
+    !saved_message_count
+    (List.length resume_checkpoint.messages)
+
 let test_dispatch_keeper_phase_event_uses_room_base_path () =
   let base_dir = temp_dir "keeper_lifecycle_registry_phase" in
   Fun.protect
@@ -1977,6 +2099,10 @@ let () =
             test_compact_if_needed_emergency_bypass_ignores_cooldown;
           test_case "compaction records saved tokens metric" `Quick
             test_compact_if_needed_records_saved_tokens_metric;
+          test_case "pre-dispatch resume uses loaded working context" `Quick
+            test_pre_dispatch_resume_checkpoint_uses_loaded_working_context;
+          test_case "pre-dispatch resume saves compacted context" `Quick
+            test_pre_dispatch_resume_checkpoint_saves_compacted_context;
         ] );
       ( "registry_dispatch",
         [

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4681,6 +4681,17 @@ let test_max_context_resolution_separates_override_and_effective_budget () =
   check int "effective budget caps to primary budget"
     resolution.primary_budget resolution.effective_budget
 
+let test_resolved_max_context_for_turn_uses_effective_budget () =
+  let labels = [ "unknown:model" ] in
+  let meta = { minimal_meta with max_context_override = Some 1_000_000 } in
+  let resolution =
+    KEC.resolve_max_context_resolution
+      ~requested_override:meta.max_context_override labels
+  in
+  check int "turn dispatch budget is capped to effective budget"
+    resolution.effective_budget
+    (UT.resolved_max_context_for_turn ~meta labels)
+
 let test_side_effect_reclassification_ignores_keeper_read_only_tools () =
   let original =
     Agent_sdk.Error.Api
@@ -6479,6 +6490,8 @@ let () =
             test_resolved_max_context_for_turn_uses_primary_budget;
           test_case "max_context resolution separates override and effective budget" `Quick
             test_max_context_resolution_separates_override_and_effective_budget;
+          test_case "resolved max_context dispatch uses effective budget" `Quick
+            test_resolved_max_context_for_turn_uses_effective_budget;
           test_case "read-only keeper tools do not become ambiguous partial" `Quick
             test_side_effect_reclassification_ignores_keeper_read_only_tools;
           test_case "mixed tool sets only keep mutating keeper tools" `Quick


### PR DESCRIPTION
## Summary
- cap keeper dispatch max_context to the effective model budget instead of the requested override
- stop reloading a raw OAS checkpoint immediately before Agent.resume; resume from the sanitized MASC working context
- run and persist pre-dispatch checkpoint compaction before OAS dispatch, then expose wake-payload compaction truth

## Why
The failing keeper logs showed local Ollama turns running with 64k budget and then timing out after 1200s. The code loaded a sanitized/trimmed MASC working context, but the Agent.resume path separately reloaded and passed the raw checkpoint to OAS, bypassing that hygiene. A timed-out turn could therefore reload the same bloated checkpoint repeatedly.

## Validation
- DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_lifecycle.exe test/test_keeper_unified.exe test/test_pbt_context_overflow.exe
- _build/default/test/test_keeper_lifecycle.exe
- _build/default/test/test_keeper_unified.exe
- _build/default/test/test_pbt_context_overflow.exe
- git diff --check