### PR TITLE
feat(keeper-composite): expose fiber latches + noop counters in /keepers/composite

### DIFF
--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -117,6 +117,10 @@ type snapshot = {
   invariants : invariants_check;
   is_live : bool;
   last_outcome : last_outcome option;
+  fiber_stop_flag : bool;
+  fiber_wakeup_flag : bool;
+  consecutive_noop_count : int;
+  idle_seconds : int;
 }
 
 let ksm_phase_to_string = function
@@ -456,6 +460,14 @@ let observe
            selected_model = lc.ct_selected_model;
          }
        | None -> None);
+    fiber_stop_flag = Atomic.get entry.fiber_stop;
+    fiber_wakeup_flag = Atomic.get entry.fiber_wakeup;
+    consecutive_noop_count =
+      entry.meta.runtime.proactive_rt.consecutive_noop_count;
+    idle_seconds =
+      (let last = entry.meta.runtime.proactive_rt.last_ts in
+       if last <= 0.0 then 0
+       else int_of_float (max 0.0 (Time_compat.now () -. last)));
   }
 
 (* Fleet fold — observe every currently-registered keeper under
@@ -539,4 +551,8 @@ let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
              | None -> `Null);
         ]
       | None -> `Null);
+    "fiber_stop_flag", `Bool s.fiber_stop_flag;
+    "fiber_wakeup_flag", `Bool s.fiber_wakeup_flag;
+    "consecutive_noop_count", `Int s.consecutive_noop_count;
+    "idle_seconds", `Int s.idle_seconds;
   ]

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -160,6 +160,26 @@ type snapshot = {
       (** Most recent completed turn, surfaced separately from live
           state so operators can see "what just finished" without
           confusing it with "what's running now". *)
+  fiber_stop_flag : bool;
+      (** Snapshot of [registry_entry.fiber_stop] at observation time.
+          When [true] without a corresponding stopped/dead phase, the
+          keepalive loop will exit on its next iteration — used to
+          discriminate fiber-supervisor wedge from cycle-gate wedge in
+          fleet silence diagnoses. *)
+  fiber_wakeup_flag : bool;
+      (** Snapshot of [registry_entry.fiber_wakeup]. [true] means a
+          wake signal is queued; the next [interruptible_sleep] chunk
+          will return early. Stale [true] points at a wake source
+          that was set but never consumed. *)
+  consecutive_noop_count : int;
+      (** Lifetime [consecutive_noop_count] from the proactive runtime.
+          Increments per cycle that produced no text and only used
+          observation-only tools; resets on substantive output. Reaching
+          ≥3 caps the noop backoff multiplier at 8x. *)
+  idle_seconds : int;
+      (** Wall-clock seconds since the keeper last did something the
+          metrics layer treated as substantive. Compared against
+          [proactive.idle_sec] to gate scheduled-autonomous turns. *)
 }
 
 (** Derive a composite snapshot from a live registry entry.


### PR DESCRIPTION
## Why

PR #10296 fixed the wedge in issue #10254 (`fix(keeper): reset fiber latches on launch`). The diagnosis took two competing hypotheses (H1: claimable filter regression, H2: stale `fiber_stop` Atomic) because the existing `/api/v1/keepers/composite` JSON exposes phase + last_outcome but not the per-keeper Atomic latches or proactive-cooldown counters that actually govern whether a fiber is alive, woken, in noop backoff, or just past its idle gate.

This PR adds those four fields so the **next** instance of "fleet went silent" — whether it's a different latch drift, a noop-backoff overshoot, or an idle_gate misconfiguration — is one curl away from a verdict instead of a multi-hour static analysis pass.

## What

`Keeper_composite_observer.snapshot` gains four fields:

- `fiber_stop_flag : bool` — `Atomic.get registry_entry.fiber_stop` at observation time
- `fiber_wakeup_flag : bool` — `Atomic.get registry_entry.fiber_wakeup`
- `consecutive_noop_count : int` — `meta.runtime.proactive_rt.consecutive_noop_count` (drives the 1-2-4-8x cooldown multiplier)
- `idle_seconds : int` — `now - meta.runtime.proactive_rt.last_ts` (compared against `proactive.idle_sec` to gate scheduled-autonomous turns)

Pure projection — no I/O, no lifecycle effect. Dashboard fiber reads `Atomic.t` lock-free, concurrent with the keeper fiber writing them. The four fields land at the end of the existing JSON object so the contract is additive.

## Diagnostic value

For #10254-class wedges:

- `fiber_stop_flag = true` while phase = Running → fiber_supervisor wedge (the bug #10296 just fixed)
- `fiber_wakeup_flag = true` for sustained periods → wake source set but never consumed
- `consecutive_noop_count >= 3` with effective_cooldown growing → noop-backoff lock
- `idle_seconds` < `proactive.idle_sec` while turn_phase = idle → cycle is ticking but `should_run = false` for some other reason (returns to H1-style claimable filter audit)

## Risk

Additive. No public type removed or renamed; the Transport Drift Gate fingerprint should still match. Inline tests don't cover the observer, but the four reads are trivial — the existing observer test still passes after the additions, which is what `lib/keeper/runtest` exercises.

## Followups

UI side (Preact / Bonsai dashboards) can render the four new fields as a "fiber state" column on the agents directory page. Out of scope for this PR — server contract first.