### PR TITLE
perf(prompt-registry): byte-wise template substitution, hoist unresolved-var regex

### DIFF
--- a/lib/prompt_registry/prompt_registry.ml
+++ b/lib/prompt_registry/prompt_registry.ml
@@ -400,17 +400,58 @@ let update_metrics ~id ~version ~score () : unit =
 
 (** {1 Template Rendering} *)
 
+(* Static unresolved-var detector — same pattern, hoisted out of
+   [render_template] so [Re.compile] runs once at module load instead
+   of per render call. *)
+let unresolved_var_re =
+  Re.Pcre.re {|\{\{[^}]+\}\}|} |> Re.compile
+
+(* Byte-wise [pattern → replacement] substring substitution.
+
+   Replaces [Re.replace_string (Re.str pattern |> Re.compile)] which
+   compiled a fresh DFA per variable.  [render_template] is hot —
+   keeper prompts call it per turn with ~15 vars, so the prior form
+   built O(vars × calls) regexes for what is just literal substring
+   replace.  Empty pattern short-circuits to the input string to match
+   [Re.str ""] semantics. *)
+let replace_substring_all ~pattern ~replacement s =
+  let plen = String.length pattern in
+  let slen = String.length s in
+  if plen = 0 then s
+  else
+    let rec match_at i j =
+      if j = plen then true
+      else if String.unsafe_get s (i + j) <> String.unsafe_get pattern j
+      then false
+      else match_at i (j + 1)
+    in
+    let buf = Buffer.create slen in
+    let last = slen - plen in
+    let rec loop i =
+      if i > last then begin
+        Buffer.add_substring buf s i (slen - i);
+        Buffer.contents buf
+      end
+      else if match_at i 0 then begin
+        Buffer.add_string buf replacement;
+        loop (i + plen)
+      end
+      else begin
+        Buffer.add_char buf (String.unsafe_get s i);
+        loop (i + 1)
+      end
+    in
+    loop 0
+
 (** Render a prompt template with the given variables *)
 let render_template ~template ~vars () : (string, string) result =
   try
     let result = ref template in
     List.iter (fun (name, value) ->
       let pattern = Printf.sprintf "{{%s}}" name in
-      result := Re.replace_string (Re.str pattern |> Re.compile) ~by:value !result
+      result := replace_substring_all ~pattern ~replacement:value !result
     ) vars;
-    (* Check for unresolved variables anywhere in the result *)
-    let regex = Re.Pcre.re {|\{\{[^}]+\}\}|} |> Re.compile in
-    let has_unresolved = Re.execp regex !result in
+    let has_unresolved = Re.execp unresolved_var_re !result in
     if has_unresolved then
       Error "Unresolved variables in template"
     else


### PR DESCRIPTION
## Summary

`Prompt_registry.render_template` sits on the keeper turn loop — every prompt build paid:

- One `Re.compile` per variable for the `{{name}}` literal substring replace
- One `Re.compile` for the static `\{\{[^}]+\}\}` unresolved-var detector

So a 15-var keeper prompt rebuilt 16 DFAs before the first match. Both are pure substring/static-pattern operations:

```ocaml
(* before *)
List.iter (fun (name, value) ->
  let pattern = Printf.sprintf "{{%s}}" name in
  result := Re.replace_string (Re.str pattern |> Re.compile) ~by:value !result
) vars;
let regex = Re.Pcre.re {|\{\{[^}]+\}\}|} |> Re.compile in
let has_unresolved = Re.execp regex !result in
```

After:

- `unresolved_var_re` hoisted to module-level `let` (compile once at load).
- Per-variable substitution rewritten as a byte-wise `replace_substring_all` using `String.unsafe_get` + `Buffer.t`: zero `Re.compile`, zero `String.sub` allocations, single result buffer per variable.

Hot callers: `keeper_prompt`, `keeper_deliberation`, `keeper_unified_prompt`, `dashboard_governance_judge`, `dashboard_operator_judge` — fleet-wide saving.

Same anti-pattern series:
- #10250 / #10252: `Mention` per-call `Re.compile` (merged)
- #10260: `Coord_gc.mentions_open_task` M×N compile (merged)
- #10267: `Mcp_server_eio_call_tool.contains_casefold` (merged)
- #10286: dashboard helper hoist + byte scan (merged)
- #10301: `Bounded` + `Auto_recall` (in-flight)
- #10303: `Masc_error_recovery` + `Coord_git` (in-flight)
- This PR: `Prompt_registry.render_template`

## Test plan
- [x] `dune build @check` clean
- [x] `dune build @runtest` clean (test_prompt_registry_defaults, test_keeper_unified, test_keeper_deliberation, test_operator_control_keeper exercise this path)
- Behavior preserved: `replace_substring_all` is a literal substring replace identical to `Re.replace_string (Re.str pattern)`. Empty pattern short-circuits to input (matches `Re.str ""` semantics). Unresolved-var regex is the same PCRE pattern, just hoisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)