### PR TITLE
fix(dashboard): surface telemetry raw JSON copy

### DIFF
--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -232,6 +232,30 @@ describe('TelemetryUnified', () => {
     expect(copyButton?.getAttribute('title')).toBe('Copy telemetry entry JSON')
   })
 
+  it('surfaces a raw JSON copy action inside an expanded telemetry entry', async () => {
+    const fetchTelemetry = vi.fn().mockResolvedValue(baseTelemetry)
+    const fetchTelemetrySummary = vi.fn().mockResolvedValue(baseSummary)
+    const { TelemetryUnified } = await loadPanel(fetchTelemetry, fetchTelemetrySummary)
+
+    await act(async () => {
+      render(html`<${TelemetryUnified} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    const rowToggle = container.querySelector('button[aria-expanded="false"]') as HTMLButtonElement | null
+    expect(rowToggle).not.toBeNull()
+    await act(async () => {
+      rowToggle?.click()
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    const expandedCopyButton = container.querySelector('[aria-label="Copy expanded telemetry entry JSON"]') as HTMLButtonElement | null
+    expect(expandedCopyButton).not.toBeNull()
+    expect(expandedCopyButton?.getAttribute('title')).toBe('Copy expanded telemetry entry JSON')
+  })
+
   it('condenses consecutive noisy telemetry into grouped categories', async () => {
     const fetchTelemetry = vi.fn().mockResolvedValue({
       ...baseTelemetry,
@@ -299,6 +323,19 @@ describe('TelemetryUnified', () => {
     expect(container.textContent).toContain('Polling / no-op')
     expect(container.textContent).toContain('Polling / no-op · masc_status · 3 events')
     expect(container.textContent).toContain('task_claimed: keeper-alpha')
+
+    const groupToggle = Array.from(container.querySelectorAll('button[aria-expanded="false"]'))
+      .find(button => button.textContent?.includes('Polling / no-op')) as HTMLButtonElement | undefined
+    expect(groupToggle).toBeTruthy()
+    await act(async () => {
+      groupToggle?.click()
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    const expandedCopyButton = container.querySelector('[aria-label="Copy expanded telemetry group JSON"]') as HTMLButtonElement | null
+    expect(expandedCopyButton).not.toBeNull()
+    expect(expandedCopyButton?.getAttribute('title')).toBe('Copy expanded telemetry group JSON')
   })
 
   it('groups heartbeat keeper metrics into a heartbeat category', async () => {

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -538,8 +538,19 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
               ${scopeBadges.map(badge => html`<span class="rounded bg-[var(--white-4)] px-2 py-1 text-3xs text-[var(--text-dim)] font-mono">${badge}</span>`)}
             </div>
           ` : null}
-          <pre class="text-3xs font-mono text-[var(--text-muted)] bg-[rgba(0,0,0,0.3)] rounded p-2 overflow-x-auto max-h-75 overflow-y-auto whitespace-pre-wrap break-all">
+          <div class="rounded bg-[rgba(0,0,0,0.3)] p-2">
+            <div class="mb-1.5 flex items-center justify-between gap-2">
+              <span class="text-3xs font-medium text-[var(--text-dim)]">Raw JSON</span>
+              <${CopyIdButton}
+                value=${rawJson}
+                label="expanded telemetry entry JSON"
+                ariaLabel="Copy expanded telemetry entry JSON"
+                size=${13}
+              />
+            </div>
+            <pre class="m-0 text-3xs font-mono text-[var(--text-muted)] overflow-x-auto max-h-75 overflow-y-auto whitespace-pre-wrap break-all">
 ${rawJson}</pre>
+          </div>
         </div>
       ` : null}
     </div>
@@ -612,11 +623,21 @@ function GroupRow({ item }: { item: Extract<TelemetryDisplayItem, { kind: 'group
               </div>
             `
           })}
-          <details class="rounded bg-[var(--black-20)] px-2 py-1.5">
-            <summary class="cursor-pointer text-3xs text-[var(--text-dim)]">Raw JSON</summary>
-            <pre class="mt-2 text-3xs font-mono text-[var(--text-muted)] overflow-x-auto max-h-70 overflow-y-auto whitespace-pre-wrap break-all">
+          <div class="rounded bg-[var(--black-20)] px-2 py-1.5">
+            <div class="flex items-start justify-between gap-2">
+              <details class="min-w-0 flex-1">
+                <summary class="cursor-pointer text-3xs text-[var(--text-dim)]">Raw JSON</summary>
+                <pre class="mt-2 text-3xs font-mono text-[var(--text-muted)] overflow-x-auto max-h-70 overflow-y-auto whitespace-pre-wrap break-all">
 ${rawJson}</pre>
-          </details>
+              </details>
+              <${CopyIdButton}
+                value=${rawJson}
+                label="expanded telemetry group JSON"
+                ariaLabel="Copy expanded telemetry group JSON"
+                size=${13}
+              />
+            </div>
+          </div>
         ` : null}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add an explicit copy action inside expanded telemetry Raw JSON detail blocks.
- Keep the existing compact row copy action and reuse the shared CopyIdButton/copyToClipboard path.
- Cover both single telemetry entries and condensed telemetry groups with dashboard tests.

## Why
The fleet-health default view already had a compact row-level copy icon, but the expanded Raw JSON block did not expose a local copy affordance. Operators were reading the detail pane but had to notice the small row icon instead of copying from the block they were inspecting.

## Validation
- pnpm install --offline --frozen-lockfile
- pnpm exec vitest run src/components/telemetry-unified.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false