### PR TITLE
fix(dispatch): reject foreign author claims on board_post (#10297)

### DIFF
--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -75,7 +75,14 @@ let canonicalize_board_actor_field field arguments =
     [author] — we used to reject those calls at pre-hook validation, which
     forced every caller to know about the legacy schema field. The board store
     keeps canonical keeper names as principals while preserving raw runtime
-    agent names in metadata. *)
+    agent names in metadata.
+
+    Identity SSOT (#10297): when [args.author] is non-empty and disagrees with
+    [ctx.agent_name] (after canonicalisation), the dispatcher rewrites the
+    field to the trusted ctx name and preserves the caller-supplied claim
+    under [meta.author_claim_overridden] for forensics.  This prevents an
+    LLM-controlled keeper from impersonating another principal by writing
+    a foreign name into [author]. *)
 let ensure_board_post_author ~agent_name arguments =
   match arguments with
   | `Assoc fields -> (
@@ -84,9 +91,23 @@ let ensure_board_post_author ~agent_name arguments =
         | Some (`String s) -> String.trim s
         | _ -> ""
       in
-      let raw_author =
-        if existing <> "" && existing <> "anonymous" then existing
-        else String.trim agent_name
+      let ctx_name = String.trim agent_name in
+      let canonical_from_ctx =
+        if ctx_name = "" then ""
+        else Server_utils.board_actor_author_for_write ctx_name
+      in
+      let raw_author, claim_overridden =
+        match existing with
+        | "" -> (ctx_name, None)
+        | "anonymous" -> (ctx_name, None)
+        | other ->
+            let canonical_from_caller =
+              Server_utils.board_actor_author_for_write other
+            in
+            if canonical_from_ctx <> ""
+               && String.equal canonical_from_caller canonical_from_ctx
+            then (other, None)
+            else (ctx_name, Some other)
       in
       if raw_author = "" then arguments
       else
@@ -95,6 +116,12 @@ let ensure_board_post_author ~agent_name arguments =
         let fields =
           if String.equal canonical raw_author then fields
           else json_upsert_meta_string_field "author_raw_agent_name" raw_author fields
+        in
+        let fields =
+          match claim_overridden with
+          | None -> fields
+          | Some claim ->
+              json_upsert_meta_string_field "author_claim_overridden" claim fields
         in
         `Assoc fields)
   | _ -> arguments

--- a/test/dune
+++ b/test/dune
@@ -129,6 +129,7 @@
         test_worktree_live_context
         test_worktree_status_single_flight_9632
         test_tool_input_validation
+        test_inline_dispatch_author_ssot
         test_autoresearch_codegen
         test_autoresearch_oas_primitives
         test_autoresearch_target_score
@@ -268,6 +269,7 @@
           test_worktree_live_context
           test_worktree_status_single_flight_9632
           test_tool_input_validation
+          test_inline_dispatch_author_ssot
           test_autoresearch_codegen
           test_autoresearch_oas_primitives
           test_autoresearch_target_score

--- a/test/test_inline_dispatch_author_ssot.ml
+++ b/test/test_inline_dispatch_author_ssot.ml
@@ -1,0 +1,103 @@
+(** Identity SSOT for [keeper_board_post] dispatcher.
+
+    Regression for masc-mcp #10297: a non-empty caller-supplied [author]
+    must not bypass [ctx.agent_name].  When the two disagree (after
+    canonicalisation), the dispatcher rewrites [author] to the trusted
+    ctx name and preserves the LLM's claim under
+    [meta.author_claim_overridden]. *)
+
+open Alcotest
+
+let canonical = Server_utils.board_actor_author_for_write
+
+let lookup_string fields key =
+  match List.assoc_opt key fields with
+  | Some (`String s) -> Some s
+  | _ -> None
+
+let lookup_meta_string fields key =
+  match List.assoc_opt "_meta" fields with
+  | Some (`Assoc meta) -> lookup_string meta key
+  | _ -> None
+
+let dispatch_author ~ctx ~caller_author =
+  let args =
+    match caller_author with
+    | None -> `Assoc [ ("body", `String "test") ]
+    | Some a ->
+        `Assoc [ ("body", `String "test"); ("author", `String a) ]
+  in
+  match Tool_inline_dispatch_extra.ensure_board_post_author ~agent_name:ctx args with
+  | `Assoc fields -> fields
+  | _ -> failwith "expected `Assoc"
+
+let test_blank_author_uses_ctx () =
+  let ctx = "keeper-velvet-hammer-agent" in
+  let fields = dispatch_author ~ctx ~caller_author:None in
+  check (option string) "author = canonical(ctx)"
+    (Some (canonical ctx))
+    (lookup_string fields "author");
+  check (option string) "no override claim recorded"
+    None
+    (lookup_meta_string fields "author_claim_overridden")
+
+let test_anonymous_author_uses_ctx () =
+  let ctx = "keeper-velvet-hammer-agent" in
+  let fields = dispatch_author ~ctx ~caller_author:(Some "anonymous") in
+  check (option string) "author = canonical(ctx)"
+    (Some (canonical ctx))
+    (lookup_string fields "author");
+  check (option string) "no override claim for anonymous"
+    None
+    (lookup_meta_string fields "author_claim_overridden")
+
+let test_matching_canonical_author_kept () =
+  (* LLM names itself with the same canonical identity (just a different raw
+     form) — keep its choice and record the raw form for forensics. *)
+  let ctx = "keeper-velvet-hammer-agent" in
+  let fields = dispatch_author ~ctx ~caller_author:(Some "velvet-hammer") in
+  check (option string) "author = canonical (matches ctx canonical)"
+    (Some (canonical ctx))
+    (lookup_string fields "author");
+  check (option string) "no override claim when canonicals match"
+    None
+    (lookup_meta_string fields "author_claim_overridden")
+
+let test_foreign_author_rewritten_to_ctx () =
+  (* The bug: velvet-hammer claimed [author = "analyst"]. The dispatcher
+     must reject the claim and rewrite to the trusted ctx. *)
+  let ctx = "keeper-velvet-hammer-agent" in
+  let fields = dispatch_author ~ctx ~caller_author:(Some "analyst") in
+  check (option string) "author rewritten to canonical(ctx)"
+    (Some (canonical ctx))
+    (lookup_string fields "author");
+  check (option string) "LLM claim preserved in meta"
+    (Some "analyst")
+    (lookup_meta_string fields "author_claim_overridden")
+
+let test_empty_ctx_keeps_caller_value () =
+  (* Defensive: if ctx is somehow empty (no agent_name), fall through to
+     the caller-supplied value rather than producing a blank author.
+     This preserves prior behaviour for HTTP surfaces that authenticate
+     via tokens not yet bound to a keeper identity. *)
+  let fields = dispatch_author ~ctx:"" ~caller_author:(Some "analyst") in
+  check (option string) "caller value retained when ctx blank"
+    (Some "analyst")
+    (lookup_string fields "author")
+
+let () =
+  run "inline_dispatch_author_ssot"
+    [
+      ("ensure_board_post_author", [
+           test_case "blank author falls back to ctx" `Quick
+             test_blank_author_uses_ctx;
+           test_case "anonymous author falls back to ctx" `Quick
+             test_anonymous_author_uses_ctx;
+           test_case "matching canonical author is kept" `Quick
+             test_matching_canonical_author_kept;
+           test_case "foreign author is rewritten to ctx and claim preserved"
+             `Quick test_foreign_author_rewritten_to_ctx;
+           test_case "empty ctx leaves caller value alone" `Quick
+             test_empty_ctx_keeps_caller_value;
+         ]);
+    ]


### PR DESCRIPTION
## 요약

**Issue**: #10297 — keeper LLM이 `keeper_board_post` 호출 시 `args.author`에 다른 principal 이름(예: `"analyst"`)을 적으면 board store가 그대로 기록함. `ctx.agent_name`(velvet-hammer)이 무시되어 identity spoofing 가능.

## Root cause

`lib/tool_inline_dispatch_extra.ml:79-93` `ensure_board_post_author`:

```ocaml
let raw_author =
  if existing <> "" && existing <> "anonymous" then existing
  else String.trim agent_name
in
```

caller-supplied non-empty `author`가 trusted ctx와 비교 없이 통과.

## Fix

caller value를 canonical form으로 변환 후 ctx canonical과 비교. 불일치 시 ctx로 rewrite + LLM의 claim을 `meta.author_claim_overridden`에 보존(forensics).

### 동작 매트릭스

| `ctx.agent_name` | `args.author` | 결과 `author` | meta override |
|------------------|---------------|--------------|---------------|
| keeper-velvet-hammer-agent | (absent/blank/anonymous) | velvet-hammer | — |
| keeper-velvet-hammer-agent | "velvet-hammer" | velvet-hammer | — |
| keeper-velvet-hammer-agent | "keeper-velvet-hammer-agent" | velvet-hammer | — |
| keeper-velvet-hammer-agent | **"analyst"** | **velvet-hammer** | **"analyst"** |
| (empty) | "analyst" | analyst | — (legacy fallback) |

마지막 case (ctx 비어있음)는 unauthenticated HTTP surface가 token 기반 인증을 사용하지만 keeper identity로 binding되지 않은 경우. 기존 동작 보존하여 blank author 방지.

## 패턴 분류

같은 클래스: masc-mcp #6527 trilogy + #6623 (`mcp-dispatcher-ctx-agent-name-ssot` feedback memory). MCP dispatcher는 caller-supplied identity 필드가 runtime contract와 disagreement 시 reject 또는 rewrite.

## 검증

```text
DUNE_CACHE=disabled dune build --root . --cache=disabled @check
→ EXIT=0

새 단위 테스트: test/test_inline_dispatch_author_ssot.ml (5 case 커버)
```

병렬 cycle의 dune lock 경합으로 로컬 단위 테스트 실행은 CI에 위임.

## Defensive guards

- Draft + `do-not-merge` label
- `gh pr merge --disable-auto`

## 관련

- Issue: `#10297`
- Similar: `#6527` trilogy, `#6623`
