### PR TITLE
fix(keeper): keep nudges within active tool surface

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1210,16 +1210,16 @@ let run_turn
           chunks
           @ (match guidance_section with Some s -> [s] | None -> [])
         in
-        let allowed_tool_names =
-          Keeper_exec_tools.keeper_allowed_tool_names meta
-        in
-        let preferred_tools =
-          Keeper_tool_guidance.render_preferred_tools ~allowed_tool_names
-        in
-        let gh_workflow =
-          Keeper_tool_guidance.render_gh_workflow ~allowed_tool_names
-          |> Option.map (Printf.sprintf "\n\n%s")
-          |> Option.value ~default:""
+        (* [discover_work_nudge] runs in [before_turn], before the
+           [before_turn_params] hook computes the final per-turn
+           [tool_filter_override].  That final surface can be narrower
+           than keeper policy metadata (for example on last-turn
+           safety narrowing), so this nudge must not advertise concrete
+           tool names derived from the broader static policy. *)
+        let active_schema_guard =
+          "Use only tool schemas currently shown by the runtime. If an \
+           execution tool is absent from the active schema list, do not name \
+           or call it; emit [STATE] or use a visible handoff/status tool."
         in
         let unknown_tool_guard =
           Keeper_tool_guidance.render_unknown_tool_guard ()
@@ -1230,12 +1230,12 @@ let run_turn
            Some (Printf.sprintf
              "## Discovered Work (auto, %ds interval)\n\n%s\n\n\
               ### Use the smallest real action now\n\
-              %s%s\n\n\
+              %s\n\n\
               %s\n\n\
               Do not print fenced pseudo-calls. Pick the smallest viable \
               action and emit one or more structured tool calls now."
-             interval (String.concat "\n\n" sections) preferred_tools
-             gh_workflow unknown_tool_guard))
+             interval (String.concat "\n\n" sections) active_schema_guard
+             unknown_tool_guard))
   in
   let base_hooks =
     (* Issue #8597 #3-5: dropped ~config / ~session / ~ctx_snapshot —
@@ -1394,8 +1394,10 @@ let run_turn
                       let nudge =
                         Printf.sprintf
                           "[CLAIMED TASK] You hold %s. Do NOT call claim_next again. \
-                           Use keeper_bash, keeper_shell, keeper_fs_read, or other \
-                           execution tools to start working on it now."
+                           Use an execution tool visible in your active runtime schema \
+                           to start working on it now. If no execution tool is visible, \
+                           emit [STATE] with the blocker instead of inventing a tool \
+                           name."
                           (Keeper_id.Task_id.to_string task_id)
                       in
                       (match ctx with

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1594,7 +1594,17 @@ let test_work_discovery_nudge_uses_registered_keeper_tool_schemas () =
        "Requires an active claimed task/current_task_id");
   check bool "keeper_shell gh runtime allows sandbox fallback" true
     (source_file_contains "lib/keeper/keeper_shell_gh_context.ml"
-       "task_id = \"(sandbox)\"")
+       "task_id = \"(sandbox)\"");
+  check bool
+    "work discovery nudge avoids pre-filter policy tool names"
+    false
+    (source_file_contains "lib/keeper/keeper_agent_run.ml"
+       "render_preferred_tools ~allowed_tool_names");
+  check bool
+    "claimed-task nudge avoids hard-coded execution tool names"
+    false
+    (source_file_contains "lib/keeper/keeper_agent_run.ml"
+       "Use keeper_bash, keeper_shell, keeper_fs_read")
 
 (* ---------- Config tests ---------- *)
 


### PR DESCRIPTION
## Summary
- stop work-discovery nudges from rendering concrete tool names from broad keeper policy before the per-turn tool surface is finalized
- make claimed-task nudges refer to the active runtime schema instead of hard-coded execution tool names
- add regression guards so future prompt changes do not reintroduce pre-filter tool advertising

## Why it matters
This is a follow-up to the merged #10272 review. The runtime can narrow `all_allowed` after policy metadata is read, especially on last-turn safety paths. If a nudge advertises tools from the broader policy before `tool_filter_override` is computed, keepers can be instructed to call tools that are absent from the actual schema, which feeds the required-tool loop failure mode.

## Verification
- `git diff --check origin/main...HEAD`
- `bash scripts/health_snapshot.sh --skip-build --baseline-ref origin/main --fail-on-lib-regression`
- `scripts/dune-local.sh build test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_unified.exe` -> 290 tests passed
