### PR TITLE
perf(validation,coord-utils): hoist Safe_path and room-id regexes

### DIFF
--- a/lib/coord/coord_utils_ops.ml
+++ b/lib/coord/coord_utils_ops.ml
@@ -12,6 +12,18 @@ let validate_task_id id =
   (* Delegate to Validation module for consistent security checks *)
   Validation.Task_id.validate id
 
+(* Allowed character class for room ids: [A-Za-z0-9._-]+, anchored.
+   Hoisted to module load so room-id validation (called per MCP
+   request that takes a [room]/[coord] parameter) doesn't pay
+   [Re.compile] per call. *)
+let room_id_allowed_re =
+  Re.(compile
+        (whole_string
+           (rep1 (alt [
+             rg 'A' 'Z'; rg 'a' 'z'; rg '0' '9';
+             char '.'; char '_'; char '-';
+           ]))))
+
 let validate_room_id room_id =
   let room_id = String.trim room_id in
   if room_id = "" then Error "Coord id cannot be empty"
@@ -21,7 +33,7 @@ let validate_room_id room_id =
     Error "Coord id cannot contain path separators"
   else if contains_substring room_id ".." then
     Error "Coord id cannot contain traversal segments"
-  else if not (Re.execp (Re.compile (Re.(whole_string (rep1 (alt [rg 'A' 'Z'; rg 'a' 'z'; rg '0' '9'; char '.'; char '_'; char '-']))))) room_id) then
+  else if not (Re.execp room_id_allowed_re room_id) then
     Error "Coord id may only contain letters, digits, dot, underscore, and hyphen"
   else Ok room_id
 

--- a/lib/core/validation.ml
+++ b/lib/core/validation.ml
@@ -152,6 +152,17 @@ module Safe_path : sig
   val validate_relative : string -> (string, string) result
   val sanitize_filename : string -> string
 end = struct
+  (* Static patterns hoisted to module load.  [Safe_path] is on every
+     MCP tool argument-validation path, so the prior per-call form
+     paid 4 [Re.compile] for every parameter check. *)
+  let traversal_re = Re.Pcre.re {|\.\./|} |> Re.compile
+
+  let path_separator_re = Re.Pcre.re {|[/\\]|} |> Re.compile
+
+  let dotdot_re = Re.Pcre.re {|\.\.|} |> Re.compile
+
+  let unsafe_char_re = Re.Pcre.re {|[^a-zA-Z0-9_.\-]|} |> Re.compile
+
   let validate_relative path =
     let reject reason =
       log_rejection ~validator:"Safe_path" ~input:path ~reason;
@@ -163,17 +174,16 @@ end = struct
       reject "absolute paths not allowed"
     else if Base.String.is_prefix path ~prefix:".." then
       reject "path traversal not allowed"
-    else if Re.execp (Re.Pcre.re {|\.\./|} |> Re.compile) path then
+    else if Re.execp traversal_re path then
       reject "path traversal not allowed"
     else
       Ok path
 
   let sanitize_filename name =
-    (* Remove any path separators and dangerous characters *)
     name
-    |> Re.replace_string (Re.Pcre.re {|[/\\]|} |> Re.compile) ~by:"_"
-    |> Re.replace_string (Re.Pcre.re {|\.\.|} |> Re.compile) ~by:"_"
-    |> Re.replace_string (Re.Pcre.re {|[^a-zA-Z0-9_.\-]|} |> Re.compile) ~by:"_"
+    |> Re.replace_string path_separator_re ~by:"_"
+    |> Re.replace_string dotdot_re ~by:"_"
+    |> Re.replace_string unsafe_char_re ~by:"_"
 end
 
 (** Numeric validation *)


### PR DESCRIPTION
## Summary

Two MCP-argument-validation hot paths still paid `Re.compile` per call.

### `Validation.Safe_path`

```ocaml
(* before *)
else if Re.execp (Re.Pcre.re {|\.\./|} |> Re.compile) path then ...

let sanitize_filename name =
  name
  |> Re.replace_string (Re.Pcre.re {|[/\\]|} |> Re.compile) ~by:"_"
  |> Re.replace_string (Re.Pcre.re {|\.\.|} |> Re.compile) ~by:"_"
  |> Re.replace_string (Re.Pcre.re {|[^a-zA-Z0-9_.\-]|} |> Re.compile) ~by:"_"
```

4 static PCRE patterns rebuilt every parameter check. Hoisted to module-level `let`:
- `traversal_re`, `path_separator_re`, `dotdot_re`, `unsafe_char_re`.

### `Coord_utils_ops.validate_room_id`

```ocaml
(* before *)
else if not (Re.execp (Re.compile
  (Re.(whole_string (rep1 (alt [rg 'A' 'Z'; rg 'a' 'z'; rg '0' '9'; char '.'; char '_'; char '-']))))) room_id) then ...
```

Static anchored alternation rebuilt every call. Fires for every MCP request that takes a `room`/`coord` argument. Hoisted to `room_id_allowed_re`.

Same anti-pattern series:
- #10250 / #10252: `Mention` (merged)
- #10260: `Coord_gc.mentions_open_task` (merged)
- #10267: `Mcp_server_eio_call_tool.contains_casefold` (merged)
- #10286: dashboard helpers (merged)
- #10301: `Bounded` + `Auto_recall` (merged)
- #10303: `Masc_error_recovery` + `Coord_git` (merged)
- #10315: `Prompt_registry.render_template` (merged)
- #10323: link preview module hoist (in-flight)
- This PR: validation + room-id hoist

## Test plan
- [x] `dune build @check` clean
- Behavior preserved: same patterns, same flags, same fold order in `sanitize_filename`. Only the `Re.compile` site moves from per-call to module load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)