### PR TITLE
fix(dashboard): add keeper tool I/O copy actions

### DIFF
--- a/dashboard/src/components/keeper-tool-call-inspector-render.test.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector-render.test.ts
@@ -1,0 +1,86 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+void vi
+vi.setConfig({ testTimeout: 120_000 })
+
+async function flushUi(): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < 4; i += 1) {
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(0)
+    }
+  })
+}
+
+async function loadInspector(fetchKeeperToolCalls: ReturnType<typeof vi.fn>) {
+  vi.resetModules()
+  vi.doMock('../api/dashboard', () => ({
+    fetchKeeperToolCalls,
+  }))
+  return import('./keeper-tool-call-inspector')
+}
+
+describe('KeeperToolCallInspector render', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.clearAllMocks()
+    vi.resetModules()
+    vi.doUnmock('../api/dashboard')
+    vi.useRealTimers()
+  })
+
+  it('surfaces copy actions for expanded tool call input and output', async () => {
+    const fetchKeeperToolCalls = vi.fn().mockResolvedValue({
+      keeper: 'analyst',
+      count: 1,
+      source: 'tool_call_io',
+      health: 'ok',
+      entries: [
+        {
+          ts: 1_777_100_000,
+          keeper: 'analyst',
+          tool: 'keeper_bash',
+          input: { cmd: 'pwd' },
+          output: '{"ok":true}',
+          success: true,
+          duration_ms: 42,
+          model: 'claude_code:auto',
+        },
+      ],
+    })
+
+    const { KeeperToolCallInspector } = await loadInspector(fetchKeeperToolCalls)
+    await act(async () => {
+      render(html`<${KeeperToolCallInspector} keeperName="analyst" />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    const rowToggle = container.querySelector('button[aria-expanded="false"]') as HTMLButtonElement | null
+    expect(rowToggle).not.toBeNull()
+    await act(async () => {
+      rowToggle?.click()
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    const inputCopy = container.querySelector('[aria-label="Copy tool call input"]') as HTMLButtonElement | null
+    const outputCopy = container.querySelector('[aria-label="Copy tool call output"]') as HTMLButtonElement | null
+    expect(inputCopy).not.toBeNull()
+    expect(outputCopy).not.toBeNull()
+    expect(inputCopy?.getAttribute('title')).toBe('Copy tool call input')
+    expect(outputCopy?.getAttribute('title')).toBe('Copy tool call output')
+  })
+})

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -12,6 +12,7 @@ import { SectionCap } from './common/section-cap'
 import { toolCategory, formatDuration, durationColor } from './tool-call-shared'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { parseToolBlobMarker } from '../lib/tool-blob-marker'
+import { CopyIdButton } from './common/copy-id-button'
 
 // Delegated to lib/format-time (SSOT)
 const formatTimestamp = formatTimeHms
@@ -99,9 +100,38 @@ export function formatOutput(output: string | { _blob: { sha256: string; bytes: 
 
 // ── Single tool call row (expandable) ───────────────────
 
+function CopyableToolCallBlock({
+  title,
+  value,
+  maxHeightClass,
+  ariaLabel,
+}: {
+  title: string
+  value: string
+  maxHeightClass: string
+  ariaLabel: string
+}) {
+  return html`
+    <div>
+      <div class="mb-1 flex items-center justify-between gap-2">
+        <${SectionCap}>${title}<//>
+        <${CopyIdButton}
+          value=${value}
+          label=${`tool call ${title.toLowerCase()}`}
+          ariaLabel=${ariaLabel}
+          size=${12}
+        />
+      </div>
+      <pre class=${`text-xs font-mono bg-[var(--bg-deep)] rounded p-2 overflow-x-auto ${maxHeightClass} whitespace-pre-wrap text-[var(--text-strong)]`}>${value}</pre>
+    </div>
+  `
+}
+
 function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
   const expanded = useSignal(false)
   const cat = toolCategory(entry.tool)
+  const formattedInput = formatInput(entry.input)
+  const formattedOutput = formatOutput(entry.output)
 
   return html`
     <div
@@ -132,14 +162,18 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
           ${entry.model ? html`
             <div class="text-3xs text-[var(--text-muted)]">model: <span class="text-[var(--text-strong)] font-mono">${entry.model}</span></div>
           ` : null}
-          <div>
-            <${SectionCap} class="mb-1">Input<//>
-            <pre class="text-xs font-mono bg-[var(--bg-deep)] rounded p-2 overflow-x-auto max-h-48 whitespace-pre-wrap text-[var(--text-strong)]">${formatInput(entry.input)}</pre>
-          </div>
-          <div>
-            <${SectionCap} class="mb-1">Output<//>
-            <pre class="text-xs font-mono bg-[var(--bg-deep)] rounded p-2 overflow-x-auto max-h-64 whitespace-pre-wrap text-[var(--text-strong)]">${formatOutput(entry.output)}</pre>
-          </div>
+          <${CopyableToolCallBlock}
+            title="Input"
+            value=${formattedInput}
+            maxHeightClass="max-h-48"
+            ariaLabel="Copy tool call input"
+          />
+          <${CopyableToolCallBlock}
+            title="Output"
+            value=${formattedOutput}
+            maxHeightClass="max-h-64"
+            ariaLabel="Copy tool call output"
+          />
         </div>
       ` : null}
     </div>


### PR DESCRIPTION
## Summary
- add shared clipboard actions to expanded keeper tool call Input and Output blocks
- keep the existing formatting path for JSON/blob output, then copy the exact rendered text operators inspect
- cover the expanded row copy controls with a focused render test

## Why
Operators already had raw telemetry copy support, but the keeper-specific tool-call inspector still forced manual selection from preformatted blocks. This makes the exact keeper tool input/output copyable from the detail panel without adding a second clipboard implementation.

## Validation
- pnpm exec vitest run src/components/keeper-tool-call-inspector.test.ts src/components/keeper-tool-call-inspector-render.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- git diff --check HEAD~1 HEAD