### PR TITLE
feat(cascade): JSONL snapshot of trust state every minute (Phase 0b)

### DIFF
--- a/lib/cascade/cascade_trust_persist.ml
+++ b/lib/cascade/cascade_trust_persist.ml
@@ -1,0 +1,114 @@
+(** Cascade trust JSONL snapshot — see [cascade_trust_persist.mli].
+
+    Layering note: this module sits at the cascade layer (alongside
+    [cascade_health_tracker]) and does NOT depend on dashboard layer
+    serializers, even though the JSON shape mirrors
+    [Dashboard_cascade.provider_entry_to_json].  The duplication is
+    intentional — dashboard depends on cascade, not the reverse. *)
+
+module H = Cascade_health_tracker
+
+let snapshot_interval_s =
+  match Sys.getenv_opt "MASC_CASCADE_TRUST_SNAPSHOT_SEC" with
+  | None -> 60.0
+  | Some raw ->
+    let trimmed = String.trim raw in
+    if trimmed = "" then 60.0
+    else
+      match Safe_ops.float_of_string_safe trimmed with
+      | Some v when v > 0.0 -> v
+      | _ ->
+        Log.Misc.warn
+          "Invalid MASC_CASCADE_TRUST_SNAPSHOT_SEC=%S, using 60.0" raw;
+        60.0
+
+(* ── Store cache ────────────────────────────────────── *)
+
+let store_ref : (string * Dated_jsonl.t) option ref = ref None
+
+let reset_for_testing () = store_ref := None
+
+let get_or_create_store ~base_path : Dated_jsonl.t =
+  match !store_ref with
+  | Some (cached, s) when String.equal cached base_path -> s
+  | _ ->
+    let dir = Filename.concat base_path "cascade_trust" in
+    Fs_compat.mkdir_p dir;
+    let s = Dated_jsonl.create ~base_dir:dir () in
+    store_ref := Some (base_path, s);
+    s
+
+(* ── Serialization ──────────────────────────────────── *)
+
+let provider_info_to_json (info : H.provider_info) : Yojson.Safe.t =
+  let fingerprints =
+    `List
+      (List.map
+         (fun (fp, count) ->
+           `Assoc
+             [ ("fingerprint", `String fp); ("count", `Int count) ])
+         info.top_fingerprints)
+  in
+  let last_failure_at =
+    match info.last_failure_at with
+    | Some t -> `Float t
+    | None -> `Null
+  in
+  let cooldown_expires_at =
+    match info.cooldown_expires_at with
+    | Some t -> `Float t
+    | None -> `Null
+  in
+  `Assoc
+    [ ("provider_key", `String info.provider_key)
+    ; ("success_rate", `Float info.success_rate)
+    ; ("consecutive_failures", `Int info.consecutive_failures)
+    ; ("in_cooldown", `Bool info.in_cooldown)
+    ; ("cooldown_expires_at", cooldown_expires_at)
+    ; ("events_in_window", `Int info.events_in_window)
+    ; ("rejected_in_window", `Int info.rejected_in_window)
+    ; ("top_fingerprints", fingerprints)
+    ; ("last_failure_at", last_failure_at)
+    ]
+
+let snapshot_to_json ~ts (infos : H.provider_info list) : Yojson.Safe.t =
+  `Assoc
+    [ ("ts", `Float ts)
+    ; ("providers", `List (List.map provider_info_to_json infos))
+    ]
+
+(* ── Public API ─────────────────────────────────────── *)
+
+let snapshot_now ~base_path =
+  try
+    let store = get_or_create_store ~base_path in
+    let infos = H.all_providers H.global in
+    let json = snapshot_to_json ~ts:(Unix.gettimeofday ()) infos in
+    Dated_jsonl.append store json
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Misc.warn "cascade_trust_persist: snapshot_now failed: %s"
+      (Printexc.to_string exn)
+
+let start_snapshot_fiber ~sw ~clock ~base_path =
+  let _store = get_or_create_store ~base_path in
+  Eio.Fiber.fork ~sw (fun () ->
+    Log.Misc.info
+      "cascade_trust_persist: snapshot fiber started (interval=%.0fs)"
+      snapshot_interval_s;
+    let rec loop () =
+      Eio.Time.sleep clock snapshot_interval_s;
+      snapshot_now ~base_path;
+      loop ()
+    in
+    loop ());
+  Shutdown.register
+    ~name:"cascade_trust_persist_snapshot"
+    ~priority:25
+    (fun () ->
+      try snapshot_now ~base_path
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+        Log.Misc.warn
+          "cascade_trust_persist: shutdown snapshot failed: %s"
+          (Printexc.to_string exn))

--- a/lib/cascade/cascade_trust_persist.mli
+++ b/lib/cascade/cascade_trust_persist.mli
@@ -1,0 +1,40 @@
+(** Cascade trust JSONL snapshot.
+
+    Periodically snapshots the global {!Cascade_health_tracker} state to
+    [base_path/cascade_trust/YYYY-MM/DD.jsonl] for offline analysis of
+    failure fingerprints, success-rate evolution, and provider availability.
+
+    Pull model: a tick fiber polls {!Cascade_health_tracker.all_providers}
+    every [snapshot_interval_s] (default 60s, env
+    [MASC_CASCADE_TRUST_SNAPSHOT_SEC]) and appends one JSON object per
+    tick.  Each object carries [ts] (Unix timestamp) and [providers]
+    (list of structured provider rows mirroring {!provider_info}).
+
+    Companion to Phase 0a observability (PR #10292) — fingerprint counter
+    in {!Cascade_health_tracker} captures the *what*, this module
+    captures the *over time*.  Phase 1 (in-memory trust_score) consumes
+    these snapshots offline to calibrate reward / decay defaults.
+
+    Best-effort: I/O failures are logged but never propagated.
+
+    @since 0.174.0 *)
+
+val snapshot_interval_s : float
+(** Snapshot tick interval in seconds.  Default 60.0.
+    Override via [MASC_CASCADE_TRUST_SNAPSHOT_SEC]. *)
+
+val snapshot_now : base_path:string -> unit
+(** Append one snapshot record immediately to today's day-file.  Reads
+    {!Cascade_health_tracker.global} via {!Cascade_health_tracker.all_providers}.
+    Used by the tick fiber and shutdown hook. *)
+
+val start_snapshot_fiber :
+  sw:Eio.Switch.t -> clock:_ Eio.Time.clock -> base_path:string -> unit
+(** Spawn a background fiber that calls {!snapshot_now} every
+    [snapshot_interval_s].  Registers a shutdown hook for one final
+    snapshot. *)
+
+val reset_for_testing : unit -> unit
+(** Clear cached store state.  Does not cancel any fiber started via
+    {!start_snapshot_fiber}; call only when no fiber is active or after
+    its switch has been cancelled. *)

--- a/lib/dune
+++ b/lib/dune
@@ -52,6 +52,7 @@
    cascade_strategy
    cascade_strategy_trace
    cascade_throttle
+   cascade_trust_persist
    cancellation
    context_overflow_action_tracker
    gate_keeper_backend

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -501,6 +501,13 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
     result);
   Tool_metrics_persist.start_flush_fiber ~sw ~clock
     ~base_path:state.room_config.base_path;
+  (* Cascade trust JSONL snapshot fiber (Phase 0b observability).  Polls
+     [Cascade_health_tracker.global] every minute and appends one JSON
+     object per tick to base_path/cascade_trust/YYYY-MM/DD.jsonl.  Phase 1
+     (in-memory trust_score) consumes these snapshots offline to calibrate
+     reward / decay defaults instead of magic numbers. *)
+  Cascade_trust_persist.start_snapshot_fiber ~sw ~clock
+    ~base_path:state.room_config.base_path;
   (* #9876: Hebbian consolidation fiber. Prior to this, the graph was
      write-only — strengthen/weaken populated synapses but decay +
      pruning never ran (zero production callers of [consolidate]).

--- a/test/dune
+++ b/test/dune
@@ -979,6 +979,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_cascade_trust_persist)
+ (modules test_cascade_trust_persist)
+ (libraries masc_test_deps))
+
+(test
  (name test_cascade_model_resolve)
  (modules test_cascade_model_resolve)
  (libraries masc_test_deps unix))

--- a/test/test_cascade_trust_persist.ml
+++ b/test/test_cascade_trust_persist.ml
@@ -1,0 +1,205 @@
+(** Unit tests for [Cascade_trust_persist].
+
+    Verifies the snapshot-to-JSONL contract without spinning a real
+    fiber: each test creates a temp base_path, mutates the global
+    [Cascade_health_tracker] via the public record_* API, calls
+    [snapshot_now], then re-reads the JSONL and asserts the shape.
+
+    Test isolation: tests share [Cascade_health_tracker.global], so
+    each test uses a unique [provider_key] prefix to avoid cross-talk.
+    [reset_for_testing ()] clears the persist module's store cache
+    between tests so each gets a fresh [Dated_jsonl.t]. *)
+
+open Alcotest
+module H = Masc_mcp.Cascade_health_tracker
+module P = Masc_mcp.Cascade_trust_persist
+
+let temp_base_path () =
+  let dir = Filename.temp_file "cascade-trust-persist-" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+(* [Dated_jsonl.append] uses [Eio.Mutex] internally, which requires the
+   [Cancel.Get_context] effect handler installed by [Eio_main.run].
+   Wrap each test in an Eio runtime so [snapshot_now] is callable.
+   Production callers spawn from within [Eio.Fiber.fork ~sw], so this
+   is a test-environment concern only. *)
+let with_temp_base f =
+  let dir = temp_base_path () in
+  P.reset_for_testing ();
+  Fun.protect
+    ~finally:(fun () ->
+      P.reset_for_testing ();
+      rm_rf dir)
+    (fun () -> Eio_main.run (fun _env -> f dir))
+
+let read_all_jsonl_in dir : Yojson.Safe.t list =
+  let cascade_dir = Filename.concat dir "cascade_trust" in
+  if not (Sys.file_exists cascade_dir) then []
+  else
+    let lines = ref [] in
+    let rec walk path =
+      if Sys.is_directory path then
+        Sys.readdir path
+        |> Array.iter (fun name -> walk (Filename.concat path name))
+      else if Filename.check_suffix path ".jsonl" then
+        let ic = open_in path in
+        Fun.protect
+          ~finally:(fun () -> close_in_noerr ic)
+          (fun () ->
+            try
+              while true do
+                lines := input_line ic :: !lines
+              done
+            with End_of_file -> ())
+    in
+    walk cascade_dir;
+    List.rev_map Yojson.Safe.from_string !lines
+
+let member key json = Yojson.Safe.Util.member key json
+
+let to_list_exn = function
+  | `List xs -> xs
+  | _ -> fail "expected JSON list"
+
+let to_string_exn = function
+  | `String s -> s
+  | _ -> fail "expected JSON string"
+
+(* ── Tests ─────────────────────────────────────── *)
+
+let test_snapshot_writes_jsonl_record () =
+  with_temp_base (fun dir ->
+    P.snapshot_now ~base_path:dir;
+    match read_all_jsonl_in dir with
+    | [] -> fail "snapshot_now produced no JSONL record"
+    | _ :: _ -> ())
+
+let test_snapshot_record_has_ts_and_providers () =
+  with_temp_base (fun dir ->
+    P.snapshot_now ~base_path:dir;
+    match read_all_jsonl_in dir with
+    | [] -> fail "no record"
+    | record :: _ ->
+      (match member "ts" record with
+       | `Float _ -> ()
+       | _ -> fail "ts must be float");
+      (match member "providers" record with
+       | `List _ -> ()
+       | _ -> fail "providers must be list"))
+
+let test_snapshot_includes_recorded_provider () =
+  with_temp_base (fun dir ->
+    let key = "test_persist_includes:" ^ string_of_int (Random.bits ()) in
+    H.record_failure H.global ~provider_key:key
+      ~error_kind:"failure" ~error_reason:"boom" ();
+    P.snapshot_now ~base_path:dir;
+    match read_all_jsonl_in dir with
+    | [] -> fail "no record"
+    | record :: _ ->
+      let providers = to_list_exn (member "providers" record) in
+      let found =
+        List.exists
+          (fun p ->
+            match member "provider_key" p with
+            | `String k -> String.equal k key
+            | _ -> false)
+          providers
+      in
+      check bool "recorded provider appears in snapshot" true found)
+
+let test_snapshot_provider_record_shape () =
+  with_temp_base (fun dir ->
+    let key = "test_persist_shape:" ^ string_of_int (Random.bits ()) in
+    H.record_failure H.global ~provider_key:key
+      ~error_kind:"timeout" ~error_reason:"deadline" ();
+    P.snapshot_now ~base_path:dir;
+    match read_all_jsonl_in dir with
+    | [] -> fail "no record"
+    | record :: _ ->
+      let providers = to_list_exn (member "providers" record) in
+      match
+        List.find_opt
+          (fun p ->
+            match member "provider_key" p with
+            | `String k -> String.equal k key
+            | _ -> false)
+          providers
+      with
+      | None -> fail "missing recorded provider"
+      | Some p ->
+        let required_fields =
+          [ "provider_key"
+          ; "success_rate"
+          ; "consecutive_failures"
+          ; "in_cooldown"
+          ; "events_in_window"
+          ; "rejected_in_window"
+          ; "top_fingerprints"
+          ; "last_failure_at"
+          ]
+        in
+        List.iter
+          (fun field ->
+            match member field p with
+            | `Null when field = "last_failure_at" -> ()
+            | `Null -> fail (Printf.sprintf "field %s missing" field)
+            | _ -> ())
+          required_fields;
+        let fps = to_list_exn (member "top_fingerprints" p) in
+        check bool "top_fingerprints non-empty after failure"
+          true (fps <> []);
+        match fps with
+        | first :: _ ->
+          let fp_str = to_string_exn (member "fingerprint" first) in
+          check bool "fingerprint kind prefix preserved"
+            true
+            (String.length fp_str >= String.length "timeout"
+             && String.sub fp_str 0 (String.length "timeout") = "timeout")
+        | [] -> fail "unreachable")
+
+let test_two_snapshots_produce_two_records () =
+  with_temp_base (fun dir ->
+    P.snapshot_now ~base_path:dir;
+    P.snapshot_now ~base_path:dir;
+    let records = read_all_jsonl_in dir in
+    check int "two snapshot calls → two JSONL records"
+      2 (List.length records))
+
+let test_snapshot_does_not_throw_on_empty_tracker () =
+  with_temp_base (fun dir ->
+    (* Brand-new tracker scope: even if global has data from earlier
+       tests, the call must not raise. *)
+    P.snapshot_now ~base_path:dir;
+    match read_all_jsonl_in dir with
+    | [] -> fail "expected at least one record"
+    | _ -> ())
+
+let () =
+  Random.self_init ();
+  run "cascade_trust_persist"
+    [ ( "snapshot"
+      , [ test_case "writes a JSONL record" `Quick
+            test_snapshot_writes_jsonl_record
+        ; test_case "record has ts + providers" `Quick
+            test_snapshot_record_has_ts_and_providers
+        ; test_case "recorded provider appears" `Quick
+            test_snapshot_includes_recorded_provider
+        ; test_case "provider record has expected shape" `Quick
+            test_snapshot_provider_record_shape
+        ; test_case "two calls → two records" `Quick
+            test_two_snapshots_produce_two_records
+        ; test_case "no throw on empty tracker" `Quick
+            test_snapshot_does_not_throw_on_empty_tracker
+        ] )
+    ]


### PR DESCRIPTION
**Stack**: based on #10292 (Phase 0a fingerprint counter). Will rebase to `main` once #10292 lands.

## Why

Phase 0a counters live in memory only — they reset on restart, and there is no cross-time view of how a provider's failure mix evolves. For Phase 1 (in-memory `trust_score`) calibration we need ~1 week of fleet data, which means disk persistence with date-split storage.

User insight driving this work: **\"안된 모델은 자꾸 안된다 (error, rate limit, etc..)\"** — failures are persistent, not random. Without time-series data we cannot quantify *how* persistent.

## Changes

### `lib/cascade/cascade_trust_persist.{ml,mli}` (new)

- `snapshot_now ~base_path`: pulls `Cascade_health_tracker.all_providers H.global`, serializes one JSON object `{ts, providers: [...]}` per call, appends to `base_path/cascade_trust/YYYY-MM/DD.jsonl` via `Dated_jsonl`.
- `start_snapshot_fiber ~sw ~clock ~base_path`: 1-min tick fiber + shutdown hook for one final snapshot.
- **Pull model** (no enqueue queue) — polling tracker is cheaper than backpressure plumbing.
- Best-effort: I/O failures are logged but never propagated.
- Env: `MASC_CASCADE_TRUST_SNAPSHOT_SEC` (default 60.0).

### `lib/dune`
Register `cascade_trust_persist` module.

### `lib/server/server_bootstrap_loops.ml`
Spawn snapshot fiber next to existing `Tool_metrics_persist.start_flush_fiber`.

## Test plan

- **6 alcotest cases** in `test/test_cascade_trust_persist.ml` (all 6/6 pass):
  - writes a JSONL record
  - record has `ts` + `providers` keys
  - recorded provider appears in snapshot
  - provider record exposes full shape (`top_fingerprints` + others)
  - two calls → two records
  - no throw on empty tracker
- Each test wrapped in `Eio_main.run` because `Dated_jsonl.append` uses `Eio.Mutex.use_rw` which needs the `Cancel.Get_context` effect handler. Production paths always run from `Eio.Fiber.fork ~sw` so this is a test-only concern (memory `feedback_eio-mutex-vs-stdlib`).
- `dune build @check` exit=0.

## Layering

`cascade_trust_persist` sits at the cascade layer alongside `cascade_health_tracker`; it does NOT depend on `dashboard_cascade` even though the JSON shape mirrors it. Dashboard depends on cascade, not the reverse — small duplication is the right trade-off vs cyclic deps.

## Storage volume

1 record/min × 1440 min/day × ~10 providers per snapshot ≈ 1440 records × ~2 KB / day ≈ **~3 MB/day**. Date-split + future `Dated_jsonl.prune` keeps growth bounded. No alert needed.

## Phase 1 (next, separate PR)

Consume these snapshots offline to derive reward / decay defaults for in-memory `trust_score = config_weight × clamp(trust, 0, 2.0)`. Persistent failure classification (same fingerprint × N within 30 min → `penalty_decay 0.7→0.3`) addresses the user observation that failed providers tend to keep failing.

## 안전 가드

Draft + `do-not-merge` label. Auto-merge off. Stack의 base가 `feat/cascade-trust-observability` (PR #10292) — #10292 머지 후 자동으로 `main` 기준으로 rebase 가능.

## Plan reference

`~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-s-binary-crown.md`