### PR TITLE
fix(keeper): expose accountability coverage gaps

### DIFF
--- a/lib/keeper/keeper_accountability.ml
+++ b/lib/keeper/keeper_accountability.ml
@@ -33,6 +33,11 @@ type claim_event = {
 
 type resolution_event = {
   claim_id : string;
+  agent_name : string option;
+  keeper_name : string option;
+  task_id : string option;
+  kind : claim_kind option;
+  subject : string option;
   status : claim_status;
   resolved_at : string;
   reason : string option;
@@ -147,6 +152,10 @@ let option_int_field key = function
   | Some value -> [ (key, `Int value) ]
   | None -> []
 
+let option_claim_kind_field key = function
+  | Some value -> [ (key, `String (claim_kind_to_string value)) ]
+  | None -> []
+
 let claim_event_to_json (event : claim_event) =
   `Assoc
     ([
@@ -175,6 +184,11 @@ let resolution_event_to_json (event : resolution_event) =
        ( "supporting_evidence_refs",
          `List (List.map (fun r -> `String r) event.supporting_evidence_refs) );
      ]
+    @ option_string_field "agent_name" event.agent_name
+    @ option_string_field "keeper_name" event.keeper_name
+    @ option_string_field "task_id" event.task_id
+    @ option_claim_kind_field "kind" event.kind
+    @ option_string_field "subject" event.subject
     @ option_string_field "reason" event.reason)
 
 let event_date_string ts =
@@ -183,6 +197,13 @@ let event_date_string ts =
     (tm.Unix.tm_year + 1900)
     (tm.Unix.tm_mon + 1)
     tm.Unix.tm_mday
+
+let iso8601_of_unix ts =
+  let tm = Unix.gmtime ts in
+  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+    (tm.Unix.tm_year + 1900)
+    (tm.Unix.tm_mon + 1)
+    tm.Unix.tm_mday tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
 
 let claim_event_of_json json =
   match json_string_opt "event_type" json with
@@ -229,6 +250,14 @@ let resolution_event_of_json json =
             Some
               {
                 claim_id;
+                agent_name = json_string_opt "agent_name" json;
+                keeper_name = json_string_opt "keeper_name" json;
+                task_id = json_string_opt "task_id" json;
+                kind =
+                  (match json_string_opt "kind" json with
+                  | Some value -> claim_kind_of_string value
+                  | None -> None);
+                subject = json_string_opt "subject" json;
                 status;
                 resolved_at;
                 reason = json_string_opt "reason" json;
@@ -246,6 +275,95 @@ let read_window_entries (config : Coord_query.config) =
   let since = event_date_string (now -. (float_of_int summary_window_days *. 86400.0)) in
   let until = event_date_string now in
   Dated_jsonl.read_range (get_store config) ~since ~until
+
+type decision_activity = {
+  decision_signal_count : int;
+  latest_decision_at : string option;
+  latest_decision_age_s : float option;
+}
+
+let decision_ts_unix_opt json =
+  let ts_unix = Safe_ops.json_float ~default:0.0 "ts_unix" json in
+  if ts_unix > 0.0 then Some ts_unix
+  else
+    match json_string_opt "ts" json with
+    | Some value -> Types_core.parse_iso8601_opt value
+    | None -> None
+
+let candidate_decision_keeper_names keeper_name =
+  let raw = String.trim keeper_name in
+  let canonical = normalize_keeper_name raw in
+  [ raw; canonical; "keeper-" ^ canonical ]
+  |> List.filter (fun value -> value <> "" && value <> "keeper-")
+  |> List.sort_uniq String.compare
+
+let keeper_decision_log_path (config : Coord_query.config) name =
+  let keepers_dir =
+    Filename.concat (Common.masc_dir_from_base_path ~base_path:config.base_path)
+      "keepers"
+  in
+  Filename.concat keepers_dir (name ^ ".decisions.jsonl")
+
+let read_file_tail_lines path ~max_bytes ~max_lines =
+  if max_lines <= 0 || not (Sys.file_exists path) || Sys.is_directory path then
+    []
+  else
+    try
+      let size =
+        match (Unix.stat path).Unix.st_size with
+        | size when size > 0 -> size
+        | _ -> 0
+      in
+      let start = max 0 (size - max_bytes) in
+      let ic = open_in_bin path in
+      Fun.protect
+        ~finally:(fun () -> close_in_noerr ic)
+        (fun () ->
+          seek_in ic start;
+          if start > 0 then (
+            match input_line ic with
+            | _partial_prefix -> ()
+            | exception End_of_file -> ());
+          let lines = ref [] in
+          (try
+             while true do
+               lines := input_line ic :: !lines
+             done
+           with End_of_file -> ());
+          !lines |> List.filteri (fun idx _ -> idx < max_lines) |> List.rev)
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | _ -> []
+
+let recent_decision_timestamps config ~keeper_name ~now =
+  let cutoff = now -. (float_of_int summary_window_days *. 86400.0) in
+  candidate_decision_keeper_names keeper_name
+  |> List.concat_map (fun candidate ->
+         let path = keeper_decision_log_path config candidate in
+         read_file_tail_lines path ~max_bytes:500000 ~max_lines:128)
+  |> List.filter_map (fun line ->
+         try Yojson.Safe.from_string line |> decision_ts_unix_opt
+         with
+         | Eio.Cancel.Cancelled _ as exn -> raise exn
+         | Yojson.Json_error _ -> None)
+  |> List.filter (fun ts -> ts >= cutoff && ts <= now +. 60.0)
+
+let decision_activity_for_keeper config ~keeper_name ~now =
+  let timestamps = recent_decision_timestamps config ~keeper_name ~now in
+  let latest =
+    List.fold_left
+      (fun acc ts ->
+        match acc with
+        | None -> Some ts
+        | Some prev -> Some (Float.max prev ts))
+      None timestamps
+  in
+  {
+    decision_signal_count = List.length timestamps;
+    latest_decision_at = Option.map iso8601_of_unix latest;
+    latest_decision_age_s =
+      Option.map (fun ts -> Float.max 0.0 (now -. ts)) latest;
+  }
 
 let materialize_claims jsons =
   let claims : (string, claim_snapshot) Hashtbl.t = Hashtbl.create 64 in
@@ -320,6 +438,21 @@ let append_claim (config : Coord_query.config) (event : claim_event) =
 let append_resolution (config : Coord_query.config) (event : resolution_event) =
   Dated_jsonl.append (get_store config) (resolution_event_to_json event)
 
+let resolution_for_claim ?(resolved_at = Types.now_iso ()) ?reason ~status
+    ~evidence_refs (claim : claim_event) =
+  {
+    claim_id = claim.claim_id;
+    agent_name = Some claim.agent_name;
+    keeper_name = Some claim.keeper_name;
+    task_id = claim.task_id;
+    kind = Some claim.kind;
+    subject = Some claim.subject;
+    status;
+    resolved_at;
+    reason;
+    supporting_evidence_refs = normalize_refs evidence_refs;
+  }
+
 let task_title_for_id (config : Coord_query.config) task_id =
   Coord_query.get_tasks_safe config
   |> List.find_opt (fun (task : Types.task) -> String.equal task.id task_id)
@@ -370,13 +503,7 @@ let resolve_recent_task_commitment config ~agent_name ~task_id ~status ~reason
   with
   | Some snapshot ->
       append_resolution config
-        {
-          claim_id = snapshot.claim.claim_id;
-          status;
-          resolved_at = Types.now_iso ();
-          reason;
-          supporting_evidence_refs = normalize_refs evidence_refs;
-        }
+        (resolution_for_claim snapshot.claim ~status ?reason ~evidence_refs)
   | None -> ()
 
 let maybe_support_recent_completion_claim config ~agent_name ~task_id ~evidence_refs =
@@ -392,20 +519,15 @@ let maybe_support_recent_completion_claim config ~agent_name ~task_id ~evidence_
   with
   | Some snapshot ->
       append_resolution config
-        {
-          claim_id = snapshot.claim.claim_id;
-          status = Supported;
-          resolved_at = Types.now_iso ();
-          reason = Some "task_done";
-          supporting_evidence_refs = normalize_refs evidence_refs;
-        }
+        (resolution_for_claim snapshot.claim ~status:Supported
+           ~reason:"task_done" ~evidence_refs)
   | None ->
       let created_at = Types.now_iso () in
       let claim_id =
         make_claim_id ~agent_name ~kind:Completion_claim ~subject:title
           ~task_id:(Some task_id) ~created_at
       in
-      append_claim config
+      let claim =
         {
           claim_id;
           agent_name;
@@ -419,15 +541,12 @@ let maybe_support_recent_completion_claim config ~agent_name ~task_id ~evidence_
           created_at;
           evidence_refs = normalize_refs evidence_refs;
           synthetic = true;
-        };
-      append_resolution config
-        {
-          claim_id;
-          status = Supported;
-          resolved_at = created_at;
-          reason = Some "task_done";
-          supporting_evidence_refs = normalize_refs evidence_refs;
         }
+      in
+      append_claim config claim;
+      append_resolution config
+        (resolution_for_claim claim ~resolved_at:created_at ~status:Supported
+           ~reason:"task_done" ~evidence_refs)
 
 (* #8605 family: exhaustive on [Types.task_action]. The previous
    string match silently no-oped for typos and any future transition
@@ -488,16 +607,16 @@ let record_completion_claim (config : Coord_query.config) ~keeper_name ~agent_na
         open_recent_claim ~now snapshots ~agent_name ~kind:Completion_claim
           ~subject ~task_id:normalized_task_id ~max_age_sec:dedupe_window_sec
       in
-      let claim_id =
+      let resolution_claim =
         match recent_existing with
-        | Some snapshot -> snapshot.claim.claim_id
+        | Some snapshot -> snapshot.claim
         | None ->
             let created_at = Types.now_iso () in
             let claim_id =
               make_claim_id ~agent_name ~kind:Completion_claim ~subject
                 ~task_id:normalized_task_id ~created_at
             in
-            append_claim config
+            let claim =
               {
                 claim_id;
                 agent_name;
@@ -511,20 +630,18 @@ let record_completion_claim (config : Coord_query.config) ~keeper_name ~agent_na
                 created_at;
                 evidence_refs = normalize_refs evidence_refs;
                 synthetic = false;
-              };
-            claim_id
+              }
+            in
+            append_claim config claim;
+            claim
       in
       if strong_evidence then
         append_resolution config
-          {
-            claim_id;
-            status = Supported;
-            resolved_at = Types.now_iso ();
-            reason = Some "same_turn_evidence";
-            supporting_evidence_refs =
-              supporting_refs_for_turn ~trace_id ~turn_number
-                strong_evidence_refs;
-          }
+          (resolution_for_claim resolution_claim ~status:Supported
+             ~reason:"same_turn_evidence"
+             ~evidence_refs:
+               (supporting_refs_for_turn ~trace_id ~turn_number
+                  strong_evidence_refs))
 
 let risk_band_of_metrics ~evidence_coverage ~unsupported_completion_rate
     ~open_overdue_commitments =
@@ -549,6 +666,8 @@ let summary_json_of_snapshots ~keeper_name ~agent_name ~now snapshots =
   let resolved_claims = ref 0 in
   let unsupported_completion_claims = ref 0 in
   let total_completion_claims = ref 0 in
+  let task_commitment_count = ref 0 in
+  let completion_claim_count = ref 0 in
   let open_overdue_commitments = ref 0 in
   let supported_task_commitments = ref 0 in
   let resolved_task_commitments = ref 0 in
@@ -560,6 +679,7 @@ let summary_json_of_snapshots ~keeper_name ~agent_name ~now snapshots =
       let created_unix = created_at_unix snapshot.claim in
       (match snapshot.claim.kind with
       | Task_commitment -> (
+          incr task_commitment_count;
           match status with
           | Supported ->
               incr supported_task_commitments;
@@ -570,6 +690,7 @@ let summary_json_of_snapshots ~keeper_name ~agent_name ~now snapshots =
           | Pending -> ()
           | Unsupported -> ())
       | Completion_claim ->
+          incr completion_claim_count;
           if status <> Pending && not snapshot.claim.synthetic then
             incr total_completion_claims;
           if status = Unsupported && not snapshot.claim.synthetic then
@@ -658,27 +779,91 @@ let summary_json_of_snapshots ~keeper_name ~agent_name ~now snapshots =
       ("unsupported_completion_rate", `Float unsupported_completion_rate);
       ("open_overdue_commitments", `Int !open_overdue_commitments);
       ("recent_supported_claims", `Int !recent_supported_claims);
+      ("accountability_claim_count", `Int (List.length snapshots));
+      ("task_commitment_count", `Int !task_commitment_count);
+      ("completion_claim_count", `Int !completion_claim_count);
       ("risk_band", `String risk_band);
       ("routing_hint", `String routing_hint);
       ("history", `List history);
     ]
 
-let source_label ~source ~keeper_name =
+let source_label ~source ~keeper_name ~coverage_gap =
   match source with
   | "direct_agent" -> "Direct runtime alias history"
   | "canonical_keeper_fallback" ->
       Printf.sprintf "Inherited from canonical identity: %s" keeper_name
+  | _ when coverage_gap ->
+      "No accountability history; recent decision activity exists"
   | _ -> "No accountability history"
 
-let with_accountability_source ~source ~keeper_name json =
+let with_accountability_source ~source ~keeper_name ~coverage_gap json =
   match json with
   | `Assoc fields ->
       `Assoc
         (fields
          @ [
              ("source", `String source);
-             ("source_label", `String (source_label ~source ~keeper_name));
+             ("source_label", `String (source_label ~source ~keeper_name ~coverage_gap));
            ])
+  | other -> other
+
+let assoc_replace key value fields =
+  let replaced = ref false in
+  let mapped =
+    List.map
+      (fun (field_key, field_value) ->
+        if String.equal field_key key then (
+          replaced := true;
+          (field_key, value))
+        else
+          (field_key, field_value))
+      fields
+  in
+  if !replaced then mapped else mapped @ [ (key, value) ]
+
+let with_accountability_coverage ~coverage_gap ~decision_activity json =
+  let coverage_health =
+    if coverage_gap then "coverage_gap"
+    else if decision_activity.decision_signal_count = 0 then
+      "no_recent_activity"
+    else
+      "ok"
+  in
+  let coverage_routing_hint =
+    if coverage_gap then "accountability_coverage_gap_review"
+    else "normal"
+  in
+  let coverage_fields =
+    [
+      ("coverage_health", `String coverage_health);
+      ("coverage_gap", `Bool coverage_gap);
+      ( "coverage_gap_reason",
+        if coverage_gap then
+          `String "recent_decisions_without_accountability_claims"
+        else
+          `Null );
+      ("decision_signal_count", `Int decision_activity.decision_signal_count);
+      ( "latest_decision_at",
+        match decision_activity.latest_decision_at with
+        | Some value -> `String value
+        | None -> `Null );
+      ( "latest_decision_age_s",
+        match decision_activity.latest_decision_age_s with
+        | Some value -> `Float value
+        | None -> `Null );
+      ("coverage_routing_hint", `String coverage_routing_hint);
+    ]
+  in
+  match json with
+  | `Assoc fields ->
+      let fields =
+        if coverage_gap then
+          assoc_replace "routing_hint"
+            (`String "accountability_coverage_gap_review") fields
+        else
+          fields
+      in
+      `Assoc (fields @ coverage_fields)
   | other -> other
 
 let accountability_summary_lookup (config : Coord_query.config) =
@@ -711,8 +896,17 @@ let accountability_summary_lookup (config : Coord_query.config) =
           | Some items -> ("canonical_keeper_fallback", items)
           | None -> ("none", []))
     in
+    let decision_activity =
+      decision_activity_for_keeper config ~keeper_name ~now
+    in
+    let coverage_gap =
+      String.equal source "none"
+      && snapshots = []
+      && decision_activity.decision_signal_count > 0
+    in
     summary_json_of_snapshots ~keeper_name ~agent_name ~now snapshots
-    |> with_accountability_source ~source ~keeper_name
+    |> with_accountability_source ~source ~keeper_name ~coverage_gap
+    |> with_accountability_coverage ~coverage_gap ~decision_activity
 
 let accountability_summary_json (config : Coord_query.config) ~keeper_name
     ~agent_name =

--- a/test/test_keeper_accountability.ml
+++ b/test/test_keeper_accountability.ml
@@ -93,6 +93,50 @@ let append_accountability_event base_dir ~created_at json =
 let string_member key json = Yojson.Safe.Util.(json |> member key |> to_string)
 let int_member key json = Yojson.Safe.Util.(json |> member key |> to_int)
 let float_member key json = Yojson.Safe.Util.(json |> member key |> to_float)
+let bool_member key json = Yojson.Safe.Util.(json |> member key |> to_bool)
+
+let string_member_opt key json =
+  match Yojson.Safe.Util.(json |> member key) with
+  | `String value -> Some value
+  | _ -> None
+
+let read_jsonl_file path =
+  if not (Sys.file_exists path) then []
+  else
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+        let rows = ref [] in
+        (try
+           while true do
+             let line = input_line ic in
+             if String.trim line <> "" then
+               try rows := Yojson.Safe.from_string line :: !rows
+               with Yojson.Json_error _ -> ()
+           done
+         with End_of_file -> ());
+        List.rev !rows)
+
+let read_accountability_events base_dir =
+  let root = Filename.concat base_dir ".masc/accountability" in
+  let rec gather path =
+    if not (Sys.file_exists path) then []
+    else if Sys.is_directory path then
+      Sys.readdir path
+      |> Array.to_list
+      |> List.concat_map (fun child -> gather (Filename.concat path child))
+    else if Filename.check_suffix path ".jsonl" then
+      read_jsonl_file path
+    else
+      []
+  in
+  gather root
+
+let append_decision_log_event config keeper_name json =
+  let path = Keeper_types.keeper_decision_log_path config keeper_name in
+  Fs_compat.mkdir_p (Filename.dirname path);
+  append_jsonl path json
 
 let test_same_turn_evidence_marks_claim_supported () =
   with_room (fun config ->
@@ -355,6 +399,69 @@ let test_task_transition_normalizes_keeper_name_in_history () =
       check string "history keeper_name is canonical" "sangsu"
         (string_member "keeper_name" first))
 
+let test_task_transition_resolution_rows_include_identity () =
+  with_room ~agent_name:"keeper-sangsu-agent" (fun config ->
+      Keeper_accountability.record_task_transition config
+        ~agent_name:"keeper-sangsu-agent" ~task_id:"task-resolution"
+        ~transition:Types.Claim ~details:(`Assoc []);
+      Keeper_accountability.record_task_transition config
+        ~agent_name:"keeper-sangsu-agent" ~task_id:"task-resolution"
+        ~transition:Types.Done_action ~details:(`Assoc []);
+      let resolution =
+        read_accountability_events config.base_path
+        |> List.find_opt (fun json ->
+               string_member_opt "event_type" json = Some "claim_resolved")
+      in
+      match resolution with
+      | None -> Alcotest.fail "expected claim_resolved row"
+      | Some row ->
+          check string "resolution agent_name" "keeper-sangsu-agent"
+            (string_member "agent_name" row);
+          check string "resolution keeper_name" "sangsu"
+            (string_member "keeper_name" row);
+          check string "resolution task_id" "task-resolution"
+            (string_member "task_id" row);
+          check string "resolution kind" "task_commitment"
+            (string_member "kind" row);
+          check string "resolution subject" "task-resolution"
+            (string_member "subject" row))
+
+let test_recent_decision_without_claim_exposes_coverage_gap () =
+  with_room ~agent_name:"keeper-sangsu-agent" (fun config ->
+      let now = Unix.gettimeofday () in
+      append_decision_log_event config "sangsu"
+        (`Assoc
+           [
+             ("id", `String "decision-active-no-accountability");
+             ("ts", `String (iso_of_unix now));
+             ("ts_unix", `Float now);
+             ("keeper_name", `String "sangsu");
+             ("agent_name", `String "keeper-sangsu-agent");
+             ("outcome", `String "success");
+             ("tools_used", `List [ `String "keeper_task_claim" ]);
+           ]);
+      let summary =
+        Keeper_accountability.accountability_summary_json config
+          ~keeper_name:"sangsu" ~agent_name:"keeper-sangsu-agent"
+      in
+      check string "summary source still no accountability history" "none"
+        (string_member "source" summary);
+      check string "coverage health" "coverage_gap"
+        (string_member "coverage_health" summary);
+      check bool "coverage gap" true (bool_member "coverage_gap" summary);
+      check string "coverage reason"
+        "recent_decisions_without_accountability_claims"
+        (string_member "coverage_gap_reason" summary);
+      check string "routing hint" "accountability_coverage_gap_review"
+        (string_member "routing_hint" summary);
+      check string "source label mentions decision activity"
+        "No accountability history; recent decision activity exists"
+        (string_member "source_label" summary);
+      check int "decision signal count" 1
+        (int_member "decision_signal_count" summary);
+      check int "claim count" 0
+        (int_member "accountability_claim_count" summary))
+
 let test_unmapped_alias_exposes_no_history_source () =
   with_room ~agent_name:"orphan-eager-viper" (fun config ->
       let summary =
@@ -366,6 +473,10 @@ let test_unmapped_alias_exposes_no_history_source () =
       check string "unmapped alias source label"
         "No accountability history"
         (string_member "source_label" summary);
+      check string "unmapped alias coverage health" "no_recent_activity"
+        (string_member "coverage_health" summary);
+      check bool "unmapped alias coverage gap" false
+        (bool_member "coverage_gap" summary);
       check string "unmapped alias risk remains low" "low"
         (string_member "risk_band" summary);
       let rep =
@@ -703,6 +814,10 @@ let () =
             test_direct_agent_history_exposes_direct_source;
           test_case "task transition canonicalizes keeper name in history"
             `Quick test_task_transition_normalizes_keeper_name_in_history;
+          test_case "task transition resolution rows include identity"
+            `Quick test_task_transition_resolution_rows_include_identity;
+          test_case "recent decision without claim exposes coverage gap"
+            `Quick test_recent_decision_without_claim_exposes_coverage_gap;
           test_case "unmapped alias exposes no-history source" `Quick
             test_unmapped_alias_exposes_no_history_source;
           test_case "claim tool exposes routing warning for high risk keeper"


### PR DESCRIPTION
## Summary
- add identity fields to accountability claim_resolved rows so raw ledger fleet distributions no longer bucket resolutions under null agent_name
- add accountability summary coverage fields that detect recent keeper decisions with zero accountability claims as coverage_gap instead of a silent low-risk empty state
- include claim-count and decision-signal counters in the summary for dashboard/API consumers

## Validation
- env DUNE_BUILD_DIR=_build_10314_accountability_gap3 DUNE_JOBS=2 DUNE_CACHE=disabled MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_keeper_accountability.exe
- env MASC_BASE_PATH=/tmp/masc-test-10314-accountability-gap-amended _build_10314_accountability_gap3/default/test/test_keeper_accountability.exe
- git diff --check origin/main..HEAD
- bash scripts/ci/check-silent-failure-patterns.sh
- bash scripts/ml_line_cap_audit.sh --baseline-ref origin/main --fail-on-regression
- bash scripts/ci/check-telemetry-coverage.sh

Fixes #10314