### PR TITLE
fix(cost): resolve auto model pricing status (#10318)

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -202,6 +202,9 @@ let record_tool_use_failure ~keeper_name ~tool_name =
 let empty_response_model_metric =
   "masc_after_turn_response_model_empty_total"
 
+let alias_response_model_metric =
+  "masc_after_turn_response_model_alias_total"
+
 let unknown_model_sentinel = "unknown_provider"
 
 let zero_usage : Oas.Types.api_usage =
@@ -220,6 +223,38 @@ let canonical_model_id_of_telemetry ~model
       String.trim id
   | _ -> model
 
+let known_provider_model_id_of_label model =
+  let trimmed = String.trim model in
+  match String.index_opt trimmed ':' with
+  | None -> None
+  | Some idx when idx <= 0 || idx >= String.length trimmed - 1 -> None
+  | Some idx ->
+      let provider = provider_of_model trimmed in
+      if String.equal provider "unknown" then None
+      else
+        Some
+          (String.sub trimmed (idx + 1) (String.length trimmed - idx - 1)
+           |> String.trim)
+
+let model_id_leaf model =
+  match known_provider_model_id_of_label model with
+  | Some id -> id
+  | None -> String.trim model
+
+let is_auto_model_label model =
+  String.equal
+    (String.lowercase_ascii (model_id_leaf model))
+    "auto"
+
+let canonical_model_id_opt
+    (telemetry : Oas.Types.inference_telemetry option) =
+  match telemetry with
+  | Some { canonical_model_id = Some id; _ } ->
+      let trimmed = String.trim id in
+      if trimmed = "" || is_auto_model_label trimmed then None
+      else Some trimmed
+  | Some _ | None -> None
+
 (* #10083: layered fallback for [response.model] empty-string leaks.
    Non-empty raw model is returned unchanged.  When empty, we consult
    the telemetry envelope's [canonical_model_id] (which OAS populates
@@ -232,11 +267,24 @@ let canonical_model_id_of_telemetry ~model
 let resolve_after_turn_model ~keeper_name
     ~(response : Oas.Types.api_response) =
   let raw_model = response.model in
-  if String.trim raw_model <> "" then raw_model
+  if String.trim raw_model <> "" then
+    match canonical_model_id_opt response.telemetry with
+    | Some canonical when is_auto_model_label raw_model ->
+        Prometheus.inc_counter alias_response_model_metric
+          ~labels:
+            [
+              ("keeper", keeper_name);
+              ("alias", model_id_leaf raw_model);
+              ("source", "telemetry_canonical");
+            ]
+          ();
+        Log.Keeper.warn
+          "keeper:%s after_turn response.model alias=%s → canonical=%s"
+          keeper_name raw_model canonical;
+        canonical
+    | Some _ | None -> raw_model
   else begin
-    let canonical =
-      canonical_model_id_of_telemetry ~model:"" response.telemetry
-    in
+    let canonical = canonical_model_id_of_telemetry ~model:"" response.telemetry in
     let resolved, source =
       if String.trim canonical <> "" then canonical, "telemetry_resolved"
       else unknown_model_sentinel, "unknown_sentinel"
@@ -301,7 +349,10 @@ let estimate_usage_cost_usd ~(model : string) (usage : Oas.Types.api_usage)
   | Some pricing ->
     Llm_provider.Pricing.estimate_cost ~pricing
       ~input_tokens:usage.input_tokens
-      ~output_tokens:usage.output_tokens ()
+      ~output_tokens:usage.output_tokens
+      ~cache_creation_input_tokens:usage.cache_creation_input_tokens
+      ~cache_read_input_tokens:usage.cache_read_input_tokens
+      ()
   | None ->
     Prometheus.inc_counter
       "masc_pricing_catalog_miss_total"
@@ -313,6 +364,83 @@ let estimate_usage_cost_usd ~(model : string) (usage : Oas.Types.api_usage)
        agent_sdk/llm_provider/pricing.ml, then bump the OAS pin."
       model usage.input_tokens usage.output_tokens;
     0.0
+
+type cost_status =
+  | Cost_reported_or_estimated
+  | Cost_known_free
+  | Cost_no_tokens
+  | Cost_usage_missing
+  | Cost_usage_untrusted
+  | Cost_provider_unknown
+  | Cost_unpriced_model
+
+let cost_status_to_string = function
+  | Cost_reported_or_estimated -> "priced"
+  | Cost_known_free -> "known_free"
+  | Cost_no_tokens -> "no_tokens"
+  | Cost_usage_missing -> "usage_missing"
+  | Cost_usage_untrusted -> "usage_untrusted"
+  | Cost_provider_unknown -> "provider_unknown"
+  | Cost_unpriced_model -> "unpriced_model"
+
+let cost_status_reason = function
+  | Cost_reported_or_estimated ->
+      "provider_reported_or_pricing_catalog_estimate"
+  | Cost_known_free -> "known_structurally_unmetered_or_zero_price"
+  | Cost_no_tokens -> "no_billable_tokens"
+  | Cost_usage_missing -> "usage_missing"
+  | Cost_usage_untrusted -> "usage_untrusted"
+  | Cost_provider_unknown -> "provider_unknown"
+  | Cost_unpriced_model -> "pricing_catalog_miss"
+
+let pricing_model_for_ledger ~model ~telemetry =
+  match canonical_model_id_opt telemetry with
+  | Some canonical when is_auto_model_label model -> canonical
+  | Some canonical when String.trim model = "" -> canonical
+  | Some canonical when String.equal (String.trim model) unknown_model_sentinel ->
+      canonical
+  | Some _ | None -> String.trim model
+
+let model_resolution_source_for_ledger ~model ~pricing_model =
+  let trimmed = String.trim model in
+  if String.equal trimmed pricing_model then "raw"
+  else if String.equal trimmed "" then "telemetry_canonical_empty"
+  else if is_auto_model_label trimmed then "telemetry_canonical_alias"
+  else if String.equal trimmed unknown_model_sentinel then
+    "telemetry_canonical_unknown"
+  else "raw"
+
+let pricing_catalog_status ~pricing_model =
+  match Llm_provider.Pricing.pricing_for_model_opt pricing_model with
+  | Some pricing
+    when pricing.input_per_million = 0.0
+         && pricing.output_per_million = 0.0 ->
+      "hit_free"
+  | Some _ -> "hit_paid"
+  | None -> "miss"
+
+let cost_status_for_event
+    ~(provider : string)
+    ~(pricing_model : string)
+    ~(usage_missing : bool)
+    ~(usage_trusted : bool)
+    ~(input_tokens : int)
+    ~(output_tokens : int)
+    ~(cost_usd : float) =
+  if usage_missing then Cost_usage_missing
+  else if not usage_trusted then Cost_usage_untrusted
+  else if input_tokens <= 0 && output_tokens <= 0 then Cost_no_tokens
+  else if cost_usd > 0.0 then Cost_reported_or_estimated
+  else if structurally_unmetered_provider provider then Cost_known_free
+  else if String.equal provider "unknown" then Cost_provider_unknown
+  else
+    match Llm_provider.Pricing.pricing_for_model_opt pricing_model with
+    | Some pricing
+      when pricing.input_per_million = 0.0
+           && pricing.output_per_million = 0.0 ->
+        Cost_known_free
+    | Some _ -> Cost_reported_or_estimated
+    | None -> Cost_unpriced_model
 
 let cost_usd_for_usage ?provider_kind ~(model : string)
     (usage : Oas.Types.api_usage)
@@ -469,6 +597,29 @@ let emit_cost_event
   let safe_input_tokens = if usage_trusted then input_tokens else 0 in
   let safe_output_tokens = if usage_trusted then output_tokens else 0 in
   let safe_cost_usd = if usage_trusted then cost_usd else 0.0 in
+  let provider = provider_of_model_with_telemetry ~model ~telemetry in
+  let pricing_model = pricing_model_for_ledger ~model ~telemetry in
+  let cost_status =
+    cost_status_for_event
+      ~provider
+      ~pricing_model
+      ~usage_missing
+      ~usage_trusted
+      ~input_tokens
+      ~output_tokens
+      ~cost_usd:safe_cost_usd
+  in
+  let cost_status_label = cost_status_to_string cost_status in
+  let cost_status_reason_label = cost_status_reason cost_status in
+  Prometheus.inc_counter
+    "masc_cost_ledger_status_total"
+    ~labels:
+      [
+        ("provider", provider);
+        ("status", cost_status_label);
+        ("reason", cost_status_reason_label);
+      ]
+    ();
   let raw_usage_fields =
     if usage_missing || usage_trusted then []
     else
@@ -501,12 +652,19 @@ let emit_cost_event
   let entry = `Assoc ([
     ("agent", `String agent_name);
     ("task_id", Json_util.string_opt_to_json task_id);
-    ( "provider",
-      `String (provider_of_model_with_telemetry ~model ~telemetry) );
+    ("provider", `String provider);
     ("model", `String model);
     ("input_tokens", `Int safe_input_tokens);
     ("output_tokens", `Int safe_output_tokens);
     ("cost_usd", `Float safe_cost_usd);
+    ("cost_status", `String cost_status_label);
+    ("cost_status_reason", `String cost_status_reason_label);
+    ("cost_pricing_model", `String pricing_model);
+    ( "cost_pricing_catalog",
+      `String (pricing_catalog_status ~pricing_model) );
+    ( "model_resolution_source",
+      `String
+        (model_resolution_source_for_ledger ~model ~pricing_model) );
     ("usage_missing", `Bool usage_missing);
     ("timestamp", `String (Types.now_iso ()));
     ("source", `String "auto_trajectory");

--- a/test/test_keeper_hooks_oas_pricing.ml
+++ b/test/test_keeper_hooks_oas_pricing.ml
@@ -43,6 +43,20 @@ let test_known_model_returns_nonzero_cost () =
     "sonnet-4-6 exact"
     4.5 cost
 
+let test_cache_tokens_use_provider_cache_rates () =
+  let usage =
+    mk_usage ~input:1_000_000 ~output:0
+      ~cache_creation:100_000 ~cache_read:200_000 ()
+  in
+  let cost = Hooks.estimate_usage_cost_usd
+    ~model:"claude-sonnet-4-6" usage
+  in
+  (* regular input 700k * $3/M + cache write 100k * $3/M * 1.25
+     + cache read 200k * $3/M * 0.1 = $2.535 *)
+  Alcotest.(check (float 0.001))
+    "cache tokens use Anthropic cache multipliers"
+    2.535 cost
+
 let test_unknown_model_emits_catalog_miss () =
   let sentinel_model = "pricing-test-unknown-xyz-2026-04-24" in
   let before = catalog_miss_for sentinel_model in
@@ -110,6 +124,8 @@ let () =
         [
           Alcotest.test_case "known model → non-zero cost"
             `Quick test_known_model_returns_nonzero_cost;
+          Alcotest.test_case "cache tokens use provider cache rates"
+            `Quick test_cache_tokens_use_provider_cache_rates;
           Alcotest.test_case "unknown model → catalog miss metric"
             `Quick test_unknown_model_emits_catalog_miss;
           Alcotest.test_case "repeated miss accumulates"

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -180,6 +180,68 @@ let test_emit_cost_event_marks_untrusted_usage () =
      | `Null -> true
      | _ -> false)
 
+let test_emit_cost_event_marks_unpriced_paid_model () =
+  let root = temp_dir () in
+  let telemetry : Agent_sdk.Types.inference_telemetry =
+    {
+      system_fingerprint = None;
+      timings = None;
+      reasoning_tokens = None;
+      request_latency_ms = 100;
+      peak_memory_gb = None;
+      provider_kind = Some Llm_provider.Provider_kind.OpenAI_compat;
+      reasoning_effort = None;
+      canonical_model_id = Some "future-openai-model-v9";
+      effective_context_window = Some 128000;
+      provider_internal_action_count = None;
+    }
+  in
+  Hooks.emit_cost_event ~masc_root:root ~agent_name:"keeper"
+    ~task_id:None ~model:"future-openai-model-v9"
+    ~input_tokens:1000 ~output_tokens:500 ~cost_usd:0.0
+    ~telemetry ();
+  let json = read_jsonl_line (Filename.concat root "costs.jsonl") in
+  check string "provider" "openai" (json |> member "provider" |> to_string);
+  check string "cost status" "unpriced_model"
+    (json |> member "cost_status" |> to_string);
+  check string "cost reason" "pricing_catalog_miss"
+    (json |> member "cost_status_reason" |> to_string);
+  check string "pricing model" "future-openai-model-v9"
+    (json |> member "cost_pricing_model" |> to_string);
+  check string "pricing catalog" "miss"
+    (json |> member "cost_pricing_catalog" |> to_string)
+
+let test_emit_cost_event_records_auto_resolution_source () =
+  let root = temp_dir () in
+  let telemetry : Agent_sdk.Types.inference_telemetry =
+    {
+      system_fingerprint = None;
+      timings = None;
+      reasoning_tokens = None;
+      request_latency_ms = 100;
+      peak_memory_gb = None;
+      provider_kind = Some Llm_provider.Provider_kind.OpenAI_compat;
+      reasoning_effort = None;
+      canonical_model_id = Some "gpt-4.1";
+      effective_context_window = Some 128000;
+      provider_internal_action_count = None;
+    }
+  in
+  Hooks.emit_cost_event ~masc_root:root ~agent_name:"keeper"
+    ~task_id:None ~model:"auto"
+    ~input_tokens:1000 ~output_tokens:500 ~cost_usd:0.01
+    ~telemetry ();
+  let json = read_jsonl_line (Filename.concat root "costs.jsonl") in
+  check string "provider" "openai" (json |> member "provider" |> to_string);
+  check string "pricing model" "gpt-4.1"
+    (json |> member "cost_pricing_model" |> to_string);
+  check string "model resolution source" "telemetry_canonical_alias"
+    (json |> member "model_resolution_source" |> to_string);
+  check string "pricing catalog" "hit_paid"
+    (json |> member "cost_pricing_catalog" |> to_string);
+  check string "cost status" "priced"
+    (json |> member "cost_status" |> to_string)
+
 let test_cost_usd_for_usage_falls_back_for_paid_provider () =
   let model = "openai:gpt-4.1" in
   let usage = make_usage ~input_tokens:1000 ~output_tokens:500 () in
@@ -447,6 +509,10 @@ let () =
             test_emit_cost_event_writes_wall_tok_s_without_provider_timings
         ; test_case "emit_cost_event marks untrusted usage" `Quick
             test_emit_cost_event_marks_untrusted_usage
+        ; test_case "emit_cost_event marks unpriced paid model" `Quick
+            test_emit_cost_event_marks_unpriced_paid_model
+        ; test_case "emit_cost_event records auto resolution source" `Quick
+            test_emit_cost_event_records_auto_resolution_source
         ; test_case "cost fallback estimates paid provider usage" `Quick
             test_cost_usd_for_usage_falls_back_for_paid_provider
         ; test_case "cost fallback preserves reported cost" `Quick

--- a/test/test_response_model_empty_10083.ml
+++ b/test/test_response_model_empty_10083.ml
@@ -26,11 +26,18 @@ module Hooks = Masc_mcp.Keeper_hooks_oas
 module Prom = Masc_mcp.Prometheus
 
 let metric_name = Hooks.empty_response_model_metric
+let alias_metric_name = Hooks.alias_response_model_metric
 
 let counter_for ~keeper ~source =
   Prom.metric_value_or_zero
     metric_name
     ~labels:[ ("keeper", keeper); ("source", source) ]
+    ()
+
+let alias_counter_for ~keeper ~alias ~source =
+  Prom.metric_value_or_zero
+    alias_metric_name
+    ~labels:[ ("keeper", keeper); ("alias", alias); ("source", source) ]
     ()
 
 let make_zero_usage : Agent_sdk.Types.api_usage =
@@ -141,6 +148,24 @@ let test_empty_canonical_id_falls_through_to_sentinel () =
     before_telemetry
     (counter_for ~keeper ~source:"telemetry_resolved")
 
+(* Raw model [auto] is non-empty, but it is not a billable model ID.
+   When OAS supplies [canonical_model_id], use that for downstream
+   metrics and pricing attribution instead of poisoning costs.jsonl with
+   model="auto". *)
+let test_auto_raw_falls_back_to_canonical_model_id () =
+  let keeper = "test-keeper-auto-canonical-10318" in
+  let before =
+    alias_counter_for ~keeper ~alias:"auto" ~source:"telemetry_canonical"
+  in
+  let telemetry = make_telemetry ~canonical_model_id:"gpt-4.1" () in
+  let response = make_response ~model:"auto" ~telemetry () in
+  let resolved = Hooks.resolve_after_turn_model ~keeper_name:keeper ~response in
+  Alcotest.(check string) "auto resolved to canonical" "gpt-4.1" resolved;
+  Alcotest.(check (float 0.0001))
+    "alias fallback counter +1"
+    (before +. 1.0)
+    (alias_counter_for ~keeper ~alias:"auto" ~source:"telemetry_canonical")
+
 let () =
   Alcotest.run "response_model_empty_10083"
     [
@@ -154,5 +179,7 @@ let () =
             test_empty_everywhere_uses_sentinel;
           Alcotest.test_case "empty canonical_model_id falls through" `Quick
             test_empty_canonical_id_falls_through_to_sentinel;
+          Alcotest.test_case "raw auto -> telemetry canonical" `Quick
+            test_auto_raw_falls_back_to_canonical_model_id;
         ] );
     ]


### PR DESCRIPTION
## Summary
- resolve response.model=auto through OAS canonical_model_id before keeper cost attribution
- include cache token multipliers in fallback pricing estimates
- add additive costs.jsonl status fields so 0 USD is classified as priced, known_free, unpriced_model, provider_unknown, usage_missing, usage_untrusted, or no_tokens
- emit masc_cost_ledger_status_total and alias fallback metrics for operator validation

## Verification
- git diff --check
- env MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=2 DUNE_CACHE=disabled DUNE_BUILD_DIR=/tmp/masc-10318-build scripts/dune-local.sh build --cache=disabled test/test_keeper_hooks_oas_pricing.exe test/test_keeper_hooks_oas_telemetry.exe test/test_response_model_empty_10083.exe
- /tmp/masc-10318-build/default/test/test_keeper_hooks_oas_pricing.exe
- /tmp/masc-10318-build/default/test/test_keeper_hooks_oas_telemetry.exe
- /tmp/masc-10318-build/default/test/test_response_model_empty_10083.exe
- env MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=2 DUNE_CACHE=disabled DUNE_BUILD_DIR=/tmp/masc-10318-build scripts/dune-local.sh build --cache=disabled test/test_model_inference_metrics.exe
- /tmp/masc-10318-build/default/test/test_model_inference_metrics.exe