### PR TITLE
perf(verification,tool-library): drop per-call Re.compile from substring helpers

### DIFF
--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -8,6 +8,16 @@
 
 open Printf
 
+(* Static frontmatter patterns used during candidate promotion.
+   Hoisted to module load — promotion is rare relative to keeper
+   message paths but the patterns are pure literals, so there is no
+   reason to rebuild them per call. *)
+let promote_confidence_re =
+  Re.Pcre.re {|confidence: [0-9.]+|} |> Re.compile
+
+let promote_verified_by_re =
+  Re.Pcre.re {|verified_by: \[\]|} |> Re.compile
+
 (** Confidence threshold for routing documents to library vs candidates. *)
 let library_confidence_threshold = 0.5
 
@@ -276,16 +286,16 @@ let handle_promote ctx args =
     | src_path :: _ ->
         try
           let content = In_channel.with_open_text src_path In_channel.input_all in
-          (* Update confidence in frontmatter *)
-          let updated = Re.replace_string
-            (Re.Pcre.re {|confidence: [0-9.]+|} |> Re.compile)
-            ~by:(sprintf "confidence: %.2f" new_confidence)
-            content in
-          (* Add verifier *)
-          let with_verifier = Re.replace_string
-            (Re.Pcre.re {|verified_by: \[\]|} |> Re.compile)
-            ~by:(sprintf "verified_by: [%s]" ctx.agent_name)
-            updated in
+          let updated =
+            Re.replace_string promote_confidence_re
+              ~by:(sprintf "confidence: %.2f" new_confidence)
+              content
+          in
+          let with_verifier =
+            Re.replace_string promote_verified_by_re
+              ~by:(sprintf "verified_by: [%s]" ctx.agent_name)
+              updated
+          in
           (* Move to library *)
           let dest_path = Filename.concat (library_root ()) (Filename.basename src_path) in
           Out_channel.with_open_text dest_path (fun oc -> Out_channel.output_string oc with_verifier);

--- a/lib/verification.ml
+++ b/lib/verification.ml
@@ -209,27 +209,51 @@ let request_of_yojson = function
 let generate_id () =
   Random_id.prefixed ~prefix:"vrf-" ~bytes:16
 
+(* Byte-wise substring containment.
+
+   [Contains]/[Not_contains] criteria interpolate user-supplied needles,
+   so [Re.compile] cannot be hoisted.  But these are pure substring
+   checks with no regex semantics — every criterion evaluation
+   previously paid a fresh DFA build before [execp] could run.  Replace
+   with a naive scan; needle/haystack are bounded by criterion shape
+   and serialised JSON output so there is no DFA gain to lose. *)
+let needle_in_string ~needle haystack =
+  let nlen = String.length needle in
+  let hlen = String.length haystack in
+  if nlen = 0 then true
+  else if nlen > hlen then false
+  else
+    let rec match_at i j =
+      if j = nlen then true
+      else if String.unsafe_get haystack (i + j) <> String.unsafe_get needle j
+      then false
+      else match_at i (j + 1)
+    in
+    let last = hlen - nlen in
+    let rec loop i =
+      if i > last then false
+      else if match_at i 0 then true
+      else loop (i + 1)
+    in
+    loop 0
+
 (** Automated criterion evaluation *)
 let evaluate_criterion output criterion =
   let output_str = Yojson.Safe.to_string output in
   match criterion with
   | Schema_match _schema ->
-      (* Schema matching: check if output is valid JSON matching expected structure *)
       (match output with
        | `Null -> Fail "output is null"
-       | _ -> Pass)  (* Basic check; full JSON schema validation could be added *)
+       | _ -> Pass)
   | Contains needle ->
-      if String.length needle > 0 &&
-        Re.execp (Re.str needle |> Re.compile) output_str
+      if String.length needle > 0 && needle_in_string ~needle output_str
       then Pass
       else Fail (Printf.sprintf "output does not contain '%s'" needle)
   | Not_contains needle ->
-      if String.length needle > 0 &&
-        Re.execp (Re.str needle |> Re.compile) output_str
+      if String.length needle > 0 && needle_in_string ~needle output_str
       then Fail (Printf.sprintf "output contains forbidden '%s'" needle)
       else Pass
   | Custom _ ->
-      (* Custom criteria require human/MODEL verifier judgment *)
       Partial (0.5, "custom criterion requires verifier judgment")
 
 (** Evaluate all criteria, return aggregate verdict *)


### PR DESCRIPTION
## Summary

Two more substring-only paths still rebuilt regex DFAs on every call.

### `Verification.evaluate_criterion`

```ocaml
(* before *)
| Contains needle ->
    if String.length needle > 0 &&
      Re.execp (Re.str needle |> Re.compile) output_str
    then Pass
    else Fail (...)
| Not_contains needle ->
    if String.length needle > 0 &&
      Re.execp (Re.str needle |> Re.compile) output_str
    then Fail (...)
    else Pass
```

`Contains`/`Not_contains` interpolate user-supplied needles, so `Re.compile` could not be hoisted. But the criterion is a pure substring check with no regex semantics. Replaced with `needle_in_string`, a byte-wise scan using `String.unsafe_get` with empty-needle `true` and `nlen > hlen` short-circuits. Every criterion evaluation now skips DFA construction entirely.

### `Tool_library.promote_to_library`

```ocaml
(* before *)
let updated = Re.replace_string
  (Re.Pcre.re {|confidence: [0-9.]+|} |> Re.compile) ~by:... content in
let with_verifier = Re.replace_string
  (Re.Pcre.re {|verified_by: \[\]|} |> Re.compile) ~by:... updated in
```

Two static frontmatter patterns rebuilt per promotion. Promotion is rare relative to keeper message paths, but the patterns are pure literals — hoisted to `promote_confidence_re` / `promote_verified_by_re` at module load.

Same anti-pattern series:
- #10250 / #10252: `Mention` (merged)
- #10260: `Coord_gc.mentions_open_task` (merged)
- #10267: `Mcp_server_eio_call_tool.contains_casefold` (merged)
- #10286: dashboard helpers (merged)
- #10301: `Bounded` + `Auto_recall` (merged)
- #10303: `Masc_error_recovery` + `Coord_git` (merged)
- #10315: `Prompt_registry.render_template` (merged)
- #10323: link preview module hoist (merged)
- #10324: `Safe_path` + `validate_room_id` (in-flight)
- This PR: `Verification` + `Tool_library`

## Test plan
- [x] `dune build @check` clean
- Behavior preserved:
  - `Verification.needle_in_string`: empty-needle `true`, `nlen>hlen` `false`, byte equality identical to `Re.execp (Re.str needle)`.
  - `Tool_library` promotions: same patterns, same `replace_string` order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)