### PR TITLE
fix(dashboard): refresh drift baseline (#10326)

### DIFF
--- a/scripts/dashboard-drift-baseline.json
+++ b/scripts/dashboard-drift-baseline.json
@@ -1,11 +1,12 @@
 {
   "_comment": "Dashboard styling-drift baseline. Regenerate with scripts/dashboard-drift-check.sh --regenerate.",
   "_patterns": "See scripts/dashboard-drift-check.sh PATTERNS array.",
-  "bg-white-alpha": 49,
-  "border-white-alpha": 18,
+  "bg-white-alpha": 74,
+  "border-white-alpha": 29,
   "text-zinc": 0,
   "bg-zinc": 0,
   "border-zinc": 0,
-  "rounded-px-literal": 11,
-  "text-9px": 0
+  "rounded-px-literal": 15,
+  "text-9px": 0,
+  "text-px-literal": 20
 }


### PR DESCRIPTION
## Summary
- refresh the dashboard drift baseline to match current origin/main counts
- add the missing text-px-literal ratchet entry so current main no longer defaults it to 0

## Verification
- bash scripts/dashboard-drift-check.sh
- bash scripts/dashboard-drift-check.sh --print
- git diff --check

Closes #10326