### PR TITLE
Add Phase 3 code IDE design-system components

### DIFF
--- a/dashboard/design-system/preview/cb-group-j.jsx
+++ b/dashboard/design-system/preview/cb-group-j.jsx
@@ -1,0 +1,446 @@
+// preview/cb-group-j.jsx
+// Phase 3 · Code IDE v2 seed data + E1/E2 surfaces.
+
+window.MASC_P3 = (function () {
+  const keepers = [
+    { id: "nick0cave", initials: "NC", role: "captain", color: "var(--brass-1)" },
+    { id: "masc-improver", initials: "MI", role: "improver", color: "var(--ok)" },
+    { id: "sangsu", initials: "SG", role: "analyst", color: "var(--info)" },
+    { id: "qa-king", initials: "QA", role: "qa", color: "var(--err)" },
+    { id: "rama", initials: "RA", role: "research", color: "var(--stalled)" },
+  ];
+
+  const files = [
+    { path: "lib/keeper/keeper_runtime_trust_snapshot.ml", kind: "file", ext: ".ml", owners: ["nick0cave", "sangsu"], status: "modified", adds: 18, dels: 4, recent: true, pinned: true, touched: "2m", branch: "main" },
+    { path: "lib/dashboard/dashboard_fleet_fsm.ml", kind: "file", ext: ".ml", owners: ["masc-improver"], status: "modified", adds: 42, dels: 9, recent: true, pinned: false, touched: "8m", branch: "main" },
+    { path: "dashboard/src/components/FleetFSMPanel.tsx", kind: "file", ext: ".tsx", owners: ["sangsu", "masc-improver"], status: "added", adds: 126, dels: 0, recent: true, pinned: true, touched: "11m", branch: "feat/keeper-clarity" },
+    { path: "dashboard/src/styles/mission.css", kind: "file", ext: ".css", owners: ["qa-king"], status: "modified", adds: 17, dels: 12, recent: false, pinned: false, touched: "24m", branch: "fix/dashboard-9712" },
+    { path: "docs/COMMAND-PLANE-RUNBOOK.md", kind: "file", ext: ".md", owners: ["nick0cave", "rama", "sangsu"], status: "modified", adds: 31, dels: 8, recent: true, pinned: false, touched: "27m", branch: "main" },
+    { path: "scripts/harness_trpg_agent_env.sh", kind: "file", ext: ".sh", owners: ["qa-king"], status: "deleted", adds: 0, dels: 77, recent: false, pinned: false, touched: "41m", branch: "wt/sangsu-smoke" },
+    { path: "test/test_goal_fsm.ml", kind: "file", ext: ".ml", owners: ["qa-king", "sangsu"], status: "modified", adds: 64, dels: 21, recent: true, pinned: true, touched: "53m", branch: "main" },
+    { path: "memory/handoff-2026-04-25-fsm.md", kind: "file", ext: ".md", owners: ["rama"], status: "added", adds: 22, dels: 0, recent: false, pinned: false, touched: "1h", branch: "ar-93ff2489" },
+    { path: ".github/workflows/ci.yml", kind: "file", ext: ".yml", owners: ["nick0cave", "qa-king"], status: "modified", adds: 9, dels: 3, recent: false, pinned: false, touched: "2h", branch: "main" },
+    { path: "lib/cascade/cascade_profile.ml", kind: "file", ext: ".ml", owners: ["sangsu", "rama"], status: "unchanged", adds: 0, dels: 0, recent: false, pinned: false, touched: "3h", branch: "ar-aadab70d" },
+  ];
+
+  const editorLines = [
+    { n: 181, keeper: "sangsu", hash: "51f062", age: "2m", text: "let runtime_cause snapshot =", tokens: [["tok-key", "let"], ["", " runtime_cause snapshot ="]] },
+    { n: 182, keeper: "sangsu", hash: "51f062", age: "2m", text: "  match snapshot.fsm_signal with", tokens: [["tok-key", "  match"], ["", " snapshot."], ["tok-prop", "fsm_signal"], ["tok-key", " with"]] },
+    { n: 183, keeper: "nick0cave", hash: "da11b0", age: "7m", text: "  | Loaded { stale_for_sec; source } when stale_for_sec > 420 ->", tokens: [["", "  | "], ["tok-fn", "Loaded"], ["", " { stale_for_sec; source } "], ["tok-key", "when"], ["", " stale_for_sec > "], ["tok-str", "420"], ["", " ->"]] },
+    { n: 184, keeper: "nick0cave", hash: "da11b0", age: "7m", text: "      Runtime_stall { source; stale_for_sec }", tokens: [["", "      "], ["tok-fn", "Runtime_stall"], ["", " { source; stale_for_sec }"]] },
+    { n: 185, keeper: "masc-improver", hash: "918fd2", age: "18m", text: "  | Blocked reason -> Operator_visible_blocker reason", tokens: [["", "  | "], ["tok-fn", "Blocked"], ["", " reason -> "], ["tok-fn", "Operator_visible_blocker"], ["", " reason"]] },
+    { n: 186, keeper: "qa-king", hash: "f20b81", age: "31m", text: "  | Running -> No_issue", tokens: [["", "  | "], ["tok-fn", "Running"], ["", " -> "], ["tok-fn", "No_issue"]] },
+    { n: 187, keeper: "sangsu", hash: "51f062", age: "2m", text: "  | Missing -> Missing_runtime_signal", tokens: [["", "  | "], ["tok-fn", "Missing"], ["", " -> "], ["tok-fn", "Missing_runtime_signal"]] },
+    { n: 188, keeper: "rama", hash: "44a1b9", age: "1h", text: "  | Unknown raw -> Unknown_runtime_state raw", tokens: [["", "  | "], ["tok-fn", "Unknown"], ["", " raw -> "], ["tok-fn", "Unknown_runtime_state"], ["", " raw"]] },
+    { n: 189, keeper: "masc-improver", hash: "918fd2", age: "18m", text: "", tokens: [["", ""]] },
+    { n: 190, keeper: "nick0cave", hash: "da11b0", age: "7m", text: "let render_receipt cause =", tokens: [["tok-key", "let"], ["", " "], ["tok-fn", "render_receipt"], ["", " cause ="]] },
+    { n: 191, keeper: "nick0cave", hash: "da11b0", age: "7m", text: "  Receipt.with_signal ~kind:\"fleet_fsm\" cause", tokens: [["", "  "], ["tok-fn", "Receipt.with_signal"], ["", " ~kind:"], ["tok-str", "\"fleet_fsm\""], ["", " cause"]] },
+    { n: 192, keeper: "qa-king", hash: "f20b81", age: "31m", text: "  |> Receipt.assert_operator_visible", tokens: [["", "  |> "], ["tok-fn", "Receipt.assert_operator_visible"]] },
+  ];
+
+  const splitLines = [
+    { n: 18, text: "export function FleetFSMPanel({ snapshot }) {" },
+    { n: 19, text: "  const cause = snapshot.runtime_cause" },
+    { n: 20, text: "  return <RuntimeCause cause={cause} />" },
+    { n: 21, text: "}" },
+  ];
+
+  const mergeHunks = [
+    { id: "h1", file: "dashboard/src/store.ts", line: 442, ours: "dashboardLoading.value = false", theirs: "runtimeTruthLoading.value = false", base: "loading.value = false" },
+    { id: "h2", file: "lib/dashboard/dashboard_fleet_fsm.ml", line: 187, ours: "| Missing -> Missing_runtime_signal", theirs: "| Missing -> Runtime_stall { source = \"fsm\"; stale_for_sec = 0 }", base: "| Missing -> Unknown" },
+    { id: "h3", file: "docs/COMMAND-PLANE-RUNBOOK.md", line: 91, ours: "Fleet FSM stalls are surfaced in the cockpit.", theirs: "Fleet FSM stalls are operator-visible receipts.", base: "Fleet FSM stalls are logged." },
+  ];
+
+  const reviewThreads = [
+    { id: "r1", line: 183, keeper: "qa-king", verdict: "flag", body: "stale_for_sec threshold needs test coverage", replies: 2 },
+    { id: "r2", line: 187, keeper: "sangsu", verdict: "approve", body: "Missing state now has explicit runtime cause", replies: 1 },
+    { id: "r3", line: 191, keeper: "masc-improver", verdict: "defer", body: "receipt kind should stay aligned with dashboard schema", replies: 0 },
+  ];
+
+  const pr = {
+    number: 10310,
+    title: "fix(dashboard): surface fleet FSM runtime causes",
+    state: "open",
+    source: "codex/fleet-fsm-runtime-cause",
+    base: "main",
+    author: "nick0cave",
+    labels: ["dashboard", "runtime-trust", "human-approved-ready"],
+    reviewers: [
+      { name: "sangsu", status: "approved" },
+      { name: "qa-king", status: "changes" },
+      { name: "masc-improver", status: "requested" },
+      { name: "rama", status: "approved" },
+      { name: "velvet-hammer", status: "flagged" },
+    ],
+    checks: [
+      { name: "SafeAuto", status: "fail", duration: "41s", details: ["runtime cause evidence lacks source path", "one stale FSM fixture missing timestamp", "review thread unresolved at L183"] },
+      { name: "keeper-test-suite", status: "pass", duration: "8m 22s" },
+      { name: "merge-blocker tests", status: "pass", duration: "3m 18s" },
+      { name: "cascade-replay", status: "running", duration: "1m 04s" },
+      { name: "type-check", status: "pass", duration: "2m 11s" },
+      { name: "lint", status: "pass", duration: "46s" },
+    ],
+  };
+
+  const prFiles = [
+    { path: "lib/dashboard/dashboard_fleet_fsm.ml", status: "modified", adds: 42, dels: 9, review: "approved", expanded: true },
+    { path: "dashboard/src/components/FleetFSMPanel.tsx", status: "added", adds: 126, dels: 0, review: "viewed" },
+    { path: "dashboard/src/store.ts", status: "modified", adds: 17, dels: 4, review: "needed" },
+    { path: "docs/COMMAND-PLANE-RUNBOOK.md", status: "modified", adds: 31, dels: 8, review: "none" },
+    { path: "scripts/fleet-fsm-fixture.sh", status: "renamed", adds: 8, dels: 3, review: "viewed" },
+    { path: "test/test_dashboard_fsm.ml", status: "deleted", adds: 0, dels: 77, review: "needed" },
+  ];
+
+  const comments = [
+    { by: "qa-king", at: "9m", verdict: "flag", body: "L183 threshold changed without negative fixture. Add one stale snapshot with source path." },
+    { by: "nick0cave", at: "7m", verdict: "reply", body: "Fixture added locally. Keeping threshold as runtime-trust default." },
+    { by: "sangsu", at: "3m", verdict: "approve", body: "Data lineage is now explicit enough for cockpit display.", nested: true },
+  ];
+
+  const commits = [
+    { hash: "1014c9", keeper: "nick0cave", branch: "main", subject: "fix(dashboard): surface fleet FSM runtime causes", age: "2m", adds: 112, dels: 21 },
+    { hash: "7afa7d", keeper: "masc-improver", branch: "feat/keeper-clarity", subject: "refactor keeper claim decision tree", age: "14m", adds: 88, dels: 43 },
+    { hash: "e45f2e", keeper: "sangsu", branch: "feat/oas-error-cascade-name-label-10285", subject: "label cascade mismatch errors", age: "24m", adds: 31, dels: 6 },
+    { hash: "35e89b", keeper: "rama", branch: "diag/personality-resync-fields-10269", subject: "trace resync fields through keeper manifest", age: "38m", adds: 42, dels: 10 },
+    { hash: "717da6", keeper: "qa-king", branch: "feat/auth-rotate-shared-tokens-10304", subject: "add auth rotation regression case", age: "41m", adds: 53, dels: 18 },
+    { hash: "5c89fb", keeper: "sangsu", branch: "codex/git-access-risk-policy-20260424", subject: "tighten git access risk policy", age: "1h", adds: 21, dels: 8 },
+    { hash: "1c5fb3", keeper: "masc-improver", branch: "chore/tool-access-policy-immutable-dedupe", subject: "dedupe immutable tool access policy", age: "2h", adds: 64, dels: 55 },
+    { hash: "b61067", keeper: "nick0cave", branch: "feat/cascade-trust-observability", subject: "surface cascade trust receipts", age: "2h", adds: 119, dels: 44 },
+    { hash: "c5ad9c", keeper: "qa-king", branch: "auto-provision-sandbox", subject: "sandbox provisioning smoke", age: "3h", adds: 27, dels: 12 },
+    { hash: "44a1b9", keeper: "rama", branch: "ar-93ff2489", subject: "record autoresearch cascade conclusion", age: "4h", adds: 18, dels: 2 },
+    { hash: "918fd2", keeper: "masc-improver", branch: "feat/keeper-clarity", subject: "split invocation from candidacy scoring", age: "4h", adds: 80, dels: 34 },
+    { hash: "da11b0", keeper: "nick0cave", branch: "main", subject: "merge PR 9712 follow-up", age: "5h", adds: 12, dels: 1 },
+  ];
+
+  const worktrees = [
+    { path: ".worktrees/design-system-phase3-ide-v2", branch: "codex/design-system-phase3-ide-v2", keepers: ["nick0cave", "sangsu"], status: "dirty", touched: "now" },
+    { path: ".worktrees/feat/oas-error-cascade-name-label-10285", branch: "feat/oas-error-cascade-name-label-10285", keepers: ["sangsu"], status: "clean", touched: "24m" },
+    { path: ".worktrees/worktree-sangsu-smoke", branch: "wt/sangsu-smoke", keepers: ["sangsu", "qa-king"], status: "dirty", touched: "53m" },
+    { path: ".worktrees/ar-93ff2489", branch: "ar-93ff2489", keepers: ["rama"], status: "stale", touched: "4h" },
+  ];
+
+  const stashes = [
+    { id: "stash@{0}", branch: "feat/keeper-clarity", keeper: "masc-improver", summary: "WIP keeper.claim() split", age: "18m", files: 4, adds: 44, dels: 19 },
+    { id: "stash@{1}", branch: "wt/sangsu-smoke", keeper: "sangsu", summary: "debug cascade auth payload", age: "1h", files: 7, adds: 72, dels: 12 },
+    { id: "stash@{2}", branch: "fix/dashboard-9712", keeper: "nick0cave", summary: "temporary dashboard fixture", age: "3h", files: 2, adds: 18, dels: 4 },
+    { id: "stash@{3}", branch: "ar-93ff2489", keeper: "rama", summary: "research note + trace digest", age: "6h", files: 3, adds: 29, dels: 0 },
+  ];
+
+  const searchResults = [
+    { file: "lib/dashboard/dashboard_fleet_fsm.ml", line: 187, text: "| Missing -> Missing_runtime_signal", ext: ".ml" },
+    { file: "dashboard/src/components/FleetFSMPanel.tsx", line: 42, text: "const cause = snapshot.runtime_cause", ext: ".tsx" },
+    { file: "dashboard/src/store.ts", line: 442, text: "runtimeTruthLoading.value = false", ext: ".ts" },
+    { file: "docs/COMMAND-PLANE-RUNBOOK.md", line: 91, text: "Fleet FSM stalls are operator-visible receipts.", ext: ".md" },
+    { file: "test/test_goal_fsm.ml", line: 63, text: "assert_runtime_cause Missing_runtime_signal", ext: ".ml" },
+    { file: "scripts/harness_dashboard_execution_smoke.sh", line: 210, text: "assert_json_has runtime_cause", ext: ".sh" },
+  ];
+
+  return {
+    keepers, files, editorLines, splitLines, mergeHunks, reviewThreads,
+    pr, prFiles, comments, commits, worktrees, stashes, searchResults,
+  };
+})();
+
+const P3J = window.MASC_P3;
+
+function p3Keeper(id) {
+  return P3J.keepers.find(k => k.id === id) || P3J.keepers[0];
+}
+
+function p3KeeperIds(keepers) {
+  if (!keepers) return P3J.keepers.map(k => k.id);
+  if (keepers instanceof Set) return Array.from(keepers);
+  if (Array.isArray(keepers)) return keepers;
+  return [keepers].filter(Boolean);
+}
+
+function P3Header({ title, meta, right }) {
+  return (
+    <div className="ix-head">
+      <span className="ix-head-title">{title}</span>
+      <span className="ix-head-meta">{meta}</span>
+      {right && <span className="ix-head-right">{right}</span>}
+    </div>
+  );
+}
+
+function P3KeeperDots({ ids, compact }) {
+  return (
+    <span className={`ix-kdots ${compact ? "compact" : ""}`}>
+      {ids.map(id => <span key={id} title={id} style={{ background: p3Keeper(id).color }} />)}
+    </span>
+  );
+}
+
+function P3CodeLine({ line, activeKeeper, reviewLine }) {
+  const k = p3Keeper(line.keeper);
+  return (
+    <div className={`ix-edit-line ${activeKeeper === line.keeper ? "spot" : ""} ${reviewLine === line.n ? "review-hot" : ""}`}>
+      <span className="ix-edit-attrib" style={{ borderColor: k.color, color: k.color }}>{k.initials}</span>
+      <span className="ix-edit-num">{line.n}</span>
+      <span className="ix-edit-src">
+        {line.tokens.map((part, i) => <span key={i} className={part[0]}>{part[1]}</span>)}
+      </span>
+    </div>
+  );
+}
+
+// ═════════════════════════════════════════════════════════════════
+// E1 · FILE TREE EXPLORER
+// ═════════════════════════════════════════════════════════════════
+
+function IxTreeAllowed({ branch = "main", keepers }) {
+  const [focus, setFocus] = useState(null);
+  const selected = p3KeeperIds(keepers);
+  const rows = P3J.files.filter(f => !focus || f.owners.includes(focus));
+  return (
+    <div className="ix-tree">
+      <P3Header title="E1-A · allowed_paths overlay" meta={`${branch} · ${selected.length} keeper scope`} right="hover keeper chip to spotlight" />
+      <div className="ix-tree-keepers" onMouseLeave={() => setFocus(null)}>
+        {P3J.keepers.map(k => (
+          <button key={k.id} onMouseEnter={() => setFocus(k.id)} className={focus === k.id ? "on" : ""}>
+            <span style={{ background: k.color }} />{k.id}
+          </button>
+        ))}
+      </div>
+      <div className="ix-tree-list">
+        {rows.map(file => (
+          <div key={file.path} className={`ix-tree-row ${file.status} ${focus && !file.owners.includes(focus) ? "dim" : ""}`}>
+            <span className="ix-tree-icon">{file.path.includes("/") ? "▸" : "·"}</span>
+            <span className="ix-tree-path">{file.path}</span>
+            <P3KeeperDots ids={file.owners} />
+            <span className="ix-tree-diff">+{file.adds} −{file.dels}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function IxTreeFilter({ branch = "main", keepers }) {
+  const [q, setQ] = useState("dashboard");
+  const [ext, setExt] = useState("all");
+  const [recent, setRecent] = useState(false);
+  const selected = p3KeeperIds(keepers);
+  const rows = P3J.files.filter(f => {
+    const qOk = f.path.toLowerCase().includes(q.toLowerCase());
+    const extOk = ext === "all" || f.ext === ext;
+    const recentOk = !recent || f.recent;
+    const keeperOk = selected.length === 0 || f.owners.some(o => selected.includes(o));
+    return qOk && extOk && recentOk && keeperOk;
+  });
+  return (
+    <div className="ix-tree">
+      <P3Header title="E1-B · filter bar" meta={`${branch} · live path/ext/keeper filters`} right={`${rows.length} visible`} />
+      <div className="ix-tree-filter">
+        <input value={q} onChange={e => setQ(e.target.value)} placeholder="path glob / search" />
+        {["all", ".ml", ".tsx", ".ts", ".md"].map(x => (
+          <button key={x} className={ext === x ? "on" : ""} onClick={() => setExt(x)}>{x}</button>
+        ))}
+        <button className={recent ? "on" : ""} onClick={() => setRecent(v => !v)}>recent</button>
+      </div>
+      <div className="ix-tree-list">
+        {rows.map(file => (
+          <div key={file.path} className={`ix-tree-row ${file.status}`}>
+            <span className="ix-tree-icon">{file.ext}</span>
+            <span className="ix-tree-path">{file.path}</span>
+            <P3KeeperDots ids={file.owners} />
+            <span className="ix-tree-age">{file.touched}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function IxTreeTabs({ branch = "main" }) {
+  const [tab, setTab] = useState("recent");
+  const rows = {
+    recent: P3J.files.filter(f => f.recent),
+    pinned: P3J.files.filter(f => f.pinned),
+    changed: P3J.files.filter(f => f.status !== "unchanged"),
+    search: P3J.files.filter(f => f.path.includes("fsm") || f.path.includes("keeper")),
+  }[tab];
+  return (
+    <div className="ix-tree">
+      <P3Header title="E1-C · recent / pinned / changed / search" meta={`${branch} · file memory`} right={`${rows.length} rows`} />
+      <div className="ix-tree-tabs">
+        {["recent", "pinned", "changed", "search"].map(t => <button key={t} className={tab === t ? "on" : ""} onClick={() => setTab(t)}>{t}</button>)}
+      </div>
+      <div className="ix-tree-list">
+        {rows.map(file => (
+          <div key={file.path} className={`ix-tree-row ${file.status}`}>
+            <span className="ix-tree-icon">{file.pinned ? "◆" : "·"}</span>
+            <span className="ix-tree-path">{file.path}</span>
+            <span className={`ix-tree-status ${file.status}`}>{file.status}</span>
+            <span className="ix-tree-age">{file.touched}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function IxTreeDiff({ branch = "main", keepers }) {
+  const selected = p3KeeperIds(keepers);
+  const dirs = {};
+  P3J.files.forEach(f => {
+    const dir = f.path.split("/")[0];
+    dirs[dir] = dirs[dir] || { adds: 0, dels: 0, n: 0 };
+    dirs[dir].adds += f.adds;
+    dirs[dir].dels += f.dels;
+    dirs[dir].n += 1;
+  });
+  return (
+    <div className="ix-tree">
+      <P3Header title="E1-D · diff annotated tree" meta={`${branch} · ${selected.length} keepers`} right="+/- rolled up by directory" />
+      <div className="ix-tree-list">
+        {Object.entries(dirs).map(([dir, d]) => (
+          <div key={dir} className="ix-tree-row dir">
+            <span className="ix-tree-icon">▾</span>
+            <span className="ix-tree-path">{dir}/ <span className="muted">{d.n} files</span></span>
+            <span className="ix-tree-diff">+{d.adds} −{d.dels}</span>
+          </div>
+        ))}
+        {P3J.files.map(file => (
+          <div key={file.path} className={`ix-tree-row ${file.status}`}>
+            <span className="ix-tree-icon">·</span>
+            <span className="ix-tree-path">{file.path}</span>
+            <span className={`ix-tree-status ${file.status}`}>{file.status}</span>
+            <span className="ix-tree-diff">+{file.adds} −{file.dels}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ═════════════════════════════════════════════════════════════════
+// E2 · EDITOR SURFACES
+// ═════════════════════════════════════════════════════════════════
+
+function IxEditAttrib({ branch = "main", keepers }) {
+  const [active, setActive] = useState(null);
+  const selected = p3KeeperIds(keepers);
+  return (
+    <div className="ix-edit">
+      <P3Header title="E2-A · attribution gutter" meta={`${branch} · ${selected.length} keeper scope`} right={active || "hover a keeper"} />
+      <div className="ix-edit-keepers" onMouseLeave={() => setActive(null)}>
+        {P3J.keepers.map(k => <button key={k.id} onMouseEnter={() => setActive(k.id)} className={active === k.id ? "on" : ""}><span style={{ background: k.color }} />{k.id}</button>)}
+      </div>
+      <div className="ix-edit-code">
+        {P3J.editorLines.map(line => <P3CodeLine key={line.n} line={line} activeKeeper={active} />)}
+      </div>
+    </div>
+  );
+}
+
+function IxEditSplit({ branch = "main" }) {
+  const [sync, setSync] = useState(true);
+  const leftRef = useRef(null);
+  const rightRef = useRef(null);
+  const onScroll = (from) => {
+    if (!sync) return;
+    const src = from === "left" ? leftRef.current : rightRef.current;
+    const dst = from === "left" ? rightRef.current : leftRef.current;
+    if (src && dst) dst.scrollTop = src.scrollTop;
+  };
+  return (
+    <div className="ix-edit ix-edit-split">
+      <P3Header title="E2-B · split 2-pane" meta={`${branch} · prod vs feature`} right={<button onClick={() => setSync(v => !v)}>{sync ? "sync scroll on" : "sync scroll off"}</button>} />
+      <div className="ix-edit-split-grid">
+        <div className="ix-edit-pane">
+          <div className="ix-edit-bc">main · dashboard_fleet_fsm.ml</div>
+          <div ref={leftRef} onScroll={() => onScroll("left")} className="ix-edit-scroll">
+            {P3J.editorLines.slice(0, 8).map(line => <P3CodeLine key={line.n} line={line} />)}
+          </div>
+        </div>
+        <div className="ix-edit-pane">
+          <div className="ix-edit-bc">feature · FleetFSMPanel.tsx</div>
+          <div ref={rightRef} onScroll={() => onScroll("right")} className="ix-edit-scroll">
+            {P3J.splitLines.concat(P3J.splitLines).map((line, i) => (
+              <div key={`${line.n}-${i}`} className="ix-edit-line">
+                <span className="ix-edit-num">{line.n + i}</span>
+                <span className="ix-edit-src">{line.text}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function IxEditMerge({ branch = "main" }) {
+  const [choice, setChoice] = useState({ h1: "ours", h2: "manual", h3: "theirs" });
+  const pick = (id, v) => setChoice(prev => ({ ...prev, [id]: v }));
+  const resolved = Object.values(choice).filter(Boolean).length;
+  return (
+    <div className="ix-edit ix-edit-merge">
+      <P3Header title="E2-C · 3-way merge resolver" meta={`${branch} · ${resolved}/${P3J.mergeHunks.length} resolved`} right="base · ours · theirs · result" />
+      <div className="ix-merge-grid ix-merge-hdr"><span>base</span><span>ours</span><span>theirs</span><span>result</span></div>
+      {P3J.mergeHunks.map(h => (
+        <div key={h.id} className="ix-merge-block">
+          <div className="ix-merge-file">{h.file}:{h.line}</div>
+          <div className="ix-merge-grid">
+            <pre>{h.base}</pre>
+            <pre>{h.ours}</pre>
+            <pre>{h.theirs}</pre>
+            <pre className="result">{choice[h.id] === "ours" ? h.ours : choice[h.id] === "theirs" ? h.theirs : `${h.ours}\n${h.theirs}`}</pre>
+          </div>
+          <div className="ix-merge-actions">
+            {["ours", "theirs", "manual"].map(v => <button key={v} className={choice[h.id] === v ? "on" : ""} onClick={() => pick(h.id, v)}>{v}</button>)}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function IxEditReview({ branch = "main" }) {
+  const [hot, setHot] = useState(null);
+  return (
+    <div className="ix-edit ix-edit-review">
+      <P3Header title="E2-D · inline review" meta={`${branch} · ${P3J.reviewThreads.length} threads`} right="line-pinned comments" />
+      <div className="ix-review-grid">
+        <div className="ix-edit-code">
+          {P3J.editorLines.map(line => <P3CodeLine key={line.n} line={line} reviewLine={hot} />)}
+        </div>
+        <div className="ix-review-side">
+          {P3J.reviewThreads.map(t => (
+            <div key={t.id} className={`ix-review-thread ${t.verdict}`} onMouseEnter={() => setHot(t.line)} onMouseLeave={() => setHot(null)}>
+              <div className="h"><span className="ln">L{t.line}</span><span className="who">@{t.keeper}</span><span className={`chip is-${t.verdict === "approve" ? "ok" : t.verdict === "flag" ? "warn" : "idle"}`}>{t.verdict}</span></div>
+              <div className="body">{t.body}</div>
+              <div className="ft">↩ {t.replies} replies · resolve</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function IxEditBlame({ branch = "main" }) {
+  return (
+    <div className="ix-edit ix-edit-blame">
+      <P3Header title="E2-E · blame gutter" meta={`${branch} · hash · keeper · age`} right="hover rows for commit metadata" />
+      <div className="ix-edit-code">
+        {P3J.editorLines.map(line => {
+          const k = p3Keeper(line.keeper);
+          return (
+            <div key={line.n} className={`ix-edit-line age-${line.age.endsWith("m") ? "fresh" : "old"}`} title={`${line.hash} · ${line.keeper} · ${line.age} · ${line.text}`}>
+              <span className="ix-blame-cell"><b>{line.hash}</b><i style={{ color: k.color }}>{k.initials}</i><em>{line.age}</em></span>
+              <span className="ix-edit-num">{line.n}</span>
+              <span className="ix-edit-src">{line.tokens.map((part, i) => <span key={i} className={part[0]}>{part[1]}</span>)}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, {
+  IxTreeAllowed, IxTreeFilter, IxTreeTabs, IxTreeDiff,
+  IxEditAttrib, IxEditSplit, IxEditMerge, IxEditReview, IxEditBlame,
+});

--- a/dashboard/design-system/preview/cb-group-k.jsx
+++ b/dashboard/design-system/preview/cb-group-k.jsx
@@ -1,0 +1,342 @@
+// preview/cb-group-k.jsx
+// Phase 3 · Code IDE v2 E3/E4/E5 surfaces.
+
+const P3K = window.MASC_P3;
+const P2K = window.MASC_P2 || {};
+
+function k3Keeper(id) {
+  return (P3K.keepers || []).find(k => k.id === id) || { id, initials: id.slice(0, 2), color: "var(--idle)" };
+}
+
+function k3KeeperIds(keepers) {
+  if (!keepers) return P3K.keepers.map(k => k.id);
+  if (keepers instanceof Set) return Array.from(keepers);
+  if (Array.isArray(keepers)) return keepers;
+  return [keepers].filter(Boolean);
+}
+
+function K3Header({ title, meta, right }) {
+  return (
+    <div className="ix-head">
+      <span className="ix-head-title">{title}</span>
+      <span className="ix-head-meta">{meta}</span>
+      {right && <span className="ix-head-right">{right}</span>}
+    </div>
+  );
+}
+
+function K3Status({ status }) {
+  const kind = status === "pass" || status === "approved" ? "ok" : status === "fail" || status === "changes" || status === "flagged" ? "err" : status === "running" || status === "requested" ? "warn" : "idle";
+  return <span className={`ix-status ${kind}`}>{status}</span>;
+}
+
+// ═════════════════════════════════════════════════════════════════
+// E3 · PR INSPECTOR
+// ═════════════════════════════════════════════════════════════════
+
+function IxPrHeader({ branch = "main", keepers }) {
+  const pr = P3K.pr;
+  const selected = k3KeeperIds(keepers);
+  const pass = pr.checks.filter(c => c.status === "pass").length;
+  return (
+    <div className="ix-pr">
+      <K3Header title="E3-A · PR header" meta={`${branch} · source to base`} right={`${pass}/${pr.checks.length} passing`} />
+      <div className="ix-pr-head">
+        <div className="ix-pr-title">
+          <span className={`ix-pr-state ${pr.state}`}>{pr.state}</span>
+          <span className="num">#{pr.number}</span>
+          <span>{pr.title}</span>
+        </div>
+        <div className="ix-pr-branches"><span>{pr.source}</span><b>→</b><span>{pr.base}</span><em>{selected.length} keepers selected</em></div>
+        <div className="ix-pr-labels">{pr.labels.map(l => <span key={l}>{l}</span>)}</div>
+        <div className="ix-pr-reviewers">
+          {pr.reviewers.map(r => {
+            const k = k3Keeper(r.name);
+            return <span key={r.name} className={r.status}><i style={{ background: k.color }}>{k.initials}</i><b>{r.name}</b><K3Status status={r.status} /></span>;
+          })}
+        </div>
+        <div className="ix-pr-merge"><span>merge blocked</span><button disabled>WAITING FOR SAFEAUTO</button></div>
+      </div>
+    </div>
+  );
+}
+
+function IxPrFiles({ branch = "main" }) {
+  const [sort, setSort] = useState("review");
+  const [open, setOpen] = useState(new Set(["lib/dashboard/dashboard_fleet_fsm.ml"]));
+  const toggle = (path) => {
+    const next = new Set(open);
+    next.has(path) ? next.delete(path) : next.add(path);
+    setOpen(next);
+  };
+  const rows = [...P3K.prFiles].sort((a, b) => {
+    if (sort === "alpha") return a.path.localeCompare(b.path);
+    if (sort === "size") return (b.adds + b.dels) - (a.adds + a.dels);
+    return a.review.localeCompare(b.review);
+  });
+  return (
+    <div className="ix-pr">
+      <K3Header title="E3-B · files changed" meta={`${branch} · ${rows.length} files`} right={<span className="ix-sort">{["review", "alpha", "size"].map(s => <button key={s} className={sort === s ? "on" : ""} onClick={() => setSort(s)}>{s}</button>)}</span>} />
+      <div className="ix-pr-files">
+        {rows.map(file => (
+          <div key={file.path} className="ix-pr-file">
+            <div className="row" onClick={() => toggle(file.path)}>
+              <span className="tw">{open.has(file.path) ? "▾" : "▸"}</span>
+              <span className="path">{file.path}</span>
+              <span className={`st ${file.status}`}>{file.status}</span>
+              <span className="diff">+{file.adds} −{file.dels}</span>
+              <span className={`rv ${file.review}`}>{file.review}</span>
+            </div>
+            {open.has(file.path) && (
+              <pre className="ix-pr-diff">{`@@ -181,7 +181,10 @@
+- | Missing -> Unknown
++ | Missing -> Missing_runtime_signal
++ | Loaded stale -> Runtime_stall stale
++ | Blocked reason -> Operator_visible_blocker reason
+  | Running -> No_issue`}</pre>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function IxPrThread({ branch = "main" }) {
+  const [resolved, setResolved] = useState(false);
+  return (
+    <div className="ix-pr">
+      <K3Header title="E3-C · comment thread" meta={`${branch} · lib/dashboard/dashboard_fleet_fsm.ml:L183`} right={<button onClick={() => setResolved(v => !v)}>{resolved ? "resolved" : "open"}</button>} />
+      <div className={`ix-pr-thread ${resolved ? "resolved" : ""}`}>
+        {P3K.comments.map((c, i) => (
+          <div key={`${c.by}-${i}`} className={`msg ${c.nested ? "nested" : ""}`}>
+            <div className="h"><span className="by">@{c.by}</span><span className="at">{c.at}</span><K3Status status={c.verdict} /></div>
+            <div className="body">{c.body}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function IxPrChecks({ branch = "main" }) {
+  const [safeOpen, setSafeOpen] = useState(true);
+  return (
+    <div className="ix-pr">
+      <K3Header title="E3-D · CI checks panel" meta={`${branch} · SafeAuto + test gates`} right={`${P3K.pr.checks.length} checks`} />
+      <div className="ix-pr-checks">
+        {P3K.pr.checks.map(check => (
+          <div key={check.name} className="ix-pr-check">
+            <div className="row" onClick={() => check.name === "SafeAuto" && setSafeOpen(v => !v)}>
+              <span className="name">{check.name}</span>
+              <K3Status status={check.status} />
+              <span className="dur">{check.duration}</span>
+              <span className="log">log</span>
+            </div>
+            {check.name === "SafeAuto" && safeOpen && (
+              <div className="findings">
+                {check.details.map(d => <span key={d}>{d}</span>)}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ═════════════════════════════════════════════════════════════════
+// E4 · BRANCH / GIT GRAPH
+// ═════════════════════════════════════════════════════════════════
+
+function IxGraphDag({ branch = "main" }) {
+  const nodes = [
+    { x: 40, y: 32, keeper: "nick0cave", hash: "1014c9", label: "main" },
+    { x: 120, y: 32, keeper: "nick0cave", hash: "7afa7d", label: "" },
+    { x: 200, y: 74, keeper: "masc-improver", hash: "918fd2", label: "feat/keeper-clarity" },
+    { x: 280, y: 74, keeper: "masc-improver", hash: "1c5fb3", label: "" },
+    { x: 360, y: 118, keeper: "sangsu", hash: "e45f2e", label: "oas-label" },
+    { x: 440, y: 118, keeper: "rama", hash: "44a1b9", label: "ar-93ff2489" },
+    { x: 520, y: 32, keeper: "qa-king", hash: "717da6", label: "merge" },
+    { x: 600, y: 32, keeper: "nick0cave", hash: "da11b0", label: "tag v0.42" },
+  ];
+  return (
+    <div className="ix-graph">
+      <K3Header title="E4-A · branch DAG" meta={`${branch} · svg topology`} right="4 branches · 1 merge" />
+      <svg className="ix-graph-dag" viewBox="0 0 680 170">
+        <path d="M40 32 C160 32 240 32 360 32 C440 32 500 32 600 32" />
+        <path d="M120 32 C160 42 168 74 200 74 L280 74 C320 74 330 118 360 118 L440 118 C480 118 490 48 520 32" />
+        {nodes.map(n => {
+          const k = k3Keeper(n.keeper);
+          return (
+            <g key={n.hash} className={n.label === branch || n.label === "main" ? "active" : ""}>
+              <circle cx={n.x} cy={n.y} r="7" fill={k.color} />
+              <text x={n.x + 12} y={n.y + 4}>{n.hash}</text>
+              {n.label && <text className="label" x={n.x + 12} y={n.y - 10}>{n.label}</text>}
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}
+
+function IxGraphCommits({ branch = "main", keepers }) {
+  const [filter, setFilter] = useState("all");
+  const selected = k3KeeperIds(keepers);
+  const rows = P3K.commits.filter(c => (filter === "all" || c.keeper === filter) && (selected.length === 0 || selected.includes(c.keeper)));
+  return (
+    <div className="ix-graph">
+      <K3Header title="E4-B · commit list" meta={`${branch} · keeper attribution`} right={`${rows.length} commits`} />
+      <div className="ix-graph-filters">
+        {["all", ...P3K.keepers.map(k => k.id)].map(k => <button key={k} className={filter === k ? "on" : ""} onClick={() => setFilter(k)}>{k}</button>)}
+      </div>
+      <div className="ix-commits">
+        {rows.map(c => {
+          const k = k3Keeper(c.keeper);
+          return (
+            <div key={c.hash} className="ix-commit-row">
+              <span className="hash">{c.hash}</span><span className="keeper" style={{ color: k.color }}>{c.keeper}</span><span className="subj">{c.subject}</span><span className="branch">{c.branch}</span><span className="age">{c.age}</span><span className="diff">+{c.adds} −{c.dels}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function IxGraphWorktrees({ branch = "main" }) {
+  return (
+    <div className="ix-graph">
+      <K3Header title="E4-C · worktree picker" meta={`${branch} · active sandboxes`} right={`${P3K.worktrees.length} worktrees`} />
+      <div className="ix-worktrees">
+        {P3K.worktrees.map(w => (
+          <div key={w.path} className={`ix-worktree-card ${w.status}`}>
+            <div className="path">{w.path}</div>
+            <div className="branch">{w.branch}</div>
+            <div className="keepers">{w.keepers.map(k => <span key={k}>@{k}</span>)}</div>
+            <div className="ft"><K3Status status={w.status} /><span>{w.touched}</span><button>switch</button><button>open</button></div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function IxGraphStashes({ branch = "main" }) {
+  const [open, setOpen] = useState("stash@{0}");
+  return (
+    <div className="ix-graph">
+      <K3Header title="E4-D · stash list" meta={`${branch} · recover keeper work`} right={`${P3K.stashes.length} stashes`} />
+      <div className="ix-stashes">
+        {P3K.stashes.map(s => (
+          <div key={s.id} className="ix-stash-row">
+            <div className="row" onClick={() => setOpen(open === s.id ? null : s.id)}>
+              <span className="id">{s.id}</span><span className="branch">{s.branch}</span><span className="keeper">@{s.keeper}</span><span className="sum">{s.summary}</span><span className="age">{s.age}</span><span>{s.files} files</span>
+            </div>
+            {open === s.id && <div className="detail">inspect · apply · pop · drop <span>+{s.adds} −{s.dels}</span></div>}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ═════════════════════════════════════════════════════════════════
+// E5 · TERMINAL / SEARCH
+// ═════════════════════════════════════════════════════════════════
+
+function IxTerm({ branch = "main" }) {
+  const cascade = (P2K.cascadeAudit && P2K.cascadeAudit[1]) || null;
+  return (
+    <div className="ix-term">
+      <K3Header title="E5-A · cascade-aware terminal" meta={`${branch} · PWD .worktrees/${branch}`} right="history 8 · cascade trace inline" />
+      <div className="ix-term-body">
+        {[
+          "$ git status --short",
+          " M dashboard/design-system/preview/cb-group-j.jsx",
+          "$ masc keeper claim task-4012 --keeper sangsu",
+          "claim accepted · task-4012 · branch=codex/design-system-phase3-ide-v2",
+        ].map((line, i) => <div key={i} className={`ix-term-line ${line.startsWith("$") ? "prompt" : ""}`}>{line}</div>)}
+        {cascade && (
+          <div className="cb-cascade">
+            <div className="id">{cascade.id} · {cascade.cascade} · {cascade.trigger}</div>
+            {cascade.hops.map(h => (
+              <div key={h.i} className={`step ${h.status}`}>
+                <span className="ix">{h.i}</span><span className="name">{h.model}</span><span className="ms">{h.ms}ms</span>
+              </div>
+            ))}
+            <div className="total">total <span className="n">{cascade.total_ms}ms</span> · {cascade.outcome}</div>
+          </div>
+        )}
+        {[
+          "$ pnpm run typecheck",
+          "typecheck passed · dashboard · 2m11s",
+          "$ rg runtime_cause dashboard lib test",
+          "6 matches · open with E5-B search",
+        ].map((line, i) => <div key={`b-${i}`} className={`ix-term-line ${line.startsWith("$") ? "prompt" : ""}`}>{line}</div>)}
+      </div>
+    </div>
+  );
+}
+
+function IxSearch({ branch = "main" }) {
+  const [q, setQ] = useState("runtime");
+  const [regex, setRegex] = useState(false);
+  const [word, setWord] = useState(false);
+  const rows = P3K.searchResults.filter(r => r.text.toLowerCase().includes(q.toLowerCase()) || r.file.toLowerCase().includes(q.toLowerCase()));
+  const grouped = rows.reduce((acc, r) => {
+    acc[r.file] = acc[r.file] || [];
+    acc[r.file].push(r);
+    return acc;
+  }, {});
+  return (
+    <div className="ix-search">
+      <K3Header title="E5-B · project search" meta={`${branch} · rg-style`} right={`${rows.length} matches`} />
+      <div className="ix-search-bar">
+        <input value={q} onChange={e => setQ(e.target.value)} />
+        <button className={regex ? "on" : ""} onClick={() => setRegex(v => !v)}>regex</button>
+        <button className={word ? "on" : ""} onClick={() => setWord(v => !v)}>whole word</button>
+        <input readOnly value="*.{ml,ts,tsx,md,sh}" />
+      </div>
+      <div className="ix-search-results">
+        {Object.entries(grouped).map(([file, items]) => (
+          <div key={file} className="ix-search-file">
+            <div className="file">{file} <span>{items.length}</span></div>
+            {items.map(item => <div key={`${file}-${item.line}`} className="hit"><span>{item.line}</span><code>{item.text.split(q).map((p, i) => <React.Fragment key={i}>{i > 0 && <mark>{q}</mark>}{p}</React.Fragment>)}</code></div>)}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function IxFindReplace({ branch = "main" }) {
+  const [find, setFind] = useState("runtime");
+  const [replace, setReplace] = useState("execution");
+  const matches = P3K.editorLines.filter(l => l.text.toLowerCase().includes(find.toLowerCase()));
+  return (
+    <div className="ix-search ix-find-wrap">
+      <K3Header title="E5-C · find / replace" meta={`${branch} · current editor`} right={`${matches.length ? 1 : 0} of ${matches.length}`} />
+      <div className="ix-find">
+        <input value={find} onChange={e => setFind(e.target.value)} />
+        <input value={replace} onChange={e => setReplace(e.target.value)} />
+        <button>prev</button><button>next</button><button>replace</button><button>replace all</button><button>selection</button>
+      </div>
+      <div className="ix-edit-code">
+        {P3K.editorLines.slice(0, 8).map(line => (
+          <div key={line.n} className={`ix-edit-line ${line.text.toLowerCase().includes(find.toLowerCase()) ? "review-hot" : ""}`}>
+            <span className="ix-edit-num">{line.n}</span>
+            <span className="ix-edit-src">{line.text}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, {
+  IxPrHeader, IxPrFiles, IxPrThread, IxPrChecks,
+  IxGraphDag, IxGraphCommits, IxGraphWorktrees, IxGraphStashes,
+  IxTerm, IxSearch, IxFindReplace,
+});

--- a/dashboard/design-system/preview/cb-root.jsx
+++ b/dashboard/design-system/preview/cb-root.jsx
@@ -78,6 +78,43 @@ function App() {
         <DCArtboard id="ib-nd"  label="C · Operator nudge log + compose"        width={780} height={500}><OperatorNudgeLog/></DCArtboard>
       </DCSection>
 
+      {/* ════════ PHASE 3 · CODE IDE v2 ════════ */}
+
+      <DCSection id="ide-tree" title="E1 · File Tree Explorer" subtitle="allowed_paths overlay · live filters · recent/pinned/changing memory · diff rollups.">
+        <DCArtboard id="e1-allowed" label="A · Tree + allowed_paths overlay" width={920} height={520}><IxTreeAllowed branch="main" keepers={["nick0cave","sangsu","masc-improver"]}/></DCArtboard>
+        <DCArtboard id="e1-filter"  label="B · Filter bar" width={920} height={420}><IxTreeFilter branch="feat/keeper-clarity" keepers={["sangsu","masc-improver"]}/></DCArtboard>
+        <DCArtboard id="e1-tabs"    label="C · Recent / pinned / changed / search" width={780} height={420}><IxTreeTabs branch="main"/></DCArtboard>
+        <DCArtboard id="e1-diff"    label="D · Diff-annotated tree" width={920} height={520}><IxTreeDiff branch="main" keepers={["nick0cave","qa-king"]}/></DCArtboard>
+      </DCSection>
+
+      <DCSection id="ide-edit" title="E2 · Editor Surfaces" subtitle="attribution · split panes · 3-way merge · inline review · blame gutter.">
+        <DCArtboard id="e2-attrib" label="A · Single editor + attribution gutter" width={920} height={420}><IxEditAttrib branch="main" keepers={["nick0cave","sangsu","qa-king"]}/></DCArtboard>
+        <DCArtboard id="e2-split"  label="B · Split 2-pane" width={1080} height={420}><IxEditSplit branch="feat/keeper-clarity"/></DCArtboard>
+        <DCArtboard id="e2-merge"  label="C · 3-way merge resolver" width={1080} height={520}><IxEditMerge branch="codex/fleet-fsm-runtime-cause"/></DCArtboard>
+        <DCArtboard id="e2-review" label="D · Inline review with comments" width={1080} height={460}><IxEditReview branch="main"/></DCArtboard>
+        <DCArtboard id="e2-blame"  label="E · Blame gutter" width={920} height={420}><IxEditBlame branch="main"/></DCArtboard>
+      </DCSection>
+
+      <DCSection id="ide-pr" title="E3 · PR Inspector" subtitle="PR header · files changed · comment thread · CI checks with SafeAuto.">
+        <DCArtboard id="e3-head"   label="A · PR header" width={920} height={300}><IxPrHeader branch="codex/fleet-fsm-runtime-cause" keepers={["nick0cave","sangsu"]}/></DCArtboard>
+        <DCArtboard id="e3-files"  label="B · Files changed list" width={1080} height={480}><IxPrFiles branch="codex/fleet-fsm-runtime-cause"/></DCArtboard>
+        <DCArtboard id="e3-thread" label="C · Comment thread" width={780} height={320}><IxPrThread branch="codex/fleet-fsm-runtime-cause"/></DCArtboard>
+        <DCArtboard id="e3-checks" label="D · CI checks panel" width={920} height={360}><IxPrChecks branch="codex/fleet-fsm-runtime-cause"/></DCArtboard>
+      </DCSection>
+
+      <DCSection id="ide-graph" title="E4 · Branch / Git Graph" subtitle="DAG · keeper-attributed commits · worktree picker · stash recovery.">
+        <DCArtboard id="e4-dag"   label="A · Branch DAG (SVG)" width={920} height={340}><IxGraphDag branch="main"/></DCArtboard>
+        <DCArtboard id="e4-comm"  label="B · Commit list with keeper attribution" width={1080} height={460}><IxGraphCommits branch="main" keepers={["nick0cave","sangsu","masc-improver","qa-king","rama"]}/></DCArtboard>
+        <DCArtboard id="e4-wt"    label="C · Worktree picker" width={920} height={360}><IxGraphWorktrees branch="main"/></DCArtboard>
+        <DCArtboard id="e4-stash" label="D · Stash list" width={920} height={340}><IxGraphStashes branch="main"/></DCArtboard>
+      </DCSection>
+
+      <DCSection id="ide-term" title="E5 · Terminal / Search" subtitle="cascade-aware terminal · project search · find/replace overlay.">
+        <DCArtboard id="e5-term" label="A · Cascade-aware terminal pane" width={920} height={440}><IxTerm branch="codex/design-system-phase3-ide-v2"/></DCArtboard>
+        <DCArtboard id="e5-rg"   label="B · Project search (rg-style)" width={920} height={420}><IxSearch branch="main"/></DCArtboard>
+        <DCArtboard id="e5-find" label="C · Find / replace in file" width={920} height={360}><IxFindReplace branch="main"/></DCArtboard>
+      </DCSection>
+
       {/* ════════ PHASE 2 · TRACK 1 · WORK PLANE ════════ */}
 
       <DCSection id="goal-zone" title="G1 · Goal Zone" subtitle="Real goals.json — horizon, phase, metric, parent tree, snapshot diff.">

--- a/dashboard/design-system/preview/components.css
+++ b/dashboard/design-system/preview/components.css
@@ -907,3 +907,195 @@
 .nd-compose .ft .targets { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-3); }
 .nd-compose .ft .send { margin-left:auto; padding:4px 12px; background:var(--brass-3); border:1px solid var(--brass-1); color:var(--brass-1); font-family:var(--font-mono); font-size:var(--fs-10); text-transform:uppercase; letter-spacing:.08em; cursor:pointer; }
 .nd-compose .ft .send:hover { background:var(--brass-2); color:var(--bg-0); }
+
+/* ═══════════════════════════════════════════════════
+   PHASE 3 · CODE IDE v2  (E1-E5)
+   ═══════════════════════════════════════════════════ */
+
+.ix-head { display:flex; align-items:center; gap:8px; padding:5px 8px; min-height:24px; background:var(--bg-2); border:1px solid var(--line-2); color:var(--fg-2); font-family:var(--font-mono); font-size:var(--fs-10); }
+.ix-head-title { color:var(--fg-1); font-weight:600; letter-spacing:.04em; }
+.ix-head-meta { color:var(--fg-4); }
+.ix-head-right { margin-left:auto; color:var(--brass-1); display:inline-flex; align-items:center; gap:4px; }
+.ix-head-right button, .ix-sort button { padding:1px 6px; background:var(--bg-1); border:1px solid var(--line-1); color:var(--fg-3); font:inherit; cursor:pointer; }
+.ix-head-right button:hover, .ix-sort button:hover { color:var(--fg-1); }
+.ix-sort { display:inline-flex; gap:2px; }
+.ix-sort button.on { color:var(--brass-1); border-color:var(--brass-3); background:rgb(var(--brass-glow)/.08); }
+.muted { color:var(--fg-4); }
+
+.ix-status { display:inline-flex; align-items:center; height:16px; padding:0 5px; border:1px solid var(--line-2); font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.06em; text-transform:uppercase; white-space:nowrap; }
+.ix-status.ok { color:var(--ok-fg); border-color:var(--ok-border); background:var(--ok-bg); }
+.ix-status.warn { color:var(--warn); border-color:var(--warn); background:rgb(201 162 74 / .08); }
+.ix-status.err { color:var(--err-fg); border-color:var(--err-border); background:var(--err-bg); }
+.ix-status.idle { color:var(--fg-3); border-color:var(--line-2); background:var(--bg-2); }
+
+/* E1 · file tree */
+.ix-tree { display:flex; flex-direction:column; gap:6px; height:100%; min-height:0; background:var(--bg-0); color:var(--fg-1); overflow:hidden; }
+.ix-tree-keepers, .ix-edit-keepers, .ix-graph-filters { display:flex; flex-wrap:wrap; gap:3px; padding:6px 8px; background:var(--bg-1); border:1px solid var(--line-1); }
+.ix-tree-keepers button, .ix-edit-keepers button, .ix-graph-filters button { display:inline-flex; align-items:center; gap:5px; padding:2px 7px; background:var(--bg-2); border:1px solid var(--line-1); color:var(--fg-3); font-family:var(--font-mono); font-size:var(--fs-10); cursor:pointer; }
+.ix-tree-keepers button span, .ix-edit-keepers button span { width:7px; height:7px; border-radius:50%; }
+.ix-tree-keepers button.on, .ix-edit-keepers button.on, .ix-graph-filters button.on { color:var(--brass-1); border-color:var(--brass-3); background:rgb(var(--brass-glow)/.08); }
+.ix-tree-filter { display:grid; grid-template-columns:minmax(150px,1fr) repeat(6,auto); gap:3px; padding:6px 8px; background:var(--bg-1); border:1px solid var(--line-1); }
+.ix-tree-filter input, .ix-search-bar input, .ix-find input { min-width:0; padding:4px 7px; background:var(--bg-0); border:1px solid var(--line-1); color:var(--fg-1); font-family:var(--font-mono); font-size:var(--fs-11); }
+.ix-tree-filter button, .ix-search-bar button, .ix-find button { padding:3px 7px; background:var(--bg-2); border:1px solid var(--line-1); color:var(--fg-3); font-family:var(--font-mono); font-size:var(--fs-10); cursor:pointer; }
+.ix-tree-filter button.on, .ix-search-bar button.on { color:var(--brass-1); border-color:var(--brass-3); background:rgb(var(--brass-glow)/.08); }
+.ix-tree-tabs { display:flex; gap:2px; padding:0 8px; border-bottom:1px solid var(--line-2); }
+.ix-tree-tabs button { padding:5px 10px 4px; background:transparent; border:0; border-bottom:2px solid transparent; color:var(--fg-3); font-family:var(--font-mono); font-size:var(--fs-10); text-transform:uppercase; letter-spacing:.08em; cursor:pointer; }
+.ix-tree-tabs button.on { color:var(--brass-1); border-bottom-color:var(--brass-1); }
+.ix-tree-list { min-height:0; overflow:auto; display:flex; flex-direction:column; gap:1px; }
+.ix-tree-row { display:grid; grid-template-columns:22px minmax(0,1fr) auto auto; gap:7px; align-items:center; min-height:24px; padding:3px 8px; background:var(--bg-1); border:1px solid var(--line-1); border-left:2px solid var(--line-1); font-family:var(--font-mono); font-size:var(--fs-11); }
+.ix-tree-row.dir { background:var(--bg-2); border-left-color:var(--brass-3); }
+.ix-tree-row.added { border-left-color:var(--ok); }
+.ix-tree-row.modified { border-left-color:var(--info); }
+.ix-tree-row.deleted { border-left-color:var(--err); opacity:.86; }
+.ix-tree-row.unchanged { border-left-color:var(--line-2); color:var(--fg-3); }
+.ix-tree-row.dim { opacity:.35; }
+.ix-tree-icon { color:var(--fg-4); font-size:var(--fs-10); }
+.ix-tree-path { min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--fg-1); }
+.ix-kdots { display:inline-flex; align-items:center; min-width:36px; }
+.ix-kdots span { width:9px; height:9px; border-radius:50%; border:1px solid var(--bg-0); margin-left:-3px; }
+.ix-kdots span:first-child { margin-left:0; }
+.ix-kdots.compact span { width:7px; height:7px; }
+.ix-tree-diff, .ix-tree-age { color:var(--fg-3); font-variant-numeric:tabular-nums; font-size:var(--fs-10); }
+.ix-tree-status { padding:1px 5px; border:1px solid var(--line-2); font-size:var(--fs-9); text-transform:uppercase; letter-spacing:.05em; }
+.ix-tree-status.added { color:var(--ok-fg); border-color:var(--ok-border); background:var(--ok-bg); }
+.ix-tree-status.modified { color:var(--info); border-color:var(--info); }
+.ix-tree-status.deleted { color:var(--err-fg); border-color:var(--err-border); background:var(--err-bg); }
+.ix-tree-status.renamed, .ix-tree-status.unchanged { color:var(--fg-3); }
+
+/* E2 · editor */
+.ix-edit { display:flex; flex-direction:column; gap:6px; height:100%; min-height:0; background:var(--bg-0); color:var(--fg-1); overflow:hidden; }
+.ix-edit-code { min-height:0; overflow:auto; background:var(--bg-1); border:1px solid var(--line-1); padding:4px 0; }
+.ix-edit-line { display:grid; grid-template-columns:30px 42px minmax(0,1fr); gap:6px; align-items:baseline; min-height:22px; padding:0 8px; font-family:var(--font-mono); font-size:var(--fs-12); line-height:1.45; border-left:2px solid transparent; }
+.ix-edit-line:hover { background:var(--hover-overlay); }
+.ix-edit-line.spot { background:rgb(var(--brass-glow)/.06); }
+.ix-edit-line.review-hot { background:var(--warn-bg, rgb(201 162 74 / .10)); border-left-color:var(--warn); }
+.ix-edit-attrib { height:16px; border-left:3px solid; padding-left:4px; font-size:var(--fs-9); color:var(--fg-3); }
+.ix-edit-num { color:var(--fg-4); text-align:right; font-size:var(--fs-10); font-variant-numeric:tabular-nums; }
+.ix-edit-src { min-width:0; overflow:hidden; white-space:pre; color:var(--fg-1); }
+.ix-edit-split-grid { display:grid; grid-template-columns:1fr 1fr; gap:8px; min-height:0; flex:1; }
+.ix-edit-pane { min-width:0; display:flex; flex-direction:column; border:1px solid var(--line-2); background:var(--bg-1); }
+.ix-edit-bc { padding:4px 8px; background:var(--bg-2); border-bottom:1px solid var(--line-2); color:var(--fg-3); font-family:var(--font-mono); font-size:var(--fs-10); }
+.ix-edit-scroll { overflow:auto; min-height:0; max-height:310px; padding:4px 0; }
+.ix-edit-scroll .ix-edit-line { grid-template-columns:42px minmax(0,1fr); }
+.ix-merge-grid { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:1px; }
+.ix-merge-hdr span { padding:4px 8px; background:var(--bg-2); border:1px solid var(--line-2); color:var(--fg-4); font-family:var(--font-mono); font-size:var(--fs-9); text-transform:uppercase; letter-spacing:.08em; }
+.ix-merge-block { border:1px solid var(--line-2); background:var(--bg-1); }
+.ix-merge-file { padding:4px 8px; color:var(--brass-1); font-family:var(--font-mono); font-size:var(--fs-10); border-bottom:1px solid var(--line-1); }
+.ix-merge-block pre { margin:0; min-height:42px; padding:7px 8px; overflow:auto; background:var(--bg-0); border-right:1px solid var(--line-1); color:var(--fg-2); font-family:var(--font-mono); font-size:var(--fs-10); white-space:pre-wrap; }
+.ix-merge-block pre.result { color:var(--ok-fg); background:var(--ok-bg); }
+.ix-merge-actions { display:flex; gap:3px; padding:5px 8px; background:var(--bg-2); }
+.ix-merge-actions button { padding:2px 8px; background:var(--bg-1); border:1px solid var(--line-1); color:var(--fg-3); font-family:var(--font-mono); font-size:var(--fs-10); cursor:pointer; }
+.ix-merge-actions button.on { color:var(--brass-1); border-color:var(--brass-3); }
+.ix-review-grid { display:grid; grid-template-columns:minmax(0,1fr) 260px; gap:8px; min-height:0; flex:1; }
+.ix-review-side { min-height:0; overflow:auto; display:flex; flex-direction:column; gap:5px; }
+.ix-review-thread { padding:7px 8px; background:var(--bg-1); border:1px solid var(--line-1); border-left:2px solid var(--line-2); }
+.ix-review-thread.flag { border-left-color:var(--warn); }
+.ix-review-thread.approve { border-left-color:var(--ok); }
+.ix-review-thread.defer { border-left-color:var(--info); }
+.ix-review-thread .h { display:flex; align-items:center; gap:5px; margin-bottom:4px; font-family:var(--font-mono); font-size:var(--fs-10); }
+.ix-review-thread .ln { color:var(--brass-1); }
+.ix-review-thread .who { color:var(--fg-3); }
+.ix-review-thread .body { color:var(--fg-1); font-family:var(--font-mono); font-size:var(--fs-11); line-height:1.4; }
+.ix-review-thread .ft { margin-top:5px; color:var(--fg-4); font-family:var(--font-mono); font-size:var(--fs-9); text-transform:uppercase; letter-spacing:.05em; }
+.ix-blame .ix-edit-line { grid-template-columns:112px 42px minmax(0,1fr); }
+.ix-blame-cell { display:grid; grid-template-columns:44px 22px 32px; gap:4px; color:var(--fg-4); font-size:var(--fs-10); }
+.ix-blame-cell b { color:var(--fg-2); font-weight:400; }
+.ix-blame-cell i { font-style:normal; }
+.ix-blame-cell em { font-style:normal; color:var(--fg-4); }
+.ix-edit-line.age-fresh .ix-blame-cell b { color:var(--brass-1); }
+
+/* E3 · PR inspector */
+.ix-pr, .ix-graph, .ix-term, .ix-search { display:flex; flex-direction:column; gap:6px; height:100%; min-height:0; background:var(--bg-0); color:var(--fg-1); overflow:hidden; }
+.ix-pr-head { display:flex; flex-direction:column; gap:8px; padding:10px; background:var(--bg-1); border:1px solid var(--line-2); }
+.ix-pr-title { display:flex; align-items:center; gap:8px; font-size:var(--fs-14); color:var(--fg-1); }
+.ix-pr-title .num { color:var(--brass-1); font-family:var(--font-mono); }
+.ix-pr-state { padding:1px 6px; border:1px solid var(--ok-border); background:var(--ok-bg); color:var(--ok-fg); font-family:var(--font-mono); font-size:var(--fs-9); text-transform:uppercase; letter-spacing:.08em; }
+.ix-pr-branches { display:flex; align-items:center; gap:7px; color:var(--fg-3); font-family:var(--font-mono); font-size:var(--fs-11); }
+.ix-pr-branches span { color:var(--fg-1); padding:2px 6px; background:var(--bg-2); border:1px solid var(--line-1); }
+.ix-pr-branches b { color:var(--fg-4); font-weight:400; }
+.ix-pr-branches em { margin-left:auto; color:var(--fg-4); font-style:normal; }
+.ix-pr-labels, .ix-pr-reviewers { display:flex; flex-wrap:wrap; gap:4px; }
+.ix-pr-labels span { padding:2px 6px; background:var(--bg-2); border:1px solid var(--line-1); color:var(--fg-3); font-family:var(--font-mono); font-size:var(--fs-10); }
+.ix-pr-reviewers span { display:inline-flex; align-items:center; gap:5px; padding:3px 6px; background:var(--bg-2); border:1px solid var(--line-1); font-family:var(--font-mono); font-size:var(--fs-10); }
+.ix-pr-reviewers i { display:inline-flex; align-items:center; justify-content:center; width:18px; height:18px; color:var(--bg-0); font-style:normal; font-size:var(--fs-9); border-radius:50%; }
+.ix-pr-reviewers b { color:var(--fg-2); font-weight:400; }
+.ix-pr-merge { display:flex; align-items:center; gap:8px; padding-top:2px; font-family:var(--font-mono); font-size:var(--fs-10); color:var(--warn); }
+.ix-pr-merge button { margin-left:auto; padding:4px 10px; background:var(--bg-2); border:1px solid var(--line-2); color:var(--fg-4); font:inherit; }
+.ix-pr-files, .ix-pr-checks, .ix-pr-thread { min-height:0; overflow:auto; }
+.ix-pr-file, .ix-pr-check { background:var(--bg-1); border:1px solid var(--line-1); margin-bottom:2px; }
+.ix-pr-file .row, .ix-pr-check .row { display:grid; grid-template-columns:20px minmax(0,1fr) 72px 64px 72px; gap:6px; align-items:center; padding:5px 8px; font-family:var(--font-mono); font-size:var(--fs-11); cursor:pointer; }
+.ix-pr-check .row { grid-template-columns:minmax(0,1fr) 70px 60px 36px; cursor:default; }
+.ix-pr-file .path, .ix-pr-check .name { min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--fg-1); }
+.ix-pr-file .tw { color:var(--fg-4); }
+.ix-pr-file .st, .ix-pr-file .rv { padding:1px 5px; border:1px solid var(--line-2); color:var(--fg-3); font-size:var(--fs-9); text-transform:uppercase; letter-spacing:.05em; }
+.ix-pr-file .st.added { color:var(--ok-fg); border-color:var(--ok-border); background:var(--ok-bg); }
+.ix-pr-file .st.deleted { color:var(--err-fg); border-color:var(--err-border); background:var(--err-bg); }
+.ix-pr-file .st.modified { color:var(--info); border-color:var(--info); }
+.ix-pr-file .diff { color:var(--fg-3); text-align:right; }
+.ix-pr-diff { margin:0; padding:8px 10px; color:var(--fg-2); background:var(--bg-0); border-top:1px solid var(--line-1); font-family:var(--font-mono); font-size:var(--fs-10); line-height:1.45; overflow:auto; }
+.ix-pr-thread { display:flex; flex-direction:column; gap:4px; padding:8px; background:var(--bg-1); border:1px solid var(--line-2); }
+.ix-pr-thread.resolved { opacity:.68; }
+.ix-pr-thread .msg { padding:7px 8px; background:var(--bg-2); border:1px solid var(--line-1); border-left:2px solid var(--brass-3); }
+.ix-pr-thread .msg.nested { margin-left:24px; border-left-color:var(--ok); }
+.ix-pr-thread .h { display:flex; gap:6px; align-items:center; margin-bottom:4px; font-family:var(--font-mono); font-size:var(--fs-10); }
+.ix-pr-thread .by { color:var(--brass-1); }
+.ix-pr-thread .at, .ix-pr-check .dur, .ix-pr-check .log { color:var(--fg-4); }
+.ix-pr-thread .body { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-1); line-height:1.4; }
+.ix-pr-check .findings { display:flex; flex-direction:column; gap:2px; padding:0 8px 7px 8px; }
+.ix-pr-check .findings span { padding:3px 6px; background:var(--err-bg); border:1px solid var(--err-border); color:var(--err-fg); font-family:var(--font-mono); font-size:var(--fs-10); }
+
+/* E4 · graph */
+.ix-graph-dag { width:100%; height:210px; background:var(--bg-1); border:1px solid var(--line-2); }
+.ix-graph-dag path { fill:none; stroke:var(--line-3); stroke-width:2; }
+.ix-graph-dag text { fill:var(--fg-3); font-family:var(--font-mono); font-size:10px; }
+.ix-graph-dag text.label { fill:var(--brass-1); font-size:9px; letter-spacing:.04em; }
+.ix-graph-dag g.active circle { stroke:var(--brass-1); stroke-width:2; filter:drop-shadow(0 0 5px rgb(var(--brass-glow)/.7)); }
+.ix-commits, .ix-stashes { min-height:0; overflow:auto; display:flex; flex-direction:column; gap:1px; }
+.ix-commit-row { display:grid; grid-template-columns:54px 96px minmax(0,1fr) 150px 42px 58px; gap:7px; align-items:center; min-height:25px; padding:4px 8px; background:var(--bg-1); border:1px solid var(--line-1); font-family:var(--font-mono); font-size:var(--fs-10); }
+.ix-commit-row .hash { color:var(--brass-1); }
+.ix-commit-row .subj { color:var(--fg-1); min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.ix-commit-row .branch, .ix-commit-row .age, .ix-commit-row .diff { color:var(--fg-4); }
+.ix-worktrees { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:7px; min-height:0; overflow:auto; }
+.ix-worktree-card { display:flex; flex-direction:column; gap:5px; padding:8px; background:var(--bg-1); border:1px solid var(--line-2); border-left:2px solid var(--line-2); font-family:var(--font-mono); font-size:var(--fs-10); }
+.ix-worktree-card.clean { border-left-color:var(--ok); }
+.ix-worktree-card.dirty { border-left-color:var(--warn); }
+.ix-worktree-card.stale { border-left-color:var(--err); }
+.ix-worktree-card .path { color:var(--fg-1); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.ix-worktree-card .branch { color:var(--brass-1); }
+.ix-worktree-card .keepers { display:flex; flex-wrap:wrap; gap:3px; }
+.ix-worktree-card .keepers span { padding:1px 5px; background:var(--bg-2); border:1px solid var(--line-1); color:var(--fg-3); }
+.ix-worktree-card .ft { display:flex; align-items:center; gap:5px; color:var(--fg-4); }
+.ix-worktree-card .ft button { margin-left:auto; padding:1px 5px; background:var(--bg-2); border:1px solid var(--line-1); color:var(--fg-3); font:inherit; cursor:pointer; }
+.ix-worktree-card .ft button + button { margin-left:0; }
+.ix-stash-row { background:var(--bg-1); border:1px solid var(--line-1); font-family:var(--font-mono); font-size:var(--fs-10); }
+.ix-stash-row .row { display:grid; grid-template-columns:72px 150px 94px minmax(0,1fr) 42px 52px; gap:6px; align-items:center; padding:5px 8px; cursor:pointer; }
+.ix-stash-row .id, .ix-stash-row .keeper { color:var(--brass-1); }
+.ix-stash-row .branch, .ix-stash-row .age { color:var(--fg-4); }
+.ix-stash-row .sum { color:var(--fg-1); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.ix-stash-row .detail { padding:5px 8px; border-top:1px solid var(--line-1); background:var(--bg-0); color:var(--fg-3); display:flex; gap:8px; }
+.ix-stash-row .detail span { margin-left:auto; color:var(--brass-1); }
+
+/* E5 · terminal/search */
+.ix-term-body { min-height:0; overflow:auto; padding:8px; background:var(--bg-1); border:1px solid var(--line-2); font-family:var(--font-mono); font-size:var(--fs-11); line-height:1.45; }
+.ix-term-line { color:var(--fg-2); white-space:pre-wrap; }
+.ix-term-line.prompt { color:var(--brass-1); margin-top:4px; }
+.ix-search-bar { display:grid; grid-template-columns:minmax(180px,1fr) auto auto minmax(130px,.5fr); gap:4px; padding:6px 8px; background:var(--bg-1); border:1px solid var(--line-1); }
+.ix-search-results { min-height:0; overflow:auto; display:flex; flex-direction:column; gap:4px; }
+.ix-search-file { background:var(--bg-1); border:1px solid var(--line-1); }
+.ix-search-file .file { padding:4px 8px; background:var(--bg-2); border-bottom:1px solid var(--line-1); color:var(--brass-1); font-family:var(--font-mono); font-size:var(--fs-10); }
+.ix-search-file .file span { float:right; color:var(--fg-4); }
+.ix-search-file .hit { display:grid; grid-template-columns:44px minmax(0,1fr); gap:6px; padding:3px 8px; border-bottom:1px solid var(--line-1); font-family:var(--font-mono); font-size:var(--fs-10); }
+.ix-search-file .hit span { color:var(--fg-4); text-align:right; }
+.ix-search-file code { color:var(--fg-2); white-space:pre-wrap; }
+.ix-search-file mark { background:rgb(var(--brass-glow)/.22); color:var(--brass-1); padding:0 1px; }
+.ix-find-wrap { position:relative; }
+.ix-find { display:grid; grid-template-columns:minmax(90px,1fr) minmax(90px,1fr) repeat(5,auto); gap:4px; padding:6px 8px; background:var(--bg-2); border:1px solid var(--line-2); }
+
+@media (max-width: 900px) {
+  .ix-edit-split-grid, .ix-review-grid, .ix-worktrees { grid-template-columns:1fr; }
+  .ix-pr-file .row { grid-template-columns:20px minmax(0,1fr) 64px; }
+  .ix-pr-file .diff, .ix-pr-file .rv { display:none; }
+  .ix-commit-row { grid-template-columns:54px 90px minmax(0,1fr) 44px; }
+  .ix-commit-row .branch, .ix-commit-row .diff { display:none; }
+  .ix-find, .ix-search-bar, .ix-tree-filter { grid-template-columns:1fr 1fr; }
+}

--- a/dashboard/design-system/preview/components.html
+++ b/dashboard/design-system/preview/components.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="../colors_and_type.css" />
   <link rel="stylesheet" href="../source_styles/tokens.css" />
   <link rel="stylesheet" href="../source_styles/primitives.css" />
-  <link rel="stylesheet" href="components.css?v=2" />
+  <link rel="stylesheet" href="components.css?v=3" />
   <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
   <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
   <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
@@ -32,6 +32,8 @@
   <script type="text/babel" src="cb-group-f.jsx"></script>
   <script type="text/babel" src="cb-group-h.jsx"></script>
   <script type="text/babel" src="cb-group-i.jsx"></script>
+  <script type="text/babel" src="cb-group-j.jsx"></script>
+  <script type="text/babel" src="cb-group-k.jsx"></script>
   <script type="text/babel" src="cb-root.jsx"></script>
 </body>
 </html>

--- a/dashboard/design-system/preview/index.html
+++ b/dashboard/design-system/preview/index.html
@@ -50,6 +50,7 @@
     <div class="grid">
       <a class="card" href="components.html"><span class="stripe"></span><span class="n">11 components · 31 variants</span><span class="title">Zone library</span><span class="desc">Topbar, ticker, KPI, lifeline, sidebar, swimlanes, deck, rail, composer, status bar, drawer.</span><span class="count">pannable design canvas</span></a>
       <a class="card" href="scope-phase2.html"><span class="stripe"></span><span class="n">Phase 2 scope</span><span class="title">Phase 2 Manifest</span><span class="desc">12 zones · 4 tracks · IDE backbone. Goal/Task/Comms/Obs/Cog scope locked.</span><span class="count">spec doc</span></a>
+      <a class="card" href="scope-phase3.html"><span class="stripe"></span><span class="n">Phase 3 scope</span><span class="title">Code IDE v2 Manifest</span><span class="desc">E1-E5 · 20 variants. Tree, editor, PR, graph, terminal/search.</span><span class="count">spec doc</span></a>
       <a class="card" href="code-mode.html"><span class="stripe"></span><span class="n">9 sections · split + 3D explode</span><span class="title">Code Mode</span><span class="desc">IDE layer: tree · editor · review · activity · split · z-axis exploded overlays.</span></a>
       <a class="card" href="swimlanes.html"><span class="stripe"></span><span class="n">5 extensions</span><span class="title">Swimlanes · extended</span><span class="desc">Empty · waterfall · handoff · collapsed groups · 3 density modes.</span></a>
       <a class="card" href="layers.html"><span class="stripe"></span><span class="n">5 overlays</span><span class="title">Stacked Overlays</span><span class="desc">Time · Parallel · Tools · Approve · Notes. Exploded 3D z-axis view.</span></a>
@@ -59,6 +60,15 @@
     <h2>Phase 2 · IDE backbone</h2>
     <div class="grid">
       <a class="card" href="components.html#ide-backbone"><span class="stripe"></span><span class="n">I0 · 3 variants</span><span class="title">IDE Backbone</span><span class="desc">Branch selector · keeper multi-select · operator nudge log. Cross-cuts all zones.</span><span class="count">game-changer · cockpit foundation</span></a>
+    </div>
+
+    <h2>Phase 3 · Code IDE plane</h2>
+    <div class="grid">
+      <a class="card" href="components.html#ide-tree"><span class="stripe"></span><span class="n">E1 · 4 variants</span><span class="title">File Tree Explorer</span><span class="desc">allowed_paths overlay · filter bar · recent/pinned tabs · diff annotated tree.</span></a>
+      <a class="card" href="components.html#ide-edit"><span class="stripe"></span><span class="n">E2 · 5 variants</span><span class="title">Editor Surfaces</span><span class="desc">Attribution gutter · split pane · merge resolver · inline review · blame gutter.</span></a>
+      <a class="card" href="components.html#ide-pr"><span class="stripe"></span><span class="n">E3 · 4 variants</span><span class="title">PR Inspector</span><span class="desc">PR header · files changed · review thread · CI checks with SafeAuto.</span></a>
+      <a class="card" href="components.html#ide-graph"><span class="stripe"></span><span class="n">E4 · 4 variants</span><span class="title">Branch / Git Graph</span><span class="desc">SVG DAG · commit list · worktree picker · stash recovery.</span></a>
+      <a class="card" href="components.html#ide-term"><span class="stripe"></span><span class="n">E5 · 3 variants</span><span class="title">Terminal / Search</span><span class="desc">Cascade-aware terminal · rg-style project search · find/replace overlay.</span></a>
     </div>
 
     <h2>Phase 2 · Work plane</h2>

--- a/dashboard/design-system/preview/scope-phase3.html
+++ b/dashboard/design-system/preview/scope-phase3.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8" />
+<title>MASC · Phase 3 Scope</title>
+<link rel="stylesheet" href="../colors_and_type.css" />
+<link rel="stylesheet" href="../source_styles/tokens.css" />
+<link rel="stylesheet" href="../source_styles/primitives.css" />
+<link rel="stylesheet" href="components.css" />
+<link rel="stylesheet" href="_preview.css" />
+<style>
+  body { margin:0; padding:0 0 96px; background:var(--bg-0); color:var(--fg-1); font:13px/1.45 var(--font-sans); }
+  .pg { max-width:1320px; margin:0 auto; padding:32px 40px 0; }
+  .pg-head { display:grid; grid-template-columns:1fr auto; gap:24px; align-items:end; padding-bottom:20px; margin-bottom:28px; border-bottom:1px solid var(--line-3); }
+  .eyebrow { font:500 10px/1 var(--font-mono); letter-spacing:.12em; text-transform:uppercase; color:var(--brass-1); margin-bottom:10px; }
+  h1 { margin:0 0 8px; font:500 26px/1.15 var(--font-sans); color:var(--fg-0); }
+  .sub { max-width:760px; color:var(--fg-3); }
+  .meta { text-align:right; font:10px/1.5 var(--font-mono); color:var(--fg-3); letter-spacing:.08em; text-transform:uppercase; }
+  .meta b { color:var(--brass-1); font-weight:500; }
+  .toc { display:grid; grid-template-columns:repeat(5,1fr); gap:1px; background:var(--line-3); border:1px solid var(--line-3); margin-bottom:34px; }
+  .toc a { display:block; padding:12px 14px; background:var(--bg-1); color:var(--fg-2); text-decoration:none; font:11px/1.55 var(--font-mono); }
+  .toc a b { display:block; color:var(--brass-1); font-size:10px; letter-spacing:.1em; text-transform:uppercase; margin-bottom:6px; }
+  .zones { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:14px; margin-bottom:36px; }
+  .zone { background:var(--bg-1); border:1px solid var(--line-2); padding:16px 18px 18px; }
+  .zhead { display:flex; align-items:baseline; gap:10px; padding-bottom:10px; margin-bottom:12px; border-bottom:1px dashed var(--line-2); }
+  .zid { font:500 10px/1 var(--font-mono); color:var(--bg-0); background:var(--brass-1); padding:4px 6px; }
+  .ztitle { margin:0; flex:1; color:var(--fg-1); font:500 14px/1.2 var(--font-sans); }
+  .zkind { color:var(--fg-3); font:10px/1 var(--font-mono); letter-spacing:.08em; text-transform:uppercase; }
+  .lead { margin:0 0 14px; color:var(--fg-2); font-size:12px; }
+  .lbl { margin:0 0 5px; color:var(--fg-3); font:500 9px/1 var(--font-mono); letter-spacing:.1em; text-transform:uppercase; }
+  ul { margin:0 0 14px; padding:0; list-style:none; display:grid; gap:4px; }
+  li { color:var(--fg-2); font:11px/1.45 var(--font-mono); }
+  li::before { content:"- "; color:var(--brass-1); }
+  code { color:var(--brass-1); font-family:var(--font-mono); }
+  table { width:100%; border-collapse:collapse; background:var(--bg-1); border:1px solid var(--line-2); font:11px/1.45 var(--font-mono); }
+  th, td { padding:8px 10px; border-bottom:1px solid var(--line-1); text-align:left; vertical-align:top; }
+  th { color:var(--fg-4); background:var(--bg-2); text-transform:uppercase; letter-spacing:.08em; }
+  td:first-child { color:var(--brass-1); white-space:nowrap; }
+  .accept { margin-top:30px; padding:16px 18px; background:var(--bg-1); border:1px solid var(--line-2); border-left:2px solid var(--brass-1); }
+  .accept h2 { margin:0 0 10px; font:500 15px/1.2 var(--font-sans); }
+  @media (max-width:900px) { .pg-head, .zones, .toc { grid-template-columns:1fr; } .meta { text-align:left; } }
+</style>
+</head>
+<body>
+<div class="pg">
+  <header class="pg-head">
+    <div>
+      <div class="eyebrow">Phase 3 · Code IDE v2</div>
+      <h1>MASC Cockpit IDE Plane</h1>
+      <div class="sub">The cockpit becomes code-aware: tree ownership, editor attribution, PR review, branch topology, terminal traces, and project search all share branch + keeper context.</div>
+    </div>
+    <div class="meta">zones <b>5</b><br/>variants <b>20</b><br/>files <b>j+k</b><br/>prototype <b>IDE</b></div>
+  </header>
+
+  <nav class="toc">
+    <a href="#e1"><b>E1</b>File tree explorer<br/>4 variants</a>
+    <a href="#e2"><b>E2</b>Editor surfaces<br/>5 variants</a>
+    <a href="#e3"><b>E3</b>PR inspector<br/>4 variants</a>
+    <a href="#e4"><b>E4</b>Branch / graph<br/>4 variants</a>
+    <a href="#e5"><b>E5</b>Terminal / search<br/>3 variants</a>
+  </nav>
+
+  <div class="zones">
+    <section class="zone" id="e1">
+      <div class="zhead"><span class="zid">E1</span><h2 class="ztitle">File Tree Explorer</h2><span class="zkind">navigation</span></div>
+      <p class="lead">The tree shows ownership, change state, and recent/pinned memory before the operator opens a file.</p>
+      <div class="lbl">Variants</div>
+      <ul><li>allowed_paths overlay</li><li>filter bar</li><li>recent / pinned / changed / search tabs</li><li>diff annotated tree</li></ul>
+      <div class="lbl">Public components</div>
+      <code>IxTreeAllowed · IxTreeFilter · IxTreeTabs · IxTreeDiff</code>
+    </section>
+
+    <section class="zone" id="e2">
+      <div class="zhead"><span class="zid">E2</span><h2 class="ztitle">Editor Surfaces</h2><span class="zkind">code</span></div>
+      <p class="lead">The editor explains who touched each line, what changed, what reviewers said, and how conflicts resolve.</p>
+      <div class="lbl">Variants</div>
+      <ul><li>attribution gutter</li><li>split 2-pane</li><li>3-way merge resolver</li><li>inline review</li><li>blame gutter</li></ul>
+      <div class="lbl">Public components</div>
+      <code>IxEditAttrib · IxEditSplit · IxEditMerge · IxEditReview · IxEditBlame</code>
+    </section>
+
+    <section class="zone" id="e3">
+      <div class="zhead"><span class="zid">E3</span><h2 class="ztitle">PR Inspector</h2><span class="zkind">review</span></div>
+      <p class="lead">PR state, file diffs, comment threads, and CI/SafeAuto status stay inside the cockpit.</p>
+      <div class="lbl">Variants</div>
+      <ul><li>PR header</li><li>files changed</li><li>comment thread</li><li>CI checks panel</li></ul>
+      <div class="lbl">Public components</div>
+      <code>IxPrHeader · IxPrFiles · IxPrThread · IxPrChecks</code>
+    </section>
+
+    <section class="zone" id="e4">
+      <div class="zhead"><span class="zid">E4</span><h2 class="ztitle">Branch / Git Graph</h2><span class="zkind">topology</span></div>
+      <p class="lead">Parallel keeper work becomes navigable through branch DAGs, attributed commits, worktrees, and stashes.</p>
+      <div class="lbl">Variants</div>
+      <ul><li>SVG branch DAG</li><li>commit list with keeper attribution</li><li>worktree picker</li><li>stash list</li></ul>
+      <div class="lbl">Public components</div>
+      <code>IxGraphDag · IxGraphCommits · IxGraphWorktrees · IxGraphStashes</code>
+    </section>
+
+    <section class="zone" id="e5">
+      <div class="zhead"><span class="zid">E5</span><h2 class="ztitle">Terminal / Search</h2><span class="zkind">tools</span></div>
+      <p class="lead">The terminal is cascade-aware, while search and find/replace share the active branch and editor context.</p>
+      <div class="lbl">Variants</div>
+      <ul><li>cascade-aware terminal</li><li>rg-style project search</li><li>find / replace overlay</li></ul>
+      <div class="lbl">Public components</div>
+      <code>IxTerm · IxSearch · IxFindReplace</code>
+    </section>
+  </div>
+
+  <table>
+    <thead><tr><th>Surface</th><th>Wiring</th><th>Design constraint</th></tr></thead>
+    <tbody>
+      <tr><td>Preview canvas</td><td><code>components.html</code> loads <code>cb-group-j.jsx</code> and <code>cb-group-k.jsx</code>; <code>cb-root.jsx</code> adds five sections.</td><td>All component classes use the <code>.ix-*</code> prefix.</td></tr>
+      <tr><td>Cockpit prototype</td><td><code>IdePlane</code> composes tree, editor, PR, graph, search, and terminal modes from the same public components.</td><td>No duplicate cockpit-only component implementation.</td></tr>
+      <tr><td>Seed data</td><td><code>window.MASC_P3</code> keeps realistic keeper, PR, git, file, and search fixtures in one place.</td><td>Data stays plausible MASC content; no lorem ipsum.</td></tr>
+    </tbody>
+  </table>
+
+  <div class="accept">
+    <h2>Acceptance Criteria</h2>
+    <ul>
+      <li>All 20 variants render under <code>preview/components.html</code>.</li>
+      <li>Every public component accepts <code>{ branch, keepers }</code> and tolerates <code>Set</code> or array keeper context.</li>
+      <li>Cockpit IDE mode toggles between edit, review, merge, graph, and search without console errors.</li>
+      <li>Bottom terminal is collapsible in the cockpit prototype.</li>
+      <li>Visual language remains dark brass, mono-first, dense, hairline-bordered, and icon-light.</li>
+    </ul>
+  </div>
+</div>
+</body>
+</html>

--- a/dashboard/design-system/ui_kits/cockpit/Planes.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/Planes.jsx
@@ -139,20 +139,58 @@ function CognitionPlane({ branch, keepers }) {
 }
 
 // ═════════════════════════════════════════════════════════════
-// IDE PLANE — I0 IDE Backbone (branch · keepers · operator nudges)
+// IDE PLANE — Phase 3 Code IDE v2
 // ═════════════════════════════════════════════════════════════
 function IdePlane({ branch, keepers }) {
+  const [mode, setMode] = usePlaneState("edit");
+  const [terminalOpen, setTerminalOpen] = usePlaneState(true);
+  const ctx = { branch, keepers };
+  const keeperCount = keepers ? keepers.size : 0;
+
+  const center =
+    mode === "review" ? <window.IxEditReview {...ctx}/> :
+    mode === "merge"  ? <window.IxEditMerge {...ctx}/> :
+    mode === "graph"  ? <window.IxGraphDag {...ctx}/> :
+    mode === "search" ? <window.IxSearch {...ctx}/> :
+    <window.IxEditAttrib {...ctx}/>;
+
+  const right =
+    mode === "review" ? <window.IxPrThread {...ctx}/> :
+    mode === "merge" || mode === "graph" || mode === "search" ? null :
+    <div className="ide-v2-right-stack">
+      <window.IxPrHeader {...ctx}/>
+      <window.IxPrChecks {...ctx}/>
+    </div>;
+
   return (
-    <div className="plane">
-      <PlaneHeader title="IDE Backbone" subtitle="Operator just observes & nudges; keepers do the work." branch={branch} keepers={keepers} />
-      <div className="plane-body">
-        <div className="plane-ide-grid">
-          <div><window.BranchSelector/></div>
-          <div style={{display:"flex",flexDirection:"column",gap:12}}>
-            <window.KeeperMultiSelect/>
-            <window.OperatorNudgeLog/>
-          </div>
+    <div className="plane ide-v2">
+      <PlaneHeader title="IDE Plane" subtitle="Tree · editor · PR · graph · terminal/search." branch={branch} keepers={keepers} />
+      <div className="ide-v2-modebar">
+        <div className="ide-v2-branch">
+          <span className="lbl">branch</span>
+          <span className="name">{branch || "main"}</span>
+          <span className="meta">{keeperCount} keepers · worktree active</span>
         </div>
+        <div className="ide-v2-modes">
+          {["edit","review","merge","graph","search"].map(m => (
+            <button key={m} className={mode === m ? "active" : ""} onClick={() => setMode(m)}>{m}</button>
+          ))}
+        </div>
+        <button className={`ide-v2-terminal-toggle ${terminalOpen ? "active" : ""}`} onClick={() => setTerminalOpen(v => !v)}>
+          terminal
+        </button>
+      </div>
+      <div className={`ide-v2-body ${right ? "" : "wide"} ${terminalOpen ? "term-open" : ""}`}>
+        <div className="ide-v2-tree">
+          <window.IxTreeDiff {...ctx}/>
+        </div>
+        <div className="ide-v2-center">{center}</div>
+        {right && <div className="ide-v2-right">{right}</div>}
+        {terminalOpen && (
+          <div className="ide-v2-terminal">
+            <window.IxTerm {...ctx}/>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/dashboard/design-system/ui_kits/cockpit/cockpit.css
+++ b/dashboard/design-system/ui_kits/cockpit/cockpit.css
@@ -774,6 +774,122 @@ button { font: inherit; }
   align-items: start;
 }
 
+/* Phase 3 IDE plane composition */
+.ide-v2 { min-width: 0; }
+.ide-v2-modebar {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) auto auto;
+  gap: 8px;
+  align-items: center;
+  padding: 6px 10px;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--line-2);
+}
+.ide-v2-branch {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+.ide-v2-branch .lbl {
+  color: var(--fg-4);
+  text-transform: uppercase;
+  letter-spacing: .1em;
+}
+.ide-v2-branch .name {
+  min-width: 0;
+  max-width: 260px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 2px 7px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-1);
+  color: var(--brass-1);
+}
+.ide-v2-branch .meta { color: var(--fg-4); }
+.ide-v2-modes {
+  display: flex;
+  gap: 2px;
+  overflow-x: auto;
+}
+.ide-v2-modes::-webkit-scrollbar { display: none; }
+.ide-v2-modes button,
+.ide-v2-terminal-toggle {
+  padding: 4px 9px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-1);
+  color: var(--fg-3);
+  font: 10px/1 var(--font-mono);
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.ide-v2-modes button.active,
+.ide-v2-terminal-toggle.active {
+  color: var(--brass-1);
+  border-color: var(--brass-3);
+  background: rgb(var(--brass-glow)/.08);
+}
+.ide-v2-body {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(220px, 25%) minmax(0, 1fr) minmax(260px, 28%);
+  grid-template-rows: minmax(0, 1fr) minmax(180px, 34%);
+  gap: 8px;
+  padding: 8px;
+  background: var(--bg-0);
+}
+.ide-v2-body.wide {
+  grid-template-columns: minmax(220px, 25%) minmax(0, 1fr);
+}
+.ide-v2-tree,
+.ide-v2-center,
+.ide-v2-right,
+.ide-v2-terminal {
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+.ide-v2-tree { grid-row: 1 / span 2; }
+.ide-v2-center { grid-column: 2; grid-row: 1; }
+.ide-v2-right { grid-column: 3; grid-row: 1; }
+.ide-v2-right-stack {
+  height: 100%;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 8px;
+}
+.ide-v2-terminal {
+  grid-column: 2 / span 2;
+  grid-row: 2;
+}
+.ide-v2-body.wide .ide-v2-terminal { grid-column: 2; }
+.ide-v2-body:not(.term-open) { grid-template-rows: minmax(0, 1fr); }
+
+@media (max-width: 1200px) {
+  .ide-v2-body,
+  .ide-v2-body.wide {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(360px, 1fr) auto auto;
+  }
+  .ide-v2-tree,
+  .ide-v2-center,
+  .ide-v2-right,
+  .ide-v2-terminal {
+    grid-column: 1;
+    grid-row: auto;
+    min-height: 240px;
+  }
+  .ide-v2-modebar {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Mode tabs need to scroll horizontally on narrow screens (now 6 modes) */
 .tb-modes { overflow-x: auto; max-width: 360px; flex-shrink: 0; }
 .tb-modes::-webkit-scrollbar { display: none; }

--- a/dashboard/design-system/ui_kits/cockpit/index.html
+++ b/dashboard/design-system/ui_kits/cockpit/index.html
@@ -21,6 +21,8 @@
 <script type="text/babel" src="../../preview/cb-group-f.jsx"></script>
 <script type="text/babel" src="../../preview/cb-group-h.jsx"></script>
 <script type="text/babel" src="../../preview/cb-group-i.jsx"></script>
+<script type="text/babel" src="../../preview/cb-group-j.jsx"></script>
+<script type="text/babel" src="../../preview/cb-group-k.jsx"></script>
 <script type="text/babel" src="Chrome.jsx"></script>
 <script type="text/babel" src="Panels.jsx"></script>
 <script type="text/babel" src="Planes.jsx"></script>


### PR DESCRIPTION
## Summary

- Adds Phase 3 Code IDE v2 design-system components for E1-E5: file tree, editor, PR inspector, git graph, terminal, and search.
- Introduces `preview/cb-group-j.jsx` and `preview/cb-group-k.jsx` with 20 public component variants backed by shared `window.MASC_P3` seed data.
- Wires the components into the preview canvas, Phase 3 scope page, design-system hub, and cockpit `IdePlane` so the prototype uses the same component surface.

## Scope

- Follow-up to #10283.
- Covers Phase 3 issues: #10276, #10277, #10278, #10279, #10280, #10281, #10282.
- Inherited blocker tracked separately: #10326.
- No backend API changes.
- No new package dependencies.

## Validation

- `git diff --check origin/main..HEAD` passed.
- GitHub CI passed on head `8fc37571ea55857cbe786cbd4ed2c11b3a2272e2`:
  - `Build and Test`
  - `Dashboard`
  - `Health`
  - `Lint`
  - `Meta Guards`
  - `CI Gate`
- Babel JSX transform passed for:
  - `dashboard/design-system/preview/cb-group-j.jsx`
  - `dashboard/design-system/preview/cb-group-k.jsx`
  - `dashboard/design-system/preview/cb-root.jsx`
  - `dashboard/design-system/ui_kits/cockpit/Planes.jsx`
- Static preview server returned HTTP 200 for:
  - `preview/components.html`
  - `preview/scope-phase3.html`
  - `ui_kits/cockpit/index.html`
- Local `pnpm run typecheck` could not run in this checkout because `dashboard/node_modules` is missing and `tsc` is unavailable; CI Dashboard installed dependencies and passed TypeScript typecheck plus dashboard tests.
- Local `scripts/dashboard-drift-check.sh` reports existing `dashboard/src` drift counts when run directly from this checkout; CI Dashboard drift gate passed for this PR. The local-main drift diagnostic remains tracked in #10326.

## Notes

- Playwright visual verification was attempted but blocked by the existing MCP browser profile lock.
- The PR is opened as draft for review of the component system and cockpit composition.
