### PR TITLE
fix(dashboard): ignore MCP control SSE notifications (#10320)

### DIFF
--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -137,6 +137,37 @@ describe('parseSSEMessage', () => {
     expect(msg?.type).toBe('oas:slot_scheduler_observed')
   })
 
+  it('silently ignores MCP JSON-RPC control notifications on the SSE stream', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(parseSSEMessage({
+      jsonrpc: '2.0',
+      method: 'notifications/tools/list_changed',
+    })).toBeNull()
+    expect(parseSSEMessage({
+      jsonrpc: '2.0',
+      method: 'notifications/resources/updated',
+      params: { uri: 'status.json' },
+    })).toBeNull()
+    expect(parseSSEMessage({
+      jsonrpc: '2.0',
+      method: 'notifications/message',
+      params: { level: 'info', data: 'ready' },
+    })).toBeNull()
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('still warns when a dashboard board notification is missing its event type', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(parseSSEMessage({
+      jsonrpc: '2.0',
+      method: 'notifications/board',
+      params: { post_id: 'p1' },
+    })).toBeNull()
+    expect(warnSpy).toHaveBeenCalledOnce()
+    warnSpy.mockRestore()
+  })
+
   it('returns null and warns on invalid input', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const msg = parseSSEMessage({ type: 'not_a_real_type' })

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -141,6 +141,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
 }
 
+function isIgnorableMcpNotification(value: unknown): boolean {
+  if (!isRecord(value)) return false
+  if (value.jsonrpc !== '2.0') return false
+  if (typeof value.method !== 'string') return false
+  if (value.method === 'notifications/board') return false
+  return value.method.startsWith('notifications/')
+}
+
 function isSSEEventType(value: unknown): value is SSEEventType {
   return typeof value === 'string' && (
     FIXED_SSE_EVENT_TYPES.has(value) || value.startsWith('oas:')
@@ -280,6 +288,7 @@ export class SSESchemaDriftError extends Error {
  *  On failure logs a console.warn with the drift issue and returns null;
  *  the caller drops the event. */
 export function parseSSEMessage(raw: unknown): SSEMessage | null {
+  if (isIgnorableMcpNotification(raw)) return null
   const result = SSEMessageSchema.safeParse(raw)
   if (result.success) return result.data
   // Surface drift in dev tools without crashing the stream. Aggregate issues


### PR DESCRIPTION
## Summary
- stop classifying MCP JSON-RPC control notifications as dashboard SSE schema drift
- keep malformed dashboard board notifications noisy so real server/client contract drift still surfaces
- add focused parser coverage for both cases

## Evidence
- live observer SSE stream on 127.0.0.1:8935 carried valid dashboard events plus MCP/runtime traffic; `notifications/*` control events are not dashboard events
- server code can broadcast `notifications/tools/list_changed`, `notifications/resources/updated`, and `notifications/message` on the shared SSE transport

## Verification
- `pnpm install --offline --frozen-lockfile`
- `pnpm exec vitest run src/schemas/sse.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint src/schemas/sse.ts src/schemas/sse.test.ts` (files ignored by current eslint target list; no lint errors emitted)
- `git diff --check`

Closes #10320