### PR TITLE
diag(agent-stress): emit Timeout/Parse_degraded from failure path (#10341)

### DIFF
--- a/lib/keeper/keeper_agent_memory_episode.ml
+++ b/lib/keeper/keeper_agent_memory_episode.ml
@@ -64,6 +64,47 @@ let record_success
     Log.Keeper.error "keeper:%s episode_create failed: %s"
       keeper_name (Printexc.to_string exn)
 
+(** #10341: classify [error_kind] into the matching {!Agent_stress.stress_kind}
+    so the stress ledger receives signal for failure modes other than the
+    keepalive-only [Failure_streak] currently emitted by
+    [keeper_keepalive].  Returns [None] for kinds that do not map to a
+    pre-existing stress dimension (those are still recorded in the
+    institution episode store via [store_failed_turn_episode]).
+
+    Mapping rationale:
+    - [*_timeout] / [*_timeout_*] / [oas_timeout_budget] → [Timeout]
+      (matches the Timeout dimension defined in agent_stress.mli).
+    - [completion_contract_violation] → [Parse_degraded] (the LLM
+      response failed contract parse — semantically a parse-degraded
+      output, not a timeout or hard failure streak). *)
+let stress_kind_of_error_kind error_kind : Agent_stress.stress_kind option =
+  let trimmed = String.trim error_kind in
+  let ends_with suffix s =
+    let ls = String.length s in
+    let lp = String.length suffix in
+    ls >= lp && String.equal (String.sub s (ls - lp) lp) suffix
+  in
+  let contains needle s =
+    let ln = String.length needle in
+    let ls = String.length s in
+    if ln = 0 || ln > ls then false
+    else
+      let rec loop i =
+        if i + ln > ls then false
+        else if String.equal (String.sub s i ln) needle then true
+        else loop (i + 1)
+      in
+      loop 0
+  in
+  if trimmed = "" then None
+  else if ends_with "_timeout" trimmed
+       || contains "_timeout_" trimmed
+       || String.equal trimmed "oas_timeout_budget"
+  then Some Agent_stress.Timeout
+  else if String.equal trimmed "completion_contract_violation"
+  then Some Agent_stress.Parse_degraded
+  else None
+
 let record_failure
     ~(config : Coord_utils.config)
     ~(keeper_name : string)
@@ -76,6 +117,19 @@ let record_failure
   try
     Memory_oas_bridge.store_failed_turn_episode ~memory
       ~keeper_name ~turn ~trace_id ~error_kind ~error_message ();
+    (* #10341: surface non-keepalive failure modes (timeout, parse) into
+       the Agent_stress ledger so the stress dimensions defined in
+       agent_stress.mli stop being write-only-for-Failure_streak. *)
+    (match stress_kind_of_error_kind error_kind with
+     | None -> ()
+     | Some kind ->
+         Agent_stress.record
+           {
+             agent_name = keeper_name;
+             room_id = "";
+             kind;
+             timestamp = Unix.gettimeofday ();
+           });
     let episodes, procedures =
       Memory_oas_bridge.flush_incremental ~memory ~agent_name:keeper_name
     in

--- a/test/dune
+++ b/test/dune
@@ -136,6 +136,7 @@
         test_worktree_status_single_flight_9632
         test_tool_input_validation
         test_failure_learnings_10325
+        test_agent_stress_emit_10341
         test_autoresearch_codegen
         test_autoresearch_oas_primitives
         test_autoresearch_target_score
@@ -285,6 +286,7 @@
           test_worktree_status_single_flight_9632
           test_tool_input_validation
           test_failure_learnings_10325
+          test_agent_stress_emit_10341
           test_autoresearch_codegen
           test_autoresearch_oas_primitives
           test_autoresearch_target_score

--- a/test/test_agent_stress_emit_10341.ml
+++ b/test/test_agent_stress_emit_10341.ml
@@ -1,0 +1,98 @@
+(** Agent_stress emit-site coverage for non-keepalive failure modes.
+
+    Regression for masc-mcp #10341: the [Agent_stress] module defines
+    five stress dimensions (Failure_streak, Fallback_approval, Timeout,
+    Parse_degraded, Task_released) but only [Failure_streak] was being
+    written by [keeper_keepalive].  Result: 24h+ stale ledger with 1
+    entry while institution episodes recorded 76 turn failures.
+
+    This test pins the [stress_kind_of_error_kind] classifier so future
+    error_kind additions get explicit decisions. *)
+
+open Alcotest
+open Masc_mcp
+
+let kind_eq a b =
+  match (a, b) with
+  | Agent_stress.Timeout, Agent_stress.Timeout -> true
+  | Agent_stress.Parse_degraded, Agent_stress.Parse_degraded -> true
+  | Agent_stress.Failure_streak n, Agent_stress.Failure_streak m -> n = m
+  | Agent_stress.Fallback_approval, Agent_stress.Fallback_approval -> true
+  | Agent_stress.Task_released, Agent_stress.Task_released -> true
+  | Agent_stress.Turn_failure _, Agent_stress.Turn_failure _ ->
+      (* Turn_failure carries diagnostic record fields (consecutive,
+         threshold, ...) added by #10362.  This test suite only
+         exercises the [stress_kind_of_error_kind] classifier from
+         #10341 which never returns Turn_failure, so structural
+         equality on the variant tag is sufficient. *)
+      true
+  | _ -> false
+
+let opt_kind = testable
+    (fun fmt -> function
+      | None -> Fmt.string fmt "None"
+      | Some Agent_stress.Timeout -> Fmt.string fmt "Some Timeout"
+      | Some Agent_stress.Parse_degraded -> Fmt.string fmt "Some Parse_degraded"
+      | Some (Agent_stress.Failure_streak n) ->
+          Fmt.pf fmt "Some (Failure_streak %d)" n
+      | Some Agent_stress.Fallback_approval ->
+          Fmt.string fmt "Some Fallback_approval"
+      | Some Agent_stress.Task_released -> Fmt.string fmt "Some Task_released"
+      | Some (Agent_stress.Turn_failure _) ->
+          Fmt.string fmt "Some Turn_failure")
+    (fun a b ->
+       match (a, b) with
+       | None, None -> true
+       | Some x, Some y -> kind_eq x y
+       | _ -> false)
+
+let classify = Keeper_agent_memory_episode.stress_kind_of_error_kind
+
+let test_oas_timeout_budget_to_timeout () =
+  check opt_kind "oas_timeout_budget -> Timeout"
+    (Some Agent_stress.Timeout)
+    (classify "oas_timeout_budget")
+
+let test_turn_timeout_to_timeout () =
+  check opt_kind "turn_timeout -> Timeout"
+    (Some Agent_stress.Timeout)
+    (classify "turn_timeout");
+  check opt_kind "ambiguous_post_commit_timeout -> Timeout"
+    (Some Agent_stress.Timeout)
+    (classify "ambiguous_post_commit_timeout");
+  check opt_kind "autonomous_slot_wait_timeout -> Timeout"
+    (Some Agent_stress.Timeout)
+    (classify "autonomous_slot_wait_timeout");
+  check opt_kind "turn_timeout_after_queue_wait -> Timeout"
+    (Some Agent_stress.Timeout)
+    (classify "turn_timeout_after_queue_wait")
+
+let test_completion_contract_violation_to_parse_degraded () =
+  check opt_kind "completion_contract_violation -> Parse_degraded"
+    (Some Agent_stress.Parse_degraded)
+    (classify "completion_contract_violation")
+
+let test_unmapped_kinds_return_none () =
+  check opt_kind "cascade_exhausted -> None"
+    None (classify "cascade_exhausted");
+  check opt_kind "no_tool_capable_provider -> None"
+    None (classify "no_tool_capable_provider");
+  check opt_kind "empty string -> None"
+    None (classify "");
+  check opt_kind "whitespace -> None"
+    None (classify "   ")
+
+let () =
+  run "agent_stress_emit_10341"
+    [
+      ("classifier", [
+           test_case "oas_timeout_budget maps to Timeout" `Quick
+             test_oas_timeout_budget_to_timeout;
+           test_case "*_timeout suffix maps to Timeout" `Quick
+             test_turn_timeout_to_timeout;
+           test_case "completion_contract_violation maps to Parse_degraded"
+             `Quick test_completion_contract_violation_to_parse_degraded;
+           test_case "unmapped kinds return None" `Quick
+             test_unmapped_kinds_return_none;
+         ]);
+    ]


### PR DESCRIPTION
## 요약

**Issue**: #10341 — `Agent_stress` 모듈은 5개 stress dimension(Failure_streak, Fallback_approval, **Timeout**, **Parse_degraded**, Task_released)을 type-level에 정의하지만 실제 emit은 1종(Failure_streak)만. 24h+ 가동 fleet에서 `agent_stress.jsonl`에 1 entry, 같은 기간 institution_episodes는 76 turn failure. **Stress detector가 fleet failure의 0.5%만 capture**.

## Fix scope (부분 fix)

이 PR은 issue의 **옵션 B의 timeout/parse 부분**을 wire-up. `record_failure` (실패 episode store path)에서 `error_kind` → `Agent_stress.kind` 매핑하여 emit:

| `error_kind` | `Agent_stress.kind` |
|--------------|---------------------|
| `oas_timeout_budget` | `Timeout` |
| `turn_timeout` / `*_timeout_*` 등 timeout suffix | `Timeout` |
| `completion_contract_violation` | `Parse_degraded` |
| `cascade_exhausted` 등 기타 | (emit 없음 — 의도적 silent) |

selective mapping 의도: clean semantic match 있는 kind만 emit. unrelated kind는 ledger를 generic dump로 만들지 않도록 silent. `Failure_streak`는 `keeper_keepalive`가 계속 소유 (streak counter는 single failure에서 misleading).

## 미완 (후속)

- 모듈 rename (옵션 A): `Agent_stress` → `Heartbeat_stress` 또는 다른 이름. 지금 scope에서는 너무 invasive.
- `Fallback_approval` emit: anti-rationalization fallback 경로에 emit 사이트 미상.
- `Task_released` emit: keeper task 양도/포기 경로에 emit 사이트 미상.
- 3개 미와이어 dimension은 별도 follow-up PR로.

## 검증

```text
DUNE_CACHE=disabled dune build --root . --cache=disabled @check
→ EXIT=0

dune exec test/test_agent_stress_emit_10341.exe
→ 4/4 OK
  - oas_timeout_budget → Timeout
  - 4개 *_timeout suffix → Timeout
  - completion_contract_violation → Parse_degraded
  - cascade_exhausted / blank → None (silent)
```

## 영향 (예상)

운영 환경에서 keeper turn fail 시 `error_kind`가 timeout-class면 `agent_stress.jsonl`에 entry 추가. 24h후:
- Before: 1 entry / 76 failure (0.5%)
- After (예상): timeout 비율에 비례 (memory `feedback_keeper-5gate-fallback-pressure.md`의 5-gate 분포에서 oas_timeout_budget이 dominant fallback의 36/200, ~18%)

dashboard `Agent_stress.recent` API consumer는 자동으로 새 시그널 표시.

## Defensive guards

- Draft + `do-not-merge` label
- `gh pr merge --disable-auto`

## 관련

- Issue: `#10341`
- 메모리: `feedback_keeper-5gate-fallback-pressure.md` (5-gate fallback 분포)
- 인접: `#10325` (institution episodes failure learnings boilerplate — 같은 layer의 다른 측면)
