### PR TITLE
perf(keeper): drop per-call Re.compile from substring keepers, byte-wise String_util

### DIFF
--- a/lib/core/string_util.ml
+++ b/lib/core/string_util.ml
@@ -1,21 +1,52 @@
+(* Byte-wise substring containment.
+
+   Old form allocated [String.sub] per inner-loop step; this version
+   uses [String.unsafe_get] with index-checked match.  Empty-needle
+   short-circuits to [true] (matching [Re.str ""] / [Re.execp]
+   semantics that callers relied on). *)
 let contains_substring haystack needle =
   let hay_len = String.length haystack in
   let needle_len = String.length needle in
   if needle_len = 0 then true
   else if needle_len > hay_len then false
   else
-    let rec loop idx =
-      if idx + needle_len > hay_len then false
-      else if String.sub haystack idx needle_len = needle then true
-      else loop (idx + 1)
+    let rec match_at i j =
+      if j = needle_len then true
+      else if String.unsafe_get haystack (i + j)
+            <> String.unsafe_get needle j
+      then false
+      else match_at i (j + 1)
+    in
+    let last = hay_len - needle_len in
+    let rec loop i =
+      if i > last then false
+      else if match_at i 0 then true
+      else loop (i + 1)
     in
     loop 0
 
+(* ASCII case-insensitive substring containment without lowercasing
+   either string.  Lowering happens byte-by-byte during compare. *)
 let contains_substring_ci haystack needle =
-  needle <> "" &&
-  contains_substring
-    (String.lowercase_ascii haystack)
-    (String.lowercase_ascii needle)
+  let hay_len = String.length haystack in
+  let needle_len = String.length needle in
+  if needle_len = 0 then false
+  else if needle_len > hay_len then false
+  else
+    let rec match_at i j =
+      if j = needle_len then true
+      else
+        let h = Char.lowercase_ascii (String.unsafe_get haystack (i + j)) in
+        let n = Char.lowercase_ascii (String.unsafe_get needle j) in
+        if h <> n then false else match_at i (j + 1)
+    in
+    let last = hay_len - needle_len in
+    let rec loop i =
+      if i > last then false
+      else if match_at i 0 then true
+      else loop (i + 1)
+    in
+    loop 0
 
 type truncation =
   | Untouched of string

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -837,13 +837,11 @@ let priority_for_kind ~(kind : string) : int =
   | "progress" -> 66
   | _ -> 60
 
+(* Byte-wise containment via [String_util.contains_substring_ci] —
+   per-call [Re.compile] is gone and the two [String.lowercase_ascii]
+   allocations are avoided since the helper folds case inline. *)
 let contains_any_ci (text : string) (needles : string list) : bool =
-  let hay = String.lowercase_ascii text in
-  List.exists
-    (fun needle ->
-      let n = String.lowercase_ascii needle in
-      n <> "" && Re.execp (Re.str n |> Re.compile) hay)
-    needles
+  List.exists (String_util.contains_substring_ci text) needles
 
 let signal_bonus ~(text : string) : int =
   let high_priority_words = [

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -144,21 +144,13 @@ let is_memory_recall_query (s : string) : bool =
     "뭐라고 물어봤"; (* "what did I ask" *)
   ] in
   let needles = en_keywords @ ko_keywords in
-  List.exists (fun n ->
-    Re.execp (Re.str n |> Re.compile) q
-  ) needles
+  List.exists (String_util.contains_substring q) needles
 
 let expected_topic_hint (s : string) : string option =
   let q = String.lowercase_ascii s in
-  let has_ko needle =
-    Re.execp (Re.str needle |> Re.compile) s
-  in
-  let has_en needle =
-    Re.execp (Re.str needle |> Re.compile) q
-  in
-  if Re.execp (Re.str "날씨" |> Re.compile) s
-     || Re.execp (Re.str "weather" |> Re.compile) q
-  then
+  let has_ko needle = String_util.contains_substring s needle in
+  let has_en needle = String_util.contains_substring q needle in
+  if has_ko "날씨" || has_en "weather" then
     Some "weather"
   else if has_ko "첫 질문"
        || has_en "first question"

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -385,7 +385,7 @@ let board_signal_match
       |> List.filter (fun target ->
              let needle = "@" ^ String.lowercase_ascii (String.trim target) in
              needle <> "@"
-             && Re.execp (Re.str needle |> Re.compile) haystack)
+             && String_util.contains_substring haystack needle)
     in
     if matched_targets <> [] then
       { explicit_mention = true; matched_targets; score = 100 }
@@ -597,10 +597,8 @@ let collect_board_events ~(base_path : string) ~(continuity_summary : string)
              in
              List.exists
                (fun target ->
-                 let needle =
-                   "@" ^ String.lowercase_ascii target
-                 in
-                 Re.execp (Re.str needle |> Re.compile) haystack)
+                 let needle = "@" ^ String.lowercase_ascii target in
+                 String_util.contains_substring haystack needle)
                targets)
            recent)
     in


### PR DESCRIPTION
## Summary

Four keeper hot-path substring helpers compiled fresh `Re.t` per call:

- **`Keeper_memory_policy.contains_any_ci`** — 14 keepers × turn × N keywords paid `Re.compile` + 2 `String.lowercase_ascii` per needle.
- **`Keeper_world_observation`** (×2) — mention scan over board posts rebuilt `Re.t` per `(target × post)`.
- **`Keeper_memory_recall.expected_topic_hint`** — 6+ inline `Re.execp (Re.str ... |> Re.compile)` per query; every memory recall paid the cost.

All sites collapse to substring containment. `String_util` already exposes `contains_substring` / `contains_substring_ci`; both are now rewritten as byte-wise scans using `String.unsafe_get`:

```ocaml
(* before *)
let contains_substring haystack needle =
  ...
  if idx + needle_len > hay_len then false
  else if String.sub haystack idx needle_len = needle then true
  ...

(* after *)
let contains_substring haystack needle =
  ...
  let rec match_at i j =
    if j = needle_len then true
    else if String.unsafe_get haystack (i + j) <> String.unsafe_get needle j then false
    else match_at i (j + 1)
  in
  ...

(* contains_substring_ci folds case inline during compare,
   no String.lowercase_ascii pre-allocation *)
```

Keepers switch to these helpers — per-call `Re.compile` is gone, both `String.lowercase_ascii` allocations are avoided in the CI path.

Same anti-pattern series:
- #10250 / #10252: `Mention` (merged)
- #10260: `Coord_gc.mentions_open_task` (merged)
- #10267: `Mcp_server_eio_call_tool.contains_casefold` (merged)
- #10286: dashboard helpers (merged)
- #10301: `Bounded` + `Auto_recall` (merged)
- #10303: `Masc_error_recovery` + `Coord_git` (merged)
- #10315: `Prompt_registry.render_template` (merged)
- #10323: link preview module hoist (merged)
- #10324: `Safe_path` + `validate_room_id` (merged)
- #10337: `Verification` + `Tool_library` (in-flight)
- This PR: keepers + `String_util` byte-wise

## Test plan
- [x] `dune build @check` clean
- [x] `dune build` for downstream test executables (test_anti_rationalization, test_keeper_shell_containment, test_team_memory, test_keeper_bash_safety) clean
- Behavior preserved:
  - `String_util.contains_substring`: empty-needle `true`, `nlen>hlen` `false`, byte equality identical to `String.sub` compare.
  - `String_util.contains_substring_ci`: empty-needle `false` (matches old short-circuit), `Char.lowercase_ascii` is identical to `String.lowercase_ascii` byte-by-byte on ASCII.
  - Keeper helpers: same logical predicate, just different inner primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)