### PR TITLE
fix(verification): tighten literal substring helper contract

### DIFF
--- a/lib/verification.ml
+++ b/lib/verification.ml
@@ -209,24 +209,22 @@ let request_of_yojson = function
 let generate_id () =
   Random_id.prefixed ~prefix:"vrf-" ~bytes:16
 
-(* Byte-wise substring containment.
+(* Byte-wise non-empty literal substring containment.
 
    [Contains]/[Not_contains] criteria interpolate user-supplied needles,
    so [Re.compile] cannot be hoisted.  But these are pure substring
-   checks with no regex semantics — every criterion evaluation
+   checks with no regex semantics: every criterion evaluation
    previously paid a fresh DFA build before [execp] could run.  Replace
-   with a naive scan; needle/haystack are bounded by criterion shape
-   and serialised JSON output so there is no DFA gain to lose. *)
-let needle_in_string ~needle haystack =
+   with a bounded scan and keep the empty-needle contract local to this
+   helper: [Contains ""] must fail and [Not_contains ""] must pass. *)
+let contains_nonempty_literal ~needle haystack =
   let nlen = String.length needle in
   let hlen = String.length haystack in
-  if nlen = 0 then true
-  else if nlen > hlen then false
+  if nlen = 0 || nlen > hlen then false
   else
     let rec match_at i j =
       if j = nlen then true
-      else if String.unsafe_get haystack (i + j) <> String.unsafe_get needle j
-      then false
+      else if String.get haystack (i + j) <> String.get needle j then false
       else match_at i (j + 1)
     in
     let last = hlen - nlen in
@@ -246,11 +244,11 @@ let evaluate_criterion output criterion =
        | `Null -> Fail "output is null"
        | _ -> Pass)
   | Contains needle ->
-      if String.length needle > 0 && needle_in_string ~needle output_str
+      if contains_nonempty_literal ~needle output_str
       then Pass
       else Fail (Printf.sprintf "output does not contain '%s'" needle)
   | Not_contains needle ->
-      if String.length needle > 0 && needle_in_string ~needle output_str
+      if contains_nonempty_literal ~needle output_str
       then Fail (Printf.sprintf "output contains forbidden '%s'" needle)
       else Pass
   | Custom _ ->

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -97,6 +97,16 @@ let test_evaluate_not_contains () =
     (match V.evaluate_criterion output (V.Not_contains "hello") with
      | V.Fail _ -> true | _ -> false)
 
+let test_evaluate_literal_and_empty_needles () =
+  let output = `String "literal .* needle" in
+  Alcotest.(check bool) "contains treats regex metacharacters literally" true
+    (V.evaluate_criterion output (V.Contains ".*") = V.Pass);
+  Alcotest.(check bool) "contains empty needle stays fail" true
+    (match V.evaluate_criterion output (V.Contains "") with
+     | V.Fail _ -> true | _ -> false);
+  Alcotest.(check bool) "not_contains empty needle stays pass" true
+    (V.evaluate_criterion output (V.Not_contains "") = V.Pass)
+
 let test_evaluate_schema_match () =
   let output = `Assoc [("key", `String "value")] in
   Alcotest.(check bool) "schema non-null pass" true
@@ -404,6 +414,8 @@ let () =
     "evaluation", [
       Alcotest.test_case "contains" `Quick test_evaluate_contains;
       Alcotest.test_case "not_contains" `Quick test_evaluate_not_contains;
+      Alcotest.test_case "literal and empty needles" `Quick
+        test_evaluate_literal_and_empty_needles;
       Alcotest.test_case "schema_match" `Quick test_evaluate_schema_match;
       Alcotest.test_case "custom" `Quick test_evaluate_custom;
       Alcotest.test_case "all pass" `Quick test_evaluate_all_pass;


### PR DESCRIPTION
## Summary
- follow up #10337 by making the substring helper contract match its call sites
- rename the helper to non-empty literal containment and return false for empty needles
- add regression coverage for literal regex metacharacters and empty needle behavior

## Verification
- git diff --check HEAD~1..HEAD
- scripts/dune-local.sh build test/test_verification.exe
- ./_build/default/test/test_verification.exe