### PR TITLE
fix(telemetry): tolerate nullable tool call ids

### DIFF
--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -109,9 +109,90 @@ let get_telemetry_store config : Dated_jsonl.t =
       Hashtbl.replace telemetry_store_cache base store;
       store)
 
+let assoc_opt name fields = List.assoc_opt name fields
+
+let error_field context name = Error (context ^ "." ^ name)
+
+let json_string context name fields =
+  match assoc_opt name fields with
+  | Some (`String value) -> Ok value
+  | Some _ | None -> error_field context name
+
+let json_bool context name fields =
+  match assoc_opt name fields with
+  | Some (`Bool value) -> Ok value
+  | Some _ | None -> error_field context name
+
+let json_int context name fields =
+  match assoc_opt name fields with
+  | Some (`Int value) -> Ok value
+  | Some (`Intlit value) -> (
+      try Ok (int_of_string value) with Failure _ -> error_field context name)
+  | Some _ | None -> error_field context name
+
+let json_float context name fields =
+  match assoc_opt name fields with
+  | Some (`Float value) -> Ok value
+  | Some (`Int value) -> Ok (float_of_int value)
+  | Some (`Intlit value) -> (
+      try Ok (float_of_string value) with Failure _ -> error_field context name)
+  | Some _ | None -> error_field context name
+
+let json_string_opt context name fields =
+  match assoc_opt name fields with
+  | None | Some `Null -> Ok None
+  | Some (`String value) -> Ok (Some value)
+  | Some _ -> error_field context name
+
+let event_record_of_yojson_lenient json =
+  match event_record_of_yojson json with
+  | Ok record -> Ok record
+  | Error original_error -> (
+      match json with
+      | `Assoc fields -> (
+          match assoc_opt "event" fields with
+          | Some (`List [ `String "Tool_called"; `Assoc event_fields ]) ->
+              let context = "Telemetry_eio.event" in
+              let ( let* ) = Result.bind in
+              let* timestamp =
+                json_float "Telemetry_eio.event_record" "timestamp" fields
+              in
+              let* tool_name = json_string context "tool_name" event_fields in
+              let* success = json_bool context "success" event_fields in
+              let* duration_ms = json_int context "duration_ms" event_fields in
+              let* agent_id = json_string_opt context "agent_id" event_fields in
+              let* source = json_string_opt context "source" event_fields in
+              let* session_id =
+                json_string_opt context "session_id" event_fields
+              in
+              let* operation_id =
+                json_string_opt context "operation_id" event_fields
+              in
+              let* worker_run_id =
+                json_string_opt context "worker_run_id" event_fields
+              in
+              Ok
+                {
+                  timestamp;
+                  event =
+                    Tool_called
+                      {
+                        tool_name;
+                        success;
+                        duration_ms;
+                        agent_id;
+                        source;
+                        session_id;
+                        operation_id;
+                        worker_run_id;
+                      };
+                }
+          | _ -> Error original_error)
+      | _ -> Error original_error)
+
 let parse_event_records (jsons : Yojson.Safe.t list) : event_record list =
   List.filter_map (fun json ->
-    match event_record_of_yojson json with
+    match event_record_of_yojson_lenient json with
     | Ok record -> Some record
     | Error msg ->
         Eio.traceln "[TelemetryEio] parse_event_records drop: %s" msg;
@@ -127,7 +208,7 @@ let read_all_events_from_path (file : string) : event_record list =
     |> List.filter (fun line -> String.trim line <> "")
     |> List.filter_map (fun line ->
         try
-          match event_record_of_yojson (Yojson.Safe.from_string line) with
+          match event_record_of_yojson_lenient (Yojson.Safe.from_string line) with
           | Ok record -> Some record
           | Error msg ->
               Eio.traceln "[TelemetryEio] read_all_events_from_path drop: %s" msg;

--- a/test/test_telemetry_eio_coverage.ml
+++ b/test/test_telemetry_eio_coverage.ml
@@ -134,6 +134,76 @@ let test_event_record_type () =
   } in
   check (float 0.1) "timestamp" 1704067200.0 r.timestamp
 
+let check_one_tool_called_record label json ~operation_id ~worker_run_id =
+  match Telemetry_eio.parse_event_records [json] with
+  | [ record ] -> (
+      match record.event with
+      | Telemetry_eio.Tool_called r ->
+          check string (label ^ " tool_name") "keeper_bash" r.tool_name;
+          check bool (label ^ " success") false r.success;
+          check int (label ^ " duration_ms") 658 r.duration_ms;
+          check (option string) (label ^ " agent_id")
+            (Some "keeper-masc-improver-agent") r.agent_id;
+          check (option string) (label ^ " operation_id") operation_id
+            r.operation_id;
+          check (option string) (label ^ " worker_run_id") worker_run_id
+            r.worker_run_id
+      | _ -> fail (label ^ ": expected Tool_called"))
+  | records ->
+      fail
+        (Printf.sprintf "%s: expected one parsed record, got %d" label
+           (List.length records))
+
+let test_parse_event_records_tool_called_null_options () =
+  let json =
+    `Assoc
+      [
+        ("timestamp", `Float 1777120367.858374);
+        ( "event",
+          `List
+            [
+              `String "Tool_called";
+              `Assoc
+                [
+                  ("tool_name", `String "keeper_bash");
+                  ("success", `Bool false);
+                  ("duration_ms", `Int 658);
+                  ("agent_id", `String "keeper-masc-improver-agent");
+                  ("source", `String "keeper_internal");
+                  ("session_id", `String "mcp-session");
+                  ("operation_id", `Null);
+                  ("worker_run_id", `Null);
+                ];
+            ] );
+      ]
+  in
+  check_one_tool_called_record "null options" json ~operation_id:None
+    ~worker_run_id:None
+
+let test_parse_event_records_tool_called_missing_options () =
+  let json =
+    `Assoc
+      [
+        ("timestamp", `Int 1777120367);
+        ( "event",
+          `List
+            [
+              `String "Tool_called";
+              `Assoc
+                [
+                  ("tool_name", `String "keeper_bash");
+                  ("success", `Bool false);
+                  ("duration_ms", `Int 658);
+                  ("agent_id", `String "keeper-masc-improver-agent");
+                  ("source", `String "keeper_internal");
+                  ("session_id", `String "mcp-session");
+                ];
+            ] );
+      ]
+  in
+  check_one_tool_called_record "missing options" json ~operation_id:None
+    ~worker_run_id:None
+
 (* ============================================================
    metrics Type Tests
    ============================================================ *)
@@ -396,6 +466,10 @@ let () =
     ];
     "event_record", [
       test_case "type" `Quick test_event_record_type;
+      test_case "tool_called null option fields" `Quick
+        test_parse_event_records_tool_called_null_options;
+      test_case "tool_called missing option fields" `Quick
+        test_parse_event_records_tool_called_missing_options;
     ];
     "metrics", [
       test_case "type" `Quick test_metrics_type;


### PR DESCRIPTION
## 목표
Telemetry JSONL 재읽기 경로에서 `Tool_called` 이벤트의 nullable/missing option 필드(`operation_id`, `worker_run_id`, `agent_id`, `source`, `session_id`)가 derived `_of_yojson` parser에 의해 거부되어 발생하는 `[TelemetryEio] parse_event_records drop: Telemetry_eio.event.worker_run_id` 노이즈를 제거합니다.

## 변경 파일
- `lib/telemetry_eio.ml:147` — `event_record_of_yojson_lenient` 어댑터 추가. strict-first → fallback 패턴으로 정상 케이스 비용 영향 없음. `Yojson.Safe.t`의 `Intlit` variant까지 처리.
- `test/test_telemetry_eio_coverage.ml:157` — `null` 값과 missing key 두 케이스 모두를 `Ok None`으로 매핑하는지 확인하는 회귀 테스트 2건.

## 설계 메모
- derived `event_record_of_yojson`은 그대로 유지하고, lenient 경로를 별도 함수로 격리. JSON serializer/parser key symmetry 원칙(round-trip 유지)에 부합.
- option 필드 5종(`agent_id`, `source`, `session_id`, `operation_id`, `worker_run_id`)을 `null` 또는 missing 양쪽 모두 `Ok None`으로 흡수. unknown variant는 strict 에러로 fail-closed.
- `parse_event_records`와 `read_all_events_from_path` 두 호출자 모두 lenient parser로 전환.

## 로컬 검증
- `git diff --check`: 통과
- `ocamlc -stop-after parsing` (수정 두 파일): 통과
- `dune build test/test_telemetry_eio_coverage.exe`: EXIT=0 (격리된 `_build_telemetry_fix`, `--cache=disabled`)
- `dune exec test/test_telemetry_eio_coverage.exe`: **35/35 통과**, 신규 2 케이스(`tool_called null option fields`, `tool_called missing option fields`) 포함

## 미검증 (남은 항목)
- 전체 `dune runtest` 미실행 — 호스트의 동시 dune 빌드 20+ 부하 회피 목적으로 단일 테스트만 격리 실행. CI에 위임.
- 라이브 telemetry JSONL 샘플(실 운용 로그)에서 drop 메시지 0 확인 — main 머지 후 모니터링 필요.

## 머지 보호
- `do-not-merge` 라벨 부착 (auto-merge가 Draft를 flip하는 이슈 회피)
- Required checks green + 라벨 제거 후 수동 Ready 전환 권장.