### PR TITLE
fix(keeper): persist cache usage metrics

### DIFF
--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -1194,6 +1194,8 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
         ([
           ("input_tokens", `Int result.usage.input_tokens);
           ("output_tokens", `Int result.usage.output_tokens);
+          ("cache_creation_tokens", `Int result.usage.cache_creation_input_tokens);
+          ("cache_read_tokens", `Int result.usage.cache_read_input_tokens);
           ("total_tokens",
            `Int (Keeper_exec_context.total_tokens result.usage));
         ]
@@ -1203,6 +1205,8 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
         ([
           ("input_tokens", `Null);
           ("output_tokens", `Null);
+          ("cache_creation_tokens", `Null);
+          ("cache_read_tokens", `Null);
           ("total_tokens", `Null);
         ]
         @ usage_trust_json_fields usage_trust)

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1683,6 +1683,8 @@ let sample_tool_surface_metrics () : Masc_mcp.Keeper_agent_run.tool_surface_metr
   }
 let make_run_result ~text ~tools ~model ~input_tok ~output_tok
     ?(usage_reported = true)
+    ?(cache_creation_tokens = 0)
+    ?(cache_read_tokens = 0)
     ?(tool_calls = [])
     ?proof
     ?trace_ref
@@ -1697,7 +1699,14 @@ let make_run_result ~text ~tools ~model ~input_tok ~output_tok
     cascade_observation;
     turn_count = 1;
     tool_calls_made = List.length tools;
-    usage = { input_tokens = input_tok; output_tokens = output_tok; cache_creation_input_tokens = 0; cache_read_input_tokens = 0; cost_usd = None };
+    usage =
+      {
+        input_tokens = input_tok;
+        output_tokens = output_tok;
+        cache_creation_input_tokens = cache_creation_tokens;
+        cache_read_input_tokens = cache_read_tokens;
+        cost_usd = None;
+      };
     usage_reported;
     tools_used = tools;
     tool_calls;
@@ -2628,8 +2637,75 @@ let test_append_metrics_snapshot_nulls_unreported_usage () =
         (match usage |> member "output_tokens" with `Null -> true | _ -> false);
       check bool "snapshot total_tokens null when usage unreported" true
         (match usage |> member "total_tokens" with `Null -> true | _ -> false);
+      check bool "snapshot cache_creation_tokens null when usage unreported" true
+        (match usage |> member "cache_creation_tokens" with `Null -> true | _ -> false);
+      check bool "snapshot cache_read_tokens null when usage unreported" true
+        (match usage |> member "cache_read_tokens" with `Null -> true | _ -> false);
       check bool "snapshot cost_usd null when usage unreported" true
         (match json |> member "cost_usd" with `Null -> true | _ -> false))
+
+let test_append_metrics_snapshot_persists_cache_usage () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Coord.default_config base_dir in
+      let result =
+        make_run_result
+          ~text:"Claude reported cache usage."
+          ~tools:[]
+          ~model:"claude:claude-sonnet-4-6"
+          ~input_tok:2000
+          ~output_tok:200
+          ~cache_creation_tokens:1500
+          ~cache_read_tokens:300
+          ()
+      in
+      UM.append_metrics_snapshot
+        ~config
+        ~meta:minimal_meta
+        ~observation:base_observation
+        ~result
+        ~latency_ms:321
+        ~turn_cost:0.42
+        ~turn_generation:1
+        ~channel:"turn"
+        ~snapshot_source:"test"
+        ~context_ratio:0.1
+        ~context_tokens:10
+        ~context_max:100_000
+        ~message_count:2
+        ~compaction:
+          {
+            Masc_mcp.Keeper_exec_context.applied = false;
+            attempted = false;
+            failure_reason = None;
+            trigger = None;
+            decision = "no_compaction";
+            before_tokens = 0;
+            after_tokens = 0;
+            saved_tokens = 0;
+          }
+        ~handoff_json:None
+        ();
+      let metrics_store =
+        Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
+      in
+      let line =
+        match Dated_jsonl.read_recent_lines metrics_store 1 with
+        | [ line ] -> line
+        | _ -> fail "expected one metrics line"
+      in
+      let usage =
+        Yojson.Safe.Util.(Yojson.Safe.from_string line |> member "usage")
+      in
+      let open Yojson.Safe.Util in
+      check int "cache creation persisted"
+        1500 (usage |> member "cache_creation_tokens" |> to_int);
+      check int "cache read persisted"
+        300 (usage |> member "cache_read_tokens" |> to_int))
 
 let test_append_metrics_snapshot_marks_untrusted_usage () =
   Eio_main.run @@ fun env ->
@@ -6234,6 +6310,8 @@ let () =
             test_append_metrics_snapshot_counts_only_mode_violation_refs;
           test_case "snapshot nulls unreported usage" `Quick
             test_append_metrics_snapshot_nulls_unreported_usage;
+          test_case "snapshot persists cache usage" `Quick
+            test_append_metrics_snapshot_persists_cache_usage;
           test_case "snapshot marks untrusted usage" `Quick
             test_append_metrics_snapshot_marks_untrusted_usage;
           test_case "decision record persists tool call details" `Quick


### PR DESCRIPTION
## Summary
- Persist `cache_creation_tokens` and `cache_read_tokens` inside keeper metrics `usage` JSONL rows.
- Keep unreported usage explicit with `null` cache fields instead of absent fields.
- Add regression coverage for reported cache usage and unreported null cache fields.

## Live remeasure
- OAS #1186 is merged and current MASC main is already pinned past that fix.
- Scanning `~/me/.masc/keepers/*/metrics/2026-04/25.jsonl` after `2026-04-25T09:56:54Z` found 21 turn rows, all `claude_code:auto`.
- `input_tokens > 1_000_000`: 0 rows.
- `(input_tokens=0, output_tokens=0)` turn usage: 0 rows.
- Cache fields were absent from keeper metrics `usage`, which this PR fixes.

Closes #9959

## Validation
- `git diff --check origin/main...HEAD`
- `env DUNE_BUILD_DIR=_build_9959_cache_usage_jsonl_latest DUNE_JOBS=2 DUNE_CACHE=disabled MASC_DUNE_THROTTLE=0 scripts/dune-local.sh build test/test_keeper_unified.exe test/test_keeper_usage_trust_anthropic_cache_9959.exe`
- `env MASC_BASE_PATH=/tmp/masc-test-9959-cache-usage-jsonl-latest _build_9959_cache_usage_jsonl_latest/default/test/test_keeper_unified.exe` (292 tests)
- `env MASC_BASE_PATH=/tmp/masc-test-9959-cache-usage-trust-latest _build_9959_cache_usage_jsonl_latest/default/test/test_keeper_usage_trust_anthropic_cache_9959.exe` (9 tests)
- `bash scripts/ci/check-telemetry-coverage.sh`
- `bash scripts/ml_line_cap_audit.sh --baseline-ref origin/main --fail-on-regression`
- `bash scripts/ci/check-silent-failure-patterns.sh`
