### PR TITLE
perf(tool-board,notify,inline-dispatch): drop per-call Re.compile, reuse String_util

### DIFF
--- a/lib/core/string_util.ml
+++ b/lib/core/string_util.ml
@@ -48,6 +48,39 @@ let contains_substring_ci haystack needle =
     in
     loop 0
 
+(* Byte-wise non-overlapping replace: scans [haystack] for [needle] and
+   substitutes [by] for each occurrence. Empty needle is a no-op (would
+   loop forever otherwise). Skips ahead by [needle_len] after a match,
+   matching [Re.replace_string] semantics for non-overlapping replacement. *)
+let replace_substring ~needle ~by haystack =
+  let hay_len = String.length haystack in
+  let needle_len = String.length needle in
+  if needle_len = 0 || needle_len > hay_len then haystack
+  else
+    let buf = Buffer.create hay_len in
+    let rec match_at i j =
+      if j = needle_len then true
+      else if String.unsafe_get haystack (i + j)
+            <> String.unsafe_get needle j
+      then false
+      else match_at i (j + 1)
+    in
+    let last = hay_len - needle_len in
+    let rec loop i =
+      if i > last then
+        Buffer.add_substring buf haystack i (hay_len - i)
+      else if match_at i 0 then begin
+        Buffer.add_string buf by;
+        loop (i + needle_len)
+      end
+      else begin
+        Buffer.add_char buf (String.unsafe_get haystack i);
+        loop (i + 1)
+      end
+    in
+    loop 0;
+    Buffer.contents buf
+
 type truncation =
   | Untouched of string
   | Truncated of { prefix : string; suffix : string; dropped_bytes : int }

--- a/lib/core/string_util.mli
+++ b/lib/core/string_util.mli
@@ -10,6 +10,13 @@ val contains_substring_ci : string -> string -> bool
     Returns [false] when [needle] is empty, matching the behavior
     of the original per-module [contains_ci] helpers. *)
 
+val replace_substring : needle:string -> by:string -> string -> string
+(** [replace_substring ~needle ~by haystack] substitutes [by] for every
+    non-overlapping occurrence of [needle] in [haystack]. Returns
+    [haystack] unchanged when [needle] is empty or longer than the
+    haystack. Matches [Re.replace_string (Re.str needle |> Re.compile)]
+    semantics for ASCII / byte-equal patterns. *)
+
 type truncation =
   | Untouched of string
   | Truncated of { prefix : string; suffix : string; dropped_bytes : int }

--- a/lib/notify.ml
+++ b/lib/notify.ml
@@ -92,7 +92,7 @@ let focus_on_osascript () =
 
 let render_focus_template template payload =
   let replace token value acc =
-    Re.replace_string (Re.str token |> Re.compile) ~by:value acc
+    String_util.replace_substring ~needle:token ~by:value acc
   in
   template
   |> replace "{{target}}" (token_value payload.target_agent)

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -925,14 +925,12 @@ let handle_board_cleanup args =
   let author_pattern = get_string_opt args "author_pattern" in
   let now = Time_compat.now () in
   let age_threshold = now -. (float_of_int max_age_hours *. 3600.0) in
-  let title_re = Option.map (fun p ->
-    Re.str (String.lowercase_ascii p) |> Re.compile) title_pattern in
-  let author_re = Option.map (fun p ->
-    Re.str (String.lowercase_ascii p) |> Re.compile) author_pattern in
-  let matches_opt re s =
-    match re with
+  let title_needle = Option.map String.lowercase_ascii title_pattern in
+  let author_needle = Option.map String.lowercase_ascii author_pattern in
+  let matches_opt needle s =
+    match needle with
     | None -> true
-    | Some compiled -> Re.execp compiled (String.lowercase_ascii s)
+    | Some n -> String_util.contains_substring (String.lowercase_ascii s) n
   in
   let all_posts =
     Board_dispatch.list_posts ~sort_by:Recent ~limit:500 ()
@@ -942,8 +940,8 @@ let handle_board_cleanup args =
       p.created_at < age_threshold
       && (not require_no_comments || p.reply_count = 0)
       && (not require_no_votes || (p.votes_up = 0 && p.votes_down = 0))
-      && matches_opt title_re p.title
-      && matches_opt author_re (Board.Agent_id.to_string p.author))
+      && matches_opt title_needle p.title
+      && matches_opt author_needle (Board.Agent_id.to_string p.author))
       all_posts
   in
   let targets = List.filteri (fun i _ -> i < limit) candidates in

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -253,7 +253,7 @@ let dispatch (ctx : context) ~(name : string) : tool_result option =
                  let desc_l = String.lowercase_ascii schema.description in
                  let haystack = name_l ^ " " ^ desc_l in
                  words |> List.exists (fun w ->
-                   Re.execp (Re.str w |> Re.compile) haystack))
+                   String_util.contains_substring haystack w))
           |> List.filteri (fun i _ -> i < limit)
         in
         let results = List.map (fun (schema : Types.tool_schema) ->


### PR DESCRIPTION
## Summary

Stack on top of #10347 (`perf/keeper-substring`) — three remaining hot paths compiled a fresh DFA per call for what was always a byte-equal substring scan:

- **`tool_board.handle_board_cleanup`** — title/author needles compiled per cleanup invocation (up to 500 posts × 2 needles per call).
- **`notify.render_focus_template`** — three \`Re.str|>compile\` per render for static \`{{target}}\`/\`{{from}}\`/\`{{task}}\` tokens.
- **`tool_inline_dispatch.masc_discover_tools`** — needle compiled \`M schemas × N query words\` times per discover call.

All three now route through `String_util`. Added `String_util.replace_substring ~needle ~by` that mirrors \`Re.replace_string (Re.str needle |> Re.compile)\` for ASCII patterns without allocating a regex — uses the same byte-wise \`unsafe_get\` loop as \`contains_substring\`, emits non-overlapping matches via \`Buffer\`.

## Behavior preservation

- title/author cleanup: input still lowercased before compare.
- focus template: empty needle is a no-op (\`{{...}}\` tokens are always non-empty).
- discover_tools: each word check is a substring scan against the same lowercased \`name desc\` haystack — no DFA build.

## Test plan

- [x] \`dune build @check\` clean
- [x] test_string_util (13), test_notify_coverage (58), test_tool_board_coverage (61) all pass

## Stack

Depends on #10347. Base is \`main\` because gh refused stacked head/base on same-branch tip; rebase will be a no-op once #10347 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)