### PR TITLE
fix(agent_stress): emit Turn_failure stress from keeper_unified_turn (#10341)

### DIFF
--- a/lib/agent_stress.ml
+++ b/lib/agent_stress.ml
@@ -7,10 +7,19 @@
 
 type stress_kind =
   | Failure_streak of int
+  | Turn_failure of turn_failure
   | Fallback_approval
   | Timeout
   | Parse_degraded
   | Task_released
+
+and turn_failure = {
+  consecutive : int;
+  threshold : int;
+  counted_toward_crash : bool;
+  recoverable : bool;
+  error_kind : string option;
+}
 
 type event = {
   agent_name : string;
@@ -26,6 +35,20 @@ type event = {
 let stress_kind_to_json = function
   | Failure_streak n ->
     `Assoc [("type", `String "failure_streak"); ("count", `Int n)]
+  | Turn_failure f ->
+    let base = [
+      ("type", `String "turn_failure");
+      ("consecutive", `Int f.consecutive);
+      ("threshold", `Int f.threshold);
+      ("counted_toward_crash", `Bool f.counted_toward_crash);
+      ("recoverable", `Bool f.recoverable);
+    ] in
+    let fields =
+      match f.error_kind with
+      | None -> base
+      | Some kind -> base @ [("error_kind", `String kind)]
+    in
+    `Assoc fields
   | Fallback_approval ->
     `Assoc [("type", `String "fallback_approval")]
   | Timeout ->

--- a/lib/agent_stress.mli
+++ b/lib/agent_stress.mli
@@ -12,10 +12,19 @@
 (** Stress event kinds -- each maps to a measurable condition. *)
 type stress_kind =
   | Failure_streak of int        (** consecutive failure count *)
+  | Turn_failure of turn_failure (** keeper turn ended in an error/partial outcome *)
   | Fallback_approval            (** anti-rat or post-verifier fell back to approve *)
   | Timeout                      (** OAS/LLM call timed out *)
   | Parse_degraded               (** LLM response required fallback parsing *)
   | Task_released                (** agent released a task (gave up) *)
+
+and turn_failure = {
+  consecutive : int;             (** persistent turn-failure streak after this turn *)
+  threshold : int;               (** crash threshold used for the decision *)
+  counted_toward_crash : bool;   (** false for auto-recoverable/transient failures *)
+  recoverable : bool;            (** whether keeper can continue without crash escalation *)
+  error_kind : string option;    (** coarse sdk error family; never the raw error text *)
+}
 
 (** A single stress observation. *)
 type event = {

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -516,6 +516,32 @@ let sdk_error_kind = function
   | Oas.Error.A2a _ -> "a2a"
   | Oas.Error.Internal _ -> "internal"
 
+let record_turn_failure_stress
+    ~(meta : keeper_meta)
+    ~(is_auto_recoverable : bool)
+    ~(consecutive : int)
+    ~(threshold : int)
+    ~(err : Oas.Error.sdk_error)
+  : unit =
+  let room_id =
+    match meta.joined_room_ids with
+    | room_id :: _ -> room_id
+    | [] -> ""
+  in
+  Agent_stress.record {
+    agent_name = meta.name;
+    room_id;
+    kind =
+      Turn_failure {
+        consecutive;
+        threshold;
+        counted_toward_crash = not is_auto_recoverable;
+        recoverable = is_auto_recoverable;
+        error_kind = Some (sdk_error_kind err);
+      };
+    timestamp = Unix.gettimeofday ();
+  }
+
 let oas_timeout_guard_sec = 30.0
 
 let min_oas_timeout_budget_sec = 30.0
@@ -2190,6 +2216,12 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           let threshold =
             Runtime_params.get Governance_registry.keeper_max_turn_failures
           in
+          record_turn_failure_stress
+            ~meta
+            ~is_auto_recoverable
+            ~consecutive:count
+            ~threshold
+            ~err;
           if count >= threshold then begin
             Log.Keeper.error
               "%s: %d consecutive persistent turn failures (threshold=%d), escalating to supervisor crash path"

--- a/test/dune
+++ b/test/dune
@@ -54,6 +54,7 @@
         test_keeper_hooks_oas_provider
         test_keeper_hooks_oas_pricing
         test_keeper_hooks_oas_telemetry
+        test_agent_stress
         test_keeper_tool_use_failure_counter
         test_keeper_compaction_outcome_counter
         test_keeper_usage_trust_counter
@@ -193,6 +194,7 @@
           test_keeper_hooks_oas_provider
           test_keeper_hooks_oas_pricing
           test_keeper_hooks_oas_telemetry
+          test_agent_stress
           test_keeper_tool_use_failure_counter
           test_keeper_compaction_outcome_counter
           test_keeper_usage_trust_counter

--- a/test/test_agent_stress.ml
+++ b/test/test_agent_stress.ml
@@ -1,0 +1,113 @@
+module Stress = Masc_mcp.Agent_stress
+
+let assoc_field name = function
+  | `Assoc fields -> List.assoc_opt name fields
+  | _ -> None
+
+let nested_assoc_field outer inner json =
+  match assoc_field outer json with
+  | Some (`Assoc fields) -> List.assoc_opt inner fields
+  | _ -> None
+
+let test_turn_failure_json_contract () =
+  let event : Stress.event =
+    {
+      agent_name = "sangsu";
+      room_id = "default";
+      kind =
+        Stress.Turn_failure {
+          consecutive = 2;
+          threshold = 3;
+          counted_toward_crash = true;
+          recoverable = false;
+          error_kind = Some "api";
+        };
+      timestamp = 1_777_120_045.0;
+    }
+  in
+  let json = Stress.event_to_json event in
+  Alcotest.(check (option string))
+    "agent"
+    (Some "sangsu")
+    (match assoc_field "agent_name" json with
+     | Some (`String s) -> Some s
+     | _ -> None);
+  Alcotest.(check (option string))
+    "kind type"
+    (Some "turn_failure")
+    (match nested_assoc_field "kind" "type" json with
+     | Some (`String s) -> Some s
+     | _ -> None);
+  Alcotest.(check (option int))
+    "consecutive"
+    (Some 2)
+    (match nested_assoc_field "kind" "consecutive" json with
+     | Some (`Int n) -> Some n
+     | _ -> None);
+  Alcotest.(check (option int))
+    "threshold"
+    (Some 3)
+    (match nested_assoc_field "kind" "threshold" json with
+     | Some (`Int n) -> Some n
+     | _ -> None);
+  Alcotest.(check (option bool))
+    "counted toward crash"
+    (Some true)
+    (match nested_assoc_field "kind" "counted_toward_crash" json with
+     | Some (`Bool b) -> Some b
+     | _ -> None);
+  Alcotest.(check (option bool))
+    "recoverable"
+    (Some false)
+    (match nested_assoc_field "kind" "recoverable" json with
+     | Some (`Bool b) -> Some b
+     | _ -> None);
+  Alcotest.(check (option string))
+    "error kind"
+    (Some "api")
+    (match nested_assoc_field "kind" "error_kind" json with
+     | Some (`String s) -> Some s
+     | _ -> None)
+
+let test_turn_failure_omits_absent_error_kind () =
+  let event : Stress.event =
+    {
+      agent_name = "janitor";
+      room_id = "";
+      kind =
+        Stress.Turn_failure {
+          consecutive = 0;
+          threshold = 3;
+          counted_toward_crash = false;
+          recoverable = true;
+          error_kind = None;
+        };
+      timestamp = 1.0;
+    }
+  in
+  let json = Stress.event_to_json event in
+  Alcotest.(check (option string))
+    "kind type"
+    (Some "turn_failure")
+    (match nested_assoc_field "kind" "type" json with
+     | Some (`String s) -> Some s
+     | _ -> None);
+  Alcotest.(check bool)
+    "no raw/absent error field"
+    true
+    (Option.is_none (nested_assoc_field "kind" "error_kind" json))
+
+let () =
+  Alcotest.run
+    "Agent_stress"
+    [
+      ( "turn failure"
+      , [
+          Alcotest.test_case
+            "serializes typed turn failure stress" `Quick
+            test_turn_failure_json_contract;
+          Alcotest.test_case
+            "omits absent error kind" `Quick
+            test_turn_failure_omits_absent_error_kind;
+        ] );
+    ]


### PR DESCRIPTION
Fixes #10341

## Problem

`Agent_stress` had a single emit site (`keeper_keepalive` room presence
check) and a single kind (`Failure_streak`). `~/.masc/agent_stress.jsonl`
showed **1 entry / 24h+ stale**, while `institution_episodes.jsonl`
recorded **76 turn failures (35%)** in the same window — i.e. the stress
detector captured ~0.5% of fleet failures.

Per the issue this corresponds to RFC-0001 Gate A only; Gates B/C/D
(turn failure, OAS timeout, cascade exhaustion, idempotency loop) were
unimplemented.

## Change

| File | Change |
|------|--------|
| `lib/agent_stress.ml` / `.mli` | New `Turn_failure of turn_failure` variant + JSON projection. Fields: `consecutive`, `threshold`, `counted_toward_crash`, `recoverable`, `error_kind` |
| `lib/keeper/keeper_unified_turn.ml` | New `record_turn_failure_stress` helper called from `run_keeper_cycle`'s persistent-failure branch (after `consecutive_persistent_turn_failures` increments) |
| `test/test_agent_stress.ml` (new) | JSON contract tests — both `Some` and `None` `error_kind` paths |
| `test/dune` | Register `test_agent_stress` |

## Design notes

- `threshold` is read from `Runtime_params.get Governance_registry.keeper_max_turn_failures` at emit time — so governance policy changes automatically flow into the stress ledger (no hardcoded threshold).
- `error_kind` is the sdk error family (network/api/cancelled/...) via `sdk_error_kind`; never the raw error string (privacy + cardinality).
- `is_auto_recoverable` is already computed by the turn loop; we forward it as `recoverable` and derive `counted_toward_crash = not is_auto_recoverable` so dashboards can split transient noise from genuine pressure.

## Test plan

- [x] Clean build: `rm -rf _build && DUNE_CACHE=disabled scripts/dune-local.sh build --cache=disabled` — green
- [x] `dune runtest test/test_agent_stress.exe` — 2/2 pass
- [ ] CI green
- [ ] (follow-up) extend emit sites to OAS timeout / cascade exhaustion / idempotency loop (RFC-0001 Gates C/D)

## Notes

- `do-not-merge` label as guard against auto-merge flip until I verify CI signal manually (per `do-not-merge-label-insufficient` lesson).
- Original implementation: codex hand-off (workspace continuation after quota). Built + tested + pushed by claude.