### PR TITLE
fix(keeper): register sandbox cleanup in server background loop

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -606,6 +606,23 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
           let sub_expired = A2a_tools.cleanup_stale_subscriptions () in
           if sub_expired > 0 then
             Log.Server.info "Expired %d stale A2A subscriptions" sub_expired;
+          (* Keeper sandbox: remove stale Docker containers when owner_pid is
+             dead, container age exceeds MASC_KEEPER_SANDBOX_CLEANUP_STALE_AFTER_SEC
+             (default 6h), or container is stopped. Internally throttled by
+             MASC_KEEPER_SANDBOX_CLEANUP_INTERVAL_SEC (default 5min); janitor
+             ticks faster but the helper short-circuits when called too soon. *)
+          (match
+             Keeper_sandbox_runtime.maybe_cleanup_stale_containers
+               ~base_path:state.room_config.base_path
+               ~timeout_sec:30.0 ()
+           with
+           | None -> ()
+           | Some result ->
+               if result.removed > 0 || result.errors <> [] then
+                 Log.Server.info
+                   "Sandbox cleanup: scanned=%d removed=%d errors=%d"
+                   result.scanned result.removed
+                   (List.length result.errors));
           (* Periodic JSONL prune: every 24h, clean dated JSONL files *)
           let now = Unix.gettimeofday () in
           if now -. !last_prune >= Masc_time_constants.day then begin


### PR DESCRIPTION
## Summary
- Register `Keeper_sandbox_runtime.maybe_cleanup_stale_containers` in server background maintenance loop
- Resolves orphan-container leak when all keepers are simultaneously stuck

## Problem
`cleanup_stale_containers` was reactive-only — called from `keeper_turn_sandbox_runtime.create`, `keeper_sandbox_control.cleanup_stale`, and `keeper_shell_docker`. All three fire at the start of a new keeper turn. When the fleet is stuck (oas_timeout_budget hangs, ollama saturation, fail-open fallback), no keeper reaches a new turn → no callsite → no cleanup.

## Evidence
- `masc-keeper-turn-nick0cave-none-79647-1777049590740` survived 20+ hours
- Labels: `owner_pid=79647` (dead via `kill -0` ESRCH), `started_at=1777049590.741` (started 04-25 01:53 KST)
- Both staleness conditions met: `owner_dead && age > 6h`
- Server restarted at 21:17 KST; container persisted across restart
- Zero `cleanup_stale_*` events in 26,162 log lines

Root cause verified by:
- Hash match: `MD5("/Users/dancer/me") = faea17a48b78fb01a31db776cafba454` matches container's `base_path_hash` label
- `should_remove_container` returns `stopped(F) || owner_dead(T) || expired(T) = T`
- The cleanup would have removed it; it never ran

## Fix
17-line addition to `start_background_maintenance`'s janitor fiber, mirroring existing patterns (SSE/agent_registry/A2A cleanups). Internal throttle (`MASC_KEEPER_SANDBOX_CLEANUP_INTERVAL_SEC`, default 5min) short-circuits redundant calls, so the janitor's ~30s tick costs nothing extra.

## Test plan
- [x] `dune build @check` passes locally
- [ ] Deploy this binary, observe `nick0cave` container removed within ~5min of next janitor tick
- [ ] Verify INFO log: `Sandbox cleanup: scanned=N removed=1 errors=0`
- [ ] 24h soak: zero new orphan containers

## Related diagnosis
Self-diagnosis recorded in `~/me/memory/handoff-2026-04-25-keeper-iter11-22-summary.md` (27차/28차 sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)