### PR TITLE
perf(output-parse,memory-bank): hoist Re.compile out of pytest/cargo/consensus paths

### DIFF
--- a/lib/exec/output_parse.ml
+++ b/lib/exec/output_parse.ml
@@ -9,6 +9,18 @@ let files_changed_re = Re.Pcre.re {|\b(\d+) file|} |> Re.compile
 let insertions_re = Re.Pcre.re {|\b(\d+) insertion|} |> Re.compile
 let deletions_re = Re.Pcre.re {|\b(\d+) deletion|} |> Re.compile
 
+(* --- pytest summary counters: prefix set is closed (passed/failed/error/
+   skipped), so build the four DFAs once at module init instead of per line.
+   Using exec_opt means the prior execp+exec double-compile is also gone. *)
+let pytest_passed_re = Re.Pcre.re {|(\d+) passed|} |> Re.compile
+let pytest_failed_re = Re.Pcre.re {|(\d+) failed|} |> Re.compile
+let pytest_error_re = Re.Pcre.re {|(\d+) error|} |> Re.compile
+let pytest_skipped_re = Re.Pcre.re {|(\d+) skipped|} |> Re.compile
+
+(* --- cargo test result line counters --- *)
+let cargo_passed_re = Re.Pcre.re {|(\d+) passed|} |> Re.compile
+let cargo_failed_re = Re.Pcre.re {|(\d+) failed|} |> Re.compile
+
 (* --- git status --porcelain --- *)
 
 let parse_git_status_porcelain output =
@@ -273,32 +285,22 @@ let parse_pytest output =
       if String.length l < 5 then ()
       else
         (* Summary line: "X passed, Y failed, Z errors, W skipped" *)
-        let extract_count prefix =
-          match Re.execp (Re.compile (Re.Pcre.re
-            (Printf.sprintf "(\\d+) %s" prefix))) l with
-          | true ->
-              (match Re.exec (Re.compile (Re.Pcre.re
-                (Printf.sprintf "(\\d+) %s" prefix))) l with
-               | exception _ -> ()
-               | m ->
-                   match int_of_string_opt (Re.Group.get m 1) with
-                   | Some n ->
-                       if prefix = "passed" then passed := n
-                       else if prefix = "failed" then failed := n
-                       else if prefix = "error" then errors := n
-                       else if prefix = "skipped" then skipped := n
-                       else ()
-                   | None -> ())
-          | false -> ()
+        let extract_count re slot =
+          match Re.exec_opt re l with
+          | None -> ()
+          | Some m ->
+              (match int_of_string_opt (Re.Group.get m 1) with
+               | Some n -> slot := n
+               | None -> ())
         in
         if String_util.contains_substring l "passed"
            || String_util.contains_substring l "failed"
            || String_util.contains_substring l "error"
         then begin
-          extract_count "passed";
-          extract_count "failed";
-          extract_count "error";
-          extract_count "skipped"
+          extract_count pytest_passed_re passed;
+          extract_count pytest_failed_re failed;
+          extract_count pytest_error_re errors;
+          extract_count pytest_skipped_re skipped
         end)
     lines;
   let total = !passed + !failed + !errors + !skipped in
@@ -321,15 +323,15 @@ let parse_cargo_test output =
       if String_util.contains_substring l "test result:" then begin
         (* "test result: ok. X passed; 0 failed; ..." *)
         let extract re =
-          match Re.exec (Re.compile (Re.Pcre.re re)) l with
-          | exception _ -> 0
-          | m ->
+          match Re.exec_opt re l with
+          | None -> 0
+          | Some m ->
               match int_of_string_opt (Re.Group.get m 1) with
               | Some n -> n
               | None -> 0
         in
-        passed := !passed + extract "(\\d+) passed";
-        failed := !failed + extract "(\\d+) failed"
+        passed := !passed + extract cargo_passed_re;
+        failed := !failed + extract cargo_failed_re
       end)
     lines;
   let total = !passed + !failed in

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -100,23 +100,34 @@ let dedup_memory_candidates
     in
     go [] exact
 
+(* Punctuation strip used by the dedup key — fully static, hoist to
+   module level so the DFA is built once per process. *)
+let normalize_punct_re =
+  Re.Pcre.re {re|[ \t\n\r!"#$%&'()*+,\-./:;<=>?@\[\]^_`{|}~]+|re} |> Re.compile
+
 let normalize_memory_text_key (s : string) : string =
   s
   |> String.trim
   |> String.lowercase_ascii
-  |> Re.replace_string (Re.Pcre.re {re|[ \t\n\r!"#$%&'()*+,\-./:;<=>?@\[\]^_`{|}~]+|re} |> Re.compile) ~by:""
+  |> Re.replace_string normalize_punct_re ~by:""
 
-let consensus_re () =
-  let default = Re.Pcre.re {|\d{6,}ep\+?|} |> Re.compile in
+(* Consensus marker: env var is process-lifetime constant, so build the
+   compiled regex once and cache it.  Stdlib.Lazy is safe here: the thunk
+   is a pure regex compile (no effects, no I/O) and produces an
+   identical value on any racing force, so the OCaml 5 multi-domain
+   "double force" concern collapses to redundant computation. *)
+let consensus_default_re = Re.Pcre.re {|\d{6,}ep\+?|} |> Re.compile
+
+let consensus_re_cached = lazy (
   match Sys.getenv_opt "MASC_KEEPER_MEMORY_CONSENSUS_PATTERN" with
-  | None -> default
+  | None -> consensus_default_re
   | Some raw ->
       let pat = String.trim raw in
-      if pat = "" then default
-      else Re.Pcre.re pat |> Re.compile
+      if pat = "" then consensus_default_re
+      else Re.Pcre.re pat |> Re.compile)
 
 let has_inflated_consensus_marker (s : string) : bool =
-  Re.execp (consensus_re ()) s
+  Re.execp (Lazy.force consensus_re_cached) s
 
 let memory_placeholders () =
   let base =


### PR DESCRIPTION
## Summary

Two more module-init regex hoists in code paths called many times per minute under normal keeper traffic.

### \`lib/exec/output_parse.ml\`
- \`parse_pytest.extract_count\` compiled the same PCRE **twice** per prefix (\`execp\` then \`exec\`), four prefixes per matching summary line. Prefix set is closed (\`passed\`/\`failed\`/\`error\`/\`skipped\`), so the four DFAs become module-level constants and the double-compile collapses to a single \`Re.exec_opt\`.
- \`parse_cargo_test\` had the same pattern with two literal needles; also hoisted.

### \`lib/keeper/keeper_memory_bank.ml\`
- \`normalize_memory_text_key\` compiled the punctuation-strip PCRE on every call. Pattern is fully static → module-level \`let\`.
- \`consensus_re ()\` compiled the env-conditional PCRE on every call to \`has_inflated_consensus_marker\`. Env var is process-lifetime constant → wrap in \`Stdlib.lazy\` and force once.
  - **Stdlib.lazy, not Eio.Lazy**: callers include plain-OCaml unit tests with no Eio context. The thunk is a pure regex compile with no effects, so the OCaml 5 multi-domain \"double force\" concern reduces to redundant compute with identical results. Tried Eio.Lazy first — \`test_keeper_memory\` blew up with \`Stdlib.Effect.Unhandled(Eio__core__Cancel.Get_context)\`.

## Behavior preservation

- pytest/cargo: int extraction semantics unchanged; \`exec_opt None\` matches the prior \`execp=false\` branch.
- consensus regex: invalid env-supplied PCRE still raises (now at first force instead of every call), matching the original observable behavior on the first invocation.

## Test plan

- [x] \`dune build @check\` — clean
- [x] \`test_keeper_memory\` — 63/63 pass
- [x] \`test_output_parse_p14\` — 12/12 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)