### PR TITLE
diag(keeper-runtime): per-field personality drift on re-sync (#10269)

### DIFF
--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -58,6 +58,33 @@ let personality_diff_summary fields =
       personality_field_diff_entry name current target)
     fields
 
+(** #10269: per-call helper used at runtime re-sync sites (this PR).
+    Complements [personality_diff_summary] (batch over a list) by
+    emitting raw + trimmed previews on a single field at the moment a
+    re-sync fires.  Different output shape from
+    [personality_field_diff_entry] above:
+    [field(raw_meta_len=N raw_target_len=N trim_meta=S trim_target=S)]
+    so dashboards can distinguish raw-length drift from trimmed-content
+    drift (TOML triple-quote drop vs JSON encoding drift vs persona
+    overlay).  Returns [None] when the two trim-equal so steady-state
+    keepers stay quiet.  Trimmed previews truncated to 32 bytes each
+    to keep a wide [instructions] field log-friendly. *)
+let personality_field_diff_summary ~field ~current ~target =
+  if personality_text_equal current target then None
+  else
+    let preview s =
+      let trimmed = String.trim s in
+      if String.length trimmed <= 32 then trimmed
+      else String.sub trimmed 0 32 ^ "..."
+    in
+    Some
+      (Printf.sprintf
+         "%s(raw_meta_len=%d raw_target_len=%d trim_meta=%S trim_target=%S)"
+         field
+         (String.length current) (String.length target)
+         (preview current) (preview target))
+
+
 type boot_meta_resolution = {
   meta : keeper_meta;
   materialized : bool;
@@ -375,6 +402,39 @@ let ensure_keeper_meta config name =
         "ensure_keeper_meta: re-syncing [%s] for %s"
         (String.concat "," cats)
         meta.name;
+      (* #10269: nick0cave alone re-syncs [personality] on every reconcile
+         tick (~371 events / 3000 logs).  When personality is in [cats],
+         emit a follow-up info line listing the specific fields that
+         differ along with their raw lengths and trim-normalised
+         previews so root cause (TOML triple-quote, JSON encoding drift,
+         persona overlay) is visible without code-reading. *)
+      if personality_changed then begin
+        let diffs =
+          List.filter_map Fun.id
+            [
+              personality_field_diff_summary ~field:"goal"
+                ~current:meta.goal ~target:target_goal;
+              personality_field_diff_summary ~field:"short_goal"
+                ~current:meta.short_goal ~target:target_short_goal;
+              personality_field_diff_summary ~field:"mid_goal"
+                ~current:meta.mid_goal ~target:target_mid_goal;
+              personality_field_diff_summary ~field:"long_goal"
+                ~current:meta.long_goal ~target:target_long_goal;
+              personality_field_diff_summary ~field:"will"
+                ~current:meta.will ~target:target_will;
+              personality_field_diff_summary ~field:"needs"
+                ~current:meta.needs ~target:target_needs;
+              personality_field_diff_summary ~field:"desires"
+                ~current:meta.desires ~target:target_desires;
+              personality_field_diff_summary ~field:"instructions"
+                ~current:meta.instructions ~target:target_instructions;
+            ]
+        in
+        Log.Keeper.info
+          "ensure_keeper_meta: personality drift fields for %s: %s"
+          meta.name
+          (String.concat "; " diffs)
+      end;
       let updated = { meta with
         proactive = {
           enabled = target_proactive;

--- a/test/dune
+++ b/test/dune
@@ -656,6 +656,7 @@
         test_keeper_runtime_config_ssot
         test_dashboard_render_timing_9766
         test_task_status_label_10421
+        test_personality_field_diff_10269
         test_keeper_task_dispatch
         test_keeper_tag_dispatch
         test_autoresearch_knowledge
@@ -836,6 +837,7 @@
         test_keeper_runtime_config_ssot
         test_dashboard_render_timing_9766
         test_task_status_label_10421
+        test_personality_field_diff_10269
         test_keeper_task_dispatch
         test_keeper_tag_dispatch
         test_autoresearch_knowledge

--- a/test/test_personality_field_diff_10269.ml
+++ b/test/test_personality_field_diff_10269.ml
@@ -1,0 +1,81 @@
+(** #10269: nick0cave personality re-syncs every reconcile cycle (~371
+    events / 3000 logs) but the existing log line ["re-syncing
+    [personality] for nick0cave"] does not say which of the eight
+    personality fields differ or how.  These tests pin the
+    [personality_field_diff_summary] helper that the runtime now calls
+    after the re-sync log so operators can map the storm to a concrete
+    field + length signature. *)
+
+open Alcotest
+module Kr = Masc_mcp.Keeper_runtime
+
+let opt_string = option string
+
+let test_trim_equal_returns_none () =
+  check opt_string "trailing newline drift collapses"
+    None
+    (Kr.personality_field_diff_summary
+       ~field:"instructions" ~current:"hello\n" ~target:"hello");
+  check opt_string "leading whitespace drift collapses"
+    None
+    (Kr.personality_field_diff_summary
+       ~field:"goal" ~current:"  same  " ~target:"same");
+  check opt_string "identical strings collapse"
+    None
+    (Kr.personality_field_diff_summary
+       ~field:"will" ~current:"x" ~target:"x")
+
+let test_inner_diff_returns_summary () =
+  match
+    Kr.personality_field_diff_summary
+      ~field:"instructions" ~current:"alpha bravo" ~target:"alpha gamma"
+  with
+  | None -> fail "expected Some summary for inner content drift"
+  | Some s ->
+      check bool "summary tags field" true
+        (Astring.String.is_prefix ~affix:"instructions(" s);
+      check bool "summary exposes meta length" true
+        (Astring.String.is_infix ~affix:"raw_meta_len=11" s);
+      check bool "summary exposes target length" true
+        (Astring.String.is_infix ~affix:"raw_target_len=11" s)
+
+let test_length_drift_returns_summary () =
+  match
+    Kr.personality_field_diff_summary
+      ~field:"goal" ~current:"short" ~target:"a much longer goal text"
+  with
+  | None -> fail "expected Some summary for length drift"
+  | Some s ->
+      check bool "asymmetric length is reported" true
+        (Astring.String.is_infix ~affix:"raw_meta_len=5" s);
+      check bool "asymmetric length is reported" true
+        (Astring.String.is_infix ~affix:"raw_target_len=23" s)
+
+let test_long_field_truncates_preview () =
+  let long_a = String.make 200 'a' in
+  let long_b = String.make 200 'b' in
+  match
+    Kr.personality_field_diff_summary
+      ~field:"instructions" ~current:long_a ~target:long_b
+  with
+  | None -> fail "expected Some summary"
+  | Some s ->
+      check bool "ellipsis present for long preview" true
+        (Astring.String.is_infix ~affix:"..." s);
+      (* Sanity: full 200-char string must NOT appear. *)
+      check bool "untruncated preview must not appear" false
+        (Astring.String.is_infix ~affix:long_a s)
+
+let () =
+  run "personality_field_diff_10269" [
+    ("diff_summary", [
+        test_case "trim-equal pairs return None" `Quick
+          test_trim_equal_returns_none;
+        test_case "inner content diff returns Some summary" `Quick
+          test_inner_diff_returns_summary;
+        test_case "length drift surfaces both raw lengths" `Quick
+          test_length_drift_returns_summary;
+        test_case "long preview is truncated" `Quick
+          test_long_field_truncates_preview;
+      ]);
+  ]


### PR DESCRIPTION
## 요약

**Issue**: #10269 — `ensure_keeper_meta`가 매 reconcile cycle (~15s) 마다 `nick0cave`의 `[personality]` 필드를 re-sync. 다른 13 keeper는 0회. 371 events / 3000 logs ≈ 12.4% log noise + disk write churn (예상 21,600 events/day).

## Fix scope (옵션 A — 진단 로깅)

이 PR은 issue가 권장한 옵션 A 그대로. **behavior change 없음, observability만**.

기존 로그:
```
ensure_keeper_meta: re-syncing [personality] for nick0cave
```

신규 follow-up 라인 (personality re-sync 시에만):
```
ensure_keeper_meta: personality drift fields for nick0cave: \
  instructions(raw_meta_len=1008 raw_target_len=2243 \
  trim_meta="...32-char preview..." trim_target="...32-char preview...")
```

8개 personality 필드 중 어느 게 다른지 + raw length 비대칭 + 32-char trim preview를 함께 출력.

## 왜 이 형식인가

후보 root cause들:

1. **TOML triple-quote newline drop**: leading/trailing newline 차이 → `String.trim`으로 collapse되면 `personality_text_equal` true 반환 → re-sync 안 일어남. 즉 trim으로 안 잡히는 inner whitespace가 범인.
2. **JSON encoding round-trip**: write_meta가 `\n`을 escape했다가 다음 read에서 다른 형태 복원 → length 차이로 드러남.
3. **Persona overlay drift**: 동적 timestamp / merge 결과 변동 → 같은 길이지만 inner content 차이.

`raw_meta_len=A raw_target_len=B`가 다르면 (1) 또는 (2). 같은 길이인데 trim_meta/trim_target preview가 다르면 (3). 다음 1 cycle log로 즉시 분기.

## 검증

```text
DUNE_CACHE=disabled dune build --root . --cache=disabled @check
→ EXIT=0

dune exec test/test_personality_field_diff_10269.exe
→ 4/4 OK
  - trim-equal pairs return None  (10061 trim-newline 정상 collapse)
  - inner content diff returns Some summary
  - length drift surfaces both raw lengths
  - long preview is truncated (200-byte field → "..." 절단)
```

## 미완 (후속, 진단 결과 후 결정)

옵션 B/C/D는 root cause 파악 후 선택:

- **B (stronger normalize)**: trim + `\n` collapse + NFC unicode. over-normalize 위험.
- **C (defaults caching)**: TOML 재파싱이 매 cycle 새 instance 생성 시. memoize + mtime check.
- **D (re-sync rate limit)**: log noise 차단만 — 근본 fix 아님.

이 PR이 main에 들어간 후 1-2 cycle 동안 새 로그를 관찰 → root cause를 짚은 follow-up PR.

## Defensive guards

- Draft + `do-not-merge` label
- `gh pr merge --disable-auto`

## 관련

- Issue: `#10269`
- 메모리 `feedback_json-serializer-parser-key-symmetry.md` (round-trip property test 부재 패턴)
- 인접: `#10259` (cascade materializer 4 keeper 거부; nick0cave 공통이지만 별개 path)
