### PR TITLE
perf: hoist Re.compile in 4 hot paths, add String_util.find_substring

### DIFF
--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -407,8 +407,9 @@ let search ~query ~limit =
   match backend () with
   | Jsonl store ->
       let query_lower = String.lowercase_ascii query in
-      let pattern = Re.str query_lower |> Re.compile in
-      let matches_str s = Re.execp pattern (String.lowercase_ascii s) in
+      let matches_str s =
+        String_util.contains_substring (String.lowercase_ascii s) query_lower
+      in
       let predicate (p : Board.post) =
         matches_str p.title
         || matches_str p.content

--- a/lib/cache_eio.ml
+++ b/lib/cache_eio.ml
@@ -34,10 +34,14 @@ let ensure_cache_dir config =
   let dir = cache_dir config in
   Fs_compat.mkdir_p dir
 
+(* Pattern is a static character class — hoist out of [sanitize_key]
+   so we build the DFA once per process instead of per cache lookup. *)
+let unsafe_filename_char_re = Re.Pcre.re "[^a-zA-Z0-9_-]" |> Re.compile
+
 (** Sanitize key for filename *)
 let sanitize_key key =
   (* Replace unsafe chars with underscore, limit length *)
-  let safe = Re.replace_string (Re.Pcre.re "[^a-zA-Z0-9_-]" |> Re.compile) ~by:"_" key in
+  let safe = Re.replace_string unsafe_filename_char_re ~by:"_" key in
   if String.length safe > 64 then
     String.sub safe 0 64
   else safe

--- a/lib/core/string_util.ml
+++ b/lib/core/string_util.ml
@@ -29,6 +29,7 @@ let contains_substring haystack needle =
    after [pos] (default 0), or [None] if absent. Empty needle returns
    [Some pos], matching [Re.exec_opt (Re.str "" |> Re.compile)] semantics. *)
 let find_substring ?(pos = 0) haystack needle =
+  if pos < 0 then invalid_arg "String_util.find_substring: negative position";
   let hay_len = String.length haystack in
   let needle_len = String.length needle in
   if needle_len = 0 then Some pos

--- a/lib/core/string_util.ml
+++ b/lib/core/string_util.ml
@@ -25,6 +25,30 @@ let contains_substring haystack needle =
     in
     loop 0
 
+(* Byte-wise substring search: returns the index of the first match at or
+   after [pos] (default 0), or [None] if absent. Empty needle returns
+   [Some pos], matching [Re.exec_opt (Re.str "" |> Re.compile)] semantics. *)
+let find_substring ?(pos = 0) haystack needle =
+  let hay_len = String.length haystack in
+  let needle_len = String.length needle in
+  if needle_len = 0 then Some pos
+  else if pos + needle_len > hay_len then None
+  else
+    let rec match_at i j =
+      if j = needle_len then true
+      else if String.unsafe_get haystack (i + j)
+            <> String.unsafe_get needle j
+      then false
+      else match_at i (j + 1)
+    in
+    let last = hay_len - needle_len in
+    let rec loop i =
+      if i > last then None
+      else if match_at i 0 then Some i
+      else loop (i + 1)
+    in
+    loop pos
+
 (* ASCII case-insensitive substring containment without lowercasing
    either string.  Lowering happens byte-by-byte during compare. *)
 let contains_substring_ci haystack needle =

--- a/lib/core/string_util.mli
+++ b/lib/core/string_util.mli
@@ -10,6 +10,12 @@ val contains_substring_ci : string -> string -> bool
     Returns [false] when [needle] is empty, matching the behavior
     of the original per-module [contains_ci] helpers. *)
 
+val find_substring : ?pos:int -> string -> string -> int option
+(** [find_substring ?pos haystack needle] returns the byte index of the
+    first occurrence of [needle] in [haystack] at or after [pos]
+    (default 0), or [None] if absent. Empty needle returns [Some pos],
+    matching [Re.exec_opt (Re.str "" |> Re.compile)] semantics. *)
+
 val replace_substring : needle:string -> by:string -> string -> string
 (** [replace_substring ~needle ~by haystack] substitutes [by] for every
     non-overlapping occurrence of [needle] in [haystack]. Returns

--- a/lib/core/string_util.mli
+++ b/lib/core/string_util.mli
@@ -14,7 +14,8 @@ val find_substring : ?pos:int -> string -> string -> int option
 (** [find_substring ?pos haystack needle] returns the byte index of the
     first occurrence of [needle] in [haystack] at or after [pos]
     (default 0), or [None] if absent. Empty needle returns [Some pos],
-    matching [Re.exec_opt (Re.str "" |> Re.compile)] semantics. *)
+    matching [Re.exec_opt (Re.str "" |> Re.compile)] semantics. Raises
+    [Invalid_argument] when [pos] is negative. *)
 
 val replace_substring : needle:string -> by:string -> string -> string
 (** [replace_substring ~needle ~by haystack] substitutes [by] for every

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -73,16 +73,16 @@ let inject_default_agent_name ~(worker_name : string)
   | _ -> args
 
 let extract_prompt_block ~start_marker ~end_marker (text : string) =
-  let start_re = Re.str start_marker |> Re.compile in
-  let end_re = Re.str end_marker |> Re.compile in
-  match Re.exec_opt start_re text with
+  (* Markers are caller-supplied so we can't hoist; but they're literal
+     bytes, so a byte-wise [find_substring] is cheaper than building a
+     fresh DFA per call. *)
+  match String_util.find_substring text start_marker with
   | None -> None
-  | Some g ->
-    let start_idx = Re.Group.stop g 0 in
-    (match Re.exec_opt ~pos:start_idx end_re text with
+  | Some marker_pos ->
+    let start_idx = marker_pos + String.length start_marker in
+    (match String_util.find_substring ~pos:start_idx text end_marker with
     | None -> None
-    | Some g2 ->
-      let end_idx = Re.Group.start g2 0 in
+    | Some end_idx ->
       let raw = String.sub text start_idx (end_idx - start_idx) |> String.trim in
       if raw = "" then None else Some raw)
 

--- a/lib/task_sandbox.ml
+++ b/lib/task_sandbox.ml
@@ -44,26 +44,27 @@ let git_exit ~cwd args =
   | Unix.WSIGNALED _, _ -> 128
   | Unix.WSTOPPED _, _ -> 128
 
+(* Worktree-message regexes are static — hoist so the DFAs are built
+   once at module init instead of per [extract_*] call. *)
+let abs_path_re = Re.Pcre.re {|Path: (/[^ \t\n\r]+)|} |> Re.compile
+let rel_worktree_re = Re.Pcre.re {|\.worktrees/[^ \t\n\r]+|} |> Re.compile
+let branch_name_re = Re.Pcre.re {|Branch: ([^ \t\n\r]+)|} |> Re.compile
+
 (** Extract absolute worktree path from [Coord_worktree.worktree_create_r]
     success message. Tries "Path: <absolute>" first, then falls back to
     constructing from a relative [.worktrees/...] segment. *)
 let extract_worktree_path ~base_path msg =
-  (* Try absolute path from "Path: /..." *)
-  let abs_re = Re.Pcre.re {|Path: (/[^ \t\n\r]+)|} |> Re.compile in
-  match Re.exec_opt abs_re msg with
+  match Re.exec_opt abs_path_re msg with
   | Some g -> Some (Re.Group.get g 1)
   | None ->
-    (* Fallback: relative path *)
-    let rel_re = Re.Pcre.re {|\.worktrees/[^ \t\n\r]+|} |> Re.compile in
-    (match Re.exec_opt rel_re msg with
+    (match Re.exec_opt rel_worktree_re msg with
     | Some g -> Some (Filename.concat base_path (Re.Group.get g 0))
     | None -> None)
 
 (** Extract branch name from success message.
     Format: "Branch: agent/task-NNN" *)
 let extract_branch_name msg =
-  let re = Re.Pcre.re {|Branch: ([^ \t\n\r]+)|} |> Re.compile in
-  match Re.exec_opt re msg with
+  match Re.exec_opt branch_name_re msg with
   | Some g -> Some (Re.Group.get g 1)
   | None -> None
 

--- a/test/test_string_util.ml
+++ b/test/test_string_util.ml
@@ -148,10 +148,41 @@ let test_safe_invalid_utf8_best_effort () =
       (* Best-effort: ASCII "A" should be preserved, orphan dropped *)
       check string "best-effort keeps ASCII" "A" prefix
 
+(* ---- find_substring ---- *)
+
+let check_int_option = check (option int)
+
+let test_find_substring_basic () =
+  check_int_option "first occurrence" (Some 0)
+    (SU.find_substring "abcabc" "abc");
+  check_int_option "respects pos" (Some 3)
+    (SU.find_substring ~pos:1 "abcabc" "abc");
+  check_int_option "absent" None
+    (SU.find_substring "abcabc" "z")
+
+let test_find_substring_boundaries () =
+  check_int_option "match at last valid index" (Some 2)
+    (SU.find_substring ~pos:2 "aaaa" "aa");
+  check_int_option "pos past last valid index" None
+    (SU.find_substring ~pos:3 "aaaa" "aa");
+  check_int_option "pos at end" None
+    (SU.find_substring ~pos:4 "aaaa" "a")
+
+let test_find_substring_empty_needle () =
+  check_int_option "empty returns pos" (Some 2)
+    (SU.find_substring ~pos:2 "abc" "");
+  check_int_option "empty can return end" (Some 3)
+    (SU.find_substring ~pos:3 "abc" "")
+
+let test_find_substring_rejects_negative_pos () =
+  check_raises "negative pos" (Invalid_argument
+    "String_util.find_substring: negative position")
+    (fun () -> ignore (SU.find_substring ~pos:(-1) "abc" "a"))
+
 (* ---- Test runner ---- *)
 
 let () =
-  run "string_util UTF-8 safety"
+  run "string_util"
     [ ( "utf8_char_boundary",
         [ test_case "ASCII in-bounds" `Quick test_boundary_ascii_in_bounds;
           test_case "Korean cuts back" `Quick test_boundary_korean_cuts_back;
@@ -171,4 +202,10 @@ let () =
           test_case "was_truncated + to_string" `Quick
             test_was_truncated_and_to_string;
           test_case "invalid UTF-8 best-effort" `Quick
-            test_safe_invalid_utf8_best_effort ] ) ]
+            test_safe_invalid_utf8_best_effort ] );
+      ( "find_substring",
+        [ test_case "basic" `Quick test_find_substring_basic;
+          test_case "boundaries" `Quick test_find_substring_boundaries;
+          test_case "empty needle" `Quick test_find_substring_empty_needle;
+          test_case "negative pos rejected" `Quick
+            test_find_substring_rejects_negative_pos ] ) ]


### PR DESCRIPTION
## Summary

Four more module-init regex hoists and a new \`String_util.find_substring\` helper. Each callsite compiled a fresh DFA per call for what was either a static pattern or a literal substring scan.

### lib/core/string_util.ml{,.mli}
- New helper: \`find_substring ?pos haystack needle -> int option\`. Byte-wise scan using \`String.unsafe_get\`; same loop shape as the existing \`contains_substring\` but returns the index. Empty needle returns \`Some pos\`.

### lib/cache_eio.ml
- \`sanitize_key\`: static character class re-compiled per cache lookup. Hoist to module-level. Cache-heavy paths call this many times per minute.

### lib/task_sandbox.ml
- Three fixed PCREs (\`Path: /...\`, \`.worktrees/...\`, \`Branch: ...\`) compiled per worktree-create call. Hoist to module level.

### lib/local/worker_container_types.ml
- \`extract_prompt_block\`: markers are caller-supplied so we can't hoist a compiled regex. Switch to \`String_util.find_substring\` — the prior code compiled both markers per invocation just to do byte-equal searches.

### lib/board_dispatch.ml
- Board search predicate compiled \`Re.str query_lower\` per query then ran \`execp\` against a freshly lowercased post field for every post. Replace with \`String_util.contains_substring\` — equivalent semantics, no DFA.

## Behavior preserved

- All hoists keep identical regex; only build-time changes.
- \`find_substring\` on empty needle yields \`Some pos\`, mirroring \`Re.exec_opt (Re.str "" |> compile)\`.
- Board search: query_lower vs post-field lowercasing unchanged.

## Test plan

- [x] \`dune build @check\` clean
- [x] test_string_util 13/13
- [x] test_cache_eio_coverage 11/11
- [x] test_board_dispatch 27/27

🤖 Generated with [Claude Code](https://claude.com/claude-code)