### PR TITLE
diag(telemetry): error_kind / error_message on Tool_called (#10358)

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -714,12 +714,34 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   if telemetry_enabled then
     (match state.Mcp_server.fs with
      | Some fs ->
+         (* #10358: classify failures so the 17.3% [success=false]
+            tail in [telemetry/YYYY-MM/DD.jsonl] becomes diagnosable
+            without cross-referencing audit_log.  [error_kind] keeps a
+            small closed vocabulary (timeout vs other) so dashboards
+            can group; [error_message] carries the already-truncated
+            preview that [audit_log.log_tool_call] received. *)
+         let telemetry_error_kind =
+           if success then None
+           else if !timeout_hit then Some "timeout"
+           else Some "tool_failure"
+         in
+         let telemetry_error_message =
+           if success then None
+           else
+             let preview =
+               String_util.utf8_safe ~max_bytes:200 ~suffix:"..." message
+               |> String_util.to_string
+             in
+             if String.length preview = 0 then None else Some preview
+         in
          (try Telemetry_eio.track_tool_called ~fs state.Mcp_server.room_config
                 ~tool_name:name ~agent_id:agent_name ~success ~duration_ms
                 ~source:(Tool_registry.string_of_source source)
                 ?session_id:telemetry_session_id
                 ?operation_id:telemetry_operation_id
                 ?worker_run_id:telemetry_worker_run_id
+                ?error_kind:telemetry_error_kind
+                ?error_message:telemetry_error_message
                 ()
           with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
             log_mcp_exn ~label:"telemetry tracking failed" exn)

--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -30,6 +30,14 @@ type event =
       session_id: string option;
       operation_id: string option;
       worker_run_id: string option;
+      (* #10358: 17.3% of Tool_called events have success=false but
+         no diagnostic fields — operators cannot tell timeout from
+         OOM/4xx/cancel.  Both fields stay optional so existing call
+         sites that lack error context (worker_container, http
+         keeper streams) remain valid; only the MCP dispatcher
+         currently populates them. *)
+      error_kind: string option;
+      error_message: string option;
     }
   | Tool_assigned of { agent_id: string; profile: string; preset: string option; tool_count: int; assignment_id: string }
 [@@deriving yojson, show]
@@ -171,6 +179,16 @@ let event_record_of_yojson_lenient json =
               let* worker_run_id =
                 json_string_opt context "worker_run_id" event_fields
               in
+              (* #10358: lenient parser must accept rows from before the
+                 error fields existed (they appear as missing) and rows
+                 from after (Some "..." or None).  Both keys are
+                 [json_string_opt] so missing collapses to [None]. *)
+              let* error_kind =
+                json_string_opt context "error_kind" event_fields
+              in
+              let* error_message =
+                json_string_opt context "error_message" event_fields
+              in
               Ok
                 {
                   timestamp;
@@ -185,6 +203,8 @@ let event_record_of_yojson_lenient json =
                         session_id;
                         operation_id;
                         worker_run_id;
+                        error_kind;
+                        error_message;
                       };
                 }
           | _ -> Error original_error)
@@ -436,7 +456,8 @@ let track_error ?fs config ~code ~message ~context =
   track ?fs config (Error_occurred { code; message; context })
 
 let track_tool_called ?fs config ~tool_name ~success ~duration_ms ?agent_id
-    ?source ?session_id ?operation_id ?worker_run_id () =
+    ?source ?session_id ?operation_id ?worker_run_id
+    ?error_kind ?error_message () =
   track ?fs config
     (Tool_called
        {
@@ -448,6 +469,8 @@ let track_tool_called ?fs config ~tool_name ~success ~duration_ms ?agent_id
          session_id;
          operation_id;
          worker_run_id;
+         error_kind;
+         error_message;
        })
 
 let track_tool_assigned ?fs config ~agent_id ~profile ?preset ~tool_count ~assignment_id () =

--- a/test/dune
+++ b/test/dune
@@ -1044,6 +1044,7 @@
         test_cache_eio_coverage test_run_eio_coverage
         test_handover_eio_coverage test_mcp_server_eio_coverage
         test_http_server_eio_coverage test_telemetry_eio_coverage
+        test_tool_called_error_field_10358
         test_room_git_coverage test_prometheus_coverage
         test_auto_responder_coverage test_tool_plan_coverage
         test_tool_worktree_coverage
@@ -1079,6 +1080,7 @@
         test_cache_eio_coverage test_run_eio_coverage
         test_handover_eio_coverage test_mcp_server_eio_coverage
         test_http_server_eio_coverage test_telemetry_eio_coverage
+        test_tool_called_error_field_10358
         test_room_git_coverage test_prometheus_coverage
         test_auto_responder_coverage test_tool_plan_coverage
         test_tool_worktree_coverage

--- a/test/test_observability_provider_contracts.ml
+++ b/test/test_observability_provider_contracts.ml
@@ -278,6 +278,8 @@ let test_event_serialization_roundtrip () =
           session_id = None;
           operation_id = None;
           worker_run_id = None;
+          error_kind = None;
+          error_message = None;
         };
       T.Error_occurred { code = "E001"; message = "test"; context = "test" } ]
   in

--- a/test/test_telemetry_eio_coverage.ml
+++ b/test/test_telemetry_eio_coverage.ml
@@ -110,6 +110,8 @@ let test_event_tool_called () =
     session_id = Some "mcp-session-1";
     operation_id = Some "op-1";
     worker_run_id = Some "run-1";
+    error_kind = None;
+    error_message = None;
   } in
   match e with
   | Telemetry_eio.Tool_called r ->

--- a/test/test_tool_called_error_field_10358.ml
+++ b/test/test_tool_called_error_field_10358.ml
@@ -1,0 +1,94 @@
+(** #10358: Tool_called events had success=true|false but no error
+    discriminator — 142/679 (17.3%) failures landed in
+    [telemetry/YYYY-MM/DD.jsonl] with no diagnostic field, forcing
+    operators to cross-reference audit_log to know why. These tests
+    pin the new optional [error_kind] and [error_message] payload
+    fields and the lenient parser's tolerance for missing keys (older
+    rows pre-dating this PR). *)
+
+open Alcotest
+module T = Masc_mcp.Telemetry_eio
+
+let optional_string_eq = option string
+
+let make ~success ~error_kind ~error_message =
+  T.Tool_called
+    {
+      tool_name = "test_tool";
+      success;
+      duration_ms = 12;
+      agent_id = Some "test-agent";
+      source = Some "external_mcp";
+      session_id = Some "sess-1";
+      operation_id = Some "op-1";
+      worker_run_id = Some "run-1";
+      error_kind;
+      error_message;
+    }
+
+let test_payload_round_trip_with_error () =
+  let event = make ~success:false
+                ~error_kind:(Some "timeout")
+                ~error_message:(Some "deadline 200ms hit") in
+  let json = T.event_to_yojson event in
+  let str = Yojson.Safe.to_string json in
+  check bool "error_kind serialised" true
+    (Astring.String.is_infix ~affix:"\"error_kind\"" str);
+  check bool "timeout literal present" true
+    (Astring.String.is_infix ~affix:"\"timeout\"" str);
+  check bool "error_message literal present" true
+    (Astring.String.is_infix ~affix:"deadline 200ms" str)
+
+let test_payload_round_trip_no_error () =
+  let event = make ~success:true ~error_kind:None ~error_message:None in
+  match T.event_of_yojson (T.event_to_yojson event) with
+  | Ok (T.Tool_called r) ->
+      check bool "success preserved" true r.success;
+      check optional_string_eq "error_kind None" None r.error_kind;
+      check optional_string_eq "error_message None" None r.error_message
+  | Ok _ | Error _ -> fail "expected Tool_called round-trip"
+
+(* The lenient parser is what dashboards/diagnostics actually use to
+   read existing telemetry day-files.  Rows written before this PR
+   omit [error_kind] / [error_message] entirely; they must continue
+   to parse with [None] for the new fields rather than failing. *)
+let test_lenient_parser_accepts_legacy_rows () =
+  let legacy_json =
+    `Assoc [
+      "timestamp", `Float 1700000000.0;
+      "event", `List [
+        `String "Tool_called";
+        `Assoc [
+          "tool_name", `String "legacy_tool";
+          "success", `Bool false;
+          "duration_ms", `Int 50;
+          "agent_id", `String "agent-x";
+          "source", `String "external_mcp";
+          "session_id", `Null;
+          "operation_id", `Null;
+          "worker_run_id", `Null;
+          (* error_kind and error_message keys absent on purpose *)
+        ];
+      ];
+    ]
+  in
+  match T.event_record_of_yojson_lenient legacy_json with
+  | Ok { event = T.Tool_called r; _ } ->
+      check string "tool_name parsed" "legacy_tool" r.tool_name;
+      check bool "success parsed" false r.success;
+      check optional_string_eq "missing error_kind defaults None" None r.error_kind;
+      check optional_string_eq "missing error_message defaults None" None r.error_message
+  | Ok _ | Error _ ->
+      fail "lenient parser must accept legacy Tool_called rows without error fields"
+
+let () =
+  run "tool_called_error_field_10358" [
+    ("error_payload", [
+        test_case "Some error_kind / error_message survives serialise" `Quick
+          test_payload_round_trip_with_error;
+        test_case "None payload round-trips through yojson" `Quick
+          test_payload_round_trip_no_error;
+        test_case "lenient parser accepts pre-#10358 rows" `Quick
+          test_lenient_parser_accepts_legacy_rows;
+      ]);
+  ]


### PR DESCRIPTION
## 요약

**Issue**: #10358 — `telemetry/2026-04/25.jsonl`의 `Tool_called` 854 events 중 142건 (17.3%)이 `success=false`인데 어떤 종류의 실패인지 ledger만 보고는 0% 진단 가능. timeout / OOM / cancel / 4xx / 5xx가 단일 boolean으로 collapse.

## Fix scope (옵션 B 부분, surgical)

이슈의 5 옵션 중 **옵션 B (Tool_called에 error 필드 추가)**의 가장 작은 surgical 부분만 구현:

| 변경 | 영향 |
|------|------|
| `Telemetry_eio.event` ADT의 `Tool_called`에 `error_kind: string option`, `error_message: string option` 추가 | non-breaking (옵셔널) |
| `track_tool_called` 시그니처에 `?error_kind ?error_message` 추가 | non-breaking (옵셔널 인자) |
| `mcp_server_eio_call_tool.ml`에서만 wire-up | dominant fleet path |
| `event_record_of_yojson_lenient` parser에 두 키의 `json_string_opt` 처리 추가 | 기존 day-file 호환 |

## 다른 3 callsite는 미와이어 (의도적)

`server_routes_http_keeper_stream` (×2), `local/worker_container`는 이번 PR에서 수정 **안 함**:
- 옵셔널 인자 시그니처라 컴파일 영향 없음
- 해당 경로들은 현재 error context 직접 보유 안 함 (별도 plumbing 작업 필요)
- 분리하지 않으면 PR이 invasive해져서 conflict 위험 증가

후속 PR로 해당 사이트의 plumbing 작업을 분리.

## error_kind 값

작은 closed vocabulary로 dashboard 그룹화 용이:

- `"timeout"` — soft deadline (`timeout_hit=true`)
- `"tool_failure"` — 그 외 모든 실패

추후 `"cancelled"`, `"oom"`, `"http_4xx"`, `"http_5xx"` 등 추가 분류는 source-side로 evidence 잡힌 후 별도 PR.

## error_message

200-byte UTF-8-safe 잘림 (audit_log가 이미 받는 same preview 재사용). 빈 문자열이면 `None` 변환.

## Lenient parser 호환성

기존 `~/me/.masc/telemetry/2026-04/22-25.jsonl`은 두 새 필드 없이 작성됨. `event_record_of_yojson_lenient`가 두 키를 `json_string_opt`로 처리하므로 missing → `None`. 기존 ledger 재파싱 안전.

## 검증

```text
DUNE_CACHE=disabled dune build --root . --cache=disabled @check
→ EXIT=0

dune exec test/test_tool_called_error_field_10358.exe
→ 3/3 OK
  - Some error_kind / error_message survives serialise
  - None payload round-trips through yojson
  - lenient parser accepts pre-#10358 rows
```

기존 단위 테스트 2건 (`test_telemetry_eio_coverage`, `test_observability_provider_contracts`) 도 신규 필드를 명시적 `None`으로 빌드 통과.

## 영향 (예상)

머지 후 24h:
- `success=false` Tool_called 행에 `error_kind` 필드 등장 (timeout 식별 가능)
- iter101 #10285 (kimi_cli systemic fail) — telemetry만으로 timeout 비율 grouping 가능
- 17.3% failure tail의 timeout-fraction이 dominant인지 첫 empirical 측정

## 미완 (후속)

- 옵션 A (`Task_started/completed/Agent_left`을 `masc_transition` MCP path에서도 emit) — 별도 PR
- 옵션 C (dead variant `Handoff_triggered` 0 caller 정리) — 별도 PR
- 옵션 D (cross-ledger invariant) — #10314 fix와 함께
- 다른 3 Tool_called callsite plumbing — 별도 PR

## Defensive guards

- Draft + `do-not-merge` label
- `gh pr merge --disable-auto`

## 관련

- Issue: `#10358`
- 인접: `#10285` (kimi_cli fail mode 구분), `#10314` (accountability single callsite), `#10325` (failure 사유 부재 mirror)
- 메모리: `feedback_keeper-5gate-fallback-pressure.md` (20-55% error rate, telemetry 17.3% 일치)
