### PR TITLE
perf(drift-guard,board-votes): hoist 2 more per-call Re.compile

### DIFF
--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -687,10 +687,12 @@ let available_flairs = [
   ("meta", "🔧", "Meta");
 ]
 
+(* Flair tag pattern — pure literal, hoist out of per-post extraction. *)
+let flair_tag_re = Re.Pcre.re {|\[flair:([a-z]+)\]|} |> Re.compile
+
 (** Extract flair from content (format: [flair:name] at start) *)
 let extract_flair content =
-  let re = Re.Pcre.re {|\[flair:([a-z]+)\]|} |> Re.compile in
-  match Re.exec_opt re content with
+  match Re.exec_opt flair_tag_re content with
   | Some g ->
     let flair_name = Re.Group.get g 1 in
     (match List.find_opt (fun (name, _, _) -> name = flair_name) available_flairs with

--- a/lib/drift_guard.ml
+++ b/lib/drift_guard.ml
@@ -75,11 +75,15 @@ let factual_size_ratio_floor () =
 let structural_divergence_threshold () =
   Runtime_params.get Governance_registry.drift_structural_divergence_threshold
 
+(* Whitespace splitter for [tokenize] — pattern is a static character
+   class, hoist out of the per-call hot path. *)
+let whitespace_split_re = Re.Pcre.re "[ \t\r\n]+" |> Re.compile
+
 let tokenize (s : string) : string list =
   let trimmed = String.trim s in
   if trimmed = "" then []
   else
-    let tokens = Re.split (Re.Pcre.re "[ \t\r\n]+" |> Re.compile) trimmed in
+    let tokens = Re.split whitespace_split_re trimmed in
     let trim_punct token =
       let is_punct = function
         | '.'


### PR DESCRIPTION
## Summary

Two more module-init regex hoists.

### lib/drift_guard.ml
- \`tokenize\` compiled the whitespace-split PCRE per call. \`tokenize\` is on the drift-detection hot path (every text snippet gets split before Jaccard scoring). Pattern is fully static → module-level \`let\`.

### lib/board_votes.ml
- \`extract_flair\` compiled the flair-tag PCRE per post during karma JSON shaping. \`post_to_yojson_with_karma\` fans out across every paginated board listing, so even a 50-post window paid 50 fresh DFA builds.

Behavior preserved — only the \`let\` binding moved.

## Test plan

- [x] \`dune build @check\` clean
- [x] \`test_drift_guard_core\` 5/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)