### PR TITLE
fix(dated_jsonl): file-scope mutex registry shares lock across instances (#10372)

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -19,8 +19,52 @@ type t = {
   mutex : Eio.Mutex.t;
 }
 
+(* #10372: file-scope mutex registry keyed on canonical [base_dir].
+
+   Pre-fix every [create] minted a fresh [Eio.Mutex.t]. When two
+   stores pointed at the same JSONL directory their mutexes were
+   distinct, so concurrent [append] calls did not coordinate.
+   [oas_sse_bridge.ml:483] in particular re-creates the store on
+   every relay error while another fiber still holds the previous
+   instance, opening a window where 4-8 KB [oas_worker:build]
+   payloads interleave inside the same line — POSIX [O_APPEND]
+   only guarantees atomicity up to PIPE_BUF (4096 B Linux,
+   512 B macOS) and [output_string] is buffered, so the kernel
+   sees several [write(2)] calls per logical line.
+
+   The registry forces every store rooted at the same directory
+   to share one mutex. An explicit [?mutex] argument still wins,
+   keeping test isolation patterns intact. *)
+let registry : (string, Eio.Mutex.t) Hashtbl.t = Hashtbl.create 16
+let registry_guard = Stdlib.Mutex.create ()
+
+let canonicalize_base_dir base_dir =
+  try Unix.realpath base_dir
+  with Unix.Unix_error _ ->
+    let len = String.length base_dir in
+    if len > 1 && base_dir.[len - 1] = '/' then
+      String.sub base_dir 0 (len - 1)
+    else base_dir
+
+let mutex_for_base_dir base_dir =
+  let canon = canonicalize_base_dir base_dir in
+  Stdlib.Mutex.lock registry_guard;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock registry_guard)
+    (fun () ->
+      match Hashtbl.find_opt registry canon with
+      | Some m -> m
+      | None ->
+          let m = Eio.Mutex.create () in
+          Hashtbl.add registry canon m;
+          m)
+
 let create ~base_dir ?mutex () =
-  let mutex = match mutex with Some m -> m | None -> Eio.Mutex.create () in
+  let mutex =
+    match mutex with
+    | Some m -> m
+    | None -> mutex_for_base_dir base_dir
+  in
   { base_dir; mutex }
 
 let base_dir t = t.base_dir
@@ -314,3 +358,15 @@ let prune t ~days =
   end
 
 (* Duplicate count_entries removed — canonical definition at line 225 *)
+
+module For_testing = struct
+  let mutex t = t.mutex
+
+  let mutex_for_base_dir = mutex_for_base_dir
+
+  let registry_size () =
+    Stdlib.Mutex.lock registry_guard;
+    Fun.protect
+      ~finally:(fun () -> Stdlib.Mutex.unlock registry_guard)
+      (fun () -> Hashtbl.length registry)
+end

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -47,3 +47,16 @@ val load_tail_lines : string -> max_lines:int -> string list
 (** [load_tail_lines file ~max_lines] efficiently reads the last [max_lines]
     from a large file without loading the whole file into memory.
     Reads backwards in chunks. Returns chronologically (oldest first). *)
+
+module For_testing : sig
+  val mutex : t -> Eio.Mutex.t
+  (** Expose the internal mutex so tests can verify sharing. *)
+
+  val mutex_for_base_dir : string -> Eio.Mutex.t
+  (** Lookup or insert the registry entry for [base_dir].
+      Equivalent to the default-mutex path of {!create}. *)
+
+  val registry_size : unit -> int
+  (** Number of distinct [base_dir] keys currently held by the
+      file-scope mutex registry. *)
+end

--- a/test/dune
+++ b/test/dune
@@ -1447,6 +1447,12 @@
  (modules test_goal_phase_awaiting_verification_10411)
  (libraries masc_mcp alcotest))
 
+(test
+ (name test_dated_jsonl_mutex_registry_10372)
+ (modules test_dated_jsonl_mutex_registry_10372)
+ (libraries dated_jsonl fs_compat alcotest eio eio_main yojson unix))
+
+
 ; ============================================================
 ; Special: Heartbeat/keeper minimal deps
 ; ============================================================

--- a/test/test_dated_jsonl_mutex_registry_10372.ml
+++ b/test/test_dated_jsonl_mutex_registry_10372.ml
@@ -1,0 +1,165 @@
+(** #10372 — pin the file-scope mutex registry contract.
+
+    Pre-fix [Dated_jsonl.create] minted a fresh [Eio.Mutex.t]
+    per call.  When two instances pointed at the same JSONL
+    directory, their mutexes did not coordinate and concurrent
+    [append] could interleave.  Real-world trigger:
+    [oas_sse_bridge.ml] re-creates the store on every relay
+    error while another fiber still holds the previous instance,
+    producing 1.52% line corruption (16/1056) on day 25 — all
+    [masc:oas_worker:build] payloads in the 4-8 KB range past
+    POSIX [PIPE_BUF].
+
+    The registry forces every store rooted at the same canonical
+    [base_dir] to share one mutex.  An explicit [?mutex] argument
+    still overrides, preserving test isolation patterns.
+
+    Tests pin:
+
+    1. Same [base_dir] → physically identical mutex.
+    2. Different [base_dir] → distinct mutexes.
+    3. Explicit [?mutex] bypasses the registry.
+    4. Trailing-slash variants normalize to the same mutex.
+    5. Behavioural: concurrent appends through two store
+       instances at the same dir produce all-parseable lines,
+       even with payloads larger than [PIPE_BUF]. *)
+
+open Alcotest
+
+module D = Dated_jsonl
+
+let counter = ref 0
+
+let tmpdir prefix =
+  incr counter;
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "%s_%d_%d_%.0f" prefix !counter (Unix.getpid ())
+         (Unix.gettimeofday ()))
+  in
+  Fs_compat.mkdir_p dir;
+  dir
+
+(* --- 1. same base_dir → identical mutex ---------------- *)
+
+let test_same_base_dir_shares_mutex () =
+  let dir = tmpdir "djmr_same" in
+  let a = D.create ~base_dir:dir () in
+  let b = D.create ~base_dir:dir () in
+  check bool "same base_dir → physically identical mutex" true
+    (D.For_testing.mutex a == D.For_testing.mutex b)
+
+(* --- 2. different base_dir → distinct mutexes ---------- *)
+
+let test_different_base_dir_distinct_mutex () =
+  let dir_a = tmpdir "djmr_diff_a" in
+  let dir_b = tmpdir "djmr_diff_b" in
+  let a = D.create ~base_dir:dir_a () in
+  let b = D.create ~base_dir:dir_b () in
+  check bool "distinct base_dir → distinct mutex" false
+    (D.For_testing.mutex a == D.For_testing.mutex b)
+
+(* --- 3. explicit ?mutex bypasses the registry --------- *)
+
+let test_explicit_mutex_overrides_registry () =
+  let dir = tmpdir "djmr_explicit" in
+  let registry_mutex = D.For_testing.mutex_for_base_dir dir in
+  let injected = Eio.Mutex.create () in
+  let store = D.create ~base_dir:dir ~mutex:injected () in
+  check bool "explicit mutex used verbatim" true
+    (D.For_testing.mutex store == injected);
+  check bool "explicit mutex differs from registry entry" false
+    (D.For_testing.mutex store == registry_mutex)
+
+(* --- 4. trailing-slash variants share the mutex -------- *)
+
+let test_trailing_slash_normalizes () =
+  let dir = tmpdir "djmr_slash" in
+  let a = D.create ~base_dir:dir () in
+  let b = D.create ~base_dir:(dir ^ "/") () in
+  check bool "trailing slash normalises to same mutex" true
+    (D.For_testing.mutex a == D.For_testing.mutex b)
+
+(* --- 5. concurrent appends produce all-parseable lines  *)
+
+(* Payload large enough to exercise the buffered [output_string]
+   path that previously split into multiple [write(2)] calls past
+   [PIPE_BUF].  We don't depend on the writer's exact threshold;
+   we only assert that NO line is truncated or interleaved
+   regardless of how many fibers append concurrently. *)
+let big_payload tag =
+  let body = String.make 6000 '.' in
+  `Assoc
+    [
+      ("tag", `String tag);
+      ("body", `String body);
+      ("ts", `Float (Unix.gettimeofday ()));
+    ]
+
+let read_today_lines dir =
+  let open Unix in
+  let tm = gmtime (gettimeofday ()) in
+  let month =
+    Printf.sprintf "%04d-%02d" (tm.tm_year + 1900) (tm.tm_mon + 1)
+  in
+  let day = Printf.sprintf "%02d.jsonl" tm.tm_mday in
+  let path = Filename.concat (Filename.concat dir month) day in
+  if not (Sys.file_exists path) then []
+  else
+    Fs_compat.load_file path
+    |> String.split_on_char '\n'
+    |> List.filter (fun l -> String.trim l <> "")
+
+let test_concurrent_two_instances_no_corruption () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "djmr_concurrent" in
+  (* Two instances at the same dir — pre-fix this would mint
+     two distinct mutexes; post-fix the registry forces sharing. *)
+  let store_a = D.create ~base_dir:dir () in
+  let store_b = D.create ~base_dir:dir () in
+  check bool "registry shares mutex across instances" true
+    (D.For_testing.mutex store_a == D.For_testing.mutex store_b);
+  let n = 40 in
+  Eio.Fiber.both
+    (fun () ->
+      for i = 0 to n - 1 do
+        D.append store_a (big_payload (Printf.sprintf "a-%d" i))
+      done)
+    (fun () ->
+      for i = 0 to n - 1 do
+        D.append store_b (big_payload (Printf.sprintf "b-%d" i))
+      done);
+  let lines = read_today_lines dir in
+  check int "all 80 lines present" (2 * n) (List.length lines);
+  let parsed_count =
+    List.fold_left
+      (fun acc line ->
+        match Yojson.Safe.from_string line with
+        | _ -> acc + 1
+        | exception Yojson.Json_error _ -> acc)
+      0 lines
+  in
+  check int "every line parses as JSON" (2 * n) parsed_count
+
+let () =
+  run "dated_jsonl_mutex_registry_10372"
+    [
+      ( "registry-identity",
+        [
+          test_case "same base_dir shares mutex" `Quick
+            test_same_base_dir_shares_mutex;
+          test_case "different base_dir distinct mutex" `Quick
+            test_different_base_dir_distinct_mutex;
+          test_case "explicit ?mutex bypasses registry" `Quick
+            test_explicit_mutex_overrides_registry;
+          test_case "trailing slash normalises" `Quick
+            test_trailing_slash_normalizes;
+        ] );
+      ( "concurrent-append",
+        [
+          test_case "two instances at same dir do not corrupt" `Quick
+            test_concurrent_two_instances_no_corruption;
+        ] );
+    ]


### PR DESCRIPTION
Closes #10372. File-scope mutex registry in Dated_jsonl keyed on canonical base_dir. Pre-fix two stores at the same dir minted distinct mutexes; oas_sse_bridge re-creating the store on every relay error opened a window where 4-8 KB payloads interleaved past POSIX PIPE_BUF (4096 B Linux, 512 B macOS). Day 25: 16/1056 broken lines (1.52%, 50x day 24), all masc:oas_worker:build. Tests: 5 new cases (registry identity + concurrent two-instance non-corruption with 6 KB payloads). Explicit ?mutex still wins for test isolation. Pre-existing read_recent failures unrelated.