### PR TITLE
fix(keeper-toml): dedup per-cycle WARN spam (#10259, option D)

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -932,6 +932,28 @@ let load_keeper_toml (path : string)
           let id = Ids.Keeper_id.generate ~name ~path in
           Ok (name, { defaults with manifest_path = Some path; id = Some id })
 
+(* #10259: every reconcile cycle calls [discover_keepers_toml], so a
+   persistent fail mode (4 keepers stuck on cascade_name "ollama_only"
+   while the materializer rejects it) emits 4 identical WARNs per
+   cycle — 16+ events in a 43-minute window of system_log.  Dedup by
+   [(filename, error_text)] so an unchanged failure is logged only on
+   first observation; a *new* error text for the same file still
+   emits, and a fresh process starts the table empty so restart
+   diagnoses survive.  Mirrors the [logged_invalid_fallback] pattern
+   in [Keeper_cascade_profile]. *)
+let logged_toml_skip : (string * string, unit) Hashtbl.t = Hashtbl.create 8
+
+let log_toml_skip_once ~file ~error =
+  let key = (file, error) in
+  if Hashtbl.mem logged_toml_skip key then false
+  else begin
+    Hashtbl.add logged_toml_skip key ();
+    Log.Keeper.warn "toml_loader: skipping %s: %s" file error;
+    true
+  end
+
+let reset_logged_toml_skip_for_test () = Hashtbl.clear logged_toml_skip
+
 let discover_keepers_toml (dir : string)
     : (string * keeper_profile_defaults) list =
   if not (Fs_compat.file_exists dir && Sys.is_directory dir) then []
@@ -946,7 +968,7 @@ let discover_keepers_toml (dir : string)
          match load_keeper_toml path with
          | Ok pair -> Some pair
          | Error e ->
-           Log.Keeper.warn "toml_loader: skipping %s: %s" f e;
+           let _emitted = log_toml_skip_once ~file:f ~error:e in
            None)
 
 let keeper_toml_path_opt name =

--- a/test/dune
+++ b/test/dune
@@ -662,6 +662,7 @@
         test_dashboard_render_timing_9766
         test_task_status_label_10421
         test_personality_field_diff_10269
+        test_toml_skip_dedup_10259
         test_keeper_task_dispatch
         test_keeper_tag_dispatch
         test_autoresearch_knowledge
@@ -843,6 +844,7 @@
         test_dashboard_render_timing_9766
         test_task_status_label_10421
         test_personality_field_diff_10269
+        test_toml_skip_dedup_10259
         test_keeper_task_dispatch
         test_keeper_tag_dispatch
         test_autoresearch_knowledge

--- a/test/test_toml_skip_dedup_10259.ml
+++ b/test/test_toml_skip_dedup_10259.ml
@@ -1,0 +1,79 @@
+(** #10259: every reconcile cycle re-emits "toml_loader: skipping
+    janitor.toml: invalid cascade_name 'ollama_only' ..." for the same
+    4 keepers.  16+ identical WARN events landed in
+    system_log_2026-04-25.jsonl in a 43-minute window — 25%+ of the
+    800-line tail.  These tests pin [log_toml_skip_once] dedup logic:
+    same (file, error) emits once; new error text re-emits; reset
+    helper restarts the bookkeeping for fresh process / test
+    isolation. *)
+
+open Alcotest
+module K = Masc_mcp.Keeper_types_profile
+
+let test_first_call_emits () =
+  K.reset_logged_toml_skip_for_test ();
+  let emitted =
+    K.log_toml_skip_once
+      ~file:"janitor.toml"
+      ~error:"invalid cascade_name 'ollama_only' (reserved: ...)"
+  in
+  check bool "first observation emits" true emitted
+
+let test_repeat_call_suppressed () =
+  K.reset_logged_toml_skip_for_test ();
+  let _ = K.log_toml_skip_once
+    ~file:"janitor.toml" ~error:"invalid cascade_name 'ollama_only'"
+  in
+  let second = K.log_toml_skip_once
+    ~file:"janitor.toml" ~error:"invalid cascade_name 'ollama_only'"
+  in
+  let third = K.log_toml_skip_once
+    ~file:"janitor.toml" ~error:"invalid cascade_name 'ollama_only'"
+  in
+  check bool "second emission suppressed" false second;
+  check bool "third emission suppressed" false third
+
+let test_distinct_files_both_emit () =
+  K.reset_logged_toml_skip_for_test ();
+  let a = K.log_toml_skip_once
+    ~file:"janitor.toml" ~error:"E"
+  in
+  let b = K.log_toml_skip_once
+    ~file:"taskmaster.toml" ~error:"E"
+  in
+  check bool "different file emits even with same error" true a;
+  check bool "different file emits even with same error" true b
+
+let test_distinct_errors_both_emit () =
+  K.reset_logged_toml_skip_for_test ();
+  let a = K.log_toml_skip_once
+    ~file:"janitor.toml" ~error:"invalid cascade_name 'ollama_only'"
+  in
+  let b = K.log_toml_skip_once
+    ~file:"janitor.toml" ~error:"invalid cascade_name 'big_three'"
+  in
+  check bool "first error emits" true a;
+  check bool "different error text re-emits" true b
+
+let test_reset_restores_first_emission () =
+  K.reset_logged_toml_skip_for_test ();
+  let _ = K.log_toml_skip_once ~file:"x.toml" ~error:"e" in
+  let suppressed = K.log_toml_skip_once ~file:"x.toml" ~error:"e" in
+  check bool "before reset: suppressed" false suppressed;
+  K.reset_logged_toml_skip_for_test ();
+  let after_reset = K.log_toml_skip_once ~file:"x.toml" ~error:"e" in
+  check bool "after reset: emits again" true after_reset
+
+let () =
+  run "toml_skip_dedup_10259" [
+    ("dedup", [
+        test_case "first call emits" `Quick test_first_call_emits;
+        test_case "repeat call suppressed" `Quick test_repeat_call_suppressed;
+        test_case "distinct files both emit (same error)" `Quick
+          test_distinct_files_both_emit;
+        test_case "distinct error text re-emits (same file)" `Quick
+          test_distinct_errors_both_emit;
+        test_case "reset restores first-emission semantics" `Quick
+          test_reset_restores_first_emission;
+      ]);
+  ]


### PR DESCRIPTION
## 요약

**Issue**: #10259 — 4 keeper(`taskmaster, qa-king, nick0cave, janitor`)의 TOML reconcile이 매 cycle silent fail. 같은 `WARN toml_loader: skipping <file>: invalid cascade_name 'ollama_only'`가 매 cycle × 4 file = 16+ 회 / 43분 window에 반복 (system_log tail의 25%+).

## Fix scope (옵션 D만)

이슈의 4 옵션 중 가장 surgical인 **D (log dedup)** 만 구현. WARN flood 차단.

| 옵션 | 이 PR |
|------|-------|
| A — materializer root cause | ❌ (별도 PR, OTOML parsing 또는 second-pass 가설 검증 필요) |
| B — drift gate | ❌ (별도 PR, `cascade-validate` 명령 추가) |
| C — validator fallback | ❌ (별도 PR, decoupling) |
| **D — dedup** | ✅ |

## 변경

`Keeper_types_profile.discover_keepers_toml`의 WARN call:

```ocaml
match load_keeper_toml path with
| Ok pair -> Some pair
| Error e ->
-  Log.Keeper.warn "toml_loader: skipping %s: %s" f e;
+  let _emitted = log_toml_skip_once ~file:f ~error:e in
   None
```

신규 helper:

```ocaml
let logged_toml_skip : (string * string, unit) Hashtbl.t = Hashtbl.create 8

let log_toml_skip_once ~file ~error =
  let key = (file, error) in
  if Hashtbl.mem logged_toml_skip key then false
  else begin
    Hashtbl.add logged_toml_skip key ();
    Log.Keeper.warn "toml_loader: skipping %s: %s" file error;
    true
  end
```

Dedup key는 `(file, error_text)`:
- 같은 file × 같은 error → 첫 emission만
- 같은 file × **새 error_text** → 재 emission (다른 실패 모드 발견 시 알림)
- 다른 file → 독립적으로 첫 emission
- 프로세스 restart → table 비워져서 진단 재표면화

`Keeper_cascade_profile.logged_invalid_fallback` (lib/keeper/keeper_cascade_profile.ml:131-133)와 동일 패턴.

## 검증

```text
DUNE_CACHE=disabled dune build --root . --cache=disabled @check
→ EXIT=0

dune exec test/test_toml_skip_dedup_10259.exe
→ 5/5 OK
  - first call emits
  - repeat call suppressed
  - distinct files both emit (same error)
  - distinct error text re-emits (same file)
  - reset restores first-emission semantics
```

## 영향 (예상)

머지 후:
- 4 keeper × 16 cycle = 64 → 4 (각 keeper 1회만) WARN
- system_log 25%+ noise 제거
- root cause는 여전히 주기적 reconcile 실패 — 후속 PR(옵션 A)에서 처리
- 프로세스 restart 후 첫 cycle은 다시 WARN (진단 재표면화) → 정상

## 보존되는 진단성

새 error_text가 등장하면 즉시 emission. 즉:
- 운영자가 첫 cycle WARN을 본 후 cleanup 시도
- 다른 fail mode 발생 시 새 WARN으로 즉시 인지
- Restart 시 모든 stale failure가 재표면화

## Defensive guards

- Draft + `do-not-merge` label
- `gh pr merge --disable-auto`

## 관련

- Issue: `#10259`
- 후속: 옵션 A (materializer parse path 진단), 옵션 B (cascade-validate drift gate), 옵션 C (validator fallback decouple)
- 메모리: `feedback_config-root-scope-discipline.md` (config root narrow drift 패턴)
- 패턴 참조: `Keeper_cascade_profile.logged_invalid_fallback` (lib/keeper/keeper_cascade_profile.ml:131-133)
