### PR TITLE
fix(keeper-fs): scrub roots= leak from path-rejection errors (#10349)

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -197,28 +197,24 @@ let format_path_rejection ~(raw : string) ~(resolved : string)
     ~(allowed_norms : string list) : string =
   let resolved_hint =
     if Filename.is_relative raw && resolved <> raw then
-      Printf.sprintf
-        "; relative paths are checked against your sandbox boundary (resolved=%s)"
-        resolved
+      "; relative paths are checked against your sandbox boundary"
     else
       ""
   in
   let playground_hint =
     if raw_looks_like_playground_subdir raw then
       match playground_root_of_allowed allowed_norms with
-      | Some pg ->
+      | Some _ ->
         Printf.sprintf
           ". Your raw path already looks sandbox-relative. Use it as-is \
-           (for example path=%S) and do not prepend %s; call \
-           keeper_context_status and use sandbox_repos / sandbox_mind if \
-           unsure."
-          raw pg
+           (for example path=%S); call keeper_context_status and use \
+           sandbox_repos / sandbox_mind if unsure."
+          raw
       | None -> ""
     else ""
   in
-  Printf.sprintf
-    "path_outside_sandbox: %s%s (sandbox roots: [%s])%s"
-    raw resolved_hint (String.concat ", " allowed_norms) playground_hint
+  Printf.sprintf "path_outside_sandbox: %s%s%s" raw resolved_hint
+    playground_hint
 
 let resolve_keeper_target_path ~(config : Coord.config)
     ~(allowed_paths : string list) ~(raw_path : string)
@@ -358,17 +354,19 @@ let resolve_keeper_read_path ~(config : Coord.config)
       let search_roots =
         if allowed_norms = [] then [root_norm] else allowed_norms
       in
+      let reject_outside_sandbox () =
+        Prometheus.inc_counter Prometheus.metric_keeper_path_rejection
+          ~labels:[ ("kind", "out_of_roots") ] ();
+        Error
+          (format_path_rejection ~raw ~resolved:target_norm ~allowed_norms)
+      in
       if not within_allowed then
         if Filename.is_relative raw then
           (match maybe_resolve_missing_relative_read_path ~roots:search_roots ~raw_path:raw with
            | Ok (Some resolved) -> Ok resolved
-           | Ok None ->
-               Error
-                 (format_path_rejection ~raw ~resolved:target_norm ~allowed_norms)
+           | Ok None -> reject_outside_sandbox ()
            | Error e -> Error e)
-        else
-          Error
-            (format_path_rejection ~raw ~resolved:target_norm ~allowed_norms)
+        else reject_outside_sandbox ()
       else if path_exists candidate || allows_missing_leaf_read ~raw ~candidate then
         Ok candidate
       else if Filename.is_relative raw then

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -375,18 +375,24 @@ let resolve_keeper_read_path ~(config : Coord.config)
         (match maybe_resolve_missing_relative_read_path ~roots:search_roots ~raw_path:raw with
          | Ok (Some resolved) -> Ok resolved
          | Ok None ->
+             (* #10349: keep the rejection signal in the
+                Prometheus counter; do NOT echo the resolved
+                roots back to the LLM.  When keeper identity
+                drifts (turn 433 evidence), the roots can
+                belong to a sibling sandbox, leaking its
+                directory layout to the wrong keeper. *)
+             Prometheus.inc_counter Prometheus.metric_keeper_path_rejection
+               ~labels:[ ("kind", "not_found_relative") ] ();
              Error
-               (Printf.sprintf
-                  "path_not_found_under_allowed_roots: %s (roots=[%s])"
-                  raw (String.concat ", " search_roots))
+               (Printf.sprintf "path_not_found_under_allowed_roots: %s" raw)
          | Error e -> Error e)
-      else
+      else begin
+        Prometheus.inc_counter Prometheus.metric_keeper_path_rejection
+          ~labels:[ ("kind", "out_of_roots") ] ();
         Error
-          (Printf.sprintf
-             "path_not_found_under_allowed_roots: %s (roots=[%s])"
-             target_norm
-             (String.concat ", "
-                (if allowed_norms = [] then [root_norm] else allowed_norms)))
+          (Printf.sprintf "path_not_found_under_allowed_roots: %s"
+             target_norm)
+      end
 
 let process_status_to_json (st : Unix.process_status) : Yojson.Safe.t =
   let sem = Masc_exec.Exit_code.of_process_status st in

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -341,6 +341,23 @@ let metric_keeper_operator_clear = "masc_keeper_operator_clear_total"
 let metric_keeper_compaction_noop =
   "masc_keeper_compaction_noop_total"
 
+(* #10349: keeper FS path rejection counter.  Pre-fix the
+   user-facing error string carried [(roots=[<list>])] which
+   exposes the resolver's view of allowed sandbox roots to the
+   LLM.  Combined with the keeper identity drift documented in
+   the issue (turn 433: contract emitted [masc-improver/Docker]
+   while the resolver enumerated [analyst]'s sandbox), the
+   error became a side-channel oracle for sibling sandboxes.
+
+   The leak lives strictly in the user-visible string; the
+   structured side-channel (Eio.traceln + this counter) keeps
+   the rejection observable for operators without echoing the
+   roots list back to the LLM.  Labels:
+   - [kind] = "out_of_roots" (path resolved outside allowed)
+              | "not_found_relative" (relative path matched no root) *)
+let metric_keeper_path_rejection =
+  "masc_keeper_path_rejection_total"
+
 (* Keeper keepalive (keeper_keepalive.ml). *)
 let metric_keeper_heartbeat_successes =
   "masc_keeper_heartbeat_successes_total"

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -342,12 +342,13 @@ let metric_keeper_compaction_noop =
   "masc_keeper_compaction_noop_total"
 
 (* #10349: keeper FS path rejection counter.  Pre-fix the
-   user-facing error string carried [(roots=[<list>])] which
-   exposes the resolver's view of allowed sandbox roots to the
-   LLM.  Combined with the keeper identity drift documented in
-   the issue (turn 433: contract emitted [masc-improver/Docker]
-   while the resolver enumerated [analyst]'s sandbox), the
-   error became a side-channel oracle for sibling sandboxes.
+   user-facing read-path rejection strings carried the resolver's
+   view of allowed sandbox roots (for example [(roots=[<list>])]
+   and [(sandbox roots: [<list>])]) to the LLM.  Combined with
+   the keeper identity drift documented in the issue (turn 433:
+   contract emitted [masc-improver/Docker] while the resolver
+   enumerated [analyst]'s sandbox), the error became a
+   side-channel oracle for sibling sandboxes.
 
    The leak lives strictly in the user-visible string; the
    structured side-channel (Eio.traceln + this counter) keeps

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -136,6 +136,16 @@ val metric_keeper_compaction_noop : string
 
 val metric_keeper_operator_compact : string
 val metric_keeper_operator_clear : string
+
+(** #10349: counter incremented whenever
+    [Keeper_alerting_path.resolve_keeper_read_path] rejects a
+    path.  Replaces the previous user-facing leak of
+    [(roots=[<list>])] which became a side-channel oracle for
+    sibling sandboxes when keeper identity drifted across
+    contract/gate/FS-resolver layers.  Labels:
+    [kind="out_of_roots"|"not_found_relative"]. *)
+val metric_keeper_path_rejection : string
+
 val metric_keeper_heartbeat_successes : string
 val metric_keeper_heartbeat_failures : string
 val metric_keeper_tool_call_duration : string

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -139,10 +139,11 @@ val metric_keeper_operator_clear : string
 
 (** #10349: counter incremented whenever
     [Keeper_alerting_path.resolve_keeper_read_path] rejects a
-    path.  Replaces the previous user-facing leak of
-    [(roots=[<list>])] which became a side-channel oracle for
-    sibling sandboxes when keeper identity drifted across
-    contract/gate/FS-resolver layers.  Labels:
+    path.  Replaces the previous user-facing leak of resolver
+    allowed roots ([(roots=[<list>])] and
+    [(sandbox roots: [<list>])]) which became a side-channel
+    oracle for sibling sandboxes when keeper identity drifted
+    across contract/gate/FS-resolver layers.  Labels:
     [kind="out_of_roots"|"not_found_relative"]. *)
 val metric_keeper_path_rejection : string
 

--- a/test/dune
+++ b/test/dune
@@ -1456,7 +1456,6 @@
  (modules test_goal_phase_awaiting_verification_10411)
  (libraries masc_mcp alcotest))
 
-(test
  (name test_dated_jsonl_mutex_registry_10372)
  (modules test_dated_jsonl_mutex_registry_10372)
  (libraries dated_jsonl fs_compat alcotest eio eio_main yojson unix))
@@ -1465,6 +1464,17 @@
  (name test_anti_rationalization_korean_10385)
  (modules test_anti_rationalization_korean_10385)
  (libraries masc_mcp alcotest unix))
+
+ (name test_keeper_path_roots_leak_10349)
+ (modules test_keeper_path_roots_leak_10349)
+ (libraries
+  masc_mcp
+  fs_compat
+  astring
+  alcotest
+  eio
+  eio_main
+  unix))
 ; ============================================================
 ; Special: Heartbeat/keeper minimal deps
 ; ============================================================

--- a/test/dune
+++ b/test/dune
@@ -1456,6 +1456,7 @@
  (modules test_goal_phase_awaiting_verification_10411)
  (libraries masc_mcp alcotest))
 
+(test
  (name test_dated_jsonl_mutex_registry_10372)
  (modules test_dated_jsonl_mutex_registry_10372)
  (libraries dated_jsonl fs_compat alcotest eio eio_main yojson unix))
@@ -1465,6 +1466,7 @@
  (modules test_anti_rationalization_korean_10385)
  (libraries masc_mcp alcotest unix))
 
+(test
  (name test_keeper_path_roots_leak_10349)
  (modules test_keeper_path_roots_leak_10349)
  (libraries

--- a/test/test_keeper_path_roots_leak_10349.ml
+++ b/test/test_keeper_path_roots_leak_10349.ml
@@ -1,0 +1,172 @@
+(** #10349 — pin the keeper FS path-rejection oracle removal.
+
+    Pre-fix [resolve_keeper_read_path] returned errors of the
+    form [path_not_found_under_allowed_roots: <p> (roots=[...])]
+    where [<roots>] was the resolver-side view of the keeper's
+    allowed sandbox roots.  Combined with the keeper identity
+    drift documented in the issue (turn 433 trace: contract
+    layer claimed [masc-improver/Docker] while the resolver
+    enumerated [analyst]'s sandbox), the trailing roots list
+    became a side-channel oracle: the LLM driving keeper A
+    could observe sibling keeper B's directory layout via the
+    error string.
+
+    The user-visible message is now opaque
+    ([path_not_found_under_allowed_roots: <p>]) and the
+    rejection signal is preserved on the operator side via
+    [masc_keeper_path_rejection_total{kind}].
+
+    Tests pin:
+    1. Out-of-roots rejection: error has no [roots=] substring.
+    2. Not-found-relative rejection: same.
+    3. Counter labels: each kind ticks its own label.
+    4. The legacy prefix [path_not_found_under_allowed_roots:]
+       remains, so existing classifiers and circuit breaker
+       matchers keep recognising the error class. *)
+
+open Alcotest
+open Masc_mcp
+
+let counter = ref 0
+
+let mk_dir prefix =
+  incr counter;
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "%s_%d_%d_%.0f" prefix !counter (Unix.getpid ())
+         (Unix.gettimeofday ()))
+  in
+  (try Unix.mkdir dir 0o755
+   with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let git_dir = Filename.concat dir ".git" in
+  (try Unix.mkdir git_dir 0o755
+   with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let lib_dir = Filename.concat dir "lib" in
+  (try Unix.mkdir lib_dir 0o755
+   with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  dir
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then (
+      Sys.readdir path
+      |> Array.iter (fun n -> rm_rf (Filename.concat path n));
+      Unix.rmdir path)
+    else Sys.remove path
+
+let with_clean_env f =
+  let saved = try Some (Sys.getenv "MASC_BASE_PATH") with Not_found -> None in
+  Unix.putenv "MASC_BASE_PATH" "";
+  Fun.protect
+    ~finally:(fun () ->
+      match saved with
+      | Some v -> Unix.putenv "MASC_BASE_PATH" v
+      | None -> Unix.putenv "MASC_BASE_PATH" "")
+    f
+
+let counter_value labels =
+  Prometheus.metric_value_or_zero
+    Prometheus.metric_keeper_path_rejection
+    ~labels ()
+
+let assert_no_roots_leak msg err =
+  check bool (msg ^ ": no '(roots=' substring") false
+    (Astring.String.is_infix ~affix:"(roots=" err);
+  check bool (msg ^ ": no 'roots=[' substring") false
+    (Astring.String.is_infix ~affix:"roots=[" err);
+  check bool (msg ^ ": legacy prefix preserved") true
+    (Astring.String.is_prefix
+       ~affix:"path_not_found_under_allowed_roots:" err)
+
+(* --- 1. out-of-roots rejection: opaque error + counter --- *)
+
+let test_out_of_roots_no_leak () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_clean_env @@ fun () ->
+  let dir = mk_dir "kpath_out" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      let config = Coord.default_config dir in
+      let labels = [ ("kind", "out_of_roots") ] in
+      let before = counter_value labels in
+      (* Absolute path inside root with trailing slash and a
+         missing leaf → bypasses [allows_missing_leaf_read]
+         (which only forgives parent-exists/non-slash paths)
+         and falls into the out_of_roots branch. *)
+      let target = Filename.concat dir "lib/never_exists_10349/" in
+      let result =
+        Keeper_alerting_path.resolve_keeper_read_path ~config
+          ~allowed_paths:[ "lib" ] ~raw_path:target
+      in
+      check bool "rejection occurred" true (Result.is_error result);
+      let err = Result.get_error result in
+      assert_no_roots_leak "out_of_roots" err;
+      check (float 0.0001) "out_of_roots counter +1"
+        (before +. 1.0)
+        (counter_value labels))
+
+(* --- 2. not-found-relative rejection: opaque + counter --- *)
+
+let test_not_found_relative_no_leak () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_clean_env @@ fun () ->
+  let dir = mk_dir "kpath_rel" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      let config = Coord.default_config dir in
+      let labels = [ ("kind", "not_found_relative") ] in
+      let before = counter_value labels in
+      let result =
+        Keeper_alerting_path.resolve_keeper_read_path ~config
+          ~allowed_paths:[] ~raw_path:"nonexistent_repo_10349/"
+      in
+      check bool "rejection occurred" true (Result.is_error result);
+      let err = Result.get_error result in
+      assert_no_roots_leak "not_found_relative" err;
+      check (float 0.0001) "not_found_relative counter +1"
+        (before +. 1.0)
+        (counter_value labels))
+
+(* --- 3. counter labels are isolated per kind ------------- *)
+
+let test_counter_labels_isolated () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_clean_env @@ fun () ->
+  let dir = mk_dir "kpath_iso" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      let config = Coord.default_config dir in
+      let other_labels = [ ("kind", "out_of_roots") ] in
+      let before_other = counter_value other_labels in
+      let _ =
+        Keeper_alerting_path.resolve_keeper_read_path ~config
+          ~allowed_paths:[] ~raw_path:"definitely_missing_10349/"
+      in
+      check (float 0.0001)
+        "out_of_roots counter unaffected by not_found_relative bump"
+        before_other
+        (counter_value other_labels))
+
+let () =
+  run "keeper_path_roots_leak_10349"
+    [
+      ( "no-roots-leak",
+        [
+          test_case "out_of_roots error is opaque" `Quick
+            test_out_of_roots_no_leak;
+          test_case "not_found_relative error is opaque" `Quick
+            test_not_found_relative_no_leak;
+        ] );
+      ( "counter-labels",
+        [
+          test_case "kinds tick independent label series" `Quick
+            test_counter_labels_isolated;
+        ] );
+    ]

--- a/test/test_keeper_path_roots_leak_10349.ml
+++ b/test/test_keeper_path_roots_leak_10349.ml
@@ -17,10 +17,11 @@
     [masc_keeper_path_rejection_total{kind}].
 
     Tests pin:
-    1. Out-of-roots rejection: error has no [roots=] substring.
-    2. Not-found-relative rejection: same.
-    3. Counter labels: each kind ticks its own label.
-    4. The legacy prefix [path_not_found_under_allowed_roots:]
+    1. Outside-sandbox rejection: error has no resolver roots.
+    2. Out-of-roots rejection: error has no [roots=] substring.
+    3. Not-found-relative rejection: same.
+    4. Counter labels: each kind ticks its own label.
+    5. The legacy prefix [path_not_found_under_allowed_roots:]
        remains, so existing classifiers and circuit breaker
        matchers keep recognising the error class. *)
 
@@ -75,11 +76,45 @@ let assert_no_roots_leak msg err =
     (Astring.String.is_infix ~affix:"(roots=" err);
   check bool (msg ^ ": no 'roots=[' substring") false
     (Astring.String.is_infix ~affix:"roots=[" err);
+  check bool (msg ^ ": no sandbox roots substring") false
+    (Astring.String.is_infix ~affix:"sandbox roots:" err);
+  check bool (msg ^ ": no resolved path hint") false
+    (Astring.String.is_infix ~affix:"resolved=" err)
+
+let assert_legacy_not_found_prefix msg err =
   check bool (msg ^ ": legacy prefix preserved") true
     (Astring.String.is_prefix
        ~affix:"path_not_found_under_allowed_roots:" err)
 
-(* --- 1. out-of-roots rejection: opaque error + counter --- *)
+(* --- 1. outside-sandbox rejection: opaque error + counter --- *)
+
+let test_path_outside_sandbox_no_leak () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_clean_env @@ fun () ->
+  let dir = mk_dir "kpath_sandbox" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      let config = Coord.default_config dir in
+      let labels = [ ("kind", "out_of_roots") ] in
+      let before = counter_value labels in
+      let result =
+        Keeper_alerting_path.resolve_keeper_read_path ~config
+          ~allowed_paths:[ "lib" ] ~raw_path:"README.md"
+      in
+      check bool "rejection occurred" true (Result.is_error result);
+      let err = Result.get_error result in
+      assert_no_roots_leak "path_outside_sandbox" err;
+      check bool "path_outside_sandbox prefix preserved" true
+        (Astring.String.is_prefix ~affix:"path_outside_sandbox:" err);
+      check bool "allowed root path is not leaked" false
+        (Astring.String.is_infix ~affix:(Filename.concat dir "lib") err);
+      check (float 0.0001) "out_of_roots counter +1"
+        (before +. 1.0)
+        (counter_value labels))
+
+(* --- 2. out-of-roots rejection: opaque error + counter --- *)
 
 let test_out_of_roots_no_leak () =
   Eio_main.run @@ fun env ->
@@ -104,11 +139,12 @@ let test_out_of_roots_no_leak () =
       check bool "rejection occurred" true (Result.is_error result);
       let err = Result.get_error result in
       assert_no_roots_leak "out_of_roots" err;
+      assert_legacy_not_found_prefix "out_of_roots" err;
       check (float 0.0001) "out_of_roots counter +1"
         (before +. 1.0)
         (counter_value labels))
 
-(* --- 2. not-found-relative rejection: opaque + counter --- *)
+(* --- 3. not-found-relative rejection: opaque + counter --- *)
 
 let test_not_found_relative_no_leak () =
   Eio_main.run @@ fun env ->
@@ -128,11 +164,12 @@ let test_not_found_relative_no_leak () =
       check bool "rejection occurred" true (Result.is_error result);
       let err = Result.get_error result in
       assert_no_roots_leak "not_found_relative" err;
+      assert_legacy_not_found_prefix "not_found_relative" err;
       check (float 0.0001) "not_found_relative counter +1"
         (before +. 1.0)
         (counter_value labels))
 
-(* --- 3. counter labels are isolated per kind ------------- *)
+(* --- 4. counter labels are isolated per kind ------------- *)
 
 let test_counter_labels_isolated () =
   Eio_main.run @@ fun env ->
@@ -159,6 +196,8 @@ let () =
     [
       ( "no-roots-leak",
         [
+          test_case "path_outside_sandbox error is opaque" `Quick
+            test_path_outside_sandbox_no_leak;
           test_case "out_of_roots error is opaque" `Quick
             test_out_of_roots_no_leak;
           test_case "not_found_relative error is opaque" `Quick


### PR DESCRIPTION
## Goal

Close the keeper FS path-rejection side channel from #10349. The resolver must not echo its view of a keeper's allowed sandbox roots back to the LLM when a read path is rejected.

## Root Cause

The original leak was visible on `path_not_found_under_allowed_roots: <path> (roots=[...])`.

Review found a second LLM-visible path in the same resolver: `path_outside_sandbox` still included `(sandbox roots: [...])`, and relative-path errors also carried `resolved=<absolute path>`. With keeper identity drift, those roots can describe the wrong keeper's sandbox and become an oracle for sibling directory layout.

## Change

- Make `path_not_found_under_allowed_roots` opaque while preserving the existing classifier prefix.
- Make `path_outside_sandbox` opaque as well:
  - no `(sandbox roots: [...])`
  - no `resolved=<absolute path>`
  - no full playground root in the hint
- Preserve operator observability with `masc_keeper_path_rejection_total{kind}`.
- Tick `kind="out_of_roots"` for outside-sandbox read rejections too, not only missing absolute leaves.

## Verification

- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_path_roots_leak_10349.exe test/test_keeper_tool_exposure.exe`
- `./_build/default/test/test_keeper_path_roots_leak_10349.exe` (4 tests, run ID `L0YKPOCP`)
- `./_build/default/test/test_keeper_tool_exposure.exe` (59 tests, run ID `QZGWJ348`)

Refs #10349.
