### PR TITLE
perf: route 7 forked contains_substring helpers through String_util SSOT

### DIFF
--- a/lib/cascade_catalog_validator.ml
+++ b/lib/cascade_catalog_validator.ml
@@ -11,21 +11,9 @@ type issue = {
 module StringMap = Map.Make (String)
 
 let contains_substring ~needle s =
-  let needle_len = String.length needle in
-  let s_len = String.length s in
-  if needle_len = 0 || needle_len > s_len then
-    false
-  else
-    let limit = s_len - needle_len in
-    let rec loop i =
-      if i > limit then
-        false
-      else if String.sub s i needle_len = needle then
-        true
-      else
-        loop (i + 1)
-    in
-    loop 0
+  (* Empty needle returns false here, distinct from String_util.contains_substring's
+     Re-compatible empty=true.  Guard preserves the original validator contract. *)
+  String.length needle > 0 && String_util.contains_substring s needle
 
 let has_suffix ~suffix s =
   let suffix_len = String.length suffix in

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -127,17 +127,7 @@ let status_offline = "offline"
 let status_backoff = "backoff"
 
 let contains_substring haystack needle =
-  let haystack_len = String.length haystack in
-  let needle_len = String.length needle in
-  if needle_len = 0 then true
-  else if needle_len > haystack_len then false
-  else
-    let rec loop index =
-      if index + needle_len > haystack_len then false
-      else if String.sub haystack index needle_len = needle then true
-      else loop (index + 1)
-    in
-    loop 0
+  String_util.contains_substring haystack needle
 
 let degraded_reason_of_error message =
   let lower = String.lowercase_ascii message in

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -144,15 +144,7 @@ let runtime_contract_json_from_fields ~keeper_name ?agent_name ?trace_id
     ]
 
 let contains_substring haystack needle =
-  let haystack_len = String.length haystack in
-  let needle_len = String.length needle in
-  let rec loop i =
-    if needle_len = 0 then true
-    else if i + needle_len > haystack_len then false
-    else if String.sub haystack i needle_len = needle then true
-    else loop (i + 1)
-  in
-  loop 0
+  String_util.contains_substring haystack needle
 
 let json_string_field name = function
   | `Assoc fields -> (

--- a/lib/planning_eio.ml
+++ b/lib/planning_eio.ml
@@ -77,14 +77,7 @@ let write_file_content path content =
   Fs_compat.save_file path content
 
 let find_substring_from haystack ~needle ~from =
-  let haystack_len = String.length haystack in
-  let needle_len = String.length needle in
-  let rec loop i =
-    if i + needle_len > haystack_len then None
-    else if String.sub haystack i needle_len = needle then Some i
-    else loop (i + 1)
-  in
-  loop from
+  String_util.find_substring ~pos:from haystack needle
 
 let normalize_placeholder value =
   match String.trim value with

--- a/lib/planning_eio.ml
+++ b/lib/planning_eio.ml
@@ -77,7 +77,8 @@ let write_file_content path content =
   Fs_compat.save_file path content
 
 let find_substring_from haystack ~needle ~from =
-  String_util.find_substring ~pos:from haystack needle
+  if from > String.length haystack then None
+  else String_util.find_substring ~pos:from haystack needle
 
 let normalize_placeholder value =
   match String.trim value with

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -1049,13 +1049,9 @@ let dashboard_shell_payload_json ?(light = false) (config : Coord.config) : Yojs
 let dashboard_shell_auth_json ~(request : Httpun.Request.t) (config : Coord.config) :
     Yojson.Safe.t =
   let contains_substring haystack needle =
-    let haystack_len = String.length haystack in
-    let needle_len = String.length needle in
-    let rec loop idx =
-      idx + needle_len <= haystack_len
-      && (String.sub haystack idx needle_len = needle || loop (idx + 1))
-    in
-    needle_len > 0 && loop 0
+    (* Empty-needle returns false here, unlike String_util.contains_substring's
+       Re.execp-compatible empty=true. Guard preserves the original contract. *)
+    String.length needle > 0 && String_util.contains_substring haystack needle
   in
   let dashboard_auth_error_code = function
     | Types.InvalidToken _ -> Some "invalid_token"

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -103,17 +103,9 @@ let state_net_opt = function
   | None -> Eio_context.get_net_opt ()
 
 let contains_substring ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  let rec loop idx =
-    if idx + needle_len > haystack_len then
-      false
-    else if String.sub haystack idx needle_len = needle then
-      true
-    else
-      loop (idx + 1)
-  in
-  needle_len > 0 && loop 0
+  (* Empty needle returns false (unlike String_util's Re-compatible
+     empty=true).  Guard preserves the prior caller contract. *)
+  String.length needle > 0 && String_util.contains_substring haystack needle
 
 let host_header_has_forbidden_authority_chars value =
   let has_forbidden_char =

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -132,15 +132,7 @@ let contains_forbidden_shell_chars_coding cmd =
   String.exists (fun ch -> List.mem ch forbidden_shell_chars_coding_base) cmd
   || has_dangerous_ampersand cmd
 
-let contains_substring s needle =
-  let s_len = String.length s in
-  let needle_len = String.length needle in
-  let rec loop i =
-    if i + needle_len > s_len then false
-    else if String.sub s i needle_len = needle then true
-    else loop (i + 1)
-  in
-  if needle_len = 0 then true else loop 0
+let contains_substring s needle = String_util.contains_substring s needle
 
 let has_process_substitution cmd =
   contains_substring cmd "<(" || contains_substring cmd ">("

--- a/test/test_planning_eio.ml
+++ b/test/test_planning_eio.ml
@@ -122,6 +122,12 @@ let test_load_nonexistent () =
       (* Expected behavior *)
       ()
 
+let test_find_substring_from_preserves_empty_needle_bounds () =
+  check (option int) "empty needle at end" (Some 3)
+    (Planning_eio.find_substring_from "abc" ~needle:"" ~from:3);
+  check (option int) "empty needle past end" None
+    (Planning_eio.find_substring_from "abc" ~needle:"" ~from:4)
+
 let test_update_plan () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -412,6 +418,8 @@ let () =
       test_case "init" `Quick test_init;
       test_case "load" `Quick test_load;
       test_case "load_nonexistent" `Quick test_load_nonexistent;
+      test_case "find_substring_from_preserves_empty_needle_bounds" `Quick
+        test_find_substring_from_preserves_empty_needle_bounds;
       test_case "update_plan" `Quick test_update_plan;
       test_case "update_plan_full_context_syncs_deliverable" `Quick
         test_update_plan_full_context_syncs_deliverable;


### PR DESCRIPTION
## Summary

PR #10347 introduced \`String_util.contains_substring\` (byte-wise \`String.unsafe_get\` loop, no per-step \`String.sub\` allocation). Seven modules still carried their own forks of the slower \`String.sub\` form, all on hot validation/parsing paths. This PR routes each through the SSOT while preserving caller-visible contracts.

## Direct delegation (empty needle = true, matches SSOT)

- \`lib/worker_dev_tools.ml\` — bash command parsing
- \`lib/dashboard/dashboard_governance_judge.ml\` — degraded-reason classifier
- \`lib/keeper/keeper_runtime_contract.ml\` — keeper contract introspection

## Wrapped with empty-needle guard (empty = false in original)

SSOT returns true on empty, so guard preserves the validator/router contract:

- \`lib/server/server_dashboard_http_core.ml\` — dashboard auth error router
- \`lib/server/server_routes_http_common.ml\` — HTTP host/header guard
- \`lib/cascade_catalog_validator.ml\` — cascade catalog validator

## Position-returning helper

- \`lib/planning_eio.ml\` — \`find_substring_from\` now delegates to \`String_util.find_substring ~pos\`. Empty-needle returns \`Some pos\` in both, so contract is preserved.

## Why retain local helpers as thin wrappers

Surgical change — caller signatures and identifiers stay untouched. Each forked helper is now a 1-line delegate.

## Test plan

- [x] \`dune build @check\` clean
- [x] \`test_string_util\` 17/17
- [x] \`test_worker_dev_tools\` 120/120

🤖 Generated with [Claude Code](https://claude.com/claude-code)