### PR TITLE
diag(dashboard): phase breakdown in slow-render WARN (#9766)

### DIFF
--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -45,6 +45,35 @@ let messages_safe config =
 let assoc_upsert fields key value =
   (key, value) :: List.remove_assoc key fields
 
+(** #9766: per-render phase timing record used to surface a breakdown
+    in the [slow render] WARN.  Pure values so a unit test can pin
+    the formatting / per-keeper averaging without booting Eio. *)
+type render_phase_timings_ms = {
+  total_ms : float;
+  snapshot_ms : float;
+  operations_ms : float;
+  enrich_ms : float;
+  data_load_ms : float;
+  assemble_ms : float;
+  n_keepers : int;
+}
+
+let per_keeper_enrich_ms (t : render_phase_timings_ms) =
+  if t.n_keepers > 0 then t.enrich_ms /. float_of_int t.n_keepers else 0.0
+
+let format_slow_render_timings (t : render_phase_timings_ms) =
+  Printf.sprintf
+    "total=%.0fms (keepers=%d) snapshot=%.0fms operations=%.0fms \
+     enrich=%.0fms (per_keeper=%.0fms) data_load=%.0fms assemble=%.0fms"
+    t.total_ms
+    t.n_keepers
+    t.snapshot_ms
+    t.operations_ms
+    t.enrich_ms
+    (per_keeper_enrich_ms t)
+    t.data_load_ms
+    t.assemble_ms
+
 let enrich_keeper_with_diagnostic ~(config : Coord.config) (keeper_json : Yojson.Safe.t) =
   let open Yojson.Safe.Util in
   match keeper_json with
@@ -201,6 +230,7 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
               ~lightweight_summary:true
               ctx)
       in
+      let t_after_snapshot = Time_compat.now () in
       Eio.Fiber.yield ();
       (* Yield between heavy computation phases to prevent fiber starvation.
          Eio's cooperative scheduler needs explicit yields in CPU-bound paths
@@ -211,12 +241,14 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
       let execution_queue =
         build_execution_queue session_contexts operation_contexts
       in
+      let t_after_operations = Time_compat.now () in
       let keepers =
         member_assoc "keepers" snapshot_json |> member_assoc "items"
         |> function
         | `List items -> List.map (enrich_keeper_with_diagnostic ~config) items
         | _ -> []
       in
+      let t_after_enrich = Time_compat.now () in
       Eio.Fiber.yield ();
       (* Load tasks/agents/messages — needed for worker_support_briefs.
          In light mode, tasks and messages are NOT serialized in the
@@ -225,6 +257,7 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
       let tasks = tasks_safe config in
       let agents = agents_safe config in
       let messages = messages_safe config in
+      let t_after_data_load = Time_compat.now () in
       let now_ts = Time_compat.now () in
       let worker_rows =
         build_worker_support_briefs ~now_ts ~tasks ~agents ~messages session_contexts
@@ -299,16 +332,30 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
         ]);
       ] in
       let t_end = Time_compat.now () in
-      let total_ms = (t_end -. t_start) *. 1000.0 in
-      if total_ms > 10000.0 then
-        Log.Dashboard.warn
-          "[dashboard_execution] slow render: total=%.0fms (keepers=%d)"
-          total_ms
-          (List.length keepers)
+      let phase_ms a b = (b -. a) *. 1000.0 in
+      let timings : render_phase_timings_ms = {
+        total_ms = phase_ms t_start t_end;
+        snapshot_ms = phase_ms t_start t_after_snapshot;
+        operations_ms = phase_ms t_after_snapshot t_after_operations;
+        enrich_ms = phase_ms t_after_operations t_after_enrich;
+        data_load_ms = phase_ms t_after_enrich t_after_data_load;
+        assemble_ms = phase_ms t_after_data_load t_end;
+        n_keepers = List.length keepers;
+      } in
+      (* #9766: surface phase breakdown in the slow-render WARN so the
+         59.8s/9-keeper sample (~6.6s/keeper) can be attributed to a
+         specific phase without rebuilding the binary with extra
+         instrumentation.  enrich covers the per-keeper [List.map
+         enrich_keeper_with_diagnostic] which is the suspected hot path. *)
+      if timings.total_ms > 10000.0 then
+        Log.Dashboard.warn "[dashboard_execution] slow render: %s"
+          (format_slow_render_timings timings)
       else
         Log.Dashboard.debug
-          "[dashboard_execution] timing: total=%.0fms"
-          total_ms;
+          "[dashboard_execution] timing: total=%.0fms snapshot=%.0fms \
+           enrich=%.0fms data_load=%.0fms assemble=%.0fms"
+          timings.total_ms timings.snapshot_ms timings.enrich_ms
+          timings.data_load_ms timings.assemble_ms;
       if light then
         `Assoc (base_fields @ task_fields)
       else

--- a/lib/dashboard/dashboard_execution.mli
+++ b/lib/dashboard/dashboard_execution.mli
@@ -8,3 +8,24 @@ val json :
   proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t option ->
   unit ->
   Yojson.Safe.t
+
+(** #9766: per-render phase timing surfaced in the [slow render] WARN.
+    Pure value type so unit tests can pin the formatter without
+    booting Eio. *)
+type render_phase_timings_ms = {
+  total_ms : float;
+  snapshot_ms : float;
+  operations_ms : float;
+  enrich_ms : float;
+  data_load_ms : float;
+  assemble_ms : float;
+  n_keepers : int;
+}
+
+val per_keeper_enrich_ms : render_phase_timings_ms -> float
+(** Average enrich-phase ms per keeper.  Returns [0.0] when
+    [n_keepers = 0] to avoid divide-by-zero in startup races. *)
+
+val format_slow_render_timings : render_phase_timings_ms -> string
+(** Render the breakdown into the WARN suffix.  Stable format so
+    log scrapers can parse it. *)

--- a/test/dune
+++ b/test/dune
@@ -599,6 +599,7 @@
         test_keeper_tool_exposure
         test_keeper_runtime_denylist
         test_keeper_runtime_config_ssot
+        test_dashboard_render_timing_9766
         test_keeper_task_dispatch
         test_keeper_tag_dispatch
         test_autoresearch_knowledge
@@ -775,6 +776,7 @@
         test_keeper_tool_exposure
         test_keeper_runtime_denylist
         test_keeper_runtime_config_ssot
+        test_dashboard_render_timing_9766
         test_keeper_task_dispatch
         test_keeper_tag_dispatch
         test_autoresearch_knowledge

--- a/test/test_dashboard_render_timing_9766.ml
+++ b/test/test_dashboard_render_timing_9766.ml
@@ -1,0 +1,66 @@
+(** #9766: dashboard_execution slow render warns at >10s but the
+    pre-fix log only said "total=59804ms (keepers=9)" — no breakdown
+    of which phase ate the budget.  These tests pin the phase-timing
+    formatter so production WARNs reliably contain the per-phase ms
+    counts and the per-keeper enrich average. *)
+
+open Alcotest
+module DE = Masc_mcp.Dashboard_execution
+
+let sample_timings () : DE.render_phase_timings_ms = {
+  total_ms = 59800.0;
+  snapshot_ms = 1200.0;
+  operations_ms = 800.0;
+  enrich_ms = 54000.0;
+  data_load_ms = 2500.0;
+  assemble_ms = 1300.0;
+  n_keepers = 9;
+}
+
+let test_per_keeper_average () =
+  let t = sample_timings () in
+  (* 54000 / 9 = 6000 *)
+  check (float 1e-3) "average per-keeper enrich ms"
+    6000.0
+    (DE.per_keeper_enrich_ms t)
+
+let test_per_keeper_zero_keepers_safe () =
+  let t = { (sample_timings ()) with n_keepers = 0; enrich_ms = 0.0 } in
+  check (float 1e-9) "zero keepers does not divide-by-zero"
+    0.0
+    (DE.per_keeper_enrich_ms t)
+
+let test_format_includes_all_phases () =
+  let s = DE.format_slow_render_timings (sample_timings ()) in
+  let must_contain affix =
+    check bool ("contains: " ^ affix) true
+      (Astring.String.is_infix ~affix s)
+  in
+  must_contain "total=59800ms";
+  must_contain "keepers=9";
+  must_contain "snapshot=1200ms";
+  must_contain "operations=800ms";
+  must_contain "enrich=54000ms";
+  must_contain "per_keeper=6000ms";
+  must_contain "data_load=2500ms";
+  must_contain "assemble=1300ms"
+
+let test_format_with_zero_keepers () =
+  let t = { (sample_timings ()) with n_keepers = 0; enrich_ms = 0.0 } in
+  let s = DE.format_slow_render_timings t in
+  check bool "zero keepers reports per_keeper=0" true
+    (Astring.String.is_infix ~affix:"per_keeper=0ms" s)
+
+let () =
+  run "dashboard_render_timing_9766" [
+    ("phase_timing", [
+        test_case "per-keeper average is enrich/n" `Quick
+          test_per_keeper_average;
+        test_case "zero keepers does not divide-by-zero" `Quick
+          test_per_keeper_zero_keepers_safe;
+        test_case "format includes every phase" `Quick
+          test_format_includes_all_phases;
+        test_case "format handles zero keepers" `Quick
+          test_format_with_zero_keepers;
+      ]);
+  ]


### PR DESCRIPTION
## 요약

**Issue**: #9766 — `[dashboard_execution] slow render: total=59804ms (keepers=9)`. 6.6s/keeper 추정. 기존 WARN은 total + keeper count만 출력 → 어느 phase가 budget을 잡아먹는지 불가시.

## Fix scope (issue 1단계 — Profile-first)

이슈가 권장한 단계: "1. Profile the render pipeline to identify the bottleneck." 이 PR이 바로 그 단계.

**의도적으로 behavior 변경 없음**:
- ❌ Eio.Fiber.List 병렬화 — 가설 (CPU vs I/O bound) 미검증, 공식 fixture 없음
- ❌ snapshot caching — 어느 phase가 hot인지 모르고 추가하면 wrong-cache risk
- ✅ phase별 timing surfacing → empirical evidence first

## 변경

5 phase 측정점 추가:
- `t_after_snapshot` — projection cache fetch 후
- `t_after_operations` — operation/queue context build 후
- `t_after_enrich` — `List.map enrich_keeper_with_diagnostic` 후 (가설상 hot)
- `t_after_data_load` — tasks/agents/messages load 후
- `t_end` — assemble 후

Pure helper:
```ocaml
type render_phase_timings_ms = {
  total_ms : float;
  snapshot_ms : float;
  operations_ms : float;
  enrich_ms : float;
  data_load_ms : float;
  assemble_ms : float;
  n_keepers : int;
}

val per_keeper_enrich_ms : render_phase_timings_ms -> float
val format_slow_render_timings : render_phase_timings_ms -> string
```

WARN 형식:
```
[dashboard_execution] slow render: total=59800ms (keepers=9) \
  snapshot=1200ms operations=800ms enrich=54000ms (per_keeper=6000ms) \
  data_load=2500ms assemble=1300ms
```

## 수정 옵션 (1-2 cycle 후 결정)

phase WARN sample 수신 후:

| dominant phase | 후속 fix |
|----------------|---------|
| `enrich` (가설) | `Eio.Fiber.List` 병렬화 또는 per-keeper meta read 캐싱 |
| `snapshot` | `Dashboard_projection_cache` TTL/invalidation 검토 |
| `data_load` | tasks/agents/messages I/O 분리 또는 스냅샷 사용 |
| `operations` | operation_context build 비효율 분석 |
| `assemble` | JSON 큰 fields 큐잉/선별 |

phase가 명확해진 후 wrong-fix 위험 없이 surgical 작업.

## 검증

```text
DUNE_CACHE=disabled dune build --root . --cache=disabled @check
→ EXIT=0

dune exec test/test_dashboard_render_timing_9766.exe
→ 4/4 OK
  - per-keeper average is enrich/n
  - zero keepers does not divide-by-zero
  - format includes every phase
  - format handles zero keepers
```

## 영향

- 운영 환경에서 다음 slow-render WARN 발생 시 phase 분포 자동 출력
- 기존 `> 10000ms` threshold 유지 — 정상 render는 debug-only 출력 유지
- behavior 변경 없음 (timing 측정 + log 형식만)

## Defensive guards

- Draft + `do-not-merge` label
- `gh pr merge --disable-auto`

## 관련

- Issue: `#9766`
- 인접: `#9734` ([Dashboard] operator_snapshot 30-36s timeout), 같은 surface의 다른 측면
