### PR TITLE
perf: route 13 forked starts_with/has_prefix/has_suffix helpers through Stdlib

### DIFF
--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -283,10 +283,7 @@ module FileSystem = struct
     )
 
   (** List keys with prefix *)
-  let starts_with ~prefix value =
-    let prefix_len = String.length prefix in
-    String.length value >= prefix_len
-    && String.sub value 0 prefix_len = prefix
+  let starts_with ~prefix value = String.starts_with ~prefix value
 
 
   let rec collect_keys_under ~requested_prefix ~logical_prefix path acc =

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -436,13 +436,9 @@ let is_fixture_voter_target target =
         String.sub target (idx + 1) (String.length target - idx - 1)
     | _ -> target
   in
-  let has_prefix ~prefix s =
-    let prefix_len = String.length prefix in
-    String.length s >= prefix_len && String.sub s 0 prefix_len = prefix
-  in
-  has_prefix ~prefix:"hot-voter-" voter
-  || has_prefix ~prefix:"synthetic-voter-" voter
-  || has_prefix ~prefix:"test-voter-" voter
+  String.starts_with ~prefix:"hot-voter-" voter
+  || String.starts_with ~prefix:"synthetic-voter-" voter
+  || String.starts_with ~prefix:"test-voter-" voter
 
 let quarantine_enabled () =
   (* #9886: production ledger observed 112/112 (100%) fixture-pattern

--- a/lib/cascade_catalog_validator.ml
+++ b/lib/cascade_catalog_validator.ml
@@ -28,10 +28,10 @@ let contains_substring ~needle s =
     loop 0
 
 let has_suffix ~suffix s =
-  let suffix_len = String.length suffix in
-  let s_len = String.length s in
-  s_len > suffix_len
-  && String.sub s (s_len - suffix_len) suffix_len = suffix
+  (* Original strict-greater length: rejects [s = suffix] case where the
+     entire string is the suffix.  String.ends_with admits equality, so
+     guard preserves the prior validator contract. *)
+  String.length s > String.length suffix && String.ends_with ~suffix s
 
 let is_provider_unavailable_error msg =
   contains_substring ~needle:"unavailable" msg

--- a/lib/grpc/masc_grpc_server.ml
+++ b/lib/grpc/masc_grpc_server.ml
@@ -154,9 +154,7 @@ module Reflection_bridge = struct
   let masc_symbols =
     [ Masc_grpc_service.service_name ]
 
-  let has_prefix ~prefix value =
-    String.length value >= String.length prefix
-    && String.sub value 0 (String.length prefix) = prefix
+  let has_prefix ~prefix value = String.starts_with ~prefix value
 
   let decode_varint (bytes : string) (pos : int ref) : int =
     let result = ref 0 in

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -5,7 +5,7 @@ let project_root_of_config (config : Coord.config) : string =
   if Filename.basename base = Common.masc_dirname then Filename.dirname base else base
 
 let starts_with ~(prefix : string) (s : string) : bool =
-  Base.String.is_prefix s ~prefix
+  String.starts_with ~prefix s
 
 let strip_trailing_slashes = Env_config_core.strip_trailing_slashes
 

--- a/lib/keeper/keeper_sandbox_containment.ml
+++ b/lib/keeper/keeper_sandbox_containment.ml
@@ -4,9 +4,7 @@ let normalize p =
   Keeper_alerting_path.normalize_path_for_check p
   |> Keeper_alerting_path.strip_trailing_slashes
 
-let starts_with ~prefix s =
-  String.length s >= String.length prefix
-  && String.sub s 0 (String.length prefix) = prefix
+let starts_with ~prefix s = String.starts_with ~prefix s
 
 (** Build the absolute, normalized playground bundle root for [meta]
     under [config.base_path]. *)

--- a/lib/keeper/social_model/keeper_social_model_magentic_ledger_fsm.ml
+++ b/lib/keeper/social_model/keeper_social_model_magentic_ledger_fsm.ml
@@ -67,9 +67,7 @@ let event_of_string value =
 
 let model_name = Types.model_id_to_string Types.Magentic_ledger_v1
 
-let has_prefix s prefix =
-  let s_len = String.length s and prefix_len = String.length prefix in
-  s_len >= prefix_len && String.sub s 0 prefix_len = prefix
+let has_prefix s prefix = String.starts_with ~prefix s
 
 let belief_summary_field belief_summary field_name =
   let parts =

--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -62,10 +62,7 @@ let source_to_string = function
   | Legacy_traceln -> "legacy_traceln"
   | Client_tool_host -> "client_tool_host"
 
-let has_prefix ~prefix value =
-  let prefix_len = String.length prefix in
-  String.length value >= prefix_len
-  && String.sub value 0 prefix_len = prefix
+let has_prefix ~prefix value = String.starts_with ~prefix value
 
 let infer_legacy_level message =
   let trimmed = String.trim message in

--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -496,9 +496,7 @@ let read_hw_decode_tok_per_sec (fields : (string * Yojson.Safe.t) list) =
   | Some _ as v -> v
   | None -> read "provider_tokens_per_second"
 
-let starts_with ~prefix s =
-  let plen = String.length prefix in
-  String.length s >= plen && String.sub s 0 plen = prefix
+let starts_with ~prefix s = String.starts_with ~prefix s
 
 let canonical_cost_model_id ~(provider : string option) model =
   match provider with

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -827,10 +827,7 @@ module Kimi_cli_transport_local = struct
             index + 1)
       start_index blocks
 
-  let starts_with text prefix =
-    let prefix_len = String.length prefix in
-    String.length text >= prefix_len
-    && String.sub text 0 prefix_len = prefix
+  let starts_with text prefix = String.starts_with ~prefix text
 
   let resumable_session_detail =
     "kimi_cli reported a resumable CLI session. Resumable session available via -r."

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -141,7 +141,7 @@ let parse_host_port host_header default_host default_port =
         with Eio.Cancel.Cancelled _ as e -> raise e | _ -> (default_host, default_port))
 
 (** Utility: string prefix check *)
-let starts_with ~prefix s = Base.String.is_prefix s ~prefix
+let starts_with ~prefix s = String.starts_with ~prefix s
 
 (** Allowed origins for DNS rebinding protection.
     SSOT: [Masc_network_defaults.allowed_origins]. *)

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -35,10 +35,7 @@ let validate_name = function
 let parse_name request =
   validate_name (Server_utils.query_param request "name")
 
-let starts_with ~prefix value =
-  let prefix_len = String.length prefix in
-  String.length value >= prefix_len
-  && String.equal (String.sub value 0 prefix_len) prefix
+let starts_with ~prefix value = String.starts_with ~prefix value
 
 let trim_opt = function
   | Some raw ->

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -352,7 +352,7 @@ type turn_request_result = {
 exception Timeout of string
 
 (** Safe string prefix check *)
-let starts_with ~prefix s = Base.String.is_prefix s ~prefix
+let starts_with ~prefix s = String.starts_with ~prefix s
 
 (** Check if an error is retryable (transient)
     Retryable errors: connection failures, timeouts, HTTP 5xx *)


### PR DESCRIPTION
## Summary

OCaml 5.0+ ships \`String.starts_with\` and \`String.ends_with\` in Stdlib, so the per-module forks all reduce to a 1-line delegate or are flat-out removable. This PR retires 13 forks, all of which were the same \`String.length + String.sub\` allocation pattern that \`String_util.contains_substring\` (PR #10347) already replaced for substring search.

## Pure prefix forks (custom impl → \`Stdlib.String.starts_with\`)

- \`lib/model_inference_metrics.ml\`
- \`lib/oas_worker_exec_transport.ml\`
- \`lib/backend/backend.ml\`
- \`lib/server/server_routes_http_routes_sidecar.ml\`
- \`lib/keeper/keeper_sandbox_containment.ml\`
- \`lib/grpc/masc_grpc_server.ml\` (named \`has_prefix\`)
- \`lib/masc_log/log.ml\` (named \`has_prefix\`)
- \`lib/keeper/social_model/keeper_social_model_magentic_ledger_fsm.ml\` (positional \`has_prefix s prefix\`)

## Inline removal (\`let-in\` helper → direct call)

- \`lib/board_votes.ml\`: \`synthetic_voter_p\` folded 3 calls into \`String.starts_with\` directly, dropping the let-binding.

## Suffix fork (Stdlib + length-strictness guard)

- \`lib/cascade_catalog_validator.ml\`: had \`has_suffix s_len > suffix_len\` (rejects whole-string-equals-suffix). \`String.ends_with\` admits equality, so wrap with the strict-greater length guard to preserve the validator contract.

## Base.String → Stdlib.String (minor dep simplification)

- \`lib/server/server_routes_http_common.ml\`
- \`lib/voice/voice_bridge.ml\`
- \`lib/keeper/keeper_alerting_path.ml\`

## Test plan

- [x] \`dune build @check\` clean
- [x] \`test_string_util\` 17/17, \`test_worker_dev_tools\` 120/120, \`test_backend\` 10/10, \`test_grpc_client\` 15/15, \`test_keeper_social_model_magentic_ledger_fsm\` 5/5, \`test_cascade_catalog_runtime\` 13/13

🤖 Generated with [Claude Code](https://claude.com/claude-code)