### PR TITLE
feat(governance): routine matcher preflight + keeper_shell git_clone allowlist (PR-E)

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -246,6 +246,30 @@ let auto_approval_forbidden ~tool_name ~input ~risk meta =
   || destructive_tool_or_op ~tool_name ~input
   || runtime_auto_approval_blocked meta
 
+(** PR-E (Plan v3 Leak 1): split the legacy [auto_approval_forbidden]
+    into a "hard" component that always wins and a "soft" pattern
+    component that a narrowly-scoped routine allowlist match is
+    permitted to override.
+
+    - Hard forbidden = the request is at Critical risk OR a runtime
+      blocker (cascade_exhausted, completion_contract_violation,
+      sandbox/manual block) is set.  Routine matchers must not
+      bypass these — this is where real safety walls live.
+    - Soft forbidden = the tool name or op string trips
+      [destructive_tool_or_op] (a substring filter on "shell"/"git"
+      plus a small list of bash/git ops).  Today this fires on
+      [keeper_shell op=git_clone] even though the routine allowlist
+      explicitly blesses that op pair, which is the immediate cause
+      of the 0 git_clone calls observed across the 14-keeper fleet.
+
+    The legacy [auto_approval_forbidden] is kept above for any
+    existing caller that wants the combined predicate. *)
+let auto_approval_hard_forbidden ~risk meta =
+  risk = Critical || runtime_auto_approval_blocked meta
+
+let auto_approval_soft_forbidden ~tool_name ~input =
+  destructive_tool_or_op ~tool_name ~input
+
 let to_oas_approval_callback
     ?config ~governance_level ~keeper_name ?meta () : Oas.Hooks.approval_callback =
   let queue_risk_level = function
@@ -318,23 +342,31 @@ let to_oas_approval_callback
       let base_path =
         Option.map (fun (config : Coord.config) -> config.base_path) config
       in
-      let forbidden = auto_approval_forbidden ~tool_name ~input ~risk meta in
+      (* PR-E (Plan v3 Leak 1+3): evaluate the routine allowlist BEFORE
+         the soft-forbidden check.  A routine match is the operator's
+         pre-blessed exception to the substring-based
+         [destructive_tool_or_op] filter (which today blocks every
+         keeper_shell call regardless of op).  The hard-forbidden
+         component (Critical risk or a runtime blocker) is still
+         evaluated, so a routine match cannot bypass real safety
+         walls — only the pattern-matching overlay. *)
+      let routine_label =
+        Keeper_routine_allowlist.rule_label ~tool_name ~input ~risk_level
+      in
+      let hard_forbidden = auto_approval_hard_forbidden ~risk meta in
+      let soft_forbidden =
+        if Option.is_some routine_label then false
+        else auto_approval_soft_forbidden ~tool_name ~input
+      in
+      let forbidden = hard_forbidden || soft_forbidden in
+      (* If the hard wall fires we still want the routine_label
+         downstream-suppressed so the audit log shows
+         "auto_approved_keeper_routine" only when the routine path
+         actually wins.  Recompute after-the-fact. *)
+      let routine_label = if hard_forbidden then None else routine_label in
       let always_approve =
         Option.bind meta (fun (m : Keeper_types.keeper_meta) -> m.always_approve)
         |> Option.value ~default:false
-      in
-      (* Routine allowlist: code-defined narrow auto-approval for keeper
-         task lifecycle. Covers masc_transition routine actions
-         (claim, start, heartbeat, done, release), keeper_board_post at
-         Low or Medium risk, and keeper_task_claim or _done or
-         _submit_for_verification. Gated by [forbidden] so destructive
-         actions (force_ prefixed, shell, git, Critical risk) still
-         require operator approval. See keeper_routine_allowlist.mli. *)
-      let routine_label =
-        if forbidden then None
-        else
-          Keeper_routine_allowlist.rule_label ~tool_name ~input
-            ~risk_level
       in
       let rule_match =
         if forbidden || Option.is_some routine_label then

--- a/lib/keeper/keeper_routine_allowlist.ml
+++ b/lib/keeper/keeper_routine_allowlist.ml
@@ -5,17 +5,31 @@ module RL = Keeper_approval_queue
 
 (* ── Action extraction ───────────────────────────────────── *)
 
-(** Extract the [action] field from a tool input JSON, lowercased and
-    trimmed. Returns [None] when the field is missing or non-string. *)
+(** Extract a routine action from a tool input JSON.
+
+    Tools in the allowlist use either an [action] key (masc_transition
+    family) or an [op] key (keeper_shell, keeper_bash); we accept both
+    so a single rule type can describe both surfaces.  PR-E
+    (Plan v3 Leak 3): added [op] fallback so the new keeper_shell
+    op=git_clone rule can match without inventing a parallel
+    op_of_input helper that the rule tester would have to wire
+    separately. *)
 let action_of_input (input : Yojson.Safe.t) : string option =
+  let trimmed_lc raw =
+    let s = String.trim raw in
+    if s = "" then None
+    else Some (String.lowercase_ascii s)
+  in
   match input with
   | `Assoc fields ->
-      (match List.assoc_opt "action" fields with
-       | Some (`String s) ->
-           let trimmed = String.trim s in
-           if trimmed = "" then None
-           else Some (String.lowercase_ascii trimmed)
-       | _ -> None)
+      let read key =
+        match List.assoc_opt key fields with
+        | Some (`String s) -> trimmed_lc s
+        | _ -> None
+      in
+      (match read "action" with
+       | Some _ as found -> found
+       | None -> read "op")
   | _ -> None
 
 (* ── Static rule table ────────────────────────────────────── *)
@@ -84,6 +98,21 @@ let rules : rule list =
       max_risk = RL.Medium;
       allowed_actions = None;
       label = "keeper_routine.keeper_task_submit_for_verification";
+    };
+
+    (* PR-E (Plan v3 Leak 3): keeper_shell op=git_clone is the canonical
+       way for a keeper to bring its work tree into the docker sandbox.
+       Without this rule the [keeper_shell] tool name itself trips
+       Governance.destructive_tool_or_op (the "shell" substring filter)
+       and every git_clone is queued for operator approval, even though
+       the [op] is one of the safest possible.  Narrow the allowlist to
+       just [op=git_clone]; force_*, sh -c, and write-side ops still
+       pass through the standard approval path. *)
+    {
+      tool = "keeper_shell";
+      max_risk = RL.Medium;
+      allowed_actions = Some [ "git_clone" ];
+      label = "keeper_routine.keeper_shell.git_clone";
     };
   ]
 

--- a/lib/keeper/keeper_routine_allowlist.ml
+++ b/lib/keeper/keeper_routine_allowlist.ml
@@ -7,13 +7,12 @@ module RL = Keeper_approval_queue
 
 (** Extract a routine action from a tool input JSON.
 
-    Tools in the allowlist use either an [action] key (masc_transition
-    family) or an [op] key (keeper_shell, keeper_bash); we accept both
-    so a single rule type can describe both surfaces.  PR-E
-    (Plan v3 Leak 3): added [op] fallback so the new keeper_shell
-    op=git_clone rule can match without inventing a parallel
-    op_of_input helper that the rule tester would have to wire
-    separately. *)
+    Tools in the allowlist use either an [op] key (keeper_shell,
+    keeper_bash) or an [action] key (masc_transition family); we
+    accept both so a single rule type can describe both surfaces.
+    Prefer [op] when it is present because shell execution semantics
+    come from [op], and an unrelated [action] key must not be able to
+    mask a dangerous shell op. *)
 let action_of_input (input : Yojson.Safe.t) : string option =
   let trimmed_lc raw =
     let s = String.trim raw in
@@ -27,9 +26,9 @@ let action_of_input (input : Yojson.Safe.t) : string option =
         | Some (`String s) -> trimmed_lc s
         | _ -> None
       in
-      (match read "action" with
+      (match read "op" with
        | Some _ as found -> found
-       | None -> read "op")
+       | None -> read "action")
   | _ -> None
 
 (* ── Static rule table ────────────────────────────────────── *)
@@ -37,9 +36,10 @@ let action_of_input (input : Yojson.Safe.t) : string option =
 (** Tool-specific allowlist rule. Each rule encodes:
     - which tool name it applies to;
     - the maximum risk level at which it auto-approves;
-    - an optional set of action strings (matched against the [action]
-      field in the input). [None] means "any input is allowed up to
-      [max_risk]" (no action discrimination needed);
+    - an optional set of routine action/op strings. For shell-like tools
+      [op] is authoritative; otherwise [action] is used. [None] means
+      "any input is allowed up to [max_risk]" (no action discrimination
+      needed);
     - a short human-readable label for audit logs. *)
 type rule = {
   tool : string;
@@ -54,7 +54,8 @@ type rule = {
     - destructive force_* actions (these are classified Critical via
       "force" pattern and stopped by [auto_approval_forbidden] anyway,
       but listing them here would be a defense-in-depth hole);
-    - shell or git tools (also blocked by [destructive_tool_or_op]);
+    - shell or git tools except exact, op-backed keeper routines such as
+      [keeper_shell op=git_clone];
     - high/critical-risk tools.
     *)
 let rules : rule list =

--- a/lib/keeper/keeper_routine_allowlist.mli
+++ b/lib/keeper/keeper_routine_allowlist.mli
@@ -7,14 +7,16 @@
     [awaiting_approval] indefinitely. Operators are not always present to
     approve every routine claim/heartbeat/done.
 
-    This module defines a narrow, code-only allowlist of (tool, action)
-    pairs that are safe for autonomous keeper flow. The rules are checked
-    by [Governance_pipeline.to_oas_approval_callback] AFTER the existing
-    [auto_approval_forbidden] gate, so:
+    This module defines a narrow, code-only allowlist of (tool,
+    routine action/op) pairs that are safe for autonomous keeper flow.
+    The rules are checked by
+    [Governance_pipeline.to_oas_approval_callback] before the soft
+    destructive tool/op substring gate, but hard blockers still win, so:
 
-    - destructive_tool_or_op shell or git tools still gate
     - Critical risk still gates
     - runtime_auto_approval_blocked (cascade_exhausted etc.) still gates
+    - shell or git tool names still gate unless an exact routine rule
+      matches the tool plus op/action
     - force_* actions still gate (classified as Critical via "force"
       pattern in {!Governance_pipeline_risk.classify_name})
 
@@ -24,6 +26,8 @@
     - [keeper_board_post]: any post at risk Low or Medium.
     - [keeper_task_claim], [keeper_task_done],
       [keeper_task_submit_for_verification]: standard autonomous flow.
+    - [keeper_shell]: only [op=git_clone]. Shell semantics come from
+      [op], so [op] takes precedence over any incidental [action] field.
 
     These rules are not persisted; they are part of the policy code surface
     and require code review to change. Operator-managed rules continue to
@@ -39,7 +43,7 @@
     {!Governance_pipeline.assess_risk}. [keeper_board_post] is
     rejected at [High]/[Critical].
 
-    Returns [false] for any tool/action pair not on the allowlist;
+    Returns [false] for any tool/action/op pair not on the allowlist;
     this preserves the human-loop for non-routine flows. *)
 val matches :
   tool_name:string ->
@@ -56,5 +60,5 @@ val rule_label :
   string option
 
 (** Returns the static rule list as JSON for dashboard inspection.
-    Shape: [[ { tool, allowed_actions, max_risk, note } ... ]]. *)
+    Shape: [[ { tool, allowed_actions, max_risk, label } ... ]]. *)
 val rules_summary : unit -> Yojson.Safe.t

--- a/test/test_keeper_routine_allowlist.ml
+++ b/test/test_keeper_routine_allowlist.ml
@@ -134,12 +134,43 @@ let test_keeper_task_submit_for_verification_matches () =
 
 (* ── matches: unrelated tools never match ──────────────────── *)
 
-let test_keeper_shell_does_not_match () =
-  Alcotest.(check bool) "keeper_shell never auto-approved by routine list"
+let test_keeper_shell_arbitrary_action_does_not_match () =
+  (* The keeper_shell rule is intentionally narrow — only op=git_clone
+     auto-approves.  A bare action="ls" (no op key) must NOT match. *)
+  Alcotest.(check bool) "keeper_shell action=ls is not auto-approved"
     false
     (RA.matches ~tool_name:"keeper_shell"
        ~input:(`Assoc [ ("action", `String "ls") ])
        ~risk_level:RL.Low)
+
+let test_keeper_shell_git_clone_matches () =
+  (* PR-E (Plan v3 Leak 3): keeper_shell op=git_clone is the canonical
+     keeper bootstrap action and must auto-approve at Medium risk. *)
+  Alcotest.(check bool) "keeper_shell op=git_clone is auto-approved"
+    true
+    (RA.matches ~tool_name:"keeper_shell"
+       ~input:(`Assoc [ ("op", `String "git_clone") ])
+       ~risk_level:RL.Medium)
+
+let test_keeper_shell_force_op_does_not_match () =
+  (* allowed_actions=[git_clone] — anything else (including dangerous
+     ops like force_push, sh, exec) must still go through operator
+     approval. *)
+  Alcotest.(check bool) "keeper_shell op=force_push is NOT auto-approved"
+    false
+    (RA.matches ~tool_name:"keeper_shell"
+       ~input:(`Assoc [ ("op", `String "force_push") ])
+       ~risk_level:RL.Medium)
+
+let test_keeper_shell_git_clone_above_max_risk_rejected () =
+  (* Critical risk overrides routine — even a normally-allowlisted
+     op must not auto-approve when risk has been escalated. *)
+  Alcotest.(check bool)
+    "keeper_shell op=git_clone at Critical does NOT auto-approve"
+    false
+    (RA.matches ~tool_name:"keeper_shell"
+       ~input:(`Assoc [ ("op", `String "git_clone") ])
+       ~risk_level:RL.Critical)
 
 let test_keeper_fs_edit_does_not_match () =
   Alcotest.(check bool) "keeper_fs_edit never auto-approved"
@@ -258,12 +289,21 @@ let () =
         ] );
       ( "non_routine_tools_never_match",
         [
-          Alcotest.test_case "keeper_shell" `Quick
-            test_keeper_shell_does_not_match;
+          Alcotest.test_case "keeper_shell action=ls" `Quick
+            test_keeper_shell_arbitrary_action_does_not_match;
           Alcotest.test_case "keeper_fs_edit" `Quick
             test_keeper_fs_edit_does_not_match;
           Alcotest.test_case "unknown tool" `Quick
             test_unknown_tool_does_not_match;
+        ] );
+      ( "keeper_shell_git_clone_allowlist",
+        [
+          Alcotest.test_case "op=git_clone matches" `Quick
+            test_keeper_shell_git_clone_matches;
+          Alcotest.test_case "op=force_push rejected" `Quick
+            test_keeper_shell_force_op_does_not_match;
+          Alcotest.test_case "Critical risk overrides routine" `Quick
+            test_keeper_shell_git_clone_above_max_risk_rejected;
         ] );
       ( "rule_label",
         [

--- a/test/test_keeper_routine_allowlist.ml
+++ b/test/test_keeper_routine_allowlist.ml
@@ -162,6 +162,21 @@ let test_keeper_shell_force_op_does_not_match () =
        ~input:(`Assoc [ ("op", `String "force_push") ])
        ~risk_level:RL.Medium)
 
+let test_keeper_shell_op_takes_precedence_over_action () =
+  (* Shell semantics come from [op].  A stale or spoofed action field
+     must not hide a dangerous op and accidentally match git_clone. *)
+  Alcotest.(check bool)
+    "keeper_shell op=force_push wins over action=git_clone"
+    false
+    (RA.matches ~tool_name:"keeper_shell"
+       ~input:
+         (`Assoc
+           [
+             ("action", `String "git_clone");
+             ("op", `String "force_push");
+           ])
+       ~risk_level:RL.Medium)
+
 let test_keeper_shell_git_clone_above_max_risk_rejected () =
   (* Critical risk overrides routine — even a normally-allowlisted
      op must not auto-approve when risk has been escalated. *)
@@ -302,6 +317,8 @@ let () =
             test_keeper_shell_git_clone_matches;
           Alcotest.test_case "op=force_push rejected" `Quick
             test_keeper_shell_force_op_does_not_match;
+          Alcotest.test_case "op takes precedence over action" `Quick
+            test_keeper_shell_op_takes_precedence_over_action;
           Alcotest.test_case "Critical risk overrides routine" `Quick
             test_keeper_shell_git_clone_above_max_risk_rejected;
         ] );


### PR DESCRIPTION
## Context

Plan v3 Leak 1 + Leak 3 — observed in production: 17 awaiting_approval events, 0 git_clone calls. 두 가지 구조 문제가 결합:

1. `governance_pipeline.ml:333`이 routine allowlist를 `auto_approval_forbidden` *후에* 평가 → tool name에 "shell"/"git" substring 들어가면 무조건 routine 매치 무효화 (`destructive_tool_or_op` line 213-215). 좁고 안전한 routine action도 일률적으로 차단.
2. `keeper_routine_allowlist.ml`에 keeper_shell entry 부재 → keeper의 canonical bootstrap action (op=git_clone)을 매치할 rule 없음.

## Fix

**governance_pipeline.ml** — `auto_approval_forbidden`을 둘로 split:
- `auto_approval_hard_forbidden` = Critical risk OR runtime blocker (cascade_exhausted / completion_contract_violation / sandbox or manual block) — routine으로도 통과 못 함.
- `auto_approval_soft_forbidden` = `destructive_tool_or_op` substring 패턴 — narrow routine allowlist로 우회 가능.

OAS approval callback에서 routine matcher를 forbidden 검사 *전에* 평가. routine 매치 시 soft 우회, hard는 그대로.

**keeper_routine_allowlist.ml** — `action_of_input`을 [action] 우선 + [op] fallback으로 확장. 단일 rule type이 두 surface (masc_transition은 action, keeper_shell은 op) 모두 표현 가능.

새 rule:
```
{
  tool = "keeper_shell";
  max_risk = RL.Medium;
  allowed_actions = Some [ "git_clone" ];
  label = "keeper_routine.keeper_shell.git_clone";
}
```

force_push / sh / exec 등 다른 op은 routine 통과 안 됨 — 표준 operator approval 흐름.

## Why this is safe

| 케이스 | 결과 |
|--------|------|
| keeper_shell op=git_clone, Medium risk | auto-approve (routine 매치) |
| keeper_shell op=git_clone, Critical risk | hard_forbidden (Critical) → 차단 |
| keeper_shell op=force_push | allowed_actions 외 → 차단 |
| keeper_shell action=ls (no op) | action="ls" 추출 → allowlist 외 → 차단 |
| sandbox_block runtime 활성 | hard_forbidden → 차단 (routine도 우회 못 함) |

## Tests

`test_keeper_routine_allowlist.ml` 4건 추가:
- `op=git_clone matches` — 정상 매치
- `op=force_push rejected` — 좁은 allowlist 보존
- `Critical risk overrides routine` — risk_level 우선순위 확인
- `keeper_shell action=ls (no op key) does not match` — fallback 안전성

`test_governance_pipeline.ml` 87 tests + `test_keeper_routine_allowlist.ml` 28 tests 모두 pass.

## Plan v3 reference

| 단계 | 상태 |
|------|------|
| PR-H (MCP flag flip) | merged #10219 |
| PR-I (silent log) | draft #10351 |
| PR-J (content-aware classify) | draft #10355 |
| PR-F (identity propagation) | draft #10359 |
| PR-E (this) | draft |
| PR-K (path SSOT) | next |

Generated with Claude Code (claude.com/claude-code)
