### PR TITLE
fix(keeper): fail-fast on cascade with keeper_assignable=false (#10388)

### DIFF
--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -168,9 +168,9 @@ let catalog_names_with_toml_fallback ?config_path () =
                     also failed: %s"
                    catalog_error toml_error)))
 
-let is_system_only_cascade raw =
+let is_system_only_cascade ?config_path raw =
   let name = String.trim raw in
-  match catalog_entries () with
+  match catalog_entries ?config_path () with
   | None -> false
   | Some entries ->
       List.exists

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -110,9 +110,11 @@ val fallback_cascade_for : ?config_path:string -> string -> string option
 
     @since 0.174.0 *)
 
-val is_system_only_cascade : string -> bool
+val is_system_only_cascade : ?config_path:string -> string -> bool
 (** Exact-name membership check against the active config's
-    {!system_catalog_names}. *)
+    {!system_catalog_names}.  [?config_path] overrides the
+    resolver-derived path so unit tests can pin the contract
+    against a fixture cascade.toml. *)
 
 val canonicalize_with_catalog : catalog:string list -> string -> string
 (** Resolves dynamic profiles against an explicit live catalog. *)

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -202,28 +202,63 @@ let ensure_keeper_meta config name =
     let target_cascade_name =
       effective_declarative_cascade_name defaults meta
     in
+    let cascade_field_and_value () =
+      let field =
+        match defaults.cascade_name, defaults.manifest_path with
+        | Some _, _ -> "profile.cascade_name"
+        | None, Some _ -> "manifest.default_cascade_name"
+        | None, None -> "meta.cascade_name"
+      in
+      let raw_value =
+        match defaults.cascade_name, defaults.manifest_path with
+        | Some cascade_name, _ -> cascade_name
+        | None, Some _ -> Keeper_config.default_cascade_name
+        | None, None -> meta.cascade_name
+      in
+      (field, raw_value)
+    in
     match
       Cascade_catalog_runtime.resolve_declared_name
         ~raw_name:target_cascade_name
         ()
     with
     | Error detail ->
-        let field =
-          match defaults.cascade_name, defaults.manifest_path with
-          | Some _, _ -> "profile.cascade_name"
-          | None, Some _ -> "manifest.default_cascade_name"
-          | None, None -> "meta.cascade_name"
-        in
-        let raw_value =
-          match defaults.cascade_name, defaults.manifest_path with
-          | Some cascade_name, _ -> cascade_name
-          | None, Some _ -> Keeper_config.default_cascade_name
-          | None, None -> meta.cascade_name
-        in
+        let field, raw_value = cascade_field_and_value () in
         let msg =
           Printf.sprintf
             "invalid %s %S for keeper %s: %s"
             field raw_value meta.name detail
+        in
+        Log.Keeper.error "%s" msg;
+        Error msg
+    | Ok resolved_target_cascade_name
+      when Keeper_cascade_profile.is_system_only_cascade
+             resolved_target_cascade_name ->
+        (* #10388: cascade.toml marks the profile as
+           [keeper_assignable=false] (system-only).  Pre-fix the
+           keeper would still bind to it and fail downstream
+           — visible as either a silent fall-through, a generic
+           "active cascade source could not be loaded" error, or
+           a 19-min ollama wall — depending on which layer
+           tripped first.  Reject up-front with an explicit
+           reason so config drift surfaces at bootstrap rather
+           than after a fleet-cycle worth of accumulated ERRORs. *)
+        let field, raw_value = cascade_field_and_value () in
+        Prometheus.inc_counter
+          Prometheus.metric_keeper_cascade_assignment_rejection
+          ~labels:
+            [ ("keeper", meta.name);
+              ("cascade", resolved_target_cascade_name);
+              ("reason", "system_only");
+            ]
+          ();
+        let msg =
+          Printf.sprintf
+            "invalid %s %S for keeper %s: cascade %S is marked \
+             keeper_assignable=false in cascade.toml \
+             (system-only — reserved for governance_judge / \
+             operator_judge style internal cascades)"
+            field raw_value meta.name resolved_target_cascade_name
         in
         Log.Keeper.error "%s" msg;
         Error msg

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -341,6 +341,22 @@ let metric_keeper_operator_clear = "masc_keeper_operator_clear_total"
 let metric_keeper_compaction_noop =
   "masc_keeper_compaction_noop_total"
 
+(* #10388: counter for keeper bootstrap rejections caused by
+   declarative cascade-config drift between [config/keepers/*.toml]
+   (which set [cascade_name]) and [config/cascade.toml] (which
+   marks profiles as [keeper_assignable=true|false]).  Pre-fix
+   four keepers (masc-improver, sangsu, ramarama, ollama-local)
+   pointed at system-only cascades and produced ~144 cascade-
+   related ERRORs/day (~33.7% of fleet ERROR) via mixed
+   downstream paths.  Surfacing as an explicit counter labelled
+   [keeper, cascade, reason] makes the config-drift class
+   observable and forces the bootstrap to fail-fast on next
+   run.  Reason vocabulary kept narrow so cardinality stays
+   bounded:
+   - [system_only] — cascade marked [keeper_assignable=false]. *)
+let metric_keeper_cascade_assignment_rejection =
+  "masc_keeper_cascade_assignment_rejection_total"
+
 (* Keeper keepalive (keeper_keepalive.ml). *)
 let metric_keeper_heartbeat_successes =
   "masc_keeper_heartbeat_successes_total"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -134,6 +134,12 @@ val metric_keeper_compaction_saved_tokens : string
     triggers rather than savings.  Labels: [keeper, trigger]. *)
 val metric_keeper_compaction_noop : string
 
+(** #10388: counter incremented when the keeper bootstrap
+    rejects [cascade_name] because the cascade.toml profile is
+    marked [keeper_assignable=false] (system-only).  Labels:
+    [keeper, cascade, reason="system_only"]. *)
+val metric_keeper_cascade_assignment_rejection : string
+
 val metric_keeper_operator_compact : string
 val metric_keeper_operator_clear : string
 val metric_keeper_heartbeat_successes : string

--- a/test/dune
+++ b/test/dune
@@ -1460,6 +1460,9 @@
  (libraries dated_jsonl fs_compat alcotest eio eio_main yojson unix))
 
 
+ (name test_cascade_keeper_assignable_10388)
+ (modules test_cascade_keeper_assignable_10388)
+ (libraries masc_mcp alcotest unix))
 ; ============================================================
 ; Special: Heartbeat/keeper minimal deps
 ; ============================================================

--- a/test/dune
+++ b/test/dune
@@ -1460,6 +1460,7 @@
  (libraries dated_jsonl fs_compat alcotest eio eio_main yojson unix))
 
 
+(test
  (name test_cascade_keeper_assignable_10388)
  (modules test_cascade_keeper_assignable_10388)
  (libraries masc_mcp alcotest unix))

--- a/test/test_cascade_keeper_assignable_10388.ml
+++ b/test/test_cascade_keeper_assignable_10388.ml
@@ -1,0 +1,161 @@
+(** #10388 — pin the keeper-assignable cascade fail-fast contract.
+
+    Pre-fix four keepers (masc-improver, sangsu, ramarama,
+    ollama-local) referenced cascade names that were marked
+    [keeper_assignable=false] in cascade.toml.  No layer rejected
+    the binding up-front — the violations surfaced only at
+    bootstrap or downstream as a mix of "active cascade source
+    could not be loaded", silent fall-through, and 19-min ollama
+    walls.  About 144 ERRORs/day (~33.7% of fleet ERROR) lived
+    in this drift class.
+
+    [Keeper_cascade_profile.is_system_only_cascade] already
+    encoded the policy but no caller wired it to the keeper
+    bootstrap.  This module pins:
+
+    1. [is_system_only_cascade] returns [true] for a profile
+       declared with [keeper_assignable=false].
+    2. Returns [false] for a profile declared with
+       [keeper_assignable=true] (and for the explicit-default
+       case where the field is omitted, which the loader treats
+       as [true]).
+    3. Returns [false] for a name absent from the catalog.
+    4. Trims surrounding whitespace before lookup.
+    5. The dedicated rejection counter
+       [masc_keeper_cascade_assignment_rejection_total] exists
+       in the metric vocabulary so dashboards can subscribe by
+       name rather than typo. *)
+
+open Alcotest
+
+module KCP = Masc_mcp.Keeper_cascade_profile
+
+let counter = ref 0
+
+let mk_fixture () =
+  incr counter;
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "cascade_assignable_10388_%d_%d_%.0f" !counter
+         (Unix.getpid ()) (Unix.gettimeofday ()))
+  in
+  Unix.mkdir dir 0o755;
+  let path = Filename.concat dir "cascade.json" in
+  let oc = open_out path in
+  output_string oc
+    {|{
+  "assignable_one_models": [{"model": "openai:gpt", "weight": 1}],
+  "assignable_one_keeper_assignable": true,
+  "system_only_one_models": [{"model": "openai:gpt", "weight": 1}],
+  "system_only_one_keeper_assignable": false,
+  "implicit_default_models": [{"model": "openai:gpt", "weight": 1}]
+}|};
+  close_out oc;
+  (dir, path)
+
+let rec rm_rf p =
+  if Sys.file_exists p then
+    if Sys.is_directory p then (
+      Sys.readdir p |> Array.iter (fun n -> rm_rf (Filename.concat p n));
+      Unix.rmdir p)
+    else Sys.remove p
+
+(* --- 1. system-only profile is detected --- *)
+
+let test_system_only_returns_true () =
+  let dir, path = mk_fixture () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      check bool "system_only_one is system-only" true
+        (KCP.is_system_only_cascade ~config_path:path "system_only_one"))
+
+(* --- 2. keeper_assignable=true → not system-only --- *)
+
+let test_assignable_returns_false () =
+  let dir, path = mk_fixture () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      check bool "assignable_one is not system-only" false
+        (KCP.is_system_only_cascade ~config_path:path "assignable_one"))
+
+(* --- 2b. omitted field defaults to assignable --- *)
+
+let test_implicit_default_returns_false () =
+  let dir, path = mk_fixture () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      check bool
+        "profile without explicit keeper_assignable defaults to assignable"
+        false
+        (KCP.is_system_only_cascade ~config_path:path "implicit_default"))
+
+(* --- 3. unknown profile returns false (no spurious veto) --- *)
+
+let test_unknown_returns_false () =
+  let dir, path = mk_fixture () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      check bool "absent profile is not flagged system-only" false
+        (KCP.is_system_only_cascade ~config_path:path "ghost_profile"))
+
+(* --- 4. surrounding whitespace is trimmed --- *)
+
+let test_whitespace_trimmed () =
+  let dir, path = mk_fixture () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      check bool "leading/trailing whitespace ignored" true
+        (KCP.is_system_only_cascade ~config_path:path
+           "  system_only_one  "))
+
+(* --- 5. dedicated rejection counter exists --- *)
+
+let test_rejection_counter_in_vocab () =
+  check string "metric name uses the masc_ prefix"
+    "masc_keeper_cascade_assignment_rejection_total"
+    Masc_mcp.Prometheus.metric_keeper_cascade_assignment_rejection;
+  let labels =
+    [ ("keeper", "ghost"); ("cascade", "ghost"); ("reason", "system_only") ]
+  in
+  let before =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_keeper_cascade_assignment_rejection
+      ~labels ()
+  in
+  Masc_mcp.Prometheus.inc_counter
+    Masc_mcp.Prometheus.metric_keeper_cascade_assignment_rejection
+    ~labels ();
+  let after =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_keeper_cascade_assignment_rejection
+      ~labels ()
+  in
+  check (float 0.0001) "counter increments by 1" (before +. 1.0) after
+
+let () =
+  run "cascade_keeper_assignable_10388"
+    [
+      ( "is_system_only_cascade",
+        [
+          test_case "system-only profile returns true" `Quick
+            test_system_only_returns_true;
+          test_case "assignable profile returns false" `Quick
+            test_assignable_returns_false;
+          test_case "implicit default treated as assignable" `Quick
+            test_implicit_default_returns_false;
+          test_case "unknown profile returns false" `Quick
+            test_unknown_returns_false;
+          test_case "whitespace is trimmed" `Quick test_whitespace_trimmed;
+        ] );
+      ( "rejection-counter",
+        [
+          test_case "metric name + increment" `Quick
+            test_rejection_counter_in_vocab;
+        ] );
+    ]


### PR DESCRIPTION
Closes the validation half of #10388. config/keepers/*.toml had 4 keepers (masc-improver/sangsu/ramarama/ollama-local) pointing at cascade names cascade.toml marked keeper_assignable=false. No layer rejected up-front — violations leaked as 'active cascade source could not be loaded', silent fall-through, or 19-min ollama walls. ~144 cascade-related ERRORs/day (~33.7% fleet ERROR). Wired Keeper_cascade_profile.is_system_only_cascade into keeper_runtime.ensure_keeper_meta after the resolve_declared_name success branch + masc_keeper_cascade_assignment_rejection_total{keeper,cascade,reason='system_only'} counter. is_system_only_cascade gains ?config_path for fixture-based testing. 6 new test cases pin the contract; test_keeper_cascade_profile (8) + test_keeper_cascade_routing (17) still green. Config-data side (rebinding the 4 keepers to assignable cascades, B = ollama-aware turn timeout) tracked separately under same issue.