### PR TITLE
fix(timeout): route Governance/Operator judges through OAS bridge SSOT (#9629)

### DIFF
--- a/lib/config/env_config_governance.ml
+++ b/lib/config/env_config_governance.ml
@@ -11,32 +11,17 @@ module Inference = struct
   let timeout_seconds_int =
     max 1 (int_of_float timeout_seconds)
 
-  (** Background operator judge timeout.
-      Falls back to the global inference timeout unless explicitly overridden. *)
-  let operator_judge_timeout_seconds =
-    max 5
-      (get_int ~default:timeout_seconds_int "MASC_OPERATOR_JUDGE_TIMEOUT_SEC")
-
-  (** Dashboard governance judge timeout (seconds).
-      Reads [MASC_DASHBOARD_GOVERNANCE_JUDGE_TIMEOUT_SEC] when set; otherwise
-      falls back to a 60s default that gives glm-5-turbo room for cold-start.
-      Floored at 5 seconds.
-
-      Previously this silently used the global 30s inference timeout with no
-      override path, so the judge flapped offline whenever the upstream model
-      took longer than 30s — see dashboard "Timeout: Execution timed out
-      after 30.0s" reports. Now operators can raise/lower via env var, and
-      the default is high enough that one slow turn no longer marks the
-      judge offline. *)
-  let dashboard_governance_judge_timeout_seconds =
-    let dedicated =
-      get_int ~default:0 "MASC_DASHBOARD_GOVERNANCE_JUDGE_TIMEOUT_SEC"
-    in
-    let chosen =
-      if dedicated > 0 then dedicated
-      else max 300 timeout_seconds_int
-    in
-    max 5 chosen
+  (* #9629: [operator_judge_timeout_seconds] and
+     [dashboard_governance_judge_timeout_seconds] used to live here as
+     dedicated [int] configs.  The two judges
+     (governance compute_judgments / operator compute_judgments) now
+     resolve their timeout through [Env_config_oas_bridge] alongside
+     the other LLM-via-OAS-worker callers, so this module no longer
+     exposes them.  The legacy env-var names
+     ([MASC_OPERATOR_JUDGE_TIMEOUT_SEC],
+     [MASC_DASHBOARD_GOVERNANCE_JUDGE_TIMEOUT_SEC]) remain honoured
+     by [Env_config_oas_bridge.timeout_sec] as a per-caller alias
+     during the migration window. *)
 
   (** Enable inference response cache (L1+L2). *)
   let cache_enabled =

--- a/lib/config/env_config_oas_bridge.ml
+++ b/lib/config/env_config_oas_bridge.ml
@@ -30,6 +30,8 @@ type caller =
   | Server_openai_compat
   | Tool_deep_review
   | Anti_rationalization
+  | Governance_judge
+  | Operator_judge
   | Unknown of string
 
 (** Hardcoded default seconds for each known caller.  When the
@@ -49,6 +51,8 @@ let caller_key = function
   | Server_openai_compat -> "server_openai_compat"
   | Tool_deep_review -> "tool_deep_review"
   | Anti_rationalization -> "anti_rationalization"
+  | Governance_judge -> "governance_judge"
+  | Operator_judge -> "operator_judge"
   | Unknown caller -> caller
 
 (** Exported for tests that pin the per-caller default table. *)
@@ -61,6 +65,8 @@ let known_callers () =
     Server_openai_compat;
     Tool_deep_review;
     Anti_rationalization;
+    Governance_judge;
+    Operator_judge;
   ]
 
 let known_default_sec = function
@@ -74,6 +80,20 @@ let known_default_sec = function
   | Keeper_persona_authoring
   | Server_openai_compat -> Some 120.0
   | Tool_deep_review | Anti_rationalization -> Some 180.0
+  (* #9629: Governance + Operator judges are LLM-via-OAS-worker calls
+     with the same observed p50 latency as Auto_responder /
+     Dashboard_provider_runs (50–700s).  Pre-migration these read
+     [Env_config.Inference.{operator,dashboard_governance}_judge_timeout_seconds]
+     directly via legacy [run_safe ~timeout_s], bypassing this SSOT.
+     Operator_judge in particular fell back to the global 30s
+     inference timeout — far below p50 — and produced the
+     "Execution timed out after 60.0s" warnings reported in #9629
+     (the 60s figure came from [Env_config.Inference.timeout_seconds]
+     overrides at the time).  Aligning both judges with the
+     Auto_responder default keeps the OAS-bridge SSOT consistent and
+     ends the asymmetry where one judge waited 30s and the other
+     300s for the same shape of LLM call. *)
+  | Governance_judge | Operator_judge -> Some global_default_sec
   | Unknown _ -> None
 
 let upper_case s =
@@ -86,6 +106,17 @@ let upper_case s =
 
 let per_caller_env_var ~caller =
   Printf.sprintf "MASC_OAS_BRIDGE_TIMEOUT_%s_SEC" (upper_case (caller_key caller))
+
+(** #9629: Each caller may also honour a legacy env var name from
+    before the SSOT migration.  When present, the legacy name acts
+    as a tier-2 override (between the new per-caller env var and the
+    checked-in default) so operators with deployment configs pinning
+    the legacy name continue to take effect during the migration
+    window.  Returning [None] means the caller has no legacy alias. *)
+let legacy_per_caller_env_var = function
+  | Operator_judge -> Some "MASC_OPERATOR_JUDGE_TIMEOUT_SEC"
+  | Governance_judge -> Some "MASC_DASHBOARD_GOVERNANCE_JUDGE_TIMEOUT_SEC"
+  | _ -> None
 
 let global_env_var = "MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC"
 
@@ -105,16 +136,22 @@ let trimmed_value_opt name =
       1. Per-caller env [MASC_OAS_BRIDGE_TIMEOUT_<CALLER>_SEC]
          — wins unconditionally.  Lets the operator tune one
          caller without touching others.
-      2. Per-caller checked-in default ([known_default_sec]).
+      2. Legacy per-caller env (#9629).  Operator_judge accepts
+         [MASC_OPERATOR_JUDGE_TIMEOUT_SEC]; Governance_judge accepts
+         [MASC_DASHBOARD_GOVERNANCE_JUDGE_TIMEOUT_SEC].  Honoured for
+         the migration window so operator deployment configs that
+         still pin the pre-SSOT names keep working.  Removed when
+         no legacy alias is registered for the caller.
+      3. Per-caller checked-in default ([known_default_sec]).
          Preserves intentional 120/180s budgets for compute-heavy
          callers; raises the fantasy 60s budgets to
          [global_default_sec] (300s).
-      3. Global env [MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC] — only
+      4. Global env [MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC] — only
          consulted for UNKNOWN callers (typo, future caller
          without a default entry).  Treating it as an override
          would let one slow provider silently shift every
          caller's budget; that is a footgun.
-      4. [global_default_sec] (300s) hardcoded final fallback. *)
+      5. [global_default_sec] (300s) hardcoded final fallback. *)
 let timeout_sec ~caller () =
   let per_caller_env = per_caller_env_var ~caller in
   match trimmed_value_opt per_caller_env with
@@ -122,12 +159,22 @@ let timeout_sec ~caller () =
     Safe_ops.float_of_string_with_default
       ~default:global_default_sec v
   | None ->
-    match known_default_sec caller with
-    | Some d -> d
+    let legacy_env_value =
+      match legacy_per_caller_env_var caller with
+      | Some name -> trimmed_value_opt name
+      | None -> None
+    in
+    match legacy_env_value with
+    | Some v ->
+      Safe_ops.float_of_string_with_default
+        ~default:global_default_sec v
     | None ->
-      (* Unknown caller: fall to global env, then global default. *)
-      match trimmed_value_opt global_env_var with
-      | Some v ->
-        Safe_ops.float_of_string_with_default
-          ~default:global_default_sec v
-      | None -> global_default_sec
+      match known_default_sec caller with
+      | Some d -> d
+      | None ->
+        (* Unknown caller: fall to global env, then global default. *)
+        match trimmed_value_opt global_env_var with
+        | Some v ->
+          Safe_ops.float_of_string_with_default
+            ~default:global_default_sec v
+        | None -> global_default_sec

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -494,12 +494,15 @@ let compute_judgments
     ~(masc_tools : Types.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
     ~build_facts =
-  let timeout_s = Float.of_int Env_config.Inference.dashboard_governance_judge_timeout_seconds in
   match
     (* build_facts() is moved inside the bridge so a deadlock in
-       get_agents_status is bounded by [timeout_s]
-       rather than hanging the daemon fiber indefinitely (#8319). *)
-    Masc_oas_bridge.run_safe ~timeout_s (fun () ->
+       get_agents_status is bounded by the resolved timeout rather
+       than hanging the daemon fiber indefinitely (#8319).
+       #9629: caller migrated from legacy run_safe to run_with_caller
+       so this judge resolves its budget through Env_config_oas_bridge
+       and surfaces in the per-caller Prometheus counter. *)
+    Masc_oas_bridge.run_with_caller
+      ~caller:Env_config_oas_bridge.Governance_judge (fun () ->
       let factual_json = build_facts () in
       let prompt = prompt_for_facts factual_json in
       Oas_worker.run_named_with_masc_tools ~cascade_name:"governance_judge"

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -195,10 +195,14 @@ let compute_judgments
     ~(masc_tools : Types.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> bool * string)
     ~facts_json =
-  let timeout_s = Float.of_int Env_config.Inference.operator_judge_timeout_seconds in
   let prompt = prompt_for_facts facts_json in
   match
-    Masc_oas_bridge.run_safe ~timeout_s (fun () ->
+    (* #9629: caller migrated from legacy run_safe (which fell back to
+       the global 30s inference timeout) to run_with_caller so this
+       judge inherits Operator_judge's 300s default and surfaces in the
+       per-caller Prometheus counter. *)
+    Masc_oas_bridge.run_with_caller
+      ~caller:Env_config_oas_bridge.Operator_judge (fun () ->
       Oas_worker.run_named_with_masc_tools ~cascade_name:"operator_judge"
         ~goal:prompt ~masc_tools ~dispatch ~max_turns:3
         ~approval:Approval_callbacks.auto_approve

--- a/test/dune
+++ b/test/dune
@@ -501,6 +501,18 @@
     (run %{test}))))
  (libraries masc_test_deps))
 
+; #9629: judge callers (Governance_judge, Operator_judge) added to
+; the OAS bridge SSOT.  Dedicated stanza for the same MASC_BASE_PATH
+; reason as #10094.
+(test
+ (name test_oas_bridge_judge_callers_9629)
+ (modules test_oas_bridge_judge_callers_9629)
+ (action
+  (setenv MASC_BASE_PATH /tmp/test-oas-bridge-judge-callers-9629
+   (setenv MASC_BASE_PATH_INPUT /tmp/test-oas-bridge-judge-callers-9629
+    (run %{test}))))
+ (libraries masc_test_deps))
+
 ; #10115: dedicated stanza so MASC_BASE_PATH is set BEFORE the
 ; test executable loads. Same rationale as #10091/#10097/#10101.
 (test

--- a/test/test_oas_bridge_judge_callers_9629.ml
+++ b/test/test_oas_bridge_judge_callers_9629.ml
@@ -1,0 +1,135 @@
+(* test/test_oas_bridge_judge_callers_9629.ml
+
+   #9629: Governance compute_judgments and Operator compute_judgments
+   were calling [Masc_oas_bridge.run_safe] directly with a timeout
+   resolved from the legacy [Env_config.Inference.{operator,
+   dashboard_governance}_judge_timeout_seconds] readers.  Operator_judge
+   in particular fell back to the 30s global inference timeout — far
+   below the observed p50 of LLM-via-OAS-worker calls — and produced
+   the "Execution timed out after 60.0s" warnings reported in the
+   issue.  Governance_judge had a 300s default but lived outside the
+   per-caller Prometheus counter.
+
+   This test pins:
+
+     1. Both judges resolve to [global_default_sec] (300s) by default,
+        matching the other LLM-via-OAS-worker callers
+        (Auto_responder / Dashboard_provider_runs).
+     2. The legacy per-caller env vars
+        ([MASC_OPERATOR_JUDGE_TIMEOUT_SEC],
+        [MASC_DASHBOARD_GOVERNANCE_JUDGE_TIMEOUT_SEC]) are still
+        honoured as a fallback so operator deployment configs that
+        pin the pre-SSOT names continue to take effect.
+     3. The new per-caller env var
+        ([MASC_OAS_BRIDGE_TIMEOUT_GOVERNANCE_JUDGE_SEC] etc.) beats
+        the legacy env var when both are set — operators migrating
+        to the SSOT do not have to unset the legacy var first.
+     4. The legacy override does not leak into other callers — only
+        the registered judge consumes its alias. *)
+
+let () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-judge-callers-9629-%06x"
+         (Random.bits ()))
+  in
+  Unix.putenv "MASC_BASE_PATH" dir
+
+module Cfg = Env_config_oas_bridge
+
+let legacy_envs =
+  [
+    "MASC_OPERATOR_JUDGE_TIMEOUT_SEC";
+    "MASC_DASHBOARD_GOVERNANCE_JUDGE_TIMEOUT_SEC";
+  ]
+
+let clear_all_envs () =
+  Unix.putenv Cfg.global_env_var "";
+  List.iter
+    (fun caller -> Unix.putenv (Cfg.per_caller_env_var ~caller) "")
+    (Cfg.known_callers ());
+  List.iter (fun name -> Unix.putenv name "") legacy_envs
+
+let test_judge_defaults_match_global () =
+  clear_all_envs ();
+  Alcotest.(check (float 0.0001))
+    "Governance_judge defaults to global_default_sec"
+    Cfg.global_default_sec
+    (Cfg.timeout_sec ~caller:Cfg.Governance_judge ());
+  Alcotest.(check (float 0.0001))
+    "Operator_judge defaults to global_default_sec"
+    Cfg.global_default_sec
+    (Cfg.timeout_sec ~caller:Cfg.Operator_judge ())
+
+let test_legacy_env_honoured_as_fallback () =
+  clear_all_envs ();
+  Unix.putenv "MASC_OPERATOR_JUDGE_TIMEOUT_SEC" "75.0";
+  Unix.putenv "MASC_DASHBOARD_GOVERNANCE_JUDGE_TIMEOUT_SEC" "90.0";
+  Alcotest.(check (float 0.0001))
+    "Operator_judge honours legacy env"
+    75.0
+    (Cfg.timeout_sec ~caller:Cfg.Operator_judge ());
+  Alcotest.(check (float 0.0001))
+    "Governance_judge honours legacy env"
+    90.0
+    (Cfg.timeout_sec ~caller:Cfg.Governance_judge ());
+  clear_all_envs ()
+
+let test_new_env_beats_legacy_env () =
+  clear_all_envs ();
+  Unix.putenv "MASC_OPERATOR_JUDGE_TIMEOUT_SEC" "75.0";
+  Unix.putenv
+    (Cfg.per_caller_env_var ~caller:Cfg.Operator_judge)
+    "55.0";
+  Alcotest.(check (float 0.0001))
+    "new per-caller env wins over legacy env"
+    55.0
+    (Cfg.timeout_sec ~caller:Cfg.Operator_judge ());
+  clear_all_envs ()
+
+let test_legacy_env_does_not_leak_to_other_callers () =
+  clear_all_envs ();
+  Unix.putenv "MASC_OPERATOR_JUDGE_TIMEOUT_SEC" "13.0";
+  Alcotest.(check (float 0.0001))
+    "Tool_deep_review unaffected by Operator_judge legacy env"
+    180.0
+    (Cfg.timeout_sec ~caller:Cfg.Tool_deep_review ());
+  Alcotest.(check (float 0.0001))
+    "Auto_responder unaffected by Operator_judge legacy env"
+    Cfg.global_default_sec
+    (Cfg.timeout_sec ~caller:Cfg.Auto_responder ());
+  clear_all_envs ()
+
+let test_judges_listed_in_known_callers () =
+  let keys =
+    List.map Cfg.caller_key (Cfg.known_callers ())
+  in
+  Alcotest.(check bool)
+    "Governance_judge appears in known_callers"
+    true
+    (List.mem "governance_judge" keys);
+  Alcotest.(check bool)
+    "Operator_judge appears in known_callers"
+    true
+    (List.mem "operator_judge" keys)
+
+let () =
+  Alcotest.run "oas_bridge_judge_callers_9629"
+    [
+      ( "defaults",
+        [
+          Alcotest.test_case "judge defaults match global default"
+            `Quick test_judge_defaults_match_global;
+          Alcotest.test_case "judges listed in known_callers"
+            `Quick test_judges_listed_in_known_callers;
+        ] );
+      ( "legacy_aliases",
+        [
+          Alcotest.test_case "legacy env honoured as fallback"
+            `Quick test_legacy_env_honoured_as_fallback;
+          Alcotest.test_case "new env beats legacy env"
+            `Quick test_new_env_beats_legacy_env;
+          Alcotest.test_case "legacy env does not leak"
+            `Quick test_legacy_env_does_not_leak_to_other_callers;
+        ] );
+    ]


### PR DESCRIPTION
Fixes #9629

## Problem

\`dashboard_governance_judge.compute_judgments\` and \`dashboard_operator_judge.compute_judgments\` were calling \`Masc_oas_bridge.run_safe\` directly, with the timeout resolved from \`Env_config.Inference.{operator,dashboard_governance}_judge_timeout_seconds\`:

| Judge | Pre-fix default | Caller in Prometheus counter? |
|-------|----------------|-------------------------------|
| Operator_judge | **30s** (fell back to \`MASC_INFERENCE_TIMEOUT_SEC\`) | No (legacy \`run_safe\` path) |
| Governance_judge | 300s | No (legacy \`run_safe\` path) |
| Auto_responder, Dashboard_provider_runs (analogous shape) | 300s | Yes (\`Env_config_oas_bridge\`) |

Same shape of call (LLM via OAS worker), asymmetric budgets, both sites missing from the #10094 SSOT — operator could not see in \`metric_oas_bridge_timeout{caller=...}\` which judge was timing out.

The 60s timeout in #9629's symptom was an operator override at the time; the structural problem is the SSOT bypass.

## Change

| File | Change |
|------|--------|
| \`lib/config/env_config_oas_bridge.ml\` | Add \`Governance_judge\` / \`Operator_judge\` typed callers (default \`global_default_sec\` = 300s) + \`legacy_per_caller_env_var\` alias map |
| \`lib/config/env_config_governance.ml\` | Remove the now-unused legacy \`int\` configs; legacy env-var names live on as aliases in the OAS bridge SSOT |
| \`lib/dashboard/dashboard_governance_judge.ml\` | \`run_safe ~timeout_s\` → \`run_with_caller ~caller:Governance_judge\` |
| \`lib/dashboard/dashboard_operator_judge.ml\` | \`run_safe ~timeout_s\` → \`run_with_caller ~caller:Operator_judge\` |
| \`test/test_oas_bridge_judge_callers_9629.ml\` (new) | Pin defaults + legacy alias semantics + leakage isolation |
| \`test/dune\` | Register new test |

## Lookup order (post-fix, per caller)

1. New \`MASC_OAS_BRIDGE_TIMEOUT_<CALLER>_SEC\` env (operator-tunable)
2. **Legacy per-caller alias** (judges only): \`MASC_OPERATOR_JUDGE_TIMEOUT_SEC\`, \`MASC_DASHBOARD_GOVERNANCE_JUDGE_TIMEOUT_SEC\`
3. Per-caller hardcoded default (300s for both judges)
4. \`MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC\` (unknown callers only)
5. \`global_default_sec\` (300s)

Operator deployment configs pinning the pre-SSOT names continue to take effect — no breaking change for the migration window.

## Test plan

- [x] Clean build: \`rm -rf _build && DUNE_CACHE=disabled scripts/dune-local.sh build --cache=disabled\` — green
- [x] \`dune runtest test/test_oas_bridge_judge_callers_9629.exe\` — 5/5 pass
- [x] \`dune runtest test/test_oas_bridge_timeout_ssot_10094.exe\` — 6/6 pass (no regression on the existing #10094 contract)
- [ ] CI green
- [ ] (operational) Verify \`metric_oas_bridge_timeout{caller=\"governance_judge\"}\` and \`{caller=\"operator_judge\"}\` appear in Prometheus after deploy

## Notes

- \`do-not-merge\` label as guard against auto-merge flip until I verify CI signal manually.
- Symmetric default (300s) intentionally — keeping the asymmetry would let one judge silently flap while the other tolerated the same model latency. The operator can still split them via env var.