### PR TITLE
fix(masc-log): align system_log filename to UTC (#10392)

### DIFF
--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -131,6 +131,18 @@ let timestamp_iso () =
     (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
     tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
 
+(** #10392: pure helper that formats the UTC date for filename
+    construction.  Both [Ring.date_string] and the yesterday/cutoff
+    computations in [Ring.load_from_file] / [Ring.cleanup_old_files]
+    feed through this helper so the UTC convention is pinned at a
+    single site.  Exposed for unit tests that need to verify the
+    KST/UTC boundary case (KST midnight = UTC 15:00) without
+    depending on the host clock. *)
+let format_utc_date_of (t : float) =
+  let tm = Unix.gmtime t in
+  Printf.sprintf "%04d-%02d-%02d"
+    (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
+
 (** In-memory ring buffer for dashboard log viewer.
     Fixed capacity, oldest entries evicted on overflow.
     Lock-free: single-writer (log functions), multi-reader (API).
@@ -173,11 +185,7 @@ module Ring = struct
   let file_current_date : string ref = ref ""
   let file_base_dir : string ref = ref ""
 
-  let date_string () =
-    let t = Time_compat.now () in
-    let tm = Unix.localtime t in
-    Printf.sprintf "%04d-%02d-%02d"
-      (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
+  let date_string () = format_utc_date_of (Time_compat.now ())
 
   let log_file_path dir date =
     Filename.concat dir (Printf.sprintf "system_log_%s.jsonl" date)
@@ -277,12 +285,11 @@ module Ring = struct
     ensure_dir dir;
     let today = date_string () in
     (* Load today's and yesterday's logs *)
-    let yesterday =
-      let t = Time_compat.now () -. 86400.0 in
-      let tm = Unix.localtime t in
-      Printf.sprintf "%04d-%02d-%02d"
-        (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
-    in
+    (* #10392: yesterday's filename uses the same UTC convention as
+       [date_string] so [load_from_file] re-reads what was actually
+       written.  Pre-fix this used [Unix.localtime] which on KST hosts
+       loaded a file 9 hours skewed from the today computation. *)
+    let yesterday = format_utc_date_of (Time_compat.now () -. 86400.0) in
     let load_file path =
       if Sys.file_exists path then begin
         let ic = open_in path in
@@ -327,11 +334,13 @@ module Ring = struct
   let cleanup_old_files ?(keep_days = 7) dir =
     if Sys.file_exists dir then begin
       let files = protect ~default:[||] (fun () -> Sys.readdir dir) in
+      (* #10392: cutoff date uses UTC because [date_string] now writes
+         filenames in UTC.  Mixed timezones here would cause [keep_days]
+         retention to be off by ~1 day at the KST/UTC boundary and
+         occasionally delete a file that is still within retention. *)
       let cutoff =
-        let t = Time_compat.now () -. (float_of_int keep_days *. 86400.0) in
-        let tm = Unix.localtime t in
-        Printf.sprintf "%04d-%02d-%02d"
-          (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
+        format_utc_date_of
+          (Time_compat.now () -. (float_of_int keep_days *. 86400.0))
       in
       Array.iter (fun fname ->
         if has_prefix ~prefix:"system_log_" fname

--- a/lib/masc_log/log.mli
+++ b/lib/masc_log/log.mli
@@ -39,6 +39,13 @@ val init_from_env : unit -> unit
 val timestamp : unit -> string
 (** Get current timestamp as formatted string. *)
 
+val format_utc_date_of : float -> string
+(** #10392: format the [YYYY-MM-DD] UTC date for a Unix timestamp.
+    Used internally for [system_log_<date>.jsonl] filename construction
+    so the filename matches the entry [ts] field (also UTC).  Exposed
+    for unit tests; production code calls [Ring.date_string] which
+    delegates here. *)
+
 val log : level -> ?ctx:string -> ('a, unit, string, unit) format4 -> 'a
 (** Log a message at the given level with optional context. *)
 

--- a/test/dune
+++ b/test/dune
@@ -664,6 +664,7 @@
         test_personality_field_diff_10269
         test_toml_skip_dedup_10259
         test_discovery_history_models_10404
+        test_masc_log_utc_filename_10392
         test_keeper_task_dispatch
         test_keeper_tag_dispatch
         test_autoresearch_knowledge
@@ -847,6 +848,7 @@
         test_personality_field_diff_10269
         test_toml_skip_dedup_10259
         test_discovery_history_models_10404
+        test_masc_log_utc_filename_10392
         test_keeper_task_dispatch
         test_keeper_tag_dispatch
         test_autoresearch_knowledge

--- a/test/test_masc_log_utc_filename_10392.ml
+++ b/test/test_masc_log_utc_filename_10392.ml
@@ -1,0 +1,59 @@
+(** #10392: system_log filename used [Unix.localtime] (KST in operator
+    setup) while entries used UTC.  Result: system_log_2026-04-26.jsonl
+    contained only entries dated 2026-04-25T15:xx:xxZ — KST midnight
+    boundary lands at UTC 15:00, so [grep 2026-04-26] hit zero rows in
+    today's file.  These tests pin the now-UTC convention against
+    synthetic timestamps so the regression cannot creep back in via a
+    timezone-naive helper. *)
+
+open Alcotest
+module L = Log
+
+(* 2026-04-25T15:00:00Z = KST 2026-04-26T00:00:00 — this is the exact
+   boundary that pre-fix landed entries in the wrong file. *)
+let kst_midnight_utc = 1777129200.0
+
+(* Sanity: a known UTC instant. *)
+let known_utc = 1777089600.0  (* 2026-04-25T04:00:00Z *)
+
+let test_kst_midnight_lands_in_utc_25 () =
+  check string "KST midnight is still UTC date 2026-04-25"
+    "2026-04-25"
+    (L.format_utc_date_of kst_midnight_utc)
+
+let test_kst_midnight_minus_1s_also_25 () =
+  check string "1 second before KST midnight is also UTC 2026-04-25"
+    "2026-04-25"
+    (L.format_utc_date_of (kst_midnight_utc -. 1.0))
+
+let test_kst_midnight_plus_1s_still_25 () =
+  check string "1 second after KST midnight is still UTC 2026-04-25"
+    "2026-04-25"
+    (L.format_utc_date_of (kst_midnight_utc +. 1.0))
+
+let test_known_utc_morning () =
+  check string "2026-04-25T04:00:00Z formats as 2026-04-25"
+    "2026-04-25"
+    (L.format_utc_date_of known_utc)
+
+let test_utc_day_boundary () =
+  (* 2026-04-26T00:00:00Z = UTC midnight = KST 09:00 same day *)
+  check string "UTC midnight rolls the date over"
+    "2026-04-26"
+    (L.format_utc_date_of (kst_midnight_utc +. 9.0 *. 3600.0))
+
+let () =
+  run "masc_log_utc_filename_10392" [
+    ("utc_filename", [
+        test_case "KST midnight lands in UTC date -1" `Quick
+          test_kst_midnight_lands_in_utc_25;
+        test_case "1s before KST midnight" `Quick
+          test_kst_midnight_minus_1s_also_25;
+        test_case "1s after KST midnight (UTC 15:00:01)" `Quick
+          test_kst_midnight_plus_1s_still_25;
+        test_case "known UTC morning timestamp" `Quick
+          test_known_utc_morning;
+        test_case "UTC midnight rolls forward" `Quick
+          test_utc_day_boundary;
+      ]);
+  ]


### PR DESCRIPTION
## 요약

**Issue**: #10392 — `lib/masc_log/log.ml`이 filename에 `Unix.localtime` (KST), entry timestamp에 `Unix.gmtime` (UTC) 사용. 결과: `system_log_2026-04-26.jsonl`이 전부 `2026-04-25T15:xx:xxZ` entry로 채워짐 (KST 자정 = UTC 15:00 boundary). `grep 2026-04-26 system_log_2026-04-26.jsonl` → 0건 hit.

## Root cause

```
$ jq -r '.ts | .[0:10]' system_log_2026-04-26.jsonl | sort | uniq -c
  69 2026-04-25     ← filename 26, 모든 entry UTC 25
```

3 filename-related 사이트가 `Unix.localtime` 사용:
- `Ring.date_string` (line 181) — today's filename
- `Ring.load_from_file` yesterday (line 285)
- `Ring.cleanup_old_files` cutoff (line 335)

`Dated_jsonl`은 모두 `Unix.gmtime` 일관 사용. 두 ledger system 분기.

## Fix

3 사이트를 single pure helper `format_utc_date_of : float -> string`로 통합:

```ocaml
let format_utc_date_of (t : float) =
  let tm = Unix.gmtime t in
  Printf.sprintf "%04d-%02d-%02d"
    (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
```

| 사이트 | 변경 |
|--------|------|
| `Ring.date_string ()` | `format_utc_date_of (Time_compat.now ())` |
| `Ring.load_from_file` yesterday | `format_utc_date_of (Time_compat.now () -. 86400.0)` |
| `Ring.cleanup_old_files` cutoff | `format_utc_date_of (now -. keep_days * 86400)` |

## 의도적 보존

- `timestamp ()` (line 120): `Unix.localtime` 유지. 이건 stderr console 표시용 (operator-facing human-readable), filename 아님.
- entry `ts` (timestamp_iso): 이미 `Unix.gmtime`. 변동 없음.

## 검증

```text
DUNE_CACHE=disabled dune build --root . --cache=disabled @check
→ EXIT=0

dune exec test/test_masc_log_utc_filename_10392.exe
→ 5/5 OK
  - KST midnight lands in UTC date -1 (1777129200.0 → "2026-04-25")
  - 1s before KST midnight → "2026-04-25"
  - 1s after KST midnight (UTC 15:00:01) → "2026-04-25"
  - known UTC morning timestamp (UTC 04:00) → "2026-04-25"
  - UTC midnight rolls forward (KST 09:00) → "2026-04-26"
```

KST 자정 boundary case가 핵심: 전 case에서 UTC 날짜 일관.

## 영향 (예상)

머지 후 첫 KST 자정에:
- 이전: `system_log_<KST_date>.jsonl` rotation, entries는 UTC인데 file은 KST
- 머지 후: `system_log_<UTC_date>.jsonl` rotation, file과 entry timezone 일치

**Day boundary 1회 transition**: 머지 시점에 따라 한 번 file 이동/병합 노출. 이후 안정.

`grep 2026-04-XX system_log_2026-04-XX.jsonl`이 hit하기 시작 → 외부 도구 (dashboard log viewer, ops scripts) 의도대로 작동.

## Defensive guards

- Draft + `do-not-merge` label
- `gh pr merge --disable-auto`

## 관련

- Issue: `#10392`
- 일관 reference: `Dated_jsonl` (lib/dated_jsonl/dated_jsonl.ml `today_parts`)
- `display timestamp` (line 120): 의도적으로 localtime 보존
