### PR TITLE
perf(judge): SSOT normalize_text in Dashboard_http_helpers

### DIFF
--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -375,9 +375,7 @@ let parse_string_list json key =
              | _ -> None)
   | _ -> []
 
-let normalize_text raw =
-  raw |> String.trim |> String.split_on_char '\n' |> List.map String.trim
-  |> List.filter (fun item -> item <> "") |> String.concat " " |> String.trim
+let normalize_text = Dashboard_http_helpers.normalize_text
 
 let normalize_allowed_tool_name value =
   value |> String.trim |> String.lowercase_ascii

--- a/lib/dashboard/dashboard_http_helpers.ml
+++ b/lib/dashboard/dashboard_http_helpers.ml
@@ -156,3 +156,11 @@ let count_where items predicate =
   List.fold_left
     (fun acc item -> if predicate item then acc + 1 else acc)
     0 items
+
+(** Collapse multi-line text into a single trimmed line, dropping blank
+    rows.  Used by judge modules to normalize LLM output before scoring,
+    so this is the SSOT — Dashboard_governance_judge and
+    Dashboard_operator_judge previously each carried an identical fork. *)
+let normalize_text raw =
+  raw |> String.trim |> String.split_on_char '\n' |> List.map String.trim
+  |> List.filter (fun item -> item <> "") |> String.concat " " |> String.trim

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -82,9 +82,7 @@ let runtime_status base_path =
         last_error = st.last_error;
       })
 
-let normalize_text raw =
-  raw |> String.trim |> String.split_on_char '\n' |> List.map String.trim
-  |> List.filter (fun item -> item <> "") |> String.concat " " |> String.trim
+let normalize_text = Dashboard_http_helpers.normalize_text
 
 let parse_string_list json key =
   match json |> member key with


### PR DESCRIPTION
## Summary

\`Dashboard_governance_judge\` and \`Dashboard_operator_judge\` each carried an *identical* \`normalize_text\` fork — same body, same purpose (collapse multi-line LLM output into a single trimmed line, drop blanks). This PR moves it once into \`Dashboard_http_helpers\` (the existing dashboard-internal SSOT) and aliases both judges to it.

## Behavior preservation

The two forks were byte-identical, so the alias is a no-op semantically.

## Test plan

- [x] \`test_judge_diagnostics\` 5/5
- [x] \`test_judge_json_recovery\` 6/6
- [x] \`test_governance_pipeline\` 87/87
- [x] \`test_governance_yojson_roundtrip\` 9/9

\`test_dashboard_governance\` projection #9 \"approval fiber did not resume\" is a pre-existing flaky test on \`origin/main\` — same failure without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)