### PR TITLE
fix(masc_log): rotate filename on UTC to match entry timestamps (#10392)

### DIFF
--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -176,9 +176,16 @@ module Ring = struct
   let file_current_date : string ref = ref ""
   let file_base_dir : string ref = ref ""
 
+  (* #10392: filename uses UTC so the boundary aligns with the
+     entry timestamps (which are written by [timestamp_iso] as
+     UTC ISO8601, line 130).  Pre-fix the rotation crossed at
+     KST 00:00:00 (= UTC 15:00:00), so [system_log_2026-04-26.jsonl]
+     held entries dated [2026-04-25T15:xx:xxZ] — date-grep on
+     the filename returned 0 hits.  Aligns with [Dated_jsonl]
+     which already rotates on UTC. *)
   let date_string () =
     let t = Time_compat.now () in
-    let tm = Unix.localtime t in
+    let tm = Unix.gmtime t in
     Printf.sprintf "%04d-%02d-%02d"
       (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
 
@@ -279,10 +286,13 @@ module Ring = struct
   let load_from_file dir =
     ensure_dir dir;
     let today = date_string () in
-    (* Load today's and yesterday's logs *)
+    (* Load today's and yesterday's logs.  #10392: must use UTC
+       so the [yesterday] computation lines up with the UTC
+       filename produced by [date_string]; otherwise the lookup
+       lands on a file the writer never created. *)
     let yesterday =
       let t = Time_compat.now () -. 86400.0 in
-      let tm = Unix.localtime t in
+      let tm = Unix.gmtime t in
       Printf.sprintf "%04d-%02d-%02d"
         (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
     in
@@ -331,8 +341,13 @@ module Ring = struct
     if Sys.file_exists dir then begin
       let files = protect ~default:[||] (fun () -> Sys.readdir dir) in
       let cutoff =
+        (* #10392: must use UTC so the cutoff string lexically
+           compares against the UTC-named files produced by
+           [date_string].  Pre-fix the localtime cutoff drifted
+           by up to 9 hours from the filename TZ, intermittently
+           skipping or doubly-deleting boundary days. *)
         let t = Time_compat.now () -. (float_of_int keep_days *. 86400.0) in
-        let tm = Unix.localtime t in
+        let tm = Unix.gmtime t in
         Printf.sprintf "%04d-%02d-%02d"
           (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
       in
@@ -416,6 +431,10 @@ module Ring = struct
       ("total", `Int (Atomic.get total));
       ("entries", `List (List.map entry_to_json entries));
     ]
+
+  module For_testing = struct
+    let date_string = date_string
+  end
 end
 
 (** Log a message at given level with optional context *)

--- a/lib/masc_log/log.mli
+++ b/lib/masc_log/log.mli
@@ -90,6 +90,13 @@ module Ring : sig
 
   val cleanup_old_files : ?keep_days:int -> string -> unit
   (** Remove log files older than [keep_days] (default 7). *)
+
+  module For_testing : sig
+    val date_string : unit -> string
+    (** UTC date string ([YYYY-MM-DD]) used for the current
+        [system_log_<date>.jsonl] filename.  Exposed so tests
+        can pin the boundary against the entry-timestamp TZ. *)
+  end
 end
 
 val client_tool_host_error :

--- a/test/dune
+++ b/test/dune
@@ -1377,6 +1377,11 @@
  (modules test_dated_jsonl)
  (libraries dated_jsonl fs_compat alcotest eio eio_main yojson unix))
 
+(test
+ (name test_log_filename_utc_10392)
+ (modules test_log_filename_utc_10392)
+ (libraries masc_log time_compat alcotest unix))
+
 ; ============================================================
 ; Special: Heartbeat/keeper minimal deps
 ; ============================================================

--- a/test/test_log_filename_utc_10392.ml
+++ b/test/test_log_filename_utc_10392.ml
@@ -1,0 +1,82 @@
+(** #10392 — pin the system_log filename TZ to UTC so it matches
+    the entry timestamps written by [Log.timestamp_iso].
+
+    Pre-fix [Ring.date_string] returned a KST localtime date,
+    while every JSONL [.ts] field was UTC ISO8601 written by
+    [timestamp_iso] (line 130).  At KST 09:00 the rotation crossed
+    days while the entry timestamps had already advanced 9 h
+    earlier, so [system_log_2026-04-26.jsonl] held lines tagged
+    [2026-04-25T15:xx:xxZ] — date-grep on the filename returned
+    zero hits and the cross-correlation with [Dated_jsonl]
+    (UTC throughout) broke.
+
+    Tests pin:
+
+    1. [Ring.For_testing.date_string ()] is identical to a fresh
+       [Unix.gmtime (Time_compat.now ())] formatted the same way
+       — i.e. the writer follows UTC, not localtime.
+    2. The boundary held under a +9 h forced offset so localtime
+       and UTC differ in date — verifying the writer doesn't
+       fall back to [Unix.localtime] when the TZ environment
+       implies KST. *)
+
+open Alcotest
+
+module L = Log
+
+let format_utc_now () =
+  let t = Time_compat.now () in
+  let tm = Unix.gmtime t in
+  Printf.sprintf "%04d-%02d-%02d"
+    (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
+
+(* --- 1. date_string == UTC formatted now ---------------- *)
+
+let test_date_string_matches_utc_now () =
+  let expected = format_utc_now () in
+  let actual = L.Ring.For_testing.date_string () in
+  (* If the test crosses a UTC midnight between the two reads
+     (extremely unlikely in <1 ms), accept either neighbour. *)
+  if actual = expected then check string "matches UTC now" expected actual
+  else
+    let neighbour =
+      let t = Time_compat.now () +. 0.001 in
+      let tm = Unix.gmtime t in
+      Printf.sprintf "%04d-%02d-%02d"
+        (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
+    in
+    check bool
+      (Printf.sprintf "matches UTC neighbour (got %s, expected %s or %s)"
+         actual expected neighbour)
+      true (actual = neighbour)
+
+(* --- 2. KST TZ override does not bend the writer to localtime --- *)
+
+let with_env name value f =
+  let saved = try Some (Sys.getenv name) with Not_found -> None in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match saved with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
+let test_kst_env_does_not_shift_filename () =
+  with_env "TZ" "Asia/Seoul" @@ fun () ->
+  let expected = format_utc_now () in
+  let actual = L.Ring.For_testing.date_string () in
+  check string "TZ=Asia/Seoul does not shift the writer to KST"
+    expected actual
+
+let () =
+  run "log_filename_utc_10392"
+    [
+      ( "utc-rotation",
+        [
+          test_case "date_string returns UTC date" `Quick
+            test_date_string_matches_utc_now;
+          test_case "KST TZ env does not bend writer" `Quick
+            test_kst_env_does_not_shift_filename;
+        ] );
+    ]

--- a/test/test_masc_log.ml
+++ b/test/test_masc_log.ml
@@ -16,8 +16,10 @@ let rm_rf dir =
   in
   try rm dir with _ -> ()
 
+(* #10392: writer rotates on UTC so the expected filename
+   must compute the date with [Unix.gmtime], not localtime. *)
 let today_log_path dir =
-  let tm = Unix.localtime (Unix.gettimeofday ()) in
+  let tm = Unix.gmtime (Unix.gettimeofday ()) in
   Filename.concat dir
     (Printf.sprintf "system_log_%04d-%02d-%02d.jsonl"
        (tm.Unix.tm_year + 1900)


### PR DESCRIPTION
Closes #10392 (option A: UTC unification). Pre-fix Ring.date_string used Unix.localtime so the system_log filename rotated at KST 00:00 while every entry .ts field was UTC ISO8601 from timestamp_iso. system_log_2026-04-26.jsonl held entries dated 2026-04-25T15:xx:xxZ — date-grep on the filename returned 0 hits and cross-correlation with Dated_jsonl (UTC throughout) drifted 9 h. Three filename-side calls switched to Unix.gmtime (date_string, yesterday loader, cleanup_old_files cutoff). stdout timestamp() and dashboard generate() keep localtime — those are human display, not file boundaries. Ring.For_testing.date_string exposed for contract pinning. 2 new + 8 test_masc_log + 3 test_error_logging_coverage all green.