### PR TITLE
fix(keeper-config): reject cascade_name with keeper_assignable=false (#10388)

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -668,24 +668,42 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
                     List.sort_uniq String.compare
                       (reserved_cascade_names @ catalog)
                   in
-                  if List.mem normalized all_valid then Ok ()
-                  else
-                    let suffix =
-                      match source with
-                      | Keeper_cascade_profile.Live_catalog -> ""
-                      | Keeper_cascade_profile.Toml_section_fallback
-                          { catalog_error } ->
-                          Printf.sprintf
-                            " [degraded toml-section fallback; live \
-                             catalog unavailable: %s]"
-                            catalog_error
-                    in
+                  let suffix =
+                    match source with
+                    | Keeper_cascade_profile.Live_catalog -> ""
+                    | Keeper_cascade_profile.Toml_section_fallback
+                        { catalog_error } ->
+                        Printf.sprintf
+                          " [degraded toml-section fallback; live \
+                           catalog unavailable: %s]"
+                          catalog_error
+                  in
+                  if not (List.mem normalized all_valid) then
                     Error
                       (Printf.sprintf
                          "invalid cascade_name '%s' (known: %s)%s"
                          raw
                          (String.concat ", " all_valid)
                          suffix)
+                  (* #10388: keeper_assignable=false cascades must reject
+                     at config-load to avoid runtime reconcile failures. *)
+                  else if Keeper_cascade_profile.is_system_only_cascade normalized
+                  then
+                    let assignable =
+                      Keeper_cascade_profile.keeper_catalog_names ()
+                    in
+                    let assignable_hint =
+                      if assignable = [] then "(none)"
+                      else String.concat ", " assignable
+                    in
+                    Error
+                      (Printf.sprintf
+                         "cascade_name '%s' is system-only \
+                          (keeper_assignable=false); keepers must \
+                          reference an assignable cascade. \
+                          Assignable: %s"
+                         raw assignable_hint)
+                  else Ok ()
               | Error fallback_error ->
                   Error
                     (Printf.sprintf

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -195,13 +195,17 @@ keeper_assignable = false
 let test_cascade_name_accepts_catalog_entry () =
   (* "tool_use_strict" is a known catalog entry in cascade.json,
      distinct from compile-time variants.  Tests that the live catalog
-     is consulted during validation. *)
+     is consulted during validation.
+
+     #10388: must filter out system-only ([keeper_assignable=false])
+     entries — the validator now rejects those, and a real-catalog
+     entry like [cross_verifier] is system-only. *)
   let catalog =
-    try Masc_mcp.Keeper_cascade_profile.catalog_names ()
+    try Masc_mcp.Keeper_cascade_profile.keeper_catalog_names ()
     with _ -> []
   in
   let test_name =
-    (* Pick a catalog entry that is NOT a compile-time variant *)
+    (* Pick an assignable catalog entry that is NOT a compile-time variant *)
     match
       List.find_opt
         (fun n ->
@@ -224,6 +228,66 @@ let test_cascade_name_accepts_catalog_entry () =
       (* If catalog is unavailable, skip rather than fail *)
       if catalog = [] then ()
       else fail (Printf.sprintf "%s should be accepted: %s" test_name e)
+
+(** #10388: keepers must not reference cascades flagged
+    [keeper_assignable=false].  Pre-fix the validator only checked
+    catalog membership; system-only cascades (e.g. [tool_use_strict])
+    passed and the keeper failed every reconcile tick at runtime
+    (4 keepers / 59 events/day on 2026-04-25). *)
+let test_cascade_name_rejects_system_only () =
+  with_config_dir
+    {|
+[everyday_assignable]
+models = ["ollama:auto"]
+keeper_assignable = true
+
+[system_only_lane]
+models = ["ollama:auto"]
+keeper_assignable = false
+|}
+    (fun _dir ->
+      let result =
+        with_temp_toml
+          "[keeper]\nname = \"testkeeper\"\ncascade_name = \"system_only_lane\"\n"
+          KTP.load_keeper_toml
+      in
+      match result with
+      | Ok _ -> fail "system-only cascade_name should be rejected"
+      | Error e ->
+          check bool "error mentions system-only" true
+            (contains ~needle:"system-only" e);
+          check bool "error mentions keeper_assignable" true
+            (contains ~needle:"keeper_assignable=false" e);
+          check bool "error lists assignable subset" true
+            (contains ~needle:"everyday_assignable" e))
+
+let test_cascade_name_accepts_assignable_after_system_only_added () =
+  (* Sanity: the new gate must not regress assignable cascades when a
+     sibling profile happens to be system-only. *)
+  with_config_dir
+    {|
+[everyday_assignable]
+models = ["ollama:auto"]
+keeper_assignable = true
+
+[system_only_lane]
+models = ["ollama:auto"]
+keeper_assignable = false
+|}
+    (fun _dir ->
+      let result =
+        with_temp_toml
+          "[keeper]\nname = \"testkeeper\"\ncascade_name = \"everyday_assignable\"\n"
+          KTP.load_keeper_toml
+      in
+      match result with
+      | Ok _ -> ()
+      | Error e ->
+          fail
+            (Printf.sprintf
+               "everyday_assignable (keeper_assignable=true) should be \
+                accepted: %s"
+               e))
 
 let test_tool_preset_accepts_dispatch () =
   let result =
@@ -316,6 +380,10 @@ let () =
             test_cascade_name_error_lists_live_catalog;
           test_case "accepts catalog entry (legacy alias)" `Quick
             test_cascade_name_accepts_catalog_entry;
+          test_case "rejects system-only cascade (keeper_assignable=false)"
+            `Quick test_cascade_name_rejects_system_only;
+          test_case "accepts assignable when system-only sibling exists"
+            `Quick test_cascade_name_accepts_assignable_after_system_only_added;
           test_case "accepts dispatch tool_preset" `Quick
             test_tool_preset_accepts_dispatch;
         ] );


### PR DESCRIPTION
## 요약

**Issue**: #10388 — `config/keepers/*.toml` 4 keeper가 `cascade_name`으로 `keeper_assignable=false`로 명시된 cascade 참조. 결과: 매 reconcile cycle reject + 일별 59 invalid-profile ERROR (전체 fleet ERROR의 33.7%).

| Keeper | cascade_name | keeper_assignable | 상태 |
|--------|--------------|-------------------|------|
| masc-improver | tool_use_strict | false | 매 cycle reject |
| sangsu | tool_use_strict | false | 매 cycle reject |
| ramarama | local_only | false | 매 cycle reject |
| ollama-local | local_only | false | 매 cycle reject |

## Fix scope (옵션 A only)

이슈의 4 옵션 중 가장 surgical:

| 옵션 | 이 PR |
|------|-------|
| **A — Schema validation at load time** | ✅ |
| B — ollama-aware turn timeout | ❌ (cascade.toml 정책 결정 필요) |
| C — 5 keeper의 cascade_name 명시 | ❌ (config TOML 변경, 별도) |
| D — `local_only` 정책 명확화 | ❌ (의도 결정 필요) |

## 변경

`Keeper_types_profile`의 cascade_name validator (lib/keeper/keeper_types_profile.ml:660-680):

```ocaml
match Keeper_cascade_profile.catalog_names_result () with
| Ok catalog ->
    let all_valid = ... in
    if not (List.mem normalized all_valid) then
      Error "invalid cascade_name '%s' (known: %s)" raw all_valid
+   (* #10388: catalog membership alone is insufficient. *)
+   else if Keeper_cascade_profile.is_system_only_cascade normalized then
+     let assignable = Keeper_cascade_profile.keeper_catalog_names () in
+     Error "cascade_name '%s' is system-only (keeper_assignable=false); \
+            keepers must reference an assignable cascade. Assignable: %s"
+           raw (String.concat ", " assignable)
    else Ok ()
```

`is_system_only_cascade`와 `keeper_catalog_names`는 이미 `Keeper_cascade_profile`에 존재하지만 keeper config path에서 unused 상태였음. 이 PR이 그 gap을 메움.

## 검증

```text
DUNE_CACHE=disabled dune build --root . --cache=disabled @check
→ EXIT=0

dune exec test/test_keeper_toml_config_validation.exe
→ 13/13 OK
신규:
  - rejects system-only cascade (keeper_assignable=false)
  - accepts assignable when system-only sibling exists
기존 보정:
  - accepts catalog entry (legacy alias) — keeper_catalog_names로 변경
    (실제 catalog가 cross_verifier 등 system-only entry 포함)
```

## 영향 (예상)

머지 후 다음 keeper config reload:
- 4 violation keeper config가 load-time에 reject → operator 즉시 인지
- 매 cycle 발생하던 59 invalid-profile ERROR/day 차단
- 4 keeper의 cascade_name이 assignable subset로 수정될 때까지 keeper 진입 차단 (intentional)

config TOML 정정 작업 (옵션 C/D)은 별도 follow-up. 이 PR은 *gate*만 추가.

## error message 디자인

```
cascade_name 'tool_use_strict' is system-only \
(keeper_assignable=false); keepers must reference an \
assignable cascade. Assignable: big_three, ollama_only, ...
```

- system-only 표현 + 명확한 reason
- assignable subset을 함께 출력 → operator가 어느 cascade로 바꿔야 할지 즉시 인지

## Defensive guards

- Draft + `do-not-merge` label
- `gh pr merge --disable-auto`

## 관련

- Issue: `#10388`
- 인접: `#10259` (cascade materializer silent fail — 같은 config drift class), `#10314` (accountability silent — 4 reject keeper가 ledger에서 사라지는 mirror)
- 미해결 옵션 (별도 PR): 옵션 B (ollama turn timeout), C (5 keeper cascade_name 명시), D (local_only 정책)
- 패턴: `Keeper_cascade_profile.is_system_only_cascade` + `keeper_catalog_names` 재사용
