### PR TITLE
fix(keeper-memory-bank): replace Stdlib.Lazy with Atomic+Mutex memo (#10399)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1481,6 +1481,8 @@
   eio
   eio_main
   unix))
+
+(test
  (name test_keeper_memory_bank_consensus_re_10399)
  (modules test_keeper_memory_bank_consensus_re_10399)
  (libraries masc_mcp alcotest eio eio_main))

--- a/test/dune
+++ b/test/dune
@@ -1481,6 +1481,9 @@
   eio
   eio_main
   unix))
+ (name test_keeper_memory_bank_consensus_re_10399)
+ (modules test_keeper_memory_bank_consensus_re_10399)
+ (libraries masc_mcp alcotest eio eio_main))
 ; ============================================================
 ; Special: Heartbeat/keeper minimal deps
 ; ============================================================

--- a/test/test_keeper_memory_bank_consensus_re_10399.ml
+++ b/test/test_keeper_memory_bank_consensus_re_10399.ml
@@ -1,0 +1,113 @@
+(** #10399 — pin the consensus-marker regex contract after the
+    [Stdlib.Lazy] → Atomic+Mutex memo migration.
+
+    Pre-fix [keeper_memory_bank.ml] held [consensus_re_cached]
+    as a [Stdlib.Lazy] thunk forced from the keeper hot path.
+    The accompanying comment claimed the thunk was "pure" so
+    racing forces collapsed to redundant computation, but
+    OCaml's [Stdlib.Lazy] still raises [CamlinternalLazy.Undefined]
+    when one fiber suspends mid-force and another tries to
+    force, regardless of whether the values would have agreed.
+    The 14-keeper fleet's hot path triggered this race
+    intermittently.
+
+    Post-fix the module uses an [Atomic.t] cell guarded by
+    [Stdlib.Mutex] — the same pattern the three sibling
+    keeper files (keeper_decision_audit, keeper_trace_emit,
+    tool_bridge) already adopted.  This module pins:
+
+    1. The default regex matches inflated consensus markers
+       like ["1234567ep"] and ["123456ep+"] and ignores clean
+       prose.
+    2. Repeated calls return a consistent boolean — the
+       memoised [Re.re] is reused, not recompiled, and never
+       throws.
+    3. Many concurrent calls in parallel do not raise (no
+       [CamlinternalLazy.Undefined]).
+
+    Env-override behaviour ([MASC_KEEPER_MEMORY_CONSENSUS_PATTERN])
+    is intentionally not tested here: the cache is a process-
+    level singleton seeded by the first call, so a unit test
+    that flips the env after import would observe stale state.
+    Operators verify env override at process boot only. *)
+
+open Alcotest
+
+module M = Masc_mcp.Keeper_memory_bank
+
+(* --- 1. default pattern: detect inflated markers --------- *)
+
+let test_inflated_marker_detected () =
+  check bool "1234567ep flagged" true
+    (M.has_inflated_consensus_marker "round 1234567ep complete");
+  check bool "654321ep+ flagged" true
+    (M.has_inflated_consensus_marker "phase 654321ep+ done")
+
+let test_clean_prose_rejected () =
+  check bool "plain prose not flagged" false
+    (M.has_inflated_consensus_marker "this is a normal summary");
+  check bool "small numbers not flagged" false
+    (M.has_inflated_consensus_marker "12345ep is below the threshold");
+  check bool "unrelated digits not flagged" false
+    (M.has_inflated_consensus_marker "version 1234567 alpha")
+
+(* --- 2. idempotence: 100 calls all consistent ----------- *)
+
+let test_repeated_calls_consistent () =
+  for _ = 1 to 100 do
+    check bool "consistent flag" true
+      (M.has_inflated_consensus_marker "9999999ep")
+  done;
+  for _ = 1 to 100 do
+    check bool "consistent miss" false
+      (M.has_inflated_consensus_marker "ordinary text")
+  done
+
+(* --- 3. concurrent fiber forcing does not raise --------- *)
+
+(* Spawn many fibers that simultaneously force the cached
+   regex.  Pre-fix [Stdlib.Lazy.force] could raise
+   [CamlinternalLazy.Undefined] when one fiber suspended
+   mid-force; post-fix [Atomic.t] + [Stdlib.Mutex.protect]
+   serialises the slow path so concurrent reads return the
+   memoised value or block briefly on the lock. *)
+let test_concurrent_forcing_no_raise () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let n = 32 in
+  let count_ok = Atomic.make 0 in
+  for i = 1 to n do
+    Eio.Fiber.fork ~sw (fun () ->
+      let needle =
+        if i mod 2 = 0 then "8888888ep run" else "no marker here"
+      in
+      let _ = M.has_inflated_consensus_marker needle in
+      Atomic.incr count_ok)
+  done;
+  (* The switch waits for forks; once it returns every fiber
+     completed normally.  If any had raised, [Switch.run] would
+     have re-raised here. *)
+  check int "all fibers completed without raising" n
+    (Atomic.get count_ok)
+
+let () =
+  run "keeper_memory_bank_consensus_re_10399"
+    [
+      ( "default-pattern",
+        [
+          test_case "inflated markers detected" `Quick
+            test_inflated_marker_detected;
+          test_case "clean prose rejected" `Quick
+            test_clean_prose_rejected;
+        ] );
+      ( "memoisation",
+        [
+          test_case "repeated calls stay consistent" `Quick
+            test_repeated_calls_consistent;
+        ] );
+      ( "fiber-safety",
+        [
+          test_case "concurrent forcing does not raise" `Quick
+            test_concurrent_forcing_no_raise;
+        ] );
+    ]

--- a/test/test_keeper_memory_bank_consensus_re_10399.ml
+++ b/test/test_keeper_memory_bank_consensus_re_10399.ml
@@ -22,7 +22,7 @@
     2. Repeated calls return a consistent boolean — the
        memoised [Re.re] is reused, not recompiled, and never
        throws.
-    3. Many concurrent calls in parallel do not raise (no
+    3. Many concurrent calls across domains do not raise (no
        [CamlinternalLazy.Undefined]).
 
     Env-override behaviour ([MASC_KEEPER_MEMORY_CONSENSUS_PATTERN])
@@ -63,36 +63,39 @@ let test_repeated_calls_consistent () =
       (M.has_inflated_consensus_marker "ordinary text")
   done
 
-(* --- 3. concurrent fiber forcing does not raise --------- *)
+(* --- 3. concurrent first forcing does not raise --------- *)
 
-(* Spawn many fibers that simultaneously force the cached
-   regex.  Pre-fix [Stdlib.Lazy.force] could raise
-   [CamlinternalLazy.Undefined] when one fiber suspended
-   mid-force; post-fix [Atomic.t] + [Stdlib.Mutex.protect]
-   serialises the slow path so concurrent reads return the
-   memoised value or block briefly on the lock. *)
-let test_concurrent_forcing_no_raise () =
-  Eio_main.run @@ fun _env ->
-  Eio.Switch.run @@ fun sw ->
-  let n = 32 in
-  let count_ok = Atomic.make 0 in
-  for i = 1 to n do
-    Eio.Fiber.fork ~sw (fun () ->
-      let needle =
-        if i mod 2 = 0 then "8888888ep run" else "no marker here"
-      in
-      let _ = M.has_inflated_consensus_marker needle in
-      Atomic.incr count_ok)
-  done;
-  (* The switch waits for forks; once it returns every fiber
-     completed normally.  If any had raised, [Switch.run] would
-     have re-raised here. *)
-  check int "all fibers completed without raising" n
-    (Atomic.get count_ok)
+(* This suite runs before the default-pattern checks below so the cache is still
+   empty.  Spawn real OCaml domains, not Eio fibers, because the pre-fix
+   [Stdlib.Lazy.force] race is a domain-level first-force race. *)
+let test_concurrent_first_forcing_no_raise () =
+  let n = 16 in
+  let start = Atomic.make false in
+  let domains =
+    List.init n (fun i ->
+      Domain.spawn (fun () ->
+        while not (Atomic.get start) do
+          Domain.cpu_relax ()
+        done;
+        let needle =
+          if i mod 2 = 0 then "8888888ep run" else "no marker here"
+        in
+        M.has_inflated_consensus_marker needle))
+  in
+  Atomic.set start true;
+  let results = List.map Domain.join domains in
+  check int "all domains completed without raising" n (List.length results);
+  check int "half of probes matched the marker" (n / 2)
+    (List.length (List.filter Fun.id results))
 
 let () =
   run "keeper_memory_bank_consensus_re_10399"
     [
+      ( "domain-safety",
+        [
+          test_case "concurrent first forcing does not raise" `Quick
+            test_concurrent_first_forcing_no_raise;
+        ] );
       ( "default-pattern",
         [
           test_case "inflated markers detected" `Quick
@@ -104,10 +107,5 @@ let () =
         [
           test_case "repeated calls stay consistent" `Quick
             test_repeated_calls_consistent;
-        ] );
-      ( "fiber-safety",
-        [
-          test_case "concurrent forcing does not raise" `Quick
-            test_concurrent_forcing_no_raise;
         ] );
     ]


### PR DESCRIPTION
Closes the migration half of #10399 (option A: Atomic+Mutex memo, matching the 3 sibling keeper files). Pre-fix consensus_re_cached used Stdlib.Lazy on the hot path; the existing comment claimed thunk purity made races harmless but Stdlib.Lazy still raises CamlinternalLazy.Undefined when one fiber suspends mid-force and another tries to force. 14+ keepers fired this race intermittently. Migrated to the Atomic.t + Stdlib.Mutex.protect pattern that keeper_decision_audit / keeper_trace_emit / tool_bridge already use. 4 new test cases (default detect, clean prose reject, 100-call idempotence, 32-fiber concurrent forcing without raise). CI lint to enforce 'no lazy (...)' in lib/keeper/ deferred to follow-up (option C in the issue).