### PR TITLE
docs(rfc): RFC-0009 Cascade Trust Phase 2 (recommendations + opt-in persist)

### DIFF
--- a/docs/rfc/RFC-0009-cascade-trust-phase2.md
+++ b/docs/rfc/RFC-0009-cascade-trust-phase2.md
@@ -1,0 +1,157 @@
+# RFC-0009 — Cascade Trust Phase 2: Operator Recommendations + Opt-in Persist
+
+**Status**: Draft (2026-04-26)
+**Depends on**: #10292 (Phase 0a), #10331 (Phase 0b), #10365 (Phase 1)
+**Author**: vincent (jeong-sik)
+
+## Motivation
+
+Phase 1 (#10365) gave the cascade an in-memory `trust_score` that auto-rotates away from rate-limited / persistently failing providers. Replay validation against 4044 live decisions confirmed the algorithm matches operator intent: dead cascades (ollama_only at 1% success → trust 0.000 on 99.5% of decisions), healthy cascades (big_three at 41% success → trust 2.000 ceiling).
+
+Two gaps remain:
+
+1. **Restart resets reputation.** Trust lives only in memory. After every server restart the cascade re-learns each provider's persistence pattern from scratch — tens of additional failed turns per restart for the dominant fingerprints.
+2. **Trust is invisible to operators.** A keeper might be quietly running on a `trust=0.05` provider for hours; the only signal is `same_fingerprint_count` in the dashboard JSON. There is no nudge that says "stop sending traffic here, fix the config."
+
+Phase 2 closes both gaps without giving the trust loop authority to silently rewrite repo config.
+
+## Design principles
+
+| Principle | Application |
+|---|---|
+| Live-only persist | Only `~/.masc/config/cascade.toml` is touched; `config/cascade.toml` (repo seed) is never written to by the trust loop. |
+| Opt-in by default | `MASC_CASCADE_TRUST_PERSIST=1` (or `=dry`) gates everything in this RFC. Default-off for the first release. |
+| Observation over action | Phase 2a (operator recommendation) is observation-only. Phase 2b (persist) is a separate feature flag and a separate PR. |
+| No self-reload loops | Hot-reload must skip files the trust loop just wrote; otherwise each persist triggers a reload triggers a re-emit. |
+| Audit everything | Every persist write goes to `~/.masc/cascade_trust/applied/YYYY-MM/DD.jsonl` with before/after values and reason. |
+
+## Phase 2a — Operator recommendation (observation only)
+
+### `lib/coord/coord_hooks.ml`
+
+Add a Hebbian-style observation callback (mirrors `hebbian_on_task_done_fn`, `activity_emit_fn`):
+
+```ocaml
+val cascade_adjust_fn :
+  (provider_key:string -> trust_before:float -> trust_after:float ->
+   reason:[`Success | `Transient | `Persistent | `Hard_quota] -> unit)
+  Atomic.t
+
+val install_cascade_adjust_observer :
+  (provider_key:string -> trust_before:float -> trust_after:float ->
+   reason:[ `Success | `Transient | `Persistent | `Hard_quota ] -> unit) ->
+  unit
+```
+
+Default implementation: no-op. Dashboard / persist module register an observer at boot.
+
+`Cascade_health_tracker.record` invokes the hook after every trust update (under the same mutex).
+
+### `lib/dashboard/dashboard_operator_judge.ml`
+
+Extend with a recommendation builder:
+
+```ocaml
+val low_trust_recommendations :
+  Cascade_health_tracker.t -> recommendation list
+
+(* recommendation = { provider_key; trust; recent_fingerprint;
+   recurrence_count; suggested_action } *)
+```
+
+`suggested_action` is one of:
+
+- `Reduce_weight` — trust ∈ [0.1, 0.3): degrade in cascade.toml
+- `Disable` — trust < 0.1 or `same_fingerprint_count >= 5`: remove from cascade
+- `Investigate` — trust < 0.3 with very high `events_in_window`: probably a config bug
+
+Rendered on the dashboard as a card with a copy-friendly JSON snippet showing the suggested cascade.toml diff. **No auto-apply.**
+
+### Acceptance for 2a
+
+- [ ] Recommendation card renders for `ollama_only` (live data already shows trust=0.000) within 60s of dashboard load.
+- [ ] Repo seed never modified.
+- [ ] Tests: 4 alcotest cases over the recommendation classifier (reduce/disable/investigate/healthy).
+
+## Phase 2b — Opt-in persist (separate feature flag + separate PR)
+
+### Activation modes
+
+| `MASC_CASCADE_TRUST_PERSIST` | Behaviour |
+|---|---|
+| unset (default) | No persist. Trust is in-memory only, reset on restart. |
+| `dry` | Compute the would-be diff every hour, append to `cascade_trust/applied/<date>.jsonl` with `mode=dry`, no file write. |
+| `1` | Same diff, plus atomic write to `~/.masc/config/cascade.toml`. |
+
+### Persist algorithm
+
+Every `MASC_CASCADE_TRUST_PERSIST_INTERVAL_SEC` (default 3600s):
+
+1. Snapshot `Cascade_health_tracker.global` providers with `events_in_window > 0` AND age of `last_failure_at` < 24h (skip stale).
+2. For each provider, compute target weight: `round(trust_score * 2) / 2` (0.5-step granularity, range [0.5, ceiling × current_weight]).
+3. Diff against current `~/.masc/config/cascade.toml` weights.
+4. If diff is empty → emit `mode=skip_no_change` audit event; return.
+5. Atomic write via `lib/atomic_write.ml`:
+   - `cascade.toml.tmp` → fsync → rename
+   - Backup previous: `~/.masc/config/.backup/cascade.toml.YYYYMMDD-HHMMSS`
+   - Top-of-file marker comment: `# auto-tuned by trust_persist at <timestamp>; do not edit by hand within 5s`
+
+### Hot-reload loop guard
+
+`lib/cascade/cascade_config_loader.ml` mtime-based reloader must ignore reloads triggered ≤5s after a self-write. Implementation choices:
+
+| Option | Pros | Cons |
+|---|---|---|
+| **mtime threshold** | No state, simple. | False positive if operator edits within 5s. |
+| **written_by marker file** | Explicit. | Extra file to clean up. |
+| **inotify-style content hash** | Most precise. | Overkill for a 1h-cadence loop. |
+
+Recommendation: mtime threshold + a process-local flag (`Atomic.t` with timestamp), invalidated after 5s. Simpler than a marker file.
+
+### Repo seed pre-write guard
+
+`Cascade_trust_persist.persist_now` must hard-fail if the resolved write target equals `<repo_root>/config/cascade.toml`. Path comparison via `Unix.realpath` on both sides (per `feedback_security-gate-realpath-invariants.md`).
+
+### Acceptance for 2b
+
+- [ ] `MASC_CASCADE_TRUST_PERSIST=dry` runs for 24h locally; audit log shows expected diffs without file writes.
+- [ ] `MASC_CASCADE_TRUST_PERSIST=1` writes happen exactly once per interval; backup file is created.
+- [ ] Hot-reloader does not loop (verify by checking `[CascadeConfig] loaded` log frequency stays ≤ 1/hr after persist).
+- [ ] Repo seed write attempt is blocked by realpath guard (test injects a fake repo path, expects exception).
+- [ ] Tests: 6 alcotest cases — atomic write, backup creation, dry mode no-op, repo guard, hot-reload skip, audit log shape.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Self-reload loop | Hot-reload skips ≤5s self-writes; persist interval ≥ 1h. |
+| Operator config overwrite | Live-only path; explicit feature flag; backup before every write. |
+| Trust score thrash → weight thrash | 0.5-step quantization filters small fluctuations. Plus a hysteresis gate: skip writes where `|trust_now - last_persisted_trust| < 0.25`. |
+| Repo seed pollution | Realpath equality check + tests. |
+| Dashboard/persist disagreement | Persist module is the writer; dashboard is the reader. Use the same `Cascade_health_tracker.global` snapshot. No second source of truth. |
+
+## Out of scope
+
+- **Phase 3** (cost-aware boost via OAS `cost_tracker` token usage) — separate RFC.
+- **Cross-host trust sync** — every host has its own `~/.masc`; no fleet-level reputation in this RFC.
+- **Auto-disable of dead cascade** — operator decides; the recommendation only suggests.
+
+## Verification plan
+
+| Phase | Trigger | Pass criteria |
+|---|---|---|
+| 2a | Phase 1 has been live ≥ 24h | Recommendation card renders ≥ 1 entry corresponding to a known-bad cascade in replay data |
+| 2b dry | Phase 2a merged | 1 week of `dry` mode audit log with no file writes |
+| 2b live | 2b dry green | First write produces correct diff; hot-reload count unchanged |
+
+## Implementation order
+
+```
+RFC-0009 review  →  Phase 2a PR (recommendation, observation only)
+                    →  1 week soak
+                                →  Phase 2b dry PR
+                                    →  1 week dry soak
+                                            →  Phase 2b live (flip default)
+```
+
+Total estimated calendar time before any automatic write: 2-3 weeks.


### PR DESCRIPTION
## Summary

Design RFC for Cascade Trust Phase 2, building on:

- **#10292** — Phase 0a: fingerprint counter for trust observability (merged)
- **#10331** — Phase 0b: JSONL snapshot of trust state every minute (merged)
- **#10365** — Phase 1: in-memory `trust_score` auto-rotation on persistent failures (merged)

Phase 2 splits into two stages with distinct risk profiles:

| Stage | What it does | Risk |
|---|---|---|
| **2a** Operator recommendation | Dashboard card surfaces low-trust providers with a copy-friendly cascade.toml diff suggestion. **No automatic writes.** | observation-only |
| **2b dry** | `MASC_CASCADE_TRUST_PERSIST=dry` computes the same diff hourly and appends to an audit log. Still no writes. | observation-only with intent signal |
| **2b live** | `MASC_CASCADE_TRUST_PERSIST=1` performs atomic write to `~/.masc/config/cascade.toml` only. | gated by realpath check, mtime self-write guard, 0.25 hysteresis |

## Why split

- 2a is the cheap, reversible win (merge, ship, watch dashboard for a week).
- 2b dry surfaces would-be writes for inspection without committing to the loop.
- 2b live only flips after the dry log has been reviewed and the recommendation card has stabilised.

Total estimated calendar time before any automatic config write: 2-3 weeks.

## Replay-validated motivation

Phase 1 replay against the live `decisions.jsonl` corpus already showed:

- `ollama_only` (562 events, 1% success) → trust 0.000 on 99.5% of decisions. With Phase 2a a dashboard card would currently say "Disable ollama_only — trust=0.000, persistent fingerprint=276s timeout × 380".
- `big_three` (842 events, 41% success) → trust 2.000 ceiling. No recommendation needed.

So the recommendation card has immediate signal on day 1.

## Anti-pattern guards

- `masc-oas-layer-boundary` — recommendation logic stays in MASC; OAS-side signals (cost_tracker tokens) are deferred to Phase 3.
- `placeholder-over-fake-state` — operator card shows "no recommendation yet" when trust history < 1h, never a stale snapshot.
- Repo seed protection: realpath equality check vs `<repo_root>/config/cascade.toml`, not string compare.
- Hot-reload self-trigger: mtime threshold + process-local flag (per `feedback_security-gate-realpath-invariants.md`).

## Open questions

1. **Dashboard surface**: where does the recommendation card live — under existing Cascade panel, or a new "Operator actions" panel? Bias toward existing panel to avoid adding nav.
2. **Audit log retention**: cascade_trust JSONL is already 1-min cadence (Phase 0b). Persist audit (Phase 2b) is hourly — same `cascade_trust/applied/` subdir or separate?
3. **Hysteresis threshold (0.25 default)**: derived from "0.5 quantization step / 2 = avoid one-event-flip". Should be empirical from 2b dry data, not magic.

## Test plan

- [ ] Phase 2a: 4 alcotest cases over the recommendation classifier (reduce/disable/investigate/healthy)
- [ ] Phase 2b dry: 1 week local soak with `MASC_CASCADE_TRUST_PERSIST=dry`, audit log review
- [ ] Phase 2b live: 6 alcotest cases — atomic write, backup creation, dry mode no-op, repo guard, hot-reload skip, audit log shape
- [ ] Hot-reload regression: `[CascadeConfig] loaded` log frequency stays ≤ 1/hr after persist