### PR TITLE
perf(json-string-field): route 2 forks through Json_util SSOT

### DIFF
--- a/lib/heuristic_metrics.ml
+++ b/lib/heuristic_metrics.ml
@@ -256,22 +256,9 @@ let coverage_report_of_events events =
     Hashtbl.create 16
   in
   let unique_tuples : (string, unit) Hashtbl.t = Hashtbl.create 16 in
-  let json_string_field name json =
-    match Yojson.Safe.Util.member name json with
-    | `String value -> Some value
-    | _ -> None
-  in
-  let json_float_field name json =
-    match Yojson.Safe.Util.member name json with
-    | `Float value -> Some value
-    | `Int value -> Some (Float.of_int value)
-    | _ -> None
-  in
-  let json_bool_field name json =
-    match Yojson.Safe.Util.member name json with
-    | `Bool value -> Some value
-    | _ -> None
-  in
+  let json_string_field name json = Json_util.get_string json name in
+  let json_float_field name json = Json_util.get_float json name in
+  let json_bool_field name json = Json_util.get_bool json name in
   List.iter
     (fun json ->
        match json_string_field "module" json, json_string_field "site" json with

--- a/lib/keeper/keeper_exec_preflight.ml
+++ b/lib/keeper/keeper_exec_preflight.ml
@@ -1,11 +1,6 @@
 open Keeper_types
 
-let json_string_field name = function
-  | `Assoc fields -> (
-      match List.assoc_opt name fields with
-      | Some (`String value) -> Some value
-      | _ -> None)
-  | _ -> None
+let json_string_field name json = Json_util.get_string json name
 
 let handle_keeper_preflight_check
       ~(config : Coord.config)


### PR DESCRIPTION
## Summary

\`Json_util.get_string\`/\`get_float\`/\`get_bool\` already exist as the codebase SSOT for typed JSON field access. Two of the \`json_string_field\` forks were byte-equivalent.

## Changes

### \`lib/keeper/keeper_exec_preflight.ml\`
Toplevel \`json_string_field name = function | \`Assoc fields -> ...\` collapses to a 1-line \`Json_util.get_string\` delegation. \`Yojson.member\` on a non-\`Assoc\` returns \`\`Null\` which the existing wildcard already handles, so semantics are preserved.

### \`lib/heuristic_metrics.ml\`
Local \`let-in\` helpers for string/float/bool field access — all three were exact duplicates of \`Json_util.get_string\`/\`get_float\`/\`get_bool\`. Replaced with thin delegates to keep call-site identifiers unchanged.

## Deferred

The other 4 \`json_string_field\` variants in the tree differ in trim/empty filtering or default semantics and need caller-by-caller analysis.

## Test plan

- [x] \`dune build @check\` clean
- [x] \`test_heuristic_metrics_diagnostics\` OK
- [x] \`test_heuristic_metrics_scrub\` 5/5
- [x] \`test_heuristic_metrics_boot_wireup\` 2/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)