### PR TITLE
fix(cascade): use scheduler-safe RNG mutex

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -701,15 +701,18 @@ type cascade_source = Named | Default_fallback | Hardcoded_defaults
     3. Selected item becomes first; rest sorted by weight desc
 
     @since 0.137.0 *)
-(* Shared weighted-shuffle RNG.  Protect draws with Eio.Mutex because
-   [Random.State.int] mutates the state and this path can be hit from
-   concurrent server fibers on the same domain. *)
+(* Shared weighted-shuffle RNG.  Protect draws because [Random.State.int]
+   mutates the state and this path can be hit from concurrent server fibers.
+   Use [Stdlib.Mutex], not [Eio.Mutex]: selection-trace/dashboard helpers are
+   also exercised from non-Eio contexts where [Eio.Mutex] raises
+   [Effect.Unhandled(Cancel.Get_context)].  The critical section is a single
+   RNG draw, so blocking briefly is acceptable. *)
 let weighted_shuffle_rng = Random.State.make_self_init ()
-let weighted_shuffle_rng_mu = Eio.Mutex.create ()
+let weighted_shuffle_rng_mu = Stdlib.Mutex.create ()
 
 let weighted_random_int bound =
-  Eio.Mutex.use_rw ~protect:true weighted_shuffle_rng_mu (fun () ->
-    Random.State.int weighted_shuffle_rng bound)
+  Stdlib.Mutex.protect weighted_shuffle_rng_mu (fun () ->
+      Random.State.int weighted_shuffle_rng bound)
 
 let weighted_shuffle
     ?(rand_int = weighted_random_int)


### PR DESCRIPTION
## Summary
- replace the weighted-shuffle global RNG guard with Stdlib.Mutex
- keep dashboard/selection-trace paths safe when called outside an Eio scheduler
- document why Eio.Mutex is wrong for this shared pure/runtime helper

## Why
After #10331/#10365 landed, Dashboard_cascade.config_json can call Cascade_config.selection_trace_of_weighted_entries from non-Eio test/dashboard projection paths. The old Eio.Mutex guard raised Effect.Unhandled(Cancel.Get_context), breaking dashboard cascade tests and risking the same failure in startup/test contexts.

## Verification
- MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh exec ./test/test_dashboard_cascade.exe
- MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh exec ./test/test_cascade_catalog_runtime.exe