### PR TITLE
fix(discovery-history): preserve all loaded models per probe (#10404)

### DIFF
--- a/lib/discovery_history.ml
+++ b/lib/discovery_history.ml
@@ -25,11 +25,19 @@ let get_or_create_store ~base_path : Dated_jsonl.t =
 
 (* ── Serialization ────────────────────────────────────────── *)
 
+(* #10404: pre-fix this record stored only the head of [e.models] in
+   [model_id], silently discarding 6 of 7 loaded ollama models.  Across
+   2026-04-22..25 every one of 164 probes recorded "qwen3:8b" while
+   four cascades reference "qwen3.6:27b-coding-nvfp4".  Add a [models]
+   list that preserves the full probe payload, and keep [model_id]
+   populated with the head for any external reader that already
+   indexes by it. *)
 type probe_record = {
   ts : float;
   endpoint_url : string;
   healthy : bool;
   model_id : string option;
+  models : string list;
   ctx_size : int option;
   total_slots : int option;
   busy_slots : int option;
@@ -38,11 +46,13 @@ type probe_record = {
 
 let endpoint_to_record (e : Llm_provider.Discovery.endpoint_status) : probe_record =
   let open Llm_provider.Discovery in
+  let models = List.map (fun m -> m.id) e.models in
   {
     ts = Time_compat.now ();
     endpoint_url = e.url;
     healthy = e.healthy;
-    model_id = (match e.models with m :: _ -> Some m.id | [] -> None);
+    model_id = (match models with m :: _ -> Some m | [] -> None);
+    models;
     ctx_size = Option.map (fun (p : server_props) -> p.ctx_size) e.props;
     total_slots = Option.map (fun (s : slot_status) -> s.total) e.slots;
     busy_slots = Option.map (fun (s : slot_status) -> s.busy) e.slots;
@@ -57,8 +67,14 @@ let record_to_json (r : probe_record) : Yojson.Safe.t =
     ]
   in
   let opt key f = function Some v -> [(key, f v)] | None -> [] in
+  let models_field =
+    if r.models = [] then []
+    else
+      [ ("models", `List (List.map (fun s -> `String s) r.models)) ]
+  in
   let extras =
     opt "model_id" (fun s -> `String s) r.model_id
+    @ models_field
     @ opt "ctx_size" (fun n -> `Int n) r.ctx_size
     @ opt "total_slots" (fun n -> `Int n) r.total_slots
     @ opt "busy_slots" (fun n -> `Int n) r.busy_slots

--- a/lib/discovery_history.mli
+++ b/lib/discovery_history.mli
@@ -10,6 +10,27 @@ val record_probe :
 (** Append probe results for all endpoints to today's JSONL file.
     Silently catches I/O failures (best-effort persistence). *)
 
+(** #10404: probe records previously stored only the head model in
+    [model_id], silently discarding additional models loaded on the
+    same endpoint.  [models] now carries the full list; [model_id]
+    stays populated with the head for backward compatibility with
+    existing JSONL readers that index by it. *)
+type probe_record = {
+  ts : float;
+  endpoint_url : string;
+  healthy : bool;
+  model_id : string option;
+  models : string list;
+  ctx_size : int option;
+  total_slots : int option;
+  busy_slots : int option;
+  idle_slots : int option;
+}
+
+val record_to_json : probe_record -> Yojson.Safe.t
+(** Serialise a probe record.  Exposed for unit tests; production code
+    calls it through [record_probe]. *)
+
 val read_recent :
   base_path:string -> count:int -> Yojson.Safe.t list
 (** Read the most recent [count] probe entries in chronological order. *)

--- a/test/dune
+++ b/test/dune
@@ -663,6 +663,7 @@
         test_task_status_label_10421
         test_personality_field_diff_10269
         test_toml_skip_dedup_10259
+        test_discovery_history_models_10404
         test_keeper_task_dispatch
         test_keeper_tag_dispatch
         test_autoresearch_knowledge
@@ -845,6 +846,7 @@
         test_task_status_label_10421
         test_personality_field_diff_10269
         test_toml_skip_dedup_10259
+        test_discovery_history_models_10404
         test_keeper_task_dispatch
         test_keeper_tag_dispatch
         test_autoresearch_knowledge

--- a/test/test_discovery_history_models_10404.ml
+++ b/test/test_discovery_history_models_10404.ml
@@ -1,0 +1,77 @@
+(** #10404: pre-fix [Discovery_history.endpoint_to_record] kept only the
+    head of the loaded model list, recording 'qwen3:8b' for every probe
+    while four cascades referenced 'qwen3.6:27b-coding-nvfp4'.  These
+    tests pin the new [models : string list] field and verify the head
+    backward-compatibility (model_id stays populated). *)
+
+open Alcotest
+module DH = Masc_mcp.Discovery_history
+
+let make ~models : DH.probe_record = {
+  ts = 1777129200.0;
+  endpoint_url = "http://127.0.0.1:11434";
+  healthy = true;
+  model_id = (match models with m :: _ -> Some m | [] -> None);
+  models;
+  ctx_size = Some 40960;
+  total_slots = Some 4;
+  busy_slots = Some 0;
+  idle_slots = Some 4;
+}
+
+let json_string_of (json : Yojson.Safe.t) = Yojson.Safe.to_string json
+
+let test_models_list_is_emitted () =
+  let r = make ~models:[
+    "qwen3:8b";
+    "qwen3.6:27b-coding-nvfp4";
+    "qwen3.6:27b-coding-bf16";
+    "supergemma4:e4b-abliterated-mlx";
+  ] in
+  let s = json_string_of (DH.record_to_json r) in
+  check bool "models field present" true
+    (Astring.String.is_infix ~affix:"\"models\":" s);
+  check bool "second model preserved" true
+    (Astring.String.is_infix ~affix:"qwen3.6:27b-coding-nvfp4" s);
+  check bool "fourth model preserved" true
+    (Astring.String.is_infix ~affix:"supergemma4:e4b-abliterated-mlx" s)
+
+let test_model_id_is_head_for_legacy_readers () =
+  let r = make ~models:[
+    "qwen3:8b";
+    "qwen3.6:27b-coding-nvfp4";
+  ] in
+  let s = json_string_of (DH.record_to_json r) in
+  check bool "model_id field still present" true
+    (Astring.String.is_infix ~affix:"\"model_id\":\"qwen3:8b\"" s)
+
+let test_empty_models_omits_field () =
+  let r = make ~models:[] in
+  let s = json_string_of (DH.record_to_json r) in
+  check bool "no models field when list empty" false
+    (Astring.String.is_infix ~affix:"\"models\":" s);
+  check bool "no model_id field when empty" false
+    (Astring.String.is_infix ~affix:"\"model_id\":" s)
+
+let test_single_model_round_trip () =
+  let r = make ~models:[ "qwen3.6:27b-coding-nvfp4" ] in
+  let s = json_string_of (DH.record_to_json r) in
+  check bool "single-model models field present" true
+    (Astring.String.is_infix ~affix:"\"models\":[\"qwen3.6:27b-coding-nvfp4\"]" s);
+  check bool "single-model model_id matches head" true
+    (Astring.String.is_infix
+       ~affix:"\"model_id\":\"qwen3.6:27b-coding-nvfp4\"" s)
+
+let () =
+  run "discovery_history_models_10404" [
+    ("model_preservation", [
+        test_case "full models list serialised" `Quick
+          test_models_list_is_emitted;
+        test_case "model_id stays = head for legacy readers" `Quick
+          test_model_id_is_head_for_legacy_readers;
+        test_case "empty model list omits both fields" `Quick
+          test_empty_models_omits_field;
+        test_case "single-model round-trip stays consistent" `Quick
+          test_single_model_round_trip;
+      ]);
+  ]


### PR DESCRIPTION
## 요약

**Issue**: #10404 — `lib/discovery_history.ml`이 ollama probe 결과의 첫 번째 모델만 `model_id`에 기록 (`m :: _ → Some m.id`). 시스템에 7 model이 loaded되어 있어도 discovery JSONL은 `qwen3:8b` 하나만 표시. 4 cascade (ollama_only, local_only, local_recovery, local_with_kimi_coding_with_glm)가 `qwen3.6:27b-coding-nvfp4`를 사용하지만 discovery에는 안 보임.

## 정량

```
2026-04-22..25 (4-day total): 164 probe entries
모두 model_id="qwen3:8b" → 100% 동일 record
실제 cascade 사용 model: qwen3.6:27b-coding-nvfp4 → discovery 0건
```

## Fix scope (옵션 A — additive 보존)

이슈의 4 옵션 중 옵션 A 채택. 기존 reader 호환을 위해 **additive**:

| field | 변경 |
|-------|------|
| `model_id : string option` | 그대로 (head 모델, backward compat) |
| `models : string list` | **신규** — 전체 모델 list 보존 |

```ocaml
type probe_record = {
  ts : float;
  endpoint_url : string;
  healthy : bool;
  model_id : string option;
  models : string list;       (* NEW: full list *)
  ctx_size : int option;
  total_slots : int option;
  busy_slots : int option;
  idle_slots : int option;
}

let endpoint_to_record (e : Discovery.endpoint_status) : probe_record =
  let models = List.map (fun m -> m.id) e.models in
  {
    ...
    model_id = (match models with m :: _ -> Some m | [] -> None);
    models;
    ...
  }
```

JSON serialization:
- `models` field만 새로 emit. 빈 list면 omit (no schema noise on dead endpoints)
- `model_id`는 그대로 유지 → 기존 JSONL reader 영향 없음

## 검증

```text
DUNE_CACHE=disabled dune build --root . --cache=disabled @check
→ EXIT=0

dune exec test/test_discovery_history_models_10404.exe
→ 4/4 OK
  - full models list serialised (4-model probe → 모두 JSON에)
  - model_id stays = head for legacy readers
  - empty model list omits both fields
  - single-model round-trip stays consistent
```

## 영향 (예상)

머지 후 다음 probe cycle:
- 7 모델 모두 `models` array에 등장 → operator/dashboard가 multi-model load 인지
- `model_id` 그대로 유지 → 기존 dashboard/external reader 영향 없음
- 4 cascade가 지정한 `qwen3.6:27b-coding-nvfp4` 가용성이 discovery에서 visible
- multi-model load balancing의 health 추적 가능

## Schema migration

- 기존 JSONL row: `models` 필드 부재 → reader가 missing key로 인지 → 빈 list로 fallback
- 신규 row: `models` 필드 + `model_id` (head) 둘 다 emit
- backward 호환: 기존 reader가 `model_id` 만 보면 변경 없음 (head는 그대로)

## Defensive guards

- Draft + `do-not-merge` label
- `gh pr merge --disable-auto`

## 관련

- Issue: `#10404`
- 인접: `#10388` (cascade keeper_assignable violation — same fleet observability gap), `#10358` (telemetry attrition — multi-information lossy emit pattern)
- 메모리: `feedback_no-collapse-richer-enum-at-sdk-boundary.md` (boundary에서 richer info 축소 금지)
