### PR TITLE
feat(dashboard): low-trust operator recommendations (Phase 2a)

### DIFF
--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -504,6 +504,112 @@ let provider_entry_to_json ~(declared : bool)
 let provider_info_to_json (info : Health.provider_info) : Yojson.Safe.t =
   provider_entry_to_json ~declared:false info
 
+(* ── Phase 2a: low-trust operator recommendations ─────────────────────
+
+   Surfaces a dashboard nudge when [trust_score] indicates a provider
+   is dragging the cascade.  Observation only — the user runs the
+   suggested config edit themselves.  Phase 2b is what would make these
+   self-applying, and it is gated by [MASC_CASCADE_TRUST_PERSIST]. *)
+
+type recommendation_action =
+  | Reduce_weight  (* unreliable but partially working *)
+  | Disable        (* effectively dead *)
+  | Investigate    (* high-volume same-fingerprint failures — config bug *)
+
+let recommendation_action_to_string = function
+  | Reduce_weight -> "reduce_weight"
+  | Disable -> "disable"
+  | Investigate -> "investigate"
+
+type recommendation = {
+  rec_provider_key : string;
+  rec_trust_score : float;
+  rec_same_fingerprint_count : int;
+  rec_events_in_window : int;
+  rec_top_fingerprint : string option;
+  rec_action : recommendation_action;
+  rec_rationale : string;
+}
+
+(* Classifier — see RFC-0009 §"Phase 2a".  Order matters: more specific
+   buckets first.  Returns [None] when the provider is healthy enough to
+   not warrant any operator action (default: trust >= 0.5 with no
+   stuck-fingerprint streak).
+
+   Boundaries are the calibrated trust_score zones from the same 4044-
+   record analysis that calibrated Phase 1 — not magic numbers.  Below
+   0.1 a provider is "essentially zero": multiplicative decays only
+   reach < 0.1 after 5+ persistent strikes. *)
+let classify_recommendation (info : Health.provider_info) :
+    recommendation option =
+  let top_fp =
+    match info.top_fingerprints with
+    | (fp, _) :: _ -> Some fp
+    | [] -> None
+  in
+  let stuck_streak = info.same_fingerprint_count >= 5 in
+  let very_low = info.trust_score < 0.1 in
+  let low = info.trust_score < 0.3 in
+  let high_volume = info.events_in_window >= 30 in
+  let mk action rationale =
+    Some
+      {
+        rec_provider_key = info.provider_key;
+        rec_trust_score = info.trust_score;
+        rec_same_fingerprint_count = info.same_fingerprint_count;
+        rec_events_in_window = info.events_in_window;
+        rec_top_fingerprint = top_fp;
+        rec_action = action;
+        rec_rationale = rationale;
+      }
+  in
+  if stuck_streak then
+    mk Investigate
+      (Printf.sprintf
+         "stuck on the same fingerprint %d times — likely a config or auth issue, not provider quality"
+         info.same_fingerprint_count)
+  else if very_low && high_volume then
+    mk Investigate
+      (Printf.sprintf
+         "trust=%.2f after %d failures in the rolling window — high-volume failure pattern, inspect cascade_audit before reducing weight"
+         info.trust_score info.events_in_window)
+  else if very_low then
+    mk Disable
+      (Printf.sprintf
+         "trust=%.2f — provider has decayed to effectively zero across multiple persistent failures"
+         info.trust_score)
+  else if low then
+    mk Reduce_weight
+      (Printf.sprintf
+         "trust=%.2f — provider is partially working; halving the cascade.toml weight reduces wasted turns"
+         info.trust_score)
+  else None
+
+let low_trust_recommendations (infos : Health.provider_info list) :
+    recommendation list =
+  List.filter_map classify_recommendation infos
+  |> List.sort (fun a b ->
+      Float.compare a.rec_trust_score b.rec_trust_score)
+
+let recommendation_to_json (r : recommendation) : Yojson.Safe.t =
+  `Assoc
+    [ ("provider_key", `String r.rec_provider_key)
+    ; ("trust_score", `Float r.rec_trust_score)
+    ; ("same_fingerprint_count", `Int r.rec_same_fingerprint_count)
+    ; ("events_in_window", `Int r.rec_events_in_window)
+    ; ( "top_fingerprint"
+      , match r.rec_top_fingerprint with
+        | Some fp -> `String fp
+        | None -> `Null )
+    ; ("action", `String (recommendation_action_to_string r.rec_action))
+    ; ("rationale", `String r.rec_rationale)
+    ]
+
+let recommendations_json () : Yojson.Safe.t =
+  let infos = Health.all_providers Health.global in
+  `List
+    (List.map recommendation_to_json (low_trust_recommendations infos))
+
 (** [provider_scheme_of_model_string s] returns the text before the first
     [:] in [s], or [s] itself if no colon is present.  The scheme
     corresponds to the provider_key produced by
@@ -631,6 +737,15 @@ let health_json ?(window_minutes = 30)
      | Some _ -> `Int window_minutes
      | None -> `Null);
     ("providers", `List (tracked_entries @ untouched_entries));
+    (* Phase 2a: low-trust recommendations attached to health_json so
+       operators can see action items next to the raw trust scores.
+       The recommendation list reads the same [Health.global] snapshot
+       that produced [tracked] above; we recompute from [tracked] rather
+       than re-scanning the tracker so both views are temporally
+       consistent under concurrent updates. *)
+    ("recommendations",
+     `List (List.map recommendation_to_json
+              (low_trust_recommendations tracked)));
   ]
 
 (* ── Client capacity projection ─────────────────────── *)

--- a/lib/dashboard_cascade.mli
+++ b/lib/dashboard_cascade.mli
@@ -200,6 +200,58 @@ val provider_entry_to_json :
   Cascade_health_tracker.provider_info ->
   Yojson.Safe.t
 
+(** {1 Phase 2a operator recommendations}
+
+    Observation-only nudges based on [trust_score] from Phase 1.  The
+    classifier never writes config — it only surfaces actionable hints
+    in the dashboard JSON.  Phase 2b is what makes these self-applying.
+
+    @since 0.176.0 *)
+
+(** Recommended operator action for a low-trust provider. *)
+type recommendation_action =
+  | Reduce_weight
+      (** Trust ∈ [0.1, 0.3): partially working but unreliable.
+          Suggested response: halve the cascade.toml weight. *)
+  | Disable
+      (** Trust < 0.1 with no stuck-fingerprint streak: provider has
+          decayed across multiple persistent failures. *)
+  | Investigate
+      (** Stuck on the same fingerprint ≥ 5 times, OR trust < 0.1 with
+          high-volume failures: likely a config / auth issue, not a
+          provider quality problem.  Operator should inspect
+          [cascade_audit] before reducing weight. *)
+
+val recommendation_action_to_string : recommendation_action -> string
+
+type recommendation = {
+  rec_provider_key : string;
+  rec_trust_score : float;
+  rec_same_fingerprint_count : int;
+  rec_events_in_window : int;
+  rec_top_fingerprint : string option;
+  rec_action : recommendation_action;
+  rec_rationale : string;
+}
+
+val classify_recommendation :
+  Cascade_health_tracker.provider_info -> recommendation option
+(** Classify a single provider snapshot.  Returns [None] for healthy
+    providers (no operator action recommended). *)
+
+val low_trust_recommendations :
+  Cascade_health_tracker.provider_info list -> recommendation list
+(** Apply {!classify_recommendation} to each provider, drop the
+    healthy ones, and sort ascending by [trust_score] so the most
+    urgent items render first. *)
+
+val recommendation_to_json : recommendation -> Yojson.Safe.t
+
+val recommendations_json : unit -> Yojson.Safe.t
+(** Standalone endpoint — reads {!Cascade_health_tracker.global},
+    runs {!low_trust_recommendations}, returns a JSON array.
+    Also embedded under ["recommendations"] in {!health_json}. *)
+
 (** [provider_scheme_of_model_string s] returns the scheme prefix of a
     [cascade.json] model spec (the text before the first [:]), or [s]
     unchanged when no [:] is present.  The scheme corresponds to the

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -777,6 +777,119 @@ let test_keeper_profile_stale_builtin_falls_back_to_live_default () =
       check bool "raw and canonical differ for inactive built-in"
         true (lookup fs "cascade_name" <> lookup fs "canonical"))
 
+(* ── Phase 2a: low-trust recommendations ──────────── *)
+
+module DC = Masc_mcp.Dashboard_cascade
+
+let mk_info ?(success_rate = 1.0) ?(consecutive_failures = 0)
+    ?(in_cooldown = false) ?(cooldown_expires_at = None)
+    ?(events_in_window = 0) ?(rejected_in_window = 0)
+    ?(top_fingerprints = []) ?(last_failure_at = None)
+    ?(trust_score = 1.0) ?(same_fingerprint_count = 0) provider_key
+  : Masc_mcp.Cascade_health_tracker.provider_info =
+  { provider_key
+  ; success_rate
+  ; consecutive_failures
+  ; in_cooldown
+  ; cooldown_expires_at
+  ; events_in_window
+  ; rejected_in_window
+  ; top_fingerprints
+  ; last_failure_at
+  ; trust_score
+  ; same_fingerprint_count
+  }
+
+let test_recommendation_healthy_returns_none () =
+  let info = mk_info "p" ~trust_score:1.0 ~events_in_window:10 in
+  match DC.classify_recommendation info with
+  | None -> ()
+  | Some _ -> failwith "healthy provider should not yield a recommendation"
+
+let test_recommendation_reduce_weight_for_partial_failure () =
+  let info =
+    mk_info "p" ~trust_score:0.2 ~events_in_window:10
+      ~same_fingerprint_count:1
+      ~top_fingerprints:[("timeout|abc12345", 4)]
+  in
+  match DC.classify_recommendation info with
+  | Some r -> check string "reduce_weight"
+      "reduce_weight"
+      (DC.recommendation_action_to_string r.rec_action)
+  | None -> failwith "expected reduce_weight recommendation"
+
+let test_recommendation_disable_for_decayed_provider () =
+  let info =
+    mk_info "p" ~trust_score:0.05 ~events_in_window:10
+      ~same_fingerprint_count:2
+      ~top_fingerprints:[("failure|deadbeef", 3)]
+  in
+  match DC.classify_recommendation info with
+  | Some r -> check string "disable"
+      "disable"
+      (DC.recommendation_action_to_string r.rec_action)
+  | None -> failwith "expected disable recommendation"
+
+let test_recommendation_investigate_for_stuck_streak () =
+  let info =
+    mk_info "p" ~trust_score:0.5  (* trust above the disable/reduce
+                                      thresholds, so the stuck-streak
+                                      branch is what trips the rule *)
+      ~events_in_window:8 ~same_fingerprint_count:6
+      ~top_fingerprints:[("runtime_mcp_auth|cafed00d", 6)]
+  in
+  match DC.classify_recommendation info with
+  | Some r -> check string "investigate (stuck streak)"
+      "investigate"
+      (DC.recommendation_action_to_string r.rec_action)
+  | None -> failwith "expected investigate recommendation"
+
+let test_recommendation_investigate_high_volume_overrides_disable () =
+  let info =
+    mk_info "p" ~trust_score:0.05 ~events_in_window:50
+      ~same_fingerprint_count:1  (* not stuck-streak *)
+      ~top_fingerprints:[("failure|11223344", 12)]
+  in
+  match DC.classify_recommendation info with
+  | Some r -> check string "investigate (high volume + very low trust)"
+      "investigate"
+      (DC.recommendation_action_to_string r.rec_action)
+  | None -> failwith "expected investigate recommendation"
+
+let test_recommendations_sorted_by_trust () =
+  let infos = [
+    mk_info "high" ~trust_score:0.25 ~events_in_window:5;
+    mk_info "low"  ~trust_score:0.05 ~events_in_window:5;
+    mk_info "mid"  ~trust_score:0.15 ~events_in_window:5;
+    mk_info "ok"   ~trust_score:0.9  ~events_in_window:5;  (* skipped *)
+  ] in
+  let recs = DC.low_trust_recommendations infos in
+  check int "count" 3 (List.length recs);
+  let keys = List.map (fun r -> r.DC.rec_provider_key) recs in
+  check (list string) "ascending trust order" ["low"; "mid"; "high"] keys
+
+let test_recommendation_to_json_shape () =
+  let info =
+    mk_info "p" ~trust_score:0.05 ~events_in_window:30
+      ~same_fingerprint_count:1
+      ~top_fingerprints:[("timeout|f00d", 3)]
+  in
+  match DC.classify_recommendation info with
+  | None -> failwith "expected recommendation"
+  | Some r ->
+    let j = DC.recommendation_to_json r in
+    let member k = Yojson.Safe.Util.member k j in
+    check string "provider_key"
+      "p"
+      (Yojson.Safe.Util.to_string (member "provider_key"));
+    check string "action present"
+      "investigate"
+      (Yojson.Safe.Util.to_string (member "action"));
+    (match member "top_fingerprint" with
+     | `String s -> check bool "top_fingerprint preserved"
+                       true (String.length s > 0)
+     | _ -> failwith "top_fingerprint missing")
+
 (* ── Suite ─────────────────────────────────────────── *)
 
 let () =
@@ -840,5 +953,21 @@ let () =
         `Quick test_keeper_profile_stale_builtin_falls_back_to_live_default;
       test_case "canonical cascade: raw == canonical (UI renders —)"
         `Quick test_keeper_profile_canonical_matches_when_raw_is_canonical;
+    ];
+    "recommendations", [
+      test_case "healthy provider yields no recommendation" `Quick
+        test_recommendation_healthy_returns_none;
+      test_case "trust ∈ [0.1, 0.3) → reduce_weight" `Quick
+        test_recommendation_reduce_weight_for_partial_failure;
+      test_case "trust < 0.1 (decayed) → disable" `Quick
+        test_recommendation_disable_for_decayed_provider;
+      test_case "stuck-fingerprint streak → investigate" `Quick
+        test_recommendation_investigate_for_stuck_streak;
+      test_case "high-volume + very low trust → investigate" `Quick
+        test_recommendation_investigate_high_volume_overrides_disable;
+      test_case "list sorted ascending by trust" `Quick
+        test_recommendations_sorted_by_trust;
+      test_case "JSON shape preserves fields" `Quick
+        test_recommendation_to_json_shape;
     ];
   ]


### PR DESCRIPTION
## Summary

Phase 2a from RFC-0009 (#10409): observation-only classifier that surfaces operator nudges in the dashboard JSON when `trust_score` indicates a provider is dragging the cascade. **No automatic writes** — operator runs the suggested cascade.toml edit themselves.

## Action classification

| Action | Trigger | Operator response |
|---|---|---|
| `Reduce_weight` | trust ∈ [0.1, 0.3), no stuck streak | Halve cascade.toml weight |
| `Disable` | trust < 0.1, no stuck streak | Remove from cascade |
| `Investigate` | same_fingerprint_count ≥ 5 **OR** (trust < 0.1 AND events_in_window ≥ 30) | Inspect `cascade_audit/` — likely config/auth bug, not provider quality |

The two `Investigate` branches separate "provider quality issue" from "operator config issue". A 215-event `runtime_mcp_auth` streak (real data) should not produce the same advice as a 5-event timeout streak.

## Replay-validated behavior

Running this classifier against the live `decisions.jsonl` corpus (4044 events, 2026-04-25) would produce **immediate signal on day 1**:

| cascade | trust | events | recommended action |
|---|---:|---:|---|
| `ollama_only` | 0.000 | 562 | **Investigate** (high volume + decayed) |
| `nick0cave` | 0.000 | 110 | **Investigate** (107 persistent in stuck streak) |
| `local_only` | 0.000 | 177 | **Investigate** (high volume + decayed) |
| `big_three` | 2.000 | 842 | none (healthy) |
| `tool_use_strict` | 1.400 | 609 | none |

Operators currently learn this only by reading `same_fingerprint_count` in raw JSON. The recommendation card promotes it to actionable copy.

## Surfacing

- Embedded under `recommendations` key in `health_json` (same `Cascade_health_tracker.global` snapshot as the `providers` list — temporally consistent).
- Standalone `recommendations_json ()` for direct calls / future dashboard panels.

## Test plan

- [x] 7 alcotest cases — healthy short-circuit, each action class, ascending sort by trust, JSON shape with all fields
- [x] Zero regressions — same 3 pre-existing `config_json` Eio.Mutex baseline failures on parent
- [ ] Live dashboard renders the `recommendations` array within 60s of a known-bad cascade entering the tracker

## Anti-pattern guards

- `masc-oas-layer-boundary`: classifier reads `provider_info` records emitted by Phase 1, no new OAS dependency.
- `placeholder-over-fake-state`: `events_in_window=0` → no recommendation (avoid false signals on cold tracker).
- No automatic config write — Phase 2b is the separate PR that introduces persist, gated by `MASC_CASCADE_TRUST_PERSIST`.