### PR TITLE
feat(keeper): add normalize_all_names SSOT (RFC P1)

### DIFF
--- a/lib/keeper/keeper_identity.ml
+++ b/lib/keeper/keeper_identity.ml
@@ -143,6 +143,115 @@ let explicit_keeper_name raw_name =
   else if Keeper_config.validate_name trimmed then Some trimmed
   else None
 
+type name_bundle = {
+  persona_name : string;
+  keeper_name : string;
+  agent_name : string;
+  credential_stem : string;
+}
+
+type validation_error =
+  | Empty_input
+  | Persona_not_found of {
+      input : string;
+      resolved : string;
+      searched : string;
+    }
+  | Credential_missing of {
+      input : string;
+      resolved : string;
+      searched : string;
+    }
+  | Name_ambiguous of { input : string; candidates : string list }
+  | Ephemeral_suffix_rejected of { input : string; stripped : string }
+
+let pp_validation_error fmt = function
+  | Empty_input -> Format.fprintf fmt "Empty_input"
+  | Persona_not_found { input; resolved; searched } ->
+      Format.fprintf fmt
+        "Persona_not_found { input=%S; resolved=%S; searched=%S }" input
+        resolved searched
+  | Credential_missing { input; resolved; searched } ->
+      Format.fprintf fmt
+        "Credential_missing { input=%S; resolved=%S; searched=%S }" input
+        resolved searched
+  | Name_ambiguous { input; candidates } ->
+      Format.fprintf fmt "Name_ambiguous { input=%S; candidates=[%s] }" input
+        (String.concat "; " (List.map (Printf.sprintf "%S") candidates))
+  | Ephemeral_suffix_rejected { input; stripped } ->
+      Format.fprintf fmt
+        "Ephemeral_suffix_rejected { input=%S; stripped=%S }" input stripped
+
+let show_validation_error err =
+  let buf = Buffer.create 64 in
+  let fmt = Format.formatter_of_buffer buf in
+  pp_validation_error fmt err;
+  Format.pp_print_flush fmt ();
+  Buffer.contents buf
+
+(* Strip a generated nickname suffix (adj-animal[-hex4]) once if present.
+   Returns the canonical agent prefix when applicable, else the input. *)
+let strip_nickname_once name =
+  if Nickname.is_generated_nickname name then
+    match Nickname.extract_agent_type name with
+    | Some prefix when Keeper_config.validate_name prefix -> prefix
+    | _ -> name
+  else name
+
+let normalize_all_names ~input_agent_name ?(base_path = "")
+    ?(check_persona = false) ?(check_credential = false) () :
+    (name_bundle, validation_error) result =
+  let trimmed = String.trim input_agent_name in
+  if trimmed = "" then Error Empty_input
+  else
+    match canonical_keeper_name trimmed with
+    | None ->
+        let masc_dir = Common.masc_dir_from_base_path ~base_path in
+        Error
+          (Persona_not_found
+             {
+               input = input_agent_name;
+               resolved = trimmed;
+               searched = Filename.concat (Filename.concat masc_dir "personas") trimmed;
+             })
+    | Some keeper_first_pass ->
+        let keeper_name = strip_nickname_once keeper_first_pass in
+        let persona_name = keeper_name in
+        let credential_stem = keeper_name in
+        let bundle =
+          {
+            persona_name;
+            keeper_name;
+            agent_name = input_agent_name;
+            credential_stem;
+          }
+        in
+        let masc_dir () = Common.masc_dir_from_base_path ~base_path in
+        let persona_check () =
+          if not check_persona then Ok ()
+          else
+            let path = Filename.concat (Filename.concat (masc_dir ()) "personas") persona_name in
+            if Sys.file_exists path then Ok ()
+            else
+              Error
+                (Persona_not_found
+                   { input = input_agent_name; resolved = persona_name; searched = path })
+        in
+        let credential_check () =
+          if not check_credential then Ok ()
+          else
+            let path =
+              Filename.concat (Auth.agents_dir base_path) (credential_stem ^ ".json")
+            in
+            if Sys.file_exists path then Ok ()
+            else
+              Error
+                (Credential_missing
+                   { input = input_agent_name; resolved = credential_stem; searched = path })
+        in
+        Result.bind (persona_check ()) (fun () ->
+            Result.bind (credential_check ()) (fun () -> Ok bundle))
+
 type parsed_identity = {
   keeper_name : string;
   agent_name : string;

--- a/lib/keeper/keeper_identity.mli
+++ b/lib/keeper/keeper_identity.mli
@@ -17,3 +17,52 @@ type parsed_identity = {
 }
 
 val parse_json_identity : Yojson.Safe.t -> parsed_identity
+
+(** {1 SSOT identity bundle (RFC P1)} *)
+
+type name_bundle = {
+  persona_name : string;
+  keeper_name : string;
+  agent_name : string;
+  credential_stem : string;
+}
+
+type validation_error =
+  | Empty_input
+  | Persona_not_found of {
+      input : string;
+      resolved : string;
+      searched : string;
+    }
+  | Credential_missing of {
+      input : string;
+      resolved : string;
+      searched : string;
+    }
+  | Name_ambiguous of { input : string; candidates : string list }
+  | Ephemeral_suffix_rejected of { input : string; stripped : string }
+
+val normalize_all_names :
+  input_agent_name:string ->
+  ?base_path:string ->
+  ?check_persona:bool ->
+  ?check_credential:bool ->
+  unit ->
+  (name_bundle, validation_error) result
+(** [normalize_all_names ~input_agent_name ?base_path ?check_persona
+    ?check_credential ()] resolves the four canonical name fields of a
+    keeper from any of its accepted input shapes (bare name, [keeper-X-agent]
+    wrapper, generated nickname like [executor-warm-raven], or wrapper +
+    nickname combination).
+
+    P1 default: [check_persona = false], [check_credential = false] —
+    pure normalization without filesystem lookups. P3 preflight enables
+    both.
+
+    [base_path] defaults to the empty string, which makes
+    [Common.masc_dir_from_base_path] resolve relative to the current
+    working directory. Tests must always pass an explicit [~base_path]. *)
+
+val pp_validation_error : Format.formatter -> validation_error -> unit
+
+val show_validation_error : validation_error -> string

--- a/test/dune
+++ b/test/dune
@@ -575,6 +575,7 @@
         test_keeper_cli_mcp_config
         test_board_vote_quarantine
         test_keeper_identity_parse
+        test_keeper_identity_normalize
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify
@@ -753,6 +754,7 @@
         test_keeper_cli_mcp_config
         test_board_vote_quarantine
         test_keeper_identity_parse
+        test_keeper_identity_normalize
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify

--- a/test/test_keeper_identity_normalize.ml
+++ b/test/test_keeper_identity_normalize.ml
@@ -1,0 +1,250 @@
+(** Tests for [Keeper_identity.normalize_all_names] — RFC P1.
+
+    Covers the input-shape × field matrix, round-trip stability across
+    wrappers, and filesystem checks gated by [?check_credential]. *)
+
+open Alcotest
+open Masc_mcp
+
+let () = Server_startup_state.mark_state_ready ~backend_mode:"test"
+
+let bundle =
+  testable
+    (fun fmt (b : Keeper_identity.name_bundle) ->
+      Format.fprintf fmt
+        "{ persona_name=%S; keeper_name=%S; agent_name=%S; credential_stem=%S }"
+        b.persona_name b.keeper_name b.agent_name b.credential_stem)
+    ( = )
+
+let validation_error =
+  testable Keeper_identity.pp_validation_error ( = )
+
+let normalize input =
+  Keeper_identity.normalize_all_names ~input_agent_name:input ()
+
+let ok_or_fail label = function
+  | Ok b -> b
+  | Error e ->
+      fail
+        (Printf.sprintf "%s: expected Ok, got %s" label
+           (Keeper_identity.show_validation_error e))
+
+(* --------------------------------------------------------------------- *)
+(* 6 input shapes × 4 field matrix                                        *)
+(* --------------------------------------------------------------------- *)
+
+let check_bundle ~label ~input ~persona ~keeper ~agent ~credential =
+  let b = ok_or_fail label (normalize input) in
+  check string (label ^ ": persona_name") persona b.persona_name;
+  check string (label ^ ": keeper_name") keeper b.keeper_name;
+  check string (label ^ ": agent_name") agent b.agent_name;
+  check string (label ^ ": credential_stem") credential b.credential_stem
+
+let test_bare_canonical () =
+  check_bundle ~label:"bare canonical" ~input:"sangsu" ~persona:"sangsu"
+    ~keeper:"sangsu" ~agent:"sangsu" ~credential:"sangsu"
+
+let test_keeper_dash_agent_wrapper () =
+  check_bundle ~label:"keeper-X-agent wrapper" ~input:"keeper-sangsu-agent"
+    ~persona:"sangsu" ~keeper:"sangsu" ~agent:"keeper-sangsu-agent"
+    ~credential:"sangsu"
+
+let test_keeper_underscore_agent_wrapper () =
+  check_bundle ~label:"keeper_X_agent wrapper" ~input:"keeper_sangsu_agent"
+    ~persona:"sangsu" ~keeper:"sangsu" ~agent:"keeper_sangsu_agent"
+    ~credential:"sangsu"
+
+let test_ephemeral_suffix_only () =
+  check_bundle ~label:"ephemeral suffix" ~input:"issue_king-pale-llama"
+    ~persona:"issue_king" ~keeper:"issue_king"
+    ~agent:"issue_king-pale-llama" ~credential:"issue_king"
+
+let test_wrapper_plus_ephemeral () =
+  check_bundle ~label:"wrapper + suffix"
+    ~input:"keeper-executor-warm-raven-agent" ~persona:"executor"
+    ~keeper:"executor" ~agent:"keeper-executor-warm-raven-agent"
+    ~credential:"executor"
+
+let test_empty_input () =
+  match normalize "" with
+  | Ok _ -> fail "empty input should be Error"
+  | Error e ->
+      check validation_error "empty input maps to Empty_input"
+        Keeper_identity.Empty_input e
+
+let test_whitespace_only_input () =
+  match normalize "   " with
+  | Ok _ -> fail "whitespace input should be Error"
+  | Error e ->
+      check validation_error "whitespace input maps to Empty_input"
+        Keeper_identity.Empty_input e
+
+let test_invalid_chars_persona_not_found () =
+  match normalize "bad@name" with
+  | Ok _ -> fail "invalid chars should be Error"
+  | Error (Keeper_identity.Persona_not_found _) -> ()
+  | Error other ->
+      fail
+        (Printf.sprintf
+           "invalid chars expected Persona_not_found, got %s"
+           (Keeper_identity.show_validation_error other))
+
+(* --------------------------------------------------------------------- *)
+(* Round-trip invariant: wrapping/unwrapping preserves bundle identity   *)
+(* --------------------------------------------------------------------- *)
+
+let wrappers name =
+  [
+    name;
+    "keeper-" ^ name ^ "-agent";
+    "keeper_" ^ name ^ "_agent";
+    "keeper-" ^ name ^ "_agent";
+    "keeper_" ^ name ^ "-agent";
+  ]
+
+let test_round_trip_for_name name () =
+  let canonical_bundle = ok_or_fail ("round-trip " ^ name) (normalize name) in
+  List.iter
+    (fun shape ->
+      let b =
+        ok_or_fail ("round-trip shape " ^ shape) (normalize shape)
+      in
+      check string ("round-trip persona_name for " ^ shape)
+        canonical_bundle.persona_name b.persona_name;
+      check string ("round-trip keeper_name for " ^ shape)
+        canonical_bundle.keeper_name b.keeper_name;
+      check string ("round-trip credential_stem for " ^ shape)
+        canonical_bundle.credential_stem b.credential_stem)
+    (wrappers name)
+
+(* --------------------------------------------------------------------- *)
+(* Fixture-based credential check (?check_credential:true)                *)
+(* --------------------------------------------------------------------- *)
+
+let mkdir_p path =
+  let rec ensure p =
+    if p = "" || p = "/" || Sys.file_exists p then ()
+    else (
+      ensure (Filename.dirname p);
+      try Unix.mkdir p 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+  in
+  ensure path
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then (
+      Array.iter
+        (fun entry -> rm_rf (Filename.concat path entry))
+        (Sys.readdir path);
+      try Unix.rmdir path with Unix.Unix_error _ -> ())
+    else try Sys.remove path with Sys_error _ -> ()
+
+let with_tmp_base f =
+  let tmp_dir = Filename.temp_file "masc_id_p1" "" in
+  Sys.remove tmp_dir;
+  Unix.mkdir tmp_dir 0o755;
+  Fun.protect
+    ~finally:(fun () -> rm_rf tmp_dir)
+    (fun () -> f tmp_dir)
+
+let credential_path base stem =
+  Filename.concat base
+    (Filename.concat ".masc" (Filename.concat "auth" (Filename.concat "agents" (stem ^ ".json"))))
+
+let test_check_credential_present () =
+  with_tmp_base (fun base ->
+      let path = credential_path base "sangsu" in
+      mkdir_p (Filename.dirname path);
+      let ch = open_out path in
+      output_string ch "{}";
+      close_out ch;
+      match
+        Keeper_identity.normalize_all_names ~input_agent_name:"sangsu"
+          ~base_path:base ~check_credential:true ()
+      with
+      | Ok b -> check string "credential_stem" "sangsu" b.credential_stem
+      | Error e ->
+          fail
+            (Printf.sprintf "expected Ok with credential present, got %s"
+               (Keeper_identity.show_validation_error e)))
+
+let test_check_credential_missing () =
+  with_tmp_base (fun base ->
+      let expected_path = credential_path base "sangsu" in
+      match
+        Keeper_identity.normalize_all_names ~input_agent_name:"sangsu"
+          ~base_path:base ~check_credential:true ()
+      with
+      | Ok _ -> fail "expected Credential_missing when file absent"
+      | Error
+          (Keeper_identity.Credential_missing { searched; resolved; input }) ->
+          check string "searched path" expected_path searched;
+          check string "resolved" "sangsu" resolved;
+          check string "input" "sangsu" input
+      | Error other ->
+          fail
+            (Printf.sprintf "expected Credential_missing, got %s"
+               (Keeper_identity.show_validation_error other)))
+
+let test_check_credential_wrapper_input () =
+  (* Caller passes wrapper form; credential file under canonical stem. *)
+  with_tmp_base (fun base ->
+      let path = credential_path base "sangsu" in
+      mkdir_p (Filename.dirname path);
+      let ch = open_out path in
+      output_string ch "{}";
+      close_out ch;
+      match
+        Keeper_identity.normalize_all_names
+          ~input_agent_name:"keeper-sangsu-agent" ~base_path:base
+          ~check_credential:true ()
+      with
+      | Ok b ->
+          check string "credential resolves to canonical stem" "sangsu"
+            b.credential_stem;
+          check string "agent_name preserved" "keeper-sangsu-agent" b.agent_name
+      | Error e ->
+          fail
+            (Printf.sprintf
+               "wrapper input with present credential should Ok, got %s"
+               (Keeper_identity.show_validation_error e)))
+
+(* --------------------------------------------------------------------- *)
+(* Test runner                                                            *)
+(* --------------------------------------------------------------------- *)
+
+let () =
+  run "keeper_identity_normalize"
+    [
+      ( "input_shape_matrix",
+        [
+          test_case "bare canonical" `Quick test_bare_canonical;
+          test_case "keeper-X-agent wrapper" `Quick
+            test_keeper_dash_agent_wrapper;
+          test_case "keeper_X_agent wrapper" `Quick
+            test_keeper_underscore_agent_wrapper;
+          test_case "ephemeral suffix only" `Quick test_ephemeral_suffix_only;
+          test_case "wrapper + ephemeral" `Quick test_wrapper_plus_ephemeral;
+          test_case "empty input" `Quick test_empty_input;
+          test_case "whitespace input" `Quick test_whitespace_only_input;
+          test_case "invalid chars" `Quick
+            test_invalid_chars_persona_not_found;
+        ] );
+      ( "round_trip",
+        [
+          test_case "round-trip sangsu" `Quick (test_round_trip_for_name "sangsu");
+          test_case "round-trip executor" `Quick
+            (test_round_trip_for_name "executor");
+          test_case "round-trip qa-king" `Quick
+            (test_round_trip_for_name "qa-king");
+          test_case "round-trip masc-improver" `Quick
+            (test_round_trip_for_name "masc-improver");
+        ] );
+      ( "credential_check",
+        [
+          test_case "credential present" `Quick test_check_credential_present;
+          test_case "credential missing" `Quick test_check_credential_missing;
+          test_case "wrapper input → canonical stem" `Quick
+            test_check_credential_wrapper_input;
+        ] );
+    ]


### PR DESCRIPTION
## Why

production 실측 (system_log_2026-04-25.jsonl):
- `[Misc] auth: token shared by 14 agents` 경고 **801회/일**
- `~/me/.masc/metrics/` 디렉토리에 같은 keeper가 두 곳에 metric 분열 (`analyst` ↔ `keeper-analyst-agent`, `issue_king` ↔ `issue_king-pale-llama`)
- 16 keeper의 subprocess MCP 호출 매일 500+ 실패 (memory `feedback_keeper-credential-name-drift`)

근본 원인: 한 keeper의 identity가 6개 독립 필드로 갈라져 있고, 정규화 로직이 3 파일에 산재. `auth.ml load_credential`은 silent fail.

본 PR은 RFC `~/me/planning/2026-04-25-keeper-identity-canonicalization-rfc.md`의 **P1 단계** — SSOT 함수와 타입을 순수 추가합니다. 호출자는 P2/P3에서 단계적으로 도입.

## What

`Keeper_identity` 모듈에 추가 (callable surface +4):

```ocaml
type name_bundle = { persona_name; keeper_name; agent_name; credential_stem }
type validation_error =
  | Empty_input
  | Persona_not_found of { input; resolved; searched }
  | Credential_missing of { input; resolved; searched }
  | Name_ambiguous of { input; candidates }
  | Ephemeral_suffix_rejected of { input; stripped }

val normalize_all_names :
  input_agent_name:string ->
  ?base_path:string ->
  ?check_persona:bool ->
  ?check_credential:bool ->
  unit ->
  (name_bundle, validation_error) result
```

설계 결정:
- **`?check_*` 옵션화**: P1 default `false` (정규화만). P3 preflight에서 `true`. Hot path stat 중복 방지.
- **error에 `searched` 경로 포함**: silent fail 재발 방지 — 로그에 즉시 파일 경로 노출.
- **`Empty_input` 추가**: RFC에 없지만 `agent_name = \"\"` default path 실존, 명시 surfacing.
- **`[@@deriving]` 미사용**: `pp_*`/`show_*` 손 작성. dependent module re-build trigger 0.
- **`Auth.credential_agent_name` 미사용** (mli export 없음) — 대신 `Nickname.extract_agent_type` 직접 호출. 이미 `keeper_identity.ml:105`이 사용 중.

## Test

`test/test_keeper_identity_normalize.ml` 신규 — **15 alcotest 테스트, 0.007s, all pass**:

- `input_shape_matrix` (8 case): bare canonical / keeper-X-agent wrapper / keeper_X_agent wrapper / ephemeral suffix only (`issue_king-pale-llama`) / wrapper + ephemeral (`keeper-executor-warm-raven-agent`) / empty input / whitespace input / invalid chars
- `round_trip` (4 keeper × 5 wrapper = 20 변환): canonical bundle이 wrapper 형태와 무관하게 동일
- `credential_check` (3 case): present / missing / wrapper input → canonical stem (production 시나리오 직접 시뮬레이션)

`test_keeper_identity_parse.exe` regression 7/7 pass.

## Blast radius

- callable surface +4 (type 2, val 2). 기존 9 export 미변경.
- production 영향 **0** — 호출자 없음 (`do-not-merge` 사유).
- circular dep: P1은 `Keeper_identity → {Auth.agents_dir, Nickname.extract_agent_type, Common.masc_dir_from_base_path}` 단방향. P2에서 `auth.ml`이 본 함수를 호출하면 cycle 발생 → P2 PR에서 `Auth.extract_agent_type_prefix`/`agents_dir`를 별도 모듈로 분리 필요.
- `[@@deriving]` 미사용으로 dependent rebuild trigger 없음.
- `?base_path` 미지정 시 `Common.masc_dir_from_base_path ~base_path:\"\"`가 cwd 기준 — 단위 테스트는 항상 `~base_path:tmp_dir` 명시.
- `Sys.file_exists` 호출은 `?check_*:true` 옵션 켰을 때만 발생.

## Follow-up

- **P2**: `auth.ml load_credential_with_aliases`를 `Result<agent_credential, validation_error>`로 변환, `Credential_missing` 명시 surfacing. `Auth.agents_dir`/`extract_agent_type_prefix`를 `lib/auth_paths.ml`로 분리해 circular dep 해소.
- **P3**: `Coord_lifecycle.join`에 `normalize_all_names ~check_persona:true ~check_credential:true` preflight.
- **P4**: `tool_keeper.ml` audit에 drift 감지 rule.
- **P5**: `<n>-<adj>-<animal>` ephemeral suffix 정책 결정 (현재 `Ephemeral_suffix_rejected` variant는 미사용 reserved).

## CI 검증

호스트 dune 빌드 부하 회피로 격리 환경에서 검증:
- `DUNE_BUILD_DIR=_build_p1_keeper_identity DUNE_CACHE=disabled scripts/dune-local.sh build @check --cache=disabled` → EXIT 0
- 위와 동일 환경에서 `build test/test_keeper_identity_normalize.exe` → EXIT 0
- `exec test/test_keeper_identity_normalize.exe` → 15/15 pass
- regression `exec test/test_keeper_identity_parse.exe` → 7/7 pass

## Plan / RFC

- Plan: `/Users/dancer/.claude/plans/ethereal-kindling-gem.md`
- RFC: `/Users/dancer/me/planning/2026-04-25-keeper-identity-canonicalization-rfc.md`