### PR TITLE
fix(goal-fsm): add Awaiting_verification exit transitions (#10411)

### DIFF
--- a/lib/goal/goal_phase.ml
+++ b/lib/goal/goal_phase.ml
@@ -103,6 +103,19 @@ let decide_transition ~phase ~(action : action) ~has_effective_verifier_policy
   | Awaiting_approval, Approve_completion -> Ok Complete
   | Awaiting_approval, Reject_completion -> Ok (Move_to Blocked)
   | Awaiting_approval, Drop -> Ok (Move_to Dropped)
+  (* #10411: Awaiting_verification previously had only the Drop
+     transition.  A goal that entered verification (Executing +
+     Request_complete + has_effective_verifier_policy) had no FSM
+     path back out for verifier success/failure or operator
+     pause/block — verifier output could not propagate to goal
+     completion.  Mirror Awaiting_approval semantics for the verifier
+     outcome (Approve = pass, Reject = fail) and add operator
+     pause/block escapes so manual recovery does not require
+     side-stepping the FSM through direct phase assignment. *)
+  | Awaiting_verification, Approve_completion -> Ok Complete
+  | Awaiting_verification, Reject_completion -> Ok (Move_to Blocked)
+  | Awaiting_verification, Pause -> Ok (Move_to Paused)
+  | Awaiting_verification, Operator_block -> Ok (Move_to Blocked)
   | Awaiting_verification, Drop -> Ok (Move_to Dropped)
   | Completed, Reopen -> Ok (Move_to Executing)
   | Completed, Drop -> Ok (Move_to Dropped)

--- a/test/dune
+++ b/test/dune
@@ -616,6 +616,7 @@
         test_keeper_runtime_denylist
         test_keeper_runtime_config_ssot
         test_dashboard_render_timing_9766
+        test_goal_phase_verification_10411
         test_keeper_task_dispatch
         test_keeper_tag_dispatch
         test_autoresearch_knowledge
@@ -794,6 +795,7 @@
         test_keeper_runtime_denylist
         test_keeper_runtime_config_ssot
         test_dashboard_render_timing_9766
+        test_goal_phase_verification_10411
         test_keeper_task_dispatch
         test_keeper_tag_dispatch
         test_autoresearch_knowledge

--- a/test/test_goal_phase_verification_10411.ml
+++ b/test/test_goal_phase_verification_10411.ml
@@ -1,0 +1,101 @@
+(** #10411: Goal_phase.Awaiting_verification was a dead end — the only
+    transition out was [Drop].  A goal that entered verification (via
+    Executing + Request_complete + has_effective_verifier_policy) had
+    no FSM path for verifier success/failure or operator pause/block,
+    so verifier outcomes could not propagate to goal completion in
+    code (`Goal_phase.Completed` was never assigned via FSM).
+
+    These tests pin the four new transitions and the existing Drop
+    semantics. *)
+
+open Alcotest
+module GP = Masc_mcp.Goal_phase
+
+let outcome_eq a b =
+  match (a, b) with
+  | GP.Complete, GP.Complete -> true
+  | GP.Open_verification, GP.Open_verification -> true
+  | GP.Open_approval, GP.Open_approval -> true
+  | GP.Move_to p1, GP.Move_to p2 -> GP.to_string p1 = GP.to_string p2
+  | _ -> false
+
+let outcome_pp fmt = function
+  | GP.Complete -> Format.fprintf fmt "Complete"
+  | GP.Open_verification -> Format.fprintf fmt "Open_verification"
+  | GP.Open_approval -> Format.fprintf fmt "Open_approval"
+  | GP.Move_to p -> Format.fprintf fmt "Move_to %s" (GP.to_string p)
+
+let outcome = testable outcome_pp outcome_eq
+
+let decide ~phase ~action =
+  GP.decide_transition ~phase ~action
+    ~has_effective_verifier_policy:false
+    ~require_completion_approval:false
+
+let test_approve_completion_completes_verification () =
+  match decide ~phase:GP.Awaiting_verification ~action:GP.Approve_completion with
+  | Ok o -> check outcome "verifier pass routes to Complete" GP.Complete o
+  | Error e -> fail e
+
+let test_reject_completion_blocks_verification () =
+  match decide ~phase:GP.Awaiting_verification ~action:GP.Reject_completion with
+  | Ok o ->
+      check outcome "verifier fail routes to Blocked"
+        (GP.Move_to GP.Blocked) o
+  | Error e -> fail e
+
+let test_pause_pauses_verification () =
+  match decide ~phase:GP.Awaiting_verification ~action:GP.Pause with
+  | Ok o ->
+      check outcome "Pause from verification reaches Paused"
+        (GP.Move_to GP.Paused) o
+  | Error e -> fail e
+
+let test_operator_block_blocks_verification () =
+  match decide ~phase:GP.Awaiting_verification ~action:GP.Operator_block with
+  | Ok o ->
+      check outcome "Operator_block from verification reaches Blocked"
+        (GP.Move_to GP.Blocked) o
+  | Error e -> fail e
+
+let test_drop_still_drops_verification () =
+  match decide ~phase:GP.Awaiting_verification ~action:GP.Drop with
+  | Ok o ->
+      check outcome "Drop preserved"
+        (GP.Move_to GP.Dropped) o
+  | Error e -> fail e
+
+(* Regression: actions that have no business in verification should
+   still raise the directed error.  Resume / Operator_unblock / Reopen
+   never made sense from this phase pre-fix and must stay rejected. *)
+let test_unrelated_action_rejected () =
+  let unrelated = [
+    GP.Resume;
+    GP.Operator_unblock;
+    GP.Reopen;
+    GP.Request_complete;
+  ] in
+  List.iter (fun action ->
+    match decide ~phase:GP.Awaiting_verification ~action with
+    | Ok _ ->
+        fail (Printf.sprintf "%s should be rejected from Awaiting_verification"
+                (GP.action_to_string action))
+    | Error _ -> ()) unrelated
+
+let () =
+  run "goal_phase_verification_10411" [
+    ("verification_exits", [
+        test_case "Approve_completion -> Complete" `Quick
+          test_approve_completion_completes_verification;
+        test_case "Reject_completion -> Blocked" `Quick
+          test_reject_completion_blocks_verification;
+        test_case "Pause -> Paused" `Quick
+          test_pause_pauses_verification;
+        test_case "Operator_block -> Blocked" `Quick
+          test_operator_block_blocks_verification;
+        test_case "Drop preserved" `Quick
+          test_drop_still_drops_verification;
+        test_case "unrelated actions stay rejected" `Quick
+          test_unrelated_action_rejected;
+      ]);
+  ]


### PR DESCRIPTION
## 요약

**Issue**: #10411 — `Goal_phase.decide_transition` FSM의 `Awaiting_verification` phase에 outgoing transition이 `Drop`만. verification 성공 → `Completed` / 실패 → `Blocked` 자동 path 부재. `verifier_policy` 활성 goal은 verification 도달 시 manual operator action 없이 escape 불가.

```bash
$ rg "phase = Goal_phase\.Completed" lib/ | wc -l
0
```

→ `Goal_phase.Completed`가 FSM 통해 직접 assignment되는 위치 0건.

## Fix scope (옵션 A only)

이슈의 옵션 중 가장 surgical:

| 옵션 | 이 PR |
|------|-------|
| **A — 4 transition 추가 (Approve/Reject/Pause/Operator_block)** | ✅ |
| B — 새 action `Verification_passed`/`Verification_failed` 도입 | ❌ (action ADT 확장, 별도) |
| C — Cascade verifier output → FSM 호출 wiring | ❌ (consumer 별도) |

## 변경

`lib/goal/goal_phase.ml`:

```ocaml
| Awaiting_approval, Approve_completion -> Ok Complete
| Awaiting_approval, Reject_completion -> Ok (Move_to Blocked)
| Awaiting_approval, Drop -> Ok (Move_to Dropped)
+ (* #10411: Awaiting_verification mirrors Awaiting_approval semantics *)
+ | Awaiting_verification, Approve_completion -> Ok Complete
+ | Awaiting_verification, Reject_completion -> Ok (Move_to Blocked)
+ | Awaiting_verification, Pause -> Ok (Move_to Paused)
+ | Awaiting_verification, Operator_block -> Ok (Move_to Blocked)
| Awaiting_verification, Drop -> Ok (Move_to Dropped)  (* preserved *)
```

semantics:
- `Approve_completion` = verifier 통과 → `Complete` (phase = Completed)
- `Reject_completion` = verifier 실패 → `Move_to Blocked`
- `Pause` = operator 보류 → `Move_to Paused`
- `Operator_block` = operator 차단 → `Move_to Blocked`
- `Drop` = 기존 transition 유지

`Resume`, `Operator_unblock`, `Reopen`, `Request_complete`는 Awaiting_verification에서 의미 없음 → 기존 reject 유지.

## 검증

```text
DUNE_CACHE=disabled dune build --root . --cache=disabled @check
→ EXIT=0

dune exec test/test_goal_phase_verification_10411.exe
→ 6/6 OK
  - Approve_completion -> Complete
  - Reject_completion -> Blocked
  - Pause -> Paused
  - Operator_block -> Blocked
  - Drop preserved
  - unrelated actions stay rejected
```

## 영향 (예상)

이 PR 머지만으로는 운영 변화 없음 — caller 코드가 새 transition을 trigger 해야 효과. 후속 PR(C):
- `Goal_verification` complete event → `decide_transition ~action:Approve_completion` 호출
- `Goal_verification` failure event → `decide_transition ~action:Reject_completion` 호출
- 위 호출이 wire 되면 cascade `cross_verifier` output이 goal phase로 자동 propagate

이 PR은 *FSM gate*만 추가. consumer wiring은 #10405 (goal_janitor never scheduled) 같은 인접 follow-up과 함께 처리.

## Defensive guards

- Draft + `do-not-merge` label
- `gh pr merge --disable-auto`

## 관련

- Issue: `#10411`
- 인접: `#10405` (goal_janitor never scheduled — 같은 goal lifecycle gap), `#10388` (cross_verifier cascade existence)
- 메모리: `feedback_no-collapse-richer-enum-at-sdk-boundary.md` (FSM 상태 enum의 풍부한 transition 보존)
