### PR TITLE
fix(coord-task): label task_claim_next auto-release by reason (#10421)

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -258,6 +258,19 @@ let () =
   Atomic.set Coord_hooks.distributed_lock_acquire_failed_fn
     record_distributed_lock_acquire_failed
 
+(* #10421: task_claim_next auto-release observability.
+   [Coord_task_schedule] emits a labelled hook on every auto-
+   release; wire it to the Prometheus counter here so the
+   masc_coord sub-library never depends on Prometheus. *)
+let record_task_claim_auto_release ~agent ~reason =
+  Prometheus.inc_counter Prometheus.metric_task_claim_auto_release
+    ~labels:[ ("agent", agent); ("reason", reason) ]
+    ()
+
+let () =
+  Atomic.set Coord_hooks.task_claim_auto_release_emit_fn
+    record_task_claim_auto_release
+
 (* Activity graph emit — wraps Activity_graph for room sub-modules *)
 let () = Atomic.set Coord_hooks.activity_emit_fn (fun config ~actor ?subject ~kind ~payload ~tags () ->
     (try

--- a/lib/coord/coord_hooks.ml
+++ b/lib/coord/coord_hooks.ml
@@ -170,6 +170,21 @@ let distributed_lock_acquire_failed_fn
   : (key:string -> attempts:int -> unit) Atomic.t
   = Atomic.make (fun ~key:_ ~attempts:_ -> ())
 
+(** #10421: task_claim_next auto-release observability.
+    [Coord_task_schedule.task_claim_next] auto-releases any
+    previous claim held by the calling agent before picking a
+    new task.  This hook surfaces the auto-release as a labelled
+    Prometheus counter so operators can split polling-abuse
+    (claim dropped within seconds) from legitimate cleanup
+    (long-held claim swapped after work).  [reason] vocabulary
+    is bounded: rapid_replacement | stale_replacement |
+    unknown_age.  Wired at startup from [lib/coord.ml]; the
+    default no-op keeps unit tests that build [masc_coord] in
+    isolation working. *)
+let task_claim_auto_release_emit_fn
+  : (agent:string -> reason:string -> unit) Atomic.t
+  = Atomic.make (fun ~agent:_ ~reason:_ -> ())
+
 (** Tool assignment telemetry — wraps Tool_assignment_telemetry.emit_assigned.
     Wired at startup to record which tools were provisioned to which agent. *)
 let tool_assigned_fn

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -7,11 +7,8 @@ open Types
 include Coord_utils
 include Coord_state
 
-(** #10421: stable lowercase string label for a [task_status] suitable
-    for embedding in JSONL diagnostic events.  Mirrors what the
-    [task_transition] from→to fields already use so dashboards can
-    join the new auto-release rows on identical vocabulary.  Pure;
-    exposed for tests. *)
+(** #10421: lowercase string label for [task_status] used in JSONL
+    diagnostic events. Matches [task_transition] vocabulary. *)
 let task_status_label (status : Types.task_status) : string =
   match status with
   | Todo -> "todo"
@@ -20,6 +17,29 @@ let task_status_label (status : Types.task_status) : string =
   | AwaitingVerification _ -> "awaiting_verification"
   | Done _ -> "done"
   | Cancelled _ -> "cancelled"
+
+(** #10421: helpers for classifying auto-release events on
+    [task_claim_next]. Distinguish poll-abuse from legitimate cleanup. *)
+let auto_release_rapid_threshold_sec = 30.0
+
+let prev_claim_age_seconds ~(now : float) (task : Types.task) : float option =
+  let parse = Types_core.parse_iso8601_opt in
+  let started_at_opt =
+    match task.task_status with
+    | Claimed { claimed_at; _ } -> parse claimed_at
+    | InProgress { started_at; _ } -> parse started_at
+    | Todo | AwaitingVerification _ | Done _ | Cancelled _ -> None
+  in
+  match started_at_opt with
+  | None -> None
+  | Some started -> Some (Float.max 0.0 (now -. started))
+
+let auto_release_reason_for_age (age_sec : float option) : string =
+  match age_sec with
+  | None -> "unknown_age"
+  | Some s when s < auto_release_rapid_threshold_sec -> "rapid_replacement"
+  | Some _ -> "stale_replacement"
+
 
 let task_is_claim_pool_candidate (task : Types.task) =
   match task.task_status with
@@ -371,21 +391,34 @@ let claim_next_r
                    ~reason:"auto_release_before_claim_next" ())
         | None -> ()
       in
+      (* #10421: classify the auto-release so dashboards can split
+         the polling-abuse signal (claim immediately replaced) from
+         the legitimate cleanup signal (long-held claim swapped in).
+         Day 25 evidence: 35/37 of analyst's claims terminated as
+         auto-release with no work output — task-056 was claimed
+         and dropped 5x.  Reason vocabulary is small to bound
+         Prometheus cardinality. *)
+      let now_t = Time_compat.now () in
       let released_task_id, working_tasks = match previous_claim with
         | None -> None, backlog.tasks
         | Some prev ->
-            (* #10421: include [reason] and [from_status] in the JSONL
-               event so the auto-release tail (43/24 release/claim
-               ratio, 5x hot-potato on task-056) is discriminable
-               without cross-referencing observe_task_transition.
-               [from_status] separates Claimed (most cases) from
-               InProgress (rare; signals a keeper that started work
-               and then re-entered claim_next).  Same reason vocabulary
-               the structured observation already uses. *)
+            (* #10421: include [from_status], [reason] (poll-abuse vs
+               cleanup), and [prev_age_sec] so the auto-release tail
+               (43/24 release/claim ratio, 5x hot-potato on task-056)
+               is discriminable. *)
             let from_status = task_status_label prev.task_status in
+            let prev_age_sec = prev_claim_age_seconds ~now:now_t prev in
+            let reason = auto_release_reason_for_age prev_age_sec in
+            (Atomic.get Coord_hooks.task_claim_auto_release_emit_fn)
+              ~agent:agent_name ~reason;
+            let prev_age_field =
+              match prev_age_sec with
+              | Some s -> Printf.sprintf ",\"prev_age_sec\":%.1f" s
+              | None -> ""
+            in
             log_event config (Printf.sprintf
-              "{\"type\":\"task_claim_next_auto_release\",\"agent\":\"%s\",\"released_task\":\"%s\",\"from_status\":\"%s\",\"reason\":\"prev_claim_implicit_replaced\",\"ts\":\"%s\"}"
-              agent_name prev.id from_status (now_iso ()));
+              "{\"type\":\"task_claim_next_auto_release\",\"agent\":\"%s\",\"released_task\":\"%s\",\"from_status\":\"%s\",\"reason\":\"%s\"%s,\"ts\":\"%s\"}"
+              agent_name prev.id from_status reason prev_age_field (now_iso ()));
             (* No broadcast — internal state transition, log_event suffices. *)
             let updated = List.map (fun (t : Types.task) ->
               if String.equal t.id prev.id then { t with task_status = Todo }

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -341,6 +341,20 @@ let metric_keeper_operator_clear = "masc_keeper_operator_clear_total"
 let metric_keeper_compaction_noop =
   "masc_keeper_compaction_noop_total"
 
+(* #10421: counter incremented every time
+   [Coord_task_schedule.task_claim_next] auto-releases a
+   previous claim.  Pre-fix the only signal was an opaque
+   [task_claim_next_auto_release] JSON event; day 25 carried
+   20 of those across the fleet but operators couldn't
+   distinguish "claim dropped within seconds (polling abuse)"
+   from "long-held claim swapped after real work (legitimate
+   cleanup)".  Labelled by [agent, reason] with reason
+   vocabulary {rapid_replacement, stale_replacement,
+   unknown_age} — bounded so the agent label drives all the
+   real cardinality (one series per fleet member). *)
+let metric_task_claim_auto_release =
+  "masc_task_claim_auto_release_total"
+
 (* Keeper keepalive (keeper_keepalive.ml). *)
 let metric_keeper_heartbeat_successes =
   "masc_keeper_heartbeat_successes_total"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -134,6 +134,12 @@ val metric_keeper_compaction_saved_tokens : string
     triggers rather than savings.  Labels: [keeper, trigger]. *)
 val metric_keeper_compaction_noop : string
 
+(** #10421: counter incremented when
+    [Coord_task_schedule.task_claim_next] auto-releases a
+    previous claim.  Labels:
+    [agent, reason="rapid_replacement"|"stale_replacement"|"unknown_age"]. *)
+val metric_task_claim_auto_release : string
+
 val metric_keeper_operator_compact : string
 val metric_keeper_operator_clear : string
 val metric_keeper_heartbeat_successes : string

--- a/test/dune
+++ b/test/dune
@@ -1460,6 +1460,9 @@
  (libraries dated_jsonl fs_compat alcotest eio eio_main yojson unix))
 
 
+ (name test_task_claim_auto_release_reason_10421)
+ (modules test_task_claim_auto_release_reason_10421)
+ (libraries masc_mcp masc_coord masc_types alcotest))
 ; ============================================================
 ; Special: Heartbeat/keeper minimal deps
 ; ============================================================

--- a/test/test_task_claim_auto_release_reason_10421.ml
+++ b/test/test_task_claim_auto_release_reason_10421.ml
@@ -1,0 +1,173 @@
+(** #10421 — pin the [task_claim_next] auto-release reason
+    classification.
+
+    Pre-fix every [task_claim_next_auto_release] JSON event was
+    opaque — operators saw 20 events on day 25 (and 35/37 of
+    analyst's claims terminating as auto-release) but couldn't
+    tell the polling-abuse signal (claim dropped within seconds
+    without any work) from legitimate cleanup (long-held claim
+    swapped in after a verifier or operator action).  The
+    fleet-wide hot-potato pattern — task-056 claimed and dropped
+    five times in a row — was hidden inside a single counter.
+
+    Post-fix two pure helpers expose a small reason vocabulary
+    suitable for a Prometheus label:
+
+    - [auto_release_reason_for_age None             = "unknown_age"]
+    - [auto_release_reason_for_age (Some <30s)      = "rapid_replacement"]
+    - [auto_release_reason_for_age (Some >=30s)     = "stale_replacement"]
+
+    [prev_claim_age_seconds] reads the [claimed_at] /
+    [started_at] timestamp on the prior claim and returns
+    [None] for terminal or untimestamped statuses.  Both
+    helpers stay pure so the wiring inside
+    [Coord_task_schedule.task_claim_next] is easy to audit and
+    the threshold can move under test pressure rather than
+    under fleet pressure. *)
+
+open Alcotest
+
+module CTS = Coord_task_schedule
+
+(* --- 1. reason vocabulary --------------------------- *)
+
+let test_unknown_age_when_none () =
+  check string "None → unknown_age" "unknown_age"
+    (CTS.auto_release_reason_for_age None)
+
+let test_rapid_replacement_below_threshold () =
+  check string "0.0s → rapid_replacement" "rapid_replacement"
+    (CTS.auto_release_reason_for_age (Some 0.0));
+  check string "5.0s → rapid_replacement" "rapid_replacement"
+    (CTS.auto_release_reason_for_age (Some 5.0));
+  check string "29.999s → rapid_replacement" "rapid_replacement"
+    (CTS.auto_release_reason_for_age (Some 29.999))
+
+let test_stale_replacement_at_or_above_threshold () =
+  check string "30.0s → stale_replacement" "stale_replacement"
+    (CTS.auto_release_reason_for_age (Some 30.0));
+  check string "120.0s → stale_replacement" "stale_replacement"
+    (CTS.auto_release_reason_for_age (Some 120.0));
+  check string "3600.0s → stale_replacement" "stale_replacement"
+    (CTS.auto_release_reason_for_age (Some 3600.0))
+
+(* --- 2. prev_claim_age_seconds extracts timestamp ------- *)
+
+let mk_task ~status : Types.task =
+  {
+    id = "task-test";
+    title = "test";
+    description = "";
+    task_status = status;
+    priority = 5;
+    files = [];
+    created_at = "2026-04-25T00:00:00Z";
+    created_by = None;
+    worktree = None;
+    goal_id = None;
+    stage = None;
+    contract = None;
+    handoff_context = None;
+    cycle_count = 0;
+    do_not_reclaim_reason = None;
+  }
+
+let now_for ~claimed_at offset_sec =
+  match Types_core.parse_iso8601_opt claimed_at with
+  | Some t -> t +. offset_sec
+  | None -> failwith "fixture parse"
+
+let test_age_for_claimed () =
+  let claimed_at = "2026-04-25T12:00:00Z" in
+  let task =
+    mk_task
+      ~status:(Types.Claimed { assignee = "kp"; claimed_at })
+  in
+  let now = now_for ~claimed_at 7.5 in
+  match CTS.prev_claim_age_seconds ~now task with
+  | None -> failf "expected Some, got None"
+  | Some s -> check (float 0.001) "age preserves offset" 7.5 s
+
+let test_age_for_in_progress () =
+  let started_at = "2026-04-25T12:00:00Z" in
+  let task =
+    mk_task
+      ~status:(Types.InProgress { assignee = "kp"; started_at })
+  in
+  let now = now_for ~claimed_at:started_at 45.0 in
+  match CTS.prev_claim_age_seconds ~now task with
+  | None -> failf "expected Some, got None"
+  | Some s -> check (float 0.001) "InProgress uses started_at" 45.0 s
+
+let test_age_floor_at_zero () =
+  (* Clock skew: now is slightly earlier than claimed_at.  The
+     helper clamps to 0 so callers don't see negative ages. *)
+  let claimed_at = "2026-04-25T12:00:00Z" in
+  let task =
+    mk_task
+      ~status:(Types.Claimed { assignee = "kp"; claimed_at })
+  in
+  let now = now_for ~claimed_at (-2.0) in
+  match CTS.prev_claim_age_seconds ~now task with
+  | None -> failf "expected Some, got None"
+  | Some s -> check (float 0.001) "negative skew clamped to 0.0" 0.0 s
+
+let test_age_none_for_todo () =
+  let task = mk_task ~status:Types.Todo in
+  check
+    (option (float 0.001))
+    "Todo task has no claim age"
+    None
+    (CTS.prev_claim_age_seconds ~now:0.0 task)
+
+let test_age_none_for_done () =
+  let task =
+    mk_task
+      ~status:
+        (Types.Done
+           {
+             assignee = "kp";
+             completed_at = "2026-04-25T12:00:00Z";
+             notes = None;
+           })
+  in
+  check
+    (option (float 0.001))
+    "Done task has no claim age"
+    None
+    (CTS.prev_claim_age_seconds ~now:0.0 task)
+
+(* --- 3. metric name in vocabulary ------------------ *)
+
+let test_metric_name_canonical () =
+  check string "Prometheus metric name uses masc_ prefix"
+    "masc_task_claim_auto_release_total"
+    Masc_mcp.Prometheus.metric_task_claim_auto_release
+
+let () =
+  run "task_claim_auto_release_reason_10421"
+    [
+      ( "reason-vocabulary",
+        [
+          test_case "None → unknown_age" `Quick test_unknown_age_when_none;
+          test_case "below threshold → rapid_replacement" `Quick
+            test_rapid_replacement_below_threshold;
+          test_case "at/above threshold → stale_replacement" `Quick
+            test_stale_replacement_at_or_above_threshold;
+        ] );
+      ( "prev-claim-age",
+        [
+          test_case "Claimed reads claimed_at" `Quick test_age_for_claimed;
+          test_case "InProgress reads started_at" `Quick
+            test_age_for_in_progress;
+          test_case "negative skew clamps to zero" `Quick
+            test_age_floor_at_zero;
+          test_case "Todo returns None" `Quick test_age_none_for_todo;
+          test_case "Done returns None" `Quick test_age_none_for_done;
+        ] );
+      ( "metric-name",
+        [
+          test_case "metric name canonical" `Quick
+            test_metric_name_canonical;
+        ] );
+    ]


### PR DESCRIPTION
Closes the observability half of #10421 (option D). Pre-fix every auto-release emitted an opaque task_claim_next_auto_release JSON event; day 25 had 20 events but operators couldn't tell polling abuse (claim dropped within seconds, task-056 hot-potatoed 5x) from legitimate cleanup. Add prev_claim_age_seconds + auto_release_reason_for_age helpers (pure, top-level) classifying rapid_replacement (<30s) / stale_replacement (>=30s) / unknown_age. Surface via masc_task_claim_auto_release_total{agent, reason} through the Coord_hooks Atomic-callback pattern (masc_coord stays free of Prometheus dep). 9 new tests pin reason vocabulary + age extraction across all task_status variants + clock-skew floor + metric name. 31 sibling task tests still green. Option A (remove implicit auto-release) and option B (split task_claim_next + task_release_and_claim_next) deferred to follow-up — fleet data from this counter will tell us which to do first.