### PR TITLE
feat(design-system): semantic color tokens + theme infra

### DIFF
--- a/dashboard/design-system/README.md
+++ b/dashboard/design-system/README.md
@@ -161,6 +161,79 @@ Bundled as `--elev-0 … --elev-6` (bg + border + shadow). Low-level elements st
 
 ---
 
+## Token tiers & theming
+
+Tokens are arranged in three layers. Components should reference the
+**semantic** layer when possible so theme overrides flow without
+touching component CSS.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ raw         #0c0b08    #d4a14a    #6b9e6b                    │
+│             --bg-0     --brass-1  --ok                       │
+│ ▼                                                            │
+│ semantic    --color-bg-page   --color-accent-fg              │
+│             --color-fg-primary  --color-status-added         │
+│             --color-keeper-1..5  --color-focus-ring          │
+│ ▼                                                            │
+│ component   .ix-tree { background: var(--color-bg-surface) } │
+│             .chip   { color: var(--color-accent-fg) }        │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**Raw tier** — palette anchors. Defined in `source_styles/tokens.css` and
+mirrored in `colors_and_type.css`. Treat as private-ish: prefer the
+semantic alias unless you genuinely need a literal palette pick.
+
+**Semantic tier** — meaning over hex. The full alias matrix:
+
+| Alias | Maps to (dark default) | Used for |
+|-------|------------------------|----------|
+| `--color-bg-page` | `--bg-0` | top-level page bg |
+| `--color-bg-surface` | `--bg-1` | resting panel / chrome |
+| `--color-bg-elevated` | `--bg-2` | card / popover |
+| `--color-fg-primary` | `--fg-1` | body text |
+| `--color-fg-secondary` | `--fg-2` | label / dim text |
+| `--color-fg-muted` | `--fg-3` | caption / disabled |
+| `--color-border-default` | `--line-1` | hairline border |
+| `--color-border-strong` | `--line-2` | emphasized border |
+| `--color-accent` | `--brass-1` | active/running marker |
+| `--color-accent-fg` | `--brass-1` | text/glyph on accent |
+| `--color-status-added` | `--ok` | diff added / created |
+| `--color-status-modified` | `--warn` | diff modified / at-risk |
+| `--color-status-deleted` | `--err` | diff deleted / failed |
+| `--color-keeper-1..5` | `--k-{nick,masc,sangsu,qa,rama}` | fleet attribution |
+| `--color-focus-ring` | `--brass-1` | `:focus-visible` outline color |
+
+**Component tier** — the actual component CSS. References semantic
+aliases. Migrating a component from raw to semantic is a one-line swap.
+
+### Theming
+
+The system is **dark-by-design**. A `[data-theme="light"]` override
+exists as foundation infrastructure for future surfaces but the dark
+brass aesthetic remains the canonical look.
+
+```js
+import { setTheme, getTheme } from './preview/cb-shared.jsx';
+
+setTheme('light');   // flips semantic aliases, persists to localStorage
+setTheme('dark');    // explicit dark
+setTheme(null);      // clear → falls back to prefers-color-scheme
+```
+
+The override only redefines the **semantic** alias values. Raw tokens
+(`--bg-0`, `--brass-1`) keep their dark values. A component still using
+raw tokens stays dark in light mode — this is intentional. Migration is
+gradual: swap component CSS from raw to semantic and the theme starts
+working for that component.
+
+`@media (prefers-color-scheme: light)` is honored only when no explicit
+`data-theme` is set, so a user's chosen theme is never overridden by OS
+preference.
+
+---
+
 ## Iconography
 
 MASC uses **essentially no icons**. This is deliberate.

--- a/dashboard/design-system/preview/cb-group-a.jsx
+++ b/dashboard/design-system/preview/cb-group-a.jsx
@@ -11,13 +11,15 @@ function TopbarStandard() {
   return (
     <div className="cb-board">
       <header className="cb-topbar" aria-label="MASC topbar">
+      <header className="cb-topbar" role="banner" aria-label="MASC topbar">
         <div className="brand">
           <span className="brand-mark" aria-hidden="true" />
           <span className="brand-name">MASC</span>
-          <span className="ver">v0.42.1</span>
+          <span className="ver" aria-label="Build version 0.42.1">v0.42.1</span>
         </div>
         <div className="sep" aria-hidden="true" />
         <button type="button" className="goal-switch" aria-haspopup="menu" aria-label="Switch goal: goal-merge-blockers">
+        <button type="button" className="goal-switch" aria-haspopup="menu" aria-label="Active goal: goal-merge-blockers">
           <Dot kind="brass" size="sm" />
           <span>goal-merge-blockers</span>
           <span className="caret" aria-hidden="true">▾</span>
@@ -25,6 +27,7 @@ function TopbarStandard() {
         <div className="mode-tabs" role="tablist" aria-label="View mode">
           {[['dash','Dash'],['code','Code'],['split','Split']].map(([k,l]) => (
             <button key={k} type="button" role="tab" aria-selected={mode===k} tabIndex={mode===k?0:-1} className={mode===k?'on':''} onClick={()=>setMode(k)}>{l}</button>
+            <button key={k} type="button" role="tab" aria-selected={mode===k} tabIndex={mode===k ? 0 : -1} className={mode===k?'on':''} onClick={()=>setMode(k)}>{l}</button>
           ))}
         </div>
         <div className="right">
@@ -32,8 +35,10 @@ function TopbarStandard() {
             {['c','n','l'].map(d => (
               <button key={d} type="button" role="radio" aria-checked={density===d} aria-label={DENSITY_LABEL[d]} className={density===d?'on':''} onClick={()=>setDensity(d)}>{d}</button>
             ))}
+          <div className="density" role="radiogroup" aria-label="Density">
+            {['c','n','l'].map(d => <button key={d} type="button" role="radio" aria-checked={density===d} className={density===d?'on':''} onClick={()=>setDensity(d)}>{d}</button>)}
           </div>
-          <span className="stamp">BUILD 2604 · 16:32:45Z</span>
+          <span className="stamp" aria-label="Build 2604, 16:32:45 UTC">BUILD 2604 · 16:32:45Z</span>
         </div>
       </header>
       <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
@@ -46,13 +51,15 @@ function TopbarExpanded() {
   return (
     <div className="cb-board">
       <header className="cb-topbar" aria-label="MASC topbar with branch and fleet">
+      <header className="cb-topbar" role="banner" aria-label="MASC topbar (expanded)">
         <div className="brand">
           <span className="brand-mark" aria-hidden="true" />
           <span className="brand-name">MASC</span>
-          <span className="ver">v0.42.1</span>
+          <span className="ver" aria-label="Build version 0.42.1">v0.42.1</span>
         </div>
         <div className="sep" aria-hidden="true" />
         <button type="button" className="goal-switch" aria-haspopup="menu" aria-label="Switch goal: goal-merge-blockers">
+        <button type="button" className="goal-switch" aria-haspopup="menu" aria-label="Active goal: goal-merge-blockers">
           <Dot kind="brass" size="sm" />
           <span>goal-merge-blockers</span>
           <span className="caret" aria-hidden="true">▾</span>
@@ -60,8 +67,10 @@ function TopbarExpanded() {
         <span className="branch" aria-label="Active branch: release-0.42">release-0.42</span>
         <div className="sep" aria-hidden="true" />
         <div className="mode-tabs" role="tablist" aria-label="View mode">
+        <span className="branch" aria-label="Branch release-0.42">release-0.42</span>
           {[['dash','Dash'],['code','Code'],['split','Split']].map(([k,l]) => (
             <button key={k} type="button" role="tab" aria-selected={mode===k} tabIndex={mode===k?0:-1} className={mode===k?'on':''} onClick={()=>setMode(k)}>{l}</button>
+            <button key={k} type="button" role="tab" aria-selected={mode===k} tabIndex={mode===k ? 0 : -1} className={mode===k?'on':''} onClick={()=>setMode(k)}>{l}</button>
           ))}
         </div>
         <div className="right">
@@ -71,8 +80,14 @@ function TopbarExpanded() {
             <span className="av" style={{background:'var(--k-sangsu)'}} aria-hidden="true" />
             <span className="av" style={{background:'var(--k-qa)'}} aria-hidden="true" />
             <span className="av" style={{background:'var(--k-rama)'}} aria-hidden="true" />
+          <div className="avatars" role="list" aria-label="Active keepers: nick0cave, masc-improver, sangsu, qa-king, rama">
+            <span className="av" role="listitem" aria-label="nick0cave" style={{background:'var(--k-nick)'}} />
+            <span className="av" role="listitem" aria-label="masc-improver" style={{background:'var(--k-masc)'}} />
+            <span className="av" role="listitem" aria-label="sangsu" style={{background:'var(--k-sangsu)'}} />
+            <span className="av" role="listitem" aria-label="qa-king" style={{background:'var(--k-qa)'}} />
+            <span className="av" role="listitem" aria-label="rama" style={{background:'var(--k-rama)'}} />
           </div>
-          <span className="stamp">5 ACTIVE · 2 IDLE</span>
+          <span className="stamp" aria-label="5 active keepers, 2 idle">5 ACTIVE · 2 IDLE</span>
         </div>
       </header>
       <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
@@ -84,6 +99,7 @@ function TopbarMinimal() {
   return (
     <div className="cb-board">
       <header className="cb-topbar minimal" aria-label="MASC topbar (minimal)">
+      <header className="cb-topbar minimal" role="banner" aria-label="MASC topbar (minimal)">
         <div className="brand">
           <span className="brand-mark" aria-hidden="true" />
           <span className="brand-name">MASC</span>
@@ -93,7 +109,7 @@ function TopbarMinimal() {
           <button type="button" role="tab" aria-selected="false" tabIndex={-1}>Code</button>
         </div>
         <div className="right">
-          <span className="stamp">16:32:45Z</span>
+          <span className="stamp" aria-label="16:32:45 UTC">16:32:45Z</span>
         </div>
       </header>
       <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
@@ -110,13 +126,14 @@ function TickerMarquee() {
   return (
     <div className="cb-board">
       <div className="cb-ticker" role="region" aria-label="Fleet event ticker (marquee)">
+      <div className="cb-ticker" role="log" aria-live="polite" aria-label="Fleet event ticker (marquee)">
         <div className="tape">
           {evs.map((e, i) => (
-            <span key={i} className={`evt ${e.kind}`}>
+            <span key={i} className={`evt ${e.kind}`} role="listitem" aria-label={`${e.keeper} ${e.kind}: ${e.text}, at ${e.t.slice(0,8)}`}>
               <Dot kind={kClass(e.keeper)} size="sm" />
-              <span className="k">{e.keeper}</span>
-              <span className="body">{e.text}</span>
-              <span className="t">{e.t.slice(0,8)}</span>
+              <span className="k" aria-hidden="true">{e.keeper}</span>
+              <span className="body" aria-hidden="true">{e.text}</span>
+              <span className="t" aria-hidden="true">{e.t.slice(0,8)}</span>
             </span>
           ))}
         </div>
@@ -130,12 +147,13 @@ function TickerChunks() {
   return (
     <div className="cb-board">
       <div className="cb-ticker chunks" role="region" aria-label="Fleet event ticker (chunked)">
+      <div className="cb-ticker chunks" role="log" aria-live="polite" aria-label="Fleet event ticker (chunked)">
         <div className="tape">
           {evs.map((e, i) => (
-            <span key={i} className={`evt ${e.kind}`}>
+            <span key={i} className={`evt ${e.kind}`} role="listitem" aria-label={`${e.keeper} ${e.kind}: ${e.text.slice(0,40)}`}>
               <Dot kind={kClass(e.keeper)} size="sm" />
-              <span className="k">{e.keeper}</span>
-              <span className="body">{e.text.slice(0, 40)}</span>
+              <span className="k" aria-hidden="true">{e.keeper}</span>
+              <span className="body" aria-hidden="true">{e.text.slice(0, 40)}</span>
             </span>
           ))}
         </div>
@@ -149,13 +167,14 @@ function TickerVertical() {
   return (
     <div className="cb-board">
       <div className="cb-ticker vertical" role="region" aria-label="Fleet event ticker (side rail)">
+      <div className="cb-ticker vertical" role="log" aria-live="polite" aria-label="Fleet event ticker (vertical)">
         <div className="tape">
           {evs.map((e, i) => (
-            <span key={i} className={`evt ${e.kind}`} style={{display:'flex', alignItems:'center', gap:6}}>
-              <span className="t">{e.t.slice(0,8)}</span>
+            <span key={i} className={`evt ${e.kind}`} role="listitem" aria-label={`${e.t.slice(0,8)} ${e.keeper} ${e.kind}: ${e.text}`} style={{display:'flex', alignItems:'center', gap:6}}>
+              <span className="t" aria-hidden="true">{e.t.slice(0,8)}</span>
               <Dot kind={kClass(e.keeper)} size="sm" />
-              <span className="k">{e.keeper}</span>
-              <span className="body">{e.text}</span>
+              <span className="k" aria-hidden="true">{e.keeper}</span>
+              <span className="body" aria-hidden="true">{e.text}</span>
             </span>
           ))}
         </div>
@@ -182,15 +201,24 @@ function kpiCellAriaLabel(c) {
   return `${c.lbl}: ${c.val} ${c.cap}${delta}${kind}${live}`;
 }
 
+function kpiCellLabel(c) {
+  const parts = [`${c.lbl}: ${c.val}`, c.cap];
+  if (c.delta) parts.push(`delta ${c.delta}`);
+  if (c.kind === 'ok') parts.push('ok');
+  if (c.kind === 'err') parts.push('error');
+  if (c.live) parts.push('live');
+  return parts.filter(Boolean).join(', ');
 function KpiStandard() {
   return (
     <div className="cb-board">
       <div className="cb-kpi" role="list" aria-label="Fleet KPI strip">
+      <div className="cb-kpi" role="list" aria-label="KPI strip (standard)">
         {KPI_CELLS.map((c, i) => (
           <div key={i} role="listitem" aria-label={kpiCellAriaLabel(c)} className={`cell ${c.live?'live':''} ${c.kind?`is-${c.kind}`:''}`}>
             <span className="lbl" aria-hidden="true">{c.lbl}</span>
             <span className="val" aria-hidden="true">{c.val}</span>
             <span className="cap" aria-hidden="true">{c.cap}{c.delta ? <> · <span className={`delta ${c.deltaKind}`}>{c.delta}</span></> : null}</span>
+          <div key={i} role="listitem" aria-label={kpiCellLabel(c)} className={`cell ${c.live?'live':''} ${c.kind?`is-${c.kind}`:''}`}>
             {c.spark ? <Spark color={c.live?'brass':'brass'} bars={14} /> : null}
           </div>
         ))}
@@ -203,10 +231,12 @@ function KpiCompact() {
   return (
     <div className="cb-board">
       <div className="cb-kpi compact" role="list" aria-label="Fleet KPI strip (compact)">
+      <div className="cb-kpi compact" role="list" aria-label="KPI strip (compact)">
         {KPI_CELLS.map((c, i) => (
           <div key={i} role="listitem" aria-label={kpiCellAriaLabel(c)} className={`cell ${c.live?'live':''} ${c.kind?`is-${c.kind}`:''}`}>
             <span className="lbl" aria-hidden="true">{c.lbl}</span>
             <span className="val" aria-hidden="true">{c.val}</span>
+          <div key={i} role="listitem" aria-label={`${c.lbl}: ${c.val}`} className={`cell ${c.live?'live':''} ${c.kind?`is-${c.kind}`:''}`}>
           </div>
         ))}
       </div>
@@ -218,11 +248,13 @@ function KpiStacked() {
   return (
     <div className="cb-board">
       <div className="cb-kpi stacked" role="list" aria-label="Fleet KPI strip (stacked)">
+      <div className="cb-kpi stacked" role="list" aria-label="KPI strip (stacked)">
         {KPI_CELLS.slice(0,6).map((c, i) => (
           <div key={i} role="listitem" aria-label={kpiCellAriaLabel(c)} className={`cell ${c.live?'live':''} ${c.kind?`is-${c.kind}`:''}`}>
             <span className="lbl" aria-hidden="true">{c.lbl}</span>
             <span className="val big" aria-hidden="true">{c.val}</span>
             <span className="cap" aria-hidden="true">{c.cap}</span>
+          <div key={i} role="listitem" aria-label={kpiCellLabel(c)} className={`cell ${c.live?'live':''} ${c.kind?`is-${c.kind}`:''}`}>
           </div>
         ))}
       </div>
@@ -244,6 +276,8 @@ function LifelineBeat() {
         <span className="label" aria-hidden="true">LIFELINE</span>
         <Heartbeat phase={phase} />
         <span className="bpm" aria-hidden="true"><span className="n">72</span> BPM · 60s</span>
+      <div className="cb-lifeline" role="region" aria-label="Lifeline · 72 BPM, 60 second window">
+        <span aria-hidden="true"><Heartbeat phase={phase} /></span>
       </div>
       <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
     </div>
@@ -256,10 +290,13 @@ function LifelineStacked() {
   return (
     <div className="cb-board">
       <div className="cb-lifeline stack" role="list" aria-label="Per-keeper heartbeat lifelines">
+      <div className="cb-lifeline stack" role="list" aria-label="Per-keeper lifelines">
         {fleet.map((k, i) => (
           <div className="row" key={k.id} role="listitem" aria-label={`${k.id} heartbeat, ${k.status === 'running' ? 'running' : k.status}`}>
             <span className="name" aria-hidden="true">{k.id}</span>
             <Heartbeat width={240} height={14} phase={(phase + i*0.07) % 1} />
+          <div className="row" key={k.id} role="listitem" aria-label={`${k.id} · ${k.status === 'running' ? 'running' : 'idle'}`}>
+            <span aria-hidden="true"><Heartbeat width={240} height={14} phase={(phase + i*0.07) % 1} /></span>
             <Dot kind={kClass(k.id)} size="sm" beat={k.status==='running'} />
           </div>
         ))}

--- a/dashboard/design-system/preview/cb-group-b.jsx
+++ b/dashboard/design-system/preview/cb-group-b.jsx
@@ -1,32 +1,55 @@
 // cb-group-b.jsx — Sidebar, Swimlanes, Deck, Rail
 const D2 = window.MASC_DATA;
 
+function activateOnEnterOrSpace(handler) {
+  return (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handler();
+    }
+  };
+}
+
 // ─── SIDEBAR variants ──────────────────────────────────────────────
 function SidebarFleet() {
   const [sel, setSel] = useState('nick0cave');
   return (
-    <div className="cb-sidebar">
-      <div className="sec-h">FLEET <span className="count">{D2.keepers.length}</span></div>
-      {D2.keepers.map(k => (
-        <div key={k.id} className={`row ${sel===k.id?'sel':''} ${k.status==='idle'?'idle':''}`} onClick={()=>setSel(k.id)}>
-          <Dot kind={kClass(k.id)} size="sm" beat={k.status==='running'} />
-          <span className="name">{k.id}</span>
-          <span className="meta">{k.task}</span>
-        </div>
-      ))}
-      <div className="sec-h" style={{marginTop:4}}>GOALS <span className="count">{D2.goals.length}</span></div>
-      {D2.goals.map(g => (
-        <div key={g.id} className="row goal-row">
-          <div className="id">{g.id}</div>
-          <div className="title">{g.title}</div>
-          <div className="meta-row">
-            <span>{g.progress}/{g.total}</span>
-            <span className="bar" style={{flex:1, height:3}}><span className="fill" style={{width:`${100*g.progress/g.total}%`}} /></span>
-            <span>P{g.priority}</span>
+    <nav className="cb-sidebar" aria-label="Fleet sidebar">
+      <div className="sec-h" role="heading" aria-level={3}>FLEET <span className="count">{D2.keepers.length}</span></div>
+      <div role="list" aria-label="Keepers">
+        {D2.keepers.map(k => (
+          <div key={k.id}
+               role="listitem"
+               aria-label={`${k.id} · ${k.task} · ${k.status}${sel===k.id ? ' · selected' : ''}`}
+               aria-selected={sel===k.id}
+               tabIndex={0}
+               onClick={()=>setSel(k.id)}
+               onKeyDown={activateOnEnterOrSpace(()=>setSel(k.id))}
+               className={`row ${sel===k.id?'sel':''} ${k.status==='idle'?'idle':''}`}>
+            <Dot kind={kClass(k.id)} size="sm" beat={k.status==='running'} />
+            <span className="name" aria-hidden="true">{k.id}</span>
+            <span className="meta" aria-hidden="true">{k.task}</span>
           </div>
-        </div>
-      ))}
-    </div>
+        ))}
+      </div>
+      <div className="sec-h" role="heading" aria-level={3} style={{marginTop:4}}>GOALS <span className="count">{D2.goals.length}</span></div>
+      <div role="list" aria-label="Goals">
+        {D2.goals.map(g => (
+          <div key={g.id}
+               role="listitem"
+               aria-label={`${g.id} · ${g.title} · ${g.progress} of ${g.total} · priority ${g.priority}`}
+               className="row goal-row">
+            <div className="id" aria-hidden="true">{g.id}</div>
+            <div className="title" aria-hidden="true">{g.title}</div>
+            <div className="meta-row" aria-hidden="true">
+              <span>{g.progress}/{g.total}</span>
+              <span className="bar" style={{flex:1, height:3}}><span className="fill" style={{width:`${100*g.progress/g.total}%`}} /></span>
+              <span>P{g.priority}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </nav>
   );
 }
 
@@ -35,41 +58,61 @@ function SidebarGrouped() {
   const other = D2.keepers.filter(k=>!(k.status==='running'||k.status==='pending'));
   const [sel, setSel] = useState('nick0cave');
   return (
-    <div className="cb-sidebar">
-      <div className="sec-h">ACTIVE <span className="count">{active.length}</span></div>
-      {active.map(k => (
-        <div key={k.id} className={`row ${sel===k.id?'sel':''}`} onClick={()=>setSel(k.id)}>
-          <Dot kind={kClass(k.id)} size="sm" beat={k.status==='running'} />
-          <span className="name">{k.id}</span>
-          <span className="meta">{k.t || k.task}</span>
-        </div>
-      ))}
-      <div className="sec-h">STANDBY <span className="count">{other.length}</span></div>
-      {other.map(k => (
-        <div key={k.id} className="row idle">
-          <Dot kind={k.status==='stalled'?'stalled':k.status==='fail'?'err':'idle'} size="sm" />
-          <span className="name">{k.id}</span>
-          <span className="meta">{k.status}</span>
-        </div>
-      ))}
-    </div>
+    <nav className="cb-sidebar" aria-label="Fleet sidebar (grouped)">
+      <div className="sec-h" role="heading" aria-level={3}>ACTIVE <span className="count">{active.length}</span></div>
+      <div role="list" aria-label="Active keepers">
+        {active.map(k => (
+          <div key={k.id}
+               role="listitem"
+               aria-label={`${k.id} · ${k.t || k.task}${sel===k.id ? ' · selected' : ''}`}
+               aria-selected={sel===k.id}
+               tabIndex={0}
+               onClick={()=>setSel(k.id)}
+               onKeyDown={activateOnEnterOrSpace(()=>setSel(k.id))}
+               className={`row ${sel===k.id?'sel':''}`}>
+            <Dot kind={kClass(k.id)} size="sm" beat={k.status==='running'} />
+            <span className="name" aria-hidden="true">{k.id}</span>
+            <span className="meta" aria-hidden="true">{k.t || k.task}</span>
+          </div>
+        ))}
+      </div>
+      <div className="sec-h" role="heading" aria-level={3}>STANDBY <span className="count">{other.length}</span></div>
+      <div role="list" aria-label="Standby keepers">
+        {other.map(k => (
+          <div key={k.id} role="listitem" aria-label={`${k.id} · ${k.status}`} className="row idle">
+            <Dot kind={k.status==='stalled'?'stalled':k.status==='fail'?'err':'idle'} size="sm" />
+            <span className="name" aria-hidden="true">{k.id}</span>
+            <span className="meta" aria-hidden="true">{k.status}</span>
+          </div>
+        ))}
+      </div>
+    </nav>
   );
 }
 
 function SidebarIcons() {
   const [sel, setSel] = useState('nick0cave');
   return (
-    <div className="cb-sidebar icons">
-      <div className="sec-h">FLEET <span className="count">{D2.keepers.length}</span></div>
-      {D2.keepers.map(k => (
-        <div key={k.id} className={`row ${sel===k.id?'sel':''} ${k.status==='idle'?'idle':''}`} onClick={()=>setSel(k.id)}>
-          <span className="icon">{k.role[0]}</span>
-          <Dot kind={kClass(k.id)} size="sm" beat={k.status==='running'} />
-          <span className="name">{k.id}</span>
-          <span className="meta">{k.task}</span>
-        </div>
-      ))}
-    </div>
+    <nav className="cb-sidebar icons" aria-label="Fleet sidebar (icons)">
+      <div className="sec-h" role="heading" aria-level={3}>FLEET <span className="count">{D2.keepers.length}</span></div>
+      <div role="list" aria-label="Keepers">
+        {D2.keepers.map(k => (
+          <div key={k.id}
+               role="listitem"
+               aria-label={`${k.role}: ${k.id} · ${k.task}${sel===k.id ? ' · selected' : ''}`}
+               aria-selected={sel===k.id}
+               tabIndex={0}
+               onClick={()=>setSel(k.id)}
+               onKeyDown={activateOnEnterOrSpace(()=>setSel(k.id))}
+               className={`row ${sel===k.id?'sel':''} ${k.status==='idle'?'idle':''}`}>
+            <span className="icon" aria-hidden="true">{k.role[0]}</span>
+            <Dot kind={kClass(k.id)} size="sm" beat={k.status==='running'} />
+            <span className="name" aria-hidden="true">{k.id}</span>
+            <span className="meta" aria-hidden="true">{k.task}</span>
+          </div>
+        ))}
+      </div>
+    </nav>
   );
 }
 
@@ -79,25 +122,32 @@ function SwimlanesGlyph() {
   const [sel, setSel] = useState('nick0cave');
   const nowX = 0.78;
   return (
-    <div className="cb-swim">
-      <div className="axis">
+    <div className="cb-swim" role="region" aria-label="Fleet swimlanes · 60-second window">
+      <div className="axis" aria-hidden="true">
         <span>-60s</span><span>-45s</span><span>-30s</span><span>-15s</span><span>NOW</span>
       </div>
       <div className="lanes-body">
         {lanes.map(k => (
-          <div key={k.id} className={`lane ${sel===k.id?'sel':''}`} onClick={()=>setSel(k.id)}>
+          <div key={k.id}
+               role="group"
+               aria-label={`${k.id} timeline${sel===k.id ? ' · selected' : ''}`}
+               aria-selected={sel===k.id}
+               tabIndex={0}
+               onClick={()=>setSel(k.id)}
+               onKeyDown={activateOnEnterOrSpace(()=>setSel(k.id))}
+               className={`lane ${sel===k.id?'sel':''}`}>
             <div className="lane-head">
               <Dot kind={kClass(k.id)} size="sm" beat={k.status==='running'} />
-              <span className="name">{k.id}</span>
+              <span className="name" aria-hidden="true">{k.id}</span>
             </div>
-            <div className="lane-track">
+            <div className="lane-track" aria-hidden="true">
               {(D2.laneEvents[k.id]||[]).map((e,i) => (
                 <span key={i} className={`ev ev-${e.k}`} style={{left:`${e.x*100}%`}} />
               ))}
             </div>
           </div>
         ))}
-        <div className="now" style={{left:`calc(130px + ${nowX*100}% - ${nowX*130}px)`}}>
+        <div className="now" aria-hidden="true" style={{left:`calc(130px + ${nowX*100}% - ${nowX*130}px)`}}>
           <span className="head">NOW</span>
         </div>
       </div>
@@ -108,25 +158,25 @@ function SwimlanesDense() {
   const lanes = D2.keepers.slice(0,8);
   const nowX = 0.78;
   return (
-    <div className="cb-swim dense">
-      <div className="axis">
+    <div className="cb-swim dense" role="region" aria-label="Fleet swimlanes · dense, 60-second window">
+      <div className="axis" aria-hidden="true">
         <span>-60s</span><span>-45s</span><span>-30s</span><span>-15s</span><span>NOW</span>
       </div>
       <div className="lanes-body">
         {lanes.map(k => (
-          <div key={k.id} className="lane">
+          <div key={k.id} role="group" aria-label={`${k.id} timeline`} className="lane">
             <div className="lane-head">
               <Dot kind={kClass(k.id)} size="sm" beat={k.status==='running'} />
-              <span className="name">{k.id}</span>
+              <span className="name" aria-hidden="true">{k.id}</span>
             </div>
-            <div className="lane-track">
+            <div className="lane-track" aria-hidden="true">
               {(D2.laneEvents[k.id]||[]).map((e,i) => (
                 <span key={i} className={`ev ev-${e.k}`} style={{left:`${e.x*100}%`}} />
               ))}
             </div>
           </div>
         ))}
-        <div className="now" style={{left:`calc(130px + ${nowX*100}% - ${nowX*130}px)`}}>
+        <div className="now" aria-hidden="true" style={{left:`calc(130px + ${nowX*100}% - ${nowX*130}px)`}}>
           <span className="head">NOW</span>
         </div>
       </div>
@@ -136,7 +186,6 @@ function SwimlanesDense() {
 function SwimlanesBars() {
   const lanes = D2.keepers.slice(0,5);
   const nowX = 0.78;
-  // aggregate segments
   const agg = {
     'nick0cave':     [{x:.05,w:.14},{x:.22,w:.22},{x:.60,w:.16}],
     'masc-improver': [{x:.08,w:.20},{x:.42,w:.28}],
@@ -145,25 +194,25 @@ function SwimlanesBars() {
     'rama':          [{x:.06,w:.22}],
   };
   return (
-    <div className="cb-swim bars">
-      <div className="axis">
+    <div className="cb-swim bars" role="region" aria-label="Fleet swimlanes · aggregated bars, 60-second window">
+      <div className="axis" aria-hidden="true">
         <span>-60s</span><span>-45s</span><span>-30s</span><span>-15s</span><span>NOW</span>
       </div>
       <div className="lanes-body">
         {lanes.map(k => (
-          <div key={k.id} className="lane">
+          <div key={k.id} role="group" aria-label={`${k.id} aggregated timeline`} className="lane">
             <div className="lane-head">
               <Dot kind={kClass(k.id)} size="sm" beat={k.status==='running'} />
-              <span className="name">{k.id}</span>
+              <span className="name" aria-hidden="true">{k.id}</span>
             </div>
-            <div className="lane-track">
+            <div className="lane-track" aria-hidden="true">
               {(agg[k.id]||[]).map((a,i) => (
                 <span key={i} className="agg" style={{left:`${a.x*100}%`, width:`${a.w*100}%`}} />
               ))}
             </div>
           </div>
         ))}
-        <div className="now" style={{left:`calc(130px + ${nowX*100}% - ${nowX*130}px)`}}>
+        <div className="now" aria-hidden="true" style={{left:`calc(130px + ${nowX*100}% - ${nowX*130}px)`}}>
           <span className="head">NOW</span>
         </div>
       </div>
@@ -176,24 +225,43 @@ const TABS = [
   ['board','Board',0],['tasks','Tasks',7],['goals','Goals',4],
   ['ver','Verified',12],['prov','Providers',4],['sand','Sandbox',0],['casc','Cascade',3],
 ];
+
+function DeckTabs({active, onSelect}) {
+  return (
+    <div className="tabs" role="tablist" aria-label="Deck sections">
+      {TABS.map(([k,l,n]) => (
+        <button key={k}
+                type="button"
+                role="tab"
+                aria-selected={active===k}
+                tabIndex={active===k ? 0 : -1}
+                aria-label={n ? `${l}, ${n} items` : l}
+                className={`tab ${active===k?'on':''}`}
+                onClick={onSelect ? ()=>onSelect(k) : undefined}>
+          {l}{n ? <span className="badge" aria-hidden="true">{n}</span> : null}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 function DeckTasks() {
   const [tab, setTab] = useState('tasks');
   const [sel, setSel] = useState('t-9f2a');
   return (
     <div className="cb-deck">
-      <div className="tabs">
-        {TABS.map(([k,l,n]) => (
-          <button key={k} className={`tab ${tab===k?'on':''}`} onClick={()=>setTab(k)}>
-            {l}{n ? <span className="badge">{n}</span> : null}
-          </button>
-        ))}
-      </div>
-      <div className="body">
-        <table>
-          <thead><tr><th>ID</th><th>Task</th><th>Keeper</th><th>Goal</th><th>Status</th><th>T</th></tr></thead>
+      <DeckTabs active={tab} onSelect={setTab} />
+      <div className="body" role="tabpanel" aria-label="Tasks">
+        <table aria-label="Task list">
+          <thead><tr><th scope="col">ID</th><th scope="col">Task</th><th scope="col">Keeper</th><th scope="col">Goal</th><th scope="col">Status</th><th scope="col">T</th></tr></thead>
           <tbody>
             {D2.tasks.map(t => (
-              <tr key={t.id} className={sel===t.id?'sel':''} onClick={()=>setSel(t.id)}>
+              <tr key={t.id}
+                  className={sel===t.id?'sel':''}
+                  aria-selected={sel===t.id}
+                  tabIndex={0}
+                  onClick={()=>setSel(t.id)}
+                  onKeyDown={activateOnEnterOrSpace(()=>setSel(t.id))}>
                 <td>{t.id}</td>
                 <td className="title">{t.title}</td>
                 <td><Dot kind={kClass(t.keeper)} size="sm" /> {t.keeper}</td>
@@ -218,26 +286,25 @@ function DeckKanban() {
   ];
   return (
     <div className="cb-deck">
-      <div className="tabs">
-        {TABS.map(([k,l,n]) => (
-          <button key={k} className={`tab ${k==='board'?'on':''}`}>
-            {l}{n ? <span className="badge">{n}</span> : null}
-          </button>
-        ))}
-      </div>
-      <div className="cb-kanban">
+      <DeckTabs active="board" />
+      <div className="cb-kanban" role="tabpanel" aria-label="Board">
         {cols.map(([title, items]) => (
-          <div key={title} className="col">
-            <div className="col-h">{title} <span className="ct">{items.length}</span></div>
-            {items.map(t => (
-              <div key={t.id} className={`card ${t.status==='running'?'running':''} ${t.status==='fail'?'fail':''}`}>
-                <span className="id">{t.id}</span>
-                <span className="title">{t.title}</span>
-                <span className="foot">
-                  <Dot kind={kClass(t.keeper)} size="sm" /> {t.keeper} · {t.t}
-                </span>
-              </div>
-            ))}
+          <div key={title} role="group" aria-label={`${title} · ${items.length} tasks`} className="col">
+            <div className="col-h" role="heading" aria-level={4}>{title} <span className="ct" aria-hidden="true">{items.length}</span></div>
+            <div role="list" aria-label={`${title} tasks`}>
+              {items.map(t => (
+                <div key={t.id}
+                     role="listitem"
+                     aria-label={`${t.id} · ${t.title} · ${t.keeper} · ${t.t}`}
+                     className={`card ${t.status==='running'?'running':''} ${t.status==='fail'?'fail':''}`}>
+                  <span className="id" aria-hidden="true">{t.id}</span>
+                  <span className="title" aria-hidden="true">{t.title}</span>
+                  <span className="foot" aria-hidden="true">
+                    <Dot kind={kClass(t.keeper)} size="sm" /> {t.keeper} · {t.t}
+                  </span>
+                </div>
+              ))}
+            </div>
           </div>
         ))}
       </div>
@@ -248,25 +315,26 @@ function DeckKanban() {
 function DeckProviders() {
   return (
     <div className="cb-deck">
-      <div className="tabs">
-        {TABS.map(([k,l,n]) => (
-          <button key={k} className={`tab ${k==='prov'?'on':''}`}>{l}{n?<span className="badge">{n}</span>:null}</button>
-        ))}
-      </div>
-      <div className="cb-pmatrix">
-        <div className="row h"><span>PROVIDER</span><span>MODEL</span><span style={{textAlign:'right'}}>TPS</span><span style={{textAlign:'right'}}>CAS</span><span>TREND</span><span style={{textAlign:'right'}}>ST</span></div>
-        {D2.providers.map(p => (
-          <div key={p.id} className="row">
-            <span className="pname">{p.id}</span>
-            <span className="model">{p.model}</span>
-            <span className="tps">{p.tps}</span>
-            <span className="cas">@{p.cascade}</span>
-            <span><Spark color={p.status==='ok'?'ok':p.status==='warn'?'warn':'brass'} bars={18} /></span>
-            <span style={{textAlign:'right'}}>
-              <Chip kind={p.status==='ok'?'ok':p.status==='warn'?'warn':'ghost'}>{p.status.toUpperCase()}</Chip>
-            </span>
-          </div>
-        ))}
+      <DeckTabs active="prov" />
+      <div className="cb-pmatrix" role="tabpanel" aria-label="Providers">
+        <div className="row h" role="row" aria-hidden="true"><span>PROVIDER</span><span>MODEL</span><span style={{textAlign:'right'}}>TPS</span><span style={{textAlign:'right'}}>CAS</span><span>TREND</span><span style={{textAlign:'right'}}>ST</span></div>
+        <div role="list" aria-label="Provider matrix">
+          {D2.providers.map(p => (
+            <div key={p.id}
+                 role="listitem"
+                 aria-label={`${p.id} · ${p.model} · TPS ${p.tps} · cascade ${p.cascade} · status ${p.status}`}
+                 className="row">
+              <span className="pname" aria-hidden="true">{p.id}</span>
+              <span className="model" aria-hidden="true">{p.model}</span>
+              <span className="tps" aria-hidden="true">{p.tps}</span>
+              <span className="cas" aria-hidden="true">@{p.cascade}</span>
+              <span aria-hidden="true"><Spark color={p.status==='ok'?'ok':p.status==='warn'?'warn':'brass'} bars={18} /></span>
+              <span style={{textAlign:'right'}} aria-hidden="true">
+                <Chip kind={p.status==='ok'?'ok':p.status==='warn'?'warn':'ghost'}>{p.status.toUpperCase()}</Chip>
+              </span>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );
@@ -275,15 +343,18 @@ function DeckProviders() {
 // ─── RAIL variants ────────────────────────────────────────────────
 function RailActivity() {
   return (
-    <div className="cb-rail">
+    <aside className="cb-rail" aria-label="Activity rail">
       <div className="sec">
-        <div className="sec-h">ACTIVITY <span className="right">11 · 60s</span></div>
-        <div className="body" style={{maxHeight:320, overflow:'auto'}}>
+        <div className="sec-h" role="heading" aria-level={3}>ACTIVITY <span className="right" aria-hidden="true">11 · 60s</span></div>
+        <div className="body" role="log" aria-live="polite" aria-label="Recent fleet events" style={{maxHeight:320, overflow:'auto'}}>
           {D2.events.map((e, i) => (
-            <div key={i} className={`ev ${e.kind}`}>
-              <span className="t">{e.t.slice(0,8)}</span>
-              <span className="icon"><Dot kind={kClass(e.keeper)} size="sm" /></span>
-              <span className="body">
+            <div key={i}
+                 role="listitem"
+                 aria-label={`${e.t.slice(0,8)} · ${e.keeper} ${e.kind}: ${e.text}`}
+                 className={`ev ${e.kind}`}>
+              <span className="t" aria-hidden="true">{e.t.slice(0,8)}</span>
+              <span className="icon" aria-hidden="true"><Dot kind={kClass(e.keeper)} size="sm" /></span>
+              <span className="body" aria-hidden="true">
                 <span className="who">{e.keeper}</span>
                 <span className="text">{e.text}</span>
               </span>
@@ -291,35 +362,42 @@ function RailActivity() {
           ))}
         </div>
       </div>
-    </div>
+    </aside>
   );
 }
 
 function RailCascade() {
   return (
-    <div className="cb-rail">
+    <aside className="cb-rail" aria-label="Cascade rail">
       <div className="sec">
-        <div className="sec-h">CASCADE <span className="right">cascade-3f19</span></div>
-        <div className="cb-cascade">
-          <span className="id">trace · hit @step=2</span>
-          {D2.cascade.steps.map((s, i) => (
-            <div key={i} className={`step ${s.status==='hit'?'hit':s.status==='miss'?'miss':'skip'}`}>
-              <span className="ix">{s.status==='hit'?'●':s.status==='miss'?'✕':'·'}</span>
-              <span className="name">{s.provider}</span>
-              <span className="ms">{s.ms ? `${s.ms}ms` : s.reason}</span>
-            </div>
-          ))}
-          <div className="total">total <span className="n">{D2.cascade.total_ms}ms</span> · hit@step 2</div>
+        <div className="sec-h" role="heading" aria-level={3}>CASCADE <span className="right" aria-hidden="true">cascade-3f19</span></div>
+        <div className="cb-cascade" role="region" aria-label={`Cascade trace cascade-3f19 · hit at step 2 · total ${D2.cascade.total_ms}ms`}>
+          <span className="id" aria-hidden="true">trace · hit @step=2</span>
+          <ol aria-label="Cascade steps" style={{listStyle:'none', margin:0, padding:0}}>
+            {D2.cascade.steps.map((s, i) => (
+              <li key={i}
+                  className={`step ${s.status==='hit'?'hit':s.status==='miss'?'miss':'skip'}`}
+                  aria-label={`Step ${i+1} · ${s.provider} · ${s.status}${s.ms ? ` · ${s.ms}ms` : ''}${s.reason ? ` · ${s.reason}` : ''}`}>
+                <span className="ix" aria-hidden="true">{s.status==='hit'?'●':s.status==='miss'?'✕':'·'}</span>
+                <span className="name" aria-hidden="true">{s.provider}</span>
+                <span className="ms" aria-hidden="true">{s.ms ? `${s.ms}ms` : s.reason}</span>
+              </li>
+            ))}
+          </ol>
+          <div className="total" aria-hidden="true">total <span className="n">{D2.cascade.total_ms}ms</span> · hit@step 2</div>
         </div>
       </div>
       <div className="sec">
-        <div className="sec-h">RECENT <span className="right">3</span></div>
-        <div className="body">
+        <div className="sec-h" role="heading" aria-level={3}>RECENT <span className="right" aria-hidden="true">3</span></div>
+        <div className="body" role="log" aria-live="polite" aria-label="Recent events">
           {D2.events.slice(0,3).map((e,i) => (
-            <div key={i} className={`ev ${e.kind}`}>
-              <span className="t">{e.t.slice(0,8)}</span>
-              <span className="icon"><Dot kind={kClass(e.keeper)} size="sm" /></span>
-              <span className="body">
+            <div key={i}
+                 role="listitem"
+                 aria-label={`${e.t.slice(0,8)} · ${e.keeper} ${e.kind}: ${e.text}`}
+                 className={`ev ${e.kind}`}>
+              <span className="t" aria-hidden="true">{e.t.slice(0,8)}</span>
+              <span className="icon" aria-hidden="true"><Dot kind={kClass(e.keeper)} size="sm" /></span>
+              <span className="body" aria-hidden="true">
                 <span className="who">{e.keeper}</span>
                 <span className="text">{e.text}</span>
               </span>
@@ -327,7 +405,7 @@ function RailCascade() {
           ))}
         </div>
       </div>
-    </div>
+    </aside>
   );
 }
 

--- a/dashboard/design-system/preview/cb-group-c.jsx
+++ b/dashboard/design-system/preview/cb-group-c.jsx
@@ -11,14 +11,14 @@ function ComposerPrompt() {
   ], 22);
   return (
     <div className="cb-board">
-      <div style={{flex:1, background:'var(--bg-0)'}} />
-      <div className="cb-composer">
-        <div className="line">
-          <span className="prompt">masc&gt;</span>
-          <span>{typed}</span>
-          <span className="caret" style={{color:'var(--brass-1)'}}>▌</span>
+      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div className="cb-composer" role="region" aria-label="Command composer">
+        <div className="line" aria-live="polite">
+          <span className="prompt" aria-hidden="true">masc&gt;</span>
+          <span aria-label={`Current input: ${typed}`}>{typed}</span>
+          <span className="caret" aria-hidden="true" style={{color:'var(--brass-1)'}}>▌</span>
         </div>
-        <div className="hint">
+        <div className="hint" aria-hidden="true">
           <span><span className="kbd">⌘K</span>command</span>
           <span><span className="kbd">⌘↵</span>run</span>
           <span><span className="kbd">↑</span>history</span>
@@ -40,23 +40,29 @@ function ComposerSuggest() {
   ];
   return (
     <div className="cb-board">
-      <div style={{flex:1, background:'var(--bg-0)'}} />
-      <div className="cb-composer" style={{position:'relative'}}>
-        <div className="sug">
+      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div className="cb-composer" role="region" aria-label="Command composer with suggestions" style={{position:'relative'}}>
+        <div className="sug" role="listbox" aria-label="Command suggestions">
           {sugs.map((s, i) => (
-            <div key={i} className={`item ${on===i?'on':''}`} onMouseEnter={()=>setOn(i)}>
-              <span className="kind">{s.kind}</span>
-              <span style={{color:'var(--fg-1)'}}>{s.name}</span>
-              <span style={{color:'var(--fg-3)', marginLeft:8}}>{s.desc}</span>
+            <div key={i}
+                 role="option"
+                 aria-selected={on===i}
+                 aria-label={`${s.kind} ${s.name}: ${s.desc}`}
+                 tabIndex={on===i ? 0 : -1}
+                 className={`item ${on===i?'on':''}`}
+                 onMouseEnter={()=>setOn(i)}>
+              <span className="kind" aria-hidden="true">{s.kind}</span>
+              <span aria-hidden="true" style={{color:'var(--fg-1)'}}>{s.name}</span>
+              <span aria-hidden="true" style={{color:'var(--fg-3)', marginLeft:8}}>{s.desc}</span>
             </div>
           ))}
         </div>
         <div className="line">
-          <span className="prompt">masc&gt;</span>
-          <span className="fn">keeper.</span>
-          <span className="caret" style={{color:'var(--brass-1)'}}>▌</span>
+          <span className="prompt" aria-hidden="true">masc&gt;</span>
+          <span className="fn" aria-label="Current input: keeper.">keeper.</span>
+          <span className="caret" aria-hidden="true" style={{color:'var(--brass-1)'}}>▌</span>
         </div>
-        <div className="hint">
+        <div className="hint" aria-hidden="true">
           <span><span className="kbd">↑↓</span>move</span>
           <span><span className="kbd">⇥</span>accept</span>
           <span><span className="kbd">esc</span>dismiss</span>
@@ -69,38 +75,40 @@ function ComposerSuggest() {
 function ComposerMultiLine() {
   return (
     <div className="cb-board">
-      <div style={{flex:1, background:'var(--bg-0)'}} />
-      <div className="cb-composer">
-        <div className="line">
-          <span className="prompt">masc&gt;</span>
-          <span className="fn">cascade.run</span>
-          <span>(</span>
-        </div>
-        <div className="line" style={{paddingLeft:18}}>
-          <span className="arg">goal</span>
-          <span>=</span>
-          <span className="str">"goal-merge-blockers"</span>
-          <span>,</span>
-        </div>
-        <div className="line" style={{paddingLeft:18}}>
-          <span className="arg">providers</span>
-          <span>=</span>
-          <span>[</span>
-          <Chip kind="ghost">anthropic</Chip>
-          <Chip kind="ghost">moonshot</Chip>
-          <span>]</span>
-          <span>,</span>
-        </div>
-        <div className="line" style={{paddingLeft:18}}>
-          <span className="arg">dry_run</span>
-          <span>=</span>
-          <span className="fn">false</span>
-          <span className="caret" style={{color:'var(--brass-1)'}}>▌</span>
-        </div>
-        <div className="line">
-          <span>)</span>
-        </div>
-        <div className="hint">
+      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div className="cb-composer" role="region" aria-label="Multi-line command composer">
+        <pre aria-label="cascade.run(goal=&quot;goal-merge-blockers&quot;, providers=[anthropic, moonshot], dry_run=false)" style={{margin:0, font:'inherit', background:'transparent'}}>
+          <div className="line">
+            <span className="prompt" aria-hidden="true">masc&gt;</span>
+            <span className="fn" aria-hidden="true">cascade.run</span>
+            <span aria-hidden="true">(</span>
+          </div>
+          <div className="line" style={{paddingLeft:18}} aria-hidden="true">
+            <span className="arg">goal</span>
+            <span>=</span>
+            <span className="str">"goal-merge-blockers"</span>
+            <span>,</span>
+          </div>
+          <div className="line" style={{paddingLeft:18}} aria-hidden="true">
+            <span className="arg">providers</span>
+            <span>=</span>
+            <span>[</span>
+            <Chip kind="ghost">anthropic</Chip>
+            <Chip kind="ghost">moonshot</Chip>
+            <span>]</span>
+            <span>,</span>
+          </div>
+          <div className="line" style={{paddingLeft:18}} aria-hidden="true">
+            <span className="arg">dry_run</span>
+            <span>=</span>
+            <span className="fn">false</span>
+            <span className="caret" style={{color:'var(--brass-1)'}}>▌</span>
+          </div>
+          <div className="line" aria-hidden="true">
+            <span>)</span>
+          </div>
+        </pre>
+        <div className="hint" aria-hidden="true">
           <span><span className="kbd">⌘↵</span>run</span>
           <span><span className="kbd">⇧↵</span>newline</span>
           <span style={{marginLeft:'auto', color:'var(--fg-4)'}}>4 lines · will burn ~1.2s</span>
@@ -114,20 +122,20 @@ function ComposerMultiLine() {
 function StatusStandard() {
   return (
     <div className="cb-board">
-      <div style={{flex:1, background:'var(--bg-0)'}} />
-      <div className="cb-statusbar">
-        <span className="seg"><span className="on">●</span>CONNECTED</span>
-        <span className="sep" />
+      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div className="cb-statusbar" role="status" aria-live="polite" aria-label="System status: connected, build 2604, version 0.42.1, anthropic ok, moonshot ok, openai degraded, xai offline, TPS 1.24s, time 16:32:45 UTC">
+        <span className="seg"><span className="on" aria-hidden="true">●</span>CONNECTED</span>
+        <span className="sep" aria-hidden="true" />
         <span className="seg">BUILD <span className="brass">2604</span></span>
         <span className="seg">v0.42.1</span>
-        <span className="sep" />
+        <span className="sep" aria-hidden="true" />
         <span className="seg">PROVIDERS</span>
-        <span className="seg"><span className="on">●</span>anthropic</span>
-        <span className="seg"><span className="on">●</span>moonshot</span>
-        <span className="seg" style={{color:'var(--warn-fg)'}}>●openai</span>
-        <span className="seg off">●xai</span>
+        <span className="seg"><span className="on" aria-hidden="true">●</span>anthropic</span>
+        <span className="seg"><span className="on" aria-hidden="true">●</span>moonshot</span>
+        <span className="seg" style={{color:'var(--warn-fg)'}}><span aria-hidden="true">●</span>openai</span>
+        <span className="seg off"><span aria-hidden="true">●</span>xai</span>
         <span className="seg push-right">TPS <span className="brass">1.24s</span></span>
-        <span className="sep" />
+        <span className="sep" aria-hidden="true" />
         <span className="seg">16:32:45Z</span>
       </div>
     </div>
@@ -137,11 +145,11 @@ function StatusStandard() {
 function StatusCompact() {
   return (
     <div className="cb-board">
-      <div style={{flex:1, background:'var(--bg-0)'}} />
-      <div className="cb-statusbar">
-        <span className="seg"><span className="brass">●</span>MASC</span>
+      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div className="cb-statusbar" role="status" aria-live="polite" aria-label="MASC: 5 of 8 keepers active, 3 providers ok, TPS 1.24s">
+        <span className="seg"><span className="brass" aria-hidden="true">●</span>MASC</span>
         <span className="seg">5/8 ACTIVE</span>
-        <span className="seg push-right"><span className="on">●●●</span><span className="off">●</span></span>
+        <span className="seg push-right" aria-hidden="true"><span className="on">●●●</span><span className="off">●</span></span>
         <span className="seg">1.24s</span>
       </div>
     </div>
@@ -151,18 +159,18 @@ function StatusCompact() {
 function StatusVerbose() {
   return (
     <div className="cb-board">
-      <div style={{flex:1, background:'var(--bg-0)'}} />
-      <div className="cb-statusbar" style={{height:28, flexWrap:'wrap'}}>
-        <span className="seg"><span className="on">●</span>CONNECTED</span>
-        <span className="sep" />
+      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div className="cb-statusbar" role="status" aria-live="polite" aria-label="Connected · goal goal-merge-blockers, task t-9f2a, keeper nick0cave, cascade hit at step 2 in 1.24s, suite 3 fail of 47 pass" style={{height:28, flexWrap:'wrap'}}>
+        <span className="seg"><span className="on" aria-hidden="true">●</span>CONNECTED</span>
+        <span className="sep" aria-hidden="true" />
         <span className="seg">goal <span className="brass">goal-merge-blockers</span></span>
         <span className="seg">task <span style={{color:'var(--fg-2)'}}>t-9f2a</span></span>
         <span className="seg">keeper <span style={{color:'var(--brass-1)'}}>nick0cave</span></span>
-        <span className="sep" />
+        <span className="sep" aria-hidden="true" />
         <span className="seg">CASCADE hit@2 · <span className="brass">1.24s</span></span>
-        <span className="sep" />
+        <span className="sep" aria-hidden="true" />
         <span className="seg">SUITE <span style={{color:'var(--err-fg)'}}>3 FAIL</span> / 47 PASS</span>
-        <span className="seg push-right">⌘K for commands</span>
+        <span className="seg push-right" aria-hidden="true">⌘K for commands</span>
       </div>
     </div>
   );
@@ -171,15 +179,15 @@ function StatusVerbose() {
 // ─── DRAWER variants ───────────────────────────────────────────────
 function DrawerTask() {
   return (
-    <div className="cb-drawer">
+    <div className="cb-drawer" role="dialog" aria-label="Task drawer · t-9f2a · Rebase PR #9712 + green CI · running">
       <div className="head">
         <div className="idrow">
           <span>t-9f2a</span>
-          <span>·</span>
+          <span aria-hidden="true">·</span>
           <span>goal-merge-blockers</span>
-          <button className="close">×</button>
+          <button type="button" className="close" aria-label="Close drawer">×</button>
         </div>
-        <div className="title">Rebase PR #9712 + green CI</div>
+        <div className="title" role="heading" aria-level={2}>Rebase PR #9712 + green CI</div>
         <div className="meta">
           <Chip kind="brass"><Dot kind="brass" size="sm" beat /> RUNNING</Chip>
           <Chip kind="ghost">P1</Chip>
@@ -187,8 +195,8 @@ function DrawerTask() {
         </div>
       </div>
       <div className="body">
-        <div>
-          <div className="sec-title">DETAILS</div>
+        <section aria-labelledby="drawer-task-details">
+          <div className="sec-title" id="drawer-task-details" role="heading" aria-level={3}>DETAILS</div>
           <dl className="kv">
             <dt>KEEPER</dt><dd>nick0cave</dd>
             <dt>TOOL</dt><dd>tool.write_file</dd>
@@ -196,28 +204,28 @@ function DrawerTask() {
             <dt>STARTED</dt><dd>16:31:27Z</dd>
             <dt>CASCADE</dt><dd>moonshot @step=2 · 1.24s</dd>
           </dl>
-        </div>
-        <div>
-          <div className="sec-title">REVIEW · 3</div>
-          <div className="thread">
-            <div className="cmt flag">
-              <div className="h">
+        </section>
+        <section aria-labelledby="drawer-task-review">
+          <div className="sec-title" id="drawer-task-review" role="heading" aria-level={3}>REVIEW · 3</div>
+          <div className="thread" role="log" aria-live="polite" aria-label="Review thread, 3 comments">
+            <div className="cmt flag" role="article" aria-label="Flag from sangsu, 3 minutes ago: drift detected at pipeline.ts L187 — signature mismatch">
+              <div className="h" aria-hidden="true">
                 <span className="kind">FLAG</span>
                 <span style={{color:'var(--fg-2)'}}>sangsu</span>
                 <span className="t">3m ago</span>
               </div>
               <div className="body">drift detected at pipeline.ts L187 — signature mismatch</div>
             </div>
-            <div className="cmt question">
-              <div className="h">
+            <div className="cmt question" role="article" aria-label="Question from qa-king, 2 minutes ago: is the backport going to re-open suite-merge-blockers?">
+              <div className="h" aria-hidden="true">
                 <span className="kind">QUESTION</span>
                 <span style={{color:'var(--fg-2)'}}>qa-king</span>
                 <span className="t">2m ago</span>
               </div>
               <div className="body">is the backport going to re-open suite-merge-blockers?</div>
             </div>
-            <div className="cmt note">
-              <div className="h">
+            <div className="cmt note" role="article" aria-label="Note from nick0cave, 1 minute ago: rebased on release-0.42, re-running CI">
+              <div className="h" aria-hidden="true">
                 <span className="kind">NOTE</span>
                 <span style={{color:'var(--fg-2)'}}>nick0cave</span>
                 <span className="t">1m ago</span>
@@ -225,13 +233,13 @@ function DrawerTask() {
               <div className="body">rebased on release-0.42 · re-running CI</div>
             </div>
           </div>
-        </div>
+        </section>
       </div>
-      <div className="acts">
-        <button className="btn primary">APPROVE</button>
-        <button className="btn">CLAIM</button>
-        <button className="btn">FLAG</button>
-        <button className="btn danger" style={{marginLeft:'auto'}}>RETIRE</button>
+      <div className="acts" role="toolbar" aria-label="Task actions">
+        <button type="button" className="btn primary">APPROVE</button>
+        <button type="button" className="btn">CLAIM</button>
+        <button type="button" className="btn">FLAG</button>
+        <button type="button" className="btn danger" style={{marginLeft:'auto'}}>RETIRE</button>
       </div>
     </div>
   );
@@ -240,52 +248,55 @@ function DrawerTask() {
 function DrawerGoal() {
   const g = D3.goals[1];
   return (
-    <div className="cb-drawer">
+    <div className="cb-drawer" role="dialog" aria-label={`Goal drawer · ${g.id} · ${g.title} · ${g.progress} of ${g.total} · priority ${g.priority}`}>
       <div className="head">
         <div className="idrow">
           <span>{g.id}</span>
-          <span>·</span>
+          <span aria-hidden="true">·</span>
           <span>P{g.priority}</span>
-          <button className="close">×</button>
+          <button type="button" className="close" aria-label="Close drawer">×</button>
         </div>
-        <div className="title">{g.title}</div>
+        <div className="title" role="heading" aria-level={2}>{g.title}</div>
         <div className="meta">
           <Chip kind="brass">ACTIVE</Chip>
           <Chip kind="ghost">{g.progress}/{g.total}</Chip>
-          <span className="bar" style={{width:100, alignSelf:'center'}}><span className="fill" style={{width:`${100*g.progress/g.total}%`}} /></span>
+          <span className="bar" aria-hidden="true" style={{width:100, alignSelf:'center'}}><span className="fill" style={{width:`${100*g.progress/g.total}%`}} /></span>
         </div>
       </div>
       <div className="body">
-        <div>
-          <div className="sec-title">TASKS · 5</div>
-          <div style={{display:'flex', flexDirection:'column', gap:4}}>
+        <section aria-labelledby="drawer-goal-tasks">
+          <div className="sec-title" id="drawer-goal-tasks" role="heading" aria-level={3}>TASKS · 5</div>
+          <div role="list" aria-label="Tasks under this goal" style={{display:'flex', flexDirection:'column', gap:4}}>
             {(() => {
               const seen = new Set();
               return D3.tasks.filter(t=>t.goal==='goal-keeper-clarity').concat(D3.tasks.slice(2,5)).filter(t=>{ if(seen.has(t.id)) return false; seen.add(t.id); return true; }).slice(0,5);
             })().map(t=>(
-              <div key={t.id} style={{display:'flex', alignItems:'center', gap:7, padding:'4px 7px', background:'var(--bg-1)', border:'1px solid var(--line-1)', borderRadius:3, fontSize:11}}>
+              <div key={t.id}
+                   role="listitem"
+                   aria-label={`${t.id} · ${t.title} · ${t.keeper} · ${t.status}`}
+                   style={{display:'flex', alignItems:'center', gap:7, padding:'4px 7px', background:'var(--bg-1)', border:'1px solid var(--line-1)', borderRadius:3, fontSize:11}}>
                 <Dot kind={kClass(t.keeper)} size="sm" />
-                <span className="cb-mono" style={{color:'var(--fg-4)'}}>{t.id}</span>
-                <span style={{color:'var(--fg-1)', flex:1}}>{t.title}</span>
+                <span className="cb-mono" aria-hidden="true" style={{color:'var(--fg-4)'}}>{t.id}</span>
+                <span aria-hidden="true" style={{color:'var(--fg-1)', flex:1}}>{t.title}</span>
                 <Pill kind={t.status==='running'?'running':t.status==='fail'?'err':t.status==='stalled'?'stalled':'paused'}>{t.status}</Pill>
               </div>
             ))}
           </div>
-        </div>
-        <div>
-          <div className="sec-title">KEEPERS</div>
+        </section>
+        <section aria-labelledby="drawer-goal-keepers">
+          <div className="sec-title" id="drawer-goal-keepers" role="heading" aria-level={3}>KEEPERS</div>
           <dl className="kv">
             <dt>OWNER</dt><dd>masc-improver</dd>
             <dt>CONTRIB</dt><dd>nick0cave · sangsu</dd>
             <dt>OPENED</dt><dd>2026-04-20 09:14Z</dd>
             <dt>TARGET</dt><dd>2026-04-28</dd>
           </dl>
-        </div>
+        </section>
       </div>
-      <div className="acts">
-        <button className="btn primary">SPAWN TASK</button>
-        <button className="btn">PAUSE GOAL</button>
-        <button className="btn" style={{marginLeft:'auto'}}>PIN</button>
+      <div className="acts" role="toolbar" aria-label="Goal actions">
+        <button type="button" className="btn primary">SPAWN TASK</button>
+        <button type="button" className="btn">PAUSE GOAL</button>
+        <button type="button" className="btn" style={{marginLeft:'auto'}}>PIN</button>
       </div>
     </div>
   );
@@ -293,15 +304,15 @@ function DrawerGoal() {
 
 function DrawerKeeper() {
   return (
-    <div className="cb-drawer">
+    <div className="cb-drawer" role="dialog" aria-label="Keeper drawer · nick0cave · captain · running">
       <div className="head">
         <div className="idrow">
           <span>keeper</span>
-          <span>·</span>
+          <span aria-hidden="true">·</span>
           <span>captain</span>
-          <button className="close">×</button>
+          <button type="button" className="close" aria-label="Close drawer">×</button>
         </div>
-        <div className="title" style={{fontFamily:'var(--font-mono)'}}>
+        <div className="title" role="heading" aria-level={2} style={{fontFamily:'var(--font-mono)'}}>
           <Dot kind="brass" beat style={{marginRight:6, verticalAlign:'middle'}} />
           nick0cave
         </div>
@@ -312,14 +323,14 @@ function DrawerKeeper() {
         </div>
       </div>
       <div className="body">
-        <div>
-          <div className="sec-title">HEARTBEAT</div>
-          <div style={{background:'var(--bg-1)', padding:6, border:'1px solid var(--line-1)', borderRadius:3}}>
-            <Heartbeat width={260} height={40} />
+        <section aria-labelledby="drawer-keeper-heartbeat">
+          <div className="sec-title" id="drawer-keeper-heartbeat" role="heading" aria-level={3}>HEARTBEAT</div>
+          <div aria-label="Heartbeat trace, 60-second window" style={{background:'var(--bg-1)', padding:6, border:'1px solid var(--line-1)', borderRadius:3}}>
+            <span aria-hidden="true"><Heartbeat width={260} height={40} /></span>
           </div>
-        </div>
-        <div>
-          <div className="sec-title">CURRENT</div>
+        </section>
+        <section aria-labelledby="drawer-keeper-current">
+          <div className="sec-title" id="drawer-keeper-current" role="heading" aria-level={3}>CURRENT</div>
           <dl className="kv">
             <dt>TASK</dt><dd>t-9f2a</dd>
             <dt>GOAL</dt><dd>goal-merge-blockers</dd>
@@ -327,23 +338,26 @@ function DrawerKeeper() {
             <dt>TPS</dt><dd>1.24s</dd>
             <dt>UPTIME</dt><dd>47m 12s</dd>
           </dl>
-        </div>
-        <div>
-          <div className="sec-title">LAST 3 EVENTS</div>
-          <div style={{display:'flex', flexDirection:'column', gap:4, fontSize:11}}>
+        </section>
+        <section aria-labelledby="drawer-keeper-events">
+          <div className="sec-title" id="drawer-keeper-events" role="heading" aria-level={3}>LAST 3 EVENTS</div>
+          <div role="log" aria-live="polite" aria-label="Last 3 events from nick0cave" style={{display:'flex', flexDirection:'column', gap:4, fontSize:11}}>
             {D3.events.filter(e=>e.keeper==='nick0cave').slice(0,3).map((e,i)=>(
-              <div key={i} style={{fontFamily:'var(--font-mono)', fontSize:10, color:'var(--fg-2)'}}>
-                <span style={{color:'var(--fg-4)'}}>{e.t.slice(0,8)} </span>
-                {e.text}
+              <div key={i}
+                   role="listitem"
+                   aria-label={`${e.t.slice(0,8)} · ${e.text}`}
+                   style={{fontFamily:'var(--font-mono)', fontSize:10, color:'var(--fg-2)'}}>
+                <span aria-hidden="true" style={{color:'var(--fg-4)'}}>{e.t.slice(0,8)} </span>
+                <span aria-hidden="true">{e.text}</span>
               </div>
             ))}
           </div>
-        </div>
+        </section>
       </div>
-      <div className="acts">
-        <button className="btn primary">ASSIGN TASK</button>
-        <button className="btn">PAUSE</button>
-        <button className="btn danger" style={{marginLeft:'auto'}}>RETIRE</button>
+      <div className="acts" role="toolbar" aria-label="Keeper actions">
+        <button type="button" className="btn primary">ASSIGN TASK</button>
+        <button type="button" className="btn">PAUSE</button>
+        <button type="button" className="btn danger" style={{marginLeft:'auto'}}>RETIRE</button>
       </div>
     </div>
   );

--- a/dashboard/design-system/preview/cb-group-d.jsx
+++ b/dashboard/design-system/preview/cb-group-d.jsx
@@ -7,16 +7,17 @@ const P2 = window.MASC_P2;
 // SHARED: zone header with branch + keeper context (IDE backbone)
 // ─────────────────────────────────────────────────────────────────
 function ZoneHeader({ title, branch = "main", keepers = [], meta, right }) {
+  const headingId = `zh-${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
   return (
-    <div className="ph">
-      <span className="ttl">{title}</span>
-      <span className="br-pill">{branch}</span>
+    <div className="ph" role="toolbar" aria-labelledby={headingId}>
+      <span className="ttl" id={headingId} role="heading" aria-level={3}>{title}</span>
+      <span className="br-pill" aria-label={`Branch ${branch}`}>{branch}</span>
       {keepers.slice(0, 3).map(k => (
-        <span key={k} className="kpr-pill"><span className="dot" />{k}</span>
+        <span key={k} className="kpr-pill" aria-label={`Keeper ${k}`}><span className="dot" aria-hidden="true" />{k}</span>
       ))}
-      {keepers.length > 3 && <span className="kpr-pill">+{keepers.length - 3}</span>}
+      {keepers.length > 3 && <span className="kpr-pill" aria-label={`Plus ${keepers.length - 3} more keepers`}>+{keepers.length - 3}</span>}
       {meta && <span className="meta" style={{marginLeft: 8}}>{meta}</span>}
-      <span className="grow" />
+      <span className="grow" aria-hidden="true" />
       {right}
     </div>
   );
@@ -34,7 +35,7 @@ function GoalHorizonTrack() {
     { hz: "long",  label: "장기", note: "quarter", goals: P2.goals.filter(g => g.horizon === "long") },
   ];
   return (
-    <div className="cbp">
+    <section className="cbp" aria-label="Goal horizon track">
       <ZoneHeader
         title="GOAL · HORIZON"
         branch="main"
@@ -44,22 +45,25 @@ function GoalHorizonTrack() {
       />
       <div className="body">
         {groups.map(g => (
-          <div key={g.hz} className="gz-track">
-            <div className="hz">
+          <div key={g.hz} className="gz-track" role="group" aria-label={`${g.label} horizon · ${g.note} · ${g.goals.length} goals`}>
+            <div className="hz" aria-hidden="true">
               <span>{g.label}</span>
               <span className="n">{g.note}</span>
               <span className="n" style={{marginTop:'auto', color:'var(--brass-1)'}}>{g.goals.length}</span>
             </div>
-            <div className="lst">
-              {g.goals.length === 0 && <div className="cb-mute" style={{padding:'8px',fontFamily:'var(--font-mono)',fontSize:'10px'}}>— no goals at this horizon —</div>}
+            <div className="lst" role="list" aria-label={`${g.label} goals`}>
+              {g.goals.length === 0 && <div className="cb-mute" role="listitem" style={{padding:'8px',fontFamily:'var(--font-mono)',fontSize:'10px'}}>— no goals at this horizon —</div>}
               {g.goals.map(go => (
-                <div key={go.id} className={`gz-card ${go.status === 'done' ? 'done' : ''} ${go.phase}`}>
-                  <div className="top">
+                <div key={go.id}
+                     role="listitem"
+                     aria-label={`${go.id} · ${go.title} · phase ${go.phase} · ${go.progress} of ${go.total} (${Math.round(go.progress / go.total * 100)}%) · target ${go.target_value} ${go.metric}${go.status === 'done' ? ' · done' : ''}`}
+                     className={`gz-card ${go.status === 'done' ? 'done' : ''} ${go.phase}`}>
+                  <div className="top" aria-hidden="true">
                     <span className="id">{go.id} · <span style={{color:'var(--info-fg)'}}>{go.phase}</span></span>
                     <span className="ttl" title={go.title}>{go.title}</span>
                     <span className="met"><span>{go.metric}</span> · target <span className="v">{go.target_value}</span></span>
                   </div>
-                  <div className="prog">
+                  <div className="prog" aria-hidden="true">
                     <span className="pct">{Math.round(go.progress / go.total * 100)}%</span>
                     <span className="b"><i style={{width: `${go.progress / go.total * 100}%`}} /></span>
                     <span style={{color:'var(--fg-4)',fontSize:'9px'}}>{go.progress}/{go.total}</span>
@@ -70,7 +74,7 @@ function GoalHorizonTrack() {
           </div>
         ))}
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -78,7 +82,7 @@ function GoalHorizonTrack() {
 function GoalMetricTree() {
   const roots = P2.goals.filter(g => !g.parent);
   return (
-    <div className="cbp">
+    <section className="cbp" aria-label="Goal metric tree">
       <ZoneHeader
         title="GOAL · TREE"
         branch="main"
@@ -86,46 +90,59 @@ function GoalMetricTree() {
         meta="parent → child"
       />
       <div className="body flat">
-        <div className="gz-hdr">
+        <div className="gz-hdr" role="row" aria-hidden="true">
           <span style={{gridColumn:'1 / 2'}}>goal · metric</span>
           <span style={{textAlign:'right'}}>progress</span>
           <span style={{textAlign:'right'}}>phase</span>
         </div>
-        {roots.map(root => (
-          <React.Fragment key={root.id}>
-            <div className="gz-tree-row">
-              <span className="ttl">
-                {root.title}
-                <small>{root.id} · {root.metric}</small>
-              </span>
-              <span className="num">{root.progress}/{root.total}</span>
-              <span className={`ph ${root.phase} ${root.status === 'done' ? 'done' : ''}`} style={{textAlign:'right'}}>
-                {root.status === 'done' ? 'done' : root.phase}
-              </span>
-            </div>
-            {P2.goals.filter(g => g.parent === root.id).map(child => (
-              <div key={child.id} className="gz-tree-row child">
-                <span className="ttl">
-                  {child.title}
-                  <small>{child.id} · {child.metric}</small>
-                </span>
-                <span className="num">{child.progress}/{child.total}</span>
-                <span className={`ph ${child.phase} ${child.status === 'done' ? 'done' : ''}`} style={{textAlign:'right'}}>
-                  {child.status === 'done' ? 'done' : child.phase}
-                </span>
-              </div>
-            ))}
-          </React.Fragment>
-        ))}
+        <div role="tree" aria-label={`${roots.length} root goals`}>
+          {roots.map(root => {
+            const children = P2.goals.filter(g => g.parent === root.id);
+            return (
+              <React.Fragment key={root.id}>
+                <div className="gz-tree-row"
+                     role="treeitem"
+                     aria-level={1}
+                     aria-expanded={children.length > 0 ? 'true' : undefined}
+                     aria-label={`${root.title} · ${root.id} · ${root.metric} · ${root.progress} of ${root.total} · phase ${root.status === 'done' ? 'done' : root.phase}`}>
+                  <span className="ttl" aria-hidden="true">
+                    {root.title}
+                    <small>{root.id} · {root.metric}</small>
+                  </span>
+                  <span className="num" aria-hidden="true">{root.progress}/{root.total}</span>
+                  <span className={`ph ${root.phase} ${root.status === 'done' ? 'done' : ''}`} aria-hidden="true" style={{textAlign:'right'}}>
+                    {root.status === 'done' ? 'done' : root.phase}
+                  </span>
+                </div>
+                {children.map(child => (
+                  <div key={child.id}
+                       className="gz-tree-row child"
+                       role="treeitem"
+                       aria-level={2}
+                       aria-label={`${child.title} · ${child.id} · ${child.metric} · ${child.progress} of ${child.total} · phase ${child.status === 'done' ? 'done' : child.phase}`}>
+                    <span className="ttl" aria-hidden="true">
+                      {child.title}
+                      <small>{child.id} · {child.metric}</small>
+                    </span>
+                    <span className="num" aria-hidden="true">{child.progress}/{child.total}</span>
+                    <span className={`ph ${child.phase} ${child.status === 'done' ? 'done' : ''}`} aria-hidden="true" style={{textAlign:'right'}}>
+                      {child.status === 'done' ? 'done' : child.phase}
+                    </span>
+                  </div>
+                ))}
+              </React.Fragment>
+            );
+          })}
+        </div>
       </div>
-    </div>
+    </section>
   );
 }
 
 // G1-C · Snapshot diff (yesterday → today)
 function GoalSnapshotDiff() {
   return (
-    <div className="cbp">
+    <section className="cbp" aria-label="Goal snapshot diff (yesterday vs today)">
       <ZoneHeader
         title="GOAL · SNAPSHOT"
         branch="main"
@@ -134,18 +151,22 @@ function GoalSnapshotDiff() {
         right={<span className="meta" style={{color:'var(--brass-1)'}}>{P2.goalSnapshots.length} drift</span>}
       />
       <div className="body">
-        <div className="gz-snap">
+        <div className="gz-snap" role="list" aria-label="Goal snapshot rows">
           {P2.goalSnapshots.map(s => {
             const g = P2.goals.find(x => x.id === s.goal);
             const yPct = Math.round(s.yesterday.progress / s.yesterday.total * 100);
             const tPct = Math.round(s.today.progress / s.today.total * 100);
+            const phaseShifted = s.today.phase !== s.yesterday.phase;
             return (
-              <div key={s.goal} className="gz-snap-row">
-                <div className="ttl">
+              <div key={s.goal}
+                   className="gz-snap-row"
+                   role="listitem"
+                   aria-label={`${g?.title || s.goal} · yesterday ${s.yesterday.progress} of ${s.yesterday.total} (${yPct}%), phase ${s.yesterday.phase} → today ${s.today.progress} of ${s.today.total} (${tPct}%), phase ${s.today.phase}${phaseShifted ? ', phase shift' : ''}`}>
+                <div className="ttl" aria-hidden="true">
                   {g?.title || s.goal}
                   <span className="id">{s.goal}</span>
                 </div>
-                <div className="diff">
+                <div className="diff" aria-hidden="true">
                   <div className="y">
                     <span className="lbl">yesterday</span>
                     <span>progress: <span className="v" style={{color:'var(--fg-2)'}}>{s.yesterday.progress}/{s.yesterday.total}</span> · {yPct}%</span>
@@ -157,7 +178,7 @@ function GoalSnapshotDiff() {
                     <span className="lbl">today</span>
                     <span>progress: <span className="v">{s.today.progress}/{s.today.total}</span> · {tPct}%</span>
                     <br />
-                    <span>phase: {s.today.phase} {s.today.phase !== s.yesterday.phase && <span style={{color:'var(--ok-fg)',marginLeft:6,fontSize:'9px'}}>↗ phase shift</span>}</span>
+                    <span>phase: {s.today.phase} {phaseShifted && <span style={{color:'var(--ok-fg)',marginLeft:6,fontSize:'9px'}}>↗ phase shift</span>}</span>
                   </div>
                 </div>
               </div>
@@ -165,7 +186,7 @@ function GoalSnapshotDiff() {
           })}
         </div>
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -191,31 +212,31 @@ function TaskBacklog() {
     return t.status === filter;
   });
   return (
-    <div className="cbp">
+    <section className="cbp" aria-label="Task backlog">
       <ZoneHeader
         title="TASK · BACKLOG"
         branch="main"
         keepers={["nick0cave","masc-improver","sangsu","qa-king"]}
         meta={`${P2.tasks.length} total`}
         right={
-          <div className="filt">
+          <div className="filt" role="radiogroup" aria-label="Task status filter">
             {filters.map(f => (
-              <button key={f.id} className={filter===f.id ? 'on' : ''} onClick={()=>setFilter(f.id)}>{f.label} {f.n}</button>
+              <button key={f.id} type="button" role="radio" aria-checked={filter===f.id} aria-label={`${f.label}, ${f.n} tasks`} className={filter===f.id ? 'on' : ''} onClick={()=>setFilter(f.id)}>{f.label} {f.n}</button>
             ))}
           </div>
         }
       />
       <div className="body flat" style={{overflow:'auto'}}>
-        <table className="t">
+        <table className="t" aria-label={`Task backlog · ${rows.length} rows`}>
           <thead>
             <tr>
-              <th style={{width:64}}>id</th>
-              <th style={{width:80}}>status</th>
-              <th>title</th>
-              <th style={{width:130}}>branch</th>
-              <th style={{width:110}}>keeper</th>
-              <th style={{width:130}}>goal</th>
-              <th style={{width:60, textAlign:'right'}}>age</th>
+              <th scope="col" style={{width:64}}>id</th>
+              <th scope="col" style={{width:80}}>status</th>
+              <th scope="col">title</th>
+              <th scope="col" style={{width:130}}>branch</th>
+              <th scope="col" style={{width:110}}>keeper</th>
+              <th scope="col" style={{width:130}}>goal</th>
+              <th scope="col" style={{width:60, textAlign:'right'}}>age</th>
             </tr>
           </thead>
           <tbody>
@@ -224,11 +245,11 @@ function TaskBacklog() {
                 <td className="id">{t.id}</td>
                 <td>
                   <span className={`stat ${t.status}`}>{t.status}</span>
-                  {t.drift && <span className="drift">DRIFT</span>}
+                  {t.drift && <span className="drift" aria-label="Drift detected">DRIFT</span>}
                 </td>
                 <td className="pri">{t.title}</td>
-                <td className="mute">⎇ {t.branch}</td>
-                <td>{t.keeper ? <span style={{color:'var(--brass-1)'}}>{t.keeper}</span> : <span className="mute">—</span>}</td>
+                <td className="mute" aria-label={`Branch ${t.branch}`}><span aria-hidden="true">⎇ </span>{t.branch}</td>
+                <td>{t.keeper ? <span style={{color:'var(--brass-1)'}}>{t.keeper}</span> : <span className="mute" aria-label="No keeper">—</span>}</td>
                 <td className="mute" title={t.goal}>{t.goal.replace('goal-','')}</td>
                 <td className="num">{t.age}</td>
               </tr>
@@ -236,7 +257,7 @@ function TaskBacklog() {
           </tbody>
         </table>
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -244,40 +265,43 @@ function TaskBacklog() {
 function TaskStaleAlert() {
   const stale = P2.tasks.filter(t => t.drift || (t.claim_age && t.claim_age !== '—' && (t.claim_age.endsWith('h') || parseInt(t.claim_age) > 10)));
   return (
-    <div className="cbp">
+    <section className="cbp" aria-label="Task stale claims alert">
       <ZoneHeader
         title="TASK · STALE CLAIMS"
         branch="main"
         keepers={["taskmaster","velvet-hammer"]}
         meta={`${stale.length} need attention · check age > 10m or drift=true`}
-        right={<span className="meta" style={{color:'var(--err-fg)'}}>● action required</span>}
+        right={<span className="meta" role="status" style={{color:'var(--err-fg)'}}><span aria-hidden="true">● </span>action required</span>}
       />
       <div className="body">
-        <div className="tz-alert">
+        <div className="tz-alert" role="list" aria-label={`${stale.length} stale claims`}>
           {stale.map(t => (
-            <div key={t.id} className="row">
-              <div className="who">
+            <div key={t.id}
+                 className="row"
+                 role="listitem"
+                 aria-label={`${t.id} · ${t.title} · claimed ${t.claim_age} ago by ${t.keeper || 'nobody'}${t.drift ? ' · metadata drift' : ''}`}>
+              <div className="who" aria-hidden="true">
                 <span className="id">{t.id}</span> · {t.title}
                 <span className="age">claimed {t.claim_age} ago by {t.keeper || 'nobody'}</span>
               </div>
-              <div className="why">
+              <div className="why" aria-hidden="true">
                 {t.drift ? 'metadata_drift detected · backlog L42' : `claim_age > threshold · last activity ${t.age} ago`}
                 <br />
                 <span style={{color:'var(--fg-4)'}}>⎇ {t.branch} · {t.tools}</span>
               </div>
-              <div className="acts">
-                <button>nudge</button>
-                <button className="danger">force-release</button>
-                <button className="primary">reassign</button>
+              <div className="acts" role="toolbar" aria-label={`Actions for ${t.id}`}>
+                <button type="button">nudge</button>
+                <button type="button" className="danger">force-release</button>
+                <button type="button" className="primary">reassign</button>
               </div>
             </div>
           ))}
         </div>
-        <div style={{marginTop:8, padding:'6px 8px', borderTop:'1px dashed var(--line-2)', fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--fg-4)'}}>
+        <div role="note" style={{marginTop:8, padding:'6px 8px', borderTop:'1px dashed var(--line-2)', fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--fg-4)'}}>
           taskmaster cannot force-release others' claims · operator nudge channel: <span style={{color:'var(--brass-1)'}}>hint</span>
         </div>
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -285,7 +309,7 @@ function TaskStaleAlert() {
 function TaskWall() {
   const keepers = ["nick0cave","masc-improver","sangsu","qa-king","ramarama","executor","issue_king","janitor"];
   return (
-    <div className="cbp">
+    <section className="cbp" aria-label="Task wall · per keeper">
       <ZoneHeader
         title="TASK · PER-KEEPER WALL"
         branch="main"
@@ -293,31 +317,36 @@ function TaskWall() {
         meta={`${keepers.length} keepers · grouped by owner`}
       />
       <div className="body">
-        <div className="tz-wall">
+        <div className="tz-wall" role="list" aria-label="Per-keeper task columns">
           {keepers.map(k => {
             const ts = P2.tasks.filter(t => t.keeper === k);
             return (
-              <div key={k} className={`kpr ${ts.length === 0 ? 'empty' : ''}`}>
-                <div className="h">
+              <div key={k}
+                   role="listitem"
+                   className={`kpr ${ts.length === 0 ? 'empty' : ''}`}
+                   aria-label={`${k} · ${ts.length} task${ts.length === 1 ? '' : 's'}${ts.some(t=>t.status==='running') ? ' · running' : ''}`}>
+                <div className="h" aria-hidden="true">
                   <Dot kind={kClass(k)} size="sm" beat={ts.some(t=>t.status==='running')} />
                   <span className="nm">{k}</span>
                   <span className="cn">{ts.length}</span>
                 </div>
-                {ts.length === 0
-                  ? <div className="tk">— idle —</div>
-                  : ts.map(t => (
-                      <div key={t.id} className={`tk ${t.status}`}>
-                        <span className="id">{t.id.replace('task-','')}</span>
-                        <span className="t" title={t.title}>{t.title}</span>
-                      </div>
-                    ))
-                }
+                <div role="list" aria-label={`Tasks owned by ${k}`}>
+                  {ts.length === 0
+                    ? <div className="tk" role="listitem" aria-label="Idle">— idle —</div>
+                    : ts.map(t => (
+                        <div key={t.id} className={`tk ${t.status}`} role="listitem" aria-label={`${t.id} · ${t.title} · ${t.status}`}>
+                          <span className="id" aria-hidden="true">{t.id.replace('task-','')}</span>
+                          <span className="t" aria-hidden="true" title={t.title}>{t.title}</span>
+                        </div>
+                      ))
+                  }
+                </div>
               </div>
             );
           })}
         </div>
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -328,7 +357,7 @@ function TaskWall() {
 // G3-A · Daily ledger
 function AccountabilityLedger() {
   return (
-    <div className="cbp">
+    <section className="cbp" aria-label="Accountability daily ledger">
       <ZoneHeader
         title="ACCOUNTABILITY · DAILY LEDGER"
         branch="main"
@@ -337,22 +366,27 @@ function AccountabilityLedger() {
         right={<span className="meta">approved 3 · flagged 2 · rejected 1 · deferred 1</span>}
       />
       <div className="body flat" style={{overflow:'auto'}}>
-        {P2.ledger.map((row, i) => (
-          <div key={i} className="ac-row">
-            <span className="ts">{row.ts}</span>
-            <span className={`vd ${row.verdict}`}>{row.verdict}</span>
-            <span className="sub">
-              {row.subject}
-              <span className="ev">evidence: {row.evidence}</span>
-            </span>
-            <span className="sig">
-              {row.signed_by}
-              <span className="scope">{row.scope}</span>
-            </span>
-          </div>
-        ))}
+        <div role="log" aria-label="Daily verdict ledger" aria-live="polite">
+          {P2.ledger.map((row, i) => (
+            <div key={i}
+                 className="ac-row"
+                 role="listitem"
+                 aria-label={`${row.ts} · ${row.verdict} · ${row.subject} · evidence ${row.evidence} · signed by ${row.signed_by} · scope ${row.scope}`}>
+              <span className="ts" aria-hidden="true">{row.ts}</span>
+              <span className={`vd ${row.verdict}`} aria-hidden="true">{row.verdict}</span>
+              <span className="sub" aria-hidden="true">
+                {row.subject}
+                <span className="ev">evidence: {row.evidence}</span>
+              </span>
+              <span className="sig" aria-hidden="true">
+                {row.signed_by}
+                <span className="scope">{row.scope}</span>
+              </span>
+            </div>
+          ))}
+        </div>
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -367,7 +401,7 @@ function ResponsibilityMatrix() {
     return 'z4';
   };
   return (
-    <div className="cbp">
+    <section className="cbp" aria-label="Responsibility matrix · keeper × scope">
       <ZoneHeader
         title="ACCOUNTABILITY · RESPONSIBILITY MATRIX"
         branch="main"
@@ -375,12 +409,12 @@ function ResponsibilityMatrix() {
         meta={`${rows.length} keepers × ${cols.length} scopes · last 7 days`}
       />
       <div className="body" style={{overflow:'auto'}}>
-        <table className="ac-mtx">
+        <table className="ac-mtx" aria-label={`Responsibility matrix · ${rows.length} keepers · ${cols.length} scopes`}>
           <thead>
             <tr>
-              <th className="row-h" style={{textAlign:'left'}}>keeper / scope</th>
-              {cols.map(c => <th key={c} className="col-h">{c}</th>)}
-              <th style={{width:32}}>Σ</th>
+              <th className="row-h" scope="col" style={{textAlign:'left'}}>keeper / scope</th>
+              {cols.map(c => <th key={c} className="col-h" scope="col">{c}</th>)}
+              <th scope="col" style={{width:32}}>Σ</th>
             </tr>
           </thead>
           <tbody>
@@ -388,34 +422,34 @@ function ResponsibilityMatrix() {
               const total = grid[r].reduce((a,b)=>a+b, 0);
               return (
                 <tr key={r}>
-                  <th className="row-h">{r}</th>
+                  <th className="row-h" scope="row">{r}</th>
                   {grid[r].map((n, i) => (
-                    <td key={i} className={bucket(n)} title={`${r} × ${cols[i]}: ${n} verdicts`}>{n || '·'}</td>
+                    <td key={i} className={bucket(n)} aria-label={`${r} × ${cols[i]}: ${n} verdicts`} title={`${r} × ${cols[i]}: ${n} verdicts`}>{n || '·'}</td>
                   ))}
-                  <td style={{color:'var(--brass-1)', fontWeight:600}}>{total}</td>
+                  <td style={{color:'var(--brass-1)', fontWeight:600}} aria-label={`${r} total: ${total} verdicts`}>{total}</td>
                 </tr>
               );
             })}
             <tr style={{borderTop:'2px solid var(--brass-2)'}}>
-              <th className="row-h" style={{color:'var(--brass-1)'}}>Σ scope</th>
+              <th className="row-h" scope="row" style={{color:'var(--brass-1)'}}>Σ scope</th>
               {cols.map((_, i) => {
                 const sum = rows.reduce((a, r) => a + grid[r][i], 0);
-                return <td key={i} style={{color:'var(--brass-1)', fontWeight:600}}>{sum}</td>;
+                return <td key={i} aria-label={`${cols[i]} total: ${sum} verdicts`} style={{color:'var(--brass-1)', fontWeight:600}}>{sum}</td>;
               })}
-              <td style={{color:'var(--brass-1)', fontWeight:600}}>{rows.reduce((a, r) => a + grid[r].reduce((x,y)=>x+y, 0), 0)}</td>
+              <td aria-label={`Grand total verdicts`} style={{color:'var(--brass-1)', fontWeight:600}}>{rows.reduce((a, r) => a + grid[r].reduce((x,y)=>x+y, 0), 0)}</td>
             </tr>
           </tbody>
         </table>
-        <div style={{marginTop:8, padding:'6px 8px', fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--fg-4)', display:'flex', gap:8, alignItems:'center'}}>
-          <span>density:</span>
-          <span style={{padding:'1px 6px', background:'var(--bg-0)', border:'1px solid var(--line-1)'}}>0</span>
-          <span style={{padding:'1px 6px', background:'rgb(var(--brass-glow)/.05)', color:'var(--fg-2)'}}>1–2</span>
-          <span style={{padding:'1px 6px', background:'rgb(var(--brass-glow)/.12)', color:'var(--fg-1)'}}>3–4</span>
-          <span style={{padding:'1px 6px', background:'rgb(var(--brass-glow)/.22)', color:'var(--brass-1)'}}>5–6</span>
-          <span style={{padding:'1px 6px', background:'var(--brass-1)', color:'var(--bg-0)'}}>7+</span>
+        <div role="note" aria-label="Matrix density legend" style={{marginTop:8, padding:'6px 8px', fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--fg-4)', display:'flex', gap:8, alignItems:'center'}}>
+          <span aria-hidden="true">density:</span>
+          <span aria-hidden="true" style={{padding:'1px 6px', background:'var(--bg-0)', border:'1px solid var(--line-1)'}}>0</span>
+          <span aria-hidden="true" style={{padding:'1px 6px', background:'rgb(var(--brass-glow)/.05)', color:'var(--fg-2)'}}>1–2</span>
+          <span aria-hidden="true" style={{padding:'1px 6px', background:'rgb(var(--brass-glow)/.12)', color:'var(--fg-1)'}}>3–4</span>
+          <span aria-hidden="true" style={{padding:'1px 6px', background:'rgb(var(--brass-glow)/.22)', color:'var(--brass-1)'}}>5–6</span>
+          <span aria-hidden="true" style={{padding:'1px 6px', background:'var(--brass-1)', color:'var(--bg-0)'}}>7+</span>
         </div>
       </div>
-    </div>
+    </section>
   );
 }
 

--- a/dashboard/design-system/preview/cb-group-e.jsx
+++ b/dashboard/design-system/preview/cb-group-e.jsx
@@ -10,117 +10,117 @@ const P2e = window.MASC_P2;
 // helper — render a single post card
 function BoardPost({ post, expanded = false }) {
   const net = post.votes_up - post.votes_down;
+  const summary = `${post.author} · ${post.kind}${post.hearth ? ' · ' + post.hearth : ''} · ${post.title} · ${net > 0 ? '+' + net : net} net votes · ${post.replies} replies · ${post.at}`;
   return (
-    <div className={`bd-post ${post.kind} ${post.hearth === 'merge-blocker' ? 'hot' : ''}`}>
-      <div className="vote">
-        <span className="up" title="upvote">▲</span>
-        <span className={`net ${net < 0 ? 'neg' : ''}`}>{net > 0 ? `+${net}` : net}</span>
-        <span className="dn" title="downvote">▼</span>
+    <article className={`bd-post ${post.kind} ${post.hearth === 'merge-blocker' ? 'hot' : ''}`} aria-label={summary}>
+      <div className="vote" role="group" aria-label="Vote controls">
+        <button type="button" className="up" aria-label="Upvote">▲</button>
+        <span className={`net ${net < 0 ? 'neg' : ''}`} aria-label={`${net > 0 ? '+' + net : net} net votes`}>{net > 0 ? `+${net}` : net}</span>
+        <button type="button" className="dn" aria-label="Downvote">▼</button>
       </div>
       <div className="main">
-        <div className="h">
+        <div className="h" aria-hidden="true">
           <span className="au">{post.author}</span>
           <span className={`kk ${post.kind}`}>{post.kind}</span>
           {post.hearth && <span className="he">♨ {post.hearth}</span>}
           <span className="at">{post.at}</span>
           {post.expires && <span className="exp">expires {post.expires}</span>}
         </div>
-        <div className="ttl">{post.title}</div>
+        <div className="ttl" role="heading" aria-level={4}>{post.title}</div>
         <div className={`body ${expanded ? 'expand' : 'clip'}`}>{post.body}</div>
-        {post.state_block && <div className="state-block">{post.state_block}</div>}
-        <div className="ft">
-          <button>↳ reply ({post.replies})</button>
-          <button>★ pin</button>
-          <button>⊘ mute</button>
-          <button>⌗ permalink</button>
+        {post.state_block && <div className="state-block" aria-label={`State block: ${post.state_block}`}>{post.state_block}</div>}
+        <div className="ft" role="toolbar" aria-label={`Actions for ${post.id}`}>
+          <button type="button">↳ reply ({post.replies})</button>
+          <button type="button">★ pin</button>
+          <button type="button">⊘ mute</button>
+          <button type="button">⌗ permalink</button>
         </div>
       </div>
-      <div className="meta-r">
+      <div className="meta-r" aria-hidden="true">
         <span>{post.id}</span>
         <span>{post.replies} replies</span>
       </div>
-    </div>
+    </article>
   );
 }
 
 // C1-A · Feed (hearth-grouped)
 function BoardFeed() {
-  // group posts by hearth
+  const [filter, setFilter] = useState('all');
   const byHearth = {};
   P2e.boardPosts.forEach(p => {
     const k = p.hearth || '— no hearth —';
     (byHearth[k] = byHearth[k] || []).push(p);
   });
-  // sort hearths so merge-blocker first
   const order = ['merge-blocker','keeper-clarity','routing','backlog hygiene','reporting','— no hearth —'];
   const hearths = Object.keys(byHearth).sort((a, b) => {
     const ai = order.indexOf(a); const bi = order.indexOf(b);
     return (ai === -1 ? 99 : ai) - (bi === -1 ? 99 : bi);
   });
   return (
-    <div className="cbp">
+    <section className="cbp" aria-label="Board feed (hearth-grouped)">
       <ZoneHeader
         title="BOARD · FEED"
         branch="main"
         keepers={["scholar","janitor","taskmaster","verdict"]}
         meta={`${P2e.boardPosts.length} live · ${hearths.length} hearths · sort: hot`}
         right={
-          <div className="filt">
-            <button className="on">all</button>
-            <button>direct</button>
-            <button>automation</button>
+          <div className="filt" role="radiogroup" aria-label="Post filter">
+            {['all','direct','automation'].map(f => (
+              <button key={f} type="button" role="radio" aria-checked={filter===f} className={filter===f ? 'on' : ''} onClick={()=>setFilter(f)}>{f}</button>
+            ))}
           </div>
         }
       />
       <div className="body">
         {hearths.map(h => (
-          <div key={h} className="bd-hearth-grp">
-            <div className="hh">{h} <span className="cn">· {byHearth[h].length}</span></div>
-            <div className="bd-feed">
-              {byHearth[h].map(p => <BoardPost key={p.id} post={p} />)}
+          <div key={h} className="bd-hearth-grp" role="group" aria-label={`${h} · ${byHearth[h].length} posts`}>
+            <div className="hh" role="heading" aria-level={3}>{h} <span className="cn" aria-hidden="true">· {byHearth[h].length}</span></div>
+            <div className="bd-feed" role="list" aria-label={`${h} posts`}>
+              {byHearth[h].map(p => <div key={p.id} role="listitem"><BoardPost post={p} /></div>)}
             </div>
           </div>
         ))}
       </div>
-    </div>
+    </section>
   );
 }
 
 // C1-B · Single post + thread
 function BoardThread() {
-  const post = P2e.boardPosts.find(p => p.id === 'p-d179ccfb');  // scholar's "Backlog 정리" post w/ replies
+  const post = P2e.boardPosts.find(p => p.id === 'p-d179ccfb');
   const replies = P2e.boardComments.filter(c => c.post_id === post.id);
   return (
-    <div className="cbp">
+    <section className="cbp" aria-label={`Board post · ${post.id} · ${replies.length} replies`}>
       <ZoneHeader
         title="BOARD · POST"
         branch="main"
         keepers={[post.author]}
         meta={`${post.id} · ${replies.length} replies · ${post.votes_up}↑ ${post.votes_down}↓`}
-        right={<span className="meta">↩ back to feed</span>}
+        right={<button type="button" className="meta" aria-label="Back to feed">↩ back to feed</button>}
       />
       <div className="body">
         <BoardPost post={post} expanded={true} />
-        <div style={{padding:'4px 0', fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--fg-4)', letterSpacing:'.08em', textTransform:'uppercase'}}>
+        <div role="heading" aria-level={3} style={{padding:'4px 0', fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--fg-4)', letterSpacing:'.08em', textTransform:'uppercase'}}>
           ━━ {replies.length} replies
         </div>
-        <div className="bd-thread">
+        <div className="bd-thread" role="log" aria-live="polite" aria-label={`${replies.length} replies on ${post.id}`}>
           {replies.map(r => (
-            <div key={r.id} className="reply">
-              <div className="h">
+            <article key={r.id} className="reply" aria-label={`${r.author} at ${r.at}: ${r.body}`}>
+              <div className="h" aria-hidden="true">
                 <span className="au">{r.author}</span>
                 <span className="at">{r.at}</span>
               </div>
               <div className="body">{r.body}</div>
-            </div>
+            </article>
           ))}
         </div>
-        <div style={{marginTop:8, padding:'6px 8px', background:'var(--bg-1)', border:'1px dashed var(--line-2)', fontFamily:'var(--font-mono)', fontSize:'11px', color:'var(--fg-4)'}}>
-          <span style={{color:'var(--brass-1)'}}>masc&gt;</span> reply...
-          <span style={{color:'var(--brass-1)', animation:'anim-blink 1s step-end infinite'}}> ▌</span>
+        <div role="textbox" aria-label="Reply composer (placeholder)" style={{marginTop:8, padding:'6px 8px', background:'var(--bg-1)', border:'1px dashed var(--line-2)', fontFamily:'var(--font-mono)', fontSize:'11px', color:'var(--fg-4)'}}>
+          <span aria-hidden="true" style={{color:'var(--brass-1)'}}>masc&gt;</span> reply...
+          <span aria-hidden="true" style={{color:'var(--brass-1)', animation:'anim-blink 1s step-end infinite'}}> ▌</span>
         </div>
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -131,25 +131,25 @@ function BoardHotAuto() {
   const automation = P2e.boardPosts.filter(p => p.kind === 'automation');
   const shown = tab === 'hot' ? direct : automation;
   return (
-    <div className="cbp">
+    <section className="cbp" aria-label="Board · direct vs automation toggle">
       <ZoneHeader
         title="BOARD · MODE TOGGLE"
         branch="main"
         keepers={["scholar","janitor"]}
         meta={`direct ${direct.length} · automation ${automation.length}`}
         right={
-          <div className="filt">
-            <button className={tab==='hot'?'on':''} onClick={()=>setTab('hot')}>direct {direct.length}</button>
-            <button className={tab==='auto'?'on':''} onClick={()=>setTab('auto')}>automation {automation.length}</button>
+          <div className="filt" role="tablist" aria-label="Post category">
+            <button type="button" role="tab" aria-selected={tab==='hot'} aria-controls="board-mode-panel" tabIndex={tab==='hot'?0:-1} className={tab==='hot'?'on':''} onClick={()=>setTab('hot')}>direct {direct.length}</button>
+            <button type="button" role="tab" aria-selected={tab==='auto'} aria-controls="board-mode-panel" tabIndex={tab==='auto'?0:-1} className={tab==='auto'?'on':''} onClick={()=>setTab('auto')}>automation {automation.length}</button>
           </div>
         }
       />
-      <div className="body">
-        <div className="bd-feed">
-          {shown.map(p => <BoardPost key={p.id} post={p} />)}
+      <div className="body" id="board-mode-panel" role="tabpanel" aria-label={tab==='hot' ? 'Direct posts' : 'Automation posts'}>
+        <div className="bd-feed" role="list" aria-label={`${shown.length} posts`}>
+          {shown.map(p => <div key={p.id} role="listitem"><BoardPost post={p} /></div>)}
         </div>
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -157,7 +157,6 @@ function BoardHotAuto() {
 // C2 · MESSAGES / BROADCAST
 // ═══════════════════════════════════════════════════════════════════
 
-// helper — render message body with @mention highlight
 function renderMsgBody(body, mentions = []) {
   if (!mentions.length) return body;
   let parts = [body];
@@ -176,7 +175,7 @@ function MessageRoomTimeline() {
   const [room, setRoom] = useState('default');
   const msgs = P2e.messages.filter(m => m.room === room);
   return (
-    <div className="cbp">
+    <section className="cbp" aria-label="Message room timeline">
       <ZoneHeader
         title="MESSAGES · ROOM TIMELINE"
         branch="main"
@@ -185,46 +184,53 @@ function MessageRoomTimeline() {
       />
       <div className="body flat" style={{padding:0}}>
         <div className="ms-room">
-          <div className="roomlist">
+          <div className="roomlist" role="tablist" aria-label="Rooms" aria-orientation="vertical">
             {P2e.rooms.map(r => (
-              <div key={r.id} className={`room ${room===r.id?'on':''}`} onClick={()=>setRoom(r.id)}>
-                <span className="nm">{r.name}</span>
-                <span className={`un ${r.unread===0?'zero':''}`}>{r.unread}</span>
-              </div>
+              <button key={r.id}
+                      type="button"
+                      role="tab"
+                      aria-selected={room===r.id}
+                      aria-controls="ms-room-panel"
+                      tabIndex={room===r.id ? 0 : -1}
+                      aria-label={`#${r.name}, ${r.unread} unread`}
+                      className={`room ${room===r.id?'on':''}`}
+                      onClick={()=>setRoom(r.id)}>
+                <span className="nm" aria-hidden="true">{r.name}</span>
+                <span className={`un ${r.unread===0?'zero':''}`} aria-hidden="true">{r.unread}</span>
+              </button>
             ))}
           </div>
-          <div className="feed">
-            <div className="timeline">
+          <div className="feed" id="ms-room-panel" role="tabpanel" aria-label={`#${room} timeline · ${msgs.length} messages`}>
+            <div className="timeline" role="log" aria-live="polite">
               {msgs.map(m => (
-                <div key={m.seq} className="ms-msg">
-                  <div className="seq">#{m.seq}</div>
+                <article key={m.seq} className="ms-msg" aria-label={`#${m.seq} · ${m.from} ${m.kind} at ${m.at}: ${m.body}`}>
+                  <div className="seq" aria-hidden="true">#{m.seq}</div>
                   <div className="body">
-                    <div className="h">
+                    <div className="h" aria-hidden="true">
                       <span className="au">{m.from}</span>
                       <span className={`kk ${m.kind}`}>{m.kind}</span>
                       <span className="at">{m.at}</span>
                     </div>
                     <div className="text">{renderMsgBody(m.body, m.mentions)}</div>
-                    {m.state && <div className="state-block">{m.state}</div>}
+                    {m.state && <div className="state-block" aria-label={`State block: ${m.state}`}>{m.state}</div>}
                   </div>
-                </div>
+                </article>
               ))}
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </section>
   );
 }
 
 // C2-B · Mention inbox
 function MentionInbox() {
-  // pretend "I" am nick0cave; show all msgs that @ me
   const me = 'nick0cave';
   const mine = P2e.messages.filter(m => m.mentions.includes(me));
   const otherMentions = P2e.messages.filter(m => m.mentions.length > 0 && !m.mentions.includes(me));
   return (
-    <div className="cbp">
+    <section className="cbp" aria-label={`Mention inbox · ${mine.length} for me, ${otherMentions.length} others`}>
       <ZoneHeader
         title="MESSAGES · MENTIONS"
         branch="main"
@@ -233,34 +239,34 @@ function MentionInbox() {
         right={<span className="meta" style={{color:'var(--brass-1)'}}>@{me}</span>}
       />
       <div className="body">
-        <div style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--brass-1)', letterSpacing:'.1em', textTransform:'uppercase', padding:'2px 0'}}>━━ for me · {mine.length}</div>
-        <div className="ms-inbox">
+        <div role="heading" aria-level={3} style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--brass-1)', letterSpacing:'.1em', textTransform:'uppercase', padding:'2px 0'}}>━━ for me · {mine.length}</div>
+        <div className="ms-inbox" role="log" aria-live="polite" aria-label={`${mine.length} mentions for me`}>
           {mine.map(m => (
-            <div key={m.seq} className="mn">
-              <div className="h">
+            <article key={m.seq} className="mn" aria-label={`#${m.seq} · ${m.from} in #${m.room} at ${m.at}: ${m.body}`}>
+              <div className="h" aria-hidden="true">
                 <span className="au">{m.from}</span>
                 <span className="rm">→ #{m.room}</span>
                 <span className="at">{m.at} · #{m.seq}</span>
               </div>
               <div className="text">{renderMsgBody(m.body, m.mentions)}</div>
-            </div>
+            </article>
           ))}
         </div>
-        <div style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--fg-4)', letterSpacing:'.1em', textTransform:'uppercase', padding:'8px 0 2px', borderTop:'1px dashed var(--line-2)'}}>━━ other mentions · {otherMentions.length}</div>
-        <div className="ms-inbox">
+        <div role="heading" aria-level={3} style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--fg-4)', letterSpacing:'.1em', textTransform:'uppercase', padding:'8px 0 2px', borderTop:'1px dashed var(--line-2)'}}>━━ other mentions · {otherMentions.length}</div>
+        <div className="ms-inbox" role="log" aria-live="polite" aria-label={`${otherMentions.length} other mentions`}>
           {otherMentions.map(m => (
-            <div key={m.seq} className="mn" style={{borderLeftColor:'var(--info)', opacity:.7}}>
-              <div className="h">
+            <article key={m.seq} className="mn" aria-label={`#${m.seq} · ${m.from} in #${m.room} at ${m.at}: ${m.body}`} style={{borderLeftColor:'var(--info)', opacity:.7}}>
+              <div className="h" aria-hidden="true">
                 <span className="au">{m.from}</span>
                 <span className="rm">→ #{m.room}</span>
                 <span className="at">{m.at} · #{m.seq}</span>
               </div>
               <div className="text">{renderMsgBody(m.body, m.mentions)}</div>
-            </div>
+            </article>
           ))}
         </div>
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -268,7 +274,7 @@ function MentionInbox() {
 function StateBlockMessage() {
   const stateMsgs = P2e.messages.filter(m => m.state);
   return (
-    <div className="cbp">
+    <section className="cbp" aria-label="State-block messages">
       <ZoneHeader
         title="MESSAGES · [STATE] BLOCKS"
         branch="main"
@@ -276,25 +282,31 @@ function StateBlockMessage() {
         meta={`${stateMsgs.length} state-bearing msgs · structured payload`}
       />
       <div className="body">
-        <div style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--fg-4)', padding:'4px 0', lineHeight:1.5}}>
+        <p style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--fg-4)', padding:'4px 0', lineHeight:1.5}}>
           [STATE] blocks are inline, machine-readable structure inside human prose. Keepers stamp them on every broadcast that changes goal/intention/blocker state. Other keepers parse them silently and update local belief.
-        </div>
-        {stateMsgs.map(m => (
-          <div key={m.seq} className="ms-msg" style={{padding:'8px 10px', background:'var(--bg-1)', border:'1px solid var(--line-1)', borderLeft:'2px solid var(--brass-2)', borderRadius:0}}>
-            <div className="seq">#{m.seq}</div>
-            <div className="body">
-              <div className="h">
-                <span className="au">{m.from}</span>
-                <span className={`kk ${m.kind}`}>{m.kind}</span>
-                <span className="at">→ #{m.room} · {m.at}</span>
+        </p>
+        <div role="list" aria-label={`${stateMsgs.length} state messages`}>
+          {stateMsgs.map(m => (
+            <article key={m.seq}
+                     role="listitem"
+                     className="ms-msg"
+                     aria-label={`#${m.seq} · ${m.from} ${m.kind} → #${m.room} · ${m.at}: ${m.body} · state: ${m.state}`}
+                     style={{padding:'8px 10px', background:'var(--bg-1)', border:'1px solid var(--line-1)', borderLeft:'2px solid var(--brass-2)', borderRadius:0}}>
+              <div className="seq" aria-hidden="true">#{m.seq}</div>
+              <div className="body">
+                <div className="h" aria-hidden="true">
+                  <span className="au">{m.from}</span>
+                  <span className={`kk ${m.kind}`}>{m.kind}</span>
+                  <span className="at">→ #{m.room} · {m.at}</span>
+                </div>
+                <div className="text">{renderMsgBody(m.body, m.mentions)}</div>
+                <div className="state-block" aria-label={`State block: ${m.state}`}>{m.state}</div>
               </div>
-              <div className="text">{renderMsgBody(m.body, m.mentions)}</div>
-              <div className="state-block">{m.state}</div>
-            </div>
-          </div>
-        ))}
+            </article>
+          ))}
+        </div>
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -306,22 +318,22 @@ function StateBlockMessage() {
 function ComposerV2Broadcast() {
   return (
     <div className="cb-board" style={{flexDirection:'column-reverse'}}>
-      <div className="cm2">
-        <div className="toolbar">
-          <div className="seg">
-            <button className="on">broadcast</button>
-            <button>dm</button>
-            <button>state</button>
+      <div className="cm2" role="region" aria-label="Composer v2 · broadcast">
+        <div className="toolbar" role="toolbar" aria-label="Composer toolbar">
+          <div className="seg" role="radiogroup" aria-label="Message kind">
+            <button type="button" role="radio" aria-checked="true" className="on">broadcast</button>
+            <button type="button" role="radio" aria-checked="false">dm</button>
+            <button type="button" role="radio" aria-checked="false">state</button>
           </div>
-          <span className="room-sel">default</span>
-          <span className="grow" />
-          <span style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--fg-4)', letterSpacing:'.04em'}}>
+          <span className="room-sel" aria-label="Target room: default">default</span>
+          <span className="grow" aria-hidden="true" />
+          <span aria-label="Sequence 9 keepers, 38 chars" style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--fg-4)', letterSpacing:'.04em'}}>
             seq {P2e.messages[0].seq + 1} · 9 keepers · 38 chars
           </span>
-          <button className="send">send ⌘↵</button>
+          <button type="button" className="send">send ⌘↵</button>
         </div>
-        <div className="ed">claimed task-031. backporting to release-0.42 next.<span className="caret">▌</span></div>
-        <div className="hint">
+        <div className="ed" role="textbox" aria-label="Broadcast composer" aria-multiline="true">claimed task-031. backporting to release-0.42 next.<span className="caret" aria-hidden="true">▌</span></div>
+        <div className="hint" aria-hidden="true">
           <span><span className="kbd">@</span>mention</span>
           <span><span className="kbd">[</span>state-block</span>
           <span><span className="kbd">⌘D</span>dm-mode</span>
@@ -329,7 +341,7 @@ function ComposerV2Broadcast() {
           <span style={{marginLeft:'auto'}}>last broadcast 16s ago</span>
         </div>
       </div>
-      <div style={{flex:1, background:'var(--bg-0)'}} />
+      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
     </div>
   );
 }
@@ -338,49 +350,52 @@ function ComposerV2Broadcast() {
 function ComposerV2Mention() {
   return (
     <div className="cb-board" style={{flexDirection:'column-reverse'}}>
-      <div className="cm2" style={{position:'relative'}}>
-        {/* autocomplete dropdown */}
-        <div style={{
+      <div className="cm2" role="region" aria-label="Composer v2 · mention with autocomplete" style={{position:'relative'}}>
+        <div role="listbox" aria-label="Mention autocomplete (match @nick)" style={{
           position:'absolute', bottom:'100%', left:14, marginBottom:4,
           background:'var(--bg-1)', border:'1px solid var(--brass-2)', borderRadius:0, minWidth:240, padding:0,
           fontFamily:'var(--font-mono)', fontSize:'11px',
           boxShadow:'0 -4px 12px rgb(0 0 0 / .4)',
         }}>
-          <div style={{padding:'3px 8px', background:'var(--bg-2)', color:'var(--fg-4)', fontSize:'9px', letterSpacing:'.1em', textTransform:'uppercase'}}>match @nick</div>
+          <div role="presentation" style={{padding:'3px 8px', background:'var(--bg-2)', color:'var(--fg-4)', fontSize:'9px', letterSpacing:'.1em', textTransform:'uppercase'}}>match @nick</div>
           {[
             { id:'nick0cave', role:'Captain · merge', match:true },
             { id:'nickelodeon', role:'(unknown — alias)', match:false },
           ].map((k, i) => (
-            <div key={k.id} style={{
-              padding:'4px 8px', display:'flex', gap:6, alignItems:'center',
-              background: i===0 ? 'rgb(var(--brass-glow)/.12)' : 'transparent',
-              borderLeft: i===0 ? '2px solid var(--brass-1)' : '2px solid transparent',
-              cursor:'pointer',
-              opacity: k.match ? 1 : .5,
-            }}>
-              <span style={{color:'var(--brass-1)'}}>@{k.id}</span>
-              <span style={{color:'var(--fg-4)', marginLeft:'auto', fontSize:'9px', letterSpacing:'.04em', textTransform:'uppercase'}}>{k.role}</span>
+            <div key={k.id}
+                 role="option"
+                 aria-selected={i===0}
+                 aria-label={`@${k.id} · ${k.role}${k.match ? '' : ' · no match'}`}
+                 style={{
+                   padding:'4px 8px', display:'flex', gap:6, alignItems:'center',
+                   background: i===0 ? 'rgb(var(--brass-glow)/.12)' : 'transparent',
+                   borderLeft: i===0 ? '2px solid var(--brass-1)' : '2px solid transparent',
+                   cursor:'pointer',
+                   opacity: k.match ? 1 : .5,
+                 }}>
+              <span aria-hidden="true" style={{color:'var(--brass-1)'}}>@{k.id}</span>
+              <span aria-hidden="true" style={{color:'var(--fg-4)', marginLeft:'auto', fontSize:'9px', letterSpacing:'.04em', textTransform:'uppercase'}}>{k.role}</span>
             </div>
           ))}
         </div>
-        <div className="toolbar">
-          <div className="seg">
-            <button className="on">broadcast</button>
-            <button>dm</button>
-            <button>state</button>
+        <div className="toolbar" role="toolbar" aria-label="Composer toolbar">
+          <div className="seg" role="radiogroup" aria-label="Message kind">
+            <button type="button" role="radio" aria-checked="true" className="on">broadcast</button>
+            <button type="button" role="radio" aria-checked="false">dm</button>
+            <button type="button" role="radio" aria-checked="false">state</button>
           </div>
-          <span className="room-sel">merge-blockers</span>
-          <span className="grow" />
-          <button className="send">send ⌘↵</button>
+          <span className="room-sel" aria-label="Target room: merge-blockers">merge-blockers</span>
+          <span className="grow" aria-hidden="true" />
+          <button type="button" className="send">send ⌘↵</button>
         </div>
-        <div className="ed">PR #9712 commit 51f062 confirmed in da11b0632. closing the dup task. <span className="mention">@nick</span><span className="caret">▌</span></div>
-        <div className="targets">
-          will mention:
-          <span className="t-pill">@nick0cave</span>
-          <span style={{marginLeft:'auto', color:'var(--fg-4)', textTransform:'none'}}>↑↓ pick · ⇥ accept · esc dismiss</span>
+        <div className="ed" role="textbox" aria-label="Composer with mention" aria-multiline="true">PR #9712 commit 51f062 confirmed in da11b0632. closing the dup task. <span className="mention">@nick</span><span className="caret" aria-hidden="true">▌</span></div>
+        <div className="targets" aria-label="Will mention: @nick0cave">
+          <span aria-hidden="true">will mention:</span>
+          <span className="t-pill" aria-hidden="true">@nick0cave</span>
+          <span aria-hidden="true" style={{marginLeft:'auto', color:'var(--fg-4)', textTransform:'none'}}>↑↓ pick · ⇥ accept · esc dismiss</span>
         </div>
       </div>
-      <div style={{flex:1, background:'var(--bg-0)'}} />
+      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
     </div>
   );
 }
@@ -389,35 +404,35 @@ function ComposerV2Mention() {
 function ComposerV2State() {
   return (
     <div className="cb-board" style={{flexDirection:'column-reverse'}}>
-      <div className="cm2">
-        <div className="toolbar">
-          <div className="seg">
-            <button>broadcast</button>
-            <button>dm</button>
-            <button className="on">state</button>
+      <div className="cm2" role="region" aria-label="Composer v2 · state-block compose">
+        <div className="toolbar" role="toolbar" aria-label="Composer toolbar">
+          <div className="seg" role="radiogroup" aria-label="Message kind">
+            <button type="button" role="radio" aria-checked="false">broadcast</button>
+            <button type="button" role="radio" aria-checked="false">dm</button>
+            <button type="button" role="radio" aria-checked="true" className="on">state</button>
           </div>
-          <span className="room-sel">default</span>
-          <span style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--brass-1)', letterSpacing:'.04em'}}>
+          <span className="room-sel" aria-label="Target room: default">default</span>
+          <span aria-label="Structured · machine-readable" style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--brass-1)', letterSpacing:'.04em'}}>
             ◆ structured · machine-readable
           </span>
-          <span className="grow" />
-          <button className="send">send ⌘↵</button>
+          <span className="grow" aria-hidden="true" />
+          <button type="button" className="send">send ⌘↵</button>
         </div>
-        <div className="ed">
+        <div className="ed" role="textbox" aria-label="State-block composer · 4 keys: Goal, Phase, Next, Blocker" aria-multiline="true">
           claimed task-031. backporting to release-0.42 next.
           {'\n'}
-          <span className="state-block">[STATE]{'\n'}Goal: goal-merge-blockers{'\n'}Phase: executing{'\n'}Next: rebase + ci{'\n'}Blocker: none{'\n'}[/STATE]<span className="caret">▌</span></span>
+          <span className="state-block">[STATE]{'\n'}Goal: goal-merge-blockers{'\n'}Phase: executing{'\n'}Next: rebase + ci{'\n'}Blocker: none{'\n'}[/STATE]<span className="caret" aria-hidden="true">▌</span></span>
         </div>
-        <div className="targets">
-          parsed keys:
-          <span className="t-pill">Goal</span>
-          <span className="t-pill">Phase</span>
-          <span className="t-pill">Next</span>
-          <span className="t-pill">Blocker</span>
-          <span style={{marginLeft:'auto', color:'var(--fg-4)', textTransform:'none'}}>4 keys · valid · will update belief in 9 keepers</span>
+        <div className="targets" aria-label="Parsed keys: Goal, Phase, Next, Blocker · 4 keys valid · will update belief in 9 keepers">
+          <span aria-hidden="true">parsed keys:</span>
+          <span className="t-pill" aria-hidden="true">Goal</span>
+          <span className="t-pill" aria-hidden="true">Phase</span>
+          <span className="t-pill" aria-hidden="true">Next</span>
+          <span className="t-pill" aria-hidden="true">Blocker</span>
+          <span aria-hidden="true" style={{marginLeft:'auto', color:'var(--fg-4)', textTransform:'none'}}>4 keys · valid · will update belief in 9 keepers</span>
         </div>
       </div>
-      <div style={{flex:1, background:'var(--bg-0)'}} />
+      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
     </div>
   );
 }

--- a/dashboard/design-system/preview/cb-group-f.jsx
+++ b/dashboard/design-system/preview/cb-group-f.jsx
@@ -4,7 +4,6 @@
 
 const P2f = window.MASC_P2;
 
-// helper — format ms as human-readable
 function fmtMs(ms) {
   if (ms < 1000) return `${ms}ms`;
   if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
@@ -13,111 +12,77 @@ function fmtMs(ms) {
   return `${m}m${s.toString().padStart(2, '0')}`;
 }
 
-// ═════════════════════════════════════════════════════════════════
-// O1 · CASCADE INSPECTOR
-// ═════════════════════════════════════════════════════════════════
+// shared cascade card sub-component
+function CascadeCard({ c, hitModel, triedSet, showPool, compactModel = false }) {
+  return (
+    <article className={`csc-card outcome-${c.outcome}`} aria-label={`${c.id} · ${c.cascade} · ${c.outcome === 'error' ? c.error_category : 'ok'} · ${c.hops.length} hops · ${fmtMs(c.total_ms)}`}>
+      <div className="h" aria-hidden="true">
+        <span className="id">{c.id}</span>
+        <span className="nm">{c.cascade}</span>
+        {c.trigger && <span className="tg">· {c.trigger} · {c.at}</span>}
+        <span className={`out ${c.outcome}`}>{c.outcome === 'error' ? c.error_category : 'ok'}</span>
+      </div>
+      {showPool && (
+        <div className="csc-pool" role="list" aria-label={`Configured pool · ${c.configured.length} models`}>
+          <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',color:'var(--fg-4)',letterSpacing:'.08em',textTransform:'uppercase',marginRight:'4px'}}>configured pool ({c.configured.length}):</span>
+          {c.configured.map(m => {
+            const cls = m === hitModel ? 'hit' : triedSet.has(m) ? 'tried' : '';
+            return <span key={m} role="listitem" aria-label={`${m}${cls === 'hit' ? ' (hit)' : cls === 'tried' ? ' (tried)' : ''}`} className={`mp ${cls}`}>{m}</span>;
+          })}
+        </div>
+      )}
+      <ol className="hops" aria-label={`${c.hops.length} cascade hops`}>
+        {c.hops.map(h => (
+          <li key={h.i} className="hop" aria-label={`Step ${h.i} · ${h.model} · ${h.status} · ${fmtMs(h.ms)}${h.reason ? ' · ' + h.reason : ''}`}>
+            <span className="step" aria-hidden="true">{h.i}</span>
+            <span className="mdl" aria-hidden="true">{compactModel && h.model.length > 24 ? h.model.slice(0,24)+'…' : h.model}</span>
+            <span className={`st ${h.status}`} aria-hidden="true">{h.status}</span>
+            <span className="ms" aria-hidden="true">{fmtMs(h.ms)}</span>
+            {h.reason && <span className="reason" aria-hidden="true">↳ {h.reason}</span>}
+          </li>
+        ))}
+      </ol>
+      <div className="ft" aria-hidden="true">
+        {showPool ? <span>PRIMARY · {c.primary}</span> : null}
+        <span>HOPS · {c.hops.length}{showPool ? `/${c.configured.length}` : ''}</span>
+        <span>TOTAL · <span className="ms">{fmtMs(c.total_ms)}</span></span>
+        {c.selected && <span>SELECTED · {c.selected}</span>}
+      </div>
+    </article>
+  );
+}
 
-// O1-A · Cascade list (compact view of multiple runs)
+// O1-A · Cascade list
 function CascadeList() {
   return (
-    <div className="csc-list">
+    <div className="csc-list" role="list" aria-label={`${P2f.cascadeAudit.length} cascade runs`}>
       {P2f.cascadeAudit.map(c => (
-        <div key={c.id} className={`csc-card outcome-${c.outcome}`}>
-          <div className="h">
-            <span className="id">{c.id}</span>
-            <span className="nm">{c.cascade}</span>
-            <span className="tg">· {c.trigger} · {c.at}</span>
-            <span className={`out ${c.outcome}`}>{c.outcome === 'error' ? c.error_category : 'ok'}</span>
-          </div>
-          <div className="hops">
-            {c.hops.map(h => (
-              <div key={h.i} className="hop">
-                <span className="step">{h.i}</span>
-                <span className="mdl">{h.model}</span>
-                <span className={`st ${h.status}`}>{h.status}</span>
-                <span className="ms">{fmtMs(h.ms)}</span>
-                <span className="reason">↳ {h.reason}</span>
-              </div>
-            ))}
-          </div>
-          <div className="ft">
-            <span>HOPS · {c.hops.length}</span>
-            <span>TOTAL · <span className="ms">{fmtMs(c.total_ms)}</span></span>
-            {c.selected && <span>SELECTED · {c.selected}</span>}
-          </div>
-        </div>
+        <div key={c.id} role="listitem"><CascadeCard c={c} /></div>
       ))}
     </div>
   );
 }
 
-// O1-B · Single cascade deep-dive (the failed one) with configured pool
+// O1-B · Cascade deep-dive
 function CascadeDeepDive() {
-  const c = P2f.cascadeAudit[0];  // ca-7f29 the failed one
+  const c = P2f.cascadeAudit[0];
   const triedSet = new Set(c.hops.map(h => h.model));
   const hitModel = c.hops.find(h => h.status === 'hit')?.model;
   return (
-    <div className="csc-card outcome-error" style={{borderLeftWidth:'3px'}}>
-      <div className="h">
-        <span className="id">{c.id}</span>
-        <span className="nm">{c.cascade}</span>
-        <span className="tg">· {c.trigger} · {c.at}</span>
-        <span className="out error">{c.error_category}</span>
-      </div>
-      <div className="csc-pool">
-        <span style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',color:'var(--fg-4)',letterSpacing:'.08em',textTransform:'uppercase',marginRight:'4px'}}>configured pool ({c.configured.length}):</span>
-        {c.configured.map(m => {
-          const cls = m === hitModel ? 'hit' : triedSet.has(m) ? 'tried' : '';
-          return <span key={m} className={`mp ${cls}`}>{m}</span>;
-        })}
-      </div>
-      <div className="hops">
-        {c.hops.map(h => (
-          <div key={h.i} className="hop">
-            <span className="step">{h.i}</span>
-            <span className="mdl">{h.model}</span>
-            <span className={`st ${h.status}`}>{h.status}</span>
-            <span className="ms">{fmtMs(h.ms)}</span>
-            <span className="reason">↳ {h.reason}</span>
-          </div>
-        ))}
-      </div>
-      <div className="ft">
-        <span>PRIMARY · {c.primary}</span>
-        <span>HOPS · {c.hops.length}/{c.configured.length}</span>
-        <span>TOTAL · <span className="ms">{fmtMs(c.total_ms)}</span></span>
-      </div>
-    </div>
+    <section aria-label={`Cascade deep dive · ${c.id} · ${c.error_category}`} style={{borderLeftWidth:'3px'}}>
+      <CascadeCard c={c} hitModel={hitModel} triedSet={triedSet} showPool />
+    </section>
   );
 }
 
-// O1-C · Side-by-side compare (success vs failure pattern)
+// O1-C · Cascade compare
 function CascadeCompare() {
   const failed = P2f.cascadeAudit.find(c => c.outcome === 'error');
   const ok = P2f.cascadeAudit.find(c => c.outcome === 'ok');
   return (
-    <div style={{display:'grid', gridTemplateColumns:'1fr 1fr', gap:'8px'}}>
+    <div role="group" aria-label="Cascade comparison · success vs failure" style={{display:'grid', gridTemplateColumns:'1fr 1fr', gap:'8px'}}>
       {[failed, ok].map(c => (
-        <div key={c.id} className={`csc-card outcome-${c.outcome}`}>
-          <div className="h">
-            <span className="id">{c.id}</span>
-            <span className="nm">{c.cascade}</span>
-            <span className={`out ${c.outcome}`}>{c.outcome === 'error' ? c.error_category : 'ok'}</span>
-          </div>
-          <div className="hops">
-            {c.hops.map(h => (
-              <div key={h.i} className="hop">
-                <span className="step">{h.i}</span>
-                <span className="mdl">{h.model.length > 24 ? h.model.slice(0,24)+'…' : h.model}</span>
-                <span className={`st ${h.status}`}>{h.status}</span>
-                <span className="ms">{fmtMs(h.ms)}</span>
-              </div>
-            ))}
-          </div>
-          <div className="ft">
-            <span>TOTAL · <span className="ms">{fmtMs(c.total_ms)}</span></span>
-          </div>
-        </div>
+        <CascadeCard key={c.id} c={c} compactModel />
       ))}
     </div>
   );
@@ -127,62 +92,57 @@ function CascadeCompare() {
 // O2 · AUDIT LEDGER
 // ═════════════════════════════════════════════════════════════════
 
-// O2-A · Streaming ledger (all event types)
-function AuditLedger() {
+function AuditLedgerHeader({ left, right }) {
   return (
-    <div style={{background:'var(--bg-1)',border:'1px solid var(--line-2)'}}>
-      <div style={{padding:'5px 8px',borderBottom:'1px solid var(--line-2)',display:'flex',gap:'8px',background:'var(--bg-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>
-        <span>tail · audit.jsonl</span>
-        <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{P2f.auditEvents.length} events</span>
-      </div>
-      {P2f.auditEvents.map((e, i) => {
-        const [cat] = e.kind.split('.');
-        return (
-          <div key={i} className="aud-row">
-            <span className="ts">{e.ts.replace('Z','')}</span>
-            <span className={`kn ${cat}`}>{e.kind}</span>
-            <span className="ac">{e.actor}</span>
-            <span className="sb">
-              {e.subject}
-              {Object.keys(e.payload).length > 0 && (
-                <span className="pl">↳ {Object.entries(e.payload).map(([k,v]) => `${k}=${v}`).join(' · ')}</span>
-              )}
-            </span>
-            <span className="du">{e.duration > 0 ? fmtMs(e.duration) : '—'}</span>
-          </div>
-        );
-      })}
+    <div role="heading" aria-level={3} style={{padding:'5px 8px',borderBottom:'1px solid var(--line-2)',display:'flex',gap:'8px',background:'var(--bg-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>
+      <span>{left}</span>
+      <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{right}</span>
     </div>
   );
 }
 
-// O2-B · Filtered by actor (focus on one keeper)
+function AuditRow({ e }) {
+  const [cat] = e.kind.split('.');
+  return (
+    <div className="aud-row" role="listitem" aria-label={`${e.ts.replace('Z','')} · ${e.kind} · ${e.actor} · ${e.subject}${e.duration > 0 ? ' · ' + fmtMs(e.duration) : ''}`}>
+      <span className="ts" aria-hidden="true">{e.ts.replace('Z','')}</span>
+      <span className={`kn ${cat}`} aria-hidden="true">{e.kind}</span>
+      <span className="ac" aria-hidden="true">{e.actor}</span>
+      <span className="sb" aria-hidden="true">
+        {e.subject}
+        {Object.keys(e.payload || {}).length > 0 && (
+          <span className="pl">↳ {Object.entries(e.payload).map(([k,v]) => `${k}=${v}`).join(' · ')}</span>
+        )}
+      </span>
+      <span className="du" aria-hidden="true">{e.duration > 0 ? fmtMs(e.duration) : '—'}</span>
+    </div>
+  );
+}
+
+function AuditLedger() {
+  return (
+    <section aria-label="Audit ledger" style={{background:'var(--bg-1)',border:'1px solid var(--line-2)'}}>
+      <AuditLedgerHeader left="tail · audit.jsonl" right={`${P2f.auditEvents.length} events`} />
+      <div role="log" aria-live="polite" aria-label={`${P2f.auditEvents.length} audit events`}>
+        {P2f.auditEvents.map((e, i) => <AuditRow key={i} e={e} />)}
+      </div>
+    </section>
+  );
+}
+
 function AuditByActor() {
   const actor = 'sangsu';
   const filtered = P2f.auditEvents.filter(e => e.actor === actor || e.subject.includes(actor));
   return (
-    <div style={{background:'var(--bg-1)',border:'1px solid var(--line-2)'}}>
-      <div style={{padding:'5px 8px',borderBottom:'1px solid var(--line-2)',display:'flex',gap:'8px',background:'var(--bg-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>
-        <span>filter · actor={actor}</span>
-        <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{filtered.length} matches</span>
+    <section aria-label={`Audit ledger filtered by actor ${actor}`} style={{background:'var(--bg-1)',border:'1px solid var(--line-2)'}}>
+      <AuditLedgerHeader left={`filter · actor=${actor}`} right={`${filtered.length} matches`} />
+      <div role="list" aria-label={`${filtered.length} matching audit events`}>
+        {filtered.map((e, i) => <AuditRow key={i} e={e} />)}
       </div>
-      {filtered.map((e, i) => {
-        const [cat] = e.kind.split('.');
-        return (
-          <div key={i} className="aud-row">
-            <span className="ts">{e.ts.replace('Z','')}</span>
-            <span className={`kn ${cat}`}>{e.kind}</span>
-            <span className="ac">{e.actor}</span>
-            <span className="sb">{e.subject}</span>
-            <span className="du">{e.duration > 0 ? fmtMs(e.duration) : '—'}</span>
-          </div>
-        );
-      })}
-    </div>
+    </section>
   );
 }
 
-// O2-C · Event-kind summary (counts + costs roll-up)
 function AuditSummary() {
   const counts = {};
   P2f.auditEvents.forEach(e => {
@@ -191,25 +151,27 @@ function AuditSummary() {
   const sorted = Object.entries(counts).sort((a,b) => b[1] - a[1]);
   const total = P2f.auditEvents.length;
   return (
-    <div style={{display:'flex',flexDirection:'column',gap:'2px'}}>
-      <div style={{padding:'5px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
+    <section aria-label={`Audit summary · ${sorted.length} kinds · ${total} events`} style={{display:'flex',flexDirection:'column',gap:'2px'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
         <span>summary · last 12 events</span>
         <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{total} total</span>
       </div>
-      {sorted.map(([kind, n]) => {
-        const [cat] = kind.split('.');
-        const pct = (n / total * 100).toFixed(0);
-        return (
-          <div key={kind} style={{display:'grid',gridTemplateColumns:'140px 30px 1fr',gap:'6px',alignItems:'center',padding:'3px 8px',background:'var(--bg-1)',border:'1px solid var(--line-1)'}}>
-            <span className={`kn ${cat}`} style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',padding:'1px 5px',border:'1px solid var(--line-2)',justifySelf:'flex-start'}}>{kind}</span>
-            <span style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--brass-1)',fontVariantNumeric:'tabular-nums',textAlign:'right'}}>{n}</span>
-            <div style={{height:'10px',background:'var(--bg-2)',border:'1px solid var(--line-1)',position:'relative'}}>
-              <div style={{height:'100%',width:`${pct}%`,background:'linear-gradient(90deg, var(--brass-3), var(--brass-1))'}}></div>
+      <div role="list" aria-label="Event kind summary rows">
+        {sorted.map(([kind, n]) => {
+          const [cat] = kind.split('.');
+          const pct = (n / total * 100).toFixed(0);
+          return (
+            <div key={kind} role="listitem" aria-label={`${kind}: ${n} events (${pct}%)`} style={{display:'grid',gridTemplateColumns:'140px 30px 1fr',gap:'6px',alignItems:'center',padding:'3px 8px',background:'var(--bg-1)',border:'1px solid var(--line-1)'}}>
+              <span className={`kn ${cat}`} aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',padding:'1px 5px',border:'1px solid var(--line-2)',justifySelf:'flex-start'}}>{kind}</span>
+              <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--brass-1)',fontVariantNumeric:'tabular-nums',textAlign:'right'}}>{n}</span>
+              <div aria-hidden="true" style={{height:'10px',background:'var(--bg-2)',border:'1px solid var(--line-1)',position:'relative'}}>
+                <div style={{height:'100%',width:`${pct}%`,background:'linear-gradient(90deg, var(--brass-3), var(--brass-1))'}}></div>
+              </div>
             </div>
-          </div>
-        );
-      })}
-    </div>
+          );
+        })}
+      </div>
+    </section>
   );
 }
 
@@ -220,50 +182,50 @@ function AuditSummary() {
 function SafeAutoHero() {
   const sa = P2f.safeAutonomy;
   return (
-    <div className="sa-hero">
-      <div className="gauge">
+    <div className="sa-hero" role="region" aria-label={`Safe Autonomy Score: ${sa.global_score}, status ${sa.status}, ${sa.findings_total} findings (${sa.findings.filter(f=>f.sev==='high').length} high), ${sa.keeper_count} keepers audited, last run ${sa.last_run.replace('Z','')}, trend −4 vs 24h ago`}>
+      <div className="gauge" aria-hidden="true">
         <span className="lbl">Safe Autonomy Score</span>
         <span className={`v ${sa.status}`}>{sa.global_score}</span>
         <span className="st">{sa.status}</span>
       </div>
-      <div className="meta">
+      <div className="meta" aria-hidden="true">
         <span className="k">findings</span><span className="v">{sa.findings_total} ({sa.findings.filter(f=>f.sev==='high').length} high)</span>
         <span className="k">keepers audited</span><span className="v">{sa.keeper_count}</span>
         <span className="k">last run</span><span className="v">{sa.last_run.replace('Z','')}</span>
         <span className="k">trend</span><span className="v" style={{color:'var(--err-fg)'}}>−4 vs 24h ago</span>
       </div>
-      <div className="spark">
+      <div className="spark" aria-hidden="true">
         <Spark data={sa.history.map(h => h - 70)} bars={sa.history.length} color="brass" />
       </div>
     </div>
   );
 }
 
-// O3-A · Score hero + finding list
 function SafeAutoDashboard() {
   const sa = P2f.safeAutonomy;
   return (
-    <div style={{display:'flex',flexDirection:'column',gap:'8px'}}>
+    <section aria-label="Safe Autonomy dashboard · score and findings" style={{display:'flex',flexDirection:'column',gap:'8px'}}>
       <SafeAutoHero />
       <div style={{background:'var(--bg-1)',border:'1px solid var(--line-2)'}}>
-        <div style={{padding:'5px 8px',borderBottom:'1px solid var(--line-2)',display:'flex',gap:'8px',background:'var(--bg-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>
+        <div role="heading" aria-level={3} style={{padding:'5px 8px',borderBottom:'1px solid var(--line-2)',display:'flex',gap:'8px',background:'var(--bg-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>
           <span>findings ({sa.findings.length})</span>
           <span style={{marginLeft:'auto'}}>severity ↓</span>
         </div>
-        {sa.findings.map((f, i) => (
-          <div key={i} className="sa-find">
-            <span className={`sev ${f.sev}`}>{f.sev}</span>
-            <span className="kpr">{f.keeper}</span>
-            <span className="rule">{f.rule}</span>
-            <span className="loc">{f.file}<span className="ln">:{f.line}</span></span>
-          </div>
-        ))}
+        <div role="list" aria-label={`${sa.findings.length} findings`}>
+          {sa.findings.map((f, i) => (
+            <div key={i} role="listitem" aria-label={`${f.sev} · ${f.keeper} · ${f.rule} · ${f.file}:${f.line}`} className="sa-find">
+              <span className={`sev ${f.sev}`} aria-hidden="true">{f.sev}</span>
+              <span className="kpr" aria-hidden="true">{f.keeper}</span>
+              <span className="rule" aria-hidden="true">{f.rule}</span>
+              <span className="loc" aria-hidden="true">{f.file}<span className="ln">:{f.line}</span></span>
+            </div>
+          ))}
+        </div>
       </div>
-    </div>
+    </section>
   );
 }
 
-// O3-B · By-keeper rollup (matrix view)
 function SafeAutoByKeeper() {
   const sa = P2f.safeAutonomy;
   const byKeeper = {};
@@ -274,36 +236,37 @@ function SafeAutoByKeeper() {
   });
   const sorted = Object.entries(byKeeper).sort((a,b) => (b[1].high*9 + b[1].medium*3 + b[1].low) - (a[1].high*9 + a[1].medium*3 + a[1].low));
   return (
-    <div style={{display:'flex',flexDirection:'column',gap:'4px'}}>
-      <div style={{padding:'5px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
+    <section aria-label={`Safe Autonomy findings · by keeper · ${sorted.length} keepers`} style={{display:'flex',flexDirection:'column',gap:'4px'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
         <span>findings by keeper</span>
         <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{sorted.length} keepers</span>
       </div>
-      {sorted.map(([k, v]) => (
-        <div key={k} style={{display:'grid',gridTemplateColumns:'120px 60px 60px 60px 1fr',gap:'6px',alignItems:'center',padding:'4px 8px',background:'var(--bg-1)',border:'1px solid var(--line-1)'}}>
-          <span style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--brass-1)'}}>{k}</span>
-          <span className="sev high"   style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',padding:'1px 5px',textAlign:'center',opacity: v.high?1:0.15}}>{v.high}</span>
-          <span className="sev medium" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',padding:'1px 5px',textAlign:'center',opacity: v.medium?1:0.15}}>{v.medium}</span>
-          <span className="sev low"    style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',padding:'1px 5px',textAlign:'center',opacity: v.low?1:0.15}}>{v.low}</span>
-          <span style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-3)'}}>{v.items.map(i=>i.rule.split(' ')[0]).join(' · ')}</span>
-        </div>
-      ))}
-    </div>
+      <div role="list">
+        {sorted.map(([k, v]) => (
+          <div key={k} role="listitem" aria-label={`${k} · ${v.high} high, ${v.medium} medium, ${v.low} low`} style={{display:'grid',gridTemplateColumns:'120px 60px 60px 60px 1fr',gap:'6px',alignItems:'center',padding:'4px 8px',background:'var(--bg-1)',border:'1px solid var(--line-1)'}}>
+            <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--brass-1)'}}>{k}</span>
+            <span className="sev high"   aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',padding:'1px 5px',textAlign:'center',opacity: v.high?1:0.15}}>{v.high}</span>
+            <span className="sev medium" aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',padding:'1px 5px',textAlign:'center',opacity: v.medium?1:0.15}}>{v.medium}</span>
+            <span className="sev low"    aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',padding:'1px 5px',textAlign:'center',opacity: v.low?1:0.15}}>{v.low}</span>
+            <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-3)'}}>{v.items.map(i=>i.rule.split(' ')[0]).join(' · ')}</span>
+          </div>
+        ))}
+      </div>
+    </section>
   );
 }
 
-// O3-C · Trend (history chart)
 function SafeAutoTrend() {
   const sa = P2f.safeAutonomy;
   const min = Math.min(...sa.history);
   const max = Math.max(...sa.history);
   return (
-    <div style={{background:'var(--bg-1)',border:'1px solid var(--line-2)',padding:'12px'}}>
-      <div style={{display:'flex',gap:'12px',alignItems:'baseline',marginBottom:'8px',fontFamily:'var(--font-mono)'}}>
+    <section aria-label={`Safe Autonomy trend · last 15 runs · min ${min}, current ${sa.global_score}, max ${max}`} style={{background:'var(--bg-1)',border:'1px solid var(--line-2)',padding:'12px'}}>
+      <div role="heading" aria-level={3} style={{display:'flex',gap:'12px',alignItems:'baseline',marginBottom:'8px',fontFamily:'var(--font-mono)'}}>
         <span style={{fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>autonomy score · last 15 runs</span>
         <span style={{marginLeft:'auto',fontSize:'var(--fs-10)',color:'var(--fg-3)'}}>min {min} · current <span style={{color:'var(--err-fg)'}}>{sa.global_score}</span> · max {max}</span>
       </div>
-      <div style={{display:'flex',alignItems:'flex-end',height:'80px',gap:'3px'}}>
+      <div aria-hidden="true" style={{display:'flex',alignItems:'flex-end',height:'80px',gap:'3px'}}>
         {sa.history.map((v, i) => {
           const pct = ((v - 70) / 15) * 100;
           const bad = v < 78;
@@ -314,10 +277,10 @@ function SafeAutoTrend() {
           );
         })}
       </div>
-      <div style={{display:'flex',justifyContent:'space-between',marginTop:'4px',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',color:'var(--fg-4)'}}>
+      <div aria-hidden="true" style={{display:'flex',justifyContent:'space-between',marginTop:'4px',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',color:'var(--fg-4)'}}>
         <span>−15</span><span>now</span>
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -325,68 +288,66 @@ function SafeAutoTrend() {
 // O4 · COST DASHBOARD
 // ═════════════════════════════════════════════════════════════════
 
-// O4-A · Per-agent token + cost table (sorted by cost desc)
 function CostPerAgent() {
   const rows = [...P2f.costs.perAgent].sort((a,b) => b.cost - a.cost);
   const maxCost = Math.max(...rows.map(r => r.cost));
   const maxLat = Math.max(...rows.map(r => r.p95_ms));
   return (
-    <div style={{display:'flex',flexDirection:'column',gap:'8px'}}>
-      <div className="cs-tot">
-        <div className="cell">
-          <span className="lbl">Total Cost</span>
-          <span className="v">${P2f.costs.total_cost_usd.toFixed(2)}</span>
-          <span className="sub">last 24h</span>
+    <section aria-label={`Cost dashboard · per agent · total $${P2f.costs.total_cost_usd.toFixed(2)}`} style={{display:'flex',flexDirection:'column',gap:'8px'}}>
+      <div className="cs-tot" role="list" aria-label="Cost totals">
+        <div className="cell" role="listitem" aria-label={`Total Cost: $${P2f.costs.total_cost_usd.toFixed(2)}, last 24h`}>
+          <span className="lbl" aria-hidden="true">Total Cost</span>
+          <span className="v" aria-hidden="true">${P2f.costs.total_cost_usd.toFixed(2)}</span>
+          <span className="sub" aria-hidden="true">last 24h</span>
         </div>
-        <div className="cell">
-          <span className="lbl">Tokens In</span>
-          <span className="v">{(rows.reduce((s,r)=>s+r.in_tok,0)/1e6).toFixed(2)}M</span>
-          <span className="sub">9 agents</span>
+        <div className="cell" role="listitem" aria-label={`Tokens In: ${(rows.reduce((s,r)=>s+r.in_tok,0)/1e6).toFixed(2)}M, 9 agents`}>
+          <span className="lbl" aria-hidden="true">Tokens In</span>
+          <span className="v" aria-hidden="true">{(rows.reduce((s,r)=>s+r.in_tok,0)/1e6).toFixed(2)}M</span>
+          <span className="sub" aria-hidden="true">9 agents</span>
         </div>
-        <div className="cell">
-          <span className="lbl">p50 Latency</span>
-          <span className="v">{P2f.costs.p50}<span style={{fontSize:'12px',color:'var(--fg-3)'}}>ms</span></span>
-          <span className="sub">global</span>
+        <div className="cell" role="listitem" aria-label={`p50 Latency: ${P2f.costs.p50}ms, global`}>
+          <span className="lbl" aria-hidden="true">p50 Latency</span>
+          <span className="v" aria-hidden="true">{P2f.costs.p50}<span style={{fontSize:'12px',color:'var(--fg-3)'}}>ms</span></span>
+          <span className="sub" aria-hidden="true">global</span>
         </div>
-        <div className="cell">
-          <span className="lbl">p95 Latency</span>
-          <span className="v" style={{color:'var(--err-fg)'}}>{P2f.costs.p95}<span style={{fontSize:'12px',color:'var(--fg-3)'}}>ms</span></span>
-          <span className="sub">over budget</span>
+        <div className="cell" role="listitem" aria-label={`p95 Latency: ${P2f.costs.p95}ms, over budget`}>
+          <span className="lbl" aria-hidden="true">p95 Latency</span>
+          <span className="v" aria-hidden="true" style={{color:'var(--err-fg)'}}>{P2f.costs.p95}<span style={{fontSize:'12px',color:'var(--fg-3)'}}>ms</span></span>
+          <span className="sub" aria-hidden="true">over budget</span>
         </div>
       </div>
-      <table className="cb-table cs-tbl">
+      <table className="cb-table cs-tbl" aria-label={`Per-agent cost table · ${rows.length} agents`}>
         <thead>
           <tr>
-            <th>Agent</th>
-            <th>In Tok</th>
-            <th>Out Tok</th>
-            <th>$ Cost</th>
-            <th>Cost</th>
-            <th>p50</th>
-            <th>p95</th>
-            <th>p95 trend</th>
+            <th scope="col">Agent</th>
+            <th scope="col">In Tok</th>
+            <th scope="col">Out Tok</th>
+            <th scope="col">$ Cost</th>
+            <th scope="col">Cost</th>
+            <th scope="col">p50</th>
+            <th scope="col">p95</th>
+            <th scope="col">p95 trend</th>
           </tr>
         </thead>
         <tbody>
           {rows.map(r => (
             <tr key={r.agent}>
-              <td style={{color:'var(--brass-1)'}}>{r.agent}</td>
+              <th scope="row" style={{color:'var(--brass-1)'}}>{r.agent}</th>
               <td className="lat-num">{(r.in_tok/1000).toFixed(0)}k</td>
               <td className="lat-num">{(r.out_tok/1000).toFixed(1)}k</td>
               <td className="lat-num" style={{color:'var(--brass-1)'}}>${r.cost.toFixed(2)}</td>
-              <td className="bar"><i style={{width:`${r.cost/maxCost*100}%`}}></i></td>
+              <td className="bar" aria-hidden="true"><i style={{width:`${r.cost/maxCost*100}%`}}></i></td>
               <td className="lat-num">{r.p50_ms}</td>
-              <td className={`lat-num ${r.p95_ms > 8000 ? 'bad' : ''}`}>{r.p95_ms}</td>
-              <td className="bar lat"><i style={{width:`${r.p95_ms/maxLat*100}%`}}></i></td>
+              <td className={`lat-num ${r.p95_ms > 8000 ? 'bad' : ''}`} aria-label={`${r.p95_ms}ms${r.p95_ms > 8000 ? ' · over budget' : ''}`}>{r.p95_ms}</td>
+              <td className="bar lat" aria-hidden="true"><i style={{width:`${r.p95_ms/maxLat*100}%`}}></i></td>
             </tr>
           ))}
         </tbody>
       </table>
-    </div>
+    </section>
   );
 }
 
-// O4-B · Provider × model heatmap
 function CostMatrix() {
   const m = P2f.costs.matrix;
   const flat = m.grid.flat().filter(v => v > 0);
@@ -400,46 +361,45 @@ function CostMatrix() {
     return 'z4';
   };
   return (
-    <div style={{display:'flex',flexDirection:'column',gap:'8px'}}>
-      <div style={{padding:'5px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
+    <section aria-label={`Cost matrix · provider × model · total $${P2f.costs.total_cost_usd.toFixed(2)} over 24h`} style={{display:'flex',flexDirection:'column',gap:'8px'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
         <span>provider × model · $ spent (24h)</span>
         <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>${P2f.costs.total_cost_usd.toFixed(2)}</span>
       </div>
-      <table className="cs-mat">
+      <table className="cs-mat" aria-label="Provider × model cost matrix">
         <thead>
           <tr>
-            <th></th>
-            {m.models.map(md => <th key={md}>{md}</th>)}
+            <th scope="col"></th>
+            {m.models.map(md => <th key={md} scope="col">{md}</th>)}
           </tr>
         </thead>
         <tbody>
           {m.providers.map((p, i) => (
             <tr key={p}>
-              <th className="row-h">{p}</th>
+              <th className="row-h" scope="row">{p}</th>
               {m.grid[i].map((v, j) => (
-                <td key={j} className={zone(v)}>{v > 0 ? `$${v.toFixed(2)}` : '—'}</td>
+                <td key={j} className={zone(v)} aria-label={`${p} × ${m.models[j]}: ${v > 0 ? '$' + v.toFixed(2) : 'no spend'}`}>{v > 0 ? `$${v.toFixed(2)}` : '—'}</td>
               ))}
             </tr>
           ))}
         </tbody>
       </table>
-    </div>
+    </section>
   );
 }
 
-// O4-C · Latency histogram + p50/p95 markers
 function CostLatency() {
   const buckets = P2f.costs.latencyBuckets;
   const max = Math.max(...buckets.map(b => b.n));
   const total = buckets.reduce((s,b) => s+b.n, 0);
   return (
-    <div style={{display:'flex',flexDirection:'column',gap:'8px'}}>
-      <div style={{padding:'5px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'12px'}}>
+    <section aria-label={`Cost latency distribution · ${total} calls · p50 ${P2f.costs.p50}ms · p95 ${P2f.costs.p95}ms`} style={{display:'flex',flexDirection:'column',gap:'8px'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'12px'}}>
         <span>latency distribution · {total} calls</span>
         <span style={{marginLeft:'auto'}}>p50 · <span style={{color:'var(--brass-1)'}}>{P2f.costs.p50}ms</span></span>
         <span>p95 · <span style={{color:'var(--err-fg)'}}>{P2f.costs.p95}ms</span></span>
       </div>
-      <div className="cs-hist">
+      <div className="cs-hist" role="img" aria-label={`Latency histogram · ${buckets.length} buckets`}>
         {buckets.map((b, i) => {
           const pct = b.n / max * 100;
           const bad = b.lo >= 8000;
@@ -451,20 +411,20 @@ function CostLatency() {
           );
         })}
       </div>
-      <div style={{display:'grid',gridTemplateColumns:'repeat(4, 1fr)',gap:'1px',background:'var(--line-2)',border:'1px solid var(--line-2)'}}>
+      <div role="list" aria-label="Latency band totals" style={{display:'grid',gridTemplateColumns:'repeat(4, 1fr)',gap:'1px',background:'var(--line-2)',border:'1px solid var(--line-2)'}}>
         {[
           { l:'< 1s',  v: buckets.filter(b=>b.hi<=1000).reduce((s,b)=>s+b.n,0), c:'var(--ok-fg)' },
           { l:'1–4s',  v: buckets.filter(b=>b.lo>=1000&&b.hi<=4000).reduce((s,b)=>s+b.n,0), c:'var(--brass-1)' },
           { l:'4–16s', v: buckets.filter(b=>b.lo>=4000&&b.hi<=16000).reduce((s,b)=>s+b.n,0), c:'var(--warn)' },
           { l:'> 16s', v: buckets.filter(b=>b.lo>=16000).reduce((s,b)=>s+b.n,0), c:'var(--err-fg)' },
         ].map(b => (
-          <div key={b.l} style={{background:'var(--bg-1)',padding:'6px 10px',display:'flex',flexDirection:'column',gap:'2px'}}>
-            <span style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>{b.l}</span>
-            <span style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-13)',color:b.c,fontVariantNumeric:'tabular-nums'}}>{b.v}<span style={{fontSize:'var(--fs-10)',color:'var(--fg-4)',marginLeft:'4px'}}>· {(b.v/total*100).toFixed(0)}%</span></span>
+          <div key={b.l} role="listitem" aria-label={`${b.l}: ${b.v} calls (${(b.v/total*100).toFixed(0)}%)`} style={{background:'var(--bg-1)',padding:'6px 10px',display:'flex',flexDirection:'column',gap:'2px'}}>
+            <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>{b.l}</span>
+            <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-13)',color:b.c,fontVariantNumeric:'tabular-nums'}}>{b.v}<span style={{fontSize:'var(--fs-10)',color:'var(--fg-4)',marginLeft:'4px'}}>· {(b.v/total*100).toFixed(0)}%</span></span>
           </div>
         ))}
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -472,53 +432,52 @@ function CostLatency() {
 // O5 · HEURISTIC + STRESS
 // ═════════════════════════════════════════════════════════════════
 
-// O5-A · Heuristic firing log
 function HeuristicLog() {
   return (
-    <div style={{background:'var(--bg-1)',border:'1px solid var(--line-2)'}}>
-      <div style={{padding:'5px 8px',borderBottom:'1px solid var(--line-2)',display:'flex',gap:'8px',background:'var(--bg-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>
+    <section aria-label={`Heuristic firing log · ${P2f.heuristics.filter(h=>h.triggered).length} fired of ${P2f.heuristics.length}`} style={{background:'var(--bg-1)',border:'1px solid var(--line-2)'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',borderBottom:'1px solid var(--line-2)',display:'flex',gap:'8px',background:'var(--bg-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>
         <span>tail · keeper_hooks_oas.heuristics.jsonl</span>
         <span style={{marginLeft:'auto',color:'var(--err-fg)'}}>{P2f.heuristics.filter(h=>h.triggered).length}/{P2f.heuristics.length} fired</span>
       </div>
-      {P2f.heuristics.map((h, i) => (
-        <div key={i} className={`hr-row ${h.triggered ? 'fired' : ''}`}>
-          <span className="ts">{h.ts.replace('Z','')}</span>
-          <span className="mod">{h.module}</span>
-          <span className="site">{h.site}<span className="det" style={{display:'block'}}>↳ {h.detail}</span></span>
-          <span className="num">value · <span className={h.triggered?'over':''}>{h.value}</span></span>
-          <span className="num">thr · {h.threshold}</span>
-          <span className={`fl ${h.triggered ? 't' : 'f'}`}>{h.triggered ? 'fire' : 'ok'}</span>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-// O5-B · Stress board (per-agent stressors)
-function StressBoard() {
-  return (
-    <div style={{display:'flex',flexDirection:'column',gap:'8px'}}>
-      <div style={{padding:'5px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
-        <span>agent stress · agent_stress.jsonl</span>
-        <span style={{marginLeft:'auto',color:'var(--err-fg)'}}>{P2f.stress.length} active</span>
-      </div>
-      <div className="st-grid">
-        {P2f.stress.map((s, i) => (
-          <div key={i} className={`scard ${s.kind}`}>
-            <div className="h">
-              <span className="ag">{s.agent}</span>
-              <span className="at">{s.at.replace('Z','')}</span>
-            </div>
-            <span className="kind">{s.kind}</span>
-            <span className="cn">count · <span className="v">{s.count}</span> · room {s.room}</span>
+      <div role="log" aria-live="polite" aria-label={`${P2f.heuristics.length} heuristic rows`}>
+        {P2f.heuristics.map((h, i) => (
+          <div key={i} role="listitem" aria-label={`${h.ts.replace('Z','')} · ${h.module} · ${h.site} · value ${h.value} threshold ${h.threshold} · ${h.triggered ? 'fire' : 'ok'}${h.detail ? ' · ' + h.detail : ''}`} className={`hr-row ${h.triggered ? 'fired' : ''}`}>
+            <span className="ts" aria-hidden="true">{h.ts.replace('Z','')}</span>
+            <span className="mod" aria-hidden="true">{h.module}</span>
+            <span className="site" aria-hidden="true">{h.site}<span className="det" style={{display:'block'}}>↳ {h.detail}</span></span>
+            <span className="num" aria-hidden="true">value · <span className={h.triggered?'over':''}>{h.value}</span></span>
+            <span className="num" aria-hidden="true">thr · {h.threshold}</span>
+            <span className={`fl ${h.triggered ? 't' : 'f'}`} aria-hidden="true">{h.triggered ? 'fire' : 'ok'}</span>
           </div>
         ))}
       </div>
-    </div>
+    </section>
   );
 }
 
-// O5-C · Module-grouped firing rate
+function StressBoard() {
+  return (
+    <section aria-label={`Agent stress board · ${P2f.stress.length} active stressors`} style={{display:'flex',flexDirection:'column',gap:'8px'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
+        <span>agent stress · agent_stress.jsonl</span>
+        <span style={{marginLeft:'auto',color:'var(--err-fg)'}}>{P2f.stress.length} active</span>
+      </div>
+      <div className="st-grid" role="list" aria-label="Stress cards">
+        {P2f.stress.map((s, i) => (
+          <article key={i} role="listitem" aria-label={`${s.agent} · ${s.kind} · count ${s.count} · room ${s.room} · ${s.at.replace('Z','')}`} className={`scard ${s.kind}`}>
+            <div className="h" aria-hidden="true">
+              <span className="ag">{s.agent}</span>
+              <span className="at">{s.at.replace('Z','')}</span>
+            </div>
+            <span className="kind" aria-hidden="true">{s.kind}</span>
+            <span className="cn" aria-hidden="true">count · <span className="v">{s.count}</span> · room {s.room}</span>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 function HeuristicByModule() {
   const byMod = {};
   P2f.heuristics.forEach(h => {
@@ -529,25 +488,27 @@ function HeuristicByModule() {
   });
   const rows = Object.entries(byMod).sort((a,b) => b[1].fired - a[1].fired);
   return (
-    <div style={{display:'flex',flexDirection:'column',gap:'4px'}}>
-      <div style={{padding:'5px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
+    <section aria-label={`Heuristic firing rate by module · ${rows.length} modules`} style={{display:'flex',flexDirection:'column',gap:'4px'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
         <span>heuristic firing rate · by module</span>
       </div>
-      {rows.map(([mod, v]) => {
-        const pct = v.total > 0 ? v.fired / v.total * 100 : 0;
-        return (
-          <div key={mod} style={{display:'grid',gridTemplateColumns:'160px 80px 1fr 60px',gap:'8px',alignItems:'center',padding:'5px 8px',background:'var(--bg-1)',border:'1px solid var(--line-1)'}}>
-            <span style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--fg-1)'}}>{mod}</span>
-            <span style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-3)'}}>{v.fired}/{v.total} fired</span>
-            <div style={{height:'10px',background:'var(--bg-2)',border:'1px solid var(--line-1)'}}>
-              <div style={{height:'100%',width:`${pct}%`,background: pct > 50 ? 'linear-gradient(90deg, var(--warn), var(--err))' : 'linear-gradient(90deg, var(--brass-3), var(--brass-1))'}}></div>
+      <div role="list">
+        {rows.map(([mod, v]) => {
+          const pct = v.total > 0 ? v.fired / v.total * 100 : 0;
+          return (
+            <div key={mod} role="listitem" aria-label={`${mod} · ${v.fired} of ${v.total} fired (${pct.toFixed(0)}%) · sites ${[...v.sites].join(', ')}`} style={{display:'grid',gridTemplateColumns:'160px 80px 1fr 60px',gap:'8px',alignItems:'center',padding:'5px 8px',background:'var(--bg-1)',border:'1px solid var(--line-1)'}}>
+              <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--fg-1)'}}>{mod}</span>
+              <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-3)'}}>{v.fired}/{v.total} fired</span>
+              <div aria-hidden="true" style={{height:'10px',background:'var(--bg-2)',border:'1px solid var(--line-1)'}}>
+                <div style={{height:'100%',width:`${pct}%`,background: pct > 50 ? 'linear-gradient(90deg, var(--warn), var(--err))' : 'linear-gradient(90deg, var(--brass-3), var(--brass-1))'}}></div>
+              </div>
+              <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color: pct > 50 ? 'var(--err-fg)' : 'var(--brass-1)',fontVariantNumeric:'tabular-nums',textAlign:'right'}}>{pct.toFixed(0)}%</span>
+              <span aria-hidden="true" style={{gridColumn:'1 / -1',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',color:'var(--fg-4)',letterSpacing:'.04em'}}>sites · {[...v.sites].join(' · ')}</span>
             </div>
-            <span style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color: pct > 50 ? 'var(--err-fg)' : 'var(--brass-1)',fontVariantNumeric:'tabular-nums',textAlign:'right'}}>{pct.toFixed(0)}%</span>
-            <span style={{gridColumn:'1 / -1',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',color:'var(--fg-4)',letterSpacing:'.04em'}}>sites · {[...v.sites].join(' · ')}</span>
-          </div>
-        );
-      })}
-    </div>
+          );
+        })}
+      </div>
+    </section>
   );
 }
 

--- a/dashboard/design-system/preview/cb-group-h.jsx
+++ b/dashboard/design-system/preview/cb-group-h.jsx
@@ -4,48 +4,59 @@
 
 const P2h = window.MASC_P2;
 
-// ═════════════════════════════════════════════════════════════════
-// K1 · KEEPER INSPECTOR v2
-// ═════════════════════════════════════════════════════════════════
-
-// K1-A · BDI Panel — will / needs / desires + goal horizons, per-keeper selector
-function KeeperBDIPanel() {
-  const [sel, setSel] = useState('sangsu');
-  const k = P2h.keepersFull.find(kp => kp.id === sel);
+function KeeperTabs({ keepers, sel, onSelect, label }) {
   return (
-    <div style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div className="ki-tabs">
-        {P2h.keepersFull.map(kp => (
-          <button key={kp.id} className={sel === kp.id ? 'on' : ''} onClick={() => setSel(kp.id)}>
-            <Dot kind={kClass(kp.id)} size="sm" /> {kp.id}
-          </button>
-        ))}
-      </div>
-      <div style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',display:'flex',alignItems:'center',gap:'8px',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-3)'}}>
-        <Dot kind={kClass(k.id)} beat />
-        <span style={{color:'var(--brass-1)'}}>{k.id}</span>
-        <span>·</span>
-        <span>{k.role}</span>
-        <span style={{marginLeft:'auto',color:'var(--fg-4)',fontSize:'var(--fs-9)'}}>social · {k.social_model}</span>
-      </div>
-      <div className="ki-bdi">
-        {[['will', k.will], ['needs', k.needs], ['desires', k.desires]].map(([lbl, v]) => (
-          <div key={lbl} className="row">
-            <span className="lbl">{lbl}</span>
-            <span className="v">{v}</span>
-          </div>
-        ))}
-        <div className="hz">
-          <span className="lbl">short</span><span className="v">{k.short_goal}</span>
-          <span className="lbl">mid</span>  <span className="v">{k.mid_goal}</span>
-          <span className="lbl">long</span> <span className="v">{k.long_goal}</span>
-        </div>
-      </div>
+    <div className="ki-tabs" role="tablist" aria-label={label}>
+      {keepers.map(kp => (
+        <button key={kp.id}
+                type="button"
+                role="tab"
+                aria-selected={sel === kp.id}
+                tabIndex={sel === kp.id ? 0 : -1}
+                aria-label={`Keeper ${kp.id}`}
+                className={sel === kp.id ? 'on' : ''}
+                onClick={() => onSelect(kp.id)}>
+          <Dot kind={kClass(kp.id)} size="sm" /> <span aria-hidden="true">{kp.id}</span>
+        </button>
+      ))}
     </div>
   );
 }
 
-// K1-B · Tool access + cascade config — per-keeper comparison table
+// K1-A · BDI Panel
+function KeeperBDIPanel() {
+  const [sel, setSel] = useState('sangsu');
+  const k = P2h.keepersFull.find(kp => kp.id === sel);
+  return (
+    <section aria-label="Keeper BDI panel · will, needs, desires" style={{display:'flex',flexDirection:'column',gap:'6px'}}>
+      <KeeperTabs keepers={P2h.keepersFull} sel={sel} onSelect={setSel} label="Select keeper for BDI panel" />
+      <div role="tabpanel" aria-label={`BDI panel for ${k.id}`}>
+        <div role="region" aria-label={`${k.id} · ${k.role} · social model ${k.social_model}`} style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',display:'flex',alignItems:'center',gap:'8px',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-3)'}}>
+          <Dot kind={kClass(k.id)} beat />
+          <span aria-hidden="true" style={{color:'var(--brass-1)'}}>{k.id}</span>
+          <span aria-hidden="true">·</span>
+          <span aria-hidden="true">{k.role}</span>
+          <span aria-hidden="true" style={{marginLeft:'auto',color:'var(--fg-4)',fontSize:'var(--fs-9)'}}>social · {k.social_model}</span>
+        </div>
+        <dl className="ki-bdi" aria-label="BDI attributes">
+          {[['will', k.will], ['needs', k.needs], ['desires', k.desires]].map(([lbl, v]) => (
+            <div key={lbl} className="row">
+              <dt className="lbl">{lbl}</dt>
+              <dd className="v">{v}</dd>
+            </div>
+          ))}
+          <div className="hz">
+            <dt className="lbl">short</dt><dd className="v">{k.short_goal}</dd>
+            <dt className="lbl">mid</dt>  <dd className="v">{k.mid_goal}</dd>
+            <dt className="lbl">long</dt> <dd className="v">{k.long_goal}</dd>
+          </div>
+        </dl>
+      </div>
+    </section>
+  );
+}
+
+// K1-B · Tool access + cascade config
 function KeeperToolAccess() {
   const [sel, setSel] = useState('sangsu');
   const k = P2h.keepersFull.find(kp => kp.id === sel);
@@ -60,69 +71,66 @@ function KeeperToolAccess() {
     { lbl: 'mention targets', v: null, mentions: k.mention },
   ];
   return (
-    <div style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div className="ki-tabs">
-        {P2h.keepersFull.map(kp => (
-          <button key={kp.id} className={sel === kp.id ? 'on' : ''} onClick={() => setSel(kp.id)}>
-            <Dot kind={kClass(kp.id)} size="sm" /> {kp.id}
-          </button>
-        ))}
-      </div>
-      <div className="ki-access">
+    <section aria-label="Keeper tool access and cascade config" style={{display:'flex',flexDirection:'column',gap:'6px'}}>
+      <KeeperTabs keepers={P2h.keepersFull} sel={sel} onSelect={setSel} label="Select keeper for tool access" />
+      <dl className="ki-access" role="tabpanel" aria-label={`Tool access for ${k.id}`}>
         {rows.map(r => (
           <div key={r.lbl} className="row">
-            <span className="lbl">{r.lbl}</span>
-            <span className={`v ${r.cls || ''}`}>
+            <dt className="lbl">{r.lbl}</dt>
+            <dd className={`v ${r.cls || ''}`}>
               {r.mentions
                 ? r.mentions.map(m => <span key={m} className="mention">@{m}</span>)
                 : r.v}
-            </span>
+            </dd>
           </div>
         ))}
-      </div>
-    </div>
+      </dl>
+    </section>
   );
 }
 
-// K1-C · Token / handoff stats — bar chart across all keepers
+// K1-C · Token / handoff stats
 function KeeperTokenStats() {
   const keepers = P2h.keepersFull;
   const maxIn  = Math.max(...keepers.map(k => k.tokens.in));
-  const maxOut = Math.max(...keepers.map(k => k.tokens.out));
   return (
-    <div style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'12px'}}>
+    <section aria-label={`Token usage across ${keepers.length} keepers · ${(keepers.reduce((s,k)=>s+k.tokens.in,0)/1e6).toFixed(2)}M total in`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'12px'}}>
         <span>token usage · all keepers</span>
         <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>
           {(keepers.reduce((s,k)=>s+k.tokens.in,0)/1e6).toFixed(2)}M in total
         </span>
       </div>
-      <div className="ki-stats">
-        <div className="hdr">
-          <span>keeper</span><span>in tok</span><span>out tok</span><span>in distribution</span>
-        </div>
-        {[...keepers].sort((a,b) => b.tokens.in - a.tokens.in).map(k => (
-          <div key={k.id} className="row">
-            <span className="ag"><Dot kind={kClass(k.id)} size="sm" /> {k.id}</span>
-            <span className="num">{(k.tokens.in/1000).toFixed(0)}k</span>
-            <span className="num">{(k.tokens.out/1000).toFixed(1)}k</span>
-            <div className="bar"><i style={{width:`${k.tokens.in/maxIn*100}%`}} /></div>
-          </div>
-        ))}
-      </div>
-      <div style={{display:'grid',gridTemplateColumns:'repeat(3,1fr)',gap:'1px',background:'var(--line-1)',border:'1px solid var(--line-2)'}}>
+      <table className="ki-stats" aria-label="Per-keeper token usage">
+        <thead>
+          <tr className="hdr">
+            <th scope="col">keeper</th><th scope="col">in tok</th><th scope="col">out tok</th><th scope="col">in distribution</th>
+          </tr>
+        </thead>
+        <tbody>
+          {[...keepers].sort((a,b) => b.tokens.in - a.tokens.in).map(k => (
+            <tr key={k.id} className="row">
+              <th scope="row" className="ag"><Dot kind={kClass(k.id)} size="sm" /> <span aria-hidden="true">{k.id}</span></th>
+              <td className="num">{(k.tokens.in/1000).toFixed(0)}k</td>
+              <td className="num">{(k.tokens.out/1000).toFixed(1)}k</td>
+              <td className="bar" aria-hidden="true"><i style={{width:`${k.tokens.in/maxIn*100}%`}} /></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div role="list" aria-label="Token totals" style={{display:'grid',gridTemplateColumns:'repeat(3,1fr)',gap:'1px',background:'var(--line-1)',border:'1px solid var(--line-2)'}}>
         {[
           { lbl:'Total In', v:`${(keepers.reduce((s,k)=>s+k.tokens.in,0)/1e6).toFixed(2)}M` },
           { lbl:'Total Out', v:`${(keepers.reduce((s,k)=>s+k.tokens.out,0)/1000).toFixed(0)}k` },
           { lbl:'Keepers', v:keepers.length },
         ].map(c => (
-          <div key={c.lbl} style={{background:'var(--bg-1)',padding:'6px 10px',display:'flex',flexDirection:'column',gap:'2px'}}>
-            <span style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>{c.lbl}</span>
-            <span style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-14)',color:'var(--brass-1)',fontVariantNumeric:'tabular-nums'}}>{c.v}</span>
+          <div key={c.lbl} role="listitem" aria-label={`${c.lbl}: ${c.v}`} style={{background:'var(--bg-1)',padding:'6px 10px',display:'flex',flexDirection:'column',gap:'2px'}}>
+            <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>{c.lbl}</span>
+            <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-14)',color:'var(--brass-1)',fontVariantNumeric:'tabular-nums'}}>{c.v}</span>
           </div>
         ))}
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -130,31 +138,30 @@ function KeeperTokenStats() {
 // K2 · DECISIONS / MEMORY
 // ═════════════════════════════════════════════════════════════════
 
-// K2-A · Decisions stream — chronological, belief/desire/intention/blocker
 function DecisionsStream() {
   const [filter, setFilter] = useState('all');
   const keepers = ['all', ...new Set(P2h.decisions.map(d => d.keeper))];
   const rows = filter === 'all' ? P2h.decisions : P2h.decisions.filter(d => d.keeper === filter);
   return (
-    <div style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',alignItems:'center',gap:'6px'}}>
-        <span>decisions.jsonl</span>
-        <span style={{marginLeft:'auto',display:'flex',gap:'2px'}}>
+    <section aria-label={`Decisions stream · ${rows.length} entries${filter !== 'all' ? ` · filtered by ${filter}` : ''}`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
+      <div role="toolbar" aria-label="Decisions filter" style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',alignItems:'center',gap:'6px'}}>
+        <span aria-hidden="true">decisions.jsonl</span>
+        <span role="radiogroup" aria-label="Filter by keeper" style={{marginLeft:'auto',display:'flex',gap:'2px'}}>
           {keepers.map(k => (
-            <button key={k} onClick={() => setFilter(k)}
+            <button key={k} type="button" role="radio" aria-checked={filter===k} onClick={() => setFilter(k)}
               style={{padding:'1px 6px',background: filter===k ? 'var(--brass-3)' : 'var(--bg-1)',border:'1px solid var(--line-2)',color: filter===k ? 'var(--brass-1)' : 'var(--fg-3)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',cursor:'pointer'}}>
               {k}
             </button>
           ))}
         </span>
       </div>
-      <div style={{background:'var(--bg-0)',border:'1px solid var(--line-1)'}}>
+      <div role="log" aria-live="polite" aria-label={`${rows.length} decisions`} style={{background:'var(--bg-0)',border:'1px solid var(--line-1)'}}>
         {rows.map(d => (
-          <div key={d.id} className="dec-row">
-            <span className="ts">{d.ts.slice(11,19)}</span>
-            <span className="kpr">{d.keeper}</span>
-            <span className={`out ${d.outcome}`}>{d.outcome}</span>
-            <div className="body">
+          <div key={d.id} className="dec-row" role="listitem" aria-label={`${d.ts.slice(11,19)} · ${d.keeper} · ${d.outcome} · ${d.speech_act} via ${d.channel}${d.intention ? ' → ' + d.intention : ''}${d.blocker ? ' · blocker ' + d.blocker : ''}${d.belief ? ' · belief ' + d.belief : ''} · ${(d.latency_ms/1000).toFixed(1)}s`}>
+            <span className="ts" aria-hidden="true">{d.ts.slice(11,19)}</span>
+            <span className="kpr" aria-hidden="true">{d.keeper}</span>
+            <span className={`out ${d.outcome}`} aria-hidden="true">{d.outcome}</span>
+            <div className="body" aria-hidden="true">
               <span className="act">
                 {d.speech_act} · {d.channel}
                 {d.intention && <span style={{color:'var(--fg-2)'}}> → {d.intention}</span>}
@@ -166,43 +173,42 @@ function DecisionsStream() {
           </div>
         ))}
       </div>
-    </div>
+    </section>
   );
 }
 
-// K2-B · Memory entries — tag-filtered with keeper attribution
 function MemoryEntries() {
   const [tag, setTag] = useState('all');
   const tags = ['all', 'verified', 'learned', 'observed', 'plan'];
   const rows = tag === 'all' ? P2h.memoryEntries : P2h.memoryEntries.filter(m => m.tag === tag);
   return (
-    <div style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',alignItems:'center',gap:'6px'}}>
-        <span>memory.jsonl</span>
-        <span style={{marginLeft:'auto',display:'flex',gap:'2px'}}>
+    <section aria-label={`Memory entries · ${rows.length} rows${tag !== 'all' ? ` · tag ${tag}` : ''}`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
+      <div role="toolbar" aria-label="Memory tag filter" style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',alignItems:'center',gap:'6px'}}>
+        <span aria-hidden="true">memory.jsonl</span>
+        <span role="radiogroup" aria-label="Filter by tag" style={{marginLeft:'auto',display:'flex',gap:'2px'}}>
           {tags.map(t => (
-            <button key={t} onClick={() => setTag(t)}
+            <button key={t} type="button" role="radio" aria-checked={tag===t} onClick={() => setTag(t)}
               style={{padding:'1px 6px',background: tag===t ? 'var(--brass-3)' : 'var(--bg-1)',border:'1px solid var(--line-2)',color: tag===t ? 'var(--brass-1)' : 'var(--fg-3)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',cursor:'pointer'}}>
               {t}
             </button>
           ))}
         </span>
       </div>
-      <div style={{background:'var(--bg-0)',border:'1px solid var(--line-1)'}}>
+      <div role="list" aria-label={`${rows.length} memory entries`} style={{background:'var(--bg-0)',border:'1px solid var(--line-1)'}}>
         {rows.length > 0 ? rows.map((m, i) => (
-          <div key={i} className="mem-row">
-            <span className="ts">{m.at.slice(11,19)}</span>
-            <span className="kpr">{m.keeper}</span>
-            <span className={`tag ${m.tag}`}>{m.tag}</span>
-            <span className="body">{m.body}</span>
+          <div key={i} className="mem-row" role="listitem" aria-label={`${m.at.slice(11,19)} · ${m.keeper} · ${m.tag} · ${m.body}`}>
+            <span className="ts" aria-hidden="true">{m.at.slice(11,19)}</span>
+            <span className="kpr" aria-hidden="true">{m.keeper}</span>
+            <span className={`tag ${m.tag}`} aria-hidden="true">{m.tag}</span>
+            <span className="body" aria-hidden="true">{m.body}</span>
           </div>
         )) : (
-          <div style={{padding:'12px 8px',fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--fg-4)',textAlign:'center'}}>
+          <div role="status" style={{padding:'12px 8px',fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--fg-4)',textAlign:'center'}}>
             no entries for tag "{tag}"
           </div>
         )}
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -210,60 +216,70 @@ function MemoryEntries() {
 // K3 · INSTITUTION EPISODES
 // ═════════════════════════════════════════════════════════════════
 
-// K3-A · Turn cards — episode summary + learnings inline
 function EpisodeCards() {
   const [open, setOpen] = useState('ep-tm-t5');
   return (
-    <div style={{display:'flex',flexDirection:'column',gap:'0'}}>
-      <div style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px',marginBottom:'4px'}}>
+    <section aria-label={`Institution episodes · ${P2h.episodes.length} episodes`} style={{display:'flex',flexDirection:'column',gap:'0'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px',marginBottom:'4px'}}>
         <span>institution_episodes.jsonl</span>
         <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{P2h.episodes.length} episodes</span>
       </div>
-      {P2h.episodes.map(ep => {
-        const isOpen = open === ep.id;
-        return (
-          <div key={ep.id} className="ep-card" onClick={() => setOpen(isOpen ? null : ep.id)} style={{cursor:'pointer'}}>
-            <div className="h">
-              <span className="id">{ep.id}</span>
-              <span className="ts">{ep.ts.slice(11,19)}</span>
-              <div className="pp">
-                {ep.participants.map(p => <span key={p} className="p">{p}</span>)}
+      <div role="list" aria-label="Episode cards">
+        {P2h.episodes.map(ep => {
+          const isOpen = open === ep.id;
+          return (
+            <article key={ep.id}
+                     role="listitem"
+                     aria-label={`${ep.id} · ${ep.ts.slice(11,19)} · ${ep.participants.join(', ')} · ${ep.outcome} · ${ep.summary}`}
+                     aria-expanded={isOpen}
+                     tabIndex={0}
+                     onClick={() => setOpen(isOpen ? null : ep.id)}
+                     onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setOpen(isOpen ? null : ep.id); } }}
+                     className="ep-card"
+                     style={{cursor:'pointer'}}>
+              <div className="h" aria-hidden="true">
+                <span className="id">{ep.id}</span>
+                <span className="ts">{ep.ts.slice(11,19)}</span>
+                <div className="pp">
+                  {ep.participants.map(p => <span key={p} className="p">{p}</span>)}
+                </div>
+                <span className="oc">{ep.outcome}</span>
               </div>
-              <span className="oc">{ep.outcome}</span>
-            </div>
-            <div className="sm">{ep.summary}</div>
-            {isOpen && (
-              <div className="lns">
-                {ep.learnings.map((l, i) => (
-                  <div key={i} className="ln">{l}</div>
-                ))}
-              </div>
-            )}
-          </div>
-        );
-      })}
-    </div>
+              <div className="sm" aria-hidden="true">{ep.summary}</div>
+              {isOpen && (
+                <div className="lns" role="list" aria-label="Learnings">
+                  {ep.learnings.map((l, i) => (
+                    <div key={i} className="ln" role="listitem">{l}</div>
+                  ))}
+                </div>
+              )}
+            </article>
+          );
+        })}
+      </div>
+    </section>
   );
 }
 
-// K3-B · Learnings extraction — all learnings grouped by episode
 function EpisodeLearnings() {
   return (
-    <div className="ep-learn">
+    <section aria-label="Episode learnings · grouped by episode" className="ep-learn">
       {P2h.episodes.map(ep => (
-        <div key={ep.id} className="grp">
-          <div className="grp-h">
-            <span>{ep.id}</span>
-            <span style={{color:'var(--fg-4)'}}>·</span>
-            <span>{ep.participants.join(' + ')}</span>
-            <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{ep.learnings.length} learnings</span>
+        <div key={ep.id} className="grp" role="group" aria-label={`${ep.id} · ${ep.participants.join(' + ')} · ${ep.learnings.length} learnings`}>
+          <div className="grp-h" role="heading" aria-level={4}>
+            <span aria-hidden="true">{ep.id}</span>
+            <span aria-hidden="true" style={{color:'var(--fg-4)'}}>·</span>
+            <span aria-hidden="true">{ep.participants.join(' + ')}</span>
+            <span aria-hidden="true" style={{marginLeft:'auto',color:'var(--brass-1)'}}>{ep.learnings.length} learnings</span>
           </div>
-          {ep.learnings.map((l, i) => (
-            <div key={i} className="item">{l}</div>
-          ))}
+          <ul role="list" aria-label={`Learnings from ${ep.id}`} style={{listStyle:'none', margin:0, padding:0}}>
+            {ep.learnings.map((l, i) => (
+              <li key={i} className="item">{l}</li>
+            ))}
+          </ul>
         </div>
       ))}
-    </div>
+    </section>
   );
 }
 
@@ -271,20 +287,19 @@ function EpisodeLearnings() {
 // K4 · AUTORESEARCH
 // ═════════════════════════════════════════════════════════════════
 
-// K4-A · Loop list — all 6 ar-* loops with status, confidence, branch, owner
 function ARLoopList() {
   const confCls = (c) => c >= 0.8 ? 'hi' : c >= 0.5 ? '' : c >= 0.35 ? 'lo' : 'vlo';
   return (
-    <div style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px'}}>
+    <section aria-label={`Autoresearch loops · ${P2h.arLoops.filter(l=>l.status==='open').length} open · ${P2h.arLoops.filter(l=>l.status==='closed').length} closed`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px'}}>
         <span>autoresearch loops</span>
         <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{P2h.arLoops.filter(l=>l.status==='open').length} open · {P2h.arLoops.filter(l=>l.status==='closed').length} closed</span>
       </div>
-      <div style={{background:'var(--bg-0)'}}>
+      <div role="list" aria-label={`${P2h.arLoops.length} autoresearch loops`} style={{background:'var(--bg-0)'}}>
         {P2h.arLoops.map(l => (
-          <div key={l.id} className="ar-row">
-            <span className="id">{l.id.slice(0,11)}</span>
-            <div style={{display:'flex',flexDirection:'column',gap:'2px'}}>
+          <div key={l.id} className="ar-row" role="listitem" aria-label={`${l.id} · ${l.topic} · owner ${l.owner}${l.branch ? ' · branch ' + l.branch : ''} · ${l.hypotheses}H ${l.evidences}E ${l.conclusions}C · ${l.status} · ${(l.confidence*100).toFixed(0)}% confidence`}>
+            <span className="id" aria-hidden="true">{l.id.slice(0,11)}</span>
+            <div aria-hidden="true" style={{display:'flex',flexDirection:'column',gap:'2px'}}>
               <span className="topic">{l.topic}</span>
               <span style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-4)'}}>
                 owner · {l.owner}
@@ -292,92 +307,92 @@ function ARLoopList() {
                 {' · '}{l.hypotheses}H · {l.evidences}E · {l.conclusions}C
               </span>
             </div>
-            <span className={`st ${l.status}`}>{l.status}</span>
-            <span className={`conf ${confCls(l.confidence)}`}>{(l.confidence*100).toFixed(0)}%</span>
+            <span className={`st ${l.status}`} aria-hidden="true">{l.status}</span>
+            <span className={`conf ${confCls(l.confidence)}`} aria-hidden="true">{(l.confidence*100).toFixed(0)}%</span>
           </div>
         ))}
       </div>
-    </div>
+    </section>
   );
 }
 
-// K4-B · Finding card — detailed view of a selected finding
 function ARFindingCard() {
   const [sel, setSel] = useState('f-001');
   const f = P2h.findings.find(x => x.id === sel);
   return (
-    <div style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div style={{display:'flex',gap:'2px'}}>
+    <section aria-label="Autoresearch finding card" style={{display:'flex',flexDirection:'column',gap:'6px'}}>
+      <div role="tablist" aria-label="Select finding" style={{display:'flex',gap:'2px'}}>
         {P2h.findings.map(x => (
-          <button key={x.id} onClick={() => setSel(x.id)}
+          <button key={x.id} type="button" role="tab" aria-selected={sel===x.id} aria-controls="ar-finding-panel" tabIndex={sel===x.id ? 0 : -1} onClick={() => setSel(x.id)}
             style={{padding:'3px 10px',background: sel===x.id ? 'var(--brass-3)' : 'var(--bg-2)',border:'1px solid var(--line-2)',color: sel===x.id ? 'var(--brass-1)' : 'var(--fg-3)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',cursor:'pointer'}}>
             {x.id}
           </button>
         ))}
       </div>
-      <div className="ar-find">
-        <div className="hdr">
+      <article className="ar-find" id="ar-finding-panel" role="tabpanel" aria-label={`Finding ${f.id} · loop ${f.loop} · ${(f.confidence*100).toFixed(0)}% confidence`}>
+        <div className="hdr" aria-hidden="true">
           <span className="id">{f.id}</span>
           <span className="loop">loop · {f.loop}</span>
           <span style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-4)'}}>{f.at.slice(11,19)}</span>
           <span className="conf">{(f.confidence*100).toFixed(0)}% confidence</span>
         </div>
-        <div>
-          <div className="sec-h">hypothesis</div>
+        <section aria-labelledby={`ar-${f.id}-hyp`}>
+          <div className="sec-h" id={`ar-${f.id}-hyp`} role="heading" aria-level={4}>hypothesis</div>
           <div className="hy">{f.hypothesis}</div>
-        </div>
-        <div>
-          <div className="sec-h">evidence ({f.evidence.length})</div>
-          <div className="ev-list">
-            {f.evidence.map((e, i) => <div key={i} className="ev">{e}</div>)}
-          </div>
-        </div>
-        <div>
-          <div className="sec-h">conclusion</div>
+        </section>
+        <section aria-labelledby={`ar-${f.id}-ev`}>
+          <div className="sec-h" id={`ar-${f.id}-ev`} role="heading" aria-level={4}>evidence ({f.evidence.length})</div>
+          <ul className="ev-list" role="list" style={{listStyle:'none', margin:0, padding:0}}>
+            {f.evidence.map((e, i) => <li key={i} className="ev">{e}</li>)}
+          </ul>
+        </section>
+        <section aria-labelledby={`ar-${f.id}-co`}>
+          <div className="sec-h" id={`ar-${f.id}-co`} role="heading" aria-level={4}>conclusion</div>
           <div className="co">{f.conclusion}</div>
-        </div>
-      </div>
-    </div>
+        </section>
+      </article>
+    </section>
   );
 }
 
-// K4-C · Hypothesis → evidence → conclusion flow (ar-78d41e9c, closed loop)
 function ARHypothesisFlow() {
   const loop = P2h.arLoops.find(l => l.id === 'ar-78d41e9c');
   const finding = P2h.findings.find(f => f.loop === 'ar-78d41e9c');
   return (
-    <div style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px'}}>
+    <section aria-label={`${loop.id} · ${loop.topic} · closed · ${(loop.confidence*100).toFixed(0)}% confidence`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px'}}>
         <span>{loop.id}</span>
         <span style={{color:'var(--fg-3)'}}>· {loop.topic}</span>
         <span style={{marginLeft:'auto',color:'var(--ok-fg)'}}>closed · {(loop.confidence*100).toFixed(0)}% confidence</span>
       </div>
-      <div className="ar-flow">
-        <div className="step">
-          <div className="step-h">
-            <span className="step-n">1</span>
+      <ol className="ar-flow" aria-label="Hypothesis to evidence to conclusion flow" style={{listStyle:'none', margin:0, padding:0}}>
+        <li className="step">
+          <div className="step-h" role="heading" aria-level={4}>
+            <span className="step-n" aria-hidden="true">1</span>
             <span className="step-t">Hypothesis</span>
           </div>
           <div className="step-body">{finding.hypothesis}</div>
-        </div>
-        <div className="connector">↓</div>
-        <div className="step">
-          <div className="step-h">
-            <span className="step-n">2</span>
+        </li>
+        <li className="connector" aria-hidden="true">↓</li>
+        <li className="step">
+          <div className="step-h" role="heading" aria-level={4}>
+            <span className="step-n" aria-hidden="true">2</span>
             <span className="step-t">Evidence ({finding.evidence.length} items)</span>
           </div>
-          {finding.evidence.map((e, i) => <div key={i} className="ev">{e}</div>)}
-        </div>
-        <div className="connector">↓</div>
-        <div className="step">
-          <div className="step-h">
-            <span className="step-n">3</span>
+          <ul role="list" style={{listStyle:'none', margin:0, padding:0}}>
+            {finding.evidence.map((e, i) => <li key={i} className="ev">{e}</li>)}
+          </ul>
+        </li>
+        <li className="connector" aria-hidden="true">↓</li>
+        <li className="step">
+          <div className="step-h" role="heading" aria-level={4}>
+            <span className="step-n" aria-hidden="true">3</span>
             <span className="step-t">Conclusion</span>
           </div>
           <div className="ar-con">{finding.conclusion}</div>
-        </div>
-      </div>
-    </div>
+        </li>
+      </ol>
+    </section>
   );
 }
 

--- a/dashboard/design-system/preview/cb-group-i.jsx
+++ b/dashboard/design-system/preview/cb-group-i.jsx
@@ -40,15 +40,14 @@ function BranchSelector() {
   const [sel, setSel] = useState('main');
   const cur = P2i.branches.find(b => b.name === sel);
   return (
-    <div style={{display:'flex',flexDirection:'column',gap:'8px'}}>
-      {/* header bar — looks like topbar branch widget */}
-      <div className="br-bar">
-        <span className="lbl">branch</span>
-        <span className="sel">
+    <section aria-label="Branch selector" style={{display:'flex',flexDirection:'column',gap:'8px'}}>
+      <div className="br-bar" role="region" aria-label={`Active branch ${cur.name} · ${cur.ahead} ahead, ${cur.behind} behind · HEAD ${cur.head} · ${cur.keepers.length} keepers`}>
+        <span className="lbl" aria-hidden="true">branch</span>
+        <span className="sel" aria-hidden="true">
           <span className="nm">{cur.name}</span>
           <span className="ca">▾</span>
         </span>
-        <span className="meta">
+        <span className="meta" aria-hidden="true">
           <span className="ah">↑{cur.ahead}</span>
           <span className="bh">↓{cur.behind}</span>
           <span>·</span>
@@ -58,39 +57,45 @@ function BranchSelector() {
         </span>
       </div>
 
-      {/* full branch list */}
-      <div style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px'}}>
         <span>switch branch · {P2i.branches.length} known</span>
         <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>active · {sel}</span>
       </div>
-      <div className="br-list">
+      <div className="br-list" role="radiogroup" aria-label="Branch list">
         {P2i.branches.map(b => (
-          <div key={b.name} className={`row ${b.name === sel ? 'on' : ''}`} onClick={() => setSel(b.name)}>
-            <span className="glyph">⎇</span>
-            <span className="nm">
+          <div key={b.name}
+               role="radio"
+               aria-checked={b.name === sel}
+               aria-label={`${b.name} · ${b.tag} · ${b.status} · ${b.ahead} ahead, ${b.behind} behind · HEAD ${b.head}`}
+               tabIndex={0}
+               onClick={() => setSel(b.name)}
+               onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSel(b.name); } }}
+               className={`row ${b.name === sel ? 'on' : ''}`}>
+            <span className="glyph" aria-hidden="true">⎇</span>
+            <span className="nm" aria-hidden="true">
               {b.name}
               <span className={`tag ${b.tag}`}>{b.tag}</span>
             </span>
-            <span className={`st ${b.status}`}>{b.status}</span>
-            <span className="ahbh">
+            <span className={`st ${b.status}`} aria-hidden="true">{b.status}</span>
+            <span className="ahbh" aria-hidden="true">
               <span className="ah">↑{b.ahead}</span>
               <span className="bh">↓{b.behind}</span>
             </span>
-            <span className="head">{b.head}</span>
+            <span className="head" aria-hidden="true">{b.head}</span>
             <span style={{display:'none'}} />
           </div>
         ))}
       </div>
-      <div style={{padding:'5px 10px',background:'var(--bg-1)',border:'1px solid var(--line-1)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-3)',display:'flex',gap:'8px',alignItems:'center'}}>
-        <span style={{color:'var(--fg-4)'}}>active branch keepers ·</span>
+      <div role="list" aria-label={`Active branch keepers · ${cur.keepers.length}`} style={{padding:'5px 10px',background:'var(--bg-1)',border:'1px solid var(--line-1)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-3)',display:'flex',gap:'8px',alignItems:'center'}}>
+        <span aria-hidden="true" style={{color:'var(--fg-4)'}}>active branch keepers ·</span>
         {cur.keepers.map(k => (
-          <span key={k} style={{display:'inline-flex',alignItems:'center',gap:'4px'}}>
-            <span style={{display:'inline-block',width:'8px',height:'8px',borderRadius:'50%',background:keeperColor(k)}}/>
-            <span style={{color:'var(--brass-1)'}}>{k}</span>
+          <span key={k} role="listitem" aria-label={k} style={{display:'inline-flex',alignItems:'center',gap:'4px'}}>
+            <span aria-hidden="true" style={{display:'inline-block',width:'8px',height:'8px',borderRadius:'50%',background:keeperColor(k)}}/>
+            <span aria-hidden="true" style={{color:'var(--brass-1)'}}>{k}</span>
           </span>
         ))}
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -107,37 +112,41 @@ function KeeperMultiSelect() {
     setSel(next);
   };
   return (
-    <div className="km-bar">
-      <div className="h">
-        <span className="lbl">keeper filter</span>
-        <span className="cnt">{sel.size} of {allKeepers.length} selected</span>
-        <button className="clr" onClick={() => setSel(new Set())}>clear</button>
-        <button className="clr" onClick={() => setSel(new Set(allKeepers.map(k => k.id)))}>all</button>
+    <section className="km-bar" aria-label={`Keeper multi-select · ${sel.size} of ${allKeepers.length} selected`}>
+      <div className="h" role="toolbar" aria-label="Keeper filter controls">
+        <span className="lbl" aria-hidden="true">keeper filter</span>
+        <span className="cnt" aria-live="polite">{sel.size} of {allKeepers.length} selected</span>
+        <button type="button" className="clr" aria-label="Clear all keepers" onClick={() => setSel(new Set())}>clear</button>
+        <button type="button" className="clr" aria-label="Select all keepers" onClick={() => setSel(new Set(allKeepers.map(k => k.id)))}>all</button>
       </div>
-      <div className="km-chips">
+      <div className="km-chips" role="group" aria-label={`${allKeepers.length} keepers · multi-select`}>
         {allKeepers.map(k => {
           const on = sel.has(k.id);
           return (
-            <span key={k.id} className={`km-chip ${on ? 'on' : ''}`} onClick={() => toggle(k.id)}>
-              <span style={{display:'inline-block',width:'7px',height:'7px',borderRadius:'50%',background:keeperColor(k.id)}}/>
-              <span>{k.id}</span>
-              <span className="role">· {k.role}</span>
-              <span className="x">{on ? '×' : '+'}</span>
-            </span>
+            <button key={k.id}
+                    type="button"
+                    aria-pressed={on}
+                    aria-label={`${k.id} · ${k.role}${on ? ' · selected' : ''}`}
+                    onClick={() => toggle(k.id)}
+                    className={`km-chip ${on ? 'on' : ''}`}>
+              <span aria-hidden="true" style={{display:'inline-block',width:'7px',height:'7px',borderRadius:'50%',background:keeperColor(k.id)}}/>
+              <span aria-hidden="true">{k.id}</span>
+              <span className="role" aria-hidden="true">· {k.role}</span>
+              <span className="x" aria-hidden="true">{on ? '×' : '+'}</span>
+            </button>
           );
         })}
       </div>
-      {/* echo: where this filter applies */}
-      <div style={{padding:'5px 10px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-3)',display:'flex',flexWrap:'wrap',gap:'4px',alignItems:'center'}}>
-        <span style={{color:'var(--fg-4)'}}>filter applied to ·</span>
+      <div role="status" aria-live="polite" aria-label={`Filter applied to 8 zones · ${sel.size === 0 ? 'all hidden' : sel.size + '-way scope'}`} style={{padding:'5px 10px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-3)',display:'flex',flexWrap:'wrap',gap:'4px',alignItems:'center'}}>
+        <span aria-hidden="true" style={{color:'var(--fg-4)'}}>filter applied to ·</span>
         {['Swimlanes','Activity','Audit','Decisions','Memory','Cost','Stress','Episodes'].map(z => (
-          <span key={z} style={{padding:'1px 5px',background:'var(--bg-1)',border:'1px solid var(--line-1)',color:'var(--fg-2)'}}>{z}</span>
+          <span key={z} aria-hidden="true" style={{padding:'1px 5px',background:'var(--bg-1)',border:'1px solid var(--line-1)',color:'var(--fg-2)'}}>{z}</span>
         ))}
-        <span style={{marginLeft:'auto',color: sel.size === 0 ? 'var(--err-fg)' : 'var(--brass-1)'}}>
+        <span aria-hidden="true" style={{marginLeft:'auto',color: sel.size === 0 ? 'var(--err-fg)' : 'var(--brass-1)'}}>
           {sel.size === 0 ? '⚠ all hidden' : `→ ${sel.size}-way scope`}
         </span>
       </div>
-    </div>
+    </section>
   );
 }
 
@@ -150,44 +159,49 @@ function OperatorNudgeLog() {
   const [body, setBody] = useState('');
   const [targets] = useState(['sangsu']);
   return (
-    <div style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px'}}>
+    <section aria-label={`Operator nudge log · ${P2i.nudges.length} total · ${P2i.nudges.filter(n => !n.ack).length} pending ack`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px'}}>
         <span>operator · nudge log</span>
         <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{P2i.nudges.length} nudges · {P2i.nudges.filter(n => !n.ack).length} pending ack</span>
       </div>
-      <div style={{background:'var(--bg-0)'}}>
+      <div role="log" aria-live="polite" aria-label={`${P2i.nudges.length} nudges`} style={{background:'var(--bg-0)'}}>
         {P2i.nudges.map(n => (
-          <div key={n.id} className="nd-row">
-            <span className="ts">{n.at.replace('Z','')}</span>
-            <span className={`ch ${n.channel}`}>{n.channel}</span>
-            <span className="to">
+          <div key={n.id} className="nd-row" role="listitem" aria-label={`${n.at.replace('Z','')} · ${n.channel} · to ${n.to.map(k => '@' + k).join(', ')} · ${n.body} · ${n.ack ? 'acknowledged' : 'pending acknowledgment'}`}>
+            <span className="ts" aria-hidden="true">{n.at.replace('Z','')}</span>
+            <span className={`ch ${n.channel}`} aria-hidden="true">{n.channel}</span>
+            <span className="to" aria-hidden="true">
               {n.to.map(k => <span key={k} className="k">@{k}</span>)}
             </span>
-            <span className="body">{n.body}</span>
-            <span className={`ack ${n.ack ? 'y' : 'n'}`}>{n.ack ? '✓ ack' : '… pending'}</span>
+            <span className="body" aria-hidden="true">{n.body}</span>
+            <span className={`ack ${n.ack ? 'y' : 'n'}`} aria-hidden="true">{n.ack ? '✓ ack' : '… pending'}</span>
           </div>
         ))}
       </div>
-      <div className="nd-compose">
+      <form className="nd-compose" aria-label="Compose new nudge" onSubmit={(e) => e.preventDefault()}>
         <div className="h">
-          <span className="lbl">new nudge</span>
-          <div className="channels">
+          <span className="lbl" id="nudge-compose-label" role="heading" aria-level={4}>new nudge</span>
+          <div className="channels" role="radiogroup" aria-label="Nudge channel">
             {['hint','approve','reject','redirect'].map(c => (
-              <button key={c} className={channel === c ? 'on' : ''} onClick={() => setChannel(c)}>{c}</button>
+              <button key={c} type="button" role="radio" aria-checked={channel === c} className={channel === c ? 'on' : ''} onClick={() => setChannel(c)}>{c}</button>
             ))}
           </div>
         </div>
         <textarea
+          aria-labelledby="nudge-compose-label"
+          aria-label="Nudge body"
           placeholder="훈수만 두세요 — '실행은 keeper들이 알아서…'"
           value={body}
           onChange={e => setBody(e.target.value)}
         />
         <div className="ft">
-          <span className="targets">to · {targets.map(t => `@${t}`).join(', ') || '<none>'}</span>
-          <button className="send" disabled={!body.trim()}>send nudge ⏎</button>
+          <span className="targets" aria-label={`Sending to ${targets.map(t => '@' + t).join(', ') || 'no targets'}`}>
+            <span aria-hidden="true">to · </span>
+            <span aria-hidden="true">{targets.map(t => `@${t}`).join(', ') || '<none>'}</span>
+          </span>
+          <button type="submit" className="send" disabled={!body.trim()} aria-label="Send nudge">send nudge ⏎</button>
         </div>
-      </div>
-    </div>
+      </form>
+    </section>
   );
 }
 

--- a/dashboard/design-system/preview/cb-shared.jsx
+++ b/dashboard/design-system/preview/cb-shared.jsx
@@ -67,6 +67,37 @@ function kClass(id) {
   })[id] || 'idle';
 }
 
+// Theme — read/write the active data-theme on <html>.
+// Persists to localStorage under "masc-ds-theme" so a reload survives the
+// choice. Pass null to clear and fall back to prefers-color-scheme.
+const THEME_STORAGE_KEY = 'masc-ds-theme';
+
+function getTheme() {
+  return document.documentElement.dataset.theme || null;
+}
+
+function setTheme(theme) {
+  if (theme === null || theme === undefined) {
+    delete document.documentElement.dataset.theme;
+    try { localStorage.removeItem(THEME_STORAGE_KEY); } catch (_) {}
+    return;
+  }
+  document.documentElement.dataset.theme = theme;
+  try { localStorage.setItem(THEME_STORAGE_KEY, theme); } catch (_) {}
+}
+
+// Restore persisted theme on first script load. Safe to call from
+// any page that imports cb-shared.jsx; subsequent calls are no-ops
+// because dataset.theme is already set.
+(function restoreTheme() {
+  if (document.documentElement.dataset.theme) return;
+  let saved = null;
+  try { saved = localStorage.getItem(THEME_STORAGE_KEY); } catch (_) {}
+  if (saved === 'light' || saved === 'dark') {
+    document.documentElement.dataset.theme = saved;
+  }
+})();
+
 // Typing hook — types a string into state, char by char, looping
 function useTyping(strings, cps = 18) {
   const [text, setText] = useState('');
@@ -90,4 +121,4 @@ function useTyping(strings, cps = 18) {
   return text;
 }
 
-Object.assign(window, { Dot, Spark, Heartbeat, Chip, Pill, Vhead, kClass, useTyping });
+Object.assign(window, { Dot, Spark, Heartbeat, Chip, Pill, Vhead, kClass, useTyping, getTheme, setTheme });

--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -368,12 +368,95 @@ body[data-density="comfortable"]  { --density: 1.15; }
   --_motion-scope: 1;
 }
 
+/* ─────────────────────────────────────────────────────────────────
+   Semantic color tier — alias layer over raw tokens.
+   Components SHOULD reference --color-* over raw --bg-*/--fg-*/--brass-*
+   so theme overrides (data-theme / prefers-color-scheme) work without
+   touching component CSS. Raw tokens remain valid for escape hatches.
+   Tracking: issue #10389. */
+:root {
+  --color-bg-page:        var(--bg-0);
+  --color-bg-surface:     var(--bg-1);
+  --color-bg-elevated:    var(--bg-2);
+
+  --color-fg-primary:     var(--fg-1);
+  --color-fg-secondary:   var(--fg-2);
+  --color-fg-muted:       var(--fg-3);
+
+  --color-border-default: var(--line-1);
+  --color-border-strong:  var(--line-2);
+
+  --color-accent-fg:      var(--brass-1);
+  /* --color-accent already defined in colors_and_type.css */
+
+  --color-status-added:    var(--ok);
+  --color-status-modified: var(--warn);
+  --color-status-deleted:  var(--err);
+
+  --color-keeper-1: var(--k-nick);
+  --color-keeper-2: var(--k-masc);
+  --color-keeper-3: var(--k-sangsu);
+  --color-keeper-4: var(--k-qa);
+  --color-keeper-5: var(--k-rama);
+
+  /* outline color used by component :focus-visible rules.
+     Pairs with PR #10394 introducing this token in components.css. */
+  --color-focus-ring: var(--brass-1);
+}
+
+/* Light theme override — semantic layer only.
+   Raw tokens stay dark; components migrated to --color-* flip with theme,
+   un-migrated components stay dark. This is the gradual migration path. */
+:root[data-theme="light"] {
+  --color-bg-page:        #f7f5f0;
+  --color-bg-surface:     #fdfcf8;
+  --color-bg-elevated:    #ffffff;
+
+  --color-fg-primary:     #1a1612;
+  --color-fg-secondary:   #4a423a;
+  --color-fg-muted:       #7a7065;
+
+  --color-border-default: #d8d2c4;
+  --color-border-strong:  #b8b0a0;
+
+  --color-accent-fg:      var(--brass-3);
+
+  --color-status-added:    #3d7a3d;
+  --color-status-modified: #8a6a1a;
+  --color-status-deleted:  #a04030;
+
+  /* Keeper hues are attribution markers; keep saturation the same so a
+     person stays recognizable across themes. */
+
+  --color-focus-ring: var(--brass-3);
+}
+
+/* Auto light theme when user has no explicit data-theme set.
+   :not([data-theme]) prevents this from overriding an explicit choice. */
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme]) {
+    --color-bg-page:        #f7f5f0;
+    --color-bg-surface:     #fdfcf8;
+    --color-bg-elevated:    #ffffff;
+    --color-fg-primary:     #1a1612;
+    --color-fg-secondary:   #4a423a;
+    --color-fg-muted:       #7a7065;
+    --color-border-default: #d8d2c4;
+    --color-border-strong:  #b8b0a0;
+    --color-accent-fg:      var(--brass-3);
+    --color-status-added:    #3d7a3d;
+    --color-status-modified: #8a6a1a;
+    --color-status-deleted:  #a04030;
+    --color-focus-ring: var(--brass-3);
+  }
+}
+
 /* Reset / base */
 *, *::before, *::after { box-sizing: border-box; }
 html, body { margin: 0; padding: 0; height: 100%; }
 body {
-  background: var(--bg-0);
-  color: var(--fg-1);
+  background: var(--color-bg-page);
+  color: var(--color-fg-primary);
   font: var(--fs-13)/var(--lh-body) var(--font-sans);
   -webkit-font-smoothing: antialiased;
   font-feature-settings: "cv08", "ss01";


### PR DESCRIPTION
## Summary

Adds the 15-token semantic alias matrix required by Phase 3.5 tracking
issue #10389 acceptance criteria, layered over existing raw tokens so
component CSS can opt into theme-responsive variables without touching
raw palette anchors. PR #10394 ships only the a11y portion of #10389;
this PR is the **token + theme grounding** that the next steps build on.

Closes (partial): #10389 — token matrix + theme infra layers.

## Token tiers (now)

```
raw       --bg-0  --brass-1  --ok        (palette anchors, kept)
  ▼
semantic  --color-bg-page   --color-accent-fg  --color-keeper-1
          --color-focus-ring  --color-status-added  ...   (this PR)
  ▼
component .ix-tree { background: var(--color-bg-surface) }   (future)
```

## Tokens added (`source_styles/tokens.css`)

| Alias | Maps to (dark) | Light override |
|-------|---------------|----------------|
| `--color-bg-page` | `--bg-0` | `#f7f5f0` |
| `--color-bg-surface` | `--bg-1` | `#fdfcf8` |
| `--color-bg-elevated` | `--bg-2` | `#ffffff` |
| `--color-fg-primary` | `--fg-1` | `#1a1612` |
| `--color-fg-secondary` | `--fg-2` | `#4a423a` |
| `--color-fg-muted` | `--fg-3` | `#7a7065` |
| `--color-border-default` | `--line-1` | `#d8d2c4` |
| `--color-border-strong` | `--line-2` | `#b8b0a0` |
| `--color-accent-fg` | `--brass-1` | `--brass-3` |
| `--color-status-added` | `--ok` | `#3d7a3d` |
| `--color-status-modified` | `--warn` | `#8a6a1a` |
| `--color-status-deleted` | `--err` | `#a04030` |
| `--color-keeper-1..5` | `--k-{nick,masc,sangsu,qa,rama}` | (kept) |
| `--color-focus-ring` | `--brass-1` | `--brass-3` |

`--color-accent` already existed in `colors_and_type.css` — left as-is.

## Theme infrastructure

- `:root[data-theme="light"]` redefines the **semantic alias** set only.
  Raw tokens (`--bg-0`, `--brass-1`, …) keep dark values. Components
  still using raw tokens stay dark in light mode — this is intentional
  and enables gradual component migration.
- `@media (prefers-color-scheme: light)` fallback gated by
  `:root:not([data-theme])` so an explicit user choice via `setTheme()`
  always wins over OS preference.
- `body { background: var(--color-bg-page); color: var(--color-fg-primary); }`
  swap. In dark mode the alias resolves to the same raw token (zero
  visual delta); in light mode the body bg now flips correctly.

## API (`preview/cb-shared.jsx`)

```js
setTheme('light');   // flips and persists to localStorage
setTheme('dark');    // explicit dark
setTheme(null);      // clear → falls back to prefers-color-scheme
getTheme();          // → 'light' | 'dark' | null
```

`localStorage` key: `masc-ds-theme`. Restore-on-load runs once at script
import; no-op if `dataset.theme` is already set.

## README

New section **"Token tiers & theming"** documents the raw → semantic →
component layer architecture, the full alias table, and the theming
API. Lives between *Visual foundations* and *Iconography*.

## Validation

- `pnpm test` — 4065/4065 pass, 242/242 files (vitest, 120s)
- `pnpm typecheck` — `tsc --noEmit` exit 0
- Token coverage grep:
  ```bash
  for t in --color-bg-page ... --color-focus-ring; do
    rg -F -e "${t}:" dashboard/design-system/
  done
  ```
  → 15/15 OK in dark default + 14/14 in light override + 14/14 in
  `prefers-color-scheme` fallback.
- Manual visual smoke: **deferred** to do-not-merge gate. Operator
  should open `dashboard/design-system/preview/components.html` in
  Chrome, run `setTheme('light')` in console, confirm page bg flips
  to warm off-white. `setTheme('dark')` returns to brass aesthetic.
  `setTheme(null)` clears.

## Backwards compatibility

- All existing raw tokens unchanged. No component CSS modified outside
  the body rule swap.
- Single `body` rule swap is identity in dark mode (no visual change).
- Light mode visually mismatches in components still using raw tokens
  — by design. Each component migrates independently.

## Out of scope (follow-up)

- **Phase 1/2 a11y replication** (cb-group-a~i) and the **43 jagged
  hex/rgb literals** in `cb-group-d/e/i.jsx`, `code-mode.jsx`,
  `design-canvas.jsx`, `snippets.jsx` — separate PR (PR-B in the
  internal sequence).
- **Playwright 60-PNG snapshot baseline** — PR-C.
- **Lighthouse a11y CI ≥95 gate** — PR-D, after PR-B settles real
  scores.
- **Light palette polish** — current light values are functional
  placeholders. A formal light palette warrants design review.
- **Removing `--color-focus-ring` local declaration in PR #10394's
  `preview/components.css`** — that PR's locally-scoped definition
  becomes redundant once this PR lands. Cleanup will fold into PR-B.

## Test plan

- [ ] Manual: open `preview/components.html` in Chrome, console
      `setTheme('light')`, confirm page bg flips, `setTheme('dark')`
      returns. axe DevTools shows no new contrast violations on dark.
- [ ] Manual: console `setTheme(null)` clears localStorage and
      reload picks up `prefers-color-scheme` if set.
- [ ] CI green on Build and Test, Dashboard, Lint, Meta Guards,
      TLA+ Model Checking, Health, CI Gate.
- [ ] Confirm `do-not-merge` label remains attached after
      `label-and-review` action runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)