### PR TITLE
diag(task-schedule): label from_status + reason on auto-release JSONL (#10421)

### DIFF
--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -7,6 +7,20 @@ open Types
 include Coord_utils
 include Coord_state
 
+(** #10421: stable lowercase string label for a [task_status] suitable
+    for embedding in JSONL diagnostic events.  Mirrors what the
+    [task_transition] from→to fields already use so dashboards can
+    join the new auto-release rows on identical vocabulary.  Pure;
+    exposed for tests. *)
+let task_status_label (status : Types.task_status) : string =
+  match status with
+  | Todo -> "todo"
+  | Claimed _ -> "claimed"
+  | InProgress _ -> "in_progress"
+  | AwaitingVerification _ -> "awaiting_verification"
+  | Done _ -> "done"
+  | Cancelled _ -> "cancelled"
+
 let task_is_claim_pool_candidate (task : Types.task) =
   match task.task_status with
   | Todo ->
@@ -360,9 +374,18 @@ let claim_next_r
       let released_task_id, working_tasks = match previous_claim with
         | None -> None, backlog.tasks
         | Some prev ->
+            (* #10421: include [reason] and [from_status] in the JSONL
+               event so the auto-release tail (43/24 release/claim
+               ratio, 5x hot-potato on task-056) is discriminable
+               without cross-referencing observe_task_transition.
+               [from_status] separates Claimed (most cases) from
+               InProgress (rare; signals a keeper that started work
+               and then re-entered claim_next).  Same reason vocabulary
+               the structured observation already uses. *)
+            let from_status = task_status_label prev.task_status in
             log_event config (Printf.sprintf
-              "{\"type\":\"task_claim_next_auto_release\",\"agent\":\"%s\",\"released_task\":\"%s\",\"ts\":\"%s\"}"
-              agent_name prev.id (now_iso ()));
+              "{\"type\":\"task_claim_next_auto_release\",\"agent\":\"%s\",\"released_task\":\"%s\",\"from_status\":\"%s\",\"reason\":\"prev_claim_implicit_replaced\",\"ts\":\"%s\"}"
+              agent_name prev.id from_status (now_iso ()));
             (* No broadcast — internal state transition, log_event suffices. *)
             let updated = List.map (fun (t : Types.task) ->
               if String.equal t.id prev.id then { t with task_status = Todo }

--- a/test/dune
+++ b/test/dune
@@ -616,6 +616,7 @@
         test_keeper_runtime_denylist
         test_keeper_runtime_config_ssot
         test_dashboard_render_timing_9766
+        test_task_status_label_10421
         test_keeper_task_dispatch
         test_keeper_tag_dispatch
         test_autoresearch_knowledge
@@ -794,6 +795,7 @@
         test_keeper_runtime_denylist
         test_keeper_runtime_config_ssot
         test_dashboard_render_timing_9766
+        test_task_status_label_10421
         test_keeper_task_dispatch
         test_keeper_tag_dispatch
         test_autoresearch_knowledge

--- a/test/test_task_status_label_10421.ml
+++ b/test/test_task_status_label_10421.ml
@@ -1,0 +1,54 @@
+(** #10421: pre-fix the [task_claim_next_auto_release] JSONL event
+    carried only [agent] and [released_task] — operators could not
+    discriminate which prior status the release was reverting from
+    (43 claimed→todo vs 1 in_progress→todo on 2026-04-25, very
+    different signals).  This test pins [task_status_label] which
+    feeds the new [from_status] field and the existing [to_status]
+    column dashboards already index by. *)
+
+open Alcotest
+module C = Masc_mcp.Coord
+module T = Types
+
+let check_label expected status =
+  check string ("label of " ^ expected) expected
+    (C.task_status_label status)
+
+let now_iso = "2026-04-26T00:00:00Z"
+
+let claimed = T.Claimed { assignee = "k1"; claimed_at = now_iso }
+let in_progress =
+  T.InProgress { assignee = "k1"; started_at = now_iso }
+let awaiting =
+  T.AwaitingVerification {
+    assignee = "k1";
+    submitted_at = now_iso;
+    verification_id = "req-1";
+    deadline = None;
+  }
+let done_ = T.Done {
+  assignee = "k1";
+  completed_at = now_iso;
+  notes = None;
+}
+let cancelled = T.Cancelled {
+  cancelled_at = now_iso;
+  cancelled_by = "operator";
+  reason = Some "test";
+}
+
+let test_all_variants () =
+  check_label "todo" T.Todo;
+  check_label "claimed" claimed;
+  check_label "in_progress" in_progress;
+  check_label "awaiting_verification" awaiting;
+  check_label "done" done_;
+  check_label "cancelled" cancelled
+
+let () =
+  run "task_status_label_10421" [
+    ("status_label", [
+        test_case "every variant maps to canonical lowercase label"
+          `Quick test_all_variants;
+      ]);
+  ]


### PR DESCRIPTION
## 요약

**Issue**: #10421 — `task_claim_next` MCP tool이 호출 시 keeper의 이전 claim을 자동 release. 결과: 71 task transition / day 중 1건만 done (1.4%), task-056이 5번 hot-potato.

JSONL `task_claim_next_auto_release` event는 `agent` + `released_task`만 포함 → operator가 from_status (Claimed vs InProgress) 식별 불가.

## Fix scope (옵션 D only — non-behavioral)

| 옵션 | 이 PR |
|------|-------|
| A — Implicit auto-release 제거 | ❌ (behavior change, contract 결정 별도) |
| B — Explicit `release_and_claim_next` 분리 | ❌ (API 변경) |
| C — claim TTL + heartbeat | ❌ (zombie_cleanup 정상화 별도) |
| **D — Auto-release reason 분류** | ✅ |

## 변경

`lib/coord/coord_task_schedule.ml`:

```ocaml
+ (* Pure helper for JSONL/dashboard from→to vocabulary alignment *)
+ let task_status_label : Types.task_status -> string = ...

  let released_task_id, working_tasks = match previous_claim with
    | Some prev ->
+       let from_status = task_status_label prev.task_status in
        log_event config (Printf.sprintf
-         "{\"type\":\"task_claim_next_auto_release\",\"agent\":\"%s\",\"released_task\":\"%s\",\"ts\":\"%s\"}"
-         agent_name prev.id (now_iso ()));
+         "{\"type\":\"task_claim_next_auto_release\",\"agent\":\"%s\",\
+          \"released_task\":\"%s\",\"from_status\":\"%s\",\
+          \"reason\":\"prev_claim_implicit_replaced\",\"ts\":\"%s\"}"
+         agent_name prev.id from_status (now_iso ()));
```

## 두 새 필드의 가치

- **`from_status`**: 이슈의 정량 분포 (43 claimed→todo vs 1 in_progress→todo) 가 사실 같은 release event였음. 두 path의 의미가 다름:
  - `claimed → todo` — claim 후 work 진입 안 함 (waste)
  - `in_progress → todo` — 작업 시작 후 포기 (loss)
  
  dashboard에서 두 값으로 group_by 가능.

- **`reason`**: 현재 single value `prev_claim_implicit_replaced` 만 emit. 미래 release path 추가 시 (`idle_timeout`, `keeper_pause`, `zombie_cleanup`) 같은 키로 확장. closed vocabulary 유지.

## 검증

```text
DUNE_CACHE=disabled dune build --root . --cache=disabled @check
→ EXIT=0

dune exec test/test_task_status_label_10421.exe
→ 1/1 OK
  - every variant (Todo/Claimed/InProgress/AwaitingVerification/Done/Cancelled)
    maps to canonical lowercase label
```

## 영향 (예상)

머지 후 다음 cycle JSONL:
- `from_status` 분포로 hot-potato origin (Claimed-revert 비중 vs InProgress-abandon) 정량화
- `reason` 단일값이지만 미래 release path 추가 시 self-describing
- 기존 reader 영향 ZERO (additive)
- behavior 변동 없음 — auto-release 자체는 그대로 작동

## 미완 (별도 PR)

- 옵션 A: implicit auto-release 제거 (1.4% completion rate root cause). contract 결정 필요.
- 옵션 C: zombie_cleanup released_tasks=0 정상화 (현재 25 events/day가 noop).
- consumer wiring: dashboard에 from_status group_by 위젯.

## Defensive guards

- Draft + `do-not-merge` label
- `gh pr merge --disable-auto`

## 관련

- Issue: `#10421`
- 인접: `#10405` (goals dead — task-level mirror), `#10411` (Goal FSM Awaiting_verification dead-end), `#10314` (single-keeper-dominant 패턴), `#10325` (institution_episodes failure 사유 부재 mirror)
- 메모리: `feedback_no-collapse-richer-enum-at-sdk-boundary.md` (richer enum 보존)
