### PR TITLE
feat(keeper): emit sandbox cleanup error messages in janitor loop

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -625,11 +625,16 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
            with
            | None -> ()
            | Some result ->
-               if result.removed > 0 || result.errors <> [] then
+               if result.removed > 0 || result.errors <> [] then begin
                  Log.Server.info
                    "Sandbox cleanup: scanned=%d removed=%d errors=%d"
                    result.scanned result.removed
-                   (List.length result.errors));
+                   (List.length result.errors);
+                 List.iter
+                   (fun err ->
+                     Log.Server.warn "Sandbox cleanup error: %s" err)
+                   result.errors
+               end);
           (* Periodic JSONL prune: every 24h, clean dated JSONL files *)
           let now = Unix.gettimeofday () in
           if now -. !last_prune >= Masc_time_constants.day then begin


### PR DESCRIPTION
## Summary
- Follow-up to #10366: emit each error string from cleanup result at WARN
- Resolves visibility gap that hid server-context `docker rm -f` failures

## Problem
#10366 added the sandbox cleanup hook to the janitor loop and emits a single INFO line on activity:
```
Sandbox cleanup: scanned=1 removed=0 errors=1
```
The error *count* tells the operator something is wrong but offers no diagnostic content.

## Concrete failure
In build deployed at 01:18 KST (commit `2a684f9153`), the janitor logged `scanned=1 removed=0 errors=1` every 5 minutes from 16:22 to 16:47 UTC. The helper correctly found the leaked `nick0cave` container and tried to remove it, but the inner `docker rm -f` failed silently. Running the identical `docker rm -f fcb4f745b818` from a shell on the same host returned exit 0 instantly. The failure is server-context-specific — without the message body, the next round of triage starts blind again.

## Fix
Emit each error string from `result.errors` at WARN. The existing INFO count stays.

```diff
- if result.removed > 0 || result.errors <> [] then
-   Log.Server.info "Sandbox cleanup: scanned=%d removed=%d errors=%d" ...
+ if result.removed > 0 || result.errors <> [] then begin
+   Log.Server.info "Sandbox cleanup: scanned=%d removed=%d errors=%d" ...;
+   List.iter (fun err -> Log.Server.warn "Sandbox cleanup error: %s" err)
+     result.errors
+ end
```

## Test plan
- [x] `dune build @check` passes locally
- [ ] Deploy + restart, induce a cleanup error (e.g. running a sandbox container that resists `docker rm -f`), confirm WARN line shows up with message body

## Related
- #10366 (cleanup hook registration)
- 39차/40차 diagnosis in `~/me/memory/handoff-2026-04-25-keeper-iter11-22-summary.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)