### PR TITLE
perf(ws-transport): drop String.sub prefix-allocation in two SSE/route hot paths

### DIFF
--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -489,11 +489,8 @@ let parse_cache : (string * parsed_sse_event option) Atomic.t =
 let sse_data_prefix = "data:"
 
 let extract_sse_data_payload_line line =
-  let prefix_len = String.length sse_data_prefix in
-  if
-    String.length line >= prefix_len
-    && String.equal (String.sub line 0 prefix_len) sse_data_prefix
-  then
+  if String.starts_with ~prefix:sse_data_prefix line then
+    let prefix_len = String.length sse_data_prefix in
     let raw = String.sub line prefix_len (String.length line - prefix_len) in
     if String.length raw > 0 && Char.equal raw.[0] ' ' then
       Some (String.sub raw 1 (String.length raw - 1))

--- a/lib/transport.ml
+++ b/lib/transport.ml
@@ -676,7 +676,8 @@ module Rest = struct
       | None -> (
           match http_method, path with
           | _, p
-            when String.length p > 14 && String.sub p 0 14 = "/api/v1/tools/" ->
+            when String.starts_with ~prefix:"/api/v1/tools/" p
+                 && String.length p > 14 ->
               String.sub p 14 (String.length p - 14)
           | _ -> "unknown")
     in


### PR DESCRIPTION
## Summary

Two more sites where the prefix check allocated via \`String.sub\` before comparing — both directly on the WebSocket message stream that the transport migration is hammering.

### \`lib/server/server_mcp_transport_ws.ml\`
\`extract_sse_data_payload_line\` ran \`String.sub line 0 5 = \"data:\"\` per SSE line per WS frame. Replaced with \`String.starts_with\` — same semantics, no per-line allocation. This sits inside the parse cache miss path (\`Transport_metrics.inc_ws_parse_cache_miss\`), so on cold cache traffic the savings compound across every dashboard event.

### \`lib/transport.ml\`
\`/api/v1/tools/<name>\` route extraction did \`String.sub p 0 14\` to match the prefix, then \`String.sub\` again to slice the suffix. The prefix check now uses \`String.starts_with\`; the suffix slice is unchanged.

## Behavior preservation

\`String.starts_with\` already enforces the length-greater-or-equal check; the remaining \`String.length p > 14\` keeps the strict-greater guard so empty tool-name URIs still fall through to \"unknown\".

## Test plan

- [x] \`dune build @check\` clean
- [x] \`test_sse\` 4/4, \`test_sse_coverage\` 35/35
- [x] \`test_transport_coverage\` 109/109, \`test_transport_integration\` 9/9

🤖 Generated with [Claude Code](https://claude.com/claude-code)