### PR TITLE
fix(keeper-prompt): teach keepers to chdir before git in sandbox (#10424)

### DIFF
--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -39,6 +39,29 @@ When passing `path` or `cwd` to keeper tools:
 
 Including a host storage prefix causes path doubling errors. The tool maps your sandbox path for you.
 
+## Git commands
+
+`git` does not search across mount-point boundaries.  In your sandbox the
+mount point is the sandbox root (`.`) which is **not** a repository — only
+its `repos/<REPO_NAME>/` subdirectories are.  Running `git status`,
+`git diff`, `git log`, etc. from the sandbox root will fail with:
+
+```
+fatal: not a git repository (or any parent up to mount point /home/keeper/playground)
+Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
+```
+
+Always change directory first, or use `git -C` to scope a single command:
+
+- `cd repos/<REPO_NAME> && git status`
+- `git -C repos/<REPO_NAME> log --oneline -5`
+- `cd repos/<REPO_NAME>/.worktrees/{your-name}-<task_id> && git diff`
+
+When invoking `keeper_bash`, supply `cwd: "repos/<REPO_NAME>"` (or the
+worktree path) instead of relying on the sandbox-root default cwd.  This
+is the most common cause of `sandbox docker exec failed` events in the
+fleet log (#10424: 9x increase from 2 to 56 events/day across 04-24..26).
+
 ## Project
 
 Clone targets are controlled by `config/tool_policy.toml` `[git_clone]`.


### PR DESCRIPTION
## 요약

**Issue**: #10424 — Sandbox 내부 `git` 명령이 `/home/keeper/playground` mount point에서 실행되며 `fatal: not a git repository` 발생. 4월 24-26일 9x 증가 (2 → 18 → 56/day projection). masc-improver, analyst가 dominant.

## Fix scope (옵션 D — prompt-level guidance)

이슈의 5 옵션 중 가장 surgical:

| 옵션 | 이 PR |
|------|-------|
| A — Sandbox launch chdir to repos/<repo> | ❌ (multi-repo case 처리 필요) |
| B — keeper_bash wrapper auto-chdir 주입 | ❌ (heuristic risk, repo 추론 불가) |
| C — Sandbox root에 fail-fast 명시 메시지 | ❌ (runtime hook, 별도 PR) |
| **D — Keeper prompt에 chdir 명시** | ✅ (single config edit) |
| E — keeper.toml multi-repo 검토 | ❌ (operations) |

## 변경

`config/prompts/keeper.world.md`의 "Path Resolution Rule" 다음에 신규 "Git commands" 섹션 추가:

```markdown
## Git commands

`git` does not search across mount-point boundaries.  In your sandbox the
mount point is the sandbox root (`.`) which is **not** a repository — only
its `repos/<REPO_NAME>/` subdirectories are.  Running `git status`,
`git diff`, `git log`, etc. from the sandbox root will fail with:

\```
fatal: not a git repository (or any parent up to mount point /home/keeper/playground)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
\```

Always change directory first, or use `git -C` to scope a single command:

- `cd repos/<REPO_NAME> && git status`
- `git -C repos/<REPO_NAME> log --oneline -5`
- `cd repos/<REPO_NAME>/.worktrees/{your-name}-<task_id> && git diff`

When invoking `keeper_bash`, supply `cwd: "repos/<REPO_NAME>"` ...
```

## 디자인

- 정확한 fleet error message를 prompt에 인용 → keeper LLM이 mental model에서 즉시 매칭
- 3 concrete pattern (`cd && git`, `git -C`, `keeper_bash cwd:`) → 다양한 호출 컨텍스트 cover
- #10424 issue ref 포함 → traceability

## 검증

```text
DUNE_CACHE=disabled dune build --root . --cache=disabled @check
→ EXIT=0

dune exec test/test_prompt_registry_defaults.exe
→ 11/11 OK (기존 keeper.world 로딩 테스트 통과)
```

## 영향 (예상)

머지 후 다음 keeper 프로세스 재시작:
- `keeper.world` 시스템 프롬프트에 새 섹션 포함
- LLM이 git 호출 전 chdir 학습
- "fatal: not a git repository" 에러 빈도 감소 예상

## 미완 (별도 PR)

- 옵션 A: sandbox launch chdir (multi-repo case 디자인 필요)
- 옵션 C: runtime fail-fast (sandbox root에서 git 실행 detect → 명시적 가이드 메시지)

prompt-level fix만으로 100% 해결은 아님 (LLM이 instruction 무시 가능). 후속 runtime gate로 보강.

## Defensive guards

- Draft + `do-not-merge` label
- `gh pr merge --disable-auto`

## 관련

- Issue: `#10424`
- 인접: `#10421` (task FSM auto-release — 본 issue가 직접 원인 중 하나), `#10388` (cascade keeper_assignable violation), `#10314` (accountability silent — masc-improver/analyst silent의 mirror)
- 메모리: `feedback_dogfooding-principle.md` (sandbox 동작 직접 사용 검증)
