### PR TITLE
perf(transport-read-model): single-pass trim_trailing_slashes

### DIFF
--- a/lib/transport_read_model.ml
+++ b/lib/transport_read_model.ml
@@ -5,12 +5,17 @@ type http_context = {
   include_configured : bool;
 }
 
-let rec trim_trailing_slashes value =
+let trim_trailing_slashes value =
+  (* Single-pass scan + at-most-one [String.sub], instead of recursing
+     once per trailing '/'.  base_url normalization runs on every
+     binding/handshake so even the small-N case adds up. *)
   let len = String.length value in
-  if len > 0 && value.[len - 1] = '/' then
-    trim_trailing_slashes (String.sub value 0 (len - 1))
-  else
-    value
+  let rec last_non_slash i =
+    if i < 0 || value.[i] <> '/' then i else last_non_slash (i - 1)
+  in
+  let last = last_non_slash (len - 1) in
+  if last = len - 1 then value
+  else String.sub value 0 (last + 1)
 
 let trim_nonempty value =
   let trimmed = String.trim value in


### PR DESCRIPTION
## Summary

\`trim_trailing_slashes\` recursed once per trailing \`/\`, allocating a fresh \`String.sub\` on every step. \`base_url\` normalization runs on every binding lookup and every websocket handshake, so even the typical small-N case adds up across the WS-transition workload.

Replace with a single backward scan to find the last non-\`/\` index, then **at most one** \`String.sub\`. Identity-equal return when the input has no trailing slash (no allocation at all).

## Test plan

- [x] \`dune build @check\` clean
- [x] \`test_transport_read_model\` 9/9

🤖 Generated with [Claude Code](https://claude.com/claude-code)