### PR TITLE
fix(goal-janitor): periodic sweep fiber in bootstrap loops (#10405)

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -354,6 +354,25 @@ module Verification = struct
     get_float ~default:60.0 "MASC_VERIFICATION_TIMEOUT_CHECK_INTERVAL_SEC"
 end
 
+(** {1 Goal Janitor}
+
+    #10405: Goal_janitor.run was only invoked from the dashboard
+    DELETE handler.  4 goals stagnated for 4 days with [last_review_at
+    = null] and [goals_snapshots/] empty.  Add a periodic background
+    fiber that sweeps stagnated goals on a 1-hour cadence by default. *)
+module Goal_janitor = struct
+  (** Enable the periodic goal_janitor sweep fiber.  Default: true.
+      Set MASC_GOAL_JANITOR_ENABLED=false to disable when debugging. *)
+  let enabled () =
+    get_bool ~default:true "MASC_GOAL_JANITOR_ENABLED"
+
+  (** Sweep interval in seconds.  Default: 3600 (1 hour).
+      Goal stagnation is measured in days, so the cadence does not need
+      to be tight; a coarse sweep keeps the fleet log uncluttered. *)
+  let interval_seconds =
+    get_float ~default:3600.0 "MASC_GOAL_JANITOR_INTERVAL_SEC"
+end
+
 (** {1 Slot Scheduling} *)
 
 module Slot = struct

--- a/lib/env_config_runtime.mli
+++ b/lib/env_config_runtime.mli
@@ -160,6 +160,15 @@ module Verification : sig
   val timeout_check_interval_seconds : float
 end
 
+(** #10405: periodic Goal_janitor sweep.  Pre-fix the only caller was
+    the dashboard DELETE handler, so 4 active goals stagnated for 4
+    days with [last_review_at = null].  The bootstrap loop reads
+    these to spawn a periodic sweep fiber. *)
+module Goal_janitor : sig
+  val enabled : unit -> bool
+  val interval_seconds : float
+end
+
 module Board : sig
   type backend =
     | Jsonl

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -329,6 +329,33 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
       loop ()
     in
     loop ());
+  (* #10405: Goal_janitor.run was previously only invoked by the
+     dashboard DELETE handler, so stagnated [Active] goals never got
+     promoted to [Dropped] and [last_review_at] stayed null indefinitely
+     (4 goals stale for 4 days observed on 2026-04-25).  Spawn a
+     periodic sweep fiber on a 1-hour cadence so the existing
+     [stagnant_days] / [dropped_ttl_days] thresholds actually fire.
+     [enabled ()] is true by default; flipping it to false leaves the
+     dashboard DELETE path as the only caller (pre-fix behaviour). *)
+  fork_subsystem "goal_janitor" (fun () ->
+    if not (Env_config_runtime.Goal_janitor.enabled ()) then
+      Log.Server.info "goal_janitor: disabled via MASC_GOAL_JANITOR_ENABLED=false"
+    else begin
+      let interval = Env_config_runtime.Goal_janitor.interval_seconds in
+      let rec loop () =
+        Eio.Time.sleep clock interval;
+        (try
+           let _result = Goal_janitor.run state.room_config in
+           ()
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+           Log.Server.warn "goal_janitor: sweep failed: %s"
+             (Printexc.to_string exn));
+        loop ()
+      in
+      loop ()
+    end);
   (* Auto-boot keepers from keeper meta and start keepalive loops.
      Retries unbooted keepers up to [max_retries] times so transient
      failures (model resolution, discovery timing) don't permanently


### PR DESCRIPTION
## 요약

**Issue**: #10405 — `Goal_janitor.run`이 dashboard DELETE handler에서만 호출됨. periodic / cron / Eio.Time scheduler 부재. 결과:

- 4 active goals × 4일 stale (`last_review_at = null`)
- `goals_snapshots/` 0 bytes
- Goal phase FSM의 자동 stale → Dropped 전이 비활성

```bash
$ rg "Goal_janitor\." lib/
lib/server/server_dashboard_http_delete_actions.ml:  let result = Goal_janitor.run config in
```

**유일한 caller**: HTTP DELETE handler.

## Fix scope (옵션 A only)

이슈의 4 옵션 중 가장 surgical:

| 옵션 | 이 PR |
|------|-------|
| **A — Periodic sweep fiber 추가** | ✅ |
| B — Goal review 자동화 (keeper turn마다) | ❌ (별도 product decision) |
| C — `goals_snapshots/` emit hook | ❌ (Goal_store path 별도) |
| D — Stale alert (Slack/dashboard) | ❌ (notification stack 결정 필요) |

## 변경

**1. `lib/config/env_config_runtime.ml` + `lib/env_config_runtime.mli`**:

새 `Goal_janitor` 모듈:

```ocaml
module Goal_janitor = struct
  let enabled () = get_bool ~default:true "MASC_GOAL_JANITOR_ENABLED"
  let interval_seconds = get_float ~default:3600.0 "MASC_GOAL_JANITOR_INTERVAL_SEC"
end
```

**2. `lib/server/server_bootstrap_loops.ml`**:

새 `goal_janitor` subsystem (verification_timeout 다음에 fork):

```ocaml
fork_subsystem "goal_janitor" (fun () ->
  if not (Env_config_runtime.Goal_janitor.enabled ()) then
    Log.Server.info "goal_janitor: disabled via MASC_GOAL_JANITOR_ENABLED=false"
  else begin
    let interval = Env_config_runtime.Goal_janitor.interval_seconds in
    let rec loop () =
      Eio.Time.sleep clock interval;
      (try let _ = Goal_janitor.run state.room_config in ()
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn -> Log.Server.warn "goal_janitor: sweep failed: %s"
                  (Printexc.to_string exn));
      loop ()
    in
    loop ()
  end);
```

## 디자인 결정

- **1-hour 기본 cadence**: stagnation은 days 단위라 sec/min 단위 sweep은 noise. coarse sweep으로 fleet log 깨끗.
- **enabled 토글**: 기본 true, 디버깅 시 false로 dashboard-only fallback 가능 (pre-fix 동작).
- **WARN on sweep fail + Cancelled re-raise**: 다른 subsystem (verification_timeout, session_cleanup)와 동일 패턴.

## 검증

```text
DUNE_CACHE=disabled dune build --root . --cache=disabled @check
→ EXIT=0
```

기존 단위 테스트 모두 영향 없음 (env_config 추가 + bootstrap loop 추가, 기존 path 변경 없음).

## 영향 (예상)

머지 후 다음 server restart:
- 1 hour 후 첫 sweep: `Goal_janitor.run`이 stagnated goals를 `Dropped`로 전이
- 4 stale goals (4일+) → `phase=Dropped`, `last_review_at` 갱신
- `goals_snapshots/`는 별도 emit path 필요 (옵션 C 후속)

## 미완 (별도 PR)

- 옵션 B: keeper turn마다 owned goal `last_review_at` 갱신
- 옵션 C: `goals_snapshots/<timestamp>.json` emit hook
- 옵션 D: stale alert (Slack/dashboard)

## Defensive guards

- Draft + `do-not-merge` label
- `gh pr merge --disable-auto`

## 관련

- Issue: `#10405`
- 인접: `#10411` (Goal FSM Awaiting_verification dead-end — 같은 goal lifecycle gap), `#10421` (task FSM auto-release — task-level mirror), `#9880` (governance decorative — goals.json input 부재)
- 메모리: `feedback_keeper-fleet-investigation.md` (RFC 추적이 goals.json 통해야 함)
