### PR TITLE
perf(keeper-api-route): drop per-suffix String.sub allocations

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -248,33 +248,37 @@ type keeper_post_route_kind =
   | Keeper_post_unknown
 
 let classify_keeper_post_route req_path =
-  let prefix = keeper_api_prefix in
-  let plen = String.length prefix in
-  let tlen = String.length req_path in
-  let ends_with suffix =
-    let slen = String.length suffix in
-    tlen > plen + slen
-    && String.sub req_path 0 plen = prefix
-    && String.sub req_path (tlen - slen) slen = suffix
-  in
-  if ends_with keeper_suffix_tools then Keeper_post_tools
-  else if ends_with keeper_suffix_config then Keeper_post_config
-  else if ends_with keeper_suffix_boot then Keeper_post_boot
-  else if ends_with keeper_suffix_shutdown then Keeper_post_shutdown
-  else if ends_with keeper_suffix_reset then Keeper_post_reset
-  else if ends_with keeper_suffix_clear then Keeper_post_clear
-  else if ends_with keeper_suffix_checkpoints then Keeper_post_checkpoints
-  else if ends_with keeper_suffix_directive then Keeper_post_directive
-  else Keeper_post_unknown
+  (* Hoist the prefix check out of the per-suffix loop and route both
+     comparisons through Stdlib's allocation-free [starts_with] /
+     [ends_with]. Old form ran [String.sub req_path 0 plen] once per
+     suffix candidate (8x) plus a fresh suffix [String.sub] each time —
+     up to 16 allocations per keeper API request. *)
+  if not (String.starts_with ~prefix:keeper_api_prefix req_path) then
+    Keeper_post_unknown
+  else
+    let plen = String.length keeper_api_prefix in
+    let tlen = String.length req_path in
+    let ends_with suffix =
+      tlen > plen + String.length suffix
+      && String.ends_with ~suffix req_path
+    in
+    if ends_with keeper_suffix_tools then Keeper_post_tools
+    else if ends_with keeper_suffix_config then Keeper_post_config
+    else if ends_with keeper_suffix_boot then Keeper_post_boot
+    else if ends_with keeper_suffix_shutdown then Keeper_post_shutdown
+    else if ends_with keeper_suffix_reset then Keeper_post_reset
+    else if ends_with keeper_suffix_clear then Keeper_post_clear
+    else if ends_with keeper_suffix_checkpoints then Keeper_post_checkpoints
+    else if ends_with keeper_suffix_directive then Keeper_post_directive
+    else Keeper_post_unknown
 
 let keeper_path_ends_with req_path suffix =
-  let prefix = keeper_api_prefix in
-  let plen = String.length prefix in
+  let plen = String.length keeper_api_prefix in
   let tlen = String.length req_path in
   let slen = String.length suffix in
   tlen > plen + slen
-  && String.sub req_path 0 plen = prefix
-  && String.sub req_path (tlen - slen) slen = suffix
+  && String.starts_with ~prefix:keeper_api_prefix req_path
+  && String.ends_with ~suffix req_path
 
 let extract_keeper_name_for_suffix req_path suffix =
   let plen = String.length keeper_api_prefix in


### PR DESCRIPTION
## Summary

\`classify_keeper_post_route\` checked 8 suffixes against \`req_path\`. The per-suffix \`ends_with\` inner closure ran:

\`\`\`ocaml
String.sub req_path 0 plen = prefix
&& String.sub req_path (tlen - slen) slen = suffix
\`\`\`

**Up to 16 \`String.sub\` allocations per keeper API request** (8 prefix copies + 8 suffix copies). The prefix is invariant across the loop, so it should be hoisted; both comparisons are byte-equal so they collapse to \`Stdlib.String.starts_with\` / \`String.ends_with\` which avoid the copies entirely.

Same allocation pattern lived in \`keeper_path_ends_with\` — also routed through Stdlib.

## Behavior preservation

\`starts_with\` already enforces length-≥, but the explicit \`tlen > plen + slen\` strict-greater guard stays so empty keeper-name URIs still fall through to \`Keeper_post_unknown\`.

## Build note

\`@check\` currently fails on \`origin/main\` due to a pre-existing field mismatch in \`lib/dashboard_cascade.ml\` (\`same_fingerprint_count\`/\`trust_score\` not in \`provider_info\`). This PR builds cleanly in isolation; the file-level dune target for the touched module passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)