### PR TITLE
fix: unblock main build after Phase-1 trust revert orphans (#10441)

### DIFF
--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -306,10 +306,12 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason ~now () =
       (* Terminal structural errors are not quota exhaustion, but they have the
          same retry shape: the next cascade tick will hit the same provider
          state and fail again.  Cool down immediately to keep fallback from
-         becoming a hidden tax on every request. *)
+         becoming a hidden tax on every request.  #10441: the
+         [apply_trust_failure_locked] step was removed by #10412 (Phase 1
+         revert).  Keep [bump_failure_fp] for fingerprint history but discard
+         its return value — there's no trust adjustment to feed it into. *)
       state.consecutive_failures <- state.consecutive_failures + 1;
-      let persistent = bump_failure_fp () in
-      apply_trust_failure_locked state ~persistent;
+      bump_failure_fp ();
       let new_until = now +. terminal_failure_cooldown_sec in
       if new_until > state.cooldown_until then
         state.cooldown_until <- new_until)

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -521,59 +521,20 @@ type recommendation = {
   rec_rationale : string;
 }
 
-(* Classifier — see RFC-0009 §"Phase 2a".  Order matters: more specific
-   buckets first.  Returns [None] when the provider is healthy enough to
-   not warrant any operator action (default: trust >= 0.5 with no
-   stuck-fingerprint streak).
+(* Classifier — see RFC-0009 §"Phase 2a".
 
-   Boundaries are the calibrated trust_score zones from the same 4044-
-   record analysis that calibrated Phase 1 — not magic numbers.  Below
-   0.1 a provider is "essentially zero": multiplicative decays only
-   reach < 0.1 after 5+ persistent strikes. *)
+   #10441: Phase 1 was reverted in #10412, removing [trust_score] and
+   [same_fingerprint_count] from [Health.provider_info].  This classifier was
+   shipped by #10416 against a base that still had those fields, so its
+   per-provider trust thresholds no longer have any input data.  Stub it to
+   always emit [None] until the trust pipeline is reinstated; the type
+   surface stays alive so consumers ([low_trust_recommendations],
+   [recommendations_json]) keep their signatures.  See #10428 for the
+   redesign discussion. *)
 let classify_recommendation (info : Health.provider_info) :
     recommendation option =
-  let top_fp =
-    match info.top_fingerprints with
-    | (fp, _) :: _ -> Some fp
-    | [] -> None
-  in
-  let stuck_streak = info.same_fingerprint_count >= 5 in
-  let very_low = info.trust_score < 0.1 in
-  let low = info.trust_score < 0.3 in
-  let high_volume = info.events_in_window >= 30 in
-  let mk action rationale =
-    Some
-      {
-        rec_provider_key = info.provider_key;
-        rec_trust_score = info.trust_score;
-        rec_same_fingerprint_count = info.same_fingerprint_count;
-        rec_events_in_window = info.events_in_window;
-        rec_top_fingerprint = top_fp;
-        rec_action = action;
-        rec_rationale = rationale;
-      }
-  in
-  if stuck_streak then
-    mk Investigate
-      (Printf.sprintf
-         "stuck on the same fingerprint %d times — likely a config or auth issue, not provider quality"
-         info.same_fingerprint_count)
-  else if very_low && high_volume then
-    mk Investigate
-      (Printf.sprintf
-         "trust=%.2f after %d failures in the rolling window — high-volume failure pattern, inspect cascade_audit before reducing weight"
-         info.trust_score info.events_in_window)
-  else if very_low then
-    mk Disable
-      (Printf.sprintf
-         "trust=%.2f — provider has decayed to effectively zero across multiple persistent failures"
-         info.trust_score)
-  else if low then
-    mk Reduce_weight
-      (Printf.sprintf
-         "trust=%.2f — provider is partially working; halving the cascade.toml weight reduces wasted turns"
-         info.trust_score)
-  else None
+  let _ = info in
+  None
 
 let low_trust_recommendations (infos : Health.provider_info list) :
     recommendation list =

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -780,12 +780,19 @@ let test_keeper_profile_stale_builtin_falls_back_to_live_default () =
 
 module DC = Masc_mcp.Dashboard_cascade
 
+(* #10441: [trust_score] and [same_fingerprint_count] were removed from
+   [provider_info] by the Phase 1 revert (#10412).  Drop them from the
+   constructor signature and ignore the optional args so existing call
+   sites that still pass them keep type-checking until the recommendation
+   tests below are updated. *)
 let mk_info ?(success_rate = 1.0) ?(consecutive_failures = 0)
     ?(in_cooldown = false) ?(cooldown_expires_at = None)
     ?(events_in_window = 0) ?(rejected_in_window = 0)
     ?(top_fingerprints = []) ?(last_failure_at = None)
     ?(trust_score = 1.0) ?(same_fingerprint_count = 0) provider_key
   : Masc_mcp.Cascade_health_tracker.provider_info =
+  let _ = trust_score in
+  let _ = same_fingerprint_count in
   { provider_key
   ; success_rate
   ; consecutive_failures
@@ -795,8 +802,6 @@ let mk_info ?(success_rate = 1.0) ?(consecutive_failures = 0)
   ; rejected_in_window
   ; top_fingerprints
   ; last_failure_at
-  ; trust_score
-  ; same_fingerprint_count
   }
 
 let test_recommendation_healthy_returns_none () =
@@ -953,20 +958,23 @@ let () =
       test_case "canonical cascade: raw == canonical (UI renders —)"
         `Quick test_keeper_profile_canonical_matches_when_raw_is_canonical;
     ];
+    (* #10441: Phase 1 was reverted in #10412, removing [trust_score]
+       and [same_fingerprint_count] from [provider_info].  The
+       Phase-2a classifier reads those fields and now stubs to
+       [None] until the trust pipeline is reinstated, so the six
+       recommendation-firing tests (reduce_weight / disable /
+       stuck-streak / high-volume / sort / JSON shape) have no
+       data to exercise.  Keep the healthy-provider test which is
+       still meaningful (verifies the stub path) and drop the
+       rest until #10428 redesigns the classifier. *)
     "recommendations", [
       test_case "healthy provider yields no recommendation" `Quick
         test_recommendation_healthy_returns_none;
-      test_case "trust ∈ [0.1, 0.3) → reduce_weight" `Quick
-        test_recommendation_reduce_weight_for_partial_failure;
-      test_case "trust < 0.1 (decayed) → disable" `Quick
-        test_recommendation_disable_for_decayed_provider;
-      test_case "stuck-fingerprint streak → investigate" `Quick
-        test_recommendation_investigate_for_stuck_streak;
-      test_case "high-volume + very low trust → investigate" `Quick
-        test_recommendation_investigate_high_volume_overrides_disable;
-      test_case "list sorted ascending by trust" `Quick
-        test_recommendations_sorted_by_trust;
-      test_case "JSON shape preserves fields" `Quick
-        test_recommendation_to_json_shape;
     ];
   ]
+let _ = test_recommendation_reduce_weight_for_partial_failure
+let _ = test_recommendation_disable_for_decayed_provider
+let _ = test_recommendation_investigate_for_stuck_streak
+let _ = test_recommendation_investigate_high_volume_overrides_disable
+let _ = test_recommendations_sorted_by_trust
+let _ = test_recommendation_to_json_shape


### PR DESCRIPTION
**CRITICAL: main build was broken.** #10412 reverted Phase-1 trust scoring (#10365), but #10300 (Kimi cooldown) and #10416 (Phase-2a recommendations) were merged on top still referencing the deleted apply_trust_failure_locked, info.trust_score, info.same_fingerprint_count. Three compile errors. CI on the merge commits had cancel-in-progress masking the failure (separate governance gap noted in the issue). Fix follows issue's option 2 (remove the call) for site 1; for sites 2 and 3 (#10416 orphans not in original report) stub classify_recommendation to return None and drop the dead fields from the test record literal. 6 recommendation tests removed from the run list since their input data no longer exists; healthy-provider test stays. Full dune build green; cascade test suites (33+31+9+6) all pass.