### PR TITLE
fix(telemetry): cover Tool_assigned in lenient parser (sibling of #10356)

### DIFF
--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -164,6 +164,36 @@ let event_record_of_yojson_lenient json =
                         stderr_excerpt;
                       };
                 }
+          | Some (`List [ `String "Tool_assigned"; `Assoc event_fields ]) ->
+              let context = "Telemetry_eio.event" in
+              let ( let* ) = Result.bind in
+              let* timestamp =
+                Telemetry_json_fields.float
+                  "Telemetry_eio.event_record" "timestamp" fields
+              in
+              let* agent_id =
+                Telemetry_json_fields.string context "agent_id" event_fields
+              in
+              let* profile =
+                Telemetry_json_fields.string context "profile" event_fields
+              in
+              let* preset =
+                Telemetry_json_fields.string_opt context "preset" event_fields
+              in
+              let* tool_count =
+                Telemetry_json_fields.int context "tool_count" event_fields
+              in
+              let* assignment_id =
+                Telemetry_json_fields.string context "assignment_id"
+                  event_fields
+              in
+              Ok
+                {
+                  timestamp;
+                  event =
+                    Tool_assigned
+                      { agent_id; profile; preset; tool_count; assignment_id };
+                }
           | _ -> Error original_error)
       | _ -> Error original_error)
 

--- a/test/test_telemetry_eio_coverage.ml
+++ b/test/test_telemetry_eio_coverage.ml
@@ -211,6 +211,66 @@ let test_parse_event_records_tool_called_missing_options () =
   check_one_tool_called_record "missing options" json ~operation_id:None
     ~worker_run_id:None
 
+let check_one_tool_assigned_record label json ~preset =
+  match Telemetry_eio.parse_event_records [json] with
+  | [ record ] -> (
+      match record.event with
+      | Telemetry_eio.Tool_assigned r ->
+          check string (label ^ " agent_id")
+            "keeper-masc-improver-agent" r.agent_id;
+          check string (label ^ " profile") "default" r.profile;
+          check (option string) (label ^ " preset") preset r.preset;
+          check int (label ^ " tool_count") 32 r.tool_count;
+          check string (label ^ " assignment_id") "asg-001" r.assignment_id
+      | _ -> fail (label ^ ": expected Tool_assigned"))
+  | records ->
+      fail
+        (Printf.sprintf "%s: expected one parsed record, got %d" label
+           (List.length records))
+
+let test_parse_event_records_tool_assigned_null_preset () =
+  let json =
+    `Assoc
+      [
+        ("timestamp", `Float 1777120367.858374);
+        ( "event",
+          `List
+            [
+              `String "Tool_assigned";
+              `Assoc
+                [
+                  ("agent_id", `String "keeper-masc-improver-agent");
+                  ("profile", `String "default");
+                  ("preset", `Null);
+                  ("tool_count", `Int 32);
+                  ("assignment_id", `String "asg-001");
+                ];
+            ] );
+      ]
+  in
+  check_one_tool_assigned_record "null preset" json ~preset:None
+
+let test_parse_event_records_tool_assigned_missing_preset () =
+  let json =
+    `Assoc
+      [
+        ("timestamp", `Int 1777120367);
+        ( "event",
+          `List
+            [
+              `String "Tool_assigned";
+              `Assoc
+                [
+                  ("agent_id", `String "keeper-masc-improver-agent");
+                  ("profile", `String "default");
+                  ("tool_count", `Int 32);
+                  ("assignment_id", `String "asg-001");
+                ];
+            ] );
+      ]
+  in
+  check_one_tool_assigned_record "missing preset" json ~preset:None
+
 (* ============================================================
    metrics Type Tests
    ============================================================ *)
@@ -477,6 +537,10 @@ let () =
         test_parse_event_records_tool_called_null_options;
       test_case "tool_called missing option fields" `Quick
         test_parse_event_records_tool_called_missing_options;
+      test_case "tool_assigned null preset field" `Quick
+        test_parse_event_records_tool_assigned_null_preset;
+      test_case "tool_assigned missing preset field" `Quick
+        test_parse_event_records_tool_assigned_missing_preset;
     ];
     "metrics", [
       test_case "type" `Quick test_metrics_type;


### PR DESCRIPTION
## Why

PR #10356에서 `event_record_of_yojson_lenient`을 추가했지만 `Tool_called` variant만 다뤘습니다. `Tool_assigned`도 `preset: string option` 필드가 있어 동일한 drop pattern에 노출되어 있습니다.

production 로그 실측 (live-hotfix-10299.log + masc-mcp-postfix.err): Tool_assigned 관련 drop **0건** — 아직 발화되지 않은 시한폭탄. preventive coverage.

## What

`lib/telemetry_eio.ml:107` `event_record_of_yojson_lenient`의 fallback match에 `Tool_assigned` 케이스 추가. 동일한 `Telemetry_json_fields.string_opt` 헬퍼 사용으로 `null` 또는 missing `preset`을 모두 `Ok None`으로 매핑.

callable surface 변경 0. derived `event_record_of_yojson` strict path는 그대로, fallback만 확장.

## Test

`test/test_telemetry_eio_coverage.ml`에 2 alcotest 케이스 추가:
- `tool_assigned null preset field`: `("preset", \`Null)` 입력 → `Ok` with `preset = None`
- `tool_assigned missing preset field`: `preset` key 자체 누락 → `Ok` with `preset = None`

기존 `test_parse_event_records_tool_called_*` 4 케이스와 대칭. helper도 동일 패턴.

## Test 실행 상태 (중요)

main이 현재 깨져있어 (`#10416` Phase 2a가 reverted Phase 1에 의존, 1시간 전 머지) full test exec 불가. 진행중 fix PR:
- #10446 hotfix(main): unbreak build (Ready, BLOCKED)
- #10447 revert(P0): unbreak main — revert #10416 (Draft)

본 PR의 `lib/telemetry_eio.ml` 변경은 격리 build로 syntactic/type 정합성 확인:
```
DUNE_BUILD_DIR=_build_tool_assigned DUNE_CACHE=disabled \\
  scripts/dune-local.sh build _build_tool_assigned/default/lib/.masc_mcp.objs/byte/masc_mcp__Telemetry_eio.cmo
```
→ `Telemetry_eio.cmo`/`.cmx`/`.cmi`/`.o` 모두 생성 성공.

main 정상화 후 CI 자동 재평가. 코드 자체는 #10356과 동일 패턴이라 회귀 위험 없음.

## Blast radius

- callable surface 0 변경
- production 영향 0 (drop이 아직 없으니 흡수해도 변화 없음, 추후 Tool_assigned 신규 호출에서 null 들어와도 drop 안 됨)
- 기존 9 option Tool_called 처리 변경 없음

## Follow-up

같은 패턴이 향후 신규 option 필드 또는 신규 variant 추가 시 재발 가능. 구조적 fix 후보:
- (B) Generic `lenient_event_of_yojson` — 모든 variant 일괄 처리
- (C) `[@@deriving yojson]`을 lenient ppx로 교체

본 PR은 reactive (A) 단계. (B)/(C)는 별도 RFC.