### PR TITLE
feat(dashboard/design-system): a11y baseline for Phase 1 cb-group-a

### DIFF
--- a/dashboard/design-system/preview/cb-group-a.jsx
+++ b/dashboard/design-system/preview/cb-group-a.jsx
@@ -1,37 +1,42 @@
 // cb-group-a.jsx — Topbar, Ticker, KPI Strip, Lifeline (with variants)
 const D = window.MASC_DATA;
 
+// ─── density label helper ──────────────────────────────────────────
+const DENSITY_LABEL = { c: 'Compact', n: 'Normal', l: 'Loose' };
+
 // ─── TOPBAR variants ───────────────────────────────────────────────
 function TopbarStandard() {
   const [mode, setMode] = useState('dash');
   const [density, setDensity] = useState('n');
   return (
     <div className="cb-board">
-      <header className="cb-topbar">
+      <header className="cb-topbar" aria-label="MASC topbar">
         <div className="brand">
-          <span className="brand-mark" />
+          <span className="brand-mark" aria-hidden="true" />
           <span className="brand-name">MASC</span>
           <span className="ver">v0.42.1</span>
         </div>
-        <div className="sep" />
-        <button className="goal-switch">
+        <div className="sep" aria-hidden="true" />
+        <button type="button" className="goal-switch" aria-haspopup="menu" aria-label="Switch goal: goal-merge-blockers">
           <Dot kind="brass" size="sm" />
           <span>goal-merge-blockers</span>
-          <span className="caret">▾</span>
+          <span className="caret" aria-hidden="true">▾</span>
         </button>
-        <div className="mode-tabs">
+        <div className="mode-tabs" role="tablist" aria-label="View mode">
           {[['dash','Dash'],['code','Code'],['split','Split']].map(([k,l]) => (
-            <button key={k} className={mode===k?'on':''} onClick={()=>setMode(k)}>{l}</button>
+            <button key={k} type="button" role="tab" aria-selected={mode===k} tabIndex={mode===k?0:-1} className={mode===k?'on':''} onClick={()=>setMode(k)}>{l}</button>
           ))}
         </div>
         <div className="right">
-          <div className="density">
-            {['c','n','l'].map(d => <button key={d} className={density===d?'on':''} onClick={()=>setDensity(d)}>{d}</button>)}
+          <div className="density" role="radiogroup" aria-label="Display density">
+            {['c','n','l'].map(d => (
+              <button key={d} type="button" role="radio" aria-checked={density===d} aria-label={DENSITY_LABEL[d]} className={density===d?'on':''} onClick={()=>setDensity(d)}>{d}</button>
+            ))}
           </div>
           <span className="stamp">BUILD 2604 · 16:32:45Z</span>
         </div>
       </header>
-      <div style={{flex:1, background:'var(--bg-0)'}} />
+      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
     </div>
   );
 }
@@ -40,37 +45,37 @@ function TopbarExpanded() {
   const [mode, setMode] = useState('split');
   return (
     <div className="cb-board">
-      <header className="cb-topbar">
+      <header className="cb-topbar" aria-label="MASC topbar with branch and fleet">
         <div className="brand">
-          <span className="brand-mark" />
+          <span className="brand-mark" aria-hidden="true" />
           <span className="brand-name">MASC</span>
           <span className="ver">v0.42.1</span>
         </div>
-        <div className="sep" />
-        <button className="goal-switch">
+        <div className="sep" aria-hidden="true" />
+        <button type="button" className="goal-switch" aria-haspopup="menu" aria-label="Switch goal: goal-merge-blockers">
           <Dot kind="brass" size="sm" />
           <span>goal-merge-blockers</span>
-          <span className="caret">▾</span>
+          <span className="caret" aria-hidden="true">▾</span>
         </button>
-        <span className="branch">release-0.42</span>
-        <div className="sep" />
-        <div className="mode-tabs">
+        <span className="branch" aria-label="Active branch: release-0.42">release-0.42</span>
+        <div className="sep" aria-hidden="true" />
+        <div className="mode-tabs" role="tablist" aria-label="View mode">
           {[['dash','Dash'],['code','Code'],['split','Split']].map(([k,l]) => (
-            <button key={k} className={mode===k?'on':''} onClick={()=>setMode(k)}>{l}</button>
+            <button key={k} type="button" role="tab" aria-selected={mode===k} tabIndex={mode===k?0:-1} className={mode===k?'on':''} onClick={()=>setMode(k)}>{l}</button>
           ))}
         </div>
         <div className="right">
-          <div className="avatars">
-            <span className="av" style={{background:'var(--k-nick)'}} />
-            <span className="av" style={{background:'var(--k-masc)'}} />
-            <span className="av" style={{background:'var(--k-sangsu)'}} />
-            <span className="av" style={{background:'var(--k-qa)'}} />
-            <span className="av" style={{background:'var(--k-rama)'}} />
+          <div className="avatars" role="group" aria-label="5 active keepers">
+            <span className="av" style={{background:'var(--k-nick)'}} aria-hidden="true" />
+            <span className="av" style={{background:'var(--k-masc)'}} aria-hidden="true" />
+            <span className="av" style={{background:'var(--k-sangsu)'}} aria-hidden="true" />
+            <span className="av" style={{background:'var(--k-qa)'}} aria-hidden="true" />
+            <span className="av" style={{background:'var(--k-rama)'}} aria-hidden="true" />
           </div>
           <span className="stamp">5 ACTIVE · 2 IDLE</span>
         </div>
       </header>
-      <div style={{flex:1, background:'var(--bg-0)'}} />
+      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
     </div>
   );
 }
@@ -78,20 +83,20 @@ function TopbarExpanded() {
 function TopbarMinimal() {
   return (
     <div className="cb-board">
-      <header className="cb-topbar minimal">
+      <header className="cb-topbar minimal" aria-label="MASC topbar (minimal)">
         <div className="brand">
-          <span className="brand-mark" />
+          <span className="brand-mark" aria-hidden="true" />
           <span className="brand-name">MASC</span>
         </div>
-        <div className="mode-tabs">
-          <button className="on">Dash</button>
-          <button>Code</button>
+        <div className="mode-tabs" role="tablist" aria-label="View mode">
+          <button type="button" role="tab" aria-selected="true" tabIndex={0} className="on">Dash</button>
+          <button type="button" role="tab" aria-selected="false" tabIndex={-1}>Code</button>
         </div>
         <div className="right">
           <span className="stamp">16:32:45Z</span>
         </div>
       </header>
-      <div style={{flex:1, background:'var(--bg-0)'}} />
+      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
     </div>
   );
 }
@@ -104,7 +109,7 @@ function TickerMarquee() {
   const evs = [...tickerEvents(), ...tickerEvents()];
   return (
     <div className="cb-board">
-      <div className="cb-ticker">
+      <div className="cb-ticker" role="region" aria-label="Fleet event ticker (marquee)">
         <div className="tape">
           {evs.map((e, i) => (
             <span key={i} className={`evt ${e.kind}`}>
@@ -116,7 +121,7 @@ function TickerMarquee() {
           ))}
         </div>
       </div>
-      <div style={{flex:1, background:'var(--bg-0)'}} />
+      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
     </div>
   );
 }
@@ -124,7 +129,7 @@ function TickerChunks() {
   const evs = [...tickerEvents(), ...tickerEvents()];
   return (
     <div className="cb-board">
-      <div className="cb-ticker chunks">
+      <div className="cb-ticker chunks" role="region" aria-label="Fleet event ticker (chunked)">
         <div className="tape">
           {evs.map((e, i) => (
             <span key={i} className={`evt ${e.kind}`}>
@@ -135,7 +140,7 @@ function TickerChunks() {
           ))}
         </div>
       </div>
-      <div style={{flex:1, background:'var(--bg-0)'}} />
+      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
     </div>
   );
 }
@@ -143,7 +148,7 @@ function TickerVertical() {
   const evs = [...tickerEvents(), ...tickerEvents()];
   return (
     <div className="cb-board">
-      <div className="cb-ticker vertical">
+      <div className="cb-ticker vertical" role="region" aria-label="Fleet event ticker (side rail)">
         <div className="tape">
           {evs.map((e, i) => (
             <span key={i} className={`evt ${e.kind}`} style={{display:'flex', alignItems:'center', gap:6}}>
@@ -155,7 +160,7 @@ function TickerVertical() {
           ))}
         </div>
       </div>
-      <div style={{flex:1, background:'var(--bg-0)'}} />
+      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
     </div>
   );
 }
@@ -169,51 +174,59 @@ const KPI_CELLS = [
   { lbl:'TASKS',  val:'12', cap:'IN FLIGHT', live:false },
   { lbl:'CASCADE',val:'2', cap:'HIT @STEP', live:false, spark:true },
 ];
+
+function kpiCellAriaLabel(c) {
+  const live = c.live ? ' (live)' : '';
+  const delta = c.delta ? `, ${c.deltaKind === 'pos' ? 'up' : 'down'} ${c.delta}` : '';
+  const kind = c.kind === 'ok' ? ' (passing)' : c.kind === 'err' ? ' (failing)' : '';
+  return `${c.lbl}: ${c.val} ${c.cap}${delta}${kind}${live}`;
+}
+
 function KpiStandard() {
   return (
     <div className="cb-board">
-      <div className="cb-kpi">
+      <div className="cb-kpi" role="list" aria-label="Fleet KPI strip">
         {KPI_CELLS.map((c, i) => (
-          <div key={i} className={`cell ${c.live?'live':''} ${c.kind?`is-${c.kind}`:''}`}>
-            <span className="lbl">{c.lbl}</span>
-            <span className="val">{c.val}</span>
-            <span className="cap">{c.cap}{c.delta ? <> · <span className={`delta ${c.deltaKind}`}>{c.delta}</span></> : null}</span>
+          <div key={i} role="listitem" aria-label={kpiCellAriaLabel(c)} className={`cell ${c.live?'live':''} ${c.kind?`is-${c.kind}`:''}`}>
+            <span className="lbl" aria-hidden="true">{c.lbl}</span>
+            <span className="val" aria-hidden="true">{c.val}</span>
+            <span className="cap" aria-hidden="true">{c.cap}{c.delta ? <> · <span className={`delta ${c.deltaKind}`}>{c.delta}</span></> : null}</span>
             {c.spark ? <Spark color={c.live?'brass':'brass'} bars={14} /> : null}
           </div>
         ))}
       </div>
-      <div style={{flex:1, background:'var(--bg-0)'}} />
+      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
     </div>
   );
 }
 function KpiCompact() {
   return (
     <div className="cb-board">
-      <div className="cb-kpi compact">
+      <div className="cb-kpi compact" role="list" aria-label="Fleet KPI strip (compact)">
         {KPI_CELLS.map((c, i) => (
-          <div key={i} className={`cell ${c.live?'live':''} ${c.kind?`is-${c.kind}`:''}`}>
-            <span className="lbl">{c.lbl}</span>
-            <span className="val">{c.val}</span>
+          <div key={i} role="listitem" aria-label={kpiCellAriaLabel(c)} className={`cell ${c.live?'live':''} ${c.kind?`is-${c.kind}`:''}`}>
+            <span className="lbl" aria-hidden="true">{c.lbl}</span>
+            <span className="val" aria-hidden="true">{c.val}</span>
           </div>
         ))}
       </div>
-      <div style={{flex:1, background:'var(--bg-0)'}} />
+      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
     </div>
   );
 }
 function KpiStacked() {
   return (
     <div className="cb-board">
-      <div className="cb-kpi stacked">
+      <div className="cb-kpi stacked" role="list" aria-label="Fleet KPI strip (stacked)">
         {KPI_CELLS.slice(0,6).map((c, i) => (
-          <div key={i} className={`cell ${c.live?'live':''} ${c.kind?`is-${c.kind}`:''}`}>
-            <span className="lbl">{c.lbl}</span>
-            <span className="val big">{c.val}</span>
-            <span className="cap">{c.cap}</span>
+          <div key={i} role="listitem" aria-label={kpiCellAriaLabel(c)} className={`cell ${c.live?'live':''} ${c.kind?`is-${c.kind}`:''}`}>
+            <span className="lbl" aria-hidden="true">{c.lbl}</span>
+            <span className="val big" aria-hidden="true">{c.val}</span>
+            <span className="cap" aria-hidden="true">{c.cap}</span>
           </div>
         ))}
       </div>
-      <div style={{flex:1, background:'var(--bg-0)'}} />
+      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
     </div>
   );
 }
@@ -227,12 +240,12 @@ function LifelineBeat() {
   }, []);
   return (
     <div className="cb-board">
-      <div className="cb-lifeline">
-        <span className="label">LIFELINE</span>
+      <div className="cb-lifeline" role="img" aria-label="Lifeline heartbeat at 72 BPM, 60 second window">
+        <span className="label" aria-hidden="true">LIFELINE</span>
         <Heartbeat phase={phase} />
-        <span className="bpm"><span className="n">72</span> BPM · 60s</span>
+        <span className="bpm" aria-hidden="true"><span className="n">72</span> BPM · 60s</span>
       </div>
-      <div style={{flex:1, background:'var(--bg-0)'}} />
+      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
     </div>
   );
 }
@@ -242,16 +255,16 @@ function LifelineStacked() {
   const fleet = D.keepers.slice(0, 5);
   return (
     <div className="cb-board">
-      <div className="cb-lifeline stack">
+      <div className="cb-lifeline stack" role="list" aria-label="Per-keeper heartbeat lifelines">
         {fleet.map((k, i) => (
-          <div className="row" key={k.id}>
-            <span className="name">{k.id}</span>
+          <div className="row" key={k.id} role="listitem" aria-label={`${k.id} heartbeat, ${k.status === 'running' ? 'running' : k.status}`}>
+            <span className="name" aria-hidden="true">{k.id}</span>
             <Heartbeat width={240} height={14} phase={(phase + i*0.07) % 1} />
             <Dot kind={kClass(k.id)} size="sm" beat={k.status==='running'} />
           </div>
         ))}
       </div>
-      <div style={{flex:1, background:'var(--bg-0)'}} />
+      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
     </div>
   );
 }

--- a/dashboard/design-system/preview/cb-shared.jsx
+++ b/dashboard/design-system/preview/cb-shared.jsx
@@ -3,16 +3,16 @@
 
 const { useState, useEffect, useMemo, useRef } = React;
 
-// Status dot
+// Status dot — decorative; meaning lives in the adjacent text.
 function Dot({ kind = 'idle', size = 'md', beat = false, style }) {
-  return <span className={`cb-dot ${kind} ${size === 'sm' ? 'sm' : size === 'lg' ? 'lg' : ''} ${beat ? 'beat' : ''}`} style={style} />;
+  return <span className={`cb-dot ${kind} ${size === 'sm' ? 'sm' : size === 'lg' ? 'lg' : ''} ${beat ? 'beat' : ''}`} style={style} aria-hidden="true" />;
 }
 
 // Mini sparkline (random but seeded bars) — used in KPI + lifeline
 function Spark({ data, color = 'brass', bars = 14 }) {
   const d = data || Array.from({ length: bars }, (_, i) => 30 + Math.sin(i * 0.7) * 20 + Math.random() * 30);
   return (
-    <span className={`spark is-${color}`} style={{ height: 16 }}>
+    <span className={`spark is-${color}`} style={{ height: 16 }} aria-hidden="true">
       {d.map((h, i) => <i key={i} style={{ height: `${Math.max(5, Math.min(100, h))}%` }} />)}
     </span>
   );
@@ -34,7 +34,7 @@ function Heartbeat({ height = 32, width = 320, phase = 0 }) {
     points.push(`${x.toFixed(1)},${y.toFixed(1)}`);
   }
   return (
-    <svg viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none">
+    <svg viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none" aria-hidden="true" focusable="false">
       <polyline points={points.join(' ')} fill="none" stroke="var(--brass-1)" strokeWidth="1.2" />
       <circle cx={width - 2} cy={height / 2} r="2" fill="var(--brass-1)">
         <animate attributeName="r" values="2;3.5;2" dur="1.4s" repeatCount="indefinite" />

--- a/dashboard/design-system/preview/components.css
+++ b/dashboard/design-system/preview/components.css
@@ -1147,3 +1147,23 @@
   position:absolute; width:1px; height:1px; padding:0; margin:-1px;
   overflow:hidden; clip:rect(0 0 0 0); white-space:nowrap; border:0;
 }
+
+/* ─────────── a11y · Phase 1/2 cockpit components ───────────
+   Same focus-ring + ARIA-driven active state pattern as Phase 3.5,
+   applied to .cb-* surfaces (topbar tabs/radios, kpi cells, lifeline). */
+.cb-topbar button:focus-visible,
+.cb-topbar [role="tab"]:focus-visible,
+.cb-topbar [role="radio"]:focus-visible,
+.cb-kpi [role="listitem"]:focus-visible,
+.cb-lifeline:focus-visible {
+  outline:2px solid var(--color-focus-ring);
+  outline-offset:1px;
+  z-index:1;
+}
+
+.cb-topbar .mode-tabs button[aria-selected="true"] {
+  color:var(--bg-0); background:var(--brass-2);
+}
+.cb-topbar .density button[aria-checked="true"] {
+  color:var(--brass-1); background:rgb(var(--brass-glow)/.1);
+}


### PR DESCRIPTION
## Summary

Apply the a11y baseline pattern shipped in PR #10394 (Phase 3 Code IDE v2) to **Phase 1 cockpit components — first batch (cb-group-a)**. Same `role` / `aria-*` / `:focus-visible` shape, no new design tokens, no visual change.

Tracking: #10448. This PR closes the **cb-group-a** checklist item; cb-group-b~i ship as follow-up PRs.

## Scope

3 files modified, +100/−67 lines.

| File | Change |
|------|--------|
| `dashboard/design-system/preview/cb-group-a.jsx` | 11 component variants patched (Topbar 3 · Ticker 3 · KPI 3 · Lifeline 2) |
| `dashboard/design-system/preview/cb-shared.jsx` | `Dot` / `Spark` / `Heartbeat` decorative primitives default to `aria-hidden="true"` |
| `dashboard/design-system/preview/components.css` | New `Phase 1/2 cockpit components` a11y block (focus-ring + ARIA-driven active state mirror for `.cb-*`) |

### Per-component a11y matrix

| Variant | ARIA roles / attrs | Notes |
|---------|-------------------|-------|
| `TopbarStandard` / `TopbarExpanded` | `role="tablist"` + `role="tab"` + `aria-selected` for mode-tabs · `role="radiogroup"` + `role="radio"` + `aria-checked` for density · `aria-haspopup="menu"` + `aria-label` for goal-switch | density labels expanded (`Compact` / `Normal` / `Loose`) |
| `TopbarMinimal` | Same `tablist`/`tab` shape applied to the static 2-button mode-tab | tabIndex roving on selected |
| `TickerMarquee` / `Chunks` / `Vertical` | `role="region"` + `aria-label="Fleet event ticker (variant)"` | `aria-live` left at default off — marquee animation, SR navigates on demand |
| `KpiStandard` / `Compact` / `Stacked` | `role="list"` + `role="listitem"` + computed `aria-label` per cell | inner `lbl` / `val` / `cap` marked `aria-hidden` to avoid double-read |
| `LifelineBeat` | `role="img"` + composed `aria-label="Lifeline heartbeat at 72 BPM, 60 second window"` | SVG already `aria-hidden` from `cb-shared` |
| `LifelineStacked` | `role="list"` + per-row `role="listitem"` with `${keeper.id} heartbeat, ${status}` | |

### `cb-shared` decorative defaults

`Dot`, `Spark`, `Heartbeat` are pure visual indicators — meaning is always carried by adjacent text. Defaulting them to `aria-hidden="true"` (and `focusable="false"` on the SVG) eliminates double-read across **all** `cb-group-*` callers, not just the ones touched here.

## Validation

- **DOM (Chrome headless `--dump-dom`)** — counted on `components.html`:
  - `role="tab"` 8 (3 Standard + 3 Expanded + 2 Minimal mode-tabs) + 4 from existing `IxTreeTabs`
  - `aria-checked` 6 (3 Standard + 3 Expanded density radios) + existing IxEdit/IxTree filters
  - `aria-hidden` propagated to every `Dot` / `Spark` / `Heartbeat` instance fleet-wide
- **Visual smoke (Chrome headless screenshot, 1280×2400 viewport)** — Phase 1 zone (Topbar / Ticker / KPI / Lifeline) renders identically to the pre-patch baseline. No layout shift, no color change.
- **No tokens introduced** — reuses `--color-focus-ring` already shipped by PR #10394.

## Out of scope (follow-up PRs under #10448)

- `cb-group-b.jsx` (Sidebar / Swimlanes / Deck / Rail)
- `cb-group-c.jsx` (Composer / Status / Drawer)
- `cb-group-d.jsx` (Work Plane: Goal / Task / Accountability)
- `cb-group-e.jsx` (Comms Plane: Board / Messages / Composer)
- `cb-group-f.jsx` (Observe Plane: Cascade / Audit / SafeAuto / Cost / Heuristic)
- `cb-group-h.jsx` (Cognition Plane: Keeper / Decisions / Episodes / AR)
- `cb-group-i.jsx` (IDE Backbone: BranchSelector / KeeperMultiSelect / OperatorNudgeLog)
- Light theme override (`design intent change — separate proposal)
- Playwright snapshot baseline (separate infra PR, tracked in #10389)

## Test plan

- [ ] CI required checks green (Build/Test, Dashboard, Health, Lint, Meta Guards)
- [ ] No visual regression in `components.html` Phase 1 sections
- [ ] DOM dump confirms ARIA attributes on all cb-group-a interactive controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)
