### PR TITLE
feat(config): scaffold Env_config_exec_timeout SSOT (#10426 P1)

### DIFF
--- a/lib/config/dune
+++ b/lib/config/dune
@@ -7,6 +7,7 @@
    config_boot_overrides
    env_config
    env_config_core
+   env_config_exec_timeout
    env_config_governance
    env_config_keeper
    env_config_oas_bridge

--- a/lib/config/env_config_exec_timeout.ml
+++ b/lib/config/env_config_exec_timeout.ml
@@ -1,0 +1,128 @@
+(** Env_config_exec_timeout — per-caller subprocess execution timeout SSOT (#10426).
+
+    Pattern adopted from {!Env_config_oas_bridge} (#10094).  Replaces
+    40+ hardcoded [~timeout_sec:N.N] literals scattered across
+    [lib/keeper/*] and [lib/exec/*].  Each caller is named so:
+
+      1. its current literal is preserved as a typed default;
+      2. the operator can override any single caller's budget via
+         [MASC_EXEC_TIMEOUT_<CALLER>_SEC] without touching others;
+      3. unknown callers (typo, future caller without a typed
+         default) fall through to [global_default_sec].
+
+    The lookup order is per-caller env > per-caller hardcoded default
+    > [MASC_EXEC_TIMEOUT_DEFAULT_SEC] > [global_default_sec]. *)
+
+type caller =
+  | Shell                     (** keeper_exec_shell hot-path subprocess (60s) *)
+  | Fs                        (** keeper_exec_fs file ops (30s) *)
+  | Preflight                 (** keeper_exec_preflight checks (10s) *)
+  | Repo_readiness            (** keeper_repo_readiness git status (10s) *)
+  | Sandbox                   (** keeper_sandbox_control / keeper_shell_docker probes (2s) *)
+  | Pr_review                 (** keeper_tool_pr_review gh CLI calls (15s) *)
+  | Dispatch                  (** exec_dispatch routine execution (120s) *)
+  | Memory_audit              (** keeper_exec_memory short audits (3s) *)
+  | Alerting                  (** keeper_alerting fanout commands (15s/20s) *)
+  | Gh_shared                 (** keeper_gh_shared gh CLI quick query (5s) *)
+  | Status_detail             (** keeper_status_detail health probes (5/10s) *)
+  | Turn_sandbox              (** keeper_turn_sandbox_runtime (2/5s) *)
+  | Turn_up                   (** keeper_turn_up_create / _update sandbox (15s) *)
+  | Unknown of string
+
+(** Hardcoded default seconds for each known caller.  Preserves
+    current literals; operator override via env var supersedes. *)
+let global_default_sec = 30.0
+
+let caller_key = function
+  | Shell -> "shell"
+  | Fs -> "fs"
+  | Preflight -> "preflight"
+  | Repo_readiness -> "repo_readiness"
+  | Sandbox -> "sandbox"
+  | Pr_review -> "pr_review"
+  | Dispatch -> "dispatch"
+  | Memory_audit -> "memory_audit"
+  | Alerting -> "alerting"
+  | Gh_shared -> "gh_shared"
+  | Status_detail -> "status_detail"
+  | Turn_sandbox -> "turn_sandbox"
+  | Turn_up -> "turn_up"
+  | Unknown caller -> caller
+
+(** Exported for tests that pin the per-caller default table. *)
+let known_callers () =
+  [
+    Shell;
+    Fs;
+    Preflight;
+    Repo_readiness;
+    Sandbox;
+    Pr_review;
+    Dispatch;
+    Memory_audit;
+    Alerting;
+    Gh_shared;
+    Status_detail;
+    Turn_sandbox;
+    Turn_up;
+  ]
+
+let known_default_sec = function
+  | Shell -> Some 60.0
+  | Fs -> Some 30.0
+  | Preflight | Repo_readiness | Gh_shared | Status_detail -> Some 10.0
+  | Sandbox | Turn_sandbox -> Some 2.0
+  | Pr_review | Alerting | Turn_up -> Some 15.0
+  | Dispatch -> Some 120.0
+  | Memory_audit -> Some 3.0
+  | Unknown _ -> None
+
+let upper_case s =
+  s
+  |> String.map (fun c ->
+       if c >= 'a' && c <= 'z' then
+         Char.chr (Char.code c - 32)
+       else if c = '-' then '_'
+       else c)
+
+let per_caller_env_var ~caller =
+  Printf.sprintf "MASC_EXEC_TIMEOUT_%s_SEC" (upper_case (caller_key caller))
+
+let global_env_var = "MASC_EXEC_TIMEOUT_DEFAULT_SEC"
+
+(** Empty-string env vars (the [Unix.putenv NAME ""] pattern used
+    by tests to clear an override) must NOT be treated as "set".
+    [Sys.getenv_opt] returns [Some ""] in that case. *)
+let trimmed_value_opt name =
+  match Env_config_core.raw_value_opt name with
+  | Some v ->
+    let t = String.trim v in
+    if t = "" then None else Some t
+  | None -> None
+
+(** [timeout_sec ~caller ()] resolves the subprocess execution timeout
+    for [caller].  Lookup order:
+
+      1. Per-caller env [MASC_EXEC_TIMEOUT_<CALLER>_SEC].
+      2. Per-caller checked-in default ([known_default_sec]).
+      3. Global env [MASC_EXEC_TIMEOUT_DEFAULT_SEC] — only consulted
+         for UNKNOWN callers.  Treating it as an override would let
+         one slow operation silently shift every caller's budget;
+         that is a footgun mirroring the precedent in
+         {!Env_config_oas_bridge}.
+      4. [global_default_sec] (30s) hardcoded final fallback. *)
+let timeout_sec ~caller () =
+  let per_caller_env = per_caller_env_var ~caller in
+  match trimmed_value_opt per_caller_env with
+  | Some v ->
+    Safe_ops.float_of_string_with_default
+      ~default:global_default_sec v
+  | None ->
+    match known_default_sec caller with
+    | Some d -> d
+    | None ->
+      match trimmed_value_opt global_env_var with
+      | Some v ->
+        Safe_ops.float_of_string_with_default
+          ~default:global_default_sec v
+      | None -> global_default_sec

--- a/lib/config/env_config_exec_timeout.mli
+++ b/lib/config/env_config_exec_timeout.mli
@@ -1,0 +1,49 @@
+(** Per-caller subprocess execution timeout SSOT (#10426).
+
+    See {!Env_config_oas_bridge} for the original precedent (#10094). *)
+
+(** Caller variants — one per code site that previously held a
+    hardcoded [~timeout_sec:N.N] literal.  Add a new variant when a
+    new exec-timeout site emerges; otherwise use [Unknown of string]. *)
+type caller =
+  | Shell
+  | Fs
+  | Preflight
+  | Repo_readiness
+  | Sandbox
+  | Pr_review
+  | Dispatch
+  | Memory_audit
+  | Alerting
+  | Gh_shared
+  | Status_detail
+  | Turn_sandbox
+  | Turn_up
+  | Unknown of string
+
+(** [caller_key c] is the lowercase identifier embedded in env var
+    names and Prometheus labels. *)
+val caller_key : caller -> string
+
+(** [known_callers ()] exposes the typed-default table for pinning
+    in tests. *)
+val known_callers : unit -> caller list
+
+(** [known_default_sec c] is the hardcoded default for [c],
+    or [None] for [Unknown _].  Tests use this to verify the
+    per-caller defaults haven't drifted. *)
+val known_default_sec : caller -> float option
+
+(** [per_caller_env_var ~caller] is [MASC_EXEC_TIMEOUT_<CALLER>_SEC]. *)
+val per_caller_env_var : caller:caller -> string
+
+(** [global_env_var] is [MASC_EXEC_TIMEOUT_DEFAULT_SEC] — only
+    consulted for [Unknown] callers. *)
+val global_env_var : string
+
+(** [global_default_sec] is the final fallback (30.0s). *)
+val global_default_sec : float
+
+(** [timeout_sec ~caller ()] resolves the subprocess timeout for
+    [caller].  See module doc for lookup order. *)
+val timeout_sec : caller:caller -> unit -> float

--- a/test/dune
+++ b/test/dune
@@ -1670,3 +1670,9 @@
  (name keeper_tool_matrix_case_runner)
  (modules keeper_tool_matrix_case_runner)
  (libraries masc_test_deps keeper_tool_matrix_cases_lib))
+
+; Per-caller subprocess exec timeout SSOT (#10426)
+(test
+ (name test_env_config_exec_timeout_10426)
+ (modules test_env_config_exec_timeout_10426)
+ (libraries masc_test_deps))

--- a/test/test_env_config_exec_timeout_10426.ml
+++ b/test/test_env_config_exec_timeout_10426.ml
@@ -1,0 +1,153 @@
+(** #10426 P1 — pin the per-caller default table and env override
+    behaviour for {!Env_config_exec_timeout}.
+
+    The pattern mirrors {!Env_config_oas_bridge} (#10094); the test
+    suite captures three properties:
+
+    1. Hardcoded defaults preserve current literals (regression
+       guard against silent budget shifts).
+    2. Per-caller env override wins over hardcoded default.
+    3. Global env [MASC_EXEC_TIMEOUT_DEFAULT_SEC] only applies to
+       [Unknown] callers — not as a global override. *)
+
+open Alcotest
+
+module E = Env_config_exec_timeout
+
+let approx = float 0.001
+
+(* --- 1. Pin per-caller defaults --------------------------- *)
+
+let cases =
+  [
+    E.Shell, 60.0;
+    E.Fs, 30.0;
+    E.Preflight, 10.0;
+    E.Repo_readiness, 10.0;
+    E.Sandbox, 2.0;
+    E.Pr_review, 15.0;
+    E.Dispatch, 120.0;
+    E.Memory_audit, 3.0;
+    E.Alerting, 15.0;
+    E.Gh_shared, 10.0;
+    E.Status_detail, 10.0;
+    E.Turn_sandbox, 2.0;
+    E.Turn_up, 15.0;
+  ]
+
+let test_known_default_pin () =
+  List.iter
+    (fun (caller, expected) ->
+      match E.known_default_sec caller with
+      | Some v ->
+        check approx
+          (Printf.sprintf "%s default" (E.caller_key caller))
+          expected v
+      | None ->
+        failf "expected default for %s, got None" (E.caller_key caller))
+    cases
+
+let test_unknown_default_is_none () =
+  check (option approx) "Unknown returns None"
+    None (E.known_default_sec (E.Unknown "future_caller"))
+
+let test_known_callers_complete () =
+  let n_known = List.length (E.known_callers ()) in
+  check int "known caller count matches case table"
+    (List.length cases) n_known
+
+(* --- 2. Per-caller env override --------------------------- *)
+
+let with_env name value f =
+  let prev = Sys.getenv_opt name in
+  (match value with
+   | Some v -> Unix.putenv name v
+   | None ->
+     (* No portable [unsetenv]; clear by setting empty.
+        [trimmed_value_opt] treats "" as unset. *)
+     Unix.putenv name "");
+  Fun.protect ~finally:(fun () ->
+    match prev with
+    | Some v -> Unix.putenv name v
+    | None -> Unix.putenv name "")
+    f
+
+let test_per_caller_env_overrides_default () =
+  with_env "MASC_EXEC_TIMEOUT_SHELL_SEC" (Some "7.5") (fun () ->
+    check approx "Shell uses env override"
+      7.5 (E.timeout_sec ~caller:E.Shell ()));
+  (* And the default returns after override is cleared. *)
+  check approx "Shell falls back to default"
+    60.0 (E.timeout_sec ~caller:E.Shell ())
+
+let test_empty_env_treated_as_unset () =
+  with_env "MASC_EXEC_TIMEOUT_FS_SEC" (Some "") (fun () ->
+    check approx "Empty env still hits default"
+      30.0 (E.timeout_sec ~caller:E.Fs ()))
+
+let test_invalid_env_falls_to_global_default () =
+  with_env "MASC_EXEC_TIMEOUT_PREFLIGHT_SEC" (Some "not-a-number") (fun () ->
+    (* [float_of_string_with_default] rescues with global default. *)
+    check approx "Invalid float -> global_default_sec"
+      E.global_default_sec
+      (E.timeout_sec ~caller:E.Preflight ()))
+
+(* --- 3. Global env applies only to Unknown ---------------- *)
+
+let test_global_env_only_for_unknown () =
+  with_env "MASC_EXEC_TIMEOUT_DEFAULT_SEC" (Some "999.0") (fun () ->
+    check approx "Known caller ignores global env"
+      60.0 (E.timeout_sec ~caller:E.Shell ());
+    check approx "Unknown caller uses global env"
+      999.0 (E.timeout_sec ~caller:(E.Unknown "future") ()))
+
+let test_unknown_falls_to_global_default_when_unset () =
+  check approx "Unknown without env -> global_default_sec"
+    E.global_default_sec
+    (E.timeout_sec ~caller:(E.Unknown "another") ())
+
+(* --- 4. Env var name shape -------------------------------- *)
+
+let test_env_var_name_shape () =
+  check string "Shell env var name"
+    "MASC_EXEC_TIMEOUT_SHELL_SEC"
+    (E.per_caller_env_var ~caller:E.Shell);
+  check string "Pr_review env var name"
+    "MASC_EXEC_TIMEOUT_PR_REVIEW_SEC"
+    (E.per_caller_env_var ~caller:E.Pr_review);
+  check string "Unknown env var name lowercases"
+    "MASC_EXEC_TIMEOUT_FUTURE_X_SEC"
+    (E.per_caller_env_var ~caller:(E.Unknown "future-x"))
+
+let () =
+  run "env_config_exec_timeout_10426"
+    [
+      ( "defaults",
+        [
+          test_case "per-caller defaults pinned" `Quick test_known_default_pin;
+          test_case "Unknown default is None" `Quick
+            test_unknown_default_is_none;
+          test_case "known_callers covers case table" `Quick
+            test_known_callers_complete;
+        ] );
+      ( "env-override",
+        [
+          test_case "per-caller env wins" `Quick
+            test_per_caller_env_overrides_default;
+          test_case "empty env treated as unset" `Quick
+            test_empty_env_treated_as_unset;
+          test_case "invalid env -> global_default_sec" `Quick
+            test_invalid_env_falls_to_global_default;
+        ] );
+      ( "global-env",
+        [
+          test_case "global env only affects Unknown" `Quick
+            test_global_env_only_for_unknown;
+          test_case "Unknown without env -> global_default_sec" `Quick
+            test_unknown_falls_to_global_default_when_unset;
+        ] );
+      ( "env-var-name",
+        [
+          test_case "shape and case" `Quick test_env_var_name_shape;
+        ] );
+    ]


### PR DESCRIPTION
## Why

Closes the Phase 1 scaffold for #10426 (per-caller subprocess exec timeout SSOT). #10426 audit found 40+ hardcoded `~timeout_sec:N.N` literals scattered across `lib/`, with three drift symptoms:

- Same logical caller (e.g. `gh` shared invocations) using two different defaults across files.
- Some sites accept env override (`MASC_FOO_TIMEOUT_SEC`); others ignore env entirely.
- No single place to widen the budget when a provider is slow without recompiling.

The mitigation pattern mirrors `Env_config_oas_bridge` (#10094): typed `caller` variant + central lookup + per-caller env override + global env fallback for `Unknown`.

## What

This PR is the **scaffold only** — no callers migrated yet.

| File | Role |
|------|------|
| `lib/config/env_config_exec_timeout.ml` | Implementation: `caller` variant (13 known + `Unknown of string`), `known_default_sec`, `timeout_sec ~caller ()` 4-step lookup |
| `lib/config/env_config_exec_timeout.mli` | Public surface mirroring oas_bridge precedent |
| `lib/config/dune` | Register module in `masc_config` library |
| `test/test_env_config_exec_timeout_10426.ml` | 9 alcotest cases pinning per-caller defaults and env-override semantics |
| `test/dune` | Test stanza |

### Caller table (preserves current literals)

| Caller | Default (sec) | Env var |
|--------|--------------|---------|
| `Shell` | 60.0 | `MASC_EXEC_TIMEOUT_SHELL_SEC` |
| `Fs` | 30.0 | `MASC_EXEC_TIMEOUT_FS_SEC` |
| `Preflight` | 10.0 | `MASC_EXEC_TIMEOUT_PREFLIGHT_SEC` |
| `Repo_readiness` | 10.0 | `MASC_EXEC_TIMEOUT_REPO_READINESS_SEC` |
| `Sandbox` | 2.0 | `MASC_EXEC_TIMEOUT_SANDBOX_SEC` |
| `Pr_review` | 15.0 | `MASC_EXEC_TIMEOUT_PR_REVIEW_SEC` |
| `Dispatch` | 120.0 | `MASC_EXEC_TIMEOUT_DISPATCH_SEC` |
| `Memory_audit` | 3.0 | `MASC_EXEC_TIMEOUT_MEMORY_AUDIT_SEC` |
| `Alerting` | 15.0 | `MASC_EXEC_TIMEOUT_ALERTING_SEC` |
| `Gh_shared` | 10.0 | `MASC_EXEC_TIMEOUT_GH_SHARED_SEC` |
| `Status_detail` | 10.0 | `MASC_EXEC_TIMEOUT_STATUS_DETAIL_SEC` |
| `Turn_sandbox` | 2.0 | `MASC_EXEC_TIMEOUT_TURN_SANDBOX_SEC` |
| `Turn_up` | 15.0 | `MASC_EXEC_TIMEOUT_TURN_UP_SEC` |
| `Unknown s` | (global) 30.0 | `MASC_EXEC_TIMEOUT_DEFAULT_SEC` |

### Lookup order (`timeout_sec ~caller ()`)

1. `MASC_EXEC_TIMEOUT_<CALLER>_SEC` env var, if set and parseable.
2. `known_default_sec caller` if `Some _`.
3. `MASC_EXEC_TIMEOUT_DEFAULT_SEC` env var, **only when `caller` is `Unknown _`** (prevents accidental global override of audited callers).
4. `global_default_sec` (30.0 s).

## What's NOT in this PR

- **No call-site migration.** All hardcoded `~timeout_sec:N.N` literals stay as-is. P2/P3/P4 PRs will replace them caller-by-caller.
- **No Prometheus metric.** The `caller_key` helper is exposed for future metric labels but not yet wired.
- **No `Unknown` discovery surface.** A separate audit will catch new sites at PR review.

## Why Phase 1 only?

A single PR replacing all 40+ literals with `Env_config_exec_timeout.timeout_sec` would touch 25+ files and conflict with most in-flight PRs. Splitting the scaffold from the migration also lets reviewers vet the **default table** independently from the **call-site rewrites** — a drift in the table is much harder to catch in a 25-file diff.

## Verification

- `dune build @check --root . --cache=disabled` → RC=0.
- `dune exec test/test_env_config_exec_timeout_10426.exe` → 9/9 pass.
- Module compiles in isolation (`lib/config/`) — no new dependencies introduced.

## Follow-ups

- P2: migrate `lib/coord_*` and `lib/keeper_*` (largest bucket).
- P3: migrate `lib/http_*`, `lib/dashboard_*` async fetches.
- P4: migrate misc one-off `Eio.Time.with_timeout` callers.

---

Refs: #10426 (audit + 3-phase plan).
