### PR TITLE
fix(transport): correct tunnel host detection in legacy_messages_endpoint_url

### DIFF
--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -165,10 +165,11 @@ let legacy_messages_endpoint_url (request : Httpun.Request.t) session_id =
         match Httpun.Headers.get request.headers "x-forwarded-proto" with
         | Some p -> p
         | None ->
-            if
-              String.length host >= 17
-              && String.sub host 0 17 = "masc.crying.pict"
-            then "https"
+            (* Length-mismatched [String.sub host 0 17 = "masc.crying.pict"]
+               (17-char substring vs 16-char literal) was always false, so
+               tunnel hosts silently advertised http://. starts_with also
+               drops a per-request allocation. *)
+            if String.starts_with ~prefix:"masc.crying.pict" host then "https"
             else "http"
       in
       Printf.sprintf "%s://%s/messages?session_id=%s" proto host session_id


### PR DESCRIPTION
## Why

`legacy_messages_endpoint_url` chooses `https://` vs `http://` for the rebuilt URL when no `x-forwarded-proto` header is present. The proto detection branch read:

\`\`\`ocaml
String.length host >= 17 && String.sub host 0 17 = "masc.crying.pict"
\`\`\`

The literal \`"masc.crying.pict"\` is **16 chars**, the substring is **17 chars** — equality of two strings of different lengths is always false. Tunnel hosts (\`masc.crying.pictures\`) therefore silently advertised \`http://\` in the legacy /messages endpoint URL whenever the upstream didn't set \`x-forwarded-proto\`.

## What

Replace the broken length-mismatched check with \`String.starts_with ~prefix:"masc.crying.pict" host\`:

- Semantically correct — \`String.starts_with\` handles the length comparison itself, no off-by-one possible.
- Drops a per-request \`String.sub\` allocation.
- Same observable behaviour as the original *intent*; tunnel hosts now advertise \`https://\` as designed.

## Verify

- \`dune build @check\` — passes.
- This branch was rebased on the freshly fixed main (post #10445).

## Risk

Behaviour change for the narrow case of tunnel host + missing \`x-forwarded-proto\`. Production traffic already arrives with \`x-forwarded-proto\` from the Cloudflare tunnel, so the change is mostly visible to local/dev paths exercising the legacy endpoint without the proxy header.