### PR TITLE
perf(h2-gateway): drop per-request String.sub allocations on route prefix match

### DIFF
--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -702,8 +702,9 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             H2.Body.Writer.write_string body csv;
             H2.Body.Writer.close body)
 
-      | `GET, p when String.length p > 27
-                   && String.sub p 0 27 = "/api/v1/autoresearch/loops/" ->
+      | `GET, p
+        when String.starts_with ~prefix:"/api/v1/autoresearch/loops/" p
+             && String.length p > 27 ->
           with_server_state h2_reqd (fun state ->
             let base_path = state.Mcp_server.room_config.base_path in
             let loop_id = String.trim (String.sub p 27 (String.length p - 27)) in

--- a/lib/server/server_h2_gateway_routes_extra.ml
+++ b/lib/server/server_h2_gateway_routes_extra.ml
@@ -74,7 +74,9 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path
       h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors;
       true
 
-  | `GET, p when String.length p > 14 && String.sub p 0 14 = "/api/v1/board/" ->
+  | `GET, p
+    when String.starts_with ~prefix:"/api/v1/board/" p
+         && String.length p > 14 ->
       let post_id = String.sub p 14 (String.length p - 14) in
       let format = Option.value ~default:"nested" (query_param httpun_request "format") in
       let (status, body) = board_post_detail_json ~response_format:format ~post_id in
@@ -120,8 +122,9 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path
        | Error _ -> h2_respond_text h2_reqd "404 Not Found" ~status:`Not_found);
       true
 
-  | `GET, p when String.length p > 18
-               && String.sub p 0 18 = "/dashboard/assets/" ->
+  | `GET, p
+    when String.starts_with ~prefix:"/dashboard/assets/" p
+         && String.length p > 18 ->
       let filename = String.sub p 18 (String.length p - 18) in
       if not (Web_dashboard.is_safe_asset_relative_path filename) then begin
         h2_respond_text h2_reqd "404 Not Found" ~status:`Not_found;


### PR DESCRIPTION
## Why

Three H2 gateway routes built a fresh \`String.sub\` just to compare with a literal prefix:

\`\`\`ocaml
String.length p > N && String.sub p 0 N = \"<prefix>\"
\`\`\`

Each match allocates a copy of the path's leading N bytes only to discard it after the equality check. On the gRPC ingress hot path this is a per-request allocation pure waste — \`String.starts_with\` reads the same bytes without copying.

## What

Three sites converted to \`String.starts_with ~prefix\`:

- \`server_h2_gateway_routes_extra.ml\` — \`/api/v1/board/\`, \`/dashboard/assets/\`
- \`server_h2_gateway.ml\` — \`/api/v1/autoresearch/loops/\`

The trailing \`String.length p > N\` is preserved (we still need the path to be longer than the prefix so the suffix carries an id/filename).

## Verify

- \`dune build @check\` — passes.
- Same exact match semantics; only the allocation goes away.

## Risk

Low. Same length-guard + prefix match, no semantic change. Existing route handlers downstream still receive the same suffix via \`String.sub p N (length p - N)\`.