### PR TITLE
refactor(keeper): migrate 4 timeout literals to Env_config_exec_timeout SSOT (#10426 P2-A)

### DIFF
--- a/lib/keeper/keeper_exec_preflight.ml
+++ b/lib/keeper/keeper_exec_preflight.ml
@@ -19,7 +19,8 @@ let handle_keeper_preflight_check
   (* Check 1: gh auth status *)
   let () =
     let st, out =
-      Process_eio.run_argv_with_status ~timeout_sec:10.0
+      Process_eio.run_argv_with_status
+        ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Preflight ())
         [ "/bin/zsh"; "-lc"; "gh auth status 2>&1" ]
     in
     add_check "gh_auth" (st = Unix.WEXITED 0) out
@@ -31,7 +32,8 @@ let handle_keeper_preflight_check
       add_check "repo_access" true "(current project)"
     else
       let st, out =
-        Process_eio.run_argv_with_status ~timeout_sec:10.0
+        Process_eio.run_argv_with_status
+          ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Preflight ())
           [ "/bin/zsh"; "-lc";
             Printf.sprintf "gh repo view %s --json name,defaultBranchRef 2>&1"
               (Filename.quote repo) ]

--- a/lib/keeper/keeper_repo_readiness.ml
+++ b/lib/keeper/keeper_repo_readiness.ml
@@ -214,7 +214,9 @@ let inspect
         ]
     else
       let status =
-        run_git ~timeout_sec:10.0 ~clone_path [ "status"; "--porcelain" ]
+        run_git
+          ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Repo_readiness ())
+          ~clone_path [ "status"; "--porcelain" ]
       in
       let dirty = status.ok && String.trim status.output <> "" in
       let branch =
@@ -235,7 +237,9 @@ let inspect
         | None -> None, None
         | Some _ -> (
             let counts =
-              run_git ~timeout_sec:10.0 ~clone_path
+              run_git
+                ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Repo_readiness ())
+                ~clone_path
                 [ "rev-list"; "--left-right"; "--count"; "@{upstream}...HEAD" ]
             in
             if counts.ok then


### PR DESCRIPTION
## Why

First call-site migration onto the typed-caller exec-timeout SSOT introduced in #10452 (P1). Scope is intentionally narrow: only literals whose value already matches the SSOT default for their caller.

The audit motivating #10426 found 40+ scattered `~timeout_sec:N.N` literals across `lib/`. P2 migrates them caller-by-caller. P2-A is the cleanest 1:1 bucket — `Preflight` (10.0) and `Repo_readiness` (10.0).

## What

| File | Lines | Caller | Default |
|------|-------|--------|---------|
| `lib/keeper/keeper_exec_preflight.ml` | 22, 34 | `Preflight` | 10.0 |
| `lib/keeper/keeper_repo_readiness.ml` | 217, 238 | `Repo_readiness` | 10.0 |

All 4 sites previously held `~timeout_sec:10.0` literals — defaults match exactly, so behavior is preserved.

After this PR, operators can widen either caller via:
- `MASC_EXEC_TIMEOUT_PREFLIGHT_SEC=30` for `gh` preflight checks
- `MASC_EXEC_TIMEOUT_REPO_READINESS_SEC=30` for sandbox repo `git status` / `rev-list` probes

without recompiling.

## Out of scope

- `read_only_probe_timeout_sec = 15.0` constant in `keeper_repo_readiness.ml` — audited as intentional (read-only probe is faster than full status). Flagged for a separate review whether the 15.0/10.0 split inside one file is intentional.
- All other `~timeout_sec` literals in `lib/keeper/` and `lib/coord/` (Sandbox 2.0, Pr_review 15.0, Alerting 15.0/20.0, Gh_shared 5.0/10.0, etc.) — staged for P2-B / P2-C / P2-D to keep diffs ≤ 4 sites per PR.
- No new env vars or Prometheus labels — `Env_config_exec_timeout` exposes them but downstream wiring is a separate concern.

## Verification

- `dune build lib/ --root . --cache=disabled` → RC=0.
- Defaults verified equal to literals via #10452 test pin (`test_known_default_pin`).

## Why so small?

Per `feedback_dont-overgeneralize-review-findings`: keep migration PRs ≤ ~4 sites. Larger batches make table drift hard to spot in review. The full P2 sweep will be a series of similarly-sized PRs.

---

Refs: #10426 (audit + plan), #10452 (P1 SSOT scaffold).
