### PR TITLE
perf(dashboard): delegate contains_ci to String_util SSOT

### DIFF
--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -138,19 +138,12 @@ let dashboard_memory_subsystems_http_json ~(config : Coord_utils.config) request
     | _ -> []
   in
   let total = List.length all_episodes in
+  (* Empty filter [q] used to match all episodes; preserve that and
+     delegate non-empty matching to the SSOT helper, which scans byte by
+     byte without lowercasing the haystack or allocating per position. *)
   let contains_ci haystack needle =
-    let h = String.lowercase_ascii haystack in
-    let hlen = String.length h in
-    let nlen = String.length needle in
-    if nlen = 0 then true
-    else if nlen > hlen then false
-    else
-      let rec scan i =
-        if i + nlen > hlen then false
-        else if String.sub h i nlen = needle then true
-        else scan (i + 1)
-      in
-      scan 0
+    String.length needle = 0
+    || String_util.contains_substring_ci haystack needle
   in
   let filtered =
     all_episodes


### PR DESCRIPTION
## Why

The episode-search helper inside the runtime dashboard handler hand-rolled a case-insensitive substring scan with three layers of waste:

1. \`String.lowercase_ascii haystack\` — fresh copy per call.
2. \`String.sub h i nlen = needle\` inside the scan loop — fresh copy per *position*.
3. Only the haystack was lowercased; comparison with the raw \`needle\` would silently fail to match if the needle contained uppercase ASCII.

## What

Delegate to \`String_util.contains_substring_ci\` (already in main as the SSOT), which scans byte by byte and lowercases both sides during the comparison without allocating. Preserve the \"empty filter matches all\" semantic with an explicit \`String.length needle = 0\` guard at the call site.

Net diff: +5 / -12.

## Verify

- \`dune build @check\` passes.
- Filter call shape preserved (\`contains_ci e.summary q\`, \`contains_ci e.event_type q\`, etc.) — only the helper body changed.

## Risk

Behaviour change: needles with uppercase ASCII now match correctly, where the old hand-rolled version silently dropped them. If any caller relied on the broken behaviour the result set will grow; in the dashboard episode filter this is the intended UX.