### PR TITLE
perf(string): consolidate contains_casefold forks onto String_util SSOT

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -28,35 +28,13 @@ let int_of_env_default name ~default ~min_v ~max_v =
       in
       max min_v (min max_v parsed)
 
-(* Substring containment, ASCII case-insensitive.
-
-   Old version compiled a fresh [Re.t] from the needle on every call —
-   ~20 hot call-sites, all string literals, mostly tool-error
-   classification on the per-call path.  The needles are short
-   (< 30 chars) and haystacks are bounded error messages, so a naive
-   byte-wise scan with inline [Char.lowercase_ascii] is strictly
-   cheaper than DFA construction and avoids the two
-   [String.lowercase_ascii] allocations the old form needed. *)
+(* Substring containment, ASCII case-insensitive.  Delegates to
+   [String_util.contains_substring_ci] (which scans byte-wise without
+   allocating) and preserves the local "empty needle matches all"
+   semantic with an explicit guard. *)
 let contains_casefold haystack needle =
-  let nlen = String.length needle in
-  let hlen = String.length haystack in
-  if nlen = 0 then true
-  else if nlen > hlen then false
-  else
-    let rec match_at i j =
-      if j = nlen then true
-      else if Char.lowercase_ascii (String.unsafe_get haystack (i + j))
-            <> Char.lowercase_ascii (String.unsafe_get needle j)
-      then false
-      else match_at i (j + 1)
-    in
-    let last = hlen - nlen in
-    let rec loop i =
-      if i > last then false
-      else if match_at i 0 then true
-      else loop (i + 1)
-    in
-    loop 0
+  String.length needle = 0
+  || String_util.contains_substring_ci haystack needle
 
 let parse_status_from_message ~success ~message =
   if not success then

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -20,18 +20,14 @@ let keeper_chat_stream_error_json message =
         `Assoc [ ("message", `String message) ] );
     ]
 
+(* Empty needle preserves the legacy "matches all" semantic; non-empty
+   matching delegates to the SSOT helper, which scans byte-wise with
+   inline [Char.lowercase_ascii] and avoids the two
+   [String.lowercase_ascii] allocations plus the per-position
+   [String.sub] of the old form. *)
 let contains_casefold haystack needle =
-  let haystack = String.lowercase_ascii haystack in
-  let needle = String.lowercase_ascii needle in
-  let hlen = String.length haystack in
-  let nlen = String.length needle in
-  let rec loop idx =
-    if nlen = 0 then true
-    else if idx + nlen > hlen then false
-    else if String.sub haystack idx nlen = needle then true
-    else loop (idx + 1)
-  in
-  loop 0
+  String.length needle = 0
+  || String_util.contains_substring_ci haystack needle
 
 
 (* No external timeout for keeper_msg. Keeper has its own internal limits


### PR DESCRIPTION
## Why

Two modules carried their own \`contains_casefold\`:

| Module | Form | Cost |
|---|---|---|
| \`lib/mcp_server_eio_call_tool.ml\` | byte-wise inline | already optimized, but a fork |
| \`lib/server/server_routes_http_keeper_stream.ml\` | lowercased both sides upfront + per-position \`String.sub\` | 2 unnecessary allocations per call + O(haystack-len) sub allocations |

\`String_util.contains_substring_ci\` (in main) already does byte-wise case-insensitive matching with no allocation, lowercasing inline during the compare.

## What

Delegate both forks to the SSOT helper, preserving the local \"empty needle matches all\" semantic with an explicit \`String.length needle = 0\` guard. Net: +13 / -39.

## Why it matters

The \`mcp_server_eio_call_tool.ml\` version is on the **MCP request hot path** — every tool call evaluates ~20 case-insensitive substring matches against the message string for input/auth/timeout/transient classification. Both modules now share one implementation, so future improvements to \`String_util.contains_substring_ci\` (BMH/KMP, etc.) reach every caller.

## Verify

- \`dune build @check\` passes.
- Both forks had identical empty-needle semantic (\`true\`); the wrapper guard preserves it.

## Risk

Low. The MCP version was already byte-wise so there's no behaviour change there beyond losing the inlined version. The keeper stream version becomes faster and free of repeated \`String.sub\` allocations.