### PR TITLE
fix(keeper-runtime): align turn_timeout_sec_live default with SSOT (#10456)

### DIFF
--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -70,9 +70,12 @@ let autonomous_max_idle_turns_live () =
   max 2 (min 50 (get_int ~default:10 "MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS"))
 
 let turn_timeout_sec_live () =
+  (* SSOT: must match Env_config_keeper.KeeperKeepalive.turn_timeout_sec
+     (range [60, 7200], default 3600 post-#9637). Drift here was the
+     mathematical root of #10388 (1200 - 30 oas_guard = 1170s budget). *)
   Float.max 60.0
-    (Float.min 3600.0
-       (get_float ~default:1200.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
+    (Float.min 7200.0
+       (get_float ~default:3600.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
 
 let admission_wait_timeout_sec_live () =
   Float.max 5.0

--- a/test/dune
+++ b/test/dune
@@ -660,6 +660,7 @@
         test_keeper_runtime_denylist
         test_keeper_runtime_config_ssot
         test_dashboard_render_timing_9766
+        test_keeper_turn_timeout_default_10456
         test_task_status_label_10421
         test_personality_field_diff_10269
         test_toml_skip_dedup_10259
@@ -843,6 +844,7 @@
         test_keeper_runtime_denylist
         test_keeper_runtime_config_ssot
         test_dashboard_render_timing_9766
+        test_keeper_turn_timeout_default_10456
         test_task_status_label_10421
         test_personality_field_diff_10269
         test_toml_skip_dedup_10259

--- a/test/test_keeper_turn_timeout_default_10456.ml
+++ b/test/test_keeper_turn_timeout_default_10456.ml
@@ -1,0 +1,106 @@
+(** #10456 — pin {!Env_config_keeper.KeeperKeepalive.turn_timeout_sec}
+    SSOT default (3600) and the source literal in
+    {!Keeper_runtime_resolved.turn_timeout_sec_live}.
+
+    Pre-fix drift was:
+    - env_config_keeper:301 default=3600 (post-#9637)
+    - keeper_runtime_resolved:75 default=1200 (stale)
+
+    Math: 1200 - 30 (oas_timeout_guard_sec) = 1170s — exact match for
+    #10388 cascade ollama timeout walls.
+
+    This test pins the SSOT and source-level literal so silent
+    re-divergence shows up as a test failure. *)
+
+open Alcotest
+
+module E = Env_config_keeper.KeeperKeepalive
+
+let approx = float 0.001
+
+let test_ssot_default_3600 () =
+  check approx
+    "env_config_keeper.KeeperKeepalive.turn_timeout_sec SSOT must stay at 3600 (#9637)"
+    3600.0 E.turn_timeout_sec
+
+let resolver_source_path =
+  let candidates =
+    [
+      "lib/keeper/keeper_runtime_resolved.ml";
+      "../lib/keeper/keeper_runtime_resolved.ml";
+      "../../lib/keeper/keeper_runtime_resolved.ml";
+    ]
+  in
+  match List.find_opt Sys.file_exists candidates with
+  | Some p -> Some p
+  | None -> None
+
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+
+let test_resolver_default_matches_ssot () =
+  match resolver_source_path with
+  | None -> skip ()
+  | Some p ->
+      let body = read_file p in
+      (* The fix replaces default:1200.0 with default:3600.0 in
+         turn_timeout_sec_live. Guard: must NOT contain the stale literal
+         on the same line as MASC_KEEPER_TURN_TIMEOUT_SEC. *)
+      let stale_pattern = "~default:1200.0 \"MASC_KEEPER_TURN_TIMEOUT_SEC\"" in
+      let canonical_pattern =
+        "~default:3600.0 \"MASC_KEEPER_TURN_TIMEOUT_SEC\""
+      in
+      let contains s sub =
+        let n = String.length s and m = String.length sub in
+        let rec loop i =
+          if i + m > n then false
+          else if String.sub s i m = sub then true
+          else loop (i + 1)
+        in
+        loop 0
+      in
+      let has_stale = contains body stale_pattern in
+      let has_canonical = contains body canonical_pattern in
+      check bool "no stale 1200 default in resolver" false has_stale;
+      check bool "canonical 3600 default in resolver" true has_canonical
+
+let test_resolver_upper_matches_ssot () =
+  match resolver_source_path with
+  | None -> skip ()
+  | Some p ->
+      let body = read_file p in
+      (* The fix raises Float.min upper bound from 3600.0 to 7200.0 in
+         turn_timeout_sec_live block. Both 3600.0 and 7200.0 may appear
+         elsewhere; we just guard that 7200.0 is present after the fix. *)
+      let canonical_upper = "Float.min 7200.0" in
+      let contains s sub =
+        let n = String.length s and m = String.length sub in
+        let rec loop i =
+          if i + m > n then false
+          else if String.sub s i m = sub then true
+          else loop (i + 1)
+        in
+        loop 0
+      in
+      check bool "canonical 7200 upper bound in resolver" true
+        (contains body canonical_upper)
+
+let () =
+  run "keeper_turn_timeout_default_10456"
+    [
+      ( "ssot-pin",
+        [
+          test_case "env_config_keeper SSOT default is 3600 (post-#9637)"
+            `Quick test_ssot_default_3600;
+        ] );
+      ( "resolver-drift-gate",
+        [
+          test_case "resolver default literal matches SSOT (no 1200 drift)"
+            `Quick test_resolver_default_matches_ssot;
+          test_case "resolver upper bound literal matches SSOT (7200)" `Quick
+            test_resolver_upper_matches_ssot;
+        ] );
+    ]


### PR DESCRIPTION
## 요약

`lib/keeper/keeper_runtime_resolved.ml:75`의 `turn_timeout_sec_live` default가 stale `1200.0`. `lib/config/env_config_keeper.ml:301`은 #9637 이후 `3600.0`으로 raise되었지만 resolver 경로는 미반영. caller `keeper_unified_turn.ml:1528`이 stale resolver를 읽어 runtime budget이 **1200 - 30 (oas_timeout_guard_sec) = 1170s** — #10388 cascade ollama timeout error의 정확 수치.

## 변경

`lib/keeper/keeper_runtime_resolved.ml:72-78`:
- `default:1200.0` → `default:3600.0` (SSOT)
- `Float.min 3600.0` → `Float.min 7200.0` (SSOT)
- SSOT를 가리키는 inline comment 추가 (재발산 방지)

## 검증

`test/test_keeper_turn_timeout_default_10456.ml` 신규 (3/3 pass):
1. `Env_config_keeper.KeeperKeepalive.turn_timeout_sec` SSOT 값 pin (3600)
2. resolver source-level grep — stale `1200.0` 도입 시 fail
3. resolver upper `7200.0` 제거 시 fail

```text
DUNE_CACHE=disabled dune build --root . --cache=disabled @check  → EXIT=0
dune exec test/test_keeper_turn_timeout_default_10456.exe        → 3/3 OK
```

## 영향

- **#10388 root cause**: cascade ollama_only 19.47분 timeout의 mathematical origin 직접 제거
- **#10421 부분 원인**: keeper turn 1170s 후 timeout → release without done. 1.4% done rate mechanism의 한 layer
- **fleet 영향**: ollama 사용 4 keeper (janitor, nick0cave, qa-king, taskmaster)의 turn budget이 actual generation latency와 align

## 비목표

- Option B (resolver를 SSOT로 위임): `_live` 함수는 매 호출시 env re-read (live reload), `Env_config_keeper.turn_timeout_sec`은 eager `let` (부팅 시 1회). 의미론 다름. minimal-fix가 우선
- Option C (CI lint): dual-default 검출 lint는 별도 작업

## Defensive guards

- Draft + `do-not-merge` label
- 운영자 명시 승인 후 merge

## 관련

- Issue: `#10456`
- Root cause for: `#10388`
- Partial mechanism for: `#10421`
- Source SSOT: `#9637` (env_config_keeper raise)