### PR TITLE
chore(bonsai): remove dead Directory fetch calls from main.ml

### DIFF
--- a/dashboard_bonsai/bin/main.ml
+++ b/dashboard_bonsai/bin/main.ml
@@ -135,10 +135,6 @@ let () =
   Dashboard_bonsai_lib.Logs_fetch.start_polling ();
   Dashboard_bonsai_lib.Keepers_fetch.run ();
   Dashboard_bonsai_lib.Keepers_fetch.start_polling ();
-  Dashboard_bonsai_lib.Directory_execution_fetch.run ();
-  Dashboard_bonsai_lib.Directory_execution_fetch.start_polling ();
-  Dashboard_bonsai_lib.Directory_mission_fetch.run ();
-  Dashboard_bonsai_lib.Directory_mission_fetch.start_polling ();
   Dashboard_bonsai_lib.Archive_runs_fetch.run ();
   Dashboard_bonsai_lib.Archive_runs_fetch.start_polling ();
   Dashboard_bonsai_lib.Overview_fetch.run ();


### PR DESCRIPTION
## Summary
- Remove 4 dead `Directory_execution_fetch`/`Directory_mission_fetch` call sites from `dashboard_bonsai/bin/main.ml`
- These modules were deleted in #9582 but the call sites were missed
- No runtime impact — `dashboard_bonsai` is excluded from the dune workspace, so this code was never compiled

## Test plan
- [x] `rg "Directory_execution_fetch|Directory_mission_fetch" dashboard_bonsai/` returns empty
- [ ] CI green (server-side tests unaffected)

Closes #10470

🤖 Generated with [Claude Code](https://claude.com/claude-code)