### PR TITLE
refactor(dashboard/design-system): a11y refinements for cb-group-d (Work Plane)

### DIFF
--- a/dashboard/design-system/preview/cb-group-d.jsx
+++ b/dashboard/design-system/preview/cb-group-d.jsx
@@ -9,13 +9,13 @@ const P2 = window.MASC_P2;
 function ZoneHeader({ title, branch = "main", keepers = [], meta, right }) {
   const headingId = `zh-${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
   return (
-    <div className="ph" role="toolbar" aria-labelledby={headingId}>
+    <div className="ph" role="group" aria-labelledby={headingId}>
       <span className="ttl" id={headingId} role="heading" aria-level={3}>{title}</span>
       <span className="br-pill" aria-label={`Branch ${branch}`}>{branch}</span>
       {keepers.slice(0, 3).map(k => (
-        <span key={k} className="kpr-pill" aria-label={`Keeper ${k}`}><span className="dot" aria-hidden="true" />{k}</span>
+        <span key={k} className="kpr-pill" role="img" aria-label={`Keeper ${k}`}><span className="dot" aria-hidden="true" />{k}</span>
       ))}
-      {keepers.length > 3 && <span className="kpr-pill" aria-label={`Plus ${keepers.length - 3} more keepers`}>+{keepers.length - 3}</span>}
+      {keepers.length > 3 && <span className="kpr-pill" role="img" aria-label={`Plus ${keepers.length - 3} more keepers`}>+{keepers.length - 3}</span>}
       {meta && <span className="meta" style={{marginLeft: 8}}>{meta}</span>}
       <span className="grow" aria-hidden="true" />
       {right}
@@ -265,16 +265,16 @@ function TaskBacklog() {
 function TaskStaleAlert() {
   const stale = P2.tasks.filter(t => t.drift || (t.claim_age && t.claim_age !== '—' && (t.claim_age.endsWith('h') || parseInt(t.claim_age) > 10)));
   return (
-    <section className="cbp" aria-label="Task stale claims alert">
+    <section className="cbp" role="region" aria-label={`Task stale claims · ${stale.length} need attention`}>
       <ZoneHeader
         title="TASK · STALE CLAIMS"
         branch="main"
         keepers={["taskmaster","velvet-hammer"]}
         meta={`${stale.length} need attention · check age > 10m or drift=true`}
-        right={<span className="meta" role="status" style={{color:'var(--err-fg)'}}><span aria-hidden="true">● </span>action required</span>}
+        right={<span className="meta" role="status" aria-live="polite" style={{color:'var(--err-fg)'}}><span aria-hidden="true">● </span>action required</span>}
       />
       <div className="body">
-        <div className="tz-alert" role="list" aria-label={`${stale.length} stale claims`}>
+        <div className="tz-alert" role="list" aria-label={`${stale.length} stale claims requiring attention`}>
           {stale.map(t => (
             <div key={t.id}
                  className="row"
@@ -366,11 +366,10 @@ function AccountabilityLedger() {
         right={<span className="meta">approved 3 · flagged 2 · rejected 1 · deferred 1</span>}
       />
       <div className="body flat" style={{overflow:'auto'}}>
-        <div role="log" aria-label="Daily verdict ledger" aria-live="polite">
+        <div role="log" aria-label="Daily verdict ledger" aria-live="polite" aria-relevant="additions">
           {P2.ledger.map((row, i) => (
-            <div key={i}
+            <article key={i}
                  className="ac-row"
-                 role="listitem"
                  aria-label={`${row.ts} · ${row.verdict} · ${row.subject} · evidence ${row.evidence} · signed by ${row.signed_by} · scope ${row.scope}`}>
               <span className="ts" aria-hidden="true">{row.ts}</span>
               <span className={`vd ${row.verdict}`} aria-hidden="true">{row.verdict}</span>
@@ -382,7 +381,7 @@ function AccountabilityLedger() {
                 {row.signed_by}
                 <span className="scope">{row.scope}</span>
               </span>
-            </div>
+            </article>
           ))}
         </div>
       </div>


### PR DESCRIPTION
## Summary

Refinement-only PR following the cb-group-c (#10458) and cb-group-i (#10462) pattern: tighten WAI-ARIA semantics on top of PR #10437's bulk a11y baseline. Single file, +9/−10, zero visual change.

## Per-component changes

| Component | Change | Reason |
|-----------|--------|--------|
| `ZoneHeader` (helper) | `role="toolbar"` → `role="group"` | No actionable buttons inside; toolbar role implies a tool collection. group is the correct WAI-ARIA primitive. |
| `ZoneHeader` keeper pills | + `role="img"` | Decorative dot + keeper name = visual badge. img + aria-label is the canonical pattern for icon-with-label badges. |
| `TaskStaleAlert` `<section>` | `aria-label` plain → `role="region"` + `aria-label` with stale count | Region landmark + count makes screen reader announcement meaningful (`"Task stale claims · 5 need attention"`). |
| `TaskStaleAlert` right-rail status | + `aria-live="polite"` | Status changes (count of stale claims) ought to announce. |
| `TaskStaleAlert` tz-alert list | aria-label enriched with `"requiring attention"` | More descriptive, action-oriented. |
| `AccountabilityLedger` log container | + `aria-relevant="additions"` | Default is "additions text" — being explicit avoids spurious announcements on attribute changes. |
| `AccountabilityLedger` entries | `<div>` → `<article>` | Each verdict (approved / flagged / rejected / deferred) is self-contained. `<article>` is the semantic HTML element for syndicated content, removes need for `role` attribute. |

## Validation

- Visual smoke: zero pixel change (className preserved, role/aria attribute only)
- DOM ARIA application verified

## Out of scope

- cb-group-e/f/h refinements (#10437 already shipped baseline; refinements deferred unless specific gaps surface)

Refs #10448 #10437

🤖 Generated with [Claude Code](https://claude.com/claude-code)
