### PR TITLE
refactor(dashboard/design-system): extract SectionHeading primitive (Phase 1)

### DIFF
--- a/dashboard/design-system/preview/cb-group-b.jsx
+++ b/dashboard/design-system/preview/cb-group-b.jsx
@@ -15,7 +15,7 @@ function SidebarFleet() {
   const [sel, setSel] = useState('nick0cave');
   return (
     <nav className="cb-sidebar" aria-label="Fleet sidebar">
-      <div className="sec-h" role="heading" aria-level={3}>FLEET <span className="count">{D2.keepers.length}</span></div>
+      <SectionHeading title="FLEET" count={D2.keepers.length} />
       <div role="list" aria-label="Keepers">
         {D2.keepers.map(k => (
           <div key={k.id}
@@ -32,7 +32,7 @@ function SidebarFleet() {
           </div>
         ))}
       </div>
-      <div className="sec-h" role="heading" aria-level={3} style={{marginTop:4}}>GOALS <span className="count">{D2.goals.length}</span></div>
+      <SectionHeading title="GOALS" count={D2.goals.length} style={{marginTop:4}} />
       <div role="list" aria-label="Goals">
         {D2.goals.map(g => (
           <div key={g.id}
@@ -59,7 +59,7 @@ function SidebarGrouped() {
   const [sel, setSel] = useState('nick0cave');
   return (
     <nav className="cb-sidebar" aria-label="Fleet sidebar (grouped)">
-      <div className="sec-h" role="heading" aria-level={3}>ACTIVE <span className="count">{active.length}</span></div>
+      <SectionHeading title="ACTIVE" count={active.length} />
       <div role="list" aria-label="Active keepers">
         {active.map(k => (
           <div key={k.id}
@@ -76,7 +76,7 @@ function SidebarGrouped() {
           </div>
         ))}
       </div>
-      <div className="sec-h" role="heading" aria-level={3}>STANDBY <span className="count">{other.length}</span></div>
+      <SectionHeading title="STANDBY" count={other.length} />
       <div role="list" aria-label="Standby keepers">
         {other.map(k => (
           <div key={k.id} role="listitem" aria-label={`${k.id} · ${k.status}`} className="row idle">
@@ -94,7 +94,7 @@ function SidebarIcons() {
   const [sel, setSel] = useState('nick0cave');
   return (
     <nav className="cb-sidebar icons" aria-label="Fleet sidebar (icons)">
-      <div className="sec-h" role="heading" aria-level={3}>FLEET <span className="count">{D2.keepers.length}</span></div>
+      <SectionHeading title="FLEET" count={D2.keepers.length} />
       <div role="list" aria-label="Keepers">
         {D2.keepers.map(k => (
           <div key={k.id}
@@ -346,7 +346,7 @@ function RailActivity() {
   return (
     <aside className="cb-rail" aria-label="Activity rail">
       <div className="sec">
-        <div className="sec-h" role="heading" aria-level={3}>ACTIVITY <span className="right" aria-hidden="true">11 · 60s</span></div>
+        <SectionHeading title="ACTIVITY" right="11 · 60s" />
         <div className="body" role="log" aria-live="polite" aria-label="Recent fleet events" style={{maxHeight:320, overflow:'auto'}}>
           {D2.events.map((e, i) => (
             <div key={i}
@@ -371,7 +371,7 @@ function RailCascade() {
   return (
     <aside className="cb-rail" aria-label="Cascade rail">
       <div className="sec">
-        <div className="sec-h" role="heading" aria-level={3}>CASCADE <span className="right" aria-hidden="true">cascade-3f19</span></div>
+        <SectionHeading title="CASCADE" right="cascade-3f19" />
         <div className="cb-cascade" role="region" aria-label={`Cascade trace cascade-3f19 · hit at step 2 · total ${D2.cascade.total_ms}ms`}>
           <span className="id" aria-hidden="true">trace · hit @step=2</span>
           <ol aria-label="Cascade steps" style={{listStyle:'none', margin:0, padding:0}}>
@@ -389,7 +389,7 @@ function RailCascade() {
         </div>
       </div>
       <div className="sec">
-        <div className="sec-h" role="heading" aria-level={3}>RECENT <span className="right" aria-hidden="true">3</span></div>
+        <SectionHeading title="RECENT" right="3" />
         <div className="body" role="log" aria-live="polite" aria-label="Recent events">
           {D2.events.slice(0,3).map((e,i) => (
             <div key={i}

--- a/dashboard/design-system/preview/cb-group-c.jsx
+++ b/dashboard/design-system/preview/cb-group-c.jsx
@@ -196,7 +196,7 @@ function DrawerTask() {
       </div>
       <div className="body">
         <section aria-labelledby="drawer-task-details">
-          <div className="sec-title" id="drawer-task-details" role="heading" aria-level={3}>DETAILS</div>
+          <SectionHeading variant="title" title="DETAILS" id="drawer-task-details" />
           <dl className="kv">
             <dt>KEEPER</dt><dd>nick0cave</dd>
             <dt>TOOL</dt><dd>tool.write_file</dd>
@@ -206,7 +206,7 @@ function DrawerTask() {
           </dl>
         </section>
         <section aria-labelledby="drawer-task-review">
-          <div className="sec-title" id="drawer-task-review" role="heading" aria-level={3}>REVIEW · 3</div>
+          <SectionHeading variant="title" title="REVIEW · 3" id="drawer-task-review" />
           <div className="thread" role="log" aria-live="polite" aria-label="Review thread, 3 comments">
             <div className="cmt flag" role="article" aria-label="Flag from sangsu, 3 minutes ago: drift detected at pipeline.ts L187 — signature mismatch">
               <div className="h" aria-hidden="true">
@@ -265,7 +265,7 @@ function DrawerGoal() {
       </div>
       <div className="body">
         <section aria-labelledby="drawer-goal-tasks">
-          <div className="sec-title" id="drawer-goal-tasks" role="heading" aria-level={3}>TASKS · 5</div>
+          <SectionHeading variant="title" title="TASKS · 5" id="drawer-goal-tasks" />
           <div role="list" aria-label="Tasks under this goal" style={{display:'flex', flexDirection:'column', gap:4}}>
             {(() => {
               const seen = new Set();
@@ -284,7 +284,7 @@ function DrawerGoal() {
           </div>
         </section>
         <section aria-labelledby="drawer-goal-keepers">
-          <div className="sec-title" id="drawer-goal-keepers" role="heading" aria-level={3}>KEEPERS</div>
+          <SectionHeading variant="title" title="KEEPERS" id="drawer-goal-keepers" />
           <dl className="kv">
             <dt>OWNER</dt><dd>masc-improver</dd>
             <dt>CONTRIB</dt><dd>nick0cave · sangsu</dd>
@@ -324,13 +324,13 @@ function DrawerKeeper() {
       </div>
       <div className="body">
         <section aria-labelledby="drawer-keeper-heartbeat">
-          <div className="sec-title" id="drawer-keeper-heartbeat" role="heading" aria-level={3}>HEARTBEAT</div>
+          <SectionHeading variant="title" title="HEARTBEAT" id="drawer-keeper-heartbeat" />
           <div aria-label="Heartbeat trace, 60-second window" style={{background:'var(--bg-1)', padding:6, border:'1px solid var(--line-1)', borderRadius:3}}>
             <span aria-hidden="true"><Heartbeat width={260} height={40} /></span>
           </div>
         </section>
         <section aria-labelledby="drawer-keeper-current">
-          <div className="sec-title" id="drawer-keeper-current" role="heading" aria-level={3}>CURRENT</div>
+          <SectionHeading variant="title" title="CURRENT" id="drawer-keeper-current" />
           <dl className="kv">
             <dt>TASK</dt><dd>t-9f2a</dd>
             <dt>GOAL</dt><dd>goal-merge-blockers</dd>
@@ -340,7 +340,7 @@ function DrawerKeeper() {
           </dl>
         </section>
         <section aria-labelledby="drawer-keeper-events">
-          <div className="sec-title" id="drawer-keeper-events" role="heading" aria-level={3}>LAST 3 EVENTS</div>
+          <SectionHeading variant="title" title="LAST 3 EVENTS" id="drawer-keeper-events" />
           <div role="log" aria-live="polite" aria-label="Last 3 events from nick0cave" style={{display:'flex', flexDirection:'column', gap:4, fontSize:11}}>
             {D3.events.filter(e=>e.keeper==='nick0cave').slice(0,3).map((e,i)=>(
               <div key={i}

--- a/dashboard/design-system/preview/cb-group-h.jsx
+++ b/dashboard/design-system/preview/cb-group-h.jsx
@@ -337,17 +337,17 @@ function ARFindingCard() {
           <span className="conf">{(f.confidence*100).toFixed(0)}% confidence</span>
         </div>
         <section aria-labelledby={`ar-${f.id}-hyp`}>
-          <div className="sec-h" id={`ar-${f.id}-hyp`} role="heading" aria-level={4}>hypothesis</div>
+          <SectionHeading title="hypothesis" level={4} id={`ar-${f.id}-hyp`} />
           <div className="hy">{f.hypothesis}</div>
         </section>
         <section aria-labelledby={`ar-${f.id}-ev`}>
-          <div className="sec-h" id={`ar-${f.id}-ev`} role="heading" aria-level={4}>evidence ({f.evidence.length})</div>
+          <SectionHeading title={`evidence (${f.evidence.length})`} level={4} id={`ar-${f.id}-ev`} />
           <ul className="ev-list" role="list" style={{listStyle:'none', margin:0, padding:0}}>
             {f.evidence.map((e, i) => <li key={i} className="ev">{e}</li>)}
           </ul>
         </section>
         <section aria-labelledby={`ar-${f.id}-co`}>
-          <div className="sec-h" id={`ar-${f.id}-co`} role="heading" aria-level={4}>conclusion</div>
+          <SectionHeading title="conclusion" level={4} id={`ar-${f.id}-co`} />
           <div className="co">{f.conclusion}</div>
         </section>
       </article>

--- a/dashboard/design-system/preview/cb-shared.jsx
+++ b/dashboard/design-system/preview/cb-shared.jsx
@@ -56,6 +56,42 @@ function Pill({ kind, children }) {
 // Variant caption that sits above an artboard
 function Vhead({ children }) { return <div className="cb-vhead">{children}</div>; }
 
+// Section heading — replaces inline `sec-h` / `sec-title` divs.
+// `variant` selects the className ('h' → .sec-h, 'title' → .sec-title).
+// `title` + `count` + `right` cover the common structured cases; `children`
+// overrides them for ad-hoc markup. `id` enables aria-labelledby cross-refs.
+function SectionHeading({
+  variant = 'h',
+  level = 3,
+  id,
+  title,
+  count,
+  right,
+  className,
+  style,
+  children,
+}) {
+  const base = variant === 'title' ? 'sec-title' : 'sec-h';
+  const cls = base + (className ? ' ' + className : '');
+  return (
+    <div
+      className={cls}
+      role="heading"
+      aria-level={level}
+      {...(id ? { id } : {})}
+      {...(style ? { style } : {})}
+    >
+      {children ?? (
+        <>
+          {title}
+          {count != null && <> <span className="count">{count}</span></>}
+          {right != null && <> <span className="right" aria-hidden="true">{right}</span></>}
+        </>
+      )}
+    </div>
+  );
+}
+
 // Utility — get keeper color var name from id
 function kClass(id) {
   return ({
@@ -121,4 +157,4 @@ function useTyping(strings, cps = 18) {
   return text;
 }
 
-Object.assign(window, { Dot, Spark, Heartbeat, Chip, Pill, Vhead, kClass, useTyping, getTheme, setTheme });
+Object.assign(window, { Dot, Spark, Heartbeat, Chip, Pill, Vhead, SectionHeading, kClass, useTyping, getTheme, setTheme });


### PR DESCRIPTION
## Summary

Phase 1 of the design system consistency cleanup (#10448 follow-up). Hoists the inline `sec-h` / `sec-title` heading divs into a shared `SectionHeading` primitive in `cb-shared.jsx` and migrates every existing call site so the design system has one canonical heading component.

## API

```jsx
<SectionHeading
  variant="h"          // 'h' (.sec-h) | 'title' (.sec-title)
  level={3}            // aria-level (1-6)
  id="optional"        // for aria-labelledby cross-refs
  title="FLEET"        // main text
  count={8}            // -> <span class="count">8</span>
  right="11 . 60s"     // -> <span class="right" aria-hidden>11 . 60s</span>
  className="extra"    // composed with .sec-h / .sec-title
  style={{...}}        // passthrough
>{children}</SectionHeading>  // children override title/count/right
```

## Migration (18 sites, ZERO visual change)

| File | Sites | Variant |
|------|-------|---------|
| `cb-group-b.jsx` | 8 sec-h | Sidebar Fleet/Goals/Active/Standby (4) + Rail Activity/Cascade/Recent (3) + icons Fleet (1) |
| `cb-group-c.jsx` | 7 sec-title | Drawer Task Details/Review, Goal Tasks/Keepers, Keeper Heartbeat/Current/Last 3 Events |
| `cb-group-h.jsx` | 3 sec-h | AR find hypothesis/evidence/conclusion (level 4, with section ids) |

Diff stat: +55 / -19 across 4 files. ClassName, `role="heading"`, `aria-level`, and inner `<span class="count">` / `<span class="right" aria-hidden>` structure are preserved at every call site.

## Verification

`components.html` is currently broken on `cb-group-a.jsx` (the JSX-union duplicate from squash, #10467 fixes it; this PR's branch picked it up via rebase, but kept the isolated harness pattern documented as the safe approach).

- Built isolated test harness `_section-heading-test.html` loading only `cb-shared.jsx` + `cb-group-b/c/h.jsx`.
- Chrome `--headless --dump-dom` confirmed each variant emits the exact pre-refactor attribute set:
  ```
  <div class="sec-h" role="heading" aria-level="3">FLEET <span class="count">8</span></div>
  <div class="sec-h" role="heading" aria-level="3" style="margin-top: 4px;">GOALS <span class="count">4</span></div>
  <div class="sec-h" role="heading" aria-level="3">ACTIVITY <span class="right" aria-hidden="true">11 . 60s</span></div>
  <div class="sec-title" role="heading" aria-level="3" id="drawer-task-details">DETAILS</div>
  <div class="sec-h" role="heading" aria-level="4" id="ar-test-hyp">hypothesis</div>
  <div class="sec-h" role="heading" aria-level="4" id="ar-test-ev">evidence (3)</div>
  ```
- Screenshot at 1280x3500 matches the pre-refactor render. No console errors.
- Harness HTML removed before commit; only the 4 production files ship.

## Test plan

- [x] All 18 sites compile (Babel parses cb-shared / cb-group-b / cb-group-c / cb-group-h).
- [x] Rendered DOM identical to pre-refactor markup for every migrated call site.
- [x] aria-level preserved (3 for cb-group-b/c, 4 for cb-group-h).
- [x] `id` attribute present only when supplied (cb-group-c drawers + cb-group-h AR finds).
- [x] `style={{marginTop:4}}` preserved on the GOALS heading.
- [x] No literal `sec-h` / `sec-title` JSX usages remain in `cb-group-*.jsx` (CSS rules and `snippets.jsx` HTML strings intentionally left).

## Labels

`enhancement` + `do-not-merge` (consistency refactor, not urgent; full safety on top of the recent design-system cascade).