### PR TITLE
docs(design-system): ARIA pattern catalog + SPEC links in READMEs

### DIFF
--- a/dashboard/design-system/README.md
+++ b/dashboard/design-system/README.md
@@ -4,6 +4,15 @@
 
 ---
 
+## SSOT documents
+
+- **[`SPEC.md`](SPEC.md)** — canonical design system specification covering both `dashboard/`(Preact) and `dashboard_bonsai/`(Bonsai/OCaml). Token taxonomy (Raw/Semantic/Role), canonical vocabulary, theme matrix, ARIA pattern catalog, governance.
+- **[`patterns/a11y/`](patterns/a11y/)** — ARIA pattern catalog: `region` · `list` · `tablist` · `radiogroup` · `log` · `dialog`. Each file has JSX + Bonsai examples, keyboard contracts, screen reader expectations.
+
+새 token / 컴포넌트 패턴 / 테마 추가는 SPEC.md 갱신이 선행되어야 합니다.
+
+---
+
 ## What MASC is
 
 MASC is a **single-pane-of-glass cockpit** where a human operator (or agent) can watch multiple AI keepers work in parallel across codebases, tasks, goals, and providers. It fuses two modes into one view:

--- a/dashboard/design-system/patterns/a11y/dialog.md
+++ b/dashboard/design-system/patterns/a11y/dialog.md
@@ -1,0 +1,112 @@
+# `role="dialog"` — Modal / drawer / confirm
+
+> SPEC v0.1 §5.6 — pattern catalog
+
+## 사용 시점
+
+- 모달 (확인 prompt, 설정 패널)
+- drawer (사이드 패널이 portal 또는 dimmed background와 함께 뜨는 경우)
+- 일시적 콘텐츠인데 키보드 focus를 trap해야 하는 경우
+
+## 사용하지 말 것
+
+- 페이지 일부에 항상 보이는 패널 (그건 `region`)
+- 자동으로 닫히는 toast (그건 `role="status"`)
+- 인라인 dropdown menu (그건 `role="menu"` + `aria-haspopup`)
+
+## 필수 attribute
+
+| Attribute | 값 | 위치 | 이유 |
+|-----------|-----|------|------|
+| `role` | `"dialog"` | 부모 | dialog landmark |
+| `aria-modal` | `"true"` | 부모 | 외부 콘텐츠 inert 표시 |
+| `aria-labelledby` | 제목 element id | 부모 | dialog 제목 |
+| `aria-describedby` | 설명 element id | 부모 (선택) | 추가 컨텍스트 |
+| `tabIndex` | `-1` | 부모 (focus 받을 수 있게) | 첫 focus target |
+
+## JSX 예시 (제안 패턴 — 현재 preview에 dialog 컴포넌트 부재)
+
+```jsx
+function ConfirmDialog({ titleId, descId, title, desc, onConfirm, onCancel }) {
+  const ref = useRef(null);
+  useEffect(() => { ref.current?.focus(); }, []);
+
+  return (
+    <div className="dialog-overlay">
+      <div ref={ref}
+           role="dialog"
+           aria-modal="true"
+           aria-labelledby={titleId}
+           aria-describedby={descId}
+           tabIndex={-1}
+           onKeyDown={(e) => {
+             if (e.key === 'Escape') {
+               e.preventDefault();
+               onCancel();
+             }
+           }}>
+        <h2 id={titleId}>{title}</h2>
+        <p id={descId}>{desc}</p>
+        <button onClick={onConfirm}>Confirm</button>
+        <button onClick={onCancel}>Cancel</button>
+      </div>
+    </div>
+  );
+}
+```
+
+## Bonsai 예시 (제안 패턴)
+
+```ocaml
+let confirm_dialog ~title ~desc ~on_confirm ~on_cancel =
+  Vdom.Node.div
+    ~attrs:[ Style.dialog_overlay ]
+    [ Vdom.Node.div
+        ~attrs:[ Style.dialog
+               ; Attr.role "dialog"
+               ; Attr.create "aria-modal" "true"
+               ; Attr.create "aria-labelledby" "dialog-title"
+               ; Attr.create "aria-describedby" "dialog-desc"
+               ; Attr.tabindex (-1)
+               ; Attr.on_keydown (fun e ->
+                   if String.equal e##.key "Escape"
+                   then on_cancel
+                   else Effect.Ignore) ]
+        [ Vdom.Node.h2 ~attrs:[ Attr.id "dialog-title" ] [ Vdom.Node.text title ]
+        ; Vdom.Node.p  ~attrs:[ Attr.id "dialog-desc"  ] [ Vdom.Node.text desc ]
+        ; ... ] ]
+```
+
+## 키보드 동작 (필수)
+
+| Key | 동작 |
+|-----|------|
+| `Esc` | dialog 닫기 (= cancel) |
+| `Tab` | dialog 내부 focus 순환 (focus trap 필수) |
+| `Shift+Tab` | 역방향 순환 |
+| (open 시) | 첫 의미있는 element에 focus 자동 이동 |
+| (close 시) | dialog 호출한 trigger element로 focus 복귀 |
+
+**focus trap**은 dialog 내부의 `tabbable` element 첫/마지막을 wrap-around 시키는 로직. JSX는 `react-focus-trap`/`focus-trap-react`, Bonsai는 수동 구현 또는 `Vdom.Attr.on_keydown` + DOM API.
+
+## Screen reader 기대값
+
+| SR | Announcement (open 시) |
+|----|------------------------|
+| VoiceOver | "Confirm deletion, dialog · You are about to delete keeper-3. This cannot be undone. · Confirm button" |
+| NVDA | "Confirm deletion · dialog · You are about to delete keeper-3. This cannot be undone." |
+
+## Antipatterns
+
+- ❌ `role="dialog"` 없이 visual modal만 — SR이 모달임을 모름, 외부 콘텐츠 계속 탐색 가능
+- ❌ `aria-modal="true"` 없으면 SR이 외부와 분리하지 않음
+- ❌ Esc 미구현 — 키보드 사용자가 갇힘
+- ❌ focus가 자동 이동 안 함 — open 후 사용자가 Tab 1번 더 눌러야 dialog 진입
+- ❌ close 후 focus가 body로 떨어짐 — trigger element로 복귀해야 흐름 유지
+- ❌ `aria-labelledby` 없이 `aria-label`만 — 시각 제목과 SR 제목이 분리되어 동기화 깨짐 (둘 다 가능하지만 labelledby가 우선)
+
+## 관련 패턴
+
+- 비동기 알림 → `role="status"` (dialog보다 가벼움, focus trap 없음)
+- inline expandable → `aria-expanded` + `aria-controls` (dialog 아님)
+- dropdown menu → `role="menu"` + `aria-haspopup="menu"`

--- a/dashboard/design-system/patterns/a11y/list.md
+++ b/dashboard/design-system/patterns/a11y/list.md
@@ -1,0 +1,78 @@
+# `role="list"` / `role="listitem"` — Homogeneous collection
+
+> SPEC v0.1 §5.2 — pattern catalog
+
+## 사용 시점
+
+- keeper 리스트, swimlane row 컬렉션, log line 컬렉션
+- DOM이 `<ul><li>`가 아닌데 의미는 list인 경우 (CSS reset 또는 div-based layout)
+- 항목 수와 위치를 SR에게 알릴 가치가 있는 경우
+
+## 사용하지 말 것
+
+- `<ul><li>` native element를 쓰는 경우 (native가 더 우수)
+- 항목들이 *서로 다른 의미*를 가질 때 (그땐 region 또는 group 사용)
+- 단일 선택을 위한 항목들 (그건 `radiogroup` 사용)
+
+## 필수 attribute
+
+| Attribute | 값 | 위치 | 이유 |
+|-----------|-----|------|------|
+| `role` | `"list"` | 부모 컨테이너 | list landmark |
+| `aria-label` | "Active keepers" 등 | 부모 | list 의미 |
+| `role` | `"listitem"` | 각 자식 | 항목 식별 |
+| `aria-label` | 항목 의미 | 각 자식 (텍스트가 안 보이면) | 항목 announce |
+
+## JSX 예시 — `dashboard/design-system/preview/cb-group-a.jsx`
+
+```jsx
+<div className="kpi-strip" role="list" aria-label={`${kpis.length} key indicators`}>
+  {kpis.map(k => (
+    <div key={k.id}
+         role="listitem"
+         aria-label={`${k.label} · ${k.value} · ${k.delta}`}
+         className="kpi">
+      <span className="lbl" aria-hidden="true">{k.label}</span>
+      <span className="val" aria-hidden="true">{k.value}</span>
+      <span className="dlt" aria-hidden="true">{k.delta}</span>
+    </div>
+  ))}
+</div>
+```
+
+## Bonsai 예시 — `dashboard_bonsai/src/dead_keepers_view.ml`
+
+```ocaml
+Vdom.Node.div
+  ~attrs:[ Attr.role "list"
+         ; Attr.create "aria-label" "Dead keepers list" ]
+  (List.map keepers ~f:(fun k ->
+     Vdom.Node.div
+       ~attrs:[ Attr.role "listitem"
+              ; Attr.create "aria-label" (sprintf "%s · %s" k.name k.cause) ]
+       [ ... ]))
+```
+
+## 키보드 동작
+
+별도 동작 없음 (탐색용). 항목이 활성화 가능하면 별도 `tabIndex={0}` + `onKeyDown`이 필요하지만, 그 시점에선 list가 아니라 `tablist`/`radiogroup`/`grid` 검토.
+
+## Screen reader 기대값
+
+| SR | Announcement |
+|----|--------------|
+| VoiceOver | "list, 5 items" → "keeper-1 active 12 tasks done, list item, 1 of 5" |
+| NVDA | "list with 5 items" → "keeper-1 active 12 tasks done, list item, 1 of 5" |
+
+## Antipatterns
+
+- ❌ 부모 `role="list"` 없이 자식만 `role="listitem"` — orphan listitem은 무효
+- ❌ 자식 div에 `role="listitem"`을 박았는데 텍스트가 다 `aria-hidden="true"` — 라벨 없는 listitem
+- ❌ 매 listitem에 동일 aria-label (예: "Item") — 항목 구분 불가
+- ❌ list 안에 list가 깊게 중첩 — 평면 listitem이 SR에게 더 명확
+
+## 관련 패턴
+
+- 단일 선택 → `radiogroup.md`
+- tab 전환 → `tablist.md`
+- 시간순 누적 → `log.md`

--- a/dashboard/design-system/patterns/a11y/log.md
+++ b/dashboard/design-system/patterns/a11y/log.md
@@ -1,0 +1,94 @@
+# `role="log"` / `aria-live` — Time-sequenced append
+
+> SPEC v0.1 §5.5 — pattern catalog
+
+## 사용 시점
+
+- 시간순 누적 콘텐츠 (operator nudge log, activity feed, terminal output)
+- 새 항목이 도착하면 자동으로 SR에게 announce해야 할 때
+- 사용자가 항목 하나하나에 focus를 두지 않고 흐름으로 인지하는 영역
+
+## 사용하지 말 것
+
+- 정적 항목 컬렉션 (그건 `role="list"`)
+- 사용자가 explicit하게 다음 항목으로 이동하는 UI (그건 list + 키보드 nav)
+- 한 번 뜨고 사라지는 toast (그건 `role="status"` 또는 `role="alert"`)
+
+## 필수 attribute
+
+| Attribute | 값 | 위치 | 이유 |
+|-----------|-----|------|------|
+| `role` | `"log"` | 부모 | log landmark |
+| `aria-live` | `"polite"` | 부모 | 새 항목 시 announce, 다른 announcement 가로채지 않음 |
+| `aria-label` | "Operator nudges" 등 | 부모 | log 의미 |
+| `role` | `"listitem"` | 각 항목 | 항목 식별 |
+| `aria-atomic` | `"false"` (default) | 부모 | 변경된 부분만 announce (전체 재 announce 회피) |
+
+`role="log"`는 implicit `aria-live="polite"`를 가지지만, 명시적으로 부착하는 게 SR 호환성에 안전.
+
+## JSX 예시 — `dashboard/design-system/preview/cb-group-i.jsx`
+
+```jsx
+<div role="log"
+     aria-live="polite"
+     aria-label={`${P2i.nudges.length} nudges`}
+     style={{background:'var(--bg-0)'}}>
+  {P2i.nudges.map(n => (
+    <div key={n.id}
+         className="nd-row"
+         role="listitem"
+         aria-label={`${n.at.replace('Z','')} · ${n.channel} · to ${n.to.map(k => '@' + k).join(', ')} · ${n.body} · ${n.ack ? 'acknowledged' : 'pending acknowledgment'}`}>
+      {/* visual content with aria-hidden */}
+    </div>
+  ))}
+</div>
+```
+
+## Bonsai 예시 — `dashboard_bonsai/src/logs_view.ml` (적용 시점)
+
+```ocaml
+let nudge_log ~nudges =
+  Vdom.Node.div
+    ~attrs:[ Style.nudge_log
+           ; Attr.role "log"
+           ; Attr.create "aria-live" "polite"
+           ; Attr.create "aria-label" (sprintf "%d nudges" (List.length nudges)) ]
+    (List.map nudges ~f:(fun n ->
+      Vdom.Node.div
+        ~attrs:[ Attr.role "listitem"
+               ; Attr.create "aria-label" (nudge_summary n) ]
+        [ ... ]))
+```
+
+## 키보드 동작
+
+별도 동작 없음 (탐색용). 사용자가 log 항목에 focus 두고 싶으면 listitem에 `tabIndex={0}` 부착, 단 그러면 `aria-live`의 announcement가 focus와 경쟁할 수 있음 — 보통 log는 read-only.
+
+## Screen reader 기대값
+
+| SR | Announcement |
+|----|--------------|
+| VoiceOver (새 항목 도착) | "10:23 · hint · to @sangsu · 'check the deploy' · pending acknowledgment" |
+| NVDA (idle) | log 영역 진입 시 "log · 5 items" |
+
+## `aria-live="polite"` vs `"assertive"`
+
+| 값 | 사용처 | 효과 |
+|----|--------|------|
+| `polite` | 일반 log, 상태 갱신, status pill | 다른 announcement 끝난 후 발화 |
+| `assertive` | 즉시 사용자 주의 필요 (error, security alert) | 진행 중 announcement 끊고 즉시 발화 |
+
+assertive 남용은 SR 사용자에게 압박감을 주므로 신중히. log는 거의 항상 polite.
+
+## Antipatterns
+
+- ❌ `aria-atomic="true"` — 새 항목 추가 시 전체 log를 재 announce해서 시끄러움
+- ❌ `role="log"`인데 `aria-label` 없음 — 익명 log
+- ❌ visible text 없는 listitem (모든 자식이 `aria-hidden="true"`)에 부모 aria-label도 없음 — silent log
+- ❌ log 항목을 click 가능한 button으로 — log는 read-only, action은 list + 명시 button
+
+## 관련 패턴
+
+- 단발 status 메시지 → `role="status"` + `aria-live="polite"` (log보다 가벼움)
+- 즉시 alert → `role="alert"`
+- 대화형 메시지 → `role="region"` + 내부에 form

--- a/dashboard/design-system/patterns/a11y/radiogroup.md
+++ b/dashboard/design-system/patterns/a11y/radiogroup.md
@@ -1,0 +1,105 @@
+# `role="radiogroup"` / `role="radio"` — Single-choice form
+
+> SPEC v0.1 §5.4 — pattern catalog
+
+## 사용 시점
+
+- 단일 선택 (branch selector, channel chooser, theme selector)
+- 옵션 수가 고정적이고 SR에게 "N 중 1 선택"을 알려야 할 때
+- 시각적으로 라디오 버튼이 아니어도 의미가 라디오라면 ARIA로 표현
+
+## 사용하지 말 것
+
+- 콘텐츠 전환 (그건 `tablist`)
+- 복수 선택 (그건 checkbox 또는 `aria-pressed` 토글)
+- form value가 아닌 단순 view filter (그건 toolbar + `aria-pressed`)
+
+## 필수 attribute
+
+| Attribute | 값 | 위치 |
+|-----------|-----|------|
+| `role` | `"radiogroup"` | 부모 |
+| `aria-label` | "Branch selection" 등 | 부모 |
+| `role` | `"radio"` | 각 옵션 |
+| `aria-checked` | `"true"` / `"false"` | 각 옵션 |
+| `tabIndex` | checked만 `0`, 나머지 `-1` | 각 옵션 (roving) |
+| `aria-label` | 옵션 의미 | 텍스트가 안 보이거나 메타데이터가 추가 정보일 때 |
+
+## JSX 예시 — `dashboard/design-system/preview/cb-group-i.jsx`
+
+```jsx
+<div className="br-list" role="radiogroup" aria-label="Branch list">
+  {P2i.branches.map(b => (
+    <div key={b.name}
+         role="radio"
+         aria-checked={b.name === sel}
+         aria-label={`${b.name} · ${b.tag} · ${b.status} · ${b.ahead} ahead, ${b.behind} behind · HEAD ${b.head}`}
+         tabIndex={0}
+         onClick={() => setSel(b.name)}
+         onKeyDown={(e) => {
+           if (e.key === 'Enter' || e.key === ' ') {
+             e.preventDefault();
+             setSel(b.name);
+           }
+         }}
+         className={`row ${b.name === sel ? 'on' : ''}`}>
+      {/* visual content with aria-hidden */}
+    </div>
+  ))}
+</div>
+```
+
+## Bonsai 예시 (제안 패턴)
+
+```ocaml
+let radiogroup ~options ~selected ~on_select ~label =
+  Vdom.Node.div
+    ~attrs:[ Attr.role "radiogroup"
+           ; Attr.create "aria-label" label ]
+    (List.map options ~f:(fun (id, label) ->
+      let checked = String.equal id selected in
+      Vdom.Node.div
+        ~attrs:[ Attr.role "radio"
+               ; Attr.create "aria-checked" (Bool.to_string checked)
+               ; Attr.create "aria-label" label
+               ; Attr.tabindex (if checked then 0 else -1)
+               ; Attr.on_click (fun _ -> on_select id) ]
+        [ ... ]))
+```
+
+## 키보드 동작 (필수)
+
+| Key | 동작 |
+|-----|------|
+| `↑` `↓` (또는 `←` `→`) | 이전/다음 옵션 + 자동 선택 |
+| `Home` | 첫 옵션 |
+| `End` | 마지막 옵션 |
+| `Tab` | radiogroup 진입/탈출만 (그룹 내부 이동은 화살표) |
+
+## Screen reader 기대값
+
+| SR | Announcement |
+|----|--------------|
+| VoiceOver | "Branch list · 5 options · feat/design-system-spec, radio button, checked, 2 of 5" |
+| NVDA | "Branch list, grouping · feat/design-system-spec, radio button, checked, 2 of 5" |
+
+## `aria-checked` vs `aria-selected` vs `aria-pressed`
+
+| Attribute | 사용처 | 의미 |
+|-----------|--------|------|
+| `aria-checked` | radio, checkbox, switch | "값이 선택된 상태인가" |
+| `aria-selected` | tab, listbox option, gridcell | "현재 보여지는/하이라이트된 것인가" |
+| `aria-pressed` | toggle button | "버튼이 눌린 상태인가 (sticky)" |
+
+이 셋을 혼용하면 SR이 무엇을 announce할지 결정 못 함. radiogroup에는 **반드시 `aria-checked`만**.
+
+## Antipatterns
+
+- ❌ `role="radio"`에 `aria-pressed` 부착 — 두 개의 state 모델 충돌
+- ❌ 모든 옵션 `tabIndex={0}` — 그룹이 Tab 키 N번 (roving 깨짐). 단, 옵션 수가 적고 모두 Tab으로 도달해야 하는 특수 케이스라면 전체 `0` + Arrow 미구현도 받아들임. SPEC §5는 표준 권장.
+- ❌ `aria-checked` 없이 visual class만 — SR 사용자가 활성 옵션 모름
+
+## 관련 패턴
+
+- 콘텐츠 전환 → `tablist.md`
+- 다중 선택 → checkbox 또는 toolbar + `aria-pressed`

--- a/dashboard/design-system/patterns/a11y/region.md
+++ b/dashboard/design-system/patterns/a11y/region.md
@@ -1,0 +1,67 @@
+# `role="region"` — Named landmark
+
+> SPEC v0.1 §5.1 — pattern catalog
+
+## 사용 시점
+
+- 데이터 시각화 박스(KPI, lifeline, swimlane mock 등)
+- 명명된 콘텐츠 영역인데 `<section>` 의미만으로 부족할 때
+- screen reader 사용자가 landmark navigation으로 점프할 가치가 있는 영역
+
+## 사용하지 말 것
+
+- 너무 작은 부분(버튼, 단일 라벨)
+- 페이지 전체 레이아웃 (이미 `<main>`, `<nav>` 등의 native landmark가 있음)
+- 동질적 항목의 컬렉션 (그건 `role="list"` 사용)
+
+## 필수 attribute
+
+| Attribute | 값 | 이유 |
+|-----------|-----|------|
+| `role` | `"region"` | landmark로 식별 |
+| `aria-label` | 영역 의미를 한 문장으로 | landmark navigation 시 announce |
+| (또는) `aria-labelledby` | 가까운 헤딩 id | label이 페이지에 보이는 텍스트면 이쪽 |
+
+## JSX 예시 — `dashboard/design-system/preview/cb-group-j.jsx`
+
+```jsx
+<div className="lifeline-card"
+     role="region"
+     aria-label={`Lifeline · ${lane.name} · ${lane.points.length}-point sparkline`}>
+  <div className="lifeline-svg">{/* ... */}</div>
+</div>
+```
+
+## Bonsai 예시 — `dashboard_bonsai/src/keepers_view.ml`
+
+```ocaml
+let directory ~keepers =
+  Vdom.Node.div
+    ~attrs:[ Style.directory
+           ; Attr.role "region"
+           ; Attr.create "aria-label" "Live keepers" ]
+    [ ... ]
+```
+
+## 키보드 동작
+
+별도 동작 없음. landmark navigation은 screen reader 단축키(NVDA `D`, VoiceOver rotor 등)로 처리.
+
+## Screen reader 기대값
+
+| SR | Announcement |
+|----|--------------|
+| VoiceOver | "Lifeline, keeper-1, 24-point sparkline, region" |
+| NVDA | "region, Lifeline keeper-1 24-point sparkline" |
+
+## Antipatterns
+
+- ❌ `aria-label` 없이 `role="region"`만 — 이름 없는 landmark는 SR rotor에서 무용지물
+- ❌ `role="region"`을 `<button>`/`<a>` 같은 interactive element에 부착 — interactive role과 충돌
+- ❌ 시각 mock의 SVG/canvas 자체에 `role="region"` — 부모 div에 부착하고 SVG는 `aria-hidden="true"`
+
+## 관련 패턴
+
+- 동질적 항목 컬렉션 → `list.md`
+- 시간순 추가 콘텐츠 → `log.md`
+- 콘텐츠 전환 UI → `tablist.md`

--- a/dashboard/design-system/patterns/a11y/tablist.md
+++ b/dashboard/design-system/patterns/a11y/tablist.md
@@ -1,0 +1,109 @@
+# `role="tablist"` / `role="tab"` — Content switcher
+
+> SPEC v0.1 §5.3 — pattern catalog
+
+## 사용 시점
+
+- 컨텐츠 전환 UI (keeper inspector tab, deck mode, code mode chooser)
+- 한 번에 하나의 panel만 보임
+- 탭 활성화가 page navigation이 아니라 같은 컨테이너 내 콘텐츠 교체
+
+## 사용하지 말 것
+
+- 페이지 전환 (그건 `<a href>` + `aria-current` 사용)
+- 단순 토글 버튼 (그건 `aria-pressed` 사용)
+- 복수 선택 (그건 group + checkbox 사용)
+
+## 필수 attribute
+
+| Attribute | 값 | 위치 |
+|-----------|-----|------|
+| `role` | `"tablist"` | 부모 |
+| `aria-label` | "Keeper inspector views" 등 | 부모 |
+| `role` | `"tab"` | 각 탭 버튼 |
+| `aria-selected` | `"true"` / `"false"` | 각 탭 |
+| `aria-controls` | 해당 panel id | 각 탭 (강력 권장) |
+| `tabIndex` | 활성 탭만 `0`, 나머지 `-1` | 각 탭 (roving tabindex) |
+| `role` | `"tabpanel"` | 콘텐츠 영역 (옵션) |
+| `id` | 탭의 aria-controls 대상 | tabpanel |
+
+## JSX 예시 — `dashboard/design-system/preview/cb-group-h.jsx`
+
+```jsx
+function KeeperTabs({ tabs, active, onSelect, label }) {
+  return (
+    <div className="kt-tabs" role="tablist" aria-label={label}>
+      {tabs.map(t => (
+        <button key={t.id}
+                type="button"
+                role="tab"
+                aria-selected={active === t.id}
+                aria-controls={`tabpanel-${t.id}`}
+                tabIndex={active === t.id ? 0 : -1}
+                onClick={() => onSelect(t.id)}
+                onKeyDown={(e) => {
+                  if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+                    e.preventDefault();
+                    const idx = tabs.findIndex(x => x.id === active);
+                    const next = e.key === 'ArrowLeft' ? idx - 1 : idx + 1;
+                    onSelect(tabs[(next + tabs.length) % tabs.length].id);
+                  }
+                }}
+                className={active === t.id ? 'on' : ''}>
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+```
+
+## Bonsai 예시 (제안 패턴 — 향후 적용)
+
+```ocaml
+let tablist ~tabs ~active ~on_select ~label =
+  Vdom.Node.div
+    ~attrs:[ Style.tablist
+           ; Attr.role "tablist"
+           ; Attr.create "aria-label" label ]
+    (List.map tabs ~f:(fun (id, label) ->
+      let selected = String.equal id active in
+      Vdom.Node.button
+        ~attrs:[ Attr.role "tab"
+               ; Attr.create "aria-selected" (Bool.to_string selected)
+               ; Attr.create "aria-controls" ("tabpanel-" ^ id)
+               ; Attr.tabindex (if selected then 0 else -1)
+               ; Attr.on_click (fun _ -> on_select id) ]
+        [ Vdom.Node.text label ]))
+```
+
+## 키보드 동작 (필수)
+
+| Key | 동작 |
+|-----|------|
+| `←` `→` | 이전/다음 탭으로 이동 + 자동 선택 |
+| `Home` | 첫 탭 |
+| `End` | 마지막 탭 |
+| `Enter` `Space` | 명시적 활성화 (자동 선택 없는 모드일 때) |
+
+**Roving tabindex**: 탭 그룹 전체가 Tab 키 1번에 진입, 그 후 ←→로 이동. 비활성 탭의 `tabIndex={-1}` 필수.
+
+## Screen reader 기대값
+
+| SR | Announcement |
+|----|--------------|
+| VoiceOver | "Activity, tab, selected, 1 of 4, tab list, Keeper inspector views" |
+| NVDA | "Keeper inspector views, tab list, Activity tab, selected, 1 of 4" |
+
+## Antipatterns
+
+- ❌ 모든 탭이 `tabIndex={0}` — Tab 키 N번에 모든 탭 통과 (roving 깨짐)
+- ❌ `role="tab"` 부모가 `role="tablist"`가 아닌 경우 — 탭 그룹 식별 불가
+- ❌ `aria-selected` 없이 visual class만 — SR 사용자가 활성 탭 모름
+- ❌ Arrow key 없이 click만 — 키보드 사용자에게 비효율적
+
+## 관련 패턴
+
+- 단일 선택 (라디오) → `radiogroup.md` (tab과 다름 — radio는 form value, tab은 view switch)
+- 토글 버튼 → `aria-pressed` (별도 catalog 항목 없음)
+- 페이지 전환 → `aria-current="page"`

--- a/dashboard_bonsai/README.md
+++ b/dashboard_bonsai/README.md
@@ -6,6 +6,14 @@ Jane Street **Bonsai** (OCaml + js_of_ocaml) 기반 masc-mcp 대시보드 island
 - **Preact**: `/dashboard/*` (기존)
 - **Bonsai**: `/dashboard/b/*` (이 디렉토리)
 
+## Design system SSOT
+
+본 surface는 [`../dashboard/design-system/SPEC.md`](../dashboard/design-system/SPEC.md)의 canonical design system을 따릅니다.
+
+- Token vocabulary (raw/semantic/role) 및 5 named theme variants(`dark-fantasy`/`cyberpunk`/`terminal`/`parchment`/`paper`)는 SPEC §3, §4에 정의.
+- ARIA 패턴(region · list · tablist · radiogroup · log · dialog)은 [`../dashboard/design-system/patterns/a11y/`](../dashboard/design-system/patterns/a11y/)에 JSX + Bonsai 예시로 카탈로그화.
+- bonsai 자체 raw token은 점진적으로 SPEC canonical로 정렬 중. 새 token/패턴 추가는 SPEC PR 선행.
+
 ## 현재 상태 (Phase 0 ~ 1 진행)
 
 - `/dashboard/b/hello` — Bonsai 부트 확인용 (logs_view 전체 렌더)


### PR DESCRIPTION
## Summary

PR-S3 of the design system definition trilogy (#10459 SPEC + #10471 tokens.css + 본 PR catalog).

SPEC v0.1 §5에 정의된 6 ARIA 패턴을 실제 catalog 파일로 기술. JSX(`dashboard/`) + Bonsai(`dashboard_bonsai/`) 예시 동시 제공. 양쪽 README에 SPEC.md 링크 추가.

본 PR은 **순수 문서**. 코드 변경 0건. 시각 회귀 0.

## 신규 카탈로그

| 파일 | 라인 | 패턴 contract |
|------|------|---------------|
| `patterns/a11y/region.md` | 67 | Named landmark — `aria-label` 필수, interactive role과 충돌 금지 |
| `patterns/a11y/list.md` | 78 | Homogeneous collection — orphan listitem 금지, 모든 항목 라벨 차별화 |
| `patterns/a11y/tablist.md` | 109 | Content switcher — roving tabindex (활성 0, 비활성 -1), Arrow Left/Right + Home/End |
| `patterns/a11y/radiogroup.md` | 105 | Single-choice form — `aria-checked` vs `selected` vs `pressed` 비교 |
| `patterns/a11y/log.md` | 94 | Time-sequenced append — `aria-live="polite"` vs `assertive` |
| `patterns/a11y/dialog.md` | 112 | Modal — focus trap 의무, Esc 닫기, trigger element로 focus 복귀 |

각 파일 구조: 사용 시점 → 사용하지 말 것 → 필수 attribute → JSX 예시(cb-group-* 발췌) → Bonsai 예시(`Attr.role` + `Attr.create`) → 키보드 동작 → screen reader 기대값(VoiceOver + NVDA) → Antipatterns → 관련 패턴 cross-link.

## README 갱신

- `dashboard/design-system/README.md` — 상단에 "SSOT documents" 섹션 추가, SPEC.md + patterns/a11y/ link
- `dashboard_bonsai/README.md` — "Design system SSOT" 섹션 추가, 양쪽 surface가 같은 SPEC을 따른다는 governance 메시지

## Stack 관계

본 PR은 **#10459 (SPEC v0.1)** 머지 후 정합. SPEC §5에서 `patterns/a11y/<name>.md` 경로를 참조하므로 SPEC이 먼저 main에 있어야 일관성. SPEC 머지 후 본 PR base를 main으로 변경 + ready 가능.

## Out of scope (후속 PR)

- 카탈로그에 등재된 Bonsai "제안 패턴"(예: `KeeperTabs` Bonsai 변환)을 실제 `dashboard_bonsai/src/`에 적용 — bonsai a11y 마이그레이션 plan
- `aria-pressed` 토글 패턴, `role="grid"` 등 추가 패턴 — SPEC v0.2

## Test plan

- [x] 6 catalog 파일 신규 작성 (565줄 total)
- [x] 양쪽 README에 SPEC.md 링크 추가
- [ ] (사용자) catalog의 JSX 예시가 main의 cb-group-*.jsx와 일치하는지 spot check
- [ ] (사용자) Bonsai 예시 코드가 syntactic하게 valid한지 spot check (적용 시점에 정합)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
