### PR TITLE
perf(string): consolidate two more contains_ci forks onto String_util SSOT

### DIFF
--- a/lib/autoresearch_knowledge.ml
+++ b/lib/autoresearch_knowledge.ml
@@ -135,18 +135,15 @@ let load_all_findings ~base_path () : finding list =
            Log.Keeper.warn "Skipping malformed finding: %s" msg;
            None)
 
+(* Empty needle preserves the legacy "matches all" semantic; non-empty
+   matching delegates to [String_util.contains_substring_ci]. The
+   helper is misleadingly named — the body was case-sensitive — but
+   the caller in [search_findings] already lowercases both sides, so
+   the SSOT (which does inline byte-wise lowercasing) is a drop-in
+   replacement. Future cleanup: drop the upstream pre-lowering. *)
 let contains_ci ~needle haystack =
-  let nlen = String.length needle in
-  let hlen = String.length haystack in
-  if nlen = 0 then true
-  else if nlen > hlen then false
-  else
-    let rec scan i =
-      if i + nlen > hlen then false
-      else if String.sub haystack i nlen = needle then true
-      else scan (i + 1)
-    in
-    scan 0
+  String.length needle = 0
+  || String_util.contains_substring_ci haystack needle
 
 let rec take n = function
   | [] -> []

--- a/lib/gh_exit_class.ml
+++ b/lib/gh_exit_class.ml
@@ -20,20 +20,14 @@ type rule = {
   class_ : t;
 }
 
+(* Empty needle preserves the legacy "matches all" semantic; non-empty
+   matching delegates to [String_util.contains_substring_ci], which
+   scans byte-wise with inline [Char.lowercase_ascii] and avoids the
+   two [String.lowercase_ascii] allocations plus per-position
+   [String.sub]. *)
 let contains_ci ~haystack ~needle =
-  let h = String.lowercase_ascii haystack in
-  let n = String.lowercase_ascii needle in
-  let hl = String.length h in
-  let nl = String.length n in
-  if nl = 0 then true
-  else if nl > hl then false
-  else
-    let rec scan i =
-      if i + nl > hl then false
-      else if String.sub h i nl = n then true
-      else scan (i + 1)
-    in
-    scan 0
+  String.length needle = 0
+  || String_util.contains_substring_ci haystack needle
 
 (* Default rule table. Ordered: most-specific first.
 


### PR DESCRIPTION
## Why

Following #10468 (contains_casefold consolidation), two more forks of the same hand-rolled scan remained in the tree:

| Module | Form | Notes |
|---|---|---|
| \`lib/gh_exit_class.ml\` | lowercased both sides upfront + per-position \`String.sub\` | Wasteful but cold path (gh CLI exit-class classification). |
| \`lib/autoresearch_knowledge.ml\` | named \`contains_ci\` but body was case-sensitive | Caller pre-lowered both sides to compensate. |

## What

Both delegate to \`String_util.contains_substring_ci\`, preserving the local \"empty needle matches all\" semantic with an explicit guard.

For \`autoresearch_knowledge\`, the caller in \`search_findings\` still pre-lowers both \`query\` and the joined haystack — that's now a no-op overhead (\`Char.lowercase_ascii\` on already-lowercase ASCII is identity); a separate PR can drop the redundant pre-lowering.

Net: +15 / -24.

## Verify

- \`dune build @check\` passes.
- \`gh_exit_class\` callers unchanged (cold path).
- \`autoresearch_knowledge.search_findings\` semantics unchanged in practice (caller-lowered haystack + caller-lowered needle was already CI; SSOT is too).

## Risk

Low. Previously identical empty-needle semantic preserved by guard. SSOT does CI matching by design, so the misleading helper name is now accurate.