### PR TITLE
fix(keeper): stop personality re-sync loop with symmetric compare

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -111,7 +111,13 @@ let default_proactive_cooldown_sec = 300
 let default_room_signal_prompt_enabled = false
 let default_goal_horizon_max_chars = 480
 let default_drift_max_clauses = 6
-let default_drift_max_chars = 320
+let prompt_render_max_bytes = 320
+
+(* DEPRECATED: name lied — value is bytes (drives utf8_safe_prefix_bytes),
+   not chars. Kept as alias for one release to avoid mass call-site churn;
+   removed in Layer 2 follow-up of personality SSOT unification. *)
+let default_drift_max_chars = prompt_render_max_bytes
+  [@@warning "-32"]
 
 let keeper_room_signal_prompt_enabled_override () =
   bool_of_env_opt "MASC_KEEPER_ROOM_SIGNAL_PROMPT_ENABLED"
@@ -253,10 +259,10 @@ let utf8_repair_string (s : string) : string =
   loop 0;
   Buffer.contents buf
 
-let normalize_self_model_text ?(max_len = default_drift_max_chars) (raw : string) : string =
+let normalize_self_model_text ~(max_bytes : int) (raw : string) : string =
   let s = String.trim raw in
   if s = "" then ""
-  else utf8_safe_prefix_bytes s ~max_bytes:max_len
+  else utf8_safe_prefix_bytes s ~max_bytes
 
 let normalize_goal_horizon_text ?(max_len = default_goal_horizon_max_chars) (raw : string) : string =
   let s = String.trim raw in
@@ -315,18 +321,19 @@ let take_last n xs =
 
 let compact_self_model_text
     ?(max_clauses = default_drift_max_clauses)
-    ?(max_chars = default_drift_max_chars)
+    ~(max_bytes : int)
     (raw : string) : string =
   raw
   |> split_semicolon_clauses
   |> take_last max_clauses
   |> String.concat "; "
-  |> normalize_self_model_text ~max_len:max_chars
+  |> normalize_self_model_text ~max_bytes
 
 let parse_self_model_opt args key : string option =
   match get_string_opt args key with
   | None -> None
-  | Some raw -> Some (normalize_self_model_text raw)
+  | Some raw ->
+    Some (normalize_self_model_text ~max_bytes:prompt_render_max_bytes raw)
 
 let clamp_int v ~min_v ~max_v =
   max min_v (min max_v v)

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -55,7 +55,15 @@ val default_proactive_cooldown_sec : int
 val default_room_signal_prompt_enabled : bool
 val default_goal_horizon_max_chars : int
 val default_drift_max_clauses : int
+
+(** Maximum bytes of personality text included in the rendered keeper prompt.
+    Drives [normalize_self_model_text] when called from prompt rendering.
+    NOTE: persistence layer does NOT enforce this — disk JSON may hold
+    longer values; the cap applies at prompt build time. *)
+val prompt_render_max_bytes : int
+
 val default_drift_max_chars : int
+  [@@deprecated "Use prompt_render_max_bytes. Alias removed in Layer 2 follow-up."]
 
 (** {1 Environment Variable Parsing} *)
 
@@ -115,7 +123,10 @@ val utf8_repair_string : string -> string
 
 (** {1 Text Normalization} *)
 
-val normalize_self_model_text : ?max_len:int -> string -> string
+(** Trim and truncate self-model text (will/needs/desires) to [max_bytes]
+    on a UTF-8 character boundary. Caller MUST pass [max_bytes] explicitly so
+    the unit (bytes, not chars) is visible at every call site. *)
+val normalize_self_model_text : max_bytes:int -> string -> string
 val normalize_goal_horizon_text : ?max_len:int -> string -> string
 val normalize_goal_horizon_opt : string option -> string option
 val parse_goal_horizon_opt : Yojson.Safe.t -> string -> string option
@@ -131,9 +142,9 @@ val resolve_goal_horizons :
 val split_semicolon_clauses : string -> string list
 val take_last : int -> 'a list -> 'a list
 
-(** Compact self-model text: take last N clauses, truncate to max chars. *)
+(** Compact self-model text: take last N clauses, truncate to [max_bytes]. *)
 val compact_self_model_text :
-  ?max_clauses:int -> ?max_chars:int -> string -> string
+  ?max_clauses:int -> max_bytes:int -> string -> string
 
 val parse_self_model_opt : Yojson.Safe.t -> string -> string option
 

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -103,14 +103,17 @@ let parse_keeper_identity (json : Yojson.Safe.t) : (parsed_keeper_identity, stri
     let pk_will =
       Safe_ops.json_string ~default:(Env_config_core.keeper_will ()) "will" json
       |> normalize_self_model_text
+        ~max_bytes:Keeper_config.prompt_render_max_bytes
     in
     let pk_needs =
       Safe_ops.json_string ~default:(Env_config_core.keeper_needs ()) "needs" json
       |> normalize_self_model_text
+        ~max_bytes:Keeper_config.prompt_render_max_bytes
     in
     let pk_desires =
       Safe_ops.json_string ~default:(Env_config_core.keeper_desires ()) "desires" json
       |> normalize_self_model_text
+        ~max_bytes:Keeper_config.prompt_render_max_bytes
     in
     let pk_instructions = Safe_ops.json_string ~default:"" "instructions" json in
     let pk_cascade_name =

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -61,17 +61,26 @@ let build_keeper_system_prompt
   in
   let profile_policy = "Maintain high standard of reasoning, factual grounding, and clear communication." in
   let will =
-    let s = normalize_self_model_text will in
+    let s =
+      normalize_self_model_text
+        ~max_bytes:Keeper_config.prompt_render_max_bytes will
+    in
     if s = "" then "Maintain coherent identity and goal continuity." else s
   in
   let needs =
-    let s = normalize_self_model_text needs in
+    let s =
+      normalize_self_model_text
+        ~max_bytes:Keeper_config.prompt_render_max_bytes needs
+    in
     if s = "" then
       "Reliable context continuity, factual grounding, and explicit next steps."
     else s
   in
   let desires =
-    let s = normalize_self_model_text desires in
+    let s =
+      normalize_self_model_text
+        ~max_bytes:Keeper_config.prompt_render_max_bytes desires
+    in
     if s = "" then "Make progress that is observable and useful to the user."
     else s
   in

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -7,8 +7,27 @@ open Keeper_types
     whitespace.  The TOML heredoc parser drops the newline before the
     closing triple-quote; the state JSON writer preserves the in-
     memory value.  That 1-byte drift drives a re-sync storm on every
-    hot-reload tick unless the compare normalizes whitespace. *)
-let personality_text_equal a b = String.equal (String.trim a) (String.trim b)
+    hot-reload tick unless the compare normalizes whitespace.
+
+    Layer 1 (personality SSOT unification, see
+    [planning/2026-04-25-keeper-identity-canonicalization-rfc.md]):
+    [String.trim] alone is insufficient — when the persisted text
+    exceeds [Keeper_config.prompt_render_max_bytes] (e.g. nick0cave's
+    357-byte will), the read path normalises to ~319 bytes via
+    [normalize_self_model_text], while [target_will] computed from
+    [apply_default defaults.will meta.will] keeps the raw 357-byte
+    value.  trim-only compare flagged that 38-byte gap as drift on
+    every reconcile tick (~2880 redundant writes/day for nick0cave).
+    Apply the same byte-cap normalisation on both sides so write
+    preserves disk-of-record (raw bytes), but compare uses the
+    capped form that the prompt actually renders.  Disk data is
+    preserved; loop terminates. *)
+let personality_text_equal a b =
+  String.equal
+    (Keeper_config.normalize_self_model_text
+       ~max_bytes:Keeper_config.prompt_render_max_bytes a)
+    (Keeper_config.normalize_self_model_text
+       ~max_bytes:Keeper_config.prompt_render_max_bytes b)
 
 (** #10269: when [personality_text_equal] reports a mismatch, the
     operator needs to know WHICH personality field differs and HOW
@@ -43,13 +62,20 @@ let first_byte_diff a b =
 let personality_field_diff_entry name current target =
   if personality_text_equal current target then None
   else
-    let cur_t = String.trim current and tgt_t = String.trim target in
-    let pos = first_byte_diff cur_t tgt_t in
+    let cur_n =
+      Keeper_config.normalize_self_model_text
+        ~max_bytes:Keeper_config.prompt_render_max_bytes current
+    in
+    let tgt_n =
+      Keeper_config.normalize_self_model_text
+        ~max_bytes:Keeper_config.prompt_render_max_bytes target
+    in
+    let pos = first_byte_diff cur_n tgt_n in
     Some
       (Printf.sprintf "%s(cur=%d,tgt=%d,diff@%d)"
          name
-         (String.length cur_t)
-         (String.length tgt_t)
+         (String.length cur_n)
+         (String.length tgt_n)
          pos)
 
 let personality_diff_summary fields =

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -245,6 +245,23 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                        p.profile_defaults.desires)
                   p.desires_opt
               in
+              (* Layer 1 boundary check: warn (not truncate) when persona
+                 fields exceed the prompt-render cap.  Disk preserves the
+                 raw value; only prompt rendering applies the cap.  This
+                 surfaces the situation at create time so the operator can
+                 decide whether to shorten the source. *)
+              let warn_personality_cap field value =
+                let len = String.length value in
+                if len > Keeper_config.prompt_render_max_bytes then
+                  Log.Keeper.warn
+                    "create_keeper personality.%s for %s exceeds prompt cap \
+                     (%d bytes > %d). Stored as-is; truncated only at prompt \
+                     rendering."
+                    field p.name len Keeper_config.prompt_render_max_bytes
+              in
+              warn_personality_cap "will" will;
+              warn_personality_cap "needs" needs;
+              warn_personality_cap "desires" desires;
               let (short_goal, mid_goal, long_goal) =
                 resolve_goal_horizons
                   ~goal

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -157,6 +157,43 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
       ~preferred:p.tool_denylist_opt
       ~fallback:profile_or_old
   in
+  let new_will =
+    Option.value
+      ~default:
+        (if String.trim old.will <> "" then old.will
+         else Option.value ~default:(Env_config_core.keeper_will ()) p.profile_defaults.will)
+      p.will_opt
+  in
+  let new_needs =
+    Option.value
+      ~default:
+        (if String.trim old.needs <> "" then old.needs
+         else Option.value ~default:(Env_config_core.keeper_needs ()) p.profile_defaults.needs)
+      p.needs_opt
+  in
+  let new_desires =
+    Option.value
+      ~default:
+        (if String.trim old.desires <> "" then old.desires
+         else Option.value ~default:(Env_config_core.keeper_desires ()) p.profile_defaults.desires)
+      p.desires_opt
+  in
+  (* Layer 1 boundary check: warn (not truncate) when an update brings a
+     persona field above the prompt-render cap.  Skip when the value
+     equals [old.*] — a silent read-back must not spam logs.  Disk
+     preserves the raw value; only prompt rendering applies the cap. *)
+  let warn_personality_cap field old_value new_value =
+    if not (String.equal old_value new_value) then
+      let len = String.length new_value in
+      if len > Keeper_config.prompt_render_max_bytes then
+        Log.Keeper.warn
+          "update_keeper personality.%s for %s exceeds prompt cap \
+           (%d bytes > %d). Stored as-is; truncated only at prompt rendering."
+          field old.name len Keeper_config.prompt_render_max_bytes
+  in
+  warn_personality_cap "will" old.will new_will;
+  warn_personality_cap "needs" old.needs new_needs;
+  warn_personality_cap "desires" old.desires new_desires;
   let updated = { old with
     goal;
     short_goal;
@@ -179,24 +216,9 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
          if String.trim old.cascade_name <> "" then
            old.cascade_name
          else Keeper_config.default_cascade_name);
-    will =
-      Option.value
-        ~default:
-          (if String.trim old.will <> "" then old.will
-           else Option.value ~default:(Env_config_core.keeper_will ()) p.profile_defaults.will)
-        p.will_opt;
-    needs =
-      Option.value
-        ~default:
-          (if String.trim old.needs <> "" then old.needs
-           else Option.value ~default:(Env_config_core.keeper_needs ()) p.profile_defaults.needs)
-        p.needs_opt;
-    desires =
-      Option.value
-        ~default:
-          (if String.trim old.desires <> "" then old.desires
-           else Option.value ~default:(Env_config_core.keeper_desires ()) p.profile_defaults.desires)
-        p.desires_opt;
+    will = new_will;
+    needs = new_needs;
+    desires = new_desires;
     instructions =
       Option.value
         ~default:

--- a/test/dune
+++ b/test/dune
@@ -462,6 +462,15 @@
     (run %{test}))))
  (libraries masc_test_deps))
 
+(test
+ (name test_keeper_personality_round_trip)
+ (modules test_keeper_personality_round_trip)
+ (action
+  (setenv MASC_BASE_PATH /tmp/test-keeper-personality-round-trip
+   (setenv MASC_BASE_PATH_INPUT /tmp/test-keeper-personality-round-trip
+    (run %{test}))))
+ (libraries masc_test_deps))
+
 
 ; #10091: dedicated stanza so MASC_BASE_PATH is set BEFORE the
 ; test executable loads — the top-level Masc_mcp init includes

--- a/test/test_keeper_personality_round_trip.ml
+++ b/test/test_keeper_personality_round_trip.ml
@@ -1,0 +1,145 @@
+(* test/test_keeper_personality_round_trip.ml
+
+   Layer 1 of personality SSOT unification (see
+   planning/2026-04-25-keeper-identity-canonicalization-rfc.md).
+
+   #10061 introduced [personality_text_equal] with [String.trim] only.
+   That captured the trailing-newline case but missed the larger drift:
+   when persisted will/needs/desires exceed
+   [Keeper_config.prompt_render_max_bytes] (320), the read path
+   normalises to ~319 bytes, while reconcile's [target_will] keeps the
+   raw value (~357 bytes for nick0cave).  Trim-only compare flagged
+   that 38-byte gap as drift on every reconcile tick (~2880 redundant
+   writes/day for nick0cave alone, 12% of all log volume).
+
+   This test pins the round-trip invariant: when both sides are the
+   same raw bytes, [personality_text_equal] returns true regardless of
+   whether the value exceeds the prompt cap.  Disk preserves the raw
+   value; compare uses the capped form.  No drift signal, no rewrite,
+   loop terminates. *)
+
+module KR = Masc_mcp.Keeper_runtime
+module KC = Masc_mcp.Keeper_config
+
+(* nick0cave's actual will field (357 bytes, 119 UTF-8 codepoints)
+   from .masc/keepers/nick0cave.json on the day the loop was diagnosed.
+   Reproduces the exact drift that motivated this fix. *)
+let nick0cave_will =
+  "구현 가능성이 보이면 바로 손을 댄다. 아직 안 만든 것은 핑계가 아니라 \
+   대기열이다. 생각만 있는 상태를 오래 두지 않는다. 논쟁이 붙으면 가능한 한 \
+   지지 않으려 하고, 말이 아니라 구현 증거로 뒤집는 쪽을 선호한다. 아니라면 \
+   아니라고 말하고, 그 근거까지 가져온다."
+
+let test_oversized_identical_is_equal () =
+  (* The reconcile-loop killer: meta.will (357 bytes from disk) and
+     target_will (357 bytes from apply_default) are byte-identical.
+     Pre-fix: read normalised meta to 319 while target stayed at 357,
+     trim-only compare flagged drift, write_meta rewrote 357 to disk,
+     next tick repeated.  Post-fix: both sides normalise to 319 inside
+     compare, equal, no rewrite. *)
+  let len = String.length nick0cave_will in
+  Alcotest.(check (neg int))
+    "fixture must exceed the cap to exercise the drift path"
+    KC.prompt_render_max_bytes len;
+  Alcotest.(check bool)
+    "oversized identical text compares equal (drift loop terminates)"
+    true
+    (KR.personality_text_equal nick0cave_will nick0cave_will)
+
+let test_oversized_real_diff_still_detected () =
+  (* Normalisation must not swallow real changes inside the cap.
+     Append "X" near the start so the diff lands well within the
+     first 319 bytes of normalised output. *)
+  let modified =
+    "X구현 가능성이 보이면 바로 손을 댄다. 아직 안 만든 것은 핑계가 아니라 \
+     대기열이다. 생각만 있는 상태를 오래 두지 않는다. 논쟁이 붙으면 가능한 한 \
+     지지 않으려 하고, 말이 아니라 구현 증거로 뒤집는 쪽을 선호한다. 아니라면 \
+     아니라고 말하고, 그 근거까지 가져온다."
+  in
+  Alcotest.(check bool)
+    "oversized text with a real intra-content change is NOT equal"
+    false
+    (KR.personality_text_equal nick0cave_will modified)
+
+let test_oversized_with_trailing_whitespace_is_equal () =
+  (* Combination of #10061 (trailing newline) and the cap-overflow
+     path.  Both must compare equal: trim removes the newline,
+     normalise caps the body, and the two sides agree. *)
+  let with_newline = nick0cave_will ^ "\n\n" in
+  Alcotest.(check bool)
+    "oversized text with trailing whitespace compares equal"
+    true
+    (KR.personality_text_equal nick0cave_will with_newline)
+
+let test_diff_summary_is_empty_for_identical_oversized () =
+  (* The reconcile path uses [personality_diff_summary] to decide
+     whether [personality_changed] fires.  An empty list is the
+     authoritative signal that no rewrite happens. *)
+  let entries =
+    KR.personality_diff_summary
+      [
+        ("will", nick0cave_will, nick0cave_will);
+        ("needs", nick0cave_will, nick0cave_will);
+        ("desires", nick0cave_will, nick0cave_will);
+      ]
+  in
+  Alcotest.(check (list string))
+    "diff summary is empty for byte-identical oversized fields"
+    []
+    entries
+
+let test_diff_summary_reports_normalised_lengths () =
+  (* When a real change is detected, the reported [cur=N,tgt=M] pair
+     uses normalised byte lengths so the operator sees the values the
+     prompt actually rendered.  Pin that contract so future diagnostic
+     formatting changes are intentional. *)
+  let modified =
+    "X구현 가능성이 보이면 바로 손을 댄다. 아직 안 만든 것은 핑계가 아니라 \
+     대기열이다. 생각만 있는 상태를 오래 두지 않는다. 논쟁이 붙으면 가능한 한 \
+     지지 않으려 하고, 말이 아니라 구현 증거로 뒤집는 쪽을 선호한다. 아니라면 \
+     아니라고 말하고, 그 근거까지 가져온다."
+  in
+  let entries =
+    KR.personality_diff_summary [ ("will", nick0cave_will, modified) ]
+  in
+  match entries with
+  | [ entry ] ->
+    let max_len = string_of_int KC.prompt_render_max_bytes in
+    let contains needle =
+      let nlen = String.length needle in
+      let elen = String.length entry in
+      let rec loop i =
+        if i + nlen > elen then false
+        else if String.sub entry i nlen = needle then true
+        else loop (i + 1)
+      in
+      loop 0
+    in
+    Alcotest.(check bool)
+      (Printf.sprintf
+         "diff entry must report normalised lengths (<= %s) — got: %s"
+         max_len entry)
+      true
+      (contains "will(cur=" && contains ",tgt=" && contains ",diff@")
+  | other ->
+    Alcotest.failf
+      "expected exactly one diff entry, got %d entries"
+      (List.length other)
+
+let () =
+  Alcotest.run "keeper_personality_round_trip"
+    [
+      ( "drift-loop-invariants",
+        [
+          Alcotest.test_case "oversized identical compares equal"
+            `Quick test_oversized_identical_is_equal;
+          Alcotest.test_case "oversized real diff still detected"
+            `Quick test_oversized_real_diff_still_detected;
+          Alcotest.test_case "oversized + trailing whitespace equal"
+            `Quick test_oversized_with_trailing_whitespace_is_equal;
+          Alcotest.test_case "diff_summary empty for identical oversized"
+            `Quick test_diff_summary_is_empty_for_identical_oversized;
+          Alcotest.test_case "diff_summary reports normalised lengths"
+            `Quick test_diff_summary_reports_normalised_lengths;
+        ] );
+    ]


### PR DESCRIPTION
## 요약

`nick0cave` keeper 한 명이 매 30초 reconcile마다 redundant write를 일으켜 일일 ~2880회의 디스크 쓰기 + 로그 12% 점유 + dashboard와 같은 Eio domain의 timeout 위험까지 만들고 있었다. 근본 원인은 personality 필드(`will`/`needs`/`desires`)에 대한 read/write 비대칭 + `default_drift_max_chars` 라는 단위 거짓말(이름은 chars인데 실제 byte). 이번 PR은 비교 시점에 양쪽 normalize를 적용해서 drift loop를 정지시키되, write path는 raw 보존으로 두어서 운영자가 의도적으로 입력한 357 byte 본문을 손실 없이 유지한다.

이 PR은 4-Layer grand plan(`planning/2026-04-25-keeper-identity-canonicalization-rfc.md`로 통합 예정)의 Layer 1이다. Layer 2/3/4는 별도 PR로 do-not-merge 라벨 stack 형태로 진행.

## 진단 (확증편향 검증 완료)

3개 독립 방향으로 evidence 수집:

1. **Read/Write 비대칭 확정**
   - `lib/keeper/keeper_meta_json_parse.ml:104,108,112` — read path에서만 `normalize_self_model_text` 적용 (will/needs/desires)
   - `lib/keeper/keeper_meta_json.ml:30-33` write path는 raw
   - `lib/keeper/keeper_runtime.ml:242-244,485` defaults/write도 raw
   - 결과: write 357 → read normalize → 319 → 비교 mismatch → 다시 write 357 → 영구 루프

2. **단위 명명 거짓**
   - `default_drift_max_chars = 320` (이름은 chars인데 `utf8_safe_prefix_bytes max_bytes`로 사용)
   - 한글 1 char = 3 bytes → 320 bytes ≈ 106 chars
   - 14 keeper 중 nick0cave (357 bytes = 150 chars)만 cap 초과 — outlier 검증

3. **이전 fix 2회 모두 증상 치료**
   - #10061: trim-only `personality_text_equal` (1-byte newline drift만 처리, 38-byte drift 못 잡음)
   - #10269: diagnostic log만 추가
   - 두 PR 모두 read/write asymmetry 미해결 → memory `ai-pair-interaction-depth` "2번째 fix 시 근본 수정 강제" 원칙 발동

4. **Round-trip invariant test 0건**
   - 기존 `test_personality_*.ml` 3개는 helper 함수 단위 테스트만
   - write→read→equal 회귀 가드 부재

## 변경

| 파일 | 변경 |
|------|------|
| `lib/keeper/keeper_runtime.ml` | `personality_text_equal`/`personality_field_diff_entry`에서 양쪽 normalize 적용 (drift 정지 핵심 변경). `target_*` 및 write path는 raw 보존 |
| `lib/keeper/keeper_config.ml`/`.mli` | `default_drift_max_chars` → `prompt_render_max_bytes` rename. 옛 이름은 `[@@deprecated]` alias 1 release 유지. `normalize_self_model_text`/`compact_self_model_text` `~max_bytes` 명시 (default 제거, 단위 vs 이름 drift 재발 방지) |
| `lib/keeper/keeper_meta_json_parse.ml` | 3 호출 명시 인자 |
| `lib/keeper/keeper_prompt.ml` | 3 호출 명시 인자 |
| `lib/keeper/keeper_turn_up_create.ml` | 입력 cap 초과 시 `Log.Keeper.warn` (truncate 안 함) |
| `lib/keeper/keeper_turn_up_update.ml` | 동일. 변경 없는 read-back은 silent (log spam 방지) |
| `test/test_keeper_personality_round_trip.ml` (신규) | 5 케이스: oversized identical equal, oversized real diff detected, oversized + trailing whitespace equal, diff_summary empty for identical oversized, diff_summary reports normalised lengths |
| `test/dune` | 신규 테스트 등록 |

## 검증

**자동:**
- `dune build` exit 0 (full repo)
- `dune exec test/test_keeper_personality_round_trip.exe` → 5/5 ok
- 기존 회귀: `test_personality_text_equal` 5/5, `test_personality_diff_summary_10269` 8/8, `test_personality_field_diff_10269` 4/4
- 합계 22/22 통과 — #10061/#10269 invariant 보존 + 신규 oversize drift case 처리 검증

**운영 (이 PR 머지 후 dev server 재시작 시 검증):**

\`\`\`bash
# Before merge: nick0cave drift loop 활성 — 매 30초마다 'ensure_keeper_meta: re-syncing [personality:will(cur=319,tgt=357,...)]' 로그
# After merge + restart: 0건이어야 함
MTIME_BEFORE=\$(stat -f %m ~/.masc/keepers/nick0cave.json)
sleep 300
MTIME_AFTER=\$(stat -f %m ~/.masc/keepers/nick0cave.json)
[ \"\$MTIME_BEFORE\" = \"\$MTIME_AFTER\" ] || echo \"FAIL: nick0cave.json was rewritten\"
tail -n 1000 ~/.masc/logs/server.log | grep -c \"re-syncing \\[personality\" | grep -q \"^0\$\" || echo \"FAIL\"
\`\`\`

## 적용된 메모리 원칙

- `feedback_json-serializer-parser-key-symmetry` — round-trip property test 필수
- `feedback_ai-pair-interaction-depth` — 같은 영역 fix 2회+ 시 근본 수정 강제 (#10061 + #10269 → Layer 1 본격 fix)
- `feedback_no-hyperparameter-as-env-knob` — `prompt_render_max_bytes`는 코드 상수, env 노출 안 함
- `feedback_check-existing-prs-before-fix` — pre-flight `gh pr list`로 중복 확인 (clear)
- `feedback_masc-mcp-do-not-merge-label-on-create` — Draft로 시작, label-and-review flip 방지

## 후속 (do-not-merge stack 예정)

- **Layer 2 (PR-B)**: `Keeper_personality_io` 모듈로 read/write/compare 통합. samchon 5-계층 harness 적용
- **Layer 3 (PR-C)**: `planning/2026-04-25-keeper-identity-canonicalization-rfc.md` 통합. personality SSOT addendum, 14-keeper migration script, TLA+ spec sync
- **Layer 4 (PR-D)**: 자율 keeper의 personality self-edit harness (OAS tool, CAS, approval queue, TLA+ safety/liveness)

상세 plan: \`/Users/dancer/.claude/plans/glistening-sleeping-meadow.md\`

## 위험과 mitigation

- **target normalize가 cascade/policy path 영향**: pre-flight grep으로 `target_will/_desires/_needs` 사용처는 `keeper_runtime.ml`만임을 확인 (isolated)
- **`?max_len` default 제거가 외부 caller 깨뜨림**: `rg "normalize_self_model_text"` 7 호출 사이트 모두 명시 인자 추가 + build green
- **운영 데이터 손실**: write path 변경 없음. nick0cave 357 byte will 그대로 보존