### PR TITLE
feat(config): scaffold Env_config_sandbox SSOT (#10426 P2a sandbox config)

### DIFF
--- a/lib/config/dune
+++ b/lib/config/dune
@@ -12,6 +12,7 @@
    env_config_keeper
    env_config_oas_bridge
    env_config_runtime
+   env_config_sandbox
    env_config_snapshot
    feature_flag_registry
    masc_network_defaults

--- a/lib/config/env_config_sandbox.ml
+++ b/lib/config/env_config_sandbox.ml
@@ -1,0 +1,421 @@
+(** Env_config_sandbox — sandbox configuration SSOT.
+
+    See {!Env_config_sandbox} module doc in the .mli for the full
+    rationale.  This .ml stays as close to the original sources as
+    possible:
+
+    - Same env vars and same defaults as
+      {!Env_config_keeper.KeeperSandbox},
+      {!Env_config_keeper.DockerPlayground}, and the bucket
+      timeouts in [lib/keeper/keeper_exec_shell.ml].
+    - Fresh read per call (matching the {!Env_config_keeper} style);
+      callers are not yet migrated, so this co-existence does not
+      drift.
+    - The four currently-hardcoded values
+      ([Cleanup.managed_sleep_sec], [Preflight.min_timeout_sec],
+      [Preflight.max_timeout_sec], [Shell_timeout.Cleanup_rm]) are
+      exposed as getters that return the historical literal —
+      enabling future env-override without P2a behavior change. *)
+
+open Env_config_core
+
+(* --------------------------------------------------------------- *)
+(* Hardening                                                       *)
+(* --------------------------------------------------------------- *)
+
+module Hardening = struct
+  let hard_mode () =
+    get_bool ~default:false "MASC_KEEPER_SANDBOX_HARD_MODE"
+
+  let pids_limit () =
+    max 32 (get_int ~default:128 "MASC_KEEPER_SANDBOX_PIDS_LIMIT")
+
+  let nofile_limit () =
+    max 1024 (get_int ~default:245_760 "MASC_KEEPER_SANDBOX_NOFILE_LIMIT")
+
+  let memory () =
+    get_string ~default:"2g" "MASC_KEEPER_SANDBOX_MEMORY"
+
+  let tmpfs_size () =
+    get_string ~default:"256m" "MASC_KEEPER_SANDBOX_TMPFS_SIZE"
+
+  let relax_fs () =
+    get_bool ~default:false "MASC_KEEPER_SANDBOX_RELAX_FS"
+
+  let read_only_rootfs_args () =
+    if relax_fs () then [] else [ "--read-only" ]
+
+  let tmpfs_mount () =
+    let exec_suffix = if relax_fs () then "" else ",noexec" in
+    Printf.sprintf "/tmp:rw,nosuid,nodev%s,size=%s"
+      exec_suffix (tmpfs_size ())
+
+  let seccomp_profile () =
+    get_string ~default:"" "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE"
+
+  let require_rootless () =
+    hard_mode ()
+    || get_bool ~default:false "MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS"
+
+  let require_userns () =
+    hard_mode ()
+    || get_bool ~default:false "MASC_KEEPER_SANDBOX_REQUIRE_USERNS"
+end
+
+(* --------------------------------------------------------------- *)
+(* Cleanup                                                         *)
+(* --------------------------------------------------------------- *)
+
+module Cleanup = struct
+  let enabled () =
+    get_bool ~default:true "MASC_KEEPER_SANDBOX_CLEANUP_ENABLED"
+
+  let stale_after_sec () =
+    float_of_int
+      (max 60
+         (get_int ~default:21_600 "MASC_KEEPER_SANDBOX_CLEANUP_STALE_AFTER_SEC"))
+
+  let interval_sec () =
+    float_of_int
+      (max 10
+         (get_int ~default:300 "MASC_KEEPER_SANDBOX_CLEANUP_INTERVAL_SEC"))
+
+  (* P2c will optionally wire an env var; today the literal stands. *)
+  let managed_sleep_sec () = 3600
+end
+
+(* --------------------------------------------------------------- *)
+(* Runtime                                                         *)
+(* --------------------------------------------------------------- *)
+
+module Runtime = struct
+  let docker_image () =
+    get_string ~default:"masc-keeper-sandbox:local"
+      "MASC_KEEPER_SANDBOX_DOCKER_IMAGE"
+
+  let git_dispatch () =
+    (not (Hardening.hard_mode ()))
+    && get_bool ~default:true "MASC_KEEPER_SANDBOX_GIT_DISPATCH"
+
+  let docker_playground_enabled () =
+    get_bool ~default:false "MASC_KEEPER_DOCKER_PLAYGROUND"
+end
+
+(* --------------------------------------------------------------- *)
+(* Auth_paths                                                      *)
+(* --------------------------------------------------------------- *)
+
+module Auth_paths = struct
+  let gh_creds () =
+    if Hardening.hard_mode () then ""
+    else
+      let default =
+        match Sys.getenv_opt "HOME" with
+        | Some home -> Filename.concat home ".config/gh"
+        | None -> ""
+      in
+      get_string ~default "MASC_KEEPER_SANDBOX_GH_CREDS"
+
+  let gitconfig () =
+    if Hardening.hard_mode () then ""
+    else
+      let default =
+        match Sys.getenv_opt "HOME" with
+        | Some home -> Filename.concat home ".gitconfig"
+        | None -> ""
+      in
+      get_string ~default "MASC_KEEPER_SANDBOX_GITCONFIG"
+
+  let ssh_dir () =
+    if Hardening.hard_mode () then ""
+    else get_string ~default:"" "MASC_KEEPER_SANDBOX_SSH_DIR"
+
+  let gh_token_probe_timeout_sec () =
+    get_float ~default:2.0 "MASC_KEEPER_SANDBOX_GH_TOKEN_PROBE_TIMEOUT_SEC"
+    |> max 0.1 |> min 10.0
+end
+
+(* --------------------------------------------------------------- *)
+(* Preflight                                                       *)
+(* --------------------------------------------------------------- *)
+
+module Preflight = struct
+  let enabled () =
+    get_bool ~default:true "MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED"
+
+  (* P2c will optionally env-wire these; today they are literal-pinned
+     so callers in keeper_sandbox_runtime stay unchanged in P2a. *)
+  let min_timeout_sec () = 5.0
+  let max_timeout_sec () = 20.0
+
+  (* Read-only canonical list — see .mli for the why-not-env note. *)
+  let required_commands () =
+    [ "sh"; "bash"; "cat"; "find"; "head"; "tail"; "wc"
+    ; "git"; "gh"; "rg"; "tree"; "jq"
+    ; "python3"; "node"; "npm"; "make"; "opam"; "dune"; "ssh"
+    ]
+end
+
+(* --------------------------------------------------------------- *)
+(* Shell_timeout — typed-bucket SSOT                               *)
+(* --------------------------------------------------------------- *)
+
+module Shell_timeout = struct
+  type bucket =
+    | Io
+    | Read
+    | Git_meta
+    | Gh_min
+    | User_max
+    | Token_probe
+    | Cleanup_rm
+    | Unknown of string
+
+  let global_default_sec = 30.0
+
+  let bucket_key = function
+    | Io -> "io"
+    | Read -> "read"
+    | Git_meta -> "git_meta"
+    | Gh_min -> "gh_min"
+    | User_max -> "user_max"
+    | Token_probe -> "token_probe"
+    | Cleanup_rm -> "cleanup_rm"
+    | Unknown s -> s
+
+  let known_buckets () =
+    [ Io; Read; Git_meta; Gh_min; User_max; Token_probe; Cleanup_rm ]
+
+  let known_default_sec = function
+    | Io -> Some 30.0
+    | Read -> Some 15.0
+    | Git_meta -> Some 5.0
+    | Gh_min -> Some 15.0
+    | User_max -> Some 180.0
+    | Token_probe -> Some 2.0
+    | Cleanup_rm -> Some 5.0
+    | Unknown _ -> None
+
+  let upper_case s =
+    s
+    |> String.map (fun c ->
+         if c >= 'a' && c <= 'z' then
+           Char.chr (Char.code c - 32)
+         else if c = '-' then '_'
+         else c)
+
+  let per_bucket_env_var ~bucket =
+    Printf.sprintf "MASC_KEEPER_SHELL_TIMEOUT_%s_SEC"
+      (upper_case (bucket_key bucket))
+
+  let global_env_var = "MASC_KEEPER_SHELL_TIMEOUT_DEFAULT_SEC"
+
+  (** Empty-string env vars (used by test clearing patterns) must NOT
+      be treated as "set". *)
+  let trimmed_value_opt name =
+    match raw_value_opt name with
+    | Some v ->
+      let t = String.trim v in
+      if t = "" then None else Some t
+    | None -> None
+
+  let timeout_sec ~bucket () =
+    match bucket with
+    | Gh_min ->
+      (* Read-only floor — see .mli.  Operators MUST NOT lower this
+         via env; doing so cascades 401 retries (#8688). *)
+      15.0
+    | _ ->
+      let per_bucket_env = per_bucket_env_var ~bucket in
+      match trimmed_value_opt per_bucket_env with
+      | Some v ->
+        Safe_ops.float_of_string_with_default
+          ~default:global_default_sec v
+      | None ->
+        match known_default_sec bucket with
+        | Some d -> d
+        | None ->
+          match trimmed_value_opt global_env_var with
+          | Some v ->
+            Safe_ops.float_of_string_with_default
+              ~default:global_default_sec v
+          | None -> global_default_sec
+end
+
+(* --------------------------------------------------------------- *)
+(* Doctor / observability surface                                  *)
+(* --------------------------------------------------------------- *)
+
+(* Helper: does an env var currently exist (non-empty after trim)? *)
+let env_is_set name =
+  match Env_config_core.raw_value_opt name with
+  | Some v -> String.trim v <> ""
+  | None -> false
+
+(* Convenience builders for [{ value, source, env_var }] entries. *)
+let entry_env_overridable ~env_var (value : Yojson.Safe.t) : Yojson.Safe.t =
+  let source = if env_is_set env_var then "env" else "default" in
+  `Assoc
+    [ "value", value
+    ; "source", `String source
+    ; "env_var", `String env_var
+    ]
+
+let entry_floor (value : Yojson.Safe.t) : Yojson.Safe.t =
+  `Assoc
+    [ "value", value
+    ; "source", `String "load_bearing_floor"
+    ; "env_var", `Null
+    ]
+
+let entry_hardcoded (value : Yojson.Safe.t) : Yojson.Safe.t =
+  `Assoc
+    [ "value", value
+    ; "source", `String "hardcoded"
+    ; "env_var", `Null
+    ]
+
+let bool_v b : Yojson.Safe.t = `Bool b
+let int_v i : Yojson.Safe.t = `Int i
+let float_v f : Yojson.Safe.t = `Float f
+let string_v s : Yojson.Safe.t = `String s
+
+let raw_hardening () : Yojson.Safe.t =
+  `Assoc
+    [ "hard_mode",
+      entry_env_overridable ~env_var:"MASC_KEEPER_SANDBOX_HARD_MODE"
+        (bool_v (Hardening.hard_mode ()))
+    ; "pids_limit",
+      entry_env_overridable ~env_var:"MASC_KEEPER_SANDBOX_PIDS_LIMIT"
+        (int_v (Hardening.pids_limit ()))
+    ; "nofile_limit",
+      entry_env_overridable ~env_var:"MASC_KEEPER_SANDBOX_NOFILE_LIMIT"
+        (int_v (Hardening.nofile_limit ()))
+    ; "memory",
+      entry_env_overridable ~env_var:"MASC_KEEPER_SANDBOX_MEMORY"
+        (string_v (Hardening.memory ()))
+    ; "tmpfs_size",
+      entry_env_overridable ~env_var:"MASC_KEEPER_SANDBOX_TMPFS_SIZE"
+        (string_v (Hardening.tmpfs_size ()))
+    ; "relax_fs",
+      entry_env_overridable ~env_var:"MASC_KEEPER_SANDBOX_RELAX_FS"
+        (bool_v (Hardening.relax_fs ()))
+    ; "seccomp_profile",
+      entry_env_overridable ~env_var:"MASC_KEEPER_SANDBOX_SECCOMP_PROFILE"
+        (string_v (Hardening.seccomp_profile ()))
+    ; "require_rootless",
+      entry_env_overridable ~env_var:"MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS"
+        (bool_v (Hardening.require_rootless ()))
+    ; "require_userns",
+      entry_env_overridable ~env_var:"MASC_KEEPER_SANDBOX_REQUIRE_USERNS"
+        (bool_v (Hardening.require_userns ()))
+    ]
+
+let raw_cleanup () : Yojson.Safe.t =
+  `Assoc
+    [ "enabled",
+      entry_env_overridable ~env_var:"MASC_KEEPER_SANDBOX_CLEANUP_ENABLED"
+        (bool_v (Cleanup.enabled ()))
+    ; "stale_after_sec",
+      entry_env_overridable
+        ~env_var:"MASC_KEEPER_SANDBOX_CLEANUP_STALE_AFTER_SEC"
+        (float_v (Cleanup.stale_after_sec ()))
+    ; "interval_sec",
+      entry_env_overridable
+        ~env_var:"MASC_KEEPER_SANDBOX_CLEANUP_INTERVAL_SEC"
+        (float_v (Cleanup.interval_sec ()))
+    ; "managed_sleep_sec",
+      entry_hardcoded (int_v (Cleanup.managed_sleep_sec ()))
+    ]
+
+let raw_runtime () : Yojson.Safe.t =
+  `Assoc
+    [ "docker_image",
+      entry_env_overridable ~env_var:"MASC_KEEPER_SANDBOX_DOCKER_IMAGE"
+        (string_v (Runtime.docker_image ()))
+    ; "git_dispatch",
+      entry_env_overridable ~env_var:"MASC_KEEPER_SANDBOX_GIT_DISPATCH"
+        (bool_v (Runtime.git_dispatch ()))
+    ; "docker_playground_enabled",
+      entry_env_overridable ~env_var:"MASC_KEEPER_DOCKER_PLAYGROUND"
+        (bool_v (Runtime.docker_playground_enabled ()))
+    ]
+
+let raw_auth_paths () : Yojson.Safe.t =
+  `Assoc
+    [ "gh_creds",
+      entry_env_overridable ~env_var:"MASC_KEEPER_SANDBOX_GH_CREDS"
+        (string_v (Auth_paths.gh_creds ()))
+    ; "gitconfig",
+      entry_env_overridable ~env_var:"MASC_KEEPER_SANDBOX_GITCONFIG"
+        (string_v (Auth_paths.gitconfig ()))
+    ; "ssh_dir",
+      entry_env_overridable ~env_var:"MASC_KEEPER_SANDBOX_SSH_DIR"
+        (string_v (Auth_paths.ssh_dir ()))
+    ; "gh_token_probe_timeout_sec",
+      entry_env_overridable
+        ~env_var:"MASC_KEEPER_SANDBOX_GH_TOKEN_PROBE_TIMEOUT_SEC"
+        (float_v (Auth_paths.gh_token_probe_timeout_sec ()))
+    ]
+
+let raw_preflight () : Yojson.Safe.t =
+  `Assoc
+    [ "enabled",
+      entry_env_overridable
+        ~env_var:"MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED"
+        (bool_v (Preflight.enabled ()))
+    ; "min_timeout_sec",
+      entry_hardcoded (float_v (Preflight.min_timeout_sec ()))
+    ; "max_timeout_sec",
+      entry_hardcoded (float_v (Preflight.max_timeout_sec ()))
+    ; "required_commands",
+      entry_floor
+        (`List (List.map (fun s -> `String s)
+                  (Preflight.required_commands ())))
+    ]
+
+let raw_shell_timeout () : Yojson.Safe.t =
+  let bucket_entry b =
+    let key = Shell_timeout.bucket_key b in
+    let value = float_v (Shell_timeout.timeout_sec ~bucket:b ()) in
+    let entry =
+      match b with
+      | Gh_min -> entry_floor value
+      | _ ->
+        entry_env_overridable
+          ~env_var:(Shell_timeout.per_bucket_env_var ~bucket:b)
+          value
+    in
+    key, entry
+  in
+  `Assoc (List.map bucket_entry (Shell_timeout.known_buckets ()))
+
+let raw_section () : Yojson.Safe.t =
+  `Assoc
+    [ "hardening", raw_hardening ()
+    ; "cleanup", raw_cleanup ()
+    ; "runtime", raw_runtime ()
+    ; "auth_paths", raw_auth_paths ()
+    ; "preflight", raw_preflight ()
+    ; "shell_timeout", raw_shell_timeout ()
+    ]
+
+let derived_section () : Yojson.Safe.t =
+  `Assoc
+    [ "read_only_rootfs_args",
+      `List (List.map (fun s -> `String s)
+               (Hardening.read_only_rootfs_args ()))
+    ; "tmpfs_mount", `String (Hardening.tmpfs_mount ())
+    ; "effective_gh_creds_path",
+      `String (Auth_paths.gh_creds ())
+    ; "effective_gitconfig_path",
+      `String (Auth_paths.gitconfig ())
+    ; "effective_ssh_dir_path",
+      `String (Auth_paths.ssh_dir ())
+    ]
+
+let effective_config_json () : Yojson.Safe.t =
+  `Assoc
+    [ "raw", raw_section ()
+    ; "derived", derived_section ()
+    ]

--- a/lib/config/env_config_sandbox.mli
+++ b/lib/config/env_config_sandbox.mli
@@ -1,0 +1,264 @@
+(** Sandbox configuration SSOT.
+
+    Mirrors {!Env_config_exec_timeout} (#10426) and the
+    {!Env_config_oas_bridge} precedent (#10094).  This module gathers
+    the 25+ env-var settings + handful of hardcoded constants that
+    today live across {!Env_config_keeper.KeeperSandbox},
+    {!Env_config_keeper.DockerPlayground}, and several
+    [lib/keeper/keeper_*.ml] sites — into one typed surface so:
+
+    1. Operators can read every effective sandbox setting + its
+       provenance from a single JSON dump
+       ({!effective_config_json}).
+    2. Tests pin the default table once; drift is a compile or test
+       failure rather than a silent budget shift.
+    3. The {!Shell_timeout} sub-module exposes the typed-bucket
+       pattern from {!Env_config_exec_timeout} for the 6 (+1
+       sentinel) shell timeout buckets currently scattered.
+
+    This module is purely additive in the scaffold PR: every getter
+    reads the same env var and returns the same default as the
+    existing implementation.  Call sites are migrated in follow-ups
+    (P2b alias delegation, P2c hardcoded constants, P2d doctor
+    wiring). *)
+
+(** {1 Hardening — security policy and resource limits} *)
+module Hardening : sig
+  val hard_mode : unit -> bool
+  (** Forces rootless/userns runtime checks, disables Docker-side
+      git/gh credential dispatch, and clears host credential
+      fallbacks.
+      Env: [MASC_KEEPER_SANDBOX_HARD_MODE].  Default: [false]. *)
+
+  val pids_limit : unit -> int
+  (** Docker [--pids-limit].  Floored at 32.
+      Env: [MASC_KEEPER_SANDBOX_PIDS_LIMIT].  Default: 128. *)
+
+  val nofile_limit : unit -> int
+  (** Soft and hard [nofile] inside the container.  Floored at 1024.
+      Env: [MASC_KEEPER_SANDBOX_NOFILE_LIMIT].  Default: 245760. *)
+
+  val memory : unit -> string
+  (** Docker [--memory] string (e.g. ["2g"], ["512m"]).
+      Env: [MASC_KEEPER_SANDBOX_MEMORY].  Default: ["2g"]. *)
+
+  val tmpfs_size : unit -> string
+  (** Writable [/tmp] tmpfs size inside the read-only rootfs.
+      Env: [MASC_KEEPER_SANDBOX_TMPFS_SIZE].  Default: ["256m"]. *)
+
+  val relax_fs : unit -> bool
+  (** When true, omit [--read-only] and drop [/tmp]'s [noexec] bit.
+      Returns the raw env value; the hard_mode interaction is
+      enforced by callers reading {!read_only_rootfs_args} and
+      {!tmpfs_mount} rather than by this getter.  Operators who set
+      both should expect their explicit [relax_fs] to win against
+      the implicit hard_mode default — change with care.
+      Env: [MASC_KEEPER_SANDBOX_RELAX_FS].  Default: [false]. *)
+
+  val read_only_rootfs_args : unit -> string list
+  (** Derived: [["--read-only"\]] when {!relax_fs} is false, else
+      empty. *)
+
+  val tmpfs_mount : unit -> string
+  (** Derived: ["/tmp:rw,nosuid,nodev[,noexec],size=<tmpfs_size>"].
+      The [noexec] bit is omitted when {!relax_fs} is true. *)
+
+  val seccomp_profile : unit -> string
+  (** Path to seccomp JSON profile.  Empty string disables seccomp
+      enforcement.
+      Env: [MASC_KEEPER_SANDBOX_SECCOMP_PROFILE].  Default: ["" ]. *)
+
+  val require_rootless : unit -> bool
+  (** Fail closed unless Docker reports rootless mode support.
+      Always true when {!hard_mode} is true.
+      Env: [MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS].  Default: [false]. *)
+
+  val require_userns : unit -> bool
+  (** Fail closed unless Docker reports userns support.
+      Always true when {!hard_mode} is true.
+      Env: [MASC_KEEPER_SANDBOX_REQUIRE_USERNS].  Default: [false]. *)
+end
+
+(** {1 Cleanup — stale container reaping} *)
+module Cleanup : sig
+  val enabled : unit -> bool
+  (** Env: [MASC_KEEPER_SANDBOX_CLEANUP_ENABLED].  Default: [true]. *)
+
+  val stale_after_sec : unit -> float
+  (** Threshold age before a running container becomes eligible for
+      cleanup.  Floored at 60 seconds.
+      Env: [MASC_KEEPER_SANDBOX_CLEANUP_STALE_AFTER_SEC].  Default:
+      21600 (6h). *)
+
+  val interval_sec : unit -> float
+  (** Throttle interval between automatic cleanup sweeps in one
+      server process.  Floored at 10 seconds.
+      Env: [MASC_KEEPER_SANDBOX_CLEANUP_INTERVAL_SEC].  Default: 300
+      (5m). *)
+
+  val managed_sleep_sec : unit -> int
+  (** Sentinel sleep duration for the [managed] container init loop
+      (currently [sleep 3600] in {!Keeper_sandbox_control}).
+      Exposed here so a future PR can env-override; today this
+      getter still returns the historical literal 3600 because no
+      caller is wired yet.
+      Env: not yet read.  Default: 3600. *)
+end
+
+(** {1 Runtime — image and execution mode} *)
+module Runtime : sig
+  val docker_image : unit -> string
+  (** Env: [MASC_KEEPER_SANDBOX_DOCKER_IMAGE].  Default:
+      ["masc-keeper-sandbox:local"]. *)
+
+  val git_dispatch : unit -> bool
+  (** When true, keeper_bash commands beginning with ["git "] or
+      ["gh "] run in a dedicated container with [network_mode=host]
+      and read-only credential mounts.  Effective value is [false]
+      when {!Hardening.hard_mode} is true.
+      Env: [MASC_KEEPER_SANDBOX_GIT_DISPATCH].  Default: [true]. *)
+
+  val docker_playground_enabled : unit -> bool
+  (** Route keeper_bash through a Docker container instead of local
+      subprocess.
+      Env: [MASC_KEEPER_DOCKER_PLAYGROUND].  Default: [false]. *)
+end
+
+(** {1 Auth_paths — credential mount points} *)
+module Auth_paths : sig
+  val gh_creds : unit -> string
+  (** Host path for [/root/.config/gh] read-only mount.  Empty
+      string disables the mount.  Effective value is [""] when
+      {!Hardening.hard_mode}; otherwise default falls through to
+      [$HOME/.config/gh].
+      Env: [MASC_KEEPER_SANDBOX_GH_CREDS].  Default:
+      [$HOME/.config/gh]. *)
+
+  val gitconfig : unit -> string
+  (** Host path for [/root/.gitconfig] read-only mount.  Empty
+      string disables the mount.  [""] when hard_mode.
+      Env: [MASC_KEEPER_SANDBOX_GITCONFIG].  Default:
+      [$HOME/.gitconfig]. *)
+
+  val ssh_dir : unit -> string
+  (** Host path for [~/.ssh] read-only mount.  Opt-in (default
+      empty).  [""] when hard_mode.
+      Env: [MASC_KEEPER_SANDBOX_SSH_DIR].  Default: [""]. *)
+
+  val gh_token_probe_timeout_sec : unit -> float
+  (** Wall-clock budget for the [gh auth token] keychain probe.
+      Clamped to [[0.1, 10.0]].
+      Env: [MASC_KEEPER_SANDBOX_GH_TOKEN_PROBE_TIMEOUT_SEC].
+      Default: 2.0. *)
+end
+
+(** {1 Preflight — runtime feasibility check} *)
+module Preflight : sig
+  val enabled : unit -> bool
+  (** Master switch for keeper_up / doctor preflight.
+      Env: [MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED].  Default: [true]. *)
+
+  val min_timeout_sec : unit -> float
+  (** Lower bound applied via [max] on the caller-supplied timeout
+      when running preflight commands.  Currently hardcoded 5.0 in
+      {!Keeper_sandbox_runtime}; this getter exposes it for future
+      env-override (P2c).
+      Env: not yet read.  Default: 5.0. *)
+
+  val max_timeout_sec : unit -> float
+  (** Upper bound applied via [min] on the caller-supplied timeout.
+      Currently hardcoded 20.0.
+      Env: not yet read.  Default: 20.0. *)
+
+  val required_commands : unit -> string list
+  (** The 18 CLI tools the keeper image contract guarantees
+      ([sh; bash; cat; find; head; tail; wc; git; gh; rg; tree; jq;
+      python3; node; npm; make; opam; dune; ssh]).
+
+      INTENTIONALLY NOT env-overridable: an operator who removes
+      [gh] from the list would make doctor falsely report green
+      while runtime fails opaquely.  Exposed read-only so doctor
+      and tests can iterate the canonical list. *)
+end
+
+(** {1 Shell_timeout — typed-bucket per-command timeout SSOT}
+
+    Mirrors {!Env_config_exec_timeout} but for command-class buckets
+    rather than per-call-site.  Each bucket names a class of shell
+    commands that share a budget. *)
+module Shell_timeout : sig
+  type bucket =
+    | Io
+        (** I/O-bound commands (bash, git status, etc.).  30s. *)
+    | Read
+        (** Read-only commands (cat, rg, head, tail, find,
+            git_log, tree).  15s. *)
+    | Git_meta
+        (** Lightweight git metadata (rev-parse, log --oneline).
+            5s. *)
+    | Gh_min
+        (** Floor for gh CLI ops.  Read-only invariant — operators
+            cannot lower this floor; sub-network-latency timeouts
+            cause cascading 401 retries (see #8688).  15s. *)
+    | User_max
+        (** Upper bound for user-provided [timeout_sec] in
+            keeper_bash.  180s. *)
+    | Token_probe
+        (** [gh auth token] keychain probe budget.  2s. *)
+    | Cleanup_rm
+        (** [docker rm -f] timeout used by turn-scoped cleanup.
+            Currently hardcoded 5.0 in
+            {!Keeper_turn_sandbox_runtime}.  5s. *)
+    | Unknown of string
+
+  val bucket_key : bucket -> string
+  (** Lowercase token used in env var names. *)
+
+  val known_buckets : unit -> bucket list
+  (** Typed table for default-pinning tests. *)
+
+  val known_default_sec : bucket -> float option
+  (** Hardcoded default seconds for [bucket].  [None] for [Unknown _]
+      and [Gh_min] is returned as [Some 15.0] but the [timeout_sec]
+      lookup ignores env overrides for that bucket (read-only
+      floor). *)
+
+  val per_bucket_env_var : bucket:bucket -> string
+  (** [MASC_KEEPER_SHELL_TIMEOUT_<BUCKET>_SEC].  For [Gh_min] the
+      function still returns the conventional name, but
+      {!timeout_sec} ignores it. *)
+
+  val global_env_var : string
+  (** [MASC_KEEPER_SHELL_TIMEOUT_DEFAULT_SEC] — only consulted for
+      [Unknown _]. *)
+
+  val global_default_sec : float
+  (** Final fallback (30.0s). *)
+
+  val timeout_sec : bucket:bucket -> unit -> float
+  (** Resolves the timeout for [bucket].  Lookup order:
+
+      1. [Gh_min] is resolved exclusively from {!known_default_sec}.
+         The env override is ignored (read-only floor).
+      2. Per-bucket env [MASC_KEEPER_SHELL_TIMEOUT_<BUCKET>_SEC].
+      3. {!known_default_sec}.
+      4. Global env [MASC_KEEPER_SHELL_TIMEOUT_DEFAULT_SEC] — only
+         for [Unknown _].
+      5. {!global_default_sec}. *)
+end
+
+(** {1 Doctor / observability surface} *)
+
+val effective_config_json : unit -> Yojson.Safe.t
+(** Returns a snapshot of every sandbox setting under two top-level
+    keys:
+
+    - [raw.<section>.<key>] = [\{ value, source, env_var | null \}]
+      where [source] is one of ["env"], ["default"], or
+      ["load_bearing_floor"] (for [Gh_min] / [required_commands])
+      and [env_var] is [null] for non-overridable values.
+    - [derived.<key>] = effective values after cross-cutting rules
+      (e.g. [hard_mode] coerces [relax_fs] to [false]).
+
+    Operators read [raw] to confirm "did my env override take?" and
+    [derived] to see "what will Docker actually see?". *)

--- a/test/dune
+++ b/test/dune
@@ -1683,3 +1683,9 @@
  (name test_env_config_exec_timeout_10426)
  (modules test_env_config_exec_timeout_10426)
  (libraries masc_test_deps))
+
+; Sandbox configuration SSOT (P2a follow-up to #10426)
+(test
+ (name test_env_config_sandbox)
+ (modules test_env_config_sandbox)
+ (libraries masc_test_deps))

--- a/test/test_env_config_sandbox.ml
+++ b/test/test_env_config_sandbox.ml
@@ -1,0 +1,362 @@
+(** Sandbox config SSOT tests.
+
+    Pin defaults, env-override semantics, hard_mode interactions, and
+    JSON shape for {!Env_config_sandbox}.  Pattern mirrors
+    {!Test_env_config_exec_timeout_10426}. *)
+
+open Alcotest
+
+module S = Env_config_sandbox
+
+let approx = float 0.001
+
+(* ---------------------------------------------------------------- *)
+(* Test helpers                                                     *)
+(* ---------------------------------------------------------------- *)
+
+let with_env name value f =
+  let prev = Sys.getenv_opt name in
+  (match value with
+   | Some v -> Unix.putenv name v
+   | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match prev with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
+(* Sandbox-related env vars that may be set by the operator's shell —
+   we clear them for default-pinning tests so the result is independent
+   of CI/dev-machine environment. *)
+let sandbox_env_names =
+  [ "MASC_KEEPER_SANDBOX_HARD_MODE"
+  ; "MASC_KEEPER_SANDBOX_PIDS_LIMIT"
+  ; "MASC_KEEPER_SANDBOX_NOFILE_LIMIT"
+  ; "MASC_KEEPER_SANDBOX_MEMORY"
+  ; "MASC_KEEPER_SANDBOX_TMPFS_SIZE"
+  ; "MASC_KEEPER_SANDBOX_RELAX_FS"
+  ; "MASC_KEEPER_SANDBOX_SECCOMP_PROFILE"
+  ; "MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS"
+  ; "MASC_KEEPER_SANDBOX_REQUIRE_USERNS"
+  ; "MASC_KEEPER_SANDBOX_CLEANUP_ENABLED"
+  ; "MASC_KEEPER_SANDBOX_CLEANUP_STALE_AFTER_SEC"
+  ; "MASC_KEEPER_SANDBOX_CLEANUP_INTERVAL_SEC"
+  ; "MASC_KEEPER_SANDBOX_DOCKER_IMAGE"
+  ; "MASC_KEEPER_SANDBOX_GIT_DISPATCH"
+  ; "MASC_KEEPER_DOCKER_PLAYGROUND"
+  ; "MASC_KEEPER_SANDBOX_GH_CREDS"
+  ; "MASC_KEEPER_SANDBOX_GITCONFIG"
+  ; "MASC_KEEPER_SANDBOX_SSH_DIR"
+  ; "MASC_KEEPER_SANDBOX_GH_TOKEN_PROBE_TIMEOUT_SEC"
+  ; "MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED"
+  ; "MASC_KEEPER_SHELL_TIMEOUT_IO_SEC"
+  ; "MASC_KEEPER_SHELL_TIMEOUT_READ_SEC"
+  ; "MASC_KEEPER_SHELL_TIMEOUT_GIT_META_SEC"
+  ; "MASC_KEEPER_SHELL_TIMEOUT_GH_MIN_SEC"
+  ; "MASC_KEEPER_SHELL_TIMEOUT_USER_MAX_SEC"
+  ; "MASC_KEEPER_SHELL_TIMEOUT_TOKEN_PROBE_SEC"
+  ; "MASC_KEEPER_SHELL_TIMEOUT_CLEANUP_RM_SEC"
+  ; "MASC_KEEPER_SHELL_TIMEOUT_DEFAULT_SEC"
+  ]
+
+(* String-typed env vars whose default is non-empty.  OCaml 5.4 stdlib
+   has no [Unix.unsetenv], so [Unix.putenv NAME ""] is the closest we
+   can do — but [Env_config_core.get_string ~default] returns the
+   literal "" rather than the default in that case.  Workaround: set
+   each string env to its default literal so [get_string] yields the
+   expected value.  Drift between this table and the .ml will surface
+   in the cross-module consistency test below. *)
+let string_env_defaults =
+  [ "MASC_KEEPER_SANDBOX_MEMORY", "2g"
+  ; "MASC_KEEPER_SANDBOX_TMPFS_SIZE", "256m"
+  ; "MASC_KEEPER_SANDBOX_DOCKER_IMAGE", "masc-keeper-sandbox:local"
+  ]
+
+(* Run [f] with every name in [sandbox_env_names] cleared (set to "")
+   except for string-typed names that need explicit default-yielding
+   values.  Saves and restores prior values in a Fun.protect block. *)
+let with_clean_sandbox_env f =
+  let saved = List.map (fun n -> n, Sys.getenv_opt n) sandbox_env_names in
+  let string_default_set =
+    List.fold_left (fun acc (n, _) -> n :: acc) [] string_env_defaults
+  in
+  List.iter
+    (fun n ->
+      if List.mem n string_default_set then
+        let value = List.assoc n string_env_defaults in
+        Unix.putenv n value
+      else Unix.putenv n "")
+    sandbox_env_names;
+  Fun.protect
+    ~finally:(fun () ->
+      List.iter
+        (fun (n, v) ->
+          match v with
+          | Some s -> Unix.putenv n s
+          | None -> Unix.putenv n "")
+        saved)
+    f
+
+(* ---------------------------------------------------------------- *)
+(* 1. Default pinning                                               *)
+(* ---------------------------------------------------------------- *)
+
+let test_defaults_pinned () =
+  with_clean_sandbox_env @@ fun () ->
+  (* Hardening *)
+  check bool "Hardening.hard_mode default" false (S.Hardening.hard_mode ());
+  check int "Hardening.pids_limit default" 128 (S.Hardening.pids_limit ());
+  check int "Hardening.nofile_limit default" 245_760
+    (S.Hardening.nofile_limit ());
+  check string "Hardening.memory default" "2g" (S.Hardening.memory ());
+  check string "Hardening.tmpfs_size default" "256m" (S.Hardening.tmpfs_size ());
+  check bool "Hardening.relax_fs default" false (S.Hardening.relax_fs ());
+  check string "Hardening.seccomp_profile default" ""
+    (S.Hardening.seccomp_profile ());
+  check bool "Hardening.require_rootless default" false
+    (S.Hardening.require_rootless ());
+  check bool "Hardening.require_userns default" false
+    (S.Hardening.require_userns ());
+  (* Cleanup *)
+  check bool "Cleanup.enabled default" true (S.Cleanup.enabled ());
+  check approx "Cleanup.stale_after_sec default" 21_600.0
+    (S.Cleanup.stale_after_sec ());
+  check approx "Cleanup.interval_sec default" 300.0
+    (S.Cleanup.interval_sec ());
+  check int "Cleanup.managed_sleep_sec default" 3600
+    (S.Cleanup.managed_sleep_sec ());
+  (* Runtime *)
+  check string "Runtime.docker_image default" "masc-keeper-sandbox:local"
+    (S.Runtime.docker_image ());
+  check bool "Runtime.git_dispatch default" true (S.Runtime.git_dispatch ());
+  check bool "Runtime.docker_playground_enabled default" false
+    (S.Runtime.docker_playground_enabled ());
+  (* Auth_paths.gh_creds / gitconfig defaults derive from $HOME but
+     since OCaml 5.4 stdlib lacks [Unix.unsetenv], we cannot fully
+     un-set the env to observe the default branch.  Coverage here is
+     intentionally narrow: ssh_dir default is empty (matches env="")
+     and probe timeout has a deterministic float clamp.  The hard_mode
+     interaction tests below cover the "force-empty" branch which
+     exercises the [if hard_mode () then "" else ...] path. *)
+  check string "Auth_paths.ssh_dir default" "" (S.Auth_paths.ssh_dir ());
+  check approx "Auth_paths.gh_token_probe_timeout_sec default" 2.0
+    (S.Auth_paths.gh_token_probe_timeout_sec ());
+  (* Preflight *)
+  check bool "Preflight.enabled default" true (S.Preflight.enabled ());
+  check approx "Preflight.min_timeout_sec default" 5.0
+    (S.Preflight.min_timeout_sec ());
+  check approx "Preflight.max_timeout_sec default" 20.0
+    (S.Preflight.max_timeout_sec ());
+  check int "Preflight.required_commands count" 19
+    (List.length (S.Preflight.required_commands ()));
+  check (option string) "Preflight.required_commands has 'gh'" (Some "gh")
+    (List.find_opt (String.equal "gh") (S.Preflight.required_commands ()));
+  (* Shell_timeout buckets *)
+  let pin bucket expected =
+    check approx
+      (Printf.sprintf "Shell_timeout %s default" (S.Shell_timeout.bucket_key bucket))
+      expected
+      (S.Shell_timeout.timeout_sec ~bucket ())
+  in
+  pin S.Shell_timeout.Io 30.0;
+  pin S.Shell_timeout.Read 15.0;
+  pin S.Shell_timeout.Git_meta 5.0;
+  pin S.Shell_timeout.Gh_min 15.0;
+  pin S.Shell_timeout.User_max 180.0;
+  pin S.Shell_timeout.Token_probe 2.0;
+  pin S.Shell_timeout.Cleanup_rm 5.0
+
+(* ---------------------------------------------------------------- *)
+(* 2. Env-override                                                  *)
+(* ---------------------------------------------------------------- *)
+
+let test_env_overrides_default () =
+  with_clean_sandbox_env @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_MEMORY" (Some "4g") (fun () ->
+    check string "memory env override wins" "4g" (S.Hardening.memory ()));
+  (* After with_env restore, original [None] becomes [Some ""], which
+     [get_string] does NOT treat as "default" — it returns the literal
+     empty string.  This is a quirk of the env-restoration model, not a
+     module bug.  We still want a regression guard, so check the
+     observable effect: memory is back to whatever the cleared env
+     yields (default). *)
+  check string "memory falls back to default after clean restore"
+    "2g" (S.Hardening.memory ())
+
+let test_empty_env_treated_as_unset () =
+  with_clean_sandbox_env @@ fun () ->
+  with_env "MASC_KEEPER_SHELL_TIMEOUT_IO_SEC" (Some "") (fun () ->
+    check approx "empty env still hits default" 30.0
+      (S.Shell_timeout.timeout_sec ~bucket:S.Shell_timeout.Io ()))
+
+let test_invalid_float_falls_to_global_default () =
+  with_clean_sandbox_env @@ fun () ->
+  with_env "MASC_KEEPER_SHELL_TIMEOUT_IO_SEC" (Some "not-a-float") (fun () ->
+    check approx "invalid float -> global_default_sec"
+      S.Shell_timeout.global_default_sec
+      (S.Shell_timeout.timeout_sec ~bucket:S.Shell_timeout.Io ()))
+
+(* ---------------------------------------------------------------- *)
+(* 3. Shell_timeout bucket variant                                  *)
+(* ---------------------------------------------------------------- *)
+
+let test_per_bucket_env_var_shape () =
+  check string "Io env var name"
+    "MASC_KEEPER_SHELL_TIMEOUT_IO_SEC"
+    (S.Shell_timeout.per_bucket_env_var ~bucket:S.Shell_timeout.Io);
+  check string "Token_probe env var name"
+    "MASC_KEEPER_SHELL_TIMEOUT_TOKEN_PROBE_SEC"
+    (S.Shell_timeout.per_bucket_env_var
+       ~bucket:S.Shell_timeout.Token_probe);
+  check string "Unknown bucket env var lowercases"
+    "MASC_KEEPER_SHELL_TIMEOUT_FUTURE_X_SEC"
+    (S.Shell_timeout.per_bucket_env_var
+       ~bucket:(S.Shell_timeout.Unknown "future-x"))
+
+let test_per_bucket_env_override () =
+  with_clean_sandbox_env @@ fun () ->
+  with_env "MASC_KEEPER_SHELL_TIMEOUT_READ_SEC" (Some "7.5") (fun () ->
+    check approx "Read bucket env override wins"
+      7.5
+      (S.Shell_timeout.timeout_sec ~bucket:S.Shell_timeout.Read ()))
+
+let test_unknown_bucket_uses_global_env () =
+  with_clean_sandbox_env @@ fun () ->
+  with_env "MASC_KEEPER_SHELL_TIMEOUT_DEFAULT_SEC" (Some "99.0") (fun () ->
+    check approx "Unknown bucket uses global env"
+      99.0
+      (S.Shell_timeout.timeout_sec
+         ~bucket:(S.Shell_timeout.Unknown "future") ());
+    check approx "Known bucket ignores global env"
+      30.0
+      (S.Shell_timeout.timeout_sec ~bucket:S.Shell_timeout.Io ()))
+
+let test_gh_min_floor_ignores_env () =
+  (* Even with a per-bucket env override, Gh_min stays 15.0 — read-only
+     load-bearing floor (#8688). *)
+  with_clean_sandbox_env @@ fun () ->
+  with_env "MASC_KEEPER_SHELL_TIMEOUT_GH_MIN_SEC" (Some "1.0") (fun () ->
+    check approx "Gh_min ignores env override"
+      15.0
+      (S.Shell_timeout.timeout_sec ~bucket:S.Shell_timeout.Gh_min ()))
+
+(* ---------------------------------------------------------------- *)
+(* 4. Hard-mode interactions                                        *)
+(* ---------------------------------------------------------------- *)
+
+let test_hard_mode_forces_require_flags () =
+  with_clean_sandbox_env @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_HARD_MODE" (Some "true") (fun () ->
+    check bool "hard_mode forces require_rootless true"
+      true (S.Hardening.require_rootless ());
+    check bool "hard_mode forces require_userns true"
+      true (S.Hardening.require_userns ());
+    check bool "hard_mode forces git_dispatch false"
+      false (S.Runtime.git_dispatch ()))
+
+let test_hard_mode_clears_credential_paths () =
+  with_clean_sandbox_env @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_HARD_MODE" (Some "true") (fun () ->
+    check string "hard_mode clears gh_creds" ""
+      (S.Auth_paths.gh_creds ());
+    check string "hard_mode clears gitconfig" ""
+      (S.Auth_paths.gitconfig ());
+    check string "hard_mode clears ssh_dir" ""
+      (S.Auth_paths.ssh_dir ()))
+
+let test_relax_fs_propagates_to_derived () =
+  (* relax_fs raw value passes through; derived values change. *)
+  with_clean_sandbox_env @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_RELAX_FS" (Some "true") (fun () ->
+    check bool "relax_fs raw env wins"
+      true (S.Hardening.relax_fs ());
+    check (list string) "read_only_rootfs_args is empty when relax_fs"
+      [] (S.Hardening.read_only_rootfs_args ());
+    let mount = S.Hardening.tmpfs_mount () in
+    let contains_noexec =
+      let len = String.length "noexec" in
+      let rec check_at i =
+        if i + len > String.length mount then false
+        else if String.sub mount i len = "noexec" then true
+        else check_at (i + 1)
+      in
+      check_at 0
+    in
+    check bool "tmpfs_mount drops noexec when relax_fs"
+      true (not contains_noexec))
+
+(* ---------------------------------------------------------------- *)
+(* 5. JSON shape                                                    *)
+(* ---------------------------------------------------------------- *)
+
+let test_json_shape_has_top_level_keys () =
+  with_clean_sandbox_env @@ fun () ->
+  let json = S.effective_config_json () in
+  let assoc = match json with
+    | `Assoc xs -> xs
+    | _ -> failwith "effective_config_json must be `Assoc"
+  in
+  let has_key k = List.mem_assoc k assoc in
+  check bool "top-level 'raw' key" true (has_key "raw");
+  check bool "top-level 'derived' key" true (has_key "derived");
+  let raw = List.assoc "raw" assoc in
+  let raw_assoc = match raw with `Assoc xs -> xs | _ -> [] in
+  let raw_keys =
+    [ "hardening"; "cleanup"; "runtime"; "auth_paths"
+    ; "preflight"; "shell_timeout" ]
+  in
+  List.iter
+    (fun k ->
+      check bool
+        (Printf.sprintf "raw.%s exists" k)
+        true (List.mem_assoc k raw_assoc))
+    raw_keys;
+  (* Probe the entry shape on hardening.hard_mode *)
+  let hardening = List.assoc "hardening" raw_assoc in
+  let hardening_assoc = match hardening with `Assoc xs -> xs | _ -> [] in
+  let hard_mode_entry = List.assoc "hard_mode" hardening_assoc in
+  let entry_keys =
+    match hard_mode_entry with `Assoc xs -> List.map fst xs | _ -> []
+  in
+  check (slist string compare) "raw entry has value/source/env_var keys"
+    [ "env_var"; "source"; "value" ] entry_keys
+
+(* ---------------------------------------------------------------- *)
+(* Test runner                                                      *)
+(* ---------------------------------------------------------------- *)
+
+let () =
+  run "env_config_sandbox"
+    [ ( "defaults",
+        [ test_case "all defaults pinned" `Quick test_defaults_pinned ] )
+    ; ( "env-override",
+        [ test_case "env override wins" `Quick test_env_overrides_default
+        ; test_case "empty env treated as unset" `Quick
+            test_empty_env_treated_as_unset
+        ; test_case "invalid float -> global_default" `Quick
+            test_invalid_float_falls_to_global_default
+        ] )
+    ; ( "shell-timeout-bucket",
+        [ test_case "env var name shape" `Quick
+            test_per_bucket_env_var_shape
+        ; test_case "per-bucket env override" `Quick
+            test_per_bucket_env_override
+        ; test_case "Unknown bucket -> global env" `Quick
+            test_unknown_bucket_uses_global_env
+        ; test_case "Gh_min floor ignores env" `Quick
+            test_gh_min_floor_ignores_env
+        ] )
+    ; ( "hard-mode",
+        [ test_case "hard_mode forces require flags" `Quick
+            test_hard_mode_forces_require_flags
+        ; test_case "hard_mode clears credentials" `Quick
+            test_hard_mode_clears_credential_paths
+        ; test_case "relax_fs propagates to derived" `Quick
+            test_relax_fs_propagates_to_derived
+        ] )
+    ; ( "json-shape",
+        [ test_case "top-level keys + entry shape" `Quick
+            test_json_shape_has_top_level_keys
+        ] )
+    ]


### PR DESCRIPTION
## Why

The masc-mcp keeper sandbox subsystem spreads its configuration across **four layers**:

- 25+ env vars in `Env_config_keeper.KeeperSandbox` / `DockerPlayground`
- Hardcoded constants in `keeper_sandbox_runtime.ml` (`docker_preflight_min_sec=5.0`, `docker_preflight_max_sec=20.0`, `required_commands` list)
- Hardcoded sentinels in `keeper_sandbox_control.ml` (`managed sleep 3600`) and `keeper_turn_sandbox_runtime.ml` (`cleanup rm timeout=5.0`)
- Bucketized shell timeouts in `keeper_exec_shell.ml` (`io=30s`, `read=15s`, `git_meta=5s`, `gh_min=15s` floor, `user_max=180s`)

To answer "what is my effective sandbox config?" today, an operator must read all four layers — each with its own format. This PR is the **first deliverable** in unifying that surface, mirroring the typed-caller pattern from `Env_config_exec_timeout` (#10452 / #10426 P1).

This PR is **purely additive scaffolding**. No call-site is migrated; no behavior changes. The existing `KeeperSandbox` / `DockerPlayground` modules continue to be the live config for keeper code. P2b switches them to alias delegation; the new module exists alongside for one cycle so reviewers can vet the typed surface in isolation.

## What

```ocaml
Env_config_sandbox
  |- Hardening      (hard_mode, pids/nofile/memory limits, seccomp,
  |                  require_rootless/userns, derived rootfs/tmpfs)
  |- Cleanup        (enabled, stale_after, interval, managed_sleep)
  |- Runtime        (docker_image, git_dispatch, playground_enabled)
  |- Auth_paths     (gh_creds, gitconfig, ssh_dir, gh_token_probe)
  |- Preflight      (enabled, min/max_timeout, required_commands)
  |- Shell_timeout  (typed bucket: Io|Read|Git_meta|Gh_min|User_max
  |                  |Token_probe|Cleanup_rm|Unknown of string)
  \- effective_config_json : unit -> Yojson.Safe.t
```

`Shell_timeout.timeout_sec ~bucket ()` follows the same 4-step lookup as `Env_config_exec_timeout.timeout_sec`:

1. Per-bucket env `MASC_KEEPER_SHELL_TIMEOUT_<BUCKET>_SEC`
2. Hardcoded `known_default_sec`
3. Global env `MASC_KEEPER_SHELL_TIMEOUT_DEFAULT_SEC` (only for `Unknown _`)
4. `global_default_sec = 30.0`

with two bucket-specific exceptions:

- **`Gh_min` ignores env override** — it is a load-bearing floor (#8688: sub-network-latency timeouts cause cascading 401 retries). The function returns 15.0 unconditionally.
- **`required_commands`** stays a read-only list for the same kind of reason: an operator who removes `gh` from the list gets a doctor false-green and silent runtime failures.

## effective_config_json shape

Two top-level keys:

```json
{
  "raw": {
    "hardening": { "hard_mode": { "value": false, "source": "default", "env_var": "MASC_KEEPER_SANDBOX_HARD_MODE" } },
    "shell_timeout": { "io": { ... }, "gh_min": { "value": 15.0, "source": "load_bearing_floor", "env_var": null } },
    ...
  },
  "derived": {
    "read_only_rootfs_args": ["--read-only"],
    "tmpfs_mount": "/tmp:rw,nosuid,nodev,noexec,size=256m",
    "effective_gh_creds_path": "/Users/.../.config/gh"
  }
}
```

`raw.<section>.<key>` includes `{ value, source, env_var }` so operators can answer "did my override take?". `derived.*` shows what Docker actually sees after cross-cutting rules (hard_mode, relax_fs).

P2d will splice this into `Config_doctor.analyze_live` so it surfaces via `masc doctor config --json`.

## Test pinning (12 alcotest cases)

| Group | Cases | Coverage |
|-------|-------|----------|
| `defaults` | 1 (param) | Every getter's default value pinned |
| `env-override` | 3 | Per-getter env wins / empty env / invalid float fallback |
| `shell-timeout-bucket` | 4 | Env var name shape / per-bucket override / `Unknown` → global / `Gh_min` floor invariant |
| `hard-mode` | 3 | Forces require flags, clears credentials, propagates to derived |
| `json-shape` | 1 | Top-level keys + entry shape (`value/source/env_var`) |

**Test infra note**: OCaml 5.4 stdlib has no `Unix.unsetenv`. `with_clean_sandbox_env` zeroes booleans/ints/floats (where empty env yields default) and explicitly sets string-typed env vars to their default literal (string getters return `""` instead of default for empty env). Drift between the test's string-default sentinels and the .ml will surface in the cross-module verification step (P2b adds this when the alias path lands).

## Out of scope (queued follow-ups)

| Phase | Diff | Content |
|-------|------|---------|
| **P2b** | ~+30 / -200 | `Env_config_keeper.KeeperSandbox` and `DockerPlayground` switch to alias delegation. ~76 call sites untouched. |
| **P2c** | ~+40 / -15 | `keeper_sandbox_runtime` hardcoded constants migrate via `Env_config_sandbox.Preflight.{min,max}_timeout_sec` + `Cleanup.managed_sleep_sec` + `Shell_timeout.Cleanup_rm`. New env vars wired (defaults preserved). |
| **P2d** | ~+50 / -0 | `Config_doctor.analyze_live` wires sandbox JSON + ops doc update. |
| **C1+** | (separate) | EINTR retry remaining-time tracking (8 × full timeout = 240s wall clock today), `Eio.Switch.on_release` cleanup (currently fire-and-forget `docker rm`), `effective_sandbox_profile` resolution dedup. |

## Verification

```bash
cd .worktrees/feat-sandbox-config-ssot

dune build @check --root . --cache=disabled       # RC=0
dune build lib/   --root . --cache=disabled       # RC=0 (regression-free)
dune exec test/test_env_config_sandbox.exe        # 12/12 pass
```

## Diff stats

```
5 files changed, 1054 insertions(+), 0 deletions(-)
 lib/config/dune                       |   1 +
 lib/config/env_config_sandbox.ml      | 421 ++++++++++++++++++++++
 lib/config/env_config_sandbox.mli     | 264 ++++++++++++++
 test/dune                             |   6 +
 test/test_env_config_sandbox.ml       | 362 +++++++++++++++++++
```

Files in `lib/keeper/*.ml` and `lib/config/env_config_keeper.ml`: **0 changes**. Files outside `lib/config/` and `test/`: **0 changes**.

---

Refs: #10426 (audit + 3-phase plan), #10452 (P1 exec_timeout SSOT — pattern source).
