### PR TITLE
perf(server-auth): drop two allocations from Bearer header check

### DIFF
--- a/lib/core/string_util.ml
+++ b/lib/core/string_util.ml
@@ -73,6 +73,22 @@ let contains_substring_ci haystack needle =
     in
     loop 0
 
+(* ASCII case-insensitive prefix check.  No allocation; lowercases
+   byte by byte during compare. *)
+let starts_with_ci ~prefix s =
+  let plen = String.length prefix in
+  let slen = String.length s in
+  if plen > slen then false
+  else
+    let rec match_at i =
+      if i = plen then true
+      else
+        let p = Char.lowercase_ascii (String.unsafe_get prefix i) in
+        let c = Char.lowercase_ascii (String.unsafe_get s i) in
+        if p <> c then false else match_at (i + 1)
+    in
+    match_at 0
+
 (* Byte-wise non-overlapping replace: scans [haystack] for [needle] and
    substitutes [by] for each occurrence. Empty needle is a no-op (would
    loop forever otherwise). Skips ahead by [needle_len] after a match,

--- a/lib/core/string_util.mli
+++ b/lib/core/string_util.mli
@@ -10,6 +10,12 @@ val contains_substring_ci : string -> string -> bool
     Returns [false] when [needle] is empty, matching the behavior
     of the original per-module [contains_ci] helpers. *)
 
+val starts_with_ci : prefix:string -> string -> bool
+(** [starts_with_ci ~prefix s] is the ASCII case-insensitive variant of
+    [String.starts_with]. Performs no allocation; lowercases each byte
+    of [prefix] and [s] inline during the compare. Returns [true] when
+    [prefix] is empty. *)
+
 val find_substring : ?pos:int -> string -> string -> int option
 (** [find_substring ?pos haystack needle] returns the byte index of the
     first occurrence of [needle] in [haystack] at or after [pos]

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -67,7 +67,7 @@ let ensure_strict_http_token_auth ~endpoint auth_config =
 let bearer_token_from_header value =
   let prefix_len = 7 in (* String.length "Bearer " *)
   if String.length value > prefix_len
-     && String.lowercase_ascii (String.sub value 0 prefix_len) = "bearer "
+     && String_util.starts_with_ci ~prefix:"Bearer " value
   then Some (String.sub value prefix_len (String.length value - prefix_len))
   else None
 

--- a/test/test_string_util.ml
+++ b/test/test_string_util.ml
@@ -217,6 +217,26 @@ let test_contains_substring_ci_empty_and_literal () =
   check bool "regex wildcard is not magic" false
     (SU.contains_substring_ci "literal abc needle" ".*")
 
+let test_starts_with_ci_basic () =
+  check bool "exact case" true
+    (SU.starts_with_ci ~prefix:"Bearer " "Bearer abc123");
+  check bool "lowercase prefix vs mixed value" true
+    (SU.starts_with_ci ~prefix:"bearer " "Bearer abc123");
+  check bool "uppercase prefix vs lowercase value" true
+    (SU.starts_with_ci ~prefix:"BEARER " "bearer abc123");
+  check bool "mismatch" false
+    (SU.starts_with_ci ~prefix:"Bearer " "Basic abc123")
+
+let test_starts_with_ci_boundaries () =
+  check bool "empty prefix matches anything" true
+    (SU.starts_with_ci ~prefix:"" "anything");
+  check bool "empty prefix matches empty string" true
+    (SU.starts_with_ci ~prefix:"" "");
+  check bool "prefix longer than string" false
+    (SU.starts_with_ci ~prefix:"hello" "hi");
+  check bool "exact length equal" true
+    (SU.starts_with_ci ~prefix:"abc" "ABC")
+
 
 (* ---- Test runner ---- *)
 
@@ -258,4 +278,7 @@ let () =
       ( "contains_substring_ci",
         [ test_case "ASCII" `Quick test_contains_substring_ci_ascii;
           test_case "empty and literal" `Quick
-            test_contains_substring_ci_empty_and_literal ] ) ]
+            test_contains_substring_ci_empty_and_literal ] );
+      ( "starts_with_ci",
+        [ test_case "basic" `Quick test_starts_with_ci_basic;
+          test_case "boundaries" `Quick test_starts_with_ci_boundaries ] ) ]


### PR DESCRIPTION
## Why

\`bearer_token_from_header\` is on the auth hot path — every authenticated HTTP request runs it. The CI prefix check was:

\`\`\`ocaml
String.lowercase_ascii (String.sub value 0 prefix_len) = \"bearer \"
\`\`\`

Two allocations to compare 7 bytes:
1. \`String.sub\` copies the leading 7 chars.
2. \`String.lowercase_ascii\` allocates again to lowercase them.

## What

Add \`String_util.starts_with_ci\` as the SSOT for ASCII case-insensitive prefix checks — byte-wise scan, no allocation, lowercases each byte inline during the compare. Migrate \`bearer_token_from_header\` to use it.

\`\`\`ocaml
val starts_with_ci : prefix:string -> string -> bool
\`\`\`

Future header-CI checks (X-Forwarded-*, Connection: upgrade, etc.) reuse the same helper.

## Verify

- \`dune build @check\` passes.
- \`dune runtest test/test_string_util\` — 25/25 pass, including new \`starts_with_ci basic\` and \`starts_with_ci boundaries\` cases (empty prefix, prefix longer than string, exact match, mixed case).

## Risk

Low. Same observable behaviour: returns \`Some token\` iff the value's first 7 chars match \"Bearer \" case-insensitively. The \`String.length value > 7\` guard is preserved.