### PR TITLE
feat(keeper): operator broadcast on pause + stale watchdog fiber

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -334,12 +334,105 @@ let to_json (receipt : t) =
       ("ended_at", `String receipt.ended_at);
     ]
 
+(* Operator broadcast hook (#fleet-stall 2026-04-26): operator_disposition
+   was a derived display field — emitted nowhere. A pause_human/alert_exhausted
+   verdict therefore had no transition out: dashboard turned a chip red, but
+   no event reached operators and no supervisor handoff fired. We now emit a
+   structured "keeper.operator_broadcast_required" activity event so the gate
+   verdict becomes addressable instead of cosmetic. *)
+let needs_operator_broadcast = function
+  | "pause_human" | "alert_exhausted" | "unknown" -> true
+  | _ -> false
+
+let emit_operator_broadcast config (receipt : t) ~disposition ~reason =
+  let payload =
+    `Assoc
+      [ "schema", `String "keeper.operator_broadcast_required.v1"
+      ; "keeper_name", `String receipt.keeper_name
+      ; "agent_name", `String receipt.agent_name
+      ; "trace_id", `String receipt.trace_id
+      ; "generation", `Int receipt.generation
+      ; "disposition", `String disposition
+      ; "disposition_reason", `String reason
+      ; "outcome", `String receipt.outcome
+      ; "terminal_reason_code", `String receipt.terminal_reason_code
+      ; "cascade_name", `String receipt.cascade_name
+      ; "cascade_outcome", `String receipt.cascade_outcome
+      ; "tool_contract_result", `String receipt.tool_contract_result
+      ; ( "error_kind"
+        , match receipt.error_kind with
+          | Some v -> `String v
+          | None -> `Null )
+      ; ( "error_message"
+        , match receipt.error_message with
+          | Some v -> `String v
+          | None -> `Null )
+      ; "ended_at", `String receipt.ended_at
+      ]
+  in
+  let event =
+    Activity_graph.emit config
+      ~actor:{ Activity_graph.kind = "agent"; id = receipt.agent_name }
+      ~kind:"keeper.operator_broadcast_required"
+      ~payload
+      ()
+  in
+  Log.Keeper.info
+    "%s: operator_broadcast_required emitted disposition=%s reason=%s seq=%d"
+    receipt.keeper_name disposition reason event.seq
+
 let append (config : Coord.config) (receipt : t) =
   let store =
     Keeper_types_support.keeper_execution_receipt_store config
       receipt.keeper_name
   in
-  Dated_jsonl.append store (to_json receipt)
+  Dated_jsonl.append store (to_json receipt);
+  let disposition, reason = operator_disposition receipt in
+  if needs_operator_broadcast disposition then
+    try emit_operator_broadcast config receipt ~disposition ~reason with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      (* fail-closed: log loud, do not silently swallow. The append itself
+         has already persisted the receipt; the broadcast failure is its
+         own diagnostic that watchdogs/log alerts will pick up. *)
+      Log.Keeper.error
+        "%s: operator_broadcast_required EMIT FAILED disposition=%s \
+         reason=%s exn=%s"
+        receipt.keeper_name disposition reason (Printexc.to_string exn)
+
+(* Watchdog-driven broadcast (#fleet-stall 2026-04-26 Step 3): emitted by a
+   supervisor-side fiber when a Running keeper has not produced a turn for
+   longer than the stale threshold. This is the path that catches the
+   "KSM=Running but no live turn" failure mode where the heartbeat fiber is
+   blocked on a long call and would otherwise never produce a receipt. *)
+let emit_stale_keeper_broadcast config
+    ~keeper_name ~agent_name ~trace_id ~generation
+    ~stale_seconds ~last_turn_ts =
+  let payload =
+    `Assoc
+      [ "schema", `String "keeper.operator_broadcast_required.v1"
+      ; "keeper_name", `String keeper_name
+      ; "agent_name", `String agent_name
+      ; "trace_id", `String trace_id
+      ; "generation", `Int generation
+      ; "disposition", `String "stalled"
+      ; "disposition_reason"
+      , `String (Printf.sprintf "stale_turn_%.0fs" stale_seconds)
+      ; "stale_seconds", `Float stale_seconds
+      ; "last_turn_ts", `Float last_turn_ts
+      ; "source", `String "watchdog"
+      ]
+  in
+  let event =
+    Activity_graph.emit config
+      ~actor:{ Activity_graph.kind = "watchdog"; id = keeper_name }
+      ~kind:"keeper.operator_broadcast_required"
+      ~payload
+      ()
+  in
+  Log.Keeper.error
+    "%s: stale_keeper_broadcast emitted last_turn=%.0fs ago seq=%d"
+    keeper_name stale_seconds event.seq
 
 let latest_json (config : Coord.config) keeper_name =
   let store =

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -63,7 +63,31 @@ type t =
 val stop_reason_to_string : Oas_worker.stop_reason -> string
 val sandbox_kind_of_meta : Keeper_types.keeper_meta -> string
 val to_json : t -> Yojson.Safe.t
+
+(** Derived display pair (disposition, reason) computed from receipt fields.
+    Exposed for test access; the runtime path consumes it via [append]. *)
+val operator_disposition : t -> string * string
+
+(** [needs_operator_broadcast disposition] returns true when the disposition
+    indicates a silent dead-end that operators must be notified about. *)
+val needs_operator_broadcast : string -> bool
+
 val append : Coord.config -> t -> unit
 val latest_json : Coord.config -> string -> Yojson.Safe.t option
 val latest_json_by_keeper :
   Coord.config -> string list -> (string * Yojson.Safe.t) list
+
+(** Emit a watchdog-sourced operator_broadcast_required event for a keeper
+    that has been Running but not produced a turn within the stale
+    threshold. Used by the supervisor watchdog fiber (Step 3 of the
+    keeper-pause-broadcast-watchdog change) to convert silent stalls into
+    addressable events. *)
+val emit_stale_keeper_broadcast :
+  Coord.config ->
+  keeper_name:string ->
+  agent_name:string ->
+  trace_id:string ->
+  generation:int ->
+  stale_seconds:float ->
+  last_turn_ts:float ->
+  unit

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -127,6 +127,63 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
          "%s: Fiber_started rejected during supervised launch: %s"
          meta.name
          (Keeper_state_machine.transition_error_to_string err));
+  (* Stale-turn watchdog (#fleet-stall 2026-04-26 Step 3).
+     Runs in its own Eio fiber so it stays responsive even if the heartbeat
+     fiber is blocked on a long synchronous call (the failure mode that
+     produced the "KSM=Running but no live turn" cluster). Polls
+     last_turn_ts via Keeper_registry; emits operator_broadcast_required
+     once per stale window so a Running-but-mute keeper becomes an
+     addressable event instead of a cosmetic dashboard chip.
+     Constants kept inline (no env knob — see memory:
+     no-hyperparameter-as-env-knob). *)
+  let stale_threshold_sec = 300.0 in
+  let watchdog_poll_sec = 30.0 in
+  let last_broadcast_ts = ref 0.0 in
+  Eio.Fiber.fork ~sw:ctx.sw (fun () ->
+    let rec watchdog_loop () =
+      if Atomic.get reg.fiber_stop then ()
+      else begin
+        Eio.Fiber.yield ();
+        let now = Time_compat.now () in
+        (try
+           match Keeper_registry.get ~base_path meta.name with
+           | Some entry
+             when entry.phase = Keeper_state_machine.Running ->
+             let last_turn = entry.meta.runtime.usage.last_turn_ts in
+             let stale =
+               last_turn > 0.0 && now -. last_turn > stale_threshold_sec
+             in
+             let cooldown_ok =
+               !last_broadcast_ts = 0.0
+               || now -. !last_broadcast_ts > stale_threshold_sec
+             in
+             if stale && cooldown_ok then begin
+               last_broadcast_ts := now;
+               Keeper_execution_receipt.emit_stale_keeper_broadcast
+                 ctx.config
+                 ~keeper_name:meta.name
+                 ~agent_name:meta.agent_name
+                 ~trace_id:
+                   (Keeper_id.Trace_id.to_string entry.meta.runtime.trace_id)
+                 ~generation:entry.meta.runtime.generation
+                 ~stale_seconds:(now -. last_turn)
+                 ~last_turn_ts:last_turn
+             end
+           | _ -> ()
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+           Log.Keeper.warn
+             "%s: stale watchdog tick failed (suppressed): %s"
+             meta.name (Printexc.to_string exn));
+        (try Eio.Time.sleep ctx.clock watchdog_poll_sec with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | _ -> ());
+        watchdog_loop ()
+      end
+    in
+    try watchdog_loop ()
+    with Eio.Cancel.Cancelled _ -> ());
   Eio.Fiber.fork ~sw:ctx.sw (fun () ->
     let resolved = ref false in
     let resolve_done value =

--- a/specs/keeper-state-machine/OperatorPauseBroadcast-buggy.cfg
+++ b/specs/keeper-state-machine/OperatorPauseBroadcast-buggy.cfg
@@ -1,0 +1,9 @@
+\* Bug model: must violate PauseLeadsToBroadcast.
+\* TLC should report invariant or property violation.
+SPECIFICATION SpecBuggy
+CONSTANTS
+  Keepers = {k1, k2}
+INVARIANTS
+  TypeOK
+PROPERTIES
+  PauseLeadsToBroadcast

--- a/specs/keeper-state-machine/OperatorPauseBroadcast.cfg
+++ b/specs/keeper-state-machine/OperatorPauseBroadcast.cfg
@@ -1,0 +1,9 @@
+SPECIFICATION Spec
+CONSTANTS
+  Keepers = {k1, k2}
+INVARIANTS
+  TypeOK
+  EmittedBeforeResolved
+PROPERTIES
+  PauseLeadsToBroadcast
+  OperatorPauseEverHandled

--- a/specs/keeper-state-machine/OperatorPauseBroadcast.tla
+++ b/specs/keeper-state-machine/OperatorPauseBroadcast.tla
@@ -1,0 +1,131 @@
+---- MODULE OperatorPauseBroadcast ----
+\* Operator Pause Broadcast — guarantees gate verdicts are addressable
+\*
+\* Bug class
+\*   keeper_execution_receipt.operator_disposition was a derived display
+\*   field with no transition out: a "pause_human" verdict simply turned
+\*   a dashboard chip red and no event reached operators or supervisor.
+\*   Symmetrically, KSM=Running keepers whose heartbeat fiber blocked on
+\*   a long call produced no receipt at all — silent stall.
+\*
+\* Property under audit
+\*   For every keeper that enters PauseHuman or StaleRunning, an
+\*   OperatorBroadcast event is eventually emitted (leads-to). The clean
+\*   model satisfies this; the bug model (where emit is silently dropped)
+\*   must violate it.
+\*
+\* Anchors (OCaml runtime)
+\*   - lib/keeper/keeper_execution_receipt.ml: needs_operator_broadcast +
+\*     emit_operator_broadcast called from append (this PR's Step 2).
+\*   - lib/keeper/keeper_supervisor.ml: stale watchdog fiber forks under
+\*     ctx.sw and calls emit_stale_keeper_broadcast (this PR's Step 3).
+
+EXTENDS Naturals, FiniteSets, TLC
+
+CONSTANTS Keepers
+
+VARIABLES
+  phase,            \* keeper -> {Idle, Running, PauseHuman, StaleRunning, Resolved}
+  emitted,          \* keeper -> BOOLEAN  (broadcast already emitted)
+  ticks             \* monotonic clock for liveness fairness
+
+vars == <<phase, emitted, ticks>>
+
+Phases == {"Idle", "Running", "PauseHuman", "StaleRunning", "Resolved"}
+
+TypeOK ==
+  /\ phase \in [Keepers -> Phases]
+  /\ emitted \in [Keepers -> BOOLEAN]
+  /\ ticks \in Nat
+
+Init ==
+  /\ phase = [k \in Keepers |-> "Idle"]
+  /\ emitted = [k \in Keepers |-> FALSE]
+  /\ ticks = 0
+
+Tick ==
+  /\ ticks' = ticks + 1
+  /\ UNCHANGED <<phase, emitted>>
+
+\* A keeper picks up work.
+StartTurn(k) ==
+  /\ phase[k] = "Idle"
+  /\ phase' = [phase EXCEPT ![k] = "Running"]
+  /\ UNCHANGED <<emitted, ticks>>
+
+\* Operator gate fails (tool_required_unsatisfied / api_error / unknown).
+\* Receipt is appended; new code path emits broadcast.
+EnterPauseHuman(k) ==
+  /\ phase[k] = "Running"
+  /\ phase' = [phase EXCEPT ![k] = "PauseHuman"]
+  /\ emitted' = [emitted EXCEPT ![k] = TRUE]      \* Step 2 emit
+  /\ UNCHANGED ticks
+
+\* Heartbeat fiber blocks; no receipt. Watchdog is the only path that
+\* rescues this from silence.
+EnterStaleRunning(k) ==
+  /\ phase[k] = "Running"
+  /\ phase' = [phase EXCEPT ![k] = "StaleRunning"]
+  /\ UNCHANGED <<emitted, ticks>>
+
+WatchdogEmit(k) ==
+  /\ phase[k] = "StaleRunning"
+  /\ ~emitted[k]
+  /\ emitted' = [emitted EXCEPT ![k] = TRUE]      \* Step 3 emit
+  /\ UNCHANGED <<phase, ticks>>
+
+\* Operator acts on broadcast (out of scope: just terminal sink).
+Resolve(k) ==
+  /\ emitted[k]
+  /\ phase[k] \in {"PauseHuman", "StaleRunning"}
+  /\ phase' = [phase EXCEPT ![k] = "Resolved"]
+  /\ UNCHANGED <<emitted, ticks>>
+
+Next ==
+  \/ \E k \in Keepers : StartTurn(k) \/ EnterPauseHuman(k)
+                       \/ EnterStaleRunning(k) \/ WatchdogEmit(k)
+                       \/ Resolve(k)
+  \/ Tick
+
+Spec ==
+  /\ Init
+  /\ [][Next]_vars
+  /\ \A k \in Keepers : WF_vars(WatchdogEmit(k))
+  /\ \A k \in Keepers : WF_vars(Resolve(k))
+
+\* === Bug Model ===========================================================
+\* Models the pre-fix behavior: PauseHuman emit is silently dropped,
+\* watchdog emit absent. This must violate the safety/liveness pair.
+
+EnterPauseHumanBuggy(k) ==
+  /\ phase[k] = "Running"
+  /\ phase' = [phase EXCEPT ![k] = "PauseHuman"]
+  /\ UNCHANGED <<emitted, ticks>>           \* note: no emit
+
+NextBuggy ==
+  \/ \E k \in Keepers : StartTurn(k) \/ EnterPauseHumanBuggy(k)
+                       \/ EnterStaleRunning(k) \/ Resolve(k)
+  \/ Tick
+
+SpecBuggy ==
+  /\ Init
+  /\ [][NextBuggy]_vars
+
+\* === Properties ==========================================================
+
+\* Safety (per-step). A keeper that has reached PauseHuman or StaleRunning
+\* must not advance past those phases (toward Resolved) without first
+\* emitting. emitted is monotone-increasing.
+EmittedBeforeResolved ==
+  \A k \in Keepers : phase[k] = "Resolved" => emitted[k]
+
+\* Liveness. A pause/stall always leads to an emitted broadcast.
+PauseLeadsToBroadcast ==
+  \A k \in Keepers :
+    (phase[k] \in {"PauseHuman", "StaleRunning"}) ~> emitted[k]
+
+\* Composite invariant the user actually cares about: the gate verdict
+\* never sits silent forever.
+OperatorPauseEverHandled == PauseLeadsToBroadcast
+
+============================================================================

--- a/test/dune
+++ b/test/dune
@@ -74,6 +74,7 @@
         test_keeper_accountability
         test_accountability_emit_skip_10314
         test_keeper_exec_status
+        test_keeper_pause_broadcast
         test_keeper_adaptive_thinking
         test_keeper_turn_intent
         test_keeper_lifecycle
@@ -225,6 +226,7 @@
           test_keeper_accountability
           test_accountability_emit_skip_10314
           test_keeper_exec_status
+          test_keeper_pause_broadcast
         test_keeper_adaptive_thinking
           test_keeper_turn_intent
           test_keeper_lifecycle

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -1,0 +1,210 @@
+(* Tests for keeper_execution_receipt operator_disposition / broadcast hook
+   (#fleet-stall 2026-04-26).
+
+   Verifies that the silent-dead-end fix in
+   [Keeper_execution_receipt.append] classifies pause/exhausted/unknown
+   states as broadcast-worthy, while healthy/forward-progress states do
+   not trigger an operator broadcast. The end-to-end Activity_graph emit
+   path is exercised by the integration smoke (Step 5 part 2). *)
+
+open Alcotest
+
+module R = Masc_mcp.Keeper_execution_receipt
+
+let mk_tool_surface ?(tool_requirement = "required")
+    ?(missing_required_tools = []) () : R.tool_surface =
+  {
+    turn_lane = "unified";
+    tool_surface_class = "post_dispatch";
+    tool_requirement;
+    visible_tool_count = 1;
+    tool_gate_enabled = true;
+    tool_surface_fallback_used = false;
+    required_tools = [];
+    missing_required_tools;
+  }
+
+let mk_receipt
+    ?(outcome = "error")
+    ?(terminal_reason_code = "")
+    ?(tool_contract_result = "satisfied")
+    ?(tools_used = [ "Read" ])
+    ?(tool_requirement = "required")
+    ?(cascade_outcome = "completed")
+    ?(error_kind = None)
+    ?(error_message = None)
+    ?(degraded_retry_applied = false)
+    ?(cascade_fallback_applied = false)
+    () : R.t =
+  {
+    keeper_name = "test-keeper";
+    agent_name = "test-agent";
+    trace_id = "trace-test";
+    generation = 1;
+    turn_count = Some 1;
+    current_task_id = None;
+    goal_ids = [];
+    outcome;
+    terminal_reason_code;
+    response_text_present = true;
+    model_used = None;
+    requested_tools = [];
+    reported_tools = [];
+    observed_tools = [];
+    canonical_tools = [];
+    unexpected_tools = [];
+    tools_used;
+    tool_contract_result;
+    tool_surface = mk_tool_surface ~tool_requirement ();
+    sandbox_kind = "local";
+    sandbox_root = None;
+    network_mode = "offline";
+    approval_profile = None;
+    approval_profile_derived = false;
+    cascade_name = "default";
+    cascade_selected_model = None;
+    cascade_attempt_count = 1;
+    cascade_fallback_applied;
+    cascade_outcome;
+    degraded_retry_applied;
+    degraded_retry_cascade = None;
+    fallback_reason = None;
+    cascade_rotation_attempts = [];
+    stop_reason = None;
+    error_kind;
+    error_message;
+    started_at = "2026-04-26T00:00:00Z";
+    ended_at = "2026-04-26T00:00:01Z";
+  }
+
+let check_disp label receipt expected_disp expected_reason =
+  let disp, reason = R.operator_disposition receipt in
+  check string (label ^ " (disposition)") expected_disp disp;
+  check string (label ^ " (reason)") expected_reason reason
+
+(* === Bug class: tool_contract_result violations must pause_human ====== *)
+
+let violation_variants =
+  [
+    "violated";
+    "unknown";
+    "needs_execution_progress";
+    "missing_required_tool_use";
+    "passive_only";
+    "claim_only_after_owned_task";
+    "tool_surface_mismatch";
+    "no_tool_capable_provider";
+  ]
+
+let test_pause_human_for_each_violation () =
+  List.iter
+    (fun v ->
+      let r = mk_receipt ~tool_contract_result:v () in
+      check_disp ("violation:" ^ v) r "pause_human"
+        "tool_required_unsatisfied")
+    violation_variants
+
+let test_pause_human_when_no_tools_used () =
+  let r = mk_receipt ~tools_used:[] () in
+  check_disp "tools_used=[]" r "pause_human" "tool_required_unsatisfied"
+
+(* === Cascade exhausted always alerts ================================ *)
+
+let test_alert_for_cascade_exhausted () =
+  let r =
+    mk_receipt ~terminal_reason_code:"cascade_exhausted"
+      ~cascade_outcome:"exhausted" ()
+  in
+  check_disp "cascade_exhausted" r "alert_exhausted" "cascade_exhausted"
+
+(* === Unknown / unmapped state must NOT silently look healthy ========= *)
+
+let test_unknown_when_unmapped () =
+  let r =
+    mk_receipt ~outcome:"weird" ~cascade_outcome:"weird"
+      ~tool_contract_result:"satisfied" ()
+  in
+  check_disp "unmapped" r "unknown" "unmapped_cascade_state"
+
+(* === Forward-progress states do NOT broadcast ======================== *)
+
+let test_pass_for_healthy () =
+  let r =
+    mk_receipt ~outcome:"ok" ~cascade_outcome:"completed"
+      ~tool_contract_result:"satisfied" ~terminal_reason_code:"completed"
+      ()
+  in
+  check_disp "healthy" r "pass" "healthy"
+
+let test_pass_next_for_cascade_fallback () =
+  let r =
+    mk_receipt ~cascade_fallback_applied:true
+      ~cascade_outcome:"passed_to_next_model"
+      ~tool_contract_result:"satisfied" ()
+  in
+  check_disp "cascade_fallback" r "pass_next_model" "cascade_fallback"
+
+let test_fail_open_for_degraded_retry () =
+  let r =
+    mk_receipt ~degraded_retry_applied:true
+      ~tool_contract_result:"satisfied" ()
+  in
+  check_disp "degraded_retry" r "fail_open_next_cascade" "degraded_retry"
+
+(* === Trigger predicate ============================================== *)
+
+let test_needs_broadcast_predicate () =
+  check bool "pause_human triggers" true (R.needs_operator_broadcast "pause_human");
+  check bool "alert_exhausted triggers" true
+    (R.needs_operator_broadcast "alert_exhausted");
+  check bool "unknown triggers" true (R.needs_operator_broadcast "unknown");
+  check bool "pass does not" false (R.needs_operator_broadcast "pass");
+  check bool "pass_next_model does not" false
+    (R.needs_operator_broadcast "pass_next_model");
+  check bool "fail_open_next_cascade does not" false
+    (R.needs_operator_broadcast "fail_open_next_cascade")
+
+(* === Symmetric coverage: each broadcast disposition is reachable ===== *)
+
+let test_each_broadcast_disp_is_reachable () =
+  (* pause_human via violation *)
+  let r1 = mk_receipt ~tool_contract_result:"violated" () in
+  let d1, _ = R.operator_disposition r1 in
+  check bool "pause_human reachable" true (R.needs_operator_broadcast d1);
+  (* alert_exhausted via cascade_outcome *)
+  let r2 = mk_receipt ~cascade_outcome:"cascade_exhausted" () in
+  let d2, _ = R.operator_disposition r2 in
+  check bool "alert_exhausted reachable" true (R.needs_operator_broadcast d2);
+  (* unknown via unmapped *)
+  let r3 =
+    mk_receipt ~outcome:"weird" ~cascade_outcome:"weird"
+      ~tool_contract_result:"satisfied" ()
+  in
+  let d3, _ = R.operator_disposition r3 in
+  check bool "unknown reachable" true (R.needs_operator_broadcast d3)
+
+let () =
+  run "keeper_pause_broadcast"
+    [
+      ( "operator_disposition",
+        [
+          test_case "all 8 contract violations -> pause_human" `Quick
+            test_pause_human_for_each_violation;
+          test_case "tools_used=[] -> pause_human" `Quick
+            test_pause_human_when_no_tools_used;
+          test_case "cascade_exhausted -> alert_exhausted" `Quick
+            test_alert_for_cascade_exhausted;
+          test_case "unmapped -> unknown" `Quick test_unknown_when_unmapped;
+          test_case "ok+completed -> pass" `Quick test_pass_for_healthy;
+          test_case "fallback -> pass_next_model" `Quick
+            test_pass_next_for_cascade_fallback;
+          test_case "degraded -> fail_open_next_cascade" `Quick
+            test_fail_open_for_degraded_retry;
+        ] );
+      ( "needs_operator_broadcast",
+        [
+          test_case "exact predicate" `Quick test_needs_broadcast_predicate;
+          test_case "all 3 broadcast paths reachable" `Quick
+            test_each_broadcast_disp_is_reachable;
+        ] );
+    ]


### PR DESCRIPTION
## Background — Fleet Stall 2026-04-26

Dashboard에서 14개 keeper가 두 군집으로 정확히 갈렸음:
- **stale 5종** (federated-rabin, velvet-hammer, sangsu, masc-improver, +1) — `KSM=Running이지만 live turn 없음 · latest 30m ago · last receipt: healthy`
- **정체 9종** (taskmaster/scholar/ramarama/nick0cave/ollama-local/janitor/executor + issue_king/analyst + qa-king) — `operator pause: tool_required_unsatisfied` 또는 `terminal: ollama_saturated`

사용자 비판 (정확히 코드로 입증됨):
> 제한이 이런식으로 있다면 분명히 널리 전반적 오퍼레이터에게 알려서 승인 여부를 묻던가, 자동으로 수퍼바이저가 이 다음 상황으로 인계해야 한다.

탐색 결과 `operator_disposition`은 receipt의 derived 필드일 뿐 어떤 transition도 emit하지 않았고, supervisor/broadcast는 권한·텍스트로만 존재. `keeper_keepalive`의 heartbeat과 turn-dispatch는 같은 Eio fiber에 fuse되어 turn block이 곧 watchdog 부재.

## 변경 요약 (Sharp Fail-Loud)

| Step | 위치 | 동작 |
|------|------|------|
| **2 broadcast emit** | `keeper_execution_receipt.append` | disposition이 \`pause_human\` / \`alert_exhausted\` / \`unknown\`이면 \`keeper.operator_broadcast_required\` Activity_graph 이벤트 emit. fail-closed (Log.Keeper.error). |
| **3 stale watchdog fiber** | `keeper_supervisor.launch_supervised_fiber` | 별도 \`Eio.Fiber.fork ~sw:ctx.sw\`. 30s 폴, 300s threshold + 300s cooldown. \`emit_stale_keeper_broadcast\` 호출. env knob 없음. |
| **4 TLA+** | `specs/keeper-state-machine/OperatorPauseBroadcast.tla` | \`Spec\`(clean, WF on WatchdogEmit/Resolve) + \`SpecBuggy\`(emit 삼킴). invariant \`PauseLeadsToBroadcast\` (leads-to). cfg 2개. |
| **5 unit tests** | `test/test_keeper_pause_broadcast.ml` | 9 케이스 PASS (0.001s). 8 contract violation × pause_human, tools_used=[], cascade_exhausted, unmapped→unknown, 3 forward-progress(broadcast 안 함), predicate 정확성+도달성. |

Step 1 (Terminal enum 승격)은 broadcast 자체보다 quality 개선이라 후속 PR로 분리.

## Critical Files

- `lib/keeper/keeper_execution_receipt.ml` (+95) — needs_operator_broadcast, emit_operator_broadcast, emit_stale_keeper_broadcast, append hook
- `lib/keeper/keeper_execution_receipt.mli` (+24) — operator_disposition + needs_operator_broadcast 노출 (테스트용)
- `lib/keeper/keeper_supervisor.ml` (+57) — watchdog fiber 별도 fork
- `specs/keeper-state-machine/OperatorPauseBroadcast.tla` (+121, new) + 2 cfg
- `test/test_keeper_pause_broadcast.ml` (+184, new)
- `test/dune` (+2)

## 검증

- ✅ \`dune build lib/\` exit=0 (full lib build, 43 concurrent dune contention 환경)
- ✅ \`dune exec test/test_keeper_pause_broadcast.exe\` — 9/9 PASS
- ⏳ TLC 검증은 로컬 미설치 (CI에서 실행 권장)
- ⏳ 14 keeper 그대로 둔 채 watchdog 5분 후 broadcast 발생 여부 관찰 (smoke)

## Memory references

- no-collapse-richer-enum-at-sdk-boundary (Step 1 deferred 근거)
- gate-response-llm-readable (broadcast fail-closed)
- no-hyperparameter-as-env-knob (코드 상수)
- keeper-dashboard-same-domain-coupling (fiber-fusion 진단)
- tla-spec-audit-outcome-trichotomy (clean+buggy cfg 둘 다 검증)
- do-not-merge-label-insufficient (이 PR 생성 직후 ready --undo + merge --disable-auto 이중 복구)

## Plan

\`planning/claude-plans/20m-stale-ksm-running-federated-rabin.md\`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>