### PR TITLE
refactor(keeper): migrate 4 Sandbox/Turn_sandbox timeout literals to SSOT (#10426 P2-B)

### DIFF
--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -68,7 +68,10 @@ let start_managed_container
     let network_args, network_label =
       Keeper_sandbox_runtime.docker_network_args network_mode
     in
-    match live_containers ~config ~meta ~timeout_sec:2.0 with
+    let probe_timeout =
+      Env_config_exec_timeout.timeout_sec ~caller:Sandbox ()
+    in
+    match live_containers ~config ~meta ~timeout_sec:probe_timeout with
     | Ok containers -> (
         match running_managed_container ~network_label containers with
         | Some container ->
@@ -87,7 +90,9 @@ let start_managed_container
             else
               let _cleanup =
                 Keeper_sandbox_runtime.maybe_cleanup_stale_containers
-                  ~base_path:config.base_path ~timeout_sec:2.0 ()
+                  ~base_path:config.base_path
+                  ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Sandbox ())
+                  ()
               in
               match
                 Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -201,7 +201,9 @@ let run_docker_shell_command_with_status
   else
     let _cleanup =
       Keeper_sandbox_runtime.maybe_cleanup_stale_containers
-        ~base_path:config.base_path ~timeout_sec:2.0 ()
+        ~base_path:config.base_path
+        ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Sandbox ())
+        ()
     in
     match ensure_keeper_sandbox_runtime ~timeout_sec with
     | Error err -> sandbox_error err

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -135,7 +135,9 @@ let start_container (t : t) ~(timeout_sec : float) =
   else
     let _cleanup =
       Keeper_sandbox_runtime.maybe_cleanup_stale_containers
-        ~base_path:t.config.base_path ~timeout_sec:2.0 ()
+        ~base_path:t.config.base_path
+        ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Turn_sandbox ())
+        ()
     in
     match Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime ~timeout_sec with
     | Error _ as err -> err


### PR DESCRIPTION
## Why

Second call-site migration onto the `Env_config_exec_timeout` SSOT (#10452 P1). Scope continues the 1:1 default-matching strategy from #10457 (P2-A): only literals whose hardcoded value already equals the SSOT default for the chosen caller. Behavior is byte-for-byte preserved.

## What

| File | Lines | Caller | Default | Op |
|------|-------|--------|---------|-----|
| `lib/keeper/keeper_sandbox_control.ml` | 71, 90 | `Sandbox` | 2.0 | `live_containers` probe + `maybe_cleanup_stale_containers` |
| `lib/keeper/keeper_shell_docker.ml` | 204 | `Sandbox` | 2.0 | ephemeral docker shell pre-cleanup |
| `lib/keeper/keeper_turn_sandbox_runtime.ml` | 138 | `Turn_sandbox` | 2.0 | turn-scoped sandbox runtime pre-start cleanup |

Both `Sandbox` and `Turn_sandbox` defaults are 2.0 — the variant split lets operators tune budgets independently:

- `MASC_EXEC_TIMEOUT_SANDBOX_SEC` — operator-facing sandbox control
- `MASC_EXEC_TIMEOUT_TURN_SANDBOX_SEC` — turn-scoped runtime hot path

## Out of scope

- `lib/keeper/keeper_exec_shell.ml:335` (`shell_command_available` PATH probe at `~timeout_sec:2.0`) — different semantic class (command availability check, not a sandbox container operation). Deferred to a later P2 PR after audit confirms which `caller` variant fits.
- All other `~timeout_sec` literals in `lib/keeper/`, `lib/coord/`, `lib/dashboard_*` etc. — staged across P2-C / P2-D / P2-E.

## Verification

- `dune build lib/ --root . --cache=disabled` → RC=0.
- Defaults equal to literals (verified by `test_known_default_pin` in #10452).

## Why this small?

Per `feedback_dont-overgeneralize-review-findings`: ≤4 sites per PR keeps drift visible in review. The next bucket is `Pr_review` / `Alerting` / `Gh_shared` mixed group — distinct PR.

---

Refs: #10426 (audit + 3-phase plan), #10452 (P1 SSOT scaffold), #10457 (P2-A first migration).
