### PR TITLE
fix(keeper): raise turn_timeout default 1200→3600 (sync with #9637)

### DIFF
--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -72,7 +72,7 @@ let autonomous_max_idle_turns_live () =
 let turn_timeout_sec_live () =
   Float.max 60.0
     (Float.min 3600.0
-       (get_float ~default:1200.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
+       (get_float ~default:3600.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
 
 let admission_wait_timeout_sec_live () =
   Float.max 5.0


### PR DESCRIPTION
## 요약

#9637 가 keeper turn wall-clock timeout default 를 1200s → 3600s 로 raise 했지만, 같은 env var (`MASC_KEEPER_TURN_TIMEOUT_SEC`) 를 읽는 두 번째 위치 (`lib/keeper/keeper_runtime_resolved.ml:75`) 가 누락되어 있었다. 이게 server bootstrap path (`Keeper_runtime_resolved.init`) 에서 실제 사용되는 default 라서, env var 미설정 시 모든 keeper turn 이 ~1170-1220s 에서 timeout으로 종결됐다.

## 패치

```diff
 let turn_timeout_sec_live () =
   Float.max 60.0
     (Float.min 3600.0
-       (get_float ~default:1200.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
+       (get_float ~default:3600.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
```

1줄 변경. 다른 default 는 sync 됨:
- `lib/config/env_config_keeper.ml:303` → `default:3600.0` ✓
- `lib/config/env_config_snapshot.ml:735` → `default:"3600.0"` ✓
- `lib/keeper/keeper_runtime_resolved.ml:75` → `default:1200.0` ❌ → **3600.0 (this PR)**

`admission_wait_timeout_sec_live` (line 79) 의 `Float.min 1200.0` clamp 는 **별도 변수** (`MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC`) 의 의도된 cap 이므로 변경하지 않음.

## Repro

`a562056b2b` binary 가동 중 9건 timeout 누적 (cross-cascade, cross-keeper):

| keeper | turns | cascade | latency |
|--------|-------|---------|---------|
| nick0cave | 298, 299, 300 | ollama_only | 1170-1203s |
| scholar | 15 | big_three | 1170s |
| executor | 18, 19, 21 | big_three | 1170-1221s |
| qa-king | 265, 266 | ollama_only | 1170-1189s |

3 cascade 종류, 4 keeper, 3 binary 모두 동일 ~1200s timeout — env_config_keeper default(3600) 과 무관하게 1200s 적용 = `keeper_runtime_resolved` 가 actual SSOT 임을 확인.

## Active path 검증

`grep` 결과 `Keeper_runtime_resolved` 호출 위치:
- `lib/server/server_runtime_bootstrap.ml:273` `Keeper_runtime_resolved.init ()` (server startup)
- `lib/server/server_dashboard_http_runtime_info.ml:455` (dashboard 노출)
- `lib/keeper/keeper_turn_up_create.ml:141` `bootstrap_max_active_keepers ()`
- `lib/operator/operator_control_snapshot.ml` (operator paths)

→ dead code 아님, production turn dispatch path 의 active 컴포넌트.

## Test plan

- [ ] CI `dune build` + `runtest` green
- [ ] 머지 후 restart → keeper turn 이 1200s 에서 끊기지 않는지 1h 관찰
- [ ] env_config_keeper.ml + env_config_snapshot.ml 의 3600 default 와 sync 확인 (이미 일치)

## Memory 패턴

`oas-pin-must-bump-version-floor` 와 유사 — multi-axis sync 에서 한 location 누락. #9637 변경 시 keeper_runtime_resolved.ml 누락이 root cause.

🤖 Diagnosed by /loop monitoring cycle, evidence in reports/masc-error-rca-20260425-005144.md context.