### PR TITLE
fix(oas-sse-bridge): handle InferenceTelemetry variant after OAS pin bump

### DIFF
--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -333,6 +333,12 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
            ?turn:(payload_int_opt "turn" payload)
            ?tool_name:(payload_string_opt "tool_name" payload)
            ())
+  | Oas.Event_bus.InferenceTelemetry _ ->
+      (* Per-token telemetry from OAS#1202; not surfaced over SSE — the
+         dashboard receives token usage via the existing AgentCompleted
+         payload aggregate. Skip the relay to avoid flooding SSE
+         consumers with high-frequency low-value events. *)
+      None
 
 let relay_max_attempts = 3
 let relay_max_queue_depth = 256


### PR DESCRIPTION
## Why

#10481 bumped the OAS pin to \`367de4e\`, which adds the \`InferenceTelemetry\` variant to \`Oas.Event_bus.event\`. The \`native_event_to_json\` match in \`lib/oas_sse_bridge.ml\` is non-exhaustive (no catch-all), so under CI's \`OCAMLPARAM=_,warn-error=+a\` the new variant trips warning 8 \`[partial-match]\` and breaks the Lint job.

#10478 merged through this window because its CI snapshot pre-dated #10481 by ~2 minutes — it never re-ran against the bumped pin. Subsequent PRs (e.g. #10483) hit the broken state on first CI run.

## What

Add an explicit \`InferenceTelemetry _ -> None\` case to \`native_event_to_json\`. Drop the event from the SSE relay on purpose:

- It is per-token high-frequency telemetry from OAS#1202.
- The dashboard already receives token usage aggregated in \`AgentCompleted.result\`.
- Routing each token event through SSE would flood consumers with low-value frames.

## Why an explicit case, not a catch-all

A trailing \`| _ -> None\` would also silence the warning, but it would also silently mask future variants from #10481-style pin bumps. Keeping the match exhaustive surfaces the next variant as a CI build-error — same spirit as the OAS pin bump drift gate (\`feedback_oas-pin-bump-drift-gate.md\`).

## Verify

- Local \`opam reinstall agent_sdk\` to the same pin (\`367de4e\`).
- \`OCAMLPARAM='_,warn-error=+a' dune build @check\` passes after \`rm -rf _build\`.
- Reproduces the CI Lint failure pre-fix; clean post-fix.

## Risk

Low. Same observable wire format. Telemetry callers via OAS direct hooks are unaffected; only the SSE bridge declines to relay this variant.