### PR TITLE
fix(oas-sse-bridge): handle InferenceTelemetry variant — unbreaks main build

### DIFF
--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -314,6 +314,28 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
         ]
       in
       Some (wrap ~event_type:"slot_scheduler_observed" ~payload ())
+  | Oas.Event_bus.InferenceTelemetry
+      { agent_name; turn; provider; model
+      ; prompt_tokens; completion_tokens
+      ; prompt_ms; decode_ms; decode_tok_s } ->
+      let int_opt = function Some n -> `Int n | None -> `Null in
+      let float_opt = function Some f -> `Float f | None -> `Null in
+      let payload =
+        `Assoc
+          [ ("agent_name", `String agent_name)
+          ; ("turn", `Int turn)
+          ; ("provider", `String provider)
+          ; ("model", `String model)
+          ; ("prompt_tokens", int_opt prompt_tokens)
+          ; ("completion_tokens", int_opt completion_tokens)
+          ; ("prompt_ms", float_opt prompt_ms)
+          ; ("decode_ms", float_opt decode_ms)
+          ; ("decode_tok_s", float_opt decode_tok_s)
+          ]
+      in
+      Some
+        (wrap ~event_type:"inference_telemetry" ~payload
+           ~agent_name ~turn ())
   | Oas.Event_bus.Custom (name, payload) ->
       (* Wire compatibility: dashboard consumers historically decoded
          [masc:broadcast] / [masc:keeper:snapshot] (all colons).


### PR DESCRIPTION
## Why (P0 — main does not build)

OAS pin bump #10481 (`367de4e`, OAS PR #1202) added a new `InferenceTelemetry` variant to `Oas.Event_bus.payload`. `lib/oas_sse_bridge.ml:native_event_to_json` is an exhaustive match — the new variant triggered warning 8 (partial-match) which this project promotes to error. `dune build` on main fails immediately:

```
File "lib/oas_sse_bridge.ml", lines 126-335, characters 2-14:
Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
  Here is an example of a case that is not matched: InferenceTelemetry _
```

## What

Add a serialization arm before the `Custom` catch-all that surfaces the full record as a JSON payload:

```ocaml
| Oas.Event_bus.InferenceTelemetry
    { agent_name; turn; provider; model
    ; prompt_tokens; completion_tokens
    ; prompt_ms; decode_ms; decode_tok_s } ->
    let int_opt = function Some n -> `Int n | None -> `Null in
    let float_opt = function Some f -> `Float f | None -> `Null in
    let payload =
      `Assoc
        [ ("agent_name", `String agent_name)
        ; ("turn", `Int turn)
        ; ("provider", `String provider)
        ; ("model", `String model)
        ; ("prompt_tokens", int_opt prompt_tokens)
        ; ("completion_tokens", int_opt completion_tokens)
        ; ("prompt_ms", float_opt prompt_ms)
        ; ("decode_ms", float_opt decode_ms)
        ; ("decode_tok_s", float_opt decode_tok_s)
        ]
    in
    Some
      (wrap ~event_type:"inference_telemetry" ~payload
         ~agent_name ~turn ())
```

Wrap envelope passes `~agent_name` and `~turn` so SSE consumers can correlate inference timings with the matching `TurnCompleted` event. Optional fields (token counts, ms timings, throughput) become explicit `` `Null `` when None — matching the convention used by `AgentCompleted`'s usage block (line 144-149).

## Verification

```bash
dune build lib/oas_sse_bridge.ml --cache=disabled  # RC=0
dune build lib/                  --cache=disabled  # RC=0 (regression-free)
```

## Risk / scope

- **Pure additive**: no existing arm modified. Behavior of all other variants unchanged.
- **No test added**: this is a 1-arm patch on a serialization function whose other arms have no test coverage either. Adding a test fixture for `InferenceTelemetry` JSON shape is reasonable but not blocking — staged as a follow-up if needed.
- **Other Event_bus consumers** (`lib/server/server_bootstrap_loops.ml`, `lib/keeper/keeper_unified_turn.ml`, `lib/keeper/keeper_guards.ml`) all match specific variants (not exhaustive) — no other warn 8 triggers.

---

P0 unblocks every in-flight PR (CI red across the board until main builds again).

Refs: #10481 (OAS pin bump), OAS PR #1202 (InferenceTelemetry).
