### PR TITLE
feat(auth): add load_credential_of for explicit identity-mismatch surfacing (RFC P2-a)

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -348,6 +348,36 @@ let load_credential_with_aliases config agent_name : agent_credential option =
       legacy_credential_aliases agent_name
       |> List.find_map (load_credential config)
 
+type load_credential_error =
+  | Credential_missing of { ctx_agent_name : string }
+  | Credential_mismatch of {
+      ctx_agent_name : string;
+      resolved_credential_stem : string;
+    }
+
+let pp_load_credential_error fmt = function
+  | Credential_missing { ctx_agent_name } ->
+      Format.fprintf fmt
+        "Credential_missing { ctx_agent_name = %S }" ctx_agent_name
+  | Credential_mismatch { ctx_agent_name; resolved_credential_stem } ->
+      Format.fprintf fmt
+        "Credential_mismatch { ctx_agent_name = %S; resolved_credential_stem \
+         = %S }"
+        ctx_agent_name resolved_credential_stem
+
+let show_load_credential_error err =
+  Format.asprintf "%a" pp_load_credential_error err
+
+let load_credential_of config ~ctx_agent_name ~resolved_credential_stem :
+    (agent_credential, load_credential_error) result =
+  if String.equal resolved_credential_stem ctx_agent_name then
+    match load_credential config ctx_agent_name with
+    | Some cred -> Ok cred
+    | None -> Error (Credential_missing { ctx_agent_name })
+  else
+    Error
+      (Credential_mismatch { ctx_agent_name; resolved_credential_stem })
+
 (** Save agent credential.
 
     When [cred.id] is present the credential is stored under

--- a/lib/auth.mli
+++ b/lib/auth.mli
@@ -45,6 +45,64 @@ val load_credential : string -> string -> agent_credential option
 (** [load_credential config agent_name] looks up the agent's credential.
     Falls back to agent-type prefix for generated nicknames. *)
 
+(** Outcome of {!load_credential_of}: distinguishes "no credential file
+    at all" from "credential found but its owner does not match the
+    dispatcher-validated [ctx_agent_name]".  The second case is the
+    {b dual identity} mode where {!load_credential} silently returned a
+    credential whose [agent_name] differs from the caller's claimed
+    identity (e.g. requested [sangsu] resolves to bare-nickname cred
+    while [ctx_agent_name] is [keeper-sangsu-agent]).
+    [load_credential_of] surfaces the mismatch instead of
+    perpetuating it. *)
+type load_credential_error =
+  | Credential_missing of { ctx_agent_name : string }
+  | Credential_mismatch of {
+      ctx_agent_name : string;
+      resolved_credential_stem : string;
+    }
+
+val pp_load_credential_error :
+  Format.formatter -> load_credential_error -> unit
+
+val show_load_credential_error : load_credential_error -> string
+
+val load_credential_of :
+  string ->
+  ctx_agent_name:string ->
+  resolved_credential_stem:string ->
+  (agent_credential, load_credential_error) result
+(** [load_credential_of config ~ctx_agent_name ~resolved_credential_stem]
+    looks up a keeper credential and {b rejects identity drift
+    explicitly}.
+
+    Caller is responsible for resolving the requested alias to a
+    [resolved_credential_stem] before calling — typically through
+    {!Keeper_identity.normalize_all_names} on the dispatch site.  This
+    keeps [Auth] free of any dependency on [Keeper_identity] (the
+    inverse direction is required by P3 preflight, so Auth → Keeper
+    would be a cycle).
+
+    Branches (RFC §2.2, adjusted for the dependency direction):
+    {ul
+    {- [resolved_credential_stem = ctx_agent_name] — load directly.
+       Returns [Error (Credential_missing _)] on absence.}
+    {- otherwise — return [Error (Credential_mismatch _)] {b without}
+       falling back to a different identity, even when a credential
+       for [resolved_credential_stem] exists on disk.}}
+
+    Convention: when the caller has nothing to resolve (empty alias or
+    alias already equal to ctx), it should pass [ctx_agent_name] as
+    [resolved_credential_stem]; the function then degenerates to a
+    simple exact-match lookup with explicit error variants.
+
+    This replaces the silent fallback in {!load_credential_with_aliases}
+    where a stem of [sangsu] against a [ctx_agent_name] of
+    [keeper-sangsu-agent] would return the bare-nickname credential and
+    perpetuate dual identity.  Callers that still need the legacy
+    behavior keep using {!load_credential_with_aliases}; new dispatcher
+    paths should adopt [load_credential_of] one site at a time
+    (RFC P2-b through P2-d). *)
+
 val save_credential : string -> agent_credential -> unit
 
 val delete_credential : string -> string -> unit

--- a/test/dune
+++ b/test/dune
@@ -69,6 +69,7 @@
         test_process_timeout_counter
         test_git_fetch_timeout_9587
         test_auth_ambiguous_lookup_9786
+        test_auth_load_credential_of
         test_keeper_wake_telemetry
         test_keeper_memory
         test_keeper_accountability
@@ -221,6 +222,7 @@
           test_process_timeout_counter
           test_git_fetch_timeout_9587
           test_auth_ambiguous_lookup_9786
+          test_auth_load_credential_of
           test_keeper_wake_telemetry
           test_keeper_memory
           test_keeper_accountability

--- a/test/test_auth_load_credential_of.ml
+++ b/test/test_auth_load_credential_of.ml
@@ -1,0 +1,143 @@
+(* test/test_auth_load_credential_of.ml
+
+   RFC P2-a unit test for [Auth.load_credential_of].
+
+   Pins the 3 explicit branches that distinguish "credential missing"
+   from "credential exists but its owner does not match the dispatcher
+   ctx" — the dual-identity surfacing semantic that
+   [load_credential_with_aliases] silently absorbs.
+
+   Cases:
+   1. resolved_credential_stem = ctx_agent_name, file exists -> Ok
+   2. resolved_credential_stem = ctx_agent_name, file missing -> Error Credential_missing
+   3. resolved_credential_stem <> ctx_agent_name -> Error Credential_mismatch
+      (even when a credential for resolved_credential_stem exists on disk
+       — the function rejects rather than falling back) *)
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then (
+      Sys.readdir path
+      |> Array.iter (fun e -> rm_rf (Filename.concat path e));
+      Unix.rmdir path)
+    else
+      Sys.remove path
+
+let with_temp_base f =
+  let base =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-p2a-loadof-%06x" (Random.bits ()))
+  in
+  Unix.mkdir base 0o755;
+  Fun.protect
+    ~finally:(fun () -> rm_rf base)
+    (fun () -> f base)
+
+let write_cred ~base ~agent_name ~token_hash =
+  let agents_dir = Filename.concat base ".masc/auth/agents" in
+  let rec mkdirs p =
+    if Sys.file_exists p then ()
+    else begin
+      mkdirs (Filename.dirname p);
+      try Unix.mkdir p 0o755 with Unix.Unix_error _ -> ()
+    end
+  in
+  mkdirs agents_dir;
+  let path = Filename.concat agents_dir (agent_name ^ ".json") in
+  let json =
+    Printf.sprintf
+      "{\"agent_name\":%S,\"token\":%S,\"role\":\"agent\",\"created_at\":\"2026-04-26T00:00:00Z\"}"
+      agent_name token_hash
+  in
+  let oc = open_out path in
+  output_string oc json;
+  close_out oc
+
+let test_exact_match_load_ok () =
+  with_temp_base (fun base ->
+    write_cred ~base ~agent_name:"keeper-sangsu-agent"
+      ~token_hash:"abc123";
+    match
+      Masc_mcp.Auth.load_credential_of base
+        ~ctx_agent_name:"keeper-sangsu-agent"
+        ~resolved_credential_stem:"keeper-sangsu-agent"
+    with
+    | Ok cred ->
+        assert (cred.agent_name = "keeper-sangsu-agent");
+        print_endline "PASS: exact match -> Ok cred"
+    | Error e ->
+        Printf.printf "FAIL: expected Ok, got Error %s\n"
+          (Masc_mcp.Auth.show_load_credential_error e);
+        exit 1)
+
+let test_exact_match_missing_returns_credential_missing () =
+  with_temp_base (fun base ->
+    (* No cred file written *)
+    match
+      Masc_mcp.Auth.load_credential_of base
+        ~ctx_agent_name:"keeper-ghost-agent"
+        ~resolved_credential_stem:"keeper-ghost-agent"
+    with
+    | Ok _ ->
+        print_endline "FAIL: expected Credential_missing, got Ok";
+        exit 1
+    | Error (Masc_mcp.Auth.Credential_missing { ctx_agent_name }) ->
+        assert (ctx_agent_name = "keeper-ghost-agent");
+        print_endline "PASS: missing file -> Credential_missing"
+    | Error (Masc_mcp.Auth.Credential_mismatch _) ->
+        print_endline "FAIL: expected Credential_missing, got Credential_mismatch";
+        exit 1)
+
+let test_mismatch_rejects_even_when_resolved_stem_exists () =
+  (* Dual-identity scenario: bare nickname cred exists on disk, but ctx
+     is canonical. load_credential_of must reject rather than fall back. *)
+  with_temp_base (fun base ->
+    write_cred ~base ~agent_name:"sangsu" ~token_hash:"bare-token";
+    write_cred ~base ~agent_name:"keeper-sangsu-agent"
+      ~token_hash:"canonical-token";
+    match
+      Masc_mcp.Auth.load_credential_of base
+        ~ctx_agent_name:"keeper-sangsu-agent"
+        ~resolved_credential_stem:"sangsu"
+    with
+    | Ok _ ->
+        print_endline "FAIL: expected Credential_mismatch, got Ok (silent fallback)";
+        exit 1
+    | Error (Masc_mcp.Auth.Credential_missing _) ->
+        print_endline "FAIL: expected Credential_mismatch, got Credential_missing";
+        exit 1
+    | Error
+        (Masc_mcp.Auth.Credential_mismatch
+           { ctx_agent_name; resolved_credential_stem }) ->
+        assert (ctx_agent_name = "keeper-sangsu-agent");
+        assert (resolved_credential_stem = "sangsu");
+        print_endline
+          "PASS: ctx<>stem -> Credential_mismatch (no silent fallback)")
+
+let test_mismatch_rejects_even_when_neither_exists () =
+  with_temp_base (fun base ->
+    match
+      Masc_mcp.Auth.load_credential_of base
+        ~ctx_agent_name:"keeper-a-agent"
+        ~resolved_credential_stem:"b"
+    with
+    | Ok _ ->
+        print_endline "FAIL: expected Credential_mismatch";
+        exit 1
+    | Error (Masc_mcp.Auth.Credential_missing _) ->
+        print_endline "FAIL: ctx<>stem must take mismatch branch even when nothing exists";
+        exit 1
+    | Error
+        (Masc_mcp.Auth.Credential_mismatch
+           { ctx_agent_name; resolved_credential_stem }) ->
+        assert (ctx_agent_name = "keeper-a-agent");
+        assert (resolved_credential_stem = "b");
+        print_endline "PASS: empty filesystem still produces Credential_mismatch")
+
+let () =
+  Random.self_init ();
+  test_exact_match_load_ok ();
+  test_exact_match_missing_returns_credential_missing ();
+  test_mismatch_rejects_even_when_resolved_stem_exists ();
+  test_mismatch_rejects_even_when_neither_exists ();
+  print_endline "All P2-a load_credential_of tests passed"


### PR DESCRIPTION
## Summary
- 새 함수 `Auth.load_credential_of`: dispatcher-validated `ctx_agent_name` vs caller-resolved `resolved_credential_stem` 비교 → 일치 시 load, 불일치 시 `Credential_mismatch` error.
- 새 nominal variant `load_credential_error` (`Credential_missing` / `Credential_mismatch`) + pp/show helpers.
- 기존 `load_credential` / `load_credential_with_aliases` 그대로 유지 → caller migrate 0건 → 운영 영향 0.

## Why (사용자 우려와 직접 매핑)
사용자 명시 의도: \"keeper-sangsu-agent === sangsu, 다중이 인격안하도록 동일성 유지\".

검증된 evidence (2026-04-26):
- 6 keeper(sangsu/issue_king/janitor/masc-improver/nick0cave/qa-king)가 bare nickname + canonical \`keeper-X-agent\` cred 양쪽 다 보유, **다른 token**
- \`load_credential_with_aliases:344-349\` first-hit로 caller alias가 결정론적으로 cred 선택 → dual identity 분열 영속
- 119 \`silent_auth_token_resolve_error / token_mismatch\` burst (2026-04-25 19:18-19:25, 7분)는 이 mechanism의 downstream 증상

본 PR은 RFC P2-a — 새 dispatcher 경로가 dual identity를 silent 통과시키지 않고 explicit error로 reject할 수 있는 함수를 추가. caller migration은 후속 P2-b/c/d/e PR.

## Scope
- 변경 파일 2: \`lib/auth.ml\`, \`lib/auth.mli\`
- 변경 라인 +88
- caller migrate: 0
- 기존 동작: 변화 없음

## Design deviation from RFC §2.2
RFC §2.2 spec은 Auth 안에서 \`Keeper_identity.normalize_all_names\` 호출. 그러나 Keeper_identity의 \`~check_credential\` 옵션이 Auth를 호출 → \`Auth → Keeper_identity → Auth\` transitive cycle. dune이 reject.

해결: caller-side normalize. Auth는 stem 비교만, normalize는 caller(P2-b/c) 책임. layer order 유지.

## Test plan
- [ ] dune build (main의 \`lib/oas_sse_bridge.ml\` partial-match 깨짐은 본 PR 무관 — 별도 PR로 해결 필요)
- [ ] unit test 추가 (별도 commit 또는 P2-b 동반):
  - empty stem == ctx → load 성공
  - exact match → load 성공
  - mismatch → \`Credential_mismatch\`
  - missing file → \`Credential_missing\`
- [ ] 첫 caller (P2-b: server_auth.ml:655) 머지 후 fleet smoke

## References
- RFC: \`~/me/planning/2026-04-25-keeper-identity-canonicalization-rfc.md\` §2.2
- Implementation supplement: \`~/me/planning/2026-04-26-keeper-identity-implementation-supplement.md\`
- memory: \`feedback_dual-identity-credential-coexistence.md\`, \`feedback_keeper-credential-name-drift.md\`

## Series
- **P2-a (this)**: additive function only
- P2-b: server_auth.ml first caller migrate
- P2-c: dispatcher / transport caller migrate
- P2-d: auth_doctor migrate
- P2-e: load_credential_with_aliases deprecate

🤖 Generated with [Claude Code](https://claude.com/claude-code)