### PR TITLE
feat(keeper): per-variant terminal_reason_code for Oas.Error.Api

### DIFF
--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -52,13 +52,32 @@ let sdk_error_kind = function
   | Oas.Error.A2a _ -> "a2a"
   | Oas.Error.Internal _ -> "internal"
 
+(* Per-variant terminal_reason_code for Oas.Error.Api.
+   Previously every API failure collapsed to "api_error", so 7 keepers
+   stuck on different conditions (rate limit, overload, server fault,
+   auth) all displayed the same dashboard chip and the broadcast
+   payload could not differentiate them. Memory:
+   no-collapse-richer-enum-at-sdk-boundary. *)
+let api_error_terminal_reason_code (err : Oas.Error.api_error) : string =
+  match err with
+  | Oas.Retry.RateLimited _ -> "api_error_rate_limited"
+  | Oas.Retry.Overloaded _ -> "api_error_overloaded"
+  | Oas.Retry.ServerError { status; _ } ->
+    Printf.sprintf "api_error_server:%d" status
+  | Oas.Retry.AuthError _ -> "api_error_auth"
+  | Oas.Retry.InvalidRequest _ -> "api_error_invalid_request"
+  | Oas.Retry.NotFound _ -> "api_error_not_found"
+  | Oas.Retry.ContextOverflow _ -> "api_error_context_overflow"
+  | Oas.Retry.NetworkError _ -> "api_error_network"
+  | Oas.Retry.Timeout _ -> "api_error_timeout"
+
 let terminal_reason_code_of_sdk_error = function
   | Oas.Error.Agent
       (Oas.Error.CompletionContractViolation { contract; _ }) ->
     Printf.sprintf
       "completion_contract_violation:%s"
       (Oas.Completion_contract_id.to_string contract)
-  | Oas.Error.Api _ -> "api_error"
+  | Oas.Error.Api err -> api_error_terminal_reason_code err
   | Oas.Error.Agent _ -> "agent_error"
   | Oas.Error.Mcp _ -> "mcp_error"
   | Oas.Error.Config _ -> "config_error"

--- a/test/dune
+++ b/test/dune
@@ -75,6 +75,7 @@
         test_accountability_emit_skip_10314
         test_keeper_exec_status
         test_keeper_pause_broadcast
+        test_keeper_terminal_reason
         test_keeper_adaptive_thinking
         test_keeper_turn_intent
         test_keeper_lifecycle
@@ -227,6 +228,7 @@
           test_accountability_emit_skip_10314
           test_keeper_exec_status
           test_keeper_pause_broadcast
+          test_keeper_terminal_reason
         test_keeper_adaptive_thinking
           test_keeper_turn_intent
           test_keeper_lifecycle

--- a/test/test_keeper_terminal_reason.ml
+++ b/test/test_keeper_terminal_reason.ml
@@ -1,0 +1,126 @@
+(* Tests for keeper_agent_error.terminal_reason_code_of_sdk_error.
+
+   Before this change, every Agent_sdk.Error.Api variant collapsed to a single
+   "api_error" string, so the dashboard chip + the operator broadcast
+   payload could not differentiate rate-limit / overload / auth / server
+   faults. These tests pin down the per-variant terminal reason code so a
+   future refactor cannot silently re-collapse the enum (memory:
+   no-collapse-richer-enum-at-sdk-boundary). *)
+
+open Alcotest
+
+module KAE = Masc_mcp.Keeper_agent_error
+
+let mk_api err = Agent_sdk.Error.Api err
+let code = KAE.terminal_reason_code_of_sdk_error
+
+let test_rate_limited () =
+  check string "rate_limited" "api_error_rate_limited"
+    (code (mk_api (Agent_sdk.Retry.RateLimited
+                     { retry_after = None; message = "x" })))
+
+let test_overloaded () =
+  check string "overloaded" "api_error_overloaded"
+    (code (mk_api (Agent_sdk.Retry.Overloaded { message = "x" })))
+
+let test_server_error_includes_status () =
+  check string "server 503" "api_error_server:503"
+    (code (mk_api (Agent_sdk.Retry.ServerError { status = 503; message = "x" })));
+  check string "server 500" "api_error_server:500"
+    (code (mk_api (Agent_sdk.Retry.ServerError { status = 500; message = "x" })))
+
+let test_auth_error () =
+  check string "auth" "api_error_auth"
+    (code (mk_api (Agent_sdk.Retry.AuthError { message = "x" })))
+
+let test_invalid_request () =
+  check string "invalid_request" "api_error_invalid_request"
+    (code (mk_api (Agent_sdk.Retry.InvalidRequest { message = "x" })))
+
+let test_not_found () =
+  check string "not_found" "api_error_not_found"
+    (code (mk_api (Agent_sdk.Retry.NotFound { message = "x" })))
+
+let test_context_overflow () =
+  check string "context_overflow" "api_error_context_overflow"
+    (code (mk_api (Agent_sdk.Retry.ContextOverflow
+                     { message = "x"; limit = Some 200_000 })))
+
+let test_network_error () =
+  check string "network" "api_error_network"
+    (code (mk_api (Agent_sdk.Retry.NetworkError
+                     { message = "x"
+                     ; kind = Llm_provider.Http_client.Connection_refused })))
+
+let test_timeout () =
+  check string "timeout" "api_error_timeout"
+    (code (mk_api (Agent_sdk.Retry.Timeout { message = "x" })))
+
+(* Other variants kept their existing codes — guard against accidental
+   churn in adjacent branches. *)
+
+let test_other_variants_unchanged () =
+  check string "agent" "agent_error"
+    (code (Agent_sdk.Error.Agent
+             (Agent_sdk.Error.MaxTurnsExceeded { turns = 1; limit = 1 })));
+  check string "mcp" "mcp_error"
+    (code (Agent_sdk.Error.Mcp
+             (Agent_sdk.Error.InitializeFailed { detail = "x" })));
+  check string "config" "config_error"
+    (code (Agent_sdk.Error.Config
+             (Agent_sdk.Error.MissingEnvVar { var_name = "X" })));
+  check string "io" "io_error"
+    (code (Agent_sdk.Error.Io (Agent_sdk.Error.ValidationFailed { detail = "x" })));
+  check string "internal" "internal_error"
+    (code (Agent_sdk.Error.Internal "x"))
+
+(* No two distinct API variants share a code — that's the whole point.
+   Encode it as a property: the 9 returned codes are pairwise distinct. *)
+
+let test_all_api_codes_distinct () =
+  let codes =
+    [
+      code (mk_api (Agent_sdk.Retry.RateLimited
+                      { retry_after = None; message = "" }));
+      code (mk_api (Agent_sdk.Retry.Overloaded { message = "" }));
+      code (mk_api (Agent_sdk.Retry.ServerError { status = 503; message = "" }));
+      code (mk_api (Agent_sdk.Retry.AuthError { message = "" }));
+      code (mk_api (Agent_sdk.Retry.InvalidRequest { message = "" }));
+      code (mk_api (Agent_sdk.Retry.NotFound { message = "" }));
+      code (mk_api (Agent_sdk.Retry.ContextOverflow
+                      { message = ""; limit = None }));
+      code (mk_api (Agent_sdk.Retry.NetworkError
+                      { message = ""
+                      ; kind = Llm_provider.Http_client.Connection_refused }));
+      code (mk_api (Agent_sdk.Retry.Timeout { message = "" }));
+    ]
+  in
+  let unique =
+    List.sort_uniq String.compare codes |> List.length
+  in
+  check int "9 variants -> 9 distinct codes" 9 unique
+
+let () =
+  run "keeper_terminal_reason"
+    [
+      ( "api_error variants",
+        [
+          test_case "RateLimited" `Quick test_rate_limited;
+          test_case "Overloaded" `Quick test_overloaded;
+          test_case "ServerError carries status" `Quick
+            test_server_error_includes_status;
+          test_case "AuthError" `Quick test_auth_error;
+          test_case "InvalidRequest" `Quick test_invalid_request;
+          test_case "NotFound" `Quick test_not_found;
+          test_case "ContextOverflow" `Quick test_context_overflow;
+          test_case "NetworkError" `Quick test_network_error;
+          test_case "Timeout" `Quick test_timeout;
+        ] );
+      ( "regression",
+        [
+          test_case "non-Api variants unchanged" `Quick
+            test_other_variants_unchanged;
+          test_case "all 9 api codes are pairwise distinct" `Quick
+            test_all_api_codes_distinct;
+        ] );
+    ]


### PR DESCRIPTION
## Background

Follow-up to [#10484](https://github.com/jeong-sik/masc-mcp/pull/10484) (keeper pause broadcast + watchdog). That PR introduced the broadcast hook; this PR makes the broadcast *content* discriminating instead of generic.

\`Oas.Error.Api\` is already a 9-variant rich enum (\`Retry.api_error\`: RateLimited, Overloaded, ServerError, AuthError, InvalidRequest, NotFound, ContextOverflow, NetworkError, Timeout). \`keeper_agent_error.terminal_reason_code_of_sdk_error\` collapsed all of these to a single \`"api_error"\` string. Result on the fleet stall dashboard: 7 keepers all showed \`terminal: api_error\` with no way to distinguish a rate-limit from a 5xx server fault from a network failure.

Memory: \`no-collapse-richer-enum-at-sdk-boundary\` — this is the masc-mcp side of that guard.

## Variant mapping

| Variant | New code |
|---|---|
| \`RateLimited\` | \`api_error_rate_limited\` |
| \`Overloaded\` | \`api_error_overloaded\` |
| \`ServerError\` | \`api_error_server:<status>\` |
| \`AuthError\` | \`api_error_auth\` |
| \`InvalidRequest\` | \`api_error_invalid_request\` |
| \`NotFound\` | \`api_error_not_found\` |
| \`ContextOverflow\` | \`api_error_context_overflow\` |
| \`NetworkError\` | \`api_error_network\` |
| \`Timeout\` | \`api_error_timeout\` |

\`ServerError\` keeps the HTTP status because three keepers stuck on different 5xx codes is a different operator decision from one stuck on 503 overload — status is the cheapest disambiguator already in the variant.

## Drive-by fix (separate commit)

Commit 1 wires \`Oas.Event_bus.InferenceTelemetry\` in \`lib/oas_sse_bridge.ml\`. The OAS pin bump #10481 introduced this variant but did not update the consumer; with \`dune-project [-warn-error +8]\`, any test target fails to link. \`lib/\` alone builds because the partial-match warning only surfaces when the consumer is reached during dependent compilation. This was blocking ALL test runs on main — separate commit to keep the Step 1 diff reviewable.

## Compatibility

- Receipt schema unchanged. Only the content of an existing \`terminal_reason_code\` string becomes more specific.
- \`rg '"api_error"'\` over lib/ + test/ confirms no caller pattern-matches on the literal old string.
- Adjacent (non-Api) branches preserved verbatim. Regression test pins them.

## Tests

\`test/test_keeper_terminal_reason.ml\` — 11 cases, all passing (0.001s):
- 9 Api variants, each pinned to its code
- ServerError carries status (503, 500 verified)
- Non-Api variants unchanged (regression guard)
- Property: all 9 Api codes pairwise distinct

## Commits

1. \`fix(oas-bridge): wire InferenceTelemetry SSE projection (#10481 follow-up)\`
2. \`feat(keeper): per-variant terminal_reason_code for Oas.Error.Api\`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>