### PR TITLE
fix(oas-sse-bridge): handle InferenceTelemetry variant from OAS 0.176.0

### DIFF
--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -314,6 +314,32 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
         ]
       in
       Some (wrap ~event_type:"slot_scheduler_observed" ~payload ())
+  | Oas.Event_bus.InferenceTelemetry
+      { agent_name; turn; provider; model;
+        prompt_tokens; completion_tokens;
+        prompt_ms; decode_ms; decode_tok_s } ->
+      let int_opt = function
+        | None -> `Null
+        | Some n -> `Int n
+      in
+      let float_opt = function
+        | None -> `Null
+        | Some f -> `Float f
+      in
+      let payload =
+        `Assoc [
+          ("agent_name", `String agent_name);
+          ("turn", `Int turn);
+          ("provider", `String provider);
+          ("model", `String model);
+          ("prompt_tokens", int_opt prompt_tokens);
+          ("completion_tokens", int_opt completion_tokens);
+          ("prompt_ms", float_opt prompt_ms);
+          ("decode_ms", float_opt decode_ms);
+          ("decode_tok_s", float_opt decode_tok_s);
+        ]
+      in
+      Some (wrap ~event_type:"inference_telemetry" ~payload ~agent_name ~turn ())
   | Oas.Event_bus.Custom (name, payload) ->
       (* Wire compatibility: dashboard consumers historically decoded
          [masc:broadcast] / [masc:keeper:snapshot] (all colons).


### PR DESCRIPTION
## 요약

OAS 0.176.0+ `Event_bus.InferenceTelemetry` variant (per-turn 추론 timings + token usage)가 추가됐으나 masc-mcp `oas_sse_bridge.ml`이 미처리하여 main 빌드가 `partial-match` warning-as-error로 깨짐.

## 진단

- main HEAD `145858df1d`에서 `dune build` 실패
- 위치: `lib/oas_sse_bridge.ml:126-335` `native_event_to_json` match
- 누락 case: `Oas.Event_bus.InferenceTelemetry _`
- 메모리 \`feedback_oas-pin-bump-drift-gate.md\` (masc-mcp#8023)의 정확한 패턴 — pinned SHA 공개 타입 표면 drift

## fix

`SlotSchedulerObserved` 직후, `Custom` 직전에 explicit case 추가:
- 9 필드 모두 emit (agent_name/turn/provider/model + option int×2 + option float×3)
- `wrap` 호출에 `~agent_name ~turn` 전달 (다른 envelope 일관성)
- option 필드는 \`Null\`로 (OAS mli 가이드: 부재 필드는 \"backend did not report\" — fabricate 금지)

## 안티패턴 회피

메모리 \`feedback_no-silent-protocol-downgrade-for-telemetry.md\` (masc-mcp#8968/#8969) 경고에 따라 wildcard drop 대신 explicit emit. dashboard inference_telemetry 신호 보존.

## 검증

- \`DUNE_CACHE=disabled dune build --root=. --cache=disabled @check\` exit 0
- 26 insertions / 0 deletions / 1 file