### PR TITLE
feat(provider-tool-support): per-provider filter rejection observability (#10474)

### DIFF
--- a/lib/provider_tool_support.ml
+++ b/lib/provider_tool_support.ml
@@ -118,10 +118,109 @@ let supports_required_tool_use ?runtime_mcp_policy
     | false, true -> caps.supports_inline_tools || runtime_mcp
     | false, false -> true
 
+(* #10474: when [supports_required_tool_use] returns false, attribute
+   the rejection to the most actionable single cause so dashboards
+   can show "5 codex_cli + 1 kimi_cli rejected for
+   runtime_mcp_http_headers_required" instead of a flat counter.
+
+   Priority order (most-specific first):
+   1. [runtime_mcp_http_headers_required] — runtime_mcp caps are
+      present but the policy demands HTTP headers and the provider
+      does not support them. This is the #10474 case; operator can
+      either swap to stdio MCP or pick header-capable providers.
+   2. [runtime_mcp_caps_missing] — provider lacks
+      [supports_runtime_mcp_tools] or [supports_runtime_tool_events].
+      Inline path was also unavailable; cascade authoring problem.
+   3. [inline_tool_choice_unsupported] — only [require_tool_choice]
+      mode and provider has no [supports_inline_tool_choice].
+   4. [inline_tools_unsupported] — only [require_tool_support] mode
+      and provider has no [supports_inline_tools].
+   5. [filter_disabled] — both [require_*] flags false, no rejection
+      should occur; emitted only as a defensive default.
+
+   Returns [None] when the provider passes the filter; classification
+   is only meaningful for the rejection path. *)
+type rejection_reason =
+  | Runtime_mcp_http_headers_required
+  | Runtime_mcp_caps_missing
+  | Inline_tool_choice_unsupported
+  | Inline_tools_unsupported
+  | Filter_disabled
+
+let rejection_reason_label = function
+  | Runtime_mcp_http_headers_required -> "runtime_mcp_http_headers_required"
+  | Runtime_mcp_caps_missing -> "runtime_mcp_caps_missing"
+  | Inline_tool_choice_unsupported -> "inline_tool_choice_unsupported"
+  | Inline_tools_unsupported -> "inline_tools_unsupported"
+  | Filter_disabled -> "filter_disabled"
+
+let classify_rejection ?runtime_mcp_policy
+    ~require_tool_choice_support ~require_tool_support
+    (provider_cfg : Llm_provider.Provider_config.t) =
+  if not require_tool_choice_support && not require_tool_support then
+    None
+  else if supports_required_tool_use ?runtime_mcp_policy
+            ~require_tool_choice_support ~require_tool_support
+            provider_cfg
+  then None
+  else
+    let caps = capabilities_of_config provider_cfg in
+    let runtime_mcp_caps_ok =
+      caps.supports_runtime_mcp_tools && caps.supports_runtime_tool_events
+    in
+    let runtime_mcp_blocked_by_headers =
+      runtime_mcp_caps_ok &&
+      (match runtime_mcp_policy with
+       | Some policy ->
+         runtime_mcp_policy_requires_http_headers policy
+         && not caps.supports_runtime_mcp_http_headers
+       | None -> false)
+    in
+    let inline_path_ok =
+      match require_tool_choice_support, require_tool_support with
+      | true, _ -> caps.supports_inline_tool_choice
+      | false, true -> caps.supports_inline_tools
+      | false, false -> true
+    in
+    if runtime_mcp_blocked_by_headers && not inline_path_ok then
+      Some Runtime_mcp_http_headers_required
+    else if not runtime_mcp_caps_ok && not inline_path_ok then
+      Some Runtime_mcp_caps_missing
+    else if require_tool_choice_support
+            && not caps.supports_inline_tool_choice
+            && not runtime_mcp_caps_ok then
+      Some Inline_tool_choice_unsupported
+    else if require_tool_support
+            && not caps.supports_inline_tools
+            && not runtime_mcp_caps_ok then
+      Some Inline_tools_unsupported
+    else
+      Some Filter_disabled
+
 let provider_debug_label (cfg : Llm_provider.Provider_config.t) =
   Printf.sprintf "%s:%s"
     (Llm_provider.Provider_config.string_of_provider_kind cfg.kind)
     cfg.model_id
+
+let provider_kind_label (cfg : Llm_provider.Provider_config.t) =
+  Llm_provider.Provider_config.string_of_provider_kind cfg.kind
+
+(* #10474: emit a Prometheus counter per rejected provider so
+   operators can see which rejection reason dominates per cascade.
+   Cardinality: cascades × provider_kinds × ~5 reasons; bounded by
+   the small set of cascade names actually configured (~10) and
+   provider kinds (~10). *)
+let cascade_filter_rejection_metric =
+  "masc_cascade_filter_rejection_total"
+
+let record_filter_rejection ~cascade ~provider_cfg ~reason =
+  Prometheus.inc_counter cascade_filter_rejection_metric
+    ~labels:[
+      ("cascade", cascade);
+      ("provider_kind", provider_kind_label provider_cfg);
+      ("reason", rejection_reason_label reason);
+    ]
+    ()
 
 let apply_required_tool_use_filter ?runtime_mcp_policy
     ~require_tool_choice_support ~require_tool_support ~label
@@ -129,13 +228,28 @@ let apply_required_tool_use_filter ?runtime_mcp_policy
   if not require_tool_choice_support && not require_tool_support then
     providers
   else
-    let filtered =
-      List.filter
+    let kept, rejected =
+      List.partition
         (supports_required_tool_use ?runtime_mcp_policy
            ~require_tool_choice_support ~require_tool_support)
         providers
     in
-    if filtered = [] && providers <> [] then (
+    (* #10474: emit per-provider rejection observability so dashboards
+       can attribute "cascade dead" events to a specific cause. The
+       all-providers-removed warn line below kept for human-readable
+       logs; counter is the machine-consumable signal. *)
+    List.iter
+      (fun provider_cfg ->
+        match
+          classify_rejection ?runtime_mcp_policy
+            ~require_tool_choice_support ~require_tool_support
+            provider_cfg
+        with
+        | Some reason ->
+          record_filter_rejection ~cascade:label ~provider_cfg ~reason
+        | None -> ())
+      rejected;
+    if kept = [] && providers <> [] then (
       let runtime_mcp_http_headers =
         match runtime_mcp_policy with
         | Some policy -> runtime_mcp_policy_requires_http_headers policy
@@ -146,4 +260,4 @@ let apply_required_tool_use_filter ?runtime_mcp_policy
         label
         (String.concat ", " (List.map provider_debug_label providers))
         runtime_mcp_http_headers);
-    filtered
+    kept

--- a/test/dune
+++ b/test/dune
@@ -672,6 +672,7 @@
         test_keeper_turn_timeout_default_10456
         test_task_status_label_10421
         test_task_completion_path_10449
+        test_filter_rejection_10474
         test_personality_field_diff_10269
         test_toml_skip_dedup_10259
         test_discovery_history_models_10404
@@ -858,6 +859,7 @@
         test_keeper_turn_timeout_default_10456
         test_task_status_label_10421
         test_task_completion_path_10449
+        test_filter_rejection_10474
         test_personality_field_diff_10269
         test_toml_skip_dedup_10259
         test_discovery_history_models_10404

--- a/test/test_filter_rejection_10474.ml
+++ b/test/test_filter_rejection_10474.ml
@@ -1,0 +1,100 @@
+(** #10474: pin the [classify_rejection] vocabulary that feeds
+    [masc_cascade_filter_rejection_total]. Each branch represents
+    a distinct operator action, so collapsing the labels would
+    erase the actionable diagnosis ("swap to stdio MCP" vs "add
+    a header-capable provider" vs "fix cascade authoring"). *)
+
+open Alcotest
+module P = Masc_mcp.Provider_tool_support
+module L = Llm_provider
+
+(* Build a minimal Provider_config; [Provider_config.make] applies
+   per-kind defaults so the test stays aligned with capability
+   resolution (which keys off [kind] + [model_id]). *)
+let make_provider ~kind ~model_id =
+  L.Provider_config.make ~kind ~model_id ~base_url:"" ()
+
+let codex = make_provider ~kind:Codex_cli ~model_id:"gpt-5.4"
+let kimi = make_provider ~kind:Kimi_cli ~model_id:"kimi-for-coding"
+
+let policy_with_headers : L.Llm_transport.runtime_mcp_policy =
+  { L.Llm_transport.empty_runtime_mcp_policy with
+    servers = [
+      L.Llm_transport.Http_server {
+        name = "test_http";
+        url = "https://example/mcp";
+        headers = [ ("authorization", "Bearer x") ];
+      }
+    ];
+  }
+
+let policy_without_headers : L.Llm_transport.runtime_mcp_policy =
+  { L.Llm_transport.empty_runtime_mcp_policy with
+    servers = [
+      L.Llm_transport.Stdio_server {
+        name = "test_stdio";
+        command = "mcp";
+        args = [];
+        env = [];
+      }
+    ];
+  }
+
+let label = function
+  | Some r -> P.rejection_reason_label r
+  | None -> "<accepted>"
+
+(* Codex_cli has tool_policy=no_tool_http_headers; so it cannot satisfy
+   a runtime_mcp_policy that needs headers. *)
+let test_codex_blocked_by_headers () =
+  let r =
+    P.classify_rejection ~runtime_mcp_policy:policy_with_headers
+      ~require_tool_choice_support:true ~require_tool_support:true codex
+  in
+  check string "codex_cli rejected with header-required policy"
+    "runtime_mcp_http_headers_required" (label r)
+
+(* Kimi_cli's normalize_cli_provider_caps sets runtime_mcp_tools=true
+   AND supports_tool_choice=false; so it relies entirely on runtime
+   mcp. With a policy that demands HTTP headers and kimi_cli's
+   no_tool_http_headers policy, the rejection cause is the same as
+   codex — the tool_policy mismatch, not capability gaps. *)
+let test_kimi_blocked_by_headers () =
+  let r =
+    P.classify_rejection ~runtime_mcp_policy:policy_with_headers
+      ~require_tool_choice_support:true ~require_tool_support:true kimi
+  in
+  check string "kimi_cli rejected with header-required policy"
+    "runtime_mcp_http_headers_required" (label r)
+
+(* Without HTTP headers in the policy, kimi_cli passes via runtime
+   mcp because it has runtime_mcp_tools=true. *)
+let test_kimi_passes_stdio_policy () =
+  let r =
+    P.classify_rejection ~runtime_mcp_policy:policy_without_headers
+      ~require_tool_choice_support:true ~require_tool_support:true kimi
+  in
+  check string "kimi_cli accepted with stdio-only policy"
+    "<accepted>" (label r)
+
+let test_filter_disabled () =
+  let r =
+    P.classify_rejection
+      ~require_tool_choice_support:false ~require_tool_support:false codex
+  in
+  check string "filter disabled returns None"
+    "<accepted>" (label r)
+
+let () =
+  run "filter_rejection_10474" [
+    ("classify_rejection", [
+        test_case "codex_cli blocked by HTTP-headers policy" `Quick
+          test_codex_blocked_by_headers;
+        test_case "kimi_cli blocked by HTTP-headers policy" `Quick
+          test_kimi_blocked_by_headers;
+        test_case "kimi_cli passes stdio-only policy" `Quick
+          test_kimi_passes_stdio_policy;
+        test_case "filter disabled bypasses classification" `Quick
+          test_filter_disabled;
+      ]);
+  ]


### PR DESCRIPTION
## Summary

Phase 1 / option C from the [#10474 mitigation plan](https://github.com/jeong-sik/masc-mcp/issues/10474#issuecomment-4320546067): emit per-provider, per-cascade rejection counters so operators can attribute "cascade dead" events to a specific cause.

The pre-existing warn-line was the only signal:
```
cascade %s: required tool-use gate removed all providers (...)
```
That tells you *that* it happened, not *why each provider* was rejected. Different rejection causes need different operator actions:

| Cause | Action |
|-------|--------|
| `runtime_mcp_http_headers_required` (#10474) | Swap to stdio MCP, or pick header-capable providers (Anthropic, Gemini API) |
| `runtime_mcp_caps_missing` | Cascade authoring fix — declared provider lacks runtime_mcp caps entirely |
| `inline_tool_choice_unsupported` | Operator picked tool_choice mode the provider can't satisfy |
| `inline_tools_unsupported` | Operator picked tool_use mode the provider can't satisfy |

Collapsing these into one label would erase the diagnosis.

## Changes

- `Provider_tool_support.rejection_reason` — typed 5-way enum (4 actionable + 1 defensive default).
- `classify_rejection` — pure helper, priority order (HTTP-headers > runtime_mcp caps > inline-*). Returns `None` when the provider passes.
- `apply_required_tool_use_filter` — `List.partition` instead of `List.filter` so the rejected set is available; emits `masc_cascade_filter_rejection_total{cascade,provider_kind,reason}` per rejected provider.
- `test/test_filter_rejection_10474.ml` — 4 cases (codex × header-policy, kimi × header-policy, kimi × stdio-policy, filter-disabled) pinning the label vocabulary.

## Cardinality

cascades × provider_kinds × ~5 reasons. Bounded by the small set of cascades configured (~10) and provider kinds (~10). Safe for Prometheus.

## Why structural

This is a **Layer 2 blind spot fix**, same class as #9864 (sibling memory entry: `feedback_cascade-declared-vs-runtime-two-filter-layers`). The runtime filter rejects providers but doesn't tell anyone *which gate* rejected them. `classify_rejection` is the audit trail that turns "cascade dead" into a 1-line operator instruction.

## Local build note

Local opam has `agent_sdk = 0.176.0-5-gNNN` (post-`InferenceTelemetry`). Repo's `agent_sdk.opam` requires `>= 0.176.0` so CI installs `= 0.176.0` (pre-variant), but local pulls in newer with the new event variant, breaking `lib/oas_sse_bridge.ml` exhaustiveness for unrelated reasons. Code in this PR was verified to compile standalone (`Provider_tool_support` cmx) and types/classifier covered by the new test. Will file separate issue for the OAS pin / oas_sse_bridge gap.

## Verification

- [x] Module compiles standalone (`provider_tool_support.cmx`)
- [x] Classifier coverage by `test/test_filter_rejection_10474.ml` (4 cases)
- [ ] CI runs full build + test
- [ ] Operator review of label vocabulary before metric is dashboard-ed

## Roadmap

- **Phase 1 (this PR)**: per-provider rejection observability.
- Phase 2: cascade authoring-time validation (issue #10474 option E) — flag cascades whose declared providers all reject under expected runtime_mcp_policy.
- Phase 3 (operator): audit `governance_judge`, `operator_judge` cascades for the same fault class.

Refs #9864 (sibling Layer 2 fix), #10449 (sibling completion-path observability), memory `feedback_cascade-declared-vs-runtime-two-filter-layers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)