### PR TITLE
fix(sse_bridge): handle Oas.Event_bus.InferenceTelemetry

### DIFF
--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -314,6 +314,26 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
         ]
       in
       Some (wrap ~event_type:"slot_scheduler_observed" ~payload ())
+  | Oas.Event_bus.InferenceTelemetry
+      { agent_name; turn; provider; model;
+        prompt_tokens; completion_tokens;
+        prompt_ms; decode_ms; decode_tok_s } ->
+      let int_opt v = Option.fold ~none:`Null ~some:(fun i -> `Int i) v in
+      let float_opt v = Option.fold ~none:`Null ~some:(fun f -> `Float f) v in
+      let payload =
+        `Assoc [
+          ("agent_name", `String agent_name);
+          ("turn", `Int turn);
+          ("provider", `String provider);
+          ("model", `String model);
+          ("prompt_tokens", int_opt prompt_tokens);
+          ("completion_tokens", int_opt completion_tokens);
+          ("prompt_ms", float_opt prompt_ms);
+          ("decode_ms", float_opt decode_ms);
+          ("decode_tok_s", float_opt decode_tok_s);
+        ]
+      in
+      Some (wrap ~event_type:"inference_telemetry" ~payload ~agent_name ~turn ())
   | Oas.Event_bus.Custom (name, payload) ->
       (* Wire compatibility: dashboard consumers historically decoded
          [masc:broadcast] / [masc:keeper:snapshot] (all colons).


### PR DESCRIPTION
## Summary
- OAS PR#1202가 도입한 `InferenceTelemetry` constructor가 `oas_sse_bridge.ml`의 기존 match에 누락되어 warning 8 (partial-match) → build error 발생.
- 새 case를 추가해 inference_telemetry SSE event로 wire (agent_name, turn, provider, model, prompt/completion tokens, prompt/decode ms, decode_tok_s).
- 이 fix가 없으면 agent_sdk@367de4e5로 pin된 상태에서 masc-mcp main_eio.exe 빌드 자체가 깨짐 → OAS PR#1199 (codex `--ephemeral` session race fix) 배포도 막힘.

## Why this matters now
- 진행 중 keeper 디버깅에서 OAS pin은 이미 `367de4e5`로 갱신됨 (PR#1199/#1200/#1202 포함)
- 그러나 masc-mcp 빌드 안 되어 서버는 5:27 KST 시작된 OLD binary로 계속 운영 중
- 결과: 04-26 system_log에 64건 `codex_core::session: thread <id> not found` errors 잔존 (PR#1199 배포되면 0이 될 패턴)

## Test plan
- [x] `dune build bin/main_eio.exe` succeeds (44 MB binary 생성, mtime 10:37 KST 검증)
- [x] `strings main_eio.exe | grep -c ephemeral` returns 6 (OAS#1199 fix 포함 확인)
- [ ] 서버 재시작 후 codex thread-not-found errors 0으로 떨어지는지 확인

## Memory rules referenced
- `OAS pin bump drift gate` (#8023) — 이번 partial-match가 정확히 그 패턴
- `Korean PR/이슈 한국어` — 본문 한국어, commit/title 영어 conventional commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)