### PR TITLE
feat(design-system): migrate cb-group-* preview to --color-bg-* aliases (PR-M1)

### DIFF
--- a/dashboard/design-system/preview/cb-group-a.jsx
+++ b/dashboard/design-system/preview/cb-group-a.jsx
@@ -36,7 +36,7 @@ function TopbarStandard() {
           <span className="stamp" aria-label="Build 2604, 16:32:45 UTC">BUILD 2604 · 16:32:45Z</span>
         </div>
       </header>
-      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div style={{flex:1, background:'var(--color-bg-page)'}} aria-hidden="true" />
     </div>
   );
 }
@@ -75,7 +75,7 @@ function TopbarExpanded() {
           <span className="stamp" aria-label="5 active keepers, 2 idle">5 ACTIVE · 2 IDLE</span>
         </div>
       </header>
-      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div style={{flex:1, background:'var(--color-bg-page)'}} aria-hidden="true" />
     </div>
   );
 }
@@ -96,7 +96,7 @@ function TopbarMinimal() {
           <span className="stamp" aria-label="16:32:45 UTC">16:32:45Z</span>
         </div>
       </header>
-      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div style={{flex:1, background:'var(--color-bg-page)'}} aria-hidden="true" />
     </div>
   );
 }
@@ -121,7 +121,7 @@ function TickerMarquee() {
           ))}
         </div>
       </div>
-      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div style={{flex:1, background:'var(--color-bg-page)'}} aria-hidden="true" />
     </div>
   );
 }
@@ -140,7 +140,7 @@ function TickerChunks() {
           ))}
         </div>
       </div>
-      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div style={{flex:1, background:'var(--color-bg-page)'}} aria-hidden="true" />
     </div>
   );
 }
@@ -160,7 +160,7 @@ function TickerVertical() {
           ))}
         </div>
       </div>
-      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div style={{flex:1, background:'var(--color-bg-page)'}} aria-hidden="true" />
     </div>
   );
 }
@@ -195,7 +195,7 @@ function KpiStandard() {
           </div>
         ))}
       </div>
-      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div style={{flex:1, background:'var(--color-bg-page)'}} aria-hidden="true" />
     </div>
   );
 }
@@ -210,7 +210,7 @@ function KpiCompact() {
           </div>
         ))}
       </div>
-      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div style={{flex:1, background:'var(--color-bg-page)'}} aria-hidden="true" />
     </div>
   );
 }
@@ -226,7 +226,7 @@ function KpiStacked() {
           </div>
         ))}
       </div>
-      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div style={{flex:1, background:'var(--color-bg-page)'}} aria-hidden="true" />
     </div>
   );
 }
@@ -245,7 +245,7 @@ function LifelineBeat() {
         <Heartbeat phase={phase} />
         <span className="bpm" aria-hidden="true"><span className="n">72</span> BPM · 60s</span>
       </div>
-      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div style={{flex:1, background:'var(--color-bg-page)'}} aria-hidden="true" />
     </div>
   );
 }
@@ -264,7 +264,7 @@ function LifelineStacked() {
           </div>
         ))}
       </div>
-      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div style={{flex:1, background:'var(--color-bg-page)'}} aria-hidden="true" />
     </div>
   );
 }

--- a/dashboard/design-system/preview/cb-group-c.jsx
+++ b/dashboard/design-system/preview/cb-group-c.jsx
@@ -11,7 +11,7 @@ function ComposerPrompt() {
   ], 22);
   return (
     <div className="cb-board">
-      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div style={{flex:1, background:'var(--color-bg-page)'}} aria-hidden="true" />
       <div className="cb-composer" role="region" aria-label="Command composer">
         <div className="line" aria-live="polite">
           <span className="prompt" aria-hidden="true">masc&gt;</span>
@@ -40,7 +40,7 @@ function ComposerSuggest() {
   ];
   return (
     <div className="cb-board">
-      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div style={{flex:1, background:'var(--color-bg-page)'}} aria-hidden="true" />
       <div className="cb-composer" role="region" aria-label="Command composer with suggestions" style={{position:'relative'}}>
         <div className="sug" role="listbox" aria-label="Command suggestions">
           {sugs.map((s, i) => (
@@ -75,7 +75,7 @@ function ComposerSuggest() {
 function ComposerMultiLine() {
   return (
     <div className="cb-board">
-      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div style={{flex:1, background:'var(--color-bg-page)'}} aria-hidden="true" />
       <div className="cb-composer" role="region" aria-label="Multi-line command composer">
         <pre aria-label="cascade.run(goal=&quot;goal-merge-blockers&quot;, providers=[anthropic, moonshot], dry_run=false)" style={{margin:0, font:'inherit', background:'transparent'}}>
           <div className="line">
@@ -122,7 +122,7 @@ function ComposerMultiLine() {
 function StatusStandard() {
   return (
     <div className="cb-board">
-      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div style={{flex:1, background:'var(--color-bg-page)'}} aria-hidden="true" />
       <div className="cb-statusbar" role="status" aria-live="polite" aria-label="System status: connected, build 2604, version 0.42.1, anthropic ok, moonshot ok, openai degraded, xai offline, TPS 1.24s, time 16:32:45 UTC">
         <span className="seg" role="group" aria-label="Connection: connected"><span className="on" aria-hidden="true">●</span>CONNECTED</span>
         <span className="sep" aria-hidden="true" />
@@ -145,7 +145,7 @@ function StatusStandard() {
 function StatusCompact() {
   return (
     <div className="cb-board">
-      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div style={{flex:1, background:'var(--color-bg-page)'}} aria-hidden="true" />
       <div className="cb-statusbar" role="status" aria-live="polite" aria-label="MASC: 5 of 8 keepers active, 3 providers ok, TPS 1.24s">
         <span className="seg" role="group" aria-label="MASC"><span className="brass" aria-hidden="true">●</span>MASC</span>
         <span className="seg" role="group" aria-label="5 of 8 keepers active">5/8 ACTIVE</span>
@@ -159,7 +159,7 @@ function StatusCompact() {
 function StatusVerbose() {
   return (
     <div className="cb-board">
-      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div style={{flex:1, background:'var(--color-bg-page)'}} aria-hidden="true" />
       <div className="cb-statusbar" role="status" aria-live="polite" aria-label="Connected · goal goal-merge-blockers, task t-9f2a, keeper nick0cave, cascade hit at step 2 in 1.24s, suite 3 fail of 47 pass" style={{height:28, flexWrap:'wrap'}}>
         <span className="seg" role="group" aria-label="Connection: connected"><span className="on" aria-hidden="true">●</span>CONNECTED</span>
         <span className="sep" aria-hidden="true" />
@@ -274,7 +274,7 @@ function DrawerGoal() {
               <div key={t.id}
                    role="listitem"
                    aria-label={`${t.id} · ${t.title} · ${t.keeper} · ${t.status}`}
-                   style={{display:'flex', alignItems:'center', gap:7, padding:'4px 7px', background:'var(--bg-1)', border:'1px solid var(--line-1)', borderRadius:3, fontSize:11}}>
+                   style={{display:'flex', alignItems:'center', gap:7, padding:'4px 7px', background:'var(--color-bg-surface)', border:'1px solid var(--line-1)', borderRadius:3, fontSize:11}}>
                 <Dot kind={kClass(t.keeper)} size="sm" />
                 <span className="cb-mono" aria-hidden="true" style={{color:'var(--fg-4)'}}>{t.id}</span>
                 <span aria-hidden="true" style={{color:'var(--fg-1)', flex:1}}>{t.title}</span>
@@ -325,7 +325,7 @@ function DrawerKeeper() {
       <div className="body">
         <section aria-labelledby="drawer-keeper-heartbeat">
           <SectionHeading variant="title" title="HEARTBEAT" id="drawer-keeper-heartbeat" />
-          <div aria-label="Heartbeat trace, 60-second window" style={{background:'var(--bg-1)', padding:6, border:'1px solid var(--line-1)', borderRadius:3}}>
+          <div aria-label="Heartbeat trace, 60-second window" style={{background:'var(--color-bg-surface)', padding:6, border:'1px solid var(--line-1)', borderRadius:3}}>
             <span aria-hidden="true"><Heartbeat width={260} height={40} /></span>
           </div>
         </section>

--- a/dashboard/design-system/preview/cb-group-d.jsx
+++ b/dashboard/design-system/preview/cb-group-d.jsx
@@ -441,11 +441,11 @@ function ResponsibilityMatrix() {
         </table>
         <div role="note" aria-label="Matrix density legend" style={{marginTop:8, padding:'6px 8px', fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--fg-4)', display:'flex', gap:8, alignItems:'center'}}>
           <span aria-hidden="true">density:</span>
-          <span aria-hidden="true" style={{padding:'1px 6px', background:'var(--bg-0)', border:'1px solid var(--line-1)'}}>0</span>
+          <span aria-hidden="true" style={{padding:'1px 6px', background:'var(--color-bg-page)', border:'1px solid var(--line-1)'}}>0</span>
           <span aria-hidden="true" style={{padding:'1px 6px', background:'rgb(var(--brass-glow)/.05)', color:'var(--fg-2)'}}>1–2</span>
           <span aria-hidden="true" style={{padding:'1px 6px', background:'rgb(var(--brass-glow)/.12)', color:'var(--fg-1)'}}>3–4</span>
           <span aria-hidden="true" style={{padding:'1px 6px', background:'rgb(var(--brass-glow)/.22)', color:'var(--brass-1)'}}>5–6</span>
-          <span aria-hidden="true" style={{padding:'1px 6px', background:'var(--brass-1)', color:'var(--bg-0)'}}>7+</span>
+          <span aria-hidden="true" style={{padding:'1px 6px', background:'var(--brass-1)', color:'var(--color-bg-page)'}}>7+</span>
         </div>
       </div>
     </section>

--- a/dashboard/design-system/preview/cb-group-e.jsx
+++ b/dashboard/design-system/preview/cb-group-e.jsx
@@ -115,7 +115,7 @@ function BoardThread() {
             </article>
           ))}
         </div>
-        <div role="textbox" aria-label="Reply composer (placeholder)" style={{marginTop:8, padding:'6px 8px', background:'var(--bg-1)', border:'1px dashed var(--line-2)', fontFamily:'var(--font-mono)', fontSize:'11px', color:'var(--fg-4)'}}>
+        <div role="textbox" aria-label="Reply composer (placeholder)" style={{marginTop:8, padding:'6px 8px', background:'var(--color-bg-surface)', border:'1px dashed var(--line-2)', fontFamily:'var(--font-mono)', fontSize:'11px', color:'var(--fg-4)'}}>
           <span aria-hidden="true" style={{color:'var(--brass-1)'}}>masc&gt;</span> reply...
           <span aria-hidden="true" style={{color:'var(--brass-1)', animation:'anim-blink 1s step-end infinite'}}> ▌</span>
         </div>
@@ -291,7 +291,7 @@ function StateBlockMessage() {
                      role="listitem"
                      className="ms-msg"
                      aria-label={`#${m.seq} · ${m.from} ${m.kind} → #${m.room} · ${m.at}: ${m.body} · state: ${m.state}`}
-                     style={{padding:'8px 10px', background:'var(--bg-1)', border:'1px solid var(--line-1)', borderLeft:'2px solid var(--brass-2)', borderRadius:0}}>
+                     style={{padding:'8px 10px', background:'var(--color-bg-surface)', border:'1px solid var(--line-1)', borderLeft:'2px solid var(--brass-2)', borderRadius:0}}>
               <div className="seq" aria-hidden="true">#{m.seq}</div>
               <div className="body">
                 <div className="h" aria-hidden="true">
@@ -341,7 +341,7 @@ function ComposerV2Broadcast() {
           <span style={{marginLeft:'auto'}}>last broadcast 16s ago</span>
         </div>
       </div>
-      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div style={{flex:1, background:'var(--color-bg-page)'}} aria-hidden="true" />
     </div>
   );
 }
@@ -353,11 +353,11 @@ function ComposerV2Mention() {
       <div className="cm2" role="region" aria-label="Composer v2 · mention with autocomplete" style={{position:'relative'}}>
         <div role="listbox" aria-label="Mention autocomplete (match @nick)" style={{
           position:'absolute', bottom:'100%', left:14, marginBottom:4,
-          background:'var(--bg-1)', border:'1px solid var(--brass-2)', borderRadius:0, minWidth:240, padding:0,
+          background:'var(--color-bg-surface)', border:'1px solid var(--brass-2)', borderRadius:0, minWidth:240, padding:0,
           fontFamily:'var(--font-mono)', fontSize:'11px',
           boxShadow:'0 -4px 12px rgb(0 0 0 / .4)',
         }}>
-          <div role="presentation" style={{padding:'3px 8px', background:'var(--bg-2)', color:'var(--fg-4)', fontSize:'9px', letterSpacing:'.1em', textTransform:'uppercase'}}>match @nick</div>
+          <div role="presentation" style={{padding:'3px 8px', background:'var(--color-bg-panel-alt)', color:'var(--fg-4)', fontSize:'9px', letterSpacing:'.1em', textTransform:'uppercase'}}>match @nick</div>
           {[
             { id:'nick0cave', role:'Captain · merge', match:true },
             { id:'nickelodeon', role:'(unknown — alias)', match:false },
@@ -395,7 +395,7 @@ function ComposerV2Mention() {
           <span aria-hidden="true" style={{marginLeft:'auto', color:'var(--fg-4)', textTransform:'none'}}>↑↓ pick · ⇥ accept · esc dismiss</span>
         </div>
       </div>
-      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div style={{flex:1, background:'var(--color-bg-page)'}} aria-hidden="true" />
     </div>
   );
 }
@@ -432,7 +432,7 @@ function ComposerV2State() {
           <span aria-hidden="true" style={{marginLeft:'auto', color:'var(--fg-4)', textTransform:'none'}}>4 keys · valid · will update belief in 9 keepers</span>
         </div>
       </div>
-      <div style={{flex:1, background:'var(--bg-0)'}} aria-hidden="true" />
+      <div style={{flex:1, background:'var(--color-bg-page)'}} aria-hidden="true" />
     </div>
   );
 }

--- a/dashboard/design-system/preview/cb-group-f.jsx
+++ b/dashboard/design-system/preview/cb-group-f.jsx
@@ -94,7 +94,7 @@ function CascadeCompare() {
 
 function AuditLedgerHeader({ left, right }) {
   return (
-    <div role="heading" aria-level={3} style={{padding:'5px 8px',borderBottom:'1px solid var(--line-2)',display:'flex',gap:'8px',background:'var(--bg-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>
+    <div role="heading" aria-level={3} style={{padding:'5px 8px',borderBottom:'1px solid var(--line-2)',display:'flex',gap:'8px',background:'var(--color-bg-panel-alt)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>
       <span>{left}</span>
       <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{right}</span>
     </div>
@@ -121,7 +121,7 @@ function AuditRow({ e }) {
 
 function AuditLedger() {
   return (
-    <section aria-label="Audit ledger" style={{background:'var(--bg-1)',border:'1px solid var(--line-2)'}}>
+    <section aria-label="Audit ledger" style={{background:'var(--color-bg-surface)',border:'1px solid var(--line-2)'}}>
       <AuditLedgerHeader left="tail · audit.jsonl" right={`${P2f.auditEvents.length} events`} />
       <div role="log" aria-live="polite" aria-label={`${P2f.auditEvents.length} audit events`}>
         {P2f.auditEvents.map((e, i) => <AuditRow key={i} e={e} />)}
@@ -134,7 +134,7 @@ function AuditByActor() {
   const actor = 'sangsu';
   const filtered = P2f.auditEvents.filter(e => e.actor === actor || e.subject.includes(actor));
   return (
-    <section aria-label={`Audit ledger filtered by actor ${actor}`} style={{background:'var(--bg-1)',border:'1px solid var(--line-2)'}}>
+    <section aria-label={`Audit ledger filtered by actor ${actor}`} style={{background:'var(--color-bg-surface)',border:'1px solid var(--line-2)'}}>
       <AuditLedgerHeader left={`filter · actor=${actor}`} right={`${filtered.length} matches`} />
       <div role="list" aria-label={`${filtered.length} matching audit events`}>
         {filtered.map((e, i) => <AuditRow key={i} e={e} />)}
@@ -152,7 +152,7 @@ function AuditSummary() {
   const total = P2f.auditEvents.length;
   return (
     <section aria-label={`Audit summary · ${sorted.length} kinds · ${total} events`} style={{display:'flex',flexDirection:'column',gap:'2px'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
         <span>summary · last 12 events</span>
         <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{total} total</span>
       </div>
@@ -161,10 +161,10 @@ function AuditSummary() {
           const [cat] = kind.split('.');
           const pct = (n / total * 100).toFixed(0);
           return (
-            <div key={kind} role="listitem" aria-label={`${kind}: ${n} events (${pct}%)`} style={{display:'grid',gridTemplateColumns:'140px 30px 1fr',gap:'6px',alignItems:'center',padding:'3px 8px',background:'var(--bg-1)',border:'1px solid var(--line-1)'}}>
+            <div key={kind} role="listitem" aria-label={`${kind}: ${n} events (${pct}%)`} style={{display:'grid',gridTemplateColumns:'140px 30px 1fr',gap:'6px',alignItems:'center',padding:'3px 8px',background:'var(--color-bg-surface)',border:'1px solid var(--line-1)'}}>
               <span className={`kn ${cat}`} aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',padding:'1px 5px',border:'1px solid var(--line-2)',justifySelf:'flex-start'}}>{kind}</span>
               <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--brass-1)',fontVariantNumeric:'tabular-nums',textAlign:'right'}}>{n}</span>
-              <div aria-hidden="true" style={{height:'10px',background:'var(--bg-2)',border:'1px solid var(--line-1)',position:'relative'}}>
+              <div aria-hidden="true" style={{height:'10px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-1)',position:'relative'}}>
                 <div style={{height:'100%',width:`${pct}%`,background:'linear-gradient(90deg, var(--brass-3), var(--brass-1))'}}></div>
               </div>
             </div>
@@ -206,8 +206,8 @@ function SafeAutoDashboard() {
   return (
     <section aria-label="Safe Autonomy dashboard · score and findings" style={{display:'flex',flexDirection:'column',gap:'8px'}}>
       <SafeAutoHero />
-      <div style={{background:'var(--bg-1)',border:'1px solid var(--line-2)'}}>
-        <div role="heading" aria-level={3} style={{padding:'5px 8px',borderBottom:'1px solid var(--line-2)',display:'flex',gap:'8px',background:'var(--bg-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>
+      <div style={{background:'var(--color-bg-surface)',border:'1px solid var(--line-2)'}}>
+        <div role="heading" aria-level={3} style={{padding:'5px 8px',borderBottom:'1px solid var(--line-2)',display:'flex',gap:'8px',background:'var(--color-bg-panel-alt)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>
           <span>findings ({sa.findings.length})</span>
           <span style={{marginLeft:'auto'}}>severity ↓</span>
         </div>
@@ -237,13 +237,13 @@ function SafeAutoByKeeper() {
   const sorted = Object.entries(byKeeper).sort((a,b) => (b[1].high*9 + b[1].medium*3 + b[1].low) - (a[1].high*9 + a[1].medium*3 + a[1].low));
   return (
     <section aria-label={`Safe Autonomy findings · by keeper · ${sorted.length} keepers`} style={{display:'flex',flexDirection:'column',gap:'4px'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
         <span>findings by keeper</span>
         <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{sorted.length} keepers</span>
       </div>
       <div role="list">
         {sorted.map(([k, v]) => (
-          <div key={k} role="listitem" aria-label={`${k} · ${v.high} high, ${v.medium} medium, ${v.low} low`} style={{display:'grid',gridTemplateColumns:'120px 60px 60px 60px 1fr',gap:'6px',alignItems:'center',padding:'4px 8px',background:'var(--bg-1)',border:'1px solid var(--line-1)'}}>
+          <div key={k} role="listitem" aria-label={`${k} · ${v.high} high, ${v.medium} medium, ${v.low} low`} style={{display:'grid',gridTemplateColumns:'120px 60px 60px 60px 1fr',gap:'6px',alignItems:'center',padding:'4px 8px',background:'var(--color-bg-surface)',border:'1px solid var(--line-1)'}}>
             <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--brass-1)'}}>{k}</span>
             <span className="sev high"   aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',padding:'1px 5px',textAlign:'center',opacity: v.high?1:0.15}}>{v.high}</span>
             <span className="sev medium" aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',padding:'1px 5px',textAlign:'center',opacity: v.medium?1:0.15}}>{v.medium}</span>
@@ -261,7 +261,7 @@ function SafeAutoTrend() {
   const min = Math.min(...sa.history);
   const max = Math.max(...sa.history);
   return (
-    <section aria-label={`Safe Autonomy trend · last 15 runs · min ${min}, current ${sa.global_score}, max ${max}`} style={{background:'var(--bg-1)',border:'1px solid var(--line-2)',padding:'12px'}}>
+    <section aria-label={`Safe Autonomy trend · last 15 runs · min ${min}, current ${sa.global_score}, max ${max}`} style={{background:'var(--color-bg-surface)',border:'1px solid var(--line-2)',padding:'12px'}}>
       <div role="heading" aria-level={3} style={{display:'flex',gap:'12px',alignItems:'baseline',marginBottom:'8px',fontFamily:'var(--font-mono)'}}>
         <span style={{fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>autonomy score · last 15 runs</span>
         <span style={{marginLeft:'auto',fontSize:'var(--fs-10)',color:'var(--fg-3)'}}>min {min} · current <span style={{color:'var(--err-fg)'}}>{sa.global_score}</span> · max {max}</span>
@@ -362,7 +362,7 @@ function CostMatrix() {
   };
   return (
     <section aria-label={`Cost matrix · provider × model · total $${P2f.costs.total_cost_usd.toFixed(2)} over 24h`} style={{display:'flex',flexDirection:'column',gap:'8px'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
         <span>provider × model · $ spent (24h)</span>
         <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>${P2f.costs.total_cost_usd.toFixed(2)}</span>
       </div>
@@ -394,7 +394,7 @@ function CostLatency() {
   const total = buckets.reduce((s,b) => s+b.n, 0);
   return (
     <section aria-label={`Cost latency distribution · ${total} calls · p50 ${P2f.costs.p50}ms · p95 ${P2f.costs.p95}ms`} style={{display:'flex',flexDirection:'column',gap:'8px'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'12px'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'12px'}}>
         <span>latency distribution · {total} calls</span>
         <span style={{marginLeft:'auto'}}>p50 · <span style={{color:'var(--brass-1)'}}>{P2f.costs.p50}ms</span></span>
         <span>p95 · <span style={{color:'var(--err-fg)'}}>{P2f.costs.p95}ms</span></span>
@@ -418,7 +418,7 @@ function CostLatency() {
           { l:'4–16s', v: buckets.filter(b=>b.lo>=4000&&b.hi<=16000).reduce((s,b)=>s+b.n,0), c:'var(--warn)' },
           { l:'> 16s', v: buckets.filter(b=>b.lo>=16000).reduce((s,b)=>s+b.n,0), c:'var(--err-fg)' },
         ].map(b => (
-          <div key={b.l} role="listitem" aria-label={`${b.l}: ${b.v} calls (${(b.v/total*100).toFixed(0)}%)`} style={{background:'var(--bg-1)',padding:'6px 10px',display:'flex',flexDirection:'column',gap:'2px'}}>
+          <div key={b.l} role="listitem" aria-label={`${b.l}: ${b.v} calls (${(b.v/total*100).toFixed(0)}%)`} style={{background:'var(--color-bg-surface)',padding:'6px 10px',display:'flex',flexDirection:'column',gap:'2px'}}>
             <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>{b.l}</span>
             <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-13)',color:b.c,fontVariantNumeric:'tabular-nums'}}>{b.v}<span style={{fontSize:'var(--fs-10)',color:'var(--fg-4)',marginLeft:'4px'}}>· {(b.v/total*100).toFixed(0)}%</span></span>
           </div>
@@ -434,8 +434,8 @@ function CostLatency() {
 
 function HeuristicLog() {
   return (
-    <section aria-label={`Heuristic firing log · ${P2f.heuristics.filter(h=>h.triggered).length} fired of ${P2f.heuristics.length}`} style={{background:'var(--bg-1)',border:'1px solid var(--line-2)'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',borderBottom:'1px solid var(--line-2)',display:'flex',gap:'8px',background:'var(--bg-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>
+    <section aria-label={`Heuristic firing log · ${P2f.heuristics.filter(h=>h.triggered).length} fired of ${P2f.heuristics.length}`} style={{background:'var(--color-bg-surface)',border:'1px solid var(--line-2)'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',borderBottom:'1px solid var(--line-2)',display:'flex',gap:'8px',background:'var(--color-bg-panel-alt)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>
         <span>tail · keeper_hooks_oas.heuristics.jsonl</span>
         <span style={{marginLeft:'auto',color:'var(--err-fg)'}}>{P2f.heuristics.filter(h=>h.triggered).length}/{P2f.heuristics.length} fired</span>
       </div>
@@ -458,7 +458,7 @@ function HeuristicLog() {
 function StressBoard() {
   return (
     <section aria-label={`Agent stress board · ${P2f.stress.length} active stressors`} style={{display:'flex',flexDirection:'column',gap:'8px'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
         <span>agent stress · agent_stress.jsonl</span>
         <span style={{marginLeft:'auto',color:'var(--err-fg)'}}>{P2f.stress.length} active</span>
       </div>
@@ -489,17 +489,17 @@ function HeuristicByModule() {
   const rows = Object.entries(byMod).sort((a,b) => b[1].fired - a[1].fired);
   return (
     <section aria-label={`Heuristic firing rate by module · ${rows.length} modules`} style={{display:'flex',flexDirection:'column',gap:'4px'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
         <span>heuristic firing rate · by module</span>
       </div>
       <div role="list">
         {rows.map(([mod, v]) => {
           const pct = v.total > 0 ? v.fired / v.total * 100 : 0;
           return (
-            <div key={mod} role="listitem" aria-label={`${mod} · ${v.fired} of ${v.total} fired (${pct.toFixed(0)}%) · sites ${[...v.sites].join(', ')}`} style={{display:'grid',gridTemplateColumns:'160px 80px 1fr 60px',gap:'8px',alignItems:'center',padding:'5px 8px',background:'var(--bg-1)',border:'1px solid var(--line-1)'}}>
+            <div key={mod} role="listitem" aria-label={`${mod} · ${v.fired} of ${v.total} fired (${pct.toFixed(0)}%) · sites ${[...v.sites].join(', ')}`} style={{display:'grid',gridTemplateColumns:'160px 80px 1fr 60px',gap:'8px',alignItems:'center',padding:'5px 8px',background:'var(--color-bg-surface)',border:'1px solid var(--line-1)'}}>
               <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--fg-1)'}}>{mod}</span>
               <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-3)'}}>{v.fired}/{v.total} fired</span>
-              <div aria-hidden="true" style={{height:'10px',background:'var(--bg-2)',border:'1px solid var(--line-1)'}}>
+              <div aria-hidden="true" style={{height:'10px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-1)'}}>
                 <div style={{height:'100%',width:`${pct}%`,background: pct > 50 ? 'linear-gradient(90deg, var(--warn), var(--err))' : 'linear-gradient(90deg, var(--brass-3), var(--brass-1))'}}></div>
               </div>
               <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color: pct > 50 ? 'var(--err-fg)' : 'var(--brass-1)',fontVariantNumeric:'tabular-nums',textAlign:'right'}}>{pct.toFixed(0)}%</span>

--- a/dashboard/design-system/preview/cb-group-h.jsx
+++ b/dashboard/design-system/preview/cb-group-h.jsx
@@ -31,7 +31,7 @@ function KeeperBDIPanel() {
     <section aria-label="Keeper BDI panel · will, needs, desires" style={{display:'flex',flexDirection:'column',gap:'6px'}}>
       <KeeperTabs keepers={P2h.keepersFull} sel={sel} onSelect={setSel} label="Select keeper for BDI panel" />
       <div role="tabpanel" aria-label={`BDI panel for ${k.id}`}>
-        <div role="region" aria-label={`${k.id} · ${k.role} · social model ${k.social_model}`} style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',display:'flex',alignItems:'center',gap:'8px',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-3)'}}>
+        <div role="region" aria-label={`${k.id} · ${k.role} · social model ${k.social_model}`} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',display:'flex',alignItems:'center',gap:'8px',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-3)'}}>
           <Dot kind={kClass(k.id)} beat />
           <span aria-hidden="true" style={{color:'var(--brass-1)'}}>{k.id}</span>
           <span aria-hidden="true">·</span>
@@ -95,7 +95,7 @@ function KeeperTokenStats() {
   const maxIn  = Math.max(...keepers.map(k => k.tokens.in));
   return (
     <section aria-label={`Token usage across ${keepers.length} keepers · ${(keepers.reduce((s,k)=>s+k.tokens.in,0)/1e6).toFixed(2)}M total in`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'12px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'12px'}}>
         <span>token usage · all keepers</span>
         <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>
           {(keepers.reduce((s,k)=>s+k.tokens.in,0)/1e6).toFixed(2)}M in total
@@ -124,7 +124,7 @@ function KeeperTokenStats() {
           { lbl:'Total Out', v:`${(keepers.reduce((s,k)=>s+k.tokens.out,0)/1000).toFixed(0)}k` },
           { lbl:'Keepers', v:keepers.length },
         ].map(c => (
-          <div key={c.lbl} role="listitem" aria-label={`${c.lbl}: ${c.v}`} style={{background:'var(--bg-1)',padding:'6px 10px',display:'flex',flexDirection:'column',gap:'2px'}}>
+          <div key={c.lbl} role="listitem" aria-label={`${c.lbl}: ${c.v}`} style={{background:'var(--color-bg-surface)',padding:'6px 10px',display:'flex',flexDirection:'column',gap:'2px'}}>
             <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>{c.lbl}</span>
             <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-14)',color:'var(--brass-1)',fontVariantNumeric:'tabular-nums'}}>{c.v}</span>
           </div>
@@ -144,18 +144,18 @@ function DecisionsStream() {
   const rows = filter === 'all' ? P2h.decisions : P2h.decisions.filter(d => d.keeper === filter);
   return (
     <section aria-label={`Decisions stream · ${rows.length} entries${filter !== 'all' ? ` · filtered by ${filter}` : ''}`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div role="toolbar" aria-label="Decisions filter" style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',alignItems:'center',gap:'6px'}}>
+      <div role="toolbar" aria-label="Decisions filter" style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',alignItems:'center',gap:'6px'}}>
         <span aria-hidden="true">decisions.jsonl</span>
         <span role="radiogroup" aria-label="Filter by keeper" style={{marginLeft:'auto',display:'flex',gap:'2px'}}>
           {keepers.map(k => (
             <button key={k} type="button" role="radio" aria-checked={filter===k} onClick={() => setFilter(k)}
-              style={{padding:'1px 6px',background: filter===k ? 'var(--brass-3)' : 'var(--bg-1)',border:'1px solid var(--line-2)',color: filter===k ? 'var(--brass-1)' : 'var(--fg-3)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',cursor:'pointer'}}>
+              style={{padding:'1px 6px',background: filter===k ? 'var(--brass-3)' : 'var(--color-bg-surface)',border:'1px solid var(--line-2)',color: filter===k ? 'var(--brass-1)' : 'var(--fg-3)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',cursor:'pointer'}}>
               {k}
             </button>
           ))}
         </span>
       </div>
-      <div role="log" aria-live="polite" aria-label={`${rows.length} decisions`} style={{background:'var(--bg-0)',border:'1px solid var(--line-1)'}}>
+      <div role="log" aria-live="polite" aria-label={`${rows.length} decisions`} style={{background:'var(--color-bg-page)',border:'1px solid var(--line-1)'}}>
         {rows.map(d => (
           <div key={d.id} className="dec-row" role="listitem" aria-label={`${d.ts.slice(11,19)} · ${d.keeper} · ${d.outcome} · ${d.speech_act} via ${d.channel}${d.intention ? ' → ' + d.intention : ''}${d.blocker ? ' · blocker ' + d.blocker : ''}${d.belief ? ' · belief ' + d.belief : ''} · ${(d.latency_ms/1000).toFixed(1)}s`}>
             <span className="ts" aria-hidden="true">{d.ts.slice(11,19)}</span>
@@ -183,18 +183,18 @@ function MemoryEntries() {
   const rows = tag === 'all' ? P2h.memoryEntries : P2h.memoryEntries.filter(m => m.tag === tag);
   return (
     <section aria-label={`Memory entries · ${rows.length} rows${tag !== 'all' ? ` · tag ${tag}` : ''}`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div role="toolbar" aria-label="Memory tag filter" style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',alignItems:'center',gap:'6px'}}>
+      <div role="toolbar" aria-label="Memory tag filter" style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',alignItems:'center',gap:'6px'}}>
         <span aria-hidden="true">memory.jsonl</span>
         <span role="radiogroup" aria-label="Filter by tag" style={{marginLeft:'auto',display:'flex',gap:'2px'}}>
           {tags.map(t => (
             <button key={t} type="button" role="radio" aria-checked={tag===t} onClick={() => setTag(t)}
-              style={{padding:'1px 6px',background: tag===t ? 'var(--brass-3)' : 'var(--bg-1)',border:'1px solid var(--line-2)',color: tag===t ? 'var(--brass-1)' : 'var(--fg-3)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',cursor:'pointer'}}>
+              style={{padding:'1px 6px',background: tag===t ? 'var(--brass-3)' : 'var(--color-bg-surface)',border:'1px solid var(--line-2)',color: tag===t ? 'var(--brass-1)' : 'var(--fg-3)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',cursor:'pointer'}}>
               {t}
             </button>
           ))}
         </span>
       </div>
-      <div role="list" aria-label={`${rows.length} memory entries`} style={{background:'var(--bg-0)',border:'1px solid var(--line-1)'}}>
+      <div role="list" aria-label={`${rows.length} memory entries`} style={{background:'var(--color-bg-page)',border:'1px solid var(--line-1)'}}>
         {rows.length > 0 ? rows.map((m, i) => (
           <div key={i} className="mem-row" role="listitem" aria-label={`${m.at.slice(11,19)} · ${m.keeper} · ${m.tag} · ${m.body}`}>
             <span className="ts" aria-hidden="true">{m.at.slice(11,19)}</span>
@@ -220,7 +220,7 @@ function EpisodeCards() {
   const [open, setOpen] = useState('ep-tm-t5');
   return (
     <section aria-label={`Institution episodes · ${P2h.episodes.length} episodes`} style={{display:'flex',flexDirection:'column',gap:'0'}}>
-      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px',marginBottom:'4px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px',marginBottom:'4px'}}>
         <span>institution_episodes.jsonl</span>
         <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{P2h.episodes.length} episodes</span>
       </div>
@@ -291,11 +291,11 @@ function ARLoopList() {
   const confCls = (c) => c >= 0.8 ? 'hi' : c >= 0.5 ? '' : c >= 0.35 ? 'lo' : 'vlo';
   return (
     <section aria-label={`Autoresearch loops · ${P2h.arLoops.filter(l=>l.status==='open').length} open · ${P2h.arLoops.filter(l=>l.status==='closed').length} closed`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px'}}>
         <span>autoresearch loops</span>
         <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{P2h.arLoops.filter(l=>l.status==='open').length} open · {P2h.arLoops.filter(l=>l.status==='closed').length} closed</span>
       </div>
-      <div role="list" aria-label={`${P2h.arLoops.length} autoresearch loops`} style={{background:'var(--bg-0)'}}>
+      <div role="list" aria-label={`${P2h.arLoops.length} autoresearch loops`} style={{background:'var(--color-bg-page)'}}>
         {P2h.arLoops.map(l => (
           <div key={l.id} className="ar-row" role="listitem" aria-label={`${l.id} · ${l.topic} · owner ${l.owner}${l.branch ? ' · branch ' + l.branch : ''} · ${l.hypotheses}H ${l.evidences}E ${l.conclusions}C · ${l.status} · ${(l.confidence*100).toFixed(0)}% confidence`}>
             <span className="id" aria-hidden="true">{l.id.slice(0,11)}</span>
@@ -324,7 +324,7 @@ function ARFindingCard() {
       <div role="tablist" aria-label="Select finding" style={{display:'flex',gap:'2px'}}>
         {P2h.findings.map(x => (
           <button key={x.id} type="button" role="tab" aria-selected={sel===x.id} aria-controls="ar-finding-panel" tabIndex={sel===x.id ? 0 : -1} onClick={() => setSel(x.id)}
-            style={{padding:'3px 10px',background: sel===x.id ? 'var(--brass-3)' : 'var(--bg-2)',border:'1px solid var(--line-2)',color: sel===x.id ? 'var(--brass-1)' : 'var(--fg-3)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',cursor:'pointer'}}>
+            style={{padding:'3px 10px',background: sel===x.id ? 'var(--brass-3)' : 'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',color: sel===x.id ? 'var(--brass-1)' : 'var(--fg-3)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',cursor:'pointer'}}>
             {x.id}
           </button>
         ))}
@@ -360,7 +360,7 @@ function ARHypothesisFlow() {
   const finding = P2h.findings.find(f => f.loop === 'ar-78d41e9c');
   return (
     <section aria-label={`${loop.id} · ${loop.topic} · closed · ${(loop.confidence*100).toFixed(0)}% confidence`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px'}}>
         <span>{loop.id}</span>
         <span style={{color:'var(--fg-3)'}}>· {loop.topic}</span>
         <span style={{marginLeft:'auto',color:'var(--ok-fg)'}}>closed · {(loop.confidence*100).toFixed(0)}% confidence</span>

--- a/dashboard/design-system/preview/cb-group-i.jsx
+++ b/dashboard/design-system/preview/cb-group-i.jsx
@@ -65,7 +65,7 @@ function BranchSelector() {
         </span>
       </button>
 
-      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px'}}>
         <span aria-hidden="true">switch branch · {P2i.branches.length} known</span>
         <span aria-hidden="true" style={{marginLeft:'auto',color:'var(--brass-1)'}}>active · {sel}</span>
       </div>
@@ -97,7 +97,7 @@ function BranchSelector() {
           );
         })}
       </div>
-      <div role="list" aria-label={`Active branch keepers · ${cur.keepers.length}`} style={{padding:'5px 10px',background:'var(--bg-1)',border:'1px solid var(--line-1)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-3)',display:'flex',gap:'8px',alignItems:'center'}}>
+      <div role="list" aria-label={`Active branch keepers · ${cur.keepers.length}`} style={{padding:'5px 10px',background:'var(--color-bg-surface)',border:'1px solid var(--line-1)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-3)',display:'flex',gap:'8px',alignItems:'center'}}>
         <span aria-hidden="true" style={{color:'var(--fg-4)'}}>active branch keepers ·</span>
         {cur.keepers.map(k => (
           <span key={k} role="listitem" aria-label={k} style={{display:'inline-flex',alignItems:'center',gap:'4px'}}>
@@ -149,10 +149,10 @@ function KeeperMultiSelect() {
           );
         })}
       </div>
-      <div role="status" aria-live="polite" aria-label={`Filter applied to 8 zones · ${sel.size === 0 ? 'all hidden' : sel.size + '-way scope'}`} style={{padding:'5px 10px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-3)',display:'flex',flexWrap:'wrap',gap:'4px',alignItems:'center'}}>
+      <div role="status" aria-live="polite" aria-label={`Filter applied to 8 zones · ${sel.size === 0 ? 'all hidden' : sel.size + '-way scope'}`} style={{padding:'5px 10px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-3)',display:'flex',flexWrap:'wrap',gap:'4px',alignItems:'center'}}>
         <span aria-hidden="true" style={{color:'var(--fg-4)'}}>filter applied to ·</span>
         {['Swimlanes','Activity','Audit','Decisions','Memory','Cost','Stress','Episodes'].map(z => (
-          <span key={z} aria-hidden="true" style={{padding:'1px 5px',background:'var(--bg-1)',border:'1px solid var(--line-1)',color:'var(--fg-2)'}}>{z}</span>
+          <span key={z} aria-hidden="true" style={{padding:'1px 5px',background:'var(--color-bg-surface)',border:'1px solid var(--line-1)',color:'var(--fg-2)'}}>{z}</span>
         ))}
         <span aria-hidden="true" style={{marginLeft:'auto',color: sel.size === 0 ? 'var(--err-fg)' : 'var(--brass-1)'}}>
           {sel.size === 0 ? '⚠ all hidden' : `→ ${sel.size}-way scope`}
@@ -172,11 +172,11 @@ function OperatorNudgeLog() {
   const [targets] = useState(['sangsu']);
   return (
     <section aria-label={`Operator nudge log · ${P2i.nudges.length} total · ${P2i.nudges.filter(n => !n.ack).length} pending ack`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--bg-2)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px'}}>
         <span>operator · nudge log</span>
         <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{P2i.nudges.length} nudges · {P2i.nudges.filter(n => !n.ack).length} pending ack</span>
       </div>
-      <div role="log" aria-live="polite" aria-label="Operator nudge history" style={{background:'var(--bg-0)'}}>
+      <div role="log" aria-live="polite" aria-label="Operator nudge history" style={{background:'var(--color-bg-page)'}}>
         {P2i.nudges.map(n => (
           <article key={n.id} className="nd-row" aria-label={`${n.at.replace('Z','')} · ${n.channel} · to ${n.to.map(k => '@' + k).join(', ')} · ${n.body} · ${n.ack ? 'acknowledged' : 'pending acknowledgment'}`}>
             <span className="ts" aria-hidden="true">{n.at.replace('Z','')}</span>

--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -377,7 +377,9 @@ body[data-density="comfortable"]  { --density: 1.15; }
 :root {
   --color-bg-page:        var(--bg-0);
   --color-bg-surface:     var(--bg-1);
-  --color-bg-elevated:    var(--bg-2);
+  --color-bg-panel-alt:   var(--bg-2);
+  --color-bg-elevated:    var(--bg-3);
+  --color-bg-hover:       var(--bg-4);
 
   --color-fg-primary:     var(--fg-1);
   --color-fg-secondary:   var(--fg-2);
@@ -410,7 +412,9 @@ body[data-density="comfortable"]  { --density: 1.15; }
 :root[data-theme="light"] {
   --color-bg-page:        #f7f5f0;
   --color-bg-surface:     #fdfcf8;
+  --color-bg-panel-alt:   #f0ece0;
   --color-bg-elevated:    #ffffff;
+  --color-bg-hover:       #e8e2d0;
 
   --color-fg-primary:     #1a1612;
   --color-fg-secondary:   #4a423a;
@@ -437,7 +441,9 @@ body[data-density="comfortable"]  { --density: 1.15; }
   :root:not([data-theme]) {
     --color-bg-page:        #f7f5f0;
     --color-bg-surface:     #fdfcf8;
+    --color-bg-panel-alt:   #f0ece0;
     --color-bg-elevated:    #ffffff;
+    --color-bg-hover:       #e8e2d0;
     --color-fg-primary:     #1a1612;
     --color-fg-secondary:   #4a423a;
     --color-fg-muted:       #7a7065;


### PR DESCRIPTION
## Summary

Migration phase 첫 PR. SPEC v0.1 §3.1 surface stack의 canonical alias를 tokens.css에 완성하고, preview cb-group-* 컴포넌트의 raw `--bg-*` 직접 참조를 모두 semantic alias로 치환.

이 PR이 답하는 질문: **"디자인 시스템 예제에 맞게 하나씩 뜯어고치고 있긴한가?"** → 이제 yes.

## tokens.css 보강

| 변경 | Before | After |
|------|--------|-------|
| `--color-bg-elevated` 매핑 정정 | `var(--bg-2)` (PR #10427 오매핑) | `var(--bg-3)` (SPEC §3.1 일치) |
| `--color-bg-panel-alt` 신규 | (없음) | `var(--bg-2)` |
| `--color-bg-hover` 신규 | (없음) | `var(--bg-4)` |

3 곳 동기 적용: `:root` (dark default) + `:root[data-theme="light"]` + `@media (prefers-color-scheme:light)` 블록.

## cb-group-* 컴포넌트 치환

| 파일 | refs |
|------|------|
| cb-group-a.jsx | 11 |
| cb-group-c.jsx | 8 |
| cb-group-d.jsx | 2 |
| cb-group-e.jsx | 7 |
| cb-group-f.jsx | 20 |
| cb-group-h.jsx | 14 |
| cb-group-i.jsx | 6 |
| **total** | **68** |

매핑:
- `var(--bg-0)` → `var(--color-bg-page)` (page bg)
- `var(--bg-1)` → `var(--color-bg-surface)` (panel/topbar)
- `var(--bg-2)` → `var(--color-bg-panel-alt)` (panel variant)
- `var(--bg-3)` → `var(--color-bg-elevated)` (elevated card)
- `var(--bg-4)` → `var(--color-bg-hover)` (hover/active row)

## Validation

```
$ rg -c "var\(--bg-[0-4]\)" dashboard/design-system/preview/cb-group-*.jsx
(empty — 0 raw refs remaining)

$ rg -c "var\(--color-bg-" dashboard/design-system/preview/cb-group-*.jsx
cb-group-i.jsx: 6
cb-group-d.jsx: 2
cb-group-h.jsx: 14
cb-group-e.jsx: 7
cb-group-f.jsx: 20
cb-group-c.jsx: 8
cb-group-a.jsx: 11

$ pnpm test
Test Files  242 passed (242)
     Tests  4065 passed (4065)
```

## Pre-existing inconsistency 발견 + 정정

- `--color-bg-elevated`는 SPEC §3.1상 "떠있는 카드" 의미로 `--bg-3` 매핑이어야 하나 PR #10427에서 `--bg-2`로 잘못 매핑됨.
- 코드 소비처 0건 확인 후 (`git grep "color-bg-elevated"` → README/SPEC/tokens.css 정의만, 컴포넌트 0) 안전하게 SPEC 일치로 정정.

## Visual regression

**0** (alias가 raw로 resolve되어 동치 변환). dashboard `preview/components.html`을 Chrome으로 열어 색 변화 없음 확인 권장.

## Stack

본 PR은 **main 직접 base**. PR-M2(`--fg-*`), PR-M3(`--line-*`), PR-M4(`--brass-*`), PR-M5(status), PR-M6(keeper) 등 후속 migration도 main 위에 독립 적층.

`do-not-merge` 라벨 유지 — 시각 검증 완료까지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
