### PR TITLE
refactor(keeper): migrate 5 Alerting/Pr_review timeout literals to SSOT (#10426 P2-C)

### DIFF
--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -317,7 +317,7 @@ let post_keeper_alert_slack
     ] in
     let (status, out) =
       Process_eio.run_argv_with_stdin_and_status
-        ~timeout_sec:15.0
+        ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Alerting ())
         ~stdin_content:payload
         argv
     in
@@ -362,7 +362,7 @@ let slack_api_post_json
   ] in
   let (status, out) =
     Process_eio.run_argv_with_stdin_and_status
-      ~timeout_sec:15.0
+      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Alerting ())
       ~stdin_content:body
       argv
   in

--- a/lib/keeper/keeper_tool_pr_review.ml
+++ b/lib/keeper/keeper_tool_pr_review.ml
@@ -89,14 +89,16 @@ let handle_keeper_pr_review_read
       "cd %s && gh pr view %d%s --json title,body,state,files,reviews,comments,additions,deletions 2>&1"
       (Filename.quote root) pr_number repo_flag in
     let st_meta, out_meta =
-      Process_eio.run_argv_with_status ~timeout_sec:15.0
+      Process_eio.run_argv_with_status
+        ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Pr_review ())
         [ "/bin/zsh"; "-lc"; meta_cmd ] in
     (* Get PR diff (truncated) *)
     let diff_cmd = Printf.sprintf
       "cd %s && gh pr diff %d%s 2>&1 | head -c %d"
       (Filename.quote root) pr_number repo_flag Common.max_tool_output_bytes in
     let st_diff, out_diff =
-      Process_eio.run_argv_with_status ~timeout_sec:15.0
+      Process_eio.run_argv_with_status
+        ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Pr_review ())
         [ "/bin/zsh"; "-lc"; diff_cmd ] in
     let diff_truncated = String.length out_diff >= Common.max_tool_output_bytes in
     let meta_ok = (st_meta = Unix.WEXITED 0) in
@@ -228,7 +230,8 @@ let handle_keeper_pr_review_reply
           owner_repo comment_id
           (Filename.quote body) in
         let st, out =
-          Process_eio.run_argv_with_status ~timeout_sec:15.0
+          Process_eio.run_argv_with_status
+            ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Pr_review ())
             [ "/bin/zsh"; "-lc"; cmd ] in
         Log.Keeper.info "pr_review_reply: pr=%d comment=%d keeper=%s ok=%b"
           pr_number comment_id meta.name (st = Unix.WEXITED 0);


### PR DESCRIPTION
## Why

Third call-site migration onto `Env_config_exec_timeout` (#10452 P1, #10457 P2-A, #10486 P2-B). Same 1:1 default-matching strategy: only literals whose value already equals the SSOT default for the chosen caller. Behavior is byte-for-byte preserved.

## What

| File | Lines | Caller | Default | Op |
|------|-------|--------|---------|-----|
| `lib/keeper/keeper_alerting.ml` | 320, 365 | `Alerting` | 15.0 | Slack / webhook curl POSTs |
| `lib/keeper/keeper_tool_pr_review.ml` | 92, 99, 231 | `Pr_review` | 15.0 | `gh pr view`/`gh pr diff` metadata + comment reply |

After this PR, operators can widen either bucket via:
- `MASC_EXEC_TIMEOUT_ALERTING_SEC` for Slack/webhook fanouts
- `MASC_EXEC_TIMEOUT_PR_REVIEW_SEC` for gh PR review tooling

without recompile.

## Out of scope (default deviation — needs separate decision)

These literals exist in the same files but their values differ from the chosen caller's default. Each needs human review on whether to bump the default, introduce a new caller variant, or leave as-is:

| File | Line | Value | Caller default | Note |
|------|------|-------|----------------|------|
| `keeper_alerting.ml` | 452 | 20.0 | Alerting=15.0 | wider-budget alerting variant? |
| `keeper_tool_pr_review.ml` | 167 | 30.0 | Pr_review=15.0 | full-diff fetch needs more than meta? |
| `keeper_tool_pr_review.ml` | 216 | 5.0 | Pr_review=15.0 | tight reply cycle? |
| `keeper_gh_shared.ml` | 651 | 5.0 | Gh_shared=10.0 | quick `gh` query bucket? |

Tracked separately for analysis.

## Verification

`dune build lib/ --root . --cache=disabled` → RC=0 (validated by cherry-picking `fix/oas-bridge-inference-telemetry` for #10490 P0 fix, then dropping the cherry-pick before commit so this branch contains only the migration). Once #10490 lands, this branch rebases cleanly onto main with the fix already absorbed.

---

Refs: #10426 (audit + plan), #10452 (P1 SSOT), #10457 (P2-A), #10486 (P2-B), #10490 (P0 build fix dependency).
