### PR TITLE
feat(design-system): migrate cb-group-* preview to --color-fg-* aliases (PR-M2)

### DIFF
--- a/dashboard/design-system/SPEC.md
+++ b/dashboard/design-system/SPEC.md
@@ -265,6 +265,8 @@ bonsai의 5 테마는 production user에게 URL hash로 공유 가능한 자산.
 | `keeperColor()` 헬퍼 | `dashboard/design-system/preview/cb-group-i.jsx` | 12 keeper persona를 attribution token 5종으로 환원 불가 — hex extension 의도적 |
 | `rgba(... / .NN)` alpha 조합 | 어느 곳이든 | `rgb(var(--token-glow) / .12)` 형태로 raw token alpha 조합은 허용 |
 | 폰트 fallback chain | `--font-*` 정의 내 | system font name (e.g., `Inter`, `JetBrains Mono`) |
+| 4-slot status pattern | `tokens.css`의 `--{ok\|warn\|err\|info\|idle\|stalled}-{soft\|fg\|border\|ring}` | 컴포넌트별 정교한 surface/text/border/ring 4 slot 조합. single-slot semantic alias로 환원 불가. 컴포넌트는 raw 참조 허용 (PR-M5 결정). |
+| `--brass-2` mid tone | accent palette mid-tone 사용처 | SPEC v0.1 §3.4은 accent를 fg/fg-dim 2 slot만 정의. 사용 빈도 증가 시 `--color-accent-fg-mid` 추가 검토. |
 
 ### 6.3 Surface 적용 의무
 

--- a/dashboard/design-system/preview/cb-group-a.jsx
+++ b/dashboard/design-system/preview/cb-group-a.jsx
@@ -14,11 +14,11 @@ const DENSITY_LABEL = { c: 'Compact', n: 'Normal', l: 'Loose' };
 
 const TOPBAR_DEFAULT_KEEPERS = ["nick0cave","masc-improver","sangsu","qa-king","rama"];
 const TOPBAR_KEEPER_COLOR = {
-  "nick0cave": "var(--k-nick)",
-  "masc-improver": "var(--k-masc)",
-  "sangsu": "var(--k-sangsu)",
-  "qa-king": "var(--k-qa)",
-  "rama": "var(--k-rama)",
+  "nick0cave": "var(--color-keeper-1)",
+  "masc-improver": "var(--color-keeper-2)",
+  "sangsu": "var(--color-keeper-3)",
+  "qa-king": "var(--color-keeper-4)",
+  "rama": "var(--color-keeper-5)",
 };
 
 function TopbarStandard({

--- a/dashboard/design-system/preview/cb-group-c.jsx
+++ b/dashboard/design-system/preview/cb-group-c.jsx
@@ -16,7 +16,7 @@ function ComposerPrompt() {
         <div className="line" aria-live="polite">
           <span className="prompt" aria-hidden="true">masc&gt;</span>
           <span aria-label={`Current input: ${typed}`}>{typed}</span>
-          <span className="caret" aria-hidden="true" style={{color:'var(--brass-1)'}}>▌</span>
+          <span className="caret" aria-hidden="true" style={{color:'var(--color-accent-fg)'}}>▌</span>
         </div>
         <div className="hint" aria-hidden="true">
           <span><span className="kbd">⌘K</span>command</span>
@@ -60,7 +60,7 @@ function ComposerSuggest() {
         <div className="line">
           <span className="prompt" aria-hidden="true">masc&gt;</span>
           <span className="fn" aria-label="Current input: keeper.">keeper.</span>
-          <span className="caret" aria-hidden="true" style={{color:'var(--brass-1)'}}>▌</span>
+          <span className="caret" aria-hidden="true" style={{color:'var(--color-accent-fg)'}}>▌</span>
         </div>
         <div className="hint" aria-hidden="true">
           <span><span className="kbd">↑↓</span>move</span>
@@ -102,7 +102,7 @@ function ComposerMultiLine() {
             <span className="arg">dry_run</span>
             <span>=</span>
             <span className="fn">false</span>
-            <span className="caret" style={{color:'var(--brass-1)'}}>▌</span>
+            <span className="caret" style={{color:'var(--color-accent-fg)'}}>▌</span>
           </div>
           <div className="line" aria-hidden="true">
             <span>)</span>
@@ -165,7 +165,7 @@ function StatusVerbose() {
         <span className="sep" aria-hidden="true" />
         <span className="seg" role="group" aria-label="Goal goal-merge-blockers">goal <span className="brass">goal-merge-blockers</span></span>
         <span className="seg" role="group" aria-label="Task t-9f2a">task <span style={{color:'var(--color-fg-secondary)'}}>t-9f2a</span></span>
-        <span className="seg" role="group" aria-label="Keeper nick0cave">keeper <span style={{color:'var(--brass-1)'}}>nick0cave</span></span>
+        <span className="seg" role="group" aria-label="Keeper nick0cave">keeper <span style={{color:'var(--color-accent-fg)'}}>nick0cave</span></span>
         <span className="sep" aria-hidden="true" />
         <span className="seg" role="group" aria-label="Cascade hit at step 2 in 1.24 seconds">CASCADE hit@2 · <span className="brass">1.24s</span></span>
         <span className="sep" aria-hidden="true" />
@@ -274,7 +274,7 @@ function DrawerGoal() {
               <div key={t.id}
                    role="listitem"
                    aria-label={`${t.id} · ${t.title} · ${t.keeper} · ${t.status}`}
-                   style={{display:'flex', alignItems:'center', gap:7, padding:'4px 7px', background:'var(--color-bg-surface)', border:'1px solid var(--line-1)', borderRadius:3, fontSize:11}}>
+                   style={{display:'flex', alignItems:'center', gap:7, padding:'4px 7px', background:'var(--color-bg-surface)', border:'1px solid var(--color-border-default)', borderRadius:3, fontSize:11}}>
                 <Dot kind={kClass(t.keeper)} size="sm" />
                 <span className="cb-mono" aria-hidden="true" style={{color:'var(--color-fg-disabled)'}}>{t.id}</span>
                 <span aria-hidden="true" style={{color:'var(--color-fg-primary)', flex:1}}>{t.title}</span>
@@ -325,7 +325,7 @@ function DrawerKeeper() {
       <div className="body">
         <section aria-labelledby="drawer-keeper-heartbeat">
           <SectionHeading variant="title" title="HEARTBEAT" id="drawer-keeper-heartbeat" />
-          <div aria-label="Heartbeat trace, 60-second window" style={{background:'var(--color-bg-surface)', padding:6, border:'1px solid var(--line-1)', borderRadius:3}}>
+          <div aria-label="Heartbeat trace, 60-second window" style={{background:'var(--color-bg-surface)', padding:6, border:'1px solid var(--color-border-default)', borderRadius:3}}>
             <span aria-hidden="true"><Heartbeat width={260} height={40} /></span>
           </div>
         </section>

--- a/dashboard/design-system/preview/cb-group-c.jsx
+++ b/dashboard/design-system/preview/cb-group-c.jsx
@@ -52,8 +52,8 @@ function ComposerSuggest() {
                  className={`item ${on===i?'on':''}`}
                  onMouseEnter={()=>setOn(i)}>
               <span className="kind" aria-hidden="true">{s.kind}</span>
-              <span aria-hidden="true" style={{color:'var(--fg-1)'}}>{s.name}</span>
-              <span aria-hidden="true" style={{color:'var(--fg-3)', marginLeft:8}}>{s.desc}</span>
+              <span aria-hidden="true" style={{color:'var(--color-fg-primary)'}}>{s.name}</span>
+              <span aria-hidden="true" style={{color:'var(--color-fg-muted)', marginLeft:8}}>{s.desc}</span>
             </div>
           ))}
         </div>
@@ -111,7 +111,7 @@ function ComposerMultiLine() {
         <div className="hint" aria-hidden="true">
           <span><span className="kbd">⌘↵</span>run</span>
           <span><span className="kbd">⇧↵</span>newline</span>
-          <span style={{marginLeft:'auto', color:'var(--fg-4)'}}>4 lines · will burn ~1.2s</span>
+          <span style={{marginLeft:'auto', color:'var(--color-fg-disabled)'}}>4 lines · will burn ~1.2s</span>
         </div>
       </div>
     </div>
@@ -164,7 +164,7 @@ function StatusVerbose() {
         <span className="seg" role="group" aria-label="Connection: connected"><span className="on" aria-hidden="true">●</span>CONNECTED</span>
         <span className="sep" aria-hidden="true" />
         <span className="seg" role="group" aria-label="Goal goal-merge-blockers">goal <span className="brass">goal-merge-blockers</span></span>
-        <span className="seg" role="group" aria-label="Task t-9f2a">task <span style={{color:'var(--fg-2)'}}>t-9f2a</span></span>
+        <span className="seg" role="group" aria-label="Task t-9f2a">task <span style={{color:'var(--color-fg-secondary)'}}>t-9f2a</span></span>
         <span className="seg" role="group" aria-label="Keeper nick0cave">keeper <span style={{color:'var(--brass-1)'}}>nick0cave</span></span>
         <span className="sep" aria-hidden="true" />
         <span className="seg" role="group" aria-label="Cascade hit at step 2 in 1.24 seconds">CASCADE hit@2 · <span className="brass">1.24s</span></span>
@@ -211,7 +211,7 @@ function DrawerTask() {
             <div className="cmt flag" role="article" aria-label="Flag from sangsu, 3 minutes ago: drift detected at pipeline.ts L187 — signature mismatch">
               <div className="h" aria-hidden="true">
                 <span className="kind">FLAG</span>
-                <span style={{color:'var(--fg-2)'}}>sangsu</span>
+                <span style={{color:'var(--color-fg-secondary)'}}>sangsu</span>
                 <span className="t">3m ago</span>
               </div>
               <div className="body">drift detected at pipeline.ts L187 — signature mismatch</div>
@@ -219,7 +219,7 @@ function DrawerTask() {
             <div className="cmt question" role="article" aria-label="Question from qa-king, 2 minutes ago: is the backport going to re-open suite-merge-blockers?">
               <div className="h" aria-hidden="true">
                 <span className="kind">QUESTION</span>
-                <span style={{color:'var(--fg-2)'}}>qa-king</span>
+                <span style={{color:'var(--color-fg-secondary)'}}>qa-king</span>
                 <span className="t">2m ago</span>
               </div>
               <div className="body">is the backport going to re-open suite-merge-blockers?</div>
@@ -227,7 +227,7 @@ function DrawerTask() {
             <div className="cmt note" role="article" aria-label="Note from nick0cave, 1 minute ago: rebased on release-0.42, re-running CI">
               <div className="h" aria-hidden="true">
                 <span className="kind">NOTE</span>
-                <span style={{color:'var(--fg-2)'}}>nick0cave</span>
+                <span style={{color:'var(--color-fg-secondary)'}}>nick0cave</span>
                 <span className="t">1m ago</span>
               </div>
               <div className="body">rebased on release-0.42 · re-running CI</div>
@@ -276,8 +276,8 @@ function DrawerGoal() {
                    aria-label={`${t.id} · ${t.title} · ${t.keeper} · ${t.status}`}
                    style={{display:'flex', alignItems:'center', gap:7, padding:'4px 7px', background:'var(--color-bg-surface)', border:'1px solid var(--line-1)', borderRadius:3, fontSize:11}}>
                 <Dot kind={kClass(t.keeper)} size="sm" />
-                <span className="cb-mono" aria-hidden="true" style={{color:'var(--fg-4)'}}>{t.id}</span>
-                <span aria-hidden="true" style={{color:'var(--fg-1)', flex:1}}>{t.title}</span>
+                <span className="cb-mono" aria-hidden="true" style={{color:'var(--color-fg-disabled)'}}>{t.id}</span>
+                <span aria-hidden="true" style={{color:'var(--color-fg-primary)', flex:1}}>{t.title}</span>
                 <Pill kind={t.status==='running'?'running':t.status==='fail'?'err':t.status==='stalled'?'stalled':'paused'}>{t.status}</Pill>
               </div>
             ))}
@@ -346,8 +346,8 @@ function DrawerKeeper() {
               <div key={i}
                    role="article"
                    aria-label={`${e.t.slice(0,8)} · ${e.text}`}
-                   style={{fontFamily:'var(--font-mono)', fontSize:10, color:'var(--fg-2)'}}>
-                <span aria-hidden="true" style={{color:'var(--fg-4)'}}>{e.t.slice(0,8)} </span>
+                   style={{fontFamily:'var(--font-mono)', fontSize:10, color:'var(--color-fg-secondary)'}}>
+                <span aria-hidden="true" style={{color:'var(--color-fg-disabled)'}}>{e.t.slice(0,8)} </span>
                 <span aria-hidden="true">{e.text}</span>
               </div>
             ))}

--- a/dashboard/design-system/preview/cb-group-d.jsx
+++ b/dashboard/design-system/preview/cb-group-d.jsx
@@ -49,7 +49,7 @@ function GoalHorizonTrack() {
             <div className="hz" aria-hidden="true">
               <span>{g.label}</span>
               <span className="n">{g.note}</span>
-              <span className="n" style={{marginTop:'auto', color:'var(--brass-1)'}}>{g.goals.length}</span>
+              <span className="n" style={{marginTop:'auto', color:'var(--color-accent-fg)'}}>{g.goals.length}</span>
             </div>
             <div className="lst" role="list" aria-label={`${g.label} goals`}>
               {g.goals.length === 0 && <div className="cb-mute" role="listitem" style={{padding:'8px',fontFamily:'var(--font-mono)',fontSize:'10px'}}>— no goals at this horizon —</div>}
@@ -148,7 +148,7 @@ function GoalSnapshotDiff() {
         branch="main"
         keepers={["scholar"]}
         meta="2026-04-22 → 2026-04-23"
-        right={<span className="meta" style={{color:'var(--brass-1)'}}>{P2.goalSnapshots.length} drift</span>}
+        right={<span className="meta" style={{color:'var(--color-accent-fg)'}}>{P2.goalSnapshots.length} drift</span>}
       />
       <div className="body">
         <div className="gz-snap" role="list" aria-label="Goal snapshot rows">
@@ -249,7 +249,7 @@ function TaskBacklog() {
                 </td>
                 <td className="pri">{t.title}</td>
                 <td className="mute" aria-label={`Branch ${t.branch}`}><span aria-hidden="true">⎇ </span>{t.branch}</td>
-                <td>{t.keeper ? <span style={{color:'var(--brass-1)'}}>{t.keeper}</span> : <span className="mute" aria-label="No keeper">—</span>}</td>
+                <td>{t.keeper ? <span style={{color:'var(--color-accent-fg)'}}>{t.keeper}</span> : <span className="mute" aria-label="No keeper">—</span>}</td>
                 <td className="mute" title={t.goal}>{t.goal.replace('goal-','')}</td>
                 <td className="num">{t.age}</td>
               </tr>
@@ -297,8 +297,8 @@ function TaskStaleAlert() {
             </div>
           ))}
         </div>
-        <div role="note" style={{marginTop:8, padding:'6px 8px', borderTop:'1px dashed var(--line-2)', fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--color-fg-disabled)'}}>
-          taskmaster cannot force-release others' claims · operator nudge channel: <span style={{color:'var(--brass-1)'}}>hint</span>
+        <div role="note" style={{marginTop:8, padding:'6px 8px', borderTop:'1px dashed var(--color-border-strong)', fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--color-fg-disabled)'}}>
+          taskmaster cannot force-release others' claims · operator nudge channel: <span style={{color:'var(--color-accent-fg)'}}>hint</span>
         </div>
       </div>
     </section>
@@ -425,27 +425,27 @@ function ResponsibilityMatrix() {
                   {grid[r].map((n, i) => (
                     <td key={i} className={bucket(n)} aria-label={`${r} × ${cols[i]}: ${n} verdicts`} title={`${r} × ${cols[i]}: ${n} verdicts`}>{n || '·'}</td>
                   ))}
-                  <td style={{color:'var(--brass-1)', fontWeight:600}} aria-label={`${r} total: ${total} verdicts`}>{total}</td>
+                  <td style={{color:'var(--color-accent-fg)', fontWeight:600}} aria-label={`${r} total: ${total} verdicts`}>{total}</td>
                 </tr>
               );
             })}
             <tr style={{borderTop:'2px solid var(--brass-2)'}}>
-              <th className="row-h" scope="row" style={{color:'var(--brass-1)'}}>Σ scope</th>
+              <th className="row-h" scope="row" style={{color:'var(--color-accent-fg)'}}>Σ scope</th>
               {cols.map((_, i) => {
                 const sum = rows.reduce((a, r) => a + grid[r][i], 0);
-                return <td key={i} aria-label={`${cols[i]} total: ${sum} verdicts`} style={{color:'var(--brass-1)', fontWeight:600}}>{sum}</td>;
+                return <td key={i} aria-label={`${cols[i]} total: ${sum} verdicts`} style={{color:'var(--color-accent-fg)', fontWeight:600}}>{sum}</td>;
               })}
-              <td aria-label={`Grand total verdicts`} style={{color:'var(--brass-1)', fontWeight:600}}>{rows.reduce((a, r) => a + grid[r].reduce((x,y)=>x+y, 0), 0)}</td>
+              <td aria-label={`Grand total verdicts`} style={{color:'var(--color-accent-fg)', fontWeight:600}}>{rows.reduce((a, r) => a + grid[r].reduce((x,y)=>x+y, 0), 0)}</td>
             </tr>
           </tbody>
         </table>
         <div role="note" aria-label="Matrix density legend" style={{marginTop:8, padding:'6px 8px', fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--color-fg-disabled)', display:'flex', gap:8, alignItems:'center'}}>
           <span aria-hidden="true">density:</span>
-          <span aria-hidden="true" style={{padding:'1px 6px', background:'var(--color-bg-page)', border:'1px solid var(--line-1)'}}>0</span>
-          <span aria-hidden="true" style={{padding:'1px 6px', background:'rgb(var(--brass-glow)/.05)', color:'var(--color-fg-secondary)'}}>1–2</span>
-          <span aria-hidden="true" style={{padding:'1px 6px', background:'rgb(var(--brass-glow)/.12)', color:'var(--color-fg-primary)'}}>3–4</span>
-          <span aria-hidden="true" style={{padding:'1px 6px', background:'rgb(var(--brass-glow)/.22)', color:'var(--brass-1)'}}>5–6</span>
-          <span aria-hidden="true" style={{padding:'1px 6px', background:'var(--brass-1)', color:'var(--color-bg-page)'}}>7+</span>
+          <span aria-hidden="true" style={{padding:'1px 6px', background:'var(--color-bg-page)', border:'1px solid var(--color-border-default)'}}>0</span>
+          <span aria-hidden="true" style={{padding:'1px 6px', background:'rgb(var(--color-accent-glow)/.05)', color:'var(--color-fg-secondary)'}}>1–2</span>
+          <span aria-hidden="true" style={{padding:'1px 6px', background:'rgb(var(--color-accent-glow)/.12)', color:'var(--color-fg-primary)'}}>3–4</span>
+          <span aria-hidden="true" style={{padding:'1px 6px', background:'rgb(var(--color-accent-glow)/.22)', color:'var(--color-accent-fg)'}}>5–6</span>
+          <span aria-hidden="true" style={{padding:'1px 6px', background:'var(--color-accent-fg)', color:'var(--color-bg-page)'}}>7+</span>
         </div>
       </div>
     </section>

--- a/dashboard/design-system/preview/cb-group-d.jsx
+++ b/dashboard/design-system/preview/cb-group-d.jsx
@@ -66,7 +66,7 @@ function GoalHorizonTrack() {
                   <div className="prog" aria-hidden="true">
                     <span className="pct">{Math.round(go.progress / go.total * 100)}%</span>
                     <span className="b"><i style={{width: `${go.progress / go.total * 100}%`}} /></span>
-                    <span style={{color:'var(--fg-4)',fontSize:'9px'}}>{go.progress}/{go.total}</span>
+                    <span style={{color:'var(--color-fg-disabled)',fontSize:'9px'}}>{go.progress}/{go.total}</span>
                   </div>
                 </div>
               ))}
@@ -169,7 +169,7 @@ function GoalSnapshotDiff() {
                 <div className="diff" aria-hidden="true">
                   <div className="y">
                     <span className="lbl">yesterday</span>
-                    <span>progress: <span className="v" style={{color:'var(--fg-2)'}}>{s.yesterday.progress}/{s.yesterday.total}</span> · {yPct}%</span>
+                    <span>progress: <span className="v" style={{color:'var(--color-fg-secondary)'}}>{s.yesterday.progress}/{s.yesterday.total}</span> · {yPct}%</span>
                     <br />
                     <span>phase: {s.yesterday.phase}</span>
                   </div>
@@ -287,7 +287,7 @@ function TaskStaleAlert() {
               <div className="why" aria-hidden="true">
                 {t.drift ? 'metadata_drift detected · backlog L42' : `claim_age > threshold · last activity ${t.age} ago`}
                 <br />
-                <span style={{color:'var(--fg-4)'}}>⎇ {t.branch} · {t.tools}</span>
+                <span style={{color:'var(--color-fg-disabled)'}}>⎇ {t.branch} · {t.tools}</span>
               </div>
               <div className="acts" role="toolbar" aria-label={`Actions for ${t.id}`}>
                 <button type="button">nudge</button>
@@ -297,7 +297,7 @@ function TaskStaleAlert() {
             </div>
           ))}
         </div>
-        <div role="note" style={{marginTop:8, padding:'6px 8px', borderTop:'1px dashed var(--line-2)', fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--fg-4)'}}>
+        <div role="note" style={{marginTop:8, padding:'6px 8px', borderTop:'1px dashed var(--line-2)', fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--color-fg-disabled)'}}>
           taskmaster cannot force-release others' claims · operator nudge channel: <span style={{color:'var(--brass-1)'}}>hint</span>
         </div>
       </div>
@@ -439,11 +439,11 @@ function ResponsibilityMatrix() {
             </tr>
           </tbody>
         </table>
-        <div role="note" aria-label="Matrix density legend" style={{marginTop:8, padding:'6px 8px', fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--fg-4)', display:'flex', gap:8, alignItems:'center'}}>
+        <div role="note" aria-label="Matrix density legend" style={{marginTop:8, padding:'6px 8px', fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--color-fg-disabled)', display:'flex', gap:8, alignItems:'center'}}>
           <span aria-hidden="true">density:</span>
           <span aria-hidden="true" style={{padding:'1px 6px', background:'var(--color-bg-page)', border:'1px solid var(--line-1)'}}>0</span>
-          <span aria-hidden="true" style={{padding:'1px 6px', background:'rgb(var(--brass-glow)/.05)', color:'var(--fg-2)'}}>1–2</span>
-          <span aria-hidden="true" style={{padding:'1px 6px', background:'rgb(var(--brass-glow)/.12)', color:'var(--fg-1)'}}>3–4</span>
+          <span aria-hidden="true" style={{padding:'1px 6px', background:'rgb(var(--brass-glow)/.05)', color:'var(--color-fg-secondary)'}}>1–2</span>
+          <span aria-hidden="true" style={{padding:'1px 6px', background:'rgb(var(--brass-glow)/.12)', color:'var(--color-fg-primary)'}}>3–4</span>
           <span aria-hidden="true" style={{padding:'1px 6px', background:'rgb(var(--brass-glow)/.22)', color:'var(--brass-1)'}}>5–6</span>
           <span aria-hidden="true" style={{padding:'1px 6px', background:'var(--brass-1)', color:'var(--color-bg-page)'}}>7+</span>
         </div>

--- a/dashboard/design-system/preview/cb-group-e.jsx
+++ b/dashboard/design-system/preview/cb-group-e.jsx
@@ -255,7 +255,7 @@ function MentionInbox() {
         <div role="heading" aria-level={3} style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--color-fg-disabled)', letterSpacing:'.1em', textTransform:'uppercase', padding:'8px 0 2px', borderTop:'1px dashed var(--color-border-strong)'}}>━━ other mentions · {otherMentions.length}</div>
         <div className="ms-inbox" role="log" aria-live="polite" aria-label={`${otherMentions.length} other mentions`}>
           {otherMentions.map(m => (
-            <article key={m.seq} className="mn" aria-label={`#${m.seq} · ${m.from} in #${m.room} at ${m.at}: ${m.body}`} style={{borderLeftColor:'var(--info)', opacity:.7}}>
+            <article key={m.seq} className="mn" aria-label={`#${m.seq} · ${m.from} in #${m.room} at ${m.at}: ${m.body}`} style={{borderLeftColor:'var(--color-status-info)', opacity:.7}}>
               <div className="h" aria-hidden="true">
                 <span className="au">{m.from}</span>
                 <span className="rm">→ #{m.room}</span>

--- a/dashboard/design-system/preview/cb-group-e.jsx
+++ b/dashboard/design-system/preview/cb-group-e.jsx
@@ -101,7 +101,7 @@ function BoardThread() {
       />
       <div className="body">
         <BoardPost post={post} expanded={true} />
-        <div role="heading" aria-level={3} style={{padding:'4px 0', fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--fg-4)', letterSpacing:'.08em', textTransform:'uppercase'}}>
+        <div role="heading" aria-level={3} style={{padding:'4px 0', fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--color-fg-disabled)', letterSpacing:'.08em', textTransform:'uppercase'}}>
           ━━ {replies.length} replies
         </div>
         <div className="bd-thread" role="log" aria-live="polite" aria-label={`${replies.length} replies on ${post.id}`}>
@@ -115,7 +115,7 @@ function BoardThread() {
             </article>
           ))}
         </div>
-        <div role="textbox" aria-label="Reply composer (placeholder)" style={{marginTop:8, padding:'6px 8px', background:'var(--color-bg-surface)', border:'1px dashed var(--line-2)', fontFamily:'var(--font-mono)', fontSize:'11px', color:'var(--fg-4)'}}>
+        <div role="textbox" aria-label="Reply composer (placeholder)" style={{marginTop:8, padding:'6px 8px', background:'var(--color-bg-surface)', border:'1px dashed var(--line-2)', fontFamily:'var(--font-mono)', fontSize:'11px', color:'var(--color-fg-disabled)'}}>
           <span aria-hidden="true" style={{color:'var(--brass-1)'}}>masc&gt;</span> reply...
           <span aria-hidden="true" style={{color:'var(--brass-1)', animation:'anim-blink 1s step-end infinite'}}> ▌</span>
         </div>
@@ -252,7 +252,7 @@ function MentionInbox() {
             </article>
           ))}
         </div>
-        <div role="heading" aria-level={3} style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--fg-4)', letterSpacing:'.1em', textTransform:'uppercase', padding:'8px 0 2px', borderTop:'1px dashed var(--line-2)'}}>━━ other mentions · {otherMentions.length}</div>
+        <div role="heading" aria-level={3} style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--color-fg-disabled)', letterSpacing:'.1em', textTransform:'uppercase', padding:'8px 0 2px', borderTop:'1px dashed var(--line-2)'}}>━━ other mentions · {otherMentions.length}</div>
         <div className="ms-inbox" role="log" aria-live="polite" aria-label={`${otherMentions.length} other mentions`}>
           {otherMentions.map(m => (
             <article key={m.seq} className="mn" aria-label={`#${m.seq} · ${m.from} in #${m.room} at ${m.at}: ${m.body}`} style={{borderLeftColor:'var(--info)', opacity:.7}}>
@@ -282,7 +282,7 @@ function StateBlockMessage() {
         meta={`${stateMsgs.length} state-bearing msgs · structured payload`}
       />
       <div className="body">
-        <p style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--fg-4)', padding:'4px 0', lineHeight:1.5}}>
+        <p style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--color-fg-disabled)', padding:'4px 0', lineHeight:1.5}}>
           [STATE] blocks are inline, machine-readable structure inside human prose. Keepers stamp them on every broadcast that changes goal/intention/blocker state. Other keepers parse them silently and update local belief.
         </p>
         <div role="list" aria-label={`${stateMsgs.length} state messages`}>
@@ -327,7 +327,7 @@ function ComposerV2Broadcast() {
           </div>
           <span className="room-sel" aria-label="Target room: default">default</span>
           <span className="grow" aria-hidden="true" />
-          <span aria-label="Sequence 9 keepers, 38 chars" style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--fg-4)', letterSpacing:'.04em'}}>
+          <span aria-label="Sequence 9 keepers, 38 chars" style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--color-fg-disabled)', letterSpacing:'.04em'}}>
             seq {P2e.messages[0].seq + 1} · 9 keepers · 38 chars
           </span>
           <button type="button" className="send">send ⌘↵</button>
@@ -357,7 +357,7 @@ function ComposerV2Mention() {
           fontFamily:'var(--font-mono)', fontSize:'11px',
           boxShadow:'0 -4px 12px rgb(0 0 0 / .4)',
         }}>
-          <div role="presentation" style={{padding:'3px 8px', background:'var(--color-bg-panel-alt)', color:'var(--fg-4)', fontSize:'9px', letterSpacing:'.1em', textTransform:'uppercase'}}>match @nick</div>
+          <div role="presentation" style={{padding:'3px 8px', background:'var(--color-bg-panel-alt)', color:'var(--color-fg-disabled)', fontSize:'9px', letterSpacing:'.1em', textTransform:'uppercase'}}>match @nick</div>
           {[
             { id:'nick0cave', role:'Captain · merge', match:true },
             { id:'nickelodeon', role:'(unknown — alias)', match:false },
@@ -374,7 +374,7 @@ function ComposerV2Mention() {
                    opacity: k.match ? 1 : .5,
                  }}>
               <span aria-hidden="true" style={{color:'var(--brass-1)'}}>@{k.id}</span>
-              <span aria-hidden="true" style={{color:'var(--fg-4)', marginLeft:'auto', fontSize:'9px', letterSpacing:'.04em', textTransform:'uppercase'}}>{k.role}</span>
+              <span aria-hidden="true" style={{color:'var(--color-fg-disabled)', marginLeft:'auto', fontSize:'9px', letterSpacing:'.04em', textTransform:'uppercase'}}>{k.role}</span>
             </div>
           ))}
         </div>
@@ -392,7 +392,7 @@ function ComposerV2Mention() {
         <div className="targets" aria-label="Will mention: @nick0cave">
           <span aria-hidden="true">will mention:</span>
           <span className="t-pill" aria-hidden="true">@nick0cave</span>
-          <span aria-hidden="true" style={{marginLeft:'auto', color:'var(--fg-4)', textTransform:'none'}}>↑↓ pick · ⇥ accept · esc dismiss</span>
+          <span aria-hidden="true" style={{marginLeft:'auto', color:'var(--color-fg-disabled)', textTransform:'none'}}>↑↓ pick · ⇥ accept · esc dismiss</span>
         </div>
       </div>
       <div style={{flex:1, background:'var(--color-bg-page)'}} aria-hidden="true" />
@@ -429,7 +429,7 @@ function ComposerV2State() {
           <span className="t-pill" aria-hidden="true">Phase</span>
           <span className="t-pill" aria-hidden="true">Next</span>
           <span className="t-pill" aria-hidden="true">Blocker</span>
-          <span aria-hidden="true" style={{marginLeft:'auto', color:'var(--fg-4)', textTransform:'none'}}>4 keys · valid · will update belief in 9 keepers</span>
+          <span aria-hidden="true" style={{marginLeft:'auto', color:'var(--color-fg-disabled)', textTransform:'none'}}>4 keys · valid · will update belief in 9 keepers</span>
         </div>
       </div>
       <div style={{flex:1, background:'var(--color-bg-page)'}} aria-hidden="true" />

--- a/dashboard/design-system/preview/cb-group-e.jsx
+++ b/dashboard/design-system/preview/cb-group-e.jsx
@@ -115,9 +115,9 @@ function BoardThread() {
             </article>
           ))}
         </div>
-        <div role="textbox" aria-label="Reply composer (placeholder)" style={{marginTop:8, padding:'6px 8px', background:'var(--color-bg-surface)', border:'1px dashed var(--line-2)', fontFamily:'var(--font-mono)', fontSize:'11px', color:'var(--color-fg-disabled)'}}>
-          <span aria-hidden="true" style={{color:'var(--brass-1)'}}>masc&gt;</span> reply...
-          <span aria-hidden="true" style={{color:'var(--brass-1)', animation:'anim-blink 1s step-end infinite'}}> ▌</span>
+        <div role="textbox" aria-label="Reply composer (placeholder)" style={{marginTop:8, padding:'6px 8px', background:'var(--color-bg-surface)', border:'1px dashed var(--color-border-strong)', fontFamily:'var(--font-mono)', fontSize:'11px', color:'var(--color-fg-disabled)'}}>
+          <span aria-hidden="true" style={{color:'var(--color-accent-fg)'}}>masc&gt;</span> reply...
+          <span aria-hidden="true" style={{color:'var(--color-accent-fg)', animation:'anim-blink 1s step-end infinite'}}> ▌</span>
         </div>
       </div>
     </section>
@@ -236,10 +236,10 @@ function MentionInbox() {
         branch="main"
         keepers={[me]}
         meta={`${mine.length} for me · ${otherMentions.length} others`}
-        right={<span className="meta" style={{color:'var(--brass-1)'}}>@{me}</span>}
+        right={<span className="meta" style={{color:'var(--color-accent-fg)'}}>@{me}</span>}
       />
       <div className="body">
-        <div role="heading" aria-level={3} style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--brass-1)', letterSpacing:'.1em', textTransform:'uppercase', padding:'2px 0'}}>━━ for me · {mine.length}</div>
+        <div role="heading" aria-level={3} style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--color-accent-fg)', letterSpacing:'.1em', textTransform:'uppercase', padding:'2px 0'}}>━━ for me · {mine.length}</div>
         <div className="ms-inbox" role="log" aria-live="polite" aria-label={`${mine.length} mentions for me`}>
           {mine.map(m => (
             <article key={m.seq} className="mn" aria-label={`#${m.seq} · ${m.from} in #${m.room} at ${m.at}: ${m.body}`}>
@@ -252,7 +252,7 @@ function MentionInbox() {
             </article>
           ))}
         </div>
-        <div role="heading" aria-level={3} style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--color-fg-disabled)', letterSpacing:'.1em', textTransform:'uppercase', padding:'8px 0 2px', borderTop:'1px dashed var(--line-2)'}}>━━ other mentions · {otherMentions.length}</div>
+        <div role="heading" aria-level={3} style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--color-fg-disabled)', letterSpacing:'.1em', textTransform:'uppercase', padding:'8px 0 2px', borderTop:'1px dashed var(--color-border-strong)'}}>━━ other mentions · {otherMentions.length}</div>
         <div className="ms-inbox" role="log" aria-live="polite" aria-label={`${otherMentions.length} other mentions`}>
           {otherMentions.map(m => (
             <article key={m.seq} className="mn" aria-label={`#${m.seq} · ${m.from} in #${m.room} at ${m.at}: ${m.body}`} style={{borderLeftColor:'var(--info)', opacity:.7}}>
@@ -291,7 +291,7 @@ function StateBlockMessage() {
                      role="listitem"
                      className="ms-msg"
                      aria-label={`#${m.seq} · ${m.from} ${m.kind} → #${m.room} · ${m.at}: ${m.body} · state: ${m.state}`}
-                     style={{padding:'8px 10px', background:'var(--color-bg-surface)', border:'1px solid var(--line-1)', borderLeft:'2px solid var(--brass-2)', borderRadius:0}}>
+                     style={{padding:'8px 10px', background:'var(--color-bg-surface)', border:'1px solid var(--color-border-default)', borderLeft:'2px solid var(--brass-2)', borderRadius:0}}>
               <div className="seq" aria-hidden="true">#{m.seq}</div>
               <div className="body">
                 <div className="h" aria-hidden="true">
@@ -368,12 +368,12 @@ function ComposerV2Mention() {
                  aria-label={`@${k.id} · ${k.role}${k.match ? '' : ' · no match'}`}
                  style={{
                    padding:'4px 8px', display:'flex', gap:6, alignItems:'center',
-                   background: i===0 ? 'rgb(var(--brass-glow)/.12)' : 'transparent',
-                   borderLeft: i===0 ? '2px solid var(--brass-1)' : '2px solid transparent',
+                   background: i===0 ? 'rgb(var(--color-accent-glow)/.12)' : 'transparent',
+                   borderLeft: i===0 ? '2px solid var(--color-accent-fg)' : '2px solid transparent',
                    cursor:'pointer',
                    opacity: k.match ? 1 : .5,
                  }}>
-              <span aria-hidden="true" style={{color:'var(--brass-1)'}}>@{k.id}</span>
+              <span aria-hidden="true" style={{color:'var(--color-accent-fg)'}}>@{k.id}</span>
               <span aria-hidden="true" style={{color:'var(--color-fg-disabled)', marginLeft:'auto', fontSize:'9px', letterSpacing:'.04em', textTransform:'uppercase'}}>{k.role}</span>
             </div>
           ))}
@@ -412,7 +412,7 @@ function ComposerV2State() {
             <button type="button" role="radio" aria-checked="true" className="on">state</button>
           </div>
           <span className="room-sel" aria-label="Target room: default">default</span>
-          <span aria-label="Structured · machine-readable" style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--brass-1)', letterSpacing:'.04em'}}>
+          <span aria-label="Structured · machine-readable" style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--color-accent-fg)', letterSpacing:'.04em'}}>
             ◆ structured · machine-readable
           </span>
           <span className="grow" aria-hidden="true" />

--- a/dashboard/design-system/preview/cb-group-f.jsx
+++ b/dashboard/design-system/preview/cb-group-f.jsx
@@ -24,7 +24,7 @@ function CascadeCard({ c, hitModel, triedSet, showPool, compactModel = false }) 
       </div>
       {showPool && (
         <div className="csc-pool" role="list" aria-label={`Configured pool · ${c.configured.length} models`}>
-          <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',color:'var(--fg-4)',letterSpacing:'.08em',textTransform:'uppercase',marginRight:'4px'}}>configured pool ({c.configured.length}):</span>
+          <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',color:'var(--color-fg-disabled)',letterSpacing:'.08em',textTransform:'uppercase',marginRight:'4px'}}>configured pool ({c.configured.length}):</span>
           {c.configured.map(m => {
             const cls = m === hitModel ? 'hit' : triedSet.has(m) ? 'tried' : '';
             return <span key={m} role="listitem" aria-label={`${m}${cls === 'hit' ? ' (hit)' : cls === 'tried' ? ' (tried)' : ''}`} className={`mp ${cls}`}>{m}</span>;
@@ -94,7 +94,7 @@ function CascadeCompare() {
 
 function AuditLedgerHeader({ left, right }) {
   return (
-    <div role="heading" aria-level={3} style={{padding:'5px 8px',borderBottom:'1px solid var(--line-2)',display:'flex',gap:'8px',background:'var(--color-bg-panel-alt)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>
+    <div role="heading" aria-level={3} style={{padding:'5px 8px',borderBottom:'1px solid var(--line-2)',display:'flex',gap:'8px',background:'var(--color-bg-panel-alt)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)'}}>
       <span>{left}</span>
       <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{right}</span>
     </div>
@@ -152,7 +152,7 @@ function AuditSummary() {
   const total = P2f.auditEvents.length;
   return (
     <section aria-label={`Audit summary · ${sorted.length} kinds · ${total} events`} style={{display:'flex',flexDirection:'column',gap:'2px'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex'}}>
         <span>summary · last 12 events</span>
         <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{total} total</span>
       </div>
@@ -207,7 +207,7 @@ function SafeAutoDashboard() {
     <section aria-label="Safe Autonomy dashboard · score and findings" style={{display:'flex',flexDirection:'column',gap:'8px'}}>
       <SafeAutoHero />
       <div style={{background:'var(--color-bg-surface)',border:'1px solid var(--line-2)'}}>
-        <div role="heading" aria-level={3} style={{padding:'5px 8px',borderBottom:'1px solid var(--line-2)',display:'flex',gap:'8px',background:'var(--color-bg-panel-alt)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>
+        <div role="heading" aria-level={3} style={{padding:'5px 8px',borderBottom:'1px solid var(--line-2)',display:'flex',gap:'8px',background:'var(--color-bg-panel-alt)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)'}}>
           <span>findings ({sa.findings.length})</span>
           <span style={{marginLeft:'auto'}}>severity ↓</span>
         </div>
@@ -237,7 +237,7 @@ function SafeAutoByKeeper() {
   const sorted = Object.entries(byKeeper).sort((a,b) => (b[1].high*9 + b[1].medium*3 + b[1].low) - (a[1].high*9 + a[1].medium*3 + a[1].low));
   return (
     <section aria-label={`Safe Autonomy findings · by keeper · ${sorted.length} keepers`} style={{display:'flex',flexDirection:'column',gap:'4px'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex'}}>
         <span>findings by keeper</span>
         <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{sorted.length} keepers</span>
       </div>
@@ -248,7 +248,7 @@ function SafeAutoByKeeper() {
             <span className="sev high"   aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',padding:'1px 5px',textAlign:'center',opacity: v.high?1:0.15}}>{v.high}</span>
             <span className="sev medium" aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',padding:'1px 5px',textAlign:'center',opacity: v.medium?1:0.15}}>{v.medium}</span>
             <span className="sev low"    aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',padding:'1px 5px',textAlign:'center',opacity: v.low?1:0.15}}>{v.low}</span>
-            <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-3)'}}>{v.items.map(i=>i.rule.split(' ')[0]).join(' · ')}</span>
+            <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--color-fg-muted)'}}>{v.items.map(i=>i.rule.split(' ')[0]).join(' · ')}</span>
           </div>
         ))}
       </div>
@@ -263,8 +263,8 @@ function SafeAutoTrend() {
   return (
     <section aria-label={`Safe Autonomy trend · last 15 runs · min ${min}, current ${sa.global_score}, max ${max}`} style={{background:'var(--color-bg-surface)',border:'1px solid var(--line-2)',padding:'12px'}}>
       <div role="heading" aria-level={3} style={{display:'flex',gap:'12px',alignItems:'baseline',marginBottom:'8px',fontFamily:'var(--font-mono)'}}>
-        <span style={{fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>autonomy score · last 15 runs</span>
-        <span style={{marginLeft:'auto',fontSize:'var(--fs-10)',color:'var(--fg-3)'}}>min {min} · current <span style={{color:'var(--err-fg)'}}>{sa.global_score}</span> · max {max}</span>
+        <span style={{fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)'}}>autonomy score · last 15 runs</span>
+        <span style={{marginLeft:'auto',fontSize:'var(--fs-10)',color:'var(--color-fg-muted)'}}>min {min} · current <span style={{color:'var(--err-fg)'}}>{sa.global_score}</span> · max {max}</span>
       </div>
       <div aria-hidden="true" style={{display:'flex',alignItems:'flex-end',height:'80px',gap:'3px'}}>
         {sa.history.map((v, i) => {
@@ -277,7 +277,7 @@ function SafeAutoTrend() {
           );
         })}
       </div>
-      <div aria-hidden="true" style={{display:'flex',justifyContent:'space-between',marginTop:'4px',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',color:'var(--fg-4)'}}>
+      <div aria-hidden="true" style={{display:'flex',justifyContent:'space-between',marginTop:'4px',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',color:'var(--color-fg-disabled)'}}>
         <span>−15</span><span>now</span>
       </div>
     </section>
@@ -307,12 +307,12 @@ function CostPerAgent() {
         </div>
         <div className="cell" role="listitem" aria-label={`p50 Latency: ${P2f.costs.p50}ms, global`}>
           <span className="lbl" aria-hidden="true">p50 Latency</span>
-          <span className="v" aria-hidden="true">{P2f.costs.p50}<span style={{fontSize:'12px',color:'var(--fg-3)'}}>ms</span></span>
+          <span className="v" aria-hidden="true">{P2f.costs.p50}<span style={{fontSize:'12px',color:'var(--color-fg-muted)'}}>ms</span></span>
           <span className="sub" aria-hidden="true">global</span>
         </div>
         <div className="cell" role="listitem" aria-label={`p95 Latency: ${P2f.costs.p95}ms, over budget`}>
           <span className="lbl" aria-hidden="true">p95 Latency</span>
-          <span className="v" aria-hidden="true" style={{color:'var(--err-fg)'}}>{P2f.costs.p95}<span style={{fontSize:'12px',color:'var(--fg-3)'}}>ms</span></span>
+          <span className="v" aria-hidden="true" style={{color:'var(--err-fg)'}}>{P2f.costs.p95}<span style={{fontSize:'12px',color:'var(--color-fg-muted)'}}>ms</span></span>
           <span className="sub" aria-hidden="true">over budget</span>
         </div>
       </div>
@@ -362,7 +362,7 @@ function CostMatrix() {
   };
   return (
     <section aria-label={`Cost matrix · provider × model · total $${P2f.costs.total_cost_usd.toFixed(2)} over 24h`} style={{display:'flex',flexDirection:'column',gap:'8px'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex'}}>
         <span>provider × model · $ spent (24h)</span>
         <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>${P2f.costs.total_cost_usd.toFixed(2)}</span>
       </div>
@@ -394,7 +394,7 @@ function CostLatency() {
   const total = buckets.reduce((s,b) => s+b.n, 0);
   return (
     <section aria-label={`Cost latency distribution · ${total} calls · p50 ${P2f.costs.p50}ms · p95 ${P2f.costs.p95}ms`} style={{display:'flex',flexDirection:'column',gap:'8px'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'12px'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',gap:'12px'}}>
         <span>latency distribution · {total} calls</span>
         <span style={{marginLeft:'auto'}}>p50 · <span style={{color:'var(--brass-1)'}}>{P2f.costs.p50}ms</span></span>
         <span>p95 · <span style={{color:'var(--err-fg)'}}>{P2f.costs.p95}ms</span></span>
@@ -419,8 +419,8 @@ function CostLatency() {
           { l:'> 16s', v: buckets.filter(b=>b.lo>=16000).reduce((s,b)=>s+b.n,0), c:'var(--err-fg)' },
         ].map(b => (
           <div key={b.l} role="listitem" aria-label={`${b.l}: ${b.v} calls (${(b.v/total*100).toFixed(0)}%)`} style={{background:'var(--color-bg-surface)',padding:'6px 10px',display:'flex',flexDirection:'column',gap:'2px'}}>
-            <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>{b.l}</span>
-            <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-13)',color:b.c,fontVariantNumeric:'tabular-nums'}}>{b.v}<span style={{fontSize:'var(--fs-10)',color:'var(--fg-4)',marginLeft:'4px'}}>· {(b.v/total*100).toFixed(0)}%</span></span>
+            <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)'}}>{b.l}</span>
+            <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-13)',color:b.c,fontVariantNumeric:'tabular-nums'}}>{b.v}<span style={{fontSize:'var(--fs-10)',color:'var(--color-fg-disabled)',marginLeft:'4px'}}>· {(b.v/total*100).toFixed(0)}%</span></span>
           </div>
         ))}
       </div>
@@ -435,7 +435,7 @@ function CostLatency() {
 function HeuristicLog() {
   return (
     <section aria-label={`Heuristic firing log · ${P2f.heuristics.filter(h=>h.triggered).length} fired of ${P2f.heuristics.length}`} style={{background:'var(--color-bg-surface)',border:'1px solid var(--line-2)'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',borderBottom:'1px solid var(--line-2)',display:'flex',gap:'8px',background:'var(--color-bg-panel-alt)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',borderBottom:'1px solid var(--line-2)',display:'flex',gap:'8px',background:'var(--color-bg-panel-alt)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)'}}>
         <span>tail · keeper_hooks_oas.heuristics.jsonl</span>
         <span style={{marginLeft:'auto',color:'var(--err-fg)'}}>{P2f.heuristics.filter(h=>h.triggered).length}/{P2f.heuristics.length} fired</span>
       </div>
@@ -458,7 +458,7 @@ function HeuristicLog() {
 function StressBoard() {
   return (
     <section aria-label={`Agent stress board · ${P2f.stress.length} active stressors`} style={{display:'flex',flexDirection:'column',gap:'8px'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex'}}>
         <span>agent stress · agent_stress.jsonl</span>
         <span style={{marginLeft:'auto',color:'var(--err-fg)'}}>{P2f.stress.length} active</span>
       </div>
@@ -489,7 +489,7 @@ function HeuristicByModule() {
   const rows = Object.entries(byMod).sort((a,b) => b[1].fired - a[1].fired);
   return (
     <section aria-label={`Heuristic firing rate by module · ${rows.length} modules`} style={{display:'flex',flexDirection:'column',gap:'4px'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex'}}>
         <span>heuristic firing rate · by module</span>
       </div>
       <div role="list">
@@ -497,13 +497,13 @@ function HeuristicByModule() {
           const pct = v.total > 0 ? v.fired / v.total * 100 : 0;
           return (
             <div key={mod} role="listitem" aria-label={`${mod} · ${v.fired} of ${v.total} fired (${pct.toFixed(0)}%) · sites ${[...v.sites].join(', ')}`} style={{display:'grid',gridTemplateColumns:'160px 80px 1fr 60px',gap:'8px',alignItems:'center',padding:'5px 8px',background:'var(--color-bg-surface)',border:'1px solid var(--line-1)'}}>
-              <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--fg-1)'}}>{mod}</span>
-              <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-3)'}}>{v.fired}/{v.total} fired</span>
+              <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--color-fg-primary)'}}>{mod}</span>
+              <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--color-fg-muted)'}}>{v.fired}/{v.total} fired</span>
               <div aria-hidden="true" style={{height:'10px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-1)'}}>
                 <div style={{height:'100%',width:`${pct}%`,background: pct > 50 ? 'linear-gradient(90deg, var(--warn), var(--err))' : 'linear-gradient(90deg, var(--brass-3), var(--brass-1))'}}></div>
               </div>
               <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color: pct > 50 ? 'var(--err-fg)' : 'var(--brass-1)',fontVariantNumeric:'tabular-nums',textAlign:'right'}}>{pct.toFixed(0)}%</span>
-              <span aria-hidden="true" style={{gridColumn:'1 / -1',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',color:'var(--fg-4)',letterSpacing:'.04em'}}>sites · {[...v.sites].join(' · ')}</span>
+              <span aria-hidden="true" style={{gridColumn:'1 / -1',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',color:'var(--color-fg-disabled)',letterSpacing:'.04em'}}>sites · {[...v.sites].join(' · ')}</span>
             </div>
           );
         })}

--- a/dashboard/design-system/preview/cb-group-f.jsx
+++ b/dashboard/design-system/preview/cb-group-f.jsx
@@ -94,9 +94,9 @@ function CascadeCompare() {
 
 function AuditLedgerHeader({ left, right }) {
   return (
-    <div role="heading" aria-level={3} style={{padding:'5px 8px',borderBottom:'1px solid var(--line-2)',display:'flex',gap:'8px',background:'var(--color-bg-panel-alt)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)'}}>
+    <div role="heading" aria-level={3} style={{padding:'5px 8px',borderBottom:'1px solid var(--color-border-strong)',display:'flex',gap:'8px',background:'var(--color-bg-panel-alt)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)'}}>
       <span>{left}</span>
-      <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{right}</span>
+      <span style={{marginLeft:'auto',color:'var(--color-accent-fg)'}}>{right}</span>
     </div>
   );
 }
@@ -121,7 +121,7 @@ function AuditRow({ e }) {
 
 function AuditLedger() {
   return (
-    <section aria-label="Audit ledger" style={{background:'var(--color-bg-surface)',border:'1px solid var(--line-2)'}}>
+    <section aria-label="Audit ledger" style={{background:'var(--color-bg-surface)',border:'1px solid var(--color-border-strong)'}}>
       <AuditLedgerHeader left="tail · audit.jsonl" right={`${P2f.auditEvents.length} events`} />
       <div role="log" aria-live="polite" aria-label={`${P2f.auditEvents.length} audit events`}>
         {P2f.auditEvents.map((e, i) => <AuditRow key={i} e={e} />)}
@@ -134,7 +134,7 @@ function AuditByActor() {
   const actor = 'sangsu';
   const filtered = P2f.auditEvents.filter(e => e.actor === actor || e.subject.includes(actor));
   return (
-    <section aria-label={`Audit ledger filtered by actor ${actor}`} style={{background:'var(--color-bg-surface)',border:'1px solid var(--line-2)'}}>
+    <section aria-label={`Audit ledger filtered by actor ${actor}`} style={{background:'var(--color-bg-surface)',border:'1px solid var(--color-border-strong)'}}>
       <AuditLedgerHeader left={`filter · actor=${actor}`} right={`${filtered.length} matches`} />
       <div role="list" aria-label={`${filtered.length} matching audit events`}>
         {filtered.map((e, i) => <AuditRow key={i} e={e} />)}
@@ -152,20 +152,20 @@ function AuditSummary() {
   const total = P2f.auditEvents.length;
   return (
     <section aria-label={`Audit summary · ${sorted.length} kinds · ${total} events`} style={{display:'flex',flexDirection:'column',gap:'2px'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-strong)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex'}}>
         <span>summary · last 12 events</span>
-        <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{total} total</span>
+        <span style={{marginLeft:'auto',color:'var(--color-accent-fg)'}}>{total} total</span>
       </div>
       <div role="list" aria-label="Event kind summary rows">
         {sorted.map(([kind, n]) => {
           const [cat] = kind.split('.');
           const pct = (n / total * 100).toFixed(0);
           return (
-            <div key={kind} role="listitem" aria-label={`${kind}: ${n} events (${pct}%)`} style={{display:'grid',gridTemplateColumns:'140px 30px 1fr',gap:'6px',alignItems:'center',padding:'3px 8px',background:'var(--color-bg-surface)',border:'1px solid var(--line-1)'}}>
-              <span className={`kn ${cat}`} aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',padding:'1px 5px',border:'1px solid var(--line-2)',justifySelf:'flex-start'}}>{kind}</span>
-              <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--brass-1)',fontVariantNumeric:'tabular-nums',textAlign:'right'}}>{n}</span>
-              <div aria-hidden="true" style={{height:'10px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-1)',position:'relative'}}>
-                <div style={{height:'100%',width:`${pct}%`,background:'linear-gradient(90deg, var(--brass-3), var(--brass-1))'}}></div>
+            <div key={kind} role="listitem" aria-label={`${kind}: ${n} events (${pct}%)`} style={{display:'grid',gridTemplateColumns:'140px 30px 1fr',gap:'6px',alignItems:'center',padding:'3px 8px',background:'var(--color-bg-surface)',border:'1px solid var(--color-border-default)'}}>
+              <span className={`kn ${cat}`} aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',padding:'1px 5px',border:'1px solid var(--color-border-strong)',justifySelf:'flex-start'}}>{kind}</span>
+              <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--color-accent-fg)',fontVariantNumeric:'tabular-nums',textAlign:'right'}}>{n}</span>
+              <div aria-hidden="true" style={{height:'10px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-default)',position:'relative'}}>
+                <div style={{height:'100%',width:`${pct}%`,background:'linear-gradient(90deg, var(--color-accent-fg-dim), var(--color-accent-fg))'}}></div>
               </div>
             </div>
           );
@@ -206,8 +206,8 @@ function SafeAutoDashboard() {
   return (
     <section aria-label="Safe Autonomy dashboard · score and findings" style={{display:'flex',flexDirection:'column',gap:'8px'}}>
       <SafeAutoHero />
-      <div style={{background:'var(--color-bg-surface)',border:'1px solid var(--line-2)'}}>
-        <div role="heading" aria-level={3} style={{padding:'5px 8px',borderBottom:'1px solid var(--line-2)',display:'flex',gap:'8px',background:'var(--color-bg-panel-alt)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)'}}>
+      <div style={{background:'var(--color-bg-surface)',border:'1px solid var(--color-border-strong)'}}>
+        <div role="heading" aria-level={3} style={{padding:'5px 8px',borderBottom:'1px solid var(--color-border-strong)',display:'flex',gap:'8px',background:'var(--color-bg-panel-alt)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)'}}>
           <span>findings ({sa.findings.length})</span>
           <span style={{marginLeft:'auto'}}>severity ↓</span>
         </div>
@@ -237,14 +237,14 @@ function SafeAutoByKeeper() {
   const sorted = Object.entries(byKeeper).sort((a,b) => (b[1].high*9 + b[1].medium*3 + b[1].low) - (a[1].high*9 + a[1].medium*3 + a[1].low));
   return (
     <section aria-label={`Safe Autonomy findings · by keeper · ${sorted.length} keepers`} style={{display:'flex',flexDirection:'column',gap:'4px'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-strong)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex'}}>
         <span>findings by keeper</span>
-        <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{sorted.length} keepers</span>
+        <span style={{marginLeft:'auto',color:'var(--color-accent-fg)'}}>{sorted.length} keepers</span>
       </div>
       <div role="list">
         {sorted.map(([k, v]) => (
-          <div key={k} role="listitem" aria-label={`${k} · ${v.high} high, ${v.medium} medium, ${v.low} low`} style={{display:'grid',gridTemplateColumns:'120px 60px 60px 60px 1fr',gap:'6px',alignItems:'center',padding:'4px 8px',background:'var(--color-bg-surface)',border:'1px solid var(--line-1)'}}>
-            <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--brass-1)'}}>{k}</span>
+          <div key={k} role="listitem" aria-label={`${k} · ${v.high} high, ${v.medium} medium, ${v.low} low`} style={{display:'grid',gridTemplateColumns:'120px 60px 60px 60px 1fr',gap:'6px',alignItems:'center',padding:'4px 8px',background:'var(--color-bg-surface)',border:'1px solid var(--color-border-default)'}}>
+            <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--color-accent-fg)'}}>{k}</span>
             <span className="sev high"   aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',padding:'1px 5px',textAlign:'center',opacity: v.high?1:0.15}}>{v.high}</span>
             <span className="sev medium" aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',padding:'1px 5px',textAlign:'center',opacity: v.medium?1:0.15}}>{v.medium}</span>
             <span className="sev low"    aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',padding:'1px 5px',textAlign:'center',opacity: v.low?1:0.15}}>{v.low}</span>
@@ -261,7 +261,7 @@ function SafeAutoTrend() {
   const min = Math.min(...sa.history);
   const max = Math.max(...sa.history);
   return (
-    <section aria-label={`Safe Autonomy trend · last 15 runs · min ${min}, current ${sa.global_score}, max ${max}`} style={{background:'var(--color-bg-surface)',border:'1px solid var(--line-2)',padding:'12px'}}>
+    <section aria-label={`Safe Autonomy trend · last 15 runs · min ${min}, current ${sa.global_score}, max ${max}`} style={{background:'var(--color-bg-surface)',border:'1px solid var(--color-border-strong)',padding:'12px'}}>
       <div role="heading" aria-level={3} style={{display:'flex',gap:'12px',alignItems:'baseline',marginBottom:'8px',fontFamily:'var(--font-mono)'}}>
         <span style={{fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)'}}>autonomy score · last 15 runs</span>
         <span style={{marginLeft:'auto',fontSize:'var(--fs-10)',color:'var(--color-fg-muted)'}}>min {min} · current <span style={{color:'var(--err-fg)'}}>{sa.global_score}</span> · max {max}</span>
@@ -272,7 +272,7 @@ function SafeAutoTrend() {
           const bad = v < 78;
           return (
             <div key={i} style={{flex:1,display:'flex',flexDirection:'column',alignItems:'center',gap:'2px'}}>
-              <div style={{width:'100%',height:`${pct}%`,background: bad ? 'linear-gradient(180deg, var(--err), var(--err-border))' : 'linear-gradient(180deg, var(--brass-1), var(--brass-3))'}}></div>
+              <div style={{width:'100%',height:`${pct}%`,background: bad ? 'linear-gradient(180deg, var(--err), var(--err-border))' : 'linear-gradient(180deg, var(--color-accent-fg), var(--color-accent-fg-dim))'}}></div>
             </div>
           );
         })}
@@ -332,10 +332,10 @@ function CostPerAgent() {
         <tbody>
           {rows.map(r => (
             <tr key={r.agent}>
-              <th scope="row" style={{color:'var(--brass-1)'}}>{r.agent}</th>
+              <th scope="row" style={{color:'var(--color-accent-fg)'}}>{r.agent}</th>
               <td className="lat-num">{(r.in_tok/1000).toFixed(0)}k</td>
               <td className="lat-num">{(r.out_tok/1000).toFixed(1)}k</td>
-              <td className="lat-num" style={{color:'var(--brass-1)'}}>${r.cost.toFixed(2)}</td>
+              <td className="lat-num" style={{color:'var(--color-accent-fg)'}}>${r.cost.toFixed(2)}</td>
               <td className="bar" aria-hidden="true"><i style={{width:`${r.cost/maxCost*100}%`}}></i></td>
               <td className="lat-num">{r.p50_ms}</td>
               <td className={`lat-num ${r.p95_ms > 8000 ? 'bad' : ''}`} aria-label={`${r.p95_ms}ms${r.p95_ms > 8000 ? ' · over budget' : ''}`}>{r.p95_ms}</td>
@@ -362,9 +362,9 @@ function CostMatrix() {
   };
   return (
     <section aria-label={`Cost matrix · provider × model · total $${P2f.costs.total_cost_usd.toFixed(2)} over 24h`} style={{display:'flex',flexDirection:'column',gap:'8px'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-strong)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex'}}>
         <span>provider × model · $ spent (24h)</span>
-        <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>${P2f.costs.total_cost_usd.toFixed(2)}</span>
+        <span style={{marginLeft:'auto',color:'var(--color-accent-fg)'}}>${P2f.costs.total_cost_usd.toFixed(2)}</span>
       </div>
       <table className="cs-mat" aria-label="Provider × model cost matrix">
         <thead>
@@ -394,9 +394,9 @@ function CostLatency() {
   const total = buckets.reduce((s,b) => s+b.n, 0);
   return (
     <section aria-label={`Cost latency distribution · ${total} calls · p50 ${P2f.costs.p50}ms · p95 ${P2f.costs.p95}ms`} style={{display:'flex',flexDirection:'column',gap:'8px'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',gap:'12px'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-strong)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',gap:'12px'}}>
         <span>latency distribution · {total} calls</span>
-        <span style={{marginLeft:'auto'}}>p50 · <span style={{color:'var(--brass-1)'}}>{P2f.costs.p50}ms</span></span>
+        <span style={{marginLeft:'auto'}}>p50 · <span style={{color:'var(--color-accent-fg)'}}>{P2f.costs.p50}ms</span></span>
         <span>p95 · <span style={{color:'var(--err-fg)'}}>{P2f.costs.p95}ms</span></span>
       </div>
       <div className="cs-hist" role="img" aria-label={`Latency histogram · ${buckets.length} buckets`}>
@@ -411,10 +411,10 @@ function CostLatency() {
           );
         })}
       </div>
-      <div role="list" aria-label="Latency band totals" style={{display:'grid',gridTemplateColumns:'repeat(4, 1fr)',gap:'1px',background:'var(--line-2)',border:'1px solid var(--line-2)'}}>
+      <div role="list" aria-label="Latency band totals" style={{display:'grid',gridTemplateColumns:'repeat(4, 1fr)',gap:'1px',background:'var(--color-border-strong)',border:'1px solid var(--color-border-strong)'}}>
         {[
           { l:'< 1s',  v: buckets.filter(b=>b.hi<=1000).reduce((s,b)=>s+b.n,0), c:'var(--ok-fg)' },
-          { l:'1–4s',  v: buckets.filter(b=>b.lo>=1000&&b.hi<=4000).reduce((s,b)=>s+b.n,0), c:'var(--brass-1)' },
+          { l:'1–4s',  v: buckets.filter(b=>b.lo>=1000&&b.hi<=4000).reduce((s,b)=>s+b.n,0), c:'var(--color-accent-fg)' },
           { l:'4–16s', v: buckets.filter(b=>b.lo>=4000&&b.hi<=16000).reduce((s,b)=>s+b.n,0), c:'var(--warn)' },
           { l:'> 16s', v: buckets.filter(b=>b.lo>=16000).reduce((s,b)=>s+b.n,0), c:'var(--err-fg)' },
         ].map(b => (
@@ -434,8 +434,8 @@ function CostLatency() {
 
 function HeuristicLog() {
   return (
-    <section aria-label={`Heuristic firing log · ${P2f.heuristics.filter(h=>h.triggered).length} fired of ${P2f.heuristics.length}`} style={{background:'var(--color-bg-surface)',border:'1px solid var(--line-2)'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',borderBottom:'1px solid var(--line-2)',display:'flex',gap:'8px',background:'var(--color-bg-panel-alt)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)'}}>
+    <section aria-label={`Heuristic firing log · ${P2f.heuristics.filter(h=>h.triggered).length} fired of ${P2f.heuristics.length}`} style={{background:'var(--color-bg-surface)',border:'1px solid var(--color-border-strong)'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',borderBottom:'1px solid var(--color-border-strong)',display:'flex',gap:'8px',background:'var(--color-bg-panel-alt)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)'}}>
         <span>tail · keeper_hooks_oas.heuristics.jsonl</span>
         <span style={{marginLeft:'auto',color:'var(--err-fg)'}}>{P2f.heuristics.filter(h=>h.triggered).length}/{P2f.heuristics.length} fired</span>
       </div>
@@ -458,7 +458,7 @@ function HeuristicLog() {
 function StressBoard() {
   return (
     <section aria-label={`Agent stress board · ${P2f.stress.length} active stressors`} style={{display:'flex',flexDirection:'column',gap:'8px'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-strong)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex'}}>
         <span>agent stress · agent_stress.jsonl</span>
         <span style={{marginLeft:'auto',color:'var(--err-fg)'}}>{P2f.stress.length} active</span>
       </div>
@@ -489,20 +489,20 @@ function HeuristicByModule() {
   const rows = Object.entries(byMod).sort((a,b) => b[1].fired - a[1].fired);
   return (
     <section aria-label={`Heuristic firing rate by module · ${rows.length} modules`} style={{display:'flex',flexDirection:'column',gap:'4px'}}>
-      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex'}}>
+      <div role="heading" aria-level={3} style={{padding:'5px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-strong)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex'}}>
         <span>heuristic firing rate · by module</span>
       </div>
       <div role="list">
         {rows.map(([mod, v]) => {
           const pct = v.total > 0 ? v.fired / v.total * 100 : 0;
           return (
-            <div key={mod} role="listitem" aria-label={`${mod} · ${v.fired} of ${v.total} fired (${pct.toFixed(0)}%) · sites ${[...v.sites].join(', ')}`} style={{display:'grid',gridTemplateColumns:'160px 80px 1fr 60px',gap:'8px',alignItems:'center',padding:'5px 8px',background:'var(--color-bg-surface)',border:'1px solid var(--line-1)'}}>
+            <div key={mod} role="listitem" aria-label={`${mod} · ${v.fired} of ${v.total} fired (${pct.toFixed(0)}%) · sites ${[...v.sites].join(', ')}`} style={{display:'grid',gridTemplateColumns:'160px 80px 1fr 60px',gap:'8px',alignItems:'center',padding:'5px 8px',background:'var(--color-bg-surface)',border:'1px solid var(--color-border-default)'}}>
               <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--color-fg-primary)'}}>{mod}</span>
               <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--color-fg-muted)'}}>{v.fired}/{v.total} fired</span>
-              <div aria-hidden="true" style={{height:'10px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-1)'}}>
-                <div style={{height:'100%',width:`${pct}%`,background: pct > 50 ? 'linear-gradient(90deg, var(--warn), var(--err))' : 'linear-gradient(90deg, var(--brass-3), var(--brass-1))'}}></div>
+              <div aria-hidden="true" style={{height:'10px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-default)'}}>
+                <div style={{height:'100%',width:`${pct}%`,background: pct > 50 ? 'linear-gradient(90deg, var(--warn), var(--err))' : 'linear-gradient(90deg, var(--color-accent-fg-dim), var(--color-accent-fg))'}}></div>
               </div>
-              <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color: pct > 50 ? 'var(--err-fg)' : 'var(--brass-1)',fontVariantNumeric:'tabular-nums',textAlign:'right'}}>{pct.toFixed(0)}%</span>
+              <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color: pct > 50 ? 'var(--err-fg)' : 'var(--color-accent-fg)',fontVariantNumeric:'tabular-nums',textAlign:'right'}}>{pct.toFixed(0)}%</span>
               <span aria-hidden="true" style={{gridColumn:'1 / -1',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',color:'var(--color-fg-disabled)',letterSpacing:'.04em'}}>sites · {[...v.sites].join(' · ')}</span>
             </div>
           );

--- a/dashboard/design-system/preview/cb-group-f.jsx
+++ b/dashboard/design-system/preview/cb-group-f.jsx
@@ -272,7 +272,7 @@ function SafeAutoTrend() {
           const bad = v < 78;
           return (
             <div key={i} style={{flex:1,display:'flex',flexDirection:'column',alignItems:'center',gap:'2px'}}>
-              <div style={{width:'100%',height:`${pct}%`,background: bad ? 'linear-gradient(180deg, var(--err), var(--err-border))' : 'linear-gradient(180deg, var(--color-accent-fg), var(--color-accent-fg-dim))'}}></div>
+              <div style={{width:'100%',height:`${pct}%`,background: bad ? 'linear-gradient(180deg, var(--color-status-err), var(--err-border))' : 'linear-gradient(180deg, var(--color-accent-fg), var(--color-accent-fg-dim))'}}></div>
             </div>
           );
         })}
@@ -415,7 +415,7 @@ function CostLatency() {
         {[
           { l:'< 1s',  v: buckets.filter(b=>b.hi<=1000).reduce((s,b)=>s+b.n,0), c:'var(--ok-fg)' },
           { l:'1–4s',  v: buckets.filter(b=>b.lo>=1000&&b.hi<=4000).reduce((s,b)=>s+b.n,0), c:'var(--color-accent-fg)' },
-          { l:'4–16s', v: buckets.filter(b=>b.lo>=4000&&b.hi<=16000).reduce((s,b)=>s+b.n,0), c:'var(--warn)' },
+          { l:'4–16s', v: buckets.filter(b=>b.lo>=4000&&b.hi<=16000).reduce((s,b)=>s+b.n,0), c:'var(--color-status-warn)' },
           { l:'> 16s', v: buckets.filter(b=>b.lo>=16000).reduce((s,b)=>s+b.n,0), c:'var(--err-fg)' },
         ].map(b => (
           <div key={b.l} role="listitem" aria-label={`${b.l}: ${b.v} calls (${(b.v/total*100).toFixed(0)}%)`} style={{background:'var(--color-bg-surface)',padding:'6px 10px',display:'flex',flexDirection:'column',gap:'2px'}}>
@@ -500,7 +500,7 @@ function HeuristicByModule() {
               <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--color-fg-primary)'}}>{mod}</span>
               <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--color-fg-muted)'}}>{v.fired}/{v.total} fired</span>
               <div aria-hidden="true" style={{height:'10px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-default)'}}>
-                <div style={{height:'100%',width:`${pct}%`,background: pct > 50 ? 'linear-gradient(90deg, var(--warn), var(--err))' : 'linear-gradient(90deg, var(--color-accent-fg-dim), var(--color-accent-fg))'}}></div>
+                <div style={{height:'100%',width:`${pct}%`,background: pct > 50 ? 'linear-gradient(90deg, var(--color-status-warn), var(--color-status-err))' : 'linear-gradient(90deg, var(--color-accent-fg-dim), var(--color-accent-fg))'}}></div>
               </div>
               <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color: pct > 50 ? 'var(--err-fg)' : 'var(--color-accent-fg)',fontVariantNumeric:'tabular-nums',textAlign:'right'}}>{pct.toFixed(0)}%</span>
               <span aria-hidden="true" style={{gridColumn:'1 / -1',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',color:'var(--color-fg-disabled)',letterSpacing:'.04em'}}>sites · {[...v.sites].join(' · ')}</span>

--- a/dashboard/design-system/preview/cb-group-h.jsx
+++ b/dashboard/design-system/preview/cb-group-h.jsx
@@ -31,12 +31,12 @@ function KeeperBDIPanel() {
     <section aria-label="Keeper BDI panel · will, needs, desires" style={{display:'flex',flexDirection:'column',gap:'6px'}}>
       <KeeperTabs keepers={P2h.keepersFull} sel={sel} onSelect={setSel} label="Select keeper for BDI panel" />
       <div role="tabpanel" aria-label={`BDI panel for ${k.id}`}>
-        <div role="region" aria-label={`${k.id} · ${k.role} · social model ${k.social_model}`} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',display:'flex',alignItems:'center',gap:'8px',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-3)'}}>
+        <div role="region" aria-label={`${k.id} · ${k.role} · social model ${k.social_model}`} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',display:'flex',alignItems:'center',gap:'8px',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--color-fg-muted)'}}>
           <Dot kind={kClass(k.id)} beat />
           <span aria-hidden="true" style={{color:'var(--brass-1)'}}>{k.id}</span>
           <span aria-hidden="true">·</span>
           <span aria-hidden="true">{k.role}</span>
-          <span aria-hidden="true" style={{marginLeft:'auto',color:'var(--fg-4)',fontSize:'var(--fs-9)'}}>social · {k.social_model}</span>
+          <span aria-hidden="true" style={{marginLeft:'auto',color:'var(--color-fg-disabled)',fontSize:'var(--fs-9)'}}>social · {k.social_model}</span>
         </div>
         <dl className="ki-bdi" aria-label="BDI attributes">
           {[['will', k.will], ['needs', k.needs], ['desires', k.desires]].map(([lbl, v]) => (
@@ -95,7 +95,7 @@ function KeeperTokenStats() {
   const maxIn  = Math.max(...keepers.map(k => k.tokens.in));
   return (
     <section aria-label={`Token usage across ${keepers.length} keepers · ${(keepers.reduce((s,k)=>s+k.tokens.in,0)/1e6).toFixed(2)}M total in`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'12px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',gap:'12px'}}>
         <span>token usage · all keepers</span>
         <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>
           {(keepers.reduce((s,k)=>s+k.tokens.in,0)/1e6).toFixed(2)}M in total
@@ -125,7 +125,7 @@ function KeeperTokenStats() {
           { lbl:'Keepers', v:keepers.length },
         ].map(c => (
           <div key={c.lbl} role="listitem" aria-label={`${c.lbl}: ${c.v}`} style={{background:'var(--color-bg-surface)',padding:'6px 10px',display:'flex',flexDirection:'column',gap:'2px'}}>
-            <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)'}}>{c.lbl}</span>
+            <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)'}}>{c.lbl}</span>
             <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-14)',color:'var(--brass-1)',fontVariantNumeric:'tabular-nums'}}>{c.v}</span>
           </div>
         ))}
@@ -144,12 +144,12 @@ function DecisionsStream() {
   const rows = filter === 'all' ? P2h.decisions : P2h.decisions.filter(d => d.keeper === filter);
   return (
     <section aria-label={`Decisions stream · ${rows.length} entries${filter !== 'all' ? ` · filtered by ${filter}` : ''}`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div role="toolbar" aria-label="Decisions filter" style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',alignItems:'center',gap:'6px'}}>
+      <div role="toolbar" aria-label="Decisions filter" style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',alignItems:'center',gap:'6px'}}>
         <span aria-hidden="true">decisions.jsonl</span>
         <span role="radiogroup" aria-label="Filter by keeper" style={{marginLeft:'auto',display:'flex',gap:'2px'}}>
           {keepers.map(k => (
             <button key={k} type="button" role="radio" aria-checked={filter===k} onClick={() => setFilter(k)}
-              style={{padding:'1px 6px',background: filter===k ? 'var(--brass-3)' : 'var(--color-bg-surface)',border:'1px solid var(--line-2)',color: filter===k ? 'var(--brass-1)' : 'var(--fg-3)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',cursor:'pointer'}}>
+              style={{padding:'1px 6px',background: filter===k ? 'var(--brass-3)' : 'var(--color-bg-surface)',border:'1px solid var(--line-2)',color: filter===k ? 'var(--brass-1)' : 'var(--color-fg-muted)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',cursor:'pointer'}}>
               {k}
             </button>
           ))}
@@ -164,7 +164,7 @@ function DecisionsStream() {
             <div className="body" aria-hidden="true">
               <span className="act">
                 {d.speech_act} · {d.channel}
-                {d.intention && <span style={{color:'var(--fg-2)'}}> → {d.intention}</span>}
+                {d.intention && <span style={{color:'var(--color-fg-secondary)'}}> → {d.intention}</span>}
               </span>
               {d.blocker && <span className="blk">⚠ {d.blocker}</span>}
               {d.belief  && <span className="bel">↳ {d.belief}</span>}
@@ -183,12 +183,12 @@ function MemoryEntries() {
   const rows = tag === 'all' ? P2h.memoryEntries : P2h.memoryEntries.filter(m => m.tag === tag);
   return (
     <section aria-label={`Memory entries · ${rows.length} rows${tag !== 'all' ? ` · tag ${tag}` : ''}`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div role="toolbar" aria-label="Memory tag filter" style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',alignItems:'center',gap:'6px'}}>
+      <div role="toolbar" aria-label="Memory tag filter" style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',alignItems:'center',gap:'6px'}}>
         <span aria-hidden="true">memory.jsonl</span>
         <span role="radiogroup" aria-label="Filter by tag" style={{marginLeft:'auto',display:'flex',gap:'2px'}}>
           {tags.map(t => (
             <button key={t} type="button" role="radio" aria-checked={tag===t} onClick={() => setTag(t)}
-              style={{padding:'1px 6px',background: tag===t ? 'var(--brass-3)' : 'var(--color-bg-surface)',border:'1px solid var(--line-2)',color: tag===t ? 'var(--brass-1)' : 'var(--fg-3)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',cursor:'pointer'}}>
+              style={{padding:'1px 6px',background: tag===t ? 'var(--brass-3)' : 'var(--color-bg-surface)',border:'1px solid var(--line-2)',color: tag===t ? 'var(--brass-1)' : 'var(--color-fg-muted)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',cursor:'pointer'}}>
               {t}
             </button>
           ))}
@@ -203,7 +203,7 @@ function MemoryEntries() {
             <span className="body" aria-hidden="true">{m.body}</span>
           </div>
         )) : (
-          <div role="status" style={{padding:'12px 8px',fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--fg-4)',textAlign:'center'}}>
+          <div role="status" style={{padding:'12px 8px',fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--color-fg-disabled)',textAlign:'center'}}>
             no entries for tag "{tag}"
           </div>
         )}
@@ -220,7 +220,7 @@ function EpisodeCards() {
   const [open, setOpen] = useState('ep-tm-t5');
   return (
     <section aria-label={`Institution episodes · ${P2h.episodes.length} episodes`} style={{display:'flex',flexDirection:'column',gap:'0'}}>
-      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px',marginBottom:'4px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',gap:'8px',marginBottom:'4px'}}>
         <span>institution_episodes.jsonl</span>
         <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{P2h.episodes.length} episodes</span>
       </div>
@@ -268,7 +268,7 @@ function EpisodeLearnings() {
         <div key={ep.id} className="grp" role="group" aria-label={`${ep.id} · ${ep.participants.join(' + ')} · ${ep.learnings.length} learnings`}>
           <div className="grp-h" role="heading" aria-level={4}>
             <span aria-hidden="true">{ep.id}</span>
-            <span aria-hidden="true" style={{color:'var(--fg-4)'}}>·</span>
+            <span aria-hidden="true" style={{color:'var(--color-fg-disabled)'}}>·</span>
             <span aria-hidden="true">{ep.participants.join(' + ')}</span>
             <span aria-hidden="true" style={{marginLeft:'auto',color:'var(--brass-1)'}}>{ep.learnings.length} learnings</span>
           </div>
@@ -291,7 +291,7 @@ function ARLoopList() {
   const confCls = (c) => c >= 0.8 ? 'hi' : c >= 0.5 ? '' : c >= 0.35 ? 'lo' : 'vlo';
   return (
     <section aria-label={`Autoresearch loops · ${P2h.arLoops.filter(l=>l.status==='open').length} open · ${P2h.arLoops.filter(l=>l.status==='closed').length} closed`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',gap:'8px'}}>
         <span>autoresearch loops</span>
         <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{P2h.arLoops.filter(l=>l.status==='open').length} open · {P2h.arLoops.filter(l=>l.status==='closed').length} closed</span>
       </div>
@@ -301,9 +301,9 @@ function ARLoopList() {
             <span className="id" aria-hidden="true">{l.id.slice(0,11)}</span>
             <div aria-hidden="true" style={{display:'flex',flexDirection:'column',gap:'2px'}}>
               <span className="topic">{l.topic}</span>
-              <span style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-4)'}}>
+              <span style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--color-fg-disabled)'}}>
                 owner · {l.owner}
-                {l.branch && <span style={{color:'var(--fg-3)'}}> · ⎇ {l.branch}</span>}
+                {l.branch && <span style={{color:'var(--color-fg-muted)'}}> · ⎇ {l.branch}</span>}
                 {' · '}{l.hypotheses}H · {l.evidences}E · {l.conclusions}C
               </span>
             </div>
@@ -324,7 +324,7 @@ function ARFindingCard() {
       <div role="tablist" aria-label="Select finding" style={{display:'flex',gap:'2px'}}>
         {P2h.findings.map(x => (
           <button key={x.id} type="button" role="tab" aria-selected={sel===x.id} aria-controls="ar-finding-panel" tabIndex={sel===x.id ? 0 : -1} onClick={() => setSel(x.id)}
-            style={{padding:'3px 10px',background: sel===x.id ? 'var(--brass-3)' : 'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',color: sel===x.id ? 'var(--brass-1)' : 'var(--fg-3)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',cursor:'pointer'}}>
+            style={{padding:'3px 10px',background: sel===x.id ? 'var(--brass-3)' : 'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',color: sel===x.id ? 'var(--brass-1)' : 'var(--color-fg-muted)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',cursor:'pointer'}}>
             {x.id}
           </button>
         ))}
@@ -333,7 +333,7 @@ function ARFindingCard() {
         <div className="hdr" aria-hidden="true">
           <span className="id">{f.id}</span>
           <span className="loop">loop · {f.loop}</span>
-          <span style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-4)'}}>{f.at.slice(11,19)}</span>
+          <span style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--color-fg-disabled)'}}>{f.at.slice(11,19)}</span>
           <span className="conf">{(f.confidence*100).toFixed(0)}% confidence</span>
         </div>
         <section aria-labelledby={`ar-${f.id}-hyp`}>
@@ -360,9 +360,9 @@ function ARHypothesisFlow() {
   const finding = P2h.findings.find(f => f.loop === 'ar-78d41e9c');
   return (
     <section aria-label={`${loop.id} · ${loop.topic} · closed · ${(loop.confidence*100).toFixed(0)}% confidence`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',gap:'8px'}}>
         <span>{loop.id}</span>
-        <span style={{color:'var(--fg-3)'}}>· {loop.topic}</span>
+        <span style={{color:'var(--color-fg-muted)'}}>· {loop.topic}</span>
         <span style={{marginLeft:'auto',color:'var(--ok-fg)'}}>closed · {(loop.confidence*100).toFixed(0)}% confidence</span>
       </div>
       <ol className="ar-flow" aria-label="Hypothesis to evidence to conclusion flow" style={{listStyle:'none', margin:0, padding:0}}>

--- a/dashboard/design-system/preview/cb-group-h.jsx
+++ b/dashboard/design-system/preview/cb-group-h.jsx
@@ -31,9 +31,9 @@ function KeeperBDIPanel() {
     <section aria-label="Keeper BDI panel · will, needs, desires" style={{display:'flex',flexDirection:'column',gap:'6px'}}>
       <KeeperTabs keepers={P2h.keepersFull} sel={sel} onSelect={setSel} label="Select keeper for BDI panel" />
       <div role="tabpanel" aria-label={`BDI panel for ${k.id}`}>
-        <div role="region" aria-label={`${k.id} · ${k.role} · social model ${k.social_model}`} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',display:'flex',alignItems:'center',gap:'8px',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--color-fg-muted)'}}>
+        <div role="region" aria-label={`${k.id} · ${k.role} · social model ${k.social_model}`} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-strong)',display:'flex',alignItems:'center',gap:'8px',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--color-fg-muted)'}}>
           <Dot kind={kClass(k.id)} beat />
-          <span aria-hidden="true" style={{color:'var(--brass-1)'}}>{k.id}</span>
+          <span aria-hidden="true" style={{color:'var(--color-accent-fg)'}}>{k.id}</span>
           <span aria-hidden="true">·</span>
           <span aria-hidden="true">{k.role}</span>
           <span aria-hidden="true" style={{marginLeft:'auto',color:'var(--color-fg-disabled)',fontSize:'var(--fs-9)'}}>social · {k.social_model}</span>
@@ -95,9 +95,9 @@ function KeeperTokenStats() {
   const maxIn  = Math.max(...keepers.map(k => k.tokens.in));
   return (
     <section aria-label={`Token usage across ${keepers.length} keepers · ${(keepers.reduce((s,k)=>s+k.tokens.in,0)/1e6).toFixed(2)}M total in`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',gap:'12px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-strong)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',gap:'12px'}}>
         <span>token usage · all keepers</span>
-        <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>
+        <span style={{marginLeft:'auto',color:'var(--color-accent-fg)'}}>
           {(keepers.reduce((s,k)=>s+k.tokens.in,0)/1e6).toFixed(2)}M in total
         </span>
       </div>
@@ -118,7 +118,7 @@ function KeeperTokenStats() {
           ))}
         </tbody>
       </table>
-      <div role="list" aria-label="Token totals" style={{display:'grid',gridTemplateColumns:'repeat(3,1fr)',gap:'1px',background:'var(--line-1)',border:'1px solid var(--line-2)'}}>
+      <div role="list" aria-label="Token totals" style={{display:'grid',gridTemplateColumns:'repeat(3,1fr)',gap:'1px',background:'var(--color-border-default)',border:'1px solid var(--color-border-strong)'}}>
         {[
           { lbl:'Total In', v:`${(keepers.reduce((s,k)=>s+k.tokens.in,0)/1e6).toFixed(2)}M` },
           { lbl:'Total Out', v:`${(keepers.reduce((s,k)=>s+k.tokens.out,0)/1000).toFixed(0)}k` },
@@ -126,7 +126,7 @@ function KeeperTokenStats() {
         ].map(c => (
           <div key={c.lbl} role="listitem" aria-label={`${c.lbl}: ${c.v}`} style={{background:'var(--color-bg-surface)',padding:'6px 10px',display:'flex',flexDirection:'column',gap:'2px'}}>
             <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)'}}>{c.lbl}</span>
-            <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-14)',color:'var(--brass-1)',fontVariantNumeric:'tabular-nums'}}>{c.v}</span>
+            <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-14)',color:'var(--color-accent-fg)',fontVariantNumeric:'tabular-nums'}}>{c.v}</span>
           </div>
         ))}
       </div>
@@ -144,18 +144,18 @@ function DecisionsStream() {
   const rows = filter === 'all' ? P2h.decisions : P2h.decisions.filter(d => d.keeper === filter);
   return (
     <section aria-label={`Decisions stream · ${rows.length} entries${filter !== 'all' ? ` · filtered by ${filter}` : ''}`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div role="toolbar" aria-label="Decisions filter" style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',alignItems:'center',gap:'6px'}}>
+      <div role="toolbar" aria-label="Decisions filter" style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-strong)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',alignItems:'center',gap:'6px'}}>
         <span aria-hidden="true">decisions.jsonl</span>
         <span role="radiogroup" aria-label="Filter by keeper" style={{marginLeft:'auto',display:'flex',gap:'2px'}}>
           {keepers.map(k => (
             <button key={k} type="button" role="radio" aria-checked={filter===k} onClick={() => setFilter(k)}
-              style={{padding:'1px 6px',background: filter===k ? 'var(--brass-3)' : 'var(--color-bg-surface)',border:'1px solid var(--line-2)',color: filter===k ? 'var(--brass-1)' : 'var(--color-fg-muted)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',cursor:'pointer'}}>
+              style={{padding:'1px 6px',background: filter===k ? 'var(--color-accent-fg-dim)' : 'var(--color-bg-surface)',border:'1px solid var(--color-border-strong)',color: filter===k ? 'var(--color-accent-fg)' : 'var(--color-fg-muted)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',cursor:'pointer'}}>
               {k}
             </button>
           ))}
         </span>
       </div>
-      <div role="log" aria-live="polite" aria-label={`${rows.length} decisions`} style={{background:'var(--color-bg-page)',border:'1px solid var(--line-1)'}}>
+      <div role="log" aria-live="polite" aria-label={`${rows.length} decisions`} style={{background:'var(--color-bg-page)',border:'1px solid var(--color-border-default)'}}>
         {rows.map(d => (
           <div key={d.id} className="dec-row" role="listitem" aria-label={`${d.ts.slice(11,19)} · ${d.keeper} · ${d.outcome} · ${d.speech_act} via ${d.channel}${d.intention ? ' → ' + d.intention : ''}${d.blocker ? ' · blocker ' + d.blocker : ''}${d.belief ? ' · belief ' + d.belief : ''} · ${(d.latency_ms/1000).toFixed(1)}s`}>
             <span className="ts" aria-hidden="true">{d.ts.slice(11,19)}</span>
@@ -183,18 +183,18 @@ function MemoryEntries() {
   const rows = tag === 'all' ? P2h.memoryEntries : P2h.memoryEntries.filter(m => m.tag === tag);
   return (
     <section aria-label={`Memory entries · ${rows.length} rows${tag !== 'all' ? ` · tag ${tag}` : ''}`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div role="toolbar" aria-label="Memory tag filter" style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',alignItems:'center',gap:'6px'}}>
+      <div role="toolbar" aria-label="Memory tag filter" style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-strong)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',alignItems:'center',gap:'6px'}}>
         <span aria-hidden="true">memory.jsonl</span>
         <span role="radiogroup" aria-label="Filter by tag" style={{marginLeft:'auto',display:'flex',gap:'2px'}}>
           {tags.map(t => (
             <button key={t} type="button" role="radio" aria-checked={tag===t} onClick={() => setTag(t)}
-              style={{padding:'1px 6px',background: tag===t ? 'var(--brass-3)' : 'var(--color-bg-surface)',border:'1px solid var(--line-2)',color: tag===t ? 'var(--brass-1)' : 'var(--color-fg-muted)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',cursor:'pointer'}}>
+              style={{padding:'1px 6px',background: tag===t ? 'var(--color-accent-fg-dim)' : 'var(--color-bg-surface)',border:'1px solid var(--color-border-strong)',color: tag===t ? 'var(--color-accent-fg)' : 'var(--color-fg-muted)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',cursor:'pointer'}}>
               {t}
             </button>
           ))}
         </span>
       </div>
-      <div role="list" aria-label={`${rows.length} memory entries`} style={{background:'var(--color-bg-page)',border:'1px solid var(--line-1)'}}>
+      <div role="list" aria-label={`${rows.length} memory entries`} style={{background:'var(--color-bg-page)',border:'1px solid var(--color-border-default)'}}>
         {rows.length > 0 ? rows.map((m, i) => (
           <div key={i} className="mem-row" role="listitem" aria-label={`${m.at.slice(11,19)} · ${m.keeper} · ${m.tag} · ${m.body}`}>
             <span className="ts" aria-hidden="true">{m.at.slice(11,19)}</span>
@@ -220,9 +220,9 @@ function EpisodeCards() {
   const [open, setOpen] = useState('ep-tm-t5');
   return (
     <section aria-label={`Institution episodes · ${P2h.episodes.length} episodes`} style={{display:'flex',flexDirection:'column',gap:'0'}}>
-      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',gap:'8px',marginBottom:'4px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-strong)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',gap:'8px',marginBottom:'4px'}}>
         <span>institution_episodes.jsonl</span>
-        <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{P2h.episodes.length} episodes</span>
+        <span style={{marginLeft:'auto',color:'var(--color-accent-fg)'}}>{P2h.episodes.length} episodes</span>
       </div>
       <div role="list" aria-label="Episode cards">
         {P2h.episodes.map(ep => {
@@ -270,7 +270,7 @@ function EpisodeLearnings() {
             <span aria-hidden="true">{ep.id}</span>
             <span aria-hidden="true" style={{color:'var(--color-fg-disabled)'}}>·</span>
             <span aria-hidden="true">{ep.participants.join(' + ')}</span>
-            <span aria-hidden="true" style={{marginLeft:'auto',color:'var(--brass-1)'}}>{ep.learnings.length} learnings</span>
+            <span aria-hidden="true" style={{marginLeft:'auto',color:'var(--color-accent-fg)'}}>{ep.learnings.length} learnings</span>
           </div>
           <ul role="list" aria-label={`Learnings from ${ep.id}`} style={{listStyle:'none', margin:0, padding:0}}>
             {ep.learnings.map((l, i) => (
@@ -291,9 +291,9 @@ function ARLoopList() {
   const confCls = (c) => c >= 0.8 ? 'hi' : c >= 0.5 ? '' : c >= 0.35 ? 'lo' : 'vlo';
   return (
     <section aria-label={`Autoresearch loops · ${P2h.arLoops.filter(l=>l.status==='open').length} open · ${P2h.arLoops.filter(l=>l.status==='closed').length} closed`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',gap:'8px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-strong)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',gap:'8px'}}>
         <span>autoresearch loops</span>
-        <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{P2h.arLoops.filter(l=>l.status==='open').length} open · {P2h.arLoops.filter(l=>l.status==='closed').length} closed</span>
+        <span style={{marginLeft:'auto',color:'var(--color-accent-fg)'}}>{P2h.arLoops.filter(l=>l.status==='open').length} open · {P2h.arLoops.filter(l=>l.status==='closed').length} closed</span>
       </div>
       <div role="list" aria-label={`${P2h.arLoops.length} autoresearch loops`} style={{background:'var(--color-bg-page)'}}>
         {P2h.arLoops.map(l => (
@@ -324,7 +324,7 @@ function ARFindingCard() {
       <div role="tablist" aria-label="Select finding" style={{display:'flex',gap:'2px'}}>
         {P2h.findings.map(x => (
           <button key={x.id} type="button" role="tab" aria-selected={sel===x.id} aria-controls="ar-finding-panel" tabIndex={sel===x.id ? 0 : -1} onClick={() => setSel(x.id)}
-            style={{padding:'3px 10px',background: sel===x.id ? 'var(--brass-3)' : 'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',color: sel===x.id ? 'var(--brass-1)' : 'var(--color-fg-muted)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',cursor:'pointer'}}>
+            style={{padding:'3px 10px',background: sel===x.id ? 'var(--color-accent-fg-dim)' : 'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-strong)',color: sel===x.id ? 'var(--color-accent-fg)' : 'var(--color-fg-muted)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',cursor:'pointer'}}>
             {x.id}
           </button>
         ))}
@@ -360,7 +360,7 @@ function ARHypothesisFlow() {
   const finding = P2h.findings.find(f => f.loop === 'ar-78d41e9c');
   return (
     <section aria-label={`${loop.id} · ${loop.topic} · closed · ${(loop.confidence*100).toFixed(0)}% confidence`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',gap:'8px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-strong)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',gap:'8px'}}>
         <span>{loop.id}</span>
         <span style={{color:'var(--color-fg-muted)'}}>· {loop.topic}</span>
         <span style={{marginLeft:'auto',color:'var(--ok-fg)'}}>closed · {(loop.confidence*100).toFixed(0)}% confidence</span>

--- a/dashboard/design-system/preview/cb-group-i.jsx
+++ b/dashboard/design-system/preview/cb-group-i.jsx
@@ -10,7 +10,7 @@ const P2i = window.MASC_P2;
 // keeper color helper (uses kClass from cb-shared)
 function keeperColor(id) {
   return ({
-    'nick0cave':     'var(--brass-1)',
+    'nick0cave':     'var(--color-accent-fg)',
     'masc-improver': 'var(--ok)',
     'sangsu':        'var(--info)',
     'qa-king':       'var(--err)',
@@ -18,7 +18,7 @@ function keeperColor(id) {
     'ramarama':      'var(--stalled)',
     'scholar':       '#9aa6b8',
     'janitor':       '#7a8290',
-    'taskmaster':    'var(--brass-3)',
+    'taskmaster':    'var(--color-accent-fg-dim)',
     'velvet-hammer': '#c97070',
     'verdict':       '#b89070',
     'sojin':         '#8aa890',
@@ -65,9 +65,9 @@ function BranchSelector() {
         </span>
       </button>
 
-      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',gap:'8px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-strong)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',gap:'8px'}}>
         <span aria-hidden="true">switch branch · {P2i.branches.length} known</span>
-        <span aria-hidden="true" style={{marginLeft:'auto',color:'var(--brass-1)'}}>active · {sel}</span>
+        <span aria-hidden="true" style={{marginLeft:'auto',color:'var(--color-accent-fg)'}}>active · {sel}</span>
       </div>
       <div className="br-list" role="listbox" aria-label="Available branches">
         {P2i.branches.map(b => {
@@ -97,12 +97,12 @@ function BranchSelector() {
           );
         })}
       </div>
-      <div role="list" aria-label={`Active branch keepers · ${cur.keepers.length}`} style={{padding:'5px 10px',background:'var(--color-bg-surface)',border:'1px solid var(--line-1)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--color-fg-muted)',display:'flex',gap:'8px',alignItems:'center'}}>
+      <div role="list" aria-label={`Active branch keepers · ${cur.keepers.length}`} style={{padding:'5px 10px',background:'var(--color-bg-surface)',border:'1px solid var(--color-border-default)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--color-fg-muted)',display:'flex',gap:'8px',alignItems:'center'}}>
         <span aria-hidden="true" style={{color:'var(--color-fg-disabled)'}}>active branch keepers ·</span>
         {cur.keepers.map(k => (
           <span key={k} role="listitem" aria-label={k} style={{display:'inline-flex',alignItems:'center',gap:'4px'}}>
             <span aria-hidden="true" style={{display:'inline-block',width:'8px',height:'8px',borderRadius:'50%',background:keeperColor(k)}}/>
-            <span aria-hidden="true" style={{color:'var(--brass-1)'}}>{k}</span>
+            <span aria-hidden="true" style={{color:'var(--color-accent-fg)'}}>{k}</span>
           </span>
         ))}
       </div>
@@ -149,12 +149,12 @@ function KeeperMultiSelect() {
           );
         })}
       </div>
-      <div role="status" aria-live="polite" aria-label={`Filter applied to 8 zones · ${sel.size === 0 ? 'all hidden' : sel.size + '-way scope'}`} style={{padding:'5px 10px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--color-fg-muted)',display:'flex',flexWrap:'wrap',gap:'4px',alignItems:'center'}}>
+      <div role="status" aria-live="polite" aria-label={`Filter applied to 8 zones · ${sel.size === 0 ? 'all hidden' : sel.size + '-way scope'}`} style={{padding:'5px 10px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-strong)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--color-fg-muted)',display:'flex',flexWrap:'wrap',gap:'4px',alignItems:'center'}}>
         <span aria-hidden="true" style={{color:'var(--color-fg-disabled)'}}>filter applied to ·</span>
         {['Swimlanes','Activity','Audit','Decisions','Memory','Cost','Stress','Episodes'].map(z => (
-          <span key={z} aria-hidden="true" style={{padding:'1px 5px',background:'var(--color-bg-surface)',border:'1px solid var(--line-1)',color:'var(--color-fg-secondary)'}}>{z}</span>
+          <span key={z} aria-hidden="true" style={{padding:'1px 5px',background:'var(--color-bg-surface)',border:'1px solid var(--color-border-default)',color:'var(--color-fg-secondary)'}}>{z}</span>
         ))}
-        <span aria-hidden="true" style={{marginLeft:'auto',color: sel.size === 0 ? 'var(--err-fg)' : 'var(--brass-1)'}}>
+        <span aria-hidden="true" style={{marginLeft:'auto',color: sel.size === 0 ? 'var(--err-fg)' : 'var(--color-accent-fg)'}}>
           {sel.size === 0 ? '⚠ all hidden' : `→ ${sel.size}-way scope`}
         </span>
       </div>
@@ -172,9 +172,9 @@ function OperatorNudgeLog() {
   const [targets] = useState(['sangsu']);
   return (
     <section aria-label={`Operator nudge log · ${P2i.nudges.length} total · ${P2i.nudges.filter(n => !n.ack).length} pending ack`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',gap:'8px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-strong)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',gap:'8px'}}>
         <span>operator · nudge log</span>
-        <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{P2i.nudges.length} nudges · {P2i.nudges.filter(n => !n.ack).length} pending ack</span>
+        <span style={{marginLeft:'auto',color:'var(--color-accent-fg)'}}>{P2i.nudges.length} nudges · {P2i.nudges.filter(n => !n.ack).length} pending ack</span>
       </div>
       <div role="log" aria-live="polite" aria-label="Operator nudge history" style={{background:'var(--color-bg-page)'}}>
         {P2i.nudges.map(n => (

--- a/dashboard/design-system/preview/cb-group-i.jsx
+++ b/dashboard/design-system/preview/cb-group-i.jsx
@@ -11,11 +11,11 @@ const P2i = window.MASC_P2;
 function keeperColor(id) {
   return ({
     'nick0cave':     'var(--color-accent-fg)',
-    'masc-improver': 'var(--ok)',
-    'sangsu':        'var(--info)',
-    'qa-king':       'var(--err)',
-    'rama':          'var(--stalled)',
-    'ramarama':      'var(--stalled)',
+    'masc-improver': 'var(--color-status-ok)',
+    'sangsu':        'var(--color-status-info)',
+    'qa-king':       'var(--color-status-err)',
+    'rama':          'var(--color-status-stalled)',
+    'ramarama':      'var(--color-status-stalled)',
     'scholar':       '#9aa6b8',
     'janitor':       '#7a8290',
     'taskmaster':    'var(--color-accent-fg-dim)',
@@ -29,7 +29,7 @@ function keeperColor(id) {
     'codex-mcp-client': '#6a7080',
     'ollama-local':  '#7a9080',
     'scholar2':      '#9aa6b8',
-  })[id] || 'var(--idle)';
+  })[id] || 'var(--color-status-idle)';
 }
 
 // ═════════════════════════════════════════════════════════════════

--- a/dashboard/design-system/preview/cb-group-i.jsx
+++ b/dashboard/design-system/preview/cb-group-i.jsx
@@ -61,11 +61,11 @@ function BranchSelector() {
           <span>·</span>
           <span className="head">HEAD {cur.head}</span>
           <span>·</span>
-          <span style={{color:'var(--fg-3)'}}>{cur.keepers.length} keepers</span>
+          <span style={{color:'var(--color-fg-muted)'}}>{cur.keepers.length} keepers</span>
         </span>
       </button>
 
-      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',gap:'8px'}}>
         <span aria-hidden="true">switch branch · {P2i.branches.length} known</span>
         <span aria-hidden="true" style={{marginLeft:'auto',color:'var(--brass-1)'}}>active · {sel}</span>
       </div>
@@ -97,8 +97,8 @@ function BranchSelector() {
           );
         })}
       </div>
-      <div role="list" aria-label={`Active branch keepers · ${cur.keepers.length}`} style={{padding:'5px 10px',background:'var(--color-bg-surface)',border:'1px solid var(--line-1)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-3)',display:'flex',gap:'8px',alignItems:'center'}}>
-        <span aria-hidden="true" style={{color:'var(--fg-4)'}}>active branch keepers ·</span>
+      <div role="list" aria-label={`Active branch keepers · ${cur.keepers.length}`} style={{padding:'5px 10px',background:'var(--color-bg-surface)',border:'1px solid var(--line-1)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--color-fg-muted)',display:'flex',gap:'8px',alignItems:'center'}}>
+        <span aria-hidden="true" style={{color:'var(--color-fg-disabled)'}}>active branch keepers ·</span>
         {cur.keepers.map(k => (
           <span key={k} role="listitem" aria-label={k} style={{display:'inline-flex',alignItems:'center',gap:'4px'}}>
             <span aria-hidden="true" style={{display:'inline-block',width:'8px',height:'8px',borderRadius:'50%',background:keeperColor(k)}}/>
@@ -149,10 +149,10 @@ function KeeperMultiSelect() {
           );
         })}
       </div>
-      <div role="status" aria-live="polite" aria-label={`Filter applied to 8 zones · ${sel.size === 0 ? 'all hidden' : sel.size + '-way scope'}`} style={{padding:'5px 10px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--fg-3)',display:'flex',flexWrap:'wrap',gap:'4px',alignItems:'center'}}>
-        <span aria-hidden="true" style={{color:'var(--fg-4)'}}>filter applied to ·</span>
+      <div role="status" aria-live="polite" aria-label={`Filter applied to 8 zones · ${sel.size === 0 ? 'all hidden' : sel.size + '-way scope'}`} style={{padding:'5px 10px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--color-fg-muted)',display:'flex',flexWrap:'wrap',gap:'4px',alignItems:'center'}}>
+        <span aria-hidden="true" style={{color:'var(--color-fg-disabled)'}}>filter applied to ·</span>
         {['Swimlanes','Activity','Audit','Decisions','Memory','Cost','Stress','Episodes'].map(z => (
-          <span key={z} aria-hidden="true" style={{padding:'1px 5px',background:'var(--color-bg-surface)',border:'1px solid var(--line-1)',color:'var(--fg-2)'}}>{z}</span>
+          <span key={z} aria-hidden="true" style={{padding:'1px 5px',background:'var(--color-bg-surface)',border:'1px solid var(--line-1)',color:'var(--color-fg-secondary)'}}>{z}</span>
         ))}
         <span aria-hidden="true" style={{marginLeft:'auto',color: sel.size === 0 ? 'var(--err-fg)' : 'var(--brass-1)'}}>
           {sel.size === 0 ? '⚠ all hidden' : `→ ${sel.size}-way scope`}
@@ -172,7 +172,7 @@ function OperatorNudgeLog() {
   const [targets] = useState(['sangsu']);
   return (
     <section aria-label={`Operator nudge log · ${P2i.nudges.length} total · ${P2i.nudges.filter(n => !n.ack).length} pending ack`} style={{display:'flex',flexDirection:'column',gap:'6px'}}>
-      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--fg-4)',display:'flex',gap:'8px'}}>
+      <div role="heading" aria-level={3} style={{padding:'4px 8px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--line-2)',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',letterSpacing:'.12em',textTransform:'uppercase',color:'var(--color-fg-disabled)',display:'flex',gap:'8px'}}>
         <span>operator · nudge log</span>
         <span style={{marginLeft:'auto',color:'var(--brass-1)'}}>{P2i.nudges.length} nudges · {P2i.nudges.filter(n => !n.ack).length} pending ack</span>
       </div>

--- a/dashboard/design-system/preview/cb-group-j.jsx
+++ b/dashboard/design-system/preview/cb-group-j.jsx
@@ -3,7 +3,7 @@
 
 window.MASC_P3 = (function () {
   const keepers = [
-    { id: "nick0cave", initials: "NC", role: "captain", color: "var(--brass-1)" },
+    { id: "nick0cave", initials: "NC", role: "captain", color: "var(--color-accent-fg)" },
     { id: "masc-improver", initials: "MI", role: "improver", color: "var(--ok)" },
     { id: "sangsu", initials: "SG", role: "analyst", color: "var(--info)" },
     { id: "qa-king", initials: "QA", role: "qa", color: "var(--err)" },

--- a/dashboard/design-system/preview/cb-group-j.jsx
+++ b/dashboard/design-system/preview/cb-group-j.jsx
@@ -4,10 +4,10 @@
 window.MASC_P3 = (function () {
   const keepers = [
     { id: "nick0cave", initials: "NC", role: "captain", color: "var(--color-accent-fg)" },
-    { id: "masc-improver", initials: "MI", role: "improver", color: "var(--ok)" },
-    { id: "sangsu", initials: "SG", role: "analyst", color: "var(--info)" },
-    { id: "qa-king", initials: "QA", role: "qa", color: "var(--err)" },
-    { id: "rama", initials: "RA", role: "research", color: "var(--stalled)" },
+    { id: "masc-improver", initials: "MI", role: "improver", color: "var(--color-status-ok)" },
+    { id: "sangsu", initials: "SG", role: "analyst", color: "var(--color-status-info)" },
+    { id: "qa-king", initials: "QA", role: "qa", color: "var(--color-status-err)" },
+    { id: "rama", initials: "RA", role: "research", color: "var(--color-status-stalled)" },
   ];
 
   const files = [

--- a/dashboard/design-system/preview/cb-group-k.jsx
+++ b/dashboard/design-system/preview/cb-group-k.jsx
@@ -5,7 +5,7 @@ const P3K = window.MASC_P3;
 const P2K = window.MASC_P2 || {};
 
 function k3Keeper(id) {
-  return (P3K.keepers || []).find(k => k.id === id) || { id, initials: id.slice(0, 2), color: "var(--idle)" };
+  return (P3K.keepers || []).find(k => k.id === id) || { id, initials: id.slice(0, 2), color: "var(--color-status-idle)" };
 }
 
 function k3KeeperIds(keepers) {

--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -398,9 +398,21 @@ body[data-density="comfortable"]  { --density: 1.15; }
      Used in 3 cb-group-* refs as escape hatch — escalate to SPEC §3.4 if
      count grows. */
 
+  /* Single-slot status (general state) — diff-context use:
+     --color-status-added/modified/deleted alias the same raw hues. */
+  --color-status-ok:       var(--ok);
+  --color-status-warn:     var(--warn);
+  --color-status-err:      var(--err);
+  --color-status-info:     var(--info);
+  --color-status-idle:     var(--idle);
+  --color-status-stalled:  var(--stalled);
+
   --color-status-added:    var(--ok);
   --color-status-modified: var(--warn);
   --color-status-deleted:  var(--err);
+
+  /* 4-slot status pattern (--ok-soft/-fg/-border/-ring etc.) is intentional
+     escape hatch — see SPEC §6.2. Component-specific composition stays raw. */
 
   --color-keeper-1: var(--k-nick);
   --color-keeper-2: var(--k-masc);
@@ -436,6 +448,13 @@ body[data-density="comfortable"]  { --density: 1.15; }
   --color-accent-fg-dim:  #8a5f28;
   --color-accent-glow:    var(--brass-glow);
 
+  --color-status-ok:       #3d7a3d;
+  --color-status-warn:     #8a6a1a;
+  --color-status-err:      #a04030;
+  --color-status-info:     #4a6080;
+  --color-status-idle:     #807870;
+  --color-status-stalled:  #6a4080;
+
   --color-status-added:    #3d7a3d;
   --color-status-modified: #8a6a1a;
   --color-status-deleted:  #a04030;
@@ -465,6 +484,12 @@ body[data-density="comfortable"]  { --density: 1.15; }
     --color-accent-fg:      var(--brass-3);
     --color-accent-fg-dim:  #8a5f28;
     --color-accent-glow:    var(--brass-glow);
+    --color-status-ok:       #3d7a3d;
+    --color-status-warn:     #8a6a1a;
+    --color-status-err:      #a04030;
+    --color-status-info:     #4a6080;
+    --color-status-idle:     #807870;
+    --color-status-stalled:  #6a4080;
     --color-status-added:    #3d7a3d;
     --color-status-modified: #8a6a1a;
     --color-status-deleted:  #a04030;

--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -384,6 +384,7 @@ body[data-density="comfortable"]  { --density: 1.15; }
   --color-fg-primary:     var(--fg-1);
   --color-fg-secondary:   var(--fg-2);
   --color-fg-muted:       var(--fg-3);
+  --color-fg-disabled:    var(--fg-4);
 
   --color-border-default: var(--line-1);
   --color-border-strong:  var(--line-2);
@@ -419,6 +420,7 @@ body[data-density="comfortable"]  { --density: 1.15; }
   --color-fg-primary:     #1a1612;
   --color-fg-secondary:   #4a423a;
   --color-fg-muted:       #7a7065;
+  --color-fg-disabled:    #b0a898;
 
   --color-border-default: #d8d2c4;
   --color-border-strong:  #b8b0a0;
@@ -447,6 +449,7 @@ body[data-density="comfortable"]  { --density: 1.15; }
     --color-fg-primary:     #1a1612;
     --color-fg-secondary:   #4a423a;
     --color-fg-muted:       #7a7065;
+    --color-fg-disabled:    #b0a898;
     --color-border-default: #d8d2c4;
     --color-border-strong:  #b8b0a0;
     --color-accent-fg:      var(--brass-3);

--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -388,9 +388,15 @@ body[data-density="comfortable"]  { --density: 1.15; }
 
   --color-border-default: var(--line-1);
   --color-border-strong:  var(--line-2);
+  --color-border-divider: var(--line-3);
 
   --color-accent-fg:      var(--brass-1);
+  --color-accent-fg-dim:  var(--brass-3);
+  --color-accent-glow:    var(--brass-glow);
   /* --color-accent already defined in colors_and_type.css */
+  /* NOTE: --brass-2 is a "mid" tone with no canonical alias yet (SPEC v0.1).
+     Used in 3 cb-group-* refs as escape hatch — escalate to SPEC §3.4 if
+     count grows. */
 
   --color-status-added:    var(--ok);
   --color-status-modified: var(--warn);
@@ -424,8 +430,11 @@ body[data-density="comfortable"]  { --density: 1.15; }
 
   --color-border-default: #d8d2c4;
   --color-border-strong:  #b8b0a0;
+  --color-border-divider: #c8c0b0;
 
   --color-accent-fg:      var(--brass-3);
+  --color-accent-fg-dim:  #8a5f28;
+  --color-accent-glow:    var(--brass-glow);
 
   --color-status-added:    #3d7a3d;
   --color-status-modified: #8a6a1a;
@@ -452,7 +461,10 @@ body[data-density="comfortable"]  { --density: 1.15; }
     --color-fg-disabled:    #b0a898;
     --color-border-default: #d8d2c4;
     --color-border-strong:  #b8b0a0;
+    --color-border-divider: #c8c0b0;
     --color-accent-fg:      var(--brass-3);
+    --color-accent-fg-dim:  #8a5f28;
+    --color-accent-glow:    var(--brass-glow);
     --color-status-added:    #3d7a3d;
     --color-status-modified: #8a6a1a;
     --color-status-deleted:  #a04030;


### PR DESCRIPTION
## Summary

Migration phase PR-M2 (`--fg-*` text category). PR-M1(bg) 위에 stack.

## tokens.css 보강

| 변경 | Before | After |
|------|--------|-------|
| `--color-fg-disabled` 신규 | (없음) | `var(--fg-4)` |

3 곳 동기 적용: `:root` (dark) + `:root[data-theme="light"]` + `@media (prefers-color-scheme:light)` (light placeholder `#b0a898`).

## cb-group-* 컴포넌트 치환 (75 refs)

| 파일 | refs |
|------|------|
| cb-group-i.jsx | 8 |
| cb-group-h.jsx | 19 |
| cb-group-f.jsx | 21 |
| cb-group-e.jsx | 9 |
| cb-group-d.jsx | 7 |
| cb-group-c.jsx | 11 |

매핑:
- `var(--fg-1)` → `var(--color-fg-primary)`
- `var(--fg-2)` → `var(--color-fg-secondary)`
- `var(--fg-3)` → `var(--color-fg-muted)`
- `var(--fg-4)` → `var(--color-fg-disabled)`

## Validation

- `rg "var(--fg-[1-4])" preview/cb-group-*.jsx` → 0 raw 잔존
- `rg "var(--color-fg-" preview/cb-group-*.jsx` → 75 semantic refs
- 시각 회귀 0 (alias 동치)

## Stack

- Base: `feat/design-system-bg-migration` (PR-M1, #10500)
- PR-M1 머지 후 base를 main으로 변경

`do-not-merge` 라벨 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
