### PR TITLE
feat(dashboard): expose keeper wake button on stuck keepers

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -24,6 +24,7 @@ import {
   sendKeeperMessageDetailed,
   shutdownKeeper,
   streamKeeperMessage,
+  wakeKeeper,
 } from './keeper'
 
 afterEach(() => {
@@ -277,6 +278,39 @@ describe('keeper lifecycle', () => {
     const [url, init] = fetchMock.mock.calls[0]!
     expect(url).toBe('/api/v1/keepers/janitor/directive')
     expect(JSON.parse(init.body)).toEqual({ action: 'resume' })
+  })
+
+  it('sends POST with action=wakeup via directive endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, action: 'wakeup', name: 'sangsu' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await wakeKeeper('sangsu')
+
+    expect(result.ok).toBe(true)
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe('/api/v1/keepers/sangsu/directive')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body)).toEqual({ action: 'wakeup' })
+  })
+
+  it('returns error when wakeup directive fails', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: false, error: 'Keeper not found' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await wakeKeeper('nonexistent')
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toBe('Keeper not found')
   })
 
   it('returns error when pause directive fails', async () => {

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -472,6 +472,15 @@ export function resumeKeeper(name: string): Promise<KeeperLifecycleResponse> {
     `Failed to resume ${name}`,
   )
 }
+
+export function wakeKeeper(name: string): Promise<KeeperLifecycleResponse> {
+  return safeKeeperPostWithBody(
+    `/api/v1/keepers/${encodeURIComponent(name)}/directive`,
+    { action: 'wakeup' },
+    `Failed to wake ${name}`,
+  )
+}
+
 // --- Keeper tool policy editing ---
 
 interface KeeperToolPolicyInput {

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -22,6 +22,7 @@ import {
   pauseKeeper,
   resumeKeeper,
   shutdownKeeper,
+  wakeKeeper,
 } from '../api/keeper'
 import { TimeAgo } from './common/time-ago'
 import type { Keeper } from '../types'
@@ -226,13 +227,20 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
   if (!needsAttention && !hasActivitySignal) return null
 
   const directiveLoading = signal(false)
-  const handleDirective = async (action: 'pause' | 'resume') => {
+  const handleDirective = async (action: 'pause' | 'resume' | 'wakeup') => {
     directiveLoading.value = true
     try {
-      const fn = action === 'pause' ? pauseKeeper : resumeKeeper
+      const fn =
+        action === 'pause' ? pauseKeeper
+          : action === 'resume' ? resumeKeeper
+          : wakeKeeper
       const res = await fn(keeper.name)
       if (res.ok) {
-        showToast(action === 'pause' ? `${keeper.name} 일시정지됨` : `${keeper.name} 재개됨`, 'success')
+        const msg =
+          action === 'pause' ? `${keeper.name} 일시정지됨`
+            : action === 'resume' ? `${keeper.name} 재개됨`
+            : `${keeper.name} 깨움 신호 전송됨`
+        showToast(msg, 'success')
         await refreshAfterRuntimeAction()
       } else {
         showToast(res.error ?? '실패', 'error')
@@ -284,7 +292,15 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
               class="inline-flex items-center rounded px-2 py-0.5 text-2xs font-medium bg-[var(--white-6)] hover:bg-[var(--white-8)] text-[var(--text-strong)] transition-colors disabled:opacity-50"
               disabled=${directiveLoading.value}
               onClick=${() => handleDirective('pause')}
-            >일시정지</button>`}
+            >일시정지</button>
+            ${(hbStale || runtimeBlockerClass === 'oas_timeout_budget' || runtimeBlockerClass === 'cascade_exhausted' || runtimeBlockerClass === 'turn_timeout')
+              ? html`<button
+                  class="inline-flex items-center rounded px-2 py-0.5 text-2xs font-medium bg-[var(--warn-14)] hover:bg-[var(--warn-24)] text-[var(--warn)] transition-colors disabled:opacity-50"
+                  disabled=${directiveLoading.value}
+                  onClick=${() => handleDirective('wakeup')}
+                  title="자고 있는 keeper의 sleep을 깨워 다음 turn을 시도합니다. fiber가 살아 있을 때만 효과가 있습니다."
+                >깨우기</button>`
+              : null}`}
         ${keeper.paused && keeper.keepalive_running && continueGate
           ? html`<span>하트비트는 유지되지만 승인 전까지 자동 재개하지 않습니다.</span>`
           : keeper.paused && keeper.keepalive_running


### PR DESCRIPTION
## Summary

Dashboard에 keeper **깨우기 버튼** 추가. HTTP API (`POST /api/v1/keepers/:name/directive` action=`wakeup`)는 이미 존재하지만 dashboard UI가 그 경로를 노출하지 않았던 격차를 닫음.

**관찰 시점 (2026-04-26 KST)**: 5개 keeper (sangsu, nick0cave, masc-improver, scholar, janitor)가 ~4h40m 침묵 — 전날 20:34-20:51Z UTC fleet-wide oas_timeout_budget 사건 직후 멈춘 상태. 운영자가 dashboard에서 복구할 방법 없음. wakeup directive 자체는 200 OK를 반환하지만 UI 진입점이 없었음.

## 변경

| 파일 | 변경 |
|------|------|
| `dashboard/src/api/keeper.ts` | `wakeKeeper(name)` 추가 — `{action: 'wakeup'}` POST. pauseKeeper / resumeKeeper 패턴 차용 |
| `dashboard/src/components/keeper-detail.ts` | `handleDirective` union 확장 (`'pause' \| 'resume' \| 'wakeup'`), 분기별 toast 메시지, **"깨우기" 버튼**을 runtime banner에 추가 |
| `dashboard/src/api/keeper.test.ts` | wake action 성공/실패 vitest 2건 (pause/resume 패턴 차용) |

### 버튼 노출 조건

건강한 keeper에서는 보이지 않아 reflex click으로 autonomy를 방해하지 않도록 **gated**:

- `hbStale` 활성, OR
- `runtimeBlockerClass` ∈ {`oas_timeout_budget`, `cascade_exhausted`, `turn_timeout`}

이 외엔 비표시. 사용자가 *분명히 stuck*인 keeper에 한해 깨움 직접 트리거 가능.

### 버튼 toolitp

> "자고 있는 keeper의 sleep을 깨워 다음 turn을 시도합니다. fiber가 살아 있을 때만 효과가 있습니다."

정직성 의도: wakeup은 active `interruptible_sleep`을 *깨우는* 것일 뿐 사망한 fiber를 *살리는* 것이 아님. 사망 fiber 복구는 후속 **PR-M (Cycle FAILED → Keeper_fiber_crash propagation)** 에서 다룸.

## 검증

```
pnpm test src/api/keeper.test.ts → 13/13 pass (11 기존 + 2 신규)
pnpm build → 번들 clean, type 에러 없음
```

수동 시각 확인은 사용자 dashboard에서 — `do-not-merge` 라벨로 visual review 보호.

## Plan v6 reference

`~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-k-wise-pudding.md` § 2.8 (Leak 9). 본 PR은 PR-N (UX), PR-M (root cause)이 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
