### PR TITLE
fix(oas-sse-bridge): handle InferenceTelemetry variant (P0 main build)

### DIFF
--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -314,6 +314,25 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
         ]
       in
       Some (wrap ~event_type:"slot_scheduler_observed" ~payload ())
+  | Oas.Event_bus.InferenceTelemetry
+      { agent_name; turn; provider; model; prompt_tokens; completion_tokens;
+        prompt_ms; decode_ms; decode_tok_s } ->
+      let opt_int = function Some v -> `Int v | None -> `Null in
+      let opt_float = function Some v -> `Float v | None -> `Null in
+      let payload =
+        `Assoc [
+          ("agent_name", `String agent_name);
+          ("turn", `Int turn);
+          ("provider", `String provider);
+          ("model", `String model);
+          ("prompt_tokens", opt_int prompt_tokens);
+          ("completion_tokens", opt_int completion_tokens);
+          ("prompt_ms", opt_float prompt_ms);
+          ("decode_ms", opt_float decode_ms);
+          ("decode_tok_s", opt_float decode_tok_s);
+        ]
+      in
+      Some (wrap ~event_type:"inference_telemetry" ~payload ~agent_name ())
   | Oas.Event_bus.Custom (name, payload) ->
       (* Wire compatibility: dashboard consumers historically decoded
          [masc:broadcast] / [masc:keeper:snapshot] (all colons).


### PR DESCRIPTION
## P0 — main build broken

#10481 (OAS pin bump 367de4e adds `InferenceTelemetry` event) merged 후 main 빌드 깨짐:

\`\`\`
File \"lib/oas_sse_bridge.ml\", lines 126-335, characters 2-14:
Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
  Here is an example of a case that is not matched: InferenceTelemetry _
\`\`\`

## 변경

\`lib/oas_sse_bridge.ml\` Event_bus payload match 분기에 \`InferenceTelemetry\` case 추가. dashboard/governance가 새 telemetry stream을 silent drop이 아니라 SSE \`inference_telemetry\` 이벤트로 수신.

신규 case가 노출하는 필드:
- agent_name, turn, provider, model
- prompt_tokens, completion_tokens (Int|Null)
- prompt_ms, decode_ms, decode_tok_s (Float|Null)

## 검증

\`\`\`
DUNE_CACHE=disabled dune build --root . --cache=disabled @check  → EXIT=0
\`\`\`

(pre-fix: partial-match warning as error)

## 비목표

- dashboard에서 inference_telemetry 시각화: 별도 PR
- InferenceTelemetry → Prometheus counter: 별도 PR

## Defensive guards

P0 hotfix이므로 운영자 즉시 머지 권장. Draft 비활성, do-not-merge 라벨 미부착.