### PR TITLE
feat(dashboard): expose keeper wakeup directive (#10492)

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -24,6 +24,7 @@ import {
   sendKeeperMessageDetailed,
   shutdownKeeper,
   streamKeeperMessage,
+  wakeupKeeper,
 } from './keeper'
 
 afterEach(() => {
@@ -277,6 +278,39 @@ describe('keeper lifecycle', () => {
     const [url, init] = fetchMock.mock.calls[0]!
     expect(url).toBe('/api/v1/keepers/janitor/directive')
     expect(JSON.parse(init.body)).toEqual({ action: 'resume' })
+  })
+
+  it('sends POST with action=wakeup via directive endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, action: 'wakeup', name: 'sangsu' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await wakeupKeeper('sangsu')
+
+    expect(result.ok).toBe(true)
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe('/api/v1/keepers/sangsu/directive')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body)).toEqual({ action: 'wakeup' })
+  })
+
+  it('encodes keeper name in wakeup directive URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await wakeupKeeper('keeper with space')
+
+    const [url] = fetchMock.mock.calls[0]!
+    expect(url).toBe('/api/v1/keepers/keeper%20with%20space/directive')
   })
 
   it('returns error when pause directive fails', async () => {

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -472,6 +472,14 @@ export function resumeKeeper(name: string): Promise<KeeperLifecycleResponse> {
     `Failed to resume ${name}`,
   )
 }
+
+export function wakeupKeeper(name: string): Promise<KeeperLifecycleResponse> {
+  return safeKeeperPostWithBody(
+    `/api/v1/keepers/${encodeURIComponent(name)}/directive`,
+    { action: 'wakeup' },
+    `Failed to wake ${name}`,
+  )
+}
 // --- Keeper tool policy editing ---
 
 interface KeeperToolPolicyInput {

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -22,6 +22,7 @@ import {
   pauseKeeper,
   resumeKeeper,
   shutdownKeeper,
+  wakeupKeeper,
 } from '../api/keeper'
 import { TimeAgo } from './common/time-ago'
 import type { Keeper } from '../types'
@@ -226,13 +227,17 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
   if (!needsAttention && !hasActivitySignal) return null
 
   const directiveLoading = signal(false)
-  const handleDirective = async (action: 'pause' | 'resume') => {
+  const handleDirective = async (action: 'pause' | 'resume' | 'wakeup') => {
     directiveLoading.value = true
     try {
-      const fn = action === 'pause' ? pauseKeeper : resumeKeeper
+      const fn = action === 'pause' ? pauseKeeper : action === 'resume' ? resumeKeeper : wakeupKeeper
       const res = await fn(keeper.name)
       if (res.ok) {
-        showToast(action === 'pause' ? `${keeper.name} 일시정지됨` : `${keeper.name} 재개됨`, 'success')
+        const successLabel =
+          action === 'pause' ? `${keeper.name} 일시정지됨`
+          : action === 'resume' ? `${keeper.name} 재개됨`
+          : `${keeper.name} 깨움 신호 전송됨`
+        showToast(successLabel, 'success')
         await refreshAfterRuntimeAction()
       } else {
         showToast(res.error ?? '실패', 'error')
@@ -285,6 +290,16 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
               disabled=${directiveLoading.value}
               onClick=${() => handleDirective('pause')}
             >일시정지</button>`}
+        <button
+          class=${`inline-flex items-center rounded px-2 py-0.5 text-2xs font-medium transition-colors disabled:opacity-50 ${
+            hbStale
+              ? 'bg-[var(--warn-14)] hover:bg-[var(--warn-24)] text-[var(--warn)]'
+              : 'bg-[var(--white-6)] hover:bg-[var(--white-8)] text-[var(--text-strong)]'
+          }`}
+          disabled=${directiveLoading.value}
+          onClick=${() => handleDirective('wakeup')}
+          title="강제로 keeper fiber 를 깨우는 신호를 보냅니다 (heartbeat skip 무시)"
+        >${hbStale ? '강제 깨우기' : '깨우기'}</button>
         ${keeper.paused && keeper.keepalive_running && continueGate
           ? html`<span>하트비트는 유지되지만 승인 전까지 자동 재개하지 않습니다.</span>`
           : keeper.paused && keeper.keepalive_running


### PR DESCRIPTION
## Closes
Closes #10492

## 증상
Operator가 dashboard에서 stuck/sleeping keeper를 깨울 수단 없음. 라이브 증거: 14 keeper 중 8개(57%)가 ~5시간 stuck (ramarama, sangsu, ollama-local, executor, scholar, masc-improver, velvet-hammer, issue_king).

## 근본원인 (1줄)
백엔드 `POST /api/v1/keepers/<name>/directive`가 `wakeup` action을 정확히 지원(`server_dashboard_http_keeper_api.ml:840-926`)하나, frontend `dashboard/src/api/keeper.ts`가 `pause`/`resume`만 export하고 `wakeup`은 미노출. UI 노출 gap.

## 변경
- `dashboard/src/api/keeper.ts`: `wakeupKeeper(name)` 추가, 기존 `safeKeeperPostWithBody` 패턴 그대로 재사용.
- `dashboard/src/components/keeper-detail.ts`:
  - `handleDirective` action union 확장 (`'pause' | 'resume' | 'wakeup'`)
  - "깨우기" 버튼을 pause/resume 옆에 항상 노출 (paused 여부 무관)
  - `hbStale` 시 warn-tone(`bg-[var(--warn-14)]`) + 라벨 "강제 깨우기"
  - 토스트 분기에 wakeup success label 추가

## 증명
- `pnpm test src/api/keeper.test.ts`: 13/13 passed (2 신규 wakeup 테스트 + URL encoding 테스트)
- `pnpm typecheck`: clean
- `pnpm lint`: clean

## Out of scope (별도 이슈)
- `clear_error`/`reset_error` directive: 백엔드에 미존재 → 별도 PR 필요.
- "5h stuck"의 root cause(왜 잠드는지): heartbeat / cascade param / reconcile blocker 진단(메모리 `feedback_keeper-silence-diagnosis-pattern.md` 순서).
- Auto-wake on stale: policy 의사결정 필요(operator-mediated가 적절).

## Defensive PR posture
- Draft 유지
- `do-not-merge` label
- 직후 `gh pr ready --undo` + `gh pr merge --disable-auto` 실행 (메모리 `feedback_do-not-merge-label-insufficient.md`)

## 검증 방법 (운영)
PR 머지 후 dashboard에서:
1. `/keepers/<stuck-name>` 라우트 진입
2. "깨우기" 버튼 클릭 (heartbeat stale 상태면 "강제 깨우기"로 보임)
3. `~/.masc/keepers/<name>/progress.md` mtime 갱신 확인 (수 초 이내)
4. 백엔드 로그에 `wakeup_keeper` 호출 로그 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)