### PR TITLE
fix(oas-sse-bridge): drop redundant InferenceTelemetry skip after #10490

### DIFF
--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -355,12 +355,6 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
            ?turn:(payload_int_opt "turn" payload)
            ?tool_name:(payload_string_opt "tool_name" payload)
            ())
-  | Oas.Event_bus.InferenceTelemetry _ ->
-      (* Per-token telemetry from OAS#1202; not surfaced over SSE — the
-         dashboard receives token usage via the existing AgentCompleted
-         payload aggregate. Skip the relay to avoid flooding SSE
-         consumers with high-frequency low-value events. *)
-      None
 
 let relay_max_attempts = 3
 let relay_max_queue_depth = 256


### PR DESCRIPTION
## Why

#10489 (mine) added \`| Oas.Event_bus.InferenceTelemetry _ -> None\` to keep the match exhaustive after the OAS pin bump. #10490 (concurrent fix) instead added a richer handler that *relays* the event with structured payload. Both merged.

The richer case at line 317 now matches first and absorbs every \`InferenceTelemetry\` event, so my \`None\` clause at line 358 is unreachable — \`warning 11 [redundant-case]\`. With \`OCAMLPARAM=_,warn-error=+a\` this turns into a build error and blocks every fresh PR (e.g. \`perf/mcp-accept-redundant-lower\` was unable to build cleanly until this is removed).

## What

Delete the redundant 6-line skip clause. The richer handler from #10490 stays as the single source of truth for \`InferenceTelemetry\`.

## Verify

- Local \`OCAMLPARAM='_,warn-error=+a' dune build @check\` passes after the deletion (errored before).
- No behavioural change — #10490's handler is always reached.

## Risk

None. The deleted case was unreachable.