### PR TITLE
hotfix(main): drop duplicate InferenceTelemetry emit arm in oas_sse_bridge

### DIFF
--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -314,28 +314,6 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
         ]
       in
       Some (wrap ~event_type:"slot_scheduler_observed" ~payload ())
-  | Oas.Event_bus.InferenceTelemetry
-      { agent_name; turn; provider; model
-      ; prompt_tokens; completion_tokens
-      ; prompt_ms; decode_ms; decode_tok_s } ->
-      let int_opt = function Some n -> `Int n | None -> `Null in
-      let float_opt = function Some f -> `Float f | None -> `Null in
-      let payload =
-        `Assoc
-          [ ("agent_name", `String agent_name)
-          ; ("turn", `Int turn)
-          ; ("provider", `String provider)
-          ; ("model", `String model)
-          ; ("prompt_tokens", int_opt prompt_tokens)
-          ; ("completion_tokens", int_opt completion_tokens)
-          ; ("prompt_ms", float_opt prompt_ms)
-          ; ("decode_ms", float_opt decode_ms)
-          ; ("decode_tok_s", float_opt decode_tok_s)
-          ]
-      in
-      Some
-        (wrap ~event_type:"inference_telemetry" ~payload
-           ~agent_name ~turn ())
   | Oas.Event_bus.Custom (name, payload) ->
       (* Wire compatibility: dashboard consumers historically decoded
          [masc:broadcast] / [masc:keeper:snapshot] (all colons).


### PR DESCRIPTION
## 요약

Main 빌드 깨짐 — `lib/oas_sse_bridge.ml`에 `InferenceTelemetry` 매치 arm이 2개 (lines 317, 358), 두번째가 redundant-case 경고로 빌드 실패.

## 원인

PR #10489, #10490이 동일한 OAS pin bump(#10481, OAS#1202) 처리를 16초 차이로 머지. autocoder 두 fleet이 서로의 작업을 못 봄.

- #10489 (line 317-338): InferenceTelemetry를 SSE event로 emit
- #10490 (line 358-363): InferenceTelemetry를 SSE 미전송 (policy: high-freq, AgentCompleted aggregate에 포함되어 redundant)

두 arm 다 같이 있으면 line 358이 unreachable → \`Error (warning 11 [redundant-case])\`.

## 수정

Line 358의 skip policy가 의도적이고 명시적 — `dashboard receives token usage via the existing AgentCompleted payload aggregate`. Line 317-338 (emit arm) 제거.

## 검증

- 로컬 \`dune build lib/\` 통과 (이전엔 redundant-case 경고로 fail)
- 17개 queued PR 전부 동일 사유로 CI fail 중 — 이 hotfix 머지 후 unblock 예정

## 근거 메모리

- \`feedback_check-existing-prs-before-fix.md\`: PR 작성 전 \`gh pr list\` 확인. 두 autocoder fleet이 같은 OAS pin 후속 fix 동시 진행한 사례.
- \`feedback_oas-pin-bump-drift-gate.md\`: OAS pin SHA bump 시 공개 타입 표면 fingerprint diff로 CI 차단 필요.