### PR TITLE
fix(oas-sse-bridge): drop redundant InferenceTelemetry skip case (P0 main build)

### DIFF
--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -355,12 +355,6 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
            ?turn:(payload_int_opt "turn" payload)
            ?tool_name:(payload_string_opt "tool_name" payload)
            ())
-  | Oas.Event_bus.InferenceTelemetry _ ->
-      (* Per-token telemetry from OAS#1202; not surfaced over SSE — the
-         dashboard receives token usage via the existing AgentCompleted
-         payload aggregate. Skip the relay to avoid flooding SSE
-         consumers with high-frequency low-value events. *)
-      None
 
 let relay_max_attempts = 3
 let relay_max_queue_depth = 256


### PR DESCRIPTION
## P0 — main build still broken after #10490

#10490이 active InferenceTelemetry emit을 추가했지만, 이후 머지된 다른 PR이 unreachable한 \"skip\" case를 Custom 분기 뒤에 추가. 결과:

\`\`\`
File \"lib/oas_sse_bridge.ml\", line 358
Error (warning 11 [redundant-case]): this match case is unused.
\`\`\`

## 변경

\`lib/oas_sse_bridge.ml\` line 358-363의 dead case 6줄 제거. 상단의 active emit은 그대로.

## 검증

\`\`\`
DUNE_CACHE=disabled dune build --root . --cache=disabled @check  → EXIT=0
\`\`\`

## 비고

- #10510도 같은 fix 시도 중인데 Meta Guards fail (별도 lint 문제 있을 가능성). 본 PR은 더 minimal scope (-6 lines only, no related cleanup).
- 운영자 즉시 머지 권장 — main 빌드 복구 P0.

## Defensive guards

P0 hotfix이므로 Draft 비활성, do-not-merge 미부착.