### PR TITLE
feat(design-system): migrate cb-group-a keeper attribution to --color-keeper-* (PR-M6)

### DIFF
--- a/dashboard/design-system/SPEC.md
+++ b/dashboard/design-system/SPEC.md
@@ -265,6 +265,8 @@ bonsai의 5 테마는 production user에게 URL hash로 공유 가능한 자산.
 | `keeperColor()` 헬퍼 | `dashboard/design-system/preview/cb-group-i.jsx` | 12 keeper persona를 attribution token 5종으로 환원 불가 — hex extension 의도적 |
 | `rgba(... / .NN)` alpha 조합 | 어느 곳이든 | `rgb(var(--token-glow) / .12)` 형태로 raw token alpha 조합은 허용 |
 | 폰트 fallback chain | `--font-*` 정의 내 | system font name (e.g., `Inter`, `JetBrains Mono`) |
+| 4-slot status pattern | `tokens.css`의 `--{ok\|warn\|err\|info\|idle\|stalled}-{soft\|fg\|border\|ring}` | 컴포넌트별 정교한 surface/text/border/ring 4 slot 조합. single-slot semantic alias로 환원 불가. 컴포넌트는 raw 참조 허용 (PR-M5 결정). |
+| `--brass-2` mid tone | accent palette mid-tone 사용처 | SPEC v0.1 §3.4은 accent를 fg/fg-dim 2 slot만 정의. 사용 빈도 증가 시 `--color-accent-fg-mid` 추가 검토. |
 
 ### 6.3 Surface 적용 의무
 

--- a/dashboard/design-system/preview/cb-group-a.jsx
+++ b/dashboard/design-system/preview/cb-group-a.jsx
@@ -14,11 +14,11 @@ const DENSITY_LABEL = { c: 'Compact', n: 'Normal', l: 'Loose' };
 
 const TOPBAR_DEFAULT_KEEPERS = ["nick0cave","masc-improver","sangsu","qa-king","rama"];
 const TOPBAR_KEEPER_COLOR = {
-  "nick0cave": "var(--k-nick)",
-  "masc-improver": "var(--k-masc)",
-  "sangsu": "var(--k-sangsu)",
-  "qa-king": "var(--k-qa)",
-  "rama": "var(--k-rama)",
+  "nick0cave": "var(--color-keeper-1)",
+  "masc-improver": "var(--color-keeper-2)",
+  "sangsu": "var(--color-keeper-3)",
+  "qa-king": "var(--color-keeper-4)",
+  "rama": "var(--color-keeper-5)",
 };
 
 function TopbarStandard({

--- a/dashboard/design-system/preview/cb-group-e.jsx
+++ b/dashboard/design-system/preview/cb-group-e.jsx
@@ -255,7 +255,7 @@ function MentionInbox() {
         <div role="heading" aria-level={3} style={{fontFamily:'var(--font-mono)', fontSize:'10px', color:'var(--color-fg-disabled)', letterSpacing:'.1em', textTransform:'uppercase', padding:'8px 0 2px', borderTop:'1px dashed var(--color-border-strong)'}}>━━ other mentions · {otherMentions.length}</div>
         <div className="ms-inbox" role="log" aria-live="polite" aria-label={`${otherMentions.length} other mentions`}>
           {otherMentions.map(m => (
-            <article key={m.seq} className="mn" aria-label={`#${m.seq} · ${m.from} in #${m.room} at ${m.at}: ${m.body}`} style={{borderLeftColor:'var(--info)', opacity:.7}}>
+            <article key={m.seq} className="mn" aria-label={`#${m.seq} · ${m.from} in #${m.room} at ${m.at}: ${m.body}`} style={{borderLeftColor:'var(--color-status-info)', opacity:.7}}>
               <div className="h" aria-hidden="true">
                 <span className="au">{m.from}</span>
                 <span className="rm">→ #{m.room}</span>

--- a/dashboard/design-system/preview/cb-group-f.jsx
+++ b/dashboard/design-system/preview/cb-group-f.jsx
@@ -272,7 +272,7 @@ function SafeAutoTrend() {
           const bad = v < 78;
           return (
             <div key={i} style={{flex:1,display:'flex',flexDirection:'column',alignItems:'center',gap:'2px'}}>
-              <div style={{width:'100%',height:`${pct}%`,background: bad ? 'linear-gradient(180deg, var(--err), var(--err-border))' : 'linear-gradient(180deg, var(--color-accent-fg), var(--color-accent-fg-dim))'}}></div>
+              <div style={{width:'100%',height:`${pct}%`,background: bad ? 'linear-gradient(180deg, var(--color-status-err), var(--err-border))' : 'linear-gradient(180deg, var(--color-accent-fg), var(--color-accent-fg-dim))'}}></div>
             </div>
           );
         })}
@@ -415,7 +415,7 @@ function CostLatency() {
         {[
           { l:'< 1s',  v: buckets.filter(b=>b.hi<=1000).reduce((s,b)=>s+b.n,0), c:'var(--ok-fg)' },
           { l:'1–4s',  v: buckets.filter(b=>b.lo>=1000&&b.hi<=4000).reduce((s,b)=>s+b.n,0), c:'var(--color-accent-fg)' },
-          { l:'4–16s', v: buckets.filter(b=>b.lo>=4000&&b.hi<=16000).reduce((s,b)=>s+b.n,0), c:'var(--warn)' },
+          { l:'4–16s', v: buckets.filter(b=>b.lo>=4000&&b.hi<=16000).reduce((s,b)=>s+b.n,0), c:'var(--color-status-warn)' },
           { l:'> 16s', v: buckets.filter(b=>b.lo>=16000).reduce((s,b)=>s+b.n,0), c:'var(--err-fg)' },
         ].map(b => (
           <div key={b.l} role="listitem" aria-label={`${b.l}: ${b.v} calls (${(b.v/total*100).toFixed(0)}%)`} style={{background:'var(--color-bg-surface)',padding:'6px 10px',display:'flex',flexDirection:'column',gap:'2px'}}>
@@ -500,7 +500,7 @@ function HeuristicByModule() {
               <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color:'var(--color-fg-primary)'}}>{mod}</span>
               <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-10)',color:'var(--color-fg-muted)'}}>{v.fired}/{v.total} fired</span>
               <div aria-hidden="true" style={{height:'10px',background:'var(--color-bg-panel-alt)',border:'1px solid var(--color-border-default)'}}>
-                <div style={{height:'100%',width:`${pct}%`,background: pct > 50 ? 'linear-gradient(90deg, var(--warn), var(--err))' : 'linear-gradient(90deg, var(--color-accent-fg-dim), var(--color-accent-fg))'}}></div>
+                <div style={{height:'100%',width:`${pct}%`,background: pct > 50 ? 'linear-gradient(90deg, var(--color-status-warn), var(--color-status-err))' : 'linear-gradient(90deg, var(--color-accent-fg-dim), var(--color-accent-fg))'}}></div>
               </div>
               <span aria-hidden="true" style={{fontFamily:'var(--font-mono)',fontSize:'var(--fs-11)',color: pct > 50 ? 'var(--err-fg)' : 'var(--color-accent-fg)',fontVariantNumeric:'tabular-nums',textAlign:'right'}}>{pct.toFixed(0)}%</span>
               <span aria-hidden="true" style={{gridColumn:'1 / -1',fontFamily:'var(--font-mono)',fontSize:'var(--fs-9)',color:'var(--color-fg-disabled)',letterSpacing:'.04em'}}>sites · {[...v.sites].join(' · ')}</span>

--- a/dashboard/design-system/preview/cb-group-i.jsx
+++ b/dashboard/design-system/preview/cb-group-i.jsx
@@ -11,11 +11,11 @@ const P2i = window.MASC_P2;
 function keeperColor(id) {
   return ({
     'nick0cave':     'var(--color-accent-fg)',
-    'masc-improver': 'var(--ok)',
-    'sangsu':        'var(--info)',
-    'qa-king':       'var(--err)',
-    'rama':          'var(--stalled)',
-    'ramarama':      'var(--stalled)',
+    'masc-improver': 'var(--color-status-ok)',
+    'sangsu':        'var(--color-status-info)',
+    'qa-king':       'var(--color-status-err)',
+    'rama':          'var(--color-status-stalled)',
+    'ramarama':      'var(--color-status-stalled)',
     'scholar':       '#9aa6b8',
     'janitor':       '#7a8290',
     'taskmaster':    'var(--color-accent-fg-dim)',
@@ -29,7 +29,7 @@ function keeperColor(id) {
     'codex-mcp-client': '#6a7080',
     'ollama-local':  '#7a9080',
     'scholar2':      '#9aa6b8',
-  })[id] || 'var(--idle)';
+  })[id] || 'var(--color-status-idle)';
 }
 
 // ═════════════════════════════════════════════════════════════════

--- a/dashboard/design-system/preview/cb-group-j.jsx
+++ b/dashboard/design-system/preview/cb-group-j.jsx
@@ -4,10 +4,10 @@
 window.MASC_P3 = (function () {
   const keepers = [
     { id: "nick0cave", initials: "NC", role: "captain", color: "var(--color-accent-fg)" },
-    { id: "masc-improver", initials: "MI", role: "improver", color: "var(--ok)" },
-    { id: "sangsu", initials: "SG", role: "analyst", color: "var(--info)" },
-    { id: "qa-king", initials: "QA", role: "qa", color: "var(--err)" },
-    { id: "rama", initials: "RA", role: "research", color: "var(--stalled)" },
+    { id: "masc-improver", initials: "MI", role: "improver", color: "var(--color-status-ok)" },
+    { id: "sangsu", initials: "SG", role: "analyst", color: "var(--color-status-info)" },
+    { id: "qa-king", initials: "QA", role: "qa", color: "var(--color-status-err)" },
+    { id: "rama", initials: "RA", role: "research", color: "var(--color-status-stalled)" },
   ];
 
   const files = [

--- a/dashboard/design-system/preview/cb-group-k.jsx
+++ b/dashboard/design-system/preview/cb-group-k.jsx
@@ -5,7 +5,7 @@ const P3K = window.MASC_P3;
 const P2K = window.MASC_P2 || {};
 
 function k3Keeper(id) {
-  return (P3K.keepers || []).find(k => k.id === id) || { id, initials: id.slice(0, 2), color: "var(--idle)" };
+  return (P3K.keepers || []).find(k => k.id === id) || { id, initials: id.slice(0, 2), color: "var(--color-status-idle)" };
 }
 
 function k3KeeperIds(keepers) {

--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -398,9 +398,21 @@ body[data-density="comfortable"]  { --density: 1.15; }
      Used in 3 cb-group-* refs as escape hatch — escalate to SPEC §3.4 if
      count grows. */
 
+  /* Single-slot status (general state) — diff-context use:
+     --color-status-added/modified/deleted alias the same raw hues. */
+  --color-status-ok:       var(--ok);
+  --color-status-warn:     var(--warn);
+  --color-status-err:      var(--err);
+  --color-status-info:     var(--info);
+  --color-status-idle:     var(--idle);
+  --color-status-stalled:  var(--stalled);
+
   --color-status-added:    var(--ok);
   --color-status-modified: var(--warn);
   --color-status-deleted:  var(--err);
+
+  /* 4-slot status pattern (--ok-soft/-fg/-border/-ring etc.) is intentional
+     escape hatch — see SPEC §6.2. Component-specific composition stays raw. */
 
   --color-keeper-1: var(--k-nick);
   --color-keeper-2: var(--k-masc);
@@ -436,6 +448,13 @@ body[data-density="comfortable"]  { --density: 1.15; }
   --color-accent-fg-dim:  #8a5f28;
   --color-accent-glow:    var(--brass-glow);
 
+  --color-status-ok:       #3d7a3d;
+  --color-status-warn:     #8a6a1a;
+  --color-status-err:      #a04030;
+  --color-status-info:     #4a6080;
+  --color-status-idle:     #807870;
+  --color-status-stalled:  #6a4080;
+
   --color-status-added:    #3d7a3d;
   --color-status-modified: #8a6a1a;
   --color-status-deleted:  #a04030;
@@ -465,6 +484,12 @@ body[data-density="comfortable"]  { --density: 1.15; }
     --color-accent-fg:      var(--brass-3);
     --color-accent-fg-dim:  #8a5f28;
     --color-accent-glow:    var(--brass-glow);
+    --color-status-ok:       #3d7a3d;
+    --color-status-warn:     #8a6a1a;
+    --color-status-err:      #a04030;
+    --color-status-info:     #4a6080;
+    --color-status-idle:     #807870;
+    --color-status-stalled:  #6a4080;
     --color-status-added:    #3d7a3d;
     --color-status-modified: #8a6a1a;
     --color-status-deleted:  #a04030;


### PR DESCRIPTION
## Summary

Migration phase PR-M6 (--k-* keeper attribution category). PR-M5 위에 stack.

SPEC §3.6 keeper 5 attribution을 `--color-keeper-1~5`로 치환. tokens.css alias는 PR #10427에서 이미 등재됨 (별도 보강 불필요).

## cb-group-a.jsx 치환 (5 refs)

| Raw | Semantic |
|-----|----------|
| `var(--k-nick)` | `var(--color-keeper-1)` |
| `var(--k-masc)` | `var(--color-keeper-2)` |
| `var(--k-sangsu)` | `var(--color-keeper-3)` |
| `var(--k-qa)` | `var(--color-keeper-4)` |
| `var(--k-rama)` | `var(--color-keeper-5)` |

## Validation

- preview raw `--k-*` 잔존 **0** (`rg "var\(--k-" dashboard/design-system/preview/` empty)
- `--color-keeper-*` 확산 **5 refs** (cb-group-a)
- 시각 회귀 0 (alias가 raw로 resolve)

## Out-of-scope (별도 후속)

- `dashboard/design-system/source_styles/layers.css` 10 refs (production CSS — 시각 검증 부담으로 분리)
- `cb-group-i.jsx`의 `keeperColor()` helper 12 hex 리터럴 (SPEC §6.2 escape hatch — 5 attribution slot으론 환원 불가)

## Stack

base = `feat/design-system-status-migration` (PR-M5 #10518)

## Migration Phase 진행 현황

| PR | 카테고리 | refs | 상태 |
|----|---------|------|------|
| PR-M1 #10500 | `--bg-*` surface | 68 | MERGED to main |
| PR-M2 #10503 | `--fg-*` text | 75 | OPEN (stack head) |
| PR-M3 #10508 | `--line-*` border | 46 | stack-merged into M2 |
| PR-M4 #10509 | `--brass-*` accent | 54 | stack-merged into M3 |
| PR-M5 #10518 | status single-slot | 15 | Draft (visual verify pending) |
| **PR-M6 (this)** | `--k-*` keeper | 5 | Draft |

총 263 raw token refs → semantic alias 치환 완료 (preview cb-group-* 범위).

## Test plan

- [ ] CI green
- [ ] Chrome으로 `preview/components.html` 5 themes 토글 색 변화 정상 (시각 검증)
- [ ] do-not-merge 라벨 부착 (시각 검증 전 머지 차단)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
