### PR TITLE
fix(ci): register OperatorPauseBroadcast.tla in known_unchecked_specs (P0 cascade unblock)

### DIFF
--- a/scripts/ci/check-tla-harness-coverage.sh
+++ b/scripts/ci/check-tla-harness-coverage.sh
@@ -21,6 +21,7 @@ specs/keeper-state-machine/KeeperDwellMonotone.tla
 specs/keeper-state-machine/KeeperMemoryLifecycle.tla
 specs/keeper-state-machine/KeeperOutcomesConservation.tla
 specs/keeper-state-machine/KeeperReconcileLiveness.tla
+specs/keeper-state-machine/OperatorPauseBroadcast.tla
 specs/keeper-state-machine/KeeperSocialModelMagenticLedger.tla
 specs/keeper-state-machine/KeeperWorkPipeline.tla
 specs/server-state/ServerState.tla


### PR DESCRIPTION
## Problem

`scripts/ci/check-tla-harness-coverage.sh` (Meta Guards step) fails on every open PR with:

```
FAIL: cfg-backed TLA+ specs not covered by scripts/tla-check.sh:
  specs/keeper-state-machine/OperatorPauseBroadcast.tla
```

#10484 added `OperatorPauseBroadcast.tla` + `.cfg` + `-buggy.cfg` but did not wire it into `scripts/tla-check.sh` nor `known_unchecked_specs`. Result: cascade fail across 8+ open PRs (#10491, #10493, #10502, #10503, #10513, #10514, #10517, …) — Meta Guards red on every branch.

## Fix

Add the spec to the `known_unchecked_specs` allowlist alongside the other keeper-state-machine specs that are not yet wired into TLC. Unblocks merge queue immediately. Actual `run_tlc` wiring is deferred to a follow-up PR (separate concern: TLC-runtime cost + spec validity verification).

## Verification

```
$ bash scripts/ci/check-tla-harness-coverage.sh
=== TLA harness coverage: PASS ===
Known unchecked cfg-backed specs (18):
  …
  specs/keeper-state-machine/OperatorPauseBroadcast.tla
  …
```

## Why fix-forward (not revert)

Spec is intentional infrastructure for #10484 operator broadcast. Reverting #10484 would lose the keeper feature. Single-line allowlist entry is the minimum change to unblock cascade.
