### PR TITLE
refactor(yojson): drop unused decoder for dead types (sweep 3/3)

### DIFF
--- a/lib/agent_identity.ml
+++ b/lib/agent_identity.ml
@@ -89,7 +89,7 @@ type t = {
   mutable last_seen : float;      (** Last activity timestamp *)
   metadata : (string * string) list;  (** Additional metadata *)
 }
-[@@deriving yojson]
+[@@deriving to_yojson]
 
 (** Generate a unique agent UUID from name + timestamp hash *)
 let generate_uuid ~agent_name =

--- a/lib/agent_identity.mli
+++ b/lib/agent_identity.mli
@@ -63,7 +63,6 @@ val same_agent : t -> t -> bool
 val channel_to_yojson : channel -> Yojson.Safe.t
 val channel_of_yojson : Yojson.Safe.t -> (channel, string) result
 val to_yojson : t -> Yojson.Safe.t
-val of_yojson : Yojson.Safe.t -> (t, string) result
 
 (** {1 MAGI Archetype System} *)
 

--- a/lib/eval_gate.ml
+++ b/lib/eval_gate.ml
@@ -317,7 +317,7 @@ type post_eval_result = {
   cost_usd : float;
   should_warn : bool;      (** true if result is suspicious but not fatal *)
   warning : string option;
-} [@@deriving yojson { strict = false }]
+} [@@deriving to_yojson]
 
 (** Evaluate a tool call result after execution.
     Returns evaluation metadata for trajectory recording. *)

--- a/lib/eval_gate.mli
+++ b/lib/eval_gate.mli
@@ -61,7 +61,6 @@ type post_eval_result = {
 }
 
 val post_eval_result_to_yojson : post_eval_result -> Yojson.Safe.t
-val post_eval_result_of_yojson : Yojson.Safe.t -> (post_eval_result, string) result
 
 val post_eval :
   config:gate_config ->

--- a/scripts/lint/yojson-option-default.allowlist
+++ b/scripts/lint/yojson-option-default.allowlist
@@ -8,12 +8,7 @@ lib/agent_card.ml:29: skill.description
 lib/agent_card.ml:46: security_scheme.bearer_format
 lib/agent_card.ml:47: security_scheme.api_key_name
 lib/agent_card.ml:48: security_scheme.api_key_in
-lib/agent_identity.ml:84: t.channel
-lib/agent_identity.ml:85: t.user_id
-lib/agent_identity.ml:86: t.room_id
 lib/build_identity.ml:5: t.commit
-lib/eval_gate.ml:316: post_eval_result.error_message
-lib/eval_gate.ml:319: post_eval_result.warning
 lib/metrics_store_eio.ml:21: task_metric.completed_at
 lib/metrics_store_eio.ml:23: task_metric.error_message
 lib/metrics_store_eio.ml:25: task_metric.handoff_from


### PR DESCRIPTION
## Summary

Strict-by-deletion sweep for the `yojson-option-default` lint baseline (sweep 3/3).
Two types had **DEAD_DECODER** classification per audit (#10356): the auto-generated `*_of_yojson` is never called in `lib/` or `test/`, only the encoder is used. The right fix is removal of the decoder, not adding `[@default None]` to every option field — no decoder means no missing-key silent-failure class, so the type structurally drops out of the lint scope.

## Changes

| File | Change |
|------|--------|
| `lib/agent_identity.ml` | type `t`: `[@@deriving yojson]` -> `[@@deriving to_yojson]` |
| `lib/agent_identity.mli` | Drop `val of_yojson` (encoder retained) |
| `lib/eval_gate.ml` | type `post_eval_result`: `[@@deriving yojson { strict = false }]` -> `[@@deriving to_yojson]`. The `{ strict = false }` was a workaround for the dead decoder — encoder-only doesn't need it. |
| `lib/eval_gate.mli` | Drop `val post_eval_result_of_yojson` |
| `scripts/lint/yojson-option-default.allowlist` | Remove 5 entries now out of scope (3 `agent_identity.ml` + 2 `eval_gate.ml`) |

## Why strict-by-deletion (not `[@default None]`)?

The lint catches "missing key silently becomes `None`" — a real silent-failure class for **live decoders**. But if the decoder has zero callers, that class is structurally impossible: nothing can hit the missing-key path because nothing calls the decoder. Adding `[@default None]` to dead code is theatrical work — it pretends to harden a path nobody walks. Deletion makes the safety property a tautology and shrinks the lint surface.

## Audit evidence (DEAD_DECODER verified)

```
$ rg -tocaml "Agent_identity\.t_of_yojson|Agent_identity\.of_yojson" lib/ test/
(zero matches; rg exit 1)

$ rg -tocaml "post_eval_result_of_yojson" lib/ test/
lib/eval_gate.mli:val post_eval_result_of_yojson : Yojson.Safe.t -> (post_eval_result, string) result
  (declaration only; no callers)
```

Encoder usage retained:
- `Agent_identity.to_yojson`: kept (encoder generation preserved via `to_yojson` deriver)
- `eval_gate`: `post_eval_result_to_yojson` is wrapped by `post_eval_to_json` and used in tests

## Verification

- [x] `DUNE_CACHE=disabled dune build @check` -> exit 0, no warnings
- [x] `test/test_agent_identity.exe` -> 19/19 pass
- [x] `test/test_eval_gate.exe` -> 24/24 pass
- [x] `test/test_eval_gate_evasion.exe` -> 23/23 pass
- [x] `python3 scripts/lint/yojson-option-default.py` -> exit 0, 14 violations at baseline (was 19, -5 expected)

## Refs

- Audit: #10356
- Sweep series: #10450, #10463
- Lint rule: #10501

## Status

Draft + `do-not-merge` per workflow. Don't ready, don't auto-merge.