### PR TITLE
feat(yojson): @default None + PBT for persistence-boundary fields (sweep 2/3)

### DIFF
--- a/lib/metrics_store_eio.ml
+++ b/lib/metrics_store_eio.ml
@@ -18,12 +18,12 @@ type task_metric = {
   agent_id: string;         (* Agent name: claude, gemini, codex *)
   task_id: string;          (* Task being measured *)
   started_at: float;        (* Unix timestamp *)
-  completed_at: float option;  (* None if still in progress *)
+  completed_at: float option [@default None];  (* None if still in progress *)
   success: bool;            (* Task succeeded? *)
-  error_message: string option;  (* Error if failed *)
+  error_message: string option [@default None];  (* Error if failed *)
   collaborators: string list;  (* Other agents involved - for Hebbian *)
-  handoff_from: string option;  (* Previous agent if handoff *)
-  handoff_to: string option;    (* Next agent if handoff out *)
+  handoff_from: string option [@default None];  (* Previous agent if handoff *)
+  handoff_to: string option [@default None];    (* Next agent if handoff out *)
 } [@@deriving yojson, show]
 
 (** Aggregated metrics for fitness calculation *)

--- a/lib/prompt_registry/prompt_registry_types.ml
+++ b/lib/prompt_registry/prompt_registry_types.ml
@@ -10,7 +10,7 @@ type prompt_entry = {
   template : string;
   version : string;
   variables : string list;
-  metrics : prompt_metrics option;
+  metrics : prompt_metrics option; [@default None]
   created_at : float;
   deprecated : bool;
 }

--- a/lib/prompt_registry/prompt_registry_types.mli
+++ b/lib/prompt_registry/prompt_registry_types.mli
@@ -12,7 +12,7 @@ type prompt_entry = {
   template : string;
   version : string;
   variables : string list;
-  metrics : prompt_metrics option;
+  metrics : prompt_metrics option; [@default None]
   created_at : float;
   deprecated : bool;
 }

--- a/scripts/lint/yojson-option-default.allowlist
+++ b/scripts/lint/yojson-option-default.allowlist
@@ -9,9 +9,3 @@ lib/agent_card.ml:46: security_scheme.bearer_format
 lib/agent_card.ml:47: security_scheme.api_key_name
 lib/agent_card.ml:48: security_scheme.api_key_in
 lib/build_identity.ml:5: t.commit
-lib/metrics_store_eio.ml:21: task_metric.completed_at
-lib/metrics_store_eio.ml:23: task_metric.error_message
-lib/metrics_store_eio.ml:25: task_metric.handoff_from
-lib/metrics_store_eio.ml:26: task_metric.handoff_to
-lib/prompt_registry/prompt_registry_types.ml:13: prompt_entry.metrics
-lib/prompt_registry/prompt_registry_types.mli:15: prompt_entry.metrics

--- a/test/dune
+++ b/test/dune
@@ -345,9 +345,11 @@
 ; ============================================================
 (tests
  (names test_pbt_mention test_pbt_validation test_pbt_text_processing test_pbt_context_overflow
-        test_keeper_state_machine_pbt test_telemetry_eio_pbt)
+        test_keeper_state_machine_pbt test_telemetry_eio_pbt
+        test_metrics_store_eio_pbt test_prompt_registry_pbt)
  (modules test_pbt_mention test_pbt_validation test_pbt_text_processing test_pbt_context_overflow
-          test_keeper_state_machine_pbt test_telemetry_eio_pbt)
+          test_keeper_state_machine_pbt test_telemetry_eio_pbt
+          test_metrics_store_eio_pbt test_prompt_registry_pbt)
  (libraries masc_test_deps))
 
 ; ============================================================

--- a/test/test_metrics_store_eio_pbt.ml
+++ b/test/test_metrics_store_eio_pbt.ml
@@ -1,0 +1,140 @@
+(** Property-based tests for [Metrics_store_eio.task_metric] yojson contract.
+
+    Same root-cause class as #10356 / #10450 / #10463 (telemetry_eio), but for
+    a different persistence boundary: per-agent JSONL files at
+    [.masc/metrics/{agent}/YYYY-MM.jsonl]. Files outlive any single MASC
+    process — keeper restarts, agent rotations, and month-boundary rollovers
+    all read records previously written by a different version. A producer
+    that elides a [None] option key, or a future schema migration that adds
+    a new option field, must not silently drop the entire row.
+
+    [task_metric] has four [option] fields (completed_at, error_message,
+    handoff_from, handoff_to). Annotating each with [\[@default None\]] makes
+    [ppx_deriving_yojson] tolerate both `null` and missing keys. This suite
+    pins that contract.
+
+    Properties:
+    1. [prop_roundtrip] — every encoded record decodes back to itself.
+       Catches [@@deriving yojson] / [@default] drift between encoder and
+       decoder on any of the four option fields.
+    2. [prop_null_absorption] — for each option key, replacing its encoded
+       value with [`Null] still yields a successful decode (with that field
+       = [None]).
+    3. [prop_drop_absorption] — same as (2) but the key is removed entirely.
+       Future producers may elide [None] fields; readers must remain
+       tolerant. *)
+
+module Metrics_store_eio = Masc_mcp.Metrics_store_eio
+
+let opt_string =
+  let open QCheck.Gen in
+  oneof [ return None; map (fun s -> Some s) string_small ]
+
+let opt_float =
+  let open QCheck.Gen in
+  oneof [ return None; map (fun n -> Some (float_of_int n)) nat_small ]
+
+let gen_task_metric : Metrics_store_eio.task_metric QCheck.Gen.t =
+  let open QCheck.Gen in
+  let* id = string_small in
+  let* agent_id = string_small in
+  let* task_id = string_small in
+  let* started_at = map float_of_int nat_small in
+  let* completed_at = opt_float in
+  let* success = bool in
+  let* error_message = opt_string in
+  let* collaborators = list_size (int_range 0 3) string_small in
+  let* handoff_from = opt_string in
+  let* handoff_to = opt_string in
+  return
+    Metrics_store_eio.
+      {
+        id;
+        agent_id;
+        task_id;
+        started_at;
+        completed_at;
+        success;
+        error_message;
+        collaborators;
+        handoff_from;
+        handoff_to;
+      }
+
+let arb_task_metric =
+  QCheck.make ~print:Metrics_store_eio.show_task_metric gen_task_metric
+
+(** Every option field name on [task_metric]. Keep in sync with the record. *)
+let task_metric_option_keys =
+  [ "completed_at"; "error_message"; "handoff_from"; "handoff_to" ]
+
+(** Saturated record — every option key is [Some _], so the encoded JSON
+    contains the full key set we will mutate. *)
+let saturated_task_metric : Metrics_store_eio.task_metric =
+  {
+    id = "metric-1";
+    agent_id = "keeper-claude";
+    task_id = "task-42";
+    started_at = 1_777_120_000.0;
+    completed_at = Some 1_777_120_001.0;
+    success = false;
+    error_message = Some "boom";
+    collaborators = [ "gemini"; "codex" ];
+    handoff_from = Some "claude";
+    handoff_to = Some "codex";
+  }
+
+let null_field key fields =
+  List.map (fun (k, v) -> if k = key then (k, `Null) else (k, v)) fields
+
+let drop_field key fields = List.filter (fun (k, _) -> k <> key) fields
+
+let mutate_top f json =
+  match json with
+  | `Assoc top -> `Assoc (f top)
+  | _ -> json
+
+let prop_roundtrip =
+  QCheck.Test.make ~count:200
+    ~name:"task_metric JSON round-trip" arb_task_metric (fun r ->
+      let json = Metrics_store_eio.task_metric_to_yojson r in
+      match Metrics_store_eio.task_metric_of_yojson json with
+      | Ok r' -> r = r'
+      | Error _ -> false)
+
+let prop_null_absorption =
+  QCheck.Test.make ~count:1
+    ~name:"task_metric: nulling any optional key still parses"
+    QCheck.unit (fun () ->
+      let base =
+        Metrics_store_eio.task_metric_to_yojson saturated_task_metric
+      in
+      List.for_all
+        (fun key ->
+          let mutated = mutate_top (null_field key) base in
+          match Metrics_store_eio.task_metric_of_yojson mutated with
+          | Ok _ -> true
+          | Error _ -> false)
+        task_metric_option_keys)
+
+let prop_drop_absorption =
+  QCheck.Test.make ~count:1
+    ~name:"task_metric: dropping any optional key still parses"
+    QCheck.unit (fun () ->
+      let base =
+        Metrics_store_eio.task_metric_to_yojson saturated_task_metric
+      in
+      List.for_all
+        (fun key ->
+          let mutated = mutate_top (drop_field key) base in
+          match Metrics_store_eio.task_metric_of_yojson mutated with
+          | Ok _ -> true
+          | Error _ -> false)
+        task_metric_option_keys)
+
+let () =
+  let suite =
+    List.map QCheck_alcotest.to_alcotest
+      [ prop_roundtrip; prop_null_absorption; prop_drop_absorption ]
+  in
+  Alcotest.run "Metrics_store_eio PBT" [ ("yojson contract", suite) ]

--- a/test/test_prompt_registry_pbt.ml
+++ b/test/test_prompt_registry_pbt.ml
@@ -1,0 +1,115 @@
+(** Property-based tests for [Prompt_registry_types.prompt_entry] yojson
+    contract.
+
+    Same root-cause class as #10356 / #10450 / #10463 (telemetry_eio) and the
+    metrics_store_eio companion suite, but for a distinct persistence
+    boundary: prompt entries are written as standalone JSON files in a
+    user-configured prompts directory and reloaded across keeper restarts
+    (see [Prompt_registry.load_from_disk]). A schema migration that adds a
+    new option field, or a producer that elides [None]'s [metrics] key, must
+    not silently drop the entry on reload.
+
+    [prompt_entry] has one [option] field today ([metrics]). The PBT is
+    still worth keeping: it pins the encoder/decoder contract so that
+    future option fields inherit the same null/drop tolerance by default,
+    rather than waiting for a silent-failure regression.
+
+    Properties:
+    1. [prop_roundtrip] — every encoded entry decodes back to itself.
+    2. [prop_null_absorption] — replacing [metrics]'s value with [`Null]
+       still yields a successful decode.
+    3. [prop_drop_absorption] — removing the [metrics] key entirely still
+       yields a successful decode. *)
+
+module Types = Prompt_registry.Types
+
+let opt_metrics =
+  let open QCheck.Gen in
+  oneof
+    [
+      return None;
+      map
+        (fun (usage_count, avg_score_int, last_used_int) ->
+          Some
+            Types.
+              {
+                usage_count;
+                avg_score = float_of_int avg_score_int /. 100.0;
+                last_used = float_of_int last_used_int;
+              })
+        (triple nat_small (int_range 0 1000) nat_small);
+    ]
+
+let gen_prompt_entry : Types.prompt_entry QCheck.Gen.t =
+  let open QCheck.Gen in
+  let* id = string_small in
+  let* template = string_small in
+  let* version = string_small in
+  let* variables = list_size (int_range 0 3) string_small in
+  let* metrics = opt_metrics in
+  let* created_at = map float_of_int nat_small in
+  let* deprecated = bool in
+  return
+    Types.
+      { id; template; version; variables; metrics; created_at; deprecated }
+
+let show_prompt_entry (e : Types.prompt_entry) : string =
+  Yojson.Safe.pretty_to_string (Types.prompt_entry_to_yojson e)
+
+let arb_prompt_entry = QCheck.make ~print:show_prompt_entry gen_prompt_entry
+
+let saturated_prompt_entry : Types.prompt_entry =
+  {
+    id = "code-review-v2";
+    template = "Review {{x}}";
+    version = "2.0";
+    variables = [ "x" ];
+    metrics = Some { usage_count = 7; avg_score = 0.82; last_used = 1.0 };
+    created_at = 1_777_120_000.0;
+    deprecated = false;
+  }
+
+let null_field key fields =
+  List.map (fun (k, v) -> if k = key then (k, `Null) else (k, v)) fields
+
+let drop_field key fields = List.filter (fun (k, _) -> k <> key) fields
+
+let mutate_top f json =
+  match json with
+  | `Assoc top -> `Assoc (f top)
+  | _ -> json
+
+let prop_roundtrip =
+  QCheck.Test.make ~count:200
+    ~name:"prompt_entry JSON round-trip" arb_prompt_entry (fun r ->
+      let json = Types.prompt_entry_to_yojson r in
+      match Types.prompt_entry_of_yojson json with
+      | Ok r' -> r = r'
+      | Error _ -> false)
+
+let prop_null_absorption =
+  QCheck.Test.make ~count:1
+    ~name:"prompt_entry: nulling [metrics] still parses" QCheck.unit
+    (fun () ->
+      let base = Types.prompt_entry_to_yojson saturated_prompt_entry in
+      let mutated = mutate_top (null_field "metrics") base in
+      match Types.prompt_entry_of_yojson mutated with
+      | Ok _ -> true
+      | Error _ -> false)
+
+let prop_drop_absorption =
+  QCheck.Test.make ~count:1
+    ~name:"prompt_entry: dropping [metrics] still parses" QCheck.unit
+    (fun () ->
+      let base = Types.prompt_entry_to_yojson saturated_prompt_entry in
+      let mutated = mutate_top (drop_field "metrics") base in
+      match Types.prompt_entry_of_yojson mutated with
+      | Ok _ -> true
+      | Error _ -> false)
+
+let () =
+  let suite =
+    List.map QCheck_alcotest.to_alcotest
+      [ prop_roundtrip; prop_null_absorption; prop_drop_absorption ]
+  in
+  Alcotest.run "Prompt_registry PBT" [ ("yojson contract", suite) ]


### PR DESCRIPTION
## Audit classification

`NEEDS_PBT` — same root-cause class as #10356 / #10450 / #10463 / #10501. These five option fields cross JSONL/JSON file persistence boundaries that outlive any single MASC process:

- `lib/metrics_store_eio.ml` `task_metric.{completed_at,error_message,handoff_from,handoff_to}` — written to `.masc/metrics/{agent_id}/YYYY-MM.jsonl`. Cross-process on keeper restart and month-boundary rollover.
- `lib/prompt_registry/prompt_registry_types.ml(i)` `prompt_entry.metrics` — written as standalone JSON files in the user-configured prompts directory; reloaded at every `Prompt_registry.load_from_disk`.

Without `[@default None]`, `ppx_deriving_yojson` treats a missing key as a hard decode error. Callers log and discard the entire row — silent drop today on any producer that elides a `None` key or any schema migration that adds a new option field.

## Pattern reuse (#10463)

Mirrors `test/test_telemetry_eio_pbt.ml` (introduced by #10463, merge `318a371010`):

- Property 1 — round-trip closure: `of_yojson (to_yojson r) = Ok r` on 200 random records.
- Property 2 — null-absorption: replace each option key's value with `` `Null `` in encoded JSON; decoder still `Ok`.
- Property 3 — drop-absorption: same but with the key removed entirely. Future producers may elide `None` fields; readers must remain tolerant.

Properties (2) + (3) make new option fields automatically safe — no per-variant lenient code to remember.

## Files changed

- `lib/metrics_store_eio.ml` — 4 fields annotated with `[@default None]`.
- `lib/prompt_registry/prompt_registry_types.ml` + `.mli` — 1 field annotated, kept in sync.
- `scripts/lint/yojson-option-default.allowlist` — 6 lines removed (5 fields + 1 mli mirror); baseline 19 → 13.
- `test/test_metrics_store_eio_pbt.ml` — new, 3 properties × QCheck.
- `test/test_prompt_registry_pbt.ml` — new, 3 properties × QCheck.
- `test/dune` — register the two new PBT modules in the QCheck test group.

## Build / test verification

| Step | Result |
| --- | --- |
| `DUNE_CACHE=disabled dune build @check` | exit 0 |
| `dune build test/test_metrics_store_eio_pbt.exe test/test_prompt_registry_pbt.exe` | exit 0 |
| `_build/default/test/test_metrics_store_eio_pbt.exe` | 3/3 OK (200 round-trips + null/drop sweeps) |
| `_build/default/test/test_prompt_registry_pbt.exe` | 3/3 OK |
| `_build/default/test/test_metrics_store_eio.exe` (existing) | 9/9 OK |
| `_build/default/test/test_prompt_registry_defaults.exe` (existing) | 11/11 OK |
| `python3 scripts/lint/yojson-option-default.py` | `13 violation(s) at baseline (no new)` exit 0 |

## Status

Draft + `do-not-merge` label per `feedback_masc-mcp-do-not-merge-label-on-create`. No `gh pr ready`, no `--auto`. Sweep 3/3 (remaining 13 NEEDS_PBT entries) tracked separately.

Refs: #10356, #10450, #10463, #10501.