### PR TITLE
fix(deps): pin agent_sdk upper bound to <0.177.0 (#10497)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -41,7 +41,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.176.0))
+  (agent_sdk (and (>= 0.176.0) (< 0.177.0)))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -25,7 +25,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.176.0"}
+  "agent_sdk" {>= "0.176.0" & < "0.177.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}


### PR DESCRIPTION
## 요약

\`agent_sdk { >= 0.176.0 }\` open upper bound가 오늘 main build break (InferenceTelemetry partial-match) + 12분 만에 6 중복 PR cascade의 근본 원인. \`(>= \"0.176.0\")\` → \`(>= \"0.176.0\" & < \"0.177.0\")\` 으로 minor version cap 추가.

## 변경

- \`dune-project\`: \`(agent_sdk (and (>= 0.176.0) (< 0.177.0)))\`
- \`masc_mcp.opam\`: \`\"agent_sdk\" {>= \"0.176.0\" & < \"0.177.0\"}\`

## 검증

\`\`\`
DUNE_CACHE=disabled dune build --root . --cache=disabled @check  → EXIT=0
\`\`\`

(현재 pinned 0.176.0 agent_sdk 호환)

## 영향

다음 OAS minor 릴리즈가 새 \`Event_bus.payload\` variant 추가 시:
- **before**: 로컬 \`opam install --update-deps\` 사용자가 silent build break, CI는 floor만 설치해서 안 잡힘
- **after**: opam constraint solver가 reject → coordinated pin bump PR (consumer handler를 같은 PR에 포함) 강제

이는 #10481 패턴(OAS pin bump를 single coordinated PR로 묶기)을 SSOT로 강제. 
\`feedback_oas-pin-bump-drift-gate\` 메모리와 align.

## 비목표

- Forward-compat shim (oas_sse_bridge에 \`| _ -> None\` catch-all 추가): 별도 결정 사항. exhaustive match는 의도적 — 새 variant마다 명시적 라우팅 결정을 강제. catch-all은 silent drop이 되어 dashboard observer가 미수신.
- agent_sdk patch level (0.176.x) 자동 수용은 유지: \`< 0.177.0\` 은 0.176.99까지 허용.

## Defensive guards

Draft + \`do-not-merge\` 라벨 (운영자 승인 후 머지).

## 관련

- Issue: \`#10497\`
- Today's incident: \`#10485\` (build break) + #10490/#10511 fix
- Pattern memory: \`feedback_oas-pin-bump-drift-gate\`