### PR TITLE
perf(strings): replace String.sub equality with String.starts_with across 8 hot paths

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -92,11 +92,11 @@ let string_to_action = function
   | "circuit_open" -> CircuitOpen
   | "circuit_close" -> CircuitClose
   | "search_refinement" -> SearchRefinement
-  | s when String.length s > 10 && String.sub s 0 10 = "tool_call:" ->
+  | s when String.length s > 10 && String.starts_with ~prefix:"tool_call:" s ->
       ToolCall (String.sub s 10 (String.length s - 10))
-  | s when String.length s > 20 && String.sub s 0 20 = "governance_decision:" ->
+  | s when String.length s > 20 && String.starts_with ~prefix:"governance_decision:" s ->
       GovernanceDecision (String.sub s 20 (String.length s - 20))
-  | s when String.length s > 7 && String.sub s 0 7 = "custom:" ->
+  | s when String.length s > 7 && String.starts_with ~prefix:"custom:" s ->
       Custom (String.sub s 7 (String.length s - 7))
   | s -> Custom s
 

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -294,7 +294,7 @@ type agent_profile = {
 let extract_persona_name (agent_name : string) : string =
   let s = agent_name in
   let s =
-    if String.length s > 7 && String.sub s 0 7 = "keeper-" then
+    if String.length s > 7 && String.starts_with ~prefix:"keeper-" s then
       String.sub s 7 (String.length s - 7)
     else s
   in

--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -252,7 +252,7 @@ let executor_outcomes_json (config : Coord.config) : Yojson.Safe.t =
       match r.event with
       | Telemetry_eio.Tool_called { tool_name; success; _ }
         when String.length tool_name > 9
-          && String.sub tool_name 0 9 = "executor:" ->
+          && String.starts_with ~prefix:"executor:" tool_name ->
         incr total;
         if success then incr successes
       | Telemetry_eio.Tool_called _ -> ()

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -274,7 +274,7 @@ let tool_title_of_name name =
   | Some title -> title
   | None ->
     let trimmed =
-      if String.length name > 5 && String.sub name 0 5 = "masc_" then
+      if String.length name > 5 && String.starts_with ~prefix:"masc_" name then
         String.sub name 5 (String.length name - 5)
       else
         name

--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -322,7 +322,7 @@ let native_event_to_json (evt : Oas.Event_bus.event) : Yojson.Safe.t option =
          Translate EVERY dot to colon for [masc.*] events so existing
          SSE consumers continue to decode the full multi-segment name. *)
       let event_type =
-        if String.length name > 5 && String.sub name 0 5 = "masc."
+        if String.length name > 5 && String.starts_with ~prefix:"masc." name
         then String.map (fun c -> if c = '.' then ':' else c) name
         else name
       in

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -11,7 +11,7 @@ let ag_ui_event_of_masc_event event =
     let lines = String.split_on_char '\n' event in
     let data_line =
       List.find_opt
-        (fun l -> String.length l > 6 && String.sub l 0 6 = "data: ")
+        (fun l -> String.length l > 6 && String.starts_with ~prefix:"data: " l)
         lines
     in
     match data_line with

--- a/lib/server/server_openai_compat.ml
+++ b/lib/server/server_openai_compat.ml
@@ -151,7 +151,7 @@ let handle_chat_completions ~config ~sw ~clock (body : string)
       (* Check if this is a keeper route *)
       let is_keeper_prefix =
         String.length model > 7
-        && String.sub model 0 7 = "keeper:"
+        && String.starts_with ~prefix:"keeper:" model
       in
       if is_keeper_prefix then begin
         let keeper_name = String.sub model 7 (String.length model - 7) in

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1100,8 +1100,8 @@ let startup_prune_keeper_checkpoints (state : Mcp_server.server_state) =
              files
              |> List.filter (fun f ->
                let len = String.length f in
-               len > 5 && String.sub f 0 5 = "ckpt-"
-               && String.sub f (len - 5) 5 = ".json")
+               len > 5 && String.starts_with ~prefix:"ckpt-" f
+               && String.ends_with ~suffix:".json" f)
              |> List.sort (fun a b -> compare b a)
            in
            if List.length ckpt_files > 3 then


### PR DESCRIPTION
## What

`String.sub s 0 N = "<prefix>"` 패턴 8건을 `String.starts_with ~prefix:"<prefix>" s`로 교체. 길이 가드(`String.length s > N`)는 의미 보존을 위해 유지.

## Why

각 매치는 substring을 새로 alloc해서 prefix 비교. `String.starts_with` (Stdlib, OCaml 5.0+)는 byte-wise 비교 — alloc 없음. Hot paths:

- `oas_sse_bridge.ml`: SSE event_type "masc." prefix → 매 SSE event 1회
- `audit_log.ml`: tool_call/governance_decision/custom prefix dispatch → 매 audit 라인 3회
- `mcp_server_eio_tool_profile.ml`: "masc_" tool name strip → 매 MCP tool list 호출 N회
- `server_mcp_transport_http_agui.ml`: SSE "data: " line filter → 매 AG-UI line 1회
- `server_runtime_bootstrap.ml`: ckpt-*.json 파일 필터 (덤으로 ends_with도 변환)
- `server_openai_compat.ml`: "keeper:" model prefix → 매 OpenAI compat 요청 1회
- `dashboard_http_monitoring.ml`: "executor:" tool stat → telemetry replay N회
- `dashboard_execution_helpers.ml`: "keeper-" agent name strip → 매 dashboard render N회

## Test

`OCAMLPARAM='_,warn-error=+a' dune build @check` clean. 의미 보존: `length > N && starts_with ~prefix` ↔ `length > N && sub = literal` 동등 (length=N 케이스 양쪽 모두 false).

## Scope

Sweep 1차분. 추가 후보 (gh_command_validation.ml 5건, resilience.ml 2건, anti_rationalization.ml 2건 등 ~20건)는 별도 PR로 분리 — lowercase 처리 + error-message magic string 등 review 부하가 다름.
