### PR TITLE
feat(coord): preflight normalize_all_names before Coord.join (RFC P3-a, logging-only)

### DIFF
--- a/lib/keeper/keeper_identity.ml
+++ b/lib/keeper/keeper_identity.ml
@@ -189,6 +189,16 @@ let show_validation_error err =
   Format.pp_print_flush fmt ();
   Buffer.contents buf
 
+(* Stable snake_case label for Prometheus metric outcome labels. Keep
+   exhaustive — adding a new variant must require updating this match
+   so no telemetry path silently aggregates to a generic bucket. *)
+let validation_error_outcome_label = function
+  | Empty_input -> "empty_input"
+  | Persona_not_found _ -> "persona_not_found"
+  | Credential_missing _ -> "credential_missing"
+  | Name_ambiguous _ -> "name_ambiguous"
+  | Ephemeral_suffix_rejected _ -> "ephemeral_suffix_rejected"
+
 (* Strip a generated nickname suffix (adj-animal[-hex4]) once if present.
    Returns the canonical agent prefix when applicable, else the input. *)
 let strip_nickname_once name =

--- a/lib/keeper/keeper_identity.mli
+++ b/lib/keeper/keeper_identity.mli
@@ -66,3 +66,10 @@ val normalize_all_names :
 val pp_validation_error : Format.formatter -> validation_error -> unit
 
 val show_validation_error : validation_error -> string
+
+val validation_error_outcome_label : validation_error -> string
+(** Stable snake_case label for Prometheus metric outcome labels
+    ([masc_coord_join_normalize_outcome_total] in RFC P3-a). The
+    pattern match is exhaustive so a new [validation_error] variant
+    forces an update here rather than silently aggregating to an
+    "unknown" bucket. *)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -652,6 +652,14 @@ let metric_silent_auth_token_resolve_error =
 let metric_silent_dashboard_actor_fallback =
   "masc_silent_dashboard_actor_fallback_total"
 
+(** Counter for Coord.join preflight outcomes (RFC P3-a, logging-only mode).
+   Labels: outcome (ok | empty_input | persona_not_found | credential_missing
+   | name_ambiguous | ephemeral_suffix_rejected). Cross-reference with
+   [metric_silent_auth_token_resolve_error] to attribute 119-burst pattern
+   to a normalize_all_names branch before promoting P3-a to hard-error. *)
+let metric_coord_join_normalize_outcome =
+  "masc_coord_join_normalize_outcome_total"
+
 
 (** {1 Built-in Metrics} *)
 
@@ -1029,6 +1037,15 @@ let init () =
      from the bearer token (Ok None / Error _) and fell back to \
      request_actor_hint. Labels: outcome (none | error). Counter exposes \
      the path that masks identity drift in the HTTP transport."
+    Counter;
+  add metric_coord_join_normalize_outcome
+    "Total Coord.join calls preflighted by Keeper_identity.normalize_all_names \
+     (RFC P3-a). Labels: outcome (ok | empty_input | persona_not_found | \
+     credential_missing | name_ambiguous | ephemeral_suffix_rejected). \
+     Logging-only mode: non-ok outcomes still proceed with the original \
+     agent_name; counter classifies bootstrap-window silent-fallback patterns \
+     (paired with masc_silent_auth_token_resolve_error_total) before the \
+     mode is promoted to hard-error in a follow-up PR."
     Counter;
   (* Transport metrics — registered here so transport_metrics.ml can use
      module constants instead of string literals. *)

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -306,6 +306,16 @@ val metric_silent_dashboard_actor_fallback : string
     token resolved to no agent ([Ok None]) or an error.
     Labels: [outcome] = "none" | "error". *)
 
+val metric_coord_join_normalize_outcome : string
+(** RFC P3-a (2026-04-26): Coord.join preflighted by
+    [Keeper_identity.normalize_all_names] in logging-only mode.
+    Labels: [outcome] = "ok" | "empty_input" | "persona_not_found"
+    | "credential_missing" | "name_ambiguous" | "ephemeral_suffix_rejected".
+    Non-ok outcomes still proceed with the original agent_name; the
+    counter classifies bootstrap-window silent-fallback patterns
+    (cross-reference [metric_silent_auth_token_resolve_error]) before
+    the mode is promoted to hard-error in a follow-up PR. *)
+
 
 (** {1 Transport metrics} *)
 

--- a/lib/tool_inline_dispatch_coord.ml
+++ b/lib/tool_inline_dispatch_coord.ml
@@ -127,7 +127,37 @@ let handle_join (ctx : context) : tool_result option =
   let mcp_session_id = ctx.mcp_session_id in
   let sid = Option.value ~default:"-" mcp_session_id in
   let caps = arg_get_string_list ctx "capabilities" in
-  let result = Coord.join config ~agent_name ~capabilities:caps () in
+  (* RFC P3-a — preflight Keeper_identity.normalize_all_names (logging-only).
+     Reasons: (1) classify bootstrap-window silent_auth_token_resolve_error
+     bursts by normalize branch; (2) when promoted to hard-error in a
+     follow-up PR, transient-nickname joins will already use the canonical
+     keeper_name. In logging-only mode every error path emits a warn +
+     Prometheus inc and falls through with the original [agent_name]. *)
+  let resolved_agent_name =
+    match
+      Keeper_identity.normalize_all_names
+        ~input_agent_name:agent_name
+        ~base_path:config.base_path
+        ~check_persona:true ~check_credential:true ()
+    with
+    | Ok bundle ->
+        Prometheus.inc_counter Prometheus.metric_coord_join_normalize_outcome
+          ~labels:[ ("outcome", "ok") ] ();
+        bundle.keeper_name
+    | Error err ->
+        let outcome = Keeper_identity.validation_error_outcome_label err in
+        Prometheus.inc_counter Prometheus.metric_coord_join_normalize_outcome
+          ~labels:[ ("outcome", outcome) ] ();
+        Log.Misc.warn
+          "[sid=%s] [silent:coord_join_normalize] agent=%s outcome=%s detail=%s \
+           - logging-only mode, proceeding with original agent_name"
+          sid agent_name outcome
+          (Keeper_identity.show_validation_error err);
+        agent_name
+  in
+  let result =
+    Coord.join config ~agent_name:resolved_agent_name ~capabilities:caps ()
+  in
   (* GC: reap zombie agents on join. Best-effort. *)
   (try let _ = Coord.cleanup_zombies config in ()
    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->

--- a/test/dune
+++ b/test/dune
@@ -641,6 +641,7 @@
         test_keeper_personality_io_validate
         test_keeper_personality_io_compare
         test_keeper_personality_io_render
+        test_keeper_identity_outcome_label
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify
@@ -836,6 +837,7 @@
         test_keeper_personality_io_validate
         test_keeper_personality_io_compare
         test_keeper_personality_io_render
+        test_keeper_identity_outcome_label
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify

--- a/test/test_keeper_identity_outcome_label.ml
+++ b/test/test_keeper_identity_outcome_label.ml
@@ -1,0 +1,57 @@
+(** Tests for [Keeper_identity.validation_error_outcome_label] — RFC P3-a
+    Prometheus label SSOT. The compiler enforces exhaustiveness on the
+    match in [keeper_identity.ml]; these tests fix the actual label
+    strings so a rename in one variant doesn't silently break dashboards
+    that pivot on [outcome=...]. *)
+
+open Alcotest
+open Masc_mcp
+
+let label_of = Keeper_identity.validation_error_outcome_label
+
+let test_empty_input () =
+  check string "Empty_input" "empty_input" (label_of Keeper_identity.Empty_input)
+
+let dummy_input = "kpper"
+
+let test_persona_not_found () =
+  let err =
+    Keeper_identity.Persona_not_found
+      { input = dummy_input; resolved = "kpper"; searched = "/x" }
+  in
+  check string "Persona_not_found" "persona_not_found" (label_of err)
+
+let test_credential_missing () =
+  let err =
+    Keeper_identity.Credential_missing
+      { input = dummy_input; resolved = "kpper"; searched = "/x" }
+  in
+  check string "Credential_missing" "credential_missing" (label_of err)
+
+let test_name_ambiguous () =
+  let err =
+    Keeper_identity.Name_ambiguous { input = dummy_input; candidates = [ "a"; "b" ] }
+  in
+  check string "Name_ambiguous" "name_ambiguous" (label_of err)
+
+let test_ephemeral_suffix_rejected () =
+  let err =
+    Keeper_identity.Ephemeral_suffix_rejected
+      { input = dummy_input; stripped = "kpper" }
+  in
+  check string "Ephemeral_suffix_rejected" "ephemeral_suffix_rejected"
+    (label_of err)
+
+let () =
+  run "keeper_identity_outcome_label"
+    [
+      ( "P3-a outcome labels",
+        [
+          test_case "Empty_input" `Quick test_empty_input;
+          test_case "Persona_not_found" `Quick test_persona_not_found;
+          test_case "Credential_missing" `Quick test_credential_missing;
+          test_case "Name_ambiguous" `Quick test_name_ambiguous;
+          test_case "Ephemeral_suffix_rejected" `Quick
+            test_ephemeral_suffix_rejected;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Adds `Keeper_identity.normalize_all_names` preflight to `handle_join` in `lib/tool_inline_dispatch_coord.ml`. **Logging-only mode** — every error path emits a warn + Prometheus inc and falls through with the original `agent_name`, classifying bootstrap-window `silent_auth_token_resolve_error` bursts by normalize branch before promoting P3-a to hard-error in a follow-up PR.

## Why

Bootstrap window에서 keeper subprocess가 transient nickname(`executor-warm-raven` 등)으로 join 시도하면 normalize 전 그대로 `Coord.join`에 전달됨. 이게 119 burst (2026-04-25 19:18-19:25, `masc_silent_auth_token_resolve_error_total`)의 silent-fallback 뒤편 메커니즘.

본 PR은 **분류만** — 새 metric `masc_coord_join_normalize_outcome_total`이 (a) ok / (b) empty_input / (c) persona_not_found / (d) credential_missing / (e) name_ambiguous / (f) ephemeral_suffix_rejected 중 어느 분기에서 silent fallback이 발생하는지 시계열로 분리해 dashboard에 노출. 1 release 안정성 관찰 후 hard-error 모드 PR로 승격.

## Changes

| File | Lines | Purpose |
|------|-------|---------|
| `lib/keeper/keeper_identity.ml(.mli)` | +17 | `validation_error_outcome_label`: compiler-enforced exhaustive match → 새 variant 추가 시 silent miss 차단 |
| `lib/prometheus.ml(.mli)` | +27 | `metric_coord_join_normalize_outcome` 정의 + register + doc |
| `lib/tool_inline_dispatch_coord.ml` | +30 | `handle_join` 직전 normalize_all_names + logging-only fallback |
| `test/test_keeper_identity_outcome_label.ml` | +58 | 5 variant × label string 고정 (dashboard rename 방지) |
| `test/dune` | +2 | 테스트 등록 (names+modules 양쪽) |

총 +134 lines, -1 line. caller migrate 0건. 운영 동작 영향 = (a) Coord.join이 canonical `bundle.keeper_name`으로 호출됨 — 정상 caller에는 영향 없음(canonical name 그대로), transient nickname caller는 normalize 후 정확한 keeper_name으로 join. (b) Error 발생 시 metric inc + warn log, **join 자체는 통과**.

## Mode 결정 근거

- **Logging-only first** — 사용자 결정. silent fallback이 어떤 normalize 분기에서 발생하는지 데이터로 입증된 후 hard-error 정책 결정 가능.
- 1 release(약 1주) 후 별도 PR로 hard-error 승격 — Error 시 join reject + dispatcher 명시적 error.

## Test plan

- [x] `dune build --root . @check` green (worktree)
- [x] `dune exec test/test_keeper_identity_outcome_label.exe` — 5/5 pass
- [ ] CI green
- [ ] Production smoke (do-not-merge 라벨 해제 전): 다음 server restart 후 `masc_coord_join_normalize_outcome_total{outcome="ok"}` 시계열 확인 + 119 burst 재현 시 outcome label로 분류 가능한지 검증

## References

- RFC: `~/me/planning/2026-04-25-keeper-identity-canonicalization-rfc.md` §2.3
- Supplement: `~/me/planning/2026-04-26-keeper-identity-implementation-supplement.md` §3
- Plan: `~/.claude/plans/glistening-sleeping-meadow.md` Active Parallel Execution Track B
- Memory: `feedback_no-derived-tag-when-existing-identifier-suffices.md` — outcome enum이 `validation_error` variant 그대로 매핑 (새 vocabulary 도입 안 함)

## do-not-merge 사유

logging-only 모드 안정성 관찰 + Prometheus dashboard 추가 + Track A (Layer 2 PR-B) 병렬 진행 동안 보호.

🤖 Generated with [Claude Code](https://claude.com/claude-code)