### PR TITLE
feat(design-system): absorb bonsai --space-1~8 into canonical tokens.css (PR-S3a)

### DIFF
--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -739,3 +739,25 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
   --t-wait:  #E5E0D1;
   --t-err:   #8B3A3A;
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   BONSAI STRUCTURAL TOKENS (spacing primitives)
+   ───────────────────────────────────────────────────────────────────
+   Bonsai surface uses a 4px-grid spacing scale. These values are
+   theme-invariant (no [data-theme] override in colors_and_type.css).
+
+   Absorbed into canonical tokens.css for SSOT consolidation. Bonsai's
+   colors_and_type.css continues to define the same values until
+   PR-S2.5 redirects bonsai to import canonical tokens.css.
+   ═══════════════════════════════════════════════════════════════════ */
+
+:root {
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+}


### PR DESCRIPTION
## Summary

PR-S3 (bonsai vocabulary 잔여 absorb) 첫 슬라이스. dashboard `tokens.css`와 bonsai `colors_and_type.css` 사이 누락된 38 tokens 중 가장 안전한 **8 spacing primitives**를 먼저 absorb.

## 배경

PR #10471 ("absorb bonsai vocabulary into canonical tokens.css")는 color/type 토큰을 absorb했으나 **structural tokens** (spacing/radius/shadow/font/scrollbar)은 빠졌습니다.

bonsai-only token 분류 (38건):

| 카테고리 | tokens | theme override | 안전도 |
|---------|--------|---------------|-------|
| **spacing** | `--space-1~8` (8) | ❌ none | ✅ S3a (이 PR) |
| radius | `--radius-xs/sm/md/lg/pill` (5) | cyberpunk/terminal=0 | S3b |
| shadow | `--shadow-card/panel/glow/raised` (4) | theme별 | S3c |
| font | `--font-body/display/ui` (3) | theme별 | S3d |
| color extras | `--brass/-fill` × 7 pair (14) | parchment에 정의 | S3e |
| scrollbar/ink | `--scrollbar-thumb-*` `--ink-5/6` (4) | parchment-only | S3f |

`--space-1~8`는 bonsai에서 `:root` 안에만 정의되며 어느 `[data-theme]` 블록도 override하지 않음 → **theme-invariant** 4px-grid scale.

## 추가 내용 (tokens.css)

```css
/* BONSAI STRUCTURAL TOKENS (spacing primitives) */
:root {
  --space-1: 4px;
  --space-2: 8px;
  --space-3: 12px;
  --space-4: 16px;
  --space-5: 24px;
  --space-6: 32px;
  --space-7: 48px;
  --space-8: 64px;
}
```

## 안전성 분석

- **시각 회귀 0**: bonsai surface는 자기 `colors_and_type.css`로 동일 값을 정의하고 있어 양쪽 공존이 safe (cascade resolve order 무관, 같은 값).
- **dashboard 영향 0**: dashboard 컴포넌트는 아직 `--space-*` 참조 안 함 (Tailwind utility 사용). 단순히 SSOT 정의만 추가.
- **bonsai 영향 0**: bonsai는 자기 파일을 계속 사용. PR-S2.5 redirect 전까지 dual definition.

## Out-of-scope (별도 후속 PR)

- PR-S3b: `--radius-*` (cyberpunk/terminal 0 override)
- PR-S3c: `--shadow-*` (theme별)
- PR-S3d: `--font-*` (theme별)
- PR-S3e: color fill pair 7종 (parchment에만 정의되는 light pair)
- PR-S3f: scrollbar / `--ink-5/6` (parchment-only)
- PR-S2.5: bonsai SSOT redirect (PR-S3a-f 완료 후)

## Test plan

- [ ] CI green
- [ ] tokens.css validity (CSS parser pass)
- [ ] bonsai surface 시각 회귀 0 (자기 파일을 계속 사용 중이므로 동작 변화 없어야 함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
