### PR TITLE
feat(design-system): absorb bonsai --radius-* into canonical tokens.css (PR-S3b)

### DIFF
--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -801,3 +801,30 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
   --space-7: 48px;
   --space-8: 64px;
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   BONSAI STRUCTURAL TOKENS (radius primitives)
+   ───────────────────────────────────────────────────────────────────
+   cyberpunk + terminal flatten xs/sm/md to 0 (sharp corners).
+   parchment + paper inherit :root values.
+   ═══════════════════════════════════════════════════════════════════ */
+
+:root {
+  --radius-xs:   2px;
+  --radius-sm:   4px;
+  --radius-md:   6px;
+  --radius-lg:   12px;
+  --radius-pill: 999px;
+}
+
+[data-theme="cyberpunk"] {
+  --radius-xs: 0;
+  --radius-sm: 0;
+  --radius-md: 0;
+}
+
+[data-theme="terminal"] {
+  --radius-xs: 0;
+  --radius-sm: 0;
+  --radius-md: 0;
+}


### PR DESCRIPTION
## Summary

PR-S3 두 번째 슬라이스 — bonsai radius primitives 5종 absorb. PR-S3a (#10534) 위에 stack.

## 추가 토큰

```css
/* :root (default = dark-fantasy 값) */
--radius-xs:   2px;
--radius-sm:   4px;
--radius-md:   6px;
--radius-lg:   12px;
--radius-pill: 999px;

/* cyberpunk + terminal: sharp corners */
[data-theme="cyberpunk"] { --radius-xs/sm/md: 0; }
[data-theme="terminal"]  { --radius-xs/sm/md: 0; }
```

bonsai `colors_and_type.css` 70-74 / 122 / 157번 줄과 정확히 동일.

## 안전성

- **시각 회귀 0**: bonsai surface는 자기 colors_and_type.css 계속 사용. dual definition 공존이지만 값이 동일해 conflict 없음.
- **dashboard 영향 0**: dashboard 컴포넌트는 `--radius-*` 참조 안 함. 단순 SSOT 확보만.
- **theme override 정확성**: `parchment` / `paper`는 colors_and_type.css에서도 override 안 함 → :root 값 상속 동일.

## Stack

base = `feat/design-system-absorb-space` (PR-S3a #10534)

## 후속

- PR-S3c: `--shadow-card/panel/glow/raised` (theme별 override)
- PR-S3d: `--font-body/display/ui` (theme별)
- PR-S3e: color fill pair × 7 (parchment-only)
- PR-S3f: `--scrollbar-*`, `--ink-5/6` (parchment-only)
- PR-S2.5: bonsai SSOT redirect (S3a-f 완료 후)

## Test plan

- [ ] CI green
- [ ] 시각 회귀 0 (bonsai 자기 파일 계속 사용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
