### PR TITLE
refactor(lint): exempt encoder-only deriving from yojson option-default rule

### DIFF
--- a/scripts/lint/yojson-option-default.py
+++ b/scripts/lint/yojson-option-default.py
@@ -38,13 +38,43 @@ DEFAULT_BASELINE = (
     REPO_ROOT / "scripts" / "lint" / "yojson-option-default.allowlist"
 )
 
-DERIVING_RE = re.compile(r"\[@@deriving[^]]*\byojson\b")
+DERIVING_BLOCK_RE = re.compile(r"\[@@deriving([^]]*)\]")
+# Decoders that consume incoming JSON and therefore must handle missing keys.
+# Encoder-only derivers (`to_yojson`) cannot fail on a missing optional field
+# because there is no decode path. Whole-token match against the deriver list
+# avoids false-positives like `to_yojson` accidentally matching `\byojson\b`
+# (Python's `\b` happens to treat `_y` as non-boundary because `_` is a word
+# character, but relying on that quirk is fragile — parse the comma-separated
+# token list explicitly).
+DECODING_DERIVERS = frozenset({"yojson", "of_yojson"})
 TYPE_START_RE = re.compile(r"^\s*(?:type|and)\s+\w")
 OPTION_FIELD_RE = re.compile(
     r"^\s*([\w']+)\s*:\s*[^;]*\boption\b[^;]*;"
 )
 DEFAULT_NONE_RE = re.compile(r"\[@default\s+None\s*\]")
 YOJSON_OPTION_RE = re.compile(r"\[@yojson\.option\]")
+
+
+def _has_decoding_deriver(text: str) -> bool:
+    """True iff text contains a `[@@deriving ...]` block whose comma-separated
+    token list includes `yojson` or `of_yojson` as a whole token. Encoder-only
+    derivers like `to_yojson` are exempt because they cannot fail on a missing
+    optional key (no decode path exists).
+
+    Per-deriver options like `{strict = false}` are tolerated by stripping
+    everything up to the first whitespace/brace.
+    """
+    for match in DERIVING_BLOCK_RE.finditer(text):
+        body = match.group(1)
+        for raw in body.split(","):
+            token = raw.strip()
+            if not token:
+                continue
+            # Trim ppx options: `yojson { strict = false }` -> `yojson`.
+            head = re.split(r"[\s{(]", token, maxsplit=1)[0]
+            if head in DECODING_DERIVERS:
+                return True
+    return False
 
 
 @dataclass(frozen=True)
@@ -87,7 +117,7 @@ def _scan_file(path: Path) -> list[Violation]:
         if not in_block:
             return
         joined = "\n".join(line for _, line in block_lines)
-        if DERIVING_RE.search(joined):
+        if _has_decoding_deriver(joined):
             for ln, line in block_lines:
                 m = OPTION_FIELD_RE.match(line)
                 if not m:
@@ -128,11 +158,11 @@ def _scan_file(path: Path) -> list[Violation]:
                 block_lines = [(i + 1, line)]
                 # If the deriving attribute is on the same line, close
                 # immediately after.
-                if DERIVING_RE.search(line):
+                if DERIVING_BLOCK_RE.search(line):
                     flush(i + 1)
         else:
             block_lines.append((i + 1, line))
-            if DERIVING_RE.search(line):
+            if DERIVING_BLOCK_RE.search(line):
                 flush(i + 1)
             elif line.strip() == "" and i + 1 < len(src):
                 nxt = src[i + 1]


### PR DESCRIPTION
## Why

Follow-up to #10501 (yojson option-default lint with Python line-walker). Companion to in-flight #10526 / #10527 which switch dead types to encoder-only `[@@deriving to_yojson]`.

Two issues with the previous deriver detector `re.compile(r\"\[@@deriving[^]]*\byojson\b\")`:

1. **Token-suffix fragility.** The regex relies on Python's `\b` treating `_y` as a non-boundary because `_` is a word character. That happens to skip `to_yojson` today, but it is the wrong tool for a comma-separated token list. A future author reaching for `re.IGNORECASE` or porting to a different regex flavor would silently start flagging `to_yojson` types as missing-default violations.
2. **`of_yojson` blind spot.** A type with only `[@@deriving of_yojson]` *does* need `[@default None]` on optional fields (decoder is generated), but `\byojson\b` never matched `of_yojson` either.

## What

Parse the contents of every `[@@deriving ...]` block as a comma-separated token list, strip per-deriver options like `{strict = false}`, and check membership against the decoding-deriver set `{yojson, of_yojson}`. Encoder-only derivers (`to_yojson`) are exempt — no decode path means no failure mode on missing optional keys.

The block-flushing trigger in the state machine is widened to `DERIVING_BLOCK_RE` (any deriving attribute closes the type block). The decode-vs-encode decision is moved inside `flush` via `_has_decoding_deriver`.

## Canary verification

Temporary `lib/canary_to_yojson.ml` with `type t = { x : string option }`:

| deriving                          | result                          | status |
|-----------------------------------|---------------------------------|--------|
| `[@@deriving to_yojson]`          | exit 0 (not flagged)            | new behavior |
| `[@@deriving yojson]`             | exit 1 (flagged)                | unchanged |
| `[@@deriving of_yojson]`          | exit 1 (flagged)                | new behavior |
| `[@@deriving show, to_yojson, eq]`| exit 0 (not flagged)            | new behavior |

Canary deleted before commit.

## Baseline

`scripts/lint/yojson-option-default.allowlist` is unchanged at 19 violations: no current main type uses `to_yojson`-only or `of_yojson`-only deriving, so behavior on existing code is identical. Once #10526 / #10527 land, the three `Agent_identity.t.{channel,user_id,room_id}` entries will drop out of the baseline automatically.

## Build

`DUNE_CACHE=disabled dune build @check --root .` whole-repo clean.

## Refinement B (deferred)

The follow-up plan to replace the Python line-walker with a `compiler-libs.common` OCaml binary (`scripts/lint/yojson_option_default_lint/main.ml`) is intentionally not in this PR. The current Python covers the rule surface; ppxlib/compiler-libs setup is outside the budget for a pure-correctness refinement. Tracking informally — open an issue if it becomes load-bearing.

## Labels

- `do-not-merge` — manual review wanted before this enters the auto-merge queue, because a lint logic change touches CI gating for every type with yojson derivers.