### PR TITLE
refactor(keeper): consolidate personality I/O via samchon-style harness (Layer 2 PR-B)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -438,6 +438,7 @@
    keeper_meta_tool_access
    keeper_meta_contract
    keeper_meta_json_scrub
+   keeper_personality_io
    keeper_meta_json_parse
    keeper_meta_json
    keeper_types_support
@@ -652,6 +653,7 @@
  keeper_meta_tool_access
  keeper_meta_contract
  keeper_meta_json_scrub
+ keeper_personality_io
  keeper_meta_json_parse
  keeper_meta_json
  keeper_types_support

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -10,28 +10,38 @@ include Keeper_meta_json_scrub
 
 let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
   let rt = m.runtime in
+  (* Layer 2 PR-B (commit 5): personality fields go through
+     [Keeper_personality_io.to_json].  Inlining four [`String] pairs
+     created the original asymmetry that drove the drift loop
+     (#10479 PR-A); centralising the write side guarantees symmetry
+     with [Keeper_personality_io.parse].
+     "models" is intentionally omitted from serialization (see
+     removed_keeper_meta_key_names + scrub_persisted_keeper_meta_json
+     — re-emitting causes a scrub → write → re-scrub loop). *)
+  let personality_pairs =
+    Keeper_personality_io.to_json
+      {
+        will = m.will;
+        needs = m.needs;
+        desires = m.desires;
+        instructions = m.instructions;
+      }
+  in
   `Assoc
-    [ "name", `String m.name
-    ; "agent_name", `String m.agent_name
-    ; "trace_id", `String (Keeper_id.Trace_id.to_string rt.trace_id)
-    ; "trace_history", `List (List.map (fun s -> `String s) rt.trace_history)
-    ; "goal", `String m.goal
-    ; "short_goal", `String m.short_goal
-    ; "mid_goal", `String m.mid_goal
-    ; "long_goal", `String m.long_goal
-    ; "social_model", `String m.social_model
-    ; "cascade_name", `String m.cascade_name
-      (* "models" intentionally omitted from serialization.  The field
-       is in removed_keeper_meta_key_names (via removed_keeper_input_key_names)
-       and scrub_persisted_keeper_meta_json strips it on every load.
-       Re-emitting it here creates a scrub → write → re-scrub loop that
-       fires ~20 INFO log lines per keeper per session.  Models are
-       resolved at runtime from cascade config, not from persisted meta. *)
-    ; "will", `String m.will
-    ; "needs", `String m.needs
-    ; "desires", `String m.desires
-    ; "instructions", `String m.instructions
-    ; "policy_voice_enabled", `Bool m.policy_voice_enabled
+    ([ "name", `String m.name
+     ; "agent_name", `String m.agent_name
+     ; "trace_id", `String (Keeper_id.Trace_id.to_string rt.trace_id)
+     ; "trace_history", `List (List.map (fun s -> `String s) rt.trace_history)
+     ; "goal", `String m.goal
+     ; "short_goal", `String m.short_goal
+     ; "mid_goal", `String m.mid_goal
+     ; "long_goal", `String m.long_goal
+     ; "social_model", `String m.social_model
+     ; "cascade_name", `String m.cascade_name
+     ]
+     @ personality_pairs
+     @ [
+      "policy_voice_enabled", `Bool m.policy_voice_enabled
     ; "sandbox_profile", `String (sandbox_profile_to_string m.sandbox_profile)
     ; "network_mode", `String (network_mode_to_string m.network_mode)
     ; "shared_memory_scope", `String (shared_memory_scope_to_string m.shared_memory_scope)
@@ -138,7 +148,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
         | None -> `Null )
     ; "oas_env", `Assoc (List.map (fun (k, v) -> k, `String v) m.oas_env)
     ; "meta_version", `Int m.meta_version
-    ]
+    ])
 ;;
 
 include Keeper_meta_json_parse

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -100,22 +100,28 @@ let parse_keeper_identity (json : Yojson.Safe.t) : (parsed_keeper_identity, stri
         "social_model"
         json
     in
-    let pk_will =
-      Safe_ops.json_string ~default:(Env_config_core.keeper_will ()) "will" json
-      |> normalize_self_model_text
-        ~max_bytes:Keeper_config.prompt_render_max_bytes
+    (* Layer 2 PR-B (commit 5): delegate the four personality fields
+       to [Keeper_personality_io].  parse + coerce yields trim-only
+       canonicalisation; truncation moved to the prompt-render path
+       (Keeper_prompt) so disk and in-memory stay byte-identical.
+       Decision Resolution: write raw, compare normalize, render
+       truncate. *)
+    let personality_defaults : Keeper_personality_io.raw_personality =
+      {
+        will = Env_config_core.keeper_will ();
+        needs = Env_config_core.keeper_needs ();
+        desires = Env_config_core.keeper_desires ();
+        instructions = "";
+      }
     in
-    let pk_needs =
-      Safe_ops.json_string ~default:(Env_config_core.keeper_needs ()) "needs" json
-      |> normalize_self_model_text
-        ~max_bytes:Keeper_config.prompt_render_max_bytes
+    let personality =
+      Keeper_personality_io.parse ~defaults:personality_defaults json
+      |> Keeper_personality_io.coerce |> Keeper_personality_io.to_raw
     in
-    let pk_desires =
-      Safe_ops.json_string ~default:(Env_config_core.keeper_desires ()) "desires" json
-      |> normalize_self_model_text
-        ~max_bytes:Keeper_config.prompt_render_max_bytes
-    in
-    let pk_instructions = Safe_ops.json_string ~default:"" "instructions" json in
+    let pk_will = personality.will in
+    let pk_needs = personality.needs in
+    let pk_desires = personality.desires in
+    let pk_instructions = personality.instructions in
     let pk_cascade_name =
       (* Preserve the raw cascade_name as persisted in runtime JSON so the
        dashboard can distinguish "declared in TOML" from "canonicalized

--- a/lib/keeper/keeper_personality_io.ml
+++ b/lib/keeper/keeper_personality_io.ml
@@ -1,0 +1,31 @@
+(** Keeper_personality_io — symmetric I/O harness (incremental).
+
+    Commit 1: types + parse + to_json. Future commits add coerce,
+    validate, merge_with_defaults, compare_normalized; caller migration
+    is the last step in this PR. *)
+
+type raw_personality = {
+  will : string;
+  needs : string;
+  desires : string;
+  instructions : string;
+}
+
+let empty = { will = ""; needs = ""; desires = ""; instructions = "" }
+
+let parse ?(defaults = empty) (json : Yojson.Safe.t) : raw_personality =
+  {
+    will = Safe_ops.json_string ~default:defaults.will "will" json;
+    needs = Safe_ops.json_string ~default:defaults.needs "needs" json;
+    desires = Safe_ops.json_string ~default:defaults.desires "desires" json;
+    instructions =
+      Safe_ops.json_string ~default:defaults.instructions "instructions" json;
+  }
+
+let to_json (p : raw_personality) : (string * Yojson.Safe.t) list =
+  [
+    ("will", `String p.will);
+    ("needs", `String p.needs);
+    ("desires", `String p.desires);
+    ("instructions", `String p.instructions);
+  ]

--- a/lib/keeper/keeper_personality_io.ml
+++ b/lib/keeper/keeper_personality_io.ml
@@ -132,3 +132,16 @@ let compare_normalized (current : coerced_personality)
       ]
   in
   match diffs with [] -> `Equal | _ :: _ -> `Drift diffs
+
+let to_prompt_form ~max_bytes (p : raw_personality) : raw_personality =
+  let render s =
+    let trimmed = String.trim s in
+    if trimmed = "" then ""
+    else Keeper_config.utf8_safe_prefix_bytes trimmed ~max_bytes
+  in
+  {
+    will = render p.will;
+    needs = render p.needs;
+    desires = render p.desires;
+    instructions = render p.instructions;
+  }

--- a/lib/keeper/keeper_personality_io.ml
+++ b/lib/keeper/keeper_personality_io.ml
@@ -29,3 +29,18 @@ let to_json (p : raw_personality) : (string * Yojson.Safe.t) list =
     ("desires", `String p.desires);
     ("instructions", `String p.instructions);
   ]
+
+(* coerced_personality is just raw_personality under a different name.
+   The .mli keeps the constructor private so callers cannot bypass
+   [coerce] to mint one — same trick samchon uses for parser stages. *)
+type coerced_personality = raw_personality
+
+let coerce (p : raw_personality) : coerced_personality =
+  {
+    will = String.trim p.will;
+    needs = String.trim p.needs;
+    desires = String.trim p.desires;
+    instructions = String.trim p.instructions;
+  }
+
+let to_raw (c : coerced_personality) : raw_personality = c

--- a/lib/keeper/keeper_personality_io.ml
+++ b/lib/keeper/keeper_personality_io.ml
@@ -89,3 +89,46 @@ let check_byte_caps ?max_bytes (c : coerced_personality) =
   |> check Desires c.desires
   |> check Needs c.needs
   |> check Will c.will
+
+type field_diff = {
+  field : field;
+  current_bytes : int;
+  target_bytes : int;
+  diff_offset : int;
+}
+
+let first_byte_diff a b =
+  let la = String.length a in
+  let lb = String.length b in
+  let n = min la lb in
+  let rec scan i =
+    if i = n then n
+    else if a.[i] <> b.[i] then i
+    else scan (i + 1)
+  in
+  scan 0
+
+let field_diff_of_strings ~field ~current ~target =
+  if String.equal current target then None
+  else
+    Some
+      {
+        field;
+        current_bytes = String.length current;
+        target_bytes = String.length target;
+        diff_offset = first_byte_diff current target;
+      }
+
+let compare_normalized (current : coerced_personality)
+    (target : coerced_personality) =
+  let diffs =
+    List.filter_map
+      (fun (field, c, t) -> field_diff_of_strings ~field ~current:c ~target:t)
+      [
+        (Will, current.will, target.will);
+        (Needs, current.needs, target.needs);
+        (Desires, current.desires, target.desires);
+        (Instructions, current.instructions, target.instructions);
+      ]
+  in
+  match diffs with [] -> `Equal | _ :: _ -> `Drift diffs

--- a/lib/keeper/keeper_personality_io.ml
+++ b/lib/keeper/keeper_personality_io.ml
@@ -44,3 +44,48 @@ let coerce (p : raw_personality) : coerced_personality =
   }
 
 let to_raw (c : coerced_personality) : raw_personality = c
+
+type field = Will | Needs | Desires | Instructions
+
+let field_to_string = function
+  | Will -> "will"
+  | Needs -> "needs"
+  | Desires -> "desires"
+  | Instructions -> "instructions"
+
+type cap_warning = {
+  field : field;
+  observed_bytes : int;
+  cap_bytes : int;
+  hint : string;
+}
+
+let make_hint ~field ~observed ~cap =
+  Printf.sprintf
+    "%s exceeds %d-byte cap by %d bytes — prompt-render path will \
+     truncate; consider tightening at source."
+    (field_to_string field) cap (observed - cap)
+
+let check_byte_caps ?max_bytes (c : coerced_personality) =
+  let cap =
+    match max_bytes with
+    | Some n -> n
+    | None -> Keeper_config.prompt_render_max_bytes
+  in
+  let check field value acc =
+    let observed = String.length value in
+    if observed > cap then
+      {
+        field;
+        observed_bytes = observed;
+        cap_bytes = cap;
+        hint = make_hint ~field ~observed ~cap;
+      }
+      :: acc
+    else acc
+  in
+  []
+  |> check Instructions c.instructions
+  |> check Desires c.desires
+  |> check Needs c.needs
+  |> check Will c.will

--- a/lib/keeper/keeper_personality_io.mli
+++ b/lib/keeper/keeper_personality_io.mli
@@ -47,3 +47,22 @@ val to_json : raw_personality -> (string * Yojson.Safe.t) list
     are returned as a list (rather than an [`Assoc]) so the caller can
     splice them into a larger record without an intermediate
     [Yojson.Safe.Util.combine] round-trip. *)
+
+(** Personality after the coerce step. Wraps [raw_personality] so the
+    type system distinguishes "trimmed and ready for compare" from
+    "as persisted on disk". Use [to_raw] to project back to the disk
+    representation. The constructor is private — only [coerce] can
+    produce a value of this type. *)
+type coerced_personality
+
+val coerce : raw_personality -> coerced_personality
+(** [coerce p] applies the canonical text normalisation used by the
+    compare path: [String.trim] on every field. No truncation, no NFC,
+    no encoding rewrite — those belong to the validate layer (length
+    cap, structured errors) and to the prompt-render path
+    ([Keeper_prompt.render_for_prompt ~max_bytes]) added in later
+    commits. Idempotent: [coerce (to_raw (coerce p)) = coerce p]. *)
+
+val to_raw : coerced_personality -> raw_personality
+(** Project a coerced value back to a [raw_personality]. Loses the
+    "this has been coerced" type tag but keeps the byte contents. *)

--- a/lib/keeper/keeper_personality_io.mli
+++ b/lib/keeper/keeper_personality_io.mli
@@ -95,3 +95,33 @@ val check_byte_caps :
     Always pure — no logging, no Prometheus, no transformation. The
     caller chooses what to do with the warnings (soft-warn at create/
     update boundaries; structured-feedback in Layer 4 retry). *)
+
+(** {1 Compare} *)
+
+(** Per-field drift report when two coerced personalities differ.
+    [diff_offset] is the byte index of the first differing character
+    in the trimmed values, useful for log strings like
+    [will(cur=319,tgt=357,diff@319)] (the format Layer 1
+    [Keeper_runtime.personality_field_diff_entry] emits). *)
+type field_diff = {
+  field : field;
+  current_bytes : int;
+  target_bytes : int;
+  diff_offset : int;
+}
+
+val compare_normalized :
+  coerced_personality ->
+  coerced_personality ->
+  [ `Equal | `Drift of field_diff list ]
+(** [compare_normalized current target] returns [`Equal] when every
+    field matches byte-for-byte after coerce, or [`Drift diffs] with
+    one entry per differing field (in canonical order:
+    will, needs, desires, instructions).
+
+    Replacement for [Keeper_runtime.personality_text_equal] /
+    [personality_diff_summary] / [personality_field_diff_entry]
+    introduced in Layer 1. Because both inputs are already
+    [coerced_personality], there is no way to compare a raw value
+    against a trimmed one — the type system enforces the symmetry
+    Layer 1 had to enforce at runtime. *)

--- a/lib/keeper/keeper_personality_io.mli
+++ b/lib/keeper/keeper_personality_io.mli
@@ -66,3 +66,32 @@ val coerce : raw_personality -> coerced_personality
 val to_raw : coerced_personality -> raw_personality
 (** Project a coerced value back to a [raw_personality]. Loses the
     "this has been coerced" type tag but keeps the byte contents. *)
+
+(** {1 Validate} *)
+
+(** Identifier of the personality field that triggered a warning.
+    Wrapping in a sum makes the cap-warning record portable to Layer 4
+    structured-feedback responses without leaking string keys. *)
+type field = Will | Needs | Desires | Instructions
+
+val field_to_string : field -> string
+(** Snake_case name of the field — stable identifier for log lines and
+    Prometheus labels. *)
+
+(** Soft warning emitted when a field exceeds the configured byte cap.
+    The harness never truncates: callers decide whether to soft-warn
+    (default for boundary code) or reject (Layer 4 self-edit). *)
+type cap_warning = {
+  field : field;
+  observed_bytes : int;
+  cap_bytes : int;
+  hint : string;
+}
+
+val check_byte_caps :
+  ?max_bytes:int -> coerced_personality -> cap_warning list
+(** [check_byte_caps ?max_bytes p] returns a warning per oversized
+    field. [max_bytes] defaults to [Keeper_config.prompt_render_max_bytes].
+    Always pure — no logging, no Prometheus, no transformation. The
+    caller chooses what to do with the warnings (soft-warn at create/
+    update boundaries; structured-feedback in Layer 4 retry). *)

--- a/lib/keeper/keeper_personality_io.mli
+++ b/lib/keeper/keeper_personality_io.mli
@@ -1,0 +1,49 @@
+(** Keeper_personality_io — symmetric I/O for keeper personality fields
+    (will / needs / desires / instructions).
+
+    SSOT for read, write, and compare paths. Replaces the read-only
+    normalization in [Keeper_meta_json_parse] (which was symmetric only
+    after Layer 1 PR-A #10479) and the raw write in [Keeper_meta_json].
+
+    This module is being built as a samchon-style harness. The five
+    layers are introduced in stacked commits within the same PR; the
+    first commit lands [parse]/[to_json] and pins the round-trip
+    invariant via [test/test_keeper_personality_io_parse.ml]. Subsequent
+    commits add [coerce], [validate], [merge_with_defaults], and
+    [compare_normalized]. Caller migration (Keeper_meta_json,
+    Keeper_meta_json_parse, Keeper_runtime, Keeper_prompt) follows once
+    the harness is complete.
+
+    Layer 1 fix and 14-keeper byte audit (2026-04-26) confirmed only
+    [nick0cave] exceeds the prompt_render_max_bytes cap, so the harness
+    deliberately keeps cap-exceeding values intact on disk and warns
+    only at the create/update boundary. *)
+
+(** Raw personality record as it appears on disk and in memory. The
+    four fields are kept separate from the rest of [keeper_meta] so
+    the I/O harness can reason about them without dragging the full
+    record schema into every test. *)
+type raw_personality = {
+  will : string;
+  needs : string;
+  desires : string;
+  instructions : string;
+}
+
+val empty : raw_personality
+(** All four fields = "". Useful as a fallback when a keeper has no
+    persisted JSON yet. *)
+
+val parse : ?defaults:raw_personality -> Yojson.Safe.t -> raw_personality
+(** [parse ?defaults json] reads the four personality strings from a
+    keeper JSON object, falling back to [defaults] (or [empty]) when
+    a field is missing or the wrong shape. **No normalization is
+    applied** — that belongs to the [coerce] layer added in a later
+    commit. The return value is the raw bytes as persisted. *)
+
+val to_json : raw_personality -> (string * Yojson.Safe.t) list
+(** [to_json p] returns the four [(key, `String value)] pairs in the
+    canonical order used by [Keeper_meta_json.meta_to_json]. The pairs
+    are returned as a list (rather than an [`Assoc]) so the caller can
+    splice them into a larger record without an intermediate
+    [Yojson.Safe.Util.combine] round-trip. *)

--- a/lib/keeper/keeper_personality_io.mli
+++ b/lib/keeper/keeper_personality_io.mli
@@ -125,3 +125,20 @@ val compare_normalized :
     [coerced_personality], there is no way to compare a raw value
     against a trimmed one — the type system enforces the symmetry
     Layer 1 had to enforce at runtime. *)
+
+(** {1 Render for prompt} *)
+
+val to_prompt_form :
+  max_bytes:int -> raw_personality -> raw_personality
+(** [to_prompt_form ~max_bytes p] returns a copy of [p] with each
+    field trimmed and then truncated to [max_bytes] using
+    [Keeper_config.utf8_safe_prefix_bytes] (UTF-8 boundary safe).
+    This is the only place in the harness where data is shortened —
+    parse / coerce / compare all preserve raw bytes. Callers are
+    responsible for fallback defaults when a field is empty after
+    trimming.
+
+    The output type is [raw_personality] (not [coerced_personality])
+    because the truncation may break the "trim-only" invariant —
+    after slicing on a UTF-8 boundary the trailing whitespace
+    promise no longer holds in general. *)

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -60,29 +60,29 @@ let build_keeper_system_prompt
       ~mid_goal_opt:(Some mid_goal) ~long_goal_opt:(Some long_goal)
   in
   let profile_policy = "Maintain high standard of reasoning, factual grounding, and clear communication." in
+  (* Layer 2 PR-B (commit 7): three normalize_self_model_text calls
+     consolidated through [Keeper_personality_io.to_prompt_form]. The
+     fallback strings below are the same; only the trim+truncate path
+     is centralised so a future cap change (Layer 3 RFC integration)
+     touches one location instead of three. *)
+  let rendered =
+    Keeper_personality_io.to_prompt_form
+      ~max_bytes:Keeper_config.prompt_render_max_bytes
+      { will; needs; desires; instructions = "" }
+  in
   let will =
-    let s =
-      normalize_self_model_text
-        ~max_bytes:Keeper_config.prompt_render_max_bytes will
-    in
-    if s = "" then "Maintain coherent identity and goal continuity." else s
+    if rendered.will = "" then "Maintain coherent identity and goal continuity."
+    else rendered.will
   in
   let needs =
-    let s =
-      normalize_self_model_text
-        ~max_bytes:Keeper_config.prompt_render_max_bytes needs
-    in
-    if s = "" then
+    if rendered.needs = "" then
       "Reliable context continuity, factual grounding, and explicit next steps."
-    else s
+    else rendered.needs
   in
   let desires =
-    let s =
-      normalize_self_model_text
-        ~max_bytes:Keeper_config.prompt_render_max_bytes desires
-    in
-    if s = "" then "Make progress that is observable and useful to the user."
-    else s
+    if rendered.desires = "" then
+      "Make progress that is observable and useful to the user."
+    else rendered.desires
   in
   let custom =
     let s = String.trim instructions in

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -22,12 +22,20 @@ open Keeper_types
     preserves disk-of-record (raw bytes), but compare uses the
     capped form that the prompt actually renders.  Disk data is
     preserved; loop terminates. *)
+(* Layer 2 PR-B (commit 6): delegate to [Keeper_personality_io].
+   compare path now uses [coerce] (trim only) — symmetric with the
+   read path migrated in commit 5. The Layer 1 "trim AND truncate"
+   workaround is no longer needed because read / write / compare all
+   see the same raw bytes; truncation lives at the prompt-render
+   boundary. *)
 let personality_text_equal a b =
-  String.equal
-    (Keeper_config.normalize_self_model_text
-       ~max_bytes:Keeper_config.prompt_render_max_bytes a)
-    (Keeper_config.normalize_self_model_text
-       ~max_bytes:Keeper_config.prompt_render_max_bytes b)
+  let one_field s : Keeper_personality_io.coerced_personality =
+    Keeper_personality_io.coerce
+      { will = s; needs = ""; desires = ""; instructions = "" }
+  in
+  match Keeper_personality_io.compare_normalized (one_field a) (one_field b) with
+  | `Equal -> true
+  | `Drift _ -> false
 
 (** #10269: when [personality_text_equal] reports a mismatch, the
     operator needs to know WHICH personality field differs and HOW
@@ -48,35 +56,30 @@ let personality_text_equal a b =
 
     The summary is cheap: only invoked on the cycle that actually
     performs a re-sync, never on the stable steady-state path. *)
-let first_byte_diff a b =
-  let len_a = String.length a and len_b = String.length b in
-  let limit = min len_a len_b in
-  let rec loop i =
-    if i >= limit then
-      if len_a = len_b then -1 else limit
-    else if Char.equal a.[i] b.[i] then loop (i + 1)
-    else i
-  in
-  loop 0
-
+(* Layer 2 PR-B (commit 6): same delegation pattern. Log format
+   "<name>(cur=N,tgt=N,diff@P)" preserved verbatim so dashboard log
+   scrapers don't need to migrate. The numbers now reflect post-trim
+   bytes (no truncation), so a 357-byte nick0cave will reads cur=357
+   instead of cur=319 — the value the disk actually holds. *)
 let personality_field_diff_entry name current target =
-  if personality_text_equal current target then None
-  else
-    let cur_n =
-      Keeper_config.normalize_self_model_text
-        ~max_bytes:Keeper_config.prompt_render_max_bytes current
-    in
-    let tgt_n =
-      Keeper_config.normalize_self_model_text
-        ~max_bytes:Keeper_config.prompt_render_max_bytes target
-    in
-    let pos = first_byte_diff cur_n tgt_n in
-    Some
-      (Printf.sprintf "%s(cur=%d,tgt=%d,diff@%d)"
-         name
-         (String.length cur_n)
-         (String.length tgt_n)
-         pos)
+  let one_field s : Keeper_personality_io.coerced_personality =
+    Keeper_personality_io.coerce
+      { will = s; needs = ""; desires = ""; instructions = "" }
+  in
+  match
+    Keeper_personality_io.compare_normalized (one_field current) (one_field target)
+  with
+  | `Equal -> None
+  | `Drift diffs ->
+      (* compare_normalized only inspected the [will] slot we wrapped
+         around the input; the diff list therefore has at most one
+         entry. *)
+      (match diffs with
+       | [] -> None
+       | d :: _ ->
+           Some
+             (Printf.sprintf "%s(cur=%d,tgt=%d,diff@%d)" name
+                d.current_bytes d.target_bytes d.diff_offset))
 
 let personality_diff_summary fields =
   List.filter_map

--- a/test/dune
+++ b/test/dune
@@ -634,6 +634,7 @@
         test_keeper_personality_io_coerce
         test_keeper_personality_io_validate
         test_keeper_personality_io_compare
+        test_keeper_personality_io_render
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify
@@ -825,6 +826,7 @@
         test_keeper_personality_io_coerce
         test_keeper_personality_io_validate
         test_keeper_personality_io_compare
+        test_keeper_personality_io_render
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify

--- a/test/dune
+++ b/test/dune
@@ -631,6 +631,7 @@
         test_keeper_identity_parse
         test_keeper_identity_normalize
         test_keeper_personality_io_parse
+        test_keeper_personality_io_coerce
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify
@@ -819,6 +820,7 @@
         test_keeper_identity_parse
         test_keeper_identity_normalize
         test_keeper_personality_io_parse
+        test_keeper_personality_io_coerce
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify

--- a/test/dune
+++ b/test/dune
@@ -633,6 +633,7 @@
         test_keeper_personality_io_parse
         test_keeper_personality_io_coerce
         test_keeper_personality_io_validate
+        test_keeper_personality_io_compare
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify
@@ -823,6 +824,7 @@
         test_keeper_personality_io_parse
         test_keeper_personality_io_coerce
         test_keeper_personality_io_validate
+        test_keeper_personality_io_compare
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify

--- a/test/dune
+++ b/test/dune
@@ -632,6 +632,7 @@
         test_keeper_identity_normalize
         test_keeper_personality_io_parse
         test_keeper_personality_io_coerce
+        test_keeper_personality_io_validate
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify
@@ -821,6 +822,7 @@
         test_keeper_identity_normalize
         test_keeper_personality_io_parse
         test_keeper_personality_io_coerce
+        test_keeper_personality_io_validate
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify

--- a/test/dune
+++ b/test/dune
@@ -630,6 +630,7 @@
         test_board_vote_quarantine
         test_keeper_identity_parse
         test_keeper_identity_normalize
+        test_keeper_personality_io_parse
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify
@@ -817,6 +818,7 @@
         test_board_vote_quarantine
         test_keeper_identity_parse
         test_keeper_identity_normalize
+        test_keeper_personality_io_parse
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify

--- a/test/test_keeper_personality_io_coerce.ml
+++ b/test/test_keeper_personality_io_coerce.ml
@@ -1,0 +1,117 @@
+(** Tests for [Keeper_personality_io.coerce] — samchon harness commit 2. *)
+
+open Alcotest
+open Masc_mcp
+
+let p_eq =
+  testable
+    (fun fmt (p : Keeper_personality_io.raw_personality) ->
+      Format.fprintf fmt
+        "{ will=%S; needs=%S; desires=%S; instructions=%S }" p.will p.needs
+        p.desires p.instructions)
+    ( = )
+
+let make ?(will = "") ?(needs = "") ?(desires = "") ?(instructions = "") () :
+    Keeper_personality_io.raw_personality =
+  { will; needs; desires; instructions }
+
+let coerce_to_raw p =
+  Keeper_personality_io.to_raw (Keeper_personality_io.coerce p)
+
+let nick0cave_will =
+  "Manifest the unsung. Surface threads the room is sliding past—the \
+   half-spoken claim, the conflict no one names, the operator note marked \
+   stale. When others optimise throughput I optimise legibility: pause \
+   the loop, restate the disagreement in plain words, attach the next \
+   minimal experiment."
+
+(* --------------------------------------------------------------------- *)
+(* trim semantics                                                        *)
+(* --------------------------------------------------------------------- *)
+
+let test_coerce_trims_leading_trailing_whitespace () =
+  let p =
+    make ~will:"  surrounded  " ~needs:"\t\ttabbed\t\t"
+      ~desires:"\n\nnewlines\n\n" ~instructions:"" ()
+  in
+  let expected =
+    make ~will:"surrounded" ~needs:"tabbed" ~desires:"newlines" ()
+  in
+  check p_eq "trim whitespace from all four fields" expected (coerce_to_raw p)
+
+let test_coerce_preserves_inner_whitespace () =
+  let p =
+    make ~will:"  hello world  " ~needs:"  multi\nline  "
+      ~desires:"  tabs\there  " ()
+  in
+  let expected =
+    make ~will:"hello world" ~needs:"multi\nline" ~desires:"tabs\there" ()
+  in
+  check p_eq "inner whitespace preserved" expected (coerce_to_raw p)
+
+let test_coerce_empty_fields_stay_empty () =
+  check p_eq "empty stays empty" Keeper_personality_io.empty
+    (coerce_to_raw Keeper_personality_io.empty)
+
+let test_coerce_only_whitespace_becomes_empty () =
+  let p = make ~will:"   " ~needs:"\t\n  \n" ~desires:"\n" () in
+  check p_eq "only-whitespace fields collapse to empty"
+    Keeper_personality_io.empty (coerce_to_raw p)
+
+(* --------------------------------------------------------------------- *)
+(* idempotency: coerce(coerce(p)) = coerce(p)                            *)
+(* --------------------------------------------------------------------- *)
+
+let test_coerce_is_idempotent () =
+  let inputs =
+    [
+      Keeper_personality_io.empty;
+      make ~will:"clean" ~needs:"clean" ~desires:"clean" ();
+      make ~will:"  with whitespace  " ~needs:"\nnewline-prefix" ();
+      make ~will:nick0cave_will ();
+    ]
+  in
+  List.iter
+    (fun p ->
+      let once = coerce_to_raw p in
+      let twice = coerce_to_raw once in
+      check p_eq "coerce idempotent" once twice)
+    inputs
+
+(* --------------------------------------------------------------------- *)
+(* nick0cave fixture: oversized utf8 trims correctly                     *)
+(* --------------------------------------------------------------------- *)
+
+let test_coerce_oversized_utf8_unchanged_when_no_surrounding_whitespace ()
+    =
+  let p = make ~will:nick0cave_will () in
+  let coerced = coerce_to_raw p in
+  check string "oversized utf8 byte-identical when no whitespace"
+    nick0cave_will coerced.will
+
+let () =
+  run "keeper_personality_io_coerce"
+    [
+      ( "trim semantics",
+        [
+          test_case "trims leading + trailing whitespace" `Quick
+            test_coerce_trims_leading_trailing_whitespace;
+          test_case "preserves inner whitespace" `Quick
+            test_coerce_preserves_inner_whitespace;
+          test_case "empty stays empty" `Quick
+            test_coerce_empty_fields_stay_empty;
+          test_case "only-whitespace → empty" `Quick
+            test_coerce_only_whitespace_becomes_empty;
+        ] );
+      ( "idempotency",
+        [
+          test_case "coerce(coerce(p)) = coerce(p)" `Quick
+            test_coerce_is_idempotent;
+        ] );
+      ( "oversized fixture",
+        [
+          test_case "nick0cave will: byte-identical when no surrounding ws"
+            `Quick
+            test_coerce_oversized_utf8_unchanged_when_no_surrounding_whitespace;
+        ] );
+    ]

--- a/test/test_keeper_personality_io_compare.ml
+++ b/test/test_keeper_personality_io_compare.ml
@@ -1,0 +1,155 @@
+(** Tests for [Keeper_personality_io.compare_normalized] — samchon
+    harness commit 4. Replacement for the Layer 1
+    [Keeper_runtime.personality_text_equal / _diff_summary] family. *)
+
+open Alcotest
+open Masc_mcp
+
+let make ?(will = "") ?(needs = "") ?(desires = "") ?(instructions = "") () :
+    Keeper_personality_io.raw_personality =
+  { will; needs; desires; instructions }
+
+let coerce p = Keeper_personality_io.coerce p
+
+let drift_fields = function
+  | `Equal -> []
+  | `Drift diffs ->
+      List.map
+        (fun (d : Keeper_personality_io.field_diff) ->
+          Keeper_personality_io.field_to_string d.field)
+        diffs
+
+let assert_equal ~label a b =
+  match Keeper_personality_io.compare_normalized (coerce a) (coerce b) with
+  | `Equal -> ()
+  | `Drift _ -> fail (Printf.sprintf "%s: expected Equal, got Drift" label)
+
+let assert_drift ~label ~expected_fields a b =
+  match Keeper_personality_io.compare_normalized (coerce a) (coerce b) with
+  | `Equal -> fail (Printf.sprintf "%s: expected Drift, got Equal" label)
+  | `Drift diffs ->
+      let got =
+        List.map
+          (fun (d : Keeper_personality_io.field_diff) ->
+            Keeper_personality_io.field_to_string d.field)
+          diffs
+      in
+      check (list string) label expected_fields got
+
+(* --------------------------------------------------------------------- *)
+(* Equal: trim differences swallowed                                     *)
+(* --------------------------------------------------------------------- *)
+
+let test_identical_inputs_equal () =
+  let p = make ~will:"a" ~needs:"b" ~desires:"c" ~instructions:"d" () in
+  assert_equal ~label:"identical" p p
+
+let test_trailing_whitespace_equal () =
+  let a = make ~will:"hello" () in
+  let b = make ~will:"hello   " () in
+  assert_equal ~label:"trailing whitespace" a b
+
+let test_leading_newline_equal () =
+  let a = make ~needs:"alpha" () in
+  let b = make ~needs:"\n\nalpha" () in
+  assert_equal ~label:"leading newlines" a b
+
+let test_only_whitespace_vs_empty_equal () =
+  let a = make ~desires:"" () in
+  let b = make ~desires:"   \n\t" () in
+  assert_equal ~label:"only-whitespace vs empty" a b
+
+(* --------------------------------------------------------------------- *)
+(* Drift: real content differences                                       *)
+(* --------------------------------------------------------------------- *)
+
+let test_single_field_drift () =
+  let a = make ~will:"alpha" () in
+  let b = make ~will:"beta" () in
+  assert_drift ~label:"single field" ~expected_fields:[ "will" ] a b
+
+let test_multiple_field_drift_canonical_order () =
+  let a = make ~will:"a" ~desires:"d" () in
+  let b = make ~will:"b" ~desires:"e" () in
+  assert_drift ~label:"two fields" ~expected_fields:[ "will"; "desires" ] a b
+
+let test_all_fields_drift () =
+  let a =
+    make ~will:"a1" ~needs:"n1" ~desires:"d1" ~instructions:"i1" ()
+  in
+  let b =
+    make ~will:"a2" ~needs:"n2" ~desires:"d2" ~instructions:"i2" ()
+  in
+  assert_drift ~label:"all four fields"
+    ~expected_fields:[ "will"; "needs"; "desires"; "instructions" ] a b
+
+(* --------------------------------------------------------------------- *)
+(* Diff details: byte counts + offset                                    *)
+(* --------------------------------------------------------------------- *)
+
+let test_diff_offset_matches_first_byte () =
+  let a = make ~will:"abcXYZ" () in
+  let b = make ~will:"abcDEF" () in
+  match Keeper_personality_io.compare_normalized (coerce a) (coerce b) with
+  | `Equal -> fail "expected Drift"
+  | `Drift [ d ] ->
+      check int "diff_offset is index of first differing byte" 3 d.diff_offset;
+      check int "current_bytes" 6 d.current_bytes;
+      check int "target_bytes" 6 d.target_bytes
+  | `Drift _ -> fail "expected exactly 1 diff"
+
+let test_prefix_relation_offset_at_shorter_length () =
+  let a = make ~will:"abc" () in
+  let b = make ~will:"abcdef" () in
+  match Keeper_personality_io.compare_normalized (coerce a) (coerce b) with
+  | `Drift [ d ] ->
+      check int "offset = shorter length" 3 d.diff_offset;
+      check int "current_bytes" 3 d.current_bytes;
+      check int "target_bytes" 6 d.target_bytes
+  | _ -> fail "expected exactly 1 diff"
+
+(* --------------------------------------------------------------------- *)
+(* Layer 1 regression: nick0cave 357-byte will, asymmetric raw vs trim  *)
+(* --------------------------------------------------------------------- *)
+
+let test_oversized_with_trailing_newline_still_equal () =
+  (* The exact pattern that caused the original drift loop:
+     write path stored "will\n" (raw) while read path normalised
+     to "will" (no newline). After Layer 1 + this harness both go
+     through coerce, so they compare Equal. *)
+  let nick0cave = String.make 357 'a' in
+  let a = make ~will:nick0cave () in
+  let b = make ~will:(nick0cave ^ "\n") () in
+  assert_equal ~label:"nick0cave 357B with trailing newline" a b
+
+let () =
+  run "keeper_personality_io_compare"
+    [
+      ( "Equal: trim swallows whitespace",
+        [
+          test_case "identical inputs" `Quick test_identical_inputs_equal;
+          test_case "trailing whitespace" `Quick test_trailing_whitespace_equal;
+          test_case "leading newlines" `Quick test_leading_newline_equal;
+          test_case "only-whitespace vs empty" `Quick
+            test_only_whitespace_vs_empty_equal;
+        ] );
+      ( "Drift: real content differences",
+        [
+          test_case "single field" `Quick test_single_field_drift;
+          test_case "two fields in canonical order" `Quick
+            test_multiple_field_drift_canonical_order;
+          test_case "all four fields" `Quick test_all_fields_drift;
+        ] );
+      ( "Diff details",
+        [
+          test_case "diff_offset is index of first differing byte" `Quick
+            test_diff_offset_matches_first_byte;
+          test_case "prefix relation: offset at shorter length" `Quick
+            test_prefix_relation_offset_at_shorter_length;
+        ] );
+      ( "Layer 1 regression",
+        [
+          test_case "nick0cave 357B + trailing newline → Equal" `Quick
+            test_oversized_with_trailing_newline_still_equal;
+        ] );
+    ]

--- a/test/test_keeper_personality_io_parse.ml
+++ b/test/test_keeper_personality_io_parse.ml
@@ -1,0 +1,131 @@
+(** Tests for [Keeper_personality_io.parse] and [.to_json] —
+    samchon harness commit 1.
+
+    Goal: pin the round-trip invariant from day one. parse(to_json(p)) = p
+    for any [raw_personality]. The next commits in this PR add coerce,
+    validate, merge_with_defaults, compare_normalized; each layer
+    extends this test file rather than introducing a new round-trip
+    surface. *)
+
+open Alcotest
+open Masc_mcp
+
+let p_eq =
+  testable
+    (fun fmt (p : Keeper_personality_io.raw_personality) ->
+      Format.fprintf fmt
+        "{ will=%S; needs=%S; desires=%S; instructions=%S }" p.will p.needs
+        p.desires p.instructions)
+    ( = )
+
+let make ?(will = "") ?(needs = "") ?(desires = "") ?(instructions = "") () :
+    Keeper_personality_io.raw_personality =
+  { will; needs; desires; instructions }
+
+let json_of (p : Keeper_personality_io.raw_personality) : Yojson.Safe.t =
+  `Assoc (Keeper_personality_io.to_json p)
+
+(* nick0cave live data — 357-byte will, 322-byte desires (Layer 1 fix
+   confirmed only this keeper exceeds prompt_render_max_bytes; we fix
+   it as a regression fixture so the harness preserves byte-for-byte
+   even at oversized inputs). *)
+let nick0cave_will =
+  "Manifest the unsung. Surface threads the room is sliding past—the \
+   half-spoken claim, the conflict no one names, the operator note marked \
+   stale. When others optimise throughput I optimise legibility: pause \
+   the loop, restate the disagreement in plain words, attach the next \
+   minimal experiment."
+
+(* --------------------------------------------------------------------- *)
+(* parse: defaults                                                       *)
+(* --------------------------------------------------------------------- *)
+
+let test_parse_empty_object_defaults_to_empty () =
+  check p_eq "empty object → empty record" Keeper_personality_io.empty
+    (Keeper_personality_io.parse (`Assoc []))
+
+let test_parse_empty_object_with_defaults () =
+  let defaults = make ~will:"d_will" ~needs:"d_needs" () in
+  check p_eq "empty object → defaults" defaults
+    (Keeper_personality_io.parse ~defaults (`Assoc []))
+
+let test_parse_partial_object_picks_defaults_only_for_missing () =
+  let defaults = make ~will:"d_will" ~needs:"d_needs" () in
+  let json = `Assoc [ ("will", `String "explicit_will") ] in
+  let expected = make ~will:"explicit_will" ~needs:"d_needs" () in
+  check p_eq "partial object" expected
+    (Keeper_personality_io.parse ~defaults json)
+
+(* --------------------------------------------------------------------- *)
+(* round-trip: to_json |> parse                                          *)
+(* --------------------------------------------------------------------- *)
+
+let round_trip p = Keeper_personality_io.parse (json_of p)
+
+let test_round_trip_empty () =
+  check p_eq "empty round-trip" Keeper_personality_io.empty
+    (round_trip Keeper_personality_io.empty)
+
+let test_round_trip_ascii () =
+  let p =
+    make ~will:"a will" ~needs:"a need" ~desires:"a desire"
+      ~instructions:"some inst" ()
+  in
+  check p_eq "ascii round-trip" p (round_trip p)
+
+let test_round_trip_korean_oversized () =
+  let p =
+    make ~will:nick0cave_will ~needs:"" ~desires:"another desire"
+      ~instructions:"" ()
+  in
+  check p_eq "oversized utf8 round-trip" p (round_trip p)
+
+let test_round_trip_with_whitespace_and_newlines () =
+  let p =
+    make ~will:"  trailing space  " ~needs:"\n\nleading newlines"
+      ~desires:"trailing newline\n" ~instructions:"" ()
+  in
+  check p_eq "whitespace preserved on round-trip" p (round_trip p)
+
+(* --------------------------------------------------------------------- *)
+(* shape robustness                                                      *)
+(* --------------------------------------------------------------------- *)
+
+let test_parse_handles_non_string_field_via_default () =
+  (* When a field is the wrong shape, Safe_ops.json_string returns the
+     default — this is the existing behaviour we are preserving. *)
+  let json =
+    `Assoc [ ("will", `Int 42); ("needs", `String "ok needs") ]
+  in
+  let defaults = make ~will:"d_will" () in
+  let expected = make ~will:"d_will" ~needs:"ok needs" () in
+  check p_eq "wrong-shape field → default" expected
+    (Keeper_personality_io.parse ~defaults json)
+
+let () =
+  run "keeper_personality_io_parse"
+    [
+      ( "parse defaults",
+        [
+          test_case "empty object → empty record" `Quick
+            test_parse_empty_object_defaults_to_empty;
+          test_case "empty object → defaults" `Quick
+            test_parse_empty_object_with_defaults;
+          test_case "partial object" `Quick
+            test_parse_partial_object_picks_defaults_only_for_missing;
+        ] );
+      ( "round-trip",
+        [
+          test_case "empty" `Quick test_round_trip_empty;
+          test_case "ascii" `Quick test_round_trip_ascii;
+          test_case "korean oversized (nick0cave fixture)" `Quick
+            test_round_trip_korean_oversized;
+          test_case "whitespace + newlines preserved" `Quick
+            test_round_trip_with_whitespace_and_newlines;
+        ] );
+      ( "shape robustness",
+        [
+          test_case "wrong-shape field → default" `Quick
+            test_parse_handles_non_string_field_via_default;
+        ] );
+    ]

--- a/test/test_keeper_personality_io_render.ml
+++ b/test/test_keeper_personality_io_render.ml
@@ -1,0 +1,117 @@
+(** Tests for [Keeper_personality_io.to_prompt_form] — samchon
+    harness commit 7. The render layer is the only place in the
+    harness where data is shortened (UTF-8 boundary safe truncation). *)
+
+open Alcotest
+open Masc_mcp
+
+let make ?(will = "") ?(needs = "") ?(desires = "") ?(instructions = "") () :
+    Keeper_personality_io.raw_personality =
+  { will; needs; desires; instructions }
+
+(* --------------------------------------------------------------------- *)
+(* Trim + truncate semantics                                             *)
+(* --------------------------------------------------------------------- *)
+
+let test_under_cap_only_trims () =
+  let p = make ~will:"  hello world  " () in
+  let r =
+    Keeper_personality_io.to_prompt_form ~max_bytes:1024 p
+  in
+  check string "trim only when under cap" "hello world" r.will
+
+let test_over_cap_truncates () =
+  let p = make ~will:(String.make 500 'x') () in
+  let r = Keeper_personality_io.to_prompt_form ~max_bytes:200 p in
+  check int "truncated to cap" 200 (String.length r.will)
+
+let test_empty_stays_empty () =
+  let r =
+    Keeper_personality_io.to_prompt_form ~max_bytes:320
+      Keeper_personality_io.empty
+  in
+  check string "empty will" "" r.will;
+  check string "empty needs" "" r.needs;
+  check string "empty desires" "" r.desires;
+  check string "empty instructions" "" r.instructions
+
+let test_only_whitespace_becomes_empty () =
+  let p = make ~will:"   \n\t" () in
+  let r = Keeper_personality_io.to_prompt_form ~max_bytes:320 p in
+  check string "only-whitespace → empty (no garbage cap-applied)" "" r.will
+
+(* --------------------------------------------------------------------- *)
+(* nick0cave 357-byte fixture: matches Layer 1 truncation behaviour      *)
+(* --------------------------------------------------------------------- *)
+
+let test_oversized_ascii_truncates_to_exact_cap () =
+  let p = make ~will:(String.make 357 'a') () in
+  let r =
+    Keeper_personality_io.to_prompt_form
+      ~max_bytes:Keeper_config.prompt_render_max_bytes p
+  in
+  check int "byte length = cap" Keeper_config.prompt_render_max_bytes
+    (String.length r.will)
+
+let test_truncate_per_field_independent () =
+  (* Each field is checked against the cap independently; needs being
+     short doesn't affect will being truncated. *)
+  let p =
+    make ~will:(String.make 500 'a') ~needs:"short" ~desires:"" ()
+  in
+  let r = Keeper_personality_io.to_prompt_form ~max_bytes:200 p in
+  check int "will at cap" 200 (String.length r.will);
+  check string "needs unchanged" "short" r.needs;
+  check string "desires unchanged" "" r.desires
+
+(* --------------------------------------------------------------------- *)
+(* Behaviour parity with normalize_self_model_text                       *)
+(* --------------------------------------------------------------------- *)
+
+let test_matches_normalize_self_model_text_for_each_field () =
+  let cap = Keeper_config.prompt_render_max_bytes in
+  let inputs =
+    [
+      "  ascii_short  ";
+      String.make 500 'x';
+      "";
+      "single line no whitespace";
+    ]
+  in
+  List.iter
+    (fun raw ->
+      let via_helper =
+        Keeper_config.normalize_self_model_text ~max_bytes:cap raw
+      in
+      let p = make ~will:raw () in
+      let r = Keeper_personality_io.to_prompt_form ~max_bytes:cap p in
+      check string
+        (Printf.sprintf "to_prompt_form parity for input of length %d"
+           (String.length raw))
+        via_helper r.will)
+    inputs
+
+let () =
+  run "keeper_personality_io_render"
+    [
+      ( "trim + truncate semantics",
+        [
+          test_case "under cap → trim only" `Quick test_under_cap_only_trims;
+          test_case "over cap → truncate" `Quick test_over_cap_truncates;
+          test_case "empty stays empty" `Quick test_empty_stays_empty;
+          test_case "only whitespace → empty" `Quick
+            test_only_whitespace_becomes_empty;
+        ] );
+      ( "nick0cave fixture",
+        [
+          test_case "oversized ascii truncates to exact cap" `Quick
+            test_oversized_ascii_truncates_to_exact_cap;
+          test_case "per-field truncate independent" `Quick
+            test_truncate_per_field_independent;
+        ] );
+      ( "behaviour parity",
+        [
+          test_case "matches normalize_self_model_text per field" `Quick
+            test_matches_normalize_self_model_text_for_each_field;
+        ] );
+    ]

--- a/test/test_keeper_personality_io_validate.ml
+++ b/test/test_keeper_personality_io_validate.ml
@@ -1,0 +1,118 @@
+(** Tests for [Keeper_personality_io.check_byte_caps] — samchon
+    harness commit 3.
+
+    Validate is diagnostic-only: warnings are produced but the input
+    is never transformed (per Decision Resolution "Both + 입력 경계
+    검증" — write raw, soft-warn at boundary). *)
+
+open Alcotest
+open Masc_mcp
+
+let make ?(will = "") ?(needs = "") ?(desires = "") ?(instructions = "") () :
+    Keeper_personality_io.raw_personality =
+  { will; needs; desires; instructions }
+
+let coerce p = Keeper_personality_io.coerce p
+
+(* nick0cave-shaped fixture: deterministic 357-byte string mirroring
+   the actual nick0cave will length on disk (Layer 1 fix evidence,
+   2026-04-26). Using String.make so the exact byte count is verifiable
+   and not dependent on OCaml string-literal line-continuation rules
+   (which strip leading whitespace after [\<NL>]). *)
+let nick0cave_will = String.make 357 'a'
+
+let nick0cave_desires = String.make 322 'a'
+(* exact 322 bytes, only over the 320 cap, simulates nick0cave desires
+   structurally without quoting Korean prose. *)
+
+let test_empty_returns_no_warnings () =
+  let warnings = Keeper_personality_io.check_byte_caps (coerce (make ())) in
+  check int "no warnings on empty" 0 (List.length warnings)
+
+let test_within_cap_returns_no_warnings () =
+  let p =
+    make ~will:(String.make 100 'x') ~needs:(String.make 50 'y')
+      ~desires:(String.make 200 'z') ~instructions:"" ()
+  in
+  let warnings = Keeper_personality_io.check_byte_caps (coerce p) in
+  check int "no warnings under cap" 0 (List.length warnings)
+
+let test_oversized_will_emits_one_warning () =
+  let p = make ~will:nick0cave_will () in
+  let warnings = Keeper_personality_io.check_byte_caps (coerce p) in
+  check int "one warning" 1 (List.length warnings);
+  let w = List.hd warnings in
+  check string "field is will" "will"
+    (Keeper_personality_io.field_to_string w.field);
+  check int "observed bytes" (String.length nick0cave_will) w.observed_bytes;
+  check int "cap bytes" Keeper_config.prompt_render_max_bytes w.cap_bytes
+
+let test_two_oversized_fields_emit_two_warnings () =
+  let p = make ~will:nick0cave_will ~desires:nick0cave_desires () in
+  let warnings = Keeper_personality_io.check_byte_caps (coerce p) in
+  check int "two warnings" 2 (List.length warnings);
+  let fields =
+    List.map
+      (fun (w : Keeper_personality_io.cap_warning) ->
+        Keeper_personality_io.field_to_string w.field)
+      warnings
+    |> List.sort compare
+  in
+  check (list string) "both fields reported" [ "desires"; "will" ] fields
+
+let test_custom_max_bytes_overrides_default () =
+  let p = make ~will:(String.make 50 'x') () in
+  let warnings =
+    Keeper_personality_io.check_byte_caps ~max_bytes:30 (coerce p)
+  in
+  check int "warning at custom cap" 1 (List.length warnings);
+  let w = List.hd warnings in
+  check int "cap is custom value" 30 w.cap_bytes;
+  check int "observed is byte length" 50 w.observed_bytes
+
+let test_does_not_transform_input () =
+  (* Verify the diagnostic-only contract: a value that triggered a
+     warning must round-trip unchanged through to_raw. *)
+  let p = make ~will:nick0cave_will () in
+  let coerced = coerce p in
+  let _warnings = Keeper_personality_io.check_byte_caps coerced in
+  let raw_after = Keeper_personality_io.to_raw coerced in
+  check string "will byte-identical after validate" nick0cave_will
+    raw_after.will
+
+let test_warning_hint_is_human_readable () =
+  let p = make ~will:nick0cave_will () in
+  let warnings = Keeper_personality_io.check_byte_caps (coerce p) in
+  let w = List.hd warnings in
+  check bool "hint mentions will" true
+    (let prefix = "will " in
+     String.length w.hint >= String.length prefix
+     && String.sub w.hint 0 (String.length prefix) = prefix);
+  check bool "hint is non-empty" true (String.length w.hint > 0)
+
+let () =
+  run "keeper_personality_io_validate"
+    [
+      ( "no warnings",
+        [
+          test_case "empty input" `Quick test_empty_returns_no_warnings;
+          test_case "all fields under cap" `Quick
+            test_within_cap_returns_no_warnings;
+        ] );
+      ( "warnings",
+        [
+          test_case "one oversized field → 1 warning" `Quick
+            test_oversized_will_emits_one_warning;
+          test_case "two oversized fields → 2 warnings" `Quick
+            test_two_oversized_fields_emit_two_warnings;
+          test_case "custom max_bytes overrides default" `Quick
+            test_custom_max_bytes_overrides_default;
+        ] );
+      ( "diagnostic contract",
+        [
+          test_case "validate does not transform input" `Quick
+            test_does_not_transform_input;
+          test_case "warning hint is human readable" `Quick
+            test_warning_hint_is_human_readable;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Layer 2 PR-B — consolidate scattered read/write/compare logic for keeper personality fields (will / needs / desires / instructions) into a single \`Keeper_personality_io\` module, modelled on the samchon 5-layer harness pattern (parse → coerce → validate → to_json → merge_with_defaults → compare_normalized).

**Status: scaffold (commit 1/N)** — types + parse + to_json + round-trip pin. Subsequent commits in this PR add the remaining harness layers and migrate the four caller sites. PR is intentionally Draft + do-not-merge for the duration.

## Why

After Layer 1 PR-A #10479 (merged \`037c5c9c24\`, drift loop fix verified), the personality data path is functionally correct but structurally split across three locations:

- read normalize: \`lib/keeper/keeper_meta_json_parse.ml:103-117\` (3 fields, all use \`~max_bytes:Keeper_config.prompt_render_max_bytes\`)
- write raw: \`lib/keeper/keeper_meta_json.ml:30-33\` (4 keys, raw bytes)
- compare: \`lib/keeper/keeper_runtime.ml:25-30, 62-79, 81-85, 98-111\` (4 helpers)

This means a future PR can re-introduce read/write asymmetry by editing only one of the three locations. Layer 2 collapses them into a single SSOT module so:

1. parse + to_json live next to each other → round-trip property test pins symmetry compiler-enforced
2. coerce/validate can be added without touching caller code
3. compare uses the same coerce path → cannot diverge from read

## Plan (5 commits)

| Commit | Layer | Status |
|--------|-------|--------|
| 1 (this) | parse + to_json + round-trip pin | ✅ |
| 2 | coerce (trim, NFC, drop control chars) | pending |
| 3 | validate (length cap, structured errors) | pending |
| 4 | merge_with_defaults (RFC layered SSOT) + compare_normalized | pending |
| 5 | caller migration (4 files) + deprecation forwarding shims | pending |

Full plan: \`~/.claude/plans/glistening-sleeping-meadow.md\` Layer 2 + Active Parallel Execution Track A.

## Changes (commit 1)

| File | Lines | Purpose |
|------|-------|---------|
| \`lib/keeper/keeper_personality_io.ml(.mli)\` | +91 | type \`raw_personality\`, \`empty\`, \`parse ?defaults\`, \`to_json\` |
| \`test/test_keeper_personality_io_parse.ml\` | +119 | 8 tests: defaults (3), round-trip (4 incl. nick0cave 357B fixture), shape robustness (1) |
| \`lib/dune\`, \`test/dune\` | +4 | module + test registration (both lists) |

Total +215 lines, 0 caller changes. **Operational impact: 0** (no caller migrated yet).

## Why Draft + do-not-merge

Caller migration (commit 5) touches \`Keeper_meta_json\`, \`Keeper_meta_json_parse\`, \`Keeper_runtime\`, \`Keeper_prompt\` simultaneously — should not partially merge. Stack stays Draft until all 5 commits are in and \`dune build @runtest\` is fully green.

## Test plan (commit 1)

- [x] \`dune build --root . @check\` green
- [x] \`dune exec test/test_keeper_personality_io_parse.exe\` — 8/8 pass
  - parse: empty obj → empty record / explicit defaults / partial object
  - round-trip: empty / ascii / nick0cave 357-byte korean / whitespace+newlines
  - shape: non-string field → default
- [ ] CI green (this commit)
- [ ] Subsequent commits each add their own layer + extend test file

## Plan to test the round-trip claim ahead of commit 5

After commit 5, the existing 14-keeper byte audit (used to verify Layer 1 fix) will be re-run as a regression gate. Any keeper whose disk JSON differs after parse → to_json → write must fail loudly.

## References

- Plan: \`~/.claude/plans/glistening-sleeping-meadow.md\` Layer 2 + Track A
- Layer 1 PR-A: #10479 (merged \`037c5c9c24\`)
- Track B (parallel): #10533 (P3-a Coord.join preflight)
- Memory: \`feedback_record-update-bypass-builder-drift.md\`, \`feedback_json-serializer-parser-key-symmetry.md\`, \`feedback_test-dune-names-modules-not-duplicate.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)