### PR TITLE
perf(mcp-accept): drop redundant lowercase from accept-header callbacks

### DIFF
--- a/lib/mcp_transport_protocol/mcp_transport_protocol.ml
+++ b/lib/mcp_transport_protocol/mcp_transport_protocol.ml
@@ -135,21 +135,22 @@ module Http_negotiation = struct
                 ~type_:(String.lowercase_ascii mt.type_)
                 ~subtype:(String.lowercase_ascii mt.subtype))
 
+  (* [exists_accepted] already passes [type_]/[subtype] lowercased to
+     [check] (see above), so callbacks compare against lowercase
+     literals directly — no second lowercase allocation per media
+     type. *)
   let accepts_sse_header = function
     | None -> false
     | Some h ->
         exists_accepted h ~check:(fun ~type_ ~subtype ->
-            String.lowercase_ascii type_ = "text"
-            && String.lowercase_ascii subtype = "event-stream")
+            type_ = "text" && subtype = "event-stream")
 
   let accepts_json = function
     | None -> false
     | Some h ->
         exists_accepted h ~check:(fun ~type_ ~subtype ->
-            let t = String.lowercase_ascii type_ in
-            let s = String.lowercase_ascii subtype in
-            (t = "application" && s = "json")
-            || (t = "*" && s = "*"))
+            (type_ = "application" && subtype = "json")
+            || (type_ = "*" && subtype = "*"))
 
   let accepts_streamable_mcp = function
     | None -> false


### PR DESCRIPTION
## What

`Mcp_transport_protocol.Http_negotiation`의 `accepts_sse_header`/`accepts_json` 콜백에서 `String.lowercase_ascii type_`/`subtype` 호출 제거. `exists_accepted`가 이미 lowercase로 변환해서 전달함.

## Why

`exists_accepted h ~check:(fun ~type_ ~subtype -> ...)` 호출 측이 (lib/mcp_transport_protocol/mcp_transport_protocol.ml:130-141):

```ocaml
mt.quality > 0.0
&& check
     ~type_:(String.lowercase_ascii mt.type_)
     ~subtype:(String.lowercase_ascii mt.subtype)
```

callback 내부에서 또 `String.lowercase_ascii type_ = "text"`처럼 재처리하고 있어 매 media_type 마다 4 string alloc (이미 lowercase된 string의 lowercase 호출). HTTP Accept 헤더당 ~2-3 media_type라 매 MCP HTTP 요청 ~10 redundant alloc.

## Test

`OCAMLPARAM='_,warn-error=+a' dune build @check` clean. 의미 보존: 입력이 이미 lowercase이므로 재호출은 identity. lowercase literal과 직접 비교가 동등.

## Note

이전 cycle에서 main 회귀(redundant case warning)로 push 못 했고, `perf/oas-sse-redundant-case` 셋의 cleanup이 #10511로 들어가면서 main 빌드 회복 → 후속 #10516으로 cascade unblock된 뒤 push.
