### PR TITLE
fix(obs): inline rejection context in cascade-no-callable-models ERROR (#10528)

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -1145,7 +1145,17 @@ let run_named
   let name = Printf.sprintf "oas-%s" cascade_name in
   match candidate_cfgs with
   | [] ->
-      Log.Misc.error "cascade %s: no callable models available" cascade_name;
+      (* #10528: surface rejection context inline so operators can classify
+         root cause from a single log line. Pre-fix: only the cascade name
+         was logged; the sibling WARN with the configured provider list
+         (provider_tool_support.ml:144) was a separate event requiring
+         time/level cross-search. *)
+      Log.Misc.error
+        "cascade %s: no callable models available — configured=[%s] require_tool_choice_support=%b require_tool_support=%b"
+        cascade_name
+        (String.concat ", " configured_labels)
+        require_tool_choice_support
+        require_tool_support;
       Error
       (sdk_error_of_masc_internal_error
          (if require_tool_choice_support then


### PR DESCRIPTION
## 요약

cascade exhaustion ERROR가 cascade 이름만 표시 → operator가 root cause 분류 불가. configured providers + 두 tool-use 요구 플래그를 같은 ERROR line에 inline.

## 변경

\`lib/oas_worker_named.ml:1146-1149\` (단일 Log.Misc.error format string 확장)

**Before:**
\`\`\`
cascade cross_verifier: no callable models available
\`\`\`

**After:**
\`\`\`
cascade cross_verifier: no callable models available —
  configured=[codex_cli:auto, kimi_cli:kimi-for-coding, gemini_cli:auto]
  require_tool_choice_support=true require_tool_support=false
\`\`\`

SDK error payload (\`No_tool_capable_provider\` record)는 그대로 — downstream 동작 무변.

## 검증

\`\`\`
DUNE_CACHE=disabled dune build --root . --cache=disabled @check  → EXIT=0
\`\`\`

## 영향

13 cascade-exhausted ERROR (2 days, 3 cascade) 모두 root cause를 single-line으로 분류 가능. dashboard observer + log stream tail이 즉시 actionable.

## 관련

- Issue: \`#10528\`
- Cross-link: \`#10474\` (cross_verifier 가 본 issue로 진단)
- 메모리 \`feedback_gate-response-llm-readable\` 의 사람-가독성 패턴 적용

## Defensive guards

Draft + \`do-not-merge\` 라벨 (운영자 승인 후 머지).