### PR TITLE
perf(strings): replace String.sub equality with String.starts_with (sweep 2: 7 files)

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -363,12 +363,12 @@ let parse_verdict (text : string) : (verdict, string) result =
            c = ' ' || c = ':' || c = '-')
   in
   if String.length upper >= 7
-     && String.sub upper 0 7 = "APPROVE"
+     && String.starts_with ~prefix:"APPROVE" upper
      && has_boundary "APPROVE"
   then
     Ok Approve
   else if String.length upper >= 6
-          && String.sub upper 0 6 = "REJECT"
+          && String.starts_with ~prefix:"REJECT" upper
           && has_boundary "REJECT"
   then
     let rest =

--- a/lib/cdal/adversarial_eval.ml
+++ b/lib/cdal/adversarial_eval.ml
@@ -291,14 +291,14 @@ let check_untested_additions inputs =
     List.exists
       (fun path ->
         let base = Filename.basename path in
-        String.length base > 5 && String.sub base 0 5 = "test_")
+        String.length base > 5 && String.starts_with ~prefix:"test_" base)
       changed_paths
   in
   let lib_files =
     List.filter
       (fun path ->
         let base = Filename.basename path in
-        not (String.length base > 5 && String.sub base 0 5 = "test_"))
+        not (String.length base > 5 && String.starts_with ~prefix:"test_" base))
       changed_paths
   in
   if List.length lib_files > 0 && not has_test_file then

--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -300,7 +300,7 @@ let running_under_test_executable () =
   let basename =
     Sys.executable_name |> Filename.basename |> String.lowercase_ascii
   in
-  String.length basename >= 5 && String.sub basename 0 5 = "test_"
+  String.length basename >= 5 && String.starts_with ~prefix:"test_" basename
 
 (** #9903: production base-path safeguard for test executables.
 

--- a/lib/coord/coord_git.ml
+++ b/lib/coord/coord_git.ml
@@ -302,9 +302,9 @@ let list ~base_path =
         let branch = ref "" in
         List.iter
           (fun line ->
-            if String.length line > 9 && String.sub line 0 9 = "worktree " then
+            if String.length line > 9 && String.starts_with ~prefix:"worktree " line then
               path := String.sub line 9 (String.length line - 9)
-            else if String.length line > 7 && String.sub line 0 7 = "branch " then
+            else if String.length line > 7 && String.starts_with ~prefix:"branch " line then
               branch := String.sub line 7 (String.length line - 7))
           block;
         if !path <> "" then

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -69,7 +69,7 @@ let test_exec_home_guard ~op path =
     Sys.executable_name |> Filename.basename |> String.lowercase_ascii
   in
   let is_test_exec =
-    String.length basename >= 5 && String.sub basename 0 5 = "test_"
+    String.length basename >= 5 && String.starts_with ~prefix:"test_" basename
   in
   if not is_test_exec then ()
   else

--- a/lib/ocaml/session_tracker/test/test_session_tracker_qa.ml
+++ b/lib/ocaml/session_tracker/test/test_session_tracker_qa.ml
@@ -48,9 +48,9 @@ let escape_string s =
 
 let parse_connection_url url =
   let url =
-    if String.length url > 13 && String.sub url 0 13 = "postgresql://" then
+    if String.length url > 13 && String.starts_with ~prefix:"postgresql://" url then
       String.sub url 13 (String.length url - 13)
-    else if String.length url > 11 && String.sub url 0 11 = "postgres://" then
+    else if String.length url > 11 && String.starts_with ~prefix:"postgres://" url then
       String.sub url 11 (String.length url - 11)
     else
       url

--- a/lib/tool_misc_web_search.ml
+++ b/lib/tool_misc_web_search.ml
@@ -118,7 +118,7 @@ let decode_html_entities text =
       | Some semi ->
           let entity = String.sub basic index (semi - index + 1) in
           if String.length entity >= 4
-             && String.sub entity 0 2 = "&#"
+             && String.starts_with ~prefix:"&#" entity
           then (
             match decode_numeric entity with
             | Some _ -> loop (semi + 1)


### PR DESCRIPTION
## What

`String.sub s 0 N = "<prefix>"` 패턴 11 hunk를 `String.starts_with ~prefix:"<prefix>" s`로 교체. #10532 sweep 1차의 후속 — 단순 prefix 비교만 묶음.

## Files

- `lib/coord/coord_git.ml`: `git worktree list --porcelain` 파싱 (worktree/branch prefix) — `coord_worktrees` API 호출마다 N라인
- `lib/anti_rationalization.ml`: governance APPROVE/REJECT decision 파서 — keeper governance turn 마다 1회
- `lib/cdal/adversarial_eval.ml`: changed_paths의 `test_*` 분류 — adversarial harness당 N파일
- `lib/config/env_config_core.ml`: 실행파일 basename `test_*` 검사 — process bootstrap 1회
- `lib/fs_compat/fs_compat.ml`: 동상의 base path safeguard — process bootstrap 1회
- `lib/ocaml/session_tracker/test/test_session_tracker_qa.ml`: PG URL prefix 분기
- `lib/tool_misc_web_search.ml`: HTML entity `&#` 파싱 — search 결과 디코딩마다 N entity

## Why

각 매치는 substring을 새로 alloc해서 prefix 비교. `String.starts_with` (Stdlib OCaml 5.0+)는 byte-wise loop, alloc 없음. 길이 가드는 의미 보존 위해 유지.

## Test

`OCAMLPARAM='_,warn-error=+a' dune build @check` clean.

## Note

`gh_command_validation.ml` (5건, lowercase 처리) + `resilience.ml` (2건, error-message magic) + `audit_log.ml` (이미 #10532에 포함)는 별도 PR로 분리 — review 컨텍스트가 다름.
