### PR TITLE
feat(design-system): absorb bonsai --shadow-* (4 of 5) into canonical tokens.css (PR-S3c)

### DIFF
--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -788,3 +788,35 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
   --radius-sm: 0;
   --radius-md: 0;
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   BONSAI STRUCTURAL TOKENS (shadow primitives)
+   ───────────────────────────────────────────────────────────────────
+   4 tokens with theme-specific overrides. `--shadow-inset` is NOT
+   absorbed here — dashboard tokens.css already defines it with a
+   different semantic (top-edge highlight vs bonsai's full ring).
+   Resolution deferred to a later PR.
+   ═══════════════════════════════════════════════════════════════════ */
+
+:root {
+  --shadow-card:   0 1px 4px rgba(0, 0, 0, 0.5);
+  --shadow-panel:  0 2px 12px rgba(0, 0, 0, 0.6);
+  --shadow-glow:   0 0 20px var(--accent-glow);
+  --shadow-raised: 0 8px 24px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--border-highlight);
+}
+
+[data-theme="cyberpunk"] {
+  --shadow-panel: 0 0 16px rgba(106, 47, 214, 0.3);
+  --shadow-glow:  0 0 24px rgba(0, 255, 204, 0.2), 0 0 48px rgba(0, 255, 204, 0.05);
+}
+
+[data-theme="terminal"] {
+  --shadow-panel: 0 0 8px rgba(0, 255, 0, 0.1);
+  --shadow-glow:  0 0 16px rgba(0, 255, 0, 0.15);
+}
+
+[data-theme="parchment"] {
+  --shadow-panel: 0 1px 2px rgba(0,0,0,0.06), 0 0 0 1px rgba(0,0,0,0.06);
+  --shadow-card:  0 1px 0 rgba(0,0,0,0.04);
+  --shadow-glow:  none;
+}


### PR DESCRIPTION
## Summary

PR-S3 세 번째 슬라이스 — bonsai `--shadow-*` 4종 absorb (5종 중). PR-S3b (#10535) 위에 stack.

## 추가 토큰

```css
/* :root */
--shadow-card:   0 1px 4px rgba(0, 0, 0, 0.5);
--shadow-panel:  0 2px 12px rgba(0, 0, 0, 0.6);
--shadow-glow:   0 0 20px var(--accent-glow);
--shadow-raised: 0 8px 24px rgba(0,0,0,0.55), 0 0 0 1px var(--border-highlight);

/* cyberpunk: panel + glow */
/* terminal:  panel + glow */
/* parchment: panel + card override + glow:none */
/* paper:     inherits :root */
```

## 명시적 미포함: `--shadow-inset` (충돌)

| Surface | 정의 | 의미 |
|---------|------|------|
| dashboard `tokens.css:282` | `inset 0 1px 0 rgb(255 255 255 / .03)` | top-edge highlight |
| bonsai `colors_and_type.css:81` | `inset 0 0 0 1px rgba(196,162,101,0.25)` | full ring border |

같은 이름이 다른 시각 의미를 가짐. SSOT 통합 작업 중 발견된 첫 충돌. 후속 PR(S3g)에서 다음 셋 중 하나 결정:

1. bonsai 측 rename (`--shadow-ring` 등)
2. dashboard 측 rename
3. 둘 다 namespace prefix (`--shadow-inset-edge` vs `--shadow-inset-ring`)

## 안전성

- **시각 회귀 0**: bonsai surface는 자기 colors_and_type.css 계속 사용. dual definition 공존, 값 동일 → cascade resolve 안전.
- **dashboard 영향 0**: dashboard 컴포넌트가 `--shadow-card/panel/glow/raised` 참조 안 함.

## Stack

base = `feat/design-system-absorb-radius` (PR-S3b #10535)

## 후속

- PR-S3d: `--font-body/display/ui` (theme별 override)
- PR-S3e: color fill pair × 7 (parchment-only)
- PR-S3f: `--scrollbar-*`, `--ink-5/6` (parchment-only)
- PR-S3g: `--shadow-inset` 충돌 해소
- PR-S2.5: bonsai SSOT redirect (S3a-g 완료 후)

## Test plan

- [ ] CI green
- [ ] CSS validity
- [ ] bonsai 시각 회귀 0 (자기 파일 계속 사용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
