### PR TITLE
feat(design-system): absorb bonsai shadow + font tokens (PR-S3c restore + S3d)

### DIFF
--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -828,3 +828,63 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
   --radius-sm: 0;
   --radius-md: 0;
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   BONSAI STRUCTURAL TOKENS (shadow primitives)
+   ───────────────────────────────────────────────────────────────────
+   4 tokens with theme-specific overrides. `--shadow-inset` is NOT
+   absorbed here — dashboard tokens.css already defines it with a
+   different semantic (top-edge highlight vs bonsai's full ring).
+   Resolution deferred to a later PR.
+   ═══════════════════════════════════════════════════════════════════ */
+
+:root {
+  --shadow-card:   0 1px 4px rgba(0, 0, 0, 0.5);
+  --shadow-panel:  0 2px 12px rgba(0, 0, 0, 0.6);
+  --shadow-glow:   0 0 20px var(--accent-glow);
+  --shadow-raised: 0 8px 24px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--border-highlight);
+}
+
+[data-theme="cyberpunk"] {
+  --shadow-panel: 0 0 16px rgba(106, 47, 214, 0.3);
+  --shadow-glow:  0 0 24px rgba(0, 255, 204, 0.2), 0 0 48px rgba(0, 255, 204, 0.05);
+}
+
+[data-theme="terminal"] {
+  --shadow-panel: 0 0 8px rgba(0, 255, 0, 0.1);
+  --shadow-glow:  0 0 16px rgba(0, 255, 0, 0.15);
+}
+
+[data-theme="parchment"] {
+  --shadow-panel: 0 1px 2px rgba(0,0,0,0.06), 0 0 0 1px rgba(0,0,0,0.06);
+  --shadow-card:  0 1px 0 rgba(0,0,0,0.04);
+  --shadow-glow:  none;
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   BONSAI STRUCTURAL TOKENS (font stacks)
+   ───────────────────────────────────────────────────────────────────
+   bonsai's display/body/ui font stacks. dashboard already defines
+   `--font-mono` separately (line ~152) — not duplicated here.
+
+   cyberpunk + terminal collapse all stacks to monospace for
+   intentional aesthetic. parchment + paper inherit :root.
+   ═══════════════════════════════════════════════════════════════════ */
+
+:root {
+  --font-display: 'Cinzel', 'Noto Sans KR', 'EB Garamond', serif;
+  --font-body:    'EB Garamond', 'Noto Sans KR', Georgia, serif;
+  --font-ui:      'Noto Sans KR', 'IBM Plex Sans KR', -apple-system, sans-serif;
+}
+
+[data-theme="cyberpunk"] {
+  --font-display: 'Share Tech Mono', 'Noto Sans KR', monospace;
+  --font-body:    'Noto Sans KR', sans-serif;
+  --font-ui:      'Share Tech Mono', 'Noto Sans KR', monospace;
+}
+
+[data-theme="terminal"] {
+  --font-display: 'JetBrains Mono', 'Noto Sans KR', monospace;
+  --font-body:    'JetBrains Mono', 'Noto Sans KR', monospace;
+  --font-ui:      'JetBrains Mono', 'Noto Sans KR', monospace;
+}


### PR DESCRIPTION
## Summary

PR-S3c (#10545)는 MERGED로 표시되어 있지만 **실제로는 origin/main에 도달하지 못했다**. base가 stack branch (`feat/design-system-absorb-radius`)였기 때문에 그 stack branch에만 squash됐고, PR-S3b(#10535)가 main에 rebase + force-push되면서 stack의 S3c patch가 사라짐. 이후 #10535 squash 머지 시 main에는 S3b만 들어감.

이 PR이 두 가지를 함께 처리한다:

1. **PR-S3c 복원** — shadow primitives 4종 (32 lines)
2. **PR-S3d 본래 의도** — font stacks 3종 (28 lines)

main에 +60 lines, deletions 0, 다른 토큰 의미 변경 없음.

## 추가 토큰

### Shadow primitives (S3c 복원)

```css
:root {
  --shadow-card:   0 1px 4px rgba(0, 0, 0, 0.5);
  --shadow-panel:  0 2px 12px rgba(0, 0, 0, 0.6);
  --shadow-glow:   0 0 20px var(--accent-glow);
  --shadow-raised: 0 8px 24px rgba(...), 0 0 0 1px var(--border-highlight);
}
/* cyberpunk + terminal + parchment overrides */
```

`--shadow-inset` 미포함 (의도). bonsai vs dashboard semantic 충돌 → PR-S3g(#10562)에서 `--shadow-ring` 으로 rename되어 처리.

### Font stacks (S3d)

```css
:root {
  --font-display: 'Cinzel', 'Noto Sans KR', 'EB Garamond', serif;
  --font-body:    'EB Garamond', 'Noto Sans KR', Georgia, serif;
  --font-ui:      'Noto Sans KR', 'IBM Plex Sans KR', -apple-system, sans-serif;
}
/* cyberpunk + terminal: monospace 통일 */
```

`--font-mono` 미포함 (이미 dashboard tokens.css:152 정의). 향후 PR-S3h에서 stack 정합성 검토.

## 안전성

- **시각 회귀 0**: bonsai surface는 자기 colors_and_type.css 계속 사용. 추가만 dual definition으로 안전 공존.
- **dashboard 영향 0**: dashboard 컴포넌트는 `--shadow-*`/`--font-display/body/ui` 미참조 (Tailwind utility 사용).
- **theme override 정확성**: `parchment` / `paper`는 colors_and_type.css에서도 override 안 함 → :root 값 상속 동일.

## 사고 분석 (post-mortem)

원인: stack PR(#10545)이 `base=feat/design-system-absorb-radius`로 머지됐는데, 그 base branch가 이후 main에 rebase + force-push되며 stack 변경분이 소실. GitHub은 mergeCommit oid를 보유해 PR을 MERGED로 표시하지만 commit이 main의 ancestor가 아니므로 코드는 도달 못 함.

방지: stack PR을 머지할 때 base를 main으로 변경하거나, base PR force-push 시 stack 의존 patches가 보존되는지 확인.

후속: feedback memory 추가 권장 — `feedback_stack-pr-base-force-push-loses-patches.md`.

## Test plan

- [ ] CI green
- [ ] CSS validity
- [ ] bonsai 시각 회귀 0 (자기 파일 사용)
- [ ] main의 tokens.css에 `--shadow-card`, `--font-display` 둘 다 존재 확인 (post-merge)

## Related

- 사고 origin: PR-S3c #10545 (state=MERGED but not main ancestor)
- Stack base: PR-S3b #10535 (이미 머지)
- Followup: PR-S3e #10555, PR-S3f #10556, PR-S3h #10563

🤖 Generated with [Claude Code](https://claude.com/claude-code)
