### PR TITLE
perf(gh-validation): replace String.sub equality with String.starts_with (5 hunks)

### DIFF
--- a/lib/gh_command_validation.ml
+++ b/lib/gh_command_validation.ml
@@ -108,10 +108,10 @@ let extract_gh_api_method cmd =
     | [] -> "GET"
     | "-X" :: m :: _ | "--method" :: m :: _ -> String.uppercase_ascii m
     | tok :: _ when String.length tok > 9
-                    && String.sub tok 0 9 = "--method=" ->
+                    && String.starts_with ~prefix:"--method=" tok ->
       String.uppercase_ascii (String.sub tok 9 (String.length tok - 9))
     | tok :: _ when String.length tok > 3
-                    && String.sub tok 0 3 = "-X=" ->
+                    && String.starts_with ~prefix:"-X=" tok ->
       String.uppercase_ascii (String.sub tok 3 (String.length tok - 3))
     | _ :: rest -> find rest
   in
@@ -156,7 +156,7 @@ let extract_gh_repo_owner cmd =
   let rec find = function
     | [] -> None
     | "--repo" :: slug :: _ | "-R" :: slug :: _ -> owner_of_slug slug
-    | tok :: rest when String.length tok > 7 && String.sub tok 0 7 = "--repo=" ->
+    | tok :: rest when String.length tok > 7 && String.starts_with ~prefix:"--repo=" tok ->
       let slug = String.sub tok 7 (String.length tok - 7) in
       (match owner_of_slug slug with
        | Some _ as o -> o
@@ -265,9 +265,9 @@ let has_implicit_post_flags parts =
     | tok :: rest ->
       let tok_lower = String.lowercase_ascii tok in
       if tok = "-f" || tok = "-F" || tok = "--field" || tok = "--raw-field"
-         || String.length tok_lower > 3 && String.sub tok_lower 0 3 = "-f="
-         || String.length tok_lower > 8 && String.sub tok_lower 0 8 = "--field="
-         || String.length tok_lower > 12 && String.sub tok_lower 0 12 = "--raw-field="
+         || String.length tok_lower > 3 && String.starts_with ~prefix:"-f=" tok_lower
+         || String.length tok_lower > 8 && String.starts_with ~prefix:"--field=" tok_lower
+         || String.length tok_lower > 12 && String.starts_with ~prefix:"--raw-field=" tok_lower
       then true
       else check rest
   in


### PR DESCRIPTION
## What

`lib/gh_command_validation.ml`의 5건 `String.sub tok 0 N = "<flag>"` → `String.starts_with ~prefix:"<flag>" tok`. 길이 가드 유지.

- HTTP method 추출: `--method=`, `-X=`
- repo 검사: `--repo=`
- mutating field 검사 (lowercased): `-f=`, `--field=`, `--raw-field=`

## Why

`gh_command_validation`은 keeper의 GH CLI invocation 검증 hot path — 매 `gh` invocation 시 token마다 호출. 5 매치 모두 substring을 새로 alloc해서 prefix 비교. `String.starts_with` (Stdlib OCaml 5.0+)는 byte-wise loop, alloc 0.

`-f=`/`--field=`/`--raw-field=`는 caller가 이미 `String.lowercase_ascii tok`로 lowercased token을 비교하므로, prefix가 ASCII literal일 때 의미 동등.

## Test

`OCAMLPARAM='_,warn-error=+a' dune build @check` clean.

## Sweep series

- #10532 sweep 1 (8 파일)
- #10543 sweep 2 (7 파일)
- 본 PR: gh-cmd 단독 (lowercase context 별도 분리)
- 후속: `lib/coord/resilience.ml` (error-message magic, 보수적 검토 필요)
