### PR TITLE
feat(metrics): emit Prometheus counter on keeper contract violations (#10530)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -2348,6 +2348,10 @@ let run_turn
                  meta.name result.turns
                  (List.length actual_keeper_tool_names)
                  reason;
+               Prometheus.inc_counter
+                 Prometheus.metric_keeper_contract_violations
+                 ~labels:[ ("keeper_name", meta.name); ("kind", "passive") ]
+                 ();
                Error (contract_violation_error reason)
            | Ok (), None ->
                receipt_tool_contract_result_ref := tool_contract_status ();
@@ -2374,6 +2378,10 @@ let run_turn
                  meta.name result.turns
                  (List.length actual_keeper_tool_names)
                  contract_str reason;
+               Prometheus.inc_counter
+                 Prometheus.metric_keeper_contract_violations
+                 ~labels:[ ("keeper_name", meta.name); ("kind", "text_only") ]
+                 ();
                Error (contract_violation_error reason)
          in
          let finalize_response_text raw_response_text =

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -187,6 +187,12 @@ let metric_keeper_cache_read_tokens =
 let metric_keeper_usage_anomalies =
   "masc_keeper_usage_anomalies_total"
 
+(** #10530: keeper required-tool-contract violations (passive-only or
+    text-only turns rejected by the keeper agent loop).
+    Labels: keeper_name, kind \in \{passive,text_only\}. *)
+let metric_keeper_contract_violations =
+  "masc_keeper_contract_violations_total"
+
 (* #10047: [append_metrics_snapshot] failures in [keeper_turn.ml] and
    [keeper_unified_turn.ml] used to be log-only, masking state/metric
    divergence. Surface as a counter so dashboards can alert on silent
@@ -925,6 +931,9 @@ let init () =
     Counter;
   add metric_keeper_usage_anomalies
     "Keeper turns whose reported usage was marked untrusted (labels: keeper_name, model, reason)"
+    Counter;
+  add metric_keeper_contract_violations
+    "Keeper turns rejected for required-tool-contract violations (labels: keeper_name, kind={passive|text_only}). #10530."
     Counter;
   (* Tool schema budget gauges — set once at boot via
      [set_tool_schema_stats]. Covers #7483 Step 1. *)

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -74,6 +74,11 @@ val metric_keeper_output_tokens : string
 val metric_keeper_cache_creation_tokens : string
 val metric_keeper_cache_read_tokens : string
 val metric_keeper_usage_anomalies : string
+
+(** #10530: keeper required-tool-contract violations.
+    Labels: keeper_name, kind \in \{passive,text_only\}. *)
+val metric_keeper_contract_violations : string
+
 val metric_keeper_metric_emit_dropped : string
 val metric_keeper_context_max_observed : string
 (** #9953: bucketed counter for observed [context_max] values.


### PR DESCRIPTION
## 요약

Live: 18 contract violations / 7 keeper / day (executor 6x hottest). ERROR log line만 있고 fleet-wide counter 없음 → dashboard alert 불가능, 만성 offender 식별 불가. Prometheus counter 추가.

## 변경

- \`lib/prometheus.ml/.mli\`: \`metric_keeper_contract_violations\` (\`masc_keeper_contract_violations_total\`)
- \`lib/keeper/keeper_agent_run.ml\`: 2 violation site에 \`inc_counter\` 호출
  - passive-only tools rejection (\`kind=passive\`)
  - text-only response rejection (\`kind=text_only\`)
- Labels: \`keeper_name\`, \`kind\`

## 검증

\`\`\`
DUNE_CACHE=disabled dune build --root . --cache=disabled @check  → EXIT=0
\`\`\`

## 비목표 (이번 PR 아님)

- Option A (violation reason을 next-cascade prompt에 inject): cascade FSM state 통한 plumbing 필요. 별도 multi-cycle PR.
- Option B (consecutive-violation streak escalation: pause keeper at N=3): 본 metric의 derived signal로 추후 가능.
- Option C (dashboard chip with 한국어 \"계약 위반 N회\"): metric exposed 후 별도 UI PR.

본 PR은 *observability-only* — retry/cascade/keeper 행동 변경 없음.

## 영향

- Dashboard에 fleet-wide contract violation rate graph 가능 (Grafana / Prometheus query)
- \`rate(masc_keeper_contract_violations_total{kind=\"passive\"}[5m])\` 등 alert
- 만성 offender (executor 6x) 즉시 식별

## 관련

- Issue: \`#10530\`
- Cross: \`#10474\` (cascade exhaustion family), \`#10528\` (cascade ERROR observability)

## Defensive guards

Draft + \`do-not-merge\` 라벨 (운영자 승인 후 머지).