### PR TITLE
refactor(keeper): migrate 3 sandbox hardcoded constants to Env_config_sandbox SSOT (#10426 P2c)

### DIFF
--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -158,7 +158,9 @@ let start_managed_container
                       image;
                       "sh";
                       "-lc";
-                      "trap : TERM INT; while :; do sleep 3600; done";
+                      Printf.sprintf
+                        "trap : TERM INT; while :; do sleep %d; done"
+                        (Env_config_sandbox.Cleanup.managed_sleep_sec ());
                     ]
                   in
                   let st, out =

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -86,8 +86,12 @@ type docker_preflight =
     next_actions : string list;
   }
 
-let docker_preflight_min_sec = 5.0
-let docker_preflight_max_sec = 20.0
+(* P2c: literals lifted to Env_config_sandbox.Preflight (#10426 P2c).
+   Today the SSOT getters return the same hardcoded values; future env
+   wiring (per Env_config_sandbox.Preflight doc) tunes these without
+   touching this file. *)
+let docker_preflight_min_sec = Env_config_sandbox.Preflight.min_timeout_sec ()
+let docker_preflight_max_sec = Env_config_sandbox.Preflight.max_timeout_sec ()
 
 let docker_preflight_timeout ~timeout_sec =
   min docker_preflight_max_sec (max docker_preflight_min_sec timeout_sec)

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -325,5 +325,10 @@ let cleanup (t : t) =
         Keeper_sandbox_runtime.docker_command_argv ()
         @ [ "rm"; "-f"; container_name ]
       in
-      let _st, _out = run_argv_with_status_retry_eintr ~timeout_sec:5.0 argv in
+      let _st, _out =
+        run_argv_with_status_retry_eintr
+          ~timeout_sec:(Env_config_sandbox.Shell_timeout.timeout_sec
+                          ~bucket:Cleanup_rm ())
+          argv
+      in
       ()


### PR DESCRIPTION
## Why

Final scaffolding step for the sandbox config SSOT track (#10426). After #10480 (P2a SSOT) and #10536 (P2b alias delegation), three sandbox-related literals still lived as hardcoded constants in `lib/keeper/`. This PR migrates them to call `Env_config_sandbox` directly, completing the call-site coupling. Behavior is byte-for-byte preserved — the SSOT getters return the same historical values; future env wiring tunes them without touching keeper code.

## What

| File | Lines | Constant | New SSOT call |
|------|-------|----------|---------------|
| `lib/keeper/keeper_sandbox_runtime.ml` | 89-90 | `docker_preflight_min_sec = 5.0` / `max_sec = 20.0` (module bindings) | `Env_config_sandbox.Preflight.min_timeout_sec ()` / `max_timeout_sec ()` |
| `lib/keeper/keeper_sandbox_control.ml` | 161 | `"sleep 3600"` string literal (managed container init) | `Printf.sprintf "... sleep %d ..." (Env_config_sandbox.Cleanup.managed_sleep_sec ())` |
| `lib/keeper/keeper_turn_sandbox_runtime.ml` | 328 | `~timeout_sec:5.0` (cleanup `docker rm -f`) | `~timeout_sec:(Env_config_sandbox.Shell_timeout.timeout_sec ~bucket:Cleanup_rm ())` |

The first row keeps the value-binding semantics (frozen at module load, not per-call) by calling `()` at the binding site. `docker_preflight_timeout` clamp helper at line 92-93 continues to read both bounds via the same compact name.

The `sleep 3600` migration switches from a fixed string fragment to `Printf.sprintf` because the duration is now dynamic.

## Verification

- `dune build lib/ --root . --cache=disabled` → RC=0.
- `dune exec test/test_keeper_docker_read.exe` → 32/32 pass (sandbox profile invariants: hard_mode, relax_fs, network mode, container labels, cleanup labels, preflight clamp).

## Diff

```
3 files changed, 15 insertions(+), 4 deletions(-)
```

## Independence from #10536 (P2b)

P2b aliases `KeeperSandbox` → `Env_config_sandbox`. P2c migrates direct-call sites. Different files (`env_config_keeper.ml` vs `keeper_sandbox_*.ml`), no conflict — they can land in either order.

## What remains

- **P2d**: `Config_doctor.analyze_live` JSON wiring for `effective_config_json` (operator-facing `masc doctor config --json`).
- **Default-deviation analysis** (separate PR): Alerting 20s, Pr_review 30s/5s, Gh_shared 5s, `keeper_exec_shell.ml:335` PATH probe — decide bump default vs. new caller variant vs. keep hardcoded.
- **Correctness series (C1-C3)** (separate plan): EINTR retry remaining-time tracking, `Eio.Switch.on_release` cleanup, `effective_sandbox_profile` resolution dedup.

---

Refs: #10426 (audit + plan), #10480 (P2a SSOT scaffold), #10536 (P2b alias delegation).
