### PR TITLE
feat(auth): observability warn on legacy alias-fallback (RFC P2-b)

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -345,8 +345,25 @@ let load_credential_with_aliases config agent_name : agent_credential option =
   match load_credential config agent_name with
   | Some _ as c -> c
   | None ->
-      legacy_credential_aliases agent_name
-      |> List.find_map (load_credential config)
+      let aliases = legacy_credential_aliases agent_name in
+      let result = List.find_map (load_credential config) aliases in
+      (match result with
+       | Some cred ->
+           (* Observability for RFC P2-b: every silent alias-fallback hit
+              indicates a dual-identity caller (e.g. requested
+              [keeper-sangsu-agent] while only bare [sangsu] credential
+              exists, or vice versa). The fallback preserves availability
+              by routing to the legacy credential, but [cred.agent_name]
+              reveals the file the request was served from — different
+              from the requested name. P2-a's [load_credential_of]
+              surfaces this as [Credential_mismatch]; this warn measures
+              how often the legacy fallback is still load-bearing while
+              migrations are in flight. *)
+           Log.Auth.warn
+             "[identity_drift:alias_fallback] requested=%s resolved=%s aliases_tried=[%s]"
+             agent_name cred.agent_name (String.concat ";" aliases)
+       | None -> ());
+      result
 
 type load_credential_error =
   | Credential_missing of { ctx_agent_name : string }


### PR DESCRIPTION
## Summary

P2-a (#10491 merged) added \`Auth.load_credential_of\` for explicit dual-identity surfacing. Before bulk-migrating callers (P2-c~e), we need production data on how often the legacy alias fallback in \`load_credential_with_aliases\` actually fires.

## 변경

\`lib/auth.ml\` — emit \`Log.Auth.warn [identity_drift:alias_fallback] requested=X resolved=Y aliases_tried=[...]\` whenever the alias path returns Some. Behavior unchanged — same credential returned.

## 증거 기반

- 6 keepers (\`sangsu / issue_king / janitor / masc-improver / nick0cave / qa-king\`) 보유 dual cred files (bare nickname + canonical \`keeper-X-agent\`, 다른 token).
- Bare cred mtime: \`2026-04-24\`. Canonical cred mtime: \`2026-04-26\` (mass-create migration).
- 어떤 caller가 bare nickname 으로 dispatch 시 alias fallback이 silent 작동 중. 빈도/주체 미측정.

## 효과

- Production에서 alias fallback이 load-bearing 인 빈도/keeper별 측정 가능.
- P2-c~e migration 의 우선순위 결정 데이터 확보.
- 행동 변화 0 — fallback 동작 동일.

## Risk

Low — Log.Auth.warn 한 줄 추가. 기존 caller 영향 0.

## Test plan

- [x] \`dune build lib/\` green (no warn-error)
- [ ] CI green (Build/Test/Lint/Health/Meta Guards)
- [ ] post-merge: log grep \`identity_drift:alias_fallback\` 빈도 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)