### PR TITLE
fix(config): remove codex_cli from 4 seed cascades (#10097)

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -1,30 +1,25 @@
 comment = "Checked-in seed for cascade authoring. Keep repo defaults boring: bootstrap keeper profile big_three, local keeper profile ollama_only, system-only fallback/judge/phase-routing profiles (default, governance_judge, operator_judge, local_only, local_recovery, tool_rerank), and move personal/live experiments to $MASC_BASE_PATH/.masc/config/cascade.toml."
 
 [default]
-comment = "System-only fallback profile for unknown/missing cascade names. Mirrors big_three without Claude CLI so automatic recovery does not pull Claude by default."
+comment = "System-only fallback profile for unknown/missing cascade names. codex_cli removed per #10097 (lib/oas_worker_exec_transport.ml:16-26 — keeper-bound MCP omission strips 35+ runtime tools per turn → end_turn early stops). Server config validator rejects weight=0, so removal of the model entry is the only path. Restore once OAS transport ships per-turn auth via stdin/env (not argv-leak-prone TOML override)."
 models = [
-  { model = "codex_cli:auto", weight = 1 },
   { model = "gemini_cli:auto", weight = 1 },
-  { model = "codex_cli:gpt-5.3-codex-spark", weight = 1 },
 ]
 temperature = 0.2
 max_tokens = 16384
 keeper_assignable = false
 
 [big_three]
-comment = "Canonical keeper bootstrap profile exposed by the checked-in seed. Automatic keepers stay off Claude CLI unless an operator opts in via live config."
+comment = "Canonical keeper bootstrap profile. codex_cli removed per #10097 (keeper-bound MCP tool omission strips 35+ runtime tools per turn). Server config validator rejects weight=0, hence model removal. Effective lane = gemini_cli until codex_cli auth-header path lands without argv leak."
 models = [
-  { model = "codex_cli:auto", weight = 1 },
   { model = "gemini_cli:auto", weight = 1 },
-  { model = "codex_cli:gpt-5.3-codex-spark", weight = 1 },
 ]
 temperature = 0.2
 max_tokens = 16384
 
 [governance_judge]
-comment = "System-only dashboard governance judge profile. Explicitly defined so background judge loops do not inherit fallback providers such as Claude CLI."
+comment = "System-only dashboard governance judge profile. codex_cli removed per #10097 (judge probes also lose keeper-bound MCP surface)."
 models = [
-  { model = "codex_cli:auto", weight = 1 },
   { model = "gemini_cli:auto", weight = 1 },
 ]
 temperature = 0.2
@@ -32,9 +27,8 @@ max_tokens = 16384
 keeper_assignable = false
 
 [operator_judge]
-comment = "System-only dashboard operator judge profile. Mirrors governance_judge so background control loops stay off Claude CLI by default."
+comment = "System-only dashboard operator judge profile. codex_cli removed per #10097."
 models = [
-  { model = "codex_cli:auto", weight = 1 },
   { model = "gemini_cli:auto", weight = 1 },
 ]
 temperature = 0.2


### PR DESCRIPTION
## Summary
- 4 seed cascades (`default`, `big_three`, `governance_judge`, `operator_judge`)에서 `codex_cli` model entry 자체 제거
- #10097 keeper-bound MCP tool omission으로 35+ runtime tool 손실 → `end_turn` early stops 발생
- Live config `local_with_kimi_coding_with_glm` 보존 (operator opt-in)

## Why
Production fleet 진단 (2026-04-26, /tmp/masc-restart-54.log):
- 12/14 docker-sandbox keepers WARN: "structural provider limitation for keeper-X-agent"
- **18 `end_turn` early stops / 11 keeper cycles** (60% turn before budget exhausted)
- `proactive_idle_sec` / `cooldown_sec` uncorrelated (0 events)

근거 코드: `lib/oas_worker_exec_transport.ml:16-26` 주석

**왜 weight=0이 아니라 model 제거?** Server config validator는 `weight > 0` 강제 (`/api/v1/cascade/config/raw` POST에서 "invalid TOML: expected default.models[0].weight to be > 0" 거부). 모델 자체 제거가 유일한 path.

## Trade-off
- (+) 새 사용자/배포가 setup 시 즉시 useful turn (gemini_cli 잔존)
- (-) Codex Spark token surplus 미사용 — 단 operator가 `local_with_kimi_coding_with_glm` opt-in 시 여전히 사용 가능
- (+) Argv-leak 보안 우려도 회피 (codex_cli 자체 미사용)

## Verification (Production Live)
- Sun Apr 26 12:34 KST: live cascade.toml에서 codex_cli 제거 + POST /api/v1/cascade/config/raw → validation_status=validated
- cascade.json mtime 12:33:52 (server materialize 후)
- big_three keeper-assignable cascade providers: ['claude_code', 'gemini_cli'] (codex_cli 사라짐)

## Reverting
codex_cli model entry를 cascade에 복원. 단 다음 조건 후에만:
1. OAS #10097 follow-up (per-turn auth via stdin/env, argv-leak 회피) 머지
2. masc-mcp `oas_worker_exec_transport.ml:523-534` omission gate 정정

## Test plan
- [ ] CI cascade-related test 통과 확인
- [ ] OAS #10097 follow-up tracking issue 생성

## Diagnosis Trace
- agent #21 (proactive turn termination): codex_cli omission causally upstream of `end_turn` early stops
- agent #20 (OAS feasibility): structural limitation 가정 부정 — 실제는 argv-leak prevention policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)