### PR TITLE
feat(design-system): absorb bonsai paper-theme color extras + ink-5/6 (PR-S3e)

### DIFF
--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -761,3 +761,30 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
   --space-7: 48px;
   --space-8: 64px;
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   BONSAI STRUCTURAL TOKENS (radius primitives)
+   ───────────────────────────────────────────────────────────────────
+   cyberpunk + terminal flatten xs/sm/md to 0 (sharp corners).
+   parchment + paper inherit :root values.
+   ═══════════════════════════════════════════════════════════════════ */
+
+:root {
+  --radius-xs:   2px;
+  --radius-sm:   4px;
+  --radius-md:   6px;
+  --radius-lg:   12px;
+  --radius-pill: 999px;
+}
+
+[data-theme="cyberpunk"] {
+  --radius-xs: 0;
+  --radius-sm: 0;
+  --radius-md: 0;
+}
+
+[data-theme="terminal"] {
+  --radius-xs: 0;
+  --radius-sm: 0;
+  --radius-md: 0;
+}

--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -820,3 +820,31 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
   --shadow-card:  0 1px 0 rgba(0,0,0,0.04);
   --shadow-glow:  none;
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   BONSAI STRUCTURAL TOKENS (font stacks)
+   ───────────────────────────────────────────────────────────────────
+   bonsai's display/body/ui font stacks. dashboard already defines
+   `--font-mono` separately (line ~152) — not duplicated here.
+
+   cyberpunk + terminal collapse all stacks to monospace for
+   intentional aesthetic. parchment + paper inherit :root.
+   ═══════════════════════════════════════════════════════════════════ */
+
+:root {
+  --font-display: 'Cinzel', 'Noto Sans KR', 'EB Garamond', serif;
+  --font-body:    'EB Garamond', 'Noto Sans KR', Georgia, serif;
+  --font-ui:      'Noto Sans KR', 'IBM Plex Sans KR', -apple-system, sans-serif;
+}
+
+[data-theme="cyberpunk"] {
+  --font-display: 'Share Tech Mono', 'Noto Sans KR', monospace;
+  --font-body:    'Noto Sans KR', sans-serif;
+  --font-ui:      'Share Tech Mono', 'Noto Sans KR', monospace;
+}
+
+[data-theme="terminal"] {
+  --font-display: 'JetBrains Mono', 'Noto Sans KR', monospace;
+  --font-body:    'JetBrains Mono', 'Noto Sans KR', monospace;
+  --font-ui:      'JetBrains Mono', 'Noto Sans KR', monospace;
+}

--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -788,3 +788,35 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
   --radius-sm: 0;
   --radius-md: 0;
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   BONSAI STRUCTURAL TOKENS (shadow primitives)
+   ───────────────────────────────────────────────────────────────────
+   4 tokens with theme-specific overrides. `--shadow-inset` is NOT
+   absorbed here — dashboard tokens.css already defines it with a
+   different semantic (top-edge highlight vs bonsai's full ring).
+   Resolution deferred to a later PR.
+   ═══════════════════════════════════════════════════════════════════ */
+
+:root {
+  --shadow-card:   0 1px 4px rgba(0, 0, 0, 0.5);
+  --shadow-panel:  0 2px 12px rgba(0, 0, 0, 0.6);
+  --shadow-glow:   0 0 20px var(--accent-glow);
+  --shadow-raised: 0 8px 24px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--border-highlight);
+}
+
+[data-theme="cyberpunk"] {
+  --shadow-panel: 0 0 16px rgba(106, 47, 214, 0.3);
+  --shadow-glow:  0 0 24px rgba(0, 255, 204, 0.2), 0 0 48px rgba(0, 255, 204, 0.05);
+}
+
+[data-theme="terminal"] {
+  --shadow-panel: 0 0 8px rgba(0, 255, 0, 0.1);
+  --shadow-glow:  0 0 16px rgba(0, 255, 0, 0.15);
+}
+
+[data-theme="parchment"] {
+  --shadow-panel: 0 1px 2px rgba(0,0,0,0.06), 0 0 0 1px rgba(0,0,0,0.06);
+  --shadow-card:  0 1px 0 rgba(0,0,0,0.04);
+  --shadow-glow:  none;
+}

--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -716,6 +716,22 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
   --ink-2:   #2E2E2C;
   --ink-3:   #515049;
   --ink-4:   #656358;
+  --ink-5:   #9A978D;
+  --ink-6:   #BCB8AC;
+
+  /* Named hue tokens (paper-only) — color/fill pairs from bonsai
+     vocabulary. Used for keeper attribution accents, swimlane categories,
+     and t-* trace frames in the light-on-paper theme. */
+  --forest:  #2D5F4E;  --forest-fill: #CFDFD7;
+  --brass:   #8C6A1E;  --brass-fill:  #E9DDB8;
+  --brick:   #8B3A3A;  --brick-fill:  #E8CFCB;
+  --ember:   #B35A1F;  --ember-fill:  #ECD5BD;
+  --slate:   #3E4A5C;  --slate-fill:  #D6DBE2;
+  --plum:    #5C3E56;  --plum-fill:   #E0D4DE;
+  --teal:    #236874;  --teal-fill:   #CEDEE2;
+
+  --status-idle: var(--ink-5);
+
   --bg-deep:      var(--paper);
   --bg-panel:     var(--paper-2);
   --bg-panel-alt: var(--paper-3);

--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -739,3 +739,25 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
   --t-wait:  #E5E0D1;
   --t-err:   #8B3A3A;
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   BONSAI STRUCTURAL TOKENS (spacing primitives)
+   ───────────────────────────────────────────────────────────────────
+   Bonsai surface uses a 4px-grid spacing scale. These values are
+   theme-invariant (no [data-theme] override in colors_and_type.css).
+
+   Absorbed into canonical tokens.css for SSOT consolidation. Bonsai's
+   colors_and_type.css continues to define the same values until
+   PR-S2.5 redirects bonsai to import canonical tokens.css.
+   ═══════════════════════════════════════════════════════════════════ */
+
+:root {
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+}


### PR DESCRIPTION
## Summary

PR-S3 다섯 번째 슬라이스 — bonsai의 `[data-theme="paper"]` 한정 vocabulary 16종 absorb. PR-S3d (#10546) 위에 stack.

## 추가 토큰 (paper 블록 안)

| 카테고리 | 토큰 | 값 |
|---------|------|-----|
| Ink extension | `--ink-5` `--ink-6` | `#9A978D` `#BCB8AC` |
| Hue (7 pair) | `--forest` `--brass` `--brick` `--ember` `--slate` `--plum` `--teal` | bonsai paper 정의 그대로 |
| Hue fill (7 pair) | `--*-fill` | 각 hue의 light wash |
| Missing override | `--status-idle: var(--ink-5)` | paper-only 누락 보강 |

## 의도적 미변경

기존 paper 블록의 literal hex 정의 (예: `--accent-brass: #8C6A1E`)는 유지. bonsai는 `var(--brass)` 형태로 참조하지만 dashboard는 literal — 결과 색은 같음. 후속 PR-S3h에서 var() 참조로 리팩터링 가능 (paper 블록 SSOT를 bonsai와 동형으로).

## 충돌 분석

| 토큰 | dashboard 다른 위치 | 충돌? |
|-----|---------------------|------|
| `--brass` | `--brass-1/-2/-3/-glow` (raw step), `--brass-soft/-fg/-border/-ring` (semantic role) | ❌ 다른 이름 |
| `--brass-fill` | (없음) | ❌ |
| 나머지 6 hue | (없음) | ❌ |
| `--ink-5/6` | (없음) | ❌ (`--ink-2/3/4`만 있음) |

`paper` 블록 scope 안에서만 정의되어 다른 테마에 누출되지 않음.

## 안전성

- **시각 회귀 0**: paper 테마 활성 시에만 새 토큰 선언, 기존 정의 변경 없음
- **다른 테마 영향 0**: dark-fantasy/cyberpunk/terminal/parchment 무관
- **bonsai 영향 0**: 자기 colors_and_type.css 계속 사용

## Stack

base = `feat/design-system-absorb-font` (PR-S3d #10546)

## 후속

- PR-S3f: `--scrollbar-thumb` / `--scrollbar-thumb-hover` (:root only, 2 tokens) — 마지막 absorb
- PR-S3g: `--shadow-inset` 충돌 해소
- PR-S3h: paper 블록 literal → `var()` 리팩터링 (선택, 시각 회귀 0)
- PR-S2.5: bonsai SSOT redirect (S3a-g 완료 후)

## Test plan

- [ ] CI green
- [ ] CSS validity
- [ ] paper 테마 시각 회귀 0 (기존 정의 보존, 추가만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
