### PR TITLE
feat(design-system): absorb bonsai paper colors + scrollbar (S3e restore + S3f, last absorb 38/38)

### DIFF
--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -904,3 +904,17 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
   --font-body:    'JetBrains Mono', 'Noto Sans KR', monospace;
   --font-ui:      'JetBrains Mono', 'Noto Sans KR', monospace;
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   BONSAI STRUCTURAL TOKENS (scrollbar primitives)
+   ───────────────────────────────────────────────────────────────────
+   Theme-invariant. dashboard surface has its own ::-webkit-scrollbar-
+   thumb rule (uses --line-2/-3) and does not consume these tokens.
+   bonsai surface reads via var(--scrollbar-thumb, var(--border-main))
+   pattern with --border-main fallback when this file is the SSOT.
+   ═══════════════════════════════════════════════════════════════════ */
+
+:root {
+  --scrollbar-thumb:       #2a1f1a;
+  --scrollbar-thumb-hover: #3d2e22;
+}

--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -756,6 +756,22 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
   --ink-2:   #2E2E2C;
   --ink-3:   #515049;
   --ink-4:   #656358;
+  --ink-5:   #9A978D;
+  --ink-6:   #BCB8AC;
+
+  /* Named hue tokens (paper-only) — color/fill pairs from bonsai
+     vocabulary. Used for keeper attribution accents, swimlane categories,
+     and t-* trace frames in the light-on-paper theme. */
+  --forest:  #2D5F4E;  --forest-fill: #CFDFD7;
+  --brass:   #8C6A1E;  --brass-fill:  #E9DDB8;
+  --brick:   #8B3A3A;  --brick-fill:  #E8CFCB;
+  --ember:   #B35A1F;  --ember-fill:  #ECD5BD;
+  --slate:   #3E4A5C;  --slate-fill:  #D6DBE2;
+  --plum:    #5C3E56;  --plum-fill:   #E0D4DE;
+  --teal:    #236874;  --teal-fill:   #CEDEE2;
+
+  --status-idle: var(--ink-5);
+
   --bg-deep:      var(--paper);
   --bg-panel:     var(--paper-2);
   --bg-panel-alt: var(--paper-3);


### PR DESCRIPTION
## Summary

PR-S3 마지막 absorb. PR-S3e(#10555)와 PR-S3f(#10556) 두 patch를 묶어 단일 main 머지로 처리.

**S3c/S3d 사고와 동일 패턴 두 번째 발생**: PR-S3e(#10555)는 GitHub UI상 MERGED지만 base가 stack branch(`feat/design-system-absorb-font`)였기 때문에 그 stack 브랜치에만 squash됨. main에 도달 못 함 — `git merge-base --is-ancestor 3e34d9b90d origin/main`이 false. 이 PR이 S3e 16 토큰을 복원함.

## 추가 토큰 (총 +30 lines, 1 file)

### Paper-theme color extras + ink-5/6 (S3e 복원)

```css
/* paper override 안에 추가 */
--ink-5:   #9A978D;
--ink-6:   #BCB8AC;

/* Named hue tokens (paper-only) — keeper attribution / swimlane / t-* trace */
--forest:  #2D5F4E;  --forest-fill: #CFDFD7;
--brass:   #8C6A1E;  --brass-fill:  #E9DDB8;
--brick:   #8B3A3A;  --brick-fill:  #E8CFCB;
--ember:   #B35A1F;  --ember-fill:  #ECD5BD;
--slate:   #3E4A5C;  --slate-fill:  #D6DBE2;
--plum:    #5C3E56;  --plum-fill:   #E0D4DE;
--teal:    #236874;  --teal-fill:   #CEDEE2;

--status-idle: var(--ink-5);
```

### Scrollbar primitives (S3f, 본래 의도)

```css
:root {
  --scrollbar-thumb:       #2a1f1a;
  --scrollbar-thumb-hover: #3d2e22;
}
```

## Surface 영향

| Surface | 동작 |
|---------|------|
| dashboard | 자체 `::-webkit-scrollbar-thumb` 규칙 보유 (`--line-2/-3` 사용) → 새 토큰 dormant |
| bonsai | `var(--scrollbar-thumb, var(--border-main))` → SSOT redirect 시 canonical 사용 |

## PR-S3 absorb 진행률 (post-merge)

| PR | 토큰 | 누적 | main 도달 |
|----|------|------|-----------|
| S3a #10534 | `--space-1~8` (8) | 8/38 | ✅ |
| S3b #10535 | `--radius-*` (5) | 13/38 | ✅ |
| S3c #10545 | `--shadow-*` (4) | 17/38 | ❌→ S3d#10546이 복원 ✅ |
| S3d #10546 | `--font-*` (3) | 20/38 | ✅ (S3c 동시 복원) |
| S3e #10555 | paper colors + ink-5/6 (16) | 36/38 | ❌→ 본 PR이 복원 |
| **S3f (this)** | `--scrollbar-*` (2) | **38/38** | (이 PR 머지로 38/38) |

## 안전성

- **시각 회귀 0**: bonsai surface는 자기 colors_and_type.css 계속 사용. dual-definition 안전.
- **dashboard 영향 0**: dashboard는 paper colors / scrollbar 토큰 미참조.
- **theme override 정확성**: paper 컬러 토큰은 `[data-theme="paper"]` block 안에만 추가. 다른 테마 영향 없음.

## 사고 분석

`feedback_stack-pr-base-force-push-loses-patches.md` 참조. 동일 함정 두 번째 사례:
- 1차: PR-S3c #10545 (shadow tokens 32 lines 손실) → S3d#10546이 복원
- 2차: PR-S3e #10555 (paper colors 16 tokens 손실) → 본 PR이 복원

근본 방지: stack PR을 main에 머지할 때 `gh pr edit <N> --base main` 수행 후 머지. base PR force-push 시 stack 상위 patches 보존 확인.

## 후속 (PR-S2.5 사전조건)

- **이 PR 머지 시 PR-S3 absorb 38/38 완료**
- PR-S3g #10562 (`--shadow-inset` rename → `--shadow-ring`)는 이미 머지
- PR-S3h #10563 (`--font-mono` stack 정합성, 선택)
- PR-S2.5: bonsai SSOT redirect 진행 가능 — `colors_and_type.css` → dashboard `tokens.css` redirect

## Test plan

- [ ] CI green
- [ ] CSS validity
- [ ] 시각 회귀 0 (양 surface 자기 정의 유지)
- [ ] post-merge: `git show origin/main:dashboard/design-system/source_styles/tokens.css | grep -c "forest-fill\|scrollbar-thumb"` 둘 다 ≥ 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
