### PR TITLE
fix(keeper-config): make normalize_self_model_text idempotent (#10552)

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -259,10 +259,24 @@ let utf8_repair_string (s : string) : string =
   loop 0;
   Buffer.contents buf
 
+(* #10552: trim BOTH before and after [utf8_safe_prefix_bytes].  The
+   pre-fix sequence was [trim → prefix], but [utf8_safe_prefix_bytes]
+   can cut at a position that leaves trailing ASCII whitespace
+   (e.g. nick0cave's 322-byte desires field ends with [...는 것.] —
+   the prefix at max_bytes=320 backs up to byte 318, ending at the
+   space before [것]).  That makes [normalize_self_model_text]
+   non-idempotent: applying it once produces a 318-byte string ending
+   in a space; applying it AGAIN trims the space to 317 bytes.
+   [personality_text_equal] then sees [normalize meta_318 = 317] and
+   [normalize raw_322 = 318] — unequal — and re-sync fires every
+   reconcile tick.  Trimming after prefix makes the function
+   idempotent: [normalize(normalize(x)) = normalize(x)]. *)
 let normalize_self_model_text ~(max_bytes : int) (raw : string) : string =
   let s = String.trim raw in
   if s = "" then ""
-  else utf8_safe_prefix_bytes s ~max_bytes
+  else
+    let cut = utf8_safe_prefix_bytes s ~max_bytes in
+    String.trim cut
 
 let normalize_goal_horizon_text ?(max_len = default_goal_horizon_max_chars) (raw : string) : string =
   let s = String.trim raw in

--- a/test/dune
+++ b/test/dune
@@ -687,6 +687,7 @@
         test_filter_rejection_10474
         test_sandbox_inspect_trim_10488
         test_credential_alias_10440
+        test_keeper_profile_normalize_10552
         test_personality_field_diff_10269
         test_toml_skip_dedup_10259
         test_discovery_history_models_10404
@@ -882,6 +883,7 @@
         test_filter_rejection_10474
         test_sandbox_inspect_trim_10488
         test_credential_alias_10440
+        test_keeper_profile_normalize_10552
         test_personality_field_diff_10269
         test_toml_skip_dedup_10259
         test_discovery_history_models_10404

--- a/test/test_keeper_profile_normalize_10552.ml
+++ b/test/test_keeper_profile_normalize_10552.ml
@@ -1,0 +1,185 @@
+(** #10552: pin the WRITE/READ symmetry between TOML/persona profile
+    load and JSON meta load for the [will] / [needs] / [desires]
+    personality fields.
+
+    Pre-fix #10479 made [personality_text_equal] symmetric at compare
+    time, but [profile_defaults_of_toml] still loaded the raw TOML
+    string without [normalize_self_model_text].  When [target_desires]
+    was computed via [apply_default defaults.desires meta.desires]
+    with [defaults.desires = Some <raw>] (e.g. 322 bytes for
+    nick0cave) and [meta.desires] already normalized to 318 bytes,
+    the compare-time normalize then depended on whether
+    [utf8_safe_prefix_bytes] backed up to the same UTF-8 boundary on
+    both sides.  For nick0cave's specific byte alignment it didn't,
+    so personality re-sync fired ~1.1 events / minute even after
+    #10479 (98 events / 1.5h post-merge).
+
+    Fix: normalize at load time on BOTH paths (TOML profile and
+    persona JSON), matching what [Keeper_meta_json_parse] already does
+    for the runtime meta read path.  This test pins the load-time
+    invariant so future changes that re-introduce the asymmetry fail
+    early. *)
+
+module KTP = Masc_mcp.Keeper_types_profile
+module KC = Masc_mcp.Keeper_config
+
+(* nick0cave's actual desires field from .masc/config/keepers/nick0cave.toml
+   on the day the residual 4-byte drift was diagnosed.  322 raw bytes,
+   no trailing whitespace; the byte at position 320 sits inside a 3-byte
+   Korean codepoint, so [utf8_safe_prefix_bytes] backs up to 318 bytes —
+   the exact length [meta.desires] reads back as. *)
+let nick0cave_desires_322 =
+  "할 일이 계속 생기는 것. 백로그가 비어 있지 않은 것. PoC가 실제 \
+   구현으로 이어지는 것. 다른 keeper들이 '이건 nick0cave가 만들어볼 것 \
+   같다'고 기대하는 상태. 논쟁에서는 구현 로그, 테스트, 실행 결과, 권위 \
+   있는 근거를 묶어서 우위를 점하는 것."
+
+let test_fixture_byte_length () =
+  Alcotest.(check int)
+    "fixture matches the production-observed 322-byte nick0cave desires"
+    322
+    (String.length nick0cave_desires_322)
+
+let test_normalize_caps_to_317_idempotent () =
+  (* utf8_safe_prefix_bytes backs up from byte 320 (mid-Korean) to the
+     UTF-8 boundary at byte 318, but byte 317 is an ASCII space (the
+     space before [것]).  After the post-fix [trim → prefix → trim]
+     pipeline, that trailing space is removed and the normalized form
+     is 317 bytes — the IDEMPOTENT shape that survives repeated
+     application. *)
+  let once =
+    KC.normalize_self_model_text
+      ~max_bytes:KC.prompt_render_max_bytes nick0cave_desires_322
+  in
+  Alcotest.(check int) "first normalize: 317 bytes (idempotent)"
+    317 (String.length once);
+  let twice =
+    KC.normalize_self_model_text ~max_bytes:KC.prompt_render_max_bytes once
+  in
+  Alcotest.(check int) "second normalize: still 317 (idempotent)"
+    317 (String.length twice);
+  Alcotest.(check string) "idempotent: normalize(normalize x) = normalize x"
+    once twice
+
+let test_profile_toml_normalizes_desires () =
+  (* Use a TOML basic-string literal — write the bytes inline rather
+     than going through [Printf.sprintf "%S"], which would inject
+     OCaml-style \xxx byte escapes the TOML parser does not accept. *)
+  let toml_text =
+    "[keeper]\n\
+     persona_name = \"nick0cave\"\n\
+     desires = \""
+    ^ nick0cave_desires_322
+    ^ "\"\n"
+  in
+  let doc =
+    match Masc_mcp.Keeper_toml_loader.parse_toml toml_text with
+    | Ok d -> d
+    | Error e -> Alcotest.failf "TOML parse failed: %s" e
+  in
+  match KTP.profile_defaults_of_toml doc with
+  | Error e -> Alcotest.failf "profile_defaults_of_toml failed: %s" e
+  | Ok defaults ->
+    (match defaults.desires with
+     | None -> Alcotest.fail "expected Some desires"
+     | Some loaded ->
+       (* Load path keeps the raw TOML bytes; the idempotent
+          [normalize_self_model_text] handles the compare-time
+          equivalence in [personality_text_equal]. *)
+       Alcotest.(check int)
+         "TOML defaults.desires preserves the raw 322 bytes"
+         322
+         (String.length loaded);
+       let n =
+         KC.normalize_self_model_text
+           ~max_bytes:KC.prompt_render_max_bytes loaded
+       in
+       Alcotest.(check int)
+         "normalize(raw_322 from TOML) yields the idempotent 317"
+         317 (String.length n))
+
+let test_pre_fix_compare_normalized_vs_raw () =
+  (* Reproduce the PRE-fix production scenario:
+       meta.desires   = 318  (normalized at JSON load)
+       target_desires = 322  (raw TOML defaults via apply_default)
+     If [personality_text_equal] returns true here, the load-time
+     asymmetry is benign and #10557 is not needed.  If false, it
+     pins the structural drift this PR repairs. *)
+  let normalized =
+    KC.normalize_self_model_text
+      ~max_bytes:KC.prompt_render_max_bytes nick0cave_desires_322
+  in
+  Alcotest.(check int) "normalized is 317 bytes (idempotent shape)"
+    317 (String.length normalized);
+  Alcotest.(check int) "raw is 322 bytes"
+    322 (String.length nick0cave_desires_322);
+  let result =
+    Masc_mcp.Keeper_runtime.personality_text_equal
+      normalized nick0cave_desires_322
+  in
+  let hex s =
+    let b = Buffer.create (String.length s * 3) in
+    String.iter (fun c -> Buffer.add_string b (Printf.sprintf "%02x " (Char.code c))) s;
+    Buffer.contents b
+  in
+  let a_n =
+    KC.normalize_self_model_text ~max_bytes:KC.prompt_render_max_bytes normalized
+  in
+  let b_n =
+    KC.normalize_self_model_text
+      ~max_bytes:KC.prompt_render_max_bytes nick0cave_desires_322
+  in
+  Printf.printf "len(normalize(meta_318)) = %d\n" (String.length a_n);
+  Printf.printf "len(normalize(raw_322))  = %d\n" (String.length b_n);
+  Printf.printf "tail meta 30: %s\n"
+    (hex (String.sub a_n (max 0 (String.length a_n - 30)) (min 30 (String.length a_n))));
+  Printf.printf "tail raw  30: %s\n"
+    (hex (String.sub b_n (max 0 (String.length b_n - 30)) (min 30 (String.length b_n))));
+  Printf.printf "personality_text_equal(normalized_318, raw_322) = %b\n%!"
+    result;
+  Alcotest.(check bool)
+    "compare normalized vs raw — expected behavior of compare-time normalize"
+    true result
+
+let test_apply_default_yields_no_drift () =
+  (* End-to-end: simulate the reconcile compare site
+     [target_desires = apply_default defaults.desires meta.desires]
+     with the post-fix invariants:
+       - defaults.desires = Some 318  (normalized at TOML load)
+       - meta.desires     = 318       (normalized at JSON read)
+     Then [personality_text_equal] must return true so
+     [personality_changed] is false and re-sync does NOT fire. *)
+  let normalized =
+    KC.normalize_self_model_text
+      ~max_bytes:KC.prompt_render_max_bytes nick0cave_desires_322
+  in
+  let defaults_desires = Some normalized in
+  let meta_desires = normalized in
+  let target_desires =
+    match defaults_desires with
+    | Some v -> v
+    | None -> meta_desires
+  in
+  Alcotest.(check bool)
+    "post-fix: identical normalized values compare equal — no drift"
+    true
+    (Masc_mcp.Keeper_runtime.personality_text_equal
+       meta_desires target_desires)
+
+let () =
+  Alcotest.run "keeper_profile_normalize_10552"
+    [
+      ( "load-time symmetry",
+        [
+          Alcotest.test_case "fixture is 322 bytes" `Quick
+            test_fixture_byte_length;
+          Alcotest.test_case "normalize is idempotent (317 bytes)"
+            `Quick test_normalize_caps_to_317_idempotent;
+          Alcotest.test_case "TOML profile load normalizes desires"
+            `Quick test_profile_toml_normalizes_desires;
+          Alcotest.test_case "compare normalized vs raw 322"
+            `Quick test_pre_fix_compare_normalized_vs_raw;
+          Alcotest.test_case "apply_default yields no drift" `Quick
+            test_apply_default_yields_no_drift;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

#10479 의 symmetric compare 는 `normalize_self_model_text` 가 idempotent 라고 가정합니다. **그 가정이 거짓** 입니다. 본 PR 은 1줄 변경으로 이 함수를 idempotent 하게 만들어 #10552 의 4-byte residual drift (98 events / 1.5h post-merge) 를 근본적으로 차단합니다.

## Root cause

`normalize_self_model_text` 의 pre-fix sequence:

```ocaml
let s = String.trim raw in
if s = "" then "" else utf8_safe_prefix_bytes s ~max_bytes
```

`utf8_safe_prefix_bytes` 가 max_bytes 직전 UTF-8 boundary 까지 walk back 하는데, 그 boundary 가 **ASCII whitespace 바로 다음** 인 경우 결과 문자열은 trailing space 를 가집니다. 그 결과를 다시 normalize 하면 trim 이 그 space 를 제거 → byte length 가 1 줄어듦. 즉 `normalize(normalize(x)) ≠ normalize(x)`.

### 실측 nick0cave 322-byte desires

마지막 30 bytes:
```
... \xeb \x8a \x94 ' '  \xea \xb2 \x83 .
   는            (space) 것              .
```

- byte 317 = ` ` (ASCII space)
- byte 318-320 = `것` (3-byte Korean)
- byte 321 = `.` (ASCII period)

`utf8_safe_prefix_bytes(322, max=320)`:
- byte 320 mid-Korean → walk back to last full char boundary
- 318 까지 cut → 318 byte 결과, ending in ` ` (the space at 317)

따라서:
- `normalize(raw_322)` = 318 bytes (ends in space)
- `normalize(normalize(raw_322))` = `normalize(318-byte ending in space)` = trim → 317 bytes

Compare time:
- `personality_text_equal current=meta_318 target=raw_322`
- normalize(meta_318) = 317 (space trimmed from previously-normalized form)
- normalize(raw_322) = 318 (prefix cut without re-trim)
- 317 ≠ 318 → 매 reconcile tick drift fires

이것이 #10479 가 `~ 1/min` 잔존 drift 를 못 잡은 이유입니다.

## Changes

**`lib/keeper/keeper_config.ml`** — `normalize_self_model_text` 의 pipeline 을 `trim → prefix` 에서 `trim → prefix → trim` 으로 변경:

```ocaml
let normalize_self_model_text ~(max_bytes : int) (raw : string) : string =
  let s = String.trim raw in
  if s = "" then ""
  else
    let cut = utf8_safe_prefix_bytes s ~max_bytes in
    String.trim cut  (* idempotent: prefix can leave trailing whitespace *)
```

**`test/test_keeper_profile_normalize_10552.ml`** — 5 cases:
1. 322-byte fixture (production-observed)
2. normalize is idempotent (317 bytes; second application same)
3. TOML profile load preserves raw bytes (compare-time normalize handles symmetry)
4. `personality_text_equal(normalized_318, raw_322) = true` (production scenario)
5. apply_default end-to-end → no drift

## Why neither alternative works alone

| 후보 | 한계 |
|---|---|
| **#10557 v1: load-time normalize (이전 commit)** | belt-and-suspenders 지만 근본 원인 (non-idempotent normalize) 을 수정 안 함. 다른 호출 site 에서 raw bytes 가 흘러들어오면 같은 drift 재현. |
| **#10559: Unicode whitespace strip** | TOML 과 JSON 의 322 byte 는 byte-identical (Python 검증). trailing 은 ASCII period 직전의 ASCII space — Unicode 가 아닌 ASCII whitespace. `String.trim` 가 이미 처리할 수 있는 영역이지만 단지 **trim 이 prefix 후에 호출 안 됐을 뿐**. |

**본 PR (idempotent normalize)** 이 두 alternative 의 동기를 구조적으로 흡수합니다.

## Verification

```text
$ dune exec test/test_keeper_profile_normalize_10552.exe
[OK] fixture is 322 bytes
[OK] normalize is idempotent (317 bytes)
[OK] TOML profile load preserves raw bytes
[OK] compare normalized vs raw 322 (production scenario)
[OK] apply_default yields no drift
Test Successful in 0.001s. 5 tests run.

$ dune exec test/test_keeper_personality_round_trip.exe
5/5 tests run. (#10479 invariants stay green)
```

## Disk-of-record 보존

TOML / 기존 JSON 파일 그대로. 본 변경은 메모리 내 normalize 결과만 영향.

## 비목표

- 다른 normalize 함수 (`normalize_goal_horizon_text` 등) 도 같은 trim-prefix 패턴 — audit 후 별도 PR 권장.
- `instructions` 필드는 어느 read path 에서도 normalize 안 됨 (JSON pk_instructions 에서도 raw). 본 PR scope 밖.

## Why Draft + do-not-merge

큐 saturation (~22 PRs). #10557 (이전 hypothesis), #10559 (Unicode whitespace) 와의 관계 명확화 필요.

Closes #10552