### PR TITLE
fix(keeper-config): strip Unicode trailing whitespace in personality normalize (#10552)

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -259,8 +259,54 @@ let utf8_repair_string (s : string) : string =
   loop 0;
   Buffer.contents buf
 
+(** #10552: trim Unicode whitespace beyond ASCII so TOML/JSON sources that
+    end with NBSP (U+00A0 = 2 bytes), ideographic space (U+3000 = 3 bytes),
+    or zero-width space (U+200B = 3 bytes) compare equal to a stripped
+    counterpart. [String.trim] only handles ASCII whitespace, so a 4-byte
+    drift survived the #10479 symmetric-compare fix and continued to fire
+    nick0cave personality re-sync at ~1/min. *)
+let utf8_trim_trailing_whitespace (s : string) : string =
+  let n = String.length s in
+  let is_ascii_ws_byte b =
+    let c = Char.code b in
+    c = 0x20 || c = 0x09 || c = 0x0A || c = 0x0B || c = 0x0C || c = 0x0D
+  in
+  let ends_with_unicode_ws end_pos =
+    if end_pos < 2 then None
+    else
+      let b0 = Char.code s.[end_pos - 2] in
+      let b1 = Char.code s.[end_pos - 1] in
+      if b0 = 0xC2 && b1 = 0xA0 then Some 2  (* U+00A0 NBSP : C2 A0 *)
+      else if end_pos >= 3 then begin
+        let b_2 = Char.code s.[end_pos - 3] in
+        if b_2 = 0xE3 && b0 = 0x80 && b1 = 0x80 then Some 3  (* U+3000 *)
+        else if b_2 = 0xE2 && b0 = 0x80
+             && (b1 = 0x8B || b1 = 0xA8 || b1 = 0xA9)
+        then Some 3  (* U+200B / U+2028 / U+2029 *)
+        else None
+      end
+      else None
+  in
+  let rec loop_end pos =
+    if pos = 0 then 0
+    else if is_ascii_ws_byte s.[pos - 1] then loop_end (pos - 1)
+    else
+      match ends_with_unicode_ws pos with
+      | Some k -> loop_end (pos - k)
+      | None -> pos
+  in
+  let trimmed_end = loop_end n in
+  let rec loop_start pos =
+    if pos >= trimmed_end then trimmed_end
+    else if is_ascii_ws_byte s.[pos] then loop_start (pos + 1)
+    else pos
+  in
+  let trimmed_start = loop_start 0 in
+  if trimmed_start = 0 && trimmed_end = n then s
+  else String.sub s trimmed_start (trimmed_end - trimmed_start)
+
 let normalize_self_model_text ~(max_bytes : int) (raw : string) : string =
-  let s = String.trim raw in
+  let s = utf8_trim_trailing_whitespace raw in
   if s = "" then ""
   else utf8_safe_prefix_bytes s ~max_bytes
 

--- a/test/test_keeper_personality_round_trip.ml
+++ b/test/test_keeper_personality_round_trip.ml
@@ -71,6 +71,28 @@ let test_oversized_with_trailing_whitespace_is_equal () =
     true
     (KR.personality_text_equal nick0cave_will with_newline)
 
+let test_unicode_trailing_whitespace_is_equal () =
+  (* #10552: NBSP (U+00A0 = C2 A0) and ideographic space (U+3000 = E3 80 80)
+     are not stripped by [String.trim] but were the residual 4-byte drift
+     that survived the #10479 symmetric-compare fix and kept nick0cave's
+     personality re-sync firing at ~1/min. After [utf8_trim_trailing_whitespace],
+     both sides must collapse to the same normalised form. *)
+  let with_nbsp = nick0cave_will ^ "\xC2\xA0\xC2\xA0" in  (* 2 NBSP = 4 bytes *)
+  let with_ideographic = nick0cave_will ^ "\xE3\x80\x80" in  (* 1 IS = 3 bytes *)
+  let with_zero_width = nick0cave_will ^ "\xE2\x80\x8B" in  (* 1 ZWS = 3 bytes *)
+  Alcotest.(check bool)
+    "trailing NBSP (C2 A0) compares equal"
+    true
+    (KR.personality_text_equal nick0cave_will with_nbsp);
+  Alcotest.(check bool)
+    "trailing ideographic space (E3 80 80) compares equal"
+    true
+    (KR.personality_text_equal nick0cave_will with_ideographic);
+  Alcotest.(check bool)
+    "trailing zero-width space (E2 80 8B) compares equal"
+    true
+    (KR.personality_text_equal nick0cave_will with_zero_width)
+
 let test_diff_summary_is_empty_for_identical_oversized () =
   (* The reconcile path uses [personality_diff_summary] to decide
      whether [personality_changed] fires.  An empty list is the
@@ -137,6 +159,8 @@ let () =
             `Quick test_oversized_real_diff_still_detected;
           Alcotest.test_case "oversized + trailing whitespace equal"
             `Quick test_oversized_with_trailing_whitespace_is_equal;
+          Alcotest.test_case "unicode trailing whitespace equal (#10552)"
+            `Quick test_unicode_trailing_whitespace_is_equal;
           Alcotest.test_case "diff_summary empty for identical oversized"
             `Quick test_diff_summary_is_empty_for_identical_oversized;
           Alcotest.test_case "diff_summary reports normalised lengths"


### PR DESCRIPTION
## 요약

#10479 fix가 38-byte drift는 잡았지만 **4-byte residual** (nick0cave, ~98 events/1.5h, ~1/min)이 잔존. \`String.trim\`이 ASCII whitespace만 처리하는 한계 — Unicode whitespace (NBSP, ideographic space, ZWS, line/para separator) trailing이 통과.

## 변경

\`lib/keeper/keeper_config.ml\`:
- 신규 \`utf8_trim_trailing_whitespace\` (ASCII + 4 Unicode whitespace 클래스 처리)
- \`normalize_self_model_text\`가 이 함수 사용 (이전: \`String.trim\`)

\`test/test_keeper_personality_round_trip.ml\`:
- 신규 \`test_unicode_trailing_whitespace_is_equal\` (NBSP / IS / ZWS 3 case)

## 검증

\`\`\`
DUNE_CACHE=disabled dune build --root . --cache=disabled @check  → EXIT=0
dune exec test/test_keeper_personality_round_trip.exe            → 6/6 pass
\`\`\`

## Live evidence (2026-04-26 02:50Z)

| Pair | Pre-#10479 | Post-#10479 (잔존) |
|---|---|---|
| 38-byte (319/357) | 504 | **0** ✓ |
| 4-byte (318/322) | 509 | **98** ✗ → 본 PR로 0 예상 |

## Unicode whitespace coverage

| Class | UTF-8 bytes | Length |
|---|---|---|
| U+00A0 NBSP | C2 A0 | 2 |
| U+3000 Ideographic Space | E3 80 80 | 3 |
| U+200B Zero-Width Space | E2 80 8B | 3 |
| U+2028 Line Separator | E2 80 A8 | 3 |
| U+2029 Paragraph Separator | E2 80 A9 | 3 |

## 비목표

- Disk persistence는 raw bytes 그대로 보존 (저장은 의도된 source-of-truth)
- 다른 normalize 함수 (\`normalize_goal_horizon_text\` 등)는 본 PR scope 아님 (별도 audit 필요)

## 관련

- Issue: \`#10552\`
- Predecessor: \`#10479\` (symmetric-compare, 38-byte drift만 fix)
- Memory \`feedback_unit-name-lie-asymmetric-normalize.md\` family

## Defensive guards

Draft + \`do-not-merge\` 라벨.