### PR TITLE
perf(ws): single String.sub for SSE data payload (drop intermediate raw)

### DIFF
--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -490,11 +490,17 @@ let sse_data_prefix = "data:"
 
 let extract_sse_data_payload_line line =
   if String.starts_with ~prefix:sse_data_prefix line then
+    let line_len = String.length line in
     let prefix_len = String.length sse_data_prefix in
-    let raw = String.sub line prefix_len (String.length line - prefix_len) in
-    if String.length raw > 0 && Char.equal raw.[0] ' ' then
-      Some (String.sub raw 1 (String.length raw - 1))
-    else Some raw
+    (* Per RFC: a single optional space follows "data:". Fold the skip
+       into the same [String.sub] to avoid an intermediate allocation
+       on the dashboard fanout hot path (~1 alloc per SSE data line). *)
+    let start =
+      if line_len > prefix_len && Char.equal line.[prefix_len] ' '
+      then prefix_len + 1
+      else prefix_len
+    in
+    Some (String.sub line start (line_len - start))
   else None
 
 let extract_sse_data_line sse_event =


### PR DESCRIPTION
## What

`extract_sse_data_payload_line` (lib/server/server_mcp_transport_ws.ml:491-498)에서 leading-space skip을 별도 `String.sub`로 처리하던 부분을 단일 `String.sub` start offset 계산으로 통합.

## Why

dashboard fanout hot path. WS 클라이언트가 활성화될 때마다 백엔드 SSE 이벤트를 line 단위로 split → 각 data line에 대해 호출. 매 SSE data line마다:
- 변경 전: `String.sub` 1-2회 (`raw` substring + leading-space-skip 시 추가 1회)
- 변경 후: `String.sub` 1회 (start offset에 space skip 포함)

WS 세션 N개 × 초당 SSE event M개 환경에서 N×M alloc 절감.

## Semantics

4 입력 케이스 동일 결과:
| 입력 | 변경 전 | 변경 후 |
|------|---------|---------|
| `data: hello` | `"hello"` | `"hello"` |
| `data:hello` | `"hello"` | `"hello"` |
| `data: ` | `""` | `""` |
| `data:` | `""` | `""` |

## Test

`OCAMLPARAM='_,warn-error=+a' dune build @check` clean. 함수가 internal helper라 직접 unit test는 없으며 `extract_sse_data_line` (callers) → `parse_sse_dashboard_event` 경유 통합 테스트가 통과하면 동등성 보장.
