### PR TITLE
refactor(design-system): resolve --shadow-inset collision via bonsai rename to --shadow-ring (PR-S3g)

### DIFF
--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -808,10 +808,10 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
 /* ═══════════════════════════════════════════════════════════════════
    BONSAI STRUCTURAL TOKENS (shadow primitives)
    ───────────────────────────────────────────────────────────────────
-   4 tokens with theme-specific overrides. `--shadow-inset` is NOT
-   absorbed here — dashboard tokens.css already defines it with a
-   different semantic (top-edge highlight vs bonsai's full ring).
-   Resolution deferred to a later PR.
+   `--shadow-card/panel/glow/raised`: per-theme overrides below.
+   `--shadow-ring`: 1px inset border ring. Renamed from bonsai's
+   former `--shadow-inset` (PR-S3g) to disambiguate from dashboard's
+   `--shadow-inset` which is a top-edge highlight (line ~282).
    ═══════════════════════════════════════════════════════════════════ */
 
 :root {
@@ -819,6 +819,7 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
   --shadow-panel:  0 2px 12px rgba(0, 0, 0, 0.6);
   --shadow-glow:   0 0 20px var(--accent-glow);
   --shadow-raised: 0 8px 24px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--border-highlight);
+  --shadow-ring:   inset 0 0 0 1px rgba(196, 162, 101, 0.25);
 }
 
 [data-theme="cyberpunk"] {

--- a/dashboard_bonsai/static/colors_and_type.css
+++ b/dashboard_bonsai/static/colors_and_type.css
@@ -78,7 +78,7 @@
   --shadow-card:   0 1px 4px rgba(0, 0, 0, 0.5);
   --shadow-raised: 0 8px 24px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--border-highlight);
   --shadow-glow:   0 0 20px var(--accent-glow);
-  --shadow-inset:  inset 0 0 0 1px rgba(196, 162, 101, 0.25);
+  --shadow-ring:   inset 0 0 0 1px rgba(196, 162, 101, 0.25);
 
   /* Spacing (4px grid) */
   --space-1:  4px;
@@ -354,7 +354,7 @@ hr {
 .btn.primary {
   border-color: var(--accent-brass);
   color: var(--accent-brass);
-  box-shadow: var(--shadow-inset);
+  box-shadow: var(--shadow-ring);
 }
 .btn.primary:hover { background: var(--accent-glow); color: var(--text-bright); }
 .btn.ghost { background: transparent; }
@@ -424,7 +424,7 @@ hr {
 .frame-gothic {
   position: relative;
   border: 1px solid var(--border-highlight);
-  box-shadow: var(--shadow-inset), var(--shadow-panel);
+  box-shadow: var(--shadow-ring), var(--shadow-panel);
 }
 .frame-gothic::before,
 .frame-gothic::after {


### PR DESCRIPTION
## Summary

`--shadow-inset` 이름 충돌 해소. PR-S3f (#10556) 위에 stack.

## 문제

| Surface | 정의 위치 | 값 | 의미 |
|---------|----------|-----|------|
| dashboard | `tokens.css:282` | `inset 0 1px 0 rgb(255 255 255 / .03)` | top-edge highlight (subtle bright top edge) |
| bonsai | `colors_and_type.css:81` | `inset 0 0 0 1px rgba(196,162,101,0.25)` | 1px ring border (full inset border) |

같은 이름이 다른 시각 효과. SSOT 통합 작업 중 발견된 첫 의미 충돌.

## 결정 — bonsai 측 rename

- dashboard의 `--shadow-inset`은 표준 CSS 관용어 의미 (inner shadow → top-edge highlight)
- bonsai는 의미적으로 ring border (`box-shadow: inset 0 0 0 Xpx color` = 내부 1px 둘레 박스)이므로 `--shadow-ring`이 더 정확
- dashboard 정의/소비자 보존, bonsai만 변경

## 변경

### dashboard_bonsai/static/colors_and_type.css

```diff
-  --shadow-inset:  inset 0 0 0 1px rgba(196, 162, 101, 0.25);
+  --shadow-ring:   inset 0 0 0 1px rgba(196, 162, 101, 0.25);

 .btn.primary {
   ...
-  box-shadow: var(--shadow-inset);
+  box-shadow: var(--shadow-ring);

 .frame-gothic {
   ...
-  box-shadow: var(--shadow-inset), var(--shadow-panel);
+  box-shadow: var(--shadow-ring), var(--shadow-panel);
}
```

### dashboard/design-system/source_styles/tokens.css

PR-S3c에서 만든 `BONSAI STRUCTURAL TOKENS (shadow primitives)` 블록 :root에 1줄 추가:

```css
--shadow-ring: inset 0 0 0 1px rgba(196, 162, 101, 0.25);
```

헤더 주석도 갱신 (이전 "Resolution deferred to a later PR" → rename 사실 기록).

## 안전성

- **bonsai 시각 회귀 0**: resolved value 동일 (`inset 0 0 0 1px rgba(196, 162, 101, 0.25)`), 이름만 변경.
- **dashboard 영향 0**: dashboard 컴포넌트는 `--shadow-ring` 미참조. SSOT 정의만 확장.
- **외부 consumer 검증**: `rg "var\(--shadow-inset)"` → bonsai 2건 모두 수정. dashboard `--shadow-inset` 정의는 그대로, consumer는 별도 영향 없음.

## Stack

base = `feat/design-system-absorb-scrollbar` (PR-S3f #10556)

## 후속

- PR-S3h: `--font-mono` stack 정합성 검토 (선택)
- **PR-S2.5: bonsai SSOT redirect 진행 가능** — vocabulary 100% 일치, 충돌 0

## Test plan

- [ ] CI green
- [ ] CSS validity
- [ ] bonsai surface `.btn.primary` / `.frame-gothic` 시각 회귀 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
