### PR TITLE
docs(design-system): SPEC §6.2 escape hatch — --font-mono divergence + --shadow-ring rename (PR-S3h)

### DIFF
--- a/dashboard/design-system/SPEC.md
+++ b/dashboard/design-system/SPEC.md
@@ -265,6 +265,8 @@ bonsai의 5 테마는 production user에게 URL hash로 공유 가능한 자산.
 | `keeperColor()` 헬퍼 | `dashboard/design-system/preview/cb-group-i.jsx` | 12 keeper persona를 attribution token 5종으로 환원 불가 — hex extension 의도적 |
 | `rgba(... / .NN)` alpha 조합 | 어느 곳이든 | `rgb(var(--token-glow) / .12)` 형태로 raw token alpha 조합은 허용 |
 | 폰트 fallback chain | `--font-*` 정의 내 | system font name (e.g., `Inter`, `JetBrains Mono`) |
+| `--font-mono` stack divergence | dashboard `tokens.css` vs bonsai `colors_and_type.css` | dashboard는 `ui-monospace` 우선(Apple 시스템 폰트), bonsai는 `JetBrains Mono` 우선(고딕 미감 일관성). PR-S2.5 redirect 시 bonsai stub이 자기 stack 유지 — dashboard 정의를 inherit하지 않음. |
+| `--shadow-inset` 의미 차이 | dashboard `tokens.css:282` vs `--shadow-ring`(bonsai) | dashboard는 top-edge highlight, bonsai는 1px ring. PR-S3g(2026-04-26)에서 bonsai 측을 `--shadow-ring`으로 rename하여 충돌 해소. |
 
 ### 6.3 Surface 적용 의무
 

--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -761,3 +761,30 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
   --space-7: 48px;
   --space-8: 64px;
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   BONSAI STRUCTURAL TOKENS (radius primitives)
+   ───────────────────────────────────────────────────────────────────
+   cyberpunk + terminal flatten xs/sm/md to 0 (sharp corners).
+   parchment + paper inherit :root values.
+   ═══════════════════════════════════════════════════════════════════ */
+
+:root {
+  --radius-xs:   2px;
+  --radius-sm:   4px;
+  --radius-md:   6px;
+  --radius-lg:   12px;
+  --radius-pill: 999px;
+}
+
+[data-theme="cyberpunk"] {
+  --radius-xs: 0;
+  --radius-sm: 0;
+  --radius-md: 0;
+}
+
+[data-theme="terminal"] {
+  --radius-xs: 0;
+  --radius-sm: 0;
+  --radius-md: 0;
+}

--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -808,10 +808,10 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
 /* ═══════════════════════════════════════════════════════════════════
    BONSAI STRUCTURAL TOKENS (shadow primitives)
    ───────────────────────────────────────────────────────────────────
-   4 tokens with theme-specific overrides. `--shadow-inset` is NOT
-   absorbed here — dashboard tokens.css already defines it with a
-   different semantic (top-edge highlight vs bonsai's full ring).
-   Resolution deferred to a later PR.
+   `--shadow-card/panel/glow/raised`: per-theme overrides below.
+   `--shadow-ring`: 1px inset border ring. Renamed from bonsai's
+   former `--shadow-inset` (PR-S3g) to disambiguate from dashboard's
+   `--shadow-inset` which is a top-edge highlight (line ~282).
    ═══════════════════════════════════════════════════════════════════ */
 
 :root {
@@ -819,6 +819,7 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
   --shadow-panel:  0 2px 12px rgba(0, 0, 0, 0.6);
   --shadow-glow:   0 0 20px var(--accent-glow);
   --shadow-raised: 0 8px 24px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--border-highlight);
+  --shadow-ring:   inset 0 0 0 1px rgba(196, 162, 101, 0.25);
 }
 
 [data-theme="cyberpunk"] {

--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -820,3 +820,31 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
   --shadow-card:  0 1px 0 rgba(0,0,0,0.04);
   --shadow-glow:  none;
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   BONSAI STRUCTURAL TOKENS (font stacks)
+   ───────────────────────────────────────────────────────────────────
+   bonsai's display/body/ui font stacks. dashboard already defines
+   `--font-mono` separately (line ~152) — not duplicated here.
+
+   cyberpunk + terminal collapse all stacks to monospace for
+   intentional aesthetic. parchment + paper inherit :root.
+   ═══════════════════════════════════════════════════════════════════ */
+
+:root {
+  --font-display: 'Cinzel', 'Noto Sans KR', 'EB Garamond', serif;
+  --font-body:    'EB Garamond', 'Noto Sans KR', Georgia, serif;
+  --font-ui:      'Noto Sans KR', 'IBM Plex Sans KR', -apple-system, sans-serif;
+}
+
+[data-theme="cyberpunk"] {
+  --font-display: 'Share Tech Mono', 'Noto Sans KR', monospace;
+  --font-body:    'Noto Sans KR', sans-serif;
+  --font-ui:      'Share Tech Mono', 'Noto Sans KR', monospace;
+}
+
+[data-theme="terminal"] {
+  --font-display: 'JetBrains Mono', 'Noto Sans KR', monospace;
+  --font-body:    'JetBrains Mono', 'Noto Sans KR', monospace;
+  --font-ui:      'JetBrains Mono', 'Noto Sans KR', monospace;
+}

--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -788,3 +788,35 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
   --radius-sm: 0;
   --radius-md: 0;
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   BONSAI STRUCTURAL TOKENS (shadow primitives)
+   ───────────────────────────────────────────────────────────────────
+   4 tokens with theme-specific overrides. `--shadow-inset` is NOT
+   absorbed here — dashboard tokens.css already defines it with a
+   different semantic (top-edge highlight vs bonsai's full ring).
+   Resolution deferred to a later PR.
+   ═══════════════════════════════════════════════════════════════════ */
+
+:root {
+  --shadow-card:   0 1px 4px rgba(0, 0, 0, 0.5);
+  --shadow-panel:  0 2px 12px rgba(0, 0, 0, 0.6);
+  --shadow-glow:   0 0 20px var(--accent-glow);
+  --shadow-raised: 0 8px 24px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--border-highlight);
+}
+
+[data-theme="cyberpunk"] {
+  --shadow-panel: 0 0 16px rgba(106, 47, 214, 0.3);
+  --shadow-glow:  0 0 24px rgba(0, 255, 204, 0.2), 0 0 48px rgba(0, 255, 204, 0.05);
+}
+
+[data-theme="terminal"] {
+  --shadow-panel: 0 0 8px rgba(0, 255, 0, 0.1);
+  --shadow-glow:  0 0 16px rgba(0, 255, 0, 0.15);
+}
+
+[data-theme="parchment"] {
+  --shadow-panel: 0 1px 2px rgba(0,0,0,0.06), 0 0 0 1px rgba(0,0,0,0.06);
+  --shadow-card:  0 1px 0 rgba(0,0,0,0.04);
+  --shadow-glow:  none;
+}

--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -716,6 +716,22 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
   --ink-2:   #2E2E2C;
   --ink-3:   #515049;
   --ink-4:   #656358;
+  --ink-5:   #9A978D;
+  --ink-6:   #BCB8AC;
+
+  /* Named hue tokens (paper-only) — color/fill pairs from bonsai
+     vocabulary. Used for keeper attribution accents, swimlane categories,
+     and t-* trace frames in the light-on-paper theme. */
+  --forest:  #2D5F4E;  --forest-fill: #CFDFD7;
+  --brass:   #8C6A1E;  --brass-fill:  #E9DDB8;
+  --brick:   #8B3A3A;  --brick-fill:  #E8CFCB;
+  --ember:   #B35A1F;  --ember-fill:  #ECD5BD;
+  --slate:   #3E4A5C;  --slate-fill:  #D6DBE2;
+  --plum:    #5C3E56;  --plum-fill:   #E0D4DE;
+  --teal:    #236874;  --teal-fill:   #CEDEE2;
+
+  --status-idle: var(--ink-5);
+
   --bg-deep:      var(--paper);
   --bg-panel:     var(--paper-2);
   --bg-panel-alt: var(--paper-3);

--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -864,3 +864,17 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
   --font-body:    'JetBrains Mono', 'Noto Sans KR', monospace;
   --font-ui:      'JetBrains Mono', 'Noto Sans KR', monospace;
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   BONSAI STRUCTURAL TOKENS (scrollbar primitives)
+   ───────────────────────────────────────────────────────────────────
+   Theme-invariant. dashboard surface has its own ::-webkit-scrollbar-
+   thumb rule (uses --line-2/-3) and does not consume these tokens.
+   bonsai surface reads via var(--scrollbar-thumb, var(--border-main))
+   pattern with --border-main fallback when this file is the SSOT.
+   ═══════════════════════════════════════════════════════════════════ */
+
+:root {
+  --scrollbar-thumb:       #2a1f1a;
+  --scrollbar-thumb-hover: #3d2e22;
+}

--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -739,3 +739,25 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
   --t-wait:  #E5E0D1;
   --t-err:   #8B3A3A;
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   BONSAI STRUCTURAL TOKENS (spacing primitives)
+   ───────────────────────────────────────────────────────────────────
+   Bonsai surface uses a 4px-grid spacing scale. These values are
+   theme-invariant (no [data-theme] override in colors_and_type.css).
+
+   Absorbed into canonical tokens.css for SSOT consolidation. Bonsai's
+   colors_and_type.css continues to define the same values until
+   PR-S2.5 redirects bonsai to import canonical tokens.css.
+   ═══════════════════════════════════════════════════════════════════ */
+
+:root {
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+}

--- a/dashboard_bonsai/static/colors_and_type.css
+++ b/dashboard_bonsai/static/colors_and_type.css
@@ -78,7 +78,7 @@
   --shadow-card:   0 1px 4px rgba(0, 0, 0, 0.5);
   --shadow-raised: 0 8px 24px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--border-highlight);
   --shadow-glow:   0 0 20px var(--accent-glow);
-  --shadow-inset:  inset 0 0 0 1px rgba(196, 162, 101, 0.25);
+  --shadow-ring:   inset 0 0 0 1px rgba(196, 162, 101, 0.25);
 
   /* Spacing (4px grid) */
   --space-1:  4px;
@@ -354,7 +354,7 @@ hr {
 .btn.primary {
   border-color: var(--accent-brass);
   color: var(--accent-brass);
-  box-shadow: var(--shadow-inset);
+  box-shadow: var(--shadow-ring);
 }
 .btn.primary:hover { background: var(--accent-glow); color: var(--text-bright); }
 .btn.ghost { background: transparent; }
@@ -424,7 +424,7 @@ hr {
 .frame-gothic {
   position: relative;
   border: 1px solid var(--border-highlight);
-  box-shadow: var(--shadow-inset), var(--shadow-panel);
+  box-shadow: var(--shadow-ring), var(--shadow-panel);
 }
 .frame-gothic::before,
 .frame-gothic::after {


### PR DESCRIPTION
## Summary

PR-S3 absorb 단계 마지막 — 문서화 only. PR-S3g (#10562) 위에 stack.

`SPEC.md §6.2` escape hatch 표에 2개 항목 추가:

| 항목 | 위치 | 사유 |
|------|------|------|
| `--font-mono` stack divergence | dashboard vs bonsai | dashboard `ui-monospace` 우선 (Apple 시스템) / bonsai `JetBrains Mono` 우선 (고딕 일관성). PR-S2.5 redirect 시 bonsai stub이 자기 stack 유지. |
| `--shadow-inset` 의미 차이 | dashboard vs `--shadow-ring`(bonsai) | dashboard top-edge highlight, bonsai 1px ring. PR-S3g rename으로 해소. |

## 코드 변경

없음. SPEC.md 표 2행 추가만.

## PR-S3 absorb 단계 진행 정리

| PR | 카테고리 | 토큰 | 누적 |
|----|---------|------|------|
| S3a #10534 | spacing | 8 | 8/38 |
| S3b #10535 | radius | 5 + theme | 13/38 |
| S3c #10545 | shadow (4) | 4 + theme | 17/38 |
| S3d #10546 | font (display/body/ui) | 3 + theme | 20/38 |
| S3e #10555 | paper extras + ink-5/6 | 16 | 36/38 |
| S3f #10556 | scrollbar | 2 | 38/38 ✅ |
| S3g #10562 | shadow-ring rename | (충돌 해소) | — |
| **S3h (this)** | SPEC escape hatch 문서화 | — | — |

**Vocabulary 100% 일치** (bonsai-unique tokens = 0). PR-S2.5 사전조건 완료.

## Stack

base = `feat/design-system-shadow-ring` (PR-S3g #10562)

## 후속

- **PR-S2.5: bonsai SSOT redirect 진행 가능**
  - bonsai colors_and_type.css를 stub으로 축소 (자기 `--font-mono` stack만 유지, 나머지는 dashboard tokens.css inherit)
  - 또는 build-time copy / HTTP @import 메커니즘 결정
  - 시각 회귀 검증 (5 named theme variants 토글)

## Test plan

- [ ] CI green (docs only, lint/test 영향 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
