### PR TITLE
feat(config-doctor): expose sandbox SSOT snapshot in JSON output (#10426 P2d)

### DIFF
--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -746,6 +746,11 @@ let to_yojson (report : t) =
         match report.sandbox_preflight with
         | Some value -> value
         | None -> `Null );
+      (* Sandbox configuration SSOT snapshot (#10426 P2d).  Operators can
+         read [raw.<section>.<key>] for per-setting provenance
+         (env vs default vs load_bearing_floor) and [derived.*] for the
+         post-cross-cutting-rule values Docker actually sees. *)
+      ( "sandbox_config", Env_config_sandbox.effective_config_json () );
     ]
 
 let render_text (report : t) =


### PR DESCRIPTION
## Why

`Env_config_sandbox.effective_config_json` (#10480 P2a) was designed so operators could read every sandbox setting + provenance in one place. This PR wires it into `Config_doctor.to_yojson` so it surfaces via the existing `masc-mcp doctor config --json` command.

This completes the sandbox config SSOT track started in #10426:

| PR | Phase | Content |
|----|-------|---------|
| #10480 | P2a | `Env_config_sandbox` module + tests |
| #10536 | P2b | `KeeperSandbox` / `DockerPlayground` alias delegation |
| #10551 | P2c | hardcoded constants migration (preflight bounds, sleep, cleanup rm) |
| **this PR** | **P2d** | `Config_doctor` JSON wiring |

## What

```ocaml
@@ to_yojson @@
       ( "sandbox_preflight",
         match report.sandbox_preflight with
         | Some value -> value
         | None -> `Null );
+      (* Sandbox configuration SSOT snapshot (#10426 P2d). *)
+      ( "sandbox_config", Env_config_sandbox.effective_config_json () );
     ]
```

After this PR:

```bash
$ masc-mcp doctor config --json | jq .sandbox_config.raw.shell_timeout.gh_min
{
  "value": 15.0,
  "source": "load_bearing_floor",
  "env_var": null
}

$ masc-mcp doctor config --json | jq .sandbox_config.derived.tmpfs_mount
"/tmp:rw,nosuid,nodev,noexec,size=256m"

$ MASC_KEEPER_SANDBOX_HARD_MODE=true masc-mcp doctor config --json \
    | jq .sandbox_config.raw.hardening.hard_mode
{
  "value": true,
  "source": "env",
  "env_var": "MASC_KEEPER_SANDBOX_HARD_MODE"
}
```

## Diff

```
1 file changed, 5 insertions(+)
```

## Verification

- `dune build lib/ --root . --cache=disabled` → RC=0.

**Note**: `test_config_doctor` `doctor.007` (`analyze_live surfaces sandbox preflight failure as warn`) has a **pre-existing failure on main** (`status downgrades to warn` expected `warn`, received `error`) unrelated to this PR. This change adds a single additive JSON field and does not touch `status` computation. Failure reproduces with this PR reverted (verified via `git stash` round-trip). Filing separately.

## What's next

- Default-deviation analysis (separate PR): Alerting 20s, Pr_review 30s/5s, Gh_shared 5s, `keeper_exec_shell.ml:335` PATH probe.
- Correctness series (C1-C3, separate plan): EINTR retry remaining-time tracking, `Eio.Switch.on_release` cleanup, `effective_sandbox_profile` resolution dedup.

---

Refs: #10426 (audit + plan), #10480 (P2a SSOT scaffold), #10536 (P2b alias), #10551 (P2c hardcoded migration).
