### PR TITLE
fix(gh-validation): inline allowed command list in blocked error (#10561)

### DIFF
--- a/lib/gh_command_validation.ml
+++ b/lib/gh_command_validation.ml
@@ -215,10 +215,16 @@ let validate_gh_command ?(allowed_orgs = []) cmd =
     | (Some command, subcmd) ->
       let command = String.lowercase_ascii command in
       if not (List.mem command gh_allowed_commands) then
+        (* #10561: inline the allowed list so the LLM sees valid alternatives
+           on the same retry instead of random-guessing into the next
+           [gh_command_blocked] error.  Same pattern as
+           [path_not_found_under_allowed_roots] which surfaces roots=[...].
+           Memory: feedback_tool-error-messages-teach-llm. *)
         Error
           (Printf.sprintf
-             "gh command blocked: '%s' is not in the approved command list"
-             command)
+             "gh command blocked: '%s' is not in the approved command list (allowed=[%s])"
+             command
+             (String.concat ", " gh_allowed_commands))
       else
         let sub =
           Option.value ~default:"" subcmd |> String.lowercase_ascii

--- a/test/dune
+++ b/test/dune
@@ -675,6 +675,7 @@
         test_keeper_runtime_denylist
         test_keeper_runtime_config_ssot
         test_dashboard_render_timing_9766
+        test_gh_command_blocked_message_10561
         test_keeper_turn_timeout_default_10456
         test_task_status_label_10421
         test_task_completion_path_10449
@@ -863,6 +864,7 @@
         test_keeper_runtime_denylist
         test_keeper_runtime_config_ssot
         test_dashboard_render_timing_9766
+        test_gh_command_blocked_message_10561
         test_keeper_turn_timeout_default_10456
         test_task_status_label_10421
         test_task_completion_path_10449

--- a/test/test_gh_command_blocked_message_10561.ml
+++ b/test/test_gh_command_blocked_message_10561.ml
@@ -1,0 +1,46 @@
+(** #10561: pin the [gh_command_blocked] error to surface the allowed
+    command list inline so the LLM can self-correct on the same retry
+    instead of random-guessing into the next [gh_command_blocked] event
+    (13 events / day pre-fix, executor circuit_breaker tripped 1x). *)
+
+open Alcotest
+
+module GHV = Masc_mcp.Gh_command_validation
+
+let contains s sub =
+  let n = String.length s and m = String.length sub in
+  let rec loop i =
+    if i + m > n then false
+    else if String.sub s i m = sub then true
+    else loop (i + 1)
+  in
+  loop 0
+
+let test_disallowed_command_surfaces_allowed_list () =
+  match GHV.validate_gh_command "auth login" with
+  | Ok _ -> failf "expected gh_command_blocked for 'auth'"
+  | Error msg ->
+      check bool
+        (Printf.sprintf "error must mention allowed list — got: %s" msg)
+        true
+        (contains msg "allowed=[" && contains msg "pr"
+         && contains msg "issue" && contains msg "repo");
+      check bool "error must still mention the rejected command" true
+        (contains msg "'auth'")
+
+let test_allowed_command_passes () =
+  match GHV.validate_gh_command "pr list --state open" with
+  | Ok _ -> ()
+  | Error msg -> failf "expected pr list to pass, got: %s" msg
+
+let () =
+  run "gh_command_blocked_message_10561"
+    [
+      ( "error-message-shape",
+        [
+          test_case "disallowed command lists allowed alternatives" `Quick
+            test_disallowed_command_surfaces_allowed_list;
+          test_case "allowed command (pr list) still passes" `Quick
+            test_allowed_command_passes;
+        ] );
+    ]


### PR DESCRIPTION
## 요약

\`gh_command_blocked\` 에러가 어떤 subcommand가 허용되는지 LLM에 안 알려줌 → random retry → 13 events/day, executor circuit_breaker 1회 trip. allowed list inline으로 self-correct 가능.

## 변경

\`lib/gh_command_validation.ml:217-221\`:

**Before:**
\`\`\`
gh command blocked: 'auth' is not in the approved command list
\`\`\`

**After:**
\`\`\`
gh command blocked: 'auth' is not in the approved command list
  (allowed=[api, cache, gist, issue, label, pr, project, release,
            repo, ruleset, run, search, status, workflow])
\`\`\`

\`test/test_gh_command_blocked_message_10561.ml\` 신규 (2/2 pass): allowed marker + representative subset (pr/issue/repo) pin.

## 검증

\`\`\`
DUNE_CACHE=disabled dune build --root . --cache=disabled @check  → EXIT=0
dune exec test/test_gh_command_blocked_message_10561.exe         → 2/2 OK
\`\`\`

## 영향

- 13 events/day → 의미 있게 감소 예상 (LLM이 같은 retry에서 다른 allowed subcommand 선택)
- circuit_breaker trip rate 감소
- memory \`feedback_tool-error-messages-teach-llm\` family 정착

## 관련

- Issue: \`#10561\`
- 동일 패턴: \`path_not_found_under_allowed_roots\` (이미 \`roots=[...]\` 표시)
- Memory: \`feedback_tool-error-messages-teach-llm\`, \`feedback_gate-response-llm-readable\`

## Defensive guards

Draft + \`do-not-merge\`.