### PR TITLE
perf(lists): replace List.length emptiness check with [] equality (13 hunks)

### DIFF
--- a/lib/cdal/adversarial_eval.ml
+++ b/lib/cdal/adversarial_eval.ml
@@ -301,7 +301,7 @@ let check_untested_additions inputs =
         not (String.length base > 5 && String.starts_with ~prefix:"test_" base))
       changed_paths
   in
-  if List.length lib_files > 0 && not has_test_file then
+  if lib_files <> [] && not has_test_file then
     [
       {
         finding_id = next_finding_id ();

--- a/lib/coord/resilience.ml
+++ b/lib/coord/resilience.ml
@@ -82,7 +82,7 @@ module ZeroZombie = struct
       Returns list of cleaned agent names. *)
   let cleanup ~cleanup_fn =
     let cleaned = cleanup_fn () in
-    if List.length cleaned > 0 then begin
+    if cleaned <> [] then begin
       global_stats.total_cleanups <- global_stats.total_cleanups + 1;
       global_stats.last_cleanup_ts <- Time.now ();
       global_stats.last_cleaned_agents <- cleaned

--- a/lib/dashboard.ml
+++ b/lib/dashboard.ml
@@ -83,7 +83,7 @@ let format_section (s : section) : string =
   let top_border = header ^ String.make (border_len - String.length header) '=' in
   let bottom_border = String.make border_len '-' in
   let content =
-    if List.length s.content = 0 then
+    if s.content = [] then
       [Printf.sprintf "  %s" s.empty_msg]
     else
       List.map (fun line ->

--- a/lib/dashboard/dashboard_execution_sessions.ml
+++ b/lib/dashboard/dashboard_execution_sessions.ml
@@ -170,7 +170,7 @@ let build_session_seed session_json _cards =
       if explicit > 0 then explicit else List.length member_names
     in
     let counts_basis =
-      if List.length (string_list_of_json (member_assoc "planned_participants" summary)) > 0 then
+      if string_list_of_json (member_assoc "planned_participants" summary) <> [] then
         "live=recent_turns · planned=planned_participants"
       else
         "live=recent_turns · planned=known_members"

--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -200,7 +200,7 @@ let _build_session_context session_json _cards =
       if explicit > 0 then explicit else List.length member_names
     in
     let counts_basis =
-      if List.length (string_list_of_json (member_assoc "planned_participants" summary)) > 0 then
+      if string_list_of_json (member_assoc "planned_participants" summary) <> [] then
         "live=recent_turns · planned=planned_participants"
       else
         "live=recent_turns · planned=known_members"

--- a/lib/institution_eio.ml
+++ b/lib/institution_eio.ml
@@ -545,7 +545,7 @@ let format_for_injection ?(include_patterns=true) ?(max_patterns=5) (inst : inst
   ) inst.succession.onboarding_steps;
 
   (* Alumni Network *)
-  if List.length inst.alumni > 0 then begin
+  if inst.alumni <> [] then begin
     let recent_alumni = List.filteri (fun i _ -> i < 3) inst.alumni in
     Buffer.add_string buf (Printf.sprintf "\n👥 Recent predecessors: %s\n"
       (String.concat ", " recent_alumni))

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1600,7 +1600,7 @@ let run_turn
               let tool_choice =
                 if computed_surface.is_last_turn
                 then current_params.tool_choice
-                else if computed_surface.tool_gate_requested && List.length all_allowed > 0
+                else if computed_surface.tool_gate_requested && all_allowed <> []
                 then
                   Some
                     (preferred_tool_choice_for_required_turn

--- a/lib/metrics_store_eio.ml
+++ b/lib/metrics_store_eio.ml
@@ -240,7 +240,7 @@ let get_recent config ~agent_id ~days : task_metric list =
 (** Calculate aggregated metrics for fitness - synchronous *)
 let calculate_agent_metrics config ~agent_id ~days : agent_metrics option =
   let metrics = get_recent config ~agent_id ~days in
-  if List.length metrics = 0 then
+  if metrics = [] then
     None
   else
     let now = Time_compat.now () in
@@ -265,7 +265,7 @@ let calculate_agent_metrics config ~agent_id ~days : agent_metrics option =
     (* Calculate handoff success rate *)
     let handoffs = List.filter (fun m -> Option.is_some m.handoff_from || Option.is_some m.handoff_to) metrics in
     let successful_handoffs = List.filter (fun m -> m.success) handoffs in
-    let handoff_rate = if List.length handoffs > 0 then
+    let handoff_rate = if handoffs <> [] then
       float_of_int (List.length successful_handoffs) /. float_of_int (List.length handoffs)
     else 1.0 in  (* No handoffs = perfect handoff rate *)
 

--- a/lib/procedural_memory.ml
+++ b/lib/procedural_memory.ml
@@ -196,7 +196,7 @@ let top_procedures ~agent_name ~limit : procedure list =
 (** Format procedures for capsule injection. *)
 let format_for_dna ~agent_name ~limit : string =
   let procs = top_procedures ~agent_name ~limit in
-  if List.length procs = 0 then ""
+  if procs = [] then ""
   else
     let lines = List.map (fun p ->
       sprintf "- %s (confidence: %.0f%%, evidence: %d)"

--- a/lib/tempo.ml
+++ b/lib/tempo.ml
@@ -104,7 +104,7 @@ let is_pending_task (task : Types.task) : bool =
 
 (** Calculate adaptive tempo based on task urgency *)
 let calculate_adaptive_tempo (tasks : Types.task list) : float * string =
-  if List.length tasks = 0 then
+  if tasks = [] then
     (default_config.max_interval_s, "idle - no pending tasks")
   else
     let urgent_count = List.filter (fun t -> t.Types.priority <= 2) tasks |> List.length in

--- a/lib/thompson_sampling.ml
+++ b/lib/thompson_sampling.ml
@@ -605,7 +605,7 @@ let select_with_feedback ~agents ~max_n ~pending_triggers ~tick_interval_s =
     Max = ln(n_agents) for uniform selection. *)
 let selection_entropy () =
   let stats = get_all_stats () in
-  if List.length stats = 0 then 0.0
+  if stats = [] then 0.0
   else begin
     let total_selections = List.fold_left (fun acc s -> acc + s.selections) 0 stats in
     if total_selections = 0 then 0.0

--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -93,7 +93,7 @@ let parse_frontmatter content =
   let lines = String.split_on_char '\n' content in
   let rec find_end acc = function
     | [] -> (List.rev acc, [])
-    | "---" :: rest when List.length acc > 0 -> (List.rev acc, rest)
+    | "---" :: rest when acc <> [] -> (List.rev acc, rest)
     | line :: rest -> find_end (line :: acc) rest
   in
   match lines with


### PR DESCRIPTION
## What

`List.length lst = 0`/`List.length lst > 0`을 `lst = []`/`lst <> []`로 교체. 13 hunk × 12 파일.

`List.length`는 O(N) (list 끝까지 walk). 빈 리스트 검사는 O(1) head-cell 패턴 매칭으로 충분.

## Files

- `lib/thompson_sampling.ml`: agent stats 빈 검사 (selection entropy)
- `lib/dashboard.ml`: dashboard section content 빈 검사
- `lib/metrics_store_eio.ml`: metrics + handoffs 빈 검사 (handoffs는 분모 재사용으로 emptiness check만 변환)
- `lib/tempo.ml`: pending tasks 빈 검사 (adaptive tempo)
- `lib/tool_library.ml`: parser accumulator 빈 검사 (frontmatter 파싱 hot loop)
- `lib/institution_eio.ml`: alumni 빈 검사
- `lib/procedural_memory.ml`: top procedures 빈 검사
- `lib/coord/resilience.ml`: cleanup 결과 빈 검사 (event)
- `lib/cdal/adversarial_eval.ml`: lib_files 빈 검사 (changed_paths 분류)
- `lib/dashboard/dashboard_mission.ml`: planned_participants 빈 검사 (dashboard render)
- `lib/dashboard/dashboard_execution_sessions.ml`: 동상
- `lib/keeper/keeper_agent_run.ml`: tool_gate all_allowed 빈 검사 (매 keeper turn)

## Why

`List.length lst = 0`은 short-circuit 없이 list 끝까지 fold. 1024 element list면 1024 cons cell traversal 후 0 비교. 반면 `lst = []`는 head pattern 1 비교로 immediate. Hot path (dashboard render, keeper turn, tempo loop, metrics aggregation, parsing) 적용 시 차이가 큼.

## Test

`OCAMLPARAM='_,warn-error=+a' dune build @check` clean. polymorphic equality는 `[]`와 비교 시 head-cell match로 컴파일 — 일반 `(=)` 호출 없이 inline 가능.

## Boundary cases not changed

- `List.length lst <= N` (N>0): emptiness가 아닌 경계 조건 — 보존
- `let n = List.length lst in ... n ...`: length 자체를 변수로 사용 — 보존
- `List.length handoffs > 0` 직후 `... List.length handoffs`: 분모 재사용 케이스는 emptiness check만 `<>` []로 변환, 분모는 그대로 (한 번은 어차피 length 호출)
