### PR TITLE
fix(keeper-supervisor): handle Stale_turn_timeout in cohort_key (P0 build + #10565)

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -611,6 +611,7 @@ let cohort_key_of_reason = function
   | Some (Keeper_registry.Heartbeat_consecutive_failures _) -> "heartbeat_failures"
   | Some (Keeper_registry.Turn_consecutive_failures _) -> "turn_failures"
   | Some (Keeper_registry.Ambiguous_partial_commit _) -> "ambiguous_partial_commit"
+  | Some (Keeper_registry.Stale_turn_timeout _) -> "stale_turn_timeout"
   | Some Keeper_registry.Fiber_unresolved -> "fiber_unresolved"
   | Some (Keeper_registry.Exception _) -> "exception"
   | None -> "unknown"


### PR DESCRIPTION
## P0 — main build broken + #10565 test fail

main이 Stale_turn_timeout variant 추가 후 cohort_key_of_reason 미업데이트로 빌드 깨짐:

\`\`\`
File \"lib/keeper/keeper_supervisor.ml\", lines 610-616
Error (warning 8 [partial-match]): not matched: Some (Stale_turn_timeout _)
\`\`\`

## 변경

\`lib/keeper/keeper_supervisor.ml:611\` cohort_key_of_reason에 \`Stale_turn_timeout → \"stale_turn_timeout\"\` 1줄 추가 (sibling 명명 규칙 따름).

## 검증

\`\`\`
dune build @check                       → EXIT=0
dune exec test/test_config_doctor.exe   → 8/8 OK (이전: 1 fail)
\`\`\`

## #10565 부수 효과

\`test_config_doctor\` doctor.007 \"warn vs error\" failure는 별도 root cause가 아니라 partial-match 빌드 실패가 stale test 바이너리를 produce한 결과. P0 fix 후 8/8 정상.

## Defensive guards

P0 hotfix이므로 Draft 비활성, 즉시 머지 권장.