### PR TITLE
fix(keeper-supervisor): add Stale_turn_timeout cohort key (P0 main build)

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -610,6 +610,7 @@ let cleanup_dead_tombstone (ctx : _ context)
 let cohort_key_of_reason = function
   | Some (Keeper_registry.Heartbeat_consecutive_failures _) -> "heartbeat_failures"
   | Some (Keeper_registry.Turn_consecutive_failures _) -> "turn_failures"
+  | Some (Keeper_registry.Stale_turn_timeout _) -> "stale_turn_timeout"
   | Some (Keeper_registry.Ambiguous_partial_commit _) -> "ambiguous_partial_commit"
   | Some Keeper_registry.Fiber_unresolved -> "fiber_unresolved"
   | Some (Keeper_registry.Exception _) -> "exception"


### PR DESCRIPTION
## Problem

Main 빌드 깨짐. `OCAMLPARAM='_,warn-error=+a' dune build @check` 실패:

```
File "lib/keeper/keeper_supervisor.ml", lines 610-616
Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
  Here is an example of a case that is not matched:
    Some (Stale_turn_timeout _)
```

#10540 `fix(keeper): stale watchdog triggers fiber restart instead of cosmetic broadcast`이 `Keeper_registry.failure_reason`에 `Stale_turn_timeout of float` variant를 추가했지만, 같은 ADT를 매치하는 `cohort_key_of_reason` (lib/keeper/keeper_supervisor.ml:610) 업데이트 누락 → strict mode 빌드 실패 → 모든 PR cascade fail.

## Fix

해당 variant를 `"stale_turn_timeout"` cohort key로 추가. self-preservation gate의 dominant-cohort 분류가 새 failure mode를 정확히 묶도록 함 (이전엔 partial match로 미분류 → fall-through 동작 정의 자체가 없었음).

## Verification

```
$ OCAMLPARAM='_,warn-error=+a' dune build @check
$ # clean
```

## Why fix-forward

`#10540`이 introducted한 stale-watchdog는 fleet-stall recovery의 핵심 — revert 부적절. 1줄 cohort key 추가가 최소 변경. variant 추가 PR이 모든 매치 사이트를 sweep하는 lint를 도입할 가치가 있음 (별도 follow-up).
