### PR TITLE
perf(lookup): replace try Hashtbl.find/Unix.getenv with _opt variants (2 hot paths)

### DIFF
--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -24,9 +24,8 @@ let rec resolve_arg = function
       let buf = Buffer.create 64 in
       List.iter (fun a -> Buffer.add_string buf (resolve_arg a)) parts;
       Buffer.contents buf
-  | Var name -> (
-      try Unix.getenv name
-      with Not_found -> "")
+  | Var name ->
+      (match Sys.getenv_opt name with Some v -> v | None -> "")
 
 let resolve_env env_bindings =
   List.map

--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -1323,7 +1323,9 @@ let provider_rollup (agg : aggregate) : provider_stats list =
       | None -> ()
       | Some p ->
         let existing =
-          try Hashtbl.find by_provider p with Not_found -> []
+          match Hashtbl.find_opt by_provider p with
+          | Some v -> v
+          | None -> []
         in
         Hashtbl.replace by_provider p (m :: existing))
     agg.models;


### PR DESCRIPTION
## What

`try ... with Not_found -> default` → `_opt` 변형으로 교체.

- `lib/exec/exec_dispatch.ml:27-29`: `Var name -> try Unix.getenv name with Not_found -> ""` → `Sys.getenv_opt`
- `lib/model_inference_metrics.ml:1320`: `try Hashtbl.find by_provider p with Not_found -> []` → `Hashtbl.find_opt` + match

## Why

`try/with` exception 경로는 OCaml에서 cheap이지만 `Printexc.backtrace` 활성화 시 stack trace 빌드 cost가 발생 (production CI에서 종종 활성화). `_opt` 변형은 fast-path에서 exception 회피 + 의도 명시적.

- `Var name`: shell IR resolution. 매 dispatch_simple 호출 시 모든 arg마다 호출 — keeper subprocess execution hot path.
- `Hashtbl.find by_provider p`: model inference metrics aggregation. provider별 모델 stats roll-up — dashboard render마다.

## Test

`OCAMLPARAM='_,warn-error=+a' dune build @check` clean (rebase #10574 후).

## Note

이 PR base는 #10574 (P0 stale-turn-timeout cohort fix) 머지 대기 중. main 빌드 깨짐 (Stale_turn_timeout cohort 누락)이 풀리면 자동 unblock.
