### PR TITLE
feat(cascade): classify provider error_kind in record_failure

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -1506,10 +1506,43 @@ let run_named
           Cascade_health_tracker.(
             record_terminal_failure global ~provider_key:provider_cfg.model_id
               ~error_kind:"resumable_cli_session" ~error_reason:err_str ())
-        else
+        else (
+          (* Classify the err_str into named buckets so Cascade_health_tracker
+             fingerprint groups separate codex internal-state corruption
+             (transient_codex_rollout — auto-recovers on next call) from
+             provider-permanent failures (e.g. kimi_cli auth-rejected) and
+             generic CLI exit (network_other).  Without this, every
+             [stop=error] is grouped under a single "failure" kind and
+             dashboards can't tell a known-recoverable bug pattern from a
+             persistent provider outage.  Pattern observed: 89 codex /
+             34 kimi / 13 claude exit-1 events in 3h (#10000-class). *)
+          let error_kind =
+            let contains needle hay =
+              let nl = String.length needle in
+              let hl = String.length hay in
+              let rec loop i =
+                i + nl <= hl
+                && (String.sub hay i nl = needle || loop (i + 1))
+              in
+              loop 0
+            in
+            if contains "thread " err_str
+               && contains " not found" err_str
+               && contains "rollout" err_str
+            then "transient_codex_rollout"
+            else if contains "kimi_cli rejected" err_str then
+              "permanent_kimi_rejected"
+            else if contains "Network error: codex exited" err_str then
+              "network_codex_other"
+            else if contains "Network error: claude exited" err_str then
+              "network_claude_other"
+            else if contains "Network error: gemini exited" err_str then
+              "network_gemini_other"
+            else "failure"
+          in
           Cascade_health_tracker.(
             record_failure global ~provider_key:provider_cfg.model_id
-              ~error_kind:"failure" ~error_reason:err_str ());
+              ~error_kind ~error_reason:err_str ()));
         (* FSM: Call_err → decide *)
         (match sdk_error_to_cascade_outcome sdk_err with
          | Some outcome ->


### PR DESCRIPTION
## Summary

Cascade_health_tracker fingerprint groups all 136 provider failures today (3hr fleet activity) under single error_kind=\`failure\`. Operators can't distinguish codex internal-state bugs (auto-recoverable) from persistent provider auth failures.

## 변경

\`lib/oas_worker_named.ml\` — pattern-match err_str into named buckets BEFORE record_failure call.

| pattern | error_kind |
|---------|-----------|
| \`thread <UUID> not found\` + \`rollout\` | transient_codex_rollout |
| \`kimi_cli rejected\` | permanent_kimi_rejected |
| \`Network error: codex exited\` | network_codex_other |
| \`Network error: claude exited\` | network_claude_other |
| \`Network error: gemini exited\` | network_gemini_other |
| else | failure (fallback) |

## 정량 증거 (2026-04-26 fleet 3hr)

- 89 codex (gpt-5.2/5.4/5.5/5.4-mini) — \`codex_core::session: failed to record rollout items: thread <UUID> not found\`
- 34 kimi-for-coding — \`kimi_cli rejected the request\`
- 13 auto (claude_code) — \`claude exited with code 1\`
- 15 cascade exhaustion → 9 anti-rationalization \`LLM unavailable\` events

## 효과

- **Observability only** — record_failure outcome / FSM decision / cascade fallback 동일
- 분류 데이터 production에 누적되면 — 향후 PR 후보 1) per-kind cooldown 차등 2) transient_codex_rollout single-retry 3) provider rotation policy

## Risk

Low — error_kind 라벨만 변경. behavior 변화 0.

## Out of scope

- per-error-kind retry/cooldown 차등 (별도 PR)
- transient_codex_rollout 자동 single-retry (별도 PR)
- main build 차단 \`keeper_supervisor.ml Stale_turn_timeout\` partial-match — #10572 / #10574 in flight, 본 PR에서 중복 fix 안 함

## Test plan

- [x] dune build lib/ green
- [ ] CI green (main fix 머지 의존)
- [ ] post-merge: production log에서 분류된 error_kind 빈도 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)