### PR TITLE
feat(design-system): migrate kpi.css to semantic aliases (PR-M9)

### DIFF
--- a/dashboard/design-system/source_styles/kpi.css
+++ b/dashboard/design-system/source_styles/kpi.css
@@ -20,7 +20,7 @@
 .kpi-cell {
   position: relative;
   padding: calc(var(--sp-inline) + 2px) var(--sp-gutter);
-  border-right: 1px solid var(--line-1);
+  border-right: 1px solid var(--color-border-default);
   display: flex; flex-direction: column; justify-content: space-between;
   gap: var(--sp-inline);
   min-width: 0; overflow: hidden;
@@ -47,7 +47,7 @@
   font: var(--type-label);
   letter-spacing: var(--track-caps);
   text-transform: uppercase;
-  color: var(--fg-3);
+  color: var(--color-fg-muted);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   min-width: 0;
 }
@@ -62,7 +62,7 @@
   font: var(--type-kpi-l);
   font-weight: var(--fw-med);
   font-variant-numeric: tabular-nums;
-  color: var(--fg-1);
+  color: var(--color-fg-primary);
   letter-spacing: var(--track-tight);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;
   transition: color var(--motion-swap);
@@ -70,7 +70,7 @@
 
 .kpi-unit {
   font: var(--type-caption);
-  color: var(--fg-3);
+  color: var(--color-fg-muted);
   text-transform: uppercase;
   letter-spacing: var(--track-wide);
 }
@@ -98,7 +98,7 @@
 /* SVG sparks (polyline/path) */
 .spark path, .spark polyline {
   fill: none;
-  stroke: var(--brass-1);
+  stroke: var(--color-accent-fg);
   stroke-width: 1;
   opacity: .7;
 }
@@ -130,7 +130,7 @@
 .kpi-cell.is-brass .kpi-value { color: var(--brass-fg); }
 .kpi-cell.is-brass {
   background: linear-gradient(0deg, var(--brass-soft), transparent 70%);
-  box-shadow: inset 2px 0 0 var(--brass-1);
+  box-shadow: inset 2px 0 0 var(--color-accent-fg);
 }
 
 /* ── "Now" pulse — active / live-updating cell ── */
@@ -142,7 +142,7 @@
 .kpi-cell.is-loading .kpi-value {
   color: transparent;
   background: linear-gradient(90deg,
-    var(--bg-2) 0%, var(--bg-3) 25%, var(--bg-2) 50%, var(--bg-3) 75%, var(--bg-2) 100%);
+    var(--color-bg-panel-alt) 0%, var(--color-bg-elevated) 25%, var(--color-bg-panel-alt) 50%, var(--color-bg-elevated) 75%, var(--color-bg-panel-alt) 100%);
   background-size: 200% 100%;
   animation: anim-shimmer 2s linear infinite;
   border-radius: var(--r-1);


### PR DESCRIPTION
Production CSS kpi.css 7 refs main-safe alias migration (bg/fg/line/brass-1).

Independent off main, no stack.

| Raw | Semantic |
|-----|----------|
| `--bg-N` | `--color-bg-*` |
| `--fg-1/2/3` | `--color-fg-primary/secondary/muted` |
| `--line-1/2` | `--color-border-default/strong` |
| `--brass-1` | `--color-accent-fg` |

Validation: raw 잔존 0, 시각 회귀 0 (alias resolve).
