### PR TITLE
hotfix(keeper-supervisor): drop duplicate Stale_turn_timeout cohort_key arm

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -612,7 +612,6 @@ let cohort_key_of_reason = function
   | Some (Keeper_registry.Turn_consecutive_failures _) -> "turn_failures"
   | Some (Keeper_registry.Stale_turn_timeout _) -> "stale_turn_timeout"
   | Some (Keeper_registry.Ambiguous_partial_commit _) -> "ambiguous_partial_commit"
-  | Some (Keeper_registry.Stale_turn_timeout _) -> "stale_turn_timeout"
   | Some Keeper_registry.Fiber_unresolved -> "fiber_unresolved"
   | Some (Keeper_registry.Exception _) -> "exception"
   | None -> "unknown"


### PR DESCRIPTION
## 요약

`lib/keeper/keeper_supervisor.ml`의 `cohort_key_of_reason` 함수에서 중복된 `Some (Keeper_registry.Stale_turn_timeout _) -> "stale_turn_timeout"` arm 제거 (line 615). main 빌드 복구.

## 원인

#10572 (`P0 build + #10565`, merged 05:46Z) + #10574 (`P0 main build`, merged 05:48Z) 모두 `Stale_turn_timeout` 변수 cohort_key 처리를 추가했고, 두 PR이 90초 차이로 머지되어 line 613 + line 615에 동일 arm이 두 번 들어감 → `Error (warning 11 [redundant-case])` warn-error로 빌드 깨짐.

같은 race 패턴이 오늘 두 번째:
- 04:43Z: #10489 + #10490 InferenceTelemetry 16초 race → #10511 dedup
- 05:48Z: #10572 + #10574 Stale_turn_timeout 90초 race → 이 PR

## 수정

```diff
   | Some (Keeper_registry.Stale_turn_timeout _) -> "stale_turn_timeout"
   | Some (Keeper_registry.Ambiguous_partial_commit _) -> "ambiguous_partial_commit"
-  | Some (Keeper_registry.Stale_turn_timeout _) -> "stale_turn_timeout"
   | Some Keeper_registry.Fiber_unresolved -> "fiber_unresolved"
```

원본 arm은 line 613에 그대로 두고, 중복된 line 615만 제거. 의도된 매칭 동작 변경 없음.

## 추적: governance gap

24h 내 같은 race-merge가 main을 두 번 깨트림. 근본 fix는 별도 issue 필요:
- auto-merge가 *다른 작성자/branch의 동일 PR 영역 머지*를 base re-verify 없이 허용 → race window 발생
- `feedback_check-existing-prs-before-fix` 메모리는 *PR 작성 시점*에만 적용되어 *autocoder fleet 내 동시 작업* 미감지

`feedback_check-existing-prs-before-fix` 메모리 + `feedback_oas-pin-bump-drift-gate`의 *internal variant drift*로 확장 검토.

🤖 by /loop 10m masc-mcp PR maintenance (auto-mode)
