### PR TITLE
fix: pause directive persist + drop duplicate cohort key (P0 + #10583)

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -612,7 +612,6 @@ let cohort_key_of_reason = function
   | Some (Keeper_registry.Turn_consecutive_failures _) -> "turn_failures"
   | Some (Keeper_registry.Stale_turn_timeout _) -> "stale_turn_timeout"
   | Some (Keeper_registry.Ambiguous_partial_commit _) -> "ambiguous_partial_commit"
-  | Some (Keeper_registry.Stale_turn_timeout _) -> "stale_turn_timeout"
   | Some Keeper_registry.Fiber_unresolved -> "fiber_unresolved"
   | Some (Keeper_registry.Exception _) -> "exception"
   | None -> "unknown"

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -905,7 +905,17 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
           | Some _ | None -> ()
         in
         let proceed () =
+          (* #10583: pause was missing from the first match, falling
+             through to the [_] arm and emitting a false
+             "Unknown keeper directive: pause" WARN even though the
+             second match (line 923) handles pause correctly. The
+             persisted paused=true also was not reaching meta.json
+             because persist_paused_state(true) was never called for
+             the pause action. Adding the case here both removes the
+             false WARN and restores meta-side durability so the next
+             server restart preserves the operator's pause decision. *)
           (match action_str with
+           | "pause" -> persist_paused_state true
            | "resume" -> persist_paused_state false
            | "wakeup" -> ()
            | _ ->


### PR DESCRIPTION
## P0 — main build broken (이번에도)

#10572 + #10574 parallel-merge 후 동일 \`Stale_turn_timeout\` arm이 두 번 추가됨 → warning 11 (redundant-case) → main 빌드 깨짐.

\`\`\`
File \"lib/keeper/keeper_supervisor.ml\", line 615
Error (warning 11 [redundant-case]): this match case is unused.
\`\`\`

본 PR은 이 P0와 #10583 (pause directive 누락)을 함께 처리.

## 변경

**1. \`lib/keeper/keeper_supervisor.ml:613-615\`** — 중복 Stale_turn_timeout 1줄 삭제 (#10572가 13행, #10574가 615행 위치에 동일 case 추가)

**2. \`lib/server/server_dashboard_http_keeper_api.ml:907-912\`** — \"pause\" 케이스 추가 (#10583):
- false WARN \"Unknown keeper directive: pause\" 제거
- \`persist_paused_state(true)\` 호출 → 다음 서버 재시작 후 pause 상태 유지

## 검증

\`\`\`
DUNE_CACHE=disabled dune build --root . --cache=disabled @check  → EXIT=0
\`\`\`

## 비고

이슈 #10584가 정확히 이 패턴(parallel-PR 동시 add → 중복 case → P0)을 일반화. 메모리 \`feedback_parallel-autocoder-branch-contention\` family.

## Defensive guards

P0 hotfix (Draft 비활성, do-not-merge 미부착) — 즉시 머지 권장.