### PR TITLE
fix(check-oas-pin): allow capped floor pattern in dune-project + .opam regex

### DIFF
--- a/scripts/check-oas-pin.sh
+++ b/scripts/check-oas-pin.sh
@@ -92,12 +92,16 @@ else
   echo "OAS pin override in use: ${pin_source}"
 fi
 
-if ! grep -Eq "\\(agent_sdk \\(>= ${min_version_re}\\)\\)" "${REPO_ROOT}/dune-project"; then
+# Accept both bare floor [(agent_sdk (>= X.Y.Z))] and capped floor
+# [(agent_sdk (and (>= X.Y.Z) (< W.V.U)))]. Cap is allowed because the
+# OAS pin SHA may transiently exceed the previous minor while masc-mcp
+# opts into a forward upper bound. Floor must remain exact.
+if ! grep -Eq "\\(agent_sdk (\\(>= ${min_version_re}\\)|\\(and \\(>= ${min_version_re}\\))" "${REPO_ROOT}/dune-project"; then
   echo "dune-project agent_sdk floor is not ${OAS_AGENT_SDK_MIN_VERSION}" >&2
   exit 1
 fi
 
-if ! grep -Eq "\"agent_sdk\" \\{>= \"${min_version_re}\"\\}" "${REPO_ROOT}/masc_mcp.opam"; then
+if ! grep -Eq "\"agent_sdk\" \\{>= \"${min_version_re}\"" "${REPO_ROOT}/masc_mcp.opam"; then
   echo "masc_mcp.opam agent_sdk floor is not ${OAS_AGENT_SDK_MIN_VERSION}" >&2
   exit 1
 fi


### PR DESCRIPTION
## Problem

`#10592`로 cap raise 머지 후 main의 `dune-project`/`masc_mcp.opam`은 capped form:
- `(agent_sdk (and (>= 0.176.0) (< 0.178.0)))`
- `"agent_sdk" {>= "0.176.0" & < "0.178.0"}`

그런데 `scripts/check-oas-pin.sh:95,100`의 floor 검사 regex가 bare form만 매치:
- `\(agent_sdk \(>= ${min_version_re}\)\)` (capped form 거부)
- `"agent_sdk" \{>= "${min_version_re}"\}` (cap 부분 거부)

→ Meta Guards 단계 fail: `dune-project agent_sdk floor is not 0.176.0`. main + 모든 후속 PR cascade FAILURE.

## Fix

regex broaden:
- `\(agent_sdk (\(>= X\)|\(and \(>= X\))` — bare 또는 capped form 둘 다 수용
- `"agent_sdk" \{>= "X"` — trailing `}` 검사 제거 (cap 추가 시 `& < "Y"}` 형태가 됨)

floor exact match는 유지 (`X` = `${min_version_re}`).

## Verification

```
$ bash scripts/check-oas-pin.sh
OAS pin verified: main@367de4e5a406e07af844c370c23b7c05c572a5e0 (base version v0.176.0)
OAS API surface: ✓ matches fingerprint
```

## Why fix-forward

cap을 다시 빼면 #10592가 fix하던 solver impossible로 돌아감. regex가 capped form을 받지 못하던 게 root cause — pin/cap drift gate를 추가하면서 regex도 같이 update됐어야 함.

## Note

`#10592` 작업 중 같은 commit에 묶었지만 그 PR이 (다른 fixer로) 빠르게 squash-merged → 두 번째 commit이 deleted branch에 push되는 위반(memory `feedback_no-push-after-squash-merge.md`) 직전 탐지 → 새 PR로 분리.
