### PR TITLE
feat(config): add Git_meta + Shell_probe callers to exec_timeout SSOT (#10426 follow-up)

### DIFF
--- a/lib/config/env_config_exec_timeout.ml
+++ b/lib/config/env_config_exec_timeout.ml
@@ -27,6 +27,8 @@ type caller =
   | Status_detail             (** keeper_status_detail health probes (5/10s) *)
   | Turn_sandbox              (** keeper_turn_sandbox_runtime (2/5s) *)
   | Turn_up                   (** keeper_turn_up_create / _update sandbox (15s) *)
+  | Git_meta                  (** local git metadata (rev-parse, remote get-url) (5s) *)
+  | Shell_probe               (** PATH probes via [command -v] (2s) *)
   | Unknown of string
 
 (** Hardcoded default seconds for each known caller.  Preserves
@@ -47,6 +49,8 @@ let caller_key = function
   | Status_detail -> "status_detail"
   | Turn_sandbox -> "turn_sandbox"
   | Turn_up -> "turn_up"
+  | Git_meta -> "git_meta"
+  | Shell_probe -> "shell_probe"
   | Unknown caller -> caller
 
 (** Exported for tests that pin the per-caller default table. *)
@@ -65,17 +69,20 @@ let known_callers () =
     Status_detail;
     Turn_sandbox;
     Turn_up;
+    Git_meta;
+    Shell_probe;
   ]
 
 let known_default_sec = function
   | Shell -> Some 60.0
   | Fs -> Some 30.0
   | Preflight | Repo_readiness | Gh_shared | Status_detail -> Some 10.0
-  | Sandbox | Turn_sandbox -> Some 2.0
+  | Sandbox | Turn_sandbox | Shell_probe -> Some 2.0
   | Pr_review | Turn_up -> Some 15.0
   | Alerting -> Some 20.0
   | Dispatch -> Some 120.0
   | Memory_audit -> Some 3.0
+  | Git_meta -> Some 5.0
   | Unknown _ -> None
 
 let upper_case s =

--- a/lib/config/env_config_exec_timeout.mli
+++ b/lib/config/env_config_exec_timeout.mli
@@ -19,6 +19,16 @@ type caller =
   | Status_detail
   | Turn_sandbox
   | Turn_up
+  | Git_meta
+      (** Local git metadata commands (e.g. [git remote get-url],
+          [git rev-parse]).  Default 5.0s — these are local disk
+          operations that should complete in <1s; a 5s ceiling
+          surfaces NFS hangs or repository corruption without
+          masking them. *)
+  | Shell_probe
+      (** PATH availability probes (e.g. [command -v <name>]).
+          Default 2.0s — pure OS lookup; longer timeouts mask
+          shell-startup misconfiguration rather than helping. *)
   | Unknown of string
 
 (** [caller_key c] is the lowercase identifier embedded in env var

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -332,7 +332,11 @@ let shell_command_available name =
   let probe =
     Printf.sprintf "command -v %s >/dev/null 2>&1" (Filename.quote name)
   in
-  match run_argv_with_status_retry_eintr ~timeout_sec:2.0 [ "/bin/sh"; "-c"; probe ] with
+  match
+    run_argv_with_status_retry_eintr
+      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Shell_probe ())
+      [ "/bin/sh"; "-c"; probe ]
+  with
   | Unix.WEXITED 0, _ -> true
   | _ -> false
 (** Write playground repo state cache after successful clone/pull.

--- a/lib/keeper/keeper_gh_shared.ml
+++ b/lib/keeper/keeper_gh_shared.ml
@@ -648,7 +648,9 @@ let repo_slug_of_git_root ~git_root =
   | Some slug -> Some slug
   | None ->
     (match
-       Process_eio.run_argv_with_status ~cwd:git_root ~timeout_sec:5.0
+       Process_eio.run_argv_with_status
+         ~cwd:git_root
+         ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Git_meta ())
          [ "git"; "remote"; "get-url"; "origin" ]
      with
      | Unix.WEXITED 0, url -> repo_slug_of_remote_url url

--- a/test/test_env_config_exec_timeout_10426.ml
+++ b/test/test_env_config_exec_timeout_10426.ml
@@ -33,6 +33,8 @@ let cases =
     E.Status_detail, 10.0;
     E.Turn_sandbox, 2.0;
     E.Turn_up, 15.0;
+    E.Git_meta, 5.0;
+    E.Shell_probe, 2.0;
   ]
 
 let test_known_default_pin () =


### PR DESCRIPTION
## Why

Two new caller variants in `Env_config_exec_timeout` close gaps left by P2-A/B/C and absorb 2 of the 5 default-deviation sites tracked in #10594.

## What

| Variant | Default | Purpose | Migrated from |
|---------|---------|---------|---------------|
| `Git_meta` | 5.0s | local git metadata (`rev-parse`, `log --oneline`, `remote get-url`) | `keeper_gh_shared.ml:651` (`git remote get-url origin`) |
| `Shell_probe` | 2.0s | PATH availability checks (`command -v <name>`) | `keeper_exec_shell.ml:335` (`shell_command_available` helper) |

Both literals matched the new caller default exactly (5.0 → `Git_meta`, 2.0 → `Shell_probe`), so behavior is preserved byte-for-byte.

After this PR, operators can tune both classes independently:
- `MASC_EXEC_TIMEOUT_GIT_META_SEC=10` for slow NFS or large repos
- `MASC_EXEC_TIMEOUT_SHELL_PROBE_SEC=5` for shells with heavy startup

## Why these two together

`Git_meta` will absorb additional sites in subsequent PRs (other `keeper_*.ml` files have lightweight git ops at hardcoded 5.0s). Bundling `Shell_probe` keeps the variant additions in a single review surface.

## Diff

```
5 files changed, 28 insertions(+), 3 deletions(-)
 lib/config/env_config_exec_timeout.ml      |  9 ++++++++-
 lib/config/env_config_exec_timeout.mli     | 10 ++++++++++
 lib/keeper/keeper_exec_shell.ml            |  6 +++++-
 lib/keeper/keeper_gh_shared.ml             |  4 +++-
 test/test_env_config_exec_timeout_10426.ml |  2 ++
```

## Verification

- `dune build lib/ --root . --cache=disabled` → RC=0.
- `dune exec test/test_env_config_exec_timeout_10426.exe` → 9/9 pass (defaults pinned, env-override semantics, `known_callers` count match).

## What's next from #10594

| PR | Status |
|----|--------|
| Add `Git_meta` + `Shell_probe` (this PR) | ✅ |
| Bump `Alerting` default 15 → 20 + migrate `keeper_alerting.ml:452` | queued |
| Add `Pr_review_post` (30s) + migrate `keeper_tool_pr_review.ml:167` | queued |
| `keeper_tool_pr_review.ml:218` left hardcoded with comment | queued (smallest) |

---

Refs: #10426 (audit + plan), #10594 (deviation analysis), #10452 (P1 SSOT), #10502 (P2-C out-of-scope list).
