### PR TITLE
feat(design-system): migrate unsafe-alias categories across all surfaces (PR-M25)

### DIFF
--- a/dashboard/design-system/preview/brand.html
+++ b/dashboard/design-system/preview/brand.html
@@ -27,7 +27,7 @@
   .wordmark-dot {
     width: 14px; height: 14px; border-radius: 50%;
     background: var(--brass-1);
-    box-shadow: 0 0 12px rgb(var(--brass-glow)/.5);
+    box-shadow: 0 0 12px rgb(var(--color-accent-glow)/.5);
     position: relative;
   }
   .wordmark-dot::after {
@@ -40,7 +40,7 @@
     color: var(--fg-1);
   }
   .brass .wordmark-dot { background: #0c0b08; box-shadow: none; }
-  .brass .wordmark-dot::after { background: radial-gradient(circle at 35% 35%, rgb(var(--brass-glow)/.4), transparent 60%); }
+  .brass .wordmark-dot::after { background: radial-gradient(circle at 35% 35%, rgb(var(--color-accent-glow)/.4), transparent 60%); }
   .brass .wordmark-text { color: #0c0b08; }
 
   .brand-caption {
@@ -166,7 +166,7 @@
     left: 58%;
     width: 2px;
     background: linear-gradient(to bottom, transparent, var(--brass-1) 15%, var(--brass-1) 85%, transparent);
-    box-shadow: 0 0 16px rgb(var(--brass-glow)/.6);
+    box-shadow: 0 0 16px rgb(var(--color-accent-glow)/.6);
   }
   .meta-copy { flex: 1; display: flex; flex-direction: column; gap: 8px; max-width: 52%; }
   .meta-copy h3 {

--- a/dashboard/design-system/preview/code-mode.jsx
+++ b/dashboard/design-system/preview/code-mode.jsx
@@ -117,7 +117,7 @@ function Editor({ height = 520 }) {
         <div className="editor-minimap">
           <svg viewBox="0 0 60 520" width="100%" height="100%">
             {EDITOR_LINES.map((ln, i) => (
-              <rect key={i} x="6" y={i * 14 + 8} width={Math.random() * 40 + 6} height="2" fill={ln.diff === 'add' ? 'var(--ok)' : ln.diff === 'del' ? 'var(--err)' : 'var(--fg-4)'} opacity={ln.diff ? 0.7 : 0.3} />
+              <rect key={i} x="6" y={i * 14 + 8} width={Math.random() * 40 + 6} height="2" fill={ln.diff === 'add' ? 'var(--color-status-ok)' : ln.diff === 'del' ? 'var(--color-status-err)' : 'var(--color-fg-disabled)'} opacity={ln.diff ? 0.7 : 0.3} />
             ))}
             <rect className="minimap-viewport" x="0" y="40" width="60" height="140" />
           </svg>
@@ -272,24 +272,24 @@ function SplitMode({ w = 1400, h = 680 }) {
     <div style={{ display: 'grid', gridTemplateRows: '32px 26px 52px 180px minmax(0,1fr) 28px', width: w, height: h, background: 'var(--bg-0)', border: '1px solid var(--line-1)', borderRadius: 'var(--r-1)', overflow: 'hidden' }}>
       {/* topbar */}
       <div style={{ display: 'flex', alignItems: 'center', padding: '0 12px', gap: 10, background: 'var(--bg-1)', borderBottom: '1px solid var(--line-2)', fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--fg-2)' }}>
-        <div style={{ width: 14, height: 14, borderRadius: 2, background: 'linear-gradient(135deg, var(--brass-1), var(--brass-3))' }} />
+        <div style={{ width: 14, height: 14, borderRadius: 2, background: 'linear-gradient(135deg, var(--brass-1), var(--color-accent-fg-dim))' }} />
         <b style={{ color: 'var(--fg-1)', letterSpacing: '.04em' }}>MASC</b>
-        <span style={{ color: 'var(--fg-4)' }}>v0.42.1</span>
+        <span style={{ color: 'var(--color-fg-disabled)' }}>v0.42.1</span>
         <span style={{ width: 1, height: 14, background: 'var(--line-2)' }} />
-        <span>goal-merge-blockers <span style={{ color: 'var(--fg-4)' }}>▾</span></span>
+        <span>goal-merge-blockers <span style={{ color: 'var(--color-fg-disabled)' }}>▾</span></span>
         <div className="mode-switch" style={{ marginLeft: 12 }}>
           <button>COCKPIT</button>
           <button className="is-active">SPLIT</button>
           <button>CODE</button>
         </div>
-        <div style={{ marginLeft: 'auto', color: 'var(--fg-4)', fontSize: 10 }}>16:32:45Z · 5 keepers live</div>
+        <div style={{ marginLeft: 'auto', color: 'var(--color-fg-disabled)', fontSize: 10 }}>16:32:45Z · 5 keepers live</div>
       </div>
       {/* ticker */}
       <div style={{ display: 'flex', alignItems: 'center', padding: '0 12px', gap: 16, background: 'linear-gradient(to bottom, var(--bg-1), var(--bg-0))', borderBottom: '1px solid var(--line-1)', fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--fg-3)', whiteSpace: 'nowrap', overflow: 'hidden' }}>
         <span>16:32:40 <span style={{ color: 'var(--brass-1)' }}>nick0cave</span> edit keeper.ts:12</span>
-        <span>16:32:38 <span style={{ color: 'var(--err)' }}>qa-king</span> flag keeper.ts:10</span>
-        <span>16:32:33 <span style={{ color: 'var(--ok)' }}>sangsu</span> refactor tick()</span>
-        <span>16:32:29 <span style={{ color: 'var(--info)' }}>masc</span> commit c99012</span>
+        <span>16:32:38 <span style={{ color: 'var(--color-status-err)' }}>qa-king</span> flag keeper.ts:10</span>
+        <span>16:32:33 <span style={{ color: 'var(--color-status-ok)' }}>sangsu</span> refactor tick()</span>
+        <span>16:32:29 <span style={{ color: 'var(--color-status-info)' }}>masc</span> commit c99012</span>
       </div>
       {/* kpi mini */}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6,1fr)', gap: 1, background: 'var(--line-1)', borderBottom: '1px solid var(--line-2)' }}>
@@ -301,21 +301,21 @@ function SplitMode({ w = 1400, h = 680 }) {
           { l: 'cascade', v: '@2 · 1.24s' },
           { l: 'flags', v: '3', s: 'err' },
         ].map((k, i) => (
-          <div key={i} style={{ background: k.s === 'brass' ? 'rgb(var(--brass-glow)/.06)' : 'var(--bg-1)', padding: '8px 10px', display: 'flex', flexDirection: 'column', gap: 2, boxShadow: k.s === 'err' ? 'inset 2px 0 0 var(--err)' : k.s === 'ok' ? 'inset 2px 0 0 var(--ok)' : k.s === 'brass' ? 'inset 2px 0 0 var(--brass-1)' : 'none' }}>
+          <div key={i} style={{ background: k.s === 'brass' ? 'rgb(var(--color-accent-glow)/.06)' : 'var(--bg-1)', padding: '8px 10px', display: 'flex', flexDirection: 'column', gap: 2, boxShadow: k.s === 'err' ? 'inset 2px 0 0 var(--color-status-err)' : k.s === 'ok' ? 'inset 2px 0 0 var(--color-status-ok)' : k.s === 'brass' ? 'inset 2px 0 0 var(--brass-1)' : 'none' }}>
             <div style={{ fontSize: 9, letterSpacing: '.08em', color: 'var(--fg-3)', textTransform: 'uppercase', fontWeight: 600 }}>{k.l}</div>
             <div style={{ fontFamily: 'var(--font-mono)', fontSize: 15, color: k.s === 'err' ? 'var(--err-fg)' : k.s === 'ok' ? 'var(--ok-fg)' : k.s === 'brass' ? 'var(--brass-1)' : 'var(--fg-1)' }}>{k.v}</div>
           </div>
         ))}
       </div>
       {/* cockpit strip (180px): lifeline + mini swimlanes */}
-      <div style={{ display: 'grid', gridTemplateColumns: '280px minmax(0,1fr) 220px', background: 'var(--bg-0)', borderBottom: '2px solid var(--brass-3)', minHeight: 0, overflow: 'hidden' }}>
+      <div style={{ display: 'grid', gridTemplateColumns: '280px minmax(0,1fr) 220px', background: 'var(--bg-0)', borderBottom: '2px solid var(--color-accent-fg-dim)', minHeight: 0, overflow: 'hidden' }}>
         <div style={{ padding: 8, borderRight: '1px solid var(--line-1)', display: 'flex', flexDirection: 'column', gap: 4 }}>
           <div style={{ fontSize: 9, letterSpacing: '.08em', color: 'var(--fg-3)', textTransform: 'uppercase', fontWeight: 600 }}>FLEET</div>
           {['nick0cave', 'masc-improver', 'sangsu', 'qa-king', 'rama'].map((k, i) => (
             <div key={k} style={{ display: 'flex', alignItems: 'center', gap: 6, fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--fg-2)' }}>
-              <span style={{ width: 5, height: 5, borderRadius: '50%', background: ['var(--brass-1)', 'var(--ok)', 'var(--info)', 'var(--err)', 'var(--stalled)'][i], boxShadow: i === 0 ? '0 0 5px rgb(var(--brass-glow)/.7)' : 'none' }} />
+              <span style={{ width: 5, height: 5, borderRadius: '50%', background: ['var(--brass-1)', 'var(--color-status-ok)', 'var(--color-status-info)', 'var(--color-status-err)', 'var(--color-status-stalled)'][i], boxShadow: i === 0 ? '0 0 5px rgb(var(--color-accent-glow)/.7)' : 'none' }} />
               {k}
-              <span style={{ marginLeft: 'auto', color: 'var(--fg-4)', fontSize: 9 }}>t-{(0x9f2a + i).toString(16)}</span>
+              <span style={{ marginLeft: 'auto', color: 'var(--color-fg-disabled)', fontSize: 9 }}>t-{(0x9f2a + i).toString(16)}</span>
             </div>
           ))}
         </div>
@@ -324,11 +324,11 @@ function SplitMode({ w = 1400, h = 680 }) {
           {[0, 1, 2, 3, 4].map(i => (
             <div key={i} style={{ position: 'relative', height: 22, borderBottom: '1px solid var(--line-1)' }}>
               {[...Array(6)].map((_, j) => (
-                <span key={j} style={{ position: 'absolute', left: `${(j * 14 + Math.random() * 8)}%`, top: '50%', transform: 'translateY(-50%)', width: 8, height: 4, background: j === 5 ? 'var(--brass-2)' : ['var(--fg-2)', 'var(--info)', 'var(--ok)'][j % 3], borderRadius: 1 }} />
+                <span key={j} style={{ position: 'absolute', left: `${(j * 14 + Math.random() * 8)}%`, top: '50%', transform: 'translateY(-50%)', width: 8, height: 4, background: j === 5 ? 'var(--brass-2)' : ['var(--fg-2)', 'var(--color-status-info)', 'var(--color-status-ok)'][j % 3], borderRadius: 1 }} />
               ))}
             </div>
           ))}
-          <div style={{ position: 'absolute', top: 24, bottom: 8, left: '82%', width: 1, background: 'linear-gradient(to bottom, transparent, rgb(var(--brass-glow)/.7) 20%, rgb(var(--brass-glow)/.7) 80%, transparent)', boxShadow: '0 0 8px 1px rgb(var(--brass-glow)/.4)' }} />
+          <div style={{ position: 'absolute', top: 24, bottom: 8, left: '82%', width: 1, background: 'linear-gradient(to bottom, transparent, rgb(var(--color-accent-glow)/.7) 20%, rgb(var(--color-accent-glow)/.7) 80%, transparent)', boxShadow: '0 0 8px 1px rgb(var(--color-accent-glow)/.4)' }} />
         </div>
         <div style={{ padding: 8, borderLeft: '1px solid var(--line-1)' }}>
           <div style={{ fontSize: 9, letterSpacing: '.08em', color: 'var(--fg-3)', textTransform: 'uppercase', fontWeight: 600, marginBottom: 4 }}>NOW · keeper.ts</div>
@@ -391,8 +391,8 @@ function ExplodeLayers({ w = 900, h = 560 }) {
       <div style={{ padding: 12 }}>
         {[1, .85, .65, .4, .3, .7, .55, .95, .8].map((o, i) => (
           <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 8, height: 18 }}>
-            <span style={{ width: 3, height: 12, background: 'var(--warn)', opacity: o, boxShadow: o > 0.9 ? '0 0 6px rgb(var(--warn-glow)/.7)' : 'none', borderRadius: 1 }} />
-            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: o > 0.7 ? 'var(--warn)' : 'var(--fg-3)' }}>{o > 0.9 ? '2m' : o > 0.7 ? '8m' : o > 0.4 ? '1h' : '4h'} · {['nick', 'nick', 'masc', 'sangsu', 'masc', 'sangsu', 'sangsu', 'nick', 'masc'][i]}</span>
+            <span style={{ width: 3, height: 12, background: 'var(--color-status-warn)', opacity: o, boxShadow: o > 0.9 ? '0 0 6px rgb(var(--warn-glow)/.7)' : 'none', borderRadius: 1 }} />
+            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: o > 0.7 ? 'var(--color-status-warn)' : 'var(--fg-3)' }}>{o > 0.9 ? '2m' : o > 0.7 ? '8m' : o > 0.4 ? '1h' : '4h'} · {['nick', 'nick', 'masc', 'sangsu', 'masc', 'sangsu', 'sangsu', 'nick', 'masc'][i]}</span>
           </div>
         ))}
       </div>
@@ -400,20 +400,20 @@ function ExplodeLayers({ w = 900, h = 560 }) {
     { id: 'parallel', label: 'L2 · PARALLEL · keeper cursors', z: 200, bg: 'rgb(106 142 176 / .08)', render: () => (
       <svg viewBox={`0 0 ${w} ${h}`} style={{ width: '100%', height: '100%' }}>
         <path d={`M 40 40 Q ${w / 2} 60 ${w - 40} 120`} fill="none" stroke="var(--brass-1)" strokeWidth="1.5" opacity=".7" />
-        <path d={`M 40 120 Q ${w / 2} 180 ${w - 40} 80`} fill="none" stroke="var(--ok)" strokeWidth="1.5" opacity=".6" />
-        <path d={`M 40 200 Q ${w / 2} 160 ${w - 40} 220`} fill="none" stroke="var(--info)" strokeWidth="1.5" opacity=".6" strokeDasharray="3 3" />
+        <path d={`M 40 120 Q ${w / 2} 180 ${w - 40} 80`} fill="none" stroke="var(--color-status-ok)" strokeWidth="1.5" opacity=".6" />
+        <path d={`M 40 200 Q ${w / 2} 160 ${w - 40} 220`} fill="none" stroke="var(--color-status-info)" strokeWidth="1.5" opacity=".6" strokeDasharray="3 3" />
         <circle cx={w - 40} cy={120} r="4" fill="var(--brass-1)" />
-        <circle cx={w - 40} cy={80} r="4" fill="var(--ok)" />
-        <circle cx={w - 40} cy={220} r="4" fill="var(--info)" />
+        <circle cx={w - 40} cy={80} r="4" fill="var(--color-status-ok)" />
+        <circle cx={w - 40} cy={220} r="4" fill="var(--color-status-info)" />
       </svg>
     ) },
-    { id: 'tools', label: 'L3 · TOOLS · frequency glyphs', z: 300, bg: 'rgb(var(--brass-glow) / .06)', render: () => (
+    { id: 'tools', label: 'L3 · TOOLS · frequency glyphs', z: 300, bg: 'rgb(var(--color-accent-glow) / .06)', render: () => (
       <div style={{ padding: 12 }}>
         {[['◈', 12, 'emit'], ['⌘', 8, 'run'], ['⟳', 5, 'tick'], ['∎', 3, 'guard']].map(([g, n, lab], i) => (
           <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 8, height: 24 }}>
-            <span style={{ color: 'var(--brass-1)', fontSize: 12, textShadow: '0 0 4px rgb(var(--brass-glow)/.6)' }}>{g}</span>
+            <span style={{ color: 'var(--brass-1)', fontSize: 12, textShadow: '0 0 4px rgb(var(--color-accent-glow)/.6)' }}>{g}</span>
             <span style={{ width: n * 6, height: 2, background: 'linear-gradient(90deg, var(--brass-1), transparent)', borderRadius: 1 }} />
-            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 9, color: 'var(--fg-4)' }}>{n}×</span>
+            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 9, color: 'var(--color-fg-disabled)' }}>{n}×</span>
             <span style={{ fontFamily: 'var(--font-mono)', fontSize: 9, color: 'var(--brass-1)' }}>{lab}</span>
           </div>
         ))}
@@ -421,18 +421,18 @@ function ExplodeLayers({ w = 900, h = 560 }) {
     ) },
     { id: 'approve', label: 'L4 · APPROVE · block stamp', z: 400, bg: 'rgb(107 158 107 / .05)', render: () => (
       <div style={{ padding: 12, position: 'relative' }}>
-        <div style={{ padding: '8px 16px', background: 'rgb(107 158 107 / .08)', borderLeft: '2px solid var(--ok)', borderRadius: 2, display: 'flex', alignItems: 'center', height: 60 }}>
-          <span style={{ marginLeft: 'auto', fontFamily: 'var(--font-mono)', fontSize: 36, color: 'var(--ok)', opacity: 0.15, letterSpacing: '.08em', fontWeight: 700, transform: 'rotate(-12deg)' }}>LGTM</span>
+        <div style={{ padding: '8px 16px', background: 'rgb(107 158 107 / .08)', borderLeft: '2px solid var(--color-status-ok)', borderRadius: 2, display: 'flex', alignItems: 'center', height: 60 }}>
+          <span style={{ marginLeft: 'auto', fontFamily: 'var(--font-mono)', fontSize: 36, color: 'var(--color-status-ok)', opacity: 0.15, letterSpacing: '.08em', fontWeight: 700, transform: 'rotate(-12deg)' }}>LGTM</span>
         </div>
-        <div style={{ marginTop: 8, padding: '8px 16px', background: 'rgb(196 106 90 / .08)', borderLeft: '2px solid var(--err)', borderRadius: 2, display: 'flex', alignItems: 'center', height: 60 }}>
-          <span style={{ marginLeft: 'auto', fontFamily: 'var(--font-mono)', fontSize: 36, color: 'var(--err)', opacity: 0.15, letterSpacing: '.08em', fontWeight: 700, transform: 'rotate(-12deg)' }}>FLAG</span>
+        <div style={{ marginTop: 8, padding: '8px 16px', background: 'rgb(196 106 90 / .08)', borderLeft: '2px solid var(--color-status-err)', borderRadius: 2, display: 'flex', alignItems: 'center', height: 60 }}>
+          <span style={{ marginLeft: 'auto', fontFamily: 'var(--font-mono)', fontSize: 36, color: 'var(--color-status-err)', opacity: 0.15, letterSpacing: '.08em', fontWeight: 700, transform: 'rotate(-12deg)' }}>FLAG</span>
         </div>
       </div>
     ) },
     { id: 'notes', label: 'L5 · NOTES · pinned cards', z: 500, bg: 'rgb(138 106 160 / .08)', render: () => (
       <div style={{ padding: 12 }}>
         <div style={{ width: 240, background: 'linear-gradient(180deg, rgb(138 106 160 / .20), rgb(138 106 160 / .08))', border: '1px solid rgb(var(--stalled-glow)/.4)', borderRadius: 'var(--r-1)', padding: '6px 10px', fontSize: 11, color: 'var(--fg-1)', boxShadow: '0 4px 16px rgb(0 0 0 / .5)', backdropFilter: 'blur(4px)' }}>
-          <div style={{ fontFamily: 'var(--font-mono)', fontSize: 9, color: 'var(--stalled)', letterSpacing: '.06em', textTransform: 'uppercase', marginBottom: 4 }}>NOTE · sangsu · 2h</div>
+          <div style={{ fontFamily: 'var(--font-mono)', fontSize: 9, color: 'var(--color-status-stalled)', letterSpacing: '.06em', textTransform: 'uppercase', marginBottom: 4 }}>NOTE · sangsu · 2h</div>
           <div style={{ fontSize: 11, lineHeight: 1.4 }}>GoalRef changed the shape of goal from string to {'{'}id,priority{'}'}. Check downstream emit() contracts.</div>
         </div>
       </div>
@@ -448,7 +448,7 @@ function ExplodeLayers({ w = 900, h = 560 }) {
         ))}
       </div>
       {/* z-axis legend */}
-      <div style={{ position: 'absolute', top: 10, right: 10, zIndex: 10, fontFamily: 'var(--font-mono)', fontSize: 9, color: 'var(--fg-4)', letterSpacing: '.08em', textTransform: 'uppercase', textAlign: 'right', lineHeight: 1.6 }}>
+      <div style={{ position: 'absolute', top: 10, right: 10, zIndex: 10, fontFamily: 'var(--font-mono)', fontSize: 9, color: 'var(--color-fg-disabled)', letterSpacing: '.08em', textTransform: 'uppercase', textAlign: 'right', lineHeight: 1.6 }}>
         Z-AXIS STACK<br />
         <span style={{ color: 'var(--fg-3)' }}>5 observational layers</span>
       </div>
@@ -460,7 +460,7 @@ function ExplodeLayers({ w = 900, h = 560 }) {
               position: 'absolute', top: 80, left: 60, right: 60, bottom: 60,
               transform: `translateZ(${L.z * (pose === 0 ? 0 : pose === 2 ? .5 : 1)}px)`,
               background: L.bg,
-              border: `1px ${pose === 0 ? 'solid' : 'dashed'} rgb(var(--brass-glow)/.25)`,
+              border: `1px ${pose === 0 ? 'solid' : 'dashed'} rgb(var(--color-accent-glow)/.25)`,
               borderRadius: 'var(--r-1)',
               opacity: pose === 0 ? (i === 0 ? 1 : 0.35) : 1,
               transition: 'transform .7s cubic-bezier(.2,.7,.3,1), opacity .4s',
@@ -474,7 +474,7 @@ function ExplodeLayers({ w = 900, h = 560 }) {
         </div>
       </div>
       {/* caption */}
-      <div style={{ position: 'absolute', bottom: 10, left: 10, right: 10, display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontFamily: 'var(--font-mono)', fontSize: 9, color: 'var(--fg-4)', letterSpacing: '.04em' }}>
+      <div style={{ position: 'absolute', bottom: 10, left: 10, right: 10, display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontFamily: 'var(--font-mono)', fontSize: 9, color: 'var(--color-fg-disabled)', letterSpacing: '.04em' }}>
         <span>editor-scroll · perspective: 1800px · preserve-3d</span>
         <span>body[data-explode=1] .lyr {'{'} translateZ(40·80·120·160·200px) {'}'}</span>
       </div>

--- a/dashboard/design-system/preview/colors.html
+++ b/dashboard/design-system/preview/colors.html
@@ -123,7 +123,7 @@
   .ui-row:last-child { border-bottom: none; }
   .ui-row .d { width: 8px; height: 8px; border-radius: 50%; justify-self: center; }
   .ui-row.active {
-    background: linear-gradient(90deg, rgb(var(--brass-glow)/.08), transparent 60%);
+    background: linear-gradient(90deg, rgb(var(--color-accent-glow)/.08), transparent 60%);
     border-left: 2px solid var(--brass-1);
     padding-left: 10px;
   }
@@ -320,9 +320,9 @@
         <span class="pv-tok">idle</span>
       </div>
       <div class="ui-row active">
-        <span class="d" style="background:#d4a14a; box-shadow:0 0 8px rgb(var(--brass-glow)/.6)"></span>
+        <span class="d" style="background:#d4a14a; box-shadow:0 0 8px rgb(var(--color-accent-glow)/.6)"></span>
         <div><span class="name">masc-improver</span> <span class="meta"> · tool.write_file · running</span></div>
-        <span class="pv-tok" style="color:var(--brass-1); border-color:rgb(var(--brass-glow)/.4)">active</span>
+        <span class="pv-tok" style="color:var(--brass-1); border-color:rgb(var(--color-accent-glow)/.4)">active</span>
       </div>
       <div class="ui-row" style="background:var(--bg-2)">
         <span class="d" style="background:#6a8eb0"></span>

--- a/dashboard/design-system/preview/components.css
+++ b/dashboard/design-system/preview/components.css
@@ -10,13 +10,13 @@
 .cb-dot { display:inline-block; width:7px; height:7px; border-radius:50%; flex:0 0 auto; }
 .cb-dot.sm { width:5px; height:5px; }
 .cb-dot.lg { width:9px; height:9px; }
-.cb-dot.brass   { background: var(--brass-1); box-shadow: 0 0 5px rgb(var(--brass-glow)/.7); }
-.cb-dot.ok      { background: var(--ok); }
-.cb-dot.warn    { background: var(--warn); }
-.cb-dot.err     { background: var(--err); }
-.cb-dot.info    { background: var(--info); }
-.cb-dot.idle    { background: var(--idle); }
-.cb-dot.stalled { background: var(--stalled); }
+.cb-dot.brass   { background: var(--brass-1); box-shadow: 0 0 5px rgb(var(--color-accent-glow)/.7); }
+.cb-dot.ok      { background: var(--color-status-ok); }
+.cb-dot.warn    { background: var(--color-status-warn); }
+.cb-dot.err     { background: var(--color-status-err); }
+.cb-dot.info    { background: var(--color-status-info); }
+.cb-dot.idle    { background: var(--color-status-idle); }
+.cb-dot.stalled { background: var(--color-status-stalled); }
 .cb-dot.beat { animation: anim-heartbeat 1.4s var(--ease-inout) infinite; }
 
 /* caption label */
@@ -34,13 +34,13 @@
 /* ───── Topbar ───── */
 .cb-topbar { display:flex; align-items:center; height:36px; padding:0 12px; gap:12px; background: var(--bg-1); border-bottom:1px solid var(--line-2); flex-shrink:0; }
 .cb-topbar .brand { display:flex; align-items:center; gap:8px; }
-.cb-topbar .brand-mark { width:16px; height:16px; border-radius:2px; background: linear-gradient(135deg, var(--brass-1), var(--brass-3)); box-shadow: 0 0 6px rgb(var(--brass-glow)/.4) inset, 0 0 4px rgb(var(--brass-glow)/.5); }
+.cb-topbar .brand-mark { width:16px; height:16px; border-radius:2px; background: linear-gradient(135deg, var(--brass-1), var(--color-accent-fg-dim)); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.4) inset, 0 0 4px rgb(var(--color-accent-glow)/.5); }
 .cb-topbar .brand-name { font-family: var(--font-mono); font-size: var(--fs-13); font-weight:600; color: var(--fg-1); letter-spacing: .04em; }
-.cb-topbar .ver { font: var(--type-micro); color: var(--fg-4); letter-spacing:.06em; margin-left:-4px; }
+.cb-topbar .ver { font: var(--type-micro); color: var(--color-fg-disabled); letter-spacing:.06em; margin-left:-4px; }
 .cb-topbar .sep { width:1px; height:18px; background: var(--line-2); }
 .cb-topbar .goal-switch { display:flex; align-items:center; gap:6px; padding:3px 8px; height:22px; background: var(--bg-2); border:1px solid var(--line-1); border-radius: var(--r-1); font-family: var(--font-mono); font-size: var(--fs-11); color: var(--fg-2); cursor:pointer; }
 .cb-topbar .goal-switch:hover { background: var(--bg-3); border-color: var(--line-2); color: var(--fg-1); }
-.cb-topbar .goal-switch .caret { color: var(--fg-4); margin-left:2px; }
+.cb-topbar .goal-switch .caret { color: var(--color-fg-disabled); margin-left:2px; }
 .cb-topbar .mode-tabs { display:flex; background: var(--bg-2); border:1px solid var(--line-1); border-radius: var(--r-1); padding:2px; gap:2px; }
 .cb-topbar .mode-tabs button { height:18px; padding:0 10px; font: var(--type-caption); text-transform: uppercase; letter-spacing: .08em; color: var(--fg-3); background: transparent; border:0; border-radius: 2px; cursor:pointer; font-weight:600; }
 .cb-topbar .mode-tabs button:hover { color: var(--fg-1); }
@@ -48,8 +48,8 @@
 .cb-topbar .right { margin-left:auto; display:flex; align-items:center; gap:10px; }
 .cb-topbar .density { display:flex; background: var(--bg-2); border:1px solid var(--line-1); border-radius: var(--r-1); }
 .cb-topbar .density button { width:22px; height:20px; border:0; background:transparent; color: var(--fg-3); font-family: var(--font-mono); font-size: var(--fs-11); cursor:pointer; }
-.cb-topbar .density button.on { color: var(--brass-1); background: rgb(var(--brass-glow)/.1); }
-.cb-topbar .stamp { font: var(--type-micro); color: var(--fg-4); letter-spacing: .06em; }
+.cb-topbar .density button.on { color: var(--brass-1); background: rgb(var(--color-accent-glow)/.1); }
+.cb-topbar .stamp { font: var(--type-micro); color: var(--color-fg-disabled); letter-spacing: .06em; }
 
 /* minimal topbar variant */
 .cb-topbar.minimal .brand-name { font-size: var(--fs-11); }
@@ -58,7 +58,7 @@
 
 /* expanded topbar (with branch + avatars) */
 .cb-topbar .branch { display:flex; align-items:center; gap:4px; font-family: var(--font-mono); font-size: var(--fs-11); color: var(--fg-3); }
-.cb-topbar .branch::before { content: "⎇"; color: var(--fg-4); }
+.cb-topbar .branch::before { content: "⎇"; color: var(--color-fg-disabled); }
 .cb-topbar .avatars { display:flex; }
 .cb-topbar .avatars .av { width:18px; height:18px; border-radius:50%; border:2px solid var(--bg-1); margin-left:-6px; }
 .cb-topbar .avatars .av:first-child { margin-left:0; }
@@ -69,7 +69,7 @@
 @keyframes cb-tape { to { transform: translateX(-50%); } }
 .cb-ticker .evt { display:flex; align-items:center; gap:6px; color: var(--fg-2); }
 .cb-ticker .evt .k { color: var(--fg-3); }
-.cb-ticker .evt .t { color: var(--fg-4); font-size: var(--fs-10); }
+.cb-ticker .evt .t { color: var(--color-fg-disabled); font-size: var(--fs-10); }
 .cb-ticker .evt.err .body { color: var(--err-fg); }
 .cb-ticker .evt.flag .body { color: var(--err-fg); }
 .cb-ticker .evt.tool .body { color: var(--fg-1); }
@@ -93,8 +93,8 @@
 .cb-kpi .cell .lbl { font: var(--type-label); text-transform: uppercase; color: var(--fg-3); letter-spacing: .08em; font-weight:600; display:flex; align-items:center; gap:4px; }
 .cb-kpi .cell .val { font: var(--type-kpi-m); color: var(--fg-1); font-family: var(--font-mono); }
 .cb-kpi .cell .val.big { font: var(--type-kpi-l); }
-.cb-kpi .cell .cap { font: var(--type-micro); color: var(--fg-4); }
-.cb-kpi .cell.live { background: rgb(var(--brass-glow)/.06); animation: anim-pulse-glow 2.4s var(--ease-inout) infinite; }
+.cb-kpi .cell .cap { font: var(--type-micro); color: var(--color-fg-disabled); }
+.cb-kpi .cell.live { background: rgb(var(--color-accent-glow)/.06); animation: anim-pulse-glow 2.4s var(--ease-inout) infinite; }
 .cb-kpi .cell.live .val { color: var(--brass-1); }
 .cb-kpi .cell .spark { margin-top:auto; }
 .cb-kpi .cell.is-err .val { color: var(--err-fg); }
@@ -128,26 +128,26 @@
 .cb-sidebar { width:100%; background: var(--bg-1); display:flex; flex-direction:column; font-size: var(--fs-12); height:100%; }
 .cb-sidebar .sec { border-bottom:1px solid var(--line-1); }
 .cb-sidebar .sec-h { display:flex; align-items:center; height:28px; padding: 0 10px; border-bottom:1px solid var(--line-1); background: var(--bg-1); font: var(--type-label); text-transform: uppercase; color: var(--fg-3); letter-spacing:.08em; font-weight:600; }
-.cb-sidebar .sec-h .count { margin-left:auto; font-family: var(--font-mono); color: var(--fg-4); font-weight:500; }
+.cb-sidebar .sec-h .count { margin-left:auto; font-family: var(--font-mono); color: var(--color-fg-disabled); font-weight:500; }
 .cb-sidebar .row { display:flex; align-items:center; gap:7px; padding: 0 10px; height:22px; cursor:pointer; position:relative; font-family: var(--font-mono); font-size: var(--fs-11); }
 .cb-sidebar .row:hover { background: var(--bg-2); }
 .cb-sidebar .row.sel { background: var(--bg-3); color: var(--fg-1); }
 .cb-sidebar .row.sel::before { content:""; position:absolute; left:0; top:0; bottom:0; width:2px; background: var(--brass-1); }
 .cb-sidebar .row .name { color: var(--fg-1); }
-.cb-sidebar .row .meta { margin-left:auto; color: var(--fg-4); font-size: var(--fs-10); }
+.cb-sidebar .row .meta { margin-left:auto; color: var(--color-fg-disabled); font-size: var(--fs-10); }
 .cb-sidebar .row.idle .name { color: var(--fg-3); }
 .cb-sidebar .goal-row { flex-direction:column; align-items:stretch; height:auto; padding: 6px 10px; gap:3px; font-family: var(--font-sans); font-size: var(--fs-12); }
 .cb-sidebar .goal-row .title { color: var(--fg-1); font-size: var(--fs-12); }
-.cb-sidebar .goal-row .id { font-family: var(--font-mono); color: var(--fg-4); font-size: var(--fs-10); }
+.cb-sidebar .goal-row .id { font-family: var(--font-mono); color: var(--color-fg-disabled); font-size: var(--fs-10); }
 .cb-sidebar .goal-row .meta-row { display:flex; align-items:center; gap:6px; font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-3); }
 
 /* iconified sidebar variant */
 .cb-sidebar.icons .row { padding-left: 26px; position:relative; }
-.cb-sidebar.icons .row .icon { position:absolute; left:10px; top:50%; transform: translateY(-50%); font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-4); }
+.cb-sidebar.icons .row .icon { position:absolute; left:10px; top:50%; transform: translateY(-50%); font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-fg-disabled); }
 
 /* ───── Swimlanes ───── */
 .cb-swim { position:relative; background: var(--bg-0); padding: 12px; overflow: hidden; height:100%; }
-.cb-swim .axis { position:absolute; top: 12px; left: 130px; right: 12px; height: 16px; border-bottom: 1px solid var(--line-1); display:flex; justify-content:space-between; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-4); }
+.cb-swim .axis { position:absolute; top: 12px; left: 130px; right: 12px; height: 16px; border-bottom: 1px solid var(--line-1); display:flex; justify-content:space-between; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); }
 .cb-swim .axis span { padding: 0 2px; }
 .cb-swim .lane { display:flex; align-items:center; height: 32px; position: relative; border-bottom: 1px solid var(--line-1); }
 .cb-swim .lane-head { width: 118px; display:flex; align-items:center; gap:7px; padding-right: 12px; flex-shrink:0; }
@@ -156,14 +156,14 @@
 .cb-swim .lane.sel { background: var(--bg-2); }
 .cb-swim .lane.sel .lane-head .name { color: var(--fg-1); }
 .cb-swim .lane.sel::before { content:""; position:absolute; left:0; top:0; bottom:0; width:2px; background: var(--brass-1); }
-.cb-swim .now { position:absolute; top:28px; bottom: 4px; width:2px; background: linear-gradient(to bottom, transparent, rgb(var(--brass-glow)/.7) 20%, rgb(var(--brass-glow)/.7) 80%, transparent); box-shadow: 0 0 8px 1px rgb(var(--brass-glow)/.4); pointer-events:none; }
+.cb-swim .now { position:absolute; top:28px; bottom: 4px; width:2px; background: linear-gradient(to bottom, transparent, rgb(var(--color-accent-glow)/.7) 20%, rgb(var(--color-accent-glow)/.7) 80%, transparent); box-shadow: 0 0 8px 1px rgb(var(--color-accent-glow)/.4); pointer-events:none; }
 .cb-swim .now .head { position:absolute; top:-14px; left:-10px; width:22px; text-align:center; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--brass-1); letter-spacing: .06em; }
 .cb-swim .ev { position:absolute; top:50%; transform: translate(-50%, -50%); }
 .cb-swim .ev-tool  { width:10px; height:4px; background: var(--fg-2); border-radius:1px; }
 .cb-swim .ev-claim { width:8px; height:8px; background: var(--brass-2); transform: translate(-50%,-50%) rotate(45deg); border-radius:1px; }
 .cb-swim .ev-text  { width:7px; height:1px; background: var(--fg-3); }
-.cb-swim .ev-flag  { width:7px; height:7px; background: var(--err); border-radius:50%; transform: translate(-50%,-50%); }
-.cb-swim .ev-err   { width:8px; height:8px; transform: translate(-50%,-50%); background: var(--err); clip-path: polygon(20% 0, 50% 35%, 80% 0, 100% 20%, 65% 50%, 100% 80%, 80% 100%, 50% 65%, 20% 100%, 0 80%, 35% 50%, 0 20%); }
+.cb-swim .ev-flag  { width:7px; height:7px; background: var(--color-status-err); border-radius:50%; transform: translate(-50%,-50%); }
+.cb-swim .ev-err   { width:8px; height:8px; transform: translate(-50%,-50%); background: var(--color-status-err); clip-path: polygon(20% 0, 50% 35%, 80% 0, 100% 20%, 65% 50%, 100% 80%, 80% 100%, 50% 65%, 20% 100%, 0 80%, 35% 50%, 0 20%); }
 .cb-swim .lanes-body { margin-top: 18px; position:relative; }
 
 /* density variant: tighter lanes */
@@ -171,7 +171,7 @@
 
 /* density variant: aggregate bars instead of glyphs */
 .cb-swim.bars .ev { display:none; }
-.cb-swim.bars .lane-track .agg { position:absolute; top:50%; transform: translateY(-50%); height:10px; background: linear-gradient(90deg, rgb(var(--brass-glow)/.05), rgb(var(--brass-glow)/.35)); border-radius:2px; }
+.cb-swim.bars .lane-track .agg { position:absolute; top:50%; transform: translateY(-50%); height:10px; background: linear-gradient(90deg, rgb(var(--color-accent-glow)/.05), rgb(var(--color-accent-glow)/.35)); border-radius:2px; }
 
 /* ───── Deck (tabbed center) ───── */
 .cb-deck { display:flex; flex-direction:column; height:100%; background: var(--bg-1); }
@@ -179,9 +179,9 @@
 .cb-deck .tab { height:30px; padding: 0 12px; display:inline-flex; align-items:center; gap:6px; border:0; background:transparent; color: var(--fg-3); font: var(--type-label); text-transform: uppercase; letter-spacing: .08em; font-weight:600; cursor:pointer; position:relative; }
 .cb-deck .tab:hover { color: var(--fg-1); }
 .cb-deck .tab.on { color: var(--fg-1); }
-.cb-deck .tab.on::after { content:""; position:absolute; left:8px; right:8px; bottom:-1px; height:2px; background: var(--brass-1); box-shadow: 0 -2px 6px rgb(var(--brass-glow)/.3); }
+.cb-deck .tab.on::after { content:""; position:absolute; left:8px; right:8px; bottom:-1px; height:2px; background: var(--brass-1); box-shadow: 0 -2px 6px rgb(var(--color-accent-glow)/.3); }
 .cb-deck .tab .badge { background: var(--bg-3); border:1px solid var(--line-1); border-radius: 999px; padding: 0 5px; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-2); letter-spacing: 0; text-transform: none; font-weight: 500; height: 14px; display:inline-flex; align-items:center; }
-.cb-deck .tab.on .badge { border-color: var(--brass-3); color: var(--brass-1); }
+.cb-deck .tab.on .badge { border-color: var(--color-accent-fg-dim); color: var(--brass-1); }
 .cb-deck .body { flex:1; overflow:auto; padding: 12px; font-size: var(--fs-12); }
 
 /* deck table rows */
@@ -202,13 +202,13 @@
 .cb-kanban { display:grid; grid-template-columns: repeat(4, 1fr); gap: 8px; height:100%; padding:12px; overflow:auto; }
 .cb-kanban .col { background: var(--bg-1); border:1px solid var(--line-1); border-radius: var(--r-1); padding: 6px; display:flex; flex-direction:column; gap:6px; }
 .cb-kanban .col-h { font: var(--type-label); text-transform:uppercase; color: var(--fg-3); letter-spacing:.08em; font-weight:600; display:flex; align-items:center; gap:6px; padding: 2px 4px; }
-.cb-kanban .col-h .ct { margin-left:auto; font-family: var(--font-mono); color: var(--fg-4); font-size: var(--fs-10); font-weight:500; }
+.cb-kanban .col-h .ct { margin-left:auto; font-family: var(--font-mono); color: var(--color-fg-disabled); font-size: var(--fs-10); font-weight:500; }
 .cb-kanban .card { background: var(--bg-2); border:1px solid var(--line-1); border-radius: var(--r-1); padding: 6px 7px; font-size: var(--fs-11); display:flex; flex-direction:column; gap:3px; cursor:pointer; }
 .cb-kanban .card:hover { background: var(--bg-3); }
-.cb-kanban .card .id { font-family: var(--font-mono); color: var(--fg-4); font-size: var(--fs-9); letter-spacing: .04em; }
+.cb-kanban .card .id { font-family: var(--font-mono); color: var(--color-fg-disabled); font-size: var(--fs-9); letter-spacing: .04em; }
 .cb-kanban .card .title { color: var(--fg-1); font-size: var(--fs-11); line-height:1.3; }
 .cb-kanban .card .foot { display:flex; align-items:center; gap:6px; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-3); margin-top:2px; }
-.cb-kanban .card.running { border-color: var(--brass-3); box-shadow: 0 0 0 1px rgb(var(--brass-glow)/.2), inset 2px 0 0 var(--brass-1); }
+.cb-kanban .card.running { border-color: var(--color-accent-fg-dim); box-shadow: 0 0 0 1px rgb(var(--color-accent-glow)/.2), inset 2px 0 0 var(--brass-1); }
 .cb-kanban .card.fail { border-color: var(--err-border); }
 
 /* provider matrix variant */
@@ -218,17 +218,17 @@
 .cb-pmatrix .row .pname { color: var(--fg-1); }
 .cb-pmatrix .row .model { color: var(--fg-2); }
 .cb-pmatrix .row .tps { color: var(--fg-1); text-align:right; }
-.cb-pmatrix .row .cas { color: var(--fg-4); text-align:right; }
+.cb-pmatrix .row .cas { color: var(--color-fg-disabled); text-align:right; }
 
 /* ───── Rail (activity feed + cascade) ───── */
 .cb-rail { width:100%; height:100%; background: var(--bg-1); display:flex; flex-direction:column; border-left: 1px solid var(--line-1); font-size: var(--fs-12); }
 .cb-rail .sec { border-bottom: 1px solid var(--line-2); }
 .cb-rail .sec-h { display:flex; align-items:center; height:26px; padding: 0 10px; font: var(--type-label); text-transform: uppercase; color: var(--fg-3); letter-spacing:.08em; font-weight:600; background: var(--bg-1); border-bottom:1px solid var(--line-1); }
-.cb-rail .sec-h .right { margin-left:auto; font-family: var(--font-mono); color: var(--fg-4); font-weight:500; font-size: var(--fs-10); }
+.cb-rail .sec-h .right { margin-left:auto; font-family: var(--font-mono); color: var(--color-fg-disabled); font-weight:500; font-size: var(--fs-10); }
 .cb-rail .body { padding: 6px 0; max-height: 100%; overflow:auto; }
 .cb-rail .ev { display:grid; grid-template-columns: 54px 14px 1fr; gap: 6px; padding: 4px 10px; align-items:flex-start; font-size: var(--fs-11); cursor:pointer; }
 .cb-rail .ev:hover { background: var(--bg-2); }
-.cb-rail .ev .t { font-family: var(--font-mono); color: var(--fg-4); font-size: var(--fs-10); padding-top:2px; }
+.cb-rail .ev .t { font-family: var(--font-mono); color: var(--color-fg-disabled); font-size: var(--fs-10); padding-top:2px; }
 .cb-rail .ev .icon { display:flex; align-items:flex-start; padding-top:4px; }
 .cb-rail .ev .body { padding: 0; }
 .cb-rail .ev .who { font-family: var(--font-mono); color: var(--fg-2); font-size: var(--fs-10); margin-right:4px; }
@@ -239,15 +239,15 @@
 
 /* cascade trace */
 .cb-cascade { padding: 10px; display:flex; flex-direction:column; gap: 8px; }
-.cb-cascade .id { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-4); letter-spacing: .04em; }
+.cb-cascade .id { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-fg-disabled); letter-spacing: .04em; }
 .cb-cascade .step { display:grid; grid-template-columns: 14px 1fr auto; gap: 8px; align-items:center; height: 22px; font-family: var(--font-mono); font-size: var(--fs-11); border-bottom: 1px dashed var(--line-1); }
-.cb-cascade .step .ix { color: var(--fg-4); text-align:center; }
+.cb-cascade .step .ix { color: var(--color-fg-disabled); text-align:center; }
 .cb-cascade .step .name { color: var(--fg-1); }
 .cb-cascade .step .ms { color: var(--fg-3); font-size: var(--fs-10); }
 .cb-cascade .step.hit .name { color: var(--ok-fg); }
-.cb-cascade .step.hit .ix { color: var(--ok); }
+.cb-cascade .step.hit .ix { color: var(--color-status-ok); }
 .cb-cascade .step.miss .name { color: var(--fg-3); text-decoration: line-through; }
-.cb-cascade .step.skip .name { color: var(--fg-4); }
+.cb-cascade .step.skip .name { color: var(--color-fg-disabled); }
 .cb-cascade .total { display:flex; align-items:center; gap:6px; font-family: var(--font-mono); font-size: var(--fs-11); color: var(--fg-2); padding-top: 2px; }
 .cb-cascade .total .n { color: var(--brass-1); }
 
@@ -259,28 +259,28 @@
 .cb-composer .arg { color: var(--fg-1); }
 .cb-composer .str { color: var(--ok-fg); }
 .cb-composer input { flex:1; background:transparent; border:0; outline:none; color: var(--fg-1); font-family: inherit; font-size: var(--fs-12); padding:0; }
-.cb-composer .hint { font-size: var(--fs-10); color: var(--fg-4); display:flex; gap:12px; }
+.cb-composer .hint { font-size: var(--fs-10); color: var(--color-fg-disabled); display:flex; gap:12px; }
 .cb-composer .hint .kbd { font-family: var(--font-mono); background: var(--bg-3); border:1px solid var(--line-2); border-bottom-width:2px; border-radius:3px; padding: 0 4px; height:14px; display:inline-flex; align-items:center; font-size: var(--fs-9); color: var(--fg-3); margin-right:4px; }
 
 /* suggest dropdown */
 .cb-composer .sug { position:absolute; bottom:100%; left:0; right:0; background: var(--bg-2); border:1px solid var(--line-2); border-radius: var(--r-1) var(--r-1) 0 0; box-shadow: 0 -4px 12px rgb(0 0 0 / .4); max-height: 160px; overflow:auto; }
 .cb-composer .sug .item { padding: 4px 10px; display:flex; gap:8px; font-size: var(--fs-11); font-family: var(--font-mono); color: var(--fg-2); cursor:pointer; }
 .cb-composer .sug .item.on { background: var(--bg-3); color: var(--fg-1); }
-.cb-composer .sug .item .kind { color: var(--fg-4); }
+.cb-composer .sug .item .kind { color: var(--color-fg-disabled); }
 
 /* ───── Status bar ───── */
 .cb-statusbar { height:20px; display:flex; align-items:center; padding:0 10px; gap:14px; background: var(--bg-1); border-top:1px solid var(--line-2); font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-3); flex-shrink:0; }
 .cb-statusbar .seg { display:flex; align-items:center; gap:5px; }
 .cb-statusbar .seg.push-right { margin-left:auto; }
 .cb-statusbar .seg .on { color: var(--ok-fg); }
-.cb-statusbar .seg .off { color: var(--fg-4); }
+.cb-statusbar .seg .off { color: var(--color-fg-disabled); }
 .cb-statusbar .seg .brass { color: var(--brass-1); }
 .cb-statusbar .sep { width:1px; height:10px; background: var(--line-2); }
 
 /* ───── Drawer (inspector) ───── */
-.cb-drawer { width:100%; height:100%; background: var(--bg-2); border-left: 1px solid var(--line-3); display:flex; flex-direction:column; overflow: hidden; }
+.cb-drawer { width:100%; height:100%; background: var(--bg-2); border-left: 1px solid var(--color-border-divider); display:flex; flex-direction:column; overflow: hidden; }
 .cb-drawer .head { padding: 10px 12px; border-bottom: 1px solid var(--line-2); display:flex; flex-direction:column; gap: 4px; }
-.cb-drawer .head .idrow { display:flex; align-items:center; gap:6px; font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-4); letter-spacing: .04em; }
+.cb-drawer .head .idrow { display:flex; align-items:center; gap:6px; font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-fg-disabled); letter-spacing: .04em; }
 .cb-drawer .head .idrow .close { margin-left:auto; width:18px; height:18px; border:0; background: transparent; color: var(--fg-3); font-size: var(--fs-14); cursor:pointer; border-radius: 3px; }
 .cb-drawer .head .idrow .close:hover { background: var(--bg-3); color: var(--fg-1); }
 .cb-drawer .head .title { font-size: var(--fs-14); color: var(--fg-1); font-weight: 600; line-height:1.3; }
@@ -293,7 +293,7 @@
 .cb-drawer .acts { display:flex; gap:6px; padding: 8px 12px; border-top: 1px solid var(--line-2); }
 .cb-drawer .btn { height:22px; padding: 0 10px; font-family: var(--font-mono); font-size: var(--fs-10); letter-spacing: .08em; text-transform: uppercase; border:1px solid var(--line-2); background: var(--bg-3); color: var(--fg-2); border-radius: var(--r-1); cursor:pointer; font-weight:600; }
 .cb-drawer .btn:hover { background: var(--bg-4); color: var(--fg-1); }
-.cb-drawer .btn.primary { background: var(--brass-2); border-color: var(--brass-3); color: var(--bg-0); }
+.cb-drawer .btn.primary { background: var(--brass-2); border-color: var(--color-accent-fg-dim); color: var(--bg-0); }
 .cb-drawer .btn.danger { color: var(--err-fg); border-color: var(--err-border); }
 .cb-drawer .thread { display:flex; flex-direction:column; gap:6px; }
 .cb-drawer .cmt { padding: 5px 7px; border:1px solid var(--line-1); border-radius: var(--r-1); background: var(--bg-1); display:flex; flex-direction:column; gap:2px; }
@@ -302,7 +302,7 @@
 .cb-drawer .cmt.flag .kind { color: var(--err-fg); background: var(--err-soft); }
 .cb-drawer .cmt.question .kind { color: var(--info-fg); background: var(--info-soft); }
 .cb-drawer .cmt.note .kind { color: var(--fg-2); background: var(--bg-3); }
-.cb-drawer .cmt .t { margin-left:auto; color: var(--fg-4); }
+.cb-drawer .cmt .t { margin-left:auto; color: var(--color-fg-disabled); }
 .cb-drawer .cmt .body { color: var(--fg-1); font-size: var(--fs-11); line-height: 1.4; }
 
 
@@ -313,96 +313,96 @@
 /* shared "panel" wrapper used by all P2 zones — fills artboard */
 .cbp { width:100%; height:100%; background: var(--bg-0); color: var(--fg-1); display:flex; flex-direction:column; font-family: var(--font-sans); font-size: var(--fs-12); overflow: hidden; position: relative; }
 .cbp .ph { display:flex; align-items:center; gap:8px; padding: 6px 10px; border-bottom: 1px solid var(--line-2); background: linear-gradient(180deg, var(--bg-2), var(--bg-1)); flex-shrink:0; min-height: 28px; position: relative; }
-.cbp .ph::after { content:''; position:absolute; left:0; right:0; bottom:-1px; height:1px; background: linear-gradient(90deg, transparent, rgb(var(--brass-glow)/.3), transparent); }
+.cbp .ph::after { content:''; position:absolute; left:0; right:0; bottom:-1px; height:1px; background: linear-gradient(90deg, transparent, rgb(var(--color-accent-glow)/.3), transparent); }
 .cbp .ph .ttl { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-2); letter-spacing: .1em; text-transform: uppercase; font-weight: 600; }
-.cbp .ph .meta { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-4); letter-spacing: .04em; }
+.cbp .ph .meta { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-fg-disabled); letter-spacing: .04em; }
 .cbp .ph .grow { flex: 1; }
 .cbp .ph .crumb { color: var(--fg-3); font-family: var(--font-mono); font-size: var(--fs-10); letter-spacing: .06em; }
 .cbp .ph .crumb .br { color: var(--brass-1); }
-.cbp .ph .crumb .sep { color: var(--fg-4); margin: 0 4px; }
+.cbp .ph .crumb .sep { color: var(--color-fg-disabled); margin: 0 4px; }
 .cbp .body { flex:1; overflow:auto; padding: 8px 10px; display:flex; flex-direction:column; gap: 8px; }
 .cbp .body.flat { padding: 0; gap: 0; }
 
 /* tiny "filter chip" rail */
 .cbp .filt { display:flex; gap:4px; flex-wrap:wrap; }
 .cbp .filt button { font-family: var(--font-mono); font-size: var(--fs-10); letter-spacing: .06em; text-transform: uppercase; padding: 2px 7px; border: 1px solid var(--line-2); background: var(--bg-2); color: var(--fg-3); cursor: pointer; border-radius: 0; height: 18px; }
-.cbp .filt button.on { color: var(--brass-1); background: rgb(var(--brass-glow)/.08); border-color: var(--brass-2); }
+.cbp .filt button.on { color: var(--brass-1); background: rgb(var(--color-accent-glow)/.08); border-color: var(--brass-2); }
 .cbp .filt button:hover { color: var(--fg-1); }
 
 /* generic table inside artboards */
 .cbp table.t { width:100%; border-collapse: collapse; font-family: var(--font-mono); font-size: var(--fs-11); }
-.cbp table.t thead th { text-align:left; font-size: var(--fs-9); letter-spacing: .1em; text-transform: uppercase; color: var(--fg-4); font-weight: 600; padding: 4px 8px; border-bottom: 1px solid var(--line-2); position: sticky; top: 0; background: var(--bg-1); z-index: 1; }
+.cbp table.t thead th { text-align:left; font-size: var(--fs-9); letter-spacing: .1em; text-transform: uppercase; color: var(--color-fg-disabled); font-weight: 600; padding: 4px 8px; border-bottom: 1px solid var(--line-2); position: sticky; top: 0; background: var(--bg-1); z-index: 1; }
 .cbp table.t tbody td { padding: 4px 8px; border-bottom: 1px solid var(--line-1); color: var(--fg-2); vertical-align: middle; white-space: nowrap; }
-.cbp table.t tbody tr:hover td { background: rgb(var(--brass-glow)/.04); color: var(--fg-1); }
+.cbp table.t tbody tr:hover td { background: rgb(var(--color-accent-glow)/.04); color: var(--fg-1); }
 .cbp table.t .num { text-align:right; font-variant-numeric: tabular-nums; color: var(--fg-1); }
 .cbp table.t .id { color: var(--fg-3); }
 .cbp table.t .pri { color: var(--fg-1); white-space: normal; min-width: 0; }
-.cbp table.t .mute { color: var(--fg-4); }
+.cbp table.t .mute { color: var(--color-fg-disabled); }
 
 /* ═════ G1 · GOAL ZONE ═════ */
 .gz-track { display: grid; grid-template-columns: 80px 1fr; gap: 6px; align-items: stretch; padding: 4px 0; border-bottom: 1px dashed var(--line-1); }
 .gz-track:last-child { border-bottom: none; }
 .gz-track .hz { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--brass-1); letter-spacing: .12em; text-transform: uppercase; padding: 6px 8px; border-right: 1px solid var(--brass-2); display: flex; flex-direction: column; gap: 2px; }
-.gz-track .hz .n { color: var(--fg-4); font-size: var(--fs-9); letter-spacing: .04em; }
+.gz-track .hz .n { color: var(--color-fg-disabled); font-size: var(--fs-9); letter-spacing: .04em; }
 .gz-track .lst { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
 .gz-card { display: grid; grid-template-columns: 1fr 90px; gap: 8px; padding: 6px 8px; background: var(--bg-1); border: 1px solid var(--line-1); border-left: 2px solid var(--brass-2); border-radius: 0; align-items: center; min-width: 0; }
-.gz-card.done { border-left-color: var(--ok); opacity: .6; }
-.gz-card.discovery { border-left-color: var(--info); }
-.gz-card.verifying { border-left-color: var(--warn); }
+.gz-card.done { border-left-color: var(--color-status-ok); opacity: .6; }
+.gz-card.discovery { border-left-color: var(--color-status-info); }
+.gz-card.verifying { border-left-color: var(--color-status-warn); }
 .gz-card .top { display:flex; flex-direction:column; gap: 2px; min-width: 0; }
-.gz-card .id { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-4); letter-spacing: .06em; }
+.gz-card .id { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); letter-spacing: .06em; }
 .gz-card .ttl { font-size: var(--fs-12); color: var(--fg-1); line-height: 1.3; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .gz-card .met { display: flex; align-items: baseline; gap: 6px; font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-3); }
 .gz-card .met .v { color: var(--brass-1); font-variant-numeric: tabular-nums; }
 .gz-card .prog { display: flex; flex-direction: column; align-items: flex-end; gap: 3px; font-family: var(--font-mono); font-size: var(--fs-10); }
 .gz-card .prog .pct { color: var(--brass-1); font-variant-numeric: tabular-nums; font-size: var(--fs-13); }
 .gz-card .prog .b { width: 80px; height: 4px; background: var(--bg-3); position: relative; overflow: hidden; }
-.gz-card .prog .b i { position:absolute; left:0; top:0; bottom:0; background: linear-gradient(90deg, var(--brass-3), var(--brass-1)); }
-.gz-card.done .prog .b i { background: var(--ok); }
+.gz-card .prog .b i { position:absolute; left:0; top:0; bottom:0; background: linear-gradient(90deg, var(--color-accent-fg-dim), var(--brass-1)); }
+.gz-card.done .prog .b i { background: var(--color-status-ok); }
 
 /* horizon header bar */
-.gz-hdr { display: grid; grid-template-columns: 80px 1fr 90px; gap: 6px; padding: 4px 8px; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-4); letter-spacing: .08em; text-transform: uppercase; border-bottom: 1px solid var(--line-2); background: var(--bg-1); }
+.gz-hdr { display: grid; grid-template-columns: 80px 1fr 90px; gap: 6px; padding: 4px 8px; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); letter-spacing: .08em; text-transform: uppercase; border-bottom: 1px solid var(--line-2); background: var(--bg-1); }
 
 /* tree variant */
 .gz-tree-row { display: grid; grid-template-columns: 1fr 60px 60px; gap: 6px; padding: 5px 8px; border-bottom: 1px solid var(--line-1); align-items: center; font-family: var(--font-mono); font-size: var(--fs-11); }
-.gz-tree-row.child { padding-left: 28px; background: rgb(var(--brass-glow)/.025); }
-.gz-tree-row.child::before { content: "└"; color: var(--fg-4); margin-right: 4px; margin-left: -16px; }
+.gz-tree-row.child { padding-left: 28px; background: rgb(var(--color-accent-glow)/.025); }
+.gz-tree-row.child::before { content: "└"; color: var(--color-fg-disabled); margin-right: 4px; margin-left: -16px; }
 .gz-tree-row .ttl { color: var(--fg-1); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
-.gz-tree-row .ttl small { color: var(--fg-4); margin-left: 6px; font-size: var(--fs-9); letter-spacing: .04em; text-transform: uppercase; }
+.gz-tree-row .ttl small { color: var(--color-fg-disabled); margin-left: 6px; font-size: var(--fs-9); letter-spacing: .04em; text-transform: uppercase; }
 .gz-tree-row .num { text-align: right; font-variant-numeric: tabular-nums; color: var(--brass-1); }
 .gz-tree-row .ph { color: var(--info-fg); }
 .gz-tree-row .ph.executing { color: var(--brass-1); }
-.gz-tree-row .ph.verifying { color: var(--warn); }
+.gz-tree-row .ph.verifying { color: var(--color-status-warn); }
 .gz-tree-row .ph.done { color: var(--ok-fg); }
 
 /* snapshot diff variant */
 .gz-snap { display:flex; flex-direction:column; gap: 6px; }
 .gz-snap-row { padding: 7px 8px; background: var(--bg-1); border: 1px solid var(--line-1); border-radius: 0; }
 .gz-snap-row .ttl { font-size: var(--fs-12); color: var(--fg-1); margin-bottom: 6px; display:flex; align-items:center; gap: 6px; }
-.gz-snap-row .ttl .id { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-4); }
+.gz-snap-row .ttl .id { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); }
 .gz-snap-row .diff { display: grid; grid-template-columns: 1fr 16px 1fr; gap: 8px; align-items: center; font-family: var(--font-mono); font-size: var(--fs-10); }
 .gz-snap-row .y, .gz-snap-row .t { padding: 4px 6px; border: 1px dashed var(--line-2); background: var(--bg-2); }
 .gz-snap-row .y { color: var(--fg-3); }
-.gz-snap-row .t { color: var(--fg-1); border-style: solid; border-color: var(--brass-2); background: rgb(var(--brass-glow)/.05); }
+.gz-snap-row .t { color: var(--fg-1); border-style: solid; border-color: var(--brass-2); background: rgb(var(--color-accent-glow)/.05); }
 .gz-snap-row .arr { color: var(--brass-1); text-align: center; font-size: var(--fs-12); }
-.gz-snap-row .lbl { font-size: var(--fs-9); color: var(--fg-4); letter-spacing: .08em; text-transform: uppercase; display:block; margin-bottom: 2px; }
+.gz-snap-row .lbl { font-size: var(--fs-9); color: var(--color-fg-disabled); letter-spacing: .08em; text-transform: uppercase; display:block; margin-bottom: 2px; }
 .gz-snap-row .v { color: var(--brass-1); font-variant-numeric: tabular-nums; }
 
 /* ═════ G2 · TASK ZONE ═════ */
 .tz-row td { vertical-align: top !important; padding: 6px 8px !important; }
 .tz-row .stat { padding: 1px 6px; font-family: var(--font-mono); font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; border: 1px solid var(--line-2); color: var(--fg-3); }
-.tz-row .stat.running   { color: var(--brass-1); border-color: var(--brass-2); background: rgb(var(--brass-glow)/.08); }
+.tz-row .stat.running   { color: var(--brass-1); border-color: var(--brass-2); background: rgb(var(--color-accent-glow)/.08); }
 .tz-row .stat.pending   { color: var(--fg-3); }
 .tz-row .stat.queued    { color: var(--info-fg); border-color: var(--info-border); background: var(--info-soft); }
 .tz-row .stat.fail      { color: var(--err-fg); border-color: var(--err-border); background: var(--err-soft); }
-.tz-row .stat.stalled   { color: var(--stalled); border-color: var(--stalled); background: rgb(var(--stalled-glow)/.1); }
-.tz-row .stat.done      { color: var(--ok-fg); border-color: var(--ok); background: var(--ok-soft); opacity: .8; }
-.tz-row .stat.cancelled { color: var(--fg-4); text-decoration: line-through; }
+.tz-row .stat.stalled   { color: var(--color-status-stalled); border-color: var(--color-status-stalled); background: rgb(var(--stalled-glow)/.1); }
+.tz-row .stat.done      { color: var(--ok-fg); border-color: var(--color-status-ok); background: var(--ok-soft); opacity: .8; }
+.tz-row .stat.cancelled { color: var(--color-fg-disabled); text-decoration: line-through; }
 .tz-row .drift { color: var(--err-fg); font-size: var(--fs-9); letter-spacing: .08em; padding: 1px 5px; border: 1px solid var(--err-border); background: var(--err-soft); margin-left: 4px; }
 
 /* stale-claim alert layout */
 .tz-alert { display:flex; flex-direction:column; gap:6px; }
-.tz-alert .row { display:grid; grid-template-columns: 1fr auto auto; gap: 8px; padding: 8px 10px; background: var(--bg-1); border: 1px solid var(--err-border); border-left: 2px solid var(--err); align-items: center; }
+.tz-alert .row { display:grid; grid-template-columns: 1fr auto auto; gap: 8px; padding: 8px 10px; background: var(--bg-1); border: 1px solid var(--err-border); border-left: 2px solid var(--color-status-err); align-items: center; }
 .tz-alert .row .who { font-family: var(--font-mono); font-size: var(--fs-11); color: var(--fg-1); }
 .tz-alert .row .who .id { color: var(--brass-1); }
 .tz-alert .row .who .age { color: var(--err-fg); margin-left: 8px; font-size: var(--fs-10); }
@@ -410,36 +410,36 @@
 .tz-alert .row .acts { display:flex; gap: 4px; }
 .tz-alert .row .acts button { font-family: var(--font-mono); font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; padding: 3px 8px; background: var(--bg-3); border: 1px solid var(--line-2); color: var(--fg-2); cursor: pointer; border-radius: 0; }
 .tz-alert .row .acts button.danger { color: var(--err-fg); border-color: var(--err-border); }
-.tz-alert .row .acts button.primary { color: var(--bg-0); background: var(--brass-2); border-color: var(--brass-3); }
+.tz-alert .row .acts button.primary { color: var(--bg-0); background: var(--brass-2); border-color: var(--color-accent-fg-dim); }
 
 /* per-keeper task wall */
 .tz-wall { display:grid; grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); gap: 6px; }
 .tz-wall .kpr { padding: 6px 8px; background: var(--bg-1); border: 1px solid var(--line-1); border-top: 2px solid var(--brass-2); border-radius: 0; display:flex; flex-direction:column; gap: 4px; min-width: 0; }
 .tz-wall .kpr .h { display:flex; align-items:center; gap:5px; font-family: var(--font-mono); font-size: var(--fs-10); }
 .tz-wall .kpr .h .nm { color: var(--brass-1); }
-.tz-wall .kpr .h .cn { color: var(--fg-4); margin-left: auto; font-size: var(--fs-9); letter-spacing: .04em; }
+.tz-wall .kpr .h .cn { color: var(--color-fg-disabled); margin-left: auto; font-size: var(--fs-9); letter-spacing: .04em; }
 .tz-wall .kpr .tk { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-2); padding: 3px 5px; border-left: 2px solid var(--line-2); background: var(--bg-0); display:flex; gap: 4px; align-items: baseline; }
-.tz-wall .kpr .tk .id { color: var(--fg-4); font-size: var(--fs-9); flex-shrink: 0; }
+.tz-wall .kpr .tk .id { color: var(--color-fg-disabled); font-size: var(--fs-9); flex-shrink: 0; }
 .tz-wall .kpr .tk .t { color: var(--fg-1); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; flex: 1; }
 .tz-wall .kpr .tk.running { border-left-color: var(--brass-1); }
-.tz-wall .kpr .tk.fail { border-left-color: var(--err); }
-.tz-wall .kpr .tk.stalled { border-left-color: var(--stalled); }
-.tz-wall .kpr .tk.done { border-left-color: var(--ok); opacity: .55; }
+.tz-wall .kpr .tk.fail { border-left-color: var(--color-status-err); }
+.tz-wall .kpr .tk.stalled { border-left-color: var(--color-status-stalled); }
+.tz-wall .kpr .tk.done { border-left-color: var(--color-status-ok); opacity: .55; }
 .tz-wall .kpr.empty { opacity: .35; }
-.tz-wall .kpr.empty .tk { font-style: italic; color: var(--fg-4); }
+.tz-wall .kpr.empty .tk { font-style: italic; color: var(--color-fg-disabled); }
 
 /* ═════ G3 · ACCOUNTABILITY ═════ */
 .ac-row { display: grid; grid-template-columns: 70px 80px 1fr 110px; gap: 8px; padding: 6px 8px; border-bottom: 1px solid var(--line-1); font-family: var(--font-mono); font-size: var(--fs-11); align-items: baseline; }
-.ac-row .ts { color: var(--fg-4); font-size: var(--fs-10); }
+.ac-row .ts { color: var(--color-fg-disabled); font-size: var(--fs-10); }
 .ac-row .vd { font-size: var(--fs-9); letter-spacing: .1em; text-transform: uppercase; padding: 1px 5px; border: 1px solid var(--line-2); text-align: center; }
-.ac-row .vd.approve { color: var(--ok-fg); border-color: var(--ok); background: var(--ok-soft); }
+.ac-row .vd.approve { color: var(--ok-fg); border-color: var(--color-status-ok); background: var(--ok-soft); }
 .ac-row .vd.reject  { color: var(--err-fg); border-color: var(--err-border); background: var(--err-soft); }
-.ac-row .vd.flag    { color: var(--warn); border-color: var(--warn); background: rgb(var(--warn-glow)/.1); }
+.ac-row .vd.flag    { color: var(--color-status-warn); border-color: var(--color-status-warn); background: rgb(var(--warn-glow)/.1); }
 .ac-row .vd.defer   { color: var(--info-fg); border-color: var(--info-border); background: var(--info-soft); }
 .ac-row .sub { color: var(--fg-1); white-space: normal; line-height: 1.3; }
 .ac-row .sub .ev { color: var(--fg-3); font-size: var(--fs-9); display: block; margin-top: 1px; letter-spacing: .04em; }
 .ac-row .sig { color: var(--brass-1); text-align: right; font-size: var(--fs-10); }
-.ac-row .sig .scope { color: var(--fg-4); display: block; font-size: var(--fs-9); letter-spacing: .04em; text-transform: uppercase; }
+.ac-row .sig .scope { color: var(--color-fg-disabled); display: block; font-size: var(--fs-9); letter-spacing: .04em; text-transform: uppercase; }
 
 /* responsibility matrix */
 .ac-mtx { width:100%; border-collapse: collapse; font-family: var(--font-mono); font-size: var(--fs-10); }
@@ -448,10 +448,10 @@
 .ac-mtx th.col-h { writing-mode: vertical-rl; transform: rotate(180deg); padding: 6px 2px; height: 80px; vertical-align: bottom; }
 .ac-mtx th.row-h { text-align: left; color: var(--fg-2); font-family: var(--font-mono); font-weight: 400; }
 .ac-mtx td { color: var(--fg-3); font-variant-numeric: tabular-nums; background: var(--bg-0); transition: background .15s; cursor: default; }
-.ac-mtx td.z0 { color: var(--fg-4); opacity: .3; }
-.ac-mtx td.z1 { color: var(--fg-2); background: rgb(var(--brass-glow)/.05); }
-.ac-mtx td.z2 { color: var(--fg-1); background: rgb(var(--brass-glow)/.12); }
-.ac-mtx td.z3 { color: var(--brass-1); background: rgb(var(--brass-glow)/.22); font-weight: 600; }
+.ac-mtx td.z0 { color: var(--color-fg-disabled); opacity: .3; }
+.ac-mtx td.z1 { color: var(--fg-2); background: rgb(var(--color-accent-glow)/.05); }
+.ac-mtx td.z2 { color: var(--fg-1); background: rgb(var(--color-accent-glow)/.12); }
+.ac-mtx td.z3 { color: var(--brass-1); background: rgb(var(--color-accent-glow)/.22); font-weight: 600; }
 .ac-mtx td.z4 { color: var(--bg-0); background: var(--brass-1); font-weight: 600; }
 .ac-mtx tr:hover td { outline: 1px solid var(--brass-2); outline-offset: -1px; }
 
@@ -469,10 +469,10 @@
 /* ═════ C1 · BOARD ═════ */
 .bd-feed { display:flex; flex-direction:column; gap: 6px; }
 .bd-post { display: grid; grid-template-columns: 32px 1fr 80px; gap: 8px; padding: 8px 10px; background: var(--bg-1); border: 1px solid var(--line-1); border-left: 2px solid var(--line-2); border-radius: 0; align-items: start; }
-.bd-post.automation { border-left-color: var(--info); background: rgb(80 130 180 / .04); }
+.bd-post.automation { border-left-color: var(--color-status-info); background: rgb(80 130 180 / .04); }
 .bd-post.direct     { border-left-color: var(--brass-2); }
-.bd-post.hot        { border-left-color: var(--err); }
-.bd-post .vote { display:flex; flex-direction:column; align-items:center; gap: 1px; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-4); padding-top: 2px; }
+.bd-post.hot        { border-left-color: var(--color-status-err); }
+.bd-post .vote { display:flex; flex-direction:column; align-items:center; gap: 1px; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); padding-top: 2px; }
 .bd-post .vote .up, .bd-post .vote .dn { width: 16px; height: 12px; display:flex; align-items:center; justify-content:center; cursor:pointer; border-radius: 0; }
 .bd-post .vote .up:hover { color: var(--ok-fg); }
 .bd-post .vote .dn:hover { color: var(--err-fg); }
@@ -485,23 +485,23 @@
 .bd-post .h .kk.automation { color: var(--info-fg); border-color: var(--info-border); background: var(--info-soft); }
 .bd-post .h .kk.direct { color: var(--brass-1); border-color: var(--brass-2); }
 .bd-post .h .he { padding: 0 5px; font-size: var(--fs-9); letter-spacing: .04em; color: var(--fg-2); background: var(--bg-2); border: 1px solid var(--line-1); }
-.bd-post .h .at { color: var(--fg-4); margin-left: auto; }
-.bd-post .h .exp { color: var(--warn); font-size: var(--fs-9); letter-spacing: .04em; }
+.bd-post .h .at { color: var(--color-fg-disabled); margin-left: auto; }
+.bd-post .h .exp { color: var(--color-status-warn); font-size: var(--fs-9); letter-spacing: .04em; }
 .bd-post .ttl { font-size: var(--fs-13); color: var(--fg-1); line-height: 1.3; font-weight: 500; }
 .bd-post .body { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-2); line-height: 1.4; white-space: pre-wrap; max-height: 70px; overflow: hidden; position: relative; }
 .bd-post .body.expand { max-height: none; }
 .bd-post .body.clip::after { content:''; position: absolute; left:0; right:0; bottom:0; height: 18px; background: linear-gradient(transparent, var(--bg-1)); }
-.bd-post .state-block { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--brass-1); background: rgb(var(--brass-glow)/.06); border: 1px dashed var(--brass-2); padding: 3px 5px; margin-top: 4px; white-space: pre-wrap; }
-.bd-post .ft { display:flex; gap: 8px; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-4); letter-spacing: .04em; text-transform: uppercase; }
+.bd-post .state-block { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--brass-1); background: rgb(var(--color-accent-glow)/.06); border: 1px dashed var(--brass-2); padding: 3px 5px; margin-top: 4px; white-space: pre-wrap; }
+.bd-post .ft { display:flex; gap: 8px; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); letter-spacing: .04em; text-transform: uppercase; }
 .bd-post .ft button { background: transparent; border: none; color: inherit; font-family: inherit; font-size: inherit; letter-spacing: inherit; cursor: pointer; padding: 0; }
 .bd-post .ft button:hover { color: var(--brass-1); }
-.bd-post .meta-r { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-4); display:flex; flex-direction:column; align-items:flex-end; gap: 2px; letter-spacing: .04em; text-transform: uppercase; }
+.bd-post .meta-r { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); display:flex; flex-direction:column; align-items:flex-end; gap: 2px; letter-spacing: .04em; text-transform: uppercase; }
 
 /* hearth-grouped feed */
 .bd-hearth-grp { border-top: 1px solid var(--line-2); padding-top: 4px; margin-top: 8px; }
 .bd-hearth-grp:first-child { border-top: none; padding-top: 0; margin-top: 0; }
 .bd-hearth-grp .hh { display:flex; align-items:center; gap: 6px; padding: 4px 0; font-family: var(--font-mono); font-size: var(--fs-10); color: var(--brass-1); letter-spacing: .12em; text-transform: uppercase; font-weight: 600; }
-.bd-hearth-grp .hh .cn { color: var(--fg-4); font-size: var(--fs-9); }
+.bd-hearth-grp .hh .cn { color: var(--color-fg-disabled); font-size: var(--fs-9); }
 .bd-hearth-grp .hh::before { content: "♨"; color: var(--brass-2); font-size: var(--fs-12); }
 
 /* single post + thread */
@@ -509,33 +509,33 @@
 .bd-thread .reply { padding: 6px 8px; background: var(--bg-1); border: 1px solid var(--line-1); border-radius: 0; }
 .bd-thread .reply .h { display:flex; gap: 6px; font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-3); align-items: baseline; margin-bottom: 3px; }
 .bd-thread .reply .h .au { color: var(--brass-1); }
-.bd-thread .reply .h .at { color: var(--fg-4); margin-left: auto; }
+.bd-thread .reply .h .at { color: var(--color-fg-disabled); margin-left: auto; }
 .bd-thread .reply .body { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-2); line-height: 1.4; white-space: pre-wrap; }
 
 /* ═════ C2 · MESSAGES ═════ */
 .ms-room { display: grid; grid-template-columns: 180px 1fr; height: 100%; }
 .ms-room .roomlist { border-right: 1px solid var(--line-2); background: var(--bg-1); display:flex; flex-direction:column; }
 .ms-room .roomlist .room { padding: 6px 10px; border-bottom: 1px solid var(--line-1); cursor: pointer; display:flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: var(--fs-11); color: var(--fg-2); }
-.ms-room .roomlist .room.on { background: rgb(var(--brass-glow)/.08); color: var(--brass-1); border-left: 2px solid var(--brass-1); padding-left: 8px; }
+.ms-room .roomlist .room.on { background: rgb(var(--color-accent-glow)/.08); color: var(--brass-1); border-left: 2px solid var(--brass-1); padding-left: 8px; }
 .ms-room .roomlist .room .nm { flex: 1; }
-.ms-room .roomlist .room .nm::before { content: "#"; color: var(--fg-4); margin-right: 3px; }
-.ms-room .roomlist .room .un { font-size: var(--fs-9); color: var(--brass-1); background: rgb(var(--brass-glow)/.15); padding: 1px 5px; border-radius: 0; min-width: 18px; text-align: center; }
+.ms-room .roomlist .room .nm::before { content: "#"; color: var(--color-fg-disabled); margin-right: 3px; }
+.ms-room .roomlist .room .un { font-size: var(--fs-9); color: var(--brass-1); background: rgb(var(--color-accent-glow)/.15); padding: 1px 5px; border-radius: 0; min-width: 18px; text-align: center; }
 .ms-room .roomlist .room .un.zero { display: none; }
 .ms-room .feed { display:flex; flex-direction:column; }
 .ms-room .feed .timeline { flex:1; overflow:auto; padding: 8px 10px; display:flex; flex-direction: column; gap: 6px; }
 
 .ms-msg { display: grid; grid-template-columns: 50px 1fr; gap: 8px; font-family: var(--font-mono); font-size: var(--fs-11); }
-.ms-msg .seq { color: var(--fg-4); font-size: var(--fs-9); text-align: right; padding-top: 2px; letter-spacing: .04em; }
+.ms-msg .seq { color: var(--color-fg-disabled); font-size: var(--fs-9); text-align: right; padding-top: 2px; letter-spacing: .04em; }
 .ms-msg .body { display:flex; flex-direction:column; gap: 3px; min-width: 0; }
 .ms-msg .h { display:flex; align-items: baseline; gap: 6px; }
 .ms-msg .h .au { color: var(--brass-1); font-weight: 600; }
 .ms-msg .h .kk { padding: 0 4px; font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; border: 1px solid var(--line-2); color: var(--fg-3); }
 .ms-msg .h .kk.dm { color: var(--info-fg); border-color: var(--info-border); background: var(--info-soft); }
-.ms-msg .h .kk.broadcast { color: var(--fg-4); }
-.ms-msg .h .at { margin-left: auto; color: var(--fg-4); font-size: var(--fs-9); }
+.ms-msg .h .kk.broadcast { color: var(--color-fg-disabled); }
+.ms-msg .h .at { margin-left: auto; color: var(--color-fg-disabled); font-size: var(--fs-9); }
 .ms-msg .text { color: var(--fg-1); line-height: 1.45; word-break: break-word; }
-.ms-msg .text .mention { color: var(--brass-1); background: rgb(var(--brass-glow)/.1); padding: 0 3px; border-radius: 0; }
-.ms-msg .state-block { color: var(--brass-1); background: rgb(var(--brass-glow)/.06); border-left: 2px solid var(--brass-2); padding: 3px 6px; margin-top: 3px; white-space: pre-wrap; font-size: var(--fs-10); }
+.ms-msg .text .mention { color: var(--brass-1); background: rgb(var(--color-accent-glow)/.1); padding: 0 3px; border-radius: 0; }
+.ms-msg .state-block { color: var(--brass-1); background: rgb(var(--color-accent-glow)/.06); border-left: 2px solid var(--brass-2); padding: 3px 6px; margin-top: 3px; white-space: pre-wrap; font-size: var(--fs-10); }
 
 /* mention inbox */
 .ms-inbox { display:flex; flex-direction:column; gap: 4px; }
@@ -543,9 +543,9 @@
 .ms-inbox .mn .h { display:flex; gap: 6px; align-items: baseline; margin-bottom: 3px; }
 .ms-inbox .mn .h .au { color: var(--brass-1); font-weight: 600; }
 .ms-inbox .mn .h .rm { color: var(--info-fg); font-size: var(--fs-9); }
-.ms-inbox .mn .h .at { color: var(--fg-4); font-size: var(--fs-9); margin-left: auto; }
+.ms-inbox .mn .h .at { color: var(--color-fg-disabled); font-size: var(--fs-9); margin-left: auto; }
 .ms-inbox .mn .text { color: var(--fg-1); line-height: 1.4; }
-.ms-inbox .mn .text .mention { color: var(--brass-1); background: rgb(var(--brass-glow)/.15); padding: 0 3px; }
+.ms-inbox .mn .text .mention { color: var(--brass-1); background: rgb(var(--color-accent-glow)/.15); padding: 0 3px; }
 
 /* ═════ C3 · COMPOSER V2 (broadcast / mention / state-block) ═════ */
 .cm2 { background: var(--bg-1); border: 1px solid var(--line-2); border-top: 2px solid var(--brass-2); padding: 8px 10px; display:flex; flex-direction:column; gap: 6px; }
@@ -553,19 +553,19 @@
 .cm2 .toolbar .seg { display:flex; border: 1px solid var(--line-2); border-radius: 0; }
 .cm2 .toolbar .seg button { background: transparent; border: none; color: var(--fg-3); padding: 3px 8px; font-family: inherit; font-size: inherit; letter-spacing: .08em; text-transform: uppercase; cursor: pointer; border-right: 1px solid var(--line-2); font-weight: 600; }
 .cm2 .toolbar .seg button:last-child { border-right: none; }
-.cm2 .toolbar .seg button.on { color: var(--brass-1); background: rgb(var(--brass-glow)/.1); }
+.cm2 .toolbar .seg button.on { color: var(--brass-1); background: rgb(var(--color-accent-glow)/.1); }
 .cm2 .toolbar .room-sel { padding: 2px 6px; background: var(--bg-2); border: 1px solid var(--line-2); color: var(--brass-1); font-family: inherit; font-size: inherit; }
-.cm2 .toolbar .room-sel::before { content: "→ #"; color: var(--fg-4); }
+.cm2 .toolbar .room-sel::before { content: "→ #"; color: var(--color-fg-disabled); }
 .cm2 .toolbar .grow { flex: 1; }
 .cm2 .toolbar .send { padding: 3px 10px; background: var(--brass-2); color: var(--bg-0); border: none; font-family: inherit; font-size: inherit; letter-spacing: .08em; text-transform: uppercase; cursor: pointer; font-weight: 600; }
 .cm2 .ed { background: var(--bg-0); border: 1px solid var(--line-1); padding: 6px 8px; font-family: var(--font-mono); font-size: var(--fs-11); color: var(--fg-1); min-height: 60px; line-height: 1.5; cursor: text; white-space: pre-wrap; }
-.cm2 .ed .mention { color: var(--brass-1); background: rgb(var(--brass-glow)/.1); padding: 0 3px; }
-.cm2 .ed .state-block { color: var(--brass-1); background: rgb(var(--brass-glow)/.06); border-left: 2px solid var(--brass-2); padding: 3px 6px; margin: 3px 0; display: block; }
+.cm2 .ed .mention { color: var(--brass-1); background: rgb(var(--color-accent-glow)/.1); padding: 0 3px; }
+.cm2 .ed .state-block { color: var(--brass-1); background: rgb(var(--color-accent-glow)/.06); border-left: 2px solid var(--brass-2); padding: 3px 6px; margin: 3px 0; display: block; }
 .cm2 .ed .caret { color: var(--brass-1); animation: anim-blink 1s step-end infinite; }
 @keyframes anim-blink { 50% { opacity: 0; } }
-.cm2 .targets { display:flex; gap: 4px; flex-wrap: wrap; padding: 3px 0; border-top: 1px dashed var(--line-1); font-family: var(--font-mono); font-size: var(--fs-9); align-items: center; color: var(--fg-4); letter-spacing: .04em; text-transform: uppercase; }
-.cm2 .targets .t-pill { padding: 1px 6px; background: rgb(var(--brass-glow)/.08); color: var(--brass-1); border: 1px solid var(--brass-2); border-radius: 0; text-transform: none; letter-spacing: .04em; font-size: var(--fs-10); }
-.cm2 .hint { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-4); letter-spacing: .04em; display:flex; gap: 12px; padding-top: 3px; border-top: 1px dashed var(--line-1); }
+.cm2 .targets { display:flex; gap: 4px; flex-wrap: wrap; padding: 3px 0; border-top: 1px dashed var(--line-1); font-family: var(--font-mono); font-size: var(--fs-9); align-items: center; color: var(--color-fg-disabled); letter-spacing: .04em; text-transform: uppercase; }
+.cm2 .targets .t-pill { padding: 1px 6px; background: rgb(var(--color-accent-glow)/.08); color: var(--brass-1); border: 1px solid var(--brass-2); border-radius: 0; text-transform: none; letter-spacing: .04em; font-size: var(--fs-10); }
+.cm2 .hint { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); letter-spacing: .04em; display:flex; gap: 12px; padding-top: 3px; border-top: 1px dashed var(--line-1); }
 .cm2 .hint .kbd { display:inline-block; padding: 0 4px; border: 1px solid var(--line-2); background: var(--bg-2); color: var(--fg-2); font-size: var(--fs-9); margin-right: 4px; }
 
 
@@ -576,47 +576,47 @@
 /* ═════ O1 · CASCADE INSPECTOR ═════ */
 .csc-list { display:flex; flex-direction:column; gap: 6px; }
 .csc-card { background: var(--bg-1); border: 1px solid var(--line-2); padding: 0; display:flex; flex-direction:column; }
-.csc-card.outcome-error { border-left: 2px solid var(--err); }
-.csc-card.outcome-ok    { border-left: 2px solid var(--ok); }
+.csc-card.outcome-error { border-left: 2px solid var(--color-status-err); }
+.csc-card.outcome-ok    { border-left: 2px solid var(--color-status-ok); }
 .csc-card .h { display:flex; align-items: baseline; gap: 8px; padding: 5px 8px; background: var(--bg-2); border-bottom: 1px solid var(--line-1); font-family: var(--font-mono); font-size: var(--fs-10); }
 .csc-card .h .id  { color: var(--brass-1); }
 .csc-card .h .nm  { color: var(--fg-2); letter-spacing: .04em; }
 .csc-card .h .tg  { color: var(--fg-3); font-size: var(--fs-9); }
 .csc-card .h .out { margin-left: auto; padding: 1px 6px; font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; border:1px solid var(--line-2); }
 .csc-card .h .out.error { color: var(--err-fg); border-color: var(--err-border); background: var(--err-soft); }
-.csc-card .h .out.ok    { color: var(--ok-fg);  border-color: var(--ok); background: var(--ok-soft); }
+.csc-card .h .out.ok    { color: var(--ok-fg);  border-color: var(--color-status-ok); background: var(--ok-soft); }
 .csc-card .hops { display:flex; flex-direction:column; }
 .csc-card .hop { display: grid; grid-template-columns: 22px 1fr 70px 80px; align-items:center; gap: 8px; padding: 4px 8px; border-top: 1px dashed var(--line-1); font-family: var(--font-mono); font-size: var(--fs-10); }
 .csc-card .hop:first-child { border-top: none; }
-.csc-card .hop .step { color: var(--fg-4); text-align: center; }
+.csc-card .hop .step { color: var(--color-fg-disabled); text-align: center; }
 .csc-card .hop .mdl { color: var(--fg-1); }
 .csc-card .hop .ms  { color: var(--fg-3); text-align: right; font-variant-numeric: tabular-nums; }
 .csc-card .hop .st  { font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; padding: 0 4px; text-align: center; }
-.csc-card .hop .st.miss      { color: var(--warn); border:1px solid var(--warn); background: rgb(var(--warn-glow)/.08); }
-.csc-card .hop .st.hit       { color: var(--ok-fg); border:1px solid var(--ok); background: var(--ok-soft); }
+.csc-card .hop .st.miss      { color: var(--color-status-warn); border:1px solid var(--color-status-warn); background: rgb(var(--warn-glow)/.08); }
+.csc-card .hop .st.hit       { color: var(--ok-fg); border:1px solid var(--color-status-ok); background: var(--ok-soft); }
 .csc-card .hop .st.exhausted { color: var(--err-fg); border:1px solid var(--err-border); background: var(--err-soft); }
-.csc-card .hop .reason { grid-column: 2 / -1; color: var(--fg-4); font-size: var(--fs-9); padding-left: 0; }
-.csc-card .ft { padding: 4px 8px; background: var(--bg-0); border-top: 1px solid var(--line-1); display:flex; gap: 12px; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-4); letter-spacing: .04em; text-transform: uppercase; }
+.csc-card .hop .reason { grid-column: 2 / -1; color: var(--color-fg-disabled); font-size: var(--fs-9); padding-left: 0; }
+.csc-card .ft { padding: 4px 8px; background: var(--bg-0); border-top: 1px solid var(--line-1); display:flex; gap: 12px; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); letter-spacing: .04em; text-transform: uppercase; }
 .csc-card .ft .ms { color: var(--brass-1); }
 
 /* configured pool view (one line of pills) */
 .csc-pool { display:flex; flex-wrap: wrap; gap: 4px; padding: 5px 8px; background: var(--bg-0); border-top: 1px dashed var(--line-1); }
 .csc-pool .mp { font-family: var(--font-mono); font-size: var(--fs-9); padding: 1px 5px; border:1px solid var(--line-1); color: var(--fg-3); background: var(--bg-2); }
-.csc-pool .mp.tried { color: var(--warn); border-color: var(--warn); }
-.csc-pool .mp.hit   { color: var(--brass-1); border-color: var(--brass-2); background: rgb(var(--brass-glow)/.08); font-weight: 600; }
+.csc-pool .mp.tried { color: var(--color-status-warn); border-color: var(--color-status-warn); }
+.csc-pool .mp.hit   { color: var(--brass-1); border-color: var(--brass-2); background: rgb(var(--color-accent-glow)/.08); font-weight: 600; }
 
 /* ═════ O2 · AUDIT LEDGER ═════ */
 .aud-row { display:grid; grid-template-columns: 70px 110px 90px 1fr 60px; gap: 6px; padding: 4px 8px; border-bottom: 1px solid var(--line-1); align-items: baseline; font-family: var(--font-mono); font-size: var(--fs-11); }
-.aud-row .ts { color: var(--fg-4); font-size: var(--fs-10); }
+.aud-row .ts { color: var(--color-fg-disabled); font-size: var(--fs-10); }
 .aud-row .kn { font-size: var(--fs-9); letter-spacing: .04em; padding: 1px 5px; border: 1px solid var(--line-2); color: var(--fg-2); background: var(--bg-2); white-space: nowrap; }
 .aud-row .kn.tool       { color: var(--info-fg); }
 .aud-row .kn.suite      { color: var(--err-fg); border-color: var(--err-border); background: var(--err-soft); }
-.aud-row .kn.verdict    { color: var(--ok-fg); border-color: var(--ok); background: var(--ok-soft); }
+.aud-row .kn.verdict    { color: var(--ok-fg); border-color: var(--color-status-ok); background: var(--ok-soft); }
 .aud-row .kn.cascade    { color: var(--brass-1); border-color: var(--brass-2); }
 .aud-row .kn.task       { color: var(--fg-1); }
 .aud-row .kn.board      { color: var(--fg-3); }
 .aud-row .kn.message    { color: var(--info-fg); }
-.aud-row .kn.keeper     { color: var(--warn); border-color: var(--warn); }
+.aud-row .kn.keeper     { color: var(--color-status-warn); border-color: var(--color-status-warn); }
 .aud-row .kn.operator   { color: var(--bg-0); background: var(--brass-1); border-color: var(--brass-1); }
 .aud-row .ac { color: var(--brass-1); }
 .aud-row .sb { color: var(--fg-1); white-space: normal; }
@@ -624,62 +624,62 @@
 .aud-row .du { text-align: right; color: var(--fg-3); font-variant-numeric: tabular-nums; font-size: var(--fs-10); }
 
 /* ═════ O3 · SAFE AUTONOMY DASHBOARD ═════ */
-.sa-hero { display:grid; grid-template-columns: 200px 1fr; gap: 12px; padding: 10px 12px; background: var(--bg-1); border: 1px solid var(--line-2); border-left: 3px solid var(--err); align-items: center; }
+.sa-hero { display:grid; grid-template-columns: 200px 1fr; gap: 12px; padding: 10px 12px; background: var(--bg-1); border: 1px solid var(--line-2); border-left: 3px solid var(--color-status-err); align-items: center; }
 .sa-hero .gauge { display:flex; flex-direction:column; align-items:flex-start; gap: 4px; }
 .sa-hero .gauge .v { font-family: var(--font-mono); font-size: 48px; color: var(--brass-1); font-weight: 600; line-height: 1; font-variant-numeric: tabular-nums; }
 .sa-hero .gauge .v.fail { color: var(--err-fg); }
-.sa-hero .gauge .lbl { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-4); letter-spacing: .12em; text-transform: uppercase; }
+.sa-hero .gauge .lbl { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); letter-spacing: .12em; text-transform: uppercase; }
 .sa-hero .gauge .st { font-family: var(--font-mono); font-size: var(--fs-10); padding: 1px 6px; border: 1px solid var(--err-border); color: var(--err-fg); background: var(--err-soft); letter-spacing: .12em; text-transform: uppercase; font-weight: 600; }
 .sa-hero .meta { display:grid; grid-template-columns: 1fr 1fr; gap: 4px 12px; font-family: var(--font-mono); font-size: var(--fs-10); }
-.sa-hero .meta .k { color: var(--fg-4); letter-spacing: .04em; text-transform: uppercase; font-size: var(--fs-9); }
+.sa-hero .meta .k { color: var(--color-fg-disabled); letter-spacing: .04em; text-transform: uppercase; font-size: var(--fs-9); }
 .sa-hero .meta .v { color: var(--fg-1); font-variant-numeric: tabular-nums; }
 .sa-hero .spark { grid-column: 1 / -1; height: 28px; }
 
 .sa-find { display:grid; grid-template-columns: 50px 100px 1fr 200px; gap: 6px; padding: 4px 8px; border-bottom: 1px solid var(--line-1); align-items: baseline; font-family: var(--font-mono); font-size: var(--fs-11); }
 .sa-find .sev { padding: 1px 5px; font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; text-align: center; border:1px solid var(--line-2); }
 .sa-find .sev.high   { color: var(--err-fg); border-color: var(--err-border); background: var(--err-soft); font-weight: 600; }
-.sa-find .sev.medium { color: var(--warn); border-color: var(--warn); background: rgb(var(--warn-glow)/.1); }
+.sa-find .sev.medium { color: var(--color-status-warn); border-color: var(--color-status-warn); background: rgb(var(--warn-glow)/.1); }
 .sa-find .sev.low    { color: var(--fg-3); }
 .sa-find .kpr { color: var(--brass-1); }
 .sa-find .rule { color: var(--fg-1); white-space: normal; }
-.sa-find .loc  { color: var(--fg-4); font-size: var(--fs-10); text-align: right; }
+.sa-find .loc  { color: var(--color-fg-disabled); font-size: var(--fs-10); text-align: right; }
 .sa-find .loc .ln { color: var(--brass-1); }
 
 /* ═════ O4 · COST DASHBOARD ═════ */
 .cs-tot { display:grid; grid-template-columns: repeat(4, 1fr); gap: 1px; background: var(--line-2); border: 1px solid var(--line-2); margin-bottom: 8px; }
 .cs-tot .cell { background: var(--bg-1); padding: 8px 12px; display:flex; flex-direction:column; gap: 4px; }
-.cs-tot .cell .lbl { font-family: var(--font-mono); font-size: var(--fs-9); letter-spacing: .12em; text-transform: uppercase; color: var(--fg-4); }
+.cs-tot .cell .lbl { font-family: var(--font-mono); font-size: var(--fs-9); letter-spacing: .12em; text-transform: uppercase; color: var(--color-fg-disabled); }
 .cs-tot .cell .v { font-family: var(--font-mono); font-size: 22px; color: var(--brass-1); font-variant-numeric: tabular-nums; line-height: 1.1; }
 .cs-tot .cell .sub { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-3); }
 
 .cs-tbl td.bar { padding: 0 !important; position: relative; height: 16px; min-width: 120px; }
-.cs-tbl td.bar i { display:block; height: 100%; background: linear-gradient(90deg, var(--brass-3), var(--brass-1)); }
-.cs-tbl td.bar.lat i { background: linear-gradient(90deg, var(--info), var(--err)); }
+.cs-tbl td.bar i { display:block; height: 100%; background: linear-gradient(90deg, var(--color-accent-fg-dim), var(--brass-1)); }
+.cs-tbl td.bar.lat i { background: linear-gradient(90deg, var(--color-status-info), var(--color-status-err)); }
 .cs-tbl td.lat-num { font-variant-numeric: tabular-nums; color: var(--fg-2); text-align: right; }
 .cs-tbl td.lat-num.bad { color: var(--err-fg); }
 
 /* latency histogram */
 .cs-hist { display:flex; align-items:flex-end; height: 80px; gap: 2px; padding: 4px 8px; background: var(--bg-1); border: 1px solid var(--line-2); }
 .cs-hist .col { flex: 1; display:flex; flex-direction:column; align-items:center; gap: 2px; }
-.cs-hist .col .b { width: 100%; background: linear-gradient(180deg, var(--brass-1), var(--brass-3)); }
-.cs-hist .col .b.bad { background: linear-gradient(180deg, var(--warn), var(--err)); }
-.cs-hist .col .lab { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-4); letter-spacing: .04em; }
+.cs-hist .col .b { width: 100%; background: linear-gradient(180deg, var(--brass-1), var(--color-accent-fg-dim)); }
+.cs-hist .col .b.bad { background: linear-gradient(180deg, var(--color-status-warn), var(--color-status-err)); }
+.cs-hist .col .lab { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); letter-spacing: .04em; }
 
 /* provider × model heatmap */
 .cs-mat { width:100%; border-collapse: collapse; font-family: var(--font-mono); font-size: var(--fs-10); }
 .cs-mat th, .cs-mat td { padding: 4px 6px; text-align: center; border: 1px solid var(--line-1); font-variant-numeric: tabular-nums; }
-.cs-mat th { font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; color: var(--fg-4); background: var(--bg-1); font-weight: 600; }
+.cs-mat th { font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; color: var(--color-fg-disabled); background: var(--bg-1); font-weight: 600; }
 .cs-mat th.row-h { text-align: left; color: var(--fg-2); }
-.cs-mat td.z0 { color: var(--fg-4); opacity: .25; }
-.cs-mat td.z1 { color: var(--fg-2); background: rgb(var(--brass-glow)/.05); }
-.cs-mat td.z2 { color: var(--fg-1); background: rgb(var(--brass-glow)/.12); }
-.cs-mat td.z3 { color: var(--brass-1); background: rgb(var(--brass-glow)/.22); font-weight:600; }
+.cs-mat td.z0 { color: var(--color-fg-disabled); opacity: .25; }
+.cs-mat td.z1 { color: var(--fg-2); background: rgb(var(--color-accent-glow)/.05); }
+.cs-mat td.z2 { color: var(--fg-1); background: rgb(var(--color-accent-glow)/.12); }
+.cs-mat td.z3 { color: var(--brass-1); background: rgb(var(--color-accent-glow)/.22); font-weight:600; }
 .cs-mat td.z4 { color: var(--bg-0); background: var(--brass-1); font-weight: 600; }
 
 /* ═════ O5 · HEURISTIC + STRESS ═════ */
 .hr-row { display:grid; grid-template-columns: 70px 130px 1fr 100px 60px 50px; gap: 6px; padding: 4px 8px; border-bottom: 1px solid var(--line-1); align-items: baseline; font-family: var(--font-mono); font-size: var(--fs-11); }
-.hr-row.fired { background: rgb(var(--err-glow,255 90 90)/.04); border-left: 2px solid var(--err); padding-left: 6px; }
-.hr-row .ts { color: var(--fg-4); font-size: var(--fs-10); }
+.hr-row.fired { background: rgb(var(--err-glow,255 90 90)/.04); border-left: 2px solid var(--color-status-err); padding-left: 6px; }
+.hr-row .ts { color: var(--color-fg-disabled); font-size: var(--fs-10); }
 .hr-row .mod { color: var(--fg-1); font-weight: 500; }
 .hr-row .site { color: var(--brass-1); }
 .hr-row .det { color: var(--fg-3); font-size: var(--fs-10); white-space: normal; }
@@ -687,16 +687,16 @@
 .hr-row .num.over { color: var(--err-fg); font-weight: 600; }
 .hr-row .fl { font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; padding: 1px 4px; border:1px solid var(--line-2); text-align:center; }
 .hr-row .fl.t { color: var(--err-fg); border-color: var(--err-border); background: var(--err-soft); font-weight:600; }
-.hr-row .fl.f { color: var(--fg-4); }
+.hr-row .fl.f { color: var(--color-fg-disabled); }
 
 .st-grid { display:grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 6px; }
-.st-grid .scard { padding: 7px 9px; background: var(--bg-1); border: 1px solid var(--line-1); border-left: 3px solid var(--warn); display:flex; flex-direction:column; gap: 4px; }
-.st-grid .scard.cascade_burn { border-left-color: var(--err); }
-.st-grid .scard.failure_streak { border-left-color: var(--err); }
-.st-grid .scard.stale_claim { border-left-color: var(--warn); }
+.st-grid .scard { padding: 7px 9px; background: var(--bg-1); border: 1px solid var(--line-1); border-left: 3px solid var(--color-status-warn); display:flex; flex-direction:column; gap: 4px; }
+.st-grid .scard.cascade_burn { border-left-color: var(--color-status-err); }
+.st-grid .scard.failure_streak { border-left-color: var(--color-status-err); }
+.st-grid .scard.stale_claim { border-left-color: var(--color-status-warn); }
 .st-grid .scard .h { display:flex; gap: 6px; align-items: baseline; }
 .st-grid .scard .h .ag { color: var(--brass-1); font-family: var(--font-mono); font-size: var(--fs-12); font-weight: 600; }
-.st-grid .scard .h .at { color: var(--fg-4); font-family: var(--font-mono); font-size: var(--fs-9); margin-left: auto; }
+.st-grid .scard .h .at { color: var(--color-fg-disabled); font-family: var(--font-mono); font-size: var(--fs-9); margin-left: auto; }
 .st-grid .scard .kind { color: var(--err-fg); font-family: var(--font-mono); font-size: var(--fs-10); letter-spacing: .04em; }
 .st-grid .scard .cn { color: var(--fg-2); font-family: var(--font-mono); font-size: var(--fs-10); }
 .st-grid .scard .cn .v { color: var(--err-fg); font-weight: 600; }
@@ -716,7 +716,7 @@
 .ki-bdi .lbl { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--brass-1); letter-spacing:.06em; text-transform:uppercase; padding-top:1px; }
 .ki-bdi .v { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-1); line-height:1.45; }
 .ki-bdi .hz { display:grid; grid-template-columns:72px 1fr; gap:3px 8px; padding:5px 8px; background:var(--bg-0); border:1px solid var(--line-1); margin-top:1px; }
-.ki-bdi .hz .lbl { font-family:var(--font-mono); font-size:var(--fs-9); color:var(--fg-4); letter-spacing:.06em; text-transform:uppercase; white-space:nowrap; padding-top:1px; }
+.ki-bdi .hz .lbl { font-family:var(--font-mono); font-size:var(--fs-9); color:var(--color-fg-disabled); letter-spacing:.06em; text-transform:uppercase; white-space:nowrap; padding-top:1px; }
 .ki-bdi .hz .v { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-2); }
 
 .ki-access { display:flex; flex-direction:column; gap:1px; }
@@ -727,18 +727,18 @@
 .ki-access .off { color:var(--err-fg); }
 .ki-access .mention { font-size:var(--fs-10); padding:1px 5px; background:var(--bg-2); border:1px solid var(--line-1); color:var(--fg-2); }
 
-.ki-stats .hdr { display:grid; grid-template-columns:120px 72px 72px 1fr; gap:6px; padding:3px 8px; background:var(--bg-2); border:1px solid var(--line-2); font-family:var(--font-mono); font-size:var(--fs-9); color:var(--fg-4); letter-spacing:.08em; text-transform:uppercase; margin-bottom:1px; }
+.ki-stats .hdr { display:grid; grid-template-columns:120px 72px 72px 1fr; gap:6px; padding:3px 8px; background:var(--bg-2); border:1px solid var(--line-2); font-family:var(--font-mono); font-size:var(--fs-9); color:var(--color-fg-disabled); letter-spacing:.08em; text-transform:uppercase; margin-bottom:1px; }
 .ki-stats .row { display:grid; grid-template-columns:120px 72px 72px 1fr; gap:6px; align-items:center; padding:4px 8px; background:var(--bg-1); border:1px solid var(--line-1); margin-bottom:1px; }
 .ki-stats .ag { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--brass-1); }
 .ki-stats .num { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-2); font-variant-numeric:tabular-nums; }
 .ki-stats .bar { height:8px; background:var(--bg-2); border:1px solid var(--line-1); }
-.ki-stats .bar i { display:block; height:100%; background:linear-gradient(90deg, var(--brass-3), var(--brass-1)); }
+.ki-stats .bar i { display:block; height:100%; background:linear-gradient(90deg, var(--color-accent-fg-dim), var(--brass-1)); }
 
 /* ───── K2 · Decisions / Memory ───── */
 .dec-row { display:grid; grid-template-columns:68px 90px 60px 1fr; gap:6px; align-items:flex-start; padding:6px 8px; background:var(--bg-1); border-bottom:1px solid var(--line-1); }
 .dec-row:first-child { border-top:1px solid var(--line-2); }
 .dec-row:last-child  { border-bottom:1px solid var(--line-2); }
-.dec-row .ts  { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-4); }
+.dec-row .ts  { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-fg-disabled); }
 .dec-row .kpr { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--brass-1); }
 .dec-row .out { font-family:var(--font-mono); font-size:var(--fs-9); padding:1px 4px; border:1px solid var(--line-2); text-transform:uppercase; letter-spacing:.06em; white-space:nowrap; align-self:flex-start; }
 .dec-row .out.success { color:var(--ok-fg); border-color:var(--ok-border); background:var(--ok-bg); }
@@ -748,18 +748,18 @@
 .dec-row .body .act { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-1); }
 .dec-row .body .blk { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--err-fg); }
 .dec-row .body .bel { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-3); }
-.dec-row .body .lat { font-family:var(--font-mono); font-size:var(--fs-9); color:var(--fg-4); }
+.dec-row .body .lat { font-family:var(--font-mono); font-size:var(--fs-9); color:var(--color-fg-disabled); }
 
 .mem-row { display:grid; grid-template-columns:68px 90px 68px 1fr; gap:6px; align-items:flex-start; padding:5px 8px; background:var(--bg-1); border-bottom:1px solid var(--line-1); }
 .mem-row:first-child { border-top:1px solid var(--line-2); }
 .mem-row:last-child  { border-bottom:1px solid var(--line-2); }
-.mem-row .ts  { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-4); }
+.mem-row .ts  { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-fg-disabled); }
 .mem-row .kpr { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--brass-1); }
 .mem-row .tag { font-family:var(--font-mono); font-size:var(--fs-9); padding:1px 4px; text-transform:uppercase; letter-spacing:.06em; border:1px solid var(--line-2); align-self:flex-start; }
 .mem-row .tag.verified { color:var(--ok-fg); border-color:var(--ok-border); background:var(--ok-bg); }
-.mem-row .tag.learned  { color:var(--info); border-color:var(--info); }
+.mem-row .tag.learned  { color:var(--color-status-info); border-color:var(--color-status-info); }
 .mem-row .tag.observed { color:var(--fg-2); border-color:var(--line-2); }
-.mem-row .tag.plan     { color:var(--brass-1); border-color:var(--brass-3); background:rgb(var(--brass-glow)/.08); }
+.mem-row .tag.plan     { color:var(--brass-1); border-color:var(--color-accent-fg-dim); background:rgb(var(--color-accent-glow)/.08); }
 .mem-row .body { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-1); line-height:1.4; }
 
 /* ───── K3 · Institution Episodes ───── */
@@ -767,7 +767,7 @@
 .ep-card:last-child { margin-bottom:0; }
 .ep-card .h { display:flex; align-items:center; gap:8px; margin-bottom:4px; flex-wrap:wrap; }
 .ep-card .id { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--brass-1); }
-.ep-card .ts { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-4); }
+.ep-card .ts { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-fg-disabled); }
 .ep-card .pp { display:flex; gap:3px; flex-wrap:wrap; }
 .ep-card .pp .p { font-family:var(--font-mono); font-size:var(--fs-10); padding:1px 5px; background:var(--bg-2); border:1px solid var(--line-1); color:var(--fg-2); }
 .ep-card .sm { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-2); margin-bottom:6px; line-height:1.4; }
@@ -777,8 +777,8 @@
 .ep-card .oc { font-family:var(--font-mono); font-size:var(--fs-9); padding:1px 5px; text-transform:uppercase; letter-spacing:.06em; color:var(--ok-fg); border:1px solid var(--ok-border); background:var(--ok-bg); white-space:nowrap; }
 
 .ep-learn .grp { margin-bottom:6px; }
-.ep-learn .grp-h { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--fg-4); padding:3px 8px; background:var(--bg-2); border:1px solid var(--line-1); margin-bottom:2px; display:flex; gap:8px; }
-.ep-learn .item { display:flex; gap:8px; padding:4px 8px; background:var(--bg-1); border:1px solid var(--line-1); border-left:2px solid var(--brass-3); font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-2); line-height:1.4; margin-bottom:1px; }
+.ep-learn .grp-h { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--color-fg-disabled); padding:3px 8px; background:var(--bg-2); border:1px solid var(--line-1); margin-bottom:2px; display:flex; gap:8px; }
+.ep-learn .item { display:flex; gap:8px; padding:4px 8px; background:var(--bg-1); border:1px solid var(--line-1); border-left:2px solid var(--color-accent-fg-dim); font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-2); line-height:1.4; margin-bottom:1px; }
 .ep-learn .item::before { content:"▸"; color:var(--brass-1); flex-shrink:0; }
 
 /* ───── K4 · Autoresearch ───── */
@@ -788,11 +788,11 @@
 .ar-row .id    { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--brass-1); white-space:nowrap; }
 .ar-row .topic { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-1); }
 .ar-row .st    { font-family:var(--font-mono); font-size:var(--fs-9); padding:1px 5px; text-transform:uppercase; letter-spacing:.06em; border:1px solid var(--line-2); white-space:nowrap; }
-.ar-row .st.open   { color:var(--brass-1); border-color:var(--brass-3); background:rgb(var(--brass-glow)/.08); }
+.ar-row .st.open   { color:var(--brass-1); border-color:var(--color-accent-fg-dim); background:rgb(var(--color-accent-glow)/.08); }
 .ar-row .st.closed { color:var(--ok-fg); border-color:var(--ok-border); background:var(--ok-bg); }
 .ar-row .conf  { font-family:var(--font-mono); font-size:var(--fs-11); font-variant-numeric:tabular-nums; text-align:right; }
 .ar-row .conf.hi  { color:var(--ok-fg); }
-.ar-row .conf.lo  { color:var(--warn); }
+.ar-row .conf.lo  { color:var(--color-status-warn); }
 .ar-row .conf.vlo { color:var(--err-fg); }
 
 .ar-find { padding:10px; background:var(--bg-1); border:1px solid var(--line-2); display:flex; flex-direction:column; gap:6px; }
@@ -800,7 +800,7 @@
 .ar-find .hdr .id   { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--brass-1); }
 .ar-find .hdr .loop { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-3); }
 .ar-find .hdr .conf { font-family:var(--font-mono); font-size:var(--fs-10); padding:1px 6px; background:var(--ok-bg); border:1px solid var(--ok-border); color:var(--ok-fg); margin-left:auto; }
-.ar-find .sec-h { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--fg-4); margin-bottom:2px; }
+.ar-find .sec-h { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--color-fg-disabled); margin-bottom:2px; }
 .ar-find .hy  { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-1); line-height:1.45; padding:5px 8px; background:var(--bg-2); border:1px solid var(--line-1); border-left:2px solid var(--brass-1); }
 .ar-find .ev-list { display:flex; flex-direction:column; gap:2px; }
 .ar-find .ev  { display:flex; gap:6px; font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-2); padding:3px 8px; background:var(--bg-0); border:1px solid var(--line-1); }
@@ -811,13 +811,13 @@
 .ar-flow .step { display:flex; flex-direction:column; gap:4px; padding:10px; background:var(--bg-1); border:1px solid var(--line-2); }
 .ar-flow .step + .step { border-top:0; }
 .ar-flow .step-h { display:flex; align-items:center; gap:8px; margin-bottom:4px; }
-.ar-flow .step-n { display:flex; align-items:center; justify-content:center; width:18px; height:18px; background:var(--brass-3); color:var(--brass-1); font-family:var(--font-mono); font-size:var(--fs-9); font-weight:700; flex-shrink:0; }
-.ar-flow .step-t { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--fg-4); }
+.ar-flow .step-n { display:flex; align-items:center; justify-content:center; width:18px; height:18px; background:var(--color-accent-fg-dim); color:var(--brass-1); font-family:var(--font-mono); font-size:var(--fs-9); font-weight:700; flex-shrink:0; }
+.ar-flow .step-t { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--color-fg-disabled); }
 .ar-flow .step-body { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-1); line-height:1.45; }
 .ar-flow .ev  { display:flex; gap:6px; font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-2); padding:3px 8px; background:var(--bg-0); border:1px solid var(--line-1); margin-bottom:2px; }
 .ar-flow .ev::before { content:"▸"; color:var(--brass-1); flex-shrink:0; }
 .ar-flow .ar-con { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--ok-fg); line-height:1.45; padding:5px 8px; background:var(--ok-bg); border:1px solid var(--ok-border); border-left:2px solid var(--ok-fg); }
-.ar-flow .connector { display:flex; align-items:center; justify-content:center; height:18px; color:var(--brass-3); font-size:14px; background:var(--bg-0); border-left:1px solid var(--line-2); border-right:1px solid var(--line-2); }
+.ar-flow .connector { display:flex; align-items:center; justify-content:center; height:18px; color:var(--color-accent-fg-dim); font-size:14px; background:var(--bg-0); border-left:1px solid var(--line-2); border-right:1px solid var(--line-2); }
 
 /* ═══════════════════════════════════════════════════
    I0 · IDE BACKBONE  (branches · keepers · operator nudges)
@@ -825,39 +825,39 @@
 
 /* Branch selector */
 .br-bar { display:flex; align-items:center; gap:8px; padding:5px 10px; background:linear-gradient(to bottom, var(--bg-1), var(--bg-0)); border:1px solid var(--line-2); }
-.br-bar .lbl { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--fg-4); }
+.br-bar .lbl { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--color-fg-disabled); }
 .br-bar .sel { display:flex; align-items:center; gap:6px; padding:3px 8px; background:var(--bg-2); border:1px solid var(--line-1); cursor:pointer; }
-.br-bar .sel::before { content:"⎇"; color:var(--fg-4); }
+.br-bar .sel::before { content:"⎇"; color:var(--color-fg-disabled); }
 .br-bar .sel .nm { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--brass-1); }
-.br-bar .sel .ca { color:var(--fg-4); font-size:9px; margin-left:2px; }
+.br-bar .sel .ca { color:var(--color-fg-disabled); font-size:9px; margin-left:2px; }
 .br-bar .meta { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-3); display:flex; gap:8px; align-items:center; }
 .br-bar .meta .ah { color:var(--ok-fg); }
-.br-bar .meta .bh { color:var(--warn); }
-.br-bar .meta .head { color:var(--fg-4); }
+.br-bar .meta .bh { color:var(--color-status-warn); }
+.br-bar .meta .head { color:var(--color-fg-disabled); }
 
 .br-list { display:flex; flex-direction:column; gap:1px; }
 .br-list .row { display:grid; grid-template-columns:auto 1fr auto auto auto; gap:8px; align-items:center; padding:6px 10px; background:var(--bg-1); border:1px solid var(--line-1); cursor:pointer; }
-.br-list .row.on { background:var(--bg-2); border-color:var(--brass-3); border-left:2px solid var(--brass-1); padding-left:9px; }
+.br-list .row.on { background:var(--bg-2); border-color:var(--color-accent-fg-dim); border-left:2px solid var(--brass-1); padding-left:9px; }
 .br-list .row:hover { background:var(--bg-2); }
-.br-list .row .glyph { color:var(--fg-4); font-family:var(--font-mono); font-size:var(--fs-13); }
+.br-list .row .glyph { color:var(--color-fg-disabled); font-family:var(--font-mono); font-size:var(--fs-13); }
 .br-list .row.on .glyph { color:var(--brass-1); }
 .br-list .row .nm { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-1); display:flex; gap:6px; align-items:center; }
 .br-list .row .tag { font-family:var(--font-mono); font-size:var(--fs-9); padding:1px 5px; letter-spacing:.06em; border:1px solid var(--line-2); color:var(--fg-3); }
-.br-list .row .tag.PRIMARY      { color:var(--brass-1); border-color:var(--brass-3); background:rgb(var(--brass-glow)/.08); }
+.br-list .row .tag.PRIMARY      { color:var(--brass-1); border-color:var(--color-accent-fg-dim); background:rgb(var(--color-accent-glow)/.08); }
 .br-list .row .tag.RELEASE      { color:var(--ok-fg); border-color:var(--ok-border); background:var(--ok-bg); }
-.br-list .row .tag.FEATURE      { color:var(--info); border-color:var(--info); }
-.br-list .row .tag.FIX          { color:var(--warn); border-color:var(--warn); }
+.br-list .row .tag.FEATURE      { color:var(--color-status-info); border-color:var(--color-status-info); }
+.br-list .row .tag.FIX          { color:var(--color-status-warn); border-color:var(--color-status-warn); }
 .br-list .row .tag.WORKTREE     { color:var(--fg-2); }
 .br-list .row .tag.AUTORESEARCH { color:var(--brass-1); border-color:var(--line-2); border-style:dashed; }
 .br-list .row .st { font-family:var(--font-mono); font-size:var(--fs-9); padding:1px 5px; text-transform:uppercase; letter-spacing:.06em; border:1px solid var(--line-2); }
 .br-list .row .st.clean    { color:var(--ok-fg); border-color:var(--ok-border); background:var(--ok-bg); }
-.br-list .row .st.dirty    { color:var(--warn); border-color:var(--warn); }
+.br-list .row .st.dirty    { color:var(--color-status-warn); border-color:var(--color-status-warn); }
 .br-list .row .st.stale    { color:var(--err-fg); border-color:var(--err-border); background:var(--err-bg); }
-.br-list .row .st.research { color:var(--brass-1); border-color:var(--brass-3); }
+.br-list .row .st.research { color:var(--brass-1); border-color:var(--color-accent-fg-dim); }
 .br-list .row .ahbh { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-3); display:flex; gap:6px; }
 .br-list .row .ahbh .ah { color:var(--ok-fg); }
-.br-list .row .ahbh .bh { color:var(--warn); }
-.br-list .row .head { font-family:var(--font-mono); font-size:var(--fs-9); color:var(--fg-4); }
+.br-list .row .ahbh .bh { color:var(--color-status-warn); }
+.br-list .row .head { font-family:var(--font-mono); font-size:var(--fs-9); color:var(--color-fg-disabled); }
 .br-list .row .keepers { display:flex; gap:-2px; }
 .br-list .row .keepers .k { display:inline-block; width:16px; height:16px; border-radius:50%; border:1px solid var(--bg-1); margin-left:-4px; }
 .br-list .row .keepers .k:first-child { margin-left:0; }
@@ -865,47 +865,47 @@
 /* Keeper multi-select */
 .km-bar { display:flex; flex-direction:column; gap:6px; }
 .km-bar .h { display:flex; align-items:center; gap:8px; padding:5px 10px; background:var(--bg-2); border:1px solid var(--line-2); }
-.km-bar .h .lbl { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--fg-4); }
+.km-bar .h .lbl { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--color-fg-disabled); }
 .km-bar .h .cnt { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--brass-1); margin-left:auto; }
 .km-bar .h .clr { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-3); cursor:pointer; padding:1px 6px; border:1px solid var(--line-1); background:var(--bg-1); }
 .km-bar .h .clr:hover { color:var(--fg-1); }
 .km-chips { display:flex; flex-wrap:wrap; gap:4px; padding:8px 10px; background:var(--bg-1); border:1px solid var(--line-1); }
 .km-chip { display:inline-flex; align-items:center; gap:6px; padding:3px 8px; background:var(--bg-2); border:1px solid var(--line-1); cursor:pointer; font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-3); }
 .km-chip:hover { background:var(--bg-3); color:var(--fg-1); }
-.km-chip.on { background:rgb(var(--brass-glow)/.12); border-color:var(--brass-3); color:var(--brass-1); }
-.km-chip .role { font-size:var(--fs-9); color:var(--fg-4); letter-spacing:.04em; }
-.km-chip.on .role { color:var(--brass-3); }
-.km-chip .x { color:var(--fg-4); margin-left:2px; }
+.km-chip.on { background:rgb(var(--color-accent-glow)/.12); border-color:var(--color-accent-fg-dim); color:var(--brass-1); }
+.km-chip .role { font-size:var(--fs-9); color:var(--color-fg-disabled); letter-spacing:.04em; }
+.km-chip.on .role { color:var(--color-accent-fg-dim); }
+.km-chip .x { color:var(--color-fg-disabled); margin-left:2px; }
 .km-chip.on .x { color:var(--brass-1); }
 
 /* Operator nudge log */
 .nd-row { display:grid; grid-template-columns:64px 80px auto 1fr auto; gap:8px; align-items:flex-start; padding:6px 10px; background:var(--bg-1); border-bottom:1px solid var(--line-1); }
 .nd-row:first-child { border-top:1px solid var(--line-2); }
 .nd-row:last-child  { border-bottom:1px solid var(--line-2); }
-.nd-row .ts { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-4); }
+.nd-row .ts { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-fg-disabled); }
 .nd-row .ch { font-family:var(--font-mono); font-size:var(--fs-9); padding:1px 5px; text-transform:uppercase; letter-spacing:.06em; border:1px solid var(--line-2); white-space:nowrap; align-self:flex-start; }
-.nd-row .ch.hint     { color:var(--brass-1); border-color:var(--brass-3); background:rgb(var(--brass-glow)/.08); }
+.nd-row .ch.hint     { color:var(--brass-1); border-color:var(--color-accent-fg-dim); background:rgb(var(--color-accent-glow)/.08); }
 .nd-row .ch.approve  { color:var(--ok-fg); border-color:var(--ok-border); background:var(--ok-bg); }
 .nd-row .ch.reject   { color:var(--err-fg); border-color:var(--err-border); background:var(--err-bg); }
-.nd-row .ch.redirect { color:var(--info); border-color:var(--info); }
+.nd-row .ch.redirect { color:var(--color-status-info); border-color:var(--color-status-info); }
 .nd-row .to { display:flex; gap:3px; flex-wrap:wrap; align-items:center; }
 .nd-row .to .k { font-family:var(--font-mono); font-size:var(--fs-10); padding:1px 5px; background:var(--bg-2); border:1px solid var(--line-1); color:var(--brass-1); }
 .nd-row .body { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-1); line-height:1.4; }
 .nd-row .ack { font-family:var(--font-mono); font-size:var(--fs-9); padding:1px 5px; text-transform:uppercase; letter-spacing:.06em; align-self:flex-start; }
 .nd-row .ack.y { color:var(--ok-fg); }
-.nd-row .ack.n { color:var(--warn); }
+.nd-row .ack.n { color:var(--color-status-warn); }
 
 .nd-compose { display:flex; flex-direction:column; gap:6px; padding:10px; background:var(--bg-2); border:1px solid var(--line-2); margin-top:8px; }
 .nd-compose .h { display:flex; align-items:center; gap:8px; }
-.nd-compose .h .lbl { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--fg-4); }
+.nd-compose .h .lbl { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--color-fg-disabled); }
 .nd-compose .channels { display:flex; gap:2px; margin-left:auto; }
 .nd-compose .channels button { padding:2px 8px; font-family:var(--font-mono); font-size:var(--fs-10); text-transform:uppercase; letter-spacing:.06em; border:1px solid var(--line-1); background:var(--bg-1); color:var(--fg-3); cursor:pointer; }
-.nd-compose .channels button.on { background:var(--brass-3); border-color:var(--brass-1); color:var(--brass-1); }
+.nd-compose .channels button.on { background:var(--color-accent-fg-dim); border-color:var(--brass-1); color:var(--brass-1); }
 .nd-compose textarea { width:100%; min-height:50px; resize:vertical; padding:6px 8px; background:var(--bg-1); border:1px solid var(--line-1); color:var(--fg-1); font-family:var(--font-mono); font-size:var(--fs-11); box-sizing:border-box; }
 .nd-compose textarea:focus { outline:none; border-color:var(--brass-1); }
 .nd-compose .ft { display:flex; gap:8px; align-items:center; }
 .nd-compose .ft .targets { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-3); }
-.nd-compose .ft .send { margin-left:auto; padding:4px 12px; background:var(--brass-3); border:1px solid var(--brass-1); color:var(--brass-1); font-family:var(--font-mono); font-size:var(--fs-10); text-transform:uppercase; letter-spacing:.08em; cursor:pointer; }
+.nd-compose .ft .send { margin-left:auto; padding:4px 12px; background:var(--color-accent-fg-dim); border:1px solid var(--brass-1); color:var(--brass-1); font-family:var(--font-mono); font-size:var(--fs-10); text-transform:uppercase; letter-spacing:.08em; cursor:pointer; }
 .nd-compose .ft .send:hover { background:var(--brass-2); color:var(--bg-0); }
 
 /* ═══════════════════════════════════════════════════
@@ -914,17 +914,17 @@
 
 .ix-head { display:flex; align-items:center; gap:8px; padding:5px 8px; min-height:24px; background:var(--bg-2); border:1px solid var(--line-2); color:var(--fg-2); font-family:var(--font-mono); font-size:var(--fs-10); }
 .ix-head-title { color:var(--fg-1); font-weight:600; letter-spacing:.04em; }
-.ix-head-meta { color:var(--fg-4); }
+.ix-head-meta { color:var(--color-fg-disabled); }
 .ix-head-right { margin-left:auto; color:var(--brass-1); display:inline-flex; align-items:center; gap:4px; }
 .ix-head-right button, .ix-sort button { padding:1px 6px; background:var(--bg-1); border:1px solid var(--line-1); color:var(--fg-3); font:inherit; cursor:pointer; }
 .ix-head-right button:hover, .ix-sort button:hover { color:var(--fg-1); }
 .ix-sort { display:inline-flex; gap:2px; }
-.ix-sort button.on { color:var(--brass-1); border-color:var(--brass-3); background:rgb(var(--brass-glow)/.08); }
-.muted { color:var(--fg-4); }
+.ix-sort button.on { color:var(--brass-1); border-color:var(--color-accent-fg-dim); background:rgb(var(--color-accent-glow)/.08); }
+.muted { color:var(--color-fg-disabled); }
 
 .ix-status { display:inline-flex; align-items:center; height:16px; padding:0 5px; border:1px solid var(--line-2); font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.06em; text-transform:uppercase; white-space:nowrap; }
 .ix-status.ok { color:var(--ok-fg); border-color:var(--ok-border); background:var(--ok-bg); }
-.ix-status.warn { color:var(--warn); border-color:var(--warn); background:rgb(201 162 74 / .08); }
+.ix-status.warn { color:var(--color-status-warn); border-color:var(--color-status-warn); background:rgb(201 162 74 / .08); }
 .ix-status.err { color:var(--err-fg); border-color:var(--err-border); background:var(--err-bg); }
 .ix-status.idle { color:var(--fg-3); border-color:var(--line-2); background:var(--bg-2); }
 
@@ -933,23 +933,23 @@
 .ix-tree-keepers, .ix-edit-keepers, .ix-graph-filters { display:flex; flex-wrap:wrap; gap:3px; padding:6px 8px; background:var(--bg-1); border:1px solid var(--line-1); }
 .ix-tree-keepers button, .ix-edit-keepers button, .ix-graph-filters button { display:inline-flex; align-items:center; gap:5px; padding:2px 7px; background:var(--bg-2); border:1px solid var(--line-1); color:var(--fg-3); font-family:var(--font-mono); font-size:var(--fs-10); cursor:pointer; }
 .ix-tree-keepers button span, .ix-edit-keepers button span { width:7px; height:7px; border-radius:50%; }
-.ix-tree-keepers button.on, .ix-edit-keepers button.on, .ix-graph-filters button.on { color:var(--brass-1); border-color:var(--brass-3); background:rgb(var(--brass-glow)/.08); }
+.ix-tree-keepers button.on, .ix-edit-keepers button.on, .ix-graph-filters button.on { color:var(--brass-1); border-color:var(--color-accent-fg-dim); background:rgb(var(--color-accent-glow)/.08); }
 .ix-tree-filter { display:grid; grid-template-columns:minmax(150px,1fr) repeat(6,auto); gap:3px; padding:6px 8px; background:var(--bg-1); border:1px solid var(--line-1); }
 .ix-tree-filter input, .ix-search-bar input, .ix-find input { min-width:0; padding:4px 7px; background:var(--bg-0); border:1px solid var(--line-1); color:var(--fg-1); font-family:var(--font-mono); font-size:var(--fs-11); }
 .ix-tree-filter button, .ix-search-bar button, .ix-find button { padding:3px 7px; background:var(--bg-2); border:1px solid var(--line-1); color:var(--fg-3); font-family:var(--font-mono); font-size:var(--fs-10); cursor:pointer; }
-.ix-tree-filter button.on, .ix-search-bar button.on { color:var(--brass-1); border-color:var(--brass-3); background:rgb(var(--brass-glow)/.08); }
+.ix-tree-filter button.on, .ix-search-bar button.on { color:var(--brass-1); border-color:var(--color-accent-fg-dim); background:rgb(var(--color-accent-glow)/.08); }
 .ix-tree-tabs { display:flex; gap:2px; padding:0 8px; border-bottom:1px solid var(--line-2); }
 .ix-tree-tabs button { padding:5px 10px 4px; background:transparent; border:0; border-bottom:2px solid transparent; color:var(--fg-3); font-family:var(--font-mono); font-size:var(--fs-10); text-transform:uppercase; letter-spacing:.08em; cursor:pointer; }
 .ix-tree-tabs button.on { color:var(--brass-1); border-bottom-color:var(--brass-1); }
 .ix-tree-list { min-height:0; overflow:auto; display:flex; flex-direction:column; gap:1px; }
 .ix-tree-row { display:grid; grid-template-columns:22px minmax(0,1fr) auto auto; gap:7px; align-items:center; min-height:24px; padding:3px 8px; background:var(--bg-1); border:1px solid var(--line-1); border-left:2px solid var(--line-1); font-family:var(--font-mono); font-size:var(--fs-11); }
-.ix-tree-row.dir { background:var(--bg-2); border-left-color:var(--brass-3); }
-.ix-tree-row.added { border-left-color:var(--ok); }
-.ix-tree-row.modified { border-left-color:var(--info); }
-.ix-tree-row.deleted { border-left-color:var(--err); opacity:.86; }
+.ix-tree-row.dir { background:var(--bg-2); border-left-color:var(--color-accent-fg-dim); }
+.ix-tree-row.added { border-left-color:var(--color-status-ok); }
+.ix-tree-row.modified { border-left-color:var(--color-status-info); }
+.ix-tree-row.deleted { border-left-color:var(--color-status-err); opacity:.86; }
 .ix-tree-row.unchanged { border-left-color:var(--line-2); color:var(--fg-3); }
 .ix-tree-row.dim { opacity:.35; }
-.ix-tree-icon { color:var(--fg-4); font-size:var(--fs-10); }
+.ix-tree-icon { color:var(--color-fg-disabled); font-size:var(--fs-10); }
 .ix-tree-path { min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--fg-1); }
 .ix-kdots { display:inline-flex; align-items:center; min-width:36px; }
 .ix-kdots span { width:9px; height:9px; border-radius:50%; border:1px solid var(--bg-0); margin-left:-3px; }
@@ -958,7 +958,7 @@
 .ix-tree-diff, .ix-tree-age { color:var(--fg-3); font-variant-numeric:tabular-nums; font-size:var(--fs-10); }
 .ix-tree-status { padding:1px 5px; border:1px solid var(--line-2); font-size:var(--fs-9); text-transform:uppercase; letter-spacing:.05em; }
 .ix-tree-status.added { color:var(--ok-fg); border-color:var(--ok-border); background:var(--ok-bg); }
-.ix-tree-status.modified { color:var(--info); border-color:var(--info); }
+.ix-tree-status.modified { color:var(--color-status-info); border-color:var(--color-status-info); }
 .ix-tree-status.deleted { color:var(--err-fg); border-color:var(--err-border); background:var(--err-bg); }
 .ix-tree-status.renamed, .ix-tree-status.unchanged { color:var(--fg-3); }
 
@@ -967,10 +967,10 @@
 .ix-edit-code { min-height:0; overflow:auto; background:var(--bg-1); border:1px solid var(--line-1); padding:4px 0; }
 .ix-edit-line { display:grid; grid-template-columns:30px 42px minmax(0,1fr); gap:6px; align-items:baseline; min-height:22px; padding:0 8px; font-family:var(--font-mono); font-size:var(--fs-12); line-height:1.45; border-left:2px solid transparent; }
 .ix-edit-line:hover { background:var(--hover-overlay); }
-.ix-edit-line.spot { background:rgb(var(--brass-glow)/.06); }
-.ix-edit-line.review-hot { background:var(--warn-bg, rgb(201 162 74 / .10)); border-left-color:var(--warn); }
+.ix-edit-line.spot { background:rgb(var(--color-accent-glow)/.06); }
+.ix-edit-line.review-hot { background:var(--warn-bg, rgb(201 162 74 / .10)); border-left-color:var(--color-status-warn); }
 .ix-edit-attrib { height:16px; border-left:3px solid; padding-left:4px; font-size:var(--fs-9); color:var(--fg-3); }
-.ix-edit-num { color:var(--fg-4); text-align:right; font-size:var(--fs-10); font-variant-numeric:tabular-nums; }
+.ix-edit-num { color:var(--color-fg-disabled); text-align:right; font-size:var(--fs-10); font-variant-numeric:tabular-nums; }
 .ix-edit-src { min-width:0; overflow:hidden; white-space:pre; color:var(--fg-1); }
 .ix-edit-split-grid { display:grid; grid-template-columns:1fr 1fr; gap:8px; min-height:0; flex:1; }
 .ix-edit-pane { min-width:0; display:flex; flex-direction:column; border:1px solid var(--line-2); background:var(--bg-1); }
@@ -978,30 +978,30 @@
 .ix-edit-scroll { overflow:auto; min-height:0; max-height:310px; padding:4px 0; }
 .ix-edit-scroll .ix-edit-line { grid-template-columns:42px minmax(0,1fr); }
 .ix-merge-grid { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:1px; }
-.ix-merge-hdr span { padding:4px 8px; background:var(--bg-2); border:1px solid var(--line-2); color:var(--fg-4); font-family:var(--font-mono); font-size:var(--fs-9); text-transform:uppercase; letter-spacing:.08em; }
+.ix-merge-hdr span { padding:4px 8px; background:var(--bg-2); border:1px solid var(--line-2); color:var(--color-fg-disabled); font-family:var(--font-mono); font-size:var(--fs-9); text-transform:uppercase; letter-spacing:.08em; }
 .ix-merge-block { border:1px solid var(--line-2); background:var(--bg-1); }
 .ix-merge-file { padding:4px 8px; color:var(--brass-1); font-family:var(--font-mono); font-size:var(--fs-10); border-bottom:1px solid var(--line-1); }
 .ix-merge-block pre { margin:0; min-height:42px; padding:7px 8px; overflow:auto; background:var(--bg-0); border-right:1px solid var(--line-1); color:var(--fg-2); font-family:var(--font-mono); font-size:var(--fs-10); white-space:pre-wrap; }
 .ix-merge-block pre.result { color:var(--ok-fg); background:var(--ok-bg); }
 .ix-merge-actions { display:flex; gap:3px; padding:5px 8px; background:var(--bg-2); }
 .ix-merge-actions button { padding:2px 8px; background:var(--bg-1); border:1px solid var(--line-1); color:var(--fg-3); font-family:var(--font-mono); font-size:var(--fs-10); cursor:pointer; }
-.ix-merge-actions button.on { color:var(--brass-1); border-color:var(--brass-3); }
+.ix-merge-actions button.on { color:var(--brass-1); border-color:var(--color-accent-fg-dim); }
 .ix-review-grid { display:grid; grid-template-columns:minmax(0,1fr) 260px; gap:8px; min-height:0; flex:1; }
 .ix-review-side { min-height:0; overflow:auto; display:flex; flex-direction:column; gap:5px; }
 .ix-review-thread { padding:7px 8px; background:var(--bg-1); border:1px solid var(--line-1); border-left:2px solid var(--line-2); }
-.ix-review-thread.flag { border-left-color:var(--warn); }
-.ix-review-thread.approve { border-left-color:var(--ok); }
-.ix-review-thread.defer { border-left-color:var(--info); }
+.ix-review-thread.flag { border-left-color:var(--color-status-warn); }
+.ix-review-thread.approve { border-left-color:var(--color-status-ok); }
+.ix-review-thread.defer { border-left-color:var(--color-status-info); }
 .ix-review-thread .h { display:flex; align-items:center; gap:5px; margin-bottom:4px; font-family:var(--font-mono); font-size:var(--fs-10); }
 .ix-review-thread .ln { color:var(--brass-1); }
 .ix-review-thread .who { color:var(--fg-3); }
 .ix-review-thread .body { color:var(--fg-1); font-family:var(--font-mono); font-size:var(--fs-11); line-height:1.4; }
-.ix-review-thread .ft { margin-top:5px; color:var(--fg-4); font-family:var(--font-mono); font-size:var(--fs-9); text-transform:uppercase; letter-spacing:.05em; }
+.ix-review-thread .ft { margin-top:5px; color:var(--color-fg-disabled); font-family:var(--font-mono); font-size:var(--fs-9); text-transform:uppercase; letter-spacing:.05em; }
 .ix-blame .ix-edit-line { grid-template-columns:112px 42px minmax(0,1fr); }
-.ix-blame-cell { display:grid; grid-template-columns:44px 22px 32px; gap:4px; color:var(--fg-4); font-size:var(--fs-10); }
+.ix-blame-cell { display:grid; grid-template-columns:44px 22px 32px; gap:4px; color:var(--color-fg-disabled); font-size:var(--fs-10); }
 .ix-blame-cell b { color:var(--fg-2); font-weight:400; }
 .ix-blame-cell i { font-style:normal; }
-.ix-blame-cell em { font-style:normal; color:var(--fg-4); }
+.ix-blame-cell em { font-style:normal; color:var(--color-fg-disabled); }
 .ix-edit-line.age-fresh .ix-blame-cell b { color:var(--brass-1); }
 
 /* E3 · PR inspector */
@@ -1012,65 +1012,65 @@
 .ix-pr-state { padding:1px 6px; border:1px solid var(--ok-border); background:var(--ok-bg); color:var(--ok-fg); font-family:var(--font-mono); font-size:var(--fs-9); text-transform:uppercase; letter-spacing:.08em; }
 .ix-pr-branches { display:flex; align-items:center; gap:7px; color:var(--fg-3); font-family:var(--font-mono); font-size:var(--fs-11); }
 .ix-pr-branches span { color:var(--fg-1); padding:2px 6px; background:var(--bg-2); border:1px solid var(--line-1); }
-.ix-pr-branches b { color:var(--fg-4); font-weight:400; }
-.ix-pr-branches em { margin-left:auto; color:var(--fg-4); font-style:normal; }
+.ix-pr-branches b { color:var(--color-fg-disabled); font-weight:400; }
+.ix-pr-branches em { margin-left:auto; color:var(--color-fg-disabled); font-style:normal; }
 .ix-pr-labels, .ix-pr-reviewers { display:flex; flex-wrap:wrap; gap:4px; }
 .ix-pr-labels span { padding:2px 6px; background:var(--bg-2); border:1px solid var(--line-1); color:var(--fg-3); font-family:var(--font-mono); font-size:var(--fs-10); }
 .ix-pr-reviewers span { display:inline-flex; align-items:center; gap:5px; padding:3px 6px; background:var(--bg-2); border:1px solid var(--line-1); font-family:var(--font-mono); font-size:var(--fs-10); }
 .ix-pr-reviewers i { display:inline-flex; align-items:center; justify-content:center; width:18px; height:18px; color:var(--bg-0); font-style:normal; font-size:var(--fs-9); border-radius:50%; }
 .ix-pr-reviewers b { color:var(--fg-2); font-weight:400; }
-.ix-pr-merge { display:flex; align-items:center; gap:8px; padding-top:2px; font-family:var(--font-mono); font-size:var(--fs-10); color:var(--warn); }
-.ix-pr-merge button { margin-left:auto; padding:4px 10px; background:var(--bg-2); border:1px solid var(--line-2); color:var(--fg-4); font:inherit; }
+.ix-pr-merge { display:flex; align-items:center; gap:8px; padding-top:2px; font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-status-warn); }
+.ix-pr-merge button { margin-left:auto; padding:4px 10px; background:var(--bg-2); border:1px solid var(--line-2); color:var(--color-fg-disabled); font:inherit; }
 .ix-pr-files, .ix-pr-checks, .ix-pr-thread { min-height:0; overflow:auto; }
 .ix-pr-file, .ix-pr-check { background:var(--bg-1); border:1px solid var(--line-1); margin-bottom:2px; }
 .ix-pr-file .row, .ix-pr-check .row { display:grid; grid-template-columns:20px minmax(0,1fr) 72px 64px 72px; gap:6px; align-items:center; padding:5px 8px; font-family:var(--font-mono); font-size:var(--fs-11); cursor:pointer; }
 .ix-pr-check .row { grid-template-columns:minmax(0,1fr) 70px 60px 36px; cursor:default; }
 .ix-pr-file .path, .ix-pr-check .name { min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--fg-1); }
-.ix-pr-file .tw { color:var(--fg-4); }
+.ix-pr-file .tw { color:var(--color-fg-disabled); }
 .ix-pr-file .st, .ix-pr-file .rv { padding:1px 5px; border:1px solid var(--line-2); color:var(--fg-3); font-size:var(--fs-9); text-transform:uppercase; letter-spacing:.05em; }
 .ix-pr-file .st.added { color:var(--ok-fg); border-color:var(--ok-border); background:var(--ok-bg); }
 .ix-pr-file .st.deleted { color:var(--err-fg); border-color:var(--err-border); background:var(--err-bg); }
-.ix-pr-file .st.modified { color:var(--info); border-color:var(--info); }
+.ix-pr-file .st.modified { color:var(--color-status-info); border-color:var(--color-status-info); }
 .ix-pr-file .diff { color:var(--fg-3); text-align:right; }
 .ix-pr-diff { margin:0; padding:8px 10px; color:var(--fg-2); background:var(--bg-0); border-top:1px solid var(--line-1); font-family:var(--font-mono); font-size:var(--fs-10); line-height:1.45; overflow:auto; }
 .ix-pr-thread { display:flex; flex-direction:column; gap:4px; padding:8px; background:var(--bg-1); border:1px solid var(--line-2); }
 .ix-pr-thread.resolved { opacity:.68; }
-.ix-pr-thread .msg { padding:7px 8px; background:var(--bg-2); border:1px solid var(--line-1); border-left:2px solid var(--brass-3); }
-.ix-pr-thread .msg.nested { margin-left:24px; border-left-color:var(--ok); }
+.ix-pr-thread .msg { padding:7px 8px; background:var(--bg-2); border:1px solid var(--line-1); border-left:2px solid var(--color-accent-fg-dim); }
+.ix-pr-thread .msg.nested { margin-left:24px; border-left-color:var(--color-status-ok); }
 .ix-pr-thread .h { display:flex; gap:6px; align-items:center; margin-bottom:4px; font-family:var(--font-mono); font-size:var(--fs-10); }
 .ix-pr-thread .by { color:var(--brass-1); }
-.ix-pr-thread .at, .ix-pr-check .dur, .ix-pr-check .log { color:var(--fg-4); }
+.ix-pr-thread .at, .ix-pr-check .dur, .ix-pr-check .log { color:var(--color-fg-disabled); }
 .ix-pr-thread .body { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-1); line-height:1.4; }
 .ix-pr-check .findings { display:flex; flex-direction:column; gap:2px; padding:0 8px 7px 8px; }
 .ix-pr-check .findings span { padding:3px 6px; background:var(--err-bg); border:1px solid var(--err-border); color:var(--err-fg); font-family:var(--font-mono); font-size:var(--fs-10); }
 
 /* E4 · graph */
 .ix-graph-dag { width:100%; height:210px; background:var(--bg-1); border:1px solid var(--line-2); }
-.ix-graph-dag path { fill:none; stroke:var(--line-3); stroke-width:2; }
+.ix-graph-dag path { fill:none; stroke:var(--color-border-divider); stroke-width:2; }
 .ix-graph-dag text { fill:var(--fg-3); font-family:var(--font-mono); font-size:10px; }
 .ix-graph-dag text.label { fill:var(--brass-1); font-size:9px; letter-spacing:.04em; }
-.ix-graph-dag g.active circle { stroke:var(--brass-1); stroke-width:2; filter:drop-shadow(0 0 5px rgb(var(--brass-glow)/.7)); }
+.ix-graph-dag g.active circle { stroke:var(--brass-1); stroke-width:2; filter:drop-shadow(0 0 5px rgb(var(--color-accent-glow)/.7)); }
 .ix-commits, .ix-stashes { min-height:0; overflow:auto; display:flex; flex-direction:column; gap:1px; }
 .ix-commit-row { display:grid; grid-template-columns:54px 96px minmax(0,1fr) 150px 42px 58px; gap:7px; align-items:center; min-height:25px; padding:4px 8px; background:var(--bg-1); border:1px solid var(--line-1); font-family:var(--font-mono); font-size:var(--fs-10); }
 .ix-commit-row .hash { color:var(--brass-1); }
 .ix-commit-row .subj { color:var(--fg-1); min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
-.ix-commit-row .branch, .ix-commit-row .age, .ix-commit-row .diff { color:var(--fg-4); }
+.ix-commit-row .branch, .ix-commit-row .age, .ix-commit-row .diff { color:var(--color-fg-disabled); }
 .ix-worktrees { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:7px; min-height:0; overflow:auto; }
 .ix-worktree-card { display:flex; flex-direction:column; gap:5px; padding:8px; background:var(--bg-1); border:1px solid var(--line-2); border-left:2px solid var(--line-2); font-family:var(--font-mono); font-size:var(--fs-10); }
-.ix-worktree-card.clean { border-left-color:var(--ok); }
-.ix-worktree-card.dirty { border-left-color:var(--warn); }
-.ix-worktree-card.stale { border-left-color:var(--err); }
+.ix-worktree-card.clean { border-left-color:var(--color-status-ok); }
+.ix-worktree-card.dirty { border-left-color:var(--color-status-warn); }
+.ix-worktree-card.stale { border-left-color:var(--color-status-err); }
 .ix-worktree-card .path { color:var(--fg-1); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .ix-worktree-card .branch { color:var(--brass-1); }
 .ix-worktree-card .keepers { display:flex; flex-wrap:wrap; gap:3px; }
 .ix-worktree-card .keepers span { padding:1px 5px; background:var(--bg-2); border:1px solid var(--line-1); color:var(--fg-3); }
-.ix-worktree-card .ft { display:flex; align-items:center; gap:5px; color:var(--fg-4); }
+.ix-worktree-card .ft { display:flex; align-items:center; gap:5px; color:var(--color-fg-disabled); }
 .ix-worktree-card .ft button { margin-left:auto; padding:1px 5px; background:var(--bg-2); border:1px solid var(--line-1); color:var(--fg-3); font:inherit; cursor:pointer; }
 .ix-worktree-card .ft button + button { margin-left:0; }
 .ix-stash-row { background:var(--bg-1); border:1px solid var(--line-1); font-family:var(--font-mono); font-size:var(--fs-10); }
 .ix-stash-row .row { display:grid; grid-template-columns:72px 150px 94px minmax(0,1fr) 42px 52px; gap:6px; align-items:center; padding:5px 8px; cursor:pointer; }
 .ix-stash-row .id, .ix-stash-row .keeper { color:var(--brass-1); }
-.ix-stash-row .branch, .ix-stash-row .age { color:var(--fg-4); }
+.ix-stash-row .branch, .ix-stash-row .age { color:var(--color-fg-disabled); }
 .ix-stash-row .sum { color:var(--fg-1); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .ix-stash-row .detail { padding:5px 8px; border-top:1px solid var(--line-1); background:var(--bg-0); color:var(--fg-3); display:flex; gap:8px; }
 .ix-stash-row .detail span { margin-left:auto; color:var(--brass-1); }
@@ -1083,11 +1083,11 @@
 .ix-search-results { min-height:0; overflow:auto; display:flex; flex-direction:column; gap:4px; }
 .ix-search-file { background:var(--bg-1); border:1px solid var(--line-1); }
 .ix-search-file .file { padding:4px 8px; background:var(--bg-2); border-bottom:1px solid var(--line-1); color:var(--brass-1); font-family:var(--font-mono); font-size:var(--fs-10); }
-.ix-search-file .file span { float:right; color:var(--fg-4); }
+.ix-search-file .file span { float:right; color:var(--color-fg-disabled); }
 .ix-search-file .hit { display:grid; grid-template-columns:44px minmax(0,1fr); gap:6px; padding:3px 8px; border-bottom:1px solid var(--line-1); font-family:var(--font-mono); font-size:var(--fs-10); }
-.ix-search-file .hit span { color:var(--fg-4); text-align:right; }
+.ix-search-file .hit span { color:var(--color-fg-disabled); text-align:right; }
 .ix-search-file code { color:var(--fg-2); white-space:pre-wrap; }
-.ix-search-file mark { background:rgb(var(--brass-glow)/.22); color:var(--brass-1); padding:0 1px; }
+.ix-search-file mark { background:rgb(var(--color-accent-glow)/.22); color:var(--brass-1); padding:0 1px; }
 .ix-find-wrap { position:relative; }
 .ix-find { display:grid; grid-template-columns:minmax(90px,1fr) minmax(90px,1fr) repeat(5,auto); gap:4px; padding:6px 8px; background:var(--bg-2); border:1px solid var(--line-2); }
 
@@ -1139,7 +1139,7 @@
 .ix-edit button[aria-pressed="true"],
 .ix-pr button[aria-pressed="true"],
 .ix-search button[aria-pressed="true"] {
-  color:var(--brass-1); border-color:var(--brass-3); background:rgb(var(--brass-glow)/.08);
+  color:var(--brass-1); border-color:var(--color-accent-fg-dim); background:rgb(var(--color-accent-glow)/.08);
 }
 
 /* Visually-hidden caption for SVGs and icon-only labels. */
@@ -1165,5 +1165,5 @@
   color:var(--bg-0); background:var(--brass-2);
 }
 .cb-topbar .density button[aria-checked="true"] {
-  color:var(--brass-1); background:rgb(var(--brass-glow)/.1);
+  color:var(--brass-1); background:rgb(var(--color-accent-glow)/.1);
 }

--- a/dashboard/design-system/preview/forms.html
+++ b/dashboard/design-system/preview/forms.html
@@ -10,7 +10,7 @@
   <style>
     html, body { margin:0; background: var(--bg-0); color: var(--fg-1); font-family: var(--font-sans); }
     .page { max-width: 1180px; margin:0 auto; padding: 32px 32px 96px; }
-    .back { font: var(--type-micro); color: var(--fg-4); text-decoration:none; letter-spacing: .08em; display:inline-block; margin-bottom:20px; }
+    .back { font: var(--type-micro); color: var(--color-fg-disabled); text-decoration:none; letter-spacing: .08em; display:inline-block; margin-bottom:20px; }
     .back:hover { color: var(--fg-2); }
     h1 { font-family: var(--font-mono); font-size: 18px; font-weight: 600; margin: 0 0 4px; }
     .sub { color: var(--fg-3); font-size: 12px; margin-bottom: 28px; }
@@ -18,23 +18,23 @@
     .seg { background: var(--bg-1); border: 1px solid var(--line-1); border-radius: var(--r-1); padding: 16px 18px; margin-bottom: 10px; display: grid; grid-template-columns: 220px 1fr; gap: 20px; align-items: start; }
     .seg .meta { font-family: var(--font-mono); font-size: 11px; color: var(--fg-3); }
     .seg .meta .n { color: var(--fg-1); font-weight:600; font-size: 13px; margin-bottom: 4px; display:block; }
-    .seg .meta .code { display:block; margin-top: 6px; color: var(--fg-4); font-size: 10px; line-height: 1.5; }
+    .seg .meta .code { display:block; margin-top: 6px; color: var(--color-fg-disabled); font-size: 10px; line-height: 1.5; }
     .demo { display:flex; flex-direction:column; gap: 14px; }
 
     /* ── Text input ── */
     .field { display:flex; flex-direction:column; gap:3px; }
     .field-label { font-family: var(--font-mono); font-size: 9px; letter-spacing: .08em; color: var(--fg-3); text-transform:uppercase; font-weight:600; }
-    .field-hint { font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .04em; }
+    .field-hint { font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .04em; }
     .field-err { font-family: var(--font-mono); font-size: 9px; color: var(--err-fg); letter-spacing: .04em; }
     .input { background: var(--bg-2); border: 1px solid var(--line-2); border-radius: var(--r-1); padding: 6px 10px; color: var(--fg-1); font-family: var(--font-mono); font-size: 12px; outline: none; transition: border-color .12s, box-shadow .12s, background .12s; width: 100%; box-sizing:border-box; }
-    .input::placeholder { color: var(--fg-4); }
-    .input:focus { border-color: var(--brass-2); box-shadow: 0 0 0 1px var(--brass-2), 0 0 10px rgb(var(--brass-glow)/.18); background: var(--bg-3); }
+    .input::placeholder { color: var(--color-fg-disabled); }
+    .input:focus { border-color: var(--brass-2); box-shadow: 0 0 0 1px var(--brass-2), 0 0 10px rgb(var(--color-accent-glow)/.18); background: var(--bg-3); }
     .input:disabled { opacity: .5; cursor: not-allowed; }
-    .input.is-err { border-color: var(--err); box-shadow: 0 0 0 1px var(--err); }
-    .input.is-ok { border-color: var(--ok); }
+    .input.is-err { border-color: var(--color-status-err); box-shadow: 0 0 0 1px var(--color-status-err); }
+    .input.is-ok { border-color: var(--color-status-ok); }
     textarea.input { resize: vertical; min-height: 64px; line-height: 1.5; }
     .input-pre { display:flex; align-items:center; background: var(--bg-2); border: 1px solid var(--line-2); border-radius: var(--r-1); }
-    .input-pre .pre { padding: 6px 8px; color: var(--fg-4); font-family: var(--font-mono); font-size: 11px; border-right: 1px solid var(--line-2); background: var(--bg-1); border-radius: var(--r-1) 0 0 var(--r-1); }
+    .input-pre .pre { padding: 6px 8px; color: var(--color-fg-disabled); font-family: var(--font-mono); font-size: 11px; border-right: 1px solid var(--line-2); background: var(--bg-1); border-radius: var(--r-1) 0 0 var(--r-1); }
     .input-pre .input { border: none; background: transparent; padding-left: 8px; }
     .input-pre:focus-within { border-color: var(--brass-2); box-shadow: 0 0 0 1px var(--brass-2); }
 
@@ -46,20 +46,20 @@
     .check { display:inline-flex; align-items:center; gap: 6px; cursor:pointer; user-select:none; font-family: var(--font-mono); font-size: 11px; color: var(--fg-2); }
     .check input { position: absolute; opacity: 0; width: 0; height: 0; pointer-events:none; }
     .check .box { width: 13px; height: 13px; border: 1px solid var(--line-2); border-radius: 2px; background: var(--bg-2); display:inline-grid; place-items:center; transition: all .12s; flex-shrink:0; }
-    .check input:checked + .box { background: var(--brass-1); border-color: var(--brass-1); box-shadow: 0 0 8px rgb(var(--brass-glow)/.5); }
+    .check input:checked + .box { background: var(--brass-1); border-color: var(--brass-1); box-shadow: 0 0 8px rgb(var(--color-accent-glow)/.5); }
     .check input:checked + .box::after { content: ''; width: 6px; height: 3px; border-left: 1.5px solid var(--bg-0); border-bottom: 1.5px solid var(--bg-0); transform: rotate(-45deg) translate(1px, -1px); }
     .check input:disabled ~ * { opacity: .4; cursor: not-allowed; }
     .check .box.radio { border-radius: 50%; }
     .check input:checked + .box.radio { background: var(--bg-0); }
-    .check input:checked + .box.radio::after { content: ''; width: 7px; height: 7px; border: none; border-radius: 50%; background: var(--brass-1); transform: none; box-shadow: 0 0 6px rgb(var(--brass-glow)/.8); }
+    .check input:checked + .box.radio::after { content: ''; width: 7px; height: 7px; border: none; border-radius: 50%; background: var(--brass-1); transform: none; box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.8); }
 
     /* ── Toggle ── */
     .toggle { display:inline-flex; align-items:center; gap: 8px; cursor:pointer; user-select:none; font-family: var(--font-mono); font-size: 11px; color: var(--fg-2); }
     .toggle input { position:absolute; opacity:0; }
     .toggle .track { width: 26px; height: 14px; background: var(--bg-3); border: 1px solid var(--line-2); border-radius: 999px; position: relative; transition: all .15s; flex-shrink:0; }
     .toggle .track::after { content: ''; position: absolute; top: 1px; left: 1px; width: 10px; height: 10px; border-radius: 50%; background: var(--fg-3); transition: all .15s; }
-    .toggle input:checked + .track { background: rgb(var(--brass-glow)/.15); border-color: var(--brass-2); }
-    .toggle input:checked + .track::after { left: 13px; background: var(--brass-1); box-shadow: 0 0 6px rgb(var(--brass-glow)/.7); }
+    .toggle input:checked + .track { background: rgb(var(--color-accent-glow)/.15); border-color: var(--brass-2); }
+    .toggle input:checked + .track::after { left: 13px; background: var(--brass-1); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.7); }
 
     /* ── Segmented ── */
     .segmented { display: inline-flex; border: 1px solid var(--line-2); border-radius: var(--r-1); overflow: hidden; background: var(--bg-2); }
@@ -70,8 +70,8 @@
 
     /* ── Slider ── */
     .slider { -webkit-appearance:none; appearance:none; width:220px; height: 4px; background: var(--bg-3); border-radius: 999px; outline: none; cursor: pointer; }
-    .slider::-webkit-slider-thumb { -webkit-appearance:none; appearance:none; width: 12px; height: 12px; border-radius: 50%; background: var(--brass-1); border: 1px solid var(--brass-3); box-shadow: 0 0 6px rgb(var(--brass-glow)/.6); cursor: grab; }
-    .slider::-moz-range-thumb { width: 12px; height: 12px; border-radius: 50%; background: var(--brass-1); border: 1px solid var(--brass-3); box-shadow: 0 0 6px rgb(var(--brass-glow)/.6); cursor: grab; }
+    .slider::-webkit-slider-thumb { -webkit-appearance:none; appearance:none; width: 12px; height: 12px; border-radius: 50%; background: var(--brass-1); border: 1px solid var(--color-accent-fg-dim); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.6); cursor: grab; }
+    .slider::-moz-range-thumb { width: 12px; height: 12px; border-radius: 50%; background: var(--brass-1); border: 1px solid var(--color-accent-fg-dim); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.6); cursor: grab; }
 
     /* ── Number stepper ── */
     .stepper { display:inline-flex; align-items:center; border: 1px solid var(--line-2); border-radius: var(--r-1); background: var(--bg-2); overflow: hidden; }
@@ -81,12 +81,12 @@
 
     .row { display: flex; gap: 14px; align-items: flex-start; flex-wrap: wrap; }
     .row > .field { min-width: 0; flex: 0 0 auto; }
-    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); }
+    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled); }
 
     /* chip primitives if not loaded from primitives.css */
     .chip { display:inline-flex; align-items:center; padding: 2px 8px; font-family: var(--font-mono); font-size: 10px; background: var(--bg-2); border: 1px solid var(--line-2); color: var(--fg-2); border-radius: 999px; letter-spacing: .04em; }
-    .chip.is-brass { color: var(--brass-1); border-color: var(--brass-2); background: rgb(var(--brass-glow)/.08); }
-    .chip.is-err   { color: var(--err-fg); border-color: var(--err); background: rgb(var(--err-glow)/.08); }
+    .chip.is-brass { color: var(--brass-1); border-color: var(--brass-2); background: rgb(var(--color-accent-glow)/.08); }
+    .chip.is-err   { color: var(--err-fg); border-color: var(--color-status-err); background: rgb(var(--err-glow)/.08); }
 
     /* responsive: stack meta above demo on narrower widths */
     @media (max-width: 880px) {

--- a/dashboard/design-system/preview/index.html
+++ b/dashboard/design-system/preview/index.html
@@ -11,21 +11,21 @@
     html, body { margin:0; padding:0; background: var(--bg-0); color: var(--fg-1); font-family: var(--font-sans); min-height:100vh; }
     .hub { max-width: 1200px; margin: 0 auto; padding: 48px 32px 120px; }
     .brand { display:flex; align-items:center; gap:12px; margin-bottom: 6px; }
-    .brand-mark { width:28px; height:28px; border-radius:4px; background: linear-gradient(135deg, var(--brass-1), var(--brass-3)); box-shadow: 0 0 12px rgb(var(--brass-glow)/.35), inset 0 0 6px rgb(var(--brass-glow)/.3); }
+    .brand-mark { width:28px; height:28px; border-radius:4px; background: linear-gradient(135deg, var(--brass-1), var(--color-accent-fg-dim)); box-shadow: 0 0 12px rgb(var(--color-accent-glow)/.35), inset 0 0 6px rgb(var(--color-accent-glow)/.3); }
     h1 { font: var(--type-title); font-size: 22px; font-weight: 600; letter-spacing: -.01em; margin: 0; font-family: var(--font-mono); }
     .sub { color: var(--fg-3); font-size: 13px; margin-top: 4px; }
     h2 { font: var(--type-label); text-transform: uppercase; letter-spacing: .08em; color: var(--fg-3); font-weight: 600; font-size: 11px; margin: 40px 0 12px; padding-bottom: 6px; border-bottom: 1px solid var(--line-2); }
     .grid { display:grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 10px; }
     a.card { display:flex; flex-direction:column; gap:6px; padding: 14px 16px; background: var(--bg-1); border:1px solid var(--line-1); border-radius: var(--r-1); text-decoration:none; color: inherit; transition: background .15s, border-color .15s, transform .15s; position:relative; overflow:hidden; }
     a.card:hover { background: var(--bg-2); border-color: var(--line-2); }
-    a.card .n { font: var(--type-micro); color: var(--fg-4); letter-spacing: .08em; }
+    a.card .n { font: var(--type-micro); color: var(--color-fg-disabled); letter-spacing: .08em; }
     a.card .title { font-size: 14px; color: var(--fg-1); font-weight: 500; }
     a.card .desc { font-size: 12px; color: var(--fg-3); line-height: 1.4; }
     a.card .stripe { position:absolute; left:0; top:0; bottom:0; width:2px; background: var(--line-2); }
     a.card:hover .stripe { background: var(--brass-1); }
-    a.card .count { margin-top: 4px; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); letter-spacing: .04em; }
+    a.card .count { margin-top: 4px; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled); letter-spacing: .04em; }
     .tag { display:inline-block; font-family: var(--font-mono); font-size: 10px; padding: 1px 6px; border:1px solid var(--line-2); border-radius: 2px; color: var(--fg-3); letter-spacing: .04em; margin-right: 4px; }
-    .stamp { position: absolute; top: 24px; right: 32px; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); letter-spacing: .06em; }
+    .stamp { position: absolute; top: 24px; right: 32px; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled); letter-spacing: .06em; }
   </style>
 </head>
 <body>

--- a/dashboard/design-system/preview/layers.html
+++ b/dashboard/design-system/preview/layers.html
@@ -10,44 +10,44 @@
   <style>
     html, body { margin:0; background: var(--bg-0); color: var(--fg-1); font-family: var(--font-sans); min-height: 100vh; }
     .page { max-width: 1180px; margin:0 auto; padding: 32px 32px 96px; }
-    .back { font: var(--type-micro); color: var(--fg-4); text-decoration:none; letter-spacing: .08em; display:inline-block; margin-bottom:20px; }
+    .back { font: var(--type-micro); color: var(--color-fg-disabled); text-decoration:none; letter-spacing: .08em; display:inline-block; margin-bottom:20px; }
     .back:hover { color: var(--fg-2); }
     h1 { font-family: var(--font-mono); font-size: 18px; font-weight: 600; margin: 0 0 4px; }
     .sub { color: var(--fg-3); font-size: 12px; margin-bottom: 28px; line-height:1.5; max-width: 700px; }
     h2 { font: var(--type-label); text-transform: uppercase; letter-spacing: .08em; color: var(--fg-3); font-weight: 600; font-size: 11px; margin: 28px 0 8px; padding-bottom: 6px; border-bottom: 1px solid var(--line-2); }
     h2 .tag { margin-left: 8px; color: var(--brass-1); font-weight: 500; }
-    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); }
+    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled); }
 
     .seg { background: var(--bg-1); border: 1px solid var(--line-1); border-radius: var(--r-1); padding: 16px; margin-bottom: 10px; display:grid; grid-template-columns: 280px 1fr; gap:20px; align-items:start; }
     .seg .meta { font-family: var(--font-mono); font-size: 11px; color: var(--fg-3); line-height: 1.5; }
     .seg .meta .n { color: var(--fg-1); font-weight:600; font-size: 13px; margin-bottom: 4px; display:block; }
-    .seg .meta .code { display:block; margin-top: 8px; color: var(--fg-4); font-size: 10px; line-height: 1.5; padding: 6px 8px; background: var(--bg-2); border: 1px solid var(--line-1); border-radius: 2px; }
+    .seg .meta .code { display:block; margin-top: 8px; color: var(--color-fg-disabled); font-size: 10px; line-height: 1.5; padding: 6px 8px; background: var(--bg-2); border: 1px solid var(--line-1); border-radius: 2px; }
 
     .canvas { background: var(--bg-0); border: 1px solid var(--line-1); border-radius: var(--r-1); overflow: hidden; min-height: 180px; position:relative; }
     .src-pane { padding: 14px 18px; font-family: var(--font-mono); font-size: 11px; color: var(--fg-2); line-height: 1.7; position: relative; }
     .ln { display:flex; gap: 10px; }
-    .ln .n { color: var(--fg-4); width: 18px; text-align:right; flex-shrink:0; }
+    .ln .n { color: var(--color-fg-disabled); width: 18px; text-align:right; flex-shrink:0; }
     .k { color: #c195e8; } .t { color: #88b5d8; } .s { color: #a8c97a; } .f { color: #e8c976; }
 
     /* ── L1 TIME ── */
     .l1-wrap { padding: 14px 18px 10px; }
     .l1-rec { display:flex; gap: 2px; align-items: flex-end; height: 60px; }
-    .l1-rec .bar { width: 6px; background: var(--warn); border-radius: 1px 1px 0 0; opacity: .55; position: relative; }
+    .l1-rec .bar { width: 6px; background: var(--color-status-warn); border-radius: 1px 1px 0 0; opacity: .55; position: relative; }
     .l1-rec .bar.hot { opacity: 1; box-shadow: 0 0 8px rgb(var(--warn-glow)/.8); }
-    .l1-rec .bar.cold { opacity: .22; background: var(--fg-4); box-shadow: none; }
-    .l1-rec .bar.now { background: var(--brass-1); box-shadow: 0 0 10px rgb(var(--brass-glow)/.9); }
+    .l1-rec .bar.cold { opacity: .22; background: var(--color-fg-disabled); box-shadow: none; }
+    .l1-rec .bar.now { background: var(--brass-1); box-shadow: 0 0 10px rgb(var(--color-accent-glow)/.9); }
     .l1-rec .bar[data-by]::after { content: attr(data-by); position: absolute; top: -11px; left: 50%; transform: translateX(-50%); font-family: var(--font-mono); font-size: 7px; color: var(--brass-1); letter-spacing: .04em; white-space: nowrap; opacity: .85; }
-    .l1-axis { display:flex; justify-content:space-between; font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .04em; margin-top: 6px; padding-top: 4px; border-top: 1px dashed var(--line-1); }
-    .l1-legend { display:flex; gap: 14px; align-items:center; margin-top: 8px; font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .04em; }
+    .l1-axis { display:flex; justify-content:space-between; font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .04em; margin-top: 6px; padding-top: 4px; border-top: 1px dashed var(--line-1); }
+    .l1-legend { display:flex; gap: 14px; align-items:center; margin-top: 8px; font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .04em; }
     .l1-legend .swatch { display:inline-block; width: 10px; height: 6px; border-radius: 1px; vertical-align: middle; margin-right: 4px; }
     .l1-meta { display:flex; gap: 10px; align-items:center; padding: 6px 18px; background: var(--bg-2); border-top: 1px solid var(--line-1); border-bottom: 1px solid var(--line-1); font-family: var(--font-mono); font-size: 10px; color: var(--fg-3); }
-    .l1-meta .k { color: var(--fg-4); font-size: 9px; letter-spacing: .06em; text-transform: uppercase; margin-right: 4px; }
+    .l1-meta .k { color: var(--color-fg-disabled); font-size: 9px; letter-spacing: .06em; text-transform: uppercase; margin-right: 4px; }
     .l1-meta .v { color: var(--fg-1); font-variant-numeric: tabular-nums; margin-right: 14px; }
 
     /* ── L2 PARALLEL ── */
     .l2 { position: relative; height: 180px; padding: 14px; }
     .l2 .lane { position:absolute; left: 14px; right: 14px; height: 22px; border-bottom: 1px dashed var(--line-1); display:flex; align-items:center; }
-    .l2 .lane .name { width: 70px; font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .04em; }
+    .l2 .lane .name { width: 70px; font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .04em; }
     .l2 .cursor { position: absolute; width: 10px; height: 14px; border-radius: 1px; top: 50%; transform: translateY(-50%); }
     .l2 .cursor::after { content: ''; position: absolute; left: 5px; top: -6px; width: 1px; height: 20px; background: currentColor; opacity: .4; }
 
@@ -55,49 +55,49 @@
     .l3 { display:flex; flex-direction: column; gap: 5px; padding: 14px 18px; }
     .l3-row { display:grid; grid-template-columns: 18px 100px 1fr 70px 50px; align-items:center; gap: 10px; padding: 2px 0; border-bottom: 1px dashed transparent; }
     .l3-row:hover { border-bottom-color: var(--line-1); }
-    .l3-glyph { font-family: var(--font-mono); font-size: 13px; color: var(--brass-1); text-shadow: 0 0 4px rgb(var(--brass-glow)/.6); text-align:center; }
-    .l3-freq { height: 4px; background: linear-gradient(90deg, var(--brass-1), rgb(var(--brass-glow)/.15)); border-radius: 999px; box-shadow: 0 0 4px rgb(var(--brass-glow)/.4); }
+    .l3-glyph { font-family: var(--font-mono); font-size: 13px; color: var(--brass-1); text-shadow: 0 0 4px rgb(var(--color-accent-glow)/.6); text-align:center; }
+    .l3-freq { height: 4px; background: linear-gradient(90deg, var(--brass-1), rgb(var(--color-accent-glow)/.15)); border-radius: 999px; box-shadow: 0 0 4px rgb(var(--color-accent-glow)/.4); }
     .l3-label { font-family: var(--font-mono); font-size: 11px; color: var(--brass-2); letter-spacing: .04em; }
-    .l3-by { font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .04em; }
+    .l3-by { font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .04em; }
     .l3-count { font-family: var(--font-mono); font-size: 10px; color: var(--fg-3); text-align: right; font-variant-numeric: tabular-nums; }
-    .l3-head { display:grid; grid-template-columns: 18px 100px 1fr 70px 50px; gap: 10px; padding: 6px 18px 4px; font-family: var(--font-mono); font-size: 8px; color: var(--fg-4); letter-spacing: .08em; text-transform: uppercase; border-bottom: 1px solid var(--line-1); }
+    .l3-head { display:grid; grid-template-columns: 18px 100px 1fr 70px 50px; gap: 10px; padding: 6px 18px 4px; font-family: var(--font-mono); font-size: 8px; color: var(--color-fg-disabled); letter-spacing: .08em; text-transform: uppercase; border-bottom: 1px solid var(--line-1); }
 
     /* ── L4 APPROVE ── */
-    .l4-block { padding: 12px 18px; background: rgb(107 158 107 / .05); border-left: 2px solid var(--ok); position: relative; font-family: var(--font-mono); font-size: 11px; color: var(--fg-2); margin-bottom: 6px; }
-    .l4-block.flag { background: rgb(196 106 90 / .05); border-left-color: var(--err); }
-    .l4-stamp { position:absolute; right: 18px; top: 50%; transform: translateY(-50%) rotate(-10deg); font-family: var(--font-mono); font-size: 28px; color: var(--ok); opacity: .18; font-weight: 700; letter-spacing: .08em; }
-    .l4-block.flag .l4-stamp { color: var(--err); }
-    .l4-by { font-size: 9px; color: var(--fg-4); letter-spacing: .04em; margin-top: 3px; }
+    .l4-block { padding: 12px 18px; background: rgb(107 158 107 / .05); border-left: 2px solid var(--color-status-ok); position: relative; font-family: var(--font-mono); font-size: 11px; color: var(--fg-2); margin-bottom: 6px; }
+    .l4-block.flag { background: rgb(196 106 90 / .05); border-left-color: var(--color-status-err); }
+    .l4-stamp { position:absolute; right: 18px; top: 50%; transform: translateY(-50%) rotate(-10deg); font-family: var(--font-mono); font-size: 28px; color: var(--color-status-ok); opacity: .18; font-weight: 700; letter-spacing: .08em; }
+    .l4-block.flag .l4-stamp { color: var(--color-status-err); }
+    .l4-by { font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .04em; margin-top: 3px; }
 
     /* ── L5 NOTES ── */
     .l5 { padding: 14px 18px; display:flex; gap: 12px; align-items:flex-start; }
     .l5-note { width: 260px; background: linear-gradient(180deg, rgb(138 106 160 / .15), rgb(138 106 160 / .05)); border: 1px solid rgb(var(--stalled-glow)/.4); border-radius: var(--r-1); padding: 8px 10px; backdrop-filter: blur(3px); box-shadow: 0 6px 20px rgba(0,0,0,.45); }
-    .l5-head { display:flex; align-items:center; gap: 5px; font-family: var(--font-mono); font-size: 9px; color: var(--stalled); letter-spacing: .06em; text-transform: uppercase; margin-bottom: 4px; }
-    .l5-head .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--stalled); box-shadow: 0 0 4px rgb(var(--stalled-glow)/.8); }
+    .l5-head { display:flex; align-items:center; gap: 5px; font-family: var(--font-mono); font-size: 9px; color: var(--color-status-stalled); letter-spacing: .06em; text-transform: uppercase; margin-bottom: 4px; }
+    .l5-head .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--color-status-stalled); box-shadow: 0 0 4px rgb(var(--stalled-glow)/.8); }
     .l5-body { font-size: 11px; color: var(--fg-1); line-height: 1.45; }
-    .l5-pin { position: absolute; top: -6px; right: 20px; width: 10px; height: 10px; border-radius: 50%; background: var(--brass-1); box-shadow: 0 0 8px rgb(var(--brass-glow)/.7); border: 1px solid var(--brass-3); }
+    .l5-pin { position: absolute; top: -6px; right: 20px; width: 10px; height: 10px; border-radius: 50%; background: var(--brass-1); box-shadow: 0 0 8px rgb(var(--color-accent-glow)/.7); border: 1px solid var(--color-accent-fg-dim); }
 
     /* ── COMBINED ── */
     .combo { position: relative; padding: 14px 18px; background: var(--bg-0); }
     .combo .layer-labels { position:absolute; top: 10px; right: 14px; display:flex; flex-direction: column; gap: 3px; font-family: var(--font-mono); font-size: 9px; letter-spacing: .08em; }
     .combo .layer-labels span { padding: 2px 6px; border: 1px solid var(--line-2); border-radius: 2px; background: var(--bg-1); }
-    .combo .layer-labels .on { color: var(--brass-1); border-color: var(--brass-2); background: rgb(var(--brass-glow)/.08); }
+    .combo .layer-labels .on { color: var(--brass-1); border-color: var(--brass-2); background: rgb(var(--color-accent-glow)/.08); }
     .code-line { display:flex; align-items:center; gap: 8px; font-family: var(--font-mono); font-size: 11px; padding: 2px 0; position: relative; }
-    .code-line .time-bar { width: 3px; height: 14px; background: var(--warn); border-radius: 1px; }
-    .code-line .num { color: var(--fg-4); width: 20px; text-align: right; }
+    .code-line .time-bar { width: 3px; height: 14px; background: var(--color-status-warn); border-radius: 1px; }
+    .code-line .num { color: var(--color-fg-disabled); width: 20px; text-align: right; }
     .code-line .src { flex: 1; color: var(--fg-2); }
     .code-line .src .hl { background: rgb(201 162 74 / .12); padding: 0 2px; }
     .code-line .cursor-chip { font-size: 9px; padding: 0 4px; border-radius: 2px; font-family: var(--font-mono); letter-spacing: .04em; }
-    .code-line .cursor-chip.c-nick { background: rgb(var(--brass-glow)/.15); color: var(--brass-1); border: 1px solid var(--brass-2); }
-    .code-line .cursor-chip.c-qa { background: rgb(196 106 90 / .15); color: var(--err-fg); border: 1px solid var(--err); }
-    .code-line .cursor-chip.c-ss { background: rgb(107 158 107 / .12); color: var(--ok-fg); border: 1px solid var(--ok); }
-    .code-line .tool-glyph { color: var(--brass-1); text-shadow: 0 0 4px rgb(var(--brass-glow)/.6); font-size: 11px; }
+    .code-line .cursor-chip.c-nick { background: rgb(var(--color-accent-glow)/.15); color: var(--brass-1); border: 1px solid var(--brass-2); }
+    .code-line .cursor-chip.c-qa { background: rgb(196 106 90 / .15); color: var(--err-fg); border: 1px solid var(--color-status-err); }
+    .code-line .cursor-chip.c-ss { background: rgb(107 158 107 / .12); color: var(--ok-fg); border: 1px solid var(--color-status-ok); }
+    .code-line .tool-glyph { color: var(--brass-1); text-shadow: 0 0 4px rgb(var(--color-accent-glow)/.6); font-size: 11px; }
 
     /* bar toggle */
     .bar { display:inline-flex; gap: 0; border: 1px solid var(--line-2); border-radius: var(--r-1); overflow: hidden; background: var(--bg-1); }
     .bar button { background: transparent; border: none; color: var(--fg-3); padding: 5px 10px; font-family: var(--font-mono); font-size: 10px; letter-spacing: .08em; text-transform: uppercase; font-weight:600; cursor: pointer; border-right: 1px solid var(--line-2); }
     .bar button:last-child { border-right: none; }
-    .bar button.on { background: rgb(var(--brass-glow)/.08); color: var(--brass-1); box-shadow: inset 0 -1.5px 0 var(--brass-1); }
+    .bar button.on { background: rgb(var(--color-accent-glow)/.08); color: var(--brass-1); box-shadow: inset 0 -1.5px 0 var(--brass-1); }
   </style>
 </head>
 <body>
@@ -113,7 +113,7 @@
         <span class="code">&lt;div class="bar"&gt; &lt;button class="on"&gt;L1&lt;/button&gt; … &lt;/div&gt;</span>
       </div>
       <div class="canvas" style="min-height: 60px; display:flex; align-items:center; gap: 14px; padding: 12px 14px;">
-        <span style="font-family:var(--font-mono); font-size:9px; color:var(--fg-4); letter-spacing:.08em; text-transform:uppercase;">LAYERS</span>
+        <span style="font-family:var(--font-mono); font-size:9px; color:var(--color-fg-disabled); letter-spacing:.08em; text-transform:uppercase;">LAYERS</span>
         <div class="bar">
           <button class="on">L1 · TIME</button>
           <button class="on">L2 · PARALLEL</button>
@@ -121,7 +121,7 @@
           <button class="on">L4 · APPROVE</button>
           <button>L5 · NOTES</button>
         </div>
-        <span style="margin-left: 8px; font-family:var(--font-mono); font-size:9px; color:var(--fg-4); letter-spacing:.08em;">OPACITY</span>
+        <span style="margin-left: 8px; font-family:var(--font-mono); font-size:9px; color:var(--color-fg-disabled); letter-spacing:.08em;">OPACITY</span>
         <input type="range" min="0" max="100" value="75" style="width: 120px; accent-color: var(--brass-1);" />
         <span class="chip is-brass" style="margin-left: 2px">75%</span>
         <span style="margin-left: auto; font-family:var(--font-mono); font-size:10px; color:var(--brass-1); cursor:pointer; letter-spacing:.08em; text-transform:uppercase;">↕ EXPLODE</span>
@@ -164,10 +164,10 @@
             <span>−5h</span><span>−4h</span><span>−3h</span><span>−2h</span><span>−1h</span><span>−30m</span><span>−10m</span><span style="color: var(--brass-1)">NOW</span>
           </div>
           <div class="l1-legend">
-            <span><i class="swatch" style="background:var(--fg-4); opacity:.22"></i>cold (&gt;1h)</span>
-            <span><i class="swatch" style="background:var(--warn); opacity:.55"></i>warm</span>
-            <span><i class="swatch" style="background:var(--warn); box-shadow:0 0 4px rgb(var(--warn-glow))"></i>hot (&lt;30m)</span>
-            <span><i class="swatch" style="background:var(--brass-1); box-shadow:0 0 4px rgb(var(--brass-glow))"></i>live (&lt;1m)</span>
+            <span><i class="swatch" style="background:var(--color-fg-disabled); opacity:.22"></i>cold (&gt;1h)</span>
+            <span><i class="swatch" style="background:var(--color-status-warn); opacity:.55"></i>warm</span>
+            <span><i class="swatch" style="background:var(--color-status-warn); box-shadow:0 0 4px rgb(var(--warn-glow))"></i>hot (&lt;30m)</span>
+            <span><i class="swatch" style="background:var(--brass-1); box-shadow:0 0 4px rgb(var(--color-accent-glow))"></i>live (&lt;1m)</span>
             <span style="margin-left:auto">hover for actor + timestamp</span>
           </div>
         </div>
@@ -183,23 +183,23 @@
         <div class="l2">
           <div class="lane" style="top: 10px">
             <span class="name">nick0cave</span>
-            <span class="cursor" style="left: 70%; color: var(--brass-1); background: var(--brass-1); box-shadow: 0 0 6px rgb(var(--brass-glow)/.7)"></span>
+            <span class="cursor" style="left: 70%; color: var(--brass-1); background: var(--brass-1); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.7)"></span>
           </div>
           <div class="lane" style="top: 42px">
             <span class="name">qa-king</span>
-            <span class="cursor" style="left: 38%; color: var(--err); background: var(--err); box-shadow: 0 0 6px rgb(var(--err-glow)/.7)"></span>
+            <span class="cursor" style="left: 38%; color: var(--color-status-err); background: var(--color-status-err); box-shadow: 0 0 6px rgb(var(--err-glow)/.7)"></span>
           </div>
           <div class="lane" style="top: 74px">
             <span class="name">sangsu</span>
-            <span class="cursor" style="left: 52%; color: var(--ok); background: var(--ok); box-shadow: 0 0 6px rgb(var(--ok-glow)/.7)"></span>
+            <span class="cursor" style="left: 52%; color: var(--color-status-ok); background: var(--color-status-ok); box-shadow: 0 0 6px rgb(var(--ok-glow)/.7)"></span>
           </div>
           <div class="lane" style="top: 106px">
             <span class="name">rama</span>
-            <span class="cursor" style="left: 20%; color: var(--stalled); background: var(--stalled); opacity:.5"></span>
+            <span class="cursor" style="left: 20%; color: var(--color-status-stalled); background: var(--color-status-stalled); opacity:.5"></span>
           </div>
           <div class="lane" style="top: 138px">
             <span class="name">masc-imp</span>
-            <span class="cursor" style="left: 84%; color: var(--info); background: var(--info); box-shadow: 0 0 6px rgb(var(--info-glow)/.6)"></span>
+            <span class="cursor" style="left: 84%; color: var(--color-status-info); background: var(--color-status-info); box-shadow: 0 0 6px rgb(var(--info-glow)/.6)"></span>
           </div>
         </div>
       </div>
@@ -218,7 +218,7 @@
           <div class="l3-row"><span class="l3-glyph">⟳</span><span class="l3-label">tick()</span><span class="l3-freq" style="width: 42%"></span><span class="l3-by">14s · m-imp</span><span class="l3-count">5×</span></div>
           <div class="l3-row"><span class="l3-glyph">∎</span><span class="l3-label">guard()</span><span class="l3-freq" style="width: 25%"></span><span class="l3-by">22s · qa</span><span class="l3-count">3×</span></div>
           <div class="l3-row"><span class="l3-glyph">◐</span><span class="l3-label">pause()</span><span class="l3-freq" style="width: 17%"></span><span class="l3-by">38s · sangsu</span><span class="l3-count">2×</span></div>
-          <div class="l3-row"><span class="l3-glyph" style="color:var(--err)">↯</span><span class="l3-label" style="color:var(--err-fg)">cascade()</span><span class="l3-freq" style="width: 8%; background: linear-gradient(90deg, var(--err), rgb(var(--err-glow)/.15)); box-shadow: 0 0 4px rgb(var(--err-glow)/.5)"></span><span class="l3-by" style="color:var(--err-fg)">52s · sangsu</span><span class="l3-count">1×</span></div>
+          <div class="l3-row"><span class="l3-glyph" style="color:var(--color-status-err)">↯</span><span class="l3-label" style="color:var(--err-fg)">cascade()</span><span class="l3-freq" style="width: 8%; background: linear-gradient(90deg, var(--color-status-err), rgb(var(--err-glow)/.15)); box-shadow: 0 0 4px rgb(var(--err-glow)/.5)"></span><span class="l3-by" style="color:var(--err-fg)">52s · sangsu</span><span class="l3-count">1×</span></div>
         </div>
       </div>
     </div>
@@ -261,7 +261,7 @@
           </div>
           <div class="l5-note" style="position: relative; margin-top: 72px">
             <span class="l5-pin"></span>
-            <div class="l5-head"><span class="dot" style="background:var(--warn); box-shadow: 0 0 4px rgb(var(--warn-glow)/.8)"></span>rama · STALLED 12m · no response</div>
+            <div class="l5-head"><span class="dot" style="background:var(--color-status-warn); box-shadow: 0 0 4px rgb(var(--warn-glow)/.8)"></span>rama · STALLED 12m · no response</div>
             <div class="l5-body">Was investigating the heartbeat drop. No reply from keeper — thread held open.</div>
           </div>
         </div>
@@ -282,7 +282,7 @@
             <span class="on">L4 APPR</span>
             <span>L5 NOTE</span>
           </div>
-          <div style="font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .08em; text-transform: uppercase; margin-bottom: 6px;">src/keeper.ts · branch feat/keeper-clarity · 3 keepers attached</div>
+          <div style="font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .08em; text-transform: uppercase; margin-bottom: 6px;">src/keeper.ts · branch feat/keeper-clarity · 3 keepers attached</div>
           <div class="code-line"><span class="time-bar" style="opacity:.3; height:10px" title="L1 · cold (3h)"></span><span class="num">09</span><span class="src"><span class="k">async</span> <span class="f">tick</span>() {'{'}</span></div>
           <div class="code-line"><span class="time-bar" style="opacity:.9; box-shadow:0 0 6px rgb(var(--warn-glow)/.8)" title="L1 · 4m"></span><span class="num">10</span><span class="src">  <span class="k">if</span> (this.state !== <span class="s">'running'</span>) <span class="k">return</span>;</span><span class="cursor-chip c-qa" title="L2 · qa-king at col 24">qa-king</span></div>
           <div class="code-line"><span class="time-bar" style="opacity:1; box-shadow:0 0 8px rgb(var(--warn-glow))" title="L1 · 12s · live"></span><span class="num">11</span><span class="src">  <span class="tool-glyph" title="L3 · emit() called 12× in 60s">◈</span> <span class="f hl">emit</span>(<span class="s">'heartbeat'</span>);</span><span class="cursor-chip c-nick" title="L2 · nick0cave editing">nick0cave</span></div>
@@ -294,7 +294,7 @@
             <span class="l4-stamp" style="font-size: 22px">LGTM</span>
           </div>
           <div style="display:grid; grid-template-columns: repeat(4, 1fr); gap: 6px; margin-top: 12px; padding-top: 10px; border-top: 1px dashed var(--line-1);">
-            <div style="font-family: var(--font-mono); font-size: 9px; color: var(--fg-3); line-height: 1.5;"><b style="color:var(--warn)">① L1</b> left bar height = recency. Brighter = more recent edit.</div>
+            <div style="font-family: var(--font-mono); font-size: 9px; color: var(--fg-3); line-height: 1.5;"><b style="color:var(--color-status-warn)">① L1</b> left bar height = recency. Brighter = more recent edit.</div>
             <div style="font-family: var(--font-mono); font-size: 9px; color: var(--fg-3); line-height: 1.5;"><b style="color:var(--brass-1)">② L2</b> right chips = live keeper cursors per line.</div>
             <div style="font-family: var(--font-mono); font-size: 9px; color: var(--fg-3); line-height: 1.5;"><b style="color:var(--brass-1)">③ L3</b> inline glyph = recent tool-call site. Hover for count.</div>
             <div style="font-family: var(--font-mono); font-size: 9px; color: var(--fg-3); line-height: 1.5;"><b style="color:var(--ok-fg)">④ L4</b> trailing block + stamp = approval status of the diff.</div>

--- a/dashboard/design-system/preview/overlays.html
+++ b/dashboard/design-system/preview/overlays.html
@@ -10,12 +10,12 @@
   <style>
     html, body { margin:0; background: var(--bg-0); color: var(--fg-1); font-family: var(--font-sans); min-height: 100vh; }
     .page { max-width: 1180px; margin:0 auto; padding: 32px 32px 96px; }
-    .back { font: var(--type-micro); color: var(--fg-4); text-decoration:none; letter-spacing: .08em; display:inline-block; margin-bottom:20px; }
+    .back { font: var(--type-micro); color: var(--color-fg-disabled); text-decoration:none; letter-spacing: .08em; display:inline-block; margin-bottom:20px; }
     .back:hover { color: var(--fg-2); }
     h1 { font-family: var(--font-mono); font-size: 18px; font-weight: 600; margin: 0 0 4px; }
     .sub { color: var(--fg-3); font-size: 12px; margin-bottom: 28px; }
     h2 { font: var(--type-label); text-transform: uppercase; letter-spacing: .08em; color: var(--fg-3); font-weight: 600; font-size: 11px; margin: 28px 0 8px; padding-bottom: 6px; border-bottom: 1px solid var(--line-2); }
-    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); }
+    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled); }
 
     /* static frame that hosts a "live" overlay demo */
     .stage { position: relative; width: 100%; height: 320px; background: var(--bg-1); border: 1px solid var(--line-1); border-radius: var(--r-1); overflow: hidden; }
@@ -26,36 +26,36 @@
         var(--bg-0);
       opacity: .45;
     }
-    .stage-caption { position: absolute; top: 8px; left: 10px; font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .08em; text-transform: uppercase; }
+    .stage-caption { position: absolute; top: 8px; left: 10px; font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .08em; text-transform: uppercase; }
     .stage-action { position: absolute; top: 8px; right: 10px; }
     .btn-ghost { background: var(--bg-2); border: 1px solid var(--line-2); color: var(--fg-2); font-family: var(--font-mono); font-size: 10px; letter-spacing: .06em; text-transform: uppercase; font-weight: 600; padding: 3px 8px; border-radius: var(--r-1); cursor: pointer; }
     .btn-ghost:hover { border-color: var(--brass-2); color: var(--brass-1); }
 
     /* ────── MODAL ────── */
     .scrim { position: absolute; inset: 0; background: rgba(10, 10, 12, .68); backdrop-filter: blur(2px); display: grid; place-items: center; z-index: 2; }
-    .modal { width: min(440px, 84%); background: var(--bg-1); border: 1px solid var(--line-2); border-radius: var(--r-1); box-shadow: 0 20px 60px rgba(0,0,0,.5), 0 0 0 1px rgb(var(--brass-glow)/.08); overflow: hidden; }
+    .modal { width: min(440px, 84%); background: var(--bg-1); border: 1px solid var(--line-2); border-radius: var(--r-1); box-shadow: 0 20px 60px rgba(0,0,0,.5), 0 0 0 1px rgb(var(--color-accent-glow)/.08); overflow: hidden; }
     .modal-head { display: flex; align-items: center; gap: 8px; padding: 10px 14px; border-bottom: 1px solid var(--line-1); background: linear-gradient(180deg, var(--bg-2), var(--bg-1)); }
-    .modal-head .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--err); box-shadow: 0 0 4px var(--err-glow); }
+    .modal-head .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--color-status-err); box-shadow: 0 0 4px var(--err-glow); }
     .modal-head h3 { margin: 0; font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: .04em; color: var(--fg-1); }
-    .modal-head .close { margin-left: auto; font-family: var(--font-mono); font-size: 12px; color: var(--fg-4); cursor: pointer; background: none; border: none; }
+    .modal-head .close { margin-left: auto; font-family: var(--font-mono); font-size: 12px; color: var(--color-fg-disabled); cursor: pointer; background: none; border: none; }
     .modal-body { padding: 14px; font-size: 12px; line-height: 1.55; color: var(--fg-2); }
     .modal-body .mono { font-family: var(--font-mono); color: var(--fg-1); background: var(--bg-2); padding: 1px 5px; border-radius: 2px; border: 1px solid var(--line-1); font-size: 11px; }
     .modal-foot { display: flex; justify-content: flex-end; gap: 6px; padding: 10px 14px; border-top: 1px solid var(--line-1); background: var(--bg-0); }
     .btn { font-family: var(--font-mono); font-size: 11px; letter-spacing: .06em; text-transform: uppercase; font-weight: 600; padding: 5px 12px; border-radius: var(--r-1); cursor: pointer; border: 1px solid var(--line-2); background: var(--bg-2); color: var(--fg-2); }
     .btn:hover { border-color: var(--brass-2); color: var(--brass-1); }
-    .btn.is-danger { background: rgb(var(--err-glow)/.15); border-color: var(--err); color: var(--err-fg); }
+    .btn.is-danger { background: rgb(var(--err-glow)/.15); border-color: var(--color-status-err); color: var(--err-fg); }
     .btn.is-danger:hover { background: rgb(var(--err-glow)/.25); }
-    .btn.is-primary { background: rgb(var(--brass-glow)/.12); border-color: var(--brass-1); color: var(--brass-1); box-shadow: 0 0 8px rgb(var(--brass-glow)/.25); }
+    .btn.is-primary { background: rgb(var(--color-accent-glow)/.12); border-color: var(--brass-1); color: var(--brass-1); box-shadow: 0 0 8px rgb(var(--color-accent-glow)/.25); }
 
     /* ────── POPOVER ────── */
     .anchor-btn { position: absolute; top: 120px; left: 60px; background: var(--bg-2); border: 1px dashed var(--line-2); color: var(--fg-2); font-family: var(--font-mono); font-size: 11px; padding: 5px 10px; border-radius: var(--r-1); cursor: pointer; }
-    .popover { position: absolute; background: var(--bg-2); border: 1px solid var(--line-2); border-radius: var(--r-1); box-shadow: 0 10px 30px rgba(0,0,0,.45), 0 0 0 1px rgb(var(--brass-glow)/.08); min-width: 220px; z-index: 2; }
+    .popover { position: absolute; background: var(--bg-2); border: 1px solid var(--line-2); border-radius: var(--r-1); box-shadow: 0 10px 30px rgba(0,0,0,.45), 0 0 0 1px rgb(var(--color-accent-glow)/.08); min-width: 220px; z-index: 2; }
     .popover::before { content:''; position: absolute; top: -5px; left: 24px; width: 8px; height: 8px; background: var(--bg-2); border-left: 1px solid var(--line-2); border-top: 1px solid var(--line-2); transform: rotate(45deg); }
     .popover-row { display: flex; align-items: center; gap: 8px; padding: 6px 10px; font-family: var(--font-mono); font-size: 11px; color: var(--fg-2); cursor: pointer; border-bottom: 1px solid var(--line-1); }
     .popover-row:last-child { border-bottom: none; }
     .popover-row:hover { background: var(--bg-3); color: var(--brass-1); }
-    .popover-row .kbd { margin-left: auto; font-size: 9px; padding: 1px 4px; border: 1px solid var(--line-2); border-radius: 2px; color: var(--fg-4); background: var(--bg-1); }
-    .popover-header { padding: 6px 10px 4px; font-family: var(--font-mono); font-size: 9px; letter-spacing: .08em; color: var(--fg-4); text-transform: uppercase; font-weight: 600; border-bottom: 1px solid var(--line-1); }
+    .popover-row .kbd { margin-left: auto; font-size: 9px; padding: 1px 4px; border: 1px solid var(--line-2); border-radius: 2px; color: var(--color-fg-disabled); background: var(--bg-1); }
+    .popover-header { padding: 6px 10px 4px; font-family: var(--font-mono); font-size: 9px; letter-spacing: .08em; color: var(--color-fg-disabled); text-transform: uppercase; font-weight: 600; border-bottom: 1px solid var(--line-1); }
 
     /* ────── TOOLTIP ────── */
     .tt { position: absolute; background: var(--bg-3); color: var(--fg-1); font-family: var(--font-mono); font-size: 10px; padding: 4px 8px; border-radius: var(--r-1); border: 1px solid var(--line-2); box-shadow: 0 4px 12px rgba(0,0,0,.45); z-index: 2; max-width: 220px; }
@@ -68,43 +68,43 @@
     .toast { display: flex; align-items: flex-start; gap: 8px; padding: 8px 10px 8px 8px; background: var(--bg-2); border: 1px solid var(--line-2); border-left: 2px solid var(--line-2); border-radius: var(--r-1); box-shadow: 0 6px 18px rgba(0,0,0,.5); font-size: 11px; color: var(--fg-1); }
     .toast .icon { width: 14px; text-align: center; font-family: var(--font-mono); font-weight: 700; font-size: 11px; flex-shrink: 0; line-height: 1.4; }
     .toast .body { flex: 1; line-height: 1.4; }
-    .toast .time { font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .04em; margin-top: 1px; }
-    .toast .close { font-family: var(--font-mono); color: var(--fg-4); cursor: pointer; background: none; border: none; padding: 0 2px; }
-    .toast.is-ok { border-left-color: var(--ok); }
-    .toast.is-ok .icon { color: var(--ok); }
-    .toast.is-err { border-left-color: var(--err); }
-    .toast.is-err .icon { color: var(--err); }
+    .toast .time { font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .04em; margin-top: 1px; }
+    .toast .close { font-family: var(--font-mono); color: var(--color-fg-disabled); cursor: pointer; background: none; border: none; padding: 0 2px; }
+    .toast.is-ok { border-left-color: var(--color-status-ok); }
+    .toast.is-ok .icon { color: var(--color-status-ok); }
+    .toast.is-err { border-left-color: var(--color-status-err); }
+    .toast.is-err .icon { color: var(--color-status-err); }
     .toast.is-brass { border-left-color: var(--brass-1); }
-    .toast.is-brass .icon { color: var(--brass-1); text-shadow: 0 0 4px rgb(var(--brass-glow)/.6); }
-    .toast.is-warn { border-left-color: var(--warn); }
-    .toast.is-warn .icon { color: var(--warn); }
+    .toast.is-brass .icon { color: var(--brass-1); text-shadow: 0 0 4px rgb(var(--color-accent-glow)/.6); }
+    .toast.is-warn { border-left-color: var(--color-status-warn); }
+    .toast.is-warn .icon { color: var(--color-status-warn); }
 
     /* ────── CONTEXT MENU ────── */
     .ctxmenu { position: absolute; min-width: 200px; background: var(--bg-2); border: 1px solid var(--line-2); border-radius: var(--r-1); box-shadow: 0 10px 30px rgba(0,0,0,.5); z-index: 2; padding: 4px 0; }
     .ctxmenu .item { display: flex; align-items: center; gap: 8px; padding: 4px 10px; font-family: var(--font-mono); font-size: 11px; color: var(--fg-2); cursor: pointer; }
     .ctxmenu .item:hover { background: var(--bg-3); color: var(--brass-1); }
-    .ctxmenu .item .glyph { width: 12px; color: var(--fg-4); text-align: center; }
+    .ctxmenu .item .glyph { width: 12px; color: var(--color-fg-disabled); text-align: center; }
     .ctxmenu .item:hover .glyph { color: var(--brass-1); }
-    .ctxmenu .item .kbd { margin-left: auto; font-size: 9px; padding: 1px 4px; border: 1px solid var(--line-2); border-radius: 2px; color: var(--fg-4); background: var(--bg-1); }
+    .ctxmenu .item .kbd { margin-left: auto; font-size: 9px; padding: 1px 4px; border: 1px solid var(--line-2); border-radius: 2px; color: var(--color-fg-disabled); background: var(--bg-1); }
     .ctxmenu .sep { height: 1px; background: var(--line-1); margin: 4px 0; }
     .ctxmenu .item.is-danger { color: var(--err-fg); }
 
     /* ────── CMD PALETTE ────── */
     .cmdk-scrim { position: absolute; inset: 0; background: rgba(10,10,12,.7); backdrop-filter: blur(3px); display: flex; justify-content: center; padding-top: 40px; z-index: 2; }
-    .cmdk { width: min(520px, 86%); background: var(--bg-1); border: 1px solid var(--brass-2); box-shadow: 0 20px 60px rgba(0,0,0,.6), 0 0 40px rgb(var(--brass-glow)/.15); border-radius: var(--r-1); overflow: hidden; height: fit-content; }
+    .cmdk { width: min(520px, 86%); background: var(--bg-1); border: 1px solid var(--brass-2); box-shadow: 0 20px 60px rgba(0,0,0,.6), 0 0 40px rgb(var(--color-accent-glow)/.15); border-radius: var(--r-1); overflow: hidden; height: fit-content; }
     .cmdk-input { display: flex; align-items: center; gap: 8px; padding: 10px 14px; border-bottom: 1px solid var(--line-2); }
-    .cmdk-input .prompt { font-family: var(--font-mono); color: var(--brass-1); font-size: 13px; text-shadow: 0 0 6px rgb(var(--brass-glow)/.6); }
+    .cmdk-input .prompt { font-family: var(--font-mono); color: var(--brass-1); font-size: 13px; text-shadow: 0 0 6px rgb(var(--color-accent-glow)/.6); }
     .cmdk-input input { flex: 1; background: transparent; border: none; outline: none; color: var(--fg-1); font-family: var(--font-mono); font-size: 13px; caret-color: var(--brass-1); }
-    .cmdk-input .hint { font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .08em; text-transform: uppercase; }
+    .cmdk-input .hint { font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .08em; text-transform: uppercase; }
     .cmdk-results { max-height: 230px; overflow-y: auto; }
-    .cmdk-group-head { padding: 6px 14px 2px; font-family: var(--font-mono); font-size: 9px; letter-spacing: .08em; color: var(--fg-4); text-transform: uppercase; font-weight: 600; }
+    .cmdk-group-head { padding: 6px 14px 2px; font-family: var(--font-mono); font-size: 9px; letter-spacing: .08em; color: var(--color-fg-disabled); text-transform: uppercase; font-weight: 600; }
     .cmdk-item { display: flex; align-items: center; gap: 10px; padding: 6px 14px; font-size: 12px; color: var(--fg-2); font-family: var(--font-mono); cursor: pointer; }
-    .cmdk-item .glyph { width: 16px; color: var(--fg-4); text-align: center; }
-    .cmdk-item .meta { margin-left: auto; font-size: 10px; color: var(--fg-4); }
-    .cmdk-item.is-sel { background: rgb(var(--brass-glow)/.1); color: var(--brass-1); box-shadow: inset 2px 0 0 var(--brass-1); }
-    .cmdk-item.is-sel .glyph { color: var(--brass-1); text-shadow: 0 0 4px rgb(var(--brass-glow)/.6); }
+    .cmdk-item .glyph { width: 16px; color: var(--color-fg-disabled); text-align: center; }
+    .cmdk-item .meta { margin-left: auto; font-size: 10px; color: var(--color-fg-disabled); }
+    .cmdk-item.is-sel { background: rgb(var(--color-accent-glow)/.1); color: var(--brass-1); box-shadow: inset 2px 0 0 var(--brass-1); }
+    .cmdk-item.is-sel .glyph { color: var(--brass-1); text-shadow: 0 0 4px rgb(var(--color-accent-glow)/.6); }
     .cmdk-item.is-sel .meta { color: var(--brass-2); }
-    .cmdk-foot { display: flex; gap: 14px; padding: 6px 14px; border-top: 1px solid var(--line-2); background: var(--bg-0); font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .06em; }
+    .cmdk-foot { display: flex; gap: 14px; padding: 6px 14px; border-top: 1px solid var(--line-2); background: var(--bg-0); font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .06em; }
     .cmdk-foot .k { padding: 1px 4px; border: 1px solid var(--line-2); border-radius: 2px; color: var(--fg-3); margin-right: 3px; }
   </style>
 </head>
@@ -131,7 +131,7 @@
             <span class="mono">3 threads</span> on keeper.ts will be abandoned and any in-flight emit() calls rolled back.
           </div>
           <div class="modal-foot">
-            <button class="btn">Cancel <span style="color:var(--fg-4); margin-left:4px">ESC</span></button>
+            <button class="btn">Cancel <span style="color:var(--color-fg-disabled); margin-left:4px">ESC</span></button>
             <button class="btn is-danger">Kill &amp; abandon</button>
           </div>
         </div>
@@ -182,7 +182,7 @@
     <div class="stage">
       <div class="faux"></div>
       <div class="stage-caption">on-thread context · 3 groups separated</div>
-      <span style="position:absolute; top:110px; left:180px; font-family:var(--font-mono); font-size:11px; color:var(--brass-1); padding: 3px 8px; background: rgb(var(--brass-glow)/.1); border-radius: 2px;">thread t-9f2a</span>
+      <span style="position:absolute; top:110px; left:180px; font-family:var(--font-mono); font-size:11px; color:var(--brass-1); padding: 3px 8px; background: rgb(var(--color-accent-glow)/.1); border-radius: 2px;">thread t-9f2a</span>
       <div class="ctxmenu" style="top:140px; left:180px">
         <div class="item"><span class="glyph">↗</span>open in rail <span class="kbd">↵</span></div>
         <div class="item"><span class="glyph">#</span>jump to line</div>

--- a/dashboard/design-system/preview/primitives.html
+++ b/dashboard/design-system/preview/primitives.html
@@ -11,7 +11,7 @@
     html, body { margin:0; background: var(--bg-0); color: var(--fg-1); font-family: var(--font-sans); }
     .page { max-width: 1180px; margin:0 auto; padding: 32px 32px 96px; }
     .brand-row { display:flex; align-items:center; gap:10px; margin-bottom: 20px; }
-    .back { font: var(--type-micro); color: var(--fg-4); text-decoration:none; letter-spacing: .08em; }
+    .back { font: var(--type-micro); color: var(--color-fg-disabled); text-decoration:none; letter-spacing: .08em; }
     .back:hover { color: var(--fg-2); }
     h1 { font-family: var(--font-mono); font-size: 18px; font-weight: 600; margin: 0 0 4px; }
     .sub { color: var(--fg-3); font-size: 12px; margin-bottom: 28px; }
@@ -19,17 +19,17 @@
     .seg { background: var(--bg-1); border: 1px solid var(--line-1); border-radius: var(--r-1); padding: 16px 18px; margin-bottom: 10px; display: grid; grid-template-columns: 200px 1fr; gap: 20px; align-items: start; }
     .seg .meta { font-family: var(--font-mono); font-size: 11px; color: var(--fg-3); }
     .seg .meta .n { color: var(--fg-1); font-weight:600; font-size: 13px; margin-bottom: 4px; display:block; }
-    .seg .meta .code { display:block; margin-top: 6px; color: var(--fg-4); font-size: 10px; line-height: 1.5; }
+    .seg .meta .code { display:block; margin-top: 6px; color: var(--color-fg-disabled); font-size: 10px; line-height: 1.5; }
     .seg .demo { display:flex; flex-wrap:wrap; gap: 8px; align-items:center; min-height: 28px; }
     .seg .demo.col { flex-direction:column; align-items:stretch; gap: 4px; }
     .row-demo { display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
-    .grp-label { font: var(--type-micro); color: var(--fg-4); letter-spacing: .08em; text-transform:uppercase; margin-right: 4px; }
+    .grp-label { font: var(--type-micro); color: var(--color-fg-disabled); letter-spacing: .08em; text-transform:uppercase; margin-right: 4px; }
     .swatch { display:inline-flex; flex-direction:column; align-items:center; gap:3px; min-width: 56px; }
     .swatch .sw { width: 100%; height: 20px; border-radius: 2px; border: 1px solid var(--line-1); }
-    .swatch .lb { font: var(--type-micro); color: var(--fg-4); letter-spacing: .04em; }
+    .swatch .lb { font: var(--type-micro); color: var(--color-fg-disabled); letter-spacing: .04em; }
     /* kv showcase */
     .kv-sample { background: var(--bg-2); border:1px solid var(--line-1); border-radius: var(--r-1); padding: 8px 12px; min-width: 280px; }
-    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); }
+    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled); }
   </style>
 </head>
 <body>
@@ -48,11 +48,11 @@
         <div class="row-demo"><span class="grp-label">kinds</span>
           <span class="chip">neutral</span>
           <span class="chip is-brass"><span class="dot" style="background:var(--brass-1)"></span>brass</span>
-          <span class="chip is-ok"><span class="dot" style="background:var(--ok)"></span>ok</span>
-          <span class="chip is-warn"><span class="dot" style="background:var(--warn)"></span>warn</span>
-          <span class="chip is-err"><span class="dot" style="background:var(--err)"></span>err</span>
-          <span class="chip is-info"><span class="dot" style="background:var(--info)"></span>info</span>
-          <span class="chip is-stalled"><span class="dot" style="background:var(--stalled)"></span>stalled</span>
+          <span class="chip is-ok"><span class="dot" style="background:var(--color-status-ok)"></span>ok</span>
+          <span class="chip is-warn"><span class="dot" style="background:var(--color-status-warn)"></span>warn</span>
+          <span class="chip is-err"><span class="dot" style="background:var(--color-status-err)"></span>err</span>
+          <span class="chip is-info"><span class="dot" style="background:var(--color-status-info)"></span>info</span>
+          <span class="chip is-stalled"><span class="dot" style="background:var(--color-status-stalled)"></span>stalled</span>
           <span class="chip is-ghost">ghost</span>
         </div>
         <div class="row-demo"><span class="grp-label">sizes</span>
@@ -235,7 +235,7 @@
       <div class="demo col">
         <div class="row-demo">
           <span class="grp-label">heartbeat</span>
-          <span class="dot-k-nick" style="width:9px; height:9px; border-radius:50%; background: var(--brass-1); box-shadow: 0 0 6px rgb(var(--brass-glow)/.7)" class="anim-heartbeat"></span>
+          <span class="dot-k-nick" style="width:9px; height:9px; border-radius:50%; background: var(--brass-1); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.7)" class="anim-heartbeat"></span>
           <span style="width:16px"></span>
           <span class="grp-label">pulse-glow</span>
           <span style="width: 60px; height: 18px; border-radius: 3px; background: var(--bg-3); display:inline-block" class="anim-pulse-glow"></span>

--- a/dashboard/design-system/preview/scope-phase2.html
+++ b/dashboard/design-system/preview/scope-phase2.html
@@ -23,7 +23,7 @@
     padding: 32px 40px 0;
   }
   .pg-head {
-    border-bottom: 1px solid var(--line-3);
+    border-bottom: 1px solid var(--color-border-divider);
     padding-bottom: 20px;
     margin-bottom: 32px;
     display: grid;
@@ -63,8 +63,8 @@
     display: grid;
     grid-template-columns: repeat(4, 1fr);
     gap: 1px;
-    background: var(--line-3);
-    border: 1px solid var(--line-3);
+    background: var(--color-border-divider);
+    border: 1px solid var(--color-border-divider);
     margin-bottom: 40px;
   }
   .toc > div {

--- a/dashboard/design-system/preview/scope-phase3.html
+++ b/dashboard/design-system/preview/scope-phase3.html
@@ -11,13 +11,13 @@
 <style>
   body { margin:0; padding:0 0 96px; background:var(--bg-0); color:var(--fg-1); font:13px/1.45 var(--font-sans); }
   .pg { max-width:1320px; margin:0 auto; padding:32px 40px 0; }
-  .pg-head { display:grid; grid-template-columns:1fr auto; gap:24px; align-items:end; padding-bottom:20px; margin-bottom:28px; border-bottom:1px solid var(--line-3); }
+  .pg-head { display:grid; grid-template-columns:1fr auto; gap:24px; align-items:end; padding-bottom:20px; margin-bottom:28px; border-bottom:1px solid var(--color-border-divider); }
   .eyebrow { font:500 10px/1 var(--font-mono); letter-spacing:.12em; text-transform:uppercase; color:var(--brass-1); margin-bottom:10px; }
   h1 { margin:0 0 8px; font:500 26px/1.15 var(--font-sans); color:var(--fg-0); }
   .sub { max-width:760px; color:var(--fg-3); }
   .meta { text-align:right; font:10px/1.5 var(--font-mono); color:var(--fg-3); letter-spacing:.08em; text-transform:uppercase; }
   .meta b { color:var(--brass-1); font-weight:500; }
-  .toc { display:grid; grid-template-columns:repeat(5,1fr); gap:1px; background:var(--line-3); border:1px solid var(--line-3); margin-bottom:34px; }
+  .toc { display:grid; grid-template-columns:repeat(5,1fr); gap:1px; background:var(--color-border-divider); border:1px solid var(--color-border-divider); margin-bottom:34px; }
   .toc a { display:block; padding:12px 14px; background:var(--bg-1); color:var(--fg-2); text-decoration:none; font:11px/1.55 var(--font-mono); }
   .toc a b { display:block; color:var(--brass-1); font-size:10px; letter-spacing:.1em; text-transform:uppercase; margin-bottom:6px; }
   .zones { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:14px; margin-bottom:36px; }
@@ -34,7 +34,7 @@
   code { color:var(--brass-1); font-family:var(--font-mono); }
   table { width:100%; border-collapse:collapse; background:var(--bg-1); border:1px solid var(--line-2); font:11px/1.45 var(--font-mono); }
   th, td { padding:8px 10px; border-bottom:1px solid var(--line-1); text-align:left; vertical-align:top; }
-  th { color:var(--fg-4); background:var(--bg-2); text-transform:uppercase; letter-spacing:.08em; }
+  th { color:var(--color-fg-disabled); background:var(--bg-2); text-transform:uppercase; letter-spacing:.08em; }
   td:first-child { color:var(--brass-1); white-space:nowrap; }
   .accept { margin-top:30px; padding:16px 18px; background:var(--bg-1); border:1px solid var(--line-2); border-left:2px solid var(--brass-1); }
   .accept h2 { margin:0 0 10px; font:500 15px/1.2 var(--font-sans); }

--- a/dashboard/design-system/preview/snippets.html
+++ b/dashboard/design-system/preview/snippets.html
@@ -79,21 +79,21 @@
     /* form-control subset (mirrors forms.html) — needed so .input/.toggle/.check/.segmented snippets render in preview */
     .field { display:flex; flex-direction:column; gap:3px; }
     .field-label { font-family: var(--font-mono); font-size: 9px; letter-spacing: .08em; color: var(--fg-3); text-transform:uppercase; font-weight:600; }
-    .field-hint { font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .04em; }
+    .field-hint { font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .04em; }
     .input { background: var(--bg-2); border: 1px solid var(--line-2); border-radius: var(--r-1); padding: 6px 10px; color: var(--fg-1); font-family: var(--font-mono); font-size: 12px; outline: none; width: 100%; box-sizing:border-box; }
-    .input::placeholder { color: var(--fg-4); }
-    .input:focus { border-color: var(--brass-2); box-shadow: 0 0 0 1px var(--brass-2), 0 0 10px rgb(var(--brass-glow)/.18); background: var(--bg-3); }
+    .input::placeholder { color: var(--color-fg-disabled); }
+    .input:focus { border-color: var(--brass-2); box-shadow: 0 0 0 1px var(--brass-2), 0 0 10px rgb(var(--color-accent-glow)/.18); background: var(--bg-3); }
     .check { display:inline-flex; align-items:center; gap: 6px; cursor:pointer; user-select:none; font-family: var(--font-mono); font-size: 11px; color: var(--fg-2); }
     .check input { position: absolute; opacity: 0; width: 0; height: 0; pointer-events:none; }
     .check .box { width: 13px; height: 13px; border: 1px solid var(--line-2); border-radius: 2px; background: var(--bg-2); display:inline-grid; place-items:center; transition: all .12s; flex-shrink:0; }
-    .check input:checked + .box { background: var(--brass-1); border-color: var(--brass-1); box-shadow: 0 0 8px rgb(var(--brass-glow)/.5); }
+    .check input:checked + .box { background: var(--brass-1); border-color: var(--brass-1); box-shadow: 0 0 8px rgb(var(--color-accent-glow)/.5); }
     .check input:checked + .box::after { content: ''; width: 6px; height: 3px; border-left: 1.5px solid var(--bg-0); border-bottom: 1.5px solid var(--bg-0); transform: rotate(-45deg) translate(1px, -1px); }
     .toggle { display:inline-flex; align-items:center; gap: 8px; cursor:pointer; user-select:none; font-family: var(--font-mono); font-size: 11px; color: var(--fg-2); }
     .toggle input { position:absolute; opacity:0; }
     .toggle .track { width: 26px; height: 14px; background: var(--bg-3); border: 1px solid var(--line-2); border-radius: 999px; position: relative; transition: all .15s; flex-shrink:0; }
     .toggle .track::after { content: ''; position: absolute; top: 1px; left: 1px; width: 10px; height: 10px; border-radius: 50%; background: var(--fg-3); transition: all .15s; }
-    .toggle input:checked + .track { background: rgb(var(--brass-glow)/.15); border-color: var(--brass-2); }
-    .toggle input:checked + .track::after { left: 13px; background: var(--brass-1); box-shadow: 0 0 6px rgb(var(--brass-glow)/.7); }
+    .toggle input:checked + .track { background: rgb(var(--color-accent-glow)/.15); border-color: var(--brass-2); }
+    .toggle input:checked + .track::after { left: 13px; background: var(--brass-1); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.7); }
     .segmented { display: inline-flex; border: 1px solid var(--line-2); border-radius: var(--r-1); overflow: hidden; background: var(--bg-2); }
     .segmented button { background: transparent; border: none; color: var(--fg-3); font-family: var(--font-mono); font-size: 10px; letter-spacing: .08em; text-transform: uppercase; font-weight: 600; padding: 5px 12px; cursor: pointer; border-right: 1px solid var(--line-2); }
     .segmented button:last-child { border-right: none; }

--- a/dashboard/design-system/preview/snippets.jsx
+++ b/dashboard/design-system/preview/snippets.jsx
@@ -374,9 +374,9 @@ const SNIPPETS = [
   <div class="nd-row">
     <span class="ts">12:05</span>
     <span style="font-family:var(--font-mono);font-size:11px;color:var(--brass-1)">@sangsu</span>
-    <span style="font-family:var(--font-mono);font-size:9px;padding:1px 5px;border:1px solid var(--brass-3);color:var(--brass-1);background:rgb(var(--brass-glow)/.08);text-transform:uppercase;letter-spacing:.06em">→ keeper-merge</span>
+    <span style="font-family:var(--font-mono);font-size:9px;padding:1px 5px;border:1px solid var(--color-accent-fg-dim);color:var(--brass-1);background:rgb(var(--color-accent-glow)/.08);text-transform:uppercase;letter-spacing:.06em">→ keeper-merge</span>
     <span style="font-family:var(--font-mono);font-size:11px;color:var(--fg-1);line-height:1.4">extend probe window to 4s before fallback — see ar-2025-04-11/f-002</span>
-    <span style="font-family:var(--font-mono);font-size:9px;color:var(--fg-4);text-transform:uppercase;letter-spacing:.06em">cooldown 30s</span>
+    <span style="font-family:var(--font-mono);font-size:9px;color:var(--color-fg-disabled);text-transform:uppercase;letter-spacing:.06em">cooldown 30s</span>
   </div>
 </div>`,
   },

--- a/dashboard/design-system/preview/spacing.html
+++ b/dashboard/design-system/preview/spacing.html
@@ -18,7 +18,7 @@
   .sp-name { font: 600 10px/1.2 var(--font-mono); letter-spacing: var(--track-caps); text-transform: uppercase; color: var(--fg-2); }
   .sp-bar-wrap { height: 36px; position: relative; display: flex; align-items: center; }
   .sp-bar {
-    background: var(--brass-3);
+    background: var(--color-accent-fg-dim);
     border: 1px solid var(--brass-2);
     height: 18px;
     position: relative;

--- a/dashboard/design-system/preview/swimlanes.html
+++ b/dashboard/design-system/preview/swimlanes.html
@@ -10,77 +10,77 @@
   <style>
     html, body { margin:0; background: var(--bg-0); color: var(--fg-1); font-family: var(--font-sans); min-height: 100vh; }
     .page { max-width: 1180px; margin:0 auto; padding: 32px 32px 96px; }
-    .back { font: var(--type-micro); color: var(--fg-4); text-decoration:none; letter-spacing: .08em; display:inline-block; margin-bottom:20px; }
+    .back { font: var(--type-micro); color: var(--color-fg-disabled); text-decoration:none; letter-spacing: .08em; display:inline-block; margin-bottom:20px; }
     .back:hover { color: var(--fg-2); }
     h1 { font-family: var(--font-mono); font-size: 18px; font-weight: 600; margin: 0 0 4px; }
     .sub { color: var(--fg-3); font-size: 12px; margin-bottom: 28px; line-height:1.5; max-width: 700px; }
     h2 { font: var(--type-label); text-transform: uppercase; letter-spacing: .08em; color: var(--fg-3); font-weight: 600; font-size: 11px; margin: 28px 0 8px; padding-bottom: 6px; border-bottom: 1px solid var(--line-2); }
     h2 .tag { margin-left: 8px; color: var(--brass-1); font-weight: 500; }
-    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); }
+    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled); }
 
     .seg { background: var(--bg-1); border: 1px solid var(--line-1); border-radius: var(--r-1); padding: 16px; margin-bottom: 10px; display:grid; grid-template-columns: 260px 1fr; gap:18px; align-items:start; }
     .seg .meta { font-family: var(--font-mono); font-size: 11px; color: var(--fg-3); line-height: 1.5; }
     .seg .meta .n { color: var(--fg-1); font-weight:600; font-size: 13px; margin-bottom: 4px; display:block; }
-    .seg .meta .code { display:block; margin-top: 6px; color: var(--fg-4); font-size: 10px; }
+    .seg .meta .code { display:block; margin-top: 6px; color: var(--color-fg-disabled); font-size: 10px; }
 
     /* ── BASE LANE ── sharp / blueprint treatment */
-    .sw { position: relative; background: var(--bg-0); border: 1px solid var(--line-2); border-radius: 0; overflow: hidden; box-shadow: inset 0 0 0 1px rgb(0 0 0 / .4), 0 1px 0 rgb(var(--brass-glow)/.05); }
+    .sw { position: relative; background: var(--bg-0); border: 1px solid var(--line-2); border-radius: 0; overflow: hidden; box-shadow: inset 0 0 0 1px rgb(0 0 0 / .4), 0 1px 0 rgb(var(--color-accent-glow)/.05); }
     .sw::before, .sw::after { content: ''; position: absolute; width: 8px; height: 8px; pointer-events: none; z-index: 3; }
     .sw::before { top: 0; left: 0; border-top: 1px solid var(--brass-2); border-left: 1px solid var(--brass-2); }
     .sw::after  { bottom: 0; right: 0; border-bottom: 1px solid var(--brass-2); border-right: 1px solid var(--brass-2); }
     .sw-head { display:flex; align-items:center; gap: 10px; padding: 5px 10px; background: linear-gradient(180deg, var(--bg-2), var(--bg-1)); border-bottom: 1px solid var(--line-2); font-family: var(--font-mono); font-size: 9px; color: var(--fg-3); letter-spacing: .1em; text-transform: uppercase; position: relative; }
-    .sw-head::after { content:''; position:absolute; left:0; right:0; bottom:-1px; height:1px; background: linear-gradient(90deg, transparent, rgb(var(--brass-glow)/.4), transparent); }
-    .sw-ruler { display:flex; flex: 1; justify-content: space-between; color: var(--fg-4); }
+    .sw-head::after { content:''; position:absolute; left:0; right:0; bottom:-1px; height:1px; background: linear-gradient(90deg, transparent, rgb(var(--color-accent-glow)/.4), transparent); }
+    .sw-ruler { display:flex; flex: 1; justify-content: space-between; color: var(--color-fg-disabled); }
     .sw-ruler span { font-variant-numeric: tabular-nums; padding: 0 4px; border-left: 1px solid var(--line-1); }
     .sw-ruler span:first-child { border-left: none; padding-left: 0; }
     .sw-body { position: relative; background-image: linear-gradient(90deg, transparent 0, transparent calc(25% - 1px), var(--line-1) calc(25% - 1px), var(--line-1) 25%, transparent 25%), linear-gradient(90deg, transparent 0, transparent calc(50% - 1px), var(--line-1) calc(50% - 1px), var(--line-1) 50%, transparent 50%), linear-gradient(90deg, transparent 0, transparent calc(75% - 1px), var(--line-1) calc(75% - 1px), var(--line-1) 75%, transparent 75%); background-size: 100% 100%; background-position: 88px 0; background-repeat: no-repeat; }
     .lane { position: relative; height: 30px; display:flex; align-items:center; gap: 10px; padding: 0 10px; border-bottom: 1px solid var(--line-1); }
     .lane:last-child { border-bottom: none; }
-    .lane:hover { background: rgb(var(--brass-glow)/.025); }
+    .lane:hover { background: rgb(var(--color-accent-glow)/.025); }
     .lane-name { width: 88px; font-family: var(--font-mono); font-size: 10px; color: var(--fg-2); letter-spacing: .04em; display:flex; align-items:center; gap: 5px; flex-shrink:0; padding-right: 8px; border-right: 1px solid var(--line-2); height: 100%; box-sizing: border-box; }
     .lane-name .dot { width: 4px; height: 4px; background: currentColor; border-radius: 0; transform: rotate(45deg); flex-shrink:0; }
     .lane-track { position: relative; flex: 1; height: 18px; }
     .tick { position:absolute; top: 50%; transform: translateY(-50%); height: 10px; border-radius: 0; }
-    .tick.emit    { background: var(--brass-1); box-shadow: 0 0 4px rgb(var(--brass-glow)/.6); clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%); width: 8px !important; }
-    .tick.tool    { background: var(--info); clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%); width: 4px !important; }
-    .tick.approve { background: var(--ok); clip-path: polygon(0 0, 100% 50%, 0 100%); width: 8px !important; box-shadow: 0 0 3px rgb(var(--ok-glow)/.5); }
-    .tick.flag    { background: var(--err); clip-path: polygon(50% 0, 100% 100%, 0 100%); width: 8px !important; box-shadow: 0 0 4px rgb(var(--err-glow)/.6); }
+    .tick.emit    { background: var(--brass-1); box-shadow: 0 0 4px rgb(var(--color-accent-glow)/.6); clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%); width: 8px !important; }
+    .tick.tool    { background: var(--color-status-info); clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%); width: 4px !important; }
+    .tick.approve { background: var(--color-status-ok); clip-path: polygon(0 0, 100% 50%, 0 100%); width: 8px !important; box-shadow: 0 0 3px rgb(var(--ok-glow)/.5); }
+    .tick.flag    { background: var(--color-status-err); clip-path: polygon(50% 0, 100% 100%, 0 100%); width: 8px !important; box-shadow: 0 0 4px rgb(var(--err-glow)/.6); }
     .tick.commit  { background: var(--brass-2); height: 16px; clip-path: polygon(0 0, 100% 0, 50% 100%); width: 8px !important; }
     .span { position:absolute; top: 50%; transform: translateY(-50%); height: 8px; border-radius: 0; }
-    .span.run   { background: linear-gradient(90deg, rgb(var(--brass-glow)/.5), rgb(var(--brass-glow)/.12)); border: 1px solid var(--brass-2); border-left-width: 2px; clip-path: polygon(0 0, 100% 0, calc(100% - 4px) 100%, 0 100%); }
-    .span.stall { background: repeating-linear-gradient(45deg, rgb(var(--stalled-glow)/.35) 0 4px, transparent 4px 8px); border: 1px dashed var(--stalled); }
-    .now { position: absolute; top: 0; bottom: 0; width: 0; border-left: 1px solid rgb(var(--brass-glow)/.85); box-shadow: -1px 0 8px rgb(var(--brass-glow)/.4), 1px 0 0 rgb(var(--brass-glow)/.2); z-index: 2; }
-    .now::before { content: 'NOW'; position:absolute; top: 2px; left: 4px; font-family: var(--font-mono); font-size: 8px; color: var(--brass-1); letter-spacing: .15em; text-shadow: 0 0 4px rgb(var(--brass-glow)/.8); border: 1px solid var(--brass-2); padding: 1px 3px; background: var(--bg-0); }
-    .now::after { content: ''; position: absolute; left: -3px; top: 0; width: 7px; height: 7px; background: var(--brass-1); clip-path: polygon(50% 100%, 0 0, 100% 0); box-shadow: 0 0 6px rgb(var(--brass-glow)/.7); }
+    .span.run   { background: linear-gradient(90deg, rgb(var(--color-accent-glow)/.5), rgb(var(--color-accent-glow)/.12)); border: 1px solid var(--brass-2); border-left-width: 2px; clip-path: polygon(0 0, 100% 0, calc(100% - 4px) 100%, 0 100%); }
+    .span.stall { background: repeating-linear-gradient(45deg, rgb(var(--stalled-glow)/.35) 0 4px, transparent 4px 8px); border: 1px dashed var(--color-status-stalled); }
+    .now { position: absolute; top: 0; bottom: 0; width: 0; border-left: 1px solid rgb(var(--color-accent-glow)/.85); box-shadow: -1px 0 8px rgb(var(--color-accent-glow)/.4), 1px 0 0 rgb(var(--color-accent-glow)/.2); z-index: 2; }
+    .now::before { content: 'NOW'; position:absolute; top: 2px; left: 4px; font-family: var(--font-mono); font-size: 8px; color: var(--brass-1); letter-spacing: .15em; text-shadow: 0 0 4px rgb(var(--color-accent-glow)/.8); border: 1px solid var(--brass-2); padding: 1px 3px; background: var(--bg-0); }
+    .now::after { content: ''; position: absolute; left: -3px; top: 0; width: 7px; height: 7px; background: var(--brass-1); clip-path: polygon(50% 100%, 0 0, 100% 0); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.7); }
 
     /* ── EMPTY ── */
-    .empty-slate { text-align: center; padding: 40px 20px; color: var(--fg-4); font-family: var(--font-mono); font-size: 11px; }
+    .empty-slate { text-align: center; padding: 40px 20px; color: var(--color-fg-disabled); font-family: var(--font-mono); font-size: 11px; }
     .empty-slate .big { font-size: 22px; color: var(--fg-3); opacity: .4; letter-spacing: .1em; }
-    .empty-slate .action { margin-top: 10px; display:inline-block; padding: 4px 12px; border: 1px solid var(--brass-2); color: var(--brass-1); border-radius: 0; font-size: 10px; letter-spacing: .1em; text-transform:uppercase; cursor:pointer; background: rgb(var(--brass-glow)/.06); clip-path: polygon(6px 0, 100% 0, calc(100% - 6px) 100%, 0 100%); padding: 4px 18px; }
+    .empty-slate .action { margin-top: 10px; display:inline-block; padding: 4px 12px; border: 1px solid var(--brass-2); color: var(--brass-1); border-radius: 0; font-size: 10px; letter-spacing: .1em; text-transform:uppercase; cursor:pointer; background: rgb(var(--color-accent-glow)/.06); clip-path: polygon(6px 0, 100% 0, calc(100% - 6px) 100%, 0 100%); padding: 4px 18px; }
 
     /* ── WATERFALL ── */
-    .wf .lane-track .span.run.d1 { left: 2%; width: 22%; background: linear-gradient(90deg, var(--brass-1), rgb(var(--brass-glow)/.2)); }
-    .wf .lane-track .span.run.d2 { left: 22%; width: 28%; background: linear-gradient(90deg, var(--info), rgb(106 142 176 / .2)); }
-    .wf .lane-track .span.run.d3 { left: 48%; width: 18%; background: linear-gradient(90deg, var(--ok), rgb(107 158 107 / .2)); }
-    .wf .lane-track .span.run.d4 { left: 64%; width: 32%; background: linear-gradient(90deg, var(--brass-2), rgb(var(--brass-glow)/.1)); }
+    .wf .lane-track .span.run.d1 { left: 2%; width: 22%; background: linear-gradient(90deg, var(--brass-1), rgb(var(--color-accent-glow)/.2)); }
+    .wf .lane-track .span.run.d2 { left: 22%; width: 28%; background: linear-gradient(90deg, var(--color-status-info), rgb(106 142 176 / .2)); }
+    .wf .lane-track .span.run.d3 { left: 48%; width: 18%; background: linear-gradient(90deg, var(--color-status-ok), rgb(107 158 107 / .2)); }
+    .wf .lane-track .span.run.d4 { left: 64%; width: 32%; background: linear-gradient(90deg, var(--brass-2), rgb(var(--color-accent-glow)/.1)); }
 
     /* ── HANDOFF arrow ── sharp angle */
     .handoff { position:absolute; top:50%; height: 14px; width: 28px; transform: translateY(-100%); pointer-events:none; }
-    .handoff::before { content: ''; position: absolute; left: 0; right: 6px; top: 0; height: 1px; background: var(--brass-1); box-shadow: 0 0 4px rgb(var(--brass-glow)/.5); }
+    .handoff::before { content: ''; position: absolute; left: 0; right: 6px; top: 0; height: 1px; background: var(--brass-1); box-shadow: 0 0 4px rgb(var(--color-accent-glow)/.5); }
     .handoff::after { content: ''; position: absolute; right: 0; top: 0; width: 6px; height: 14px; border-left: 1px solid var(--brass-1); }
-    .handoff .ah { position:absolute; right: -3px; bottom: -4px; width: 7px; height: 7px; background: var(--brass-1); clip-path: polygon(50% 100%, 0 0, 100% 0); box-shadow: 0 0 4px rgb(var(--brass-glow)/.6); }
+    .handoff .ah { position:absolute; right: -3px; bottom: -4px; width: 7px; height: 7px; background: var(--brass-1); clip-path: polygon(50% 100%, 0 0, 100% 0); box-shadow: 0 0 4px rgb(var(--color-accent-glow)/.6); }
     .handoff-label { position:absolute; top: -14px; font-family: var(--font-mono); font-size: 8px; color: var(--brass-2); letter-spacing: .1em; white-space: nowrap; text-transform: uppercase; padding: 1px 4px; background: var(--bg-0); border: 1px solid var(--line-2); }
 
     /* ── COLLAPSED (grouped) ── */
-    .group-bar { position: relative; display:flex; align-items:center; gap: 10px; padding: 0 10px; height: 28px; border-bottom: 1px solid var(--line-2); background: linear-gradient(90deg, rgb(var(--brass-glow)/.06), transparent 60%); }
+    .group-bar { position: relative; display:flex; align-items:center; gap: 10px; padding: 0 10px; height: 28px; border-bottom: 1px solid var(--line-2); background: linear-gradient(90deg, rgb(var(--color-accent-glow)/.06), transparent 60%); }
     .group-name { width: 88px; font-family: var(--font-mono); font-size: 10px; color: var(--brass-1); letter-spacing: .08em; text-transform: uppercase; display:flex; align-items:center; gap:5px; flex-shrink:0; padding-right: 8px; border-right: 1px solid var(--line-2); height: 100%; box-sizing: border-box; }
     .group-name .chev { font-size: 8px; }
-    .group-name .cnt { color: var(--fg-4); font-size: 9px; font-weight: 400; letter-spacing: .04em; }
+    .group-name .cnt { color: var(--color-fg-disabled); font-size: 9px; font-weight: 400; letter-spacing: .04em; }
     .group-stack { flex: 1; position: relative; height: 18px; }
     .group-stack .mini { position:absolute; top: 0; height: 3px; background: var(--brass-1); border-radius: 0; opacity: .65; clip-path: polygon(0 0, 100% 0, calc(100% - 2px) 100%, 0 100%); }
-    .group-stack .mini:nth-child(2) { top: 5px; background: var(--info); }
-    .group-stack .mini:nth-child(3) { top: 10px; background: var(--ok); }
-    .group-stack .mini:nth-child(4) { top: 15px; background: var(--err); }
+    .group-stack .mini:nth-child(2) { top: 5px; background: var(--color-status-info); }
+    .group-stack .mini:nth-child(3) { top: 10px; background: var(--color-status-ok); }
+    .group-stack .mini:nth-child(4) { top: 15px; background: var(--color-status-err); }
     .group-stack .summary { position:absolute; right: 0; top: 0; bottom: 0; display:flex; align-items:center; gap: 6px; font-family: var(--font-mono); font-size: 9px; color: var(--fg-3); padding-right: 4px; }
     .group-stack .summary .chip-mini { padding: 1px 6px; background: var(--bg-2); border: 1px solid var(--line-2); border-radius: 0; font-size: 9px; color: var(--fg-2); letter-spacing: .04em; text-transform: uppercase; }
 
@@ -88,14 +88,14 @@
     .density-bar { display:inline-flex; gap: 0; border: 1px solid var(--line-2); border-radius: 0; overflow: hidden; background: var(--bg-1); margin-bottom: 8px; font-family: var(--font-mono); font-size: 10px; letter-spacing: .1em; text-transform:uppercase; }
     .density-bar button { background: transparent; border: none; color: var(--fg-3); padding: 4px 12px; cursor: pointer; border-right: 1px solid var(--line-2); font-weight: 600; }
     .density-bar button:last-child { border-right: none; }
-    .density-bar button.on { background: rgb(var(--brass-glow)/.1); color: var(--brass-1); box-shadow: inset 0 -2px 0 var(--brass-1); }
+    .density-bar button.on { background: rgb(var(--color-accent-glow)/.1); color: var(--brass-1); box-shadow: inset 0 -2px 0 var(--brass-1); }
     .comfy .lane { height: 38px; }
     .compact .lane { height: 22px; }
     .tiny .lane { height: 14px; border-bottom-style: solid; border-bottom-color: var(--line-1); }
     .tiny .lane-name { font-size: 9px; }
     .tiny .tick { height: 6px; }
 
-    .row { display:flex; gap:6px; align-items:center; margin-top: 6px; flex-wrap:wrap; font-family: var(--font-mono); font-size:10px; color: var(--fg-4); }
+    .row { display:flex; gap:6px; align-items:center; margin-top: 6px; flex-wrap:wrap; font-family: var(--font-mono); font-size:10px; color: var(--color-fg-disabled); }
 
     /* chip primitives if primitives.css doesn't load them */
     .chip { display:inline-flex; align-items:center; padding: 2px 8px; font-family: var(--font-mono); font-size: 10px; background: var(--bg-2); border: 1px solid var(--line-2); color: var(--fg-2); border-radius: 999px; letter-spacing: .04em; }
@@ -135,7 +135,7 @@
           <div class="empty-slate">
             <div class="big">∅</div>
             <div style="margin-top:6px">no keepers registered</div>
-            <div style="color:var(--fg-4); margin-top:4px; font-size:10px;">spawn a keeper to begin · <span style="color:var(--brass-1)">⌘K</span> then "spawn keeper"</div>
+            <div style="color:var(--color-fg-disabled); margin-top:4px; font-size:10px;">spawn a keeper to begin · <span style="color:var(--brass-1)">⌘K</span> then "spawn keeper"</div>
             <div class="action">+ SPAWN KEEPER</div>
           </div>
         </div>
@@ -151,12 +151,12 @@
         <div class="sw-head"><span>CASCADE · goal-merge-blockers</span><div class="sw-ruler"><span>t+0s</span><span>t+0.4s</span><span>t+0.8s</span><span>t+1.2s</span></div></div>
         <div class="sw-body">
           <div class="lane"><span class="lane-name" style="color:var(--brass-1)"><span class="dot"></span>router</span><div class="lane-track"><span class="span run d1"></span></div></div>
-          <div class="lane"><span class="lane-name" style="color:var(--info)"><span class="dot"></span>moonshot</span><div class="lane-track"><span class="span run d2"></span></div></div>
-          <div class="lane"><span class="lane-name" style="color:var(--ok)"><span class="dot"></span>guard</span><div class="lane-track"><span class="span run d3"></span></div></div>
+          <div class="lane"><span class="lane-name" style="color:var(--color-status-info)"><span class="dot"></span>moonshot</span><div class="lane-track"><span class="span run d2"></span></div></div>
+          <div class="lane"><span class="lane-name" style="color:var(--color-status-ok)"><span class="dot"></span>guard</span><div class="lane-track"><span class="span run d3"></span></div></div>
           <div class="lane"><span class="lane-name" style="color:var(--brass-2)"><span class="dot"></span>commit</span><div class="lane-track"><span class="span run d4"></span></div></div>
           <div class="now" style="left: 96%"></div>
         </div>
-        <div style="padding: 4px 10px; font-family:var(--font-mono); font-size:10px; color:var(--fg-4); background:var(--bg-1); border-top:1px solid var(--line-1);">total 1.24s · critical path: moonshot (320ms) → guard (210ms)</div>
+        <div style="padding: 4px 10px; font-family:var(--font-mono); font-size:10px; color:var(--color-fg-disabled); background:var(--bg-1); border-top:1px solid var(--line-1);">total 1.24s · critical path: moonshot (320ms) → guard (210ms)</div>
       </div>
     </div>
 
@@ -178,13 +178,13 @@
               </span>
             </div>
           </div>
-          <div class="lane"><span class="lane-name" style="color:var(--ok)"><span class="dot"></span>sangsu</span>
+          <div class="lane"><span class="lane-name" style="color:var(--color-status-ok)"><span class="dot"></span>sangsu</span>
             <div class="lane-track">
-              <span class="span run" style="left: 42%; width: 26%; background: linear-gradient(90deg, rgb(107 158 107 / .4), rgb(107 158 107 / .1)); border-color: var(--ok);"></span>
+              <span class="span run" style="left: 42%; width: 26%; background: linear-gradient(90deg, rgb(107 158 107 / .4), rgb(107 158 107 / .1)); border-color: var(--color-status-ok);"></span>
               <span class="tick approve" style="left: 66%; width:4px"></span>
-              <span class="handoff" style="left: 68%; width: 20px; --brass-1: var(--ok); --brass-2: var(--ok);">
-                <span class="handoff-label" style="color: var(--ok-fg); border-color: var(--ok)">→ APPROVE</span>
-                <span class="ah" style="background: var(--ok)"></span>
+              <span class="handoff" style="left: 68%; width: 20px; --brass-1: var(--color-status-ok); --brass-2: var(--color-status-ok);">
+                <span class="handoff-label" style="color: var(--ok-fg); border-color: var(--color-status-ok)">→ APPROVE</span>
+                <span class="ah" style="background: var(--color-status-ok)"></span>
               </span>
             </div>
           </div>
@@ -223,31 +223,31 @@
           <div class="group-bar">
             <span class="group-name"><span class="chev">▾</span>reviewers <span class="cnt">12</span></span>
             <div class="group-stack">
-              <span class="mini" style="left: 10%; width: 18%; background: var(--info)"></span>
-              <span class="mini" style="left: 30%; width: 22%; background: var(--info)"></span>
-              <span class="mini" style="left: 70%; width: 14%; background: var(--info)"></span>
-              <span class="mini" style="left: 88%; width: 6%; background: var(--info)"></span>
+              <span class="mini" style="left: 10%; width: 18%; background: var(--color-status-info)"></span>
+              <span class="mini" style="left: 30%; width: 22%; background: var(--color-status-info)"></span>
+              <span class="mini" style="left: 70%; width: 14%; background: var(--color-status-info)"></span>
+              <span class="mini" style="left: 88%; width: 6%; background: var(--color-status-info)"></span>
               <div class="summary">
-                <span class="chip-mini" style="color:var(--ok-fg); border-color:var(--ok)">8 approved</span>
-                <span class="chip-mini" style="color:var(--err-fg); border-color:var(--err)">3 flagged</span>
+                <span class="chip-mini" style="color:var(--ok-fg); border-color:var(--color-status-ok)">8 approved</span>
+                <span class="chip-mini" style="color:var(--err-fg); border-color:var(--color-status-err)">3 flagged</span>
               </div>
             </div>
           </div>
           <div class="group-bar">
             <span class="group-name"><span class="chev">▾</span>ci/cd <span class="cnt">8</span></span>
             <div class="group-stack">
-              <span class="mini" style="left: 2%; width: 94%; background: var(--ok); height:2px; top: 8px;"></span>
+              <span class="mini" style="left: 2%; width: 94%; background: var(--color-status-ok); height:2px; top: 8px;"></span>
               <div class="summary">
-                <span class="chip-mini" style="color:var(--ok-fg); border-color:var(--ok)">healthy · 1.4s ping</span>
+                <span class="chip-mini" style="color:var(--ok-fg); border-color:var(--color-status-ok)">healthy · 1.4s ping</span>
               </div>
             </div>
           </div>
           <div class="group-bar" style="background: rgba(196 106 90 / .05); border-bottom: none;">
             <span class="group-name" style="color: var(--err-fg)"><span class="chev">▸</span>stalled <span class="cnt">4</span></span>
             <div class="group-stack">
-              <span class="mini" style="left: 10%; width: 70%; background: var(--stalled); opacity: .6"></span>
+              <span class="mini" style="left: 10%; width: 70%; background: var(--color-status-stalled); opacity: .6"></span>
               <div class="summary">
-                <span class="chip-mini" style="color:var(--err-fg); border-color:var(--err)">&gt; 12m no heartbeat</span>
+                <span class="chip-mini" style="color:var(--err-fg); border-color:var(--color-status-err)">&gt; 12m no heartbeat</span>
               </div>
             </div>
           </div>
@@ -267,13 +267,13 @@
           <div class="sw-head"><span>COMPACT · default · 22px</span><div class="sw-ruler"><span>-60s</span><span>-30</span><span>NOW</span></div></div>
           <div class="sw-body">
             <div class="lane"><span class="lane-name" style="color:var(--brass-1)"><span class="dot"></span>nick0cave</span><div class="lane-track"><span class="span run" style="left:12%; width:18%"></span><span class="tick emit" style="left:35%; width:3px"></span><span class="span run" style="left:40%; width:35%"></span><span class="tick commit" style="left:92%; width:3px"></span></div></div>
-            <div class="lane"><span class="lane-name" style="color:var(--ok)"><span class="dot"></span>sangsu</span><div class="lane-track"><span class="tick approve" style="left:20%; width:3px"></span><span class="span run" style="left:45%; width:22%; border-color: var(--ok); background: linear-gradient(90deg, rgb(107 158 107 / .3), transparent)"></span><span class="tick approve" style="left:70%; width:3px"></span></div></div>
-            <div class="lane"><span class="lane-name" style="color:var(--err)"><span class="dot"></span>qa-king</span><div class="lane-track"><span class="tick flag" style="left:28%; width:3px"></span><span class="tick flag" style="left:58%; width:3px"></span><span class="tick flag" style="left:85%; width:3px"></span></div></div>
-            <div class="lane"><span class="lane-name" style="color:var(--stalled)"><span class="dot"></span>rama</span><div class="lane-track"><span class="span stall" style="left:8%; width:80%"></span></div></div>
+            <div class="lane"><span class="lane-name" style="color:var(--color-status-ok)"><span class="dot"></span>sangsu</span><div class="lane-track"><span class="tick approve" style="left:20%; width:3px"></span><span class="span run" style="left:45%; width:22%; border-color: var(--color-status-ok); background: linear-gradient(90deg, rgb(107 158 107 / .3), transparent)"></span><span class="tick approve" style="left:70%; width:3px"></span></div></div>
+            <div class="lane"><span class="lane-name" style="color:var(--color-status-err)"><span class="dot"></span>qa-king</span><div class="lane-track"><span class="tick flag" style="left:28%; width:3px"></span><span class="tick flag" style="left:58%; width:3px"></span><span class="tick flag" style="left:85%; width:3px"></span></div></div>
+            <div class="lane"><span class="lane-name" style="color:var(--color-status-stalled)"><span class="dot"></span>rama</span><div class="lane-track"><span class="span stall" style="left:8%; width:80%"></span></div></div>
             <div class="now" style="left:96%"></div>
           </div>
         </div>
-        <div class="row"><span>+ tick legend ·</span><span style="color:var(--brass-1)">◆ emit</span><span style="color:var(--info)">◆ tool</span><span style="color:var(--ok)">◆ approve</span><span style="color:var(--err)">◆ flag</span><span style="color:var(--brass-2)">◆ commit</span></div>
+        <div class="row"><span>+ tick legend ·</span><span style="color:var(--brass-1)">◆ emit</span><span style="color:var(--color-status-info)">◆ tool</span><span style="color:var(--color-status-ok)">◆ approve</span><span style="color:var(--color-status-err)">◆ flag</span><span style="color:var(--brass-2)">◆ commit</span></div>
       </div>
     </div>
 
@@ -285,7 +285,7 @@
         <div class="sw-head"><span>COMFY · hero · 38px</span><div class="sw-ruler"><span>-60s</span><span>-30</span><span>NOW</span></div></div>
         <div class="sw-body">
           <div class="lane"><span class="lane-name" style="color:var(--brass-1)"><span class="dot"></span>nick0cave</span><div class="lane-track"><span class="span run" style="left:12%; width:18%; height:10px"></span><span class="tick emit" style="left:35%; width:5px; height:12px"></span><span class="span run" style="left:40%; width:35%; height:10px"></span><span class="tick commit" style="left:92%; width:4px; height:18px"></span></div></div>
-          <div class="lane"><span class="lane-name" style="color:var(--ok)"><span class="dot"></span>sangsu</span><div class="lane-track"><span class="tick approve" style="left:20%; width:5px; height:12px"></span><span class="span run" style="left:45%; width:22%; height:10px; border-color: var(--ok); background: linear-gradient(90deg, rgb(107 158 107 / .4), transparent)"></span><span class="tick approve" style="left:70%; width:5px; height:12px"></span></div></div>
+          <div class="lane"><span class="lane-name" style="color:var(--color-status-ok)"><span class="dot"></span>sangsu</span><div class="lane-track"><span class="tick approve" style="left:20%; width:5px; height:12px"></span><span class="span run" style="left:45%; width:22%; height:10px; border-color: var(--color-status-ok); background: linear-gradient(90deg, rgb(107 158 107 / .4), transparent)"></span><span class="tick approve" style="left:70%; width:5px; height:12px"></span></div></div>
           <div class="now" style="left:96%"></div>
         </div>
       </div>
@@ -299,10 +299,10 @@
         <div class="sw-head"><span>TINY · rail · 14px</span><div class="sw-ruler"><span>-60</span><span>NOW</span></div></div>
         <div class="sw-body">
           <div class="lane"><span class="lane-name" style="color:var(--brass-1)"><span class="dot"></span>nick</span><div class="lane-track"><span class="span run" style="left:10%; width:65%; height: 4px;"></span><span class="tick commit" style="left:92%; width:2px"></span></div></div>
-          <div class="lane"><span class="lane-name" style="color:var(--ok)"><span class="dot"></span>ss</span><div class="lane-track"><span class="tick approve" style="left:20%; width:2px"></span><span class="tick approve" style="left:70%; width:2px"></span></div></div>
-          <div class="lane"><span class="lane-name" style="color:var(--info)"><span class="dot"></span>m-imp</span><div class="lane-track"><span class="tick tool" style="left:15%; width:2px"></span><span class="tick tool" style="left:40%; width:2px"></span><span class="tick tool" style="left:65%; width:2px"></span></div></div>
-          <div class="lane"><span class="lane-name" style="color:var(--err)"><span class="dot"></span>qa</span><div class="lane-track"><span class="tick flag" style="left:28%; width:2px"></span><span class="tick flag" style="left:85%; width:2px"></span></div></div>
-          <div class="lane"><span class="lane-name" style="color:var(--stalled)"><span class="dot"></span>rama</span><div class="lane-track"><span class="span stall" style="left:8%; width:80%; height: 3px;"></span></div></div>
+          <div class="lane"><span class="lane-name" style="color:var(--color-status-ok)"><span class="dot"></span>ss</span><div class="lane-track"><span class="tick approve" style="left:20%; width:2px"></span><span class="tick approve" style="left:70%; width:2px"></span></div></div>
+          <div class="lane"><span class="lane-name" style="color:var(--color-status-info)"><span class="dot"></span>m-imp</span><div class="lane-track"><span class="tick tool" style="left:15%; width:2px"></span><span class="tick tool" style="left:40%; width:2px"></span><span class="tick tool" style="left:65%; width:2px"></span></div></div>
+          <div class="lane"><span class="lane-name" style="color:var(--color-status-err)"><span class="dot"></span>qa</span><div class="lane-track"><span class="tick flag" style="left:28%; width:2px"></span><span class="tick flag" style="left:85%; width:2px"></span></div></div>
+          <div class="lane"><span class="lane-name" style="color:var(--color-status-stalled)"><span class="dot"></span>rama</span><div class="lane-track"><span class="span stall" style="left:8%; width:80%; height: 3px;"></span></div></div>
           <div class="now" style="left:96%"></div>
         </div>
       </div>

--- a/dashboard/design-system/preview/tokrate.html
+++ b/dashboard/design-system/preview/tokrate.html
@@ -10,30 +10,30 @@
   <style>
     html, body { margin:0; background: var(--bg-0); color: var(--fg-1); font-family: var(--font-sans); min-height: 100vh; }
     .page { max-width: 1180px; margin:0 auto; padding: 32px 32px 96px; }
-    .back { font: var(--type-micro); color: var(--fg-4); text-decoration:none; letter-spacing: .08em; display:inline-block; margin-bottom:20px; }
+    .back { font: var(--type-micro); color: var(--color-fg-disabled); text-decoration:none; letter-spacing: .08em; display:inline-block; margin-bottom:20px; }
     .back:hover { color: var(--fg-2); }
     h1 { font-family: var(--font-mono); font-size: 18px; font-weight: 600; margin: 0 0 4px; }
     .sub { color: var(--fg-3); font-size: 12px; margin-bottom: 28px; line-height:1.5; max-width: 700px; }
     h2 { font: var(--type-label); text-transform: uppercase; letter-spacing: .08em; color: var(--fg-3); font-weight: 600; font-size: 11px; margin: 28px 0 8px; padding-bottom: 6px; border-bottom: 1px solid var(--line-2); }
     h2 .tag { margin-left: 8px; color: var(--brass-1); font-weight: 500; }
-    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); }
+    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled); }
 
     .seg { background: var(--bg-1); border: 1px solid var(--line-1); border-radius: var(--r-1); padding: 16px; margin-bottom: 10px; }
     .seg .meta { font-family: var(--font-mono); font-size: 11px; color: var(--fg-3); line-height: 1.5; margin-bottom: 12px; }
     .seg .meta .n { color: var(--fg-1); font-weight:600; font-size: 13px; margin-right: 10px; }
-    .seg .meta .code { color: var(--fg-4); font-size: 10px; }
+    .seg .meta .code { color: var(--color-fg-disabled); font-size: 10px; }
 
     /* ── KPI CHIP ── */
     .kpi { display:grid; grid-template-columns: 1fr auto; grid-template-rows: auto auto; align-items:center; column-gap: 12px; row-gap: 0; padding: 8px 14px 9px 12px; background: var(--bg-2); border: 1px solid var(--line-2); border-left: 2px solid var(--brass-1); border-radius: var(--r-1); min-width: 0; overflow: hidden; }
-    .kpi.is-ok { border-left-color: var(--ok); }
-    .kpi.is-warn { border-left-color: var(--warn); }
+    .kpi.is-ok { border-left-color: var(--color-status-ok); }
+    .kpi.is-warn { border-left-color: var(--color-status-warn); }
     .kpi .label { grid-column: 1; grid-row: 1; font-family: var(--font-mono); font-size: 9px; letter-spacing: .08em; color: var(--fg-3); text-transform: uppercase; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-    .kpi .value { grid-column: 1; grid-row: 2; font-family: var(--font-mono); font-size: 22px; color: var(--brass-1); font-variant-numeric: tabular-nums; font-weight: 500; text-shadow: 0 0 6px rgb(var(--brass-glow)/.3); letter-spacing: -.02em; line-height: 1.05; white-space: nowrap; }
+    .kpi .value { grid-column: 1; grid-row: 2; font-family: var(--font-mono); font-size: 22px; color: var(--brass-1); font-variant-numeric: tabular-nums; font-weight: 500; text-shadow: 0 0 6px rgb(var(--color-accent-glow)/.3); letter-spacing: -.02em; line-height: 1.05; white-space: nowrap; }
     .kpi.is-ok .value { color: var(--ok-fg); text-shadow: 0 0 6px rgb(var(--ok-glow)/.25); }
-    .kpi.is-warn .value { color: var(--warn); text-shadow: 0 0 6px rgb(var(--warn-glow)/.25); }
+    .kpi.is-warn .value { color: var(--color-status-warn); text-shadow: 0 0 6px rgb(var(--warn-glow)/.25); }
     .kpi .unit { font-size: 10px; color: var(--fg-3); margin-left: 3px; font-weight: 400; }
     .kpi .delta { grid-column: 2; grid-row: 1 / 3; align-self: center; display:flex; flex-direction:column; align-items:flex-end; gap: 3px; font-family: var(--font-mono); font-size: 9px; }
-    .kpi .delta .d { font-size: 10px; color: var(--ok); white-space: nowrap; }
+    .kpi .delta .d { font-size: 10px; color: var(--color-status-ok); white-space: nowrap; }
     .kpi .delta .d.neg { color: var(--err-fg); }
     .kpi .delta .spark { display:flex; gap: 1px; align-items: flex-end; height: 16px; }
     .kpi .delta .spark span { display:block; width: 2px; background: currentColor; border-radius: 1px; opacity: .7; }
@@ -46,20 +46,20 @@
     .dial { position: relative; width: 200px; height: 200px; }
     .dial svg { width: 100%; height: 100%; transform: rotate(-210deg); display:block; overflow: visible; }
     .dial .tl { position:absolute; inset: 0; display:flex; flex-direction:column; align-items:center; justify-content:center; text-align: center; padding: 0 20px; }
-    .dial .tl .big { font-family: var(--font-mono); font-size: 26px; font-variant-numeric: tabular-nums; color: var(--brass-1); text-shadow: 0 0 10px rgb(var(--brass-glow)/.5); letter-spacing: -.02em; line-height: 1; white-space: nowrap; }
+    .dial .tl .big { font-family: var(--font-mono); font-size: 26px; font-variant-numeric: tabular-nums; color: var(--brass-1); text-shadow: 0 0 10px rgb(var(--color-accent-glow)/.5); letter-spacing: -.02em; line-height: 1; white-space: nowrap; }
     .dial .tl .lil { font-family: var(--font-mono); font-size: 9px; color: var(--fg-3); letter-spacing: .08em; text-transform: uppercase; margin-top: 4px; }
-    .dial .tl .mic { font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .04em; margin-top: 8px; white-space: nowrap; }
+    .dial .tl .mic { font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .04em; margin-top: 8px; white-space: nowrap; }
 
     .dial-detail { display:flex; flex-direction:column; gap: 2px; font-family: var(--font-mono); font-size: 11px; color: var(--fg-2); min-width: 0; }
     .dial-detail .row { display:grid; grid-template-columns: 110px auto 1fr; align-items:baseline; gap: 10px; padding: 5px 0; border-bottom: 1px dashed var(--line-1); }
     .dial-detail .row:last-child { border-bottom: none; }
-    .dial-detail .row .k { color: var(--fg-4); font-size: 9px; letter-spacing: .06em; text-transform: uppercase; white-space: nowrap; }
+    .dial-detail .row .k { color: var(--color-fg-disabled); font-size: 9px; letter-spacing: .06em; text-transform: uppercase; white-space: nowrap; }
     .dial-detail .row .v { color: var(--fg-1); font-variant-numeric: tabular-nums; white-space: nowrap; }
-    .dial-detail .row .x { color: var(--fg-4); font-size: 10px; text-align: right; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .dial-detail .row .x { color: var(--color-fg-disabled); font-size: 10px; text-align: right; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 
     /* ── PROVIDER TABLE ── */
     .prov { width:100%; border-collapse: collapse; font-family: var(--font-mono); font-size: 11px; }
-    .prov th { text-align: left; padding: 6px 10px; font-size: 9px; letter-spacing: .08em; color: var(--fg-4); text-transform: uppercase; font-weight: 600; border-bottom: 1px solid var(--line-2); }
+    .prov th { text-align: left; padding: 6px 10px; font-size: 9px; letter-spacing: .08em; color: var(--color-fg-disabled); text-transform: uppercase; font-weight: 600; border-bottom: 1px solid var(--line-2); }
     .prov th:last-child, .prov td:last-child { text-align: right; }
     .prov td { padding: 6px 10px; border-bottom: 1px solid var(--line-1); color: var(--fg-2); font-variant-numeric: tabular-nums; }
     .prov tr:last-child td { border-bottom: none; }
@@ -67,12 +67,12 @@
     .prov .pname { color: var(--brass-1); font-weight: 500; }
     .prov .status { display:inline-flex; align-items:center; gap: 5px; }
     .prov .status .d { width: 5px; height: 5px; border-radius: 50%; }
-    .prov .status.ok .d { background: var(--ok); box-shadow: 0 0 4px rgb(var(--ok-glow)/.7); }
-    .prov .status.slow .d { background: var(--warn); box-shadow: 0 0 4px rgb(var(--warn-glow)/.7); }
-    .prov .status.down .d { background: var(--err); box-shadow: 0 0 4px rgb(var(--err-glow)/.7); }
+    .prov .status.ok .d { background: var(--color-status-ok); box-shadow: 0 0 4px rgb(var(--ok-glow)/.7); }
+    .prov .status.slow .d { background: var(--color-status-warn); box-shadow: 0 0 4px rgb(var(--warn-glow)/.7); }
+    .prov .status.down .d { background: var(--color-status-err); box-shadow: 0 0 4px rgb(var(--err-glow)/.7); }
     .prov .mbar { display:inline-flex; align-items:center; gap: 6px; }
     .prov .mbar .b { width: 80px; height: 5px; background: var(--bg-3); border-radius: 999px; overflow: hidden; }
-    .prov .mbar .b::after { content:''; display:block; height:100%; background: var(--brass-1); width: var(--w); box-shadow: 0 0 6px rgb(var(--brass-glow)/.6); border-radius: 999px; }
+    .prov .mbar .b::after { content:''; display:block; height:100%; background: var(--brass-1); width: var(--w); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.6); border-radius: 999px; }
 
     /* ── SPARKLINE CARD ── */
     .spark-card { background: var(--bg-2); border: 1px solid var(--line-2); border-radius: var(--r-1); padding: 10px 12px; display: grid; grid-template-columns: 1fr auto; gap: 4px 16px; align-items: end; }
@@ -80,30 +80,30 @@
     .spark-card .val { grid-column: 2 / 3; font-family: var(--font-mono); font-size: 14px; color: var(--brass-1); font-variant-numeric: tabular-nums; }
     .spark-card svg { grid-column: 1 / -1; width: 100%; height: 40px; }
     .spark-card .baseline { stroke: var(--line-2); stroke-dasharray: 2 3; }
-    .spark-card .line { stroke: var(--brass-1); stroke-width: 1.4; fill: none; filter: drop-shadow(0 0 2px rgb(var(--brass-glow)/.6)); }
+    .spark-card .line { stroke: var(--brass-1); stroke-width: 1.4; fill: none; filter: drop-shadow(0 0 2px rgb(var(--color-accent-glow)/.6)); }
     .spark-card .fill { fill: url(#sf-grad); }
 
     /* ── STREAMING CURSOR ── */
     .stream { background: var(--bg-0); border: 1px solid var(--line-1); border-radius: var(--r-1); padding: 36px 16px 14px; font-family: var(--font-mono); font-size: 11px; color: var(--fg-2); line-height: 1.6; min-height: 80px; position: relative; white-space: pre-wrap; }
     .stream .out { color: var(--fg-1); }
-    .stream .partial { color: var(--fg-2); background: rgb(var(--brass-glow)/.08); padding: 0 2px; border-radius: 1px; }
-    .stream .cursor { display:inline-block; width: 7px; height: 12px; background: var(--brass-1); box-shadow: 0 0 6px rgb(var(--brass-glow)/.8); vertical-align: -2px; animation: blink 1s step-end infinite; }
+    .stream .partial { color: var(--fg-2); background: rgb(var(--color-accent-glow)/.08); padding: 0 2px; border-radius: 1px; }
+    .stream .cursor { display:inline-block; width: 7px; height: 12px; background: var(--brass-1); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.8); vertical-align: -2px; animation: blink 1s step-end infinite; }
     @keyframes blink { 50% { opacity: 0; } }
-    .stream-hud { position:absolute; top: 8px; right: 12px; display: flex; gap: 12px; font-family: var(--font-mono); font-size: 9px; letter-spacing: .06em; text-transform: uppercase; color: var(--fg-4); }
+    .stream-hud { position:absolute; top: 8px; right: 12px; display: flex; gap: 12px; font-family: var(--font-mono); font-size: 9px; letter-spacing: .06em; text-transform: uppercase; color: var(--color-fg-disabled); }
     .stream-hud .v { color: var(--brass-1); }
 
     /* ── BUDGET ── */
     .budget { display:flex; align-items: center; gap: 12px; font-family: var(--font-mono); font-size: 11px; color: var(--fg-2); }
     .budget .bar-track { flex: 1; height: 8px; background: var(--bg-3); border-radius: 999px; overflow: hidden; position: relative; border: 1px solid var(--line-1); }
-    .budget .bar-fill { height:100%; background: linear-gradient(90deg, var(--ok) 0%, var(--warn) 70%, var(--err) 95%); box-shadow: 0 0 8px rgb(var(--brass-glow)/.4); border-radius: 999px; transition: width .3s; }
-    .budget .bar-mark { position:absolute; top: -2px; width: 1px; height: 12px; background: var(--fg-4); }
+    .budget .bar-fill { height:100%; background: linear-gradient(90deg, var(--color-status-ok) 0%, var(--color-status-warn) 70%, var(--color-status-err) 95%); box-shadow: 0 0 8px rgb(var(--color-accent-glow)/.4); border-radius: 999px; transition: width .3s; }
+    .budget .bar-mark { position:absolute; top: -2px; width: 1px; height: 12px; background: var(--color-fg-disabled); }
 
     .row { display:flex; gap: 8px; align-items:center; flex-wrap: wrap; }
 
     /* chip primitives if not loaded */
     .chip { display:inline-flex; align-items:center; padding: 2px 8px; font-family: var(--font-mono); font-size: 10px; background: var(--bg-2); border: 1px solid var(--line-2); color: var(--fg-2); border-radius: 999px; letter-spacing: .04em; flex-shrink: 0; }
-    .chip.is-brass { color: var(--brass-1); border-color: var(--brass-2); background: rgb(var(--brass-glow)/.08); }
-    .chip.is-err   { color: var(--err-fg); border-color: var(--err); background: rgb(var(--err-glow)/.08); }
+    .chip.is-brass { color: var(--brass-1); border-color: var(--brass-2); background: rgb(var(--color-accent-glow)/.08); }
+    .chip.is-err   { color: var(--err-fg); border-color: var(--color-status-err); background: rgb(var(--err-glow)/.08); }
 
     @media (max-width: 880px) {
       .dial-wrap { grid-template-columns: 1fr; }
@@ -127,7 +127,7 @@
         <div class="kpi">
           <span class="label">tok/s · fleet</span>
           <span class="value">2,847<span class="unit">t/s</span></span>
-          <span class="delta"><span class="d">+412</span><span class="spark"><span style="height:40%"></span><span style="height:55%"></span><span style="height:45%"></span><span style="height:70%"></span><span style="height:85%"></span><span style="height:75%"></span><span style="height:100%; background: var(--brass-1); box-shadow: 0 0 4px rgb(var(--brass-glow))"></span></span></span>
+          <span class="delta"><span class="d">+412</span><span class="spark"><span style="height:40%"></span><span style="height:55%"></span><span style="height:45%"></span><span style="height:70%"></span><span style="height:85%"></span><span style="height:75%"></span><span style="height:100%; background: var(--brass-1); box-shadow: 0 0 4px rgb(var(--color-accent-glow))"></span></span></span>
         </div>
         <div class="kpi is-ok">
           <span class="label">tok/s · nick0cave</span>
@@ -137,7 +137,7 @@
         <div class="kpi is-warn">
           <span class="label">ttft (p95)</span>
           <span class="value">820<span class="unit">ms</span></span>
-          <span class="delta"><span class="d neg">+140</span><span class="spark" style="color: var(--warn)"><span style="height:35%"></span><span style="height:40%"></span><span style="height:45%"></span><span style="height:52%"></span><span style="height:68%"></span><span style="height:78%"></span><span style="height:90%"></span></span></span>
+          <span class="delta"><span class="d neg">+140</span><span class="spark" style="color: var(--color-status-warn)"><span style="height:35%"></span><span style="height:40%"></span><span style="height:45%"></span><span style="height:52%"></span><span style="height:68%"></span><span style="height:78%"></span><span style="height:90%"></span></span></span>
         </div>
         <div class="kpi">
           <span class="label">context · fleet avg</span>
@@ -157,15 +157,15 @@
           <svg viewBox="0 0 100 100">
             <defs>
               <linearGradient id="dial-grad" x1="0" y1="0" x2="1" y2="1">
-                <stop offset="0%" stop-color="var(--brass-3)"/>
+                <stop offset="0%" stop-color="var(--color-accent-fg-dim)"/>
                 <stop offset="100%" stop-color="var(--brass-1)"/>
               </linearGradient>
               <filter id="dial-glow" x="-20%" y="-20%" width="140%" height="140%"><feGaussianBlur stdDeviation="1.2"/><feComponentTransfer><feFuncA type="linear" slope="1.2"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
             </defs>
             <circle cx="50" cy="50" r="40" fill="none" stroke="var(--bg-3)" stroke-width="7" stroke-linecap="round" stroke-dasharray="167.55 251.33" />
-            <circle cx="50" cy="50" r="40" fill="none" stroke="var(--warn)" stroke-width="2" stroke-linecap="round" stroke-dasharray="4 251.33" stroke-dashoffset="-110" opacity=".6" />
+            <circle cx="50" cy="50" r="40" fill="none" stroke="var(--color-status-warn)" stroke-width="2" stroke-linecap="round" stroke-dasharray="4 251.33" stroke-dashoffset="-110" opacity=".6" />
             <circle cx="50" cy="50" r="40" fill="none" stroke="url(#dial-grad)" stroke-width="7" stroke-linecap="round" stroke-dasharray="120 251.33" filter="url(#dial-glow)" />
-            <g stroke="var(--fg-4)" stroke-width=".7" fill="none">
+            <g stroke="var(--color-fg-disabled)" stroke-width=".7" fill="none">
               <line x1="10" y1="50" x2="16" y2="50"/>
               <line x1="50" y1="10" x2="50" y2="16" transform="rotate(60 50 50)"/>
               <line x1="50" y1="10" x2="50" y2="16" transform="rotate(120 50 50)"/>
@@ -184,7 +184,7 @@
           <div class="row"><span class="k">current</span><span class="v">2,847 t/s</span><span class="x" style="color:var(--ok-fg)">↑ +412 · 30s</span></div>
           <div class="row"><span class="k">p95</span><span class="v">3,412 t/s</span><span class="x">peak 16:28:44</span></div>
           <div class="row"><span class="k">p50</span><span class="v">2,105 t/s</span><span class="x"></span></div>
-          <div class="row"><span class="k">ttft (p95)</span><span class="v" style="color:var(--warn)">820 ms</span><span class="x"></span></div>
+          <div class="row"><span class="k">ttft (p95)</span><span class="v" style="color:var(--color-status-warn)">820 ms</span><span class="x"></span></div>
           <div class="row"><span class="k">context used</span><span class="v">92.4k / 128k</span><span class="x" style="color:var(--brass-1)">72%</span></div>
           <div class="row"><span class="k">cost · hour</span><span class="v">$1.47</span><span class="x">moonshot@2</span></div>
         </div>
@@ -201,7 +201,7 @@
           <span class="label">tok/s · fleet</span>
           <span class="val">2,847</span>
           <svg viewBox="0 0 240 40" preserveAspectRatio="none">
-            <defs><linearGradient id="sf-grad" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="rgb(var(--brass-glow))" stop-opacity=".4"/><stop offset="100%" stop-color="rgb(var(--brass-glow))" stop-opacity="0"/></linearGradient></defs>
+            <defs><linearGradient id="sf-grad" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="rgb(var(--color-accent-glow))" stop-opacity=".4"/><stop offset="100%" stop-color="rgb(var(--color-accent-glow))" stop-opacity="0"/></linearGradient></defs>
             <path d="M 0 30 L 0 28 C 20 26, 30 22, 40 24 C 50 26, 60 18, 75 20 C 90 22, 100 14, 115 12 C 130 10, 145 18, 160 14 C 175 10, 190 6, 210 8 C 225 9, 240 4, 240 4 L 240 40 L 0 40 Z" class="fill"/>
             <path d="M 0 28 C 20 26, 30 22, 40 24 C 50 26, 60 18, 75 20 C 90 22, 100 14, 115 12 C 130 10, 145 18, 160 14 C 175 10, 190 6, 210 8 C 225 9, 240 4, 240 4" class="line"/>
             <line x1="0" y1="22" x2="240" y2="22" class="baseline"/>
@@ -209,17 +209,17 @@
         </div>
         <div class="spark-card">
           <span class="label">ttft · p95</span>
-          <span class="val" style="color:var(--warn)">820ms</span>
+          <span class="val" style="color:var(--color-status-warn)">820ms</span>
           <svg viewBox="0 0 240 40" preserveAspectRatio="none">
             <path d="M 0 30 C 30 32, 60 30, 90 24 C 120 18, 150 14, 180 10 C 200 8, 220 6, 240 4 L 240 40 L 0 40 Z" fill="rgb(201 162 74 / .12)"/>
-            <path d="M 0 30 C 30 32, 60 30, 90 24 C 120 18, 150 14, 180 10 C 200 8, 220 6, 240 4" stroke="var(--warn)" fill="none" stroke-width="1.4"/>
+            <path d="M 0 30 C 30 32, 60 30, 90 24 C 120 18, 150 14, 180 10 C 200 8, 220 6, 240 4" stroke="var(--color-status-warn)" fill="none" stroke-width="1.4"/>
           </svg>
         </div>
         <div class="spark-card">
           <span class="label">cost · $/hr</span>
           <span class="val">1.47</span>
           <svg viewBox="0 0 240 40" preserveAspectRatio="none">
-            <path d="M 0 26 L 20 24 L 40 28 L 60 22 L 80 25 L 100 18 L 120 20 L 140 14 L 160 16 L 180 12 L 200 14 L 220 10 L 240 8 L 240 40 L 0 40 Z" fill="rgb(var(--brass-glow)/.12)"/>
+            <path d="M 0 26 L 20 24 L 40 28 L 60 22 L 80 25 L 100 18 L 120 20 L 140 14 L 160 16 L 180 12 L 200 14 L 220 10 L 240 8 L 240 40 L 0 40 Z" fill="rgb(var(--color-accent-glow)/.12)"/>
             <path d="M 0 26 L 20 24 L 40 28 L 60 22 L 80 25 L 100 18 L 120 20 L 140 14 L 160 16 L 180 12 L 200 14 L 220 10 L 240 8" stroke="var(--brass-1)" fill="none" stroke-width="1.4"/>
           </svg>
         </div>
@@ -236,12 +236,12 @@
           <tr><th>provider</th><th>model</th><th>status</th><th>tok/s</th><th>ttft</th><th>ctx</th><th>$/1k</th><th>share · fleet</th></tr>
         </thead>
         <tbody>
-          <tr><td class="pname">moonshot</td><td>kimi-k2</td><td><span class="status ok"><span class="d"></span>healthy</span></td><td style="color:var(--brass-1); text-shadow: 0 0 4px rgb(var(--brass-glow)/.4)">1,412</td><td>610ms</td><td>84k/128k</td><td>$.0080</td><td><span class="mbar"><span class="b" style="--w:62%"></span>49.6%</span></td></tr>
+          <tr><td class="pname">moonshot</td><td>kimi-k2</td><td><span class="status ok"><span class="d"></span>healthy</span></td><td style="color:var(--brass-1); text-shadow: 0 0 4px rgb(var(--color-accent-glow)/.4)">1,412</td><td>610ms</td><td>84k/128k</td><td>$.0080</td><td><span class="mbar"><span class="b" style="--w:62%"></span>49.6%</span></td></tr>
           <tr><td class="pname">anthropic</td><td>claude-sonnet-4.5</td><td><span class="status ok"><span class="d"></span>healthy</span></td><td style="color:var(--brass-1)">684</td><td>720ms</td><td>48k/200k</td><td>$.0120</td><td><span class="mbar"><span class="b" style="--w:32%"></span>24.0%</span></td></tr>
-          <tr><td class="pname">openai</td><td>gpt-5</td><td><span class="status slow"><span class="d"></span>slow</span></td><td style="color:var(--warn)">426</td><td style="color:var(--warn)">1.42s</td><td>30k/256k</td><td>$.0140</td><td><span class="mbar"><span class="b" style="--w:18%; background: var(--warn) !important"></span>15.0%</span></td></tr>
+          <tr><td class="pname">openai</td><td>gpt-5</td><td><span class="status slow"><span class="d"></span>slow</span></td><td style="color:var(--color-status-warn)">426</td><td style="color:var(--color-status-warn)">1.42s</td><td>30k/256k</td><td>$.0140</td><td><span class="mbar"><span class="b" style="--w:18%; background: var(--color-status-warn) !important"></span>15.0%</span></td></tr>
           <tr><td class="pname">deepseek</td><td>r1-lite</td><td><span class="status ok"><span class="d"></span>healthy</span></td><td style="color:var(--brass-1)">285</td><td>540ms</td><td>21k/64k</td><td>$.0018</td><td><span class="mbar"><span class="b" style="--w:11%"></span>10.0%</span></td></tr>
           <tr><td class="pname">local/llama3</td><td>70b-q4</td><td><span class="status ok"><span class="d"></span>healthy</span></td><td>40</td><td>240ms</td><td>8k/32k</td><td>$.0000</td><td><span class="mbar"><span class="b" style="--w:2%"></span>1.4%</span></td></tr>
-          <tr><td class="pname">fireworks</td><td>yi-large</td><td><span class="status down"><span class="d"></span>429 rl</span></td><td style="color:var(--err-fg)">0</td><td>—</td><td>—</td><td>$.0030</td><td><span style="color:var(--fg-4)">backoff · 12s</span></td></tr>
+          <tr><td class="pname">fireworks</td><td>yi-large</td><td><span class="status down"><span class="d"></span>429 rl</span></td><td style="color:var(--err-fg)">0</td><td>—</td><td>—</td><td>$.0030</td><td><span style="color:var(--color-fg-disabled)">backoff · 12s</span></td></tr>
         </tbody>
       </table>
     </div>
@@ -276,9 +276,9 @@
           <div class="bar-track">
             <div class="bar-fill" style="width: 72%"></div>
             <div class="bar-mark" style="left: 80%"></div>
-            <div class="bar-mark" style="left: 95%; background: var(--err)"></div>
+            <div class="bar-mark" style="left: 95%; background: var(--color-status-err)"></div>
           </div>
-          <span style="color:var(--fg-1); font-variant-numeric: tabular-nums">92.4k<span style="color:var(--fg-4)">&nbsp;/&nbsp;128k</span></span>
+          <span style="color:var(--fg-1); font-variant-numeric: tabular-nums">92.4k<span style="color:var(--color-fg-disabled)">&nbsp;/&nbsp;128k</span></span>
           <span class="chip is-brass">72%</span>
         </div>
         <div class="budget">
@@ -286,9 +286,9 @@
           <div class="bar-track">
             <div class="bar-fill" style="width: 42%"></div>
             <div class="bar-mark" style="left: 80%"></div>
-            <div class="bar-mark" style="left: 95%; background: var(--err)"></div>
+            <div class="bar-mark" style="left: 95%; background: var(--color-status-err)"></div>
           </div>
-          <span style="color:var(--fg-1); font-variant-numeric: tabular-nums">54.0k<span style="color:var(--fg-4)">&nbsp;/&nbsp;128k</span></span>
+          <span style="color:var(--fg-1); font-variant-numeric: tabular-nums">54.0k<span style="color:var(--color-fg-disabled)">&nbsp;/&nbsp;128k</span></span>
           <span class="chip">42%</span>
         </div>
         <div class="budget">
@@ -296,9 +296,9 @@
           <div class="bar-track">
             <div class="bar-fill" style="width: 94%"></div>
             <div class="bar-mark" style="left: 80%"></div>
-            <div class="bar-mark" style="left: 95%; background: var(--err)"></div>
+            <div class="bar-mark" style="left: 95%; background: var(--color-status-err)"></div>
           </div>
-          <span style="color:var(--err-fg); font-variant-numeric: tabular-nums">120.3k<span style="color:var(--fg-4)">&nbsp;/&nbsp;128k</span></span>
+          <span style="color:var(--err-fg); font-variant-numeric: tabular-nums">120.3k<span style="color:var(--color-fg-disabled)">&nbsp;/&nbsp;128k</span></span>
           <span class="chip is-err">94%</span>
         </div>
         <div class="budget">
@@ -306,9 +306,9 @@
           <div class="bar-track">
             <div class="bar-fill" style="width: 68%"></div>
             <div class="bar-mark" style="left: 80%"></div>
-            <div class="bar-mark" style="left: 95%; background: var(--err)"></div>
+            <div class="bar-mark" style="left: 95%; background: var(--color-status-err)"></div>
           </div>
-          <span style="color:var(--fg-1); font-variant-numeric: tabular-nums">435k<span style="color:var(--fg-4)">&nbsp;/&nbsp;640k</span></span>
+          <span style="color:var(--fg-1); font-variant-numeric: tabular-nums">435k<span style="color:var(--color-fg-disabled)">&nbsp;/&nbsp;640k</span></span>
           <span class="chip is-brass">68%</span>
         </div>
       </div>

--- a/dashboard/design-system/source_styles/center.css
+++ b/dashboard/design-system/source_styles/center.css
@@ -21,11 +21,11 @@
 .wf-bar {
   position: absolute; top: 2px; height: 10px; border-radius: 1px; min-width: 2px;
 }
-.wf-bar.s-err { background: var(--err); }
-.wf-bar.s-info { background: var(--info); }
+.wf-bar.s-err { background: var(--color-status-err); }
+.wf-bar.s-info { background: var(--color-status-info); }
 .wf-bar.s-tool { background: var(--brass-2); }
-.wf-bar.s-text { background: var(--info); opacity: .6; }
-.wf-bar.s-noop { background: var(--idle); opacity: .4; }
+.wf-bar.s-text { background: var(--color-status-info); opacity: .6; }
+.wf-bar.s-noop { background: var(--color-status-idle); opacity: .4; }
 .wf-bar:hover { outline: 1px solid var(--color-fg-primary); z-index: 2; }
 
 .wf-scale-ctrl { display: flex; gap: 2px; margin-left: auto; }
@@ -35,7 +35,7 @@
   padding: 3px 7px; cursor: pointer; border-radius: 2px; letter-spacing: .03em;
 }
 .wf-scale-ctrl button:hover { color: var(--color-fg-primary); }
-.wf-scale-ctrl button.is-active { background: var(--color-bg-elevated); border-color: var(--brass-3); color: var(--color-accent-fg); }
+.wf-scale-ctrl button.is-active { background: var(--color-bg-elevated); border-color: var(--color-accent-fg-dim); color: var(--color-accent-fg); }
 .wf-scale-ctrl + .pane-meta { margin-left: var(--sp-3); }
 
 .feed-row {
@@ -51,14 +51,14 @@
 .feed-ts { color: var(--color-fg-muted); }
 .feed-kind { font-size: 10px; color: var(--color-fg-secondary); text-transform: uppercase; letter-spacing: .04em; }
 .feed-kind.k-tool { color: var(--color-accent-fg); }
-.feed-kind.k-error { color: var(--err); }
-.feed-kind.k-noop { color: var(--idle); }
-.feed-kind.k-text { color: var(--info); }
-.feed-kind.k-claim { color: var(--ok); }
+.feed-kind.k-error { color: var(--color-status-err); }
+.feed-kind.k-noop { color: var(--color-status-idle); }
+.feed-kind.k-text { color: var(--color-status-info); }
+.feed-kind.k-claim { color: var(--color-status-ok); }
 .feed-actor { color: var(--color-fg-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .feed-body {
   color: var(--color-fg-primary);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   font-family: var(--font-sans); font-size: var(--fs-12);
 }
-.feed-row.is-error .feed-body { color: var(--err); }
+.feed-row.is-error .feed-body { color: var(--color-status-err); }

--- a/dashboard/design-system/source_styles/code.css
+++ b/dashboard/design-system/source_styles/code.css
@@ -80,7 +80,7 @@ body[data-mode="split"] .zone-deck { display: none; }
   font-family: var(--font-mono); font-size: 11px; cursor: pointer;
 }
 .code-repo-select:hover, .code-wc-select:hover { background: var(--bg-3); }
-.code-repo-select .arrow, .code-wc-select .arrow { color: var(--fg-4); font-size: 9px; margin-left: 2px; }
+.code-repo-select .arrow, .code-wc-select .arrow { color: var(--color-fg-disabled); font-size: 9px; margin-left: 2px; }
 
 .wc-chips { display: flex; gap: 4px; flex-wrap: nowrap; overflow: hidden; }
 .wc-chip {
@@ -92,12 +92,12 @@ body[data-mode="split"] .zone-deck { display: none; }
   cursor: pointer; flex-shrink: 0;
 }
 .wc-chip:hover { background: var(--bg-3); color: var(--fg-1); }
-.wc-chip.is-active { background: var(--bg-4); color: var(--brass-1); border-color: var(--brass-3); }
+.wc-chip.is-active { background: var(--bg-4); color: var(--brass-1); border-color: var(--color-accent-fg-dim); }
 .wc-chip .wc-close {
-  color: var(--fg-4); font-size: 9px; margin-left: 1px;
+  color: var(--color-fg-disabled); font-size: 9px; margin-left: 1px;
   width: 12px; text-align: center; border-radius: 2px;
 }
-.wc-chip .wc-close:hover { color: var(--err); background: var(--bg-1); }
+.wc-chip .wc-close:hover { color: var(--color-status-err); background: var(--bg-1); }
 .wc-chip .dot { width: 5px; height: 5px; }
 
 .code-toolbar .code-search {
@@ -106,7 +106,7 @@ body[data-mode="split"] .zone-deck { display: none; }
   background: var(--bg-2); border: 1px solid var(--line-2); border-radius: var(--r-1);
   color: var(--fg-1); font-size: 11px; font-family: var(--font-mono);
 }
-.code-toolbar .code-search::placeholder { color: var(--fg-4); }
+.code-toolbar .code-search::placeholder { color: var(--color-fg-disabled); }
 .code-toolbar .spacer { flex: 1; }
 
 .code-view-tabs { display: flex; gap: 0; border: 1px solid var(--line-2); border-radius: var(--r-1); overflow: hidden; }
@@ -132,7 +132,7 @@ body[data-mode="split"] .zone-deck { display: none; }
   text-transform: uppercase; letter-spacing: .08em;
   color: var(--fg-3); font-weight: 600;
 }
-.tree-head .count { margin-left: auto; font-family: var(--font-mono); color: var(--fg-4); }
+.tree-head .count { margin-left: auto; font-family: var(--font-mono); color: var(--color-fg-disabled); }
 .tree-body {
   flex: 1; overflow-y: auto; padding: 4px 0;
   font-family: var(--font-mono); font-size: 11px;
@@ -150,22 +150,22 @@ body[data-mode="split"] .zone-deck { display: none; }
   width: 2px; background: var(--brass-1);
 }
 .tree-item .tw-indent { display: inline-block; width: 10px; flex-shrink: 0; }
-.tree-item .tw-chev { color: var(--fg-4); width: 10px; font-size: 9px; flex-shrink: 0; }
-.tree-item .tw-icon { color: var(--fg-4); width: 12px; text-align: center; flex-shrink: 0; }
+.tree-item .tw-chev { color: var(--color-fg-disabled); width: 10px; font-size: 9px; flex-shrink: 0; }
+.tree-item .tw-icon { color: var(--color-fg-disabled); width: 12px; text-align: center; flex-shrink: 0; }
 .tree-item .tw-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tree-item .tw-badges { display: flex; gap: 2px; flex-shrink: 0; }
 .tree-item .tw-keeper-dot {
   width: 6px; height: 6px; border-radius: 50%;
   background: var(--brass-1);
-  box-shadow: 0 0 4px rgb(var(--brass-glow) / .6);
+  box-shadow: 0 0 4px rgb(var(--color-accent-glow) / .6);
 }
-.tree-item .tw-keeper-dot.is-multi { background: var(--stalled); }
+.tree-item .tw-keeper-dot.is-multi { background: var(--color-status-stalled); }
 .tree-item .tw-count {
-  font-size: 9px; color: var(--fg-4); font-family: var(--font-mono);
+  font-size: 9px; color: var(--color-fg-disabled); font-family: var(--font-mono);
   padding: 0 4px; background: var(--bg-3); border-radius: 2px;
 }
-.tree-item .tw-diff-plus { color: var(--ok); font-size: 9px; }
-.tree-item .tw-diff-minus { color: var(--err); font-size: 9px; }
+.tree-item .tw-diff-plus { color: var(--color-status-ok); font-size: 9px; }
+.tree-item .tw-diff-minus { color: var(--color-status-err); font-size: 9px; }
 .tree-dir { color: var(--fg-1); font-weight: 500; }
 .tree-dir .tw-icon { color: var(--brass-2); }
 
@@ -197,13 +197,13 @@ body[data-mode="split"] .zone-deck { display: none; }
   box-shadow: inset 0 2px 0 var(--brass-1);
 }
 .editor-tab .t-close {
-  color: var(--fg-4); font-size: 10px;
+  color: var(--color-fg-disabled); font-size: 10px;
   width: 14px; height: 14px; border-radius: 2px;
   display: flex; align-items: center; justify-content: center;
 }
-.editor-tab .t-close:hover { color: var(--err); background: var(--bg-3); }
+.editor-tab .t-close:hover { color: var(--color-status-err); background: var(--bg-3); }
 .editor-tab .t-dirty {
-  width: 6px; height: 6px; border-radius: 50%; background: var(--warn);
+  width: 6px; height: 6px; border-radius: 50%; background: var(--color-status-warn);
 }
 .editor-breadcrumbs {
   height: 22px; flex-shrink: 0;
@@ -215,7 +215,7 @@ body[data-mode="split"] .zone-deck { display: none; }
 }
 .bc-seg { cursor: pointer; }
 .bc-seg:hover { color: var(--brass-1); }
-.bc-sep { color: var(--fg-4); }
+.bc-sep { color: var(--color-fg-disabled); }
 .bc-seg:last-child { color: var(--fg-1); }
 
 .editor-body {
@@ -241,11 +241,11 @@ body[data-mode="split"] .zone-deck { display: none; }
   position: relative;
 }
 .code-line:hover { background: rgb(255 255 255 / .015); }
-.code-line.is-selected { background: rgb(var(--brass-glow) / .06); }
-.code-line.is-anchor-hover { background: rgb(var(--brass-glow) / .05); }
-.code-line.is-heatmap-1 { background: rgb(var(--brass-glow) / .02); }
-.code-line.is-heatmap-2 { background: rgb(var(--brass-glow) / .05); }
-.code-line.is-heatmap-3 { background: rgb(var(--brass-glow) / .10); }
+.code-line.is-selected { background: rgb(var(--color-accent-glow) / .06); }
+.code-line.is-anchor-hover { background: rgb(var(--color-accent-glow) / .05); }
+.code-line.is-heatmap-1 { background: rgb(var(--color-accent-glow) / .02); }
+.code-line.is-heatmap-2 { background: rgb(var(--color-accent-glow) / .05); }
+.code-line.is-heatmap-3 { background: rgb(var(--color-accent-glow) / .10); }
 .code-line.is-diff-add { background: rgb(107 158 107 / .08); }
 .code-line.is-diff-del { background: rgb(196 106 90 / .08); }
 
@@ -253,7 +253,7 @@ body[data-mode="split"] .zone-deck { display: none; }
   grid-area: gutter;
   display: flex; align-items: center; justify-content: center;
   border-right: 1px solid var(--line-1);
-  color: var(--fg-4); font-size: 10px;
+  color: var(--color-fg-disabled); font-size: 10px;
   position: relative;
 }
 .cl-gutter-icon {
@@ -262,10 +262,10 @@ body[data-mode="split"] .zone-deck { display: none; }
   border-radius: 2px; cursor: pointer; font-size: 10px;
 }
 .cl-gutter-icon:hover { background: var(--bg-3); color: var(--brass-1); }
-.cl-gutter-icon.k-question { color: var(--info); }
-.cl-gutter-icon.k-flag     { color: var(--err); }
+.cl-gutter-icon.k-question { color: var(--color-status-info); }
+.cl-gutter-icon.k-flag     { color: var(--color-status-err); }
 .cl-gutter-icon.k-note     { color: var(--fg-2); }
-.cl-gutter-icon.k-approve  { color: var(--ok); }
+.cl-gutter-icon.k-approve  { color: var(--color-status-ok); }
 .cl-gutter-icon.k-suggest  { color: var(--brass-1); }
 .cl-add-btn {
   opacity: 0; transition: opacity var(--t-fast);
@@ -289,23 +289,23 @@ body[data-mode="split"] .zone-deck { display: none; }
 }
 .cl-cursor-dot {
   width: 5px; height: 5px; border-radius: 50%;
-  background: var(--brass-1); box-shadow: 0 0 5px rgb(var(--brass-glow) / .7);
+  background: var(--brass-1); box-shadow: 0 0 5px rgb(var(--color-accent-glow) / .7);
 }
-.cl-cursor-dot.is-green { background: var(--ok); box-shadow: 0 0 5px rgb(107 158 107 / .7); }
-.cl-cursor-dot.is-blue  { background: var(--info); box-shadow: 0 0 5px rgb(106 142 176 / .7); }
-.cl-cursor-dot.is-purple { background: var(--stalled); box-shadow: 0 0 5px rgb(138 106 160 / .7); }
+.cl-cursor-dot.is-green { background: var(--color-status-ok); box-shadow: 0 0 5px rgb(107 158 107 / .7); }
+.cl-cursor-dot.is-blue  { background: var(--color-status-info); box-shadow: 0 0 5px rgb(106 142 176 / .7); }
+.cl-cursor-dot.is-purple { background: var(--color-status-stalled); box-shadow: 0 0 5px rgb(138 106 160 / .7); }
 .cl-diff-mark {
   grid-area: markers;
   display: flex; align-items: center; justify-content: center;
   font-family: var(--font-mono); font-size: 11px; font-weight: 700;
 }
-.code-line.is-diff-add .cl-diff-mark { color: var(--ok); }
-.code-line.is-diff-del .cl-diff-mark { color: var(--err); }
+.code-line.is-diff-add .cl-diff-mark { color: var(--color-status-ok); }
+.code-line.is-diff-del .cl-diff-mark { color: var(--color-status-err); }
 
 .cl-lineno {
   grid-area: lineno;
   text-align: right; padding-right: 10px;
-  color: var(--fg-4); font-size: 11px;
+  color: var(--color-fg-disabled); font-size: 11px;
   border-right: 1px solid var(--line-1);
   user-select: none;
 }
@@ -314,16 +314,16 @@ body[data-mode="split"] .zone-deck { display: none; }
 .cl-blame {
   grid-area: blame;
   padding: 0 6px;
-  color: var(--fg-4); font-size: 10px;
+  color: var(--color-fg-disabled); font-size: 10px;
   border-right: 1px solid var(--line-1);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   background: var(--bg-1);
 }
 .cl-blame.is-keeper-nick { color: var(--brass-1); }
-.cl-blame.is-keeper-masc { color: var(--ok); }
-.cl-blame.is-keeper-sangsu { color: var(--info); }
-.cl-blame.is-keeper-qa { color: var(--err); }
-.cl-blame.is-keeper-rama { color: var(--stalled); }
+.cl-blame.is-keeper-masc { color: var(--color-status-ok); }
+.cl-blame.is-keeper-sangsu { color: var(--color-status-info); }
+.cl-blame.is-keeper-qa { color: var(--color-status-err); }
+.cl-blame.is-keeper-rama { color: var(--color-status-stalled); }
 
 .cl-code {
   grid-area: code;
@@ -337,21 +337,21 @@ body[data-mode="split"] .zone-deck { display: none; }
 .anchor-bracket {
   position: absolute;
   left: 4px; width: 2px;
-  background: var(--brass-3);
+  background: var(--color-accent-fg-dim);
   border-radius: 1px;
   pointer-events: none;
   opacity: 0.35;
   transition: opacity var(--t-fast), top var(--t-med), height var(--t-med);
 }
 .anchor-bracket.is-active { opacity: 1; background: var(--brass-1); width: 3px; }
-.anchor-bracket.k-flag { background: var(--err); opacity: 0.6; }
-.anchor-bracket.k-approve { background: var(--ok); opacity: 0.5; }
+.anchor-bracket.k-flag { background: var(--color-status-err); opacity: 0.6; }
+.anchor-bracket.k-approve { background: var(--color-status-ok); opacity: 0.5; }
 .anchor-bracket.is-drift {
   animation: drift-pulse 1.2s ease-out;
 }
 @keyframes drift-pulse {
-  0% { box-shadow: 0 0 0 0 rgb(var(--brass-glow) / .6); }
-  100% { box-shadow: 0 0 0 8px rgb(var(--brass-glow) / 0); }
+  0% { box-shadow: 0 0 0 0 rgb(var(--color-accent-glow) / .6); }
+  100% { box-shadow: 0 0 0 8px rgb(var(--color-accent-glow) / 0); }
 }
 .anchor-orphan-banner {
   position: sticky; top: 0; z-index: 2;
@@ -360,7 +360,7 @@ body[data-mode="split"] .zone-deck { display: none; }
   background: rgb(196 106 90 / .1);
   border: 1px solid rgb(196 106 90 / .3);
   border-radius: var(--r-1);
-  font-size: 11px; color: var(--err);
+  font-size: 11px; color: var(--color-status-err);
   display: flex; align-items: center; gap: 8px;
 }
 .anchor-orphan-banner .btn {
@@ -371,7 +371,7 @@ body[data-mode="split"] .zone-deck { display: none; }
 .tok-key    { color: #c195e8; }
 .tok-str    { color: #a8c97a; }
 .tok-num    { color: #d4a14a; }
-.tok-com    { color: var(--fg-4); font-style: italic; }
+.tok-com    { color: var(--color-fg-disabled); font-style: italic; }
 .tok-fn     { color: #e8c976; }
 .tok-var    { color: var(--fg-1); }
 .tok-type   { color: #88b5d8; }
@@ -394,8 +394,8 @@ body[data-mode="split"] .zone-deck { display: none; }
 }
 .minimap-viewport {
   position: absolute; left: 0; right: 0;
-  background: rgb(var(--brass-glow) / .08);
-  border: 1px solid rgb(var(--brass-glow) / .3);
+  background: rgb(var(--color-accent-glow) / .08);
+  border: 1px solid rgb(var(--color-accent-glow) / .3);
   pointer-events: none;
 }
 
@@ -414,7 +414,7 @@ body[data-mode="split"] .zone-deck { display: none; }
   font-size: 10px; text-transform: uppercase; letter-spacing: .08em;
   color: var(--fg-3); font-weight: 600;
 }
-.review-head .count { margin-left: auto; color: var(--fg-4); font-family: var(--font-mono); }
+.review-head .count { margin-left: auto; color: var(--color-fg-disabled); font-family: var(--font-mono); }
 .review-filter {
   display: flex; gap: 0;
   padding: 4px 8px 6px;
@@ -428,7 +428,7 @@ body[data-mode="split"] .zone-deck { display: none; }
 }
 .review-filter button:first-child { border-radius: 2px 0 0 2px; }
 .review-filter button:last-child  { border-right: 1px solid var(--line-1); border-radius: 0 2px 2px 0; }
-.review-filter button.is-active { color: var(--brass-1); background: var(--bg-3); border-color: var(--brass-3); }
+.review-filter button.is-active { color: var(--brass-1); background: var(--bg-3); border-color: var(--color-accent-fg-dim); }
 .review-list {
   flex: 1; overflow-y: auto;
 }
@@ -453,11 +453,11 @@ body[data-mode="split"] .zone-deck { display: none; }
   letter-spacing: .08em; text-transform: uppercase;
   font-family: var(--font-mono); font-weight: 600;
 }
-.thread-kind.k-question { background: rgb(106 142 176 / .15); color: var(--info); }
-.thread-kind.k-flag     { background: rgb(196 106 90 / .15); color: var(--err); }
+.thread-kind.k-question { background: rgb(106 142 176 / .15); color: var(--color-status-info); }
+.thread-kind.k-flag     { background: rgb(196 106 90 / .15); color: var(--color-status-err); }
 .thread-kind.k-note     { background: var(--bg-3); color: var(--fg-2); }
-.thread-kind.k-approve  { background: rgb(107 158 107 / .15); color: var(--ok); }
-.thread-kind.k-suggest  { background: rgb(var(--brass-glow) / .12); color: var(--brass-1); }
+.thread-kind.k-approve  { background: rgb(107 158 107 / .15); color: var(--color-status-ok); }
+.thread-kind.k-suggest  { background: rgb(var(--color-accent-glow) / .12); color: var(--brass-1); }
 .thread-anchor {
   font-family: var(--font-mono); font-size: 10px;
   color: var(--fg-3);
@@ -465,19 +465,19 @@ body[data-mode="split"] .zone-deck { display: none; }
 .thread-author {
   color: var(--fg-1); font-size: 11px; font-weight: 500;
 }
-.thread-ts { margin-left: auto; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); }
+.thread-ts { margin-left: auto; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled); }
 .thread-body {
   font-size: 12px; color: var(--fg-2); line-height: 1.4;
   display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden;
 }
 .thread-meta {
-  display: flex; gap: 8px; font-size: 10px; color: var(--fg-4);
+  display: flex; gap: 8px; font-size: 10px; color: var(--color-fg-disabled);
   font-family: var(--font-mono);
 }
 .thread-reply-count::before { content: "↩ "; }
 .thread-drift-badge {
   font-size: 9px; padding: 0 4px; background: var(--bg-3);
-  color: var(--warn); border-radius: 2px; letter-spacing: .04em;
+  color: var(--color-status-warn); border-radius: 2px; letter-spacing: .04em;
 }
 
 /* —— activity rail —— */
@@ -498,7 +498,7 @@ body[data-mode="split"] .zone-deck { display: none; }
 .activity-head .scope-pill {
   margin-left: auto;
   font-size: 9px; padding: 1px 5px;
-  background: rgb(var(--brass-glow) / .1);
+  background: rgb(var(--color-accent-glow) / .1);
   color: var(--brass-1); border-radius: 2px;
   letter-spacing: .06em;
 }
@@ -520,31 +520,31 @@ body[data-mode="split"] .zone-deck { display: none; }
   position: relative;
 }
 .act-row:hover { background: var(--bg-2); }
-.act-row.is-now { background: rgb(var(--brass-glow) / .04); }
-.act-ts { color: var(--fg-4); font-family: var(--font-mono); font-size: 10px; text-align: right; padding-top: 1px; }
+.act-row.is-now { background: rgb(var(--color-accent-glow) / .04); }
+.act-ts { color: var(--color-fg-disabled); font-family: var(--font-mono); font-size: 10px; text-align: right; padding-top: 1px; }
 .act-dot {
   width: 8px; height: 8px; border-radius: 50%;
   background: var(--fg-3);
   margin-top: 4px; border: 2px solid var(--bg-1); z-index: 1;
 }
-.act-dot.k-edit { background: var(--brass-1); box-shadow: 0 0 4px rgb(var(--brass-glow)/.5); }
-.act-dot.k-comment { background: var(--info); }
-.act-dot.k-flag { background: var(--err); }
-.act-dot.k-approve { background: var(--ok); }
-.act-dot.k-commit { background: var(--stalled); }
-.act-dot.k-refactor { background: var(--warn); }
+.act-dot.k-edit { background: var(--brass-1); box-shadow: 0 0 4px rgb(var(--color-accent-glow)/.5); }
+.act-dot.k-comment { background: var(--color-status-info); }
+.act-dot.k-flag { background: var(--color-status-err); }
+.act-dot.k-approve { background: var(--color-status-ok); }
+.act-dot.k-commit { background: var(--color-status-stalled); }
+.act-dot.k-refactor { background: var(--color-status-warn); }
 .act-body { min-width: 0; }
 .act-body .who { color: var(--fg-1); font-weight: 500; }
 .act-body .what { color: var(--fg-2); }
 .act-body .where { font-family: var(--font-mono); font-size: 10px; color: var(--fg-3); }
-.act-body .detail { font-size: 10px; color: var(--fg-4); margin-top: 2px; }
+.act-body .detail { font-size: 10px; color: var(--color-fg-disabled); margin-top: 2px; }
 
 /* —— floating add-comment popover —— */
 .comment-composer {
   position: absolute; z-index: 40;
   width: 320px;
   background: var(--bg-2);
-  border: 1px solid var(--line-3); border-radius: var(--r-2);
+  border: 1px solid var(--color-border-divider); border-radius: var(--r-2);
   box-shadow: var(--shadow-2);
   padding: 10px; font-size: 11px;
   display: none;
@@ -566,7 +566,7 @@ body[data-mode="split"] .zone-deck { display: none; }
 .comment-composer .cc-kinds button:first-child { border-radius: 2px 0 0 2px; }
 .comment-composer .cc-kinds button:last-child { border-radius: 0 2px 2px 0; border-right: 1px solid var(--line-2); }
 .comment-composer .cc-kinds button.is-active {
-  background: var(--bg-3); color: var(--brass-1); border-color: var(--brass-3);
+  background: var(--bg-3); color: var(--brass-1); border-color: var(--color-accent-fg-dim);
 }
 .comment-composer textarea {
   width: 100%; min-height: 72px;
@@ -575,7 +575,7 @@ body[data-mode="split"] .zone-deck { display: none; }
   color: var(--fg-1); font-family: var(--font-sans); font-size: 12px;
   resize: vertical; outline: none;
 }
-.comment-composer textarea:focus { border-color: var(--brass-3); }
+.comment-composer textarea:focus { border-color: var(--color-accent-fg-dim); }
 .comment-composer .cc-actions {
   display: flex; gap: 6px; margin-top: 8px; align-items: center;
 }
@@ -590,7 +590,7 @@ body[data-mode="split"] .zone-deck { display: none; }
   display: inline-flex; align-items: center; gap: 4px;
   font-size: 10px; padding: 1px 5px;
   background: rgb(196 106 90 / .1);
-  color: var(--err); border: 1px solid rgb(196 106 90 / .3);
+  color: var(--color-status-err); border: 1px solid rgb(196 106 90 / .3);
   border-radius: 2px; font-family: var(--font-mono);
 }
 

--- a/dashboard/design-system/source_styles/deck.css
+++ b/dashboard/design-system/source_styles/deck.css
@@ -26,7 +26,7 @@
 }
 .deck-tabs .deck-tab-count {
   font-family: var(--font-mono); font-size: 10px;
-  color: var(--fg-4); font-weight: 500;
+  color: var(--color-fg-disabled); font-weight: 500;
   padding: 1px 5px; background: var(--bg-3);
   border-radius: 2px; min-width: 18px; text-align: center;
 }
@@ -75,7 +75,7 @@
   font-size: 10px; text-transform: uppercase; letter-spacing: .1em;
   color: var(--fg-3); font-weight: 600;
 }
-.board-col-head .count { margin-left: auto; color: var(--fg-4); font-family: var(--font-mono); }
+.board-col-head .count { margin-left: auto; color: var(--color-fg-disabled); font-family: var(--font-mono); }
 .board-thread {
   padding: 8px 10px; border-bottom: 1px solid var(--line-1);
   display: flex; flex-direction: column; gap: 4px;
@@ -88,17 +88,17 @@
   font-size: 11px;
 }
 .board-thread .bt-from { color: var(--fg-1); font-weight: 500; }
-.board-thread .bt-arrow { color: var(--fg-4); font-family: var(--font-mono); }
+.board-thread .bt-arrow { color: var(--color-fg-disabled); font-family: var(--font-mono); }
 .board-thread .bt-to { color: var(--fg-2); }
 .board-thread .bt-ts {
-  margin-left: auto; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4);
+  margin-left: auto; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled);
 }
 .board-thread .bt-body {
   font-size: 12px; color: var(--fg-2); line-height: 1.4;
   display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
 }
 .board-thread .bt-meta {
-  display: flex; gap: 8px; font-size: 10px; color: var(--fg-4); font-family: var(--font-mono);
+  display: flex; gap: 8px; font-size: 10px; color: var(--color-fg-disabled); font-family: var(--font-mono);
 }
 .board-thread .bt-meta .tag {
   padding: 0 4px; background: var(--bg-3);
@@ -135,12 +135,12 @@
   border-radius: 2px; color: var(--fg-3);
   font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .06em;
 }
-.pill.active, .pill.running { color: var(--brass-1); border-color: var(--brass-3); }
-.pill.blocked, .pill.err, .pill.error { color: var(--err); border-color: rgb(196 106 90 / .4); }
-.pill.done, .pill.ok, .pill.verified { color: var(--ok); border-color: rgb(107 158 107 / .4); }
-.pill.stalled { color: var(--stalled); border-color: rgb(138 106 160 / .4); }
-.pill.warn, .pill.atrisk { color: var(--warn); border-color: rgb(201 162 74 / .4); }
-.pill.idle, .pill.pending { color: var(--info); border-color: rgb(106 142 176 / .4); }
+.pill.active, .pill.running { color: var(--brass-1); border-color: var(--color-accent-fg-dim); }
+.pill.blocked, .pill.err, .pill.error { color: var(--color-status-err); border-color: rgb(196 106 90 / .4); }
+.pill.done, .pill.ok, .pill.verified { color: var(--color-status-ok); border-color: rgb(107 158 107 / .4); }
+.pill.stalled { color: var(--color-status-stalled); border-color: rgb(138 106 160 / .4); }
+.pill.warn, .pill.atrisk { color: var(--color-status-warn); border-color: rgb(201 162 74 / .4); }
+.pill.idle, .pill.pending { color: var(--color-status-info); border-color: rgb(106 142 176 / .4); }
 
 .deck-bar {
   display: inline-block; width: 80px; height: 4px;
@@ -152,24 +152,24 @@
   background: var(--brass-2);
   border-radius: 2px;
 }
-.deck-bar .fill.is-ok { background: var(--ok); }
-.deck-bar .fill.is-err { background: var(--err); }
-.deck-bar .fill.is-warn { background: var(--warn); }
+.deck-bar .fill.is-ok { background: var(--color-status-ok); }
+.deck-bar .fill.is-err { background: var(--color-status-err); }
+.deck-bar .fill.is-warn { background: var(--color-status-warn); }
 
 .pr-link, .sb-link {
   font-family: var(--font-mono); font-size: 11px;
-  color: var(--info); text-decoration: none;
+  color: var(--color-status-info); text-decoration: none;
 }
 .pr-link:hover, .sb-link:hover { color: var(--brass-1); }
 .pr-state {
   display: inline-block; width: 8px; height: 8px; border-radius: 50%;
   margin-right: 5px; vertical-align: middle;
 }
-.pr-state.open { background: var(--ok); }
-.pr-state.draft { background: var(--idle); }
-.pr-state.review { background: var(--warn); }
-.pr-state.merged { background: var(--stalled); }
-.pr-state.closed { background: var(--err); }
+.pr-state.open { background: var(--color-status-ok); }
+.pr-state.draft { background: var(--color-status-idle); }
+.pr-state.review { background: var(--color-status-warn); }
+.pr-state.merged { background: var(--color-status-stalled); }
+.pr-state.closed { background: var(--color-status-err); }
 
 /* ——— GOALS tree ——— */
 .goal-tree {
@@ -205,8 +205,8 @@
   padding: 10px 12px;
   display: flex; flex-direction: column; gap: 6px;
 }
-.verif-card.is-failing { box-shadow: inset 2px 0 0 var(--err); }
-.verif-card.is-passing { box-shadow: inset 2px 0 0 var(--ok); }
+.verif-card.is-failing { box-shadow: inset 2px 0 0 var(--color-status-err); }
+.verif-card.is-passing { box-shadow: inset 2px 0 0 var(--color-status-ok); }
 .verif-head { display: flex; align-items: center; gap: 8px; }
 .verif-head .v-id { font-family: var(--font-mono); font-size: 10px; color: var(--fg-3); }
 .verif-head .v-title { color: var(--fg-1); font-size: 12px; font-weight: 500; flex: 1; }
@@ -214,13 +214,13 @@
 .verif-check { display: flex; gap: 8px; align-items: center; color: var(--fg-2); }
 .verif-check .vc-mark {
   width: 12px; text-align: center; font-family: var(--font-mono);
-  color: var(--ok);
+  color: var(--color-status-ok);
 }
-.verif-check.is-fail .vc-mark { color: var(--err); }
-.verif-check.is-fail .vc-label { color: var(--err); }
-.verif-check.is-skip .vc-mark, .verif-check.is-skip .vc-label { color: var(--fg-4); }
+.verif-check.is-fail .vc-mark { color: var(--color-status-err); }
+.verif-check.is-fail .vc-label { color: var(--color-status-err); }
+.verif-check.is-skip .vc-mark, .verif-check.is-skip .vc-label { color: var(--color-fg-disabled); }
 .verif-foot {
-  display: flex; gap: 10px; font-size: 10px; color: var(--fg-4);
+  display: flex; gap: 10px; font-size: 10px; color: var(--color-fg-disabled);
   font-family: var(--font-mono); margin-top: auto;
 }
 
@@ -243,8 +243,8 @@
   font-size: 11px;
 }
 .sandbox-card.is-running { box-shadow: inset 2px 0 0 var(--brass-1); }
-.sandbox-card.is-stopped { box-shadow: inset 2px 0 0 var(--idle); }
-.sandbox-card.is-errored { box-shadow: inset 2px 0 0 var(--err); }
+.sandbox-card.is-stopped { box-shadow: inset 2px 0 0 var(--color-status-idle); }
+.sandbox-card.is-errored { box-shadow: inset 2px 0 0 var(--color-status-err); }
 .sandbox-card .sb-head {
   display: flex; align-items: center; gap: 6px;
 }
@@ -284,7 +284,7 @@
 .cascade-step.is-failed { background: rgb(196 106 90 / .06); }
 .cascade-step.is-hit { box-shadow: inset 0 -2px 0 var(--brass-1); }
 .cascade-step .cs-num {
-  font-family: var(--font-mono); font-size: 10px; color: var(--fg-4);
+  font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled);
 }
 .cascade-step .cs-model {
   font-size: 12px; color: var(--fg-1); font-weight: 500;
@@ -297,7 +297,7 @@
 }
 .cascade-step .cs-arrow {
   position: absolute; right: -7px; top: 50%; transform: translateY(-50%);
-  color: var(--line-3); font-size: 10px; z-index: 1;
+  color: var(--color-border-divider); font-size: 10px; z-index: 1;
   background: var(--bg-0); padding: 0 1px;
 }
 .cascade-step:last-child .cs-arrow { display: none; }
@@ -306,7 +306,7 @@
   font-size: 11px; color: var(--fg-3);
 }
 .cascade-row-head .ck-name { color: var(--fg-1); font-weight: 500; }
-.cascade-row-head .ck-stat { margin-left: auto; font-family: var(--font-mono); color: var(--fg-4); }
+.cascade-row-head .ck-stat { margin-left: auto; font-family: var(--font-mono); color: var(--color-fg-disabled); }
 
 /* density helpers */
 .kv-row {

--- a/dashboard/design-system/source_styles/drawer.css
+++ b/dashboard/design-system/source_styles/drawer.css
@@ -60,12 +60,12 @@
   border: 1px solid var(--line-1); border-radius: var(--r-1);
   color: var(--fg-2); letter-spacing: .02em;
 }
-.chip-err { background: rgb(196 106 90 / .1); border-color: rgb(196 106 90 / .3); color: var(--err); }
-.chip.k-tool { color: var(--brass-1); border-color: var(--brass-3); }
-.chip.k-claim { color: var(--ok); border-color: rgb(107 158 107 / .4); }
-.chip.k-text { color: var(--info); border-color: rgb(106 142 176 / .4); }
+.chip-err { background: rgb(196 106 90 / .1); border-color: rgb(196 106 90 / .3); color: var(--color-status-err); }
+.chip.k-tool { color: var(--brass-1); border-color: var(--color-accent-fg-dim); }
+.chip.k-claim { color: var(--color-status-ok); border-color: rgb(107 158 107 / .4); }
+.chip.k-text { color: var(--color-status-info); border-color: rgb(106 142 176 / .4); }
 .chip.k-noop { color: var(--fg-3); }
-.chip.k-error { color: var(--err); border-color: rgb(196 106 90 / .4); }
+.chip.k-error { color: var(--color-status-err); border-color: rgb(196 106 90 / .4); }
 
 .pre {
   font-family: var(--font-mono); font-size: 10.5px; line-height: 1.45;
@@ -113,7 +113,7 @@
   padding: 4px 6px; border-radius: var(--r-1); font-size: var(--fs-11);
 }
 .fsm-trans:hover { background: var(--bg-2); }
-.fsm-trans.is-active { background: var(--bg-3); outline: 1px solid var(--brass-3); }
+.fsm-trans.is-active { background: var(--bg-3); outline: 1px solid var(--color-accent-fg-dim); }
 
 .bar {
   display: inline-block; flex: 1; height: 6px;
@@ -122,10 +122,10 @@
 }
 .bar-fill { display: block; height: 100%; background: var(--fg-3); }
 .bar-fill.k-tool { background: var(--brass-2); }
-.bar-fill.k-claim { background: var(--ok); }
-.bar-fill.k-text { background: var(--info); }
-.bar-fill.k-noop { background: var(--idle); }
-.bar-fill.k-error { background: var(--err); }
+.bar-fill.k-claim { background: var(--color-status-ok); }
+.bar-fill.k-text { background: var(--color-status-info); }
+.bar-fill.k-noop { background: var(--color-status-idle); }
+.bar-fill.k-error { background: var(--color-status-err); }
 
 /* ── Domain-detail drawer (tasks/goals/memory) ── */
 .dd-tag-row { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 10px; }
@@ -148,7 +148,7 @@
   background: var(--bg-2); border: 1px solid var(--line-1);
   font-size: var(--fs-12);
 }
-.dd-goal-row.is-active { border-color: var(--brass-3); background: var(--bg-3); }
+.dd-goal-row.is-active { border-color: var(--color-accent-fg-dim); background: var(--bg-3); }
 .dd-goal-tag {
   font-family: var(--font-mono); font-size: 10px;
   color: var(--fg-3); text-transform: uppercase;
@@ -156,7 +156,7 @@
 }
 .dd-goal-row.is-active .dd-goal-tag { color: var(--brass-1); }
 
-.chip.k-active   { color: var(--ok); border-color: rgb(107 158 107 / .4); }
-.chip.k-blocked  { color: var(--warn); border-color: rgb(194 157 94 / .4); }
-.chip.k-stalled  { color: var(--idle); }
-.chip.k-done     { color: var(--info); border-color: rgb(106 142 176 / .4); }
+.chip.k-active   { color: var(--color-status-ok); border-color: rgb(107 158 107 / .4); }
+.chip.k-blocked  { color: var(--color-status-warn); border-color: rgb(194 157 94 / .4); }
+.chip.k-stalled  { color: var(--color-status-idle); }
+.chip.k-done     { color: var(--color-status-info); border-color: rgb(106 142 176 / .4); }

--- a/dashboard/design-system/source_styles/kpi.css
+++ b/dashboard/design-system/source_styles/kpi.css
@@ -78,11 +78,11 @@
 .kpi-delta {
   font: var(--type-caption);
   font-variant-numeric: tabular-nums;
-  color: var(--fg-4);
+  color: var(--color-fg-disabled);
 }
 .kpi-delta.up   { color: var(--ok-fg); }
 .kpi-delta.down { color: var(--err-fg); }
-.kpi-delta.flat { color: var(--fg-4); }
+.kpi-delta.flat { color: var(--color-fg-disabled); }
 
 /* ── Spark (bottom-right corner) ── */
 .kpi-spark {
@@ -110,7 +110,7 @@
 .kpi-cell.is-crit .kpi-value { color: var(--err-fg); }
 .kpi-cell.is-crit {
   background: linear-gradient(0deg, var(--err-soft), transparent 60%);
-  box-shadow: inset 2px 0 0 var(--err);
+  box-shadow: inset 2px 0 0 var(--color-status-err);
 }
 .kpi-cell.is-crit:hover {
   background: linear-gradient(0deg, var(--err-soft), var(--hover-overlay));
@@ -119,12 +119,12 @@
 .kpi-cell.is-warn .kpi-value { color: var(--warn-fg); }
 .kpi-cell.is-warn {
   background: linear-gradient(0deg, var(--warn-soft), transparent 70%);
-  box-shadow: inset 2px 0 0 var(--warn);
+  box-shadow: inset 2px 0 0 var(--color-status-warn);
 }
 
 .kpi-cell.is-ok .kpi-value { color: var(--ok-fg); }
 .kpi-cell.is-ok {
-  box-shadow: inset 2px 0 0 var(--ok);
+  box-shadow: inset 2px 0 0 var(--color-status-ok);
 }
 
 .kpi-cell.is-brass .kpi-value { color: var(--brass-fg); }

--- a/dashboard/design-system/source_styles/layers.css
+++ b/dashboard/design-system/source_styles/layers.css
@@ -39,20 +39,20 @@
 .layer-toggle:hover { color: var(--color-fg-primary); background: var(--color-bg-elevated); }
 .layer-toggle .glyph {
   width: 10px; height: 10px; border-radius: 50%;
-  background: var(--fg-4);
+  background: var(--color-fg-disabled);
   transition: all var(--t-fast) var(--ease);
 }
 .layer-toggle.is-on .glyph { transform: scale(1.2); }
-.layer-toggle.is-on[data-layer="time"]     { color: var(--warn);   border-color: rgb(var(--warn-glow) / .4); background: rgb(var(--warn-glow) / .06); }
-.layer-toggle.is-on[data-layer="time"]     .glyph { background: var(--warn); box-shadow: 0 0 5px rgb(var(--warn-glow) / .6); }
-.layer-toggle.is-on[data-layer="parallel"] { color: var(--info);   border-color: rgb(var(--info-glow) / .4); background: rgb(var(--info-glow) / .06); }
-.layer-toggle.is-on[data-layer="parallel"] .glyph { background: var(--info); box-shadow: 0 0 5px rgb(var(--info-glow) / .6); }
-.layer-toggle.is-on[data-layer="tools"]    { color: var(--color-accent-fg); border-color: var(--brass-3); background: rgb(var(--brass-glow) / .08); }
-.layer-toggle.is-on[data-layer="tools"]    .glyph { background: var(--color-accent-fg); box-shadow: 0 0 5px rgb(var(--brass-glow) / .6); }
-.layer-toggle.is-on[data-layer="approve"]  { color: var(--ok);     border-color: rgb(var(--ok-glow) / .4); background: rgb(var(--ok-glow) / .06); }
-.layer-toggle.is-on[data-layer="approve"]  .glyph { background: var(--ok); box-shadow: 0 0 5px rgb(var(--ok-glow) / .6); }
-.layer-toggle.is-on[data-layer="notes"]    { color: var(--stalled); border-color: rgb(var(--stalled-glow) / .4); background: rgb(var(--stalled-glow) / .06); }
-.layer-toggle.is-on[data-layer="notes"]    .glyph { background: var(--stalled); box-shadow: 0 0 5px rgb(var(--stalled-glow) / .6); }
+.layer-toggle.is-on[data-layer="time"]     { color: var(--color-status-warn);   border-color: rgb(var(--warn-glow) / .4); background: rgb(var(--warn-glow) / .06); }
+.layer-toggle.is-on[data-layer="time"]     .glyph { background: var(--color-status-warn); box-shadow: 0 0 5px rgb(var(--warn-glow) / .6); }
+.layer-toggle.is-on[data-layer="parallel"] { color: var(--color-status-info);   border-color: rgb(var(--info-glow) / .4); background: rgb(var(--info-glow) / .06); }
+.layer-toggle.is-on[data-layer="parallel"] .glyph { background: var(--color-status-info); box-shadow: 0 0 5px rgb(var(--info-glow) / .6); }
+.layer-toggle.is-on[data-layer="tools"]    { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); background: rgb(var(--color-accent-glow) / .08); }
+.layer-toggle.is-on[data-layer="tools"]    .glyph { background: var(--color-accent-fg); box-shadow: 0 0 5px rgb(var(--color-accent-glow) / .6); }
+.layer-toggle.is-on[data-layer="approve"]  { color: var(--color-status-ok);     border-color: rgb(var(--ok-glow) / .4); background: rgb(var(--ok-glow) / .06); }
+.layer-toggle.is-on[data-layer="approve"]  .glyph { background: var(--color-status-ok); box-shadow: 0 0 5px rgb(var(--ok-glow) / .6); }
+.layer-toggle.is-on[data-layer="notes"]    { color: var(--color-status-stalled); border-color: rgb(var(--stalled-glow) / .4); background: rgb(var(--stalled-glow) / .06); }
+.layer-toggle.is-on[data-layer="notes"]    .glyph { background: var(--color-status-stalled); box-shadow: 0 0 5px rgb(var(--stalled-glow) / .6); }
 
 .layer-opacity {
   display: none;
@@ -77,7 +77,7 @@
   -webkit-appearance: none; appearance: none;
   width: 10px; height: 10px; border-radius: 50%;
   background: var(--color-accent-fg); cursor: pointer;
-  box-shadow: 0 0 4px rgb(var(--brass-glow) / .6);
+  box-shadow: 0 0 4px rgb(var(--color-accent-glow) / .6);
 }
 
 .layer-explode {
@@ -96,9 +96,9 @@
 }
 .layer-explode:hover { background: var(--color-bg-elevated); color: var(--color-fg-primary); }
 .layer-explode.is-on {
-  background: rgb(var(--brass-glow) / .12);
+  background: rgb(var(--color-accent-glow) / .12);
   color: var(--color-accent-fg);
-  border-color: var(--brass-3);
+  border-color: var(--color-accent-fg-dim);
 }
 
 /* ════════ DOT-MATRIX BACKGROUND ════════ */
@@ -106,7 +106,7 @@
   --dot-op: 0.12;
   --dot-size: 14px;
   background-image:
-    radial-gradient(circle at center, rgb(var(--brass-glow) / var(--dot-op)) 0.7px, transparent 1.2px);
+    radial-gradient(circle at center, rgb(var(--color-accent-glow) / var(--dot-op)) 0.7px, transparent 1.2px);
   background-size: var(--dot-size) var(--dot-size);
   background-position: 0 0;
   background-color: var(--color-bg-page);
@@ -147,7 +147,7 @@ body[data-explode="1"] .lyr-notes    { transform: translateZ(200px); }
 body[data-explode="1"] .lyr::before {
   content: "";
   position: absolute; inset: -4px;
-  border: 1px dashed rgb(var(--brass-glow) / .15);
+  border: 1px dashed rgb(var(--color-accent-glow) / .15);
   border-radius: 2px;
   pointer-events: none;
 }
@@ -162,14 +162,14 @@ body[data-explode="1"] .lyr::before {
 .time-stripe {
   position: absolute; left: 4px; width: 3px;
   border-radius: 1px;
-  background: var(--warn);
+  background: var(--color-status-warn);
   opacity: 0;
   transition: opacity var(--t-med) var(--ease), top var(--t-slow) var(--ease-out), height var(--t-slow) var(--ease-out);
 }
-.time-stripe.age-recent   { opacity: 1;   background: var(--warn);   box-shadow: 0 0 8px rgb(var(--warn-glow) / .6); }
-.time-stripe.age-near     { opacity: .7;  background: var(--warn); }
+.time-stripe.age-recent   { opacity: 1;   background: var(--color-status-warn);   box-shadow: 0 0 8px rgb(var(--warn-glow) / .6); }
+.time-stripe.age-near     { opacity: .7;  background: var(--color-status-warn); }
 .time-stripe.age-mid      { opacity: .4;  background: var(--color-fg-muted); }
-.time-stripe.age-far      { opacity: .2;  background: var(--fg-4); }
+.time-stripe.age-far      { opacity: .2;  background: var(--color-fg-disabled); }
 .time-stripe .time-label {
   position: absolute; left: 6px; top: 0;
   font-family: var(--font-mono); font-size: var(--fs-9);
@@ -227,18 +227,18 @@ body[data-explode="1"] .lyr::before {
 .tool-mark .tool-icon {
   font-size: 10px;
   color: var(--color-accent-fg);
-  text-shadow: 0 0 4px rgb(var(--brass-glow) / .6);
+  text-shadow: 0 0 4px rgb(var(--color-accent-glow) / .6);
   line-height: 1;
 }
 .tool-mark .tool-bar {
   width: 16px; height: 2px;
   background: linear-gradient(90deg, var(--color-accent-fg), transparent);
   border-radius: 1px;
-  box-shadow: 0 0 3px rgb(var(--brass-glow) / .4);
+  box-shadow: 0 0 3px rgb(var(--color-accent-glow) / .4);
 }
 .tool-mark .tool-count {
   font-size: var(--fs-9);
-  color: var(--fg-4);
+  color: var(--color-fg-disabled);
   font-family: var(--font-mono);
 }
 
@@ -257,12 +257,12 @@ body[data-explode="1"] .lyr::before {
 }
 .approve-stamp.k-approve {
   background: rgb(var(--ok-glow) / .05);
-  border-left: 2px solid var(--ok);
+  border-left: 2px solid var(--color-status-ok);
   box-shadow: inset 0 0 40px rgb(var(--ok-glow) / .04);
 }
 .approve-stamp.k-flag {
   background: rgb(var(--err-glow) / .07);
-  border-left: 2px solid var(--err);
+  border-left: 2px solid var(--color-status-err);
   box-shadow: inset 0 0 40px rgb(var(--err-glow) / .06);
   animation: flag-pulse 2.4s ease-in-out infinite;
 }
@@ -280,8 +280,8 @@ body[data-explode="1"] .lyr::before {
   transform: rotate(-12deg);
   text-transform: uppercase;
 }
-.approve-stamp.k-approve .stamp-glyph { color: var(--ok); }
-.approve-stamp.k-flag    .stamp-glyph { color: var(--err); }
+.approve-stamp.k-approve .stamp-glyph { color: var(--color-status-ok); }
+.approve-stamp.k-flag    .stamp-glyph { color: var(--color-status-err); }
 
 /* ════════ LYR: NOTES ════════
    Append-able pinned note cards, anchored to blocks. */
@@ -317,23 +317,23 @@ body[data-explode="1"] .lyr::before {
   position: absolute; left: -10px; top: 7px;
   width: 6px; height: 6px;
   border-radius: 50%;
-  background: var(--stalled);
+  background: var(--color-status-stalled);
   box-shadow: 0 0 5px rgb(var(--stalled-glow) / .6);
 }
 .note-pin .np-head {
   display: flex; align-items: baseline; gap: 6px;
   margin-bottom: 4px;
   font-family: var(--font-mono); font-size: var(--fs-9);
-  color: var(--stalled);
+  color: var(--color-status-stalled);
   letter-spacing: .06em; text-transform: uppercase;
 }
 .note-pin .np-head .np-author { color: var(--color-fg-muted); text-transform: none; letter-spacing: 0; }
-.note-pin .np-head .np-ts { margin-left: auto; color: var(--fg-4); }
+.note-pin .np-head .np-ts { margin-left: auto; color: var(--color-fg-disabled); }
 .note-pin .np-body { line-height: 1.4; color: var(--color-fg-primary); font-size: var(--fs-11); }
 .note-pin .np-actions {
   display: flex; gap: 4px; margin-top: 6px;
   font-size: var(--fs-9);
-  color: var(--fg-4);
+  color: var(--color-fg-disabled);
   font-family: var(--font-mono);
 }
 .note-pin .np-actions button {
@@ -341,7 +341,7 @@ body[data-explode="1"] .lyr::before {
   color: var(--color-fg-muted); cursor: pointer; font-size: var(--fs-9);
   letter-spacing: .06em; text-transform: uppercase;
 }
-.note-pin .np-actions button:hover { color: var(--stalled); }
+.note-pin .np-actions button:hover { color: var(--color-status-stalled); }
 .note-pin .np-actions .np-spacer { flex: 1; }
 
 /* Append-note composer at the bottom of notes layer */
@@ -353,7 +353,7 @@ body[data-explode="1"] .lyr::before {
   border: 1px dashed rgb(var(--stalled-glow) / .3);
   border-radius: var(--r-1);
   padding: 8px;
-  color: var(--stalled);
+  color: var(--color-status-stalled);
   font-size: var(--fs-10);
   font-family: var(--font-mono);
   letter-spacing: .06em;
@@ -376,7 +376,7 @@ body[data-explode="1"] .lyr::before {
 }
 .code-line.is-focused {
   filter: none;
-  background: rgb(var(--brass-glow) / .04);
+  background: rgb(var(--color-accent-glow) / .04);
 }
 
 /* ════════ Block recency aura (active when time layer on) ════════ */
@@ -385,7 +385,7 @@ body[data-layer-time="1"] .code-line.is-recent {
 }
 body[data-layer-time="1"] .code-line.is-very-recent {
   background: linear-gradient(90deg, rgb(var(--warn-glow) / .12), transparent 40%);
-  box-shadow: inset 3px 0 0 var(--warn);
+  box-shadow: inset 3px 0 0 var(--color-status-warn);
 }
 
 /* when explode is on, hide minimap (clutters the 3D view) */

--- a/dashboard/design-system/source_styles/layout.css
+++ b/dashboard/design-system/source_styles/layout.css
@@ -28,7 +28,7 @@
 .topbar-brand .brand-dot {
   display: inline-block; width: 7px; height: 7px;
   background: var(--brass-1); border-radius: 50%; margin-right: 8px;
-  box-shadow: 0 0 6px rgb(var(--brass-glow) / .5);
+  box-shadow: 0 0 6px rgb(var(--color-accent-glow) / .5);
 }
 .topbar-sep { width: 1px; height: 14px; background: var(--line-2); flex-shrink: 0; }
 .topbar-crumbs { display: flex; gap: var(--sp-2); color: var(--fg-3); min-width: 0; overflow: hidden; }
@@ -79,8 +79,8 @@
   color: var(--fg-1); font: var(--fs-13)/1 var(--font-sans);
   padding: 8px 12px; height: 32px; min-width: 0;
 }
-.composer-input::placeholder { color: var(--fg-4); }
-.composer-input:focus { border-color: var(--brass-3); outline: none; }
+.composer-input::placeholder { color: var(--color-fg-disabled); }
+.composer-input:focus { border-color: var(--color-accent-fg-dim); outline: none; }
 
 .pane { display: flex; flex-direction: column; min-height: 0; min-width: 0; border-bottom: 1px solid var(--line-1); }
 .pane:last-child { border-bottom: none; }
@@ -159,7 +159,7 @@
 .zone-deck {
   grid-area: deck;
   background: var(--bg-1);
-  border-top: 1px solid var(--line-3);
+  border-top: 1px solid var(--color-border-divider);
   display: flex; flex-direction: column;
   min-height: 0; min-width: 0;
   overflow: hidden;

--- a/dashboard/design-system/source_styles/lifeline.css
+++ b/dashboard/design-system/source_styles/lifeline.css
@@ -39,7 +39,7 @@
   width: 6px; height: 6px;
   border-radius: 50%;
   background: var(--brass-1);
-  box-shadow: 0 0 6px rgb(var(--brass-glow) / .7);
+  box-shadow: 0 0 6px rgb(var(--color-accent-glow) / .7);
   animation: anim-heartbeat 1.4s var(--ease-inout) infinite;
   margin-left: auto;
   flex-shrink: 0;
@@ -60,7 +60,7 @@
   border-bottom: 1px dotted var(--line-1);
   font-family: var(--font-mono);
   font-size: var(--fs-9);
-  color: var(--fg-4);
+  color: var(--color-fg-disabled);
   letter-spacing: 0;
   overflow: hidden;
   flex-shrink: 0;
@@ -113,14 +113,14 @@
 .ll-cell:hover { transform: scaleY(1.12); filter: brightness(1.3); outline-color: var(--fg-2); z-index: 2; }
 .ll-cell.is-active {
   outline-color: var(--brass-1);
-  box-shadow: 0 0 8px rgb(var(--brass-glow) / .5);
+  box-shadow: 0 0 8px rgb(var(--color-accent-glow) / .5);
   z-index: 3;
 }
 .ll-cell.k-tool  { background: var(--brass-2); }
-.ll-cell.k-claim { background: var(--ok); }
-.ll-cell.k-text  { background: var(--info); }
-.ll-cell.k-noop  { background: var(--idle); opacity: .45; }
-.ll-cell.k-error { background: var(--err); }
+.ll-cell.k-claim { background: var(--color-status-ok); }
+.ll-cell.k-text  { background: var(--color-status-info); }
+.ll-cell.k-noop  { background: var(--color-status-idle); opacity: .45; }
+.ll-cell.k-error { background: var(--color-status-err); }
 
 /* turn separator — thin dashed vertical */
 .ll-turnsep {
@@ -182,7 +182,7 @@
   width: 6px; height: 6px;
   border-radius: 50%;
   background: var(--brass-1);
-  box-shadow: 0 0 8px rgb(var(--brass-glow) / .8);
+  box-shadow: 0 0 8px rgb(var(--color-accent-glow) / .8);
   animation: anim-heartbeat 1.4s var(--ease-inout) infinite;
   align-self: center;
   margin-left: 4px;

--- a/dashboard/design-system/source_styles/primitives.css
+++ b/dashboard/design-system/source_styles/primitives.css
@@ -18,12 +18,12 @@
   border-radius: var(--r-1);
   white-space: nowrap;
 }
-.chip.is-brass { color: var(--brass-1); border-color: var(--brass-3); background: rgb(var(--brass-glow) / .08); }
-.chip.is-ok    { color: var(--ok);    border-color: rgb(var(--ok-glow) / .35); background: rgb(var(--ok-glow) / .08); }
-.chip.is-warn  { color: var(--warn);  border-color: rgb(var(--warn-glow) / .35); background: rgb(var(--warn-glow) / .08); }
-.chip.is-err   { color: var(--err);   border-color: rgb(var(--err-glow) / .35); background: rgb(var(--err-glow) / .08); }
-.chip.is-info  { color: var(--info);  border-color: rgb(var(--info-glow) / .35); background: rgb(var(--info-glow) / .08); }
-.chip.is-stalled { color: var(--stalled); border-color: rgb(var(--stalled-glow) / .35); background: rgb(var(--stalled-glow) / .08); }
+.chip.is-brass { color: var(--brass-1); border-color: var(--color-accent-fg-dim); background: rgb(var(--color-accent-glow) / .08); }
+.chip.is-ok    { color: var(--color-status-ok);    border-color: rgb(var(--ok-glow) / .35); background: rgb(var(--ok-glow) / .08); }
+.chip.is-warn  { color: var(--color-status-warn);  border-color: rgb(var(--warn-glow) / .35); background: rgb(var(--warn-glow) / .08); }
+.chip.is-err   { color: var(--color-status-err);   border-color: rgb(var(--err-glow) / .35); background: rgb(var(--err-glow) / .08); }
+.chip.is-info  { color: var(--color-status-info);  border-color: rgb(var(--info-glow) / .35); background: rgb(var(--info-glow) / .08); }
+.chip.is-stalled { color: var(--color-status-stalled); border-color: rgb(var(--stalled-glow) / .35); background: rgb(var(--stalled-glow) / .08); }
 .chip.is-ghost { background: transparent; border-color: var(--line-2); }
 
 /* chip size variants */
@@ -46,13 +46,13 @@
   border-radius: 999px;
   white-space: nowrap;
 }
-.pill.is-running { color: var(--brass-1); background: rgb(var(--brass-glow) / .12); }
+.pill.is-running { color: var(--brass-1); background: rgb(var(--color-accent-glow) / .12); }
 .pill.is-paused  { color: var(--fg-3);    background: var(--bg-3); }
-.pill.is-ok      { color: var(--ok);      background: rgb(var(--ok-glow) / .12); }
-.pill.is-err     { color: var(--err);     background: rgb(var(--err-glow) / .12); }
-.pill.is-warn    { color: var(--warn);    background: rgb(var(--warn-glow) / .12); }
-.pill.is-info    { color: var(--info);    background: rgb(var(--info-glow) / .12); }
-.pill.is-stalled { color: var(--stalled); background: rgb(var(--stalled-glow) / .12); }
+.pill.is-ok      { color: var(--color-status-ok);      background: rgb(var(--ok-glow) / .12); }
+.pill.is-err     { color: var(--color-status-err);     background: rgb(var(--err-glow) / .12); }
+.pill.is-warn    { color: var(--color-status-warn);    background: rgb(var(--warn-glow) / .12); }
+.pill.is-info    { color: var(--color-status-info);    background: rgb(var(--info-glow) / .12); }
+.pill.is-stalled { color: var(--color-status-stalled); background: rgb(var(--stalled-glow) / .12); }
 
 /* ════════ BAR ════════
    Progress bar — fill inside track. Used in tasks, goals, budgets. */
@@ -69,9 +69,9 @@
   background: var(--brass-2);
   transition: width var(--t-med) var(--ease-out);
 }
-.bar.is-ok  > .fill { background: var(--ok); }
-.bar.is-warn > .fill { background: var(--warn); }
-.bar.is-err > .fill { background: var(--err); }
+.bar.is-ok  > .fill { background: var(--color-status-ok); }
+.bar.is-warn > .fill { background: var(--color-status-warn); }
+.bar.is-err > .fill { background: var(--color-status-err); }
 
 /* bar with segments (a/b/c split — e.g. passing/failing/skipped) */
 .bar-seg {
@@ -79,10 +79,10 @@
   background: var(--bg-3); border-radius: 2px; overflow: hidden;
 }
 .bar-seg > span { display: block; height: 100%; }
-.bar-seg .seg-ok { background: var(--ok); }
-.bar-seg .seg-err { background: var(--err); }
-.bar-seg .seg-warn { background: var(--warn); }
-.bar-seg .seg-idle { background: var(--idle); }
+.bar-seg .seg-ok { background: var(--color-status-ok); }
+.bar-seg .seg-err { background: var(--color-status-err); }
+.bar-seg .seg-warn { background: var(--color-status-warn); }
+.bar-seg .seg-idle { background: var(--color-status-idle); }
 
 /* ════════ SPARK ════════
    Tiny bar-chart trend. Used in KPI strip + provider table.
@@ -98,11 +98,11 @@
   border-radius: 1px;
 }
 .spark.is-brass > i { background: var(--brass-2); }
-.spark.is-ok > i { background: var(--ok); }
-.spark.is-err > i { background: var(--err); }
-.spark.is-warn > i { background: var(--warn); }
+.spark.is-ok > i { background: var(--color-status-ok); }
+.spark.is-err > i { background: var(--color-status-err); }
+.spark.is-warn > i { background: var(--color-status-warn); }
 /* last bar brightens to signal "now" */
-.spark > i:last-child { background: var(--brass-1); box-shadow: 0 0 3px rgb(var(--brass-glow) / .5); }
+.spark > i:last-child { background: var(--brass-1); box-shadow: 0 0 3px rgb(var(--color-accent-glow) / .5); }
 
 /* ════════ SECTION HEAD ════════
    Panel header strip — small-caps label + optional right chip. */
@@ -118,7 +118,7 @@
   color: var(--fg-3);
   flex-shrink: 0;
 }
-.section-head > .count { margin-left: auto; font-family: var(--font-mono); color: var(--fg-4); font-weight: 500; }
+.section-head > .count { margin-left: auto; font-family: var(--font-mono); color: var(--color-fg-disabled); font-weight: 500; }
 .section-head > .tail  { margin-left: auto; display: flex; gap: 4px; align-items: center; }
 
 /* ════════ KV ROW ════════
@@ -146,16 +146,16 @@
 .btn.primary {
   background: var(--brass-2);
   color: var(--bg-0);
-  border-color: var(--brass-3);
+  border-color: var(--color-accent-fg-dim);
   font-weight: 600;
 }
 .btn.primary:hover { background: var(--brass-1); color: var(--bg-0); }
 
 .btn.danger {
   border-color: rgb(var(--err-glow) / .4);
-  color: var(--err);
+  color: var(--color-status-err);
 }
-.btn.danger:hover { background: rgb(var(--err-glow) / .1); color: var(--err); }
+.btn.danger:hover { background: rgb(var(--err-glow) / .1); color: var(--color-status-err); }
 
 .btn.ghost { border-color: transparent; color: var(--fg-3); }
 .btn.ghost:hover { background: var(--bg-2); color: var(--fg-1); }
@@ -189,11 +189,11 @@
   background: var(--line-2);
   border-radius: 1px 1px 0 0;
 }
-.band.is-running { background: var(--brass-1); box-shadow: 0 0 6px rgb(var(--brass-glow) / .5); }
-.band.is-ok      { background: var(--ok); }
-.band.is-warn    { background: var(--warn); }
-.band.is-err     { background: var(--err); }
-.band.is-stalled { background: var(--stalled); }
+.band.is-running { background: var(--brass-1); box-shadow: 0 0 6px rgb(var(--color-accent-glow) / .5); }
+.band.is-ok      { background: var(--color-status-ok); }
+.band.is-warn    { background: var(--color-status-warn); }
+.band.is-err     { background: var(--color-status-err); }
+.band.is-stalled { background: var(--color-status-stalled); }
 
 /* ════════ SEP ════════ */
 .sep-v { width: 1px; height: 16px; background: var(--line-2); margin: 0 var(--sp-2); }
@@ -208,8 +208,8 @@
   background: var(--bg-3);
   color: var(--fg-1);
 }
-.tk.is-brass { color: var(--brass-1); background: rgb(var(--brass-glow) / .08); }
-.tk.is-err   { color: var(--err);     background: rgb(var(--err-glow) / .08); }
+.tk.is-brass { color: var(--brass-1); background: rgb(var(--color-accent-glow) / .08); }
+.tk.is-err   { color: var(--color-status-err);     background: rgb(var(--err-glow) / .08); }
 
 /* ════════ SCROLL PANEL ════════
    Standard scrolling inner panel — flex:1 + min-height:0 + overflow. */
@@ -219,7 +219,7 @@
 /* ════════ TYPE ROLE CLASSES ════════
    Prefer these over raw --fs-* sizes in new styles. Role names
    match tokens.css. Each applies font shorthand + sensible color. */
-.t-micro   { font: var(--type-micro);   color: var(--fg-4); letter-spacing: var(--track-caps); text-transform: uppercase; }
+.t-micro   { font: var(--type-micro);   color: var(--color-fg-disabled); letter-spacing: var(--track-caps); text-transform: uppercase; }
 .t-caption { font: var(--type-caption); color: var(--fg-3); letter-spacing: var(--track-wide); }
 .t-label   { font: var(--type-label);   color: var(--fg-3); letter-spacing: var(--track-caps); text-transform: uppercase; font-weight: var(--fw-semi); }
 .t-meta    { font: var(--type-meta);    color: var(--fg-3); }
@@ -233,7 +233,7 @@
 
 /* colour-modifier classes that pair with type roles */
 .t-dim { color: var(--fg-3); }
-.t-mute { color: var(--fg-4); }
+.t-mute { color: var(--color-fg-disabled); }
 .t-brass { color: var(--brass-1); }
 .t-ok { color: var(--ok-fg); }
 .t-warn { color: var(--warn-fg); }
@@ -304,8 +304,8 @@ body[data-grid="1"]::before {
   pointer-events: none;
   z-index: var(--z-toast);
   background-image:
-    linear-gradient(to right,  rgb(var(--brass-glow) / .06) 1px, transparent 1px),
-    linear-gradient(to bottom, rgb(var(--brass-glow) / .06) 1px, transparent 1px);
+    linear-gradient(to right,  rgb(var(--color-accent-glow) / .06) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(var(--color-accent-glow) / .06) 1px, transparent 1px);
   background-size: var(--grid-unit) var(--grid-unit);
 }
 
@@ -319,7 +319,7 @@ body[data-grid="1"]::before {
 @keyframes anim-slide-right { from { opacity: 0; transform: translateX(-8px); } to { opacity: 1; transform: none; } }
 @keyframes anim-pop         { from { opacity: 0; transform: scale(.92); } to { opacity: 1; transform: none; } }
 @keyframes anim-pulse       { 0%,100% { opacity: 1; } 50% { opacity: .55; } }
-@keyframes anim-pulse-glow  { 0%,100% { box-shadow: 0 0 0 rgb(var(--brass-glow) / 0); } 50% { box-shadow: 0 0 10px rgb(var(--brass-glow) / .5); } }
+@keyframes anim-pulse-glow  { 0%,100% { box-shadow: 0 0 0 rgb(var(--color-accent-glow) / 0); } 50% { box-shadow: 0 0 10px rgb(var(--color-accent-glow) / .5); } }
 @keyframes anim-pulse-err   { 0%,100% { box-shadow: 0 0 0 rgb(var(--err-glow)   / 0); } 50% { box-shadow: 0 0 10px rgb(var(--err-glow)   / .55); } }
 @keyframes anim-pulse-warn  { 0%,100% { box-shadow: 0 0 0 rgb(var(--warn-glow)  / 0); } 50% { box-shadow: 0 0 10px rgb(var(--warn-glow)  / .5); } }
 @keyframes anim-pulse-ok    { 0%,100% { box-shadow: 0 0 0 rgb(var(--ok-glow)    / 0); } 50% { box-shadow: 0 0 10px rgb(var(--ok-glow)    / .5); } }
@@ -382,7 +382,7 @@ body[data-grid="1"]::before {
 .is-loading::after {
   content: "";
   position: absolute; inset: 0;
-  background: linear-gradient(90deg, transparent, rgb(var(--brass-glow) / .08), transparent);
+  background: linear-gradient(90deg, transparent, rgb(var(--color-accent-glow) / .08), transparent);
   background-size: 200% 100%;
   animation: anim-shimmer 1.4s linear infinite;
 }

--- a/dashboard/design-system/source_styles/rail.css
+++ b/dashboard/design-system/source_styles/rail.css
@@ -30,18 +30,18 @@
 
 .goal-text {
   font-size: var(--fs-12); color: var(--fg-1); line-height: 1.5;
-  background: var(--bg-2); border-left: 2px solid var(--brass-3);
+  background: var(--bg-2); border-left: 2px solid var(--color-accent-fg-dim);
   padding: var(--sp-2) var(--sp-3);
   border-radius: 0 var(--r-1) var(--r-1) 0; margin: 4px 0 8px;
 }
 .goal-text.is-short { border-left-color: var(--brass-1); }
 .goal-text.is-mid { border-left-color: var(--brass-2); }
-.goal-text.is-long { border-left-color: var(--brass-3); }
+.goal-text.is-long { border-left-color: var(--color-accent-fg-dim); }
 
 .blocker-banner {
   background: rgb(196 106 90 / .08);
   border: 1px solid rgb(196 106 90 / .3);
-  border-left: 3px solid var(--err);
+  border-left: 3px solid var(--color-status-err);
   padding: var(--sp-2) var(--sp-3);
   border-radius: var(--r-1);
   font-size: var(--fs-12); color: var(--fg-1); line-height: 1.4;
@@ -49,7 +49,7 @@
 }
 .blocker-banner .blocker-class {
   font-family: var(--font-mono); font-size: var(--fs-11);
-  color: var(--err); text-transform: uppercase; letter-spacing: .05em; margin-bottom: 4px;
+  color: var(--color-status-err); text-transform: uppercase; letter-spacing: .05em; margin-bottom: 4px;
 }
 
 .cascade-models { display: flex; flex-direction: column; gap: 2px; padding: 2px 0; }
@@ -78,7 +78,7 @@
 .tool-chip.is-last {
   border-color: var(--brass-1);
   color: var(--brass-1);
-  background: rgb(var(--brass-glow) / 0.08);
+  background: rgb(var(--color-accent-glow) / 0.08);
 }
 .tool-count {
   font-size: 9px; color: var(--fg-3);
@@ -87,7 +87,7 @@
 }
 .tool-chip.is-last .tool-count {
   color: var(--brass-1);
-  background: rgb(var(--brass-glow) / 0.15);
+  background: rgb(var(--color-accent-glow) / 0.15);
 }
 
 /* Tool Timeline (inspector tab) */
@@ -128,7 +128,7 @@
 }
 .tl-dot:hover { transform: translate(-50%, -50%) scale(1.6); z-index: 2; }
 .tl-dot.is-err {
-  box-shadow: 0 0 0 1px var(--err);
+  box-shadow: 0 0 0 1px var(--color-status-err);
 }
 
 .tl-legend {

--- a/dashboard/design-system/source_styles/sidebar.css
+++ b/dashboard/design-system/source_styles/sidebar.css
@@ -67,20 +67,20 @@
   line-height: 1.2; align-self: start;
   margin-top: 1px;
 }
-.sb-tag-active   { color: var(--ok);    border-color: rgb(107 158 107 / .4); }
-.sb-tag-blocked  { color: var(--warn);  border-color: rgb(194 157 94 / .4); }
-.sb-tag-stalled  { color: var(--idle);  }
-.sb-tag-done     { color: var(--info);  border-color: rgb(106 142 176 / .4); }
-.sb-tag-short    { color: var(--ok);    border-color: rgb(107 158 107 / .4); }
-.sb-tag-mid      { color: var(--brass-1); border-color: var(--brass-3); }
-.sb-tag-long     { color: var(--info);  border-color: rgb(106 142 176 / .4); }
-.sb-tag-tool     { color: var(--brass-1); border-color: var(--brass-3); }
-.sb-tag-claim    { color: var(--ok);    border-color: rgb(107 158 107 / .4); }
-.sb-tag-text     { color: var(--info);  border-color: rgb(106 142 176 / .4); }
-.sb-tag-error    { color: var(--err);   border-color: rgb(196 106 90 / .4); }
-.sb-tag-noop     { color: var(--fg-4); }
-.sb-tag-cont     { color: var(--brass-1); border-color: var(--brass-3); }
-.sb-tag-spk      { color: var(--info); }
+.sb-tag-active   { color: var(--color-status-ok);    border-color: rgb(107 158 107 / .4); }
+.sb-tag-blocked  { color: var(--color-status-warn);  border-color: rgb(194 157 94 / .4); }
+.sb-tag-stalled  { color: var(--color-status-idle);  }
+.sb-tag-done     { color: var(--color-status-info);  border-color: rgb(106 142 176 / .4); }
+.sb-tag-short    { color: var(--color-status-ok);    border-color: rgb(107 158 107 / .4); }
+.sb-tag-mid      { color: var(--brass-1); border-color: var(--color-accent-fg-dim); }
+.sb-tag-long     { color: var(--color-status-info);  border-color: rgb(106 142 176 / .4); }
+.sb-tag-tool     { color: var(--brass-1); border-color: var(--color-accent-fg-dim); }
+.sb-tag-claim    { color: var(--color-status-ok);    border-color: rgb(107 158 107 / .4); }
+.sb-tag-text     { color: var(--color-status-info);  border-color: rgb(106 142 176 / .4); }
+.sb-tag-error    { color: var(--color-status-err);   border-color: rgb(196 106 90 / .4); }
+.sb-tag-noop     { color: var(--color-fg-disabled); }
+.sb-tag-cont     { color: var(--brass-1); border-color: var(--color-accent-fg-dim); }
+.sb-tag-spk      { color: var(--color-status-info); }
 .sb-tag-note     { color: var(--fg-3); }
 
 .sb-empty {
@@ -112,8 +112,8 @@
   display: flex; flex-direction: column; align-items: center; gap: 1px; line-height: 1;
 }
 .sb-tab:hover { background: var(--bg-3); color: var(--fg-1); }
-.sb-tab.is-active { background: var(--bg-3); border-color: var(--brass-3); color: var(--brass-1); }
-.sb-tab-count { font-size: 10px; color: var(--fg-4); font-variant-numeric: tabular-nums; }
+.sb-tab.is-active { background: var(--bg-3); border-color: var(--color-accent-fg-dim); color: var(--brass-1); }
+.sb-tab-count { font-size: 10px; color: var(--color-fg-disabled); font-variant-numeric: tabular-nums; }
 .sb-tab.is-active .sb-tab-count { color: var(--brass-1); }
 .sb-search { padding: 6px 8px; border-bottom: 1px solid var(--line-1); flex-shrink: 0; }
 .sb-search input {
@@ -122,7 +122,7 @@
   color: var(--fg-1); font: 11px/1 var(--font-mono);
   padding: 5px 8px; height: 24px;
 }
-.sb-search input:focus { border-color: var(--brass-3); outline: none; }
+.sb-search input:focus { border-color: var(--color-accent-fg-dim); outline: none; }
 .sidebar-list { flex: 1; min-height: 0; padding: 0 0 8px; overflow-y: auto; }
 .keeper-row {
   display: grid; grid-template-columns: 8px minmax(0, 1fr) auto;

--- a/dashboard/design-system/source_styles/swimlanes.css
+++ b/dashboard/design-system/source_styles/swimlanes.css
@@ -45,7 +45,7 @@
 .sl-range {
   margin-left: auto;
   font-family: var(--font-mono); font-size: 10px;
-  color: var(--fg-4);
+  color: var(--color-fg-disabled);
   flex-shrink: 0;
   padding-left: var(--sp-3);
 }
@@ -65,7 +65,7 @@
   position: relative; flex-shrink: 0;
 }
 .sl-toggle input:checked {
-  background: var(--brass-3); border-color: var(--brass-2);
+  background: var(--color-accent-fg-dim); border-color: var(--brass-2);
 }
 .sl-toggle input:checked::after {
   content: ""; position: absolute; inset: 1px;
@@ -105,7 +105,7 @@
   position: absolute; top: 6px;
   transform: translateX(-50%);
   font-family: var(--font-mono); font-size: 10px;
-  color: var(--fg-4); white-space: nowrap;
+  color: var(--color-fg-disabled); white-space: nowrap;
   font-variant-numeric: tabular-nums;
 }
 .sl-tick.is-major { color: var(--fg-2); }
@@ -117,7 +117,7 @@
   letter-spacing: .12em;
   padding: 2px 4px;
   background: var(--bg-0);
-  border: 1px solid var(--brass-3);
+  border: 1px solid var(--color-accent-fg-dim);
   border-radius: 2px;
   z-index: 3;
 }
@@ -140,11 +140,11 @@
   position: absolute; top: 0; bottom: 0;
   width: 1px;
   background: linear-gradient(to bottom,
-    rgb(var(--brass-glow) / .0),
-    rgb(var(--brass-glow) / .7) 6%,
-    rgb(var(--brass-glow) / .7) 94%,
-    rgb(var(--brass-glow) / .0));
-  box-shadow: 0 0 4px rgb(var(--brass-glow) / .5);
+    rgb(var(--color-accent-glow) / .0),
+    rgb(var(--color-accent-glow) / .7) 6%,
+    rgb(var(--color-accent-glow) / .7) 94%,
+    rgb(var(--color-accent-glow) / .0));
+  box-shadow: 0 0 4px rgb(var(--color-accent-glow) / .5);
   pointer-events: none;
   z-index: 4;
 }
@@ -169,14 +169,14 @@
 .sl-row:hover { background: rgb(255 255 255 / .02); }
 .sl-row.is-active { background: var(--bg-2); }
 .sl-row.is-active .sl-name { color: var(--brass-1); }
-.sl-row.is-active .sl-status.dot-running { box-shadow: 0 0 6px rgb(var(--brass-glow) / .8); }
+.sl-row.is-active .sl-status.dot-running { box-shadow: 0 0 6px rgb(var(--color-accent-glow) / .8); }
 
 /* status tinted backgrounds — very subtle */
 .sl-row.st-error     { background: rgb(196 106 90 / .04); }
 .sl-row.st-error.is-active { background: rgb(196 106 90 / .10); }
 .sl-row.st-blocker   { background: rgb(201 162 74 / .04); }
 .sl-row.st-blocker.is-active { background: rgb(201 162 74 / .09); }
-.sl-row.st-running   { background: rgb(var(--brass-glow) / .02); }
+.sl-row.st-running   { background: rgb(var(--color-accent-glow) / .02); }
 
 /* collapsed empty lane — smaller, muted */
 .sl-row-collapsed {
@@ -191,7 +191,7 @@
 .sl-empty-note {
   position: absolute; left: 50%; top: 50%;
   transform: translate(-50%, -50%);
-  font: 9px/1 var(--font-mono); color: var(--fg-4);
+  font: 9px/1 var(--font-mono); color: var(--color-fg-disabled);
   letter-spacing: .08em;
 }
 
@@ -209,13 +209,13 @@
 }
 .sl-status {
   width: 6px; height: 6px; border-radius: 50%;
-  flex-shrink: 0; background: var(--idle);
+  flex-shrink: 0; background: var(--color-status-idle);
 }
-.sl-status.dot-running { background: var(--ok); box-shadow: 0 0 4px var(--ok); }
-.sl-status.dot-error { background: var(--err); }
-.sl-status.dot-blocker { background: var(--warn); }
-.sl-status.dot-stalled { background: var(--stalled); }
-.sl-status.dot-idle { background: var(--idle); }
+.sl-status.dot-running { background: var(--color-status-ok); box-shadow: 0 0 4px var(--color-status-ok); }
+.sl-status.dot-error { background: var(--color-status-err); }
+.sl-status.dot-blocker { background: var(--color-status-warn); }
+.sl-status.dot-stalled { background: var(--color-status-stalled); }
+.sl-status.dot-idle { background: var(--color-status-idle); }
 
 .sl-name {
   color: var(--fg-1); font-weight: 500;
@@ -230,7 +230,7 @@
   display: flex; gap: 3px;
 }
 .sl-meta b { color: var(--fg-1); font-weight: 500; }
-.sl-meta .err { color: var(--err); }
+.sl-meta .err { color: var(--color-status-err); }
 
 /* mini-sparkline in label */
 .sl-spark {
@@ -246,9 +246,9 @@
   background: var(--fg-3);
   border-radius: 1px 1px 0 0;
 }
-.sl-spark-bar.is-err { background: var(--err); }
+.sl-spark-bar.is-err { background: var(--color-status-err); }
 .sl-row.is-active .sl-spark-bar { background: var(--brass-2); }
-.sl-row.is-active .sl-spark-bar.is-err { background: var(--err); }
+.sl-row.is-active .sl-spark-bar.is-err { background: var(--color-status-err); }
 
 /* ─── track ─── */
 .sl-track {
@@ -267,7 +267,7 @@
   position: absolute; top: 2px; bottom: 2px;
   background: var(--brass-2);
 }
-.sl-heat.is-err { background: var(--err); }
+.sl-heat.is-err { background: var(--color-status-err); }
 
 .sl-grid {
   position: absolute; top: 0; bottom: 0;
@@ -287,7 +287,7 @@
   background: var(--brass-1);
   opacity: .8;
   pointer-events: none;
-  box-shadow: 0 0 3px rgb(var(--brass-glow) / .7);
+  box-shadow: 0 0 3px rgb(var(--color-accent-glow) / .7);
   z-index: 2;
 }
 
@@ -315,7 +315,7 @@
 }
 /* claim = diamond, green */
 .sl-glyph.k-claim .sl-glyph-mark {
-  background: var(--ok);
+  background: var(--color-status-ok);
   transform: rotate(45deg) scale(.75);
   border-radius: 1px;
   min-width: 5px;
@@ -328,7 +328,7 @@
 }
 /* text = thin line, info */
 .sl-glyph.k-text .sl-glyph-mark {
-  background: var(--info);
+  background: var(--color-status-info);
   opacity: .75;
   height: 40%;
   min-width: 2px;
@@ -339,13 +339,13 @@
   height: 30% !important;
 }
 .sl-glyph.k-noop .sl-glyph-mark {
-  background: var(--fg-4);
+  background: var(--color-fg-disabled);
   min-width: 2px;
   opacity: .6;
 }
 /* error = cross, red */
 .sl-glyph.k-error .sl-glyph-mark {
-  background: var(--err);
+  background: var(--color-status-err);
   min-width: 8px;
   width: 8px; height: 8px;
   clip-path: polygon(20% 0, 50% 30%, 80% 0, 100% 20%, 70% 50%, 100% 80%, 80% 100%, 50% 70%, 20% 100%, 0 80%, 30% 50%, 0 20%);
@@ -357,7 +357,7 @@
 }
 
 .sl-glyph.is-err .sl-glyph-mark {
-  outline: 1px solid var(--err);
+  outline: 1px solid var(--color-status-err);
   outline-offset: 1px;
 }
 .sl-glyph:hover {
@@ -375,7 +375,7 @@
   z-index: 4;
 }
 .sl-glyph.is-active .sl-glyph-mark {
-  box-shadow: 0 0 0 2px var(--bg-0), 0 0 0 3px var(--brass-1), 0 0 6px rgb(var(--brass-glow) / .7);
+  box-shadow: 0 0 0 2px var(--bg-0), 0 0 0 3px var(--brass-1), 0 0 6px rgb(var(--color-accent-glow) / .7);
   transform: scale(1.3);
   filter: brightness(1.2);
 }
@@ -402,7 +402,7 @@
 }
 .sl-ho-line {
   fill: none;
-  stroke: var(--brass-3);
+  stroke: var(--color-accent-fg-dim);
   stroke-width: 1;
   opacity: .35;
   stroke-linecap: round;
@@ -415,7 +415,7 @@
   transition: r var(--t-fast), fill var(--t-fast), opacity var(--t-fast);
 }
 .sl-ho-tail {
-  fill: var(--brass-3);
+  fill: var(--color-accent-fg-dim);
   opacity: .45;
 }
 .sl-ho.is-involved .sl-ho-line { stroke: var(--brass-1); opacity: .65; stroke-dasharray: none; }
@@ -425,7 +425,7 @@
   stroke-width: 1.6;
   opacity: 1;
   stroke-dasharray: none;
-  filter: drop-shadow(0 0 3px rgb(var(--brass-glow) / .7));
+  filter: drop-shadow(0 0 3px rgb(var(--color-accent-glow) / .7));
 }
 .sl-ho:hover .sl-ho-head { fill: var(--brass-1); opacity: 1; }
 .sl-ho.is-active .sl-ho-line {
@@ -449,17 +449,17 @@
   z-index: 3;
   background: var(--bg-3);
   color: var(--fg-1);
-  border: 1px solid var(--line-3);
+  border: 1px solid var(--color-border-divider);
   font-variant-numeric: tabular-nums;
   letter-spacing: 0;
   transition: transform var(--t-fast) var(--ease), box-shadow var(--t-fast);
 }
-.sl-cluster.k-tool { border-color: var(--brass-3); color: var(--brass-1); }
-.sl-cluster.k-claim { border-color: var(--ok); color: var(--ok); }
+.sl-cluster.k-tool { border-color: var(--color-accent-fg-dim); color: var(--brass-1); }
+.sl-cluster.k-claim { border-color: var(--color-status-ok); color: var(--color-status-ok); }
 .sl-cluster.k-error,
 .sl-cluster.is-err {
-  background: var(--err);
-  border-color: var(--err);
+  background: var(--color-status-err);
+  border-color: var(--color-status-err);
   color: var(--bg-0);
 }
 .sl-cluster:hover {

--- a/dashboard/design-system/source_styles/ticker.css
+++ b/dashboard/design-system/source_styles/ticker.css
@@ -78,6 +78,6 @@
 }
 .tk-arrow { display: inline-block; margin-right: 2px; font-size: 8px; }
 
-.tk-item.tk-up   .tk-delta { color: var(--ok); }
-.tk-item.tk-down .tk-delta { color: var(--err); }
+.tk-item.tk-up   .tk-delta { color: var(--color-status-ok); }
+.tk-item.tk-down .tk-delta { color: var(--color-status-err); }
 .tk-item.tk-flat .tk-delta { color: var(--color-fg-muted); }

--- a/dashboard/design-system/ui_kits/cockpit/cockpit.css
+++ b/dashboard/design-system/ui_kits/cockpit/cockpit.css
@@ -22,7 +22,7 @@
   --w-side: 200px;
   --w-rail: 320px;
 
-  --glow: 0 0 12px rgb(var(--brass-glow) / .5);
+  --glow: 0 0 12px rgb(var(--color-accent-glow) / .5);
 }
 
 html, body, #root { height: 100%; margin: 0; }
@@ -137,15 +137,15 @@ button { font: inherit; }
 @keyframes ticker-slide { from { transform: translateX(0); } to { transform: translateX(-100%); } }
 @media (prefers-reduced-motion: reduce) { .ticker-run { animation: none; } }
 .tk-ev { display: inline-flex; align-items: center; gap: 8px; font: 11px/1 var(--font-mono); color: var(--fg-2); }
-.tk-ev .t { color: var(--fg-4); }
+.tk-ev .t { color: var(--color-fg-disabled); }
 .tk-ev .n { color: var(--fg-1); }
 .tk-ev .k { text-transform: uppercase; letter-spacing: var(--track-caps); font-size: 9px; padding: 2px 5px; border-radius: 2px; font-weight: 600; }
-.tk-ev .k.tool  { color: var(--brass-1); background: rgb(var(--brass-glow)/.08); }
+.tk-ev .k.tool  { color: var(--brass-1); background: rgb(var(--color-accent-glow)/.08); }
 .tk-ev .k.err   { color: var(--err-fg);  background: rgb(196 106 90 / .1); }
 .tk-ev .k.claim { color: var(--info-fg); background: rgb(106 142 176 / .1); }
 .tk-ev .k.flag  { color: var(--warn-fg); background: rgb(201 162 74 / .1); }
 .tk-ev .k.note  { color: var(--fg-3);    background: var(--bg-2); }
-.tk-sep { color: var(--fg-4); }
+.tk-sep { color: var(--color-fg-disabled); }
 
 /* ═══════════════ KPI STRIP ═══════════════ */
 .kpi {
@@ -162,7 +162,7 @@ button { font: inherit; }
   position: relative;
 }
 .kpi-cell:last-child { border-right: 0; }
-.kpi-cell.live { background: linear-gradient(180deg, rgb(var(--brass-glow)/.04), transparent); }
+.kpi-cell.live { background: linear-gradient(180deg, rgb(var(--color-accent-glow)/.04), transparent); }
 .kpi-cell.live::before {
   content: ""; position: absolute; top: 10px; right: 10px;
   width: 6px; height: 6px; border-radius: 50%;
@@ -170,8 +170,8 @@ button { font: inherit; }
   animation: pulse 1.6s infinite;
 }
 @keyframes pulse {
-  0%,100% { box-shadow: 0 0 0 0 rgb(var(--brass-glow)/.6); transform: scale(1); }
-  50%     { box-shadow: 0 0 0 5px rgb(var(--brass-glow)/0);  transform: scale(1.2); }
+  0%,100% { box-shadow: 0 0 0 0 rgb(var(--color-accent-glow)/.6); transform: scale(1); }
+  50%     { box-shadow: 0 0 0 5px rgb(var(--color-accent-glow)/0);  transform: scale(1.2); }
 }
 .kpi-l { font: 600 9px/1 var(--font-mono); letter-spacing: var(--track-caps); text-transform: uppercase; color: var(--fg-3); }
 .kpi-v { font: 600 20px/1.05 var(--font-mono); color: var(--fg-1); font-variant-numeric: tabular-nums; }
@@ -206,7 +206,7 @@ button { font: inherit; }
 /* ═══════════════ SIDEBAR ═══════════════ */
 .side {
   background: var(--bg-1);
-  border-right: 1px solid var(--line-3);
+  border-right: 1px solid var(--color-border-divider);
   display: flex; flex-direction: column;
 }
 .side-sect { display: flex; flex-direction: column; border-bottom: 1px solid var(--line-2); }
@@ -216,7 +216,7 @@ button { font: inherit; }
   font: 600 9px/1 var(--font-mono); letter-spacing: var(--track-caps); text-transform: uppercase;
   color: var(--fg-3);
 }
-.side-sect-h .count { color: var(--fg-4); }
+.side-sect-h .count { color: var(--color-fg-disabled); }
 .side-sect-body { display: flex; flex-direction: column; padding-bottom: var(--sp-2); overflow-y: auto; }
 
 .keeper-row {
@@ -236,7 +236,7 @@ button { font: inherit; }
   justify-self: center;
   background: currentColor; color: var(--fg-3);
 }
-.keeper-row .d.running { color: var(--brass-1); box-shadow: 0 0 6px rgb(var(--brass-glow)/.5); animation: hb 1.4s infinite; }
+.keeper-row .d.running { color: var(--brass-1); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.5); animation: hb 1.4s infinite; }
 .keeper-row .d.ok      { color: var(--ok-fg); }
 .keeper-row .d.info    { color: var(--info-fg); }
 .keeper-row .d.err     { color: var(--err-fg); }
@@ -279,7 +279,7 @@ button { font: inherit; }
 
 /* Swimlanes */
 .sw {
-  border-bottom: 1px solid var(--line-3);
+  border-bottom: 1px solid var(--color-border-divider);
   padding: var(--sp-3) var(--sp-4);
   position: relative;
   display: flex; flex-direction: column;
@@ -287,7 +287,7 @@ button { font: inherit; }
 }
 .sw-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 8px; }
 .sw-head h3 { font: 600 10px/1 var(--font-mono); letter-spacing: var(--track-caps); text-transform: uppercase; color: var(--fg-3); }
-.sw-head .meta { font: 9px/1 var(--font-mono); color: var(--fg-4); letter-spacing: var(--track-wide); }
+.sw-head .meta { font: 9px/1 var(--font-mono); color: var(--color-fg-disabled); letter-spacing: var(--track-wide); }
 .sw-body {
   position: relative;
   flex: 1;
@@ -324,7 +324,7 @@ button { font: inherit; }
   position: absolute; top: 0; bottom: 0;
   width: 2px;
   background: linear-gradient(to bottom, transparent, var(--brass-1) 15%, var(--brass-1) 85%, transparent);
-  box-shadow: 0 0 14px rgb(var(--brass-glow)/.6);
+  box-shadow: 0 0 14px rgb(var(--color-accent-glow)/.6);
   pointer-events: none;
   left: calc(110px + 72% * (100% - 110px) / 100%);
 }
@@ -351,7 +351,7 @@ button { font: inherit; }
 }
 .deck-tab:hover { color: var(--fg-1); }
 .deck-tab.active { color: var(--brass-1); border-bottom-color: var(--brass-1); }
-.deck-tab .ct { font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); font-weight: 400; }
+.deck-tab .ct { font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); font-weight: 400; }
 .deck-tab.active .ct { color: var(--brass-2); }
 .deck-body { flex: 1; overflow: auto; padding: var(--sp-4); min-height: 0; }
 
@@ -369,7 +369,7 @@ button { font: inherit; }
   border-bottom: 1px solid var(--line-2);
   display: flex; justify-content: space-between;
 }
-.board-col-h .ct { font-weight: 400; color: var(--fg-4); }
+.board-col-h .ct { font-weight: 400; color: var(--color-fg-disabled); }
 
 .card {
   background: var(--bg-1);
@@ -382,13 +382,13 @@ button { font: inherit; }
 }
 .card:hover { background: var(--bg-2); border-color: var(--line-2); }
 .card.running {
-  background: linear-gradient(180deg, var(--bg-1), rgb(var(--brass-glow)/.04));
-  border-color: rgb(var(--brass-glow)/.3);
+  background: linear-gradient(180deg, var(--bg-1), rgb(var(--color-accent-glow)/.04));
+  border-color: rgb(var(--color-accent-glow)/.3);
 }
 .card.running::before {
   content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 2px;
   background: var(--brass-1);
-  box-shadow: 0 0 6px rgb(var(--brass-glow)/.5);
+  box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.5);
 }
 .card .top { display: flex; justify-content: space-between; align-items: center; gap: 8px; }
 .card .id  { font: 10px/1 var(--font-mono); color: var(--fg-3); letter-spacing: var(--track-wide); }
@@ -417,7 +417,7 @@ button { font: inherit; }
   font-variant-numeric: tabular-nums;
 }
 .tbl tbody tr:hover { background: var(--bg-1); }
-.tbl tbody tr.running { background: linear-gradient(90deg, rgb(var(--brass-glow)/.05), transparent 70%); }
+.tbl tbody tr.running { background: linear-gradient(90deg, rgb(var(--color-accent-glow)/.05), transparent 70%); }
 .tbl tbody tr.running td:first-child { border-left: 2px solid var(--brass-1); padding-left: 8px; }
 
 /* Chip */
@@ -428,7 +428,7 @@ button { font: inherit; }
   border: 1px solid transparent;
 }
 .chip .d { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
-.chip.running { color: var(--brass-1); background: rgb(var(--brass-glow)/.1); border-color: rgb(var(--brass-glow)/.3); }
+.chip.running { color: var(--brass-1); background: rgb(var(--color-accent-glow)/.1); border-color: rgb(var(--color-accent-glow)/.3); }
 .chip.ok      { color: var(--ok-fg); background: rgb(107 158 107 / .1); border-color: rgb(107 158 107 / .3); }
 .chip.warn    { color: var(--warn-fg); background: rgb(201 162 74 / .1); border-color: rgb(201 162 74 / .3); }
 .chip.err     { color: var(--err-fg); background: rgb(196 106 90 / .1); border-color: rgb(196 106 90 / .3); }
@@ -439,7 +439,7 @@ button { font: inherit; }
 .chip.queued  { color: #a0a0a0; background: rgb(106 106 106 / .1); border-color: rgb(106 106 106 / .3); }
 .chip.idle    { color: #a0a0a0; background: rgb(106 106 106 / .1); border-color: rgb(106 106 106 / .3); }
 .chip.done    { color: var(--ok-fg); background: rgb(107 158 107 / .1); border-color: rgb(107 158 107 / .3); }
-.chip.active  { color: var(--brass-1); background: rgb(var(--brass-glow)/.1); border-color: rgb(var(--brass-glow)/.3); }
+.chip.active  { color: var(--brass-1); background: rgb(var(--color-accent-glow)/.1); border-color: rgb(var(--color-accent-glow)/.3); }
 
 /* Providers */
 .prov-list { display: flex; flex-direction: column; gap: 8px; }
@@ -483,20 +483,20 @@ button { font: inherit; }
 .cascade-step:not(:last-child)::after {
   content: "→";
   position: absolute; right: -18px; top: 50%; transform: translateY(-50%);
-  color: var(--fg-4); font: 14px/1 var(--font-mono);
+  color: var(--color-fg-disabled); font: 14px/1 var(--font-mono);
 }
 .cascade-step .pv { font: 600 12px/1 var(--font-mono); color: var(--fg-1); }
 .cascade-step .st { font: 9px/1 var(--font-mono); letter-spacing: var(--track-caps); text-transform: uppercase; }
 .cascade-step.hit .st  { color: var(--ok-fg); }
 .cascade-step.miss .st { color: var(--warn-fg); }
-.cascade-step.skip .st { color: var(--fg-4); }
+.cascade-step.skip .st { color: var(--color-fg-disabled); }
 .cascade-step.hit { border-color: rgb(107 158 107 / .4); background: linear-gradient(180deg, var(--bg-0), rgb(107 158 107 / .04)); }
 .cascade-step .ms { font: 10px/1 var(--font-mono); color: var(--fg-3); font-variant-numeric: tabular-nums; }
 
 /* ═══════════════ RAIL ═══════════════ */
 .rail {
   background: var(--bg-1);
-  border-left: 1px solid var(--line-3);
+  border-left: 1px solid var(--color-border-divider);
   display: flex; flex-direction: column;
   overflow: hidden;
 }
@@ -522,7 +522,7 @@ button { font: inherit; }
   border-bottom: 1px solid var(--line-1);
 }
 .activity:last-child { border-bottom: 0; }
-.activity .t { color: var(--fg-4); font-size: 9px; padding-top: 2px; }
+.activity .t { color: var(--color-fg-disabled); font-size: 9px; padding-top: 2px; }
 .activity .d { width: 7px; height: 7px; border-radius: 50%; margin-top: 4px; background: var(--fg-3); }
 .activity .d.tool  { background: var(--brass-1); }
 .activity .d.claim { background: var(--info-fg); }
@@ -559,8 +559,8 @@ button { font: inherit; }
   font: 12px/1 var(--font-mono);
   outline: none;
 }
-.compose-input:focus { border-color: var(--brass-1); box-shadow: 0 0 0 2px rgb(var(--brass-glow)/.2); }
-.compose-input::placeholder { color: var(--fg-4); }
+.compose-input:focus { border-color: var(--brass-1); box-shadow: 0 0 0 2px rgb(var(--color-accent-glow)/.2); }
+.compose-input::placeholder { color: var(--color-fg-disabled); }
 .compose-btn {
   height: 28px; padding: 0 12px;
   background: var(--brass-1); color: #0c0b08; border: 1px solid var(--brass-2);
@@ -569,7 +569,7 @@ button { font: inherit; }
   cursor: pointer;
 }
 .compose-btn:hover { background: var(--brass-2); }
-.compose-hint { font: 9px/1 var(--font-mono); color: var(--fg-4); letter-spacing: var(--track-wide); }
+.compose-hint { font: 9px/1 var(--font-mono); color: var(--color-fg-disabled); letter-spacing: var(--track-wide); }
 
 /* ═══════════════ STATUS BAR ═══════════════ */
 .status {
@@ -604,8 +604,8 @@ button { font: inherit; }
   font-family: var(--font-mono);
   font-size: 11px;
 }
-.tb-branch:hover { background: var(--bg-2); border-color: var(--line-3); }
-.tb-branch::before { content: "⎇"; color: var(--fg-4); }
+.tb-branch:hover { background: var(--bg-2); border-color: var(--color-border-divider); }
+.tb-branch::before { content: "⎇"; color: var(--color-fg-disabled); }
 .tb-branch .nm { color: var(--brass-1); font-weight: 600; }
 .tb-branch .ahbh { display: inline-flex; gap: 4px; color: var(--fg-3); font-size: 10px; }
 .tb-branch .ahbh .ah { color: var(--ok-fg); }
@@ -619,7 +619,7 @@ button { font: inherit; }
   left: 8px;
   width: 360px;
   background: var(--bg-1);
-  border: 1px solid var(--line-3);
+  border: 1px solid var(--color-border-divider);
   box-shadow: 0 8px 24px rgba(0,0,0,.4);
   z-index: 50;
   font-family: var(--font-mono);
@@ -629,7 +629,7 @@ button { font: inherit; }
   padding: 6px 10px;
   background: var(--bg-2);
   border-bottom: 1px solid var(--line-2);
-  font-size: 9px; letter-spacing: .12em; text-transform: uppercase; color: var(--fg-4);
+  font-size: 9px; letter-spacing: .12em; text-transform: uppercase; color: var(--color-fg-disabled);
 }
 .tb-branch-pop .row {
   display: grid; grid-template-columns: auto 1fr auto auto;
@@ -640,7 +640,7 @@ button { font: inherit; }
 }
 .tb-branch-pop .row:hover { background: var(--bg-2); }
 .tb-branch-pop .row.on { background: var(--bg-2); border-left: 2px solid var(--brass-1); padding-left: 8px; }
-.tb-branch-pop .row .glyph { color: var(--fg-4); }
+.tb-branch-pop .row .glyph { color: var(--color-fg-disabled); }
 .tb-branch-pop .row.on .glyph { color: var(--brass-1); }
 .tb-branch-pop .row .nm { color: var(--fg-1); }
 .tb-branch-pop .row .ahbh { color: var(--fg-3); font-size: 10px; }
@@ -650,9 +650,9 @@ button { font: inherit; }
   font-size: 9px; padding: 1px 5px; border: 1px solid var(--line-2); text-transform: uppercase; letter-spacing: .06em;
 }
 .tb-branch-pop .row .st.clean    { color: var(--ok-fg); border-color: var(--ok-border); }
-.tb-branch-pop .row .st.dirty    { color: var(--warn-fg); border-color: var(--warn-border, var(--warn)); }
+.tb-branch-pop .row .st.dirty    { color: var(--warn-fg); border-color: var(--warn-border, var(--color-status-warn)); }
 .tb-branch-pop .row .st.stale    { color: var(--err-fg); border-color: var(--err-border); }
-.tb-branch-pop .row .st.research { color: var(--brass-1); border-color: var(--brass-3); }
+.tb-branch-pop .row .st.research { color: var(--brass-1); border-color: var(--color-accent-fg-dim); }
 
 /* ─── Sidebar: keeper multi-select section ─── */
 .side-keepers {
@@ -676,7 +676,7 @@ button { font: inherit; }
   user-select: none;
 }
 .side-keepers .ch:hover { background: var(--bg-2); color: var(--fg-1); }
-.side-keepers .ch.on   { background: rgb(var(--brass-glow)/.12); border-color: var(--brass-3); color: var(--brass-1); }
+.side-keepers .ch.on   { background: rgb(var(--color-accent-glow)/.12); border-color: var(--color-accent-fg-dim); color: var(--brass-1); }
 .side-keepers .ch .d   { width: 5px; height: 5px; border-radius: 50%; }
 
 /* ─── Rail: nudge log section ─── */
@@ -695,13 +695,13 @@ button { font: inherit; }
   font-size: 9px; padding: 1px 4px; border: 1px solid var(--line-2);
   text-transform: uppercase; letter-spacing: .06em; white-space: nowrap;
 }
-.rail-nudge .ch.hint     { color: var(--brass-1); border-color: var(--brass-3); }
+.rail-nudge .ch.hint     { color: var(--brass-1); border-color: var(--color-accent-fg-dim); }
 .rail-nudge .ch.approve  { color: var(--ok-fg); border-color: var(--ok-border); }
 .rail-nudge .ch.reject   { color: var(--err-fg); border-color: var(--err-border); }
-.rail-nudge .ch.redirect { color: var(--info-fg, var(--info)); border-color: var(--info); }
+.rail-nudge .ch.redirect { color: var(--info-fg, var(--color-status-info)); border-color: var(--color-status-info); }
 .rail-nudge .body { color: var(--fg-1); line-height: 1.4; }
 .rail-nudge .body .to { color: var(--brass-1); margin-right: 4px; }
-.rail-nudge .body .ts { color: var(--fg-4); display: block; font-size: 9px; margin-top: 2px; }
+.rail-nudge .body .ts { color: var(--color-fg-disabled); display: block; font-size: 9px; margin-top: 2px; }
 .rail-nudge .ack {
   font-size: 9px; padding: 0 4px; text-transform: uppercase; letter-spacing: .06em;
   align-self: flex-start;
@@ -731,7 +731,7 @@ button { font: inherit; }
   font-size: 10px; color: var(--fg-3);
 }
 .plane-hdr .ctx .br { color: var(--brass-1); }
-.plane-hdr .ctx .kp { color: var(--info-fg, var(--info)); }
+.plane-hdr .ctx .kp { color: var(--info-fg, var(--color-status-info)); }
 
 .plane-tabs {
   display: flex; gap: 0;
@@ -794,7 +794,7 @@ button { font: inherit; }
   font-size: 10px;
 }
 .ide-v2-branch .lbl {
-  color: var(--fg-4);
+  color: var(--color-fg-disabled);
   text-transform: uppercase;
   letter-spacing: .1em;
 }
@@ -809,7 +809,7 @@ button { font: inherit; }
   border: 1px solid var(--line-1);
   color: var(--brass-1);
 }
-.ide-v2-branch .meta { color: var(--fg-4); }
+.ide-v2-branch .meta { color: var(--color-fg-disabled); }
 .ide-v2-modes {
   display: flex;
   gap: 2px;
@@ -832,8 +832,8 @@ button { font: inherit; }
 .ide-v2-terminal-toggle.active,
 .ide-v2-terminal-toggle[aria-pressed="true"] {
   color: var(--brass-1);
-  border-color: var(--brass-3);
-  background: rgb(var(--brass-glow)/.08);
+  border-color: var(--color-accent-fg-dim);
+  background: rgb(var(--color-accent-glow)/.08);
 }
 .ide-v2-body {
   flex: 1;


### PR DESCRIPTION
## Summary

M2 stack (#10503/#10518/#10519)이 main에 머지된 후 활성화된 alias들로 dashboard 전 surface의 잔여 raw refs를 일괄 migration. **31 files, 833 refs**.

## 활성화된 alias (M2 stack 머지 후 main에 도착)

| Alias | Raw |
|-------|-----|
| `--color-fg-disabled` | `--fg-4` |
| `--color-border-divider` | `--line-3` |
| `--color-accent-fg-dim` | `--brass-3` |
| `--color-accent-glow` | `--brass-glow` |
| `--color-status-ok/warn/err/info/idle/stalled` | single-slot `--ok/-warn/-err/-info/-idle/-stalled` |

## 영향 범위 (31 files, 833 refs)

| Surface | Files | refs |
|---------|-------|------|
| `preview/*.html` | 16 | ~365 |
| `preview/*.jsx` (cb-group, cb-shared, code-mode, snippets) | 11 | ~140 |
| `source_styles/*.css` | 13 | ~280 |
| `ui_kits/cockpit/*` | 3 | ~48 |

## 의도적 raw 유지 (SPEC §6.2 escape hatch)

- `--brass-2` mid tone (3 refs preserved) — SPEC §3.4에 미정의
- 4-slot status pattern (`--ok-soft`, `--ok-fg`, `--ok-border`, `--ok-ring` 등 17+ refs) — single-slot semantic으론 환원 불가
- `keeperColor()` helper의 12 hex 리터럴 (`preview/cb-group-i.jsx`) — 5 attribution slot으론 환원 불가

## Out-of-scope

- `tokens.css` (SSOT 정의 자체, 재귀 방지)
- `colors_and_type.css` (parallel alias 정의 파일)
- `README/SPEC/log.md` (문서 내 코드 예제)

## Validation

- raw 잔존 (escape hatch 제외) → 0
- 시각 회귀 0 (alias가 raw로 resolve)
- 새 alias 확산 31 files

## Test plan

- [ ] CI green
- [ ] Chrome 5-theme 토글 (기존 PR 머지 cascade와 함께 검증)
- [ ] do-not-merge 라벨 (시각 검증 의도 표명)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
