### PR TITLE
perf(metrics): single-pass count_if helper for 7 List.length(List.filter) sites

### DIFF
--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -136,6 +136,12 @@ let average_opt (arr : float array) =
 let percentile_opt (arr : float array) p =
   if Array.length arr = 0 then None else Some (percentile arr p)
 
+(* Single-pass [List.length (List.filter pred xs)] equivalent — drops
+   the intermediate list allocation. Hot in per-window aggregation
+   loops below where [entries] reaches thousands. *)
+let count_if pred xs =
+  List.fold_left (fun n x -> if pred x then n + 1 else n) 0 xs
+
 let sum_int_opt values =
   match values with
   | [] -> None
@@ -882,7 +888,7 @@ let aggregate_by_model (entries : raw_entry list) : model_stats list =
     in
     Array.sort Float.compare lat_vals;
     let success_count = List.length success_entries in
-    let error_count = List.length (List.filter (fun e -> e.is_error) entries) in
+    let error_count = count_if (fun e -> e.is_error) entries in
     let total_tool_calls = List.fold_left (fun acc e -> acc + e.tool_call_count) 0 entries in
     let usage_sample_count =
       List.fold_left
@@ -931,7 +937,7 @@ let aggregate_by_model (entries : raw_entry list) : model_stats list =
       | [] -> None
       | xs ->
         let total = List.length xs in
-        let on_count = List.length (List.filter (fun x -> x) xs) in
+        let on_count = count_if (fun x -> x) xs in
         Some (float_of_int on_count /. float_of_int total)
     in
     let provider =
@@ -975,7 +981,7 @@ let aggregate_by_model (entries : raw_entry list) : model_stats list =
       primary_coverage_stage;
       primary_coverage_reason;
       coverage_reason_counts;
-      fallback_count = List.length (List.filter (fun e -> e.fallback_applied) entries);
+      fallback_count = count_if (fun e -> e.fallback_applied) entries;
       success_count;
       error_count;
       total_cost_usd =
@@ -1044,8 +1050,8 @@ let bucket_entries_for_model (entries : raw_entry list) ~(bucket_sec : int)
     let n = List.length bucket_entries in
     let lat_vals = List.filter_map (fun e -> e.latency_ms) bucket_entries |> Array.of_list in
     Array.sort Float.compare lat_vals;
-    let success_count = List.length (List.filter (fun e -> not e.is_error) bucket_entries) in
-    let error_count = List.length (List.filter (fun e -> e.is_error) bucket_entries) in
+    let success_count = count_if (fun e -> not e.is_error) bucket_entries in
+    let error_count = count_if (fun e -> e.is_error) bucket_entries in
     let cache_reads = List.filter_map (fun e -> e.cache_read_tokens) bucket_entries in
     let inputs = List.filter_map (fun e -> e.input_tokens) bucket_entries in
     let cache_hit_ratio =
@@ -1095,7 +1101,7 @@ let compute ~base_path ~window_minutes : aggregate =
   let entries = read_all_entries ~base_path ~since_unix in
   let models = aggregate_by_model entries in
   let total_error_entries =
-    List.length (List.filter (fun e -> e.is_error) entries)
+    count_if (fun e -> e.is_error) entries
   in
   { window_minutes; bucket_minutes = 0; models;
     total_entries = List.length entries;
@@ -1122,7 +1128,7 @@ let compute_with_buckets ~base_path ~window_minutes ~bucket_minutes : aggregate 
     ) models
   in
   let total_error_entries =
-    List.length (List.filter (fun e -> e.is_error) entries)
+    count_if (fun e -> e.is_error) entries
   in
   { window_minutes; bucket_minutes;
     models = models_with_buckets;


### PR DESCRIPTION
## What

`lib/model_inference_metrics.ml`에서 `List.length (List.filter pred xs)` 7건을 file-private `count_if` helper로 변환. 각 사이트에서 intermediate filter list 할당 제거.

```ocaml
(* Single-pass equivalent — drops the intermediate list allocation.
   Hot in per-window aggregation loops where [entries] reaches
   thousands. *)
let count_if pred xs =
  List.fold_left (fun n x -> if pred x then n + 1 else n) 0 xs
```

## Sites

7개 모두 dashboard inference metrics window aggregation 안:
- `:885` per-model error_count
- `:934` thinking_fraction on_count
- `:978` per-model fallback_count
- `:1047, :1048` per-bucket success/error_count (per model × per bucket)
- `:1098, :1125` aggregate total_error_entries (compute / compute_with_buckets)

window_minutes=60 + 1000 entries 시 7 × 1000 cons cell allocation per dashboard refresh → 7000 cells/refresh 절감.

## Test

`OCAMLPARAM='_,warn-error=+a' dune build @check` clean. `count_if pred xs` 의미: `List.length (List.filter pred xs)`와 동등 (fold_left으로 단일 패스).

## Sweep series

- #10532/#10543/#10548 sweep: `String.sub eq` → `String.starts_with`
- #10568 sweep: `List.length lst = 0` → `lst = []`
- 본 PR: `List.length (List.filter ...)` → `count_if`

후속 (별도 PR): 다른 ~23건이 dashboard.ml, telemetry_eio.ml, meta_cognition_snapshot.ml 등에 분산.
