### PR TITLE
perf(list-util): introduce List_util.count_if SSOT + sweep 16 sites across 14 files

### DIFF
--- a/lib/agent_reputation.ml
+++ b/lib/agent_reputation.ml
@@ -143,7 +143,7 @@ let count_mention_activity (config : Coord.config) ~(agent_name : string)
     : int * int =
   let all = Mention_inbox.read_mentions config ~target_agent:agent_name ~limit:10000 in
   let received = List.length all in
-  let responded = List.length (List.filter (fun r -> r.Mention_inbox.read_at > 0.0) all) in
+  let responded = List_util.count_if (fun r -> r.Mention_inbox.read_at > 0.0) all in
   (received, responded)
 
 (** {1 Overall Score Computation} *)

--- a/lib/core/dune
+++ b/lib/core/dune
@@ -3,5 +3,5 @@
  (name masc_core)
  (public_name masc_mcp.masc_core)
  (wrapped false)
- (modules json_util safe_ops common validation circuit_breaker eio_guard executor_pool_ref masc_runtime_events text_similarity string_util)
+ (modules json_util safe_ops common validation circuit_breaker eio_guard executor_pool_ref masc_runtime_events text_similarity string_util list_util)
  (libraries yojson unix re re.pcre eio eio.unix time_compat fs_compat masc_log runtime_events base))

--- a/lib/core/list_util.ml
+++ b/lib/core/list_util.ml
@@ -1,0 +1,11 @@
+(** List utilities — SSOT for cross-module list helpers that have no
+    direct stdlib equivalent.
+
+    [count_if] is the single-pass variant of [List.length (List.filter
+    pred xs)] — it drops the intermediate filter list allocation. The
+    pattern occurred 23 times across the codebase before this module
+    landed; centralising avoids re-defining the helper per file and
+    makes the intent searchable. *)
+
+let count_if pred xs =
+  List.fold_left (fun n x -> if pred x then n + 1 else n) 0 xs

--- a/lib/core/list_util.mli
+++ b/lib/core/list_util.mli
@@ -1,0 +1,6 @@
+(** List utilities — SSOT for cross-module list helpers. *)
+
+val count_if : ('a -> bool) -> 'a list -> int
+(** [count_if pred xs] is equivalent to [List.length (List.filter pred xs)]
+    but does not allocate the intermediate filter list. Single fold,
+    O(n) time, O(1) extra space. *)

--- a/lib/dashboard.ml
+++ b/lib/dashboard.ml
@@ -536,9 +536,9 @@ let generate_compact ?(scope = All) (config : Coord_utils.config) : string =
   (* Keeper phase summary *)
   let keeper_entries = Keeper_registry.all () in
   let keeper_by_phase phase =
-    List.length (List.filter
+    List_util.count_if
       (fun (e : Keeper_registry.registry_entry) -> e.phase = phase)
-      keeper_entries)
+      keeper_entries
   in
   let k_running = keeper_by_phase Running in
   let k_dead = keeper_by_phase Dead in

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -1235,13 +1235,13 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
                       ("all_passed", `Bool s.verdict.all_passed);
                       ("layer_count", `Int (List.length s.verdict.layer_results));
                       ("passed_count",
-                        `Int (List.length (List.filter
+                        `Int (List_util.count_if
                           (fun (lr : Dashboard_eval_feed.layer_result_json) -> lr.passed)
-                          s.verdict.layer_results)));
+                          s.verdict.layer_results));
                       ("failed_count",
-                        `Int (List.length (List.filter
+                        `Int (List_util.count_if
                           (fun (lr : Dashboard_eval_feed.layer_result_json) -> not lr.passed)
-                          s.verdict.layer_results)));
+                          s.verdict.layer_results));
                       ("timestamp", `Float s.timestamp);
                       ("baseline_status", Json_util.string_opt_to_json s.baseline_status);
                     ]

--- a/lib/dashboard/dashboard_safe_autonomy.ml
+++ b/lib/dashboard/dashboard_safe_autonomy.ml
@@ -959,13 +959,13 @@ let domain_summary_json ~id ~(keepers : keeper_snapshot list)
     @ Option.value ~default:[] extra_evidence_refs
   in
   let pass_count =
-    List.length (List.filter (fun (domain : keeper_domain) -> domain.status = Pass) keeper_domains)
+    List_util.count_if (fun (domain : keeper_domain) -> domain.status = Pass) keeper_domains
   in
   let warn_count =
-    List.length (List.filter (fun (domain : keeper_domain) -> domain.status = Warn) keeper_domains)
+    List_util.count_if (fun (domain : keeper_domain) -> domain.status = Warn) keeper_domains
   in
   let fail_count =
-    List.length (List.filter (fun (domain : keeper_domain) -> domain.status = Fail) keeper_domains)
+    List_util.count_if (fun (domain : keeper_domain) -> domain.status = Fail) keeper_domains
   in
   `Assoc
     [

--- a/lib/eval_harness.ml
+++ b/lib/eval_harness.ml
@@ -162,7 +162,7 @@ let check_tool_expectations
     (actual_calls : string list)
     : grader_result list =
   List.map (fun (exp : tool_expectation) ->
-    let call_count = List.length (List.filter (fun c -> c = exp.tool_name) actual_calls) in
+    let call_count = List_util.count_if (fun c -> c = exp.tool_name) actual_calls in
     let required_ok = if exp.required then call_count > 0 else true in
     let max_ok = match exp.max_calls with
       | None -> true
@@ -225,7 +225,7 @@ let score_std_dev (scores : float list) : float =
 (** Build eval_result from a list of eval_runs for one scenario. *)
 let summarize_runs ~(scenario : scenario) ~(k : int) (runs : eval_run list) : eval_result =
   let n = List.length runs in
-  let c = List.length (List.filter (fun r -> r.passed) runs) in
+  let c = List_util.count_if (fun r -> r.passed) runs in
   let scores = List.map (fun r -> r.weighted_score) runs in
   let mean = if n = 0 then 0.0
     else List.fold_left (+.) 0.0 scores /. float_of_int n in

--- a/lib/exec/bash_history.ml
+++ b/lib/exec/bash_history.ml
@@ -295,7 +295,7 @@ let failure_insight ~base_path ~keeper_name =
 
       (* 2. High failure rate across recent window *)
       let total = List.length recent in
-      let failures = List.length (List.filter (fun e -> not e.success) recent) in
+      let failures = List_util.count_if (fun e -> not e.success) recent in
       let rate = float_of_int failures /. float_of_int total in
       if total >= 5 && rate >= rate_threshold then
         patterns :=

--- a/lib/goal/convergence.ml
+++ b/lib/goal/convergence.ml
@@ -75,7 +75,7 @@ let check_convergence ~goal_id ~tasks ?(stagnation_threshold = 5)
   let total = List.length goal_tasks in
   if total = 0 then None
   else
-    let completed = List.length (List.filter is_completed goal_tasks) in
+    let completed = List_util.count_if is_completed goal_tasks in
     let all_terminal = List.for_all is_terminal goal_tasks in
     if all_terminal && completed = total then
       Some (AllSubTasksDone { completed; total })

--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -610,7 +610,7 @@ let upsert_goal config ?id ?horizon ?title ?metric ?target_value ?due_date
 
 let compute_rollup goals =
   let count predicate =
-    List.length (List.filter predicate goals)
+    List_util.count_if predicate goals
   in
   {
     short_count = count (fun goal -> goal.horizon = Short);

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -330,7 +330,7 @@ let handle_keeper_eval ctx args : tool_result =
         let tool_counts =
           List.map
             (fun tn ->
-              let c = List.length (List.filter (fun n -> n = tn) tool_names) in
+              let c = List_util.count_if (fun n -> n = tn) tool_names in
               (tn, c))
             unique_tools
         in

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -754,9 +754,9 @@ let sweep_and_recover (ctx : _ context) =
   ) !to_mark_dead;
   List.iter (cleanup_dead_tombstone ctx) !to_cleanup_dead;
   let active_count =
-    List.length (List.filter (fun (e : Keeper_registry.registry_entry) ->
+    List_util.count_if (fun (e : Keeper_registry.registry_entry) ->
       e.phase = Keeper_state_machine.Running || e.phase = Keeper_state_machine.Crashed
-    ) entries) in
+    ) entries in
   let restart_list =
     let keepers_dir =
       Filename.concat (Coord.masc_root_dir ctx.config) "keepers" in

--- a/lib/keeper/keeper_tool_diversity.ml
+++ b/lib/keeper/keeper_tool_diversity.ml
@@ -78,7 +78,7 @@ let compute_diversity ~(available_tools : string list)
     (stats : tool_stat list) : diversity_summary =
   let counts = List.map (fun s -> s.count) stats in
   let total_calls = List.fold_left ( + ) 0 counts in
-  let unique_tools = List.length (List.filter (fun s -> s.count > 0) stats) in
+  let unique_tools = List_util.count_if (fun s -> s.count > 0) stats in
   let n_available = List.length available_tools in
   let raw_h = shannon_entropy counts in
   let norm_h = normalized_entropy ~n_categories:n_available raw_h in

--- a/lib/meta_cognition_snapshot.ml
+++ b/lib/meta_cognition_snapshot.ml
@@ -413,10 +413,10 @@ let social_edges_json ~limit sources =
 (* ================================================================ *)
 
 let active_task_count tasks =
-  List.length (List.filter
+  List_util.count_if
     (fun (task : Types.task) ->
        not (Types.task_status_is_terminal task.task_status))
-    tasks)
+    tasks
 
 let stagnation_score ~active_agents ~active_tasks ~idle_signal_count
     ~heartbeat_count ~blocker_count =

--- a/lib/prompt_registry/prompt_registry.ml
+++ b/lib/prompt_registry/prompt_registry.ml
@@ -472,7 +472,7 @@ let stats () : registry_stats =
   with_mutex (fun () ->
     let all_entries = Hashtbl.fold (fun _ entry acc -> entry :: acc) registry [] in
     let total = List.length all_entries in
-    let active = List.length (List.filter (fun e -> not e.deprecated) all_entries) in
+    let active = List_util.count_if (fun e -> not e.deprecated) all_entries in
     let deprecated = total - active in
 
     let most_used =

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -461,8 +461,8 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
             Log.Keeper.warn
               "autoboot: gave up after %d retries; %d/%d keepers remain unbooted"
               max_retries
-              (total - List.length (List.filter (fun name ->
-                Keeper_registry.is_running ~base_path:config.base_path name) names))
+              (total - List_util.count_if (fun name ->
+                Keeper_registry.is_running ~base_path:config.base_path name) names)
               total
           else begin
             Eio.Time.sleep clock retry_interval_s;

--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -299,11 +299,11 @@ let count_tasks_in_progress events =
   List.length (List.sort_uniq String.compare in_progress)
 
 let count_completed_tasks events =
-  List.length (List.filter (fun r ->
+  List_util.count_if (fun r ->
     match r.event with
     | Task_completed _ -> true
     | _ -> false
-  ) events)
+  ) events
 
 let avg_duration events =
   let durations = List.filter_map (fun r ->
@@ -318,25 +318,25 @@ let avg_duration events =
       sum /. float_of_int (List.length times)
 
 let calculate_handoff_rate events =
-  let handoffs = List.length (List.filter (fun r ->
+  let handoffs = List_util.count_if (fun r ->
     match r.event with
     | Handoff_triggered _ -> true
     | _ -> false
-  ) events) in
-  let task_events = List.length (List.filter (fun r ->
+  ) events in
+  let task_events = List_util.count_if (fun r ->
     match r.event with
     | Task_started _ | Task_completed _ -> true
     | _ -> false
-  ) events) in
+  ) events in
   if task_events = 0 then 0.0
   else float_of_int handoffs /. float_of_int task_events
 
 let calculate_error_rate events =
-  let errors = List.length (List.filter (fun r ->
+  let errors = List_util.count_if (fun r ->
     match r.event with
     | Error_occurred _ -> true
     | _ -> false
-  ) events) in
+  ) events in
   let total = List.length events in
   if total = 0 then 0.0
   else float_of_int errors /. float_of_int total

--- a/lib/trajectory.ml
+++ b/lib/trajectory.ml
@@ -386,7 +386,7 @@ let detect_entropy ?(threshold = 3) ?args_json (acc : accumulator) (tool_name : 
 
 (** Count tool calls in current turn. *)
 let calls_in_current_turn (acc : accumulator) : int =
-  List.length (List.filter (fun (e : tool_call_entry) -> e.turn = acc.turn) acc.entries)
+  List_util.count_if (fun (e : tool_call_entry) -> e.turn = acc.turn) acc.entries
 
 (* ================================================================ *)
 (* Tool stats aggregation                                          *)


### PR DESCRIPTION
## What

`lib/core/list_util.ml` SSOT 신설 + `List.length (List.filter pred xs)` 16건 sweep. 14 파일.

```ocaml
val count_if : ('a -> bool) -> 'a list -> int
(* O(n) time, O(1) space — drops intermediate filter list. *)
```

## Why

`List.length (List.filter pred xs)`는 N크기 intermediate list 할당 후 즉시 length만 사용. fold_left으로 단일 패스 시 N cons cell allocation 절감.

Hot path가 다양:
- dashboard render (dashboard.ml, dashboard/dashboard_safe_autonomy, dashboard/dashboard_http_keeper)
- telemetry aggregation (telemetry_eio: handoffs/task_events/errors/completed)
- keeper supervisor sweep (keeper_supervisor: active_count, keeper_status, keeper_tool_diversity)
- meta-cognition snapshot (meta_cognition_snapshot: active_task_count)
- evaluation (eval_harness × 2, trajectory: calls_in_current_turn)
- mention reputation (agent_reputation: responded)
- goal/convergence (goal/convergence, goal/goal_store)
- bootstrap (server_bootstrap_loops: unbooted-count)
- prompt registry (prompt_registry: active)
- bash history (exec/bash_history: failures)

## Test

`OCAMLPARAM='_,warn-error=+a' dune build @check` clean.

## Sweep series

- #10532/#10543/#10548 sweep: `String.sub eq` → `String.starts_with`
- #10568 sweep: `List.length lst = 0` → `lst = []`
- #10607 (in-flight): file-private `count_if` for model_inference_metrics 7 sites
- 본 PR: SSOT `List_util.count_if` for 16 sites in 14 files

## Follow-up

`#10607` 머지 후 model_inference_metrics의 file-private helper를 `List_util.count_if`로 마이그레이트하는 정리 PR.
