### PR TITLE
fix(cascade): accept weight=0 in toml materializer (#10571)

### DIFF
--- a/lib/cascade/cascade_toml_materializer.ml
+++ b/lib/cascade/cascade_toml_materializer.ml
@@ -169,12 +169,20 @@ let model_entry_json ~path value =
                         loop rest
                     | Error _ as err -> err)
                 | "weight" -> (
+                    (* #10571: weight=0 means "configured but disabled"
+                       (cascade dispatcher skips the entry).  Pre-fix the
+                       validator rejected weight=0, breaking dashboard
+                       cascade.json materialization on every hot-reload
+                       once #10097 introduced explicit weight=0 entries
+                       to disable codex_cli without removing it from the
+                       seed list.  Negative weights stay rejected — they
+                       have no operational meaning. *)
                     match int_value ~path:(path ^ ".weight") field_value with
-                    | Ok value when value > 0 ->
+                    | Ok value when value >= 0 ->
                         weight := Some value;
                         loop rest
                     | Ok _ ->
-                        errorf "expected %s.weight to be > 0" path
+                        errorf "expected %s.weight to be >= 0" path
                     | Error _ as err -> err)
                 | "supports_tool_choice" -> (
                     match bool_value ~path:(path ^ ".supports_tool_choice") field_value with

--- a/test/test_cascade_toml_materialization.ml
+++ b/test/test_cascade_toml_materialization.ml
@@ -296,6 +296,48 @@ unknown_field = 1
       check bool "rejection mentions unknown field" true
         (contains_substring rendered "unknown field")
 
+let test_weight_zero_is_accepted () =
+  (* #10571: weight=0 = "configured but disabled" (cascade dispatcher
+     skips). #10097 introduced this idiom for codex_cli; pre-fix the
+     materializer rejected it and dashboard cascade.json went stale on
+     every reload. *)
+  match
+    Masc_mcp.Cascade_toml_materializer.render_toml_string_to_json_string
+      {|
+[default]
+models = [
+  { model = "codex_cli:auto", weight = 0 },
+  { model = "gemini_cli:auto", weight = 1 },
+]
+|}
+  with
+  | Error msg -> failf "weight=0 must materialize, got: %s" msg
+  | Ok _ -> ()
+
+let test_weight_negative_is_rejected () =
+  match
+    Masc_mcp.Cascade_toml_materializer.render_toml_string_to_json_string
+      {|
+[default]
+models = [
+  { model = "codex_cli:auto", weight = -1 },
+]
+|}
+  with
+  | Ok _ -> failf "negative weight must be rejected"
+  | Error msg ->
+      check bool
+        (Printf.sprintf "rejection mentions weight bound — got: %s" msg)
+        true
+        (let n = String.length msg and sub = "weight" in
+         let m = String.length sub in
+         let rec loop i =
+           if i + m > n then false
+           else if String.sub msg i m = sub then true
+           else loop (i + 1)
+         in
+         loop 0)
+
 let () =
   run "cascade_toml_materialization"
     [
@@ -320,6 +362,10 @@ let () =
             test_keeper_profile_drops_unknown_fallback_target;
           test_case "keeper profile resolves known fallback target" `Quick
             test_keeper_profile_resolves_known_fallback_target;
+          test_case "weight=0 is accepted (#10571 disabled-entry idiom)"
+            `Quick test_weight_zero_is_accepted;
+          test_case "negative weight is rejected" `Quick
+            test_weight_negative_is_rejected;
         ] );
       ( "runtime",
         [


### PR DESCRIPTION
## 요약

#10097이 \`weight = 0\` (configured but disabled) idiom 도입 후, materializer validator가 여전히 \`> 0\` 만 허용 → cascade.toml hot-reload 마다 false WARN + dashboard cascade.json stale.

## 변경

\`lib/cascade/cascade_toml_materializer.ml:171-178\`:
- guard: \`value > 0\` → \`value >= 0\`
- error msg: \`> 0\` → \`>= 0\`

\`test/test_cascade_toml_materialization.ml\`:
- \`test_weight_zero_is_accepted\`
- \`test_weight_negative_is_rejected\`

## 검증

\`\`\`
DUNE_CACHE=disabled dune build --root . --cache=disabled @check  → EXIT=0
dune exec test/test_cascade_toml_materialization.exe             → 11/13 (2 pre-existing env-dep tests, unaffected)
\`\`\`

## 영향

- 4 events/day false WARN 제거
- dashboard cascade.json view 정상 refresh
- #10097 SSOT idiom과 validator 정합

## 관련

- Issue: \`#10571\`
- Source idiom: \`#10097\` (codex_cli weight=0 disabled)

## Defensive guards

Draft + \`do-not-merge\`.