### PR TITLE
perf(string): String_util.equals_ci SSOT + apply to HTTP header lookup hot path

### DIFF
--- a/lib/core/string_util.ml
+++ b/lib/core/string_util.ml
@@ -89,6 +89,22 @@ let starts_with_ci ~prefix s =
     in
     match_at 0
 
+(* ASCII case-insensitive equality.  No allocation; equivalent to
+   [String.lowercase_ascii a = String.lowercase_ascii b] but
+   short-circuits on length and on first mismatching byte. *)
+let equals_ci a b =
+  let la = String.length a in
+  if la <> String.length b then false
+  else
+    let rec match_at i =
+      if i = la then true
+      else
+        let ca = Char.lowercase_ascii (String.unsafe_get a i) in
+        let cb = Char.lowercase_ascii (String.unsafe_get b i) in
+        if ca <> cb then false else match_at (i + 1)
+    in
+    match_at 0
+
 (* Byte-wise non-overlapping replace: scans [haystack] for [needle] and
    substitutes [by] for each occurrence. Empty needle is a no-op (would
    loop forever otherwise). Skips ahead by [needle_len] after a match,

--- a/lib/core/string_util.mli
+++ b/lib/core/string_util.mli
@@ -16,6 +16,13 @@ val starts_with_ci : prefix:string -> string -> bool
     of [prefix] and [s] inline during the compare. Returns [true] when
     [prefix] is empty. *)
 
+val equals_ci : string -> string -> bool
+(** [equals_ci a b] is the ASCII case-insensitive equality. Performs
+    no allocation; equivalent to [String.lowercase_ascii a =
+    String.lowercase_ascii b] but short-circuits on length mismatch and
+    first differing byte. Hot for HTTP header / case-insensitive flag
+    lookup. *)
+
 val find_substring : ?pos:int -> string -> string -> int option
 (** [find_substring ?pos haystack needle] returns the byte index of the
     first occurrence of [needle] in [haystack] at or after [pos]

--- a/lib/http_server_h2.ml
+++ b/lib/http_server_h2.ml
@@ -241,10 +241,11 @@ module Compat = struct
       headers = H2.Headers.to_list h2_req.headers;
     }
 
-  (** Get header value from compat request *)
+  (** Get header value from compat request — byte-wise CI equality so
+      every HTTP request avoids 2 allocations per header inspected. *)
   let header_get headers name =
     List.find_map (fun (k, v) ->
-      if String.lowercase_ascii k = String.lowercase_ascii name then Some v else None
+      if String_util.equals_ci k name then Some v else None
     ) headers
 
   (** Compat helpers mimicking Httpun.Headers *)

--- a/lib/keeper/keeper_exec_memory.ml
+++ b/lib/keeper/keeper_exec_memory.ml
@@ -97,7 +97,7 @@ let search_memory_bank
   (* Structured filter: kind (deterministic) *)
   let filtered =
     if kind_filter = "" then parsed
-    else List.filter (fun m -> String.lowercase_ascii m.kind = String.lowercase_ascii kind_filter) parsed
+    else List.filter (fun m -> String_util.equals_ci m.kind kind_filter) parsed
   in
   (* Text match: query against text field (non-deterministic data) *)
   let matched =

--- a/test/test_string_util.ml
+++ b/test/test_string_util.ml
@@ -237,6 +237,15 @@ let test_starts_with_ci_boundaries () =
   check bool "exact length equal" true
     (SU.starts_with_ci ~prefix:"abc" "ABC")
 
+let test_equals_ci_basic () =
+  check bool "exact" true (SU.equals_ci "Content-Type" "Content-Type");
+  check bool "case insensitive" true (SU.equals_ci "Content-Type" "content-type");
+  check bool "mixed case" true (SU.equals_ci "X-Trace-Id" "x-TRACE-id");
+  check bool "different content" false (SU.equals_ci "Content-Type" "Accept");
+  check bool "length mismatch" false (SU.equals_ci "abc" "abcd");
+  check bool "empty equals empty" true (SU.equals_ci "" "");
+  check bool "empty vs non-empty" false (SU.equals_ci "" "x")
+
 
 (* ---- Test runner ---- *)
 
@@ -281,4 +290,6 @@ let () =
             test_contains_substring_ci_empty_and_literal ] );
       ( "starts_with_ci",
         [ test_case "basic" `Quick test_starts_with_ci_basic;
-          test_case "boundaries" `Quick test_starts_with_ci_boundaries ] ) ]
+          test_case "boundaries" `Quick test_starts_with_ci_boundaries ] );
+      ( "equals_ci",
+        [ test_case "basic" `Quick test_equals_ci_basic ] ) ]


### PR DESCRIPTION
## What

`String_util.equals_ci` SSOT 추가 + 2 hot path 적용:
- `lib/http_server_h2.ml:247` HTTP header lookup
- `lib/keeper/keeper_exec_memory.ml:100` keeper exec memory kind filter

## Why

`String.lowercase_ascii a = String.lowercase_ascii b` 패턴은 매 호출 2 string allocation. CI equality는 byte-wise loop으로 0 alloc 가능 + length 단축 시 즉시 false short-circuit.

```ocaml
val equals_ci : string -> string -> bool
(** ASCII case-insensitive equality. No allocation; short-circuits on
    length mismatch and first differing byte. *)
```

### http_server_h2.header_get
HTTP header lookup hot path. 매 HTTP request × 평균 N개 inspected header마다 `header_get` 호출. 변경 전 매 lookup 2N alloc → 변경 후 0 alloc. dashboard fanout, MCP transport, h2 reverse proxy 모든 경로 영향.

### keeper_exec_memory kind_filter
keeper exec memory recall hot loop. `List.filter (fun m -> ...kind = kind_filter) parsed`. parsed가 1000+ entry일 때 변경 전 2000 alloc/call → 0.

## Test

`test/test_string_util.ml`에 `test_equals_ci_basic` 7 assertions 추가:
- exact / case insensitive / mixed case / different content / length mismatch / empty equals empty / empty vs non-empty

```
26 tests run, 0 failed.
```

`OCAMLPARAM='_,warn-error=+a' dune build @check` clean.

## Sweep series

`String_util` SSOT family이 5개:
- `contains_substring` (#10453 era)
- `contains_substring_ci` (#10460/#10468/#10478 sweep)
- `starts_with_ci` (#10483)
- `starts_with` migrations (#10532/#10543/#10548)
- 본 PR: `equals_ci`

## Note

다른 `String.lowercase_ascii ... = String.lowercase_ascii ...` 사이트 (gate_diff_types, cdal_judge, exec_core, tool_input_validation, coord/resilience, cascade_config, keeper_gh_shared 등)는 변수 binding 형태가 다양하거나 binding 안에서 재사용 — 별도 PR로 검토.
