### PR TITLE
revert: codex_cli removal from cascades (#10554 was mistaken)

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -1,25 +1,30 @@
 comment = "Checked-in seed for cascade authoring. Keep repo defaults boring: bootstrap keeper profile big_three, local keeper profile ollama_only, system-only fallback/judge/phase-routing profiles (default, governance_judge, operator_judge, local_only, local_recovery, tool_rerank), and move personal/live experiments to $MASC_BASE_PATH/.masc/config/cascade.toml."
 
 [default]
-comment = "System-only fallback profile for unknown/missing cascade names. codex_cli removed per #10097 (lib/oas_worker_exec_transport.ml:16-26 — keeper-bound MCP omission strips 35+ runtime tools per turn → end_turn early stops). Server config validator rejects weight=0, so removal of the model entry is the only path. Restore once OAS transport ships per-turn auth via stdin/env (not argv-leak-prone TOML override)."
+comment = "System-only fallback profile for unknown/missing cascade names. Mirrors big_three without Claude CLI so automatic recovery does not pull Claude by default."
 models = [
+  { model = "codex_cli:auto", weight = 1 },
   { model = "gemini_cli:auto", weight = 1 },
+  { model = "codex_cli:gpt-5.3-codex-spark", weight = 1 },
 ]
 temperature = 0.2
 max_tokens = 16384
 keeper_assignable = false
 
 [big_three]
-comment = "Canonical keeper bootstrap profile. codex_cli removed per #10097 (keeper-bound MCP tool omission strips 35+ runtime tools per turn). Server config validator rejects weight=0, hence model removal. Effective lane = gemini_cli until codex_cli auth-header path lands without argv leak."
+comment = "Canonical keeper bootstrap profile exposed by the checked-in seed. Automatic keepers stay off Claude CLI unless an operator opts in via live config."
 models = [
+  { model = "codex_cli:auto", weight = 1 },
   { model = "gemini_cli:auto", weight = 1 },
+  { model = "codex_cli:gpt-5.3-codex-spark", weight = 1 },
 ]
 temperature = 0.2
 max_tokens = 16384
 
 [governance_judge]
-comment = "System-only dashboard governance judge profile. codex_cli removed per #10097 (judge probes also lose keeper-bound MCP surface)."
+comment = "System-only dashboard governance judge profile. Explicitly defined so background judge loops do not inherit fallback providers such as Claude CLI."
 models = [
+  { model = "codex_cli:auto", weight = 1 },
   { model = "gemini_cli:auto", weight = 1 },
 ]
 temperature = 0.2
@@ -27,8 +32,9 @@ max_tokens = 16384
 keeper_assignable = false
 
 [operator_judge]
-comment = "System-only dashboard operator judge profile. codex_cli removed per #10097."
+comment = "System-only dashboard operator judge profile. Mirrors governance_judge so background control loops stay off Claude CLI by default."
 models = [
+  { model = "codex_cli:auto", weight = 1 },
   { model = "gemini_cli:auto", weight = 1 },
 ]
 temperature = 0.2


### PR DESCRIPTION
## Summary
Revert #10554. 사용자 의심 ("저게 진짜 영향이 있는게 사실인가?") 정당했음 — production 검증 결과 cascade에서 codex_cli 제거가 keeper proactive turn rate를 22.5x 악화시킬 수 있음.

## Empirical Evidence
| Metric | Pre-fix (10:51-12:34) | Post-fix (12:34-14:30) | Post-rollback (15:09+) |
|---|---|---|---|
| keeper proactive turn/h | 7.5 | 0.33 | turn=399, 61 정상 |
| max_turns 분포 | 79, 58, 108, 103 등 다양 | 88 단 1회 | 428, 90 정상 |

## Why the Original PR Was Mistaken

### 1. Dedup'd Metric Misled
`masc_codex_cli_mcp_tool_omission_total` counter는 같은 keeper의 같은 fingerprint omission이 반복돼도 첫 번째만 log. "12 → 12 drift 0"은 **fix 효과 아니라 dedup의 stale read**.

### 2. 진짜 Root Cause는 코드 layer
`lib/oas_worker_exec_transport.ml:16-26` 주석은 "structural provider limitation"이라 함. 그러나 agent feasibility 분석 (`/Users/dancer/me/workspace/yousleepwhen/oas/lib/llm_provider/transport_codex_cli.ml:268-294`):
- Codex CLI는 per-completion fresh spawn
- `mcp_servers.<name>.http_headers={...}` per-spawn TOML override 지원
- **Per-turn token rotation은 mechanically feasible**

진짜 보안 근거는 **argv-leak prevention** (TOML override가 argv로 ps에 노출), structural limitation 아님.

### 3. Cascade 변경의 Side Effect
codex_cli 제거 후 `big_three`는 `claude_code + gemini_cli`만 남음. 이론상 redundancy 충분하지만:
- Provider 가용성 변동 시 cascade exhaustion 가능
- 또는 cascade resolution path 자체가 codex_cli 가용 여부에 의존

(Server restart confounder는 인정 — 22.5x 감소가 전부 cascade fix 때문이라고 단정 못 함. 그러나 rollback 후 keeper 즉시 복구 = cascade 영향 가능성 높음.)

## Real Root Fix Path

| Layer | 액션 | 위험 |
|---|---|---|
| **A** | OAS #10097 follow-up: per-turn auth via stdin/env (not argv) | argv-leak 회피, 모든 stdio provider 적용 |
| **B** | masc-mcp omission gate 정정: `oas_worker_exec_transport.ml:523-534` unconditional strip → policy-aware | 작은 변경, 즉시 효과 |

## Test plan
- [ ] CI cascade-related test 통과 확인
- [ ] OAS #10097 follow-up issue 생성

🤖 Generated with [Claude Code](https://claude.com/claude-code)