### PR TITLE
feat(design-system): absorb residual bonsai vocabulary + shadow-ring rename + SPEC docs (PR-S3-rest)

### DIFF
--- a/dashboard/design-system/SPEC.md
+++ b/dashboard/design-system/SPEC.md
@@ -267,6 +267,8 @@ bonsai의 5 테마는 production user에게 URL hash로 공유 가능한 자산.
 | 폰트 fallback chain | `--font-*` 정의 내 | system font name (e.g., `Inter`, `JetBrains Mono`) |
 | 4-slot status pattern | `tokens.css`의 `--{ok\|warn\|err\|info\|idle\|stalled}-{soft\|fg\|border\|ring}` | 컴포넌트별 정교한 surface/text/border/ring 4 slot 조합. single-slot semantic alias로 환원 불가. 컴포넌트는 raw 참조 허용 (PR-M5 결정). |
 | `--brass-2` mid tone | accent palette mid-tone 사용처 | SPEC v0.1 §3.4은 accent를 fg/fg-dim 2 slot만 정의. 사용 빈도 증가 시 `--color-accent-fg-mid` 추가 검토. |
+| `--font-mono` stack divergence | dashboard `tokens.css` vs bonsai `colors_and_type.css` | dashboard는 `ui-monospace` 우선(Apple 시스템 폰트), bonsai는 `JetBrains Mono` 우선(고딕 미감 일관성). PR-S2.5 redirect 시 bonsai stub이 자기 stack 유지 — dashboard 정의를 inherit하지 않음. |
+| `--shadow-inset` 의미 차이 | dashboard `tokens.css` vs `--shadow-ring`(bonsai) | dashboard는 top-edge highlight, bonsai는 1px ring. PR-S3-rest(2026-04-26)에서 bonsai 측을 `--shadow-ring`으로 rename하여 충돌 해소. |
 
 ### 6.3 Surface 적용 의무
 

--- a/dashboard/design-system/source_styles/tokens.css
+++ b/dashboard/design-system/source_styles/tokens.css
@@ -756,6 +756,22 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
   --ink-2:   #2E2E2C;
   --ink-3:   #515049;
   --ink-4:   #656358;
+  --ink-5:   #9A978D;
+  --ink-6:   #BCB8AC;
+
+  /* Named hue tokens (paper-only) — color/fill pairs from bonsai
+     vocabulary. Used for keeper attribution accents, swimlane categories,
+     and t-* trace frames in the light-on-paper theme. */
+  --forest:  #2D5F4E;  --forest-fill: #CFDFD7;
+  --brass:   #8C6A1E;  --brass-fill:  #E9DDB8;
+  --brick:   #8B3A3A;  --brick-fill:  #E8CFCB;
+  --ember:   #B35A1F;  --ember-fill:  #ECD5BD;
+  --slate:   #3E4A5C;  --slate-fill:  #D6DBE2;
+  --plum:    #5C3E56;  --plum-fill:   #E0D4DE;
+  --teal:    #236874;  --teal-fill:   #CEDEE2;
+
+  --status-idle: var(--ink-5);
+
   --bg-deep:      var(--paper);
   --bg-panel:     var(--paper-2);
   --bg-panel-alt: var(--paper-3);
@@ -887,4 +903,29 @@ button.is-active, .btn.is-active { background: var(--bg-4); color: var(--brass-1
   --font-display: 'JetBrains Mono', 'Noto Sans KR', monospace;
   --font-body:    'JetBrains Mono', 'Noto Sans KR', monospace;
   --font-ui:      'JetBrains Mono', 'Noto Sans KR', monospace;
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   BONSAI STRUCTURAL TOKENS (scrollbar primitives)
+   ───────────────────────────────────────────────────────────────────
+   Theme-invariant. dashboard surface has its own ::-webkit-scrollbar-
+   thumb rule (uses --line-2/-3) and does not consume these tokens.
+   bonsai surface reads via var(--scrollbar-thumb, var(--border-main))
+   pattern with --border-main fallback.
+   ═══════════════════════════════════════════════════════════════════ */
+
+:root {
+  --scrollbar-thumb:       #2a1f1a;
+  --scrollbar-thumb-hover: #3d2e22;
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   BONSAI STRUCTURAL TOKENS (shadow ring)
+   ───────────────────────────────────────────────────────────────────
+   1px inset border ring. Renamed from bonsai's former --shadow-inset
+   to disambiguate from dashboard's --shadow-inset (top-edge highlight).
+   ═══════════════════════════════════════════════════════════════════ */
+
+:root {
+  --shadow-ring: inset 0 0 0 1px rgba(196, 162, 101, 0.25);
 }

--- a/dashboard_bonsai/static/colors_and_type.css
+++ b/dashboard_bonsai/static/colors_and_type.css
@@ -78,7 +78,7 @@
   --shadow-card:   0 1px 4px rgba(0, 0, 0, 0.5);
   --shadow-raised: 0 8px 24px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--border-highlight);
   --shadow-glow:   0 0 20px var(--accent-glow);
-  --shadow-inset:  inset 0 0 0 1px rgba(196, 162, 101, 0.25);
+  --shadow-ring:   inset 0 0 0 1px rgba(196, 162, 101, 0.25);
 
   /* Spacing (4px grid) */
   --space-1:  4px;
@@ -354,7 +354,7 @@ hr {
 .btn.primary {
   border-color: var(--accent-brass);
   color: var(--accent-brass);
-  box-shadow: var(--shadow-inset);
+  box-shadow: var(--shadow-ring);
 }
 .btn.primary:hover { background: var(--accent-glow); color: var(--text-bright); }
 .btn.ghost { background: transparent; }
@@ -424,7 +424,7 @@ hr {
 .frame-gothic {
   position: relative;
   border: 1px solid var(--border-highlight);
-  box-shadow: var(--shadow-inset), var(--shadow-panel);
+  box-shadow: var(--shadow-ring), var(--shadow-panel);
 }
 .frame-gothic::before,
 .frame-gothic::after {


### PR DESCRIPTION
## Summary

PR-S3 stack의 main 미도착 잔여를 단일 main-direct PR로 통합. S3a/S3b/S3c/S3d는 이미 main에 도착했고, S3e/S3f/S3g/S3h를 한 번에 정리.

## 추가 토큰

### 1) `[data-theme="paper"]` 블록 안 (S3e 동등)

```css
--ink-5: #9A978D;  --ink-6: #BCB8AC;

/* 7 named hue/fill pairs */
--forest:  #2D5F4E;  --forest-fill: #CFDFD7;
--brass:   #8C6A1E;  --brass-fill:  #E9DDB8;
--brick:   #8B3A3A;  --brick-fill:  #E8CFCB;
--ember:   #B35A1F;  --ember-fill:  #ECD5BD;
--slate:   #3E4A5C;  --slate-fill:  #D6DBE2;
--plum:    #5C3E56;  --plum-fill:   #E0D4DE;
--teal:    #236874;  --teal-fill:   #CEDEE2;

--status-idle: var(--ink-5);
```

### 2) `:root` (S3f scrollbar + S3g shadow-ring)

```css
--scrollbar-thumb:       #2a1f1a;
--scrollbar-thumb-hover: #3d2e22;
--shadow-ring: inset 0 0 0 1px rgba(196, 162, 101, 0.25);
```

## Bonsai colors_and_type.css rename (S3g)

```diff
-  --shadow-inset:  inset 0 0 0 1px rgba(196, 162, 101, 0.25);
+  --shadow-ring:   inset 0 0 0 1px rgba(196, 162, 101, 0.25);

 .btn.primary { ... box-shadow: var(--shadow-inset → --shadow-ring); }
 .frame-gothic { ... box-shadow: var(--shadow-inset → --shadow-ring), ... }
```

dashboard `--shadow-inset` (top-edge highlight) 보존, bonsai 측만 `--shadow-ring`으로 rename.

## SPEC.md §6.2 escape hatch (S3h)

| 항목 | 사유 |
|------|------|
| `--font-mono` stack divergence | dashboard `ui-monospace` 우선 / bonsai `JetBrains Mono` 우선. PR-S2.5 시 bonsai stub이 자기 stack 유지. |
| `--shadow-inset` 의미 차이 | dashboard top-edge highlight vs bonsai 1px ring. PR-S3-rest에서 bonsai 측 rename. |

## 안전성

- **시각 회귀 0**: bonsai surface는 자기 colors_and_type.css 계속 사용 (resolved value 동일)
- **dashboard 영향 0**: 새 토큰 dormant (consumer 없음), `--shadow-inset` 정의/소비 보존

## Vocabulary 100% 일치

이 PR이 머지되면 bonsai의 모든 `--*` 토큰이 dashboard tokens.css에 정의됨. **PR-S2.5 (bonsai SSOT redirect) 사전조건 완료.**

## Test plan

- [ ] CI green
- [ ] CSS validity
- [ ] bonsai surface `.btn.primary` / `.frame-gothic` / paper 테마 시각 회귀 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
