### PR TITLE
refactor(config): bump Alerting default 15→20s + migrate gh issue create site (#10426 Alerting)

### DIFF
--- a/lib/config/env_config_exec_timeout.ml
+++ b/lib/config/env_config_exec_timeout.ml
@@ -22,7 +22,7 @@ type caller =
   | Pr_review                 (** keeper_tool_pr_review gh CLI calls (15s) *)
   | Dispatch                  (** exec_dispatch routine execution (120s) *)
   | Memory_audit              (** keeper_exec_memory short audits (3s) *)
-  | Alerting                  (** keeper_alerting fanout commands (15s/20s) *)
+  | Alerting                  (** keeper_alerting fanout (Slack/webhook POST + gh issue create) (20s) *)
   | Gh_shared                 (** keeper_gh_shared gh CLI quick query (5s) *)
   | Status_detail             (** keeper_status_detail health probes (5/10s) *)
   | Turn_sandbox              (** keeper_turn_sandbox_runtime (2/5s) *)
@@ -72,7 +72,8 @@ let known_default_sec = function
   | Fs -> Some 30.0
   | Preflight | Repo_readiness | Gh_shared | Status_detail -> Some 10.0
   | Sandbox | Turn_sandbox -> Some 2.0
-  | Pr_review | Alerting | Turn_up -> Some 15.0
+  | Pr_review | Turn_up -> Some 15.0
+  | Alerting -> Some 20.0
   | Dispatch -> Some 120.0
   | Memory_audit -> Some 3.0
   | Unknown _ -> None

--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -449,7 +449,11 @@ let post_keeper_alert_github
     ]
     @ List.concat_map (fun label -> [ "--label"; label ]) labels
     in
-    let (status, out) = Process_eio.run_argv_with_status ~timeout_sec:20.0 args in
+    let (status, out) =
+      Process_eio.run_argv_with_status
+        ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Alerting ())
+        args
+    in
     match status with
     | Unix.WEXITED 0 -> (true, Some (short_preview ~max_len:200 out))
     | Unix.WEXITED n ->

--- a/test/test_env_config_exec_timeout_10426.ml
+++ b/test/test_env_config_exec_timeout_10426.ml
@@ -28,7 +28,7 @@ let cases =
     E.Pr_review, 15.0;
     E.Dispatch, 120.0;
     E.Memory_audit, 3.0;
-    E.Alerting, 15.0;
+    E.Alerting, 20.0;
     E.Gh_shared, 10.0;
     E.Status_detail, 10.0;
     E.Turn_sandbox, 2.0;


### PR DESCRIPTION
## Why

#10594 deviation #1: `keeper_alerting.ml:452` uses `~timeout_sec:20.0` while `Alerting` SSOT default was 15.0. Analysis (in #10594) recommended bumping the default rather than introducing a new caller variant — the two existing `Alerting` sites (Slack/webhook POSTs) tolerate 20s safely.

## What

1. **Default bump**: `Env_config_exec_timeout.known_default_sec Alerting` now returns `Some 20.0` (was 15.0).
2. **Migration**: `keeper_alerting.ml:452` (`gh issue create` mutation) switches from `~timeout_sec:20.0` to `~caller:Alerting`.
3. **Test**: cases table pin updated.

After this PR:
- All three `Alerting` sites use the SSOT (Slack POST × 2 + gh issue create × 1).
- Operators tune via `MASC_EXEC_TIMEOUT_ALERTING_SEC` (default 20.0).
- Operators who want the previous 15s bound: `MASC_EXEC_TIMEOUT_ALERTING_SEC=15`.

## Risk

Trivial. The two already-migrated `Alerting` sites (Slack/webhook curl POSTs) gain 5s upper budget but no behavior change — they only wait that long when the request actually hangs, which today they would already retry through the alert pipeline.

## Diff

```
3 files changed, 9 insertions(+), 4 deletions(-)
```

## Verification

- `dune build lib/ --root . --cache=disabled` → RC=0.
- `dune exec test/test_env_config_exec_timeout_10426.exe` → 9/9 pass.

---

Refs: #10426 (audit + plan), #10594 (deviation analysis), #10502 (P2-C out-of-scope list — this is the first of 4 follow-ups).
