### PR TITLE
chore(keeper): drop 12 deprecated re-exports from Keeper_exec_context (0 callers)

### DIFF
--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -65,11 +65,6 @@ let save_oas_checkpoint = Keeper_context_core.save_oas_checkpoint
 let load_context_from_checkpoint = Keeper_context_core.load_context_from_checkpoint
 let save_checkpoint = Keeper_context_core.save_checkpoint
 
-let restore_checkpoint = Keeper_context_core.restore_checkpoint
-let load_latest_checkpoint = Keeper_context_core.load_latest_checkpoint
-let context_of_legacy_checkpoint = Keeper_context_core.context_of_legacy_checkpoint
-let checkpoint_generation = Keeper_context_core.checkpoint_generation
-
 (* ================================================================ *)
 (* Re-export from Keeper_rollover                                    *)
 (* ================================================================ *)

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -189,21 +189,6 @@ val load_context_from_checkpoint :
 val save_checkpoint :
   session_context -> working_context -> generation:int -> checkpoint
 
-(** {1 Deprecated Checkpoint Helpers} *)
-
-val restore_checkpoint : checkpoint -> max_tokens:int -> working_context
-[@@deprecated "Use Keeper_context_core.restore_checkpoint directly; this re-export will be removed in a future release."]
-
-val load_latest_checkpoint : session_context -> checkpoint option
-[@@deprecated "Use Keeper_context_core.load_latest_checkpoint directly; this re-export will be removed in a future release."]
-
-val context_of_legacy_checkpoint :
-  checkpoint -> primary_model_max_tokens:int -> working_context
-[@@deprecated "Use Keeper_context_core.context_of_legacy_checkpoint directly; this re-export will be removed in a future release."]
-
-val checkpoint_generation : Oas.Checkpoint.t -> fallback:int -> int
-[@@deprecated "Use Keeper_context_core.checkpoint_generation directly; this re-export will be removed in a future release."]
-
 (** {1 Compaction} *)
 
 val compaction_policy_of_keeper : keeper_meta -> float * int * int
@@ -345,35 +330,6 @@ val append_trait_clause : base:string -> clause:string -> string
 val strip_state_blocks_text : string -> string
 val trim_to_option : string -> string option
 val user_visible_reply_text : ?fallback:string -> string -> string
-
-(** {1 Deprecated Text Processing Helpers} *)
-
-val state_snapshot_reply_fallback :
-  Keeper_memory_policy.keeper_state_snapshot option -> string option
-[@@deprecated "Use Keeper_text_processing.state_snapshot_reply_fallback directly; this re-export will be removed in a future release."]
-
-val strip_internal_reply_markup : string -> string
-[@@deprecated "Use Keeper_text_processing.strip_internal_reply_markup directly; this re-export will be removed in a future release."]
-
-val normalize_proactive_text : string -> string
-[@@deprecated "Use Keeper_text_processing.normalize_proactive_text directly; this re-export will be removed in a future release."]
-
-val extract_checkin_text : string -> string option
-[@@deprecated "Use Keeper_text_processing.extract_checkin_text directly; this re-export will be removed in a future release."]
-
-(** {1 Deprecated Proactive Terminal-Ending Detection} *)
-
-val proactive_has_terminal_punct : string -> bool
-[@@deprecated "Use Keeper_text_processing.proactive_has_terminal_punct directly; this re-export will be removed in a future release."]
-
-val proactive_has_terminal_korean_ending : string -> bool
-[@@deprecated "Use Keeper_text_processing.proactive_has_terminal_korean_ending directly; this re-export will be removed in a future release."]
-
-val proactive_has_terminal_ending : string -> bool
-[@@deprecated "Use Keeper_text_processing.proactive_has_terminal_ending directly; this re-export will be removed in a future release."]
-
-val proactive_looks_fragmentary : string -> bool
-[@@deprecated "Use Keeper_text_processing.proactive_looks_fragmentary directly; this re-export will be removed in a future release."]
 
 (** {1 Fragment Detection (used by dashboard)} *)
 


### PR DESCRIPTION
## Context

`lib/keeper/keeper_exec_context.mli`에 12개의 `[@@deprecated]` re-export가 있었고, 각각 다음과 같은 메시지를 가지고 있었습니다:

> "Use Keeper_X.<sym> directly; this re-export will be removed in a future release."

12 심볼 전부 `lib/`, `test/`, `scripts/`에서 caller가 **0건**임을 검증했고, deprecation에서 약속한 "future release"가 도래했다고 판단해 surgical 삭제합니다.

## Symbols removed

### Checkpoint helpers (4) — re-export of `Keeper_context_core`
- `restore_checkpoint`
- `load_latest_checkpoint`
- `context_of_legacy_checkpoint`
- `checkpoint_generation`

### Text processing helpers (4) — re-export of `Keeper_text_processing`
- `state_snapshot_reply_fallback`
- `strip_internal_reply_markup`
- `normalize_proactive_text`
- `extract_checkin_text`

### Proactive terminal-ending detection (4) — re-export of `Keeper_text_processing`
- `proactive_has_terminal_punct`
- `proactive_has_terminal_korean_ending`
- `proactive_has_terminal_ending`
- `proactive_looks_fragmentary`

## Diff scope

- `lib/keeper/keeper_exec_context.mli`: −44 lines (12 `val` + 3 section headers)
- `lib/keeper/keeper_exec_context.ml`: −5 lines (4 checkpoint helper `let` bindings; 8 text/proactive symbols are surfaced via existing `include Keeper_text_processing` which remains for internal usage)

Total: **49 lines deleted, 2 files**.

## Caller verification

각 12 deprecated 심볼에 대해 0 caller 확인:

\`\`\`bash
rg -n 'Keeper_exec_context\.(restore_checkpoint|load_latest_checkpoint|context_of_legacy_checkpoint|checkpoint_generation)\b' lib/ test/ scripts/
# (no output)

rg -n 'Keeper_exec_context\.(state_snapshot_reply_fallback|strip_internal_reply_markup|normalize_proactive_text|extract_checkin_text)\b' lib/ test/ scripts/
# (no output)

rg -n 'Keeper_exec_context\.(proactive_has_terminal_punct|proactive_has_terminal_korean_ending|proactive_has_terminal_ending|proactive_looks_fragmentary)\b' lib/ test/ scripts/
# (no output)
\`\`\`

## Local verification

\`\`\`
$ rm -rf _build && DUNE_CACHE=disabled dune build --cache=disabled
# (clean, no errors)

$ dune runtest
# exit 0; mcp_tool_matrix snapshot 1 internal report unchanged from baseline
\`\`\`

## DNM rationale

이 PR은 cleanup loop의 첫 candidate이고, 메모리 `feedback_do-not-merge-label-insufficient`에 의해 라벨 단독으로는 cascade flip 방지가 안 되므로 사용자 명시 승인 후 머지하도록 holdable 상태로 둡니다.

## Linked

cleanup 로그: `~/me/planning/claude-plans/mossy-chasing-toast.md` (Wave A revised → 진행 candidate #3)