### PR TITLE
refactor(keeper): move cohort_key to source-of-truth module (#10584 Option B)

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -58,6 +58,24 @@ let failure_reason_to_string = function
   | Fiber_unresolved -> "fiber_unresolved"
   | Exception s -> Printf.sprintf "exception(%s)" s
 
+(** #10584: cohort key for grouping failures by variant, ignoring
+    parameters (e.g. failure count, timeout seconds).  Lives next to
+    [failure_reason_to_string] in the source-of-truth module so any
+    new variant added to [failure_reason] forces a same-PR update of
+    BOTH conversion arms — the consumer in keeper_supervisor (and
+    any other dashboard / metrics call site) just delegates here.
+    This is Option B from #10584: avoid the recurring-P0 pattern
+    where consumer-side exhaustive matches catch up to upstream
+    variant additions only after the warn-error build trip. *)
+let failure_reason_cohort_key = function
+  | Some (Heartbeat_consecutive_failures _) -> "heartbeat_failures"
+  | Some (Turn_consecutive_failures _) -> "turn_failures"
+  | Some (Stale_turn_timeout _) -> "stale_turn_timeout"
+  | Some (Ambiguous_partial_commit _) -> "ambiguous_partial_commit"
+  | Some Fiber_unresolved -> "fiber_unresolved"
+  | Some (Exception _) -> "exception"
+  | None -> "unknown"
+
 (** Pure control-flow signal for immediate fiber termination (RFC-0002).
     Carries no state — failure reason must be pre-stored via
     [set_failure_reason] before raising. *)

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -35,6 +35,13 @@ val ambiguous_partial_commit_kind_to_string :
 
 val failure_reason_to_string : failure_reason -> string
 
+(** #10584: cohort key for grouping failures by variant (ignores
+    parameters). [None] returns ["unknown"]. New variants added to
+    [failure_reason] force a same-PR update of this function via
+    OCaml's exhaustive-match check — Option B mitigation for the
+    recurring P0 pattern (#10490, #10574). *)
+val failure_reason_cohort_key : failure_reason option -> string
+
 (** Pure control-flow signal for immediate fiber termination (RFC-0002).
     Carries no state — failure reason must be pre-stored via
     [set_failure_reason] before raising. *)

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -606,15 +606,11 @@ let cleanup_dead_tombstone (ctx : _ context)
         entry.name err
 
 (** Cohort key from structured failure_reason ADT.
-    Groups failures by variant, ignoring parameters (e.g. failure count). *)
-let cohort_key_of_reason = function
-  | Some (Keeper_registry.Heartbeat_consecutive_failures _) -> "heartbeat_failures"
-  | Some (Keeper_registry.Turn_consecutive_failures _) -> "turn_failures"
-  | Some (Keeper_registry.Stale_turn_timeout _) -> "stale_turn_timeout"
-  | Some (Keeper_registry.Ambiguous_partial_commit _) -> "ambiguous_partial_commit"
-  | Some Keeper_registry.Fiber_unresolved -> "fiber_unresolved"
-  | Some (Keeper_registry.Exception _) -> "exception"
-  | None -> "unknown"
+    #10584: delegates to [Keeper_registry.failure_reason_cohort_key] so a
+    new variant in keeper_registry forces a same-PR converter update via
+    the source module's exhaustive-match check, instead of breaking main
+    here on first build (the recurring P0 pattern from #10490 + #10574). *)
+let cohort_key_of_reason = Keeper_registry.failure_reason_cohort_key
 
 (** Self-preservation gate. Suppresses restarts when a dominant failure
     cohort exceeds ratio threshold AND minimum candidate count. *)


### PR DESCRIPTION
## 요약

#10584의 recurring P0 패턴 (cross-module exhaustive-match → variant 추가 시 main break)에 대한 Option B 시범 적용. \`cohort_key_of_reason\`을 consumer (\`keeper_supervisor.ml\`)에서 source-of-truth (\`keeper_registry.ml\`)로 이동.

## 변경

**\`lib/keeper/keeper_registry.ml/.mli\`** — 새 \`failure_reason_cohort_key : failure_reason option -> string\`. \`failure_reason_to_string\` 옆에 위치 — 새 variant 추가 시 OCaml exhaustive-match가 같은 파일 내에서 두 converter 모두 강제 update.

**\`lib/keeper/keeper_supervisor.ml:608-617\`** — inline match 9줄 → 1줄 delegation:

\`\`\`ocaml
let cohort_key_of_reason = Keeper_registry.failure_reason_cohort_key
\`\`\`

## 검증

\`\`\`
DUNE_CACHE=disabled dune build --root . --cache=disabled @check  → EXIT=0
\`\`\`

행동 동일 (delegation only), test surface 변경 없음.

## 영향

- 다음 \`failure_reason\` variant 추가 시 main 빌드 깨짐 위험 ↓
- 같은 PR에서 conversion arm을 같은 파일에서 발견 → cognitive overhead ↓
- #10490 (oas_sse_bridge ↔ Oas.Event_bus) 는 별도 PR (외부 패키지 dependency 때문에 다른 접근)

## Defensive guards

Draft + \`do-not-merge\`.

## 관련

- Issue: \`#10584\`
- Pattern instances: #10490, #10572, #10574, #10593
- Memory: \`feedback_oas-pin-bump-drift-gate\`, \`feedback_structural-bug-class-rg-sweep\`