### PR TITLE
perf(metrics): file-private take helper for top-N truncation (drops length+filteri double walk)

### DIFF
--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -142,6 +142,15 @@ let percentile_opt (arr : float array) p =
 let count_if pred xs =
   List.fold_left (fun n x -> if pred x then n + 1 else n) 0 xs
 
+(* O(min(n, length xs)) prefix take.  Replaces the
+   [if List.length xs > n then List.filteri (fun i _ -> i < n) xs else xs]
+   pattern: that walks the list twice (length, then filter) and allocates
+   the full filtered list.  This walks once and stops at [n]. *)
+let rec take n = function
+  | _ when n <= 0 -> []
+  | [] -> []
+  | x :: xs -> x :: take (n - 1) xs
+
 let sum_int_opt values =
   match values with
   | [] -> None
@@ -1001,11 +1010,11 @@ let aggregate_by_model (entries : raw_entry list) : model_stats list =
         in
         StringMap.fold (fun tool count acc -> (tool, count) :: acc) tool_map []
         |> List.sort (fun (_, a) (_, b) -> compare b a)
-        |> (fun l -> if List.length l > 10 then List.filteri (fun i _ -> i < 10) l else l));
+        |> take 10);
       recent_entries =
         success_entries
         |> List.sort (fun a b -> Float.compare b.ts_unix a.ts_unix)
-        |> (fun l -> if List.length l > 5 then List.filteri (fun i _ -> i < 5) l else l)
+        |> take 5
         |> List.map (fun e -> {
           re_ts_unix = e.ts_unix;
           re_provider = e.provider;


### PR DESCRIPTION
## What

`lib/model_inference_metrics.ml` 2 사이트의 top-N truncation 패턴을 `take` helper로 변환:

- `:998` top_tools (top 10)
- `:1002` recent_entries (top 5)

```ocaml
(* O(min(n, length xs)) prefix take. Replaces the double-walk
   length+filteri pattern. *)
let rec take n = function
  | _ when n <= 0 -> []
  | [] -> []
  | x :: xs -> x :: take (n - 1) xs
```

## Why

원래 패턴 `if List.length xs > n then List.filteri (fun i _ -> i < n) xs else xs`은:
1. `List.length` — 전체 list walk (O(N))
2. `List.filteri` — 또 한 번 walk + 새 list allocation
3. 분기 없을 때(`xs.length <= n`)도 length 호출 후 원본 반환

`take`는 single pass O(min(n, len)) + n cells만 alloc + 자동 short-circuit. 1000+ entries 시 walk 2회 → 1회, alloc 절반.

## Test

`OCAMLPARAM='_,warn-error=+a' dune build @check` clean.

## Sweep series

- #10607 머지: file-private `count_if` (#10607)
- 본 PR: file-private `take`
- 후속: List_util (#10609 머지 후) SSOT로 통합 가능. tool_team_memory.ml:366도 동일 패턴이 있어 후속 PR 후보.

## Note

`List.partial-match` warning 회피 위해 `| _ when n <= 0 -> []` 첫 catch-all 후 `| [] -> []`. 둘 다 빈 결과지만 명시적.
