### PR TITLE
feat(design-system): bonsai --shadow-inset rename + SPEC §6.2 docs (PR-S3g+S3h)

### DIFF
--- a/dashboard/design-system/SPEC.md
+++ b/dashboard/design-system/SPEC.md
@@ -267,6 +267,8 @@ bonsai의 5 테마는 production user에게 URL hash로 공유 가능한 자산.
 | 폰트 fallback chain | `--font-*` 정의 내 | system font name (e.g., `Inter`, `JetBrains Mono`) |
 | 4-slot status pattern | `tokens.css`의 `--{ok\|warn\|err\|info\|idle\|stalled}-{soft\|fg\|border\|ring}` | 컴포넌트별 정교한 surface/text/border/ring 4 slot 조합. single-slot semantic alias로 환원 불가. 컴포넌트는 raw 참조 허용 (PR-M5 결정). |
 | `--brass-2` mid tone | accent palette mid-tone 사용처 | SPEC v0.1 §3.4은 accent를 fg/fg-dim 2 slot만 정의. 사용 빈도 증가 시 `--color-accent-fg-mid` 추가 검토. |
+| `--font-mono` stack divergence | dashboard `tokens.css` vs bonsai `colors_and_type.css` | dashboard `ui-monospace` 우선 (Apple 시스템) / bonsai `JetBrains Mono` 우선 (고딕 일관성). PR-S2.5 redirect 시 bonsai stub이 자기 stack 유지. |
+| `--shadow-inset` vs `--shadow-ring` 의미 차이 | dashboard `tokens.css` (top-edge highlight) vs bonsai `colors_and_type.css` (1px ring) | 이름은 같았으나 의미가 달라 PR-S3g에서 bonsai 측을 `--shadow-ring`으로 rename. dashboard `--shadow-inset`(top-edge highlight)는 보존. |
 
 ### 6.3 Surface 적용 의무
 

--- a/dashboard_bonsai/static/colors_and_type.css
+++ b/dashboard_bonsai/static/colors_and_type.css
@@ -78,7 +78,7 @@
   --shadow-card:   0 1px 4px rgba(0, 0, 0, 0.5);
   --shadow-raised: 0 8px 24px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--border-highlight);
   --shadow-glow:   0 0 20px var(--accent-glow);
-  --shadow-inset:  inset 0 0 0 1px rgba(196, 162, 101, 0.25);
+  --shadow-ring:   inset 0 0 0 1px rgba(196, 162, 101, 0.25);
 
   /* Spacing (4px grid) */
   --space-1:  4px;
@@ -354,7 +354,7 @@ hr {
 .btn.primary {
   border-color: var(--accent-brass);
   color: var(--accent-brass);
-  box-shadow: var(--shadow-inset);
+  box-shadow: var(--shadow-ring);
 }
 .btn.primary:hover { background: var(--accent-glow); color: var(--text-bright); }
 .btn.ghost { background: transparent; }
@@ -424,7 +424,7 @@ hr {
 .frame-gothic {
   position: relative;
   border: 1px solid var(--border-highlight);
-  box-shadow: var(--shadow-inset), var(--shadow-panel);
+  box-shadow: var(--shadow-ring), var(--shadow-panel);
 }
 .frame-gothic::before,
 .frame-gothic::after {


### PR DESCRIPTION
## Summary

PR-S3 absorb 단계 잔여 정리. PR-S3-rest(#10556)는 token absorption만 머지됐고 S3g(bonsai rename) + S3h(SPEC docs)는 미반영. 본 PR로 통합.

## 변경 1 — Bonsai shadow-ring rename (S3g)

`dashboard_bonsai/static/colors_and_type.css`:

```diff
-  --shadow-inset:  inset 0 0 0 1px rgba(196, 162, 101, 0.25);
+  --shadow-ring:   inset 0 0 0 1px rgba(196, 162, 101, 0.25);

 .btn.primary { ... box-shadow: var(--shadow-inset → --shadow-ring); }
 .frame-gothic { ... box-shadow: var(--shadow-inset → --shadow-ring), var(--shadow-panel); }
```

dashboard `--shadow-inset` (top-edge highlight)는 보존 — bonsai 측만 `--shadow-ring`으로 분리하여 의미 충돌 해소.

## 변경 2 — SPEC §6.2 escape hatch 2개 추가 (S3h)

| 항목 | 사유 |
|------|------|
| `--font-mono` stack divergence | dashboard `ui-monospace` 우선 / bonsai `JetBrains Mono` 우선. PR-S2.5 redirect 시 bonsai stub이 자기 stack 유지. |
| `--shadow-inset` vs `--shadow-ring` 의미 차이 | dashboard top-edge highlight vs bonsai 1px ring. PR-S3g rename으로 해소. |

## 안전성

- **시각 회귀 0**: bonsai rename은 같은 값(`inset 0 0 0 1px rgba(196,162,101,0.25)`) 보존, 이름만 변경
- **dashboard 영향 0**: `--shadow-inset`이 dashboard에서 그대로 유지

## Vocabulary 100% 일치 + 의미 충돌 해소

이 PR이 머지되면:
1. bonsai의 모든 `--*` 토큰이 dashboard tokens.css에 정의됨 (#10556으로 38/38 absorb 완료)
2. 같은 이름의 의미 충돌 없음 (`--shadow-inset` 분리)
3. SPEC에 divergence 항목 명시

**PR-S2.5 (bonsai SSOT redirect) 사전조건 완료.**

## Test plan

- [ ] CI green
- [ ] CSS validity (rename은 valid CSS)
- [ ] bonsai surface `.btn.primary` / `.frame-gothic` 시각 회귀 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
