### PR TITLE
refactor(alerting): bump default 15→20s + migrate gh-issue-create site (#10594 site 1)

### DIFF
--- a/lib/config/env_config_exec_timeout.ml
+++ b/lib/config/env_config_exec_timeout.ml
@@ -73,6 +73,11 @@ let known_default_sec = function
   | Preflight | Repo_readiness | Gh_shared | Status_detail -> Some 10.0
   | Sandbox | Turn_sandbox -> Some 2.0
   | Pr_review | Turn_up -> Some 15.0
+  (* #10594 site 1: bumped 15.0 → 20.0 because gh issue create + Slack
+     POST + webhook fanout share this caller and the gh path can hit
+     ~18s under GitHub API load.  Operators can env-override down via
+     MASC_EXEC_TIMEOUT_ALERTING_SEC if the wider budget masks a real
+     stuck call. *)
   | Alerting -> Some 20.0
   | Dispatch -> Some 120.0
   | Memory_audit -> Some 3.0


### PR DESCRIPTION
## 요약

#10594 5개 deferred site 중 site 1: \`keeper_alerting.ml:452\` (gh issue create 20s 리터럴) 을 SSOT로 마이그레이션. \`Alerting\` caller default를 15→20s로 bump.

## 변경

- \`lib/config/env_config_exec_timeout.ml\`: Alerting을 \`Pr_review | Turn_up\` 공유 arm에서 분리, default 20.0s, inline 코멘트로 gh-issue 근거 명시
- \`lib/keeper/keeper_alerting.ml:452\`: \`~timeout_sec:20.0\` → \`~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Alerting ())\`
- \`test/test_env_config_exec_timeout_10426.ml\`: pin 15.0 → 20.0

## 검증

\`\`\`
dune build @check                                          → EXIT=0
dune exec test/test_env_config_exec_timeout_10426.exe      → 9/9 OK
\`\`\`

## 운영 escape hatch

\`MASC_EXEC_TIMEOUT_ALERTING_SEC=15\` 로 down-override 가능 (wider window가 stuck call을 mask하면).

## 비목표 (별도 PR)

- Site 2 (\`Pr_review_post\` caller 신설, 30s)
- Site 3 (5s lookup, 코멘트만)
- Site 4 (\`Git_meta\` caller 신설, 5s)
- Site 5 (\`Shell_probe\` caller 신설, 2s)

## Defensive guards

Draft + \`do-not-merge\`.

## 관련

- Issue: \`#10594\`
- Predecessor: \`#10426\` (P2-A SSOT, #10457/#10486/#10502)