### PR TITLE
perf(strings): apply String_util.equals_ci to 5 lowercase_ascii x = literal sites

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -493,7 +493,7 @@ let expand_auto_model_string ?rotation_scope (s : string) : string list =
   let trimmed = String.trim s in
   match split_provider_model trimmed with
   | Some (provider_name, model_id)
-    when String.lowercase_ascii model_id = "auto" -> (
+    when String_util.equals_ci model_id "auto" -> (
       match Provider_adapter.auto_models_for_cascade_prefix provider_name with
       | Some models when models <> [] ->
           expand_provider_auto ?rotation_scope ~spec:trimmed provider_name models

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -793,7 +793,7 @@ let handle_keeper_bash
         let hint =
           match reason with
           | Worker_dev_tools.Command_not_allowed name
-            when String.lowercase_ascii name = "gh" ->
+            when String_util.equals_ci name "gh" ->
             "`gh` is not allowed via keeper_bash. Use keeper_shell with \
              op=\"gh\" (e.g. keeper_shell op=gh cmd=\"pr list --state open\")."
           | Chain_or_redirect | Pipes_not_allowed | Unsafe_redirect ->
@@ -808,7 +808,7 @@ let handle_keeper_bash
         let alternatives =
           match reason with
           | Worker_dev_tools.Command_not_allowed name
-            when String.lowercase_ascii name = "gh" ->
+            when String_util.equals_ci name "gh" ->
             [ "Use keeper_shell with op=\"gh\" for GitHub CLI operations."
             ; "Example: keeper_shell op=gh cmd=\"pr list --state open\"."
             ]

--- a/lib/keeper/keeper_gh_shared.ml
+++ b/lib/keeper/keeper_gh_shared.ml
@@ -67,7 +67,7 @@ let normalize_gh_command (cmd : string) : string =
     |> List.filter (fun token -> token <> "")
   in
   let rec drop_leading_gh = function
-    | token :: rest when String.lowercase_ascii token = "gh" ->
+    | token :: rest when String_util.equals_ci token "gh" ->
         drop_leading_gh rest
     | remaining -> remaining
   in

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -209,7 +209,7 @@ let normalize_gh_command (cmd : string) : string =
     |> List.filter (fun token -> token <> "")
   in
   let rec drop_leading_gh = function
-    | token :: rest when String.lowercase_ascii token = "gh" ->
+    | token :: rest when String_util.equals_ci token "gh" ->
         drop_leading_gh rest
     | remaining -> remaining
   in


### PR DESCRIPTION
## What

`String.lowercase_ascii x = "literal"` 5 hunk을 `String_util.equals_ci x "literal"`로 교체. literal이 ASCII (`"gh"`, `"auto"`)이므로 의미 동등 + alloc 절감.

## Sites

- `lib/cascade/cascade_config.ml:496` cascade resolve 시 `model_id = "auto"` (auto-fanout 분기)
- `lib/keeper/keeper_gh_shared.ml:70` `drop_leading_gh` 토큰 매칭
- `lib/keeper/keeper_tool_registry.ml:212` 동상 (별도 fork)
- `lib/keeper/keeper_exec_shell.ml:796, 811` keeper_bash command_not_allowed hint 분기

## Why

각 사이트는 매 호출 1 string allocation. equals_ci는 byte-wise + length-mismatch short-circuit. 매 cascade resolve, keeper command 검증 hot path에서 잡힘.

## Test

`OCAMLPARAM='_,warn-error=+a' dune build @check` clean. 모든 5건이 ASCII literal과 비교 — 의미 동등.

## Sweep series

- `String_util.equals_ci` SSOT 도입: #10612
- 본 PR: 5 사이트 sweep
- 후속: 변수 binding 형태 (`let la = lowercase_ascii a and lb = lowercase_ascii b`)는 binding 안에서 재사용되거나 다른 형태 — 별도 검토.

## Verify

`grep -rn 'String\.lowercase_ascii [a-z_]\+ = "' lib --include "*.ml"` → 0 매치.
