### PR TITLE
fix(sandbox): auto-chdir to repos/<single> when keeper runs git/gh at root (#10424)

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -213,6 +213,50 @@ let run_docker_shell_command_with_status
         |> Keeper_alerting_path.normalize_path_for_check
         |> Keeper_alerting_path.strip_trailing_slashes
       in
+      (* #10424: keeper LLM이 sandbox root에서 cd 없이 git/gh 호출 시
+         "fatal: not a git repository" 발생. mount point는 git repo 아니고
+         repos/<repo>/ 안에만 git checkout 존재. filesystem ground truth
+         (repos/ enumeration)로 결정론적 분기:
+         - single-repo → 자동 chdir (silent)
+         - multi-repo → explicit error로 LLM이 정확한 경로 학습
+         - 0 repo → preserve (system misconfig은 별도 fail) *)
+      let cwd_normalized =
+        Keeper_alerting_path.normalize_path_for_check cwd
+        |> Keeper_alerting_path.strip_trailing_slashes
+      in
+      let repos_in_playground () =
+        let repos_dir = Filename.concat host_root "repos" in
+        if not (Sys.file_exists repos_dir && Sys.is_directory repos_dir) then []
+        else
+          try
+            Sys.readdir repos_dir
+            |> Array.to_list
+            |> List.filter (fun name ->
+              let p = Filename.concat repos_dir name in
+              try Sys.is_directory p with Sys_error _ -> false)
+            |> List.sort compare
+          with Sys_error _ -> []
+      in
+      let cwd, multi_repo_blocker =
+        if cwd_normalized = host_root && cmd_targets_git_or_gh cmd then
+          match repos_in_playground () with
+          | [single_repo] ->
+            (Filename.concat (Filename.concat host_root "repos") single_repo, None)
+          | [] -> (cwd, None)
+          | many ->
+            ( cwd
+            , Some
+                (Printf.sprintf
+                   "sandbox root에서 git/gh 직접 호출 불가 \
+                    (mount point %s는 git repo 아님). \
+                    cd repos/<one of: %s> 먼저 실행하세요."
+                   host_root
+                   (String.concat ", " many)) )
+        else (cwd, None)
+      in
+      match multi_repo_blocker with
+      | Some msg -> sandbox_error msg
+      | None ->
       let container_name = keeper_sandbox_container_name meta in
       let container_root = keeper_private_container_root meta in
       let container_cwd = docker_private_workspace_cwd ~config ~meta cwd in


### PR DESCRIPTION
## Summary
**Closes #10424.** sandbox root에서 git/gh 직접 호출 시 "fatal: not a git repository" 발생 (9x 증가, 2→18→56/day) 해결.

`lib/keeper/keeper_shell_docker.ml:218` 직전에 결정론적 분기 추가:
- **single-repo** (예: masc-improver) → 자동 chdir to `repos/<single>` (silent)
- **multi-repo** (예: analyst with grpc-direct + masc-mcp) → explicit error로 LLM에게 정확한 경로 학습 ("cd repos/<one of: A, B> 먼저")
- **0 repo** → preserve cwd (system misconfig은 별도 fail)

## Why
**Refs**: 
- #10424 issue (full diagnosis + fix design): https://github.com/jeong-sik/masc-mcp/issues/10424
- 본인 fix design comment: https://github.com/jeong-sik/masc-mcp/issues/10424#issuecomment-4321328515

**Problem (from #10424)**:
\`\`\`
registry: recording error name=analyst
error=sandbox docker exec failed (masc-keeper-sandbox:local):
fatal: not a git repository (or any parent up to mount point /home/keeper/playground)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
\`\`\`

**Filesystem ground truth** (verified):
\`\`\`
~/me/.masc/playground/analyst/repos/   → grpc-direct, masc-mcp     (multi-repo)
~/me/.masc/playground/masc-improver/repos/  → masc-mcp              (single-repo)
\`\`\`

**결정론/비결정론 경계**:
- 결정론 (filesystem `{0,1,N}` repo count): 명확한 분기 처리
- 비결정론 (LLM의 cd 누락 행동): explicit error message로 학습 압력 부여 (multi-repo case)

## Trade-off
| | + | - |
|--|---|---|
| **단일 repo auto-chdir** | masc-improver fleet 즉시 회복 (4 events/3hr 차단) | "magic" — LLM이 explicit chdir 안 하게 학습할 수도 |
| **multi-repo explicit error** | analyst 같은 ambiguous case fail-loud, LLM이 정확히 어디로 가야 할지 안내 | 첫 retry까지 keeper turn 1회 wasted |
| **0 repo preserve** | system misconfig을 가리지 않음 | (없음) |

## Out-of-scope
- 옵션 B (heuristic rewrite "cd <inferred> &&") — LLM 의도 추측 위험
- 옵션 C (dummy `.git/`) — git의 raw error semantics 보존이 더 정직
- 옵션 D (prompt instruction 강화) — 별도 PR (config/prompt_overrides.json), 본 PR과 보완

## Verification
- ✅ `bash scripts/dune-local.sh build lib/keeper/` 성공 (exit 0)
- ✅ Filesystem enumeration: `Sys.readdir + Sys.is_directory` (existing OCaml stdlib, no new deps)
- ⚠ Behavior test 미작성 — sandbox launch 통합 테스트 인프라 필요. 1-PR 가성비 낮음. CI on push로 컴파일 검증.

## Reverting
`lib/keeper/keeper_shell_docker.ml`에서 49-line 블록 제거. 단일 파일.

`do-not-merge` label — operator가 fleet 영향 검토 후 머지 결정. 특히 multi-repo keeper(analyst)의 첫 retry 패턴 관찰 필요.

## Test plan
- [ ] CI build green
- [ ] CI test green
- [ ] Operator fleet 영향 검토 (single-repo keeper 회복 + multi-repo keeper retry 패턴)
- [ ] (선택) 옵션 D — prompt instruction 강화 후속 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)