### PR TITLE
chore(keeper-config): drop default_drift_max_chars deprecated alias (0 callers)

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -113,12 +113,6 @@ let default_goal_horizon_max_chars = 480
 let default_drift_max_clauses = 6
 let prompt_render_max_bytes = 320
 
-(* DEPRECATED: name lied — value is bytes (drives utf8_safe_prefix_bytes),
-   not chars. Kept as alias for one release to avoid mass call-site churn;
-   removed in Layer 2 follow-up of personality SSOT unification. *)
-let default_drift_max_chars = prompt_render_max_bytes
-  [@@warning "-32"]
-
 let keeper_room_signal_prompt_enabled_override () =
   bool_of_env_opt "MASC_KEEPER_ROOM_SIGNAL_PROMPT_ENABLED"
 

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -62,9 +62,6 @@ val default_drift_max_clauses : int
     longer values; the cap applies at prompt build time. *)
 val prompt_render_max_bytes : int
 
-val default_drift_max_chars : int
-  [@@deprecated "Use prompt_render_max_bytes. Alias removed in Layer 2 follow-up."]
-
 (** {1 Environment Variable Parsing} *)
 
 (** Parse a boolean env var where the default is [true] when unset. *)


### PR DESCRIPTION
## Context

`lib/keeper/keeper_config.mli` 의 `default_drift_max_chars` 는 deprecation 메시지에 명시적 삭제 의지를 담고 있었습니다:

> "Use prompt_render_max_bytes. Alias removed in Layer 2 follow-up."

`.ml` 본체의 코멘트에도 동일한 약속:

> "DEPRECATED: name lied — value is bytes (drives utf8_safe_prefix_bytes), not chars. Kept as alias for one release ... removed in Layer 2 follow-up of personality SSOT unification."

Layer 2 follow-up이 도래했습니다. 또한 이 alias의 단위 거짓(`*_max_chars`인데 byte)이 메모리 `feedback_unit-name-lie-asymmetric-normalize`(masc-mcp#10479 personality re-sync drift) 사고의 원인 패턴 — alias 자체를 제거해 향후 재발을 차단합니다.

## Caller verification

\`\`\`bash
rg -n 'default_drift_max_chars' lib/ test/ scripts/
# lib/keeper/keeper_config.mli:65:val default_drift_max_chars : int  ← (this PR removes)
# lib/keeper/keeper_config.ml:119:let default_drift_max_chars = prompt_render_max_bytes  ← (this PR removes)
# 0 external callers
\`\`\`

## Diff scope

- `lib/keeper/keeper_config.mli`: -3 lines (`val` + `[@@deprecated]` + 빈 줄)
- `lib/keeper/keeper_config.ml`: -5 lines (3-line DEPRECATED 주석 + binding + 빈 줄)

Total: **9 lines deleted, 2 files**.

## What survives unchanged

`prompt_render_max_bytes` (canonical SSOT, value=320 bytes)은 그대로 유지됩니다. Drift 검증/처분 코드는 모두 이미 `prompt_render_max_bytes` 직접 참조 경로를 쓰고 있으므로 무영향.

## Local verification

\`\`\`
$ rm -rf _build && DUNE_CACHE=disabled dune build --cache=disabled
# (clean, no errors)
\`\`\`

## DNM rationale

Cleanup loop의 두 번째 candidate. 메모리 `feedback_do-not-merge-label-insufficient`에 의해 Draft + `do-not-merge` 라벨로 사용자 명시 검토 대기. #10616(첫 cleanup PR) 처분과 무관하게 독립적으로 평가 가능 — 파일 겹침 0.

## Linked

- Predecessor: #10479 (fix(keeper) personality re-sync loop with symmetric compare) — 본 cleanup의 근본 원인 fix
- Loop plan: `~/me/planning/claude-plans/mossy-chasing-toast.md` (next candidate after Tick #3 #10616)