### PR TITLE
feat(config): add Pr_review_post caller (30s) + migrate gh pr review write site (#10426 follow-up)

### DIFF
--- a/lib/config/env_config_exec_timeout.ml
+++ b/lib/config/env_config_exec_timeout.ml
@@ -19,7 +19,8 @@ type caller =
   | Preflight                 (** keeper_exec_preflight checks (10s) *)
   | Repo_readiness            (** keeper_repo_readiness git status (10s) *)
   | Sandbox                   (** keeper_sandbox_control / keeper_shell_docker probes (2s) *)
-  | Pr_review                 (** keeper_tool_pr_review gh CLI calls (15s) *)
+  | Pr_review                 (** keeper_tool_pr_review gh CLI reads (15s) *)
+  | Pr_review_post            (** keeper_tool_pr_review gh pr review write (30s) *)
   | Dispatch                  (** exec_dispatch routine execution (120s) *)
   | Memory_audit              (** keeper_exec_memory short audits (3s) *)
   | Alerting                  (** keeper_alerting fanout (Slack/webhook POST + gh issue create) (20s) *)
@@ -40,6 +41,7 @@ let caller_key = function
   | Repo_readiness -> "repo_readiness"
   | Sandbox -> "sandbox"
   | Pr_review -> "pr_review"
+  | Pr_review_post -> "pr_review_post"
   | Dispatch -> "dispatch"
   | Memory_audit -> "memory_audit"
   | Alerting -> "alerting"
@@ -58,6 +60,7 @@ let known_callers () =
     Repo_readiness;
     Sandbox;
     Pr_review;
+    Pr_review_post;
     Dispatch;
     Memory_audit;
     Alerting;
@@ -74,6 +77,7 @@ let known_default_sec = function
   | Sandbox | Turn_sandbox -> Some 2.0
   | Pr_review | Turn_up -> Some 15.0
   | Alerting -> Some 20.0
+  | Pr_review_post -> Some 30.0
   | Dispatch -> Some 120.0
   | Memory_audit -> Some 3.0
   | Unknown _ -> None

--- a/lib/config/env_config_exec_timeout.mli
+++ b/lib/config/env_config_exec_timeout.mli
@@ -12,6 +12,12 @@ type caller =
   | Repo_readiness
   | Sandbox
   | Pr_review
+  | Pr_review_post
+      (** [gh pr review --body --event] mutation (post a review with
+          body).  Default 30.0s — server-side processing of the
+          review state machine + notification fanout is materially
+          slower than read ops; the [Pr_review] 15s read budget is
+          too tight here. *)
   | Dispatch
   | Memory_audit
   | Alerting

--- a/lib/keeper/keeper_tool_pr_review.ml
+++ b/lib/keeper/keeper_tool_pr_review.ml
@@ -166,7 +166,8 @@ let handle_keeper_pr_review_comment
         (Filename.quote body)
         (pr_review_event_to_gh_flag event) in
       let st, out =
-        Process_eio.run_argv_with_status ~timeout_sec:30.0
+        Process_eio.run_argv_with_status
+          ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Pr_review_post ())
           [ "/bin/zsh"; "-lc"; cmd ] in
       Log.Keeper.info "pr_review_comment: pr=%d event=%s keeper=%s ok=%b"
         pr_number (pr_review_event_to_string event) meta.name (st = Unix.WEXITED 0);

--- a/test/test_env_config_exec_timeout_10426.ml
+++ b/test/test_env_config_exec_timeout_10426.ml
@@ -26,6 +26,7 @@ let cases =
     E.Repo_readiness, 10.0;
     E.Sandbox, 2.0;
     E.Pr_review, 15.0;
+    E.Pr_review_post, 30.0;
     E.Dispatch, 120.0;
     E.Memory_audit, 3.0;
     E.Alerting, 20.0;


### PR DESCRIPTION
## Why

#10594 deviation #2: `keeper_tool_pr_review.ml:169` uses `~timeout_sec:30.0` for `gh pr review --body --event APPROVE|REQUEST_CHANGES|COMMENT`. This is a write mutation — server-side review state machine + notification fanout is materially slower than the read ops covered by the existing `Pr_review` (15s) caller. Per analysis (#10594), the right shape is a separate caller variant rather than bumping `Pr_review` default.

## What

| Variant | Default | Site | Op |
|---------|---------|------|-----|
| `Pr_review_post` (new) | 30.0s | `keeper_tool_pr_review.ml:169` | `gh pr review --body --event` mutation |

After this PR, operators tune mutation budgets independently from read budgets:
- `MASC_EXEC_TIMEOUT_PR_REVIEW_SEC` — read ops (`gh pr view`, `gh pr diff`, comment reply)
- `MASC_EXEC_TIMEOUT_PR_REVIEW_POST_SEC` — write op (`gh pr review`)

## Diff

```
4 files changed, 14 insertions(+), 2 deletions(-)
 lib/config/env_config_exec_timeout.ml      | 4 +++-
 lib/config/env_config_exec_timeout.mli     | 6 ++++++
 lib/keeper/keeper_tool_pr_review.ml        | 4 ++--
 test/test_env_config_exec_timeout_10426.ml | 1 +
```

## Verification

- `dune build lib/ --root . --cache=disabled` → RC=0.
- `dune exec test/test_env_config_exec_timeout_10426.exe` → 9/9 pass.

## #10594 follow-up status

| PR | Status |
|----|--------|
| #10603 — Git_meta + Shell_probe | Draft |
| #10615 — Alerting bump 15→20 | Draft |
| **this PR** — Pr_review_post 30s | Draft |
| 4th — `keeper_tool_pr_review.ml:218` (5s) leave hardcoded with comment | queued |

---

Refs: #10426 (audit + plan), #10594 (deviation analysis), #10603 (prior follow-up), #10615 (prior follow-up).
