### PR TITLE
feat(design-system): migrate preview/components.css to semantic aliases (PR-M27)

### DIFF
--- a/dashboard/design-system/preview/components.css
+++ b/dashboard/design-system/preview/components.css
@@ -10,7 +10,7 @@
 .cb-dot { display:inline-block; width:7px; height:7px; border-radius:50%; flex:0 0 auto; }
 .cb-dot.sm { width:5px; height:5px; }
 .cb-dot.lg { width:9px; height:9px; }
-.cb-dot.brass   { background: var(--brass-1); box-shadow: 0 0 5px rgb(var(--brass-glow)/.7); }
+.cb-dot.brass   { background: var(--color-accent-fg); box-shadow: 0 0 5px rgb(var(--color-accent-glow)/.7); }
 .cb-dot.ok      { background: var(--ok); }
 .cb-dot.warn    { background: var(--warn); }
 .cb-dot.err     { background: var(--err); }
@@ -20,36 +20,36 @@
 .cb-dot.beat { animation: anim-heartbeat 1.4s var(--ease-inout) infinite; }
 
 /* caption label */
-.cb-caps { font: var(--type-label); color: var(--fg-3); text-transform: uppercase; letter-spacing: .08em; font-weight: 600; }
+.cb-caps { font: var(--type-label); color: var(--color-fg-muted); text-transform: uppercase; letter-spacing: .08em; font-weight: 600; }
 .cb-mono { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
-.cb-mute { color: var(--fg-3); }
+.cb-mute { color: var(--color-fg-muted); }
 
 /* tiny section header inside an artboard (shows the variant name) */
 .cb-vhead {
   position:absolute; top:-22px; left:0;
-  font: var(--type-micro); color: var(--fg-3);
+  font: var(--type-micro); color: var(--color-fg-muted);
   text-transform: uppercase; letter-spacing:.08em;
 }
 
 /* ───── Topbar ───── */
-.cb-topbar { display:flex; align-items:center; height:36px; padding:0 12px; gap:12px; background: var(--bg-1); border-bottom:1px solid var(--line-2); flex-shrink:0; }
+.cb-topbar { display:flex; align-items:center; height:36px; padding:0 12px; gap:12px; background: var(--color-bg-surface); border-bottom:1px solid var(--color-border-strong); flex-shrink:0; }
 .cb-topbar .brand { display:flex; align-items:center; gap:8px; }
-.cb-topbar .brand-mark { width:16px; height:16px; border-radius:2px; background: linear-gradient(135deg, var(--brass-1), var(--brass-3)); box-shadow: 0 0 6px rgb(var(--brass-glow)/.4) inset, 0 0 4px rgb(var(--brass-glow)/.5); }
-.cb-topbar .brand-name { font-family: var(--font-mono); font-size: var(--fs-13); font-weight:600; color: var(--fg-1); letter-spacing: .04em; }
-.cb-topbar .ver { font: var(--type-micro); color: var(--fg-4); letter-spacing:.06em; margin-left:-4px; }
-.cb-topbar .sep { width:1px; height:18px; background: var(--line-2); }
-.cb-topbar .goal-switch { display:flex; align-items:center; gap:6px; padding:3px 8px; height:22px; background: var(--bg-2); border:1px solid var(--line-1); border-radius: var(--r-1); font-family: var(--font-mono); font-size: var(--fs-11); color: var(--fg-2); cursor:pointer; }
-.cb-topbar .goal-switch:hover { background: var(--bg-3); border-color: var(--line-2); color: var(--fg-1); }
-.cb-topbar .goal-switch .caret { color: var(--fg-4); margin-left:2px; }
-.cb-topbar .mode-tabs { display:flex; background: var(--bg-2); border:1px solid var(--line-1); border-radius: var(--r-1); padding:2px; gap:2px; }
-.cb-topbar .mode-tabs button { height:18px; padding:0 10px; font: var(--type-caption); text-transform: uppercase; letter-spacing: .08em; color: var(--fg-3); background: transparent; border:0; border-radius: 2px; cursor:pointer; font-weight:600; }
-.cb-topbar .mode-tabs button:hover { color: var(--fg-1); }
-.cb-topbar .mode-tabs button.on { color: var(--bg-0); background: var(--brass-2); }
+.cb-topbar .brand-mark { width:16px; height:16px; border-radius:2px; background: linear-gradient(135deg, var(--color-accent-fg), var(--color-accent-fg-dim)); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.4) inset, 0 0 4px rgb(var(--color-accent-glow)/.5); }
+.cb-topbar .brand-name { font-family: var(--font-mono); font-size: var(--fs-13); font-weight:600; color: var(--color-fg-primary); letter-spacing: .04em; }
+.cb-topbar .ver { font: var(--type-micro); color: var(--color-fg-disabled); letter-spacing:.06em; margin-left:-4px; }
+.cb-topbar .sep { width:1px; height:18px; background: var(--color-border-strong); }
+.cb-topbar .goal-switch { display:flex; align-items:center; gap:6px; padding:3px 8px; height:22px; background: var(--color-bg-panel-alt); border:1px solid var(--color-border-default); border-radius: var(--r-1); font-family: var(--font-mono); font-size: var(--fs-11); color: var(--color-fg-secondary); cursor:pointer; }
+.cb-topbar .goal-switch:hover { background: var(--color-bg-elevated); border-color: var(--color-border-strong); color: var(--color-fg-primary); }
+.cb-topbar .goal-switch .caret { color: var(--color-fg-disabled); margin-left:2px; }
+.cb-topbar .mode-tabs { display:flex; background: var(--color-bg-panel-alt); border:1px solid var(--color-border-default); border-radius: var(--r-1); padding:2px; gap:2px; }
+.cb-topbar .mode-tabs button { height:18px; padding:0 10px; font: var(--type-caption); text-transform: uppercase; letter-spacing: .08em; color: var(--color-fg-muted); background: transparent; border:0; border-radius: 2px; cursor:pointer; font-weight:600; }
+.cb-topbar .mode-tabs button:hover { color: var(--color-fg-primary); }
+.cb-topbar .mode-tabs button.on { color: var(--color-bg-page); background: var(--brass-2); }
 .cb-topbar .right { margin-left:auto; display:flex; align-items:center; gap:10px; }
-.cb-topbar .density { display:flex; background: var(--bg-2); border:1px solid var(--line-1); border-radius: var(--r-1); }
-.cb-topbar .density button { width:22px; height:20px; border:0; background:transparent; color: var(--fg-3); font-family: var(--font-mono); font-size: var(--fs-11); cursor:pointer; }
-.cb-topbar .density button.on { color: var(--brass-1); background: rgb(var(--brass-glow)/.1); }
-.cb-topbar .stamp { font: var(--type-micro); color: var(--fg-4); letter-spacing: .06em; }
+.cb-topbar .density { display:flex; background: var(--color-bg-panel-alt); border:1px solid var(--color-border-default); border-radius: var(--r-1); }
+.cb-topbar .density button { width:22px; height:20px; border:0; background:transparent; color: var(--color-fg-muted); font-family: var(--font-mono); font-size: var(--fs-11); cursor:pointer; }
+.cb-topbar .density button.on { color: var(--color-accent-fg); background: rgb(var(--color-accent-glow)/.1); }
+.cb-topbar .stamp { font: var(--type-micro); color: var(--color-fg-disabled); letter-spacing: .06em; }
 
 /* minimal topbar variant */
 .cb-topbar.minimal .brand-name { font-size: var(--fs-11); }
@@ -57,30 +57,30 @@
 .cb-topbar.minimal .goal-switch, .cb-topbar.minimal .density { display:none; }
 
 /* expanded topbar (with branch + avatars) */
-.cb-topbar .branch { display:flex; align-items:center; gap:4px; font-family: var(--font-mono); font-size: var(--fs-11); color: var(--fg-3); }
-.cb-topbar .branch::before { content: "⎇"; color: var(--fg-4); }
+.cb-topbar .branch { display:flex; align-items:center; gap:4px; font-family: var(--font-mono); font-size: var(--fs-11); color: var(--color-fg-muted); }
+.cb-topbar .branch::before { content: "⎇"; color: var(--color-fg-disabled); }
 .cb-topbar .avatars { display:flex; }
-.cb-topbar .avatars .av { width:18px; height:18px; border-radius:50%; border:2px solid var(--bg-1); margin-left:-6px; }
+.cb-topbar .avatars .av { width:18px; height:18px; border-radius:50%; border:2px solid var(--color-bg-surface); margin-left:-6px; }
 .cb-topbar .avatars .av:first-child { margin-left:0; }
 
 /* ───── Ticker ───── */
-.cb-ticker { height:28px; display:flex; align-items:center; background: linear-gradient(to bottom, var(--bg-1), var(--bg-0)); border-bottom:1px solid var(--line-1); font-family: var(--font-mono); font-size: var(--fs-11); overflow:hidden; position:relative; flex-shrink:0; }
+.cb-ticker { height:28px; display:flex; align-items:center; background: linear-gradient(to bottom, var(--color-bg-surface), var(--color-bg-page)); border-bottom:1px solid var(--color-border-default); font-family: var(--font-mono); font-size: var(--fs-11); overflow:hidden; position:relative; flex-shrink:0; }
 .cb-ticker .tape { display:flex; align-items:center; gap:24px; white-space:nowrap; animation: cb-tape 40s linear infinite; padding-left:12px; }
 @keyframes cb-tape { to { transform: translateX(-50%); } }
-.cb-ticker .evt { display:flex; align-items:center; gap:6px; color: var(--fg-2); }
-.cb-ticker .evt .k { color: var(--fg-3); }
-.cb-ticker .evt .t { color: var(--fg-4); font-size: var(--fs-10); }
+.cb-ticker .evt { display:flex; align-items:center; gap:6px; color: var(--color-fg-secondary); }
+.cb-ticker .evt .k { color: var(--color-fg-muted); }
+.cb-ticker .evt .t { color: var(--color-fg-disabled); font-size: var(--fs-10); }
 .cb-ticker .evt.err .body { color: var(--err-fg); }
 .cb-ticker .evt.flag .body { color: var(--err-fg); }
-.cb-ticker .evt.tool .body { color: var(--fg-1); }
-.cb-ticker .evt.claim .body { color: var(--brass-1); }
+.cb-ticker .evt.tool .body { color: var(--color-fg-primary); }
+.cb-ticker .evt.claim .body { color: var(--color-accent-fg); }
 .cb-ticker::before, .cb-ticker::after { content:""; position:absolute; top:0; bottom:0; width:40px; pointer-events:none; z-index:2; }
-.cb-ticker::before { left:0; background: linear-gradient(to right, var(--bg-1), transparent); }
-.cb-ticker::after  { right:0; background: linear-gradient(to left, var(--bg-1), transparent); }
+.cb-ticker::before { left:0; background: linear-gradient(to right, var(--color-bg-surface), transparent); }
+.cb-ticker::after  { right:0; background: linear-gradient(to left, var(--color-bg-surface), transparent); }
 
 /* chunked ticker */
 .cb-ticker.chunks .tape { gap:0; }
-.cb-ticker.chunks .evt { padding:0 12px; border-right:1px solid var(--line-1); }
+.cb-ticker.chunks .evt { padding:0 12px; border-right:1px solid var(--color-border-default); }
 
 /* vertical ticker */
 .cb-ticker.vertical { flex-direction:column; height: 88px; overflow: hidden; }
@@ -88,18 +88,18 @@
 @keyframes cb-tape-v { to { transform: translateY(-50%); } }
 
 /* ───── KPI Strip ───── */
-.cb-kpi { display:grid; grid-template-columns: repeat(6, 1fr); gap:1px; background: var(--line-1); border-bottom:1px solid var(--line-2); flex-shrink:0; }
-.cb-kpi .cell { background: var(--bg-1); padding: 8px 10px; display:flex; flex-direction:column; gap:3px; position:relative; min-height:52px; }
-.cb-kpi .cell .lbl { font: var(--type-label); text-transform: uppercase; color: var(--fg-3); letter-spacing: .08em; font-weight:600; display:flex; align-items:center; gap:4px; }
-.cb-kpi .cell .val { font: var(--type-kpi-m); color: var(--fg-1); font-family: var(--font-mono); }
+.cb-kpi { display:grid; grid-template-columns: repeat(6, 1fr); gap:1px; background: var(--color-border-default); border-bottom:1px solid var(--color-border-strong); flex-shrink:0; }
+.cb-kpi .cell { background: var(--color-bg-surface); padding: 8px 10px; display:flex; flex-direction:column; gap:3px; position:relative; min-height:52px; }
+.cb-kpi .cell .lbl { font: var(--type-label); text-transform: uppercase; color: var(--color-fg-muted); letter-spacing: .08em; font-weight:600; display:flex; align-items:center; gap:4px; }
+.cb-kpi .cell .val { font: var(--type-kpi-m); color: var(--color-fg-primary); font-family: var(--font-mono); }
 .cb-kpi .cell .val.big { font: var(--type-kpi-l); }
-.cb-kpi .cell .cap { font: var(--type-micro); color: var(--fg-4); }
-.cb-kpi .cell.live { background: rgb(var(--brass-glow)/.06); animation: anim-pulse-glow 2.4s var(--ease-inout) infinite; }
-.cb-kpi .cell.live .val { color: var(--brass-1); }
+.cb-kpi .cell .cap { font: var(--type-micro); color: var(--color-fg-disabled); }
+.cb-kpi .cell.live { background: rgb(var(--color-accent-glow)/.06); animation: anim-pulse-glow 2.4s var(--ease-inout) infinite; }
+.cb-kpi .cell.live .val { color: var(--color-accent-fg); }
 .cb-kpi .cell .spark { margin-top:auto; }
 .cb-kpi .cell.is-err .val { color: var(--err-fg); }
 .cb-kpi .cell.is-ok  .val { color: var(--ok-fg); }
-.cb-kpi .cell .delta { font: var(--type-micro); color: var(--fg-3); }
+.cb-kpi .cell .delta { font: var(--type-micro); color: var(--color-fg-muted); }
 .cb-kpi .cell .delta.pos { color: var(--ok-fg); }
 .cb-kpi .cell .delta.neg { color: var(--err-fg); }
 
@@ -112,56 +112,56 @@
 .cb-kpi.stacked .cell { min-height:44px; padding: 6px 10px; }
 
 /* ───── Lifeline ───── */
-.cb-lifeline { height:48px; display:flex; align-items:center; padding:0 12px; gap:12px; background: var(--bg-1); border-bottom:1px solid var(--line-1); flex-shrink:0; }
-.cb-lifeline .label { font: var(--type-label); text-transform:uppercase; color: var(--fg-3); letter-spacing:.08em; font-weight:600; }
+.cb-lifeline { height:48px; display:flex; align-items:center; padding:0 12px; gap:12px; background: var(--color-bg-surface); border-bottom:1px solid var(--color-border-default); flex-shrink:0; }
+.cb-lifeline .label { font: var(--type-label); text-transform:uppercase; color: var(--color-fg-muted); letter-spacing:.08em; font-weight:600; }
 .cb-lifeline svg { flex:1; height:32px; }
-.cb-lifeline .bpm { font-family: var(--font-mono); font-size: var(--fs-11); color: var(--fg-2); }
-.cb-lifeline .bpm .n { color: var(--brass-1); font-weight:600; }
+.cb-lifeline .bpm { font-family: var(--font-mono); font-size: var(--fs-11); color: var(--color-fg-secondary); }
+.cb-lifeline .bpm .n { color: var(--color-accent-fg); font-weight:600; }
 
 /* stacked lifeline — 5 micro lines */
 .cb-lifeline.stack { flex-direction:column; align-items:stretch; height:auto; padding: 8px 12px; gap:4px; }
 .cb-lifeline.stack .row { display:flex; align-items:center; gap:8px; height:14px; }
-.cb-lifeline.stack .row .name { width:80px; font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-3); }
+.cb-lifeline.stack .row .name { width:80px; font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-fg-muted); }
 .cb-lifeline.stack .row svg { flex:1; height:14px; }
 
 /* ───── Sidebar ───── */
-.cb-sidebar { width:100%; background: var(--bg-1); display:flex; flex-direction:column; font-size: var(--fs-12); height:100%; }
-.cb-sidebar .sec { border-bottom:1px solid var(--line-1); }
-.cb-sidebar .sec-h { display:flex; align-items:center; height:28px; padding: 0 10px; border-bottom:1px solid var(--line-1); background: var(--bg-1); font: var(--type-label); text-transform: uppercase; color: var(--fg-3); letter-spacing:.08em; font-weight:600; }
-.cb-sidebar .sec-h .count { margin-left:auto; font-family: var(--font-mono); color: var(--fg-4); font-weight:500; }
+.cb-sidebar { width:100%; background: var(--color-bg-surface); display:flex; flex-direction:column; font-size: var(--fs-12); height:100%; }
+.cb-sidebar .sec { border-bottom:1px solid var(--color-border-default); }
+.cb-sidebar .sec-h { display:flex; align-items:center; height:28px; padding: 0 10px; border-bottom:1px solid var(--color-border-default); background: var(--color-bg-surface); font: var(--type-label); text-transform: uppercase; color: var(--color-fg-muted); letter-spacing:.08em; font-weight:600; }
+.cb-sidebar .sec-h .count { margin-left:auto; font-family: var(--font-mono); color: var(--color-fg-disabled); font-weight:500; }
 .cb-sidebar .row { display:flex; align-items:center; gap:7px; padding: 0 10px; height:22px; cursor:pointer; position:relative; font-family: var(--font-mono); font-size: var(--fs-11); }
-.cb-sidebar .row:hover { background: var(--bg-2); }
-.cb-sidebar .row.sel { background: var(--bg-3); color: var(--fg-1); }
-.cb-sidebar .row.sel::before { content:""; position:absolute; left:0; top:0; bottom:0; width:2px; background: var(--brass-1); }
-.cb-sidebar .row .name { color: var(--fg-1); }
-.cb-sidebar .row .meta { margin-left:auto; color: var(--fg-4); font-size: var(--fs-10); }
-.cb-sidebar .row.idle .name { color: var(--fg-3); }
+.cb-sidebar .row:hover { background: var(--color-bg-panel-alt); }
+.cb-sidebar .row.sel { background: var(--color-bg-elevated); color: var(--color-fg-primary); }
+.cb-sidebar .row.sel::before { content:""; position:absolute; left:0; top:0; bottom:0; width:2px; background: var(--color-accent-fg); }
+.cb-sidebar .row .name { color: var(--color-fg-primary); }
+.cb-sidebar .row .meta { margin-left:auto; color: var(--color-fg-disabled); font-size: var(--fs-10); }
+.cb-sidebar .row.idle .name { color: var(--color-fg-muted); }
 .cb-sidebar .goal-row { flex-direction:column; align-items:stretch; height:auto; padding: 6px 10px; gap:3px; font-family: var(--font-sans); font-size: var(--fs-12); }
-.cb-sidebar .goal-row .title { color: var(--fg-1); font-size: var(--fs-12); }
-.cb-sidebar .goal-row .id { font-family: var(--font-mono); color: var(--fg-4); font-size: var(--fs-10); }
-.cb-sidebar .goal-row .meta-row { display:flex; align-items:center; gap:6px; font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-3); }
+.cb-sidebar .goal-row .title { color: var(--color-fg-primary); font-size: var(--fs-12); }
+.cb-sidebar .goal-row .id { font-family: var(--font-mono); color: var(--color-fg-disabled); font-size: var(--fs-10); }
+.cb-sidebar .goal-row .meta-row { display:flex; align-items:center; gap:6px; font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-fg-muted); }
 
 /* iconified sidebar variant */
 .cb-sidebar.icons .row { padding-left: 26px; position:relative; }
-.cb-sidebar.icons .row .icon { position:absolute; left:10px; top:50%; transform: translateY(-50%); font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-4); }
+.cb-sidebar.icons .row .icon { position:absolute; left:10px; top:50%; transform: translateY(-50%); font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-fg-disabled); }
 
 /* ───── Swimlanes ───── */
-.cb-swim { position:relative; background: var(--bg-0); padding: 12px; overflow: hidden; height:100%; }
-.cb-swim .axis { position:absolute; top: 12px; left: 130px; right: 12px; height: 16px; border-bottom: 1px solid var(--line-1); display:flex; justify-content:space-between; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-4); }
+.cb-swim { position:relative; background: var(--color-bg-page); padding: 12px; overflow: hidden; height:100%; }
+.cb-swim .axis { position:absolute; top: 12px; left: 130px; right: 12px; height: 16px; border-bottom: 1px solid var(--color-border-default); display:flex; justify-content:space-between; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); }
 .cb-swim .axis span { padding: 0 2px; }
-.cb-swim .lane { display:flex; align-items:center; height: 32px; position: relative; border-bottom: 1px solid var(--line-1); }
+.cb-swim .lane { display:flex; align-items:center; height: 32px; position: relative; border-bottom: 1px solid var(--color-border-default); }
 .cb-swim .lane-head { width: 118px; display:flex; align-items:center; gap:7px; padding-right: 12px; flex-shrink:0; }
-.cb-swim .lane-head .name { font-family: var(--font-mono); font-size: var(--fs-11); color: var(--fg-2); }
+.cb-swim .lane-head .name { font-family: var(--font-mono); font-size: var(--fs-11); color: var(--color-fg-secondary); }
 .cb-swim .lane-track { position: relative; flex:1; height: 100%; }
-.cb-swim .lane.sel { background: var(--bg-2); }
-.cb-swim .lane.sel .lane-head .name { color: var(--fg-1); }
-.cb-swim .lane.sel::before { content:""; position:absolute; left:0; top:0; bottom:0; width:2px; background: var(--brass-1); }
-.cb-swim .now { position:absolute; top:28px; bottom: 4px; width:2px; background: linear-gradient(to bottom, transparent, rgb(var(--brass-glow)/.7) 20%, rgb(var(--brass-glow)/.7) 80%, transparent); box-shadow: 0 0 8px 1px rgb(var(--brass-glow)/.4); pointer-events:none; }
-.cb-swim .now .head { position:absolute; top:-14px; left:-10px; width:22px; text-align:center; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--brass-1); letter-spacing: .06em; }
+.cb-swim .lane.sel { background: var(--color-bg-panel-alt); }
+.cb-swim .lane.sel .lane-head .name { color: var(--color-fg-primary); }
+.cb-swim .lane.sel::before { content:""; position:absolute; left:0; top:0; bottom:0; width:2px; background: var(--color-accent-fg); }
+.cb-swim .now { position:absolute; top:28px; bottom: 4px; width:2px; background: linear-gradient(to bottom, transparent, rgb(var(--color-accent-glow)/.7) 20%, rgb(var(--color-accent-glow)/.7) 80%, transparent); box-shadow: 0 0 8px 1px rgb(var(--color-accent-glow)/.4); pointer-events:none; }
+.cb-swim .now .head { position:absolute; top:-14px; left:-10px; width:22px; text-align:center; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-accent-fg); letter-spacing: .06em; }
 .cb-swim .ev { position:absolute; top:50%; transform: translate(-50%, -50%); }
-.cb-swim .ev-tool  { width:10px; height:4px; background: var(--fg-2); border-radius:1px; }
+.cb-swim .ev-tool  { width:10px; height:4px; background: var(--color-fg-secondary); border-radius:1px; }
 .cb-swim .ev-claim { width:8px; height:8px; background: var(--brass-2); transform: translate(-50%,-50%) rotate(45deg); border-radius:1px; }
-.cb-swim .ev-text  { width:7px; height:1px; background: var(--fg-3); }
+.cb-swim .ev-text  { width:7px; height:1px; background: var(--color-fg-muted); }
 .cb-swim .ev-flag  { width:7px; height:7px; background: var(--err); border-radius:50%; transform: translate(-50%,-50%); }
 .cb-swim .ev-err   { width:8px; height:8px; transform: translate(-50%,-50%); background: var(--err); clip-path: polygon(20% 0, 50% 35%, 80% 0, 100% 20%, 65% 50%, 100% 80%, 80% 100%, 50% 65%, 20% 100%, 0 80%, 35% 50%, 0 20%); }
 .cb-swim .lanes-body { margin-top: 18px; position:relative; }
@@ -171,139 +171,139 @@
 
 /* density variant: aggregate bars instead of glyphs */
 .cb-swim.bars .ev { display:none; }
-.cb-swim.bars .lane-track .agg { position:absolute; top:50%; transform: translateY(-50%); height:10px; background: linear-gradient(90deg, rgb(var(--brass-glow)/.05), rgb(var(--brass-glow)/.35)); border-radius:2px; }
+.cb-swim.bars .lane-track .agg { position:absolute; top:50%; transform: translateY(-50%); height:10px; background: linear-gradient(90deg, rgb(var(--color-accent-glow)/.05), rgb(var(--color-accent-glow)/.35)); border-radius:2px; }
 
 /* ───── Deck (tabbed center) ───── */
-.cb-deck { display:flex; flex-direction:column; height:100%; background: var(--bg-1); }
-.cb-deck .tabs { display:flex; align-items:center; height:30px; border-bottom:1px solid var(--line-2); padding: 0 6px; gap:2px; background: var(--bg-1); flex-shrink:0; }
-.cb-deck .tab { height:30px; padding: 0 12px; display:inline-flex; align-items:center; gap:6px; border:0; background:transparent; color: var(--fg-3); font: var(--type-label); text-transform: uppercase; letter-spacing: .08em; font-weight:600; cursor:pointer; position:relative; }
-.cb-deck .tab:hover { color: var(--fg-1); }
-.cb-deck .tab.on { color: var(--fg-1); }
-.cb-deck .tab.on::after { content:""; position:absolute; left:8px; right:8px; bottom:-1px; height:2px; background: var(--brass-1); box-shadow: 0 -2px 6px rgb(var(--brass-glow)/.3); }
-.cb-deck .tab .badge { background: var(--bg-3); border:1px solid var(--line-1); border-radius: 999px; padding: 0 5px; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-2); letter-spacing: 0; text-transform: none; font-weight: 500; height: 14px; display:inline-flex; align-items:center; }
-.cb-deck .tab.on .badge { border-color: var(--brass-3); color: var(--brass-1); }
+.cb-deck { display:flex; flex-direction:column; height:100%; background: var(--color-bg-surface); }
+.cb-deck .tabs { display:flex; align-items:center; height:30px; border-bottom:1px solid var(--color-border-strong); padding: 0 6px; gap:2px; background: var(--color-bg-surface); flex-shrink:0; }
+.cb-deck .tab { height:30px; padding: 0 12px; display:inline-flex; align-items:center; gap:6px; border:0; background:transparent; color: var(--color-fg-muted); font: var(--type-label); text-transform: uppercase; letter-spacing: .08em; font-weight:600; cursor:pointer; position:relative; }
+.cb-deck .tab:hover { color: var(--color-fg-primary); }
+.cb-deck .tab.on { color: var(--color-fg-primary); }
+.cb-deck .tab.on::after { content:""; position:absolute; left:8px; right:8px; bottom:-1px; height:2px; background: var(--color-accent-fg); box-shadow: 0 -2px 6px rgb(var(--color-accent-glow)/.3); }
+.cb-deck .tab .badge { background: var(--color-bg-elevated); border:1px solid var(--color-border-default); border-radius: 999px; padding: 0 5px; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-secondary); letter-spacing: 0; text-transform: none; font-weight: 500; height: 14px; display:inline-flex; align-items:center; }
+.cb-deck .tab.on .badge { border-color: var(--color-accent-fg-dim); color: var(--color-accent-fg); }
 .cb-deck .body { flex:1; overflow:auto; padding: 12px; font-size: var(--fs-12); }
 
 /* deck table rows */
 .cb-deck table { width:100%; border-collapse: collapse; font-size: var(--fs-12); font-family: var(--font-sans); }
-.cb-deck th { text-align:left; font: var(--type-label); text-transform: uppercase; color: var(--fg-3); letter-spacing: .08em; font-weight:600; padding: 4px 8px; border-bottom: 1px solid var(--line-2); position:sticky; top:0; background: var(--bg-1); }
-.cb-deck td { padding: 5px 8px; border-bottom:1px solid var(--line-1); color: var(--fg-2); font-family: var(--font-mono); font-size: var(--fs-11); vertical-align: middle; }
-.cb-deck td.title { color: var(--fg-1); font-family: var(--font-sans); font-size: var(--fs-12); }
-.cb-deck tr:hover td { background: var(--bg-2); }
-.cb-deck tr.sel td { background: var(--bg-3); color: var(--fg-1); }
+.cb-deck th { text-align:left; font: var(--type-label); text-transform: uppercase; color: var(--color-fg-muted); letter-spacing: .08em; font-weight:600; padding: 4px 8px; border-bottom: 1px solid var(--color-border-strong); position:sticky; top:0; background: var(--color-bg-surface); }
+.cb-deck td { padding: 5px 8px; border-bottom:1px solid var(--color-border-default); color: var(--color-fg-secondary); font-family: var(--font-mono); font-size: var(--fs-11); vertical-align: middle; }
+.cb-deck td.title { color: var(--color-fg-primary); font-family: var(--font-sans); font-size: var(--fs-12); }
+.cb-deck tr:hover td { background: var(--color-bg-panel-alt); }
+.cb-deck tr.sel td { background: var(--color-bg-elevated); color: var(--color-fg-primary); }
 
 /* vertical tabs variant */
 .cb-deck.vertical { flex-direction:row; }
-.cb-deck.vertical .tabs { flex-direction:column; width:100px; height:100%; border-right:1px solid var(--line-2); border-bottom:0; padding: 6px 0; }
+.cb-deck.vertical .tabs { flex-direction:column; width:100px; height:100%; border-right:1px solid var(--color-border-strong); border-bottom:0; padding: 6px 0; }
 .cb-deck.vertical .tab { width: 100%; justify-content: flex-start; height: 26px; padding: 0 10px; }
 .cb-deck.vertical .tab.on::after { left:0; top:4px; bottom:4px; width: 2px; height:auto; right:auto; }
 
 /* kanban deck */
 .cb-kanban { display:grid; grid-template-columns: repeat(4, 1fr); gap: 8px; height:100%; padding:12px; overflow:auto; }
-.cb-kanban .col { background: var(--bg-1); border:1px solid var(--line-1); border-radius: var(--r-1); padding: 6px; display:flex; flex-direction:column; gap:6px; }
-.cb-kanban .col-h { font: var(--type-label); text-transform:uppercase; color: var(--fg-3); letter-spacing:.08em; font-weight:600; display:flex; align-items:center; gap:6px; padding: 2px 4px; }
-.cb-kanban .col-h .ct { margin-left:auto; font-family: var(--font-mono); color: var(--fg-4); font-size: var(--fs-10); font-weight:500; }
-.cb-kanban .card { background: var(--bg-2); border:1px solid var(--line-1); border-radius: var(--r-1); padding: 6px 7px; font-size: var(--fs-11); display:flex; flex-direction:column; gap:3px; cursor:pointer; }
-.cb-kanban .card:hover { background: var(--bg-3); }
-.cb-kanban .card .id { font-family: var(--font-mono); color: var(--fg-4); font-size: var(--fs-9); letter-spacing: .04em; }
-.cb-kanban .card .title { color: var(--fg-1); font-size: var(--fs-11); line-height:1.3; }
-.cb-kanban .card .foot { display:flex; align-items:center; gap:6px; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-3); margin-top:2px; }
-.cb-kanban .card.running { border-color: var(--brass-3); box-shadow: 0 0 0 1px rgb(var(--brass-glow)/.2), inset 2px 0 0 var(--brass-1); }
+.cb-kanban .col { background: var(--color-bg-surface); border:1px solid var(--color-border-default); border-radius: var(--r-1); padding: 6px; display:flex; flex-direction:column; gap:6px; }
+.cb-kanban .col-h { font: var(--type-label); text-transform:uppercase; color: var(--color-fg-muted); letter-spacing:.08em; font-weight:600; display:flex; align-items:center; gap:6px; padding: 2px 4px; }
+.cb-kanban .col-h .ct { margin-left:auto; font-family: var(--font-mono); color: var(--color-fg-disabled); font-size: var(--fs-10); font-weight:500; }
+.cb-kanban .card { background: var(--color-bg-panel-alt); border:1px solid var(--color-border-default); border-radius: var(--r-1); padding: 6px 7px; font-size: var(--fs-11); display:flex; flex-direction:column; gap:3px; cursor:pointer; }
+.cb-kanban .card:hover { background: var(--color-bg-elevated); }
+.cb-kanban .card .id { font-family: var(--font-mono); color: var(--color-fg-disabled); font-size: var(--fs-9); letter-spacing: .04em; }
+.cb-kanban .card .title { color: var(--color-fg-primary); font-size: var(--fs-11); line-height:1.3; }
+.cb-kanban .card .foot { display:flex; align-items:center; gap:6px; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-muted); margin-top:2px; }
+.cb-kanban .card.running { border-color: var(--color-accent-fg-dim); box-shadow: 0 0 0 1px rgb(var(--color-accent-glow)/.2), inset 2px 0 0 var(--color-accent-fg); }
 .cb-kanban .card.fail { border-color: var(--err-border); }
 
 /* provider matrix variant */
 .cb-pmatrix { padding: 12px; font-size: var(--fs-12); }
-.cb-pmatrix .row { display:grid; grid-template-columns: 100px 140px 60px 60px 1fr 60px; gap: 10px; align-items:center; height: 28px; border-bottom:1px solid var(--line-1); font-family: var(--font-mono); font-size: var(--fs-11); }
-.cb-pmatrix .row.h { color: var(--fg-3); font: var(--type-label); text-transform: uppercase; letter-spacing: .08em; font-weight:600; font-family: var(--font-sans); }
-.cb-pmatrix .row .pname { color: var(--fg-1); }
-.cb-pmatrix .row .model { color: var(--fg-2); }
-.cb-pmatrix .row .tps { color: var(--fg-1); text-align:right; }
-.cb-pmatrix .row .cas { color: var(--fg-4); text-align:right; }
+.cb-pmatrix .row { display:grid; grid-template-columns: 100px 140px 60px 60px 1fr 60px; gap: 10px; align-items:center; height: 28px; border-bottom:1px solid var(--color-border-default); font-family: var(--font-mono); font-size: var(--fs-11); }
+.cb-pmatrix .row.h { color: var(--color-fg-muted); font: var(--type-label); text-transform: uppercase; letter-spacing: .08em; font-weight:600; font-family: var(--font-sans); }
+.cb-pmatrix .row .pname { color: var(--color-fg-primary); }
+.cb-pmatrix .row .model { color: var(--color-fg-secondary); }
+.cb-pmatrix .row .tps { color: var(--color-fg-primary); text-align:right; }
+.cb-pmatrix .row .cas { color: var(--color-fg-disabled); text-align:right; }
 
 /* ───── Rail (activity feed + cascade) ───── */
-.cb-rail { width:100%; height:100%; background: var(--bg-1); display:flex; flex-direction:column; border-left: 1px solid var(--line-1); font-size: var(--fs-12); }
-.cb-rail .sec { border-bottom: 1px solid var(--line-2); }
-.cb-rail .sec-h { display:flex; align-items:center; height:26px; padding: 0 10px; font: var(--type-label); text-transform: uppercase; color: var(--fg-3); letter-spacing:.08em; font-weight:600; background: var(--bg-1); border-bottom:1px solid var(--line-1); }
-.cb-rail .sec-h .right { margin-left:auto; font-family: var(--font-mono); color: var(--fg-4); font-weight:500; font-size: var(--fs-10); }
+.cb-rail { width:100%; height:100%; background: var(--color-bg-surface); display:flex; flex-direction:column; border-left: 1px solid var(--color-border-default); font-size: var(--fs-12); }
+.cb-rail .sec { border-bottom: 1px solid var(--color-border-strong); }
+.cb-rail .sec-h { display:flex; align-items:center; height:26px; padding: 0 10px; font: var(--type-label); text-transform: uppercase; color: var(--color-fg-muted); letter-spacing:.08em; font-weight:600; background: var(--color-bg-surface); border-bottom:1px solid var(--color-border-default); }
+.cb-rail .sec-h .right { margin-left:auto; font-family: var(--font-mono); color: var(--color-fg-disabled); font-weight:500; font-size: var(--fs-10); }
 .cb-rail .body { padding: 6px 0; max-height: 100%; overflow:auto; }
 .cb-rail .ev { display:grid; grid-template-columns: 54px 14px 1fr; gap: 6px; padding: 4px 10px; align-items:flex-start; font-size: var(--fs-11); cursor:pointer; }
-.cb-rail .ev:hover { background: var(--bg-2); }
-.cb-rail .ev .t { font-family: var(--font-mono); color: var(--fg-4); font-size: var(--fs-10); padding-top:2px; }
+.cb-rail .ev:hover { background: var(--color-bg-panel-alt); }
+.cb-rail .ev .t { font-family: var(--font-mono); color: var(--color-fg-disabled); font-size: var(--fs-10); padding-top:2px; }
 .cb-rail .ev .icon { display:flex; align-items:flex-start; padding-top:4px; }
 .cb-rail .ev .body { padding: 0; }
-.cb-rail .ev .who { font-family: var(--font-mono); color: var(--fg-2); font-size: var(--fs-10); margin-right:4px; }
-.cb-rail .ev .text { color: var(--fg-1); font-size: var(--fs-11); line-height: 1.35; }
+.cb-rail .ev .who { font-family: var(--font-mono); color: var(--color-fg-secondary); font-size: var(--fs-10); margin-right:4px; }
+.cb-rail .ev .text { color: var(--color-fg-primary); font-size: var(--fs-11); line-height: 1.35; }
 .cb-rail .ev.err .text { color: var(--err-fg); }
 .cb-rail .ev.flag .text { color: var(--err-fg); }
-.cb-rail .ev.claim .text { color: var(--brass-1); }
+.cb-rail .ev.claim .text { color: var(--color-accent-fg); }
 
 /* cascade trace */
 .cb-cascade { padding: 10px; display:flex; flex-direction:column; gap: 8px; }
-.cb-cascade .id { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-4); letter-spacing: .04em; }
-.cb-cascade .step { display:grid; grid-template-columns: 14px 1fr auto; gap: 8px; align-items:center; height: 22px; font-family: var(--font-mono); font-size: var(--fs-11); border-bottom: 1px dashed var(--line-1); }
-.cb-cascade .step .ix { color: var(--fg-4); text-align:center; }
-.cb-cascade .step .name { color: var(--fg-1); }
-.cb-cascade .step .ms { color: var(--fg-3); font-size: var(--fs-10); }
+.cb-cascade .id { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-fg-disabled); letter-spacing: .04em; }
+.cb-cascade .step { display:grid; grid-template-columns: 14px 1fr auto; gap: 8px; align-items:center; height: 22px; font-family: var(--font-mono); font-size: var(--fs-11); border-bottom: 1px dashed var(--color-border-default); }
+.cb-cascade .step .ix { color: var(--color-fg-disabled); text-align:center; }
+.cb-cascade .step .name { color: var(--color-fg-primary); }
+.cb-cascade .step .ms { color: var(--color-fg-muted); font-size: var(--fs-10); }
 .cb-cascade .step.hit .name { color: var(--ok-fg); }
 .cb-cascade .step.hit .ix { color: var(--ok); }
-.cb-cascade .step.miss .name { color: var(--fg-3); text-decoration: line-through; }
-.cb-cascade .step.skip .name { color: var(--fg-4); }
-.cb-cascade .total { display:flex; align-items:center; gap:6px; font-family: var(--font-mono); font-size: var(--fs-11); color: var(--fg-2); padding-top: 2px; }
-.cb-cascade .total .n { color: var(--brass-1); }
+.cb-cascade .step.miss .name { color: var(--color-fg-muted); text-decoration: line-through; }
+.cb-cascade .step.skip .name { color: var(--color-fg-disabled); }
+.cb-cascade .total { display:flex; align-items:center; gap:6px; font-family: var(--font-mono); font-size: var(--fs-11); color: var(--color-fg-secondary); padding-top: 2px; }
+.cb-cascade .total .n { color: var(--color-accent-fg); }
 
 /* ───── Composer ───── */
-.cb-composer { background: var(--bg-1); border-top:1px solid var(--line-2); padding: 8px 10px; display:flex; flex-direction:column; gap:6px; flex-shrink:0; font-family: var(--font-mono); }
-.cb-composer .line { display:flex; align-items:center; gap:6px; font-size: var(--fs-12); color: var(--fg-2); }
-.cb-composer .prompt { color: var(--brass-1); }
+.cb-composer { background: var(--color-bg-surface); border-top:1px solid var(--color-border-strong); padding: 8px 10px; display:flex; flex-direction:column; gap:6px; flex-shrink:0; font-family: var(--font-mono); }
+.cb-composer .line { display:flex; align-items:center; gap:6px; font-size: var(--fs-12); color: var(--color-fg-secondary); }
+.cb-composer .prompt { color: var(--color-accent-fg); }
 .cb-composer .fn { color: var(--info-fg); }
-.cb-composer .arg { color: var(--fg-1); }
+.cb-composer .arg { color: var(--color-fg-primary); }
 .cb-composer .str { color: var(--ok-fg); }
-.cb-composer input { flex:1; background:transparent; border:0; outline:none; color: var(--fg-1); font-family: inherit; font-size: var(--fs-12); padding:0; }
-.cb-composer .hint { font-size: var(--fs-10); color: var(--fg-4); display:flex; gap:12px; }
-.cb-composer .hint .kbd { font-family: var(--font-mono); background: var(--bg-3); border:1px solid var(--line-2); border-bottom-width:2px; border-radius:3px; padding: 0 4px; height:14px; display:inline-flex; align-items:center; font-size: var(--fs-9); color: var(--fg-3); margin-right:4px; }
+.cb-composer input { flex:1; background:transparent; border:0; outline:none; color: var(--color-fg-primary); font-family: inherit; font-size: var(--fs-12); padding:0; }
+.cb-composer .hint { font-size: var(--fs-10); color: var(--color-fg-disabled); display:flex; gap:12px; }
+.cb-composer .hint .kbd { font-family: var(--font-mono); background: var(--color-bg-elevated); border:1px solid var(--color-border-strong); border-bottom-width:2px; border-radius:3px; padding: 0 4px; height:14px; display:inline-flex; align-items:center; font-size: var(--fs-9); color: var(--color-fg-muted); margin-right:4px; }
 
 /* suggest dropdown */
-.cb-composer .sug { position:absolute; bottom:100%; left:0; right:0; background: var(--bg-2); border:1px solid var(--line-2); border-radius: var(--r-1) var(--r-1) 0 0; box-shadow: 0 -4px 12px rgb(0 0 0 / .4); max-height: 160px; overflow:auto; }
-.cb-composer .sug .item { padding: 4px 10px; display:flex; gap:8px; font-size: var(--fs-11); font-family: var(--font-mono); color: var(--fg-2); cursor:pointer; }
-.cb-composer .sug .item.on { background: var(--bg-3); color: var(--fg-1); }
-.cb-composer .sug .item .kind { color: var(--fg-4); }
+.cb-composer .sug { position:absolute; bottom:100%; left:0; right:0; background: var(--color-bg-panel-alt); border:1px solid var(--color-border-strong); border-radius: var(--r-1) var(--r-1) 0 0; box-shadow: 0 -4px 12px rgb(0 0 0 / .4); max-height: 160px; overflow:auto; }
+.cb-composer .sug .item { padding: 4px 10px; display:flex; gap:8px; font-size: var(--fs-11); font-family: var(--font-mono); color: var(--color-fg-secondary); cursor:pointer; }
+.cb-composer .sug .item.on { background: var(--color-bg-elevated); color: var(--color-fg-primary); }
+.cb-composer .sug .item .kind { color: var(--color-fg-disabled); }
 
 /* ───── Status bar ───── */
-.cb-statusbar { height:20px; display:flex; align-items:center; padding:0 10px; gap:14px; background: var(--bg-1); border-top:1px solid var(--line-2); font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-3); flex-shrink:0; }
+.cb-statusbar { height:20px; display:flex; align-items:center; padding:0 10px; gap:14px; background: var(--color-bg-surface); border-top:1px solid var(--color-border-strong); font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-fg-muted); flex-shrink:0; }
 .cb-statusbar .seg { display:flex; align-items:center; gap:5px; }
 .cb-statusbar .seg.push-right { margin-left:auto; }
 .cb-statusbar .seg .on { color: var(--ok-fg); }
-.cb-statusbar .seg .off { color: var(--fg-4); }
-.cb-statusbar .seg .brass { color: var(--brass-1); }
-.cb-statusbar .sep { width:1px; height:10px; background: var(--line-2); }
+.cb-statusbar .seg .off { color: var(--color-fg-disabled); }
+.cb-statusbar .seg .brass { color: var(--color-accent-fg); }
+.cb-statusbar .sep { width:1px; height:10px; background: var(--color-border-strong); }
 
 /* ───── Drawer (inspector) ───── */
-.cb-drawer { width:100%; height:100%; background: var(--bg-2); border-left: 1px solid var(--line-3); display:flex; flex-direction:column; overflow: hidden; }
-.cb-drawer .head { padding: 10px 12px; border-bottom: 1px solid var(--line-2); display:flex; flex-direction:column; gap: 4px; }
-.cb-drawer .head .idrow { display:flex; align-items:center; gap:6px; font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-4); letter-spacing: .04em; }
-.cb-drawer .head .idrow .close { margin-left:auto; width:18px; height:18px; border:0; background: transparent; color: var(--fg-3); font-size: var(--fs-14); cursor:pointer; border-radius: 3px; }
-.cb-drawer .head .idrow .close:hover { background: var(--bg-3); color: var(--fg-1); }
-.cb-drawer .head .title { font-size: var(--fs-14); color: var(--fg-1); font-weight: 600; line-height:1.3; }
+.cb-drawer { width:100%; height:100%; background: var(--color-bg-panel-alt); border-left: 1px solid var(--color-border-divider); display:flex; flex-direction:column; overflow: hidden; }
+.cb-drawer .head { padding: 10px 12px; border-bottom: 1px solid var(--color-border-strong); display:flex; flex-direction:column; gap: 4px; }
+.cb-drawer .head .idrow { display:flex; align-items:center; gap:6px; font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-fg-disabled); letter-spacing: .04em; }
+.cb-drawer .head .idrow .close { margin-left:auto; width:18px; height:18px; border:0; background: transparent; color: var(--color-fg-muted); font-size: var(--fs-14); cursor:pointer; border-radius: 3px; }
+.cb-drawer .head .idrow .close:hover { background: var(--color-bg-elevated); color: var(--color-fg-primary); }
+.cb-drawer .head .title { font-size: var(--fs-14); color: var(--color-fg-primary); font-weight: 600; line-height:1.3; }
 .cb-drawer .meta { display:flex; flex-wrap:wrap; gap:5px; margin-top: 4px; }
 .cb-drawer .body { flex:1; overflow:auto; padding: 10px 12px; display:flex; flex-direction:column; gap: 12px; }
-.cb-drawer .sec-title { font: var(--type-label); text-transform: uppercase; color: var(--fg-3); letter-spacing: .08em; font-weight:600; }
+.cb-drawer .sec-title { font: var(--type-label); text-transform: uppercase; color: var(--color-fg-muted); letter-spacing: .08em; font-weight:600; }
 .cb-drawer .kv { display:grid; grid-template-columns: 80px 1fr; gap: 4px 12px; font-size: var(--fs-11); }
-.cb-drawer .kv dt { color: var(--fg-3); font: var(--type-label); text-transform: uppercase; letter-spacing: .06em; font-size: var(--fs-10); padding-top: 2px; }
-.cb-drawer .kv dd { margin:0; color: var(--fg-1); font-family: var(--font-mono); font-size: var(--fs-11); }
-.cb-drawer .acts { display:flex; gap:6px; padding: 8px 12px; border-top: 1px solid var(--line-2); }
-.cb-drawer .btn { height:22px; padding: 0 10px; font-family: var(--font-mono); font-size: var(--fs-10); letter-spacing: .08em; text-transform: uppercase; border:1px solid var(--line-2); background: var(--bg-3); color: var(--fg-2); border-radius: var(--r-1); cursor:pointer; font-weight:600; }
-.cb-drawer .btn:hover { background: var(--bg-4); color: var(--fg-1); }
-.cb-drawer .btn.primary { background: var(--brass-2); border-color: var(--brass-3); color: var(--bg-0); }
+.cb-drawer .kv dt { color: var(--color-fg-muted); font: var(--type-label); text-transform: uppercase; letter-spacing: .06em; font-size: var(--fs-10); padding-top: 2px; }
+.cb-drawer .kv dd { margin:0; color: var(--color-fg-primary); font-family: var(--font-mono); font-size: var(--fs-11); }
+.cb-drawer .acts { display:flex; gap:6px; padding: 8px 12px; border-top: 1px solid var(--color-border-strong); }
+.cb-drawer .btn { height:22px; padding: 0 10px; font-family: var(--font-mono); font-size: var(--fs-10); letter-spacing: .08em; text-transform: uppercase; border:1px solid var(--color-border-strong); background: var(--color-bg-elevated); color: var(--color-fg-secondary); border-radius: var(--r-1); cursor:pointer; font-weight:600; }
+.cb-drawer .btn:hover { background: var(--color-bg-hover); color: var(--color-fg-primary); }
+.cb-drawer .btn.primary { background: var(--brass-2); border-color: var(--color-accent-fg-dim); color: var(--color-bg-page); }
 .cb-drawer .btn.danger { color: var(--err-fg); border-color: var(--err-border); }
 .cb-drawer .thread { display:flex; flex-direction:column; gap:6px; }
-.cb-drawer .cmt { padding: 5px 7px; border:1px solid var(--line-1); border-radius: var(--r-1); background: var(--bg-1); display:flex; flex-direction:column; gap:2px; }
-.cb-drawer .cmt .h { display:flex; align-items:center; gap:5px; font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-3); }
+.cb-drawer .cmt { padding: 5px 7px; border:1px solid var(--color-border-default); border-radius: var(--r-1); background: var(--color-bg-surface); display:flex; flex-direction:column; gap:2px; }
+.cb-drawer .cmt .h { display:flex; align-items:center; gap:5px; font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-fg-muted); }
 .cb-drawer .cmt .kind { padding: 0 4px; height:12px; display:inline-flex; align-items:center; border-radius:2px; font-weight:600; letter-spacing: .04em; }
 .cb-drawer .cmt.flag .kind { color: var(--err-fg); background: var(--err-soft); }
 .cb-drawer .cmt.question .kind { color: var(--info-fg); background: var(--info-soft); }
-.cb-drawer .cmt.note .kind { color: var(--fg-2); background: var(--bg-3); }
-.cb-drawer .cmt .t { margin-left:auto; color: var(--fg-4); }
-.cb-drawer .cmt .body { color: var(--fg-1); font-size: var(--fs-11); line-height: 1.4; }
+.cb-drawer .cmt.note .kind { color: var(--color-fg-secondary); background: var(--color-bg-elevated); }
+.cb-drawer .cmt .t { margin-left:auto; color: var(--color-fg-disabled); }
+.cb-drawer .cmt .body { color: var(--color-fg-primary); font-size: var(--fs-11); line-height: 1.4; }
 
 
 /* ═══════════════════════════════════════════════════════════════════
@@ -311,155 +311,155 @@
    ═══════════════════════════════════════════════════════════════════ */
 
 /* shared "panel" wrapper used by all P2 zones — fills artboard */
-.cbp { width:100%; height:100%; background: var(--bg-0); color: var(--fg-1); display:flex; flex-direction:column; font-family: var(--font-sans); font-size: var(--fs-12); overflow: hidden; position: relative; }
-.cbp .ph { display:flex; align-items:center; gap:8px; padding: 6px 10px; border-bottom: 1px solid var(--line-2); background: linear-gradient(180deg, var(--bg-2), var(--bg-1)); flex-shrink:0; min-height: 28px; position: relative; }
-.cbp .ph::after { content:''; position:absolute; left:0; right:0; bottom:-1px; height:1px; background: linear-gradient(90deg, transparent, rgb(var(--brass-glow)/.3), transparent); }
-.cbp .ph .ttl { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-2); letter-spacing: .1em; text-transform: uppercase; font-weight: 600; }
-.cbp .ph .meta { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-4); letter-spacing: .04em; }
+.cbp { width:100%; height:100%; background: var(--color-bg-page); color: var(--color-fg-primary); display:flex; flex-direction:column; font-family: var(--font-sans); font-size: var(--fs-12); overflow: hidden; position: relative; }
+.cbp .ph { display:flex; align-items:center; gap:8px; padding: 6px 10px; border-bottom: 1px solid var(--color-border-strong); background: linear-gradient(180deg, var(--color-bg-panel-alt), var(--color-bg-surface)); flex-shrink:0; min-height: 28px; position: relative; }
+.cbp .ph::after { content:''; position:absolute; left:0; right:0; bottom:-1px; height:1px; background: linear-gradient(90deg, transparent, rgb(var(--color-accent-glow)/.3), transparent); }
+.cbp .ph .ttl { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-fg-secondary); letter-spacing: .1em; text-transform: uppercase; font-weight: 600; }
+.cbp .ph .meta { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-fg-disabled); letter-spacing: .04em; }
 .cbp .ph .grow { flex: 1; }
-.cbp .ph .crumb { color: var(--fg-3); font-family: var(--font-mono); font-size: var(--fs-10); letter-spacing: .06em; }
-.cbp .ph .crumb .br { color: var(--brass-1); }
-.cbp .ph .crumb .sep { color: var(--fg-4); margin: 0 4px; }
+.cbp .ph .crumb { color: var(--color-fg-muted); font-family: var(--font-mono); font-size: var(--fs-10); letter-spacing: .06em; }
+.cbp .ph .crumb .br { color: var(--color-accent-fg); }
+.cbp .ph .crumb .sep { color: var(--color-fg-disabled); margin: 0 4px; }
 .cbp .body { flex:1; overflow:auto; padding: 8px 10px; display:flex; flex-direction:column; gap: 8px; }
 .cbp .body.flat { padding: 0; gap: 0; }
 
 /* tiny "filter chip" rail */
 .cbp .filt { display:flex; gap:4px; flex-wrap:wrap; }
-.cbp .filt button { font-family: var(--font-mono); font-size: var(--fs-10); letter-spacing: .06em; text-transform: uppercase; padding: 2px 7px; border: 1px solid var(--line-2); background: var(--bg-2); color: var(--fg-3); cursor: pointer; border-radius: 0; height: 18px; }
-.cbp .filt button.on { color: var(--brass-1); background: rgb(var(--brass-glow)/.08); border-color: var(--brass-2); }
-.cbp .filt button:hover { color: var(--fg-1); }
+.cbp .filt button { font-family: var(--font-mono); font-size: var(--fs-10); letter-spacing: .06em; text-transform: uppercase; padding: 2px 7px; border: 1px solid var(--color-border-strong); background: var(--color-bg-panel-alt); color: var(--color-fg-muted); cursor: pointer; border-radius: 0; height: 18px; }
+.cbp .filt button.on { color: var(--color-accent-fg); background: rgb(var(--color-accent-glow)/.08); border-color: var(--brass-2); }
+.cbp .filt button:hover { color: var(--color-fg-primary); }
 
 /* generic table inside artboards */
 .cbp table.t { width:100%; border-collapse: collapse; font-family: var(--font-mono); font-size: var(--fs-11); }
-.cbp table.t thead th { text-align:left; font-size: var(--fs-9); letter-spacing: .1em; text-transform: uppercase; color: var(--fg-4); font-weight: 600; padding: 4px 8px; border-bottom: 1px solid var(--line-2); position: sticky; top: 0; background: var(--bg-1); z-index: 1; }
-.cbp table.t tbody td { padding: 4px 8px; border-bottom: 1px solid var(--line-1); color: var(--fg-2); vertical-align: middle; white-space: nowrap; }
-.cbp table.t tbody tr:hover td { background: rgb(var(--brass-glow)/.04); color: var(--fg-1); }
-.cbp table.t .num { text-align:right; font-variant-numeric: tabular-nums; color: var(--fg-1); }
-.cbp table.t .id { color: var(--fg-3); }
-.cbp table.t .pri { color: var(--fg-1); white-space: normal; min-width: 0; }
-.cbp table.t .mute { color: var(--fg-4); }
+.cbp table.t thead th { text-align:left; font-size: var(--fs-9); letter-spacing: .1em; text-transform: uppercase; color: var(--color-fg-disabled); font-weight: 600; padding: 4px 8px; border-bottom: 1px solid var(--color-border-strong); position: sticky; top: 0; background: var(--color-bg-surface); z-index: 1; }
+.cbp table.t tbody td { padding: 4px 8px; border-bottom: 1px solid var(--color-border-default); color: var(--color-fg-secondary); vertical-align: middle; white-space: nowrap; }
+.cbp table.t tbody tr:hover td { background: rgb(var(--color-accent-glow)/.04); color: var(--color-fg-primary); }
+.cbp table.t .num { text-align:right; font-variant-numeric: tabular-nums; color: var(--color-fg-primary); }
+.cbp table.t .id { color: var(--color-fg-muted); }
+.cbp table.t .pri { color: var(--color-fg-primary); white-space: normal; min-width: 0; }
+.cbp table.t .mute { color: var(--color-fg-disabled); }
 
 /* ═════ G1 · GOAL ZONE ═════ */
-.gz-track { display: grid; grid-template-columns: 80px 1fr; gap: 6px; align-items: stretch; padding: 4px 0; border-bottom: 1px dashed var(--line-1); }
+.gz-track { display: grid; grid-template-columns: 80px 1fr; gap: 6px; align-items: stretch; padding: 4px 0; border-bottom: 1px dashed var(--color-border-default); }
 .gz-track:last-child { border-bottom: none; }
-.gz-track .hz { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--brass-1); letter-spacing: .12em; text-transform: uppercase; padding: 6px 8px; border-right: 1px solid var(--brass-2); display: flex; flex-direction: column; gap: 2px; }
-.gz-track .hz .n { color: var(--fg-4); font-size: var(--fs-9); letter-spacing: .04em; }
+.gz-track .hz { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-accent-fg); letter-spacing: .12em; text-transform: uppercase; padding: 6px 8px; border-right: 1px solid var(--brass-2); display: flex; flex-direction: column; gap: 2px; }
+.gz-track .hz .n { color: var(--color-fg-disabled); font-size: var(--fs-9); letter-spacing: .04em; }
 .gz-track .lst { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
-.gz-card { display: grid; grid-template-columns: 1fr 90px; gap: 8px; padding: 6px 8px; background: var(--bg-1); border: 1px solid var(--line-1); border-left: 2px solid var(--brass-2); border-radius: 0; align-items: center; min-width: 0; }
+.gz-card { display: grid; grid-template-columns: 1fr 90px; gap: 8px; padding: 6px 8px; background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-left: 2px solid var(--brass-2); border-radius: 0; align-items: center; min-width: 0; }
 .gz-card.done { border-left-color: var(--ok); opacity: .6; }
 .gz-card.discovery { border-left-color: var(--info); }
 .gz-card.verifying { border-left-color: var(--warn); }
 .gz-card .top { display:flex; flex-direction:column; gap: 2px; min-width: 0; }
-.gz-card .id { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-4); letter-spacing: .06em; }
-.gz-card .ttl { font-size: var(--fs-12); color: var(--fg-1); line-height: 1.3; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.gz-card .met { display: flex; align-items: baseline; gap: 6px; font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-3); }
-.gz-card .met .v { color: var(--brass-1); font-variant-numeric: tabular-nums; }
+.gz-card .id { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); letter-spacing: .06em; }
+.gz-card .ttl { font-size: var(--fs-12); color: var(--color-fg-primary); line-height: 1.3; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.gz-card .met { display: flex; align-items: baseline; gap: 6px; font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-fg-muted); }
+.gz-card .met .v { color: var(--color-accent-fg); font-variant-numeric: tabular-nums; }
 .gz-card .prog { display: flex; flex-direction: column; align-items: flex-end; gap: 3px; font-family: var(--font-mono); font-size: var(--fs-10); }
-.gz-card .prog .pct { color: var(--brass-1); font-variant-numeric: tabular-nums; font-size: var(--fs-13); }
-.gz-card .prog .b { width: 80px; height: 4px; background: var(--bg-3); position: relative; overflow: hidden; }
-.gz-card .prog .b i { position:absolute; left:0; top:0; bottom:0; background: linear-gradient(90deg, var(--brass-3), var(--brass-1)); }
+.gz-card .prog .pct { color: var(--color-accent-fg); font-variant-numeric: tabular-nums; font-size: var(--fs-13); }
+.gz-card .prog .b { width: 80px; height: 4px; background: var(--color-bg-elevated); position: relative; overflow: hidden; }
+.gz-card .prog .b i { position:absolute; left:0; top:0; bottom:0; background: linear-gradient(90deg, var(--color-accent-fg-dim), var(--color-accent-fg)); }
 .gz-card.done .prog .b i { background: var(--ok); }
 
 /* horizon header bar */
-.gz-hdr { display: grid; grid-template-columns: 80px 1fr 90px; gap: 6px; padding: 4px 8px; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-4); letter-spacing: .08em; text-transform: uppercase; border-bottom: 1px solid var(--line-2); background: var(--bg-1); }
+.gz-hdr { display: grid; grid-template-columns: 80px 1fr 90px; gap: 6px; padding: 4px 8px; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); letter-spacing: .08em; text-transform: uppercase; border-bottom: 1px solid var(--color-border-strong); background: var(--color-bg-surface); }
 
 /* tree variant */
-.gz-tree-row { display: grid; grid-template-columns: 1fr 60px 60px; gap: 6px; padding: 5px 8px; border-bottom: 1px solid var(--line-1); align-items: center; font-family: var(--font-mono); font-size: var(--fs-11); }
-.gz-tree-row.child { padding-left: 28px; background: rgb(var(--brass-glow)/.025); }
-.gz-tree-row.child::before { content: "└"; color: var(--fg-4); margin-right: 4px; margin-left: -16px; }
-.gz-tree-row .ttl { color: var(--fg-1); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
-.gz-tree-row .ttl small { color: var(--fg-4); margin-left: 6px; font-size: var(--fs-9); letter-spacing: .04em; text-transform: uppercase; }
-.gz-tree-row .num { text-align: right; font-variant-numeric: tabular-nums; color: var(--brass-1); }
+.gz-tree-row { display: grid; grid-template-columns: 1fr 60px 60px; gap: 6px; padding: 5px 8px; border-bottom: 1px solid var(--color-border-default); align-items: center; font-family: var(--font-mono); font-size: var(--fs-11); }
+.gz-tree-row.child { padding-left: 28px; background: rgb(var(--color-accent-glow)/.025); }
+.gz-tree-row.child::before { content: "└"; color: var(--color-fg-disabled); margin-right: 4px; margin-left: -16px; }
+.gz-tree-row .ttl { color: var(--color-fg-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.gz-tree-row .ttl small { color: var(--color-fg-disabled); margin-left: 6px; font-size: var(--fs-9); letter-spacing: .04em; text-transform: uppercase; }
+.gz-tree-row .num { text-align: right; font-variant-numeric: tabular-nums; color: var(--color-accent-fg); }
 .gz-tree-row .ph { color: var(--info-fg); }
-.gz-tree-row .ph.executing { color: var(--brass-1); }
+.gz-tree-row .ph.executing { color: var(--color-accent-fg); }
 .gz-tree-row .ph.verifying { color: var(--warn); }
 .gz-tree-row .ph.done { color: var(--ok-fg); }
 
 /* snapshot diff variant */
 .gz-snap { display:flex; flex-direction:column; gap: 6px; }
-.gz-snap-row { padding: 7px 8px; background: var(--bg-1); border: 1px solid var(--line-1); border-radius: 0; }
-.gz-snap-row .ttl { font-size: var(--fs-12); color: var(--fg-1); margin-bottom: 6px; display:flex; align-items:center; gap: 6px; }
-.gz-snap-row .ttl .id { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-4); }
+.gz-snap-row { padding: 7px 8px; background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-radius: 0; }
+.gz-snap-row .ttl { font-size: var(--fs-12); color: var(--color-fg-primary); margin-bottom: 6px; display:flex; align-items:center; gap: 6px; }
+.gz-snap-row .ttl .id { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); }
 .gz-snap-row .diff { display: grid; grid-template-columns: 1fr 16px 1fr; gap: 8px; align-items: center; font-family: var(--font-mono); font-size: var(--fs-10); }
-.gz-snap-row .y, .gz-snap-row .t { padding: 4px 6px; border: 1px dashed var(--line-2); background: var(--bg-2); }
-.gz-snap-row .y { color: var(--fg-3); }
-.gz-snap-row .t { color: var(--fg-1); border-style: solid; border-color: var(--brass-2); background: rgb(var(--brass-glow)/.05); }
-.gz-snap-row .arr { color: var(--brass-1); text-align: center; font-size: var(--fs-12); }
-.gz-snap-row .lbl { font-size: var(--fs-9); color: var(--fg-4); letter-spacing: .08em; text-transform: uppercase; display:block; margin-bottom: 2px; }
-.gz-snap-row .v { color: var(--brass-1); font-variant-numeric: tabular-nums; }
+.gz-snap-row .y, .gz-snap-row .t { padding: 4px 6px; border: 1px dashed var(--color-border-strong); background: var(--color-bg-panel-alt); }
+.gz-snap-row .y { color: var(--color-fg-muted); }
+.gz-snap-row .t { color: var(--color-fg-primary); border-style: solid; border-color: var(--brass-2); background: rgb(var(--color-accent-glow)/.05); }
+.gz-snap-row .arr { color: var(--color-accent-fg); text-align: center; font-size: var(--fs-12); }
+.gz-snap-row .lbl { font-size: var(--fs-9); color: var(--color-fg-disabled); letter-spacing: .08em; text-transform: uppercase; display:block; margin-bottom: 2px; }
+.gz-snap-row .v { color: var(--color-accent-fg); font-variant-numeric: tabular-nums; }
 
 /* ═════ G2 · TASK ZONE ═════ */
 .tz-row td { vertical-align: top !important; padding: 6px 8px !important; }
-.tz-row .stat { padding: 1px 6px; font-family: var(--font-mono); font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; border: 1px solid var(--line-2); color: var(--fg-3); }
-.tz-row .stat.running   { color: var(--brass-1); border-color: var(--brass-2); background: rgb(var(--brass-glow)/.08); }
-.tz-row .stat.pending   { color: var(--fg-3); }
+.tz-row .stat { padding: 1px 6px; font-family: var(--font-mono); font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; border: 1px solid var(--color-border-strong); color: var(--color-fg-muted); }
+.tz-row .stat.running   { color: var(--color-accent-fg); border-color: var(--brass-2); background: rgb(var(--color-accent-glow)/.08); }
+.tz-row .stat.pending   { color: var(--color-fg-muted); }
 .tz-row .stat.queued    { color: var(--info-fg); border-color: var(--info-border); background: var(--info-soft); }
 .tz-row .stat.fail      { color: var(--err-fg); border-color: var(--err-border); background: var(--err-soft); }
 .tz-row .stat.stalled   { color: var(--stalled); border-color: var(--stalled); background: rgb(var(--stalled-glow)/.1); }
 .tz-row .stat.done      { color: var(--ok-fg); border-color: var(--ok); background: var(--ok-soft); opacity: .8; }
-.tz-row .stat.cancelled { color: var(--fg-4); text-decoration: line-through; }
+.tz-row .stat.cancelled { color: var(--color-fg-disabled); text-decoration: line-through; }
 .tz-row .drift { color: var(--err-fg); font-size: var(--fs-9); letter-spacing: .08em; padding: 1px 5px; border: 1px solid var(--err-border); background: var(--err-soft); margin-left: 4px; }
 
 /* stale-claim alert layout */
 .tz-alert { display:flex; flex-direction:column; gap:6px; }
-.tz-alert .row { display:grid; grid-template-columns: 1fr auto auto; gap: 8px; padding: 8px 10px; background: var(--bg-1); border: 1px solid var(--err-border); border-left: 2px solid var(--err); align-items: center; }
-.tz-alert .row .who { font-family: var(--font-mono); font-size: var(--fs-11); color: var(--fg-1); }
-.tz-alert .row .who .id { color: var(--brass-1); }
+.tz-alert .row { display:grid; grid-template-columns: 1fr auto auto; gap: 8px; padding: 8px 10px; background: var(--color-bg-surface); border: 1px solid var(--err-border); border-left: 2px solid var(--err); align-items: center; }
+.tz-alert .row .who { font-family: var(--font-mono); font-size: var(--fs-11); color: var(--color-fg-primary); }
+.tz-alert .row .who .id { color: var(--color-accent-fg); }
 .tz-alert .row .who .age { color: var(--err-fg); margin-left: 8px; font-size: var(--fs-10); }
-.tz-alert .row .why { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-3); padding: 0 8px; border-left: 1px solid var(--line-2); }
+.tz-alert .row .why { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-fg-muted); padding: 0 8px; border-left: 1px solid var(--color-border-strong); }
 .tz-alert .row .acts { display:flex; gap: 4px; }
-.tz-alert .row .acts button { font-family: var(--font-mono); font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; padding: 3px 8px; background: var(--bg-3); border: 1px solid var(--line-2); color: var(--fg-2); cursor: pointer; border-radius: 0; }
+.tz-alert .row .acts button { font-family: var(--font-mono); font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; padding: 3px 8px; background: var(--color-bg-elevated); border: 1px solid var(--color-border-strong); color: var(--color-fg-secondary); cursor: pointer; border-radius: 0; }
 .tz-alert .row .acts button.danger { color: var(--err-fg); border-color: var(--err-border); }
-.tz-alert .row .acts button.primary { color: var(--bg-0); background: var(--brass-2); border-color: var(--brass-3); }
+.tz-alert .row .acts button.primary { color: var(--color-bg-page); background: var(--brass-2); border-color: var(--color-accent-fg-dim); }
 
 /* per-keeper task wall */
 .tz-wall { display:grid; grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); gap: 6px; }
-.tz-wall .kpr { padding: 6px 8px; background: var(--bg-1); border: 1px solid var(--line-1); border-top: 2px solid var(--brass-2); border-radius: 0; display:flex; flex-direction:column; gap: 4px; min-width: 0; }
+.tz-wall .kpr { padding: 6px 8px; background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-top: 2px solid var(--brass-2); border-radius: 0; display:flex; flex-direction:column; gap: 4px; min-width: 0; }
 .tz-wall .kpr .h { display:flex; align-items:center; gap:5px; font-family: var(--font-mono); font-size: var(--fs-10); }
-.tz-wall .kpr .h .nm { color: var(--brass-1); }
-.tz-wall .kpr .h .cn { color: var(--fg-4); margin-left: auto; font-size: var(--fs-9); letter-spacing: .04em; }
-.tz-wall .kpr .tk { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-2); padding: 3px 5px; border-left: 2px solid var(--line-2); background: var(--bg-0); display:flex; gap: 4px; align-items: baseline; }
-.tz-wall .kpr .tk .id { color: var(--fg-4); font-size: var(--fs-9); flex-shrink: 0; }
-.tz-wall .kpr .tk .t { color: var(--fg-1); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; flex: 1; }
-.tz-wall .kpr .tk.running { border-left-color: var(--brass-1); }
+.tz-wall .kpr .h .nm { color: var(--color-accent-fg); }
+.tz-wall .kpr .h .cn { color: var(--color-fg-disabled); margin-left: auto; font-size: var(--fs-9); letter-spacing: .04em; }
+.tz-wall .kpr .tk { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-fg-secondary); padding: 3px 5px; border-left: 2px solid var(--color-border-strong); background: var(--color-bg-page); display:flex; gap: 4px; align-items: baseline; }
+.tz-wall .kpr .tk .id { color: var(--color-fg-disabled); font-size: var(--fs-9); flex-shrink: 0; }
+.tz-wall .kpr .tk .t { color: var(--color-fg-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; flex: 1; }
+.tz-wall .kpr .tk.running { border-left-color: var(--color-accent-fg); }
 .tz-wall .kpr .tk.fail { border-left-color: var(--err); }
 .tz-wall .kpr .tk.stalled { border-left-color: var(--stalled); }
 .tz-wall .kpr .tk.done { border-left-color: var(--ok); opacity: .55; }
 .tz-wall .kpr.empty { opacity: .35; }
-.tz-wall .kpr.empty .tk { font-style: italic; color: var(--fg-4); }
+.tz-wall .kpr.empty .tk { font-style: italic; color: var(--color-fg-disabled); }
 
 /* ═════ G3 · ACCOUNTABILITY ═════ */
-.ac-row { display: grid; grid-template-columns: 70px 80px 1fr 110px; gap: 8px; padding: 6px 8px; border-bottom: 1px solid var(--line-1); font-family: var(--font-mono); font-size: var(--fs-11); align-items: baseline; }
-.ac-row .ts { color: var(--fg-4); font-size: var(--fs-10); }
-.ac-row .vd { font-size: var(--fs-9); letter-spacing: .1em; text-transform: uppercase; padding: 1px 5px; border: 1px solid var(--line-2); text-align: center; }
+.ac-row { display: grid; grid-template-columns: 70px 80px 1fr 110px; gap: 8px; padding: 6px 8px; border-bottom: 1px solid var(--color-border-default); font-family: var(--font-mono); font-size: var(--fs-11); align-items: baseline; }
+.ac-row .ts { color: var(--color-fg-disabled); font-size: var(--fs-10); }
+.ac-row .vd { font-size: var(--fs-9); letter-spacing: .1em; text-transform: uppercase; padding: 1px 5px; border: 1px solid var(--color-border-strong); text-align: center; }
 .ac-row .vd.approve { color: var(--ok-fg); border-color: var(--ok); background: var(--ok-soft); }
 .ac-row .vd.reject  { color: var(--err-fg); border-color: var(--err-border); background: var(--err-soft); }
 .ac-row .vd.flag    { color: var(--warn); border-color: var(--warn); background: rgb(var(--warn-glow)/.1); }
 .ac-row .vd.defer   { color: var(--info-fg); border-color: var(--info-border); background: var(--info-soft); }
-.ac-row .sub { color: var(--fg-1); white-space: normal; line-height: 1.3; }
-.ac-row .sub .ev { color: var(--fg-3); font-size: var(--fs-9); display: block; margin-top: 1px; letter-spacing: .04em; }
-.ac-row .sig { color: var(--brass-1); text-align: right; font-size: var(--fs-10); }
-.ac-row .sig .scope { color: var(--fg-4); display: block; font-size: var(--fs-9); letter-spacing: .04em; text-transform: uppercase; }
+.ac-row .sub { color: var(--color-fg-primary); white-space: normal; line-height: 1.3; }
+.ac-row .sub .ev { color: var(--color-fg-muted); font-size: var(--fs-9); display: block; margin-top: 1px; letter-spacing: .04em; }
+.ac-row .sig { color: var(--color-accent-fg); text-align: right; font-size: var(--fs-10); }
+.ac-row .sig .scope { color: var(--color-fg-disabled); display: block; font-size: var(--fs-9); letter-spacing: .04em; text-transform: uppercase; }
 
 /* responsibility matrix */
 .ac-mtx { width:100%; border-collapse: collapse; font-family: var(--font-mono); font-size: var(--fs-10); }
-.ac-mtx th, .ac-mtx td { padding: 3px 6px; text-align: center; border: 1px solid var(--line-1); }
-.ac-mtx th { font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; color: var(--fg-3); background: var(--bg-1); font-weight: 600; }
+.ac-mtx th, .ac-mtx td { padding: 3px 6px; text-align: center; border: 1px solid var(--color-border-default); }
+.ac-mtx th { font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; color: var(--color-fg-muted); background: var(--color-bg-surface); font-weight: 600; }
 .ac-mtx th.col-h { writing-mode: vertical-rl; transform: rotate(180deg); padding: 6px 2px; height: 80px; vertical-align: bottom; }
-.ac-mtx th.row-h { text-align: left; color: var(--fg-2); font-family: var(--font-mono); font-weight: 400; }
-.ac-mtx td { color: var(--fg-3); font-variant-numeric: tabular-nums; background: var(--bg-0); transition: background .15s; cursor: default; }
-.ac-mtx td.z0 { color: var(--fg-4); opacity: .3; }
-.ac-mtx td.z1 { color: var(--fg-2); background: rgb(var(--brass-glow)/.05); }
-.ac-mtx td.z2 { color: var(--fg-1); background: rgb(var(--brass-glow)/.12); }
-.ac-mtx td.z3 { color: var(--brass-1); background: rgb(var(--brass-glow)/.22); font-weight: 600; }
-.ac-mtx td.z4 { color: var(--bg-0); background: var(--brass-1); font-weight: 600; }
+.ac-mtx th.row-h { text-align: left; color: var(--color-fg-secondary); font-family: var(--font-mono); font-weight: 400; }
+.ac-mtx td { color: var(--color-fg-muted); font-variant-numeric: tabular-nums; background: var(--color-bg-page); transition: background .15s; cursor: default; }
+.ac-mtx td.z0 { color: var(--color-fg-disabled); opacity: .3; }
+.ac-mtx td.z1 { color: var(--color-fg-secondary); background: rgb(var(--color-accent-glow)/.05); }
+.ac-mtx td.z2 { color: var(--color-fg-primary); background: rgb(var(--color-accent-glow)/.12); }
+.ac-mtx td.z3 { color: var(--color-accent-fg); background: rgb(var(--color-accent-glow)/.22); font-weight: 600; }
+.ac-mtx td.z4 { color: var(--color-bg-page); background: var(--color-accent-fg); font-weight: 600; }
 .ac-mtx tr:hover td { outline: 1px solid var(--brass-2); outline-offset: -1px; }
 
 /* IDE backbone — branch crumb (used in zone headers) */
-.cbp .ph .br-pill { font-family: var(--font-mono); font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; padding: 1px 6px 1px 14px; border: 1px solid var(--line-2); color: var(--brass-1); background: var(--bg-2); position: relative; }
+.cbp .ph .br-pill { font-family: var(--font-mono); font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; padding: 1px 6px 1px 14px; border: 1px solid var(--color-border-strong); color: var(--color-accent-fg); background: var(--color-bg-panel-alt); position: relative; }
 .cbp .ph .br-pill::before { content: "⎇"; position: absolute; left: 4px; top: 0px; font-size: var(--fs-11); color: var(--brass-2); }
-.cbp .ph .kpr-pill { font-family: var(--font-mono); font-size: var(--fs-9); letter-spacing: .04em; padding: 1px 6px; border: 1px solid var(--line-2); color: var(--fg-2); background: var(--bg-2); margin-left: 3px; }
-.cbp .ph .kpr-pill .dot { display: inline-block; width: 5px; height: 5px; border-radius: 50%; background: var(--brass-1); margin-right: 4px; vertical-align: middle; }
+.cbp .ph .kpr-pill { font-family: var(--font-mono); font-size: var(--fs-9); letter-spacing: .04em; padding: 1px 6px; border: 1px solid var(--color-border-strong); color: var(--color-fg-secondary); background: var(--color-bg-panel-alt); margin-left: 3px; }
+.cbp .ph .kpr-pill .dot { display: inline-block; width: 5px; height: 5px; border-radius: 50%; background: var(--color-accent-fg); margin-right: 4px; vertical-align: middle; }
 
 
 /* ═══════════════════════════════════════════════════════════════════
@@ -468,105 +468,105 @@
 
 /* ═════ C1 · BOARD ═════ */
 .bd-feed { display:flex; flex-direction:column; gap: 6px; }
-.bd-post { display: grid; grid-template-columns: 32px 1fr 80px; gap: 8px; padding: 8px 10px; background: var(--bg-1); border: 1px solid var(--line-1); border-left: 2px solid var(--line-2); border-radius: 0; align-items: start; }
+.bd-post { display: grid; grid-template-columns: 32px 1fr 80px; gap: 8px; padding: 8px 10px; background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-left: 2px solid var(--color-border-strong); border-radius: 0; align-items: start; }
 .bd-post.automation { border-left-color: var(--info); background: rgb(80 130 180 / .04); }
 .bd-post.direct     { border-left-color: var(--brass-2); }
 .bd-post.hot        { border-left-color: var(--err); }
-.bd-post .vote { display:flex; flex-direction:column; align-items:center; gap: 1px; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-4); padding-top: 2px; }
+.bd-post .vote { display:flex; flex-direction:column; align-items:center; gap: 1px; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); padding-top: 2px; }
 .bd-post .vote .up, .bd-post .vote .dn { width: 16px; height: 12px; display:flex; align-items:center; justify-content:center; cursor:pointer; border-radius: 0; }
 .bd-post .vote .up:hover { color: var(--ok-fg); }
 .bd-post .vote .dn:hover { color: var(--err-fg); }
-.bd-post .vote .net { color: var(--brass-1); font-weight: 600; padding: 1px 0; }
+.bd-post .vote .net { color: var(--color-accent-fg); font-weight: 600; padding: 1px 0; }
 .bd-post .vote .net.neg { color: var(--err-fg); }
 .bd-post .main { min-width: 0; display:flex; flex-direction:column; gap: 4px; }
-.bd-post .h { display:flex; align-items:center; gap: 6px; font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-3); flex-wrap: wrap; }
-.bd-post .h .au { color: var(--brass-1); }
-.bd-post .h .kk { padding: 0 5px; font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; border: 1px solid var(--line-2); color: var(--fg-3); }
+.bd-post .h { display:flex; align-items:center; gap: 6px; font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-fg-muted); flex-wrap: wrap; }
+.bd-post .h .au { color: var(--color-accent-fg); }
+.bd-post .h .kk { padding: 0 5px; font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; border: 1px solid var(--color-border-strong); color: var(--color-fg-muted); }
 .bd-post .h .kk.automation { color: var(--info-fg); border-color: var(--info-border); background: var(--info-soft); }
-.bd-post .h .kk.direct { color: var(--brass-1); border-color: var(--brass-2); }
-.bd-post .h .he { padding: 0 5px; font-size: var(--fs-9); letter-spacing: .04em; color: var(--fg-2); background: var(--bg-2); border: 1px solid var(--line-1); }
-.bd-post .h .at { color: var(--fg-4); margin-left: auto; }
+.bd-post .h .kk.direct { color: var(--color-accent-fg); border-color: var(--brass-2); }
+.bd-post .h .he { padding: 0 5px; font-size: var(--fs-9); letter-spacing: .04em; color: var(--color-fg-secondary); background: var(--color-bg-panel-alt); border: 1px solid var(--color-border-default); }
+.bd-post .h .at { color: var(--color-fg-disabled); margin-left: auto; }
 .bd-post .h .exp { color: var(--warn); font-size: var(--fs-9); letter-spacing: .04em; }
-.bd-post .ttl { font-size: var(--fs-13); color: var(--fg-1); line-height: 1.3; font-weight: 500; }
-.bd-post .body { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-2); line-height: 1.4; white-space: pre-wrap; max-height: 70px; overflow: hidden; position: relative; }
+.bd-post .ttl { font-size: var(--fs-13); color: var(--color-fg-primary); line-height: 1.3; font-weight: 500; }
+.bd-post .body { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-fg-secondary); line-height: 1.4; white-space: pre-wrap; max-height: 70px; overflow: hidden; position: relative; }
 .bd-post .body.expand { max-height: none; }
-.bd-post .body.clip::after { content:''; position: absolute; left:0; right:0; bottom:0; height: 18px; background: linear-gradient(transparent, var(--bg-1)); }
-.bd-post .state-block { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--brass-1); background: rgb(var(--brass-glow)/.06); border: 1px dashed var(--brass-2); padding: 3px 5px; margin-top: 4px; white-space: pre-wrap; }
-.bd-post .ft { display:flex; gap: 8px; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-4); letter-spacing: .04em; text-transform: uppercase; }
+.bd-post .body.clip::after { content:''; position: absolute; left:0; right:0; bottom:0; height: 18px; background: linear-gradient(transparent, var(--color-bg-surface)); }
+.bd-post .state-block { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-accent-fg); background: rgb(var(--color-accent-glow)/.06); border: 1px dashed var(--brass-2); padding: 3px 5px; margin-top: 4px; white-space: pre-wrap; }
+.bd-post .ft { display:flex; gap: 8px; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); letter-spacing: .04em; text-transform: uppercase; }
 .bd-post .ft button { background: transparent; border: none; color: inherit; font-family: inherit; font-size: inherit; letter-spacing: inherit; cursor: pointer; padding: 0; }
-.bd-post .ft button:hover { color: var(--brass-1); }
-.bd-post .meta-r { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-4); display:flex; flex-direction:column; align-items:flex-end; gap: 2px; letter-spacing: .04em; text-transform: uppercase; }
+.bd-post .ft button:hover { color: var(--color-accent-fg); }
+.bd-post .meta-r { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); display:flex; flex-direction:column; align-items:flex-end; gap: 2px; letter-spacing: .04em; text-transform: uppercase; }
 
 /* hearth-grouped feed */
-.bd-hearth-grp { border-top: 1px solid var(--line-2); padding-top: 4px; margin-top: 8px; }
+.bd-hearth-grp { border-top: 1px solid var(--color-border-strong); padding-top: 4px; margin-top: 8px; }
 .bd-hearth-grp:first-child { border-top: none; padding-top: 0; margin-top: 0; }
-.bd-hearth-grp .hh { display:flex; align-items:center; gap: 6px; padding: 4px 0; font-family: var(--font-mono); font-size: var(--fs-10); color: var(--brass-1); letter-spacing: .12em; text-transform: uppercase; font-weight: 600; }
-.bd-hearth-grp .hh .cn { color: var(--fg-4); font-size: var(--fs-9); }
+.bd-hearth-grp .hh { display:flex; align-items:center; gap: 6px; padding: 4px 0; font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-accent-fg); letter-spacing: .12em; text-transform: uppercase; font-weight: 600; }
+.bd-hearth-grp .hh .cn { color: var(--color-fg-disabled); font-size: var(--fs-9); }
 .bd-hearth-grp .hh::before { content: "♨"; color: var(--brass-2); font-size: var(--fs-12); }
 
 /* single post + thread */
-.bd-thread { display:flex; flex-direction:column; gap: 4px; padding-left: 12px; border-left: 2px solid var(--line-2); margin-left: 8px; }
-.bd-thread .reply { padding: 6px 8px; background: var(--bg-1); border: 1px solid var(--line-1); border-radius: 0; }
-.bd-thread .reply .h { display:flex; gap: 6px; font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-3); align-items: baseline; margin-bottom: 3px; }
-.bd-thread .reply .h .au { color: var(--brass-1); }
-.bd-thread .reply .h .at { color: var(--fg-4); margin-left: auto; }
-.bd-thread .reply .body { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--fg-2); line-height: 1.4; white-space: pre-wrap; }
+.bd-thread { display:flex; flex-direction:column; gap: 4px; padding-left: 12px; border-left: 2px solid var(--color-border-strong); margin-left: 8px; }
+.bd-thread .reply { padding: 6px 8px; background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-radius: 0; }
+.bd-thread .reply .h { display:flex; gap: 6px; font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-fg-muted); align-items: baseline; margin-bottom: 3px; }
+.bd-thread .reply .h .au { color: var(--color-accent-fg); }
+.bd-thread .reply .h .at { color: var(--color-fg-disabled); margin-left: auto; }
+.bd-thread .reply .body { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-fg-secondary); line-height: 1.4; white-space: pre-wrap; }
 
 /* ═════ C2 · MESSAGES ═════ */
 .ms-room { display: grid; grid-template-columns: 180px 1fr; height: 100%; }
-.ms-room .roomlist { border-right: 1px solid var(--line-2); background: var(--bg-1); display:flex; flex-direction:column; }
-.ms-room .roomlist .room { padding: 6px 10px; border-bottom: 1px solid var(--line-1); cursor: pointer; display:flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: var(--fs-11); color: var(--fg-2); }
-.ms-room .roomlist .room.on { background: rgb(var(--brass-glow)/.08); color: var(--brass-1); border-left: 2px solid var(--brass-1); padding-left: 8px; }
+.ms-room .roomlist { border-right: 1px solid var(--color-border-strong); background: var(--color-bg-surface); display:flex; flex-direction:column; }
+.ms-room .roomlist .room { padding: 6px 10px; border-bottom: 1px solid var(--color-border-default); cursor: pointer; display:flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: var(--fs-11); color: var(--color-fg-secondary); }
+.ms-room .roomlist .room.on { background: rgb(var(--color-accent-glow)/.08); color: var(--color-accent-fg); border-left: 2px solid var(--color-accent-fg); padding-left: 8px; }
 .ms-room .roomlist .room .nm { flex: 1; }
-.ms-room .roomlist .room .nm::before { content: "#"; color: var(--fg-4); margin-right: 3px; }
-.ms-room .roomlist .room .un { font-size: var(--fs-9); color: var(--brass-1); background: rgb(var(--brass-glow)/.15); padding: 1px 5px; border-radius: 0; min-width: 18px; text-align: center; }
+.ms-room .roomlist .room .nm::before { content: "#"; color: var(--color-fg-disabled); margin-right: 3px; }
+.ms-room .roomlist .room .un { font-size: var(--fs-9); color: var(--color-accent-fg); background: rgb(var(--color-accent-glow)/.15); padding: 1px 5px; border-radius: 0; min-width: 18px; text-align: center; }
 .ms-room .roomlist .room .un.zero { display: none; }
 .ms-room .feed { display:flex; flex-direction:column; }
 .ms-room .feed .timeline { flex:1; overflow:auto; padding: 8px 10px; display:flex; flex-direction: column; gap: 6px; }
 
 .ms-msg { display: grid; grid-template-columns: 50px 1fr; gap: 8px; font-family: var(--font-mono); font-size: var(--fs-11); }
-.ms-msg .seq { color: var(--fg-4); font-size: var(--fs-9); text-align: right; padding-top: 2px; letter-spacing: .04em; }
+.ms-msg .seq { color: var(--color-fg-disabled); font-size: var(--fs-9); text-align: right; padding-top: 2px; letter-spacing: .04em; }
 .ms-msg .body { display:flex; flex-direction:column; gap: 3px; min-width: 0; }
 .ms-msg .h { display:flex; align-items: baseline; gap: 6px; }
-.ms-msg .h .au { color: var(--brass-1); font-weight: 600; }
-.ms-msg .h .kk { padding: 0 4px; font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; border: 1px solid var(--line-2); color: var(--fg-3); }
+.ms-msg .h .au { color: var(--color-accent-fg); font-weight: 600; }
+.ms-msg .h .kk { padding: 0 4px; font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; border: 1px solid var(--color-border-strong); color: var(--color-fg-muted); }
 .ms-msg .h .kk.dm { color: var(--info-fg); border-color: var(--info-border); background: var(--info-soft); }
-.ms-msg .h .kk.broadcast { color: var(--fg-4); }
-.ms-msg .h .at { margin-left: auto; color: var(--fg-4); font-size: var(--fs-9); }
-.ms-msg .text { color: var(--fg-1); line-height: 1.45; word-break: break-word; }
-.ms-msg .text .mention { color: var(--brass-1); background: rgb(var(--brass-glow)/.1); padding: 0 3px; border-radius: 0; }
-.ms-msg .state-block { color: var(--brass-1); background: rgb(var(--brass-glow)/.06); border-left: 2px solid var(--brass-2); padding: 3px 6px; margin-top: 3px; white-space: pre-wrap; font-size: var(--fs-10); }
+.ms-msg .h .kk.broadcast { color: var(--color-fg-disabled); }
+.ms-msg .h .at { margin-left: auto; color: var(--color-fg-disabled); font-size: var(--fs-9); }
+.ms-msg .text { color: var(--color-fg-primary); line-height: 1.45; word-break: break-word; }
+.ms-msg .text .mention { color: var(--color-accent-fg); background: rgb(var(--color-accent-glow)/.1); padding: 0 3px; border-radius: 0; }
+.ms-msg .state-block { color: var(--color-accent-fg); background: rgb(var(--color-accent-glow)/.06); border-left: 2px solid var(--brass-2); padding: 3px 6px; margin-top: 3px; white-space: pre-wrap; font-size: var(--fs-10); }
 
 /* mention inbox */
 .ms-inbox { display:flex; flex-direction:column; gap: 4px; }
-.ms-inbox .mn { padding: 6px 8px; background: var(--bg-1); border: 1px solid var(--line-1); border-left: 2px solid var(--brass-1); border-radius: 0; font-family: var(--font-mono); font-size: var(--fs-11); }
+.ms-inbox .mn { padding: 6px 8px; background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-left: 2px solid var(--color-accent-fg); border-radius: 0; font-family: var(--font-mono); font-size: var(--fs-11); }
 .ms-inbox .mn .h { display:flex; gap: 6px; align-items: baseline; margin-bottom: 3px; }
-.ms-inbox .mn .h .au { color: var(--brass-1); font-weight: 600; }
+.ms-inbox .mn .h .au { color: var(--color-accent-fg); font-weight: 600; }
 .ms-inbox .mn .h .rm { color: var(--info-fg); font-size: var(--fs-9); }
-.ms-inbox .mn .h .at { color: var(--fg-4); font-size: var(--fs-9); margin-left: auto; }
-.ms-inbox .mn .text { color: var(--fg-1); line-height: 1.4; }
-.ms-inbox .mn .text .mention { color: var(--brass-1); background: rgb(var(--brass-glow)/.15); padding: 0 3px; }
+.ms-inbox .mn .h .at { color: var(--color-fg-disabled); font-size: var(--fs-9); margin-left: auto; }
+.ms-inbox .mn .text { color: var(--color-fg-primary); line-height: 1.4; }
+.ms-inbox .mn .text .mention { color: var(--color-accent-fg); background: rgb(var(--color-accent-glow)/.15); padding: 0 3px; }
 
 /* ═════ C3 · COMPOSER V2 (broadcast / mention / state-block) ═════ */
-.cm2 { background: var(--bg-1); border: 1px solid var(--line-2); border-top: 2px solid var(--brass-2); padding: 8px 10px; display:flex; flex-direction:column; gap: 6px; }
+.cm2 { background: var(--color-bg-surface); border: 1px solid var(--color-border-strong); border-top: 2px solid var(--brass-2); padding: 8px 10px; display:flex; flex-direction:column; gap: 6px; }
 .cm2 .toolbar { display:flex; align-items:center; gap: 4px; font-family: var(--font-mono); font-size: var(--fs-10); }
-.cm2 .toolbar .seg { display:flex; border: 1px solid var(--line-2); border-radius: 0; }
-.cm2 .toolbar .seg button { background: transparent; border: none; color: var(--fg-3); padding: 3px 8px; font-family: inherit; font-size: inherit; letter-spacing: .08em; text-transform: uppercase; cursor: pointer; border-right: 1px solid var(--line-2); font-weight: 600; }
+.cm2 .toolbar .seg { display:flex; border: 1px solid var(--color-border-strong); border-radius: 0; }
+.cm2 .toolbar .seg button { background: transparent; border: none; color: var(--color-fg-muted); padding: 3px 8px; font-family: inherit; font-size: inherit; letter-spacing: .08em; text-transform: uppercase; cursor: pointer; border-right: 1px solid var(--color-border-strong); font-weight: 600; }
 .cm2 .toolbar .seg button:last-child { border-right: none; }
-.cm2 .toolbar .seg button.on { color: var(--brass-1); background: rgb(var(--brass-glow)/.1); }
-.cm2 .toolbar .room-sel { padding: 2px 6px; background: var(--bg-2); border: 1px solid var(--line-2); color: var(--brass-1); font-family: inherit; font-size: inherit; }
-.cm2 .toolbar .room-sel::before { content: "→ #"; color: var(--fg-4); }
+.cm2 .toolbar .seg button.on { color: var(--color-accent-fg); background: rgb(var(--color-accent-glow)/.1); }
+.cm2 .toolbar .room-sel { padding: 2px 6px; background: var(--color-bg-panel-alt); border: 1px solid var(--color-border-strong); color: var(--color-accent-fg); font-family: inherit; font-size: inherit; }
+.cm2 .toolbar .room-sel::before { content: "→ #"; color: var(--color-fg-disabled); }
 .cm2 .toolbar .grow { flex: 1; }
-.cm2 .toolbar .send { padding: 3px 10px; background: var(--brass-2); color: var(--bg-0); border: none; font-family: inherit; font-size: inherit; letter-spacing: .08em; text-transform: uppercase; cursor: pointer; font-weight: 600; }
-.cm2 .ed { background: var(--bg-0); border: 1px solid var(--line-1); padding: 6px 8px; font-family: var(--font-mono); font-size: var(--fs-11); color: var(--fg-1); min-height: 60px; line-height: 1.5; cursor: text; white-space: pre-wrap; }
-.cm2 .ed .mention { color: var(--brass-1); background: rgb(var(--brass-glow)/.1); padding: 0 3px; }
-.cm2 .ed .state-block { color: var(--brass-1); background: rgb(var(--brass-glow)/.06); border-left: 2px solid var(--brass-2); padding: 3px 6px; margin: 3px 0; display: block; }
-.cm2 .ed .caret { color: var(--brass-1); animation: anim-blink 1s step-end infinite; }
+.cm2 .toolbar .send { padding: 3px 10px; background: var(--brass-2); color: var(--color-bg-page); border: none; font-family: inherit; font-size: inherit; letter-spacing: .08em; text-transform: uppercase; cursor: pointer; font-weight: 600; }
+.cm2 .ed { background: var(--color-bg-page); border: 1px solid var(--color-border-default); padding: 6px 8px; font-family: var(--font-mono); font-size: var(--fs-11); color: var(--color-fg-primary); min-height: 60px; line-height: 1.5; cursor: text; white-space: pre-wrap; }
+.cm2 .ed .mention { color: var(--color-accent-fg); background: rgb(var(--color-accent-glow)/.1); padding: 0 3px; }
+.cm2 .ed .state-block { color: var(--color-accent-fg); background: rgb(var(--color-accent-glow)/.06); border-left: 2px solid var(--brass-2); padding: 3px 6px; margin: 3px 0; display: block; }
+.cm2 .ed .caret { color: var(--color-accent-fg); animation: anim-blink 1s step-end infinite; }
 @keyframes anim-blink { 50% { opacity: 0; } }
-.cm2 .targets { display:flex; gap: 4px; flex-wrap: wrap; padding: 3px 0; border-top: 1px dashed var(--line-1); font-family: var(--font-mono); font-size: var(--fs-9); align-items: center; color: var(--fg-4); letter-spacing: .04em; text-transform: uppercase; }
-.cm2 .targets .t-pill { padding: 1px 6px; background: rgb(var(--brass-glow)/.08); color: var(--brass-1); border: 1px solid var(--brass-2); border-radius: 0; text-transform: none; letter-spacing: .04em; font-size: var(--fs-10); }
-.cm2 .hint { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-4); letter-spacing: .04em; display:flex; gap: 12px; padding-top: 3px; border-top: 1px dashed var(--line-1); }
-.cm2 .hint .kbd { display:inline-block; padding: 0 4px; border: 1px solid var(--line-2); background: var(--bg-2); color: var(--fg-2); font-size: var(--fs-9); margin-right: 4px; }
+.cm2 .targets { display:flex; gap: 4px; flex-wrap: wrap; padding: 3px 0; border-top: 1px dashed var(--color-border-default); font-family: var(--font-mono); font-size: var(--fs-9); align-items: center; color: var(--color-fg-disabled); letter-spacing: .04em; text-transform: uppercase; }
+.cm2 .targets .t-pill { padding: 1px 6px; background: rgb(var(--color-accent-glow)/.08); color: var(--color-accent-fg); border: 1px solid var(--brass-2); border-radius: 0; text-transform: none; letter-spacing: .04em; font-size: var(--fs-10); }
+.cm2 .hint { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); letter-spacing: .04em; display:flex; gap: 12px; padding-top: 3px; border-top: 1px dashed var(--color-border-default); }
+.cm2 .hint .kbd { display:inline-block; padding: 0 4px; border: 1px solid var(--color-border-strong); background: var(--color-bg-panel-alt); color: var(--color-fg-secondary); font-size: var(--fs-9); margin-right: 4px; }
 
 
 /* ═══════════════════════════════════════════════════════════════════
@@ -575,130 +575,130 @@
 
 /* ═════ O1 · CASCADE INSPECTOR ═════ */
 .csc-list { display:flex; flex-direction:column; gap: 6px; }
-.csc-card { background: var(--bg-1); border: 1px solid var(--line-2); padding: 0; display:flex; flex-direction:column; }
+.csc-card { background: var(--color-bg-surface); border: 1px solid var(--color-border-strong); padding: 0; display:flex; flex-direction:column; }
 .csc-card.outcome-error { border-left: 2px solid var(--err); }
 .csc-card.outcome-ok    { border-left: 2px solid var(--ok); }
-.csc-card .h { display:flex; align-items: baseline; gap: 8px; padding: 5px 8px; background: var(--bg-2); border-bottom: 1px solid var(--line-1); font-family: var(--font-mono); font-size: var(--fs-10); }
-.csc-card .h .id  { color: var(--brass-1); }
-.csc-card .h .nm  { color: var(--fg-2); letter-spacing: .04em; }
-.csc-card .h .tg  { color: var(--fg-3); font-size: var(--fs-9); }
-.csc-card .h .out { margin-left: auto; padding: 1px 6px; font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; border:1px solid var(--line-2); }
+.csc-card .h { display:flex; align-items: baseline; gap: 8px; padding: 5px 8px; background: var(--color-bg-panel-alt); border-bottom: 1px solid var(--color-border-default); font-family: var(--font-mono); font-size: var(--fs-10); }
+.csc-card .h .id  { color: var(--color-accent-fg); }
+.csc-card .h .nm  { color: var(--color-fg-secondary); letter-spacing: .04em; }
+.csc-card .h .tg  { color: var(--color-fg-muted); font-size: var(--fs-9); }
+.csc-card .h .out { margin-left: auto; padding: 1px 6px; font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; border:1px solid var(--color-border-strong); }
 .csc-card .h .out.error { color: var(--err-fg); border-color: var(--err-border); background: var(--err-soft); }
 .csc-card .h .out.ok    { color: var(--ok-fg);  border-color: var(--ok); background: var(--ok-soft); }
 .csc-card .hops { display:flex; flex-direction:column; }
-.csc-card .hop { display: grid; grid-template-columns: 22px 1fr 70px 80px; align-items:center; gap: 8px; padding: 4px 8px; border-top: 1px dashed var(--line-1); font-family: var(--font-mono); font-size: var(--fs-10); }
+.csc-card .hop { display: grid; grid-template-columns: 22px 1fr 70px 80px; align-items:center; gap: 8px; padding: 4px 8px; border-top: 1px dashed var(--color-border-default); font-family: var(--font-mono); font-size: var(--fs-10); }
 .csc-card .hop:first-child { border-top: none; }
-.csc-card .hop .step { color: var(--fg-4); text-align: center; }
-.csc-card .hop .mdl { color: var(--fg-1); }
-.csc-card .hop .ms  { color: var(--fg-3); text-align: right; font-variant-numeric: tabular-nums; }
+.csc-card .hop .step { color: var(--color-fg-disabled); text-align: center; }
+.csc-card .hop .mdl { color: var(--color-fg-primary); }
+.csc-card .hop .ms  { color: var(--color-fg-muted); text-align: right; font-variant-numeric: tabular-nums; }
 .csc-card .hop .st  { font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; padding: 0 4px; text-align: center; }
 .csc-card .hop .st.miss      { color: var(--warn); border:1px solid var(--warn); background: rgb(var(--warn-glow)/.08); }
 .csc-card .hop .st.hit       { color: var(--ok-fg); border:1px solid var(--ok); background: var(--ok-soft); }
 .csc-card .hop .st.exhausted { color: var(--err-fg); border:1px solid var(--err-border); background: var(--err-soft); }
-.csc-card .hop .reason { grid-column: 2 / -1; color: var(--fg-4); font-size: var(--fs-9); padding-left: 0; }
-.csc-card .ft { padding: 4px 8px; background: var(--bg-0); border-top: 1px solid var(--line-1); display:flex; gap: 12px; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-4); letter-spacing: .04em; text-transform: uppercase; }
-.csc-card .ft .ms { color: var(--brass-1); }
+.csc-card .hop .reason { grid-column: 2 / -1; color: var(--color-fg-disabled); font-size: var(--fs-9); padding-left: 0; }
+.csc-card .ft { padding: 4px 8px; background: var(--color-bg-page); border-top: 1px solid var(--color-border-default); display:flex; gap: 12px; font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); letter-spacing: .04em; text-transform: uppercase; }
+.csc-card .ft .ms { color: var(--color-accent-fg); }
 
 /* configured pool view (one line of pills) */
-.csc-pool { display:flex; flex-wrap: wrap; gap: 4px; padding: 5px 8px; background: var(--bg-0); border-top: 1px dashed var(--line-1); }
-.csc-pool .mp { font-family: var(--font-mono); font-size: var(--fs-9); padding: 1px 5px; border:1px solid var(--line-1); color: var(--fg-3); background: var(--bg-2); }
+.csc-pool { display:flex; flex-wrap: wrap; gap: 4px; padding: 5px 8px; background: var(--color-bg-page); border-top: 1px dashed var(--color-border-default); }
+.csc-pool .mp { font-family: var(--font-mono); font-size: var(--fs-9); padding: 1px 5px; border:1px solid var(--color-border-default); color: var(--color-fg-muted); background: var(--color-bg-panel-alt); }
 .csc-pool .mp.tried { color: var(--warn); border-color: var(--warn); }
-.csc-pool .mp.hit   { color: var(--brass-1); border-color: var(--brass-2); background: rgb(var(--brass-glow)/.08); font-weight: 600; }
+.csc-pool .mp.hit   { color: var(--color-accent-fg); border-color: var(--brass-2); background: rgb(var(--color-accent-glow)/.08); font-weight: 600; }
 
 /* ═════ O2 · AUDIT LEDGER ═════ */
-.aud-row { display:grid; grid-template-columns: 70px 110px 90px 1fr 60px; gap: 6px; padding: 4px 8px; border-bottom: 1px solid var(--line-1); align-items: baseline; font-family: var(--font-mono); font-size: var(--fs-11); }
-.aud-row .ts { color: var(--fg-4); font-size: var(--fs-10); }
-.aud-row .kn { font-size: var(--fs-9); letter-spacing: .04em; padding: 1px 5px; border: 1px solid var(--line-2); color: var(--fg-2); background: var(--bg-2); white-space: nowrap; }
+.aud-row { display:grid; grid-template-columns: 70px 110px 90px 1fr 60px; gap: 6px; padding: 4px 8px; border-bottom: 1px solid var(--color-border-default); align-items: baseline; font-family: var(--font-mono); font-size: var(--fs-11); }
+.aud-row .ts { color: var(--color-fg-disabled); font-size: var(--fs-10); }
+.aud-row .kn { font-size: var(--fs-9); letter-spacing: .04em; padding: 1px 5px; border: 1px solid var(--color-border-strong); color: var(--color-fg-secondary); background: var(--color-bg-panel-alt); white-space: nowrap; }
 .aud-row .kn.tool       { color: var(--info-fg); }
 .aud-row .kn.suite      { color: var(--err-fg); border-color: var(--err-border); background: var(--err-soft); }
 .aud-row .kn.verdict    { color: var(--ok-fg); border-color: var(--ok); background: var(--ok-soft); }
-.aud-row .kn.cascade    { color: var(--brass-1); border-color: var(--brass-2); }
-.aud-row .kn.task       { color: var(--fg-1); }
-.aud-row .kn.board      { color: var(--fg-3); }
+.aud-row .kn.cascade    { color: var(--color-accent-fg); border-color: var(--brass-2); }
+.aud-row .kn.task       { color: var(--color-fg-primary); }
+.aud-row .kn.board      { color: var(--color-fg-muted); }
 .aud-row .kn.message    { color: var(--info-fg); }
 .aud-row .kn.keeper     { color: var(--warn); border-color: var(--warn); }
-.aud-row .kn.operator   { color: var(--bg-0); background: var(--brass-1); border-color: var(--brass-1); }
-.aud-row .ac { color: var(--brass-1); }
-.aud-row .sb { color: var(--fg-1); white-space: normal; }
-.aud-row .sb .pl { color: var(--fg-3); font-size: var(--fs-9); display: block; margin-top: 1px; }
-.aud-row .du { text-align: right; color: var(--fg-3); font-variant-numeric: tabular-nums; font-size: var(--fs-10); }
+.aud-row .kn.operator   { color: var(--color-bg-page); background: var(--color-accent-fg); border-color: var(--color-accent-fg); }
+.aud-row .ac { color: var(--color-accent-fg); }
+.aud-row .sb { color: var(--color-fg-primary); white-space: normal; }
+.aud-row .sb .pl { color: var(--color-fg-muted); font-size: var(--fs-9); display: block; margin-top: 1px; }
+.aud-row .du { text-align: right; color: var(--color-fg-muted); font-variant-numeric: tabular-nums; font-size: var(--fs-10); }
 
 /* ═════ O3 · SAFE AUTONOMY DASHBOARD ═════ */
-.sa-hero { display:grid; grid-template-columns: 200px 1fr; gap: 12px; padding: 10px 12px; background: var(--bg-1); border: 1px solid var(--line-2); border-left: 3px solid var(--err); align-items: center; }
+.sa-hero { display:grid; grid-template-columns: 200px 1fr; gap: 12px; padding: 10px 12px; background: var(--color-bg-surface); border: 1px solid var(--color-border-strong); border-left: 3px solid var(--err); align-items: center; }
 .sa-hero .gauge { display:flex; flex-direction:column; align-items:flex-start; gap: 4px; }
-.sa-hero .gauge .v { font-family: var(--font-mono); font-size: 48px; color: var(--brass-1); font-weight: 600; line-height: 1; font-variant-numeric: tabular-nums; }
+.sa-hero .gauge .v { font-family: var(--font-mono); font-size: 48px; color: var(--color-accent-fg); font-weight: 600; line-height: 1; font-variant-numeric: tabular-nums; }
 .sa-hero .gauge .v.fail { color: var(--err-fg); }
-.sa-hero .gauge .lbl { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-4); letter-spacing: .12em; text-transform: uppercase; }
+.sa-hero .gauge .lbl { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); letter-spacing: .12em; text-transform: uppercase; }
 .sa-hero .gauge .st { font-family: var(--font-mono); font-size: var(--fs-10); padding: 1px 6px; border: 1px solid var(--err-border); color: var(--err-fg); background: var(--err-soft); letter-spacing: .12em; text-transform: uppercase; font-weight: 600; }
 .sa-hero .meta { display:grid; grid-template-columns: 1fr 1fr; gap: 4px 12px; font-family: var(--font-mono); font-size: var(--fs-10); }
-.sa-hero .meta .k { color: var(--fg-4); letter-spacing: .04em; text-transform: uppercase; font-size: var(--fs-9); }
-.sa-hero .meta .v { color: var(--fg-1); font-variant-numeric: tabular-nums; }
+.sa-hero .meta .k { color: var(--color-fg-disabled); letter-spacing: .04em; text-transform: uppercase; font-size: var(--fs-9); }
+.sa-hero .meta .v { color: var(--color-fg-primary); font-variant-numeric: tabular-nums; }
 .sa-hero .spark { grid-column: 1 / -1; height: 28px; }
 
-.sa-find { display:grid; grid-template-columns: 50px 100px 1fr 200px; gap: 6px; padding: 4px 8px; border-bottom: 1px solid var(--line-1); align-items: baseline; font-family: var(--font-mono); font-size: var(--fs-11); }
-.sa-find .sev { padding: 1px 5px; font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; text-align: center; border:1px solid var(--line-2); }
+.sa-find { display:grid; grid-template-columns: 50px 100px 1fr 200px; gap: 6px; padding: 4px 8px; border-bottom: 1px solid var(--color-border-default); align-items: baseline; font-family: var(--font-mono); font-size: var(--fs-11); }
+.sa-find .sev { padding: 1px 5px; font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; text-align: center; border:1px solid var(--color-border-strong); }
 .sa-find .sev.high   { color: var(--err-fg); border-color: var(--err-border); background: var(--err-soft); font-weight: 600; }
 .sa-find .sev.medium { color: var(--warn); border-color: var(--warn); background: rgb(var(--warn-glow)/.1); }
-.sa-find .sev.low    { color: var(--fg-3); }
-.sa-find .kpr { color: var(--brass-1); }
-.sa-find .rule { color: var(--fg-1); white-space: normal; }
-.sa-find .loc  { color: var(--fg-4); font-size: var(--fs-10); text-align: right; }
-.sa-find .loc .ln { color: var(--brass-1); }
+.sa-find .sev.low    { color: var(--color-fg-muted); }
+.sa-find .kpr { color: var(--color-accent-fg); }
+.sa-find .rule { color: var(--color-fg-primary); white-space: normal; }
+.sa-find .loc  { color: var(--color-fg-disabled); font-size: var(--fs-10); text-align: right; }
+.sa-find .loc .ln { color: var(--color-accent-fg); }
 
 /* ═════ O4 · COST DASHBOARD ═════ */
-.cs-tot { display:grid; grid-template-columns: repeat(4, 1fr); gap: 1px; background: var(--line-2); border: 1px solid var(--line-2); margin-bottom: 8px; }
-.cs-tot .cell { background: var(--bg-1); padding: 8px 12px; display:flex; flex-direction:column; gap: 4px; }
-.cs-tot .cell .lbl { font-family: var(--font-mono); font-size: var(--fs-9); letter-spacing: .12em; text-transform: uppercase; color: var(--fg-4); }
-.cs-tot .cell .v { font-family: var(--font-mono); font-size: 22px; color: var(--brass-1); font-variant-numeric: tabular-nums; line-height: 1.1; }
-.cs-tot .cell .sub { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-3); }
+.cs-tot { display:grid; grid-template-columns: repeat(4, 1fr); gap: 1px; background: var(--color-border-strong); border: 1px solid var(--color-border-strong); margin-bottom: 8px; }
+.cs-tot .cell { background: var(--color-bg-surface); padding: 8px 12px; display:flex; flex-direction:column; gap: 4px; }
+.cs-tot .cell .lbl { font-family: var(--font-mono); font-size: var(--fs-9); letter-spacing: .12em; text-transform: uppercase; color: var(--color-fg-disabled); }
+.cs-tot .cell .v { font-family: var(--font-mono); font-size: 22px; color: var(--color-accent-fg); font-variant-numeric: tabular-nums; line-height: 1.1; }
+.cs-tot .cell .sub { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-muted); }
 
 .cs-tbl td.bar { padding: 0 !important; position: relative; height: 16px; min-width: 120px; }
-.cs-tbl td.bar i { display:block; height: 100%; background: linear-gradient(90deg, var(--brass-3), var(--brass-1)); }
+.cs-tbl td.bar i { display:block; height: 100%; background: linear-gradient(90deg, var(--color-accent-fg-dim), var(--color-accent-fg)); }
 .cs-tbl td.bar.lat i { background: linear-gradient(90deg, var(--info), var(--err)); }
-.cs-tbl td.lat-num { font-variant-numeric: tabular-nums; color: var(--fg-2); text-align: right; }
+.cs-tbl td.lat-num { font-variant-numeric: tabular-nums; color: var(--color-fg-secondary); text-align: right; }
 .cs-tbl td.lat-num.bad { color: var(--err-fg); }
 
 /* latency histogram */
-.cs-hist { display:flex; align-items:flex-end; height: 80px; gap: 2px; padding: 4px 8px; background: var(--bg-1); border: 1px solid var(--line-2); }
+.cs-hist { display:flex; align-items:flex-end; height: 80px; gap: 2px; padding: 4px 8px; background: var(--color-bg-surface); border: 1px solid var(--color-border-strong); }
 .cs-hist .col { flex: 1; display:flex; flex-direction:column; align-items:center; gap: 2px; }
-.cs-hist .col .b { width: 100%; background: linear-gradient(180deg, var(--brass-1), var(--brass-3)); }
+.cs-hist .col .b { width: 100%; background: linear-gradient(180deg, var(--color-accent-fg), var(--color-accent-fg-dim)); }
 .cs-hist .col .b.bad { background: linear-gradient(180deg, var(--warn), var(--err)); }
-.cs-hist .col .lab { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--fg-4); letter-spacing: .04em; }
+.cs-hist .col .lab { font-family: var(--font-mono); font-size: var(--fs-9); color: var(--color-fg-disabled); letter-spacing: .04em; }
 
 /* provider × model heatmap */
 .cs-mat { width:100%; border-collapse: collapse; font-family: var(--font-mono); font-size: var(--fs-10); }
-.cs-mat th, .cs-mat td { padding: 4px 6px; text-align: center; border: 1px solid var(--line-1); font-variant-numeric: tabular-nums; }
-.cs-mat th { font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; color: var(--fg-4); background: var(--bg-1); font-weight: 600; }
-.cs-mat th.row-h { text-align: left; color: var(--fg-2); }
-.cs-mat td.z0 { color: var(--fg-4); opacity: .25; }
-.cs-mat td.z1 { color: var(--fg-2); background: rgb(var(--brass-glow)/.05); }
-.cs-mat td.z2 { color: var(--fg-1); background: rgb(var(--brass-glow)/.12); }
-.cs-mat td.z3 { color: var(--brass-1); background: rgb(var(--brass-glow)/.22); font-weight:600; }
-.cs-mat td.z4 { color: var(--bg-0); background: var(--brass-1); font-weight: 600; }
+.cs-mat th, .cs-mat td { padding: 4px 6px; text-align: center; border: 1px solid var(--color-border-default); font-variant-numeric: tabular-nums; }
+.cs-mat th { font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; color: var(--color-fg-disabled); background: var(--color-bg-surface); font-weight: 600; }
+.cs-mat th.row-h { text-align: left; color: var(--color-fg-secondary); }
+.cs-mat td.z0 { color: var(--color-fg-disabled); opacity: .25; }
+.cs-mat td.z1 { color: var(--color-fg-secondary); background: rgb(var(--color-accent-glow)/.05); }
+.cs-mat td.z2 { color: var(--color-fg-primary); background: rgb(var(--color-accent-glow)/.12); }
+.cs-mat td.z3 { color: var(--color-accent-fg); background: rgb(var(--color-accent-glow)/.22); font-weight:600; }
+.cs-mat td.z4 { color: var(--color-bg-page); background: var(--color-accent-fg); font-weight: 600; }
 
 /* ═════ O5 · HEURISTIC + STRESS ═════ */
-.hr-row { display:grid; grid-template-columns: 70px 130px 1fr 100px 60px 50px; gap: 6px; padding: 4px 8px; border-bottom: 1px solid var(--line-1); align-items: baseline; font-family: var(--font-mono); font-size: var(--fs-11); }
+.hr-row { display:grid; grid-template-columns: 70px 130px 1fr 100px 60px 50px; gap: 6px; padding: 4px 8px; border-bottom: 1px solid var(--color-border-default); align-items: baseline; font-family: var(--font-mono); font-size: var(--fs-11); }
 .hr-row.fired { background: rgb(var(--err-glow,255 90 90)/.04); border-left: 2px solid var(--err); padding-left: 6px; }
-.hr-row .ts { color: var(--fg-4); font-size: var(--fs-10); }
-.hr-row .mod { color: var(--fg-1); font-weight: 500; }
-.hr-row .site { color: var(--brass-1); }
-.hr-row .det { color: var(--fg-3); font-size: var(--fs-10); white-space: normal; }
-.hr-row .num { text-align: right; font-variant-numeric: tabular-nums; color: var(--fg-1); }
+.hr-row .ts { color: var(--color-fg-disabled); font-size: var(--fs-10); }
+.hr-row .mod { color: var(--color-fg-primary); font-weight: 500; }
+.hr-row .site { color: var(--color-accent-fg); }
+.hr-row .det { color: var(--color-fg-muted); font-size: var(--fs-10); white-space: normal; }
+.hr-row .num { text-align: right; font-variant-numeric: tabular-nums; color: var(--color-fg-primary); }
 .hr-row .num.over { color: var(--err-fg); font-weight: 600; }
-.hr-row .fl { font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; padding: 1px 4px; border:1px solid var(--line-2); text-align:center; }
+.hr-row .fl { font-size: var(--fs-9); letter-spacing: .08em; text-transform: uppercase; padding: 1px 4px; border:1px solid var(--color-border-strong); text-align:center; }
 .hr-row .fl.t { color: var(--err-fg); border-color: var(--err-border); background: var(--err-soft); font-weight:600; }
-.hr-row .fl.f { color: var(--fg-4); }
+.hr-row .fl.f { color: var(--color-fg-disabled); }
 
 .st-grid { display:grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 6px; }
-.st-grid .scard { padding: 7px 9px; background: var(--bg-1); border: 1px solid var(--line-1); border-left: 3px solid var(--warn); display:flex; flex-direction:column; gap: 4px; }
+.st-grid .scard { padding: 7px 9px; background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-left: 3px solid var(--warn); display:flex; flex-direction:column; gap: 4px; }
 .st-grid .scard.cascade_burn { border-left-color: var(--err); }
 .st-grid .scard.failure_streak { border-left-color: var(--err); }
 .st-grid .scard.stale_claim { border-left-color: var(--warn); }
 .st-grid .scard .h { display:flex; gap: 6px; align-items: baseline; }
-.st-grid .scard .h .ag { color: var(--brass-1); font-family: var(--font-mono); font-size: var(--fs-12); font-weight: 600; }
-.st-grid .scard .h .at { color: var(--fg-4); font-family: var(--font-mono); font-size: var(--fs-9); margin-left: auto; }
+.st-grid .scard .h .ag { color: var(--color-accent-fg); font-family: var(--font-mono); font-size: var(--fs-12); font-weight: 600; }
+.st-grid .scard .h .at { color: var(--color-fg-disabled); font-family: var(--font-mono); font-size: var(--fs-9); margin-left: auto; }
 .st-grid .scard .kind { color: var(--err-fg); font-family: var(--font-mono); font-size: var(--fs-10); letter-spacing: .04em; }
-.st-grid .scard .cn { color: var(--fg-2); font-family: var(--font-mono); font-size: var(--fs-10); }
+.st-grid .scard .cn { color: var(--color-fg-secondary); font-family: var(--font-mono); font-size: var(--fs-10); }
 .st-grid .scard .cn .v { color: var(--err-fg); font-weight: 600; }
 
 /* ═══════════════════════════════════════════════════
@@ -706,390 +706,390 @@
    ═══════════════════════════════════════════════════ */
 
 /* ───── K1 · Keeper Inspector v2 ───── */
-.ki-tabs { display:flex; gap:1px; background:var(--line-1); border:1px solid var(--line-2); margin-bottom:8px; }
-.ki-tabs button { flex:1; padding:4px 6px; background:var(--bg-1); border:0; color:var(--fg-3); font-family:var(--font-mono); font-size:var(--fs-10); cursor:pointer; display:flex; align-items:center; gap:4px; justify-content:center; white-space:nowrap; }
-.ki-tabs button.on { background:var(--bg-2); color:var(--brass-1); }
-.ki-tabs button:hover { background:var(--bg-2); color:var(--fg-1); }
+.ki-tabs { display:flex; gap:1px; background:var(--color-border-default); border:1px solid var(--color-border-strong); margin-bottom:8px; }
+.ki-tabs button { flex:1; padding:4px 6px; background:var(--color-bg-surface); border:0; color:var(--color-fg-muted); font-family:var(--font-mono); font-size:var(--fs-10); cursor:pointer; display:flex; align-items:center; gap:4px; justify-content:center; white-space:nowrap; }
+.ki-tabs button.on { background:var(--color-bg-panel-alt); color:var(--color-accent-fg); }
+.ki-tabs button:hover { background:var(--color-bg-panel-alt); color:var(--color-fg-primary); }
 
 .ki-bdi { display:flex; flex-direction:column; gap:1px; }
-.ki-bdi .row { display:grid; grid-template-columns:64px 1fr; gap:8px; padding:5px 8px; background:var(--bg-1); border:1px solid var(--line-1); align-items:flex-start; }
-.ki-bdi .lbl { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--brass-1); letter-spacing:.06em; text-transform:uppercase; padding-top:1px; }
-.ki-bdi .v { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-1); line-height:1.45; }
-.ki-bdi .hz { display:grid; grid-template-columns:72px 1fr; gap:3px 8px; padding:5px 8px; background:var(--bg-0); border:1px solid var(--line-1); margin-top:1px; }
-.ki-bdi .hz .lbl { font-family:var(--font-mono); font-size:var(--fs-9); color:var(--fg-4); letter-spacing:.06em; text-transform:uppercase; white-space:nowrap; padding-top:1px; }
-.ki-bdi .hz .v { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-2); }
+.ki-bdi .row { display:grid; grid-template-columns:64px 1fr; gap:8px; padding:5px 8px; background:var(--color-bg-surface); border:1px solid var(--color-border-default); align-items:flex-start; }
+.ki-bdi .lbl { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-accent-fg); letter-spacing:.06em; text-transform:uppercase; padding-top:1px; }
+.ki-bdi .v { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--color-fg-primary); line-height:1.45; }
+.ki-bdi .hz { display:grid; grid-template-columns:72px 1fr; gap:3px 8px; padding:5px 8px; background:var(--color-bg-page); border:1px solid var(--color-border-default); margin-top:1px; }
+.ki-bdi .hz .lbl { font-family:var(--font-mono); font-size:var(--fs-9); color:var(--color-fg-disabled); letter-spacing:.06em; text-transform:uppercase; white-space:nowrap; padding-top:1px; }
+.ki-bdi .hz .v { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--color-fg-secondary); }
 
 .ki-access { display:flex; flex-direction:column; gap:1px; }
-.ki-access .row { display:grid; grid-template-columns:130px 1fr; gap:8px; padding:4px 8px; background:var(--bg-1); border:1px solid var(--line-1); align-items:center; }
-.ki-access .lbl { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-3); }
-.ki-access .v { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-1); display:flex; gap:4px; flex-wrap:wrap; align-items:center; }
+.ki-access .row { display:grid; grid-template-columns:130px 1fr; gap:8px; padding:4px 8px; background:var(--color-bg-surface); border:1px solid var(--color-border-default); align-items:center; }
+.ki-access .lbl { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-fg-muted); }
+.ki-access .v { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--color-fg-primary); display:flex; gap:4px; flex-wrap:wrap; align-items:center; }
 .ki-access .on { color:var(--ok-fg); }
 .ki-access .off { color:var(--err-fg); }
-.ki-access .mention { font-size:var(--fs-10); padding:1px 5px; background:var(--bg-2); border:1px solid var(--line-1); color:var(--fg-2); }
+.ki-access .mention { font-size:var(--fs-10); padding:1px 5px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-default); color:var(--color-fg-secondary); }
 
-.ki-stats .hdr { display:grid; grid-template-columns:120px 72px 72px 1fr; gap:6px; padding:3px 8px; background:var(--bg-2); border:1px solid var(--line-2); font-family:var(--font-mono); font-size:var(--fs-9); color:var(--fg-4); letter-spacing:.08em; text-transform:uppercase; margin-bottom:1px; }
-.ki-stats .row { display:grid; grid-template-columns:120px 72px 72px 1fr; gap:6px; align-items:center; padding:4px 8px; background:var(--bg-1); border:1px solid var(--line-1); margin-bottom:1px; }
-.ki-stats .ag { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--brass-1); }
-.ki-stats .num { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-2); font-variant-numeric:tabular-nums; }
-.ki-stats .bar { height:8px; background:var(--bg-2); border:1px solid var(--line-1); }
-.ki-stats .bar i { display:block; height:100%; background:linear-gradient(90deg, var(--brass-3), var(--brass-1)); }
+.ki-stats .hdr { display:grid; grid-template-columns:120px 72px 72px 1fr; gap:6px; padding:3px 8px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-strong); font-family:var(--font-mono); font-size:var(--fs-9); color:var(--color-fg-disabled); letter-spacing:.08em; text-transform:uppercase; margin-bottom:1px; }
+.ki-stats .row { display:grid; grid-template-columns:120px 72px 72px 1fr; gap:6px; align-items:center; padding:4px 8px; background:var(--color-bg-surface); border:1px solid var(--color-border-default); margin-bottom:1px; }
+.ki-stats .ag { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--color-accent-fg); }
+.ki-stats .num { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-fg-secondary); font-variant-numeric:tabular-nums; }
+.ki-stats .bar { height:8px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-default); }
+.ki-stats .bar i { display:block; height:100%; background:linear-gradient(90deg, var(--color-accent-fg-dim), var(--color-accent-fg)); }
 
 /* ───── K2 · Decisions / Memory ───── */
-.dec-row { display:grid; grid-template-columns:68px 90px 60px 1fr; gap:6px; align-items:flex-start; padding:6px 8px; background:var(--bg-1); border-bottom:1px solid var(--line-1); }
-.dec-row:first-child { border-top:1px solid var(--line-2); }
-.dec-row:last-child  { border-bottom:1px solid var(--line-2); }
-.dec-row .ts  { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-4); }
-.dec-row .kpr { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--brass-1); }
-.dec-row .out { font-family:var(--font-mono); font-size:var(--fs-9); padding:1px 4px; border:1px solid var(--line-2); text-transform:uppercase; letter-spacing:.06em; white-space:nowrap; align-self:flex-start; }
+.dec-row { display:grid; grid-template-columns:68px 90px 60px 1fr; gap:6px; align-items:flex-start; padding:6px 8px; background:var(--color-bg-surface); border-bottom:1px solid var(--color-border-default); }
+.dec-row:first-child { border-top:1px solid var(--color-border-strong); }
+.dec-row:last-child  { border-bottom:1px solid var(--color-border-strong); }
+.dec-row .ts  { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-fg-disabled); }
+.dec-row .kpr { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-accent-fg); }
+.dec-row .out { font-family:var(--font-mono); font-size:var(--fs-9); padding:1px 4px; border:1px solid var(--color-border-strong); text-transform:uppercase; letter-spacing:.06em; white-space:nowrap; align-self:flex-start; }
 .dec-row .out.success { color:var(--ok-fg); border-color:var(--ok-border); background:var(--ok-bg); }
 .dec-row .out.error   { color:var(--err-fg); border-color:var(--err-border); background:var(--err-bg); }
 .dec-row .out.failure { color:var(--err-fg); border-color:var(--err-border); background:var(--err-bg); }
 .dec-row .body { display:flex; flex-direction:column; gap:2px; }
-.dec-row .body .act { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-1); }
+.dec-row .body .act { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--color-fg-primary); }
 .dec-row .body .blk { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--err-fg); }
-.dec-row .body .bel { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-3); }
-.dec-row .body .lat { font-family:var(--font-mono); font-size:var(--fs-9); color:var(--fg-4); }
+.dec-row .body .bel { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-fg-muted); }
+.dec-row .body .lat { font-family:var(--font-mono); font-size:var(--fs-9); color:var(--color-fg-disabled); }
 
-.mem-row { display:grid; grid-template-columns:68px 90px 68px 1fr; gap:6px; align-items:flex-start; padding:5px 8px; background:var(--bg-1); border-bottom:1px solid var(--line-1); }
-.mem-row:first-child { border-top:1px solid var(--line-2); }
-.mem-row:last-child  { border-bottom:1px solid var(--line-2); }
-.mem-row .ts  { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-4); }
-.mem-row .kpr { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--brass-1); }
-.mem-row .tag { font-family:var(--font-mono); font-size:var(--fs-9); padding:1px 4px; text-transform:uppercase; letter-spacing:.06em; border:1px solid var(--line-2); align-self:flex-start; }
+.mem-row { display:grid; grid-template-columns:68px 90px 68px 1fr; gap:6px; align-items:flex-start; padding:5px 8px; background:var(--color-bg-surface); border-bottom:1px solid var(--color-border-default); }
+.mem-row:first-child { border-top:1px solid var(--color-border-strong); }
+.mem-row:last-child  { border-bottom:1px solid var(--color-border-strong); }
+.mem-row .ts  { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-fg-disabled); }
+.mem-row .kpr { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-accent-fg); }
+.mem-row .tag { font-family:var(--font-mono); font-size:var(--fs-9); padding:1px 4px; text-transform:uppercase; letter-spacing:.06em; border:1px solid var(--color-border-strong); align-self:flex-start; }
 .mem-row .tag.verified { color:var(--ok-fg); border-color:var(--ok-border); background:var(--ok-bg); }
 .mem-row .tag.learned  { color:var(--info); border-color:var(--info); }
-.mem-row .tag.observed { color:var(--fg-2); border-color:var(--line-2); }
-.mem-row .tag.plan     { color:var(--brass-1); border-color:var(--brass-3); background:rgb(var(--brass-glow)/.08); }
-.mem-row .body { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-1); line-height:1.4; }
+.mem-row .tag.observed { color:var(--color-fg-secondary); border-color:var(--color-border-strong); }
+.mem-row .tag.plan     { color:var(--color-accent-fg); border-color:var(--color-accent-fg-dim); background:rgb(var(--color-accent-glow)/.08); }
+.mem-row .body { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--color-fg-primary); line-height:1.4; }
 
 /* ───── K3 · Institution Episodes ───── */
-.ep-card { padding:8px 10px; background:var(--bg-1); border:1px solid var(--line-2); margin-bottom:4px; }
+.ep-card { padding:8px 10px; background:var(--color-bg-surface); border:1px solid var(--color-border-strong); margin-bottom:4px; }
 .ep-card:last-child { margin-bottom:0; }
 .ep-card .h { display:flex; align-items:center; gap:8px; margin-bottom:4px; flex-wrap:wrap; }
-.ep-card .id { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--brass-1); }
-.ep-card .ts { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-4); }
+.ep-card .id { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--color-accent-fg); }
+.ep-card .ts { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-fg-disabled); }
 .ep-card .pp { display:flex; gap:3px; flex-wrap:wrap; }
-.ep-card .pp .p { font-family:var(--font-mono); font-size:var(--fs-10); padding:1px 5px; background:var(--bg-2); border:1px solid var(--line-1); color:var(--fg-2); }
-.ep-card .sm { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-2); margin-bottom:6px; line-height:1.4; }
+.ep-card .pp .p { font-family:var(--font-mono); font-size:var(--fs-10); padding:1px 5px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-default); color:var(--color-fg-secondary); }
+.ep-card .sm { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--color-fg-secondary); margin-bottom:6px; line-height:1.4; }
 .ep-card .lns { display:flex; flex-direction:column; gap:2px; }
-.ep-card .ln { display:flex; gap:6px; font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-3); align-items:flex-start; padding:2px 0; }
-.ep-card .ln::before { content:"·"; color:var(--brass-1); flex-shrink:0; }
+.ep-card .ln { display:flex; gap:6px; font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-fg-muted); align-items:flex-start; padding:2px 0; }
+.ep-card .ln::before { content:"·"; color:var(--color-accent-fg); flex-shrink:0; }
 .ep-card .oc { font-family:var(--font-mono); font-size:var(--fs-9); padding:1px 5px; text-transform:uppercase; letter-spacing:.06em; color:var(--ok-fg); border:1px solid var(--ok-border); background:var(--ok-bg); white-space:nowrap; }
 
 .ep-learn .grp { margin-bottom:6px; }
-.ep-learn .grp-h { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--fg-4); padding:3px 8px; background:var(--bg-2); border:1px solid var(--line-1); margin-bottom:2px; display:flex; gap:8px; }
-.ep-learn .item { display:flex; gap:8px; padding:4px 8px; background:var(--bg-1); border:1px solid var(--line-1); border-left:2px solid var(--brass-3); font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-2); line-height:1.4; margin-bottom:1px; }
-.ep-learn .item::before { content:"▸"; color:var(--brass-1); flex-shrink:0; }
+.ep-learn .grp-h { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--color-fg-disabled); padding:3px 8px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-default); margin-bottom:2px; display:flex; gap:8px; }
+.ep-learn .item { display:flex; gap:8px; padding:4px 8px; background:var(--color-bg-surface); border:1px solid var(--color-border-default); border-left:2px solid var(--color-accent-fg-dim); font-family:var(--font-mono); font-size:var(--fs-11); color:var(--color-fg-secondary); line-height:1.4; margin-bottom:1px; }
+.ep-learn .item::before { content:"▸"; color:var(--color-accent-fg); flex-shrink:0; }
 
 /* ───── K4 · Autoresearch ───── */
-.ar-row { display:grid; grid-template-columns:88px 1fr auto 56px; gap:8px; align-items:center; padding:6px 8px; border-bottom:1px solid var(--line-1); background:var(--bg-1); }
-.ar-row:first-child { border-top:1px solid var(--line-2); }
-.ar-row:last-child  { border-bottom:1px solid var(--line-2); }
-.ar-row .id    { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--brass-1); white-space:nowrap; }
-.ar-row .topic { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-1); }
-.ar-row .st    { font-family:var(--font-mono); font-size:var(--fs-9); padding:1px 5px; text-transform:uppercase; letter-spacing:.06em; border:1px solid var(--line-2); white-space:nowrap; }
-.ar-row .st.open   { color:var(--brass-1); border-color:var(--brass-3); background:rgb(var(--brass-glow)/.08); }
+.ar-row { display:grid; grid-template-columns:88px 1fr auto 56px; gap:8px; align-items:center; padding:6px 8px; border-bottom:1px solid var(--color-border-default); background:var(--color-bg-surface); }
+.ar-row:first-child { border-top:1px solid var(--color-border-strong); }
+.ar-row:last-child  { border-bottom:1px solid var(--color-border-strong); }
+.ar-row .id    { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-accent-fg); white-space:nowrap; }
+.ar-row .topic { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--color-fg-primary); }
+.ar-row .st    { font-family:var(--font-mono); font-size:var(--fs-9); padding:1px 5px; text-transform:uppercase; letter-spacing:.06em; border:1px solid var(--color-border-strong); white-space:nowrap; }
+.ar-row .st.open   { color:var(--color-accent-fg); border-color:var(--color-accent-fg-dim); background:rgb(var(--color-accent-glow)/.08); }
 .ar-row .st.closed { color:var(--ok-fg); border-color:var(--ok-border); background:var(--ok-bg); }
 .ar-row .conf  { font-family:var(--font-mono); font-size:var(--fs-11); font-variant-numeric:tabular-nums; text-align:right; }
 .ar-row .conf.hi  { color:var(--ok-fg); }
 .ar-row .conf.lo  { color:var(--warn); }
 .ar-row .conf.vlo { color:var(--err-fg); }
 
-.ar-find { padding:10px; background:var(--bg-1); border:1px solid var(--line-2); display:flex; flex-direction:column; gap:6px; }
+.ar-find { padding:10px; background:var(--color-bg-surface); border:1px solid var(--color-border-strong); display:flex; flex-direction:column; gap:6px; }
 .ar-find .hdr { display:flex; align-items:center; gap:8px; }
-.ar-find .hdr .id   { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--brass-1); }
-.ar-find .hdr .loop { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-3); }
+.ar-find .hdr .id   { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--color-accent-fg); }
+.ar-find .hdr .loop { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-fg-muted); }
 .ar-find .hdr .conf { font-family:var(--font-mono); font-size:var(--fs-10); padding:1px 6px; background:var(--ok-bg); border:1px solid var(--ok-border); color:var(--ok-fg); margin-left:auto; }
-.ar-find .sec-h { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--fg-4); margin-bottom:2px; }
-.ar-find .hy  { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-1); line-height:1.45; padding:5px 8px; background:var(--bg-2); border:1px solid var(--line-1); border-left:2px solid var(--brass-1); }
+.ar-find .sec-h { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--color-fg-disabled); margin-bottom:2px; }
+.ar-find .hy  { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--color-fg-primary); line-height:1.45; padding:5px 8px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-default); border-left:2px solid var(--color-accent-fg); }
 .ar-find .ev-list { display:flex; flex-direction:column; gap:2px; }
-.ar-find .ev  { display:flex; gap:6px; font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-2); padding:3px 8px; background:var(--bg-0); border:1px solid var(--line-1); }
-.ar-find .ev::before { content:"▸"; color:var(--brass-1); flex-shrink:0; }
+.ar-find .ev  { display:flex; gap:6px; font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-fg-secondary); padding:3px 8px; background:var(--color-bg-page); border:1px solid var(--color-border-default); }
+.ar-find .ev::before { content:"▸"; color:var(--color-accent-fg); flex-shrink:0; }
 .ar-find .co  { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--ok-fg); line-height:1.45; padding:5px 8px; background:var(--ok-bg); border:1px solid var(--ok-border); border-left:2px solid var(--ok-fg); }
 
 .ar-flow { display:flex; flex-direction:column; gap:0; }
-.ar-flow .step { display:flex; flex-direction:column; gap:4px; padding:10px; background:var(--bg-1); border:1px solid var(--line-2); }
+.ar-flow .step { display:flex; flex-direction:column; gap:4px; padding:10px; background:var(--color-bg-surface); border:1px solid var(--color-border-strong); }
 .ar-flow .step + .step { border-top:0; }
 .ar-flow .step-h { display:flex; align-items:center; gap:8px; margin-bottom:4px; }
-.ar-flow .step-n { display:flex; align-items:center; justify-content:center; width:18px; height:18px; background:var(--brass-3); color:var(--brass-1); font-family:var(--font-mono); font-size:var(--fs-9); font-weight:700; flex-shrink:0; }
-.ar-flow .step-t { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--fg-4); }
-.ar-flow .step-body { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-1); line-height:1.45; }
-.ar-flow .ev  { display:flex; gap:6px; font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-2); padding:3px 8px; background:var(--bg-0); border:1px solid var(--line-1); margin-bottom:2px; }
-.ar-flow .ev::before { content:"▸"; color:var(--brass-1); flex-shrink:0; }
+.ar-flow .step-n { display:flex; align-items:center; justify-content:center; width:18px; height:18px; background:var(--color-accent-fg-dim); color:var(--color-accent-fg); font-family:var(--font-mono); font-size:var(--fs-9); font-weight:700; flex-shrink:0; }
+.ar-flow .step-t { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--color-fg-disabled); }
+.ar-flow .step-body { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--color-fg-primary); line-height:1.45; }
+.ar-flow .ev  { display:flex; gap:6px; font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-fg-secondary); padding:3px 8px; background:var(--color-bg-page); border:1px solid var(--color-border-default); margin-bottom:2px; }
+.ar-flow .ev::before { content:"▸"; color:var(--color-accent-fg); flex-shrink:0; }
 .ar-flow .ar-con { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--ok-fg); line-height:1.45; padding:5px 8px; background:var(--ok-bg); border:1px solid var(--ok-border); border-left:2px solid var(--ok-fg); }
-.ar-flow .connector { display:flex; align-items:center; justify-content:center; height:18px; color:var(--brass-3); font-size:14px; background:var(--bg-0); border-left:1px solid var(--line-2); border-right:1px solid var(--line-2); }
+.ar-flow .connector { display:flex; align-items:center; justify-content:center; height:18px; color:var(--color-accent-fg-dim); font-size:14px; background:var(--color-bg-page); border-left:1px solid var(--color-border-strong); border-right:1px solid var(--color-border-strong); }
 
 /* ═══════════════════════════════════════════════════
    I0 · IDE BACKBONE  (branches · keepers · operator nudges)
    ═══════════════════════════════════════════════════ */
 
 /* Branch selector */
-.br-bar { display:flex; align-items:center; gap:8px; padding:5px 10px; background:linear-gradient(to bottom, var(--bg-1), var(--bg-0)); border:1px solid var(--line-2); }
-.br-bar .lbl { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--fg-4); }
-.br-bar .sel { display:flex; align-items:center; gap:6px; padding:3px 8px; background:var(--bg-2); border:1px solid var(--line-1); cursor:pointer; }
-.br-bar .sel::before { content:"⎇"; color:var(--fg-4); }
-.br-bar .sel .nm { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--brass-1); }
-.br-bar .sel .ca { color:var(--fg-4); font-size:9px; margin-left:2px; }
-.br-bar .meta { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-3); display:flex; gap:8px; align-items:center; }
+.br-bar { display:flex; align-items:center; gap:8px; padding:5px 10px; background:linear-gradient(to bottom, var(--color-bg-surface), var(--color-bg-page)); border:1px solid var(--color-border-strong); }
+.br-bar .lbl { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--color-fg-disabled); }
+.br-bar .sel { display:flex; align-items:center; gap:6px; padding:3px 8px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-default); cursor:pointer; }
+.br-bar .sel::before { content:"⎇"; color:var(--color-fg-disabled); }
+.br-bar .sel .nm { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--color-accent-fg); }
+.br-bar .sel .ca { color:var(--color-fg-disabled); font-size:9px; margin-left:2px; }
+.br-bar .meta { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-fg-muted); display:flex; gap:8px; align-items:center; }
 .br-bar .meta .ah { color:var(--ok-fg); }
 .br-bar .meta .bh { color:var(--warn); }
-.br-bar .meta .head { color:var(--fg-4); }
+.br-bar .meta .head { color:var(--color-fg-disabled); }
 
 .br-list { display:flex; flex-direction:column; gap:1px; }
-.br-list .row { display:grid; grid-template-columns:auto 1fr auto auto auto; gap:8px; align-items:center; padding:6px 10px; background:var(--bg-1); border:1px solid var(--line-1); cursor:pointer; }
-.br-list .row.on { background:var(--bg-2); border-color:var(--brass-3); border-left:2px solid var(--brass-1); padding-left:9px; }
-.br-list .row:hover { background:var(--bg-2); }
-.br-list .row .glyph { color:var(--fg-4); font-family:var(--font-mono); font-size:var(--fs-13); }
-.br-list .row.on .glyph { color:var(--brass-1); }
-.br-list .row .nm { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-1); display:flex; gap:6px; align-items:center; }
-.br-list .row .tag { font-family:var(--font-mono); font-size:var(--fs-9); padding:1px 5px; letter-spacing:.06em; border:1px solid var(--line-2); color:var(--fg-3); }
-.br-list .row .tag.PRIMARY      { color:var(--brass-1); border-color:var(--brass-3); background:rgb(var(--brass-glow)/.08); }
+.br-list .row { display:grid; grid-template-columns:auto 1fr auto auto auto; gap:8px; align-items:center; padding:6px 10px; background:var(--color-bg-surface); border:1px solid var(--color-border-default); cursor:pointer; }
+.br-list .row.on { background:var(--color-bg-panel-alt); border-color:var(--color-accent-fg-dim); border-left:2px solid var(--color-accent-fg); padding-left:9px; }
+.br-list .row:hover { background:var(--color-bg-panel-alt); }
+.br-list .row .glyph { color:var(--color-fg-disabled); font-family:var(--font-mono); font-size:var(--fs-13); }
+.br-list .row.on .glyph { color:var(--color-accent-fg); }
+.br-list .row .nm { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--color-fg-primary); display:flex; gap:6px; align-items:center; }
+.br-list .row .tag { font-family:var(--font-mono); font-size:var(--fs-9); padding:1px 5px; letter-spacing:.06em; border:1px solid var(--color-border-strong); color:var(--color-fg-muted); }
+.br-list .row .tag.PRIMARY      { color:var(--color-accent-fg); border-color:var(--color-accent-fg-dim); background:rgb(var(--color-accent-glow)/.08); }
 .br-list .row .tag.RELEASE      { color:var(--ok-fg); border-color:var(--ok-border); background:var(--ok-bg); }
 .br-list .row .tag.FEATURE      { color:var(--info); border-color:var(--info); }
 .br-list .row .tag.FIX          { color:var(--warn); border-color:var(--warn); }
-.br-list .row .tag.WORKTREE     { color:var(--fg-2); }
-.br-list .row .tag.AUTORESEARCH { color:var(--brass-1); border-color:var(--line-2); border-style:dashed; }
-.br-list .row .st { font-family:var(--font-mono); font-size:var(--fs-9); padding:1px 5px; text-transform:uppercase; letter-spacing:.06em; border:1px solid var(--line-2); }
+.br-list .row .tag.WORKTREE     { color:var(--color-fg-secondary); }
+.br-list .row .tag.AUTORESEARCH { color:var(--color-accent-fg); border-color:var(--color-border-strong); border-style:dashed; }
+.br-list .row .st { font-family:var(--font-mono); font-size:var(--fs-9); padding:1px 5px; text-transform:uppercase; letter-spacing:.06em; border:1px solid var(--color-border-strong); }
 .br-list .row .st.clean    { color:var(--ok-fg); border-color:var(--ok-border); background:var(--ok-bg); }
 .br-list .row .st.dirty    { color:var(--warn); border-color:var(--warn); }
 .br-list .row .st.stale    { color:var(--err-fg); border-color:var(--err-border); background:var(--err-bg); }
-.br-list .row .st.research { color:var(--brass-1); border-color:var(--brass-3); }
-.br-list .row .ahbh { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-3); display:flex; gap:6px; }
+.br-list .row .st.research { color:var(--color-accent-fg); border-color:var(--color-accent-fg-dim); }
+.br-list .row .ahbh { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-fg-muted); display:flex; gap:6px; }
 .br-list .row .ahbh .ah { color:var(--ok-fg); }
 .br-list .row .ahbh .bh { color:var(--warn); }
-.br-list .row .head { font-family:var(--font-mono); font-size:var(--fs-9); color:var(--fg-4); }
+.br-list .row .head { font-family:var(--font-mono); font-size:var(--fs-9); color:var(--color-fg-disabled); }
 .br-list .row .keepers { display:flex; gap:-2px; }
-.br-list .row .keepers .k { display:inline-block; width:16px; height:16px; border-radius:50%; border:1px solid var(--bg-1); margin-left:-4px; }
+.br-list .row .keepers .k { display:inline-block; width:16px; height:16px; border-radius:50%; border:1px solid var(--color-bg-surface); margin-left:-4px; }
 .br-list .row .keepers .k:first-child { margin-left:0; }
 
 /* Keeper multi-select */
 .km-bar { display:flex; flex-direction:column; gap:6px; }
-.km-bar .h { display:flex; align-items:center; gap:8px; padding:5px 10px; background:var(--bg-2); border:1px solid var(--line-2); }
-.km-bar .h .lbl { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--fg-4); }
-.km-bar .h .cnt { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--brass-1); margin-left:auto; }
-.km-bar .h .clr { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-3); cursor:pointer; padding:1px 6px; border:1px solid var(--line-1); background:var(--bg-1); }
-.km-bar .h .clr:hover { color:var(--fg-1); }
-.km-chips { display:flex; flex-wrap:wrap; gap:4px; padding:8px 10px; background:var(--bg-1); border:1px solid var(--line-1); }
-.km-chip { display:inline-flex; align-items:center; gap:6px; padding:3px 8px; background:var(--bg-2); border:1px solid var(--line-1); cursor:pointer; font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-3); }
-.km-chip:hover { background:var(--bg-3); color:var(--fg-1); }
-.km-chip.on { background:rgb(var(--brass-glow)/.12); border-color:var(--brass-3); color:var(--brass-1); }
-.km-chip .role { font-size:var(--fs-9); color:var(--fg-4); letter-spacing:.04em; }
-.km-chip.on .role { color:var(--brass-3); }
-.km-chip .x { color:var(--fg-4); margin-left:2px; }
-.km-chip.on .x { color:var(--brass-1); }
+.km-bar .h { display:flex; align-items:center; gap:8px; padding:5px 10px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-strong); }
+.km-bar .h .lbl { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--color-fg-disabled); }
+.km-bar .h .cnt { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-accent-fg); margin-left:auto; }
+.km-bar .h .clr { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-fg-muted); cursor:pointer; padding:1px 6px; border:1px solid var(--color-border-default); background:var(--color-bg-surface); }
+.km-bar .h .clr:hover { color:var(--color-fg-primary); }
+.km-chips { display:flex; flex-wrap:wrap; gap:4px; padding:8px 10px; background:var(--color-bg-surface); border:1px solid var(--color-border-default); }
+.km-chip { display:inline-flex; align-items:center; gap:6px; padding:3px 8px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-default); cursor:pointer; font-family:var(--font-mono); font-size:var(--fs-11); color:var(--color-fg-muted); }
+.km-chip:hover { background:var(--color-bg-elevated); color:var(--color-fg-primary); }
+.km-chip.on { background:rgb(var(--color-accent-glow)/.12); border-color:var(--color-accent-fg-dim); color:var(--color-accent-fg); }
+.km-chip .role { font-size:var(--fs-9); color:var(--color-fg-disabled); letter-spacing:.04em; }
+.km-chip.on .role { color:var(--color-accent-fg-dim); }
+.km-chip .x { color:var(--color-fg-disabled); margin-left:2px; }
+.km-chip.on .x { color:var(--color-accent-fg); }
 
 /* Operator nudge log */
-.nd-row { display:grid; grid-template-columns:64px 80px auto 1fr auto; gap:8px; align-items:flex-start; padding:6px 10px; background:var(--bg-1); border-bottom:1px solid var(--line-1); }
-.nd-row:first-child { border-top:1px solid var(--line-2); }
-.nd-row:last-child  { border-bottom:1px solid var(--line-2); }
-.nd-row .ts { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-4); }
-.nd-row .ch { font-family:var(--font-mono); font-size:var(--fs-9); padding:1px 5px; text-transform:uppercase; letter-spacing:.06em; border:1px solid var(--line-2); white-space:nowrap; align-self:flex-start; }
-.nd-row .ch.hint     { color:var(--brass-1); border-color:var(--brass-3); background:rgb(var(--brass-glow)/.08); }
+.nd-row { display:grid; grid-template-columns:64px 80px auto 1fr auto; gap:8px; align-items:flex-start; padding:6px 10px; background:var(--color-bg-surface); border-bottom:1px solid var(--color-border-default); }
+.nd-row:first-child { border-top:1px solid var(--color-border-strong); }
+.nd-row:last-child  { border-bottom:1px solid var(--color-border-strong); }
+.nd-row .ts { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-fg-disabled); }
+.nd-row .ch { font-family:var(--font-mono); font-size:var(--fs-9); padding:1px 5px; text-transform:uppercase; letter-spacing:.06em; border:1px solid var(--color-border-strong); white-space:nowrap; align-self:flex-start; }
+.nd-row .ch.hint     { color:var(--color-accent-fg); border-color:var(--color-accent-fg-dim); background:rgb(var(--color-accent-glow)/.08); }
 .nd-row .ch.approve  { color:var(--ok-fg); border-color:var(--ok-border); background:var(--ok-bg); }
 .nd-row .ch.reject   { color:var(--err-fg); border-color:var(--err-border); background:var(--err-bg); }
 .nd-row .ch.redirect { color:var(--info); border-color:var(--info); }
 .nd-row .to { display:flex; gap:3px; flex-wrap:wrap; align-items:center; }
-.nd-row .to .k { font-family:var(--font-mono); font-size:var(--fs-10); padding:1px 5px; background:var(--bg-2); border:1px solid var(--line-1); color:var(--brass-1); }
-.nd-row .body { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-1); line-height:1.4; }
+.nd-row .to .k { font-family:var(--font-mono); font-size:var(--fs-10); padding:1px 5px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-default); color:var(--color-accent-fg); }
+.nd-row .body { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--color-fg-primary); line-height:1.4; }
 .nd-row .ack { font-family:var(--font-mono); font-size:var(--fs-9); padding:1px 5px; text-transform:uppercase; letter-spacing:.06em; align-self:flex-start; }
 .nd-row .ack.y { color:var(--ok-fg); }
 .nd-row .ack.n { color:var(--warn); }
 
-.nd-compose { display:flex; flex-direction:column; gap:6px; padding:10px; background:var(--bg-2); border:1px solid var(--line-2); margin-top:8px; }
+.nd-compose { display:flex; flex-direction:column; gap:6px; padding:10px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-strong); margin-top:8px; }
 .nd-compose .h { display:flex; align-items:center; gap:8px; }
-.nd-compose .h .lbl { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--fg-4); }
+.nd-compose .h .lbl { font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.12em; text-transform:uppercase; color:var(--color-fg-disabled); }
 .nd-compose .channels { display:flex; gap:2px; margin-left:auto; }
-.nd-compose .channels button { padding:2px 8px; font-family:var(--font-mono); font-size:var(--fs-10); text-transform:uppercase; letter-spacing:.06em; border:1px solid var(--line-1); background:var(--bg-1); color:var(--fg-3); cursor:pointer; }
-.nd-compose .channels button.on { background:var(--brass-3); border-color:var(--brass-1); color:var(--brass-1); }
-.nd-compose textarea { width:100%; min-height:50px; resize:vertical; padding:6px 8px; background:var(--bg-1); border:1px solid var(--line-1); color:var(--fg-1); font-family:var(--font-mono); font-size:var(--fs-11); box-sizing:border-box; }
-.nd-compose textarea:focus { outline:none; border-color:var(--brass-1); }
+.nd-compose .channels button { padding:2px 8px; font-family:var(--font-mono); font-size:var(--fs-10); text-transform:uppercase; letter-spacing:.06em; border:1px solid var(--color-border-default); background:var(--color-bg-surface); color:var(--color-fg-muted); cursor:pointer; }
+.nd-compose .channels button.on { background:var(--color-accent-fg-dim); border-color:var(--color-accent-fg); color:var(--color-accent-fg); }
+.nd-compose textarea { width:100%; min-height:50px; resize:vertical; padding:6px 8px; background:var(--color-bg-surface); border:1px solid var(--color-border-default); color:var(--color-fg-primary); font-family:var(--font-mono); font-size:var(--fs-11); box-sizing:border-box; }
+.nd-compose textarea:focus { outline:none; border-color:var(--color-accent-fg); }
 .nd-compose .ft { display:flex; gap:8px; align-items:center; }
-.nd-compose .ft .targets { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--fg-3); }
-.nd-compose .ft .send { margin-left:auto; padding:4px 12px; background:var(--brass-3); border:1px solid var(--brass-1); color:var(--brass-1); font-family:var(--font-mono); font-size:var(--fs-10); text-transform:uppercase; letter-spacing:.08em; cursor:pointer; }
-.nd-compose .ft .send:hover { background:var(--brass-2); color:var(--bg-0); }
+.nd-compose .ft .targets { font-family:var(--font-mono); font-size:var(--fs-10); color:var(--color-fg-muted); }
+.nd-compose .ft .send { margin-left:auto; padding:4px 12px; background:var(--color-accent-fg-dim); border:1px solid var(--color-accent-fg); color:var(--color-accent-fg); font-family:var(--font-mono); font-size:var(--fs-10); text-transform:uppercase; letter-spacing:.08em; cursor:pointer; }
+.nd-compose .ft .send:hover { background:var(--brass-2); color:var(--color-bg-page); }
 
 /* ═══════════════════════════════════════════════════
    PHASE 3 · CODE IDE v2  (E1-E5)
    ═══════════════════════════════════════════════════ */
 
-.ix-head { display:flex; align-items:center; gap:8px; padding:5px 8px; min-height:24px; background:var(--bg-2); border:1px solid var(--line-2); color:var(--fg-2); font-family:var(--font-mono); font-size:var(--fs-10); }
-.ix-head-title { color:var(--fg-1); font-weight:600; letter-spacing:.04em; }
-.ix-head-meta { color:var(--fg-4); }
-.ix-head-right { margin-left:auto; color:var(--brass-1); display:inline-flex; align-items:center; gap:4px; }
-.ix-head-right button, .ix-sort button { padding:1px 6px; background:var(--bg-1); border:1px solid var(--line-1); color:var(--fg-3); font:inherit; cursor:pointer; }
-.ix-head-right button:hover, .ix-sort button:hover { color:var(--fg-1); }
+.ix-head { display:flex; align-items:center; gap:8px; padding:5px 8px; min-height:24px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-strong); color:var(--color-fg-secondary); font-family:var(--font-mono); font-size:var(--fs-10); }
+.ix-head-title { color:var(--color-fg-primary); font-weight:600; letter-spacing:.04em; }
+.ix-head-meta { color:var(--color-fg-disabled); }
+.ix-head-right { margin-left:auto; color:var(--color-accent-fg); display:inline-flex; align-items:center; gap:4px; }
+.ix-head-right button, .ix-sort button { padding:1px 6px; background:var(--color-bg-surface); border:1px solid var(--color-border-default); color:var(--color-fg-muted); font:inherit; cursor:pointer; }
+.ix-head-right button:hover, .ix-sort button:hover { color:var(--color-fg-primary); }
 .ix-sort { display:inline-flex; gap:2px; }
-.ix-sort button.on { color:var(--brass-1); border-color:var(--brass-3); background:rgb(var(--brass-glow)/.08); }
-.muted { color:var(--fg-4); }
+.ix-sort button.on { color:var(--color-accent-fg); border-color:var(--color-accent-fg-dim); background:rgb(var(--color-accent-glow)/.08); }
+.muted { color:var(--color-fg-disabled); }
 
-.ix-status { display:inline-flex; align-items:center; height:16px; padding:0 5px; border:1px solid var(--line-2); font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.06em; text-transform:uppercase; white-space:nowrap; }
+.ix-status { display:inline-flex; align-items:center; height:16px; padding:0 5px; border:1px solid var(--color-border-strong); font-family:var(--font-mono); font-size:var(--fs-9); letter-spacing:.06em; text-transform:uppercase; white-space:nowrap; }
 .ix-status.ok { color:var(--ok-fg); border-color:var(--ok-border); background:var(--ok-bg); }
 .ix-status.warn { color:var(--warn); border-color:var(--warn); background:rgb(201 162 74 / .08); }
 .ix-status.err { color:var(--err-fg); border-color:var(--err-border); background:var(--err-bg); }
-.ix-status.idle { color:var(--fg-3); border-color:var(--line-2); background:var(--bg-2); }
+.ix-status.idle { color:var(--color-fg-muted); border-color:var(--color-border-strong); background:var(--color-bg-panel-alt); }
 
 /* E1 · file tree */
-.ix-tree { display:flex; flex-direction:column; gap:6px; height:100%; min-height:0; background:var(--bg-0); color:var(--fg-1); overflow:hidden; }
-.ix-tree-keepers, .ix-edit-keepers, .ix-graph-filters { display:flex; flex-wrap:wrap; gap:3px; padding:6px 8px; background:var(--bg-1); border:1px solid var(--line-1); }
-.ix-tree-keepers button, .ix-edit-keepers button, .ix-graph-filters button { display:inline-flex; align-items:center; gap:5px; padding:2px 7px; background:var(--bg-2); border:1px solid var(--line-1); color:var(--fg-3); font-family:var(--font-mono); font-size:var(--fs-10); cursor:pointer; }
+.ix-tree { display:flex; flex-direction:column; gap:6px; height:100%; min-height:0; background:var(--color-bg-page); color:var(--color-fg-primary); overflow:hidden; }
+.ix-tree-keepers, .ix-edit-keepers, .ix-graph-filters { display:flex; flex-wrap:wrap; gap:3px; padding:6px 8px; background:var(--color-bg-surface); border:1px solid var(--color-border-default); }
+.ix-tree-keepers button, .ix-edit-keepers button, .ix-graph-filters button { display:inline-flex; align-items:center; gap:5px; padding:2px 7px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-default); color:var(--color-fg-muted); font-family:var(--font-mono); font-size:var(--fs-10); cursor:pointer; }
 .ix-tree-keepers button span, .ix-edit-keepers button span { width:7px; height:7px; border-radius:50%; }
-.ix-tree-keepers button.on, .ix-edit-keepers button.on, .ix-graph-filters button.on { color:var(--brass-1); border-color:var(--brass-3); background:rgb(var(--brass-glow)/.08); }
-.ix-tree-filter { display:grid; grid-template-columns:minmax(150px,1fr) repeat(6,auto); gap:3px; padding:6px 8px; background:var(--bg-1); border:1px solid var(--line-1); }
-.ix-tree-filter input, .ix-search-bar input, .ix-find input { min-width:0; padding:4px 7px; background:var(--bg-0); border:1px solid var(--line-1); color:var(--fg-1); font-family:var(--font-mono); font-size:var(--fs-11); }
-.ix-tree-filter button, .ix-search-bar button, .ix-find button { padding:3px 7px; background:var(--bg-2); border:1px solid var(--line-1); color:var(--fg-3); font-family:var(--font-mono); font-size:var(--fs-10); cursor:pointer; }
-.ix-tree-filter button.on, .ix-search-bar button.on { color:var(--brass-1); border-color:var(--brass-3); background:rgb(var(--brass-glow)/.08); }
-.ix-tree-tabs { display:flex; gap:2px; padding:0 8px; border-bottom:1px solid var(--line-2); }
-.ix-tree-tabs button { padding:5px 10px 4px; background:transparent; border:0; border-bottom:2px solid transparent; color:var(--fg-3); font-family:var(--font-mono); font-size:var(--fs-10); text-transform:uppercase; letter-spacing:.08em; cursor:pointer; }
-.ix-tree-tabs button.on { color:var(--brass-1); border-bottom-color:var(--brass-1); }
+.ix-tree-keepers button.on, .ix-edit-keepers button.on, .ix-graph-filters button.on { color:var(--color-accent-fg); border-color:var(--color-accent-fg-dim); background:rgb(var(--color-accent-glow)/.08); }
+.ix-tree-filter { display:grid; grid-template-columns:minmax(150px,1fr) repeat(6,auto); gap:3px; padding:6px 8px; background:var(--color-bg-surface); border:1px solid var(--color-border-default); }
+.ix-tree-filter input, .ix-search-bar input, .ix-find input { min-width:0; padding:4px 7px; background:var(--color-bg-page); border:1px solid var(--color-border-default); color:var(--color-fg-primary); font-family:var(--font-mono); font-size:var(--fs-11); }
+.ix-tree-filter button, .ix-search-bar button, .ix-find button { padding:3px 7px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-default); color:var(--color-fg-muted); font-family:var(--font-mono); font-size:var(--fs-10); cursor:pointer; }
+.ix-tree-filter button.on, .ix-search-bar button.on { color:var(--color-accent-fg); border-color:var(--color-accent-fg-dim); background:rgb(var(--color-accent-glow)/.08); }
+.ix-tree-tabs { display:flex; gap:2px; padding:0 8px; border-bottom:1px solid var(--color-border-strong); }
+.ix-tree-tabs button { padding:5px 10px 4px; background:transparent; border:0; border-bottom:2px solid transparent; color:var(--color-fg-muted); font-family:var(--font-mono); font-size:var(--fs-10); text-transform:uppercase; letter-spacing:.08em; cursor:pointer; }
+.ix-tree-tabs button.on { color:var(--color-accent-fg); border-bottom-color:var(--color-accent-fg); }
 .ix-tree-list { min-height:0; overflow:auto; display:flex; flex-direction:column; gap:1px; }
-.ix-tree-row { display:grid; grid-template-columns:22px minmax(0,1fr) auto auto; gap:7px; align-items:center; min-height:24px; padding:3px 8px; background:var(--bg-1); border:1px solid var(--line-1); border-left:2px solid var(--line-1); font-family:var(--font-mono); font-size:var(--fs-11); }
-.ix-tree-row.dir { background:var(--bg-2); border-left-color:var(--brass-3); }
+.ix-tree-row { display:grid; grid-template-columns:22px minmax(0,1fr) auto auto; gap:7px; align-items:center; min-height:24px; padding:3px 8px; background:var(--color-bg-surface); border:1px solid var(--color-border-default); border-left:2px solid var(--color-border-default); font-family:var(--font-mono); font-size:var(--fs-11); }
+.ix-tree-row.dir { background:var(--color-bg-panel-alt); border-left-color:var(--color-accent-fg-dim); }
 .ix-tree-row.added { border-left-color:var(--ok); }
 .ix-tree-row.modified { border-left-color:var(--info); }
 .ix-tree-row.deleted { border-left-color:var(--err); opacity:.86; }
-.ix-tree-row.unchanged { border-left-color:var(--line-2); color:var(--fg-3); }
+.ix-tree-row.unchanged { border-left-color:var(--color-border-strong); color:var(--color-fg-muted); }
 .ix-tree-row.dim { opacity:.35; }
-.ix-tree-icon { color:var(--fg-4); font-size:var(--fs-10); }
-.ix-tree-path { min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--fg-1); }
+.ix-tree-icon { color:var(--color-fg-disabled); font-size:var(--fs-10); }
+.ix-tree-path { min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--color-fg-primary); }
 .ix-kdots { display:inline-flex; align-items:center; min-width:36px; }
-.ix-kdots span { width:9px; height:9px; border-radius:50%; border:1px solid var(--bg-0); margin-left:-3px; }
+.ix-kdots span { width:9px; height:9px; border-radius:50%; border:1px solid var(--color-bg-page); margin-left:-3px; }
 .ix-kdots span:first-child { margin-left:0; }
 .ix-kdots.compact span { width:7px; height:7px; }
-.ix-tree-diff, .ix-tree-age { color:var(--fg-3); font-variant-numeric:tabular-nums; font-size:var(--fs-10); }
-.ix-tree-status { padding:1px 5px; border:1px solid var(--line-2); font-size:var(--fs-9); text-transform:uppercase; letter-spacing:.05em; }
+.ix-tree-diff, .ix-tree-age { color:var(--color-fg-muted); font-variant-numeric:tabular-nums; font-size:var(--fs-10); }
+.ix-tree-status { padding:1px 5px; border:1px solid var(--color-border-strong); font-size:var(--fs-9); text-transform:uppercase; letter-spacing:.05em; }
 .ix-tree-status.added { color:var(--ok-fg); border-color:var(--ok-border); background:var(--ok-bg); }
 .ix-tree-status.modified { color:var(--info); border-color:var(--info); }
 .ix-tree-status.deleted { color:var(--err-fg); border-color:var(--err-border); background:var(--err-bg); }
-.ix-tree-status.renamed, .ix-tree-status.unchanged { color:var(--fg-3); }
+.ix-tree-status.renamed, .ix-tree-status.unchanged { color:var(--color-fg-muted); }
 
 /* E2 · editor */
-.ix-edit { display:flex; flex-direction:column; gap:6px; height:100%; min-height:0; background:var(--bg-0); color:var(--fg-1); overflow:hidden; }
-.ix-edit-code { min-height:0; overflow:auto; background:var(--bg-1); border:1px solid var(--line-1); padding:4px 0; }
+.ix-edit { display:flex; flex-direction:column; gap:6px; height:100%; min-height:0; background:var(--color-bg-page); color:var(--color-fg-primary); overflow:hidden; }
+.ix-edit-code { min-height:0; overflow:auto; background:var(--color-bg-surface); border:1px solid var(--color-border-default); padding:4px 0; }
 .ix-edit-line { display:grid; grid-template-columns:30px 42px minmax(0,1fr); gap:6px; align-items:baseline; min-height:22px; padding:0 8px; font-family:var(--font-mono); font-size:var(--fs-12); line-height:1.45; border-left:2px solid transparent; }
 .ix-edit-line:hover { background:var(--hover-overlay); }
-.ix-edit-line.spot { background:rgb(var(--brass-glow)/.06); }
+.ix-edit-line.spot { background:rgb(var(--color-accent-glow)/.06); }
 .ix-edit-line.review-hot { background:var(--warn-bg, rgb(201 162 74 / .10)); border-left-color:var(--warn); }
-.ix-edit-attrib { height:16px; border-left:3px solid; padding-left:4px; font-size:var(--fs-9); color:var(--fg-3); }
-.ix-edit-num { color:var(--fg-4); text-align:right; font-size:var(--fs-10); font-variant-numeric:tabular-nums; }
-.ix-edit-src { min-width:0; overflow:hidden; white-space:pre; color:var(--fg-1); }
+.ix-edit-attrib { height:16px; border-left:3px solid; padding-left:4px; font-size:var(--fs-9); color:var(--color-fg-muted); }
+.ix-edit-num { color:var(--color-fg-disabled); text-align:right; font-size:var(--fs-10); font-variant-numeric:tabular-nums; }
+.ix-edit-src { min-width:0; overflow:hidden; white-space:pre; color:var(--color-fg-primary); }
 .ix-edit-split-grid { display:grid; grid-template-columns:1fr 1fr; gap:8px; min-height:0; flex:1; }
-.ix-edit-pane { min-width:0; display:flex; flex-direction:column; border:1px solid var(--line-2); background:var(--bg-1); }
-.ix-edit-bc { padding:4px 8px; background:var(--bg-2); border-bottom:1px solid var(--line-2); color:var(--fg-3); font-family:var(--font-mono); font-size:var(--fs-10); }
+.ix-edit-pane { min-width:0; display:flex; flex-direction:column; border:1px solid var(--color-border-strong); background:var(--color-bg-surface); }
+.ix-edit-bc { padding:4px 8px; background:var(--color-bg-panel-alt); border-bottom:1px solid var(--color-border-strong); color:var(--color-fg-muted); font-family:var(--font-mono); font-size:var(--fs-10); }
 .ix-edit-scroll { overflow:auto; min-height:0; max-height:310px; padding:4px 0; }
 .ix-edit-scroll .ix-edit-line { grid-template-columns:42px minmax(0,1fr); }
 .ix-merge-grid { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:1px; }
-.ix-merge-hdr span { padding:4px 8px; background:var(--bg-2); border:1px solid var(--line-2); color:var(--fg-4); font-family:var(--font-mono); font-size:var(--fs-9); text-transform:uppercase; letter-spacing:.08em; }
-.ix-merge-block { border:1px solid var(--line-2); background:var(--bg-1); }
-.ix-merge-file { padding:4px 8px; color:var(--brass-1); font-family:var(--font-mono); font-size:var(--fs-10); border-bottom:1px solid var(--line-1); }
-.ix-merge-block pre { margin:0; min-height:42px; padding:7px 8px; overflow:auto; background:var(--bg-0); border-right:1px solid var(--line-1); color:var(--fg-2); font-family:var(--font-mono); font-size:var(--fs-10); white-space:pre-wrap; }
+.ix-merge-hdr span { padding:4px 8px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-strong); color:var(--color-fg-disabled); font-family:var(--font-mono); font-size:var(--fs-9); text-transform:uppercase; letter-spacing:.08em; }
+.ix-merge-block { border:1px solid var(--color-border-strong); background:var(--color-bg-surface); }
+.ix-merge-file { padding:4px 8px; color:var(--color-accent-fg); font-family:var(--font-mono); font-size:var(--fs-10); border-bottom:1px solid var(--color-border-default); }
+.ix-merge-block pre { margin:0; min-height:42px; padding:7px 8px; overflow:auto; background:var(--color-bg-page); border-right:1px solid var(--color-border-default); color:var(--color-fg-secondary); font-family:var(--font-mono); font-size:var(--fs-10); white-space:pre-wrap; }
 .ix-merge-block pre.result { color:var(--ok-fg); background:var(--ok-bg); }
-.ix-merge-actions { display:flex; gap:3px; padding:5px 8px; background:var(--bg-2); }
-.ix-merge-actions button { padding:2px 8px; background:var(--bg-1); border:1px solid var(--line-1); color:var(--fg-3); font-family:var(--font-mono); font-size:var(--fs-10); cursor:pointer; }
-.ix-merge-actions button.on { color:var(--brass-1); border-color:var(--brass-3); }
+.ix-merge-actions { display:flex; gap:3px; padding:5px 8px; background:var(--color-bg-panel-alt); }
+.ix-merge-actions button { padding:2px 8px; background:var(--color-bg-surface); border:1px solid var(--color-border-default); color:var(--color-fg-muted); font-family:var(--font-mono); font-size:var(--fs-10); cursor:pointer; }
+.ix-merge-actions button.on { color:var(--color-accent-fg); border-color:var(--color-accent-fg-dim); }
 .ix-review-grid { display:grid; grid-template-columns:minmax(0,1fr) 260px; gap:8px; min-height:0; flex:1; }
 .ix-review-side { min-height:0; overflow:auto; display:flex; flex-direction:column; gap:5px; }
-.ix-review-thread { padding:7px 8px; background:var(--bg-1); border:1px solid var(--line-1); border-left:2px solid var(--line-2); }
+.ix-review-thread { padding:7px 8px; background:var(--color-bg-surface); border:1px solid var(--color-border-default); border-left:2px solid var(--color-border-strong); }
 .ix-review-thread.flag { border-left-color:var(--warn); }
 .ix-review-thread.approve { border-left-color:var(--ok); }
 .ix-review-thread.defer { border-left-color:var(--info); }
 .ix-review-thread .h { display:flex; align-items:center; gap:5px; margin-bottom:4px; font-family:var(--font-mono); font-size:var(--fs-10); }
-.ix-review-thread .ln { color:var(--brass-1); }
-.ix-review-thread .who { color:var(--fg-3); }
-.ix-review-thread .body { color:var(--fg-1); font-family:var(--font-mono); font-size:var(--fs-11); line-height:1.4; }
-.ix-review-thread .ft { margin-top:5px; color:var(--fg-4); font-family:var(--font-mono); font-size:var(--fs-9); text-transform:uppercase; letter-spacing:.05em; }
+.ix-review-thread .ln { color:var(--color-accent-fg); }
+.ix-review-thread .who { color:var(--color-fg-muted); }
+.ix-review-thread .body { color:var(--color-fg-primary); font-family:var(--font-mono); font-size:var(--fs-11); line-height:1.4; }
+.ix-review-thread .ft { margin-top:5px; color:var(--color-fg-disabled); font-family:var(--font-mono); font-size:var(--fs-9); text-transform:uppercase; letter-spacing:.05em; }
 .ix-blame .ix-edit-line { grid-template-columns:112px 42px minmax(0,1fr); }
-.ix-blame-cell { display:grid; grid-template-columns:44px 22px 32px; gap:4px; color:var(--fg-4); font-size:var(--fs-10); }
-.ix-blame-cell b { color:var(--fg-2); font-weight:400; }
+.ix-blame-cell { display:grid; grid-template-columns:44px 22px 32px; gap:4px; color:var(--color-fg-disabled); font-size:var(--fs-10); }
+.ix-blame-cell b { color:var(--color-fg-secondary); font-weight:400; }
 .ix-blame-cell i { font-style:normal; }
-.ix-blame-cell em { font-style:normal; color:var(--fg-4); }
-.ix-edit-line.age-fresh .ix-blame-cell b { color:var(--brass-1); }
+.ix-blame-cell em { font-style:normal; color:var(--color-fg-disabled); }
+.ix-edit-line.age-fresh .ix-blame-cell b { color:var(--color-accent-fg); }
 
 /* E3 · PR inspector */
-.ix-pr, .ix-graph, .ix-term, .ix-search { display:flex; flex-direction:column; gap:6px; height:100%; min-height:0; background:var(--bg-0); color:var(--fg-1); overflow:hidden; }
-.ix-pr-head { display:flex; flex-direction:column; gap:8px; padding:10px; background:var(--bg-1); border:1px solid var(--line-2); }
-.ix-pr-title { display:flex; align-items:center; gap:8px; font-size:var(--fs-14); color:var(--fg-1); }
-.ix-pr-title .num { color:var(--brass-1); font-family:var(--font-mono); }
+.ix-pr, .ix-graph, .ix-term, .ix-search { display:flex; flex-direction:column; gap:6px; height:100%; min-height:0; background:var(--color-bg-page); color:var(--color-fg-primary); overflow:hidden; }
+.ix-pr-head { display:flex; flex-direction:column; gap:8px; padding:10px; background:var(--color-bg-surface); border:1px solid var(--color-border-strong); }
+.ix-pr-title { display:flex; align-items:center; gap:8px; font-size:var(--fs-14); color:var(--color-fg-primary); }
+.ix-pr-title .num { color:var(--color-accent-fg); font-family:var(--font-mono); }
 .ix-pr-state { padding:1px 6px; border:1px solid var(--ok-border); background:var(--ok-bg); color:var(--ok-fg); font-family:var(--font-mono); font-size:var(--fs-9); text-transform:uppercase; letter-spacing:.08em; }
-.ix-pr-branches { display:flex; align-items:center; gap:7px; color:var(--fg-3); font-family:var(--font-mono); font-size:var(--fs-11); }
-.ix-pr-branches span { color:var(--fg-1); padding:2px 6px; background:var(--bg-2); border:1px solid var(--line-1); }
-.ix-pr-branches b { color:var(--fg-4); font-weight:400; }
-.ix-pr-branches em { margin-left:auto; color:var(--fg-4); font-style:normal; }
+.ix-pr-branches { display:flex; align-items:center; gap:7px; color:var(--color-fg-muted); font-family:var(--font-mono); font-size:var(--fs-11); }
+.ix-pr-branches span { color:var(--color-fg-primary); padding:2px 6px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-default); }
+.ix-pr-branches b { color:var(--color-fg-disabled); font-weight:400; }
+.ix-pr-branches em { margin-left:auto; color:var(--color-fg-disabled); font-style:normal; }
 .ix-pr-labels, .ix-pr-reviewers { display:flex; flex-wrap:wrap; gap:4px; }
-.ix-pr-labels span { padding:2px 6px; background:var(--bg-2); border:1px solid var(--line-1); color:var(--fg-3); font-family:var(--font-mono); font-size:var(--fs-10); }
-.ix-pr-reviewers span { display:inline-flex; align-items:center; gap:5px; padding:3px 6px; background:var(--bg-2); border:1px solid var(--line-1); font-family:var(--font-mono); font-size:var(--fs-10); }
-.ix-pr-reviewers i { display:inline-flex; align-items:center; justify-content:center; width:18px; height:18px; color:var(--bg-0); font-style:normal; font-size:var(--fs-9); border-radius:50%; }
-.ix-pr-reviewers b { color:var(--fg-2); font-weight:400; }
+.ix-pr-labels span { padding:2px 6px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-default); color:var(--color-fg-muted); font-family:var(--font-mono); font-size:var(--fs-10); }
+.ix-pr-reviewers span { display:inline-flex; align-items:center; gap:5px; padding:3px 6px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-default); font-family:var(--font-mono); font-size:var(--fs-10); }
+.ix-pr-reviewers i { display:inline-flex; align-items:center; justify-content:center; width:18px; height:18px; color:var(--color-bg-page); font-style:normal; font-size:var(--fs-9); border-radius:50%; }
+.ix-pr-reviewers b { color:var(--color-fg-secondary); font-weight:400; }
 .ix-pr-merge { display:flex; align-items:center; gap:8px; padding-top:2px; font-family:var(--font-mono); font-size:var(--fs-10); color:var(--warn); }
-.ix-pr-merge button { margin-left:auto; padding:4px 10px; background:var(--bg-2); border:1px solid var(--line-2); color:var(--fg-4); font:inherit; }
+.ix-pr-merge button { margin-left:auto; padding:4px 10px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-strong); color:var(--color-fg-disabled); font:inherit; }
 .ix-pr-files, .ix-pr-checks, .ix-pr-thread { min-height:0; overflow:auto; }
-.ix-pr-file, .ix-pr-check { background:var(--bg-1); border:1px solid var(--line-1); margin-bottom:2px; }
+.ix-pr-file, .ix-pr-check { background:var(--color-bg-surface); border:1px solid var(--color-border-default); margin-bottom:2px; }
 .ix-pr-file .row, .ix-pr-check .row { display:grid; grid-template-columns:20px minmax(0,1fr) 72px 64px 72px; gap:6px; align-items:center; padding:5px 8px; font-family:var(--font-mono); font-size:var(--fs-11); cursor:pointer; }
 .ix-pr-check .row { grid-template-columns:minmax(0,1fr) 70px 60px 36px; cursor:default; }
-.ix-pr-file .path, .ix-pr-check .name { min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--fg-1); }
-.ix-pr-file .tw { color:var(--fg-4); }
-.ix-pr-file .st, .ix-pr-file .rv { padding:1px 5px; border:1px solid var(--line-2); color:var(--fg-3); font-size:var(--fs-9); text-transform:uppercase; letter-spacing:.05em; }
+.ix-pr-file .path, .ix-pr-check .name { min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--color-fg-primary); }
+.ix-pr-file .tw { color:var(--color-fg-disabled); }
+.ix-pr-file .st, .ix-pr-file .rv { padding:1px 5px; border:1px solid var(--color-border-strong); color:var(--color-fg-muted); font-size:var(--fs-9); text-transform:uppercase; letter-spacing:.05em; }
 .ix-pr-file .st.added { color:var(--ok-fg); border-color:var(--ok-border); background:var(--ok-bg); }
 .ix-pr-file .st.deleted { color:var(--err-fg); border-color:var(--err-border); background:var(--err-bg); }
 .ix-pr-file .st.modified { color:var(--info); border-color:var(--info); }
-.ix-pr-file .diff { color:var(--fg-3); text-align:right; }
-.ix-pr-diff { margin:0; padding:8px 10px; color:var(--fg-2); background:var(--bg-0); border-top:1px solid var(--line-1); font-family:var(--font-mono); font-size:var(--fs-10); line-height:1.45; overflow:auto; }
-.ix-pr-thread { display:flex; flex-direction:column; gap:4px; padding:8px; background:var(--bg-1); border:1px solid var(--line-2); }
+.ix-pr-file .diff { color:var(--color-fg-muted); text-align:right; }
+.ix-pr-diff { margin:0; padding:8px 10px; color:var(--color-fg-secondary); background:var(--color-bg-page); border-top:1px solid var(--color-border-default); font-family:var(--font-mono); font-size:var(--fs-10); line-height:1.45; overflow:auto; }
+.ix-pr-thread { display:flex; flex-direction:column; gap:4px; padding:8px; background:var(--color-bg-surface); border:1px solid var(--color-border-strong); }
 .ix-pr-thread.resolved { opacity:.68; }
-.ix-pr-thread .msg { padding:7px 8px; background:var(--bg-2); border:1px solid var(--line-1); border-left:2px solid var(--brass-3); }
+.ix-pr-thread .msg { padding:7px 8px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-default); border-left:2px solid var(--color-accent-fg-dim); }
 .ix-pr-thread .msg.nested { margin-left:24px; border-left-color:var(--ok); }
 .ix-pr-thread .h { display:flex; gap:6px; align-items:center; margin-bottom:4px; font-family:var(--font-mono); font-size:var(--fs-10); }
-.ix-pr-thread .by { color:var(--brass-1); }
-.ix-pr-thread .at, .ix-pr-check .dur, .ix-pr-check .log { color:var(--fg-4); }
-.ix-pr-thread .body { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--fg-1); line-height:1.4; }
+.ix-pr-thread .by { color:var(--color-accent-fg); }
+.ix-pr-thread .at, .ix-pr-check .dur, .ix-pr-check .log { color:var(--color-fg-disabled); }
+.ix-pr-thread .body { font-family:var(--font-mono); font-size:var(--fs-11); color:var(--color-fg-primary); line-height:1.4; }
 .ix-pr-check .findings { display:flex; flex-direction:column; gap:2px; padding:0 8px 7px 8px; }
 .ix-pr-check .findings span { padding:3px 6px; background:var(--err-bg); border:1px solid var(--err-border); color:var(--err-fg); font-family:var(--font-mono); font-size:var(--fs-10); }
 
 /* E4 · graph */
-.ix-graph-dag { width:100%; height:210px; background:var(--bg-1); border:1px solid var(--line-2); }
-.ix-graph-dag path { fill:none; stroke:var(--line-3); stroke-width:2; }
-.ix-graph-dag text { fill:var(--fg-3); font-family:var(--font-mono); font-size:10px; }
-.ix-graph-dag text.label { fill:var(--brass-1); font-size:9px; letter-spacing:.04em; }
-.ix-graph-dag g.active circle { stroke:var(--brass-1); stroke-width:2; filter:drop-shadow(0 0 5px rgb(var(--brass-glow)/.7)); }
+.ix-graph-dag { width:100%; height:210px; background:var(--color-bg-surface); border:1px solid var(--color-border-strong); }
+.ix-graph-dag path { fill:none; stroke:var(--color-border-divider); stroke-width:2; }
+.ix-graph-dag text { fill:var(--color-fg-muted); font-family:var(--font-mono); font-size:10px; }
+.ix-graph-dag text.label { fill:var(--color-accent-fg); font-size:9px; letter-spacing:.04em; }
+.ix-graph-dag g.active circle { stroke:var(--color-accent-fg); stroke-width:2; filter:drop-shadow(0 0 5px rgb(var(--color-accent-glow)/.7)); }
 .ix-commits, .ix-stashes { min-height:0; overflow:auto; display:flex; flex-direction:column; gap:1px; }
-.ix-commit-row { display:grid; grid-template-columns:54px 96px minmax(0,1fr) 150px 42px 58px; gap:7px; align-items:center; min-height:25px; padding:4px 8px; background:var(--bg-1); border:1px solid var(--line-1); font-family:var(--font-mono); font-size:var(--fs-10); }
-.ix-commit-row .hash { color:var(--brass-1); }
-.ix-commit-row .subj { color:var(--fg-1); min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
-.ix-commit-row .branch, .ix-commit-row .age, .ix-commit-row .diff { color:var(--fg-4); }
+.ix-commit-row { display:grid; grid-template-columns:54px 96px minmax(0,1fr) 150px 42px 58px; gap:7px; align-items:center; min-height:25px; padding:4px 8px; background:var(--color-bg-surface); border:1px solid var(--color-border-default); font-family:var(--font-mono); font-size:var(--fs-10); }
+.ix-commit-row .hash { color:var(--color-accent-fg); }
+.ix-commit-row .subj { color:var(--color-fg-primary); min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.ix-commit-row .branch, .ix-commit-row .age, .ix-commit-row .diff { color:var(--color-fg-disabled); }
 .ix-worktrees { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:7px; min-height:0; overflow:auto; }
-.ix-worktree-card { display:flex; flex-direction:column; gap:5px; padding:8px; background:var(--bg-1); border:1px solid var(--line-2); border-left:2px solid var(--line-2); font-family:var(--font-mono); font-size:var(--fs-10); }
+.ix-worktree-card { display:flex; flex-direction:column; gap:5px; padding:8px; background:var(--color-bg-surface); border:1px solid var(--color-border-strong); border-left:2px solid var(--color-border-strong); font-family:var(--font-mono); font-size:var(--fs-10); }
 .ix-worktree-card.clean { border-left-color:var(--ok); }
 .ix-worktree-card.dirty { border-left-color:var(--warn); }
 .ix-worktree-card.stale { border-left-color:var(--err); }
-.ix-worktree-card .path { color:var(--fg-1); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
-.ix-worktree-card .branch { color:var(--brass-1); }
+.ix-worktree-card .path { color:var(--color-fg-primary); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.ix-worktree-card .branch { color:var(--color-accent-fg); }
 .ix-worktree-card .keepers { display:flex; flex-wrap:wrap; gap:3px; }
-.ix-worktree-card .keepers span { padding:1px 5px; background:var(--bg-2); border:1px solid var(--line-1); color:var(--fg-3); }
-.ix-worktree-card .ft { display:flex; align-items:center; gap:5px; color:var(--fg-4); }
-.ix-worktree-card .ft button { margin-left:auto; padding:1px 5px; background:var(--bg-2); border:1px solid var(--line-1); color:var(--fg-3); font:inherit; cursor:pointer; }
+.ix-worktree-card .keepers span { padding:1px 5px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-default); color:var(--color-fg-muted); }
+.ix-worktree-card .ft { display:flex; align-items:center; gap:5px; color:var(--color-fg-disabled); }
+.ix-worktree-card .ft button { margin-left:auto; padding:1px 5px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-default); color:var(--color-fg-muted); font:inherit; cursor:pointer; }
 .ix-worktree-card .ft button + button { margin-left:0; }
-.ix-stash-row { background:var(--bg-1); border:1px solid var(--line-1); font-family:var(--font-mono); font-size:var(--fs-10); }
+.ix-stash-row { background:var(--color-bg-surface); border:1px solid var(--color-border-default); font-family:var(--font-mono); font-size:var(--fs-10); }
 .ix-stash-row .row { display:grid; grid-template-columns:72px 150px 94px minmax(0,1fr) 42px 52px; gap:6px; align-items:center; padding:5px 8px; cursor:pointer; }
-.ix-stash-row .id, .ix-stash-row .keeper { color:var(--brass-1); }
-.ix-stash-row .branch, .ix-stash-row .age { color:var(--fg-4); }
-.ix-stash-row .sum { color:var(--fg-1); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
-.ix-stash-row .detail { padding:5px 8px; border-top:1px solid var(--line-1); background:var(--bg-0); color:var(--fg-3); display:flex; gap:8px; }
-.ix-stash-row .detail span { margin-left:auto; color:var(--brass-1); }
+.ix-stash-row .id, .ix-stash-row .keeper { color:var(--color-accent-fg); }
+.ix-stash-row .branch, .ix-stash-row .age { color:var(--color-fg-disabled); }
+.ix-stash-row .sum { color:var(--color-fg-primary); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.ix-stash-row .detail { padding:5px 8px; border-top:1px solid var(--color-border-default); background:var(--color-bg-page); color:var(--color-fg-muted); display:flex; gap:8px; }
+.ix-stash-row .detail span { margin-left:auto; color:var(--color-accent-fg); }
 
 /* E5 · terminal/search */
-.ix-term-body { min-height:0; overflow:auto; padding:8px; background:var(--bg-1); border:1px solid var(--line-2); font-family:var(--font-mono); font-size:var(--fs-11); line-height:1.45; }
-.ix-term-line { color:var(--fg-2); white-space:pre-wrap; }
-.ix-term-line.prompt { color:var(--brass-1); margin-top:4px; }
-.ix-search-bar { display:grid; grid-template-columns:minmax(180px,1fr) auto auto minmax(130px,.5fr); gap:4px; padding:6px 8px; background:var(--bg-1); border:1px solid var(--line-1); }
+.ix-term-body { min-height:0; overflow:auto; padding:8px; background:var(--color-bg-surface); border:1px solid var(--color-border-strong); font-family:var(--font-mono); font-size:var(--fs-11); line-height:1.45; }
+.ix-term-line { color:var(--color-fg-secondary); white-space:pre-wrap; }
+.ix-term-line.prompt { color:var(--color-accent-fg); margin-top:4px; }
+.ix-search-bar { display:grid; grid-template-columns:minmax(180px,1fr) auto auto minmax(130px,.5fr); gap:4px; padding:6px 8px; background:var(--color-bg-surface); border:1px solid var(--color-border-default); }
 .ix-search-results { min-height:0; overflow:auto; display:flex; flex-direction:column; gap:4px; }
-.ix-search-file { background:var(--bg-1); border:1px solid var(--line-1); }
-.ix-search-file .file { padding:4px 8px; background:var(--bg-2); border-bottom:1px solid var(--line-1); color:var(--brass-1); font-family:var(--font-mono); font-size:var(--fs-10); }
-.ix-search-file .file span { float:right; color:var(--fg-4); }
-.ix-search-file .hit { display:grid; grid-template-columns:44px minmax(0,1fr); gap:6px; padding:3px 8px; border-bottom:1px solid var(--line-1); font-family:var(--font-mono); font-size:var(--fs-10); }
-.ix-search-file .hit span { color:var(--fg-4); text-align:right; }
-.ix-search-file code { color:var(--fg-2); white-space:pre-wrap; }
-.ix-search-file mark { background:rgb(var(--brass-glow)/.22); color:var(--brass-1); padding:0 1px; }
+.ix-search-file { background:var(--color-bg-surface); border:1px solid var(--color-border-default); }
+.ix-search-file .file { padding:4px 8px; background:var(--color-bg-panel-alt); border-bottom:1px solid var(--color-border-default); color:var(--color-accent-fg); font-family:var(--font-mono); font-size:var(--fs-10); }
+.ix-search-file .file span { float:right; color:var(--color-fg-disabled); }
+.ix-search-file .hit { display:grid; grid-template-columns:44px minmax(0,1fr); gap:6px; padding:3px 8px; border-bottom:1px solid var(--color-border-default); font-family:var(--font-mono); font-size:var(--fs-10); }
+.ix-search-file .hit span { color:var(--color-fg-disabled); text-align:right; }
+.ix-search-file code { color:var(--color-fg-secondary); white-space:pre-wrap; }
+.ix-search-file mark { background:rgb(var(--color-accent-glow)/.22); color:var(--color-accent-fg); padding:0 1px; }
 .ix-find-wrap { position:relative; }
-.ix-find { display:grid; grid-template-columns:minmax(90px,1fr) minmax(90px,1fr) repeat(5,auto); gap:4px; padding:6px 8px; background:var(--bg-2); border:1px solid var(--line-2); }
+.ix-find { display:grid; grid-template-columns:minmax(90px,1fr) minmax(90px,1fr) repeat(5,auto); gap:4px; padding:6px 8px; background:var(--color-bg-panel-alt); border:1px solid var(--color-border-strong); }
 
 @media (max-width: 900px) {
   .ix-edit-split-grid, .ix-review-grid, .ix-worktrees { grid-template-columns:1fr; }
@@ -1105,7 +1105,7 @@
    Mouse clicks suppress the ring. Token --color-focus-ring is
    reused by every Ix* interactive surface. */
 :root {
-  --color-focus-ring: var(--brass-1);
+  --color-focus-ring: var(--color-accent-fg);
 }
 .ix-tree button:focus-visible,
 .ix-tree input:focus-visible,
@@ -1139,7 +1139,7 @@
 .ix-edit button[aria-pressed="true"],
 .ix-pr button[aria-pressed="true"],
 .ix-search button[aria-pressed="true"] {
-  color:var(--brass-1); border-color:var(--brass-3); background:rgb(var(--brass-glow)/.08);
+  color:var(--color-accent-fg); border-color:var(--color-accent-fg-dim); background:rgb(var(--color-accent-glow)/.08);
 }
 
 /* Visually-hidden caption for SVGs and icon-only labels. */
@@ -1162,8 +1162,8 @@
 }
 
 .cb-topbar .mode-tabs button[aria-selected="true"] {
-  color:var(--bg-0); background:var(--brass-2);
+  color:var(--color-bg-page); background:var(--brass-2);
 }
 .cb-topbar .density button[aria-checked="true"] {
-  color:var(--brass-1); background:rgb(var(--brass-glow)/.1);
+  color:var(--color-accent-fg); background:rgb(var(--color-accent-glow)/.1);
 }


### PR DESCRIPTION
## Summary

PR-M 시리즈 단일 PR 중 최대 — `dashboard/design-system/preview/components.css` 666 raw refs 중 560여건을 semantic alias로 일괄 치환. 잔존 106건은 SPEC §6.2 escape hatch (4-slot status + `--brass-2` mid).

## 변경

| Raw | Semantic alias |
|-----|---------------|
| `--bg-0/1/2/3/4` | `--color-bg-page/surface/panel-alt/elevated/hover` |
| `--fg-1/2/3/4` | `--color-fg-primary/secondary/muted/disabled` |
| `--line-1/2/3` | `--color-border-default/strong/divider` |
| `--brass-1` | `--color-accent-fg` |
| `--brass-3` | `--color-accent-fg-dim` |
| `--brass-glow` | `--color-accent-glow` |

## Escape hatch (의도적 raw 유지)

SPEC §6.2 예외 항목 그대로 유지:
- `--brass-2` mid tone (accent palette)
- 4-slot status: `--{ok|warn|err|info|idle|stalled}-{soft|fg|border|ring}` (컴포넌트별 정교한 surface/text/border/ring 4-slot — single-slot semantic alias로 환원 불가)

## 안전성

- **시각 회귀 0**: alias가 raw로 resolve되어 동치
- **단일 파일 수정**: 1198 line replace, 599 insertions + 599 deletions

## Test plan

- [ ] CI green
- [ ] preview/components.html 시각 회귀 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
