### PR TITLE
docs(keeper-tool-pr-review): record 5s deviation rationale at line 218 (#10594 follow-up 4/4)

### DIFF
--- a/lib/keeper/keeper_tool_pr_review.ml
+++ b/lib/keeper/keeper_tool_pr_review.ml
@@ -214,6 +214,12 @@ let handle_keeper_pr_review_reply
       let owner_repo =
         if repo <> "" then repo
         else
+          (* Deviation from Env_config_exec_timeout.Pr_review (15s):
+             one-off [nameWithOwner] lookup is read-only and tightly
+             bounded.  See #10594 — a dedicated caller variant for a
+             single site is over-engineering, so this stays
+             hardcoded.  If a third site needs 5s budget,
+             reconsider. *)
           let st, out =
             Process_eio.run_argv_with_status ~timeout_sec:5.0
               [ "/bin/zsh"; "-lc";


### PR DESCRIPTION
## Why

#10594 deviation #4 (last of the four follow-ups) — `keeper_tool_pr_review.ml:218` uses `~timeout_sec:5.0` for a one-off `gh repo view --json nameWithOwner` lookup. Analysis recommended **leaving it hardcoded** with a documentation comment rather than introducing a dedicated caller variant for a single site.

## What

6-line inline comment added directly above the `~timeout_sec:5.0` call site:

```ocaml
(* Deviation from Env_config_exec_timeout.Pr_review (15s):
   one-off [nameWithOwner] lookup is read-only and tightly
   bounded.  See #10594 — a dedicated caller variant for a
   single site is over-engineering, so this stays
   hardcoded.  If a third site needs 5s budget,
   reconsider. *)
```

The comment:
- explains the intent (intentional deviation, not drift),
- references #10594 for the broader analysis,
- gives the future-reader an actionable trigger (3rd site → reconsider).

## Diff

```
1 file changed, 6 insertions(+)
```

No code change, no build/behavior impact.

## #10594 follow-up status (final)

| PR | Status |
|----|--------|
| #10603 — Git_meta + Shell_probe | Draft |
| #10615 — Alerting bump 15→20 | Draft |
| #10626 — Pr_review_post 30s | Draft |
| **this PR** — `:218` deviation comment | Draft |

All four follow-ups now in queue. After cascade lands, every shell timeout site in `lib/keeper/` is either on `Env_config_exec_timeout` SSOT or has an inline rationale.

---

Refs: #10426 (audit + plan), #10594 (deviation analysis), #10603, #10615, #10626 (sibling follow-ups).
