### PR TITLE
perf(gate-diff): delegate contains_sub_ci to String_util.contains_substring_ci SSOT

### DIFF
--- a/lib/gate_diff_types.ml
+++ b/lib/gate_diff_types.ml
@@ -61,19 +61,14 @@ let destructive_class_substrings : (string * destructive_class) list = [
   "reboot",            System_control;
 ]
 
-(* Case-insensitive substring-hit test without a regex engine. *)
-let contains_sub_ci (s : string) (sub : string) : bool =
-  let ls = String.length s and lsub = String.length sub in
-  if lsub = 0 then true
-  else if lsub > ls then false
-  else
-    let s = String.lowercase_ascii s and sub = String.lowercase_ascii sub in
-    let rec loop i =
-      if i + lsub > ls then false
-      else if String.sub s i lsub = sub then true
-      else loop (i + 1)
-    in
-    loop 0
+(* Delegates to [String_util.contains_substring_ci] (SSOT). Preserves
+   the historical [sub = ""] -> true convention used by the original
+   inline walker; the SSOT returns [false] for empty needle so we
+   guard here. [destructive_class_substrings] never carries an empty
+   pattern, but the guard keeps the invariant explicit. *)
+let contains_sub_ci s sub =
+  if sub = "" then true
+  else String_util.contains_substring_ci s sub
 
 (* Returns the matching class (first hit in declaration order) plus
    the literal substring that triggered.  [None] means "no known


### PR DESCRIPTION
## What

`lib/gate_diff_types.contains_sub_ci`의 자체 case-insensitive substring 구현을 `String_util.contains_substring_ci` SSOT로 위임. `#10460/#10468/#10478` 1차 sweep에서 누락된 fork.

## Why

기존 구현 (라인 65-76)은:
1. `String.lowercase_ascii s` + `String.lowercase_ascii sub` — 2 string allocation
2. inner loop에서 매 i 마다 `String.sub s i lsub` — N alloc
3. 총 alloc = 2 + (s.length - sub.length + 1)

SSOT는 byte-wise scan + 0 alloc.

## Semantics

`destructive_class_substrings` iter loop의 caller(`classify_destructive`)가 사용. SSOT는 빈 needle에서 `false` 반환, 기존 wrapper는 `true` — 의미 보존을 위해 `if sub = "" then true` 가드 추가. 실제로 destructive_class_substrings는 빈 string 없음.

```ocaml
let contains_sub_ci s sub =
  if sub = "" then true
  else String_util.contains_substring_ci s sub
```

## Test

`OCAMLPARAM='_,warn-error=+a' dune build @check` clean. caller(`classify_destructive`)는 unchanged.

## Sweep series

`String_util.contains_substring_ci` 통합 진행:
- 1차 (#10460/#10468/#10478): 5 fork 통합
- 본 PR: gate_diff_types fork (1차 누락분)
- 후속 검토: cdal_judge.ml:259 `contains_sub` 같은 패턴
