### PR TITLE
feat(design-system): residual unsafe-alias sweep across 29 files (PR-M28)

### DIFF
--- a/dashboard/design-system/preview/brand.html
+++ b/dashboard/design-system/preview/brand.html
@@ -27,7 +27,7 @@
   .wordmark-dot {
     width: 14px; height: 14px; border-radius: 50%;
     background: var(--color-accent-fg);
-    box-shadow: 0 0 12px rgb(var(--brass-glow)/.5);
+    box-shadow: 0 0 12px rgb(var(--color-accent-glow)/.5);
     position: relative;
   }
   .wordmark-dot::after {
@@ -40,7 +40,7 @@
     color: var(--color-fg-primary);
   }
   .brass .wordmark-dot { background: #0c0b08; box-shadow: none; }
-  .brass .wordmark-dot::after { background: radial-gradient(circle at 35% 35%, rgb(var(--brass-glow)/.4), transparent 60%); }
+  .brass .wordmark-dot::after { background: radial-gradient(circle at 35% 35%, rgb(var(--color-accent-glow)/.4), transparent 60%); }
   .brass .wordmark-text { color: #0c0b08; }
 
   .brand-caption {
@@ -166,7 +166,7 @@
     left: 58%;
     width: 2px;
     background: linear-gradient(to bottom, transparent, var(--color-accent-fg) 15%, var(--color-accent-fg) 85%, transparent);
-    box-shadow: 0 0 16px rgb(var(--brass-glow)/.6);
+    box-shadow: 0 0 16px rgb(var(--color-accent-glow)/.6);
   }
   .meta-copy { flex: 1; display: flex; flex-direction: column; gap: 8px; max-width: 52%; }
   .meta-copy h3 {

--- a/dashboard/design-system/preview/code-mode.jsx
+++ b/dashboard/design-system/preview/code-mode.jsx
@@ -117,7 +117,7 @@ function Editor({ height = 520 }) {
         <div className="editor-minimap">
           <svg viewBox="0 0 60 520" width="100%" height="100%">
             {EDITOR_LINES.map((ln, i) => (
-              <rect key={i} x="6" y={i * 14 + 8} width={Math.random() * 40 + 6} height="2" fill={ln.diff === 'add' ? 'var(--ok)' : ln.diff === 'del' ? 'var(--err)' : 'var(--fg-4)'} opacity={ln.diff ? 0.7 : 0.3} />
+              <rect key={i} x="6" y={i * 14 + 8} width={Math.random() * 40 + 6} height="2" fill={ln.diff === 'add' ? 'var(--ok)' : ln.diff === 'del' ? 'var(--err)' : 'var(--color-fg-disabled)'} opacity={ln.diff ? 0.7 : 0.3} />
             ))}
             <rect className="minimap-viewport" x="0" y="40" width="60" height="140" />
           </svg>
@@ -272,17 +272,17 @@ function SplitMode({ w = 1400, h = 680 }) {
     <div style={{ display: 'grid', gridTemplateRows: '32px 26px 52px 180px minmax(0,1fr) 28px', width: w, height: h, background: 'var(--color-bg-page)', border: '1px solid var(--color-border-default)', borderRadius: 'var(--r-1)', overflow: 'hidden' }}>
       {/* topbar */}
       <div style={{ display: 'flex', alignItems: 'center', padding: '0 12px', gap: 10, background: 'var(--color-bg-surface)', borderBottom: '1px solid var(--color-border-strong)', fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--color-fg-secondary)' }}>
-        <div style={{ width: 14, height: 14, borderRadius: 2, background: 'linear-gradient(135deg, var(--color-accent-fg), var(--brass-3))' }} />
+        <div style={{ width: 14, height: 14, borderRadius: 2, background: 'linear-gradient(135deg, var(--color-accent-fg), var(--color-accent-fg-dim))' }} />
         <b style={{ color: 'var(--color-fg-primary)', letterSpacing: '.04em' }}>MASC</b>
-        <span style={{ color: 'var(--fg-4)' }}>v0.42.1</span>
+        <span style={{ color: 'var(--color-fg-disabled)' }}>v0.42.1</span>
         <span style={{ width: 1, height: 14, background: 'var(--color-border-strong)' }} />
-        <span>goal-merge-blockers <span style={{ color: 'var(--fg-4)' }}>▾</span></span>
+        <span>goal-merge-blockers <span style={{ color: 'var(--color-fg-disabled)' }}>▾</span></span>
         <div className="mode-switch" style={{ marginLeft: 12 }}>
           <button>COCKPIT</button>
           <button className="is-active">SPLIT</button>
           <button>CODE</button>
         </div>
-        <div style={{ marginLeft: 'auto', color: 'var(--fg-4)', fontSize: 10 }}>16:32:45Z · 5 keepers live</div>
+        <div style={{ marginLeft: 'auto', color: 'var(--color-fg-disabled)', fontSize: 10 }}>16:32:45Z · 5 keepers live</div>
       </div>
       {/* ticker */}
       <div style={{ display: 'flex', alignItems: 'center', padding: '0 12px', gap: 16, background: 'linear-gradient(to bottom, var(--color-bg-surface), var(--color-bg-page))', borderBottom: '1px solid var(--color-border-default)', fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--color-fg-muted)', whiteSpace: 'nowrap', overflow: 'hidden' }}>
@@ -301,21 +301,21 @@ function SplitMode({ w = 1400, h = 680 }) {
           { l: 'cascade', v: '@2 · 1.24s' },
           { l: 'flags', v: '3', s: 'err' },
         ].map((k, i) => (
-          <div key={i} style={{ background: k.s === 'brass' ? 'rgb(var(--brass-glow)/.06)' : 'var(--color-bg-surface)', padding: '8px 10px', display: 'flex', flexDirection: 'column', gap: 2, boxShadow: k.s === 'err' ? 'inset 2px 0 0 var(--err)' : k.s === 'ok' ? 'inset 2px 0 0 var(--ok)' : k.s === 'brass' ? 'inset 2px 0 0 var(--color-accent-fg)' : 'none' }}>
+          <div key={i} style={{ background: k.s === 'brass' ? 'rgb(var(--color-accent-glow)/.06)' : 'var(--color-bg-surface)', padding: '8px 10px', display: 'flex', flexDirection: 'column', gap: 2, boxShadow: k.s === 'err' ? 'inset 2px 0 0 var(--err)' : k.s === 'ok' ? 'inset 2px 0 0 var(--ok)' : k.s === 'brass' ? 'inset 2px 0 0 var(--color-accent-fg)' : 'none' }}>
             <div style={{ fontSize: 9, letterSpacing: '.08em', color: 'var(--color-fg-muted)', textTransform: 'uppercase', fontWeight: 600 }}>{k.l}</div>
             <div style={{ fontFamily: 'var(--font-mono)', fontSize: 15, color: k.s === 'err' ? 'var(--err-fg)' : k.s === 'ok' ? 'var(--ok-fg)' : k.s === 'brass' ? 'var(--color-accent-fg)' : 'var(--color-fg-primary)' }}>{k.v}</div>
           </div>
         ))}
       </div>
       {/* cockpit strip (180px): lifeline + mini swimlanes */}
-      <div style={{ display: 'grid', gridTemplateColumns: '280px minmax(0,1fr) 220px', background: 'var(--color-bg-page)', borderBottom: '2px solid var(--brass-3)', minHeight: 0, overflow: 'hidden' }}>
+      <div style={{ display: 'grid', gridTemplateColumns: '280px minmax(0,1fr) 220px', background: 'var(--color-bg-page)', borderBottom: '2px solid var(--color-accent-fg-dim)', minHeight: 0, overflow: 'hidden' }}>
         <div style={{ padding: 8, borderRight: '1px solid var(--color-border-default)', display: 'flex', flexDirection: 'column', gap: 4 }}>
           <div style={{ fontSize: 9, letterSpacing: '.08em', color: 'var(--color-fg-muted)', textTransform: 'uppercase', fontWeight: 600 }}>FLEET</div>
           {['nick0cave', 'masc-improver', 'sangsu', 'qa-king', 'rama'].map((k, i) => (
             <div key={k} style={{ display: 'flex', alignItems: 'center', gap: 6, fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--color-fg-secondary)' }}>
-              <span style={{ width: 5, height: 5, borderRadius: '50%', background: ['var(--color-accent-fg)', 'var(--ok)', 'var(--info)', 'var(--err)', 'var(--stalled)'][i], boxShadow: i === 0 ? '0 0 5px rgb(var(--brass-glow)/.7)' : 'none' }} />
+              <span style={{ width: 5, height: 5, borderRadius: '50%', background: ['var(--color-accent-fg)', 'var(--ok)', 'var(--info)', 'var(--err)', 'var(--stalled)'][i], boxShadow: i === 0 ? '0 0 5px rgb(var(--color-accent-glow)/.7)' : 'none' }} />
               {k}
-              <span style={{ marginLeft: 'auto', color: 'var(--fg-4)', fontSize: 9 }}>t-{(0x9f2a + i).toString(16)}</span>
+              <span style={{ marginLeft: 'auto', color: 'var(--color-fg-disabled)', fontSize: 9 }}>t-{(0x9f2a + i).toString(16)}</span>
             </div>
           ))}
         </div>
@@ -328,7 +328,7 @@ function SplitMode({ w = 1400, h = 680 }) {
               ))}
             </div>
           ))}
-          <div style={{ position: 'absolute', top: 24, bottom: 8, left: '82%', width: 1, background: 'linear-gradient(to bottom, transparent, rgb(var(--brass-glow)/.7) 20%, rgb(var(--brass-glow)/.7) 80%, transparent)', boxShadow: '0 0 8px 1px rgb(var(--brass-glow)/.4)' }} />
+          <div style={{ position: 'absolute', top: 24, bottom: 8, left: '82%', width: 1, background: 'linear-gradient(to bottom, transparent, rgb(var(--color-accent-glow)/.7) 20%, rgb(var(--color-accent-glow)/.7) 80%, transparent)', boxShadow: '0 0 8px 1px rgb(var(--color-accent-glow)/.4)' }} />
         </div>
         <div style={{ padding: 8, borderLeft: '1px solid var(--color-border-default)' }}>
           <div style={{ fontSize: 9, letterSpacing: '.08em', color: 'var(--color-fg-muted)', textTransform: 'uppercase', fontWeight: 600, marginBottom: 4 }}>NOW · keeper.ts</div>
@@ -407,13 +407,13 @@ function ExplodeLayers({ w = 900, h = 560 }) {
         <circle cx={w - 40} cy={220} r="4" fill="var(--info)" />
       </svg>
     ) },
-    { id: 'tools', label: 'L3 · TOOLS · frequency glyphs', z: 300, bg: 'rgb(var(--brass-glow) / .06)', render: () => (
+    { id: 'tools', label: 'L3 · TOOLS · frequency glyphs', z: 300, bg: 'rgb(var(--color-accent-glow) / .06)', render: () => (
       <div style={{ padding: 12 }}>
         {[['◈', 12, 'emit'], ['⌘', 8, 'run'], ['⟳', 5, 'tick'], ['∎', 3, 'guard']].map(([g, n, lab], i) => (
           <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 8, height: 24 }}>
-            <span style={{ color: 'var(--color-accent-fg)', fontSize: 12, textShadow: '0 0 4px rgb(var(--brass-glow)/.6)' }}>{g}</span>
+            <span style={{ color: 'var(--color-accent-fg)', fontSize: 12, textShadow: '0 0 4px rgb(var(--color-accent-glow)/.6)' }}>{g}</span>
             <span style={{ width: n * 6, height: 2, background: 'linear-gradient(90deg, var(--color-accent-fg), transparent)', borderRadius: 1 }} />
-            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 9, color: 'var(--fg-4)' }}>{n}×</span>
+            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 9, color: 'var(--color-fg-disabled)' }}>{n}×</span>
             <span style={{ fontFamily: 'var(--font-mono)', fontSize: 9, color: 'var(--color-accent-fg)' }}>{lab}</span>
           </div>
         ))}
@@ -448,7 +448,7 @@ function ExplodeLayers({ w = 900, h = 560 }) {
         ))}
       </div>
       {/* z-axis legend */}
-      <div style={{ position: 'absolute', top: 10, right: 10, zIndex: 10, fontFamily: 'var(--font-mono)', fontSize: 9, color: 'var(--fg-4)', letterSpacing: '.08em', textTransform: 'uppercase', textAlign: 'right', lineHeight: 1.6 }}>
+      <div style={{ position: 'absolute', top: 10, right: 10, zIndex: 10, fontFamily: 'var(--font-mono)', fontSize: 9, color: 'var(--color-fg-disabled)', letterSpacing: '.08em', textTransform: 'uppercase', textAlign: 'right', lineHeight: 1.6 }}>
         Z-AXIS STACK<br />
         <span style={{ color: 'var(--color-fg-muted)' }}>5 observational layers</span>
       </div>
@@ -460,7 +460,7 @@ function ExplodeLayers({ w = 900, h = 560 }) {
               position: 'absolute', top: 80, left: 60, right: 60, bottom: 60,
               transform: `translateZ(${L.z * (pose === 0 ? 0 : pose === 2 ? .5 : 1)}px)`,
               background: L.bg,
-              border: `1px ${pose === 0 ? 'solid' : 'dashed'} rgb(var(--brass-glow)/.25)`,
+              border: `1px ${pose === 0 ? 'solid' : 'dashed'} rgb(var(--color-accent-glow)/.25)`,
               borderRadius: 'var(--r-1)',
               opacity: pose === 0 ? (i === 0 ? 1 : 0.35) : 1,
               transition: 'transform .7s cubic-bezier(.2,.7,.3,1), opacity .4s',
@@ -474,7 +474,7 @@ function ExplodeLayers({ w = 900, h = 560 }) {
         </div>
       </div>
       {/* caption */}
-      <div style={{ position: 'absolute', bottom: 10, left: 10, right: 10, display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontFamily: 'var(--font-mono)', fontSize: 9, color: 'var(--fg-4)', letterSpacing: '.04em' }}>
+      <div style={{ position: 'absolute', bottom: 10, left: 10, right: 10, display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontFamily: 'var(--font-mono)', fontSize: 9, color: 'var(--color-fg-disabled)', letterSpacing: '.04em' }}>
         <span>editor-scroll · perspective: 1800px · preserve-3d</span>
         <span>body[data-explode=1] .lyr {'{'} translateZ(40·80·120·160·200px) {'}'}</span>
       </div>

--- a/dashboard/design-system/preview/colors.html
+++ b/dashboard/design-system/preview/colors.html
@@ -123,7 +123,7 @@
   .ui-row:last-child { border-bottom: none; }
   .ui-row .d { width: 8px; height: 8px; border-radius: 50%; justify-self: center; }
   .ui-row.active {
-    background: linear-gradient(90deg, rgb(var(--brass-glow)/.08), transparent 60%);
+    background: linear-gradient(90deg, rgb(var(--color-accent-glow)/.08), transparent 60%);
     border-left: 2px solid var(--color-accent-fg);
     padding-left: 10px;
   }
@@ -320,9 +320,9 @@
         <span class="pv-tok">idle</span>
       </div>
       <div class="ui-row active">
-        <span class="d" style="background:#d4a14a; box-shadow:0 0 8px rgb(var(--brass-glow)/.6)"></span>
+        <span class="d" style="background:#d4a14a; box-shadow:0 0 8px rgb(var(--color-accent-glow)/.6)"></span>
         <div><span class="name">masc-improver</span> <span class="meta"> · tool.write_file · running</span></div>
-        <span class="pv-tok" style="color:var(--color-accent-fg); border-color:rgb(var(--brass-glow)/.4)">active</span>
+        <span class="pv-tok" style="color:var(--color-accent-fg); border-color:rgb(var(--color-accent-glow)/.4)">active</span>
       </div>
       <div class="ui-row" style="background:var(--color-bg-panel-alt)">
         <span class="d" style="background:#6a8eb0"></span>

--- a/dashboard/design-system/preview/forms.html
+++ b/dashboard/design-system/preview/forms.html
@@ -10,7 +10,7 @@
   <style>
     html, body { margin:0; background: var(--color-bg-page); color: var(--color-fg-primary); font-family: var(--font-sans); }
     .page { max-width: 1180px; margin:0 auto; padding: 32px 32px 96px; }
-    .back { font: var(--type-micro); color: var(--fg-4); text-decoration:none; letter-spacing: .08em; display:inline-block; margin-bottom:20px; }
+    .back { font: var(--type-micro); color: var(--color-fg-disabled); text-decoration:none; letter-spacing: .08em; display:inline-block; margin-bottom:20px; }
     .back:hover { color: var(--color-fg-secondary); }
     h1 { font-family: var(--font-mono); font-size: 18px; font-weight: 600; margin: 0 0 4px; }
     .sub { color: var(--color-fg-muted); font-size: 12px; margin-bottom: 28px; }
@@ -18,23 +18,23 @@
     .seg { background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-radius: var(--r-1); padding: 16px 18px; margin-bottom: 10px; display: grid; grid-template-columns: 220px 1fr; gap: 20px; align-items: start; }
     .seg .meta { font-family: var(--font-mono); font-size: 11px; color: var(--color-fg-muted); }
     .seg .meta .n { color: var(--color-fg-primary); font-weight:600; font-size: 13px; margin-bottom: 4px; display:block; }
-    .seg .meta .code { display:block; margin-top: 6px; color: var(--fg-4); font-size: 10px; line-height: 1.5; }
+    .seg .meta .code { display:block; margin-top: 6px; color: var(--color-fg-disabled); font-size: 10px; line-height: 1.5; }
     .demo { display:flex; flex-direction:column; gap: 14px; }
 
     /* ── Text input ── */
     .field { display:flex; flex-direction:column; gap:3px; }
     .field-label { font-family: var(--font-mono); font-size: 9px; letter-spacing: .08em; color: var(--color-fg-muted); text-transform:uppercase; font-weight:600; }
-    .field-hint { font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .04em; }
+    .field-hint { font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .04em; }
     .field-err { font-family: var(--font-mono); font-size: 9px; color: var(--err-fg); letter-spacing: .04em; }
     .input { background: var(--color-bg-panel-alt); border: 1px solid var(--color-border-strong); border-radius: var(--r-1); padding: 6px 10px; color: var(--color-fg-primary); font-family: var(--font-mono); font-size: 12px; outline: none; transition: border-color .12s, box-shadow .12s, background .12s; width: 100%; box-sizing:border-box; }
-    .input::placeholder { color: var(--fg-4); }
-    .input:focus { border-color: var(--brass-2); box-shadow: 0 0 0 1px var(--brass-2), 0 0 10px rgb(var(--brass-glow)/.18); background: var(--color-bg-elevated); }
+    .input::placeholder { color: var(--color-fg-disabled); }
+    .input:focus { border-color: var(--brass-2); box-shadow: 0 0 0 1px var(--brass-2), 0 0 10px rgb(var(--color-accent-glow)/.18); background: var(--color-bg-elevated); }
     .input:disabled { opacity: .5; cursor: not-allowed; }
     .input.is-err { border-color: var(--err); box-shadow: 0 0 0 1px var(--err); }
     .input.is-ok { border-color: var(--ok); }
     textarea.input { resize: vertical; min-height: 64px; line-height: 1.5; }
     .input-pre { display:flex; align-items:center; background: var(--color-bg-panel-alt); border: 1px solid var(--color-border-strong); border-radius: var(--r-1); }
-    .input-pre .pre { padding: 6px 8px; color: var(--fg-4); font-family: var(--font-mono); font-size: 11px; border-right: 1px solid var(--color-border-strong); background: var(--color-bg-surface); border-radius: var(--r-1) 0 0 var(--r-1); }
+    .input-pre .pre { padding: 6px 8px; color: var(--color-fg-disabled); font-family: var(--font-mono); font-size: 11px; border-right: 1px solid var(--color-border-strong); background: var(--color-bg-surface); border-radius: var(--r-1) 0 0 var(--r-1); }
     .input-pre .input { border: none; background: transparent; padding-left: 8px; }
     .input-pre:focus-within { border-color: var(--brass-2); box-shadow: 0 0 0 1px var(--brass-2); }
 
@@ -46,20 +46,20 @@
     .check { display:inline-flex; align-items:center; gap: 6px; cursor:pointer; user-select:none; font-family: var(--font-mono); font-size: 11px; color: var(--color-fg-secondary); }
     .check input { position: absolute; opacity: 0; width: 0; height: 0; pointer-events:none; }
     .check .box { width: 13px; height: 13px; border: 1px solid var(--color-border-strong); border-radius: 2px; background: var(--color-bg-panel-alt); display:inline-grid; place-items:center; transition: all .12s; flex-shrink:0; }
-    .check input:checked + .box { background: var(--color-accent-fg); border-color: var(--color-accent-fg); box-shadow: 0 0 8px rgb(var(--brass-glow)/.5); }
+    .check input:checked + .box { background: var(--color-accent-fg); border-color: var(--color-accent-fg); box-shadow: 0 0 8px rgb(var(--color-accent-glow)/.5); }
     .check input:checked + .box::after { content: ''; width: 6px; height: 3px; border-left: 1.5px solid var(--color-bg-page); border-bottom: 1.5px solid var(--color-bg-page); transform: rotate(-45deg) translate(1px, -1px); }
     .check input:disabled ~ * { opacity: .4; cursor: not-allowed; }
     .check .box.radio { border-radius: 50%; }
     .check input:checked + .box.radio { background: var(--color-bg-page); }
-    .check input:checked + .box.radio::after { content: ''; width: 7px; height: 7px; border: none; border-radius: 50%; background: var(--color-accent-fg); transform: none; box-shadow: 0 0 6px rgb(var(--brass-glow)/.8); }
+    .check input:checked + .box.radio::after { content: ''; width: 7px; height: 7px; border: none; border-radius: 50%; background: var(--color-accent-fg); transform: none; box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.8); }
 
     /* ── Toggle ── */
     .toggle { display:inline-flex; align-items:center; gap: 8px; cursor:pointer; user-select:none; font-family: var(--font-mono); font-size: 11px; color: var(--color-fg-secondary); }
     .toggle input { position:absolute; opacity:0; }
     .toggle .track { width: 26px; height: 14px; background: var(--color-bg-elevated); border: 1px solid var(--color-border-strong); border-radius: 999px; position: relative; transition: all .15s; flex-shrink:0; }
     .toggle .track::after { content: ''; position: absolute; top: 1px; left: 1px; width: 10px; height: 10px; border-radius: 50%; background: var(--color-fg-muted); transition: all .15s; }
-    .toggle input:checked + .track { background: rgb(var(--brass-glow)/.15); border-color: var(--brass-2); }
-    .toggle input:checked + .track::after { left: 13px; background: var(--color-accent-fg); box-shadow: 0 0 6px rgb(var(--brass-glow)/.7); }
+    .toggle input:checked + .track { background: rgb(var(--color-accent-glow)/.15); border-color: var(--brass-2); }
+    .toggle input:checked + .track::after { left: 13px; background: var(--color-accent-fg); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.7); }
 
     /* ── Segmented ── */
     .segmented { display: inline-flex; border: 1px solid var(--color-border-strong); border-radius: var(--r-1); overflow: hidden; background: var(--color-bg-panel-alt); }
@@ -70,8 +70,8 @@
 
     /* ── Slider ── */
     .slider { -webkit-appearance:none; appearance:none; width:220px; height: 4px; background: var(--color-bg-elevated); border-radius: 999px; outline: none; cursor: pointer; }
-    .slider::-webkit-slider-thumb { -webkit-appearance:none; appearance:none; width: 12px; height: 12px; border-radius: 50%; background: var(--color-accent-fg); border: 1px solid var(--brass-3); box-shadow: 0 0 6px rgb(var(--brass-glow)/.6); cursor: grab; }
-    .slider::-moz-range-thumb { width: 12px; height: 12px; border-radius: 50%; background: var(--color-accent-fg); border: 1px solid var(--brass-3); box-shadow: 0 0 6px rgb(var(--brass-glow)/.6); cursor: grab; }
+    .slider::-webkit-slider-thumb { -webkit-appearance:none; appearance:none; width: 12px; height: 12px; border-radius: 50%; background: var(--color-accent-fg); border: 1px solid var(--color-accent-fg-dim); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.6); cursor: grab; }
+    .slider::-moz-range-thumb { width: 12px; height: 12px; border-radius: 50%; background: var(--color-accent-fg); border: 1px solid var(--color-accent-fg-dim); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.6); cursor: grab; }
 
     /* ── Number stepper ── */
     .stepper { display:inline-flex; align-items:center; border: 1px solid var(--color-border-strong); border-radius: var(--r-1); background: var(--color-bg-panel-alt); overflow: hidden; }
@@ -81,11 +81,11 @@
 
     .row { display: flex; gap: 14px; align-items: flex-start; flex-wrap: wrap; }
     .row > .field { min-width: 0; flex: 0 0 auto; }
-    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); }
+    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled); }
 
     /* chip primitives if not loaded from primitives.css */
     .chip { display:inline-flex; align-items:center; padding: 2px 8px; font-family: var(--font-mono); font-size: 10px; background: var(--color-bg-panel-alt); border: 1px solid var(--color-border-strong); color: var(--color-fg-secondary); border-radius: 999px; letter-spacing: .04em; }
-    .chip.is-brass { color: var(--color-accent-fg); border-color: var(--brass-2); background: rgb(var(--brass-glow)/.08); }
+    .chip.is-brass { color: var(--color-accent-fg); border-color: var(--brass-2); background: rgb(var(--color-accent-glow)/.08); }
     .chip.is-err   { color: var(--err-fg); border-color: var(--err); background: rgb(var(--err-glow)/.08); }
 
     /* responsive: stack meta above demo on narrower widths */

--- a/dashboard/design-system/preview/index.html
+++ b/dashboard/design-system/preview/index.html
@@ -11,21 +11,21 @@
     html, body { margin:0; padding:0; background: var(--color-bg-page); color: var(--color-fg-primary); font-family: var(--font-sans); min-height:100vh; }
     .hub { max-width: 1200px; margin: 0 auto; padding: 48px 32px 120px; }
     .brand { display:flex; align-items:center; gap:12px; margin-bottom: 6px; }
-    .brand-mark { width:28px; height:28px; border-radius:4px; background: linear-gradient(135deg, var(--color-accent-fg), var(--brass-3)); box-shadow: 0 0 12px rgb(var(--brass-glow)/.35), inset 0 0 6px rgb(var(--brass-glow)/.3); }
+    .brand-mark { width:28px; height:28px; border-radius:4px; background: linear-gradient(135deg, var(--color-accent-fg), var(--color-accent-fg-dim)); box-shadow: 0 0 12px rgb(var(--color-accent-glow)/.35), inset 0 0 6px rgb(var(--color-accent-glow)/.3); }
     h1 { font: var(--type-title); font-size: 22px; font-weight: 600; letter-spacing: -.01em; margin: 0; font-family: var(--font-mono); }
     .sub { color: var(--color-fg-muted); font-size: 13px; margin-top: 4px; }
     h2 { font: var(--type-label); text-transform: uppercase; letter-spacing: .08em; color: var(--color-fg-muted); font-weight: 600; font-size: 11px; margin: 40px 0 12px; padding-bottom: 6px; border-bottom: 1px solid var(--color-border-strong); }
     .grid { display:grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 10px; }
     a.card { display:flex; flex-direction:column; gap:6px; padding: 14px 16px; background: var(--color-bg-surface); border:1px solid var(--color-border-default); border-radius: var(--r-1); text-decoration:none; color: inherit; transition: background .15s, border-color .15s, transform .15s; position:relative; overflow:hidden; }
     a.card:hover { background: var(--color-bg-panel-alt); border-color: var(--color-border-strong); }
-    a.card .n { font: var(--type-micro); color: var(--fg-4); letter-spacing: .08em; }
+    a.card .n { font: var(--type-micro); color: var(--color-fg-disabled); letter-spacing: .08em; }
     a.card .title { font-size: 14px; color: var(--color-fg-primary); font-weight: 500; }
     a.card .desc { font-size: 12px; color: var(--color-fg-muted); line-height: 1.4; }
     a.card .stripe { position:absolute; left:0; top:0; bottom:0; width:2px; background: var(--color-border-strong); }
     a.card:hover .stripe { background: var(--color-accent-fg); }
-    a.card .count { margin-top: 4px; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); letter-spacing: .04em; }
+    a.card .count { margin-top: 4px; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled); letter-spacing: .04em; }
     .tag { display:inline-block; font-family: var(--font-mono); font-size: 10px; padding: 1px 6px; border:1px solid var(--color-border-strong); border-radius: 2px; color: var(--color-fg-muted); letter-spacing: .04em; margin-right: 4px; }
-    .stamp { position: absolute; top: 24px; right: 32px; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); letter-spacing: .06em; }
+    .stamp { position: absolute; top: 24px; right: 32px; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled); letter-spacing: .06em; }
   </style>
 </head>
 <body>

--- a/dashboard/design-system/preview/layers.html
+++ b/dashboard/design-system/preview/layers.html
@@ -10,23 +10,23 @@
   <style>
     html, body { margin:0; background: var(--color-bg-page); color: var(--color-fg-primary); font-family: var(--font-sans); min-height: 100vh; }
     .page { max-width: 1180px; margin:0 auto; padding: 32px 32px 96px; }
-    .back { font: var(--type-micro); color: var(--fg-4); text-decoration:none; letter-spacing: .08em; display:inline-block; margin-bottom:20px; }
+    .back { font: var(--type-micro); color: var(--color-fg-disabled); text-decoration:none; letter-spacing: .08em; display:inline-block; margin-bottom:20px; }
     .back:hover { color: var(--color-fg-secondary); }
     h1 { font-family: var(--font-mono); font-size: 18px; font-weight: 600; margin: 0 0 4px; }
     .sub { color: var(--color-fg-muted); font-size: 12px; margin-bottom: 28px; line-height:1.5; max-width: 700px; }
     h2 { font: var(--type-label); text-transform: uppercase; letter-spacing: .08em; color: var(--color-fg-muted); font-weight: 600; font-size: 11px; margin: 28px 0 8px; padding-bottom: 6px; border-bottom: 1px solid var(--color-border-strong); }
     h2 .tag { margin-left: 8px; color: var(--color-accent-fg); font-weight: 500; }
-    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); }
+    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled); }
 
     .seg { background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-radius: var(--r-1); padding: 16px; margin-bottom: 10px; display:grid; grid-template-columns: 280px 1fr; gap:20px; align-items:start; }
     .seg .meta { font-family: var(--font-mono); font-size: 11px; color: var(--color-fg-muted); line-height: 1.5; }
     .seg .meta .n { color: var(--color-fg-primary); font-weight:600; font-size: 13px; margin-bottom: 4px; display:block; }
-    .seg .meta .code { display:block; margin-top: 8px; color: var(--fg-4); font-size: 10px; line-height: 1.5; padding: 6px 8px; background: var(--color-bg-panel-alt); border: 1px solid var(--color-border-default); border-radius: 2px; }
+    .seg .meta .code { display:block; margin-top: 8px; color: var(--color-fg-disabled); font-size: 10px; line-height: 1.5; padding: 6px 8px; background: var(--color-bg-panel-alt); border: 1px solid var(--color-border-default); border-radius: 2px; }
 
     .canvas { background: var(--color-bg-page); border: 1px solid var(--color-border-default); border-radius: var(--r-1); overflow: hidden; min-height: 180px; position:relative; }
     .src-pane { padding: 14px 18px; font-family: var(--font-mono); font-size: 11px; color: var(--color-fg-secondary); line-height: 1.7; position: relative; }
     .ln { display:flex; gap: 10px; }
-    .ln .n { color: var(--fg-4); width: 18px; text-align:right; flex-shrink:0; }
+    .ln .n { color: var(--color-fg-disabled); width: 18px; text-align:right; flex-shrink:0; }
     .k { color: #c195e8; } .t { color: #88b5d8; } .s { color: #a8c97a; } .f { color: #e8c976; }
 
     /* ── L1 TIME ── */
@@ -34,20 +34,20 @@
     .l1-rec { display:flex; gap: 2px; align-items: flex-end; height: 60px; }
     .l1-rec .bar { width: 6px; background: var(--warn); border-radius: 1px 1px 0 0; opacity: .55; position: relative; }
     .l1-rec .bar.hot { opacity: 1; box-shadow: 0 0 8px rgb(var(--warn-glow)/.8); }
-    .l1-rec .bar.cold { opacity: .22; background: var(--fg-4); box-shadow: none; }
-    .l1-rec .bar.now { background: var(--color-accent-fg); box-shadow: 0 0 10px rgb(var(--brass-glow)/.9); }
+    .l1-rec .bar.cold { opacity: .22; background: var(--color-fg-disabled); box-shadow: none; }
+    .l1-rec .bar.now { background: var(--color-accent-fg); box-shadow: 0 0 10px rgb(var(--color-accent-glow)/.9); }
     .l1-rec .bar[data-by]::after { content: attr(data-by); position: absolute; top: -11px; left: 50%; transform: translateX(-50%); font-family: var(--font-mono); font-size: 7px; color: var(--color-accent-fg); letter-spacing: .04em; white-space: nowrap; opacity: .85; }
-    .l1-axis { display:flex; justify-content:space-between; font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .04em; margin-top: 6px; padding-top: 4px; border-top: 1px dashed var(--color-border-default); }
-    .l1-legend { display:flex; gap: 14px; align-items:center; margin-top: 8px; font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .04em; }
+    .l1-axis { display:flex; justify-content:space-between; font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .04em; margin-top: 6px; padding-top: 4px; border-top: 1px dashed var(--color-border-default); }
+    .l1-legend { display:flex; gap: 14px; align-items:center; margin-top: 8px; font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .04em; }
     .l1-legend .swatch { display:inline-block; width: 10px; height: 6px; border-radius: 1px; vertical-align: middle; margin-right: 4px; }
     .l1-meta { display:flex; gap: 10px; align-items:center; padding: 6px 18px; background: var(--color-bg-panel-alt); border-top: 1px solid var(--color-border-default); border-bottom: 1px solid var(--color-border-default); font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-muted); }
-    .l1-meta .k { color: var(--fg-4); font-size: 9px; letter-spacing: .06em; text-transform: uppercase; margin-right: 4px; }
+    .l1-meta .k { color: var(--color-fg-disabled); font-size: 9px; letter-spacing: .06em; text-transform: uppercase; margin-right: 4px; }
     .l1-meta .v { color: var(--color-fg-primary); font-variant-numeric: tabular-nums; margin-right: 14px; }
 
     /* ── L2 PARALLEL ── */
     .l2 { position: relative; height: 180px; padding: 14px; }
     .l2 .lane { position:absolute; left: 14px; right: 14px; height: 22px; border-bottom: 1px dashed var(--color-border-default); display:flex; align-items:center; }
-    .l2 .lane .name { width: 70px; font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .04em; }
+    .l2 .lane .name { width: 70px; font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .04em; }
     .l2 .cursor { position: absolute; width: 10px; height: 14px; border-radius: 1px; top: 50%; transform: translateY(-50%); }
     .l2 .cursor::after { content: ''; position: absolute; left: 5px; top: -6px; width: 1px; height: 20px; background: currentColor; opacity: .4; }
 
@@ -55,19 +55,19 @@
     .l3 { display:flex; flex-direction: column; gap: 5px; padding: 14px 18px; }
     .l3-row { display:grid; grid-template-columns: 18px 100px 1fr 70px 50px; align-items:center; gap: 10px; padding: 2px 0; border-bottom: 1px dashed transparent; }
     .l3-row:hover { border-bottom-color: var(--color-border-default); }
-    .l3-glyph { font-family: var(--font-mono); font-size: 13px; color: var(--color-accent-fg); text-shadow: 0 0 4px rgb(var(--brass-glow)/.6); text-align:center; }
-    .l3-freq { height: 4px; background: linear-gradient(90deg, var(--color-accent-fg), rgb(var(--brass-glow)/.15)); border-radius: 999px; box-shadow: 0 0 4px rgb(var(--brass-glow)/.4); }
+    .l3-glyph { font-family: var(--font-mono); font-size: 13px; color: var(--color-accent-fg); text-shadow: 0 0 4px rgb(var(--color-accent-glow)/.6); text-align:center; }
+    .l3-freq { height: 4px; background: linear-gradient(90deg, var(--color-accent-fg), rgb(var(--color-accent-glow)/.15)); border-radius: 999px; box-shadow: 0 0 4px rgb(var(--color-accent-glow)/.4); }
     .l3-label { font-family: var(--font-mono); font-size: 11px; color: var(--brass-2); letter-spacing: .04em; }
-    .l3-by { font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .04em; }
+    .l3-by { font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .04em; }
     .l3-count { font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-muted); text-align: right; font-variant-numeric: tabular-nums; }
-    .l3-head { display:grid; grid-template-columns: 18px 100px 1fr 70px 50px; gap: 10px; padding: 6px 18px 4px; font-family: var(--font-mono); font-size: 8px; color: var(--fg-4); letter-spacing: .08em; text-transform: uppercase; border-bottom: 1px solid var(--color-border-default); }
+    .l3-head { display:grid; grid-template-columns: 18px 100px 1fr 70px 50px; gap: 10px; padding: 6px 18px 4px; font-family: var(--font-mono); font-size: 8px; color: var(--color-fg-disabled); letter-spacing: .08em; text-transform: uppercase; border-bottom: 1px solid var(--color-border-default); }
 
     /* ── L4 APPROVE ── */
     .l4-block { padding: 12px 18px; background: rgb(107 158 107 / .05); border-left: 2px solid var(--ok); position: relative; font-family: var(--font-mono); font-size: 11px; color: var(--color-fg-secondary); margin-bottom: 6px; }
     .l4-block.flag { background: rgb(196 106 90 / .05); border-left-color: var(--err); }
     .l4-stamp { position:absolute; right: 18px; top: 50%; transform: translateY(-50%) rotate(-10deg); font-family: var(--font-mono); font-size: 28px; color: var(--ok); opacity: .18; font-weight: 700; letter-spacing: .08em; }
     .l4-block.flag .l4-stamp { color: var(--err); }
-    .l4-by { font-size: 9px; color: var(--fg-4); letter-spacing: .04em; margin-top: 3px; }
+    .l4-by { font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .04em; margin-top: 3px; }
 
     /* ── L5 NOTES ── */
     .l5 { padding: 14px 18px; display:flex; gap: 12px; align-items:flex-start; }
@@ -75,29 +75,29 @@
     .l5-head { display:flex; align-items:center; gap: 5px; font-family: var(--font-mono); font-size: 9px; color: var(--stalled); letter-spacing: .06em; text-transform: uppercase; margin-bottom: 4px; }
     .l5-head .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--stalled); box-shadow: 0 0 4px rgb(var(--stalled-glow)/.8); }
     .l5-body { font-size: 11px; color: var(--color-fg-primary); line-height: 1.45; }
-    .l5-pin { position: absolute; top: -6px; right: 20px; width: 10px; height: 10px; border-radius: 50%; background: var(--color-accent-fg); box-shadow: 0 0 8px rgb(var(--brass-glow)/.7); border: 1px solid var(--brass-3); }
+    .l5-pin { position: absolute; top: -6px; right: 20px; width: 10px; height: 10px; border-radius: 50%; background: var(--color-accent-fg); box-shadow: 0 0 8px rgb(var(--color-accent-glow)/.7); border: 1px solid var(--color-accent-fg-dim); }
 
     /* ── COMBINED ── */
     .combo { position: relative; padding: 14px 18px; background: var(--color-bg-page); }
     .combo .layer-labels { position:absolute; top: 10px; right: 14px; display:flex; flex-direction: column; gap: 3px; font-family: var(--font-mono); font-size: 9px; letter-spacing: .08em; }
     .combo .layer-labels span { padding: 2px 6px; border: 1px solid var(--color-border-strong); border-radius: 2px; background: var(--color-bg-surface); }
-    .combo .layer-labels .on { color: var(--color-accent-fg); border-color: var(--brass-2); background: rgb(var(--brass-glow)/.08); }
+    .combo .layer-labels .on { color: var(--color-accent-fg); border-color: var(--brass-2); background: rgb(var(--color-accent-glow)/.08); }
     .code-line { display:flex; align-items:center; gap: 8px; font-family: var(--font-mono); font-size: 11px; padding: 2px 0; position: relative; }
     .code-line .time-bar { width: 3px; height: 14px; background: var(--warn); border-radius: 1px; }
-    .code-line .num { color: var(--fg-4); width: 20px; text-align: right; }
+    .code-line .num { color: var(--color-fg-disabled); width: 20px; text-align: right; }
     .code-line .src { flex: 1; color: var(--color-fg-secondary); }
     .code-line .src .hl { background: rgb(201 162 74 / .12); padding: 0 2px; }
     .code-line .cursor-chip { font-size: 9px; padding: 0 4px; border-radius: 2px; font-family: var(--font-mono); letter-spacing: .04em; }
-    .code-line .cursor-chip.c-nick { background: rgb(var(--brass-glow)/.15); color: var(--color-accent-fg); border: 1px solid var(--brass-2); }
+    .code-line .cursor-chip.c-nick { background: rgb(var(--color-accent-glow)/.15); color: var(--color-accent-fg); border: 1px solid var(--brass-2); }
     .code-line .cursor-chip.c-qa { background: rgb(196 106 90 / .15); color: var(--err-fg); border: 1px solid var(--err); }
     .code-line .cursor-chip.c-ss { background: rgb(107 158 107 / .12); color: var(--ok-fg); border: 1px solid var(--ok); }
-    .code-line .tool-glyph { color: var(--color-accent-fg); text-shadow: 0 0 4px rgb(var(--brass-glow)/.6); font-size: 11px; }
+    .code-line .tool-glyph { color: var(--color-accent-fg); text-shadow: 0 0 4px rgb(var(--color-accent-glow)/.6); font-size: 11px; }
 
     /* bar toggle */
     .bar { display:inline-flex; gap: 0; border: 1px solid var(--color-border-strong); border-radius: var(--r-1); overflow: hidden; background: var(--color-bg-surface); }
     .bar button { background: transparent; border: none; color: var(--color-fg-muted); padding: 5px 10px; font-family: var(--font-mono); font-size: 10px; letter-spacing: .08em; text-transform: uppercase; font-weight:600; cursor: pointer; border-right: 1px solid var(--color-border-strong); }
     .bar button:last-child { border-right: none; }
-    .bar button.on { background: rgb(var(--brass-glow)/.08); color: var(--color-accent-fg); box-shadow: inset 0 -1.5px 0 var(--color-accent-fg); }
+    .bar button.on { background: rgb(var(--color-accent-glow)/.08); color: var(--color-accent-fg); box-shadow: inset 0 -1.5px 0 var(--color-accent-fg); }
   </style>
 </head>
 <body>
@@ -113,7 +113,7 @@
         <span class="code">&lt;div class="bar"&gt; &lt;button class="on"&gt;L1&lt;/button&gt; … &lt;/div&gt;</span>
       </div>
       <div class="canvas" style="min-height: 60px; display:flex; align-items:center; gap: 14px; padding: 12px 14px;">
-        <span style="font-family:var(--font-mono); font-size:9px; color:var(--fg-4); letter-spacing:.08em; text-transform:uppercase;">LAYERS</span>
+        <span style="font-family:var(--font-mono); font-size:9px; color:var(--color-fg-disabled); letter-spacing:.08em; text-transform:uppercase;">LAYERS</span>
         <div class="bar">
           <button class="on">L1 · TIME</button>
           <button class="on">L2 · PARALLEL</button>
@@ -121,7 +121,7 @@
           <button class="on">L4 · APPROVE</button>
           <button>L5 · NOTES</button>
         </div>
-        <span style="margin-left: 8px; font-family:var(--font-mono); font-size:9px; color:var(--fg-4); letter-spacing:.08em;">OPACITY</span>
+        <span style="margin-left: 8px; font-family:var(--font-mono); font-size:9px; color:var(--color-fg-disabled); letter-spacing:.08em;">OPACITY</span>
         <input type="range" min="0" max="100" value="75" style="width: 120px; accent-color: var(--color-accent-fg);" />
         <span class="chip is-brass" style="margin-left: 2px">75%</span>
         <span style="margin-left: auto; font-family:var(--font-mono); font-size:10px; color:var(--color-accent-fg); cursor:pointer; letter-spacing:.08em; text-transform:uppercase;">↕ EXPLODE</span>
@@ -164,10 +164,10 @@
             <span>−5h</span><span>−4h</span><span>−3h</span><span>−2h</span><span>−1h</span><span>−30m</span><span>−10m</span><span style="color: var(--color-accent-fg)">NOW</span>
           </div>
           <div class="l1-legend">
-            <span><i class="swatch" style="background:var(--fg-4); opacity:.22"></i>cold (&gt;1h)</span>
+            <span><i class="swatch" style="background:var(--color-fg-disabled); opacity:.22"></i>cold (&gt;1h)</span>
             <span><i class="swatch" style="background:var(--warn); opacity:.55"></i>warm</span>
             <span><i class="swatch" style="background:var(--warn); box-shadow:0 0 4px rgb(var(--warn-glow))"></i>hot (&lt;30m)</span>
-            <span><i class="swatch" style="background:var(--color-accent-fg); box-shadow:0 0 4px rgb(var(--brass-glow))"></i>live (&lt;1m)</span>
+            <span><i class="swatch" style="background:var(--color-accent-fg); box-shadow:0 0 4px rgb(var(--color-accent-glow))"></i>live (&lt;1m)</span>
             <span style="margin-left:auto">hover for actor + timestamp</span>
           </div>
         </div>
@@ -183,7 +183,7 @@
         <div class="l2">
           <div class="lane" style="top: 10px">
             <span class="name">nick0cave</span>
-            <span class="cursor" style="left: 70%; color: var(--color-accent-fg); background: var(--color-accent-fg); box-shadow: 0 0 6px rgb(var(--brass-glow)/.7)"></span>
+            <span class="cursor" style="left: 70%; color: var(--color-accent-fg); background: var(--color-accent-fg); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.7)"></span>
           </div>
           <div class="lane" style="top: 42px">
             <span class="name">qa-king</span>
@@ -282,7 +282,7 @@
             <span class="on">L4 APPR</span>
             <span>L5 NOTE</span>
           </div>
-          <div style="font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .08em; text-transform: uppercase; margin-bottom: 6px;">src/keeper.ts · branch feat/keeper-clarity · 3 keepers attached</div>
+          <div style="font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .08em; text-transform: uppercase; margin-bottom: 6px;">src/keeper.ts · branch feat/keeper-clarity · 3 keepers attached</div>
           <div class="code-line"><span class="time-bar" style="opacity:.3; height:10px" title="L1 · cold (3h)"></span><span class="num">09</span><span class="src"><span class="k">async</span> <span class="f">tick</span>() {'{'}</span></div>
           <div class="code-line"><span class="time-bar" style="opacity:.9; box-shadow:0 0 6px rgb(var(--warn-glow)/.8)" title="L1 · 4m"></span><span class="num">10</span><span class="src">  <span class="k">if</span> (this.state !== <span class="s">'running'</span>) <span class="k">return</span>;</span><span class="cursor-chip c-qa" title="L2 · qa-king at col 24">qa-king</span></div>
           <div class="code-line"><span class="time-bar" style="opacity:1; box-shadow:0 0 8px rgb(var(--warn-glow))" title="L1 · 12s · live"></span><span class="num">11</span><span class="src">  <span class="tool-glyph" title="L3 · emit() called 12× in 60s">◈</span> <span class="f hl">emit</span>(<span class="s">'heartbeat'</span>);</span><span class="cursor-chip c-nick" title="L2 · nick0cave editing">nick0cave</span></div>

--- a/dashboard/design-system/preview/overlays.html
+++ b/dashboard/design-system/preview/overlays.html
@@ -10,12 +10,12 @@
   <style>
     html, body { margin:0; background: var(--color-bg-page); color: var(--color-fg-primary); font-family: var(--font-sans); min-height: 100vh; }
     .page { max-width: 1180px; margin:0 auto; padding: 32px 32px 96px; }
-    .back { font: var(--type-micro); color: var(--fg-4); text-decoration:none; letter-spacing: .08em; display:inline-block; margin-bottom:20px; }
+    .back { font: var(--type-micro); color: var(--color-fg-disabled); text-decoration:none; letter-spacing: .08em; display:inline-block; margin-bottom:20px; }
     .back:hover { color: var(--color-fg-secondary); }
     h1 { font-family: var(--font-mono); font-size: 18px; font-weight: 600; margin: 0 0 4px; }
     .sub { color: var(--color-fg-muted); font-size: 12px; margin-bottom: 28px; }
     h2 { font: var(--type-label); text-transform: uppercase; letter-spacing: .08em; color: var(--color-fg-muted); font-weight: 600; font-size: 11px; margin: 28px 0 8px; padding-bottom: 6px; border-bottom: 1px solid var(--color-border-strong); }
-    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); }
+    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled); }
 
     /* static frame that hosts a "live" overlay demo */
     .stage { position: relative; width: 100%; height: 320px; background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-radius: var(--r-1); overflow: hidden; }
@@ -26,18 +26,18 @@
         var(--color-bg-page);
       opacity: .45;
     }
-    .stage-caption { position: absolute; top: 8px; left: 10px; font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .08em; text-transform: uppercase; }
+    .stage-caption { position: absolute; top: 8px; left: 10px; font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .08em; text-transform: uppercase; }
     .stage-action { position: absolute; top: 8px; right: 10px; }
     .btn-ghost { background: var(--color-bg-panel-alt); border: 1px solid var(--color-border-strong); color: var(--color-fg-secondary); font-family: var(--font-mono); font-size: 10px; letter-spacing: .06em; text-transform: uppercase; font-weight: 600; padding: 3px 8px; border-radius: var(--r-1); cursor: pointer; }
     .btn-ghost:hover { border-color: var(--brass-2); color: var(--color-accent-fg); }
 
     /* ────── MODAL ────── */
     .scrim { position: absolute; inset: 0; background: rgba(10, 10, 12, .68); backdrop-filter: blur(2px); display: grid; place-items: center; z-index: 2; }
-    .modal { width: min(440px, 84%); background: var(--color-bg-surface); border: 1px solid var(--color-border-strong); border-radius: var(--r-1); box-shadow: 0 20px 60px rgba(0,0,0,.5), 0 0 0 1px rgb(var(--brass-glow)/.08); overflow: hidden; }
+    .modal { width: min(440px, 84%); background: var(--color-bg-surface); border: 1px solid var(--color-border-strong); border-radius: var(--r-1); box-shadow: 0 20px 60px rgba(0,0,0,.5), 0 0 0 1px rgb(var(--color-accent-glow)/.08); overflow: hidden; }
     .modal-head { display: flex; align-items: center; gap: 8px; padding: 10px 14px; border-bottom: 1px solid var(--color-border-default); background: linear-gradient(180deg, var(--color-bg-panel-alt), var(--color-bg-surface)); }
     .modal-head .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--err); box-shadow: 0 0 4px var(--err-glow); }
     .modal-head h3 { margin: 0; font-family: var(--font-mono); font-size: 12px; font-weight: 600; letter-spacing: .04em; color: var(--color-fg-primary); }
-    .modal-head .close { margin-left: auto; font-family: var(--font-mono); font-size: 12px; color: var(--fg-4); cursor: pointer; background: none; border: none; }
+    .modal-head .close { margin-left: auto; font-family: var(--font-mono); font-size: 12px; color: var(--color-fg-disabled); cursor: pointer; background: none; border: none; }
     .modal-body { padding: 14px; font-size: 12px; line-height: 1.55; color: var(--color-fg-secondary); }
     .modal-body .mono { font-family: var(--font-mono); color: var(--color-fg-primary); background: var(--color-bg-panel-alt); padding: 1px 5px; border-radius: 2px; border: 1px solid var(--color-border-default); font-size: 11px; }
     .modal-foot { display: flex; justify-content: flex-end; gap: 6px; padding: 10px 14px; border-top: 1px solid var(--color-border-default); background: var(--color-bg-page); }
@@ -45,17 +45,17 @@
     .btn:hover { border-color: var(--brass-2); color: var(--color-accent-fg); }
     .btn.is-danger { background: rgb(var(--err-glow)/.15); border-color: var(--err); color: var(--err-fg); }
     .btn.is-danger:hover { background: rgb(var(--err-glow)/.25); }
-    .btn.is-primary { background: rgb(var(--brass-glow)/.12); border-color: var(--color-accent-fg); color: var(--color-accent-fg); box-shadow: 0 0 8px rgb(var(--brass-glow)/.25); }
+    .btn.is-primary { background: rgb(var(--color-accent-glow)/.12); border-color: var(--color-accent-fg); color: var(--color-accent-fg); box-shadow: 0 0 8px rgb(var(--color-accent-glow)/.25); }
 
     /* ────── POPOVER ────── */
     .anchor-btn { position: absolute; top: 120px; left: 60px; background: var(--color-bg-panel-alt); border: 1px dashed var(--color-border-strong); color: var(--color-fg-secondary); font-family: var(--font-mono); font-size: 11px; padding: 5px 10px; border-radius: var(--r-1); cursor: pointer; }
-    .popover { position: absolute; background: var(--color-bg-panel-alt); border: 1px solid var(--color-border-strong); border-radius: var(--r-1); box-shadow: 0 10px 30px rgba(0,0,0,.45), 0 0 0 1px rgb(var(--brass-glow)/.08); min-width: 220px; z-index: 2; }
+    .popover { position: absolute; background: var(--color-bg-panel-alt); border: 1px solid var(--color-border-strong); border-radius: var(--r-1); box-shadow: 0 10px 30px rgba(0,0,0,.45), 0 0 0 1px rgb(var(--color-accent-glow)/.08); min-width: 220px; z-index: 2; }
     .popover::before { content:''; position: absolute; top: -5px; left: 24px; width: 8px; height: 8px; background: var(--color-bg-panel-alt); border-left: 1px solid var(--color-border-strong); border-top: 1px solid var(--color-border-strong); transform: rotate(45deg); }
     .popover-row { display: flex; align-items: center; gap: 8px; padding: 6px 10px; font-family: var(--font-mono); font-size: 11px; color: var(--color-fg-secondary); cursor: pointer; border-bottom: 1px solid var(--color-border-default); }
     .popover-row:last-child { border-bottom: none; }
     .popover-row:hover { background: var(--color-bg-elevated); color: var(--color-accent-fg); }
-    .popover-row .kbd { margin-left: auto; font-size: 9px; padding: 1px 4px; border: 1px solid var(--color-border-strong); border-radius: 2px; color: var(--fg-4); background: var(--color-bg-surface); }
-    .popover-header { padding: 6px 10px 4px; font-family: var(--font-mono); font-size: 9px; letter-spacing: .08em; color: var(--fg-4); text-transform: uppercase; font-weight: 600; border-bottom: 1px solid var(--color-border-default); }
+    .popover-row .kbd { margin-left: auto; font-size: 9px; padding: 1px 4px; border: 1px solid var(--color-border-strong); border-radius: 2px; color: var(--color-fg-disabled); background: var(--color-bg-surface); }
+    .popover-header { padding: 6px 10px 4px; font-family: var(--font-mono); font-size: 9px; letter-spacing: .08em; color: var(--color-fg-disabled); text-transform: uppercase; font-weight: 600; border-bottom: 1px solid var(--color-border-default); }
 
     /* ────── TOOLTIP ────── */
     .tt { position: absolute; background: var(--color-bg-elevated); color: var(--color-fg-primary); font-family: var(--font-mono); font-size: 10px; padding: 4px 8px; border-radius: var(--r-1); border: 1px solid var(--color-border-strong); box-shadow: 0 4px 12px rgba(0,0,0,.45); z-index: 2; max-width: 220px; }
@@ -68,14 +68,14 @@
     .toast { display: flex; align-items: flex-start; gap: 8px; padding: 8px 10px 8px 8px; background: var(--color-bg-panel-alt); border: 1px solid var(--color-border-strong); border-left: 2px solid var(--color-border-strong); border-radius: var(--r-1); box-shadow: 0 6px 18px rgba(0,0,0,.5); font-size: 11px; color: var(--color-fg-primary); }
     .toast .icon { width: 14px; text-align: center; font-family: var(--font-mono); font-weight: 700; font-size: 11px; flex-shrink: 0; line-height: 1.4; }
     .toast .body { flex: 1; line-height: 1.4; }
-    .toast .time { font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .04em; margin-top: 1px; }
-    .toast .close { font-family: var(--font-mono); color: var(--fg-4); cursor: pointer; background: none; border: none; padding: 0 2px; }
+    .toast .time { font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .04em; margin-top: 1px; }
+    .toast .close { font-family: var(--font-mono); color: var(--color-fg-disabled); cursor: pointer; background: none; border: none; padding: 0 2px; }
     .toast.is-ok { border-left-color: var(--ok); }
     .toast.is-ok .icon { color: var(--ok); }
     .toast.is-err { border-left-color: var(--err); }
     .toast.is-err .icon { color: var(--err); }
     .toast.is-brass { border-left-color: var(--color-accent-fg); }
-    .toast.is-brass .icon { color: var(--color-accent-fg); text-shadow: 0 0 4px rgb(var(--brass-glow)/.6); }
+    .toast.is-brass .icon { color: var(--color-accent-fg); text-shadow: 0 0 4px rgb(var(--color-accent-glow)/.6); }
     .toast.is-warn { border-left-color: var(--warn); }
     .toast.is-warn .icon { color: var(--warn); }
 
@@ -83,28 +83,28 @@
     .ctxmenu { position: absolute; min-width: 200px; background: var(--color-bg-panel-alt); border: 1px solid var(--color-border-strong); border-radius: var(--r-1); box-shadow: 0 10px 30px rgba(0,0,0,.5); z-index: 2; padding: 4px 0; }
     .ctxmenu .item { display: flex; align-items: center; gap: 8px; padding: 4px 10px; font-family: var(--font-mono); font-size: 11px; color: var(--color-fg-secondary); cursor: pointer; }
     .ctxmenu .item:hover { background: var(--color-bg-elevated); color: var(--color-accent-fg); }
-    .ctxmenu .item .glyph { width: 12px; color: var(--fg-4); text-align: center; }
+    .ctxmenu .item .glyph { width: 12px; color: var(--color-fg-disabled); text-align: center; }
     .ctxmenu .item:hover .glyph { color: var(--color-accent-fg); }
-    .ctxmenu .item .kbd { margin-left: auto; font-size: 9px; padding: 1px 4px; border: 1px solid var(--color-border-strong); border-radius: 2px; color: var(--fg-4); background: var(--color-bg-surface); }
+    .ctxmenu .item .kbd { margin-left: auto; font-size: 9px; padding: 1px 4px; border: 1px solid var(--color-border-strong); border-radius: 2px; color: var(--color-fg-disabled); background: var(--color-bg-surface); }
     .ctxmenu .sep { height: 1px; background: var(--color-border-default); margin: 4px 0; }
     .ctxmenu .item.is-danger { color: var(--err-fg); }
 
     /* ────── CMD PALETTE ────── */
     .cmdk-scrim { position: absolute; inset: 0; background: rgba(10,10,12,.7); backdrop-filter: blur(3px); display: flex; justify-content: center; padding-top: 40px; z-index: 2; }
-    .cmdk { width: min(520px, 86%); background: var(--color-bg-surface); border: 1px solid var(--brass-2); box-shadow: 0 20px 60px rgba(0,0,0,.6), 0 0 40px rgb(var(--brass-glow)/.15); border-radius: var(--r-1); overflow: hidden; height: fit-content; }
+    .cmdk { width: min(520px, 86%); background: var(--color-bg-surface); border: 1px solid var(--brass-2); box-shadow: 0 20px 60px rgba(0,0,0,.6), 0 0 40px rgb(var(--color-accent-glow)/.15); border-radius: var(--r-1); overflow: hidden; height: fit-content; }
     .cmdk-input { display: flex; align-items: center; gap: 8px; padding: 10px 14px; border-bottom: 1px solid var(--color-border-strong); }
-    .cmdk-input .prompt { font-family: var(--font-mono); color: var(--color-accent-fg); font-size: 13px; text-shadow: 0 0 6px rgb(var(--brass-glow)/.6); }
+    .cmdk-input .prompt { font-family: var(--font-mono); color: var(--color-accent-fg); font-size: 13px; text-shadow: 0 0 6px rgb(var(--color-accent-glow)/.6); }
     .cmdk-input input { flex: 1; background: transparent; border: none; outline: none; color: var(--color-fg-primary); font-family: var(--font-mono); font-size: 13px; caret-color: var(--color-accent-fg); }
-    .cmdk-input .hint { font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .08em; text-transform: uppercase; }
+    .cmdk-input .hint { font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .08em; text-transform: uppercase; }
     .cmdk-results { max-height: 230px; overflow-y: auto; }
-    .cmdk-group-head { padding: 6px 14px 2px; font-family: var(--font-mono); font-size: 9px; letter-spacing: .08em; color: var(--fg-4); text-transform: uppercase; font-weight: 600; }
+    .cmdk-group-head { padding: 6px 14px 2px; font-family: var(--font-mono); font-size: 9px; letter-spacing: .08em; color: var(--color-fg-disabled); text-transform: uppercase; font-weight: 600; }
     .cmdk-item { display: flex; align-items: center; gap: 10px; padding: 6px 14px; font-size: 12px; color: var(--color-fg-secondary); font-family: var(--font-mono); cursor: pointer; }
-    .cmdk-item .glyph { width: 16px; color: var(--fg-4); text-align: center; }
-    .cmdk-item .meta { margin-left: auto; font-size: 10px; color: var(--fg-4); }
-    .cmdk-item.is-sel { background: rgb(var(--brass-glow)/.1); color: var(--color-accent-fg); box-shadow: inset 2px 0 0 var(--color-accent-fg); }
-    .cmdk-item.is-sel .glyph { color: var(--color-accent-fg); text-shadow: 0 0 4px rgb(var(--brass-glow)/.6); }
+    .cmdk-item .glyph { width: 16px; color: var(--color-fg-disabled); text-align: center; }
+    .cmdk-item .meta { margin-left: auto; font-size: 10px; color: var(--color-fg-disabled); }
+    .cmdk-item.is-sel { background: rgb(var(--color-accent-glow)/.1); color: var(--color-accent-fg); box-shadow: inset 2px 0 0 var(--color-accent-fg); }
+    .cmdk-item.is-sel .glyph { color: var(--color-accent-fg); text-shadow: 0 0 4px rgb(var(--color-accent-glow)/.6); }
     .cmdk-item.is-sel .meta { color: var(--brass-2); }
-    .cmdk-foot { display: flex; gap: 14px; padding: 6px 14px; border-top: 1px solid var(--color-border-strong); background: var(--color-bg-page); font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .06em; }
+    .cmdk-foot { display: flex; gap: 14px; padding: 6px 14px; border-top: 1px solid var(--color-border-strong); background: var(--color-bg-page); font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .06em; }
     .cmdk-foot .k { padding: 1px 4px; border: 1px solid var(--color-border-strong); border-radius: 2px; color: var(--color-fg-muted); margin-right: 3px; }
   </style>
 </head>
@@ -131,7 +131,7 @@
             <span class="mono">3 threads</span> on keeper.ts will be abandoned and any in-flight emit() calls rolled back.
           </div>
           <div class="modal-foot">
-            <button class="btn">Cancel <span style="color:var(--fg-4); margin-left:4px">ESC</span></button>
+            <button class="btn">Cancel <span style="color:var(--color-fg-disabled); margin-left:4px">ESC</span></button>
             <button class="btn is-danger">Kill &amp; abandon</button>
           </div>
         </div>
@@ -182,7 +182,7 @@
     <div class="stage">
       <div class="faux"></div>
       <div class="stage-caption">on-thread context · 3 groups separated</div>
-      <span style="position:absolute; top:110px; left:180px; font-family:var(--font-mono); font-size:11px; color:var(--color-accent-fg); padding: 3px 8px; background: rgb(var(--brass-glow)/.1); border-radius: 2px;">thread t-9f2a</span>
+      <span style="position:absolute; top:110px; left:180px; font-family:var(--font-mono); font-size:11px; color:var(--color-accent-fg); padding: 3px 8px; background: rgb(var(--color-accent-glow)/.1); border-radius: 2px;">thread t-9f2a</span>
       <div class="ctxmenu" style="top:140px; left:180px">
         <div class="item"><span class="glyph">↗</span>open in rail <span class="kbd">↵</span></div>
         <div class="item"><span class="glyph">#</span>jump to line</div>

--- a/dashboard/design-system/preview/primitives.html
+++ b/dashboard/design-system/preview/primitives.html
@@ -11,7 +11,7 @@
     html, body { margin:0; background: var(--color-bg-page); color: var(--color-fg-primary); font-family: var(--font-sans); }
     .page { max-width: 1180px; margin:0 auto; padding: 32px 32px 96px; }
     .brand-row { display:flex; align-items:center; gap:10px; margin-bottom: 20px; }
-    .back { font: var(--type-micro); color: var(--fg-4); text-decoration:none; letter-spacing: .08em; }
+    .back { font: var(--type-micro); color: var(--color-fg-disabled); text-decoration:none; letter-spacing: .08em; }
     .back:hover { color: var(--color-fg-secondary); }
     h1 { font-family: var(--font-mono); font-size: 18px; font-weight: 600; margin: 0 0 4px; }
     .sub { color: var(--color-fg-muted); font-size: 12px; margin-bottom: 28px; }
@@ -19,17 +19,17 @@
     .seg { background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-radius: var(--r-1); padding: 16px 18px; margin-bottom: 10px; display: grid; grid-template-columns: 200px 1fr; gap: 20px; align-items: start; }
     .seg .meta { font-family: var(--font-mono); font-size: 11px; color: var(--color-fg-muted); }
     .seg .meta .n { color: var(--color-fg-primary); font-weight:600; font-size: 13px; margin-bottom: 4px; display:block; }
-    .seg .meta .code { display:block; margin-top: 6px; color: var(--fg-4); font-size: 10px; line-height: 1.5; }
+    .seg .meta .code { display:block; margin-top: 6px; color: var(--color-fg-disabled); font-size: 10px; line-height: 1.5; }
     .seg .demo { display:flex; flex-wrap:wrap; gap: 8px; align-items:center; min-height: 28px; }
     .seg .demo.col { flex-direction:column; align-items:stretch; gap: 4px; }
     .row-demo { display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
-    .grp-label { font: var(--type-micro); color: var(--fg-4); letter-spacing: .08em; text-transform:uppercase; margin-right: 4px; }
+    .grp-label { font: var(--type-micro); color: var(--color-fg-disabled); letter-spacing: .08em; text-transform:uppercase; margin-right: 4px; }
     .swatch { display:inline-flex; flex-direction:column; align-items:center; gap:3px; min-width: 56px; }
     .swatch .sw { width: 100%; height: 20px; border-radius: 2px; border: 1px solid var(--color-border-default); }
-    .swatch .lb { font: var(--type-micro); color: var(--fg-4); letter-spacing: .04em; }
+    .swatch .lb { font: var(--type-micro); color: var(--color-fg-disabled); letter-spacing: .04em; }
     /* kv showcase */
     .kv-sample { background: var(--color-bg-panel-alt); border:1px solid var(--color-border-default); border-radius: var(--r-1); padding: 8px 12px; min-width: 280px; }
-    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); }
+    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled); }
   </style>
 </head>
 <body>
@@ -235,7 +235,7 @@
       <div class="demo col">
         <div class="row-demo">
           <span class="grp-label">heartbeat</span>
-          <span class="dot-k-nick" style="width:9px; height:9px; border-radius:50%; background: var(--color-accent-fg); box-shadow: 0 0 6px rgb(var(--brass-glow)/.7)" class="anim-heartbeat"></span>
+          <span class="dot-k-nick" style="width:9px; height:9px; border-radius:50%; background: var(--color-accent-fg); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.7)" class="anim-heartbeat"></span>
           <span style="width:16px"></span>
           <span class="grp-label">pulse-glow</span>
           <span style="width: 60px; height: 18px; border-radius: 3px; background: var(--color-bg-elevated); display:inline-block" class="anim-pulse-glow"></span>

--- a/dashboard/design-system/preview/scope-phase2.html
+++ b/dashboard/design-system/preview/scope-phase2.html
@@ -23,7 +23,7 @@
     padding: 32px 40px 0;
   }
   .pg-head {
-    border-bottom: 1px solid var(--line-3);
+    border-bottom: 1px solid var(--color-border-divider);
     padding-bottom: 20px;
     margin-bottom: 32px;
     display: grid;
@@ -63,8 +63,8 @@
     display: grid;
     grid-template-columns: repeat(4, 1fr);
     gap: 1px;
-    background: var(--line-3);
-    border: 1px solid var(--line-3);
+    background: var(--color-border-divider);
+    border: 1px solid var(--color-border-divider);
     margin-bottom: 40px;
   }
   .toc > div {

--- a/dashboard/design-system/preview/scope-phase3.html
+++ b/dashboard/design-system/preview/scope-phase3.html
@@ -11,13 +11,13 @@
 <style>
   body { margin:0; padding:0 0 96px; background:var(--color-bg-page); color:var(--color-fg-primary); font:13px/1.45 var(--font-sans); }
   .pg { max-width:1320px; margin:0 auto; padding:32px 40px 0; }
-  .pg-head { display:grid; grid-template-columns:1fr auto; gap:24px; align-items:end; padding-bottom:20px; margin-bottom:28px; border-bottom:1px solid var(--line-3); }
+  .pg-head { display:grid; grid-template-columns:1fr auto; gap:24px; align-items:end; padding-bottom:20px; margin-bottom:28px; border-bottom:1px solid var(--color-border-divider); }
   .eyebrow { font:500 10px/1 var(--font-mono); letter-spacing:.12em; text-transform:uppercase; color:var(--color-accent-fg); margin-bottom:10px; }
   h1 { margin:0 0 8px; font:500 26px/1.15 var(--font-sans); color:var(--fg-0); }
   .sub { max-width:760px; color:var(--color-fg-muted); }
   .meta { text-align:right; font:10px/1.5 var(--font-mono); color:var(--color-fg-muted); letter-spacing:.08em; text-transform:uppercase; }
   .meta b { color:var(--color-accent-fg); font-weight:500; }
-  .toc { display:grid; grid-template-columns:repeat(5,1fr); gap:1px; background:var(--line-3); border:1px solid var(--line-3); margin-bottom:34px; }
+  .toc { display:grid; grid-template-columns:repeat(5,1fr); gap:1px; background:var(--color-border-divider); border:1px solid var(--color-border-divider); margin-bottom:34px; }
   .toc a { display:block; padding:12px 14px; background:var(--color-bg-surface); color:var(--color-fg-secondary); text-decoration:none; font:11px/1.55 var(--font-mono); }
   .toc a b { display:block; color:var(--color-accent-fg); font-size:10px; letter-spacing:.1em; text-transform:uppercase; margin-bottom:6px; }
   .zones { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:14px; margin-bottom:36px; }
@@ -34,7 +34,7 @@
   code { color:var(--color-accent-fg); font-family:var(--font-mono); }
   table { width:100%; border-collapse:collapse; background:var(--color-bg-surface); border:1px solid var(--color-border-strong); font:11px/1.45 var(--font-mono); }
   th, td { padding:8px 10px; border-bottom:1px solid var(--color-border-default); text-align:left; vertical-align:top; }
-  th { color:var(--fg-4); background:var(--color-bg-panel-alt); text-transform:uppercase; letter-spacing:.08em; }
+  th { color:var(--color-fg-disabled); background:var(--color-bg-panel-alt); text-transform:uppercase; letter-spacing:.08em; }
   td:first-child { color:var(--color-accent-fg); white-space:nowrap; }
   .accept { margin-top:30px; padding:16px 18px; background:var(--color-bg-surface); border:1px solid var(--color-border-strong); border-left:2px solid var(--color-accent-fg); }
   .accept h2 { margin:0 0 10px; font:500 15px/1.2 var(--font-sans); }

--- a/dashboard/design-system/preview/snippets.html
+++ b/dashboard/design-system/preview/snippets.html
@@ -79,21 +79,21 @@
     /* form-control subset (mirrors forms.html) — needed so .input/.toggle/.check/.segmented snippets render in preview */
     .field { display:flex; flex-direction:column; gap:3px; }
     .field-label { font-family: var(--font-mono); font-size: 9px; letter-spacing: .08em; color: var(--color-fg-muted); text-transform:uppercase; font-weight:600; }
-    .field-hint { font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .04em; }
+    .field-hint { font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .04em; }
     .input { background: var(--color-bg-panel-alt); border: 1px solid var(--color-border-strong); border-radius: var(--r-1); padding: 6px 10px; color: var(--color-fg-primary); font-family: var(--font-mono); font-size: 12px; outline: none; width: 100%; box-sizing:border-box; }
-    .input::placeholder { color: var(--fg-4); }
-    .input:focus { border-color: var(--brass-2); box-shadow: 0 0 0 1px var(--brass-2), 0 0 10px rgb(var(--brass-glow)/.18); background: var(--color-bg-elevated); }
+    .input::placeholder { color: var(--color-fg-disabled); }
+    .input:focus { border-color: var(--brass-2); box-shadow: 0 0 0 1px var(--brass-2), 0 0 10px rgb(var(--color-accent-glow)/.18); background: var(--color-bg-elevated); }
     .check { display:inline-flex; align-items:center; gap: 6px; cursor:pointer; user-select:none; font-family: var(--font-mono); font-size: 11px; color: var(--color-fg-secondary); }
     .check input { position: absolute; opacity: 0; width: 0; height: 0; pointer-events:none; }
     .check .box { width: 13px; height: 13px; border: 1px solid var(--color-border-strong); border-radius: 2px; background: var(--color-bg-panel-alt); display:inline-grid; place-items:center; transition: all .12s; flex-shrink:0; }
-    .check input:checked + .box { background: var(--color-accent-fg); border-color: var(--color-accent-fg); box-shadow: 0 0 8px rgb(var(--brass-glow)/.5); }
+    .check input:checked + .box { background: var(--color-accent-fg); border-color: var(--color-accent-fg); box-shadow: 0 0 8px rgb(var(--color-accent-glow)/.5); }
     .check input:checked + .box::after { content: ''; width: 6px; height: 3px; border-left: 1.5px solid var(--color-bg-page); border-bottom: 1.5px solid var(--color-bg-page); transform: rotate(-45deg) translate(1px, -1px); }
     .toggle { display:inline-flex; align-items:center; gap: 8px; cursor:pointer; user-select:none; font-family: var(--font-mono); font-size: 11px; color: var(--color-fg-secondary); }
     .toggle input { position:absolute; opacity:0; }
     .toggle .track { width: 26px; height: 14px; background: var(--color-bg-elevated); border: 1px solid var(--color-border-strong); border-radius: 999px; position: relative; transition: all .15s; flex-shrink:0; }
     .toggle .track::after { content: ''; position: absolute; top: 1px; left: 1px; width: 10px; height: 10px; border-radius: 50%; background: var(--color-fg-muted); transition: all .15s; }
-    .toggle input:checked + .track { background: rgb(var(--brass-glow)/.15); border-color: var(--brass-2); }
-    .toggle input:checked + .track::after { left: 13px; background: var(--color-accent-fg); box-shadow: 0 0 6px rgb(var(--brass-glow)/.7); }
+    .toggle input:checked + .track { background: rgb(var(--color-accent-glow)/.15); border-color: var(--brass-2); }
+    .toggle input:checked + .track::after { left: 13px; background: var(--color-accent-fg); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.7); }
     .segmented { display: inline-flex; border: 1px solid var(--color-border-strong); border-radius: var(--r-1); overflow: hidden; background: var(--color-bg-panel-alt); }
     .segmented button { background: transparent; border: none; color: var(--color-fg-muted); font-family: var(--font-mono); font-size: 10px; letter-spacing: .08em; text-transform: uppercase; font-weight: 600; padding: 5px 12px; cursor: pointer; border-right: 1px solid var(--color-border-strong); }
     .segmented button:last-child { border-right: none; }

--- a/dashboard/design-system/preview/snippets.jsx
+++ b/dashboard/design-system/preview/snippets.jsx
@@ -374,9 +374,9 @@ const SNIPPETS = [
   <div class="nd-row">
     <span class="ts">12:05</span>
     <span style="font-family:var(--font-mono);font-size:11px;color:var(--color-accent-fg)">@sangsu</span>
-    <span style="font-family:var(--font-mono);font-size:9px;padding:1px 5px;border:1px solid var(--brass-3);color:var(--color-accent-fg);background:rgb(var(--brass-glow)/.08);text-transform:uppercase;letter-spacing:.06em">→ keeper-merge</span>
+    <span style="font-family:var(--font-mono);font-size:9px;padding:1px 5px;border:1px solid var(--color-accent-fg-dim);color:var(--color-accent-fg);background:rgb(var(--color-accent-glow)/.08);text-transform:uppercase;letter-spacing:.06em">→ keeper-merge</span>
     <span style="font-family:var(--font-mono);font-size:11px;color:var(--color-fg-primary);line-height:1.4">extend probe window to 4s before fallback — see ar-2025-04-11/f-002</span>
-    <span style="font-family:var(--font-mono);font-size:9px;color:var(--fg-4);text-transform:uppercase;letter-spacing:.06em">cooldown 30s</span>
+    <span style="font-family:var(--font-mono);font-size:9px;color:var(--color-fg-disabled);text-transform:uppercase;letter-spacing:.06em">cooldown 30s</span>
   </div>
 </div>`,
   },

--- a/dashboard/design-system/preview/spacing.html
+++ b/dashboard/design-system/preview/spacing.html
@@ -18,7 +18,7 @@
   .sp-name { font: 600 10px/1.2 var(--font-mono); letter-spacing: var(--track-caps); text-transform: uppercase; color: var(--color-fg-secondary); }
   .sp-bar-wrap { height: 36px; position: relative; display: flex; align-items: center; }
   .sp-bar {
-    background: var(--brass-3);
+    background: var(--color-accent-fg-dim);
     border: 1px solid var(--brass-2);
     height: 18px;
     position: relative;

--- a/dashboard/design-system/preview/swimlanes.html
+++ b/dashboard/design-system/preview/swimlanes.html
@@ -10,72 +10,72 @@
   <style>
     html, body { margin:0; background: var(--color-bg-page); color: var(--color-fg-primary); font-family: var(--font-sans); min-height: 100vh; }
     .page { max-width: 1180px; margin:0 auto; padding: 32px 32px 96px; }
-    .back { font: var(--type-micro); color: var(--fg-4); text-decoration:none; letter-spacing: .08em; display:inline-block; margin-bottom:20px; }
+    .back { font: var(--type-micro); color: var(--color-fg-disabled); text-decoration:none; letter-spacing: .08em; display:inline-block; margin-bottom:20px; }
     .back:hover { color: var(--color-fg-secondary); }
     h1 { font-family: var(--font-mono); font-size: 18px; font-weight: 600; margin: 0 0 4px; }
     .sub { color: var(--color-fg-muted); font-size: 12px; margin-bottom: 28px; line-height:1.5; max-width: 700px; }
     h2 { font: var(--type-label); text-transform: uppercase; letter-spacing: .08em; color: var(--color-fg-muted); font-weight: 600; font-size: 11px; margin: 28px 0 8px; padding-bottom: 6px; border-bottom: 1px solid var(--color-border-strong); }
     h2 .tag { margin-left: 8px; color: var(--color-accent-fg); font-weight: 500; }
-    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); }
+    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled); }
 
     .seg { background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-radius: var(--r-1); padding: 16px; margin-bottom: 10px; display:grid; grid-template-columns: 260px 1fr; gap:18px; align-items:start; }
     .seg .meta { font-family: var(--font-mono); font-size: 11px; color: var(--color-fg-muted); line-height: 1.5; }
     .seg .meta .n { color: var(--color-fg-primary); font-weight:600; font-size: 13px; margin-bottom: 4px; display:block; }
-    .seg .meta .code { display:block; margin-top: 6px; color: var(--fg-4); font-size: 10px; }
+    .seg .meta .code { display:block; margin-top: 6px; color: var(--color-fg-disabled); font-size: 10px; }
 
     /* ── BASE LANE ── sharp / blueprint treatment */
-    .sw { position: relative; background: var(--color-bg-page); border: 1px solid var(--color-border-strong); border-radius: 0; overflow: hidden; box-shadow: inset 0 0 0 1px rgb(0 0 0 / .4), 0 1px 0 rgb(var(--brass-glow)/.05); }
+    .sw { position: relative; background: var(--color-bg-page); border: 1px solid var(--color-border-strong); border-radius: 0; overflow: hidden; box-shadow: inset 0 0 0 1px rgb(0 0 0 / .4), 0 1px 0 rgb(var(--color-accent-glow)/.05); }
     .sw::before, .sw::after { content: ''; position: absolute; width: 8px; height: 8px; pointer-events: none; z-index: 3; }
     .sw::before { top: 0; left: 0; border-top: 1px solid var(--brass-2); border-left: 1px solid var(--brass-2); }
     .sw::after  { bottom: 0; right: 0; border-bottom: 1px solid var(--brass-2); border-right: 1px solid var(--brass-2); }
     .sw-head { display:flex; align-items:center; gap: 10px; padding: 5px 10px; background: linear-gradient(180deg, var(--color-bg-panel-alt), var(--color-bg-surface)); border-bottom: 1px solid var(--color-border-strong); font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-muted); letter-spacing: .1em; text-transform: uppercase; position: relative; }
-    .sw-head::after { content:''; position:absolute; left:0; right:0; bottom:-1px; height:1px; background: linear-gradient(90deg, transparent, rgb(var(--brass-glow)/.4), transparent); }
-    .sw-ruler { display:flex; flex: 1; justify-content: space-between; color: var(--fg-4); }
+    .sw-head::after { content:''; position:absolute; left:0; right:0; bottom:-1px; height:1px; background: linear-gradient(90deg, transparent, rgb(var(--color-accent-glow)/.4), transparent); }
+    .sw-ruler { display:flex; flex: 1; justify-content: space-between; color: var(--color-fg-disabled); }
     .sw-ruler span { font-variant-numeric: tabular-nums; padding: 0 4px; border-left: 1px solid var(--color-border-default); }
     .sw-ruler span:first-child { border-left: none; padding-left: 0; }
     .sw-body { position: relative; background-image: linear-gradient(90deg, transparent 0, transparent calc(25% - 1px), var(--color-border-default) calc(25% - 1px), var(--color-border-default) 25%, transparent 25%), linear-gradient(90deg, transparent 0, transparent calc(50% - 1px), var(--color-border-default) calc(50% - 1px), var(--color-border-default) 50%, transparent 50%), linear-gradient(90deg, transparent 0, transparent calc(75% - 1px), var(--color-border-default) calc(75% - 1px), var(--color-border-default) 75%, transparent 75%); background-size: 100% 100%; background-position: 88px 0; background-repeat: no-repeat; }
     .lane { position: relative; height: 30px; display:flex; align-items:center; gap: 10px; padding: 0 10px; border-bottom: 1px solid var(--color-border-default); }
     .lane:last-child { border-bottom: none; }
-    .lane:hover { background: rgb(var(--brass-glow)/.025); }
+    .lane:hover { background: rgb(var(--color-accent-glow)/.025); }
     .lane-name { width: 88px; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-secondary); letter-spacing: .04em; display:flex; align-items:center; gap: 5px; flex-shrink:0; padding-right: 8px; border-right: 1px solid var(--color-border-strong); height: 100%; box-sizing: border-box; }
     .lane-name .dot { width: 4px; height: 4px; background: currentColor; border-radius: 0; transform: rotate(45deg); flex-shrink:0; }
     .lane-track { position: relative; flex: 1; height: 18px; }
     .tick { position:absolute; top: 50%; transform: translateY(-50%); height: 10px; border-radius: 0; }
-    .tick.emit    { background: var(--color-accent-fg); box-shadow: 0 0 4px rgb(var(--brass-glow)/.6); clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%); width: 8px !important; }
+    .tick.emit    { background: var(--color-accent-fg); box-shadow: 0 0 4px rgb(var(--color-accent-glow)/.6); clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%); width: 8px !important; }
     .tick.tool    { background: var(--info); clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%); width: 4px !important; }
     .tick.approve { background: var(--ok); clip-path: polygon(0 0, 100% 50%, 0 100%); width: 8px !important; box-shadow: 0 0 3px rgb(var(--ok-glow)/.5); }
     .tick.flag    { background: var(--err); clip-path: polygon(50% 0, 100% 100%, 0 100%); width: 8px !important; box-shadow: 0 0 4px rgb(var(--err-glow)/.6); }
     .tick.commit  { background: var(--brass-2); height: 16px; clip-path: polygon(0 0, 100% 0, 50% 100%); width: 8px !important; }
     .span { position:absolute; top: 50%; transform: translateY(-50%); height: 8px; border-radius: 0; }
-    .span.run   { background: linear-gradient(90deg, rgb(var(--brass-glow)/.5), rgb(var(--brass-glow)/.12)); border: 1px solid var(--brass-2); border-left-width: 2px; clip-path: polygon(0 0, 100% 0, calc(100% - 4px) 100%, 0 100%); }
+    .span.run   { background: linear-gradient(90deg, rgb(var(--color-accent-glow)/.5), rgb(var(--color-accent-glow)/.12)); border: 1px solid var(--brass-2); border-left-width: 2px; clip-path: polygon(0 0, 100% 0, calc(100% - 4px) 100%, 0 100%); }
     .span.stall { background: repeating-linear-gradient(45deg, rgb(var(--stalled-glow)/.35) 0 4px, transparent 4px 8px); border: 1px dashed var(--stalled); }
-    .now { position: absolute; top: 0; bottom: 0; width: 0; border-left: 1px solid rgb(var(--brass-glow)/.85); box-shadow: -1px 0 8px rgb(var(--brass-glow)/.4), 1px 0 0 rgb(var(--brass-glow)/.2); z-index: 2; }
-    .now::before { content: 'NOW'; position:absolute; top: 2px; left: 4px; font-family: var(--font-mono); font-size: 8px; color: var(--color-accent-fg); letter-spacing: .15em; text-shadow: 0 0 4px rgb(var(--brass-glow)/.8); border: 1px solid var(--brass-2); padding: 1px 3px; background: var(--color-bg-page); }
-    .now::after { content: ''; position: absolute; left: -3px; top: 0; width: 7px; height: 7px; background: var(--color-accent-fg); clip-path: polygon(50% 100%, 0 0, 100% 0); box-shadow: 0 0 6px rgb(var(--brass-glow)/.7); }
+    .now { position: absolute; top: 0; bottom: 0; width: 0; border-left: 1px solid rgb(var(--color-accent-glow)/.85); box-shadow: -1px 0 8px rgb(var(--color-accent-glow)/.4), 1px 0 0 rgb(var(--color-accent-glow)/.2); z-index: 2; }
+    .now::before { content: 'NOW'; position:absolute; top: 2px; left: 4px; font-family: var(--font-mono); font-size: 8px; color: var(--color-accent-fg); letter-spacing: .15em; text-shadow: 0 0 4px rgb(var(--color-accent-glow)/.8); border: 1px solid var(--brass-2); padding: 1px 3px; background: var(--color-bg-page); }
+    .now::after { content: ''; position: absolute; left: -3px; top: 0; width: 7px; height: 7px; background: var(--color-accent-fg); clip-path: polygon(50% 100%, 0 0, 100% 0); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.7); }
 
     /* ── EMPTY ── */
-    .empty-slate { text-align: center; padding: 40px 20px; color: var(--fg-4); font-family: var(--font-mono); font-size: 11px; }
+    .empty-slate { text-align: center; padding: 40px 20px; color: var(--color-fg-disabled); font-family: var(--font-mono); font-size: 11px; }
     .empty-slate .big { font-size: 22px; color: var(--color-fg-muted); opacity: .4; letter-spacing: .1em; }
-    .empty-slate .action { margin-top: 10px; display:inline-block; padding: 4px 12px; border: 1px solid var(--brass-2); color: var(--color-accent-fg); border-radius: 0; font-size: 10px; letter-spacing: .1em; text-transform:uppercase; cursor:pointer; background: rgb(var(--brass-glow)/.06); clip-path: polygon(6px 0, 100% 0, calc(100% - 6px) 100%, 0 100%); padding: 4px 18px; }
+    .empty-slate .action { margin-top: 10px; display:inline-block; padding: 4px 12px; border: 1px solid var(--brass-2); color: var(--color-accent-fg); border-radius: 0; font-size: 10px; letter-spacing: .1em; text-transform:uppercase; cursor:pointer; background: rgb(var(--color-accent-glow)/.06); clip-path: polygon(6px 0, 100% 0, calc(100% - 6px) 100%, 0 100%); padding: 4px 18px; }
 
     /* ── WATERFALL ── */
-    .wf .lane-track .span.run.d1 { left: 2%; width: 22%; background: linear-gradient(90deg, var(--color-accent-fg), rgb(var(--brass-glow)/.2)); }
+    .wf .lane-track .span.run.d1 { left: 2%; width: 22%; background: linear-gradient(90deg, var(--color-accent-fg), rgb(var(--color-accent-glow)/.2)); }
     .wf .lane-track .span.run.d2 { left: 22%; width: 28%; background: linear-gradient(90deg, var(--info), rgb(106 142 176 / .2)); }
     .wf .lane-track .span.run.d3 { left: 48%; width: 18%; background: linear-gradient(90deg, var(--ok), rgb(107 158 107 / .2)); }
-    .wf .lane-track .span.run.d4 { left: 64%; width: 32%; background: linear-gradient(90deg, var(--brass-2), rgb(var(--brass-glow)/.1)); }
+    .wf .lane-track .span.run.d4 { left: 64%; width: 32%; background: linear-gradient(90deg, var(--brass-2), rgb(var(--color-accent-glow)/.1)); }
 
     /* ── HANDOFF arrow ── sharp angle */
     .handoff { position:absolute; top:50%; height: 14px; width: 28px; transform: translateY(-100%); pointer-events:none; }
-    .handoff::before { content: ''; position: absolute; left: 0; right: 6px; top: 0; height: 1px; background: var(--color-accent-fg); box-shadow: 0 0 4px rgb(var(--brass-glow)/.5); }
+    .handoff::before { content: ''; position: absolute; left: 0; right: 6px; top: 0; height: 1px; background: var(--color-accent-fg); box-shadow: 0 0 4px rgb(var(--color-accent-glow)/.5); }
     .handoff::after { content: ''; position: absolute; right: 0; top: 0; width: 6px; height: 14px; border-left: 1px solid var(--color-accent-fg); }
-    .handoff .ah { position:absolute; right: -3px; bottom: -4px; width: 7px; height: 7px; background: var(--color-accent-fg); clip-path: polygon(50% 100%, 0 0, 100% 0); box-shadow: 0 0 4px rgb(var(--brass-glow)/.6); }
+    .handoff .ah { position:absolute; right: -3px; bottom: -4px; width: 7px; height: 7px; background: var(--color-accent-fg); clip-path: polygon(50% 100%, 0 0, 100% 0); box-shadow: 0 0 4px rgb(var(--color-accent-glow)/.6); }
     .handoff-label { position:absolute; top: -14px; font-family: var(--font-mono); font-size: 8px; color: var(--brass-2); letter-spacing: .1em; white-space: nowrap; text-transform: uppercase; padding: 1px 4px; background: var(--color-bg-page); border: 1px solid var(--color-border-strong); }
 
     /* ── COLLAPSED (grouped) ── */
-    .group-bar { position: relative; display:flex; align-items:center; gap: 10px; padding: 0 10px; height: 28px; border-bottom: 1px solid var(--color-border-strong); background: linear-gradient(90deg, rgb(var(--brass-glow)/.06), transparent 60%); }
+    .group-bar { position: relative; display:flex; align-items:center; gap: 10px; padding: 0 10px; height: 28px; border-bottom: 1px solid var(--color-border-strong); background: linear-gradient(90deg, rgb(var(--color-accent-glow)/.06), transparent 60%); }
     .group-name { width: 88px; font-family: var(--font-mono); font-size: 10px; color: var(--color-accent-fg); letter-spacing: .08em; text-transform: uppercase; display:flex; align-items:center; gap:5px; flex-shrink:0; padding-right: 8px; border-right: 1px solid var(--color-border-strong); height: 100%; box-sizing: border-box; }
     .group-name .chev { font-size: 8px; }
-    .group-name .cnt { color: var(--fg-4); font-size: 9px; font-weight: 400; letter-spacing: .04em; }
+    .group-name .cnt { color: var(--color-fg-disabled); font-size: 9px; font-weight: 400; letter-spacing: .04em; }
     .group-stack { flex: 1; position: relative; height: 18px; }
     .group-stack .mini { position:absolute; top: 0; height: 3px; background: var(--color-accent-fg); border-radius: 0; opacity: .65; clip-path: polygon(0 0, 100% 0, calc(100% - 2px) 100%, 0 100%); }
     .group-stack .mini:nth-child(2) { top: 5px; background: var(--info); }
@@ -88,14 +88,14 @@
     .density-bar { display:inline-flex; gap: 0; border: 1px solid var(--color-border-strong); border-radius: 0; overflow: hidden; background: var(--color-bg-surface); margin-bottom: 8px; font-family: var(--font-mono); font-size: 10px; letter-spacing: .1em; text-transform:uppercase; }
     .density-bar button { background: transparent; border: none; color: var(--color-fg-muted); padding: 4px 12px; cursor: pointer; border-right: 1px solid var(--color-border-strong); font-weight: 600; }
     .density-bar button:last-child { border-right: none; }
-    .density-bar button.on { background: rgb(var(--brass-glow)/.1); color: var(--color-accent-fg); box-shadow: inset 0 -2px 0 var(--color-accent-fg); }
+    .density-bar button.on { background: rgb(var(--color-accent-glow)/.1); color: var(--color-accent-fg); box-shadow: inset 0 -2px 0 var(--color-accent-fg); }
     .comfy .lane { height: 38px; }
     .compact .lane { height: 22px; }
     .tiny .lane { height: 14px; border-bottom-style: solid; border-bottom-color: var(--color-border-default); }
     .tiny .lane-name { font-size: 9px; }
     .tiny .tick { height: 6px; }
 
-    .row { display:flex; gap:6px; align-items:center; margin-top: 6px; flex-wrap:wrap; font-family: var(--font-mono); font-size:10px; color: var(--fg-4); }
+    .row { display:flex; gap:6px; align-items:center; margin-top: 6px; flex-wrap:wrap; font-family: var(--font-mono); font-size:10px; color: var(--color-fg-disabled); }
 
     /* chip primitives if primitives.css doesn't load them */
     .chip { display:inline-flex; align-items:center; padding: 2px 8px; font-family: var(--font-mono); font-size: 10px; background: var(--color-bg-panel-alt); border: 1px solid var(--color-border-strong); color: var(--color-fg-secondary); border-radius: 999px; letter-spacing: .04em; }
@@ -135,7 +135,7 @@
           <div class="empty-slate">
             <div class="big">∅</div>
             <div style="margin-top:6px">no keepers registered</div>
-            <div style="color:var(--fg-4); margin-top:4px; font-size:10px;">spawn a keeper to begin · <span style="color:var(--color-accent-fg)">⌘K</span> then "spawn keeper"</div>
+            <div style="color:var(--color-fg-disabled); margin-top:4px; font-size:10px;">spawn a keeper to begin · <span style="color:var(--color-accent-fg)">⌘K</span> then "spawn keeper"</div>
             <div class="action">+ SPAWN KEEPER</div>
           </div>
         </div>
@@ -156,7 +156,7 @@
           <div class="lane"><span class="lane-name" style="color:var(--brass-2)"><span class="dot"></span>commit</span><div class="lane-track"><span class="span run d4"></span></div></div>
           <div class="now" style="left: 96%"></div>
         </div>
-        <div style="padding: 4px 10px; font-family:var(--font-mono); font-size:10px; color:var(--fg-4); background:var(--color-bg-surface); border-top:1px solid var(--color-border-default);">total 1.24s · critical path: moonshot (320ms) → guard (210ms)</div>
+        <div style="padding: 4px 10px; font-family:var(--font-mono); font-size:10px; color:var(--color-fg-disabled); background:var(--color-bg-surface); border-top:1px solid var(--color-border-default);">total 1.24s · critical path: moonshot (320ms) → guard (210ms)</div>
       </div>
     </div>
 

--- a/dashboard/design-system/preview/tokrate.html
+++ b/dashboard/design-system/preview/tokrate.html
@@ -10,25 +10,25 @@
   <style>
     html, body { margin:0; background: var(--color-bg-page); color: var(--color-fg-primary); font-family: var(--font-sans); min-height: 100vh; }
     .page { max-width: 1180px; margin:0 auto; padding: 32px 32px 96px; }
-    .back { font: var(--type-micro); color: var(--fg-4); text-decoration:none; letter-spacing: .08em; display:inline-block; margin-bottom:20px; }
+    .back { font: var(--type-micro); color: var(--color-fg-disabled); text-decoration:none; letter-spacing: .08em; display:inline-block; margin-bottom:20px; }
     .back:hover { color: var(--color-fg-secondary); }
     h1 { font-family: var(--font-mono); font-size: 18px; font-weight: 600; margin: 0 0 4px; }
     .sub { color: var(--color-fg-muted); font-size: 12px; margin-bottom: 28px; line-height:1.5; max-width: 700px; }
     h2 { font: var(--type-label); text-transform: uppercase; letter-spacing: .08em; color: var(--color-fg-muted); font-weight: 600; font-size: 11px; margin: 28px 0 8px; padding-bottom: 6px; border-bottom: 1px solid var(--color-border-strong); }
     h2 .tag { margin-left: 8px; color: var(--color-accent-fg); font-weight: 500; }
-    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); }
+    .stamp { position:fixed; top:12px; right:16px; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled); }
 
     .seg { background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-radius: var(--r-1); padding: 16px; margin-bottom: 10px; }
     .seg .meta { font-family: var(--font-mono); font-size: 11px; color: var(--color-fg-muted); line-height: 1.5; margin-bottom: 12px; }
     .seg .meta .n { color: var(--color-fg-primary); font-weight:600; font-size: 13px; margin-right: 10px; }
-    .seg .meta .code { color: var(--fg-4); font-size: 10px; }
+    .seg .meta .code { color: var(--color-fg-disabled); font-size: 10px; }
 
     /* ── KPI CHIP ── */
     .kpi { display:grid; grid-template-columns: 1fr auto; grid-template-rows: auto auto; align-items:center; column-gap: 12px; row-gap: 0; padding: 8px 14px 9px 12px; background: var(--color-bg-panel-alt); border: 1px solid var(--color-border-strong); border-left: 2px solid var(--color-accent-fg); border-radius: var(--r-1); min-width: 0; overflow: hidden; }
     .kpi.is-ok { border-left-color: var(--ok); }
     .kpi.is-warn { border-left-color: var(--warn); }
     .kpi .label { grid-column: 1; grid-row: 1; font-family: var(--font-mono); font-size: 9px; letter-spacing: .08em; color: var(--color-fg-muted); text-transform: uppercase; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-    .kpi .value { grid-column: 1; grid-row: 2; font-family: var(--font-mono); font-size: 22px; color: var(--color-accent-fg); font-variant-numeric: tabular-nums; font-weight: 500; text-shadow: 0 0 6px rgb(var(--brass-glow)/.3); letter-spacing: -.02em; line-height: 1.05; white-space: nowrap; }
+    .kpi .value { grid-column: 1; grid-row: 2; font-family: var(--font-mono); font-size: 22px; color: var(--color-accent-fg); font-variant-numeric: tabular-nums; font-weight: 500; text-shadow: 0 0 6px rgb(var(--color-accent-glow)/.3); letter-spacing: -.02em; line-height: 1.05; white-space: nowrap; }
     .kpi.is-ok .value { color: var(--ok-fg); text-shadow: 0 0 6px rgb(var(--ok-glow)/.25); }
     .kpi.is-warn .value { color: var(--warn); text-shadow: 0 0 6px rgb(var(--warn-glow)/.25); }
     .kpi .unit { font-size: 10px; color: var(--color-fg-muted); margin-left: 3px; font-weight: 400; }
@@ -46,20 +46,20 @@
     .dial { position: relative; width: 200px; height: 200px; }
     .dial svg { width: 100%; height: 100%; transform: rotate(-210deg); display:block; overflow: visible; }
     .dial .tl { position:absolute; inset: 0; display:flex; flex-direction:column; align-items:center; justify-content:center; text-align: center; padding: 0 20px; }
-    .dial .tl .big { font-family: var(--font-mono); font-size: 26px; font-variant-numeric: tabular-nums; color: var(--color-accent-fg); text-shadow: 0 0 10px rgb(var(--brass-glow)/.5); letter-spacing: -.02em; line-height: 1; white-space: nowrap; }
+    .dial .tl .big { font-family: var(--font-mono); font-size: 26px; font-variant-numeric: tabular-nums; color: var(--color-accent-fg); text-shadow: 0 0 10px rgb(var(--color-accent-glow)/.5); letter-spacing: -.02em; line-height: 1; white-space: nowrap; }
     .dial .tl .lil { font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-muted); letter-spacing: .08em; text-transform: uppercase; margin-top: 4px; }
-    .dial .tl .mic { font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); letter-spacing: .04em; margin-top: 8px; white-space: nowrap; }
+    .dial .tl .mic { font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); letter-spacing: .04em; margin-top: 8px; white-space: nowrap; }
 
     .dial-detail { display:flex; flex-direction:column; gap: 2px; font-family: var(--font-mono); font-size: 11px; color: var(--color-fg-secondary); min-width: 0; }
     .dial-detail .row { display:grid; grid-template-columns: 110px auto 1fr; align-items:baseline; gap: 10px; padding: 5px 0; border-bottom: 1px dashed var(--color-border-default); }
     .dial-detail .row:last-child { border-bottom: none; }
-    .dial-detail .row .k { color: var(--fg-4); font-size: 9px; letter-spacing: .06em; text-transform: uppercase; white-space: nowrap; }
+    .dial-detail .row .k { color: var(--color-fg-disabled); font-size: 9px; letter-spacing: .06em; text-transform: uppercase; white-space: nowrap; }
     .dial-detail .row .v { color: var(--color-fg-primary); font-variant-numeric: tabular-nums; white-space: nowrap; }
-    .dial-detail .row .x { color: var(--fg-4); font-size: 10px; text-align: right; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .dial-detail .row .x { color: var(--color-fg-disabled); font-size: 10px; text-align: right; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 
     /* ── PROVIDER TABLE ── */
     .prov { width:100%; border-collapse: collapse; font-family: var(--font-mono); font-size: 11px; }
-    .prov th { text-align: left; padding: 6px 10px; font-size: 9px; letter-spacing: .08em; color: var(--fg-4); text-transform: uppercase; font-weight: 600; border-bottom: 1px solid var(--color-border-strong); }
+    .prov th { text-align: left; padding: 6px 10px; font-size: 9px; letter-spacing: .08em; color: var(--color-fg-disabled); text-transform: uppercase; font-weight: 600; border-bottom: 1px solid var(--color-border-strong); }
     .prov th:last-child, .prov td:last-child { text-align: right; }
     .prov td { padding: 6px 10px; border-bottom: 1px solid var(--color-border-default); color: var(--color-fg-secondary); font-variant-numeric: tabular-nums; }
     .prov tr:last-child td { border-bottom: none; }
@@ -72,7 +72,7 @@
     .prov .status.down .d { background: var(--err); box-shadow: 0 0 4px rgb(var(--err-glow)/.7); }
     .prov .mbar { display:inline-flex; align-items:center; gap: 6px; }
     .prov .mbar .b { width: 80px; height: 5px; background: var(--color-bg-elevated); border-radius: 999px; overflow: hidden; }
-    .prov .mbar .b::after { content:''; display:block; height:100%; background: var(--color-accent-fg); width: var(--w); box-shadow: 0 0 6px rgb(var(--brass-glow)/.6); border-radius: 999px; }
+    .prov .mbar .b::after { content:''; display:block; height:100%; background: var(--color-accent-fg); width: var(--w); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.6); border-radius: 999px; }
 
     /* ── SPARKLINE CARD ── */
     .spark-card { background: var(--color-bg-panel-alt); border: 1px solid var(--color-border-strong); border-radius: var(--r-1); padding: 10px 12px; display: grid; grid-template-columns: 1fr auto; gap: 4px 16px; align-items: end; }
@@ -80,29 +80,29 @@
     .spark-card .val { grid-column: 2 / 3; font-family: var(--font-mono); font-size: 14px; color: var(--color-accent-fg); font-variant-numeric: tabular-nums; }
     .spark-card svg { grid-column: 1 / -1; width: 100%; height: 40px; }
     .spark-card .baseline { stroke: var(--color-border-strong); stroke-dasharray: 2 3; }
-    .spark-card .line { stroke: var(--color-accent-fg); stroke-width: 1.4; fill: none; filter: drop-shadow(0 0 2px rgb(var(--brass-glow)/.6)); }
+    .spark-card .line { stroke: var(--color-accent-fg); stroke-width: 1.4; fill: none; filter: drop-shadow(0 0 2px rgb(var(--color-accent-glow)/.6)); }
     .spark-card .fill { fill: url(#sf-grad); }
 
     /* ── STREAMING CURSOR ── */
     .stream { background: var(--color-bg-page); border: 1px solid var(--color-border-default); border-radius: var(--r-1); padding: 36px 16px 14px; font-family: var(--font-mono); font-size: 11px; color: var(--color-fg-secondary); line-height: 1.6; min-height: 80px; position: relative; white-space: pre-wrap; }
     .stream .out { color: var(--color-fg-primary); }
-    .stream .partial { color: var(--color-fg-secondary); background: rgb(var(--brass-glow)/.08); padding: 0 2px; border-radius: 1px; }
-    .stream .cursor { display:inline-block; width: 7px; height: 12px; background: var(--color-accent-fg); box-shadow: 0 0 6px rgb(var(--brass-glow)/.8); vertical-align: -2px; animation: blink 1s step-end infinite; }
+    .stream .partial { color: var(--color-fg-secondary); background: rgb(var(--color-accent-glow)/.08); padding: 0 2px; border-radius: 1px; }
+    .stream .cursor { display:inline-block; width: 7px; height: 12px; background: var(--color-accent-fg); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.8); vertical-align: -2px; animation: blink 1s step-end infinite; }
     @keyframes blink { 50% { opacity: 0; } }
-    .stream-hud { position:absolute; top: 8px; right: 12px; display: flex; gap: 12px; font-family: var(--font-mono); font-size: 9px; letter-spacing: .06em; text-transform: uppercase; color: var(--fg-4); }
+    .stream-hud { position:absolute; top: 8px; right: 12px; display: flex; gap: 12px; font-family: var(--font-mono); font-size: 9px; letter-spacing: .06em; text-transform: uppercase; color: var(--color-fg-disabled); }
     .stream-hud .v { color: var(--color-accent-fg); }
 
     /* ── BUDGET ── */
     .budget { display:flex; align-items: center; gap: 12px; font-family: var(--font-mono); font-size: 11px; color: var(--color-fg-secondary); }
     .budget .bar-track { flex: 1; height: 8px; background: var(--color-bg-elevated); border-radius: 999px; overflow: hidden; position: relative; border: 1px solid var(--color-border-default); }
-    .budget .bar-fill { height:100%; background: linear-gradient(90deg, var(--ok) 0%, var(--warn) 70%, var(--err) 95%); box-shadow: 0 0 8px rgb(var(--brass-glow)/.4); border-radius: 999px; transition: width .3s; }
-    .budget .bar-mark { position:absolute; top: -2px; width: 1px; height: 12px; background: var(--fg-4); }
+    .budget .bar-fill { height:100%; background: linear-gradient(90deg, var(--ok) 0%, var(--warn) 70%, var(--err) 95%); box-shadow: 0 0 8px rgb(var(--color-accent-glow)/.4); border-radius: 999px; transition: width .3s; }
+    .budget .bar-mark { position:absolute; top: -2px; width: 1px; height: 12px; background: var(--color-fg-disabled); }
 
     .row { display:flex; gap: 8px; align-items:center; flex-wrap: wrap; }
 
     /* chip primitives if not loaded */
     .chip { display:inline-flex; align-items:center; padding: 2px 8px; font-family: var(--font-mono); font-size: 10px; background: var(--color-bg-panel-alt); border: 1px solid var(--color-border-strong); color: var(--color-fg-secondary); border-radius: 999px; letter-spacing: .04em; flex-shrink: 0; }
-    .chip.is-brass { color: var(--color-accent-fg); border-color: var(--brass-2); background: rgb(var(--brass-glow)/.08); }
+    .chip.is-brass { color: var(--color-accent-fg); border-color: var(--brass-2); background: rgb(var(--color-accent-glow)/.08); }
     .chip.is-err   { color: var(--err-fg); border-color: var(--err); background: rgb(var(--err-glow)/.08); }
 
     @media (max-width: 880px) {
@@ -127,7 +127,7 @@
         <div class="kpi">
           <span class="label">tok/s · fleet</span>
           <span class="value">2,847<span class="unit">t/s</span></span>
-          <span class="delta"><span class="d">+412</span><span class="spark"><span style="height:40%"></span><span style="height:55%"></span><span style="height:45%"></span><span style="height:70%"></span><span style="height:85%"></span><span style="height:75%"></span><span style="height:100%; background: var(--color-accent-fg); box-shadow: 0 0 4px rgb(var(--brass-glow))"></span></span></span>
+          <span class="delta"><span class="d">+412</span><span class="spark"><span style="height:40%"></span><span style="height:55%"></span><span style="height:45%"></span><span style="height:70%"></span><span style="height:85%"></span><span style="height:75%"></span><span style="height:100%; background: var(--color-accent-fg); box-shadow: 0 0 4px rgb(var(--color-accent-glow))"></span></span></span>
         </div>
         <div class="kpi is-ok">
           <span class="label">tok/s · nick0cave</span>
@@ -157,7 +157,7 @@
           <svg viewBox="0 0 100 100">
             <defs>
               <linearGradient id="dial-grad" x1="0" y1="0" x2="1" y2="1">
-                <stop offset="0%" stop-color="var(--brass-3)"/>
+                <stop offset="0%" stop-color="var(--color-accent-fg-dim)"/>
                 <stop offset="100%" stop-color="var(--color-accent-fg)"/>
               </linearGradient>
               <filter id="dial-glow" x="-20%" y="-20%" width="140%" height="140%"><feGaussianBlur stdDeviation="1.2"/><feComponentTransfer><feFuncA type="linear" slope="1.2"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
@@ -165,7 +165,7 @@
             <circle cx="50" cy="50" r="40" fill="none" stroke="var(--color-bg-elevated)" stroke-width="7" stroke-linecap="round" stroke-dasharray="167.55 251.33" />
             <circle cx="50" cy="50" r="40" fill="none" stroke="var(--warn)" stroke-width="2" stroke-linecap="round" stroke-dasharray="4 251.33" stroke-dashoffset="-110" opacity=".6" />
             <circle cx="50" cy="50" r="40" fill="none" stroke="url(#dial-grad)" stroke-width="7" stroke-linecap="round" stroke-dasharray="120 251.33" filter="url(#dial-glow)" />
-            <g stroke="var(--fg-4)" stroke-width=".7" fill="none">
+            <g stroke="var(--color-fg-disabled)" stroke-width=".7" fill="none">
               <line x1="10" y1="50" x2="16" y2="50"/>
               <line x1="50" y1="10" x2="50" y2="16" transform="rotate(60 50 50)"/>
               <line x1="50" y1="10" x2="50" y2="16" transform="rotate(120 50 50)"/>
@@ -201,7 +201,7 @@
           <span class="label">tok/s · fleet</span>
           <span class="val">2,847</span>
           <svg viewBox="0 0 240 40" preserveAspectRatio="none">
-            <defs><linearGradient id="sf-grad" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="rgb(var(--brass-glow))" stop-opacity=".4"/><stop offset="100%" stop-color="rgb(var(--brass-glow))" stop-opacity="0"/></linearGradient></defs>
+            <defs><linearGradient id="sf-grad" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="rgb(var(--color-accent-glow))" stop-opacity=".4"/><stop offset="100%" stop-color="rgb(var(--color-accent-glow))" stop-opacity="0"/></linearGradient></defs>
             <path d="M 0 30 L 0 28 C 20 26, 30 22, 40 24 C 50 26, 60 18, 75 20 C 90 22, 100 14, 115 12 C 130 10, 145 18, 160 14 C 175 10, 190 6, 210 8 C 225 9, 240 4, 240 4 L 240 40 L 0 40 Z" class="fill"/>
             <path d="M 0 28 C 20 26, 30 22, 40 24 C 50 26, 60 18, 75 20 C 90 22, 100 14, 115 12 C 130 10, 145 18, 160 14 C 175 10, 190 6, 210 8 C 225 9, 240 4, 240 4" class="line"/>
             <line x1="0" y1="22" x2="240" y2="22" class="baseline"/>
@@ -219,7 +219,7 @@
           <span class="label">cost · $/hr</span>
           <span class="val">1.47</span>
           <svg viewBox="0 0 240 40" preserveAspectRatio="none">
-            <path d="M 0 26 L 20 24 L 40 28 L 60 22 L 80 25 L 100 18 L 120 20 L 140 14 L 160 16 L 180 12 L 200 14 L 220 10 L 240 8 L 240 40 L 0 40 Z" fill="rgb(var(--brass-glow)/.12)"/>
+            <path d="M 0 26 L 20 24 L 40 28 L 60 22 L 80 25 L 100 18 L 120 20 L 140 14 L 160 16 L 180 12 L 200 14 L 220 10 L 240 8 L 240 40 L 0 40 Z" fill="rgb(var(--color-accent-glow)/.12)"/>
             <path d="M 0 26 L 20 24 L 40 28 L 60 22 L 80 25 L 100 18 L 120 20 L 140 14 L 160 16 L 180 12 L 200 14 L 220 10 L 240 8" stroke="var(--color-accent-fg)" fill="none" stroke-width="1.4"/>
           </svg>
         </div>
@@ -236,12 +236,12 @@
           <tr><th>provider</th><th>model</th><th>status</th><th>tok/s</th><th>ttft</th><th>ctx</th><th>$/1k</th><th>share · fleet</th></tr>
         </thead>
         <tbody>
-          <tr><td class="pname">moonshot</td><td>kimi-k2</td><td><span class="status ok"><span class="d"></span>healthy</span></td><td style="color:var(--color-accent-fg); text-shadow: 0 0 4px rgb(var(--brass-glow)/.4)">1,412</td><td>610ms</td><td>84k/128k</td><td>$.0080</td><td><span class="mbar"><span class="b" style="--w:62%"></span>49.6%</span></td></tr>
+          <tr><td class="pname">moonshot</td><td>kimi-k2</td><td><span class="status ok"><span class="d"></span>healthy</span></td><td style="color:var(--color-accent-fg); text-shadow: 0 0 4px rgb(var(--color-accent-glow)/.4)">1,412</td><td>610ms</td><td>84k/128k</td><td>$.0080</td><td><span class="mbar"><span class="b" style="--w:62%"></span>49.6%</span></td></tr>
           <tr><td class="pname">anthropic</td><td>claude-sonnet-4.5</td><td><span class="status ok"><span class="d"></span>healthy</span></td><td style="color:var(--color-accent-fg)">684</td><td>720ms</td><td>48k/200k</td><td>$.0120</td><td><span class="mbar"><span class="b" style="--w:32%"></span>24.0%</span></td></tr>
           <tr><td class="pname">openai</td><td>gpt-5</td><td><span class="status slow"><span class="d"></span>slow</span></td><td style="color:var(--warn)">426</td><td style="color:var(--warn)">1.42s</td><td>30k/256k</td><td>$.0140</td><td><span class="mbar"><span class="b" style="--w:18%; background: var(--warn) !important"></span>15.0%</span></td></tr>
           <tr><td class="pname">deepseek</td><td>r1-lite</td><td><span class="status ok"><span class="d"></span>healthy</span></td><td style="color:var(--color-accent-fg)">285</td><td>540ms</td><td>21k/64k</td><td>$.0018</td><td><span class="mbar"><span class="b" style="--w:11%"></span>10.0%</span></td></tr>
           <tr><td class="pname">local/llama3</td><td>70b-q4</td><td><span class="status ok"><span class="d"></span>healthy</span></td><td>40</td><td>240ms</td><td>8k/32k</td><td>$.0000</td><td><span class="mbar"><span class="b" style="--w:2%"></span>1.4%</span></td></tr>
-          <tr><td class="pname">fireworks</td><td>yi-large</td><td><span class="status down"><span class="d"></span>429 rl</span></td><td style="color:var(--err-fg)">0</td><td>—</td><td>—</td><td>$.0030</td><td><span style="color:var(--fg-4)">backoff · 12s</span></td></tr>
+          <tr><td class="pname">fireworks</td><td>yi-large</td><td><span class="status down"><span class="d"></span>429 rl</span></td><td style="color:var(--err-fg)">0</td><td>—</td><td>—</td><td>$.0030</td><td><span style="color:var(--color-fg-disabled)">backoff · 12s</span></td></tr>
         </tbody>
       </table>
     </div>
@@ -278,7 +278,7 @@
             <div class="bar-mark" style="left: 80%"></div>
             <div class="bar-mark" style="left: 95%; background: var(--err)"></div>
           </div>
-          <span style="color:var(--color-fg-primary); font-variant-numeric: tabular-nums">92.4k<span style="color:var(--fg-4)">&nbsp;/&nbsp;128k</span></span>
+          <span style="color:var(--color-fg-primary); font-variant-numeric: tabular-nums">92.4k<span style="color:var(--color-fg-disabled)">&nbsp;/&nbsp;128k</span></span>
           <span class="chip is-brass">72%</span>
         </div>
         <div class="budget">
@@ -288,7 +288,7 @@
             <div class="bar-mark" style="left: 80%"></div>
             <div class="bar-mark" style="left: 95%; background: var(--err)"></div>
           </div>
-          <span style="color:var(--color-fg-primary); font-variant-numeric: tabular-nums">54.0k<span style="color:var(--fg-4)">&nbsp;/&nbsp;128k</span></span>
+          <span style="color:var(--color-fg-primary); font-variant-numeric: tabular-nums">54.0k<span style="color:var(--color-fg-disabled)">&nbsp;/&nbsp;128k</span></span>
           <span class="chip">42%</span>
         </div>
         <div class="budget">
@@ -298,7 +298,7 @@
             <div class="bar-mark" style="left: 80%"></div>
             <div class="bar-mark" style="left: 95%; background: var(--err)"></div>
           </div>
-          <span style="color:var(--err-fg); font-variant-numeric: tabular-nums">120.3k<span style="color:var(--fg-4)">&nbsp;/&nbsp;128k</span></span>
+          <span style="color:var(--err-fg); font-variant-numeric: tabular-nums">120.3k<span style="color:var(--color-fg-disabled)">&nbsp;/&nbsp;128k</span></span>
           <span class="chip is-err">94%</span>
         </div>
         <div class="budget">
@@ -308,7 +308,7 @@
             <div class="bar-mark" style="left: 80%"></div>
             <div class="bar-mark" style="left: 95%; background: var(--err)"></div>
           </div>
-          <span style="color:var(--color-fg-primary); font-variant-numeric: tabular-nums">435k<span style="color:var(--fg-4)">&nbsp;/&nbsp;640k</span></span>
+          <span style="color:var(--color-fg-primary); font-variant-numeric: tabular-nums">435k<span style="color:var(--color-fg-disabled)">&nbsp;/&nbsp;640k</span></span>
           <span class="chip is-brass">68%</span>
         </div>
       </div>

--- a/dashboard/design-system/source_styles/center.css
+++ b/dashboard/design-system/source_styles/center.css
@@ -35,7 +35,7 @@
   padding: 3px 7px; cursor: pointer; border-radius: 2px; letter-spacing: .03em;
 }
 .wf-scale-ctrl button:hover { color: var(--color-fg-primary); }
-.wf-scale-ctrl button.is-active { background: var(--color-bg-elevated); border-color: var(--brass-3); color: var(--color-accent-fg); }
+.wf-scale-ctrl button.is-active { background: var(--color-bg-elevated); border-color: var(--color-accent-fg-dim); color: var(--color-accent-fg); }
 .wf-scale-ctrl + .pane-meta { margin-left: var(--sp-3); }
 
 .feed-row {

--- a/dashboard/design-system/source_styles/code.css
+++ b/dashboard/design-system/source_styles/code.css
@@ -80,7 +80,7 @@ body[data-mode="split"] .zone-deck { display: none; }
   font-family: var(--font-mono); font-size: 11px; cursor: pointer;
 }
 .code-repo-select:hover, .code-wc-select:hover { background: var(--color-bg-elevated); }
-.code-repo-select .arrow, .code-wc-select .arrow { color: var(--fg-4); font-size: 9px; margin-left: 2px; }
+.code-repo-select .arrow, .code-wc-select .arrow { color: var(--color-fg-disabled); font-size: 9px; margin-left: 2px; }
 
 .wc-chips { display: flex; gap: 4px; flex-wrap: nowrap; overflow: hidden; }
 .wc-chip {
@@ -92,9 +92,9 @@ body[data-mode="split"] .zone-deck { display: none; }
   cursor: pointer; flex-shrink: 0;
 }
 .wc-chip:hover { background: var(--color-bg-elevated); color: var(--color-fg-primary); }
-.wc-chip.is-active { background: var(--color-bg-hover); color: var(--color-accent-fg); border-color: var(--brass-3); }
+.wc-chip.is-active { background: var(--color-bg-hover); color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); }
 .wc-chip .wc-close {
-  color: var(--fg-4); font-size: 9px; margin-left: 1px;
+  color: var(--color-fg-disabled); font-size: 9px; margin-left: 1px;
   width: 12px; text-align: center; border-radius: 2px;
 }
 .wc-chip .wc-close:hover { color: var(--err); background: var(--color-bg-surface); }
@@ -106,7 +106,7 @@ body[data-mode="split"] .zone-deck { display: none; }
   background: var(--color-bg-panel-alt); border: 1px solid var(--color-border-strong); border-radius: var(--r-1);
   color: var(--color-fg-primary); font-size: 11px; font-family: var(--font-mono);
 }
-.code-toolbar .code-search::placeholder { color: var(--fg-4); }
+.code-toolbar .code-search::placeholder { color: var(--color-fg-disabled); }
 .code-toolbar .spacer { flex: 1; }
 
 .code-view-tabs { display: flex; gap: 0; border: 1px solid var(--color-border-strong); border-radius: var(--r-1); overflow: hidden; }
@@ -132,7 +132,7 @@ body[data-mode="split"] .zone-deck { display: none; }
   text-transform: uppercase; letter-spacing: .08em;
   color: var(--color-fg-muted); font-weight: 600;
 }
-.tree-head .count { margin-left: auto; font-family: var(--font-mono); color: var(--fg-4); }
+.tree-head .count { margin-left: auto; font-family: var(--font-mono); color: var(--color-fg-disabled); }
 .tree-body {
   flex: 1; overflow-y: auto; padding: 4px 0;
   font-family: var(--font-mono); font-size: 11px;
@@ -150,18 +150,18 @@ body[data-mode="split"] .zone-deck { display: none; }
   width: 2px; background: var(--color-accent-fg);
 }
 .tree-item .tw-indent { display: inline-block; width: 10px; flex-shrink: 0; }
-.tree-item .tw-chev { color: var(--fg-4); width: 10px; font-size: 9px; flex-shrink: 0; }
-.tree-item .tw-icon { color: var(--fg-4); width: 12px; text-align: center; flex-shrink: 0; }
+.tree-item .tw-chev { color: var(--color-fg-disabled); width: 10px; font-size: 9px; flex-shrink: 0; }
+.tree-item .tw-icon { color: var(--color-fg-disabled); width: 12px; text-align: center; flex-shrink: 0; }
 .tree-item .tw-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tree-item .tw-badges { display: flex; gap: 2px; flex-shrink: 0; }
 .tree-item .tw-keeper-dot {
   width: 6px; height: 6px; border-radius: 50%;
   background: var(--color-accent-fg);
-  box-shadow: 0 0 4px rgb(var(--brass-glow) / .6);
+  box-shadow: 0 0 4px rgb(var(--color-accent-glow) / .6);
 }
 .tree-item .tw-keeper-dot.is-multi { background: var(--stalled); }
 .tree-item .tw-count {
-  font-size: 9px; color: var(--fg-4); font-family: var(--font-mono);
+  font-size: 9px; color: var(--color-fg-disabled); font-family: var(--font-mono);
   padding: 0 4px; background: var(--color-bg-elevated); border-radius: 2px;
 }
 .tree-item .tw-diff-plus { color: var(--ok); font-size: 9px; }
@@ -197,7 +197,7 @@ body[data-mode="split"] .zone-deck { display: none; }
   box-shadow: inset 0 2px 0 var(--color-accent-fg);
 }
 .editor-tab .t-close {
-  color: var(--fg-4); font-size: 10px;
+  color: var(--color-fg-disabled); font-size: 10px;
   width: 14px; height: 14px; border-radius: 2px;
   display: flex; align-items: center; justify-content: center;
 }
@@ -215,7 +215,7 @@ body[data-mode="split"] .zone-deck { display: none; }
 }
 .bc-seg { cursor: pointer; }
 .bc-seg:hover { color: var(--color-accent-fg); }
-.bc-sep { color: var(--fg-4); }
+.bc-sep { color: var(--color-fg-disabled); }
 .bc-seg:last-child { color: var(--color-fg-primary); }
 
 .editor-body {
@@ -241,11 +241,11 @@ body[data-mode="split"] .zone-deck { display: none; }
   position: relative;
 }
 .code-line:hover { background: rgb(255 255 255 / .015); }
-.code-line.is-selected { background: rgb(var(--brass-glow) / .06); }
-.code-line.is-anchor-hover { background: rgb(var(--brass-glow) / .05); }
-.code-line.is-heatmap-1 { background: rgb(var(--brass-glow) / .02); }
-.code-line.is-heatmap-2 { background: rgb(var(--brass-glow) / .05); }
-.code-line.is-heatmap-3 { background: rgb(var(--brass-glow) / .10); }
+.code-line.is-selected { background: rgb(var(--color-accent-glow) / .06); }
+.code-line.is-anchor-hover { background: rgb(var(--color-accent-glow) / .05); }
+.code-line.is-heatmap-1 { background: rgb(var(--color-accent-glow) / .02); }
+.code-line.is-heatmap-2 { background: rgb(var(--color-accent-glow) / .05); }
+.code-line.is-heatmap-3 { background: rgb(var(--color-accent-glow) / .10); }
 .code-line.is-diff-add { background: rgb(107 158 107 / .08); }
 .code-line.is-diff-del { background: rgb(196 106 90 / .08); }
 
@@ -253,7 +253,7 @@ body[data-mode="split"] .zone-deck { display: none; }
   grid-area: gutter;
   display: flex; align-items: center; justify-content: center;
   border-right: 1px solid var(--color-border-default);
-  color: var(--fg-4); font-size: 10px;
+  color: var(--color-fg-disabled); font-size: 10px;
   position: relative;
 }
 .cl-gutter-icon {
@@ -289,7 +289,7 @@ body[data-mode="split"] .zone-deck { display: none; }
 }
 .cl-cursor-dot {
   width: 5px; height: 5px; border-radius: 50%;
-  background: var(--color-accent-fg); box-shadow: 0 0 5px rgb(var(--brass-glow) / .7);
+  background: var(--color-accent-fg); box-shadow: 0 0 5px rgb(var(--color-accent-glow) / .7);
 }
 .cl-cursor-dot.is-green { background: var(--ok); box-shadow: 0 0 5px rgb(107 158 107 / .7); }
 .cl-cursor-dot.is-blue  { background: var(--info); box-shadow: 0 0 5px rgb(106 142 176 / .7); }
@@ -305,7 +305,7 @@ body[data-mode="split"] .zone-deck { display: none; }
 .cl-lineno {
   grid-area: lineno;
   text-align: right; padding-right: 10px;
-  color: var(--fg-4); font-size: 11px;
+  color: var(--color-fg-disabled); font-size: 11px;
   border-right: 1px solid var(--color-border-default);
   user-select: none;
 }
@@ -314,7 +314,7 @@ body[data-mode="split"] .zone-deck { display: none; }
 .cl-blame {
   grid-area: blame;
   padding: 0 6px;
-  color: var(--fg-4); font-size: 10px;
+  color: var(--color-fg-disabled); font-size: 10px;
   border-right: 1px solid var(--color-border-default);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   background: var(--color-bg-surface);
@@ -337,7 +337,7 @@ body[data-mode="split"] .zone-deck { display: none; }
 .anchor-bracket {
   position: absolute;
   left: 4px; width: 2px;
-  background: var(--brass-3);
+  background: var(--color-accent-fg-dim);
   border-radius: 1px;
   pointer-events: none;
   opacity: 0.35;
@@ -350,8 +350,8 @@ body[data-mode="split"] .zone-deck { display: none; }
   animation: drift-pulse 1.2s ease-out;
 }
 @keyframes drift-pulse {
-  0% { box-shadow: 0 0 0 0 rgb(var(--brass-glow) / .6); }
-  100% { box-shadow: 0 0 0 8px rgb(var(--brass-glow) / 0); }
+  0% { box-shadow: 0 0 0 0 rgb(var(--color-accent-glow) / .6); }
+  100% { box-shadow: 0 0 0 8px rgb(var(--color-accent-glow) / 0); }
 }
 .anchor-orphan-banner {
   position: sticky; top: 0; z-index: 2;
@@ -371,7 +371,7 @@ body[data-mode="split"] .zone-deck { display: none; }
 .tok-key    { color: #c195e8; }
 .tok-str    { color: #a8c97a; }
 .tok-num    { color: #d4a14a; }
-.tok-com    { color: var(--fg-4); font-style: italic; }
+.tok-com    { color: var(--color-fg-disabled); font-style: italic; }
 .tok-fn     { color: #e8c976; }
 .tok-var    { color: var(--color-fg-primary); }
 .tok-type   { color: #88b5d8; }
@@ -394,8 +394,8 @@ body[data-mode="split"] .zone-deck { display: none; }
 }
 .minimap-viewport {
   position: absolute; left: 0; right: 0;
-  background: rgb(var(--brass-glow) / .08);
-  border: 1px solid rgb(var(--brass-glow) / .3);
+  background: rgb(var(--color-accent-glow) / .08);
+  border: 1px solid rgb(var(--color-accent-glow) / .3);
   pointer-events: none;
 }
 
@@ -414,7 +414,7 @@ body[data-mode="split"] .zone-deck { display: none; }
   font-size: 10px; text-transform: uppercase; letter-spacing: .08em;
   color: var(--color-fg-muted); font-weight: 600;
 }
-.review-head .count { margin-left: auto; color: var(--fg-4); font-family: var(--font-mono); }
+.review-head .count { margin-left: auto; color: var(--color-fg-disabled); font-family: var(--font-mono); }
 .review-filter {
   display: flex; gap: 0;
   padding: 4px 8px 6px;
@@ -428,7 +428,7 @@ body[data-mode="split"] .zone-deck { display: none; }
 }
 .review-filter button:first-child { border-radius: 2px 0 0 2px; }
 .review-filter button:last-child  { border-right: 1px solid var(--color-border-default); border-radius: 0 2px 2px 0; }
-.review-filter button.is-active { color: var(--color-accent-fg); background: var(--color-bg-elevated); border-color: var(--brass-3); }
+.review-filter button.is-active { color: var(--color-accent-fg); background: var(--color-bg-elevated); border-color: var(--color-accent-fg-dim); }
 .review-list {
   flex: 1; overflow-y: auto;
 }
@@ -457,7 +457,7 @@ body[data-mode="split"] .zone-deck { display: none; }
 .thread-kind.k-flag     { background: rgb(196 106 90 / .15); color: var(--err); }
 .thread-kind.k-note     { background: var(--color-bg-elevated); color: var(--color-fg-secondary); }
 .thread-kind.k-approve  { background: rgb(107 158 107 / .15); color: var(--ok); }
-.thread-kind.k-suggest  { background: rgb(var(--brass-glow) / .12); color: var(--color-accent-fg); }
+.thread-kind.k-suggest  { background: rgb(var(--color-accent-glow) / .12); color: var(--color-accent-fg); }
 .thread-anchor {
   font-family: var(--font-mono); font-size: 10px;
   color: var(--color-fg-muted);
@@ -465,13 +465,13 @@ body[data-mode="split"] .zone-deck { display: none; }
 .thread-author {
   color: var(--color-fg-primary); font-size: 11px; font-weight: 500;
 }
-.thread-ts { margin-left: auto; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4); }
+.thread-ts { margin-left: auto; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled); }
 .thread-body {
   font-size: 12px; color: var(--color-fg-secondary); line-height: 1.4;
   display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden;
 }
 .thread-meta {
-  display: flex; gap: 8px; font-size: 10px; color: var(--fg-4);
+  display: flex; gap: 8px; font-size: 10px; color: var(--color-fg-disabled);
   font-family: var(--font-mono);
 }
 .thread-reply-count::before { content: "↩ "; }
@@ -498,7 +498,7 @@ body[data-mode="split"] .zone-deck { display: none; }
 .activity-head .scope-pill {
   margin-left: auto;
   font-size: 9px; padding: 1px 5px;
-  background: rgb(var(--brass-glow) / .1);
+  background: rgb(var(--color-accent-glow) / .1);
   color: var(--color-accent-fg); border-radius: 2px;
   letter-spacing: .06em;
 }
@@ -520,14 +520,14 @@ body[data-mode="split"] .zone-deck { display: none; }
   position: relative;
 }
 .act-row:hover { background: var(--color-bg-panel-alt); }
-.act-row.is-now { background: rgb(var(--brass-glow) / .04); }
-.act-ts { color: var(--fg-4); font-family: var(--font-mono); font-size: 10px; text-align: right; padding-top: 1px; }
+.act-row.is-now { background: rgb(var(--color-accent-glow) / .04); }
+.act-ts { color: var(--color-fg-disabled); font-family: var(--font-mono); font-size: 10px; text-align: right; padding-top: 1px; }
 .act-dot {
   width: 8px; height: 8px; border-radius: 50%;
   background: var(--color-fg-muted);
   margin-top: 4px; border: 2px solid var(--color-bg-surface); z-index: 1;
 }
-.act-dot.k-edit { background: var(--color-accent-fg); box-shadow: 0 0 4px rgb(var(--brass-glow)/.5); }
+.act-dot.k-edit { background: var(--color-accent-fg); box-shadow: 0 0 4px rgb(var(--color-accent-glow)/.5); }
 .act-dot.k-comment { background: var(--info); }
 .act-dot.k-flag { background: var(--err); }
 .act-dot.k-approve { background: var(--ok); }
@@ -537,14 +537,14 @@ body[data-mode="split"] .zone-deck { display: none; }
 .act-body .who { color: var(--color-fg-primary); font-weight: 500; }
 .act-body .what { color: var(--color-fg-secondary); }
 .act-body .where { font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-muted); }
-.act-body .detail { font-size: 10px; color: var(--fg-4); margin-top: 2px; }
+.act-body .detail { font-size: 10px; color: var(--color-fg-disabled); margin-top: 2px; }
 
 /* —— floating add-comment popover —— */
 .comment-composer {
   position: absolute; z-index: 40;
   width: 320px;
   background: var(--color-bg-panel-alt);
-  border: 1px solid var(--line-3); border-radius: var(--r-2);
+  border: 1px solid var(--color-border-divider); border-radius: var(--r-2);
   box-shadow: var(--shadow-2);
   padding: 10px; font-size: 11px;
   display: none;
@@ -566,7 +566,7 @@ body[data-mode="split"] .zone-deck { display: none; }
 .comment-composer .cc-kinds button:first-child { border-radius: 2px 0 0 2px; }
 .comment-composer .cc-kinds button:last-child { border-radius: 0 2px 2px 0; border-right: 1px solid var(--color-border-strong); }
 .comment-composer .cc-kinds button.is-active {
-  background: var(--color-bg-elevated); color: var(--color-accent-fg); border-color: var(--brass-3);
+  background: var(--color-bg-elevated); color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim);
 }
 .comment-composer textarea {
   width: 100%; min-height: 72px;
@@ -575,7 +575,7 @@ body[data-mode="split"] .zone-deck { display: none; }
   color: var(--color-fg-primary); font-family: var(--font-sans); font-size: 12px;
   resize: vertical; outline: none;
 }
-.comment-composer textarea:focus { border-color: var(--brass-3); }
+.comment-composer textarea:focus { border-color: var(--color-accent-fg-dim); }
 .comment-composer .cc-actions {
   display: flex; gap: 6px; margin-top: 8px; align-items: center;
 }

--- a/dashboard/design-system/source_styles/deck.css
+++ b/dashboard/design-system/source_styles/deck.css
@@ -26,7 +26,7 @@
 }
 .deck-tabs .deck-tab-count {
   font-family: var(--font-mono); font-size: 10px;
-  color: var(--fg-4); font-weight: 500;
+  color: var(--color-fg-disabled); font-weight: 500;
   padding: 1px 5px; background: var(--color-bg-elevated);
   border-radius: 2px; min-width: 18px; text-align: center;
 }
@@ -75,7 +75,7 @@
   font-size: 10px; text-transform: uppercase; letter-spacing: .1em;
   color: var(--color-fg-muted); font-weight: 600;
 }
-.board-col-head .count { margin-left: auto; color: var(--fg-4); font-family: var(--font-mono); }
+.board-col-head .count { margin-left: auto; color: var(--color-fg-disabled); font-family: var(--font-mono); }
 .board-thread {
   padding: 8px 10px; border-bottom: 1px solid var(--color-border-default);
   display: flex; flex-direction: column; gap: 4px;
@@ -88,17 +88,17 @@
   font-size: 11px;
 }
 .board-thread .bt-from { color: var(--color-fg-primary); font-weight: 500; }
-.board-thread .bt-arrow { color: var(--fg-4); font-family: var(--font-mono); }
+.board-thread .bt-arrow { color: var(--color-fg-disabled); font-family: var(--font-mono); }
 .board-thread .bt-to { color: var(--color-fg-secondary); }
 .board-thread .bt-ts {
-  margin-left: auto; font-family: var(--font-mono); font-size: 10px; color: var(--fg-4);
+  margin-left: auto; font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled);
 }
 .board-thread .bt-body {
   font-size: 12px; color: var(--color-fg-secondary); line-height: 1.4;
   display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
 }
 .board-thread .bt-meta {
-  display: flex; gap: 8px; font-size: 10px; color: var(--fg-4); font-family: var(--font-mono);
+  display: flex; gap: 8px; font-size: 10px; color: var(--color-fg-disabled); font-family: var(--font-mono);
 }
 .board-thread .bt-meta .tag {
   padding: 0 4px; background: var(--color-bg-elevated);
@@ -135,7 +135,7 @@
   border-radius: 2px; color: var(--color-fg-muted);
   font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .06em;
 }
-.pill.active, .pill.running { color: var(--color-accent-fg); border-color: var(--brass-3); }
+.pill.active, .pill.running { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); }
 .pill.blocked, .pill.err, .pill.error { color: var(--err); border-color: rgb(196 106 90 / .4); }
 .pill.done, .pill.ok, .pill.verified { color: var(--ok); border-color: rgb(107 158 107 / .4); }
 .pill.stalled { color: var(--stalled); border-color: rgb(138 106 160 / .4); }
@@ -218,9 +218,9 @@
 }
 .verif-check.is-fail .vc-mark { color: var(--err); }
 .verif-check.is-fail .vc-label { color: var(--err); }
-.verif-check.is-skip .vc-mark, .verif-check.is-skip .vc-label { color: var(--fg-4); }
+.verif-check.is-skip .vc-mark, .verif-check.is-skip .vc-label { color: var(--color-fg-disabled); }
 .verif-foot {
-  display: flex; gap: 10px; font-size: 10px; color: var(--fg-4);
+  display: flex; gap: 10px; font-size: 10px; color: var(--color-fg-disabled);
   font-family: var(--font-mono); margin-top: auto;
 }
 
@@ -284,7 +284,7 @@
 .cascade-step.is-failed { background: rgb(196 106 90 / .06); }
 .cascade-step.is-hit { box-shadow: inset 0 -2px 0 var(--color-accent-fg); }
 .cascade-step .cs-num {
-  font-family: var(--font-mono); font-size: 10px; color: var(--fg-4);
+  font-family: var(--font-mono); font-size: 10px; color: var(--color-fg-disabled);
 }
 .cascade-step .cs-model {
   font-size: 12px; color: var(--color-fg-primary); font-weight: 500;
@@ -297,7 +297,7 @@
 }
 .cascade-step .cs-arrow {
   position: absolute; right: -7px; top: 50%; transform: translateY(-50%);
-  color: var(--line-3); font-size: 10px; z-index: 1;
+  color: var(--color-border-divider); font-size: 10px; z-index: 1;
   background: var(--color-bg-page); padding: 0 1px;
 }
 .cascade-step:last-child .cs-arrow { display: none; }
@@ -306,7 +306,7 @@
   font-size: 11px; color: var(--color-fg-muted);
 }
 .cascade-row-head .ck-name { color: var(--color-fg-primary); font-weight: 500; }
-.cascade-row-head .ck-stat { margin-left: auto; font-family: var(--font-mono); color: var(--fg-4); }
+.cascade-row-head .ck-stat { margin-left: auto; font-family: var(--font-mono); color: var(--color-fg-disabled); }
 
 /* density helpers */
 .kv-row {

--- a/dashboard/design-system/source_styles/drawer.css
+++ b/dashboard/design-system/source_styles/drawer.css
@@ -61,7 +61,7 @@
   color: var(--color-fg-secondary); letter-spacing: .02em;
 }
 .chip-err { background: rgb(196 106 90 / .1); border-color: rgb(196 106 90 / .3); color: var(--err); }
-.chip.k-tool { color: var(--color-accent-fg); border-color: var(--brass-3); }
+.chip.k-tool { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); }
 .chip.k-claim { color: var(--ok); border-color: rgb(107 158 107 / .4); }
 .chip.k-text { color: var(--info); border-color: rgb(106 142 176 / .4); }
 .chip.k-noop { color: var(--color-fg-muted); }
@@ -113,7 +113,7 @@
   padding: 4px 6px; border-radius: var(--r-1); font-size: var(--fs-11);
 }
 .fsm-trans:hover { background: var(--color-bg-panel-alt); }
-.fsm-trans.is-active { background: var(--color-bg-elevated); outline: 1px solid var(--brass-3); }
+.fsm-trans.is-active { background: var(--color-bg-elevated); outline: 1px solid var(--color-accent-fg-dim); }
 
 .bar {
   display: inline-block; flex: 1; height: 6px;
@@ -148,7 +148,7 @@
   background: var(--color-bg-panel-alt); border: 1px solid var(--color-border-default);
   font-size: var(--fs-12);
 }
-.dd-goal-row.is-active { border-color: var(--brass-3); background: var(--color-bg-elevated); }
+.dd-goal-row.is-active { border-color: var(--color-accent-fg-dim); background: var(--color-bg-elevated); }
 .dd-goal-tag {
   font-family: var(--font-mono); font-size: 10px;
   color: var(--color-fg-muted); text-transform: uppercase;

--- a/dashboard/design-system/source_styles/kpi.css
+++ b/dashboard/design-system/source_styles/kpi.css
@@ -78,11 +78,11 @@
 .kpi-delta {
   font: var(--type-caption);
   font-variant-numeric: tabular-nums;
-  color: var(--fg-4);
+  color: var(--color-fg-disabled);
 }
 .kpi-delta.up   { color: var(--ok-fg); }
 .kpi-delta.down { color: var(--err-fg); }
-.kpi-delta.flat { color: var(--fg-4); }
+.kpi-delta.flat { color: var(--color-fg-disabled); }
 
 /* ── Spark (bottom-right corner) ── */
 .kpi-spark {

--- a/dashboard/design-system/source_styles/layers.css
+++ b/dashboard/design-system/source_styles/layers.css
@@ -39,7 +39,7 @@
 .layer-toggle:hover { color: var(--color-fg-primary); background: var(--color-bg-elevated); }
 .layer-toggle .glyph {
   width: 10px; height: 10px; border-radius: 50%;
-  background: var(--fg-4);
+  background: var(--color-fg-disabled);
   transition: all var(--t-fast) var(--ease);
 }
 .layer-toggle.is-on .glyph { transform: scale(1.2); }
@@ -47,8 +47,8 @@
 .layer-toggle.is-on[data-layer="time"]     .glyph { background: var(--warn); box-shadow: 0 0 5px rgb(var(--warn-glow) / .6); }
 .layer-toggle.is-on[data-layer="parallel"] { color: var(--info);   border-color: rgb(var(--info-glow) / .4); background: rgb(var(--info-glow) / .06); }
 .layer-toggle.is-on[data-layer="parallel"] .glyph { background: var(--info); box-shadow: 0 0 5px rgb(var(--info-glow) / .6); }
-.layer-toggle.is-on[data-layer="tools"]    { color: var(--color-accent-fg); border-color: var(--brass-3); background: rgb(var(--brass-glow) / .08); }
-.layer-toggle.is-on[data-layer="tools"]    .glyph { background: var(--color-accent-fg); box-shadow: 0 0 5px rgb(var(--brass-glow) / .6); }
+.layer-toggle.is-on[data-layer="tools"]    { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); background: rgb(var(--color-accent-glow) / .08); }
+.layer-toggle.is-on[data-layer="tools"]    .glyph { background: var(--color-accent-fg); box-shadow: 0 0 5px rgb(var(--color-accent-glow) / .6); }
 .layer-toggle.is-on[data-layer="approve"]  { color: var(--ok);     border-color: rgb(var(--ok-glow) / .4); background: rgb(var(--ok-glow) / .06); }
 .layer-toggle.is-on[data-layer="approve"]  .glyph { background: var(--ok); box-shadow: 0 0 5px rgb(var(--ok-glow) / .6); }
 .layer-toggle.is-on[data-layer="notes"]    { color: var(--stalled); border-color: rgb(var(--stalled-glow) / .4); background: rgb(var(--stalled-glow) / .06); }
@@ -77,7 +77,7 @@
   -webkit-appearance: none; appearance: none;
   width: 10px; height: 10px; border-radius: 50%;
   background: var(--color-accent-fg); cursor: pointer;
-  box-shadow: 0 0 4px rgb(var(--brass-glow) / .6);
+  box-shadow: 0 0 4px rgb(var(--color-accent-glow) / .6);
 }
 
 .layer-explode {
@@ -96,9 +96,9 @@
 }
 .layer-explode:hover { background: var(--color-bg-elevated); color: var(--color-fg-primary); }
 .layer-explode.is-on {
-  background: rgb(var(--brass-glow) / .12);
+  background: rgb(var(--color-accent-glow) / .12);
   color: var(--color-accent-fg);
-  border-color: var(--brass-3);
+  border-color: var(--color-accent-fg-dim);
 }
 
 /* ════════ DOT-MATRIX BACKGROUND ════════ */
@@ -106,7 +106,7 @@
   --dot-op: 0.12;
   --dot-size: 14px;
   background-image:
-    radial-gradient(circle at center, rgb(var(--brass-glow) / var(--dot-op)) 0.7px, transparent 1.2px);
+    radial-gradient(circle at center, rgb(var(--color-accent-glow) / var(--dot-op)) 0.7px, transparent 1.2px);
   background-size: var(--dot-size) var(--dot-size);
   background-position: 0 0;
   background-color: var(--color-bg-page);
@@ -147,7 +147,7 @@ body[data-explode="1"] .lyr-notes    { transform: translateZ(200px); }
 body[data-explode="1"] .lyr::before {
   content: "";
   position: absolute; inset: -4px;
-  border: 1px dashed rgb(var(--brass-glow) / .15);
+  border: 1px dashed rgb(var(--color-accent-glow) / .15);
   border-radius: 2px;
   pointer-events: none;
 }
@@ -169,7 +169,7 @@ body[data-explode="1"] .lyr::before {
 .time-stripe.age-recent   { opacity: 1;   background: var(--warn);   box-shadow: 0 0 8px rgb(var(--warn-glow) / .6); }
 .time-stripe.age-near     { opacity: .7;  background: var(--warn); }
 .time-stripe.age-mid      { opacity: .4;  background: var(--color-fg-muted); }
-.time-stripe.age-far      { opacity: .2;  background: var(--fg-4); }
+.time-stripe.age-far      { opacity: .2;  background: var(--color-fg-disabled); }
 .time-stripe .time-label {
   position: absolute; left: 6px; top: 0;
   font-family: var(--font-mono); font-size: var(--fs-9);
@@ -227,18 +227,18 @@ body[data-explode="1"] .lyr::before {
 .tool-mark .tool-icon {
   font-size: 10px;
   color: var(--color-accent-fg);
-  text-shadow: 0 0 4px rgb(var(--brass-glow) / .6);
+  text-shadow: 0 0 4px rgb(var(--color-accent-glow) / .6);
   line-height: 1;
 }
 .tool-mark .tool-bar {
   width: 16px; height: 2px;
   background: linear-gradient(90deg, var(--color-accent-fg), transparent);
   border-radius: 1px;
-  box-shadow: 0 0 3px rgb(var(--brass-glow) / .4);
+  box-shadow: 0 0 3px rgb(var(--color-accent-glow) / .4);
 }
 .tool-mark .tool-count {
   font-size: var(--fs-9);
-  color: var(--fg-4);
+  color: var(--color-fg-disabled);
   font-family: var(--font-mono);
 }
 
@@ -328,12 +328,12 @@ body[data-explode="1"] .lyr::before {
   letter-spacing: .06em; text-transform: uppercase;
 }
 .note-pin .np-head .np-author { color: var(--color-fg-muted); text-transform: none; letter-spacing: 0; }
-.note-pin .np-head .np-ts { margin-left: auto; color: var(--fg-4); }
+.note-pin .np-head .np-ts { margin-left: auto; color: var(--color-fg-disabled); }
 .note-pin .np-body { line-height: 1.4; color: var(--color-fg-primary); font-size: var(--fs-11); }
 .note-pin .np-actions {
   display: flex; gap: 4px; margin-top: 6px;
   font-size: var(--fs-9);
-  color: var(--fg-4);
+  color: var(--color-fg-disabled);
   font-family: var(--font-mono);
 }
 .note-pin .np-actions button {
@@ -376,7 +376,7 @@ body[data-explode="1"] .lyr::before {
 }
 .code-line.is-focused {
   filter: none;
-  background: rgb(var(--brass-glow) / .04);
+  background: rgb(var(--color-accent-glow) / .04);
 }
 
 /* ════════ Block recency aura (active when time layer on) ════════ */

--- a/dashboard/design-system/source_styles/layout.css
+++ b/dashboard/design-system/source_styles/layout.css
@@ -28,7 +28,7 @@
 .topbar-brand .brand-dot {
   display: inline-block; width: 7px; height: 7px;
   background: var(--color-accent-fg); border-radius: 50%; margin-right: 8px;
-  box-shadow: 0 0 6px rgb(var(--brass-glow) / .5);
+  box-shadow: 0 0 6px rgb(var(--color-accent-glow) / .5);
 }
 .topbar-sep { width: 1px; height: 14px; background: var(--color-border-strong); flex-shrink: 0; }
 .topbar-crumbs { display: flex; gap: var(--sp-2); color: var(--color-fg-muted); min-width: 0; overflow: hidden; }
@@ -79,8 +79,8 @@
   color: var(--color-fg-primary); font: var(--fs-13)/1 var(--font-sans);
   padding: 8px 12px; height: 32px; min-width: 0;
 }
-.composer-input::placeholder { color: var(--fg-4); }
-.composer-input:focus { border-color: var(--brass-3); outline: none; }
+.composer-input::placeholder { color: var(--color-fg-disabled); }
+.composer-input:focus { border-color: var(--color-accent-fg-dim); outline: none; }
 
 .pane { display: flex; flex-direction: column; min-height: 0; min-width: 0; border-bottom: 1px solid var(--color-border-default); }
 .pane:last-child { border-bottom: none; }
@@ -159,7 +159,7 @@
 .zone-deck {
   grid-area: deck;
   background: var(--color-bg-surface);
-  border-top: 1px solid var(--line-3);
+  border-top: 1px solid var(--color-border-divider);
   display: flex; flex-direction: column;
   min-height: 0; min-width: 0;
   overflow: hidden;

--- a/dashboard/design-system/source_styles/lifeline.css
+++ b/dashboard/design-system/source_styles/lifeline.css
@@ -39,7 +39,7 @@
   width: 6px; height: 6px;
   border-radius: 50%;
   background: var(--color-accent-fg);
-  box-shadow: 0 0 6px rgb(var(--brass-glow) / .7);
+  box-shadow: 0 0 6px rgb(var(--color-accent-glow) / .7);
   animation: anim-heartbeat 1.4s var(--ease-inout) infinite;
   margin-left: auto;
   flex-shrink: 0;
@@ -60,7 +60,7 @@
   border-bottom: 1px dotted var(--color-border-default);
   font-family: var(--font-mono);
   font-size: var(--fs-9);
-  color: var(--fg-4);
+  color: var(--color-fg-disabled);
   letter-spacing: 0;
   overflow: hidden;
   flex-shrink: 0;
@@ -113,7 +113,7 @@
 .ll-cell:hover { transform: scaleY(1.12); filter: brightness(1.3); outline-color: var(--color-fg-secondary); z-index: 2; }
 .ll-cell.is-active {
   outline-color: var(--color-accent-fg);
-  box-shadow: 0 0 8px rgb(var(--brass-glow) / .5);
+  box-shadow: 0 0 8px rgb(var(--color-accent-glow) / .5);
   z-index: 3;
 }
 .ll-cell.k-tool  { background: var(--brass-2); }
@@ -182,7 +182,7 @@
   width: 6px; height: 6px;
   border-radius: 50%;
   background: var(--color-accent-fg);
-  box-shadow: 0 0 8px rgb(var(--brass-glow) / .8);
+  box-shadow: 0 0 8px rgb(var(--color-accent-glow) / .8);
   animation: anim-heartbeat 1.4s var(--ease-inout) infinite;
   align-self: center;
   margin-left: 4px;

--- a/dashboard/design-system/source_styles/primitives.css
+++ b/dashboard/design-system/source_styles/primitives.css
@@ -18,7 +18,7 @@
   border-radius: var(--r-1);
   white-space: nowrap;
 }
-.chip.is-brass { color: var(--color-accent-fg); border-color: var(--brass-3); background: rgb(var(--brass-glow) / .08); }
+.chip.is-brass { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); background: rgb(var(--color-accent-glow) / .08); }
 .chip.is-ok    { color: var(--ok);    border-color: rgb(var(--ok-glow) / .35); background: rgb(var(--ok-glow) / .08); }
 .chip.is-warn  { color: var(--warn);  border-color: rgb(var(--warn-glow) / .35); background: rgb(var(--warn-glow) / .08); }
 .chip.is-err   { color: var(--err);   border-color: rgb(var(--err-glow) / .35); background: rgb(var(--err-glow) / .08); }
@@ -46,7 +46,7 @@
   border-radius: 999px;
   white-space: nowrap;
 }
-.pill.is-running { color: var(--color-accent-fg); background: rgb(var(--brass-glow) / .12); }
+.pill.is-running { color: var(--color-accent-fg); background: rgb(var(--color-accent-glow) / .12); }
 .pill.is-paused  { color: var(--color-fg-muted);    background: var(--color-bg-elevated); }
 .pill.is-ok      { color: var(--ok);      background: rgb(var(--ok-glow) / .12); }
 .pill.is-err     { color: var(--err);     background: rgb(var(--err-glow) / .12); }
@@ -102,7 +102,7 @@
 .spark.is-err > i { background: var(--err); }
 .spark.is-warn > i { background: var(--warn); }
 /* last bar brightens to signal "now" */
-.spark > i:last-child { background: var(--color-accent-fg); box-shadow: 0 0 3px rgb(var(--brass-glow) / .5); }
+.spark > i:last-child { background: var(--color-accent-fg); box-shadow: 0 0 3px rgb(var(--color-accent-glow) / .5); }
 
 /* ════════ SECTION HEAD ════════
    Panel header strip — small-caps label + optional right chip. */
@@ -118,7 +118,7 @@
   color: var(--color-fg-muted);
   flex-shrink: 0;
 }
-.section-head > .count { margin-left: auto; font-family: var(--font-mono); color: var(--fg-4); font-weight: 500; }
+.section-head > .count { margin-left: auto; font-family: var(--font-mono); color: var(--color-fg-disabled); font-weight: 500; }
 .section-head > .tail  { margin-left: auto; display: flex; gap: 4px; align-items: center; }
 
 /* ════════ KV ROW ════════
@@ -146,7 +146,7 @@
 .btn.primary {
   background: var(--brass-2);
   color: var(--color-bg-page);
-  border-color: var(--brass-3);
+  border-color: var(--color-accent-fg-dim);
   font-weight: 600;
 }
 .btn.primary:hover { background: var(--color-accent-fg); color: var(--color-bg-page); }
@@ -189,7 +189,7 @@
   background: var(--color-border-strong);
   border-radius: 1px 1px 0 0;
 }
-.band.is-running { background: var(--color-accent-fg); box-shadow: 0 0 6px rgb(var(--brass-glow) / .5); }
+.band.is-running { background: var(--color-accent-fg); box-shadow: 0 0 6px rgb(var(--color-accent-glow) / .5); }
 .band.is-ok      { background: var(--ok); }
 .band.is-warn    { background: var(--warn); }
 .band.is-err     { background: var(--err); }
@@ -208,7 +208,7 @@
   background: var(--color-bg-elevated);
   color: var(--color-fg-primary);
 }
-.tk.is-brass { color: var(--color-accent-fg); background: rgb(var(--brass-glow) / .08); }
+.tk.is-brass { color: var(--color-accent-fg); background: rgb(var(--color-accent-glow) / .08); }
 .tk.is-err   { color: var(--err);     background: rgb(var(--err-glow) / .08); }
 
 /* ════════ SCROLL PANEL ════════
@@ -219,7 +219,7 @@
 /* ════════ TYPE ROLE CLASSES ════════
    Prefer these over raw --fs-* sizes in new styles. Role names
    match tokens.css. Each applies font shorthand + sensible color. */
-.t-micro   { font: var(--type-micro);   color: var(--fg-4); letter-spacing: var(--track-caps); text-transform: uppercase; }
+.t-micro   { font: var(--type-micro);   color: var(--color-fg-disabled); letter-spacing: var(--track-caps); text-transform: uppercase; }
 .t-caption { font: var(--type-caption); color: var(--color-fg-muted); letter-spacing: var(--track-wide); }
 .t-label   { font: var(--type-label);   color: var(--color-fg-muted); letter-spacing: var(--track-caps); text-transform: uppercase; font-weight: var(--fw-semi); }
 .t-meta    { font: var(--type-meta);    color: var(--color-fg-muted); }
@@ -233,7 +233,7 @@
 
 /* colour-modifier classes that pair with type roles */
 .t-dim { color: var(--color-fg-muted); }
-.t-mute { color: var(--fg-4); }
+.t-mute { color: var(--color-fg-disabled); }
 .t-brass { color: var(--color-accent-fg); }
 .t-ok { color: var(--ok-fg); }
 .t-warn { color: var(--warn-fg); }
@@ -304,8 +304,8 @@ body[data-grid="1"]::before {
   pointer-events: none;
   z-index: var(--z-toast);
   background-image:
-    linear-gradient(to right,  rgb(var(--brass-glow) / .06) 1px, transparent 1px),
-    linear-gradient(to bottom, rgb(var(--brass-glow) / .06) 1px, transparent 1px);
+    linear-gradient(to right,  rgb(var(--color-accent-glow) / .06) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(var(--color-accent-glow) / .06) 1px, transparent 1px);
   background-size: var(--grid-unit) var(--grid-unit);
 }
 
@@ -319,7 +319,7 @@ body[data-grid="1"]::before {
 @keyframes anim-slide-right { from { opacity: 0; transform: translateX(-8px); } to { opacity: 1; transform: none; } }
 @keyframes anim-pop         { from { opacity: 0; transform: scale(.92); } to { opacity: 1; transform: none; } }
 @keyframes anim-pulse       { 0%,100% { opacity: 1; } 50% { opacity: .55; } }
-@keyframes anim-pulse-glow  { 0%,100% { box-shadow: 0 0 0 rgb(var(--brass-glow) / 0); } 50% { box-shadow: 0 0 10px rgb(var(--brass-glow) / .5); } }
+@keyframes anim-pulse-glow  { 0%,100% { box-shadow: 0 0 0 rgb(var(--color-accent-glow) / 0); } 50% { box-shadow: 0 0 10px rgb(var(--color-accent-glow) / .5); } }
 @keyframes anim-pulse-err   { 0%,100% { box-shadow: 0 0 0 rgb(var(--err-glow)   / 0); } 50% { box-shadow: 0 0 10px rgb(var(--err-glow)   / .55); } }
 @keyframes anim-pulse-warn  { 0%,100% { box-shadow: 0 0 0 rgb(var(--warn-glow)  / 0); } 50% { box-shadow: 0 0 10px rgb(var(--warn-glow)  / .5); } }
 @keyframes anim-pulse-ok    { 0%,100% { box-shadow: 0 0 0 rgb(var(--ok-glow)    / 0); } 50% { box-shadow: 0 0 10px rgb(var(--ok-glow)    / .5); } }
@@ -382,7 +382,7 @@ body[data-grid="1"]::before {
 .is-loading::after {
   content: "";
   position: absolute; inset: 0;
-  background: linear-gradient(90deg, transparent, rgb(var(--brass-glow) / .08), transparent);
+  background: linear-gradient(90deg, transparent, rgb(var(--color-accent-glow) / .08), transparent);
   background-size: 200% 100%;
   animation: anim-shimmer 1.4s linear infinite;
 }

--- a/dashboard/design-system/source_styles/rail.css
+++ b/dashboard/design-system/source_styles/rail.css
@@ -30,13 +30,13 @@
 
 .goal-text {
   font-size: var(--fs-12); color: var(--color-fg-primary); line-height: 1.5;
-  background: var(--color-bg-panel-alt); border-left: 2px solid var(--brass-3);
+  background: var(--color-bg-panel-alt); border-left: 2px solid var(--color-accent-fg-dim);
   padding: var(--sp-2) var(--sp-3);
   border-radius: 0 var(--r-1) var(--r-1) 0; margin: 4px 0 8px;
 }
 .goal-text.is-short { border-left-color: var(--color-accent-fg); }
 .goal-text.is-mid { border-left-color: var(--brass-2); }
-.goal-text.is-long { border-left-color: var(--brass-3); }
+.goal-text.is-long { border-left-color: var(--color-accent-fg-dim); }
 
 .blocker-banner {
   background: rgb(196 106 90 / .08);
@@ -78,7 +78,7 @@
 .tool-chip.is-last {
   border-color: var(--color-accent-fg);
   color: var(--color-accent-fg);
-  background: rgb(var(--brass-glow) / 0.08);
+  background: rgb(var(--color-accent-glow) / 0.08);
 }
 .tool-count {
   font-size: 9px; color: var(--color-fg-muted);
@@ -87,7 +87,7 @@
 }
 .tool-chip.is-last .tool-count {
   color: var(--color-accent-fg);
-  background: rgb(var(--brass-glow) / 0.15);
+  background: rgb(var(--color-accent-glow) / 0.15);
 }
 
 /* Tool Timeline (inspector tab) */

--- a/dashboard/design-system/source_styles/sidebar.css
+++ b/dashboard/design-system/source_styles/sidebar.css
@@ -72,14 +72,14 @@
 .sb-tag-stalled  { color: var(--idle);  }
 .sb-tag-done     { color: var(--info);  border-color: rgb(106 142 176 / .4); }
 .sb-tag-short    { color: var(--ok);    border-color: rgb(107 158 107 / .4); }
-.sb-tag-mid      { color: var(--color-accent-fg); border-color: var(--brass-3); }
+.sb-tag-mid      { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); }
 .sb-tag-long     { color: var(--info);  border-color: rgb(106 142 176 / .4); }
-.sb-tag-tool     { color: var(--color-accent-fg); border-color: var(--brass-3); }
+.sb-tag-tool     { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); }
 .sb-tag-claim    { color: var(--ok);    border-color: rgb(107 158 107 / .4); }
 .sb-tag-text     { color: var(--info);  border-color: rgb(106 142 176 / .4); }
 .sb-tag-error    { color: var(--err);   border-color: rgb(196 106 90 / .4); }
-.sb-tag-noop     { color: var(--fg-4); }
-.sb-tag-cont     { color: var(--color-accent-fg); border-color: var(--brass-3); }
+.sb-tag-noop     { color: var(--color-fg-disabled); }
+.sb-tag-cont     { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); }
 .sb-tag-spk      { color: var(--info); }
 .sb-tag-note     { color: var(--color-fg-muted); }
 
@@ -112,8 +112,8 @@
   display: flex; flex-direction: column; align-items: center; gap: 1px; line-height: 1;
 }
 .sb-tab:hover { background: var(--color-bg-elevated); color: var(--color-fg-primary); }
-.sb-tab.is-active { background: var(--color-bg-elevated); border-color: var(--brass-3); color: var(--color-accent-fg); }
-.sb-tab-count { font-size: 10px; color: var(--fg-4); font-variant-numeric: tabular-nums; }
+.sb-tab.is-active { background: var(--color-bg-elevated); border-color: var(--color-accent-fg-dim); color: var(--color-accent-fg); }
+.sb-tab-count { font-size: 10px; color: var(--color-fg-disabled); font-variant-numeric: tabular-nums; }
 .sb-tab.is-active .sb-tab-count { color: var(--color-accent-fg); }
 .sb-search { padding: 6px 8px; border-bottom: 1px solid var(--color-border-default); flex-shrink: 0; }
 .sb-search input {
@@ -122,7 +122,7 @@
   color: var(--color-fg-primary); font: 11px/1 var(--font-mono);
   padding: 5px 8px; height: 24px;
 }
-.sb-search input:focus { border-color: var(--brass-3); outline: none; }
+.sb-search input:focus { border-color: var(--color-accent-fg-dim); outline: none; }
 .sidebar-list { flex: 1; min-height: 0; padding: 0 0 8px; overflow-y: auto; }
 .keeper-row {
   display: grid; grid-template-columns: 8px minmax(0, 1fr) auto;

--- a/dashboard/design-system/source_styles/swimlanes.css
+++ b/dashboard/design-system/source_styles/swimlanes.css
@@ -45,7 +45,7 @@
 .sl-range {
   margin-left: auto;
   font-family: var(--font-mono); font-size: 10px;
-  color: var(--fg-4);
+  color: var(--color-fg-disabled);
   flex-shrink: 0;
   padding-left: var(--sp-3);
 }
@@ -65,7 +65,7 @@
   position: relative; flex-shrink: 0;
 }
 .sl-toggle input:checked {
-  background: var(--brass-3); border-color: var(--brass-2);
+  background: var(--color-accent-fg-dim); border-color: var(--brass-2);
 }
 .sl-toggle input:checked::after {
   content: ""; position: absolute; inset: 1px;
@@ -105,7 +105,7 @@
   position: absolute; top: 6px;
   transform: translateX(-50%);
   font-family: var(--font-mono); font-size: 10px;
-  color: var(--fg-4); white-space: nowrap;
+  color: var(--color-fg-disabled); white-space: nowrap;
   font-variant-numeric: tabular-nums;
 }
 .sl-tick.is-major { color: var(--color-fg-secondary); }
@@ -117,7 +117,7 @@
   letter-spacing: .12em;
   padding: 2px 4px;
   background: var(--color-bg-page);
-  border: 1px solid var(--brass-3);
+  border: 1px solid var(--color-accent-fg-dim);
   border-radius: 2px;
   z-index: 3;
 }
@@ -140,11 +140,11 @@
   position: absolute; top: 0; bottom: 0;
   width: 1px;
   background: linear-gradient(to bottom,
-    rgb(var(--brass-glow) / .0),
-    rgb(var(--brass-glow) / .7) 6%,
-    rgb(var(--brass-glow) / .7) 94%,
-    rgb(var(--brass-glow) / .0));
-  box-shadow: 0 0 4px rgb(var(--brass-glow) / .5);
+    rgb(var(--color-accent-glow) / .0),
+    rgb(var(--color-accent-glow) / .7) 6%,
+    rgb(var(--color-accent-glow) / .7) 94%,
+    rgb(var(--color-accent-glow) / .0));
+  box-shadow: 0 0 4px rgb(var(--color-accent-glow) / .5);
   pointer-events: none;
   z-index: 4;
 }
@@ -169,14 +169,14 @@
 .sl-row:hover { background: rgb(255 255 255 / .02); }
 .sl-row.is-active { background: var(--color-bg-panel-alt); }
 .sl-row.is-active .sl-name { color: var(--color-accent-fg); }
-.sl-row.is-active .sl-status.dot-running { box-shadow: 0 0 6px rgb(var(--brass-glow) / .8); }
+.sl-row.is-active .sl-status.dot-running { box-shadow: 0 0 6px rgb(var(--color-accent-glow) / .8); }
 
 /* status tinted backgrounds — very subtle */
 .sl-row.st-error     { background: rgb(196 106 90 / .04); }
 .sl-row.st-error.is-active { background: rgb(196 106 90 / .10); }
 .sl-row.st-blocker   { background: rgb(201 162 74 / .04); }
 .sl-row.st-blocker.is-active { background: rgb(201 162 74 / .09); }
-.sl-row.st-running   { background: rgb(var(--brass-glow) / .02); }
+.sl-row.st-running   { background: rgb(var(--color-accent-glow) / .02); }
 
 /* collapsed empty lane — smaller, muted */
 .sl-row-collapsed {
@@ -191,7 +191,7 @@
 .sl-empty-note {
   position: absolute; left: 50%; top: 50%;
   transform: translate(-50%, -50%);
-  font: 9px/1 var(--font-mono); color: var(--fg-4);
+  font: 9px/1 var(--font-mono); color: var(--color-fg-disabled);
   letter-spacing: .08em;
 }
 
@@ -287,7 +287,7 @@
   background: var(--color-accent-fg);
   opacity: .8;
   pointer-events: none;
-  box-shadow: 0 0 3px rgb(var(--brass-glow) / .7);
+  box-shadow: 0 0 3px rgb(var(--color-accent-glow) / .7);
   z-index: 2;
 }
 
@@ -339,7 +339,7 @@
   height: 30% !important;
 }
 .sl-glyph.k-noop .sl-glyph-mark {
-  background: var(--fg-4);
+  background: var(--color-fg-disabled);
   min-width: 2px;
   opacity: .6;
 }
@@ -375,7 +375,7 @@
   z-index: 4;
 }
 .sl-glyph.is-active .sl-glyph-mark {
-  box-shadow: 0 0 0 2px var(--color-bg-page), 0 0 0 3px var(--color-accent-fg), 0 0 6px rgb(var(--brass-glow) / .7);
+  box-shadow: 0 0 0 2px var(--color-bg-page), 0 0 0 3px var(--color-accent-fg), 0 0 6px rgb(var(--color-accent-glow) / .7);
   transform: scale(1.3);
   filter: brightness(1.2);
 }
@@ -402,7 +402,7 @@
 }
 .sl-ho-line {
   fill: none;
-  stroke: var(--brass-3);
+  stroke: var(--color-accent-fg-dim);
   stroke-width: 1;
   opacity: .35;
   stroke-linecap: round;
@@ -415,7 +415,7 @@
   transition: r var(--t-fast), fill var(--t-fast), opacity var(--t-fast);
 }
 .sl-ho-tail {
-  fill: var(--brass-3);
+  fill: var(--color-accent-fg-dim);
   opacity: .45;
 }
 .sl-ho.is-involved .sl-ho-line { stroke: var(--color-accent-fg); opacity: .65; stroke-dasharray: none; }
@@ -425,7 +425,7 @@
   stroke-width: 1.6;
   opacity: 1;
   stroke-dasharray: none;
-  filter: drop-shadow(0 0 3px rgb(var(--brass-glow) / .7));
+  filter: drop-shadow(0 0 3px rgb(var(--color-accent-glow) / .7));
 }
 .sl-ho:hover .sl-ho-head { fill: var(--color-accent-fg); opacity: 1; }
 .sl-ho.is-active .sl-ho-line {
@@ -449,12 +449,12 @@
   z-index: 3;
   background: var(--color-bg-elevated);
   color: var(--color-fg-primary);
-  border: 1px solid var(--line-3);
+  border: 1px solid var(--color-border-divider);
   font-variant-numeric: tabular-nums;
   letter-spacing: 0;
   transition: transform var(--t-fast) var(--ease), box-shadow var(--t-fast);
 }
-.sl-cluster.k-tool { border-color: var(--brass-3); color: var(--color-accent-fg); }
+.sl-cluster.k-tool { border-color: var(--color-accent-fg-dim); color: var(--color-accent-fg); }
 .sl-cluster.k-claim { border-color: var(--ok); color: var(--ok); }
 .sl-cluster.k-error,
 .sl-cluster.is-err {

--- a/dashboard/design-system/ui_kits/cockpit/cockpit.css
+++ b/dashboard/design-system/ui_kits/cockpit/cockpit.css
@@ -22,7 +22,7 @@
   --w-side: 200px;
   --w-rail: 320px;
 
-  --glow: 0 0 12px rgb(var(--brass-glow) / .5);
+  --glow: 0 0 12px rgb(var(--color-accent-glow) / .5);
 }
 
 html, body, #root { height: 100%; margin: 0; }
@@ -137,15 +137,15 @@ button { font: inherit; }
 @keyframes ticker-slide { from { transform: translateX(0); } to { transform: translateX(-100%); } }
 @media (prefers-reduced-motion: reduce) { .ticker-run { animation: none; } }
 .tk-ev { display: inline-flex; align-items: center; gap: 8px; font: 11px/1 var(--font-mono); color: var(--color-fg-secondary); }
-.tk-ev .t { color: var(--fg-4); }
+.tk-ev .t { color: var(--color-fg-disabled); }
 .tk-ev .n { color: var(--color-fg-primary); }
 .tk-ev .k { text-transform: uppercase; letter-spacing: var(--track-caps); font-size: 9px; padding: 2px 5px; border-radius: 2px; font-weight: 600; }
-.tk-ev .k.tool  { color: var(--color-accent-fg); background: rgb(var(--brass-glow)/.08); }
+.tk-ev .k.tool  { color: var(--color-accent-fg); background: rgb(var(--color-accent-glow)/.08); }
 .tk-ev .k.err   { color: var(--err-fg);  background: rgb(196 106 90 / .1); }
 .tk-ev .k.claim { color: var(--info-fg); background: rgb(106 142 176 / .1); }
 .tk-ev .k.flag  { color: var(--warn-fg); background: rgb(201 162 74 / .1); }
 .tk-ev .k.note  { color: var(--color-fg-muted);    background: var(--color-bg-panel-alt); }
-.tk-sep { color: var(--fg-4); }
+.tk-sep { color: var(--color-fg-disabled); }
 
 /* ═══════════════ KPI STRIP ═══════════════ */
 .kpi {
@@ -162,7 +162,7 @@ button { font: inherit; }
   position: relative;
 }
 .kpi-cell:last-child { border-right: 0; }
-.kpi-cell.live { background: linear-gradient(180deg, rgb(var(--brass-glow)/.04), transparent); }
+.kpi-cell.live { background: linear-gradient(180deg, rgb(var(--color-accent-glow)/.04), transparent); }
 .kpi-cell.live::before {
   content: ""; position: absolute; top: 10px; right: 10px;
   width: 6px; height: 6px; border-radius: 50%;
@@ -170,8 +170,8 @@ button { font: inherit; }
   animation: pulse 1.6s infinite;
 }
 @keyframes pulse {
-  0%,100% { box-shadow: 0 0 0 0 rgb(var(--brass-glow)/.6); transform: scale(1); }
-  50%     { box-shadow: 0 0 0 5px rgb(var(--brass-glow)/0);  transform: scale(1.2); }
+  0%,100% { box-shadow: 0 0 0 0 rgb(var(--color-accent-glow)/.6); transform: scale(1); }
+  50%     { box-shadow: 0 0 0 5px rgb(var(--color-accent-glow)/0);  transform: scale(1.2); }
 }
 .kpi-l { font: 600 9px/1 var(--font-mono); letter-spacing: var(--track-caps); text-transform: uppercase; color: var(--color-fg-muted); }
 .kpi-v { font: 600 20px/1.05 var(--font-mono); color: var(--color-fg-primary); font-variant-numeric: tabular-nums; }
@@ -206,7 +206,7 @@ button { font: inherit; }
 /* ═══════════════ SIDEBAR ═══════════════ */
 .side {
   background: var(--color-bg-surface);
-  border-right: 1px solid var(--line-3);
+  border-right: 1px solid var(--color-border-divider);
   display: flex; flex-direction: column;
 }
 .side-sect { display: flex; flex-direction: column; border-bottom: 1px solid var(--color-border-strong); }
@@ -216,7 +216,7 @@ button { font: inherit; }
   font: 600 9px/1 var(--font-mono); letter-spacing: var(--track-caps); text-transform: uppercase;
   color: var(--color-fg-muted);
 }
-.side-sect-h .count { color: var(--fg-4); }
+.side-sect-h .count { color: var(--color-fg-disabled); }
 .side-sect-body { display: flex; flex-direction: column; padding-bottom: var(--sp-2); overflow-y: auto; }
 
 .keeper-row {
@@ -236,7 +236,7 @@ button { font: inherit; }
   justify-self: center;
   background: currentColor; color: var(--color-fg-muted);
 }
-.keeper-row .d.running { color: var(--color-accent-fg); box-shadow: 0 0 6px rgb(var(--brass-glow)/.5); animation: hb 1.4s infinite; }
+.keeper-row .d.running { color: var(--color-accent-fg); box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.5); animation: hb 1.4s infinite; }
 .keeper-row .d.ok      { color: var(--ok-fg); }
 .keeper-row .d.info    { color: var(--info-fg); }
 .keeper-row .d.err     { color: var(--err-fg); }
@@ -279,7 +279,7 @@ button { font: inherit; }
 
 /* Swimlanes */
 .sw {
-  border-bottom: 1px solid var(--line-3);
+  border-bottom: 1px solid var(--color-border-divider);
   padding: var(--sp-3) var(--sp-4);
   position: relative;
   display: flex; flex-direction: column;
@@ -287,7 +287,7 @@ button { font: inherit; }
 }
 .sw-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 8px; }
 .sw-head h3 { font: 600 10px/1 var(--font-mono); letter-spacing: var(--track-caps); text-transform: uppercase; color: var(--color-fg-muted); }
-.sw-head .meta { font: 9px/1 var(--font-mono); color: var(--fg-4); letter-spacing: var(--track-wide); }
+.sw-head .meta { font: 9px/1 var(--font-mono); color: var(--color-fg-disabled); letter-spacing: var(--track-wide); }
 .sw-body {
   position: relative;
   flex: 1;
@@ -324,7 +324,7 @@ button { font: inherit; }
   position: absolute; top: 0; bottom: 0;
   width: 2px;
   background: linear-gradient(to bottom, transparent, var(--color-accent-fg) 15%, var(--color-accent-fg) 85%, transparent);
-  box-shadow: 0 0 14px rgb(var(--brass-glow)/.6);
+  box-shadow: 0 0 14px rgb(var(--color-accent-glow)/.6);
   pointer-events: none;
   left: calc(110px + 72% * (100% - 110px) / 100%);
 }
@@ -351,7 +351,7 @@ button { font: inherit; }
 }
 .deck-tab:hover { color: var(--color-fg-primary); }
 .deck-tab.active { color: var(--color-accent-fg); border-bottom-color: var(--color-accent-fg); }
-.deck-tab .ct { font-family: var(--font-mono); font-size: 9px; color: var(--fg-4); font-weight: 400; }
+.deck-tab .ct { font-family: var(--font-mono); font-size: 9px; color: var(--color-fg-disabled); font-weight: 400; }
 .deck-tab.active .ct { color: var(--brass-2); }
 .deck-body { flex: 1; overflow: auto; padding: var(--sp-4); min-height: 0; }
 
@@ -369,7 +369,7 @@ button { font: inherit; }
   border-bottom: 1px solid var(--color-border-strong);
   display: flex; justify-content: space-between;
 }
-.board-col-h .ct { font-weight: 400; color: var(--fg-4); }
+.board-col-h .ct { font-weight: 400; color: var(--color-fg-disabled); }
 
 .card {
   background: var(--color-bg-surface);
@@ -382,13 +382,13 @@ button { font: inherit; }
 }
 .card:hover { background: var(--color-bg-panel-alt); border-color: var(--color-border-strong); }
 .card.running {
-  background: linear-gradient(180deg, var(--color-bg-surface), rgb(var(--brass-glow)/.04));
-  border-color: rgb(var(--brass-glow)/.3);
+  background: linear-gradient(180deg, var(--color-bg-surface), rgb(var(--color-accent-glow)/.04));
+  border-color: rgb(var(--color-accent-glow)/.3);
 }
 .card.running::before {
   content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 2px;
   background: var(--color-accent-fg);
-  box-shadow: 0 0 6px rgb(var(--brass-glow)/.5);
+  box-shadow: 0 0 6px rgb(var(--color-accent-glow)/.5);
 }
 .card .top { display: flex; justify-content: space-between; align-items: center; gap: 8px; }
 .card .id  { font: 10px/1 var(--font-mono); color: var(--color-fg-muted); letter-spacing: var(--track-wide); }
@@ -417,7 +417,7 @@ button { font: inherit; }
   font-variant-numeric: tabular-nums;
 }
 .tbl tbody tr:hover { background: var(--color-bg-surface); }
-.tbl tbody tr.running { background: linear-gradient(90deg, rgb(var(--brass-glow)/.05), transparent 70%); }
+.tbl tbody tr.running { background: linear-gradient(90deg, rgb(var(--color-accent-glow)/.05), transparent 70%); }
 .tbl tbody tr.running td:first-child { border-left: 2px solid var(--color-accent-fg); padding-left: 8px; }
 
 /* Chip */
@@ -428,7 +428,7 @@ button { font: inherit; }
   border: 1px solid transparent;
 }
 .chip .d { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
-.chip.running { color: var(--color-accent-fg); background: rgb(var(--brass-glow)/.1); border-color: rgb(var(--brass-glow)/.3); }
+.chip.running { color: var(--color-accent-fg); background: rgb(var(--color-accent-glow)/.1); border-color: rgb(var(--color-accent-glow)/.3); }
 .chip.ok      { color: var(--ok-fg); background: rgb(107 158 107 / .1); border-color: rgb(107 158 107 / .3); }
 .chip.warn    { color: var(--warn-fg); background: rgb(201 162 74 / .1); border-color: rgb(201 162 74 / .3); }
 .chip.err     { color: var(--err-fg); background: rgb(196 106 90 / .1); border-color: rgb(196 106 90 / .3); }
@@ -439,7 +439,7 @@ button { font: inherit; }
 .chip.queued  { color: #a0a0a0; background: rgb(106 106 106 / .1); border-color: rgb(106 106 106 / .3); }
 .chip.idle    { color: #a0a0a0; background: rgb(106 106 106 / .1); border-color: rgb(106 106 106 / .3); }
 .chip.done    { color: var(--ok-fg); background: rgb(107 158 107 / .1); border-color: rgb(107 158 107 / .3); }
-.chip.active  { color: var(--color-accent-fg); background: rgb(var(--brass-glow)/.1); border-color: rgb(var(--brass-glow)/.3); }
+.chip.active  { color: var(--color-accent-fg); background: rgb(var(--color-accent-glow)/.1); border-color: rgb(var(--color-accent-glow)/.3); }
 
 /* Providers */
 .prov-list { display: flex; flex-direction: column; gap: 8px; }
@@ -483,20 +483,20 @@ button { font: inherit; }
 .cascade-step:not(:last-child)::after {
   content: "→";
   position: absolute; right: -18px; top: 50%; transform: translateY(-50%);
-  color: var(--fg-4); font: 14px/1 var(--font-mono);
+  color: var(--color-fg-disabled); font: 14px/1 var(--font-mono);
 }
 .cascade-step .pv { font: 600 12px/1 var(--font-mono); color: var(--color-fg-primary); }
 .cascade-step .st { font: 9px/1 var(--font-mono); letter-spacing: var(--track-caps); text-transform: uppercase; }
 .cascade-step.hit .st  { color: var(--ok-fg); }
 .cascade-step.miss .st { color: var(--warn-fg); }
-.cascade-step.skip .st { color: var(--fg-4); }
+.cascade-step.skip .st { color: var(--color-fg-disabled); }
 .cascade-step.hit { border-color: rgb(107 158 107 / .4); background: linear-gradient(180deg, var(--color-bg-page), rgb(107 158 107 / .04)); }
 .cascade-step .ms { font: 10px/1 var(--font-mono); color: var(--color-fg-muted); font-variant-numeric: tabular-nums; }
 
 /* ═══════════════ RAIL ═══════════════ */
 .rail {
   background: var(--color-bg-surface);
-  border-left: 1px solid var(--line-3);
+  border-left: 1px solid var(--color-border-divider);
   display: flex; flex-direction: column;
   overflow: hidden;
 }
@@ -522,7 +522,7 @@ button { font: inherit; }
   border-bottom: 1px solid var(--color-border-default);
 }
 .activity:last-child { border-bottom: 0; }
-.activity .t { color: var(--fg-4); font-size: 9px; padding-top: 2px; }
+.activity .t { color: var(--color-fg-disabled); font-size: 9px; padding-top: 2px; }
 .activity .d { width: 7px; height: 7px; border-radius: 50%; margin-top: 4px; background: var(--color-fg-muted); }
 .activity .d.tool  { background: var(--color-accent-fg); }
 .activity .d.claim { background: var(--info-fg); }
@@ -559,8 +559,8 @@ button { font: inherit; }
   font: 12px/1 var(--font-mono);
   outline: none;
 }
-.compose-input:focus { border-color: var(--color-accent-fg); box-shadow: 0 0 0 2px rgb(var(--brass-glow)/.2); }
-.compose-input::placeholder { color: var(--fg-4); }
+.compose-input:focus { border-color: var(--color-accent-fg); box-shadow: 0 0 0 2px rgb(var(--color-accent-glow)/.2); }
+.compose-input::placeholder { color: var(--color-fg-disabled); }
 .compose-btn {
   height: 28px; padding: 0 12px;
   background: var(--color-accent-fg); color: #0c0b08; border: 1px solid var(--brass-2);
@@ -569,7 +569,7 @@ button { font: inherit; }
   cursor: pointer;
 }
 .compose-btn:hover { background: var(--brass-2); }
-.compose-hint { font: 9px/1 var(--font-mono); color: var(--fg-4); letter-spacing: var(--track-wide); }
+.compose-hint { font: 9px/1 var(--font-mono); color: var(--color-fg-disabled); letter-spacing: var(--track-wide); }
 
 /* ═══════════════ STATUS BAR ═══════════════ */
 .status {
@@ -604,8 +604,8 @@ button { font: inherit; }
   font-family: var(--font-mono);
   font-size: 11px;
 }
-.tb-branch:hover { background: var(--color-bg-panel-alt); border-color: var(--line-3); }
-.tb-branch::before { content: "⎇"; color: var(--fg-4); }
+.tb-branch:hover { background: var(--color-bg-panel-alt); border-color: var(--color-border-divider); }
+.tb-branch::before { content: "⎇"; color: var(--color-fg-disabled); }
 .tb-branch .nm { color: var(--color-accent-fg); font-weight: 600; }
 .tb-branch .ahbh { display: inline-flex; gap: 4px; color: var(--color-fg-muted); font-size: 10px; }
 .tb-branch .ahbh .ah { color: var(--ok-fg); }
@@ -619,7 +619,7 @@ button { font: inherit; }
   left: 8px;
   width: 360px;
   background: var(--color-bg-surface);
-  border: 1px solid var(--line-3);
+  border: 1px solid var(--color-border-divider);
   box-shadow: 0 8px 24px rgba(0,0,0,.4);
   z-index: 50;
   font-family: var(--font-mono);
@@ -629,7 +629,7 @@ button { font: inherit; }
   padding: 6px 10px;
   background: var(--color-bg-panel-alt);
   border-bottom: 1px solid var(--color-border-strong);
-  font-size: 9px; letter-spacing: .12em; text-transform: uppercase; color: var(--fg-4);
+  font-size: 9px; letter-spacing: .12em; text-transform: uppercase; color: var(--color-fg-disabled);
 }
 .tb-branch-pop .row {
   display: grid; grid-template-columns: auto 1fr auto auto;
@@ -640,7 +640,7 @@ button { font: inherit; }
 }
 .tb-branch-pop .row:hover { background: var(--color-bg-panel-alt); }
 .tb-branch-pop .row.on { background: var(--color-bg-panel-alt); border-left: 2px solid var(--color-accent-fg); padding-left: 8px; }
-.tb-branch-pop .row .glyph { color: var(--fg-4); }
+.tb-branch-pop .row .glyph { color: var(--color-fg-disabled); }
 .tb-branch-pop .row.on .glyph { color: var(--color-accent-fg); }
 .tb-branch-pop .row .nm { color: var(--color-fg-primary); }
 .tb-branch-pop .row .ahbh { color: var(--color-fg-muted); font-size: 10px; }
@@ -652,7 +652,7 @@ button { font: inherit; }
 .tb-branch-pop .row .st.clean    { color: var(--ok-fg); border-color: var(--ok-border); }
 .tb-branch-pop .row .st.dirty    { color: var(--warn-fg); border-color: var(--warn-border, var(--warn)); }
 .tb-branch-pop .row .st.stale    { color: var(--err-fg); border-color: var(--err-border); }
-.tb-branch-pop .row .st.research { color: var(--color-accent-fg); border-color: var(--brass-3); }
+.tb-branch-pop .row .st.research { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); }
 
 /* ─── Sidebar: keeper multi-select section ─── */
 .side-keepers {
@@ -676,7 +676,7 @@ button { font: inherit; }
   user-select: none;
 }
 .side-keepers .ch:hover { background: var(--color-bg-panel-alt); color: var(--color-fg-primary); }
-.side-keepers .ch.on   { background: rgb(var(--brass-glow)/.12); border-color: var(--brass-3); color: var(--color-accent-fg); }
+.side-keepers .ch.on   { background: rgb(var(--color-accent-glow)/.12); border-color: var(--color-accent-fg-dim); color: var(--color-accent-fg); }
 .side-keepers .ch .d   { width: 5px; height: 5px; border-radius: 50%; }
 
 /* ─── Rail: nudge log section ─── */
@@ -695,13 +695,13 @@ button { font: inherit; }
   font-size: 9px; padding: 1px 4px; border: 1px solid var(--color-border-strong);
   text-transform: uppercase; letter-spacing: .06em; white-space: nowrap;
 }
-.rail-nudge .ch.hint     { color: var(--color-accent-fg); border-color: var(--brass-3); }
+.rail-nudge .ch.hint     { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); }
 .rail-nudge .ch.approve  { color: var(--ok-fg); border-color: var(--ok-border); }
 .rail-nudge .ch.reject   { color: var(--err-fg); border-color: var(--err-border); }
 .rail-nudge .ch.redirect { color: var(--info-fg, var(--info)); border-color: var(--info); }
 .rail-nudge .body { color: var(--color-fg-primary); line-height: 1.4; }
 .rail-nudge .body .to { color: var(--color-accent-fg); margin-right: 4px; }
-.rail-nudge .body .ts { color: var(--fg-4); display: block; font-size: 9px; margin-top: 2px; }
+.rail-nudge .body .ts { color: var(--color-fg-disabled); display: block; font-size: 9px; margin-top: 2px; }
 .rail-nudge .ack {
   font-size: 9px; padding: 0 4px; text-transform: uppercase; letter-spacing: .06em;
   align-self: flex-start;
@@ -794,7 +794,7 @@ button { font: inherit; }
   font-size: 10px;
 }
 .ide-v2-branch .lbl {
-  color: var(--fg-4);
+  color: var(--color-fg-disabled);
   text-transform: uppercase;
   letter-spacing: .1em;
 }
@@ -809,7 +809,7 @@ button { font: inherit; }
   border: 1px solid var(--color-border-default);
   color: var(--color-accent-fg);
 }
-.ide-v2-branch .meta { color: var(--fg-4); }
+.ide-v2-branch .meta { color: var(--color-fg-disabled); }
 .ide-v2-modes {
   display: flex;
   gap: 2px;
@@ -832,8 +832,8 @@ button { font: inherit; }
 .ide-v2-terminal-toggle.active,
 .ide-v2-terminal-toggle[aria-pressed="true"] {
   color: var(--color-accent-fg);
-  border-color: var(--brass-3);
-  background: rgb(var(--brass-glow)/.08);
+  border-color: var(--color-accent-fg-dim);
+  background: rgb(var(--color-accent-glow)/.08);
 }
 .ide-v2-body {
   flex: 1;

--- a/dashboard/design-system/ui_kits/cockpit/data.js
+++ b/dashboard/design-system/ui_kits/cockpit/data.js
@@ -2,14 +2,14 @@
 
 window.MASC_DATA = (function () {
   const keepers = [
-    { id: "nick0cave",      role: "Captain",    color: "var(--brass-1)",    dotVar: "brass",    status: "running",  task: "t-9f2a", tool: "tool.write_file" },
+    { id: "nick0cave",      role: "Captain",    color: "var(--color-accent-fg)",    dotVar: "brass",    status: "running",  task: "t-9f2a", tool: "tool.write_file" },
     { id: "masc-improver",  role: "Improver",   color: "var(--ok-fg)",      dotVar: "ok",       status: "running",  task: "t-4b11", tool: "tool.read_file" },
     { id: "sangsu",         role: "Analyst",    color: "var(--info-fg)",    dotVar: "info",     status: "pending",  task: "t-7c03", tool: "review.drift" },
     { id: "qa-king",        role: "QA",         color: "var(--err-fg)",     dotVar: "err",      status: "fail",     task: "t-2e88", tool: "suite.run" },
     { id: "rama",           role: "Researcher", color: "var(--stalled-fg)", dotVar: "stalled",  status: "stalled",  task: "t-d551", tool: "(await analyst)" },
-    { id: "scholar",        role: "Scholar",    color: "var(--fg-2)",       dotVar: "idle",     status: "idle",     task: "—",      tool: "—" },
-    { id: "taskmaster",     role: "Orchestr.",  color: "var(--fg-2)",       dotVar: "idle",     status: "idle",     task: "—",      tool: "—" },
-    { id: "velvet-hammer",  role: "Gatekeep.",  color: "var(--fg-2)",       dotVar: "idle",     status: "idle",     task: "—",      tool: "—" },
+    { id: "scholar",        role: "Scholar",    color: "var(--color-fg-secondary)",       dotVar: "idle",     status: "idle",     task: "—",      tool: "—" },
+    { id: "taskmaster",     role: "Orchestr.",  color: "var(--color-fg-secondary)",       dotVar: "idle",     status: "idle",     task: "—",      tool: "—" },
+    { id: "velvet-hammer",  role: "Gatekeep.",  color: "var(--color-fg-secondary)",       dotVar: "idle",     status: "idle",     task: "—",      tool: "—" },
   ];
 
   const goals = [


### PR DESCRIPTION
## Summary

PR-M12~M22 일괄 머지 후 main에 잔존하던 **unsafe-alias categories** 일괄 치환.

이전 M-series는 11-token mapping (`--bg-0/1/2`, `--fg-1/2/3`, `--line-1/2`, `--brass-1`)만 적용 — `--bg-3/4`, `--fg-4`, `--line-3`, `--brass-3`, `--brass-glow`는 alias가 M2 stack 머지 후에 등재되어 누락. 본 PR이 잔존분 sweep.

## 통계

- 29 files
- 333 line replace (333 insertions + 333 deletions)
- 모든 변경 = `var(--raw)` → `var(--color-semantic)` syntactic 치환

## 대상 파일

**source_styles/** (12): center, code, deck, drawer, kpi, layers, layout, lifeline, primitives, rail, sidebar, swimlanes

**preview/*.html** (13): brand, colors, forms, index, layers, overlays, primitives, scope-phase2/3, snippets, spacing, swimlanes, tokrate

**preview/*.jsx** (2): code-mode, snippets

**ui_kits/cockpit/** (2): cockpit.css, data.js

## 잔존 raw refs (의도적)

| 파일 | 건수 | 사유 |
|------|------|------|
| `source_styles/tokens.css` | 67 | SSOT 정의 (raw token 자체) |
| `preview/components.css` | 598 | PR-M27 #10627 별도 처리 중 |
| `colors_and_type.css` | 21 | legacy duplicate file (별도 정리) |
| `*.md` | 3 | 문서 예시 |

## 안전성

- **시각 회귀 0**: alias resolve 동치
- **단일 카테고리 sweep**: 같은 mapping rule 일관 적용

## Test plan

- [ ] CI green
- [ ] preview/*.html, source_styles/* 시각 회귀 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
