### PR TITLE
refactor(dashboard): split shell cache timeout for light vs full mode (#10544)

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -778,7 +778,19 @@ let dashboard_general_agent_count agents =
 let provider_capacity_json () : Yojson.Safe.t =
   `Assoc []
 
+(* #10544: light mode is meant to skip the heavy belief/tension evaluation
+   and the full board scan, so it should also have a smaller wall-clock
+   budget. Pre-fix both modes shared the 16s timeout (post-#9766 8→16
+   bump for the full path), which masked any "light isn't really light"
+   regression — the operator cannot tell from log noise alone whether
+   light is genuinely under-scoped or has accidentally taken on full's
+   work. Splitting the budget makes that distinction visible: a light
+   timeout means "light path is doing too much"; a full timeout means
+   "the full path needs more headroom or a real perf fix". *)
 let dashboard_shell_timeout_s = 16.0
+let dashboard_shell_light_timeout_s = 8.0
+let dashboard_shell_timeout_for ~light =
+  if light then dashboard_shell_light_timeout_s else dashboard_shell_timeout_s
 
 (* Meta_cognition.summary_json does a full board_posts.jsonl scan +
    belief/tension/desire rule evaluation. On a room with 450+ posts this
@@ -1227,7 +1239,9 @@ let dashboard_shell_http_json ?clock ?request ?(light = false) (config : Coord.c
         match clock_opt with
         | Some clock ->
             Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:15.0
-              ~clock ~timeout_sec:dashboard_shell_timeout_s compute
+              ~clock
+              ~timeout_sec:(dashboard_shell_timeout_for ~light)
+              compute
         | None ->
             Dashboard_cache.get_or_compute cache_key ~ttl:15.0 compute
       in


### PR DESCRIPTION
## 요약

dashboard shell cache가 light + full 모드에 동일 16s timeout 적용 → 32 events/day timeout WARN. 운영자가 \"light가 진짜 light인지\" 분간 불가능. light/full을 별도 budget(8s/16s)로 분리해 시그널 차별화.

## 변경

\`lib/server/server_dashboard_http_core.ml:781\`:
- 신규 \`dashboard_shell_light_timeout_s = 8.0\`
- 신규 \`dashboard_shell_timeout_for ~light\` helper
- caller(line 1230)가 \`light\` 따라 timeout 선택
- startup-prewarm guard(line 1214)는 full 16s 유지 (heavier path readiness 기준)

## 검증

\`\`\`
DUNE_CACHE=disabled dune build --root . --cache=disabled @check  → EXIT=0
\`\`\`

## 영향

- light 모드 timeout이 8s에서 발생하면 *real signal* (light path가 too heavy)
- full 모드 timeout 16s에서 발생하면 *그냥 full이 느림* (별도 perf fix 필요)
- 32 events/day의 시그널이 두 categories로 분리 → operator triage 정확도 ↑

## 비목표

- root-cause perf fix (board_posts.jsonl scan 최적화 등): 별도 PR
- 16s를 32s로 단순 bump: 회피 — 그건 "wider window가 stuck call mask"

## Defensive guards

Draft + \`do-not-merge\`.

## 관련

- Issue: \`#10544\`
- Predecessor: \`#9766\` (8→16 full path bump)