### PR TITLE
chore(eio_guard): drop deprecated with_rw/with_ro aliases (0 callers)

### DIFF
--- a/lib/core/eio_guard.ml
+++ b/lib/core/eio_guard.ml
@@ -50,9 +50,3 @@ let run_in_systhread f =
     Eio_unix.run_in_systhread f
   else
     f ()
-
-(** @deprecated Use {!with_mutex} instead. *)
-let with_rw = with_mutex
-
-(** @deprecated Use {!with_mutex_ro} instead. *)
-let with_ro = with_mutex_ro

--- a/lib/core/eio_guard.mli
+++ b/lib/core/eio_guard.mli
@@ -23,11 +23,5 @@ val with_mutex : Eio.Mutex.t -> (unit -> 'a) -> 'a
 val with_mutex_ro : Eio.Mutex.t -> (unit -> 'a) -> 'a
 (** Acquire read-only lock if Eio is ready, run [f] directly otherwise. *)
 
-val with_rw : Eio.Mutex.t -> (unit -> 'a) -> 'a
-(** @deprecated Alias for {!with_mutex}. *)
-
-val with_ro : Eio.Mutex.t -> (unit -> 'a) -> 'a
-(** @deprecated Alias for {!with_mutex_ro}. *)
-
 val run_in_systhread : (unit -> 'a) -> 'a
 (** Run [f] in a system thread if Eio is ready, directly otherwise. *)


### PR DESCRIPTION
## Context

`lib/core/eio_guard.{ml,mli}` 의 `with_rw` / `with_ro`는 canonical `with_mutex` / `with_mutex_ro` 의 deprecated alias였습니다:

\`\`\`ocaml
val with_rw : Eio.Mutex.t -> (unit -> 'a) -> 'a
(** @deprecated Alias for {!with_mutex}. *)

val with_ro : Eio.Mutex.t -> (unit -> 'a) -> 'a
(** @deprecated Alias for {!with_mutex_ro}. *)
\`\`\`

`with_mutex` / `with_mutex_ro` 자체에 rw vs ro 의도가 표현돼 있어 별칭은 cognitive 노이즈만 추가. 0 callers 검증 후 surgical 삭제.

## Caller verification

\`\`\`bash
rg -n '\bEio_guard\.(with_rw|with_ro)\b' lib/ test/ scripts/
# (no output — 0 hits)
\`\`\`

## Diff scope

- `lib/core/eio_guard.mli`: -6 lines (val × 2 + docstring × 2 + 빈 줄 × 2)
- `lib/core/eio_guard.ml`:  -5 lines (docstring × 2 + let × 2 + 빈 줄 × 1)

Total: **12 lines deleted, 2 files**.

## What survives unchanged

- `with_mutex` (canonical rw locking helper)
- `with_mutex_ro` (canonical ro locking helper)
- 그 외 `Eio_guard` API 전체

## Local verification

\`\`\`
$ rm -rf _build && DUNE_CACHE=disabled dune build --cache=disabled
# (clean, no errors)
\`\`\`

## DNM rationale

cleanup loop의 세 번째 candidate. 메모리 `feedback_do-not-merge-label-insufficient`에 따라 Draft + `do-not-merge` 라벨로 사용자 명시 검토 대기. #10616, #10625와 파일 겹침 0 — 독립 평가 가능.

## Linked

- Loop plan: `~/me/planning/claude-plans/mossy-chasing-toast.md`
- Predecessor cleanup PRs: #10616 (`Keeper_exec_context` 12 re-exports), #10625 (`default_drift_max_chars` alias)