### PR TITLE
refactor(design-system): apply SPEC §3 vocabulary to Overview prod (Stage 2)

### DIFF
--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -94,8 +94,8 @@ function FunnelCell({
 }) {
   return html`
     <div class="flex flex-col gap-1 min-w-0" data-testid=${testId}>
-      <span class="text-2xs uppercase tracking-wider text-[var(--text-muted)]">${label}</span>
-      <span class=${`text-2xl font-semibold tabular-nums ${toneClass ?? 'text-[var(--text-strong)]'}`}>${value}</span>
+      <span class="text-2xs uppercase tracking-wider text-[var(--color-fg-muted)]">${label}</span>
+      <span class=${`text-2xl font-semibold tabular-nums ${toneClass ?? 'text-[var(--color-fg-secondary)]'}`}>${value}</span>
     </div>
   `
 }
@@ -107,18 +107,18 @@ export function formatTargetRatio(counts: FunnelCounts): string {
 }
 
 function FunnelCard({ counts }: { counts: FunnelCounts }) {
-  const awaitingTone = counts.awaiting > 0 ? 'text-[var(--warn)]' : undefined
+  const awaitingTone = counts.awaiting > 0 ? 'text-[var(--color-status-warn)]' : undefined
   return html`
     <section class=${CARD} aria-label="오늘 상황" data-testid="overview-funnel">
       <header class="flex items-center justify-between mb-3">
-        <h2 class="text-xs font-semibold uppercase tracking-wider text-[var(--text-strong)]">오늘 상황</h2>
-        <span class="text-2xs text-[var(--text-muted)]">task 기준</span>
+        <h2 class="text-xs font-semibold uppercase tracking-wider text-[var(--color-fg-secondary)]">오늘 상황</h2>
+        <span class="text-2xs text-[var(--color-fg-muted)]">task 기준</span>
       </header>
       <div class="grid grid-cols-5 gap-4 max-[640px]:grid-cols-3 max-[640px]:gap-y-4">
         <${FunnelCell} label="신규" value=${String(counts.created)} testId="funnel-created" />
         <${FunnelCell} label="진행" value=${String(counts.inProgress)} testId="funnel-in-progress" />
         <${FunnelCell} label="검증 대기" value=${String(counts.awaiting)} toneClass=${awaitingTone} testId="funnel-awaiting" />
-        <${FunnelCell} label="완료" value=${String(counts.completed)} toneClass="text-[var(--ok)]" testId="funnel-completed" />
+        <${FunnelCell} label="완료" value=${String(counts.completed)} toneClass="text-[var(--color-status-ok)]" testId="funnel-completed" />
         <${FunnelCell} label="목표" value=${formatTargetRatio(counts)} testId="funnel-target" />
       </div>
     </section>
@@ -131,12 +131,12 @@ export function severityToneClass(severity?: string | null): string {
   switch ((severity ?? '').toLowerCase()) {
     case 'critical':
     case 'high':
-      return 'text-[var(--bad)]'
+      return 'text-[var(--color-status-err)]'
     case 'warn':
     case 'medium':
-      return 'text-[var(--warn)]'
+      return 'text-[var(--color-status-warn)]'
     default:
-      return 'text-[var(--text-muted)]'
+      return 'text-[var(--color-fg-muted)]'
   }
 }
 
@@ -144,7 +144,7 @@ function Highlight({ attention }: { attention: OperatorAttentionItem | null }) {
   if (attention === null) {
     return html`
       <section class=${CARD} aria-label="오늘의 하이라이트" data-testid="overview-highlight-empty">
-        <p class="text-sm text-[var(--text-muted)]">특별한 신호 없음</p>
+        <p class="text-sm text-[var(--color-fg-muted)]">특별한 신호 없음</p>
       </section>
     `
   }
@@ -155,7 +155,7 @@ function Highlight({ attention }: { attention: OperatorAttentionItem | null }) {
         <span class=${`text-2xs font-semibold uppercase tracking-wider shrink-0 ${severityToneClass(severity)}`}>
           ${severity.toUpperCase()}
         </span>
-        <span class="truncate text-sm text-[var(--text-strong)]">${attention.summary}</span>
+        <span class="truncate text-sm text-[var(--color-fg-secondary)]">${attention.summary}</span>
       </div>
     </section>
   `
@@ -187,8 +187,8 @@ function MissionPartyCard({ active }: { active: DashboardMissionSessionCard | nu
   if (active === null) {
     return html`
       <section class=${CARD} aria-label="진행 중 파티" data-testid="overview-party-empty">
-        <header class="text-xs font-semibold uppercase tracking-wider text-[var(--text-strong)] mb-2">진행 중 파티</header>
-        <p class="text-sm text-[var(--text-muted)]">활성 미션 없음</p>
+        <header class="text-xs font-semibold uppercase tracking-wider text-[var(--color-fg-secondary)] mb-2">진행 중 파티</header>
+        <p class="text-sm text-[var(--color-fg-muted)]">활성 미션 없음</p>
       </section>
     `
   }
@@ -200,12 +200,12 @@ function MissionPartyCard({ active }: { active: DashboardMissionSessionCard | nu
   return html`
     <section class=${CARD} aria-label="진행 중 파티" data-testid="overview-party">
       <header class="flex items-center justify-between gap-3 mb-3">
-        <h2 class="text-xs font-semibold uppercase tracking-wider text-[var(--text-strong)]">진행 중 파티</h2>
+        <h2 class="text-xs font-semibold uppercase tracking-wider text-[var(--color-fg-secondary)]">진행 중 파티</h2>
         ${startedAt !== null && startedAt !== undefined && startedAt !== ''
-          ? html`<${TimeAgo} timestamp=${startedAt} class="text-2xs text-[var(--text-muted)]" />`
+          ? html`<${TimeAgo} timestamp=${startedAt} class="text-2xs text-[var(--color-fg-muted)]" />`
           : null}
       </header>
-      <p class="text-sm text-[var(--text-strong)] mb-3 line-clamp-2" data-testid="overview-party-goal">
+      <p class="text-sm text-[var(--color-fg-secondary)] mb-3 line-clamp-2" data-testid="overview-party-goal">
         🎯 ${active.goal !== '' ? active.goal : '(목표 없음)'}
       </p>
       ${members.length > 0
@@ -215,7 +215,7 @@ function MissionPartyCard({ active }: { active: DashboardMissionSessionCard | nu
                 name => html`<${AgentAvatar} name=${name} status=${active.health ?? 'idle'} size="sm" />`,
               )}
               ${extra > 0
-                ? html`<span class="text-2xs text-[var(--text-muted)]">+${extra}</span>`
+                ? html`<span class="text-2xs text-[var(--color-fg-muted)]">+${extra}</span>`
                 : null}
             </div>
           `
@@ -224,16 +224,16 @@ function MissionPartyCard({ active }: { active: DashboardMissionSessionCard | nu
         ? html`
             <div class="flex items-center gap-2" data-testid="overview-party-progress">
               <div class="flex-1 h-2 rounded bg-card-border/40 overflow-hidden">
-                <div class="h-full bg-[var(--ok)]" style=${`width: ${pct}%`}></div>
+                <div class="h-full bg-[var(--color-status-ok)]" style=${`width: ${pct}%`}></div>
               </div>
-              <span class="text-2xs tabular-nums text-[var(--text-muted)]">${pct}%</span>
+              <span class="text-2xs tabular-nums text-[var(--color-fg-muted)]">${pct}%</span>
             </div>
           `
         : null}
       ${blocker !== null && blocker !== undefined && blocker !== ''
         ? html`
             <div
-              class="mt-3 rounded border border-[var(--warn)]/40 bg-[var(--warn)]/10 px-2 py-1 text-2xs text-[var(--warn)]"
+              class="mt-3 rounded border border-[var(--color-status-warn)]/40 bg-[var(--color-status-warn)]/10 px-2 py-1 text-2xs text-[var(--color-status-warn)]"
               data-testid="overview-party-blocker"
             >
               blocker: ${blocker}
@@ -250,13 +250,13 @@ function keeperStatusToneClass(status: string): string {
   switch (status.toLowerCase()) {
     case 'active':
     case 'busy':
-      return 'bg-[var(--ok)]'
+      return 'bg-[var(--color-status-ok)]'
     case 'offline':
     case 'inactive':
     case 'paused':
-      return 'bg-[var(--bad)]'
+      return 'bg-[var(--color-status-err)]'
     default:
-      return 'bg-[var(--text-muted)]'
+      return 'bg-[var(--color-fg-muted)]'
   }
 }
 
@@ -278,13 +278,13 @@ function KeeperStrip({ keeperList }: { keeperList: readonly Keeper[] }) {
   if (top.length === 0) {
     return html`
       <section class=${CARD} aria-label="활성 keeper" data-testid="overview-keepers-empty">
-        <p class="text-sm text-[var(--text-muted)]">활성 keeper 없음</p>
+        <p class="text-sm text-[var(--color-fg-muted)]">활성 keeper 없음</p>
       </section>
     `
   }
   return html`
     <section class=${CARD} aria-label="활성 keeper" data-testid="overview-keepers">
-      <header class="text-xs font-semibold uppercase tracking-wider text-[var(--text-strong)] mb-2">활성 keeper</header>
+      <header class="text-xs font-semibold uppercase tracking-wider text-[var(--color-fg-secondary)] mb-2">활성 keeper</header>
       <ul class="flex flex-col gap-2">
         ${top.map(
           k => html`
@@ -293,7 +293,7 @@ function KeeperStrip({ keeperList }: { keeperList: readonly Keeper[] }) {
               <${RouteLink}
                 tab="monitoring"
                 params=${{ section: 'keepers', keeper: k.name }}
-                class="text-sm text-[var(--text-strong)] truncate hover:underline"
+                class="text-sm text-[var(--color-fg-secondary)] truncate hover:underline"
               >
                 ${k.koreanName !== undefined && k.koreanName !== '' ? k.koreanName : k.name}
               <//>
@@ -301,7 +301,7 @@ function KeeperStrip({ keeperList }: { keeperList: readonly Keeper[] }) {
                 ? html`
                     <${TimeAgo}
                       timestamp=${k.last_heartbeat}
-                      class="text-2xs text-[var(--text-muted)] ml-auto shrink-0"
+                      class="text-2xs text-[var(--color-fg-muted)] ml-auto shrink-0"
                     />
                   `
                 : null}

--- a/dashboard_bonsai/src/hero.ml
+++ b/dashboard_bonsai/src/hero.ml
@@ -24,7 +24,7 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.3em;
     text-transform: uppercase;
-    color: var(--text-dim, #9a846e);
+    color: var(--color-fg-muted, #9a846e);
     margin: 0;
   }
 
@@ -38,7 +38,7 @@ stylesheet
   }
 
   .tail_brass {
-    color: var(--accent-brass, #968228);
+    color: var(--color-accent-fg, #968228);
     font-size: 18px;
     margin-left: 14px;
   }
@@ -53,7 +53,7 @@ stylesheet
     font-family: 'EB Garamond', serif;
     font-style: italic;
     font-size: 14px;
-    color: var(--text-primary, #c8b88c);
+    color: var(--color-fg-primary, #c8b88c);
     margin: 0;
     max-width: 640px;
   }

--- a/dashboard_bonsai/src/hud.ml
+++ b/dashboard_bonsai/src/hud.ml
@@ -38,13 +38,13 @@ stylesheet
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     gap: 1px;
-    background: var(--border-main);
-    border: 1px solid var(--border-highlight);
+    background: var(--color-border-default);
+    border: 1px solid var(--color-border-strong);
     border-radius: 2px;
     box-shadow:
-      inset 0 0 0 1px color-mix(in oklab, var(--accent-brass) 8%, transparent),
-      0 2px 12px color-mix(in oklab, var(--bg-deep) 60%, transparent),
-      0 16px 24px -16px color-mix(in oklab, var(--bg-deep) 90%, transparent);
+      inset 0 0 0 1px color-mix(in oklab, var(--color-accent-fg) 8%, transparent),
+      0 2px 12px color-mix(in oklab, var(--color-bg-page) 60%, transparent),
+      0 16px 24px -16px color-mix(in oklab, var(--color-bg-page) 90%, transparent);
     backdrop-filter: blur(2px);
   }
 
@@ -54,7 +54,7 @@ stylesheet
     position: absolute;
     width: 14px;
     height: 14px;
-    border: 1px solid var(--accent-brass);
+    border: 1px solid var(--color-accent-fg);
     pointer-events: none;
     z-index: 1;
   }
@@ -74,7 +74,7 @@ stylesheet
   }
 
   .cell {
-    background: var(--bg-panel);
+    background: var(--color-bg-surface);
     padding: 10px 14px;
     display: flex;
     flex-direction: column;
@@ -86,19 +86,19 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.2em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
 
   .v {
     font-family: 'JetBrains Mono', ui-monospace, Menlo, Consolas, monospace;
     font-variant-numeric: tabular-nums;
     font-size: 12px;
-    color: var(--text-primary);
+    color: var(--color-fg-primary);
   }
 
-  .v_ok   { color: var(--status-ok); }
-  .v_warn { color: var(--status-warn); }
-  .v_bad  { color: var(--status-bad); }
+  .v_ok   { color: var(--color-status-ok); }
+  .v_warn { color: var(--color-status-warn); }
+  .v_bad  { color: var(--color-status-err); }
 
   @media (prefers-contrast: more) {
     .hud { border-width: 2px; border-color: var(--text-bright); }

--- a/dashboard_bonsai/src/overview_view.ml
+++ b/dashboard_bonsai/src/overview_view.ml
@@ -25,8 +25,8 @@ stylesheet
   }
 
   .panel {
-    border: 1px solid var(--border-main);
-    background: linear-gradient(180deg, color-mix(in oklab, var(--bg-panel) 70%, transparent), color-mix(in oklab, var(--bg-deep) 85%, transparent));
+    border: 1px solid var(--color-border-default);
+    background: linear-gradient(180deg, color-mix(in oklab, var(--color-bg-surface) 70%, transparent), color-mix(in oklab, var(--color-bg-page) 85%, transparent));
     padding: 18px 20px;
     display: flex;
     flex-direction: column;
@@ -37,7 +37,7 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.25em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
     margin: 0;
   }
 
@@ -57,7 +57,7 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.2em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
   .v {
     font-family: 'JetBrains Mono', ui-monospace, monospace;
@@ -68,10 +68,10 @@ stylesheet
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-  .v_dim { color: var(--text-dim); }
-  .v_brass { color: var(--accent-brass); }
-  .v_ok { color: var(--status-ok); }
-  .v_warn { color: var(--status-warn); }
+  .v_dim { color: var(--color-fg-muted); }
+  .v_brass { color: var(--color-accent-fg); }
+  .v_ok { color: var(--color-status-ok); }
+  .v_warn { color: var(--color-status-warn); }
   .v_bad { color: var(--accent-blood); }
 
   .counts {
@@ -84,8 +84,8 @@ stylesheet
     flex-direction: column;
     gap: 6px;
     padding: 14px;
-    background: color-mix(in oklab, var(--bg-deep) 40%, transparent);
-    border: 1px solid var(--border-main);
+    background: color-mix(in oklab, var(--color-bg-page) 40%, transparent);
+    border: 1px solid var(--color-border-default);
     text-align: center;
   }
   .count_k {
@@ -93,7 +93,7 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.22em;
     text-transform: uppercase;
-    color: var(--text-dim);
+    color: var(--color-fg-muted);
   }
   .count_v {
     font-family: 'Cinzel', serif;
@@ -105,24 +105,24 @@ stylesheet
 
   .stag_bar {
     height: 6px;
-    background: color-mix(in oklab, var(--accent-brass) 15%, transparent);
+    background: color-mix(in oklab, var(--color-accent-fg) 15%, transparent);
     position: relative;
     margin-top: 6px;
   }
   .stag_fill {
     position: absolute;
     left: 0; top: 0; bottom: 0;
-    background: var(--accent-brass);
+    background: var(--color-accent-fg);
   }
-  .stag_fill_warn { background: var(--status-warn); }
+  .stag_fill_warn { background: var(--color-status-warn); }
   .stag_fill_bad { background: var(--accent-blood); }
 
   .belief {
     padding: 12px 14px;
-    border: 1px dashed var(--border-main);
+    border: 1px dashed var(--color-border-default);
     font-family: 'EB Garamond', serif;
     font-size: 14px;
-    color: var(--text-primary);
+    color: var(--color-fg-primary);
     font-style: italic;
   }
   .belief_tag {
@@ -130,7 +130,7 @@ stylesheet
     font-size: 11px;
     letter-spacing: 0.18em;
     text-transform: uppercase;
-    color: var(--accent-brass);
+    color: var(--color-accent-fg);
     margin-right: 10px;
   }
 
@@ -139,8 +139,8 @@ stylesheet
     text-align: center;
     font-family: 'EB Garamond', serif;
     font-style: italic;
-    color: var(--text-dim);
-    border: 1px dashed var(--border-main);
+    color: var(--color-fg-muted);
+    border: 1px dashed var(--color-border-default);
   }
 
   @media (max-width: 920px) {
@@ -158,8 +158,8 @@ stylesheet
     .k { color: var(--text-bright); }
     .count_k { color: var(--text-bright); }
     .count_cell { border-width: 2px; border-color: var(--text-bright); }
-    .belief { border-width: 2px; border-style: solid; border-color: var(--text-bright); color: var(--text-primary); }
-    .empty { border-width: 2px; border-style: solid; border-color: var(--text-bright); color: var(--text-primary); }
+    .belief { border-width: 2px; border-style: solid; border-color: var(--text-bright); color: var(--color-fg-primary); }
+    .empty { border-width: 2px; border-style: solid; border-color: var(--text-bright); color: var(--color-fg-primary); }
     .stag_bar { outline: 1px solid var(--text-bright); }
   }
 


### PR DESCRIPTION
## Summary

**Stage 2 of design system prod alignment series** — first per-screen migration. Replaces 66 raw tier var() refs with SPEC v0.1 §3.1-3.5 Semantic aliases in both prod surfaces (Overview screen).

Diff: **4 files, +63/-63** (sed same-line refactor). Visual diff = zero (aliases forward to same raw values).

## Per-prod changes

### Bonsai (`overview_view.ml` + `hero.ml` + `hud.ml`) — 37 refs

| Raw | Semantic | Count |
|-----|----------|-------|
| `--text-primary` | `--color-fg-primary` | 5 |
| `--text-dim` | `--color-fg-muted` | 7 |
| `--border-main` | `--color-border-default` | 5 |
| `--border-highlight` | `--color-border-strong` | 1 |
| `--accent-brass` | `--color-accent-fg` | 7 |
| `--status-ok` | `--color-status-ok` | 2 |
| `--status-warn` | `--color-status-warn` | 3 |
| `--status-bad` | `--color-status-err` | 1 |
| `--bg-deep` | `--color-bg-page` | 4 |
| `--bg-panel` | `--color-bg-surface` | 2 |

`--text-bright` + `--accent-blood` 유지 (SPEC §3.2/§3.4가 bonsai-only raw로 명시, alias 없음).

### Preact (`overview.ts`) — 29 refs

| Raw | Semantic | Count |
|-----|----------|-------|
| `--text-muted` | `--color-fg-muted` | 11 |
| `--text-strong` | `--color-fg-secondary` | 8 |
| `--warn` | `--color-status-warn` | 5 |
| `--ok` | `--color-status-ok` | 3 |
| `--bad` | `--color-status-err` | 2 |

Tailwind arbitrary-value utilities 안 (`text-[var(--*)]` form) 모두 안전하게 변환.

## Side benefit: hero.ml + hud.ml 공유

이 두 primitive는 5개 Bonsai view (overview, keepers, goals, archive_runs, dead_keepers)에서 공유됨. **이번 PR이 Overview 렌즈로 SPEC vocabulary 적용했지만 5개 view 모두 자동 정합**. Stage 3+에서 Keepers/Goals 화면 작업할 때 hero/hud는 이미 정합된 상태.

## Visual diff = zero (검증)

Stage 1 PR #10611에서 정의한 alias:
- `dashboard/src/styles/variables.css:281+`
- `dashboard_bonsai/static/colors_and_type.css :root`

각 alias는 raw 값을 가리키는 forward var() 참조. CSS cascade로 동일 computed value에 도달. 7개 테마 (dashboard dark + bonsai 5) 모두 시각 변화 zero 예상.

## Validation

- **raw 잔존 0** (Bonsai 변경 파일): grep 0건 — text-primary/dim/border-main/highlight/accent-brass/status-ok/warn/bad/bg-deep/panel
- **raw 잔존 0** (Preact `overview.ts`): grep 0건 — text-muted/strong/warn/ok/bad
- **semantic 사용 도입**: Bonsai 37 / Preact 29
- **diff stat**: 4 files, +63/-63
- **CI**: `Build and Test` + `Dashboard` workflow가 양쪽 prod 빌드 검증

## 시리즈 진행

- [x] Stage 0 audit ([#10606](https://github.com/jeong-sik/masc-mcp/pull/10606) merged)
- [x] Stage 1 SPEC aliases ([#10611](https://github.com/jeong-sik/masc-mcp/pull/10611) merged)
- [ ] Stage 1.5 `.flame_*` raw hex (별도 PR, 색 매핑 분석 후)
- [x] **Stage 2 Overview (this PR)**
- [ ] Stage 3 Keepers (다음)
- [ ] Stage 4 Goals
- [ ] Stage 5 Logs (분리 가능)
- [ ] Stage 6+ Archive Runs / Dead Keepers / Preact-only

Refs: SPEC.md, audit #10606, alias #10611

🤖 Generated with [Claude Code](https://claude.com/claude-code)
