### PR TITLE
feat(dashboard): localize 11 chips across 7 components (round-23)

### DIFF
--- a/dashboard/src/components/auth-status.ts
+++ b/dashboard/src/components/auth-status.ts
@@ -180,7 +180,7 @@ function AuthPopover() {
         </div>
 
         <div class="flex flex-col gap-2">
-          <div class="text-2xs text-[var(--text-muted)]">Actor override</div>
+          <div class="text-2xs text-[var(--text-muted)]">행위자 재정의</div>
           ${actorOverrideLocked ? html`
             <div class="text-2xs text-[var(--text-muted)]">
               검증된 세션은 token owner를 단일 actor로 사용합니다. 로컬 actor override는 저장되더라도 요청 actor로 쓰이지 않습니다.

--- a/dashboard/src/components/connector-config-form.ts
+++ b/dashboard/src/components/connector-config-form.ts
@@ -485,7 +485,7 @@ export function ConnectorConfigForm({ connectorId }: { connectorId: string }) {
                 setEntry(connectorId, { autoRestart: (ev.target as HTMLInputElement).checked })
               }}
             />
-            <span>Auto restart</span>
+            <span>자동 재시작</span>
           </label>
           <${ActionButton}
             variant="ghost"

--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -657,7 +657,7 @@ describe('ConnectorStatusPanel', () => {
     await flushUi()
 
     const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
-    expect(text).toContain('Sidecar not started')
+    expect(text).toContain('사이드카 미시작')
     expect(text).toContain('cd sidecars/discord-bot && ./run.sh')
     expect(text).toContain('Cause: no sidecar status file has been observed at /tmp/discord_status.json')
     expect(text).toContain('Next: click Start to spawn via the backend')
@@ -678,7 +678,7 @@ describe('ConnectorStatusPanel', () => {
     const chip = panel!.querySelector('[data-sidecar-status-chip]')
     expect(chip).toBeTruthy()
     expect(chip!.getAttribute('aria-label')).toContain('not running')
-    expect(chip!.textContent).toContain('Not running')
+    expect(chip!.textContent).toContain('실행 중 아님')
 
     const copyLabels = Array.from(panel!.querySelectorAll<HTMLButtonElement>('[data-copy-button]'))
       .map(button => button.getAttribute('aria-label'))
@@ -714,7 +714,7 @@ describe('ConnectorStatusPanel', () => {
     await flushUi()
 
     const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
-    expect(text).toContain('No keepers configured')
+    expect(text).toContain('설정된 키퍼 없음')
 
     // Sibling of the "Sidecar not started" panel (#8038). Same fix:
     // explicit amber override so the parent accent gradient (iMessage
@@ -726,7 +726,7 @@ describe('ConnectorStatusPanel', () => {
     const chip = emptyPanel!.querySelector('[data-no-keepers-status-chip]')
     expect(chip).toBeTruthy()
     expect(chip!.getAttribute('aria-label')).toContain('none configured')
-    expect(chip!.textContent).toContain('Not configured')
+    expect(chip!.textContent).toContain('설정 필요')
   })
 
   it('expands [▾] header toggle to show per-dot liveness and metadata', async () => {

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -965,7 +965,7 @@ function ConnectorLivePanel({
                 aria-label="Keeper directory status: unavailable"
               >
                 <span aria-hidden="true">⚠</span>
-                <span>Directory error</span>
+                <span>디렉토리 오류</span>
               </span>
               ${connector?.gate_health_checked_at
                 ? html`<span class="text-3xs text-[var(--text-dim)]">checked ${timeAgo(connector.gate_health_checked_at)}</span>`
@@ -993,9 +993,9 @@ function ConnectorLivePanel({
                   data-no-keepers-status-chip
                 >
                   <span aria-hidden="true">⊘</span>
-                  <span>Not configured</span>
+                  <span>설정 필요</span>
                 </span>
-                <span class="font-medium text-[var(--text-body)]">No keepers configured</span>
+                <span class="font-medium text-[var(--text-body)]">설정된 키퍼 없음</span>
               </div>
               <div class="text-3xs text-[var(--warn)]/80">
                 Add keeper config files under <code class="rounded bg-[var(--white-4)] px-1">config/keepers/</code> and restart the server.
@@ -1034,9 +1034,9 @@ function ConnectorLivePanel({
                       data-sidecar-status-chip
                     >
                       <span aria-hidden="true">⊘</span>
-                      <span>Not running</span>
+                      <span>실행 중 아님</span>
                     </span>
-                    <span class="font-medium text-[var(--text-body)]">Sidecar not started</span>
+                    <span class="font-medium text-[var(--text-body)]">사이드카 미시작</span>
                     ${connector?.updated_at
                       ? html`<span class="text-3xs text-[var(--text-dim)]">last seen ${timeAgo(connector.updated_at)}</span>`
                       : null}

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -856,7 +856,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <${LongText} text=${c.sources.default_manifest_path} />
       ` : null}
       ${c.sources.cascade_catalog_source_path ? html`
-        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">Cascade catalog source</div>
+        <div class="text-3xs font-semibold uppercase tracking-wider text-[var(--text-muted)] mt-2 mb-0.5">캐스케이드 카탈로그 출처</div>
         <${LongText} text=${c.sources.cascade_catalog_source_path} />
       ` : null}
       ${c.sources.cascade_runtime_json_path ? html`

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -1113,7 +1113,7 @@ export function KeeperDetailPage() {
 
           <${KeeperDetailSection}
             id="keeper-config"
-            eyebrow="Configuration"
+            eyebrow="설정"
             title="설정 / 작업 방식"
             description="분산되어 있던 tool policy, 작업 budget, playground repo, keeper config를 한 섹션으로 모았습니다."
           >
@@ -1141,7 +1141,7 @@ export function KeeperDetailPage() {
 
           <${KeeperDetailSection}
             id="keeper-debug"
-            eyebrow="Debug"
+            eyebrow="디버그"
             title="디버그"
             description="운영 중에는 덜 자주 보지만, 문제를 깊게 파고들 때 필요한 raw surface를 마지막에 모았습니다."
           >

--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -223,7 +223,7 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
 
       ${transitions.length > 0 ? html`
         <div class="grid gap-2">
-          <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">Observed transitions</div>
+          <div class="text-3xs font-semibold uppercase tracking-1 text-[var(--text-muted)]">관측된 전이</div>
           ${transitions.map(transition => html`
             <div class="rounded border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-2xs leading-normal text-[var(--text-body)]">
               <div class="flex flex-wrap items-center gap-2">

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -184,7 +184,7 @@ function ToolTable({
             <th class="text-left py-1 font-normal">Tool</th>
             <th class="text-right py-1 font-normal">Calls</th>
             <th class="text-right py-1 font-normal">Success</th>
-            <th class="text-right py-1 font-normal">Avg ms</th>
+            <th class="text-right py-1 font-normal">평균 ms</th>
             <th class="text-right py-1 font-normal">Output</th>
           </tr>
         </thead>


### PR DESCRIPTION
Round-23 follow-up to merged PRs #10524, #10573.\n\nSee commit message for full mapping. 8 files + 1 test file, 11 strings localized + 4 test assertions updated.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)